### PR TITLE
fix: Correct a wrong key string for getting smb password type

### DIFF
--- a/src/dde-file-manager-lib/gvfs/secretmanager.cpp
+++ b/src/dde-file-manager-lib/gvfs/secretmanager.cpp
@@ -231,7 +231,7 @@ bool SecretManager::userCheckedRememberPassword(const DUrl &smbDevice)
     for (auto key : m_smbLoginObjs.keys()){
         if (key.startsWith(temSmbDevice.toString())) {
             QJsonObject smbObj = m_smbLoginObjs.value(key).toObject();
-            savePasswordChecked = smbObj.value("passwordsaveFlag").toInt() == 2; // 用户勾选过记住密码
+            savePasswordChecked = smbObj.value("passwordSave").toInt() == 2; // 用户勾选过记住密码
             if(savePasswordChecked)
                 break;
         }


### PR DESCRIPTION
Correct `passwordsaveFlag` to `passwordSave`

Bug: https://pms.uniontech.com/bug-view-170201.html