### PR TITLE
fix: dde-desktop's Folder, right-click menu, click "Open", unable to open the document management window

### DIFF
--- a/src/plugins/common/core/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -206,7 +206,9 @@ bool FileOperatorMenuScene::triggered(QAction *action)
             } else {
                 dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, d->windowId, cdUrl);
             }
-        } else {
+        } else  {
+            if (d->onDesktop)
+                return dpfSignalDispatcher->publish(GlobalEventType::kOpenFiles, d->windowId, d->selectFiles);
             // 如果是目录全部是用文管内部事件打开，因为一个目录就是这么处理的，保持一致，
             // 这里开启了fileinfo的缓存，这里执行效率高
             for ( auto it = d->selectFiles.begin(); it != d->selectFiles.end();) {
@@ -219,12 +221,14 @@ bool FileOperatorMenuScene::triggered(QAction *action)
                 if (info && info->isAttributes(OptInfoType::kIsSymLink))
                     cdUrl = QUrl::fromLocalFile(info->pathOf(PathInfoType::kSymLinkTarget));
 
-                dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, cdUrl);
-                it = d->selectFiles.erase(it);
+                if (dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, cdUrl)) {
+                    it = d->selectFiles.erase(it);
+                } else {
+                    it++;
+                }
             }
             dpfSignalDispatcher->publish(GlobalEventType::kOpenFiles, d->windowId, d->selectFiles);
         }
-
         return true;
     }
 


### PR DESCRIPTION


There is no kOpenNewWindow event, and the judgment is not 'dde-desktop' before proceeding with this process

Log: dde-desktop's Folder, right-click menu, click "Open", unable to open the document management window
Bug: https://pms.uniontech.com/bug-view-242599.html