### PR TITLE
fix: [workspace] The horizontal scroll bar is not displayed

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -68,6 +68,7 @@ FileView::FileView(const QUrl &url, QWidget *parent)
     setDefaultDropAction(Qt::CopyAction);
     setDragDropOverwriteMode(true);
     setDragEnabled(true);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 
     initializeModel();
     initializeDelegate();


### PR DESCRIPTION
The display mode of adjusting the horizontal scroll bar is always display.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-206757.html