### PR TITLE
feat: Support for treeland

### DIFF
--- a/src/apps/dde-desktop/main.cpp
+++ b/src/apps/dde-desktop/main.cpp
@@ -90,6 +90,14 @@ static bool pluginsLoad()
                                                     "dfmplugin-filepreview" };
 
     QStringList blackNames { DConfigManager::instance()->value(kPluginsDConfName, "desktop.blackList").toStringList() };
+#ifdef COMPILE_ON_V23
+    if (qEnvironmentVariable("DDE_CURRENT_COMPOSITER") == "TreeLand") {
+        qCInfo(logAppDesktop) << "disable background by TreeLand";
+        if (!blackNames.contains("ddplugin-background")) {
+            blackNames.append("ddplugin-background");
+        }
+    }
+#endif
     DPF_NAMESPACE::LifeCycle::initialize({ kDesktopPluginInterface, kCommonPluginInterface }, pluginsDirs, blackNames, kLazyLoadPluginNames);
 
     qCInfo(logAppDesktop) << "Depend library paths:" << DApplication::libraryPaths();
@@ -245,9 +253,6 @@ int main(int argc, char *argv[])
             qCCritical(logAppDesktop) << "registerObject Failed" << conn.lastError();
             exit(0x0003);
         }
-
-        // Notify dde-desktop start up
-        registerDDESession();
     }
 
     if (isDesktopEnable()) {
@@ -266,6 +271,9 @@ int main(int argc, char *argv[])
     Application::instance()->dataPersistence()->setValue(DFMGLOBAL_NAMESPACE::DataPersistence::kReportGroup,
                                                          DFMGLOBAL_NAMESPACE::DataPersistence::kDesktopStartUpReportKey,
                                                          startUpData);
+
+    // Notify dde-desktop start up
+    registerDDESession();
 
     int ret { a.exec() };
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();

--- a/src/plugins/desktop/core/ddplugin-core/screen/screenproxyqt.cpp
+++ b/src/plugins/desktop/core/ddplugin-core/screen/screenproxyqt.cpp
@@ -129,6 +129,12 @@ qreal ScreenProxyQt::devicePixelRatio() const
 
 DisplayMode ScreenProxyQt::displayMode() const
 {
+#ifdef COMPILE_ON_V23
+    if (qEnvironmentVariable("DDE_CURRENT_COMPOSITER") == "TreeLand") {
+        return DisplayMode::kShowonly;
+    }
+#endif
+
     QList<ScreenPointer> allScreen = screens();
     if (allScreen.isEmpty())
         return DisplayMode::kCustom;

--- a/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.cpp
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.cpp
@@ -11,6 +11,8 @@
 #include "desktoputils/ddpugin_eventinterface_helper.h"
 
 #include <dfm-base/utils/universalutils.h>
+
+#include <QProcess>
 #else
 #include <QDBusMessage>
 #include <QDBusPendingCall>
@@ -87,15 +89,30 @@ bool EventHandle::init()
 }
 
 #ifndef COMPILE_ON_V20
+void EventHandle::startTreeland()
+{
+    fmInfo() << "call treeland-wallpaper";
+    QProcess::startDetached("/usr/libexec/treeland-wallpaper");
+}
+
 bool EventHandle::wallpaperSetting(const QString &name)
 {
-    show(name, (int)WallpaperSettings::Mode::WallpaperMode);
+    if (qEnvironmentVariable("DDE_CURRENT_COMPOSITER") == "TreeLand") {
+        startTreeland();
+    } else {
+        show(name, (int)WallpaperSettings::Mode::WallpaperMode);
+    }
+
     return true;
 }
 
 bool EventHandle::screenSaverSetting(const QString &name)
 {
-    show(name, (int)WallpaperSettings::Mode::ScreenSaverMode);
+    if (qEnvironmentVariable("DDE_CURRENT_COMPOSITER") == "TreeLand") {
+        startTreeland();
+    } else {
+        show(name, (int)WallpaperSettings::Mode::ScreenSaverMode);
+    }
     return true;
 }
 

--- a/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.h
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.h
@@ -28,7 +28,7 @@ public slots:
 protected:
     void onChanged();
     void show(QString name, int mode);
-
+    void startTreeland();
 private:
     WallpaperSettings *wallpaperSettings = nullptr;
 #endif


### PR DESCRIPTION
Disabled background with treeland.
Only Showing desktop on primary screen.
Launch treeland-wallpaper to set wallpaper.

Log: 

Task: https://pms.uniontech.com/task-view-305145.html