### PR TITLE
fix: filepath is invalid in audit log

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/auditlogjob.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/auditlogjob.cpp
@@ -115,7 +115,7 @@ void BurnFilesAuditLogJob::doLog(QDBusInterface &interface)
         if (info.isDir()) {
             for (const QFileInfo &subInfo : BurnHelper::localFileInfoListRecursive(info.absoluteFilePath())) {
                 QString subNativePath { subInfo.absoluteFilePath() };
-                subNativePath = subNativePath.replace(nativePath, nativePath);
+                subNativePath = subNativePath.replace(discPath, nativePath);
                 writeLog(interface, subInfo.absoluteFilePath(), subNativePath, subInfo.size());
             }
         } else {


### PR DESCRIPTION
`replace` interface passed in the wrong parameters

Log: fix audit log bug

Bug: https://pms.uniontech.com/bug-view-192611.html