### PR TITLE
fix: data race problem at the time of extensionlib init

### DIFF
--- a/src/dde-file-manager-lib/interfaces/dfilemenumanager.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfilemenumanager.cpp
@@ -1345,6 +1345,7 @@ void DFileMenuManager::extensionPluginCustomMenu(DFileMenu *menu,
         return;
 
     DFMGlobal::autoInitExtPluginManager();
+    DFMExtPluginManager::instance().monitorPlugins();
 
     std::string newCurrentUrl = currentUrl.toString().toStdString();
     std::string newFocusUrl = focusFile.toString().toStdString();

--- a/src/dde-file-manager-lib/interfaces/dfmglobal.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfmglobal.cpp
@@ -1208,6 +1208,11 @@ bool DFMGlobal::fileNameCorrection(const QByteArray &filePath)
 
 bool DFMGlobal::autoInitExtPluginManager()
 {
+    static QMutex mutex;
+    if (!mutex.tryLock())
+        return false;
+
+
     if (DFMExtPluginManager::instance().state() == DFMExtPluginManager::State::Invalid) {
         qInfo() << "extPluginPath:" << DFMExtPluginManager::instance().pluginPaths();
         DFMExtPluginManager::instance().scanPlugins();
@@ -1225,14 +1230,13 @@ bool DFMGlobal::autoInitExtPluginManager()
     }
 
     if (DFMExtPluginManager::instance().state() == DFMExtPluginManager::State::Initialized) {
-       if (!DFMExtPluginManager::instance().monitorPlugins()) {
-           qWarning() << "init plugin monitor failed!";
-           return false;
-       }
         qInfo() << "extPlugin initialization has been successful!";
+        mutex.unlock();
+        return true;
     }
 
-    return true;
+    mutex.unlock();
+    return false;
 }
 
 bool DFMGlobal::isDesktopFile(const DUrl &url)

--- a/src/dde-file-manager-lib/plugins/private/pluginemblemmanagerprivate.cpp
+++ b/src/dde-file-manager-lib/plugins/private/pluginemblemmanagerprivate.cpp
@@ -162,8 +162,10 @@ void PluginEmblemManagerPrivate::run()
 void PluginEmblemManagerPrivate::startWork()
 {
     bWork = true;
-    if (!isRunning())
+    if (!isRunning()) {
         start();
+        DFMExtPluginManager::instance().monitorPlugins();
+    }
 }
 
 void PluginEmblemManagerPrivate::stopWork()


### PR DESCRIPTION
1. `DFMExtPluginManager` is not a thread-safe class, add mutex for ` DFMGlobal::autoInitExtPluginManager()`
2. Deadlock happened in `DFMExtPluginManager::monitorPlugins`, assert it ony run in mainthread

Log: fix extensionlib init data race problem