### PR TITLE
fix: Asking password dialog doesnt popup after forgetting pw and unmounting

### DIFF
--- a/src/dde-file-manager-lib/gvfs/mountaskpassworddialog.cpp
+++ b/src/dde-file-manager-lib/gvfs/mountaskpassworddialog.cpp
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "mountaskpassworddialog.h"
+#include "shutil/smbintegrationswitcher.h"
+#include "../app/define.h"
+
 #include <QVBoxLayout>
 #include <QFormLayout>
 #include <QDebug>

--- a/src/dde-file-manager-lib/gvfs/secretmanager.cpp
+++ b/src/dde-file-manager-lib/gvfs/secretmanager.cpp
@@ -231,7 +231,7 @@ bool SecretManager::userCheckedRememberPassword(const DUrl &smbDevice)
     for (auto key : m_smbLoginObjs.keys()){
         if (key.startsWith(temSmbDevice.toString())) {
             QJsonObject smbObj = m_smbLoginObjs.value(key).toObject();
-            savePasswordChecked = smbObj.value("savePasswordChecked").toBool();
+            savePasswordChecked = smbObj.value("passwordsaveFlag").toInt() == 2; // 用户勾选过记住密码
             if(savePasswordChecked)
                 break;
         }

--- a/src/dde-file-manager-lib/models/computermodel.cpp
+++ b/src/dde-file-manager-lib/models/computermodel.cpp
@@ -417,7 +417,7 @@ QVariant ComputerModel::data(const QModelIndex &index, int role) const
             if(scheme == SMB_SCHEME){
                 av.clear();
                 av.append(MenuAction::UnmountAllSmbMount);
-                av.append(MenuAction::ForgetAllSmbPassword);
+                av.append(smbIntegrationSwitcher->isIntegrationMode() ? MenuAction::ForgetAllSmbPassword : MenuAction::ForgetPassword);
                 av.append(MenuAction::OpenDisk);
             }
             return QVariant::fromValue(av);

--- a/src/dde-file-manager-lib/views/computerview.cpp
+++ b/src/dde-file-manager-lib/views/computerview.cpp
@@ -30,6 +30,7 @@
 #include "controllers/vaultcontroller.h"
 #include "accessibility/ac-lib-file-manager.h"
 #include "../shutil/fileutils.h"
+#include "../shutil/smbintegrationswitcher.h"
 #include "views/dtoolbar.h"
 #include "drootfilemanager.h"
 #include "utils.h"
@@ -387,7 +388,7 @@ void ComputerView::contextMenu(const QPoint &pos)
         if(scheme == SMB_SCHEME){
             QVector<MenuAction> actionValue;
             actionValue << MenuAction::UnmountAllSmbMount
-                        << MenuAction::ForgetAllSmbPassword;
+                        << (smbIntegrationSwitcher->isIntegrationMode() ? MenuAction::ForgetAllSmbPassword : MenuAction::ForgetPassword);
             menu = DFileMenuManager::genereteMenuByKeys(actionValue, disabled);
         }else{
             menu = DFileMenuManager::genereteMenuByKeys(av, disabled);

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -369,6 +369,7 @@ void RemoteMountsStashManager::clearRemoteMounts()
 {
     //当用户手动从设置菜单中取消勾选`sambar共享端常驻显示挂载入口`复选框时,会调用此函数将配置文件中`RemoteMounts`字段缓存的常驻入口清空；
     DFMApplication::genericSetting()->removeGroup(kRemoteMounts);
+    DFMApplication::genericSetting()->sync();
 }
 
 void RemoteMountsStashManager::stashCurrentMounts()


### PR DESCRIPTION
1. Clear login data when mount smb with split mode;
2. Set saving password type to never-save mode when mount smb with split mode.

Bug: https://pms.uniontech.com/bug-view-170201.html