### PR TITLE
fix: several usb-device-formatter issues

### DIFF
--- a/usb-device-formatter/app/cmdmanager.cpp
+++ b/usb-device-formatter/app/cmdmanager.cpp
@@ -44,18 +44,34 @@ void CMDManager::init()
 {
     m_parser.addOption(m_modelModeOpt);
     m_parser.setApplicationDescription("Usb Device Formatter");
+    m_parser.addPositionalArgument("device-path", "The external device path to format. (required)");
     m_parser.addHelpOption();
     m_parser.addVersionOption();
 }
 
-bool CMDManager::isSet(const QString &name)
+bool CMDManager::isSet(const QString &name) const
 {
     return m_parser.isSet(name);
 }
 
 QString CMDManager::getPath()
 {
-    return m_parser.positionalArguments().at(0);
+    QStringList positionalArguments = m_parser.positionalArguments();
+    if (positionalArguments.count() > 0) {
+        return m_parser.positionalArguments().at(0);
+    }
+
+    return QString();
+}
+
+QStringList CMDManager::positionalArguments() const
+{
+    return m_parser.positionalArguments();
+}
+
+void CMDManager::showHelp(int exitCode)
+{
+    return m_parser.showHelp(exitCode);
 }
 
 int CMDManager::getWinId()

--- a/usb-device-formatter/app/cmdmanager.h
+++ b/usb-device-formatter/app/cmdmanager.h
@@ -37,8 +37,10 @@ public:
     static CMDManager* instance();
     void process(const QApplication &app);
     void init();
-    bool isSet(const QString& name);
+    bool isSet(const QString& name) const;
     QString getPath();
+    QStringList positionalArguments() const;
+    void showHelp(int exitCode = 0);
     int getWinId();
 
 signals:

--- a/usb-device-formatter/dialogs/messagedialog.cpp
+++ b/usb-device-formatter/dialogs/messagedialog.cpp
@@ -39,7 +39,7 @@ MessageDialog::MessageDialog(const QString &message, QWidget *parent):
 
 void MessageDialog::initUI()
 {
-    setIcon(QIcon(":/dialog/dialog_warning_64.png"));
+    setIcon(QIcon::fromTheme("dialog-warning"));
     addButton(tr("OK"), true, DDialog::ButtonRecommend);
     setTitle(m_msg);
 }

--- a/usb-device-formatter/main.cpp
+++ b/usb-device-formatter/main.cpp
@@ -98,9 +98,14 @@ int main(int argc, char *argv[])
     //Command line
     CMDManager::instance()->process(a);
 
+    // Check if we need display help text.
+    if (CMDManager::instance()->positionalArguments().isEmpty()) {
+        CMDManager::instance()->showHelp();
+    }
+
     //Check if exists path
     const QString path = CMDManager::instance()->getPath();
-    if(path.isEmpty() || !QFile::exists(path)){
+    if (path.isEmpty() || !path.startsWith("/dev/") || !QFile::exists(path)) {
         QString message = QObject::tr("Device does not exist");
         MessageDialog d(message, 0);
         d.exec();


### PR DESCRIPTION
 - no longer can be used as a tool for checking file existance
 - no longer crash if no argument provided
 - message box use icon from theme

ref: https://bugzilla.opensuse.org/show_bug.cgi?id=1134131

> - it crashes when called without parameters
> - It can be used to determine the existence of arbitrary files, since all
>  paths can be passed and the error message differentiates between not
>  existing and not a block device.