### PR TITLE
fix: [fileinfo]dde-file-manager crashes

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -205,6 +205,11 @@ public:
                                     const Global::CreateFileInfoType type = Global::CreateFileInfoType::kCreateFileInfoAuto,
                                     QString *errorString = nullptr)
     {
+        if (!url.isValid()) {
+            qWarning() << "url is unvalid !!! url = " << url;
+            return nullptr;
+        }
+
         if (InfoCacheController::instance().cacheDisable(url.scheme()))
             return qSharedPointerDynamicCast<T>(instance().SchemeFactory<FileInfo>::
                                                         create(url, errorString));


### PR DESCRIPTION
The scheme of the incoming url is file, but the url can still be invalid as well. Modify to determine if the url is valid or not during the factory construction of info.

Log: dde-file-manager crashes