### PR TITLE
修复两个不影响稳定性的低级 Bug

### DIFF
--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -143,6 +143,8 @@ void DialogManager::showErrorDialogWhenOperateDeviceFailed(OperateType type, DFM
             errMsg = tr("Wrong password");
         else if (err.code == DeviceError::kUserErrorUserCancelled)
             errMsg.clear();
+        else if (err.code == DeviceError::kDaemonErrorCannotMkdirMountPoint)
+            errMsg = tr("Cannot create the mountpoint: the file name is too long");
         else if (static_cast<int>(err.code) == EACCES)
             errMsg = tr("Permission denied");
         else if (static_cast<int>(err.code) == ENOENT)

--- a/src/plugins/filemanager/core/dfmplugin-computer/controller/computercontroller.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/controller/computercontroller.cpp
@@ -120,6 +120,12 @@ void ComputerController::doRename(quint64 winId, const QUrl &url, const QString 
 {
     Q_UNUSED(winId);
 
+    QString newName(name);
+    if (newName.trimmed().isEmpty()) {
+        qInfo() << "empty name is inputed" << name << ", ignore rename action." << url;
+        return;
+    }
+
     DFMEntryFileInfoPointer info(new EntryFileInfo(url));
     bool removable = info->extraProperty(DeviceProperty::kRemovable).toBool();
     if (removable && info->nameOf(NameInfoType::kSuffix) == SuffixInfo::kBlock) {


### PR DESCRIPTION
do not rename disks if the new name is empty after trimmed.

Log: fix issue about disks rename.

Bug: https://pms.uniontech.com/bug-view-200809.html
