### PR TITLE
fix: Use dde file manager to open multiple directories simultaneously and keep rotating in circles

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -178,17 +178,6 @@
             "permissions":"readwrite",
             "visibility":"private"
         },
-        "dfm.operate.bigfilesize": {
-            "value":"83886080",
-            "serial":0,
-            "flags":[],
-            "name":"Big File",
-            "name[zh_CN]":"大文件大小",
-            "description[zh_CN]":"用于拷贝时判断文件是否是大文件的size",
-            "description":"Size used to determine whether a file is a large file during copying",
-            "permissions":"readwrite",
-            "visibility":"private"
-        },
         "dfm.iterator.allasync": {
             "value":true,
             "serial":0,

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -92,6 +92,11 @@ void RootInfo::startWork(const QString &key, const bool getCache)
         return handleGetSourceData(key);
 
     traversaling = true;
+    {
+        QWriteLocker lk(&childrenLock);
+        childrenUrlList.clear();
+        sourceDataList.clear();
+    }
     traversalThreads.value(key)->traversalThread->start();
 }
 
@@ -275,7 +280,11 @@ void RootInfo::handleTraversalResults(const QList<FileInfoPointer> children, con
         if (!sortInfo)
             continue;
         sortInfos.append(sortInfo);
+
         infos.append(info);
+        QWriteLocker lk(&childrenLock);
+        this->childrenUrlList.append(info->fileUrl());
+        this->sourceDataList.append(sortInfo);
     }
 
     if (sortInfos.length() > 0)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -567,6 +567,11 @@ void FileSortWorker::handleAddChildren(const QString &key,
     if (!handleAddChildren(key, children, childInfos))
         return;
 
+    if (children.isEmpty() && handleSource) {
+        setSourceHandleState(isFinished);
+        return;
+    }
+
     // In the home, it is necessary to sort by display name.
     // So, using `sortAllFiles` to reorder
     auto parentUrl = parantUrl(children.first()->fileUrl());
@@ -597,8 +602,10 @@ bool FileSortWorker::handleAddChildren(const QString &key,
                                        const QList<SortInfoPointer> &children,
                                        const QList<FileInfoPointer> &childInfos)
 {
-    if (currentKey != key || isCanceled || children.isEmpty())
+    if (currentKey != key || isCanceled)
         return false;
+    if (children.isEmpty())
+        return true;
 
     // 获取相对于已有的新增加的文件
     QList<QUrl> newChildren;
@@ -636,7 +643,7 @@ bool FileSortWorker::handleAddChildren(const QString &key,
     depthMap.remove(depth - 1, parentUrl);
     depthMap.insertMulti(depth - 1, parentUrl);
     if (newChildren.isEmpty())
-        return false;
+        return true;
     insertVisibleChildren(startPos + posOffset, newChildren);
 
     return true;


### PR DESCRIPTION
When the iterator is iterating, other windows are retrieving the cache. There is an error in judging the retrieval here and it did not continue until the end of the iteration

Log: Use dde file manager to open multiple directories simultaneously and keep rotating in circles