### PR TITLE
feat: [clipboard]Optimization of shear plates

### DIFF
--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -253,6 +253,8 @@ QVariant SyncFileInfo::extendAttributes(const ExtInfoType type) const
 {
     switch (type) {
     case FileExtendedInfoType::kFileLocalDevice:
+        if (d->isLocalDevice.isValid())
+            d->isLocalDevice = FileUtils::isLocalDevice(url);
         return d->isLocalDevice;
     case FileExtendedInfoType::kFileCdRomDevice:
         return d->isCdRomDevice;

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -403,6 +403,9 @@ bool CanvasItemDelegate::isTransparent(const QModelIndex &index) const
         if (ClipBoard::instance()->clipboardFileUrlList().contains(file->urlOf(UrlInfoType::kUrl)))
             return true;
 
+        if (!file->extendAttributes(ExtInfoType::kFileLocalDevice).toBool())
+            return false;
+
         // the linked file only judges the URL, not the inode,
         // because the inode of the linked file is consistent with that of the source file
         if (!file->isAttributes(OptInfoType::kIsSymLink)) {

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -395,6 +395,9 @@ bool CollectionItemDelegate::isTransparent(const QModelIndex &index) const
         if (ClipBoard::instance()->clipboardFileUrlList().contains(file->urlOf(UrlInfoType::kUrl)))
             return true;
 
+        if (!file->extendAttributes(ExtInfoType::kFileLocalDevice).toBool())
+            return false;
+
         // the linked file only judges the URL, not the inode,
         // because the inode of the linked file is consistent with that of the source file
         if (!file->isAttributes(OptInfoType::kIsSymLink)) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -82,6 +82,9 @@ bool FileViewHelper::isTransparent(const QModelIndex &index) const
         if (ClipBoard::instance()->clipboardFileUrlList().contains(localUrl))
             return true;
 
+        if (!file->extendAttributes(ExtInfoType::kFileLocalDevice).toBool())
+            return false;
+
         // the linked file only judges the URL, not the inode,
         // because the inode of the linked file is consistent with that of the source file
         if (!file->isAttributes(OptInfoType::kIsSymLink)) {


### PR DESCRIPTION
1. Fileicon is only written to the local disk. 2. The response slot function of the clipboard is modified, and it is not cutting or not inserting inodes into local files. 3. Modify the use of inode to determine whether it is the location for cutting files. If it is not a local file, return it

Log: Optimization of shear plates