### PR TITLE
fix: [asyncfileinfo] exist() Error

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -986,8 +986,7 @@ void AsyncFileInfoPrivate::cacheAllAttributes()
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardFilePath, filePath());
     tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardParentPath, path());
     auto tmpdfmfileinfo = dfmFileInfo;
-    if (tmpdfmfileinfo)
-        tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardFileExists, tmpdfmfileinfo->exists());
+    tmp.insert(AsyncFileInfo::AsyncAttributeID::kStandardFileExists, DFile(q->fileUrl()).exists());
     // redirectedFileUrl
     auto symlink = symLinkTarget();
     if (attribute(DFileInfo::AttributeID::kStandardIsSymlink).toBool()


### PR DESCRIPTION
When creating an async file,fileinfo exist()error,evident on low performance machines

Log: as des
Bug: https://pms.uniontech.com/bug-view-213439.html.