### PR TITLE
fix: [propertydialog-UI] PropertyDIalog incomplete display in Uyghur

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -170,23 +170,31 @@ void PermissionManagerWidget::initUI()
 
     executableCheckBox = new QCheckBox(this);
     executableCheckBox->setText(tr("Allow to execute as program"));
+    executableCheckBox->setFixedWidth(196);
 
     layout->setLabelAlignment(Qt::AlignLeft);
 
     DLabel *owner = new DLabel(QObject::tr("Owner"), this);
     DFontSizeManager::instance()->bind(owner, DFontSizeManager::SizeType::T7, QFont::DemiBold);
-#ifdef DTKWIDGET_CLASS_DSizeMode
-    owner->setFixedWidth(DSizeModeHelper::element(60, 107));
-    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [owner]() {
-        owner->setFixedWidth(DSizeModeHelper::element(60, 107));
-    });
-#else
-    owner->setFixedWidth(107);
-#endif
     DLabel *group = new DLabel(QObject::tr("Group"), this);
     DFontSizeManager::instance()->bind(group, DFontSizeManager::SizeType::T7, QFont::DemiBold);
     DLabel *other = new DLabel(QObject::tr("Others"), this);
     DFontSizeManager::instance()->bind(other, DFontSizeManager::SizeType::T7, QFont::DemiBold);
+
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    owner->setFixedWidth(DSizeModeHelper::element(60, 107));
+    group->setFixedWidth(DSizeModeHelper::element(60, 107));
+    other->setFixedWidth(DSizeModeHelper::element(60, 107));
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [owner, group, other]() {
+        owner->setFixedWidth(DSizeModeHelper::element(60, 107));
+        group->setFixedWidth(DSizeModeHelper::element(60, 107));
+        other->setFixedWidth(DSizeModeHelper::element(60, 107));
+    });
+#else
+    owner->setFixedWidth(107);
+    group->setFixedWidth(107);
+    other->setFixedWidth(107);
+#endif
 
     layout->addRow(owner, ownerComboBox);
     layout->addRow(group, groupComboBox);
@@ -261,7 +269,7 @@ void PermissionManagerWidget::setExecText()
     QString text = tr("Allow to execute as program");
     QFontMetrics fontWidth(executableCheckBox->font());
     int fontSize = fontWidth.horizontalAdvance(text);
-    int fontW = executableCheckBox->width() - executableCheckBox->contentsMargins().left() - executableCheckBox->contentsMargins().right() - this->contentsMargins().left() - this->contentsMargins().right();
+    int fontW = executableCheckBox->width() - executableCheckBox->iconSize().width() - this->getContent()->layout()->contentsMargins().right() - contentsMargins().right();
     if (fontSize > fontW) {
         text = fontWidth.elidedText(text, Qt::ElideMiddle, fontW);
     }

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -126,7 +126,8 @@ void ShareControlWidget::setupUi(bool disableState)
     gridLayout->setVerticalSpacing(0);
     frame->setLayout(gridLayout);
 
-    shareSwitcher = new QCheckBox(tr("Share this folder"), this);
+    setupShareSwitcher();
+
     QWidget *switcherContainer = new QWidget(this);
     QHBoxLayout *lay = new QHBoxLayout(this);
     switcherContainer->setLayout(lay);
@@ -182,6 +183,20 @@ void ShareControlWidget::setupUi(bool disableState)
 
     timer = new QTimer(this);
     timer->setInterval(500);
+}
+
+void ShareControlWidget::setupShareSwitcher()
+{
+    shareSwitcher = new QCheckBox(this);
+    shareSwitcher->setFixedWidth(ConstDef::kWidgetFixedWidth);
+    QString text = tr("Share this folder");
+    QFontMetrics fontWidth(shareSwitcher->font());
+    int fontSize = fontWidth.horizontalAdvance(text);
+    int fontW = shareSwitcher->width() - mainLay->contentsMargins().right() - shareSwitcher->iconSize().width();
+    if (fontSize > fontW) {
+        text = fontWidth.elidedText(text, Qt::ElideMiddle, fontW);
+    }
+    shareSwitcher->setText(text);
 }
 
 void ShareControlWidget::setupNetworkPath()

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
@@ -37,6 +37,7 @@ public:
 
 protected:
     void setupUi(bool disableState = false);
+    void setupShareSwitcher();
     void setupNetworkPath();
     void setupUserName();
     void setupSharePassword();


### PR DESCRIPTION
1.Omit overly long text
2.Fixed label size

Log: as title

Bug: https://pms.uniontech.com/bug-view-205271.html