### PR TITLE
fix: 插入空白光驱，文管桌面删除弹出永久删除提示框(cherry pick)

### DIFF
--- a/src/dde-file-manager-lib/deviceinfo/udisklistener.cpp
+++ b/src/dde-file-manager-lib/deviceinfo/udisklistener.cpp
@@ -333,7 +333,8 @@ bool UDiskListener::isInRemovableDeviceFolder(const QString &path) const
         UDiskDeviceInfoPointer info = m_list.at(i);
         if (mediaTypes.contains(info->getMediaType())) {
             if (!info->getMountPointUrl().isEmpty()) {
-                if (path.startsWith(info->getMountPointUrl().toLocalFile())) {
+                const QString &localPath = info->getMountPointUrl().toLocalFile();
+                if (localPath != "/" && !localPath.isEmpty() && path.startsWith(localPath)) {
                     return true;
                 }
             }


### PR DESCRIPTION
空白光驱时，返回的光盘根目录为“/”，该目录不对，增加判断，移除即可。

Log: 解决了插入空白光驱，文管桌面删除弹出永久删除提示框的问题。
Bug: https://pms.uniontech.com/bug-view-142745.html