### PR TITLE
fix: [io]Select different disks successively to right-click on them to view the properties, and open the second properties window to stop the file statistics.

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.h
+++ b/src/dfm-base/utils/filestatisticsjob.h
@@ -83,7 +83,6 @@ private:
 private:
     void setSizeInfo();
     void statistcsOtherFileSystem();
-    void statistcsByFts();
 };
 
 }

--- a/src/dfm-base/utils/private/filestatissticsjob_p.h
+++ b/src/dfm-base/utils/private/filestatissticsjob_p.h
@@ -25,16 +25,10 @@ public:
     bool stateCheck();
 
     void processFile(const QUrl &url, const bool followLink, QQueue<QUrl> &directoryQueue);
-    void processFileByFts(const QUrl &url, const bool followLink);
     void emitSizeChanged();
     int countFileCount(const char *name);
     bool checkFileType(const FileInfo::FileType &fileType);
-    FileInfo::FileType getFileType(const uint mode);
-    void statisticDir(const QUrl &url, FTS *fts, const bool singleDepth, FTSENT *ent);
-    void statisticFile(FTSENT *ent);
-    void statisticSysLink(const QUrl &currentUrl, FTS *fts, FTSENT *ent, const bool singleDepth, const bool followLink);
     bool checkInode(const FileInfoPointer info);
-    bool checkInode(FTSENT *ent, FTS *fts);
 
     FileStatisticsJob *q;
     QTimer *notifyDataTimer;


### PR DESCRIPTION
When fts counts files, multiple threads count at the same time and fts quits. Delete fts statistics.

Log: Select different disks successively to right-click on them to view the properties, and open the second properties window to stop the file statistics.
Bug: https://pms.uniontech.com/bug-view-224111.html