### PR TITLE
fix: double clicking right button shows blankspace menu

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.cpp
@@ -330,11 +330,16 @@ void CanvasView::contextMenuEvent(QContextMenuEvent *event)
     itemDelegate()->revertAndcloseEditor();
 
     const QModelIndex &index = indexAt(event->pos());
+    bool isEmptyArea = !index.isValid();
     Qt::ItemFlags flags;
 
-    if (d->isEmptyArea(event->pos())) {
+    if (isEmptyArea) {
         d->menuProxy->showEmptyAreaMenu(flags, gridPos);
     } else {
+        // menu focus is on the index that is not selected
+        if (!selectionModel()->isSelected(index))
+            selectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
+
         flags = model()->flags(index);
         d->menuProxy->showNormalMenu(index, flags, gridPos);
     }
@@ -880,18 +885,6 @@ bool CanvasViewPrivate::itemGridpos(const QString &item, QPoint &gridPos) const
     }
 
     return false;
-}
-
-bool CanvasViewPrivate::isEmptyArea(const QPoint &pos) const
-{
-    const QModelIndex &index = q->indexAt(pos);
-    if (index.isValid() && q->selectionModel()->isSelected(index)) {
-        qDebug() << "not empty:" << pos << index.data().toString();
-        return false;
-    }
-    // todo(wangcl) expand item geometry,and so on
-
-    return true;
 }
 
 bool CanvasViewPrivate::isWaterMaskOn()

--- a/src/plugins/desktop/core/ddplugin-canvas/view/canvasview_p.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/canvasview_p.h
@@ -58,7 +58,6 @@ public:
     QRect visualRect(const QPoint &gridPos) const;
     QString visualItem(const QPoint &gridPos) const;
     bool itemGridpos(const QString &item, QPoint &gridPos) const;
-    bool isEmptyArea(const QPoint &pos) const;
     bool isWaterMaskOn();
 public:
     QModelIndex findIndex(const QString &key, bool matchStart, const QModelIndex &current, bool reverseOrder, bool excludeCurrent) const;


### PR DESCRIPTION
poping a menu on a desktop item, then double clicking right button on anther item,  a new menu will poped as blankspace menu.
select the item that is not selected and menu pop on on force to solve this issue.

Log: 

Bug: https://pms.uniontech.com/bug-view-210287.html
Influence: 桌面菜单