### PR TITLE
fix: update the geometry of the background widget before emit the bac…

### DIFF
--- a/dde-desktop/desktop.cpp
+++ b/dde-desktop/desktop.cpp
@@ -86,6 +86,9 @@ static void setWindowFlag(QWidget *w, Qt::WindowType flag, bool on)
 
 void Desktop::onBackgroundEnableChanged()
 {
+    qInfo() << "Primary Screen:" << qApp->primaryScreen();
+    qInfo() << "Background enabled:" << d->background->isEnabled();
+
     if (d->background->isEnabled()) {
         QLabel *background = d->background->backgroundForScreen(qApp->primaryScreen());
         d->screenFrame.setAttribute(Qt::WA_NativeWindow, false);
@@ -124,6 +127,9 @@ void Desktop::onBackgroundGeometryChanged(QWidget *l)
     if (!primaryBackground) {
         return;
     }
+
+    qInfo() << "primaryBackground widget geometry: " << primaryBackground->geometry()
+            << "changedBackground widget geometry:" << l->geometry();
 
     primaryBackground->activateWindow();
     QMetaObject::invokeMethod(primaryBackground, "raise", Qt::QueuedConnection);

--- a/dde-desktop/view/backgroundhelper.cpp
+++ b/dde-desktop/view/backgroundhelper.cpp
@@ -235,10 +235,18 @@ void BackgroundHelper::onScreenAdded(QScreen *screen)
 
     if (m_visible)
         l->show();
+    else
+        qDebug() << "Disable show the background widget, of screen:" << screen << screen->geometry();
 
     connect(screen, &QScreen::geometryChanged, l, [l, this, screen] () {
-        qDebug() << "screen geometry changed:" << screen;
+        qDebug() << "screen geometry changed:" << screen << screen->geometry();
 
+        // 因为接下来会发出backgroundGeometryChanged信号，
+        // 所以此处必须保证QWidget::geometry的值和接下来对其windowHandle()对象设置的geometry一致
+        l->setGeometry(screen->geometry());
+
+        // 忽略屏幕缩放，设置窗口的原始大小
+        // 调用此函数后不会立即更新QWidget::geometry，而是在收到窗口resize事件后更新
         bool hi_active = QHighDpiScaling::m_active;
         QHighDpiScaling::m_active = false;
         l->windowHandle()->handle()->setGeometry(screen->handle()->geometry());
@@ -254,7 +262,7 @@ void BackgroundHelper::onScreenAdded(QScreen *screen)
     Q_EMIT backgroundGeometryChanged(l);
     Q_EMIT backgroundAdded(l);
 
-    qInfo() << screen;
+    qInfo() << screen << screen->geometry();
 }
 
 void BackgroundHelper::onScreenRemoved(QScreen *screen)


### PR DESCRIPTION
…kgroundGeometryChanged signal

Fix the background is mistake hidden when screen geometry changed
https://github.com/linuxdeepin/internal-discussion/issues/1693

修复从复制模式切换到扩展模式后，副屏不显示壁纸窗口