### PR TITLE
fix: [icon] The default icon for files is displayed incorrectly

### DIFF
--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -121,6 +121,7 @@ void SyncFileInfo::refresh()
     d->mimeType = QMimeType();
     d->mimeTypeMode = QMimeDatabase::MatchDefault;
     d->cacheAttributes.clear();
+    d->fileIcon = QIcon();
     extendOtherCache.clear();
 }
 


### PR DESCRIPTION
When calling the refresh interface, SyncFileInfo needs to clear the icon object.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-210857.html