### PR TITLE
fix: [drag]wayland wine app drag issue

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
@@ -484,6 +484,19 @@ bool DragDropOper::dropMimeData(QDropEvent *event) const
             }
         }
         return true;
+    } else if (WindowUtils::isWayLand()) {
+        // Bug-209635，wayland下wine应用拖拽时，QDragEvent中的action为Qt::IgnoreActon
+        // 当拖拽事件action无效时，判断文件来源，wine应用默认做CopyAction处理
+        QList<QUrl> urls = event->mimeData()->urls();
+
+        if (!urls.isEmpty()) {
+            const QUrl from = QUrl(urls.first());
+            if (!from.path().contains("/.deepinwine/"))
+                return false;
+            if (model->dropMimeData(event->mimeData(), Qt::CopyAction, targetIndex.row(), targetIndex.column(), targetIndex))
+                event->acceptProposedAction();
+            return true;
+        }
     }
     return false;
 }

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -881,6 +881,19 @@ bool CollectionViewPrivate::dropMimeData(QDropEvent *event) const
             }
         }
         return true;
+    } else if (WindowUtils::isWayLand()) {
+        // Bug-209635，wayland下wine应用拖拽时，QDragEvent中的action为Qt::IgnoreActon
+        // 当拖拽事件action无效时，判断文件来源，wine应用默认做CopyAction处理
+        QList<QUrl> urls = event->mimeData()->urls();
+
+        if (!urls.isEmpty()) {
+            const QUrl from = QUrl(urls.first());
+            if (!from.path().contains("/.deepinwine/"))
+                return false;
+            if (model->dropMimeData(event->mimeData(), Qt::CopyAction, targetIndex.row(), targetIndex.column(), targetIndex))
+                event->acceptProposedAction();
+            return true;
+        }
     }
     return false;
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -250,6 +250,18 @@ bool DragDropHelper::drop(QDropEvent *event)
             view->selectionModel()->clear();
             if (event->isAccepted())
                 return true;   // TODO (xust) this is a temp workaround.
+        } else if (WindowUtils::isWayLand()) {
+            // Bug-209635，wayland下wine应用拖拽时，QDragEvent中的action为Qt::IgnoreActon
+            // 当拖拽事件action无效时，判断文件来源，wine应用默认做CopyAction处理
+            QList<QUrl> urls = event->mimeData()->urls();
+
+            if (!urls.isEmpty()) {
+                const QUrl from = QUrl(urls.first());
+                if (from.path().contains("/.deepinwine/")
+                        && view->model()->dropMimeData(event->mimeData(), Qt::CopyAction, hoverIndex.row(), hoverIndex.column(), hoverIndex.parent())) {
+                    event->acceptProposedAction();
+                }
+            }
         }
     }
 


### PR DESCRIPTION
the drop event action is broken when dragging in wayland wine app. so make it worked as copy action.

Log: fix drag issue
Bug: https://pms.uniontech.com/bug-view-209635.html