### PR TITLE
fix: [fileinfo/canvas]fix refresh fileinfo loop

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
@@ -17,7 +17,9 @@ FileProvider::FileProvider(QObject *parent)
     : QObject(parent)
 {
     qRegisterMetaType<QList<QUrl>>();
-    connect(&FileInfoHelper::instance(), &FileInfoHelper::createThumbnailFinished, this, &FileProvider::update);
+    connect(&FileInfoHelper::instance(), &FileInfoHelper::createThumbnailFinished, this, [=](const QUrl &url, const QString &) {
+        this->onFileInfoUpdated(url, "", false);
+    }, Qt::QueuedConnection);
     connect(&FileInfoHelper::instance(), &FileInfoHelper::fileRefreshFinished, this,
             &FileProvider::onFileInfoUpdated, Qt::QueuedConnection);
 }


### PR DESCRIPTION
file provider will refresh file info when recevie thumbnail create finished signal, but refresh file will create thumbnail again.

Log: fix refresh fileinfo loop
Bug: https://pms.uniontech.com/bug-view-206543.html