### PR TITLE
fix: [select-dialog] the select dialog app can not quit.

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/utils/appexitcontroller.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/utils/appexitcontroller.cpp
@@ -5,6 +5,7 @@
 #include "appexitcontroller.h"
 
 #include <QDebug>
+#include <QApplication>
 
 using namespace filedialog_core;
 
@@ -23,9 +24,9 @@ void AppExitController::onExit()
     }
     qWarning() << "App exit!";
     if (!confirmFunc)
-        exit(0);
-    if (confirmFunc && confirmFunc())
-        exit(0);
+        qApp->exit(0);
+    if (confirmFunc())
+        qApp->exit(0);
     qWarning() << "App exit failed";
 }
 


### PR DESCRIPTION
1. the thumbnail thread is waiting. 2.use qapp->exit(), it will emit abouttoexit signal, so the thumbnai thread can exit waiting state.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-211857.html