### PR TITLE
fix: [server] server crash under pressure test.

### DIFF
--- a/src/dfm-base/base/device/private/devicewatcher.cpp
+++ b/src/dfm-base/base/device/private/devicewatcher.cpp
@@ -51,9 +51,11 @@ void DeviceWatcher::stopPollingUsage()
 void DeviceWatcherPrivate::queryUsageAsync()
 {
     QtConcurrent::run([this] {
-        std::for_each(allBlockInfos.cbegin(), allBlockInfos.cend(),
+        auto blocks = allBlockInfos;
+        auto protocols = allProtocolInfos;
+        std::for_each(blocks.cbegin(), blocks.cend(),
                       [this](const QVariantMap &item) { queryUsageOfItem(item, DeviceType::kBlockDevice); });
-        std::for_each(allProtocolInfos.cbegin(), allProtocolInfos.cend(),
+        std::for_each(protocols.cbegin(), protocols.cend(),
                       [this](const QVariantMap &item) { queryUsageOfItem(item, DeviceType::kProtocolDevice); });
     });
 }


### PR DESCRIPTION
the test tests the stability when (un)mount huge amount of samba shares
in short time.
and that makes server crash in thread, items has been remove from a map,
and the map is accessed in another thread without any locker protect.

Solution: use the copy of the map in thread to iterate.

Log: fix issue that server crash under pressure tests.

Bug: https://pms.uniontech.com/bug-view-219219.html
