### PR TITLE
fix: [io/fileinfo]Fileinfo vector access overrun crash

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -192,7 +192,7 @@ bool AsyncFileInfo::isAttributes(const OptInfoType type) const
     case FileIsType::kIsExecutable:
         [[fallthrough]];
     case FileIsType::kIsSymLink:
-        return d->asyncAttribute(d->getAttributeIDIsVector()[static_cast<int>(type)]).toBool();
+        return d->asyncAttribute(d->getAttributeIDIsVector().at(static_cast<int>(type))).toBool();
     case FileIsType::kIsRoot:
         return d->asyncAttribute(AsyncAttributeID::kStandardFilePath).toString() == "/";
     default:
@@ -238,7 +238,7 @@ QVariant AsyncFileInfo::extendAttributes(const ExtInfoType type) const
     case FileExtendedInfoType::kOwnerId:
         [[fallthrough]];
     case FileExtendedInfoType::kGroupId:
-        return d->asyncAttribute(d->getAttributeIDExtendVector()[static_cast<int>(type)]);
+        return d->asyncAttribute(d->getAttributeIDExtendVector().at(static_cast<int>(type)));
     default:
         QReadLocker(&d->lock);
         return FileInfo::extendAttributes(type);
@@ -303,7 +303,7 @@ QVariant AsyncFileInfo::timeOf(const TimeInfoType type) const
 {
     qint64 data { 0 };
     if (type < FileTimeType::kDeletionTimeMSecond)
-        data = d->asyncAttribute(d->getAttributeIDVector()[static_cast<int>(type)]).value<qint64>();
+        data = d->asyncAttribute(d->getAttributeIDVector().at(static_cast<int>(type))).value<qint64>();
 
     switch (type) {
     case TimeInfoType::kCreateTime:

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -104,9 +104,9 @@ public:
     QString path() const;
     QString filePath() const;
     QString symLinkTarget() const;
-    QVector<AsyncFileInfo::AsyncAttributeID> getAttributeIDVector() const
+    QVector<AsyncFileInfo::AsyncAttributeID> &getAttributeIDVector() const
     {
-        static QVector<AsyncFileInfo::AsyncAttributeID> kTimeInfoToDFile = {
+        static QVector<AsyncFileInfo::AsyncAttributeID> kTimeInfoToDFile {
             AsyncFileInfo::AsyncAttributeID::kTimeCreated,
             AsyncFileInfo::AsyncAttributeID::kTimeCreated,
             AsyncFileInfo::AsyncAttributeID::kTimeChanged,
@@ -128,9 +128,9 @@ public:
         return kTimeInfoToDFile;
     }
     QUrl redirectedFileUrl() const;
-    QVector<AsyncFileInfo::AsyncAttributeID> getAttributeIDIsVector() const
+    QVector<AsyncFileInfo::AsyncAttributeID> &getAttributeIDIsVector() const
     {
-        static QVector<AsyncFileInfo::AsyncAttributeID> kIsToDFile = {
+        static QVector<AsyncFileInfo::AsyncAttributeID> kIsToDFile {
             AsyncFileInfo::AsyncAttributeID::kAccessCanRead,
             AsyncFileInfo::AsyncAttributeID::kAccessCanWrite,
             AsyncFileInfo::AsyncAttributeID::kAccessCanExecute,
@@ -148,7 +148,7 @@ public:
     bool canTrash() const;
     bool canRename() const;
     bool canFetch() const;
-    QVector<AsyncFileInfo::AsyncAttributeID> getAttributeIDExtendVector() const
+    QVector<AsyncFileInfo::AsyncAttributeID> &getAttributeIDExtendVector() const
     {
         static QVector<AsyncFileInfo::AsyncAttributeID> kExtendToDFile = {
             AsyncFileInfo::AsyncAttributeID::kOwnerUser,

--- a/src/dfm-base/file/local/private/syncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/syncfileinfo_p.h
@@ -103,9 +103,9 @@ public:
     QString path() const;
     QString filePath() const;
     QString symLinkTarget() const;
-    QVector<DFileInfo::AttributeID> getAttributeIDVector() const
+    QVector<DFileInfo::AttributeID> &getAttributeIDVector() const
     {
-        static QVector<DFileInfo::AttributeID> kTimeInfoToDFile = {
+        static QVector<DFileInfo::AttributeID> kTimeInfoToDFile {
             DFileInfo::AttributeID::kTimeCreated,
             DFileInfo::AttributeID::kTimeCreated,
             DFileInfo::AttributeID::kTimeChanged,
@@ -127,9 +127,9 @@ public:
         return kTimeInfoToDFile;
     }
     QUrl redirectedFileUrl() const;
-    QVector<DFileInfo::AttributeID> getAttributeIDIsVector() const
+    QVector<DFileInfo::AttributeID> &getAttributeIDIsVector() const
     {
-        static QVector<DFileInfo::AttributeID> kIsToDFile = {
+        static QVector<DFileInfo::AttributeID> kIsToDFile {
             DFileInfo::AttributeID::kAccessCanRead,
             DFileInfo::AttributeID::kAccessCanWrite,
             DFileInfo::AttributeID::kAccessCanExecute,
@@ -147,9 +147,9 @@ public:
     bool canTrash() const;
     bool canRename() const;
     bool canFetch() const;
-    QVector<DFileInfo::AttributeID> getAttributeIDExtendVector() const
+    QVector<DFileInfo::AttributeID> &getAttributeIDExtendVector() const
     {
-        static QVector<DFileInfo::AttributeID> kExtendToDFile = {
+        static QVector<DFileInfo::AttributeID> kExtendToDFile {
             DFileInfo::AttributeID::kOwnerUser,
             DFileInfo::AttributeID::kOwnerGroup,
             DFileInfo::AttributeID::kAttributeIDMax,

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -215,7 +215,7 @@ bool SyncFileInfo::isAttributes(const OptInfoType type) const
     case FileIsType::kIsHidden:
         [[fallthrough]];
     case FileIsType::kIsSymLink:
-        return d->attribute(d->getAttributeIDIsVector()[static_cast<int>(type)]).toBool();
+        return d->attribute(d->getAttributeIDIsVector().at(static_cast<int>(type))).toBool();
     case FileIsType::kIsExecutable:
         return d->isExecutable();
     case FileIsType::kIsRoot:
@@ -269,7 +269,7 @@ QVariant SyncFileInfo::extendAttributes(const ExtInfoType type) const
     case FileExtendedInfoType::kOwnerId:
         [[fallthrough]];
     case FileExtendedInfoType::kGroupId:
-        return d->attribute(d->getAttributeIDExtendVector()[static_cast<int>(type)]);
+        return d->attribute(d->getAttributeIDExtendVector().at(static_cast<int>(type)));
     default:
         QReadLocker(&d->lock);
         return FileInfo::extendAttributes(type);
@@ -334,7 +334,7 @@ QVariant SyncFileInfo::timeOf(const TimeInfoType type) const
 {
     qint64 data { 0 };
     if (type < FileTimeType::kDeletionTimeMSecond)
-        data = d->attribute(d->getAttributeIDVector()[static_cast<int>(type)]).value<qint64>();
+        data = d->attribute(d->getAttributeIDVector().at(static_cast<int>(type))).value<qint64>();
 
     switch (type) {
     case TimeInfoType::kCreateTime:


### PR DESCRIPTION
Modifying the use of static vectors in sync and async

Log: Fileinfo vector access overrun crash