### PR TITLE
fix: [trash]Read-only empty directory, deletion prompts insufficient permissions

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -68,7 +68,14 @@ JobHandlePointer TrashFileEventReceiver::doMoveToTrash(const quint64 windowId, c
 
     const QUrl &sourceFirst = sources.first();
     JobHandlePointer handle = nullptr;
-    if (!FileUtils::fileCanTrash(sourceFirst) || !dfmio::DFMUtils::supportTrash(sourceFirst)) {
+    bool nullDirDelete = false;
+    if (sources.count() == 1) {
+        auto info = InfoFactory::create<FileInfo>(sourceFirst);
+        nullDirDelete = info && info->isAttributes(OptInfoType::kIsDir)
+                && !info->isAttributes(OptInfoType::kIsSymLink)
+                && !info->isAttributes(OptInfoType::kIsWritable);
+    }
+    if (nullDirDelete || !FileUtils::fileCanTrash(sourceFirst) || !dfmio::DFMUtils::supportTrash(sourceFirst)) {
         if (DialogManagerInstance->showDeleteFilesDialog(sources, true) != QDialog::Accepted)
             return nullptr;
         handle = copyMoveJob->deletes(sources, flags);


### PR DESCRIPTION
When executing the delete shortcut, the execution is moving to the recycle bin, here read-only directories can not achieve gio's trash function, only pop-up prompt box for him to completely delete the

Log: Read-only empty directory, deletion prompts insufficient permissions
Bug: https://pms.uniontech.com/bug-view-220283.html