### PR TITLE
fix: [workspace]save file in qtcreator issue

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -178,26 +178,7 @@ void RootInfo::dofileMoved(const QUrl &fromUrl, const QUrl &toUrl)
     if (info)
         info->refresh();
 
-    if (!containsChild(toUrl)) {
-        {
-            // Before the file moved signal is received, `toUrl` may be filtered if it received a created signal
-            QMutexLocker lk(&watcherEventMutex);
-            auto iter = std::find_if(watcherEvent.cbegin(), watcherEvent.cend(), [&](const QPair<QUrl, EventType> &event) {
-                return (UniversalUtils::urlEquals(toUrl, event.first) && event.second == kAddFile);
-            });
-            if (iter != watcherEvent.cend())
-                watcherEvent.removeOne(*iter);
-        }
-        dofileCreated(toUrl);
-    } else {
-        // if watcherEvent exist toUrl rmevent,cancel this rmevent, beacuse if watcherEvent has toUrl rmevent will bypass this check
-        QMutexLocker lk(&watcherEventMutex);
-        auto iter = std::find_if(watcherEvent.cbegin(), watcherEvent.cend(), [&](const QPair<QUrl, EventType> &event) {
-            return (UniversalUtils::urlEquals(toUrl, event.first) && event.second == kRmFile);
-        });
-        if (iter != watcherEvent.cend())
-            watcherEvent.removeOne(*iter);
-    }
+    dofileCreated(toUrl);
 
     // TODO(lanxs) TODO(xust) .hidden file's attribute changed signal not emitted in removable disks (vfat/exfat).
     // but renamed from a .goutputstream_xxx file


### PR DESCRIPTION
there is no necessary to filter watcher event when receive a file move event.

Log: fix file disappear issue
Bug: https://pms.uniontech.com/bug-view-213595.html