### PR TITLE
fix: [admin] Unable to open directories containing blank spaces

### DIFF
--- a/src/apps/dde-file-manager/pkexec/com.deepin.pkexec.dde-file-manager.policy
+++ b/src/apps/dde-file-manager/pkexec/com.deepin.pkexec.dde-file-manager.policy
@@ -21,5 +21,20 @@
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/dde-file-manager</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
-
+  <action id="com.deepin.pkexec.dde-file-manager-pkexec">
+    <message>Authentication is required to view the folder</message>
+    <message xml:lang="zh_CN">查看文件夹需要输入密码</message>
+    <message xml:lang="zh_HK">查看文件夾需要輸入密碼</message>
+    <message xml:lang="zh_TW">查看資料夾需要輸入密碼</message>
+    <message xml:lang="ug">ھۆججەت قىسقۇچنى كۆرۈش ئۈچۈن پارول كىرگۈزۈشىڭىز كېرەك</message>
+    <message xml:lang="bo">ཡིག་ཁུག་ལ་ལྟ་བར་གསང་ཨང་འཇུག་དགོས།</message>
+    <icon_name>folder</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/dde-file-manager-pkexec</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
 </policyconfig>

--- a/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
+++ b/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
@@ -17,7 +17,8 @@ function run_pkexec() {
 
 function run_app() {
         echo "param in run_app: $@"
-        uid=$2
+        user_name=$(logname)
+        uid=$(id -u "$user_name")
         echo "runner uid: $uid"
         export XDG_RUNTIME_DIR=/run/user/$uid
         export WAYLAND_DISPLAY=wayland-0
@@ -28,7 +29,7 @@ function run_app() {
         export GDK_BACKEND=x11
         export $(dbus-launch)
 
-        dde-file-manager $1 -w `pwd`
+        dde-file-manager "$1" -w "$(pwd)"
 }
 
 echo "run dde-file-manager in $XDG_SESSION_TYPE"
@@ -36,11 +37,11 @@ if [ "$XDG_SESSION_TYPE" == "x11" ];then
         pkexec dde-file-manager "$@" -w `pwd`
 else
         echo "current file: $0"
-        if [ x`id -u` != "x0" ];then
-                run_pkexec $0 $@
+        if [ x$(id -u) != "x0" ];then
+                run_pkexec "$0" "$@"
                 exit 0
         fi
 
         echo "run app: $@"
-        run_app $@
+        run_app "$@"
 fi


### PR DESCRIPTION
Directories with blank spaces are incorrectly split

Log: fix open as admin

Bug: https://pms.uniontech.com/bug-view-236923.html