### PR TITLE
fix: The tab key order problem for settings password dialog

### DIFF
--- a/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.cpp
@@ -67,6 +67,11 @@ void UserSharePasswordSettingDialog::initUI()
         this->windowHandle()->setProperty("_d_dwayland_resizable", false);
         this->setFixedSize(QSize(390, 210));
     }
+
+    // The default first tab focus is window close button;
+    // The second one is m_passwordEdit, then the third one is eyes button;
+    // the last tab focus is cancel button(this->getButton(0));
+    QWidget::setTabOrder(m_passwordEdit, this->getButton(0));
 }
 
 void UserSharePasswordSettingDialog::onButtonClicked(const int &index)


### PR DESCRIPTION
Set the tab key order for password editor and cancel button.

Bug: https://pms.uniontech.com/bug-view-170441.html