### PR TITLE
fix: Copying a large number of files within the vault caused the dde-file-manager to lag

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
@@ -29,7 +29,7 @@ QString ThumbnailWorkerPrivate::createThumbnail(const QUrl &url, Global::Thumbna
         return "";
 
     if (!thumbHelper.canGenerateThumbnail(url)) {
-        qCWarning(logDFMBase) << "thumbnail: the file does not support generate thumbnails: " << url;
+        qCDebug(logDFMBase) << "thumbnail: the file does not support generate thumbnails: " << url;
         return "";
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -169,6 +169,7 @@ void FileViewModel::doExpand(const QModelIndex &index)
     connect(expandRoot, &RootInfo::watcherAddFiles, filterSortWorker.data(), &FileSortWorker::handleWatcherAddChildren, Qt::QueuedConnection);
     connect(expandRoot, &RootInfo::watcherRemoveFiles, filterSortWorker.data(), &FileSortWorker::handleWatcherRemoveChildren, Qt::QueuedConnection);
     connect(expandRoot, &RootInfo::watcherUpdateFile, filterSortWorker.data(), &FileSortWorker::handleWatcherUpdateFile, Qt::QueuedConnection);
+    connect(expandRoot, &RootInfo::watcherUpdateFiles, filterSortWorker.data(), &FileSortWorker::handleWatcherUpdateFiles, Qt::QueuedConnection);
     connect(expandRoot, &RootInfo::watcherUpdateHideFile, filterSortWorker.data(), &FileSortWorker::handleWatcherUpdateHideFile, Qt::QueuedConnection);
     connect(expandRoot, &RootInfo::traversalFinished, filterSortWorker.data(), &FileSortWorker::handleTraversalFinish, Qt::QueuedConnection);
     connect(expandRoot, &RootInfo::requestSort, filterSortWorker.data(), &FileSortWorker::handleSortDir, Qt::QueuedConnection);
@@ -846,6 +847,7 @@ void FileViewModel::connectRootAndFilterSortWork(const RootInfo *root)
     connect(root, &RootInfo::watcherAddFiles, filterSortWorker.data(), &FileSortWorker::handleWatcherAddChildren, Qt::QueuedConnection);
     connect(root, &RootInfo::watcherRemoveFiles, filterSortWorker.data(), &FileSortWorker::handleWatcherRemoveChildren, Qt::QueuedConnection);
     connect(root, &RootInfo::watcherUpdateFile, filterSortWorker.data(), &FileSortWorker::handleWatcherUpdateFile, Qt::QueuedConnection);
+    connect(root, &RootInfo::watcherUpdateFiles, filterSortWorker.data(), &FileSortWorker::handleWatcherUpdateFiles, Qt::QueuedConnection);
     connect(root, &RootInfo::watcherUpdateHideFile, filterSortWorker.data(), &FileSortWorker::handleWatcherUpdateHideFile, Qt::QueuedConnection);
     connect(root, &RootInfo::traversalFinished, filterSortWorker.data(), &FileSortWorker::handleTraversalFinish, Qt::QueuedConnection);
     connect(root, &RootInfo::requestSort, filterSortWorker.data(), &FileSortWorker::handleSortDir, Qt::QueuedConnection);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -51,7 +51,6 @@ public:
     void reset();
 
 Q_SIGNALS:
-    void childrenUpdate(const QUrl &url);
 
     void itemAdded();
     void iteratorLocalFiles(const QString &key,
@@ -61,8 +60,8 @@ Q_SIGNALS:
                             const bool isMixDirAndFile);
     void iteratorAddFile(const QString &key, const SortInfoPointer sortInfo, const FileInfoPointer info);
     void iteratorAddFiles(const QString &key, const QList<SortInfoPointer> sortInfos, const QList<FileInfoPointer> infos);
-    void watcherAddFiles(const QList<SortInfoPointer> children);
-    void watcherRemoveFiles(const QList<SortInfoPointer> children);
+    void watcherAddFiles(const QList<SortInfoPointer> &children);
+    void watcherRemoveFiles(const QList<SortInfoPointer> &children);
     void traversalFinished(const QString &key);
     void sourceDatas(const QString &key,
                      const QList<SortInfoPointer> children,
@@ -71,6 +70,7 @@ Q_SIGNALS:
                      const bool isMixDirAndFile,
                      const bool isFinished);
     void watcherUpdateFile(const SortInfoPointer sortInfo);
+    void watcherUpdateFiles(const QList<SortInfoPointer> &sortInfos);
     void watcherUpdateHideFile(const QUrl &hidUrl);
     void requestSort(const QString &key, const QUrl &dirUrl);
     void requestCloseTab(const QUrl &url);
@@ -108,7 +108,8 @@ private:
     SortInfoPointer sortFileInfo(const FileInfoPointer &info);
     void removeChildren(const QList<QUrl> &urlList);
     bool containsChild(const QUrl &url);
-    void updateChild(const QUrl &url);
+    SortInfoPointer updateChild(const QUrl &url);
+    void updateChildren(const QList<QUrl> &urls);
 
     bool checkFileEventQueue();
     void enqueueEvent(const QPair<QUrl, EventType> &e);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -271,7 +271,7 @@ void FileSortWorker::onShowHiddenFileChanged(bool isShow)
     handleFilters(newFilters);
 }
 
-void FileSortWorker::handleWatcherAddChildren(const QList<SortInfoPointer> children)
+void FileSortWorker::handleWatcherAddChildren(const QList<SortInfoPointer> &children)
 {
     for (const auto &sortInfo : children) {
         if (isCanceled)
@@ -363,6 +363,15 @@ void FileSortWorker::handleWatcherUpdateFile(const SortInfoPointer child)
     sortInfoUpdateByFileInfo(info);
 
     handleUpdateFile(child->fileUrl());
+}
+
+void FileSortWorker::handleWatcherUpdateFiles(const QList<SortInfoPointer> &children)
+{
+    for(auto sort : children) {
+        if (isCanceled)
+            return;
+        handleWatcherUpdateFile(sort);
+    }
 }
 
 void FileSortWorker::handleWatcherUpdateHideFile(const QUrl &hidUrl)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -113,9 +113,10 @@ public slots:
     void onToggleHiddenFiles();
     void onShowHiddenFileChanged(bool isShow);
 
-    void handleWatcherAddChildren(const QList<SortInfoPointer> children);
+    void handleWatcherAddChildren(const QList<SortInfoPointer> &children);
     void handleWatcherRemoveChildren(const QList<SortInfoPointer> children);
     void handleWatcherUpdateFile(const SortInfoPointer child);
+    void handleWatcherUpdateFiles(const QList<SortInfoPointer> &children);
     void handleWatcherUpdateHideFile(const QUrl &hidUrl);
 
     void handleResort(const Qt::SortOrder order, const Global::ItemRoles sortRole, const bool isMixDirAndFile);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -347,7 +347,7 @@ QStringList WorkspaceHelper::getNameFilter(const quint64 windowId)
 
 void WorkspaceHelper::laterRequestSelectFiles(const QList<QUrl> &urls)
 {
-    QTimer::singleShot(qMin(800, qMax(urls.count() * (10 + urls.count() / 150), 200)), this, [=] {
+    QTimer::singleShot(qMin(800, qMax(urls.count() * (10 + urls.count() / 150), 300)), this, [=] {
         emit requestSelectFiles(urls);
     });
 }

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -313,6 +313,7 @@ TEST_F(UT_RootInfo, DoWatcherEvent)
             [&removeUrls](RootInfo *, const QList<QUrl> &urlList) { removeUrls.append(urlList); });
     stub.set_lamda(ADDR(RootInfo, updateChild), [&updateUrls](RootInfo *, const QUrl &updateUrl) {
         updateUrls.append(updateUrl);
+        return nullptr;
     });
 
     rootInfoObj->doWatcherEvent();


### PR DESCRIPTION
 Too frequent file creation signals result in too many inserts in the model, which the main thread cannot process. Modify and merge monitor signal sending, send merge once every 200ms

Log: Copying a large number of files within the vault caused the dde-file-manager  to lag
Bug: https://pms.uniontech.com/bug-view-236221.html