### PR TITLE
fix: [extension] emblem icon canot refresh

### DIFF
--- a/include/dfm-extension/emblemicon/dfmextemblemiconplugin.h
+++ b/include/dfm-extension/emblemicon/dfmextemblemiconplugin.h
@@ -28,7 +28,7 @@ public:
 
     // Note: If the corner mark set by emblemIcons conflicts with the corner mark position set by locationEmblemIcons,
     // the conflict position will only display the corner mark set by locationEmblemIcons
-    DFM_FAKE_VIRTUAL IconsType emblemIcons(const std::string &filePath) const;
+    DFM_FAKE_VIRTUAL [[deprecated]] IconsType emblemIcons(const std::string &filePath) const;
     DFM_FAKE_VIRTUAL DFMExtEmblem locationEmblemIcons(const std::string &filePath, int systemIconCount) const;
 
     void registerEmblemIcons(const EmblemIcons &func);

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.cpp
@@ -119,8 +119,6 @@ void EmblemIconWorker::parseEmblemIcons(const QString &path, int count, QSharedP
 
     if (icons.empty())
         return;
-    if (icons.size() == 1 && icons.at(0).empty())
-        return;
 
     if (embelmCaches.contains(path)) {   // check changed
         const QList<QPair<QString, int>> &oldGroup { embelmCaches[path] };


### PR DESCRIPTION
Empty icons for empty paths are filtered out

Log: fix extension bug