### PR TITLE
fix: [menu]V23 desktop right mouse button crashes

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasselectionmodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasselectionmodel.cpp
@@ -48,8 +48,11 @@ QList<FileInfoPointer> CanvasSelectionModel::selectedFileInfos() const
 {
     auto indexs = selectedIndexesCache();
     QList<FileInfoPointer> infos;
-    for (auto index : indexs)
-        infos <<  model()->fileInfo(index);
+    for (auto index : indexs) {
+        auto info = model()->fileInfo(index);
+        if (info)
+            infos <<  info;
+    }
 
     return infos;
 }

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
@@ -89,13 +89,20 @@ void CollectionViewMenu::emptyAreaMenu()
 void CollectionViewMenu::normalMenu(const QModelIndex &index, const Qt::ItemFlags &indexFlags, const QPoint gridPos)
 {
     QList<QUrl> selectUrls;
+    QList<FileInfoPointer> selectInfos;
     for (const QModelIndex &idx : view->selectedIndexes()) {
         auto url = view->model()->fileUrl(idx);
         if (url.isValid())
             selectUrls << url;
+        auto info = view->model()->fileInfo(idx);
+        if (info)
+            selectInfos.append(info);
     }
 
     auto tgUrl = view->model()->fileUrl(index);
+    auto focusInfo = view->model()->fileInfo(index);
+    if (!focusInfo)
+        return;
 
     // first is focus
     if (selectUrls.size() > 1) {
@@ -106,6 +113,8 @@ void CollectionViewMenu::normalMenu(const QModelIndex &index, const Qt::ItemFlag
     QVariantHash params;
     params[MenuParamKey::kCurrentDir] = view->model()->fileUrl(view->model()->rootIndex());
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(selectUrls);
+    params[MenuParamKey::kFocusFileInfo] = QVariant::fromValue(focusInfo);
+    params[MenuParamKey::kSelectFileInfos] = QVariant::fromValue(selectInfos);
     params[MenuParamKey::kOnDesktop] = true;
     params[MenuParamKey::kWindowId] = view->winId();
     params[MenuParamKey::kIsEmptyArea] = false;


### PR DESCRIPTION
The normalMenu in the CollectionViewMenu class did not pass in focusinfo and selectinfos. Modify and add the passing in of the focusinfo and selectinfos parameters.

Log: V23 desktop right mouse button crashes