### PR TITLE
fix: wrong behavior of unmount button in optical device sidebar item.

### DIFF
--- a/dde-file-manager-lib/views/dfmsidebardeviceitem.cpp
+++ b/dde-file-manager-lib/views/dfmsidebardeviceitem.cpp
@@ -73,14 +73,6 @@ DFMSideBarDeviceItem::DFMSideBarDeviceItem(DUrl url, QWidget *parent)
     default:
         break;
     }
-
-    QString devs(url.path());
-    devs.replace("/dev/", "/org/freedesktop/UDisks2/block_devices/");
-    QScopedPointer<DBlockDevice> blkdev(DDiskManager::createBlockDevice(devs));
-    QScopedPointer<DDiskDevice> drv(DDiskManager::createDiskDevice(blkdev->drive()));
-    if (drv->mediaCompatibility().join(' ').contains("optical")) {
-        hide();
-    }
 }
 
 QVariantHash DFMSideBarDeviceItem::getExtraProperties() const

--- a/dde-file-manager-lib/views/dfmsidebaropticaldevitem.cpp
+++ b/dde-file-manager-lib/views/dfmsidebaropticaldevitem.cpp
@@ -50,7 +50,7 @@ DFMSideBarOpticalDevItem::DFMSideBarOpticalDevItem(DUrl url, QWidget *parent)
             this, &DFMSideBarOpticalDevItem::itemOnClick);
 
     unmountButton = new DImageButton(this);
-    unmountButton->setVisible(blk->mountPoints().size() != 0);
+    unmountButton->setVisible(drv->mediaAvailable());
     this->setContentWidget(unmountButton);
 
     connect(unmountButton, &DImageButton::clicked,


### PR DESCRIPTION
No objects of the DFMSideBarDeviceItem are created for optical devices now. They cause duplicate names.
Corrected stringified class name of DFMSideBarOpticalDevItem.

pms Task#5963