### PR TITLE
perf: use `HighPerformanceMode` when launching dde-file-dialog

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/core.h
+++ b/src/plugins/filedialog/filedialogplugin-core/core.h
@@ -24,6 +24,7 @@ private slots:
     void onAllPluginsStarted();
     void bindScene(const QString &parentScene);
     void bindSceneOnAdded(const QString &newScene);
+    void enterHighPerformanceMode();
 
 private:
     QSet<QString> waitToBind;


### PR DESCRIPTION
Pull up the CPU frequency

Log: fieldialog launching performance