### PR TITLE
fix: There are files with long file names in the safe, and the dd-file-manager is stuck when renaming

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -694,9 +694,10 @@ void IconItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) 
 
     bool showSuffix = Application::instance()->genericAttribute(Application::kShowedFileSuffix).toBool();
     const QString &filePath = index.data(kItemFilePathRole).toString();
+    const QString &filename = index.data(kItemNameRole).toString();
 
     // if file is in dlnfs' path, use char count rather than byte count to limit the filename length
-    if (DeviceUtils::isSubpathOfDlnfs(filePath))
+    if (DeviceUtils::isSubpathOfDlnfs(filePath) || filename.toLocal8Bit().length() > NAME_MAX)
         item->setCharCountLimit();
 
     QString suffix = index.data(kItemFileSuffixOfRenameRole).toString();


### PR DESCRIPTION
Inconsistent reading string length and setting whether it is a long file name

Log: There are files with long file names in the safe, and the dd-file-manager is stuck when renaming
Bug: https://pms.uniontech.com/bug-view-234987.html