### PR TITLE
fix: [music-preview] The slider not move.

### DIFF
--- a/src/plugins/common/dfmplugin-preview/pluginpreviews/music-preview/toolbarframe.cpp
+++ b/src/plugins/common/dfmplugin-preview/pluginpreviews/music-preview/toolbarframe.cpp
@@ -72,10 +72,9 @@ void ToolBarFrame::onPlayPositionChanged(qint64 pos)
 
 void ToolBarFrame::onPlayStateChanged(const QMediaPlayer::State &state)
 {
-    if (state == QMediaPlayer::StoppedState) {
-        curState = QMediaPlayer::State::StoppedState;
+    curState = state;
+    if (state == QMediaPlayer::StoppedState)
         progressSlider->setValue(0);
-    }
 
     if (state == QMediaPlayer::StoppedState || state == QMediaPlayer::PausedState) {
         playControlButton->setIcon(QIcon::fromTheme(":/icons/icons/start_normal.png"));


### PR DESCRIPTION
1. When play music, The slider not move.
2. The state not update.

Log: fix issue
Task: https://pms.uniontech.com/bug-view-235375.html