### PR TITLE
fix: [filesortwork]File Manager Crash

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -330,6 +330,12 @@ void FileSortWorker::setNameFilters(const QStringList &filters)
     nameFilters = filters;
     QMap<QUrl, FileItemData *>::iterator itr = childrenDataMap.begin();
     for (; itr != childrenDataMap.end(); ++itr) {
+        auto index = childrenUrlList.indexOf(itr.key());
+        if (index < 0)
+            continue;
+        auto sortInfo = children.at(index);
+        if (sortInfo && sortInfo->isDir)
+            continue;
         checkNameFilters(itr.value());
     }
     Q_EMIT requestUpdateView();
@@ -650,7 +656,7 @@ void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const QString &infoP
 
 void FileSortWorker::checkNameFilters(FileItemData *itemData)
 {
-    if (!itemData || (itemData->fileInfo() && itemData->fileInfo()->isAttributes(OptInfoType::kIsDir))
+    if (!itemData
             || nameFilters.isEmpty())
         return;
 


### PR DESCRIPTION
The asynchronous thread checknamefilters called the fileinfo interface of fileitemdata, causing both the main thread and asynchronous thread to execute the construction of fileinfo simultaneously, resulting in one of the fileinfo being destructed. Modify the use of other methods to determine whether the file is a directory when using the checknamefilters function on asynchronous threads.

Log: File Manager Crash