### PR TITLE
feat: [daemon/anything] Run anything service in independent process

### DIFF
--- a/src/plugins/daemon/daemonplugin-anything/anythingserver.cpp
+++ b/src/plugins/daemon/daemonplugin-anything/anythingserver.cpp
@@ -3,37 +3,146 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "anythingserver.h"
-#include <QProcess>
+#include <QStandardPaths>
 
 DAEMONPANYTHING_USE_NAMESPACE
 
+static bool loadKernelModule()
+{
+    QProcess process;
+    bool ret = false;
+
+    process.start("modprobe", { "vfs_monitor" }, QIODevice::ReadOnly);
+    if (process.waitForFinished(1000)) {
+        ret = process.exitCode() == 0;
+        qInfo() << "load kernel module vfs_monitor" << (ret ? "succeeded." : "failed.") << "exitcode(" << process.exitCode() << ")";
+    } else {
+        qInfo() << "load kernel module vfs_monitor timed out.";
+    }
+
+    return ret;
+}
+
+static bool unloadKernelModule()
+{
+    QProcess process;
+    bool ret = false;
+
+    process.start("rmmod", { "vfs_monitor" }, QIODevice::ReadOnly);
+    if (process.waitForFinished(1000)) {
+        ret = process.exitCode() == 0;
+        qInfo() << "unload kernel module vfs_monitor" << (ret ? "succeeded." : "failed.") << "exitcode(" << process.exitCode() << ")";
+    } else {
+        qInfo() << "unload kernel module vfs_monitor timed out.";
+    }
+
+    return ret;
+}
+
+static bool startAnythingByProcess(QProcess **server)
+{
+    if (QStandardPaths::findExecutable("deepin-anything-server").isEmpty()) {
+        qInfo() << "deepin-anything-server do not exist, maybe the deepin-anything-server has not been installed.";
+        return false;
+    }
+
+    if (!loadKernelModule())
+        return false;
+
+    *server = new QProcess();
+    (*server)->start("deepin-anything-server", QStringList(), QIODevice::NotOpen);
+    if (!(*server)->waitForStarted(3*1000)) {
+        qInfo() << "start deepin-anything-server fail.";
+        unloadKernelModule();
+        delete *server;
+        *server = nullptr;
+        return false;
+    }
+
+    qInfo() << "started deepin-anything-server.";
+    return true;
+}
+
+void AnythingMonitorThread::run()
+{
+    unsigned long restart_cycle = 10;
+
+    qInfo() << "started deepin-anything-server monitor thread.";
+    while (true) {
+        if (!server->waitForFinished(-1)) {
+            qInfo() << "wait deepin-anything-server quit fail.";
+            break;
+        }
+        qInfo() << "found deepin-anything-server quit.";
+        delete server;
+        server = nullptr;
+        if (*stopped) {
+            qInfo() << "found plugin stopped.";
+            break;
+        }
+        qInfo() << "restart deepin-anything-server after" << restart_cycle << "seconds";
+        QThread::sleep(restart_cycle);
+        if (!startAnythingByProcess(&server))
+            break;
+    }
+}
+
 void AnythingPlugin::initialize()
 {
-    // define the deepin anything backend share library.
-    backendLib = new QLibrary("deepin-anything-server-lib");
+    backendLib = nullptr;
+    stopped = true;
 }
 
 bool AnythingPlugin::start()
 {
+    QProcess *server;
+    bool ret;
+    AnythingMonitorThread* thread;
+
+    if (!stopped)
+        return true;
+
+    if (startAnythingByProcess(&server)) {
+        thread = new AnythingMonitorThread(server, &stopped);
+        connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+        thread->start();
+        ret = true;
+    }
+    else {
+        ret = startAnythingByLib();
+    }
+
+    stopped = !ret;
+    return ret;
+}
+
+void AnythingPlugin::stop()
+{
+    if (stopped)
+        return;
+
+    stopped = true;
+    unloadKernelModule();
+    stopAnythingByLib();
+}
+
+bool AnythingPlugin::startAnythingByLib()
+{
+    // define the deepin anything backend share library.
+    backendLib = new QLibrary("deepin-anything-server-lib");
+
     // load share library and check status.
     backendLib->load();
     if (!backendLib->isLoaded()) {
         qInfo() << "load deepin-anything-server-lib.so failed!!, maybe the deepin-anything-server has not been installed.";
+        delete backendLib;
+        backendLib = nullptr;
         return false;
     }
 
-    // load kernel module vfs_monitor
-    QProcess process;
-    process.start("modprobe", { "vfs_monitor" }, QIODevice::ReadOnly);
-    if (process.waitForFinished(1000)) {
-        if (process.exitCode() == 0) {
-            qInfo() << "load kernel module vfs_monitor succeeded.";
-        } else {
-            qInfo() << "load kernel module vfs_monitor failed.";
-            return false;
-        }
-    } else {
-        qInfo() << "load kernel module vfs_monitor timed out.";
+    if (!loadKernelModule()) {
+        delete backendLib;
+        backendLib = nullptr;
         return false;
     }
 
@@ -52,16 +161,10 @@ bool AnythingPlugin::start()
     return true;
 }
 
-void AnythingPlugin::stop()
+void AnythingPlugin::stopAnythingByLib()
 {
-    // unload kernel module vfs_monitor
-    QProcess process;
-    process.start("rmmod", { "vfs_monitor" }, QIODevice::ReadOnly);
-    if (process.waitForFinished(1000)) {
-        qInfo() << "unload kernel module vfs_monitor" << (process.exitCode() == 0 ? " succeeded." : " failed.");
-    } else {
-        qInfo() << "unload kernel module vfs_monitor timed out.";
-    }
+    if (!backendLib)
+        return;
 
     // define the anything backend instance fucntion.
     typedef void (*AnythingObj)();
@@ -79,4 +182,5 @@ void AnythingPlugin::stop()
         qInfo() << "unloaded deepin-anything-server-lib";
     }
     delete backendLib;
+    backendLib = nullptr;
 }

--- a/src/plugins/daemon/daemonplugin-anything/anythingserver.h
+++ b/src/plugins/daemon/daemonplugin-anything/anythingserver.h
@@ -8,6 +8,7 @@
 #include "daemonplugin_anything_global.h"
 
 #include <dfm-framework/dpf.h>
+#include <QProcess>
 
 DAEMONPANYTHING_BEGIN_NAMESPACE
 
@@ -22,7 +23,29 @@ public:
     virtual void stop() override;
 
 private:
+    bool startAnythingByLib();
+    void stopAnythingByLib();
+
+private:
     QLibrary *backendLib;
+    bool stopped;
+};
+
+class AnythingMonitorThread : public QThread
+{
+    Q_OBJECT
+public:
+    explicit AnythingMonitorThread(QProcess *server, bool *stopped) : QThread(nullptr)
+    {
+        this->server = server;
+        this->stopped = stopped;
+    }
+
+    void run() override;
+
+private:
+    QProcess *server;
+    bool *stopped;
 };
 
 DAEMONPANYTHING_END_NAMESPACE


### PR DESCRIPTION
Using an independent process to run anything service can solve known log conflict problems. When the service runs abnormally, the service can be restored by creating a new process.

Log: handle high CPU usage
Task: https://pms.uniontech.com/task-view-300371.html