### PR TITLE
fix: The dde-file-manager system entered the directory, but after the terminal rm deleted the directory, the dde-file-managersystem did not jump out

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -272,6 +272,7 @@ void RootInfo::doWatcherEvent()
                 emit InfoCacheController::instance().removeCacheFileInfo({ fileUrl });
                 WatcherCache::instance().removeCacheWatcherByParent(fileUrl);
                 emit requestCloseTab(fileUrl);
+                emit requestClearRoot(fileUrl);
                 QWriteLocker lk(&childrenLock);
                 childrenUrlList.clear();
                 sourceDataList.clear();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -84,6 +84,7 @@ Q_SIGNALS:
 
     void requestTreeSortDir(const QString &key, const QUrl &parent);
     void renameFileProcessStarted();
+    void requestClearRoot(const QUrl &url);
 
 public Q_SLOTS:
     void doFileDeleted(const QUrl &url);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -57,7 +57,7 @@ void FileDataManager::cleanRoot(const QUrl &rootUrl, const QString &key, const b
             if (!checkNeedCache(rootInfo) || refresh) {
                 auto root = rootInfoMap.take(rootInfo);
                 if (root)
-                    delete root;
+                    root->deleteLater();
             }
         }
     }
@@ -75,7 +75,7 @@ void FileDataManager::cleanRoot(const QUrl &rootUrl)
             rootInfoMap.value(rootInfo)->disconnect();
             auto root = rootInfoMap.take(rootInfo);
             if (root)
-                delete root;
+                root->deleteLater();
         }
     }
 }
@@ -103,8 +103,7 @@ FileDataManager::FileDataManager(QObject *parent)
 {
     isMixFileAndFolder = Application::instance()->appAttribute(Application::kFileAndDirMixedSort).toBool();
     connect(Application::instance(), &Application::appAttributeChanged, this, &FileDataManager::onAppAttributeChanged);
-    connect(&WatcherCache::instance(), &WatcherCache::fileDelete, this, &FileDataManager::onHandleFileDeleted,
-            Qt::QueuedConnection);
+
 }
 
 FileDataManager::~FileDataManager()
@@ -121,6 +120,8 @@ RootInfo *FileDataManager::createRoot(const QUrl &url)
 
     // insert it to rootInfoMap
     rootInfoMap.insert(url, root);
+    connect(root, &RootInfo::requestClearRoot, this, &FileDataManager::onHandleFileDeleted,
+            Qt::QueuedConnection);
 
     return root;
 }


### PR DESCRIPTION
Use the filedelete signal of rootinfo to send requestClearRoot for rootinfo cleaning and deconstruction

Log: The dde-file-manager system entered the directory, but after the terminal rm deleted the directory, the dde-file-managersystem did not jump out
Bug: https://pms.uniontech.com/bug-view-251907.html