### PR TITLE
feat: enable using input method on desktop

### DIFF
--- a/src/dde-desktop/view/canvasgridview.cpp
+++ b/src/dde-desktop/view/canvasgridview.cpp
@@ -1831,6 +1831,11 @@ void CanvasGridView::focusInEvent(QFocusEvent *event)
 
     /// set menu actions filter
     setMenuActionsFilter();
+
+    // WA_InputMethodEnabled will be set to false if current index is invalid in QAbstractItemView::focusInEvent
+    // Set WA_InputMethodEnabled to enbale using input method on desktop no matter whether the current index is valid or not.
+    if (!testAttribute(Qt::WA_InputMethodEnabled))
+        setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
 void CanvasGridView::focusOutEvent(QFocusEvent *event)
@@ -1967,6 +1972,15 @@ void CanvasGridView::keyboardSearch(const QString &search)
         return;
 
     d->fileViewHelper->keyboardSearch(search.toLocal8Bit().at(0));
+}
+
+QVariant CanvasGridView::inputMethodQuery(Qt::InputMethodQuery query) const
+{
+    // When no item is selected, return input method area where the current mouse is located
+    if (query == Qt::ImCursorRectangle && !currentIndex().isValid())
+        return QRect(mapFromGlobal(QCursor::pos()), iconSize());
+
+    return QAbstractItemView::inputMethodQuery(query);
 }
 
 QPixmap CanvasGridView::renderToPixmap(const QModelIndexList &indexes) const
@@ -2504,6 +2518,16 @@ void CanvasGridView::onRefreshFinished()
     else {  //自定义
         delayCustom();
     }
+}
+
+void CanvasGridView::currentChanged(const QModelIndex &current, const QModelIndex &previous)
+{
+    QAbstractItemView::currentChanged(current, previous);
+
+    // WA_InputMethodEnabled will be set to false if current index is invalid in QAbstractItemView::currentChanged
+    // To enable WA_InputMethodEnabled no matter whether the current index is valid or not.
+    if (!testAttribute(Qt::WA_InputMethodEnabled))
+        setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
 void CanvasGridView::EnableUIDebug(bool enable)

--- a/src/dde-desktop/view/canvasgridview.h
+++ b/src/dde-desktop/view/canvasgridview.h
@@ -87,6 +87,8 @@ public:
     virtual void rowsInserted(const QModelIndex &parent, int first, int last) override;
     virtual void keyboardSearch(const QString &search) override;
 
+    QVariant inputMethodQuery(Qt::InputMethodQuery query) const override;
+
 #if QT_CONFIG(draganddrop)
     virtual void startDrag(Qt::DropActions supportedActions) override;
 #endif
@@ -149,6 +151,7 @@ public slots:
     virtual void selectAll() override;
 protected slots:
     void onRefreshFinished();
+    void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
 // Debug interface
 public Q_SLOTS:
     Q_SCRIPTABLE void EnableUIDebug(bool enable);

--- a/tests/dde-desktop/src/view/ut_canvasgridview_test.cpp
+++ b/tests/dde-desktop/src/view/ut_canvasgridview_test.cpp
@@ -2364,6 +2364,43 @@ TEST_F(CanvasGridViewTest, CanvasGridViewTest_setSelection_shiftAndArrowKeys)
     }
 }
 
+TEST(CanvasGridView, inputMethodQuery)
+{
+    CanvasGridView view("");
+    stub_ext::StubExt stub;
+    QSize size(123, 456);
+    stub.set_lamda(&CanvasGridView::iconSize, [size](){
+        return size;
+    });
+
+    auto rect = view.inputMethodQuery(Qt::ImCursorRectangle).toRect();
+    EXPECT_EQ(rect.size(), size);
+}
+
+TEST(CanvasGridView, focusInEvent_inputMethod)
+{
+    CanvasGridView view("");
+    view.setAttribute(Qt::WA_InputMethodEnabled, false);
+    view.setCurrentIndex(QModelIndex());
+
+    ASSERT_FALSE(view.testAttribute(Qt::WA_InputMethodEnabled));
+    ASSERT_FALSE(view.currentIndex().isValid());
+    QFocusEvent e(QEvent::FocusIn);
+    view.focusInEvent(&e);
+
+    EXPECT_TRUE(view.testAttribute(Qt::WA_InputMethodEnabled));
+}
+
+TEST(CanvasGridView, currentChanged_inputMethod)
+{
+    CanvasGridView view("");
+    view.setAttribute(Qt::WA_InputMethodEnabled, false);
+    ASSERT_FALSE(view.testAttribute(Qt::WA_InputMethodEnabled));
+
+    view.currentChanged(QModelIndex(), QModelIndex());
+    EXPECT_TRUE(view.testAttribute(Qt::WA_InputMethodEnabled));
+}
+
 TEST(CanvasGridViewTest_end, endTest)
 {
     auto path = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);


### PR DESCRIPTION
Enable using input method on desktop when no item is selected. The QAbstractItemView is setting Qt::WA_InputMethodEnabled to false when curren index is invalid. Reimplement currentChanged and focusInEvent to set WA_InputMethodEnabled to true.