### PR TITLE
fix: [crash] App crashed when renaming files with special character sets

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -201,6 +201,34 @@ QString FileUtils::preprocessingFileName(QString name)
     return name.remove(QRegularExpression(value));
 }
 
+bool FileUtils::processLength(const QString &srcText, int srcPos, int maxLen, bool useCharCount, QString &dstText, int &dstPos)
+{
+    auto textLength = [&](const QString &text) {
+        return useCharCount ? text.length() : text.toLocal8Bit().length();
+    };
+
+    int editTextCurrLen = textLength(srcText);
+    int editTextRangeOutLen = editTextCurrLen - maxLen;
+    if (editTextRangeOutLen > 0 && maxLen != INT_MAX) {
+        QString leftText = srcText.left(srcPos);
+        QString rightText = srcText.mid(srcPos);
+
+        while (textLength(leftText + rightText) > maxLen) {
+            auto list = leftText.toUcs4();
+            list.removeLast();
+            leftText = QString::fromUcs4(list.data(), list.size());
+        }
+
+        dstPos = leftText.size();
+        dstText = leftText + rightText;
+        return srcText.size() != dstText.size();
+    } else {
+        dstText = srcText;
+        dstPos = srcPos;
+        return false;
+    }
+}
+
 bool FileUtils::isContainProhibitPath(const QList<QUrl> &urls)
 {
     QStringList prohibitPaths;

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -31,6 +31,7 @@ public:
     static bool isMtpFile(const QUrl &url);
     static bool isGphotoFile(const QUrl &url);
     static QString preprocessingFileName(QString name);
+    static bool processLength(const QString &srcText, int srcPos, int maxLen, bool useCharCount, QString &dstText, int &dstPos);
     static bool isContainProhibitPath(const QList<QUrl> &urls);
 
     // check if is trash/computer desktop file containing Deepin_id of dde-trash/dde-computer

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/itemeditor.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/itemeditor.cpp
@@ -213,27 +213,6 @@ RenameEdit *ItemEditor::createEditor()
     return edit;
 }
 
-bool ItemEditor::processLength(const QString &srcText, int srcPos, QString &dstText, int &dstPos)
-{
-    int editTextCurrLen = textLength(srcText);
-    int editTextRangeOutLen = editTextCurrLen - maximumLength();
-    if (editTextRangeOutLen > 0 && maximumLength() != INT_MAX) {
-        QVector<uint> list = srcText.toUcs4();
-        QString tmp = srcText;
-        while (textLength(tmp) > maximumLength() && srcPos > 0) {
-            list.removeAt(--srcPos);
-            tmp = QString::fromUcs4(list.data(), list.size());
-        }
-        dstText = tmp;
-        dstPos = srcPos;
-        return srcText.size() != dstText.size();
-    } else {
-        dstText = srcText;
-        dstPos = srcPos;
-        return false;
-    }
-}
-
 void ItemEditor::textChanged()
 {
     if (sender() != textEditor)
@@ -257,7 +236,7 @@ void ItemEditor::textChanged()
     bool hasInvalidChar = dstText.size() != curText.size();
     int endPos = textEditor->textCursor().position() + (dstText.length() - curText.length());
 
-    processLength(dstText, endPos, dstText, endPos);
+    DFMBASE_NAMESPACE::FileUtils::processLength(dstText, endPos, maximumLength(), useCharCount, dstText, endPos);
     if (curText != dstText) {
         textEditor->setPlainText(dstText);
         QTextCursor cursor = textEditor->textCursor();

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/itemeditor.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/itemeditor.h
@@ -87,11 +87,6 @@ signals:
 protected:
     static RenameEdit *createEditor();
     static DTK_WIDGET_NAMESPACE::DArrowRectangle *createTooltip();
-    bool processLength(const QString &srcText, int srcPos, QString &dstText, int &dstPos);
-    inline int textLength(const QString &text)
-    {
-        return useCharCount ? text.length() : text.toLocal8Bit().length();
-    }
 private slots:
     void textChanged();
 

--- a/src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp
@@ -213,27 +213,6 @@ RenameEdit *ItemEditor::createEditor()
     return edit;
 }
 
-bool ItemEditor::processLength(const QString &srcText, int srcPos, QString &dstText, int &dstPos)
-{
-    int editTextCurrLen = textLength(srcText);
-    int editTextRangeOutLen = editTextCurrLen - maximumLength();
-    if (editTextRangeOutLen > 0 && maximumLength() != INT_MAX) {
-        QVector<uint> list = srcText.toUcs4();
-        QString tmp = srcText;
-        while (textLength(tmp) > maximumLength() && srcPos > 0) {
-            list.removeAt(--srcPos);
-            tmp = QString::fromUcs4(list.data(), list.size());
-        }
-        dstText = tmp;
-        dstPos = srcPos;
-        return srcText.size() != dstText.size();
-    } else {
-        dstText = srcText;
-        dstPos = srcPos;
-        return false;
-    }
-}
-
 void ItemEditor::textChanged()
 {
     if (sender() != textEditor)
@@ -257,7 +236,7 @@ void ItemEditor::textChanged()
     bool hasInvalidChar = dstText.size() != curText.size();
     int endPos = textEditor->textCursor().position() + (dstText.length() - curText.length());
 
-    processLength(dstText, endPos, dstText, endPos);
+    DFMBASE_NAMESPACE::FileUtils::processLength(dstText, endPos, maximumLength(), useCharCount, dstText, endPos);
     if (curText != dstText) {
         textEditor->setPlainText(dstText);
         QTextCursor cursor = textEditor->textCursor();

--- a/src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.h
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.h
@@ -88,11 +88,6 @@ signals:
 protected:
     static RenameEdit *createEditor();
     static DTK_WIDGET_NAMESPACE::DArrowRectangle *createTooltip();
-    bool processLength(const QString &srcText, int srcPos, QString &dstText, int &dstPos);
-    inline int textLength(const QString &text)
-    {
-        return useCharCount ? text.length() : text.toLocal8Bit().length();
-    }
 private slots:
     void textChanged();
 

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -42,8 +42,6 @@ private:
     void drawIcon(const QStyleOptionViewItem &option, QPainter *painter, const QIcon &icon, const QRect &itemRect, QIcon::Mode iconMode, bool isEjectable) const;
     void drawMouseHoverBackground(QPainter *painter, const DPalette &palette, const QRect &r, const QColor &widgetColor) const;
     void drawMouseHoverExpandButton(QPainter *painter, const QRect &r, bool isExpanded) const;
-    int textLength(const QString &text, bool useCharCount) const;
-    void processLength(int maxLen, int textLen, bool useCharCount, QString &text, int &pos) const;
 
 Q_SIGNALS:
     void rename(const QModelIndex &index, QString newName) const;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemeditor.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemeditor.cpp
@@ -236,8 +236,7 @@ void IconItemEditor::onEditTextChanged()
 
     int endPos = getTextEdit()->textCursor().position() + (dstText.length() - currentText.length());
 
-    processLength(dstText, endPos);
-
+    FileUtils::processLength(dstText, endPos, maxCharSize(), d->useCharCountLimit, dstText, endPos);
     if (currentText != dstText) {
         d->edit->setPlainText(dstText);
         QTextCursor cursor = d->edit->textCursor();
@@ -435,28 +434,3 @@ DArrowRectangle *IconItemEditor::createTooltip()
     return tooltip;
 }
 
-bool IconItemEditor::processLength(QString &text, int &pos)
-{
-    const QString srcText = text;
-    int srcPos = pos;
-    int editTextCurrLen = textLength(srcText);
-    int editTextRangeOutLen = editTextCurrLen - maxCharSize();
-    if (editTextRangeOutLen > 0 && maxCharSize() != INT_MAX) {
-        QVector<uint> list = srcText.toUcs4();
-        QString tmp = srcText;
-        while (textLength(tmp) > maxCharSize() && srcPos > 0) {
-            list.removeAt(--srcPos);
-            tmp = QString::fromUcs4(list.data(), list.size());
-        }
-        text = tmp;
-        pos = srcPos;
-        return srcText.size() != text.size();
-    }
-    return false;
-}
-
-int IconItemEditor::textLength(const QString &text)
-{
-    Q_D(IconItemEditor);
-    return d->useCharCountLimit ? text.size() : text.toLocal8Bit().size();
-}

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemeditor.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemeditor.h
@@ -74,8 +74,6 @@ private:
     QString editTextStackAdvance();
     void pushItemToEditTextStack(const QString &item);
     static DTK_WIDGET_NAMESPACE::DArrowRectangle *createTooltip();
-    bool processLength(QString &text, int &pos);
-    int textLength(const QString &text);
 
     friend class IconItemDelegate;
     friend class FileView;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemeditor.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemeditor.cpp
@@ -108,8 +108,7 @@ void ListItemEditor::onEditorTextChanged(const QString &text)
     int currPos = this->cursorPosition();
     currPos += dstText.length() - text.length();
 
-    processLength(dstText, currPos);
-
+    FileUtils::processLength(dstText, currPos, theMaxCharSize, useCharCount, dstText, currPos);
     if (srcText != dstText) {
         QSignalBlocker blocker(this);
         this->setText(dstText);
@@ -125,29 +124,4 @@ void ListItemEditor::init()
     setAttribute(Qt::WA_TranslucentBackground);
     setContentsMargins(0, 0, 0, 0);
     connect(this, &ListItemEditor::textChanged, this, &ListItemEditor::onEditorTextChanged, Qt::UniqueConnection);
-}
-
-bool ListItemEditor::processLength(QString &text, int &pos)
-{
-    QString srcText = text;
-    int srcPos = pos;
-    int editTextCurrLen = textLength(srcText);
-    int editTextRangeOutLen = editTextCurrLen - theMaxCharSize;
-    if (editTextRangeOutLen > 0 && theMaxCharSize != INT_MAX) {
-        QVector<uint> list = srcText.toUcs4();
-        QString tmp = srcText;
-        while (textLength(tmp) > theMaxCharSize && srcPos > 0) {
-            list.removeAt(--srcPos);
-            tmp = QString::fromUcs4(list.data(), list.size());
-        }
-        text = tmp;
-        pos = srcPos;
-        return srcText.size() != text.size();
-    }
-    return false;
-}
-
-int ListItemEditor::textLength(const QString &text)
-{
-    return useCharCount ? text.size() : text.toLocal8Bit().size();
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemeditor.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemeditor.h
@@ -52,8 +52,6 @@ private slots:
 
 private:
     void init();
-    bool processLength(QString &text, int &pos);
-    int textLength(const QString &text);
 
 private:
     int theMaxCharSize { INT_MAX };

--- a/tests/plugins/desktop/core/ddplugin-canvas/delegate/ut_itemeditor.cpp
+++ b/tests/plugins/desktop/core/ddplugin-canvas/delegate/ut_itemeditor.cpp
@@ -62,18 +62,6 @@ TEST(ItemEditor, maximumLength)
     EXPECT_EQ(ie.maximumLength(), 14);
 }
 
-TEST(ItemEditor, textLength)
-{
-    ItemEditor ie;
-    const QString &text= "ni测试";
-    ie.useCharCount = false;
-    EXPECT_EQ(ie.textLength(text), 8);
-
-    ie.setCharCountLimit();
-    EXPECT_TRUE(ie.useCharCount);
-    EXPECT_EQ(ie.textLength(text), 4);
-}
-
 TEST(ItemEditor, setBaseGeometry)
 {
     ItemEditor ie;

--- a/tests/plugins/desktop/ddplugin-organizer/delegate/ut_itemeditor.cpp
+++ b/tests/plugins/desktop/ddplugin-organizer/delegate/ut_itemeditor.cpp
@@ -65,18 +65,6 @@ TEST(ItemEditor, maximumLength)
     EXPECT_EQ(ie.maximumLength(), 14);
 }
 
-TEST(ItemEditor, textLength)
-{
-    ItemEditor ie;
-    const QString &text= "ni测试";
-    ie.useCharCount = false;
-    EXPECT_EQ(ie.textLength(text), 8);
-
-    ie.setCharCountLimit();
-    EXPECT_TRUE(ie.useCharCount);
-    EXPECT_EQ(ie.textLength(text), 4);
-}
-
 TEST(ItemEditor, setBaseGeometry)
 {
     ItemEditor ie;


### PR DESCRIPTION
The length of some special characters is 2, causing the cursor to be incorrectly calculated

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-211431.html