### PR TITLE
修复“共享”菜单不显示的问题

### DIFF
--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
@@ -129,6 +129,10 @@ bool ExtendMenuScenePrivate::insertIntoExistedMenu(QAction *action, const QMap<Q
     cacheActionsSeparator.remove(action);
 
     menu->addActions(subActions);
+    auto holdingAct = menu->menuAction();
+    if (holdingAct)
+        holdingAct->setVisible(true);
+
     return true;
 }
 


### PR DESCRIPTION
make the menu visible if any subactions added.

Log: fix issue about menu visible.

Bug: https://pms.uniontech.com/bug-view-225073.html
