### PR TITLE
fix: [io/thumbnail]Thumbnail display error

### DIFF
--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -264,7 +264,7 @@ public:
 
 protected:
     explicit FileInfo(const QUrl &url);
-    QMap<FileInfo::FileExtendedInfoType, QVariant> extendOtherCache;
+    mutable QMap<FileInfo::FileExtendedInfoType, QVariant> extendOtherCache;
     QString pinyinName;
 
 private:

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -174,11 +174,12 @@ public:
     virtual QString viewOfTip(const ViewType type) const override;
     // emblems
     virtual QVariant customAttribute(const char *key, const DFMIO::DFileInfo::DFileAttributeType type) override;
+    QVariant customData(int role) const override;
     // media info
     virtual QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(DFMIO::DFileInfo::MediaType type, QList<DFMIO::DFileInfo::AttributeExtendID> ids) const override;
     // cache attribute
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
-    QMap<QUrl, QString> notifyUrls() const;
+    QMultiMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
     void cacheAsyncAttributes();
     bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -47,7 +47,7 @@ public:
     InfoHelperUeserDataPointer fileMimeTypeFuture { nullptr };
     QMap<AsyncFileInfo::AsyncAttributeID, QVariant> cacheAsyncAttributes;
     QReadWriteLock notifyLock;
-    QMap<QUrl, QString> notifyUrls;
+    QMultiMap<QUrl, QString> notifyUrls;
     AsyncFileInfo *const q;
 
 public:

--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -50,7 +50,8 @@ void FileInfoHelper::threadHandleDfmFileInfo(const QSharedPointer<FileInfo> dfil
 
     auto notifyUrls = asyncInfo->notifyUrls();
     for (const auto &url : notifyUrls.keys()) {
-        emit fileRefreshFinished(url, notifyUrls.value(url), true);
+        for (const auto &strToken : notifyUrls.values(url))
+            emit fileRefreshFinished(url, strToken, true);
     }
 
     qureingInfo.removeOneByLock(asyncInfo);


### PR DESCRIPTION
The source file of the linked file is a remote file, displaying a thumbnail error. When obtaining the file's properties in the thumbnail helper class, the default was returned (the asynchronous file information query at this time has not been completed). When the asynchronous file information acquisition is completed, refresh the thumbnail flag in fileinfo.

Log: Thumbnail display error