### PR TITLE
fix: [io] After the small files copied, the task dialog does not disappear for a long time

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -113,6 +113,7 @@ private:   // block file copy
                                    char *buffer = nullptr,
                                    const bool isDir = false,
                                    const QFileDevice::Permissions permission = QFileDevice::Permission::ReadOwner);
+    void syncBlockFile(const FileInfoPointer toInfo);
 
 private:
     QSharedPointer<QWaitCondition> waitCondition { nullptr };

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1336,6 +1336,7 @@ void FileOperateBaseWorker::determineCountProcessType()
 
                         if (targetIsRemovable) {
                             countWriteType = CountWriteSizeType::kWriteBlockType;
+                            workData->isBlockDevice = true;
                             targetDeviceStartSectorsWritten = getSectorsWritten();
                         }
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
@@ -53,6 +53,7 @@ public:
     QMap<AbstractJobHandler::JobErrorType, AbstractJobHandler::SupportAction> errorOfAction;
     std::atomic_bool needSyncEveryRW { false };
     std::atomic_bool isFsTypeVfat { false };
+    std::atomic_bool isBlockDevice { false };
     std::atomic_int64_t currentWriteSize { 0 };
     QAtomicInteger<qint64> zeroOrlinkOrDirWriteSize { 0 };   // The copy size is 0. The write statistics size of the linked file and directory
     QAtomicInteger<qint64> blockRenameWriteSize { 0 };   // The copy size is 0. The write statistics size of the linked file and directory


### PR DESCRIPTION
Modify the synchronization policy so that for files copied to a USB flash drive, this file is synchronized once.

Log: After the small files copied, the task dialog does not disappear for a long time
Bug: https://pms.uniontech.com/bug-view-208033.html