### PR TITLE
fix: Drag a large file to the system disk, but there is no prompt indicating insufficient disk space. The file manager crashes directly

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -151,6 +151,26 @@ bool DeviceProxyManager::isMptOfDevice(const QString &filePath, QString &id)
     return !id.isEmpty();
 }
 
+QVariantMap DeviceProxyManager::queryDeviceInfoByPath(const QString &path, bool reload)
+{
+    d->initMounts();
+    QString blkid, rootblkid;
+    for (auto it = d->allMounts.begin(); it != d->allMounts.end(); it++) {
+        if (it.value() == "/") {
+            rootblkid = it.key();
+            continue;
+        }
+        if (path.startsWith(it.value())
+                || (path + "/").startsWith(it.value())) {
+            blkid = it.key();
+            break;
+        }
+    }
+    if (blkid.isEmpty())
+        blkid = rootblkid;
+    return queryBlockInfo(blkid, reload);
+}
+
 DeviceProxyManager::DeviceProxyManager(QObject *parent)
     : QObject(parent), d(new DeviceProxyManagerPrivate(this, parent))
 {

--- a/src/dfm-base/base/device/deviceproxymanager.h
+++ b/src/dfm-base/base/device/deviceproxymanager.h
@@ -50,6 +50,7 @@ public:
     bool isFileOfExternalBlockMounts(const QString &filePath);
     bool isFileFromOptical(const QString &filePath);
     bool isMptOfDevice(const QString &filePath, QString &id);
+    QVariantMap queryDeviceInfoByPath(const QString &path, bool reload = false);
 
     // device signals
 Q_SIGNALS:

--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -77,6 +77,9 @@ public:
     static QString fileSystemType(const QUrl &url);
     static qint64 deviceBytesFree(const QUrl &url);
     static bool isUnmountSamba(const QUrl &url);
+    // If toDevice is true, convert the path to the device name
+    // otherwise convert the path to the mount point name
+    static QString bindPathTransform(const QString &path, bool toDevice);
 
 private:
     static bool hasMatch(const QString &txt, const QString &rex);

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1235,31 +1235,7 @@ QString FileUtils::nonExistFileName(FileInfoPointer fromInfo, FileInfoPointer ta
 
 QString FileUtils::bindPathTransform(const QString &path, bool toDevice)
 {
-    if (!path.startsWith("/") || path == "/")
-        return path;
-
-    const QMap<QString, QString> &table = DeviceUtils::fstabBindInfo();
-    if (table.isEmpty())
-        return path;
-
-    QString bindPath(path);
-    if (toDevice) {
-        for (const auto &mntPoint : table.values()) {
-            if (path.startsWith(mntPoint)) {
-                bindPath.replace(mntPoint, table.key(mntPoint));
-                break;
-            }
-        }
-    } else {
-        for (const auto &device : table.keys()) {
-            if (path.startsWith(device)) {
-                bindPath.replace(device, table[device]);
-                break;
-            }
-        }
-    }
-
-    return bindPath;
+    return DeviceUtils::bindPathTransform(path, toDevice);
 }
 
 int FileUtils::dirFfileCount(const QUrl &url)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -138,7 +138,7 @@ bool FileOperateBaseWorker::checkDiskSpaceAvailable(const QUrl &fromUrl,
     do {
         action = AbstractJobHandler::SupportAction::kNoAction;
 
-        qint64 freeBytes = DFMIO::DFMUtils::deviceBytesFree(targetOrgUrl);
+        qint64 freeBytes = DeviceUtils::deviceBytesFree(targetOrgUrl);
         action = AbstractJobHandler::SupportAction::kNoAction;
 
         if (FileOperationsUtils::isFilesSizeOutLimit(fromUrl, freeBytes))
@@ -192,6 +192,7 @@ bool FileOperateBaseWorker::checkTotalDiskSpaceAvailable(const QUrl &fromUrl, co
     do {
         action = AbstractJobHandler::SupportAction::kNoAction;
         qint64 freeBytes = DeviceUtils::deviceBytesFree(toUrl);
+        qInfo() << "current free bytes = " << freeBytes << ", write size = " << sourceFilesTotalSize;
         action = AbstractJobHandler::SupportAction::kNoAction;
         if (sourceFilesTotalSize >= freeBytes)
             action = doHandleErrorAndWait(fromUrl, toUrl, AbstractJobHandler::JobErrorType::kNotEnoughSpaceError);

--- a/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
@@ -106,10 +106,12 @@ FileManagerWindow *CoreHelper::createNewWindow(const QUrl &url)
 
 FileManagerWindow *CoreHelper::findExistsWindow(const QUrl &url)
 {
-    fmInfo() << "Find exists window for: " << url;
     auto window { FMWindowsIns.createWindow(url, false) };
-    if (window)
+
+    if (window) {
+        fmInfo() << "Find exists window for: " << url <<",for window:"<< window->winId();
         return window;
+    }
 
     fmWarning() << "Cannot find exists window for:" << url;
     auto oldWindow { defaultWindow() };


### PR DESCRIPTION

Check the disk space usage using the Gio interface. The space provided by Gio is sufficient, but in reality, it is not enough. Copying large files also uses mmap, so there will be no errors and crashes directly. Modify the unified device to obtain free space on the device

Log: Drag a large file to the system disk, but there is no prompt indicating insufficient disk space. The file manager crashes directly
Bug: https://pms.uniontech.com/bug-view-233019.html