### PR TITLE
fix: QT_INSTALL_LIBS can't assign value by qmake flags

### DIFF
--- a/src/common/common.pri
+++ b/src/common/common.pri
@@ -5,7 +5,9 @@ unix {
     top_srcdir = $$PWD/../
 
     CONFIG(release, debug|release) {
-        LIB_INSTALL_DIR = $$[QT_INSTALL_LIBS]
+        isEmpty(LIB_INSTALL_DIR) {
+       	    LIB_INSTALL_DIR = $$[QT_INSTALL_LIBS]
+        }
     }
 
     ARCH = $$QMAKE_HOST.arch


### PR DESCRIPTION
目前所有使用 LIB_INSTALL_DIR 的地方都有 isEmpty 判断， 但唯独赋值时没有判断

这样会导致 qmake LIB_INSTALL_DIR=... 传入参数失效