### PR TITLE
fix: [248523/bluetooth] menu entry not hidden.

### DIFF
--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager_p.h
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager_p.h
@@ -26,7 +26,7 @@ public:
     BluetoothManagerPrivate &operator=(BluetoothManagerPrivate &) = delete;
 
     void resolve(const QDBusReply<QString> &req);
-    void init();
+    void initInterface();
     void initConnects();
     bool connectBluetoothDBusSignals(const QString &signal, const char *slot);
     void inflateAdapter(BluetoothAdapter *adapter, const QJsonObject &adapterObj);


### PR DESCRIPTION
the bluetooth interface load too late that when first access the
CanSendFile the interface is not ready.

Log: fix issue

Bug: https://pms.uniontech.com/bug-view-248523.html
