### PR TITLE
fix: [trashfileinfo]Application files (. desktop files) cannot be restored properly after deletion

### DIFF
--- a/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
@@ -102,13 +102,6 @@ QString TrashFileInfoPrivate::fileName() const
     if (!dFileInfo)
         return QString();
 
-    if (targetUrl.isValid()) {
-        if (FileUtils::isDesktopFile(targetUrl)) {
-            DesktopFileInfo dfi(targetUrl);
-            return dfi.displayOf(DisPlayInfoType::kFileDisplayName);
-        }
-    }
-
     return dFileInfo->attribute(DFileInfo::AttributeID::kStandardName).toString();
 }
 


### PR DESCRIPTION
There was an error in obtaining the original name of the deleted file while checking the file name. If it was a desktop file in trashfileinfo, it returned the displayed name of the file, so the error occurred. Modifying the file name should return the file source file name.

Log: Application files (.desktop files) cannot be restored properly after deletion
Bug: https://pms.uniontech.com/bug-view-206719.html