### PR TITLE
fix: [search] When the window reactivates, the search bar is not hidden

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
@@ -597,14 +597,6 @@ void AddressBar::showOnFocusLostOnce()
 
 bool AddressBar::event(QEvent *e)
 {
-    // blumia: When window lost focus and then get activated, we should hide
-    //         addressbar if it's visiable.
-    if (e->type() == QEvent::WindowActivate) {
-        if (!hasFocus() && isVisible()) {
-            Q_EMIT lostFocus();
-        }
-    }
-
     if (e->type() == QEvent::KeyPress) {
         keyPressEvent(static_cast<QKeyEvent *>(e));
         return true;


### PR DESCRIPTION
as title

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-220555.html
