### PR TITLE
fix: [taborder] change tab order of smb passwd dialog.

### DIFF
--- a/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.cpp
+++ b/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.cpp
@@ -68,10 +68,14 @@ void UserSharePasswordSettingDialog::initUI()
         this->setFixedSize(QSize(390, 210));
     }
 
-    // The default first tab focus is window close button;
-    // The second one is m_passwordEdit, then the third one is eyes button;
-    // the last tab focus is cancel button(this->getButton(0));
-    QWidget::setTabOrder(m_passwordEdit, this->getButton(0));
+    setTabOrder(m_passwordEdit, getButton(0));
+    setTabOrder(getButton(0), this);
+}
+
+void UserSharePasswordSettingDialog::showEvent(QShowEvent *event)
+{
+    m_passwordEdit->setFocus();
+    DDialog::showEvent(event);
 }
 
 void UserSharePasswordSettingDialog::onButtonClicked(const int &index)

--- a/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.h
+++ b/src/dde-file-manager-lib/dialogs/usersharepasswordsettingdialog.h
@@ -20,6 +20,9 @@ public:
 
 signals:
 
+protected:
+    virtual void showEvent(QShowEvent *event) override;
+
 public slots:
     void onButtonClicked(const int& index);
 


### PR DESCRIPTION
1. as title;
2. set default focus widget to lineedit.

Log: optimize the taborder of smb password dialog.
Bug: https://pms.uniontech.com/bug-view-170441.html