### PR TITLE
fix: [io]Deep files in trash, copy and paste to local directory fails

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -455,7 +455,7 @@ bool FileOperateBaseWorker::doCheckFile(const FileInfoPointer &fromInfo, const F
     bool isTrashFile = FileUtils::isTrashFile(fromInfo->urlOf(UrlInfoType::kUrl));
     if (isTrashFile) {
         auto trashInfoUrl= trashInfo(fromInfo);
-        fileNewName = fileOriginName(trashInfoUrl);
+        fileNewName = trashInfoUrl.isValid() ? fileOriginName(trashInfoUrl) : fileName;
     }
     newTargetInfo.reset();
     if (!doCheckNewFile(fromInfo, toInfo, newTargetInfo, fileNewName, skip, true))


### PR DESCRIPTION
Read the name of the next level file in the trash without having to read the name of the original file.

Log: Deep files in trash, copy and paste to local directory fails
Bug: https://pms.uniontech.com/bug-view-220061.html