### PR TITLE
fix: search keyword contains parenthese

### DIFF
--- a/dde-file-manager-lib/shutil/dfmregularexpression.cpp
+++ b/dde-file-manager-lib/shutil/dfmregularexpression.cpp
@@ -28,7 +28,7 @@
 QString DFMRegularExpression::checkWildcardAndToRegularExpression(const QString &pattern)
 {
     if (!pattern.contains('*') && !pattern.contains('?')) {
-        return pattern;
+        return DFMRegularExpression::wildcardToRegularExpression('*' + pattern + '*');
     }
 
     return DFMRegularExpression::wildcardToRegularExpression(pattern);


### PR DESCRIPTION
Need to do a wildcard to regex convert if search keyword contains
parenthese.