### PR TITLE
fix: CD-ROM drive opens for the first time with a sorting error

### DIFF
--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.h
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.h
@@ -8,6 +8,7 @@
 #include "dfmplugin_optical_global.h"
 
 #include <dfm-base/interfaces/abstractdiriterator.h>
+#include <dfm-io/denumerator.h>
 
 #include <QSet>
 
@@ -29,12 +30,13 @@ public:
     QUrl url() const override;
 
 private:
-    QSharedPointer<QDirIterator> discIterator;
-    QSharedPointer<QDirIterator> stagingIterator;
+    QSharedPointer<dfmio::DEnumerator> discIterator { nullptr };
+    QSharedPointer<dfmio::DEnumerator> stagingIterator { nullptr };
     QString mntPoint;
     QString devFile;
     QSet<QString> seen;
     QSet<QUrl> skip;
+    QUrl currentUrl;   // 当前迭代器所在位置文件的url
     QUrl changeScheme(const QUrl &in) const;
     QUrl changeSchemeUpdate(const QUrl &in);
 };

--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.cpp
@@ -27,6 +27,14 @@ MasteredMediaFileInfo::MasteredMediaFileInfo(const QUrl &url)
     setProxy(InfoFactory::create<FileInfo>(d->backerUrl));
 }
 
+MasteredMediaFileInfo::MasteredMediaFileInfo(const QUrl &url, const FileInfoPointer proxy)
+    : ProxyFileInfo(url), d(new MasteredMediaFileInfoPrivate(this))
+{
+    assert(!proxy.isNull());
+    d->backupInfo(url);
+    setProxy(proxy);
+}
+
 bool MasteredMediaFileInfo::exists() const
 {
     if (url.isEmpty())

--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediafileinfo.h
@@ -17,6 +17,7 @@ class MasteredMediaFileInfo : public DFMBASE_NAMESPACE::ProxyFileInfo
 
 public:
     explicit MasteredMediaFileInfo(const QUrl &url);
+    explicit MasteredMediaFileInfo(const QUrl &url, const FileInfoPointer proxy);
 
     bool exists() const override;
     virtual QString displayOf(const DisplayInfoType type) const override;


### PR DESCRIPTION
Create fileinfo for optical drive on first open, asynchronous fileinfo agent created in optical drive. The asynchronous optical drive agent fileinfo has not finished querying at the time of sorting, so the attribute is wrong. Modify to use dfmio's iterator to create an asynchronous fileinfo and get all the fileinfo properties when the optical drive iterator fetches the fileinfo.

Log: CD-ROM drive opens for the first time with a sorting error