### PR TITLE
fix: [property-dialog] the rename editor show error

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -29,17 +29,18 @@ DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_propertydialog;
 
-const int kTextLineHeight = 18;
+static constexpr int kTextLineHeight { 18 };
+static constexpr int kExtendedWidgetWidth { 360 };
 
 NameTextEdit::NameTextEdit(const QString &text, QWidget *parent)
-    : QTextEdit(text, parent)
+    : DTextEdit(text, parent)
 {
     setObjectName("NameTextEdit");
     setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setFrameShape(QFrame::NoFrame);
-    setFixedSize(200, 60);
+    setFixedSize(kExtendedWidgetWidth, 60);
     setContextMenuPolicy(Qt::NoContextMenu);
 
     connect(this, &QTextEdit::textChanged, this, &NameTextEdit::slotTextChanged);

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/editstackedwidget.h
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/editstackedwidget.h
@@ -10,14 +10,14 @@
 #include <DLabel>
 #include <DIconButton>
 #include <DArrowRectangle>
+#include <DTextEdit>
 
 #include <QStackedWidget>
-#include <QTextEdit>
 #include <QTextLayout>
 #include <QTextDocument>
 
 namespace dfmplugin_propertydialog {
-class NameTextEdit : public QTextEdit
+class NameTextEdit : public DTK_WIDGET_NAMESPACE::DTextEdit
 {
     Q_OBJECT
 

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -74,6 +74,8 @@ void FilePropertyDialog::initInfoUI()
 
     QVBoxLayout *vlayout1 = new QVBoxLayout;
     vlayout1->addWidget(scrollArea);
+    vlayout1->setContentsMargins(0, 0, 0, 0);
+    vlayout1->setMargin(0);
     QVBoxLayout *widgetlayout = qobject_cast<QVBoxLayout *>(this->layout());
     widgetlayout->addLayout(vlayout1, 1);
 }
@@ -90,13 +92,12 @@ void FilePropertyDialog::createHeadUI(const QUrl &url)
     connect(editStackWidget, &EditStackedWidget::selectUrlRenamed, this, &FilePropertyDialog::onSelectUrlRenamed);
 
     QVBoxLayout *vlayout = new QVBoxLayout;
-    vlayout->setContentsMargins(10, 0, 10, 0);
+    vlayout->setContentsMargins(0, 0, 0, 0);
     vlayout->addWidget(fileIcon, 0, Qt::AlignHCenter | Qt::AlignTop);
     vlayout->addWidget(editStackWidget, 1, Qt::AlignHCenter | Qt::AlignTop);
 
     QFrame *frame = new QFrame(this);
     frame->setLayout(vlayout);
-
     addContent(frame);
 }
 


### PR DESCRIPTION
1. In property dialog, the rename editor show error
2. change the UI from QTextEditor to DTextEditor

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-238879.html