### PR TITLE
fix: [select-dialog] some app show select dialog not accept button. 

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
@@ -325,6 +325,7 @@ void FileDialogHandle::setFileMode(QFileDialog::FileMode mode)
 void FileDialogHandle::setAcceptMode(QFileDialog::AcceptMode mode)
 {
     D_D(FileDialogHandle);
+    isSetAcceptMode = true;
     CoreHelper::delayInvokeProxy(
             [d, mode]() {
                 d->dialog->setAcceptMode(mode);
@@ -478,6 +479,8 @@ void FileDialogHandle::show()
 {
     D_D(FileDialogHandle);
     if (d->dialog) {
+        if (!isSetAcceptMode && d->dialog->statusBar())
+            d->dialog->statusBar()->setMode(FileDialogStatusBar::Mode::kOpen);
         // why ?
         // Use QFileDialog will call to the current function, but `WindowsService::showWindow` will call
         // to some D-Bus interfaces in desktop.

--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.h
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.h
@@ -97,7 +97,7 @@ Q_SIGNALS:
 
 private:
     QScopedPointer<FileDialogHandlePrivate> d_ptr;
-
+    bool isSetAcceptMode { false };
     Q_DECLARE_PRIVATE_D(qGetPtrHelper(d_ptr), FileDialogHandle)
     Q_DISABLE_COPY(FileDialogHandle)
 };

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
@@ -87,6 +87,8 @@ public:
     void setHideOnAccept(bool enable);
     bool hideOnAccept() const;
 
+    FileDialogStatusBar *statusBar() const;
+
 Q_SIGNALS:
     void finished(int result);
     void accepted();
@@ -126,7 +128,6 @@ private:
     void initEventsConnect();
     void initEventsFilter();
     void updateViewState();
-    FileDialogStatusBar *statusBar() const;
     void adjustPosition(QWidget *w);
     QString modelCurrentNameFilter() const;
 


### PR DESCRIPTION

1. some application(wechat) show file dialog ,bug not set accept mode, so set default accpet mode, like old dde-file-manager.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-202061.html