### PR TITLE
refactor: enable anything depend packages for sw/loongson/arm platforms

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,8 +50,8 @@ Depends:
  ${misc:Depends},
  libdde-file-manager( =${binary:Version}),
  socat,
- deepin-anything-dkms [amd64 i386],
- deepin-anything-server [amd64 i386]
+ deepin-anything-dkms,
+ deepin-anything-server
 Recommends: dde-qt5integration, avfs, samba
 Description: File manager front end
  File manager front-end of Deepin OS
@@ -79,7 +79,7 @@ Depends:
  gvfs-backends(>=1.27.3),
  cryptsetup,
  libkf5codecs5,
- deepin-anything-libs [amd64 i386]
+ deepin-anything-libs
 Breaks: dde-file-manager(<=1.2.3-3)
 Multi-Arch: same
 Description: DDE File Manager library


### PR DESCRIPTION
deepin-anything相关的依赖去除平台判定，在任意平台都添加此依赖