### PR TITLE
fix: [UI] text in setting dialog is align center.

### DIFF
--- a/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
@@ -26,6 +26,7 @@ CheckBoxWithMessage::CheckBoxWithMessage(QWidget *parent)
     layout->addLayout(hLayout);
 
     msgLabel = new Dtk::Widget::DTipLabel("", widget);
+    msgLabel->setAlignment(Qt::AlignLeft);
     msgLabel->setWordWrap(true);
     hLayout->addWidget(msgLabel);
 


### PR DESCRIPTION
as title.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-238677.html
