### PR TITLE
fix: [crash] In list mode, the application crashed while adjusting the order of list items

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -82,6 +82,9 @@ FileView::~FileView()
 {
     disconnect(model(), &FileViewModel::stateChanged, this, &FileView::onModelStateChanged);
     disconnect(selectionModel(), &QItemSelectionModel::selectionChanged, this, &FileView::onSelectionChanged);
+
+    dpfSignalDispatcher->unsubscribe("dfmplugin_workspace", "signal_View_HeaderViewSectionChanged", this, &FileView::onHeaderViewSectionChanged);
+    dpfSignalDispatcher->unsubscribe("dfmplugin_filepreview", "signal_ThumbnailDisplay_Changed", this, &FileView::onWidgetUpdate);
 }
 
 QWidget *FileView::widget() const


### PR DESCRIPTION
The FileView does not unsubscribe from events during destruction

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-207213.html
