### PR TITLE
fix: [workspace]Incorrect mouse state

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -55,6 +55,7 @@ FileViewModel::~FileViewModel()
         itemRootData = nullptr;
     }
     FileDataManager::instance()->cleanRoot(dirRootUrl, currentKey);
+    closeCursorTimer();
 }
 
 QModelIndex FileViewModel::index(int row, int column, const QModelIndex &parent) const
@@ -104,6 +105,7 @@ QModelIndex FileViewModel::setRootUrl(const QUrl &url)
     if (!url.isValid())
         return QModelIndex();
 
+    closeCursorTimer();
     // insert root index
     beginResetModel();
     // create root by url


### PR DESCRIPTION
When closing and switching directories, the timer is not turned off and the mouse state is not set. Turn off the timer and set the mouse state when modifying the destructor and setrooturl.

Log: Incorrect mouse state