### PR TITLE
fix: [vault] Adjust the vault drag and drop logic

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultfilehelper.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultfilehelper.h
@@ -11,6 +11,7 @@
 #include <dfm-base/interfaces/abstractjobhandler.h>
 #include <dfm-base/utils/clipboard.h>
 #include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_event_defines.h>
 
 #include <QObject>
 #include <QFileDevice>


### PR DESCRIPTION
1. When ctr drag, copy files;
2. When alt drag, cut files;
3. When ordinary drag, the inside of the vault, cut files, the vault and outside, copy files.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-205799.html