### PR TITLE
fix: [launch] Open a new window but activate the old one

### DIFF
--- a/include/dfm-base/widgets/filemanagerwindowsmanager.h
+++ b/include/dfm-base/widgets/filemanagerwindowsmanager.h
@@ -28,7 +28,7 @@ public:
     static FileManagerWindowsManager &instance();
 
     void setCustomWindowCreator(WindowCreator creator);
-    FMWindow *createWindow(const QUrl &url, bool isNewWindow = false, QString *errorString = nullptr);
+    FMWindow *createWindow(const QUrl &url, bool isNewWindow = true, QString *errorString = nullptr);
     void showWindow(FMWindow *window);
     quint64 findWindowId(const QWidget *window);
     FMWindow *findWindowById(quint64 winId);

--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -289,7 +289,7 @@ void CommandParser::openInUrls()
         argumentUrls.append(url);
     }
     if (argumentUrls.isEmpty())
-        dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, QUrl(), false);
+        dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, QUrl(), true);
     for (const QUrl &url : argumentUrls)
         openWindowWithUrl(url);
 }

--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
@@ -9,6 +9,7 @@
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/finallyutil.h>
+#include <dfm-base/utils/universalutils.h>
 #include <dfm-base/shortcut/shortcut.h>
 
 #include <QDebug>
@@ -49,7 +50,7 @@ FileManagerWindow *FileManagerWindowsManagerPrivate::activeExistsWindowByUrl(con
     for (int i = 0; i != count; ++i) {
         quint64 key = windows.keys().at(i);
         auto window = windows.value(key);
-        if (window && window->currentUrl() == url) {
+        if (window && UniversalUtils::urlEquals(window->currentUrl(), url)) {
             qInfo() << "Find url: " << url << " window: " << window;
             if (window->isMinimized())
                 window->setWindowState(window->windowState() & ~Qt::WindowMinimized);
@@ -97,7 +98,7 @@ void FileManagerWindowsManagerPrivate::loadWindowState(FileManagerWindow *window
         // make window to be maximized.
         // the following calling is copyed from QWidget::showMaximized()
         window->setWindowState((window->windowState() & ~(Qt::WindowMinimized | Qt::WindowFullScreen))
-                       | Qt::WindowMaximized);
+                               | Qt::WindowMaximized);
     } else {
         window->resize(width, height);
     }
@@ -199,10 +200,9 @@ FileManagerWindowsManager::FMWindow *FileManagerWindowsManager::createWindow(con
     // Directly active window if the window exists
     if (!isNewWindow) {
         auto window = d->activeExistsWindowByUrl(showedUrl);
-        if (window)
-            return window;
-        else
+        if (!window)
             qWarning() << "Cannot find a exists window by url: " << showedUrl;
+        return window;
     }
 
     QX11Info::setAppTime(QX11Info::appUserTime());

--- a/src/plugins/filemanager/core/dfmplugin-core/events/coreeventreceiver.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-core/events/coreeventreceiver.cpp
@@ -44,14 +44,14 @@ void CoreEventReceiver::handleOpenWindow(const QUrl &url)
 {
     Q_ASSERT(qApp->applicationName() == "dde-file-manager");
 
-    CoreHelper::instance().openNewWindow(url);
+    CoreHelper::instance().openWindow(url);
 }
 
 void CoreEventReceiver::handleOpenWindow(const QUrl &url, const QVariant &opt)
 {
     Q_ASSERT(qApp->applicationName() == "dde-file-manager");
 
-    CoreHelper::instance().openNewWindow(url, opt);
+    CoreHelper::instance().openWindow(url, opt);
 }
 
 void CoreEventReceiver::handleLoadPlugins(const QStringList &names)

--- a/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.h
@@ -7,6 +7,8 @@
 
 #include "dfmplugin_core_global.h"
 
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
 #include <QObject>
 #include <QVariant>
 
@@ -22,8 +24,13 @@ public:
 
 public:
     void cd(quint64 windowId, const QUrl &url);
-    void openNewWindow(const QUrl &url, const QVariant &opt = QVariant());
+    void openWindow(const QUrl &url, const QVariant &opt = QVariant());
     void cacheDefaultWindow();
+
+private:
+    DFMBASE_NAMESPACE::FileManagerWindow *defaultWindow();
+    DFMBASE_NAMESPACE::FileManagerWindow *createNewWindow(const QUrl &url);
+    DFMBASE_NAMESPACE::FileManagerWindow *findExistsWindow(const QUrl &url);
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event) override;


### PR DESCRIPTION
1. if a window is opened that is cached, then just activate it
2. If the opened window does not match the url of the cached window, close the cached window and create a new one

Log: fix filemanager launch bug

Bug: https://pms.uniontech.com/bug-view-204795.html
Bug: https://pms.uniontech.com/bug-view-204569.html
Bug: https://pms.uniontech.com/bug-view-204571.html