### PR TITLE
fix: [trash]Files in subdirectories in trash are deleted using the delete key.

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -353,16 +353,14 @@ JobHandlePointer FileOperationsEventReceiver::doDeleteFile(const quint64 windowI
     if (sources.isEmpty())
         return nullptr;
 
-    if (SystemPathUtil::instance()->checkContainsSystemPath(sources)) {
-        DialogManagerInstance->showDeleteSystemPathWarnDialog(windowId);
+    // hook events
+    if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_DeleteFile", windowId, sources, flags)) {
         return nullptr;
     }
 
-    if (!dfmbase::FileUtils::isLocalFile(sources.first())) {
-        // hook events
-        if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_DeleteFile", windowId, sources, flags)) {
-            return nullptr;
-        }
+    if (SystemPathUtil::instance()->checkContainsSystemPath(sources)) {
+        DialogManagerInstance->showDeleteSystemPathWarnDialog(windowId);
+        return nullptr;
     }
 
     // Delete local file with shift+delete, show a confirm dialog.

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -57,12 +57,12 @@ JobHandlePointer TrashFileEventReceiver::doMoveToTrash(const quint64 windowId, c
     if (sources.isEmpty())
         return nullptr;
 
-    if (SystemPathUtil::instance()->checkContainsSystemPath(sources)) {
-        DialogManagerInstance->showDeleteSystemPathWarnDialog(windowId);
+    if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash", windowId, sources, flags)) {
         return nullptr;
     }
 
-    if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash", windowId, sources, flags)) {
+    if (SystemPathUtil::instance()->checkContainsSystemPath(sources)) {
+        DialogManagerInstance->showDeleteSystemPathWarnDialog(windowId);
         return nullptr;
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -65,6 +65,9 @@ bool TrashFileHelper::moveToTrash(const quint64 windowId, const QList<QUrl> sour
         return false;
     if (sources.first().scheme() != scheme())
         return false;
+    // trash sub dir file do not run
+    if (!FileUtils::isTrashRootFile(sources.first()) && !FileUtils::isTrashRootFile(UrlRoute::urlParent(sources.first())))
+        return true;
 
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kCleanTrash,
                                  windowId,
@@ -81,6 +84,9 @@ bool TrashFileHelper::deleteFile(const quint64 windowId, const QList<QUrl> sourc
         return false;
     if (sources.first().scheme() != scheme())
         return false;
+    // trash sub dir file do not run
+    if (!FileUtils::isTrashRootFile(sources.first()) && !FileUtils::isTrashRootFile(UrlRoute::urlParent(sources.first())))
+        return true;
 
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kCleanTrash,
                                  windowId,


### PR DESCRIPTION
Files in subdirectories in trash are blocked using delete and the shift+delete shortcut.

Log: Files in subdirectories in trash are deleted using the delete key.、
Bug: https://pms.uniontech.com/bug-view-217597.html