### PR TITLE
fix: [ui] incorrect display of blank area at the bottom of the sidebar

### DIFF
--- a/src/plugins/common/core/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -71,6 +71,7 @@ void BasicWidget::initUI()
     setSeparatorVisible(false);
 
     setTitle(QString(tr("Basic info")));
+    DFontSizeManager::instance()->bind(this, DFontSizeManager::SizeType::T6, QFont::DemiBold);
 
     setExpand(true);
 
@@ -86,6 +87,7 @@ void BasicWidget::initUI()
     fileModified = createValueLabel(frameMain, tr("Time modified"));
 
     hideFile = new DCheckBox(frameMain);
+    DFontSizeManager::instance()->bind(hideFile, DFontSizeManager::SizeType::T7, QFont::Normal);
     hideFile->setText(tr("Hide this file"));
     hideFile->setToolTip(hideFile->text());
 }

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -136,6 +136,7 @@ void PermissionManagerWidget::initUI()
     setExpandedSeparatorVisible(false);
     setSeparatorVisible(false);
     setTitle(QString(tr("Permissions")));
+    DFontSizeManager::instance()->bind(this, DFontSizeManager::SizeType::T6, QFont::DemiBold);
     setExpand(false);
 
     authorityList << QObject::tr("Access denied")   // 0
@@ -210,6 +211,7 @@ void PermissionManagerWidget::initUI()
 
     mainFrameLay->addLayout(formLay);
     mainFrameLay->addWidget(executableFrame);
+    DFontSizeManager::instance()->bind(mainFrame, DFontSizeManager::SizeType::T7, QFont::Normal);
 
     mainFrame->setLayout(mainFrameLay);
     setContent(mainFrame);

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -109,6 +109,7 @@ void ShareControlWidget::setupUi(bool disableState)
     const QString &userName = getpwuid(getuid())->pw_name;
     isSharePasswordSet = UserShareHelperInstance->isUserSharePasswordSet(userName);
     setTitle(tr("Sharing"));
+    DFontSizeManager::instance()->bind(this, DFontSizeManager::SizeType::T6, QFont::DemiBold);
     setExpandedSeparatorVisible(false);
     setSeparatorVisible(false);
 
@@ -154,6 +155,7 @@ void ShareControlWidget::setupUi(bool disableState)
     mainLayout->addLayout(basicInfoFrameLay);
     mainLayout->addWidget(moreInfoFrame);
     mainFrame->setLayout(mainLayout);
+    DFontSizeManager::instance()->bind(mainFrame, DFontSizeManager::SizeType::T7, QFont::Normal);
     setContent(mainFrame);
 
     timer = new QTimer(this);
@@ -219,7 +221,7 @@ void ShareControlWidget::setupShareAnonymousSelector()
     shareAnonymousSelector->addItems(anonymousSelections);
 }
 
-QHBoxLayout* ShareControlWidget::setupNetworkPath()
+QHBoxLayout *ShareControlWidget::setupNetworkPath()
 {
     netScheme = new QLabel("smb://", this);
 

--- a/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
@@ -17,7 +17,7 @@
 
 #include <QVBoxLayout>
 
-static constexpr int kTagWidgetHeight { 150 };
+static constexpr int kTagWidgetHeight { 114 };
 
 DWIDGET_USE_NAMESPACE
 DTK_USE_NAMESPACE
@@ -40,7 +40,7 @@ void TagWidgetPrivate::initializeUI()
     q->setLayout(mainLayout);
     QString name = tr("Tag");
     tagLable = new DLabel(name, q);
-    DFontSizeManager::instance()->bind(tagLable, DFontSizeManager::SizeType::T5, QFont::DemiBold);
+    DFontSizeManager::instance()->bind(tagLable, DFontSizeManager::SizeType::T6, QFont::DemiBold);
     tagLable->setObjectName(name);
 
     colorListWidget = new TagColorListWidget(q, TagColorListWidget::kProperty);
@@ -56,7 +56,8 @@ void TagWidgetPrivate::initializeUI()
 
     tagColorListLayout = new QVBoxLayout;
     tagColorListLayout->addWidget(tagLable, 0, Qt::AlignLeft);
-    tagColorListLayout->addWidget(colorListWidget, 0, Qt::AlignVCenter);
+    tagColorListLayout->addWidget(colorListWidget, 0, Qt::AlignLeft);
+    tagColorListLayout->setContentsMargins(0, 0, 0, 0);
 
     mainLayout->addLayout(tagColorListLayout);
 
@@ -76,8 +77,9 @@ void TagWidgetPrivate::initializeUI()
 void TagWidgetPrivate::initUiForSizeMode()
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
-    mainLayout->setContentsMargins(DSizeModeHelper::element(5, 10), 10, 10, 10);
+    mainLayout->setContentsMargins(DSizeModeHelper::element(5, 10), 6, 10, 10);
     crumbEdit->setMaximumHeight(DSizeModeHelper::element(50, 50));
+    colorListWidget->setFixedWidth(214);
     q->setFixedHeight(DSizeModeHelper::element(150, kTagWidgetHeight));
 #endif
 }

--- a/src/plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.cpp
@@ -92,7 +92,7 @@ void TagColorListWidget::initUiElement()
         if (useType == kAction)
             tagButtons[index]->setRadius(20);
         else
-            tagButtons[index]->setRadius(30);
+            tagButtons[index]->setRadius(20);
 
         QString objMark = QString("Color%1").arg(index + 1);
         tagButtons[index]->setObjectName(objMark);

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
@@ -8,6 +8,7 @@
 #include <dfm-base/mimetype/mimesappsmanager.h>
 
 #include <DRadioButton>
+#include <DFontSizeManager>
 
 #include <QCheckBox>
 #include <QVBoxLayout>
@@ -33,6 +34,7 @@ void OpenWithWidget::initUI()
     setSeparatorVisible(false);
 
     setTitle(QString(tr("Open with")));
+    DFontSizeManager::instance()->bind(this, DFontSizeManager::SizeType::T6, QFont::DemiBold);
 
     setExpand(false);
 
@@ -43,6 +45,7 @@ void OpenWithWidget::initUI()
     openWithListWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     openWithListWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     openWithListWidget->setFixedWidth(300);
+    DFontSizeManager::instance()->bind(openWithListWidget, DFontSizeManager::SizeType::T7, QFont::Normal);
 
     openWithBtnGroup = new QButtonGroup(openWithListWidget);
 

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -345,3 +345,26 @@ QModelIndex SideBarModel::findRowByUrl(const QUrl &url) const
 
     return retIndex;
 }
+
+void SideBarModel::addEmptyItem()
+{
+    //Attention!
+    //The current sidebar does not support external plugins to add groups.
+    //If this feature is implemented in the future, it is necessary to move the emptyItem item appropriately
+    int count = rowCount();
+    QSize emptyItemsize = QSize(10, 10);
+    if (count > 0) {
+        QStandardItem *lastItem = item(count - 1);
+        if (lastItem && lastItem->sizeHint() == emptyItemsize)
+            return;
+    }
+
+    beginInsertRows(QModelIndex(), rowCount(), rowCount());
+
+    auto emptyItem = new QStandardItem("");
+    emptyItem->setFlags(Qt::NoItemFlags);
+    emptyItem->setSizeHint(emptyItemsize);
+
+    QStandardItemModel::appendRow(emptyItem);
+    endInsertRows();
+}

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treemodels/sidebarmodel.h
@@ -38,6 +38,8 @@ public:
     void updateRow(const QUrl &url, const ItemInfo &newInfo);
     QModelIndex findRowByUrl(const QUrl &url) const;
 
+    void addEmptyItem();
+
 private:
     QMutex locker;
     mutable SideBarItem *curDragItem { nullptr };

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -49,6 +49,7 @@ static constexpr int kExpandIconSize = 12;
 static constexpr int kItemMargin = 10;
 static constexpr int kItemIconSize = 16;
 static constexpr int kEjectIconSize = 16;
+static constexpr int kEmptyItemSize = 10;
 
 #ifdef DTKWIDGET_CLASS_DSizeMode
 static constexpr int kCompactExpandIconSize = 10;
@@ -139,7 +140,8 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         painter->setPen(Qt::NoPen);
         painter->drawRoundedRect(r, kRadius, kRadius);
     } else if (!isDragedItem && (opt.state.testFlag(QStyle::State_MouseOver) || isDropTarget)) {   // Draw mouse over background
-        drawMouseHoverBackground(painter, palette, r, widgetColor);
+        if (item->sizeHint() != QSize(kEmptyItemSize, kEmptyItemSize))
+            drawMouseHoverBackground(painter, palette, r, widgetColor);
         if (separatorItem)
             drawMouseHoverExpandButton(painter, r, separatorItem->isExpanded());
     }

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -305,21 +305,15 @@ void SideBarWidget::initializeUi()
     leftSpacer->setBackgroundRole(QPalette::Base);
 
     QVBoxLayout *vlayout = new QVBoxLayout();
-
-    QWidget *spacer = new QWidget(this);
-    spacer->setAutoFillBackground(true);
-    spacer->setFixedHeight(10);
-    spacer->setBackgroundRole(QPalette::Base);
-
     vlayout->addWidget(sidebarView);
     vlayout->setMargin(0);
     vlayout->setSpacing(0);
-    vlayout->addWidget(spacer);
 
     hlayout->addWidget(leftSpacer);
     hlayout->addLayout(vlayout);
 
     sidebarView->setModel(kSidebarModelIns.data());
+    kSidebarModelIns->addEmptyItem();
     sidebarView->setItemDelegate(new SideBarItemDelegate(sidebarView));
     sidebarView->setContextMenuPolicy(Qt::CustomContextMenu);
     sidebarView->setFrameShape(QFrame::Shape::NoFrame);


### PR DESCRIPTION
fix incorrect display of blank area at the bottom of the sidebar and fix incorrect display of dividing lines at the bottom of the workspace

Log: fix: [ui] incorrect display of blank area at the bottom of the sidebar
Bug: https://pms.uniontech.com/bug-view-243531.html https://pms.uniontech.com/bug-view-241127.html https://pms.uniontech.com/bug-view-238993.html