### PR TITLE
fix: [computer] ejected optical drive shows usage

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -258,6 +258,10 @@ bool BlockEntryFileEntity::showSizeAndProgress() const
     if (getProperty(DeviceProperty::kMountPoint).toString().isEmpty())
         return false;
 
+    if (getProperty(DeviceProperty::kOpticalDrive).toBool()
+        && !getProperty(DeviceProperty::kMediaAvailable).toBool())
+        return false;
+
     if (datas.value(DeviceProperty::kIsEncrypted).toBool()) {
         if (datas.contains(BlockAdditionalProperty::kClearBlockProperty))
             return true;


### PR DESCRIPTION
as title.

Log: as title
