### PR TITLE
fix: [drag] Drag action error.

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -151,6 +151,7 @@ inline constexpr char kTypeAudioFlac[] { "audio/flac" };
 inline constexpr char kDataUserIDKey[] { "userid_for_drag" };
 inline constexpr char kDFMMimeDataKey[] { "dfm_mimedata_for_drag" };
 inline constexpr char kDFMTreeUrlsKey[] { "dfm_tree_urls_for_drag" };
+inline constexpr char kDFMAppTypeKey[] { "dfm_app_type_for_drag" };
 }   // namespace Mime
 
 namespace Scheme {

--- a/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/canvasproxymodel.cpp
@@ -718,6 +718,7 @@ QMimeData *CanvasProxyModel::mimeData(const QModelIndexList &indexes) const
         mimedt->setUrls(urls);
     }
     mimedt->setText(kDdeDestop);
+    mimedt->setData(DFMGLOBAL_NAMESPACE::Mime::kDFMAppTypeKey, QByteArray(kDdeDestop));
     // set user id
     SysInfoUtils::setMimeDataUserId(mimedt);
 

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/dragdropoper.cpp
@@ -181,6 +181,9 @@ void DragDropOper::preproccessDropEvent(QDropEvent *event, const QList<QUrl> &ur
         if (Q_UNLIKELY(!itemInfo))
             return;
 
+        if (event->mimeData() && !event->mimeData()->hasFormat(DFMGLOBAL_NAMESPACE::Mime::kDFMAppTypeKey))
+            return;
+
         Qt::DropAction defaultAction = Qt::CopyAction;
         const QUrl from = urls.first();
 

--- a/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
@@ -486,6 +486,7 @@ QMimeData *CollectionModel::mimeData(const QModelIndexList &indexes) const
         urls << fileUrl(idx);
     mm->setText(kDdeDesktopOrganizer);
     mm->setUrls(urls);
+    mm->setData(DFMGLOBAL_NAMESPACE::Mime::kDFMAppTypeKey, QByteArray(kDdeDesktopOrganizer));
     // set user id
     SysInfoUtils::setMimeDataUserId(mm);
 

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -463,6 +463,9 @@ void CollectionViewPrivate::preproccessDropEvent(QDropEvent *event, const QUrl &
         return;
     }
 
+    if (event->mimeData() && !event->mimeData()->hasFormat(DFMGLOBAL_NAMESPACE::Mime::kDFMAppTypeKey))
+        return;
+
     auto defaultAction = Qt::CopyAction;
     const QUrl from = urls.first();
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -457,6 +457,7 @@ QMimeData *FileViewModel::mimeData(const QModelIndexList &indexes) const
     data->setText(kDdeFileManager);
     data->setUrls(urls);
     SysInfoUtils::setMimeDataUserId(data);
+    data->setData(DFMGLOBAL_NAMESPACE::Mime::kDFMAppTypeKey, QByteArray(kDdeFileManager));
 
     return data;
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -359,6 +359,9 @@ void DragDropHelper::handleDropEvent(QDropEvent *event, bool *fall)
         if (!info)
             return;
 
+        if (event->mimeData() && !event->mimeData()->hasFormat(DFMGLOBAL_NAMESPACE::Mime::kDFMAppTypeKey))
+            return;
+
         Qt::DropAction defaultAction = Qt::CopyAction;
         if (WindowUtils::keyAltIsPressed()) {
             defaultAction = Qt::MoveAction;


### PR DESCRIPTION
1. Drag Action is set up from a third -party application, but the desktop does not perform drag behavior according to the Action execution.
2. Modify the code and identify the source of the DRAG event. If it is a third -party application, the desktop and the cultural tube will not modify this drop action.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-252557.html