### PR TITLE
fix: After the first restart, click on the idle partition and the document management will prompt "The file has been moved or deleted"

### DIFF
--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -112,6 +112,7 @@ public:
     void updateThumbnail(const QUrl &url);
     QIcon updateIcon();
     void updateMediaInfo(const DFileInfo::MediaType type, const QList<DFileInfo::AttributeExtendID> &ids);
+    bool hasAsyncAttribute(FileInfo::FileInfoAttributeID key);
 };
 
 AsyncFileInfoPrivate::AsyncFileInfoPrivate(AsyncFileInfo *qq)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -881,7 +881,10 @@ void FileViewModel::initFilterSortWork()
 
     filterSortWorker.reset(new FileSortWorker(dirRootUrl, currentKey, filterCallback, nameFilters, currentFilters));
     beginInsertRows(QModelIndex(), 0, 0);
-    filterSortWorker->setRootData(FileItemDataPointer(new FileItemData(dirRootUrl, InfoFactory::create<FileInfo>(dirRootUrl))));
+    auto rootInfo = InfoFactory::create<FileInfo>(dirRootUrl);
+    if (!rootInfo.isNull())
+        rootInfo->updateAttributes();
+    filterSortWorker->setRootData(FileItemDataPointer(new FileItemData(dirRootUrl, rootInfo)));
     endInsertRows();
     filterSortWorker->setSortAgruments(order, role, Application::instance()->appAttribute(Application::kFileAndDirMixedSort).toBool());
     filterSortWorker->setTreeView(DConfigManager::instance()->value(kViewDConfName, kTreeViewEnable, true).toBool()


### PR DESCRIPTION
After immediate mounting, immediately enter the mounting directory to determine if the file is from a local device or if it is possible that the asynchronous file information has not been read yet.

Log: After the first restart, click on the idle partition and the document management will prompt "The file has been moved or deleted"
Bug: https://pms.uniontech.com/bug-view-245579.html