### PR TITLE
fix:  valid calls in the log is risky

### DIFF
--- a/src/plugins/desktop/core/ddplugin-core/core.cpp
+++ b/src/plugins/desktop/core/ddplugin-core/core.cpp
@@ -150,9 +150,13 @@ void Core::handleLoadPlugins(const QStringList &names)
         Q_ASSERT(qApp->thread() == QThread::currentThread());
         fmInfo() << "About to load plugin:" << name;
         auto plugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj(name) };
-        if (plugin)
-            fmInfo() << "Load result: " << DPF_NAMESPACE::LifeCycle::loadPlugin(plugin)
-                    << "State: " << plugin->pluginState();
+        if (plugin) {
+            bool ret = DPF_NAMESPACE::LifeCycle::loadPlugin(plugin);
+            if (ret)
+                fmInfo() << "lazy load State: " << plugin->pluginState();
+            else
+                fmCritical() << "fail to load plugin: " << plugin->pluginState();
+        }
     });
 }
 


### PR DESCRIPTION
The new logging framework ingores code calls, causing valid code to be removed from the logs.

Log: 

Bug: https://pms.uniontech.com/bug-view-229285.html