### PR TITLE
Fix hardcoded path as per linuxdeepin/developer-center#3374

### DIFF
--- a/src/dde-file-manager-lib/shutil/fileutils.cpp
+++ b/src/dde-file-manager-lib/shutil/fileutils.cpp
@@ -1220,11 +1220,11 @@ bool FileUtils::isFileManagerSelf(const QString &desktopFile)
 QString FileUtils::defaultTerminalPath()
 {
     const static QString dde_daemon_default_term = QStringLiteral("/usr/lib/deepin-daemon/default-terminal");
-    const static QString debian_x_term_emu = QStringLiteral("/usr/bin/x-terminal-emulator");
+    const static QString debian_x_term_emu = QStandardPaths::findExecutable("x-terminal-emulator");
 
     if (QFileInfo::exists(dde_daemon_default_term)) {
         return dde_daemon_default_term;
-    } else if (QFileInfo::exists(debian_x_term_emu)) {
+    } else if (!debian_x_term_emu.isEmpty()) {
         return debian_x_term_emu;
     }
 


### PR DESCRIPTION
Change absolute path /usr/bin/x-terminal-emulator in src/dde-file-manager-lib/shutil/fileutils.cpp to x-terminal-emulator

Related: linuxdeepin/developer-center#3374