### PR TITLE
修复1070上dock插件高度问题

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/CMakeLists.txt
+++ b/src/external/dde-dock-plugins/disk-mount/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     ${DtkWidget_INCLUDE_DIRS}
     ${Gesttings_INCLUDE_DIRS}
     ${DdeDockInterface_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolwidget.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolwidget.cpp
@@ -104,6 +104,12 @@ void DiskControlWidget::removeWidgets()
     }
 }
 
+void DiskControlWidget::showEvent(QShowEvent *event)
+{
+    setFixedHeight(popWidHeight);
+    QScrollArea::showEvent(event);
+}
+
 void DiskControlWidget::paintUi()
 {
     QVBoxLayout *headerLay = new QVBoxLayout(this);
@@ -142,6 +148,7 @@ void DiskControlWidget::paintUi()
     const int maxHeight = std::min(contentHeight, 70 * 6);
     centralWidget->setFixedHeight(contentHeight);
     setFixedHeight(maxHeight);
+    popWidHeight = maxHeight;
 
     verticalScrollBar()->setPageStep(maxHeight);
     verticalScrollBar()->setMaximum(contentHeight - maxHeight);

--- a/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolwidget.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/diskcontrolwidget.h
@@ -26,6 +26,9 @@ public:
 signals:
     void diskCountChanged(const int count) const;
 
+protected:
+    void showEvent(QShowEvent *event) override;
+
 private slots:
     void onDiskListChanged();
     void onAskStopScanning(const QString &method, const QString &id);
@@ -51,6 +54,7 @@ private:
 private:
     QVBoxLayout *centralLayout { nullptr };
     QWidget *centralWidget { nullptr };
+    int popWidHeight { 0 };
 };
 
 #endif   // DISKCONTROLWIDGET_H


### PR DESCRIPTION
when upgrade to 1070, the dock pop widget's size is not correct, reason
is unknown, maybe dock has changed their code.
This is a workaround to make sure the dock plugin is sized properly
every time it is displayed.

Log: fix issue about dock plugin

Bug: https://pms.uniontech.com/bug-view-229237.html
Bug: https://pms.uniontech.com/bug-view-230009.html
