### PR TITLE
fix: [io]Baseline degradation for 1000 file off-disk copy performance comparison

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.operations.json
+++ b/assets/configs/org.deepin.dde.file-manager.operations.json
@@ -1,0 +1,28 @@
+{
+    "magic":"dsg.config.meta",
+    "version":"1.0",
+    "contents":{
+        "file.operation.bigfilesize": {
+            "value":"83886080",
+            "serial":0,
+            "flags":[],
+            "name":"Big File",
+            "name[zh_CN]":"大文件大小",
+            "description[zh_CN]":"用于拷贝时判断文件是否是大文件的size，默认是80MB",
+            "description":"Size used to determine whether a file is a large file during copying，the default is 80MB",
+            "permissions":"readwrite",
+            "visibility":"private"
+        },
+        "file.operation.blockeverysync": {
+            "value":"true",
+            "serial":0,
+            "flags":[],
+            "name":"Safe synchronization mode",
+            "name[zh_CN]":"安全同步模式",
+            "description[zh_CN]":"安全同步模式是拷贝到外设块设备时，每次写入执行同步到设备。高性能模式是拷贝到外设块设备时，每个任务完成后在进行同步到设备。默认是安全同步模式。",
+            "description":"Safe synchronization mode is when copying to a peripheral block device, synchronize to the device for each write. High-performance mode is to synchronize to the device after each task is completed when copying to a peripheral block device.The default is safe synchronization mode.",
+            "permissions":"readwrite",
+            "visibility":"private"
+        }
+    }
+}

--- a/src/plugins/common/core/dfmplugin-fileoperations/CMakeLists.txt
+++ b/src/plugins/common/core/dfmplugin-fileoperations/CMakeLists.txt
@@ -49,3 +49,4 @@ install(TARGETS
     DESTINATION
     ${DFM_PLUGIN_COMMON_CORE_DIR}
 )
+INSTALL_DCONFIG("org.deepin.dde.file-manager.operations.json")

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -351,7 +351,7 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const FileInfoPointer &fromInfo, c
 
         FileUtils::cacheCopyingFileUrl(url);
         initSignalCopyWorker();
-        if (fromInfo->size() > bigFileSize || !supportDfmioCopy) {
+        if (fromInfo->size() > bigFileSize || !supportDfmioCopy || workData->exBlockSyncEveryWrite) {
             ok = copyOtherFileWorker->doCopyFilePractically(fromInfo, toInfo, skip);
         } else {
             ok = copyOtherFileWorker->doDfmioFileCopy(fromInfo, toInfo, skip);
@@ -998,7 +998,7 @@ bool FileOperateBaseWorker::doCopyOtherFile(const FileInfoPointer fromInfo, cons
 
     FileUtils::cacheCopyingFileUrl(targetUrl);
     bool ok{ false };
-    if (fromInfo->size() > bigFileSize || !supportDfmioCopy) {
+    if (fromInfo->size() > bigFileSize || !supportDfmioCopy || workData->exBlockSyncEveryWrite) {
         ok = copyOtherFileWorker->doCopyFilePractically(fromInfo, toInfo, skip);
     } else {
         ok = copyOtherFileWorker->doDfmioFileCopy(fromInfo, toInfo, skip);
@@ -1304,9 +1304,13 @@ void FileOperateBaseWorker::determineCountProcessType()
                         }
 
                         if (targetIsRemovable) {
-                            countWriteType = CountWriteSizeType::kWriteBlockType;
+                            workData->exBlockSyncEveryWrite = FileOperationsUtils::blockSync();
+                            countWriteType = workData->exBlockSyncEveryWrite ?
+                                        CountWriteSizeType::kCustomizeType :
+                                        CountWriteSizeType::kWriteBlockType;
                             workData->isBlockDevice = true;
-                            targetDeviceStartSectorsWritten = getSectorsWritten();
+                            targetDeviceStartSectorsWritten = workData->exBlockSyncEveryWrite ?
+                                        0 : getSectorsWritten();
                         }
 
                         qDebug("Block device path: \"%s\", Sys dev path: \"%s\", Is removable: %d, Log-Sec: %d",
@@ -1327,6 +1331,18 @@ void FileOperateBaseWorker::syncFilesToDevice()
 {
     if (CountWriteSizeType::kWriteBlockType != countWriteType)
         return;
+
+    qInfo() << "start sync all file to extend block device!!!!! target : " << targetUrl;
+    for (const auto &url : completeTargetFiles) {
+        std::string stdStr = url.path().toUtf8().toStdString();
+        int tofd = open(stdStr.data(), O_RDONLY);
+        if (-1 != tofd) {
+            syncfs(tofd);
+            close(tofd);
+        }
+    }
+
+    qInfo() << "end sync all file to extend block device!!!!! target : " << targetUrl;
 
     qDebug() << __FUNCTION__ << "syncFilesToDevice begin";
     qint64 writeSize = getWriteDataSize();

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -28,7 +28,9 @@ DPFILEOPERATIONS_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 
 QSet<QString> FileOperationsUtils::fileNameUsing = {};
-static constexpr char kFileBigSize[] { "dfm.operate.bigfilesize" };
+inline constexpr char kFileOperations[] { "org.deepin.dde.file-manager.operations" };
+inline constexpr char kFileBigSize[] { "file.operation.bigfilesize" };
+inline constexpr char kBlockEverySync[] { "file.operation.blockeverysync" };
 QMutex FileOperationsUtils::mutex;
 
 /*!
@@ -154,8 +156,14 @@ bool FileOperationsUtils::isFileOnDisk(const QUrl &url)
 qint64 FileOperationsUtils::bigFileSize()
 {
     // 获取当前配置
-    qint64 alltotrash = DConfigManager::instance()->value(kDefaultCfgPath, kFileBigSize).toLongLong();
+    qint64 alltotrash = DConfigManager::instance()->value(kFileOperations, kFileBigSize).toLongLong();
     if (alltotrash <= 0)
         return 80 * 1024 * 1024;
     return alltotrash;
+}
+
+bool FileOperationsUtils::blockSync()
+{
+    bool sync = DConfigManager::instance()->value(kFileOperations, kBlockEverySync).toBool();
+    return sync;
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -74,6 +74,7 @@ private:
     static bool isAncestorUrl(const QUrl &from, const QUrl &to);
     static bool isFileOnDisk(const QUrl &url);
     static qint64 bigFileSize();
+    static bool blockSync();
 
 private:
     static QSet<QString> fileNameUsing;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
@@ -52,6 +52,7 @@ public:
     AbstractJobHandler::JobFlags jobFlags { AbstractJobHandler::JobFlag::kNoHint };   // job flag
     QMap<AbstractJobHandler::JobErrorType, AbstractJobHandler::SupportAction> errorOfAction;
     std::atomic_bool needSyncEveryRW { false };
+    std::atomic_bool exBlockSyncEveryWrite { false };
     std::atomic_bool isFsTypeVfat { false };
     std::atomic_bool isBlockDevice { false };
     std::atomic_int64_t currentWriteSize { 0 };


### PR DESCRIPTION
Add a configuration policy to enable peripheral block device synchronization for each write, and perform synchronization once for each off-disk USB flash drive write. Otherwise, all files are synchronized only at the end of this task.

Log: Baseline degradation for 1000 file off-disk copy performance comparison
Bug: https://pms.uniontech.com/bug-view-215793.html