### PR TITLE
增加 cifs 挂载参数 actimeo

### DIFF
--- a/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -318,6 +318,7 @@ std::string CifsMountHelper::convertArgs(const QVariantMap &opts)
         param += QString("gid=%1,").arg(user->pw_gid);
     }
     param += "iocharset=utf8,vers=default";
+    param += ",actimeo=5";   // bug 211337
     return param.toStdString();
 }
 


### PR DESCRIPTION
this param is used to extend the action time out when access a cifs file.

Log: add mount param for cifs.
