### PR TITLE
fix: [server] add default Exec item

### DIFF
--- a/src/apps/dde-file-manager-server/dbusservice/org.deepin.filemanager.server.service
+++ b/src/apps/dde-file-manager-server/dbusservice/org.deepin.filemanager.server.service
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.deepin.filemanager.server
+Exec=/usr/bin/false
 SystemdService=dde-filemanager-server.service


### PR DESCRIPTION
Without Exec, when the server crashes, then call the server's dbus interface will not start at all

Log: fix systemd config

Bug: https://pms.uniontech.com/bug-view-200819.html