### PR TITLE
修复事件在线程发送导致的问题

### DIFF
--- a/include/dfm-framework/event/eventchannel.h
+++ b/include/dfm-framework/event/eventchannel.h
@@ -116,12 +116,14 @@ public:
     inline QVariant push(const QString &space, const QString &topic, T param, Args &&... args)
     {
         Q_ASSERT(topic.startsWith(kSlotStrategePrefix));
+        threadEventAlert(space, topic);
         return push(EventConverter::convert(space, topic), param, std::forward<Args>(args)...);
     }
 
     template<class T, class... Args>
     [[gnu::hot]] inline QVariant push(EventType type, T param, Args &&... args)
     {
+        threadEventAlert(type);
         QReadLocker guard(&rwLock);
         if (Q_LIKELY(channelMap.contains(type))) {
             auto channel = channelMap.value(type);
@@ -134,11 +136,13 @@ public:
     inline QVariant push(const QString &space, const QString &topic)
     {
         Q_ASSERT(topic.startsWith(kSlotStrategePrefix));
+        threadEventAlert(space, topic);
         return push(EventConverter::convert(space, topic));
     }
 
     inline QVariant push(const EventType &type)
     {
+        threadEventAlert(type);
         QReadLocker guard(&rwLock);
         if (Q_LIKELY(channelMap.contains(type))) {
             auto channel = channelMap.value(type);

--- a/include/dfm-framework/event/eventdispatcher.h
+++ b/include/dfm-framework/event/eventdispatcher.h
@@ -180,12 +180,14 @@ public:
     inline bool publish(const QString &space, const QString &topic, T param, Args &&... args)
     {
         Q_ASSERT(topic.startsWith(kSignalStrategePrefix));
+        threadEventAlert(space, topic);
         return publish(EventConverter::convert(space, topic), param, std::forward<Args>(args)...);
     }
 
     template<class T, class... Args>
     [[gnu::hot]] inline bool publish(EventType type, T param, Args &&... args)
     {
+        threadEventAlert(type);
         if (!globalFilterMap.isEmpty()) {
             QVariantList ret;
             makeVariantList(&ret, param, std::forward<Args>(args)...);
@@ -206,11 +208,13 @@ public:
     inline bool publish(const QString &space, const QString &topic)
     {
         Q_ASSERT(topic.startsWith(kSignalStrategePrefix));
+        threadEventAlert(space, topic);
         return publish(EventConverter::convert(space, topic));
     }
 
     inline bool publish(EventType type)
     {
+        threadEventAlert(type);
         if (!globalFilterMap.isEmpty() && globalFiltered(type, QVariantList()))
             return false;
 

--- a/include/dfm-framework/event/eventhelper.h
+++ b/include/dfm-framework/event/eventhelper.h
@@ -11,6 +11,8 @@
 #include <QVariant>
 #include <QObject>
 #include <QUrl>
+#include <QThread>
+#include <QCoreApplication>
 
 #include <mutex>
 
@@ -52,6 +54,29 @@ inline EventType genCustomEventId()
 inline bool isValidEventType(EventType type)
 {
     return type > EventTypeScope::kInValid && type <= EventTypeScope::kCustomTop;
+}
+
+inline bool isWellKnownEvenType(EventType type)
+{
+    return type >= EventTypeScope::kWellKnownEventBase && type < EventTypeScope::kWellKnownEventTop;
+}
+
+inline void threadEventAlert(const QString &eventName)
+{
+    if (Q_UNLIKELY(QThread::currentThread() != QCoreApplication::instance()->thread()))
+        qWarning() << "[Event Thread]: The event call does not run in the main thread: " << eventName;
+}
+
+inline void threadEventAlert(const QString &space, const QString &topic)
+{
+    threadEventAlert(space + "::" + topic);
+}
+
+inline void threadEventAlert(EventType type)
+{
+    if (!isWellKnownEvenType(type))
+        return;
+    threadEventAlert(QString::number(type));
 }
 
 class EventConverter

--- a/include/dfm-framework/event/eventsequence.h
+++ b/include/dfm-framework/event/eventsequence.h
@@ -139,12 +139,14 @@ public:
     inline bool run(const QString &space, const QString &topic, T param, Args &&... args)
     {
         Q_ASSERT(topic.startsWith(kHookStrategePrefix));
+        threadEventAlert(space, topic);
         return run(EventConverter::convert(space, topic), param, std::forward<Args>(args)...);
     }
 
     template<class T, class... Args>
     inline bool run(EventType type, T param, Args &&... args)
     {
+        threadEventAlert(type);
         QReadLocker lk(&rwLock);
         if (Q_LIKELY(sequenceMap.contains(type))) {
             auto sequence = sequenceMap.value(type);
@@ -158,11 +160,13 @@ public:
     inline bool run(const QString &space, const QString &topic)
     {
         Q_ASSERT(topic.startsWith(kHookStrategePrefix));
+        threadEventAlert(space, topic);
         return run(EventConverter::convert(space, topic));
     }
 
     inline bool run(EventType type)
     {
+        threadEventAlert(type);
         QReadLocker lk(&rwLock);
         if (Q_LIKELY(sequenceMap.contains(type))) {
             auto sequence = sequenceMap.value(type);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -112,6 +112,7 @@ QModelIndex FileViewModel::setRootUrl(const QUrl &url)
     initFilterSortWork();
 
     // connect signals
+    connect(root, &RootInfo::requestCloseTab, this, [](const QUrl &url) { WorkspaceHelper::instance()->closeTab(url); }, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::getSourceData, root, &RootInfo::handleGetSourceData, Qt::QueuedConnection);
     connect(root, &RootInfo::sourceDatas, filterSortWorker.data(), &FileSortWorker::handleSourceChildren, Qt::QueuedConnection);
     connect(root, &RootInfo::iteratorLocalFiles, filterSortWorker.data(), &FileSortWorker::handleIteratorLocalChildren, Qt::QueuedConnection);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -222,7 +222,7 @@ void RootInfo::doWatcherEvent()
             if (event.second == kAddFile)
                 continue;
             else if (event.second == kRmFile) {
-                dpfSlotChannel->push("dfmplugin_workspace", "slot_Tab_Close", fileUrl);
+                emit requestCloseTab(fileUrl);
                 break;
             }
         }
@@ -236,7 +236,7 @@ void RootInfo::doWatcherEvent()
             updateChild(fileUrl);
         } else {
             removeChildren({ fileUrl });
-            dpfSlotChannel->push("dfmplugin_workspace", "slot_Tab_Close", fileUrl);
+            emit requestCloseTab(fileUrl);
         }
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -73,6 +73,7 @@ Q_SIGNALS:
     void watcherUpdateFile(const SortInfoPointer sortInfo);
     void watcherUpdateHideFile(const QUrl &hidUrl);
     void requestSort(const QString &key);
+    void requestCloseTab(const QUrl &url);
 
 public Q_SLOTS:
     void doFileDeleted(const QUrl &url);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -134,6 +134,7 @@ WorkspaceWidget *WorkspaceHelper::findWorkspaceByWindowId(quint64 windowId)
 
 void WorkspaceHelper::closeTab(const QUrl &url)
 {
+    Q_ASSERT(qApp->thread() == QThread::currentThread());
     for (auto iter = kWorkspaceMap.cbegin(); iter != kWorkspaceMap.cend(); ++iter) {
         if (iter.value())
             iter.value()->closeTab(iter.key(), url);


### PR DESCRIPTION
线程发送事件会导致事件处理函数也在线程中执行，这非常不安全，本次提交：
1. 添加警告日志，如果在非主线程使用同步事件，给以警告；
2. 修复一个因此导致的数据竞争bug。