### PR TITLE
fix: When performing file operations, the information display in the progress dialog box is not horizontally centered

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -24,7 +24,8 @@
 DWIDGET_USE_NAMESPACE
 using namespace dfmbase;
 
-static constexpr int kMsgLabelWidth { 350 };
+static constexpr int kMsgLabelWidth { 390 };
+static constexpr int kMsgLabelHoverWidth { 452 };
 static constexpr int kSpeedLabelWidth { 100 };
 static constexpr uint8_t kVirtualValue { 30 };
 static constexpr char kBtnPropertyActionName[] { "btnType" };
@@ -690,8 +691,9 @@ void TaskWidget::onMouseHover(const bool hover)
 
     lbSpeed->setHidden(hover);
     lbRmTime->setHidden(hover);
-
-    update(rect());
+    lbSrcPath->setFixedWidth(hover ? kMsgLabelHoverWidth : kMsgLabelWidth);
+    lbDstPath->setFixedWidth(hover ? kMsgLabelHoverWidth : kMsgLabelWidth);
+    adjustSize();
 }
 
 QString TaskWidget::formatTime(qint64 second) const


### PR DESCRIPTION
No adaptation during adaptive width

Log: When performing file operations, the information display in the progress dialog box is not horizontally centered
Bug: https://pms.uniontech.com/bug-view-242561.html