### PR TITLE
修复两个磁盘类型识别的问题

### DIFF
--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -60,6 +60,7 @@ public:
     static QString nameOfEncrypted(const QVariantMap &datas);
     static QString nameOfDefault(const QString &label, const quint64 &size);
     static QString nameOfSize(const quint64 &size);
+    static QString nameOfAlias(const QString &uuid);
 
     static bool checkDiskEncrypted();
     static QStringList encryptedDisks();

--- a/src/external/dde-dock-plugins/disk-mount/device/devicewatcherlite.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/devicewatcherlite.cpp
@@ -82,9 +82,10 @@ QStringList DeviceWatcherLite::allMountedRemovableBlocks()
         }
 
         // NOTE(xust): removable/hintSystem is not always correct in some certain hardwares.
-        if (!devPtr->ejectable())
-            continue;
         if (!devPtr->canPowerOff() && !devPtr->optical())
+            continue;
+        // ignore blocks not mounted under /media/
+        if (!devPtr->mountPoint().startsWith("/media/"))
             continue;
 
         mountedRemovable.append(dev);

--- a/src/external/dde-dock-plugins/disk-mount/device/devicewatcherlite.h
+++ b/src/external/dde-dock-plugins/disk-mount/device/devicewatcherlite.h
@@ -51,6 +51,12 @@ Q_SIGNALS:
 private:
     void unmountStacked(const QString &mpt);
     void removeDevice(bool unmountDone, QSharedPointer<dfmmount::DBlockDevice> blk);
+    bool isSiblingOfRoot(QSharedPointer<dfmmount::DBlockDevice> blkDev);
+    enum SearchBy {
+        kSearchByMountPoint,
+        kSearchByDevice,
+    };
+    static QString getMountInfo(const QString &in, SearchBy what);
 
 private:
     explicit DeviceWatcherLite(QObject *parent = nullptr);

--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -174,15 +174,16 @@ EntryFileInfo::EntryOrder BlockEntryFileEntity::order() const
     // NOTE(xust): removable/hintSystem is not always correct in some certain hardwares.
     if (datas.value(DeviceProperty::kMountPoint).toString() == "/")
         return EntryFileInfo::EntryOrder::kOrderSysDiskRoot;
-    if (datas.value(DeviceProperty::kIdLabel).toString().startsWith("_dde_"))
+
+    bool canPowerOff = datas.value(DeviceProperty::kCanPowerOff).toBool();
+    if (datas.value(DeviceProperty::kIdLabel).toString().startsWith("_dde_data") /* && !canPowerOff*/)
         return EntryFileInfo::EntryOrder::kOrderSysDiskData;
 
     if (datas.value(DeviceProperty::kOptical).toBool()
-            || datas.value(DeviceProperty::kOpticalDrive).toBool())
+        || datas.value(DeviceProperty::kOpticalDrive).toBool())
         return EntryFileInfo::EntryOrder::kOrderOptical;
 
-    if (datas.value(DeviceProperty::kEjectable).toBool()
-            && datas.value(DeviceProperty::kCanPowerOff).toBool())
+    if (canPowerOff)
         return EntryFileInfo::EntryOrder::kOrderRemovableDisks;
 
     return EntryFileInfo::EntryOrder::kOrderSysDisks;

--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.h
@@ -46,6 +46,7 @@ private:
     void loadDiskInfo();
     void loadWindowsVoltag();
     void resetWindowsVolTag();
+    bool isSiblingOfRoot() const;
 };
 
 }


### PR DESCRIPTION
1. 修复移动硬盘被识别为内置硬盘的问题；
2. 修复根设备的兄弟设备类型与根设备不一致的问题；

- fix: [removable] removable harddisk recognize as builtin disk.
- fix: [device] sibling of root disk can be unmounted.
