### PR TITLE
fix: Opening multiple files multiple times

### DIFF
--- a/src/dfm-base/file/local/localfilehandler_p.h
+++ b/src/dfm-base/file/local/localfilehandler_p.h
@@ -58,6 +58,8 @@ public:
     static void addRecentFile(const QString &filePath, const DesktopFile &desktopFile, const QString &mimetype);
     static void asyncAddRecentFile(const QString &desktop, const QList<QString> urls,
                                    const QMap<QString, QString> &mimeTypes);
+    static void asyncAddRecentFile(const QString &desktop, const QList<QUrl> urls,
+                                   const QString &mimeType);
 
 public:
     LocalFileHandler *q { nullptr };


### PR DESCRIPTION
After opening the file, move the recent usage records to the thread for processing

Log: Opening multiple files multiple times
Bug: https://pms.uniontech.com/bug-view-243115.html