### PR TITLE
fix: [trash/cut] Cut file, file name error

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -164,6 +164,9 @@ bool DoCutFilesWorker::doCutFile(const FileInfoPointer &fromInfo, const FileInfo
             if (sizeInfo->totalSize <= 0)
                 workData->zeroOrlinkOrDirWriteSize += workData->dirSize;
         }
+        // 执行trash的清理
+        if (FileUtils::isTrashFile(fromInfo->fileUrl()))
+            removeTrashInfo(fromInfo);
         return true;
     }
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -534,6 +534,8 @@ void AbstractWorker::saveOperations()
                 break;
             case AbstractJobHandler::JobType::kCutType:
                 operatorType = GlobalEventType::kCutFile;
+                if (!sourceUrls.isEmpty() && FileUtils::isTrashFile(sourceUrls.first()))
+                    operatorType = GlobalEventType::kMoveToTrash;
                 targetUrl = UrlRoute::urlParent(completeSourceFiles.first());
                 break;
             case AbstractJobHandler::JobType::kMoveToTrashType:

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -681,6 +681,19 @@ void FileOperateBaseWorker::initCopyWay()
     copyTid = (countWriteType == CountWriteSizeType::kTidType) ? syscall(SYS_gettid) : -1;
 }
 
+void FileOperateBaseWorker::removeTrashInfo(const FileInfoPointer &fromInfo)
+{
+    auto parentPath = fromInfo->urlOf(UrlInfoType::kParentUrl).path();
+    if (!parentPath.endsWith("files"))
+        return;
+    auto fileName = fromInfo->nameOf(NameInfoType::kFileName);
+    auto trashInfoUrl = QUrl::fromLocalFile(parentPath.replace("files", "info/") + fileName + ".trashinfo");
+    if (!localFileHandler)
+        return;
+    qDebug() << "delete trash file info. trashInfoUrl = " << trashInfoUrl;
+    localFileHandler->deleteFile(trashInfoUrl);
+}
+
 void FileOperateBaseWorker::setSkipValue(bool *skip, AbstractJobHandler::SupportAction action)
 {
     if (skip)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -82,6 +82,7 @@ public:
 protected:
     void waitThreadPoolOver();
     void initCopyWay();
+    void removeTrashInfo(const FileInfoPointer &fromInfo);
 
 private:
     void setSkipValue(bool *skip, AbstractJobHandler::SupportAction action);


### PR DESCRIPTION
Cutting from the recycle bin to another directory did not clean up trashinfo. Modify and clean trashinfo, keep the operation movetotrash

Log: Cut file, file name error
Bug: https://pms.uniontech.com/bug-view-198727.html