### PR TITLE
fix: file info error on moving a cached file.

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
@@ -134,6 +134,8 @@ void FileInfoModelPrivate::replaceData(const QUrl &oldUrl, const QUrl &newUrl)
         return;
     }
 
+    // check the newUrl whether has been in cache.
+    auto cachedInfo = InfoCacheController::instance().getCacheInfo(newUrl);
     auto newInfo = FileCreator->createFileInfo(newUrl);
     if (Q_UNLIKELY(newInfo.isNull())) {
         fmWarning() << "fail to create new file info:" << newUrl << "old" << oldUrl;
@@ -172,6 +174,11 @@ void FileInfoModelPrivate::replaceData(const QUrl &oldUrl, const QUrl &newUrl)
                 fileMap.remove(oldUrl);
                 fileMap.insert(newUrl, newInfo);
                 lk.unlock();
+
+                // refresh file because an old info cahe may exist.
+                if (cachedInfo == newInfo)
+                    newInfo->refresh();
+
                 emit q->dataReplaced(oldUrl, newUrl);
             }
 


### PR DESCRIPTION
One file that is deleted is still cached and its file info hold error data. Then a same name file created from cache  will use this error file info.

If a file that was cached needs to refresh after creating. 

Log: 

Bug: https://pms.uniontech.com/bug-view-239731.html