### PR TITLE
fix: dde-desktop Select multiple Yongzhong docx, pptx, xlsx files and press enter, only one file can be opened

### DIFF
--- a/src/dfm-base/file/local/localfilehandler_p.h
+++ b/src/dfm-base/file/local/localfilehandler_p.h
@@ -51,6 +51,7 @@ public:
 
     bool doOpenFile(const QUrl &url, const QString &desktopFile = QString());
     bool doOpenFiles(const QList<QUrl> &urls, const QString &desktopFile = QString());
+    bool doOpenFiles(const QMultiMap<QString, QString> &infos, const QMap<QString, QString> &mimeTypes);
 
     void setError(DFMIOError error);
 


### PR DESCRIPTION
Before v5, using the enter key would open one by one, while in v6, using the enter key would pass in all the URLs to open. Modify the file logic for opening files in v6 and open all files accordingly.

Log: Select multiple Yongzhong docx, pptx, xlsx files and press enter, only one file can be opened
Bug: https://pms.uniontech.com/bug-view-242945.html