### PR TITLE
fix: wallpaper bugs

### DIFF
--- a/src/dde-wallpaper-chooser/frame.cpp
+++ b/src/dde-wallpaper-chooser/frame.cpp
@@ -409,17 +409,6 @@ void Frame::keyPressEvent(QKeyEvent *event)
     }
 }
 
-void Frame::paintEvent(QPaintEvent *event)
-{
-    DBlurEffectWidget::paintEvent(event);
-
-    QPainter pa(this);
-
-    pa.setCompositionMode(QPainter::CompositionMode_SourceOut);
-    pa.setPen(QPen(QColor(255, 255, 255, 20), 1));
-    pa.drawLine(QPoint(0, 0), QPoint(width(), 0));
-}
-
 bool Frame::event(QEvent *event)
 {
 #ifndef DISABLE_SCREENSAVER

--- a/src/dde-wallpaper-chooser/frame.h
+++ b/src/dde-wallpaper-chooser/frame.h
@@ -58,7 +58,6 @@ protected:
     void showEvent(QShowEvent *) override;
     void hideEvent(QHideEvent *) override;
     void keyPressEvent(QKeyEvent *) override;
-    void paintEvent(QPaintEvent *event) override;
     bool event(QEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event) override;
 

--- a/src/dde-wallpaper-chooser/wallpaperlist.cpp
+++ b/src/dde-wallpaper-chooser/wallpaperlist.cpp
@@ -337,6 +337,19 @@ void WallpaperList::setCurrentIndex(int index)
     int nextIndex = m_items.indexOf(qobject_cast<WallpaperItem *>(itemAt(width() - ItemWidth / 2, ItemHeight / 2)),0);
     scrollAnimation.setStartValue(((prevIndex+nextIndex)/2-visualCount/2) * (ItemWidth+m_contentLayout->spacing()));
     scrollAnimation.setEndValue((index-visualCount/2) * (ItemWidth+m_contentLayout->spacing()));
+
+    //the starting direction is opposite to the target direction
+    {
+        int start = scrollAnimation.startValue().toInt();
+        int end = scrollAnimation.endValue().toInt();
+        int current = horizontalScrollBar()->value();
+        if (((start - end) * (current - start)) < 0) {
+            qDebug() << "the starting direction is opposite to the target direction"
+                     << start << end << current << horizontalScrollBar()->maximum();
+            scrollAnimation.setStartValue(current);
+        }
+    }
+
     scrollAnimation.start();
     m_index = m_items.indexOf(item, 0);
 }

--- a/tests/dde-desktop/src/dde-wallpaper-chooser/ut-wallpaperlist-test.cpp
+++ b/tests/dde-desktop/src/dde-wallpaper-chooser/ut-wallpaperlist-test.cpp
@@ -10,11 +10,8 @@
 #include <QVBoxLayout>
 #include <QAbstractAnimation>
 #include <qabstractslider.h>
-
-#define private public
-#define protected public
-
 #include <QWidget>
+#include <QScrollBar>
 #include "../dde-wallpaper-chooser/wallpaperitem.h"
 #include "../dde-wallpaper-chooser/frame.h"
 #include "../dde-wallpaper-chooser/wallpaperlist.h"
@@ -275,6 +272,13 @@ TEST_F(WallpaperlistTest, test_setcurrentindex)
     EXPECT_TRUE(m_list->m_index == 0);
     EXPECT_TRUE(isslideup);
     EXPECT_TRUE(isslidedown);
+
+    {
+        int start = m_list->scrollAnimation.startValue().toInt();
+        int end = m_list->scrollAnimation.endValue().toInt();
+        int current = m_list->horizontalScrollBar()->value();
+        EXPECT_GE((start - end) * (current - start), 0);
+    }
 }
 
 TEST_F(WallpaperlistTest, test_showDeleteButtonForItem)


### PR DESCRIPTION
1. fix the desktop wallpaper shakes when switching.
2. do not draw white line on the frame.

Log: 
Bug: https://pms.uniontech.com/bug-view-160243.html Bug: https://pms.uniontech.com/bug-view-160209.html
 
Influence: 桌面壁纸设置窗口