### PR TITLE
fix: [preview] desktop file can be review by text style

### DIFF
--- a/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/filepreviewdialog.cpp
@@ -507,7 +507,8 @@ void FilePreviewDialog::switchToPage(int index)
     QStringList key_list(mime_type.name());
 
     key_list.append(mime_type.aliases());
-    key_list.append(mime_type.allAncestors());
+    if (!info->isDesktopFile())
+        key_list.append(mime_type.allAncestors());
 
     for (const QString &key : key_list) {
         const QString &general_key = generalKey(key);


### PR DESCRIPTION
cause:
code logic error
solve:
Remove text formattion from desktop files

Log: soeved problem of desktop preview
Bug: https://pms.uniontech.com/bug-view-180785.html