### PR TITLE
fix: [disc] The capacity of the DVD+/-RW disc is displayed incorrectly

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -169,6 +169,10 @@ void DeviceManager::mountBlockDevAsync(const QString &id, const QVariantMap &opt
         }
 
         auto callback = [cb, id, this](bool ok, const OperationErrorInfo &err, const QString &mpt) {
+            // For DVD+RW/DVD-RW discs burned with PW,
+            // dfm-burn does not accurately get the capacity information,
+            // so it needs to be updated.
+            d->watcher->updateOpticalDevUsage(id, mpt);
             Q_EMIT this->blockDevMountResult(id, ok);
             if (ok)
                 Q_EMIT this->blockDevMountedManually(id, mpt);   // redundant: to notify deviceproxymanager update the cache.

--- a/src/dfm-base/base/device/private/devicewatcher.h
+++ b/src/dfm-base/base/device/private/devicewatcher.h
@@ -40,6 +40,8 @@ public:
     void initDevDatas();
 
     void queryOpticalDevUsage(const QString &id);
+    void updateOpticalDevUsage(const QString &id, const QString &mpt);
+    void saveOpticalDevUsage(const QString &id, const QVariantMap &data);
 
 private Q_SLOTS:
     void onBlkDevAdded(const QString &id);


### PR DESCRIPTION
For DVD+RW/DVD-RW discs burned, dfm-burn does not accurately get the capacity information, so it needs to be updated.

Log: fix disc bug

Bug: https://pms.uniontech.com/bug-view-230543.html