### PR TITLE
fix: [copy&cut] When copying or cutting a linked file, the operation actually affects the original file

### DIFF
--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -406,6 +406,28 @@ bool UniversalUtils::urlsTransform(const QList<QUrl> &sourceUrls, QList<QUrl> *t
     return ret;
 }
 
+bool UniversalUtils::originalUrls(const QList<QUrl> &srcUrls, QList<QUrl> *targetUrls)
+{
+    bool ret { false };
+    if (srcUrls.isEmpty())
+        return ret;
+
+    if (srcUrls.first().scheme() == Global::Scheme::kFile)
+        return ret;
+
+    for (const auto &url : srcUrls) {
+        auto info { InfoFactory::create<FileInfo>(url) };
+        if (info) {
+            ret = true;
+            targetUrls->append(info->urlOf(UrlInfoType::kOriginalUrl));
+        } else {
+            targetUrls->append(url);
+        }
+    }
+
+    return ret;
+}
+
 QString UniversalUtils::getCurrentUser()
 {
     QString user;

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -38,6 +38,7 @@ public:
 
     static bool urlEquals(const QUrl &url1, const QUrl &url2);
     static bool urlsTransform(const QList<QUrl> &sourceUrls, QList<QUrl> *targetUrls);
+    static bool originalUrls(const QList<QUrl> &srcUrls, QList<QUrl> *targetUrls);
 
     static QString getCurrentUser();
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
@@ -152,7 +152,7 @@ QString ErrorMessageAndAction::errorToString(const QUrl &url, const AbstractJobH
     case AbstractJobHandler::JobErrorType::kFailedParseUrlOfTrash:
         return tr("Failed to parse the url of trash");
     case AbstractJobHandler::JobErrorType::kFailedObtainTrashOriginalFile:
-        return tr("Failed to obtain the trash original file");
+        return tr("Restore failed: the original file does not exist");
     default:
         break;
     }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -285,7 +285,7 @@ JobHandlePointer FileOperationsEventReceiver::doCopyFile(const quint64 windowId,
     QList<QUrl> sourcesTrans = sources;
 
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::urlsTransform(sourcesTrans, &urls);
+    bool ok = UniversalUtils::originalUrls(sourcesTrans, &urls);
     if (ok && !urls.isEmpty())
         sourcesTrans = urls;
 
@@ -320,7 +320,7 @@ JobHandlePointer FileOperationsEventReceiver::doCutFile(quint64 windowId, const 
 
     QList<QUrl> sourcesTrans = sources;
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::urlsTransform(sourcesTrans, &urls);
+    bool ok = UniversalUtils::originalUrls(sourcesTrans, &urls);
     if (ok && !urls.isEmpty())
         sourcesTrans = urls;
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -127,7 +127,7 @@ void FileOperatorHelper::copyFiles(const FileView *view)
     QList<QUrl> selectedUrls = view->selectedUrlList();
     // trans url to local
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::urlsTransform(selectedUrls, &urls);
+    bool ok = UniversalUtils::originalUrls(selectedUrls, &urls);
     if (ok && !urls.isEmpty())
         selectedUrls = urls;
 
@@ -154,7 +154,7 @@ void FileOperatorHelper::cutFiles(const FileView *view)
         return;
     QList<QUrl> selectedUrls = view->selectedUrlList();
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::urlsTransform(selectedUrls, &urls);
+    bool ok = UniversalUtils::originalUrls(selectedUrls, &urls);
     if (ok && !urls.isEmpty())
         selectedUrls = urls;
 


### PR DESCRIPTION
1.The redirected file url has been written to the clipboard 
2.When performing a copy or cut operation, the file url is then converted into a redirected file url

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-199051.html