### PR TITLE
fix: [menu]File Manager Right Mouse Button Stuck

### DIFF
--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
@@ -211,7 +211,7 @@ QList<DCustomActionEntry> DCustomActionBuilder::matchActions(const QList<QUrl> &
         for (auto it = oriActions.begin(); it != oriActions.end();) {
             DCustomActionEntry &tempAction = *it;
             //协议，后缀
-            if (!isSchemeSupport(tempAction, singleUrl) || !isSuffixSupport(tempAction, singleUrl)) {
+            if (!isSchemeSupport(tempAction, singleUrl) || !isSuffixSupport(tempAction, fileInfo)) {
                 it = oriActions.erase(it);   //不支持的action移除
                 continue;
             }
@@ -423,19 +423,16 @@ bool DCustomActionBuilder::isSchemeSupport(const DCustomActionEntry &action, con
     return supportList.contains(url.scheme(), Qt::CaseInsensitive);
 }
 
-bool DCustomActionBuilder::isSuffixSupport(const DCustomActionEntry &action, const QUrl &url)
+bool DCustomActionBuilder::isSuffixSupport(const DCustomActionEntry &action, FileInfoPointer fileInfo)
 {
     QString errString;
-    const FileInfoPointer &fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
-
     auto supportList = action.supportStuffix();
     if (!fileInfo || fileInfo->isAttributes(OptInfoType::kIsDir) || supportList.isEmpty() || supportList.contains("*")) {
         return true;   //未特殊指明支持项或者包含*为支持所有
     }
-    QFileInfo info(url.toLocalFile());
 
     //例如： 7z.001,7z.002, 7z.003 ... 7z.xxx
-    QString cs = info.completeSuffix();
+    QString cs = fileInfo->nameOf(NameInfoType::kCompleteSuffix);
     if (supportList.contains(cs, Qt::CaseInsensitive)) {
         return true;
     }

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.h
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.h
@@ -42,7 +42,7 @@ private:
     static bool isMimeTypeSupport(const QString &mt, const QStringList &fileMimeTypes);
     static bool isMimeTypeMatch(const QStringList &fileMimeTypes, const QStringList &supportMimeTypes);
     static bool isSchemeSupport(const DCustomActionEntry &action, const QUrl &url);
-    static bool isSuffixSupport(const DCustomActionEntry &action, const QUrl &url);
+    static bool isSuffixSupport(const DCustomActionEntry &action, FileInfoPointer fileInfo);
     static void appendAllMimeTypes(const FileInfoPointer &fileInfo, QStringList &noParentmimeTypes, QStringList &allMimeTypes);
     static void appendParentMimeType(const QStringList &parentmimeTypes, QStringList &mimeTypes);
 

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
@@ -132,7 +132,6 @@ void ClipBoardMenuScene::updateState(QMenu *parent)
         for (const auto &info : d->selectFileInfos) {
             if (!info)
                 continue;
-            info->refresh();
 
             if (auto cut = d->predicateAction.value(ActionID::kCut)) {
                 if (!info->canAttributes(CanableInfoType::kCanRename)) {

--- a/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.cpp
@@ -170,10 +170,9 @@ bool OemMenuPrivate::isSchemeSupport(const QAction *action, const QUrl &url) con
     return supportList.contains(url.scheme(), Qt::CaseInsensitive);
 }
 
-bool OemMenuPrivate::isSuffixSupport(const QAction *action, const QUrl &url, const bool allEx7z) const
+bool OemMenuPrivate::isSuffixSupport(const QAction *action, FileInfoPointer fileInfo, const bool allEx7z) const
 {
     QString errString;
-    auto fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
 
     // X-DFM-SupportSuffix not exist
     if (!fileInfo || fileInfo->isAttributes(OptInfoType::kIsDir) || !action || (!action->property(kSupportSuffixKey).isValid() && !action->property(kSupportSuffixAliasKey).isValid())) {
@@ -227,12 +226,12 @@ bool OemMenuPrivate::isAllEx7zFile(const QList<QUrl> &files) const
     return true;
 }
 
-bool OemMenuPrivate::isValid(const QAction *action, const QUrl &url, const bool onDesktop, const bool allEx7z) const
+bool OemMenuPrivate::isValid(const QAction *action, FileInfoPointer fileInfo, const bool onDesktop, const bool allEx7z) const
 {
     if (!action)
         return false;
 
-    return isActionShouldShow(action, onDesktop) && isSchemeSupport(action, url) && isSuffixSupport(action, url, allEx7z);
+    return isActionShouldShow(action, onDesktop) && isSchemeSupport(action, fileInfo->urlOf(UrlInfoType::kUrl)) && isSuffixSupport(action, fileInfo, allEx7z);
 }
 
 void OemMenuPrivate::clearSubMenus()
@@ -462,11 +461,12 @@ void OemMenu::loadDesktopFile()
 QList<QAction *> OemMenu::emptyActions(const QUrl &currentDir, bool onDesktop)
 {
     QList<QAction *> actions = d->actionListByType[kEmptyArea];
+    auto fileInfo = InfoFactory::create<FileInfo>(currentDir);
 
     auto it = actions.begin();
     while (it != actions.end()) {
         QAction *action = *it;
-        if (!d->isValid(action, currentDir, onDesktop)) {
+        if (!d->isValid(action, fileInfo, onDesktop)) {
             it = actions.erase(it);
             continue;
         }
@@ -519,7 +519,7 @@ QList<QAction *> OemMenu::normalActions(const QList<QUrl> &files, const QList<Fi
 
         for (auto it = actions.begin(); it != actions.end();) {
             QAction *action = *it;
-            if (!d->isValid(action, file, onDesktop, bex7z)) {
+            if (!d->isValid(action, fileInfo, onDesktop, bex7z)) {
                 it = actions.erase(it);
                 continue;
             }

--- a/src/plugins/common/core/dfmplugin-menu/oemmenuscene/private/oemmenu_p.h
+++ b/src/plugins/common/core/dfmplugin-menu/oemmenuscene/private/oemmenu_p.h
@@ -7,6 +7,8 @@
 
 #include "dfmplugin_menu_global.h"
 
+#include <dfm-base/interfaces/fileinfo.h>
+
 #include <DDesktopEntry>
 
 #include <QObject>
@@ -39,9 +41,9 @@ public:
     bool isMimeTypeMatch(const QStringList &fileMimeTypes, const QStringList &supportMimeTypes) const;
     bool isActionShouldShow(const QAction *action, bool onDesktop) const;
     bool isSchemeSupport(const QAction *action, const QUrl &url) const;
-    bool isSuffixSupport(const QAction *action, const QUrl &url, const bool allEx7z = false) const;
+    bool isSuffixSupport(const QAction *action, FileInfoPointer fileInfo, const bool allEx7z = false) const;
     bool isAllEx7zFile(const QList<QUrl> &files) const;
-    bool isValid(const QAction *action, const QUrl &url, const bool onDesktop, const bool allEx7z = false) const;
+    bool isValid(const QAction *action, FileInfoPointer fileInfo, const bool onDesktop, const bool allEx7z = false) const;
 
     void clearSubMenus();
     void setActionProperty(QAction *const action, const Dtk::Core::DDesktopEntry &entry, const QString &key, const QString &section = "Desktop Entry") const;


### PR DESCRIPTION
Fileinfo was created in the isSuffixSupport function in the dcustomactionbuilder class and the oemmenu class. Modify the selected fileinfo passed in here.

Log: File Manager Right Mouse Button Stuck