### PR TITLE
fix: [workspace]Quickly switch directories, file manager crashes

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -76,7 +76,14 @@ enum ItemRoles {
     kItemFileOriginalPath = Qt::UserRole + 23,
     kItemFileDeletionDate = Qt::UserRole + 24,
     kItemFileRefreshIcon = Qt::UserRole + 25,
-    kItemFileIsAvailable = Qt::UserRole + 26,   // the item gray display and can not select
+    kItemFileIsAvailableRole = Qt::UserRole + 26, // the item gray display and can not select
+    kItemFileIsDirRole = Qt::UserRole + 27,
+    kItemFileIsWritableRole = Qt::UserRole + 28,
+    kItemFileCanRenameRole = Qt::UserRole + 29,
+    kItemFileCanDropRole = Qt::UserRole + 30,
+    kItemFileCanDragRole = Qt::UserRole + 31,
+    kItemFileSizeIntRole = Qt::UserRole + 32,
+    kItemCreateFileInfoRole = Qt::UserRole + 33,
 
     kItemUnknowRole = Qt::UserRole + 999
 };

--- a/include/dfm-base/interfaces/abstractdiriterator.h
+++ b/include/dfm-base/interfaces/abstractdiriterator.h
@@ -7,6 +7,7 @@
 
 #include <dfm-base/dfm_base_global.h>
 #include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/interfaces/sortfileinfo.h>
 
 #include <QDir>
 #include <QDirIterator>
@@ -20,32 +21,6 @@ namespace dfmbase {
 class AbstractDirIterator : public QObject
 {
     Q_OBJECT
-public:
-    struct SortFileInfo
-    {
-        QUrl url;
-        bool isFile { false };
-        bool isDir { false };
-        bool isSymLink { false };
-        bool isHide { false };
-        bool isReadable { false };
-        bool isWriteable { false };
-        bool isExecutable { false };
-        SortFileInfo(const QUrl &url, const bool isFile, const bool isDir, const bool isSymLink, const bool isHide,
-                     const bool isReadable, const bool isWriteable, const bool isExecutable)
-            : url(url),
-              isFile(isFile),
-              isDir(isDir),
-              isSymLink(isSymLink),
-              isHide(isHide),
-              isReadable(isReadable),
-              isWriteable(isWriteable),
-              isExecutable(isExecutable)
-        {
-        }
-        SortFileInfo() {}
-    };
-
 public:
     explicit AbstractDirIterator() = delete;
 
@@ -146,10 +121,6 @@ public:
 
 }
 typedef QSharedPointer<DFMBASE_NAMESPACE::AbstractDirIterator> AbstractDirIteratorPointer;
-typedef QSharedPointer<DFMBASE_NAMESPACE::AbstractDirIterator::SortFileInfo> SortInfoPointer;
-
 Q_DECLARE_METATYPE(AbstractDirIteratorPointer)
-Q_DECLARE_METATYPE(SortInfoPointer)
-Q_DECLARE_METATYPE(QList<SortInfoPointer>)
 
 #endif   // ABSTRACTDIRITERATOR_H

--- a/include/dfm-base/interfaces/sortfileinfo.h
+++ b/include/dfm-base/interfaces/sortfileinfo.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SORTFILEINFO_H
+#define SORTFILEINFO_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QScopedPointer>
+#include <QUrl>
+#include <QSharedPointer>
+
+namespace dfmbase {
+class SortFileInfoPrivate;
+class SortFileInfo
+{
+public:
+    SortFileInfo();
+    ~SortFileInfo();
+
+    void setUrl(const QUrl &url);
+    void setSize(const qint64 size);
+    void setFile(const bool isfile);
+    void setDir(const bool isdir);
+    void setSymlink(const bool isSymlink);
+    void setHide(const bool ishide);
+    void setReadable(const bool readable);
+    void setWriteable(const bool writeable);
+    void setExecutable(const bool executable);
+
+    QUrl fileUrl() const;
+    qint64 fileSize() const;
+    bool isFile() const;
+    bool isDir() const;
+    bool isSymLink() const;
+    bool isHide() const;
+    bool isReadable() const;
+    bool isWriteable() const;
+    bool isExecutable() const;
+
+private:
+    QScopedPointer<SortFileInfoPrivate> d;
+};
+}
+typedef QSharedPointer<DFMBASE_NAMESPACE::SortFileInfo> SortInfoPointer;
+Q_DECLARE_METATYPE(SortInfoPointer)
+Q_DECLARE_METATYPE(QList<SortInfoPointer>)
+
+#endif // SORTFILEINFO_H

--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -497,6 +497,19 @@ bool DeviceUtils::isMountPointOfDlnfs(const QString &path)
     });
 }
 
+bool DeviceUtils::isLowSpeedDevice(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    const QString &path = url.toLocalFile();
+    static const QString lowSpeedMountpoint { "(^/run/user/\\d+/gvfs/|^/root/.gvfs/|^/media/[\\s\\S]*/smbmounts)" };
+    // TODO(xust) /media/$USER/smbmounts might be changed in the future.
+    QRegularExpression re { lowSpeedMountpoint };
+    QRegularExpressionMatch match { re.match(path) };
+    return match.hasMatch();
+}
+
 /*!
  * \brief DeviceUtils::getLongestMountRootPath: get the mount root of a file `filePath`
  * return `/home/` for `/home/helloworld.txt`, eg.

--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -65,6 +65,7 @@ public:
 
     static bool isSubpathOfDlnfs(const QString &path);
     static bool isMountPointOfDlnfs(const QString &path);
+    static bool isLowSpeedDevice(const QUrl &url);
 
     static QString getLongestMountRootPath(const QString &filePath);
 

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -203,15 +203,17 @@ QList<SortInfoPointer> LocalDirIterator::sortFileInfoList()
     auto sortlist = d->dfmioDirIterator->sortFileInfoList();
     QList<SortInfoPointer> wsortlist;
     for (const auto &sortInfo : sortlist) {
-        wsortlist.append(SortInfoPointer(
-                new AbstractDirIterator::SortFileInfo(sortInfo->url,
-                                                      sortInfo->isFile,
-                                                      sortInfo->isDir,
-                                                      sortInfo->isSymLink,
-                                                      sortInfo->isHide,
-                                                      sortInfo->isReadable,
-                                                      sortInfo->isWriteable,
-                                                      sortInfo->isExecutable)));
+        SortInfoPointer tmp(new SortFileInfo);
+        tmp->setUrl(sortInfo->url);
+        tmp->setSize(sortInfo->filesize);
+        tmp->setFile(sortInfo->isFile);
+        tmp->setDir(sortInfo->isDir);
+        tmp->setHide(sortInfo->isHide);
+        tmp->setSymlink(sortInfo->isSymLink);
+        tmp->setReadable(sortInfo->isReadable);
+        tmp->setWriteable(sortInfo->isWriteable);
+        tmp->setExecutable(sortInfo->isExecutable);
+        wsortlist.append(tmp);
     }
     return wsortlist;
 }

--- a/src/dfm-base/interfaces/private/sortfileinfo_p.h
+++ b/src/dfm-base/interfaces/private/sortfileinfo_p.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SORTFILEINFO_P_H
+#define SORTFILEINFO_P_H
+
+#include <dfm-base/interfaces/sortfileinfo.h>
+
+#include <QPointer>
+
+namespace dfmbase {
+class SortFileInfoPrivate
+{
+public:
+    explicit SortFileInfoPrivate(SortFileInfo *qq);
+    ~SortFileInfoPrivate();
+
+public:
+    SortFileInfo *const q;   // SortFileInfo实例对象
+    QUrl url;
+    qint64 filesize { 0 };
+    bool file { false };
+    bool dir { false };
+    bool symLink { false };
+    bool hide { false };
+    bool readable { false };
+    bool writeable { false };
+    bool executable { false };
+};
+
+}
+
+#endif   // SORTFILEINFO_P_H

--- a/src/dfm-base/interfaces/sortfileinfo.cpp
+++ b/src/dfm-base/interfaces/sortfileinfo.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "private/sortfileinfo_p.h"
+
+namespace dfmbase {
+SortFileInfo::SortFileInfo()
+    : d(new SortFileInfoPrivate(this))
+{
+
+}
+
+SortFileInfo::~SortFileInfo()
+{
+
+}
+
+void SortFileInfo::setUrl(const QUrl &url)
+{
+    d->url = url;
+}
+
+void SortFileInfo::setSize(const qint64 size)
+{
+    d->filesize = size;
+}
+
+void SortFileInfo::setFile(const bool isfile)
+{
+    d->file = isfile;
+}
+
+void SortFileInfo::setDir(const bool isdir)
+{
+    d->dir = isdir;
+}
+
+void SortFileInfo::setSymlink(const bool isSymlink)
+{
+    d->symLink = isSymlink;
+}
+
+void SortFileInfo::setHide(const bool ishide)
+{
+    d->hide = ishide;
+}
+
+void SortFileInfo::setReadable(const bool readable)
+{
+    d->readable = readable;
+}
+
+void SortFileInfo::setWriteable(const bool writeable)
+{
+    d->writeable = writeable;
+}
+
+void SortFileInfo::setExecutable(const bool executable)
+{
+    d->executable = executable;
+}
+
+QUrl SortFileInfo::fileUrl() const
+{
+    return d->url;
+}
+
+qint64 SortFileInfo::fileSize() const
+{
+    return d->filesize;
+}
+
+bool SortFileInfo::isFile() const
+{
+    return d->file;
+}
+
+bool SortFileInfo::isDir() const
+{
+    return d->dir;
+}
+
+bool SortFileInfo::isSymLink() const
+{
+    return d->symLink;
+}
+
+bool SortFileInfo::isHide() const
+{
+    return d->hide;
+}
+
+bool SortFileInfo::isReadable() const
+{
+    return d->readable;
+}
+
+bool SortFileInfo::isWriteable() const
+{
+    return d->writeable;
+}
+
+bool SortFileInfo::isExecutable() const
+{
+    return d->executable;
+}
+
+SortFileInfoPrivate::SortFileInfoPrivate(SortFileInfo *qq)
+    : q(qq)
+{
+
+}
+
+SortFileInfoPrivate::~SortFileInfoPrivate()
+{
+
+}
+
+}

--- a/src/dfm-base/mimetype/dmimedatabase.cpp
+++ b/src/dfm-base/mimetype/dmimedatabase.cpp
@@ -6,6 +6,7 @@
 
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/device/deviceutils.h>
 
 #include <QUrl>
 #include <QFileInfo>
@@ -64,7 +65,7 @@ QMimeType DMimeDatabase::mimeTypeForFile(const FileInfoPointer &fileInfo, QMimeD
         }
     }
 
-    if (isMatchExtension || FileUtils::isLowSpeedDevice(QUrl::fromLocalFile(path))) {
+    if (isMatchExtension || DeviceUtils::isLowSpeedDevice(QUrl::fromLocalFile(path))) {
         result = QMimeDatabase::mimeTypeForFile(fileInfo->pathOf(PathInfoType::kFilePath), QMimeDatabase::MatchExtension);
     } else {
         result = QMimeDatabase::mimeTypeForFile(fileInfo->pathOf(PathInfoType::kFilePath), mode);
@@ -134,7 +135,7 @@ QMimeType DMimeDatabase::mimeTypeForFile(const QFileInfo &fileInfo, QMimeDatabas
             isMatchExtension = blackList.contains(filePath);
         }
     }
-    if (isMatchExtension || FileUtils::isLowSpeedDevice(QUrl::fromLocalFile(path))) {
+    if (isMatchExtension || DeviceUtils::isLowSpeedDevice(QUrl::fromLocalFile(path))) {
         result = QMimeDatabase::mimeTypeForFile(fileInfo, QMimeDatabase::MatchExtension);
     } else {
         result = QMimeDatabase::mimeTypeForFile(fileInfo, mode);

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -304,41 +304,6 @@ bool FileUtils::isSameFile(const QUrl &url1, const QUrl &url2, const Global::Cre
     return false;
 }
 
-bool FileUtils::isLowSpeedDevice(const QUrl &url)
-{
-    const QString &path = url.path();
-
-    static QMutex mutex;
-    QMutexLocker lk(&mutex);
-    static QRegularExpression regExp("^/run/user/\\d+/gvfs/(?<scheme>\\w+(-?)\\w+):\\S*",
-                                     QRegularExpression::DotMatchesEverythingOption
-                                             | QRegularExpression::DontCaptureOption
-                                             | QRegularExpression::OptimizeOnFirstUsageOption);
-
-    const QRegularExpressionMatch &match = regExp.match(path, 0, QRegularExpression::NormalMatch,
-                                                        QRegularExpression::DontCheckSubjectStringMatchOption);
-
-    if (match.hasMatch()) {
-        const QString &scheme = match.captured("scheme");
-        static QStringList schemeList = { QString(Global::Scheme::kMtp),
-                                          QString(Global::Scheme::kGPhoto),
-                                          QString(Global::Scheme::kGPhoto2),
-                                          QString(Global::Scheme::kSmb),
-                                          QString(Global::Scheme::kSmbShare),
-                                          QString(Global::Scheme::kFtp),
-                                          QString(Global::Scheme::kSFtp) };
-        return schemeList.contains(scheme);
-    }
-
-    const QString &device = dfmio::DFMUtils::devicePathFromUrl(url);
-
-    return device.startsWith(QString(Global::Scheme::kMtp) + "://")
-            || device.startsWith(QString(Global::Scheme::kGPhoto) + "://")
-            || device.startsWith(QString(Global::Scheme::kGPhoto2) + "://")
-            || device.startsWith(QString(Global::Scheme::kSmbShare) + "://")
-            || device.startsWith(QString(Global::Scheme::kSmb) + "://");
-}
-
 bool FileUtils::isLocalDevice(const QUrl &url)
 {
     //return !DFMIO::DFMUtils::fileIsRemovable(url) && !isGvfsFile(url);

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -41,7 +41,6 @@ public:
     static bool isSameDevice(const QUrl &url1, const QUrl &url2);
     static bool isSameFile(const QUrl &url1, const QUrl &url2,
                            const Global::CreateFileInfoType infoCache = Global::CreateFileInfoType::kCreateFileInfoAuto);
-    static bool isLowSpeedDevice(const QUrl &url);
     static bool isLocalDevice(const QUrl &url);
     static bool isCdRomDevice(const QUrl &url);
     static bool trashIsEmpty();

--- a/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.cpp
+++ b/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.cpp
@@ -40,6 +40,36 @@ void BasicStatusBar::clearLayoutAndAnchors()
     DAnchorsBase::clearAnchors(this);
 }
 
+void BasicStatusBar::itemSelected(const int selectFiles, const int selectFolders, const qint64 filesize, const QList<QUrl> &selectFolderList)
+{
+    if (!d->tip)
+        return;
+
+    d->fileCount = selectFiles;
+    d->fileSize = filesize;
+    d->folderCount = selectFolders;
+    d->folderContains = 0;
+    d->showContains = true;
+
+    const bool dirUrlsEmpty = selectFolderList.isEmpty();
+    if (!dirUrlsEmpty) {
+        // check mtp setting
+        const bool showInfo = Application::instance()->genericAttribute(Application::GenericAttribute::kMTPShowBottomInfo).toBool();
+        if (!showInfo) {
+            bool isMtp = FileUtils::isMtpFile(selectFolderList.first());
+            if (isMtp) {
+                d->showContains = false;
+            } else {
+                d->calcFolderContains(selectFolderList);
+            }
+        } else {
+            d->calcFolderContains(selectFolderList);
+        }
+    }
+
+    updateStatusMessage();
+}
+
 void BasicStatusBar::itemSelected(const QList<FileInfo *> &infoList)
 {
     if (!d->tip)
@@ -49,32 +79,32 @@ void BasicStatusBar::itemSelected(const QList<FileInfo *> &infoList)
     d->fileSize = 0;
     d->folderCount = 0;
     d->folderContains = 0;
+    d->showContains = true;
 
-    QList<QUrl> dirUrlList;
+    QList<QUrl> selectFolderList;
     for (const FileInfo *info : infoList) {
         if (info->isAttributes(OptInfoType::kIsDir)) {
             d->folderCount += 1;
-            dirUrlList << info->urlOf(UrlInfoType::kUrl);
+            selectFolderList << info->urlOf(UrlInfoType::kUrl);
         } else {
             d->fileCount += 1;
             d->fileSize += info->size();
         }
     }
 
-    d->showContains = true;
-    const bool dirUrlsEmpty = dirUrlList.isEmpty();
+    const bool dirUrlsEmpty = selectFolderList.isEmpty();
     if (!dirUrlsEmpty) {
         // check mtp setting
         const bool showInfo = Application::instance()->genericAttribute(Application::GenericAttribute::kMTPShowBottomInfo).toBool();
         if (!showInfo) {
-            bool isMtp = FileUtils::isMtpFile(dirUrlList.first());
+            bool isMtp = FileUtils::isMtpFile(selectFolderList.first());
             if (isMtp) {
                 d->showContains = false;
             } else {
-                d->calcFolderContains(dirUrlList);
+                d->calcFolderContains(selectFolderList);
             }
         } else {
-            d->calcFolderContains(dirUrlList);
+            d->calcFolderContains(selectFolderList);
         }
     }
 

--- a/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.h
+++ b/src/dfm-base/widgets/dfmstatusbar/basicstatusbar.h
@@ -6,6 +6,7 @@
 #define BASICSTATUSBAR_H
 
 #include <dfm-base/dfm_base_global.h>
+#include <dfm-base/interfaces/fileinfo.h>
 
 #include <QFrame>
 
@@ -22,6 +23,7 @@ public:
     virtual QSize sizeHint() const override;
     virtual void clearLayoutAndAnchors();
 
+    void itemSelected(const int selectFiles, const int selectFolders, const qint64 filesize, const QList<QUrl> &selectFolderList);
     void itemSelected(const QList<FileInfo *> &infoList);
     void itemCounted(const int count);
 

--- a/src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
@@ -167,7 +167,7 @@ void DumpISOOptDialog::onPathChanged(const QString &path)
 {
     const QUrl &url { UrlRoute::fromUserInput(path) };
     if (url.isEmpty() || !url.isValid() || !dfmbase::FileUtils::isLocalFile(url)
-        || FileUtils::isLowSpeedDevice(url) || DeviceUtils::isSamba(url)) {
+        || DeviceUtils::isLowSpeedDevice(url) || DeviceUtils::isSamba(url)) {
         qWarning() << "Path:" << path << "is prohibited";
         createImgBtn->setEnabled(false);
         return;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
@@ -23,7 +23,7 @@ FileItemData::FileItemData(const QUrl &url, const FileInfoPointer &info, FileIte
 
 FileItemData::FileItemData(const SortInfoPointer &info, FileItemData *parent)
     : parent(parent),
-      url(info->url),
+      url(info->fileUrl()),
       sortInfo(info)
 {
 }
@@ -46,8 +46,6 @@ void FileItemData::refreshInfo()
 
 FileInfoPointer FileItemData::fileInfo() const
 {
-    if (!info)
-        const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url);
     return info;
 }
 
@@ -58,53 +56,85 @@ FileItemData *FileItemData::parentData() const
 
 QVariant FileItemData::data(int role) const
 {
-    if (!info)
-        const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url);
-
-    if (info.isNull())
-        return QVariant();
-
-    auto val = info->customData(role);
-    if (val.isValid())
-        return val;
+    if (info) {
+        auto val = info->customData(role);
+        if (val.isValid())
+            return val;
+    }
 
     switch (role) {
+    case kItemCreateFileInfoRole:
+        assert(qApp->thread() == QThread::currentThread());
+        if (info.isNull())
+            const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url);
+        return QVariant();
     case kItemFilePathRole:
-        return info->displayOf(DisPlayInfoType::kFileDisplayPath);
+        if (info)
+            return info->displayOf(DisPlayInfoType::kFileDisplayPath);
+        return url.path();
     case kItemFileLastModifiedRole: {
-        auto lastModified = info->timeOf(TimeInfoType::kLastModified).value<QDateTime>();
-        return lastModified.isValid() ? lastModified.toString(FileUtils::dateTimeFormat()) : "-";
+        if (info) {
+            auto lastModified = info->timeOf(TimeInfoType::kLastModified).value<QDateTime>();
+            return lastModified.isValid() ? lastModified.toString(FileUtils::dateTimeFormat()) : "-";
+        }
+        return "-";
     }
     case kItemIconRole:
-        return info->fileIcon();
+        if (info)
+            return info->fileIcon();
+        return QIcon::fromTheme("unknown");
     case kItemFileSizeRole:
-        return info->displayOf(DisPlayInfoType::kSizeDisplayName);
+        if (info)
+            return info->displayOf(DisPlayInfoType::kSizeDisplayName);
+        return "-";
     case kItemFileMimeTypeRole:
-        return info->displayOf(DisPlayInfoType::kMimeTypeDisplayName);
+        if (info)
+            return info->displayOf(DisPlayInfoType::kMimeTypeDisplayName);
+        return QString();
     case kItemSizeHintRole:
         return QSize(-1, 26);
     case kItemNameRole:
-        return info->nameOf(NameInfoType::kFileName);
+        if (info)
+            return info->nameOf(NameInfoType::kFileName);
+        return url.fileName();
     case Qt::DisplayRole:
     case kItemEditRole:
     case kItemFileDisplayNameRole:
-        return info->displayOf(DisPlayInfoType::kFileDisplayName);
+        if (info)
+            return info->displayOf(DisPlayInfoType::kFileDisplayName);
+        return url.fileName();
     case kItemFileLastReadRole:
-        return info->customData(dfmbase::Global::kItemFileLastReadRole);
+        if (info)
+            return info->customData(dfmbase::Global::kItemFileLastReadRole);
+        return QString();
     case kItemFilePinyinNameRole:
-        return info->displayOf(DisPlayInfoType::kFileDisplayPinyinName);
+        if (info)
+            return info->displayOf(DisPlayInfoType::kFileDisplayPinyinName);
+        return url.fileName();
     case kItemFileBaseNameRole:
-        return info->nameOf(NameInfoType::kCompleteBaseName);
+        if (info)
+            return info->nameOf(NameInfoType::kCompleteBaseName);
+        return url.fileName();
     case kItemFileSuffixRole:
-        return info->nameOf(NameInfoType::kSuffix);
+        if (info)
+            return info->nameOf(NameInfoType::kSuffix);
+        return url.fileName();
     case kItemFileNameOfRenameRole:
-        return info->nameOf(NameInfoType::kFileNameOfRename);
+        if (info)
+            return info->nameOf(NameInfoType::kFileNameOfRename);
+        return url.fileName();
     case kItemFileBaseNameOfRenameRole:
-        return info->nameOf(NameInfoType::kBaseNameOfRename);
+        if (info)
+            return info->nameOf(NameInfoType::kBaseNameOfRename);
+        return url.fileName();
     case kItemFileSuffixOfRenameRole:
-        return info->nameOf(NameInfoType::kSuffixOfRename);
+        if (info)
+            return info->nameOf(NameInfoType::kSuffixOfRename);
+        return url.fileName();
     case kItemUrlRole:
-        return info->urlOf(UrlInfoType::kUrl);
+        if (info)
+            return info->urlOf(UrlInfoType::kUrl);
+        return url;
     case Qt::TextAlignmentRole:
         return Qt::AlignVCenter;
     case kItemFileIconModelToolTipRole: {
@@ -115,11 +145,40 @@ QVariant FileItemData::data(int role) const
         const QString stdDataDownPath = FileUtils::bindPathTransform(stdDownPath, true);
         if (filePath == stdDocPath || filePath == stdDownPath || filePath == stdDataDocPath || filePath == stdDataDownPath)
             return QString();
-
         QString strToolTip = data(kItemFileDisplayNameRole).toString();
         return strToolTip;
     }
-    case kItemFileIsAvailable:
+    case kItemFileIsWritableRole:
+        if (info)
+            return info->isAttributes(OptInfoType::kIsWritable);
+        if (sortInfo)
+            return sortInfo->isWriteable();
+        return true;
+    case kItemFileIsDirRole:
+        if (info)
+            return info->isAttributes(OptInfoType::kIsDir);
+        if (sortInfo)
+            return sortInfo->isDir();
+        return true;
+    case kItemFileCanRenameRole:
+        if (info)
+            return info->canAttributes(CanableInfoType::kCanRename);
+        return true;
+    case kItemFileCanDropRole:
+        if (info)
+            return info->canAttributes(CanableInfoType::kCanDrop);
+        return true;
+    case kItemFileCanDragRole:
+        if (info)
+            return info->canAttributes(CanableInfoType::kCanDrag);
+        return true;
+    case kItemFileSizeIntRole:
+        if (info)
+            return info->size();
+        if (sortInfo)
+            return sortInfo->fileSize();
+        return 0;
+    case kItemFileIsAvailableRole:
         return isAvailable;
     default:
         return QVariant();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -373,7 +373,7 @@ void RootInfo::addChildren(const QList<SortInfoPointer> &children)
             continue;
 
         QWriteLocker lk(&childrenLock);
-        childrenUrlList.append(file->url);
+        childrenUrlList.append(file->fileUrl());
         sourceDataList.append(file);
     }
 }
@@ -407,15 +407,16 @@ SortInfoPointer RootInfo::sortFileInfo(const FileInfoPointer &info)
 {
     if (!info)
         return nullptr;
-    SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
-    sortInfo->url = info->urlOf(UrlInfoType::kUrl);
-    sortInfo->isDir = info->isAttributes(OptInfoType::kIsDir);
-    sortInfo->isFile = !info->isAttributes(OptInfoType::kIsDir);
-    sortInfo->isHide = info->isAttributes(OptInfoType::kIsHidden);
-    sortInfo->isSymLink = info->isAttributes(OptInfoType::kIsHidden);
-    sortInfo->isReadable = info->isAttributes(OptInfoType::kIsReadable);
-    sortInfo->isWriteable = info->isAttributes(OptInfoType::kIsWritable);
-    sortInfo->isExecutable = info->isAttributes(OptInfoType::kIsExecutable);
+    SortInfoPointer sortInfo(new SortFileInfo);
+    sortInfo->setUrl(info->urlOf(UrlInfoType::kUrl));
+    sortInfo->setSize(info->size());
+    sortInfo->setFile(info->isAttributes(OptInfoType::kIsDir));
+    sortInfo->setDir(!info->isAttributes(OptInfoType::kIsDir));
+    sortInfo->setHide(info->isAttributes(OptInfoType::kIsHidden));
+    sortInfo->setSymlink(info->isAttributes(OptInfoType::kIsHidden));
+    sortInfo->setReadable(info->isAttributes(OptInfoType::kIsReadable));
+    sortInfo->setWriteable(info->isAttributes(OptInfoType::kIsWritable));
+    sortInfo->setExecutable(info->isAttributes(OptInfoType::kIsExecutable));
     return sortInfo;
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -210,7 +210,11 @@ bool DragDropHelper::drop(QDropEvent *event)
         if (!hoverIndex.isValid()) {
             hoverIndex = view->rootIndex();
         } else {
-            const FileInfoPointer &fileInfo = view->model()->fileInfo(hoverIndex);
+            FileInfoPointer fileInfo = view->model()->fileInfo(hoverIndex);
+            if (fileInfo.isNull())
+                hoverIndex.data(Global::ItemRoles::kItemCreateFileInfoRole);
+            fileInfo = view->model()->fileInfo(hoverIndex);
+
             if (fileInfo) {
                 bool isDrop = dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_IsDrop", fileInfo->urlOf(UrlInfoType::kUrl));
                 // NOTE: if item can not drop, the drag item will drop to root dir.

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -90,6 +90,9 @@ void IconItemDelegate::paint(QPainter *painter,
 
     Q_D(const IconItemDelegate);
 
+    if (index.isValid())
+        index.data(Global::ItemRoles::kItemCreateFileInfoRole);
+
     if (index == d->expandedIndex && !parent()->isSelected(index))
         const_cast<IconItemDelegate *>(this)->hideNotEditingIndexWidget();
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -58,6 +58,10 @@ void ListItemDelegate::paint(QPainter *painter,
                              const QModelIndex &index) const
 {
     QStyleOptionViewItem opt = option;
+
+    if (index.isValid())
+        index.data(Global::ItemRoles::kItemCreateFileInfoRole);
+
     initStyleOption(&opt, index);
     painter->setFont(opt.font);
 

--- a/tests/dfm-base/file/local/ut_localfilediriterator.cpp
+++ b/tests/dfm-base/file/local/ut_localfilediriterator.cpp
@@ -60,7 +60,7 @@ TEST_F(UT_LocalFileDirIterator, testLocalFileIterator)
     iterator->setArguments(args);
     auto infolist = iterator->sortFileInfoList();
     EXPECT_EQ(1, infolist.count());
-    EXPECT_EQ(fileUrl, infolist.first()->url);
+    EXPECT_EQ(fileUrl, infolist.first()->fileUrl());
     iterator->close();
     iterator->deleteLater();
 

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -129,7 +129,7 @@ TEST_F(UT_RootInfo, StartWork)
     rootInfoObj->startWork(key, true);
     EXPECT_FALSE(calledGetSourceData);
 
-    rootInfoObj->sourceDataList.append(SortInfoPointer(new AbstractDirIterator::SortFileInfo()));
+    rootInfoObj->sourceDataList.append(SortInfoPointer(new SortFileInfo()));
     rootInfoObj->startWork(key, true);
     EXPECT_TRUE(calledGetSourceData);
 
@@ -189,7 +189,7 @@ TEST_F(UT_RootInfo, Reset)
     rootInfoObj->traversalFinish = true;
     rootInfoObj->childrenUrlList.append(
             QUrl(QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first()));
-    rootInfoObj->sourceDataList.append(SortInfoPointer(new AbstractDirIterator::SortFileInfo()));
+    rootInfoObj->sourceDataList.append(SortInfoPointer(new SortFileInfo()));
 
     rootInfoObj->reset();
 
@@ -359,7 +359,7 @@ TEST_F(UT_RootInfo, HandleTraversalResult)
     stub.set_lamda(ADDR(RootInfo, addChild),
                    [&calledAddChild](RootInfo *, const FileInfoPointer &) {
                        calledAddChild = true;
-                       SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
+                       SortInfoPointer sortInfo(new SortFileInfo);
                        return sortInfo;
                    });
 
@@ -384,7 +384,7 @@ TEST_F(UT_RootInfo, HandleTraversalResults)
     stub.set_lamda(ADDR(RootInfo, addChild),
                    [&calledAddChild](RootInfo *, const FileInfoPointer &) {
                        calledAddChild = true;
-                       SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
+                       SortInfoPointer sortInfo(new SortFileInfo);
                        return sortInfo;
                    });
 
@@ -416,7 +416,7 @@ TEST_F(UT_RootInfo, HandleTraversalLocalResult)
     QObject::connect(rootInfoObj, &RootInfo::iteratorLocalFiles, rootInfoObj,
                      [&sendIteratorLocalFiles] { sendIteratorLocalFiles = true; });
 
-    SortInfoPointer info(new AbstractDirIterator::SortFileInfo);
+    SortInfoPointer info(new SortFileInfo);
     rootInfoObj->handleTraversalLocalResult({ info }, sortRole, sortOrder, mixDirAndFile, "");
 
     EXPECT_FALSE(addedChildren.isEmpty());
@@ -481,8 +481,8 @@ TEST_F(UT_RootInfo, AddChildrenWithUrls)
             [&addedFiles](QList<SortInfoPointer> children) { addedFiles.append(children); });
 
     stub.set_lamda(ADDR(RootInfo, addChild), [](RootInfo *, const FileInfoPointer &info) {
-        SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
-        sortInfo->url = info->urlOf(UrlInfoType::kUrl);
+        SortInfoPointer sortInfo(new SortFileInfo);
+        sortInfo->setUrl(info->urlOf(UrlInfoType::kUrl));
         return sortInfo;
     });
 
@@ -490,9 +490,9 @@ TEST_F(UT_RootInfo, AddChildrenWithUrls)
 
     EXPECT_EQ(addedFiles.length(), 3);
     if (addedFiles.length() == 3) {
-        EXPECT_EQ(addedFiles.at(0)->url, url1);
-        EXPECT_EQ(addedFiles.at(1)->url, url2);
-        EXPECT_EQ(addedFiles.at(2)->url, url3);
+        EXPECT_EQ(addedFiles.at(0)->fileUrl(), url1);
+        EXPECT_EQ(addedFiles.at(1)->fileUrl(), url2);
+        EXPECT_EQ(addedFiles.at(2)->fileUrl(), url3);
     }
 }
 
@@ -514,7 +514,7 @@ TEST_F(UT_RootInfo, AddChildrenWithFileInfos)
     stub.set_lamda(ADDR(RootInfo, addChild),
                    [&addedFiles](RootInfo *, const FileInfoPointer &info) {
                        addedFiles.append(info->urlOf(UrlInfoType::kUrl));
-                       SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo);
+                       SortInfoPointer sortInfo(new SortFileInfo);
                        return sortInfo;
                    });
 
@@ -531,14 +531,14 @@ TEST_F(UT_RootInfo, AddChildrenWithFileInfos)
 TEST_F(UT_RootInfo, AddChildrenWithSortInfos)
 {
     QUrl url1(QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation).first());
-    SortInfoPointer sortInfo1(new AbstractDirIterator::SortFileInfo);
-    sortInfo1->url = url1;
+    SortInfoPointer sortInfo1(new SortFileInfo);
+    sortInfo1->setUrl(url1);
     QUrl url2(QStandardPaths::standardLocations(QStandardPaths::DownloadLocation).first());
-    SortInfoPointer sortInfo2(new AbstractDirIterator::SortFileInfo);
-    sortInfo2->url = url2;
+    SortInfoPointer sortInfo2(new SortFileInfo);
+    sortInfo2->setUrl(url2);
     QUrl url3(QStandardPaths::standardLocations(QStandardPaths::DesktopLocation).first());
-    SortInfoPointer sortInfo3(new AbstractDirIterator::SortFileInfo);
-    sortInfo3->url = url3;
+    SortInfoPointer sortInfo3(new SortFileInfo);
+    sortInfo3->setUrl(url3);
 
     QList<SortInfoPointer> infos{ sortInfo1, sortInfo2, sortInfo3 };
 
@@ -554,9 +554,9 @@ TEST_F(UT_RootInfo, AddChildrenWithSortInfos)
     }
 
     if (rootInfoObj->sourceDataList.length() == 3) {
-        EXPECT_EQ(rootInfoObj->sourceDataList.at(0)->url, url1);
-        EXPECT_EQ(rootInfoObj->sourceDataList.at(1)->url, url2);
-        EXPECT_EQ(rootInfoObj->sourceDataList.at(2)->url, url3);
+        EXPECT_EQ(rootInfoObj->sourceDataList.at(0)->fileUrl(), url1);
+        EXPECT_EQ(rootInfoObj->sourceDataList.at(1)->fileUrl(), url2);
+        EXPECT_EQ(rootInfoObj->sourceDataList.at(2)->fileUrl(), url3);
     }
 }
 

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/utils/ut_filesortworker.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/utils/ut_filesortworker.cpp
@@ -60,7 +60,12 @@ TEST_F(UT_FileSortWorker, Bug_199473_handleUpdateFile)
     });
 
     worker->childrenUrlList.append(updateFile);
-    SortInfoPointer sortInfo(new AbstractDirIterator::SortFileInfo(updateFile, false, true, false, false, true, true, true));
+    SortInfoPointer sortInfo(new SortFileInfo());
+    sortInfo->setUrl(updateFile);
+    sortInfo->setDir(true);
+    sortInfo->setReadable(true);
+    sortInfo->setWriteable(true);
+    sortInfo->setExecutable(true);
     worker->children.append(sortInfo);
 
     worker->handleUpdateFile(updateFile);


### PR DESCRIPTION
Here, the sorting thread called fileitemdata's fileinfo to obtain the mimetype of the file, and the main thread may also have called fileinfo creation at the same time, causing fileinfo to be destructed and causing a crash. Modify the fileinfo in fileitemdata to obtain and not create it. The fileinfo of the specified item in the data is created on the main thread.

Log: Quickly switch directories, file manager crashes