### PR TITLE
fix: [vault] the root dir label show error

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
@@ -213,6 +213,17 @@ QIcon VaultFileInfo::fileIcon()
     return proxy->fileIcon();
 }
 
+QString VaultFileInfo::viewOfTip(const FileInfo::ViewType type) const
+{
+    if (type == ViewType::kEmptyDir) {
+        if (url == VaultHelper::instance()->rootUrl()) {
+            return FileInfo::viewOfTip(type);
+        }
+    }
+
+    return ProxyFileInfo::viewOfTip(type);
+}
+
 qint64 VaultFileInfo::size() const
 {
     if (!proxy)

--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.h
@@ -41,6 +41,7 @@ public:
     virtual QString nameOf(const FileNameInfoType type) const override;
 
     virtual QString displayOf(const DisplayInfoType type) const override;
+    virtual QString viewOfTip(const ViewType type) const override;
 };
 }
 #endif   //! VAULTFILEINFO_H


### PR DESCRIPTION
the root dir label show error when the dir is empty.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-213329.html