### PR TITLE
fix: [desktop] On desktop, click "win + d", the openwith dialog hide.

### DIFF
--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -240,7 +240,7 @@ void CommandParser::openWithDialog()
     }
     if (urlList.isEmpty())
         return;
-    dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", urlList);
+    dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", 0, urlList);
 }
 
 void CommandParser::openInHomeDirectory()

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -661,7 +661,7 @@ bool FileOperationsEventReceiver::handleOperationOpenFiles(const quint64 windowI
                 dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kMoveToTrash, windowId, urls, AbstractJobHandler::JobFlag::kNoHint, nullptr);
         } else {
             // deal open file with custom dialog
-            dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", urls);
+            dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", windowId, urls);
             ok = true;
         }
     }

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/openwithmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/openwithmenuscene.cpp
@@ -57,6 +57,7 @@ bool OpenWithMenuScene::initialize(const QVariantHash &params)
     if (!d->selectFiles.isEmpty())
         d->focusFile = d->selectFiles.first();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
+    d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
 
     const auto &tmpParams = dfmplugin_menu::MenuUtils::perfectMenuParams(params);
     d->isFocusOnDDEDesktopFile = tmpParams.value(MenuParamKey::kIsFocusOnDDEDesktopFile, false).toBool();
@@ -211,7 +212,7 @@ bool OpenWithMenuScene::triggered(QAction *action)
 
     if (actProperty == ActionID::kOpenWithCustom) {
         auto selectUrls = action->property(kSelectedUrls).value<QList<QUrl>>();
-        dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", selectUrls);
+        dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", d->windowId, selectUrls);
 
         return true;
     }

--- a/src/plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.cpp
@@ -7,6 +7,8 @@
 
 #include <dfm-framework/dpf.h>
 
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
 using namespace dfmplugin_utils;
 
 void OpenWithEventReceiver::initEventConnect()
@@ -14,12 +16,26 @@ void OpenWithEventReceiver::initEventConnect()
     dpfSlotChannel->connect("dfmplugin_utils", "slot_OpenWith_ShowDialog", this, &OpenWithEventReceiver::showOpenWithDialog);
 }
 
-void OpenWithEventReceiver::showOpenWithDialog(const QList<QUrl> &urls)
+void OpenWithEventReceiver::showOpenWithDialog(quint64 winId, const QList<QUrl> &urls)
 {
-    OpenWithDialog *d = new OpenWithDialog(urls);
+    QWidget *parentWidget { nullptr };
+    if (winId != 0) {
+        parentWidget  = FMWindowsIns.findWindowById(winId);
+        if (!parentWidget) {
+            QWidgetList topWidgets = qApp->topLevelWidgets();
+            auto find = std::find_if(topWidgets.begin(), topWidgets.end(), [winId](QWidget *w){
+                    return  w->internalWinId() == winId;
+            });
+            if (find != topWidgets.end()) {
+                parentWidget = *find;
+            }
+        }
+    }
+
+    OpenWithDialog *d = new OpenWithDialog(urls, parentWidget);
     d->setAttribute(Qt::WA_DeleteOnClose);
     d->setDisplayPosition(OpenWithDialog::Center);
-    d->open();
+    d->exec();
 }
 
 OpenWithEventReceiver::OpenWithEventReceiver(QObject *parent)

--- a/src/plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h
@@ -19,7 +19,7 @@ public:
     void initEventConnect();
 
 public:   //! slot event
-    void showOpenWithDialog(const QList<QUrl> &urls);
+    void showOpenWithDialog(quint64 winId, const QList<QUrl> &urls);
 };
 }
 #endif   // OPENWITHEVENTRECEIVER_H


### PR DESCRIPTION
the openwith dialog should model diskplay like old. so let the openwith dialog model display.

Log: fix issues
Bug: https://pms.uniontech.com/bug-view-199389.html