### PR TITLE
fix: filemanager crashed when recent file updated

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.h
@@ -14,11 +14,12 @@ namespace dfmplugin_recent {
 class RecentIterateWorker : public QObject
 {
     Q_OBJECT
+
 public:
     RecentIterateWorker();
 
 public slots:
-    void doWork();
+    void onRecentFileChanged(const QList<QUrl> &cachedUrls);
 
 signals:
     void updateRecentFileInfo(const QUrl &url, const QString originPath, qint64 readTime);

--- a/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.h
@@ -75,7 +75,7 @@ public:
     bool handleDropFiles(const QList<QUrl> &fromUrls, const QUrl &toUrl);
 
 signals:
-    void asyncHandleFileChanged();
+    void asyncHandleFileChanged(const QList<QUrl> &);
 
 private:
     explicit RecentManager(QObject *parent = nullptr);

--- a/tests/plugins/filemanager/core/dfmplugin-recent/files/ut_recentiteratewoker.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-recent/files/ut_recentiteratewoker.cpp
@@ -33,7 +33,7 @@ private:
     stub_ext::StubExt stub;
 };
 
-TEST_F(RecentIterateWorkerTest, doWork)
+TEST_F(RecentIterateWorkerTest, onRecentFileChanged)
 {
     stub.set_lamda(&RecentManager::init, []() {});
     stub.set_lamda(&SyncFileInfoPrivate::init, [] {});
@@ -45,7 +45,7 @@ TEST_F(RecentIterateWorkerTest, doWork)
         return true;
     });
 
-    stub.set_lamda(&QStringRef::isEmpty, []() -> bool { return false; });
+    stub.set_lamda(&QString::isEmpty, []() -> bool { return false; });
     QString str("bookmark");
     stub.set_lamda(&QXmlStreamReader::name, [str]() -> QStringRef {
         return QStringRef(&str);
@@ -61,11 +61,7 @@ TEST_F(RecentIterateWorkerTest, doWork)
     stub.set_lamda((bool (*)(QIODevice::OpenMode))((bool (QFile::*)(QIODevice::OpenMode)) & QFile::open), []() {
         return true;
     });
-    stub.set_lamda(&RecentManager::getRecentNodes, []() -> QMap<QUrl, FileInfoPointer> {
-        QMap<QUrl, FileInfoPointer> map;
-        map[QUrl("hello/uos")] = nullptr;
-        return map;
-    });
+
     RecentIterateWorker worker;
     int flag = 0;
     QObject::connect(&worker, &RecentIterateWorker::updateRecentFileInfo, [&flag](const QUrl &url, const QString originPath, qint64 readTime) {
@@ -76,7 +72,7 @@ TEST_F(RecentIterateWorkerTest, doWork)
         EXPECT_FALSE(urls.isEmpty());
         flag++;
     });
-    EXPECT_NO_FATAL_FAILURE(worker.doWork());
+    EXPECT_NO_FATAL_FAILURE(worker.onRecentFileChanged({ QUrl("hello/uos") }));
 
     EXPECT_EQ(flag, 2);
 }


### PR DESCRIPTION
Atomicity violation due to the use of `RecentManager::recentNodes` in the `RecentIterateWorker`

Log: fix crashed bug

Bug: https://pms.uniontech.com/bug-view-200131.html