### PR TITLE
fix: [quickaccess] do not show removing bookmark notice

### DIFF
--- a/src/plugins/common/core/dfmplugin-bookmark/bookmarkcallback.cpp
+++ b/src/plugins/common/core/dfmplugin-bookmark/bookmarkcallback.cpp
@@ -13,6 +13,9 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/interfaces/fileinfo.h>
 #include <dfm-framework/event/event.h>
+
+#include <dfm-io/dfile.h>
+
 #include <DMenu>
 
 #include <QApplication>
@@ -87,7 +90,7 @@ void BookmarkCallBack::cdBookMarkUrlCallBack(quint64 windowId, const QUrl &url)
     }
 
     FileInfoPointer info = InfoFactory::create<FileInfo>(url);
-    if (info && info->exists() && info->isAttributes(OptInfoType::kIsDir)) {
+    if (info && dfmio::DFile(url).exists() && info->isAttributes(OptInfoType::kIsDir)) {
         BookMarkEventCaller::sendOpenBookMarkInWindow(windowId, url);
         return;
     } else if (DeviceUtils::isSamba(url) || DeviceUtils::isFtp(url)) {


### PR DESCRIPTION

If a bookmark is created from USB disk, after ejecting USB disk, when access the bookmark, there is no notice dialog for remving bookmark.

Log: fix do not show removing bookmark notice after ejecting USB disk
Bug: https://pms.uniontech.com/bug-view-213427.html