### PR TITLE
chore: Adapt to dfmio and add init interface

### DIFF
--- a/include/dfm-base/interfaces/abstractdiriterator.h
+++ b/include/dfm-base/interfaces/abstractdiriterator.h
@@ -130,6 +130,10 @@ public:
     {
         return true;
     }
+    virtual bool initIterator()
+    {
+        return true;
+    }
 };
 
 }

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -226,6 +226,13 @@ bool LocalDirIterator::oneByOne()
     return !FileUtils::isLocalDevice(url()) || !d->dfmioDirIterator;
 }
 
+bool LocalDirIterator::initIterator()
+{
+    if (d->dfmioDirIterator)
+        return d->dfmioDirIterator->initEnumerator(oneByOne());
+    return false;
+}
+
 DEnumeratorFuture *LocalDirIterator::asyncIterator()
 {
     if (d->dfmioDirIterator)

--- a/src/dfm-base/file/local/localdiriterator.h
+++ b/src/dfm-base/file/local/localdiriterator.h
@@ -44,6 +44,7 @@ public:
     void setArguments(const QVariantMap &args) override;
     QList<SortInfoPointer> sortFileInfoList() override;
     bool oneByOne() override;
+    bool initIterator() override;
     DFMIO::DEnumeratorFuture *asyncIterator();
 };
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -70,7 +70,6 @@ void TraversalDirThreadManager::start()
         }
     }
 
-    Q_EMIT iteratorInitFinished();
     TraversalDirThread::start();
 }
 
@@ -107,6 +106,14 @@ int TraversalDirThreadManager::iteratorOneByOne(const QElapsedTimer &timere)
         emit traversalFinished();
         return 0;
     }
+
+    if (!dirIterator->initIterator()) {
+        qWarning() << "dir iterator init failed !! url : " << dirUrl;
+        emit traversalFinished();
+        return 0;
+    }
+
+    Q_EMIT iteratorInitFinished();
 
     if (!timer)
         timer = new QElapsedTimer();
@@ -156,6 +163,12 @@ int TraversalDirThreadManager::iteratorAll()
     args.insert("mixFileAndDir", isMixDirAndFile);
     args.insert("sortOrder", sortOrder);
     dirIterator->setArguments(args);
+    if (!dirIterator->initIterator()) {
+        qWarning() << "dir iterator init failed !! url : " << dirUrl;
+        emit traversalFinished();
+        return 0;
+    }
+    Q_EMIT iteratorInitFinished();
     auto fileList = dirIterator->sortFileInfoList();
 
     emit updateLocalChildren(fileList, sortRole, sortOrder, isMixDirAndFile);

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/iterator/smbshareiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/iterator/smbshareiterator.cpp
@@ -88,3 +88,10 @@ QUrl SmbShareIterator::url() const
 {
     return {};
 }
+
+bool SmbShareIterator::initIterator()
+{
+    if (d->enumerator)
+        return d->enumerator->initEnumerator(oneByOne());
+    return false;
+}

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/iterator/smbshareiterator.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/iterator/smbshareiterator.h
@@ -30,6 +30,7 @@ public:
     virtual QUrl fileUrl() const override;
     virtual const FileInfoPointer fileInfo() const override;
     virtual QUrl url() const override;
+    bool initIterator() override;
 
 private:
     QScopedPointer<SmbShareIteratorPrivate> d;

--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileiterator.cpp
@@ -60,6 +60,13 @@ const FileInfoPointer VaultFileIterator::fileInfo() const
     return InfoFactory::create<FileInfo>(fileUrl());
 }
 
+bool VaultFileIterator::initIterator()
+{
+    if (dfmioDirIterator)
+        return dfmioDirIterator->initEnumerator(oneByOne());
+    return false;
+}
+
 QUrl VaultFileIterator::url() const
 {
     return VaultHelper::instance()->rootUrl();

--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileiterator.h
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileiterator.h
@@ -34,6 +34,8 @@ public:
 
     virtual QUrl url() const override;
 
+    bool initIterator() override;
+
 private:
     QSharedPointer<dfmio::DEnumerator> dfmioDirIterator { Q_NULLPTR };
     QUrl currentUrl;


### PR DESCRIPTION
dde-file-manager needs to know that the iterator initialization is complete when iterating over files. Modifications: 1. Add initIterator interface to the AbstractDirIterator class. 2. Add initIterator interface implementations to the LocalDirIterator, VaultFileIterator and SmbShareIterator classes, calling the dfmio class. 3. DEnumerator's initEnumerator interface.3. Modify the TraversalDirThreadManager class to call initialization in the thread execution, and send the iteratorInitFinished signal when it is done

Log: dde-file-manager adapts the initEnumerator interface added by dfmio.