### PR TITLE
fix: Unable to open pdf file by Okular

### DIFF
--- a/src/dfm-base/mimetype/mimesappsmanager.cpp
+++ b/src/dfm-base/mimetype/mimesappsmanager.cpp
@@ -483,6 +483,9 @@ void MimesAppsManager::initMimeTypeApps()
             it.next();
             const QString &filePath = it.filePath();
             DesktopFile desktopFile(filePath);
+            if (desktopFile.isNoShow())
+                continue;
+
             DesktopFiles.append(filePath);
             DesktopObjs.insert(filePath, desktopFile);
             QStringList mimeTypes = desktopFile.desktopMimeType();

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -743,10 +743,12 @@ bool FileOperationsEventReceiver::handleOperationOpenFilesByApp(const quint64 wi
         app = apps.at(0);
     }
     ok = fileHandler.openFilesByApp(urls, app);
-    if (!ok) {
-        error = fileHandler.errorString();
-        dialogManager->showErrorDialog("open file by app error", error);
-    }
+    if (!ok)
+        fmWarning() << "open file by app error: "
+                    << fileHandler.errorString()
+                    << " app name: "
+                    << app;
+
     // TODO:: file openFilesByApp finished need to send file openFilesByApp finished event
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kOpenFilesByAppResult, windowId, urls, ok, error);
     return ok;


### PR DESCRIPTION
If the `NoDisplay` field of the desktop file is set to `true`, it is not displayed in the open mode

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-230471.html
