### PR TITLE
fix: The number and size of trash attributes are incorrect

### DIFF
--- a/src/plugins/common/core/dfmplugin-trashcore/utils/trashcorehelper.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/utils/trashcorehelper.cpp
@@ -45,9 +45,13 @@ std::pair<qint64, int> TrashCoreHelper::calculateTrashRoot()
 {
     qint64 size = 0;
     int count = 0;
+    QList<QUrl> files;
     DFMIO::DEnumerator enumerator(FileUtils::trashRootUrl());
     while (enumerator.hasNext()) {
         const QUrl &urlNext = enumerator.next();
+        if (files.contains(FileUtils::bindUrlTransform(urlNext)))
+            continue;
+        files << FileUtils::bindUrlTransform(urlNext);
         ++count;
         FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(urlNext);
         if (!fileInfo)


### PR DESCRIPTION
There is no deduplication in the trace attribute statistics

Log: The number and size of trash attributes are incorrect
Bug: https://pms.uniontech.com/bug-view-235295.html