### PR TITLE
fix: When copying a large file to smb/ftp, the file icon keeps flashing

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -84,8 +84,6 @@ void AsyncFileInfo::refresh()
         d->extraProperties.clear();
         d->attributesExtend.clear();
         d->extendIDs.clear();
-        d->fileIcon = QIcon();
-
     }
     {
         QWriteLocker locker(&extendOtherCacheLock);


### PR DESCRIPTION
During the copying process, the file information is constantly being refreshed, and the file icon will be cleared.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-213293.html
