### PR TITLE
修复无法从“连接到服务器”窗口清除连接历史的问题

### DIFF
--- a/src/dde-file-manager-lib/controllers/searchhistroymanager.cpp
+++ b/src/dde-file-manager-lib/controllers/searchhistroymanager.cpp
@@ -60,9 +60,8 @@ void SearchHistroyManager::clearHistory(const QStringList &schemeFilters)
         QStringList historyList = DFMApplication::appObtuselySetting()->value("Cache", "SearchHistroy").toStringList();
         for (const QString &data : historyList) {
             QUrl url(data);
-            if (url.isValid() && schemeFilters.startsWith(url.scheme()))
-                historyList.removeOne(data);
-
+            if (url.isValid() && schemeFilters.contains(url.scheme() + "://"))
+                historyList.removeAll(data);
         }
         DFMApplication::appObtuselySetting()->setValue("Cache", "SearchHistroy", historyList);
     }


### PR DESCRIPTION
from ConnectToServerDialog.
the clear logic is wrong.

Log: fix issue about history clear.

Bug: https://pms.uniontech.com/bug-view-195903.html