### PR TITLE
fix: smb integrated item display at the incorret position of sidebar

### DIFF
--- a/src/dde-file-manager-lib/shutil/smbintegrationswitcher.cpp
+++ b/src/dde-file-manager-lib/shutil/smbintegrationswitcher.cpp
@@ -74,6 +74,7 @@ void SmbIntegrationSwitcher::switchIntegrationMode(bool value)
             // 调用`取消记住密码并卸载`接口，把需要卸载的smbIp卸载掉，再通知侧边栏和计算机界面，将界面刷新为smb分离模式
             QSharedPointer<DFMUrlListBaseEvent> eventPtr = dMakeEventPointer<DFMUrlListBaseEvent>(DFMEvent::UnknowType, Q_NULLPTR, unmountList);
             appController->actionForgetAllSmbPassword(eventPtr);
+            return ;
         }
     }
     DFMApplication::setGenericAttribute(DFMApplication::GA_MergeTheEntriesOfSambaSharedFolders, value);

--- a/src/dde-file-manager-lib/views/dfmsidebar.cpp
+++ b/src/dde-file-manager-lib/views/dfmsidebar.cpp
@@ -942,7 +942,9 @@ void DFMSideBar::initDeviceConnection()
 
         if (this->findItem(url) == -1) {
             auto r = std::upper_bound(devitems.begin(), devitems.end(), url,
-            [](const DUrl & a, const DUrl & b) {
+            [&url](const DUrl & a, const DUrl & b) {
+                if(FileUtils::isSmbHostOnly(url))
+                    return false;
                 DAbstractFileInfoPointer fia = fileService->createFileInfo(nullptr, a);
                 DAbstractFileInfoPointer fib = fileService->createFileInfo(nullptr, b);
                 return DFMRootFileInfo::typeCompare(fia, fib);


### PR DESCRIPTION
To control that smb mount address like smb://x.x.x.x would be always put at the end of device group.

Bug: https://pms.uniontech.com/bug-view-169935.html