### PR TITLE
fix: Repeatedly expanding the catalog may result in display errors

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -931,7 +931,7 @@ QList<QUrl> FileSortWorker::sortAllTreeFilesByParent(const QUrl &dir, const bool
         for (const auto &parent : depthParentUrls) {
             if (isCanceled)
                 return {};
-            if (!UniversalUtils::urlEquals(dir, parent) && UniversalUtils::isParentUrl(parent, dir))
+            if (!UniversalUtils::urlEquals(dir, parent) && !UniversalUtils::isParentUrl(parent, dir))
                 continue;
 
             auto sortList = bSort ? sortTreeFiles(visibleTreeChildren.take(parent), reverse) : visibleTreeChildren.value(parent);


### PR DESCRIPTION
When sorting, it reads that the parent directory has been reversed.

Log: Repeatedly expanding the catalog may result in display errors
Bug: https://pms.uniontech.com/bug-view-225837.html