### PR TITLE
fix: [ui]Fix the desktop showing issue

### DIFF
--- a/src/plugins/server/core/serverplugin-core/devicemanagerdbus.cpp
+++ b/src/plugins/server/core/serverplugin-core/devicemanagerdbus.cpp
@@ -110,7 +110,7 @@ void DeviceManagerDBus::initConnection()
 void DeviceManagerDBus::requestRefreshDesktopAsNeeded(const QString &path, const QString &operation)
 {
     QString desktopPath = StandardPaths::location(StandardPaths::kDesktopPath);
-    if (desktopPath.isEmpty())
+    if (desktopPath.isEmpty() || path.isEmpty())
         return;
 
     fmDebug() << "looking for link files from" << desktopPath;
@@ -123,10 +123,13 @@ void DeviceManagerDBus::requestRefreshDesktopAsNeeded(const QString &path, const
         return target.startsWith(path);
     });
     if (hasFileLinkToTarget) {
-        QDBusInterface ifs("com.deepin.dde.desktop",
-                           "/com/deepin/dde/desktop",
-                           "com.deepin.dde.desktop");
-        ifs.asyncCall("Refresh");
+        // send refresh request delay 3s which walkaround the device is moounting,such as ntfs.
+        QTimer::singleShot(3 * 1000, []() {
+            QDBusInterface ifs("com.deepin.dde.desktop",
+                               "/com/deepin/dde/desktop",
+                               "com.deepin.dde.desktop");
+            ifs.asyncCall("Refresh");
+        });
         fmInfo() << "refresh desktop async finished..." << operation << path;
     }
 }


### PR DESCRIPTION
If there is a link for big NTFS mounted path, it refreshs will be blocked, delay 3s to refresh for links.

Log: fix desktop showing issue.
Bug: https://pms.uniontech.com/bug-view-247785.html