### PR TITLE
fix: [io]Failure to pop up in a timely manner indicates that files exceeding 4G cannot be copied

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -48,6 +48,8 @@ public:
                         bool *skip, bool isCountSize = false);
     bool checkDiskSpaceAvailable(const QUrl &fromUrl, const QUrl &toUrl,
                                  QSharedPointer<StorageInfo> targetStorageInfo, bool *skip);
+    bool checkFileSize(qint64 size, const QUrl &fromUrl,
+                       const QUrl &toUrl, QSharedPointer<StorageInfo> targetStorageInfo, bool *skip);
     void setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo);
     void setAllDirPermisson();
     void determineCountProcessType();


### PR DESCRIPTION
There is a check in front of the copy logic of v5 that the vfat format has been manipulated for 4g and has not been moved to v6. Check for adding vfat file operation 4g.

Log: Failure to pop up in a timely manner indicates that files exceeding 4G cannot be copied
Bug: https://pms.uniontech.com/bug-view-204799.html