### PR TITLE
fix: Holding down the Enter key in the search bar will always trigger the search

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
@@ -705,8 +705,12 @@ void AddressBar::keyPressEvent(QKeyEvent *e)
             return;
         case Qt::Key_Enter:
         case Qt::Key_Return:
-            emit returnPressed();
-            e->accept();
+            if (e->isAutoRepeat()) {
+                e->ignore();
+            } else {
+                emit returnPressed();
+                e->accept();
+            }
             return;
         default:
             break;


### PR DESCRIPTION
Press Enter to trigger only one search

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-213499.html
