### PR TITLE
fix: Desktop deletion of files cannot go to the trash

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -234,7 +234,7 @@ void DeviceProxyManagerPrivate::initMounts()
                     mpt = mpt.endsWith("/") ? mpt : mpt + "/";
                     // FIXME(xust): fix later, the kRemovable is not always correct.
                     QWriteLocker lk(&lock);
-                    if (info.value(DeviceProperty::kRemovable).toBool())
+                    if (info.value(DeviceProperty::kRemovable).toBool() && !DeviceUtils::isSystemDisk(info))
                         externalMounts.insert(dev, mpt);
                     allMounts.insert(dev, mpt);
                 }
@@ -354,7 +354,8 @@ void DeviceProxyManagerPrivate::addMounts(const QString &id, const QString &mpt)
     QWriteLocker lk(&lock);
     if (id.startsWith(kBlockDeviceIdPrefix)) {
         auto &&info = q->queryBlockInfo(id);
-        if (info.value(GlobalServerDefines::DeviceProperty::kRemovable).toBool())
+        if (info.value(GlobalServerDefines::DeviceProperty::kRemovable).toBool()
+                && !DeviceUtils::isSystemDisk(info))
             externalMounts.insert(id, p);
     } else {
         externalMounts.insert(id, p);


### PR DESCRIPTION
When determining whether the built-in disk on the motherboard is removable, add a check (! IsSystemDisk) to check if the DeviceProxyManagerPrivate is an externalblock device

Log: Desktop deletion of files cannot go to the trash