### PR TITLE
fix: Update usershare info when getChildren

### DIFF
--- a/dde-file-manager-lib/controllers/sharecontroler.cpp
+++ b/dde-file-manager-lib/controllers/sharecontroler.cpp
@@ -92,6 +92,8 @@ const QList<DAbstractFileInfoPointer> ShareControler::getChildren(const QSharedP
 
     QList<DAbstractFileInfoPointer> infolist;
 
+    userShareManager->updateUserShareInfo();
+
     ShareInfoList sharelist = userShareManager->shareInfoList();
     foreach (ShareInfo shareInfo, sharelist) {
         const DAbstractFileInfoPointer &fileInfo = DFileService::instance()->createFileInfo(this, DUrl::fromUserShareFile(shareInfo.path()));


### PR DESCRIPTION
专业版为了加快启动速度会预先启动一个文件管理器进程,此进程创建时生成了一份用户共享目录的缓存,但此时共享的目录可能还尚未挂载.此变更使文件管理器每次打开我的共享视图时均更新共享目录信息.