### PR TITLE
Fix incorrect overlap of preview images

### DIFF
--- a/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
@@ -300,6 +300,28 @@ void FilePreviewDialog::showEvent(QShowEvent *event)
     return DAbstractDialog::showEvent(event);
 }
 
+void FilePreviewDialog::hideEvent(QHideEvent *event)
+{
+    m_isSwitch = false;
+    emit signalCloseEvent();
+    if (m_preview) {
+        m_preview->contentWidget()->hide();
+        m_preview->stop();
+        disconnect(m_preview, &DFMFilePreview::titleChanged, this, &FilePreviewDialog::updateTitle);
+        m_preview->contentWidget()->setVisible(false);
+        static_cast<QVBoxLayout *>(layout())->removeWidget(m_preview->contentWidget());
+        static_cast<QHBoxLayout *>(m_statusBar->layout())->removeWidget(m_preview->statusBarWidget());
+        if (DFMGlobal::isWayLand()) {
+            m_preview->DoneCurrent();
+        } else {
+            m_preview->deleteLater();
+            m_preview = nullptr;
+        }
+    }
+
+    return DAbstractDialog::hideEvent(event);
+}
+
 void FilePreviewDialog::closeEvent(QCloseEvent *event)
 {
     m_isSwitch = false;

--- a/src/dde-file-manager-lib/dialogs/filepreviewdialog.h
+++ b/src/dde-file-manager-lib/dialogs/filepreviewdialog.h
@@ -83,6 +83,7 @@ public slots:
 private:
     void childEvent(QChildEvent *event) override;
     void showEvent(QShowEvent *event) override;
+    void hideEvent(QHideEvent *event) override;
     void closeEvent(QCloseEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     bool eventFilter(QObject *obj, QEvent *event) override;


### PR DESCRIPTION

Preview after multiple files are selected in the box. Switch to different preview files. After using ESC to exit, the preview images overlap incorrectly again

Log: Fix preview overlap
Bug: https://pms.uniontech.com/bug-view-164479.html