### PR TITLE
fix: [info] Mount FTP with GBK encoding, the view tips are incorrect

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
@@ -352,6 +352,7 @@ void TabBar::closeTabAndRemoveCachedMnts(const QString &id)
     for (const auto &url : allMntedDevs.values(id)) {
         this->closeTab(WorkspaceHelper::instance()->windowId(this), url);
         FileDataManager::instance()->cleanRoot(url);
+        emit InfoCacheController::instance().removeCacheFileInfo({ url });
     }
     allMntedDevs.remove(id);
 }


### PR DESCRIPTION
1.Used cached information from previous successful mounting
2.Delete the cached info for mount point arter it unmounted

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-201771.html
