### PR TITLE
fix: [workspace]refresh crash issue

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -112,7 +112,6 @@ private:
     void enqueueEvent(const QPair<QUrl, EventType> &e);
     QPair<QUrl, EventType> dequeueEvent();
     FileInfoPointer fileInfo(const QUrl &url);
-    QString currentKey(const QString &travseToken);
 
 public:
     AbstractFileWatcherPointer watcher;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -59,6 +59,11 @@ void TraversalDirThreadManager::setSortAgruments(const Qt::SortOrder order, cons
     }
 }
 
+void TraversalDirThreadManager::setTraversalToken(const QString &token)
+{
+    traversalToken = token;
+}
+
 void TraversalDirThreadManager::start()
 {
     auto local = dirIterator.dynamicCast<LocalDirIterator>();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -40,6 +40,8 @@ public:
                                        QObject *parent = nullptr);
     virtual ~TraversalDirThreadManager() override;
     void setSortAgruments(const Qt::SortOrder order, const dfmbase::Global::ItemRoles sortRole, const bool isMixDirAndFile);
+    void setTraversalToken(const QString &token);
+
     void start();
 
 public Q_SLOTS:

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -590,3 +590,12 @@ TEST_F(UT_RootInfo, Bug_195309_fileInfo)
     // rootInfoObj->fileInfo() did not call fileinfo.refresh() anymore.
     // EXPECT_TRUE(calledRefresh);
 }
+
+TEST_F(UT_RootInfo, Bug_221483_traversalToken) {
+    QString key("threadKey");
+    ItemRoles role = ItemRoles::kItemFileDisplayNameRole;
+    Qt::SortOrder order = Qt::AscendingOrder;
+    bool getCache = rootInfoObj->initThreadOfFileData(key, role, order, false);
+
+    EXPECT_EQ(rootInfoObj->traversalThreads.value(key)->traversalThread->traversalToken, key);
+}


### PR DESCRIPTION
the dfm crash when press the F5 key to refresh view, because the travsersal token map used between mutli threads.

Log: fix crash issue
Bug: https://pms.uniontech.com/bug-view-221483.html