### PR TITLE
修复已挂载的加密U盘无法从文管安全移除的问题

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -273,7 +273,7 @@ void DeviceManager::unmountBlockDevAsync(const QString &id, const QVariantMap &o
     }
 
     auto mpt = dev->mountPoint();
-    if (mpt.isEmpty()) {
+    if (mpt.isEmpty() && !dev->isEncrypted()) {
         if (cb)
             cb(true, Utils::genOperateErrorInfo(DeviceError::kNoError));
         return;


### PR DESCRIPTION
as title.

Log: fix issue about safely remove on encrypted disk.

Bug: https://pms.uniontech.com/bug-view-214531.html
