### PR TITLE
fix: [io/iterator]Failed to hide file

### DIFF
--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -176,13 +176,8 @@ QUrl LocalDirIterator::url() const
 void LocalDirIterator::cacheBlockIOAttribute()
 {
     const QUrl &rootUrl = this->url();
-    // Only the files in the local directory can go back to read the.
-    // hide file to determine whether it is hidden. Other directories can read
-    if (FileUtils::isLocalDevice(rootUrl)) {
-        const QUrl &url = DFMIO::DFMUtils::buildFilePath(rootUrl.toString().toStdString().c_str(), ".hidden", nullptr);
-        d->hideFileList = DFMIO::DFMUtils::hideListFromUrl(url);
-    }
-
+    const QUrl &url = DFMIO::DFMUtils::buildFilePath(rootUrl.toString().toStdString().c_str(), ".hidden", nullptr);
+    d->hideFileList = DFMIO::DFMUtils::hideListFromUrl(url);
     d->isLocalDevice = FileUtils::isLocalDevice(rootUrl);
     d->isCdRomDevice = FileUtils::isCdRomDevice(rootUrl);
 }


### PR DESCRIPTION
During asynchronous file iteration, the failure to retrieve the. hidden file resulted in a cache failure. Modify and read the. hidden file to determine if it is hidden

Log: Failed to hide file
Bug: https://pms.uniontech.com/bug-view-200835.html