### PR TITLE
fix: [workspace]New files added to the CD-ROM are deleted with a shortcut key and an error is reported.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/shortcuthelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/shortcuthelper.cpp
@@ -274,7 +274,8 @@ void ShortcutHelper::deleteFiles()
     if (selectUrls.isEmpty())
         return;
     // v5功能 判断当前目录是否有写权限，没有就提示权限错误
-    if (!view->rootIndex().data(Global::ItemRoles::kItemFileIsWritableRole).toBool()) {
+    if (selectUrls.first().scheme() == Global::Scheme::kFile
+            && !view->rootIndex().data(Global::ItemRoles::kItemFileIsWritableRole).toBool()) {
         DialogManager::instance()->showNoPermissionDialog(selectUrls);
         return;
     }
@@ -296,7 +297,8 @@ void ShortcutHelper::moveToTrash()
     if (selectUrls.isEmpty())
         return;
     // v5功能 判断当前目录是否有写权限，没有就提示权限错误
-    if (!view->rootIndex().data(Global::ItemRoles::kItemFileIsWritableRole).toBool()) {
+    if (selectUrls.first().scheme() == Global::Scheme::kFile
+            && !view->rootIndex().data(Global::ItemRoles::kItemFileIsWritableRole).toBool()) {
         DialogManager::instance()->showNoPermissionDialog(selectUrls);
         return;
     }


### PR DESCRIPTION
Optical drives are special directories whose parent directories do not have write permissions. Modify only the scheme as file to do judgment.

Log: New files added to the CD-ROM are deleted with a shortcut key and an error is reported.
Bug: https://pms.uniontech.com/bug-view-220917.html