### PR TITLE
feat: 桌面图标间距与字符数显示效果切换开关

### DIFF
--- a/src/dde-desktop/config/config.cpp
+++ b/src/dde-desktop/config/config.cpp
@@ -41,6 +41,7 @@ const QString Config::keyIconLevel = "IconLevel";
 const QString Config::keyQuickHide = "QuickHide";
 const QString Config::keyAutoMerge = "AutoMerge";
 const QString Config::keyWaterMask = "WaterMaskUseJson";
+const QString Config::keyIconSizeMode = "IconSizeMode";
 
 Config::Config()
 {

--- a/src/dde-desktop/config/config.h
+++ b/src/dde-desktop/config/config.h
@@ -46,7 +46,7 @@ public:
     static const QString keyQuickHide;
     static const QString keyAutoMerge;
     static const QString keyWaterMask;
-
+    static const QString keyIconSizeMode;
 public slots:
     void setConfig(const QString &group, const QString &key, const QVariant &value);
     void removeConfig(const QString &group, const QString &key);

--- a/src/dde-desktop/desktop.h
+++ b/src/dde-desktop/desktop.h
@@ -55,6 +55,8 @@ public slots:
     Q_SCRIPTABLE void PrintInfo();
     Q_SCRIPTABLE void Refresh();
     Q_SCRIPTABLE QList<int> GetIconSize();
+    Q_SCRIPTABLE int GetIconSizeMode();
+    Q_SCRIPTABLE bool SetIconSizeMode(int);
 protected:
     void showWallpaperSettings(QString name, int mode = 0);
 private:

--- a/src/dde-desktop/view/canvasgridview.h
+++ b/src/dde-desktop/view/canvasgridview.h
@@ -150,6 +150,7 @@ public:
     void syncIconLevel(int level);
     void updateHiddenItems();
     void updateExpandItemGeometry();
+    void updateCanvas();
 signals:
     void sortRoleChanged(int role, Qt::SortOrder order);
     void autoAlignToggled();
@@ -185,7 +186,6 @@ private:
 
     void initUI();
     void initConnection();
-    void updateCanvas();
 
     void setIconByLevel(int level);
     void increaseIcon();

--- a/src/dde-desktop/view/desktopitemdelegate.cpp
+++ b/src/dde-desktop/view/desktopitemdelegate.cpp
@@ -139,12 +139,14 @@ QSize DesktopItemDelegate::iconSizeByIconSizeLevel() const
 void DesktopItemDelegate::updateItemSizeHint()
 {
     DIconItemDelegate::updateItemSizeHint();
-    // update word width
-    textFontWidth = parent()->parent()->fontMetrics().width("中");
     auto iconSize = parent()->parent()->iconSize();
-
     int width;
-    {
+    if (sizeMode != IconSizeMode::WordNum) {
+       width = iconSize.width() * 17 / 10;
+    } else {
+        // update word width
+        textFontWidth = parent()->parent()->fontMetrics().width("中");
+
         // defalut word num
         const int minWidth = iconSize.width() + ICON_TOP_SPACE_DESKTOP * 2;
         int num = 9;
@@ -169,4 +171,14 @@ void DesktopItemDelegate::hideAllIIndexWidget()
 
     if (editor)
         editor->hide();
+}
+
+void DesktopItemDelegate::setIconSizeMode(IconSizeMode mode)
+{
+    sizeMode = mode;
+}
+
+DesktopItemDelegate::IconSizeMode DesktopItemDelegate::iconSizeMode() const
+{
+    return sizeMode;
 }

--- a/src/dde-desktop/view/desktopitemdelegate.h
+++ b/src/dde-desktop/view/desktopitemdelegate.h
@@ -30,6 +30,8 @@ class DesktopItemDelegate : public DIconItemDelegate
 {
     Q_OBJECT
 public:
+    enum class IconSizeMode{IconLevel = 0, WordNum};
+public:
     explicit DesktopItemDelegate(DFileViewHelper *parent);
     virtual ~DesktopItemDelegate() override;
 
@@ -47,6 +49,9 @@ public:
 
     void updateItemSizeHint() override;
     void hideAllIIndexWidget() override;
+
+    void setIconSizeMode(IconSizeMode mode);
+    IconSizeMode iconSizeMode() const;
 private:
     QStringList iconSizeDescriptions;
     QList<int> charOfLine;
@@ -55,5 +60,6 @@ private:
 
     // default icon size is 48px.
     int currentIconSizeIndex = -1;
+    IconSizeMode sizeMode = IconSizeMode::IconLevel;
 };
 

--- a/tests/dde-desktop/src/view/ut_canvasgridview_test.cpp
+++ b/tests/dde-desktop/src/view/ut_canvasgridview_test.cpp
@@ -746,30 +746,23 @@ TEST_F(CanvasGridViewTest, CanvasGridViewTest_keyPressEvent_AltM)
 {
     stub_ext::StubExt stu;
     QKeyEvent keyPressEvt_Key_AltM(QEvent::KeyPress, Qt::Key_M, Qt::AltModifier);
-    QTimer timer;
-    QObject::connect(&timer, &QTimer::timeout, [&]{
-        timer.stop();
-        QWidget tempWdg;
-        tempWdg.show();
-        tempWdg.close();
-    });
-    timer.start(1000);
-    stu.set_lamda(ADDR(QVariant, isValid), [](){return true;});
+    bool isOn = true;
+    bool isCall = false;
+    stu.set_lamda(ADDR(GridManager, isGsettingShow), [&isCall, &isOn](){isCall = true; return isOn;});
 
     bool judge = false;
-    stu.set_lamda(ADDR(CanvasGridView, showNormalMenu),[&judge](){judge = !judge; return;});
-    stu.set_lamda(ADDR(CanvasGridView, showEmptyAreaMenu),[&judge](){judge = !judge; return;});
+    stu.set_lamda(ADDR(CanvasGridView, showNormalMenu),[&judge](){judge = true; return;});
+    stu.set_lamda(ADDR(CanvasGridView, showEmptyAreaMenu),[&judge](){judge = true; return;});
     m_canvasGridView->keyPressEvent(&keyPressEvt_Key_AltM);
     EXPECT_TRUE(judge);
+    EXPECT_TRUE(isCall);
 
-    bool isgset = false;
-    stu.set_lamda(ADDR(GridManager, isGsettingShow), [&isgset](){isgset = true; return false;});
+    judge = false;
+    isOn = false;
+    isCall = false;
     m_canvasGridView->keyPressEvent(&keyPressEvt_Key_AltM);
-    EXPECT_TRUE(isgset);
-
-    stu.reset(&QVariant::isValid);
-    stu.set_lamda(ADDR(QVariant, isValid), [](){return false;});
-    m_canvasGridView->keyPressEvent(&keyPressEvt_Key_AltM);
+    EXPECT_FALSE(judge);
+    EXPECT_TRUE(isCall);
 }
 
 /* todo ut failed


### PR DESCRIPTION
增加图标大小显示支持按图标大小和按字符数两种模式。
增加桌面图标显示模式配置项。
增加dbus接口控制图标显示方式。

Log: 桌面图标间距与字符数显示效果切换开关
Task: https://pms.uniontech.com/task-view-145825.html
Influence: 桌面图标宽度
Change-Id: Icda476125a4087dc050779b2a2f90a2eb7870b4b