### PR TITLE
fix: [io]Non-empty folders in virtual paths, incorrect file information statistics

### DIFF
--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -59,7 +59,6 @@ private:
     QSharedPointer<QThread> thread { nullptr };
     QSharedPointer<FileInfoAsycWorker> worker { nullptr };
     std::atomic_bool stoped { false };
-    DThreadList<FileInfoPointer> qureingInfo;
     QThreadPool pool;
 };
 }

--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -561,7 +561,8 @@ void FileStatisticsJob::run()
     d->sizeInfo.reset(new FileUtils::FilesSizeInfo());
     if (d->sourceUrlList.isEmpty())
         return;
-    if (!FileUtils::isLocalDevice(d->sourceUrlList.first())) {
+    if (d->sourceUrlList.first().scheme() != Global::Scheme::kFile
+            || !FileUtils::isLocalDevice(d->sourceUrlList.first())) {
         statistcsOtherFileSystem();
         return;
     }


### PR DESCRIPTION
Virtual directory called fts, incorrect path. Need to use iterator to iteratively query the number of files

Log: Non-empty folders in virtual paths, incorrect file information statistics
Bug: https://pms.uniontech.com/bug-view-221969.html