### PR TITLE
fix: [computer] usage not display after device mounted

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -853,6 +853,7 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
                 else
                     removeDevice(url);
             }
+            onUpdateBlockItem(id);
         }
     }
 }


### PR DESCRIPTION
RED DISK, after unlocked, device size in computer view is not updated.
update item info when devices' filesystem interface changed.

Log: as title.
