### PR TITLE
fix: [fileinfo]Sent to desktop, file name incorrect

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -120,19 +120,9 @@ QString AsyncFileInfo::nameOf(const NameInfoType type) const
         if (d->asyncAttribute(AsyncAttributeID::kStandardName).isValid())
             return d->asyncAttribute(AsyncAttributeID::kStandardName).toString();
         break;
-    case FileNameInfoType::kBaseName:
-        if (d->asyncAttribute(AsyncAttributeID::kStandardBaseName).isValid())
-            return d->asyncAttribute(AsyncAttributeID::kStandardBaseName).toString();
-        break;
     case FileNameInfoType::kCompleteBaseName:
         if (d->asyncAttribute(AsyncAttributeID::kStandardCompleteBaseName).isValid())
             return d->asyncAttribute(AsyncAttributeID::kStandardCompleteBaseName).toString();
-        break;
-    case FileNameInfoType::kSuffix:
-        [[fallthrough]];
-    case FileNameInfoType::kSuffixOfRename:
-        if (d->asyncAttribute(AsyncAttributeID::kStandardSuffix).isValid())
-            return d->asyncAttribute(AsyncAttributeID::kStandardSuffix).toString();
         break;
     case FileNameInfoType::kCompleteSuffix:
         if (d->asyncAttribute(AsyncAttributeID::kStandardCompleteSuffix).isValid())
@@ -689,21 +679,6 @@ QString AsyncFileInfoPrivate::fileName() const
     return fileName;
 }
 /*!
- * \brief baseName 文件的基本名称
- *
- * url = file:///tmp/archive.tar.gz
- *
- * baseName = archive
- *
- * \param
- *
- * \return
- */
-QString AsyncFileInfoPrivate::baseName() const
-{
-    return this->attribute(DFileInfo::AttributeID::kStandardBaseName).toString();
-}
-/*!
  * \brief completeBaseName 文件的完整基本名称
  *
  * url = file:///tmp/archive.tar.gz
@@ -717,21 +692,6 @@ QString AsyncFileInfoPrivate::baseName() const
 QString AsyncFileInfoPrivate::completeBaseName() const
 {
     return this->attribute(DFileInfo::AttributeID::kStandardCompleteBaseName).toString();
-}
-/*!
- * \brief suffix 文件的suffix
- *
- * url = file:///tmp/archive.tar.gz
- *
- * suffix = gz
- *
- * \param
- *
- * \return
- */
-QString AsyncFileInfoPrivate::suffix() const
-{
-    return this->attribute(DFileInfo::AttributeID::kStandardSuffix).toString();
 }
 /*!
  * \brief suffix 文件的完整suffix
@@ -1063,9 +1023,7 @@ void AsyncFileInfoPrivate::cacheAllAttributes()
 {
     QMap<AsyncFileInfo::AsyncAttributeID, QVariant> tmp;
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardName, fileName());
-    tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardBaseName, baseName());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardCompleteBaseName, completeBaseName());
-    tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardSuffix, suffix());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardCompleteSuffix, completeSuffix());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardDisplayName, fileDisplayName());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardSize, attribute(DFileInfo::AttributeID::kStandardSize));

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -94,9 +94,7 @@ public:
 
 public:
     QString fileName() const;
-    QString baseName() const;
     QString completeBaseName() const;
-    QString suffix() const;
     QString completeSuffix() const;
     QString iconName() const;
     QString mimeTypeName() const;

--- a/src/dfm-base/file/local/private/syncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/syncfileinfo_p.h
@@ -93,9 +93,7 @@ public:
 
 public:
     QString fileName() const;
-    QString baseName() const;
     QString completeBaseName() const;
-    QString suffix() const;
     QString completeSuffix() const;
     QString iconName() const;
     QString mimeTypeName() const;

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -140,14 +140,8 @@ QString SyncFileInfo::nameOf(const NameInfoType type) const
     switch (type) {
     case FileNameInfoType::kFileName:
         return d->fileName();
-    case FileNameInfoType::kBaseName:
-        return d->baseName();
     case FileNameInfoType::kCompleteBaseName:
         return d->completeBaseName();
-    case FileNameInfoType::kSuffix:
-        [[fallthrough]];
-    case FileNameInfoType::kSuffixOfRename:
-        return d->suffix();
     case FileNameInfoType::kCompleteSuffix:
         return d->completeSuffix();
     case FileNameInfoType::kFileCopyName:
@@ -695,21 +689,6 @@ QString SyncFileInfoPrivate::fileName() const
     return fileName;
 }
 /*!
- * \brief baseName 文件的基本名称
- *
- * url = file:///tmp/archive.tar.gz
- *
- * baseName = archive
- *
- * \param
- *
- * \return
- */
-QString SyncFileInfoPrivate::baseName() const
-{
-    return this->attribute(DFileInfo::AttributeID::kStandardBaseName).toString();
-}
-/*!
  * \brief completeBaseName 文件的完整基本名称
  *
  * url = file:///tmp/archive.tar.gz
@@ -723,21 +702,6 @@ QString SyncFileInfoPrivate::baseName() const
 QString SyncFileInfoPrivate::completeBaseName() const
 {
     return this->attribute(DFileInfo::AttributeID::kStandardCompleteBaseName).toString();
-}
-/*!
- * \brief suffix 文件的suffix
- *
- * url = file:///tmp/archive.tar.gz
- *
- * suffix = gz
- *
- * \param
- *
- * \return
- */
-QString SyncFileInfoPrivate::suffix() const
-{
-    return this->attribute(DFileInfo::AttributeID::kStandardSuffix).toString();
 }
 /*!
  * \brief suffix 文件的完整suffix

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -132,6 +132,8 @@ QString dfmbase::FileInfo::nameOf(const NameInfoType type) const
         [[fallthrough]];
     case FileNameInfoType::kBaseNameOfRename:
         return dptr->baseName();
+    case FileNameInfoType::kSuffixOfRename:
+        [[fallthrough]];
     case FileNameInfoType::kSuffix:
         return dptr->suffix();
     case FileNameInfoType::kIconName:

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -677,7 +677,7 @@ QString FileUtils::nonExistSymlinkFileName(const QUrl &fileUrl, const QUrl &pare
 
     if (info && DFMIO::DFile(fileUrl).exists()) {
         QString baseName = info->displayOf(DisPlayInfoType::kFileDisplayName) == info->nameOf(NameInfoType::kFileName)
-                ? info->nameOf(NameInfoType::kCompleteBaseName)
+                ? info->nameOf(NameInfoType::kBaseName)
                 : info->displayOf(DisPlayInfoType::kFileDisplayName);
         QString shortcut = QObject::tr("Shortcut");
         QString linkBaseName;


### PR DESCRIPTION
When sending to the desktop, the basename and suffix of the file were obtained using gio's fileinfo, which is not consistent with the code in v5. Modify the use of v5 to obtain the basename and suffix of the file.

Log: Sent to desktop, file name incorrect
Bug: https://pms.uniontech.com/bug-view-205565.html