### PR TITLE
fix: [io]Shortcut keys for copying and cutting, pasting in the recycl…

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -188,7 +188,7 @@ void FileOperatorHelper::pasteFiles(const FileView *view)
     qInfo() << " paste file by clipboard and currentUrl: " << view->rootUrl();
     auto action = ClipBoard::instance()->clipboardAction();
     // trash dir can't paste files for copy
-    if (ClipBoard::kCopyAction == action && FileUtils::isTrashFile(view->rootUrl()))
+    if (FileUtils::isTrashFile(view->rootUrl()))
         return;
     auto sourceUrls = ClipBoard::instance()->clipboardFileUrlList();
     auto windowId = WorkspaceHelper::instance()->windowId(view);


### PR DESCRIPTION
…e bin should not take effect

Only copyaction is judged in the shortcut key. Modify here and return it to any trash

Log: Shortcut keys for copying and cutting, pasting in the recycle bin should not take effect
Bug: https://pms.uniontech.com/bug-view-206637.html