### PR TITLE
fix: [io]Multi-tiered mass file copying to vault within SMB is very slow

### DIFF
--- a/include/dfm-base/interfaces/abstractjobhandler.h
+++ b/include/dfm-base/interfaces/abstractjobhandler.h
@@ -33,6 +33,7 @@ public:
         kDontFormatFileName = 0x100,   // 拷贝时不处理文件名称
         kRevocation = 0x200,   // 拷贝时不处理文件名称
         kCopyRemote = 0x400,   // 深信服远程拷贝
+        kCountProgressCustomize = 0x800,   // 强制使用自己统计进度
     };
     Q_ENUM(JobFlag)
     Q_DECLARE_FLAGS(JobFlags, JobFlag)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -715,7 +715,9 @@ void FileOperateBaseWorker::initCopyWay()
         workData->signalThread = false;
     }
 
-    if (DeviceUtils::isSamba(targetUrl) || DeviceUtils::isFtp(targetUrl))
+    if (DeviceUtils::isSamba(targetUrl)
+            || DeviceUtils::isFtp(targetUrl)
+            || workData->jobFlags.testFlag(AbstractJobHandler::JobFlag::kCountProgressCustomize))
         countWriteType = CountWriteSizeType::kCustomizeType;
 
     if (!workData->signalThread) {

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultfilehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultfilehelper.cpp
@@ -49,8 +49,10 @@ bool VaultFileHelper::cutFile(const quint64 windowId, const QList<QUrl> sources,
             actualUrls << url;
         }
     }
+    auto tmpFlags = flags;
+    tmpFlags |= AbstractJobHandler::JobFlag::kCountProgressCustomize;
     const QUrl url = transUrlsToLocal({ target }).first();
-    dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kCutFile, windowId, actualUrls, url, flags, nullptr);
+    dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kCutFile, windowId, actualUrls, url, tmpFlags, nullptr);
 
     return true;
 }
@@ -70,8 +72,10 @@ bool VaultFileHelper::copyFile(const quint64 windowId, const QList<QUrl> sources
     }
 
     // if use &, transUrlsToLocal return value will free, and url is invalid, app crash, the same below
+    auto tmpFlags = flags;
+    tmpFlags |= AbstractJobHandler::JobFlag::kCountProgressCustomize;
     const QUrl url = transUrlsToLocal({ target }).first();
-    dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kCopy, windowId, actualUrls, url, flags, nullptr);
+    dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kCopy, windowId, actualUrls, url, tmpFlags, nullptr);
     return true;
 }
 


### PR DESCRIPTION
Here the copy is not slow, it's a problem when counting write speeds before there is a tid for the thread, read the io corresponding to this tid in the system and get the write size error. Modify to add jogflag to set up for their own statistics copy progress.

Log: Multi-tiered mass file copying to vault within SMB is very slow
Bug: https://pms.uniontech.com/bug-view-212635.html