### PR TITLE
fix: [search] In x-wayland, the search UI show error.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
@@ -258,7 +258,6 @@ void AddressBarPrivate::doComplete()
         completerView->setCurrentIndex(urlCompleter->completionModel()->index(0, 0));
     }
     completerView->show();
-    completerView->activateWindow();
 
     return;
 }
@@ -512,7 +511,7 @@ void AddressBarPrivate::updateIndicatorIcon()
 void AddressBarPrivate::onCompletionModelCountChanged()
 {
     if (urlCompleter->completionCount() <= 0) {
-        completerView->hide();
+        completerView->resize(0, 0);
         q->setFocus();
         return;
     }


### PR DESCRIPTION
Question:
    when the search completion count equal 0, the addressbar  hide.
Cause:
    In x-wayland, if the set window active, the focus event will be call when hide the window.
Solution:
    Don't set active the window and use resize.