### PR TITLE
fix: [computer] i18n issue.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/appentryfileentity.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/appentryfileentity.h
@@ -21,6 +21,7 @@ inline constexpr char kExecuteCommand[] { "execute_command" };
 
 class AppEntryFileEntity : public DFMBASE_NAMESPACE::AbstractEntryFileEntity
 {
+    Q_OBJECT
 public:
     explicit AppEntryFileEntity(const QUrl &url);
 


### PR DESCRIPTION
"Double click to open it" is not translated, Q_OBJECT macro is not
declared in AppEntryFileEntity class.

Log: fix i18n issue.

Bug: https://pms.uniontech.com/bug-view-198837.html
