### PR TITLE
fix: Copying a large number of empty files and folders on the USB drive, with incorrect progress bar statistics

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -407,7 +407,7 @@ void FileStatisticsJob::setSizeInfo()
 {
     d->sizeInfo->fileCount = static_cast<quint32>(d->filesCount);
     d->sizeInfo->totalSize = d->totalProgressSize;
-    d->sizeInfo->dirSize = d->sizeInfo->dirSize == 0 ? FileUtils::getMemoryPageSize() : d->sizeInfo->dirSize;
+    d->sizeInfo->dirSize = FileUtils::getMemoryPageSize();
 }
 
 void FileStatisticsJob::statistcsOtherFileSystem()
@@ -466,12 +466,6 @@ void FileStatisticsJob::statistcsOtherFileSystem()
             }
 
             if (info->isAttributes(OptInfoType::kIsDir)) {
-                if (d->sizeInfo->dirSize == 0) {
-                    struct stat statInfo;
-
-                    if (0 == stat(info->urlOf(UrlInfoType::kUrl).path().toStdString().data(), &statInfo))
-                        d->sizeInfo->dirSize = statInfo.st_size == 0 ? FileUtils::getMemoryPageSize() : static_cast<quint16>(statInfo.st_size);
-                }
                 directory_queue << url;
             }
         }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1152,7 +1152,7 @@ bool FileOperateBaseWorker::doCopyFile(const FileInfoPointer &fromInfo, const Fi
     } else if (fromInfo->isAttributes(OptInfoType::kIsDir)) {
         result = checkAndCopyDir(fromInfo, newTargetInfo, skip);
         if (result || skip)
-            workData->zeroOrlinkOrDirWriteSize += workData->dirSize;
+            workData->zeroOrlinkOrDirWriteSize += workData->dirSize <= 0 ? FileUtils::getMemoryPageSize() : workData->dirSize;
     } else {
         result = checkAndCopyFile(fromInfo, newTargetInfo, skip);
     }
@@ -1324,7 +1324,8 @@ void FileOperateBaseWorker::determineCountProcessType()
 
                         if (targetIsRemovable) {
                             workData->exBlockSyncEveryWrite = FileOperationsUtils::blockSync();
-                            countWriteType = workData->exBlockSyncEveryWrite ? CountWriteSizeType::kCustomizeType : CountWriteSizeType::kWriteBlockType;
+                            countWriteType = workData->exBlockSyncEveryWrite ? CountWriteSizeType::kCustomizeType
+                                                                             : CountWriteSizeType::kCustomizeType;
                             targetDeviceStartSectorsWritten = workData->exBlockSyncEveryWrite ? 0 : getSectorsWritten();
 
                             workData->isBlockDevice = true;


### PR DESCRIPTION
The reason for the inaccurate data statistics here is that we calculated the size of the directory as 4096, but in the write statistics of the USB drive, we calculated the size by reading and writing how many block blocks were written. The size of the directory and the 0kb file were calculated as a numerical value in the USB drive, which caused our own calculated values to not match. When modifying the statistics size, we are copying thread blocking statistics and then using our own statistics method.

Log: Copying a large number of empty files and folders on the USB drive, with incorrect progress bar statistics
Bug: https://pms.uniontech.com/bug-view-236707.html