### PR TITLE
fix: dde-desktop displays icon errors for linked files

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -496,6 +496,14 @@ void AsyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> 
 {
     auto typeAll = types;
     if (typeAll.isEmpty()) {
+        if (isAttributes(OptInfoType::kIsSymLink)) {
+            auto target = d->symLinkTarget();
+            if (!target.isEmpty() && target != filePath()) {
+                FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(target));
+                if (info)
+                    info->updateAttributes();
+            }
+        }
         // 更新所有属性
         typeAll.append(FileInfoAttributeID::kThumbnailIcon);
         typeAll.append(FileInfoAttributeID::kStandardIcon);

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -526,6 +526,14 @@ void SyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &
 {
     auto typeAll = types;
     if (typeAll.isEmpty()) {
+        if (isAttributes(OptInfoType::kIsSymLink)) {
+            auto target = d->symLinkTarget();
+            if (!target.isEmpty() && target != filePath()) {
+                FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(target));
+                if (info)
+                    info->updateAttributes();
+            }
+        }
         // 更新所有属性
         typeAll.append(FileInfoAttributeID::kThumbnailIcon);
         typeAll.append(FileInfoAttributeID::kStandardFileType);


### PR DESCRIPTION
dde-desktop displays icon errors for linked files

Log: dde-desktop displays icon errors for linked files