### PR TITLE
fix: Previewing small resolution video interface is not complete

### DIFF
--- a/src/dde-file-manager-plugins/pluginPreview/dde-video-preview-plugin/videopreview.cpp
+++ b/src/dde-file-manager-plugins/pluginPreview/dde-video-preview-plugin/videopreview.cpp
@@ -158,6 +158,8 @@ VideoPreview::VideoPreview(QObject *parent)
     //   dmr::CompositingManager::get().overrideCompositeMode(true);
 
     playerWidget = new VideoWidget(this);
+    playerWidget->setMinimumSize(800, 355);
+
     statusBar = new VideoStatusBar(this);
 }
 


### PR DESCRIPTION
Set the minimum size to solve this issue

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-174507.html
