### PR TITLE
fix: After renaming the application icon in bulk, it will turn the application icon into a text file

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -218,8 +218,10 @@ bool AsyncFileInfo::canAttributes(const CanableInfoType type) const
 QVariant AsyncFileInfo::extendAttributes(const ExtInfoType type) const
 {
     switch (type) {
-    case FileExtendedInfoType::kFileLocalDevice:
-        return d->asyncAttribute(FileInfo::FileInfoAttributeID::kStandardIsLocalDevice).toBool();
+    case FileExtendedInfoType::kFileLocalDevice: {
+        auto local = d->asyncAttribute(FileInfo::FileInfoAttributeID::kStandardIsLocalDevice);
+        return local.isValid() ? local : false;
+    }
     case FileExtendedInfoType::kFileCdRomDevice:
         return d->asyncAttribute(FileInfo::FileInfoAttributeID::kStandardIsCdRomDevice).toBool();
     case FileExtendedInfoType::kSizeFormat:

--- a/src/dfm-base/file/local/private/syncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/syncfileinfo_p.h
@@ -43,7 +43,7 @@ public:
     QMutex mutex;
     QReadWriteLock iconLock;
     QIcon fileIcon;
-    QVariant isLocalDevice;
+    QVariant isLocalDevice = true;
     QVariant isCdRomDevice;
     QSharedPointer<InfoDataFuture> mediaFuture { nullptr };
     InfoHelperUeserDataPointer fileMimeTypeFuture { nullptr };

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -283,7 +283,8 @@ bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)
     Q_ASSERT(info);
     const QString &suffix = info->nameOf(NameInfoType::kSuffix);
     if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop
-        || info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)) {
+        || info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
+            || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool()) {
         const QUrl &url = info->urlOf(UrlInfoType::kUrl);
         QMimeType type = info->fileMimeType();
         if (!type.isValid())

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -213,6 +213,10 @@ private:
                              const QUrl oldUrl,
                              const QUrl newUrl,
                              const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags);
+    bool doRenameDesktopFiles(QList<QUrl> &urls,
+                              const QPair<QString, QString> pair,
+                              QMap<QUrl, QUrl> &needDealUrls,
+                              QMap<QUrl, QUrl> &successUrls);
 
     JobHandlePointer doCopyFile(const quint64 windowId, const QList<QUrl> sources, const QUrl target,
                                 const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags, DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback callbaskHandle);


### PR DESCRIPTION
Batch renaming of desktop files requires separate processing.

Log: After renaming the application icon in bulk, it will turn the application icon into a text file
Bug: https://pms.uniontech.com/bug-view-241347.html