### PR TITLE
fix: [tag] delete tag file failed

### DIFF
--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -373,12 +373,7 @@ bool TagManager::removeTagsOfFiles(const QList<QString> &tags, const QList<QUrl>
     QMap<QString, QVariant> fileWithTag;
 
     for (const QUrl &url : files) {
-        const FileInfoPointer info = InfoFactory::create<FileInfo>(url);
-        if (info) {
-            fileWithTag[info->pathOf(FileInfo::FilePathInfoType::kFilePath)] = QVariant(tags);
-        } else {
-            fileWithTag[UrlRoute::urlToLocalPath(url)] = QVariant(tags);
-        }
+        fileWithTag[UrlRoute::urlToPath(url)] = QVariant(tags);
     }
 
     return TagProxyHandleIns->deleteFileTags(fileWithTag);


### PR DESCRIPTION
fileinfo path error ,when file is not exixst,directly use url

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-202153.html