### PR TITLE
fix: Ctrl+T shortcut key cannot open tab

### DIFF
--- a/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
@@ -689,11 +689,6 @@ void DFileManagerWindow::onRequestCloseTab(const int index, const bool &remainSt
 
     DFMBaseView *view = tab->fileView();
 
-    d->isAdvanceSearchView.removeAll(view);
-    if (d->advanceSearchBar && d->isAdvanceSearchBarVisible()) {
-        d->advanceSearchBar->resetForm(true);
-    }
-
     d->viewStackLayout->removeWidget(view->widget());
     view->deleteLater();
 
@@ -1726,20 +1721,11 @@ void DFileManagerWindow::updateAdvanceSearchBarValue(const FileFilter *filter)
         d->advanceSearchBar->updateFilterValue(filter);
 }
 
-void DFileManagerWindow::toggleAdvanceSearchBar(bool visible, bool resetForm, bool clicked)
+void DFileManagerWindow::toggleAdvanceSearchBar(bool visible, bool resetForm)
 {
     Q_D(DFileManagerWindow);
 
     if (!d->currentView) return;
-
-    if (clicked) {
-        if (visible) {
-            d->isAdvanceSearchView.append(d->currentView);
-        }
-        else {
-            d->isAdvanceSearchView.removeAll(d->currentView);
-        }
-    }
 
     if (d->isAdvanceSearchBarVisible() != visible) {
         d->setAdvanceSearchBarVisible(visible);
@@ -1772,12 +1758,5 @@ void DFileManagerWindow::clearActions()
 {
     if (fileMenuManger)
         fileMenuManger->clearActions();
-}
-
-bool DFileManagerWindow::isViewShowAdvanceSearchBar() const
-{
-    Q_D(const DFileManagerWindow);
-
-    return d->isAdvanceSearchView.contains(d->currentView);
 }
 

--- a/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
@@ -1001,6 +1001,7 @@ void DFileManagerWindow::switchToView(DFMBaseView *view)
     D_D(DFileManagerWindow);
 
     if (d->currentView == view) {
+        d->currentView->widget()->setFocus(Qt::FocusReason::OtherFocusReason);
         return;
     }
 

--- a/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
@@ -689,6 +689,11 @@ void DFileManagerWindow::onRequestCloseTab(const int index, const bool &remainSt
 
     DFMBaseView *view = tab->fileView();
 
+    d->isAdvanceSearchView.removeAll(view);
+    if (d->advanceSearchBar && d->isAdvanceSearchBarVisible()) {
+        d->advanceSearchBar->resetForm(true);
+    }
+
     d->viewStackLayout->removeWidget(view->widget());
     view->deleteLater();
 
@@ -1721,11 +1726,20 @@ void DFileManagerWindow::updateAdvanceSearchBarValue(const FileFilter *filter)
         d->advanceSearchBar->updateFilterValue(filter);
 }
 
-void DFileManagerWindow::toggleAdvanceSearchBar(bool visible, bool resetForm)
+void DFileManagerWindow::toggleAdvanceSearchBar(bool visible, bool resetForm, bool clicked)
 {
     Q_D(DFileManagerWindow);
 
     if (!d->currentView) return;
+
+    if (clicked) {
+        if (visible) {
+            d->isAdvanceSearchView.append(d->currentView);
+        }
+        else {
+            d->isAdvanceSearchView.removeAll(d->currentView);
+        }
+    }
 
     if (d->isAdvanceSearchBarVisible() != visible) {
         d->setAdvanceSearchBarVisible(visible);
@@ -1758,5 +1772,12 @@ void DFileManagerWindow::clearActions()
 {
     if (fileMenuManger)
         fileMenuManger->clearActions();
+}
+
+bool DFileManagerWindow::isViewShowAdvanceSearchBar() const
+{
+    Q_D(const DFileManagerWindow);
+
+    return d->isAdvanceSearchView.contains(d->currentView);
 }
 

--- a/src/dde-file-manager-lib/views/dfilemanagerwindow.h
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow.h
@@ -83,7 +83,7 @@ public:
     void requestToSelectUrls();
     bool isAdvanceSearchBarVisible();
     void updateAdvanceSearchBarValue(const FileFilter *filter);
-    void toggleAdvanceSearchBar(bool visible = true, bool resetForm = true);
+    void toggleAdvanceSearchBar(bool visible = true, bool resetForm = true, bool clicked = true);
     void showFilterButton();
     //获取能否析构
     bool getCanDestruct() const;
@@ -93,6 +93,8 @@ public:
      * @return
      */
     void clearActions();
+    //获取当前的view的AdvanceSearchBar是否可以显示
+    bool isViewShowAdvanceSearchBar() const;
 
 signals:
     void aboutToClose();

--- a/src/dde-file-manager-lib/views/dfilemanagerwindow.h
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow.h
@@ -83,7 +83,7 @@ public:
     void requestToSelectUrls();
     bool isAdvanceSearchBarVisible();
     void updateAdvanceSearchBarValue(const FileFilter *filter);
-    void toggleAdvanceSearchBar(bool visible = true, bool resetForm = true, bool clicked = true);
+    void toggleAdvanceSearchBar(bool visible = true, bool resetForm = true);
     void showFilterButton();
     //获取能否析构
     bool getCanDestruct() const;
@@ -93,8 +93,6 @@ public:
      * @return
      */
     void clearActions();
-    //获取当前的view的AdvanceSearchBar是否可以显示
-    bool isViewShowAdvanceSearchBar() const;
 
 signals:
     void aboutToClose();

--- a/src/dde-file-manager-lib/views/dfilemanagerwindow_p.h
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow_p.h
@@ -86,8 +86,6 @@ public:
     QPoint windowPoint;
     //是否需要关闭
     QAtomicInteger<bool> m_isNeedClosed = false;
-    // 记录那个view的AdvanceSearchBar打开了
-    QList<DFMBaseView *> isAdvanceSearchView;
 
     DFileManagerWindow *q_ptr{ nullptr };
 

--- a/src/dde-file-manager-lib/views/dfilemanagerwindow_p.h
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow_p.h
@@ -86,6 +86,8 @@ public:
     QPoint windowPoint;
     //是否需要关闭
     QAtomicInteger<bool> m_isNeedClosed = false;
+    // 记录那个view的AdvanceSearchBar打开了
+    QList<DFMBaseView *> isAdvanceSearchView;
 
     DFileManagerWindow *q_ptr{ nullptr };
 

--- a/src/dde-file-manager-lib/views/dtoolbar.cpp
+++ b/src/dde-file-manager-lib/views/dtoolbar.cpp
@@ -396,6 +396,15 @@ void DToolBar::toggleSearchButtonState(bool asb)
         m_searchButton->style()->polish(m_searchButton);
         m_searchButton->setFlat(true);
         m_searchButtonAsbState = true;
+        if (DFileManagerWindow *dfmWindow = qobject_cast<DFileManagerWindow *>(window())) {
+            if (dfmWindow->isViewShowAdvanceSearchBar()) {
+                m_searchButton->setDown(true);
+                dfmWindow->toggleAdvanceSearchBar(true, false, false);
+            }
+        }
+        else {
+            qCritical() << "window() is null or faile to cast to DFileManagerWindow.";
+        }
     } else {
         m_searchButton->setHidden(false);
         m_searchButton->style()->unpolish(m_searchButton);
@@ -404,7 +413,7 @@ void DToolBar::toggleSearchButtonState(bool asb)
         m_searchButton->setDown(false);
         m_searchButtonAsbState = false;
         if (DFileManagerWindow *dfmWindow = qobject_cast<DFileManagerWindow *>(window())) {
-            dfmWindow->toggleAdvanceSearchBar(false);
+            dfmWindow->toggleAdvanceSearchBar(false, false, false);
         }
         else {
             qCritical() << "window() is null or faile to cast to DFileManagerWindow.";

--- a/src/dde-file-manager-lib/views/dtoolbar.cpp
+++ b/src/dde-file-manager-lib/views/dtoolbar.cpp
@@ -396,15 +396,6 @@ void DToolBar::toggleSearchButtonState(bool asb)
         m_searchButton->style()->polish(m_searchButton);
         m_searchButton->setFlat(true);
         m_searchButtonAsbState = true;
-        if (DFileManagerWindow *dfmWindow = qobject_cast<DFileManagerWindow *>(window())) {
-            if (dfmWindow->isViewShowAdvanceSearchBar()) {
-                m_searchButton->setDown(true);
-                dfmWindow->toggleAdvanceSearchBar(true, false, false);
-            }
-        }
-        else {
-            qCritical() << "window() is null or faile to cast to DFileManagerWindow.";
-        }
     } else {
         m_searchButton->setHidden(false);
         m_searchButton->style()->unpolish(m_searchButton);
@@ -413,7 +404,7 @@ void DToolBar::toggleSearchButtonState(bool asb)
         m_searchButton->setDown(false);
         m_searchButtonAsbState = false;
         if (DFileManagerWindow *dfmWindow = qobject_cast<DFileManagerWindow *>(window())) {
-            dfmWindow->toggleAdvanceSearchBar(false, false, false);
+            dfmWindow->toggleAdvanceSearchBar(false);
         }
         else {
             qCritical() << "window() is null or faile to cast to DFileManagerWindow.";


### PR DESCRIPTION
After opening multiple tabs, click the current tab, causing the focus to switch to the tabbar

Log: When switching views, when the current view is detected, set the focus to the current view
Bug: https://pms.uniontech.com/bug-view-162917.html