### PR TITLE
docs: fix typo in documentation

### DIFF
--- a/docs/qdoc/components.qdoc
+++ b/docs/qdoc/components.qdoc
@@ -15,16 +15,14 @@
  */
 
 /*!
-    \page componments-zh.html
-    \title Componments (zh)
-    \nextpage Knowledge Base (zh)
+    \page components.html
+    \title Components
+    \nextpage Crumb Bar and Address Bar
 
-    开发者文档 - 组件
-
-    这里是深度文件管理器各个组件的开发设计流程文档.
+    This is a list of topics about the components of Deepin File Manager.
 
     \list
-        \li \l {Crumb Bar and Address Bar (zh)} {面包屑栏和地址栏}
+        \li \l {Crumb Bar and Address Bar}
     \endlist
 
     \sa {All DFM Classes}

--- a/docs/qdoc/components_zh.qdoc
+++ b/docs/qdoc/components_zh.qdoc
@@ -15,14 +15,16 @@
  */
 
 /*!
-    \page componments.html
-    \title Componments
-    \nextpage Crumb Bar and Address Bar
+    \page components-zh.html
+    \title Components (zh)
+    \nextpage Knowledge Base (zh)
 
-    This is a list of topics about the componments of Deepin File Manager.
+    开发者文档 - 组件
+
+    这里是深度文件管理器各个组件的开发设计流程文档.
 
     \list
-        \li \l {Crumb Bar and Address Bar}
+        \li \l {Crumb Bar and Address Bar (zh)} {面包屑栏和地址栏}
     \endlist
 
     \sa {All DFM Classes}

--- a/docs/qdoc/index.qdoc
+++ b/docs/qdoc/index.qdoc
@@ -17,7 +17,7 @@
 /*!
     \page index.html
     \title Developer Documentation Index
-    \nextpage Componments
+    \nextpage Components
 
     \section1 Welcome!
 
@@ -37,7 +37,7 @@
     Currently there are two main sections of the documentation page.
 
     \list
-        \li \l {Componments} {Componments of Deepin File Manager}
+        \li \l {Components} {Components of Deepin File Manager}
         \li \l {All DFM Classes} {All Deepin File Manager C++ Classes}
     \endlist
 

--- a/docs/qdoc/index_zh.qdoc
+++ b/docs/qdoc/index_zh.qdoc
@@ -17,7 +17,7 @@
 /*!
     \page index-zh.html
     \title Developer Documentation Index (zh)
-    \nextpage {Componments (zh)} {组件}
+    \nextpage {Components (zh)} {组件}
 
     \section1 欢迎！
 
@@ -37,7 +37,7 @@
     当前我们的文档页包含以下两个主要部分：
 
     \list
-        \li \l {Componments (zh)} {深度文件管理器 组件页}
+        \li \l {Components (zh)} {深度文件管理器 组件页}
         \li \l {All DFM Classes} {深度文件管理器的所有 C++ 类}
     \endlist
     


### PR DESCRIPTION
mis-spelled word: 'componments' should be 'components'

Resolve: https://github.com/linuxdeepin/developer-center/issues/2282