### PR TITLE
fix: [wallpapersettings] Slow loading of wallpaper settings

### DIFF
--- a/src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.h
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.h
@@ -29,7 +29,7 @@ public:
     static QVector<int> availableScreenSaverTime();
     static QStringList availableWallpaperSlide();
     void adjustGeometry();
-    void refreshList();
+    Q_INVOKABLE void refreshList();
     QPair<QString, QString> currentWallpaper() const;
 
 public:

--- a/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.cpp
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.cpp
@@ -9,7 +9,6 @@
 #include "desktoputils/ddpugin_eventinterface_helper.h"
 
 #include <dfm-base/utils/universalutils.h>
-
 #include <QDBusConnection>
 
 using namespace ddplugin_wallpapersetting;
@@ -139,12 +138,13 @@ void EventHandle::show(QString name, int mode)
 
     wallpaperSettings->show();
     wallpaperSettings->activateWindow();
-    wallpaperSettings->refreshList();
 
     // auto focus tool
     auto autoAct = new AutoActivateWindow(wallpaperSettings);
     autoAct->setWatched(wallpaperSettings);
     autoAct->start();
+
+    QMetaObject::invokeMethod(wallpaperSettings,"refreshList",Qt::QueuedConnection);
 }
 
 bool EventHandle::hookCanvasRequest(const QString &screen)


### PR DESCRIPTION
After displaying the window, proceed to retrieve the wallpaper

Log: as title

Bug: https://github.com/linuxdeepin/developer-center/issues/4338