### PR TITLE
fix: [preview] the file preview dialog show error

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -516,6 +516,7 @@ void FileStatisticsJob::run()
     d->totalSize = 0;
     d->filesCount = 0;
     d->directoryCount = 0;
+    d->sizeInfo.reset(new FileUtils::FilesSizeInfo());
     if (d->sourceUrlList.isEmpty())
         return;
     if (!FileUtils::isLocalDevice(d->sourceUrlList.first())) {
@@ -664,6 +665,7 @@ void FileStatisticsJob::statistcsByFts()
 
         d->processFileByFts(url, followLink);
     }
+    d->setState(kStoppedState);
 }
 
 }

--- a/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.cpp
+++ b/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.cpp
@@ -95,6 +95,9 @@ QWidget *UnknowFilePreview::contentWidget() const
 
 void UnknowFilePreview::setFileInfo(const FileInfoPointer info)
 {
+    if (fileCalculationUtils)
+        fileCalculationUtils->stop();
+
     const QIcon &icon = info->fileIcon();
 
     iconLabel->setPixmap(icon.pixmap(180));


### PR DESCRIPTION
1. When the the filestatisticesjob thread stop, should set the stop state
2. When the thread running, should clear the last sizefileinfo

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-201849.html