### PR TITLE
fix: [view] After cutting and replacing the files, the files are not selected

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -280,8 +280,6 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const FileInfoPointer &fromInfo, c
     if (!toInfo)
         return false;
 
-    bool oldExist = toInfo->exists();
-
     if (fromInfo->isAttributes(OptInfoType::kIsSymLink)) {
         ok = createSystemLink(fromInfo, toInfo, workData->jobFlags.testFlag(AbstractJobHandler::JobFlag::kCopyFollowSymlink), true, skip);
         if (ok) {
@@ -305,7 +303,7 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const FileInfoPointer &fromInfo, c
         FileUtils::removeCopyingFileUrl(url);
     }
 
-    if (!oldExist && toInfo->exists() && targetInfo == targetPathInfo) {
+    if (ok && toInfo->exists() && targetInfo == targetPathInfo) {
         completeSourceFiles.append(fromInfo->urlOf(UrlInfoType::kUrl));
         completeTargetFiles.append(toInfo->urlOf(UrlInfoType::kUrl));
     }


### PR DESCRIPTION
In this scenario, the copy and deletion logic is executed, but the result is not recorded

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-198683.html
