### PR TITLE
fix: [trash] show property dialog crash in trash

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailworker.cpp
@@ -167,16 +167,6 @@ void ThumbnailWorker::onTaskAdded(const ThumbnailTaskMap &taskMap)
     while (iter.hasNext()) {
         iter.next();
         QUrl fileUrl = d->originalUrl = iter.key();
-        if (UrlRoute::isVirtual(fileUrl)) {
-            auto info { InfoFactory::create<FileInfo>(fileUrl) };
-            if (!info || !info->exists())
-                continue;
-
-            fileUrl = QUrl::fromLocalFile(info->pathOf(PathInfoType::kAbsoluteFilePath));
-            if (!fileUrl.isLocalFile())
-                continue;
-        }
-
         if (!d->thumbHelper.checkThumbEnable(fileUrl))
             continue;
 


### PR DESCRIPTION
1. check the picture thumb crash in trash(it's virtual url).
2. change the virtual url to real path.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-241241.html