### PR TITLE
fix: [io/rename]Unable to copy correctly after renaming

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -227,6 +227,11 @@ bool FileOperationsEventReceiver::doRenameFiles(const quint64 windowId, const QL
         errorMsg = fileHandler.errorString();
         DialogManagerInstance->showErrorDialog(tr("Rename file error"), errorMsg);
     }
+
+    for (const auto &scUrl : successUrls.keys()) {
+        ClipBoard::instance()->replaceClipboardUrl(scUrl, successUrls.value(scUrl));
+    }
+
     return ok;
 }
 


### PR DESCRIPTION
The content in the clipboard was not modified after renaming multiple files on the desktop

Log: Unable to copy correctly after renaming
Bug: https://pms.uniontech.com/bug-view-200855.html