### PR TITLE
pref: [workspace] Interactive experience optimization

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -76,7 +76,14 @@ enum ItemRoles {
     kItemFileOriginalPath = Qt::UserRole + 23,
     kItemFileDeletionDate = Qt::UserRole + 24,
     kItemFileRefreshIcon = Qt::UserRole + 25,
-    kItemFileIsAvailable = Qt::UserRole + 26,   // the item gray display and can not select
+    kItemCreateFileInfoRole = Qt::UserRole + 26,
+    kItemFileIsDirRole = Qt::UserRole + 27,
+    kItemFileIsWritableRole = Qt::UserRole + 28,
+    kItemFileCanRenameRole = Qt::UserRole + 29,
+    kItemFileCanDropRole = Qt::UserRole + 30,
+    kItemFileCanDragRole = Qt::UserRole + 31,
+    kItemFileSizeIntRole = Qt::UserRole + 32,
+    kItemFileIsAvailableRole = Qt::UserRole + 33,   // the item gray display and can not select
 
     kItemUnknowRole = Qt::UserRole + 999
 };

--- a/include/dfm-base/interfaces/abstractdiriterator.h
+++ b/include/dfm-base/interfaces/abstractdiriterator.h
@@ -24,6 +24,7 @@ public:
     struct SortFileInfo
     {
         QUrl url;
+        qint64 filesize { 0 };
         bool isFile { false };
         bool isDir { false };
         bool isSymLink { false };
@@ -31,19 +32,6 @@ public:
         bool isReadable { false };
         bool isWriteable { false };
         bool isExecutable { false };
-        SortFileInfo(const QUrl &url, const bool isFile, const bool isDir, const bool isSymLink, const bool isHide,
-                     const bool isReadable, const bool isWriteable, const bool isExecutable)
-            : url(url),
-              isFile(isFile),
-              isDir(isDir),
-              isSymLink(isSymLink),
-              isHide(isHide),
-              isReadable(isReadable),
-              isWriteable(isWriteable),
-              isExecutable(isExecutable)
-        {
-        }
-        SortFileInfo() {}
     };
 
 public:

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -203,15 +203,17 @@ QList<SortInfoPointer> LocalDirIterator::sortFileInfoList()
     auto sortlist = d->dfmioDirIterator->sortFileInfoList();
     QList<SortInfoPointer> wsortlist;
     for (const auto &sortInfo : sortlist) {
-        wsortlist.append(SortInfoPointer(
-                new AbstractDirIterator::SortFileInfo(sortInfo->url,
-                                                      sortInfo->isFile,
-                                                      sortInfo->isDir,
-                                                      sortInfo->isSymLink,
-                                                      sortInfo->isHide,
-                                                      sortInfo->isReadable,
-                                                      sortInfo->isWriteable,
-                                                      sortInfo->isExecutable)));
+        SortInfoPointer tmp(new AbstractDirIterator::SortFileInfo);
+        tmp->url = sortInfo->url;
+        tmp->filesize = sortInfo->filesize;
+        tmp->isFile = sortInfo->isFile;
+        tmp->isDir = sortInfo->isDir;
+        tmp->isHide = sortInfo->isHide;
+        tmp->isSymLink = sortInfo->isSymLink;
+        tmp->isReadable = sortInfo->isReadable;
+        tmp->isWriteable = sortInfo->isWriteable;
+        tmp->isExecutable = sortInfo->isExecutable;
+        wsortlist.append(wsortlist);
     }
     return wsortlist;
 }

--- a/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.cpp
+++ b/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.cpp
@@ -40,41 +40,30 @@ void BasicStatusBar::clearLayoutAndAnchors()
     DAnchorsBase::clearAnchors(this);
 }
 
-void BasicStatusBar::itemSelected(const QList<FileInfo *> &infoList)
+void BasicStatusBar::itemSelected(const int selectFiles, const int selectFolders, const qint64 filesize, const QList<QUrl> &selectFolderList)
 {
     if (!d->tip)
         return;
 
-    d->fileCount = 0;
-    d->fileSize = 0;
-    d->folderCount = 0;
+    d->fileCount = selectFiles;
+    d->fileSize = filesize;
+    d->folderCount = selectFolders;
     d->folderContains = 0;
-
-    QList<QUrl> dirUrlList;
-    for (const FileInfo *info : infoList) {
-        if (info->isAttributes(OptInfoType::kIsDir)) {
-            d->folderCount += 1;
-            dirUrlList << info->urlOf(UrlInfoType::kUrl);
-        } else {
-            d->fileCount += 1;
-            d->fileSize += info->size();
-        }
-    }
-
     d->showContains = true;
-    const bool dirUrlsEmpty = dirUrlList.isEmpty();
+
+    const bool dirUrlsEmpty = selectFolderList.isEmpty();
     if (!dirUrlsEmpty) {
         // check mtp setting
         const bool showInfo = Application::instance()->genericAttribute(Application::GenericAttribute::kMTPShowBottomInfo).toBool();
         if (!showInfo) {
-            bool isMtp = FileUtils::isMtpFile(dirUrlList.first());
+            bool isMtp = FileUtils::isMtpFile(selectFolderList.first());
             if (isMtp) {
                 d->showContains = false;
             } else {
-                d->calcFolderContains(dirUrlList);
+                d->calcFolderContains(selectFolderList);
             }
         } else {
-            d->calcFolderContains(dirUrlList);
+            d->calcFolderContains(selectFolderList);
         }
     }
 

--- a/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.h
+++ b/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.h
@@ -6,6 +6,7 @@
 #define BASICSTATUSBAR_H
 
 #include <dfm-base/dfm_base_global.h>
+#include <dfm-base/interfaces/fileinfo.h>
 
 #include <QFrame>
 
@@ -22,7 +23,7 @@ public:
     virtual QSize sizeHint() const override;
     virtual void clearLayoutAndAnchors();
 
-    void itemSelected(const QList<FileInfo *> &infoList);
+    void itemSelected(const int selectFiles, const int selectFolders, const qint64 filesize, const QList<QUrl> &selectFolderList);
     void itemCounted(const int count);
 
     void updateStatusMessage();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -256,7 +256,7 @@ QVariant FileViewModel::data(const QModelIndex &index, int role) const
         itemData = filterSortWorker->childData(index.row());
     }
 
-    if (itemData && itemData->fileInfo()) {
+    if (itemData) {
         return itemData->data(role);
     } else {
         return QVariant();
@@ -319,26 +319,23 @@ bool FileViewModel::canFetchMore(const QModelIndex &parent) const
 Qt::ItemFlags FileViewModel::flags(const QModelIndex &index) const
 {
     Qt::ItemFlags flags = QAbstractItemModel::flags(index);
-    const FileInfoPointer &info = fileInfo(index);
-    if (!info)
-        return flags;
 
-    if (!index.data(kItemFileIsAvailable).toBool()) {
+    if (!index.data(kItemFileIsAvailableRole).toBool()) {
         flags &= ~(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         return flags;
     }
 
-    if (info->canAttributes(CanableInfoType::kCanRename))
+    if (index.data(kItemFileCanRenameRole).toBool())
         flags |= Qt::ItemIsEditable;
 
-    if (info->isAttributes(OptInfoType::kIsWritable)) {
-        if (info->canAttributes(CanableInfoType::kCanDrop))
+    if (index.data(kItemFileIsWritableRole).toBool()) {
+        if (index.data(kItemFileCanDropRole).toBool())
             flags |= Qt::ItemIsDropEnabled;
         else
             flags |= Qt::ItemNeverHasChildren;
     }
 
-    if (info->canAttributes(CanableInfoType::kCanDrag))
+    if (index.data(kItemFileCanDragRole).toBool())
         flags |= Qt::ItemIsDragEnabled;
 
     if (readOnly)
@@ -360,7 +357,12 @@ QMimeData *FileViewModel::mimeData(const QModelIndexList &indexes) const
 
     for (; it != indexes.end(); ++it) {
         if ((*it).column() == 0) {
-            const FileInfoPointer &fileInfo = this->fileInfo(*it);
+            FileInfoPointer fileInfo = this->fileInfo(*it);
+            if (fileInfo.isNull())
+                (*it).data(Global::ItemRoles::kItemCreateFileInfoRole);
+            fileInfo = this->fileInfo(*it);
+            if (fileInfo.isNull())
+                continue;
             const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
 
             if (urlsSet.contains(url))
@@ -386,7 +388,11 @@ bool FileViewModel::dropMimeData(const QMimeData *data, Qt::DropAction action, i
     if (!dropIndex.isValid())
         return false;
 
-    const FileInfoPointer &targetFileInfo = fileInfo(dropIndex);
+    FileInfoPointer targetFileInfo = fileInfo(dropIndex);
+    if (targetFileInfo.isNull())
+        dropIndex.data(Global::ItemRoles::kItemCreateFileInfoRole);
+
+    targetFileInfo = fileInfo(dropIndex);
     if (!targetFileInfo || (targetFileInfo->isAttributes(OptInfoType::kIsDir) && !targetFileInfo->isAttributes(OptInfoType::kIsWritable))) {
         qInfo() << "current dir is not writable!!!!!!!!";
         return false;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -210,7 +210,11 @@ bool DragDropHelper::drop(QDropEvent *event)
         if (!hoverIndex.isValid()) {
             hoverIndex = view->rootIndex();
         } else {
-            const FileInfoPointer &fileInfo = view->model()->fileInfo(hoverIndex);
+            FileInfoPointer fileInfo = view->model()->fileInfo(hoverIndex);
+            if (fileInfo.isNull())
+                hoverIndex.data(Global::ItemRoles::kItemCreateFileInfoRole);
+            fileInfo = view->model()->fileInfo(hoverIndex);
+
             if (fileInfo) {
                 bool isDrop = dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_IsDrop", fileInfo->urlOf(UrlInfoType::kUrl));
                 // NOTE: if item can not drop, the drag item will drop to root dir.

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -330,12 +330,6 @@ void FileSortWorker::setNameFilters(const QStringList &filters)
     nameFilters = filters;
     QMap<QUrl, FileItemData *>::iterator itr = childrenDataMap.begin();
     for (; itr != childrenDataMap.end(); ++itr) {
-        auto index = childrenUrlList.indexOf(itr.key());
-        if (index < 0)
-            continue;
-        auto sortInfo = children.at(index);
-        if (sortInfo && sortInfo->isDir)
-            continue;
         checkNameFilters(itr.value());
     }
     Q_EMIT requestUpdateView();
@@ -656,8 +650,7 @@ void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const QString &infoP
 
 void FileSortWorker::checkNameFilters(FileItemData *itemData)
 {
-    if (!itemData
-            || nameFilters.isEmpty())
+    if (!itemData || itemData->data(Global::ItemRoles::kItemFileIsDirRole).toBool() || nameFilters.isEmpty())
         return;
 
     QRegExp re("", Qt::CaseInsensitive, QRegExp::Wildcard);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -90,6 +90,9 @@ void IconItemDelegate::paint(QPainter *painter,
 
     Q_D(const IconItemDelegate);
 
+    if (index.isValid())
+        index.data(Global::ItemRoles::kItemCreateFileInfoRole);
+
     if (index == d->expandedIndex && !parent()->isSelected(index))
         const_cast<IconItemDelegate *>(this)->hideNotEditingIndexWidget();
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -58,6 +58,10 @@ void ListItemDelegate::paint(QPainter *painter,
                              const QModelIndex &index) const
 {
     QStyleOptionViewItem opt = option;
+
+    if (index.isValid())
+        index.data(Global::ItemRoles::kItemCreateFileInfoRole);
+
     initStyleOption(&opt, index);
     painter->setFont(opt.font);
 

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/utils/ut_filesortworker.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/utils/ut_filesortworker.cpp
@@ -60,7 +60,13 @@ TEST_F(UT_FileSortWorker, Bug_199473_handleUpdateFile)
     });
 
     worker->childrenUrlList.append(updateFile);
-    SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo(updateFile, false, true, false, false, true, true, true));
+    SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo());
+    sortInfo->url = updateFile;
+    sortInfo->filesize = 0;
+    sortInfo->isDir = true;
+    sortInfo->isReadable = true;
+    sortInfo->isWriteable = true;
+    sortInfo->isExecutable = true;
     worker->children.append(sortInfo);
 
     worker->handleUpdateFile(updateFile);


### PR DESCRIPTION
Ctrl+a file operation。 1. Modify the flags in the fileviewmodel without using fileinfo. 2. Modify the data function in the fileitemdata class to read properties without fileinfo. 3. Modify the itemselect function in the basestatusbar to display multiple selected items without traversing fileinfo. 4. Remove the fileinfo judgment from the fileitemdata function in the fileviewmodel. 5. Remove the fileinfo judgment from the fileitemdata in the selectedIndexes function in the fileview.

Log: Ctrl+a file operation
Task: https://pms.uniontech.com/task-view-269223.html