### PR TITLE
chore: avoid hardcode in Shebangs

### DIFF
--- a/src/dde-desktop/translate_desktop2ts.sh
+++ b/src/dde-desktop/translate_desktop2ts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #
@@ -7,15 +7,15 @@
 DESKTOP_COMPUTER_SOURCE_FILE=data/applications/dde-computer.desktop
 DESKTOP_COMPUTER_TS_DIR=translations/dde-computer-desktop/
 
-/usr/bin/deepin-desktop-ts-convert desktop2ts $DESKTOP_COMPUTER_SOURCE_FILE $DESKTOP_COMPUTER_TS_DIR
+deepin-desktop-ts-convert desktop2ts $DESKTOP_COMPUTER_SOURCE_FILE $DESKTOP_COMPUTER_TS_DIR
 
 
 DESKTOP_TRASH_SOURCE_FILE=data/applications/dde-trash.desktop
 DESKTOP_TRASH_TS_DIR=translations/dde-trash-desktop/
 
-/usr/bin/deepin-desktop-ts-convert desktop2ts $DESKTOP_TRASH_SOURCE_FILE $DESKTOP_TRASH_TS_DIR
+deepin-desktop-ts-convert desktop2ts $DESKTOP_TRASH_SOURCE_FILE $DESKTOP_TRASH_TS_DIR
 
 DESKTOP_HOME_SOURCE_FILE=data/applications/dde-home.desktop
 DESKTOP_HOME_TS_DIR=translations/dde-home-desktop/
 
-/usr/bin/deepin-desktop-ts-convert desktop2ts $DESKTOP_HOME_SOURCE_FILE $DESKTOP_HOME_TS_DIR
+deepin-desktop-ts-convert desktop2ts $DESKTOP_HOME_SOURCE_FILE $DESKTOP_HOME_TS_DIR

--- a/src/dde-desktop/translate_generation.sh
+++ b/src/dde-desktop/translate_generation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #

--- a/src/dde-desktop/translate_ts2desktop.sh
+++ b/src/dde-desktop/translate_ts2desktop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #
@@ -8,7 +8,7 @@ DESKTOP_COMPUTER_TEMP_FILE=data/applications/dde-computer.desktop.tmp
 DESKTOP_COMPUTER_FILE=data/applications/dde-computer.desktop
 DESKTOP_COMPUTER_TS_DIR=translations/dde-computer-desktop/
 
-/usr/bin/deepin-desktop-ts-convert ts2desktop $DESKTOP_COMPUTER_FILE $DESKTOP_COMPUTER_TS_DIR $DESKTOP_COMPUTER_TEMP_FILE
+deepin-desktop-ts-convert ts2desktop $DESKTOP_COMPUTER_FILE $DESKTOP_COMPUTER_TS_DIR $DESKTOP_COMPUTER_TEMP_FILE
 mv $DESKTOP_COMPUTER_TEMP_FILE $DESKTOP_COMPUTER_FILE
 
 
@@ -16,7 +16,7 @@ DESKTOP_TRASH_TEMP_FILE=data/applications/dde-trash.desktop.tmp
 DESKTOP_TRASH_FILE=data/applications/dde-trash.desktop
 DESKTOP_TRASH_TS_DIR=translations/dde-trash-desktop/
 
-/usr/bin/deepin-desktop-ts-convert ts2desktop $DESKTOP_TRASH_FILE $DESKTOP_TRASH_TS_DIR $DESKTOP_TRASH_TEMP_FILE
+deepin-desktop-ts-convert ts2desktop $DESKTOP_TRASH_FILE $DESKTOP_TRASH_TS_DIR $DESKTOP_TRASH_TEMP_FILE
 mv $DESKTOP_TRASH_TEMP_FILE $DESKTOP_TRASH_FILE
 
 DESKTOP_HOME_TEMP_FILE=data/applications/dde-home.desktop.tmp

--- a/src/dde-desktop/update_translations.sh
+++ b/src/dde-desktop/update_translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #

--- a/src/dde-file-manager-lib/generate_translations.sh
+++ b/src/dde-file-manager-lib/generate_translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #

--- a/src/dde-file-manager-lib/update_translations.sh
+++ b/src/dde-file-manager-lib/update_translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #

--- a/src/dde-file-manager-plugins/generate_translations.sh
+++ b/src/dde-file-manager-plugins/generate_translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #

--- a/src/dde-file-manager-plugins/update_translations.sh
+++ b/src/dde-file-manager-plugins/update_translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #

--- a/src/dde-file-manager/generate_translations.sh
+++ b/src/dde-file-manager/generate_translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #

--- a/src/dde-file-manager/translate_desktop2ts.sh
+++ b/src/dde-file-manager/translate_desktop2ts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #
@@ -7,4 +7,4 @@
 DESKTOP_SOURCE_FILE=dde-file-manager.desktop
 DESKTOP_TS_DIR=translations/dde-file-manager-desktop/
 
-/usr/bin/deepin-desktop-ts-convert desktop2ts $DESKTOP_SOURCE_FILE $DESKTOP_TS_DIR
+deepin-desktop-ts-convert desktop2ts $DESKTOP_SOURCE_FILE $DESKTOP_TS_DIR

--- a/src/dde-file-manager/translate_ts2desktop.sh
+++ b/src/dde-file-manager/translate_ts2desktop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
 #
@@ -12,8 +12,8 @@ DESKTOP_MIPS_SOURCE_FILE=mips/dde-file-manager.desktop
 
 DESKTOP_TS_DIR=translations/dde-file-manager-desktop/
 
-/usr/bin/deepin-desktop-ts-convert ts2desktop $DESKTOP_SOURCE_FILE $DESKTOP_TS_DIR $DESKTOP_TEMP_FILE
+deepin-desktop-ts-convert ts2desktop $DESKTOP_SOURCE_FILE $DESKTOP_TS_DIR $DESKTOP_TEMP_FILE
 mv $DESKTOP_TEMP_FILE $DESKTOP_SOURCE_FILE
 
-/usr/bin/deepin-desktop-ts-convert ts2desktop $DESKTOP_MIPS_SOURCE_FILE $DESKTOP_TS_DIR $DESKTOP_MIPS_TEMP_FILE
+deepin-desktop-ts-convert ts2desktop $DESKTOP_MIPS_SOURCE_FILE $DESKTOP_TS_DIR $DESKTOP_MIPS_TEMP_FILE
 mv $DESKTOP_MIPS_TEMP_FILE $DESKTOP_MIPS_SOURCE_FILE


### PR DESCRIPTION
1. 使用 /usr/bin/env 获得更好的可移植性
2. deepin-desktop-ts-convert 在 PATH 中，不需要硬编码

相关：https://github.com/linuxdeepin/developer-center/issues/3374