### PR TITLE
fix: [io/proxyinfo]Copy the application icon to the safe and paste it  without displaying it. You need to manually refresh it

### DIFF
--- a/include/dfm-base/interfaces/proxyfileinfo.h
+++ b/include/dfm-base/interfaces/proxyfileinfo.h
@@ -19,6 +19,8 @@ public:
 
 protected:
     void setProxy(const FileInfoPointer &proxy);
+    void setNotifyUrl(const QUrl &url, const QString &token);
+    void removeNotifyUrl(const QUrl &url, const QString &token);
     FileInfoPointer proxy { nullptr };
 
     // AbstractFileInfo interface

--- a/src/dfm-base/interfaces/proxyfileinfo.cpp
+++ b/src/dfm-base/interfaces/proxyfileinfo.cpp
@@ -17,9 +17,7 @@ ProxyFileInfo::ProxyFileInfo(const QUrl &url)
 
 ProxyFileInfo::~ProxyFileInfo()
 {
-    auto asyncInfo = this->proxy.dynamicCast<AsyncFileInfo>();
-    if (asyncInfo)
-        asyncInfo->removeNotifyUrl(url, QString::number(quintptr(this), 16));
+    removeNotifyUrl(url, QString::number(quintptr(this), 16));
 }
 
 QUrl ProxyFileInfo::fileUrl() const
@@ -43,10 +41,40 @@ void ProxyFileInfo::refresh()
 
 void ProxyFileInfo::setProxy(const FileInfoPointer &proxy)
 {
+    if (proxy.isNull())
+        return;
     this->proxy = proxy;
-    auto asyncInfo = this->proxy.dynamicCast<AsyncFileInfo>();
-    if (asyncInfo)
-        asyncInfo->setNotifyUrl(url, QString::number(quintptr(this), 16));
+    setNotifyUrl(url, QString::number(quintptr(this), 16));
+}
+
+void ProxyFileInfo::setNotifyUrl(const QUrl &url, const QString &token)
+{
+    if (proxy.isNull())
+        return;
+    auto tproxy = proxy.dynamicCast<ProxyFileInfo>();
+    if (!tproxy.isNull()) {
+        tproxy->setNotifyUrl(url, token);
+        return;
+    }
+    auto async = proxy.dynamicCast<AsyncFileInfo>();
+    if (async.isNull())
+        return;
+    async->setNotifyUrl(url, token);
+}
+
+void ProxyFileInfo::removeNotifyUrl(const QUrl &url, const QString &token)
+{
+    if (proxy.isNull())
+        return;
+    auto tproxy = proxy.dynamicCast<ProxyFileInfo>();
+    if (!tproxy.isNull()) {
+        tproxy->removeNotifyUrl(url, token);
+        return;
+    }
+    auto async = proxy.dynamicCast<AsyncFileInfo>();
+    if (async.isNull())
+        return;
+    async->removeNotifyUrl(url, token);
 }
 
 QString dfmbase::ProxyFileInfo::filePath() const


### PR DESCRIPTION
After updating the proxy's fileinfo, the proxy's fileinfo was not notified,When creating a monitor, when entering the directory, rootinfo creates a URL with a "/" end, while in infocache, a URL without a "/" end is used. There are two URLs in the same directory, so one is stopped and not all are stopped. Therefore, the safe is locked and unlocked, and the monitor becomes invalid.

Log: Copy the application icon to the safe and paste it without displaying it. You need to manually refresh it
Bug: https://pms.uniontech.com/bug-view-240677.html