### PR TITLE
修复因库名问题导致守护进程崩溃的问题

### DIFF
--- a/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper_p.h
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/cifsmounthelper_p.h
@@ -59,6 +59,7 @@ class CifsMountHelperPrivate
 public:
     QString probeVersion(const QString &host, ushort port);
     QString parseIP(const QString &host, uint16_t port);
+    QString parseIP_old(const QString &host);
 };
 
 DAEMONPMOUNTCONTROL_END_NAMESPACE


### PR DESCRIPTION
the smbclient library is not loaded and then the function is not
resolved. the ASSERT do not work in RELEASE mode.

fix the soname and if load failed, use default handler.

Log: fix issue about daemon cifs mount.

Bug: https://pms.uniontech.com/bug-view-216189.html
