### PR TITLE
fix: [io/thumbnail]Thumbnail display error

### DIFF
--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -264,7 +264,7 @@ public:
 
 protected:
     explicit FileInfo(const QUrl &url);
-    QMap<FileInfo::FileExtendedInfoType, QVariant> extendOtherCache;
+    mutable QMap<FileInfo::FileExtendedInfoType, QVariant> extendOtherCache;
     QString pinyinName;
 
 private:

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -466,6 +466,19 @@ QVariant AsyncFileInfo::customAttribute(const char *key, const DFileInfo::DFileA
     return QVariant();
 }
 
+QVariant AsyncFileInfo::customData(int role) const
+{
+    using namespace dfmbase::Global;
+    if (role == kItemFileRefreshIcon) {
+        extendOtherCache.remove(ExtInfoType::kFileThumbnail);
+        QWriteLocker locker(&d->iconLock);
+        d->fileIcon = QIcon();
+        return QVariant();
+    }
+
+    return FileInfo::customData(role);
+}
+
 QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> AsyncFileInfo::mediaInfoAttributes(DFileInfo::MediaType type, QList<DFileInfo::AttributeExtendID> ids) const
 {
     return d->mediaInfo(type, ids);
@@ -490,7 +503,7 @@ void AsyncFileInfo::setExtendedAttributes(const FileExtendedInfoType &key, const
     }
 }
 
-QMap<QUrl, QString> AsyncFileInfo::notifyUrls() const
+QMultiMap<QUrl, QString> AsyncFileInfo::notifyUrls() const
 {
     QReadLocker lk(&const_cast<AsyncFileInfoPrivate *>(d.data())->notifyLock);
     return d->notifyUrls;
@@ -505,8 +518,11 @@ void AsyncFileInfo::setNotifyUrl(const QUrl &url, const QString &infoPtr)
         return;
     }
     QWriteLocker lk(&d->notifyLock);
-    if (!d->notifyUrls.contains(url))
+    if (!d->notifyUrls.contains(url)) {
         d->notifyUrls.insert(url, infoPtr);
+    } else if (d->notifyUrls.values(url).contains(infoPtr)){
+        d->notifyUrls.insert(url, infoPtr);
+    }
 }
 
 void AsyncFileInfo::cacheAsyncAttributes()
@@ -1015,7 +1031,7 @@ void AsyncFileInfoPrivate::cacheAllAttributes()
         FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(symlink));
         auto asyncInfo = info.dynamicCast<AsyncFileInfo>();
         if (asyncInfo) {
-            asyncInfo->setNotifyUrl(q->fileUrl(), QString::number(quintptr(this), 16));
+            asyncInfo->setNotifyUrl(q->fileUrl(), QString::number(quintptr(q), 16));
             auto notifyUrls = q->notifyUrls();
             for (const auto &url : notifyUrls.keys()) {
                 asyncInfo->setNotifyUrl(url, notifyUrls.value(url));

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -174,11 +174,12 @@ public:
     virtual QString viewOfTip(const ViewType type) const override;
     // emblems
     virtual QVariant customAttribute(const char *key, const DFMIO::DFileInfo::DFileAttributeType type) override;
+    QVariant customData(int role) const override;
     // media info
     virtual QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(DFMIO::DFileInfo::MediaType type, QList<DFMIO::DFileInfo::AttributeExtendID> ids) const override;
     // cache attribute
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
-    QMap<QUrl, QString> notifyUrls() const;
+    QMultiMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
     void cacheAsyncAttributes();
     bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -47,7 +47,7 @@ public:
     InfoHelperUeserDataPointer fileMimeTypeFuture { nullptr };
     QMap<AsyncFileInfo::AsyncAttributeID, QVariant> cacheAsyncAttributes;
     QReadWriteLock notifyLock;
-    QMap<QUrl, QString> notifyUrls;
+    QMultiMap<QUrl, QString> notifyUrls;
     AsyncFileInfo *const q;
 
 public:

--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -51,7 +51,8 @@ void FileInfoHelper::threadHandleDfmFileInfo(const QSharedPointer<FileInfo> dfil
 
     auto notifyUrls = asyncInfo->notifyUrls();
     for (const auto &url : notifyUrls.keys()) {
-        emit fileRefreshFinished(url, notifyUrls.value(url), true);
+        for (const auto &strToken : notifyUrls.values(url))
+            emit fileRefreshFinished(url, strToken, true);
     }
 
     qureingInfo.removeOneByLock(asyncInfo);


### PR DESCRIPTION
The source file of the linked file is a remote file, displaying a thumbnail error. When obtaining the file's properties in the thumbnail helper class, the default was returned (the asynchronous file information query at this time has not been completed). When the asynchronous file information acquisition is completed, refresh the thumbnail flag in fileinfo.

Log: Thumbnail display error