### PR TITLE
fix: [fileinfo]After renaming the shortcut application icon name, the name changes to "Desktop".

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -746,7 +746,7 @@ QString AsyncFileInfoPrivate::path() const
  */
 QString AsyncFileInfoPrivate::filePath() const
 {
-    return this->attribute(DFileInfo::AttributeID::kStandardFilePath).toString();
+    return q->fileUrl().path();
 }
 
 /*!

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -737,7 +737,7 @@ QString SyncFileInfoPrivate::path() const
  */
 QString SyncFileInfoPrivate::filePath() const
 {
-    return this->attribute(DFileInfo::AttributeID::kStandardFilePath).toString();
+    return q->fileUrl().path();
 }
 
 /*!


### PR DESCRIPTION
File does not exist. Modify to use url path.

Log: After renaming the shortcut application icon name, the name changes to "Desktop"
Bug: https://pms.uniontech.com/bug-view-214163.html