### PR TITLE
fix: When clearing the recycle bin, deleted files will remain for 1 second before disappearing and being deleted

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
@@ -58,6 +58,11 @@ bool Trash::start()
     return true;
 }
 
+Trash::~Trash()
+{
+    dpfSignalDispatcher->unsubscribe("dfmplugin_workspace", "signal_Model_EmptyDir", TrashHelper::instance(), &TrashHelper::onTrashEmptyState);
+}
+
 void Trash::onWindowOpened(quint64 windId)
 {
     auto window = FMWindowsIns.findWindowById(windId);
@@ -140,6 +145,7 @@ void Trash::addCustomTopWidget()
 
 void Trash::followEvents()
 {
+    dpfSignalDispatcher->subscribe("dfmplugin_workspace", "signal_Model_EmptyDir", TrashHelper::instance(), &TrashHelper::onTrashEmptyState);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction", TrashHelper::instance(), &TrashHelper::checkDragDropAction);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_DragDrop_FileCanMove", TrashHelper::instance(), &TrashHelper::checkCanMove);
     dpfHookSequence->follow("dfmplugin_detailspace", "hook_Icon_Fetch", TrashHelper::instance(), &TrashHelper::detailViewIcon);

--- a/src/plugins/filemanager/core/dfmplugin-trash/trash.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trash.h
@@ -23,6 +23,7 @@ class Trash : public dpf::Plugin
 public:
     virtual void initialize() override;
     virtual bool start() override;
+    ~Trash() override;
 
 private slots:
     void regTrashCrumbToTitleBar();

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.cpp
@@ -295,6 +295,24 @@ void TrashHelper::onTrashStateChanged()
 
     isTrashEmpty = !isTrashEmpty;
 
+    if (isTrashEmpty)
+        return;
+
+    const QList<quint64> &windowIds = FMWindowsIns.windowIdList();
+    for (const quint64 winId : windowIds) {
+        auto window = FMWindowsIns.findWindowById(winId);
+        if (window) {
+            const QUrl &url = window->currentUrl();
+            if (url.scheme() == scheme())
+                TrashEventCaller::sendShowEmptyTrash(winId, !isTrashEmpty);
+        }
+    }
+}
+
+void TrashHelper::onTrashEmptyState() {
+    isTrashEmpty = FileUtils::trashIsEmpty();
+    if (!isTrashEmpty)
+        return;
     const QList<quint64> &windowIds = FMWindowsIns.windowIdList();
     for (const quint64 winId : windowIds) {
         auto window = FMWindowsIns.findWindowById(winId);

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.h
@@ -68,6 +68,7 @@ public:
 
     bool customColumnRole(const QUrl &rootUrl, QList<DFMGLOBAL_NAMESPACE::ItemRoles> *roleList);
     bool customRoleDisplayName(const QUrl &url, const DFMGLOBAL_NAMESPACE::ItemRoles role, QString *displayName);
+    void onTrashEmptyState();
 
 private:
     void onTrashStateChanged();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.cpp
@@ -101,3 +101,8 @@ void WorkspaceEventCaller::sendEnterDirReportLog(const QVariantMap &data)
 {
     dpfSignalDispatcher->publish("dfmplugin_workspace", "signal_ReportLog_Commit", QString("EnterDirectory"), data);
 }
+
+void WorkspaceEventCaller::sendModelFilesEmpty()
+{
+    dpfSignalDispatcher->publish(kEventNS, "signal_Model_EmptyDir");
+}

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventcaller.h
@@ -42,6 +42,7 @@ public:
     static bool sendRenameEndEdit(const quint64 &winId, const QUrl &url);
     static bool sendViewItemClicked(const QVariantMap &data);
     static void sendEnterDirReportLog(const QVariantMap &data);
+    static void sendModelFilesEmpty();
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -766,6 +766,9 @@ void FileViewModel::onRemove(int firstIndex, int count)
 void FileViewModel::onRemoveFinish()
 {
     endRemoveRows();
+
+    if (filterSortWorker && filterSortWorker->childrenCount() <= 0 && UniversalUtils::urlEquals(rootUrl(), FileUtils::trashRootUrl()))
+        WorkspaceEventCaller::sendModelFilesEmpty();
 }
 
 void FileViewModel::onUpdateView()

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -29,6 +29,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SIGNAL(signal_View_RenameEndEdit)
     DPF_EVENT_REG_SIGNAL(signal_View_ItemClicked)
     DPF_EVENT_REG_SIGNAL(signal_View_HeaderViewSectionChanged)
+    DPF_EVENT_REG_SIGNAL(signal_Model_EmptyDir)
 
     DPF_EVENT_REG_SIGNAL(signal_ReportLog_MenuData)
     DPF_EVENT_REG_SIGNAL(signal_ReportLog_Commit)


### PR DESCRIPTION
Modify the change signal that only triggers the status of the trash can after the cleaning is completed on the clear trash can interface

Log: When clearing the recycle bin, deleted files will remain for 1 second before disappearing and being deleted
Bug: https://pms.uniontech.com/bug-view-243671.html