### PR TITLE
fix: [file-preview] the file preivew dialog show error.

### DIFF
--- a/src/plugins/common/dfmplugin-preview/filepreview/views/filepreviewdialog.cpp
+++ b/src/plugins/common/dfmplugin-preview/filepreview/views/filepreviewdialog.cpp
@@ -291,8 +291,9 @@ void FilePreviewDialog::switchToPage(int index)
                 preview->contentWidget()->adjustSize();
                 int newPerviewWidth = preview->contentWidget()->size().width();
                 int newPerviewHeight = preview->contentWidget()->size().height();
-                resize(newPerviewWidth, newPerviewHeight + statusBar->height());
+                setFixedSize(newPerviewWidth, newPerviewHeight + statusBar->height());
                 playCurrentPreviewFile();
+                moveToCenter();
                 return;
             }
         }
@@ -355,8 +356,9 @@ void FilePreviewDialog::switchToPage(int index)
     preview->contentWidget()->adjustSize();
     int newPerviewWidth = preview->contentWidget()->size().width();
     int newPerviewHeight = preview->contentWidget()->size().height();
-    resize(newPerviewWidth, newPerviewHeight + statusBar->height());
+    setFixedSize(newPerviewWidth, newPerviewHeight + statusBar->height());
     updateTitle();
+    moveToCenter();
 }
 
 void FilePreviewDialog::previousPage()


### PR DESCRIPTION
problem:
    the file preview dialog shwo error and not move to center.
solve:
    1. set the dialog fixed size.
    2. set the dialog move to center.
Log: fix issue
Bug: https://pms.uniontech.com/bug-view-213489.html