### PR TITLE
fix: do not refresh file info  with file cache on desktop

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/broker/canvasmodelbroker.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/broker/canvasmodelbroker.cpp
@@ -134,9 +134,9 @@ void CanvasModelBroker::sort()
     model->sort();
 }
 
-void CanvasModelBroker::refresh(bool global, int ms)
+void CanvasModelBroker::refresh(bool global, int ms, bool updateFile)
 {
-    model->refresh(model->rootIndex(), global, ms);
+    model->refresh(model->rootIndex(), global, ms, updateFile);
 }
 
 bool CanvasModelBroker::fetch(const QUrl &url)

--- a/src/plugins/desktop/core/ddplugin-canvas/broker/canvasmodelbroker.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/broker/canvasmodelbroker.h
@@ -37,7 +37,7 @@ public slots:
     int rowCount();
     QVariant data(const QUrl &url, int itemRole);
     void sort();
-    void refresh(bool global, int ms);
+    void refresh(bool global, int ms, bool updateFile = true);
     bool fetch(const QUrl &url);
     bool take(const QUrl &url);
 private:

--- a/src/plugins/desktop/core/ddplugin-canvas/canvasmanager.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/canvasmanager.cpp
@@ -432,8 +432,8 @@ void CanvasManagerPrivate::initSetting()
 {
     // setting changed.
     connect(Application::instance(), &Application::showedHiddenFilesChanged, this, &CanvasManagerPrivate::onHiddenFlagsChanged);
-    connect(Application::instance(), &Application::previewAttributeChanged, canvasModel, &CanvasProxyModel::update);
-    connect(Application::instance(), &Application::showedFileSuffixChanged, canvasModel, &CanvasProxyModel::update);
+    connect(Application::instance(), &Application::previewAttributeChanged, sourceModel, &FileInfoModel::refreshAllFile);
+    connect(Application::instance(), &Application::showedFileSuffixChanged, sourceModel, &FileInfoModel::refreshAllFile);
 }
 
 CanvasViewPointer CanvasManagerPrivate::createView(QWidget *root, int index)

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -743,10 +743,10 @@ QRect CanvasItemDelegate::paintIcon(QPainter *painter, const QIcon &icon,
 QRectF CanvasItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info)
 {
     // todo(zy) uing extend painter by registering.
-    if (!dpfSlotChannel->push("dfmplugin_emblem", "slot_FileEmblems_Paint", painter, rect, info).toBool()) {
+    if (dpfSlotChannel->push("dfmplugin_emblem", "slot_FileEmblems_Paint", painter, rect, info).toBool()) {
         static std::once_flag printLog;
         std::call_once(printLog, []() {
-            fmWarning() << "publish `kPaintEmblems` event failed!";
+            fmInfo() << "publish `kPaintEmblems` event successfully!";
         });
     }
     return rect;

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.cpp
@@ -400,14 +400,14 @@ bool CanvasProxyModelPrivate::doSort(QList<QUrl> &files) const
     return true;
 }
 
-void CanvasProxyModelPrivate::doRefresh(bool global, bool refreshFile)
+void CanvasProxyModelPrivate::doRefresh(bool global, bool updateFile)
 {
     if (global) {
         srcModel->refresh(srcModel->rootIndex());
     } else {
-        // refresh all file info
-        if (refreshFile) {
-            // do not emit data changed signal, just refresh file info.
+        // update all file info
+        if (updateFile) {
+            // do not emit data changed signal, just update file info.
             QSignalBlocker blocker(srcModel);
             srcModel->update();
         }
@@ -415,13 +415,6 @@ void CanvasProxyModelPrivate::doRefresh(bool global, bool refreshFile)
         // reset model
         sourceAboutToBeReset();
         sourceReset();
-
-        // refresh file info in canvas model
-        {
-            // do not emit data changed signal, just refresh file info.
-            QSignalBlocker blocker(q);
-            q->update();
-        }
     }
 }
 
@@ -829,19 +822,7 @@ bool CanvasProxyModel::sort()
     return true;
 }
 
-void CanvasProxyModel::update()
-{
-    fmInfo() << "update file info in model." << d->fileMap.size();
-    if (d->fileMap.isEmpty())
-        return;
-
-    for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor)
-        itor.value()->refresh();
-
-    emit dataChanged(createIndex(0, 0), createIndex(rowCount(rootIndex()) - 1, 0));
-}
-
-void CanvasProxyModel::refresh(const QModelIndex &parent, bool global, int ms, bool refreshFile)
+void CanvasProxyModel::refresh(const QModelIndex &parent, bool global, int ms, bool updateFile)
 {
     d->isNotMixDirAndFile = !Application::instance()->appAttribute(Application::kFileAndDirMixedSort).toBool();
 
@@ -852,12 +833,12 @@ void CanvasProxyModel::refresh(const QModelIndex &parent, bool global, int ms, b
         d->refreshTimer->stop();
 
     if (ms < 1) {
-        d->doRefresh(global, refreshFile);
+        d->doRefresh(global, updateFile);
     } else {
         d->refreshTimer.reset(new QTimer);
         d->refreshTimer->setSingleShot(true);
-        connect(d->refreshTimer.get(), &QTimer::timeout, this, [this, global, refreshFile]() {
-            d->doRefresh(global, refreshFile);
+        connect(d->refreshTimer.get(), &QTimer::timeout, this, [this, global, updateFile]() {
+            d->doRefresh(global, updateFile);
         });
 
         d->refreshTimer->start(ms);

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.h
@@ -57,8 +57,7 @@ signals:
     void dataReplaced(const QUrl &oldUrl, const QUrl &newUrl);
 public slots:
     bool sort();
-    void update();
-    void refresh(const QModelIndex &parent, bool global = false, int ms = 50, bool refreshFile = true);
+    void refresh(const QModelIndex &parent, bool global = false, int ms = 50, bool updateFile = true);
     void setShowHiddenFiles(bool show);
     bool fetch(const QUrl &url);   //show \a url if exsited
     bool take(const QUrl &url);   // hide \a url

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel_p.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel_p.h
@@ -28,7 +28,7 @@ public:
     bool doSort(QList<QUrl> &files) const;
     bool lessThan(const QUrl &left, const QUrl &right) const;
 public slots:
-    void doRefresh(bool global, bool refreshFile);
+    void doRefresh(bool global, bool updateFile);
     void sourceDataChanged(const QModelIndex &sourceTopleft,
                            const QModelIndex &sourceBottomright,
                            const QVector<int> &roles);

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
@@ -56,9 +56,6 @@ void FileInfoModelPrivate::resetData(const QList<QUrl> &urls)
     QMap<QUrl, FileInfoPointer> fileMaps;
     for (const QUrl &child : urls) {
         if (auto itemInfo = FileCreator->createFileInfo(child)) {
-            if (itemInfo->isAttributes(OptInfoType::kIsSymLink) &&
-                    !FileUtils::isLocalDevice(QUrl::fromLocalFile(itemInfo->pathOf(PathInfoType::kSymLinkTarget))))
-                itemInfo->updateAttributes();
             fileUrls.append(itemInfo->urlOf(UrlInfoType::kUrl));
             fileMaps.insert(itemInfo->urlOf(UrlInfoType::kUrl), itemInfo);
         }
@@ -378,7 +375,7 @@ int FileInfoModel::modelState() const
 void FileInfoModel::update()
 {
     for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor)
-        itor.value()->refresh();
+        itor.value()->updateAttributes();
 
     emit dataChanged(createIndex(0, 0), createIndex(rowCount(rootIndex()) - 1, 0));
 }
@@ -386,6 +383,14 @@ void FileInfoModel::update()
 void FileInfoModel::updateFile(const QUrl &url)
 {
     d->updateData(url);
+}
+
+void FileInfoModel::refreshAllFile()
+{
+    for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor)
+        itor.value()->refresh();
+
+    emit dataChanged(createIndex(0, 0), createIndex(rowCount(rootIndex()) - 1, 0));
 }
 
 QModelIndex FileInfoModel::parent(const QModelIndex &child) const

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.h
@@ -37,6 +37,7 @@ public:
     Q_INVOKABLE int modelState() const;   // 0 is uninitialized, 1 is ok, 2 is refreshing.
     Q_INVOKABLE void update();
     Q_INVOKABLE void updateFile(const QUrl &url);
+    Q_INVOKABLE void refreshAllFile();
 
 public:
     QModelIndex index(int row, int column = 0,

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
@@ -170,9 +170,18 @@ void FileProvider::preupdateData(const QUrl &url)
 {
     if (!url.isValid())
         return;
+
+    // check if there is cache
+    auto cachedInfo = InfoCacheController::instance().getCacheInfo(url);
+
     // file info that is slow at first using should be called there to cache it.
     auto info = InfoFactory::create<FileInfo>(url);
     if (updateing && info) {
+
+        // cached file need to refresh.
+        if (info == cachedInfo)
+            info->updateAttributes();
+
         // get file mime type for sorting.
         info->fileMimeType();
     }

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -769,10 +769,10 @@ QRect CollectionItemDelegate::paintIcon(QPainter *painter, const QIcon &icon,
 QRectF CollectionItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info)
 {
     // todo(zy) uing extend painter by registering.
-    if (!dpfSlotChannel->push("dfmplugin_emblem", "slot_FileEmblems_Paint", painter, rect, info).toBool()) {
+    if (dpfSlotChannel->push("dfmplugin_emblem", "slot_FileEmblems_Paint", painter, rect, info).toBool()) {
         static std::once_flag printLog;
         std::call_once(printLog, []() {
-            fmWarning() << "publish `kPaintEmblems` event failed!";
+            fmInfo() << "publish `kPaintEmblems` event successfully!";
         });
     }
     return rect;

--- a/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
@@ -131,7 +131,7 @@ void FrameManagerPrivate::refeshCanvas()
 {
     // refresh immediately to prevent show the files which is move to collection view.
     if (canvas)
-        canvas->canvasModel()->refresh(0);
+        canvas->canvasModel()->refresh(0, false);
 }
 
 void FrameManagerPrivate::enableChanged(bool e)

--- a/src/plugins/desktop/ddplugin-organizer/interface/canvasmodelshell.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/interface/canvasmodelshell.cpp
@@ -53,9 +53,9 @@ bool CanvasModelShell::initialize()
     return true;
 }
 
-void CanvasModelShell::refresh(int ms)
+void CanvasModelShell::refresh(int ms, bool updateFile)
 {
-    CanvasModelPush(slot_CanvasModel_Refresh, false, ms);
+    CanvasModelPush(slot_CanvasModel_Refresh, false, ms, updateFile);
 }
 
 bool CanvasModelShell::fetch(const QUrl &url)

--- a/src/plugins/desktop/ddplugin-organizer/interface/canvasmodelshell.h
+++ b/src/plugins/desktop/ddplugin-organizer/interface/canvasmodelshell.h
@@ -20,7 +20,7 @@ public:
     explicit CanvasModelShell(QObject *parent = nullptr);
     ~CanvasModelShell();
     bool initialize();
-    void refresh(int ms = 0);
+    void refresh(int ms = 0, bool updateFile = true);
     bool fetch(const QUrl &url);
     bool take(const QUrl &url);
 signals: // unqiue and direct signals


### PR DESCRIPTION
Since fileinfo cache is turn to on, the desktop will allways get cached file info when refreshing. It cause file data(like emblem etc.) do not be updated.

Log:
Bug: https://pms.uniontech.com/bug-view-234719.html