### PR TITLE
fix: [workspace]dde-file-manager list mode enters a directory and the directory icon displays an error

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -59,6 +59,7 @@ void ListItemDelegate::paint(QPainter *painter,
 {
     QStyleOptionViewItem opt = option;
 
+    parent()->fileInfo(index);
     initStyleOption(&opt, index);
     painter->setFont(opt.font);
 


### PR DESCRIPTION
Problem with fileinfo creation order when drawing in list mode. Call fileviewmodel's fileinfo once before drawing. this interface is optimized (progress bar scrolling does not create fileinfo)

Log: dde-file-manager list mode enters a directory and the directory icon displays an error
Bug: https://pms.uniontech.com/bug-view-214489.html