### PR TITLE
Chore: missing dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ _The **master** branch is current development branch, build dependencies may cha
 * dde-dock-dev(>=4.0.5)
 * deepin-gettext-tools
 * libdtkcore-dev
+* libudisks2-qt5-dev
+* libdisomaster-dev
+* libgio-qt-dev
+* libqt5xdg-dev
+* libmediainfo-dev
+* libdde-file-manager-dev
+* libssl-dev
 * ffmpeg module(s):
   - libffmpegthumbnailer-dev
 * Qt5(>= 5.6) with modules:


### PR DESCRIPTION
added missing depends required on deepin (20.1).

Log: add missing dependencies in README