### PR TITLE
fix: Red disk mounting and uninstalling file monitor fails

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -72,7 +72,9 @@ void FileDataManager::cleanRoot(const QUrl &rootUrl)
     for (const auto &rootInfo : rootInfoKeys) {
         if (rootInfo.path().startsWith(rootPath) || rootInfo.path() == rootUrl.path()) {
             rootInfoMap.value(rootInfo)->disconnect();
-            rootInfoMap.remove(rootInfo);
+            auto root = rootInfoMap.take(rootInfo);
+            if (root)
+                delete root;
         }
     }
 }


### PR DESCRIPTION
After uninstalling the red disk, there was no destruction when cleaning up rootinfo

Log: Red disk mounting and uninstalling file monitor fails