### PR TITLE
修复设备会被挂载到 /media/root/ 目录下的问题

### DIFF
--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -127,6 +127,19 @@ QString UniversalUtils::userLoginState()
     return state;
 }
 
+quint32 UniversalUtils::currentLoginUser()
+{
+    quint32 uid = UINT32_MAX;
+    QDBusInterface loginManager("org.freedesktop.login1",
+                                "/org/freedesktop/login1/user/self",
+                                "org.freedesktop.login1.User",
+                                QDBusConnection::systemBus());
+    QVariant replay = loginManager.property(("UID"));
+    if (replay.isValid())
+        uid = replay.toULongLong();
+    return uid;
+}
+
 bool UniversalUtils::isLogined()
 {
     return userLoginState() == "active";

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -20,6 +20,7 @@ public:
     static void notifyMessage(const QString &msg);
     static void notifyMessage(const QString &title, const QString &msg);
     static QString userLoginState();
+    static quint32 currentLoginUser();
     static bool isLogined();
     static void blockShutdown(QDBusReply<QDBusUnixFileDescriptor> &replay);
     static qint64 computerMemory();


### PR DESCRIPTION
device is mounted at /media/root/$DISKNAME while root user is not
loggined. the auto mount operation is dealed in server process, and when
an admin-dfm is launched before, the server which service for admin-dfm
is launched too. and device can be mounted by the admin-server when
device plug in.

Log: fix issue about auto mount.

Bug: https://pms.uniontech.com/bug-view-205301.html
