### PR TITLE
fix: The distance between separator to sidebar item is not equal

### DIFF
--- a/src/dde-file-manager-lib/views/dfmsidebaritemdelegate.cpp
+++ b/src/dde-file-manager-lib/views/dfmsidebaritemdelegate.cpp
@@ -113,7 +113,7 @@ void DFMSideBarItemDelegate::paintSeparator(QPainter *painter, const QStyleOptio
     painter->save();
 
     int yPoint = option.rect.top() + option.rect.height() / 2;
-    qDrawShadeLine(painter, 0, yPoint, option.rect.width(), yPoint, option.palette);
+    qDrawShadeLine(painter, 0, yPoint + 1, option.rect.width(), yPoint + 1, option.palette);
 
     painter->restore();
 }


### PR DESCRIPTION
Adjust the y-position of separator.

Log: Fix the destance between separator to sidebar item is not equal for each item beside the separator.
Bug: https://pms.uniontech.com/bug-view-156515.html