### PR TITLE
fix: [fileinfo]Copying files occasionally causes file management to crash

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -150,7 +150,6 @@ public:
     explicit AsyncFileInfo(const QUrl &url);
     AsyncFileInfo(const QUrl &url, QSharedPointer<DFMIO::DFileInfo> dfileInfo);
     virtual ~AsyncFileInfo() override;
-    virtual bool initQuerier() override;
     virtual bool exists() const override;
     virtual void refresh() override;
     virtual void cacheAttribute(DFMIO::DFileInfo::AttributeID id, const QVariant &value = QVariant()) override;
@@ -182,6 +181,8 @@ public:
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
     QMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
+    void cacheAsyncAttributes();
+    bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);
 };
 }
 typedef QSharedPointer<DFMBASE_NAMESPACE::AsyncFileInfo> DFMAsyncFileInfoPointer;

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -55,7 +55,7 @@ FileInfoPointer LocalDirIteratorPrivate::fileInfo()
     } else {
         info = QSharedPointer<AsyncFileInfo>(new AsyncFileInfo(url, fileinfo));
         info->setExtendedAttributes(ExtInfoType::kFileIsHid, isHidden);
-        info->initQuerier();
+        info.dynamicCast<AsyncFileInfo>()->cacheAsyncAttributes();
     }
 
     auto infoTrans = InfoFactory::transfromInfo<FileInfo>(url.scheme(), info);

--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -15,6 +15,7 @@ DFMBASE_USE_NAMESPACE
 FileInfoHelper::FileInfoHelper(QObject *parent)
     : QObject(parent), thread(new QThread), worker(new FileInfoAsycWorker)
 {
+    moveToThread(qApp->thread());
     init();
 }
 
@@ -30,6 +31,7 @@ void FileInfoHelper::init()
     connect(this, &FileInfoHelper::fileMimeType, worker.data(), &FileInfoAsycWorker::fileMimeType, Qt::QueuedConnection);
     connect(this, &FileInfoHelper::fileInfoRefresh, worker.data(), &FileInfoAsycWorker::fileRefresh, Qt::QueuedConnection);
     connect(worker.data(), &FileInfoAsycWorker::fileMimeTypeFinished, this, &FileInfoHelper::fileMimeTypeFinished, Qt::QueuedConnection);
+    connect(this, &FileInfoHelper::fileRefreshRequest, this, &FileInfoHelper::handleFileRefresh, Qt::QueuedConnection);
 
     worker->moveToThread(thread.data());
     thread->start();
@@ -38,22 +40,21 @@ void FileInfoHelper::init()
 
 void FileInfoHelper::threadHandleDfmFileInfo(const QSharedPointer<FileInfo> dfileInfo)
 {
-    auto success = dfileInfo->initQuerier();
-    if (!success) {
-        return;
-    }
-
-    emit fileRefreshFinished(dfileInfo->fileUrl(), QString::number(quintptr(dfileInfo.data()), 16), false);
-
     auto asyncInfo = dfileInfo.dynamicCast<AsyncFileInfo>();
     if (!asyncInfo) {
         return;
     }
 
+    asyncInfo->cacheAsyncAttributes();
+
+    emit fileRefreshFinished(dfileInfo->fileUrl(), QString::number(quintptr(dfileInfo.data()), 16), false);
+
     auto notifyUrls = asyncInfo->notifyUrls();
     for (const auto &url : notifyUrls.keys()) {
         emit fileRefreshFinished(url, notifyUrls.value(url), true);
     }
+
+    qureingInfo.removeOneByLock(asyncInfo);
 }
 
 QSharedPointer<FileInfoHelperUeserData> FileInfoHelper::fileCountAsync(QUrl &url)
@@ -76,15 +77,27 @@ QSharedPointer<FileInfoHelperUeserData> FileInfoHelper::fileMimeTypeAsync(const 
 
 void FileInfoHelper::fileRefreshAsync(const QSharedPointer<FileInfo> dfileInfo)
 {
-    if (stoped)
-        return;
+    emit fileRefreshRequest(dfileInfo);
+}
 
-    if (!dfileInfo)
-        return;
-
+void FileInfoHelper::cacheFileInfoByThread(const QSharedPointer<FileInfo> dfileInfo)
+{
     QtConcurrent::run(&pool, [this, dfileInfo]() {
         threadHandleDfmFileInfo(dfileInfo);
     });
+}
+
+void FileInfoHelper::fileRefreshAsyncCallBack(bool success, void *userData)
+{
+    Q_UNUSED(success);
+    if (!userData)
+        return;
+    auto data = static_cast<FileRefreshCallBackData *>(userData);
+    if (!data || !data->info)
+        return;
+
+    FileInfoHelper::instance().cacheFileInfoByThread(data->info);
+    delete data;
 }
 
 FileInfoHelper::~FileInfoHelper()
@@ -95,6 +108,7 @@ FileInfoHelper::~FileInfoHelper()
 FileInfoHelper &FileInfoHelper::instance()
 {
     static FileInfoHelper helper;
+    helper.moveToThread(qApp->thread());
     return helper;
 }
 
@@ -105,4 +119,28 @@ void FileInfoHelper::aboutToQuit()
     worker->stopWorker();
     thread->wait();
     pool.waitForDone();
+}
+
+void FileInfoHelper::handleFileRefresh(QSharedPointer<FileInfo> dfileInfo)
+{
+    assert(qApp->thread() == QThread::currentThread());
+    if (stoped)
+        return;
+
+    if (!dfileInfo)
+        return;
+
+    auto asyncInfo = dfileInfo.dynamicCast<AsyncFileInfo>();
+    if (!asyncInfo) {
+        return;
+    }
+
+    if (qureingInfo.containsByLock(asyncInfo))
+        return;
+
+    qureingInfo.push_backByLock(asyncInfo);
+    FileRefreshCallBackData *data = new FileRefreshCallBackData;
+    data->info = asyncInfo;
+    if (!asyncInfo->asyncQueryDfmFileInfo(0, &FileInfoHelper::fileRefreshAsyncCallBack, data))
+        qureingInfo.removeOneByLock(asyncInfo);
 }

--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -24,12 +24,19 @@ class FileInfoHelper : public QObject
 {
     Q_OBJECT
 public:
+    struct FileRefreshCallBackData{
+        FileInfoPointer info{ nullptr };
+    };
+
+public:
     ~FileInfoHelper() override;
     static FileInfoHelper &instance();
     QSharedPointer<FileInfoHelperUeserData> fileCountAsync(QUrl &url);
     QSharedPointer<FileInfoHelperUeserData> fileMimeTypeAsync(const QUrl &url, const QMimeDatabase::MatchMode mode,
                                                               const QString &inod, const bool isGvfs);
     void fileRefreshAsync(const QSharedPointer<dfmbase::FileInfo> dfileInfo);
+    void cacheFileInfoByThread(const QSharedPointer<FileInfo> dfileInfo);
+    static void fileRefreshAsyncCallBack(bool success, void *userData);
 
 private:
     explicit FileInfoHelper(QObject *parent = nullptr);
@@ -49,14 +56,17 @@ Q_SIGNALS:
     void fileInfoRefresh(const QUrl &url, QSharedPointer<dfmio::DFileInfo> dfileInfo);
     // 第二个参数表示，当前是链接文件的原文件更新完成
     void fileRefreshFinished(const QUrl url, const QString infoPtr, const bool isLinkOrg);
+    void fileRefreshRequest(QSharedPointer<FileInfo> dfileInfo);
 private Q_SLOTS:
     void aboutToQuit();
+    void handleFileRefresh(QSharedPointer<FileInfo> dfileInfo);
 
 private:
     QSharedPointer<QThread> thread { nullptr };
     QSharedPointer<FileInfoAsycWorker> worker { nullptr };
     std::atomic_bool stoped { false };
     QThreadPool pool;
+    DThreadList<FileInfoPointer> qureingInfo;
 };
 }
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1253,7 +1253,6 @@ void FileOperateBaseWorker::determineCountProcessType()
     // 检查目标文件的有效性
     // 判读目标文件的位置（在可移除设备并且不是ext系列的设备上使用读取写入设备大小，
     // 其他都是读取当前线程写入磁盘的数据，如果采用多线程拷贝就自行统计）
-    qInfo() << "oooooooooooooooooooooo";
     auto rootPath = DFMUtils::mountPathFromUrl(targetOrgUrl);
     auto device = DFMUtils::deviceNameFromUrl(targetOrgUrl);
     if (device.startsWith("/dev/")) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -503,11 +503,9 @@ QPair<QUrl, RootInfo::EventType> RootInfo::dequeueEvent()
 // Here, the monitor's url is used to re-complete the current url
 FileInfoPointer RootInfo::fileInfo(const QUrl &url)
 {
-    auto info = InfoFactory::create<FileInfo>(url);
-    if (info) {
-        info->refresh();
+    auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+    if (info)
         return info;
-    }
 
     if (!watcher)
         return info;


### PR DESCRIPTION
The asynchronous file information query in the file manager is synchronized by the thread opened by the file manager itself, but at this time, a crash occurs when calling dfmio's devicePathFromUrl. Modify the use of Gio's asynchronous query file information interface to query, and cache the current queried file information using asynchronous threads.

Log: Copying files occasionally causes file management to crash
Bug: https://pms.uniontech.com/bug-view-204813.html