### PR TITLE
修复侧边栏中，可移动设备图标主题不一致的问题

### DIFF
--- a/src/dde-file-manager-lib/controllers/dfmsidebardeviceitemhandler.cpp
+++ b/src/dde-file-manager-lib/controllers/dfmsidebardeviceitemhandler.cpp
@@ -70,6 +70,11 @@ DFMSideBarItem *DFMSideBarDeviceItemHandler::createItem(const DUrl &url)
     }
     QString displayName = infoPointer->fileDisplayName();
     QString iconName = infoPointer->iconName() + "-symbolic";
+
+    // always show usb icon for removable disks.
+    if (static_cast<DFMRootFileInfo::ItemType>(infoPointer->fileType()) == DFMRootFileInfo::ItemType::UDisksRemovable)
+        iconName = "drive-removable-media-symbolic";
+
     if(url.scheme() == SMB_SCHEME){
         if (displayName.isEmpty()) {
             displayName = url.host();


### PR DESCRIPTION
for removable disks, always shows it as USB devices

Log: fix icon mis-display

Bug: https://pms.uniontech.com/bug-view-170675.html
