### PR TITLE
fix: [io]Copying large capacity files to an external device, after copying is complete, sync still takes about 20s to end

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1327,7 +1327,8 @@ void FileOperateBaseWorker::determineCountProcessType()
 
 void FileOperateBaseWorker::syncFilesToDevice()
 {
-    if (CountWriteSizeType::kWriteBlockType != countWriteType)
+
+    if (isTargetFileLocal)
         return;
 
     qInfo() << "start sync all file to extend block device!!!!! target : " << targetUrl;


### PR DESCRIPTION
Synchronize the external device with ext series file system.

Log: Copying large capacity files to an external device, after copying is complete, sync still takes about 20s to end
Bug: https://pms.uniontech.com/bug-view-224907.html