### PR TITLE
fix: [view] After the ftp is unmounted, you can still go back to the ftp mount directory by back button

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/historystack.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/historystack.h
@@ -27,7 +27,14 @@ public:
     void removeUrl(const QUrl &url);
     int currentIndex();
 
+    bool backIsExist();
+    bool forwardIsExist();
+
     // TODO(zhangs): check network exists
+
+private:
+    bool needCheckExist(const QUrl &url);
+    bool checkPathIsExist(const QUrl &url);
 
 private:
     QList<QUrl> list;

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/navwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/navwidget.cpp
@@ -25,13 +25,13 @@ void NavWidgetPrivate::updateBackForwardButtonsState()
         navBackButton->setEnabled(false);
         navForwardButton->setEnabled(false);
     } else {
-        if (curNavStack->isFirst()) {
+        if (curNavStack->isFirst() || !curNavStack->backIsExist()) {
             navBackButton->setEnabled(false);
         } else {
             navBackButton->setEnabled(true);
         }
 
-        if (curNavStack->isLast()) {
+        if (curNavStack->isLast() || !curNavStack->forwardIsExist()) {
             navForwardButton->setEnabled(false);
         } else {
             navForwardButton->setEnabled(true);


### PR DESCRIPTION
Determine the validity of the target path when updating the forward and back buttons

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-198725.html
