### PR TITLE
fix: [fileoperations] Execute ctr+z twice before taking effect.

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -767,14 +767,8 @@ bool FileOperationsEventReceiver::handleOperationRenameFile(const quint64 window
         return doRenameDesktopFile(windowId, oldUrl, newUrl, flags);
 
     if (!dfmbase::FileUtils::isLocalFile(oldUrl)) {
-        if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_RenameFile", windowId, oldUrl, newUrl, flags)) {
-            QMap<QUrl, QUrl> renamedFiles { { oldUrl, newUrl } };
-            dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kRenameFileResult,
-                                         windowId, renamedFiles, ok, error);
-            if (!flags.testFlag(AbstractJobHandler::JobFlag::kRevocation))
-                saveFileOperation({ newUrl }, { oldUrl }, GlobalEventType::kRenameFile);
+        if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_RenameFile", windowId, oldUrl, newUrl, flags))
             return true;
-        }
     }
 
     // async fileinfo need wait file quer over todo:: liyigang
@@ -827,15 +821,8 @@ bool FileOperationsEventReceiver::handleOperationRenameFiles(const quint64 windo
     bool ok = false;
     QString error;
     if (!urls.isEmpty() && !dfmbase::FileUtils::isLocalFile(urls.first())) {
-        if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_RenameFiles", windowId, urls, pair, replace)) {
-
-            dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kRenameFileResult,
-                                         windowId, successUrls, true, error);
-            if (!successUrls.isEmpty())
-                saveFileOperation(successUrls.values(), successUrls.keys(), GlobalEventType::kRenameFiles);
-
+        if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_RenameFiles", windowId, urls, pair, replace))
             return true;
-        }
     }
 
     RenameTypes type = RenameTypes::kBatchRepalce;


### PR DESCRIPTION
problem:
in vault, after rename file, should excute ctr+z twice before taking effect. because when rename file in vault, the function of saveFileOperation() run twice, the first is local path, the second is visual path. solved:
1. when rename file in vault, should not run saveFileOperation() twice.
2. when the External plugin hook the rename event, the fileoperations plugin should not do other things.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-204385.html