### PR TITLE
fix: [fileinfo]Thumbnail keeps refreshing

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -600,22 +600,21 @@ QIcon AsyncFileInfoPrivate::thumbIcon()
     if (!icon.isNull())
         return icon;
 
-    if (iconFuture && iconFuture->data.toBool()) {
-        icon = QIcon(ThumbnailProvider::instance()->thumbnailPixmap(q->fileUrl(), ThumbnailProvider::kLarge));
-        if (!icon.isNull()) {
-            QPixmap pixmap = icon.pixmap(ThumbnailProvider::kLarge, ThumbnailProvider::kLarge);
-            QPainter pa(&pixmap);
-            pa.setPen(Qt::gray);
-            pa.drawPixmap(0, 0, pixmap);
 
-            QIcon fileIcon;
-            fileIcon.addPixmap(pixmap);
-            {
-                QWriteLocker wlk(&iconLock);
-                icons.insert(IconType::kThumbIcon, fileIcon);
-            }
-            return fileIcon;
+    icon = QIcon(ThumbnailProvider::instance()->thumbnailPixmap(q->fileUrl(), ThumbnailProvider::kLarge));
+    if (!icon.isNull()) {
+        QPixmap pixmap = icon.pixmap(ThumbnailProvider::kLarge, ThumbnailProvider::kLarge);
+        QPainter pa(&pixmap);
+        pa.setPen(Qt::gray);
+        pa.drawPixmap(0, 0, pixmap);
+
+        QIcon fileIcon;
+        fileIcon.addPixmap(pixmap);
+        {
+            QWriteLocker wlk(&iconLock);
+            icons.insert(IconType::kThumbIcon, fileIcon);
         }
+        return fileIcon;
     }
 
     // else load thumb from DThumbnailProvider in async.

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -610,22 +610,20 @@ QIcon SyncFileInfoPrivate::thumbIcon()
 
     QUrl url = q->fileUrl();
 
-    if (iconFuture && iconFuture->data.toBool()) {
-        icon = QIcon(ThumbnailProvider::instance()->thumbnailPixmap(url, ThumbnailProvider::kLarge));
-        if (!icon.isNull()) {
-            QPixmap pixmap = icon.pixmap(ThumbnailProvider::kLarge, ThumbnailProvider::kLarge);
-            QPainter pa(&pixmap);
-            pa.setPen(Qt::gray);
-            pa.drawPixmap(0, 0, pixmap);
+    icon = QIcon(ThumbnailProvider::instance()->thumbnailPixmap(url, ThumbnailProvider::kLarge));
+    if (!icon.isNull()) {
+        QPixmap pixmap = icon.pixmap(ThumbnailProvider::kLarge, ThumbnailProvider::kLarge);
+        QPainter pa(&pixmap);
+        pa.setPen(Qt::gray);
+        pa.drawPixmap(0, 0, pixmap);
 
-            QIcon fileIcon;
-            fileIcon.addPixmap(pixmap);
-            {
-                QWriteLocker wlk(&iconLock);
-                icons.insert(IconType::kThumbIcon, fileIcon);
-            }
-            return fileIcon;
+        QIcon fileIcon;
+        fileIcon.addPixmap(pixmap);
+        {
+            QWriteLocker wlk(&iconLock);
+            icons.insert(IconType::kThumbIcon, fileIcon);
         }
+        return fileIcon;
     }
 
     // else load thumb from DThumbnailProvider in async.


### PR DESCRIPTION
Asynchronous threads are used every time in fileicon in fileinfo to obtain thumbnails. The desktop and civil servants call the refresh interface of fileinfo upon receiving the completion of thumbnail generation. This is caused by the thread to continue looping while trying to obtain the generated thumbnail. Modify the fileicon of fileinfo by first reading the thumbnail and returning it if there is one.

Log: Thumbnail keeps refreshing
Bug: https://pms.uniontech.com/bug-view-206629.html