### PR TITLE
fix: icon for optical media refers to non-existent file.

### DIFF
--- a/dde-file-manager-lib/themes/dark/config.ini
+++ b/dde-file-manager-lib/themes/dark/config.ini
@@ -136,11 +136,11 @@ icon=:/dark/icons/usershare_normal_16px.svg
 icon=:/dark/icons/usershare_active_16px.svg
 
 [BookmarkItem.Dvd]
-icon=:/dark/icons/dvd_normal_16px.svg
+icon=:/dark/icons/media_normal_16px.svg
 [BookmarkItem.Dvd:hover]
-icon=:/dark/icons/dvd_normal_16px.svg
+icon=:/dark/icons/media_normal_16px.svg
 [BookmarkItem.Dvd:checked]
-icon=:/dark/icons/dvd_active_16px.svg
+icon=:/dark/icons/media_active_16px.svg
 
 [BookmarkItem.System Disk]
 icon=:/dark/icons/disk_normal_16px.svg


### PR DESCRIPTION
Fixes linuxdeepin/developer-center#1414.