### PR TITLE
fix:After the desktop menu hiding policy is set, the desktop menu can…

### DIFF
--- a/src/dde-desktop/view/canvasgridview.cpp
+++ b/src/dde-desktop/view/canvasgridview.cpp
@@ -1178,6 +1178,11 @@ void CanvasGridView::keyPressEvent(QKeyEvent *event)
 
     case Qt::AltModifier:
         if (event->key() == Qt::Key_M) {
+
+            // 策略整体菜单隐藏
+            if (DFileMenuManager::menuHidden(qAppName()))
+                return;
+
             //新需求gesetting控制右键菜单隐藏功能,和产品确认调整为gsetting高于本身配置文件，即gsetting有相关配置后本身的json相关配置失效
             auto tempGsetting = GridManager::instance()->isGsettingShow("context-menu", QVariant());
             if (tempGsetting.isValid()) {


### PR DESCRIPTION
… still be displayed by 'alt + m'

Lack of policy judgment when using shortcut keys to display menus,added policy judgment when using shortcut keys to display menus

Log: 修复桌面快捷键右键菜单整体隐藏策略失败问题
Bug: https://pms.uniontech.com/bug-view-144155.html
Change-Id: Ie4dbdf1cbd756805cfed0720127b2ea1d430130d