### PR TITLE
fix: [fileinfo]The file manager occasionally crashes

### DIFF
--- a/include/dfm-base/interfaces/abstractsortfilter.h
+++ b/include/dfm-base/interfaces/abstractsortfilter.h
@@ -27,11 +27,11 @@ public:
     AbstractSortFilter();
     virtual ~AbstractSortFilter() {}
     // 左边比右边小返回true
-    virtual int lessThan(const FileInfoPointer &left, const FileInfoPointer &right,
+    virtual int lessThan(const FileInfoPointer left, const FileInfoPointer right,
                          const bool isMixDirAndFile,
                          const Global::ItemRoles role,
                          const SortScenarios ss);
-    virtual int checkFilters(const FileInfoPointer &info, const QDir::Filters filter, const QVariant &custum);
+    virtual int checkFilters(const FileInfoPointer info, const QDir::Filters filter, const QVariant &custum);
 };
 }
 

--- a/include/dfm-base/interfaces/proxyfileinfo.h
+++ b/include/dfm-base/interfaces/proxyfileinfo.h
@@ -18,7 +18,7 @@ public:
     virtual void refresh() override;
 
 protected:
-    void setProxy(const FileInfoPointer &proxy);
+    void setProxy(const FileInfoPointer proxy);
     FileInfoPointer proxy { nullptr };
 
     // AbstractFileInfo interface

--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -277,7 +277,7 @@ void CommandParser::openInUrls()
         QUrl url = UrlRoute::fromUserInput(path);
 
         if (isSet("show-item")) {
-            const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
+            const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(url);
             if (!fileInfo)
                 continue;
 

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -195,7 +195,7 @@ void TaskWidget::onShowConflictInfo(const QUrl source, const QUrl target, const 
 
     adjustSize();
     QString error;
-    const FileInfoPointer &originInfo = InfoFactory::create<FileInfo>(source, Global::CreateFileInfoType::kCreateFileInfoAuto, &error);
+    const FileInfoPointer originInfo = InfoFactory::create<FileInfo>(source, Global::CreateFileInfoType::kCreateFileInfoAuto, &error);
     if (!originInfo) {
         lbErrorMsg->setText(QString(tr("create source file %1 Info failed in show conflict Info function!")).arg(source.path()));
         showBtnByAction(AbstractJobHandler::SupportAction::kCancelAction);

--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -73,7 +73,7 @@ DesktopFileInfo::DesktopFileInfo(const QUrl &fileUrl)
 {
 }
 
-DesktopFileInfo::DesktopFileInfo(const QUrl &fileUrl, const FileInfoPointer &info)
+DesktopFileInfo::DesktopFileInfo(const QUrl &fileUrl, const FileInfoPointer info)
     : ProxyFileInfo(fileUrl), d(new DesktopFileInfoPrivate(fileUrl))
 {
     setProxy(info);

--- a/src/dfm-base/file/local/desktopfileinfo.h
+++ b/src/dfm-base/file/local/desktopfileinfo.h
@@ -17,7 +17,7 @@ class DesktopFileInfo : public ProxyFileInfo
 {
 public:
     explicit DesktopFileInfo(const QUrl &fileUrl);
-    explicit DesktopFileInfo(const QUrl &fileUrl, const FileInfoPointer &info);
+    explicit DesktopFileInfo(const QUrl &fileUrl, const FileInfoPointer info);
     bool canTag() const;
 
 public:

--- a/src/dfm-base/interfaces/abstractsortfilter.cpp
+++ b/src/dfm-base/interfaces/abstractsortfilter.cpp
@@ -10,7 +10,7 @@ AbstractSortFilter::AbstractSortFilter()
 {
 }
 
-int AbstractSortFilter::lessThan(const FileInfoPointer &left, const FileInfoPointer &right, const bool isMixDirAndFile, const Global::ItemRoles role, const SortScenarios ss)
+int AbstractSortFilter::lessThan(const FileInfoPointer left, const FileInfoPointer right, const bool isMixDirAndFile, const Global::ItemRoles role, const SortScenarios ss)
 {
     Q_UNUSED(left)
     Q_UNUSED(right)
@@ -20,7 +20,7 @@ int AbstractSortFilter::lessThan(const FileInfoPointer &left, const FileInfoPoin
     return -1;
 }
 
-int AbstractSortFilter::checkFilters(const FileInfoPointer &info, const QDir::Filters filter, const QVariant &custum)
+int AbstractSortFilter::checkFilters(const FileInfoPointer info, const QDir::Filters filter, const QVariant &custum)
 {
     Q_UNUSED(info)
     Q_UNUSED(filter)

--- a/src/dfm-base/interfaces/proxyfileinfo.cpp
+++ b/src/dfm-base/interfaces/proxyfileinfo.cpp
@@ -38,7 +38,7 @@ void ProxyFileInfo::refresh()
     return FileInfo::refresh();
 }
 
-void ProxyFileInfo::setProxy(const FileInfoPointer &proxy)
+void ProxyFileInfo::setProxy(const FileInfoPointer proxy)
 {
     this->proxy = proxy;
     auto asyncInfo = this->proxy.dynamicCast<AsyncFileInfo>();

--- a/src/dfm-base/mimetype/dmimedatabase.cpp
+++ b/src/dfm-base/mimetype/dmimedatabase.cpp
@@ -27,11 +27,11 @@ DMimeDatabase::DMimeDatabase()
 
 QMimeType DMimeDatabase::mimeTypeForFile(const QUrl &url, QMimeDatabase::MatchMode mode) const
 {
-    const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
+    const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(url);
     return mimeTypeForFile(fileInfo, mode);
 }
 
-QMimeType DMimeDatabase::mimeTypeForFile(const FileInfoPointer &fileInfo, QMimeDatabase::MatchMode mode) const
+QMimeType DMimeDatabase::mimeTypeForFile(const FileInfoPointer fileInfo, QMimeDatabase::MatchMode mode) const
 {
     // 如果是低速设备，则先从扩展名去获取mime信息；对于本地文件，保持默认的获取策略
     QMimeType result;

--- a/src/dfm-base/mimetype/dmimedatabase.h
+++ b/src/dfm-base/mimetype/dmimedatabase.h
@@ -20,7 +20,7 @@ public:
     DMimeDatabase();
 
     QMimeType mimeTypeForFile(const QUrl &url, MatchMode mode = MatchDefault) const;
-    QMimeType mimeTypeForFile(const FileInfoPointer &fileInfo, MatchMode mode = MatchDefault) const;
+    QMimeType mimeTypeForFile(const FileInfoPointer fileInfo, MatchMode mode = MatchDefault) const;
     QMimeType mimeTypeForFile(const QString &fileName, MatchMode mode, const QString &inod, const bool isGvfs = false) const;
     QMimeType mimeTypeForUrl(const QUrl &url) const;
 

--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -83,7 +83,7 @@ void onClipboardDataChanged()
             clipboardFileUrls << url;
         }
         //链接文件的inode不加入clipbordFileinode，只用url判断clip，避免多个同源链接文件的逻辑误判
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto, &errorStr);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto, &errorStr);
 
         if (!info) {
             qWarning() << QString("create file info error, case : %1").arg(errorStr);
@@ -142,7 +142,7 @@ void ClipBoard::setUrlsToClipboard(const QList<QUrl> &list, ClipBoard::Clipboard
 
         const QString &path = qurl.toLocalFile();
 
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(qurl, Global::CreateFileInfoType::kCreateFileInfoAuto, &error);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(qurl, Global::CreateFileInfoType::kCreateFileInfoAuto, &error);
 
         if (!info) {
             qWarning() << QString("create file info error, case : %1").arg(error);

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -673,7 +673,7 @@ QString FileUtils::cutFileName(const QString &name, int maxLength, bool useCharC
 
 QString FileUtils::nonExistSymlinkFileName(const QUrl &fileUrl, const QUrl &parentUrl)
 {
-    const FileInfoPointer &info = InfoFactory::create<FileInfo>(fileUrl);
+    const FileInfoPointer info = InfoFactory::create<FileInfo>(fileUrl);
 
     if (info && DFMIO::DFile(fileUrl).exists()) {
         QString baseName = info->displayOf(DisPlayInfoType::kFileDisplayName) == info->nameOf(NameInfoType::kFileName)

--- a/src/dfm-base/utils/thumbnailprovider.cpp
+++ b/src/dfm-base/utils/thumbnailprovider.cpp
@@ -116,7 +116,7 @@ uint64_t ThumbnailProviderPrivate::filePathToInode(QString filePath) const
 
 bool ThumbnailProvider::hasThumbnail(const QUrl &url) const
 {
-    const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
+    const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(url);
 
     if (!fileInfo->isAttributes(OptInfoType::kIsReadable) || !fileInfo->isAttributes(OptInfoType::kIsFile))
         return false;
@@ -301,7 +301,7 @@ QString ThumbnailProvider::createThumbnail(const QUrl &url, ThumbnailProvider::S
 {
     d->errorString.clear();
 
-    const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
+    const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(url);
 
     const QString &dirPath = fileInfo->pathOf(PathInfoType::kAbsolutePath);
     const QString &filePath = fileInfo->pathOf(PathInfoType::kAbsoluteFilePath);

--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
@@ -196,7 +196,7 @@ FileManagerWindowsManager::FMWindow *FileManagerWindowsManager::createWindow(con
 
     QUrl showedUrl = Application::instance()->appUrlAttribute(Application::kUrlOfNewWindow);
     if (!url.isEmpty()) {
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(url);
         if (info && info->isAttributes(OptInfoType::kIsFile)) {
             showedUrl = UrlRoute::urlParent(url);
         } else {

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
@@ -132,7 +132,7 @@ bool DoCleanTrashFilesWorker::cleanAllTrashFiles()
  * \param trashInfo File information in Recycle Bin
  * \return Is the execution successful
  */
-bool DoCleanTrashFilesWorker::clearTrashFile(const FileInfoPointer &trashInfo)
+bool DoCleanTrashFilesWorker::clearTrashFile(const FileInfoPointer trashInfo)
 {
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
     do {

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.h
@@ -33,7 +33,7 @@ protected:
 
 protected:
     bool cleanAllTrashFiles();
-    bool clearTrashFile(const FileInfoPointer &trashInfo);
+    bool clearTrashFile(const FileInfoPointer trashInfo);
     AbstractJobHandler::SupportAction doHandleErrorAndWait(const QUrl &from,
                                                            const AbstractJobHandler::JobErrorType &error,
                                                            const bool isTo = false,

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -144,7 +144,7 @@ bool DoCutFilesWorker::cutFiles()
     return true;
 }
 
-bool DoCutFilesWorker::doCutFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo)
+bool DoCutFilesWorker::doCutFile(const FileInfoPointer fromInfo, const FileInfoPointer targetPathInfo)
 {
     // try rename
     bool ok = false;
@@ -216,7 +216,7 @@ void DoCutFilesWorker::emitCompleteFilesUpdatedNotify(const qint64 &writCount)
     emit stateChangedNotify(info);
 }
 
-bool DoCutFilesWorker::checkSymLink(const FileInfoPointer &fileInfo)
+bool DoCutFilesWorker::checkSymLink(const FileInfoPointer fileInfo)
 {
     const QUrl &sourceUrl = fileInfo->urlOf(UrlInfoType::kUrl);
     FileInfoPointer newTargetInfo(nullptr);
@@ -238,7 +238,7 @@ bool DoCutFilesWorker::checkSymLink(const FileInfoPointer &fileInfo)
     return true;
 }
 
-bool DoCutFilesWorker::checkSelf(const FileInfoPointer &fileInfo)
+bool DoCutFilesWorker::checkSelf(const FileInfoPointer fileInfo)
 {
     const QString &fileName = fileInfo->nameOf(NameInfoType::kFileName);
     QString newFileUrl = targetInfo->urlOf(UrlInfoType::kUrl).toString();
@@ -254,7 +254,7 @@ bool DoCutFilesWorker::checkSelf(const FileInfoPointer &fileInfo)
     return false;
 }
 
-bool DoCutFilesWorker::renameFileByHandler(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetInfo)
+bool DoCutFilesWorker::renameFileByHandler(const FileInfoPointer sourceInfo, const FileInfoPointer targetInfo)
 {
     if (localFileHandler) {
         const QUrl &sourceUrl = sourceInfo->urlOf(UrlInfoType::kUrl);
@@ -264,7 +264,7 @@ bool DoCutFilesWorker::renameFileByHandler(const FileInfoPointer &sourceInfo, co
     return false;
 }
 
-bool DoCutFilesWorker::doRenameFile(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetPathInfo, FileInfoPointer &toInfo, const QString fileName, bool *ok)
+bool DoCutFilesWorker::doRenameFile(const FileInfoPointer sourceInfo, const FileInfoPointer targetPathInfo, FileInfoPointer toInfo, const QString fileName, bool *ok)
 {
     QSharedPointer<QStorageInfo> sourceStorageInfo = nullptr;
     sourceStorageInfo.reset(new QStorageInfo(sourceInfo->urlOf(UrlInfoType::kUrl).path()));

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
@@ -35,15 +35,15 @@ protected:
     void onUpdateProgress() override;
 
     bool cutFiles();
-    bool doCutFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo);
-    bool doRenameFile(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetPathInfo, FileInfoPointer &toInfo, const QString fileName, bool *ok);
-    bool renameFileByHandler(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetInfo);
+    bool doCutFile(const FileInfoPointer fromInfo, const FileInfoPointer targetPathInfo);
+    bool doRenameFile(const FileInfoPointer sourceInfo, const FileInfoPointer targetPathInfo, FileInfoPointer toInfo, const QString fileName, bool *ok);
+    bool renameFileByHandler(const FileInfoPointer sourceInfo, const FileInfoPointer targetInfo);
 
     void emitCompleteFilesUpdatedNotify(const qint64 &writCount);
 
 private:
-    bool checkSymLink(const FileInfoPointer &fromInfo);
-    bool checkSelf(const FileInfoPointer &fromInfo);
+    bool checkSymLink(const FileInfoPointer fromInfo);
+    bool checkSelf(const FileInfoPointer fromInfo);
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -154,7 +154,7 @@ bool DoDeleteFilesWorker::deleteFileOnOtherDevice(const QUrl &url)
  * \param dir delete dir
  * \return delete success
  */
-bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer &dir)
+bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer dir)
 {
     if (!stateCheck())
         return false;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.h
@@ -34,7 +34,7 @@ protected:
     bool deleteFilesOnCanNotRemoveDevice();
     bool deleteFilesOnOtherDevice();
     bool deleteFileOnOtherDevice(const QUrl &url);
-    bool deleteDirOnOtherDevice(const FileInfoPointer &dir);
+    bool deleteDirOnOtherDevice(const FileInfoPointer dir);
     AbstractJobHandler::SupportAction doHandleErrorAndWait(const QUrl &from,
                                                            const AbstractJobHandler::JobErrorType &error,
                                                            const QString &errorMsg = QString());

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -462,7 +462,7 @@ AbstractJobHandler::SupportAction DoCopyFileWorker::doHandleErrorAndWait(const Q
  * \brief FileOperateBaseWorker::readAheadSourceFile Pre read source file content
  * \param fileInfo File information of source file
  */
-void DoCopyFileWorker::readAheadSourceFile(const FileInfoPointer &fileInfo)
+void DoCopyFileWorker::readAheadSourceFile(const FileInfoPointer fileInfo)
 {
     if (fileInfo->size() <= 0)
         return;
@@ -482,8 +482,8 @@ void DoCopyFileWorker::readAheadSourceFile(const FileInfoPointer &fileInfo)
  * \param result result result Output parameter: whether skip
  * \return Is the device of the file created successfully
  */
-bool DoCopyFileWorker::createFileDevice(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                                        const FileInfoPointer &needOpenInfo, QSharedPointer<DFMIO::DFile> &file,
+bool DoCopyFileWorker::createFileDevice(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
+                                        const FileInfoPointer needOpenInfo, QSharedPointer<DFMIO::DFile> &file,
                                         bool *skip)
 {
     file.reset();
@@ -517,7 +517,7 @@ bool DoCopyFileWorker::createFileDevice(const FileInfoPointer &fromInfo, const F
  * \param result result Output parameter: whether skip
  * \return Whether the device of source file and target file is created successfully
  */
-bool DoCopyFileWorker::createFileDevices(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+bool DoCopyFileWorker::createFileDevices(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                          QSharedPointer<DFMIO::DFile> &fromeFile, QSharedPointer<DFMIO::DFile> &toFile, bool *skip)
 {
     if (!createFileDevice(fromInfo, toInfo, fromInfo, fromeFile, skip))
@@ -536,7 +536,7 @@ bool DoCopyFileWorker::createFileDevices(const FileInfoPointer &fromInfo, const 
  * \param result result Output parameter: whether skip
  * \return Open source and target files successfully
  */
-bool DoCopyFileWorker::openFiles(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+bool DoCopyFileWorker::openFiles(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                  const QSharedPointer<DFMIO::DFile> &fromeFile, const QSharedPointer<DFMIO::DFile> &toFile,
                                  bool *skip)
 {
@@ -561,7 +561,7 @@ bool DoCopyFileWorker::openFiles(const FileInfoPointer &fromInfo, const FileInfo
  * \param result result Output parameter: whether skip
  * \return wether open the file successfully
  */
-bool DoCopyFileWorker::openFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+bool DoCopyFileWorker::openFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                 const QSharedPointer<DFMIO::DFile> &file, const DFMIO::DFile::OpenFlags &flags,
                                 bool *skip)
 {
@@ -587,7 +587,7 @@ bool DoCopyFileWorker::openFile(const FileInfoPointer &fromInfo, const FileInfoP
     return true;
 }
 
-bool DoCopyFileWorker::resizeTargetFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+bool DoCopyFileWorker::resizeTargetFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                         const QSharedPointer<DFMIO::DFile> &file, bool *skip)
 {
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
@@ -616,7 +616,7 @@ bool DoCopyFileWorker::resizeTargetFile(const FileInfoPointer &fromInfo, const F
  * \param result result Output parameter: whether skip
  * \return Read successfully
  */
-bool DoCopyFileWorker::doReadFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+bool DoCopyFileWorker::doReadFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                   const QSharedPointer<DFMIO::DFile> &fromDevice,
                                   char *data, const qint64 &blockSize,
                                   qint64 &readSize, bool *skip)
@@ -686,7 +686,7 @@ bool DoCopyFileWorker::doReadFile(const FileInfoPointer &fromInfo, const FileInf
  * \param result result Output parameter: whether skip
  * \return Write successfully
  */
-bool DoCopyFileWorker::doWriteFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+bool DoCopyFileWorker::doWriteFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                    const QSharedPointer<DFMIO::DFile> &toDevice,
                                    const char *data, const qint64 readSize, bool *skip)
 {
@@ -755,7 +755,7 @@ bool DoCopyFileWorker::doWriteFile(const FileInfoPointer &fromInfo, const FileIn
 }
 
 bool DoCopyFileWorker::verifyFileIntegrity(const qint64 &blockSize, const ulong &sourceCheckSum,
-                                           const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+                                           const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                            QSharedPointer<DFMIO::DFile> &toDevice)
 {
     if (!workData->jobFlags.testFlag(AbstractJobHandler::JobFlag::kCopyIntegrityChecking))
@@ -928,7 +928,7 @@ void DoCopyFileWorker::syncBlockFile(const BlockFileCopyInfoPointer &info, bool 
  * \param fromInfo File information of source file
  * \param toInfo File information of target file
  */
-void DoCopyFileWorker::setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo)
+void DoCopyFileWorker::setTargetPermissions(const FileInfoPointer fromInfo, const FileInfoPointer toInfo)
 {
     // 修改文件修改时间
     localFileHandler->setFileTime(toInfo->urlOf(UrlInfoType::kUrl), fromInfo->timeOf(TimeInfoType::kLastRead).value<QDateTime>(), fromInfo->timeOf(TimeInfoType::kLastModified).value<QDateTime>());

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -67,30 +67,30 @@ private:   // file copy
                                                            const bool isTo = false,
                                                            const QString &errorMsg = QString());
 
-    void readAheadSourceFile(const FileInfoPointer &fileInfo);
-    bool createFileDevices(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    void readAheadSourceFile(const FileInfoPointer fileInfo);
+    bool createFileDevices(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                            QSharedPointer<DFMIO::DFile> &fromeFile, QSharedPointer<DFMIO::DFile> &toFile,
                            bool *skip);
-    bool createFileDevice(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                          const FileInfoPointer &needOpenInfo, QSharedPointer<DFMIO::DFile> &file,
+    bool createFileDevice(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
+                          const FileInfoPointer needOpenInfo, QSharedPointer<DFMIO::DFile> &file,
                           bool *skip);
-    bool openFiles(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool openFiles(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                    const QSharedPointer<DFMIO::DFile> &fromeFile, const QSharedPointer<DFMIO::DFile> &toFile,
                    bool *skip);
-    bool openFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool openFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                   const QSharedPointer<DFMIO::DFile> &file, const DFMIO::DFile::OpenFlags &flags,
                   bool *skip);
-    bool resizeTargetFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool resizeTargetFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                           const QSharedPointer<DFMIO::DFile> &file, bool *skip);
-    bool doReadFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool doReadFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                     const QSharedPointer<DFMIO::DFile> &fromDevice,
                     char *data, const qint64 &blockSize, qint64 &readSize, bool *skip);
-    bool doWriteFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool doWriteFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                      const QSharedPointer<DFMIO::DFile> &toDevice,
                      const char *data, const qint64 readSize, bool *skip);
-    void setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo);
+    void setTargetPermissions(const FileInfoPointer fromInfo, const FileInfoPointer toInfo);
     bool verifyFileIntegrity(const qint64 &blockSize, const ulong &sourceCheckSum,
-                             const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+                             const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                              QSharedPointer<DFMIO::DFile> &toFile);
     void checkRetry();
     bool isStopped();

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -92,7 +92,7 @@ void FileOperateBaseWorker::emitSpeedUpdatedNotify(const qint64 &writSize)
  * \param fromInfo File information of source file
  * \param toInfo File information of target file
  */
-void FileOperateBaseWorker::setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo)
+void FileOperateBaseWorker::setTargetPermissions(const FileInfoPointer fromInfo, const FileInfoPointer toInfo)
 {
     // 修改文件修改时间
     localFileHandler->setFileTime(toInfo->urlOf(UrlInfoType::kUrl),
@@ -109,7 +109,7 @@ void FileOperateBaseWorker::setTargetPermissions(const FileInfoPointer &fromInfo
  * \brief FileOperateBaseWorker::readAheadSourceFile Pre read source file content
  * \param fileInfo File information of source file
  */
-void FileOperateBaseWorker::readAheadSourceFile(const FileInfoPointer &fileInfo)
+void FileOperateBaseWorker::readAheadSourceFile(const FileInfoPointer fileInfo)
 {
     if (fileInfo->size() <= 0)
         return;
@@ -274,7 +274,7 @@ bool FileOperateBaseWorker::copyFileFromTrash(const QUrl &urlSource, const QUrl 
  * \param result Output parameter: whether skip
  * \return Is the copy successful
  */
-bool FileOperateBaseWorker::copyAndDeleteFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo, const FileInfoPointer &toInfo, bool *skip)
+bool FileOperateBaseWorker::copyAndDeleteFile(const FileInfoPointer fromInfo, const FileInfoPointer targetPathInfo, const FileInfoPointer toInfo, bool *skip)
 {
     bool ok = false;
     if (!toInfo)
@@ -320,8 +320,8 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const FileInfoPointer &fromInfo, c
  * \param result Output parameter: whether skip
  * \return Is it successful
  */
-bool FileOperateBaseWorker::doCheckFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, const QString &fileName,
-                                        FileInfoPointer &newTargetInfo, bool *skip)
+bool FileOperateBaseWorker::doCheckFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, const QString &fileName,
+                                        FileInfoPointer newTargetInfo, bool *skip)
 {
     // 检查源文件的文件信息
     if (!fromInfo) {
@@ -406,7 +406,7 @@ bool FileOperateBaseWorker::doCheckFile(const FileInfoPointer &fromInfo, const F
  * \param result Output parameter: whether skip
  * \return Was the linked file created successfully
  */
-bool FileOperateBaseWorker::createSystemLink(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+bool FileOperateBaseWorker::createSystemLink(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                                              const bool followLink, const bool doCopy, bool *skip)
 {
     // 创建链接文件
@@ -415,7 +415,7 @@ bool FileOperateBaseWorker::createSystemLink(const FileInfoPointer &fromInfo, co
         do {
             QUrl newUrl = newFromInfo->urlOf(UrlInfoType::kUrl);
             newUrl.setPath(newFromInfo->pathOf(PathInfoType::kSymLinkTarget));
-            const FileInfoPointer &symlinkTarget = InfoFactory::create<FileInfo>(newUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
+            const FileInfoPointer symlinkTarget = InfoFactory::create<FileInfo>(newUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
 
             if (!symlinkTarget || !symlinkTarget->exists()) {
                 break;
@@ -458,8 +458,8 @@ bool FileOperateBaseWorker::createSystemLink(const FileInfoPointer &fromInfo, co
  * \param result Output parameter: whether skip
  * \return Is it successful
  */
-bool FileOperateBaseWorker::doCheckNewFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                                           FileInfoPointer &newTargetInfo, QString &fileNewName, bool *skip, bool isCountSize)
+bool FileOperateBaseWorker::doCheckNewFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
+                                           FileInfoPointer newTargetInfo, QString &fileNewName, bool *skip, bool isCountSize)
 {
     auto newTargetUrl = createNewTargetUrl(toInfo, fileNewName);
     if (createNewTargetInfo(fromInfo, toInfo, newTargetInfo, newTargetUrl, skip, isCountSize))
@@ -559,7 +559,7 @@ bool FileOperateBaseWorker::checkAndCopyFile(const FileInfoPointer fromInfo, con
     return doCopyOtherFile(fromInfo, toInfo, skip);
 }
 
-bool FileOperateBaseWorker::checkAndCopyDir(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, bool *skip)
+bool FileOperateBaseWorker::checkAndCopyDir(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip)
 {
     emitCurrentTaskNotify(fromInfo->urlOf(UrlInfoType::kUrl), toInfo->urlOf(UrlInfoType::kUrl));
     // 检查文件的一些合法性，源文件是否存在，创建新的目标目录名称，检查新创建目标目录名称是否存在
@@ -612,7 +612,7 @@ bool FileOperateBaseWorker::checkAndCopyDir(const FileInfoPointer &fromInfo, con
         }
 
         const QUrl &url = iterator->next();
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         bool ok = doCopyFile(info, toInfo, skip);
         if (!ok && !skip) {
             return false;
@@ -679,7 +679,7 @@ void FileOperateBaseWorker::initCopyWay()
     copyTid = (countWriteType == CountWriteSizeType::kTidType) ? syscall(SYS_gettid) : -1;
 }
 
-QUrl FileOperateBaseWorker::trashInfo(const FileInfoPointer &fromInfo)
+QUrl FileOperateBaseWorker::trashInfo(const FileInfoPointer fromInfo)
 {
     auto parentPath = fromInfo->urlOf(UrlInfoType::kParentUrl).path();
     if (!parentPath.endsWith("files"))
@@ -751,7 +751,7 @@ void FileOperateBaseWorker::initSignalCopyWorker()
     }
 }
 
-QUrl FileOperateBaseWorker::createNewTargetUrl(const FileInfoPointer &toInfo, const QString &fileName)
+QUrl FileOperateBaseWorker::createNewTargetUrl(const FileInfoPointer toInfo, const QString &fileName)
 {
     QString fileNewName = formatFileName(fileName);
     // 创建文件的名称
@@ -1007,7 +1007,7 @@ void FileOperateBaseWorker::startBlockFileCopy()
     }
 }
 
-bool FileOperateBaseWorker::createNewTargetInfo(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, FileInfoPointer &newTargetInfo, const QUrl &fileNewUrl, bool *skip, bool isCountSize)
+bool FileOperateBaseWorker::createNewTargetInfo(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, FileInfoPointer newTargetInfo, const QUrl &fileNewUrl, bool *skip, bool isCountSize)
 {
     newTargetInfo.reset();
 
@@ -1052,7 +1052,7 @@ void FileOperateBaseWorker::skipMemcpyBigFile(const QUrl url)
     }
 }
 
-QVariant FileOperateBaseWorker::checkLinkAndSameUrl(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize)
+QVariant FileOperateBaseWorker::checkLinkAndSameUrl(const FileInfoPointer fromInfo, const FileInfoPointer newTargetInfo, const bool isCountSize)
 {
     if (newTargetInfo->isAttributes(OptInfoType::kIsSymLink)) {
         LocalFileHandler handler;
@@ -1069,7 +1069,7 @@ QVariant FileOperateBaseWorker::checkLinkAndSameUrl(const FileInfoPointer &fromI
     return QVariant();
 }
 
-QVariant FileOperateBaseWorker::doActionReplace(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize)
+QVariant FileOperateBaseWorker::doActionReplace(const FileInfoPointer fromInfo, const FileInfoPointer newTargetInfo, const bool isCountSize)
 {
     const QVariant &var = checkLinkAndSameUrl(fromInfo, newTargetInfo, isCountSize);
     if (var.isValid())
@@ -1085,7 +1085,7 @@ QVariant FileOperateBaseWorker::doActionReplace(const FileInfoPointer &fromInfo,
     }
 }
 
-QVariant FileOperateBaseWorker::doActionMerge(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize)
+QVariant FileOperateBaseWorker::doActionMerge(const FileInfoPointer fromInfo, const FileInfoPointer newTargetInfo, const bool isCountSize)
 {
     const bool fromIsFile = fromInfo->isAttributes(OptInfoType::kIsFile) || fromInfo->isAttributes(OptInfoType::kIsSymLink);
     const bool newTargetIsFile = newTargetInfo->isAttributes(OptInfoType::kIsFile) || newTargetInfo->isAttributes(OptInfoType::kIsSymLink);
@@ -1100,7 +1100,7 @@ QVariant FileOperateBaseWorker::doActionMerge(const FileInfoPointer &fromInfo, c
     }
 }
 
-bool FileOperateBaseWorker::doCopyFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, bool *skip)
+bool FileOperateBaseWorker::doCopyFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip)
 {
     FileInfoPointer newTargetInfo(nullptr);
     bool result = false;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -41,20 +41,20 @@ public:
     };
 
 public:
-    bool doCheckFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, const QString &fileName,
-                     FileInfoPointer &newTargetInfo, bool *skip);
-    bool doCheckNewFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                        FileInfoPointer &newTargetInfo, QString &fileNewName,
+    bool doCheckFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, const QString &fileName,
+                     FileInfoPointer newTargetInfo, bool *skip);
+    bool doCheckNewFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
+                        FileInfoPointer newTargetInfo, QString &fileNewName,
                         bool *skip, bool isCountSize = false);
     bool checkDiskSpaceAvailable(const QUrl &fromUrl, const QUrl &toUrl,
                                  QSharedPointer<StorageInfo> targetStorageInfo, bool *skip);
-    void setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo);
+    void setTargetPermissions(const FileInfoPointer fromInfo, const FileInfoPointer toInfo);
     void setAllDirPermisson();
     void determineCountProcessType();
     qint64 getWriteDataSize();
     qint64 getTidWriteSize();
     qint64 getSectorsWritten();
-    void readAheadSourceFile(const FileInfoPointer &fileInfo);
+    void readAheadSourceFile(const FileInfoPointer fileInfo);
     void syncFilesToDevice();
     AbstractJobHandler::SupportAction doHandleErrorAndWait(const QUrl &from, const QUrl &to,
                                                            const AbstractJobHandler::JobErrorType &error,
@@ -68,21 +68,21 @@ public:
     bool deleteDir(const QUrl &fromUrl, const QUrl &toUrl, bool *result, const bool force = false);
     bool copyFileFromTrash(const QUrl &urlSource, const QUrl &urlTarget, dfmio::DFile::CopyFlag flag);
 
-    bool copyAndDeleteFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo, const FileInfoPointer &toInfo,
+    bool copyAndDeleteFile(const FileInfoPointer fromInfo, const FileInfoPointer targetPathInfo, const FileInfoPointer toInfo,
                            bool *result);
-    bool createSystemLink(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool createSystemLink(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
                           const bool followLink, const bool doCopy,
                           bool *result);
     bool canWriteFile(const QUrl &url) const;
 
-    bool doCopyFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, bool *skip);
+    bool doCopyFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip);
     bool checkAndCopyFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip);
-    bool checkAndCopyDir(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, bool *skip);
+    bool checkAndCopyDir(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip);
 
 protected:
     void waitThreadPoolOver();
     void initCopyWay();
-    QUrl trashInfo(const FileInfoPointer &fromInfo);
+    QUrl trashInfo(const FileInfoPointer fromInfo);
     QString fileOriginName(const QUrl &trashInfoUrl);
     void removeTrashInfo(const QUrl &trashInfoUrl);
 
@@ -91,10 +91,10 @@ private:
     void initThreadCopy();
     void initSignalCopyWorker();
     bool actionOperating(const AbstractJobHandler::SupportAction action, const qint64 size, bool *skip);
-    bool createNewTargetInfo(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                             FileInfoPointer &newTargetInfo, const QUrl &fileNewUrl,
+    bool createNewTargetInfo(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
+                             FileInfoPointer newTargetInfo, const QUrl &fileNewUrl,
                              bool *skip, bool isCountSize = false);
-    QUrl createNewTargetUrl(const FileInfoPointer &toInfo, const QString &fileName);
+    QUrl createNewTargetUrl(const FileInfoPointer toInfo, const QString &fileName);
     bool doCopyLocalFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo);
     bool doCopyExBlockFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo);
     bool doCopyOtherFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip);
@@ -129,9 +129,9 @@ protected Q_SLOTS:
 
 private:
     QVariant
-    checkLinkAndSameUrl(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize);
-    QVariant doActionReplace(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize);
-    QVariant doActionMerge(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize);
+    checkLinkAndSameUrl(const FileInfoPointer fromInfo, const FileInfoPointer newTargetInfo, const bool isCountSize);
+    QVariant doActionReplace(const FileInfoPointer fromInfo, const FileInfoPointer newTargetInfo, const bool isCountSize);
+    QVariant doActionMerge(const FileInfoPointer fromInfo, const FileInfoPointer newTargetInfo, const bool isCountSize);
 
 protected:
     QTime time;   // time eslape

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.cpp
@@ -72,7 +72,7 @@ bool DoCopyFromTrashFilesWorker::doOperate()
         if (!stateCheck())
             return false;
 
-        const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+        const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         if (!fileInfo) {
             // pause and emit error msg
             if (AbstractJobHandler::SupportAction::kSkipAction != doHandleErrorAndWait(url, QUrl(), AbstractJobHandler::JobErrorType::kProrogramError)) {
@@ -86,7 +86,7 @@ bool DoCopyFromTrashFilesWorker::doOperate()
         const QUrl &targetFileUrl = DFMIO::DFMUtils::buildFilePath(this->targetUrl.toString().toStdString().c_str(),
                                                                    fileInfo->displayOf(DisPlayInfoType::kFileDisplayName).toStdString().c_str(), nullptr);
 
-        const FileInfoPointer &targetFileInfo = InfoFactory::create<FileInfo>(targetFileUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
+        const FileInfoPointer targetFileInfo = InfoFactory::create<FileInfo>(targetFileUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
         if (!targetFileInfo) {
             // pause and emit error msg
             if (AbstractJobHandler::SupportAction::kSkipAction != doHandleErrorAndWait(url, targetFileUrl, AbstractJobHandler::JobErrorType::kProrogramError)) {
@@ -131,8 +131,8 @@ bool DoCopyFromTrashFilesWorker::doOperate()
     return true;
 }
 
-bool DoCopyFromTrashFilesWorker::createParentDir(const FileInfoPointer &trashInfo, const FileInfoPointer &restoreInfo,
-                                                 FileInfoPointer &targetFileInfo, bool *result)
+bool DoCopyFromTrashFilesWorker::createParentDir(const FileInfoPointer trashInfo, const FileInfoPointer restoreInfo,
+                                                 FileInfoPointer targetFileInfo, bool *result)
 {
     const QUrl &fromUrl = trashInfo->urlOf(UrlInfoType::kUrl);
     const QUrl &toUrl = restoreInfo->urlOf(UrlInfoType::kUrl);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.h
@@ -33,7 +33,7 @@ protected:
 
 protected:
     bool doOperate();
-    bool createParentDir(const FileInfoPointer &trashInfo, const FileInfoPointer &restoreInfo, FileInfoPointer &targetFileInfo, bool *result);
+    bool createParentDir(const FileInfoPointer trashInfo, const FileInfoPointer restoreInfo, FileInfoPointer targetFileInfo, bool *result);
 
 private:
     QAtomicInteger<qint64> completeFilesCount { 0 };

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -219,8 +219,8 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
     return true;
 }
 
-bool DoRestoreTrashFilesWorker::createParentDir(const FileInfoPointer &trashInfo, const FileInfoPointer &restoreInfo,
-                                                FileInfoPointer &targetFileInfo, bool *result)
+bool DoRestoreTrashFilesWorker::createParentDir(const FileInfoPointer trashInfo, const FileInfoPointer restoreInfo,
+                                                FileInfoPointer targetFileInfo, bool *result)
 {
     const QUrl &fromUrl = trashInfo->urlOf(UrlInfoType::kUrl);
     const QUrl &toUrl = restoreInfo->urlOf(UrlInfoType::kUrl);
@@ -252,7 +252,7 @@ bool DoRestoreTrashFilesWorker::createParentDir(const FileInfoPointer &trashInfo
     return true;
 }
 
-bool DoRestoreTrashFilesWorker::checkRestoreInfo(const QUrl &url, FileInfoPointer &restoreInfo)
+bool DoRestoreTrashFilesWorker::checkRestoreInfo(const QUrl &url, FileInfoPointer restoreInfo)
 {
     bool result;
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.h
@@ -38,8 +38,8 @@ protected:
     bool translateUrls();
     bool doRestoreTrashFiles();
     //check disk space available before do move job
-    bool createParentDir(const FileInfoPointer &trashInfo, const FileInfoPointer &restoreInfo, FileInfoPointer &targetFileInfo, bool *result);
-    bool checkRestoreInfo(const QUrl &url, FileInfoPointer &restoreInfo);
+    bool createParentDir(const FileInfoPointer trashInfo, const FileInfoPointer restoreInfo, FileInfoPointer targetFileInfo, bool *result);
+    bool checkRestoreInfo(const QUrl &url, FileInfoPointer restoreInfo);
 
 private:
     bool mergeDir(const QUrl &urlSource, const QUrl &urlTarget, dfmio::DFile::CopyFlag flag);

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
@@ -186,7 +186,7 @@ QList<DCustomActionEntry> DCustomActionBuilder::matchActions(const QList<QUrl> &
     for (auto &singleUrl : selects) {
         //协议、后缀
         QString errString;
-        const FileInfoPointer &fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(singleUrl, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+        const FileInfoPointer fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(singleUrl, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
         if (fileInfo.isNull()) {
             qWarning() << "create selected FileInfo failed: " << singleUrl.toString() << errString;
             continue;
@@ -429,7 +429,7 @@ bool DCustomActionBuilder::isSchemeSupport(const DCustomActionEntry &action, con
 bool DCustomActionBuilder::isSuffixSupport(const DCustomActionEntry &action, const QUrl &url)
 {
     QString errString;
-    const FileInfoPointer &fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+    const FileInfoPointer fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
 
     auto supportList = action.supportStuffix();
     if (!fileInfo || fileInfo->isAttributes(OptInfoType::kIsDir) || supportList.isEmpty() || supportList.contains("*")) {
@@ -455,7 +455,7 @@ bool DCustomActionBuilder::isSuffixSupport(const DCustomActionEntry &action, con
     return match;
 }
 
-void DCustomActionBuilder::appendAllMimeTypes(const FileInfoPointer &fileInfo, QStringList &noParentmimeTypes, QStringList &allMimeTypes)
+void DCustomActionBuilder::appendAllMimeTypes(const FileInfoPointer fileInfo, QStringList &noParentmimeTypes, QStringList &allMimeTypes)
 {
     noParentmimeTypes.append(fileInfo->fileMimeType().name());
     noParentmimeTypes.append(fileInfo->fileMimeType().aliases());

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.h
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.h
@@ -42,7 +42,7 @@ private:
     static bool isMimeTypeMatch(const QStringList &fileMimeTypes, const QStringList &supportMimeTypes);
     static bool isSchemeSupport(const DCustomActionEntry &action, const QUrl &url);
     static bool isSuffixSupport(const DCustomActionEntry &action, const QUrl &url);
-    static void appendAllMimeTypes(const FileInfoPointer &fileInfo, QStringList &noParentmimeTypes, QStringList &allMimeTypes);
+    static void appendAllMimeTypes(const FileInfoPointer fileInfo, QStringList &noParentmimeTypes, QStringList &allMimeTypes);
     static void appendParentMimeType(const QStringList &parentmimeTypes, QStringList &mimeTypes);
 
 protected:

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -236,7 +236,7 @@ void PermissionManagerWidget::toggleFileExecutable(bool isChecked)
     }
 }
 
-bool PermissionManagerWidget::canChmod(const FileInfoPointer &info)
+bool PermissionManagerWidget::canChmod(const FileInfoPointer info)
 {
     if (info.isNull())
         return false;

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.h
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.h
@@ -42,7 +42,7 @@ private:
 
     void toggleFileExecutable(bool isChecked);
 
-    bool canChmod(const FileInfoPointer &info);
+    bool canChmod(const FileInfoPointer info);
 
     void setExecText();
 

--- a/src/plugins/common/dfmplugin-emblem/events/emblemeventrecevier.cpp
+++ b/src/plugins/common/dfmplugin-emblem/events/emblemeventrecevier.cpp
@@ -23,7 +23,7 @@ EmblemEventRecevier *EmblemEventRecevier::instance()
     return &ins;
 }
 
-bool EmblemEventRecevier::handlePaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer &info)
+bool EmblemEventRecevier::handlePaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer info)
 {
     int role = kItemIconRole;
     QRectF rect = paintArea;

--- a/src/plugins/common/dfmplugin-emblem/events/emblemeventrecevier.h
+++ b/src/plugins/common/dfmplugin-emblem/events/emblemeventrecevier.h
@@ -20,7 +20,7 @@ class EmblemEventRecevier : public QObject
 public:
     static EmblemEventRecevier *instance();
 
-    bool handlePaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer &info);
+    bool handlePaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer info);
 
     void initializeConnections() const;
 

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -20,7 +20,7 @@ DFMBASE_USE_NAMESPACE
 DPF_USE_NAMESPACE
 DPEMBLEM_USE_NAMESPACE
 
-void GioEmblemWorker::onProduce(const FileInfoPointer &info)
+void GioEmblemWorker::onProduce(const FileInfoPointer info)
 {
     Q_ASSERT(qApp->thread() != QThread::currentThread());
 
@@ -44,7 +44,7 @@ void GioEmblemWorker::onClear()
     cache.clear();
 }
 
-QList<QIcon> GioEmblemWorker::fetchEmblems(const FileInfoPointer &info) const
+QList<QIcon> GioEmblemWorker::fetchEmblems(const FileInfoPointer info) const
 {
     if (!info)
         return {};
@@ -75,7 +75,7 @@ QList<QIcon> GioEmblemWorker::fetchEmblems(const FileInfoPointer &info) const
     return emblemList;
 }
 
-QMap<int, QIcon> GioEmblemWorker::getGioEmblems(const FileInfoPointer &info) const
+QMap<int, QIcon> GioEmblemWorker::getGioEmblems(const FileInfoPointer info) const
 {
     QMap<int, QIcon> emblemsMap;
 
@@ -201,7 +201,7 @@ EmblemHelper::~EmblemHelper()
     workerThread.wait();
 }
 
-QList<QIcon> EmblemHelper::systemEmblems(const FileInfoPointer &info) const
+QList<QIcon> EmblemHelper::systemEmblems(const FileInfoPointer info) const
 {
     static bool hideSystemEmblems = DConfigManager::instance()->value(kConfigPath, kHideSystemEmblems, false).toBool();
     if (hideSystemEmblems)
@@ -256,7 +256,7 @@ QList<QIcon> EmblemHelper::gioEmblemIcons(const QUrl &url) const
     return {};
 }
 
-void EmblemHelper::pending(const FileInfoPointer &info)
+void EmblemHelper::pending(const FileInfoPointer info)
 {
     emit requestProduce(info);
 }

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.h
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.h
@@ -23,17 +23,17 @@ class GioEmblemWorker : public QObject
     Q_OBJECT
 
 public:
-    QList<QIcon> fetchEmblems(const FileInfoPointer &info) const;
+    QList<QIcon> fetchEmblems(const FileInfoPointer info) const;
 
 public Q_SLOTS:
-    void onProduce(const FileInfoPointer &info);
+    void onProduce(const FileInfoPointer info);
     void onClear();
 
 Q_SIGNALS:
     void emblemChanged(const QUrl &url, const Product &product);
 
 private:
-    QMap<int, QIcon> getGioEmblems(const FileInfoPointer &info) const;
+    QMap<int, QIcon> getGioEmblems(const FileInfoPointer info) const;
     bool parseEmblemString(QIcon *emblem, QString &pos, const QString &emblemStr) const;
     bool iconNamesEqual(const QList<QIcon> &first, const QList<QIcon> &second);
     void setEmblemIntoIcons(const QString &pos, const QIcon &emblem, QMap<int, QIcon> *iconMap) const;
@@ -53,14 +53,14 @@ public:
     inline bool hasEmblem(const QUrl &url) const { return productQueue.contains(url); }
     inline void clearEmblem() { productQueue.clear(); }
 
-    QList<QIcon> systemEmblems(const FileInfoPointer &info) const;
+    QList<QIcon> systemEmblems(const FileInfoPointer info) const;
     QList<QRectF> emblemRects(const QRectF &paintArea) const;
     QList<QIcon> gioEmblemIcons(const QUrl &url) const;
-    void pending(const FileInfoPointer &info);
+    void pending(const FileInfoPointer info);
     bool isExtEmblemProhibited(const QUrl &url);
 
 Q_SIGNALS:
-    void requestProduce(const FileInfoPointer &info);
+    void requestProduce(const FileInfoPointer info);
     void requestClear();
 
 private Q_SLOTS:

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
@@ -27,7 +27,7 @@ EmblemManager *EmblemManager::instance()
     return &ins;
 }
 
-bool EmblemManager::paintEmblems(int role, const FileInfoPointer &info, QPainter *painter, QRectF *paintArea)
+bool EmblemManager::paintEmblems(int role, const FileInfoPointer info, QPainter *painter, QRectF *paintArea)
 {
     Q_ASSERT(qApp->thread() == QThread::currentThread());
     Q_ASSERT(painter);

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.h
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.h
@@ -22,7 +22,7 @@ class EmblemManager : public QObject
 public:
     static EmblemManager *instance();
 
-    bool paintEmblems(int role, const FileInfoPointer &info, QPainter *painter, QRectF *paintArea);
+    bool paintEmblems(int role, const FileInfoPointer info, QPainter *painter, QRectF *paintArea);
 
 private:
     explicit EmblemManager(QObject *parent = nullptr);

--- a/src/plugins/common/dfmplugin-preview/filepreview/utils/previewdialogmanager.cpp
+++ b/src/plugins/common/dfmplugin-preview/filepreview/utils/previewdialogmanager.cpp
@@ -33,7 +33,7 @@ void PreviewDialogManager::showPreviewDialog(const quint64 winId, const QList<QU
 
     bool hasInvalidSymlink = false;
     for (const QUrl &url : selecturls) {
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(url);
 
         if (info && (dfmbase::FileUtils::isLocalFile(info->urlOf(UrlInfoType::kUrl)) || info->exists())) {
             //判断链接文件的源文件是否存在

--- a/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.cpp
+++ b/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.cpp
@@ -93,7 +93,7 @@ QWidget *UnknowFilePreview::contentWidget() const
     return contentView;
 }
 
-void UnknowFilePreview::setFileInfo(const FileInfoPointer &info)
+void UnknowFilePreview::setFileInfo(const FileInfoPointer info)
 {
     const QIcon &icon = info->fileIcon();
 

--- a/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.h
+++ b/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.h
@@ -27,7 +27,7 @@ public:
     QWidget *contentWidget() const override;
 
 private:
-    void setFileInfo(const FileInfoPointer &info);
+    void setFileInfo(const FileInfoPointer info);
 
 signals:
     void requestStartFolderSize();

--- a/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
@@ -31,7 +31,7 @@ void TagDirIteratorPrivate::loadTagsUrls(const QUrl &url)
             tagUrl.setScheme(TagManager::scheme());
             tagUrl.setPath("/" + it.key());
 
-            const FileInfoPointer &info = InfoFactory::create<FileInfo>(tagUrl);
+            const FileInfoPointer info = InfoFactory::create<FileInfo>(tagUrl);
             tagNodes.insert(tagUrl, info);
             urlList.append(tagUrl);
             ++it;
@@ -50,7 +50,7 @@ void TagDirIteratorPrivate::loadTagsUrls(const QUrl &url)
 
             tagUrl = QUrl::fromLocalFile(path);
 
-            const FileInfoPointer &info = InfoFactory::create<FileInfo>(tagUrl);
+            const FileInfoPointer info = InfoFactory::create<FileInfo>(tagUrl);
             if (!info->exists())
                 continue;
 

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -103,7 +103,7 @@ bool TagManager::canTagFile(const QUrl &url) const
     return false;
 }
 
-bool TagManager::canTagFile(const FileInfoPointer &info) const
+bool TagManager::canTagFile(const FileInfoPointer info) const
 {
     if (info.isNull())
         return false;
@@ -118,7 +118,7 @@ bool TagManager::canTagFile(const FileInfoPointer &info) const
     return canTag;
 }
 
-bool TagManager::paintListTagsHandle(int role, const FileInfoPointer &info, QPainter *painter, QRectF *rect)
+bool TagManager::paintListTagsHandle(int role, const FileInfoPointer info, QPainter *painter, QRectF *rect)
 {
     if (!canTagFile(info))
         return false;
@@ -144,7 +144,7 @@ bool TagManager::paintListTagsHandle(int role, const FileInfoPointer &info, QPai
     return false;
 }
 
-bool TagManager::paintIconTagsHandle(const FileInfoPointer &info, const QRectF &rect, QPainter *painter, ElideTextLayout *layout)
+bool TagManager::paintIconTagsHandle(const FileInfoPointer info, const QRectF &rect, QPainter *painter, ElideTextLayout *layout)
 {
     Q_UNUSED(rect)
     Q_UNUSED(painter)
@@ -276,7 +276,7 @@ QVariant TagManager::getTagsByUrls(const QList<QUrl> &filePaths, bool same) cons
 
     QStringList paths;
     for (const auto &temp : filePaths) {
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(temp);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(temp);
         if (info) {
             paths.append(temp.path());
         } else {
@@ -373,7 +373,7 @@ bool TagManager::removeTagsOfFiles(const QList<QString> &tags, const QList<QUrl>
     QMap<QString, QVariant> fileWithTag;
 
     for (const QUrl &url : files) {
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(url);
         if (info) {
             fileWithTag[info->pathOf(FileInfo::FilePathInfoType::kFilePath)] = QVariant(tags);
         } else {
@@ -494,7 +494,7 @@ bool TagManager::deleteTagData(const QStringList &data, const DeleteOpts &type)
     return ret;
 }
 
-bool TagManager::localFileCanTagFilter(const FileInfoPointer &info) const
+bool TagManager::localFileCanTagFilter(const FileInfoPointer info) const
 {
     if (info.isNull())
         return false;

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
@@ -36,10 +36,10 @@ public:
     static QUrl rootUrl();
 
     bool canTagFile(const QUrl &url) const;
-    bool canTagFile(const FileInfoPointer &info) const;
+    bool canTagFile(const FileInfoPointer info) const;
     bool pasteHandle(quint64 winId, const QList<QUrl> &fromUrls, const QUrl &to);
-    bool paintListTagsHandle(int role, const FileInfoPointer &info, QPainter *painter, QRectF *rect);
-    bool paintIconTagsHandle(const FileInfoPointer &info, const QRectF &rect, QPainter *painter, dfmbase::ElideTextLayout *layout);
+    bool paintListTagsHandle(int role, const FileInfoPointer info, QPainter *painter, QRectF *rect);
+    bool paintIconTagsHandle(const FileInfoPointer info, const QRectF &rect, QPainter *painter, dfmbase::ElideTextLayout *layout);
     bool fileDropHandle(const QList<QUrl> &fromUrls, const QUrl &toUrl);
     bool fileDropHandleWithAction(const QList<QUrl> &fromUrls, const QUrl &toUrl, Qt::DropAction *action);
     bool sepateTitlebarCrumb(const QUrl &url, QList<QVariantMap> *mapGroup);
@@ -86,7 +86,7 @@ private:
 
     QMap<QString, QString> getTagsColorName(const QStringList &tags) const;
     bool deleteTagData(const QStringList &data, const DeleteOpts &type);
-    bool localFileCanTagFilter(const FileInfoPointer &info) const;
+    bool localFileCanTagFilter(const FileInfoPointer info) const;
     QVariant transformQueryData(const QDBusVariant &var) const;
 
 private:

--- a/src/plugins/common/dfmplugin-utils/appendcompress/appendcompresshelper.cpp
+++ b/src/plugins/common/dfmplugin-utils/appendcompress/appendcompresshelper.cpp
@@ -100,7 +100,7 @@ bool AppendCompressHelper::canAppendCompress(const QList<QUrl> &fromUrls, const 
         return false;
     }
 
-    const FileInfoPointer &info = InfoFactory::create<FileInfo>(toUrl);
+    const FileInfoPointer info = InfoFactory::create<FileInfo>(toUrl);
     if (info && info->isAttributes(OptInfoType::kIsWritable) && isCompressedFile(toUrl))
         return true;
 
@@ -109,7 +109,7 @@ bool AppendCompressHelper::canAppendCompress(const QList<QUrl> &fromUrls, const 
 
 bool AppendCompressHelper::isCompressedFile(const QUrl &toUrl)
 {
-    const FileInfoPointer &info = InfoFactory::create<FileInfo>(toUrl);
+    const FileInfoPointer info = InfoFactory::create<FileInfo>(toUrl);
     if (info) {
         const QString &fileTypeName = info->nameOf(NameInfoType::kMimeTypeName);
         if (info->isAttributes(OptInfoType::kIsFile) && ((fileTypeName == "application/zip") || (fileTypeName == "application/x-7z-compressed" && !info->nameOf(NameInfoType::kFileName).endsWith(".tar.7z")))) {

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -316,7 +316,7 @@ void OpenWithDialog::initData()
 {
     //在选择默认程序时，有多个url，要传多个url
     if (curUrl.isValid() && urlList.isEmpty()) {
-        const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(curUrl);
+        const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(curUrl);
 
         if (!fileInfo)
             return;
@@ -328,7 +328,7 @@ void OpenWithDialog::initData()
         QList<QUrl> openlist;
         bool bhide = true;
         for (auto url : urlList) {
-            const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
+            const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(url);
 
             if (!fileInfo) {
                 continue;

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -240,7 +240,7 @@ void CanvasItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *model
     CanvasProxyModel *canvasModel = qobject_cast<CanvasProxyModel *>(model);
     Q_ASSERT(canvasModel);
 
-    if (const FileInfoPointer &fileInfo = canvasModel->fileInfo(index)) {
+    if (const FileInfoPointer fileInfo = canvasModel->fileInfo(index)) {
         QUrl oldUrl = fileInfo->urlOf(UrlInfoType::kUrl);
         QUrl newUrl = fileInfo->getUrlByType(UrlInfoType::kGetUrlByNewFileName, newName);
         QMetaObject::invokeMethod(FileOperatorProxyIns, "renameFile", Qt::QueuedConnection, Q_ARG(int, parent()->winId()), Q_ARG(QUrl, oldUrl), Q_ARG(QUrl, newUrl));
@@ -746,7 +746,7 @@ QRect CanvasItemDelegate::paintIcon(QPainter *painter, const QIcon &icon,
     return QRect(qRound(x), qRound(y), w, h);
 }
 
-QRectF CanvasItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect,  const FileInfoPointer &info)
+QRectF CanvasItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect,  const FileInfoPointer info)
 {
     // todo(zy) uing extend painter by registering.
     if (!dpfSlotChannel->push("dfmplugin_emblem", "slot_FileEmblems_Paint", painter, rect, info).toBool()) {

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.h
@@ -55,7 +55,7 @@ protected:
     QRect textPaintRect(const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rText, bool elide) const;
     static QRect paintIcon(QPainter *painter, const QIcon &icon, const QRectF &rect, Qt::Alignment alignment = Qt::AlignCenter,
                            QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off);
-    static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info);
+    static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer info);
     void paintLabel(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rLabel) const;
     void drawNormlText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRectF &rText) const;
     void drawHighlightText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rText) const;

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -256,7 +256,7 @@ void CollectionItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *m
     CollectionModel *regionModel = qobject_cast<CollectionModel *>(model);
     Q_ASSERT(regionModel);
 
-    if (const FileInfoPointer &fileInfo = regionModel->fileInfo(index)) {
+    if (const FileInfoPointer fileInfo = regionModel->fileInfo(index)) {
         QUrl oldUrl = fileInfo->urlOf(UrlInfoType::kUrl);
         QUrl newUrl = fileInfo->getUrlByType(UrlInfoType::kGetUrlByNewFileName, newName);
         QMetaObject::invokeMethod(FileOperatorIns, "renameFile", Qt::QueuedConnection, Q_ARG(int, parent()->winId()), Q_ARG(QUrl, oldUrl), Q_ARG(QUrl, newUrl));
@@ -771,7 +771,7 @@ QRect CollectionItemDelegate::paintIcon(QPainter *painter, const QIcon &icon,
     return QRect(qRound(x), qRound(y), w, h);
 }
 
-QRectF CollectionItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info)
+QRectF CollectionItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer info)
 {
     // todo(zy) uing extend painter by registering.
     if (!dpfSlotChannel->push("dfmplugin_emblem", "slot_FileEmblems_Paint", painter, rect, info).toBool()) {

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.h
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.h
@@ -52,7 +52,7 @@ protected:
     void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override;
     static QRect paintIcon(QPainter *painter, const QIcon &icon, const QRectF &rect, Qt::Alignment alignment = Qt::AlignCenter,
                            QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off);
-    static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info);
+    static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer info);
     void paintLabel(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rLabel) const;
     void drawNormlText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRectF &rText) const;
     void drawHighlightText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rText) const;

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -960,7 +960,7 @@ void FileDialog::showEvent(QShowEvent *event)
         overrideWindowFlags(windowFlags() & ~Qt::WindowSystemMenuHint);
     }
 
-    const FileInfoPointer &info = InfoFactory::create<FileInfo>(currentUrl());
+    const FileInfoPointer info = InfoFactory::create<FileInfo>(currentUrl());
     if (info)
         setWindowTitle(info->displayOf(DisPlayInfoType::kFileDisplayName));
 

--- a/src/plugins/filemanager/core/dfmplugin-recent/utils/recentfilehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/utils/recentfilehelper.cpp
@@ -108,7 +108,7 @@ bool RecentFileHelper::linkFile(const quint64 windowId, const QUrl url, const QU
     Q_UNUSED(windowId)
 
     if (force) {
-        const FileInfoPointer &toInfo = InfoFactory::create<FileInfo>(link);
+        const FileInfoPointer toInfo = InfoFactory::create<FileInfo>(link);
         if (toInfo && toInfo->exists()) {
             DFMBASE_NAMESPACE::LocalFileHandler fileHandler;
             fileHandler.deleteFile(link);

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -317,7 +317,7 @@ bool SideBarItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, 
     return QStyledItemDelegate::editorEvent(event, model, option, index);
 }
 
-void SideBarItemDelegate::onEditorTextChanged(const QString &text, const FileInfoPointer &info) const
+void SideBarItemDelegate::onEditorTextChanged(const QString &text, const FileInfoPointer info) const
 {
     QLineEdit *editor = qobject_cast<QLineEdit *>(sender());
     if (!editor)

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -35,7 +35,7 @@ public:
 
     bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 public Q_SLOTS:
-    void onEditorTextChanged(const QString &text, const FileInfoPointer &info) const;
+    void onEditorTextChanged(const QString &text, const FileInfoPointer info) const;
 
 private:
     void drawIcon(const QStyleOptionViewItem &option, QPainter *painter, const QIcon &icon, const QRect &itemRect, QIcon::Mode iconMode, bool isEjectable) const;

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -223,7 +223,7 @@ void TitleBarHelper::handlePressed(QWidget *sender, const QString &text, bool *i
         if (url.path().isEmpty())
             url.setPath("/");
         qInfo() << "jump :" << inputStr;
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url);
+        const FileInfoPointer info = InfoFactory::create<FileInfo>(url);
         if (info && info->exists() && info->isAttributes(OptInfoType::kIsFile)) {
             TitleBarEventCaller::sendOpenFile(sender, url);
         } else {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.cpp
@@ -69,7 +69,7 @@ void WorkspaceEventCaller::sendShowCustomTopWidget(const quint64 windowID, const
     dpfSlotChannel->push(kEventNS, "slot_ShowCustomTopWidget", windowID, scheme, visible);
 }
 
-void WorkspaceEventCaller::sendPaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer &info)
+void WorkspaceEventCaller::sendPaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer info)
 {
     dpfSlotChannel->push("dfmplugin_emblem", "slot_FileEmblems_Paint", painter, paintArea, info);
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.h
@@ -33,7 +33,7 @@ public:
     static void sendTabRemoved(const quint64 windowID, const int index);
     static void sendShowCustomTopWidget(const quint64 windowId, const QString &scheme, bool visible);
 
-    static void sendPaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer &info);
+    static void sendPaintEmblems(QPainter *painter, const QRectF &paintArea, const FileInfoPointer info);
 
     static void sendViewSelectionChanged(const quint64 windowID, const QItemSelection &selected, const QItemSelection &deselected);
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventsequence.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventsequence.cpp
@@ -29,12 +29,12 @@ WorkspaceEventSequence *WorkspaceEventSequence::instance()
     return &ins;
 }
 
-bool WorkspaceEventSequence::doPaintListItem(int role, const FileInfoPointer &info, QPainter *painter, QRectF *rect)
+bool WorkspaceEventSequence::doPaintListItem(int role, const FileInfoPointer info, QPainter *painter, QRectF *rect)
 {
     return dpfHookSequence->run(kCurrentEventSpace, "hook_Delegate_PaintListItem", role, info, painter, rect);
 }
 
-bool WorkspaceEventSequence::doPaintIconItemText(const FileInfoPointer &info, const QRectF &rect, QPainter *painter, dfmbase::ElideTextLayout *layout)
+bool WorkspaceEventSequence::doPaintIconItemText(const FileInfoPointer info, const QRectF &rect, QPainter *painter, dfmbase::ElideTextLayout *layout)
 {
     return dpfHookSequence->run(kCurrentEventSpace, "hook_Delegate_PaintIconItem", info, rect, painter, layout);
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventsequence.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventsequence.h
@@ -24,8 +24,8 @@ class WorkspaceEventSequence : public QObject
 public:
     static WorkspaceEventSequence *instance();
 
-    bool doPaintListItem(int role, const FileInfoPointer &info, QPainter *painter, QRectF *rect);
-    bool doPaintIconItemText(const FileInfoPointer &info, const QRectF &rect, QPainter *painter, dfmbase::ElideTextLayout *layout);
+    bool doPaintListItem(int role, const FileInfoPointer info, QPainter *painter, QRectF *rect);
+    bool doPaintIconItemText(const FileInfoPointer info, const QRectF &rect, QPainter *painter, dfmbase::ElideTextLayout *layout);
     bool doCheckDragTarget(const QList<QUrl> &urls, const QUrl &urlTo, Qt::DropAction *action);
     bool doFetchSelectionModes(const QUrl &url, QList<QAbstractItemView::SelectionMode> *modes);
     bool doFetchCustomColumnRoles(const QUrl &rootUrl, QList<DFMGLOBAL_NAMESPACE::ItemRoles> *roleList);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
@@ -14,7 +14,7 @@ using namespace dfmbase;
 using namespace dfmbase::Global;
 using namespace dfmplugin_workspace;
 
-FileItemData::FileItemData(const QUrl &url, const FileInfoPointer &info, FileItemData *parent)
+FileItemData::FileItemData(const QUrl &url, const FileInfoPointer info, FileItemData *parent)
     : parent(parent),
       url(url),
       info(info)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
@@ -15,7 +15,7 @@ namespace dfmplugin_workspace {
 class FileItemData
 {
 public:
-    explicit FileItemData(const QUrl &url, const FileInfoPointer &info = nullptr, FileItemData *parent = nullptr);
+    explicit FileItemData(const QUrl &url, const FileInfoPointer info = nullptr, FileItemData *parent = nullptr);
     explicit FileItemData(const SortInfoPointer &info, FileItemData *parent = nullptr);
 
     void setParentData(FileItemData *p);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -320,7 +320,7 @@ Qt::ItemFlags FileViewModel::flags(const QModelIndex &index) const
 {
     Qt::ItemFlags flags = QAbstractItemModel::flags(index);
 
-    const FileInfoPointer &info = fileInfo(index);
+    const FileInfoPointer info = fileInfo(index);
     if (!info)
         return flags;
 
@@ -361,7 +361,7 @@ QMimeData *FileViewModel::mimeData(const QModelIndexList &indexes) const
 
     for (; it != indexes.end(); ++it) {
         if ((*it).column() == 0) {
-            const FileInfoPointer &fileInfo = this->fileInfo(*it);
+            const FileInfoPointer fileInfo = this->fileInfo(*it);
             const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
 
             if (urlsSet.contains(url))
@@ -387,7 +387,7 @@ bool FileViewModel::dropMimeData(const QMimeData *data, Qt::DropAction action, i
     if (!dropIndex.isValid())
         return false;
 
-    const FileInfoPointer &targetFileInfo = fileInfo(dropIndex);
+    const FileInfoPointer targetFileInfo = fileInfo(dropIndex);
     if (targetFileInfo->isAttributes(OptInfoType::kIsDir) && !targetFileInfo->isAttributes(OptInfoType::kIsWritable)) {
         qInfo() << "current dir is not writable!!!!!!!!";
         return false;
@@ -732,7 +732,7 @@ void FileViewModel::changeState(ModelState newState)
     Q_EMIT stateChanged();
 }
 
-bool FileViewModel::passNameFilters(const FileInfoPointer &info) const
+bool FileViewModel::passNameFilters(const FileInfoPointer info) const
 {
     if (!info || !filterSortWorker)
         return true;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -121,7 +121,7 @@ private:
     void discardFilterSortObjects();
 
     void changeState(ModelState newState);
-    bool passNameFilters(const FileInfoPointer &info) const;
+    bool passNameFilters(const FileInfoPointer info) const;
 
     QUrl dirRootUrl;
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -261,7 +261,7 @@ void RootInfo::doThreadWatcherEvent()
     });
 }
 
-void RootInfo::handleTraversalResult(const FileInfoPointer &child)
+void RootInfo::handleTraversalResult(const FileInfoPointer child)
 {
     auto sortInfo = addChild(child);
     if (sortInfo)
@@ -373,7 +373,7 @@ void RootInfo::addChildren(const QList<SortInfoPointer> &children)
     }
 }
 
-SortInfoPointer RootInfo::addChild(const FileInfoPointer &child)
+SortInfoPointer RootInfo::addChild(const FileInfoPointer child)
 {
     if (!child)
         return nullptr;
@@ -398,7 +398,7 @@ SortInfoPointer RootInfo::addChild(const FileInfoPointer &child)
     return sort;
 }
 
-SortInfoPointer RootInfo::sortFileInfo(const FileInfoPointer &info)
+SortInfoPointer RootInfo::sortFileInfo(const FileInfoPointer info)
 {
     if (!info)
         return nullptr;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -83,7 +83,7 @@ public Q_SLOTS:
     void doWatcherEvent();
     void doThreadWatcherEvent();
 
-    void handleTraversalResult(const FileInfoPointer &child);
+    void handleTraversalResult(const FileInfoPointer child);
     void handleTraversalResults(QList<FileInfoPointer> children);
     void handleTraversalLocalResult(QList<SortInfoPointer> children,
                                     dfmio::DEnumerator::SortRoleCompareFlag sortRole,
@@ -100,8 +100,8 @@ private:
     void addChildren(const QList<QUrl> &urlList);
     void addChildren(const QList<FileInfoPointer> &children);
     void addChildren(const QList<SortInfoPointer> &children);
-    SortInfoPointer addChild(const FileInfoPointer &child);
-    SortInfoPointer sortFileInfo(const FileInfoPointer &info);
+    SortInfoPointer addChild(const FileInfoPointer child);
+    SortInfoPointer sortFileInfo(const FileInfoPointer info);
     void removeChildren(const QList<QUrl> &urlList);
     bool containsChild(const QUrl &url);
     void updateChild(const QUrl &url);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -209,7 +209,7 @@ bool DragDropHelper::drop(QDropEvent *event)
         if (!hoverIndex.isValid()) {
             hoverIndex = view->rootIndex();
         } else {
-            const FileInfoPointer &fileInfo = view->model()->fileInfo(hoverIndex);
+            const FileInfoPointer fileInfo = view->model()->fileInfo(hoverIndex);
             if (fileInfo) {
                 bool isDrop = dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_IsDrop", fileInfo->urlOf(UrlInfoType::kUrl));
                 // NOTE: if item can not drop, the drag item will drop to root dir.

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -83,7 +83,7 @@ void FileOperatorHelper::openFilesByMode(const FileView *view, const QList<QUrl>
     auto windowId = WorkspaceHelper::instance()->windowId(view);
 
     for (const QUrl &url : urls) {
-        const FileInfoPointer &fileInfoPtr = InfoFactory::create<FileInfo>(url);
+        const FileInfoPointer fileInfoPtr = InfoFactory::create<FileInfo>(url);
         if (fileInfoPtr) {
             if (!fileInfoPtr->exists()) {
                 // show alert
@@ -148,7 +148,7 @@ void FileOperatorHelper::copyFiles(const FileView *view)
         selectedUrls = urls;
 
     if (selectedUrls.size() == 1) {
-        const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(selectedUrls.first());
+        const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(selectedUrls.first());
         if (!fileInfo || !fileInfo->isAttributes(OptInfoType::kIsReadable))
             return;
     }
@@ -165,7 +165,7 @@ void FileOperatorHelper::copyFiles(const FileView *view)
 void FileOperatorHelper::cutFiles(const FileView *view)
 {
     qInfo() << "cut shortcut key to clipboard";
-    const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(view->rootUrl());
+    const FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(view->rootUrl());
     if (!fileInfo || !fileInfo->isAttributes(OptInfoType::kIsWritable))
         return;
     QList<QUrl> selectedUrls = view->selectedUrlList();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -892,7 +892,7 @@ void FileSortWorker::sortOnlyOrderChange()
     return;
 }
 
-void FileSortWorker::addChild(const SortInfoPointer &sortInfo, const FileInfoPointer &info)
+void FileSortWorker::addChild(const SortInfoPointer &sortInfo, const FileInfoPointer info)
 {
     if (isCanceled)
         return;
@@ -979,10 +979,10 @@ bool FileSortWorker::lessThan(const QUrl &left, const QUrl &right, AbstractSortF
     const auto &leftItem = childrenDataMap.value(left);
     const auto &rightItem = childrenDataMap.value(right);
 
-    const FileInfoPointer &leftInfo = leftItem && leftItem->fileInfo()
+    const FileInfoPointer leftInfo = leftItem && leftItem->fileInfo()
             ? leftItem->fileInfo()
             : InfoFactory::create<FileInfo>(left);
-    const FileInfoPointer &rightInfo = rightItem && rightItem->fileInfo()
+    const FileInfoPointer rightInfo = rightItem && rightItem->fileInfo()
             ? rightItem->fileInfo()
             : InfoFactory::create<FileInfo>(right);
 
@@ -1034,7 +1034,7 @@ bool FileSortWorker::lessThan(const QUrl &left, const QUrl &right, AbstractSortF
     }
 }
 
-QVariant FileSortWorker::data(const FileInfoPointer &info, ItemRoles role)
+QVariant FileSortWorker::data(const FileInfoPointer info, ItemRoles role)
 {
     if (info.isNull())
         return QVariant();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -120,13 +120,13 @@ private:
     void sortAllFiles();
     // 有序的情况下只是点击升序还是降序特殊处理
     void sortOnlyOrderChange();
-    void addChild(const SortInfoPointer &sortInfo, const FileInfoPointer &info);
+    void addChild(const SortInfoPointer &sortInfo, const FileInfoPointer info);
     void addChild(const SortInfoPointer &sortInfo,
                   const AbstractSortFilter::SortScenarios sort);
 
 private:
     bool lessThan(const QUrl &left, const QUrl &right, AbstractSortFilter::SortScenarios sort);
-    QVariant data(const FileInfoPointer &info, Global::ItemRoles role);
+    QVariant data(const FileInfoPointer info, Global::ItemRoles role);
     int insertSortList(const QUrl &needNode, const QList<QUrl> &list,
                        AbstractSortFilter::SortScenarios sort);
     bool isDefaultHiddenFile(const QUrl &fileUrl);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -305,7 +305,7 @@ void FileViewHelper::handleCommitData(QWidget *editor) const
     }
 
     const auto &index = itemDelegate()->editingIndex();
-    const FileInfoPointer &fileInfo = parent()->model()->fileInfo(index);
+    const FileInfoPointer fileInfo = parent()->model()->fileInfo(index);
 
     if (!fileInfo) {
         return;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
@@ -90,7 +90,7 @@ void FileViewMenuHelper::showNormalMenu(const QModelIndex &index, const Qt::Item
     QVariantHash params;
     params[MenuParamKey::kCurrentDir] = view->rootUrl();
 
-    const FileInfoPointer &focusFileInfo = view->model()->fileInfo(index);
+    const FileInfoPointer focusFileInfo = view->model()->fileInfo(index);
     if (focusFileInfo) {
         tgUrl = focusFileInfo->urlOf(UrlInfoType::kUrl);
         // first is focus

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -51,7 +51,7 @@ QList<QRectF> BaseItemDelegate::getCornerGeometryList(const QRectF &baseRect, co
 
 void BaseItemDelegate::paintEmblems(QPainter *painter, const QRectF &iconRect, const QModelIndex &index) const
 {
-    const FileInfoPointer &info = parent()->parent()->model()->fileInfo(index);
+    const FileInfoPointer info = parent()->parent()->model()->fileInfo(index);
     WorkspaceEventCaller::sendPaintEmblems(painter, iconRect, info);
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.cpp
@@ -68,7 +68,7 @@ void ExpandedItem::paintEvent(QPaintEvent *)
                                                                                 pa.fontMetrics().lineSpacing(), Qt::AlignCenter, &pa));
     layout->setAttribute(ElideTextLayout::kBackgroundRadius, kIconModeRectRadius);
 
-    const FileInfoPointer &info = delegate->parent()->parent()->model()->fileInfo(index);
+    const FileInfoPointer info = delegate->parent()->parent()->model()->fileInfo(index);
     if (WorkspaceEventSequence::instance()->doPaintIconItemText(info, labelRect, &pa, layout.data()))
         return;
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -404,7 +404,7 @@ void FileView::onClicked(const QModelIndex &index)
     openIndexByClicked(ClickedAction::kClicked, index);
 
     QUrl url { "" };
-    const FileInfoPointer &info = model()->fileInfo(index);
+    const FileInfoPointer info = model()->fileInfo(index);
     if (info)
         url = info->urlOf(UrlInfoType::kUrl);
     QVariantMap data;
@@ -1508,7 +1508,7 @@ void FileView::updateLoadingIndicator()
     if (state == ModelState::kBusy) {
         QString tip;
 
-        const FileInfoPointer &fileInfo = model()->fileInfo(rootIndex());
+        const FileInfoPointer fileInfo = model()->fileInfo(rootIndex());
         if (fileInfo)
             tip = fileInfo->viewOfTip(ViewInfoType::kLoading);
 
@@ -1532,7 +1532,7 @@ void FileView::updateContentLabel()
 
     if (count() <= 0) {
         // set custom empty tips
-        const FileInfoPointer &fileInfo = model()->fileInfo(rootIndex());
+        const FileInfoPointer fileInfo = model()->fileInfo(rootIndex());
         if (fileInfo) {
             d->contentLabel->setText(fileInfo->viewOfTip(ViewInfoType::kEmptyDir));
             d->contentLabel->adjustSize();
@@ -1634,7 +1634,7 @@ QUrl FileView::parseSelectedUrl(const QUrl &url)
         // todo: liuzhangjian
         // checkGvfsMountfileBusy
         QList<QUrl> ancestors;
-        if (const FileInfoPointer &currentFileInfo = InfoFactory::create<FileInfo>(rootUrl())) {
+        if (const FileInfoPointer currentFileInfo = InfoFactory::create<FileInfo>(rootUrl())) {
             if (UrlRoute::isAncestorsUrl(rootUrl(), fileUrl, &ancestors))
                 d->preSelectionUrls << (ancestors.count() > 1 ? ancestors.at(ancestors.count() - 2) : rootUrl());
         }
@@ -1676,7 +1676,7 @@ void FileView::openIndexByClicked(const ClickedAction action, const QModelIndex 
 
 void FileView::openIndex(const QModelIndex &index)
 {
-    const FileInfoPointer &info = model()->fileInfo(index);
+    const FileInfoPointer info = model()->fileInfo(index);
 
     if (!info)
         return;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -563,7 +563,7 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
     QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(displayName, QTextOption::WrapAnywhere,
                                                                                 d->textLineHeight, Qt::AlignCenter, painter));
 
-    const FileInfoPointer &info = parent()->parent()->model()->fileInfo(index);
+    const FileInfoPointer info = parent()->parent()->model()->fileInfo(index);
     if (WorkspaceEventSequence::instance()->doPaintIconItemText(info, labelRect, painter, layout.data()))
         return;
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -105,7 +105,7 @@ QWidget *ListItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     d->editingIndex = index;
     d->editor = new ListItemEditor(parent);
 
-    const FileInfoPointer &fileInfo = this->parent()->fileInfo(index);
+    const FileInfoPointer fileInfo = this->parent()->fileInfo(index);
 
     if (fileInfo->urlOf(UrlInfoType::kUrl).scheme() == "search") {
         d->editor->setFixedHeight(GlobalPrivate::kListEditorHeight * 2 - 10);
@@ -473,7 +473,7 @@ void ListItemDelegate::paintItemColumn(QPainter *painter, const QStyleOptionView
         int rol = columnRoleList.at(i);
         const QVariant &data = index.data(rol);
 
-        const FileInfoPointer &info = parent()->parent()->model()->fileInfo(index);
+        const FileInfoPointer info = parent()->parent()->model()->fileInfo(index);
         if (WorkspaceEventSequence::instance()->doPaintListItem(rol, info, painter, &columnRect))
             continue;
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
@@ -319,7 +319,7 @@ void WorkspaceWidget::handleCtrlT()
     if (view) {
         const QList<QUrl> &urls = view->selectedUrlList();
         if (urls.count() == 1) {
-            const FileInfoPointer &fileInfoPtr = InfoFactory::create<FileInfo>(urls.at(0));
+            const FileInfoPointer fileInfoPtr = InfoFactory::create<FileInfo>(urls.at(0));
             if (fileInfoPtr && fileInfoPtr->isAttributes(OptInfoType::kIsDir)) {
                 openNewTab(urls.at(0));
                 return;

--- a/tests/plugins/common/dfmplugin-tag/utils/ut_tagmanager.cpp
+++ b/tests/plugins/common/dfmplugin-tag/utils/ut_tagmanager.cpp
@@ -56,7 +56,7 @@ TEST_F(TagManagerTest, paintListTagsHandle)
     QPainter painter;
     QRectF rect;
     //overload func
-    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer ) const>(&TagManager::canTagFile);
     stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return false; });
     EXPECT_FALSE(ins->paintListTagsHandle(1, info, &painter, &rect));
     stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
@@ -69,7 +69,7 @@ TEST_F(TagManagerTest, paintIconTagsHandle2)
     FileInfoPointer info(new FileInfo(QUrl("file:///test")));
     QPainter painter;
     QRectF rect;
-    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer ) const>(&TagManager::canTagFile);
     stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return false; });
     EXPECT_FALSE(ins->paintIconTagsHandle(info, rect, &painter, nullptr));
     stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
@@ -79,7 +79,7 @@ TEST_F(TagManagerTest, paintIconTagsHandle2)
 TEST_F(TagManagerTest, fileDropHandle)
 {
     EXPECT_TRUE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), TagManager::rootUrl()));
-    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer ) const>(&TagManager::canTagFile);
     stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
     stub.set_lamda(&TagManager::setTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
     EXPECT_TRUE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), TagManager::rootUrl()));
@@ -212,7 +212,7 @@ TEST_F(TagManagerTest, pasteHandle)
 {
     EXPECT_FALSE(ins->pasteHandle(1, QList<QUrl>(), QUrl("file:///test")));
     stub.set_lamda(&TagManager::addTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
-    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer ) const>(&TagManager::canTagFile);
     stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
     stub.set_lamda(&ClipBoard::clipboardAction, []() { __DBG_STUB_INVOKE__ return ClipBoard::kCutAction; });
 

--- a/tests/plugins/desktop/ddplugin-organizer/delegate/ut_collectionitemdelegate.cpp
+++ b/tests/plugins/desktop/ddplugin-organizer/delegate/ut_collectionitemdelegate.cpp
@@ -155,7 +155,7 @@ TEST(CollectionItemDelegate, paintEmblems)
     FileInfoPointer inFile;
     stub.set_lamda((QVariant(EventChannelManager::*)(const QString &, const QString &, QPainter *, const QRectF &, const FileInfoPointer &))
                            & EventChannelManager::push,
-                   [&](EventChannelManager *, const QString &space, const QString &topic, QPainter *p, const QRectF &r, const FileInfoPointer &file) {
+                   [&](EventChannelManager *, const QString &space, const QString &topic, QPainter *p, const QRectF &r, const FileInfoPointer file) {
                        inspace = space;
                        intopic = topic;
                        inpainter = p;

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -359,7 +359,7 @@ TEST_F(UT_RootInfo, HandleTraversalResult)
 
     bool calledAddChild = false;
     stub.set_lamda(ADDR(RootInfo, addChild),
-                   [&calledAddChild](RootInfo *, const FileInfoPointer &) {
+                   [&calledAddChild](RootInfo *, const FileInfoPointer ) {
                        calledAddChild = true;
                        SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
                        return sortInfo;
@@ -384,7 +384,7 @@ TEST_F(UT_RootInfo, HandleTraversalResults)
 
     bool calledAddChild = false;
     stub.set_lamda(ADDR(RootInfo, addChild),
-                   [&calledAddChild](RootInfo *, const FileInfoPointer &) {
+                   [&calledAddChild](RootInfo *, const FileInfoPointer ) {
                        calledAddChild = true;
                        SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
                        return sortInfo;
@@ -487,7 +487,7 @@ TEST_F(UT_RootInfo, AddChildrenWithUrls)
             rootInfoObj, &RootInfo::watcherAddFiles, rootInfoObj,
             [&addedFiles](QList<SortInfoPointer> children) { addedFiles.append(children); });
 
-    stub.set_lamda(ADDR(RootInfo, addChild), [](RootInfo *, const FileInfoPointer &info) {
+    stub.set_lamda(ADDR(RootInfo, addChild), [](RootInfo *, const FileInfoPointer info) {
         SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
         sortInfo->url = info->urlOf(UrlInfoType::kUrl);
         return sortInfo;
@@ -519,7 +519,7 @@ TEST_F(UT_RootInfo, AddChildrenWithFileInfos)
 
     QList<QUrl> addedFiles{};
     stub.set_lamda(ADDR(RootInfo, addChild),
-                   [&addedFiles](RootInfo *, const FileInfoPointer &info) {
+                   [&addedFiles](RootInfo *, const FileInfoPointer info) {
                        addedFiles.append(info->urlOf(UrlInfoType::kUrl));
                        SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
                        return sortInfo;


### PR DESCRIPTION
When using fileinfopoint, use a reference so that the reference to this sharedpoint does not increase. Modify and remove the reference to the fileinfopointer used.

Log: The file manager occasionally crashes