### PR TITLE
fix: remove -fPIE from generic CXXFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_AUTOUIC ON)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wl,--as-need -fPIE")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wl,--as-needed")
 
 #安全加固
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all -Werror=return-type")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,7 +53,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 # 用于测试覆盖率的编译条件
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wl,--as-need -fPIE")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wl,--as-needed")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-inline -fno-access-control -O0 -fprofile-arcs -ftest-coverage -lgcov")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DQT_DEBUG")
 


### PR DESCRIPTION
They are not applicable for shared libraries and breaks building. Please use `--enable-default-pie` for gcc instead of inserting PIE flags to every package.

```
[16/1008] Linking CXX shared library
src/dfm-extension/libdfm-extension.so.1.0.0
FAILED: src/dfm-extension/libdfm-extension.so.1.0.0
: && /usr/bin/c++ -fPIC -march=x86-64 -mtune=generic -O2 -pipe -fno-plt
-fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat
-Werror=format-security         -fstack-clash-protection -fcf-protection
-Wp,-D_GLIBCXX_ASSERTIONS -g
-ffile-prefix-map=/build/deepin-file-manager/src=/usr/src/debug/deepin-file-manager
-flto=auto -g -Wall -Wl,--as-need -fPIE -fstack-protector-all
-Werror=return-type -Ofast -O3 -DNDEBUG
-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto -shared
-Wl,-soname,libdfm-extension.so.1 -o
src/dfm-extension/libdfm-extension.so.1.0.0
src/dfm-extension/CMakeFiles/dfm-extension.dir/dfm-extension_autogen/mocs_compilation.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/emblemicon/dfmextemblem.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/emblemicon/dfmextemblemiconlayout.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/emblemicon/dfmextemblemiconplugin.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/emblemicon/private/dfmextemblemprivate.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/menu/dfmextaction.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/menu/dfmextmenu.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/menu/dfmextmenuplugin.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/menu/dfmextmenuproxy.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/menu/private/dfmextactionprivate.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/menu/private/dfmextmenuprivate.cpp.o
src/dfm-extension/CMakeFiles/dfm-extension.dir/menu/private/dfmextmenuproxyprivate.cpp.o
&& :
/usr/bin/ld: /tmp/ccK2hZm6.ltrans0.ltrans.o: warning: relocation against
`_ZTVN6dfmext19DFMExtEmblemPrivateE' in read-only section `.text'
/usr/bin/ld: /tmp/ccK2hZm6.ltrans0.ltrans.o: relocation R_X86_64_PC32
against symbol `_ZTVN6dfmext19DFMExtEmblemPrivateE' can not be used when
making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```