### PR TITLE
fix: [thumbnail] The dde-file-manager crashed while creating thumbnail

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -73,9 +73,17 @@ QImage ThumbnailCreators::videoThumbnailCreatorFfmpeg(const QString &filePath, T
     }
 
     const auto &data = ffmpeg.readAllStandardOutput();
+    if (data.isEmpty())
+        return img;
+
     QString outputs(data);
-    if (!img.loadFromData(data))   // filter the outputs outputed by video tool.
-        outputs = outputs.split(QRegExp("[\n]"), QString::SkipEmptyParts).last();
+    if (!img.loadFromData(data)) {   // filter the outputs outputed by video tool.
+        QStringList data = outputs.split(QRegExp("[\n]"), QString::SkipEmptyParts);
+        if (data.isEmpty())
+            return img;
+
+        outputs = data.last();
+    }
 
     if (!img.loadFromData(outputs.toLocal8Bit().data(), "png"))
         qWarning() << "thumbnail: cannot load image from ffmpeg outputs." << filePath;


### PR DESCRIPTION
1.Failed to create a video file thumbnail in the FTP directory by ffmpeg 
2.Array out of bounds

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-210633.html