### PR TITLE
fix: cannot cd to computer when burn files

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
@@ -176,7 +176,11 @@ void TabBar::closeTab(quint64 winId, const QUrl &url)
             continue;
 
         QUrl curUrl = tab->getCurrentUrl();
-        if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(curUrl, url) || url.isParentOf(curUrl)) {
+        // Some URLs cannot be compared universally
+        bool closeable { dpfHookSequence->run("dfmplugin_workspace", "hook_Tab_Closeable",
+                                              curUrl, url) };
+
+        if (closeable || DFMBASE_NAMESPACE::UniversalUtils::urlEquals(curUrl, url) || url.isParentOf(curUrl)) {
             if (count() == 1) {
                 QUrl redirectToWhenDelete;
                 if (isMountedDevPath(url) || url.scheme() != Global::Scheme::kFile) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -77,6 +77,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_HOOK(hook_SendChangeCurrentUrl)
 
     DPF_EVENT_REG_HOOK(hook_Tab_SetTabName)
+    DPF_EVENT_REG_HOOK(hook_Tab_Closeable)
 
     DPF_EVENT_REG_HOOK(hook_DragDrop_CheckDragDropAction)
     DPF_EVENT_REG_HOOK(hook_DragDrop_FileDragMove)

--- a/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.cpp
@@ -129,6 +129,24 @@ bool OpticalEventReceiver::detailViewIcon(const QUrl &url, QString *iconName)
     return false;
 }
 
+bool OpticalEventReceiver::handleTabClosable(const QUrl &currentUrl, const QUrl &rootUrl)
+{
+    const auto &scheme { OpticalHelper::scheme() };
+    if (currentUrl.scheme() != scheme || rootUrl.scheme() != scheme)
+        return false;
+
+    if (OpticalHelper::burnIsOnStaging(currentUrl)) {
+        const QString &rootDev { OpticalHelper::burnDestDevice(rootUrl) };
+        const QString &curDev { OpticalHelper::burnDestDevice(currentUrl) };
+        if (rootDev == curDev) {
+            qInfo() << "Close tab: " << currentUrl;
+            return true;
+        }
+    }
+
+    return false;
+}
+
 OpticalEventReceiver::OpticalEventReceiver(QObject *parent)
     : QObject(parent)
 {

--- a/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.h
@@ -26,6 +26,7 @@ public slots:
     bool handleDropFiles(const QList<QUrl> &fromUrls, const QUrl &toUrl);
     bool handleBlockShortcutPaste(quint64 winId, const QList<QUrl> &fromUrls, const QUrl &to);
     bool detailViewIcon(const QUrl &url, QString *iconName);
+    bool handleTabClosable(const QUrl &currentUrl, const QUrl &rootUrl);
 
 public:
     explicit OpticalEventReceiver(QObject *parent = nullptr);

--- a/src/plugins/filemanager/dfmplugin-optical/optical.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/optical.cpp
@@ -141,6 +141,8 @@ void Optical::bindEvents()
                             &OpticalEventReceiver::handleDropFiles);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_PasteFiles", &OpticalEventReceiver::instance(),
                             &OpticalEventReceiver::handleBlockShortcutPaste);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_Tab_Closeable", &OpticalEventReceiver::instance(),
+                            &OpticalEventReceiver::handleTabClosable);
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Crumb_Seprate", &OpticalEventReceiver::instance(), &OpticalEventReceiver::sepateTitlebarCrumb);
     dpfHookSequence->follow("dfmplugin_detailspace", "hook_Icon_Fetch", &OpticalEventReceiver::instance(), &OpticalEventReceiver::detailViewIcon);
 }


### PR DESCRIPTION
In the disc, tab's url is 'staging', while the mount point's url is 'disc', resulting in an unmatched url. Add a event `hook_Tab_Closeable` handbled by `optical`.

Log: fix disc bug

Bug: https://pms.uniontech.com/bug-view-202249.html