### PR TITLE
fix: Sidebar item without display name is shown

### DIFF
--- a/src/dde-file-manager-lib/views/dfmsidebar.cpp
+++ b/src/dde-file-manager-lib/views/dfmsidebar.cpp
@@ -922,11 +922,12 @@ void DFMSideBar::initDeviceConnection()
         DUrl url = temUrl;
 
         QString smbIp;
-        bool needAddSmbItem = FileUtils::isSmbRelatedUrl(url, smbIp);
-        if (needAddSmbItem && isSmbItemExisted(QString("%1://%2").arg(SMB_SCHEME).arg(smbIp))){//已经添加了
+        bool isSmbUrl = FileUtils::isSmbRelatedUrl(url, smbIp);
+        if (isSmbUrl && isSmbItemExisted(QString("%1://%2").arg(SMB_SCHEME).arg(smbIp))){//已经添加了
             return;
         }
-        if (smbIntegrationSwitcher->isIntegrationMode()){ // fix bug:#168885
+        // Smb url with smb-integration mode, change `url` to format smb://x.x.x.x and show ip item in sidebar.
+        if (isSmbUrl && smbIntegrationSwitcher->isIntegrationMode()){ // fix bug:#168885, fix bug:#169979
             url = DUrl(QString("%1://%2").arg(SMB_SCHEME).arg(smbIp));
         }
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -502,4 +502,5 @@ void RemoteMountsStashManager::insertStashedSmbDevice(const QString &url)
 
     stashedSmbDevices.append(url);
     DFMApplication::genericSetting()->setValue(kStashedSmbDevices, kSmbIntegrations, stashedSmbDevices);
+    DFMApplication::genericSetting()->sync();
 }


### PR DESCRIPTION
A logic problem causes the url be handled as a smb url, so no display name got.

Bug: https://pms.uniontech.com/bug-view-169979.html