### PR TITLE
feat: [titlebar] Add 'OpenDirInNewTab' action in setting menu.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/dfmplugin_titlebar_global.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/dfmplugin_titlebar_global.h
@@ -49,7 +49,8 @@ enum MenuAction {
     kConnectToServer,
     kSetUserSharePassword,
     kChangeDiskPassword,
-    kSettings
+    kSettings,
+    kOpenInNewTab
 };
 
 // error code of change disk password

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -69,6 +69,10 @@ void TitleBarHelper::createSettingsMenu(quint64 id)
     action->setData(MenuAction::kNewWindow);
     menu->addAction(action);
 
+    action = new QAction(QObject::tr("Open in new tab"), menu);
+    action->setData(MenuAction::kOpenInNewTab);
+    menu->addAction(action);
+
     menu->addSeparator();
 
     action = new QAction(QObject::tr("Connect to Server"), menu);
@@ -240,6 +244,15 @@ void TitleBarHelper::handlePressed(QWidget *sender, const QString &text, bool *i
     }
 }
 
+void TitleBarHelper::openCurrentUrlInNewTab(quint64 windowId)
+{
+    FileManagerWindowsManager::FMWindow *window = FMWindowsIns.findWindowById(windowId);
+    if (!window)
+        return;
+
+    TitleBarEventCaller::sendOpenTab(windowId, window->currentUrl());
+}
+
 void TitleBarHelper::showSettingsDialog(quint64 windowId)
 {
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kShowSettingDialog, windowId);
@@ -309,6 +322,9 @@ void TitleBarHelper::handleSettingMenuTriggered(quint64 windowId, int action)
     switch (static_cast<MenuAction>(action)) {
     case MenuAction::kNewWindow:
         TitleBarEventCaller::sendOpenWindow(QUrl());
+        break;
+    case MenuAction::kOpenInNewTab:
+        TitleBarHelper::openCurrentUrlInNewTab(windowId);
         break;
     case MenuAction::kSettings:
         TitleBarHelper::showSettingsDialog(windowId);

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.h
@@ -29,6 +29,7 @@ public:
     static bool displayIcon();
     static void handlePressed(QWidget *sender, const QString &text, bool *isSearch = nullptr);
 
+    static void openCurrentUrlInNewTab(quint64 windowId);
     static void showSettingsDialog(quint64 windowId);
     static void showConnectToServerDialog(quint64 windowId);
     static void showUserSharePasswordSettingDialog(quint64 windowId);


### PR DESCRIPTION
1. Add open current url in new tab action in setting menu.

Log: add feat of add action in setting menu.
Task: https://pms.uniontech.com/task-view-342521.html