### PR TITLE
禁用加密状态磁盘右键菜单的重命名选项

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.0.35) unstable; urgency=medium
+
+  * update file manager baseline version to V6.0.35
+  * 
+
+ -- xushitong <xushitong@uniontech.com>  Wed, 15 Nov 2023 20:40:51 +0800
+
 dde-file-manager (6.0.34) unstable; urgency=medium
 
   * baseline of feature disk encryption

--- a/src/plugins/filemanager/core/dfmplugin-computer/menu/computermenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/menu/computermenuscene.cpp
@@ -118,6 +118,8 @@ void ComputerMenuScene::updateState(QMenu *parent)
     case AbstractEntryFileEntity::kOrderSysDiskData:
     case AbstractEntryFileEntity::kOrderSysDisks:
         keeped = QStringList { kOpenInNewWin, kOpenInNewTab, kRename, kProperty };
+        if (!d->info->renamable())
+            disabled << kRename;
         break;
 
     case AbstractEntryFileEntity::kOrderRemovableDisks: {


### PR DESCRIPTION
while device is locked.

Log: fix issue.

Bug: https://pms.uniontech.com/bug-view-228469.html
