### PR TITLE
fix: [workspace]select and edit new file in async create.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -567,6 +567,9 @@ void FileSortWorker::handleUpdateFile(const QUrl &url)
             visibleChildren.insert(showIndex, sortInfo->url);
         }
         Q_EMIT insertFinish();
+
+        // async create file will add to view while file info updated.
+        Q_EMIT selectAndEditFile(sortInfo->url);
     }
 }
 

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/utils/ut_filesortworker.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/utils/ut_filesortworker.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/localfilewatcher.h>
+
+#include <gtest/gtest.h>
+
+#include <QStandardPaths>
+
+DFMBASE_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
+DPWORKSPACE_USE_NAMESPACE
+
+class UT_FileSortWorker : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        UrlRoute::regScheme(Global::Scheme::kFile, "/", QIcon(), false, QObject::tr("System Disk"));
+        InfoFactory::regClass<dfmbase::SyncFileInfo>(Scheme::kFile);
+        WatcherFactory::regClass<LocalFileWatcher>(Scheme::kFile);
+
+        url = QUrl(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
+        url.setScheme(Scheme::kFile);
+
+        worker = new FileSortWorker(url, key);
+    }
+    void TearDown() override
+    {
+        delete worker;
+        worker = nullptr;
+
+        stub.clear();
+    }
+
+    QUrl url {};
+    QString key {"theKey"};
+    FileSortWorker *worker = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_FileSortWorker, Bug_199473_handleUpdateFile)
+{
+    stub.set_lamda(ADDR(FileSortWorker, checkFilters), []{
+        return true;
+    });
+
+    QUrl updateFile(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first() + "/updateFile");
+    updateFile.setScheme(Scheme::kFile);
+
+    QUrl selectAndEditFile {};
+    QObject::connect(worker, &FileSortWorker::selectAndEditFile, worker, [&selectAndEditFile](const QUrl &url){
+        selectAndEditFile = url;
+    });
+
+    worker->childrenUrlList.append(updateFile);
+    SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo(updateFile, false, true, false, false, true, true, true));
+    worker->children.append(sortInfo);
+
+    worker->handleUpdateFile(updateFile);
+
+    EXPECT_EQ(selectAndEditFile, updateFile);
+}


### PR DESCRIPTION
async created file will show in view after file info updated and send select signal after that.

Log: fix create file issue
Bug: https://pms.uniontech.com/bug-view-199473.html