### PR TITLE
fix: [io]dde-desktop blinks when unplugging or plugging in a USB flash drive

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -237,10 +237,10 @@ public:
         if (!info) {
             auto tarScheme = scheme(url);
             info = instance().SchemeFactory<FileInfo>::create(tarScheme, url, errorString);
-            if (info && tarScheme == Global::Scheme::kAsyncFile) {
-                info->refresh();
-                emit InfoCacheController::instance().cacheFileInfo(url, info);
-            }
+            if (info && tarScheme == Global::Scheme::kAsyncFile)
+                info->updateAttributes();
+
+            emit InfoCacheController::instance().cacheFileInfo(url, info);
         }
 
         if (!info)

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -460,7 +460,7 @@ QVariant AsyncFileInfo::customData(int role) const
             extendOtherCache.remove(ExtInfoType::kFileThumbnail);
         }
         QWriteLocker locker(&d->iconLock);
-        if (d->fileIcon.name() == "unknow")
+        if (d->fileIcon.name() == "unknown")
             d->fileIcon = QIcon();
         return QVariant();
     }
@@ -498,6 +498,7 @@ void AsyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> 
     if (typeAll.isEmpty()) {
         // 更新所有属性
         typeAll.append(FileInfoAttributeID::kThumbnailIcon);
+        typeAll.append(FileInfoAttributeID::kStandardIcon);
 
         typeAll.append(FileInfoAttributeID::kStandardSize);
         QReadLocker rlk(&d->lock);
@@ -1150,7 +1151,6 @@ int AsyncFileInfoPrivate::cacheAllAttributes()
             if (notInit && hid.isValid())
                 cacheAsyncAttributes.insert(FileInfo::FileInfoAttributeID::kStandardIsHidden, hid);
         }
-        updateIcon();
         // kMimeTypeName
         fileMimeTypeAsync();
         return 2;
@@ -1166,8 +1166,6 @@ int AsyncFileInfoPrivate::cacheAllAttributes()
 
         if (changesAttributes.isEmpty())
             return 1;
-
-        updateIcon();
 
         if (changesAttributes.contains(FileInfo::FileInfoAttributeID::kStandardFileType) ||
                 changesAttributes.contains(FileInfo::FileInfoAttributeID::kStandardFileExists) ||

--- a/src/dfm-base/utils/thumbnail/thumbnailfactory.h
+++ b/src/dfm-base/utils/thumbnail/thumbnailfactory.h
@@ -34,10 +34,11 @@ Q_SIGNALS:
     void produceFailed(const QUrl &src);
 
     void addTask(const ThumbnailWorker::ThumbnailTaskMap &taskMap);
-
+    void thumbnailJob(const QUrl &url, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 private Q_SLOTS:
     void onAboutToQuit();
     void pushTask();
+    void doJoinThumbnailJob(const QUrl &url, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 
 protected:
     explicit ThumbnailFactory(QObject *parent = nullptr);


### PR DESCRIPTION
Open local file cache, call updateatrributes to update attributes, adjust thumbnail interface, this interface does not support sub-threaded calls.

Log: dde-desktop blinks when unplugging or plugging in a USB flash drive
Bug: https://pms.uniontech.com/bug-view-222081.html