### PR TITLE
修复计算机页面中重命名磁盘时光标位置异常的问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -128,10 +128,15 @@ QWidget *ComputerItemDelegate::createEditor(QWidget *parent, const QStyleOptionV
             return;
 
         auto newLabel = text;
+        if (newLabel.toUtf8().length() <= maxLengthWhenRename)
+            return;
+
         QSignalBlocker blocker(editor);
         while (newLabel.toUtf8().length() > maxLengthWhenRename)
             newLabel.chop(1);
+        int cursorPos = editor->cursorPosition();
         editor->setText(newLabel);
+        editor->setCursorPosition(cursorPos);
     });
     connect(editor, &QLineEdit::destroyed, this, [this] {
         view->model()->setData(editingIndex, false, ComputerModel::kItemIsEditingRole);


### PR DESCRIPTION
as title.
everytime QLineEdit::setText invoked, the cursor goes to the end of the
text. save cursor pos and reset it after setText.

Log: fix issue about cursor position while renaming in computer.

Bug: https://pms.uniontech.com/bug-view-202089.html
