### PR TITLE
fix: [property-dialog] Trash dialog show error

### DIFF
--- a/src/plugins/common/core/dfmplugin-trashcore/views/trashpropertydialog.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/views/trashpropertydialog.cpp
@@ -42,18 +42,14 @@ void TrashPropertyDialog::initUI()
     fileCountAndFileSize->setRightValue(FileUtils::formatSize(0), Qt::ElideNone, Qt::AlignRight);
     fileCountAndFileSize->leftWidget()->setFixedWidth(150);
 
-    QFrame *infoFrame = new QFrame;
+    DFrame *infoFrame = new DFrame;
     infoFrame->setMaximumHeight(48);
     QHBoxLayout *infoLayout = new QHBoxLayout;
     infoLayout->setContentsMargins(10, 10, 10, 10);
     infoLayout->addWidget(fileCountAndFileSize);
     infoFrame->setLayout(infoLayout);
 
-    QString backColor = palette().color(QPalette::Base).name();
-    infoFrame->setStyleSheet(QString("background-color: %1; border-radius: 8px;").arg(backColor));
-
     QFrame *contenFrame = new QFrame;
-
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(trashIconLabel, 0, Qt::AlignHCenter);
     mainLayout->addWidget(hLine);


### PR DESCRIPTION
Not need set the style sheet, we can use the DFrame.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-219505.html