### PR TITLE
fix: service keeps crashing after logout

### DIFF
--- a/src/apps/dde-file-manager-daemon/dbusservice/dde-filemanager-daemon.service
+++ b/src/apps/dde-file-manager-daemon/dbusservice/dde-filemanager-daemon.service
@@ -5,8 +5,6 @@ Description=DDE File Manager Daemon
 Type=dbus
 BusName=com.deepin.filemanager.daemon
 ExecStart=/usr/bin/dde-file-manager-daemon
-Restart=always
-RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/src/apps/dde-file-manager-server/dbusservice/dde-filemanager-server.service
+++ b/src/apps/dde-file-manager-server/dbusservice/dde-filemanager-server.service
@@ -5,8 +5,6 @@ Description=DDE File Manager Server
 Type=dbus
 BusName=org.deepin.filemanager.server
 ExecStart=/usr/bin/dde-file-manager-server
-Restart=always
-RestartSec=1
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
There is no need to set a restart action, relying on the automatic start of the dbus call.
