### PR TITLE
fix: When copying a linked file through the menu, the original file was actually copied.

### DIFF
--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -392,34 +392,17 @@ bool UniversalUtils::urlsTransform(const QList<QUrl> &sourceUrls, QList<QUrl> *t
 {
     Q_ASSERT(targetUrls);
     bool ret { false };
-
-    for (const auto &url : sourceUrls) {
-        auto info { InfoFactory::create<FileInfo>(url) };
-        if (info && info->canAttributes(FileInfo::FileCanType::kCanRedirectionFileUrl)) {
-            ret = true;
-            targetUrls->append(info->urlOf(UrlInfoType::kRedirectedFileUrl));
-        } else {
-            targetUrls->append(url);
-        }
-    }
-
-    return ret;
-}
-
-bool UniversalUtils::originalUrls(const QList<QUrl> &srcUrls, QList<QUrl> *targetUrls)
-{
-    bool ret { false };
-    if (srcUrls.isEmpty())
+    if (sourceUrls.isEmpty())
         return ret;
 
-    const auto &srcUrl = srcUrls.first();
+    const auto &srcUrl = sourceUrls.first();
     if (srcUrl.scheme() == Global::Scheme::kFile)
         return ret;
 
     UrlInfoType urlType = (srcUrl.scheme() == Global::Scheme::kTrash)
             ? UrlInfoType::kRedirectedFileUrl
             : UrlInfoType::kOriginalUrl;
-    for (const auto &url : srcUrls) {
+    for (const auto &url : sourceUrls) {
         auto info { InfoFactory::create<FileInfo>(url) };
         if (info) {
             ret = true;

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -38,7 +38,6 @@ public:
 
     static bool urlEquals(const QUrl &url1, const QUrl &url2);
     static bool urlsTransform(const QList<QUrl> &sourceUrls, QList<QUrl> *targetUrls);
-    static bool originalUrls(const QList<QUrl> &srcUrls, QList<QUrl> *targetUrls);
 
     static QString getCurrentUser();
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -285,7 +285,7 @@ JobHandlePointer FileOperationsEventReceiver::doCopyFile(const quint64 windowId,
     QList<QUrl> sourcesTrans = sources;
 
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::originalUrls(sourcesTrans, &urls);
+    bool ok = UniversalUtils::urlsTransform(sourcesTrans, &urls);
     if (ok && !urls.isEmpty())
         sourcesTrans = urls;
 
@@ -320,7 +320,7 @@ JobHandlePointer FileOperationsEventReceiver::doCutFile(quint64 windowId, const 
 
     QList<QUrl> sourcesTrans = sources;
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::originalUrls(sourcesTrans, &urls);
+    bool ok = UniversalUtils::urlsTransform(sourcesTrans, &urls);
     if (ok && !urls.isEmpty())
         sourcesTrans = urls;
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -143,7 +143,7 @@ void FileOperatorHelper::copyFiles(const FileView *view)
     QList<QUrl> selectedUrls = view->selectedUrlList();
     // trans url to local
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::originalUrls(selectedUrls, &urls);
+    bool ok = UniversalUtils::urlsTransform(selectedUrls, &urls);
     if (ok && !urls.isEmpty())
         selectedUrls = urls;
 
@@ -170,7 +170,7 @@ void FileOperatorHelper::cutFiles(const FileView *view)
         return;
     QList<QUrl> selectedUrls = view->selectedUrlList();
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::originalUrls(selectedUrls, &urls);
+    bool ok = UniversalUtils::urlsTransform(selectedUrls, &urls);
     if (ok && !urls.isEmpty())
         selectedUrls = urls;
 


### PR DESCRIPTION
The file path to which the linked file points is written to the clipboard

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-200945.html
