### PR TITLE
fix: The disk hiding policy is invalid

### DIFF
--- a/src/dde-file-manager-lib/dialogs/dfmsettingdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/dfmsettingdialog.cpp
@@ -28,6 +28,7 @@
 #include "app/filesignalmanager.h"
 #include "dfmsettings.h"
 #include "private/dfmsettingdialog_p.h"
+#include "grouppolicy.h"
 
 #include <QCheckBox>
 #include <QFrame>

--- a/src/dde-file-manager-lib/interfaces/drootfilemanager.h
+++ b/src/dde-file-manager-lib/interfaces/drootfilemanager.h
@@ -72,6 +72,8 @@ signals:
 public Q_SLOTS:
     void hideSystemPartition();
     void policyHideSystemPartition(const QString &key);
+    void settingHideSystemPartition(bool isHide);
+
 
 private:
     explicit DRootFileManager(QObject *parent = nullptr);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -306,6 +306,8 @@ void clearStageDir(const QString &stagingRoot)
 
 void RemoteMountsStashManager::stashRemoteMount(const QString &mpt, const QString &displayName)
 {
+    DFMApplication::syncGenericAttribute();
+
     if (!DFMApplication::genericAttribute(DFMApplication::GA_AlwaysShowOfflineRemoteConnections).toBool())
         return;
     QString key {mpt}, protocol, host, share, sharePath;
@@ -402,6 +404,8 @@ void RemoteMountsStashManager::stashRemoteMount(const QString &mpt, const QStrin
 
 QList<QVariantMap> RemoteMountsStashManager::remoteMounts()
 {
+    DFMApplication::syncGenericAttribute();
+
     QList<QVariantMap> ret;
     QFile configFile(CONFIG_PATH);
     if (!configFile.open(QIODevice::ReadOnly)) {
@@ -443,6 +447,8 @@ QList<QVariantMap> RemoteMountsStashManager::remoteMounts()
 
 void RemoteMountsStashManager::removeRemoteMountItem(const QString &key)
 {
+    DFMApplication::syncGenericAttribute();
+
     QFile configFile(CONFIG_PATH);
     if (!configFile.open(QIODevice::ReadOnly)) {
         return;
@@ -566,6 +572,8 @@ QString RemoteMountsStashManager::normalizeConnUrl(const QString &url)
  */
 QStringList RemoteMountsStashManager::stashedSmbDevices()
 {
+    DFMApplication::syncGenericAttribute();
+
     QFile configFile(CONFIG_PATH);
     if (!configFile.open(QIODevice::ReadOnly))
         return QStringList();
@@ -621,6 +629,8 @@ QStringList RemoteMountsStashManager::stashedSmbDevices()
 
 void RemoteMountsStashManager::removeStashedSmbDevice(const QString &url)
 {
+    DFMApplication::syncGenericAttribute();
+
     QFile configFile(CONFIG_PATH);
     if (!configFile.open(QIODevice::ReadOnly)) {
         return;
@@ -669,6 +679,8 @@ void RemoteMountsStashManager::removeStashedSmbDevice(const QString &url)
 
 void RemoteMountsStashManager::insertStashedSmbDevice(const QString &url)
 {
+    DFMApplication::syncGenericAttribute();
+
     QMutex mutex;
     QMutexLocker locker(&mutex);
     QFile configFile(CONFIG_PATH);


### PR DESCRIPTION
 The cause is that there is a synchronization problem in reading and writing configuration files.If the synchronization is performed by reading or writing files directly, the interface is called first

Log: fix the issue of disk hiding policy is invalid
Bug: https://pms.uniontech.com/bug-view-142929.html