### PR TITLE
fix: [io]After mounting UOS FTP, the file right-click menu "Cut", "Rename" and "Delete" options are grayed out.

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -978,10 +978,9 @@ QVariant AsyncFileInfoPrivate::attribute(DFileInfo::AttributeID key, bool *ok) c
         auto value = tmp->attribute(key, &getOk);
         if (ok)
             *ok = getOk;
-        if (!getOk) {
+        if (!getOk)
             qDebug() << static_cast<int>(key) << q->fileUrl() << tmp->lastError().errorMsg();
-            return QVariant();
-        }
+
         return value;
     }
     return QVariant();


### PR DESCRIPTION


Revert to the old way of getting dfmio file attributes.

Log: After mounting UOS FTP, the file right-click menu "Cut", "Rename" and "Delete" options are grayed out.
Bug: https://pms.uniontech.com/bug-view-225387.html https://pms.uniontech.com/bug-view-225369.html