### PR TITLE
fix: 拷贝到外设不显示文件和鼠标状态不正确

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -479,10 +479,10 @@ QString AsyncFileInfo::viewOfTip(const ViewType type) const
 
 QVariant AsyncFileInfo::customAttribute(const char *key, const DFileInfo::DFileAttributeType type)
 {
-    if (d->dfmFileInfo) {
-        QReadLocker locker(&d->lock);
-        return d->dfmFileInfo->customAttribute(key, type);
-    }
+    auto tmpDfmFileInfo = d->dfmFileInfo;
+    if (tmpDfmFileInfo)
+        return tmpDfmFileInfo->customAttribute(key, type);
+
     return QVariant();
 }
 
@@ -965,9 +965,8 @@ QString AsyncFileInfoPrivate::sizeFormat() const
 
 QVariant AsyncFileInfoPrivate::attribute(DFileInfo::AttributeID key, bool *ok) const
 {
-    auto tmpDfmFileInfo = dfmFileInfo;
-    if (tmpDfmFileInfo) {
-        auto value = tmpDfmFileInfo->attribute(key, ok);
+    if (dfmFileInfo) {
+        auto value = dfmFileInfo->attribute(key, ok);
         return value;
     }
     return QVariant();

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -180,8 +180,8 @@ public:
     virtual QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(DFMIO::DFileInfo::MediaType type, QList<DFMIO::DFileInfo::AttributeExtendID> ids) const override;
     // cache attribute
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
-    QList<QUrl> notifyUrls() const;
-    void setNotifyUrl(const QUrl &url);
+    QMap<QUrl, QString> notifyUrls() const;
+    void setNotifyUrl(const QUrl &url, const QString &infoPtr);
 };
 }
 typedef QSharedPointer<DFMBASE_NAMESPACE::AsyncFileInfo> DFMAsyncFileInfoPointer;

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -55,7 +55,7 @@ public:
     InfoHelperUeserDataPointer iconFuture { nullptr };
     QMap<AsyncFileInfo::AsyncAttributeID, QVariant> cacheAsyncAttributes;
     QReadWriteLock notifyLock;
-    QList<QUrl> notifyUrls;
+    QMap<QUrl, QString> notifyUrls;
     AsyncFileInfo *const q;
 
 public:

--- a/src/dfm-base/interfaces/proxyfileinfo.cpp
+++ b/src/dfm-base/interfaces/proxyfileinfo.cpp
@@ -43,7 +43,7 @@ void ProxyFileInfo::setProxy(const FileInfoPointer &proxy)
     this->proxy = proxy;
     auto asyncInfo = this->proxy.dynamicCast<AsyncFileInfo>();
     if (asyncInfo) {
-        asyncInfo->setNotifyUrl(url);
+        asyncInfo->setNotifyUrl(url, QString::number(quintptr(this), 16));
         asyncInfo->refresh();
     }
 }

--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -53,7 +53,7 @@ Q_SIGNALS:
     void fileThumb(const QUrl &url, ThumbnailProvider::Size size, const QSharedPointer<FileInfoHelperUeserData> data);
     void fileInfoRefresh(const QUrl &url, QSharedPointer<dfmio::DFileInfo> dfileInfo);
     // 第二个参数表示，当前是链接文件的原文件更新完成
-    void fileRefreshFinished(const QUrl url, const bool isLinkOrg);
+    void fileRefreshFinished(const QUrl url, const QString infoPtr, const bool isLinkOrg);
 private Q_SLOTS:
     void aboutToQuit();
 
@@ -62,7 +62,6 @@ private:
     QSharedPointer<FileInfoAsycWorker> worker { nullptr };
     std::atomic_bool stoped { false };
     QThreadPool pool;
-    DThreadList<QUrl> queryingList;
 };
 }
 

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -233,9 +233,9 @@ void FilePropertyDialog::onSelectUrlRenamed(const QUrl &url)
         basicWidget->updateFileUrl(url);
 }
 
-void FilePropertyDialog::onFileInfoUpdated(const QUrl &url, const bool isLinkOrg)
+void FilePropertyDialog::onFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg)
 {
-    if (url != currentFileUrl || currentInfo.isNull())
+    if (url != currentFileUrl || currentInfo.isNull() || QString::number(quintptr(currentInfo.data()), 16) != infoPtr)
         return;
 
     if (isLinkOrg)

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.h
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.h
@@ -47,7 +47,7 @@ public slots:
     void addExtendedControl(QWidget *widget);
     void closeDialog();
     void onSelectUrlRenamed(const QUrl &url);
-    void onFileInfoUpdated(const QUrl &url, const bool isLinkOrg);
+    void onFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg);
 
 signals:
     void closed(const QUrl url);

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
@@ -175,8 +175,9 @@ void FileProvider::preupdateData(const QUrl &url)
     }
 }
 
-void FileProvider::onFileInfoUpdated(const QUrl &url, const bool isLinkOrg)
+void FileProvider::onFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg)
 {
+    Q_UNUSED(infoPtr);
     if (UrlRoute::urlParent(url) != rootUrl)
         return;
     emit fileInfoUpdated(url, isLinkOrg);

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.h
@@ -43,7 +43,7 @@ protected slots:
     void rename(const QUrl &oldUrl, const QUrl &newUrl);
     void update(const QUrl &url);
     void preupdateData(const QUrl &url);
-    void onFileInfoUpdated(const QUrl &url, const bool isLinkOrg);
+    void onFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg);
 
 protected:
     QUrl rootUrl;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -55,6 +55,7 @@ FileViewModel::~FileViewModel()
         itemRootData = nullptr;
     }
     FileDataManager::instance()->cleanRoot(dirRootUrl, currentKey);
+    closeCursorTimer();
 }
 
 QModelIndex FileViewModel::index(int row, int column, const QModelIndex &parent) const
@@ -107,6 +108,7 @@ QModelIndex FileViewModel::setRootUrl(const QUrl &url)
     // insert root index
     beginResetModel();
     // create root by url
+    closeCursorTimer();
     dirRootUrl = url;
     RootInfo *root = FileDataManager::instance()->fetchRoot(dirRootUrl);
     endResetModel();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -627,7 +627,7 @@ void FileSortWorker::handleRefresh()
     Q_EMIT requestFetchMore();
 }
 
-void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const bool isLinkOrg)
+void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg)
 {
     if (!childrenUrlList.contains(url))
         return;
@@ -636,7 +636,14 @@ void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const bool isLinkOrg
     if (!itemdata)
         return;
 
-    if (isLinkOrg && itemdata->fileInfo())
+    if (!itemdata->fileInfo())
+        itemdata->data(Global::ItemRoles::kItemCreateFileInfo);
+
+    auto fileInfo = itemdata->fileInfo();
+    if (!fileInfo || QString::number(quintptr(fileInfo.data()), 16) != infoPtr)
+        return;
+
+    if (isLinkOrg && fileInfo)
         itemdata->fileInfo()->customData(Global::ItemRoles::kItemFileRefreshIcon);
 
     handleUpdateFile(url);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -111,7 +111,7 @@ public slots:
     void handleFilterData(const QVariant &data);
     void handleFilterCallFunc(FileViewFilterCallback callback);
     void handleRefresh();
-    void handleFileInfoUpdated(const QUrl &url, const bool isLinkOrg);
+    void handleFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg);
 
 private:
     bool checkFilters(const SortInfoPointer &sortInfo, const bool byInfo = false);

--- a/tests/dfm-base/file/local/ut_asyncfileinfo.cpp
+++ b/tests/dfm-base/file/local/ut_asyncfileinfo.cpp
@@ -252,7 +252,7 @@ TEST_F(UT_AsyncFileInfo, testAsyncFileInfoChildren)
 
     QProcess::execute("touch ./testAsyncFileInfo/testAsyncFileInfo.txt");
     info.reset(new AsyncFileInfo(url));
-    info.dynamicCast<AsyncFileInfo>()->setNotifyUrl(url);
+    info.dynamicCast<AsyncFileInfo>()->setNotifyUrl(url, QString(""));
     info->refresh();
     while (true != info->isAttributes(OptInfoType::kIsDir)) {
         QThread::msleep(10);


### PR DESCRIPTION
When creating a new file, insert it into the cache and immediately create a new itemfiledata. When creating fileinfo in itemfiledata, you may not have obtained the cached fileinfo yet. Therefore, you have created a new one and will asynchronously query the new one. Will query the previous one instead of all subsequent ones. All fileinfo attributes are invalid. Each fileinfo can be modified to query, and a corresponding identifier can be added to the successfully queried signal. The slot function of the received signal interprets whether it is the same identifier for processing.

When closing and switching directories, the timer is not turned off and the mouse state is not set. Turn off the timer and set the mouse state when modifying the destructor and setrooturl.

Log: Paste the file into the USB drive, but the file is not displayed
Bug: https://pms.uniontech.com/bug-view-200183.html