### PR TITLE
fix: [bookmark] cd bookmark dir failed

### DIFF
--- a/src/plugins/common/core/dfmplugin-bookmark/bookmarkcallback.cpp
+++ b/src/plugins/common/core/dfmplugin-bookmark/bookmarkcallback.cpp
@@ -87,7 +87,7 @@ void BookmarkCallBack::cdBookMarkUrlCallBack(quint64 windowId, const QUrl &url)
     }
 
     FileInfoPointer info = InfoFactory::create<FileInfo>(url);
-    if (info && info->exists() && info->isDir()) {
+    if (info && info->exists() && info->isAttributes(OptInfoType::kIsDir)) {
         BookMarkEventCaller::sendOpenBookMarkInWindow(windowId, url);
         return;
     } else if (DeviceUtils::isSamba(url) || DeviceUtils::isFtp(url)) {


### PR DESCRIPTION
fileinfo should use isAttributes not isdir

Log: as de s
Bug: no