### PR TITLE
fix: After encrypting a regular partition, deleting internal files only prompts complete deletion

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -114,6 +114,7 @@ bool DeviceProxyManager::isFileOfProtocolMounts(const QString &filePath)
 {
     d->initMounts();
     const QString &path = filePath.endsWith("/") ? filePath : filePath + "/";
+    QReadLocker lk(&d->lock);
     for (auto iter = d->allMounts.constKeyValueBegin(); iter != d->allMounts.constKeyValueEnd(); ++iter) {
         if (!iter.base().key().startsWith(kBlockDeviceIdPrefix) && path.startsWith(iter.base().value()))
             return true;
@@ -125,6 +126,7 @@ bool DeviceProxyManager::isFileOfExternalBlockMounts(const QString &filePath)
 {
     d->initMounts();
     const QString &path = filePath.endsWith("/") ? filePath : filePath + "/";
+    QReadLocker lk(&d->lock);
     for (auto iter = d->externalMounts.constKeyValueBegin(); iter != d->externalMounts.constKeyValueEnd(); ++iter) {
         if (iter.base().key().startsWith(kBlockDeviceIdPrefix) && path.startsWith(iter.base().value()))
             return true;
@@ -136,6 +138,7 @@ bool DeviceProxyManager::isFileFromOptical(const QString &filePath)
 {
     d->initMounts();
     const QString &path = filePath.endsWith("/") ? filePath : filePath + "/";
+    QReadLocker lk(&d->lock);
     for (auto iter = d->allMounts.constKeyValueBegin(); iter != d->allMounts.constKeyValueEnd(); ++iter) {
         if (iter.base().key().startsWith(QString(kBlockDeviceIdPrefix) + "sr") && path.startsWith(iter.base().value()))
             return true;
@@ -147,6 +150,7 @@ bool DeviceProxyManager::isMptOfDevice(const QString &filePath, QString &id)
 {
     d->initMounts();
     const QString &path = filePath.endsWith("/") ? filePath : filePath + "/";
+    QReadLocker lk(&d->lock);
     id = d->allMounts.key(path, "");
     return !id.isEmpty();
 }
@@ -155,6 +159,7 @@ QVariantMap DeviceProxyManager::queryDeviceInfoByPath(const QString &path, bool 
 {
     d->initMounts();
     QString blkid, rootblkid;
+    QReadLocker lk(&d->lock);
     for (auto it = d->allMounts.begin(); it != d->allMounts.end(); it++) {
         if (it.value() == "/") {
             rootblkid = it.key();
@@ -229,6 +234,7 @@ void DeviceProxyManagerPrivate::initMounts()
                         continue;
                     mpt = mpt.endsWith("/") ? mpt : mpt + "/";
                     // FIXME(xust): fix later, the kRemovable is not always correct.
+                    QWriteLocker lk(&lock);
                     if (info.value(DeviceProperty::kRemovable).toBool())
                         externalMounts.insert(dev, mpt);
                     allMounts.insert(dev, mpt);
@@ -344,6 +350,7 @@ void DeviceProxyManagerPrivate::addMounts(const QString &id, const QString &mpt)
     if (!id.startsWith(kBlockDeviceIdPrefix) && DeviceUtils::isMountPointOfDlnfs(p))
         return;
 
+    QWriteLocker lk(&lock);
     if (id.startsWith(kBlockDeviceIdPrefix)) {
         auto &&info = q->queryBlockInfo(id);
         if (info.value(GlobalServerDefines::DeviceProperty::kRemovable).toBool())
@@ -356,6 +363,7 @@ void DeviceProxyManagerPrivate::addMounts(const QString &id, const QString &mpt)
 
 void DeviceProxyManagerPrivate::removeMounts(const QString &id)
 {
+    QWriteLocker lk(&lock);
     externalMounts.remove(id);
     allMounts.remove(id);
 }

--- a/src/dfm-base/base/device/private/deviceproxymanager_p.h
+++ b/src/dfm-base/base/device/private/deviceproxymanager_p.h
@@ -12,6 +12,7 @@
 #include <QScopedPointer>
 #include <QList>
 #include <QtCore/qobjectdefs.h>
+#include <QReadWriteLock>
 
 using DeviceManagerInterface = OrgDeepinFilemanagerServerDeviceManagerInterface;
 class QDBusServiceWatcher;
@@ -45,6 +46,7 @@ private:
     QScopedPointer<QDBusServiceWatcher> dbusWatcher;
     QList<QMetaObject::Connection> connections;
     int currentConnectionType = kNoneConnection;   // 0 for API connection and 1 for DBus connection
+    QReadWriteLock lock;
     QMap<QString, QString> externalMounts;
     QMap<QString, QString> allMounts;
 

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -218,10 +218,8 @@ bool AsyncFileInfo::canAttributes(const CanableInfoType type) const
 QVariant AsyncFileInfo::extendAttributes(const ExtInfoType type) const
 {
     switch (type) {
-    case FileExtendedInfoType::kFileLocalDevice: {
-        auto local = d->asyncAttribute(FileInfo::FileInfoAttributeID::kStandardIsLocalDevice);
-        return local.isValid() ? local : false;
-    }
+    case FileExtendedInfoType::kFileLocalDevice:
+        return false;
     case FileExtendedInfoType::kFileCdRomDevice:
         return d->asyncAttribute(FileInfo::FileInfoAttributeID::kStandardIsCdRomDevice).toBool();
     case FileExtendedInfoType::kSizeFormat:
@@ -1145,7 +1143,7 @@ int AsyncFileInfoPrivate::cacheAllAttributes()
     tmp.insert(FileInfo::FileInfoAttributeID::kStandardContentType, attribute(DFileInfo::AttributeID::kStandardContentType));
     // iconname
     tmp.insert(FileInfo::FileInfoAttributeID::kStandardIcon, attribute(DFileInfo::AttributeID::kStandardIcon));
-    tmp.insert(FileInfo::FileInfoAttributeID::kStandardIsLocalDevice, FileUtils::isLocalDevice(q->fileUrl()));
+    tmp.insert(FileInfo::FileInfoAttributeID::kStandardIsLocalDevice, false);
     tmp.insert(FileInfo::FileInfoAttributeID::kStandardIsCdRomDevice, FileUtils::isCdRomDevice(q->fileUrl()));
     if (q->nameOf(NameInfoType::kIconName) != attribute(DFileInfo::AttributeID::kStandardIcon)) {
         QWriteLocker rlk(&iconLock);

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -72,7 +72,6 @@ FileInfoPointer LocalDirIteratorPrivate::fileInfo(const QSharedPointer<DFileInfo
 
     if (infoTrans) {
         infoTrans->setExtendedAttributes(ExtInfoType::kFileIsHid, isHidden);
-        infoTrans->setExtendedAttributes(ExtInfoType::kFileLocalDevice, isLocalDevice);
         infoTrans->setExtendedAttributes(ExtInfoType::kFileCdRomDevice, isCdRomDevice);
         emit InfoCacheController::instance().removeCacheFileInfo({url});
         emit InfoCacheController::instance().cacheFileInfo(url, infoTrans);
@@ -254,7 +253,9 @@ bool LocalDirIterator::oneByOne()
     if (!url().isValid())
         return true;
 
-    return !FileUtils::isLocalDevice(url()) || !d->dfmioDirIterator;
+    auto info = InfoFactory::create<FileInfo>(url());
+
+    return (info ? info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : !FileUtils::isLocalDevice(url())) || !d->dfmioDirIterator;
 }
 
 bool LocalDirIterator::initIterator()

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -246,7 +246,7 @@ QVariant SyncFileInfo::extendAttributes(const ExtInfoType type) const
 {
     switch (type) {
     case FileExtendedInfoType::kFileLocalDevice:
-        return d->isLocalDevice;
+        return true;
     case FileExtendedInfoType::kFileCdRomDevice:
         return d->isCdRomDevice;
     case FileExtendedInfoType::kSizeFormat:

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -275,7 +275,8 @@ bool EmblemHelper::isExtEmblemProhibited(const QUrl &url)
     // In the block device, all file extension emblem icons are displayed by default,
     // When configuring emblem icons display, all file extension corners are displayed in the block device
     // When emblem icons hiding is configured, all file extension corners are hidden in the block device
-    if (!FileUtils::isLocalDevice(url)) {
+    auto info = InfoFactory::create<FileInfo>(url);
+    if ((info ? !info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : !FileUtils::isLocalDevice(url))) {
         bool enable { DConfigManager::instance()->value("org.deepin.dde.file-manager.emblem", "blockExtEnable", true).toBool() };
         if (enable)
             return false;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -133,7 +133,7 @@ bool DragDropHelper::dragMove(QDragMoveEvent *event)
 
         // target is not local device, origin is dir and can not write, prohibit drop
         const QUrl &targetUrl = hoverFileInfo->urlOf(UrlInfoType::kUrl);
-        if (!FileUtils::isLocalDevice(targetUrl)) {
+        if (!hoverFileInfo->extendAttributes(ExtInfoType::kFileLocalDevice).toBool()) {
             if (!info->isAttributes(OptInfoType::kIsWritable)) {
                 view->setViewSelectState(false);
                 event->ignore();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -8,6 +8,7 @@
 
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/watchercache.h>
+#include <dfm-base/base/schemefactory.h>
 
 #include <QApplication>
 
@@ -119,7 +120,8 @@ bool FileDataManager::checkNeedCache(const QUrl &url)
         return true;
 
     // mounted dir should cache files in FileDataManager
-    if (!FileUtils::isLocalDevice(url))
+    auto info = InfoFactory::create<FileInfo>(url);
+    if ((info ? !info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : !FileUtils::isLocalDevice(url)))
         return true;
 
     return false;


### PR DESCRIPTION
Modify the islocaldevice interface and use the protocol device files and removable fast devices in deviceutils to determine if they are local device files

Log: After encrypting a regular partition, deleting internal files only prompts complete deletion
Bug: https://pms.uniontech.com/bug-view-243173.html