### PR TITLE
fix: [computer] items not hide when launch another window

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
@@ -219,7 +219,7 @@ void ComputerUtils::setCursorState(bool busy)
 
 QStringList ComputerUtils::allValidBlockUUIDs()
 {
-    const auto &allBlocks = DevProxyMng->getAllBlockIds().toSet();
+    const auto &allBlocks = DevProxyMng->getAllBlockIds(GlobalServerDefines::DeviceQueryOption::kNotIgnored).toSet();
     QSet<QString> uuids;
     std::for_each(allBlocks.cbegin(), allBlocks.cend(), [&](const QString &devId) {
         const auto &&data = DevProxyMng->queryBlockInfo(devId);

--- a/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/views/computerview.cpp
@@ -132,6 +132,10 @@ void ComputerView::setStatusBarHandler(ComputerStatusBar *sb)
 void ComputerView::showEvent(QShowEvent *event)
 {
     QApplication::restoreOverrideCursor();
+    // items in computer are hidden in view, they still exist in model.
+    fmInfo() << "start update item visible in computerview.";
+    handleComputerItemVisible();
+    fmInfo() << "end update item visible in computerview.";
     DListView::showEvent(event);
 }
 


### PR DESCRIPTION
computer items are hidden in VIEW, the showevent function controls the
item visibility. and the code is removed incorrectly.

Log: as title.