### PR TITLE
fix: Copying files to external device stopped midway, unable to remove external device

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -244,12 +244,16 @@ bool DoCopyFileWorker::doCopyFilePractically(const FileInfoPointer fromInfo, con
         if (!doReadFile(fromInfo, toInfo, fromDevice, data, blockSize, sizeRead, skip)) {
             delete[] data;
             data = nullptr;
+            if (toFd > 0)
+                close(toFd);
             return false;
         }
 
         if (!doWriteFile(fromInfo, toInfo, toDevice, data, sizeRead, skip)) {
             delete[] data;
             data = nullptr;
+            if (toFd > 0)
+                close(toFd);
             return false;
         }
 


### PR DESCRIPTION
Halfway stop without closing the synchronization file descriptor

Log: Copying files to external device stopped midway, unable to remove external device
Bug: https://pms.uniontech.com/bug-view-254221.html