### PR TITLE
fix: crashed when travel disc

### DIFF
--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.cpp
@@ -70,7 +70,7 @@ bool MasteredMediaDirIterator::hasNext() const
     if (discIterator && discIterator->hasNext())
         return true;
     if (discIterator)
-        discIterator.reset(nullptr);
+        discIterator.clear();
     return stagingIterator && stagingIterator->hasNext();
 }
 


### PR DESCRIPTION
use `clear` replace to `reset(nullptr)'

Log: fix crashed when travel disc