### PR TITLE
fix: [fileinfo]Properties dialog crashes when copying large files in vault

### DIFF
--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -264,6 +264,7 @@ public:
 
 protected:
     explicit FileInfo(const QUrl &url);
+    mutable QReadWriteLock extendOtherCacheLock;
     mutable QMap<FileInfo::FileExtendedInfoType, QVariant> extendOtherCache;
     QString pinyinName;
 

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -85,6 +85,10 @@ void AsyncFileInfo::refresh()
         d->attributesExtend.clear();
         d->extendIDs.clear();
         d->fileIcon = QIcon();
+
+    }
+    {
+        QWriteLocker locker(&extendOtherCacheLock);
         extendOtherCache.clear();
     }
 }
@@ -457,7 +461,10 @@ QVariant AsyncFileInfo::customData(int role) const
 {
     using namespace dfmbase::Global;
     if (role == kItemFileRefreshIcon) {
-        extendOtherCache.remove(ExtInfoType::kFileThumbnail);
+        {
+            QWriteLocker lk(&extendOtherCacheLock);
+            extendOtherCache.remove(ExtInfoType::kFileThumbnail);
+        }
         QWriteLocker locker(&d->iconLock);
         d->fileIcon = QIcon();
         return QVariant();

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -106,6 +106,10 @@ bool SyncFileInfo::exists() const
  */
 void SyncFileInfo::refresh()
 {
+    {
+        QWriteLocker locker(&extendOtherCacheLock);
+        extendOtherCache.clear();
+    }
     QWriteLocker locker(&d->lock);
     d->dfmFileInfo->refresh();
     d->fileCountFuture.reset(nullptr);

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -421,6 +421,7 @@ QVariant dfmbase::FileInfo::extendAttributes(const ExtInfoType type) const
     case FileExtendedInfoType::kGroupId:
         return static_cast<uint>(-1);
     default:
+        QReadLocker locker(&extendOtherCacheLock);
         return extendOtherCache.value(type);
     }
 }
@@ -462,6 +463,7 @@ QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> DFMBASE_NAMESPACE::FileInfo:
   */
 void DFMBASE_NAMESPACE::FileInfo::setExtendedAttributes(const ExtInfoType &key, const QVariant &value)
 {
+    QWriteLocker locker(&extendOtherCacheLock);
     extendOtherCache.insert(key, value);
 }
 /*!

--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -114,7 +114,6 @@ FileInfoHelper::~FileInfoHelper()
 FileInfoHelper &FileInfoHelper::instance()
 {
     static FileInfoHelper helper;
-    helper.moveToThread(qApp->thread());
     return helper;
 }
 


### PR DESCRIPTION
Thumbnails use fileinfo's map extendOtherCache, which is used in the properties dialog. fileinfo is refreshed because it is being copied. multiple threads are operating on extendOtherCache at the same time. locking is applied to the map.

Log: Properties dialog crashes when copying large files in vault
Bug: https://pms.uniontech.com/bug-view-213319.html