### PR TITLE
修复磁盘加密后的显示顺序问题；增加接口获取磁盘显示名称

### DIFF
--- a/src/dfm-base/base/device/private/devicehelper.cpp
+++ b/src/dfm-base/base/device/private/devicehelper.cpp
@@ -117,6 +117,7 @@ QVariantMap DeviceHelper::loadBlockInfo(const BlockDevAutoPtr &dev)
     datas[kCleartextDevice] = getNullStrIfNotValid(Property::kEncryptedCleartextDevice);
     datas[kConnectionBus] = getNullStrIfNotValid(Property::kDriveConnectionBus);
     datas[kDriveModel] = getNullStrIfNotValid(Property::kDriveModel);
+    datas[kPreferredDevice] = getNullStrIfNotValid(Property::kBlockPreferredDevice);
 
     if (dev->optical())
         datas[kUDisks2Size] = dev->sizeTotal();

--- a/src/dfm-base/dbusservice/global_server_defines.h
+++ b/src/dfm-base/dbusservice/global_server_defines.h
@@ -80,6 +80,7 @@ inline constexpr char kDeviceIcon[] { "DeviceIcon" };
 inline constexpr char kConnectionBus[] { "connectBus" };
 inline constexpr char kUDisks2Size[] { "UDisks2Size" };
 inline constexpr char kDriveModel[] { "DriveModel" };
+inline constexpr char kPreferredDevice[] { "PreferredDevice" };
 }   // namespace DeviceProperty
 
 /*!

--- a/src/dfm-base/file/entry/entryfileinfo.cpp
+++ b/src/dfm-base/file/entry/entryfileinfo.cpp
@@ -142,6 +142,16 @@ QString EntryFileInfo::nameOf(const NameInfoType type) const
     }
 }
 
+QString EntryFileInfo::displayOf(const DisplayInfoType type) const
+{
+    switch (type) {
+    case dfmbase::DisPlayInfoType::kFileDisplayName:
+        return displayName();
+    default:
+        return FileInfo::displayOf(type);
+    }
+}
+
 QString EntryFileInfo::pathOf(const PathInfoType type) const
 {
     QString path;

--- a/src/dfm-base/file/entry/entryfileinfo.h
+++ b/src/dfm-base/file/entry/entryfileinfo.h
@@ -37,6 +37,7 @@ public:
     // AbstractFileInfo interface
     virtual bool exists() const override;
     virtual QString nameOf(const FileNameInfoType type) const override;
+    virtual QString displayOf(const DisplayInfoType type) const override;
     virtual QString pathOf(const FilePathInfoType type) const override;
     virtual QIcon fileIcon() override;
     virtual void refresh() override;

--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -182,15 +182,20 @@ AbstractEntryFileEntity::EntryOrder BlockEntryFileEntity::order() const
     // NOTE(xust): removable/hintSystem is not always correct in some certain hardwares.
     if (datas.value(DeviceProperty::kMountPoint).toString() == "/")
         return AbstractEntryFileEntity::EntryOrder::kOrderSysDiskRoot;
+    auto clearInfo = datas.value(BlockAdditionalProperty::kClearBlockProperty, QVariantHash()).toHash();
+    if (clearInfo.value(DeviceProperty::kMountPoint, "").toString() == "/")
+        return AbstractEntryFileEntity::EntryOrder::kOrderSysDiskRoot;
 
-    bool canPowerOff = datas.value(DeviceProperty::kCanPowerOff).toBool();
-    if (datas.value(DeviceProperty::kIdLabel).toString().startsWith("_dde_data") /* && !canPowerOff*/)
+    if (datas.value(DeviceProperty::kIdLabel).toString().startsWith("_dde_data"))
         return AbstractEntryFileEntity::EntryOrder::kOrderSysDiskData;
+    if (clearInfo.value(DeviceProperty::kIdLabel, "").toString() == "_dde_data")
+        return AbstractEntryFileEntity::EntryOrder::kOrderSysDiskRoot;
 
     if (datas.value(DeviceProperty::kOptical).toBool()
         || datas.value(DeviceProperty::kOpticalDrive).toBool())
         return AbstractEntryFileEntity::EntryOrder::kOrderOptical;
 
+    bool canPowerOff = datas.value(DeviceProperty::kCanPowerOff).toBool();
     if (canPowerOff && !isSiblingOfRoot())
         return AbstractEntryFileEntity::EntryOrder::kOrderRemovableDisks;
 


### PR DESCRIPTION
root device display as rootA after encrypted;
add interface to obtain the display name of a disk;

Log: fix issue about device display

Bug: https://pms.uniontech.com/bug-view-232261.html
