### PR TITLE
fix: [burn] Capacity cannot be acquired after a disc has been erased

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -150,6 +150,7 @@ QString DeviceManager::mountBlockDev(const QString &id, const QVariantMap &opts)
 void DeviceManager::mountBlockDevAsync(const QString &id, const QVariantMap &opts, CallbackType1 cb)
 {
     Q_ASSERT_X(!id.isEmpty(), __FUNCTION__, "device id cannot be emtpy!!!");
+    Q_ASSERT(qApp->thread() == QThread::currentThread());
 
     auto dev = DeviceHelper::createBlockDevice(id);
     if (!dev) {
@@ -757,7 +758,7 @@ QStringList DeviceManager::detachBlockDev(const QString &id, CallbackType2 cb)
     auto func = [this, id, isOptical, cb](bool allUnmounted, const OperationErrorInfo &err) {
         if (allUnmounted) {
             QThread::msleep(500);   // make a short delay to eject/powerOff, other wise may raise a
-                                    // 'device busy' error.
+                    // 'device busy' error.
             if (isOptical)
                 ejectBlockDevAsync(id, {}, cb);
             else
@@ -841,7 +842,7 @@ DeviceManager::DeviceManager(QObject *parent)
 {
 }
 
-DeviceManager::~DeviceManager() { }
+DeviceManager::~DeviceManager() {}
 
 void DeviceManager::doAutoMount(const QString &id, DeviceType type)
 {

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.h
@@ -64,7 +64,7 @@ protected:
     void run() override;
     bool readyToWork();
     void workingInSubProcess();
-    DFMBURN::DOpticalDiscManager *createManager(int fd);
+    [[nodiscard]] DFMBURN::DOpticalDiscManager *createManager(int fd);
     QByteArray updatedInSubProcess(DFMBURN::JobStatus status, int progress, const QString &speed, const QStringList &message);
     void comfort();
 
@@ -73,6 +73,7 @@ signals:
     void requestFailureDialog(int type, const QString &err, const QStringList &details);
     void requestCompletionDialog(const QString &msg, const QString &icon);
     void requestCloseTab(const QUrl &url);
+    void requestReloadDisc(const QString &devId);
     void burnFinished(int type, bool reuslt);
 
 public slots:

--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -9,6 +9,8 @@
 #include <dfm-base/file/local/localfilehandler.h>
 #include <dfm-base/utils/dialogmanager.h>
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -117,6 +119,11 @@ void BurnJobManager::initBurnJobConnect(AbstractBurnJob *job)
     connect(job, &AbstractBurnJob::requestErrorMessageDialog, DialogManagerInstance, &DialogManager::showErrorDialog);
     connect(job, &AbstractBurnJob::requestCloseTab, this, [](const QUrl &url) {
         dpfSlotChannel->push("dfmplugin_workspace", "slot_Tab_Close", url);
+    });
+    connect(job, &AbstractBurnJob::requestReloadDisc, this, [](const QString &devId) {
+        DevMngIns->mountBlockDevAsync(devId, {}, [devId](bool, const DFMMOUNT::OperationErrorInfo &, const QString &) {
+            DevProxyMng->reloadOpticalInfo(devId);
+        });
     });
     connect(job, &AbstractBurnJob::burnFinished, this, [this, job](int type, bool result) {
         startAuditLogForBurnFiles(job->currentDeviceInfo(),


### PR DESCRIPTION
`DeviceManager::mountBlockDevAsync` must be used in the main thread, otherwise the signal slot will be disabled

Log: fix disc bug