### PR TITLE
修复特定类型加密磁盘解锁后访问异常的问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -282,10 +282,10 @@ void BlockEntryFileEntity::loadDiskInfo()
     auto id = QString(DeviceId::kBlockDeviceIdPrefix)
             + entryUrl.path().remove("." + QString(SuffixInfo::kBlock));
 
-    datas = UniversalUtils::convertFromQMap(DevProxyMng->queryBlockInfo(id));
+    datas = UniversalUtils::convertFromQMap(DevProxyMng->queryBlockInfo(id, true));
     auto clearBlkId = datas.value(DeviceProperty::kCleartextDevice).toString();
     if (datas.value(DeviceProperty::kIsEncrypted).toBool() && clearBlkId.length() > 1) {
-        auto clearBlkData = DevProxyMng->queryBlockInfo(clearBlkId);
+        auto clearBlkData = DevProxyMng->queryBlockInfo(clearBlkId, true);
         datas.insert(BlockAdditionalProperty::kClearBlockProperty, clearBlkData);
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -676,7 +676,11 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
                 addDevice(diskGroup(), url, ComputerItemData::kLargeItem, true);
         } else {
             auto &&devUrl = ComputerUtils::makeBlockDevUrl(id);
-            if (propertyName == DeviceProperty::kOptical)
+            // when these properties changed, reload the cache.
+            QStringList queryInfoOnChanged { DeviceProperty::kOptical,
+                                             DeviceProperty::kFileSystem,
+                                             DeviceProperty::kCleartextDevice };
+            if (queryInfoOnChanged.contains(propertyName))
                 onUpdateBlockItem(id);
             Q_EMIT itemPropertyChanged(devUrl, propertyName, var.variant());
         }


### PR DESCRIPTION
as title.
when property such as IdLabel/CleartextDevice changed, the cache should
be updated to make sure devices can be accessed via dfm.

Log: update cache.
