### PR TITLE
refactor: new disk usage display strategy

### DIFF
--- a/dde-file-manager-lib/shutil/fileutils.cpp
+++ b/dde-file-manager-lib/shutil/fileutils.cpp
@@ -448,11 +448,10 @@ QString FileUtils::diskUsageString(qint64 usedSize, qint64 totalSize)
 {
     const qint64 kb = 1024;
     const qint64 mb = 1024 * kb;
-    const qint64 gb = 1024 * mb;
-    int forceUnit = (totalSize < gb && totalSize > 0) ? 2 : 3;
+    const QStringList unitDisplayText = {"B", "K", "M", "G", "T"};
 
-    return QString("%1/%2").arg(FileUtils::formatSize(usedSize, false, 0, forceUnit),
-                                FileUtils::formatSize(totalSize, true, 0, forceUnit, {"B", "K", "M", "G"}));
+    return QString("%1/%2").arg(FileUtils::formatSize(usedSize, true, 0, usedSize < mb ? 2 : -1, unitDisplayText),
+                                FileUtils::formatSize(totalSize, true, 0, totalSize < mb ? 2 : -1, unitDisplayText));
 }
 
 DUrl FileUtils::newDocumentUrl(const DAbstractFileInfoPointer targetDirInfo, const QString &baseName, const QString &suffix)


### PR DESCRIPTION
https://github.com/linuxdeepin/internal-discussion/issues/1593

1. 当小于1G时，显示M为单位，当小于1T时，显示G为单位，当大于1T时显示T。
2. 分别显示各自的单位。