### PR TITLE
fix: Unable to drag and drop MTP mounted files to the trash view area

### DIFF
--- a/src/dfm-base/mimedata/dfmmimedata.h
+++ b/src/dfm-base/mimedata/dfmmimedata.h
@@ -34,6 +34,7 @@ public:
     QList<QUrl> urls() const;
 
     bool canTrash() const;
+    bool canDelete() const;
 
     void setAttritube(const QString &name, const QVariant &value);
     QVariant attritube(const QString &name, const QVariant &defaultValue = {}) const;

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
@@ -533,7 +533,7 @@ bool DragDropOper::checkTargetEnable(const QUrl &targetUrl)
         return true;
 
     if (FileUtils::isTrashDesktopFile(targetUrl))
-        return dfmmimeData.canTrash();
+        return dfmmimeData.canTrash() || dfmmimeData.canDelete();
 
     return true;
 }

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -993,7 +993,7 @@ void CollectionViewPrivate::updateDFMMimeData(QDropEvent *event)
     dfmmimeData.clear();
     const QMimeData *data = event->mimeData();
 
-    if (data->hasFormat(DFMGLOBAL_NAMESPACE::Mime::kDFMMimeDataKey))
+    if (data && data->hasFormat(DFMGLOBAL_NAMESPACE::Mime::kDFMMimeDataKey))
         dfmmimeData = DFMMimeData::fromByteArray(data->data(DFMGLOBAL_NAMESPACE::Mime::kDFMMimeDataKey));
 }
 
@@ -1003,7 +1003,7 @@ bool CollectionViewPrivate::checkTargetEnable(const QUrl &targetUrl)
         return true;
 
     if (FileUtils::isTrashDesktopFile(targetUrl))
-        return dfmmimeData.canTrash();
+        return dfmmimeData.canTrash() || dfmmimeData.canDelete();
 
     return true;
 }

--- a/src/plugins/filemanager/core/dfmplugin-recent/files/recentfileinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/files/recentfileinfo.cpp
@@ -52,6 +52,7 @@ bool RecentFileInfo::isAttributes(const OptInfoType type) const
 bool RecentFileInfo::canAttributes(const CanableInfoType type) const
 {
     switch (type) {
+    case FileCanType::kCanDelete:
     case FileCanType::kCanTrash:
     case FileCanType::kCanRename:
         return false;

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -75,9 +75,9 @@ void SideBarViewPrivate::notifyOrderChanged()
 void SideBarViewPrivate::updateDFMMimeData(const QDropEvent *event)
 {
     dfmMimeData.clear();
-    auto data = event->mimeData();
+    const QMimeData *data = event->mimeData();
 
-    if (data->hasFormat(DFMGLOBAL_NAMESPACE::Mime::kDFMMimeDataKey))
+    if (data && data->hasFormat(DFMGLOBAL_NAMESPACE::Mime::kDFMMimeDataKey))
         dfmMimeData = DFMMimeData::fromByteArray(data->data(DFMGLOBAL_NAMESPACE::Mime::kDFMMimeDataKey));
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -40,16 +40,9 @@ bool TrashFileHelper::cutFile(const quint64 windowId, const QList<QUrl> sources,
     if (sources.isEmpty())
         return true;
 
-    const QUrl &urlSource = sources.first();
-    if (Q_UNLIKELY(!DFMBASE_NAMESPACE::FileUtils::fileCanTrash(urlSource))) {
-        dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kDeleteFiles,
-                                     windowId,
-                                     sources, flags, nullptr);
-    } else {
-        dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kMoveToTrash,
-                                     windowId,
-                                     sources, flags, nullptr);
-    }
+    dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kMoveToTrash,
+                                 windowId,
+                                 sources, flags, nullptr);
     return true;
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -374,7 +374,7 @@ bool DragDropHelper::checkTargetEnable(const QUrl &targetUrl) const
         return true;
 
     if (FileUtils::isTrashFile(targetUrl) || FileUtils::isTrashDesktopFile(targetUrl))
-        return dfmmimeData.canTrash();
+        return dfmmimeData.canTrash() || dfmmimeData.canDelete();
 
     return true;
 }


### PR DESCRIPTION
1.The MTP file attribute canTrah is false, but canDelete is true
2.Optimize the condition for dragging files to trash

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-198417.html
