### PR TITLE
fix: when dde-file-manager closed, session info would no be recorded

### DIFF
--- a/src/apps/dde-file-manager/sessionloader.cpp
+++ b/src/apps/dde-file-manager/sessionloader.cpp
@@ -149,7 +149,7 @@ void SessionBusiness::onWindowOpened(quint64 windId)
     auto window = FMWindowsIns.findWindowById(windId);
     Q_ASSERT_X(window, "WindowMonitor", "Cannot find window by id");
 
-    if (getAPI()->isInitialized()) {
+    if (!window->isHidden() && getAPI()->isInitialized()) {
         getAPI()->connectSM(window->winId());
         getAPI()->setWindowProperty(window->winId());
     }
@@ -160,5 +160,7 @@ void SessionBusiness::onCurrentUrlChanged(quint64 windId, const QUrl &url)
     auto window = FMWindowsIns.findWindowById(windId);
     Q_ASSERT_X(window, "WindowMonitor", "Cannot find window by id");
 
-    savePath(window->winId(), url.toString());
+    if (!window->isHidden()) {
+        savePath(window->winId(), url.toString());
+    }
 }


### PR DESCRIPTION
in dde-file-manager -d process, window is hidden

Log: when dde-file-manager closed, session info would no be recorded
Bug: https://pms.uniontech.com/bug-view-230871.html