### PR TITLE
fix: xdg-dirs can drag to desktop if current user is root

### DIFF
--- a/src/dfm-base/utils/sysinfoutils.cpp
+++ b/src/dfm-base/utils/sysinfoutils.cpp
@@ -9,6 +9,7 @@
 
 #include <QDBusInterface>
 #include <QDBusReply>
+#include <QDir>
 
 #include <unistd.h>
 
@@ -20,6 +21,13 @@ QString SysInfoUtils::getUser()
     static QString user = QString::fromLocal8Bit(qgetenv("USER"));
 
     return user;
+}
+
+QStringList SysInfoUtils::getAllUsersOfHome()
+{
+    QDir homeDir { "/home" };
+    static QStringList subDirs { homeDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot) };
+    return subDirs;
 }
 
 QString SysInfoUtils::getHostName()

--- a/src/dfm-base/utils/sysinfoutils.h
+++ b/src/dfm-base/utils/sysinfoutils.h
@@ -17,6 +17,7 @@ class SysInfoUtils
 
 public:
     static QString getUser();
+    static QStringList getAllUsersOfHome();
     static QString getHostName();
     static int getUserId();
 

--- a/src/dfm-base/utils/systempathutil.cpp
+++ b/src/dfm-base/utils/systempathutil.cpp
@@ -21,7 +21,7 @@ SystemPathUtil *SystemPathUtil::instance()
     return &util;
 }
 
-QString SystemPathUtil::systemPath(QString key)
+QString SystemPathUtil::systemPath(const QString &key)
 {
     if (systemPathsMap.isEmpty())
         initialize();
@@ -34,7 +34,15 @@ QString SystemPathUtil::systemPath(QString key)
     return path;
 }
 
-QString SystemPathUtil::systemPathDisplayName(QString key) const
+QString SystemPathUtil::systemPathOfUser(const QString &key, const QString &user) const
+{
+    if (xdgDirs.contains(key))
+        return "/home/" + user + "/" + key;
+
+    return {};
+}
+
+QString SystemPathUtil::systemPathDisplayName(const QString &key) const
 {
     if (systemPathDisplayNamesMap.contains(key))
         return systemPathDisplayNamesMap.value(key);
@@ -56,7 +64,7 @@ QString SystemPathUtil::systemPathDisplayNameByPath(QString path)
     return QString();
 }
 
-QString SystemPathUtil::systemPathIconName(QString key) const
+QString SystemPathUtil::systemPathIconName(const QString &key) const
 {
     if (systemPathIconNamesMap.contains(key))
         return systemPathIconNamesMap.value(key);

--- a/src/dfm-base/utils/systempathutil.h
+++ b/src/dfm-base/utils/systempathutil.h
@@ -21,10 +21,11 @@ class SystemPathUtil final : public QObject
 public:
     static SystemPathUtil *instance();
 
-    QString systemPath(QString key);
-    QString systemPathDisplayName(QString key) const;
+    QString systemPath(const QString &key);
+    QString systemPathOfUser(const QString &key, const QString &user) const;
+    QString systemPathDisplayName(const QString &key) const;
     QString systemPathDisplayNameByPath(QString path);
-    QString systemPathIconName(QString key) const;
+    QString systemPathIconName(const QString &key) const;
     QString systemPathIconNameByPath(QString path);
     bool isSystemPath(QString path) const;
     bool checkContainsSystemPath(const QList<QUrl> &urlList);


### PR DESCRIPTION
`FileUtils::isContainProhibitPath` only check xdg-dirs of current user. Travel all users if current user is root.

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-198407.html