### PR TITLE
feat: [workspace/clipboard] Interactive experience optimization

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -30,7 +30,6 @@ using namespace dfmbase;
 namespace GlobalData {
 static QList<QUrl> clipboardFileUrls;
 static QMutex clipboardFileUrlsMutex;
-static QList<quint64> clipbordFileinode;
 static QAtomicInt remoteCurrentCount = 0;
 static ClipBoard::ClipboardAction clipboardAction = ClipBoard::kUnknownAction;
 
@@ -46,7 +45,6 @@ void onClipboardDataChanged()
         clipboardFileUrls.clear();
     }
 
-    clipbordFileinode.clear();
     const QMimeData *mimeData = qApp->clipboard()->mimeData();
     if (!mimeData || mimeData->formats().isEmpty()) {
         qWarning() << "get null mimeData from QClipBoard or remote formats is null!";
@@ -73,37 +71,16 @@ void onClipboardDataChanged()
     } else {
         clipboardAction = ClipBoard::kUnknownAction;
     }
-    QString errorStr;
-    for (QUrl &url : mimeData->urls()) {
-        if (url.scheme().isEmpty())
-            url.setScheme(Global::Scheme::kFile);
 
-        {
-            QMutexLocker lk(&clipboardFileUrlsMutex);
-            clipboardFileUrls << url;
-        }
-        //链接文件的inode不加入clipbordFileinode，只用url判断clip，避免多个同源链接文件的逻辑误判
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto, &errorStr);
-
-        if (!info) {
-            qWarning() << QString("create file info error, case : %1").arg(errorStr);
-            continue;
-        }
-        if (info->isAttributes(OptInfoType::kIsSymLink))
-            continue;
-
-        struct stat statInfo;
-        int fileStat = stat(url.path().toStdString().c_str(), &statInfo);
-        if (0 == fileStat)
-            clipbordFileinode << statInfo.st_ino;
-    }
+    QMutexLocker lk(&clipboardFileUrlsMutex);
+    clipboardFileUrls << mimeData->urls();
 }
 }   // namespace GlobalData
 
 ClipBoard::ClipBoard(QObject *parent)
     : QObject(parent)
 {
-    connect(qApp->clipboard(), &QClipboard::dataChanged, this, &ClipBoard::onClipboardDataChanged);
+    connect(qApp->clipboard(), &QClipboard::dataChanged, this, &ClipBoard::onClipboardDataChanged, Qt::QueuedConnection);
     GlobalData::onClipboardDataChanged();
 }
 
@@ -267,14 +244,6 @@ QList<QUrl> ClipBoard::getRemoteUrls()
 QList<QUrl> ClipBoard::clipboardFileUrlList() const
 {
     return GlobalData::clipboardFileUrls;
-}
-/*!
- * \brief ClipBoard::clipboardFileInodeList Gets the inode of URLs in the clipboard
- * \return
- */
-QList<quint64> ClipBoard::clipboardFileInodeList() const
-{
-    return GlobalData::clipbordFileinode;
 }
 /*!
  * \brief ClipBoard::clipboardAction Gets the current operation of the clipboard

--- a/src/dfm-base/utils/clipboard.h
+++ b/src/dfm-base/utils/clipboard.h
@@ -37,7 +37,6 @@ public:
     static bool supportCut();
 
     QList<QUrl> clipboardFileUrlList() const;
-    QList<quint64> clipboardFileInodeList() const;
     ClipboardAction clipboardAction() const;
     void removeUrls(const QList<QUrl> &urls);
     void replaceClipboardUrl(const QUrl &oldUrl, const QUrl &newUrl);

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -402,13 +402,6 @@ bool CanvasItemDelegate::isTransparent(const QModelIndex &index) const
 
         if (ClipBoard::instance()->clipboardFileUrlList().contains(file->urlOf(UrlInfoType::kUrl)))
             return true;
-
-        // the linked file only judges the URL, not the inode,
-        // because the inode of the linked file is consistent with that of the source file
-        if (!file->isAttributes(OptInfoType::kIsSymLink)) {
-            if (ClipBoard::instance()->clipboardFileInodeList().contains(file->extendAttributes(ExtInfoType::kInode).toULongLong()))
-                return true;
-        }
     }
     return false;
 }

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -394,13 +394,6 @@ bool CollectionItemDelegate::isTransparent(const QModelIndex &index) const
 
         if (ClipBoard::instance()->clipboardFileUrlList().contains(file->urlOf(UrlInfoType::kUrl)))
             return true;
-
-        // the linked file only judges the URL, not the inode,
-        // because the inode of the linked file is consistent with that of the source file
-        if (!file->isAttributes(OptInfoType::kIsSymLink)) {
-            if (ClipBoard::instance()->clipboardFileInodeList().contains(file->extendAttributes(ExtInfoType::kInode).toULongLong()))
-                return true;
-        }
     }
     return false;
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -152,7 +152,9 @@ void FileOperatorHelper::copyFiles(const FileView *view)
         if (!fileInfo || !fileInfo->isAttributes(OptInfoType::kIsReadable))
             return;
     }
-    qInfo() << "copy shortcut key to clipboard, selected urls: " << selectedUrls
+
+    qDebug() << "copy shortcut key to clipboard, selected urls: " << selectedUrls;
+    qInfo() << "copy shortcut key to clipboard, selected urls count: " << selectedUrls.count()
             << " currentUrl: " << view->rootUrl();
     auto windowId = WorkspaceHelper::instance()->windowId(view);
 
@@ -174,7 +176,8 @@ void FileOperatorHelper::cutFiles(const FileView *view)
     if (ok && !urls.isEmpty())
         selectedUrls = urls;
 
-    qInfo() << "selected urls: " << selectedUrls
+    qDebug() << "selected urls: " << selectedUrls;
+    qInfo() << "selected urls count: " << selectedUrls.count()
             << " currentUrl: " << view->rootUrl();
     auto windowId = WorkspaceHelper::instance()->windowId(view);
     dpfSignalDispatcher->publish(GlobalEventType::kWriteUrlsToClipboard,

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -76,18 +76,8 @@ bool FileViewHelper::isTransparent(const QModelIndex &index) const
     //  cutting
     if (ClipBoard::instance()->clipboardAction() == ClipBoard::kCutAction) {
         QUrl localUrl = file->urlOf(UrlInfoType::kUrl);
-        if (file->canAttributes(CanableInfoType::kCanRedirectionFileUrl))
-            localUrl = file->urlOf(UrlInfoType::kRedirectedFileUrl);
-
         if (ClipBoard::instance()->clipboardFileUrlList().contains(localUrl))
             return true;
-
-        // the linked file only judges the URL, not the inode,
-        // because the inode of the linked file is consistent with that of the source file
-        if (!file->isAttributes(OptInfoType::kIsSymLink)) {
-            if (ClipBoard::instance()->clipboardFileInodeList().contains(file->extendAttributes(ExtInfoType::kInode).toULongLong()))
-                return true;
-        }
     }
 
     return false;


### PR DESCRIPTION
Modify the code copied by ctrl+c. 1. Modify the printing and use qdebug to print the selected URL. 2. Modify QClipboard:: dataChanged signal to queue connection in clipboard. 3. Modify the slot function onClipboardDataChanged in Clipboard without obtaining fileinfo. 4. Modify the use of inode to determine whether the linked file is cut.

Log: ctrl+x,ctrl+c,file operation
Task: https://pms.uniontech.com/task-view-269223.html