### PR TITLE
修复内置磁盘的识别问题，使用 ConnectionBus 辅助识别

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -81,8 +81,11 @@ QStringList DeviceManager::getAllBlockDevID(DeviceQueryOptions opts)
         if (opts.testFlag(DeviceQueryOption::kOptical)
             && !data.value(DeviceProperty::kOptical).toBool())
             continue;
+
+        bool isSystem = data.value(DeviceProperty::kHintSystem).toBool()
+                || data.value(DeviceProperty::kConnectionBus).toString() != "usb";
         if (opts.testFlag(DeviceQueryOption::kSystem)
-            && (!data.value(DeviceProperty::kHintSystem).toBool() || data.value(DeviceProperty::kConnectionBus).toString() == "usb"))
+            && !isSystem)
             continue;
         if (opts.testFlag(DeviceQueryOption::kLoop)
             && !data.value(DeviceProperty::kIsLoopDevice).toBool())


### PR DESCRIPTION
some SCSI controller has some error and cannot be fixed, cause some
inner disks are recognize as removable devices, and cannot be hidden by
'hide system disks' item.
use 'connectionBus' to help recognize if device is system disk.

Log: fix issue about device recognize.

Bug: https://pms.uniontech.com/bug-view-236747.html
