### PR TITLE
feat: Do not check the patch directory of deepin-deb-fix when checking MIME data

### DIFF
--- a/src/dfm-base/mimetype/mimesappsmanager.cpp
+++ b/src/dfm-base/mimetype/mimesappsmanager.cpp
@@ -419,9 +419,13 @@ QStringList MimesAppsManager::getApplicationsFolders()
     desktopFolders << QString("/usr/share/applications")
                    << QString("/usr/local/share/applications")
                    << QString("/usr/share/gnome/applications");
+
+    // Exclude directory for desktop files patched by deepin-deb-fix
+    QStringList desktopFoldersExclude;
+    desktopFoldersExclude << "/usr/share/deepin-desktop-fix/applications";
     // env for XDG_DATA_DIRS
     for (const QString &path : QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation)) {
-        if (desktopFolders.contains(path))
+        if (desktopFolders.contains(path) || desktopFoldersExclude.contains(path))
             continue;
         desktopFolders.append(path);
     }


### PR DESCRIPTION
Deepin-deb-fix has patched some startup scripts without adding shebang and desktop files, and placed the patched desktop files in "/usr/share/deepin-desktop-fix/applications". When checking mimedata, this directory should not be checked to prevent multiple uninstalled applications from appearing in the open application list

某些应用启动脚本没有shebeng，直接丢到systemd中启动会造成启动失败，所以做了一个deepin-deb-fix的包用于将这些有问题的脚本加上shebeng并安装到系统中，安装修补包的时候会将有问题包的desktop和启动脚本分别安装到/us/share/deepin-desktop-fix/applications/和/opt/deepin-apps-fix/中，文管会直接检查XDG_DATA_DIR来扫描这个修补目录的desktop文件，会认为是安装了一个正常的应用并错误的显示在打开方式中（其实应用并没有实际安装）.

故提此pr，文管应在这里排除修补目录来适配deepin-deb-fix（为了发版做的临时方案），后续会提pr以下面的方式修改

后续建议文管在扫描desktop文件的mime信息的时候应该提前检查一下TryExec字段是否有效，如果TryExec无效，应当忽略这个desktop文件，认为这个desktop文件是无效的

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html 参见这里的TryExec字段描述