### PR TITLE
fix: [taskdialog]Every time a small file is copied, the position of the copy window will be refreshed

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskdialog.h
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.h
@@ -40,9 +40,9 @@ Q_SIGNALS:
      */
     void closed();
 private Q_SLOTS:
-    void adjustSize();
     void moveYCenter();
     void removeTask();
+    void adjustSize();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -53,8 +53,6 @@ private:
     QMap<JobHandlePointer, QListWidgetItem *> taskItems;
     DTitlebar *titlebar { nullptr };
     QDBusReply<QDBusUnixFileDescriptor> replyBlokShutDown;
-    QMutex *addTaskMutex { nullptr };
-    QMutex *adjustSizeMutex { nullptr };
     static int kMaxHeight;
 };
 

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -307,6 +307,7 @@ void TaskWidget::onShowTaskInfo(const JobInfoPointer JobInfo)
     QString target = JobInfo->value(AbstractJobHandler::NotifyInfoKey::kTargetMsgKey).toString();
     lbSrcPath->setText(source);
     lbDstPath->setText(target);
+    auto oldheight = height();
     if (lbErrorMsg->isVisible()) {
         lbErrorMsg->setText("");
         lbErrorMsg->hide();
@@ -317,7 +318,10 @@ void TaskWidget::onShowTaskInfo(const JobInfoPointer JobInfo)
         widButton->hide();
 
     adjustSize();
-    emit heightChanged();
+    auto newhight = height();
+
+    if (oldheight != newhight)
+        emit heightChanged();
 }
 /*!
  * \brief TaskWidget::showTaskProccess 显示当前任务进度


### PR DESCRIPTION

The size of each item will be adjusted when the height of the copy progress bar is changed. Here, the position of the entire display dialog box is adjusted. Modify without adjusting the entire display dialogue position.

Log: Every time a small file is copied, the position of the copy window will be refreshed
Bug: https://pms.uniontech.com/bug-view-199201.html https://pms.uniontech.com/bug-view-199209.html