### PR TITLE
fix: should require auth

### DIFF
--- a/usb-device-formatter/pkexec/com.deepin.pkexec.usb-device-formatter.policy
+++ b/usb-device-formatter/pkexec/com.deepin.pkexec.usb-device-formatter.policy
@@ -11,7 +11,7 @@
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/usb-device-formatter</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>


### PR DESCRIPTION
taskID=5549

ref: https://bugzilla.opensuse.org/show_bug.cgi?id=1134131

> It allows locally logged in regular users to run /usr/bin/usb-device-formatter without any authentication.