### PR TITLE
回滚上次提交内容

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -289,7 +289,6 @@ void FileManagerWindow::installWorkSpace(AbstractFrame *w)
         d->workspace->setCurrentUrl(d->currentUrl);
         d->workspace->installEventFilter(this);
         emit this->workspaceInstallFinished();
-        emit currentUrlChanged(d->currentUrl);   // bug 233397
     });
 }
 


### PR DESCRIPTION
- fix: when Session recovery the first window, the path of the desktop first-level directory recovery is incorrect
- fix: rollback last commit
