### PR TITLE
fix: [workspace]GBK encoding connection, still displaying garbled code

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -52,6 +52,15 @@ void FileDataManager::cleanRoot(const QUrl &rootUrl, const QString &key, const b
         rootInfoMap.value(rootUrl)->reset();
 }
 
+void FileDataManager::cleanRoot(const QUrl &rootUrl)
+{
+    auto rootInfoKeys = rootInfoMap.keys();
+    for (const auto &rootInfo : rootInfoKeys) {
+        if (rootInfo.path().startsWith(rootUrl.path()))
+            rootInfoMap.remove(rootInfo);
+    }
+}
+
 void FileDataManager::setFileActive(const QUrl &rootUrl, const QUrl &childUrl, bool active)
 {
     RootInfo *root = rootInfoMap.value(rootUrl);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.h
@@ -30,6 +30,7 @@ public:
                     DFMGLOBAL_NAMESPACE::ItemRoles role = DFMGLOBAL_NAMESPACE::kItemFileDisplayNameRole,
                     Qt::SortOrder order = Qt::AscendingOrder);
     void cleanRoot(const QUrl &rootUrl, const QString &key, const bool refresh = false);
+    void cleanRoot(const QUrl &rootUrl);
     void setFileActive(const QUrl &rootUrl, const QUrl &childUrl, bool active);
 
 public Q_SLOTS:

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
@@ -347,6 +347,7 @@ void TabBar::closeTabAndRemoveCachedMnts(const QString &id)
         return;
     for (const auto &url : allMntedDevs.values(id)) {
         this->closeTab(WorkspaceHelper::instance()->windowId(this), url);
+        FileDataManager::instance()->cleanRoot(url);
     }
     allMntedDevs.remove(id);
 }


### PR DESCRIPTION
After receiving the offload signal, the cache was not cleared. Modify to clear the cache of rootinfo in the closeTabAndRemoveCachedMnts slot function

Log: GBK encoding connection, still displaying garbled code
Bug: https://pms.uniontech.com/bug-view-201233.html