### PR TITLE
Fix the crash in getMountPointOfFile function

### DIFF
--- a/dde-file-manager-lib/shutil/dsqlitehandle.cpp
+++ b/dde-file-manager-lib/shutil/dsqlitehandle.cpp
@@ -368,7 +368,7 @@ QPair<QString, QString> DSqliteHandle::getMountPointOfFile(DUrl url,
             && !partionsAndMountPoints->empty()) {
         QString parentPath{url.parentUrl().path()};
         std::multimap<QString, QString>::const_iterator partionAndMounpointItr{};
-        std::multimap<QString, QString>::const_iterator rootPathPartionAndMountpointItr{};
+        std::pair<QString, QString> rootPathPartionAndMountpoint;
         std::map<QString, std::multimap<QString, QString>>::const_iterator cbeg{ partionsAndMountPoints->cbegin() };
         std::map<QString, std::multimap<QString, QString>>::const_iterator cend{ partionsAndMountPoints->cend() };
 
@@ -380,7 +380,7 @@ QPair<QString, QString> DSqliteHandle::getMountPointOfFile(DUrl url,
             for (; itrOfPartionAndMountpoint != itrOfPartionAndMountpointEnd; ++itrOfPartionAndMountpoint) {
 
                 if (itrOfPartionAndMountpoint->second == ROOTPATH) {
-                    rootPathPartionAndMountpointItr = itrOfPartionAndMountpoint;
+                    rootPathPartionAndMountpoint = *itrOfPartionAndMountpoint;
                 }
 
                 if (itrOfPartionAndMountpoint->second != ROOTPATH && parentPath.startsWith(itrOfPartionAndMountpoint->second)) {
@@ -402,8 +402,8 @@ QPair<QString, QString> DSqliteHandle::getMountPointOfFile(DUrl url,
 
 
         if (partionAndMounpointItr == std::multimap<QString, QString>::const_iterator{} && parentPath.startsWith(ROOTPATH)) {
-            partionAndMountPoint.first = rootPathPartionAndMountpointItr->first;
-            partionAndMountPoint.second = rootPathPartionAndMountpointItr->second;
+            partionAndMountPoint.first = rootPathPartionAndMountpoint.first;
+            partionAndMountPoint.second = rootPathPartionAndMountpoint.second;
         }
     }
 


### PR DESCRIPTION
Previously, the function uses an iterator `rootPathPartionAndMountpointItr` to store
the partition and mount point of the root path. The iterator becomes
invalid when the iteration is over, therefore it causes SEGMENT FAULT in
some cases. In this fix, the iterator is replaced with a pair
`rootPathPartionAndMountpointItr` to store the information.

Resolves: https://github.com/linuxdeepin/dde-file-manager/issues/43