### PR TITLE
修复关闭压缩预览后，进入保险箱目录后无法从地址块跳转上级路径的问题。

### DIFF
--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/events/avfseventhandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/events/avfseventhandler.cpp
@@ -72,6 +72,10 @@ bool AvfsEventHandler::hookEnterPressed(quint64 winId, const QList<QUrl> &urls)
 bool AvfsEventHandler::sepateTitlebarCrumb(const QUrl &url, QList<QVariantMap> *mapGroup)
 {
     Q_ASSERT(mapGroup);
+
+    if (!AvfsUtils::archivePreviewEnabled())
+        return false;
+
     if (url.scheme() == AvfsUtils::scheme() || url.path().startsWith(AvfsUtils::avfsMountPoint() + "/")) {
         *mapGroup = AvfsUtils::seperateUrl(url);
         return true;


### PR DESCRIPTION
if archive-preview is disabled, the crumbbar should not be splited by
avfs module.
check if archive-preview is enable before do splitUrl.

Log: fix issue about crumbbar.
