### PR TITLE
fix: [io]Peripherals, network mounts, cell phones, these expanding directories can be slow and laggy

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -912,7 +912,9 @@ void FileSortWorker::switchListView()
 QList<QUrl> FileSortWorker::sortAllTreeFilesByParent(const QUrl &dir, const bool reverse)
 {
     QList<QUrl> visibleList;
-    int8_t depth = depthMap.key(dir, -1);
+    int8_t depth = depthMap.key(dir, -2);
+    if (depth <= -2)
+        return {};
     QList<QUrl> depthParentUrls{ dir };
     bool bSort = orgSortRole != Global::ItemRoles::kItemDisplayRole;
     // 执行排序
@@ -922,6 +924,9 @@ QList<QUrl> FileSortWorker::sortAllTreeFilesByParent(const QUrl &dir, const bool
         for(const auto &parent : depthParentUrls) {
             if (isCanceled)
                 return {};
+            if (!UniversalUtils::urlEquals(dir, parent) && UniversalUtils::isParentUrl(parent, dir))
+                continue;
+
             auto sortList = bSort ? sortTreeFiles(visibleTreeChildren.take(parent), reverse) : visibleTreeChildren.value(parent);
             if (sortList.isEmpty())
                 continue;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -68,6 +68,7 @@ void TraversalDirThreadManager::setTraversalToken(const QString &token)
 
 void TraversalDirThreadManager::start()
 {
+    running = true;
     auto local = dirIterator.dynamicCast<LocalDirIterator>();
     if (local && local->oneByOne()) {
         future = local->asyncIterator();
@@ -81,6 +82,11 @@ void TraversalDirThreadManager::start()
     TraversalDirThread::start();
 }
 
+bool TraversalDirThreadManager::isRunning() const
+{
+    return running;
+}
+
 void TraversalDirThreadManager::onAsyncIteratorOver()
 {
     Q_EMIT iteratorInitFinished();
@@ -91,6 +97,7 @@ void TraversalDirThreadManager::run()
 {
     if (dirIterator.isNull()) {
         emit traversalFinished(traversalToken);
+        running = false;
         return;
     }
 
@@ -106,6 +113,7 @@ void TraversalDirThreadManager::run()
         count = iteratorOneByOne(timer);
         qInfo() << "dir query end, file count: " << count << " url: " << dirUrl << " elapsed: " << timer.elapsed();
     }
+    running = false;
 }
 
 int TraversalDirThreadManager::iteratorOneByOne(const QElapsedTimer &timere)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -32,6 +32,7 @@ class TraversalDirThreadManager : public TraversalDirThread
     int countCeiling = 500;
     dfmio::DEnumeratorFuture *future { nullptr };
     QString traversalToken;
+    std::atomic_bool running = false;
 
 public:
     explicit TraversalDirThreadManager(const QUrl &url, const QStringList &nameFilters = QStringList(),
@@ -43,6 +44,8 @@ public:
     void setTraversalToken(const QString &token);
 
     void start();
+
+    bool isRunning() const;
 
 public Q_SLOTS:
     void onAsyncIteratorOver();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -1008,11 +1008,11 @@ bool FileView::expandOrCollapseItem(const QModelIndex &index, const QPoint &pos)
     bool expanded = model()->data(index, kItemTreeViewExpandedRole).toBool();
     if (expanded) {
         // do collapse
-        qInfo() << "do collapse item, index = " << index;
+        qInfo() << "do collapse item, index = " << index << index.row() << model()->data(index, kItemUrlRole).toUrl();
         model()->doCollapse(index);
     } else {
         // do expanded
-        qInfo() << "do expanded item, index = " << index;
+        qInfo() << "do expanded item, index = " << index << index.row() << model()->data(index, kItemUrlRole).toUrl();
         model()->doExpand(index);
     }
 


### PR DESCRIPTION
It's not a performance issue here, it's just going in circles (busy state) all the time. Expanding an empty directory once, closing it and then expanding it again keeps it spinning in circles. Modify the logic here, if you expand and then leave the closed iteration thread state change

Log: Peripherals, network mounts, cell phones, these expanding directories can be slow and laggy
Bug: https://pms.uniontech.com/bug-view-224267.html