### PR TITLE
fix: [selectdialog] repeatly show select box, the app crash

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
@@ -266,11 +266,6 @@ qulonglong FileDialogHandle::winId() const
 {
     D_DC(FileDialogHandle);
 
-    // browser use gtk start filedialog
-    // gtk call the `winId` must be showed in the window after
-    if (qApp->property("GTK").toBool())
-        waitForWindowShow();
-
     if (d->dialog)
         return d->dialog->internalWinId();
     return 0;
@@ -487,12 +482,12 @@ void FileDialogHandle::show()
     if (d->dialog) {
         if (!isSetAcceptMode && d->dialog->statusBar())
             d->dialog->statusBar()->setMode(FileDialogStatusBar::Mode::kOpen);
-            d->dialog->updateAsDefaultSize();
-            d->dialog->moveCenter();
-            setWindowStayOnTop();
-            qDebug() << QString("Select Dialog Info: befor show size is (%1, %2)").arg(d->dialog->width()).arg(d->dialog->height());
-            FMWindowsIns.showWindow(d->dialog);
-            qDebug() << QString("Select Dialog Info: after show size is (%1, %2)").arg(d->dialog->width()).arg(d->dialog->height());
+        d->dialog->updateAsDefaultSize();
+        d->dialog->moveCenter();
+        setWindowStayOnTop();
+        qDebug() << QString("Select Dialog Info: befor show size is (%1, %2)").arg(d->dialog->width()).arg(d->dialog->height());
+        FMWindowsIns.showWindow(d->dialog);
+        qDebug() << QString("Select Dialog Info: after show size is (%1, %2)").arg(d->dialog->width()).arg(d->dialog->height());
     }
 }
 
@@ -544,14 +539,6 @@ void FileDialogHandle::reject()
 
     if (d->dialog)
         d->dialog->reject();
-}
-
-void FileDialogHandle::waitForWindowShow() const
-{
-    QEventLoop loop;
-    connect(d_func()->dialog, &FileDialog::windowShowed, &loop, &QEventLoop::quit);
-    QTimer::singleShot(500, &loop, &QEventLoop::quit);
-    loop.exec();
 }
 
 void FileDialogHandle::setWindowStayOnTop()

--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.h
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.h
@@ -85,7 +85,6 @@ public Q_SLOTS:
     void reject();
 
 private:
-    void waitForWindowShow() const;
     void setWindowStayOnTop();
 
 Q_SIGNALS:

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -1017,10 +1017,6 @@ bool FileDialog::eventFilter(QObject *watched, QEvent *event)
         }
     }
 
-    if (watched == windowHandle() && event->type() == QEvent::Show) {
-        emit windowShowed();
-    }
-
     return FileManagerWindow::eventFilter(watched, event);
 }
 

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
@@ -96,7 +96,6 @@ Q_SIGNALS:
     void selectionFilesChanged();
     void selectedNameFilterChanged();
     void initialized();
-    void windowShowed();
 
 public Q_SLOTS:
     void accept();


### PR DESCRIPTION
problem:
When using vscode or Google browser repeatedly show selection box, the app crash! solved:
the window will show out immediately, so not use qeventloop to wainting for the window display.

Log: fix select dialog problem