### PR TITLE
fix: Ctrl+w can not close file manager window

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
@@ -208,8 +208,16 @@ QRectF WorkspaceWidget::itemRect(const QUrl &url, const Global::ItemRoles role)
 
 void WorkspaceWidget::onCloseCurrentTab()
 {
-    if (tabBar->count() > 1)
-        tabBar->removeTab(tabBar->getCurrentIndex());
+    if (tabBar->count() == 1) {
+        auto winId = WorkspaceHelper::instance()->windowId(this);
+        auto window = FMWindowsIns.findWindowById(winId);
+        if (window)
+            window->close();
+
+        return;
+    }
+
+    tabBar->removeTab(tabBar->getCurrentIndex());
 }
 
 void WorkspaceWidget::onSetCurrentTabIndex(const int index)


### PR DESCRIPTION
The window should be closed by Ctrl+w when no tabs exits

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-200443.html
