### PR TITLE
fix: [upgrade] file conflicts

### DIFF
--- a/debian/libdfm-extension.install
+++ b/debian/libdfm-extension.install
@@ -1,2 +1,1 @@
 usr/lib/*/libdfm-extension.so*
-usr/lib/*/dde-file-manager/plugins/extensions/.readme

--- a/src/dfm-extension/CMakeLists.txt
+++ b/src/dfm-extension/CMakeLists.txt
@@ -57,7 +57,3 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}.pc DESTINATION ${CMAKE_INS
 configure_file(${PROJECT_SOURCE_DIR}/assets/dev/${BIN_NAME}/${BIN_NAME}Config.cmake.in ${BIN_NAME}Config.cmake @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}Config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${BIN_NAME})
 
-# mkdir
-set(ASSERTS_DIR ../../assets)
-set(EXTENSIONS_LIB_DIR ${DFM_PLUGIN_DIR}/extensions)
-install(FILES ${ASSERTS_DIR}/.readme DESTINATION ${EXTENSIONS_LIB_DIR})


### PR DESCRIPTION
The `.readme` file comes from a different package in v5 and v6 and will cause oh upgrade to fail!

Log: fix upgrade problem