### PR TITLE
fix: filemanager window is showed in Initializing.

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
@@ -53,7 +53,10 @@ FileDialogHandle::FileDialogHandle(QWidget *parent)
     // install all widgets before window showed
     emit d_func()->dialog->aboutToOpen();
     d_func()->dialog->cd(QUrl::fromLocalFile(defaultPath));
-    d_func()->dialog->hide();
+
+    //! no need to hide, if the dialog is showed in creating, it must be bug.
+    //! see bug#22564
+    //d_func()->dialog->hide();
 
     connect(d_func()->dialog, &FileDialog::accepted, this, &FileDialogHandle::accepted);
     connect(d_func()->dialog, &FileDialog::rejected, this, &FileDialogHandle::rejected);

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -52,6 +52,9 @@ FileDialogPrivate::FileDialogPrivate(FileDialog *qq)
     : QObject(nullptr),
       q(qq)
 {
+    //! fix: FileDialog no needs to restore window state on creating.
+    //! see FileManagerWindowsManager::createWindow
+    q->setProperty("_dfm_Disable_RestoreWindowState_", true);
 }
 
 void FileDialogPrivate::handleSaveAcceptBtnClicked()

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -151,7 +151,6 @@ void OptionButtonBox::initializeUi()
     d->detailButton->setCheckable(true);
     d->detailButton->setFocusPolicy(Qt::NoFocus);
     d->detailButton->setIcon(QIcon::fromTheme("dfm_rightview_detail"));
-    d->detailButton->show();
 
     initUiForSizeMode();
 }


### PR DESCRIPTION
It is incorrect that showing a window that is Initializing.

When using the D-Bus interface to create a file dialog, the internal process of the file manager calls the show method, causing the file dialog to be shown and stealing the window focus upon creation. However, after the file dialog is created, it is then immediately hidden without being showed.

This results in only the creation of the file dialog, while causing other windows to lose focus.

Log: 

Bug: https://pms.uniontech.com/bug-view-22564.html
 
Influence: 文管窗口状态