### PR TITLE
fix: Fixed file drag and drop error

### DIFF
--- a/src/dde-file-manager-lib/io/dstorageinfo.h
+++ b/src/dde-file-manager-lib/io/dstorageinfo.h
@@ -73,7 +73,7 @@ inline bool operator==(const DStorageInfo &first, const DStorageInfo &second)
     if (first.d_ptr == second.d_ptr)
         return true;
 
-    return first.device() == second.device() && first.rootPath() == second.rootPath();
+    return first.device() == second.device();
 }
 
 inline bool operator!=(const DStorageInfo &first, const DStorageInfo &second)


### PR DESCRIPTION
The data disk directory and the local directory are judged to be different disks

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-162955.html
