### PR TITLE
fix: In higher versions of the QT(5.15), qApp->setActiveWindow cannot activate the window.

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
@@ -54,7 +54,7 @@ FileManagerWindow *FileManagerWindowsManagerPrivate::activeExistsWindowByUrl(con
             qInfo() << "Find url: " << url << " window: " << window;
             if (window->isMinimized())
                 window->setWindowState(window->windowState() & ~Qt::WindowMinimized);
-            qApp->setActiveWindow(window);
+            window->activateWindow();
             return window;
         }
     }


### PR DESCRIPTION
Use QWidget::activateWindow instead of qApp->setActiveWindow to activate the window.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-207689.html
