### PR TITLE
fix: [254647/dock] device list might be shorten

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
@@ -24,12 +24,6 @@ DeviceList::DeviceList(QWidget *parent)
     initConnect();
 }
 
-void DeviceList::showEvent(QShowEvent *event)
-{
-    updateHeight();
-    QScrollArea::showEvent(event);
-}
-
 void DeviceList::addDevice(const DockItemData &item)
 {
     if (deviceItems.contains(item.id))
@@ -117,7 +111,7 @@ void DeviceList::updateHeight()
     int contentHeight = 50 + kDeviceItemHeight * deviceItems.count();
     if (contentHeight > 420)
         contentHeight = 420;
-    setFixedHeight(contentHeight);
+    resize(width(), contentHeight);
 }
 
 QWidget *DeviceList::createHeader()

--- a/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.h
@@ -20,9 +20,6 @@ class DeviceList : public QScrollArea
 public:
     explicit DeviceList(QWidget *parent = nullptr);
 
-protected:
-    void showEvent(QShowEvent *event) override;
-
 private Q_SLOTS:
     void addDevice(const DockItemData &item);
     void removeDevice(const QString &id);


### PR DESCRIPTION
use `resize` to adjust the size of device list.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-254647.html
