### PR TITLE
修复压缩文件预览的一些问题

### DIFF
--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/events/avfseventhandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/events/avfseventhandler.cpp
@@ -72,7 +72,7 @@ bool AvfsEventHandler::hookEnterPressed(quint64 winId, const QList<QUrl> &urls)
 bool AvfsEventHandler::sepateTitlebarCrumb(const QUrl &url, QList<QVariantMap> *mapGroup)
 {
     Q_ASSERT(mapGroup);
-    if (url.scheme() == AvfsUtils::scheme()) {
+    if (url.scheme() == AvfsUtils::scheme() || url.path().startsWith(AvfsUtils::avfsMountPoint() + "/")) {
         *mapGroup = AvfsUtils::seperateUrl(url);
         return true;
     }

--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/files/avfsfileiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/files/avfsfileiterator.cpp
@@ -12,8 +12,9 @@ using namespace dfmplugin_avfsbrowser;
 DFMBASE_USE_NAMESPACE
 
 AvfsFileIterator::AvfsFileIterator(const QUrl &url, const QStringList &nameFilters, QDir::Filters filters, QDirIterator::IteratorFlags flags)
-    : LocalDirIterator(AvfsUtils::avfsUrlToLocal(url), nameFilters, filters, flags), d(new AvfsFileIteratorPrivate(url, this))
+    : AbstractDirIterator(AvfsUtils::avfsUrlToLocal(url), nameFilters, filters, flags), d(new AvfsFileIteratorPrivate(url, this))
 {
+    d->proxy = new LocalDirIterator(AvfsUtils::avfsUrlToLocal(url), nameFilters, filters, flags);
 }
 
 AvfsFileIterator::~AvfsFileIterator()
@@ -25,24 +26,30 @@ AvfsFileIteratorPrivate::AvfsFileIteratorPrivate(const QUrl &root, AvfsFileItera
 {
 }
 
+AvfsFileIteratorPrivate::~AvfsFileIteratorPrivate()
+{
+    if (proxy)
+        delete proxy;
+}
+
 QUrl AvfsFileIterator::next()
 {
-    return AvfsUtils::localUrlToAvfsUrl(LocalDirIterator::next());
+    return AvfsUtils::localUrlToAvfsUrl(d->proxy->next());
 }
 
 bool AvfsFileIterator::hasNext() const
 {
-    return LocalDirIterator::hasNext();
+    return d->proxy->hasNext();
 }
 
 QString AvfsFileIterator::fileName() const
 {
-    return LocalDirIterator::fileName();
+    return d->proxy->fileName();
 }
 
 QUrl AvfsFileIterator::fileUrl() const
 {
-    return AvfsUtils::localUrlToAvfsUrl(LocalDirIterator::fileUrl());
+    return AvfsUtils::localUrlToAvfsUrl(d->proxy->fileUrl());
 }
 
 const FileInfoPointer AvfsFileIterator::fileInfo() const

--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/files/avfsfileiterator.h
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/files/avfsfileiterator.h
@@ -12,7 +12,7 @@
 namespace dfmplugin_avfsbrowser {
 
 class AvfsFileIteratorPrivate;
-class AvfsFileIterator : public DFMBASE_NAMESPACE::LocalDirIterator
+class AvfsFileIterator : public DFMBASE_NAMESPACE::AbstractDirIterator
 {
     Q_OBJECT
 

--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp
@@ -117,7 +117,7 @@ bool AvfsMenuScene::triggered(QAction *action)
         else if (id == kOpen)
             AvfsEventHandler::instance()->hookOpenFiles(d->windowId, d->selectFiles);
         else if (id == kProperty)
-            AvfsEventHandler::instance()->showProperty(d->selectFiles);
+            AvfsEventHandler::instance()->showProperty(d->selectFiles.isEmpty() ? QList<QUrl> { d->currentDir } : d->selectFiles);
 
         return true;
     }

--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/private/avfsfileiterator_p.h
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/private/avfsfileiterator_p.h
@@ -7,6 +7,8 @@
 
 #include "dfmplugin_avfsbrowser_global.h"
 
+#include <dfm-base/file/local/localdiriterator.h>
+
 #include <QUrl>
 
 namespace dfmplugin_avfsbrowser {
@@ -18,10 +20,12 @@ class AvfsFileIteratorPrivate
 
 public:
     explicit AvfsFileIteratorPrivate(const QUrl &root, AvfsFileIterator *qq);
+    ~AvfsFileIteratorPrivate();
 
 private:
     AvfsFileIterator *q { nullptr };
     QUrl root;
+    dfmbase::LocalDirIterator *proxy { nullptr };
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/utils/avfsutils.h
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/utils/avfsutils.h
@@ -52,7 +52,7 @@ public:
     static QUrl makeAvfsUrl(const QString &path);
 
     static QList<QVariantMap> seperateUrl(const QUrl &url);
-    static QString parseDirIcon(const QString &path);
+    static QString parseDirIcon(QString path);
 
 private:
     explicit AvfsUtils(QObject *parent = nullptr);


### PR DESCRIPTION
1. 压缩文件内的右键菜单处理；
2. 顶部 crumbbar 的分段处理；

as title, the path of crumbbar item is not correct when enter a avfs
file. path should be the local path if there is no avfs file in

Log: fix issue about archive preview.

Bug: https://pms.uniontech.com/bug-view-212743.html
