### PR TITLE
fix: [propertyDialog] trash property dialog show error in desktop

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/menu/propertymenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/menu/propertymenuscene.cpp
@@ -4,6 +4,7 @@
 
 #include "propertymenuscene.h"
 #include "propertymenuscene_p.h"
+#include "events/propertyeventreceiver.h"
 
 #include "plugins/common/core/dfmplugin-menu/menuscene/action_defines.h"
 
@@ -141,8 +142,10 @@ bool PropertyMenuScene::triggered(QAction *action)
         return false;
 
     QString id = d->predicateAction.key(action);
-    if (id == PropertyActionId::kProperty)
-        dpfSlotChannel->push("dfmplugin_propertydialog", "slot_PropertyDialog_Show", d->selectFiles, QVariantHash());
+    if (id == PropertyActionId::kProperty) {
+        PropertyEventReceiver::instance()->handleShowPropertyDialog(d->selectFiles, QVariantHash());
+        return true;
+    }
 
     return AbstractMenuScene::triggered(action);
 }

--- a/src/plugins/common/core/dfmplugin-trashcore/trashcore.h
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashcore.h
@@ -26,6 +26,7 @@ public:
 
 private:
     void followEvents();
+    void regCustomPropertyDialog();
 };
 }   // namespace dfmplugin_trashcore
 

--- a/src/plugins/common/dfmplugin-utils/openwith/virtualopenwithplugin.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/virtualopenwithplugin.cpp
@@ -18,7 +18,9 @@ void VirtualOpenWithPlugin::initialize()
 bool VirtualOpenWithPlugin::start()
 {
     auto propertyDialogPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-propertydialog") };
-    if (propertyDialogPlugin && propertyDialogPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kInitialized) {
+    if (propertyDialogPlugin
+            && (propertyDialogPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kInitialized
+                || propertyDialogPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted)) {
         regViewToPropertyDialog();
     } else {
         connect(DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginInitialized,


### PR DESCRIPTION
cause:
the dfmplugin-propertydialog lazy load, but the dfmplugin-trashcore not lazy load, so when dfmplugin-trashcore register widget, the event not define. solved:
listen to the plugin-in initializetion completion event.

Log: fix property dialog problem
Bug: https://pms.uniontech.com/bug-view-192569.html