### PR TITLE
fix: [clipboard]dde-file-manager block for a few seconds when using the shortcut ctrl+c

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -118,14 +118,17 @@ void ClipBoard::setUrlsToClipboard(const QList<QUrl> &list, ClipBoard::Clipboard
         ba.append(qurl.toString());
 
         const QString &path = qurl.toLocalFile();
-
-        const FileInfoPointer &info = InfoFactory::create<FileInfo>(qurl, Global::CreateFileInfoType::kCreateFileInfoAuto, &error);
-
-        if (!info) {
-            qWarning() << QString("create file info error, case : %1").arg(error);
-            continue;
+        if (!path.isEmpty()) {
+            text += path + '\n';
         }
+
         if (maxIconsNum-- > 0) {
+            const FileInfoPointer &info = InfoFactory::create<FileInfo>(qurl, Global::CreateFileInfoType::kCreateFileInfoAuto, &error);
+
+            if (!info) {
+                qWarning() << QString("create file info error, case : %1").arg(error);
+                continue;
+            }
             QStringList iconList;
             if (info->isAttributes(OptInfoType::kIsSymLink)) {
                 iconList << "emblem-symbolic-link";
@@ -152,10 +155,6 @@ void ClipBoard::setUrlsToClipboard(const QList<QUrl> &list, ClipBoard::Clipboard
                 }
             }
             stream << iconList << icon;
-        }
-
-        if (!path.isEmpty()) {
-            text += path + '\n';
         }
     }
 


### PR DESCRIPTION
Commit less code, loop to create fileinfo for all url before writing to clipboard. change to take only 3 files to create fileinfo and then get icon

Log: dde-file-manager block for a few seconds when using the shortcut ctrl+c
Bug: https://pms.uniontech.com/bug-view-211657.html