### PR TITLE
fix: remove unused jemalloc from debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -66,7 +66,6 @@ Depends:
  ${misc:Depends},
  libdde-file-manager,
  libgio-qt,
- libjemalloc2,
  libqt5xdg3,
  socat,
  cryfs,


### PR DESCRIPTION
It's no longer used.