### PR TITLE
fix: [sidebar/tag] can not drop file to tag sidebar item

### DIFF
--- a/src/plugins/common/dfmplugin-tag/files/tagfileinfo.cpp
+++ b/src/plugins/common/dfmplugin-tag/files/tagfileinfo.cpp
@@ -41,6 +41,30 @@ QFileDevice::Permissions TagFileInfo::permissions() const
             | QFile::WriteGroup | QFile::WriteOwner | QFile::WriteUser | QFile::WriteOther;
 }
 
+bool TagFileInfo::isAttributes(const OptInfoType type) const
+{
+    switch (type) {
+    case FileIsType::kIsReadable:
+        return true;
+    case FileIsType::kIsWritable:
+        return true;
+    case FileIsType::kIsExecutable:
+        return true;
+    default:
+        return AbstractFileInfo::isAttributes(type);
+    }
+}
+
+bool TagFileInfo::canAttributes(const CanableInfoType type) const
+{
+    switch (type) {
+    case FileCanType::kCanDrop:
+        return true;
+    default:
+        return AbstractFileInfo::canAttributes(type);
+    }
+}
+
 QString TagFileInfo::nameOf(const NameInfoType type) const
 {
     switch (type) {

--- a/src/plugins/common/dfmplugin-tag/files/tagfileinfo.h
+++ b/src/plugins/common/dfmplugin-tag/files/tagfileinfo.h
@@ -26,6 +26,8 @@ public:
 
     QString nameOf(const FileNameInfoType type) const override;
     virtual QString displayOf(const DisplayInfoType type) const override;
+    virtual bool canAttributes(const FileCanType type) const override;
+    virtual bool isAttributes(const FileIsType type) const override;
     FileType fileType() const override;
     QIcon fileIcon() override;
 

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -559,6 +559,10 @@ Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *
     } else {
         targetItemUrl = item->url();
     }
+
+    if (!targetItemUrl.isValid())
+        return Qt::IgnoreAction;
+
     auto itemInfo = InfoFactory::create<AbstractFileInfo>(targetItemUrl);
     if (!itemInfo || !itemInfo->canAttributes(CanableInfoType::kCanDrop)) {
         return Qt::IgnoreAction;


### PR DESCRIPTION
reimplement the canAttribute and isAttribute function in tag file info.

Log: fix sidebar drop issue

Bug: https://pms.uniontech.com/bug-view-192737.html