### PR TITLE
fix: The search result does not disappear after the original file is deleted

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
@@ -217,6 +217,7 @@ private:
     QList<SelectionMode> fetchSupportSelectionModes();
 
     bool cdUp();
+    void updateVisibleIndex(const QModelIndex &index);
 };
 
 }


### PR DESCRIPTION
Check whether the file exists in the 'FileView::updateModelActiveIndex' interface. If the file does not exist, delete it
Log: fix bug
Bug: https://pms.uniontech.com/bug-view-195769.html
