### PR TITLE
fix: [fileviewmodel] refresh sync

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -287,8 +287,7 @@ void FileViewModel::refresh()
 {
     FileDataManager::instance()->cleanRoot(dirRootUrl, currentKey, true);
 
-    canFetchFiles = true;
-    fetchMore(rootIndex());
+    Q_EMIT requestRefreshAllChildren();
 }
 
 ModelState FileViewModel::currentState() const
@@ -306,7 +305,6 @@ void FileViewModel::fetchMore(const QModelIndex &parent)
         return;
     }
     canFetchFiles = false;
-    Q_EMIT requestClearAllChildren();
 
     bool ret { false };
     if (filterSortWorker.isNull()) {
@@ -665,6 +663,7 @@ void FileViewModel::initFilterSortWork()
     connect(filterSortWorker.data(), &FileSortWorker::insertFinish, this, &FileViewModel::onInsertFinish, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::removeRows, this, &FileViewModel::onRemove, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::removeFinish, this, &FileViewModel::onRemoveFinish, Qt::QueuedConnection);
+    connect(filterSortWorker.data(), &FileSortWorker::requestFetchMore, this, [this]() { canFetchFiles = true; fetchMore(rootIndex()); }, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::updateRow, this, &FileViewModel::onFileUpdated, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::selectAndEditFile, this, &FileViewModel::selectAndEditFile, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::requestSetIdel, this, [this]() { this->changeState(ModelState::kIdle); }, Qt::QueuedConnection);
@@ -676,7 +675,7 @@ void FileViewModel::initFilterSortWork()
     connect(this, &FileViewModel::requestSetFilterData, filterSortWorker.data(), &FileSortWorker::handleFilterData, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestSetFilterCallback, filterSortWorker.data(), &FileSortWorker::handleFilterCallFunc, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestGetSourceData, filterSortWorker.data(), &FileSortWorker::handleModelGetSourceData, Qt::QueuedConnection);
-    connect(this, &FileViewModel::requestClearAllChildren, filterSortWorker.data(), &FileSortWorker::handleClean, Qt::QueuedConnection);
+    connect(this, &FileViewModel::requestRefreshAllChildren, filterSortWorker.data(), &FileSortWorker::handleRefresh, Qt::QueuedConnection);
     connect(Application::instance(), &Application::showedHiddenFilesChanged, filterSortWorker.data(), &FileSortWorker::onShowHiddenFileChanged, Qt::QueuedConnection);
     connect(Application::instance(), &Application::appAttributeChanged, filterSortWorker.data(), &FileSortWorker::onAppAttributeChanged, Qt::QueuedConnection);
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -103,7 +103,7 @@ Q_SIGNALS:
     void requestChangeFilters(QDir::Filters filters);
     void requestChangeNameFilters(const QStringList &nameFilters);
     void requestUpdateFile(const QUrl &url);
-    void requestClearAllChildren();
+    void requestRefreshAllChildren();
 
     void requestSortChildren(Qt::SortOrder order, DFMGLOBAL_NAMESPACE::ItemRoles role, const bool isMixAndFile);
     void requestSetFilterData(const QVariant &data);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -546,7 +546,7 @@ void FileSortWorker::handleFilterCallFunc(FileViewFilterCallback callback)
     filterAllFilesOrdered();
 }
 
-void FileSortWorker::handleClean()
+void FileSortWorker::handleRefresh()
 {
     bool empty { false };
     {
@@ -572,6 +572,7 @@ void FileSortWorker::handleClean()
 
     if (!empty)
         Q_EMIT removeFinish();
+    Q_EMIT requestFetchMore();
 }
 
 bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool byInfo)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -63,6 +63,7 @@ signals:
     void insertFinish();
     void removeRows(int first, int count);
     void removeFinish();
+    void requestFetchMore();
     void selectAndEditFile(const QUrl &url);
 
     void requestSetIdel();
@@ -109,7 +110,7 @@ public slots:
     void handleUpdateFile(const QUrl &url);
     void handleFilterData(const QVariant &data);
     void handleFilterCallFunc(FileViewFilterCallback callback);
-    void handleClean();
+    void handleRefresh();
 
 private:
     bool checkFilters(const SortInfoPointer &sortInfo, const bool byInfo = false);


### PR DESCRIPTION
f5 diff rightclick, Caused by different execution speeds of threads

Log: as des
Bug: https://pms.uniontech.com/bug-view-192501.html