### PR TITLE
fix: [io/proxyfileinfo]The masteredmedia keeps flashing

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -504,11 +504,14 @@ void AsyncFileInfo::setNotifyUrl(const QUrl &url, const QString &infoPtr)
         return;
     }
     QWriteLocker lk(&d->notifyLock);
-    if (!d->notifyUrls.contains(url)) {
+    if (!d->notifyUrls.contains(url, infoPtr))
         d->notifyUrls.insert(url, infoPtr);
-    } else if (d->notifyUrls.values(url).contains(infoPtr)){
-        d->notifyUrls.insert(url, infoPtr);
-    }
+}
+
+void AsyncFileInfo::removeNotifyUrl(const QUrl &url, const QString &infoPtr)
+{
+    QWriteLocker lk(&d->notifyLock);
+    d->notifyUrls.remove(url, infoPtr);
 }
 
 void AsyncFileInfo::cacheAsyncAttributes()
@@ -988,7 +991,8 @@ void AsyncFileInfoPrivate::cacheAllAttributes()
             asyncInfo->setNotifyUrl(q->fileUrl(), QString::number(quintptr(q), 16));
             auto notifyUrls = q->notifyUrls();
             for (const auto &url : notifyUrls.keys()) {
-                asyncInfo->setNotifyUrl(url, notifyUrls.value(url));
+                for (const auto &infoptr : notifyUrls.values(url))
+                    asyncInfo->setNotifyUrl(url, infoptr);
             }
             asyncInfo->refresh();
         }

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -181,6 +181,7 @@ public:
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
     QMultiMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
+    void removeNotifyUrl(const QUrl &url, const QString &infoPtr);
     void cacheAsyncAttributes();
     bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);
 };

--- a/src/dfm-base/interfaces/proxyfileinfo.cpp
+++ b/src/dfm-base/interfaces/proxyfileinfo.cpp
@@ -17,6 +17,9 @@ ProxyFileInfo::ProxyFileInfo(const QUrl &url)
 
 ProxyFileInfo::~ProxyFileInfo()
 {
+    auto asyncInfo = this->proxy.dynamicCast<AsyncFileInfo>();
+    if (asyncInfo)
+        asyncInfo->removeNotifyUrl(url, QString::number(quintptr(this), 16));
 }
 
 QUrl ProxyFileInfo::fileUrl() const
@@ -42,10 +45,8 @@ void ProxyFileInfo::setProxy(const FileInfoPointer &proxy)
 {
     this->proxy = proxy;
     auto asyncInfo = this->proxy.dynamicCast<AsyncFileInfo>();
-    if (asyncInfo) {
+    if (asyncInfo)
         asyncInfo->setNotifyUrl(url, QString::number(quintptr(this), 16));
-        asyncInfo->refresh();
-    }
 }
 
 QString dfmbase::ProxyFileInfo::filePath() const


### PR DESCRIPTION
The file information for the files in the masteredmedia is an inherited proxy file information class. When you create the file information for the file in the masteredmedia, you create the proxy file information, which in turn is asynchronous file information, and then you set up the proxy and call the proxy's refresh interface. In the thumbnail creation task, after creating the file information of the file in the masteredmedia, when leaving to get its properties, it is invalid file information, resulting in the thumbnail of the file being created all the time. Modification: 1. When setting up the proxy file information, do not call the proxy file information's refresh. 2. Add an interface to remove the notification url in the asynchronous file information class. 3. Remove the notification url in the proxy when the proxy file information class destructs.

Log: The masteredmedia keeps flashing
Bug: https://pms.uniontech.com/bug-view-210839.html