### PR TITLE
fix: Empty Trash prompt file incorrect

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/filecopymovejob.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/filecopymovejob.cpp
@@ -14,8 +14,7 @@
 DFMBASE_USE_NAMESPACE
 DPFILEOPERATIONS_USE_NAMESPACE
 FileCopyMoveJob::FileCopyMoveJob(QObject *parent)
-    : QObject(parent),
-      dialogManager(DialogManagerInstance)
+    : QObject(parent)
 {
     copyMoveTaskMutex.reset(new QMutex);
     getOperationsAndDialogServiceMutex.reset(new QMutex);
@@ -27,7 +26,11 @@ FileCopyMoveJob::~FileCopyMoveJob()
 
 bool FileCopyMoveJob::getOperationsAndDialogService()
 {
-    operationsService.reset(new FileOperationsService(this));
+    if (!operationsService)
+        operationsService.reset(new FileOperationsService(this));
+
+    if (!dialogManager)
+        dialogManager = DialogManagerInstance;
 
     return operationsService && dialogManager;
 }
@@ -57,7 +60,6 @@ void FileCopyMoveJob::onHandleAddTaskWithArgs(const JobInfoPointer info)
     }
 
     dialogManager->addTask(jobHandler);
-
 }
 
 void FileCopyMoveJob::onHandleTaskFinished(const JobInfoPointer info)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.h
@@ -14,6 +14,8 @@
 #include <dfm-base/utils/clipboard.h>
 #include <dfm-base/utils/dialogmanager.h>
 
+#include <dfm-io/denumerator.h>
+
 #include <QObject>
 #include <QPointer>
 #include <QFileDevice>
@@ -27,6 +29,10 @@ class TrashFileEventReceiver final : public QObject
 
 public:
     static TrashFileEventReceiver *instance();
+
+Q_SIGNALS:
+    void cleanTrashUrls(const quint64 windowId, const QList<QUrl> sources, const DFMBASE_NAMESPACE::AbstractJobHandler::DeleteDialogNoticeType deleteNoticeType,
+                        DFMGLOBAL_NAMESPACE::OperatorHandleCallback handleCallback);
 
 public slots:
     void handleOperationMoveToTrash(const quint64 windowId,
@@ -71,6 +77,10 @@ public slots:
                                       DFMGLOBAL_NAMESPACE::OperatorHandleCallback handle,
                                       const QVariant custom,
                                       DFMBASE_NAMESPACE::Global::OperatorCallback callback);
+private slots:
+    JobHandlePointer onCleanTrashUrls(const quint64 windowId, const QList<QUrl> sources,
+                                      const DFMBASE_NAMESPACE::AbstractJobHandler::DeleteDialogNoticeType deleteNoticeType,
+                                      DFMGLOBAL_NAMESPACE::OperatorHandleCallback handleCallback);
 
 private:
     explicit TrashFileEventReceiver(QObject *parent = nullptr);
@@ -82,10 +92,15 @@ private:
     JobHandlePointer doCopyFromTrash(const quint64 windowId, const QList<QUrl> sources, const QUrl target,
                                      const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags, DFMGLOBAL_NAMESPACE::OperatorHandleCallback handleCallback);
     JobHandlePointer doCleanTrash(const quint64 windowId, const QList<QUrl> sources, const DFMBASE_NAMESPACE::AbstractJobHandler::DeleteDialogNoticeType deleteNoticeType,
-                                  DFMGLOBAL_NAMESPACE::OperatorHandleCallback handleCallback);
+                                  DFMGLOBAL_NAMESPACE::OperatorHandleCallback handleCallback, const bool showDelet = true);
+    void countTrashFile(const quint64 windowId, const DFMBASE_NAMESPACE::AbstractJobHandler::DeleteDialogNoticeType deleteNoticeType,
+                        DFMGLOBAL_NAMESPACE::OperatorHandleCallback handleCallback);
 
 private:
     QSharedPointer<FileCopyMoveJob> copyMoveJob { nullptr };
+    QSharedPointer<DFMIO::DEnumerator> trashIterator { nullptr };
+    QFuture<void> future;
+    std::atomic_bool stoped { false };
 };
 
 DPFILEOPERATIONS_END_NAMESPACE


### PR DESCRIPTION
Because when counting the files in the recycle bin, the count of gio's trash terms was incorrect, with long file names or other attachments to/data/home/ Caused by the path. Modify the use of asynchronous self counting of the number of trashes, and follow the subsequent process.

Log: Empty Trash prompt file incorrect
Bug: https://pms.uniontech.com/bug-view-194085.html