### PR TITLE
fix: [window]window state config lost

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
@@ -132,7 +132,8 @@ void FileManagerWindowsManagerPrivate::onWindowClosed(FileManagerWindow *window)
         return;
 
     if (count == 1) {   // last window
-        if (window->saveClosedSate())
+        auto isDefaultWindow = window->property("_dfm_isDefaultWindow");
+        if (window->saveClosedSate() && (!isDefaultWindow.isValid() || !isDefaultWindow.toBool()))
             saveWindowState(window);
         qInfo() << "Last window deletelater" << window->internalWinId();
         emit manager->lastWindowClosed();

--- a/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
@@ -81,6 +81,7 @@ void CoreHelper::cacheDefaultWindow()
         qWarning() << "cache window failed";
         return;
     }
+    window->setProperty("_dfm_isDefaultWindow", true);
     window->removeEventFilter(this);
     // cache all UI components
     QMetaObject::invokeMethod(window, "aboutToOpen", Qt::DirectConnection);


### PR DESCRIPTION
there is a default window hidden while all filemanager windows closed, but the default window will save default window state to the config while it closed.

Log: fix window display issue
Bug: https://pms.uniontech.com/bug-view-211293.html