### PR TITLE
fix: File size display error

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -986,7 +986,7 @@ QString AsyncFileInfoPrivate::sizeFormat() const
         return QStringLiteral("-");
     }
 
-    return FileUtils::formatSize(cacheAsyncAttributes.value(AsyncFileInfo::AsyncAttributeID::kStandardSize).toInt());
+    return FileUtils::formatSize(cacheAsyncAttributes.value(AsyncFileInfo::AsyncAttributeID::kStandardSize).toLongLong());
 }
 
 QVariant AsyncFileInfoPrivate::attribute(DFileInfo::AttributeID key, bool *ok) const


### PR DESCRIPTION
The file size exceeds the maximum value of `int` type.`long long` should be used.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-200531.html
