### PR TITLE
fix: [desktop] Abnormal display when dragging files on the desktop

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/viewpainter.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/viewpainter.cpp
@@ -172,15 +172,20 @@ void ViewPainter::drawDodge(QStyleOptionViewItem option)
         auto hoverIndex = d->dragDropOper->hoverIndex();
         auto url = model()->fileUrl(hoverIndex);
         auto selects = selectionModel()->selectedUrls();
+
         if (selects.contains(url) || (d->dodgeOper->getDodgeAnimationing() && d->dodgeOper->getDodgeItems().contains(url.toString()))) {
             // hover item selected,it draged.
             // or,it dodge animationing.
         } else if (hoverIndex.isValid() && hoverIndex != view()->currentIndex()) {
             QPainterPath path;
-            auto lastRect = view()->visualRect(hoverIndex);
+            QPen pen(QColor(30, 126, 255, 255 * 2 / 10));
+
+            const int border = 1;
+            pen.setWidth(1);
+            auto lastRect = view()->visualRect(hoverIndex).marginsRemoved(QMargins(border, border, border, border));
             path.addRoundRect(lastRect, 4, 4);
             fillPath(path, QColor(43, 167, 248, 255 * 3 / 10));
-            strokePath(path, QColor(30, 126, 255, 255 * 2 / 10));
+            strokePath(path, pen);
         }
     }
 


### PR DESCRIPTION
When painting the Hover icon, the actual drawing area is slightly larger

Log: Abnormal drag display when automatic organization is turned off