### PR TITLE
fix: [io]Cell phone MTP internal file copy failed

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -246,6 +246,34 @@ bool DeviceUtils::isSftp(const QUrl &url)
     return hasMatch(url.path(), smbMatch);
 }
 
+bool DeviceUtils::isMtpFile(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    const QString &path = url.toLocalFile();
+    static const QString gvfsMatch { R"(^/run/user/\d+/gvfs/mtp:host|^/root/.gvfs/mtp:host)" };
+    QRegularExpression re { gvfsMatch };
+    QRegularExpressionMatch match { re.match(path) };
+    return match.hasMatch();
+}
+
+bool DeviceUtils::supportDfmioCopyDevice(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    return !isMtpFile(url);
+}
+
+bool DeviceUtils::supportSetPermissionsDevice(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    return !isMtpFile(url);
+}
+
 bool DeviceUtils::isExternalBlock(const QUrl &url)
 {
     return DeviceProxyManager::instance()->isFileOfExternalBlockMounts(url.path());

--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -48,6 +48,9 @@ public:
     static bool isSamba(const QUrl &url);
     static bool isFtp(const QUrl &url);
     static bool isSftp(const QUrl &url);
+    static bool isMtpFile(const QUrl &url);
+    static bool supportDfmioCopyDevice(const QUrl &url);
+    static bool supportSetPermissionsDevice(const QUrl &url);
     static bool isExternalBlock(const QUrl &url);
     static QUrl parseNetSourceUrl(const QUrl &target);
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -11,6 +11,7 @@
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/base/application/application.h>
+#include <dfm-base/base/device/deviceutils.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -178,6 +179,11 @@ bool AbstractWorker::statisticsFilesSize()
 
     const QUrl &firstUrl = sourceUrls.first();
 
+    if (this->targetUrl.isValid()) {
+        supportGioCopy = DeviceUtils::supportDfmioCopyDevice(this->targetUrl)
+                || DeviceUtils::supportDfmioCopyDevice(firstUrl);
+        supportSetPermission = DeviceUtils::supportSetPermissionsDevice(this->targetUrl);
+    }
     // 判读源文件所在设备位置，执行异步或者同统计源文件大小
     isSourceFileLocal = FileOperationsUtils::isFileOnDisk(firstUrl);
 
@@ -241,6 +247,7 @@ bool AbstractWorker::initArgs()
     completeSourceFiles.clear();
     completeTargetFiles.clear();
     completeCustomInfos.clear();
+    bigFileSize = FileOperationsUtils::bigFileSize();
 
     return true;
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -167,6 +167,8 @@ public:
     QList<FileInfoPointer> precompleteTargetFileInfo;   // list prepare complete target file info
     bool isSourceFileLocal { false };   // source file on local device
     bool isTargetFileLocal { false };   // target file on local device
+    bool supportSetPermission { true };    // source file on mtp
+    bool supportGioCopy { true };    // source file on mtp
     bool isTargetFileExBlock { false };   // target file on extra block device
     bool isConvert { false };   // is convert operation
     QSharedPointer<WorkerData> workData { nullptr };
@@ -181,6 +183,7 @@ public:
     std::atomic_bool retry { false };
     QSharedPointer<QThreadPool> threadPool { nullptr };
     static std::atomic_bool bigFileCopy;
+    QAtomicInteger<qint64> bigFileSize { 0 };   // bigger than this is big file
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -615,7 +615,7 @@ bool FileOperateBaseWorker::checkAndCopyFile(const FileInfoPointer fromInfo, con
         while (bigFileCopy && !isStopped()) {
             QThread::msleep(10);
         }
-        if (fromInfo->size() > FileOperationsUtils::bigFileSize()) {
+        if (fromInfo->size() > bigFileSize) {
             bigFileCopy = true;
             auto result = doCopyLocalBigFile(fromInfo, toInfo, skip);
             bigFileCopy = false;
@@ -998,7 +998,7 @@ bool FileOperateBaseWorker::doCopyOtherFile(const FileInfoPointer fromInfo, cons
 
     FileUtils::cacheCopyingFileUrl(targetUrl);
     bool ok{ false };
-    if (fromInfo->size() > FileOperationsUtils::bigFileSize() && !FileUtils::isMtpFile(this->targetUrl)) {
+    if (fromInfo->size() > bigFileSize || !supportGioCopy) {
         ok = copyOtherFileWorker->doCopyFilePractically(fromInfo, toInfo, skip);
     } else {
         ok = copyOtherFileWorker->doDfmioFileCopy(fromInfo, toInfo, skip);
@@ -1184,7 +1184,7 @@ bool FileOperateBaseWorker::canWriteFile(const QUrl &url) const
 void FileOperateBaseWorker::setAllDirPermisson()
 {
     for (auto info : dirPermissonList.list()) {
-        if (info->permission && !FileUtils::isMtpFile(info->target))
+        if (info->permission && supportSetPermission)
             localFileHandler->setPermissions(info->target, info->permission);
     }
 }


### PR DESCRIPTION
g_file_copy failed to copy a file within mtp, but the file is not available in mtp. Modify g_file_copy to use gio stream mode if the source and target files are on the same mtp device.

Log: Cell phone MTP internal file copy failed
Bug: https://pms.uniontech.com/bug-view-214385.html