### PR TITLE
修复组策略隐藏磁盘的逻辑问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
@@ -268,6 +268,7 @@ void ComputerView::hideSpecificDisks(const QList<QUrl> &hiddenDisks)
         return;
     }
 
+    qInfo() << "ignored/hidden disks:" << hiddenDisks;
     for (int i = 7; i < model->items.count(); i++) {   // 7 means where the disk group start.
         auto item = model->items.at(i);
         this->setRowHidden(i, hiddenDisks.contains(item.url));

--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -655,7 +655,7 @@ void ComputerItemWatcher::onDeviceAdded(const QUrl &devUrl, int groupId, Compute
 
     cacheItem(data);
 
-    if (needSidebarItem)
+    if (!disksHiddenByDConf().contains(devUrl) && needSidebarItem)
         addSidebarItem(info);
 }
 


### PR DESCRIPTION
在组策略隐藏了磁盘项后，移除设备再接入设备。
在设备添加到计算机页面后执行了显示控制的更新，因设备在组策略列表内，因此计算机页面不显示设备项
而往侧边栏添加时，没有检查设备是否在隐藏列表内，导致侧边栏依然显示设备项

the DConfig hiddenDisks contain the plugined disk, but device still show
in sidebar.
no any check before add items in sidebar.

Log: fix issue about device hidden by DConfig.

Bug: https://pms.uniontech.com/bug-view-214055.html
