### PR TITLE
fix: All folders, the information bar in the title bar, and the displayed size are incorrect

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-detailspace/views/filebaseinfoview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-detailspace/views/filebaseinfoview.cpp
@@ -198,7 +198,8 @@ void FileBaseInfoView::basicFill(const QUrl &url)
         lastModified.isValid() ? fileChangeTime->setRightValue(lastModified.toString(FileUtils::dateTimeFormat()), Qt::ElideMiddle, Qt::AlignLeft, true, 150)
                                : fileChangeTime->setVisible(false);
     }
-    if (fileSize && fileSize->RightValue().isEmpty()) {
+    fileSize->setVisible(false);
+    if (fileSize && fileSize->RightValue().isEmpty() && !info->isAttributes(OptInfoType::kIsDir)) {
         fileSize->setVisible(true);
         fileSize->setRightValue(FileUtils::formatSize(info->size()), Qt::ElideNone, Qt::AlignLeft, true);
         fileSize->adjustHeight();


### PR DESCRIPTION
Is the directory not displaying size

Log: All folders, the information bar in the title bar, and the displayed size are incorrect
Bug: https://pms.uniontech.com/bug-view-239659.html