### PR TITLE
fix: [copy] Copy MTP folder to local, the permissions of folder is error

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -433,6 +433,12 @@ bool LocalFileHandler::setPermissions(const QUrl &url, QFileDevice::Permissions 
         return false;
     }
 
+    // if the `permissions` is invalid, do not set permissions
+    // eg. bug-199607: Copy MTP folder to local, folder permissions wrong
+    // reason: `dfm-io` uses gio to query the `unix::mode` field to get file permissions, but this field is not available in MTP file
+    if (0 == permissions)
+        return true;
+
     bool success = dfile->setPermissions(DFMIO::DFile::Permissions(uint16_t(permissions)));
     if (!success) {
         qWarning() << "set permissions failed, url: " << url;


### PR DESCRIPTION
1.dfm-io uses `gio` to query the unix::mode field to get file permissions, but this field is not available in MTP file
2.if the permissions is invalid, do not set permissions

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-199607.html
