### PR TITLE
fix: [debian] libdde-file-manager Publication type error

### DIFF
--- a/debian/libdde-file-manager.install
+++ b/debian/libdde-file-manager.install
@@ -1,5 +1,5 @@
-usr/lib/*/libdfm-base.so.*
-usr/lib/*/libdfm-framework.so.*
+usr/lib/*/libdfm-base.so*
+usr/lib/*/libdfm-framework.so*
 usr/lib/*/dde-file-manager/plugins/common-core/*.so
 usr/lib/*/dde-file-manager/tools/*
 usr/share/dde-file-manager/templates/*


### PR DESCRIPTION
Using so. * resulted in incomplete type, changed to so*

Log: as des
Bug: https://pms.uniontech.com/bug-view-198893.html