### PR TITLE
fix: [workspace]F5 shortcut held down, dde-file-manager crashes

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
@@ -41,4 +41,6 @@ private:
 
 }
 
+typedef QSharedPointer<DPWORKSPACE_NAMESPACE::FileItemData> FileItemDataPointer;
+
 #endif   // FILEITEMDATA_H

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -76,14 +76,14 @@ QModelIndex FileViewModel::index(int row, int column, const QModelIndex &parent)
     if (!filterSortWorker)
         return QModelIndex();
 
-    FileItemData *itemData = nullptr;
+    FileItemDataPointer itemData = nullptr;
     if (!isParentValid) {
         itemData = filterSortWorker->rootData();
     } else {
         itemData = filterSortWorker->childData(row);
     }
 
-    return createIndex(row, column, itemData);
+    return createIndex(row, column, itemData.data());
 }
 
 QUrl FileViewModel::rootUrl() const
@@ -98,7 +98,7 @@ QModelIndex FileViewModel::rootIndex() const
 
     auto data = filterSortWorker->rootData();
     if (data) {
-        return createIndex(0, 0, data);
+        return createIndex(0, 0, data.data());
     } else {
         return QModelIndex();
     }
@@ -158,7 +158,7 @@ FileInfoPointer FileViewModel::fileInfo(const QModelIndex &index) const
         return nullptr;
 
     const QModelIndex &parentIndex = index.parent();
-    FileItemData *item = nullptr;
+    FileItemDataPointer item{ nullptr };
     if (!parentIndex.isValid()) {
         item = filterSortWorker->rootData();
     } else {
@@ -272,7 +272,7 @@ QVariant FileViewModel::data(const QModelIndex &index, int role) const
     if (filterSortWorker.isNull())
         return QVariant();
 
-    FileItemData *itemData = nullptr;
+    FileItemDataPointer itemData = nullptr;
     int columnRole = role;
     if (!parentIndex.isValid()) {
         itemData = filterSortWorker->rootData();
@@ -783,7 +783,7 @@ void FileViewModel::initFilterSortWork()
 
     filterSortWorker.reset(new FileSortWorker(dirRootUrl, currentKey, filterCallback, nameFilters, currentFilters));
     beginInsertRows(QModelIndex(), 0, 0);
-    filterSortWorker->setRootData(new FileItemData(dirRootUrl, InfoFactory::create<FileInfo>(dirRootUrl)));
+    filterSortWorker->setRootData(FileItemDataPointer(new FileItemData(dirRootUrl, InfoFactory::create<FileInfo>(dirRootUrl))));
     endInsertRows();
     filterSortWorker->setSortAgruments(order, role, Application::instance()->appAttribute(Application::kFileAndDirMixedSort).toBool());
     filterSortWorker->moveToThread(filterSortThread.data());

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -6,6 +6,7 @@
 #define FILESORTWORKER_H
 
 #include "dfmplugin_workspace_global.h"
+#include "models/fileitemdata.h"
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/interfaces/fileinfo.h>
 #include <dfm-base/interfaces/abstractsortfilter.h>
@@ -21,7 +22,6 @@
 
 using namespace dfmbase;
 namespace dfmplugin_workspace {
-class FileItemData;
 class FileSortWorker : public QObject
 {
     Q_OBJECT
@@ -44,10 +44,10 @@ public:
                              const bool isMixDirAndFile);
     QUrl mapToIndex(int index);
     int childrenCount();
-    FileItemData *childData(const int index);
-    FileItemData *childData(const QUrl &url);
-    void setRootData(FileItemData *data);
-    FileItemData *rootData() const;
+    FileItemDataPointer childData(const int index);
+    FileItemDataPointer childData(const QUrl &url);
+    void setRootData(const FileItemDataPointer data);
+    FileItemDataPointer rootData() const;
     void cancel();
     int getChildShowIndex(const QUrl &url);
     QList<QUrl> getChildrenUrls();
@@ -115,7 +115,7 @@ public slots:
     void handleFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg);
 
 private:
-    void checkNameFilters(FileItemData *itemData);
+    void checkNameFilters(const FileItemDataPointer itemData);
     bool checkFilters(const SortInfoPointer &sortInfo, const bool byInfo = false);
     void filterAllFiles(const bool byInfo = false);
     void filterAllFilesOrdered();
@@ -142,13 +142,14 @@ private:
     QList<SortInfoPointer> children {};
     QList<QUrl> childrenUrlList {};
     QReadWriteLock childrenDataLocker;
-    QMap<QUrl, FileItemData *> childrenDataMap {};
+    QMap<QUrl, FileItemDataPointer> childrenDataMap {};
+    QMap<QUrl, FileItemDataPointer> childrenDataLastMap {};
     QList<QUrl> visibleChildren {};
     QReadWriteLock locker;
     AbstractSortFilterPointer sortAndFilter { nullptr };
     FileViewFilterCallback filterCallback { nullptr };
     QVariant filterData;
-    FileItemData *rootdata { nullptr };
+    FileItemDataPointer rootdata { nullptr };
     QString currentKey;
     Global::ItemRoles orgSortRole { Global::ItemRoles::kItemDisplayRole };
     Qt::SortOrder sortOrder { Qt::AscendingOrder };


### PR DESCRIPTION
F5 forced refresh, filesortworker thread destructed filedataitem, causing main thread to crash

Log: F5 shortcut held down, dde-file-manager crashes
Bug: https://pms.uniontech.com/bug-view-217305.html