### PR TITLE
fix: [desktop] desktop icon show error in deepin-system-monitor.

### DIFF
--- a/src/apps/dde-desktop/main.cpp
+++ b/src/apps/dde-desktop/main.cpp
@@ -182,6 +182,7 @@ int main(int argc, char *argv[])
     a.setApplicationVersion(BUILD_VERSION);
     a.setAttribute(Qt::AA_UseHighDpiPixmaps);
     a.setProductIcon(QIcon::fromTheme("deepin-toggle-desktop"));
+    a.setWindowIcon(QIcon::fromTheme("deepin-toggle-desktop"));
     {
         // load translation
         QString appName = a.applicationName();


### PR DESCRIPTION
In agreement with the deepin-system-monitor team, desktop application setWindowIcon so that the monitor can reach the icon and display it.

Log: solved problem in desktop
Bug: https://pms.uniontech.com/bug-view-198875.html