### PR TITLE
fix: [thumbnail] The wrong field was used for audio thumbnail detection

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -96,7 +96,7 @@ bool ThumbnailHelper::checkMimeTypeSupport(const QMimeType &mime)
 
     if (mimeName.startsWith("audio")
         || MimeTypeDisplayManager::instance()->supportAudioMimeTypes().contains(mimeName))
-        return checkStatus(Application::kPreviewVideo);
+        return checkStatus(Application::kPreviewAudio);
 
     if (mimeName.startsWith("video")
         || MimeTypeDisplayManager::instance()->supportVideoMimeTypes().contains(mimeName))


### PR DESCRIPTION
The audio thumbnail should use Application::kPreviewAudio

Log: fix issue
