### PR TITLE
fix: [select-dialog] select dialog name filter format item show error

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -82,6 +82,7 @@ enum ItemRoles {
     kItemFileCanRename = Qt::UserRole + 29,
     kItemFileCanDrop = Qt::UserRole + 30,
     kItemFileCanDrag = Qt::UserRole + 31,
+    kItemFileIsAvailable = Qt::UserRole + 32,   // the item gray display and can not select
 
     kItemUnknowRole = Qt::UserRole + 999
 };

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -491,7 +491,7 @@ void FileDialog::setOptions(QFileDialog::Options options)
 
     d->options = options;
 
-    dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetNameFilter",
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetReadOnly",
                          internalWinId(), options.testFlag(QFileDialog::ReadOnly));
 
     if (options.testFlag(QFileDialog::ShowDirsOnly)) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
@@ -172,7 +172,14 @@ QVariant FileItemData::data(int role) const
         if (info)
             return info->canAttributes(CanableInfoType::kCanDrag);
         return true;
+    case kItemFileIsAvailable:
+        return isAvailable;
     default:
         return QVariant();
     }
+}
+
+void FileItemData::setAvailableState(bool b)
+{
+    isAvailable = b;
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
@@ -27,11 +27,14 @@ public:
 
     QVariant data(int role) const;
 
+    void setAvailableState(bool b);
+
 private:
     FileItemData *parent { nullptr };
     QUrl url;
     FileInfoPointer info { nullptr };
     SortInfoPointer sortInfo { nullptr };
+    bool isAvailable { true };
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -115,6 +115,7 @@ public Q_SLOTS:
     void onRemove(int firstIndex, int count);
     void onRemoveFinish();
     void onSetCursorWait();
+    void onUpdateView();
 
 private:
     void initFilterSortWork();
@@ -122,7 +123,6 @@ private:
     void discardFilterSortObjects();
 
     void changeState(ModelState newState);
-    bool passNameFilters(const QModelIndex &index) const;
     void closeCursorTimer();
     void startCursorTimer();
 
@@ -141,7 +141,7 @@ private:
     QTimer waitTimer;
 
     QList<QSharedPointer<QObject>> discardedObjects {};
-    mutable QMap<QString, bool> nameFiltersMatchResultMap;
+    QStringList nameFilters {};
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -137,11 +137,6 @@ QList<QUrl> FileSortWorker::getChildrenUrls()
     return visibleChildren;
 }
 
-QStringList FileSortWorker::getNameFilters() const
-{
-    return nameFilters;
-}
-
 QDir::Filters FileSortWorker::getFilters() const
 {
     return filters;
@@ -327,22 +322,26 @@ void FileSortWorker::handleModelGetSourceData()
 
 void FileSortWorker::setFilters(QDir::Filters filters)
 {
-    resetFilters(nameFilters, filters);
+    resetFilters(filters);
 }
 
-void FileSortWorker::setNameFilters(const QStringList &nameFilters)
+void FileSortWorker::setNameFilters(const QStringList &filters)
 {
-    resetFilters(nameFilters, filters);
+    nameFilters = filters;
+    QMap<QUrl, FileItemData *>::iterator itr = childrenDataMap.begin();
+    for (; itr != childrenDataMap.end(); ++itr) {
+        checkNameFilters(itr.value());
+    }
+    Q_EMIT requestUpdateView();
 }
 
-void FileSortWorker::resetFilters(const QStringList &nameFilters, const QDir::Filters filters)
+void FileSortWorker::resetFilters(const QDir::Filters filters)
 {
     if (isCanceled)
         return;
-    if (this->nameFilters == nameFilters && this->filters == filters)
+    if (this->filters == filters)
         return;
 
-    this->nameFilters = nameFilters;
     this->filters = filters;
 
     filterAllFilesOrdered();
@@ -352,7 +351,7 @@ void FileSortWorker::onToggleHiddenFiles()
 {
     auto tmpfilters = filters;
     tmpfilters = ~(tmpfilters ^ QDir::Filter(~QDir::Hidden));
-    resetFilters(nameFilters, tmpfilters);
+    resetFilters(tmpfilters);
 }
 
 void FileSortWorker::onShowHiddenFileChanged(bool isShow)
@@ -444,7 +443,10 @@ void FileSortWorker::handleTraversalFinish(const QString &key)
 {
     if (currentKey != key)
         return;
+
     Q_EMIT requestSetIdel();
+
+    setNameFilters(nameFilters);
 }
 
 void FileSortWorker::handleSortAll(const QString &key)
@@ -649,6 +651,23 @@ void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const QString &infoP
     handleUpdateFile(url);
 }
 
+void FileSortWorker::checkNameFilters(FileItemData *itemData)
+{
+    if (!itemData || itemData->data(kItemFileIsDir).toBool() || nameFilters.isEmpty())
+        return;
+
+    QRegExp re("", Qt::CaseInsensitive, QRegExp::Wildcard);
+    for (int i = 0; i < nameFilters.size(); ++i) {
+        re.setPattern(nameFilters.at(i));
+        if (re.exactMatch(itemData->data(kItemNameRole).toString())) {
+            itemData->setAvailableState(true);
+            return;
+        }
+    }
+
+    itemData->setAvailableState(false);
+}
+
 bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool byInfo)
 {
     // 处理继承
@@ -737,19 +756,6 @@ bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool by
         if (isDir)
             return true;
     }
-
-    if (nameFilters.isEmpty()) {
-        if (sortInfo && filterCallback)
-            return filterCallback(InfoFactory::create<FileInfo>(sortInfo->url).data(), filterData);
-        return true;
-    }
-
-    QString path(sortInfo->url.path());
-    const QString &fileInfoName = path.right(path.lastIndexOf("/"));
-    // filter name
-    const bool caseSensitive = (filters & QDir::CaseSensitive) == QDir::CaseSensitive;
-    if (nameFilters.contains(fileInfoName, caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive))
-        return false;
 
     if (sortInfo && filterCallback)
         return filterCallback(InfoFactory::create<FileInfo>(sortInfo->url).data(), filterData);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -52,7 +52,6 @@ public:
     int getChildShowIndex(const QUrl &url);
     QList<QUrl> getChildrenUrls();
 
-    QStringList getNameFilters() const;
     QDir::Filters getFilters() const;
 
     DFMGLOBAL_NAMESPACE::ItemRoles getSortRole() const;
@@ -71,6 +70,8 @@ signals:
 
     // notify data
     void getSourceData(const QString &key);
+
+    void requestUpdateView();
 
     // Note that the slot functions here are executed in asynchronous threads,
     // so the link can only be Qt:: QueuedConnection,
@@ -93,9 +94,8 @@ public slots:
     // Get data from the data area according to the url, filter and sort the data
     void handleModelGetSourceData();
     void setFilters(QDir::Filters filters);
-    void setNameFilters(const QStringList &nameFilters);
-    void resetFilters(const QStringList &nameFilters = QStringList(),
-                      const QDir::Filters filters = QDir::NoFilter);
+    void setNameFilters(const QStringList &filters);
+    void resetFilters(const QDir::Filters filters = QDir::NoFilter);
     void onToggleHiddenFiles();
     void onShowHiddenFileChanged(bool isShow);
     void onAppAttributeChanged(Application::ApplicationAttribute aa, const QVariant &value);
@@ -114,6 +114,7 @@ public slots:
     void handleFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg);
 
 private:
+    void checkNameFilters(FileItemData *itemData);
     bool checkFilters(const SortInfoPointer &sortInfo, const bool byInfo = false);
     void filterAllFiles(const bool byInfo = false);
     void filterAllFilesOrdered();
@@ -133,7 +134,7 @@ private:
 
 private:
     QUrl current;
-    QStringList nameFilters;
+    QStringList nameFilters {};
     QDir::Filters filters { QDir::NoFilter };
     QDirIterator::IteratorFlags flags { QDirIterator::NoIteratorFlags };
     QList<SortInfoPointer> children {};

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -926,7 +926,8 @@ void FileView::mousePressEvent(QMouseEvent *event)
                 return;
             }
         } else {
-            d->selectHelper->setSelection(selectionModel()->selection());
+            if (selectionMode() != QAbstractItemView::SingleSelection)
+                d->selectHelper->setSelection(selectionModel()->selection());
         }
 
         d->lastMousePressedIndex = QModelIndex();

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/bug/ut_workspacepluginbugtest.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/bug/ut_workspacepluginbugtest.cpp
@@ -42,13 +42,12 @@ TEST(UT_WorkspacePluginBugTest, bug_140799_desktopFilter)
     stub_ext::StubExt stub;
     typedef QVariant(*FuncType)(Application::ApplicationAttribute);
     stub.set_lamda(static_cast<FuncType>(&Application::appAttribute), [] {return QVariant(false); });
-    stub.set_lamda(&FileUtils::isDesktopFile, [ &isExcuDesktopFileCheck ] { isExcuDesktopFileCheck = true; return ""; });
+    stub.set_lamda(&FileSortWorker::checkNameFilters, [ &isExcuDesktopFileCheck ] { isExcuDesktopFileCheck = true; });
 
     FileViewModel model;
     FileInfoPointer info(new FileInfo(QUrl("file:///home")));
     FileSortWorker *work = new FileSortWorker(QUrl("file:///home"), "1234");
-    work->nameFilters = QStringList { "*.desktop" };
+    model.nameFilters = QStringList { "*.desktop" };
     model.filterSortWorker.reset(work);
-    model.passNameFilters(QModelIndex());
     EXPECT_TRUE(isExcuDesktopFileCheck);
 }


### PR DESCRIPTION
1. remove useless code of name filter function
2. add logic code of after set namefilter, immediately refresh
3. when set SingleSelection, should not support multiple choices

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-197323.html