### PR TITLE
fix: Do not select all text when entering edit mode in the address bar

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
@@ -577,7 +577,6 @@ void AddressBar::setCurrentUrl(const QUrl &url)
 {
     QString text = dfmbase::FileUtils::isLocalFile(url) ? url.toLocalFile() : UrlRoute::urlToLocalPath(url.toString());
     this->setText(text);
-    this->setSelection(0, text.length());
 }
 
 QUrl AddressBar::currentUrl()


### PR DESCRIPTION
as title

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-201161.html