### PR TITLE
fix: [io/copy]Copying files to other directories in trash, incorrect file name

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -428,6 +428,12 @@ bool FileOperateBaseWorker::doCheckFile(const FileInfoPointer &fromInfo, const F
 
     // 创建新的目标文件并做检查
     QString fileNewName = fileName;
+    // bug 205732, 回收站文件找到源文件名称
+    bool isTrashFile = FileUtils::isTrashFile(fromInfo->urlOf(UrlInfoType::kUrl));
+    if (isTrashFile) {
+        auto trashInfoUrl= trashInfo(fromInfo);
+        fileNewName = fileOriginName(trashInfoUrl);
+    }
     newTargetInfo.reset();
     if (!doCheckNewFile(fromInfo, toInfo, newTargetInfo, fileNewName, skip, true))
         return false;


### PR DESCRIPTION


The file was not copied from the recycle bin and the original name of the file was not read from the recycle bin. Modify the name of the original file in the Recycle Bin when creating a new file name

Log: Copying files to other directories in trash, incorrect file name
Bug: https://pms.uniontech.com/bug-view-205723.html