### PR TITLE
fix: [UI] the search icon too small

### DIFF
--- a/src/dde-file-manager-lib/views/dtoolbar.cpp
+++ b/src/dde-file-manager-lib/views/dtoolbar.cpp
@@ -36,7 +36,7 @@
 
 const int DToolBar::ButtonWidth = 36;
 const int DToolBar::ButtonHeight = 36;
-static const QSize iconSize(16, 16);
+static const QSize iconSize(32, 32);
 
 /*!
  * \class DToolBar


### PR DESCRIPTION
Due to the adjustment of the gtk fix, the original size is too small, so the current size is enlarged

Log: solved UI problem
Bug: https://pms.uniontech.com/bug-view-174967.html