### PR TITLE
fix: [io]Optical drive list view, after mounting, it takes a while for the file names inside the CD-ROM to be displayed in their entirety

### DIFF
--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -130,6 +130,8 @@ QString dfmbase::FileInfo::nameOf(const NameInfoType type) const
         return dptr->fileName();
     case FileNameInfoType::kBaseName:
         [[fallthrough]];
+    case FileNameInfoType::kCompleteBaseName:
+        [[fallthrough]];
     case FileNameInfoType::kBaseNameOfRename:
         return dptr->baseName();
     case FileNameInfoType::kSuffixOfRename:


### PR DESCRIPTION
Asynchronous file information is not yet complete, go get kItemFileBaseNameRole file information. This is because the cache doesn't use the parent class fileinfo to get the attribute, and doesn't implement the kItemFileBaseNameRole attribute to get it.

Log: Optical drive list view, after mounting, it takes a while for the file names inside the CD-ROM to be displayed in their entirety
Bug: https://pms.uniontech.com/bug-view-225935.html