### PR TITLE
fix: filedialog cannot exit

### DIFF
--- a/src/apps/dde-file-dialog-wayland/main.cpp
+++ b/src/apps/dde-file-dialog-wayland/main.cpp
@@ -165,6 +165,7 @@ static void handleSIGTERM(int sig)
     qCCritical(logAppDialogWayland) << "break with !SIGTERM! " << sig;
 
     if (qApp) {
+        qApp->setProperty("SIGTERM", true);
         qApp->quit();
     }
 }
@@ -203,5 +204,10 @@ int main(int argc, char *argv[])
 
     int ret { a.exec() };
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();
+    if (qApp->property("SIGTERM").toBool()) {
+        qWarning() << "Exit app by SIGTERM, reuturn: " << ret;
+        _Exit(ret);
+    }
+
     return ret;
 }

--- a/src/apps/dde-file-dialog-x11/main.cpp
+++ b/src/apps/dde-file-dialog-x11/main.cpp
@@ -165,6 +165,7 @@ static void handleSIGTERM(int sig)
     qCCritical(logAppDialogX11) << "break with !SIGTERM! " << sig;
 
     if (qApp) {
+        qApp->setProperty("SIGTERM", true);
         qApp->quit();
     }
 }
@@ -203,5 +204,10 @@ int main(int argc, char *argv[])
 
     int ret { a.exec() };
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();
+    if (qApp->property("SIGTERM").toBool()) {
+        qWarning() << "Exit app by SIGTERM, reuturn: " << ret;
+        _Exit(ret);
+    }
+
     return ret;
 }

--- a/src/apps/dde-file-dialog/main.cpp
+++ b/src/apps/dde-file-dialog/main.cpp
@@ -162,6 +162,7 @@ static void handleSIGTERM(int sig)
     qCCritical(logAppDialog) << "break with !SIGTERM! " << sig;
 
     if (qApp) {
+        qApp->setProperty("SIGTERM", true);
         qApp->quit();
     }
 }
@@ -199,5 +200,11 @@ int main(int argc, char *argv[])
 
     int ret { a.exec() };
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();
+    qWarning() << "Main thread quit";
+    if (qApp->property("SIGTERM").toBool()) {
+        qWarning() << "Exit app by SIGTERM, reuturn: " << ret;
+        _Exit(ret);
+    }
+
     return ret;
 }

--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -247,6 +247,11 @@ void DeviceProxyManagerPrivate::connectToDBus()
 {
     if (currentConnectionType == kDBusConnecting)
         return;
+    if (qApp->property("SIGTERM").toBool()) {
+        qWarning() << "Current app state is SIGTERM";
+        return;
+    }
+
     disconnCurrentConnections();
 
     auto ptr = devMngDBus.data();


### PR DESCRIPTION
a thread is active when receive SIGTERM

Log: fix filedialog cannot exit

Bug: https://pms.uniontech.com/bug-view-239079.html
Change-Id: Ifbcdfb9a7f5bf493bdd408e5b13dd0bfc6d4c958