### PR TITLE
fix: After a file is renamed ,the corresponding file in the clipboard is not renamed

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -304,6 +304,21 @@ void ClipBoard::removeUrls(const QList<QUrl> &urls)
             setUrlsToClipboard(clipboardUrls, action);
     }
 }
+
+void ClipBoard::replaceClipboardUrl(const QUrl &oldUrl, const QUrl &newUrl)
+{
+    QList<QUrl> clipboardUrls = GlobalData::clipboardFileUrls;
+    ClipBoard::ClipboardAction action = GlobalData::clipboardAction;
+    if (clipboardUrls.isEmpty() || action == ClipBoard::kUnknownAction)
+        return;
+
+    int index = clipboardUrls.indexOf(oldUrl);
+    if (-1 == index)
+        return;
+
+    clipboardUrls.replace(index, newUrl);
+    setUrlsToClipboard(clipboardUrls, action);
+}
 /*!
  * \brief ClipBoard::getUrlsByX11 Use X11 to read URLs downloaded
  * remotely from the clipboard

--- a/src/dfm-base/utils/clipboard.h
+++ b/src/dfm-base/utils/clipboard.h
@@ -40,6 +40,7 @@ public:
     QList<quint64> clipboardFileInodeList() const;
     ClipboardAction clipboardAction() const;
     void removeUrls(const QList<QUrl> &urls);
+    void replaceClipboardUrl(const QUrl &oldUrl, const QUrl &newUrl);
 
 private:
     explicit ClipBoard(QObject *parent = nullptr);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -789,6 +789,9 @@ bool FileOperationsEventReceiver::handleOperationRenameFile(const quint64 window
     QMap<QUrl, QUrl> renamedFiles { { oldUrl, newUrl } };
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kRenameFileResult,
                                  windowId, renamedFiles, ok, error);
+    if (ok)
+        ClipBoard::instance()->replaceClipboardUrl(oldUrl, newUrl);
+
     if (!flags.testFlag(AbstractJobHandler::JobFlag::kRevocation))
         saveFileOperation({ newUrl }, { oldUrl }, GlobalEventType::kRenameFile);
     return ok;


### PR DESCRIPTION
1.as title
2.After the file is successfully renamed, change the file name on the clipboard

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-199867.html
