### PR TITLE
fix: [io]Ejecting a USB flash drive indicates that it is in use, resulting in incomplete copied data

### DIFF
--- a/src/dde-file-manager-lib/io/dfilecopymovejob.cpp
+++ b/src/dde-file-manager-lib/io/dfilecopymovejob.cpp
@@ -4517,6 +4517,11 @@ end:
                 d->setState(RunningState);
             }
         }
+        else if (d->mode == CopyMode || d->mode == CutMode){
+            while (d->state != DFileCopyMoveJob::StoppedState && d->lastProgress < 1) {
+                QThread::msleep(100);
+            }
+        }
     }
 
     d->fileStatistics->stop();


### PR DESCRIPTION
When copying to a USB drive, there is no waiting for synchronization to complete. If it is copying or cutting, wait for synchronization to complete (the USB drive is 100%).

Log: Ejecting a USB flash drive indicates that it is in use, resulting in incomplete copied data
Bug: https://pms.uniontech.com/bug-view-202519.html