### PR TITLE
fix: [io]desktop crashed when clear trash

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -130,8 +130,10 @@ JobHandlePointer TrashFileEventReceiver::doCleanTrash(const quint64 windowId, co
     }
 
     if (sources.isEmpty()) {
-        future = QtConcurrent::run([&]() {
-            countTrashFile(windowId, deleteNoticeType, handleCallback);
+        future = QtConcurrent::run([windowId, deleteNoticeType, handleCallback]() {
+            if (handleCallback)
+                return instance()->countTrashFile(windowId, deleteNoticeType, handleCallback);
+            return instance()->countTrashFile(windowId, deleteNoticeType, nullptr);
         });
         return nullptr;
     }


### PR DESCRIPTION

When asynchronous threads count the number of recycling bins, the callback function passes in a null pointer, and the function calls the lama function to crash the null pointer copy of the callback function. Modify the null judgment

Log: The desktop may experience a black screen phenomenon for a few seconds, and the trash may not be cleared
Bug: https://pms.uniontech.com/bug-view-198113.html