### PR TITLE
修复从 V5 升级后，最近使用的组策略字段与UI设置不匹配的问题

### DIFF
--- a/src/dfm-base/base/configs/dconfig/private/dconfigmanager_p.h
+++ b/src/dfm-base/base/configs/dconfig/private/dconfigmanager_p.h
@@ -20,7 +20,7 @@ DFMBASE_BEGIN_NAMESPACE
 class DConfigManager;
 class DConfigManagerPrivate
 {
-    friend DConfigManager;
+    friend class DConfigManager;
     DConfigManager *q { nullptr };
 
     QMap<QString, DTK_NAMESPACE::DCORE_NAMESPACE::DConfig *> configs;

--- a/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolwidget.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolwidget.h
@@ -17,7 +17,7 @@ class DiskControlItem;
 
 class DiskControlWidget : public QScrollArea
 {
-    friend DiskControlItem;
+    friend class DiskControlItem;
     Q_OBJECT
 public:
     explicit DiskControlWidget(QWidget *parent = nullptr);

--- a/src/plugins/filemanager/core/dfmplugin-recent/recent.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/recent.cpp
@@ -16,6 +16,7 @@
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/application/application.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-base/utils/systempathutil.h>
 
@@ -119,7 +120,7 @@ void Recent::addRecentItem()
         { "Property_Key_IsDefaultItem", true },
         { "Property_Key_PluginItemData", map }
     };
-    dpfSlotChannel->push("dfmplugin_bookmark", "slot_AddPluginItem", bookmarkMap);   //push item data to bookmark plugin as cache
+    dpfSlotChannel->push("dfmplugin_bookmark", "slot_AddPluginItem", bookmarkMap);   // push item data to bookmark plugin as cache
     dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Add", RecentHelper::rootUrl(), map);
 }
 
@@ -165,10 +166,10 @@ void Recent::regRecentCrumbToTitleBar()
 
 void Recent::installToSideBar()
 {
-    bool showRecentEnabled = Application::instance()->genericAttribute(Application::kShowRecentFileEntry).toBool();
-    if (showRecentEnabled) {
+    const auto &theSidebarVisiableList = DConfigManager::instance()->value("org.deepin.dde.file-manager.sidebar", "itemVisiable", QVariantMap()).toMap();
+    bool showRecent = theSidebarVisiableList.value("recent", true).toBool();
+    if (showRecent)
         addRecentItem();
-    }
 }
 
 void Recent::addFileOperations()

--- a/src/tools/upgrade/units/dconfigupgradeunit.h
+++ b/src/tools/upgrade/units/dconfigupgradeunit.h
@@ -23,6 +23,7 @@ private:
     static const QMap<QString, QString> &mappedActions();
     bool upgradeMenuConfigs();
     bool upgradeSmbConfigs();
+    bool upgradeRecentConfigs();
     void clearDiskHidden();
 };
 }


### PR DESCRIPTION
the dconfig value is not synced with the old GenericAttribute when
upgrade.

Log: deal issue about config synchronize.

Bug: https://pms.uniontech.com/bug-view-204981.html
