### PR TITLE
fix:[info/cache] After restoration, the icons on the desktop are displayed as jagged icons

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -228,15 +228,17 @@ public:
 
         QSharedPointer<FileInfo> info = InfoCacheController::instance().getCacheInfo(url);
         if (!info) {
-            info = instance().SchemeFactory<FileInfo>::create(scheme(url), url, errorString);
-
-            if (info) {
+            auto tarScheme = scheme(url);
+            info = instance().SchemeFactory<FileInfo>::create(tarScheme, url, errorString);
+            if (info && tarScheme == Global::Scheme::kAsyncFile) {
                 info->refresh();
                 emit InfoCacheController::instance().cacheFileInfo(url, info);
-            } else {
-                qWarning() << "info is nullptr url = " << url;
             }
         }
+
+        if (!info)
+            qWarning() << "info is nullptr url = " << url;
+
         return qSharedPointerDynamicCast<T>(info);
     }
 


### PR DESCRIPTION
This issue occurs because when deleting a file, it is incorrect to determine whether the desktopfileinfo is correct, but at this time the file's fileifno is cached. When creating a fileinfo, the local file is not cached (which does not affect any performance).

Log: After restoration, the icons on the desktop are displayed as jagged icons
Bug: https://pms.uniontech.com/bug-view-198159.html