### PR TITLE
fix: [io/leak]Fix memory or resource leaks after re entry

### DIFF
--- a/src/dfm-base/file/local/private/infodatafuture.cpp
+++ b/src/dfm-base/file/local/private/infodatafuture.cpp
@@ -36,7 +36,7 @@ void InfoDataFuture::infoMedia(const QUrl &url, const QMap<DFileInfo::AttributeE
     // 先处理数据缓存下来，再转发信号给infohelper，析构future
     attribute = std::move(map);
     finshed = true;
-    emit infoMediaAttributes(url, map);
+    emit infoMediaAttributes(url, attribute);
     future.reset(nullptr);
 }
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
@@ -136,6 +136,7 @@ bool DoCleanTrashFilesWorker::clearTrashFile(const FileInfoPointer &trashInfo)
 {
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         const QUrl &fileUrl = trashInfo->urlOf(UrlInfoType::kUrl);
         bool resultFile = deleteFile(fileUrl);
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -70,6 +70,7 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
         const QUrl &url = *it;
         emitCurrentTaskNotify(url, QUrl());
         do {
+            action = AbstractJobHandler::SupportAction::kNoAction;
             if (!localFileHandler->deleteFile(url)) {
                 action = doHandleErrorAndWait(url, AbstractJobHandler::JobErrorType::kDeleteFileError,
                                               localFileHandler->errorString());
@@ -134,6 +135,7 @@ bool DoDeleteFilesWorker::deleteFileOnOtherDevice(const QUrl &url)
 
     AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         if (!localFileHandler->deleteFile(url)) {
             action = doHandleErrorAndWait(url, AbstractJobHandler::JobErrorType::kDeleteFileError,
                                           localFileHandler->errorString());
@@ -163,6 +165,7 @@ bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer &dir)
     AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
     AbstractDirIteratorPointer iterator(nullptr);
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         QString errorMsg;
         iterator = DirIteratorFactory::create<AbstractDirIterator>(dir->urlOf(UrlInfoType::kUrl), &errorMsg);
         if (!iterator) {

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -98,6 +98,7 @@ void DoCopyFileWorker::doMemcpyLocalBigFile(const FileInfoPointer fromInfo, cons
         AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
 
         do {
+            action = AbstractJobHandler::SupportAction::kNoAction;
             if (!memcpy(destStart, sourceStart, everyCopySize)) {
                 auto lastError = strerror(errno);
                 qWarning() << "file memcpy error, url from: " << fromInfo->urlOf(UrlInfoType::kUrl)
@@ -185,6 +186,7 @@ int DoCopyFileWorker::doOpenFile(const FileInfoPointer fromInfo, const FileInfoP
         QUrl url = isTo ? toInfo->urlOf(UrlInfoType::kUrl) : fromInfo->urlOf(UrlInfoType::kUrl);
         std::string path = url.path().toStdString();
         fd = open(path.c_str(), openFlag, 0777);
+        action = AbstractJobHandler::SupportAction::kNoAction;
         if (fd < 0) {
             auto lastError = strerror(errno);
             qWarning() << "file open error, url from: " << fromInfo->urlOf(UrlInfoType::kUrl)
@@ -226,6 +228,7 @@ BlockFileCopyInfoPointer DoCopyFileWorker::doReadExBlockFile(const FileInfoPoint
         char *buffer = new char[static_cast<uint>(sizeBlock + 1)];
         AbstractJobHandler::SupportAction actionForRead = AbstractJobHandler::SupportAction::kNoAction;
         do {
+            actionForRead = AbstractJobHandler::SupportAction::kNoAction;
             readSize = read(fd, buffer, static_cast<size_t>(sizeBlock));
             auto laststr = strerror(errno);
             if (Q_UNLIKELY(!stateCheck())) {
@@ -488,6 +491,7 @@ bool DoCopyFileWorker::createFileDevice(const FileInfoPointer &fromInfo, const F
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
 
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         file.reset(new DFile(url));
         if (!file) {
             qCritical() << "create dfm io dfile failed! url = " << url;
@@ -563,6 +567,7 @@ bool DoCopyFileWorker::openFile(const FileInfoPointer &fromInfo, const FileInfoP
 {
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         if (!file->open(flags)) {
             auto lastError = file->lastError();
             qWarning() << "file open error, url from: " << fromInfo->urlOf(UrlInfoType::kUrl)
@@ -587,6 +592,7 @@ bool DoCopyFileWorker::resizeTargetFile(const FileInfoPointer &fromInfo, const F
 {
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         if (!file->write(QByteArray())) {
             action = doHandleErrorAndWait(fromInfo->urlOf(UrlInfoType::kUrl), toInfo->urlOf(UrlInfoType::kUrl),
                                           AbstractJobHandler::JobErrorType::kResizeError, true,
@@ -623,6 +629,7 @@ bool DoCopyFileWorker::doReadFile(const FileInfoPointer &fromInfo, const FileInf
         return false;
     }
     do {
+        actionForRead = AbstractJobHandler::SupportAction::kNoAction;
         readSize = fromDevice->read(data, blockSize);
         if (Q_UNLIKELY(!stateCheck())) {
             return false;
@@ -691,6 +698,7 @@ bool DoCopyFileWorker::doWriteFile(const FileInfoPointer &fromInfo, const FileIn
     do {
         bool writeFinishedOnce = true;
         const char *surplusData = data;
+        actionForWrite = AbstractJobHandler::SupportAction::kNoAction;
         do {
             if (!writeFinishedOnce)
                 qDebug() << "write not finished once, current write size: " << sizeWrite << " remain size: " << surplusSize - sizeWrite << " read size: " << readSize;
@@ -836,6 +844,7 @@ bool DoCopyFileWorker::writeBlockFile(const BlockFileCopyInfoPointer &info, bool
     AbstractJobHandler::SupportAction actionForWrite { AbstractJobHandler::SupportAction::kNoAction };
     qint64 surplusSize = info->size;
     do {
+        actionForWrite = AbstractJobHandler::SupportAction::kNoAction;
         qint64 sizeWrite = 0;
 
         if (Q_UNLIKELY(!stateCheck())) {

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -148,25 +148,3 @@ bool FileOperationsUtils::isFileOnDisk(const QUrl &url)
     }
     return true;
 }
-
-void FileOperationsUtils::getDirFiles(const QUrl &url, QList<QUrl> &files)
-{
-    DIR *dir = nullptr;
-    struct dirent *ptr = nullptr;
-    if ((dir = opendir(url.path().toStdString().data())) == nullptr) {
-        qCritical() << "Open dir error by system c opendir function";
-        return;
-    }
-
-    QString urlPath = url.path();
-    if (!urlPath.endsWith("/"))
-        urlPath.append("/");
-    files.clear();
-    while ((ptr = readdir(dir)) != nullptr) {
-        if (strcmp(ptr->d_name, ".") == 0 || strcmp(ptr->d_name, "..") == 0) {
-            continue;
-        } else if (ptr->d_type == 4 || ptr->d_type == 8 || ptr->d_type == 10) {
-            files.append(QUrl::fromLocalFile(urlPath + ptr->d_name));
-        }
-    }
-}

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -73,7 +73,6 @@ private:
     static void statisticFilesSize(const QUrl &url, SizeInfoPointer &sizeInfo, const bool &isRecordUrl = false);
     static bool isAncestorUrl(const QUrl &from, const QUrl &to);
     static bool isFileOnDisk(const QUrl &url);
-    static void getDirFiles(const QUrl &url, QList<QUrl> &files);
 
 private:
     static QSet<QString> fileNameUsing;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.cpp
@@ -147,6 +147,7 @@ bool DoCopyFromTrashFilesWorker::createParentDir(const FileInfoPointer &trashInf
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
     if (!targetFileInfo->exists()) {
         do {
+            action = AbstractJobHandler::SupportAction::kNoAction;
             DFMBASE_NAMESPACE::LocalFileHandler fileHandler;
             if (!fileHandler.mkdir(parentUrl))
                 // pause and emit error msg

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/domovetotrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/domovetotrashfilesworker.cpp
@@ -123,6 +123,7 @@ bool DoMoveToTrashFilesWorker::doMoveToTrash()
 
         AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
         do {
+            action = AbstractJobHandler::SupportAction::kNoAction;
             QString trashTime = fileHandler.trashFile(urlSource);
             if (!trashTime.isEmpty()) {
                 QUrl trashUrl = urlSource;
@@ -166,6 +167,7 @@ bool DoMoveToTrashFilesWorker::isCanMoveToTrash(const QUrl &url, bool *result)
     }
 
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         if (!canWriteFile(url))
             // pause and emit error msg
             action = doHandleErrorAndWait(url, targetUrl, AbstractJobHandler::JobErrorType::kPermissionError);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -89,6 +89,7 @@ bool DoRestoreTrashFilesWorker::translateUrls()
         QStringList deleteInfo;
         AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
         do {
+            action = AbstractJobHandler::SupportAction::kNoAction;
             auto userInfo = url.userInfo();
             deleteInfo = userInfo.split("-");
             // 错误处理
@@ -119,6 +120,7 @@ bool DoRestoreTrashFilesWorker::translateUrls()
     TrashHelper trashHelper;
     trashHelper.setDeleteInfos(targetUrls);
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         if (!trashHelper.getTrashUrls(&sourceUrls, &errorMsg))
             return false;
         if (sourceUrls.length() <= 0)
@@ -229,6 +231,7 @@ bool DoRestoreTrashFilesWorker::createParentDir(const FileInfoPointer &trashInfo
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
     if (!targetFileInfo->exists()) {
         do {
+            action = AbstractJobHandler::SupportAction::kNoAction;
             DFMBASE_NAMESPACE::LocalFileHandler fileHandler;
             if (!fileHandler.mkdir(parentUrl))
                 // pause and emit error msg
@@ -250,6 +253,7 @@ bool DoRestoreTrashFilesWorker::checkRestoreInfo(const QUrl &url, FileInfoPointe
     bool result;
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
     do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
         result = true;
         const auto &fileInfo = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         if (!fileInfo) {


### PR DESCRIPTION
1. When repairing a large file copy, resources were not released. 2. After repairing a re-entry loop, resources were released

Log: Fix memory or resource leaks after re entry