### PR TITLE
fix: [io]Open wps file error inside smb when wps is not installed.

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -585,6 +585,14 @@ qint64 DeviceUtils::deviceBytesFree(const QUrl &url)
     return DFMIO::DFMUtils::deviceBytesFree(url);
 }
 
+bool DeviceUtils::isUnmountSamba(const QUrl &url)
+{
+    if (!isSamba(url))
+        return false;
+
+    return !DevProxyMng->isFileOfProtocolMounts(url.path());
+}
+
 bool DeviceUtils::findDlnfsPath(const QString &target, Compare func)
 {
     Q_ASSERT(func);

--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -73,6 +73,7 @@ public:
 
     static QString fileSystemType(const QUrl &url);
     static qint64 deviceBytesFree(const QUrl &url);
+    static bool isUnmountSamba(const QUrl &url);
 
 private:
     static bool hasMatch(const QString &txt, const QString &rex);

--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1047,7 +1047,7 @@ bool LocalFileHandlerPrivate::doOpenFiles(const QList<QUrl> &urls, const QString
     } else {
         defaultDesktopFile = MimesAppsManager::getDefaultAppDesktopFileByMimeType(mimeType);
         if (defaultDesktopFile.isEmpty()) {
-            if (DeviceUtils::isSamba(fileUrl)) {
+            if (DeviceUtils::isUnmountSamba(fileUrl)) {
                 mimeType = QString("inode/directory");
                 defaultDesktopFile = MimesAppsManager::getDefaultAppDesktopFileByMimeType(mimeType);
                 isOpenNow = true;


### PR DESCRIPTION
When opening a file, you should judge whether the current file is a mounted smb file, if not, then mount it (using dde-file-manager) to open it, otherwise it will open the default program selection dialog.
    
Log: Open wps file error inside smb when wps is not installed.
Bug: https://pms.uniontech.com/bug-view-214661.html