### PR TITLE
fix: [workspace] The scroll bar dispaly state is wrong

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -63,8 +63,6 @@ FileView::FileView(const QUrl &url, QWidget *parent)
     setSelectionRectVisible(true);
     setDefaultDropAction(Qt::CopyAction);
     setDragDropOverwriteMode(true);
-    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     setDragEnabled(true);
 
     initializeModel();


### PR DESCRIPTION
The display state of the scroll bar does not need to be set by itself, but is uniformly set by the control center through dtk.

Log: solved UI problem of workspace
Bug: https://pms.uniontech.com/bug-view-193759.html