### PR TITLE
fix show more property windows

### DIFF
--- a/src/dde-file-manager-lib/dialogs/propertydialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/propertydialog.cpp
@@ -979,7 +979,7 @@ void PropertyDialog::raise()
     emit raised();
 }
 
-void PropertyDialog::hideEvent(QHideEvent *event)
+void PropertyDialog::closeEvent(QCloseEvent *event)
 {
     if (m_xani) {
         m_xani->stop();
@@ -992,11 +992,11 @@ void PropertyDialog::hideEvent(QHideEvent *event)
     if (m_aniLabel)
         delete  m_aniLabel;
     emit aboutToClosed(m_url);
-    DDialog::hideEvent(event);
     emit closed(m_url);
     if (m_sizeWorker) {
         m_sizeWorker->stop();
     }
+    DDialog::closeEvent(event);
 }
 
 void PropertyDialog::resizeEvent(QResizeEvent *event)

--- a/src/dde-file-manager-lib/dialogs/propertydialog.h
+++ b/src/dde-file-manager-lib/dialogs/propertydialog.h
@@ -175,7 +175,7 @@ signals:
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;
-    void hideEvent(QHideEvent *event) override;
+    void closeEvent(QCloseEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void showEvent(QShowEvent* event) override;
 


### PR DESCRIPTION
 Create a new text document on the desktop, right click "Properties" to pop up the properties window, the task bar will open the file management window, and the task bar at the lower left corner will click "Show Desktop", and the document properties window and file management window will be hidden. Click the file management of the task bar at the lower left corner of the bottom separately, and the file management window will pop up and close the file management window. Select a text document on the desktop, and right click the properties to continue to pop up a properties window, but the original one will not pop up, Through the multitask view, you can see that there are two attribute windows

Log: Use closeevent event processing
Bug: https://pms.uniontech.com/bug-view-169273.html