### PR TITLE
fix: [device] eject all devices

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -767,7 +767,11 @@ void DeviceManager::detachAllRemovableBlockDevs()
         if (!info.value(DeviceProperty::kCanPowerOff).toBool()
             && !info.value(DeviceProperty::kOptical).toBool())
             filteredDevs.removeAll(id);
+        if (DeviceUtils::isSiblingOfRoot(info))
+            filteredDevs.removeAll(id);
     }
+
+    qCInfo(logDFMBase) << "about to detaching" << filteredDevs;
 
     QStringList operated;
     for (const auto &id : filteredDevs) {

--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -86,6 +86,8 @@ public:
 
     static bool isSystemDisk(const QVariantHash &devInfo);
     static bool isSystemDisk(const QVariantMap &devInfo);
+    static bool isSiblingOfRoot(const QVariantHash &devInfo);
+    static bool isSiblingOfRoot(const QVariantMap &devInfo);
 
 private:
     static bool hasMatch(const QString &txt, const QString &rex);

--- a/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -359,15 +359,5 @@ void BlockEntryFileEntity::resetWindowsVolTag()
 
 bool BlockEntryFileEntity::isSiblingOfRoot() const
 {
-    static QString rootDrive;
-    static std::once_flag flg;
-    std::call_once(flg, [&rootDrive] {
-        const QString &rootDev = DeviceUtils::getMountInfo("/", false);
-        const QString &rootDevId = DeviceUtils::getBlockDeviceId(rootDev);
-        const auto &data = DevProxyMng->queryBlockInfo(rootDevId);
-        rootDrive = data.value(DeviceProperty::kDrive).toString();
-        fmInfo() << "got root drive:" << rootDrive << rootDev;
-    });
-
-    return rootDrive == this->datas.value(DeviceProperty::kDrive);
+    return DeviceUtils::isSiblingOfRoot(this->datas);
 }


### PR DESCRIPTION
system runs on UOS-TO-GO, the root devices is connected through USB,
which cause the eject-all operation also detach the siblings of root
device, and which is not supposed to be detached.

Log: fix issue about detach-all devices.

Bug: