### PR TITLE
修复访问 usbip 重定向设备时文管阻塞的问题

### DIFF
--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -66,6 +66,8 @@ public:
     static bool isSubpathOfDlnfs(const QString &path);
     static bool isMountPointOfDlnfs(const QString &path);
 
+    static QString getLongestMountRootPath(const QString &filePath);
+
 private:
     static bool hasMatch(const QString &txt, const QString &rex);
     using Compare = std::function<bool(const QString &, const QString &)>;

--- a/src/dfm-base/base/device/private/devicewatcher.cpp
+++ b/src/dfm-base/base/device/private/devicewatcher.cpp
@@ -164,7 +164,7 @@ void DeviceWatcher::initDevDatas()
  */
 void DeviceWatcher::queryOpticalDevUsage(const QString &id)
 {
-    FinallyUtil final([id]{ qInfo() << "query optical usage finished for" << id; });
+    FinallyUtil final([id] { qInfo() << "query optical usage finished for" << id; });
     Q_UNUSED(final);
 
     QVariantMap data = DeviceHelper::loadBlockInfo(id);
@@ -269,6 +269,8 @@ void DeviceWatcher::onBlkDevUnmounted(const QString &id)
 {
     QString oldMpt = d->allBlockInfos.value(id).value(DeviceProperty::kMountPoint).toString();
     d->allBlockInfos[id][DeviceProperty::kMountPoint] = QString();
+    d->allBlockInfos[id].remove(DeviceProperty::kSizeFree);
+    d->allBlockInfos[id].remove(DeviceProperty::kSizeUsed);
     emit DevMngIns->blockDevUnmounted(id, oldMpt);
 }
 

--- a/src/dfm-base/base/standardpaths.cpp
+++ b/src/dfm-base/base/standardpaths.cpp
@@ -37,6 +37,8 @@ QString StandardPaths::location(StandardPaths::StandardLocation type)
     case kApplicationConfigPath:
         return QDir::homePath() + "/.config";
 #ifdef APPSHAREDIR
+        // NOTE(xust): the APPSHAREDIR is associated with CMAKE_INSTALL_PREFIX
+        // if the dir not exists in DEBUG mode, change the defination of CMAKE variable in your IDE config.
     case kTranslationPath: {
         QString path = APPSHAREDIR "/translations";
         if (!QDir(path).exists()) {

--- a/src/external/dde-dock-plugins/disk-mount/device/dattachedblockdevice.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dattachedblockdevice.cpp
@@ -125,7 +125,12 @@ QPair<quint64, quint64> DAttachedBlockDevice::deviceUsage()
         clearDev.query();
         return clearDev.deviceUsage();
     }
-    return { info.value("SizeFree").toULongLong(),
+
+    quint64 free = (info.contains("SizeFree"))
+            ? info.value("SizeFree").toULongLong()
+            : info.value("SizeTotal").toULongLong();
+
+    return { free,
              info.value("SizeTotal").toULongLong() };
 }
 

--- a/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/commonmounthelper.cpp
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/commonmounthelper.cpp
@@ -33,6 +33,8 @@ QVariantMap CommonMountHelper::unmount(const QString &path, const QVariantMap &o
 
     int ret = mnt_table_parse_mtab(tab, nullptr);
     if (ret != 0) {
+        mnt_free_table(tab);
+        mnt_free_iter(iter);
         qWarning() << "device: cannot parse mtab" << ret;
         return { { MountReturnField::kResult, false },
                  { MountReturnField::kErrorMessage, "cannot parse mtab" } };
@@ -52,6 +54,9 @@ QVariantMap CommonMountHelper::unmount(const QString &path, const QVariantMap &o
         if (stdPath.startsWith(path))
             unmountTargets << descPath;
     }
+
+    mnt_free_table(tab);
+    mnt_free_iter(iter);
 
     qInfo() << "unmounting sub mounts of " << path;
     qInfo() << "unmount items: " << unmountTargets;

--- a/src/plugins/filemanager/core/dfmplugin-computer/private/computerview_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/private/computerview_p.h
@@ -8,6 +8,7 @@
 #include "views/computerview.h"
 
 namespace dfmplugin_computer {
+class ComputerStatusBar;
 class ComputerModel;
 class ComputerViewPrivate
 {
@@ -15,10 +16,12 @@ class ComputerViewPrivate
 
 public:
     explicit ComputerViewPrivate(ComputerView *qq = nullptr);
+    int visibleItemCount();
 
 private:
     ComputerView *q { nullptr };
     ComputerModel *model { nullptr };
+    ComputerStatusBar *statusBar { nullptr };
 };
 }
 #endif   // COMPUTERVIEW_P_H

--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerstatusbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerstatusbar.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "computerstatusbar.h"
+
+#include <QApplication>
+
+namespace dfmplugin_computer {
+
+void ComputerStatusBar::showSingleSelectionMessage()
+{
+    setTipText(qApp->translate("dfmbase::BasicStatusBarPrivate", "%1 item selected").arg(1));
+}
+
+}

--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerstatusbar.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerstatusbar.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef COMPUTERSTATUSBAR_H
+#define COMPUTERSTATUSBAR_H
+
+#include <dfm-base/widgets/dfmstatusbar/basicstatusbar.h>
+
+namespace dfmplugin_computer {
+class ComputerStatusBar : public DFMBASE_NAMESPACE::BasicStatusBar
+{
+    Q_OBJECT
+public:
+    explicit ComputerStatusBar(QWidget *parent)
+        : DFMBASE_NAMESPACE::BasicStatusBar(parent) { }
+
+    void showSingleSelectionMessage();
+};
+}
+
+#endif   // COMPUTERSTATUSBAR_H

--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.h
@@ -67,6 +67,7 @@ private Q_SLOTS:
     void onRenameRequest(quint64 winId, const QUrl &url);
     void hideSpecificDisks(const QList<QUrl> &hiddenDisks);
     void handleDiskSplitterVisiable();
+    void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 
 Q_SIGNALS:
     void enterPressed(const QModelIndex &index);

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -16,8 +16,8 @@
 #include <dfm-base/utils/systempathutil.h>
 #include <dfm-base/utils/finallyutil.h>
 #include <dfm-base/utils/dialogmanager.h>
-#include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -25,7 +25,6 @@
 
 #include <QGSettings>
 #include <QStandardPaths>
-#include <QStorageInfo>
 #include <QSettings>
 
 using namespace dfmplugin_titlebar;
@@ -137,18 +136,15 @@ QList<CrumbData> TitleBarHelper::crumbSeprateUrl(const QUrl &url)
         CrumbData data { QUrl::fromLocalFile(kHomePath), getDisplayName("Home"), iconName };
         list.append(data);
     } else {
-        QStorageInfo storageInfo(path);
-        if (storageInfo.isValid()) {
-            prefixPath = storageInfo.rootPath();
-            // TODO(zhangs): device info  (ref DFMFileCrumbController::seprateUrl)
+        prefixPath = DeviceUtils::getLongestMountRootPath(path);
+        // TODO(zhangs): device info  (ref DFMFileCrumbController::seprateUrl)
 
-            if (prefixPath == "/") {
-                CrumbData data(UrlRoute::rootUrl(Global::Scheme::kFile), getDisplayName("System Disk"), "drive-harddisk-root-symbolic");
-                list.append(data);
-            } else {
-                CrumbData data(QUrl::fromLocalFile(prefixPath), QString(), iconName);
-                list.append(data);
-            }
+        if (prefixPath == "/") {
+            CrumbData data(UrlRoute::rootUrl(Global::Scheme::kFile), getDisplayName("System Disk"), "drive-harddisk-root-symbolic");
+            list.append(data);
+        } else {
+            CrumbData data(QUrl::fromLocalFile(prefixPath), QString(), iconName);
+            list.append(data);
         }
     }
 


### PR DESCRIPTION
1. 补全计算机页面的状态栏；
2. 避免通过 QStorageInfo 库来获取某个文件所处的挂载根路径；
3. 修复一处内存泄露；


1. implement the status bar in computer view.
2. avoid using QStorageInfo to obtain the mount root of a directory.
3. fix a mem-leak.

Log: add status bar in computer view;

Bug: https://pms.uniontech.com/bug-view-207005.html
