### PR TITLE
fix: [watcher] When creating a new file in an FTP directory, the file is not displayed

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
@@ -94,7 +94,7 @@ QString prehandler_utils::splitMountSource(const QString &source, QString *subPa
 void travers_prehandler::doChangeCurrentUrl(quint64 winId, const QString &mpt, const QString &subPath, const QUrl &sourceUrl)
 {
     QString targetPath = mpt;
-    if (!targetPath.endsWith("/"))
+    if (!subPath.isEmpty() && !targetPath.endsWith("/"))
         targetPath.append("/");
     targetPath.append(subPath);
 


### PR DESCRIPTION
The mismatched URL resulted in the failure to use cached data when creating file watcher

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-192225.html
