### PR TITLE
fix: [io]Copying a file to a USB flash drive, the file occasionally flickers

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -228,7 +228,7 @@ public:
                 auto info = qSharedPointerDynamicCast<T>(instance().SchemeFactory<FileInfo>::
                                                                  create(Global::Scheme::kAsyncFile, url, errorString));
                 if (info)
-                    info->refresh();
+                    info->updateAttributes();
                 return info;
             }
         }

--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -222,6 +222,131 @@ public:
         kCustomType = 0x100,
     };
 
+    enum class FileInfoAttributeID : uint16_t {
+
+        kStandardType = 0,   // uint32
+        kStandardIsHidden = 1,   // boolean
+        kStandardIsBackup = 2,   // boolean
+        kStandardIsSymlink = 3,   // boolean
+        kStandardIsVirtual = 4,   // boolean
+        kStandardIsVolatile = 5,   // boolean
+        kStandardName = 6,   // byte string
+        kStandardDisplayName = 7,   // string
+        kStandardEditName = 8,   // string
+        kStandardCopyName = 9,   // string
+        kStandardIcon = 10,   // QList<QString>
+        kStandardSymbolicIcon = 11,   // QList<QString>
+        kStandardContentType = 12,   // string
+        kStandardFastContentType = 13,   // string
+        kStandardSize = 14,   // uint64
+        kStandardAllocatedSize = 15,   // uint64
+        kStandardSymlinkTarget = 16,   // byte string
+        kStandardTargetUri = 17,   // string
+        kStandardSortOrder = 18,   // int32
+        kStandardDescription = 19,   // string
+        kStandardFileExists = 20,   // bool
+        kStandardIsLocalDevice = 21,   // bool
+        kStandardIsCdRomDevice = 22,   // bool
+        kStandardFileType = 22,   // FileInfo::FileType
+
+        kEtagValue = 40,   // string
+
+        kIdFile = 60,   // string
+        kIdFilesystem = 61,   // string
+
+        kAccessCanRead = 100,   // boolean
+        kAccessCanWrite = 101,   // boolean
+        kAccessCanExecute = 102,   // boolean
+        kAccessCanDelete = 103,   // boolean
+        kAccessCanTrash = 104,   // boolean
+        kAccessCanRename = 105,   // boolean
+        kAccessPermissions = 106,   // DFile::Permissions
+
+        kMountableCanMount = 130,   // boolean
+        kMountableCanUnmount = 131,   // boolean
+        kMountableCanEject = 132,   // boolean
+        kMountableUnixDevice = 133,   // uint32
+        kMountableUnixDeviceFile = 134,   // string
+        kMountableHalUdi = 135,   // string
+        kMountableCanPoll = 136,   // boolean
+        kMountableIsMediaCheckAutomatic = 137,   // boolean
+        kMountableCanStart = 138,   // boolean
+        kMountableCanStartDegraded = 139,   // boolean
+        kMountableCanStop = 140,   // boolean
+        kMountableStartStopType = 141,   // uint32
+
+        kTimeModified = 200,   // uint64
+        kTimeModifiedUsec = 201,   // uint32
+        kTimeAccess = 202,   // uint64
+        kTimeAccessUsec = 203,   // uint32
+        kTimeChanged = 204,   // uint64
+        kTimeChangedUsec = 205,   // uint32
+        kTimeCreated = 206,   // uint64
+        kTimeCreatedUsec = 207,   // uint32
+
+        kUnixDevice = 330,   // uint32
+        kUnixInode = 331,   // uint64
+        kUnixMode = 332,   // uint32
+        kUnixNlink = 333,   // uint32
+        kUnixUID = 334,   // uint32
+        kUnixGID = 335,   // uint32
+        kUnixRdev = 336,   // uint32
+        kUnixBlockSize = 337,   // uint32
+        kUnixBlocks = 338,   // uint64
+        kUnixIsMountPoint = 339,   // boolean
+
+        kDosIsArchive = 360,   // boolean
+        kDosIsSystem = 361,   // boolean
+
+        kOwnerUser = 300,   // string
+        kOwnerUserReal = 301,   // string
+        kOwnerGroup = 302,   // string
+
+        kThumbnailPath = 390,   // byte string
+        kThumbnailFailed = 391,   // boolean
+        kThumbnailIsValid = 392,   // boolean
+        kThumbnailIcon = 393,   // QIcon
+
+        kPreviewIcon = 420,   // object
+
+        kFileSystemSize = 440,   // uint64
+        kFileSystemFree = 441,   // uint64
+        kFileSystemUsed = 442,   // uint64
+        kFileSystemType = 443,   // string
+        kFileSystemReadOnly = 444,   // boolean
+        kFileSystemUsePreview = 445,   // uint32
+        kFileSystemRemote = 446,   // boolean
+
+        kGvfsBackend = 470,   // string
+
+        kSelinuxContext = 490,   // string
+
+        kTrashItemCount = 510,   // uint32
+        kTrashDeletionDate = 511,   // string
+        kTrashOrigPath = 512,   // byte string
+
+        kRecentModified = 540,   // int64
+
+        kCustomStart = 600,
+
+        kStandardIsFile = 610,
+        kStandardIsDir = 611,
+        kStandardIsRoot = 612,
+        kStandardSuffix = 613,
+        kStandardCompleteSuffix = 614,
+        kStandardFilePath = 615,
+        kStandardParentPath = 616,
+        kStandardBaseName = 617,
+        kStandardFileName = 618,
+        kStandardCompleteBaseName = 619,
+
+        kFileMimeType = 620,
+        kFileCount = 621,
+        kFileMediaInfo = 621,
+
+        kAttributeIDMax = 999,
+    };
+
     using initQuerierAsyncCallback = std::function<void(bool, void *)>;
 
 public:
@@ -261,6 +386,8 @@ public:
     virtual QVariant customAttribute(const char *key, const DFMIO::DFileInfo::DFileAttributeType type);
     virtual QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(DFMIO::DFileInfo::MediaType type, QList<DFMIO::DFileInfo::AttributeExtendID> ids) const;
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value);
+    // 只是对相应的属性进行更新，不是清空，refresh是清空所有属性再去获取，默认是更新所有文件属性
+    virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {});
 
 protected:
     explicit FileInfo(const QUrl &url);

--- a/include/dfm-base/interfaces/proxyfileinfo.h
+++ b/include/dfm-base/interfaces/proxyfileinfo.h
@@ -82,6 +82,7 @@ public:
     virtual QVariant customAttribute(const char *key, const dfmio::DFileInfo::DFileAttributeType type) override;
     virtual QMap<dfmio::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(dfmio::DFileInfo::MediaType type, QList<dfmio::DFileInfo::AttributeExtendID> ids) const override;
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
+    virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {}) override;
 };
 }
 #endif   // PROXYFILEINFO_H

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -19,127 +19,6 @@ class AsyncFileInfo : public FileInfo
     QSharedPointer<AsyncFileInfoPrivate> d { nullptr };
 
 public:
-    enum class AsyncAttributeID : uint16_t {
-
-        kStandardType = 0,   // uint32
-        kStandardIsHidden = 1,   // boolean
-        kStandardIsBackup = 2,   // boolean
-        kStandardIsSymlink = 3,   // boolean
-        kStandardIsVirtual = 4,   // boolean
-        kStandardIsVolatile = 5,   // boolean
-        kStandardName = 6,   // byte string
-        kStandardDisplayName = 7,   // string
-        kStandardEditName = 8,   // string
-        kStandardCopyName = 9,   // string
-        kStandardIcon = 10,   // QList<QString>
-        kStandardSymbolicIcon = 11,   // QList<QString>
-        kStandardContentType = 12,   // string
-        kStandardFastContentType = 13,   // string
-        kStandardSize = 14,   // uint64
-        kStandardAllocatedSize = 15,   // uint64
-        kStandardSymlinkTarget = 16,   // byte string
-        kStandardTargetUri = 17,   // string
-        kStandardSortOrder = 18,   // int32
-        kStandardDescription = 19,   // string
-        kStandardFileExists = 20,   // bool
-        kStandardIsLocalDevice = 21,   // bool
-        kStandardIsCdRomDevice = 22,   // bool
-        kStandardFileType = 22,   // FileInfo::FileType
-
-        kEtagValue = 40,   // string
-
-        kIdFile = 60,   // string
-        kIdFilesystem = 61,   // string
-
-        kAccessCanRead = 100,   // boolean
-        kAccessCanWrite = 101,   // boolean
-        kAccessCanExecute = 102,   // boolean
-        kAccessCanDelete = 103,   // boolean
-        kAccessCanTrash = 104,   // boolean
-        kAccessCanRename = 105,   // boolean
-        kAccessPermissions = 106,   // DFile::Permissions
-
-        kMountableCanMount = 130,   // boolean
-        kMountableCanUnmount = 131,   // boolean
-        kMountableCanEject = 132,   // boolean
-        kMountableUnixDevice = 133,   // uint32
-        kMountableUnixDeviceFile = 134,   // string
-        kMountableHalUdi = 135,   // string
-        kMountableCanPoll = 136,   // boolean
-        kMountableIsMediaCheckAutomatic = 137,   // boolean
-        kMountableCanStart = 138,   // boolean
-        kMountableCanStartDegraded = 139,   // boolean
-        kMountableCanStop = 140,   // boolean
-        kMountableStartStopType = 141,   // uint32
-
-        kTimeModified = 200,   // uint64
-        kTimeModifiedUsec = 201,   // uint32
-        kTimeAccess = 202,   // uint64
-        kTimeAccessUsec = 203,   // uint32
-        kTimeChanged = 204,   // uint64
-        kTimeChangedUsec = 205,   // uint32
-        kTimeCreated = 206,   // uint64
-        kTimeCreatedUsec = 207,   // uint32
-
-        kUnixDevice = 330,   // uint32
-        kUnixInode = 331,   // uint64
-        kUnixMode = 332,   // uint32
-        kUnixNlink = 333,   // uint32
-        kUnixUID = 334,   // uint32
-        kUnixGID = 335,   // uint32
-        kUnixRdev = 336,   // uint32
-        kUnixBlockSize = 337,   // uint32
-        kUnixBlocks = 338,   // uint64
-        kUnixIsMountPoint = 339,   // boolean
-
-        kDosIsArchive = 360,   // boolean
-        kDosIsSystem = 361,   // boolean
-
-        kOwnerUser = 300,   // string
-        kOwnerUserReal = 301,   // string
-        kOwnerGroup = 302,   // string
-
-        kThumbnailPath = 390,   // byte string
-        kThumbnailFailed = 391,   // boolean
-        kThumbnailIsValid = 392,   // boolean
-
-        kPreviewIcon = 420,   // object
-
-        kFileSystemSize = 440,   // uint64
-        kFileSystemFree = 441,   // uint64
-        kFileSystemUsed = 442,   // uint64
-        kFileSystemType = 443,   // string
-        kFileSystemReadOnly = 444,   // boolean
-        kFileSystemUsePreview = 445,   // uint32
-        kFileSystemRemote = 446,   // boolean
-
-        kGvfsBackend = 470,   // string
-
-        kSelinuxContext = 490,   // string
-
-        kTrashItemCount = 510,   // uint32
-        kTrashDeletionDate = 511,   // string
-        kTrashOrigPath = 512,   // byte string
-
-        kRecentModified = 540,   // int64
-
-        kCustomStart = 600,
-
-        kStandardIsFile = 610,
-        kStandardIsDir = 611,
-        kStandardIsRoot = 612,
-        kStandardSuffix = 613,
-        kStandardCompleteSuffix = 614,
-        kStandardFilePath = 615,
-        kStandardParentPath = 616,
-        kStandardBaseName = 617,
-        kStandardFileName = 618,
-        kStandardCompleteBaseName = 619,
-
-        kAttributeIDMax = 999,
-    };
-
-public:
     enum FlagIcon {
         kWritable,   // 是否可写
         kSymLink,   // 是否是链接文件
@@ -179,6 +58,7 @@ public:
     virtual QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(DFMIO::DFileInfo::MediaType type, QList<DFMIO::DFileInfo::AttributeExtendID> ids) const override;
     // cache attribute
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
+    virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {}) override;
     QMultiMap<QUrl, QString> notifyUrls() const;
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
     void removeNotifyUrl(const QUrl &url, const QString &infoPtr);

--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -224,6 +224,12 @@ Qt::DropActions DesktopFileInfo::supportedOfAttributes(const SupportType type) c
     return ProxyFileInfo::supportedOfAttributes(type);
 }
 
+void DesktopFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &types)
+{
+    ProxyFileInfo::updateAttributes(types);
+    d->updateInfo(urlOf(UrlInfoType::kUrl));
+}
+
 bool DesktopFileInfo::canTag() const
 {
     if (d->deepinID == "dde-trash" || d->deepinID == "dde-computer")

--- a/src/dfm-base/file/local/desktopfileinfo.h
+++ b/src/dfm-base/file/local/desktopfileinfo.h
@@ -35,6 +35,7 @@ public:
     //QSet<MenuAction> disableMenuActionList() const override;
     virtual Qt::DropActions supportedOfAttributes(const SupportType type) const override;
     virtual bool canAttributes(const FileCanType type) const override;
+    virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {}) override;
     static QMap<QString, QVariant> desktopFileInfo(const QUrl &fileUrl);
 
 private:

--- a/src/dfm-base/file/local/private/syncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/syncfileinfo_p.h
@@ -31,6 +31,7 @@ class SyncFileInfoPrivate
 public:
     SyncFileInfo *const q;
     FileInfo::FileType fileType { FileInfo::FileType::kUnknown };   // 缓存文件的FileType
+    DFileInfo::MediaType mediaType { DFileInfo::MediaType::kGeneral};
     DMimeDatabase mimeDb;
     QMimeDatabase::MatchMode mimeTypeMode;
     QSharedPointer<DFileInfo> dfmFileInfo { nullptr };   // dfm文件的信息
@@ -45,7 +46,6 @@ public:
     QVariant isLocalDevice;
     QVariant isCdRomDevice;
     QSharedPointer<InfoDataFuture> mediaFuture { nullptr };
-    InfoHelperUeserDataPointer fileCountFuture { nullptr };
     InfoHelperUeserDataPointer fileMimeTypeFuture { nullptr };
     QMap<DFMIO::DFileInfo::AttributeID, QVariant> cacheAttributes;
 
@@ -95,6 +95,9 @@ public:
     void init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo> dfileInfo = nullptr);
     QMimeType mimeTypes(const QString &filePath, QMimeDatabase::MatchMode mode = QMimeDatabase::MatchDefault,
                         const QString &inod = QString(), const bool isGvfs = false);
+    FileInfo::FileType updateFileType();
+    QIcon updateIcon();
+    void updateMediaInfo(const DFileInfo::MediaType type, const QList<DFileInfo::AttributeExtendID> &ids);
 };
 }
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::SyncFileInfoPrivate *)

--- a/src/dfm-base/file/local/syncfileinfo.h
+++ b/src/dfm-base/file/local/syncfileinfo.h
@@ -61,6 +61,7 @@ public:
     virtual QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfoAttributes(DFMIO::DFileInfo::MediaType type, QList<DFMIO::DFileInfo::AttributeExtendID> ids) const override;
     // cache attribute
     virtual void setExtendedAttributes(const FileExtendedInfoType &key, const QVariant &value) override;
+    virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {}) override;
 };
 }
 typedef QSharedPointer<DFMBASE_NAMESPACE::SyncFileInfo> DFMSyncFileInfoPointer;

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -456,6 +456,11 @@ QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> DFMBASE_NAMESPACE::FileInfo:
     return QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant>();
 }
 
+void dfmbase::FileInfo::updateAttributes(const QList<dfmbase::FileInfo::FileInfoAttributeID> &types)
+{
+    Q_UNUSED(types);
+}
+
 /*!
   * \brief setExtendedAttributes 设置文件的扩展属性
   * \param ExInfo 扩展属性key \param QVariant 属性

--- a/src/dfm-base/interfaces/proxyfileinfo.cpp
+++ b/src/dfm-base/interfaces/proxyfileinfo.cpp
@@ -441,3 +441,10 @@ void dfmbase::ProxyFileInfo::setExtendedAttributes(const FileExtendedInfoType &k
 
     return FileInfo::setExtendedAttributes(key, value);
 }
+
+void ProxyFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &types)
+{
+    CALL_PROXY(updateAttributes(types));
+
+    return FileInfo::updateAttributes(types);
+}

--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -54,11 +54,15 @@ Q_SIGNALS:
 private Q_SLOTS:
     void aboutToQuit();
     void handleFileRefresh(QSharedPointer<FileInfo> dfileInfo);
+private:
+    void checkInfoRefresh(QSharedPointer<FileInfo> dfileInfo);
 
 private:
     QSharedPointer<QThread> thread { nullptr };
     QSharedPointer<FileInfoAsycWorker> worker { nullptr };
     std::atomic_bool stoped { false };
+    DThreadList<FileInfoPointer> qureingInfo;
+    DThreadList<FileInfoPointer> needQureingInfo;
     QThreadPool pool;
 };
 }

--- a/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
@@ -8,6 +8,7 @@
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
 
 #include <QGuiApplication>
@@ -61,9 +62,13 @@ void ThumbnailFactory::init()
 
 void ThumbnailFactory::joinThumbnailJob(const QUrl &url, ThumbnailSize size)
 {
+    if (FileUtils::containsCopyingFileUrl(url))
+        return;
     if (taskMap.isEmpty())
         taskPushTimer.start();
 
+    if (taskMap.contains(url))
+        return;
     taskMap.insert(url, size);
     if (taskMap.size() < kMaxCountLimit)
         return;

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
@@ -58,7 +58,7 @@ void FileInfoModelPrivate::resetData(const QList<QUrl> &urls)
         if (auto itemInfo = FileCreator->createFileInfo(child)) {
             if (itemInfo->isAttributes(OptInfoType::kIsSymLink) &&
                     !FileUtils::isLocalDevice(QUrl::fromLocalFile(itemInfo->pathOf(PathInfoType::kSymLinkTarget))))
-                itemInfo->refresh();
+                itemInfo->updateAttributes();
             fileUrls.append(itemInfo->urlOf(UrlInfoType::kUrl));
             fileMaps.insert(itemInfo->urlOf(UrlInfoType::kUrl), itemInfo);
         }
@@ -195,7 +195,7 @@ void FileInfoModelPrivate::updateData(const QUrl &url)
         // a redundant refresh is still required here, because the current variant of FileInfo
         // (like DesktopFileInfo created from DesktopFileCreator) is not in InfoCache and will not be refreshed automatically.
         if (auto info = fileMap.value(url))
-            info->refresh();
+            info->updateAttributes();
     }
 
     const QModelIndex &index = q->index(url);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -484,15 +484,16 @@ void FileSortWorker::handleWatcherUpdateFile(const SortInfoPointer child)
         return;
 
     FileInfoPointer info;
-    {
-        QReadLocker lk(&childrenDataLocker);
-        info = childrenDataMap.value(child->fileUrl())->fileInfo();
-    }
+
+    auto item = childData(child->fileUrl());
+    if (item.isNull())
+        return;
+    info = item->fileInfo();
 
     if (!info)
         return;
 
-    info->refresh();
+    info->updateAttributes();
 
     sortInfoUpdateByFileInfo(info);
 

--- a/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.cpp
@@ -101,5 +101,12 @@ QString ShareFileInfoPrivate::fileName() const
 
 void dfmplugin_myshares::ShareFileInfo::refresh()
 {
+    ProxyFileInfo::refresh();
+    d->refresh();
+}
+
+void ShareFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &types)
+{
+    ProxyFileInfo::updateAttributes(types);
     d->refresh();
 }

--- a/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.h
@@ -26,6 +26,7 @@ public:
     virtual bool isAttributes(const FileIsType type) const override;
     virtual bool canAttributes(const FileCanType type) const override;
     virtual void refresh() override;
+    virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {}) override;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.cpp
@@ -132,6 +132,17 @@ void MasteredMediaFileInfo::refresh()
     setProxy(InfoFactory::create<FileInfo>(d->backerUrl));
 }
 
+void MasteredMediaFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &types)
+{
+    ProxyFileInfo::updateAttributes(types);
+    if (proxy) {
+        return;
+    }
+
+    d->backupInfo(urlOf(UrlInfoType::kUrl));
+    setProxy(InfoFactory::create<FileInfo>(d->backerUrl));
+}
+
 bool MasteredMediaFileInfo::canAttributes(const CanableInfoType type) const
 {
     switch (type) {

--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.h
@@ -29,6 +29,7 @@ public:
     virtual bool canAttributes(const FileCanType type) const override;
     Qt::DropActions supportedOfAttributes(const SupportType type) const override;
     QString viewOfTip(const ViewType type = ViewType::kEmptyDir) const override;
+    virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {}) override;
 };
 
 }   // namepsace dfmplugin_optical


### PR DESCRIPTION
Calling customAttribute function during asynchronous file info query and refreshing under multithreading causes gfileinfo to destruct. Adjust the thumbnail generation restriction, no thumbnail generation when copying. Adjust asynchronous refresh scheduling in fileinfohelper. Update the same object before the next update.

Log: Copying a file to a USB flash drive, the file occasionally flickers
Bug: https://pms.uniontech.com/bug-view-222077.html https://pms.uniontech.com/bug-view-215169.html https://pms.uniontech.com/bug-view-211109.html