### PR TITLE
fix: [tag] the vault can tag info

### DIFF
--- a/src/plugins/common/dfmplugin-tag/tag.h
+++ b/src/plugins/common/dfmplugin-tag/tag.h
@@ -25,7 +25,8 @@ class Tag : public dpf::Plugin
     DPF_EVENT_REG_SIGNAL(signal_ReportLog_MenuData)
 
     // hook events
-    DPF_EVENT_REG_HOOK(hook_CanTag)
+    DPF_EVENT_REG_HOOK(hook_CanTag) // Warning: The event is abandoned, please do not use it.
+    DPF_EVENT_REG_HOOK(hook_CanTaged)
 
 public:
     virtual void initialize() override;

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -33,6 +33,7 @@
 
 Q_DECLARE_METATYPE(Qt::DropAction *)
 Q_DECLARE_METATYPE(QList<QUrl> *)
+Q_DECLARE_METATYPE(bool *)
 
 DPTAG_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
@@ -80,6 +81,11 @@ bool TagManager::canTagFile(const QUrl &url) const
     if (!url.isValid())
         return false;
 
+    bool canTaged { true };
+    if (dpfHookSequence->run("dfmplugin_tag", "hook_CanTaged", url, &canTaged)) {
+        return canTaged;
+    }
+
     QUrl localUrl;
     if (url.scheme() == Global::Scheme::kFile) {
         localUrl = url;
@@ -108,9 +114,14 @@ bool TagManager::canTagFile(const FileInfoPointer &info) const
     if (info.isNull())
         return false;
 
+    const QUrl &url = info->urlOf(UrlInfoType::kUrl);
+    bool canTaged { true };
+    if (dpfHookSequence->run("dfmplugin_tag", "hook_CanTaged", url, &canTaged)) {
+        return canTaged;
+    }
+
     bool canTag = localFileCanTagFilter(info);
     if (!canTag) {
-        const QUrl &url = info->urlOf(UrlInfoType::kUrl);
         if (dpfHookSequence->run("dfmplugin_tag", "hook_CanTag", url))
             return true;
     }

--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
@@ -70,6 +70,7 @@ void VaultEventReceiver::connectEvent()
     dpfHookSequence->follow("dfmplugin_fileoperations", "hook_Operation_OpenFileByApp", VaultFileHelper::instance(), &VaultFileHelper::openFileByApp);
     dpfHookSequence->follow("dfmplugin_fileoperations", "hook_Operation_SetPermission", VaultFileHelper::instance(), &VaultFileHelper::setPermision);
     dpfHookSequence->follow("dfmplugin_propertydialog", "hook_PermissionView_Ash", this, &VaultEventReceiver::handlePermissionViewAsh);
+    dpfHookSequence->follow("dfmplugin_tag", "hook_CanTaged", this, &VaultEventReceiver::handleFileCanTaged);
 }
 
 void VaultEventReceiver::computerOpenItem(quint64 winId, const QUrl &url)
@@ -254,4 +255,14 @@ bool VaultEventReceiver::handlePermissionViewAsh(const QUrl &url, bool *isAsh)
     *isAsh = true;
 
     return true;
+}
+
+bool VaultEventReceiver::handleFileCanTaged(const QUrl &url, bool *canTag)
+{
+    if (url.scheme() == VaultHelper::instance()->scheme()) {
+        *canTag = false;
+        return true;
+    }
+
+    return false;
 }

--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.h
@@ -33,6 +33,7 @@ public slots:
     bool detailViewIcon(const QUrl &url, QString *iconName);
     bool fileDropHandleWithAction(const QList<QUrl> &fromUrls, const QUrl &toUrl, Qt::DropAction *action);
     bool handlePermissionViewAsh(const QUrl &url, bool *isAsh);
+    bool handleFileCanTaged(const QUrl &url, bool *canTag);
 };
 }
 #endif   // VAULTEVENTRECEIVER_H

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultvisiblemanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultvisiblemanager.cpp
@@ -102,6 +102,8 @@ void VaultVisibleManager::pluginServiceRegister()
                 },
                 Qt::DirectConnection);
     }
+    dpfSignalDispatcher->subscribe("dfmplugin_computer", "signal_View_Refreshed",
+                                   VaultVisibleManager::instance(), &VaultVisibleManager::onComputerRefresh);
 }
 
 void VaultVisibleManager::addVaultComputerMenu()

--- a/src/plugins/filemanager/dfmplugin-vault/vault.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/vault.cpp
@@ -29,8 +29,6 @@ void Vault::initialize()
 bool Vault::start()
 {
     VaultVisibleManager::instance()->pluginServiceRegister();
-    dpfSignalDispatcher->subscribe("dfmplugin_computer", "signal_View_Refreshed",
-                                   VaultVisibleManager::instance(), &VaultVisibleManager::onComputerRefresh);
     return true;
 }
 


### PR DESCRIPTION
1. Abandoned hook_CanTag event
2. Add hook_CanMarked event
3. Vault not use tag function
4. change the tag key when virsual url.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-205873.html