### PR TITLE
fix: File name splitting on the desktop is not working

### DIFF
--- a/src/dfm-base/utils/elidetextlayout.cpp
+++ b/src/dfm-base/utils/elidetextlayout.cpp
@@ -22,7 +22,7 @@ ElideTextLayout::ElideTextLayout(const QString &text)
     attributes.insert(kFont, document->defaultFont());
     attributes.insert(kLineHeight, QFontMetrics(document->defaultFont()).height());
     attributes.insert(kBackgroundRadius, 0);
-    attributes.insert(kAlignment, Qt::AlignCenter);
+    attributes.insert(kAlignment, Qt::AlignHCenter);
     attributes.insert(kWrapMode, (uint)QTextOption::WrapAtWordBoundaryOrAnywhere);
     attributes.insert(kTextDirection, Qt::LeftToRight);
 }
@@ -48,7 +48,7 @@ QList<QRectF> ElideTextLayout::layout(const QRectF &rect, Qt::TextElideMode elid
     QList<QRectF> ret;
     QTextLayout *lay = document->firstBlock().layout();
     if (!lay) {
-        qWarning() << "invaild block" << text();
+        qWarning() << "invaild block" << document->firstBlock().text();
         return ret;
     }
 
@@ -56,14 +56,12 @@ QList<QRectF> ElideTextLayout::layout(const QRectF &rect, Qt::TextElideMode elid
     int textLineHeight = attribute<int>(kLineHeight);
     QSizeF size = rect.size();
     QPointF offset = rect.topLeft();
-
     qreal curHeight = 0;
 
     // for draw background.
     QRectF lastLineRect;
     QString elideText;
     QString curText = text();
-
     auto processLine = [this, &ret, painter, &lastLineRect, background, textLineHeight, &curText, textLines](QTextLine &line) {
         QRectF lRect = line.naturalTextRect();
         lRect.setTop(lRect.top() - (textLineHeight - line.height()));

--- a/src/plugins/common/dfmplugin-tag/tag.cpp
+++ b/src/plugins/common/dfmplugin-tag/tag.cpp
@@ -145,6 +145,7 @@ void Tag::installToSideBar()
 
 void Tag::followEvents()
 {
+    // todo 优化接口
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Delegate_PaintListItem", TagManager::instance(), &TagManager::paintListTagsHandle);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Delegate_PaintIconItem", TagManager::instance(), &TagManager::paintIconTagsHandle);
 

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -60,9 +60,9 @@ ElideTextLayout *CanvasItemDelegatePrivate::createTextlayout(const QModelIndex &
     QString name = showSuffix ? index.data(Global::ItemRoles::kItemFileDisplayNameRole).toString()
                               : index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString();
     ElideTextLayout *layout = new ElideTextLayout(name);
-    layout->setAttribute(ElideTextLayout::kWrapMode, (uint)QTextOption::WrapAnywhere);
+    layout->setAttribute(ElideTextLayout::kWrapMode, (uint)QTextOption::WrapAtWordBoundaryOrAnywhere);
     layout->setAttribute(ElideTextLayout::kLineHeight, textLineHeight);
-    layout->setAttribute(ElideTextLayout::kAlignment, Qt::AlignCenter);
+    layout->setAttribute(ElideTextLayout::kAlignment, Qt::AlignHCenter);
 
     if (painter) {
         layout->setAttribute(ElideTextLayout::kFont, painter->font());
@@ -386,6 +386,10 @@ QList<QRectF> CanvasItemDelegate::elideTextRect(const QModelIndex &index, const 
 {
     // create text Layout.
     QScopedPointer<ElideTextLayout> layout(d->createTextlayout(index));
+
+    // extend layout
+    // todo 优化接口
+    dpfHookSequence->run("ddplugin_canvas", "hook_CanvasItemDelegate_PaintText", parent()->model()->fileInfo(index), rect, nullptr, layout.data());
 
     // elide mode
     auto textLines = layout->layout(rect, elideMode);

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -64,9 +64,9 @@ ElideTextLayout *CollectionItemDelegatePrivate::createTextlayout(const QModelInd
     QString name = showSuffix ? index.data(Global::ItemRoles::kItemFileDisplayNameRole).toString()
                               : index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString();
     ElideTextLayout *layout = new ElideTextLayout(name);
-    layout->setAttribute(ElideTextLayout::kWrapMode, (uint)QTextOption::WrapAnywhere);
+    layout->setAttribute(ElideTextLayout::kWrapMode, (uint)QTextOption::WrapAtWordBoundaryOrAnywhere);
     layout->setAttribute(ElideTextLayout::kLineHeight, textLineHeight);
-    layout->setAttribute(ElideTextLayout::kAlignment, Qt::AlignCenter);
+    layout->setAttribute(ElideTextLayout::kAlignment, Qt::AlignHCenter);
     if (painter) {
         layout->setAttribute(ElideTextLayout::kFont, painter->font());
         layout->setAttribute(ElideTextLayout::kTextDirection, painter->layoutDirection());
@@ -378,6 +378,8 @@ QList<QRectF> CollectionItemDelegate::elideTextRect(const QModelIndex &index, co
 {
     // create text Layout.
     QScopedPointer<ElideTextLayout> layout(d->createTextlayout(index));
+
+    dpfHookSequence->run("ddplugin_canvas", "hook_CanvasItemDelegate_PaintText", parent()->model()->fileInfo(index), rect, nullptr, layout.data());
 
     // elide mode
     auto textLines = layout->layout(rect, elideMode);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/viewdrawhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/viewdrawhelper.cpp
@@ -147,7 +147,7 @@ void ViewDrawHelper::drawDragText(QPainter *painter, const QModelIndex &index, q
     QString fileName = view->model()->data(index, ItemRoles::kItemFileDisplayNameRole).toString();
     int textLineHeight = view->fontMetrics().height();
     QRectF boundingRect(kDragIconOutline + (dragIconSize - textWidth) / 2, dragIconSize + kDragIconOutline, textWidth, textLineHeight * 2);
-    QTextOption::WrapMode wordWrap(QTextOption::WrapAnywhere);
+    QTextOption::WrapMode wordWrap(QTextOption::WrapAtWordBoundaryOrAnywhere);
     Qt::TextElideMode mode(Qt::ElideLeft);
     int flags = Qt::AlignHCenter;
     QBrush background(view->palette().color(QPalette::ColorGroup::Active, QPalette::ColorRole::Highlight));

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.cpp
@@ -64,7 +64,7 @@ void ExpandedItem::paintEvent(QPaintEvent *)
 
     QString str = delegate->displayFileName(index);
 
-    QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(str, QTextOption::WrapAnywhere,
+    QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(str, QTextOption::WrapAtWordBoundaryOrAnywhere,
                                                                                 pa.fontMetrics().lineSpacing(), Qt::AlignCenter, &pa));
     layout->setAttribute(ElideTextLayout::kBackgroundRadius, kIconModeRectRadius);
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -335,7 +335,7 @@ QString IconItemDelegate::displayFileName(const QModelIndex &index) const
 
 QList<QRectF> IconItemDelegate::calFileNameRect(const QString &name, const QRectF &rect, Qt::TextElideMode elideMode) const
 {
-    QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(name, QTextOption::WrapAnywhere,
+    QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(name, QTextOption::WrapAtWordBoundaryOrAnywhere,
                                                                                 d->textLineHeight, Qt::AlignCenter));
     return layout->layout(rect, elideMode);
 }
@@ -560,7 +560,7 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
 
     //图标拖拽时保持活动色
     auto background = isDragMode ? (opt.palette.brush(QPalette::Normal, QPalette::Highlight)) : QBrush(Qt::NoBrush);
-    QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(displayName, QTextOption::WrapAnywhere,
+    QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(displayName, QTextOption::WrapAtWordBoundaryOrAnywhere,
                                                                                 d->textLineHeight, Qt::AlignCenter, painter));
 
     const FileInfoPointer &info = parent()->parent()->model()->fileInfo(index);


### PR DESCRIPTION
The line break marker was changed to WrapAnywhere when the file name was drawn, which caused the Chinese and English split to fail. Restore to WrapAtWordBoundaryOrAnywhere

relate to:  https://github.com/linuxdeepin/dde-file-manager/pull/761

Log: 
Bug: https://pms.uniontech.com/bug-view-208249.html

Influence: 文管&桌面文件名显示