### PR TITLE
设备插入时按需刷新桌面

### DIFF
--- a/src/plugins/desktop/core/ddplugin-core/core.cpp
+++ b/src/plugins/desktop/core/ddplugin-core/core.cpp
@@ -78,8 +78,6 @@ void Core::initialize()
 
 bool Core::start()
 {
-    connectToServer();
-
     // 手动初始化application
     app = new DFMBASE_NAMESPACE::Application();
 
@@ -94,35 +92,6 @@ void Core::stop()
 
     delete app;
     app = nullptr;
-}
-
-void Core::connectToServer()
-{
-    if (!DevProxyMng->initService()) {
-        fmCritical() << "device manager cannot connect to server!";
-        DevMngIns->startMonitor();
-    }
-    auto refreshDesktop = [](const QString &msg) {
-        fmDebug() << "refresh desktop start..." << msg;
-        QDBusInterface ifs("com.deepin.dde.desktop",
-                           "/com/deepin/dde/desktop",
-                           "com.deepin.dde.desktop");
-        ifs.asyncCall("Refresh");
-        fmDebug() << "refresh desktop async finished..." << msg;
-    };
-    connect(DevProxyMng, &DeviceProxyManager::blockDevMounted, this, [refreshDesktop](const QString &, const QString &) {
-        refreshDesktop("onBlockDevMounted");
-    });
-
-    connect(DevProxyMng, &DeviceProxyManager::blockDevUnmounted, this, [refreshDesktop](const QString &, const QString &) {
-        refreshDesktop("onBlockDevUnmounted");
-    });
-
-    connect(DevProxyMng, &DeviceProxyManager::blockDevRemoved, this, [refreshDesktop](const QString &, const QString &) {
-        refreshDesktop("onBlockDevRemoved");
-    });
-
-    fmInfo() << "connectToServer finished";
 }
 
 void Core::onStart()

--- a/src/plugins/desktop/core/ddplugin-core/core.h
+++ b/src/plugins/desktop/core/ddplugin-core/core.h
@@ -66,7 +66,6 @@ public:
     virtual bool start() override;
     virtual void stop() override;
 
-    void connectToServer();
     Q_INVOKABLE void loadLazyPlugins();
 
 protected slots:
@@ -90,7 +89,7 @@ private:
     DPF_EVENT_REG_SIGNAL(signal_ScreenProxy_ScreenGeometryChanged)
     DPF_EVENT_REG_SIGNAL(signal_ScreenProxy_ScreenAvailableGeometryChanged)
 
-    //DPF_EVENT_REG_SLOT(slot_ScreenProxy_Instance)
+    // DPF_EVENT_REG_SLOT(slot_ScreenProxy_Instance)
     DPF_EVENT_REG_SLOT(slot_ScreenProxy_PrimaryScreen)
     DPF_EVENT_REG_SLOT(slot_ScreenProxy_Screens)
     DPF_EVENT_REG_SLOT(slot_ScreenProxy_LogicScreens)
@@ -109,7 +108,7 @@ private:
     DPF_EVENT_REG_SIGNAL(signal_DesktopFrame_GeometryChanged)
     DPF_EVENT_REG_SIGNAL(signal_DesktopFrame_AvailableGeometryChanged)
 
-    //DPF_EVENT_REG_SLOT(slot_DesktopFrame_Instance)
+    // DPF_EVENT_REG_SLOT(slot_DesktopFrame_Instance)
     DPF_EVENT_REG_SLOT(slot_DesktopFrame_RootWindows)
     DPF_EVENT_REG_SLOT(slot_DesktopFrame_LayoutWidget)
 };

--- a/src/plugins/server/core/serverplugin-core/devicemanagerdbus.h
+++ b/src/plugins/server/core/serverplugin-core/devicemanagerdbus.h
@@ -54,6 +54,7 @@ public slots:
 private:
     void initialize();
     void initConnection();
+    void requestRefreshDesktopAsNeeded(const QString &path, const QString &operation);
 };
 
 #endif   // DEVICEMANAGERDBUS_H


### PR DESCRIPTION
when block device (un)mounted or removed from host, refresh desktop only
if there has a link file in desktop and it's linked to file in the block
device.

Log: fix issue.

Bug: https://pms.uniontech.com/bug-view-215015.html
Change-Id: I5b899893a96fec9984fcd6326069fadd0aa49187
