### PR TITLE
fix: [trash/restore]File restore, file manager occasionally crashes

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -154,12 +154,14 @@ void TaskDialog::setTitle(int taskCount)
 /*!
  * \brief TaskDialog::adjustSize 调整整个进度显示的高度，当每个item中的widget发生变化时
  */
-void TaskDialog::adjustSize()
+void TaskDialog::adjustSize(int hight)
 {
+    auto widgit = sender();
     int listHeight = 2;
     for (int i = 0; i < taskListWidget->count(); i++) {
         QListWidgetItem *item = taskListWidget->item(i);
-        int h = taskListWidget->itemWidget(item)->height();
+        auto wg = taskListWidget->itemWidget(item);
+        int h = widgit == wg && hight > 0 ? hight : wg->height();
         item->setSizeHint(QSize(item->sizeHint().width(), h));
         listHeight += h;
     }

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.h
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.h
@@ -42,7 +42,7 @@ Q_SIGNALS:
 private Q_SLOTS:
     void moveYCenter();
     void removeTask();
-    void adjustSize();
+    void adjustSize(int hight = 0);
 
 protected:
     void closeEvent(QCloseEvent *event) override;

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -165,6 +165,7 @@ void TaskWidget::onShowErrors(const JobInfoPointer jobInfo)
         widConfict = createConflictWidget();
         rVLayout->addWidget(widConfict);
     }
+    adjustSize();
 
     if (widConfict)
         widConfict->hide();
@@ -191,6 +192,8 @@ void TaskWidget::onShowConflictInfo(const QUrl source, const QUrl target, const 
         widConfict = createConflictWidget();
         rVLayout->addWidget(widConfict);
     }
+
+    adjustSize();
     QString error;
     const FileInfoPointer &originInfo = InfoFactory::create<FileInfo>(source, Global::CreateFileInfoType::kCreateFileInfoAuto, &error);
     if (!originInfo) {
@@ -321,7 +324,7 @@ void TaskWidget::onShowTaskInfo(const JobInfoPointer JobInfo)
     auto newhight = height();
 
     if (oldheight != newhight)
-        QTimer::singleShot(100, [this] { emit heightChanged(); });
+        emit heightChanged(newhight);
 }
 /*!
  * \brief TaskWidget::showTaskProccess 显示当前任务进度
@@ -675,6 +678,7 @@ void TaskWidget::showBtnByAction(const AbstractJobHandler::SupportActions &actio
  */
 void TaskWidget::showConflictButtons(bool showBtns, bool showConflict)
 {
+    Q_UNUSED(showConflict);
     if (!widConfict) {
         return;
     }
@@ -685,7 +689,7 @@ void TaskWidget::showConflictButtons(bool showBtns, bool showConflict)
     }
 
     adjustSize();
-    QTimer::singleShot(100, [this] { emit heightChanged(); });
+    emit heightChanged(this->height());
 }
 
 void TaskWidget::onMouseHover(const bool hover)

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.h
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.h
@@ -40,7 +40,7 @@ class TaskWidget : public QWidget
 
 Q_SIGNALS:
     void buttonClicked(AbstractJobHandler::SupportActions actions);
-    void heightChanged();
+    void heightChanged(int height);
 public Q_SLOTS:
     void parentClose();
 private Q_SLOTS:

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.h
@@ -46,6 +46,7 @@ private:
 
 private:
     QAtomicInteger<qint64> completeFilesCount { 0 };   // move to trash success file count
+    QList<QUrl> handleSourceFiles;   // List of all handled files
 };
 DPFILEOPERATIONS_END_NAMESPACE
 


### PR DESCRIPTION
The recycle bin is fully restored, and the iterator iterates out two files (actually, these two files are one). There was an issue with the first replacement and it was not recorded. The next file was processed directly. Modify 1. Record the URLs that have been manipulated, and those that have been manipulated are no longer being processed. 2. Modify the signal sending in the taskwidget, and I will call adjustsize when creating a new btn and adding a widget.

Log: File restore, file manager occasionally crashes
Bug: https://pms.uniontech.com/bug-view-200815.html https://pms.uniontech.com/bug-view-200811.html