### PR TITLE
fix: Crash 静态变量初始化顺序问题，导致Release编译产出会在启动时Crash

### DIFF
--- a/src/dde-file-manager-lib/interfaces/dfmeventdispatcher.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfmeventdispatcher.cpp
@@ -126,8 +126,14 @@ void DFMEventFuture::operator =(const DFMEventFuture &other)
 }
 
 namespace DFMEventDispatcherData {
-static QList<DFMAbstractEventHandler *> eventHandler;
-static QList<DFMAbstractEventHandler *> eventFilter;
+QList<DFMAbstractEventHandler *>& eventHandler() {
+    static QList<DFMAbstractEventHandler *> handler;
+    return handler;
+}
+QList<DFMAbstractEventHandler *>& eventFilter() {
+    static QList<DFMAbstractEventHandler *> handler;
+    return handler;
+}
 
 Q_GLOBAL_STATIC(QThreadPool, threadPool)
 }
@@ -154,7 +160,7 @@ QVariant DFMEventDispatcher::processEvent(const QSharedPointer<DFMEvent> &event,
 
     QVariant result;
 
-    for (DFMAbstractEventHandler *handler : DFMEventDispatcherData::eventFilter) {
+    for (DFMAbstractEventHandler *handler : DFMEventDispatcherData::eventFilter()) {
         if (!handler)
             continue;
         if (handler->fmEventFilter(event, target, &result))
@@ -164,7 +170,7 @@ QVariant DFMEventDispatcher::processEvent(const QSharedPointer<DFMEvent> &event,
     if (target) {
         target->fmEvent(event, &result);
     } else {
-        for (DFMAbstractEventHandler *handler : DFMEventDispatcherData::eventHandler) {
+        for (DFMAbstractEventHandler *handler : DFMEventDispatcherData::eventHandler()) {
             if (handler->fmEvent(event, &result))
                 return result;
         }
@@ -197,14 +203,14 @@ QVariant DFMEventDispatcher::processEventWithEventLoop(const QSharedPointer<DFME
 
 void DFMEventDispatcher::installEventFilter(DFMAbstractEventHandler *handler)
 {
-    if (!DFMEventDispatcherData::eventFilter.contains(handler)) {
-        DFMEventDispatcherData::eventFilter.append(handler);
+    if (!DFMEventDispatcherData::eventFilter().contains(handler)) {
+        DFMEventDispatcherData::eventFilter().append(handler);
     }
 }
 
 void DFMEventDispatcher::removeEventFilter(DFMAbstractEventHandler *handler)
 {
-    DFMEventDispatcherData::eventFilter.removeOne(handler);
+    DFMEventDispatcherData::eventFilter().removeOne(handler);
 }
 
 DFMEventDispatcher::State DFMEventDispatcher::state() const
@@ -222,13 +228,13 @@ DFMEventDispatcher::DFMEventDispatcher()
 
 void DFMEventDispatcher::installEventHandler(DFMAbstractEventHandler *handler)
 {
-    if (!DFMEventDispatcherData::eventHandler.contains(handler))
-        DFMEventDispatcherData::eventHandler.append(handler);
+    if (!DFMEventDispatcherData::eventHandler().contains(handler))
+        DFMEventDispatcherData::eventHandler().append(handler);
 }
 
 void DFMEventDispatcher::removeEventHandler(DFMAbstractEventHandler *handler)
 {
-    DFMEventDispatcherData::eventHandler.removeOne(handler);
+    DFMEventDispatcherData::eventHandler().removeOne(handler);
 }
 
 DFM_END_NAMESPACE


### PR DESCRIPTION
# BUG现象
今天arch滚了一次, 升级了 deepin-file-manager 1:5.5.3-1， 启动桌面Crash，文件管理器打不开。

# Core栈
```
(gdb) bt
#0  0x00007ffff7b7e0fb in QListData::begin() const (this=0x7ffff7fbb268 <_ZN16dde_file_manager22DFMEventDispatcherDataL12eventHandlerE.lto_priv.0>, this=<optimized out>)
    at /usr/include/qt/QtCore/qlist.h:118
#1  QList<dde_file_manager::DFMAbstractEventHandler*>::contains_impl(dde_file_manager::DFMAbstractEventHandler* const&, QListData::ArrayCompatibleLayout) const
    (t=@0x7fffffffdc18: 0x7ffff7fbd2e0 <dde_file_manager::eventProcessor>, this=0x7ffff7fbb268 <_ZN16dde_file_manager22DFMEventDispatcherDataL12eventHandlerE.lto_priv.0>)
    at /usr/include/qt/QtCore/qlist.h:1098
#2  QList<dde_file_manager::DFMAbstractEventHandler*>::contains(dde_file_manager::DFMAbstractEventHandler* const&) const
    (t=@0x7fffffffdc18: 0x7ffff7fbd2e0 <dde_file_manager::eventProcessor>, this=0x7ffff7fbb268 <_ZN16dde_file_manager22DFMEventDispatcherDataL12eventHandlerE.lto_priv.0>)
    at /usr/include/qt/QtCore/qlist.h:1081
#3  dde_file_manager::DFMEventDispatcher::installEventHandler(dde_file_manager::DFMAbstractEventHandler*)
    (this=0x7ffff7fbb280 <dde_file_manager::(anonymous namespace)::Q_QGS_fmedGlobal::innerFunction()::holder>, handler=handler@entry=0x7ffff7fbd2e0 <dde_file_manager::eventProcessor>)
    at /media/ssd1/work/deepin/dde-file-manager/src/dde-file-manager-lib/interfaces/dfmeventdispatcher.cpp:225
#4  0x00007ffff7b7e22d in dde_file_manager::DFMAbstractEventHandler::DFMAbstractEventHandler(bool) (autoInstallHandler=<optimized out>, this=0x7ffff7fbd2e0 <dde_file_manager::eventProcessor>)
    at /media/ssd1/work/deepin/dde-file-manager/src/dde-file-manager-lib/interfaces/dfmabstracteventhandler.cpp:37
#5  0x00007ffff7b7e23e in dde_file_manager::FileEventProcessor::FileEventProcessor() (this=0x7ffff7fbd2e0 <dde_file_manager::eventProcessor>, this=<optimized out>)
    at /media/ssd1/work/deepin/dde-file-manager/src/dde-file-manager-lib/controllers/fileeventprocessor.cpp:64
#6  0x00007ffff791256a in _sub_I_65535_0.0 () at /home/kkke/work/deepin/build-filemanager-unknown-Release/src/dde-file-manager-lib/libdde-file-manager.so.1
#7  0x00007ffff7fcbede in call_init () at /lib64/ld-linux-x86-64.so.2
#8  0x00007ffff7fcbfcc in _dl_init () at /lib64/ld-linux-x86-64.so.2
#9  0x00007ffff7fe396a in _dl_start_user () at /lib64/ld-linux-x86-64.so.2
#10 0x0000000000000001 in  ()
#11 0x00007fffffffe101 in  ()
#12 0x0000000000000000 in  ()
(gdb) f 3
#3  dde_file_manager::DFMEventDispatcher::installEventHandler (this=0x7ffff7fbb280 <dde_file_manager::(anonymous namespace)::Q_QGS_fmedGlobal::innerFunction()::holder>, 
    handler=handler@entry=0x7ffff7fbd2e0 <dde_file_manager::eventProcessor>) at /media/ssd1/work/deepin/dde-file-manager/src/dde-file-manager-lib/interfaces/dfmeventdispatcher.cpp:225
225         if (!DFMEventDispatcherData::eventHandler.contains(handler))
(gdb) p DFMEventDispatcherData::eventHandler
$2 = {<QListSpecialMethods<dde_file_manager::DFMAbstractEventHandler*>> = {<No data fields>}, {p = {static shared_null = {ref = {atomic = {_q_value = {<std::__atomic_base<int>> = {static _S_alignment = 4, 
                _M_i = -1}, <No data fields>}}}, alloc = 0, begin = 0, end = 0, array = {0x0}}, d = 0x0}, d = 0x0}}
```
# 结论
https://github.com/linuxdeepin/dde-file-manager/blob/uos/src/dde-file-manager-lib/controllers/fileeventprocessor.cpp#L62
`DFMEventDispatcherData::eventHandler`, `static FileEventProcessor eventProcessor`，在release编译下，应该是编译优化导致这两个静态变量构造顺序出问题，调试看是eventHandler还没有初始化。
试了在debug编译下不会crash。

把eventHandler改成静态函数，相当于强制调用时构造。

求合入，每次滚完打不开电脑很难受。这个问题留着也是个大坑，指不定哪次编译发布又出问题。

https://github.com/linuxdeepin/developer-center/issues/2251