### PR TITLE
fix: the preview window of screensaver is incongruous

### DIFF
--- a/src/plugins/desktop/ddplugin-wallpapersetting/editlabel.cpp
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/editlabel.cpp
@@ -13,11 +13,20 @@ EditLabel::EditLabel(QWidget *parent)
 {
 }
 
+void EditLabel::setHotZoom(const QRect &rect)
+{
+    hotZoom = rect;
+}
+
 void EditLabel::mousePressEvent(QMouseEvent *event)
 {
     if (Qt::MouseButton::LeftButton == event->button()) {
-        emit editLabelClicked();
-    } else {
-        QLabel::mousePressEvent(event);
+        if (!hotZoom.isValid() || hotZoom.contains(event->pos())) {
+            event->accept();
+            emit editLabelClicked();
+            return;
+        }
     }
+
+    QLabel::mousePressEvent(event);
 }

--- a/src/plugins/desktop/ddplugin-wallpapersetting/editlabel.h
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/editlabel.h
@@ -16,12 +16,14 @@ class EditLabel : public QLabel
     Q_OBJECT
 public:
     explicit EditLabel(QWidget *parent = nullptr);
-
-private:
+    void setHotZoom(const QRect &rect);
+protected:
     void mousePressEvent(QMouseEvent *event) override;
 
 Q_SIGNALS:
     void editLabelClicked();
+private:
+    QRect hotZoom;
 };
 
 }

--- a/src/plugins/desktop/ddplugin-wallpapersetting/images/edit.svg
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/images/edit.svg
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="48px" height="50px" viewBox="0 0 48 50" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>编组 7</title>
+<svg width="36px" height="36px" viewBox="0 0 36 36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>编组 10</title>
     <defs>
-        <radialGradient cx="92.7712874%" cy="8.59176253%" fx="92.7712874%" fy="8.59176253%" r="90.2548343%" gradientTransform="translate(0.927713,0.085918),scale(1.000000,0.960000),rotate(131.535976),translate(-0.927713,-0.085918)" id="radialGradient-1">
+        <radialGradient cx="92.7712874%" cy="8.59176253%" fx="92.7712874%" fy="8.59176253%" r="88.2501961%" id="radialGradient-1">
             <stop stop-color="#000000" stop-opacity="0.6" offset="0%"></stop>
             <stop stop-color="#000000" stop-opacity="0" offset="100%"></stop>
         </radialGradient>
     </defs>
-    <g id="页面-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="屏保自定义定制-显示方式调整" transform="translate(-131.000000, -960.000000)">
+    <g id="自定义屏保" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="屏保自定义定制-显示方式调整" transform="translate(-142.000000, -960.000000)">
             <g id="Group-3" transform="translate(10.000000, 900.000000)">
-                <g id="编组-7" transform="translate(121.000000, 60.000000)">
-                    <rect id="矩形" fill="url(#radialGradient-1)" x="0" y="0" width="48" height="50"></rect>
-                    <g id="ICON-/-Action-/-Edit" transform="translate(25.000001, 9.000007)" fill="#FFFFFF" fill-rule="nonzero">
+                <g id="编组-10" transform="translate(132.000000, 60.000000)">
+                    <rect id="矩形" fill="url(#radialGradient-1)" x="0" y="0" width="36" height="36"></rect>
+                    <g id="ICON-/-Action-/-Edit" transform="translate(15.000001, 7.000007)" fill="#FFFFFF" fill-rule="nonzero">
                         <path d="M3.53498033,13.3543213 L0.364999774,13.9939142 C0.200026392,14.0272002 0.0393054522,13.9204464 0.00601950669,13.755473 C-0.00200604284,13.7156964 -0.00200650674,13.6747175 0.0060181422,13.6349407 L0.645629789,10.4644969 L0.645629789,10.4644969 L8.78287766,2.327827 C9.02087521,2.08980631 9.40676424,2.08982001 9.64476491,2.32783759 C9.64477158,2.32784426 9.64477826,2.32785094 9.6447649,2.32787764 L11.6727867,4.35623203 C11.9107819,4.59425515 11.9107502,4.98014418 11.6727216,5.21813378 C11.6727197,5.21813562 11.6727179,5.21813746 11.6727105,5.21813378 L3.53498033,13.3543213 L3.53498033,13.3543213 Z M13.8215292,2.20599121 L11.7932267,0.17842535 C11.5551717,-0.0595345587 11.169286,-0.0594663974 10.9313151,0.178577595 L10.3628739,0.747214041 C10.1251103,0.985353697 10.1251106,1.37112924 10.3628746,1.60926846 L12.3909722,3.63805503 C12.6286409,3.87640442 13.0145299,3.87646996 13.2525795,3.63850127 C13.2526795,3.63840128 13.2527795,3.63830126 13.2525794,3.63790145 L13.8218343,3.06804696 C14.0595115,2.82982215 14.059375,2.4440477 13.8215292,2.20599121 Z" id="形状"></path>
                     </g>
                 </g>


### PR DESCRIPTION
1. scale preview image of screensaver to full up all widget.
2. adjust edit icon to 36px
3. set hotzoom to 28px in editlabel

Log: 优化屏保预览窗口

Bug: https://pms.uniontech.com/bug-view-192083.html
Bug: https://pms.uniontech.com/bug-view-189957.html