### PR TITLE
fix: [thumbnail] The file thumbnail is not displayed in the file detail view

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -84,6 +84,7 @@ void AsyncFileInfo::refresh()
         d->extraProperties.clear();
         d->attributesExtend.clear();
         d->extendIDs.clear();
+        d->fileIcon = QIcon();
         extendOtherCache.clear();
     }
 }

--- a/tests/plugins/common/dfmplugin-dirshare/CMakeLists.txt
+++ b/tests/plugins/common/dfmplugin-dirshare/CMakeLists.txt
@@ -15,6 +15,7 @@ file(GLOB_RECURSE SRC_FILES
 find_package(Dtk COMPONENTS Widget REQUIRED)
 find_package(Qt5 COMPONENTS DBus REQUIRED)
 find_package(Qt5 COMPONENTS Svg REQUIRED)
+find_package(Qt5 COMPONENTS Network REQUIRED)
 
 add_executable(${PROJECT_NAME}
     ${SRC_FILES}
@@ -34,6 +35,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     DFM::base
     DFM::extension
     Qt5::Svg
+    Qt5::Network
     ${DtkWidget_LIBRARIES}
 )
 


### PR DESCRIPTION
If the file has a thumbnail, replace the default icon with the thumbnail

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-211009.html