### PR TITLE
修复聚合模式下 smb:/ 被缓存的问题

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
@@ -119,6 +119,9 @@ void travers_prehandler::onSmbRootMounted(const QString &mountSource, Handler af
     if (ProtocolDeviceDisplayManager::instance()->displayMode() != SmbDisplayMode::kAggregation)
         return;
 
+    if (QUrl(mountSource).host().isEmpty())
+        return;
+
     pddmDbg << "do cache root entry" << mountSource;
     VirtualEntryDbHandler::instance()->saveData(VirtualEntryData(mountSource));
 


### PR DESCRIPTION
which should be ignored and no virtual entry should be displayed for
smb:/

Log: fix issue about smb aggregation mode.
