### PR TITLE
fix: [fileinfo]File display Icon is displayed incorrectly and has no name, after refreshing it is normal

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -540,6 +540,7 @@ bool AsyncFileInfo::asyncQueryDfmFileInfo(int ioPriority, FileInfo::initQuerierA
     }
 
     d->dfmFileInfo->initQuerierAsync(ioPriority, func, userData);
+    d->cacheing = false;
     return true;
 }
 

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -561,7 +561,7 @@ QUrl DFMBASE_NAMESPACE::FileInfoPrivate::getUrlByNewFileName(const QString &file
  */
 QString FileInfoPrivate::fileName() const
 {
-    QString filePath = q->pathOf(PathInfoType::kFilePath);
+    QString filePath = q->fileUrl().path();
 
     if (filePath.endsWith(QDir::separator())) {
         filePath.chop(1);

--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -57,8 +57,6 @@ void FileInfoHelper::threadHandleDfmFileInfo(const QSharedPointer<FileInfo> dfil
         for (const auto &strToken : notifyUrls.values(url))
             emit fileRefreshFinished(url, strToken, true);
     }
-
-    qureingInfo.removeOneByLock(asyncInfo);
 }
 
 QSharedPointer<FileInfoHelperUeserData> FileInfoHelper::fileCountAsync(QUrl &url)
@@ -131,24 +129,20 @@ void FileInfoHelper::aboutToQuit()
 
 void FileInfoHelper::handleFileRefresh(QSharedPointer<FileInfo> dfileInfo)
 {
-    assert(qApp->thread() == QThread::currentThread());
     if (stoped)
         return;
+
+    assert(qApp->thread() == QThread::currentThread());
 
     if (!dfileInfo)
         return;
 
     auto asyncInfo = dfileInfo.dynamicCast<AsyncFileInfo>();
-    if (!asyncInfo) {
-        return;
-    }
-
-    if (qureingInfo.containsByLock(asyncInfo))
+    if (!asyncInfo)
         return;
 
-    qureingInfo.push_backByLock(asyncInfo);
     FileRefreshCallBackData *data = new FileRefreshCallBackData;
     data->info = asyncInfo;
     if (!asyncInfo->asyncQueryDfmFileInfo(0, &FileInfoHelper::fileRefreshAsyncCallBack, data))
-        qureingInfo.removeOneByLock(asyncInfo);
+        delete data;
 }

--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -66,7 +66,6 @@ private:
     QSharedPointer<FileInfoAsycWorker> worker { nullptr };
     std::atomic_bool stoped { false };
     QThreadPool pool;
-    DThreadList<FileInfoPointer> qureingInfo;
 };
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -670,7 +670,7 @@ void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const QString &infoP
     if (!fileInfo || QString::number(quintptr(fileInfo.data()), 16) != infoPtr)
         return;
 
-    if (isLinkOrg && fileInfo)
+    if (fileInfo)
         itemdata->fileInfo()->customData(Global::ItemRoles::kItemFileRefreshIcon);
 
     handleUpdateFile(url);


### PR DESCRIPTION
After deleting a file, other plugins create fileinfo in into causing refresh, gio goes to asynchronously query the file information if the file doesn't exist, there is no callback function. Modify does not record whether the current fileinfo is querying.

Log: File display Icon is displayed incorrectly and has no name, after refreshing it is normal
Bug: https://pms.uniontech.com/bug-view-212879.html