### PR TITLE
fix: [property-dialog] the device name show error.

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -205,6 +205,11 @@ QString KeyValueLabel::RightValue()
     return rightValueLabel->text();
 }
 
+void KeyValueLabel::setLeftVauleLabelFixedWidth(int width)
+{
+    leftValueLabel->setFixedWidth(width);
+}
+
 void KeyValueLabel::paintEvent(QPaintEvent *evt)
 {
     Qt::TextElideMode fontWeight = propertyMap.value(kLeftElideMode).value<Qt::TextElideMode>();

--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h
@@ -81,6 +81,7 @@ public:
     QString LeftValue();
 
     QString RightValue();
+    void setLeftVauleLabelFixedWidth(int width);
 
 Q_SIGNALS:
     void valueAreaClicked();

--- a/src/plugins/filemanager/core/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
@@ -43,6 +43,7 @@ void DevicePropertyDialog::iniUI()
 
     basicInfo = new KeyValueLabel(this);
     basicInfo->setLeftFontSizeWeight(DFontSizeManager::SizeType::T7, QFont::DemiBold);
+    basicInfo->setLeftVauleLabelFixedWidth(150);
 
     devicesProgressBar = new DColoredProgressBar();
     devicesProgressBar->addThreshold(0, QColor(0xFF0080FF));
@@ -124,7 +125,8 @@ void DevicePropertyDialog::setSelectDeviceInfo(const DeviceInfo &info)
     deviceIcon->setPixmap(info.icon.pixmap(128, 128));
     setFileName(info.deviceName);
     deviceBasicWidget->selectFileInfo(info);
-    basicInfo->setLeftValue(info.deviceName, Qt::ElideMiddle, Qt::AlignLeft, true);
+    QString deviceShowName = info.deviceDesc.isEmpty() ? info.deviceName : QString("%1(%2)").arg(info.deviceName).arg(info.deviceDesc);
+    basicInfo->setLeftValue(deviceShowName, Qt::ElideMiddle, Qt::AlignLeft, true);
     setProgressBar(info.totalCapacity, info.availableSpace, !info.mountPoint.isEmpty());
     addExtendedControl(deviceBasicWidget);
 }

--- a/src/plugins/filemanager/core/dfmplugin-computer/dfmplugin_computer_global.h
+++ b/src/plugins/filemanager/core/dfmplugin-computer/dfmplugin_computer_global.h
@@ -26,6 +26,7 @@ struct DeviceInfo
     QString fileSystem;
     qint64 totalCapacity;
     qint64 availableSpace;
+    QString deviceDesc;
 };
 
 DPCOMPUTER_END_NAMESPACE

--- a/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
@@ -289,6 +289,7 @@ QWidget *ComputerUtils::devicePropertyDialog(const QUrl &url)
     devInfo.fileSystem = info->extraProperty(GlobalServerDefines::DeviceProperty::kFileSystem).toString();
     devInfo.totalCapacity = info->sizeTotal();
     devInfo.availableSpace = info->sizeFree();
+    devInfo.deviceDesc = info->extraProperty(GlobalServerDefines::DeviceProperty::kDevice).toString().mid(5);
     dialog->setSelectDeviceInfo(devInfo);
     return dialog;
 }


### PR DESCRIPTION
1. the devece name show error in device property dialog, and fix it.
2. adjust the UI

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-214867.html