### PR TITLE
fix: [sidebar] drag item by sperator item

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -408,6 +408,13 @@ void SideBarView::dropEvent(QDropEvent *event)
     }
 }
 
+void SideBarView::startDrag(Qt::DropActions supportedActions)
+{
+    if (!d->draggedUrl.isValid())
+        return;
+    DTreeView::startDrag(supportedActions);
+}
+
 QModelIndex SideBarView::indexAt(const QPoint &p) const
 {
     return QTreeView::indexAt(p);

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -43,6 +43,8 @@ protected:
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dragLeaveEvent(QDragLeaveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+    void startDrag(Qt::DropActions supportedActions) override;
+
     bool onDropData(QList<QUrl> srcUrls, QUrl dstUrl, Qt::DropAction action) const;
     Qt::DropAction canDropMimeData(SideBarItem *item, const QMimeData *data, Qt::DropActions actions) const;
     bool isAccepteDragEvent(QDropEvent *event);


### PR DESCRIPTION
Prohibit drag and drop if clicked item isn't `ItemIsDragEnabled'

Log: fix sideabr bug

Bug: https://pms.uniontech.com/bug-view-210333.html