### PR TITLE
修复最近使用在侧边栏中的显示问题

### DIFF
--- a/src/dfm-base/base/application/application.cpp
+++ b/src/dfm-base/base/application/application.cpp
@@ -93,9 +93,6 @@ void ApplicationPrivate::_q_onSettingsValueChanged(const QString &group, const Q
         case Application::kShowedFileSuffix:
             Q_EMIT self->showedFileSuffixChanged(value.toBool());
             break;
-        case Application::kShowRecentFileEntry:
-            Q_EMIT self->recentDisplayChanged(value.toBool());
-            break;
         case Application::kShowCsdCrumbBarClickableArea:
             Q_EMIT self->csdClickableAreaAttributeChanged(value.toBool());
             break;

--- a/src/dfm-base/base/application/application.h
+++ b/src/dfm-base/base/application/application.h
@@ -40,7 +40,7 @@ public:
     enum GenericAttribute {
         kIndexInternal,
         kIndexExternal,
-        kIndexFullTextSearch,   //full text search
+        kIndexFullTextSearch,   // full text search
         kPreviewCompressFile,   // open the zip as a directory
         kPreviewTextFile,   // generate thumbnails from plain text
         kPreviewDocumentFile,   // document generation thumbnails (pdf)
@@ -58,7 +58,6 @@ public:
         kShowedFileSuffix,   // show suffix
         kDisableNonRemovableDeviceUnmount,   // disable local disk uninstallation
         kHiddenSystemPartition,   // hide system partition
-        kShowRecentFileEntry,   // show "Recent Documents" entry in the sidebar
         kShowCsdCrumbBarClickableArea,   // eave an area in the breadcrumb bar that can be clicked on to go to the edit state of the address bar
         kShowFileSystemTagOnDiskIcon,   // display file system information on the disk icon
         kShowDeleteConfirmDialog,   // display the delete confirmation dialog
@@ -101,7 +100,6 @@ Q_SIGNALS:
     void showedFileSuffixChanged(bool enable);
     void previewAttributeChanged(GenericAttribute ga, bool enable);
     void showedHiddenFilesChanged(bool enable);
-    void recentDisplayChanged(bool enable);
     void csdClickableAreaAttributeChanged(bool enabled);
     void indexFullTextSearchChanged(bool enabled);
 

--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -48,7 +48,6 @@ BidirectionHash<QString, Application::GenericAttribute> SettingBackendPrivate::k
     { "advance.other.hide_loop_partitions", Application::kHideLoopPartitions },
     { "advance.other.show_crumbbar_clickable_area", Application::kShowCsdCrumbBarClickableArea },
     { "advance.other.show_filesystemtag_on_diskicon", Application::kShowFileSystemTagOnDiskIcon },
-    { "advance.items_in_sidebar.recent", Application::kShowRecentFileEntry }
 };
 
 SettingBackend::SettingBackend(QObject *parent)

--- a/src/plugins/filemanager/core/dfmplugin-recent/recent.h
+++ b/src/plugins/filemanager/core/dfmplugin-recent/recent.h
@@ -25,15 +25,12 @@ public:
     virtual bool start() override;
 
 private slots:
-    void onRecentDisplayChanged(bool enabled);
     void onWindowOpened(quint64 windId);
     void regRecentCrumbToTitleBar();
 
 private:
-    void installToSideBar();
     void addFileOperations();
     void addRecentItem();
-    void removeRecentItem();
 
     void followEvents();
     void bindWindows();

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/sidebar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/sidebar.cpp
@@ -37,7 +37,6 @@ bool SideBar::start()
         return false;
     }
     SideBarHelper::bindSettings();
-    SideBarHelper::bindRecentConf();
 
     return true;
 }

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -184,6 +184,7 @@ void SideBarHelper::updateSideBarSelection(quint64 winId)
 void SideBarHelper::bindSettings()
 {
     static const std::map<QString, QString> kvs {
+        { "advance.items_in_sidebar.recent", "recent" },
         { "advance.items_in_sidebar.home", "home" },
         { "advance.items_in_sidebar.desktop", "desktop" },
         { "advance.items_in_sidebar.videos", "videos" },
@@ -237,35 +238,6 @@ QVariantMap SideBarHelper::hiddenRules()
 QVariantMap SideBarHelper::groupExpandRules()
 {
     return DConfigManager::instance()->value(ConfigInfos::kConfName, ConfigInfos::kGroupExpandedKey).toMap();
-}
-
-void SideBarHelper::bindRecentConf()
-{
-    SyncPair pair {
-        { SettingType::kGenAttr, Application::kShowRecentFileEntry },
-        { ConfigInfos::kConfName, ConfigInfos::kVisiableKey },
-        saveRecentToConf,
-        syncRecentToAppSet,
-        isRecentConfEqual
-    };
-    ConfigSynchronizer::instance()->watchChange(pair);
-}
-
-void SideBarHelper::saveRecentToConf(const QVariant &var)
-{
-    auto &&rule = hiddenRules();
-    rule["recent"] = var.toBool();
-    DConfigManager::instance()->setValue(ConfigInfos::kConfName, ConfigInfos::kVisiableKey, rule);
-}
-
-void SideBarHelper::syncRecentToAppSet(const QString &, const QString &, const QVariant &)
-{
-    Application::instance()->setGenericAttribute(Application::kShowRecentFileEntry, hiddenRules().value("recent", true).toBool());
-}
-
-bool SideBarHelper::isRecentConfEqual(const QVariant &dcon, const QVariant &dset)
-{
-    return dcon.toMap().value("recent", true).toBool() && dset.toBool();
 }
 
 void SideBarHelper::saveGroupsStateToConfig(const QVariant &var)

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/utils/sidebarhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/utils/sidebarhelper.h
@@ -37,11 +37,6 @@ public:
     static QVariantMap hiddenRules();
     static QVariantMap groupExpandRules();
 
-    static void bindRecentConf();
-    static void saveRecentToConf(const QVariant &var);
-    static void syncRecentToAppSet(const QString &, const QString &, const QVariant &);
-    static bool isRecentConfEqual(const QVariant &dcon, const QVariant &dset);
-
     static void saveGroupsStateToConfig(const QVariant &var);
 
 public:

--- a/tests/plugins/filemanager/core/dfmplugin-recent/ut_recent.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-recent/ut_recent.cpp
@@ -30,7 +30,7 @@ class RecentTest : public testing::Test
 {
 
 protected:
-    virtual void SetUp() override {}
+    virtual void SetUp() override { }
     virtual void TearDown() override { stub.clear(); }
 
 private:
@@ -44,7 +44,6 @@ TEST_F(RecentTest, Initialize)
     stub.set_lamda(&RecentManager::init, [] { __DBG_STUB_INVOKE__ });
     stub.set_lamda(&Recent::bindWindows, [] { __DBG_STUB_INVOKE__ });
     stub.set_lamda(&Recent::followEvents, [] { __DBG_STUB_INVOKE__ });
-    stub.set_lamda(&Recent::onRecentDisplayChanged, [] { __DBG_STUB_INVOKE__ });
     EXPECT_NO_FATAL_FAILURE(ins.initialize());
 }
 
@@ -70,16 +69,6 @@ TEST_F(RecentTest, Start)
 
     stub.set_lamda(&Recent::addFileOperations, [] {});
     EXPECT_TRUE(ins.start());
-}
-
-TEST_F(RecentTest, onRecentDisplayChanged)
-{
-    stub.set_lamda(&Recent::addRecentItem, [] {});
-    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, const QUrl &);
-    auto push1 = static_cast<Push1>(&EventChannelManager::push);
-    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
-    EXPECT_NO_FATAL_FAILURE(ins.onRecentDisplayChanged(true));
-    EXPECT_NO_FATAL_FAILURE(ins.onRecentDisplayChanged(false));
 }
 
 TEST_F(RecentTest, addRecentItem)
@@ -117,10 +106,8 @@ TEST_F(RecentTest, onWindowOpened)
     stub.set_lamda(&Application::genericAttribute, []() -> bool {
         return true;
     });
-    EXPECT_NO_FATAL_FAILURE(ins.installToSideBar());
 
     stub.set_lamda(&Recent::regRecentCrumbToTitleBar, [] { __DBG_STUB_INVOKE__ });
-    stub.set_lamda(&Recent::installToSideBar, [] { __DBG_STUB_INVOKE__ });
 
     EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(1));
     EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(2));

--- a/tests/plugins/filemanager/core/dfmplugin-sidebar/utils/ut_sidebarhelper.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-sidebar/utils/ut_sidebarhelper.cpp
@@ -30,19 +30,19 @@ private:
 DFMBASE_USE_NAMESPACE
 DPSIDEBAR_USE_NAMESPACE
 
-TEST_F(UT_SideBarHelper, AllSideBar) {}
-TEST_F(UT_SideBarHelper, FindSideBarByWindowId) {}
-TEST_F(UT_SideBarHelper, AddSideBar) {}
-TEST_F(UT_SideBarHelper, RemoveSideBar) {}
-TEST_F(UT_SideBarHelper, WindowId) {}
-TEST_F(UT_SideBarHelper, CreateItemByInfo) {}
-TEST_F(UT_SideBarHelper, CreateSeparatorItem) {}
-TEST_F(UT_SideBarHelper, MakeItemIdentifier) {}
-TEST_F(UT_SideBarHelper, DefaultCdAction) {}
-TEST_F(UT_SideBarHelper, DefaultContextMenu) {}
-TEST_F(UT_SideBarHelper, RegisterSortFunc) {}
-TEST_F(UT_SideBarHelper, SortFunc) {}
-TEST_F(UT_SideBarHelper, UpdateSidebarSelection) {}
+TEST_F(UT_SideBarHelper, AllSideBar) { }
+TEST_F(UT_SideBarHelper, FindSideBarByWindowId) { }
+TEST_F(UT_SideBarHelper, AddSideBar) { }
+TEST_F(UT_SideBarHelper, RemoveSideBar) { }
+TEST_F(UT_SideBarHelper, WindowId) { }
+TEST_F(UT_SideBarHelper, CreateItemByInfo) { }
+TEST_F(UT_SideBarHelper, CreateSeparatorItem) { }
+TEST_F(UT_SideBarHelper, MakeItemIdentifier) { }
+TEST_F(UT_SideBarHelper, DefaultCdAction) { }
+TEST_F(UT_SideBarHelper, DefaultContextMenu) { }
+TEST_F(UT_SideBarHelper, RegisterSortFunc) { }
+TEST_F(UT_SideBarHelper, SortFunc) { }
+TEST_F(UT_SideBarHelper, UpdateSidebarSelection) { }
 
 TEST_F(UT_SideBarHelper, BindSettings)
 {
@@ -60,35 +60,4 @@ TEST_F(UT_SideBarHelper, HiddenRules)
     stub.set_lamda(&DConfigManager::value, [] { __DBG_STUB_INVOKE__ return QVariantMap(); });
 
     EXPECT_NO_FATAL_FAILURE(SideBarHelper::hiddenRules());
-}
-
-TEST_F(UT_SideBarHelper, BindRecentConf)
-{
-    stub.set_lamda(&ConfigSynchronizer::watchChange, [] { __DBG_STUB_INVOKE__ return true; });
-    EXPECT_NO_FATAL_FAILURE(SideBarHelper::bindRecentConf());
-}
-
-TEST_F(UT_SideBarHelper, SaveRecentToDConf)
-{
-    stub.set_lamda(&DConfigManager::setValue, [] { __DBG_STUB_INVOKE__ });
-    EXPECT_NO_FATAL_FAILURE(SideBarHelper::saveRecentToConf(true));
-    EXPECT_NO_FATAL_FAILURE(SideBarHelper::saveRecentToConf(false));
-}
-
-TEST_F(UT_SideBarHelper, SyncRecentToAppSet)
-{
-    stub.set_lamda(&Application::setGenericAttribute, [] { __DBG_STUB_INVOKE__ });
-    EXPECT_NO_FATAL_FAILURE(SideBarHelper::syncRecentToAppSet("hello", "world", "true"));
-    EXPECT_NO_FATAL_FAILURE(SideBarHelper::syncRecentToAppSet("hello", "world", "false"));
-}
-
-TEST_F(UT_SideBarHelper, IsRecentConfEqual)
-{
-    QVariantMap dcon {
-        { "recent", true },
-        { "computer", false }
-    };
-    EXPECT_TRUE(SideBarHelper::isRecentConfEqual(dcon, true));
-    dcon["recent"] = false;
-    EXPECT_FALSE(SideBarHelper::isRecentConfEqual(dcon, true));
 }


### PR DESCRIPTION
#only the dconfig item controls the visibility of the recent item in
#sidebar.

#Log: fix issue about recent item visibility in sidebar.

#Bug: https://pms.uniontech.com/bug-view-207299.html

以前控制侧边栏中最近使用项的配置应该被最新的组策略取代，但是因为一些遗留原因两者都被保留了。
文管启动时，是否向侧边栏添加入口由组策略控制，而配置面板中的值由旧的配置项控制。
因此在这种场景下，升级后删除了旧配置的本地文件，在文管启动时，则读取默认配置为 true（显示），
而组策略中该项的值为 false（不显示）。

修改方式：全面去除该配置项中旧有配置的存在，侧边栏的显示控制、配置面板中当前值的获取均由组策略提供。
移除原来的 Application 类中的该配置项枚举以及相关信号及项目中涉及到的使用。
