### PR TITLE
fix: [vault]No semi-transparent drawing after cut files in vault.

### DIFF
--- a/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
@@ -199,7 +199,8 @@ TrashFileInfo::TrashFileInfo(const QUrl &url)
 
     const QUrl &urlTarget = d->initTarget();
     if (urlTarget.isValid()) {
-        setProxy(InfoFactory::create<FileInfo>(urlTarget));
+        d->targetUrl.setPath(urlTarget.path());
+        setProxy(InfoFactory::create<FileInfo>(d->targetUrl));
     } else {
         if (!FileUtils::isTrashRootFile(url))
             qWarning() << "create proxy failed, target url is invalid, url: " << url;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -74,10 +74,15 @@ bool FileViewHelper::isTransparent(const QModelIndex &index) const
     }
 
     //  cutting
+
     if (ClipBoard::instance()->clipboardAction() == ClipBoard::kCutAction) {
         QUrl localUrl = file->urlOf(UrlInfoType::kUrl);
-        if (ClipBoard::instance()->clipboardFileUrlList().contains(localUrl))
+        auto cutUrls = ClipBoard::instance()->clipboardFileUrlList();
+        if (cutUrls.contains(localUrl))
             return true;
+
+        if (file->canAttributes(CanableInfoType::kCanRedirectionFileUrl))
+            return cutUrls.contains(QUrl::fromLocalFile(file->pathOf(PathInfoType::kAbsoluteFilePath)));
     }
 
     return false;


### PR DESCRIPTION
Optimize ctrl+c to get rid of the previous fileinfo creation to get the inode and record it in the list of cut files. When judging the semi-transparent drawing, I just use url to judge, and the virtual directory fails to judge. Modify the file that can be redirected, use the absolute path of its local file to construct the url, and judge the cut url.

Log: No semi-transparent drawing after cut files in vault.
Bug: https://pms.uniontech.com/bug-view-211525.html