### PR TITLE
fsearch: Include <unistd.h> for the usleep function

### DIFF
--- a/3rdparty/fsearch/fsearch_thread_pool.c
+++ b/3rdparty/fsearch/fsearch_thread_pool.c
@@ -20,6 +20,8 @@
 
 #include "fsearch_thread_pool.h"
 #include <sys/time.h>
+#include <unistd.h>
+
 struct _FsearchThreadPool {
     GList *threads;
     uint32_t num_threads;


### PR DESCRIPTION
This improves compatibility with compilers which do not support implicit function declarations.

Upstream fsearch does not call usleep and is therefore not affected by this issue.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
