### PR TITLE
fix: The view switchover is incorrect when the password fails to be changed

### DIFF
--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
@@ -104,10 +104,10 @@ bool ExtendMenuScenePrivate::insertIntoExistedSubActions(QAction *action, QMap<Q
         actPos = subActions.count();
         subActions.append(action);
     } else {
-        auto iter = std::find_if(subActions.begin(), subActions.end(), [actPos](const QAction *act) {
+        auto iter = std::find_if(subActions.begin(), subActions.end(), [pos](const QAction *act) {
             bool ok = false;
             int p = act->property(kActionPosInMenu).toInt(&ok);
-            return !ok || p > actPos;
+            return !ok || p > pos;
         });
 
         if (iter == subActions.end()) {

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/dialogs/diskpasswordchangingdialog.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/dialogs/diskpasswordchangingdialog.cpp
@@ -48,28 +48,16 @@ void DiskPasswordChangingDialog::initConnect()
     connect(resultWidget, &DPCResultWidget::sigCloseDialog, this, &DiskPasswordChangingDialog::close);
 }
 
-void DiskPasswordChangingDialog::displayNextPage()
-{
-    Q_ASSERT(switchPageWidget);
-
-    int nIndex = switchPageWidget->currentIndex();
-    int nCount = switchPageWidget->count();
-
-    if (nIndex < nCount - 1) {
-        switchPageWidget->setCurrentIndex(++nIndex);
-    }
-}
-
 void DiskPasswordChangingDialog::onConfirmed()
 {
     DWindowManagerHelper::instance()->setMotifFunctions(windowHandle(), DWindowManagerHelper::FUNC_CLOSE, false);
     progressWidget->start();
-    displayNextPage();
+    switchPageWidget->setCurrentWidget(progressWidget);
 }
 
 void DiskPasswordChangingDialog::onChangeCompleted(bool success, const QString &msg)
 {
     DWindowManagerHelper::instance()->setMotifFunctions(windowHandle(), DWindowManagerHelper::FUNC_CLOSE, true);
     resultWidget->setResult(success, msg);
-    displayNextPage();
+    switchPageWidget->setCurrentWidget(resultWidget);
 }

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/dialogs/diskpasswordchangingdialog.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/dialogs/diskpasswordchangingdialog.h
@@ -30,7 +30,6 @@ public Q_SLOTS:
 private:
     void initUI();
     void initConnect();
-    void displayNextPage();
 
 private:
     DPCResultWidget *resultWidget { nullptr };


### PR DESCRIPTION
Should to switch to the error message view

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-236081.html
