### PR TITLE
fix: Some unsupported pictures can be right clicked to set wallpaper

### DIFF
--- a/src/dde-file-manager-lib/interfaces/dabstractfileinfo.cpp
+++ b/src/dde-file-manager-lib/interfaces/dabstractfileinfo.cpp
@@ -953,11 +953,8 @@ QVector<MenuAction> DAbstractFileInfo::menuActionList(DAbstractFileInfo::MenuTyp
                            << MenuAction::OpenInTerminal
                            << MenuAction::Separator;
             } else if (isFile()) {
-                if (mimeTypeName().startsWith("image") && isReadable()
-//                        && !mimeTypeName().endsWith("gif")
-                        && !mimeTypeName().endsWith("svg+xml")
-                        && !mimeTypeName().endsWith("raf")
-                        && !mimeTypeName().endsWith("crw")) {
+                QList<QVariant> supportedTypes = {"image/jpeg", "image/png", "image/bmp", "image/tiff", "image/gif"};
+                if (supportedTypes.contains(mimeTypeName()) && isReadable()) {
                     actionKeys << MenuAction::SetAsWallpaper
                                << MenuAction::Separator;
                 }


### PR DESCRIPTION
Some unsupported pictures can be right clicked to set wallpaper.

Log: This function is only available for supported wallpaper file suffixes.
Bug: https://pms.uniontech.com/bug-view-174357.html