### PR TITLE
fix: [248437/dlnfs] cannot rename long name on dde-desktop

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -287,7 +287,7 @@ bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)
     const QString &suffix = info->nameOf(NameInfoType::kSuffix);
     if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop
         || info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
-            || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool()) {
+        || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool()) {
         const QUrl &url = info->urlOf(UrlInfoType::kUrl);
         QMimeType type = info->fileMimeType();
         if (!type.isValid())
@@ -1166,13 +1166,12 @@ bool FileUtils::setBackGround(const QString &pictureFilePath)
     }
 
     QDBusMessage message = QDBusMessage::createMethodCall(APPEARANCE_SERVICE,
-                                                      APPEARANCE_PATH,
-                                                      APPEARANCE_SERVICE,
-                                                      "Set");
+                                                          APPEARANCE_PATH,
+                                                          APPEARANCE_SERVICE,
+                                                          "Set");
     message.setArguments({ "greeterbackground", pictureFilePath });
     QDBusConnection::sessionBus().asyncCall(message);
     qCInfo(logDFMBase) << "setgreeterbackground calls Appearance Set";
-
 
     QDBusMessage msgIntrospect = QDBusMessage::createMethodCall(APPEARANCE_SERVICE,
                                                                 APPEARANCE_PATH,
@@ -1279,7 +1278,7 @@ bool FileUtils::fileCanTrash(const QUrl &url)
     // 获取当前配置
     bool alltotrash = DConfigManager::instance()->value(kDefaultCfgPath, kFileAllTrash).toBool();
     if (!alltotrash)
-        return info ? info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool(): isLocalDevice(url);
+        return info ? info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : isLocalDevice(url);
     if (!url.isValid())
         return false;
 
@@ -1327,7 +1326,7 @@ QString FileUtils::normalPathToTrash(const QString &normal)
 bool FileUtils::supportLongName(const QUrl &url)
 {
     const static QList<QString> datas {
-        "vfat", "exfat", "ntfs", "fuseblk"
+        "vfat", "exfat", "ntfs", "fuseblk", "fuse.dlnfs"
     };
 
     const QString &fileSystem = dfmio::DFMUtils::fsTypeFromUrl(url);

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -151,7 +151,7 @@ QWidget *CanvasItemDelegate::createEditor(QWidget *parent, const QStyleOptionVie
 {
     Q_UNUSED(index);
     auto editor = new ItemEditor(parent);
-    if (FileUtils::supportLongName(index.data(Global::ItemRoles::kItemUrlRole).toUrl()))
+    if (FileUtils::supportLongName(this->parent()->model()->rootUrl()))
         editor->setCharCountLimit();
     connect(editor, &ItemEditor::inputFocusOut, this, &CanvasItemDelegate::commitDataAndCloseEditor);
     editor->setOpacity(isTransparent(index) ? 0.3 : 1);
@@ -198,12 +198,12 @@ void CanvasItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index
 
     QString suffix = index.data(Global::ItemRoles::kItemFileSuffixOfRenameRole).toString();
     fmDebug() << "Display" << index.data(Global::ItemRoles::kItemFileDisplayNameRole).toString()
-             << "FileName" << index.data(Global::ItemRoles::kItemNameRole).toString()
-             << "FileNameofrenmae" << index.data(Global::ItemRoles::kItemFileNameOfRenameRole).toString()
-             << "BaseName" << index.data(Global::ItemRoles::kItemFileBaseNameRole).toString()
-             << "BaseNameofrename" << index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString()
-             << "suffix" << index.data(Global::ItemRoles::kItemFileSuffixRole).toString()
-             << "suffixofrename" << suffix;
+              << "FileName" << index.data(Global::ItemRoles::kItemNameRole).toString()
+              << "FileNameofrenmae" << index.data(Global::ItemRoles::kItemFileNameOfRenameRole).toString()
+              << "BaseName" << index.data(Global::ItemRoles::kItemFileBaseNameRole).toString()
+              << "BaseNameofrename" << index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString()
+              << "suffix" << index.data(Global::ItemRoles::kItemFileSuffixRole).toString()
+              << "suffixofrename" << suffix;
     if (showSuffix) {
         QString name = index.data(Global::ItemRoles::kItemFileNameOfRenameRole).toString();
         itemEditor->setMaximumLength(NAME_MAX);

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -170,7 +170,7 @@ QWidget *CollectionItemDelegate::createEditor(QWidget *parent, const QStyleOptio
 {
     Q_UNUSED(index);
     auto editor = new ItemEditor(parent);
-    if (FileUtils::supportLongName(index.data(Global::ItemRoles::kItemUrlRole).toUrl()))
+    if (FileUtils::supportLongName(this->parent()->model()->rootUrl()))
         editor->setCharCountLimit();
     connect(editor, &ItemEditor::inputFocusOut, this, &CollectionItemDelegate::commitDataAndCloseEditor);
     editor->setOpacity(isTransparent(index) ? 0.3 : 1);
@@ -221,12 +221,12 @@ void CollectionItemDelegate::setEditorData(QWidget *editor, const QModelIndex &i
 
     QString suffix = index.data(Global::ItemRoles::kItemFileSuffixOfRenameRole).toString();
     fmDebug() << "Display" << index.data(Global::ItemRoles::kItemFileDisplayNameRole).toString()
-             << "FileName" << index.data(Global::ItemRoles::kItemNameRole).toString()
-             << "FileNameofrenmae" << index.data(Global::ItemRoles::kItemFileNameOfRenameRole).toString()
-             << "BaseName" << index.data(Global::ItemRoles::kItemFileBaseNameRole).toString()
-             << "BaseNameofrename" << index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString()
-             << "suffix" << index.data(Global::ItemRoles::kItemFileSuffixRole).toString()
-             << "suffixofrename" << suffix;
+              << "FileName" << index.data(Global::ItemRoles::kItemNameRole).toString()
+              << "FileNameofrenmae" << index.data(Global::ItemRoles::kItemFileNameOfRenameRole).toString()
+              << "BaseName" << index.data(Global::ItemRoles::kItemFileBaseNameRole).toString()
+              << "BaseNameofrename" << index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString()
+              << "suffix" << index.data(Global::ItemRoles::kItemFileSuffixRole).toString()
+              << "suffixofrename" << suffix;
     if (showSuffix) {
         QString name = index.data(Global::ItemRoles::kItemFileNameOfRenameRole).toString();
         itemEditor->setMaximumLength(NAME_MAX);


### PR DESCRIPTION
wrong url that model of desktop never provide was passed to determind if
long name is supported.

Log: fix issue.

Bug: https://pms.uniontech.com/bug-view-248437.html
