### PR TITLE
fix: [fileinfo/tag]display issue in desktop

### DIFF
--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -276,12 +276,11 @@ QVariant TagManager::getTagsByUrls(const QList<QUrl> &filePaths, bool same) cons
 
     QStringList paths;
     for (const auto &temp : filePaths) {
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(temp);
-        if (info) {
-            paths.append(temp.path());
-        } else {
-            paths.append(UrlRoute::urlToLocalPath(temp));
-        }
+        QString path = UrlRoute::urlToPath(temp);
+        if (path.isEmpty())
+            path = UrlRoute::urlToLocalPath(temp);
+
+        paths.append(path);
     }
 
     return same ? TagProxyHandleIns->getSameTagsOfDiffFiles(paths) : TagProxyHandleIns->getTagsThroughFile(paths);


### PR DESCRIPTION
Can't create file info in the process that remove files, because it will cache a invalid file info.

Log: fix display issue
Bug: https://pms.uniontech.com/bug-view-198159.html