### PR TITLE
fix: Some HTML files have incorrect icons

### DIFF
--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -793,8 +793,9 @@ QString SyncFileInfoPrivate::iconName() const
 
     if (iconNameValue.isEmpty()) {
         const QStringList &list = this->attribute(DFileInfo::AttributeID::kStandardIcon).toStringList();
-        if (!list.isEmpty())
-            iconNameValue = list.first();
+        const auto &iter = std::find_if(list.begin(), list.end(), [](const QString &name) { return QIcon::hasThemeIcon(name); });
+        if (iter != list.end())
+            iconNameValue = *iter;
     }
 
     if (!FileUtils::isGvfsFile(q->fileUrl()) && iconNameValue.isEmpty())


### PR DESCRIPTION
Traverse all icon names and determine whether the icons exist in the system theme

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-199403.html