### PR TITLE
修复计算机页面磁盘名称在特定字体下显示不完整的问题。

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -334,7 +334,10 @@ void ComputerItemDelegate::drawDeviceLabelAndFs(QPainter *painter, const QStyleO
     preRectForDevName.setTop(option.rect.top() + 10);
     preRectForDevName.setHeight(fm.height());
     painter->setPen(qApp->palette().color(/*(option.state & QStyle::StateFlag::State_Selected) ? QPalette::ColorRole::BrightText : */ QPalette::ColorRole::Text));   // PO: no highlight
-    painter->drawText(preRectForDevName, Qt::TextWrapAnywhere, devName, &realPaintedRectForDevName);
+
+    int realHeight = fm.boundingRect(devName).height();
+    preRectForDevName.adjust(0, fm.height() - realHeight, 0, 0);   // make sure the text will not be clipped.
+    painter->drawText(preRectForDevName, Qt::AlignVCenter, devName, &realPaintedRectForDevName);
 
     // draw filesystem tag behind label
     if (showFsTag) {


### PR DESCRIPTION
disk name in computer view is clipped, the height of chinese charactors
is bigger than alpha charactors, so the paint rect is small than its
real bounding rect.

as title.

Log: fix issue about a UI issue.
