### PR TITLE
fix: file mimetype results are not accurate on gvfs mount device

### DIFF
--- a/dde-file-manager-lib/interfaces/dmimedatabase.cpp
+++ b/dde-file-manager-lib/interfaces/dmimedatabase.cpp
@@ -36,21 +36,11 @@ DMimeDatabase::DMimeDatabase()
 
 QMimeType DMimeDatabase::mimeTypeForFile(const QString &fileName, QMimeDatabase::MatchMode mode) const
 {
-    QFileInfo fileInfo(fileName);
-
-    // Ignore the mode argument if file is retome file
-    if (!fileInfo.isDir() && FileUtils::isGvfsMountFile(fileInfo.absoluteFilePath()))
-        return QMimeDatabase::mimeTypeForFile(fileName, QMimeDatabase::MatchExtension);
-
     return QMimeDatabase::mimeTypeForFile(fileName, mode);
 }
 
 QMimeType DMimeDatabase::mimeTypeForFile(const QFileInfo &fileInfo, QMimeDatabase::MatchMode mode) const
 {
-    // Ignore the mode argument if file is retome file
-    if (!fileInfo.isDir() && FileUtils::isGvfsMountFile(fileInfo.absoluteFilePath()))
-        return QMimeDatabase::mimeTypeForFile(fileInfo, QMimeDatabase::MatchExtension);
-
     return QMimeDatabase::mimeTypeForFile(fileInfo, mode);
 }
 

--- a/dde-file-manager-lib/io/dstorageinfo.cpp
+++ b/dde-file-manager-lib/io/dstorageinfo.cpp
@@ -227,7 +227,8 @@ bool DStorageInfo::isLowSpeedDevice() const
 
     return device.startsWith("mtp://")
             || device.startsWith("gphoto://")
-            || device.startsWith("gphoto2://");
+            || device.startsWith("gphoto2://")
+            || device.startsWith("smb-share://");
 }
 
 bool DStorageInfo::isValid() const
@@ -325,9 +326,7 @@ bool DStorageInfo::isLowSpeedDevice(const QString &path)
     if (match.hasMatch()) {
         const QString &scheme = match.captured("scheme");
 
-        if (scheme == "mtp" || scheme == "gphoto" || scheme == "gphoto2" || scheme == "smb-share") {
-            return true;
-        }
+        return (scheme == "mtp" || scheme == "gphoto" || scheme == "gphoto2" || scheme == "smb-share");
     }
 
     return DStorageInfo(path).isLowSpeedDevice();


### PR DESCRIPTION
修复gvfs挂载路径下的文件mimetype获取不精准