### PR TITLE
fix: [io]Slow display of folder information when multitasking copying or cutting and pasting files from smb server to USB flash drive.

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -279,6 +279,7 @@ void TaskWidget::onShowTaskInfo(const JobInfoPointer JobInfo)
 {
     if (isShowError)
         return;
+
     QString source = JobInfo->value(AbstractJobHandler::NotifyInfoKey::kSourceMsgKey).toString();
     QString target = JobInfo->value(AbstractJobHandler::NotifyInfoKey::kTargetMsgKey).toString();
     lbSrcPath->setText(source);
@@ -424,6 +425,7 @@ void TaskWidget::initUI()
     lbDstPath = new ElidedLable;
     lbRmTime = new QLabel;
     lbSrcPath->setFixedWidth(kMsgLabelWidth);
+    lbSrcPath->setText("In data statistics ...");
     lbDstPath->setFixedWidth(kMsgLabelWidth);
     lbSpeed->setFixedWidth(kSpeedLabelWidth);
     lbRmTime->setFixedWidth(kSpeedLabelWidth);
@@ -759,7 +761,7 @@ bool TaskWidget::showFileInfo(const FileInfoPointer info, const bool isOrg)
             .arg(info->timeOf(TimeInfoType::kLastModified).value<QDateTime>().isValid()
                          ? info->timeOf(TimeInfoType::kLastModified).value<QDateTime>().toString("yyyy/MM/dd HH:mm:ss")
                          : qApp->translate("MimeTypeDisplayManager", "Unknown"));
-    auto sizeStr = tr("In data statistics");
+    auto sizeStr = tr("In data statistics ...");
     auto titleStr = isOrg ? tr("Original folder") : tr("Target folder");
     if (info->isAttributes(OptInfoType::kIsDir)) {
         if (info->countChildFile() < 0) {

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -180,7 +180,7 @@ bool AbstractWorker::statisticsFilesSize()
     const QUrl &firstUrl = sourceUrls.first();
 
     if (this->targetUrl.isValid()) {
-        supportGioCopy = DeviceUtils::supportDfmioCopyDevice(this->targetUrl)
+        supportDfmioCopy = DeviceUtils::supportDfmioCopyDevice(this->targetUrl)
                 || DeviceUtils::supportDfmioCopyDevice(firstUrl);
         supportSetPermission = DeviceUtils::supportSetPermissionsDevice(this->targetUrl);
     }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -168,7 +168,7 @@ public:
     bool isSourceFileLocal { false };   // source file on local device
     bool isTargetFileLocal { false };   // target file on local device
     bool supportSetPermission { true };    // source file on mtp
-    bool supportGioCopy { true };    // source file on mtp
+    bool supportDfmioCopy { true };    // source file on mtp
     bool isTargetFileExBlock { false };   // target file on extra block device
     bool isConvert { false };   // is convert operation
     QSharedPointer<WorkerData> workData { nullptr };


### PR DESCRIPTION
Before copying task, using QProccess to execute lsblk to get the information of USB flash disk is blocked, so the display is blank, the worse the performance of USB flash disk copy speed also shows 0, multi-tasking are blocked at the beginning of the blocking point. Add tips in statistics by product evaluation.

Log: Slow display of folder information when multitasking copying or cutting and pasting files from smb server to USB flash drive.
Bug: https://pms.uniontech.com/bug-view-212257.html