### PR TITLE
fix: [io]The content displayed in the directory is empty with mtp

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -1107,8 +1107,6 @@ void AsyncFileInfoPrivate::cacheAllAttributes()
         tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardIsHidden, attribute(DFileInfo::AttributeID::kStandardIsHidden));
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardIsFile, attribute(DFileInfo::AttributeID::kStandardIsFile));
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardIsDir, attribute(DFileInfo::AttributeID::kStandardIsDir));
-    if (attribute(DFileInfo::AttributeID::kStandardIsDir).toBool())
-        countChildFileAsync();
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardIsSymlink, attribute(DFileInfo::AttributeID::kStandardIsSymlink));
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kAccessCanDelete, canDelete());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kAccessCanTrash, canTrash());
@@ -1144,14 +1142,6 @@ void AsyncFileInfoPrivate::cacheAllAttributes()
         QWriteLocker wlk(&iconLock);
         clearIcon();
     }
-}
-
-void AsyncFileInfoPrivate::countChildFileAsync()
-{
-    QUrl url = q->fileUrl();
-    QWriteLocker lk(&lock);
-    auto future = FileInfoHelper::instance().fileCountAsync(url);
-    fileCountFuture = future;
 }
 
 void AsyncFileInfoPrivate::fileMimeTypeAsync(QMimeDatabase::MatchMode mode)

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -227,3 +227,10 @@ bool LocalDirIterator::oneByOne()
     qInfo() << "11" << url() << FileUtils::isLocalDevice(url());
     return !FileUtils::isLocalDevice(url()) || !d->dfmioDirIterator;
 }
+
+DEnumeratorFuture *LocalDirIterator::asyncIterator()
+{
+    if (d->dfmioDirIterator)
+        return d->dfmioDirIterator->asyncIterator();
+    return nullptr;
+}

--- a/src/dfm-base/file/local/localdiriterator.h
+++ b/src/dfm-base/file/local/localdiriterator.h
@@ -8,7 +8,7 @@
 #include <dfm-base/dfm_base_global.h>
 #include <dfm-base/interfaces/abstractdiriterator.h>
 
-#include <dfm-io/denumerator.h>
+#include <dfm-io/denumeratorfuture.h>
 
 #include <QDirIterator>
 #include <QSharedPointer>
@@ -44,6 +44,7 @@ public:
     void setArguments(const QVariantMap &args) override;
     QList<SortInfoPointer> sortFileInfoList() override;
     bool oneByOne() override;
+    DFMIO::DEnumeratorFuture *asyncIterator();
 };
 }
 

--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -18,6 +18,7 @@
 #include <dfm-base/utils/systempathutil.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/networkutils.h>
 #include <dfm-base/dfm_event_defines.h>
 
 #include <dfm-io/doperator.h>
@@ -265,6 +266,11 @@ bool LocalFileHandler::openFiles(const QList<QUrl> &fileUrls)
         FileInfoPointer fileInfoLink = fileInfo;
         while (fileInfoLink->isAttributes(OptInfoType::kIsSymLink)) {
             const QString &targetLink = fileInfoLink->pathOf(PathInfoType::kSymLinkTarget);
+            // 网络文件检查
+            if (NetworkUtils::instance()->checkFtpOrSmbBusy(QUrl::fromLocalFile(targetLink))) {
+                DialogManager::instance()->showUnableToVistDir(targetLink);
+                return true;
+            }
             fileInfoLink = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(targetLink));
             if (!fileInfoLink) {
                 DialogManagerInstance->showErrorDialog(QObject::tr("Unable to find the original file"), QString());

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -168,7 +168,6 @@ public:
 
     FileInfo::FileType fileType() const;
     void cacheAllAttributes();
-    void countChildFileAsync();
     void fileMimeTypeAsync(QMimeDatabase::MatchMode mode = QMimeDatabase::MatchDefault);
     QMimeType mimeTypes(const QString &filePath, QMimeDatabase::MatchMode mode = QMimeDatabase::MatchDefault,
                         const QString &inod = QString(), const bool isGvfs = false);

--- a/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
@@ -22,7 +22,7 @@ void TrashCore::initialize()
 
     DFMBASE_NAMESPACE::UrlRoute::regScheme(TrashCoreHelper::scheme(), "/", TrashCoreHelper::icon(), true, tr("Trash"));
     // TODO(lanxs): 目前缓存存在问题，trash由于其特性，容易触发缓存更新问题，所以trash里面暂不使用缓存，等后期缓存完善再放开
-    DFMBASE_NAMESPACE::InfoFactory::regClass<TrashFileInfo>(TrashCoreHelper::scheme(), DFMBASE_NAMESPACE::InfoFactory::kNoCache);
+    DFMBASE_NAMESPACE::InfoFactory::regClass<TrashFileInfo>(TrashCoreHelper::scheme());
 
     dpfSlotChannel->connect(DPF_MACRO_TO_STR(DPTRASHCORE_NAMESPACE), "slot_TrashCore_EmptyTrash",
                             TrashCoreEventReceiver::instance(), &TrashCoreEventReceiver::handleEmptyTrash);
@@ -33,18 +33,16 @@ void TrashCore::initialize()
 bool TrashCore::start()
 {
     auto propertyDialogPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-propertydialog") };
-    if (propertyDialogPlugin &&
-            (propertyDialogPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kInitialized
-             || propertyDialogPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted)) {
+    if (propertyDialogPlugin && (propertyDialogPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kInitialized || propertyDialogPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted)) {
         regCustomPropertyDialog();
     } else {
         connect(DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginInitialized,
                 this, [this](const QString &iid, const QString &name) {
-            Q_UNUSED(iid)
-            if (name == "dfmplugin-propertydialog")
-                regCustomPropertyDialog();
-        },
-        Qt::DirectConnection);
+                    Q_UNUSED(iid)
+                    if (name == "dfmplugin-propertydialog")
+                        regCustomPropertyDialog();
+                },
+                Qt::DirectConnection);
     }
 
     return true;

--- a/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
@@ -21,7 +21,6 @@ void TrashCore::initialize()
     TrashCoreEventSender::instance();
 
     DFMBASE_NAMESPACE::UrlRoute::regScheme(TrashCoreHelper::scheme(), "/", TrashCoreHelper::icon(), true, tr("Trash"));
-    // TODO(lanxs): 目前缓存存在问题，trash由于其特性，容易触发缓存更新问题，所以trash里面暂不使用缓存，等后期缓存完善再放开
     DFMBASE_NAMESPACE::InfoFactory::regClass<TrashFileInfo>(TrashCoreHelper::scheme());
 
     dpfSlotChannel->connect(DPF_MACRO_TO_STR(DPTRASHCORE_NAMESPACE), "slot_TrashCore_EmptyTrash",

--- a/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
@@ -188,8 +188,10 @@ bool ComputerUtils::checkGvfsMountExist(const QUrl &url, int timeout)
         QThread::msleep(100);
         int ret = access(path.c_str(), F_OK);
         exist = (ret == 0);
-        qDebug() << "gvfs path: " << path.c_str() << ", exist: " << exist << ", error: " << strerror(ret);
 
+        qInfo() << "gvfs path: " << path.c_str() << ", exist: " << exist << ", error: " << strerror(errno);
+
+        exist = true;
         QMutexLocker lk(&mtxForCheckGvfs);
         condForCheckGvfs.wakeAll();
     });

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -503,9 +503,10 @@ QPair<QUrl, RootInfo::EventType> RootInfo::dequeueEvent()
 FileInfoPointer RootInfo::fileInfo(const QUrl &url)
 {
     auto info = InfoFactory::create<FileInfo>(url);
-    info->refresh();
-    if (info)
+    if (info) {
+        info->refresh();
         return info;
+    }
 
     const QUrl &parentUrl = QUrl::fromPercentEncoding(watcher->url().toString().toUtf8());
     auto path = url.path();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -15,6 +15,7 @@
 #include <QElapsedTimer>
 
 #include <dfm-io/denumerator.h>
+#include <dfm-io/denumeratorfuture.h>
 
 using namespace dfmbase;
 
@@ -29,6 +30,7 @@ class TraversalDirThreadManager : public TraversalDirThread
     QElapsedTimer *timer = Q_NULLPTR;
     int timeCeiling = 200;
     int countCeiling = 300;
+    dfmio::DEnumeratorFuture *future { nullptr };
 
 public:
     explicit TraversalDirThreadManager(const QUrl &url, const QStringList &nameFilters = QStringList(),
@@ -37,6 +39,10 @@ public:
                                        QObject *parent = nullptr);
     virtual ~TraversalDirThreadManager() override;
     void setSortAgruments(const Qt::SortOrder order, const dfmbase::Global::ItemRoles sortRole, const bool isMixDirAndFile);
+    void start();
+
+public Q_SLOTS:
+    void onAsyncIteratorOver();
 
 Q_SIGNALS:
     void updateChildrenManager(QList<FileInfoPointer> children);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -28,8 +28,8 @@ class TraversalDirThreadManager : public TraversalDirThread
     dfmio::DEnumerator::SortRoleCompareFlag sortRole { dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault };
     bool isMixDirAndFile { false };
     QElapsedTimer *timer = Q_NULLPTR;
-    int timeCeiling = 200;
-    int countCeiling = 300;
+    int timeCeiling = 1500;
+    int countCeiling = 500;
     dfmio::DEnumeratorFuture *future { nullptr };
 
 public:


### PR DESCRIPTION
1.外设文件删除到回收站后，打开回收站，被删除文件不断刷新很多次
2.已挂载Android手机，卸载后再次挂载，进入目录显示内容为空
3.回收站文件较多时，操作卡顿
4.桌面存在smb等网络链接文件，断开网络，双击打开桌面smb链接文件，桌面和文管卡死2分钟左右