### PR TITLE
fix: [preview] Preview window related bugs

### DIFF
--- a/src/plugins/common/dfmplugin-preview/filepreview/views/filepreviewdialog.h
+++ b/src/plugins/common/dfmplugin-preview/filepreview/views/filepreviewdialog.h
@@ -57,7 +57,6 @@ private:
     QString generalKey(const QString &key);
 
     QList<QUrl> fileList;
-    QList<QUrl> entryUrlList;
 
     DTK_WIDGET_NAMESPACE::DWindowCloseButton *closeButton { nullptr };
     DTK_WIDGET_NAMESPACE::DHorizontalLine *separator { nullptr };
@@ -65,6 +64,7 @@ private:
 
     bool playingVideo { false };
     bool firstEnterSwitchToPage { false };
+    bool previewDir { false };
     int currentPageIndex { -1 };
     quint64 currentWinID { 0 };
     DFMBASE_NAMESPACE::AbstractBasePreview *preview { nullptr };


### PR DESCRIPTION
1.When switching files in the preview window, the filemanager switches together 2.After moving the preview window, switching files will not center the window

Log: as title

Bug: https://pms.uniontech.com/bug-view-200501.html
    https://pms.uniontech.com/bug-view-200487.html