### PR TITLE
fix: [fileinfo]The icon of the application program changes to a gear shape after being placed on the USB drive

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -117,21 +117,31 @@ QString AsyncFileInfo::nameOf(const NameInfoType type) const
 {
     switch (type) {
     case FileNameInfoType::kFileName:
-        return d->asyncAttribute(AsyncAttributeID::kStandardName).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardName).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardName).toString();
+        break;
     case FileNameInfoType::kBaseName:
-        return d->asyncAttribute(AsyncAttributeID::kStandardBaseName).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardBaseName).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardBaseName).toString();
+        break;
     case FileNameInfoType::kCompleteBaseName:
-        return d->asyncAttribute(AsyncAttributeID::kStandardCompleteBaseName).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardCompleteBaseName).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardCompleteBaseName).toString();
+        break;
     case FileNameInfoType::kSuffix:
         [[fallthrough]];
     case FileNameInfoType::kSuffixOfRename:
         if (d->asyncAttribute(AsyncAttributeID::kStandardSuffix).isValid())
             return d->asyncAttribute(AsyncAttributeID::kStandardSuffix).toString();
-        return FileInfo::nameOf(type);
+        break;
     case FileNameInfoType::kCompleteSuffix:
-        return d->asyncAttribute(AsyncAttributeID::kStandardCompleteSuffix).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardCompleteSuffix).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardCompleteSuffix).toString();
+        break;
     case FileNameInfoType::kFileCopyName:
-        return d->asyncAttribute(AsyncAttributeID::kStandardDisplayName).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardDisplayName).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardDisplayName).toString();
+        break;
     case FileNameInfoType::kIconName:
         return d->iconName();
     case FileNameInfoType::kGenericIconName:
@@ -141,6 +151,7 @@ QString AsyncFileInfo::nameOf(const NameInfoType type) const
     default:
         return FileInfo::nameOf(type);
     }
+    return FileInfo::nameOf(type);
 }
 /*!
   * \brief 获取文件路径，默认是文件全路径，此接口不会实现异步，全部使用Qurl去
@@ -155,16 +166,21 @@ QString AsyncFileInfo::pathOf(const PathInfoType type) const
     case FilePathInfoType::kAbsoluteFilePath:
         [[fallthrough]];
     case FilePathInfoType::kCanonicalPath:
-        return d->asyncAttribute(AsyncAttributeID::kStandardFilePath).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardFilePath).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardFilePath).toString();
+        break;
     case FilePathInfoType::kPath:
         [[fallthrough]];
     case FilePathInfoType::kAbsolutePath:
-        return d->asyncAttribute(AsyncAttributeID::kStandardParentPath).toString();
+        if (d->asyncAttribute(AsyncAttributeID::kStandardParentPath).isValid())
+            return d->asyncAttribute(AsyncAttributeID::kStandardParentPath).toString();
+        break;
     case FilePathInfoType::kSymLinkTarget:
         return d->asyncAttribute(AsyncAttributeID::kStandardSymlinkTarget).toString();
     default:
         return FileInfo::pathOf(type);
     }
+    return FileInfo::pathOf(type);
 }
 /*!
  * \brief 获取文件url，默认是文件的url，此接口不会实现异步，全部使用Qurl去

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -152,7 +152,15 @@ QString dfmbase::FileInfo::pathOf(const PathInfoType type) const
     Q_UNUSED(type);
     switch (type) {
     case FilePathInfoType::kFilePath:
+        [[fallthrough]];
+    case FilePathInfoType::kAbsoluteFilePath:
+        [[fallthrough]];
+    case FilePathInfoType::kCanonicalPath:
         return url.path();
+    case FilePathInfoType::kPath:
+        [[fallthrough]];
+    case FilePathInfoType::kAbsolutePath:
+        return UrlRoute::urlParent(url).path();
     default:
         return QString();
     }


### PR DESCRIPTION
Error in obtaining suffix for asynchronous file information in the global conversion function transFileInfo of VirtualGlobalPlugin. Modify the path and nameof in asyncfileinfo to determine that the cache is invalid, and use the parent class fileinfo to obtain these strings.

Log: The icon of the application program changes to a gear shape after being placed on the USB drive
Bug: https://pms.uniontech.com/bug-view-203623.html