### PR TITLE
fix: [io/cut]Modifying the cut file process

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -203,6 +203,19 @@ void DoCutFilesWorker::onUpdateProgress()
     emitSpeedUpdatedNotify(writSize);
 }
 
+void DoCutFilesWorker::endWork()
+{
+    // delete all cut source files
+    bool skip{false};
+    for (const auto &info : cutAndDeleteFiles) {
+        if (!deleteFile(info->fileUrl(), targetOrgUrl, &skip)) {
+            qWarning() << "delete file error, so do not delete other files!!!!";
+            break;
+        }
+    }
+    return FileOperateBaseWorker::endWork();
+}
+
 void DoCutFilesWorker::emitCompleteFilesUpdatedNotify(const qint64 &writCount)
 {
     JobInfoPointer info(new QMap<quint8, QVariant>);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
@@ -33,6 +33,7 @@ protected:
     void stop() override;
     bool initArgs() override;
     void onUpdateProgress() override;
+    void endWork() override;
 
     bool cutFiles();
     bool doCutFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -135,6 +135,7 @@ protected:
     QString blocakTargetRootPath;
 
     std::atomic_int threadCopyFileCount { 0 };
+    QList<FileInfoPointer> cutAndDeleteFiles;
 };
 DPFILEOPERATIONS_END_NAMESPACE
 


### PR DESCRIPTION
If you are cutting files across disks, then perform copy synchronization first, and finally perform file deletion. Source file deletion as long as there is an error no matter how to deal with, exit the deletion process.

Log: Modifying the cut file process