### PR TITLE
fix: [filedialog] Setting showDirsOnly has no effect

### DIFF
--- a/src/dde-file-manager-lib/views/dfiledialog.cpp
+++ b/src/dde-file-manager-lib/views/dfiledialog.cpp
@@ -213,7 +213,8 @@ void DFileDialog::setDirectoryUrl(const DUrl &directory)
             url.setPath(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
         }
     }
-    getFileView()->cd(url);
+    curUrl = directory;
+    isChanged = true;
 }
 
 QUrl DFileDialog::directoryUrl() const
@@ -897,6 +898,11 @@ void DFileDialog::listViewItemClicked(const QModelIndex &index)
 
 void DFileDialog::showEvent(QShowEvent *event)
 {
+    if (getFileView() && isChanged) {
+        getFileView()->cd(curUrl);
+        isChanged = false;
+    }
+
     if (!event->spontaneous() && !testAttribute(Qt::WA_Moved)) {
         Qt::WindowStates  state = windowState();
         adjustPosition(parentWidget());

--- a/src/dde-file-manager-lib/views/dfiledialog.h
+++ b/src/dde-file-manager-lib/views/dfiledialog.h
@@ -131,6 +131,8 @@ private:
     Q_DECLARE_PRIVATE_D(qGetPtrHelper(d_ptr), DFileDialog)
 
     bool m_acceptCanOpenOnSave;
+    DUrl curUrl { DUrl() };
+    bool isChanged { false };
 };
 
 #endif // DFILEDIALOG_H


### PR DESCRIPTION
Adjust the timing of the cd.
When the window needs to be displayed, perform the cd operation.

Log: solved promblem of setting showDirsOnly no effect.
Bug: https://pms.uniontech.com/bug-view-176775.html