### PR TITLE
fix: Optical disc item was accidentally left in the dock plugin

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
@@ -50,6 +50,8 @@ void DockItemDataManager::onBlockMounted(const QString &id)
 
 void DockItemDataManager::onBlockUnmounted(const QString &id)
 {
+    if (!blocks.contains(id))
+        return;
     blocks.remove(id);
     Q_EMIT mountRemoved(id);
     updateDockVisible();
@@ -63,6 +65,13 @@ void DockItemDataManager::onBlockPropertyChanged(const QString &id, const QStrin
             onBlockUnmounted(id);
         else
             onBlockMounted(id);
+    }
+
+    // 光盘被物理弹出
+    if (id.contains(QRegularExpression("/sr[0-9]*$"))
+        && property == GlobalServerDefines::DeviceProperty::kMediaAvailable
+        && !value.variant().toBool()) {
+        onBlockUnmounted(id);
     }
 }
 


### PR DESCRIPTION
Physical eject discs remove data from Optical Disc Items by changing the property `MediaAvailable`.

Log: fix dock plugin bug

Bug: https://pms.uniontech.com/bug-view-251717.html