### PR TITLE
fix: The menu item policy of the desktop right-click menu does not ta…

### DIFF
--- a/src/dde-desktop/view/canvasgridview.cpp
+++ b/src/dde-desktop/view/canvasgridview.cpp
@@ -3573,6 +3573,7 @@ void CanvasGridView::showEmptyAreaMenu(const Qt::ItemFlags &/*indexFlags*/)
         });
         menu->popup(t_tmpPoint);
         menu->setGeometry(t_tmpPoint.x(), t_tmpPoint.y(), menu->sizeHint().width(), menu->sizeHint().height());
+        DFileMenuManager::menuFilterHiddenActions(menu, DD_MENU_ACTION_HIDDEN);
         eventLoop.exec();
         d->menuLoop = nullptr;
         menu->deleteLater();
@@ -3814,6 +3815,7 @@ void CanvasGridView::showNormalMenu(const QModelIndex &index, const Qt::ItemFlag
         });
         menu->popup(t_tmpPoint);
         menu->setGeometry(t_tmpPoint.x(), t_tmpPoint.y(), menu->sizeHint().width(), menu->sizeHint().height());
+        DFileMenuManager::menuFilterHiddenActions(menu, DD_MENU_ACTION_HIDDEN);
         eventLoop.exec();
         d->menuLoop = nullptr;
         menu->deleteLater();


### PR DESCRIPTION
…ke effect under wayland

 Added menu item policy judgment under Wayland to fix that

Log: Fixed wayland desktop right-click menu items do not take effect
Bug: https://pms.uniontech.com/bug-view-141493.html