### PR TITLE
修复全盘加密磁盘的逻辑卷组仍在计算机页面显示的问题

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/controller/computercontroller.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/controller/computercontroller.cpp
@@ -287,6 +287,14 @@ void ComputerController::mountDevice(quint64 winId, const DFMEntryFileInfoPointe
                 ComputerUtils::setCursorState();
 
                 if (ok) {
+                    auto clearDevUrl = ComputerUtils::makeBlockDevUrl(newId);
+                    EntryFileInfo clearDevInfo(clearDevUrl);
+                    if (clearDevInfo.extraProperty(DeviceProperty::kFileSystem).toString() == "LVM2_member") {
+                        ComputerItemWatcherInstance->removeDevice(ComputerUtils::makeBlockDevUrl(shellId));
+                        fmInfo() << "lvm group has been unlockded, remove it." << shellId << newId;
+                        return;
+                    }
+
                     this->mountDevice(winId, newId, shellId, act);
                 } else {
                     DialogManagerInstance->showErrorDialog(tr("Unlock device failed"), tr("Wrong password"));

--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -129,6 +129,14 @@ bool BlockEntryFileEntity::exists() const
         //        }
     }
 
+    if (isEncrypted) {
+        QVariantHash clearInfo = datas.value(BlockAdditionalProperty::kClearBlockProperty).toHash();
+        if (clearInfo.value(DeviceProperty::kFileSystem).toString() == "LVM2_member") {
+            fmInfo() << msg << "lvm group should not be displayed" << id;
+            return false;
+        }
+    }
+
     if (cryptoBackingDevice.length() > 1) {
         fmInfo() << msg << "decrypted cleartext device." << id;
         return false;


### PR DESCRIPTION
the disks are fully-encrypted, after unlocked on other host, the lvm
group still display in computer page, and it's not mountable, which
should be hidden. the INSTALLER make a udev rule to tag it as HintIgnore
so that computer page would not show that in it's original host, but
when the device is plugined in other host, the rule file is not exists
and the INSTALLER has no chance to update the rule file, dfm should hide
it by default.

Log: fix issue about lvm device display.

Bug: https://pms.uniontech.com/bug-view-231653.html
