### PR TITLE
fix: [trash/property]The icon in the right-click attribute of the trash file displays incorrectly

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.h
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.h
@@ -8,6 +8,8 @@
 #include "dfmplugin_propertydialog_global.h"
 #include "editstackedwidget.h"
 
+#include <dfm-base/interfaces/fileinfo.h>
+
 #include <DDialog>
 #include <DCheckBox>
 #include <DPlatformWindowHandle>
@@ -44,6 +46,7 @@ public slots:
     void addExtendedControl(QWidget *widget);
     void closeDialog();
     void onSelectUrlRenamed(const QUrl &url);
+    void onFileInfoUpdated(const QUrl &url, const bool isLinkOrg);
 
 signals:
     void closed(const QUrl url);
@@ -66,7 +69,7 @@ private:
     QScrollArea *scrollArea { nullptr };
     BasicWidget *basicWidget { nullptr };
     PermissionManagerWidget *permissionManagerWidget { nullptr };
-    DTK_WIDGET_NAMESPACE::DLabel *fileIcon { nullptr };
+    QLabel *fileIcon {nullptr};
     EditStackedWidget *editStackWidget { nullptr };
     QFrame *textShowFrame { nullptr };
     DTK_WIDGET_NAMESPACE::DIconButton *editButton { nullptr };
@@ -74,6 +77,7 @@ private:
     QUrl currentFileUrl {};
     int extendedHeight { 0 };
     DTK_WIDGET_NAMESPACE::DPlatformWindowHandle *platformWindowHandle { nullptr };
+    FileInfoPointer currentInfo{ nullptr };
 };
 }
 #endif   // FILEPROPERTYVIEW_H


### PR DESCRIPTION
The fileinfo used in the recycle bin does not use caching, and the proxy fileinfo for files deleted using SMB is asynchronous, as the corresponding file attributes have not been obtained yet. Modify and add the slot function, and the fileinfo update is completed before updating the icon display.

Log: The icon in the right-click attribute of the trash file displays incorrectly
Bug: https://pms.uniontech.com/bug-view-198943.html