### PR TITLE
fix: [statistics]Inaccurate display of size in folder property box

### DIFF
--- a/src/dfm-base/utils/private/filestatissticsjob_p.h
+++ b/src/dfm-base/utils/private/filestatissticsjob_p.h
@@ -33,6 +33,8 @@ public:
     void statisticDir(const QUrl &url, FTS *fts, const bool singleDepth, FTSENT *ent);
     void statisticFile(FTSENT *ent);
     void statisticSysLink(const QUrl &currentUrl, FTS *fts, FTSENT *ent, const bool singleDepth, const bool followLink);
+    bool checkInode(const FileInfoPointer info);
+    bool checkInode(FTSENT *ent, FTS *fts);
 
     FileStatisticsJob *q;
     QTimer *notifyDataTimer;
@@ -51,6 +53,7 @@ public:
     SizeInfoPointer sizeInfo { nullptr };
     QList<QUrl> fileStatistics;
     QList<QString> skipPath;
+    QList<quint64> inodelist;
     AbstractDirIteratorPointer iterator { nullptr };
     std::atomic_bool iteratorCanStop { false };
 };


### PR DESCRIPTION
Because there are linked files in the counted files, the source file size of the linked files was counted. Resulting in multiple counts of the same file. Modify the size of the statistics folder

Log: Inaccurate display of size in folder property box
Bug: https://pms.uniontech.com/bug-view-205655.html