### PR TITLE
fix: [canvas-fileoperator] The dropped files are not all selected

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
@@ -90,21 +90,11 @@ void FileOperatorProxyPrivate::callBackRenameFiles(const QList<QUrl> &sources, c
     }
 }
 
-void FileOperatorProxyPrivate::delaySelectUrls(const QList<QUrl> &urls, int ms)
+void FileOperatorProxyPrivate::delaySelectUrls(const QList<QUrl> &urls)
 {
-    if (nullptr != selectTimer.get())
-        selectTimer->stop();
-
-    if (ms < 1) {
+    QTimer::singleShot(qMax(urls.count() * (10 + urls.count() / 150), 200), this, [=] {
         doSelectUrls(urls);
-    } else {
-        selectTimer.reset(new QTimer);
-        selectTimer->setSingleShot(true);
-        connect(selectTimer.get(), &QTimer::timeout, this, [&, urls]() {
-            this->doSelectUrls(urls);
-        });
-        selectTimer->start(ms);
-    }
+    });
 }
 
 void FileOperatorProxyPrivate::doSelectUrls(const QList<QUrl> &urls)

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy_p.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy_p.h
@@ -35,14 +35,13 @@ public:
     void callBackPasteFiles(const JobInfoPointer info);
     void callBackRenameFiles(const QList<QUrl> &sources, const QList<QUrl> &targets);
 
-    void delaySelectUrls(const QList<QUrl> &urls, int ms = 10);
+    void delaySelectUrls(const QList<QUrl> &urls);
     void doSelectUrls(const QList<QUrl> &urls);
 
     void filterDesktopFile(QList<QUrl> &urls);
 
 public:
     FileOperatorProxy *const q = nullptr;
-    QSharedPointer<QTimer> selectTimer;
     DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callBack;
 
     QPair<QString, QPair<int, QPoint>> touchFileData;


### PR DESCRIPTION
After dragging and dropping files, some files were not selected

Log: Did the same processing as the workspace

Bug: https://pms.uniontech.com/bug-view-204379.html