### PR TITLE
fix: [io/trash]When there are too many files in the trash, the operation gets stuck

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -568,7 +568,8 @@ void AsyncFileInfo::setNotifyUrl(const QUrl &url)
         return;
     }
     QWriteLocker lk(&d->notifyLock);
-    d->notifyUrls.append(url);
+    if (!d->notifyUrls.contains(url))
+        d->notifyUrls.append(url);
 }
 
 void AsyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo> dfileInfo)

--- a/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.cpp
@@ -451,8 +451,8 @@ QString AsyncTrashFileInfoPrivate::displayName()
 int AsyncTrashFileInfo::countChildFile() const
 {
     if (FileUtils::isTrashRootFile(urlOf(UrlInfoType::kUrl))) {
-        if (d->dFileInfo)
-            return d->dFileInfo->attribute(DFMIO::DFileInfo::AttributeID::kTrashItemCount).toInt();
+        DFileInfo trashRootFileInfo(FileUtils::trashRootUrl());
+        return trashRootFileInfo.attribute(DFMIO::DFileInfo::AttributeID::kTrashItemCount).toInt();
     }
 
     if (isAttributes(OptInfoType::kIsDir)) {

--- a/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
@@ -395,8 +395,8 @@ QString TrashFileInfoPrivate::symLinkTarget() const
 int TrashFileInfo::countChildFile() const
 {
     if (FileUtils::isTrashRootFile(urlOf(UrlInfoType::kUrl))) {
-        if (d->dFileInfo)
-            return d->dFileInfo->attribute(DFMIO::DFileInfo::AttributeID::kTrashItemCount).toInt();
+        DFileInfo trashRootFileInfo(FileUtils::trashRootUrl());
+        return trashRootFileInfo.attribute(DFMIO::DFileInfo::AttributeID::kTrashItemCount).toInt();
     }
 
     if (isAttributes(OptInfoType::kIsDir)) {

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -279,6 +279,8 @@ bool EmblemHelper::isExtEmblemProhibited(const QUrl &url)
 void EmblemHelper::onEmblemChanged(const QUrl &url, const Product &product)
 {
     productQueue[url] = product;
+    if (product.isEmpty())
+        return;
     auto eventID { DPF_NAMESPACE::Event::instance()->eventType("ddplugin_canvas", "slot_FileInfoModel_UpdateFile") };
     if (eventID != DPF_NAMESPACE::EventTypeScope::kInValid)
         dpfSlotChannel->push("ddplugin_canvas", "slot_FileInfoModel_UpdateFile", url);

--- a/src/plugins/filemanager/core/dfmplugin-trash/private/trashdiriterator_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/private/trashdiriterator_p.h
@@ -31,6 +31,7 @@ private:
     QSharedPointer<DFMIO::DEnumerator> dEnumerator = nullptr;
     QUrl currentUrl;
     QMap<QString, QString> fstabMap;
+    FileInfoPointer fileInfo{nullptr};
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-trash/trashdiriterator.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trashdiriterator.cpp
@@ -57,14 +57,11 @@ bool TrashDirIterator::hasNext() const
     if (!has)
         return has;
 
-    if (d->fstabMap.isEmpty())
-        return has;
-
     if (d->dEnumerator) {
         const QUrl &urlNext = d->dEnumerator->next();
-        auto fileinfo = InfoFactory::create<FileInfo>(urlNext);
-        if (fileinfo) {
-            const QUrl &urlTarget = fileinfo->urlOf(UrlInfoType::kRedirectedFileUrl);
+        d->fileInfo = InfoFactory::create<FileInfo>(urlNext);
+        if (d->fileInfo) {
+            const QUrl &urlTarget = d->fileInfo->urlOf(UrlInfoType::kRedirectedFileUrl);
             for (const QString &key : d->fstabMap.keys()) {
                 if (urlTarget.path().startsWith(key))
                     return hasNext();
@@ -97,7 +94,10 @@ QUrl TrashDirIterator::fileUrl() const
 
 const FileInfoPointer TrashDirIterator::fileInfo() const
 {
-    return InfoFactory::create<FileInfo>(d->currentUrl);
+    if (d->fileInfo)
+        return d->fileInfo;
+
+    return InfoFactory::create<FileInfo>(d->currentUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
 }
 
 QUrl TrashDirIterator::url() const

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -55,8 +55,6 @@ public:
     QModelIndex rootIndex() const;
 
     QModelIndex setRootUrl(const QUrl &url);
-
-    void update();
     void refresh();
 
     ModelState currentState() const;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -747,12 +747,26 @@ void FileSortWorker::sortAllFiles()
     if (orgSortRole == Global::ItemRoles::kItemDisplayRole)
         return;
 
+    if (visibleChildren.count() <= 1)
+        return;
+
     QList<QUrl> sortList;
+    int i = 0;
+    bool sortSame = true;
     for (const auto &url : visibleChildren) {
         if (isCanceled)
             return;
-        sortList.insert(insertSortList(url, sortList, AbstractSortFilter::SortScenarios::kSortScenariosNormal), url);
+        auto sortIndex = insertSortList(url, sortList, AbstractSortFilter::SortScenarios::kSortScenariosNormal);
+        if (sortSame)
+            sortSame = sortIndex == i;
+
+        sortList.insert(sortIndex, url);
+        i++;
     }
+
+    if (sortSame)
+        return;
+
     Q_EMIT insertRows(0, sortList.length());
     {
         QWriteLocker lk(&locker);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -30,6 +30,7 @@
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/utils/networkutils.h>
+#include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/dialogmanager.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #ifdef DTKWIDGET_CLASS_DSizeMode
@@ -868,7 +869,7 @@ void FileView::setFilterCallback(const QUrl &url, const FileViewFilterCallback c
 void FileView::trashStateChanged()
 {
     if (Q_LIKELY(model()))
-        model()->update();
+        model()->updateFile(FileUtils::trashRootUrl());
 }
 
 void FileView::onHeaderViewSectionChanged(const QUrl &url)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -157,7 +157,7 @@ void FileViewPrivate::pureResizeEvent(QResizeEvent *event)
     Q_UNUSED(event)
 
     if (currentViewMode == Global::ViewMode::kListMode) {
-        if (adjustFileNameColumn)
+        if (adjustFileNameColumn && headerView)
             headerView->doFileNameColumnResize(q->width());
     }
 }


### PR DESCRIPTION
There are issues with the process of using the drawing interface.
    1. When modifying the received file information, corner markers, and thumbnail signals, only the corresponding areas will be updated.
    2. Modify the completion signal of the extended corner marker, and do not send it if there is none.
    3. The order and sorting displayed first in sortworker are the same, and the interface is not updated.
    4. When receiving changes in the status of the recycle bin, do not refresh all items and use the trashrooturl to update the specified items.
    5. Modify the trash iterator to obtain fileinfo using the one created earlier.

Log: When there are too many files in the trash, the operation gets stuck
Bug: https://pms.uniontech.com/bug-view-189691.html