### PR TITLE
fix: [views] when the computer name is very long,the name field on th…

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -129,7 +129,7 @@ void ComputerPropertyDialog::iniThread()
 void ComputerPropertyDialog::computerProcess(QMap<ComputerInfoItem, QString> computerInfo)
 {
     if (computerInfo.contains(ComputerInfoItem::kName))
-        computerName->setRightValue(computerInfo[ComputerInfoItem::kName]);
+        computerName->setRightValue(computerInfo[ComputerInfoItem::kName], Qt::TextElideMode::ElideRight);
     if (computerInfo.contains(ComputerInfoItem::kVersion))
         computerVersionNum->setRightValue(computerInfo[ComputerInfoItem::kVersion]);
     if (computerInfo.contains(ComputerInfoItem::kEdition)) {


### PR DESCRIPTION
…e property page is only partially displayed

as title

Log: When the computer name is exceeded, it is followed by an ellipsis.
Bug: https://pms.uniontech.com/bug-view-217341.html