### PR TITLE
去除回环分区设备重命名入口

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -174,6 +174,7 @@ void DeviceManager::mountBlockDevAsync(const QString &id, const QVariantMap &opt
 
         QFutureWatcher<void> *fw { new QFutureWatcher<void>() };
         connect(fw, &QFutureWatcher<void>::finished, this, [=]() {
+            qInfo() << "query optical item info finished, about to starting mounting it...";
             d->isMountingOptical = false;
             dev->mountAsync(opts, callback);
             delete fw;

--- a/src/dfm-base/base/device/private/devicewatcher.cpp
+++ b/src/dfm-base/base/device/private/devicewatcher.cpp
@@ -9,6 +9,7 @@
 #include <dfm-base/base/device/deviceutils.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
 #include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/utils/finallyutil.h>
 
 #include <QVariantMap>
 #include <QDebug>
@@ -163,6 +164,9 @@ void DeviceWatcher::initDevDatas()
  */
 void DeviceWatcher::queryOpticalDevUsage(const QString &id)
 {
+    FinallyUtil final([id]{ qInfo() << "query optical usage finished for" << id; });
+    Q_UNUSED(final);
+
     QVariantMap data = DeviceHelper::loadBlockInfo(id);
     if (data.value(DeviceProperty::kId).toString().isEmpty())
         return;

--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -210,6 +210,9 @@ bool BlockEntryFileEntity::renamable() const
         && datas.value(DeviceProperty::kCleartextDevice).toString() == "/")
         return false;
 
+    if (datas.value(DeviceProperty::kIsLoopDevice, false).toBool())
+        return false;
+
     return isAccessable();
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-computer/menu/computermenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/menu/computermenuscene.cpp
@@ -174,6 +174,10 @@ void ComputerMenuScene::updateState(QMenu *parent)
     if (!dpfSlotChannel->push("dfmplugin_workspace", "slot_Tab_Addable", d->windowId).toBool())
         disabled.append(kOpenInNewTab);
 
+    // do not show 'rename' entry for loop devices.
+    if (d->info->extraProperties().value(DeviceProperty::kIsLoopDevice, false).toBool())
+        keeped.removeAll(kRename);
+
     if (!keeped.isEmpty())
         d->updateMenu(parent, disabled, keeped);
     AbstractMenuScene::updateState(parent);


### PR DESCRIPTION
重命名入口包含计算机设备右键重命名，侧边栏设备右键重命名，设备项 F2、慢速双击重命名。

as title.
disable rename action for loop device.

Log: no rename action for loop devices.

Bug: https://pms.uniontech.com/bug-view-203421.html
