### PR TITLE
使用 ConnectionBus 字段辅助判定设备是否是系统盘

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -82,7 +82,7 @@ QStringList DeviceManager::getAllBlockDevID(DeviceQueryOptions opts)
             && !data.value(DeviceProperty::kOptical).toBool())
             continue;
         if (opts.testFlag(DeviceQueryOption::kSystem)
-            && !data.value(DeviceProperty::kHintSystem).toBool())
+            && (!data.value(DeviceProperty::kHintSystem).toBool() || data.value(DeviceProperty::kConnectionBus).toString() == "usb"))
             continue;
         if (opts.testFlag(DeviceQueryOption::kLoop)
             && !data.value(DeviceProperty::kIsLoopDevice).toBool())

--- a/src/dfm-base/dbusservice/global_server_defines.h
+++ b/src/dfm-base/dbusservice/global_server_defines.h
@@ -77,7 +77,7 @@ inline constexpr char kMediaCompatibility[] { "MediaCompatibility" };
 inline constexpr char kCleartextDevice[] { "CleartextDevice" };
 inline constexpr char kDisplayName[] { "DisplayName" };
 inline constexpr char kDeviceIcon[] { "DeviceIcon" };
-inline constexpr char kConnectionBus[] { "connectBus" };
+inline constexpr char kConnectionBus[] { "ConnectionBus" };
 inline constexpr char kUDisks2Size[] { "UDisks2Size" };
 inline constexpr char kDriveModel[] { "DriveModel" };
 inline constexpr char kPreferredDevice[] { "PreferredDevice" };


### PR DESCRIPTION
some SCSI controller has some error and cannot be fixed, cause some
inner disks are recognize as removable devices, and cannot be hidden by
'hide system disks' item.
use 'connectionBus' to help recognize if device is system disk.

Log: fix issue about device recognize.

Bug: https://pms.uniontech.com/bug-view-236747.html
