### PR TITLE
fix: [workspace]Creating a wps file in red disk space doesn't show up,it needs to be refreshed before it shows up

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -206,7 +206,7 @@ public:
                                     QString *errorString = nullptr)
     {
         if (!url.isValid()) {
-            qWarning() << "url is unvalid !!! url = " << url;
+            qWarning() << "url is invalid !!! url = " << url;
             return nullptr;
         }
 

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -524,18 +524,21 @@ void AsyncFileInfo::removeNotifyUrl(const QUrl &url, const QString &infoPtr)
     d->notifyUrls.remove(url, infoPtr);
 }
 
-bool AsyncFileInfo::cacheAsyncAttributes()
+int AsyncFileInfo::cacheAsyncAttributes()
 {
     assert(qApp->thread() != QThread::currentThread());
     auto dfmFileInfo = d->dfmFileInfo;
     if (d->tokenKey != quintptr(dfmFileInfo.data()))
-        return false;
+        return -1;
+
+    if (d->cacheingAttributes)
+        return 0;
 
     if (!d->cacheingAttributes)
         d->cacheingAttributes = true;
     d->cacheAllAttributes();
     d->cacheingAttributes = false;
-    return true;
+    return 1;
 }
 
 bool AsyncFileInfo::asyncQueryDfmFileInfo(int ioPriority, FileInfo::initQuerierAsyncCallback func, void *userData)

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -182,7 +182,8 @@ public:
     QMultiMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
     void removeNotifyUrl(const QUrl &url, const QString &infoPtr);
-    bool cacheAsyncAttributes();
+    // less 0,cache fialed, equeal 0,another cache, bigger 0 cache success
+    int cacheAsyncAttributes();
     bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);
 };
 }

--- a/src/dfm-base/interfaces/abstractfilewatcher.cpp
+++ b/src/dfm-base/interfaces/abstractfilewatcher.cpp
@@ -108,7 +108,7 @@ bool AbstractFileWatcher::startWatcher()
 bool AbstractFileWatcher::stopWatcher()
 {
     if (!d->started)
-        return false;
+        return true;
 
     if (d->stop()) {
         d->started = false;

--- a/src/dfm-base/utils/fileinfohelper.cpp
+++ b/src/dfm-base/utils/fileinfohelper.cpp
@@ -47,7 +47,14 @@ void FileInfoHelper::threadHandleDfmFileInfo(const QSharedPointer<FileInfo> dfil
     if (asyncInfo.isNull())
         return;
 
-    if (!asyncInfo->cacheAsyncAttributes())
+    auto resluts = asyncInfo->cacheAsyncAttributes();
+
+    while (resluts == 0) {
+        QThread::msleep(50);
+        resluts = asyncInfo->cacheAsyncAttributes();
+    }
+
+    if (resluts < 0)
         return;
 
     emit fileRefreshFinished(dfileInfo->fileUrl(), QString::number(quintptr(dfileInfo.data()), 16), false);

--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -59,6 +59,7 @@ private:
     QSharedPointer<QThread> thread { nullptr };
     QSharedPointer<FileInfoAsycWorker> worker { nullptr };
     std::atomic_bool stoped { false };
+    DThreadList<FileInfoPointer> qureingInfo;
     QThreadPool pool;
 };
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -30,6 +30,7 @@ RootInfo::RootInfo(const QUrl &u, const bool canCache, QObject *parent)
 
 RootInfo::~RootInfo()
 {
+    disconnect();
     cancelWatcherEvent = true;
     watcherEventFuture.waitForFinished();
     for (const auto &thread : traversalThreads) {
@@ -93,6 +94,9 @@ void RootInfo::startWork(const QString &key, const bool getCache)
 
 void RootInfo::startWatcher()
 {
+    if (needStartWatcher == false)
+        return;
+    needStartWatcher = false;
     if (watcher)
         watcher->disconnect(this);
 
@@ -112,7 +116,7 @@ void RootInfo::startWatcher()
     connect(watcher.data(), &AbstractFileWatcher::fileRename,
             this, &RootInfo::dofileMoved);
 
-    watcher->startWatcher();
+    watcher->restartWatcher();
 }
 
 int RootInfo::clearTraversalThread(const QString &key)
@@ -133,7 +137,8 @@ int RootInfo::clearTraversalThread(const QString &key)
     if (thread->traversalThread->isRunning())
         traversaling = false;
     thread->traversalThread->quit();
-
+    if (traversalThreads.isEmpty())
+        needStartWatcher = true;
     return traversalThreads.count();
 }
 
@@ -227,6 +232,8 @@ void RootInfo::doWatcherEvent()
             if (event.second == kAddFile)
                 continue;
             else if (event.second == kRmFile) {
+                emit InfoCacheController::instance().removeCacheFileInfo({ fileUrl });
+                WatcherCache::instance().removeCacheWatcherByParent(fileUrl);
                 emit requestCloseTab(fileUrl);
                 break;
             }
@@ -241,6 +248,8 @@ void RootInfo::doWatcherEvent()
             updateChild(fileUrl);
         } else {
             removeChildren({ fileUrl });
+            emit InfoCacheController::instance().removeCacheFileInfo({ fileUrl });
+            WatcherCache::instance().removeCacheWatcherByParent(fileUrl);
             emit requestCloseTab(fileUrl);
         }
     }
@@ -312,6 +321,8 @@ void RootInfo::handleTraversalSort(const QString &travseToken)
 
 void RootInfo::handleGetSourceData(const QString &currentToken)
 {
+    if (needStartWatcher)
+        startWatcher();
     QList<SortInfoPointer> newDatas = sourceDataList;
     emit sourceDatas(currentToken, newDatas, originSortRole, originSortOrder, originMixSort, !traversaling);
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -143,6 +143,7 @@ private:
 
     QList<TraversalThreadPointer> discardedThread {};
     QList<QSharedPointer<QThread>> threads {};
+    std::atomic_bool needStartWatcher { true };
 };
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -114,7 +114,8 @@ int TraversalDirThreadManager::iteratorOneByOne(const QElapsedTimer &timere)
         return 0;
     }
 
-    Q_EMIT iteratorInitFinished();
+    if (!future)
+        Q_EMIT iteratorInitFinished();
 
     if (!timer)
         timer = new QElapsedTimer();


### PR DESCRIPTION
 In the current interface, safely uninstalled the USB flash drive, did not remove the monitor, used the previous one, and has been using the monitor in the cache since then. This resulted in the files not being monitored.

Log: Creating a wps file in red disk space doesn't show up, it needs to be refreshed before it shows up
Bug: https://pms.uniontech.com/bug-view-221223.html