### PR TITLE
fix: line height is error after changing font.

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/canvasmanager.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/canvasmanager.h
@@ -42,6 +42,7 @@ public slots:
     void onWallperSetting(CanvasView *);
     void onChangeIconLevel(bool increase);
     void onTrashStateChanged();
+    void onFontChanged();
     void refresh(bool silent);
 protected slots:
     void reloadItem();

--- a/src/plugins/desktop/core/ddplugin-canvas/canvasplugin.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/canvasplugin.h
@@ -30,6 +30,7 @@ private:
     DPF_EVENT_NAMESPACE(DDP_CANVAS_NAMESPACE)
     // CanvasManager begin
     DPF_EVENT_REG_SIGNAL(signal_CanvasManager_IconSizeChanged)
+    DPF_EVENT_REG_SIGNAL(signal_CanvasManager_FontChanged)
     DPF_EVENT_REG_SIGNAL(signal_CanvasManager_AutoArrangeChanged)
 
     DPF_EVENT_REG_SLOT(slot_CanvasManager_FileInfoModel)

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -300,6 +300,11 @@ QSize CanvasItemDelegate::paintDragIcon(QPainter *painter, const QStyleOptionVie
     return paintIcon(painter, indexOption.icon, indexOption.rect, Qt::AlignCenter, QIcon::Normal).size();
 }
 
+int CanvasItemDelegate::textLineHeight() const
+{
+    return d->textLineHeight;
+}
+
 QList<QRect> CanvasItemDelegate::paintGeomertys(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     QList<QRect> geometries;

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.h
@@ -45,6 +45,7 @@ public:
     bool mayExpand(QModelIndex *who = nullptr) const;
     static QRectF boundingRect(const QList<QRectF> &rects);
     QSize paintDragIcon(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index);
+    int textLineHeight() const;
 
 public:
     QRect iconRect(const QRect &paintRect) const;

--- a/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmanagerhook.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmanagerhook.cpp
@@ -31,6 +31,11 @@ void CanvasManagerHook::iconSizeChanged(int level) const
     CanvasManagerPublish(signal_CanvasManager_IconSizeChanged, level);
 }
 
+void CanvasManagerHook::fontChanged() const
+{
+    CanvasManagerPublish(signal_CanvasManager_FontChanged);
+}
+
 void CanvasManagerHook::autoArrangeChanged(bool on) const
 {
     CanvasManagerPublish(signal_CanvasManager_AutoArrangeChanged, on);

--- a/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmanagerhook.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/hook/canvasmanagerhook.h
@@ -18,6 +18,7 @@ public:
     explicit CanvasManagerHook(QObject *parent = nullptr);
 public:
     void iconSizeChanged(int level) const override;
+    void fontChanged() const override;
     void autoArrangeChanged(bool on) const override;
     bool requestWallpaperSetting(const QString &screen) const override;
 };

--- a/src/plugins/desktop/core/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/private/canvasmanager_p.h
@@ -9,6 +9,8 @@
 #include "view/canvasview.h"
 #include "delegate/canvasitemdelegate.h"
 #include "model/fileinfomodel.h"
+#include "model/canvasproxymodel.h"
+#include "model/canvasselectionmodel.h"
 #include "hook/canvasmanagerhook.h"
 #include "hook/canvasmodelhook.h"
 #include "hook/canvasviewhook.h"

--- a/src/plugins/desktop/core/ddplugin-canvas/private/canvasmanagerhookinterface.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/private/canvasmanagerhookinterface.cpp
@@ -26,6 +26,11 @@ void CanvasManagerHookInterface::iconSizeChanged(int level) const
     return;
 }
 
+void CanvasManagerHookInterface::fontChanged() const
+{
+    return;
+}
+
 void CanvasManagerHookInterface::autoArrangeChanged(bool on) const
 {
     return;

--- a/src/plugins/desktop/core/ddplugin-canvas/private/canvasmanagerhookinterface.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/private/canvasmanagerhookinterface.h
@@ -20,6 +20,7 @@ public:
 public:
     // signals
     virtual void iconSizeChanged(int level) const;
+    virtual void fontChanged() const;
     virtual void autoArrangeChanged(bool on) const;
     virtual bool requestWallpaperSetting(const QString &screen) const;
 };

--- a/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.cpp
@@ -304,7 +304,7 @@ WId CanvasView::winId() const
 
 void CanvasView::paintEvent(QPaintEvent *event)
 {
-    ViewPainter painter(d.get());
+    ViewPainter painter(d);
     painter.setRenderHint(QPainter::HighQualityAntialiasing);
 
     // debug网格信息展示
@@ -370,7 +370,7 @@ void CanvasView::startDrag(Qt::DropActions supportedActions)
         if (!data)
             return;
 
-        QPixmap pixmap = ViewPainter::polymerize(validIndexes, d.get());
+        QPixmap pixmap = ViewPainter::polymerize(validIndexes, d);
         QDrag *drag = new QDrag(this);
         drag->setPixmap(pixmap);
         drag->setMimeData(data);
@@ -727,9 +727,6 @@ void CanvasView::initUI()
     auto delegate = new CanvasItemDelegate(this);
     setItemDelegate(delegate);
     delegate->setIconLevel(DispalyIns->iconLevel());
-
-    // repaint when selecting with mouse move.
-    connect(qApp, &QApplication::fontChanged, this, &CanvasView::updateGrid);
 
     Q_ASSERT(selectionModel());
     d->operState().setView(this);

--- a/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.h
@@ -94,7 +94,7 @@ protected:
     void focusInEvent(QFocusEvent *event) override;
     void focusOutEvent(QFocusEvent *event) override;
 private:
-    QScopedPointer<CanvasViewPrivate> d;
+    CanvasViewPrivate *d;
 };
 
 }

--- a/src/plugins/desktop/ddplugin-organizer/interface/canvasmanagershell.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/interface/canvasmanagershell.cpp
@@ -32,11 +32,13 @@ CanvasManagerShell::CanvasManagerShell(QObject *parent)
 CanvasManagerShell::~CanvasManagerShell()
 {
     CanvasManagerUnsubscribe(signal_CanvasManager_IconSizeChanged, &CanvasManagerShell::iconSizeChanged);
+    CanvasManagerUnsubscribe(signal_CanvasManager_FontChanged, &CanvasManagerShell::fontChanged);
 }
 
 bool CanvasManagerShell::initialize()
 {
     CanvasManagerSubscribe(signal_CanvasManager_IconSizeChanged, &CanvasManagerShell::iconSizeChanged);
+    CanvasManagerSubscribe(signal_CanvasManager_FontChanged, &CanvasManagerShell::fontChanged);
     return true;
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/interface/canvasmanagershell.h
+++ b/src/plugins/desktop/ddplugin-organizer/interface/canvasmanagershell.h
@@ -24,6 +24,7 @@ public:
     void setIconLevel(const int level);
 signals:
     void iconSizeChanged(const int level);
+    void fontChanged();
 };
 
 }

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmode_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmode_p.h
@@ -34,6 +34,7 @@ public slots:
     void onClearSelection();
     void onDropFile(const QString &collection, QList<QUrl> &urls);
     void onIconSizeChanged();
+    void onFontChanged();
 public:
     void restore(const QList<CollectionBaseDataPtr> &cfgs);
     FileClassifier *classifier = nullptr;

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -239,6 +239,16 @@ void NormalizedModePrivate::onIconSizeChanged()
         q->layout();
 }
 
+void NormalizedModePrivate::onFontChanged()
+{
+    for (const CollectionHolderPointer &holder : holders.values()) {
+        auto view = holder->itemView();
+        view->updateRegionView();
+    }
+
+    q->layout();
+}
+
 void NormalizedModePrivate::restore(const QList<CollectionBaseDataPtr> &cfgs)
 {
     // order by config
@@ -303,6 +313,7 @@ bool NormalizedMode::initialize(CollectionModel *m)
     connect(FileOperatorIns, &FileOperator::requestDropFile, d, &NormalizedModePrivate::onDropFile, Qt::DirectConnection);
 
     connect(canvasManagerShell, &CanvasManagerShell::iconSizeChanged, d, &NormalizedModePrivate::onIconSizeChanged);
+    connect(canvasManagerShell, &CanvasManagerShell::fontChanged, d, &NormalizedModePrivate::onFontChanged);
 
     // must be DirectConnection to keep sequential
     connect(model, &CollectionModel::rowsInserted, this, &NormalizedMode::onFileInserted, Qt::DirectConnection);

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -85,15 +85,6 @@ void CollectionViewPrivate::initConnect()
     });
 }
 
-void CollectionViewPrivate::updateRegionView()
-{
-    q->itemDelegate()->updateItemSizeHint();
-    auto itemSize = q->itemDelegate()->sizeHint(QStyleOptionViewItem(), QModelIndex());
-
-    const QMargins viewMargin(kCollectionViewMargin, kCollectionViewMargin, kCollectionViewMargin, kCollectionViewMargin);
-    updateViewSizeData(q->geometry().size(), viewMargin, itemSize);
-}
-
 QList<QRect> CollectionViewPrivate::itemPaintGeomertys(const QModelIndex &index) const
 {
     if (Q_UNLIKELY(!index.isValid()))
@@ -1228,6 +1219,15 @@ WId CollectionView::winId() const
     }
 }
 
+void CollectionView::updateRegionView()
+{
+    itemDelegate()->updateItemSizeHint();
+    auto itemSize = itemDelegate()->sizeHint(QStyleOptionViewItem(), QModelIndex());
+
+    const QMargins viewMargin(kCollectionViewMargin, kCollectionViewMargin, kCollectionViewMargin, kCollectionViewMargin);
+    d->updateViewSizeData(geometry().size(), viewMargin, itemSize);
+}
+
 void CollectionView::openEditor(const QUrl &url)
 {
     QModelIndex index = model()->index(url);
@@ -1805,7 +1805,7 @@ void CollectionView::resizeEvent(QResizeEvent *event)
 {
     QAbstractItemView::resizeEvent(event);
 
-    d->updateRegionView();
+    updateRegionView();
 
     if (d->canUpdateVerticalBarRange) {
         d->updateVerticalBarRange();

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
@@ -41,6 +41,7 @@ public:
     CollectionItemDelegate *itemDelegate() const;
     CollectionDataProvider *dataProvider() const;
     WId winId() const;
+    void updateRegionView();
 
     void openEditor(const QUrl &url);
     void selectUrl(const QUrl &url, const QItemSelectionModel::SelectionFlag &flags);

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
@@ -28,7 +28,6 @@ public:
 
     void initUI();
     void initConnect();
-    void updateRegionView();
     void updateViewSizeData(const QSize &viewSize, const QMargins &viewMargins, const QSize &itemSize);
     void updateVerticalBarRange();
     QList<QRect> itemPaintGeomertys(const QModelIndex &index) const;

--- a/tests/plugins/desktop/core/ddplugin-canvas/view/ut_canvasview.cpp
+++ b/tests/plugins/desktop/core/ddplugin-canvas/view/ut_canvasview.cpp
@@ -129,7 +129,7 @@ class TestCanvasViewPrivate : public testing::Test
 {
 public:
     void SetUp() override {
-        cvp = view.d.data();
+        cvp = view.d;
         cvp->gridMargins = QMargins(2, 2, 2, 2);
         cvp->viewMargins = QMargins(5, 5, 5, 5);
         cvp->canvasInfo = CanvasViewPrivate::CanvasInfo(10, 10, 50, 50);
@@ -371,7 +371,7 @@ public:
         model->d->fileMap.insert(in1, info1);
         model->d->fileMap.insert(in2, info2);
 
-        cvp = view->d.data();
+        cvp = view->d;
         cvp->gridMargins = QMargins(2, 2, 2, 2);
         cvp->viewMargins = QMargins(5, 5, 5, 5);
         cvp->canvasInfo = CanvasViewPrivate::CanvasInfo(10, 10, 50, 50);

--- a/tests/plugins/desktop/ddplugin-organizer/view/ut_collectionview.cpp
+++ b/tests/plugins/desktop/ddplugin-organizer/view/ut_collectionview.cpp
@@ -672,7 +672,7 @@ TEST_F(TestCollectionView, updateRegionView)
         self->d->itemSizeHint = QSize(48, 48);
     });
 
-    view->d->updateRegionView();
+    view->updateRegionView();
     EXPECT_EQ(view->d->viewMargins, QMargins(6, 2, 6, 2));
     EXPECT_EQ(view->d->columnCount, 6);
     EXPECT_EQ(view->d->cellWidth, 48);


### PR DESCRIPTION
1. Canvas handles font changes uniformly to update grid.
2.  Send an event signal to notify the font change after the canvas finishes responding.
3. Collections receive signals to update line height and relayout.

Log: 

Bug: https://pms.uniontech.com/bug-view-227813.html