### PR TITLE
fix: [desktop]dde-desktop new file or folder icon display incorrectly

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
@@ -214,11 +214,9 @@ void FileInfoModelPrivate::dataUpdated(const QUrl &url, const bool isLinkOrg)
     if (Q_UNLIKELY(!index.isValid()))
         return;
 
-    if (isLinkOrg) {
-        auto info = q->fileInfo(index);
-        if (info)
-            info->customData(Global::ItemRoles::kItemFileRefreshIcon);
-    }
+    auto info = q->fileInfo(index);
+    if (info)
+        info->customData(Global::ItemRoles::kItemFileRefreshIcon);
 
     emit q->dataChanged(index, index);
 }


### PR DESCRIPTION
Manually update the icon when you receive the asynchronous file information update completion signal.

Log: dde-desktop new file or folder icon display incorrectly