### PR TITLE
fix: lsar -J result changed after util-linux v2.33

### DIFF
--- a/dde-file-manager-lib/gvfs/gvfsmountmanager.cpp
+++ b/dde-file-manager-lib/gvfs/gvfsmountmanager.cpp
@@ -1036,11 +1036,8 @@ void GvfsMountManager::listMountsBylsblk()
                             p.setUuid(obj.value("uuid").toString());
                         }
                         if(obj.contains("rm")){
-                            QString data = obj.value("rm").toString();
-                            if(data == "1")
-                                p.setIsRemovable(true);
-                            else
-                                p.setIsRemovable(false);
+                            QVariant data(obj.value("rm"));
+                            p.setIsRemovable(data.toBool());
                         }
 
                         p.setPath(QString("/dev/%1").arg(p.name()));

--- a/partman/partition.cpp
+++ b/partman/partition.cpp
@@ -71,12 +71,11 @@ Partition Partition::getPartitionByDevicePath(const QString &devicePath)
                     if (obj.contains("mountpoint")){
                         p.setMountPoint(obj.value("mountpoint").toString());
                     }
-                    if(obj.contains("rm")){
-                        QString data = obj.value("rm").toString();
-                        if(data == "1")
-                            p.setIsRemovable(true);
-                        else
-                            p.setIsRemovable(false);
+                    if (obj.contains("rm")) {
+                        // blumia: `lsblk -J` may return value like `1`(old behavior) or `true`(changed in util-linux v2.33).
+                        //         So we convert it to QVariant and use its toBool() to make sure the result is correct.
+                        QVariant data(obj.value("rm"));
+                        p.setIsRemovable(data.toBool());
                     }
 
                     if (!p.fs().isEmpty()){
@@ -127,11 +126,8 @@ Partition Partition::getPartitionByMountPoint(const QString &mountPoint)
             ret.setMountPoint(obj.value("mountpoint").toString());
         }
         if(obj.contains("rm")){
-            QString data = obj.value("rm").toString();
-            if(data == "1")
-                ret.setIsRemovable(true);
-            else
-                ret.setIsRemovable(false);
+            QVariant data(obj.value("rm"));
+            ret.setIsRemovable(data.toBool());
         }
 
         if (!ret.fs().isEmpty()){


### PR DESCRIPTION
taskID=5547

https://bugzilla.opensuse.org/show_bug.cgi?id=1134131

> - The "removable device" detection isn't working, because it looks for
  "rm":"1" in lsblk's JSON output, however the output contains "rm":true. This
  was only recently changed in util-linux v2.33.