### PR TITLE
fix: [vault] copy file to vault, app crash

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
@@ -153,8 +153,6 @@ void VaultFileInfo::refresh()
     }
 
     proxy->refresh();
-
-    setProxy(InfoFactory::create<FileInfo>(proxy->urlOf(UrlInfoType::kUrl)));
 }
 
 bool VaultFileInfo::isAttributes(const OptInfoType type) const

--- a/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
+++ b/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
@@ -11,6 +11,7 @@
 #include "utils/encryption/vaultconfig.h"
 #include "utils/fileencrypthandle.h"
 #include "utils/fileencrypthandle_p.h"
+#include "fileutils/vaultfileinfo.h"
 
 #include <gtest/gtest.h>
 
@@ -99,4 +100,12 @@ TEST(UT_VaultPluginBugTest, bug_144787_CheckCryfs)
     QString cryfsBinary = QStandardPaths::findExecutable("cryfs");
     EXPECT_FALSE(cryfsBinary.isEmpty());
 #endif
+}
+
+TEST(UT_VaultPluginBugTest, bug_200185_CheckProxyChange)
+{
+    VaultFileInfo info(QUrl("dfmvault:///"));
+    FileInfoPointer oldprox = info.proxy;
+    info.refresh();
+    EXPECT_TRUE(oldprox == info.proxy);
 }


### PR DESCRIPTION
cause:
when refresh vault file info, the thumbnail get the icon from the file info, but the file info have be destroy, so crash.
solved:
when refresh vault file info, not destroy old file info.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-200185.html