### PR TITLE
修复无法以Enter键进入计算机页面中项的问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
@@ -108,6 +108,7 @@ bool ComputerView::eventFilter(QObject *watched, QEvent *event)
             if (idx.isValid()) {
                 if (!this->model()->data(idx, ComputerModel::DataRoles::kItemIsEditingRole).toBool()) {
                     Q_EMIT enterPressed(idx);
+                    this->cdTo(idx);
                     return true;
                 } else {
                     this->setCurrentIndex(idx);


### PR DESCRIPTION
as title

Log: fix issue that cannot enter a dir with key enter.

Bug: https://pms.uniontech.com/bug-view-218951.html
