### PR TITLE
fix: [workspace]When the peripheral creates a new file or copies a file, the file is not sorted correctly.

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -368,8 +368,11 @@ int AsyncFileInfo::countChildFileAsync() const
 
 QString AsyncFileInfo::displayOf(const DisPlayInfoType type) const
 {
-    if (type == DisPlayInfoType::kFileDisplayName)
-        return d->asyncAttribute(AsyncFileInfo::AsyncAttributeID::kStandardDisplayName).toString();
+    if (type == DisPlayInfoType::kFileDisplayName) {
+        if (d->asyncAttribute(AsyncFileInfo::AsyncAttributeID::kStandardDisplayName).isValid())
+            return d->asyncAttribute(AsyncFileInfo::AsyncAttributeID::kStandardDisplayName).toString();
+        return url.fileName();
+    }
     return FileInfo::displayOf(type);
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -125,6 +125,7 @@ private:
     void addChild(const SortInfoPointer &sortInfo, const FileInfoPointer &info);
     void addChild(const SortInfoPointer &sortInfo,
                   const AbstractSortFilter::SortScenarios sort);
+    bool sortInfoUpdateByFileInfo(const FileInfoPointer fileInfo);
 
 private:
     bool lessThan(const QUrl &left, const QUrl &right, AbstractSortFilter::SortScenarios sort);


### PR DESCRIPTION
When copying a new file to a peripheral directory, fileinfo does not have the file information. Modify fileinfo to do the sorting after getting the file information.

Log: When the peripheral creates a new file or copies a file, the file is not sorted correctly.
Bug: https://pms.uniontech.com/bug-view-215115.html