### PR TITLE
修复保险箱和回收站右键菜单缺失反选的问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-trash/menus/trashmenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/menus/trashmenuscene.cpp
@@ -167,11 +167,17 @@ bool TrashMenuScene::triggered(QAction *action)
             dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetSort", d->windowId, Global::ItemRoles::kItemFileDeletionDate);
             return true;
         }
-        qWarning() << "action not found, id: " << actId;
         return false;
-    } else {
-        return AbstractMenuScene::triggered(action);
+    } else if (auto s = scene(action)) {
+        if (s->name() == kOpenDirMenuSceneName
+            && actId == dfmplugin_menu::ActionID::kReverseSelect) {
+            dpfSlotChannel->push("dfmplugin_workspace",
+                                 "slot_View_ReverseSelect", d->windowId);
+            return true;
+        }
     }
+
+    return AbstractMenuScene::triggered(action);
 }
 
 AbstractMenuScene *TrashMenuScene::scene(QAction *action) const
@@ -201,6 +207,7 @@ TrashMenuScenePrivate::TrashMenuScenePrivate(TrashMenuScene *qq)
     selectSupportActions.insert(kPropertyMenuSceneName, "property");
     selectSupportActions.insert(kTrashMenuSceneName, TrashActionId::kRestore);
     selectSupportActions.insert(kOpenDirMenuSceneName, dfmplugin_menu::ActionID::kOpenInNewWindow);
+    selectSupportActions.insert(kOpenDirMenuSceneName, dfmplugin_menu::ActionID::kReverseSelect);
 }
 
 void TrashMenuScenePrivate::updateMenu(QMenu *menu)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -84,6 +84,8 @@ void WorkspaceEventReceiver::initConnection()
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleSelectFiles);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_SelectAll",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleSelectAll);
+    dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_ReverseSelect",
+                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleReverseSelect);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_SetSelectionMode",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleSetSelectionMode);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_SetEnabledSelectionModes",
@@ -177,6 +179,11 @@ void WorkspaceEventReceiver::handleSelectFiles(quint64 windowId, const QList<QUr
 void WorkspaceEventReceiver::handleSelectAll(quint64 windowId)
 {
     WorkspaceHelper::instance()->selectAll(windowId);
+}
+
+void WorkspaceEventReceiver::handleReverseSelect(quint64 windowId)
+{
+    WorkspaceHelper::instance()->reverseSelect(windowId);
 }
 
 void WorkspaceEventReceiver::handleSetSort(quint64 windowId, ItemRoles role)
@@ -391,4 +398,3 @@ void WorkspaceEventReceiver::handleRegisterDataCache(const QString &scheme)
 {
     //    FileModelManager::instance()->registerDataCache(scheme);
 }
-

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -36,6 +36,7 @@ public slots:
     void handleSetTabAlias(const QUrl &url, const QString &name);
     void handleSelectFiles(quint64 windowId, const QList<QUrl> &files);
     void handleSelectAll(quint64 windowId);
+    void handleReverseSelect(quint64 windowId);
     void handleSetSort(quint64 windowId, DFMBASE_NAMESPACE::Global::ItemRoles role);
 
     void handleSetSelectionMode(const quint64 windowId, const QAbstractItemView::SelectionMode mode);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -53,6 +53,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_View_GetSelectedUrls)
     DPF_EVENT_REG_SLOT(slot_View_SelectFiles)
     DPF_EVENT_REG_SLOT(slot_View_SelectAll)
+    DPF_EVENT_REG_SLOT(slot_View_ReverseSelect)
     DPF_EVENT_REG_SLOT(slot_View_SetSelectionMode)
     DPF_EVENT_REG_SLOT(slot_View_SetEnabledSelectionModes)
     DPF_EVENT_REG_SLOT(slot_View_SetDragEnabled)

--- a/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
@@ -59,6 +59,7 @@ QStringList VaultMenuScenePrivate::normalMenuActionRule()
         "copy",
         "rename",
         "delete",
+        "reverse-select",
         "separator-line",
         "send-to",
         "property"


### PR DESCRIPTION
Log: add reverse-select in trash and vault menu.

Bug: https://pms.uniontech.com/bug-view-220175.html
