### PR TITLE
chore: [ut] failed on disk-mount-plugin

### DIFF
--- a/tests/dde-dock-plugins/disk-mount/test-disk-mount.pro
+++ b/tests/dde-dock-plugins/disk-mount/test-disk-mount.pro
@@ -7,7 +7,8 @@ SRC_FOLDER = $$PWD/../../../src
 
 INCLUDEPATH += /usr/include/dde-dock
 INCLUDEPATH += $$SRC_FOLDER/dde-file-manager-lib/interfaces \
-               $$SRC_FOLDER/dde-file-manager-lib
+               $$SRC_FOLDER/dde-file-manager-lib \
+               $$SRC_FOLDER/utils \
 
 
 TARGET = test-dde-disk-mount-plugin


### PR DESCRIPTION
as title, cannot find 'rlog.h' in disk-mount-plugin ut project, the path 'utils' is not included.

Log: fix ut failed.
