### PR TITLE
chore: avoid hardcode executable path

### DIFF
--- a/src/dde-file-manager-daemon/usershare/usersharemanager.cpp
+++ b/src/dde-file-manager-daemon/usershare/usersharemanager.cpp
@@ -73,7 +73,7 @@ bool UserShareManager::addGroup(const QString &groupName)
 
     QStringList args;
     args << groupName;
-    bool ret = QProcess::startDetached("/usr/sbin/groupadd", args);
+    bool ret = QProcess::startDetached("groupadd", args);
     qDebug() << "groupadd" << groupName << ret;
     return ret;
 }

--- a/src/dde-file-manager-lib/shutil/fileutils.cpp
+++ b/src/dde-file-manager-lib/shutil/fileutils.cpp
@@ -1806,14 +1806,14 @@ bool FileUtils::writeJsonnArrayFile(const QString &filePath, const QJsonArray &a
 void FileUtils::mountAVFS()
 {
     QProcess p;
-    p.start("/usr/bin/umountavfs");
+    p.start("umountavfs", QStringList{});
     p.waitForFinished();
-    QProcess::startDetached("/usr/bin/mountavfs");
+    QProcess::startDetached("mountavfs", {});
 }
 
 void FileUtils::umountAVFS()
 {
-    QProcess::startDetached("/usr/bin/umountavfs");
+    QProcess::startDetached("umountavfs", {});
 }
 
 void FileUtils::addRecentFile(const QString &filePath, const DesktopFile &desktopFile, const QString &mimetype)


### PR DESCRIPTION
`QProcess::execute()` 本身会尝试在 PATH 中查找要执行的程序，故尝试执行 PATH 中的程序时，应当避免硬编码可执行程序的路径以提高可移植性。

是解决 https://github.com/linuxdeepin/developer-center/issues/3374 问题的一部分。

和 https://github.com/linuxdeepin/deepin-screen-recorder/pull/207 https://github.com/linuxdeepin/dde-network-core/pull/56 等类似