### PR TITLE
fix: Unable to drag tar.gz compressed file to USB drive

### DIFF
--- a/src/dfm-base/utils/infocache.cpp
+++ b/src/dfm-base/utils/infocache.cpp
@@ -151,6 +151,7 @@ void InfoCache::cacheInfo(const QUrl url, const FileInfoPointer info)
                     &InfoCache::removeCache);
             connect(watcher.data(), &AbstractFileWatcher::subfileCreated, this,
                     &InfoCache::refreshFileInfo);
+            watcher->startWatcher();
         }
         watcher->addCacheInfoConnectSize();
     }
@@ -277,7 +278,7 @@ void InfoCache::refreshFileInfo(const QUrl &url)
 {
     FileInfoPointer info = getCacheInfo(url);
     if (info)
-        info->refresh();
+        info->updateAttributes();
 }
 /*!
  * \brief timeRemoveCache 定时检查哪些fileinfo要移除


### PR DESCRIPTION
The first time a drag enters a fileino, create and cache it, modify permissions, and the infocache does not update the properties of the fileinfo. It does not start the monitor. Modifying the start monitor

Log: Unable to drag tar.gz compressed file to USB drive
Bug: https://pms.uniontech.com/bug-view-235885.html