### PR TITLE
fix: when Session recovery the first window, the path of the desktop …

### DIFF
--- a/include/dfm-base/widgets/filemanagerwindow.h
+++ b/include/dfm-base/widgets/filemanagerwindow.h
@@ -80,7 +80,6 @@ Q_SIGNALS:
 private:
     void initializeUi();
     void updateUi();
-    void initConnect();
 
 private:
     QScopedPointer<FileManagerWindowPrivate> d;

--- a/src/apps/dde-file-manager/sessionloader.cpp
+++ b/src/apps/dde-file-manager/sessionloader.cpp
@@ -123,14 +123,14 @@ void SessionBusiness::savePath(unsigned long long wid, const QString &path)
     QJsonDocument doc(jsonObj);
     QFile file(filePath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        qCWarning(logAppFileManager) << "Failed to write data:" << path << " to file:" << filePath;
+        qCWarning(logAppFileManager) << "Failed to write data:" << path << " to file:" << filePath << ",for window:" << wid;
         return;
     }
 
     file.write(doc.toJson());
     file.close();
 
-    qCInfo(logAppFileManager) << "done to write data:" << path << " to file:" << filePath;
+    qCInfo(logAppFileManager) << "done to write data:" << path << " to file:" << filePath << ",for window:" << wid;
 }
 
 bool SessionBusiness::readPath(const QString &fileName, QString *data)
@@ -183,7 +183,7 @@ void SessionBusiness::onWindowOpened(quint64 windId)
 
         getAPI()->connectSM(window->winId());
         getAPI()->setWindowProperty(window->winId());
-        qCInfo(logAppFileManager) << "update the arguments:" << arguments << ",to window:" << window->winId();
+        qCInfo(logAppFileManager) << "update the arguments:" << arguments << ",for window:" << window->winId();
     }
 }
 

--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -197,7 +197,6 @@ FileManagerWindow::FileManagerWindow(const QUrl &url, QWidget *parent)
       d(new FileManagerWindowPrivate(url, this))
 {
     initializeUi();
-    initConnect();
 }
 
 FileManagerWindow::~FileManagerWindow()
@@ -422,13 +421,6 @@ void FileManagerWindow::updateUi()
         int splitterPos = state.value("sidebar", d->kDefaultLeftWidth).toInt();
         d->setSplitterPosition(splitterPos);
     }
-}
-
-void FileManagerWindow::initConnect()
-{
-    connect(this, &FileManagerWindow::currentUrlChanged, this, [this](const QUrl &url) {
-        emit FMWindowsIns.currentUrlChanged(this->winId(), url);
-    });
 }
 
 }

--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindowsmanager.cpp
@@ -189,14 +189,19 @@ FileManagerWindowsManager::FMWindow *FileManagerWindowsManager::createWindow(con
         d->onWindowClosed(window);
     });
 
-    connect(window, &FileManagerWindow::aboutToOpen, this, [this, window]() {
+    connect(window, &FileManagerWindow::aboutToOpen, this, [this, window, url]() {
         auto &&id { window->internalWinId() };
         qCInfo(logDFMBase) << "Window showed" << id;
         emit windowOpened(id);
+        emit window->currentUrlChanged(url);   //The URL needs to notify the subscribers when the first window opened.
     });
 
     connect(window, &FileManagerWindow::reqShowHotkeyHelp, this, [this, window]() {
         d->onShowHotkeyHelp(window);
+    });
+
+    connect(window, &FileManagerWindow::currentUrlChanged, this, [this, window](const QUrl &url) {
+        emit currentUrlChanged(window->winId(), url);
     });
 
     // In order for the plugin to cache the current window (before the base frame is installed)
@@ -207,6 +212,7 @@ FileManagerWindowsManager::FMWindow *FileManagerWindowsManager::createWindow(con
     if (d->windows.size() == 1)
         window->moveCenter();
     emit windowCreated(window->internalWinId());
+
     finally.dismiss();
     return window;
 }


### PR DESCRIPTION
…first-level directory recovery is incorrect

Send the currentUrlChanged signal when opening the directory for the first time

Log: Send the currentUrlChanged signal when opening the directory for the first time
Bug: https://pms.uniontech.com/bug-view-233397.html