### PR TITLE
扩展菜单支持插入到已有的二级菜单中

### DIFF
--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
@@ -69,13 +69,13 @@ void DCustomActionBuilder::setFocusFile(const QUrl &file)
     }
 
     fileFullName = info->nameOf(NameInfoType::kFileName);
-    //baseName
+    // baseName
     if (info->isAttributes(OptInfoType::kIsDir)) {
         fileBaseName = fileFullName;
         return;
     }
-    //fix bug 65159,这里只针对一些常见的后缀处理，暂不针对一些非标准的特殊情况做处理,待后续产品有特殊要求再处理特殊情况
-    //suffixForFileName对复式后缀会返回xx.*,比如test.7z.001返回的是7z.*
+    // fix bug 65159,这里只针对一些常见的后缀处理，暂不针对一些非标准的特殊情况做处理,待后续产品有特殊要求再处理特殊情况
+    // suffixForFileName对复式后缀会返回xx.*,比如test.7z.001返回的是7z.*
     //不过在一些非标准的复式后缀判定中，仍可能判定不准确：比如：test.part1.rar被识别成rar
     //隐藏文件：".tar"、".tar.gz"后缀识别成""和".gz"
     //可能无法识别到后缀：如test.run或者.tar
@@ -188,7 +188,7 @@ QList<DCustomActionEntry> DCustomActionBuilder::matchFileCombo(const QList<DCust
 #ifdef MENU_CHECK_FOCUSONLY
     // add kFileAndDir if type is kMultiDirs or kMultiFiles.
     if (type == DCustomActionDefines::kMultiDirs
-            || type == DCustomActionDefines::kMultiFiles) {
+        || type == DCustomActionDefines::kMultiFiles) {
         type |= DCustomActionDefines::kFileAndDir;
     }
 #endif
@@ -203,14 +203,14 @@ QList<DCustomActionEntry> DCustomActionBuilder::matchFileCombo(const QList<DCust
 QList<DCustomActionEntry> DCustomActionBuilder::matchActions(const QList<QUrl> &selects,
                                                              QList<DCustomActionEntry> oriActions)
 {
-    //todo：细化功能颗粒度，一个函数尽量专职一件事
+    // todo：细化功能颗粒度，一个函数尽量专职一件事
     /*
      *根据选中内容、配置项、选中项类型匹配合适的菜单项
      *是否action支持的协议
      *是否action支持的后缀
      *action不支持类型过滤（不加上父类型过滤，todo: 为何不支持项不考虑?）
      *action支持类型过滤(类型过滤要加上父类型一起过滤)
-    */
+     */
 
     //具体配置过滤
     for (auto &singleUrl : selects) {
@@ -228,7 +228,7 @@ QList<DCustomActionEntry> DCustomActionBuilder::matchActions(const QList<QUrl> &
          * fileMimeTypesNoParent:不包含父类mimetype的集合
          * 目的是在一些应用对文件的识别支持上有差异：比如xlsx的 parentMimeTypes 是application/zip
          * 归档管理器打开则会被作为解压
-        */
+         */
 
         QStringList fileMimeTypes;
         QStringList fileMimeTypesNoParent;
@@ -338,7 +338,7 @@ QPair<QString, QStringList> DCustomActionBuilder::makeCommand(const QString &cmd
         return rets;
     };
 
-    //url转为文件路径
+    // url转为文件路径
     auto urlListToLocalFile = [](const QList<QUrl> &files) {
         QStringList rets;
         for (auto it = files.begin(); it != files.end(); ++it) {
@@ -347,7 +347,7 @@ QPair<QString, QStringList> DCustomActionBuilder::makeCommand(const QString &cmd
         return rets;
     };
 
-    //url字符串
+    // url字符串
     auto urlListToString = [](const QList<QUrl> &files) {
         QStringList rets;
         for (auto it = files.begin(); it != files.end(); ++it) {
@@ -515,14 +515,16 @@ void DCustomActionBuilder::appendParentMimeType(const QStringList &parentmimeTyp
 */
 QAction *DCustomActionBuilder::createMenu(const DCustomActionData &actionData, QWidget *parentForSubmenu) const
 {
-    //fix-bug 59298
-    //createAction 构造action 图标等, 把关于构造action参数放在createAction中
+    // fix-bug 59298
+    // createAction 构造action 图标等, 把关于构造action参数放在createAction中
     QAction *action = createAciton(actionData);
     QMenu *menu = new QMenu(parentForSubmenu);
     menu->setToolTipsVisible(true);
 
     action->setMenu(menu);
     action->setProperty(DCustomActionDefines::kCustomActionFlag, true);
+    if (!actionData.actionParentPath.isEmpty())
+        action->setProperty(DCustomActionDefines::kConfParentMenuPath, actionData.actionParentPath);
 
     //子项,子项的顺序由解析器保证
     QList<DCustomActionData> subActions = actionData.acitons();
@@ -567,6 +569,9 @@ QAction *DCustomActionBuilder::createAciton(const DCustomActionData &actionData)
     QAction *action = new QAction;
     action->setProperty(DCustomActionDefines::kCustomActionFlag, true);
 
+    if (!actionData.actionParentPath.isEmpty())
+        action->setProperty(DCustomActionDefines::kConfParentMenuPath, actionData.actionParentPath);
+
     //执行动作
     action->setProperty(DCustomActionDefines::kCustomActionCommand, actionData.command());
     action->setProperty(DCustomActionDefines::kCustomActionCommandArgFlag, actionData.commandArg());
@@ -574,13 +579,13 @@ QAction *DCustomActionBuilder::createAciton(const DCustomActionData &actionData)
     //标题
     {
         const QString &&name = makeName(actionData.name(), actionData.nameArg());
-        //TODO width是临时值，最终效果需设计定义
+        // TODO width是临时值，最终效果需设计定义
         const QString &&elidedName = fontMetriecs.elidedText(name, Qt::ElideMiddle, 150);
         action->setText(elidedName);
         if (elidedName != name)
             action->setToolTip(name);
     }
-//story#4481,产品变更暂不考虑图标
+// story#4481,产品变更暂不考虑图标
 #if 0
     //图标
     const QString &iconName = actionData.icon();

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactiondata.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactiondata.cpp
@@ -7,12 +7,24 @@
 using namespace dfmplugin_menu;
 
 DCustomActionData::DCustomActionData()
-    : actionPosition(0), actionNameArg(DCustomActionDefines::kNoneArg), actionCmdArg(DCustomActionDefines::kNoneArg), actionSeparator(DCustomActionDefines::kNone)
+    : actionPosition(0),
+      actionNameArg(DCustomActionDefines::kNoneArg),
+      actionCmdArg(DCustomActionDefines::kNoneArg),
+      actionSeparator(DCustomActionDefines::kNone)
 {
 }
 
 DCustomActionData::DCustomActionData(const DCustomActionData &other)
-    : comboPos(other.comboPos), actionPosition(other.actionPosition), actionNameArg(other.actionNameArg), actionCmdArg(other.actionCmdArg), actionName(other.actionName), actionIcon(other.actionIcon), actionCommand(other.actionCommand), actionSeparator(other.actionSeparator), childrenActions(other.childrenActions)
+    : comboPos(other.comboPos),
+      actionPosition(other.actionPosition),
+      actionNameArg(other.actionNameArg),
+      actionCmdArg(other.actionCmdArg),
+      actionName(other.actionName),
+      actionIcon(other.actionIcon),
+      actionCommand(other.actionCommand),
+      actionSeparator(other.actionSeparator),
+      childrenActions(other.childrenActions),
+      actionParentPath(other.actionParentPath)
 {
 }
 
@@ -29,6 +41,7 @@ DCustomActionData &DCustomActionData::operator=(const DCustomActionData &other)
     actionIcon = other.actionIcon;
     actionCommand = other.actionCommand;
     childrenActions = other.childrenActions;
+    actionParentPath = other.actionParentPath;
     return *this;
 }
 
@@ -69,6 +82,11 @@ QString DCustomActionData::icon() const
 QString DCustomActionData::command() const
 {
     return actionCommand;
+}
+
+QString DCustomActionData::parentPath() const
+{
+    return actionParentPath;
 }
 
 DCustomActionDefines::Separator DCustomActionData::separator() const

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactiondata.h
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactiondata.h
@@ -28,6 +28,7 @@ public:
     int position() const;
     QString icon() const;
     QString command() const;
+    QString parentPath() const;
     DCustomActionDefines::Separator separator() const;
     QList<DCustomActionData> acitons() const;
     DCustomActionDefines::ActionArg nameArg() const;
@@ -45,6 +46,7 @@ protected:
     QString actionCommand;   //菜单执行动作
     DCustomActionDefines::Separator actionSeparator;
     QList<DCustomActionData> childrenActions;   //当前action的子actions
+    QString actionParentPath;
 };
 
 //根项

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactiondefine.h
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactiondefine.h
@@ -124,6 +124,7 @@ static const char *const kConfNotShowIn("X-DDE-FileManager-NotShowIn");   // "De
 static const char *const kConfNotShowInAlias("X-DFM-NotShowIn");
 static const char *const kConfSupportSuffix("X-DDE-FileManager-SupportSuffix");   // for deepin-compress *.7z.001,*.7z.002,*.7z.003...
 static const char *const kConfSupportSuffixAlias("X-DFM-SupportSuffix");
+static const char *const kConfParentMenuPath("X-DFM-ParentMenuPath");
 static const char *const kConfSign("Sign");
 
 //菜单基本信息

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionparser.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionparser.cpp
@@ -140,7 +140,7 @@ QList<DCustomActionEntry> DCustomActionParser::getActionFiles(bool onDesktop)
 {
     QList<DCustomActionEntry> ret;
     foreach (const DCustomActionEntry &entry, actionEntry) {
-        //NotShowIn
+        // NotShowIn
         if (isActionShouldShow(entry.actionNotShowIn, onDesktop))
             ret << entry;   //一级菜单不在桌面/文管显示则跳过该项
     }
@@ -181,7 +181,7 @@ bool DCustomActionParser::parseFile(QSettings &actionSetting)
         QString targetGroup = QString("%1 %2").arg(kActionPrefix).arg(once);
         hierarchyNum = 1;
         bool isVisible = parseFile(childrenActions, actionSetting, targetGroup, basicInfos, needSort, true);
-        //bug-59348 解决解析失败 count++ 导致不能显示50个有效文件(一级菜单)
+        // bug-59348 解决解析失败 count++ 导致不能显示50个有效文件(一级菜单)
         if (isVisible) {
             topActionCount++;
         }
@@ -229,12 +229,12 @@ bool DCustomActionParser::parseFile(QList<DCustomActionData> &childrenActions, Q
     actData.actionName = name;
     actionNameDynamicArg(actData);
 
-    //story#4481,产品变更暂不考虑icon
+    // story#4481,产品变更暂不考虑icon
 #if 0
     //icon
     actData.m_icon = getValue(actionSetting, group, kActionIcon).toString();
 #endif
-    //pos
+    // pos
     actData.actionPosition = getValue(actionSetting, group, kActionPos).toInt();
     if (0 == actData.actionPosition)
         actData.actionPosition = getValue(actionSetting, group, kActionPosAlias).toInt();
@@ -242,15 +242,18 @@ bool DCustomActionParser::parseFile(QList<DCustomActionData> &childrenActions, Q
     if (0 == actData.actionPosition && isSort)   //未定义pos行为当前层级以上级指定顺序
         isSort = false;
 
-    //separator
+    // separator
     QString separator = getValue(actionSetting, group, kActionSeparator).toString().simplified();
     if (separator.isEmpty())
         separator = getValue(actionSetting, group, kActionSeparatorAlias).toString().simplified();
     actData.actionSeparator = separtor.value(separator, kNone);
 
-    //actions 父子action级联与动作
+    QString parentMenuPath = getValue(actionSetting, group, kConfParentMenuPath).toString();
+    actData.actionParentPath = parentMenuPath;
 
-    //actions 父级级联与动作
+    // actions 父子action级联与动作
+
+    // actions 父级级联与动作
     QString actions = getValue(actionSetting, group, kActionGroups).toString().simplified();
     if (actions.isEmpty()) {
         //无级联检查是否有动作
@@ -260,7 +263,7 @@ bool DCustomActionParser::parseFile(QList<DCustomActionData> &childrenActions, Q
         actData.actionCommand = command;
         execDynamicArg(actData);
     } else {
-        //add 子菜单项，父级有子菜单，则忽略动作，即便子菜单无一有效，后续也不再添加动作
+        // add 子菜单项，父级有子菜单，则忽略动作，即便子菜单无一有效，后续也不再添加动作
         QList<DCustomActionData> tpChildrenActions;
         auto actStr = getValue(actionSetting, group, kActionGroups);
 #if (QT_VERSION <= QT_VERSION_CHECK(5, 15, 0))
@@ -318,40 +321,40 @@ bool DCustomActionParser::parseFile(QList<DCustomActionData> &childrenActions, Q
             tpEntry.actionFileCombo = target;
         }
 
-        //MimeType
+        // MimeType
         QString mimeTypeStr = getValue(actionSetting, group, kConfMimeType).toString().simplified();
         if (!mimeTypeStr.isEmpty())
             tpEntry.actionMimeTypes = mimeTypeStr.split(":");
 
-        //X-DFM-ExcludeMimeTypes
+        // X-DFM-ExcludeMimeTypes
         QString excludeMimeTypesStr = getValue(actionSetting, group, kConfExcludeMimeTypes).toString().simplified();
         if (excludeMimeTypesStr.isEmpty())
             excludeMimeTypesStr = getValue(actionSetting, group, kConfExcludeMimeTypesAlias).toString().simplified();
         if (!excludeMimeTypesStr.isEmpty())
             tpEntry.actionExcludeMimeTypes = excludeMimeTypesStr.split(":");
 
-        //X-DFM-SupportSchemes
+        // X-DFM-SupportSchemes
         QString supportSchemesStr = getValue(actionSetting, group, kConfSupportSchemes).toString().simplified();
         if (supportSchemesStr.isEmpty())
             supportSchemesStr = getValue(actionSetting, group, kConfSupportSchemesAlias).toString().simplified();
         if (!supportSchemesStr.isEmpty())
             tpEntry.actionSupportSchemes = supportSchemesStr.split(":");
 
-        //X-DFM-NotShowIn
+        // X-DFM-NotShowIn
         QString supportNotShowInStr = getValue(actionSetting, group, kConfNotShowIn).toString().simplified();
         if (supportNotShowInStr.isEmpty())
             supportNotShowInStr = getValue(actionSetting, group, kConfNotShowInAlias).toString().simplified();
         if (!supportNotShowInStr.isEmpty())
             tpEntry.actionNotShowIn = supportNotShowInStr.split(":");
 
-        //X-DFM-SupportSuffix
+        // X-DFM-SupportSuffix
         QString supportSuffixStr = getValue(actionSetting, group, kConfSupportSuffix).toString().simplified();
         if (supportSuffixStr.isEmpty())
             supportSuffixStr = getValue(actionSetting, group, kConfSupportSuffixAlias).toString().simplified();
         if (!supportSuffixStr.isEmpty())
             tpEntry.actionSupportSuffix = supportSuffixStr.split(":");
 
-        //comboPos
+        // comboPos
         if (!comboPosForTopAction(actionSetting, group, actData))
             return false;   //有一级菜单项支持的类型，但全无效，自动作为无效废弃项
 
@@ -404,12 +407,12 @@ void DCustomActionParser::initHash()
     separtor.insert("Both", Separator::kBoth);
     separtor.insert("Bottom", Separator::kBottom);
 
-    //name参数类型仅支持：DirName BaseName FileName
+    // name参数类型仅支持：DirName BaseName FileName
     actionNameArg.insert(kStrActionArg[kDirName], ActionArg::kDirName);   //%d
     actionNameArg.insert(kStrActionArg[kBaseName], ActionArg::kBaseName);   //%b
     actionNameArg.insert(kStrActionArg[kFileName], ActionArg::kFileName);   //"%a",
 
-    //cmd参数类型只支持：DirPath FilePath FilePaths UrlPath UrlPaths
+    // cmd参数类型只支持：DirPath FilePath FilePaths UrlPath UrlPaths
     actionExecArg.insert(kStrActionArg[kDirPath], ActionArg::kDirPath);   //"%p"
     actionExecArg.insert(kStrActionArg[kFilePath], ActionArg::kFilePath);   //"%f"
     actionExecArg.insert(kStrActionArg[kFilePaths], ActionArg::kFilePaths);   //"%F"
@@ -456,7 +459,7 @@ bool DCustomActionParser::actionFileInfos(FileBasicInfos &basicInfo, QSettings &
 */
 void DCustomActionParser::actionNameDynamicArg(DCustomActionData &act)
 {
-    //name参数类型仅支持：DirName BaseName FileName
+    // name参数类型仅支持：DirName BaseName FileName
     int firstValidIndex = act.actionName.indexOf("%");
     auto cnt = act.actionName.length() - 1;
     if (0 == cnt || 0 > firstValidIndex) {
@@ -482,7 +485,7 @@ void DCustomActionParser::actionNameDynamicArg(DCustomActionData &act)
 */
 void DCustomActionParser::execDynamicArg(DCustomActionData &act)
 {
-    //cmd参数类型只支持：DirPath FilePath FilePaths UrlPath UrlPaths
+    // cmd参数类型只支持：DirPath FilePath FilePaths UrlPath UrlPaths
     int firstValidIndex = act.actionCommand.indexOf("%");
     auto cnt = act.actionCommand.length() - 1;
     if (0 == cnt || 0 > firstValidIndex) {

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/private/extendmenuscene_p.h
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/private/extendmenuscene_p.h
@@ -19,6 +19,9 @@ public:
     explicit ExtendMenuScenePrivate(ExtendMenuScene *qq);
     QList<QAction *> childActions(QAction *action);
     int mayComboPostion(const DCustomActionData &acdata, DCustomActionDefines::ComboType combo);
+    void getSubMenus(QMenu *currMenu, const QString &parentMenuName, QMap<QString, QMenu *> &subMenus);
+    bool insertIntoExistedMenu(QAction *act, const QMap<QString, QMenu *> &menus);
+
 public:
     DCustomActionParser *customParser = nullptr;
     QList<QAction *> extendActions;


### PR DESCRIPTION
as title.
a new filed is added to support this feature: [X-DFM-ParentMenuPath]
and the value be like [Top-Action-ID/Sub-Action-ID], the existed menu
must be actionID-ed

Log: now conf menu can be inserted into existed named menus.

Task: https://pms.uniontech.com/task-view-292837.html
