### PR TITLE
feat: avoid use hardcode path

### DIFF
--- a/src/dfm-base/CMakeLists.txt
+++ b/src/dfm-base/CMakeLists.txt
@@ -116,8 +116,9 @@ target_include_directories(${BIN_NAME} PUBLIC
     ${Qt5Widgets_PRIVATE_INCLUDE_DIRS}
     )
 
+set(ShareDir ${CMAKE_INSTALL_PREFIX}/share/dde-file-manager) # also use for install
 target_compile_definitions(
-    ${BIN_NAME} PRIVATE APPSHAREDIR="/usr/share/dde-file-manager"
+	${BIN_NAME} PRIVATE APPSHAREDIR="${ShareDir}"
 )
 
 add_library(DFM::base ALIAS ${BIN_NAME})
@@ -151,7 +152,6 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}Config.cmake DESTINATION ${
 
 # install resources files
 set(AssetsPath ${PROJECT_SOURCE_DIR}/assets)
-set(ShareDir ${CMAKE_INSTALL_PREFIX}/share/dde-file-manager)
 
 FILE(GLOB SCHEMA_FILES ${AssetsPath}/gschema/*)
 install(FILES ${SCHEMA_FILES} DESTINATION share/glib-2.0/schemas)

--- a/src/dfm-base/CMakeLists.txt
+++ b/src/dfm-base/CMakeLists.txt
@@ -158,10 +158,10 @@ install(FILES ${SCHEMA_FILES} DESTINATION share/glib-2.0/schemas)
 install(CODE "execute_process(COMMAND glib-compile-schemas ${CMAKE_INSTALL_PREFIX}/share/glib-2.0/schemas)")
 
 set(DLNFS_SCRIPT ${AssetsPath}/scripts/dfm-dlnfs-automount)
-install(FILES ${DLNFS_SCRIPT} DESTINATION /etc/deepin/dde-file-manager)
+install(FILES ${DLNFS_SCRIPT} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/deepin/dde-file-manager)
 
 set(DLNFS_SCRIPT_LAUNCHER ${AssetsPath}/scripts/99dfm-dlnfs-automount)
-install(FILES ${DLNFS_SCRIPT_LAUNCHER} DESTINATION /etc/X11/Xsession.d)
+install(FILES ${DLNFS_SCRIPT_LAUNCHER} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d)
 
 set(Mimetypes "${ShareDir}/mimetypes")
 FILE(GLOB MIMETYPE_FILES ${AssetsPath}/mimetypes/*)

--- a/src/dfm-base/base/device/private/deviceproxymanager_p.h
+++ b/src/dfm-base/base/device/private/deviceproxymanager_p.h
@@ -9,7 +9,7 @@
 
 #include <QScopedPointer>
 #include <QList>
-#include <qt5/QtCore/qobjectdefs.h>
+#include <QtCore/qobjectdefs.h>
 
 class DeviceManagerInterface;
 class QDBusServiceWatcher;

--- a/src/dfm-base/base/device/private/devicewatcher_p.h
+++ b/src/dfm-base/base/device/private/devicewatcher_p.h
@@ -8,7 +8,7 @@
 #include <QTimer>
 #include <QMutex>
 #include <QHash>
-#include <qt5/QtCore/qobjectdefs.h>
+#include <QtCore/qobjectdefs.h>
 
 #include <dfm-mount/base/dmount_global.h>
 

--- a/src/plugins/desktop/ddplugin-grandsearchdaemon/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-grandsearchdaemon/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(${PROJECT_NAME}
     ${SRC_FILES}
 )
 
-add_definitions(-DGRANDSEARCHDAEMON_LIB_DIR="/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/dde-grand-search-daemon")
+add_definitions(-DGRANDSEARCHDAEMON_LIB_DIR="${CMAKE_INSTALL_FULL_LIBDIR}/dde-grand-search-daemon")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ../../)
 

--- a/tests/plugins/desktop/ddplugin-grandsearchdaemon/CMakeLists.txt
+++ b/tests/plugins/desktop/ddplugin-grandsearchdaemon/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 project(test-ddplugin-grandsearchdaemon)
 
-add_definitions(-DGRANDSEARCHDAEMON_LIB_DIR="/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/dde-grand-search-daemon")
+add_definitions(-DGRANDSEARCHDAEMON_LIB_DIR="${CMAKE_INSTALL_FULL_LIBDIR}/dde-grand-search-daemon")
 
 # UT文件
 file(GLOB_RECURSE UT_CXX_FILE


### PR DESCRIPTION
1. chore: [cmake] use CMAKE_INSTALL_SYSCONFDIR 
Log: SYSCONFDIR is read-only single-machine data (etc)

2. fix: include path should follow Qt5Widgets_PRIVATE_INCLUDE_DIRS 
Log: should not find form /usr/include

3. feat: GRANDSEARCHDAEMON_LIB_DIR use CMAKE_INSTALL_FULL_LIBDIR 
Log: On Debian, this should be lib/multiarch-tuple when CMAKE_INSTALL_PREFIX is /usr

4. chore: don't hardcode APPSHAREDIR 
Log: use ShareDir