### PR TITLE
fix: Perform a complete deletion and addition prompt when using ctrl+Z for rollback

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -425,7 +425,7 @@ JobHandlePointer FileOperationsEventReceiver::doDeleteFile(const quint64 windowI
     }
 
     // Delete local file with shift+delete, show a confirm dialog.
-    if (!flags.testFlag(AbstractJobHandler::JobFlag::kRevocation) && DialogManagerInstance->showDeleteFilesDialog(sources) != QDialog::Accepted)
+    if (DialogManagerInstance->showDeleteFilesDialog(sources) != QDialog::Accepted)
         return nullptr;
 
     JobHandlePointer handle = copyMoveJob->deletes(sources, flags);


### PR DESCRIPTION
Perform a complete deletion and addition prompt when using ctrl+Z for rollback

Log: Perform a complete deletion and addition prompt when using ctrl+Z for rollback