### PR TITLE
fix: new window can't be open ASAP by session businees

### DIFF
--- a/src/apps/dde-file-manager/sessionloader.cpp
+++ b/src/apps/dde-file-manager/sessionloader.cpp
@@ -37,6 +37,8 @@ bool UsmSessionAPI::isInitialized() const
 
 bool UsmSessionAPI::init()
 {
+    return false;   // seesion bussion is needless this time
+
     if (initialized)
         return true;
     libUsm.setFileName("usm");


### PR DESCRIPTION
new window can't be open ASAP by session businees

Log: disable the session business until the session case is normal
Bug: https://pms.uniontech.com/bug-view-241965.html