### PR TITLE
fix: Dragging and dropping files from the trash to the dde-desktop and dock bar will prompt for deletion in the trash

### DIFF
--- a/src/dfm-base/mimedata/dfmmimedata.cpp
+++ b/src/dfm-base/mimedata/dfmmimedata.cpp
@@ -7,6 +7,7 @@
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/fileutils.h>
 
 #include <QJsonDocument>
 
@@ -20,6 +21,7 @@ inline constexpr char kVersionKey[] { "version" };
 // attritubes
 inline constexpr char kCanTrashAttr[] { "canTrash" };
 inline constexpr char kCanDeleteAttr[] { "canDelete" };
+inline constexpr char kIsTrashAttr[] { "isTrashFile" };
 
 DFMMimeDataPrivate::DFMMimeDataPrivate()
     : QSharedData(),
@@ -42,6 +44,7 @@ void DFMMimeDataPrivate::parseUrls(const QList<QUrl> &urls)
     urlList = urls;
     bool canTrash = true;
     bool canDelete = true;
+    bool isTrashUrl = false;
 
     for (const auto &url : urls) {
         auto info = InfoFactory::create<FileInfo>(url);
@@ -53,9 +56,11 @@ void DFMMimeDataPrivate::parseUrls(const QList<QUrl> &urls)
         if (!canTrash && !canDelete)
             break;
     }
-
+    isTrashUrl = urls.isEmpty() ?
+                false : FileUtils::isTrashFile(urls.first()) && !FileUtils::isTrashRootFile(urls.first());
     attributes.insert(kCanTrashAttr, canTrash);
     attributes.insert(kCanDeleteAttr, canDelete);
+    attributes.insert(kIsTrashAttr, isTrashUrl);
 }
 
 DFMMimeData::DFMMimeData()
@@ -90,6 +95,11 @@ bool DFMMimeData::canTrash() const
 bool DFMMimeData::canDelete() const
 {
     return attritube(kCanDeleteAttr, false).toBool();
+}
+
+bool DFMMimeData::isTrashFile() const
+{
+    return attritube(kIsTrashAttr, false).toBool();
 }
 
 QString DFMMimeData::version() const

--- a/src/dfm-base/mimedata/dfmmimedata.h
+++ b/src/dfm-base/mimedata/dfmmimedata.h
@@ -35,6 +35,7 @@ public:
 
     bool canTrash() const;
     bool canDelete() const;
+    bool isTrashFile() const;
 
     void setAttritube(const QString &name, const QVariant &value);
     QVariant attritube(const QString &name, const QVariant &defaultValue = {}) const;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -58,9 +58,11 @@ JobHandlePointer TrashFileEventReceiver::doMoveToTrash(const quint64 windowId, c
 {
     Q_UNUSED(windowId);
 
-    if (sources.isEmpty())
+    // 源文件是空或者源文件是回收站文件
+    if (sources.isEmpty() || FileUtils::isTrashFile(sources.first()))
         return nullptr;
 
+    // 其他插件处理了相应的操作，直接返回
     if (dpfHookSequence->run("dfmplugin_fileoperations", "hook_Operation_MoveToTrash", windowId, sources, flags)) {
         return nullptr;
     }

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
@@ -104,7 +104,6 @@ bool DragDropOper::move(QDragMoveEvent *event)
             bool canDrop = !fileInfo->canAttributes(CanableInfoType::kCanDrop) || (fileInfo->isAttributes(OptInfoType::kIsDir) && !fileInfo->isAttributes(OptInfoType::kIsWritable)) || !fileInfo->supportedOfAttributes(SupportedType::kDrop).testFlag(event->dropAction());
             if (!canDrop) {
                 handleMoveMimeData(event, curUrl);
-
                 return true;
             } else {
                 // not support drop
@@ -551,8 +550,11 @@ bool DragDropOper::checkTargetEnable(const QUrl &targetUrl)
     if (!dfmmimeData.isValid())
         return true;
 
-    if (FileUtils::isTrashDesktopFile(targetUrl))
+    if (FileUtils::isTrashDesktopFile(targetUrl)) {
+        if (dfmmimeData.isTrashFile())
+            return false;
         return dfmmimeData.canTrash() || dfmmimeData.canDelete();
+    }
 
     return true;
 }


### PR DESCRIPTION
When determining the drag and drop event igore, it is determined that moving to the trash cannot be a trash file

Log: Dragging and dropping files from the trash to the dde-desktop and dock bar will prompt for deletion in the trash
Bug: https://pms.uniontech.com/bug-view-242603.html