### PR TITLE
fix: [filedialog] Startup process

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialoghandle.cpp
@@ -49,8 +49,6 @@ FileDialogHandle::FileDialogHandle(QWidget *parent)
         abort();
     }
     auto &&defaultPath { DFMBASE_NAMESPACE::StandardPaths::location(StandardPaths::kHomePath) };
-    // install all widgets before window showed
-    emit d_func()->dialog->aboutToOpen();
     d_func()->dialog->cd(QUrl::fromLocalFile(defaultPath));
 
     //! no need to hide, if the dialog is showed in creating, it must be bug.
@@ -567,6 +565,6 @@ void FileDialogHandle::setWindowStayOnTop()
         QFunctionPointer setWindowProperty = qApp->platformFunction("_d_setWindowProperty");
         // set window stay on top
         if (setWindowProperty && d->dialog)
-            reinterpret_cast<void(*)(QWindow *, const char *, const QVariant &)>(setWindowProperty)(d->dialog->windowHandle(), "_d_dwayland_staysontop", true);
+            reinterpret_cast<void (*)(QWindow *, const char *, const QVariant &)>(setWindowProperty)(d->dialog->windowHandle(), "_d_dwayland_staysontop", true);
     }
 }

--- a/src/plugins/filemanager/core/dfmplugin-core/core.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-core/core.cpp
@@ -4,6 +4,7 @@
 
 #include "core.h"
 #include "events/coreeventreceiver.h"
+#include "utils/corehelper.h"
 
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/base/application/application.h>
@@ -99,6 +100,12 @@ void Core::connectToServer()
 void Core::onAllPluginsInitialized()
 {
     fmInfo() << "All plugins initialized";
+    // createWindow may return an existing window, which does not need to be processed again aboutToOpen
+    connect(&FMWindowsIns, &FileManagerWindowsManager::windowCreated, this, [](quint64 id) {
+        auto window { FMWindowsIns.findWindowById(id) };
+        if (window)
+            window->installEventFilter(&CoreHelper::instance());
+    });
     // subscribe events
     dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl,
                                    CoreEventReceiver::instance(), &CoreEventReceiver::handleChangeUrl);

--- a/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
@@ -124,10 +124,7 @@ FileManagerWindow *CoreHelper::findExistsWindow(const QUrl &url)
 bool CoreHelper::eventFilter(QObject *watched, QEvent *event)
 {
     auto appName = qApp->applicationName();
-    Q_ASSERT(appName == "dde-file-manager" ||
-             appName == "dde-file-dialog" ||
-             appName == "dde-select-dialog-x11" ||
-             appName == "dde-select-dialog-wayland");
+    Q_ASSERT(appName == "dde-file-manager" || appName == "dde-file-dialog" || appName == "dde-select-dialog-x11" || appName == "dde-select-dialog-wayland");
 
     // Purpose does not filter any events
     constexpr bool ret { false };
@@ -170,10 +167,4 @@ bool CoreHelper::eventFilter(QObject *watched, QEvent *event)
 CoreHelper::CoreHelper(QObject *parent)
     : QObject(parent)
 {
-    // createWindow may return an existing window, which does not need to be processed again aboutToOpen
-    connect(&FMWindowsIns, &FileManagerWindowsManager::windowCreated, this, [this](quint64 id) {
-        auto window { FMWindowsIns.findWindowById(id) };
-        if (window)
-            window->installEventFilter(this);
-    });
 }


### PR DESCRIPTION
Keeping it consistent with filemanager, triggering `aboutToOpen` when drawing ensures that the window appears more quickly. And the judgment of the view mode is normal after the process change

Log: fix filedialog

Bug: https://pms.uniontech.com/bug-view-228321.html