### PR TITLE
fix: In the blank space of the dde-file-manager or dde-desktop, using the shortcut key "Paste" in the right-click menu does not take effect

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -40,10 +40,9 @@ static constexpr char kRemoteAssistanceCopyKey[] = "uos/remote-copied-files";
 
 void onClipboardDataChanged()
 {
-    {
-        QMutexLocker lk(&clipboardFileUrlsMutex);
-        clipboardFileUrls.clear();
-    }
+
+    QMutexLocker lk(&clipboardFileUrlsMutex);
+    clipboardFileUrls.clear();
 
     const QMimeData *mimeData = qApp->clipboard()->mimeData();
     if (!mimeData || mimeData->formats().isEmpty()) {
@@ -71,8 +70,6 @@ void onClipboardDataChanged()
     } else {
         clipboardAction = ClipBoard::kUnknownAction;
     }
-
-    QMutexLocker lk(&clipboardFileUrlsMutex);
     clipboardFileUrls << mimeData->urls();
 }
 }   // namespace GlobalData
@@ -244,6 +241,7 @@ QList<QUrl> ClipBoard::getRemoteUrls()
  */
 QList<QUrl> ClipBoard::clipboardFileUrlList() const
 {
+    QMutexLocker lk(&GlobalData::clipboardFileUrlsMutex);
     return GlobalData::clipboardFileUrls;
 }
 /*!

--- a/src/plugins/desktop/core/ddplugin-canvas/menu/canvasmenuscene.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/menu/canvasmenuscene.cpp
@@ -354,6 +354,12 @@ bool CanvasMenuScene::triggered(QAction *action)
             // paste
             if (actionId == dfmplugin_menu::ActionID::kPaste) {
                 FileOperatorProxyIns->pasteFiles(d->view, d->gridPos);
+                auto point = d->gridPos;
+                QPointer<ddplugin_canvas::CanvasView> viewptr = d->view;
+                QTimer::singleShot(100, [viewptr, point](){
+                    if (!viewptr.isNull())
+                        FileOperatorProxyIns->pasteFiles(viewptr, point);
+                });
                 return true;
             }
         }
@@ -405,7 +411,11 @@ bool CanvasMenuScene::triggered(QAction *action)
                     auto index = d->view->model()->index(d->focusFile);
                     if (Q_UNLIKELY(!index.isValid()))
                         return false;
-                    d->view->edit(index, QAbstractItemView::AllEditTriggers, nullptr);
+                    QPointer<ddplugin_canvas::CanvasView> view = d->view;
+                    QTimer::singleShot(80, [view, index](){
+                        if (!view.isNull())
+                            view->edit(index, QAbstractItemView::EditKeyPressed, nullptr);
+                    });
                 } else {
                     RenameDialog renameDlg(d->selectFiles.count());
                     renameDlg.moveToCenter();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/menus/workspacemenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/menus/workspacemenuscene.cpp
@@ -205,7 +205,11 @@ bool WorkspaceMenuScene::emptyMenuTriggered(QAction *action)
     if (sceneName == kClipBoardMenuSceneName) {
         // paste
         if (actionId == dfmplugin_menu::ActionID::kPaste) {
-            FileOperatorHelperIns->pasteFiles(d->view);
+            QPointer<dfmplugin_workspace::FileView> view = d->view;
+            QTimer::singleShot(100, [view](){
+                if (!view.isNull())
+                    FileOperatorHelperIns->pasteFiles(view);
+            });
             return true;
         }
     }
@@ -277,6 +281,11 @@ bool WorkspaceMenuScene::normalMenuTriggered(QAction *action)
                 const QModelIndex &index = d->view->selectionModel()->currentIndex();
                 if (Q_UNLIKELY(!index.isValid()))
                     return false;
+                QPointer<dfmplugin_workspace::FileView> view = d->view;
+                QTimer::singleShot(80, [view, index](){
+                    if (!view.isNull())
+                        view->edit(index, QAbstractItemView::EditKeyPressed, nullptr);
+                });
                 d->view->edit(index, QAbstractItemView::EditKeyPressed, nullptr);
             } else {
                 WorkspaceEventCaller::sendShowCustomTopWidget(d->windowId, Global::Scheme::kFile, true);


### PR DESCRIPTION
After using the shortcut key and executing the trigger function, after an interval of 50ms, the window active and focus events were received, resulting in invalid reading of the cached copy data and exiting the editing state. Delay processing of these two shortcut key events. 
Log: In the blank space of the dde-file-manager or dde-desktop, using the shortcut key "Paste" in the right-click menu does not take effect 
Bug: https://pms.uniontech.com/bug-view-244903.html