### PR TITLE
fix: [filedialog] the recent item not hide

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -14,6 +14,7 @@
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -423,7 +424,8 @@ void FileDialog::setAcceptMode(QFileDialog::AcceptMode mode)
     if (mode == QFileDialog::AcceptOpen) {
         statusBar()->setMode(FileDialogStatusBar::kOpen);
         setFileMode(d->fileMode);
-        urlSchemeEnable("recent", true);
+        QVariantMap vMap = DConfigManager::instance()->value("org.deepin.dde.file-manager.sidebar", "itemVisiable").toMap();
+        urlSchemeEnable("recent", vMap.value("recent", true).toBool());
 
         disconnect(statusBar()->lineEdit(), &DLineEdit::textChanged,
                    this, &FileDialog::onCurrentInputNameChanged);


### PR DESCRIPTION
cause:
not judge the recent item from dconfig.
solution:
add the judge by dconfig.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-238675.html