### PR TITLE
chore: bump version to V6.0.29

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.0.29) unstable; urgency=medium
+
+  * update file manager baseline version to V6.0.29
+
+ -- toberyan <zhengyouge@uniontech.com>  Wed, 23 Aug 2023 23:14:09 +0800
+
 dde-file-manager (6.0.28) unstable; urgency=medium
 
   * update file manager baseline version to V6.0.28


### PR DESCRIPTION
chore: bump version to V6.0.29

release version V6.0.29

While refreshing the thumbnail, the file information object obtained through item has already been destructed

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-215989.html