### PR TITLE
fix: [search] the filter is invalid

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
@@ -333,9 +333,13 @@ bool AdvanceSearchBarPrivate::shouldVisiableByFilterRule(FileInfo *info, QVarian
             parentPath += '/';
 
         QString filePath = info->pathOf(PathInfoType::kFilePath);
-        filePath = filePath.mid(filePath.indexOf(parentPath) + 1);
-        if (filePath.contains('/'))
-            return false;
+        int index = filePath.indexOf(parentPath);
+        if (index != -1) {
+            int indexWithoutParent = index + parentPath.length();
+            filePath = filePath.mid(indexWithoutParent);
+            if (filePath.contains('/'))
+                return false;
+        }
     }
 
     if (filter.comboValid[kFileType]) {


### PR DESCRIPTION
1. In search model, the range filter is invalid.
2. code logic error and fix it.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-242913.html