### PR TITLE
fix: The wallpaper size does not match the window

### DIFF
--- a/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
@@ -122,7 +122,10 @@ QString BackgroundManager::backgroundPath(const QString &screen)
 void BackgroundManager::onBackgroundBuild()
 {
     // get wallpapers
-    d->bridge->request(d->backgroundPaths.isEmpty());
+    if (d->bridge->isForce() && d->bridge->isRunning())
+        qWarning() << "a force requestion is running. skip to get wallpaper.";
+    else
+        d->bridge->request(d->backgroundPaths.isEmpty());
 
     QList<QWidget *> root = ddplugin_desktop_util::desktopFrameRootWindows();
     if (root.size() == 1) {
@@ -288,11 +291,6 @@ BackgroundBridge::~BackgroundBridge()
 
 void BackgroundBridge::request(bool refresh)
 {
-    if (force && future.isRunning()) {
-        qWarning() << "a force requestion is running.";
-        return;
-    }
-
     terminate(true);
 
     QList<Requestion> requestion;
@@ -347,7 +345,7 @@ void BackgroundBridge::forceRequest()
 
 void BackgroundBridge::terminate(bool wait)
 {
-    qInfo() << "terminate last requestion, wait:" << wait << "running:" << getting << future.isRunning();
+    qInfo() << "terminate last requestion, wait:" << wait << "running:" << getting << future.isRunning() << "force" << force;
     if (!getting)
         return;
 
@@ -401,8 +399,8 @@ void BackgroundBridge::onFinished(void *pData)
 
     if (repeat) {
         qInfo() << "need to request again.";
-        request(true);
         repeat = false;
+        request(true);
     }
 }
 

--- a/src/plugins/desktop/ddplugin-background/backgroundmanager_p.h
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager_p.h
@@ -32,6 +32,9 @@ public:
     inline bool isRunning() const {
         return future.isRunning();
     }
+    inline bool isForce() const {
+        return force;
+    }
     inline void setRepeat() {
         repeat = true;
     }

--- a/tests/plugins/desktop/ddplugin-background/ut_backgroundmanager.cpp
+++ b/tests/plugins/desktop/ddplugin-background/ut_backgroundmanager.cpp
@@ -252,7 +252,7 @@ TEST_F(UT_backGroundManager, request)
     });
     bgm->d->bridge->force = true;
     bgm->d->bridge->request(true);
-    EXPECT_FALSE(callTerminate);
+    EXPECT_TRUE(callTerminate);
 
     bgm->d->bridge->force = false;
     QWidget *widget = new QWidget;


### PR DESCRIPTION
When initializing the wallpaper window, the screen size is used to scale the wallpaper, but the resolution of the screen changes when generating the wallpaper. Due to the non interruptible process of obtaining wallpaper during the initialization process, the resolution change failed to retrieve the wallpaper again.


Log: 

Bug:https://pms.uniontech.com/bug-view-214485.html

Influence: 壁纸