### PR TITLE
fix: Optimize the way updating thumbnails.

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmodelhook.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmodelhook.cpp
@@ -57,9 +57,9 @@ bool CanvasModelHook::dataRested(QList<QUrl> *urls, void *extData) const
     return CanvasModelRunHook(hook_CanvasModel_DataRested, urls, extData);
 }
 
-bool CanvasModelHook::dataChanged(const QUrl &url, void *extData) const
+bool CanvasModelHook::dataChanged(const QUrl &url, const QVector<int> &roles, void *extData) const
 {
-    return CanvasModelRunHook(hook_CanvasModel_DataChanged, url, extData);
+    return CanvasModelRunHook(hook_CanvasModel_DataChanged, url, roles, extData);
 }
 
 bool CanvasModelHook::dropMimeData(const QMimeData *data, const QUrl &dir, Qt::DropAction action, void *extData) const

--- a/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmodelhook.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmodelhook.h
@@ -22,7 +22,7 @@ public:
     bool dataRemoved(const QUrl &url, void *extData = nullptr) const override;    // must return false
     bool dataRenamed(const QUrl &oldUrl, const QUrl &newUrl, void *extData = nullptr) const override;
     bool dataRested(QList<QUrl> *urls, void *extData = nullptr) const override;   // must return false
-    bool dataChanged(const QUrl &url, void *extData = nullptr) const override;   // must return false
+    bool dataChanged(const QUrl &url, const QVector<int> &roles, void *extData = nullptr) const override;   // must return false
     bool dropMimeData(const QMimeData *data, const QUrl &dir, Qt::DropAction action, void *extData = nullptr) const override;
     bool mimeData(const QList<QUrl> &urls, QMimeData *out, void *extData = nullptr) const override;
     bool mimeTypes (QStringList *types, void *extData = nullptr) const override;

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasmodelfilter.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasmodelfilter.h
@@ -19,7 +19,7 @@ public:
     explicit CanvasModelFilter(CanvasProxyModel *m);
     virtual bool insertFilter(const QUrl &url);
     virtual bool resetFilter(QList<QUrl> &urls);
-    virtual bool updateFilter(const QUrl &url);
+    virtual bool updateFilter(const QUrl &url, const QVector<int> &roles = {});
     virtual bool removeFilter(const QUrl &url);
     virtual bool renameFilter(const QUrl &oldUrl, const QUrl &newUrl);
 protected:
@@ -32,7 +32,7 @@ public:
     using CanvasModelFilter::CanvasModelFilter;
     bool insertFilter(const QUrl &url) override;
     bool resetFilter(QList<QUrl> &urls) override;
-    bool updateFilter(const QUrl &url) override;
+    bool updateFilter(const QUrl &url, const QVector<int> &roles = {}) override;
     bool renameFilter(const QUrl &oldUrl, const QUrl &newUrl) override;
 };
 

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.h
@@ -58,7 +58,7 @@ signals:
 public slots:
     bool sort();
     void update();
-    void refresh(const QModelIndex &parent, bool global = false, int ms = 50);
+    void refresh(const QModelIndex &parent, bool global = false, int ms = 50, bool refreshFile = true);
     void setShowHiddenFiles(bool show);
     bool fetch(const QUrl &url);   //show \a url if exsited
     bool take(const QUrl &url);   // hide \a url

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel_p.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel_p.h
@@ -28,7 +28,7 @@ public:
     bool doSort(QList<QUrl> &files) const;
     bool lessThan(const QUrl &left, const QUrl &right) const;
 public slots:
-    void doRefresh(bool global);
+    void doRefresh(bool global, bool refreshFile);
     void sourceDataChanged(const QModelIndex &sourceTopleft,
                            const QModelIndex &sourceBottomright,
                            const QVector<int> &roles);
@@ -44,7 +44,7 @@ public slots:
 public:
     bool insertFilter(const QUrl &url);
     bool resetFilter(QList<QUrl> &urls);
-    bool updateFilter(const QUrl &url);
+    bool updateFilter(const QUrl &url , const QVector<int> &roles);
     bool removeFilter(const QUrl &url);
     bool renameFilter(const QUrl &oldUrl, const QUrl &newUrl);
 

--- a/src/plugins/desktop/core/ddplugin-canvas/model/modelhookinterface.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/modelhookinterface.cpp
@@ -41,7 +41,7 @@ bool ModelHookInterface::dataRested(QList<QUrl> *urls, void *extData) const
     return false;
 }
 
-bool ModelHookInterface::dataChanged(const QUrl &url, void *extData) const
+bool ModelHookInterface::dataChanged(const QUrl &url, const QVector<int> &roles, void *extData) const
 {
     return false;
 }

--- a/src/plugins/desktop/core/ddplugin-canvas/model/modelhookinterface.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/modelhookinterface.h
@@ -25,7 +25,7 @@ public:
     virtual bool dataRemoved(const QUrl &url, void *extData = nullptr) const;    // must return false
     virtual bool dataRenamed(const QUrl &oldUrl, const QUrl &newUrl, void *extData = nullptr) const;
     virtual bool dataRested(QList<QUrl> *urls, void *extData = nullptr) const;   // must return false
-    virtual bool dataChanged(const QUrl &url, void *extData = nullptr) const;   // must return false
+    virtual bool dataChanged(const QUrl &url, const QVector<int> &roles, void *extData = nullptr) const;   // must return false
     virtual bool dropMimeData(const QMimeData *data, const QUrl &dir, Qt::DropAction action, void *extData = nullptr) const;
     virtual bool mimeData(const QList<QUrl> &urls, QMimeData *out, void *extData = nullptr) const;
     virtual bool mimeTypes (QStringList *types, void *extData = nullptr) const;

--- a/src/plugins/desktop/ddplugin-organizer/broker/organizerbroker.h
+++ b/src/plugins/desktop/ddplugin-organizer/broker/organizerbroker.h
@@ -23,7 +23,7 @@ public:
 signals:
 
 public slots:
-    virtual void refreshModel(bool global, int ms) = 0;
+    virtual void refreshModel(bool global, int ms, bool file) = 0;
     virtual QString gridPoint(const QUrl &item, QPoint *point) = 0;
     virtual QRect visualRect(const QString &id, const QUrl &item) = 0;
     virtual QAbstractItemView * view(const QString &id) = 0;

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmodebroker.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmodebroker.cpp
@@ -19,10 +19,10 @@ NormalizedModeBroker::NormalizedModeBroker(NormalizedMode *parent)
     Q_ASSERT(mode);
 }
 
-void NormalizedModeBroker::refreshModel(bool global, int ms)
+void NormalizedModeBroker::refreshModel(bool global, int ms, bool file)
 {
     if (auto m = mode->getModel())
-        m->refresh(m->rootIndex(), global, ms);
+        m->refresh(m->rootIndex(), global, ms, file);
 }
 
 QString NormalizedModeBroker::gridPoint(const QUrl &item, QPoint *point)

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmodebroker.h
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmodebroker.h
@@ -16,7 +16,7 @@ class NormalizedModeBroker : public OrganizerBroker
 public:
     explicit NormalizedModeBroker(NormalizedMode *parent = nullptr);
 public slots:
-    void refreshModel(bool global, int ms) override;
+    void refreshModel(bool global, int ms, bool file) override;
     QString gridPoint(const QUrl &item, QPoint *point) override;
     QRect visualRect(const QString &id, const QUrl &item) override;
     QAbstractItemView *view(const QString &id) override;

--- a/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.h
+++ b/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.h
@@ -34,7 +34,7 @@ public:
     FileInfoPointer fileInfo(const QModelIndex &index) const;
     QList<QUrl> files() const;
     QUrl fileUrl(const QModelIndex &index) const;
-    void refresh(const QModelIndex &parent, bool global = false, int ms = 50);
+    void refresh(const QModelIndex &parent, bool global = false, int ms = 50, bool file = true);
     void update();
     bool fetch(const QList<QUrl> &urls);
     bool take(const QList<QUrl> &urls);

--- a/src/plugins/desktop/ddplugin-organizer/models/collectionmodel_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/models/collectionmodel_p.h
@@ -22,7 +22,7 @@ public:
     void reset();
     void clearMapping();
     void createMapping();
-    void doRefresh(bool global);
+    void doRefresh(bool global, bool file);
 public slots:
     void sourceDataChanged(const QModelIndex &sourceTopleft,
                            const QModelIndex &sourceBottomright,

--- a/src/plugins/desktop/ddplugin-organizer/models/filters/hiddenfilefilter.h
+++ b/src/plugins/desktop/ddplugin-organizer/models/filters/hiddenfilefilter.h
@@ -20,7 +20,7 @@ public:
     bool acceptInsert(const QUrl &url) override;
     QList<QUrl> acceptReset(const QList<QUrl> &urls) override;
     bool acceptRename(const QUrl &oldUrl, const QUrl &newUrl) override;
-    bool acceptUpdate(const QUrl &url) override;
+    bool acceptUpdate(const QUrl &url, const QVector<int> &roles = {}) override;
 protected slots:
     void updateFlag();
     void hiddenFlagChanged(bool showHidden);

--- a/src/plugins/desktop/ddplugin-organizer/models/filters/innerdesktopappfilter.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/filters/innerdesktopappfilter.cpp
@@ -45,7 +45,7 @@ void ddplugin_organizer::InnerDesktopAppFilter::update()
 
 void InnerDesktopAppFilter::refreshModel()
 {
-    dpfSlotChannel->push("ddplugin_organizer", "slot_CollectionModel_Refresh", false, 50);
+    dpfSlotChannel->push("ddplugin_organizer", "slot_CollectionModel_Refresh", false, 50, false);
 }
 
 bool InnerDesktopAppFilter::acceptInsert(const QUrl &url)

--- a/src/plugins/desktop/ddplugin-organizer/models/generalmodelfilter.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/generalmodelfilter.cpp
@@ -58,13 +58,13 @@ bool GeneralModelFilter::acceptRename(const QUrl &oldUrl, const QUrl &newUrl)
     return ModelDataHandler::acceptRename(oldUrl, newUrl) && ret;
 }
 
-bool GeneralModelFilter::acceptUpdate(const QUrl &url)
+bool GeneralModelFilter::acceptUpdate(const QUrl &url, const QVector<int> &roles)
 {
     // these filters is like Notifier.
     // so it will don't interrupt when some one return true.
     bool ret = true;
     for (const auto &filter : modelFilters)
-        ret = ret && filter->acceptUpdate(url);
+        ret = ret && filter->acceptUpdate(url, roles);
 
-    return ModelDataHandler::acceptUpdate(url) && ret;
+    return ModelDataHandler::acceptUpdate(url, roles) && ret;
 }

--- a/src/plugins/desktop/ddplugin-organizer/models/generalmodelfilter.h
+++ b/src/plugins/desktop/ddplugin-organizer/models/generalmodelfilter.h
@@ -20,7 +20,7 @@ public:
     bool acceptInsert(const QUrl &url) override;
     QList<QUrl> acceptReset(const QList<QUrl> &urls) override;
     bool acceptRename(const QUrl &oldUrl, const QUrl &newUrl) override;
-    bool acceptUpdate(const QUrl &url) override;
+    bool acceptUpdate(const QUrl &url, const QVector<int> &roles = {}) override;
 protected:
     QList<QSharedPointer<ModelDataHandler>> modelFilters;
 };

--- a/src/plugins/desktop/ddplugin-organizer/models/modeldatahandler.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/modeldatahandler.cpp
@@ -29,7 +29,7 @@ bool ModelDataHandler::acceptRename(const QUrl &oldUrl, const QUrl &newUrl)
     return true;
 }
 
-bool ModelDataHandler::acceptUpdate(const QUrl &url)
+bool ModelDataHandler::acceptUpdate(const QUrl &url, const QVector<int> &roles)
 {
     Q_UNUSED(url)
     return true;

--- a/src/plugins/desktop/ddplugin-organizer/models/modeldatahandler.h
+++ b/src/plugins/desktop/ddplugin-organizer/models/modeldatahandler.h
@@ -9,6 +9,7 @@
 
 #include <QObject>
 #include <QUrl>
+#include <QVector>
 
 namespace ddplugin_organizer {
 
@@ -21,7 +22,7 @@ public:
     virtual bool acceptInsert(const QUrl &url);
     virtual QList<QUrl> acceptReset(const QList<QUrl> &urls);
     virtual bool acceptRename(const QUrl &oldUrl, const QUrl &newUrl);
-    virtual bool acceptUpdate(const QUrl &url);
+    virtual bool acceptUpdate(const QUrl &url, const QVector<int> &roles = {});
 };
 }
 

--- a/tests/plugins/desktop/core/ddplugin-canvas/model/ut_canvasproxymodel.cpp
+++ b/tests/plugins/desktop/core/ddplugin-canvas/model/ut_canvasproxymodel.cpp
@@ -1017,7 +1017,7 @@ public:
         cr = true;
         return rr;
     }
-    bool updateFilter(const QUrl &url) override
+    bool updateFilter(const QUrl &url, const QVector<int> &roles) override
     {
         cu = true;
         return ru;
@@ -1224,7 +1224,7 @@ TEST_F(TestCanvasModelFilter, updateFilter)
     bool ret = true;
 
     {
-        ret = model.d->updateFilter(in);
+        ret = model.d->updateFilter(in, {});
         EXPECT_FALSE(ret);
         EXPECT_TRUE(f1->cu);
         EXPECT_TRUE(f2->cu);
@@ -1237,7 +1237,7 @@ TEST_F(TestCanvasModelFilter, updateFilter)
         f2->cu = false;
         f3->cu = false;
         f1->ru = true;
-        ret = model.d->updateFilter(in);
+        ret = model.d->updateFilter(in, {});
         EXPECT_TRUE(ret);
         EXPECT_TRUE(f1->cu);
         EXPECT_TRUE(f2->cu);
@@ -1251,7 +1251,7 @@ TEST_F(TestCanvasModelFilter, updateFilter)
         f3->cu = false;
         f1->ru = false;
         f2->ru = true;
-        ret = model.d->updateFilter(in);
+        ret = model.d->updateFilter(in, {});
         EXPECT_TRUE(ret);
         EXPECT_TRUE(f1->cu);
         EXPECT_TRUE(f2->cu);
@@ -1265,7 +1265,7 @@ TEST_F(TestCanvasModelFilter, updateFilter)
         f3->cu = false;
         f2->ru = false;
         f3->ru = true;
-        ret = model.d->updateFilter(in);
+        ret = model.d->updateFilter(in, {});
         EXPECT_TRUE(ret);
         EXPECT_TRUE(f1->cu);
         EXPECT_TRUE(f2->cu);

--- a/tests/plugins/desktop/core/ddplugin-canvas/ut_canvasmanager.cpp
+++ b/tests/plugins/desktop/core/ddplugin-canvas/ut_canvasmanager.cpp
@@ -657,7 +657,7 @@ TEST(CanvasManagerPrivate, onHiddenFlagsChanged)
     });
 
     QModelIndex ridx;
-    stub.set_lamda(&CanvasProxyModel::refresh, [&ridx](CanvasProxyModel *, const QModelIndex &parent, bool global, int ms){
+    stub.set_lamda(&CanvasProxyModel::refresh, [&ridx](CanvasProxyModel *, const QModelIndex &parent, bool global, int ms, bool file){
         ridx = parent;
         EXPECT_FALSE(global);
         EXPECT_GT(ms, 0);

--- a/tests/plugins/desktop/ddplugin-organizer/models/ut_generalmodelfilter.cpp
+++ b/tests/plugins/desktop/ddplugin-organizer/models/ut_generalmodelfilter.cpp
@@ -52,7 +52,7 @@ public:
     bool acceptInsert(const QUrl &url) override{instert = true; return false;}
     QList<QUrl> acceptReset(const QList<QUrl> &urls) override {reset = true; return {};}
     bool acceptRename(const QUrl &oldUrl, const QUrl &newUrl) override {rename = true; return false;}
-    bool acceptUpdate(const QUrl &url) override {update = true; return false;}
+    bool acceptUpdate(const QUrl &url, const QVector<int> &roles = {}) override {update = true; return false;}
 public:
     bool instert = false;
     bool reset = false;


### PR DESCRIPTION
1. use old thumbnail ad file icon when file updated to resolve icon flicking.
2. then all fileinfo refresh calling should use refreshFileInfos.
3. the datachanged signal emited by thumbnail will lead model refresh by .hidden file. use role kItemCreateFileInfoRole to mark that file content is changed and need to refresh model.

Log: 优化桌面缩率图

Bug: https://pms.uniontech.com/bug-view-211109.html