### PR TITLE
fix: [trash/cut]Cut file, file name incorrect

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
@@ -36,7 +36,7 @@ protected:
 
     bool cutFiles();
     bool doCutFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo);
-    bool doRenameFile(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetPathInfo, FileInfoPointer &toInfo, bool *ok);
+    bool doRenameFile(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetPathInfo, FileInfoPointer &toInfo, const QString fileName, bool *ok);
     bool renameFileByHandler(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetInfo);
 
     void emitCompleteFilesUpdatedNotify(const qint64 &writCount);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -82,7 +82,9 @@ public:
 protected:
     void waitThreadPoolOver();
     void initCopyWay();
-    void removeTrashInfo(const FileInfoPointer &fromInfo);
+    QUrl trashInfo(const FileInfoPointer &fromInfo);
+    QString fileOriginName(const QUrl &trashInfoUrl);
+    void removeTrashInfo(const QUrl &trashInfoUrl);
 
 private:
     void setSkipValue(bool *skip, AbstractJobHandler::SupportAction action);


### PR DESCRIPTION
Delete the same file name in the same directory to the recycle bin, and rename the source file with the name '. n'. I didn't get the source file name after cutting it out. Modify and read the file name in trashinfo for cutting.

Log: Cut file, file name incorrect
Bug: https://pms.uniontech.com/bug-view-198935.html