### PR TITLE
fix: Missing files in folder

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -609,8 +609,7 @@ bool FileOperateBaseWorker::checkAndCopyDir(const FileInfoPointer &fromInfo, con
         }
 
         const QUrl &url = iterator->next();
-        Q_UNUSED(url);
-        const FileInfoPointer &info = iterator->fileInfo();
+        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         bool ok = doCopyFile(info, toInfo, skip);
         if (!ok && !skip) {
             return false;


### PR DESCRIPTION
When obtaining the fileinfo of the iterator, an asynchronous fileinfo was created, resulting in incorrect determination of the number of directories. Modify fileinfo to directly create the same fileinfo.

Log: Missing files in folder
Bug: https://pms.uniontech.com/bug-view-195709.html