### PR TITLE
fix: [clipboard]dde-file-manager stuck at ctrl+x

### DIFF
--- a/src/dfm-base/utils/systempathutil.h
+++ b/src/dfm-base/utils/systempathutil.h
@@ -36,6 +36,8 @@ private:
     void initialize();
     void mkPath(const QString &path);
     void cleanPath(QString *path) const;
+    bool checkContainsSystemPathByFileInfo(const QList<QUrl> &urlList);
+    bool checkContainsSystemPathByFileUrl(const QList<QUrl> &urlList);
 
 public:
     void loadSystemPaths();


### PR DESCRIPTION
When determining if the system path is included, use url to get the file path if the scheme starts with file, and use fileinfo to get the others.

Log: dde-file-manager stuck at ctrl+x
Bug: https://pms.uniontech.com/bug-view-217799.html