### PR TITLE
fix: Entering the empty directory on Android phones

### DIFF
--- a/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
@@ -21,7 +21,7 @@ void TrashCore::initialize()
     TrashCoreEventSender::instance();
 
     DFMBASE_NAMESPACE::UrlRoute::regScheme(TrashCoreHelper::scheme(), "/", TrashCoreHelper::icon(), true, tr("Trash"));
-    DFMBASE_NAMESPACE::InfoFactory::regClass<TrashFileInfo>(TrashCoreHelper::scheme());
+    DFMBASE_NAMESPACE::InfoFactory::regClass<TrashFileInfo>(TrashCoreHelper::scheme(), DFMBASE_NAMESPACE::InfoFactory::kNoCache);
 
     dpfSlotChannel->connect(DPF_MACRO_TO_STR(DPTRASHCORE_NAMESPACE), "slot_TrashCore_EmptyTrash",
                             TrashCoreEventReceiver::instance(), &TrashCoreEventReceiver::handleEmptyTrash);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -91,7 +91,7 @@ void RootInfo::startWork(const QString &key, const bool getCache)
 
     if (!traversalThreads.contains(key))
         return;
-    if (getCache)
+    if (getCache && !sourceDataList.isEmpty())
         return handleGetSourceData(key);
 
     currentKey = key;


### PR DESCRIPTION
Retrieved the cache and determined that when entering the directory, if there are no files in the cached directory, iterate again

Log: Entering the empty directory on Android phones
Bug: https://pms.uniontech.com/bug-view-192655.html