### PR TITLE
修正各文件系统磁盘重命名时的字符限制

### DIFF
--- a/src/dde-file-manager-lib/models/computermodel.cpp
+++ b/src/dde-file-manager-lib/models/computermodel.cpp
@@ -507,12 +507,10 @@ QVariant ComputerModel::data(const QModelIndex &index, int role) const
 
     if (role == DataRoles::EditorLengthRole) {
         if (pitmdata->fi) {
-            // 普通文件系统限制最长输入字符为 40, vfat exfat 由于文件系统的原因，只能输入 11 个字节
-            // todo: ext filesystems only allow 16 bytes/charactors for label length, and vfat is 11, ntfs is 32,
-            // make a static map to storage it, do it later...
             const QString &fs = pitmdata->fi->extraProperties()["fsType"].toString().toLower();
-            return fs.endsWith("fat") ? 11 : 40;
+            return FileUtils::maxLabelLengthOfFileSystem(fs);
         }
+        return 11;
     }
 
     if (role == DataRoles::AppEntryDescription) {

--- a/src/dde-file-manager-lib/shutil/fileutils.cpp
+++ b/src/dde-file-manager-lib/shutil/fileutils.cpp
@@ -2303,6 +2303,25 @@ bool FileUtils::isArchiveByMimetype(const QString &mimetype)
     return mimeTypeDisplayManager->supportArchiveMimetypes().contains(mimetype);
 }
 
+int FileUtils::maxLabelLengthOfFileSystem(const QString &fs)
+{
+    const static QMap<QString, int> limits {
+        {"vfat", 11},   // man 8 mkfs.fat
+        {"ext2", 16},   // man 8 mke2fs
+        {"ext3", 16},   // man 8 mke2fs
+        {"ext4", 16},   // man 8 mke2fs
+        {"btrfs", 255}, // https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-filesystem
+        {"f2fs", 512},  // https://www.kernel.org/doc/Documentation/filesystems/f2fs.txt    https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/tree/mkfs/f2fs_format_main.c
+        {"jfs", 16},    // jfsutils/mkfs/mkfs.c:730
+        {"exfat", 15},  // man 8 mkexfatfs
+        {"nilfs2", 80}, // man 8 mkfs.nilfs2
+        {"ntfs", 32},   // https://docs.microsoft.com/en-us/dotnet/api/system.io.driveinfo.volumelabel?view=netframework-4.8
+        {"reiserfs", 15},// man 8 mkreiserfs said its max length is 16, but after tested, only 15 chars are accepted.
+        {"xfs", 12}     // https://github.com/edward6/reiser4progs/blob/master/include/reiser4/types.h fs_hint_t
+    };
+    return limits.value(fs, 11);
+}
+
 //优化苹果文件不卡显示，存在判断错误的可能，只能临时优化，需系统提升ios传输效率
 bool FileUtils::isDesktopFile(const QString &filePath)
 {

--- a/src/dde-file-manager-lib/shutil/fileutils.h
+++ b/src/dde-file-manager-lib/shutil/fileutils.h
@@ -169,6 +169,8 @@ public:
 
     static QList<QStringList> catFstabFileInfo(const QString &mountPoint);
     static bool isArchiveByMimetype(const QString &mimetype);
+
+    static int maxLabelLengthOfFileSystem(const QString &fs);
 };
 
 #endif // FILEUTILS_H

--- a/src/dde-file-manager-lib/views/computerviewitemdelegate.cpp
+++ b/src/dde-file-manager-lib/views/computerviewitemdelegate.cpp
@@ -342,12 +342,12 @@ QWidget *ComputerViewItemDelegate::createEditor(QWidget *parent, const QStyleOpt
     connect(le, &QLineEdit::textChanged, this, [le, maxLenInBytes](const QString &txt) {
         if (!le)
             return;
-        if (txt.toUtf8().length() > maxLenInBytes) {
-            const QSignalBlocker blocker(le);
-            QString newLabel = txt;
+
+        auto newLabel = txt;
+        const QSignalBlocker blocker(le);
+        while (newLabel.toUtf8().length() > maxLenInBytes)
             newLabel.chop(1);
-            le->setText(newLabel);
-        }
+        le->setText(newLabel);
     });
 
     connect(le, &QLineEdit::destroyed, this, [this, le] {


### PR DESCRIPTION
the max label length of vfat filesystem is 11 bytes but more charactors
can be inputed.

Log: fix issue about disk rename.

Bug: https://pms.uniontech.com/bug-view-170115.html
Bug: https://pms.uniontech.com/bug-view-170133.html
