### PR TITLE
fix: [io/workspace]Rename unsuccessful

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -178,8 +178,8 @@ bool LocalFileHandler::renameFile(const QUrl &url, const QUrl &newUrl, const boo
         const QUrl &fromParentUrl = UrlRoute::urlParent(url);
         const QUrl &toParentUrl = UrlRoute::urlParent(newUrl);
         if (fromParentUrl == toParentUrl) {
-            FileInfoPointer toInfo = InfoFactory::create<FileInfo>(newUrl);
-            const QString &newName = toInfo->nameOf(NameInfoType::kFileName);
+            // if fileinfo or other operation query info in mtp device, file will rename false. mtp device is busy
+            const QString &newName = newUrl.fileName();
             QSharedPointer<DFMIO::DOperator> oper { new DFMIO::DOperator(url) };
             if (!oper) {
                 qWarning() << "create operator failed, url: " << url;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -699,6 +699,8 @@ QString FileOperateBaseWorker::fileOriginName(const QUrl &trashInfoUrl)
         return QString();
     }
     auto data = file.readAll().simplified().split(' ');
+    // trash info file readAll() = "[Trash Info] Path=%E6%96%B0%E5%BB%BAWord%E6%96%87%E6%A1%A3.doc DeletionDate=2023-05-05T11:19:06";
+    // has three char " ", so data has 4 item, the 3th is the "Path=%E6%96%B0%E5%BB%BAWord%E6%96%87%E6%A1%A3.doc"
     if (data.size() <= 3) {
         qWarning() << "reade trash file info err,trashInfoUrl = " << trashInfoUrl;
         return QString();

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -772,7 +772,8 @@ bool FileOperationsEventReceiver::handleOperationRenameFile(const quint64 window
         }
     }
 
-    FileInfoPointer toFileInfo = InfoFactory::create<FileInfo>(newUrl);
+    // async fileinfo need wait file quer over todo:: liyigang
+    FileInfoPointer toFileInfo = InfoFactory::create<FileInfo>(newUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (toFileInfo && toFileInfo->exists()) {
         dialogManager->showRenameNameSameErrorDialog(toFileInfo->nameOf(NameInfoType::kFileName));
         return false;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -42,8 +42,6 @@ FileViewModel::FileViewModel(QAbstractItemView *parent)
     currentKey = QString::number(quintptr(this), 16);
     itemRootData = new FileItemData(dirRootUrl);
     connect(&FileInfoHelper::instance(), &FileInfoHelper::createThumbnailFinished, this, &FileViewModel::onFileThumbUpdated);
-    connect(&FileInfoHelper::instance(), &FileInfoHelper::fileRefreshFinished, this,
-            &FileViewModel::onFileLinkOrgUpdated, Qt::QueuedConnection);
 }
 
 FileViewModel::~FileViewModel()
@@ -604,26 +602,7 @@ void FileViewModel::onFileThumbUpdated(const QUrl &url)
 
     auto view = qobject_cast<FileView *>(QObject::parent());
     if (view) {
-        view->update(view->visualRect(updateIndex));
-    } else {
-        Q_EMIT dataChanged(updateIndex, updateIndex);
-    }
-}
-
-void FileViewModel::onFileLinkOrgUpdated(const QUrl &url, const bool isLinkOrg)
-{
-    auto updateIndex = getIndexByUrl(url);
-    if (!updateIndex.isValid())
-        return;
-    if (isLinkOrg) {
-        auto info = fileInfo(updateIndex);
-        if (info)
-            info->customData(Global::ItemRoles::kItemFileRefreshIcon);
-    }
-
-    auto view = qobject_cast<FileView *>(QObject::parent());
-    if (view) {
-        view->update(view->visualRect(updateIndex));
+        view->update(updateIndex);
     } else {
         Q_EMIT dataChanged(updateIndex, updateIndex);
     }
@@ -633,7 +612,7 @@ void FileViewModel::onFileUpdated(int show)
 {
     auto view = qobject_cast<FileView *>(QObject::parent());
     if (view) {
-        view->update(view->visualRect(index(show, 0, rootIndex())));
+        view->update(index(show, 0, rootIndex()));
     } else {
         Q_EMIT dataChanged(index(show, 0, rootIndex()), index(show, 0, rootIndex()));
     }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -109,7 +109,6 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void onFileThumbUpdated(const QUrl &url);
-    void onFileLinkOrgUpdated(const QUrl &url, const bool isLinkOrg);
     void onFileUpdated(int show);
     void onInsert(int firstIndex, int count);
     void onInsertFinish();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -111,6 +111,7 @@ public slots:
     void handleFilterData(const QVariant &data);
     void handleFilterCallFunc(FileViewFilterCallback callback);
     void handleRefresh();
+    void handleFileInfoUpdated(const QUrl &url, const bool isLinkOrg);
 
 private:
     bool checkFilters(const SortInfoPointer &sortInfo, const bool byInfo = false);


### PR DESCRIPTION
An asynchronous FileInfo was created before renaming, causing information to be queried for files under mtp, resulting in MTP device busy at the time of renaming. The previous MTP information query completed when the file was added on the interface, but this is the file information query that was not created the last time the file was added, so it determines whether the file exists or is an error. Modify 1. Fileinfo is created synchronously before renaming (asynchronous for next phase optimization, waiting for asynchronous queries to complete). 2. When adding a file, do the file information again

Log: Rename unsuccessful
Bug: https://pms.uniontech.com/bug-view-197913.html