### PR TITLE
fix: Open trash in multiple windows without displaying files

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -719,7 +719,6 @@ void FileViewModel::updateThumbnailIcon(const QModelIndex &index, const QString 
 
 void FileViewModel::setTreeView(const bool isTree)
 {
-    FileDataManager::instance()->cleanRoot(rootUrl(), currentKey, false, false);
     Q_EMIT requestTreeView(isTree);
 }
 


### PR DESCRIPTION
When setting up the tree view, the iterator was turned off, but it is iterating. So the iteration cannot produce the file.

Log: Open trash in multiple windows without displaying files