### PR TITLE
fix: When previewing text documents in the file manager, the file manager crashes after closing the preview window

### DIFF
--- a/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
@@ -514,12 +514,14 @@ void FilePreviewDialog::switchToPage(int index)
 
         if (preview) {
             preview->initialize(this, m_statusBar);
-            if (info->canRedirectionFileUrl() && preview->setFileUrl(info->redirectedFileUrl()))
+            if (info->canRedirectionFileUrl() && preview->setFileUrl(info->redirectedFileUrl())) {
                 break;
-            else if (preview->setFileUrl(m_fileList.at(index)))
+            } else if (preview->setFileUrl(m_fileList.at(index))) {
                 break;
-            else
+            } else {
                 preview->deleteLater();
+                preview = nullptr;
+            }
         }
     }
     if (!preview) {
@@ -544,6 +546,7 @@ void FilePreviewDialog::switchToPage(int index)
         static_cast<QVBoxLayout *>(layout())->removeWidget(m_preview->contentWidget());
         static_cast<QHBoxLayout *>(m_statusBar->layout())->removeWidget(m_preview->statusBarWidget());
         m_preview->deleteLater();
+        m_preview = nullptr;
     }
 
     static_cast<QVBoxLayout *>(layout())->insertWidget(0, preview->contentWidget());
@@ -599,9 +602,11 @@ void FilePreviewDialog::done(int r)
 
 void FilePreviewDialog::DoneCurrent()
 {
-//    if (this != nullptr && m_preview) {
-//        m_preview->DoneCurrent();
-//    }
+#if(0)
+    if (this != nullptr && m_preview) {
+        m_preview->DoneCurrent();
+    }
+#endif
 }
 
 void FilePreviewDialog::playCurrentPreviewFile()

--- a/src/dde-file-manager-plugins/pluginPreview/dde-text-preview-plugin/textpreview.cpp
+++ b/src/dde-file-manager-plugins/pluginPreview/dde-text-preview-plugin/textpreview.cpp
@@ -40,8 +40,6 @@ TextPreview::TextPreview(QObject *parent)
 
 TextPreview::~TextPreview()
 {
-    if (textBrowser)
-        textBrowser->deleteLater();
 }
 
 bool TextPreview::setFileUrl(const DUrl &url)


### PR DESCRIPTION
The problem of the order of recycling objects, and the problem of paging display data; adjust the order of object recycling, and the logic of paging display.
    
Log: Optimize the preview text effect on different platforms
    
Bug: https://pms.uniontech.com/bug-view-141049.html
    
Influence: Preview Text Plugin