### PR TITLE
fix: CPU usage is too high after opening the filemanager

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -14,9 +14,6 @@
 #include <DApplicationHelper>
 #include <DPalette>
 #include <DPaletteHelper>
-#ifdef DTKWIDGET_CLASS_DSizeMode
-#    include <DSizeMode>
-#endif
 
 #include <QPainter>
 #include <QGraphicsScene>
@@ -75,9 +72,6 @@ void ComputerItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &
     painter->setRenderHint(QPainter::RenderHint::Antialiasing);
 
     ComputerItemData::ShapeType type = ComputerItemData::ShapeType(index.data(ComputerModel::DataRoles::kItemShapeTypeRole).toInt());
-#ifdef DTKWIDGET_CLASS_DSizeMode
-    view->setSpacing(DSizeModeHelper::element(5, 10));
-#endif
     switch (type) {
     case ComputerItemData::kSplitterItem:
         paintSplitter(painter, option, index);

--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
@@ -12,7 +12,10 @@
 
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/dbusservice/global_server_defines.h>
-
+#ifdef DTKWIDGET_CLASS_DSizeMode
+#    include <DGuiApplicationHelper>
+#    include <DSizeMode>
+#endif
 #include <dfm-framework/dpf.h>
 
 #include <QEvent>
@@ -139,7 +142,11 @@ void ComputerView::initView()
     this->setItemDelegate(new ComputerItemDelegate(this));
     qobject_cast<QListView *>(this)->setWrapping(true);
     qobject_cast<QListView *>(this)->setFlow(QListView::Flow::LeftToRight);
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    this->setSpacing(DSizeModeHelper::element(5, 10));
+#else
     this->setSpacing(10);
+#endif
     this->setResizeMode(QListView::ResizeMode::Adjust);
     this->setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
     this->setEditTriggers(QListView::EditKeyPressed | QListView::SelectedClicked);
@@ -197,6 +204,11 @@ void ComputerView::initConnect()
         else
             ComputerEventCaller::sendEnterInNewTab(ComputerUtils::getWinId(this), ComputerUtils::rootUrl());
     });
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this]() {
+        this->setSpacing(DSizeModeHelper::element(5, 10));
+    });
+#endif
 }
 
 void ComputerView::connectShortcut(QKeySequence seq, std::function<void(DFMEntryFileInfoPointer)> slot)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -11,6 +11,7 @@
 #define DPWORKSPACE_NAMESPACE dfmplugin_workspace
 
 #include <dfm-framework/event/eventhelper.h>
+#include "dtkwidget_config.h"
 
 #include <QList>
 #include <QDir>
@@ -39,12 +40,14 @@ enum class ModelState : uint8_t {
     kIdle,
     kBusy
 };
+#ifdef DTKWIDGET_CLASS_DSizeMode
+inline constexpr int kCompactIconViewSpacing { 0 };
+inline constexpr int kCompactIconModeColumnPadding { 5 };
+#endif
 
 inline constexpr int kIconViewSpacing { 5 };
-inline constexpr int kCompactIconViewSpacing { 0 };
 inline constexpr int kListViewSpacing { 0 };
 inline constexpr int kIconModeColumnPadding { 10 };
-inline constexpr int kCompactIconModeColumnPadding { 5 };
 inline constexpr int kDefualtHeaderSectionWidth { 140 };
 inline constexpr int kMinimumHeaderSectionWidth { 120 };
 inline constexpr int kListViewHeaderHeight { 36 };


### PR DESCRIPTION
The function of setspacing is frequently triggered leads to high CPU usage.

Log: Adjust the way of the trigger setspacing function

Bug: https://pms.uniontech.com/bug-view-197165.html