### PR TITLE
refactor: proxy dfmmd scheme

### DIFF
--- a/dde-desktop/view/canvasgridview.cpp
+++ b/dde-desktop/view/canvasgridview.cpp
@@ -2290,11 +2290,11 @@ void CanvasGridView::showEmptyAreaMenu(const Qt::ItemFlags &/*indexFlags*/)
     const QModelIndex &index = rootIndex();
     const DAbstractFileInfoPointer &info = model()->fileInfo(index);
     QVector<MenuAction> actions;
-    if (!autoMerge()) {
+//    if (!autoMerge()) {
         actions << MenuAction::NewFolder << MenuAction::NewDocument
                 << MenuAction::SortBy;
         actions << MenuAction::Paste;
-    }
+//    }
     actions << MenuAction::SelectAll << MenuAction::OpenInTerminal
             << MenuAction::Property << MenuAction::Separator;
 

--- a/dde-desktop/view/canvasgridview.cpp
+++ b/dde-desktop/view/canvasgridview.cpp
@@ -2290,11 +2290,11 @@ void CanvasGridView::showEmptyAreaMenu(const Qt::ItemFlags &/*indexFlags*/)
     const QModelIndex &index = rootIndex();
     const DAbstractFileInfoPointer &info = model()->fileInfo(index);
     QVector<MenuAction> actions;
-//    if (!autoMerge()) {
+    if (!autoMerge()) {
         actions << MenuAction::NewFolder << MenuAction::NewDocument
                 << MenuAction::SortBy;
         actions << MenuAction::Paste;
-//    }
+    }
     actions << MenuAction::SelectAll << MenuAction::OpenInTerminal
             << MenuAction::Property << MenuAction::Separator;
 

--- a/dde-file-manager-lib/controllers/appcontroller.cpp
+++ b/dde-file-manager-lib/controllers/appcontroller.cpp
@@ -344,10 +344,9 @@ void AppController::actionAddToBookMark(const QSharedPointer<DFMUrlBaseEvent> &e
 
 void AppController::actionNewFolder(const QSharedPointer<DFMUrlBaseEvent> &event)
 {
-    const QString targetDir = event->url().toLocalFile(); // ???????????????????????????????
-    const QString name = FileUtils::newDocmentName(targetDir, tr("New Folder"), QString());
+    DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, event->url());
 
-    fileService->mkdir(event->sender(), DUrl::fromLocalFile(name));
+    fileService->mkdir(event->sender(), FileUtils::newDocumentUrl(info, tr("New Folder"), QString()));
 }
 
 void AppController::actionSelectAll(quint64 winId)
@@ -374,38 +373,30 @@ void AppController::actionClearTrash(const QObject *sender)
 
 void AppController::actionNewWord(const QSharedPointer<DFMUrlBaseEvent> &event)
 {
-    const DUrl &fileUrl = event->url();
     int windowId = event->windowId();
-//    QString targetFile = FileUtils::newDocmentName(fileUrl.toLocalFile(), QObject::tr("Document"), "doc");
-//    AppController::selectionAndRenameFile = qMakePair(DUrl::fromLocalFile(targetFile), windowId);
-    FileUtils::cpTemplateFileToTargetDir(fileUrl.toLocalFile(), QObject::tr("Document"), "doc", windowId);
+    DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, event->url());
+    FileUtils::cpTemplateFileToTargetDir(info->toLocalFile(), QObject::tr("Document"), "doc", windowId);
 }
 
 void AppController::actionNewExcel(const QSharedPointer<DFMUrlBaseEvent> &event)
 {
-    const DUrl &fileUrl = event->url();
     int windowId = event->windowId();
-//    QString targetFile = FileUtils::newDocmentName(fileUrl.toLocalFile(), QObject::tr("Spreadsheet"), "xls");
-//    AppController::selectionAndRenameFile = qMakePair(DUrl::fromLocalFile(targetFile), windowId);
-    FileUtils::cpTemplateFileToTargetDir(fileUrl.toLocalFile(), QObject::tr("Spreadsheet"), "xls", windowId);
+    DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, event->url());
+    FileUtils::cpTemplateFileToTargetDir(info->toLocalFile(), QObject::tr("Spreadsheet"), "xls", windowId);
 }
 
 void AppController::actionNewPowerpoint(const QSharedPointer<DFMUrlBaseEvent> &event)
 {
-    const DUrl &fileUrl = event->url();
     int windowId = event->windowId();
-//    QString targetFile = FileUtils::newDocmentName(fileUrl.toLocalFile(), QObject::tr("Presentation"), "ppt");
-//    AppController::selectionAndRenameFile = qMakePair(DUrl::fromLocalFile(targetFile), windowId);
-    FileUtils::cpTemplateFileToTargetDir(fileUrl.toLocalFile(), QObject::tr("Presentation"), "ppt", windowId);
+    DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, event->url());
+    FileUtils::cpTemplateFileToTargetDir(info->toLocalFile(), QObject::tr("Presentation"), "ppt", windowId);
 }
 
 void AppController::actionNewText(const QSharedPointer<DFMUrlBaseEvent> &event)
 {
-    const DUrl &fileUrl = event->url();
     int windowId = event->windowId();
-//    QString targetFile = FileUtils::newDocmentName(fileUrl.toLocalFile(), QObject::tr("Text"), "txt");
-//    AppController::selectionAndRenameFile = qMakePair(DUrl::fromLocalFile(targetFile), windowId);
-    FileUtils::cpTemplateFileToTargetDir(fileUrl.toLocalFile(), QObject::tr("Text"), "txt", windowId);
+    DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, event->url());
+    FileUtils::cpTemplateFileToTargetDir(info->toLocalFile(), QObject::tr("Text"), "txt", windowId);
 }
 
 void AppController::actionMount(const QSharedPointer<DFMUrlBaseEvent> &event)

--- a/dde-file-manager-lib/controllers/appcontroller.cpp
+++ b/dde-file-manager-lib/controllers/appcontroller.cpp
@@ -344,7 +344,7 @@ void AppController::actionAddToBookMark(const QSharedPointer<DFMUrlBaseEvent> &e
 
 void AppController::actionNewFolder(const QSharedPointer<DFMUrlBaseEvent> &event)
 {
-    const QString targetDir = event->url().toLocalFile();
+    const QString targetDir = event->url().toLocalFile(); // ???????????????????????????????
     const QString name = FileUtils::newDocmentName(targetDir, tr("New Folder"), QString());
 
     fileService->mkdir(event->sender(), DUrl::fromLocalFile(name));

--- a/dde-file-manager-lib/controllers/appcontroller.h
+++ b/dde-file-manager-lib/controllers/appcontroller.h
@@ -163,6 +163,7 @@ private:
     bool m_hasLaunchAppInterface = false;
 
     friend class FileController;
+    friend class MergedDesktopController;
     friend class DFileSystemModel;
     friend class DFileViewHelper;
     friend class DRenameBar;

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
@@ -308,7 +308,7 @@ bool MergedDesktopController::touch(const QSharedPointer<DFMTouchFileEvent> &eve
 
 bool MergedDesktopController::setPermissions(const QSharedPointer<DFMSetPermissionEvent> &event) const
 {
-    return DFileService::instance()->setPermissions(event->sender(), event->url(), event->permissions());
+    return DFileService::instance()->setPermissions(event->sender(), convertToRealPath(event->url()), event->permissions());
 }
 
 bool MergedDesktopController::compressFiles(const QSharedPointer<DFMCompressEvnet> &event) const

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
@@ -29,9 +29,125 @@
 #include "interfaces/dfmstandardpaths.h"
 #include "models/mergeddesktopfileinfo.h"
 #include "interfaces/private/mergeddesktop_common_p.h"
+#include "private/dabstractfilewatcher_p.h"
 
 #include <QList>
 #include <QStandardPaths>
+
+class MergedDesktopWatcherPrivate;
+class MergedDesktopWatcher : public DAbstractFileWatcher
+{
+public:
+    explicit MergedDesktopWatcher(const DUrl &url, DAbstractFileWatcher *baseWatcher, QObject *parent = nullptr);
+
+    void setEnabledSubfileWatcher(const DUrl &subfileUrl, bool enabled = true) override;
+
+private:
+    void addWatcher(const DUrl &url);
+    void removeWatcher(const DUrl &url);
+
+    void onFileAttributeChanged(const DUrl &url);
+    void onFileModified(const DUrl &url);
+
+    Q_DECLARE_PRIVATE(MergedDesktopWatcher)
+};
+
+class MergedDesktopWatcherPrivate : public DAbstractFileWatcherPrivate
+{
+public:
+    MergedDesktopWatcherPrivate(DAbstractFileWatcher *qq)
+        : DAbstractFileWatcherPrivate(qq) {}
+
+    bool start() override
+    {
+        started = true;
+
+        return true;
+    }
+
+    bool stop() override
+    {
+        started = false;
+
+        return true;
+    }
+
+    QMap<DUrl, DAbstractFileWatcher *> urlToWatcherMap;
+
+    Q_DECLARE_PUBLIC(MergedDesktopWatcher)
+};
+
+MergedDesktopWatcher::MergedDesktopWatcher(const DUrl &url, DAbstractFileWatcher *baseWatcher, QObject *parent)
+    : DAbstractFileWatcher(*new MergedDesktopWatcherPrivate(this), url, parent)
+{
+    connect(baseWatcher, &DAbstractFileWatcher::fileAttributeChanged, this, &MergedDesktopWatcher::onFileAttributeChanged);
+    connect(baseWatcher, &DAbstractFileWatcher::fileModified, this, &MergedDesktopWatcher::onFileModified);
+}
+
+void MergedDesktopWatcher::setEnabledSubfileWatcher(const DUrl &subfileUrl, bool enabled)
+{
+    if (subfileUrl.scheme() != DFMMD_SCHEME) {
+        return;
+    }
+
+    if (enabled) {
+        addWatcher(subfileUrl);
+    } else {
+        removeWatcher(subfileUrl);
+    }
+}
+
+void MergedDesktopWatcher::addWatcher(const DUrl &url)
+{
+    Q_D(MergedDesktopWatcher);
+
+    if (!url.isValid() || d->urlToWatcherMap.contains(url)) {
+        return;
+    }
+
+    DUrl real_url = MergedDesktopController::convertToRealPath(url);
+
+    DAbstractFileWatcher *watcher = DFileService::instance()->createFileWatcher(this, real_url);
+
+    if (!watcher) {
+        return;
+    }
+
+    watcher->moveToThread(this->thread());
+    watcher->setParent(this);
+
+    connect(watcher, &DAbstractFileWatcher::fileAttributeChanged, this, &MergedDesktopWatcher::onFileAttributeChanged);
+    connect(watcher, &DAbstractFileWatcher::fileModified, this, &MergedDesktopWatcher::onFileModified);
+
+    d->urlToWatcherMap[url] = watcher;
+
+    if (d->started) {
+        watcher->startWatcher();
+    }
+}
+
+void MergedDesktopWatcher::removeWatcher(const DUrl &url)
+{
+    Q_D(MergedDesktopWatcher);
+
+    DAbstractFileWatcher *watcher = d->urlToWatcherMap.take(url);
+
+    if (!watcher) {
+        return;
+    }
+
+    watcher->deleteLater();
+}
+
+void MergedDesktopWatcher::onFileAttributeChanged(const DUrl &url)
+{
+    emit fileAttributeChanged(MergedDesktopController::convertToDFMMDPath(url));
+}
+
+void MergedDesktopWatcher::onFileModified(const DUrl &url)
+{
+    emit fileModified(MergedDesktopController::convertToDFMMDPath(url));
+}
 
 MergedDesktopController::MergedDesktopController(QObject *parent)
     : DAbstractFileController(parent),
@@ -45,7 +161,7 @@ MergedDesktopController::MergedDesktopController(QObject *parent)
 
 const DAbstractFileInfoPointer MergedDesktopController::createFileInfo(const QSharedPointer<DFMCreateFileInfoEvnet> &event) const
 {
-    return DAbstractFileInfoPointer(new MergedDesktopFileInfo(event->url()));
+    return DAbstractFileInfoPointer(new MergedDesktopFileInfo(event->url(), currentUrl));
 }
 
 const QList<DAbstractFileInfoPointer> MergedDesktopController::getChildren(const QSharedPointer<DFMGetChildrensEvent> &event) const
@@ -57,7 +173,7 @@ const QList<DAbstractFileInfoPointer> MergedDesktopController::getChildren(const
     // blumia: 文件监听占用完了的时候有可能桌面会监听不到文件变动,此时即便 F5 也不会刷新该 Controller 存储的整理桌面数据,故改为每次都重新初始化整理数据
     initData();
 
-    DUrl currentUrl { event->url() };
+    currentUrl = event->url();
     QString path { currentUrl.path() };
     QList<DAbstractFileInfoPointer> infoList;
 
@@ -70,7 +186,7 @@ const QList<DAbstractFileInfoPointer> MergedDesktopController::getChildren(const
             QString entryName = entryNameByEnum(oneType);
             DUrl url(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(oneType));
             DAbstractFileInfoPointer infoPtr {
-                DFileService::instance()->createFileInfo(this, url)
+                new MergedDesktopFileInfo(url, currentUrl)
             };
             infoList.push_back(infoPtr);
             if (expandedEntries.contains(entryName)) {
@@ -81,7 +197,9 @@ const QList<DAbstractFileInfoPointer> MergedDesktopController::getChildren(const
 
     auto appendFolders = [this, &infoList]() {
         for (const DUrl & url : arrangedFileUrls[DMD_FOLDER]) {
-            DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, url);
+            DAbstractFileInfoPointer info {
+                new MergedDesktopFileInfo(convertToDFMMDPath(url), currentUrl)
+            };
             infoList.append(info);
         }
     };
@@ -89,7 +207,7 @@ const QList<DAbstractFileInfoPointer> MergedDesktopController::getChildren(const
     auto makeAndInsertInfo = [this, &infoList](QString urlStr) {
         DUrl entryUrl(urlStr);
         DAbstractFileInfoPointer adeEntryInfoPtr {
-            DFileService::instance()->createFileInfo(this, entryUrl)
+            new MergedDesktopFileInfo(convertToDFMMDPath(entryUrl), currentUrl)
         };
         infoList.push_back(adeEntryInfoPtr);
     };
@@ -125,32 +243,128 @@ const QList<DAbstractFileInfoPointer> MergedDesktopController::getChildren(const
 
 DAbstractFileWatcher *MergedDesktopController::createFileWatcher(const QSharedPointer<DFMCreateFileWatcherEvent> &) const
 {
-    return new DFileWatcher(QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first(), nullptr);
+    return new MergedDesktopWatcher(DUrl(DFMMD_ROOT MERGEDDESKTOP_FOLDER), m_desktopFileWatcher, nullptr);
+}
+
+bool MergedDesktopController::openFile(const QSharedPointer<DFMOpenFileEvent> &event) const
+{
+    return DFileService::instance()->openFile(event->sender(), convertToRealPath(event->url()));
+}
+
+bool MergedDesktopController::openFileByApp(const QSharedPointer<DFMOpenFileByAppEvent> &event) const
+{
+    return DFileService::instance()->openFileByApp(event->sender(), event->appName(), convertToRealPath(event->url()));
 }
 
 DUrlList MergedDesktopController::moveToTrash(const QSharedPointer<DFMMoveToTrashEvent> &event) const
 {
-    DUrlList urlList = event->urlList();
-    for (const DUrl &url : urlList) {
-        if (url.scheme() == DFMMD_SCHEME) {
-            urlList.removeOne(url);
-        }
-    }
+    DUrlList urlList = convertToRealPaths(event->urlList());
     return DFileService::instance()->moveToTrash(event->sender(), urlList);
+}
+
+bool MergedDesktopController::writeFilesToClipboard(const QSharedPointer<DFMWriteUrlsToClipboardEvent> &event) const
+{
+    DUrlList urlList = convertToRealPaths(event->urlList());
+    return DFileService::instance()->writeFilesToClipboard(event->sender(), event->action(), urlList);
 }
 
 DUrlList MergedDesktopController::pasteFile(const QSharedPointer<DFMPasteEvent> &event) const
 {
-    return DAbstractFileController::pasteFile(
-                dMakeEventPointer<DFMPasteEvent>(event->sender(), event->action(),
-                                                 DUrl::fromLocalFile(QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first()),
-                                                 event->fileUrlList())
-                );
+    return DFileService::instance()->pasteFile(event->sender(), event->action(),
+                                               DUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)),
+                                               event->fileUrlList());
+}
+
+bool MergedDesktopController::deleteFiles(const QSharedPointer<DFMDeleteEvent> &event) const
+{
+    DUrlList urlList = convertToRealPaths(event->urlList());
+    return DFileService::instance()->deleteFiles(event->sender(), urlList);
+}
+
+bool MergedDesktopController::renameFile(const QSharedPointer<DFMRenameEvent> &event) const
+{
+    return DFileService::instance()->renameFile(event->sender(),
+                                                convertToRealPath(event->fromUrl()),
+                                                convertToRealPath(event->toUrl()));
 }
 
 bool MergedDesktopController::openInTerminal(const QSharedPointer<DFMOpenInTerminalEvent> &event) const
 {
-    return DFileService::instance()->openInTerminal(event->sender(), DUrl::fromLocalFile(DFMStandardPaths::location(DFMStandardPaths::DesktopPath)));
+    return DFileService::instance()->openInTerminal(event->sender(),
+                                                    DUrl::fromLocalFile(DFMStandardPaths::location(DFMStandardPaths::DesktopPath)));
+}
+
+bool MergedDesktopController::mkdir(const QSharedPointer<DFMMkdirEvent> &event) const
+{
+    return DFileService::instance()->mkdir(event->sender(),
+                                           DUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)));
+}
+
+bool MergedDesktopController::touch(const QSharedPointer<DFMTouchFileEvent> &event) const
+{
+    return DFileService::instance()->touchFile(event->sender(),
+                                               DUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)));
+}
+
+bool MergedDesktopController::setPermissions(const QSharedPointer<DFMSetPermissionEvent> &event) const
+{
+    return DFileService::instance()->setPermissions(event->sender(), event->url(), event->permissions());
+}
+
+bool MergedDesktopController::compressFiles(const QSharedPointer<DFMCompressEvnet> &event) const
+{
+    DUrlList urlList = convertToRealPaths(event->urlList());
+    return DFileService::instance()->compressFiles(event->sender(), urlList);
+}
+
+bool MergedDesktopController::decompressFile(const QSharedPointer<DFMDecompressEvnet> &event) const
+{
+    DUrlList urlList = convertToRealPaths(event->urlList());
+    return DFileService::instance()->decompressFile(event->sender(), urlList);
+}
+
+bool MergedDesktopController::createSymlink(const QSharedPointer<DFMCreateSymlinkEvent> &event) const
+{
+    return DFileService::instance()->createSymlink(event->sender(),
+                                                   convertToRealPath(event->fileUrl()),
+                                                   convertToRealPath(event->toUrl()));
+}
+
+bool MergedDesktopController::setFileTags(const QSharedPointer<DFMSetFileTagsEvent> &event) const
+{
+    return DFileService::instance()->setFileTags(event->sender(), convertToRealPath(event->url()), event->tags());
+}
+
+bool MergedDesktopController::removeTagsOfFile(const QSharedPointer<DFMRemoveTagsOfFileEvent> &event) const
+{
+    return DFileService::instance()->removeTagsOfFile(event->sender(), convertToRealPath(event->url()), event->tags());
+}
+
+QList<QString> MergedDesktopController::getTagsThroughFiles(const QSharedPointer<DFMGetTagsThroughFilesEvent> &event) const
+{
+    DUrlList urlList = convertToRealPaths(event->urlList());
+    return DFileService::instance()->getTagsThroughFiles(event->sender(), urlList);
+}
+
+DFileDevice *MergedDesktopController::createFileDevice(const QSharedPointer<DFMUrlBaseEvent> &event) const
+{
+    return DFileService::instance()->createFileDevice(event->sender(), convertToRealPath(event->url()));
+}
+
+DFileHandler *MergedDesktopController::createFileHandler(const QSharedPointer<DFMUrlBaseEvent> &event) const
+{
+    return DFileService::instance()->createFileHandler(event->sender(), convertToRealPath(event->url()));
+}
+
+DStorageInfo *MergedDesktopController::createStorageInfo(const QSharedPointer<DFMUrlBaseEvent> &event) const
+{
+    return DFileService::instance()->createStorageInfo(event->sender(), convertToRealPath(event->url()));
+}
+
+bool MergedDesktopController::setExtensionPropertys(const QSharedPointer<DFMSetFileExtensionPropertys> &event) const
+{
+    return DFileService::instance()->setExtensionPropertys(event->sender(), convertToRealPath(event->url()),
+                                                           event->extensionPropertys());
 }
 
 const QString MergedDesktopController::entryNameByEnum(DMD_TYPES singleType)
@@ -197,78 +411,7 @@ DMD_TYPES MergedDesktopController::entryTypeByName(QString entryName)
 }
 
 
-void MergedDesktopController::desktopFilesCreated(const DUrl &url)
-{
-    DMD_TYPES typeInfo = checkUrlArrangedType(url);
-    arrangedFileUrls[typeInfo].append(url);
-    if (typeInfo == DMD_FOLDER) {
-        DUrl parentUrl(DFMMD_ROOT VIRTUALFOLDER_FOLDER "/");
-        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::subfileCreated, url);
-    } else {
-        DUrl parentUrl(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(typeInfo) + "/");
-        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::subfileCreated, url);
-    }
-    DUrl parentUrl2(DFMMD_ROOT MERGEDDESKTOP_FOLDER);
-    DAbstractFileWatcher::ghostSignal(parentUrl2, &DAbstractFileWatcher::subfileCreated, url);
-}
-
-void MergedDesktopController::desktopFilesRemoved(const DUrl &url)
-{
-    for (unsigned int i = DMD_FIRST_TYPE; i <= DMD_ALL_TYPE; i++) {
-        DMD_TYPES typeInfo = static_cast<DMD_TYPES>(i);
-        if (arrangedFileUrls[typeInfo].removeOne(url)) {
-            if (typeInfo == DMD_FOLDER) {
-                DUrl parentUrl(DFMMD_ROOT VIRTUALFOLDER_FOLDER "/");
-                DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileDeleted, url);
-            } else {
-                DUrl parentUrl(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(typeInfo) + "/");
-                DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileDeleted, url);
-            }
-            DUrl parentUrl2(DFMMD_ROOT MERGEDDESKTOP_FOLDER);
-            DAbstractFileWatcher::ghostSignal(parentUrl2, &DAbstractFileWatcher::fileDeleted, url);
-            return;
-        }
-    }
-}
-
-void MergedDesktopController::desktopFilesRenamed(const DUrl &oriUrl, const DUrl &dstUrl)
-{
-    for (unsigned int i = DMD_FIRST_TYPE; i <= DMD_ALL_TYPE; i++) {
-        DMD_TYPES typeInfo = static_cast<DMD_TYPES>(i);
-        if (arrangedFileUrls[typeInfo].removeOne(oriUrl)) {
-            break;
-        }
-    }
-    DMD_TYPES typeInfo = checkUrlArrangedType(dstUrl);
-    arrangedFileUrls[typeInfo].append(dstUrl);
-
-    if (typeInfo == DMD_FOLDER) {
-        DUrl parentUrl(DFMMD_ROOT VIRTUALFOLDER_FOLDER "/");
-        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileMoved, oriUrl, dstUrl);
-    } else {
-        DUrl parentUrl(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(typeInfo) + "/");
-        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileMoved, oriUrl, dstUrl);
-    }
-    DUrl parentUrl2(DFMMD_ROOT MERGEDDESKTOP_FOLDER);
-    DAbstractFileWatcher::ghostSignal(parentUrl2, &DAbstractFileWatcher::fileMoved, oriUrl, dstUrl);
-}
-
-void MergedDesktopController::initData() const
-{
-    arrangedFileUrls.clear();
-
-    QDir desktopDir(QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first());
-    const QStringList &fileList = desktopDir.entryList(QDir::AllEntries | QDir::NoDotAndDotDot);
-    for (const QString &oneFile : fileList) {
-        DUrl oneUrl = DUrl::fromLocalFile(desktopDir.filePath(oneFile));
-        DMD_TYPES typeInfo = checkUrlArrangedType(oneUrl);
-        arrangedFileUrls[typeInfo].append(oneUrl);
-    }
-
-    return;
-}
-
-DMD_TYPES MergedDesktopController::checkUrlArrangedType(const DUrl url) const
+DMD_TYPES MergedDesktopController::checkUrlArrangedType(const DUrl url)
 {
     DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, url);
     if (info) {
@@ -293,10 +436,135 @@ DMD_TYPES MergedDesktopController::checkUrlArrangedType(const DUrl url) const
     return DMD_OTHER;
 }
 
+void MergedDesktopController::desktopFilesCreated(const DUrl &url)
+{
+    DMD_TYPES typeInfo = checkUrlArrangedType(url);
+    arrangedFileUrls[typeInfo].append(url);
+    DUrl vUrl = convertToDFMMDPath(url, typeInfo);
+
+    if (typeInfo == DMD_FOLDER) {
+        DUrl parentUrl(DFMMD_ROOT VIRTUALFOLDER_FOLDER "/");
+        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::subfileCreated, vUrl);
+    } else {
+        DUrl parentUrl(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(typeInfo) + "/");
+        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::subfileCreated, vUrl);
+    }
+    DUrl parentUrl2(DFMMD_ROOT MERGEDDESKTOP_FOLDER);
+    DAbstractFileWatcher::ghostSignal(parentUrl2, &DAbstractFileWatcher::subfileCreated, vUrl);
+}
+
+void MergedDesktopController::desktopFilesRemoved(const DUrl &url)
+{
+    for (unsigned int i = DMD_FIRST_TYPE; i <= DMD_ALL_TYPE; i++) {
+        DMD_TYPES typeInfo = static_cast<DMD_TYPES>(i);
+        if (arrangedFileUrls[typeInfo].removeOne(url)) {
+            DUrl vUrl = convertToDFMMDPath(url, typeInfo);
+
+            if (typeInfo == DMD_FOLDER) {
+                DUrl parentUrl(DFMMD_ROOT VIRTUALFOLDER_FOLDER "/");
+                DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileDeleted, vUrl);
+            } else {
+                DUrl parentUrl(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(typeInfo) + "/");
+                DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileDeleted, vUrl);
+            }
+            DUrl parentUrl2(DFMMD_ROOT MERGEDDESKTOP_FOLDER);
+            DAbstractFileWatcher::ghostSignal(parentUrl2, &DAbstractFileWatcher::fileDeleted, vUrl);
+            return;
+        }
+    }
+}
+
+void MergedDesktopController::desktopFilesRenamed(const DUrl &oriUrl, const DUrl &dstUrl)
+{
+    for (unsigned int i = DMD_FIRST_TYPE; i <= DMD_ALL_TYPE; i++) {
+        DMD_TYPES typeInfo = static_cast<DMD_TYPES>(i);
+        if (arrangedFileUrls[typeInfo].removeOne(oriUrl)) {
+            break;
+        }
+    }
+
+    DMD_TYPES typeInfo = checkUrlArrangedType(dstUrl);
+    arrangedFileUrls[typeInfo].append(dstUrl);
+
+    DUrl vOriUrl = convertToDFMMDPath(oriUrl, typeInfo);
+    DUrl vDstUrl = convertToDFMMDPath(dstUrl, typeInfo);
+
+    if (typeInfo == DMD_FOLDER) {
+        DUrl parentUrl(DFMMD_ROOT VIRTUALFOLDER_FOLDER "/");
+        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileMoved, vOriUrl, vDstUrl);
+    } else {
+        DUrl parentUrl(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(typeInfo) + "/");
+        DAbstractFileWatcher::ghostSignal(parentUrl, &DAbstractFileWatcher::fileMoved, vOriUrl, vDstUrl);
+    }
+    DUrl parentUrl2(DFMMD_ROOT MERGEDDESKTOP_FOLDER);
+    DAbstractFileWatcher::ghostSignal(parentUrl2, &DAbstractFileWatcher::fileMoved, vOriUrl, vDstUrl);
+}
+
+void MergedDesktopController::initData() const
+{
+    arrangedFileUrls.clear();
+
+    QDir desktopDir(QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first());
+    const QStringList &fileList = desktopDir.entryList(QDir::AllEntries | QDir::NoDotAndDotDot);
+    for (const QString &oneFile : fileList) {
+        DUrl oneUrl = DUrl::fromLocalFile(desktopDir.filePath(oneFile));
+        DMD_TYPES typeInfo = checkUrlArrangedType(oneUrl);
+        arrangedFileUrls[typeInfo].append(oneUrl);
+    }
+
+    return;
+}
+
 void MergedDesktopController::appendEntryFiles(QList<DAbstractFileInfoPointer> &infoList, const DMD_TYPES &entryType) const
 {
     for (const DUrl & url : arrangedFileUrls[entryType]) {
-        DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, url);
+        DAbstractFileInfoPointer info {
+            new MergedDesktopFileInfo(convertToDFMMDPath(url), currentUrl)
+        };
         infoList.append(info);
     }
+}
+
+DUrl MergedDesktopController::convertToDFMMDPath(const DUrl &oriUrl)
+{
+    DMD_TYPES typeInfo = checkUrlArrangedType(oriUrl);
+    QDir desktopDir(QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first());
+
+    return convertToDFMMDPath(oriUrl, typeInfo);
+}
+
+DUrl MergedDesktopController::convertToDFMMDPath(const DUrl &oriUrl, DMD_TYPES oneType)
+{
+    DUrl vUrl;
+
+    if (oneType == DMD_FOLDER) {
+        vUrl = DUrl(DFMMD_ROOT VIRTUALFOLDER_FOLDER + oriUrl.fileName());
+    } else {
+        vUrl = DUrl(DFMMD_ROOT VIRTUALENTRY_FOLDER + entryNameByEnum(oneType) + QDir::separator() + oriUrl.fileName());
+    }
+
+    return vUrl;
+}
+
+DUrl MergedDesktopController::convertToRealPath(const DUrl &oneUrl)
+{
+    if (oneUrl.scheme() != DFMMD_SCHEME) return oneUrl;
+
+    QString desktopPath = QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first() + QDir::separator();
+
+    return DUrl::fromLocalFile(desktopPath + oneUrl.fileName());
+}
+
+DUrlList MergedDesktopController::convertToRealPaths(DUrlList urlList)
+{
+    for (DUrl &url : urlList) {
+        DAbstractFileInfoPointer info = DFileService::instance()->createFileInfo(nullptr, url);
+        if (info && info->isVirtualEntry()) {
+            urlList.removeOne(url);
+            continue;
+        }
+        url = convertToRealPath(url);
+    }
+
+    return urlList;
 }

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
@@ -24,6 +24,7 @@
 #include "dfmevent.h"
 #include "dfilewatcher.h"
 #include "dfileservices.h"
+#include "appcontroller.h"
 
 #include "interfaces/dfileservices.h"
 #include "interfaces/dfmstandardpaths.h"
@@ -294,16 +295,26 @@ bool MergedDesktopController::openInTerminal(const QSharedPointer<DFMOpenInTermi
                                                     DUrl::fromLocalFile(DFMStandardPaths::location(DFMStandardPaths::DesktopPath)));
 }
 
+// fixme: AppController::actionNewFolder 调了 FileUtils::newDocumentUrl 调了 getUrlByChildFileName ,可能需要重写
+//        否则在自动整理视图下新建文件后不会被选中
 bool MergedDesktopController::mkdir(const QSharedPointer<DFMMkdirEvent> &event) const
 {
-    return DFileService::instance()->mkdir(event->sender(),
-                                           DUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)));
+    bool result = DFileService::instance()->mkdir(event->sender(),
+                                                  DUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)));
+
+    AppController::selectionAndRenameFile = qMakePair(event->url(), event->windowId());
+
+    return result;
 }
 
 bool MergedDesktopController::touch(const QSharedPointer<DFMTouchFileEvent> &event) const
 {
-    return DFileService::instance()->touchFile(event->sender(),
+    bool result = DFileService::instance()->touchFile(event->sender(),
                                                DUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)));
+
+    AppController::selectionAndRenameFile = qMakePair(event->url(), event->windowId());
+
+    return result;
 }
 
 bool MergedDesktopController::setPermissions(const QSharedPointer<DFMSetPermissionEvent> &event) const

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
@@ -271,6 +271,8 @@ bool MergedDesktopController::writeFilesToClipboard(const QSharedPointer<DFMWrit
 
 DUrlList MergedDesktopController::pasteFile(const QSharedPointer<DFMPasteEvent> &event) const
 {
+    return DUrlList(); // disabled for now.
+
     return DFileService::instance()->pasteFile(event->sender(), event->action(),
                                                DUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)),
                                                event->fileUrlList());

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
@@ -361,10 +361,10 @@ DStorageInfo *MergedDesktopController::createStorageInfo(const QSharedPointer<DF
     return DFileService::instance()->createStorageInfo(event->sender(), convertToRealPath(event->url()));
 }
 
-bool MergedDesktopController::setExtensionPropertys(const QSharedPointer<DFMSetFileExtensionPropertys> &event) const
+bool MergedDesktopController::setExtraProperties(const QSharedPointer<DFMSetFileExtraProperties> &event) const
 {
-    return DFileService::instance()->setExtensionPropertys(event->sender(), convertToRealPath(event->url()),
-                                                           event->extensionPropertys());
+    return DFileService::instance()->setExtraProperties(event->sender(), convertToRealPath(event->url()),
+                                                           event->extraProperties());
 }
 
 const QString MergedDesktopController::entryNameByEnum(DMD_TYPES singleType)

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.cpp
@@ -439,6 +439,10 @@ DMD_TYPES MergedDesktopController::checkUrlArrangedType(const DUrl url)
 void MergedDesktopController::desktopFilesCreated(const DUrl &url)
 {
     DMD_TYPES typeInfo = checkUrlArrangedType(url);
+    if (arrangedFileUrls[typeInfo].contains(url)) {
+        qWarning() << url << "existed, it must be a bug!!!!!!!!";
+        arrangedFileUrls[typeInfo].removeAll(url);
+    }
     arrangedFileUrls[typeInfo].append(url);
     DUrl vUrl = convertToDFMMDPath(url, typeInfo);
 

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
@@ -65,7 +65,7 @@ public:
     DFM_NAMESPACE::DFileHandler *createFileHandler(const QSharedPointer<DFMUrlBaseEvent> &event) const override;
     DFM_NAMESPACE::DStorageInfo *createStorageInfo(const QSharedPointer<DFMUrlBaseEvent> &event) const override;
 
-    bool setExtensionPropertys(const QSharedPointer<DFMSetFileExtensionPropertys> &event) const override;
+    bool setExtraProperties(const QSharedPointer<DFMSetFileExtraProperties> &event) const override;
 
     const static QString entryNameByEnum(DMD_TYPES singleType);
     static DMD_TYPES entryTypeByName(QString entryName);

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
@@ -41,15 +41,39 @@ public:
     const QList<DAbstractFileInfoPointer> getChildren(const QSharedPointer<DFMGetChildrensEvent> &event) const override;
     DAbstractFileWatcher *createFileWatcher(const QSharedPointer<DFMCreateFileWatcherEvent> &) const override;
 
-//    bool openFile(const QSharedPointer<DFMOpenFileEvent> &event) const override;
+    bool openFile(const QSharedPointer<DFMOpenFileEvent> &event) const override;
+    bool openFileByApp(const QSharedPointer<DFMOpenFileByAppEvent> &event) const override;
     DUrlList moveToTrash(const QSharedPointer<DFMMoveToTrashEvent> &event) const override;
-//    bool writeFilesToClipboard(const QSharedPointer<DFMWriteUrlsToClipboardEvent> &event) const override;
+    bool writeFilesToClipboard(const QSharedPointer<DFMWriteUrlsToClipboardEvent> &event) const override;
     DUrlList pasteFile(const QSharedPointer<DFMPasteEvent> &event) const override;
-//    bool deleteFiles(const QSharedPointer<DFMDeleteEvent> &event) const override;
+    bool deleteFiles(const QSharedPointer<DFMDeleteEvent> &event) const override;
+    bool renameFile(const QSharedPointer<DFMRenameEvent> &event) const override;
     bool openInTerminal(const QSharedPointer<DFMOpenInTerminalEvent> &event) const override;
+
+    bool mkdir(const QSharedPointer<DFMMkdirEvent> &event) const override;
+    bool touch(const QSharedPointer<DFMTouchFileEvent> &event) const override;
+    bool setPermissions(const QSharedPointer<DFMSetPermissionEvent> &event) const override;//
+    bool compressFiles(const QSharedPointer<DFMCompressEvnet> &event) const override;
+    bool decompressFile(const QSharedPointer<DFMDecompressEvnet> &event) const override;//
+    bool createSymlink(const QSharedPointer<DFMCreateSymlinkEvent> &event) const override;
+
+    bool setFileTags(const QSharedPointer<DFMSetFileTagsEvent> &event) const override;
+    bool removeTagsOfFile(const QSharedPointer<DFMRemoveTagsOfFileEvent> &event) const override;
+    QList<QString> getTagsThroughFiles(const QSharedPointer<DFMGetTagsThroughFilesEvent> &event) const override;
+
+    DFM_NAMESPACE::DFileDevice *createFileDevice(const QSharedPointer<DFMUrlBaseEvent> &event) const override;//
+    DFM_NAMESPACE::DFileHandler *createFileHandler(const QSharedPointer<DFMUrlBaseEvent> &event) const override;
+    DFM_NAMESPACE::DStorageInfo *createStorageInfo(const QSharedPointer<DFMUrlBaseEvent> &event) const override;
+
+    bool setExtensionPropertys(const QSharedPointer<DFMSetFileExtensionPropertys> &event) const override;
 
     const static QString entryNameByEnum(DMD_TYPES singleType);
     static DMD_TYPES entryTypeByName(QString entryName);
+    static DUrl convertToDFMMDPath(const DUrl &oriUrl);
+    static DUrl convertToDFMMDPath(const DUrl &oriUrl, DMD_TYPES oneType);
+    static DUrl convertToRealPath(const DUrl &oneUrl);
+    static DUrlList convertToRealPaths(DUrlList urlList);
+    static DMD_TYPES checkUrlArrangedType(const DUrl url);
 
 public slots:
     void desktopFilesCreated(const DUrl &url);
@@ -58,7 +82,6 @@ public slots:
 
 private:
     void initData() const;
-    DMD_TYPES checkUrlArrangedType(const DUrl url) const;
     void appendEntryFiles(QList<DAbstractFileInfoPointer> &infoList, const DMD_TYPES &entryType) const;
 
     DFileWatcher* m_desktopFileWatcher;

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
@@ -45,23 +45,23 @@ public:
     bool openFileByApp(const QSharedPointer<DFMOpenFileByAppEvent> &event) const override;
     DUrlList moveToTrash(const QSharedPointer<DFMMoveToTrashEvent> &event) const override;
     bool writeFilesToClipboard(const QSharedPointer<DFMWriteUrlsToClipboardEvent> &event) const override;
-    DUrlList pasteFile(const QSharedPointer<DFMPasteEvent> &event) const override;
+    DUrlList pasteFile(const QSharedPointer<DFMPasteEvent> &event) const override;//
     bool deleteFiles(const QSharedPointer<DFMDeleteEvent> &event) const override;
     bool renameFile(const QSharedPointer<DFMRenameEvent> &event) const override;
     bool openInTerminal(const QSharedPointer<DFMOpenInTerminalEvent> &event) const override;
 
     bool mkdir(const QSharedPointer<DFMMkdirEvent> &event) const override;
     bool touch(const QSharedPointer<DFMTouchFileEvent> &event) const override;
-    bool setPermissions(const QSharedPointer<DFMSetPermissionEvent> &event) const override;//
+    bool setPermissions(const QSharedPointer<DFMSetPermissionEvent> &event) const override;
     bool compressFiles(const QSharedPointer<DFMCompressEvnet> &event) const override;
-    bool decompressFile(const QSharedPointer<DFMDecompressEvnet> &event) const override;//
+    bool decompressFile(const QSharedPointer<DFMDecompressEvnet> &event) const override;
     bool createSymlink(const QSharedPointer<DFMCreateSymlinkEvent> &event) const override;
 
     bool setFileTags(const QSharedPointer<DFMSetFileTagsEvent> &event) const override;
     bool removeTagsOfFile(const QSharedPointer<DFMRemoveTagsOfFileEvent> &event) const override;
     QList<QString> getTagsThroughFiles(const QSharedPointer<DFMGetTagsThroughFilesEvent> &event) const override;
 
-    DFM_NAMESPACE::DFileDevice *createFileDevice(const QSharedPointer<DFMUrlBaseEvent> &event) const override;//
+    DFM_NAMESPACE::DFileDevice *createFileDevice(const QSharedPointer<DFMUrlBaseEvent> &event) const override;
     DFM_NAMESPACE::DFileHandler *createFileHandler(const QSharedPointer<DFMUrlBaseEvent> &event) const override;
     DFM_NAMESPACE::DStorageInfo *createStorageInfo(const QSharedPointer<DFMUrlBaseEvent> &event) const override;
 

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
@@ -45,12 +45,12 @@ public:
     bool openFileByApp(const QSharedPointer<DFMOpenFileByAppEvent> &event) const override;
     DUrlList moveToTrash(const QSharedPointer<DFMMoveToTrashEvent> &event) const override;
     bool writeFilesToClipboard(const QSharedPointer<DFMWriteUrlsToClipboardEvent> &event) const override;
-    DUrlList pasteFile(const QSharedPointer<DFMPasteEvent> &event) const override;//
+    DUrlList pasteFile(const QSharedPointer<DFMPasteEvent> &event) const override;
     bool deleteFiles(const QSharedPointer<DFMDeleteEvent> &event) const override;
     bool renameFile(const QSharedPointer<DFMRenameEvent> &event) const override;
     bool openInTerminal(const QSharedPointer<DFMOpenInTerminalEvent> &event) const override;
 
-    bool mkdir(const QSharedPointer<DFMMkdirEvent> &event) const override;
+    bool mkdir(const QSharedPointer<DFMMkdirEvent> &event) const override; // AppController::actionNewFolder 有问题
     bool touch(const QSharedPointer<DFMTouchFileEvent> &event) const override;
     bool setPermissions(const QSharedPointer<DFMSetPermissionEvent> &event) const override;
     bool compressFiles(const QSharedPointer<DFMCompressEvnet> &event) const override;

--- a/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
+++ b/dde-file-manager-lib/controllers/mergeddesktopcontroller.h
@@ -85,6 +85,7 @@ private:
     void appendEntryFiles(QList<DAbstractFileInfoPointer> &infoList, const DMD_TYPES &entryType) const;
 
     DFileWatcher* m_desktopFileWatcher;
+    mutable DUrl currentUrl;
 //    mutable bool dataInitialized = false;
     mutable QMap<DMD_TYPES, QList<DUrl> > arrangedFileUrls;
 };

--- a/dde-file-manager-lib/interfaces/dabstractfileinfo.cpp
+++ b/dde-file-manager-lib/interfaces/dabstractfileinfo.cpp
@@ -1177,6 +1177,8 @@ DUrl DAbstractFileInfo::getUrlByNewFileName(const QString &fileName) const
 
 DUrl DAbstractFileInfo::getUrlByChildFileName(const QString &fileName) const
 {
+    CALL_PROXY(getUrlByChildFileName(fileName));
+
     if (!isDir()) {
         return DUrl();
     }

--- a/dde-file-manager-lib/interfaces/dfilesystemmodel.cpp
+++ b/dde-file-manager-lib/interfaces/dfilesystemmodel.cpp
@@ -1022,10 +1022,7 @@ void DFileSystemModelPrivate::_q_processFileEvent()
             continue;
         }
 
-        // TODO: 此处不应当特判协议，这里的特判是由于整理桌面视图下的项目并非都是整理桌面协议的 URL，
-        //       应当将整理桌面视图下的项目均使用整理桌面协议代理，然后移除特判。
-        //      （判断 parentUrl != rootUrl 应当保留）
-        if (info->parentUrl() != rootUrl && rootUrl.scheme() != DFMMD_SCHEME) {
+        if (info->parentUrl() != rootUrl) {
             continue;
         }
 

--- a/dde-file-manager-lib/models/mergeddesktopfileinfo.cpp
+++ b/dde-file-manager-lib/models/mergeddesktopfileinfo.cpp
@@ -137,7 +137,8 @@ MergedDesktopFileInfo::MergedDesktopFileInfo(const DUrl &url, const DUrl &parent
 
     QString path = url.path();
     QString fileName = url.fileName();
-    QString realPath = QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first() + QDir::separator() + fileName;
+    QString desktopPath = QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first();
+    QString realPath = desktopPath + QDir::separator() + fileName;
 
     if (path.startsWith(VIRTUALENTRY_PATH)) {
         if (path.split('/', QString::SkipEmptyParts).count() != 2) {
@@ -152,7 +153,11 @@ MergedDesktopFileInfo::MergedDesktopFileInfo(const DUrl &url, const DUrl &parent
             setProxy(DAbstractFileInfoPointer(new VirtualEntryInfo(url)));
         }
     } else if (path.startsWith(MERGEDDESKTOP_PATH)) {
-        setProxy(DAbstractFileInfoPointer(new VirtualEntryInfo(url)));
+        if (path == MERGEDDESKTOP_PATH) {
+            setProxy(DAbstractFileInfoPointer(DFileService::instance()->createFileInfo(nullptr, DUrl::fromLocalFile(desktopPath))));
+        } else {
+            setProxy(DAbstractFileInfoPointer(new VirtualEntryInfo(url)));
+        }
     }
 }
 

--- a/dde-file-manager-lib/models/mergeddesktopfileinfo.cpp
+++ b/dde-file-manager-lib/models/mergeddesktopfileinfo.cpp
@@ -186,3 +186,23 @@ QString MergedDesktopFileInfo::genericIconName() const
 
     return DAbstractFileInfo::genericIconName();
 }
+
+bool MergedDesktopFileInfo::canRedirectionFileUrl() const
+{
+    Q_D(const MergedDesktopFileInfo);
+    if (d->proxy) {
+        return true;
+    }
+
+    return DAbstractFileInfo::canRedirectionFileUrl();
+}
+
+DUrl MergedDesktopFileInfo::redirectedFileUrl() const
+{
+    Q_D(const MergedDesktopFileInfo);
+    if (d->proxy) {
+        return d->proxy->fileUrl();
+    }
+
+    return DAbstractFileInfo::redirectedFileUrl();
+}

--- a/dde-file-manager-lib/models/mergeddesktopfileinfo.cpp
+++ b/dde-file-manager-lib/models/mergeddesktopfileinfo.cpp
@@ -26,6 +26,7 @@
 #include "private/dabstractfileinfo_p.h"
 #include "private/mergeddesktop_common_p.h"
 
+#include <QIcon>
 #include <QStandardPaths>
 
 class VirtualEntryInfo : public DAbstractFileInfo
@@ -119,41 +120,64 @@ public:
     }
 };
 
-class DesktopFileInfo : public DAbstractFileInfo
-{
-public:
-    DesktopFileInfo(const DUrl &url) : DAbstractFileInfo(url)
-    {
-        QStringList urlPartList = url.path().split('/', QString::SkipEmptyParts);
-        if (!urlPartList.isEmpty()) {
-            QString fileName = url.path().split('/', QString::SkipEmptyParts).last();
-            QString realPath = QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first() + QDir::separator() + fileName;
-            setProxy(DFileService::instance()->createFileInfo(nullptr, DUrl::fromLocalFile(realPath)));
-        }
-    }
-};
-
 class MergedDesktopFileInfoPrivate : public DAbstractFileInfoPrivate
 {
 public:
     MergedDesktopFileInfoPrivate(const DUrl &url, MergedDesktopFileInfo *qq)
         : DAbstractFileInfoPrivate(url, qq, true) {}
+
+    DUrl m_parentUrl;
 };
 
-MergedDesktopFileInfo::MergedDesktopFileInfo(const DUrl &url)
+MergedDesktopFileInfo::MergedDesktopFileInfo(const DUrl &url, const DUrl &parentUrl)
     : DAbstractFileInfo(*new MergedDesktopFileInfoPrivate(url, this))
 {
+    Q_D(MergedDesktopFileInfo);
+    d->m_parentUrl = parentUrl;
+
     QString path = url.path();
+    QString fileName = url.fileName();
+    QString realPath = QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first() + QDir::separator() + fileName;
 
     if (path.startsWith(VIRTUALENTRY_PATH)) {
-        setProxy(DAbstractFileInfoPointer(new VirtualEntryInfo(url)));
+        if (path.split('/', QString::SkipEmptyParts).count() != 2) {
+            setProxy(DAbstractFileInfoPointer(DFileService::instance()->createFileInfo(nullptr, DUrl::fromLocalFile(realPath))));
+        } else {
+            setProxy(DAbstractFileInfoPointer(new VirtualEntryInfo(url)));
+        }
     } else if (path.startsWith(VIRTUALFOLDER_PATH)) {
         if (path != VIRTUALFOLDER_PATH) {
-            setProxy(DAbstractFileInfoPointer(new DesktopFileInfo(url)));
+            setProxy(DAbstractFileInfoPointer(DFileService::instance()->createFileInfo(nullptr, DUrl::fromLocalFile(realPath))));
         } else {
             setProxy(DAbstractFileInfoPointer(new VirtualEntryInfo(url)));
         }
     } else if (path.startsWith(MERGEDDESKTOP_PATH)) {
         setProxy(DAbstractFileInfoPointer(new VirtualEntryInfo(url)));
     }
+}
+
+DUrl MergedDesktopFileInfo::parentUrl() const
+{
+    Q_D(const MergedDesktopFileInfo);
+    return d->m_parentUrl;
+}
+
+QString MergedDesktopFileInfo::iconName() const
+{
+    Q_D(const MergedDesktopFileInfo);
+    if (d->proxy) {
+        return d->proxy->iconName();
+    }
+
+    return DAbstractFileInfo::iconName();
+}
+
+QString MergedDesktopFileInfo::genericIconName() const
+{
+    Q_D(const MergedDesktopFileInfo);
+    if (d->proxy) {
+        return d->proxy->genericIconName();
+    }
+
+    return DAbstractFileInfo::genericIconName();
 }

--- a/dde-file-manager-lib/models/mergeddesktopfileinfo.h
+++ b/dde-file-manager-lib/models/mergeddesktopfileinfo.h
@@ -28,7 +28,11 @@ class MergedDesktopFileInfoPrivate;
 class MergedDesktopFileInfo : public DAbstractFileInfo
 {
 public:
-    MergedDesktopFileInfo(const DUrl &url);
+    MergedDesktopFileInfo(const DUrl &url, const DUrl &parentUrl);
+
+    DUrl parentUrl() const override;
+    QString iconName() const override;
+    QString genericIconName() const override;
 
 private:
     Q_DECLARE_PRIVATE(MergedDesktopFileInfo)

--- a/dde-file-manager-lib/models/mergeddesktopfileinfo.h
+++ b/dde-file-manager-lib/models/mergeddesktopfileinfo.h
@@ -34,6 +34,9 @@ public:
     QString iconName() const override;
     QString genericIconName() const override;
 
+    bool canRedirectionFileUrl() const override;
+    DUrl redirectedFileUrl() const override;
+
 private:
     Q_DECLARE_PRIVATE(MergedDesktopFileInfo)
 };

--- a/dde-file-manager-lib/shutil/fileutils.cpp
+++ b/dde-file-manager-lib/shutil/fileutils.cpp
@@ -449,6 +449,31 @@ QString FileUtils::diskUsageString(qint64 usedSize, qint64 totalSize)
     return QString("%1/%2").arg(FileUtils::formatSize(usedSize, false, 0, forceUnit), FileUtils::formatSize(totalSize, true, 0, forceUnit, {"B", "K", "M", "G"}));
 }
 
+DUrl FileUtils::newDocumentUrl(const DAbstractFileInfoPointer targetDirInfo, const QString &baseName, const QString &suffix)
+{
+    if (targetDirInfo->isVirtualEntry()) {
+        return DUrl();
+    }
+
+    int i = 0;
+    QString fileName = suffix.isEmpty() ? QString("%1").arg(baseName) : QString("%1.%2").arg(baseName, suffix);
+    DUrl fileUrl = targetDirInfo->getUrlByChildFileName(fileName);
+    while (true) {
+        DAbstractFileInfoPointer newInfo = DFileService::instance()->createFileInfo(nullptr, fileUrl);
+        if (newInfo && newInfo->exists()) {
+            ++i;
+            fileName = suffix.isEmpty()
+                    ? QString("%1 %2").arg(baseName, QString::number(i))
+                    : QString("%1 %2.%3").arg(baseName, QString::number(i), suffix);
+            fileUrl = targetDirInfo->getUrlByChildFileName(fileName);
+        } else {
+            return fileUrl;
+        }
+    }
+
+    return DUrl();
+}
+
 QString FileUtils::newDocmentName(QString targetdir, const QString &baseName, const QString &suffix)
 {
     if (targetdir.isEmpty())

--- a/dde-file-manager-lib/shutil/fileutils.h
+++ b/dde-file-manager-lib/shutil/fileutils.h
@@ -34,6 +34,7 @@
 #include "properties.h"
 #include "durl.h"
 #include "dfmglobal.h"
+#include "dabstractfileinfo.h"
 
 /**
  * @class FileUtils
@@ -65,6 +66,7 @@ public:
       const QIcon &defaultIcon = QIcon::fromTheme("application-x-executable"));
     static QString formatSize(qint64 num , bool withUnitVisible = true, int precision = 1, int forceUnit = -1, QStringList unitList = QStringList());
     static QString diskUsageString(qint64 usedSize, qint64 totalSize);
+    static DUrl newDocumentUrl(const DAbstractFileInfoPointer targetDirInfo, const QString& baseName, const QString& suffix);
     static QString newDocmentName(QString targetdir, const QString& baseName, const QString& suffix);
     static bool cpTemplateFileToTargetDir(const QString& targetdir, const QString& baseName, const QString& suffix, WId windowId);
 


### PR DESCRIPTION
粘贴和新建文件依然是禁用掉的（因为目前没动画），功能应和现在已发布的版本一致。