### PR TITLE
修复外部扩展右键菜单url参数问题

### DIFF
--- a/include/dfm-extension/menu/dfmextmenuplugin.h
+++ b/include/dfm-extension/menu/dfmextmenuplugin.h
@@ -32,11 +32,11 @@ public:
 
     DFM_FAKE_VIRTUAL void initialize(DFMEXT::DFMExtMenuProxy *proxy);
     DFM_FAKE_VIRTUAL bool buildNormalMenu(DFMEXT::DFMExtMenu *main,
-                                          const std::string &currentUrl,
-                                          const std::string &focusUrl,
-                                          const std::list<std::string> &urlList,
+                                          const std::string &currentPath,
+                                          const std::string &focusPath,
+                                          const std::list<std::string> &pathList,
                                           bool onDesktop);
-    DFM_FAKE_VIRTUAL bool buildEmptyAreaMenu(DFMEXT::DFMExtMenu *main, const std::string &currentUrl, bool onDesktop);
+    DFM_FAKE_VIRTUAL bool buildEmptyAreaMenu(DFMEXT::DFMExtMenu *main, const std::string &currentPath, bool onDesktop);
 
 public:
     void registerInitialize(const InitializeFunc &func);

--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -424,6 +424,28 @@ bool UniversalUtils::urlsTransformToLocal(const QList<QUrl> &sourceUrls, QList<Q
     return ret;
 }
 
+bool UniversalUtils::urlTransformToLocal(const QUrl &sourceUrl, QUrl *targetUrls)
+{
+    Q_ASSERT(sourceUrl.isValid());
+    Q_ASSERT(targetUrls);
+    bool ret { false };
+
+    if (sourceUrl.scheme() == Global::Scheme::kFile) {
+        *targetUrls = sourceUrl;
+        return ret;
+    }
+
+    auto info { InfoFactory::create<FileInfo>(sourceUrl) };
+    if (info && info->canAttributes(FileInfo::FileCanType::kCanRedirectionFileUrl)) {
+        ret = true;
+        *targetUrls = info->urlOf(UrlInfoType::kRedirectedFileUrl);
+    } else {
+        *targetUrls = sourceUrl;
+    }
+
+    return ret;
+}
+
 QString UniversalUtils::getCurrentUser()
 {
     QString user;

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -39,6 +39,7 @@ public:
 
     static bool urlEquals(const QUrl &url1, const QUrl &url2);
     static bool urlsTransformToLocal(const QList<QUrl> &sourceUrls, QList<QUrl> *targetUrls);
+    static bool urlTransformToLocal(const QUrl &sourceUrl, QUrl *targetUrls);
 
     static QString getCurrentUser();
 

--- a/src/dfm-extension/menu/dfmextmenuplugin.cpp
+++ b/src/dfm-extension/menu/dfmextmenuplugin.cpp
@@ -38,13 +38,13 @@ void DFMExtMenuPlugin::registerInitialize(const DFMExtMenuPlugin::InitializeFunc
 }
 
 bool DFMExtMenuPlugin::buildNormalMenu(DFMExtMenu *main,
-                                       const std::string &currentUrl,
-                                       const std::string &focusUrl,
-                                       const std::list<std::string> &urlList,
+                                       const std::string &currentPath,
+                                       const std::string &focusPath,
+                                       const std::list<std::string> &pathList,
                                        bool onDesktop)
 {
     if (d->buildNormalMeunFunc)
-        return d->buildNormalMeunFunc(main, currentUrl, focusUrl, urlList, onDesktop);
+        return d->buildNormalMeunFunc(main, currentPath, focusPath, pathList, onDesktop);
 
     return false;
 }
@@ -54,10 +54,10 @@ void DFMExtMenuPlugin::registerBuildNormalMenu(const DFMExtMenuPlugin::BuildNorm
     d->buildNormalMeunFunc = func;
 }
 
-bool DFMExtMenuPlugin::buildEmptyAreaMenu(DFMExtMenu *main, const std::string &currentUrl, bool onDesktop)
+bool DFMExtMenuPlugin::buildEmptyAreaMenu(DFMExtMenu *main, const std::string &currentPath, bool onDesktop)
 {
     if (d->buildEmptyAreaMenuFunc)
-        return d->buildEmptyAreaMenuFunc(main, currentUrl, onDesktop);
+        return d->buildEmptyAreaMenuFunc(main, currentPath, onDesktop);
 
     return false;
 }

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
@@ -65,9 +65,15 @@ QString ExtendMenuScene::name() const
 bool ExtendMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
+    UniversalUtils::urlTransformToLocal(d->currentDir, &d->transformedCurrentDir);
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
+    UniversalUtils::urlsTransformToLocal(d->selectFiles, &d->transformedSelectFiles);
+    Q_ASSERT(d->selectFiles.size() == d->transformedSelectFiles.size());
     if (!d->selectFiles.isEmpty())
         d->focusFile = d->selectFiles.first();
+    if (!d->transformedSelectFiles.isEmpty())
+        d->transformedFocusFile = d->transformedSelectFiles.first();
+
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->indexFlags = params.value(MenuParamKey::kIndexFlags).value<Qt::ItemFlags>();
@@ -257,7 +263,8 @@ bool ExtendMenuScene::triggered(QAction *action)
         qDebug() << "argflag" << argFlag << "dir" << d->currentDir << "foucs" << d->focusFile << "selected" << d->selectFiles;
         qInfo() << "extend" << action->text() << cmd;
 
-        QPair<QString, QStringList> runable = DCustomActionBuilder::makeCommand(cmd, argFlag, d->currentDir, d->focusFile, d->selectFiles);
+        QPair<QString, QStringList> runable = DCustomActionBuilder::makeCommand(
+                cmd, argFlag, d->transformedCurrentDir, d->transformedFocusFile, d->transformedSelectFiles);
         qInfo() << "exec:" << runable.first << runable.second;
 
         if (!runable.first.isEmpty())

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/private/extendmenuscene_p.h
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/private/extendmenuscene_p.h
@@ -26,6 +26,11 @@ public:
 
     QMap<int, QList<QAction *>> cacheLocateActions;
     QMap<QAction *, DCustomActionDefines::Separator> cacheActionsSeparator;
+
+    // External extensions may not know the meaning of the url inside the DFM
+    QUrl transformedCurrentDir;
+    QList<QUrl> transformedSelectFiles;
+    QUrl transformedFocusFile;
 };
 
 }

--- a/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/oemmenuscene/oemmenuscene.cpp
@@ -65,9 +65,15 @@ QString OemMenuScene::name() const
 bool OemMenuScene::initialize(const QVariantHash &params)
 {
     d->currentDir = params.value(MenuParamKey::kCurrentDir).toUrl();
+    UniversalUtils::urlTransformToLocal(d->currentDir, &d->transformedCurrentDir);
     d->selectFiles = params.value(MenuParamKey::kSelectFiles).value<QList<QUrl>>();
+    UniversalUtils::urlsTransformToLocal(d->selectFiles, &d->transformedSelectFiles);
+    Q_ASSERT(d->selectFiles.size() == d->transformedSelectFiles.size());
     if (!d->selectFiles.isEmpty())
         d->focusFile = d->selectFiles.first();
+    if (!d->transformedSelectFiles.isEmpty())
+        d->transformedFocusFile = d->transformedSelectFiles.first();
+
     d->onDesktop = params.value(MenuParamKey::kOnDesktop).toBool();
     d->isEmptyArea = params.value(MenuParamKey::kIsEmptyArea).toBool();
     d->indexFlags = params.value(MenuParamKey::kIndexFlags).value<Qt::ItemFlags>();
@@ -135,7 +141,8 @@ bool OemMenuScene::triggered(QAction *action)
     if (!d->oemActions.contains(action) && !d->oemChildActions.contains(action))
         return AbstractMenuScene::triggered(action);
 
-    QPair<QString, QStringList> runable = d->oemMenu->makeCommand(action, d->currentDir, d->focusFile, d->selectFiles);
+    QPair<QString, QStringList> runable = d->oemMenu->makeCommand(
+            action, d->transformedCurrentDir, d->transformedFocusFile, d->transformedSelectFiles);
     if (!runable.first.isEmpty())
         return UniversalUtils::runCommand(runable.first, runable.second);
 

--- a/src/plugins/common/core/dfmplugin-menu/oemmenuscene/private/oemmenuscene_p.h
+++ b/src/plugins/common/core/dfmplugin-menu/oemmenuscene/private/oemmenuscene_p.h
@@ -24,6 +24,11 @@ public:
 
     QList<QAction *> oemActions;
     QList<QAction *> oemChildActions;
+
+    // External extensions may not know the meaning of the url inside the DFM
+    QUrl transformedCurrentDir;
+    QList<QUrl> transformedSelectFiles;
+    QUrl transformedFocusFile;
 };
 
 }

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.cpp
@@ -81,19 +81,19 @@ bool ExtensionLibMenuScene::create(QMenu *parent)
     }
 
     DFMExtMenuImpl *extMenuImpl { new DFMExtMenuImpl(parent) };
-    const std::string &newCurrentUrl { d->transformedCurrentDir.toString().toStdString() };
-    const std::string &newFocusUrl { d->transformedFocusFile.toString().toStdString() };
+    const std::string &newCurrentPath { d->transformedCurrentDir.toLocalFile().toStdString() };
+    const std::string &newFocusPath { d->transformedFocusFile.toLocalFile().toStdString() };
 
     for (auto menu : ExtensionPluginManager::instance().menuPlugins()) {
         menu->initialize(ExtensionPluginManager::instance().pluginMenuProxy());
         if (d->isEmptyArea) {
-            menu->buildEmptyAreaMenu(extMenuImpl, newCurrentUrl, d->onDesktop);
+            menu->buildEmptyAreaMenu(extMenuImpl, newCurrentPath, d->onDesktop);
         } else {
-            std::list<std::string> newSelectedFiles;
-            std::for_each(d->transformedSelectFiles.cbegin(), d->transformedSelectFiles.cend(), [&newSelectedFiles](const QUrl &url) {
-                newSelectedFiles.push_back(url.toString().toStdString());
+            std::list<std::string> newSelectedPaths;
+            std::for_each(d->transformedSelectFiles.cbegin(), d->transformedSelectFiles.cend(), [&newSelectedPaths](const QUrl &url) {
+                newSelectedPaths.push_back(url.toLocalFile().toStdString());
             });
-            menu->buildNormalMenu(extMenuImpl, newCurrentUrl, newFocusUrl, newSelectedFiles, d->onDesktop);
+            menu->buildNormalMenu(extMenuImpl, newCurrentPath, newFocusPath, newSelectedPaths, d->onDesktop);
         }
     }
 

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/extensionlibmenuscene_p.h
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/extensionlibmenuscene_p.h
@@ -22,6 +22,11 @@ public:
 
 private:
     ExtensionLibMenuScene *q { nullptr };
+
+    // External extensions may not know the meaning of the url inside the DFM
+    QUrl transformedCurrentDir;
+    QList<QUrl> transformedSelectFiles;
+    QUrl transformedFocusFile;
 };
 
 }   // namespace dfmplugin_utils


### PR DESCRIPTION
Customized urls in DFM can't be parsed third parties, it needs to be converted and passed out as parameter
