### PR TITLE
fix: Two files with the same name appear on the multi-screen desktop

### DIFF
--- a/src/dde-desktop/view/canvasgridview.cpp
+++ b/src/dde-desktop/view/canvasgridview.cpp
@@ -2216,8 +2216,12 @@ bool CanvasGridView::setCurrentUrl(const DUrl &url)
         bool findOldPos = false;
         QPoint oldPos = QPoint(-1, -1);
 
-        if (GridManager::instance()->contains(m_screenNum, oriUrl.toString()) && !oriUrl.fileName().isEmpty()) {
-            oldPos = GridManager::instance()->position(m_screenNum, oriUrl.toString());
+        QPair<int, QPoint> oriUrlPos;
+        QPair<int, QPoint> dstUrlPos;
+        auto findOld = GridManager::instance()->find(oriUrl.toString(), oriUrlPos);
+
+        if (findOld && !oriUrl.fileName().isEmpty()) {
+            oldPos = oriUrlPos.second;
             findOldPos = true;
         }
 
@@ -2226,7 +2230,7 @@ bool CanvasGridView::setCurrentUrl(const DUrl &url)
             findNewPos = true;
         }
 
-        findNewPos &= !GridManager::instance()->contains(m_screenNum, dstUrl.toString());
+        findNewPos &= !GridManager::instance()->find(dstUrl.toString(), dstUrlPos);
 
         if (!findNewPos) {
             Q_EMIT itemDeleted(oriUrl);
@@ -2244,7 +2248,7 @@ bool CanvasGridView::setCurrentUrl(const DUrl &url)
                     if (GridManager::instance()->autoArrange())
                         this->delayArrage();
                 } else
-                    GridManager::instance()->add(m_screenNum, oldPos, dstUrl.toString());
+                    GridManager::instance()->add(oriUrlPos.first, oldPos, dstUrl.toString());
 
                 if (GridManager::instance()->autoMerge())
                     this->delayModelRefresh();


### PR DESCRIPTION
 After a file is deleted from the compression program, two files with the same name appear on the multi-screen desktop.Use all screen data to decide whether to include or delete files by adjusting the desktop logic

Log: fix two files with the same name appear on the desktop in multi-screen
Bug: https://pms.uniontech.com/bug-view-140381.html