### PR TITLE
fix: After the search is completed, select a result and press Ctrl+A, but can not select all

### DIFF
--- a/src/dde-file-manager-lib/interfaces/dfmcrumbbar.cpp
+++ b/src/dde-file-manager-lib/interfaces/dfmcrumbbar.cpp
@@ -255,7 +255,6 @@ void DFMCrumbBarPrivate::initConnections()
     q->connect(addressBar, &DFMAddressBar::lostFocus, q, [q, this]() {
         if (crumbController && !qobject_cast<DFileManagerWindow *>(q->window())->isAdvanceSearchBarVisible()) {
             crumbController->processAction(DFMCrumbInterface::AddressBarLostFocus);
-            q->setFocus();
         }
     });
 

--- a/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
+++ b/src/dde-file-manager-lib/views/dfilemanagerwindow.cpp
@@ -1288,6 +1288,7 @@ void DFileManagerWindow::initRightView()
     f.setBold(true);
     trashLabel->setFont(f);
     QPushButton *emptyTrashButton = new QPushButton{ this };
+    emptyTrashButton->setFocusPolicy(Qt::NoFocus);
     emptyTrashButton->setContentsMargins(0, 0, 0, 0);
     emptyTrashButton->setObjectName("EmptyTrashButton");
     AC_SET_ACCESSIBLE_NAME(emptyTrashButton, AC_DM_RIGHT_VIEW_EMPTY_TRASH_BUTTON);

--- a/src/dde-file-manager-lib/views/dtoolbar.cpp
+++ b/src/dde-file-manager-lib/views/dtoolbar.cpp
@@ -392,6 +392,7 @@ void DToolBar::toggleSearchButtonState(bool asb)
         m_searchButton->setHidden(true);
         m_searchButton->setObjectName("filterButton");
         m_searchButton->setIcon(QIcon::fromTheme("dfm_view_filter"));
+        m_searchButton->setIconSize(iconSize);
         m_searchButton->style()->unpolish(m_searchButton);
         m_searchButton->style()->polish(m_searchButton);
         m_searchButton->setFlat(true);
@@ -410,6 +411,7 @@ void DToolBar::toggleSearchButtonState(bool asb)
         m_searchButton->style()->unpolish(m_searchButton);
         m_searchButton->style()->polish(m_searchButton);
         m_searchButton->setIcon(QIcon::fromTheme("search"));
+        m_searchButton->setIconSize(QSize(30, 30));
         m_searchButton->setDown(false);
         m_searchButtonAsbState = false;
         if (DFileManagerWindow *dfmWindow = qobject_cast<DFileManagerWindow *>(window())) {


### PR DESCRIPTION
The focus is setted to the DFMCrumbBar, when it lost form the Addressbar

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-178887.html
