### PR TITLE
fix: [workspace]tooltip display issue

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -135,9 +135,10 @@ bool IconItemDelegate::helpEvent(QHelpEvent *event, QAbstractItemView *view, con
 
         const QList<QRect> &geometries = paintGeomertys(option, index);
 
-        if (tooltip.isEmpty() || index == view->rootIndex() || geometries.count() < 3) {   // 当从一个需要显示tooltip的icon上移动光标到不需要显示的icon上时立即隐藏当前tooltip
+        if (tooltip.isEmpty() || index == view->rootIndex() || geometries.count() < 3
+                || option.fontMetrics.horizontalAdvance(tooltip) <= geometries[1].width() * 2) {   // 当从一个需要显示tooltip的icon上移动光标到不需要显示的icon上时立即隐藏当前tooltip
             ItemDelegateHelper::hideTooltipImmediately();
-        } else if (option.fontMetrics.horizontalAdvance(tooltip) > geometries[1].width() * 2) {
+        } else {
             int tooltipsize = tooltip.size();
             const int nlong = 32;
             int lines = tooltipsize / nlong + 1;


### PR DESCRIPTION
hide the file name tooltip immediately when cursor move out from the item.

Log: fix tooltip display issue
Bug: https://pms.uniontech.com/bug-view-200807.html