### PR TITLE
fix: [vault] File sorting error in vault

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp
@@ -81,6 +81,13 @@ VaultFileInfo::VaultFileInfo(const QUrl &url)
     setProxy(InfoFactory::create<FileInfo>(d->localUrl,  Global::CreateFileInfoType::kCreateFileInfoAsyncAndCache));
 }
 
+VaultFileInfo::VaultFileInfo(const QUrl &url, const FileInfoPointer &proxy)
+    : ProxyFileInfo(url), d(new VaultFileInfoPrivate(url, this))
+{
+    d->localUrl = VaultHelper::vaultToLocalUrl(url);
+    setProxy(proxy);
+}
+
 VaultFileInfo::~VaultFileInfo()
 {
 }

--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.h
@@ -17,6 +17,7 @@ class VaultFileInfo : public DFMBASE_NAMESPACE::ProxyFileInfo
 
 public:
     explicit VaultFileInfo(const QUrl &url);
+    explicit VaultFileInfo(const QUrl &url, const FileInfoPointer &proxy);
     virtual ~VaultFileInfo() override;
 
     virtual VaultFileInfo &operator=(const VaultFileInfo &fileinfo);


### PR DESCRIPTION
Root cause:
When sorting, not get the Correct async file attributes. solved:
when iterator the file info, get and cache the attributes.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-214339.html