### PR TITLE
fix: [UI] The search icon in the search bar is too small

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
@@ -504,7 +504,7 @@ void AddressBarPrivate::onCompletionHighlighted(const QString &highlightedComple
 void AddressBarPrivate::updateIndicatorIcon()
 {
     QIcon indicatorIcon;
-    QString scope = indicatorType == AddressBar::IndicatorType::Search ? "search_action" : "go-right";
+    QString scope = indicatorType == AddressBar::IndicatorType::Search ? "search_indicator" : "go-right";
     indicatorIcon = QIcon::fromTheme(scope);
     indicatorAction.setIcon(indicatorIcon);
 }


### PR DESCRIPTION
Replace search_action with search_indicator

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-209411.html
