### PR TITLE
fix: when Session recovery the first window, the path of the desktop first-level directory recovery is incorrect

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -289,6 +289,7 @@ void FileManagerWindow::installWorkSpace(AbstractFrame *w)
         d->workspace->setCurrentUrl(d->currentUrl);
         d->workspace->installEventFilter(this);
         emit this->workspaceInstallFinished();
+        emit currentUrlChanged(d->currentUrl);   // bug 233397
     });
 }
 


### PR DESCRIPTION
Send the currentUrlChanged signal when opening the directory for the
first time

Log: Send the currentUrlChanged signal when opening the directory for
the first time
Bug: https://pms.uniontech.com/bug-view-233397.html
