### PR TITLE
fix: [workspace]Paste error when selecting multiple directories with different levels of hierarchy

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -689,8 +689,8 @@ QList<QUrl> FileView::selectedTreeViewUrlList() const
         });
     for (const QModelIndex &index : selectIndex) {
         bool expandIsParent = expandIndex.isValid() ?
-                    index.data(Global::ItemRoles::kItemUrlRole).toString().startsWith(
-                        expandIndex.data(Global::ItemRoles::kItemUrlRole).toString()) : false;
+                    index.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt() >
+                        expandIndex.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt() : false;
         if (index.parent() != rootIndex ||
                 (expandIndex.isValid() && expandIsParent))
             continue;


### PR DESCRIPTION
Error determining parent directory when calculating selected url in treeview.

Log: Paste error when selecting multiple directories with different levels of hierarchy
Bug: https://pms.uniontech.com/bug-view-224219.html