### PR TITLE
修复系统盘、数据盘加密后的显示问题

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -117,9 +117,11 @@ QString DeviceUtils::convertSuitableDisplayName(const QVariantMap &devInfo)
     if (!alias.isEmpty())
         return alias;
 
+    QVariantMap clearInfo = devInfo.value(BlockAdditionalProperty::kClearBlockProperty).toMap();
+    QString mpt = clearInfo.value(kMountPoint, devInfo.value(kMountPoint).toString()).toString();
+    QString idLabel = clearInfo.value(kIdLabel, devInfo.value(kIdLabel).toString()).toString();
     // NOTE(xust): removable/hintSystem is not always correct in some certain hardwares.
-    if (devInfo.value(kMountPoint).toString() == "/"
-        || devInfo.value(kIdLabel).toString().startsWith("_dde_")) {
+    if (mpt == "/" || idLabel.startsWith("_dde_")) {
         return nameOfSystemDisk(devInfo);
     } else if (devInfo.value(kIsEncrypted).toBool()) {
         return nameOfEncrypted(devInfo);
@@ -362,15 +364,16 @@ QMap<QString, QString> DeviceUtils::fstabBindInfo()
 
 QString DeviceUtils::nameOfSystemDisk(const QVariantMap &datas)
 {
-    QString label = datas.value(kIdLabel).toString();
+    QVariantMap clearInfo = datas.value(BlockAdditionalProperty::kClearBlockProperty).toMap();
+
+    QString mountPoint = clearInfo.value(kMountPoint, datas.value(kMountPoint)).toString();
+    QString label = clearInfo.value(kIdLabel, datas.value(kIdLabel)).toString();
     qlonglong size = datas.value(kSizeTotal).toLongLong();
-    QString mountPoint = datas.value(kMountPoint).toString();
 
     // get system disk name if there is no alias
     if (mountPoint == "/")
         return QObject::tr("System Disk");
-    if (!mountPoint.startsWith("/media/"))
-    {
+    if (!mountPoint.startsWith("/media/")) {
         if (label.startsWith("_dde_data"))
             return QObject::tr("Data Disk");
         if (label.startsWith("_dde_"))
@@ -440,7 +443,8 @@ QString DeviceUtils::nameOfEncrypted(const QVariantMap &datas)
         qlonglong clearDevSize = clearDevData.value(kSizeTotal).toLongLong();
         return nameOfDefault(clearDevLabel, clearDevSize);
     } else {
-        return QObject::tr("%1 Encrypted").arg(nameOfSize(datas.value(kSizeTotal).toLongLong()));
+        return QObject::tr("%1 Encrypted")
+                .arg(nameOfSize(datas.value(kSizeTotal).toLongLong()));
     }
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -77,7 +77,6 @@ QIcon BlockEntryFileEntity::icon() const
     case DFMBASE_NAMESPACE::AbstractEntryFileEntity::EntryOrder::kOrderSysDiskRoot:
         return QIcon::fromTheme(IconName::kRootBlock);
     case DFMBASE_NAMESPACE::AbstractEntryFileEntity::EntryOrder::kOrderSysDiskData:
-        return QIcon::fromTheme(IconName::kInnerBlock);
     case DFMBASE_NAMESPACE::AbstractEntryFileEntity::EntryOrder::kOrderSysDisks:
         return isEncrypted
                 ? QIcon::fromTheme(IconName::kEncryptedInnerBlock)
@@ -189,7 +188,7 @@ AbstractEntryFileEntity::EntryOrder BlockEntryFileEntity::order() const
     if (datas.value(DeviceProperty::kIdLabel).toString().startsWith("_dde_data"))
         return AbstractEntryFileEntity::EntryOrder::kOrderSysDiskData;
     if (clearInfo.value(DeviceProperty::kIdLabel, "").toString() == "_dde_data")
-        return AbstractEntryFileEntity::EntryOrder::kOrderSysDiskRoot;
+        return AbstractEntryFileEntity::EntryOrder::kOrderSysDiskData;
 
     if (datas.value(DeviceProperty::kOptical).toBool()
         || datas.value(DeviceProperty::kOpticalDrive).toBool())


### PR DESCRIPTION
root device display as rootA after encrypted;
add interface to obtain the display name of a disk;

Log: fix issue about device display

Bug: https://pms.uniontech.com/bug-view-232261.html
