### PR TITLE
fix: avoid hardcoded exec path

### DIFF
--- a/src/dde-file-manager-lib/shutil/fileutils.cpp
+++ b/src/dde-file-manager-lib/shutil/fileutils.cpp
@@ -1220,11 +1220,11 @@ bool FileUtils::isFileManagerSelf(const QString &desktopFile)
 QString FileUtils::defaultTerminalPath()
 {
     const static QString dde_daemon_default_term = QStringLiteral("/usr/lib/deepin-daemon/default-terminal");
-    const static QString debian_x_term_emu = QStringLiteral("/usr/bin/x-terminal-emulator");
+    const static QString debian_x_term_emu = QStandardPaths::findExecutable("x-terminal-emulator");
 
     if (QFileInfo::exists(dde_daemon_default_term)) {
         return dde_daemon_default_term;
-    } else if (QFileInfo::exists(debian_x_term_emu)) {
+    } else if (!debian_x_term_emu.isEmpty()) {
         return debian_x_term_emu;
     }
 

--- a/src/dde-file-manager-lib/shutil/fileutils.cpp
+++ b/src/dde-file-manager-lib/shutil/fileutils.cpp
@@ -1226,9 +1226,9 @@ QString FileUtils::defaultTerminalPath()
         return dde_daemon_default_term;
     } else if (!debian_x_term_emu.isEmpty()) {
         return debian_x_term_emu;
+    } else {
+	return QStandardPaths::findExecutable("xterm");
     }
-
-    return QStandardPaths::findExecutable("xterm");
 }
 
 bool FileUtils::setBackground(const QString &pictureFilePath)


### PR DESCRIPTION
Replace absolute path to executable /usr/bin/x-terminal-emulator in src/dde-file-manager-lib/shutil/fileutils.cpp with just x-terminal-emulator

Related: linuxdeepin/developer-center#3374

Hopefully I got the commit message format correct this time. If so, please review this pull request and approve if there are no outstanding issues, thanks :smile: 