### PR TITLE
fix: [settings]set sidebar visible no response

### DIFF
--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -6,7 +6,10 @@
 #include "private/settingbackend_p.h"
 #include "dconfig/dconfigmanager.h"
 
+#include <DSettings>
+
 #include <QDebug>
+#include <QApplication>
 
 DFMBASE_USE_NAMESPACE
 
@@ -70,6 +73,17 @@ SettingBackend *SettingBackend::instance()
 {
     static SettingBackend ins;
     return &ins;
+}
+
+void SettingBackend::setToSettings(DSettings *settings)
+{
+    if (settings) {
+        // NOTE: Must move SettingBackend to main thread before call dtk setBackend().
+        // The setBackend func will move the SettingBackend object to anthor thread,
+        // but the last thread which the SettingBackend object in was destroyed.
+        moveToThread(QApplication::instance()->thread());
+        settings->setBackend(this);
+    }
 }
 
 QStringList SettingBackend::keys() const

--- a/src/dfm-base/base/configs/settingbackend.h
+++ b/src/dfm-base/base/configs/settingbackend.h
@@ -23,6 +23,8 @@ class SettingBackend : public DSettingsBackend
 public:
     static SettingBackend *instance();
 
+    void setToSettings(DSettings *settings);
+
     QStringList keys() const;
     QVariant getOption(const QString &key) const;
     void doSync();

--- a/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
@@ -199,10 +199,9 @@ SettingDialog::SettingDialog(QWidget *parent)
     loadSettings(settingTemplate);
 
     // load conf value
-    auto backen = SettingBackend::instance();
     if (dtkSettings) {
         dtkSettings->setParent(this);
-        dtkSettings->setBackend(backen);
+        SettingBackend::instance()->setToSettings(dtkSettings);
         updateSettings("QObject", dtkSettings);
     }
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/customtopwidgetinterface.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/customtopwidgetinterface.cpp
@@ -4,16 +4,21 @@
 
 #include "customtopwidgetinterface.h"
 
+#include <QWidget>
+
 using namespace dfmplugin_workspace;
 CustomTopWidgetInterface::CustomTopWidgetInterface(QObject *parent)
     : QObject(parent)
 {
 }
 
-QWidget *CustomTopWidgetInterface::create()
+QWidget *CustomTopWidgetInterface::create(QWidget *parent)
 {
-    if (createTopWidgetFunc)
-        return createTopWidgetFunc();
+    if (createTopWidgetFunc) {
+        auto widget = createTopWidgetFunc();
+        widget->setParent(parent);
+        return widget;
+    }
     return nullptr;
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/customtopwidgetinterface.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/customtopwidgetinterface.h
@@ -21,7 +21,7 @@ class CustomTopWidgetInterface : public QObject
 public:
     explicit CustomTopWidgetInterface(QObject *parent = nullptr);
 
-    QWidget *create();
+    QWidget *create(QWidget *parent = nullptr);
     bool isShowFromUrl(QWidget *w, const QUrl &url);
     void setKeepShow(bool keep);
     bool isKeepShow() const;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
@@ -256,6 +256,9 @@ void RenameBar::eventDispatcher()
 
     setVisible(false);
     reset();
+
+    if (parentWidget())
+        parentWidget()->setFocus();
 }
 
 void RenameBar::hideRenameBar()

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
@@ -158,7 +158,7 @@ void WorkspaceWidget::setCustomTopWidgetVisible(const QString &scheme, bool visi
     } else {
         auto interface = WorkspaceHelper::instance()->createTopWidgetByScheme(scheme);
         if (interface) {
-            TopWidgetPtr topWidgetPtr = QSharedPointer<QWidget>(interface->create());
+            TopWidgetPtr topWidgetPtr = QSharedPointer<QWidget>(interface->create(this));
             if (topWidgetPtr) {
                 widgetLayout->insertWidget(widgetLayout->indexOf(tabBottomLine) + 1, topWidgetPtr.get());
                 topWidgets.insert(scheme, topWidgetPtr);


### PR DESCRIPTION
the setting backend will be move to another thread, but it will failed while last thread destroyed. So move the SettingBackend to the main thread before call the setBackend() func.

Log: fix settings issue
Bug: https://pms.uniontech.com/bug-view-203247.html