### PR TITLE
feat: [menu]Remove parameters passed out using fileinfo from the right-click menu bar

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -224,12 +224,12 @@ public:
             if (type == Global::CreateFileInfoType::kCreateFileInfoSync) {
                 return qSharedPointerDynamicCast<T>(instance().SchemeFactory<FileInfo>::
                                                             create(url, errorString));
-            } else if (type == Global::CreateFileInfoType::kCreateFileInfoSync) {
+            } else if (type == Global::CreateFileInfoType::kCreateFileInfoAsync) {
                 auto info = qSharedPointerDynamicCast<T>(instance().SchemeFactory<FileInfo>::
                                                                  create(Global::Scheme::kAsyncFile, url, errorString));
                 if (info)
                     info->refresh();
-                return info;
+                return qSharedPointerDynamicCast<T>(info);
             }
         }
 
@@ -237,14 +237,17 @@ public:
         if (!info) {
             auto tarScheme = scheme(url);
             info = instance().SchemeFactory<FileInfo>::create(tarScheme, url, errorString);
-            if (info && tarScheme == Global::Scheme::kAsyncFile) {
-                info->refresh();
-                emit InfoCacheController::instance().cacheFileInfo(url, info);
-            }
-        }
 
-        if (!info)
-            qWarning() << "info is nullptr url = " << url;
+            if (!info) {
+                qWarning() << "info is nullptr url = " << url;
+                return qSharedPointerDynamicCast<T>(info);
+            }
+
+            if (tarScheme == Global::Scheme::kAsyncFile)
+                info->refresh();
+
+            emit InfoCacheController::instance().cacheFileInfo(url, info);
+        }
 
         return qSharedPointerDynamicCast<T>(info);
     }

--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -102,7 +102,7 @@ enum CreateFileInfoType : uint8_t {
     kCreateFileInfoSync = 1,
     kCreateFileInfoAsync = 2,
     kCreateFileInfoSyncAndCache = 3,    // create file info Synchronize and cache file info
-    kCreateFileInfoAsyncAndCache = 4    // create file info Asynchronous and cache file info
+    kCreateFileInfoAsyncAndCache = 4,    // create file info Asynchronous and cache file info
 };
 
 namespace Mime {

--- a/include/dfm-base/dfm_menu_defines.h
+++ b/include/dfm-base/dfm_menu_defines.h
@@ -13,8 +13,6 @@ namespace MenuParamKey {
 // file menu params for initialize
 inline constexpr char kCurrentDir[] = "currentDir";   // QUrl
 inline constexpr char kSelectFiles[] = "selectFiles";   // QList<QUrl>
-inline constexpr char kSelectFileInfos[] = "selectFileInfos";   // QList<FileInfoPointer>
-inline constexpr char kFocusFileInfo[] = "focusFileInfo";   // FileInfoPointer
 inline constexpr char kOnDesktop[] = "onDesktop";   // bool
 inline constexpr char kWindowId[] = "windowId";   // quint64
 inline constexpr char kIsEmptyArea[] = "isEmptyArea";   // bool

--- a/src/dfm-base/interfaces/private/abstractmenuscene_p.h
+++ b/src/dfm-base/interfaces/private/abstractmenuscene_p.h
@@ -22,7 +22,6 @@ public:
 public:
     QUrl currentDir;
     QList<QUrl> selectFiles;
-    QList<FileInfoPointer> selectFileInfos;
     QUrl focusFile;
     bool onDesktop { false };
     bool isEmptyArea { false };

--- a/src/plugins/common/core/dfmplugin-bookmark/menu/bookmarkmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-bookmark/menu/bookmarkmenuscene.cpp
@@ -50,11 +50,8 @@ bool BookmarkMenuScene::initialize(const QVariantHash &params)
     d->showBookMarkMenu = true;
     d->isSystemPathIncluded = params.value(MenuParamKey::kIsSystemPathIncluded, false).toBool();
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
 
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
 
@@ -72,7 +69,8 @@ bool BookmarkMenuScene::create(QMenu *parent)
     if (!d->showBookMarkMenu)
         return AbstractMenuScene::create(parent);
 
-    for (const auto &info : d->selectFileInfos) {
+    for (const auto &url : d->selectFiles) {
+        auto info = InfoFactory::create<FileInfo>(url);
         if ((info && !info->isAttributes(OptInfoType::kIsDir)) || d->isSystemPathIncluded)
             return AbstractMenuScene::create(parent);
     }

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
@@ -117,19 +117,19 @@ QString DCustomActionBuilder::getCompleteSuffix(const QString &fileName, const Q
 /*!
     检查 \a files 文件列表中的文件组合
  */
-DCustomActionDefines::ComboType DCustomActionBuilder::checkFileCombo(const QList<QUrl> &files, const QList<FileInfoPointer> &infos)
+DCustomActionDefines::ComboType DCustomActionBuilder::checkFileCombo(const QList<QUrl> &files)
 {
-    Q_UNUSED(files)
     int fileCount = 0;
     int dirCount = 0;
     QString errString;
 
-    for (const auto &info : infos) {
-        if (info.isNull()) {
-            qDebug() << errString;
+    for (const auto &file : files) {
+        if (!file.isValid())
             continue;
-        }
 
+        auto info = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(file, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+        if (info.isNull())
+            continue;
         //目前只判断是否为文件夹
         info->isAttributes(OptInfoType::kIsDir) ? ++dirCount : ++fileCount;
 
@@ -167,7 +167,7 @@ QList<DCustomActionEntry> DCustomActionBuilder::matchFileCombo(const QList<DCust
     return ret;
 }
 
-QList<DCustomActionEntry> DCustomActionBuilder::matchActions(const QList<QUrl> &selects, const QList<FileInfoPointer> &selectInfos,
+QList<DCustomActionEntry> DCustomActionBuilder::matchActions(const QList<QUrl> &selects,
                                                              QList<DCustomActionEntry> oriActions)
 {
     //todo：细化功能颗粒度，一个函数尽量专职一件事
@@ -180,14 +180,14 @@ QList<DCustomActionEntry> DCustomActionBuilder::matchActions(const QList<QUrl> &
     */
 
     //具体配置过滤
-    for (auto &fileInfo : selectInfos) {
+    for (auto &singleUrl : selects) {
         //协议、后缀
+        QString errString;
+        const FileInfoPointer &fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(singleUrl, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
         if (fileInfo.isNull()) {
-            qWarning() << "create selected FileInfo failed ! ";
-            continue;
+           qWarning() << "create selected FileInfo failed: " << singleUrl.toString() << errString;
+           continue;
         }
-
-        auto singleUrl = fileInfo->urlOf(UrlInfoType::kUrl);
 
         /*
          * 选中文件类型过滤：

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.h
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.h
@@ -28,11 +28,10 @@ public:
     void setActiveDir(const QUrl &dir);
     void setFocusFile(const QUrl &file);
     QString getCompleteSuffix(const QString &fileName, const QString &suf);
-    static DCustomActionDefines::ComboType checkFileCombo(const QList<QUrl> &files, const QList<FileInfoPointer> &infos);
+    static DCustomActionDefines::ComboType checkFileCombo(const QList<QUrl> &files);
     static QList<DCustomActionEntry> matchFileCombo(const QList<DCustomActionEntry> &rootActions,
                                                     DCustomActionDefines::ComboTypes type);
     static QList<DCustomActionEntry> matchActions(const QList<QUrl> &selects,
-                                                  const QList<FileInfoPointer> &selectInfos,
                                                   QList<DCustomActionEntry> oriActions);
     static QPair<QString, QStringList> makeCommand(const QString &cmd, DCustomActionDefines::ActionArg arg,
                                                    const QUrl &dir, const QUrl &foucs, const QList<QUrl> &files);

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
@@ -66,11 +66,8 @@ bool ExtendMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->indexFlags = params.value(MenuParamKey::kIndexFlags).value<Qt::ItemFlags>();
@@ -80,6 +77,15 @@ bool ExtendMenuScene::initialize(const QVariantHash &params)
         qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFile << d->currentDir;
         return false;
     }
+
+    if (!d->isEmptyArea) {
+           QString errString;
+           d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+           if (d->focusFileInfo.isNull()) {
+               qDebug() << "create focus fileinfo error, case: " << errString << ". focus file url : " << d->focusFile;
+               return false;
+           }
+       }
 
     return AbstractMenuScene::initialize(params);
 }
@@ -116,7 +122,7 @@ bool ExtendMenuScene::create(QMenu *parent)
     //获取文件列表的组合
     DCustomActionDefines::ComboType fileCombo = DCustomActionDefines::kBlankSpace;
     if (!d->isEmptyArea) {
-        fileCombo = builder.checkFileCombo(d->selectFiles, d->selectFileInfos);
+        fileCombo = builder.checkFileCombo(d->selectFiles);
         if (fileCombo == DCustomActionDefines::kBlankSpace)
             return false;
 
@@ -128,7 +134,7 @@ bool ExtendMenuScene::create(QMenu *parent)
     auto usedEntrys = builder.matchFileCombo(rootEntry, fileCombo);
 
     //匹配类型支持
-    usedEntrys = builder.matchActions(d->selectFiles, d->selectFileInfos, usedEntrys);
+    usedEntrys = builder.matchActions(d->selectFiles, usedEntrys);
     qDebug() << "selected combo" << fileCombo << "entry count" << usedEntrys.size();
 
     if (usedEntrys.isEmpty())

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/opendirmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/opendirmenuscene.cpp
@@ -50,11 +50,8 @@ bool OpenDirMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
@@ -62,6 +59,15 @@ bool OpenDirMenuScene::initialize(const QVariantHash &params)
     if (!d->initializeParamsIsValid()) {
         qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFile << d->currentDir;
         return false;
+    }
+
+    if (!d->isEmptyArea) {
+        QString errString;
+        d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+        if (d->focusFileInfo.isNull()) {
+            qDebug() << "create focus fileinfo error, case: " << errString << ". focus file url : " << d->focusFile;
+            return false;
+        }
     }
 
     return AbstractMenuScene::initialize(params);

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/sendtomenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/sendtomenuscene.cpp
@@ -51,16 +51,14 @@ bool SendToMenuScene::initialize(const QVariantHash &params)
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    if (!d->isEmptyArea) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
 
     d->isFocusOnDDEDesktopFile = params.value(MenuParamKey::kIsFocusOnDDEDesktopFile, false).toBool();
     d->isSystemPathIncluded = params.value(MenuParamKey::kIsSystemPathIncluded, false).toBool();
     if (!d->initializeParamsIsValid()) {
-        qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFileInfo << d->currentDir;
+        qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFile << d->currentDir;
         return false;
     }
 
@@ -179,7 +177,7 @@ bool SendToMenuScene::triggered(QAction *action)
             if (!linkPath.isEmpty()) {
                 dpfSignalDispatcher->publish(GlobalEventType::kCreateSymlink,
                                              d->windowId,
-                                             d->focusFileInfo,
+                                             d->focusFile,
                                              QUrl::fromLocalFile(linkPath),
                                              true,
                                              false);

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/sharemenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/sharemenuscene.cpp
@@ -45,20 +45,17 @@ bool ShareMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
     d->isFocusOnDDEDesktopFile = params.value(MenuParamKey::kIsFocusOnDDEDesktopFile, false).toBool();
     d->isSystemPathIncluded = params.value(MenuParamKey::kIsSystemPathIncluded, false).toBool();
 
-    auto selectFileInfo = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    for (auto info : selectFileInfo) {
-        if (info->isAttributes(OptInfoType::kIsDir)) {
+    for (auto url : d->selectFiles) {
+        auto f = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(url);
+        if (f && f->isAttributes(OptInfoType::kIsDir)) {
             d->folderSelected = true;
             break;
         }

--- a/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.cpp
@@ -477,7 +477,7 @@ QList<QAction *> OemMenu::emptyActions(const QUrl &currentDir, bool onDesktop)
     return actions;
 }
 
-QList<QAction *> OemMenu::normalActions(const QList<QUrl> &files, const QList<FileInfoPointer> &fileInfos, bool onDesktop)
+QList<QAction *> OemMenu::normalActions(const QList<QUrl> &files, bool onDesktop)
 {
     QString menuType;
 
@@ -500,12 +500,12 @@ QList<QAction *> OemMenu::normalActions(const QList<QUrl> &files, const QList<Fi
 
     QStringList filePaths;
     bool bex7z = d->isAllEx7zFile(files);
-    for (const FileInfoPointer &fileInfo : fileInfos) {
+    for (const QUrl &file : files) {
+        auto fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(file, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
         if (!fileInfo) {
             qWarning() << "createFileInfo failed!";
             continue;
         }
-        auto file = fileInfo->urlOf(UrlInfoType::kUrl);
         filePaths << file.path();
 
         QStringList fileMimeTypes, fmts;

--- a/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.h
+++ b/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenu.h
@@ -7,8 +7,6 @@
 
 #include "dfmplugin_menu_global.h"
 
-#include <dfm-base/interfaces/fileinfo.h>
-
 #include <QObject>
 #include <QAction>
 #include <QScopedPointer>
@@ -25,7 +23,7 @@ public:
 
     void loadDesktopFile();
     QList<QAction *> emptyActions(const QUrl &currentDir, bool onDesktop = false);
-    QList<QAction *> normalActions(const QList<QUrl> &files, const QList<FileInfoPointer> &fileInfos, bool onDesktop = false);
+    QList<QAction *> normalActions(const QList<QUrl> &files, bool onDesktop = false);
     QPair<QString, QStringList> makeCommand(const QAction *action, const QUrl &dir, const QUrl &foucs, const QList<QUrl> &files);
 
 private:

--- a/src/plugins/common/core/dfmplugin-propertydialog/menu/propertymenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/menu/propertymenuscene.cpp
@@ -74,11 +74,8 @@ bool PropertyMenuScene::initialize(const QVariantHash &params)
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
 
     if (!d->initializeParamsIsValid()) {
@@ -114,7 +111,13 @@ bool PropertyMenuScene::create(QMenu *parent)
     tempAction->setProperty(ActionPropertyKey::kActionID, PropertyActionId::kProperty);
 
     QList<QUrl> redirectedUrlList;
-    for (const auto &fileInfo : d->selectFileInfos) {
+    for (const auto &fileUrl : d->selectFiles) {
+        QString errString;
+        auto fileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(fileUrl, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+        if (fileInfo.isNull()) {
+            qDebug() << "create focus fileinfo error, case: " << errString << ". focus file url : " << d->focusFile;
+            continue;
+        }
         redirectedUrlList << fileInfo->urlOf(UrlInfoType::kRedirectedFileUrl);
     }
 

--- a/src/plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.cpp
@@ -157,11 +157,8 @@ bool SendToDiscMenuScene::initialize(const QVariantHash &params)
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->predicateName.insert(ActionId::kStageKey, QObject::tr("Add to disc"));
     d->predicateName.insert(ActionId::kMountImageKey, QObject::tr("Mount"));
@@ -210,6 +207,7 @@ bool SendToDiscMenuScene::create(QMenu *parent)
     d->addToSendto(parent);
 
     // mount image
+    d->focusFileInfo = InfoFactory::create<FileInfo>(d->focusFile);
     if (d->focusFileInfo) {
         static QSet<QString> mountable { "application/x-cd-image", "application/x-iso9660-image" };
         if (mountable.contains(d->focusFileInfo->nameOf(NameInfoType::kMimeTypeName))) {

--- a/src/plugins/common/dfmplugin-dirshare/dirsharemenu/dirsharemenuscene.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/dirsharemenu/dirsharemenuscene.cpp
@@ -68,9 +68,8 @@ bool DirShareMenuScene::initialize(const QVariantHash &params)
     if (u.scheme() != Global::Scheme::kFile)
         return false;
 
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-    if (!d->focusFileInfo->isAttributes(OptInfoType::kIsDir))
+    d->focusFileInfo = InfoFactory::create<FileInfo>(u);
+    if (d->focusFileInfo && !d->focusFileInfo->isAttributes(OptInfoType::kIsDir))
         return false;
 
     return AbstractMenuScene::initialize(params);

--- a/src/plugins/common/dfmplugin-tag/menu/tagdirmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagdirmenuscene.cpp
@@ -98,11 +98,8 @@ bool TagDirMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
 

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.cpp
@@ -50,11 +50,9 @@ bool ExtensionLibMenuScene::initialize(const QVariantHash &params)
     // init default info
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (d->selectFiles.count() > 0)
+        d->focusFile = d->selectFiles.first();
+
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
 

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasselectionmodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasselectionmodel.cpp
@@ -43,16 +43,3 @@ QList<QUrl> CanvasSelectionModel::selectedUrls() const
 
     return urls;
 }
-
-QList<FileInfoPointer> CanvasSelectionModel::selectedFileInfos() const
-{
-    auto indexs = selectedIndexesCache();
-    QList<FileInfoPointer> infos;
-    for (auto index : indexs) {
-        auto info = model()->fileInfo(index);
-        if (info)
-            infos <<  info;
-    }
-
-    return infos;
-}

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasselectionmodel.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasselectionmodel.h
@@ -7,8 +7,6 @@
 
 #include "ddplugin_canvas_global.h"
 
-#include <dfm-base/interfaces/fileinfo.h>
-
 #include <QItemSelectionModel>
 
 namespace ddplugin_canvas {
@@ -21,7 +19,6 @@ public:
     CanvasProxyModel *model() const;
     QModelIndexList selectedIndexesCache() const;
     QList<QUrl> selectedUrls() const;
-    QList<FileInfoPointer> selectedFileInfos() const;
 public slots:
     void clearSelectedCache();
 protected:

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
@@ -94,7 +94,6 @@ void CanvasViewMenuProxy::showEmptyAreaMenu(const Qt::ItemFlags &indexFlags, con
 void CanvasViewMenuProxy::showNormalMenu(const QModelIndex &index, const Qt::ItemFlags &indexFlags, const QPoint gridPos)
 {
     auto selectUrls = view->selectionModel()->selectedUrls();
-    auto selectInfos = view->selectionModel()->selectedFileInfos();
     auto tgUrl = view->model()->fileUrl(index);
 
     // extend menu
@@ -116,20 +115,10 @@ void CanvasViewMenuProxy::showNormalMenu(const QModelIndex &index, const Qt::Ite
     }
 
     // TODO(Lee)：多文件筛选、多选中包含 计算机 回收站 主目录时不显示扩展菜单
-    FileInfoPointer focusFileInfo = view->model()->fileInfo(index);
-    if (!focusFileInfo) {
-        index.data(Global::ItemRoles::kItemCreateFileInfo);
-        focusFileInfo = view->model()->fileInfo(index);
-    }
-
-    if (!focusFileInfo)
-        return;
 
     QVariantHash params;
     params[MenuParamKey::kCurrentDir] = view->model()->rootUrl();
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(selectUrls);
-    params[MenuParamKey::kSelectFileInfos] = QVariant::fromValue(selectInfos);
-    params[MenuParamKey::kFocusFileInfo] = QVariant::fromValue(focusFileInfo);
     params[MenuParamKey::kOnDesktop] = true;
     params[MenuParamKey::kWindowId] = view->winId();
     params[MenuParamKey::kIsEmptyArea] = false;

--- a/src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp
@@ -478,7 +478,7 @@ bool ExtendCanvasScene::actionFilter(AbstractMenuScene *caller, QAction *action)
                 if (1 == d->selectFiles.count()) {
                     auto index = d->view->model()->index(d->focusFile);
                     if (Q_UNLIKELY(!index.isValid()))
-                        qWarning() << "can not rename: invaild file" << d->focusFileInfo;
+                        qWarning() << "can not rename: invaild file" << d->focusFile;
                     else
                         d->view->edit(index, QAbstractItemView::AllEditTriggers, nullptr);
                 } else {

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
@@ -89,20 +89,13 @@ void CollectionViewMenu::emptyAreaMenu()
 void CollectionViewMenu::normalMenu(const QModelIndex &index, const Qt::ItemFlags &indexFlags, const QPoint gridPos)
 {
     QList<QUrl> selectUrls;
-    QList<FileInfoPointer> selectInfos;
     for (const QModelIndex &idx : view->selectedIndexes()) {
         auto url = view->model()->fileUrl(idx);
         if (url.isValid())
             selectUrls << url;
-        auto info = view->model()->fileInfo(idx);
-        if (info)
-            selectInfos.append(info);
     }
 
     auto tgUrl = view->model()->fileUrl(index);
-    auto focusInfo = view->model()->fileInfo(index);
-    if (!focusInfo)
-        return;
 
     // first is focus
     if (selectUrls.size() > 1) {
@@ -113,8 +106,6 @@ void CollectionViewMenu::normalMenu(const QModelIndex &index, const Qt::ItemFlag
     QVariantHash params;
     params[MenuParamKey::kCurrentDir] = view->model()->fileUrl(view->model()->rootIndex());
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(selectUrls);
-    params[MenuParamKey::kFocusFileInfo] = QVariant::fromValue(focusInfo);
-    params[MenuParamKey::kSelectFileInfos] = QVariant::fromValue(selectInfos);
     params[MenuParamKey::kOnDesktop] = true;
     params[MenuParamKey::kWindowId] = view->winId();
     params[MenuParamKey::kIsEmptyArea] = false;

--- a/src/plugins/filemanager/core/dfmplugin-recent/menus/recentmenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/menus/recentmenuscene.cpp
@@ -57,24 +57,26 @@ bool RecentMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->indexFlags = params.value(MenuParamKey::kIndexFlags).value<Qt::ItemFlags>();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
 
     if (!d->initializeParamsIsValid()) {
-        qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFileInfo << d->currentDir;
+        qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFile << d->currentDir;
         return false;
     }
 
     QList<AbstractMenuScene *> currentScene;
     if (!d->isEmptyArea) {
         QString errString;
+        d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+        if (d->focusFileInfo.isNull()) {
+            qDebug() << "create focus fileinfo error, case: " << errString << ". focus file url : " << d->focusFile;
+            return false;
+        }
         if (auto workspaceScene = dfmplugin_menu_util::menuSceneCreateScene(kWorkspaceMenuSceneName))
             currentScene.append(workspaceScene);
     } else {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/menus/workspacemenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/menus/workspacemenuscene.cpp
@@ -66,11 +66,8 @@ bool WorkspaceMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->indexFlags = params.value(MenuParamKey::kIndexFlags).value<Qt::ItemFlags>();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -363,9 +363,7 @@ QMimeData *FileViewModel::mimeData(const QModelIndexList &indexes) const
 
     for (; it != indexes.end(); ++it) {
         if ((*it).column() == 0) {
-            const FileInfoPointer &fileInfo = this->fileInfo(*it);
-            const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
-
+            const QUrl &url = it->data(Global::ItemRoles::kItemUrlRole).value<QUrl>();
             if (urlsSet.contains(url))
                 continue;
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -83,16 +83,15 @@ public Q_SLOTS:
     void doWatcherEvent();
     void doThreadWatcherEvent();
 
-    void handleTraversalResult(const FileInfoPointer &child);
-    void handleTraversalResults(QList<FileInfoPointer> children);
+    void handleTraversalResults(QList<FileInfoPointer> children, const QString &travseToken);
     void handleTraversalLocalResult(QList<SortInfoPointer> children,
                                     dfmio::DEnumerator::SortRoleCompareFlag sortRole,
                                     Qt::SortOrder sortOrder,
-                                    bool isMixDirAndFile);
-    void handleTraversalFinish();
+                                    bool isMixDirAndFile, const QString &travseToken);
+    void handleTraversalFinish(const QString &travseToken);
 
-    void handleTraversalSort();
-    void handleGetSourceData(const QString &key);
+    void handleTraversalSort(const QString &travseToken);
+    void handleGetSourceData(const QString &travseToken);
 
 private:
     void initConnection(const TraversalThreadManagerPointer &traversalThread);
@@ -111,6 +110,7 @@ private:
     void enqueueEvent(const QPair<QUrl, EventType> &e);
     QPair<QUrl, EventType> dequeueEvent();
     FileInfoPointer fileInfo(const QUrl &url);
+    QString currentKey(const QString &travseToken);
 
 public:
     AbstractFileWatcherPointer watcher;
@@ -120,7 +120,6 @@ private:
     QUrl hiddenFileUrl;
 
     QMap<QString, QSharedPointer<DirIteratorThread>> traversalThreads;
-    QString currentKey;
     std::atomic_bool traversalFinish { false };
 
     QReadWriteLock childrenLock;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
@@ -83,8 +83,7 @@ void FileViewMenuHelper::showEmptyAreaMenu()
     delete scene;
 }
 
-void FileViewMenuHelper::showNormalMenu(const QModelIndex &index, const Qt::ItemFlags &indexFlags, const QList<QUrl> &selectUrls,
-                                        const QList<FileInfoPointer> &selectInfos)
+void FileViewMenuHelper::showNormalMenu(const QModelIndex &index, const Qt::ItemFlags &indexFlags, const QList<QUrl> &selectUrls)
 {
     setWaitCursor();
     auto scene = dfmplugin_menu_util::menuSceneCreateScene(currentMenuScene());
@@ -107,9 +106,6 @@ void FileViewMenuHelper::showNormalMenu(const QModelIndex &index, const Qt::Item
         focusFileInfo = view->model()->fileInfo(index);
     }
 
-    if (!focusFileInfo)
-        return;
-
     if (focusFileInfo) {
         tgUrl = focusFileInfo->urlOf(UrlInfoType::kUrl);
         // first is focus
@@ -119,9 +115,7 @@ void FileViewMenuHelper::showNormalMenu(const QModelIndex &index, const Qt::Item
 
 
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(tmpSelectUrls);
-    params[MenuParamKey::kFocusFileInfo] = QVariant::fromValue(focusFileInfo);
     params[MenuParamKey::kIndexFlags] = QVariant::fromValue(indexFlags);
-    params[MenuParamKey::kSelectFileInfos] = QVariant::fromValue(selectInfos);
     params[MenuParamKey::kOnDesktop] = false;
     params[MenuParamKey::kIsEmptyArea] = false;
     params[MenuParamKey::kWindowId] = FMWindowsIns.findWindowId(view);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewmenuhelper.h
@@ -22,8 +22,7 @@ public:
     explicit FileViewMenuHelper(FileView *view = nullptr);
     static bool disableMenu();
     void showEmptyAreaMenu();
-    void showNormalMenu(const QModelIndex &index, const Qt::ItemFlags &indexFlags, const QList<QUrl> &selectUrls,
-                        const QList<FileInfoPointer> &selectInfos);
+    void showNormalMenu(const QModelIndex &index, const Qt::ItemFlags &indexFlags, const QList<QUrl> &selectUrls);
 
     void setMenuScene(const QString &scene);
     void setWaitCursor();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -31,6 +31,7 @@ class TraversalDirThreadManager : public TraversalDirThread
     int timeCeiling = 1500;
     int countCeiling = 500;
     dfmio::DEnumeratorFuture *future { nullptr };
+    QString traversalToken;
 
 public:
     explicit TraversalDirThreadManager(const QUrl &url, const QStringList &nameFilters = QStringList(),
@@ -45,14 +46,15 @@ public Q_SLOTS:
     void onAsyncIteratorOver();
 
 Q_SIGNALS:
-    void updateChildrenManager(QList<FileInfoPointer> children);
+    void updateChildrenManager(QList<FileInfoPointer> children, QString traversalToken);
     // Special processing If it is a local file, directly read all the simple sorting lists of the file
     void updateLocalChildren(QList<SortInfoPointer> children,
                              dfmio::DEnumerator::SortRoleCompareFlag sortRole,
                              Qt::SortOrder sortOrder,
-                             bool isMixDirAndFile);
-    void traversalFinished();
-    void traversalRequestSort();
+                             bool isMixDirAndFile,
+                             QString traversalToken);
+    void traversalFinished(QString traversalToken);
+    void traversalRequestSort(QString traversalToken);
 
 protected:
     virtual void run() override;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -1209,16 +1209,12 @@ void FileView::contextMenuEvent(QContextMenuEvent *event)
 
         QModelIndex rootIndex = this->rootIndex();
         QList<QUrl> selectUrls;
-        QList<FileInfoPointer> selectInfos;
         for (const QModelIndex &tmpIndex : selectedIndexes()) {
             if (tmpIndex.parent() != rootIndex)
                 continue;
             selectUrls << model()->data(tmpIndex, ItemRoles::kItemUrlRole).toUrl();
-            auto info = model()->fileInfo(tmpIndex);
-            if (info)
-                selectInfos << info;
         }
-        d->viewMenuHelper->showNormalMenu(index, model()->flags(index), selectUrls, selectInfos);
+        d->viewMenuHelper->showNormalMenu(index, model()->flags(index), selectUrls);
     }
     d->viewMenuHelper->reloadCursor();
 }

--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp
@@ -46,12 +46,12 @@ bool AvfsMenuScene::initialize(const QVariantHash &params)
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
 
     d->showOpenWith = d->selectFiles.count() == 1;
     if (d->showOpenWith) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
+        if (!d->selectFiles.isEmpty())
+            d->focusFileInfo = InfoFactory::create<FileInfo>(d->selectFiles.first());
+        d->focusFile = d->selectFiles.first();
         d->showOpenWith = d->focusFileInfo && !d->focusFileInfo->isAttributes(OptInfoType::kIsDir)
                 && !AvfsUtils::isSupportedArchives(AvfsUtils::avfsUrlToLocal(d->focusFile));
     }

--- a/src/plugins/filemanager/dfmplugin-optical/menus/opticalmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/menus/opticalmenuscene.cpp
@@ -44,10 +44,9 @@ bool OpticalMenuScene::initialize(const QVariantHash &params)
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
+    if (!d->selectFiles.isEmpty()) {
+        d->focusFile = d->selectFiles.first();
+        d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile);
     }
     QString backer { MasteredMediaFileInfo(d->currentDir).extraProperties()["mm_backer"].toString() };
     if (backer.isEmpty())

--- a/src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene.cpp
@@ -228,11 +228,8 @@ bool SearchMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
 

--- a/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
@@ -116,18 +116,15 @@ bool VaultMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
-    d->selectFileInfos = params.value(MenuParamKey::kSelectFileInfos).value<QList<FileInfoPointer>>();
-    if (d->selectFiles.count() > 0) {
-        d->focusFileInfo = params.value(MenuParamKey::kFocusFileInfo).value<FileInfoPointer>();
-        d->focusFile = d->focusFileInfo->urlOf(UrlInfoType::kUrl);
-    }
+    if (!d->selectFiles.isEmpty())
+        d->focusFile = d->selectFiles.first();
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->indexFlags = params.value(MenuParamKey::kIndexFlags).value<Qt::ItemFlags>();
     d->windowId = params.value(MenuParamKey::kWindowId).toULongLong();
 
     if (!d->initializeParamsIsValid()) {
-        qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFileInfo << d->currentDir;
+        qWarning() << "menu scene:" << name() << " init failed." << d->selectFiles.isEmpty() << d->focusFile << d->currentDir;
         return false;
     }
 

--- a/tests/plugins/common/core/dfmplugin-menu/menuscene/ut_sendtomenuscene.cpp
+++ b/tests/plugins/common/core/dfmplugin-menu/menuscene/ut_sendtomenuscene.cpp
@@ -47,7 +47,6 @@ TEST_F(UT_SendToMenuScene, bug_203001_initialize)
     EXPECT_TRUE(scene.initialize(params));
 
     auto focusInfo = InfoFactory::create<FileInfo>(url);
-    params[MenuParamKey::kFocusFileInfo] = QVariant::fromValue(focusInfo);
     params[MenuParamKey::kIsEmptyArea] = false;
     EXPECT_FALSE(scene.initialize(params));
 

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -123,7 +123,6 @@ TEST_F(UT_RootInfo, StartWork)
     if (!rootInfoObj->watcher.isNull()) {
         EXPECT_TRUE(calledStartWatcher);
     }
-    EXPECT_EQ(rootInfoObj->currentKey, key);
     EXPECT_TRUE(calledThreadStart);
     EXPECT_FALSE(calledGetSourceData);
 
@@ -138,7 +137,6 @@ TEST_F(UT_RootInfo, StartWork)
     calledGetSourceData = false;
     calledThreadStart = false;
     rootInfoObj->startWork(key, true);
-    EXPECT_NE(rootInfoObj->currentKey, unexistKey);
     EXPECT_FALSE(calledThreadStart);
     // EXPECT_FALSE(calledGetSourceData);
 }
@@ -369,8 +367,6 @@ TEST_F(UT_RootInfo, HandleTraversalResult)
     QObject::connect(rootInfoObj, &RootInfo::iteratorAddFile, rootInfoObj,
                      [&sendIteratorAddFile] { sendIteratorAddFile = true; });
 
-    rootInfoObj->handleTraversalResult(info);
-
     EXPECT_TRUE(calledAddChild);
     EXPECT_TRUE(sendIteratorAddFile);
 }
@@ -394,7 +390,7 @@ TEST_F(UT_RootInfo, HandleTraversalResults)
     QObject::connect(rootInfoObj, &RootInfo::iteratorAddFiles, rootInfoObj,
                      [&sendIteratorAddFiles] { sendIteratorAddFiles = true; });
 
-    rootInfoObj->handleTraversalResults({ info });
+    rootInfoObj->handleTraversalResults({ info }, "");
 
     EXPECT_TRUE(calledAddChild);
     EXPECT_TRUE(sendIteratorAddFiles);
@@ -419,7 +415,7 @@ TEST_F(UT_RootInfo, HandleTraversalLocalResult)
                      [&sendIteratorLocalFiles] { sendIteratorLocalFiles = true; });
 
     SortInfoPointer info(new AbstractDirIterator::SortFileInfo);
-    rootInfoObj->handleTraversalLocalResult({ info }, sortRole, sortOrder, mixDirAndFile);
+    rootInfoObj->handleTraversalLocalResult({ info }, sortRole, sortOrder, mixDirAndFile, "");
 
     EXPECT_FALSE(addedChildren.isEmpty());
     EXPECT_EQ(rootInfoObj->originSortRole, sortRole);
@@ -430,30 +426,26 @@ TEST_F(UT_RootInfo, HandleTraversalLocalResult)
 
 TEST_F(UT_RootInfo, HandleTraversalFinish)
 {
-    rootInfoObj->currentKey = "current key";
     rootInfoObj->traversalFinish = false;
 
     QString currentKey("");
     QObject::connect(rootInfoObj, &RootInfo::traversalFinished, rootInfoObj,
                      [&currentKey](const QString &key) { currentKey.append(key); });
 
-    rootInfoObj->handleTraversalFinish();
+    rootInfoObj->handleTraversalFinish("");
 
-    EXPECT_EQ(currentKey, rootInfoObj->currentKey);
     EXPECT_TRUE(rootInfoObj->traversalFinish);
 }
 
 TEST_F(UT_RootInfo, HandleTraversalSort)
 {
-    rootInfoObj->currentKey = "current key";
-
     QString currentKey("");
     QObject::connect(rootInfoObj, &RootInfo::requestSort, rootInfoObj,
                      [&currentKey](const QString &key) { currentKey.append(key); });
 
-    rootInfoObj->handleTraversalSort();
+    rootInfoObj->handleTraversalSort("");
 
-    EXPECT_EQ(currentKey, rootInfoObj->currentKey);
+    EXPECT_EQ(currentKey, "");
 }
 
 TEST_F(UT_RootInfo, HandleGetSourceData)


### PR DESCRIPTION
1. Open the local file information cache. 2. Remove the focusfileinfo parameter passed out from the menu. 3. Remove the selectfileinfos parameter QList<FileInfoPointer>

Log: Remove parameters passed out using fileinfo from the right-click menu bar