### PR TITLE
fix: Vault monitor failure

### DIFF
--- a/src/dfm-base/utils/infocache.cpp
+++ b/src/dfm-base/utils/infocache.cpp
@@ -139,22 +139,25 @@ void InfoCache::cacheInfo(const QUrl url, const FileInfoPointer info)
             return;
     }
 
-    //获取监视器，监听当前的file的改变
-    QSharedPointer<AbstractFileWatcher> watcher { nullptr };
-    watcher = WatcherFactory::create<AbstractFileWatcher>(UrlRoute::urlParent(url));
-    if (watcher) {
-        if (watcher->getCacheInfoConnectSize() == 0) {
-            connect(watcher.data(), &AbstractFileWatcher::fileDeleted, this, &InfoCache::removeCache);
-            connect(watcher.data(), &AbstractFileWatcher::fileAttributeChanged, this,
-                    &InfoCache::refreshFileInfo);
-            connect(watcher.data(), &AbstractFileWatcher::fileRename, this,
-                    &InfoCache::removeCache);
-            connect(watcher.data(), &AbstractFileWatcher::subfileCreated, this,
-                    &InfoCache::refreshFileInfo);
-            watcher->startWatcher();
+    //获取监视器，监听当前的file的改变 当没有缓存加入监视器后，这里的watcher就会析构，如果启动了就要停止监控，这个是代理
+    // 代理就将启动的缓存了监视关闭了。本来没有缓存的监视器监视就没有意义
+    if (!WatcherCache::instance().cacheDisable(url.scheme())) {
+        auto watcher = WatcherFactory::create<AbstractFileWatcher>(UrlRoute::urlParent(url));
+        if (watcher) {
+            if (watcher->getCacheInfoConnectSize() == 0) {
+                connect(watcher.data(), &AbstractFileWatcher::fileDeleted, this, &InfoCache::removeCache);
+                connect(watcher.data(), &AbstractFileWatcher::fileAttributeChanged, this,
+                        &InfoCache::refreshFileInfo);
+                connect(watcher.data(), &AbstractFileWatcher::fileRename, this,
+                        &InfoCache::removeCache);
+                connect(watcher.data(), &AbstractFileWatcher::subfileCreated, this,
+                        &InfoCache::refreshFileInfo);
+                    watcher->startWatcher();
+            }
+            watcher->addCacheInfoConnectSize();
         }
-        watcher->addCacheInfoConnectSize();
     }
+
 
     // 插入到主和副的所有缓存中
     d->status = kCacheCopy;


### PR DESCRIPTION
The scheme file monitor of dfmvault will not be added to the cache, so it is started here, and the monitoring of the agent will be stopped during subsequent deconstruction. Modify items that have not been added to the cache and do not monitor them

Log: Vault monitor failure