### PR TITLE
fix: [io/mimetype]Application icon display error on desktop

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -122,7 +122,9 @@ QString AsyncFileInfo::nameOf(const NameInfoType type) const
     case FileNameInfoType::kSuffix:
         [[fallthrough]];
     case FileNameInfoType::kSuffixOfRename:
-        return d->asyncAttribute(AsyncAttributeID::kStandardSuffix).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardSuffix).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardSuffix).toString();
+        return FileInfo::nameOf(type);
     case FileNameInfoType::kCompleteSuffix:
         return d->asyncAttribute(AsyncAttributeID::kStandardCompleteSuffix).toString();
     case FileNameInfoType::kFileCopyName:
@@ -601,7 +603,7 @@ void AsyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo
 
 QMimeType AsyncFileInfoPrivate::mimeTypes(const QString &filePath, QMimeDatabase::MatchMode mode, const QString &inod, const bool isGvfs)
 {
-    static DFMBASE_NAMESPACE::DMimeDatabase db;
+    DFMBASE_NAMESPACE::DMimeDatabase db;
     if (isGvfs) {
         return db.mimeTypeForFile(filePath, mode, inod, isGvfs);
     }

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -627,7 +627,7 @@ void SyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo>
 
 QMimeType SyncFileInfoPrivate::mimeTypes(const QString &filePath, QMimeDatabase::MatchMode mode, const QString &inod, const bool isGvfs)
 {
-    static DFMBASE_NAMESPACE::DMimeDatabase db;
+    DFMBASE_NAMESPACE::DMimeDatabase db;
     if (isGvfs) {
         return db.mimeTypeForFile(filePath, mode, inod, isGvfs);
     }

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -150,7 +150,12 @@ QString dfmbase::FileInfo::nameOf(const NameInfoType type) const
 QString dfmbase::FileInfo::pathOf(const PathInfoType type) const
 {
     Q_UNUSED(type);
-    return QString();
+    switch (type) {
+    case FilePathInfoType::kFilePath:
+        return url.path();
+    default:
+        return QString();
+    }
 }
 /*!
  * \brief permission 判断文件是否有传入的权限

--- a/src/dfm-base/utils/fileinfoasycworker.cpp
+++ b/src/dfm-base/utils/fileinfoasycworker.cpp
@@ -33,7 +33,7 @@ void FileInfoAsycWorker::fileMimeType(const QUrl &url,
 {
     if (isStoped())
         return;
-    static DFMBASE_NAMESPACE::DMimeDatabase db;
+    DFMBASE_NAMESPACE::DMimeDatabase db;
     QMimeType type;
     if (isGvfs) {
         type = db.mimeTypeForFile(url.path(), mode, inod, isGvfs);

--- a/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.cpp
@@ -377,7 +377,7 @@ void OemMenuPrivate::appendParentMineType(const QStringList &parentmimeTypes, QS
     if (parentmimeTypes.isEmpty())
         return;
 
-    const static DFMBASE_NAMESPACE::DMimeDatabase db;
+    DFMBASE_NAMESPACE::DMimeDatabase db;
     for (const QString &mtName : parentmimeTypes) {
         QMimeType mt = db.mimeTypeForName(mtName);
         mimeTypes.append(mt.name());

--- a/src/plugins/common/dfmplugin-utils/global/virtualglobalplugin.cpp
+++ b/src/plugins/common/dfmplugin-utils/global/virtualglobalplugin.cpp
@@ -23,10 +23,13 @@ static QSharedPointer<dfmbase::FileInfo> transFileInfo(QSharedPointer<dfmbase::F
     const QString &suffix = fileInfo->nameOf(NameInfoType::kSuffix);
     if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop
         || fileInfo->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)) {
-        const QMimeType &mt = fileInfo->fileMimeType();
+        const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
+        QMimeType mt = fileInfo->fileMimeType();
+        if (!mt.isValid())
+            mt = DMimeDatabase().mimeTypeForFile(url.path(),QMimeDatabase::MatchDefault, QString());
+
         if (mt.name() == "application/x-desktop"
             && mt.suffixes().contains(DFMBASE_NAMESPACE::Global::Scheme::kDesktop, Qt::CaseInsensitive)) {
-            const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
             return FileInfoPointer(new DFMBASE_NAMESPACE::DesktopFileInfo(url, fileInfo));
         }
     }


### PR DESCRIPTION
When creating an asynchronous fileinfo, it was determined that the file mimetype had not yet been obtained, so the desktopfileinfo was not created. When the mimetype is invalid, use dmimedatabase to obtain it.

Log: Application icon display error on desktop
Bug: https://pms.uniontech.com/bug-view-199101.html