### PR TITLE
修复光盘文件缩略图显示问题

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -170,6 +170,8 @@ void DeviceManager::mountBlockDevAsync(const QString &id, const QVariantMap &opt
 
         auto callback = [cb, id, this](bool ok, const OperationErrorInfo &err, const QString &mpt) {
             Q_EMIT this->blockDevMountResult(id, ok);
+            if (ok)
+                Q_EMIT this->blockDevMountedManually(id, mpt);   // redundant: to notify deviceproxymanager update the cache.
             if (cb)
                 cb(ok, err, mpt);
         };
@@ -205,6 +207,8 @@ void DeviceManager::mountBlockDevAsync(const QString &id, const QVariantMap &opt
                 this->blockDevMountResult(id, ok);
                 if (!mpt.isEmpty() && removable && !optical)
                     DeviceManagerPrivate::handleDlnfsMount(mpt, true);
+                if (ok)
+                    Q_EMIT this->blockDevMountedManually(id, mpt);   // redundant: to notify deviceproxymanager update the cache.
                 if (cb)
                     cb(ok, err, mpt);
             };

--- a/src/dfm-base/base/device/devicemanager.h
+++ b/src/dfm-base/base/device/devicemanager.h
@@ -125,6 +125,8 @@ Q_SIGNALS:
 
     void mountNetworkDeviceResult(bool ret, DFMMOUNT::DeviceError err, const QString &msg);
 
+    void blockDevMountedManually(const QString &id, const QString &mpt);
+
 private:
     explicit DeviceManager(QObject *parent = nullptr);
     virtual ~DeviceManager() override;

--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -255,6 +255,9 @@ void DeviceProxyManagerPrivate::connectToDBus()
     connections << q->connect(ptr, &DeviceManagerInterface::ProtocolDeviceMounted, this, &DeviceProxyManagerPrivate::addMounts);
     connections << q->connect(ptr, &DeviceManagerInterface::ProtocolDeviceUnmounted, this, &DeviceProxyManagerPrivate::removeMounts);
 
+    // redundant signal. this signal is emitted before the mount callback invoked, to make sure the cache is updated before use.
+    connections << q->connect(DevMngIns, &DeviceManager::blockDevMountedManually, this, &DeviceProxyManagerPrivate::addMounts);
+
     currentConnectionType = kDBusConnecting;
 }
 
@@ -290,6 +293,9 @@ void DeviceProxyManagerPrivate::connectToAPI()
     connections << q->connect(ptr, &DeviceManager::protocolDevRemoved, this, &DeviceProxyManagerPrivate::removeMounts);
     connections << q->connect(ptr, &DeviceManager::protocolDevMounted, this, &DeviceProxyManagerPrivate::addMounts);
     connections << q->connect(ptr, &DeviceManager::protocolDevUnmounted, this, &DeviceProxyManagerPrivate::removeMounts);
+
+    // redundant signal. this signal is emitted before the mount callback invoked, to make sure the cache is updated before use.
+    connections << q->connect(ptr, &DeviceManager::blockDevMountedManually, this, &DeviceProxyManagerPrivate::addMounts);
 
     currentConnectionType = kAPIConnecting;
 


### PR DESCRIPTION
在计算机页面双击进入光盘，将执行异步挂载操作，在挂载的回调函数中执行了目录跳转，从而触发了文件列表刷新及缩略图生成。
在缩略图模块中，会判定文件是否来源于外部设备。在调用判定外部设备文件的函数时，有可能返回 false。其原因是，该函数所使用的缓存依靠设备挂载的信号进行更新。
而设备挂载的异步函数执行时，该信号可能还未触发。
解决方案为，在设备挂载完成即将执行回调函数时，发出一个冗余的设备挂载信号用于更新 DeviceProxyManager 中的缓存信息，以便其他模块在访问该函数时，缓存已为最新。

`isFileOfExternalBlockMounts` function invoked when generate thumbnail,
and this function might return false when the optical device is just
mounted, which causes the thumbs cannot be displayed for optical files.

to fix this, emit a redundant signal before execute the callback function
to update the cache used by `isFileOfExternalBlockMounts` function.

Log: fix issue about thumbnail of optical files.

Bug: https://pms.uniontech.com/bug-view-211395.html
