### PR TITLE
fix: Copy files to the MTP without showing thumbnails

### DIFF
--- a/src/dfm-base/utils/thumbnail/private/thumbnailworker_p.h
+++ b/src/dfm-base/utils/thumbnail/private/thumbnailworker_p.h
@@ -21,7 +21,6 @@ public:
     explicit ThumbnailWorkerPrivate(ThumbnailWorker *qq);
     QString createThumbnail(const QUrl &url, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
     bool checkFileStable(const QUrl &url);
-    QIcon createIcon(const QString &iconName);
 
     ThumbnailWorker *q { nullptr };
     DMimeDatabase mimeDb;

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -94,12 +94,12 @@ QImage ThumbnailCreators::videoThumbnailCreatorLib(const QString &filePath, Thum
 {
     Q_UNUSED(size)
 
-    static QLibrary *lib = new QLibrary("libimageviewer.so", qApp);
+    static QLibrary lib("libimageviewer.so");
     QImage img;
 
-    if (lib && (lib->isLoaded() || lib->load())) {
+    if (lib.isLoaded() || lib.load()) {
         typedef void (*GetMovieCover)(const QUrl &, const QString &, QImage *);
-        GetMovieCover func = reinterpret_cast<GetMovieCover>(lib->resolve("getMovieCover"));
+        GetMovieCover func = reinterpret_cast<GetMovieCover>(lib.resolve("getMovieCover"));
 
         if (func)
             func(QUrl::fromLocalFile(filePath), filePath, &img);

--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -111,7 +111,6 @@ bool ThumbnailHelper::checkMimeTypeSupport(const QMimeType &mime)
                  || mimeName == Mime::kTypeAppMxf))
         return checkStatus(Application::kPreviewDocumentFile);
 
-    qDebug() << "thumbnail: not supported mimetype: " << mime;
     return false;
 }
 

--- a/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
@@ -76,27 +76,12 @@ bool ThumbnailWorkerPrivate::checkFileStable(const QUrl &url)
         return true;
 
     // 修改时间稳定
-    qint64 mtime = info->timeOf(TimeInfoType::kLastModifiedSecond).toLongLong();
+    qint64 mtime = info->timeOf(TimeInfoType::kMetadataChangeTimeSecond).toLongLong();
     qint64 curTime = QDateTime::currentDateTime().toTime_t();
     if (curTime - mtime < 2)
         return false;
 
     return true;
-}
-
-QIcon ThumbnailWorkerPrivate::createIcon(const QString &iconName)
-{
-    QIcon icon(iconName);
-    if (!icon.isNull()) {
-        QPixmap pixmap = icon.pixmap(Global::kLarge, Global::kLarge);
-        QPainter pa(&pixmap);
-        pa.setPen(Qt::gray);
-        pa.drawPixmap(0, 0, pixmap);
-
-        icon.addPixmap(pixmap);
-    }
-
-    return icon;
 }
 
 ThumbnailWorker::ThumbnailWorker(QObject *parent)
@@ -161,8 +146,8 @@ void ThumbnailWorker::createThumbnail(const QUrl &url, Global::ThumbnailSize siz
     // if not, rejoin the event queue and create thumbnail later
     if (!d->checkFileStable(url)) {
         QMetaObject::invokeMethod(this, "onTaskAdded", Qt::QueuedConnection,
-                                    Q_ARG(QUrl, d->originalUrl),
-                                    Q_ARG(Global::ThumbnailSize, size));
+                                  Q_ARG(QUrl, d->originalUrl),
+                                  Q_ARG(dfmbase::Global::ThumbnailSize, size));
         return;
     }
 


### PR DESCRIPTION
1.The last modification time in the file information is incorrect
2.QMetaObject: : invokeMethod parameter type is not correct

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-212871.html
