### PR TITLE
fix: [property-dialog] the thumbnail image not show.

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.h
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.h
@@ -58,6 +58,7 @@ private:
     void createBasicWidget(const QUrl &url);
     void createPermissionManagerWidget(const QUrl &url);
     int contentHeight();
+    void setFileIcon(QLabel *fileIcon, FileInfoPointer fileInfo);
 
 protected:
     virtual void mousePressEvent(QMouseEvent *event) override;


### PR DESCRIPTION
problem:
The thumbnail image not show in property dialog.
solved:
Get the thumbnail and show.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-208031.html