### PR TITLE
chore: always compile organizer but don't install.

### DIFF
--- a/src/plugins/desktop/CMakeLists.txt
+++ b/src/plugins/desktop/CMakeLists.txt
@@ -5,23 +5,10 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-if(NOT DEFINED DESKTOP_ENABLE_ORGANIZER)
-    if (COMPLIE_ON_V23)
-    set(DESKTOP_ENABLE_ORGANIZER ON)
-    else()
-    set(DESKTOP_ENABLE_ORGANIZER OFF)
-    endif()
-endif()
-
 add_subdirectory(core/ddplugin-core)
 add_subdirectory(core/ddplugin-canvas)
 add_subdirectory(core/ddplugin-dbusregister)
 add_subdirectory(ddplugin-background)
 add_subdirectory(ddplugin-wallpapersetting)
 add_subdirectory(ddplugin-grandsearchdaemon)
-
-message(STATUS "DESKTOP_ENABLE_ORGANIZER: ${DESKTOP_ENABLE_ORGANIZER}")
-if (DESKTOP_ENABLE_ORGANIZER)
 add_subdirectory(ddplugin-organizer)
-endif()
-

--- a/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
@@ -47,10 +47,24 @@ target_link_libraries(${PROJECT_NAME}
     ${DtkGui_LIBRARIES}
     )
 
-#install library file
-install(TARGETS
-    ${PROJECT_NAME}
-    LIBRARY
-    DESTINATION
-    ${DFM_PLUGIN_DESKTOP_EDGE_DIR}
-)
+if(NOT DEFINED INSTALL_DESKTOP_ORGANIZER)
+    if (COMPLIE_ON_V23)
+    set(INSTALL_DESKTOP_ORGANIZER ON)
+    else()
+    set(INSTALL_DESKTOP_ORGANIZER OFF)
+    endif()
+endif()
+
+message(STATUS "INSTALL_DESKTOP_ORGANIZER: ${INSTALL_DESKTOP_ORGANIZER}")
+
+if (INSTALL_DESKTOP_ORGANIZER)
+    #install library file
+    install(TARGETS
+        ${PROJECT_NAME}
+        LIBRARY
+        DESTINATION
+        ${DFM_PLUGIN_DESKTOP_EDGE_DIR}
+    )
+endif()
+
+


### PR DESCRIPTION
1. need to always compile organizer plugins.
2. using INSTALL_DESKTOP_ORGANIZER to control whether instrall it.

Log: