### PR TITLE
fix: Crash caused by modifying property box

### DIFF
--- a/src/dde-file-manager-lib/dialogs/propertydialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/propertydialog.cpp
@@ -515,6 +515,12 @@ PropertyDialog::PropertyDialog(const DFMEvent &event, const DUrl url, QWidget *p
     initConnect();
 }
 
+PropertyDialog::~PropertyDialog()
+{
+    emit aboutToClosed(m_url);
+    emit closed(m_url);
+}
+
 void PropertyDialog::initUI()
 {
     m_icon->setFixedHeight(128);

--- a/src/dde-file-manager-lib/dialogs/propertydialog.h
+++ b/src/dde-file-manager-lib/dialogs/propertydialog.h
@@ -139,6 +139,7 @@ class PropertyDialog : public DDialog
 
 public:
     explicit PropertyDialog(const DFMEvent &event, const DUrl url, QWidget *parent = nullptr);
+    ~PropertyDialog() override;
 
 public:
     void initUI();


### PR DESCRIPTION
【M】 Right click the file attribute, then ESC, and then right-click the attribute. The file management crashes

1. Open the file management, select a file, right click Properties, and click ESC. At this time, the properties pop-up window disappears. Select the file again, right click Properties, and the file manager crashes

Log: Crash caused by modifying property box
Bug: https://pms.uniontech.com/bug-view-171025.html