### PR TITLE
fix: thumbnail genrate infinitely in cache dir

### DIFF
--- a/src/dfm-base/utils/thumbnailprovider.cpp
+++ b/src/dfm-base/utils/thumbnailprovider.cpp
@@ -34,7 +34,7 @@
 #include <poppler/cpp/poppler-page-renderer.h>
 
 constexpr char kFormat[] { ".png" };
-constexpr char cacheDirSign[] { ".thumbnailCacheDir" };
+constexpr char kCacheDirSign[] { ".thumbnailCacheDir" };
 
 inline QByteArray dataToMd5Hex(const QByteArray &data)
 {
@@ -243,12 +243,12 @@ QPixmap ThumbnailProvider::thumbnailPixmap(const QUrl &fileUrl, Size size) const
     if (!fileInfo)
         return QString();
 
-    const QString &DirPath = fileInfo->pathOf(PathInfoType::kPath);
+    const QString &dirPath = fileInfo->pathOf(PathInfoType::kPath);
     const QString &filePath = fileInfo->pathOf(PathInfoType::kFilePath);
 
     // 目录下存在signFile，说明是缓存目录
     // fix: 用户通过数据盘或软链接访问缓存目录时无限生成缩略图的bug
-    if (QFile::exists(QDir(DirPath).absoluteFilePath(cacheDirSign))) {
+    if (QFile::exists(QDir(dirPath).absoluteFilePath(kCacheDirSign))) {
         return filePath;
     }
 
@@ -292,12 +292,12 @@ QString ThumbnailProvider::createThumbnail(const QUrl &url, ThumbnailProvider::S
 
     const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
 
-    const QString &DirPath = fileInfo->pathOf(PathInfoType::kAbsolutePath);
+    const QString &dirPath = fileInfo->pathOf(PathInfoType::kAbsolutePath);
     const QString &filePath = fileInfo->pathOf(PathInfoType::kAbsoluteFilePath);
 
     // 目录下存在signFile，说明是缓存目录
     // fix: 用户通过数据盘或软链接访问缓存目录时无限生成缩略图的bug
-    if (QFile::exists(QDir(DirPath).absoluteFilePath(cacheDirSign))) {
+    if (QFile::exists(QDir(dirPath).absoluteFilePath(kCacheDirSign))) {
         return filePath;
     }
 
@@ -354,7 +354,7 @@ QString ThumbnailProvider::createThumbnail(const QUrl &url, ThumbnailProvider::S
     QFileInfo(thumbnail).absoluteDir().mkpath(".");
 
     // 当前缓存文件夹下不存在signFile，则生成
-    const QString signFilePath = QFileInfo(thumbnail).absoluteDir().absoluteFilePath(cacheDirSign);
+    const QString signFilePath = QFileInfo(thumbnail).absoluteDir().absoluteFilePath(kCacheDirSign);
     if (!QFile::exists(signFilePath)) {
         QFile signFile(signFilePath);
         if(!signFile.open(QIODevice::WriteOnly)) {

--- a/src/dfm-base/utils/thumbnailprovider.cpp
+++ b/src/dfm-base/utils/thumbnailprovider.cpp
@@ -248,7 +248,7 @@ QPixmap ThumbnailProvider::thumbnailPixmap(const QUrl &fileUrl, Size size) const
 
     // 目录下存在signFile，说明是缓存目录
     // fix: 用户通过数据盘或软链接访问缓存目录时无限生成缩略图的bug
-    if (QFile::exists(QDir(dirPath).absoluteFilePath(kCacheDirSign))) {
+    if (DFMIO::DFile(QDir(dirPath).absoluteFilePath(kCacheDirSign)).exists()){
         return filePath;
     }
 
@@ -297,7 +297,7 @@ QString ThumbnailProvider::createThumbnail(const QUrl &url, ThumbnailProvider::S
 
     // 目录下存在signFile，说明是缓存目录
     // fix: 用户通过数据盘或软链接访问缓存目录时无限生成缩略图的bug
-    if (QFile::exists(QDir(dirPath).absoluteFilePath(kCacheDirSign))) {
+    if (DFMIO::DFile(QDir(dirPath).absoluteFilePath(kCacheDirSign)).exists()) {
         return filePath;
     }
 
@@ -355,9 +355,9 @@ QString ThumbnailProvider::createThumbnail(const QUrl &url, ThumbnailProvider::S
 
     // 当前缓存文件夹下不存在signFile，则生成
     const QString signFilePath = QFileInfo(thumbnail).absoluteDir().absoluteFilePath(kCacheDirSign);
-    if (!QFile::exists(signFilePath)) {
+    if (!DFMIO::DFile(signFilePath).exists()) {
         QFile signFile(signFilePath);
-        if(!signFile.open(QIODevice::WriteOnly)) {
+        if(signFile.open(QIODevice::WriteOnly)) {
             signFile.close();
         }
     }
@@ -661,7 +661,7 @@ void ThumbnailProvider::initThumnailTool()
                 const QStringList keys = document.object().toVariantMap().value("Keys").toStringList();
                 const QString &toolFilePath = fileInfo.absoluteDir().filePath(fileInfo.baseName());
 
-                if (!QFile::exists(toolFilePath)) {
+                if (!DFMIO::DFile(toolFilePath).exists()) {
                     continue;
                 }
 


### PR DESCRIPTION
fix: https://github.com/linuxdeepin/developer-center/issues/4078

替换了原有判断当前目录是否为缩略图缓存目录的字符串匹配算法。改为判断文件夹目录Inode是否一致，以解决访问/data/主目录或是软链接下的缓存目录时，无限生成缩略图的bug。

![截图_dde-file-manager_20230414171747](https://user-images.githubusercontent.com/76643630/232002721-cb49a88f-70cf-40b9-8a84-00886c3f8d20.png)

