### PR TITLE
fix: The size item display error

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
@@ -5,6 +5,7 @@
 #include "multifilepropertydialog.h"
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/universalutils.h>
 
 #include <DFontSizeManager>
 
@@ -24,7 +25,9 @@ MultiFilePropertyDialog::MultiFilePropertyDialog(const QList<QUrl> &urls, QWidge
     setFixedSize(300, 360);
     fileCalculationUtils = new FileStatisticsJob;
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &MultiFilePropertyDialog::updateFolderSizeLabel);
-    fileCalculationUtils->start(urlList);
+    QList<QUrl> targets;
+    UniversalUtils::urlsTransformToLocal(urlList, &targets);
+    fileCalculationUtils->start(targets);
     calculateFileCount();
     this->setAttribute(Qt::WA_DeleteOnClose, true);
 }


### PR DESCRIPTION
In the vault, the size item in the multifile property dialog is not displayed correctly

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-200971.html
