### PR TITLE
修复加密设备卸载可能导致 server 崩溃的问题

### DIFF
--- a/src/dfm-base/base/device/private/devicehelper.cpp
+++ b/src/dfm-base/base/device/private/devicehelper.cpp
@@ -62,14 +62,14 @@ QVariantMap DeviceHelper::loadBlockInfo(const QString &id)
     auto dev = DeviceHelper::createBlockDevice(id);
     if (!dev) {
         qCWarning(logDFMBase) << "device is not exist!: " << id;
-        return {};
+        return QVariantMap();
     }
     return loadBlockInfo(dev);
 }
 
 QVariantMap DeviceHelper::loadBlockInfo(const BlockDevAutoPtr &dev)
 {
-    if (!dev) return {};
+    if (!dev) return QVariantMap();
 
     auto getNullStrIfNotValid = [&dev](Property p) {
         auto ret = dev->getProperty(p);

--- a/src/dfm-base/base/device/private/devicewatcher.cpp
+++ b/src/dfm-base/base/device/private/devicewatcher.cpp
@@ -304,6 +304,8 @@ void DeviceWatcher::onBlkDevFsRemoved(const QString &id)
     // this will not happen frequently
     if (!data.isEmpty())
         d->allBlockInfos.insert(id, data);
+    else
+        d->allBlockInfos.remove(id);
 
     emit DevMngIns->blockDevFsRemoved(id);
     using namespace GlobalServerDefines;
@@ -383,6 +385,8 @@ QVariantMap DeviceWatcher::getDevInfo(const QString &id, dfmmount::DeviceType ty
     if (type == DFMMOUNT::DeviceType::kBlockDevice) {
         if (reload) {
             QVariantMap newInfo = DeviceHelper::loadBlockInfo(id);
+            if (newInfo.isEmpty())
+                return QVariantMap();
             // Xust: fix issue that no device usage display when dfm launched
             // But I still don't understand what's being done here, maybe a more reasonable explanation is needed from xust
             bool isOptical { newInfo[DeviceProperty::kOpticalDrive].toBool() };
@@ -393,8 +397,7 @@ QVariantMap DeviceWatcher::getDevInfo(const QString &id, dfmmount::DeviceType ty
             }
             d->allBlockInfos.insert(id, newInfo);
         }
-
-        return d->allBlockInfos.value(id);
+        return d->allBlockInfos.value(id, QVariantMap());
     } else if (type == DFMMOUNT::DeviceType::kProtocolDevice) {
         if (reload) {
             const auto &&info = DeviceHelper::loadProtocolInfo(id);
@@ -402,7 +405,7 @@ QVariantMap DeviceWatcher::getDevInfo(const QString &id, dfmmount::DeviceType ty
                 d->allProtocolInfos.insert(id, DeviceHelper::loadProtocolInfo(id));
         }
 
-        return d->allProtocolInfos.value(id);
+        return d->allProtocolInfos.value(id, QVariantMap());
     }
     return QVariantMap();
 }

--- a/src/plugins/server/core/serverplugin-core/devicemanagerdbus.cpp
+++ b/src/plugins/server/core/serverplugin-core/devicemanagerdbus.cpp
@@ -80,7 +80,8 @@ void DeviceManagerDBus::initConnection()
     connect(DevMngIns, &DeviceManager::blockDevUnlocked, this, &DeviceManagerDBus::BlockDeviceUnlocked);
     connect(DevMngIns, &DeviceManager::blockDevLocked, this, &DeviceManagerDBus::BlockDeviceLocked);
     connect(DevMngIns, &DeviceManager::blockDevPropertyChanged, this, [this](const QString &id, const QString &property, const QVariant &val) {
-        emit this->BlockDevicePropertyChanged(id, property, QDBusVariant(val));
+        if (!val.isNull() && val.isValid())
+            emit this->BlockDevicePropertyChanged(id, property, QDBusVariant(val));
     });
 
     connect(DevMngIns, &DeviceManager::protocolDevMounted, this, &DeviceManagerDBus::ProtocolDeviceMounted);


### PR DESCRIPTION
as title.
an invalid QVariant is passed to DBus, DBus doesn't accept invalid
values and will abort when such a value passed in.

Log: fix server crash.
