### PR TITLE
fix: Correct a misspelling word in postinst

### DIFF
--- a/debian/libdde-file-manager.postinst
+++ b/debian/libdde-file-manager.postinst
@@ -3,7 +3,7 @@
 #dfm-upgrade
 
 function createUpgradeFlag(){
-echo "File manager is ready to upgratde configuration."
+echo "File manager is ready to upgrade configuration."
 homeDir="/home"
 for user in `ls $homeDir`
 do


### PR DESCRIPTION
Change "upgratde" to "upgrade".

![微信图片_20240305130510](https://github.com/linuxdeepin/dde-file-manager/assets/60058876/92750074-fd9c-4eb2-9c0b-e0054e8cd716)
