### PR TITLE
fix: [io]The red disk monitor is not working.

### DIFF
--- a/src/dfm-base/utils/watchercache.cpp
+++ b/src/dfm-base/utils/watchercache.cpp
@@ -106,8 +106,10 @@ void WatcherCache::removeCacheWatcherByParent(const QUrl &parent)
     Q_D(WatcherCache);
     auto keys = d->watchers.keys();
     for (const auto &url : keys) {
-        if (url.scheme() == parent.scheme() && url.path().startsWith(parent.path()))
+        if (url.scheme() == parent.scheme() && url.path().startsWith(parent.path())) {
+            d->watchers.value(url)->stopWatcher();
             d->watchers.remove(url);
+        }
     }
 }
 


### PR DESCRIPTION
When the file manager went to the red disk, unmounted and mounted the red disk again, the monitoring did not stop, causing the underlying gio to monitor the same directory as the last time. The monitor is actively stopped when exiting the current directory, and also when removing the monitor.

Log: The red disk monitor is not working.