### PR TITLE
fix:  [sidebar/drag] drag item from inner group to other group in sideabr

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.h
@@ -34,6 +34,7 @@ public:
 
 private:
     QMutex locker;
+    mutable SideBarItem *curDragItem { nullptr };
 };
 
 DPSIDEBAR_END_NAMESPACE


### PR DESCRIPTION
`sourceItem` is error since the correct `parent` value cannot be obtained. save `curDragItem` in `SideBarModel::mimeData`

Log: fix drag bug

Bug: https://pms.uniontech.com/bug-view-192829.html
Bug: https://pms.uniontech.com/bug-view-192807.html