### PR TITLE
fix: remove the duplicated `StartupNotify` key in dde-open.desktop

### DIFF
--- a/dde-file-manager/dde-open.desktop
+++ b/dde-file-manager/dde-open.desktop
@@ -7,6 +7,5 @@ Icon=dde-file-manager
 NoDisplay=true
 StartupNotify=true
 Name=DDE Open Dialog
-StartupNotify=true
 Terminal=false
 Type=Application


### PR DESCRIPTION
remove the duplicated `StartupNotify` key in dde-open.desktop

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>