### PR TITLE
fix: Copying a large number of empty files and folders on a USB drive causes the system to freeze

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/selecthelper.cpp
@@ -103,35 +103,31 @@ void SelectHelper::selection(const QRect &rect, QItemSelectionModel::SelectionFl
 
 void SelectHelper::select(const QList<QUrl> &urls)
 {
-    QList<QModelIndex> indexes {};
-    for (const QUrl &url : urls) {
-        const QModelIndex &index = view->model()->getIndexByUrl(url);
-        indexes << index;
-    }
+    if (urls.isEmpty())
+        return;
 
-    select(indexes);
-}
-
-void SelectHelper::select(const QList<QModelIndex> &indexes)
-{
     QModelIndex firstIndex;
     QModelIndex lastIndex;
-
     const QModelIndex &root = view->rootIndex();
     view->selectionModel()->clearSelection();
-    view->setCurrentIndex(QModelIndex());
-    for (const QModelIndex &index : indexes) {
+    QList<QModelIndex> indexes {};
+    QItemSelection selction;
+    for (const QUrl &url : urls) {
+        const QModelIndex &index = view->model()->getIndexByUrl(url);
+
         if (!index.isValid() || index == root) {
             continue;
         }
 
-        view->selectionModel()->select(index, QItemSelectionModel::Select);
+        selction.merge(QItemSelection(index,index), QItemSelectionModel::Select);
 
         if (!firstIndex.isValid())
             firstIndex = index;
 
         lastIndex = index;
     }
+
+    view->selectionModel()->select(selction, QItemSelectionModel::Select);
 
     if (lastIndex.isValid())
         view->selectionModel()->setCurrentIndex(lastIndex, QItemSelectionModel::Select);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/selecthelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/selecthelper.h
@@ -29,7 +29,6 @@ public:
     void setSelection(const QItemSelection &selection);
     void selection(const QRect &rect, QItemSelectionModel::SelectionFlags flags);
     void select(const QList<QUrl> &urls);
-    void select(const QList<QModelIndex> &indexes);
 
 private:
     void caculateSelection(const QRect &rect, QItemSelection *selection);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -347,7 +347,7 @@ QStringList WorkspaceHelper::getNameFilter(const quint64 windowId)
 
 void WorkspaceHelper::laterRequestSelectFiles(const QList<QUrl> &urls)
 {
-    QTimer::singleShot(qMax(urls.count() * (10 + urls.count() / 150), 200), this, [=] {
+    QTimer::singleShot(qMin(800, qMax(urls.count() * (10 + urls.count() / 150), 200)), this, [=] {
         emit requestSelectFiles(urls);
     });
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -609,11 +609,6 @@ void FileView::selectFiles(const QList<QUrl> &files) const
     d->selectHelper->select(files);
 }
 
-void FileView::selectIndexes(const QList<QModelIndex> &indexes) const
-{
-    d->selectHelper->select(indexes);
-}
-
 void FileView::setSelectionMode(const QAbstractItemView::SelectionMode mode)
 {
     if (d->enabledSelectionModes.contains(mode))
@@ -1925,17 +1920,8 @@ void FileView::updateSelectedUrl()
     if (d->preSelectionUrls.isEmpty() || model()->currentState() != ModelState::kIdle)
         return;
 
-    QList<QModelIndex> indexes {};
-    for (const QUrl &url : d->preSelectionUrls) {
-        const QModelIndex &index = model()->getIndexByUrl(url);
-        if (index.isValid())
-            indexes << index;
-    }
-
-    if (!indexes.isEmpty()) {
-        selectIndexes(indexes);
-        d->preSelectionUrls.clear();
-    }
+    selectFiles(d->preSelectionUrls);
+    d->preSelectionUrls.clear();
 }
 
 void FileView::updateListHeaderView()

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
@@ -78,7 +78,6 @@ public:
     bool isSelected(const QModelIndex &index) const;
     int selectedIndexCount() const;
     void selectFiles(const QList<QUrl> &files) const;
-    void selectIndexes(const QList<QModelIndex> &indexes) const;
     void setSelectionMode(const SelectionMode mode);
     void reverseSelect() const;
     void setEnabledSelectionModes(const QList<SelectionMode> &modes);


### PR DESCRIPTION
It is because the efficiency of selecting a large number of files is low, and inserting items at this time will cause all events of QT to freeze.

Log: Copying a large number of empty files and folders on a USB drive causes the system to freeze
Bug: https://pms.uniontech.com/bug-view-236699.html