### PR TITLE
fix: build section error in makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ $ apt build-dep dde-file-manager
 2. Build:
 ```
 $ cd dde-file-manager
-$ mkdir Build
-$ cd Build
-$ qmake ..
+$ mkdir build
+$ cd build
+$ qmake ../filemanager.pro
 $ make
 ```
 


### PR DESCRIPTION
use 'build' instead of 'Build' 
'Build' is not in the .gitignore file 

use 'qmake ../filemanager.pro' instead of 'qmake ..'
```txt
➜  Build git:(823a71510) ✗ qmake ..
Cannot read /home/wurongjie/Src/github.com/linuxdeepin/dde-file-manager: file to open is a directory
Error processing project file: ..
➜  Build git:(823a71510) qmake ../filemanager.pro 
Project MESSAGE: Build arch: x86_64
Project MESSAGE: x86 ENABLE_DAEMON
Project MESSAGE: Deepin Anything server plugin enabled for x86_64
```