### PR TITLE
fix: [mount] refresh desktop just after device mounted may cause a short blocking.

### DIFF
--- a/src/dde-dock-plugins/disk-mount/diskcontrolwidget.cpp
+++ b/src/dde-dock-plugins/disk-mount/diskcontrolwidget.cpp
@@ -630,10 +630,12 @@ void DiskControlWidget::refreshDesktop()
 {
     qDebug() << "call desktop.canvas.reFresh";
     // call desktop.canvas.reFresh
-    DDBusSender()
-            .service("com.deepin.dde.desktop")
-            .path("/com/deepin/dde/desktop")
-            .interface("com.deepin.dde.desktop")
-            .method(QString("Refresh"))
-            .call();
+    QTimer::singleShot(100, nullptr, []{
+        DDBusSender()
+                .service("com.deepin.dde.desktop")
+                .path("/com/deepin/dde/desktop")
+                .interface("com.deepin.dde.desktop")
+                .method(QString("Refresh"))
+                .call();
+    });
 }


### PR DESCRIPTION
make a short delay to refresh desktop when device mounted.

Log: fix issue.

Bug: https://pms.uniontech.com/bug-view-160755.html
