### PR TITLE
fix: [workspace] U disk not have thumbnail

### DIFF
--- a/src/dfm-base/utils/thumbnailprovider.cpp
+++ b/src/dfm-base/utils/thumbnailprovider.cpp
@@ -7,12 +7,13 @@
 
 #include <dfm-base/mimetype/dmimedatabase.h>
 #include <dfm-base/mimetype/mimetypedisplaymanager.h>
-#include <dfm-base/base/standardpaths.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/file/local/localfilehandler.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/schemefactory.h>
-#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/base/standardpaths.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
 
 #include <dfm-io/dfmio_utils.h>
 
@@ -240,6 +241,8 @@ bool ThumbnailProvider::thumbnailEnable(const QUrl &url) const
         return DConfigManager::instance()->value("org.deepin.dde.file-manager.preview", "mtpThumbnailEnable", true).toBool();
     } else if (FileUtils::isGvfsFile(url)) {
         return Application::instance()->genericAttribute(Application::kShowThunmbnailInRemote).toBool();
+    } else if (DevProxyMng->isFileOfExternalBlockMounts(url.path())) {
+        return true;
     }
 
     return false;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
@@ -85,15 +85,14 @@ void WorkspaceWidget::setCurrentUrl(const QUrl &url)
     if (!views.contains(scheme)) {
         QString error;
         ViewPtr fileView = ViewFactory::create<AbstractBaseView>(url, &error);
-#ifdef ENABLE_TESTING
-        dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
-                             qobject_cast<QWidget *>(fileView->widget()), AcName::kAcFileView);
-#endif
-
         if (!fileView) {
             qWarning() << "Cannot create view for " << url << "Reason: " << error;
             return;
         }
+#ifdef ENABLE_TESTING
+        dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
+                             qobject_cast<QWidget *>(fileView->widget()), AcName::kAcFileView);
+#endif
 
         views.insert(url.scheme(), fileView);
         viewStackLayout->addWidget(fileView->widget());


### PR DESCRIPTION
add logic code, let U disk has thumbnail.
(the old code thinks that the U disk belongs to the local device, but the new code do not thinks this. so add the new logic to show thumbnail)

Log: solved problem of thumbnail
Bug: https://pms.uniontech.com/bug-view-198599.html