### PR TITLE
fix: [shortcut]Add a prompt to use the Delete key to delete files with no permission to operate.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -343,10 +343,6 @@ void RootInfo::addChildren(const QList<QUrl> &urlList)
         if (!child)
             continue;
 
-        // 在收到文件创建前，fileinfo的实例已缓存，所以这是异步的fileinfo就不会刷新，判断文件是否存在还是false
-        // 所以再次刷新fileinfo
-        child->refresh();
-
         auto sortInfo = addChild(child);
         if (sortInfo)
             newSortInfo.append(sortInfo);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/shortcuthelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/shortcuthelper.cpp
@@ -270,11 +270,17 @@ void ShortcutHelper::undoFiles()
 
 void ShortcutHelper::deleteFiles()
 {
-    if (view->selectedUrlList().isEmpty())
+    const QList<QUrl> &selectUrls = view->selectedUrlList();
+    if (selectUrls.isEmpty())
         return;
+    // v5功能 判断当前目录是否有写权限，没有就提示权限错误
+    if (!view->rootIndex().data(Global::ItemRoles::kItemFileIsWritableRole).toBool()) {
+        DialogManager::instance()->showNoPermissionDialog(selectUrls);
+        return;
+    }
 
     auto windowId = WorkspaceHelper::instance()->windowId(view);
-    if (dpfHookSequence->run(kCurrentEventSpace, "hook_ShortCut_DeleteFiles", windowId, view->selectedUrlList()))
+    if (dpfHookSequence->run(kCurrentEventSpace, "hook_ShortCut_DeleteFiles", windowId, selectUrls))
         return;
 
     // Todo(yanghao):only support trash on root url
@@ -286,16 +292,21 @@ void ShortcutHelper::deleteFiles()
 
 void ShortcutHelper::moveToTrash()
 {
+    const QList<QUrl> &selectUrls = view->selectedUrlList();
+    if (selectUrls.isEmpty())
+        return;
+    // v5功能 判断当前目录是否有写权限，没有就提示权限错误
+    if (!view->rootIndex().data(Global::ItemRoles::kItemFileIsWritableRole).toBool()) {
+        DialogManager::instance()->showNoPermissionDialog(selectUrls);
+        return;
+    }
     auto windowId = WorkspaceHelper::instance()->windowId(view);
-    if (dpfHookSequence->run(kCurrentEventSpace, "hook_ShortCut_MoveToTrash", windowId, view->selectedUrlList()))
+    if (dpfHookSequence->run(kCurrentEventSpace, "hook_ShortCut_MoveToTrash", windowId, selectUrls))
         return;
     // Todo(lanxs): QUrl to LocalFile
     // complete deletion eg: gvfs, vault
     // only support trash on root url
-    const QList<QUrl> &urls = view->selectedUrlList();
-
-    if (!urls.isEmpty())
-        FileOperatorHelperIns->moveToTrash(view, urls);
+    FileOperatorHelperIns->moveToTrash(view, selectUrls);
 }
 
 void ShortcutHelper::touchFolder()


### PR DESCRIPTION
Add a prompt when delete and shift+delete are used to delete a directory without write permission.

Log: Add a prompt to use the Delete key to delete files with no permission to operate.
Bug: https://pms.uniontech.com/bug-view-217789.html