### PR TITLE
fix: [device] cannot safely remove decrypted devices.

### DIFF
--- a/src/dde-file-manager-lib/gvfs/gvfsmountmanager.cpp
+++ b/src/dde-file-manager-lib/gvfs/gvfsmountmanager.cpp
@@ -1023,13 +1023,10 @@ void GvfsMountManager::ask_disk_password_cb(GMountOperation *op, const char *mes
     bool anonymous = g_mount_operation_get_anonymous(op);
     GPasswordSave passwordSave = g_mount_operation_get_password_save(op);
 
-    const char *default_password = g_mount_operation_get_password(op);
-
     qCDebug(mountManager()) << "anonymous" << anonymous;
     qCDebug(mountManager()) << "message" << message;
     qCDebug(mountManager()) << "username" << default_user;
     qCDebug(mountManager()) << "domain" << default_domain;
-    qCDebug(mountManager()) << "password" << default_password;
     qCDebug(mountManager()) << "GAskPasswordFlags" << flags;
     qCDebug(mountManager()) << "passwordSave" << passwordSave;
 
@@ -1054,7 +1051,6 @@ void GvfsMountManager::ask_disk_password_cb(GMountOperation *op, const char *mes
         if (code == 0) {
             p.clear();
         }
-        qCDebug(mountManager()) << "password is:" << p;
         std::string pstd = p.toStdString();
         g_mount_operation_set_password(op, pstd.c_str());
         mountSecretDiskAskPasswordDialog->deleteLater();


### PR DESCRIPTION
wrong DriveName is obtained from cleartext device, the drive'name is
obtained from cleartext device while it should be obtained from
cryptobackingdevice.

Log: fix issue

Bug: https://pms.uniontech.com/bug-view-154455.html
Change-Id: I5faa34793458444c0b4899bf72a056ed809fcf6c
