### PR TITLE
修复拔插光驱后，光驱不显示的问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -134,7 +134,7 @@ bool BlockEntryFileEntity::exists() const
     }
 
     quint64 blkSize = { qvariant_cast<quint64>(datas.value(DeviceProperty::kSizeTotal)) };
-    if (blkSize < 1024) {
+    if (blkSize < 1024 && !opticalDrive && !hasFileSystem) {
         qInfo() << "block device is ignored cause tiny size: " << blkSize << id;
         return false;
     }


### PR DESCRIPTION
optical drive is incorrectly ignored by its tiny size.
only ignore tiny size blocks which do not have filesystem and is not
optical drive.

Log: fix issue about optical drive missing.
