### PR TITLE
feat: [dconf] headless mode for `dde-file-manger`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(Qt5 COMPONENTS Widgets REQUIRED)
 find_package(DtkCMake REQUIRED)
 #if no debug, can't out in code define key '__FUNCTION__' and so on
 add_definitions(-DQT_MESSAGELOGCONTEXT)
+# TODO: control it by CI. (Automation Testing)
 add_definitions(-DENABLE_TESTING)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -155,6 +155,17 @@
             "description":"If the value is set to true, the DDE Desktop will not load any plugins and no desktop window.",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "dfm.headless": {
+            "value":false,
+            "serial":0,
+            "flags":[],
+            "name":"Enable dde-file-manger headless",
+            "name[zh_CN]":"启用文件管理器常驻进程。",
+            "description[zh_CN]":"如果值为true，文件管理器将常驻后台，牺牲内存来换取热启动速度。",
+            "description":"If the value is true, the filemanager will be as a daemon, sacrificing memory for hot start speed",
+            "permissions":"readwrite",
+            "visibility":"private"
         }
     }
 }

--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -8,6 +8,7 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/standardpaths.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -41,13 +42,22 @@ QString CommandParser::value(const QString &name) const
 
 void CommandParser::processCommand()
 {
-    // whether to add setQuitOnLastWindowClosed
-    if (isSet("d"))
-        ::exit(0);   // NOTE: daemon process not supported now
+    if (isSet("d")) {
+        bool enableHeadless { DConfigManager::instance()->value(kDefaultCfgPath, "dfm.headless", false).toBool() };
+        if (enableHeadless) {
+            qInfo() << "Start headless";
+            // whether to add setQuitOnLastWindowClosed
+            return;
+        }
+        qWarning() << "Cannot start dde-file-manager in no window mode "
+                      "unless you can set the value of `dfm.daemon` in DConfig to `true`!";
+        ::exit(0);
+    }
 
     if (isSet("e")) {
-        // Todo(yanghao): event from json handle, the old filemanager does not seem to be used
-        return;
+        // TODO: event from json handle, the old filemanager does not seem to be used
+        qWarning() << "Cannot supported now";
+        exit(0);
     }
 
     if (isSet("p")) {

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -9,6 +9,7 @@
 #include "tools/upgrade/builtininterface.h"
 
 #include <dfm-base/utils/sysinfoutils.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -292,5 +293,12 @@ int main(int argc, char *argv[])
 
     int ret { a.exec() };
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();
+
+    bool enableHeadless { DConfigManager::instance()->value(kDefaultCfgPath, "dfm.headless", false).toBool() };
+    if (enableHeadless && !SysInfoUtils::isOpenAsAdmin()) {
+        a.closeServer();
+        QProcess::startDetached(QString("%1 -d").arg(QString(argv[0])));
+    }
+
     return ret;
 }


### PR DESCRIPTION
Use DConfig to control daemon enablement

Log: daemon mode for `dde-file-manger`