### PR TITLE
挂载 cifs 时的参数列表更灵活

### DIFF
--- a/src/plugins/daemon/daemonplugin-mountcontrol/daemonplugin_mountcontrol_global.h
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/daemonplugin_mountcontrol_global.h
@@ -21,7 +21,7 @@ inline constexpr char kPort[] { "port" };
 inline constexpr char kIp[] { "ip" };
 inline constexpr char kMountName[] { "mntName" };
 inline constexpr char kTimeout[] { "timeout" };
-inline constexpr char kTryWaitReconn[] { "waitReconn" };
+inline constexpr char kVersion[] { "version" };
 inline constexpr char kUnmountAllStacked[] { "unmountAllStacked" };
 }
 

--- a/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper.h
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper.h
@@ -34,7 +34,8 @@ private:
     QString mountRoot();
     QString decryptPasswd(const QString &passwd);
     uint invokerUid();
-    std::string convertArgs(const QVariantMap &opts);
+    QString convertFixableArgs(const QVariantMap &opts);
+    QStringList generateFlexiableParamTable(const QVariantMap &opts);
     bool checkAuth();
     bool mkdir(const QString &path);
     bool rmdir(const QString &path);


### PR DESCRIPTION
在挂载前生成 cifs 灵活参数列表的组合，目前包括超时（handletimeout=1000*secs / wait_reconnect_timeout=secs 以及无超时参数）
和 （vers=default/2.0/1.0），一共9种组合，依次 retry 直到挂载成功或参数组合遍历结束。

as title.
generate a flexiable param table, and loop it until cifs share is mounted
or param table iterate finished.
return success or the last error info.

Log: support more flexiable params when mount cifs.

Bug: https://pms.uniontech.com/bug-view-210139.html
