### PR TITLE
fix: keyboard search crash

### DIFF
--- a/src/dde-file-manager-lib/views/dfileview.cpp
+++ b/src/dde-file-manager-lib/views/dfileview.cpp
@@ -1436,7 +1436,7 @@ void DFileView::updateModelActiveIndex()
         if (fileInfo) {
             fileInfo->makeToActive();
 
-            if (!fileInfo->exists()) {
+            if (!fileInfo->exists() && fileInfo->filePath().isEmpty()) {
                 m_isRemovingCase = true;
                 model()->removeRow(i, rootIndex());
             } else if (fileWatcher) {


### PR DESCRIPTION
1. The file manager does not display special files without permissions, which causes the program to crash when searching.
2. Show special files without permissions.

Log: Optimization view
Bug: https://pms.uniontech.com/bug-view-163361.html