### PR TITLE
fix: [workspace] hide file need refresh

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
@@ -18,6 +18,8 @@
 
 #include <dfm-framework/dpf.h>
 
+#include <dfm-io/dfmio_utils.h>
+
 Q_DECLARE_METATYPE(QList<QUrl> *)
 Q_DECLARE_METATYPE(Qt::DropAction *)
 Q_DECLARE_METATYPE(QString *)
@@ -175,9 +177,10 @@ void VaultEventReceiver::handleHideFilesResult(const quint64 &winId, const QList
                     info->pathOf(PathInfoType::kPath));
             QSharedPointer<AbstractFileWatcher> watcher = WatcherCache::instance().getCacheWatcher(parentUrlVirtual);
             if (!watcher.isNull()) {
-                const QString &hideFilePath = info->pathOf(PathInfoType::kPath) + "/.hidden";
-                const QUrl &hideFileUrl = QUrl::fromLocalFile(hideFilePath);
-                emit watcher->fileAttributeChanged(hideFileUrl);
+                QUrl hiddenFileUrl;
+                hiddenFileUrl.setScheme(url.scheme());
+                hiddenFileUrl.setPath(DFMIO::DFMUtils::buildFilePath(url.path().toStdString().c_str(), ".hidden", nullptr));
+                emit watcher->fileAttributeChanged(hiddenFileUrl);
             }
         }
     }

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultvisiblemanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultvisiblemanager.cpp
@@ -58,7 +58,7 @@ void VaultVisibleManager::infoRegister()
 
         //注册Scheme为"vault"的扩展的文件信息
         InfoFactory::regClass<VaultFileInfo>(VaultHelper::instance()->scheme());
-        WatcherFactory::regClass<VaultFileWatcher>(VaultHelper::instance()->scheme());
+        WatcherFactory::regClass<VaultFileWatcher>(VaultHelper::instance()->scheme(), WatcherFactory::kNoCache);
         DirIteratorFactory::regClass<VaultFileIterator>(VaultHelper::instance()->scheme());
         EntryEntityFactor::registCreator<VaultEntryFileEntity>("vault");
         infoRegisterState = true;


### PR DESCRIPTION
1. the hidden file path error in rootInfo, it is the parent path.
2. the last file can not hide, because error code logic.
3. send virtual path to workspace in vault.
4. the vault watcher set not cache.

Log: sloved problem of workspace
Bug: https://pms.uniontech.com/bug-view-192887.html
         https://pms.uniontech.com/bug-view-193161.html
