### PR TITLE
fix: dde-desktop Select multiple Yongzhong docx, pptx, xlsx files and press enter, only one file can be opened

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1043,7 +1043,7 @@ bool LocalFileHandlerPrivate::doOpenFiles(const QList<QUrl> &urls, const QString
         defaultDesktopFile = desktopFile;
     } else {
         defaultDesktopFile = MimesAppsManager::getDefaultAppDesktopFileByMimeType(mimeType);
-        if (defaultDesktopFile.isEmpty()) {
+        if (defaultDesktopFile.isEmpty() || !dfmio::DFile(fileUrl).exists()) {
             if (DeviceUtils::isUnmountSamba(fileUrl)) {
                 mimeType = QString("inode/directory");
                 defaultDesktopFile = MimesAppsManager::getDefaultAppDesktopFileByMimeType(mimeType);

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
@@ -237,6 +237,13 @@ void FileOperatorProxy::openFiles(const CanvasView *view)
         openFiles(view, urls);
 }
 
+void FileOperatorProxy::openFilesByShortCut(const CanvasView *view)
+{
+    auto urls = view->selectionModel()->selectedUrls();
+    for(const auto &url : urls)
+        openFiles(view, { url });
+}
+
 void FileOperatorProxy::openFiles(const CanvasView *view, const QList<QUrl> &urls)
 {
     dpfSignalDispatcher->publish(GlobalEventType::kOpenFiles, view->winId(), urls);

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.h
@@ -28,6 +28,7 @@ public:
     void cutFiles(const CanvasView *view);
     void pasteFiles(const CanvasView *view, const QPoint pos = QPoint(0, 0));
     void openFiles(const CanvasView *view);
+    void openFilesByShortCut(const CanvasView *view);
     void openFiles(const CanvasView *view, const QList<QUrl> &urls);
     Q_INVOKABLE void renameFile(int wid, const QUrl &oldUrl, const QUrl &newUrl);
     void renameFiles(const CanvasView *view, const QList<QUrl> &urls, const QPair<QString, QString> &pair, const bool replace);

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/shortcutoper.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/shortcutoper.cpp
@@ -85,7 +85,7 @@ bool ShortcutOper::keyPressed(QKeyEvent *event)
         switch (key) {
         case Qt::Key_Return:
         case Qt::Key_Enter:
-            FileOperatorProxyIns->openFiles(view);
+            FileOperatorProxyIns->openFilesByShortCut(view);
             return true;
         case Qt::Key_Space:
             if (!event->isAutoRepeat())


### PR DESCRIPTION
Before v5, using the enter key would open one by one, while in v6, using the enter key would pass in all the URLs to open. Modify the file logic for opening files in v6 and open all files accordingly.

Log: dde-desktop Select multiple Yongzhong docx, pptx, xlsx files and press enter, only one file can be opened
Bug: https://pms.uniontech.com/bug-view-242945.html