### PR TITLE
组策略隐藏的磁盘同时在侧边栏和计算机中隐藏

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
@@ -301,6 +301,17 @@ void ComputerView::handleDiskSplitterVisiable()
 
 void ComputerView::handlePartitionsVisiable()
 {
+    /* NOTE(xust): disks hidden by dconfig is treat as disks hidden by HintIgnore.
+     * devices should be hidden both in sidebar and computer.
+     * hidden in sidebar is handled in ComputerItemWatcher when dconfig changed.
+     * this part only handle items hidden in computer.
+     *
+     * HintIgnore > DConfig > SettingPanel
+     *
+     * hidden by HintIgnore is handled in BlockEntryFileEntity::exist() function.
+     * if it's true, treat the device as not exists.
+     */
+
     const auto &&hiddenPartitions = ComputerItemWatcher::hiddenPartitions();
     hideSpecificDisks(hiddenPartitions);
     handleDiskSplitterVisiable();

--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.h
@@ -45,6 +45,7 @@ public:
     void updateSidebarItem(const QUrl &url, const QString &newName, bool editable);
     void addSidebarItem(DFMEntryFileInfoPointer info);
     void removeSidebarItem(const QUrl &url);
+    void handleSidebarItemsVisiable();
 
     void insertUrlMapper(const QString &devId, const QUrl &mntUrl);
 


### PR DESCRIPTION
1. treat dconfig change as HintIgnore change, hide disks both in sidebar
and computer page;
2. add log when init devies to help locate where blocks when loading
devices.

Log: support hide disks by dconfig.

Task: https://pms.uniontech.com/task-view-267111.html
