### PR TITLE
Fix preview key problem

### DIFF
--- a/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
@@ -356,15 +356,17 @@ bool FilePreviewDialog::eventFilter(QObject *obj, QEvent *event)
         if (!e->isAutoRepeat()) {
             switch (e->key()) {
             case Qt::Key_Left:
-            case Qt::Key_Up:
-                if (!e->isAutoRepeat())
+            case Qt::Key_Up:{
+                if (canNextOrPre() && !e->isAutoRepeat())
                     previousPage();
                 break;
+            }
             case Qt::Key_Right:
-            case Qt::Key_Down:
-                if (!e->isAutoRepeat())
+            case Qt::Key_Down: {
+                if (canNextOrPre() && !e->isAutoRepeat())
                     nextPage();
                 break;
+            }
             case Qt::Key_Escape:
             case Qt::Key_Space: {
                 // 视频预览的前一秒禁止再次播放
@@ -694,6 +696,14 @@ void FilePreviewDialog::updateDialog()
     int newPerviewHeight = m_preview->contentWidget()->size().height();
     resize(newPerviewWidth, newPerviewHeight + m_statusBar->height());
     moveToCenter();
+}
+
+bool FilePreviewDialog::canNextOrPre()
+{
+    qint64 cur = QDateTime::currentMSecsSinceEpoch();
+    qint64 old = keyPressTime;
+    keyPressTime = cur;
+    return cur - 50 > old;
 }
 
 DFM_END_NAMESPACE

--- a/src/dde-file-manager-lib/dialogs/filepreviewdialog.h
+++ b/src/dde-file-manager-lib/dialogs/filepreviewdialog.h
@@ -96,6 +96,7 @@ private:
     void updateTitle();
 
     void updateDialog();
+    bool canNextOrPre();
 
     DUrlList m_fileList;
     DUrlList m_entryUrlList;
@@ -107,6 +108,7 @@ private:
     bool m_playingVideo = false;
     bool m_firstEnterSwitchToPage = false;
     int m_currentPageIndex = -1;
+    QAtomicInteger<qint64> keyPressTime = {0};
     QAtomicInteger<bool> m_isSwitch = false;
     DFMFilePreview *m_preview = nullptr;
 

--- a/src/dde-file-manager-lib/interfaces/dfilesystemmodel.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfilesystemmodel.cpp
@@ -1485,7 +1485,7 @@ QVariant DFileSystemModel::data(const QModelIndex &index, int role) const
             if (rect.left() <= cursor_pos.x() && rect.right() >= cursor_pos.x()) {
                 const QString &tooltip = data(index, columnActiveRole(i - 1)).toString();
 
-                if (option.fontMetrics.width(tooltip, -1, Qt::Alignment(index.data(Qt::TextAlignmentRole).toInt())) > rect.width()) {
+                if (option.fontMetrics.width(tooltip, -1, static_cast<int>(Qt::Alignment(index.data(Qt::TextAlignmentRole).toInt()))) > rect.width()) {
                     return tooltip;
                 } else {
                     break;
@@ -3192,7 +3192,8 @@ bool DFileSystemModel::releaseJobController()
             QPointer<DFileSystemModel> me = this;
             d->eventLoop = &eventLoop;
 
-            connect(d->jobController, &JobController::destroyed, &eventLoop, &QEventLoop::quit);
+            connect(d->jobController.data(), &JobController::finished, &eventLoop, &QEventLoop::quit);
+            connect(d->jobController.data(), &JobController::destroyed, &eventLoop, &QEventLoop::quit);
 
             d->jobController->stopAndDeleteLater();
 
@@ -3203,14 +3204,6 @@ bool DFileSystemModel::releaseJobController()
             d->eventLoop = Q_NULLPTR;
 
             if (code != 0) {
-                //                if (d->jobController) { //有时候d->jobController已销毁，会导致崩溃
-                //fix bug 33007 在释放d->jobController时，eventLoop退出异常，
-                //此时d->jobController有可能已经在析构了，不能调用terminate
-                //                    d->jobController->terminate();
-                //                    d->jobController->quit();
-                //                    d->jobController.clear();
-                //                    d->jobController->stopAndDeleteLater();
-                //                }
                 return false;
             }
 

--- a/src/dde-file-manager-lib/io/dfilecopymovejob.cpp
+++ b/src/dde-file-manager-lib/io/dfilecopymovejob.cpp
@@ -4517,11 +4517,6 @@ end:
                 d->setState(RunningState);
             }
         }
-        else if (d->mode == CopyMode){
-            while (d->state != DFileCopyMoveJob::StoppedState && d->lastProgress < 1) {
-                QThread::msleep(100);
-            }
-        }
     }
 
     d->fileStatistics->stop();


### PR DESCRIPTION
fix: 【N】 The arrow key previews multiple files, one of which is always missed in the first preview

There are five files on the desktop: community forum, test.pdf, uos.png, video.png, zip.zip In the preview status, press the right key on the keypad to preview the file in sequence. When previewing in sequence, there is a test.pdf missing (if you do not press the right key on the keypad, pressing [>] will not cause this problem)

Log: Fix preview key problem
Bug: https://pms.uniontech.com/bug-view-171079.html