### PR TITLE
fix: 删除文件时，剪贴板出现两次上次拷贝的文件(cherry pick)

### DIFF
--- a/src/dde-file-manager-lib/interfaces/dfileservices.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfileservices.cpp
@@ -622,15 +622,18 @@ DUrlList DFileService::moveToTrash(const QObject *sender, const DUrlList &list) 
     {
         QList<QUrl> org = DFMGlobal::instance()->clipboardFileUrlList();
         DFMGlobal::ClipboardAction action = DFMGlobal::instance()->clipboardAction();
+        bool isRemoved = false;
         if (!org.isEmpty() && action != DFMGlobal::UnknowAction) {
             for (const DUrl &nd : list) {
                 if (org.isEmpty())
                     break;
-                org.removeAll(nd);
+                int count = org.removeAll(nd);
+                if (count != 0)
+                    isRemoved = true;
             }
             if (org.isEmpty()) //没有文件则清空剪切板
                 DFMGlobal::clearClipboard();
-            else
+            else if (isRemoved)
                 DFMGlobal::setUrlsToClipboard(org, action);
         }
     }


### PR DESCRIPTION
修改逻辑，当上一次的剪贴板内容修改后，才更新剪贴板内容

Log: 解决了删除文件时，剪贴板出现两次上次拷贝的文件问题
Bug: https://pms.uniontech.com/bug-view-127385.html