### PR TITLE
fix: [io/watcher]Monitor failure in mtp directory

### DIFF
--- a/include/dfm-base/utils/threadcontainer.h
+++ b/include/dfm-base/utils/threadcontainer.h
@@ -358,6 +358,11 @@ public:
         return myMap.clear();
     }
 
+    inline QList<DKey> keys() {
+        QMutexLocker lk(&mutex);
+        return  myMap.keys();
+    }
+
 private:
     QMap<DKey, DValue> myMap;   // 当前的QMap
     QMutex mutex;   // 当前的锁

--- a/include/dfm-base/utils/watchercache.h
+++ b/include/dfm-base/utils/watchercache.h
@@ -32,6 +32,7 @@ public:
 
     void cacheWatcher(const QUrl &url, const QSharedPointer<AbstractFileWatcher> &watcher);
     void removeCacheWatcher(const QUrl &url);
+    void removeCacheWatcherByParent(const QUrl &parent);
     bool cacheDisable(const QString &scheme);
     void setCacheDisbale(const QString &scheme, bool disbale = true);
 };

--- a/src/dfm-base/utils/watchercache.cpp
+++ b/src/dfm-base/utils/watchercache.cpp
@@ -98,6 +98,19 @@ void WatcherCache::removeCacheWatcher(const QUrl &url)
     d->watchers.remove(url);
 }
 
+void WatcherCache::removeCacheWatcherByParent(const QUrl &parent)
+{
+    if (parent.path() == "/")
+        return;
+
+    Q_D(WatcherCache);
+    auto keys = d->watchers.keys();
+    for (const auto &url : keys) {
+        if (url.scheme() == parent.scheme() && url.path().startsWith(parent.path()))
+            d->watchers.remove(url);
+    }
+}
+
 bool WatcherCache::cacheDisable(const QString &scheme)
 {
     return d->disableCahceSchemes.contains(scheme);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
@@ -353,6 +353,7 @@ void TabBar::closeTabAndRemoveCachedMnts(const QString &id)
         this->closeTab(WorkspaceHelper::instance()->windowId(this), url);
         FileDataManager::instance()->cleanRoot(url);
         emit InfoCacheController::instance().removeCacheFileInfo({ url });
+        WatcherCache::instance().removeCacheWatcherByParent(url);
     }
     allMntedDevs.remove(id);
 }


### PR DESCRIPTION
After entering a directory mounted by MTP, a monitor was created for caching, but the device was uninstalled without removing the monitor. After being mounted again, the monitor became invalid. Modify the removal of monitors during device uninstallation.

Log: Monitor failure in mtp directory