### PR TITLE
fix: cant not enter dir when access sftp mount from dock

### DIFF
--- a/src/dde-file-manager-lib/controllers/fileeventprocessor.cpp
+++ b/src/dde-file-manager-lib/controllers/fileeventprocessor.cpp
@@ -380,22 +380,22 @@ bool FileEventProcessor::fmEvent(const QSharedPointer<DFMEvent> &event, QVariant
                 serverIP = url.host();
             } else {
                 QString path = QUrl::fromPercentEncoding(url.path().toUtf8());
-                if(FileUtils::isSmbPath(path)){
+                if (FileUtils::isSmbPath(path)){
                     serverIP = FileUtils::smbAttribute(path,FileUtils::SmbAttribute::kServer);
-                }else if(url.scheme() == FILE_SCHEME){
-                    if(path.contains("ftp:host")){
-                        serverIP = path.section("ftp:host=",-1);
-                        serverIP = serverIP.section("/",0,0);
-                        port = 21;
-                    }else if(path.contains("sftp:host")){
+                }else if (url.scheme() == FILE_SCHEME){
+                    if (path.contains("sftp:host")){ // `sftp` must be judged firstly than `ftp`
                         serverIP = path.section("sftp:host=",-1);
                         serverIP = serverIP.section("/",0,0);
                         port = 22;
+                    } else if (path.contains("ftp:host")){
+                        serverIP = path.section("ftp:host=",-1);
+                        serverIP = serverIP.section("/",0,0);
+                        port = 21;
                     }
                 }
             }
             bool re = CheckNetwork::isHostAndPortConnectV2(serverIP,port);
-            if(!serverIP.isEmpty() && !re){
+            if (!serverIP.isEmpty() && !re){
                 WindowManager::instance()->showNewWindow(DUrl(COMPUTER_ROOT), e->force());
                 continue;
             }


### PR DESCRIPTION
Swapping the judge order between `sftp` and `ftp` symbol

Bug: https://pms.uniontech.com/bug-view-167415.html