### PR TITLE
perf: [plugins] disbale lazylist of plugins if enable headless

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -125,7 +125,7 @@ static bool pluginsLoad()
 
     // disbale lazy load if enbale headless
     bool enableHeadless { DConfigManager::instance()->value(kDefaultCfgPath, "dfm.headless", false).toBool() };
-    if (enableHeadless)
+    if (enableHeadless && CommandParser::instance().isSet("d"))
         DPF_NAMESPACE::LifeCycle::initialize({ kFmPluginInterface, kCommonPluginInterface }, pluginsDirs, blackNames);
     else
         DPF_NAMESPACE::LifeCycle::initialize({ kFmPluginInterface, kCommonPluginInterface }, pluginsDirs, blackNames, kLazyLoadPluginNames);


### PR DESCRIPTION
Always use lazylist when filemanger first launched

Log: