### PR TITLE
fix: [thumbnail] File thumbnails are not displayed in mounted directories

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -228,10 +228,10 @@ bool ThumbnailHelper::checkThumbEnable(const QUrl &url)
     if (!enable) {
         if (FileUtils::isMtpFile(url)) {
             enable = DConfigManager::instance()->value("org.deepin.dde.file-manager.preview", "mtpThumbnailEnable", true).toBool();
-        } else if (FileUtils::isGvfsFile(url)) {
-            enable = Application::instance()->genericAttribute(Application::kShowThunmbnailInRemote).toBool();
         } else if (DevProxyMng->isFileOfExternalBlockMounts(url.path())) {
             enable = true;
+        } else {
+            enable = Application::instance()->genericAttribute(Application::kShowThunmbnailInRemote).toBool();
         }
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -739,11 +739,8 @@ void FileViewModel::onGenericAttributeChanged(Application::GenericAttribute ga, 
     case Application::kPreviewVideo:
     case Application::kPreviewTextFile:
     case Application::kPreviewDocumentFile:
-        Q_EMIT requestClearThumbnail();
-        break;
     case Application::kShowThunmbnailInRemote:
-        if (FileUtils::isGvfsFile(rootUrl()))
-            Q_EMIT requestClearThumbnail();
+        Q_EMIT requestClearThumbnail();
         break;
     default:
         break;


### PR DESCRIPTION
If Show Remote file thumbnails is checked, the mount directory is also displayed

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-214671.html