### PR TITLE
fix: [device] Cannot delete files in ext4 format USB flash drive from the bottom

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -307,7 +307,7 @@ void DeviceProxyManagerPrivate::disconnCurrentConnections()
 void DeviceProxyManagerPrivate::addMounts(const QString &id, const QString &mpt)
 {
     QString p = mpt.endsWith("/") ? mpt : mpt + "/";
-    if (DeviceUtils::isMountPointOfDlnfs(p))
+    if (!id.startsWith(kBlockDeviceIdPrefix) && DeviceUtils::isMountPointOfDlnfs(p))
         return;
 
     if (id.startsWith(kBlockDeviceIdPrefix)) {


### PR DESCRIPTION
The unplugged USB drive was not added to the block device, resulting in a judgment failure. Modify the judgment of adding devices after receiving the mount signal

Log: Cannot delete files in ext4 format USB flash drive from the bottom
Bug: https://pms.uniontech.com/bug-view-198783.html