### PR TITLE
chore: update the baseline version to 6.0.25 that fixed boomark issues

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.0.25) unstable; urgency=medium
+
+  * update file manager V6.0.25 baseline version
+
+ -- lvwujun <lvwujun@uniontech.com>  Wed, 2 Aug 2023 10:05:21 +0800
+
 dde-file-manager (6.0.24) unstable; urgency=medium
 
   * update file manager V6.0.24 baseline version


### PR DESCRIPTION
update the baseline version to 6.0.25 that fixed boomark issues

Log: update the baseline version to 6.0.25 that fixed boomark issues
Bug: yes