### PR TITLE
fix: [background] Unable to obtain the correct wallpaper in multi Wor…

### DIFF
--- a/src/plugins/desktop/ddplugin-background/backgroundservice.cpp
+++ b/src/plugins/desktop/ddplugin-background/backgroundservice.cpp
@@ -15,6 +15,7 @@ BackgroundService::BackgroundService(QObject *parent)
     wmInter->setTimeout(200);
     qInfo() << "create com.deepin.wm end";
 
+    currentWorkspaceIndex = getCurrentWorkspaceIndex();
     connect(wmInter, &WMInter::WorkspaceSwitched, this, &BackgroundService::onWorkspaceSwitched);
 }
 
@@ -36,4 +37,21 @@ void BackgroundService::onWorkspaceSwitched(int from, int to)
 QString BackgroundService::getDefaultBackground()
 {
     return QString("/usr/share/backgrounds/default_background.jpg");
+}
+
+int BackgroundService::getCurrentWorkspaceIndex()
+{
+    QString configPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/kwinrc";
+    QSettings settings(configPath, QSettings::IniFormat);
+
+    bool ok = false;
+    int currentIdx = settings.value("Workspace/CurrentDesktop", 1).toInt(&ok);
+    qInfo() << "get currentWorkspaceIndex form config : " << currentIdx;
+
+    if (!ok || currentIdx < 1) {
+        currentIdx = 1;
+        qWarning() << "No CurrentWorkspaceIndex obtained, Check if the configuration file has changed";
+    }
+
+    return currentIdx;
 }

--- a/src/plugins/desktop/ddplugin-background/backgroundservice.h
+++ b/src/plugins/desktop/ddplugin-background/backgroundservice.h
@@ -32,6 +32,7 @@ protected slots:
     void onWorkspaceSwitched(int from, int to);
 
 protected:
+    int getCurrentWorkspaceIndex();
     int currentWorkspaceIndex = 1; // worksapce index is started with 1.
     WMInter *wmInter = nullptr;
 };

--- a/src/plugins/desktop/ddplugin-background/backgroundwm.cpp
+++ b/src/plugins/desktop/ddplugin-background/backgroundwm.cpp
@@ -57,8 +57,8 @@ QString BackgroundWM::getBackgroundFromWm(const QString &screen)
 QString BackgroundWM::getBackgroundFromConfig(const QString &screen)
 {
     QString path;
-    QString homePath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first();
-    QFile wmFile(homePath + "/.config/deepinwmrc");
+    QString configPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first();
+    QFile wmFile(configPath + "/deepinwmrc");
     if (wmFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
 
         // Find the background path based on the workspace and screen name


### PR DESCRIPTION
…kspace after reboot.

Log: When starting the desktop, read the configuration file to obtain the correct workspace.

Bug: https://pms.uniontech.com/bug-view-197559.html