### PR TITLE
fix: [thumbnail]Switching to a directory with linked files with remote files crashes

### DIFF
--- a/src/dfm-base/interfaces/abstractfileinfo.cpp
+++ b/src/dfm-base/interfaces/abstractfileinfo.cpp
@@ -37,8 +37,11 @@ Q_GLOBAL_STATIC_WITH_ARGS(int, type_id, { qRegisterMetaType<AbstractFileInfoPoin
 AbstractFileInfo::AbstractFileInfo(const QUrl &url)
     : url(url)
 {
-    if (url.path().endsWith(QDir::separator()) && url.path() != QDir::separator())
-        this->url.setPath(url.path().left(url.path().lastIndexOf(QDir::separator())));
+    if (url.path().endsWith(QDir::separator()) && url.path() != QDir::separator()) {
+        auto path = url.path();
+        path.chop(1);
+        this->url.setPath(path);
+    }
     Q_UNUSED(type_id)
 }
 
@@ -86,10 +89,6 @@ QString dfmbase::AbstractFileInfo::absoluteFilePath() const
 QString dfmbase::AbstractFileInfo::fileName() const
 {
     QString filePath = this->filePath();
-
-    if (filePath.endsWith(QDir::separator())) {
-        filePath.chop(1);
-    }
 
     int index = filePath.lastIndexOf(QDir::separator());
 

--- a/src/dfm-base/utils/thumbnailprovider.cpp
+++ b/src/dfm-base/utils/thumbnailprovider.cpp
@@ -108,6 +108,8 @@ QString ThumbnailProviderPrivate::sizeToFilePath(ThumbnailProvider::Size size) c
 uint64_t ThumbnailProviderPrivate::filePathToInode(QString filePath) const
 {
     FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    if (fileInfo.isNull())
+        return static_cast<uint64_t>(-1);
     return fileInfo->extendAttributes(FileInfo::FileExtendedInfoType::kInode).toULongLong();
 }
 
@@ -251,6 +253,9 @@ QPixmap ThumbnailProvider::thumbnailPixmap(const QUrl &fileUrl, Size size) const
 
     const QString &dirPath = fileInfo->pathOf(PathInfoType::kPath);
     const QString &filePath = fileInfo->pathOf(PathInfoType::kFilePath);
+
+    if (dirPath.isEmpty() || filePath.isEmpty())
+        return QString();
 
     // 判断目录inode值，是否为缓存目录
     // fix: 用户通过数据盘或软链接访问缓存目录时无限生成缩略图的bug

--- a/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.cpp
@@ -5,15 +5,15 @@
 #include "asynctrashfileinfo.h"
 #include "utils/trashcorehelper.h"
 
-#include "dfm-base/interfaces/private/fileinfo_p.h"
-#include "dfm-base/dfm_global_defines.h"
-#include "dfm-base/base/schemefactory.h"
-#include "dfm-base/utils/fileutils.h"
-#include "dfm-base/file/local/desktopfileinfo.h"
-#include "dfm-base/file/local/asyncfileinfo.h"
-#include "dfm-base/utils/universalutils.h"
-#include "dfm-base/base/standardpaths.h"
-#include "dfm-base/utils/fileinfohelper.h"
+#include <dfm-base/interfaces/private/fileinfo_p.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/file/local/desktopfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/standardpaths.h>
+#include <dfm-base/utils/fileinfohelper.h>
 
 #include <dfm-io/denumerator.h>
 

--- a/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.h
+++ b/src/plugins/common/core/dfmplugin-trashcore/asynctrashfileinfo.h
@@ -6,7 +6,7 @@
 #define ASYNCTRASHFILEINFO_H
 
 #include "dfmplugin_trashcore_global.h"
-#include "dfm-base/interfaces/proxyfileinfo.h"
+#include <dfm-base/interfaces/proxyfileinfo.h>
 
 namespace dfmplugin_trashcore {
 


### PR DESCRIPTION

The file directory obtained when obtaining thumbnails is empty, resulting in the created fileinfo being empty. Before determining whether it is empty, judge whether fileinfo is empty

Log: Switching to a directory with linked files with remote files crashes