### PR TITLE
fix: Opening multiple SMB server windows, unable to refresh SMB server modifications

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -840,10 +840,14 @@ void FileViewModel::onWorkFinish(int visiableCount, int totalCount)
     closeCursorTimer();
 }
 
-void FileViewModel::connectRootAndFilterSortWork(const RootInfo *root)
+void FileViewModel::connectRootAndFilterSortWork(RootInfo *root)
 {
     if (filterSortWorker.isNull())
         return;
+    auto token = QString::number(quintptr(filterSortWorker.data()), 16);
+    if (root->connectTokens().contains(token))
+        return;
+    root->addConnectToken(token);
     connect(root, &RootInfo::requestCloseTab, this, [](const QUrl &url) { WorkspaceHelper::instance()->closeTab(url); }, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::getSourceData, root, &RootInfo::handleGetSourceData, Qt::QueuedConnection);
     connect(root, &RootInfo::sourceDatas, filterSortWorker.data(), &FileSortWorker::handleSourceChildren, Qt::QueuedConnection);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -135,7 +135,7 @@ public Q_SLOTS:
     void onWorkFinish(int visiableCount, int totalCount);
 
 private:
-    void connectRootAndFilterSortWork(const RootInfo *root);
+    void connectRootAndFilterSortWork(RootInfo *root);
     void initFilterSortWork();
     void quitFilterSortWork();
     void discardFilterSortObjects();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -51,6 +51,8 @@ bool RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::Ite
         traversalThread->traversalThread->disconnect();
     } else {
         isGetCache = (canCache && traversalFinish) || traversaling;
+        if (canCache && traversalFinish && isRefresh)
+            isGetCache = false;
     }
 
     traversalThread.reset(new DirIteratorThread);
@@ -130,7 +132,7 @@ void RootInfo::startWatcher()
     watcher->restartWatcher();
 }
 
-int RootInfo::clearTraversalThread(const QString &key)
+int RootInfo::clearTraversalThread(const QString &key, const bool isRefresh)
 {
     if (!traversalThreads.contains(key))
         return traversalThreads.count();
@@ -153,6 +155,7 @@ int RootInfo::clearTraversalThread(const QString &key)
     if (traversalThreads.isEmpty())
         needStartWatcher = true;
 
+    this->isRefresh = isRefresh;
     return traversalThreads.count();
 }
 
@@ -366,6 +369,9 @@ void RootInfo::handleTraversalFinish(const QString &travseToken)
     traversaling = false;
     emit traversalFinished(travseToken);
     traversalFinish = true;
+    if (isRefresh) {
+        isRefresh = false;
+    }
 }
 
 void RootInfo::handleTraversalSort(const QString &travseToken)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -46,9 +46,16 @@ public:
     bool initThreadOfFileData(const QString &key,
                               DFMGLOBAL_NAMESPACE::ItemRoles role, Qt::SortOrder order, bool isMixFileAndFolder);
     void startWork(const QString &key, const bool getCache = false);
-    int clearTraversalThread(const QString &key);
+    int clearTraversalThread(const QString &key, const bool isRefresh = false);
 
     void reset();
+
+    void addConnectToken(const QString &token) {
+        if (connectedTokens.contains(token))
+            return;
+        connectedTokens << token;
+    }
+    QStringList connectTokens() const { return connectedTokens; }
 
 Q_SIGNALS:
 
@@ -147,6 +154,8 @@ private:
     QList<TraversalThreadPointer> discardedThread {};
     QList<QSharedPointer<QThread>> threads {};
     std::atomic_bool needStartWatcher { true };
+    std::atomic_bool isRefresh { false };
+    QStringList connectedTokens;
 };
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -51,12 +51,13 @@ void FileDataManager::cleanRoot(const QUrl &rootUrl, const QString &key, const b
             continue;
 
         if (rootInfo.path().startsWith(rootPath) || rootInfo.path() == rootUrl.path()) {
-            auto count = rootInfoMap.value(rootInfo)->clearTraversalThread(key);
+            auto count = rootInfoMap.value(rootInfo)->clearTraversalThread(key, refresh);
             if (count > 0)
                 continue;
             if (!checkNeedCache(rootInfo) || refresh) {
-                rootInfoMap.value(rootInfo)->disconnect();
-                rootInfoMap.value(rootInfo)->reset();
+                auto root = rootInfoMap.take(rootInfo);
+                if (root)
+                    delete root;
             }
         }
     }


### PR DESCRIPTION
Because in multi window mode, cache data is obtained when starting stacking. When modifying to multiple windows, each window is refreshed before re iterating.

Log: Opening multiple SMB server windows, unable to refresh SMB server modifications
Bug: https://pms.uniontech.com/bug-view-248847.html