### PR TITLE
修复组策略值变更而设置面板不同步的问题

### DIFF
--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -38,7 +38,6 @@ BidirectionHash<QString, Application::GenericAttribute> SettingBackendPrivate::k
     { "advance.mount.auto_mount", Application::kAutoMount },
     { "advance.mount.auto_mount_and_open", Application::kAutoMountAndOpen },
     { "advance.mount.mtp_show_bottom_info", Application::kMTPShowBottomInfo },
-    { "advance.mount.always_show_offline_remote_connection", Application::kAlwaysShowOfflineRemoteConnections },
     { "advance.mount.merge_the_entries_of_samba_shared_folders", Application::kMergeTheEntriesOfSambaSharedFolders },
     { "advance.dialog.default_chooser_dialog", Application::kOverrideFileChooserDialog },
     { "advance.dialog.delete_confirmation_dialog", Application::kShowDeleteConfirmDialog },


### PR DESCRIPTION
modify the 'dfm.samba.permanent' in dconfig editor, and open the setting
dialog, the item 'show offline...' is not sync.
the value is not obtained from dconfig but from the application json. the
value should be detached from application json config.

Log: fix issue about setting value.

Bug: https://pms.uniontech.com/bug-view-191891.html
