### PR TITLE
fix: [io]Mobile MTP, cut file to other directory, then click breadcrumb to return, file still shows, refresh disappears

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -975,7 +975,7 @@ QVariant AsyncFileInfoPrivate::attribute(DFileInfo::AttributeID key, bool *ok) c
     auto tmp = dfmFileInfo;
     if (tmp && tmp->queryAttributeFinished()) {
         bool getOk{false};
-        auto value = dfmFileInfo->attribute(key, &getOk);
+        auto value = tmp->attribute(key, &getOk);
         if (ok)
             *ok = getOk;
         if (!getOk) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -141,11 +141,9 @@ int RootInfo::clearTraversalThread(const QString &key)
     if (thread->traversalThread->isRunning())
         traversaling = false;
     thread->traversalThread->quit();
-    if (traversalThreads.isEmpty()) {
-        if (watcher)
-            watcher->stopWatcher();
+    if (traversalThreads.isEmpty())
         needStartWatcher = true;
-    }
+
     return traversalThreads.count();
 }
 


### PR DESCRIPTION
Monitor is turned off

Log: Mobile MTP, cut file to other directory, then click breadcrumb to return, file still shows, refresh disappears
Bug: https://pms.uniontech.com/bug-view-224781.html