### PR TITLE
fix: [device]Unable to determine the deletion of USB drive files after enabling the long file name function

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -203,7 +203,7 @@ void DeviceProxyManagerPrivate::initMounts()
                 auto &&info = query(q, dev, false);
                 auto mpt = info.value(DeviceProperty::kMountPoint).toString();
                 if (!mpt.isEmpty()) {
-                    if (DeviceUtils::isMountPointOfDlnfs(mpt))
+                    if (DeviceUtils::isMountPointOfDlnfs(mpt) && !info.value(DeviceProperty::kId).toString().startsWith(kBlockDeviceIdPrefix))
                         continue;
                     mpt = mpt.endsWith("/") ? mpt : mpt + "/";
                     if (info.value(DeviceProperty::kRemovable).toBool())


### PR DESCRIPTION

Skipped when determining that the ext4 type USB drive is dlnfs when initializing peripheral devices in DeviceProxyManager. Supplementary judgment is not a block_ Devices only skipped.

Log: Unable to determine the deletion of USB drive files after enabling the long file name function
Bug: https://pms.uniontech.com/bug-view-197921.html