### PR TITLE
fix: Bug fix related to smb-unmount and text-preview and dialog

### DIFF
--- a/src/dde-file-manager-lib/dialogs/connecttoserverdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/connecttoserverdialog.cpp
@@ -284,7 +284,6 @@ void ConnectToServerDialog::initUI()
     addContent(contentFrame);
     QStringList stringList = Singleton<SearchHistroyManager>::instance()->toStringList();
     QStringList hostList;
-    QString lastOne;
     foreach (const QString& hisString, stringList) {
         DUrl testUrl(hisString);
         QString host = testUrl.host();
@@ -294,7 +293,7 @@ void ConnectToServerDialog::initUI()
 
         hostList << QString("%1://%2").arg(scheme).arg(host);
     }
-    lastOne = hostList.last();
+    QString lastOne = hostList.count() > 0 ? hostList.last() : QString();
     hostList.removeDuplicates();//由于历史记录中有很多设备相同，但是路径不同的记录，这里又只提取了设备，所以这里显示时要去重。
     QStringList schemeList;
     schemeList << QString("%1://").arg(SMB_SCHEME);
@@ -303,6 +302,7 @@ void ConnectToServerDialog::initUI()
 
     while(hostList.count() > Max_HISTORY_ITEM - 1 )
         hostList.takeFirst();
+
     m_completer = new QCompleter(hostList,this);
     m_completer->setCaseSensitivity(Qt::CaseInsensitive);
     m_completer->setFilterMode(Qt::MatchContains);
@@ -384,6 +384,7 @@ void ConnectToServerDialog::initConnect()
             m_serverComboBox->clearEditText();
             m_serverComboBox->completer()->setModel(new QStringListModel());
             Singleton<SearchHistroyManager>::instance()->clearHistory();
+            DFMApplication::appObtuselySetting()->sync();
         }
 
        if(string.contains("://")){

--- a/src/dde-file-manager-lib/interfaces/dfilemenumanager.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfilemenumanager.cpp
@@ -236,7 +236,7 @@ DFileMenu *DFileMenuManager::createNormalMenu(const DUrl &currentUrl, const DUrl
                     DUrl mountUrl;
                     QString shareName = FileUtils::smbAttribute(rootFile->path(),FileUtils::SmbAttribute::kShareName);
                     QString shareHost = FileUtils::smbAttribute(rootFile->path(),FileUtils::SmbAttribute::kServer);
-                    QString name = currentUrl.path();
+                    QString name = currentUrl.path().toLower();//共享文件夹名称转小写
                     QString host = currentUrl.host();
                     if(name.startsWith("/"))
                         name = name.mid(1);

--- a/tests/dde-desktop/src/view/ut_canvasgridview_test.cpp
+++ b/tests/dde-desktop/src/view/ut_canvasgridview_test.cpp
@@ -96,7 +96,7 @@ void waitDataEvent(CanvasGridView *view)
 
     QEventLoop loop;
     QObject::connect(model, &DFileSystemModel::sigJobFinished, &loop,&QEventLoop::quit,Qt::QueuedConnection);
-    QTimer::singleShot(2000, &loop, &QEventLoop::quit);
+    QTimer::singleShot(5000, &loop, &QEventLoop::quit);//the original value is 2000
     loop.exec();
     view->delayCustom(0);
 }


### PR DESCRIPTION
1、In smb-unmount operating, folder name must be converted to lower;
2、Adding codec judgement when preview text file;
3、Fixing open connect-to-server dialog crash problem when history is empty.

Log: 1、修复不能卸载含大写字母的smb目录；2、修复预览含中文字符的文本文件乱码问题；3、修复清空访问记录后打开连接到服务器对话框文管奔溃问题
Task: https://pms.uniontech.com/task-view-119241.html
Bug: https://pms.uniontech.com/bug-view-148289.html
Bug: https://pms.uniontech.com/bug-view-148819.html