### PR TITLE
fix: [workspace] The top spacing is too small

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -76,7 +76,7 @@ inline constexpr int kMinMoveLenght { 3 };
 inline constexpr int kIconHorizontalMargin { 15 };   // 水平Margin的宽度
 inline constexpr int kCompactIconHorizontalMargin { 10 };
 inline constexpr int kIconVerticalTopMargin { 15 };   // 水平Margin的宽度
-inline constexpr int kCompactIconVerticalTopMargin { 0 };
+inline constexpr int kCompactIconVerticalTopMargin { 10 };
 inline constexpr int kTreeItemIndent { 17 };
 inline constexpr int kTreeExpandArrowWidth { 20 };
 inline constexpr int kTreeExpandArrowHeight { 20 };


### PR DESCRIPTION
1. The top spacing is too small in Compact mode
2. Set the spacing is 10px

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-237039.html