### PR TITLE
修复两个问题

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -164,9 +164,11 @@ static bool pluginsLoad()
 
 static void handleSIGTERM(int sig)
 {
-    qCritical() << "break with !SIGTERM! " << sig;
+    qWarning() << "break with !SIGTERM! " << sig;
 
     if (qApp) {
+        // Don't use headless if SIGTERM, cause system shutdown blocked
+        qApp->setProperty("SIGTERM", true);
         qApp->quit();
     }
 }
@@ -317,7 +319,8 @@ int main(int argc, char *argv[])
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();
 
     bool enableHeadless { DConfigManager::instance()->value(kDefaultCfgPath, "dfm.headless", false).toBool() };
-    if (enableHeadless && !SysInfoUtils::isOpenAsAdmin()) {
+    bool isSigterm { qApp->property("SIGTERM").toBool() };
+    if (!isSigterm && enableHeadless && !SysInfoUtils::isOpenAsAdmin()) {
         a.closeServer();
         QProcess::startDetached(QString("%1 -d").arg(QString(argv[0])));
     }

--- a/tests/plugins/desktop/ddplugin-organizer/view/ut_collectionview.cpp
+++ b/tests/plugins/desktop/ddplugin-organizer/view/ut_collectionview.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <DApplication>
+#include <DFileDragClient>
 #include <QMenu>
 #include <QItemSelection>
 #include <QItemSelectionRange>
@@ -32,6 +33,7 @@
 using namespace testing;
 using namespace dfmbase;
 using namespace ddplugin_organizer;
+DGUI_USE_NAMESPACE
 
 TEST(CollectionViewPrivate, helpAction) {
 

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_fileviewmodel.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_fileviewmodel.cpp
@@ -567,6 +567,9 @@ TEST_F(UT_FileViewModel, OnSetCursorWait) {
     EXPECT_EQ(cursor.shape(), Qt::WaitCursor);
 }
 
+// TODO(liuyangming): QThread::wait is overload after Qt5.15
+// adaptor it
+#if (QT_VERSION <= QT_VERSION_CHECK(5, 15, 0))
 TEST_F(UT_FileViewModel, QuitFilterSortWork) {
     bool calledCancel = false;
     bool calledQuit = false;
@@ -599,6 +602,7 @@ TEST_F(UT_FileViewModel, QuitFilterSortWork) {
     EXPECT_TRUE(calledQuit);
     EXPECT_TRUE(calledWait);
 }
+#endif
 
 TEST_F(UT_FileViewModel, DiscardFilterSortObjects) {
     bool calledCancel = false;


### PR DESCRIPTION
1. UT导致v23无法编译
2. 注销、重启会触发SIGTERM，此时如果是headless模式，会导致filemanger重复启停，使注销、重启超时