### PR TITLE
fix: [workaround] lost file type in audit log

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/auditlogjob.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/auditlogjob.cpp
@@ -85,7 +85,7 @@ void CopyFromDiscAuditLog::writeLog(QDBusInterface &interface, const QString &sr
     static const QString &kUserName { SysInfoUtils::getUser() };
     static const QString &kHostName { SysInfoUtils::getHostName() };
 
-    auto fmInfo { InfoFactory::create<FileInfo>(QUrl::fromLocalFile(srcPath)) };
+    auto fmInfo { InfoFactory::create<FileInfo>(QUrl::fromLocalFile(srcPath), Global::CreateFileInfoType::kCreateFileInfoSync) };
     const QString &fileType { fmInfo ? fmInfo->displayOf(DisPlayInfoType::kMimeTypeDisplayName) : "" };
     const QString &curLog { kLogTemplate.arg(dateTime).arg(kHostName).arg(kUserName).arg(kCount).arg(srcPath).arg(destPath).arg(fileType).arg(FileUtils::formatSize(fmInfo->size())) };
     interface.call("WriteLog", kLogKey, curLog);
@@ -138,7 +138,7 @@ void BurnFilesAuditLogJob::writeLog(QDBusInterface &interface, const QString &di
     static qint64 baseID { QDateTime::currentSecsSinceEpoch() };
 
     qint64 id { baseID + (index++) };
-    auto fmInfo { InfoFactory::create<FileInfo>(QUrl::fromLocalFile(discPath)) };
+    auto fmInfo { InfoFactory::create<FileInfo>(QUrl::fromLocalFile(discPath), Global::CreateFileInfoType::kCreateFileInfoSync) };
     const QString &fileType { fmInfo ? fmInfo->displayOf(DisPlayInfoType::kMimeTypeDisplayName) : "" };
     QString curLog { kLogTemplate.arg(id).arg(dateTime).arg(burner).arg(discType).arg(result).arg(kUserName).arg(nativePath).arg(FileUtils::formatSize(size)).arg(fileType) };
     interface.call("WriteLog", kLogKey, curLog);


### PR DESCRIPTION
asyncfileinfo cannot acquire property, use syncfileinfo

Log: fix audit log

Bug: https://pms.uniontech.com/bug-view-204291.html