### PR TITLE
fix: [recent/fileinfo]File manager opens, leaves, closes, and occasionally crashes after recent use

### DIFF
--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -102,64 +102,13 @@ public:
     QString path() const;
     QString filePath() const;
     QString symLinkTarget() const;
-    QVector<AsyncFileInfo::AsyncAttributeID> &getAttributeIDVector() const
-    {
-        static QVector<AsyncFileInfo::AsyncAttributeID> kTimeInfoToDFile {
-            AsyncFileInfo::AsyncAttributeID::kTimeCreated,
-            AsyncFileInfo::AsyncAttributeID::kTimeCreated,
-            AsyncFileInfo::AsyncAttributeID::kTimeChanged,
-            AsyncFileInfo::AsyncAttributeID::kTimeModified,
-            AsyncFileInfo::AsyncAttributeID::kTimeAccess,
-            AsyncFileInfo::AsyncAttributeID::kTimeAccess,
-            AsyncFileInfo::AsyncAttributeID::kTimeCreated,
-            AsyncFileInfo::AsyncAttributeID::kTimeCreated,
-            AsyncFileInfo::AsyncAttributeID::kTimeChanged,
-            AsyncFileInfo::AsyncAttributeID::kTimeModified,
-            AsyncFileInfo::AsyncAttributeID::kTimeAccess,
-            AsyncFileInfo::AsyncAttributeID::kTimeAccess,
-            AsyncFileInfo::AsyncAttributeID::kTimeCreatedUsec,
-            AsyncFileInfo::AsyncAttributeID::kTimeCreatedUsec,
-            AsyncFileInfo::AsyncAttributeID::kTimeChangedUsec,
-            AsyncFileInfo::AsyncAttributeID::kTimeModifiedUsec,
-            AsyncFileInfo::AsyncAttributeID::kTimeAccessUsec,
-        };
-        return kTimeInfoToDFile;
-    }
     QUrl redirectedFileUrl() const;
-    QVector<AsyncFileInfo::AsyncAttributeID> &getAttributeIDIsVector() const
-    {
-        static QVector<AsyncFileInfo::AsyncAttributeID> kIsToDFile {
-            AsyncFileInfo::AsyncAttributeID::kAccessCanRead,
-            AsyncFileInfo::AsyncAttributeID::kAccessCanWrite,
-            AsyncFileInfo::AsyncAttributeID::kAccessCanExecute,
-            AsyncFileInfo::AsyncAttributeID::kStandardIsHidden,
-            AsyncFileInfo::AsyncAttributeID::kStandardIsFile,
-            AsyncFileInfo::AsyncAttributeID::kStandardIsDir,
-            AsyncFileInfo::AsyncAttributeID::kStandardIsSymlink,
-        };
-
-        return kIsToDFile;
-    }
     bool isExecutable() const;
     bool isPrivate() const;
     bool canDelete() const;
     bool canTrash() const;
     bool canRename() const;
     bool canFetch() const;
-    QVector<AsyncFileInfo::AsyncAttributeID> &getAttributeIDExtendVector() const
-    {
-        static QVector<AsyncFileInfo::AsyncAttributeID> kExtendToDFile = {
-            AsyncFileInfo::AsyncAttributeID::kOwnerUser,
-            AsyncFileInfo::AsyncAttributeID::kOwnerGroup,
-            AsyncFileInfo::AsyncAttributeID::kAttributeIDMax,
-            AsyncFileInfo::AsyncAttributeID::kUnixInode,
-            AsyncFileInfo::AsyncAttributeID::kUnixUID,
-            AsyncFileInfo::AsyncAttributeID::kUnixGID,
-            AsyncFileInfo::AsyncAttributeID::kStandardIsHidden,
-        };
-
-        return kExtendToDFile;
-    }
     QString sizeFormat() const;
     QVariant attribute(DFileInfo::AttributeID key, bool *ok = nullptr) const;
     QVariant asyncAttribute(AsyncFileInfo::AsyncAttributeID key) const;

--- a/src/dfm-base/file/local/private/syncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/syncfileinfo_p.h
@@ -101,64 +101,13 @@ public:
     QString path() const;
     QString filePath() const;
     QString symLinkTarget() const;
-    QVector<DFileInfo::AttributeID> &getAttributeIDVector() const
-    {
-        static QVector<DFileInfo::AttributeID> kTimeInfoToDFile {
-            DFileInfo::AttributeID::kTimeCreated,
-            DFileInfo::AttributeID::kTimeCreated,
-            DFileInfo::AttributeID::kTimeChanged,
-            DFileInfo::AttributeID::kTimeModified,
-            DFileInfo::AttributeID::kTimeAccess,
-            DFileInfo::AttributeID::kTimeAccess,
-            DFileInfo::AttributeID::kTimeCreated,
-            DFileInfo::AttributeID::kTimeCreated,
-            DFileInfo::AttributeID::kTimeChanged,
-            DFileInfo::AttributeID::kTimeModified,
-            DFileInfo::AttributeID::kTimeAccess,
-            DFileInfo::AttributeID::kTimeAccess,
-            DFileInfo::AttributeID::kTimeCreatedUsec,
-            DFileInfo::AttributeID::kTimeCreatedUsec,
-            DFileInfo::AttributeID::kTimeChangedUsec,
-            DFileInfo::AttributeID::kTimeModifiedUsec,
-            DFileInfo::AttributeID::kTimeAccessUsec,
-        };
-        return kTimeInfoToDFile;
-    }
     QUrl redirectedFileUrl() const;
-    QVector<DFileInfo::AttributeID> &getAttributeIDIsVector() const
-    {
-        static QVector<DFileInfo::AttributeID> kIsToDFile {
-            DFileInfo::AttributeID::kAccessCanRead,
-            DFileInfo::AttributeID::kAccessCanWrite,
-            DFileInfo::AttributeID::kAccessCanExecute,
-            DFileInfo::AttributeID::kStandardIsHidden,
-            DFileInfo::AttributeID::kStandardIsFile,
-            DFileInfo::AttributeID::kStandardIsDir,
-            DFileInfo::AttributeID::kStandardIsSymlink,
-        };
-
-        return kIsToDFile;
-    }
     bool isExecutable() const;
     bool isPrivate() const;
     bool canDelete() const;
     bool canTrash() const;
     bool canRename() const;
     bool canFetch() const;
-    QVector<DFileInfo::AttributeID> &getAttributeIDExtendVector() const
-    {
-        static QVector<DFileInfo::AttributeID> kExtendToDFile {
-            DFileInfo::AttributeID::kOwnerUser,
-            DFileInfo::AttributeID::kOwnerGroup,
-            DFileInfo::AttributeID::kAttributeIDMax,
-            DFileInfo::AttributeID::kUnixInode,
-            DFileInfo::AttributeID::kUnixUID,
-            DFileInfo::AttributeID::kUnixGID,
-            DFileInfo::AttributeID::kStandardIsHidden,
-        };
-
-        return kExtendToDFile;
-    }
     QString sizeFormat() const;
     QVariant attribute(DFileInfo::AttributeID key, bool *ok = nullptr) const;
     QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfo(DFileInfo::MediaType type, QList<DFileInfo::AttributeExtendID> ids);

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -199,17 +199,17 @@ bool SyncFileInfo::isAttributes(const OptInfoType type) const
 {
     switch (type) {
     case FileIsType::kIsFile:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kStandardIsFile).toBool();
     case FileIsType::kIsDir:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool();
     case FileIsType::kIsReadable:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kAccessCanRead).toBool();
     case FileIsType::kIsWritable:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kAccessCanWrite).toBool();
     case FileIsType::kIsHidden:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kStandardIsHidden).toBool();
     case FileIsType::kIsSymLink:
-        return d->attribute(d->getAttributeIDIsVector().at(static_cast<int>(type))).toBool();
+        return d->attribute(DFileInfo::AttributeID::kStandardIsSymlink).toBool();
     case FileIsType::kIsExecutable:
         return d->isExecutable();
     case FileIsType::kIsRoot:
@@ -253,17 +253,17 @@ QVariant SyncFileInfo::extendAttributes(const ExtInfoType type) const
     case FileExtendedInfoType::kSizeFormat:
         return d->sizeFormat();
     case FileExtendedInfoType::kInode:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kUnixInode);
     case FileExtendedInfoType::kOwner:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kOwnerUser);
     case FileExtendedInfoType::kGroup:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kOwnerGroup);
     case FileExtendedInfoType::kFileIsHid:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kStandardIsHidden);
     case FileExtendedInfoType::kOwnerId:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kUnixUID);
     case FileExtendedInfoType::kGroupId:
-        return d->attribute(d->getAttributeIDExtendVector().at(static_cast<int>(type)));
+        return d->attribute(DFileInfo::AttributeID::kUnixGID);
     default:
         QReadLocker(&d->lock);
         return FileInfo::extendAttributes(type);
@@ -326,41 +326,37 @@ qint64 SyncFileInfo::size() const
  */
 QVariant SyncFileInfo::timeOf(const TimeInfoType type) const
 {
-    qint64 data { 0 };
-    if (type < FileTimeType::kDeletionTimeMSecond)
-        data = d->attribute(d->getAttributeIDVector().at(static_cast<int>(type))).value<qint64>();
-
     switch (type) {
     case TimeInfoType::kCreateTime:
-        [[fallthrough]];
+        return QDateTime::fromSecsSinceEpoch(d->attribute(DFileInfo::AttributeID::kTimeCreated).value<qint64>());
     case TimeInfoType::kBirthTime:
-        [[fallthrough]];
+        return QDateTime::fromSecsSinceEpoch(d->attribute(DFileInfo::AttributeID::kTimeCreated).value<qint64>());
     case TimeInfoType::kMetadataChangeTime:
-        [[fallthrough]];
+        return QDateTime::fromSecsSinceEpoch(d->attribute(DFileInfo::AttributeID::kTimeChanged).value<qint64>());
     case TimeInfoType::kLastModified:
-        [[fallthrough]];
+        return QDateTime::fromSecsSinceEpoch(d->attribute(DFileInfo::AttributeID::kTimeModified).value<qint64>());
     case TimeInfoType::kLastRead:
-        return QDateTime::fromSecsSinceEpoch(data);
+        return QDateTime::fromSecsSinceEpoch(d->attribute(DFileInfo::AttributeID::kTimeAccess).value<qint64>());
     case TimeInfoType::kCreateTimeSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeCreated).value<qint64>();
     case TimeInfoType::kBirthTimeSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeCreated).value<qint64>();
     case TimeInfoType::kMetadataChangeTimeSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeChanged).value<qint64>();
     case TimeInfoType::kLastModifiedSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeModified).value<qint64>();
     case TimeInfoType::kLastReadSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeAccess).value<qint64>();
     case TimeInfoType::kCreateTimeMSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeCreatedUsec).value<qint64>();
     case TimeInfoType::kBirthTimeMSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeCreatedUsec).value<qint64>();
     case TimeInfoType::kMetadataChangeTimeMSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeChangedUsec).value<qint64>();
     case TimeInfoType::kLastModifiedMSecond:
-        [[fallthrough]];
+        return d->attribute(DFileInfo::AttributeID::kTimeModifiedUsec).value<qint64>();
     case TimeInfoType::kLastReadMSecond:
-        return data;
+        return d->attribute(DFileInfo::AttributeID::kTimeAccessUsec).value<qint64>();
     default:
         return FileInfo::timeOf(type);
     }

--- a/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.cpp
@@ -49,6 +49,8 @@ void RecentIterateWorker::onRecentFileChanged(const QList<QUrl> &cachedUrls)
 
         const QUrl &url { QUrl(location) };
         auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+        if (stopped)
+            return;
         if (info && info->exists() && info->isAttributes(OptInfoType::kIsFile)) {
             const auto &bindPath = FileUtils::bindPathTransform(info->pathOf(PathInfoType::kAbsoluteFilePath), false);
             QUrl recentUrl { QUrl::fromLocalFile(bindPath) };
@@ -72,6 +74,11 @@ void RecentIterateWorker::onRecentFileChanged(const QList<QUrl> &cachedUrls)
     }
     if (!deletedUrls.isEmpty())
         emit deleteExistRecentUrls(deletedUrls);
+}
+
+void RecentIterateWorker::stop()
+{
+    stopped = true;
 }
 
 }   // namespace dfmplugin_recent

--- a/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.h
@@ -20,10 +20,14 @@ public:
 
 public slots:
     void onRecentFileChanged(const QList<QUrl> &cachedUrls);
+public:
+    void stop();
 
 signals:
     void updateRecentFileInfo(const QUrl &url, const QString originPath, qint64 readTime);
     void deleteExistRecentUrls(const QList<QUrl> &urls);
+private:
+    std::atomic_bool stopped{ false };
 };
 }
 #endif   // RECENTITERATEWORKER_H

--- a/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.cpp
@@ -177,6 +177,7 @@ RecentManager::~RecentManager()
 {
     if (watcher)
         watcher->stopWatcher();
+    iteratorWorker->stop();
     workerThread.quit();
     workerThread.wait(15000);
 }


### PR DESCRIPTION
When closing, the system is destructing. Here, the Static variable in the fileinfo of the file information has been modified, and the vector access again is out of bounds. Modify each attribute of fileinfo and pass it in yourself. Add the stop flag in the identifier worker and exit once stopped.

Log: File manager opens, leaves, closes, and occasionally crashes after recent use