### PR TITLE
fix: [copy]Copying images from the phone to SMB without displaying them, requires refreshing before displaying them

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -977,9 +977,6 @@ QVariant AsyncFileInfoPrivate::attribute(DFileInfo::AttributeID key, bool *ok) c
         auto value = tmp->attribute(key, &getOk);
         if (ok)
             *ok = getOk;
-        if (!getOk)
-            qCWarning(logDFMBase) << static_cast<int>(key) << q->fileUrl() << tmp->lastError().errorMsg();
-
         return value;
     }
     return QVariant();

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -172,6 +172,8 @@ bool DoCopyFileWorker::doDfmioFileCopy(FileInfoPointer fromInfo, FileInfoPointer
 
     workData->everyFileWriteSize.remove(fromUrl);
     delete data;
+    if (toInfo->exists())
+        FileUtils::notifyFileChangeManual(DFMBASE_NAMESPACE::Global::FileNotifyType::kFileAdded, toInfo->urlOf(UrlInfoType::kUrl));
 
     return ret;
 }


### PR DESCRIPTION
I used g when copying on my phone_ File_ The copy function does not send file creation information on its own in SMB, but adds file creation information

Log: Copying images from the phone to SMB without displaying them, requires refreshing before displaying them
Bug: https://pms.uniontech.com/bug-view-235705.html