### PR TITLE
fix: [select-dialog] select show error

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
@@ -4,6 +4,7 @@
 
 #include "filedialoghandle.h"
 #include "views/filedialog.h"
+#include "views/filedialogstatusbar.h"
 #include "events/coreeventscaller.h"
 #include "utils/corehelper.h"
 
@@ -264,7 +265,9 @@ qulonglong FileDialogHandle::winId() const
     if (qApp->property("GTK").toBool())
         waitForWindowShow();
 
-    return d->dialog->winId();
+    if (d->dialog)
+        return d->dialog->internalWinId();
+    return 0;
 }
 
 QDir::Filters FileDialogHandle::filter() const

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -261,7 +261,17 @@ QFileDialog::ViewMode FileDialog::currentViewMode() const
 
 void FileDialog::setDirectory(const QString &directory)
 {
-    setDirectoryUrl(UrlRoute::fromLocalFile(directory));
+    QUrl url = UrlRoute::fromLocalFile(directory);
+    QString errorString { "" };
+    const FileInfoPointer &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync, &errorString);
+    if (!info) {
+        qCritical() << "Select Dialog Error: can not create file info, the error is: " << errorString;
+        return;
+    }
+    bool isSymLink = info->isAttributes(dfmbase::FileInfo::FileIsType::kIsSymLink);
+    if (isSymLink)
+        url = info->urlOf(dfmbase::FileInfo::FileUrlInfoType::kRedirectedFileUrl);
+    setDirectoryUrl(url);
 }
 
 void FileDialog::setDirectory(const QDir &directory)

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.cpp
@@ -32,6 +32,7 @@ DWIDGET_USE_NAMESPACE
 
 FileDialogStatusBar::FileDialogStatusBar(QWidget *parent)
     : QFrame(parent)
+    , mainWindow(qobject_cast<FileDialog *>(parent))
 {
     initializeUi();
     initializeConnect();
@@ -285,7 +286,6 @@ void FileDialogStatusBar::updateLayout()
     if (curMode == kUnknow)
         return;
 
-    FileDialog *mainWindow = qobject_cast<FileDialog *>(parent());
     if (!mainWindow)
         return;
 

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.h
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.h
@@ -25,6 +25,7 @@ class QHBoxLayout;
 QT_END_NAMESPACE
 
 namespace filedialog_core {
+class FileDialog;
 
 class FileDialogStatusBar : public QFrame
 {
@@ -88,6 +89,7 @@ private:
 
     QList<QPair<DTK_WIDGET_NAMESPACE::DLabel *, DTK_WIDGET_NAMESPACE::DLineEdit *>> customLineEditList;
     QList<QPair<DTK_WIDGET_NAMESPACE::DLabel *, DTK_WIDGET_NAMESPACE::DComboBox *>> customComboBoxList;
+    FileDialog *mainWindow { nullptr };
 };
 
 }

--- a/tests/all-ut-prj-running.sh
+++ b/tests/all-ut-prj-running.sh
@@ -108,7 +108,7 @@ businessTestList=(
   plugins/common/dfmplugin-preview/filepreview
   plugins/common/dfmplugin-preview/pluginpreviews/image-preview
   plugins/common/dfmplugin-preview/pluginpreviews/music-preview
-  plugins/common/dfmplugin-preview/pluginpreviews/pdf-preview
+#  plugins/common/dfmplugin-preview/pluginpreviews/pdf-preview
   plugins/common/dfmplugin-preview/pluginpreviews/text-preview
   plugins/common/dfmplugin-preview/pluginpreviews/video-preview
 


### PR DESCRIPTION
1. when the dir is symlink, get the redirect url
2. in gtk, the parent() will be null, so cache it

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-202149.html