### PR TITLE
fix: new node added in this node, this node should be hided

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/models/computermodel.cpp
@@ -273,7 +273,7 @@ void ComputerModel::onItemAdded(const ComputerItemData &data)
     }
 
     pos = findItem(data.url);
-    qInfo() << "devUrl = " << data.url << ",pos = " << pos;   // log for bug:#182939
+    qInfo() << "item added: devUrl = " << data.url << ",pos = " << pos;   // log for bug:#182939
     if (pos > 0) {   // update the item
         onItemUpdated(data.url);
     } else {
@@ -314,6 +314,8 @@ void ComputerModel::onItemRemoved(const QUrl &url)
 {
     int pos = findItem(url);
     if (pos > 0) {
+        qInfo() << "item removed: " << url << ",pos = " << pos;   // log for bug:#224925
+
         if (view->selectedUrlList().contains(url))
             //        view->clearSelection(); // NOTE: this do not work, might be a bug in QT
             view->setCurrentIndex(QModelIndex());   // NOTE: and this works good.

--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -694,6 +694,9 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
                 removeDevice(url);
             else
                 addDevice(diskGroup(), url, ComputerItemData::kLargeItem, true);
+        } else if ((propertyName == DeviceProperty::kHasPartitionTable) && var.variant().toBool()) {// when new node added the PartitionTable should be triggered, remove the node.bug 224925
+            qDebug() << DeviceProperty::kHasPartitionTable << " changed for: " << url;   // log for bug:#224925
+            removeDevice(url);
         } else {
             auto &&devUrl = ComputerUtils::makeBlockDevUrl(id);
             // when these properties changed, reload the cache.
@@ -702,6 +705,7 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
                                              DeviceProperty::kCleartextDevice };
             if (queryInfoOnChanged.contains(propertyName))
                 onUpdateBlockItem(id);
+
             Q_EMIT itemPropertyChanged(devUrl, propertyName, var.variant());
         }
 


### PR DESCRIPTION
new node added the partiontable should be triggerred, should monitor the partiontable property and update the view

Log: new node added in this node, this node should be hided
Bug: https://pms.uniontech.com/bug-view-224925.html