### PR TITLE
fix: [property] The close all dialog show error

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/utils/propertydialogutil.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/utils/propertydialogutil.cpp
@@ -7,6 +7,7 @@
 #include "propertydialogmanager.h"
 
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/utils/windowutils.h>
 
 #include <DArrowLineDrawer>
 
@@ -238,21 +239,7 @@ QWidget *PropertyDialogUtil::createCustomizeView(const QUrl &url)
 
 QPoint PropertyDialogUtil::getPropertyPos(int dialogWidth, int dialogHeight)
 {
-    const QScreen *cursor_screen = Q_NULLPTR;
-    const QPoint &cursor_pos = QCursor::pos();
-
-    auto screens = qApp->screens();
-    auto iter = std::find_if(screens.begin(), screens.end(), [cursor_pos](const QScreen *screen) {
-        return screen->geometry().contains(cursor_pos);
-    });
-
-    if (iter != screens.end()) {
-        cursor_screen = *iter;
-    }
-
-    if (!cursor_screen) {
-        cursor_screen = qApp->primaryScreen();
-    }
+    const QScreen *cursor_screen = WindowUtils::cursorScreen();
 
     int x = (cursor_screen->availableSize().width() - dialogWidth) / 2;
     int y = (cursor_screen->availableSize().height()- kBottomReserveHeight - dialogHeight) / 2;
@@ -263,21 +250,7 @@ QPoint PropertyDialogUtil::getPropertyPos(int dialogWidth, int dialogHeight)
 QPoint PropertyDialogUtil::getPerportyPos(int dialogWidth, int dialogHeight, int count, int index)
 {
     Q_UNUSED(dialogHeight)
-    const QScreen *cursor_screen = Q_NULLPTR;
-    const QPoint &cursor_pos = QCursor::pos();
-
-    auto screens = qApp->screens();
-    auto iter = std::find_if(screens.begin(), screens.end(), [cursor_pos](const QScreen *screen) {
-        return screen->geometry().contains(cursor_pos);
-    });
-
-    if (iter != screens.end()) {
-        cursor_screen = *iter;
-    }
-
-    if (!cursor_screen) {
-        cursor_screen = qApp->primaryScreen();
-    }
+    const QScreen *cursor_screen = WindowUtils::cursorScreen();
 
     int desktopWidth = cursor_screen->size().width();
     //    int desktopHeight = cursor_screen->size().height();//后面未用，注释掉

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/closealldialog.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/closealldialog.cpp
@@ -5,6 +5,7 @@
 #include "closealldialog.h"
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/windowutils.h>
 
 #include <DLabel>
 #include <DCommandLinkButton>
@@ -14,6 +15,7 @@
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QFontMetrics>
+#include <QScreen>
 
 DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
@@ -93,12 +95,12 @@ void CloseAllDialog::showEvent(QShowEvent *event)
 {
     Q_UNUSED(event)
 
-    QRect screenGeometry = qApp->desktop()->availableGeometry();
-
+    QScreen *cursor_screen = WindowUtils::cursorScreen();
+    QRect screenGeometry = cursor_screen->availableGeometry();
     int geometryHeight = screenGeometry.height() - UniversalUtils::dockHeight();
     int geometryWidth = screenGeometry.width();
 
-    move((geometryWidth - width()) / 2, geometryHeight - height());
+    move(QPoint((geometryWidth - width()) / 2, geometryHeight - height()) + cursor_screen->geometry().topLeft());
 
     setTotalMessage(0, 0);
     return DAbstractDialog::showEvent(event);


### PR DESCRIPTION
Under the dual screen, the position displayed of close all dialog is not rihght.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-216031.html