### PR TITLE
fix: Do not display thumbnails for newly created text files when starting the dde-file-manager for the first time

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -67,7 +67,7 @@ const QStringList &ThumbnailHelper::defaultThumbnailDirs()
 
 bool ThumbnailHelper::canGenerateThumbnail(const QUrl &url)
 {
-    const auto &info = InfoFactory::create<FileInfo>(url);
+    const auto &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (!info || !info->isAttributes(FileInfo::FileIsType::kIsReadable) || !info->isAttributes(FileInfo::FileIsType::kIsFile))
         return false;
 


### PR DESCRIPTION
The file size obtained during thumbnail regeneration is incorrect. Create a synchronized fileinfo during thumbnail regeneration.

Log: Do not display thumbnails for newly created text files when starting the dde file manager for the first time
Bug: https://pms.uniontech.com/bug-view-244529.html