### PR TITLE
fix: The favorites disappear after update file manager.

### DIFF
--- a/src/dde-file-manager-lib/controllers/dfmrootcontroller.cpp
+++ b/src/dde-file-manager-lib/controllers/dfmrootcontroller.cpp
@@ -307,11 +307,7 @@ const QList<DAbstractFileInfoPointer> DFMRootController::getChildren(const QShar
                 qWarning() << "protocol or host is empty: " << mount;
                 continue;
             }
-            //考虑到用户升级到有smb挂载项聚合功能的版本后的兼容性，把配置中缓存的.remote挂载信息移到StashedSmbDevices字段中
-            //以smb://x.x.x.x格式保存
-            if(protocol == SMB_SCHEME){
-                RemoteMountsStashManager::insertStashedSmbDevice(QString("%1://%2").arg(protocol).arg(host));
-            }
+
             /*smb挂载项聚合功能中，这里不再对缓存的挂载目录创建DFMRootFileInfo对象（请保留此部分注释）
             QString path = QString("%1://%2/%3").arg(protocol).arg(host).arg(share);
             path.append(QString(".%1").arg(SUFFIX_STASHED_REMOTE));

--- a/src/dde-file-manager-lib/views/dfmsidebaritemdelegate.cpp
+++ b/src/dde-file-manager-lib/views/dfmsidebaritemdelegate.cpp
@@ -113,7 +113,7 @@ void DFMSideBarItemDelegate::paintSeparator(QPainter *painter, const QStyleOptio
     painter->save();
 
     int yPoint = option.rect.top() + option.rect.height() / 2;
-    qDrawShadeLine(painter, 0, yPoint, option.rect.width(), yPoint, option.palette);
+    qDrawShadeLine(painter, 0, yPoint + 1, option.rect.width(), yPoint + 1, option.palette);
 
     painter->restore();
 }


### PR DESCRIPTION
After updating to new version and start dfm first time, the bookmark module operate config file by DTK API; But the smb module operate config file manually; Fix method: smb module also operate config file by DTK API.
    
    Log: The favorites disappear after update file manager.
    Bug: https://pms.uniontech.com/bug-view-153497.html
