### PR TITLE
fix: [menu]The 'Send to' option is no longer available

### DIFF
--- a/src/plugins/common/core/dfmplugin-menu/menuscene/sendtomenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/sendtomenuscene.cpp
@@ -50,6 +50,7 @@ bool SendToMenuScene::initialize(const QVariantHash &params)
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
+    d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
     if (!d->isEmptyArea) {
         d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
         d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);

--- a/tests/plugins/common/CMakeLists.txt
+++ b/tests/plugins/common/CMakeLists.txt
@@ -11,4 +11,5 @@ add_subdirectory(dfmplugin-utils)
 
 add_subdirectory(core/dfmplugin-fileoperations)
 add_subdirectory(core/dfmplugin-propertydialog)
+add_subdirectory(core/dfmplugin-menu)
 

--- a/tests/plugins/common/core/dfmplugin-menu/CMakeLists.txt
+++ b/tests/plugins/common/core/dfmplugin-menu/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(test-dfmplugin-menu)
+
+set(PluginPath ${PROJECT_SOURCE_PATH}/plugins/common/core/dfmplugin-menu/)
+
+# UT文件
+file(GLOB_RECURSE UT_CXX_FILE
+    FILES_MATCHING PATTERN "*.cpp" "*.h")
+file(GLOB_RECURSE SRC_FILES
+    FILES_MATCHING PATTERN "${PluginPath}/*.cpp" "${PluginPath}/*.h")
+
+add_executable(${PROJECT_NAME}
+    ${SRC_FILES}
+    ${UT_CXX_FILE}
+    ${CPP_STUB_SRC}
+)
+
+find_package(Dtk COMPONENTS Widget REQUIRED)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    "${PluginPath}")
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    DFM::base
+    DFM::framework
+    ${DtkWidget_LIBRARIES}
+)
+
+add_test(
+  NAME menu
+  COMMAND $<TARGET_FILE:${PROJECT_NAME}>
+)

--- a/tests/plugins/common/core/dfmplugin-menu/main.cpp
+++ b/tests/plugins/common/core/dfmplugin-menu/main.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <sanitizer/asan_interface.h>
+#include <QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    int ret = RUN_ALL_TESTS();
+
+#ifdef ENABLE_TSAN_TOOL
+    __sanitizer_set_report_path("../../../asan_dfmplugin-menu.log");
+#endif
+
+    return ret;
+}

--- a/tests/plugins/common/core/dfmplugin-menu/menuscene/ut_sendtomenuscene.cpp
+++ b/tests/plugins/common/core/dfmplugin-menu/menuscene/ut_sendtomenuscene.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/core/dfmplugin-menu/menuscene/sendtomenuscene.h"
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+
+#include <QMenu>
+#include <QDir>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+DFMBASE_USE_NAMESPACE
+DPMENU_USE_NAMESPACE
+
+class UT_SendToMenuScene : public testing::Test
+{
+protected:
+    virtual void SetUp() override {
+        // 注册路由
+        UrlRoute::regScheme(Global::Scheme::kFile, "/", QIcon(), false, QObject::tr("System Disk"));
+        // 注册Scheme为"file"的扩展的文件信息 本地默认文件的
+        InfoFactory::regClass<dfmbase::SyncFileInfo>(Global::Scheme::kFile);}
+    virtual void TearDown() override { stub.clear(); }
+    ~UT_SendToMenuScene() override;
+
+private:
+    stub_ext::StubExt stub;
+};
+
+UT_SendToMenuScene::~UT_SendToMenuScene(){
+
+}
+
+TEST_F(UT_SendToMenuScene, bug_203001_initialize)
+{
+    QVariantHash params;
+    auto url = QUrl::fromLocalFile(QDir::currentPath());
+    params[MenuParamKey::kCurrentDir] = url;
+    params[MenuParamKey::kOnDesktop] = false;
+    params[MenuParamKey::kIsEmptyArea] = true;
+    SendToMenuScene scene;
+    EXPECT_TRUE(scene.initialize(params));
+
+    auto focusInfo = InfoFactory::create<FileInfo>(url);
+    params[MenuParamKey::kFocusFileInfo] = QVariant::fromValue(focusInfo);
+    params[MenuParamKey::kIsEmptyArea] = false;
+    EXPECT_FALSE(scene.initialize(params));
+
+    params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl>() << url);
+    EXPECT_TRUE(scene.initialize(params));
+}


### PR DESCRIPTION
The d ->selectFiles initialization has been deleted in SendToMenuScene. Modify and add the initialization of d ->selectFiles

Log: The 'Send to' option is no longer available
Bug: https://pms.uniontech.com/bug-view-203001.html