### PR TITLE
fix: [clipboard] The urls in the clipboard was not removed when the files were deleted

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -284,6 +284,26 @@ ClipBoard::ClipboardAction ClipBoard::clipboardAction() const
 {
     return GlobalData::clipboardAction;
 }
+
+void ClipBoard::removeUrls(const QList<QUrl> &urls)
+{
+    QList<QUrl> clipboardUrls = GlobalData::clipboardFileUrls;
+    ClipBoard::ClipboardAction action = GlobalData::clipboardAction;
+
+    if (!clipboardUrls.isEmpty() && action != ClipBoard::kUnknownAction) {
+        bool hasRemoved = false;
+        for (int i = 0; i < urls.size() && !clipboardUrls.isEmpty(); ++i) {
+            int cnt = clipboardUrls.removeAll(urls[i]);
+            if (!hasRemoved && cnt != 0)
+                hasRemoved = true;
+        }
+
+        if (clipboardUrls.isEmpty())
+            clearClipboard();
+        else if (hasRemoved)
+            setUrlsToClipboard(clipboardUrls, action);
+    }
+}
 /*!
  * \brief ClipBoard::getUrlsByX11 Use X11 to read URLs downloaded
  * remotely from the clipboard

--- a/src/dfm-base/utils/clipboard.h
+++ b/src/dfm-base/utils/clipboard.h
@@ -39,6 +39,7 @@ public:
     QList<QUrl> clipboardFileUrlList() const;
     QList<quint64> clipboardFileInodeList() const;
     ClipboardAction clipboardAction() const;
+    void removeUrls(const QList<QUrl> &urls);
 
 private:
     explicit ClipBoard(QObject *parent = nullptr);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
@@ -120,7 +120,7 @@ bool DoCleanTrashFilesWorker::cleanAllTrashFiles()
             return false;
 
         cleanTrashFilesCount++;
-        completeTargetFiles.append(fileInfo->urlOf(UrlInfoType::kUrl));
+        completeTargetFiles.append(fileInfo->urlOf(UrlInfoType::kRedirectedFileUrl));
         ++it;
     }
     return true;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventhandler.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventhandler.cpp
@@ -5,6 +5,7 @@
 #include "fileoperationseventhandler.h"
 
 #include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/utils/clipboard.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -45,6 +46,24 @@ void FileOperationsEventHandler::publishJobResultEvent(AbstractJobHandler::JobTy
         break;
     default:
         qWarning() << "Invalid Job Type";
+    }
+}
+
+void FileOperationsEventHandler::removeUrlsInClipboard(AbstractJobHandler::JobType jobType, const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls, bool ok)
+{
+    if (!ok)
+        return;
+
+    switch (jobType) {
+    case AbstractJobHandler::JobType::kDeleteType:
+    case AbstractJobHandler::JobType::kMoveToTrashType:
+        ClipBoard::instance()->removeUrls(srcUrls);
+        break;
+    case AbstractJobHandler::JobType::kCleanTrashType:
+        ClipBoard::instance()->removeUrls(destUrls);
+        break;
+    default:
+        break;
     }
 }
 
@@ -89,4 +108,5 @@ void FileOperationsEventHandler::handleFinishedNotify(const JobInfoPointer &jobI
     auto customInfos = jobInfo->value(AbstractJobHandler::NotifyInfoKey::kCompleteCustomInfosKey).toList();
     auto jobType = jobInfo->value(AbstractJobHandler::NotifyInfoKey::kJobtypeKey).value<DFMBASE_NAMESPACE::AbstractJobHandler::JobType>();
     publishJobResultEvent(jobType, srcUrls, destUrls, customInfos, *ok, *errMsg);
+    removeUrlsInClipboard(jobType, srcUrls, destUrls, *ok);
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventhandler.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventhandler.h
@@ -33,6 +33,10 @@ private:
                                const QList<QUrl> &destUrls,
                                const QVariantList &customInfos,
                                bool ok, const QString &errMsg);
+    void removeUrlsInClipboard(DFMBASE_NAMESPACE::AbstractJobHandler::JobType jobType,
+                               const QList<QUrl> &srcUrls,
+                               const QList<QUrl> &destUrls,
+                               bool ok);
 };
 
 DPFILEOPERATIONS_END_NAMESPACE

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -150,6 +150,7 @@ JobHandlePointer TrashFileEventReceiver::doCleanTrash(const quint64 windowId, co
         urls.push_back(FileUtils::trashRootUrl());
 
     JobHandlePointer handle = copyMoveJob->cleanTrash(urls);
+    FileOperationsEventHandler::instance()->handleJobResult(AbstractJobHandler::JobType::kCleanTrashType, handle);
     if (handleCallback)
         handleCallback(handle);
     return handle;
@@ -203,8 +204,7 @@ void TrashFileEventReceiver::handleOperationRestoreFromTrash(const quint64 windo
 void TrashFileEventReceiver::handleOperationCleanTrash(const quint64 windowId, const QList<QUrl> sources, const AbstractJobHandler::DeleteDialogNoticeType deleteNoticeType,
                                                        DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback)
 {
-    auto handle = doCleanTrash(windowId, sources, deleteNoticeType, handleCallback);
-    FileOperationsEventHandler::instance()->handleJobResult(AbstractJobHandler::JobType::kCleanTrashType, handle);
+    doCleanTrash(windowId, sources, deleteNoticeType, handleCallback);
 }
 
 void TrashFileEventReceiver::handleOperationMoveToTrash(const quint64 windowId,


### PR DESCRIPTION
When performing delete, move to trash, or empty trash operations, the corresponding records in the clipboard need to be deleted.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-198775.html
