### PR TITLE
fix:  When pasting for the first time, the dde-desktop right-click "Paste" will be grayed out, and the operation will be restored to normal

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -83,8 +83,7 @@ ClipBoard::ClipBoard(QObject *parent)
     connect(qApp->clipboard(), &QClipboard::dataChanged, this, [this]() {
         onClipboardDataChanged();
         emit clipboardDataChanged();
-    },
-            Qt::QueuedConnection);
+    });
 }
 
 ClipBoard *ClipBoard::instance()


### PR DESCRIPTION
Wayland needs to have focus in order to read the clipboard, and using asynchronous connection to the clipboard resulted in the first read failure

Log:  When pasting for the first time, the dde-desktop right-click "Paste" will be grayed out, and the operation will be restored to normal
Bug: https://pms.uniontech.com/bug-view-242599.html