### PR TITLE
修复开启安全中心磁盘扫描后插入磁盘文管UI阻塞的问题

### DIFF
--- a/src/dfm-base/base/device/private/devicewatcher.cpp
+++ b/src/dfm-base/base/device/private/devicewatcher.cpp
@@ -252,8 +252,9 @@ void DeviceWatcher::onBlkDevRemoved(const QString &id)
 
 void DeviceWatcher::onBlkDevMounted(const QString &id, const QString &mpt)
 {
-    const auto &info = d->allBlockInfos.value(id);
-    d->queryUsageOfItem(info, dfmmount::DeviceType::kBlockDevice);
+    const QVariantMap &info = d->allBlockInfos.value(id);
+    // query info async avoid blocking main thread when disks' IO load is too high.
+    QtConcurrent::run(d.data(), &DeviceWatcherPrivate::queryUsageOfItem, info, DFMMOUNT::DeviceType::kBlockDevice);
     emit DevMngIns->blockDevMounted(id, mpt);
 }
 


### PR DESCRIPTION
when device mounted, query device's usage async to avoid blocking main
thread.

Log: fix issue about UI blocking when scanning device.

Bug: https://pms.uniontech.com/bug-view-178461.html
