### PR TITLE
fix: The speed of cutting files from the trash to USB drive is very slow

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -152,6 +152,7 @@ bool DoCutFilesWorker::doCutFile(const FileInfoPointer &fromInfo, const FileInfo
     if (doRenameFile(fromInfo, targetPathInfo, toInfo, &ok) || ok) {
         workData->currentWriteSize += fromInfo->size();
         if (fromInfo->isAttributes(OptInfoType::kIsFile)) {
+            workData->blockRenameWriteSize += fromInfo->size();
             workData->currentWriteSize += (fromInfo->size() > 0 ? fromInfo->size() : FileUtils::getMemoryPageSize());
             if (fromInfo->size() <= 0)
                 workData->zeroOrlinkOrDirWriteSize += FileUtils::getMemoryPageSize();


### PR DESCRIPTION
At the same time, cutting was performed on the USB drive and the rename operation was performed, but no files were written. The statistics progress of how many sectors were read and written to the file on the USB flash drive, so the statistics progress was used incorrectly. Write size when adding rename, count reprocessing

Log: The speed of cutting files from the trash to USB drive is very slow
Bug: https://pms.uniontech.com/bug-view-198449.html