### PR TITLE
fix: [workspace]Upgrade from 1054 to 1060 File Manager Crash

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -889,7 +889,8 @@ void FileView::mousePressEvent(QMouseEvent *event)
         QModelIndex index = indexAt(event->pos());
         d->selectHelper->click(isEmptyArea ? QModelIndex() : index);
 
-        itemDelegate()->commitDataAndCloseActiveEditor();
+        if (itemDelegate())
+            itemDelegate()->commitDataAndCloseActiveEditor();
 
         if (isEmptyArea) {
             if (selectionMode() != QAbstractItemView::SingleSelection)


### PR DESCRIPTION
When the view is not created completely, itemdelete is a null pointer. Judgment empty before use.

Log: Upgrade from 1054 to 1060 File Manager Crash