### PR TITLE
修复特定场景下，磁盘重命名被无限触发的问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.h
@@ -36,7 +36,7 @@ private:
     void paintCustomWidget(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paintSmallItem(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paintLargeItem(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void prepareColor(QPainter *painter, const QStyleOptionViewItem &option) const;
+    void prepareColor(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
     void drawDeviceIcon(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void drawDeviceLabelAndFs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;

--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
@@ -96,12 +96,15 @@ bool ComputerView::eventFilter(QObject *watched, QEvent *event)
             this->event(event);
             return true;
         }
+
         if (ke->key() == Qt::Key::Key_Enter || ke->key() == Qt::Key::Key_Return) {
             const auto &idx = this->selectionModel()->currentIndex();
             if (idx.isValid()) {
                 if (!this->model()->data(idx, ComputerModel::DataRoles::kItemIsEditingRole).toBool()) {
                     Q_EMIT enterPressed(idx);
                     return true;
+                } else {
+                    this->setCurrentIndex(idx);
                 }
             }
         }


### PR DESCRIPTION
rename triggered infinitely in some case.
when click in an item and out of the lineedit, the edit event is
triggered again.
clear selection when editing item.

Log: fix issue about rename disk.

Bug: https://pms.uniontech.com/bug-view-178367.html
