### PR TITLE
fix: [detail-view] icon show error

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-detailspace/views/detailview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-detailspace/views/detailview.cpp
@@ -166,7 +166,9 @@ void DetailView::createHeadUI(const QUrl &url, int widgetFilter)
         if (icon.isNull())
             icon = info->fileIcon();
 
-        iconLabel->setPixmap(icon.pixmap(targetSize));
+        QPixmap px = icon.pixmap(targetSize);
+        px.setDevicePixelRatio(qApp->devicePixelRatio());
+        iconLabel->setPixmap(px);
         iconLabel->setAlignment(Qt::AlignCenter);
         iconLabel->setContentsMargins(0, 0, 0, 15);
         vLayout->insertWidget(0, iconLabel, 0, Qt::AlignHCenter);


### PR DESCRIPTION
1. not set the device pixe ratio.
2. set the devicepixratio.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-242485.html