### PR TITLE
fix: [fileinfo]Copying files occasionally causes file management to crash

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -150,7 +150,6 @@ public:
     explicit AsyncFileInfo(const QUrl &url);
     AsyncFileInfo(const QUrl &url, QSharedPointer<DFMIO::DFileInfo> dfileInfo);
     virtual ~AsyncFileInfo() override;
-    virtual bool initQuerier() override;
     virtual bool exists() const override;
     virtual void refresh() override;
     virtual void cacheAttribute(DFMIO::DFileInfo::AttributeID id, const QVariant &value = QVariant()) override;
@@ -182,6 +181,8 @@ public:
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
     QMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
+    void cacheAsyncAttributes();
+    bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);
 };
 }
 typedef QSharedPointer<DFMBASE_NAMESPACE::AsyncFileInfo> DFMAsyncFileInfoPointer;

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -55,7 +55,7 @@ FileInfoPointer LocalDirIteratorPrivate::fileInfo()
     } else {
         info = QSharedPointer<AsyncFileInfo>(new AsyncFileInfo(url, fileinfo));
         info->setExtendedAttributes(ExtInfoType::kFileIsHid, isHidden);
-        info->initQuerier();
+        info.dynamicCast<AsyncFileInfo>()->cacheAsyncAttributes();
     }
 
     auto infoTrans = InfoFactory::transfromInfo<FileInfo>(url.scheme(), info);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1298,7 +1298,6 @@ void FileOperateBaseWorker::determineCountProcessType()
     // 检查目标文件的有效性
     // 判读目标文件的位置（在可移除设备并且不是ext系列的设备上使用读取写入设备大小，
     // 其他都是读取当前线程写入磁盘的数据，如果采用多线程拷贝就自行统计）
-
     if (!targetStorageInfo)
         targetStorageInfo.reset(new StorageInfo(targetUrl.path()));
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -508,14 +508,12 @@ QPair<QUrl, RootInfo::EventType> RootInfo::dequeueEvent()
 // Here, the monitor's url is used to re-complete the current url
 FileInfoPointer RootInfo::fileInfo(const QUrl &url)
 {
-    auto info = InfoFactory::create<FileInfo>(url);
-    if (info) {
-        info->refresh();
+    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+    if (!info.isNull())
         return info;
-    }
 
     if (!watcher)
-        return info;
+        return nullptr;
 
     const QUrl &parentUrl = QUrl::fromPercentEncoding(watcher->url().toString().toUtf8());
     auto path = url.path();


### PR DESCRIPTION
The asynchronous file information query in the file manager is synchronized by the thread opened by the file manager itself, but at this time, a crash occurs when calling dfmio's devicePathFromUrl. Modify the use of Gio's asynchronous query file information interface to query, and cache the current queried file information using asynchronous threads.

Log: Copying files occasionally causes file management to crash
Bug: https://pms.uniontech.com/bug-view-204813.html