### PR TITLE
fix: The gear icon is displayed on the USB flash drive when deleting files to the trash

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -1137,6 +1137,10 @@ int AsyncFileInfoPrivate::cacheAllAttributes()
     tmp.insert(FileInfo::FileInfoAttributeID::kStandardIcon, attribute(DFileInfo::AttributeID::kStandardIcon));
     tmp.insert(FileInfo::FileInfoAttributeID::kStandardIsLocalDevice, FileUtils::isLocalDevice(q->fileUrl()));
     tmp.insert(FileInfo::FileInfoAttributeID::kStandardIsCdRomDevice, FileUtils::isCdRomDevice(q->fileUrl()));
+    if (q->nameOf(NameInfoType::kIconName) != attribute(DFileInfo::AttributeID::kStandardIcon)) {
+        QWriteLocker rlk(&iconLock);
+        fileIcon = QIcon();
+    }
     if (cacheTmp.isEmpty()) {
         {
             QWriteLocker lk(&lock);

--- a/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
+++ b/src/plugins/common/core/dfmplugin-trashcore/trashfileinfo.cpp
@@ -432,6 +432,9 @@ QVariant TrashFileInfo::customData(int role) const
         return urlOf(UrlInfoType::kOriginalUrl).path();
     else if (role == kItemFileDeletionDate)
         return d->deletionTime().toString(FileUtils::dateTimeFormat());
+    else if (role == Global::ItemRoles::kItemFileRefreshIcon){
+        return ProxyFileInfo::customData(role);
+    }
     else
         return QVariant();
 }


### PR DESCRIPTION
The customData of trashfileinfo does not implement kitemFileRefreshIcon. Add an implementation to clean up the fileicon when comparing iconname inconsistencies when caching properties in asyncfileinfo

Log: The gear icon is displayed on the USB flash drive when deleting files to the trash
Bug: https://pms.uniontech.com/bug-view-237591.html