### PR TITLE
fix: [workspace] Edit box select file error

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -164,7 +164,7 @@ void ListItemDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionV
 void ListItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
     // 这里设置了光标选中位置后最终还是会被全选，移到eventFilter中处理
-    return QStyledItemDelegate::setEditorData(editor, index);
+    return QAbstractItemDelegate::setEditorData(editor, index);
 }
 
 bool ListItemDelegate::eventFilter(QObject *object, QEvent *event)


### PR DESCRIPTION
The style of the edit box is drawn by dde-file-manager, and does not need to be drawn by QStyleitemDelegate

Log: update workspace UI
Bug: https://pms.uniontech.com/bug-view-192357.html