### PR TITLE
fix: [disk-mount] icon theme

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/widgets/diskpluginitem.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/diskpluginitem.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "diskpluginitem.h"
+#include "diskmountplugin.h"
 
 #include <QPainter>
 #include <QDebug>
@@ -40,7 +41,7 @@ void DiskPluginItem::updateIcon()
 {
     QString &&iconName = "drive-removable-dock-symbolic";
 
-#ifndef COMPILE_ON_V20
+#if defined(COMPILE_ON_V23) || defined(USE_DOCK_NEW_INTERFACE)
     if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
         iconName.append(PLUGIN_MIN_ICON_NAME);
 #else


### PR DESCRIPTION
Don't judge `PLUGIN_BACKGROUND_MIN_SIZE` if `USE_DOCK_NEW_INTERFACE` defined

Log: interface adaptation

Bug: https://pms.uniontech.com/bug-view-221295.html