### PR TITLE
fix: [io]After sending a folder to the desktop with smb service mounted, the link target file cannot be found when previewing it with space.

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -618,8 +618,11 @@ QIcon AsyncFileInfoPrivate::defaultIcon()
         const auto &&target = q->pathOf(PathInfoType::kSymLinkTarget);
         if (!target.isEmpty() && target != q->pathOf(PathInfoType::kFilePath)) {
             FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(target));
-            if (info)
+            if (info) {
+                if (info->fileIcon().name() == "unknown")
+                    info->customData(Global::ItemRoles::kItemFileRefreshIcon);
                 icon = info->fileIcon();
+            }
         }
     }
 

--- a/src/plugins/common/dfmplugin-preview/filepreview/utils/previewdialogmanager.cpp
+++ b/src/plugins/common/dfmplugin-preview/filepreview/utils/previewdialogmanager.cpp
@@ -44,10 +44,16 @@ void PreviewDialogManager::showPreviewDialog(const quint64 winId, const QList<QU
                     continue;
                 }
 
-                const FileInfoPointer linkInfo = InfoFactory::create<FileInfo>(targetUrl);
-                if (!linkInfo || !linkInfo->exists()) {
+                dfmio::DFile file(targetUrl);
+                if (!file.exists()) {
                     hasInvalidSymlink = true;
                     continue;
+                }
+
+                const FileInfoPointer linkInfo = InfoFactory::create<FileInfo>(targetUrl);
+                if (linkInfo && !linkInfo->exists() && linkInfo->timeOf(TimeInfoType::kCreateTimeSecond) == 0) {
+                    info->refresh();
+                    linkInfo->refresh();
                 }
             }
         }

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
@@ -56,6 +56,9 @@ void FileInfoModelPrivate::resetData(const QList<QUrl> &urls)
     QMap<QUrl, FileInfoPointer> fileMaps;
     for (const QUrl &child : urls) {
         if (auto itemInfo = FileCreator->createFileInfo(child)) {
+            if (itemInfo->isAttributes(OptInfoType::kIsSymLink) &&
+                    !FileUtils::isLocalDevice(QUrl::fromLocalFile(itemInfo->pathOf(PathInfoType::kSymLinkTarget))))
+                itemInfo->refresh();
             fileUrls.append(itemInfo->urlOf(UrlInfoType::kUrl));
             fileMaps.insert(itemInfo->urlOf(UrlInfoType::kUrl), itemInfo);
         }


### PR DESCRIPTION
After reboot, it is not mounted, and when it is mounted again, the desktop does not listen to the protocol device, so it doesn't update the fileinfo. so there is something wrong with the attribute.

Log: After sending a folder to the desktop with smb service mounted, the link target file cannot be found when previewing it with space.
Bug: https://pms.uniontech.com/bug-view-219383.html