### PR TITLE
Fix adjustModeSwitcherPoint() not declared error when DISABLE_SCREENSAVER defined

### DIFF
--- a/dde-wallpaper-chooser/frame.h
+++ b/dde-wallpaper-chooser/frame.h
@@ -79,16 +79,19 @@ protected:
     bool event(QEvent *event) override;
 
 private:
+#if !defined(DISABLE_SCREENSAVER) || !defined(DISABLE_WALLPAPER_CAROUSEL)
+    void adjustModeSwitcherPoint();
+    DSegmentedControl *m_switchModeControl;
+#endif
+
 #ifndef DISABLE_SCREENSAVER
     void setMode(int mode);
     void reLayoutTools();
-    void adjustModeSwitcherPoint();
 
     Mode m_mode = WallpaperMode;
     QHBoxLayout *m_toolLayout;
     QLabel *m_waitControlLabel;
     DSegmentedControl *m_waitControl;
-    DSegmentedControl *m_switchModeControl;
     QCheckBox *m_lockScreenBox;
 #else
     const Mode m_mode = WallpaperMode;


### PR DESCRIPTION
In dde-wallpaper-chooser/frame.h, "adjustModeSwitcherPoint()" won't be declared when DISABLE_SCREENSAVER is defined. But "adjustModeSwitcherPoint()" will be defined in frame.cpp because DISABLE_WALLPAPER_CAROUSEL is not defined at the same time. Then the compiler will complain an error that "adjustModeSwitcherPoint()" is not declared.

I try to fix this issue with this patch.