### PR TITLE
fix: When sending SMB files to the desktop, the main directory in the dde-file-manager sidebar accesses the desktop directory, causing the dde-file-manger to crash

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -502,7 +502,7 @@ void AsyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> 
     auto typeAll = types;
     if (typeAll.isEmpty()) {
         if (isAttributes(OptInfoType::kIsSymLink)) {
-            auto target = d->symLinkTarget();
+            auto target = pathOf(PathInfoType::kSymLinkTarget);
             if (!target.isEmpty() && target != filePath()) {
                 FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(target));
                 if (info)

--- a/src/dfm-base/file/local/localfileiconprovider.cpp
+++ b/src/dfm-base/file/local/localfileiconprovider.cpp
@@ -40,7 +40,13 @@ QIcon LocalFileIconProviderPrivate::fileSystemIcon(const QString &path) const
 
 QIcon LocalFileIconProviderPrivate::fromTheme(QString iconName) const
 {
-    QIcon icon = QIcon::fromTheme(iconName);
+    QIcon icon;
+    {
+        static QMutex mut;
+        QMutexLocker lk(&mut);
+        icon = QIcon::fromTheme(iconName);
+    }
+
 
     if (Q_LIKELY(!icon.isNull()))
         return icon;


### PR DESCRIPTION
When using the fromthem interface with multiple threads, it caused a crash. Here, a lock is added to handle it

Log: When sending SMB files to the desktop, the main directory in the dde-file-manager sidebar accesses the desktop directory, causing the dde-file-manager to crash
Bug: https://pms.uniontech.com/bug-view-249663.html