### PR TITLE
fix: 任务栏磁盘悬浮框中显示为英文

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/diskmountplugin.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/diskmountplugin.cpp
@@ -30,6 +30,10 @@ DiskMountPlugin::DiskMountPlugin(QObject *parent)
       tipsLabel(new TipsWidget),
       diskPluginItem(new DiskPluginItem)
 {
+    QTranslator *translator = new QTranslator(this);
+    translator->load(QString("/usr/share/dde-file-manager/translations/dde-file-manager_%1.qm").arg(QLocale::system().name()));
+    QCoreApplication::installTranslator(translator);
+
     diskPluginItem->setVisible(false);
     tipsLabel->setObjectName("diskmount");
     tipsLabel->setVisible(false);
@@ -43,11 +47,6 @@ const QString DiskMountPlugin::pluginName() const
 
 void DiskMountPlugin::init(PluginProxyInterface *proxyInter)
 {
-    QString &&applicationName = qApp->applicationName();
-    qApp->setApplicationName("dde-disk-mount-plugin");
-    qApp->loadTranslator();
-    qApp->setApplicationName(applicationName);
-
     std::call_once(DiskMountPlugin::onceFlag(), [this, proxyInter]() {
         setProxyInter(proxyInter);   // `m_proxyInter` from Base class `PluginsItemInterface`
         DevProxyMng->connectToService();


### PR DESCRIPTION
磁盘插件翻译加载的路径存在问题，应该采用绝对路径加载

Log: 修复任务栏磁盘悬浮框中显示为英文的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/3810
Influence: 任务栏磁盘插件悬浮框