### PR TITLE
fix: [search] The shortcut key cannot be used to call out the search filtering view

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -60,8 +60,10 @@ void TitleBarWidget::stopSpinner()
 
 void TitleBarWidget::handleHotkeyCtrlF()
 {
-    if (searchButton->isVisible())
-        onSearchButtonClicked();
+    if (searchButtonSwitchState)
+        searchButton->setChecked(!searchButton->isChecked());
+
+    onSearchButtonClicked();
 }
 
 void TitleBarWidget::handleHotkeyCtrlL()

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -111,8 +111,8 @@ void Search::regSearchSettingConfig()
     if (!ret)
         fmWarning() << "cannot regist dconfig of search plugin:" << err;
 
+    SettingJsonGenerator::instance()->addGroup(SearchSettings::kGroupSearch, tr("Search"));
     if (SearchHelper::anythingInterface().isValid()) {
-        SettingJsonGenerator::instance()->addGroup(SearchSettings::kGroupSearch, tr("Search"));
         SettingJsonGenerator::instance()->addCheckBoxConfig(SearchSettings::kIndexInternal,
                                                             tr("Auto index internal disk"),
                                                             false);


### PR DESCRIPTION
as title

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-236227.html
