### PR TITLE
fix: [io] 重启系统挂载smb后，桌面smb链接文件不可用

### DIFF
--- a/src/plugins/server/core/serverplugin-core/devicemanagerdbus.cpp
+++ b/src/plugins/server/core/serverplugin-core/devicemanagerdbus.cpp
@@ -78,10 +78,19 @@ void DeviceManagerDBus::initConnection()
             emit this->BlockDevicePropertyChanged(id, property, QDBusVariant(val));
     });
 
-    connect(DevMngIns, &DeviceManager::protocolDevMounted, this, &DeviceManagerDBus::ProtocolDeviceMounted);
-    connect(DevMngIns, &DeviceManager::protocolDevUnmounted, this, &DeviceManagerDBus::ProtocolDeviceUnmounted);
-    connect(DevMngIns, &DeviceManager::protocolDevAdded, this, &DeviceManagerDBus::ProtocolDeviceAdded);
     connect(DevMngIns, &DeviceManager::protocolDevRemoved, this, &DeviceManagerDBus::ProtocolDeviceRemoved);
+    connect(DevMngIns, &DeviceManager::protocolDevMounted, this, [this](const QString &id, const QString &mpt) {
+        emit ProtocolDeviceMounted(id, mpt);
+        requestRefreshDesktopAsNeeded(mpt, "onMount");
+    });
+    connect(DevMngIns, &DeviceManager::protocolDevUnmounted, this, [this](const QString &id, const QString &oldMpt) {
+        emit ProtocolDeviceUnmounted(id, oldMpt);
+        requestRefreshDesktopAsNeeded(oldMpt, "onUnmount");
+    });
+    connect(DevMngIns, &DeviceManager::protocolDevRemoved, this, [this](const QString &id, const QString &oldMpt) {
+        emit ProtocolDeviceRemoved(id, oldMpt);
+        requestRefreshDesktopAsNeeded(oldMpt, "onRemove");
+    });
 
     connect(DevMngIns, &DeviceManager::blockDevMounted, this, [this](const QString &id, const QString &mpt) {
         emit BlockDeviceMounted(id, mpt);


### PR DESCRIPTION
After restarting the system and reconnecting with the folder sent to the desktop by the SMB server, it is still not possible to drag files to the folder of this shortcut on the desktop，Add desktop refresh handling during protocol device mounting and uninstallation

Log: After restarting the system and reconnecting with the folder sent to the desktop by the SMB server, it is still not possible to drag files to the folder of this shortcut on the desktop
Bug: https://pms.uniontech.com/bug-view-236365.html