### PR TITLE
fix: When right-clicking on a file with a thumbnail, the thumbnail will be automatically refreshed

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -1208,10 +1208,6 @@ void FileView::contextMenuEvent(QContextMenuEvent *event)
             selectionModel()->select(index, QItemSelectionModel::Select);
         }
 
-        auto info = model()->fileInfo(index);
-        if (info)
-            info->refresh();
-
         d->viewMenuHelper->showNormalMenu(index, model()->flags(index));
     }
 }


### PR DESCRIPTION
When right-clicking on the file, its file information is refreshed

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-207175.html
