### PR TITLE
fix: Dragging and dropping the cut file results in abnormal file status

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventhandler.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventhandler.cpp
@@ -62,6 +62,9 @@ void FileOperationsEventHandler::removeUrlsInClipboard(AbstractJobHandler::JobTy
     case AbstractJobHandler::JobType::kCleanTrashType:
         ClipBoard::instance()->removeUrls(destUrls);
         break;
+    case AbstractJobHandler::JobType::kCutType:
+        ClipBoard::instance()->removeUrls(srcUrls);
+        break;
     default:
         break;
     }


### PR DESCRIPTION
1.After dragging, the content of the clipboard is not clear 2.Fixed the same issue in sidebarView、workspace、desktop。

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-199031.html