### PR TITLE
fix: Change dbus interface of deepin control center

### DIFF
--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.cpp
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.cpp
@@ -15,16 +15,19 @@
 #    define BluetoothService "com.deepin.daemon.Bluetooth"
 #    define BluetoothPath "/com/deepin/daemon/Bluetooth"
 #    define BluetoothInterface "com.deepin.daemon.Bluetooth"
+#    define ControlcenterService "com.deepin.dde.ControlCenter"
+#    define ControlcenterPath "/com/deepin/dde/ControlCenter"
+#    define ControlcenterInterface "com.deepin.dde.ControlCenter"
 #else
 #    define BluetoothService "org.deepin.dde.Bluetooth1"
 #    define BluetoothPath "/org/deepin/dde/Bluetooth1"
 #    define BluetoothInterface "org.deepin.dde.Bluetooth1"
+#    define ControlcenterService "org.deepin.dde.ControlCenter1"
+#    define ControlcenterPath "org/deepin/dde/ControlCenter1"
+#    define ControlcenterInterface "org.deepin.dde.ControlCenter1"
 #endif
 
 #define BluetoothPage "bluetooth"
-#define ControlcenterService "com.deepin.dde.ControlCenter"
-#define ControlcenterPath "/com/deepin/dde/ControlCenter"
-#define ControlcenterInterface "com.deepin.dde.ControlCenter"
 
 using namespace dfmplugin_utils;
 

--- a/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.cpp
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.cpp
@@ -157,8 +157,8 @@ void EventHandle::show(QString name, int mode)
 #else
 bool EventHandle::wallpaperSetting(const QString &name)
 {
-    QDBusMessage msg = QDBusMessage::createMethodCall("com.deepin.dde.ControlCenter", "/com/deepin/dde/ControlCenter",
-                                   "com.deepin.dde.ControlCenter", "ShowPage");
+    QDBusMessage msg = QDBusMessage::createMethodCall("org.deepin.dde.ControlCenter1", "/org/deepin/dde/ControlCenter1",
+                                   "org.deepin.dde.ControlCenter1", "ShowPage");
     msg.setArguments({QVariant::fromValue(QString("personalization")), QVariant::fromValue(QString("WallpaperSetting"))});
     QDBusConnection::sessionBus().asyncCall(msg, 5);
     fmInfo() << "ControlCenter serivce called." << msg.service() << msg.arguments();
@@ -167,8 +167,8 @@ bool EventHandle::wallpaperSetting(const QString &name)
 
 bool EventHandle::screenSaverSetting(const QString &name)
 {
-    QDBusMessage msg = QDBusMessage::createMethodCall("com.deepin.dde.ControlCenter", "/com/deepin/dde/ControlCenter",
-                                   "com.deepin.dde.ControlCenter", "ShowPage");
+    QDBusMessage msg = QDBusMessage::createMethodCall("org.deepin.dde.ControlCenter1", "/org/deepin/dde/ControlCenter1",
+                                   "org.deepin.dde.ControlCenter1", "ShowPage");
     msg.setArguments({QVariant::fromValue(QString("personalization")), QVariant::fromValue(QString("ScreensaverSetting"))});
     QDBusConnection::sessionBus().asyncCall(msg, 5);
     fmInfo() << "ControlCenter serivce called." << msg.service() << msg.arguments();


### PR DESCRIPTION
Change dbus interface of deepin control center

Log: The dbus interface name was renamed to org.deepin.dde.ControlCenter1