### PR TITLE
fix: [trash]Incorrect dde-desktop trash icon

### DIFF
--- a/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashcore.cpp
@@ -18,10 +18,10 @@ using namespace dfmplugin_trashcore;
 
 void TrashCore::initialize()
 {
-    TrashCoreEventSender::instance();
-
     DFMBASE_NAMESPACE::UrlRoute::regScheme(TrashCoreHelper::scheme(), "/", TrashCoreHelper::icon(), true, tr("Trash"));
     DFMBASE_NAMESPACE::InfoFactory::regClass<TrashFileInfo>(TrashCoreHelper::scheme(), DFMBASE_NAMESPACE::InfoFactory::kNoCache);
+
+    TrashCoreEventSender::instance();
 
     dpfSlotChannel->connect(DPF_MACRO_TO_STR(DPTRASHCORE_NAMESPACE), "slot_TrashCore_EmptyTrash",
                             TrashCoreEventReceiver::instance(), &TrashCoreEventReceiver::handleEmptyTrash);


### PR DESCRIPTION
When initializing TrashCoreEventSender, the FileUtils::trashIsEmpty interface is called to set the flag isEmpty in TrashCoreEventSender. at this time, trashinfo is not yet registered, so the TrashCoreEventSender flag isEmpty is true, clearing the trash will not send the trash is empty event. Modify to register trashinfo first then initialize TrashCoreEventSender.

Log: Incorrect dde-desktop trash icon
Bug: https://pms.uniontech.com/bug-view-213989.html