### PR TITLE
fix: [wayland/sidebar] drag item to other group in sidebar

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -69,6 +69,14 @@ bool SideBarModel::canDropMimeData(const QMimeData *data, Qt::DropAction action,
     return QStandardItemModel::canDropMimeData(data, action, row, column, parent);
 }
 
+bool SideBarModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent)
+{
+    if (!canDropMimeData(data, action, row, column, parent))
+        return false;
+
+    return QStandardItemModel::dropMimeData(data, action, row, column, parent);
+}
+
 QMimeData *SideBarModel::mimeData(const QModelIndexList &indexes) const
 {
     curDragItem = nullptr;

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.h
@@ -22,6 +22,8 @@ public:
     explicit SideBarModel(QObject *parent = nullptr);
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action,
                          int row, int column, const QModelIndex &parent) const override;
+    bool dropMimeData(const QMimeData *data, Qt::DropAction action,
+                      int row, int column, const QModelIndex &parent) override;
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
     SideBarItem *itemFromIndex(const QModelIndex &index) const;
     SideBarItem *itemFromIndex(int index, const QModelIndex &parent = QModelIndex()) const;


### PR DESCRIPTION
handle drop data that ended by `dropMimeData`

Log: fix drag bug in sidebar

Bug: https://pms.uniontech.com/bug-view-192829.html