### PR TITLE
fix: [mount] create the default mount root

### DIFF
--- a/src/plugins/daemon/daemonplugin-accesscontrol/accesscontrol.h
+++ b/src/plugins/daemon/daemonplugin-accesscontrol/accesscontrol.h
@@ -29,11 +29,11 @@ private:
     void initConnect();
 
 private slots:
-    void onFileCreatedInHomePath();
+    void createUserMountDirs();
+    void createUserMountDir(const QString &objPath);
 
 private:
     QScopedPointer<AccessControlDBus> accessControlManager;
-    QScopedPointer<DFMIO::DWatcher> watcher;
 };
 
 DAEMONPAC_END_NAMESPACE


### PR DESCRIPTION
user home may not same with user name, use $USER_HOME to create user
mount root dir is not always correct.
read userlist from Accounts interface, and create default user mount dir
when user added.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-243627.html