### PR TITLE
fix: never treat mobile device as Data Disk.

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -364,14 +364,18 @@ QString DeviceUtils::nameOfSystemDisk(const QVariantMap &datas)
 {
     QString label = datas.value(kIdLabel).toString();
     qlonglong size = datas.value(kSizeTotal).toLongLong();
+    QString mountPoint = datas.value(kMountPoint).toString();
 
     // get system disk name if there is no alias
-    if (datas.value(kMountPoint).toString() == "/")
+    if (mountPoint == "/")
         return QObject::tr("System Disk");
-    if (datas.value(kIdLabel).toString().startsWith("_dde_data"))
-        return QObject::tr("Data Disk");
-    if (datas.value(kIdLabel).toString().startsWith("_dde_"))
-        return datas.value(kIdLabel).toString().mid(5);
+    if (!mountPoint.startsWith("/media/"))
+    {
+        if (label.startsWith("_dde_data"))
+            return QObject::tr("Data Disk");
+        if (label.startsWith("_dde_"))
+            return datas.value(kIdLabel).toString().mid(5);
+    }
     return nameOfDefault(label, size);
 }
 


### PR DESCRIPTION
增加判断条件，当挂载点不以"/media/"开头时，分区卷标以"_dde_data"开头的分区才会被显示为数据分区。
以避免移动设备中分卷卷标以"_dde_data"开头的分区被显示为数据分区，造成难以区分外置磁盘和内置磁盘的情况。
[论坛反馈](https://bbs.deepin.org/post/262009)