### PR TITLE
fix: [iterator]Incomplete file display on burned CD-ROM drive

### DIFF
--- a/include/dfm-base/interfaces/abstractdiriterator.h
+++ b/include/dfm-base/interfaces/abstractdiriterator.h
@@ -43,7 +43,7 @@ public:
      *
      * \param
      *
-     * \return bool 返回是否还有下一个文件
+     * \return bool 返回是否还有下一个文件  hasnext 会跳转到下一个
      */
     virtual bool hasNext() const = 0;
     /*!

--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.cpp
@@ -67,7 +67,12 @@ QUrl MasteredMediaDirIterator::next()
 
 bool MasteredMediaDirIterator::hasNext() const
 {
-    return (discIterator && discIterator->hasNext()) || (stagingIterator && stagingIterator->hasNext());
+    // hasnext 会跳转到下一个
+    if (discIterator && discIterator->hasNext())
+        return true;
+    if (discIterator)
+        discIterator.reset(nullptr);
+    return stagingIterator && stagingIterator->hasNext();
 }
 
 QString MasteredMediaDirIterator::fileName() const

--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.h
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.h
@@ -30,7 +30,7 @@ public:
     QUrl url() const override;
 
 private:
-    QSharedPointer<dfmio::DEnumerator> discIterator { nullptr };
+    mutable QSharedPointer<dfmio::DEnumerator> discIterator { nullptr };
     QSharedPointer<dfmio::DEnumerator> stagingIterator { nullptr };
     QString mntPoint;
     QString devFile;


### PR DESCRIPTION
There is still a directory to be burned here in the CD-ROM drive that needs to be iterated over, modify the hasnext logic

Log: Incomplete file display on burned CD-ROM drive