### PR TITLE
fix: [workspace]The file manager cannot enter the mtp directory

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -42,6 +42,8 @@ FileViewModel::FileViewModel(QAbstractItemView *parent)
     currentKey = QString::number(quintptr(this), 16);
     itemRootData = new FileItemData(dirRootUrl);
     connect(&FileInfoHelper::instance(), &FileInfoHelper::createThumbnailFinished, this, &FileViewModel::onFileThumbUpdated);
+    connect(&waitTimer, &QTimer::timeout, this, &FileViewModel::onSetCursorWait);
+    waitTimer.setInterval(30);
 }
 
 FileViewModel::~FileViewModel()
@@ -642,8 +644,8 @@ void FileViewModel::onSetCursorWait()
     if (currentState() != ModelState::kBusy)
             return;
 
-    while (QApplication::overrideCursor())
-        QApplication::restoreOverrideCursor();
+    if (QApplication::overrideCursor() && QApplication::overrideCursor()->shape() == Qt::CursorShape::WaitCursor)
+        return;
 
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 }
@@ -788,7 +790,8 @@ void FileViewModel::closeCursorTimer()
 
 void FileViewModel::startCursorTimer()
 {
-    waitTimer.start();
+    if (!waitTimer.isActive())
+        waitTimer.start();
 
     onSetCursorWait();
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
@@ -19,6 +19,8 @@
 
 #include <DMenu>
 
+#include <QApplication>
+
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_workspace;
 
@@ -153,7 +155,8 @@ QString FileViewMenuHelper::currentMenuScene() const
 
 void FileViewMenuHelper::setWaitCursor()
 {
-    reloadCursor();
+    if (QApplication::overrideCursor() && QApplication::overrideCursor()->shape() == Qt::CursorShape::WaitCursor)
+        return;
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 }
 


### PR DESCRIPTION
The timer in mouse state does not have a link slot function, causing. Add slot function and set mouse state judgment.

Log: The file manager cannot enter the mtp directory