### PR TITLE
fix: [ui] ban animation of the propertydialog

### DIFF
--- a/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
+++ b/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
@@ -45,13 +45,14 @@ void BasicStatusBarPrivate::initTipLabel()
 
 void BasicStatusBarPrivate::initLayout()
 {
+    q->setFixedHeight(30);
     q->setContentsMargins(0, 0, 0, 0);
     auto vLayout = new QVBoxLayout(q);
     vLayout->setMargin(0);
     vLayout->setSpacing(0);
     auto line = new DTK_WIDGET_NAMESPACE::DHorizontalLine(q);
     line->setContentsMargins(0, 0, 0, 0);
-    line->setFixedHeight(1);
+    line->setLineWidth(1);
     vLayout->addWidget(line);
 
     layout = new QHBoxLayout;
@@ -67,7 +68,7 @@ void BasicStatusBarPrivate::calcFolderContains(const QList<QUrl> &folderList)
 {
     discardCurrentJob();
 
-    fileStatisticsJog.reset( new FileStatisticsJob());
+    fileStatisticsJog.reset(new FileStatisticsJob());
     fileStatisticsJog->setFileHints(FileStatisticsJob::kExcludeSourceFile | FileStatisticsJob::kSingleDepth);
 
     if (isJobDisconnect) {
@@ -113,7 +114,7 @@ void BasicStatusBarPrivate::discardCurrentJob()
 
     if (fileStatisticsJog->isRunning()) {
         auto waitDeletePointer = fileStatisticsJog;
-        connect(waitDeletePointer.data(), &FileStatisticsJob::finished, this, [this,waitDeletePointer]{
+        connect(waitDeletePointer.data(), &FileStatisticsJob::finished, this, [this, waitDeletePointer] {
             waitDeleteJobList.removeOne(waitDeletePointer);
         });
         fileStatisticsJog->stop();

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -15,6 +15,7 @@
 
 #include <DFontSizeManager>
 #include <denhancedwidget.h>
+#include <dtkgui_config.h>
 
 #include <QDateTime>
 #include <QKeyEvent>
@@ -49,6 +50,9 @@ FilePropertyDialog::FilePropertyDialog(QWidget *parent)
     this->setAttribute(Qt::WA_DeleteOnClose, true);
     connect(&FileInfoHelper::instance(), &FileInfoHelper::fileRefreshFinished, this,
             &FilePropertyDialog::onFileInfoUpdated, Qt::QueuedConnection);
+#ifdef DTKGUI_VERSION_STR
+    platformWindowHandle->setWindowEffect(DPlatformWindowHandle::EffectScene::EffectNoStart);
+#endif
 }
 
 FilePropertyDialog::~FilePropertyDialog()


### PR DESCRIPTION
Cancel the pop-up animation of the propertydialog to make the file manager and desktop consistent

Log: ban animation of the propertydialog
Bug: https://pms.uniontech.com/bug-view-245215.html