### PR TITLE
fix: [workspace]file disappeared that transfer to smb dir.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -822,11 +822,9 @@ void FileView::updateVisibleIndex(const QModelIndex &index)
         return;
 
     if (!info->exists()) {
-        const auto rootInfo = FileDataManager::instance()->fetchRoot(rootUrl());
-        if (!rootInfo)
-            return;
-
-        rootInfo->doFileDeleted(info->urlOf(FileInfo::FileUrlInfoType::kUrl));
+        // some time can't receive watcher event when file be deleted.
+        // call updateFile func to filter the file which is no existed.
+        model()->updateFile(info->urlOf(FileInfo::FileUrlInfoType::kUrl));
     } else {
         model()->setIndexActive(index);
     }


### PR DESCRIPTION
Async file can't get right property at first time and be removed from model. So just filter the file when the exist() return false.

Log: fix display issue
Bug: https://pms.uniontech.com/bug-view-197871.html