### PR TITLE
fix: [workspace]view shortcut issue

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -1306,7 +1306,7 @@ QModelIndex FileView::moveCursor(QAbstractItemView::CursorAction cursorAction, Q
     }
 
     if (index.isValid()) {
-        if (viewMode() == IconMode) {
+        if (d->currentViewMode == DFMGLOBAL_NAMESPACE::ViewMode::kIconMode) {
             bool lastRow = indexOfRow(index) == rowCount() - 1;
 
             if (!lastRow


### PR DESCRIPTION
in icon view mode, press down key should select the last item when the cursor move from the row front of the last row to the last row item.

Log: fix view shortcut issue
Bug: https://pms.uniontech.com/bug-view-218033.html