### PR TITLE
fix attribute dialog box cannot be displayed

### DIFF
--- a/src/dde-file-manager-lib/controllers/avfsfilecontroller.cpp
+++ b/src/dde-file-manager-lib/controllers/avfsfilecontroller.cpp
@@ -172,3 +172,12 @@ DUrlList AVFSFileController::moveToTrash(const QSharedPointer<DFMMoveToTrashEven
     emit fileSignalManager->requestShowNoPermissionDialog(noPermissionEvent);
     return DUrlList();
 }
+
+
+bool AVFSFileController::deleteFiles(const QSharedPointer<DFMDeleteEvent> &event) const
+{
+    DFMUrlListBaseEvent noPermissionEvent(nullptr, event->urlList());
+    noPermissionEvent.setWindowId(static_cast<quint64>(static_cast<int>(event->windowId())));
+    emit fileSignalManager->requestShowNoPermissionDialog(noPermissionEvent);
+    return true;
+}

--- a/src/dde-file-manager-lib/controllers/avfsfilecontroller.h
+++ b/src/dde-file-manager-lib/controllers/avfsfilecontroller.h
@@ -29,6 +29,7 @@ public:
     bool writeFilesToClipboard(const QSharedPointer<DFMWriteUrlsToClipboardEvent> &event) const override;
 
     bool openInTerminal(const QSharedPointer<DFMOpenInTerminalEvent> &event) const override;
+    bool deleteFiles(const QSharedPointer<DFMDeleteEvent> &event) const override;
     DUrlList moveToTrash(const QSharedPointer<DFMMoveToTrashEvent> &event) const override;
 
     static DUrl realUrl(const DUrl &url);

--- a/src/dde-file-manager-lib/dialogs/dialogmanager.cpp
+++ b/src/dde-file-manager-lib/dialogs/dialogmanager.cpp
@@ -897,6 +897,7 @@ void DialogManager::showPropertyDialog(const DFMUrlListBaseEvent &event)
                 if (m_propertyDialogs.contains(url)) {
                     dialog = m_propertyDialogs.value(url);
                     dialog->raise();
+                    dialog->activateWindow();
                 } else {
                     dialog = new PropertyDialog(event, url);
                     dialog->setWindowFlags(dialog->windowFlags() & ~ Qt::FramelessWindowHint);
@@ -909,6 +910,7 @@ void DialogManager::showPropertyDialog(const DFMUrlListBaseEvent &event)
                         dialog->move(pos);
                     }
                     dialog->show();
+                    dialog->activateWindow();
 
                     connect(dialog, &PropertyDialog::closed, this, &DialogManager::removePropertyDialog);
                     //                connect(dialog, &PropertyDialog::raised, this, &DialogManager::raiseAllPropertyDialog);

--- a/src/dde-file-manager-lib/dialogs/dialogmanager.cpp
+++ b/src/dde-file-manager-lib/dialogs/dialogmanager.cpp
@@ -924,6 +924,7 @@ void DialogManager::showPropertyDialog(const DFMUrlListBaseEvent &event)
         m_multiFilesPropertyDialog->show();
         m_multiFilesPropertyDialog->moveToCenter();
         m_multiFilesPropertyDialog->raise();
+        m_multiFilesPropertyDialog->activateWindow();
     }
 }
 
@@ -933,6 +934,7 @@ void DialogManager::showShareOptionsInPropertyDialog(const DFMUrlListBaseEvent &
     showPropertyDialog(event);
     if (m_propertyDialogs.contains(url)) {
         PropertyDialog *dialog = m_propertyDialogs.value(url);
+        dialog->activateWindow();
         if (dialog->expandGroup().count() > 1) {
             dialog->expandGroup().at(0)->setAnimationDuration(0);
             dialog->expandGroup().at(1)->setAnimationDuration(0);
@@ -957,10 +959,13 @@ void DialogManager::showTrashPropertyDialog(const DFMEvent &event)
     QPoint pos = getPerportyPos(m_trashDialog->size().width(), m_trashDialog->size().height(), 1, 0);
     m_trashDialog->move(pos);
     m_trashDialog->show();
+    m_trashDialog->activateWindow();
 
     TIMER_SINGLESHOT(100, {
-        if (m_trashDialog)
+        if (m_trashDialog) {
             m_trashDialog->raise();
+            m_trashDialog->activateWindow();
+        }
     }, this)
 }
 
@@ -970,15 +975,18 @@ void DialogManager::showComputerPropertyDialog()
         m_computerDialog->updateComputerInfo();
         m_computerDialog->show();
         m_computerDialog->raise();
+        m_computerDialog->activateWindow();
         return;
     }
     m_computerDialog = new ComputerPropertyDialog;
     QPoint pos = getPerportyPos(m_computerDialog->size().width(), m_computerDialog->size().height(), 1, 0);
     m_computerDialog->show();
     m_computerDialog->move(pos);
+    m_computerDialog->activateWindow();
 
     TIMER_SINGLESHOT(100, {
         m_computerDialog->raise();
+        m_computerDialog->activateWindow();
     },
     this)
 }
@@ -989,6 +997,7 @@ void DialogManager::showDevicePropertyDialog(const DFMEvent &event)
     if (w) {
         PropertyDialog *dialog = new PropertyDialog(event, event.fileUrl());
         dialog->show();
+        dialog->activateWindow();
     }
 }
 

--- a/src/dde-file-manager-lib/dialogs/filepreviewdialog.h
+++ b/src/dde-file-manager-lib/dialogs/filepreviewdialog.h
@@ -94,6 +94,8 @@ private:
 
     void updateTitle();
 
+    void updateDialog();
+
     DUrlList m_fileList;
     DUrlList m_entryUrlList;
 
@@ -104,6 +106,7 @@ private:
     bool m_playingVideo = false;
     bool m_firstEnterSwitchToPage = false;
     int m_currentPageIndex = -1;
+    QAtomicInteger<bool> m_isSwitch = false;
     DFMFilePreview *m_preview = nullptr;
 
 };

--- a/src/dde-file-manager-lib/views/dtoolbar.cpp
+++ b/src/dde-file-manager-lib/views/dtoolbar.cpp
@@ -176,7 +176,7 @@ void DToolBar::initContollerToolBar()
     m_contollerToolBar->setFrameShape(QFrame::NoFrame);
     m_contollerToolBar->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     m_contollerToolBarContentLayout = new QHBoxLayout(m_contollerToolBar);
-    m_contollerToolBarContentLayout->setContentsMargins(14, 1, 14, 1);
+    m_contollerToolBarContentLayout->setContentsMargins(14, 0, 14, 0);
     m_contollerToolBarContentLayout->setSpacing(20);
 }
 


### PR DESCRIPTION
fix: Click "Display Desktop" again, and the property page of the computer cannot be displayed

After the desktop is displayed, the previous property box is hidden. Call activewindow when modifying the call property box

Log: fix attribute dialog box cannot be displayed
Bug: https://pms.uniontech.com/bug-view-162747.html