### PR TITLE
fix: [titlebar]The address bar folder title name is incorrect

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
@@ -81,7 +81,12 @@ QList<CrumbData> CrumbInterface::seprateUrl(const QUrl &url)
     for (int count = urls.size() - 1; count >= 0; count--) {
         QUrl curUrl { urls.at(count) };
         QStringList pathList { curUrl.path().split("/") };
-        CrumbData data { curUrl, pathList.isEmpty() ? "" : pathList.last() };
+        QString displayText = pathList.isEmpty() ? "" : pathList.last();
+        if (curUrl.scheme() == Global::Scheme::kTrash) {
+            auto info = InfoFactory::create<FileInfo>(curUrl);
+            displayText = info ? info->displayOf(DisPlayInfoType::kFileDisplayName) : displayText;
+        }
+        CrumbData data { curUrl, displayText};
         if (UrlRoute::isRootUrl(curUrl))
             data.iconName = UrlRoute::icon(curUrl.scheme()).name();
         list.append(data);


### PR DESCRIPTION
In the trash file, the gio trash mechanism is used, and files with the same name will be added with. index. suffix after the file name. So the address in the titl column shows an error. If the schema is trash, use the displayname in fileinfo.

Log: The address bar folder title name is incorrect
Bug: https://pms.uniontech.com/bug-view-205729.html