### PR TITLE
fix: Enter the directory and keep circling around

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -840,14 +840,16 @@ void FileViewModel::onWorkFinish(int visiableCount, int totalCount)
     closeCursorTimer();
 }
 
-void FileViewModel::connectRootAndFilterSortWork(RootInfo *root)
+void FileViewModel::connectRootAndFilterSortWork(RootInfo *root, const bool refresh)
 {
     if (filterSortWorker.isNull())
         return;
-    auto token = QString::number(quintptr(filterSortWorker.data()), 16);
-    if (root->connectTokens().contains(token))
-        return;
-    root->addConnectToken(token);
+    if (refresh) {
+        auto token = QString::number(quintptr(filterSortWorker.data()), 16);
+        if (root->connectTokens().contains(token))
+            return;
+        root->addConnectToken(token);
+    }
     connect(root, &RootInfo::requestCloseTab, this, [](const QUrl &url) { WorkspaceHelper::instance()->closeTab(url); }, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::getSourceData, root, &RootInfo::handleGetSourceData, Qt::QueuedConnection);
     connect(root, &RootInfo::sourceDatas, filterSortWorker.data(), &FileSortWorker::handleSourceChildren, Qt::QueuedConnection);
@@ -909,7 +911,7 @@ void FileViewModel::initFilterSortWork()
         canFetchFiles = true;
         fetchingUrl = rootUrl();
         RootInfo *root = FileDataManager::instance()->fetchRoot(dirRootUrl);
-        connectRootAndFilterSortWork(root);
+        connectRootAndFilterSortWork(root, true);
         fetchMore(rootIndex()); }, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::updateRow, this, &FileViewModel::onFileUpdated, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::selectAndEditFile, this, &FileViewModel::selectAndEditFile, Qt::QueuedConnection);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.h
@@ -135,7 +135,7 @@ public Q_SLOTS:
     void onWorkFinish(int visiableCount, int totalCount);
 
 private:
-    void connectRootAndFilterSortWork(RootInfo *root);
+    void connectRootAndFilterSortWork(RootInfo *root, const bool refresh = false);
     void initFilterSortWork();
     void quitFilterSortWork();
     void discardFilterSortObjects();


### PR DESCRIPTION
Signal connection issue, can only be determined when forcibly refreshing to determine if it has been connected

Log: Enter the directory and keep circling around