### PR TITLE
修复dock插件不显示已挂载的加密设备的问题

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/device/devicewatcherlite.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/devicewatcherlite.cpp
@@ -72,6 +72,8 @@ QStringList DeviceWatcherLite::allMountedRemovableBlocks()
             continue;
         if (!devPtr->removable())
             continue;
+
+        QString encryptedMpt;
         if (devPtr->isEncrypted()) {
             QString clearDevID = devPtr->getProperty(Property::kEncryptedCleartextDevice).toString();
             if (clearDevID.isEmpty()) {
@@ -80,6 +82,7 @@ QStringList DeviceWatcherLite::allMountedRemovableBlocks()
                 QSharedPointer<DBlockDevice> clearDev = monitor->createDeviceById(clearDevID).objectCast<DBlockDevice>();
                 if (!clearDev || clearDev->mountPoint().isEmpty())
                     continue;
+                encryptedMpt = clearDev->mountPoint();
             }
         }
 
@@ -87,7 +90,8 @@ QStringList DeviceWatcherLite::allMountedRemovableBlocks()
         if (!devPtr->canPowerOff() && !devPtr->optical())
             continue;
         // ignore blocks not mounted under /media/
-        if (!devPtr->mountPoint().startsWith("/media/"))
+        if (!devPtr->mountPoint().startsWith("/media/")
+            && !encryptedMpt.startsWith("/media"))
             continue;
 
         if (isSiblingOfRoot(devPtr))

--- a/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolitem.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolitem.cpp
@@ -58,6 +58,8 @@ void DiskControlItem::mouseReleaseEvent(QMouseEvent *e)
     QUrl &&mountPoint = QUrl(attachedDev->mountpointUrl());
     QUrl &&url = QUrl(attachedDev->accessPointUrl());
 
+    qInfo() << "Open " << url;
+
     // 光盘文件系统剥离 RockRidge 后，udisks 的默认挂载权限为 500，为遵从 linux 权限限制，在这里添加访问目录的权限校验
     QFile f(mountPoint.path());
     if (url.scheme() == "burn" && f.exists() && !f.permissions().testFlag(QFile::ExeUser)) {


### PR DESCRIPTION
the mounted encrypted disk is not shown in dock plugin.
it's ignored because the mount point of encrypted-shell device is empty.

Log: fix issue about dock.

Bug: https://pms.uniontech.com/bug-view-215103.html
