### PR TITLE
fix: [workspace] File name filtering is missing

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -123,6 +123,7 @@ private:
     void discardFilterSortObjects();
 
     void changeState(ModelState newState);
+    bool passNameFilters(const AbstractFileInfoPointer &info) const;
 
     QUrl dirRootUrl;
 
@@ -138,6 +139,7 @@ private:
     QString currentKey;
 
     QList<QSharedPointer<QObject>> discardedObjects {};
+    mutable QMap<QString, bool> nameFiltersMatchResultMap;
 };
 
 }


### PR DESCRIPTION
The function of file name filtering is missing.

Log: solved problem of workspace
Bug: https://pms.uniontech.com/bug-view-192395.html 
         https://pms.uniontech.com/bug-view-192625.html