### PR TITLE
fix: [vault] When 1000+ files, the vault freeze

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -213,6 +213,13 @@ public:
             return qSharedPointerDynamicCast<T>(instance().SchemeFactory<FileInfo>::
                                                         create(url, errorString));
 
+        if (type == Global::CreateFileInfoType::kCreateFileInfoSyncAndCache)
+            return qSharedPointerDynamicCast<T>(getFileInfoFromCache(url,  Global::CreateFileInfoType::kCreateFileInfoSyncAndCache, errorString));
+
+        if (type == Global::CreateFileInfoType::kCreateFileInfoAsyncAndCache && url.scheme() == Global::Scheme::kFile)
+            return qSharedPointerDynamicCast<T>(getFileInfoFromCache(url,  Global::CreateFileInfoType::kCreateFileInfoAsyncAndCache, errorString));
+
+
         if (url.scheme() == Global::Scheme::kFile) {
             if (type == Global::CreateFileInfoType::kCreateFileInfoSync) {
                 return qSharedPointerDynamicCast<T>(instance().SchemeFactory<FileInfo>::
@@ -246,6 +253,7 @@ private:
     static InfoFactory &instance();   // 获取全局实例
     explicit InfoFactory() {}
     static QString scheme(const QUrl &url);
+    static QSharedPointer<FileInfo> getFileInfoFromCache(const QUrl &url, Global::CreateFileInfoType type, QString *errorString);
 };
 
 class ViewFactory final : public SchemeFactory<AbstractBaseView>

--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -91,9 +91,11 @@ enum CreateFileType : uint8_t {
 };
 
 enum CreateFileInfoType : uint8_t {
-    kCreateFileInfoAuto = 0,   // auto can cache file info, other type can't
+    kCreateFileInfoAuto = 0,   // auto can cache file info, virtual schema will synchronize create file info
     kCreateFileInfoSync = 1,
     kCreateFileInfoAsync = 2,
+    kCreateFileInfoSyncAndCache = 3,    // create file info Synchronize and cache file info
+    kCreateFileInfoAsyncAndCache = 4    // create file info Asynchronous and cache file info
 };
 
 namespace Mime {

--- a/src/dfm-base/base/schemefactory.cpp
+++ b/src/dfm-base/base/schemefactory.cpp
@@ -30,6 +30,24 @@ QString InfoFactory::scheme(const QUrl &url)
     return scheme;
 }
 
+QSharedPointer<FileInfo> InfoFactory::getFileInfoFromCache(const QUrl &url, Global::CreateFileInfoType type, QString *errorString)
+{
+    QSharedPointer<FileInfo> info = InfoCacheController::instance().getCacheInfo(url);
+    if (!info) {
+        if (type == Global::CreateFileInfoType::kCreateFileInfoSyncAndCache) {
+            info = instance().SchemeFactory<FileInfo>::create(url, errorString);
+        } else if (type == Global::CreateFileInfoType::kCreateFileInfoAsyncAndCache) {
+            info = instance().SchemeFactory<FileInfo>::create(Global::Scheme::kAsyncFile, url, errorString);
+            if (info) {
+                info->refresh();
+            }
+        }
+        if (info)
+            emit InfoCacheController::instance().cacheFileInfo(url, info);
+    }
+    return info;
+}
+
 WatcherFactory &WatcherFactory::instance()
 {
     static WatcherFactory ins;

--- a/src/dfm-base/utils/thumbnailprovider.cpp
+++ b/src/dfm-base/utils/thumbnailprovider.cpp
@@ -354,6 +354,10 @@ QString ThumbnailProvider::createThumbnail(const QUrl &url, ThumbnailProvider::S
         image.reset(new QImage(1, 1, QImage::Format_Mono));
     }
 
+    if (thumbnail.isEmpty())
+        thumbnail = DFMIO::DFMUtils::buildFilePath(StandardPaths::location(StandardPaths::kThumbnailLargePath).toStdString().c_str(),
+                                                                           thumbnailName.toStdString().c_str(), nullptr);
+
     image->setText(QT_STRINGIFY(Thumb::URL), fileUrl);
     const qint64 fileModify = fileInfo->timeOf(TimeInfoType::kLastModifiedSecond).value<qint64>();
     image->setText(QT_STRINGIFY(Thumb::MTime), QString::number(fileModify));

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/newcreatemenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/newcreatemenuscene.cpp
@@ -125,7 +125,6 @@ void NewCreateMenuScene::updateState(QMenu *parent)
     auto curDirInfo = InfoFactory::create<FileInfo>(d->currentDir);
     if (!curDirInfo)
         return;
-    curDirInfo->refresh();
     if (!curDirInfo->isAttributes(OptInfoType::kIsWritable)) {
         auto actions = parent->actions();
         for (auto act : actions) {

--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
@@ -84,7 +84,7 @@ VaultFileInfo::VaultFileInfo(const QUrl &url)
     : ProxyFileInfo(url), d(new VaultFileInfoPrivate(this))
 {
     QUrl tempUrl = VaultHelper::vaultToLocalUrl(url);
-    setProxy(InfoFactory::create<FileInfo>(tempUrl));
+    setProxy(InfoFactory::create<FileInfo>(tempUrl,  Global::CreateFileInfoType::kCreateFileInfoSyncAndCache));
 }
 
 VaultFileInfo::~VaultFileInfo()

--- a/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
+++ b/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
@@ -109,3 +109,20 @@ TEST(UT_VaultPluginBugTest, bug_200185_CheckProxyChange)
     info.refresh();
     EXPECT_TRUE(oldprox == info.proxy);
 }
+
+TEST(UT_VaultPluginBugTest, bug_199947_CacheVaultFileInfo)
+{
+    bool isCache { false };
+    stub_ext::StubExt stub;
+    stub.set_lamda(&InfoFactory::create<FileInfo>, [&isCache](const QUrl &url,
+                                                              const Global::CreateFileInfoType type,
+                                                              QString *errorString){
+        if (type == Global::CreateFileInfoType::kCreateFileInfoSyncAndCache)
+            isCache = true;
+        return nullptr;
+    });
+    stub.set_lamda(&ProxyFileInfo::setProxy, []{});
+
+    VaultFileInfo info(QUrl("dfmvault:///"));
+    EXPECT_TRUE(isCache);
+}


### PR DESCRIPTION
1. let the vault fileinfo in cache
2. create the vault fileinfo, let it cache
3. create the vault fileinfo by vaultfileiterator, let it cache

Log: Optimize the safe of the safe
Bug: https://pms.uniontech.com/bug-view-199947.html