### PR TITLE
fix: "used space" bar doesn't appear if the icons are set to "extra small"

### DIFF
--- a/dde-file-manager-lib/views/computerview.cpp
+++ b/dde-file-manager-lib/views/computerview.cpp
@@ -274,8 +274,8 @@ bool ComputerViewItem::eventFilter(QObject *obj, QEvent *event)
 bool ComputerViewItem::event(QEvent *event)
 {
     if (event->type() == QEvent::Resize) {
-        event->ignore();   // If the program tries to resize itself, then it does that incorrectly. So, the resizing event should be ignored.
-        resize(width(), (getIconLabel()->height() + TEXT_LINE_HEIGHT + ICON_MODE_ICON_SPACING + 90));
+        event->~QEvent();
+        resize(width(), getIconLabel()->height()+TEXT_LINE_HEIGHT+ ICON_MODE_ICON_SPACING + 90);
         adjustPosition();
         return true;
     }

--- a/dde-file-manager-lib/views/computerview.cpp
+++ b/dde-file-manager-lib/views/computerview.cpp
@@ -285,8 +285,8 @@ void ComputerViewItem::adjustPosition()
 {
     m_sizeLabel->setFixedWidth(this->width());
     m_sizeLabel->setAlignment(Qt::AlignCenter);
-    m_sizeLabel->move(0, getTextEdit()->y() + getTextEdit()->height());
-    m_progressLine->move((this->width() - m_progressLine->width()) / 2, m_sizeLabel->y() + m_sizeLabel->height() + 3);
+    m_sizeLabel->move(0, getTextEdit()->y() + getTextEdit()->height() - 7);
+    m_progressLine->move((this->width() - m_progressLine->width()) / 2 , m_sizeLabel->y() + m_progressLine->height() + 25);
 }
 
 bool ComputerViewItem::checked() const

--- a/dde-file-manager-lib/views/computerview.cpp
+++ b/dde-file-manager-lib/views/computerview.cpp
@@ -274,7 +274,7 @@ bool ComputerViewItem::eventFilter(QObject *obj, QEvent *event)
 bool ComputerViewItem::event(QEvent *event)
 {
     if (event->type() == QEvent::Resize) {
-        resize(width(), getIconLabel()->height() + TEXT_LINE_HEIGHT + ICON_MODE_ICON_SPACING + 90);
+        resize(width(), getIconLabel()->height() + 24 + ICON_MODE_ICON_SPACING + 90);
         adjustPosition();
         return true;
     }

--- a/dde-file-manager-lib/views/computerview.cpp
+++ b/dde-file-manager-lib/views/computerview.cpp
@@ -275,7 +275,7 @@ bool ComputerViewItem::event(QEvent *event)
 {
     if (event->type() == QEvent::Resize) {
         event->~QEvent();
-        resize(width(), getIconLabel()->height()+TEXT_LINE_HEIGHT+ ICON_MODE_ICON_SPACING + 90);
+        resize(width(), getIconLabel()->height() + TEXT_LINE_HEIGHT + ICON_MODE_ICON_SPACING + 90);
         adjustPosition();
         return true;
     }

--- a/dde-file-manager-lib/views/computerview.cpp
+++ b/dde-file-manager-lib/views/computerview.cpp
@@ -274,7 +274,7 @@ bool ComputerViewItem::eventFilter(QObject *obj, QEvent *event)
 bool ComputerViewItem::event(QEvent *event)
 {
     if (event->type() == QEvent::Resize) {
-        event->ignore();   \\ If the program tries to resize itself, then it does that incorrectly. So, the resizing event should be ignored.
+        event->ignore();   // If the program tries to resize itself, then it does that incorrectly. So, the resizing event should be ignored.
         resize(width(), (getIconLabel()->height() + TEXT_LINE_HEIGHT + ICON_MODE_ICON_SPACING + 90));
         adjustPosition();
         return true;

--- a/dde-file-manager-lib/views/computerview.cpp
+++ b/dde-file-manager-lib/views/computerview.cpp
@@ -274,7 +274,7 @@ bool ComputerViewItem::eventFilter(QObject *obj, QEvent *event)
 bool ComputerViewItem::event(QEvent *event)
 {
     if (event->type() == QEvent::Resize) {
-        resize(width(), getIconLabel()->height() + getTextEdit()->height() + ICON_MODE_ICON_SPACING + 45);
+        resize(width(), getIconLabel()->height() + TEXT_LINE_HEIGHT + ICON_MODE_ICON_SPACING + 90);
         adjustPosition();
         return true;
     }
@@ -285,8 +285,8 @@ void ComputerViewItem::adjustPosition()
 {
     m_sizeLabel->setFixedWidth(this->width());
     m_sizeLabel->setAlignment(Qt::AlignCenter);
-    m_sizeLabel->move(0, getTextEdit()->y() + getTextEdit()->height() - 7);
-    m_progressLine->move((this->width() - m_progressLine->width()) / 2 , m_sizeLabel->y() + m_progressLine->height() + 25);
+    m_sizeLabel->move(0, getTextEdit()->y() + getTextEdit()->height());
+    m_progressLine->move((this->width() - m_progressLine->width()) / 2, m_sizeLabel->y() + m_sizeLabel->height() + 3);
 }
 
 bool ComputerViewItem::checked() const

--- a/dde-file-manager-lib/views/computerview.cpp
+++ b/dde-file-manager-lib/views/computerview.cpp
@@ -274,7 +274,8 @@ bool ComputerViewItem::eventFilter(QObject *obj, QEvent *event)
 bool ComputerViewItem::event(QEvent *event)
 {
     if (event->type() == QEvent::Resize) {
-        resize(width(), getIconLabel()->height() + 24 + ICON_MODE_ICON_SPACING + 90);
+        event->ignore();   \\ If the program tries to resize itself, then it does that incorrectly. So, the resizing event should be ignored.
+        resize(width(), (getIconLabel()->height() + TEXT_LINE_HEIGHT + ICON_MODE_ICON_SPACING + 90));
         adjustPosition();
         return true;
     }


### PR DESCRIPTION
It's a fix to a bug. First file manager couldn't show the "used space" bar if the icons were set to "extra small". Now the bug has fixed.

It's a fix to this issue, https://github.com/linuxdeepin/developer-center/issues/998
Before,
![DeepinScreenshot_dde-desktop_20190525213904](https://user-images.githubusercontent.com/33563064/58371728-a8976880-7f35-11e9-8e97-5f84561ce9be.png)
After,
![DeepinScreenshot_dde-desktop_20190525213928](https://user-images.githubusercontent.com/33563064/58371734-b4832a80-7f35-11e9-9979-5006d1e6ea13.png)
