### PR TITLE
fix: Unable to delete peripheral files

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -179,7 +179,7 @@ bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer &dir)
     while (iterator->hasNext()) {
         const QUrl &url = iterator->next();
 
-        const auto &info = iterator->fileInfo();
+        const auto &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);;
         if (!info) {
             // pause and emit error msg
             if (doHandleErrorAndWait(url, AbstractJobHandler::JobErrorType::kProrogramError) == AbstractJobHandler::SupportAction::kSkipAction)


### PR DESCRIPTION
When obtaining the fileinfo of the iterator, an asynchronous fileinfo was created, resulting in incorrect determination of the number of directories. Modify fileinfo to directly create the same fileinfo.

Log: Unable to delete peripheral files
Bug: https://pms.uniontech.com/bug-view-194699.html