### PR TITLE
fix: Add setText when writing to the clipboard, triggering the dbus signal of the clipboard

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -191,6 +191,7 @@ void ClipBoard::setCurUrlToClipboardForRemote(const QUrl &curUrl)
         return;
     QMimeData *mimeData = new QMimeData();
     mimeData->setData(GlobalData::kRemoteAssistanceCopyKey, localPath);
+    mimeData->setText(curUrl.toString());
     qApp->clipboard()->setMimeData(mimeData);
 }
 /*!


### PR DESCRIPTION
Add setText when writing to the clipboard, triggering the dbus signal of the clipboard

Log: Add setText when writing to the clipboard, triggering the dbus signal of the clipboard
Bug: https://pms.uniontech.com/bug-view-245689.html