### PR TITLE
fix: [watcher] fix watcher failed under specific conditions

### DIFF
--- a/src/dde-file-manager-lib/interfaces/dfilewatcher.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfilewatcher.cpp
@@ -95,6 +95,7 @@ bool DFileWatcherPrivate::start()
 
     started = true;
 
+    bool pathAdded = false;
     foreach (const QString &path, parentPathList(this->path)) {
         if (watchFileList.contains(path))
             continue;
@@ -109,15 +110,20 @@ bool DFileWatcherPrivate::start()
                 }
                 if (shouldAddToPath && !watcher_file_private->addPath(path)) {
                     qWarning() << Q_FUNC_INFO << "start watch failed, file path =" << path;
-                    q->stopWatcher();
-                    started = false;
-                    return false;
+                    continue;
                 }
             }
         }
 
+        pathAdded = true;
         watchFileList << path;
         filePathToWatcherCount[path] = filePathToWatcherCount.value(path, 0) + 1;
+    }
+
+    if(!pathAdded) {
+        q->stopWatcher();
+        started = false;
+        return false;
     }
 
     q->connect(watcher_file_private, &DFileSystemWatcher::fileDeleted,


### PR DESCRIPTION
before, it will add all parent path to watcher when create watcher, if one of paths failed, the watcher will stop and failed. now, failed path will be skipped.

Log: fix watcher bug

Bug: https://pms.uniontech.com/bug-view-159619.html