### PR TITLE
fix: fix rename file remind button text color when file name startwit…

### DIFF
--- a/src/dde-file-manager-lib/dialogs/dialogmanager.cpp
+++ b/src/dde-file-manager-lib/dialogs/dialogmanager.cpp
@@ -486,7 +486,7 @@ std::pair<bool, bool> DialogManager::showRenameNameDotBeginDialog()
     d.setTitle(tr("This file will be hidden if the file name starts with '.'. Do you want to hide it?"));
     auto checkBox = new QCheckBox(tr("Don't ask again"));
     d.insertContent(0, checkBox);
-    d.addButton(tr("Hide"), true, DDialog::ButtonRecommend);
+    d.addButton(tr("Hide"), true, DDialog::ButtonWarning);
     d.addButton(tr("Cancel"));
 
     d.setDefaultButton(1);


### PR DESCRIPTION
use red color to instead bule in button

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-165675.html