### PR TITLE
fix: Too many open files when creating thumbnails

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
@@ -150,9 +150,10 @@ void ThumbnailWorker::createThumbnail(const QUrl &url, Global::ThumbnailSize siz
     // check whether the file is stable
     // if not, rejoin the event queue and create thumbnail later
     if (!d->checkFileStable(url)) {
-        ThumbnailTaskMap taskMap { { url, size } };
-        QMetaObject::invokeMethod(this, "onTaskAdded", Qt::QueuedConnection,
-                                  Q_ARG(ThumbnailTaskMap, taskMap));
+        ThumbnailTaskMap taskMap { { d->originalUrl, size } };
+        QTimer::singleShot(2000, this, [taskMap, this] {
+            onTaskAdded(taskMap);
+        });
         return;
     }
 


### PR DESCRIPTION
When the file is unstable (the modification time is less than 2 seconds from the current time), the file is re-added to the thumbnail creation queue

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-227647.html
