### PR TITLE
fix: Trash, multiple options are grayed out in the right-click menu of the first level file search

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -418,7 +418,15 @@ bool FileUtils::isTrashFile(const QUrl &url)
 
 bool FileUtils::isTrashRootFile(const QUrl &url)
 {
-    return UniversalUtils::urlEquals(url, trashRootUrl());
+    if (UniversalUtils::urlEquals(url, trashRootUrl()))
+        return true;
+
+    if (UniversalUtils::urlEquals(url, QUrl::fromLocalFile(StandardPaths::location(StandardPaths::kTrashLocalFilesPath))))
+        return true;
+
+    const QString &rule = QString("/.Trash-%1/files").arg(getuid());
+
+    return url.toString().endsWith(rule);
 }
 
 bool FileUtils::isHigherHierarchy(const QUrl &urlBase, const QUrl &urlCompare)

--- a/src/plugins/filemanager/core/dfmplugin-trash/menus/trashmenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/menus/trashmenuscene.cpp
@@ -276,8 +276,11 @@ void TrashMenuScenePrivate::updateMenu(QMenu *menu)
 
             if (actId == TrashActionId::kRestore
                 || actId == dfmplugin_menu::ActionID::kDelete
-                || actId == dfmplugin_menu::ActionID::kCut)
-                act->setEnabled(FileUtils::isTrashRootFile(curDir));
+                || actId == dfmplugin_menu::ActionID::kCut) {
+                // 这还应该判断当前文件的父目录
+                auto fileurl = focusFileInfo->urlOf(UrlInfoType::kParentUrl);
+                act->setEnabled(FileUtils::isTrashRootFile(curDir) || FileUtils::isTrashRootFile(fileurl));
+            }
 
             if (actId == TrashActionId::kRestore)
                 actionRestore = act;


### PR DESCRIPTION
The files found in the first level directory of trash only determine whether the current display directory is trashroot, without determining whether the current parent is

Log: Trash, multiple options are grayed out in the right-click menu of the first level file search
Bug: https://pms.uniontech.com/bug-view-233067.html