### PR TITLE
fix: Add proxy and link file asynchronous query signaling

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -554,6 +554,23 @@ void AsyncFileInfo::setExtendedAttributes(const FileExtendedInfoType &key, const
     }
 }
 
+QList<QUrl> AsyncFileInfo::notifyUrls() const
+{
+    QReadLocker lk(&const_cast<AsyncFileInfoPrivate *>(d.data())->notifyLock);
+    return d->notifyUrls;
+}
+// if url is unvalid, it will clear all notify urls
+void AsyncFileInfo::setNotifyUrl(const QUrl &url)
+{
+    if (!url.isValid()) {
+        QWriteLocker lk(&d->notifyLock);
+        d->notifyUrls.clear();
+        return;
+    }
+    QWriteLocker lk(&d->notifyLock);
+    d->notifyUrls.append(url);
+}
+
 void AsyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo> dfileInfo)
 {
     mimeTypeMode = QMimeDatabase::MatchDefault;
@@ -1067,6 +1084,19 @@ void AsyncFileInfoPrivate::cacheAllAttributes()
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardFilePath, filePath());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardParentPath, path());
     // redirectedFileUrl
+    auto symlink = symLinkTarget();
+    if (!symlink.isEmpty() && !FileUtils::isLocalFile(QUrl::fromLocalFile(symlink))) {
+        FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(symlink));
+        auto asyncInfo = info.dynamicCast<AsyncFileInfo>();
+        if (asyncInfo) {
+            asyncInfo->setNotifyUrl(q->fileUrl());
+            auto notifyUrls = q->notifyUrls();
+            for (const auto &url : notifyUrls) {
+                asyncInfo->setNotifyUrl(url);
+            }
+            asyncInfo->refresh();
+        }
+    }
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardSymlinkTarget, symLinkTarget());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kAccessCanRead, attribute(DFileInfo::AttributeID::kAccessCanRead));
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kAccessCanWrite, attribute(DFileInfo::AttributeID::kAccessCanWrite));

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -16,7 +16,7 @@ namespace dfmbase {
 class AsyncFileInfoPrivate;
 class AsyncFileInfo : public FileInfo
 {
-    AsyncFileInfoPrivate *d = nullptr;
+    QSharedPointer<AsyncFileInfoPrivate> d { nullptr };
 
 public:
     enum class AsyncAttributeID : uint16_t {
@@ -180,6 +180,8 @@ public:
     virtual QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(DFMIO::DFileInfo::MediaType type, QList<DFMIO::DFileInfo::AttributeExtendID> ids) const override;
     // cache attribute
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
+    QList<QUrl> notifyUrls() const;
+    void setNotifyUrl(const QUrl &url);
 };
 }
 typedef QSharedPointer<DFMBASE_NAMESPACE::AsyncFileInfo> DFMAsyncFileInfoPointer;

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -28,11 +28,12 @@ class AsyncFileInfoPrivate
 {
 public:
     friend class AsyncFileInfo;
+    QMimeDatabase::MatchMode mimeTypeMode;
     std::atomic_int enableThumbnail = { -1 };   // 小于0时表示此值未初始化，0表示不支持，1表示支持
     std::atomic_bool loadingThumbnail = { false };
     std::atomic_bool notInit { false };
     std::atomic_bool cacheing { false };
-    QMimeDatabase::MatchMode mimeTypeMode;
+    char memrySeat[5];
     QSharedPointer<DFileInfo> dfmFileInfo { nullptr };   // dfm文件的信息
     QVariantHash extraProperties;   // 扩展属性列表
     QMap<DFileInfo::AttributeExtendID, QVariant> attributesExtend;   // 缓存的fileinfo 扩展信息
@@ -50,6 +51,8 @@ public:
     InfoHelperUeserDataPointer fileMimeTypeFuture { nullptr };
     InfoHelperUeserDataPointer iconFuture { nullptr };
     QMap<AsyncFileInfo::AsyncAttributeID, QVariant> cacheAsyncAttributes;
+    QReadWriteLock notifyLock;
+    QList<QUrl> notifyUrls;
     AsyncFileInfo *const q;
 
 public:

--- a/src/dfm-base/file/local/syncfileinfo.h
+++ b/src/dfm-base/file/local/syncfileinfo.h
@@ -17,7 +17,7 @@ namespace dfmbase {
 class SyncFileInfoPrivate;
 class SyncFileInfo : public FileInfo
 {
-    QSharedPointer<SyncFileInfoPrivate> d = nullptr;
+    QSharedPointer<SyncFileInfoPrivate> d { nullptr };
 
 public:
     enum FlagIcon {

--- a/src/dfm-base/interfaces/proxyfileinfo.cpp
+++ b/src/dfm-base/interfaces/proxyfileinfo.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "proxyfileinfo.h"
+#include "dfm-base/file/local/asyncfileinfo.h"
 
 DFMBASE_USE_NAMESPACE
 
@@ -42,7 +43,11 @@ void ProxyFileInfo::refresh()
 void ProxyFileInfo::setProxy(const FileInfoPointer &proxy)
 {
     this->proxy = proxy;
-    this->proxy->refresh();
+    auto asyncInfo = this->proxy.dynamicCast<AsyncFileInfo>();
+    if (asyncInfo) {
+        asyncInfo->setNotifyUrl(url);
+        asyncInfo->refresh();
+    }
 }
 
 QString dfmbase::ProxyFileInfo::filePath() const

--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -62,8 +62,6 @@ private:
     QSharedPointer<FileInfoAsycWorker> worker { nullptr };
     std::atomic_bool stoped { false };
     QThreadPool pool;
-    QReadWriteLock symLinkHashLock;
-    QHash<QUrl, QUrl> symLinkHash;
     DThreadList<QUrl> queryingList;
 };
 }

--- a/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.h
+++ b/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ASYNCTRASHFILEINFO_H
+#define ASYNCTRASHFILEINFO_H
+
+#include "dfmplugin_trashcore_global.h"
+#include "dfm-base/interfaces/proxyfileinfo.h"
+
+namespace dfmplugin_trashcore {
+
+class AsyncTrashFileInfoPrivate;
+class AsyncTrashFileInfo : public DFMBASE_NAMESPACE::ProxyFileInfo
+{
+    friend class TrashFileInfoPrivate;
+
+public:
+    explicit AsyncTrashFileInfo(const QUrl &url);
+    ~AsyncTrashFileInfo() override;
+
+    virtual bool initQuerier() override;
+    virtual void refresh() override;
+    virtual QString nameOf(const FileNameInfoType type) const override;
+    virtual QString displayOf(const DisplayInfoType type) const override;
+    virtual QString pathOf(const FilePathInfoType type) const override;
+    virtual QUrl urlOf(const FileUrlInfoType type) const override;
+    virtual bool exists() const override;
+    virtual bool canAttributes(const FileCanType type) const override;
+    virtual Qt::DropActions supportedOfAttributes(const SupportType type) const override;
+    virtual bool isAttributes(const FileIsType type) const override;
+    virtual QFile::Permissions permissions() const override;
+    virtual QIcon fileIcon() override;
+
+    virtual qint64 size() const override;
+    virtual int countChildFile() const override;
+
+    virtual QVariant timeOf(const FileTimeType type) const override;
+    virtual QVariant customData(int role) const override;
+
+private:
+    QSharedPointer<AsyncTrashFileInfoPrivate> d { nullptr };
+
+    // AbstractFileInfo interface
+public:
+    virtual QUrl fileUrl() const override;
+};
+
+}
+
+Q_DECLARE_METATYPE(QFile::Permissions);
+
+#endif   // ASYNCTRASHFILEINFO_H


### PR DESCRIPTION
1。 In asyncfileinfo, modify d to sharedpointer. 2. Add interfaces notifyUrls and setNotifyUrls. After this asynchronous query is completed, send all url signals that require notification 3. When adding a proxy, the proxy sets the notifyurl. The target file for the linked file is set to notifyurl4. Sending a notifyurl signal in the fileinfo helper

Log: Add proxy and link file asynchronous query signaling Bug: