### PR TITLE
fix: [menu/asyncfileinfout]The right mouse button of the file manageris stuck, and the ut modification of asyncfileinfo

### DIFF
--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -4,6 +4,7 @@
 
 #include "fileinfohelper.h"
 #include "dfm-base/file/local/asyncfileinfo.h"
+#include "dfm-base/utils/fileutils.h"
 
 #include <QGuiApplication>
 #include <QTimer>
@@ -37,6 +38,7 @@ void FileInfoHelper::init()
 
     worker->moveToThread(thread.data());
     thread->start();
+    pool.setMaxThreadCount(std::max(FileUtils::getCpuProcessCount(), 10));
 }
 
 void FileInfoHelper::threadHandleDfmFileInfo(const QSharedPointer<FileInfo> dfileInfo)

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/openwithmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/openwithmenuscene.cpp
@@ -150,8 +150,11 @@ void OpenWithMenuScene::updateState(QMenu *parent)
 
         QString errString;
         QList<QUrl> redirectedUrls;
+        auto tempSelectInfos = d->selectFileInfos;
+        if (d->selectFiles.count() > d->selectFileInfos.count())
+            tempSelectInfos << InfoFactory::create<FileInfo>(d->selectFiles.last());
 
-        for (auto info : d->selectFileInfos) {
+        for (auto info : tempSelectInfos) {
             if (Q_UNLIKELY(info.isNull())) {
                 qDebug() << errString;
                 break;


### PR DESCRIPTION
Fileinfo was created in the updateState function in the FileOperatorMenuScene class. Modify here to use the selected fileinfo. If the selected file passed in does not match the selected fieldinfo, add the fileinfo of the last selected file. UT modification is processed using asynchronous threads.

Log: The right mouse button of the file manager is stuck, and the ut modification of asyncfileinfo