### PR TITLE
feat: add dconfig to disable desktop

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -144,6 +144,17 @@
             "description":"外设和网络挂载设备nas盘删除文件进入到回收站",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "dd.disabled": {
+            "value":false,
+            "serial":0,
+            "flags":[],
+            "name":"Disabled Desktop",
+            "name[zh_CN]":"禁用桌面。",
+            "description[zh_CN]":"如果值为true，DDE桌面将不加载任何插件，无桌面窗口。",
+            "description":"If the value is set to true, the DDE Desktop will not load any plugins and no desktop window.",
+            "permissions":"readwrite",
+            "visibility":"private"
         }
     }
 }

--- a/src/apps/dde-desktop/main.cpp
+++ b/src/apps/dde-desktop/main.cpp
@@ -7,6 +7,10 @@
 #include "config.h"   //cmake
 #include "tools/upgrade/builtininterface.h"
 
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <dfm-framework/dpf.h>
+
 #include <DApplication>
 #include <DMainWindow>
 
@@ -19,8 +23,6 @@
 #include <QDBusInterface>
 #include <QProcess>
 #include <QDateTime>
-
-#include <dfm-framework/dpf.h>
 
 #include <iostream>
 #include <algorithm>
@@ -165,6 +167,16 @@ static void checkUpgrade(DApplication *app)
     return;
 }
 
+static bool isDesktopEnable()
+{
+    bool enable = !(dfmbase::DConfigManager::instance()->value(
+                   dfmbase::kDefaultCfgPath,
+                   "dd.disabled",
+                   false
+                   ).toBool());
+    return enable;
+}
+
 int main(int argc, char *argv[])
 {
     QString mainTime = QDateTime::currentDateTime().toString();
@@ -208,11 +220,15 @@ int main(int argc, char *argv[])
         registerDDESession();
     }
 
-    checkUpgrade(&a);
+    if (isDesktopEnable()) {
+        checkUpgrade(&a);
 
-    if (!pluginsLoad()) {
-        qCritical() << "Load pugin failed!";
-        abort();
+        if (!pluginsLoad()) {
+            qCritical() << "Load pugin failed!";
+            abort();
+        }
+    } else {
+        qWarning() << "desktop is disabled...";
     }
 
     int ret { a.exec() };

--- a/src/dfm-base/base/configs/dconfig/dconfigmanager.cpp
+++ b/src/dfm-base/base/configs/dconfig/dconfigmanager.cpp
@@ -115,7 +115,7 @@ QVariant DConfigManager::value(const QString &config, const QString &key, const 
         qWarning() << "Config: " << config << "is not registered!!!";
     return fallback;
 #else
-    return QVariant();
+    return fallback;
 #endif
 }
 


### PR DESCRIPTION
1. add dconfig key dd.disabled in org.deepin.dde.file-manager.
2. if dd.disabled is true, the desktop do not load any plugins.

Log: 
Task: https://pms.uniontech.com/task-view-256381.html