### PR TITLE
fix: [ui] Problems drawing the icon icon for an item on a sidebar

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -39,7 +39,9 @@ public Q_SLOTS:
     void onEditorTextChanged(const QString &text, const FileInfoPointer &info) const;
 
 private:
-    void drawIcon(const QStyleOptionViewItem &option, QPainter *painter, const QIcon &icon, const QRect &itemRect, QIcon::Mode iconMode, bool isEjectable) const;
+    void drawIcon(const QStyleOptionViewItem &option, QPainter *painter,
+                  const QRect &itemRect, bool isEjectable, QSize iconSize, QIcon::Mode iconMode, QPalette::ColorGroup cg) const;
+
     void drawMouseHoverBackground(QPainter *painter, const DPalette &palette, const QRect &r, const QColor &widgetColor) const;
     void drawMouseHoverExpandButton(QPainter *painter, const QRect &r, bool isExpanded) const;
 


### PR DESCRIPTION
If there is the same icon object in titbar and sidebar, using `QStyle::drawItemPixmap` passed into `QIcon::Disabled` will result in an exception for the color drawn in DTK. This modification uses the QStyleOptionViewItem::icon object directly, which should be a standalone object, not cached.

Log: fix ui bug

Bug: https://pms.uniontech.com/bug-view-211909.html