### PR TITLE
fix: [workspace]refresh crash issue

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -55,6 +55,7 @@ bool RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::Ite
                                           QDir::AllEntries | QDir::NoDotAndDotDot | QDir::System | QDir::Hidden,
                                           QDirIterator::FollowSymlinks));
     traversalThread->traversalThread->setSortAgruments(order, role, isMixFileAndFolder);
+    traversalThread->traversalThread->setTraversalToken(key);
     initConnection(traversalThread->traversalThread);
     traversalThreads.insert(key, traversalThread);
 
@@ -265,7 +266,7 @@ void RootInfo::handleTraversalResult(const FileInfoPointer &child, const QString
 {
     auto sortInfo = addChild(child);
     if (sortInfo)
-        Q_EMIT iteratorAddFile(currentKey(travseToken), sortInfo, child);
+        Q_EMIT iteratorAddFile(travseToken, sortInfo, child);
 }
 
 void RootInfo::handleTraversalResults(QList<FileInfoPointer> children, const QString &travseToken)
@@ -281,7 +282,7 @@ void RootInfo::handleTraversalResults(QList<FileInfoPointer> children, const QSt
     }
 
     if (sortInfos.length() > 0)
-        Q_EMIT iteratorAddFiles(currentKey(travseToken), sortInfos, infos);
+        Q_EMIT iteratorAddFiles(travseToken, sortInfos, infos);
 }
 
 void RootInfo::handleTraversalLocalResult(QList<SortInfoPointer> children,
@@ -295,19 +296,19 @@ void RootInfo::handleTraversalLocalResult(QList<SortInfoPointer> children,
     addChildren(children);
     traversaling = false;
 
-    Q_EMIT iteratorLocalFiles(currentKey(travseToken), children, originSortRole, originSortOrder, originMixSort);
+    Q_EMIT iteratorLocalFiles(travseToken, children, originSortRole, originSortOrder, originMixSort);
 }
 
 void RootInfo::handleTraversalFinish(const QString &travseToken)
 {
     traversaling = false;
-    emit traversalFinished(currentKey(travseToken));
+    emit traversalFinished(travseToken);
     traversalFinish = true;
 }
 
 void RootInfo::handleTraversalSort(const QString &travseToken)
 {
-    emit requestSort(currentKey(travseToken));
+    emit requestSort(travseToken);
 }
 
 void RootInfo::handleGetSourceData(const QString &currentToken)
@@ -532,14 +533,4 @@ FileInfoPointer RootInfo::fileInfo(const QUrl &url)
     currentUrl.setPath(currentUrl.path(QUrl::PrettyDecoded) + QDir::separator() + url.fileName());
     info = InfoFactory::create<FileInfo>(currentUrl);
     return info;
-}
-
-QString RootInfo::currentKey(const QString &travseToken)
-{
-    assert(!travseToken.isEmpty());
-    for (const auto &traversalThread : traversalThreads) {
-        if (travseToken == QString::number(quintptr(traversalThread->traversalThread.data()), 16))
-            return traversalThreads.key(traversalThread);
-    }
-    return QString();
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -112,7 +112,6 @@ private:
     void enqueueEvent(const QPair<QUrl, EventType> &e);
     QPair<QUrl, EventType> dequeueEvent();
     FileInfoPointer fileInfo(const QUrl &url);
-    QString currentKey(const QString &travseToken);
 
 public:
     AbstractFileWatcherPointer watcher;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -59,6 +59,11 @@ void TraversalDirThreadManager::setSortAgruments(const Qt::SortOrder order, cons
     }
 }
 
+void TraversalDirThreadManager::setTraversalToken(const QString &token)
+{
+    traversalToken = token;
+}
+
 void TraversalDirThreadManager::start()
 {
     auto local = dirIterator.dynamicCast<LocalDirIterator>();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -40,6 +40,8 @@ public:
                                        QObject *parent = nullptr);
     virtual ~TraversalDirThreadManager() override;
     void setSortAgruments(const Qt::SortOrder order, const dfmbase::Global::ItemRoles sortRole, const bool isMixDirAndFile);
+    void setTraversalToken(const QString &token);
+
     void start();
 
 public Q_SLOTS:

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -590,3 +590,12 @@ TEST_F(UT_RootInfo, Bug_195309_fileInfo)
     // rootInfoObj->fileInfo() did not call fileinfo.refresh() anymore.
     // EXPECT_TRUE(calledRefresh);
 }
+
+TEST_F(UT_RootInfo, Bug_221483_traversalToken) {
+    QString key("threadKey");
+    ItemRoles role = ItemRoles::kItemFileDisplayNameRole;
+    Qt::SortOrder order = Qt::AscendingOrder;
+    rootInfoObj->initThreadOfFileData(key, role, order, false);
+
+    EXPECT_EQ(rootInfoObj->traversalThreads.value(key)->traversalThread->traversalToken, key);
+}


### PR DESCRIPTION
the dfm crash when press the F5 key to refresh view, because the travsersal token map used between mutli threads.

Log: fix crash issue
Bug: https://pms.uniontech.com/bug-view-221483.html