### PR TITLE
fix: Three bugs are fixed

### DIFF
--- a/src/dde-file-manager-lib/dialogs/connecttoserverdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/connecttoserverdialog.cpp
@@ -284,6 +284,7 @@ void ConnectToServerDialog::initUI()
     addContent(contentFrame);
     QStringList stringList = Singleton<SearchHistroyManager>::instance()->toStringList();
     QStringList hostList;
+    QString lastOne;
     foreach (const QString& hisString, stringList) {
         DUrl testUrl(hisString);
         QString host = testUrl.host();
@@ -293,6 +294,7 @@ void ConnectToServerDialog::initUI()
 
         hostList << QString("%1://%2").arg(scheme).arg(host);
     }
+    lastOne = hostList.last();
     hostList.removeDuplicates();//由于历史记录中有很多设备相同，但是路径不同的记录，这里又只提取了设备，所以这里显示时要去重。
     QStringList schemeList;
     schemeList << QString("%1://").arg(SMB_SCHEME);
@@ -301,7 +303,6 @@ void ConnectToServerDialog::initUI()
 
     while(hostList.count() > Max_HISTORY_ITEM - 1 )
         hostList.takeFirst();
-
     m_completer = new QCompleter(hostList,this);
     m_completer->setCaseSensitivity(Qt::CaseInsensitive);
     m_completer->setFilterMode(Qt::MatchContains);
@@ -313,7 +314,6 @@ void ConnectToServerDialog::initUI()
 
     m_serverComboBox->addItems(hostList);
     m_serverComboBox->insertItem(m_serverComboBox->count(), tr("Clear History"));
-    m_serverComboBox->setEditable(true);
     m_serverComboBox->setCompleter(m_completer);
     m_serverComboBox->clearEditText();
 
@@ -325,9 +325,11 @@ void ConnectToServerDialog::initUI()
 
 
     if(hostList.count() > 0){
-        QString lastOne = hostList.last();
         QString scheme = lastOne.section("://",0,0);
         if(!scheme.isEmpty()){
+            int checkedIndex = m_serverComboBox->findText(lastOne);
+            if(checkedIndex >= 0)
+                m_serverComboBox->setCurrentIndex(checkedIndex);
             m_serverComboBox->setEditText(lastOne.section("//",-1));
             m_schemeComboBox->setCurrentText(scheme + "://");
         }
@@ -408,6 +410,9 @@ void ConnectToServerDialog::initConnect()
         if ( history!= m_schemeComboBox->currentText() + m_serverComboBox->currentText()) {
             DUrl histroyUrl(history);
             m_schemeComboBox->setCurrentText(histroyUrl.scheme()+"://");
+            int checkedIndex = m_serverComboBox->findText(history);
+            if(checkedIndex >= 0)
+                m_serverComboBox->setCurrentIndex(checkedIndex);
             m_serverComboBox->setCurrentText(histroyUrl.host());
             if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
                 m_addButton->setIcon(QIcon(QPixmap(":icons/deepin/builtin/light/icons/collect_cancel.svg").scaled(16,16)));

--- a/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.cpp
@@ -56,6 +56,13 @@ void UserSharePasswordSettingDialog::initUI()
     QPalette pe;
     pe.setColor(QPalette::WindowText, QColor("#526A7F"));
     QLabel* notes = new QLabel(tr("Set a password on the shared folder for non-anonymous access"),this);
+    QFontMetrics fm = QFontMetrics( notes->font());
+    qInfo()<<fm.width(notes->text());
+    qInfo()<<this->width();
+    if (fm.width(notes->text()) > this->width()){
+        notes->setToolTip(notes->text());
+        notes->setText(QFontMetrics(notes->font()).elidedText(notes->text(), Qt::ElideRight, fm.width(notes->text()) - 70));
+    }
     notes->setAttribute(Qt::WA_TranslucentBackground, true);
     notes->setPalette(pe);
     layout->addWidget(notes);

--- a/src/dde-file-manager-lib/gvfs/networkmanager.cpp
+++ b/src/dde-file-manager-lib/gvfs/networkmanager.cpp
@@ -149,6 +149,7 @@ void NetworkManager::addSmbServerToHistory(const DUrl &url)
         }else{//访问连接已经包含在历史记录中,先移除再追加到最后，用于下次打开对话框时显示上次连接。
             historyManager->removeSearchHistory(toHistory);
             historyManager->writeIntoSearchHistory(toHistory);
+            qInfo()<<"1 hostList = "<<historyManager->toStringList();
         }
     }
 }

--- a/src/dde-file-manager-lib/views/dfmaddressbar.cpp
+++ b/src/dde-file-manager-lib/views/dfmaddressbar.cpp
@@ -462,11 +462,9 @@ void DFMAddressBar::initConnections()
         if (!DUrl::fromUserInput(str).isLocalFile()) {
             //从配置文件中更新historyList，因为搜索历史列表可能在连接到服务器对话框中有改变
             QStringList list = Singleton<SearchHistroyManager>::instance()->toStringList();
-            if(!list.isEmpty())
-                historyList.append(list);
+            historyList.append(list);
             historyList.removeDuplicates();
             if (!historyList.contains(str) || !list.contains(str)) {
-
                 DUrl inputUrl(str);
                 if (!inputUrl.scheme().isEmpty() && inputUrl.scheme() == SMB_SCHEME){
                     //smb挂载路径不在这里写入历史记录，在NetworkManager中挂载成功后写入
@@ -683,6 +681,10 @@ void DFMAddressBar::updateCompletionState(const QString &text)
 
         // History completion.
         isHistoryInCompleterModel = true;
+        //这里需要重新给historyList赋值，否则当前刚访问过的smb地址不会立即出现在候选下拉框中fix bug:142829
+        //因为smb地址是在访问成功后写入缓存文件，没有及时添加到这里的historyList中。
+        historyList.clear();
+        historyList.append(Singleton<SearchHistroyManager>::instance()->toStringList());
         // 修复bug-62117 搜索补全中不显示保险箱全路径
         QStringList::iterator itr = historyList.begin();
         while (itr != historyList.end()) {


### PR DESCRIPTION
1、Notice can not be fully shown in the share password settings dialog;2、History url can not be recored for the first time access in the address bar;3、Last access history cannot be shown as default in the connect to server. 

Log: 1、修复共享密码设置提示在英文模式下显示不全；2、地址栏访问历史记录不能在第一次被记录；3、最后一次访问记录不能在连接到服务器对话框作为默认显示
Bug: https://pms.uniontech.com/bug-view-142791.html
Bug: https://pms.uniontech.com/bug-view-142829.html
Bug: https://pms.uniontech.com/bug-view-143199.html