### PR TITLE
fix: [workspace]Icon view optimization, multi-select text drawing, reserved images on both sides

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -50,7 +50,7 @@ inline constexpr int kCompactIconViewSpacing { 0 };
 inline constexpr int kCompactIconModeColumnPadding { 5 };
 #endif
 
-inline constexpr int kIconViewSpacing { 5 };
+inline constexpr int kIconViewSpacing { 5 }; // icon模式下的间距的一半
 inline constexpr int kListViewSpacing { 0 };
 inline constexpr int kIconModeColumnPadding { 10 };
 inline constexpr int kDefualtHeaderSectionWidth { 140 };
@@ -64,6 +64,8 @@ inline constexpr int kListModeLeftMargin { 10 };
 inline constexpr int kListModeRightMargin { 10 };
 inline constexpr int kColumnPadding { 10 };
 inline constexpr int kMinMoveLenght { 3 };
+inline constexpr int kIconHorizontalMargin { 15 }; // 水平Margin的宽度
+inline constexpr int kCompactIconHorizontalMargin { 10 };
 
 // tab defines
 inline constexpr int kMaxTabCount { 8 };

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -267,32 +267,28 @@ int FileViewHelper::caculateListItemIndex(const QSize &itemSize, const QPoint &p
 
 int FileViewHelper::caculateIconItemIndex(const FileView *view, const QSize &itemSize, const QPoint &pos)
 {
-    int iconModeColumnPadding = kIconModeColumnPadding;
     int iconViewSpacing = kIconViewSpacing;
 #ifdef DTKWIDGET_CLASS_DSizeMode
-    iconModeColumnPadding = DSizeModeHelper::element(kCompactIconModeColumnPadding, kIconModeColumnPadding);
     iconViewSpacing = DSizeModeHelper::element(kCompactIconViewSpacing, kIconViewSpacing);
 #endif
 
     int itemHeight = itemSize.height() + iconViewSpacing * 2;
-    if (pos.y() % itemHeight < (iconViewSpacing + iconModeColumnPadding)
-        || pos.y() % itemHeight > (itemHeight - iconModeColumnPadding))
+    if (pos.y()  % itemHeight < iconViewSpacing
+        || pos.y() % itemHeight > (itemHeight - iconViewSpacing))
         return -1;
 
     int itemWidth = itemSize.width() + iconViewSpacing * 2;
-
-    if (pos.x() % itemWidth <= (iconViewSpacing + iconModeColumnPadding)
-        || pos.x() % itemWidth > (itemHeight - iconModeColumnPadding))
+    if (pos.x() % itemWidth < iconViewSpacing
+        || pos.x() % itemWidth > (itemHeight - iconViewSpacing))
         return -1;
 
     int columnIndex = pos.x() / itemWidth;
-    int contentWidth = view->maximumViewportSize().width();
-    int columnCount = qMax((contentWidth - 1) / itemWidth, 1);
+    int columnCount = view->itemCountForRow();
 
     if (columnIndex >= columnCount)
         return -1;
 
-    int rowIndex = pos.y() / (itemSize.height() + iconViewSpacing * 2);
+    int rowIndex = pos.y() / itemHeight;
     return rowIndex * columnCount + columnIndex;
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/itemdelegatehelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/itemdelegatehelper.h
@@ -15,8 +15,8 @@
 namespace dfmplugin_workspace {
 
 // begin file view item icon delegate global define
-inline constexpr int kIconModeTextPadding = { 4 };
-inline constexpr int kIconModeIconSpacing = { 6 };
+inline constexpr int kIconModeTextPadding = { 4 }; // 选中背景和文字之间的距离
+inline constexpr int kIconModeIconSpacing = { 6 }; // icon与背景的边距
 inline constexpr int kIconModeRectRadius = kIconModeTextPadding;
 inline constexpr int kIconModeBackRadius = { 6 };
 inline constexpr int kIconModeColumuPadding { 10 };

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
@@ -114,6 +114,7 @@ public:
     QRectF itemRect(const QUrl &url, const DFMGLOBAL_NAMESPACE::ItemRoles role) const;
 
     bool isVerticalScrollBarSliderDragging() const;
+    void updateViewportContentsMargins(const QSize &itemSize);
 
     using DListView::edit;
     using DListView::updateGeometries;


### PR DESCRIPTION
Modify the setting of contentmargin, modify the text drawing after multiple choice attempts to select, adjust the logic of icon view's selection interpretation.

Log: Icon view optimization, multi-select text drawing, reserved images on both sides