### PR TITLE
fix: [io/fileinfo]Vault Search Manager Crashed

### DIFF
--- a/src/dfm-base/base/schemefactory.cpp
+++ b/src/dfm-base/base/schemefactory.cpp
@@ -16,7 +16,10 @@ InfoFactory &InfoFactory::instance()
 QString InfoFactory::scheme(const QUrl &url)
 {
     auto scheme = url.scheme();
-    if (scheme == Global::Scheme::kFile && !FileUtils::isLocalDevice(url))
+    if (scheme != Global::Scheme::kFile)
+        return scheme;
+
+    if (!FileUtils::isLocalDevice(url))
         return Global::Scheme::kAsyncFile;
 
     dfmio::DFileInfo dinfo(url);

--- a/tests/dfm-base/base/ut_schemefactory.cpp
+++ b/tests/dfm-base/base/ut_schemefactory.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+
+#include <gtest/gtest.h>
+
+class UT_InfoFactory : public testing::Test
+{
+protected:
+    virtual void SetUp() override {}
+    virtual void TearDown() override { stub.clear(); }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+DFMBASE_USE_NAMESPACE
+
+TEST_F(UT_InfoFactory, Bug_199927_199517_scheme)
+{
+    QUrl url("dfmvault:///10000/oooo");
+    InfoFactory infoFactory;
+    EXPECT_EQ("dfmvault", infoFactory.scheme(url));
+
+    stub_ext::StubExt stub;
+    stub.set_lamda(&FileUtils::isLocalDevice, []{ __DBG_STUB_INVOKE__ return false; });
+    url = QUrl("file:///10000/oooo");
+    EXPECT_EQ("asyncfile", infoFactory.scheme(url));
+
+    stub.set_lamda(&FileUtils::isLocalDevice, []{ __DBG_STUB_INVOKE__ return true; });
+    EXPECT_EQ("file", infoFactory.scheme(url));
+
+    int testi{ 0 };
+    stub.set_lamda(&FileUtils::isLocalDevice, [&testi]{
+        __DBG_STUB_INVOKE__
+        if (testi > 0)
+            return false;
+        testi++;
+        return true; });
+    int testa{ 0 };
+    stub.set_lamda(&dfmio::DFileInfo::attribute, []{ __DBG_STUB_INVOKE__ return true; });
+    EXPECT_EQ("asyncfile", infoFactory.scheme(url));
+}


### PR DESCRIPTION
Create fileinfo in the vault, using the scheme of vault, and create file information using gio. The scheme here that is not a file does not need to be processed. Modify the scheme that is not a file and return it directly

Log: Vault Search Manager Crashed
Bug: https://pms.uniontech.com/bug-view-199517.html https://pms.uniontech.com/bug-view-199517.html