### PR TITLE
计算机页面中支持通过 uuid 隐藏任意块设备

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/models/computermodel.cpp
@@ -252,7 +252,7 @@ void ComputerModel::initConnect()
         this->beginResetModel();
         items = datas;
         this->endResetModel();
-        QTimer::singleShot(0, this, [this]() { view->handlePartitionsVisiable(); });
+        view->handlePartitionsVisiable();
     });
     connect(ComputerItemWatcherInstance, &ComputerItemWatcher::itemAdded, this, &ComputerModel::onItemAdded);
     connect(ComputerItemWatcherInstance, &ComputerItemWatcher::itemRemoved, this, &ComputerModel::onItemRemoved);

--- a/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
@@ -217,14 +217,11 @@ void ComputerUtils::setCursorState(bool busy)
         QApplication::restoreOverrideCursor();
 }
 
-QStringList ComputerUtils::allSystemUUIDs()
+QStringList ComputerUtils::allValidBlockUUIDs()
 {
-    const auto &systemDisks = DevProxyMng->getAllBlockIds(GlobalServerDefines::DeviceQueryOption::kSystem).toSet();
-    const auto &loopDisks = DevProxyMng->getAllBlockIds(GlobalServerDefines::DeviceQueryOption::kLoop).toSet();
-    auto systemDiskNoLoop = systemDisks - loopDisks;
-
+    const auto &allBlocks = DevProxyMng->getAllBlockIds().toSet();
     QSet<QString> uuids;
-    std::for_each(systemDiskNoLoop.cbegin(), systemDiskNoLoop.cend(), [&](const QString &devId) {
+    std::for_each(allBlocks.cbegin(), allBlocks.cend(), [&](const QString &devId) {
         const auto &&data = DevProxyMng->queryBlockInfo(devId);
         const auto &&uuid = data.value(GlobalServerDefines::DeviceProperty::kUUID).toString();
         if (!uuid.isEmpty())
@@ -233,9 +230,9 @@ QStringList ComputerUtils::allSystemUUIDs()
     return uuids.values();
 }
 
-QList<QUrl> ComputerUtils::systemBlkDevUrlByUUIDs(const QStringList &uuids)
+QList<QUrl> ComputerUtils::blkDevUrlByUUIDs(const QStringList &uuids)
 {
-    const auto &&devIds = DevProxyMng->getAllBlockIdsByUUID(uuids, GlobalServerDefines::DeviceQueryOption::kSystem);
+    const auto &&devIds = DevProxyMng->getAllBlockIdsByUUID(uuids);
     QList<QUrl> ret;
     for (const auto &id : devIds)
         ret << makeBlockDevUrl(id);

--- a/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.h
@@ -76,8 +76,8 @@ public:
     static bool checkGvfsMountExist(const QUrl &url, int timeout = 2000);
     static void setCursorState(bool busy = false);
 
-    static QStringList allSystemUUIDs();
-    static QList<QUrl> systemBlkDevUrlByUUIDs(const QStringList &uuids);
+    static QStringList allValidBlockUUIDs();
+    static QList<QUrl> blkDevUrlByUUIDs(const QStringList &uuids);
 
 public:
     static bool contextMenuEnabled;   // TODO(xust) tmp solution, using GroupPolicy instead.

--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.h
@@ -66,8 +66,6 @@ private Q_SLOTS:
     void onMenuRequest(const QPoint &pos);
     void onRenameRequest(quint64 winId, const QUrl &url);
     void hideSpecificDisks(const QList<QUrl> &hiddenDisks);
-    void hideSystemPartitions(bool hide);
-    void hideLoopPartitions(bool hide);
     void handleDiskSplitterVisiable();
 
 Q_SIGNALS:

--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.h
@@ -53,6 +53,8 @@ public:
     int getGroupId(const QString &groupName);
 
     static QList<QUrl> disksHiddenByDConf();
+    static QList<QUrl> disksHiddenBySettingPanel();
+    static QList<QUrl> hiddenPartitions();
 
 public Q_SLOTS:
     void startQueryItems();
@@ -65,9 +67,7 @@ Q_SIGNALS:
     void itemPropertyChanged(const QUrl &url, const QString &property, const QVariant &var);
     void itemSizeChanged(const QUrl &url, qlonglong, qlonglong);
     void hideFileSystemTag(bool hide);
-    void hideNativeDisks(bool hide);
-    void hideLoopPartitions(bool hide);
-    void hideDisks(const QList<QUrl> &devs);
+    void updatePartitionsVisiable();
 
 protected Q_SLOTS:
     void onDeviceAdded(const QUrl &devUrl, int groupId, ComputerItemData::ShapeType shape = ComputerItemData::kLargeItem, bool needSidebarItem = true);

--- a/tests/plugins/filemanager/core/dfmplugin-computer/utils/ut_computerutils.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-computer/utils/ut_computerutils.cpp
@@ -213,12 +213,12 @@ TEST_F(UT_ComputerUtils, AllSystemUUIDs)
     };
     stub.set_lamda(&DeviceProxyManager::getAllBlockIds, [&] { __DBG_STUB_INVOKE__ return devs.takeFirst(); });
     stub.set_lamda(&DeviceProxyManager::queryBlockInfo, [] { __DBG_STUB_INVOKE__ return QVariantMap { { GlobalServerDefines::DeviceProperty::kUUID, "ssss" } }; });
-    EXPECT_FALSE(ComputerUtils::allSystemUUIDs().isEmpty());
+    EXPECT_FALSE(ComputerUtils::allValidBlockUUIDs().isEmpty());
 }
 
 TEST_F(UT_ComputerUtils, SystemBlkDevUrlByUUIDs)
 {
     stub.set_lamda(&DeviceProxyManager::getAllBlockIdsByUUID, [] { __DBG_STUB_INVOKE__
                 return QStringList{"/org/freedesktop/UDisks2/block_devices/sda1", "/org/freedesktop/UDisks2/block_devices/sda2"}; });
-    EXPECT_TRUE(ComputerUtils::systemBlkDevUrlByUUIDs({}).count() >= 0);
+    EXPECT_TRUE(ComputerUtils::blkDevUrlByUUIDs({}).count() >= 0);
 }

--- a/tests/plugins/filemanager/core/dfmplugin-computer/watcher/ut_computeritemwatcher.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-computer/watcher/ut_computeritemwatcher.cpp
@@ -156,8 +156,8 @@ TEST_F(UT_ComputerItemWatcher, OnGenAttributeChanged)
 TEST_F(UT_ComputerItemWatcher, OnDConfigChanged)
 {
     stub.set_lamda(&DConfigManager::value, [] { __DBG_STUB_INVOKE__ return QStringList {}; });
-    stub.set_lamda(ComputerUtils::allSystemUUIDs, [] { __DBG_STUB_INVOKE__ return QStringList {}; });
-    stub.set_lamda(ComputerUtils::systemBlkDevUrlByUUIDs, [] { __DBG_STUB_INVOKE__ return QList<QUrl> {}; });
+    stub.set_lamda(ComputerUtils::allValidBlockUUIDs, [] { __DBG_STUB_INVOKE__ return QStringList {}; });
+    stub.set_lamda(ComputerUtils::blkDevUrlByUUIDs, [] { __DBG_STUB_INVOKE__ return QList<QUrl> {}; });
     EXPECT_NO_FATAL_FAILURE(ins->onDConfigChanged("org.deepin.dde.file-manager", "dfm.disk.hidden"));
 }
 


### PR DESCRIPTION
梳理了组策略隐藏、配置面板隐藏间的逻辑关系，整理了磁盘显示控制代码，使其更加简单易懂便于维护。
各种隐藏方式优先级为 HintIgnore > DConfig > SettingPanel，

