### PR TITLE
fix: [workspace] After copying/cutting/dragging multiple files, only …

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/selecthelper.cpp
@@ -120,6 +120,7 @@ void SelectHelper::select(const QList<QModelIndex> &indexes)
 
     const QModelIndex &root = view->rootIndex();
     view->selectionModel()->clearSelection();
+    view->setCurrentIndex(QModelIndex());
     for (const QModelIndex &index : indexes) {
         if (!index.isValid() || index == root) {
             continue;
@@ -134,7 +135,7 @@ void SelectHelper::select(const QList<QModelIndex> &indexes)
     }
 
     if (lastIndex.isValid())
-        view->setCurrentIndex(lastIndex);
+        view->selectionModel()->setCurrentIndex(lastIndex, QItemSelectionModel::Select);
 
     if (firstIndex.isValid())
         view->scrollTo(firstIndex, QAbstractItemView::PositionAtTop);


### PR DESCRIPTION
…one file is selected

1. as title
2. After copying a single file, it may not be selected.

Log: solved problem of workspace select file.
Bug: https://pms.uniontech.com/bug-view-195697.html https://pms.uniontech.com/bug-view-195387.html