### PR TITLE
fix: Creating or copying files will not automatically refresh, in vault

### DIFF
--- a/src/dfm-base/file/local/localfilewatcher.cpp
+++ b/src/dfm-base/file/local/localfilewatcher.cpp
@@ -35,6 +35,12 @@ bool LocalFileWatcherPrivate::start()
     if (watcher.isNull())
         return false;
 
+    dfmio::DFile file(url);
+    if (!file.exists()) {
+        qCWarning(logDFMBase) << "watcher start failed, error: watcher dir is not exists ! url = " << url;
+        return false;
+    }
+
     started = watcher->start();
     if (!started)
         qCWarning(logDFMBase) << "watcher start failed, error: " << watcher->lastError().errorMsg();


### PR DESCRIPTION
The monitor that started a non-existent directory in vault was not removed, resulting in the failure of subsequent monitors in the same directory

Log: Creating or copying files will not automatically refresh, in vault
Bug: https://pms.uniontech.com/bug-view-245141.html