### PR TITLE
fix: [io]Peripheral paste the same name directory selection coexistence, file sorting is not correct

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -524,13 +524,20 @@ void AsyncFileInfo::removeNotifyUrl(const QUrl &url, const QString &infoPtr)
     d->notifyUrls.remove(url, infoPtr);
 }
 
-void AsyncFileInfo::cacheAsyncAttributes()
+bool AsyncFileInfo::cacheAsyncAttributes()
 {
     assert(qApp->thread() != QThread::currentThread());
+    auto dfmFileInfo = d->dfmFileInfo;
+    if (d->tokenKey != quintptr(dfmFileInfo.data()))
+        return false;
+
+    if (d->cacheing)
+        return false;
     if (!d->cacheing)
         d->cacheing = true;
     d->cacheAllAttributes();
     d->cacheing = false;
+    return true;
 }
 
 bool AsyncFileInfo::asyncQueryDfmFileInfo(int ioPriority, FileInfo::initQuerierAsyncCallback func, void *userData)
@@ -545,7 +552,7 @@ bool AsyncFileInfo::asyncQueryDfmFileInfo(int ioPriority, FileInfo::initQuerierA
     if (!d->dfmFileInfo) {
         d->cacheing = false;
         return false;
-    }
+    } 
 
     d->dfmFileInfo->initQuerierAsync(ioPriority, func, userData);
     d->cacheing = false;
@@ -575,6 +582,7 @@ void AsyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo
     if (dfileInfo) {
         notInit = true;
         dfmFileInfo = dfileInfo;
+        tokenKey = quintptr(dfmFileInfo.data());
         return;
     }
 
@@ -584,6 +592,7 @@ void AsyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo
         qWarning("Failed, dfm-io use factory create fileinfo");
         abort();
     }
+    tokenKey = quintptr(dfmFileInfo.data());
 }
 
 QMimeType AsyncFileInfoPrivate::mimeTypes(const QString &filePath, QMimeDatabase::MatchMode mode, const QString &inod, const bool isGvfs)

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -182,7 +182,7 @@ public:
     QMultiMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
     void removeNotifyUrl(const QUrl &url, const QString &infoPtr);
-    void cacheAsyncAttributes();
+    bool cacheAsyncAttributes();
     bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);
 };
 }

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -48,6 +48,7 @@ public:
     QMap<AsyncFileInfo::AsyncAttributeID, QVariant> cacheAsyncAttributes;
     QReadWriteLock notifyLock;
     QMultiMap<QUrl, QString> notifyUrls;
+    quint64 tokenKey{0};
     AsyncFileInfo *const q;
 
 public:

--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -44,11 +44,11 @@ void FileInfoHelper::threadHandleDfmFileInfo(const QSharedPointer<FileInfo> dfil
         return;
 
     auto asyncInfo = dfileInfo.dynamicCast<AsyncFileInfo>();
-    if (!asyncInfo) {
+    if (asyncInfo.isNull())
         return;
-    }
 
-    asyncInfo->cacheAsyncAttributes();
+    if (!asyncInfo->cacheAsyncAttributes())
+        return;
 
     emit fileRefreshFinished(dfileInfo->fileUrl(), QString::number(quintptr(dfileInfo.data()), 16), false);
 

--- a/tests/dfm-base/file/local/ut_localfilediriterator.cpp
+++ b/tests/dfm-base/file/local/ut_localfilediriterator.cpp
@@ -56,7 +56,7 @@ TEST_F(UT_LocalFileDirIterator, testLocalFileIterator)
     stub.set_lamda(&FileUtils::isLocalDevice, []{ __DBG_STUB_INVOKE__ return false;});
     typedef FileInfoPointer (*TransfromInfo)(const QString &, FileInfoPointer);
     stub.set_lamda(static_cast<TransfromInfo>(&dfmbase::InfoFactory::transfromInfo), []{ __DBG_STUB_INVOKE__ return nullptr;});
-    stub.set_lamda(&AsyncFileInfo::cacheAsyncAttributes, []{ __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&AsyncFileInfo::cacheAsyncAttributes, []{ __DBG_STUB_INVOKE__  return true;});
     EXPECT_TRUE(iterator->fileInfo().isNull());
 
     EXPECT_EQ(fileUrl, iterator->fileUrl());


### PR DESCRIPTION
Asynchronous file information is created when a file is received from the monitor to create a file, multiple queries are executed, and caching of file attributes is performed in multiple threads, but the corresponding dfmfileinfo is different. So accessing file attributes at this point is incorrect.

Log: Peripheral paste the same name directory selection coexistence, file sorting is not correct need to refresh manually
Bug: https://pms.uniontech.com/bug-view-217143.html