### PR TITLE
fix: dde-file-manager crashes with detailed usage information

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-detailspace/views/filebaseinfoview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-detailspace/views/filebaseinfoview.cpp
@@ -198,7 +198,10 @@ void FileBaseInfoView::basicFill(const QUrl &url)
         lastModified.isValid() ? fileChangeTime->setRightValue(lastModified.toString(FileUtils::dateTimeFormat()), Qt::ElideMiddle, Qt::AlignLeft, true, 150)
                                : fileChangeTime->setVisible(false);
     }
-    fileSize->setVisible(false);
+
+    if (fileSize)
+        fileSize->setVisible(false);
+
     if (fileSize && fileSize->RightValue().isEmpty() && !info->isAttributes(OptInfoType::kIsDir)) {
         fileSize->setVisible(true);
         fileSize->setRightValue(FileUtils::formatSize(info->size()), Qt::ElideNone, Qt::AlignLeft, true);


### PR DESCRIPTION
dde-file-manager crashes with detailed usage information

Log: Recently, when I clicked on the detailed interface, I crashed
Bug: https://pms.uniontech.com/bug-view-240309.html