### PR TITLE
fix: start before kwin

### DIFF
--- a/debian/dde-file-manager.conffiles
+++ b/debian/dde-file-manager.conffiles
@@ -1,0 +1,1 @@
+remove-on-upgrade /etc/xdg/autostart/dde-filemanager-server.desktop

--- a/debian/dde-file-manager.install
+++ b/debian/dde-file-manager.install
@@ -25,4 +25,3 @@ usr/lib/systemd/user/
 etc/dbus-1/system.d/com.deepin.filemanager.daemon.conf
 etc/X11/Xsession.d/99dfm-dlnfs-automount
 etc/deepin/dde-file-manager/dfm-dlnfs-automount
-etc/xdg/autostart

--- a/src/apps/dde-file-manager-server/CMakeLists.txt
+++ b/src/apps/dde-file-manager-server/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRCS
     main.cpp
 )
 
+find_package(PkgConfig REQUIRED)
 find_package(Qt5 COMPONENTS
     Core
     DBus
@@ -36,6 +37,16 @@ target_link_libraries(
     ${DtkWidget_LIBRARIES}
 )
 
+if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
+    pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)
+endif()
+
+macro(install_symlink filepath wantsdir)
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/link/${wantsdir}/)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${SYSTEMD_USER_UNIT_DIR}/${filepath} ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath})
+    install(FILES ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath} DESTINATION ${SYSTEMD_USER_UNIT_DIR}/${wantsdir}/)
+endmacro(install_symlink)
+
 # binary
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
@@ -47,6 +58,4 @@ install(FILES dbusservice/org.deepin.filemanager.server.service
 install(FILES dbusservice/dde-filemanager-server.service
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/user)
 
-# xdg-autostart
-install(FILES dbusservice/dde-filemanager-server.desktop
-    DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/xdg/autostart)
+install_symlink(dde-filemanager-server.service dde-session-initialized.target.wants)

--- a/src/apps/dde-file-manager-server/dbusservice/dde-filemanager-server.desktop
+++ b/src/apps/dde-file-manager-server/dbusservice/dde-filemanager-server.desktop
@@ -1,8 +1,0 @@
-[Desktop Entry]
-Comment=DDE File Manager Server
-Exec=systemctl --user enable dde-filemanager-server.service --now --runtime
-Name=DDE File Manager Server
-NoDisplay=true
-OnlyShowIn=Deepin;DDE
-Type=Application
-X-Deepin-Vendor=user-custom

--- a/src/apps/dde-file-manager-server/dbusservice/dde-filemanager-server.service
+++ b/src/apps/dde-file-manager-server/dbusservice/dde-filemanager-server.service
@@ -1,6 +1,13 @@
 [Unit]
 Description=DDE File Manager Server
 
+Requisite=dde-session-pre.target
+After=dde-session-pre.target
+
+Requisite=dde-session-initialized.target
+PartOf=dde-session-initialized.target
+Before=dde-session-initialized.target
+
 [Service]
 Type=dbus
 BusName=org.deepin.filemanager.server


### PR DESCRIPTION
调整 dde-file-manager 启动顺序和依赖关系

Log: start before kwin