### PR TITLE
fix: lost "Clear recent history" action in sidebar

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-recent/recent.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/recent.cpp
@@ -81,18 +81,10 @@ void Recent::onWindowOpened(quint64 windId)
     else
         connect(window, &FileManagerWindow::titleBarInstallFinished, this, &Recent::regRecentCrumbToTitleBar, Qt::DirectConnection);
 
-    auto bookmarkPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-bookmark") };
-    if (bookmarkPlugin && bookmarkPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
-        updateRecentItemToSideBar();
-    } else {
-        connect(
-                DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this, [this](const QString &iid, const QString &name) {
-                    Q_UNUSED(iid)
-                    if (name == "dfmplugin-bookmark")
-                        updateRecentItemToSideBar();
-                },
-                Qt::DirectConnection);
-    }
+    if (window->sideBar())
+        regRecentItemToSideBar();
+    else
+        connect(window, &FileManagerWindow::sideBarInstallFinished, this, &Recent::regRecentItemToSideBar, Qt::DirectConnection);
 }
 
 void Recent::updateRecentItemToSideBar()
@@ -149,6 +141,22 @@ void Recent::regRecentCrumbToTitleBar()
     QVariantMap property;
     property["Property_Key_HideTreeViewBtn"] = true;
     dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", RecentHelper::scheme(), property);
+}
+
+void Recent::regRecentItemToSideBar()
+{
+    auto bookmarkPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-bookmark") };
+    if (bookmarkPlugin && bookmarkPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
+        updateRecentItemToSideBar();
+    } else {
+        connect(
+                DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this, [this](const QString &iid, const QString &name) {
+                    Q_UNUSED(iid)
+                    if (name == "dfmplugin-bookmark")
+                        updateRecentItemToSideBar();
+                },
+                Qt::DirectConnection);
+    }
 }
 
 void Recent::addFileOperations()

--- a/src/plugins/filemanager/core/dfmplugin-recent/recent.h
+++ b/src/plugins/filemanager/core/dfmplugin-recent/recent.h
@@ -27,6 +27,7 @@ public:
 private slots:
     void onWindowOpened(quint64 windId);
     void regRecentCrumbToTitleBar();
+    void regRecentItemToSideBar();
 
 private:
     void addFileOperations();

--- a/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
@@ -71,6 +71,22 @@ void Trash::onWindowOpened(quint64 windId)
     else
         connect(window, &FileManagerWindow::titleBarInstallFinished, this, &Trash::regTrashCrumbToTitleBar, Qt::DirectConnection);
 
+    if (window->sideBar())
+        regTrashItemToSideBar();
+    else
+        connect(window, &FileManagerWindow::sideBarInstallFinished, this, &Trash::regTrashItemToSideBar, Qt::DirectConnection);
+}
+
+void Trash::regTrashCrumbToTitleBar()
+{
+    static std::once_flag flag;
+    std::call_once(flag, []() {
+        dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", TrashHelper::scheme(), QVariantMap {});
+    });
+}
+
+void Trash::regTrashItemToSideBar()
+{
     auto bookmarkPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-bookmark") };
     if (bookmarkPlugin && bookmarkPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
         updateTrashItemToSideBar();
@@ -83,14 +99,6 @@ void Trash::onWindowOpened(quint64 windId)
                 },
                 Qt::DirectConnection);
     }
-}
-
-void Trash::regTrashCrumbToTitleBar()
-{
-    static std::once_flag flag;
-    std::call_once(flag, []() {
-        dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", TrashHelper::scheme(), QVariantMap {});
-    });
 }
 
 void Trash::updateTrashItemToSideBar()

--- a/src/plugins/filemanager/core/dfmplugin-trash/trash.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trash.h
@@ -27,6 +27,7 @@ public:
 
 private slots:
     void regTrashCrumbToTitleBar();
+    void regTrashItemToSideBar();
     void onWindowOpened(quint64 windId);
 
 private:


### PR DESCRIPTION
`SideBar::onWindowOpened` invoked after `Recent::onWindowOpened`

Log: fix lost "Clear recent history" action in sidebar

Bug: https://pms.uniontech.com/bug-view-250369.html