### PR TITLE
feat: [cifs] mount cifs with flexiable version/timeout params

### DIFF
--- a/src/plugins/daemon/daemonplugin-mountcontrol/daemonplugin_mountcontrol_global.h
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/daemonplugin_mountcontrol_global.h
@@ -21,7 +21,7 @@ inline constexpr char kPort[] { "port" };
 inline constexpr char kIp[] { "ip" };
 inline constexpr char kMountName[] { "mntName" };
 inline constexpr char kTimeout[] { "timeout" };
-inline constexpr char kTryWaitReconn[] { "waitReconn" };
+inline constexpr char kVersion[] { "version" };
 inline constexpr char kUnmountAllStacked[] { "unmountAllStacked" };
 }
 

--- a/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper.h
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper.h
@@ -34,7 +34,8 @@ private:
     QString mountRoot();
     QString decryptPasswd(const QString &passwd);
     uint invokerUid();
-    std::string convertArgs(const QVariantMap &opts);
+    QString convertFixableArgs(const QVariantMap &opts);
+    QStringList generateFlexiableParamTable(const QVariantMap &opts);
     bool checkAuth();
     bool mkdir(const QString &path);
     bool rmdir(const QString &path);


### PR DESCRIPTION
as title.
generate a flexiable param table, and loop it until cifs share is mounted or param table iterate finished.
return success or the last error info.

Log: support more flexiable params when mount cifs.

Bug: https://pms.uniontech.com/bug-view-210139.html