### PR TITLE
feat: [workspace]The workspace supports tree-structured directories

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -90,6 +90,9 @@ enum ItemRoles {
     kItemFileCanDragRole = Qt::UserRole + 31,
     kItemFileSizeIntRole = Qt::UserRole + 32,
     kItemCreateFileInfoRole = Qt::UserRole + 33,
+    kItemTreeViewDepthRole = Qt::UserRole + 34,
+    kItemTreeViewExpandabledRole = Qt::UserRole + 35,
+    kItemTreeViewCanExpandRole = Qt::UserRole + 36, // item can expand
     kItemUnknowRole = Qt::UserRole + 999
 };
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
@@ -209,6 +209,12 @@ QVariant FileItemData::data(int role) const
         return 0;
     case kItemFileIsAvailableRole:
         return isAvailable;
+    case kItemTreeViewDepthRole:
+        return QVariant(depth);
+    case kItemTreeViewExpandabledRole:
+        return QVariant(expandabled);
+    case kItemTreeViewCanExpandRole:
+        return canExpand();
     default:
         return QVariant();
     }
@@ -217,4 +223,32 @@ QVariant FileItemData::data(int role) const
 void FileItemData::setAvailableState(bool b)
 {
     isAvailable = b;
+}
+
+void FileItemData::setExpandabled(bool b)
+{
+    expandabled = b;
+}
+
+void FileItemData::setDepth(const int8_t depth)
+{
+    this->depth = depth;
+}
+
+void FileItemData::setSubFileCount(const int count)
+{
+    subFileCount = count;
+}
+
+bool FileItemData::canExpand() const
+{
+    if (info) {
+        if (!info->isDir())
+            return false;
+    } else {
+        if (sortInfo && !sortInfo->isDir())
+            return false;
+    }
+
+    return subFileCount > 0;
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
@@ -30,6 +30,12 @@ public:
     QVariant data(int role) const;
 
     void setAvailableState(bool b);
+    void setExpandabled(bool b);
+    void setDepth(const int8_t depth);
+    void setSubFileCount(const int count);
+
+private:
+    bool canExpand() const;
 
 private:
     FileItemData *parent { nullptr };
@@ -37,6 +43,9 @@ private:
     FileInfoPointer info { nullptr };
     SortInfoPointer sortInfo { nullptr };
     bool isAvailable { true };
+    std::atomic_int8_t depth { 0 };
+    std::atomic_bool expandabled { false };
+    std::atomic_int subFileCount{ 0 }; // sub file count,not contain hide file
 };
 
 }


### PR DESCRIPTION
Fileitemdata adds the attributes whether to expand or not, whether it can be expanded or not, and the current depth.

Log: The workspace supports tree-structured directories
Task: https://pms.uniontech.com/task-view-292383.html