### PR TITLE
fix: the process do not exit by started with daemon

### DIFF
--- a/src/dde-file-manager/main.cpp
+++ b/src/dde-file-manager/main.cpp
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
 
         if (CommandLineManager::instance()->isSet("d")) {
             fileManagerApp;
-            app.setQuitOnLastWindowClosed(false);
+            app.setQuitOnLastWindowClosed(true);
         } else {
             CommandLineManager::instance()->processCommand();
         }


### PR DESCRIPTION
the process do not exit by started with daemon.
set QuitOnLastWindowClosed to true to allow file manager exit current process, and start a new one.

Log: 
Bug: https://pms.uniontech.com/bug-view-172643.html