### PR TITLE
fix: Removing removable disk causes crash when dragging files from re…

### DIFF
--- a/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
@@ -379,6 +379,10 @@ bool DFileManagerWindowPrivate::cdForTab(Tab *tab, const DUrl &fileUrl)
     }
 
     if (!current_view || !DFMViewManager::instance()->isSuited(fileUrl, current_view)) {
+        DFileView *fv = dynamic_cast<DFileView *>(currentView);
+        if (fv)
+            fv->cancelDrag();
+
         DFMBaseView *view = DFMViewManager::instance()->createViewByUrl(fileUrl);
         if (view) {
             viewStackLayout->addWidget(view->widget());

--- a/src/dde-file-manager-lib/views/dfileview.cpp
+++ b/src/dde-file-manager-lib/views/dfileview.cpp
@@ -924,6 +924,18 @@ int DFileView::verticalOffset() const
     return DListView::verticalOffset();
 }
 
+void DFileView::cancelDrag()
+{
+    auto allDragObjs =  this->findChildren<QDrag*>();
+    if (allDragObjs.isEmpty())
+        return;
+
+    for(auto tempDrag : allDragObjs) {
+        if (tempDrag)
+            tempDrag->cancel();
+    }
+}
+
 void DFileView::setFilters(QDir::Filters filters)
 {
     model()->setFilters(filters);

--- a/src/dde-file-manager-lib/views/dfileview.h
+++ b/src/dde-file-manager-lib/views/dfileview.h
@@ -168,6 +168,8 @@ public:
 
     int verticalOffset() const override;
 
+    void cancelDrag();
+
 public slots:
     bool cd(const DUrl &url);
     bool cdUp();


### PR DESCRIPTION
…movable disk

 1. The root cause is that the QDrag's parent object is deleted during dragging
 2. When switching directories, determine whether there is a dragging behavior in the current directory. If so, cancel the dragging and execute the subsequent process.

Log: fix the crash that dragging files from removable disk
Bug: https://pms.uniontech.com/bug-view-144199.html