### PR TITLE
fix: [io]Unable to iterate over files

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -83,16 +83,16 @@ public Q_SLOTS:
     void doWatcherEvent();
     void doThreadWatcherEvent();
 
-    void handleTraversalResult(const FileInfoPointer &child);
-    void handleTraversalResults(QList<FileInfoPointer> children);
+    void handleTraversalResult(const FileInfoPointer &child, const QString &travseToken);
+    void handleTraversalResults(QList<FileInfoPointer> children, const QString &travseToken);
     void handleTraversalLocalResult(QList<SortInfoPointer> children,
                                     dfmio::DEnumerator::SortRoleCompareFlag sortRole,
                                     Qt::SortOrder sortOrder,
-                                    bool isMixDirAndFile);
-    void handleTraversalFinish();
+                                    bool isMixDirAndFile, const QString &travseToken);
+    void handleTraversalFinish(const QString &travseToken);
 
-    void handleTraversalSort();
-    void handleGetSourceData(const QString &key);
+    void handleTraversalSort(const QString &travseToken);
+    void handleGetSourceData(const QString &currentToken);
 
 private:
     void initConnection(const TraversalThreadManagerPointer &traversalThread);
@@ -111,6 +111,7 @@ private:
     void enqueueEvent(const QPair<QUrl, EventType> &e);
     QPair<QUrl, EventType> dequeueEvent();
     FileInfoPointer fileInfo(const QUrl &url);
+    QString currentKey(const QString &travseToken);
 
 public:
     AbstractFileWatcherPointer watcher;
@@ -120,8 +121,8 @@ private:
     QUrl hiddenFileUrl;
 
     QMap<QString, QSharedPointer<DirIteratorThread>> traversalThreads;
-    QString currentKey;
     std::atomic_bool traversalFinish { false };
+    std::atomic_bool traversaling { false };
 
     QReadWriteLock childrenLock;
     QList<QUrl> childrenUrlList {};

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -191,6 +191,17 @@ void FileSortWorker::handleSourceChildren(const QString &key,
 {
     if (currentKey != key)
         return;
+
+    if (this->childrenUrlList.isEmpty()) {
+        handleIteratorLocalChildren(key, children, sortRole, sortOrder, isMixDirAndFile);
+        if (isFinished) {
+            Q_EMIT requestSetIdel();
+        } else {
+            Q_EMIT getSourceData(currentKey);
+        }
+        return;
+    }
+
     // 获取相对于已有的新增加的文件
     QList<QUrl> newChildren;
     for (const auto &sortInfo : children) {
@@ -224,6 +235,7 @@ void FileSortWorker::handleSourceChildren(const QString &key,
         }
         return;
     }
+
     bool onebyone = !visibleChildren.isEmpty();
     // 排序
     if (!onebyone)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -31,6 +31,7 @@ class TraversalDirThreadManager : public TraversalDirThread
     int timeCeiling = 1500;
     int countCeiling = 500;
     dfmio::DEnumeratorFuture *future { nullptr };
+    QString traversalToken;
 
 public:
     explicit TraversalDirThreadManager(const QUrl &url, const QStringList &nameFilters = QStringList(),
@@ -45,14 +46,14 @@ public Q_SLOTS:
     void onAsyncIteratorOver();
 
 Q_SIGNALS:
-    void updateChildrenManager(QList<FileInfoPointer> children);
+    void updateChildrenManager(QList<FileInfoPointer> children, QString traversalToken);
     // Special processing If it is a local file, directly read all the simple sorting lists of the file
     void updateLocalChildren(QList<SortInfoPointer> children,
                              dfmio::DEnumerator::SortRoleCompareFlag sortRole,
                              Qt::SortOrder sortOrder,
-                             bool isMixDirAndFile);
-    void traversalFinished();
-    void traversalRequestSort();
+                             bool isMixDirAndFile, QString traversalToken);
+    void traversalFinished(QString traversalToken);
+    void traversalRequestSort(QString traversalToken);
 
 protected:
     virtual void run() override;

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -123,7 +123,6 @@ TEST_F(UT_RootInfo, StartWork)
     if (!rootInfoObj->watcher.isNull()) {
         EXPECT_TRUE(calledStartWatcher);
     }
-    EXPECT_EQ(rootInfoObj->currentKey, key);
     EXPECT_TRUE(calledThreadStart);
     EXPECT_FALSE(calledGetSourceData);
 
@@ -138,7 +137,6 @@ TEST_F(UT_RootInfo, StartWork)
     calledGetSourceData = false;
     calledThreadStart = false;
     rootInfoObj->startWork(key, true);
-    EXPECT_NE(rootInfoObj->currentKey, unexistKey);
     EXPECT_FALSE(calledThreadStart);
     // EXPECT_FALSE(calledGetSourceData);
 }
@@ -369,7 +367,7 @@ TEST_F(UT_RootInfo, HandleTraversalResult)
     QObject::connect(rootInfoObj, &RootInfo::iteratorAddFile, rootInfoObj,
                      [&sendIteratorAddFile] { sendIteratorAddFile = true; });
 
-    rootInfoObj->handleTraversalResult(info);
+    rootInfoObj->handleTraversalResult(info, "");
 
     EXPECT_TRUE(calledAddChild);
     EXPECT_TRUE(sendIteratorAddFile);
@@ -394,7 +392,7 @@ TEST_F(UT_RootInfo, HandleTraversalResults)
     QObject::connect(rootInfoObj, &RootInfo::iteratorAddFiles, rootInfoObj,
                      [&sendIteratorAddFiles] { sendIteratorAddFiles = true; });
 
-    rootInfoObj->handleTraversalResults({ info });
+    rootInfoObj->handleTraversalResults({ info }, "");
 
     EXPECT_TRUE(calledAddChild);
     EXPECT_TRUE(sendIteratorAddFiles);
@@ -419,7 +417,7 @@ TEST_F(UT_RootInfo, HandleTraversalLocalResult)
                      [&sendIteratorLocalFiles] { sendIteratorLocalFiles = true; });
 
     SortInfoPointer info(new AbstractDirIterator::SortFileInfo);
-    rootInfoObj->handleTraversalLocalResult({ info }, sortRole, sortOrder, mixDirAndFile);
+    rootInfoObj->handleTraversalLocalResult({ info }, sortRole, sortOrder, mixDirAndFile, "");
 
     EXPECT_FALSE(addedChildren.isEmpty());
     EXPECT_EQ(rootInfoObj->originSortRole, sortRole);
@@ -430,30 +428,25 @@ TEST_F(UT_RootInfo, HandleTraversalLocalResult)
 
 TEST_F(UT_RootInfo, HandleTraversalFinish)
 {
-    rootInfoObj->currentKey = "current key";
     rootInfoObj->traversalFinish = false;
 
     QString currentKey("");
     QObject::connect(rootInfoObj, &RootInfo::traversalFinished, rootInfoObj,
                      [&currentKey](const QString &key) { currentKey.append(key); });
 
-    rootInfoObj->handleTraversalFinish();
+    rootInfoObj->handleTraversalFinish("");
 
-    EXPECT_EQ(currentKey, rootInfoObj->currentKey);
     EXPECT_TRUE(rootInfoObj->traversalFinish);
 }
 
 TEST_F(UT_RootInfo, HandleTraversalSort)
 {
-    rootInfoObj->currentKey = "current key";
 
     QString currentKey("");
     QObject::connect(rootInfoObj, &RootInfo::requestSort, rootInfoObj,
                      [&currentKey](const QString &key) { currentKey.append(key); });
 
-    rootInfoObj->handleTraversalSort();
-
-    EXPECT_EQ(currentKey, rootInfoObj->currentKey);
+    rootInfoObj->handleTraversalSort("");
 }
 
 TEST_F(UT_RootInfo, HandleGetSourceData)


### PR DESCRIPTION
When the same url is opened using multiple windows at the same time, there is only one rootinfo corresponding to multiple models, but one model corresponds to one Iterator. All iteration signals of the Iterator are connected to rootinfo, and the correct model is not found. Add a token to find the correct model.

Log: Unable to iterate over files
Bug: https://pms.uniontech.com/bug-view-205505.html