### PR TITLE
feat: Network Neighborhood feature blocking

### DIFF
--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -486,7 +486,12 @@ void UniversalUtils::prepareForSleep(QObject *obj, const char *cslot)
             "org.freedesktop.login1.Manager",
             "PrepareForSleep",
             obj,
-            cslot);
+                cslot);
+}
+
+bool UniversalUtils::isNetworkRoot(const QUrl &url)
+{
+    return urlEquals(url, QUrl("network:///"));
 }
 
 }

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -46,6 +46,7 @@ public:
     static void userChange(QObject *obj, const char *cslot = nullptr);
 
     static void prepareForSleep(QObject *obj, const char *cslot = nullptr);
+    static bool isNetworkRoot(const QUrl &url);
 };
 
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations.cpp
@@ -22,6 +22,7 @@ DPFILEOPERATIONS_USE_NAMESPACE
 void FileOperations::initialize()
 {
     initEventHandle();
+    followEvents();
 }
 
 bool FileOperations::start()
@@ -279,4 +280,14 @@ void FileOperations::initEventHandle()
                                                                                      const QList<QUrl>,
                                                                                      const QVariant,
                                                                                      AbstractJobHandler::OperatorCallback)>(&FileOperationsEventReceiver::handleOperationHideFiles));
+}
+
+void FileOperations::followEvents()
+{
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_DeleteFiles",
+                            FileOperationsEventReceiver::instance(), &FileOperationsEventReceiver::handleShortCut);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_MoveToTrash",
+                            FileOperationsEventReceiver::instance(), &FileOperationsEventReceiver::handleShortCut);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_PasteFiles",
+                            FileOperationsEventReceiver::instance(), &FileOperationsEventReceiver::handleShortCutPaste);
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations.h
@@ -47,6 +47,8 @@ public:
 
 private slots:
     void initEventHandle();
+private:
+    void followEvents();
 };
 
 DPFILEOPERATIONS_END_NAMESPACE

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -1181,4 +1181,31 @@ void FileOperationsEventReceiver::handleOperationHideFiles(const quint64 windowI
         callback(args);
     }
 }
+
+bool FileOperationsEventReceiver::handleShortCut(quint64, const QList<QUrl> &urls, const QUrl &rootUrl)
+{
+    if (urls.isEmpty())
+        return false;
+    const auto &currentFileInfo = InfoFactory::create<FileInfo>(rootUrl);
+    // v5功能 判断当前目录是否有写权限，没有就提示权限错误
+    if (urls.first().scheme() == Global::Scheme::kFile
+            && !currentFileInfo->isAttributes(OptInfoType::kIsWritable)) {
+        DialogManager::instance()->showNoPermissionDialog(urls);
+        return true;
+    }
+    return false;
+}
+
+bool FileOperationsEventReceiver::handleShortCutPaste(quint64, const QList<QUrl> &, const QUrl &target)
+{
+    if (target.scheme() == Global::Scheme::kFile) {
+        const auto &currentFileInfo = InfoFactory::create<FileInfo>(target);
+        if (currentFileInfo && currentFileInfo->isAttributes(OptInfoType::kIsDir) && !currentFileInfo->isAttributes(OptInfoType::kIsWritable)) {
+            // show error tip message
+            DialogManager::instance()->showNoPermissionDialog(QList<QUrl>() << target);
+            return true;
+        }
+    }
+    return false;
+}
 }   // namespace dfmplugin_fileoperations

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -183,6 +183,9 @@ public slots:
     void handleOperationHideFiles(const quint64 windowId, const QList<QUrl> urls,
                                   const QVariant custom, DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
 
+    bool handleShortCut(quint64, const QList<QUrl> &urls, const QUrl &rootUrl);
+    bool handleShortCutPaste(quint64, const QList<QUrl> &, const QUrl &target);
+
 private:
     enum class RenameTypes {
         kBatchRepalce,

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -86,10 +86,13 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_HOOK(hook_DragDrop_IsDrop)
     DPF_EVENT_REG_HOOK(hook_DragDrop_FileCanMove)
 
+    DPF_EVENT_REG_HOOK(hook_ShortCut_CopyFiles)
+    DPF_EVENT_REG_HOOK(hook_ShortCut_CutFiles)
     DPF_EVENT_REG_HOOK(hook_ShortCut_PasteFiles)
     DPF_EVENT_REG_HOOK(hook_ShortCut_DeleteFiles)
     DPF_EVENT_REG_HOOK(hook_ShortCut_MoveToTrash)
     DPF_EVENT_REG_HOOK(hook_ShortCut_EnterPressed)
+    DPF_EVENT_REG_HOOK(hook_ShortCut_PreViewFiles)
 
     DPF_EVENT_REG_HOOK(hook_Delegate_PaintListItem)
     DPF_EVENT_REG_HOOK(hook_Delegate_LayoutText)

--- a/src/plugins/filemanager/dfmplugin-myshares/events/shareeventhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/events/shareeventhelper.cpp
@@ -29,7 +29,7 @@ bool ShareEventHelper::blockPaste(quint64, const QList<QUrl> &fromUrls, const QU
     return false;
 }
 
-bool ShareEventHelper::blockDelete(quint64, const QList<QUrl> &urls)
+bool ShareEventHelper::blockDelete(quint64, const QList<QUrl> &urls, const QUrl &)
 {
     if (containsShareUrl(urls)) {
         qDebug() << "delete event is blocked, trying to delete usershare:///*";
@@ -38,7 +38,7 @@ bool ShareEventHelper::blockDelete(quint64, const QList<QUrl> &urls)
     return false;
 }
 
-bool ShareEventHelper::blockMoveToTrash(quint64, const QList<QUrl> &urls)
+bool ShareEventHelper::blockMoveToTrash(quint64, const QList<QUrl> &urls, const QUrl &)
 {
     if (containsShareUrl(urls)) {
         qDebug() << "move to trash event is blocked, trying to delete usershare:///*";

--- a/src/plugins/filemanager/dfmplugin-myshares/events/shareeventhelper.h
+++ b/src/plugins/filemanager/dfmplugin-myshares/events/shareeventhelper.h
@@ -18,8 +18,8 @@ class ShareEventHelper : public QObject
 public:
     static ShareEventHelper *instance();
     bool blockPaste(quint64 winId, const QList<QUrl> &fromUrls, const QUrl &to);
-    bool blockDelete(quint64 winId, const QList<QUrl> &urls);
-    bool blockMoveToTrash(quint64 winId, const QList<QUrl> &urls);
+    bool blockDelete(quint64 winId, const QList<QUrl> &urls, const QUrl &);
+    bool blockMoveToTrash(quint64 winId, const QList<QUrl> &urls, const QUrl&);
     bool hookSendOpenWindow(const QList<QUrl> &urls);
     bool hookSendChangeCurrentUrl(quint64 winId, const QUrl &url);
 

--- a/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.cpp
@@ -22,7 +22,7 @@ OpticalEventReceiver &OpticalEventReceiver::instance()
     return ins;
 }
 
-bool OpticalEventReceiver::handleDeleteFilesShortcut(quint64, const QList<QUrl> &urls)
+bool OpticalEventReceiver::handleDeleteFilesShortcut(quint64, const QList<QUrl> &urls, const QUrl &)
 {
     auto iter = std::find_if(urls.cbegin(), urls.cend(), [](const QUrl &url) {
         return OpticalHelper::burnIsOnDisc(url);

--- a/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-optical/events/opticaleventreceiver.h
@@ -20,7 +20,7 @@ public:
     static OpticalEventReceiver &instance();
 
 public slots:
-    bool handleDeleteFilesShortcut(quint64, const QList<QUrl> &urls);
+    bool handleDeleteFilesShortcut(quint64, const QList<QUrl> &urls, const QUrl &);
     bool handleCheckDragDropAction(const QList<QUrl> &urls, const QUrl &urlTo, Qt::DropAction *action);
     bool sepateTitlebarCrumb(const QUrl &url, QList<QVariantMap> *mapGroup);
     bool handleDropFiles(const QList<QUrl> &fromUrls, const QUrl &toUrl);

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
@@ -34,7 +34,7 @@ bool SmbBrowserEventReceiver::detailViewIcon(const QUrl &url, QString *iconName)
     return false;
 }
 
-bool SmbBrowserEventReceiver::cancelDelete(quint64, const QList<QUrl> &urls)
+bool SmbBrowserEventReceiver::cancelDelete(quint64, const QList<QUrl> &urls, const QUrl &rootUrl)
 {
     if (urls.first().scheme() != DFMBASE_NAMESPACE::Global::Scheme::kSmb
         && urls.first().scheme() != DFMBASE_NAMESPACE::Global::Scheme::kFtp
@@ -42,7 +42,22 @@ bool SmbBrowserEventReceiver::cancelDelete(quint64, const QList<QUrl> &urls)
         qDebug() << "SmbBrowser could't delete";
         return false;
     }
+    // Network Neighborhood dot not use
+    if (UniversalUtils::isNetworkRoot(rootUrl)) {
+        qDebug() << "Network Neighborhood view SmbBrowser could't delete";
+        return true;
+    }
     return true;
+}
+
+bool SmbBrowserEventReceiver::cancelMoveToTrash(quint64, const QList<QUrl> &, const QUrl &rootUrl)
+{
+    // Network Neighborhood dot not use
+    if (UniversalUtils::isNetworkRoot(rootUrl)) {
+        qDebug() << "Network Neighborhood view SmbBrowser could't using";
+        return true;
+    }
+    return false;
 }
 
 bool SmbBrowserEventReceiver::hookSetTabName(const QUrl &url, QString *tabName)

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.h
@@ -21,7 +21,8 @@ public:
 
 public Q_SLOTS:
     bool detailViewIcon(const QUrl &url, QString *iconName);
-    bool cancelDelete(quint64, const QList<QUrl> &urls);
+    bool cancelDelete(quint64, const QList<QUrl> &urls, const QUrl&rootUrl);
+    bool cancelMoveToTrash(quint64, const QList<QUrl> &, const QUrl&rootUrl);
 
     bool hookSetTabName(const QUrl &url, QString *tabName);
 

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp
@@ -53,7 +53,6 @@ bool SmbBrowserMenuScene::initialize(const QVariantHash &params)
         return false;
 
     d->url = d->selectFiles.first();
-
     auto subScenes = subscene();
     if (auto filterScene = dfmplugin_menu_util::menuSceneCreateScene("DConfigMenuFilter"))
         subScenes << filterScene;
@@ -93,8 +92,9 @@ void SmbBrowserMenuScene::updateState(QMenu *parent)
         return AbstractMenuScene::updateState(parent);
 
     bool isMounted = smb_browser_utils::isSmbMounted(d->url.toString());
-    mountAct->setVisible(!isMounted);
+    mountAct->setVisible(d->url.path() == "/" ? false : !isMounted);
     unmountAct->setVisible(isMounted);
+    propertyAct->setVisible(d->url.path() == "/" ? false : isMounted);
     propertyAct->setEnabled(isMounted);
 
     AbstractMenuScene::updateState(parent);

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
@@ -137,6 +137,11 @@ void SmbBrowser::followEvents()
 {
     dpfHookSequence->follow("dfmplugin_detailspace", "hook_Icon_Fetch", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::detailViewIcon);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_DeleteFiles", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::cancelDelete);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_MoveToTrash", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::cancelMoveToTrash);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_PasteFiles", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::cancelMoveToTrash);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_CopyFiles", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::cancelMoveToTrash);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_CutFiles", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::cancelMoveToTrash);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_PreViewFiles", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::cancelMoveToTrash);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Tab_SetTabName", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookSetTabName);
 }
 

--- a/tests/plugins/filemanager/dfmplugin-myshares/events/ut_shareeventhelper.cpp
+++ b/tests/plugins/filemanager/dfmplugin-myshares/events/ut_shareeventhelper.cpp
@@ -29,19 +29,19 @@ TEST_F(UT_ShareEventHelper, BlockPaste)
 TEST_F(UT_ShareEventHelper, BlockDelete)
 {
     stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return true; });
-    EXPECT_TRUE(ShareEventHelper::instance()->blockDelete(0, { QUrl("usershare:///hello") }));
+    EXPECT_TRUE(ShareEventHelper::instance()->blockDelete(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
 
     stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return false; });
-    EXPECT_FALSE(ShareEventHelper::instance()->blockDelete(0, { QUrl("usershare:///hello") }));
+    EXPECT_FALSE(ShareEventHelper::instance()->blockDelete(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
 }
 
 TEST_F(UT_ShareEventHelper, BlockMoveToTrash)
 {
     stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return true; });
-    EXPECT_TRUE(ShareEventHelper::instance()->blockMoveToTrash(0, { QUrl("usershare:///hello") }));
+    EXPECT_TRUE(ShareEventHelper::instance()->blockMoveToTrash(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
 
     stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return false; });
-    EXPECT_FALSE(ShareEventHelper::instance()->blockMoveToTrash(0, { QUrl("usershare:///hello") }));
+    EXPECT_FALSE(ShareEventHelper::instance()->blockMoveToTrash(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
 }
 
 TEST_F(UT_ShareEventHelper, HookSendOpenWindow)

--- a/tests/plugins/filemanager/dfmplugin-smbbrowser/events/ut_smbbrowsereventreceiver.cpp
+++ b/tests/plugins/filemanager/dfmplugin-smbbrowser/events/ut_smbbrowsereventreceiver.cpp
@@ -52,8 +52,8 @@ TEST_F(UT_SmbBrowserEventReceiver, DetailViewIcon)
 
 TEST_F(UT_SmbBrowserEventReceiver, CancelDelete)
 {
-    EXPECT_FALSE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl::fromLocalFile("/") }));
-    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("smb://1.2.3.4/hello") }));
-    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("ftp://1.2.3.4/hello") }));
-    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("sftp://1.2.3.4/hello") }));
+    EXPECT_FALSE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl::fromLocalFile("/") }, QUrl("usershare:///hello")));
+    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("smb://1.2.3.4/hello") }, QUrl("usershare:///hello")));
+    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("ftp://1.2.3.4/hello") }, QUrl("usershare:///hello")));
+    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("sftp://1.2.3.4/hello") }, QUrl("usershare:///hello")));
 }


### PR DESCRIPTION
Block shortcuts delete and shift+delete in Network Neighborhood, mount and properties in menu, and block space previews

Log: Network Neighborhood feature blocking
Task: https://pms.uniontech.com/task-view-297613.html