### PR TITLE
fix: root window geometry is error when fake screen is replaced to real

### DIFF
--- a/src/plugins/desktop/core/ddplugin-core/core.h
+++ b/src/plugins/desktop/core/ddplugin-core/core.h
@@ -37,6 +37,8 @@ public slots:
     DFMBASE_NAMESPACE::AbstractDesktopFrame *desktopFrame();
     QList<QWidget *> rootWindows();
     void layoutWidget();
+
+    bool screensInUse(QStringList *out);
 private slots:
     void publishScreenChanged();
     void publishDisplayModeChanged();
@@ -97,6 +99,8 @@ private:
     DPF_EVENT_REG_SLOT(slot_ScreenProxy_DisplayMode)
     DPF_EVENT_REG_SLOT(slot_ScreenProxy_LastChangedMode)
     DPF_EVENT_REG_SLOT(slot_ScreenProxy_Reset)
+
+    DPF_EVENT_REG_HOOK(hook_ScreenProxy_ScreensInUse)
 
     // WindowFrame begin
     DPF_EVENT_REG_SIGNAL(signal_DesktopFrame_WindowAboutToBeBuilded)

--- a/src/plugins/desktop/core/ddplugin-core/frame/windowframe.cpp
+++ b/src/plugins/desktop/core/ddplugin-core/frame/windowframe.cpp
@@ -124,6 +124,11 @@ void WindowFrame::layoutChildren()
     }
 }
 
+QStringList WindowFrame::bindedScreens()
+{
+    return d->windows.keys();
+}
+
 void WindowFrame::buildBaseWindow()
 {
     // tell other module that the base windows will be rebuild.
@@ -156,7 +161,7 @@ void WindowFrame::buildBaseWindow()
         } else {
             winPtr = d->createWindow(primary);
         }
-        qInfo() << "primary frame" << primary->name();
+        qInfo() << "primary frame" << primary->name() << primary->geometry();
         d->updateProperty(winPtr, primary, true);
         d->windows.insert(primary->name(), winPtr);
 
@@ -176,14 +181,14 @@ void WindowFrame::buildBaseWindow()
         for (ScreenPointer s : screens) {
             BaseWindowPointer winPtr = d->windows.value(s->name());
             if (!winPtr.isNull()) {
-                qInfo() << "update frame" << s->name();
                 if (winPtr->geometry() != s->geometry())
                     winPtr->setGeometry(s->geometry());
+                qInfo() << "update frame" << s->name() << "win" << winPtr->geometry() << "screen" << s->geometry();
             } else {
                 // 添加缺少的数据
-                qInfo() << "screen:" << s->name() << " added, create frame.";
                 winPtr = d->createWindow(s);
                 d->windows.insert(s->name(), winPtr);
+                qInfo() << "screen:" << s->name()  << s->geometry() << " added, create frame." << winPtr->geometry();
             }
 
             d->updateProperty(winPtr, s, (s == primary));
@@ -223,6 +228,8 @@ void WindowFrame::onGeometryChanged()
             win->setGeometry(sp->geometry());
             d->updateProperty(win, sp, (sp == primary));
             changed = true;
+        } else {
+            qWarning() << "no window for" << sp->name();
         }
     }
 
@@ -242,6 +249,8 @@ void WindowFrame::onAvailableGeometryChanged()
                 continue;
             d->updateProperty(win, sp, (sp == primary));
             changed = true;
+        } else {
+            qWarning() << "no window for" << sp->name();
         }
     }
 

--- a/src/plugins/desktop/core/ddplugin-core/frame/windowframe.h
+++ b/src/plugins/desktop/core/ddplugin-core/frame/windowframe.h
@@ -22,6 +22,7 @@ public:
     bool init();
     QList<QWidget *> rootWindows() const override;
     void layoutChildren() override;
+    QStringList bindedScreens();
 public slots:
     void buildBaseWindow();
     void onGeometryChanged();

--- a/src/plugins/desktop/core/ddplugin-core/screen/screenproxyqt.h
+++ b/src/plugins/desktop/core/ddplugin-core/screen/screenproxyqt.h
@@ -36,6 +36,7 @@ private slots:
 
 protected:
     void processEvent() override;
+    bool checkUsedScreens();
 
 private:
     void connectScreen(DFMBASE_NAMESPACE::ScreenPointer);


### PR DESCRIPTION
When the fake screen is restored to the real screen, there is no signal from Qt, and the desktop cannot update the main screen.

Log: 

Bug: https://pms.uniontech.com/bug-view-214195.html