### PR TITLE
fix: [workspace]view paint busy

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -76,10 +76,9 @@ bool FileViewHelper::isTransparent(const QModelIndex &index) const
     //  cutting
     if (ClipBoard::instance()->clipboardAction() == ClipBoard::kCutAction) {
         QUrl localUrl = file->urlOf(UrlInfoType::kUrl);
-        QList<QUrl> urls {};
-        bool ok = UniversalUtils::urlsTransform({ localUrl }, &urls);
-        if (ok && !urls.isEmpty())
-            localUrl = urls.first();
+        if (file->canAttributes(CanableInfoType::kCanRedirectionFileUrl))
+            localUrl = file->urlOf(UrlInfoType::kRedirectedFileUrl);
+
         if (ClipBoard::instance()->clipboardFileUrlList().contains(localUrl))
             return true;
 

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
@@ -10,6 +10,7 @@
 #include <dfm-framework/dpf.h>
 
 #include <QDebug>
+#include <QRegularExpression>
 
 using namespace dfmplugin_smbbrowser;
 DFMBASE_USE_NAMESPACE


### PR DESCRIPTION
Can not create fileinfo when painting view item because it may stuck in an endless loop.

Log: view optimization.
Bug: https://pms.uniontech.com/bug-view-198447.html