### PR TITLE
fix: [workspace] Sliding bars and rolling very slowly.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -484,12 +484,20 @@ void FileView::wheelEvent(QWheelEvent *event)
             emit viewStateChanged();
             event->accept();
         } else {
+#ifdef QT_SCROLL_WHEEL_ANI
             DListView::wheelEvent(event);
+#else
+            verticalScrollBar()->setSliderPosition(verticalScrollBar()->sliderPosition() - event->angleDelta().y());
+#endif
         }
     } else if (event->modifiers() == Qt::AltModifier || event->orientation() == Qt::Horizontal) {
         horizontalScrollBar()->setSliderPosition(horizontalScrollBar()->sliderPosition() - event->angleDelta().x());
     } else {
+#ifdef QT_SCROLL_WHEEL_ANI
         DListView::wheelEvent(event);
+#else
+        verticalScrollBar()->setSliderPosition(verticalScrollBar()->sliderPosition() - event->angleDelta().y());
+#endif
     }
 }
 


### PR DESCRIPTION
1. When qt version below 5.11.3.59, rolling very slowly.
2. Add protection code to avoid this situation.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-249759.html