### PR TITLE
fix: [vault] hide file invalid in vault

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.h
@@ -27,7 +27,6 @@ public slots:
     void handleCurrentUrlChanged(const quint64 &winId, const QUrl &url);
     bool handleSideBarItemDragMoveData(const QList<QUrl> &urls, const QUrl &url, Qt::DropAction *action);
     bool handleShortCutPasteFiles(const quint64 &winId, const QList<QUrl> &fromUrls, const QUrl &to);
-    void handleHideFilesResult(const quint64 &winId, const QList<QUrl> &urls, bool ok);
     bool changeUrlEventFilter(quint64 windowId, const QUrl &url);
     bool handlePathtoVirtual(const QList<QUrl> files, QList<QUrl> *virtualFiles);
     bool detailViewIcon(const QUrl &url, QString *iconName);

--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfilewatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfilewatcher.cpp
@@ -53,7 +53,10 @@ void VaultFileWatcher::onFileRename(const QUrl &fromUrl, const QUrl &toUrl)
 
 void VaultFileWatcher::onSubfileCreated(const QUrl &url)
 {
-    QUrl furl = VaultHelper::instance()->pathToVaultVirtualUrl(url.path());
-    fmDebug() << url;
-    emit subfileCreated(furl);
+    QUrl vurl = VaultHelper::instance()->pathToVaultVirtualUrl(url.path());
+    if (vurl.toString().endsWith(QString(QDir::separator()) + ".hidden")) {
+        emit fileRename(QUrl(), vurl);
+    } else {
+        emit subfileCreated(vurl);
+    }
 }

--- a/tests/plugins/filemanager/dfmplugin-vault/events/ut_vaulteventreceiver.cpp
+++ b/tests/plugins/filemanager/dfmplugin-vault/events/ut_vaulteventreceiver.cpp
@@ -302,24 +302,6 @@ TEST(UT_VaultEventReceiver, handleShortCutPasteFiles_three)
     EXPECT_FALSE(isOk);
 }
 
-TEST(UT_VaultEventReceiver, handleHideFilesResult)
-{
-    bool isGetWatcher { false };
-
-    stub_ext::StubExt stub;
-    stub.set_lamda(&InfoFactory::create<FileInfo>, []{
-        return QSharedPointer<SyncFileInfo>(new SyncFileInfo(QUrl("file:///home/UT_TEST")));
-    });
-    stub.set_lamda(&WatcherCache::getCacheWatcher, [ &isGetWatcher ]{
-        isGetWatcher = true;
-        return QSharedPointer<LocalFileWatcher>(new LocalFileWatcher(QUrl("file:///home/UT_TEST")));
-    });
-
-    VaultEventReceiver::instance()->handleHideFilesResult(0, QList<QUrl>() << QUrl(), true);
-
-    EXPECT_TRUE(isGetWatcher);
-}
-
 TEST(UT_VaultEventReceiver, changeUrlEventFilter_one)
 {
     bool isCreate { false };


### PR DESCRIPTION
1. When first create .hidden file, hide file invalid.
2. change the create logic to update the .hidden file.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-244729.html