### PR TITLE
fix: The performance is slow when accessing the SMB folder. After entering 1 second, the folder icon style will refresh from an unavailable state before displaying normally

### DIFF
--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -254,8 +254,10 @@ bool LocalDirIterator::oneByOne()
         return true;
 
     auto info = InfoFactory::create<FileInfo>(url());
+    if (info)
+        return !info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() || !d->dfmioDirIterator;
 
-    return (info ? info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : !FileUtils::isLocalDevice(url())) || !d->dfmioDirIterator;
+    return !FileUtils::isLocalDevice(url()) || !d->dfmioDirIterator;
 }
 
 bool LocalDirIterator::initIterator()


### PR DESCRIPTION
The oneByOne in the LocalDirIterator iterator returned false and did not go through asynchronous caching and create fileinfo

Log: The performance is slow when accessing the SMB folder. After entering 1 second, the folder icon style will refresh from an unavailable state before displaying normally
Bug: https://pms.uniontech.com/bug-view-246809.html