### PR TITLE
fix: [io][crash] The DFM crashed when progress dialog is closed during the copy lage files

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -646,7 +646,7 @@ void FileOperateBaseWorker::waitThreadPoolOver()
     }
     bool isExBlockWriteOverFlag = false;
     // wait thread pool copy local file or copy big file over
-    while (!isStopped() && threadPool && threadPool->activeThreadCount() > 0) {
+    while (threadPool && threadPool->activeThreadCount() > 0) {
         if (isTargetFileExBlock && workData->blockCopyInfoQueue.size() == 0 && threadPool->activeThreadCount() == 1 && !isExBlockWriteOverFlag) {
             // do last block file write
             isExBlockWriteOverFlag = true;


### PR DESCRIPTION
Resources need to be released after all threads have exited

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-192717.html
