### PR TITLE
fix: [workspace]too many times that setIndexActive() func be called.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -484,11 +484,13 @@ void FileView::updateModelActiveIndex()
 
     const RandeIndex &rande = randeList.first();
 
-    for (int i = d->visibleIndexRande.first; i < rande.first; ++i) {
+    int minInactiveIndex = qMin(rande.first - 1, d->visibleIndexRande.second);
+    for (int i = d->visibleIndexRande.first; i <= minInactiveIndex; ++i) {
         model()->setIndexActive(model()->index(i, 0, rootIndex()), false);
     }
 
-    for (int i = rande.second; i < d->visibleIndexRande.second; ++i) {
+    int maxInactiveIndex = qMax(rande.second + 1, d->visibleIndexRande.first);
+    for (int i = maxInactiveIndex; i <= d->visibleIndexRande.second; ++i) {
         model()->setIndexActive(model()->index(i, 0, rootIndex()), false);
     }
 
@@ -914,7 +916,7 @@ void FileView::resizeEvent(QResizeEvent *event)
         doItemsLayout();
 
     if (rootIndex().isValid())
-        updateModelActiveIndex();
+        delayUpdateModelActiveIndex();
 }
 
 void FileView::setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags flags)
@@ -1485,7 +1487,7 @@ void FileView::initializeModel()
     setSelectionModel(selectionModel);
 
     d->updateActiveIndexTimer = new QTimer(this);
-    d->updateActiveIndexTimer->setInterval(100);
+    d->updateActiveIndexTimer->setInterval(500);
     d->updateActiveIndexTimer->setSingleShot(true);
 }
 


### PR DESCRIPTION
just need set the index inactive which already be actived when view scrolling.

Log: fix view freezing issue
Bug: https://pms.uniontech.com/bug-view-200133.html