### PR TITLE
fix: [workspace]some treeview bugs

### DIFF
--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -486,7 +486,15 @@ void UniversalUtils::prepareForSleep(QObject *obj, const char *cslot)
             "org.freedesktop.login1.Manager",
             "PrepareForSleep",
             obj,
-            cslot);
+                cslot);
+}
+
+bool UniversalUtils::isParentUrl(const QUrl &child, const QUrl &parent)
+{
+    auto parentStr = parent.toString();
+    parentStr = parentStr.endsWith(QDir::separator()) ?
+                parentStr : parentStr + QDir::separator();
+    return child.toString().startsWith(parentStr);
 }
 
 }

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -46,6 +46,8 @@ public:
     static void userChange(QObject *obj, const char *cslot = nullptr);
 
     static void prepareForSleep(QObject *obj, const char *cslot = nullptr);
+
+    static bool isParentUrl(const QUrl &child, const QUrl &parent);
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-recent/recent.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/recent.cpp
@@ -61,6 +61,7 @@ bool Recent::start()
 
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterFileView", RecentHelper::scheme());
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterMenuScene", RecentHelper::scheme(), RecentMenuCreator::name());
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_NotSupportTreeView", RecentHelper::scheme());
 
     addFileOperations();
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -67,6 +67,8 @@ void WorkspaceEventReceiver::initConnection()
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleCloseTabs);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Tab_SetAlias",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleSetTabAlias);
+    dpfSlotChannel->connect(kCurrentEventSpace, "slot_NotSupportTreeView",
+                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleNotSupportTreeView);
 
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_GetVisualGeometry",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleGetVisualGeometry);
@@ -191,6 +193,11 @@ void WorkspaceEventReceiver::handleReverseSelect(quint64 windowId)
 void WorkspaceEventReceiver::handleSetSort(quint64 windowId, ItemRoles role)
 {
     WorkspaceHelper::instance()->setSort(windowId, role);
+}
+
+void WorkspaceEventReceiver::handleNotSupportTreeView(const QString &scheme)
+{
+    WorkspaceHelper::instance()->setNotSupportTreeView(scheme);
 }
 
 void WorkspaceEventReceiver::handleSetSelectionMode(const quint64 windowId, const QAbstractItemView::SelectionMode mode)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -38,6 +38,7 @@ public slots:
     void handleSelectAll(quint64 windowId);
     void handleReverseSelect(quint64 windowId);
     void handleSetSort(quint64 windowId, DFMBASE_NAMESPACE::Global::ItemRoles role);
+    void handleNotSupportTreeView(const QString &scheme);
 
     void handleSetSelectionMode(const quint64 windowId, const QAbstractItemView::SelectionMode mode);
     void handleSetEnabledSelectionModes(const quint64 windowId, const QList<QAbstractItemView::SelectionMode> &modes);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -864,7 +864,8 @@ void FileViewModel::initFilterSortWork()
     filterSortWorker->setRootData(FileItemDataPointer(new FileItemData(dirRootUrl, InfoFactory::create<FileInfo>(dirRootUrl))));
     endInsertRows();
     filterSortWorker->setSortAgruments(order, role, Application::instance()->appAttribute(Application::kFileAndDirMixedSort).toBool());
-    filterSortWorker->setTreeView(Application::instance()->appAttribute(Application::kListItemExpandable).toBool());
+    filterSortWorker->setTreeView(Application::instance()->appAttribute(Application::kListItemExpandable).toBool()
+                                  && WorkspaceHelper::instance()->supportTreeView(rootUrl().scheme()));
     filterSortWorker->moveToThread(filterSortThread.data());
 
     // connect signals

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -286,7 +286,7 @@ void FileSortWorker::handleWatcherRemoveChildren(const QList<SortInfoPointer> ch
 
         if (sortInfo->isDir() && visibleTreeChildren.keys().contains(sortInfo->fileUrl()))
         {
-            removeSubDir(sortInfo->fileUrl(), false);
+            removeSubDir(sortInfo->fileUrl());
             continue;
         }
     }
@@ -322,6 +322,7 @@ void FileSortWorker::handleWatcherRemoveChildren(const QList<SortInfoPointer> ch
             visibleChildren.removeAt(showIndex);
         }
         Q_EMIT removeFinish();
+
     }
     this->children.insert(parentUrl, subChildren);
     visibleTreeChildren.insert(parentUrl, subVisibleList);
@@ -528,7 +529,7 @@ void FileSortWorker::handleCloseExpand(const QString &key, const QUrl &parent)
         return;
     if (!children.keys().contains(parent))
         return;
-    removeSubDir(parent, false);
+    removeSubDir(parent);
 }
 
 void FileSortWorker::handleSwitchTreeView(const bool isTree)
@@ -704,7 +705,7 @@ void FileSortWorker::filterAndSortFiles(const QUrl &dir, const bool fileter, con
     // 移除所有的children，和itemdata
     if (!removeDirs.isEmpty()) {
         auto removeItemList = removeChildrenByParents(removeDirs);
-        if (removeItemList.isEmpty())
+        if (!removeItemList.isEmpty())
             removeFileItems(removeItemList);
     }
 }
@@ -723,10 +724,11 @@ QList<QUrl> FileSortWorker::filterFilesByParent(const QUrl &dir, const bool byIn
         for(const auto &parent : depthParentUrls) {
             if (isCanceled)
                 return {};
-            if (!parent.toString().startsWith(dir.toString()))
+            if (!UniversalUtils::urlEquals(parent, current) && !UniversalUtils::isParentUrl(parent, dir))
                 continue;
-
-            if (!UniversalUtils::urlEquals(parent, current) && !checkFilters(children.value(UrlRoute::urlParent(parent)).value(parent), byInfo)) {
+            auto sortInfo = children.value(UrlRoute::urlParent(parent)).value(parent);
+            if (!UniversalUtils::urlEquals(parent, current) &&
+                    !checkFilters(sortInfo, byInfo)) {
                 allSubUnShowDir.append(removeVisibleTreeChildren(parent));
                 continue;
             }
@@ -915,9 +917,6 @@ QList<QUrl> FileSortWorker::sortAllTreeFilesByParent(const QUrl &dir, const bool
         for(const auto &parent : depthParentUrls) {
             if (isCanceled)
                 return {};
-            if (!parent.toString().startsWith(dir.toString()))
-                continue;
-
             auto sortList = bSort ? sortTreeFiles(visibleTreeChildren.take(parent), reverse) : visibleTreeChildren.value(parent);
             if (sortList.isEmpty())
                 continue;
@@ -979,36 +978,32 @@ QList<QUrl> FileSortWorker::sortTreeFiles(const QList<QUrl> &children, const boo
     return sortList;
 }
 
-QList<QUrl> FileSortWorker::removeChildrenByParents(const QList<QUrl> &dirs, const bool removeSelf)
+QList<QUrl> FileSortWorker::removeChildrenByParents(const QList<QUrl> &dirs)
 {
     QList<QUrl> urls;
     for (const auto &dir :dirs) {
-        if (removeSelf)
-            urls.append(dir);
         for (const auto &sortInfo : children.value(dir))
             urls << sortInfo->fileUrl();
         children.remove(dir);
+        auto item = childData(dir);
+        if (item)
+            item->setExpanded(false);
     }
     return urls;
 }
 
-QList<QUrl> FileSortWorker::removeVisibleTreeChildren(const QUrl &parent, const bool removeSelf)
+QList<QUrl> FileSortWorker::removeVisibleTreeChildren(const QUrl &parent)
 {
     auto depth = depthMap.key(parent);
     QList<QUrl> depthParentUrls = depthMap.values(depth);
     QList<QUrl> removeUrls { };
-    if (removeSelf) {
-        removeUrls.append(parent);
-        auto list = visibleTreeChildren.take(UrlRoute::urlParent(parent));
-        list.removeOne(parent);
-        visibleTreeChildren.insert(UrlRoute::urlParent(parent), list);
-    }
     while (!depthParentUrls.isEmpty()) {
         if (isCanceled)
             return {};
         for (const auto &child : depthParentUrls) {
-            if (child.toString().startsWith(parent.toString())) {
-                removeUrls.append(child);
+            if (UniversalUtils::urlEquals(child, parent) || UniversalUtils::isParentUrl(child, parent)) {
+                if (!removeUrls.contains(child))
+                    removeUrls.append(child);
                 visibleTreeChildren.remove(child);
                 depthMap.remove(depth, child);
             }
@@ -1020,19 +1015,19 @@ QList<QUrl> FileSortWorker::removeVisibleTreeChildren(const QUrl &parent, const 
     return removeUrls;
 }
 
-void FileSortWorker::removeSubDir(const QUrl &dir, const bool removeSelf)
+void FileSortWorker::removeSubDir(const QUrl &dir)
 {
     auto startPos = findStartPos(dir);
     auto endPos = findEndPos(dir);
 
     // 移除可显示的所有的url
-    auto removeDir = removeVisibleTreeChildren(dir, removeSelf);
+    auto removeDir = removeVisibleTreeChildren(dir);
     // 移除界面所有显示的url
     removeVisibleChildren(startPos, endPos == -1 ? childrenCount() - startPos : endPos - startPos);
     // 移除itemdata
     if (removeDir.isEmpty())
         return;
-    auto removeList = removeChildrenByParents(removeDir, removeSelf);
+    auto removeList = removeChildrenByParents(removeDir);
     if (removeList.isEmpty())
         return;
     removeFileItems(removeList);
@@ -1092,7 +1087,7 @@ int FileSortWorker::findStartPos(const QList<QUrl> &list, const QUrl &parent)
 void FileSortWorker::insertVisibleChildren(const int startPos, const QList<QUrl> &filterUrls,
                                            const InsertOpt opt, const int endPos)
 {
-    if (isCanceled || filterUrls.isEmpty())
+    if (isCanceled)
         return;
 
     Q_EMIT insertRows(startPos, filterUrls.length());

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -164,9 +164,9 @@ private:
     void switchListView();
     QList<QUrl> sortAllTreeFilesByParent(const QUrl &dir, const bool reverse = false);
     QList<QUrl> sortTreeFiles(const QList<QUrl> &children, const bool reverse = false);
-    QList<QUrl> removeChildrenByParents(const QList<QUrl> &dirs, const bool removeSelf = true);
-    QList<QUrl> removeVisibleTreeChildren(const QUrl &parent, const bool removeSelf = true);
-    void removeSubDir(const QUrl &dir, const bool removeSelf = true);
+    QList<QUrl> removeChildrenByParents(const QList<QUrl> &dirs);
+    QList<QUrl> removeVisibleTreeChildren(const QUrl &parent);
+    void removeSubDir(const QUrl &dir);
     void removeFileItems(const QList<QUrl> &urls);
     int8_t findDepth(const QUrl &parent);
     int findEndPos(const QUrl &dir);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -186,6 +186,7 @@ private:
 
     bool checkFilters(const SortInfoPointer &sortInfo, const bool byInfo = false);
     bool isDefaultHiddenFile(const QUrl &fileUrl);
+    QUrl parantUrl(const QUrl &url);
 
 private:
     QUrl current;
@@ -212,6 +213,7 @@ private:
     QMap<QUrl, QList<QUrl>> visibleTreeChildren{};
     QMultiMap<int8_t, QUrl> depthMap;
     std::atomic_bool istree;
+    std::atomic_bool currentSupportTreeView {false};
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -390,6 +390,17 @@ bool WorkspaceHelper::registeredFileView(const QString &scheme) const
     return registeredFileViewScheme.contains(scheme);
 }
 
+void WorkspaceHelper::setNotSupportTreeView(const QString &scheme)
+{
+    if (!notSupportTreeView.contains(scheme))
+        notSupportTreeView.append(scheme);
+}
+
+bool WorkspaceHelper::supportTreeView(const QString &scheme) const
+{
+    return !notSupportTreeView.contains(scheme);
+}
+
 void WorkspaceHelper::installWorkspaceWidgetToWindow(const quint64 windowID)
 {
     WorkspaceWidget *widget = nullptr;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.h
@@ -94,6 +94,9 @@ public:
     void registerFileView(const QString &scheme);
     bool registeredFileView(const QString &scheme) const;
 
+    void setNotSupportTreeView(const QString &scheme);
+    bool supportTreeView(const QString &scheme) const;
+
     static QMap<quint64, QPair<QUrl, QUrl>> kSelectionAndRenameFile;   //###: for creating new file.
     static QMap<quint64, QPair<QUrl, QUrl>> kSelectionFile;   //###: rename a file which must be existance.
 
@@ -119,6 +122,7 @@ private:
     DefaultViewMode defaultViewMode;
 
     QList<QString> registeredFileViewScheme {};
+    QList<QString> notSupportTreeView{};
 
     Q_DISABLE_COPY(WorkspaceHelper)
 };

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -736,9 +736,14 @@ QList<QUrl> FileView::selectedTreeViewUrlList() const
             return left.row() < right.row();
         });
     for (const QModelIndex &index : selectIndex) {
-        bool expandIsParent = expandIndex.isValid() ?
-                    index.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt() >
-                        expandIndex.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt() : false;
+        bool expandIsParent = false;
+        if (expandIndex.isValid()) {
+            auto parentUrl = expandIndex.data(Global::ItemRoles::kItemUrlRole).toUrl();
+            auto child = index.data(Global::ItemRoles::kItemUrlRole).toUrl();
+            expandIsParent = (index.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt()
+                    > expandIndex.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt())
+                    && UniversalUtils::isParentUrl(child, parentUrl);
+        }
         if (index.parent() != rootIndex ||
                 (expandIndex.isValid() && expandIsParent))
             continue;
@@ -775,9 +780,14 @@ void FileView::selectedTreeViewUrlList(QList<QUrl> &selectedUrls, QList<QUrl> &t
         });
     for (const QModelIndex &index : selectIndex) {
         selectedUrls.append(index.data(Global::ItemRoles::kItemUrlRole).toUrl());
-        bool expandIsParent = expandIndex.isValid() ?
-                    index.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt() >
-                        expandIndex.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt() : false;
+        bool expandIsParent = false;
+        if (expandIndex.isValid()) {
+            auto parentUrl = expandIndex.data(Global::ItemRoles::kItemUrlRole).toUrl();
+            auto child = index.data(Global::ItemRoles::kItemUrlRole).toUrl();
+            expandIsParent = (index.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt()
+                    > expandIndex.data(Global::ItemRoles::kItemTreeViewDepthRole).toInt())
+                    && UniversalUtils::isParentUrl(child, parentUrl);
+        }
         if (index.parent() != rootIndex ||
                 (expandIndex.isValid() && expandIsParent))
             continue;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -190,6 +190,8 @@ bool FileView::setRootUrl(const QUrl &url)
 
     const QUrl &fileUrl = parseSelectedUrl(url);
     const QModelIndex &index = model()->setRootUrl(fileUrl);
+    d->itemsExpandable = Application::instance()->appAttribute(Application::kListItemExpandable).toBool()
+            && WorkspaceHelper::instance()->supportTreeView(fileUrl.scheme());
 
     setRootIndex(index);
 
@@ -1040,9 +1042,11 @@ void FileView::onWidgetUpdate()
 
 void FileView::onAppAttributeChanged(Application::ApplicationAttribute aa, const QVariant &value)
 {
-    if (aa == Application::kListItemExpandable) {
-        d->itemsExpandable = value.toBool();
-
+    if (aa == Application::kListItemExpandable ) {
+        if (d->itemsExpandable ==
+                (value.toBool() && WorkspaceHelper::instance()->supportTreeView(rootUrl().scheme())))
+            return;
+        d->itemsExpandable = (value.toBool() && WorkspaceHelper::instance()->supportTreeView(rootUrl().scheme()));
         // todo: try to repaint the list
         setViewMode(d->currentViewMode);
     }
@@ -1740,7 +1744,8 @@ void FileView::initializeDelegate()
     setDelegate(Global::ViewMode::kIconMode, new IconItemDelegate(d->fileViewHelper));
     setDelegate(Global::ViewMode::kListMode, new ListItemDelegate(d->fileViewHelper));
 
-    d->itemsExpandable = Application::instance()->appAttribute(Application::kListItemExpandable).toBool();
+    d->itemsExpandable = Application::instance()->appAttribute(Application::kListItemExpandable).toBool()
+            && WorkspaceHelper::instance()->supportTreeView(rootUrl().scheme());
 }
 
 void FileView::initializeStatusBar()

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -40,6 +40,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_ShowCustomTopWidget)
     DPF_EVENT_REG_SLOT(slot_GetCustomTopWidgetVisible)
     DPF_EVENT_REG_SLOT(slot_CheckSchemeViewIsFileView)
+    DPF_EVENT_REG_SLOT(slot_NotSupportTreeView)
 
     DPF_EVENT_REG_SLOT(slot_Tab_Addable)
     DPF_EVENT_REG_SLOT(slot_Tab_Close)

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -85,6 +85,7 @@ void Search::regSearchToWorkspace()
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterFileView", SearchHelper::scheme());
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterMenuScene", SearchHelper::scheme(), SearchMenuCreator::name());
     dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetDefaultViewMode", SearchHelper::scheme(), Global::ViewMode::kListMode);
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_NotSupportTreeView", SearchHelper::scheme());
 
     CreateTopWidgetCallback createCallback { []() { return new AdvanceSearchBar(); } };
     ShowTopWidgetCallback showCallback { SearchHelper::showTopWidget };

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
@@ -66,6 +66,9 @@ bool SmbBrowser::start()
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterFileView", QString(Global::Scheme::kFtp));
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterFileView", QString(Global::Scheme::kSFtp));
 
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_NotSupportTreeView", smb_browser_utils::networkScheme());
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_NotSupportTreeView", QString(Global::Scheme::kSmb));
+
     ProtocolDeviceDisplayManager::instance();
     registerNetworkAccessPrehandler();
 


### PR DESCRIPTION
The parent directory in fileview and filesortworker is incorrectly determined, and the items removed are incorrectly determined when removing.Add registration event does not support treeview, search, smb, network is not supported.

Log: fix some treeview bug
Bug: https://pms.uniontech.com/bug-view-224181.html https://pms.uniontech.com/bug-view-224167.html https://pms.uniontech.com/bug-view-223713.html https://pms.uniontech.com/bug-view-224219.html https://pms.uniontech.com/bug-view-223715.html https://pms.uniontech.com/bug-view-223895.html