### PR TITLE
修复断网时唤起 dock 插件导致的 dock 僵死问题

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/device/dattachedprotocoldevice.h
+++ b/src/external/dde-dock-plugins/disk-mount/device/dattachedprotocoldevice.h
@@ -33,9 +33,15 @@ public:
 
 protected:
     void query() override;
+    bool checkNetwork();
+    bool parseHostAndPort(QString &host, QString &port);
 
 private:
     QSharedPointer<dfmmount::DProtocolDevice> device;
+    quint64 lastNetCheck = 0;
+    quint64 latestTotalSize = 0;
+    quint64 latestFreeSize = 0;
+    bool isNetworkDev = false;
 };
 
 #endif   // DATTACHEDPROTOCOLDEVICE_H


### PR DESCRIPTION
mount sftp and disconnect the network, trigger the dock plugin makes
dock freeze.
freeze at usage query, do query after network check successed.

Log: fix issue about dock freezing.

Bug: https://pms.uniontech.com/bug-view-198549.html
