### PR TITLE
fix: [workspace] drag file to weixin failed in some platform.

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.cpp
@@ -20,6 +20,8 @@ DFMBASE_USE_NAMESPACE
 DFMGLOBAL_USE_NAMESPACE
 using namespace ddplugin_canvas;
 
+inline constexpr char kDdeDestop[] { "dde-desktop" };
+
 CanvasProxyModelPrivate::CanvasProxyModelPrivate(CanvasProxyModel *qq)
     : QObject(qq), q(qq)
 {
@@ -715,7 +717,7 @@ QMimeData *CanvasProxyModel::mimeData(const QModelIndexList &indexes) const
     } else {
         mimedt->setUrls(urls);
     }
-
+    mimedt->setText(kDdeDestop);
     // set user id
     SysInfoUtils::setMimeDataUserId(mimedt);
 

--- a/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
@@ -22,6 +22,8 @@
 DFMBASE_USE_NAMESPACE
 using namespace ddplugin_organizer;
 
+inline constexpr char kDdeDesktopOrganizer[] { "dde-desktop-organizer" };
+
 CollectionModelPrivate::CollectionModelPrivate(CollectionModel *qq)
     : QObject(qq), q(qq)
 {
@@ -482,9 +484,8 @@ QMimeData *CollectionModel::mimeData(const QModelIndexList &indexes) const
 
     for (const QModelIndex &idx : indexes)
         urls << fileUrl(idx);
-
+    mm->setText(kDdeDesktopOrganizer);
     mm->setUrls(urls);
-
     // set user id
     SysInfoUtils::setMimeDataUserId(mm);
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -37,6 +37,8 @@ DFMGLOBAL_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_workspace;
 
+inline constexpr char kDdeFileManager[] { "dde-fileManager" };
+
 FileViewModel::FileViewModel(QAbstractItemView *parent)
     : QAbstractItemModel(parent)
 
@@ -452,7 +454,7 @@ QMimeData *FileViewModel::mimeData(const QModelIndexList &indexes) const
     }
 
     QMimeData *data = new QMimeData();
-
+    data->setText(kDdeFileManager);
     data->setUrls(urls);
     SysInfoUtils::setMimeDataUserId(data);
 


### PR DESCRIPTION
1. If not set the mimeData text, the weixin will ignore the drag event.
2. The weixin not override the drag event, it use the default of qt5.15.
3. So, file manager set the text.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-248591.html