### PR TITLE
fix: Dragging to a read-only directory or a read-only USB drive with the mouse status disabled

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -102,7 +102,7 @@ bool DragDropHelper::dragMove(QDragMoveEvent *event)
         return true;
 
     QUrl toUrl = hoverFileInfo->urlOf(UrlInfoType::kUrl);
-    if (!checkTargetEnable(toUrl)) {
+    if (!checkTargetEnable(toUrl) || !hoverFileInfo->isAttributes(OptInfoType::kIsWritable)) {
         event->ignore();
         currentHoverIndexUrl = toUrl;
         return true;


### PR DESCRIPTION
Dragging to a read-only directory or a read-only USB drive with the mouse status disabled

Log: Dragging to a read-only directory or a read-only USB drive with the mouse status disabled
Bug: https://pms.uniontech.com/bug-view-254291.html