### PR TITLE
fix: The file manager does not support shortcut keys such as Ctrl+d to delete files and Ctrl+shift+n to create new folders and directories

### DIFF
--- a/src/dfm-base/shortcut/shortcut.cpp
+++ b/src/dfm-base/shortcut/shortcut.cpp
@@ -26,11 +26,13 @@ Shortcut::Shortcut(QObject *parent)
                       << ShortcutItem(tr("To parent directory"), "Ctrl + Up ")
                       << ShortcutItem(tr("Permanently delete"), "Shift + Delete ")
                       << ShortcutItem(tr("Delete file"), "Delete")
+                      << ShortcutItem(tr("Delete file"), "Ctrl + D ")
                       << ShortcutItem(tr("Select all"), "Ctrl + A ")
                       << ShortcutItem(tr("Copy"), "Ctrl + C ")
                       << ShortcutItem(tr("Cut"), "Ctrl + X ")
                       << ShortcutItem(tr("Paste"), "Ctrl + V ")
-                      << ShortcutItem(tr("Rename"), "F2 ");
+                      << ShortcutItem(tr("Rename"), "F2 ")
+                      << ShortcutItem(tr("Open in terminal"), "Shift + T ");
     group2.groupName = tr("New/Search");
     group2.groupItems << ShortcutItem(tr("New window"), "Ctrl + N ")
                       << ShortcutItem(tr("New folder"), "Ctrl + Shift + N ")

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/shortcutoper.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/shortcutoper.cpp
@@ -140,6 +140,9 @@ bool ShortcutOper::keyPressed(QKeyEvent *event)
         case Qt::Key_Z:
             FileOperatorProxyIns->undoFiles(view);
             return true;
+        case Qt::Key_D:
+            FileOperatorProxyIns->moveToTrash(view);
+            return true;
         default:
             break;
         }
@@ -151,6 +154,9 @@ bool ShortcutOper::keyPressed(QKeyEvent *event)
     } else if (modifiers == (Qt::ControlModifier | Qt::ShiftModifier)) {
         if (key == Qt::Key_I) {
             view->d->keySelector->toggleSelect();
+            return true;
+        } else if (key == Qt::Key_N) {
+            FileOperatorProxyIns->touchFolder(view, view->d->gridAt(QCursor::pos()));
             return true;
         }
     }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/shortcuthelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/shortcuthelper.cpp
@@ -177,6 +177,11 @@ bool ShortcutHelper::processKeyPressEvent(QKeyEvent *event)
             openAction(view->selectedUrlList());
             return true;
         }
+        case Qt::Key_D:
+        {
+            moveToTrash();
+            return true;
+        }
         default:
             break;
         }


### PR DESCRIPTION
Implement corresponding shortcut key functions on the dde-desktop and dde-file-manager

Log: The file manager does not support shortcut keys such as Ctrl+d to delete files and Ctrl+shift+n to create new folders and directories
Bug: https://pms.uniontech.com/bug-view-248449.html