### PR TITLE
fix: [infocache]The probability of right clicking to copy, cut, rename, or delete a file is grayed out and cannot be clicked

### DIFF
--- a/include/dfm-base/utils/infocache.h
+++ b/include/dfm-base/utils/infocache.h
@@ -93,6 +93,7 @@ public:
     FileInfoPointer getCacheInfo(const QUrl &url);
 Q_SIGNALS:
     void cacheFileInfo(const QUrl url, const FileInfoPointer info);
+    void removeCacheFileInfo(const QList<QUrl> &urls);
 
 private:
     explicit InfoCacheController(QObject *parent = nullptr);

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -64,6 +64,7 @@ FileInfoPointer LocalDirIteratorPrivate::fileInfo()
     infoTrans->setExtendedAttributes(ExtInfoType::kFileCdRomDevice, isCdRomDevice);
 
     if (infoTrans) {
+        emit InfoCacheController::instance().removeCacheFileInfo({url});
         emit InfoCacheController::instance().cacheFileInfo(url, infoTrans);
     } else {
         qWarning() << "info is nullptr url = " << url;

--- a/src/dfm-base/utils/infocache.cpp
+++ b/src/dfm-base/utils/infocache.cpp
@@ -409,6 +409,7 @@ void InfoCacheController::init()
     removeTimer->moveToThread(qApp->thread());
     connect(removeTimer.data(), &QTimer::timeout, worker.data(), &CacheWorker::dealRemoveInfo, Qt::QueuedConnection);
     connect(this, &InfoCacheController::cacheFileInfo, worker.data(), &CacheWorker::cacheInfo, Qt::QueuedConnection);
+    connect(this, &InfoCacheController::removeCacheFileInfo, worker.data(), &CacheWorker::removeCaches, Qt::QueuedConnection);
     connect(&InfoCache::instance(), &InfoCache::cacheRemoveCaches, worker.data(), &CacheWorker::removeCaches, Qt::QueuedConnection);
     connect(&InfoCache::instance(), &InfoCache::cacheRemoveInfosTime, worker.data(), &CacheWorker::removeInfosTime, Qt::QueuedConnection);
     connect(&InfoCache::instance(), &InfoCache::cacheDisconnectWatcher, worker.data(), &CacheWorker::disconnectWatcher, Qt::QueuedConnection);


### PR DESCRIPTION

The asyncfileinfo used for peripheral interface drawing and the asyncfileinfo used for right-click menu are not the same instance. So asyncfileinfo did not complete the query, and both reading and writing were errors. After the query is completed, it will display correctly. Add and remove cache interfaces, and first remove the information in the current cache interface during iteration.

Log: The probability of right clicking to copy, cut, rename, or delete a file is grayed out and cannot be clicked
Bug: https://pms.uniontech.com/bug-view-197911.html