### PR TITLE
fix: After encrypting a regular partition, the file icons inside the partition do not display thumbnails

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -232,18 +232,11 @@ bool ThumbnailHelper::checkThumbEnable(const QUrl &url)
             return false;
     }
 
-    bool isLocalDevice = FileUtils::isLocalDevice(fileUrl);
-    bool isCdRomDevice = FileUtils::isCdRomDevice(fileUrl);
-    bool enable = isLocalDevice && !isCdRomDevice;
-
-    if (!enable) {
-        if (FileUtils::isMtpFile(fileUrl)) {
-            enable = DConfigManager::instance()->value("org.deepin.dde.file-manager.preview", "mtpThumbnailEnable", true).toBool();
-        } else if (DevProxyMng->isFileOfExternalBlockMounts(fileUrl.path())) {
-            enable = true;
-        } else {
-            enable = Application::instance()->genericAttribute(Application::kShowThunmbnailInRemote).toBool();
-        }
+    bool enable{ true };
+    if (FileUtils::isMtpFile(fileUrl)) { // 是否是mtpfile
+        enable = DConfigManager::instance()->value("org.deepin.dde.file-manager.preview", "mtpThumbnailEnable", true).toBool();
+    } else if (DevProxyMng->isFileOfProtocolMounts(fileUrl.path())) { // 是否是协议设备
+        enable = Application::instance()->genericAttribute(Application::kShowThunmbnailInRemote).toBool();
     }
 
     if (!enable)


### PR DESCRIPTION
Check the thumbnail for incorrect judgment, modify the judgment here

Log: After encrypting a regular partition, the file icons inside the partition do not display thumbnails
Bug: https://pms.uniontech.com/bug-view-241851.html