### PR TITLE
fix: sw_64 should not use mips's desktop file

### DIFF
--- a/dde-file-manager/dde-file-manager.pro
+++ b/dde-file-manager/dde-file-manager.pro
@@ -62,7 +62,7 @@ DEFINES += APPSHAREDIR=\\\"$$PREFIX/share/$$TARGET\\\"
 target.path = $$BINDIR
 
 desktop.path = $${PREFIX}/share/applications/
-isEqual(ARCH, sw_64) | isEqual(ARCH, mips64) | isEqual(ARCH, mips32) {
+isEqual(ARCH, mips64) | isEqual(ARCH, mips32) {
     desktop.files = $$PWD/mips/$${TARGET}.desktop
 }else{
     desktop.files = $${TARGET}.desktop


### PR DESCRIPTION
taskID=5338

``` plain
重现步骤
版本号一致：4.8.4.1-1+stable

连续按super+e，神威上只能打开一个计算机窗口；

x86上，可以打开多个

神威上

deepin@deepin-pc:~$ cat /usr/share/applications/dde-file-manager.desktop | grep Exec
Exec=/usr/bin/file-manager.sh %u
Exec=/usr/bin/file-manager.sh --new-window
```