### PR TITLE
fix: After clicking "Restore Default" in the setting dialog, sometimes "Default View" will not sync

### DIFF
--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -67,6 +67,7 @@ SettingBackend::SettingBackend(QObject *parent)
 
     connect(Application::instance(), &Application::appAttributeEdited, this, &SettingBackend::onValueChanged);
     connect(Application::instance(), &Application::genericAttributeEdited, this, &SettingBackend::onValueChanged);
+    connect(this, &SettingBackend::optionSetted, this, &SettingBackend::onOptionSetted, Qt::QueuedConnection);
 
     initPresetSettingConfig();
 
@@ -175,7 +176,7 @@ void SettingBackend::removeSerialDataKey(const QString &key)
     d->serialDataKey.remove(key);
 }
 
-void SettingBackend::doSetOption(const QString &key, const QVariant &value)
+void SettingBackend::onOptionSetted(const QString &key, const QVariant &value)
 {
     if (d->serialDataKey.contains(key)) {
         d->saveAsAppAttr(key, value);
@@ -187,6 +188,11 @@ void SettingBackend::doSetOption(const QString &key, const QVariant &value)
         d->saveAsGenAttr(key, value);
         d->saveByFunc(key, value);
     }
+}
+
+void SettingBackend::doSetOption(const QString &key, const QVariant &value)
+{
+    Q_EMIT optionSetted(key, value);
 }
 
 void SettingBackend::onValueChanged(int attribute, const QVariant &value)

--- a/src/dfm-base/base/configs/settingbackend.h
+++ b/src/dfm-base/base/configs/settingbackend.h
@@ -38,6 +38,12 @@ public:
     void addToSerialDataKey(const QString &key);
     void removeSerialDataKey(const QString &key);
 
+Q_SIGNALS:
+    void optionSetted(const QString &key, const QVariant &value);
+
+public Q_SLOTS:
+    void onOptionSetted(const QString &key, const QVariant &value);
+
 protected:
     void doSetOption(const QString &key, const QVariant &value);
     void onValueChanged(int attribute, const QVariant &value);


### PR DESCRIPTION
Asynchronous setting error

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-226155.html
