### PR TITLE
Fix: dde-file-manager-daemon.log save location

### DIFF
--- a/dde-file-manager-daemon/dbusservice/dde-filemanager-daemon.service
+++ b/dde-file-manager-daemon/dbusservice/dde-filemanager-daemon.service
@@ -5,7 +5,6 @@ Description=DDE File Manager Daemon
 Type=dbus
 BusName=com.deepin.filemanager.daemon
 ExecStart=/usr/bin/dde-file-manager-daemon
-Environment=XDG_CACHE_HOME=/var/cache
 
 [Install]
 WantedBy=multi-user.target

--- a/dde-file-manager-daemon/main.cpp
+++ b/dde-file-manager-daemon/main.cpp
@@ -58,6 +58,9 @@ int main(int argc, char *argv[])
     a.setOrganizationName("deepin");
 
     QDBusConnection connection = QDBusConnection::systemBus();
+    DTK_CORE_NAMESPACE::DLogManager::setlogFilePath("/var/log/" + QCoreApplication::organizationName() +
+                                                    QLatin1Char('/') + QCoreApplication::applicationName() +
+                                                    QLatin1Char('/') + QCoreApplication::applicationName() + ".log");
     DTK_CORE_NAMESPACE::DLogManager::registerConsoleAppender();
     DTK_CORE_NAMESPACE::DLogManager::registerFileAppender();
 

--- a/dde-file-manager-daemon/main.cpp
+++ b/dde-file-manager-daemon/main.cpp
@@ -57,10 +57,15 @@ int main(int argc, char *argv[])
 
     a.setOrganizationName("deepin");
 
+    QString logPath = "/var/log/" + QCoreApplication::organizationName() + QLatin1Char('/') +
+                      QCoreApplication::applicationName() + QLatin1Char('/');
+    QDir logDir(logPath);
+    if (!logDir.exists()) {
+        QDir().mkpath(logPath);
+    }
+
     QDBusConnection connection = QDBusConnection::systemBus();
-    DTK_CORE_NAMESPACE::DLogManager::setlogFilePath("/var/log/" + QCoreApplication::organizationName() +
-                                                    QLatin1Char('/') + QCoreApplication::applicationName() +
-                                                    QLatin1Char('/') + QCoreApplication::applicationName() + ".log");
+    DTK_CORE_NAMESPACE::DLogManager::setlogFilePath(logPath + QCoreApplication::applicationName() + ".log");
     DTK_CORE_NAMESPACE::DLogManager::registerConsoleAppender();
     DTK_CORE_NAMESPACE::DLogManager::registerFileAppender();
 


### PR DESCRIPTION
Now saved to `/var/log/deepin/dde-file-manager-daemon/dde-file-manager-daemon.log`