### PR TITLE
fix: The transfer of big data files is paused for about 5 minutes before resuming the transfer. The system's displayed transfer speed does not match the actual speed

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -375,7 +375,7 @@ void TaskWidget::onShowSpeedUpdatedInfo(const JobInfoPointer JobInfo)
     if (speedValue.isValid()) {
         QString speedStr = QString();
         bool ok = false;
-        qint64 speed = speedValue.toInt(&ok);
+        qint64 speed = speedValue.toLongLong(&ok);
         if (ok)
             speedStr = FileUtils::formatSize(speed) + "/s";
         else
@@ -391,6 +391,8 @@ void TaskWidget::onShowSpeedUpdatedInfo(const JobInfoPointer JobInfo)
             rmTimeStr = formatTime(rmTime);
         else
             rmTimeStr = remindValue.toString();
+        if (rmTime < 0)
+            rmTimeStr = "";
         lbRmTime->setText(rmTimeStr);
     }
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
@@ -83,7 +83,10 @@ void DoCopyFilesWorker::stop()
 
 bool DoCopyFilesWorker::initArgs()
 {
-    time.start();
+    if (!time) {
+        time = new QElapsedTimer();
+        time->start();
+    }
 
     AbstractWorker::initArgs();
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -65,7 +65,10 @@ void DoCutFilesWorker::stop()
 
 bool DoCutFilesWorker::initArgs()
 {
-    time.start();
+    if (!time) {
+        time = new QElapsedTimer();
+        time->start();
+    }
 
     AbstractWorker::initArgs();
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -184,6 +184,8 @@ public:
     QSharedPointer<QThreadPool> threadPool { nullptr };
     static std::atomic_bool bigFileCopy;
     QAtomicInteger<qint64> bigFileSize { 0 };   // bigger than this is big file
+    QElapsedTimer *time{ nullptr };   // time eslape
+    std::atomic_int64_t elapsed { 0 };
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -74,11 +74,18 @@ AbstractJobHandler::SupportAction FileOperateBaseWorker::doHandleErrorAndWait(co
 void FileOperateBaseWorker::emitSpeedUpdatedNotify(const qint64 &writSize)
 {
     JobInfoPointer info(new QMap<quint8, QVariant>);
-    qint64 speed = writSize * 1000 / (time.elapsed() == 0 ? 1 : time.elapsed());
+    qint64 elTime = 1;
+    if (time) {
+        elTime = time->elapsed() == 0 ? 1 : time->elapsed();
+        elTime += elapsed;
+    }
+
+    qint64 speed = currentState == AbstractJobHandler::JobState::kRunningState
+            ? writSize * 1000 / (elTime) : 0;
     info->insert(AbstractJobHandler::NotifyInfoKey::kJobtypeKey, QVariant::fromValue(jobType));
     info->insert(AbstractJobHandler::NotifyInfoKey::kJobStateKey, QVariant::fromValue(currentState));
     info->insert(AbstractJobHandler::NotifyInfoKey::kSpeedKey, QVariant::fromValue(speed));
-    info->insert(AbstractJobHandler::NotifyInfoKey::kRemindTimeKey, QVariant::fromValue(speed == 0 ? 0 : (sourceFilesTotalSize - writSize) / speed));
+    info->insert(AbstractJobHandler::NotifyInfoKey::kRemindTimeKey, QVariant::fromValue(speed == 0 ? -1 : (sourceFilesTotalSize - writSize) / speed));
 
     emit stateChangedNotify(info);
     emit speedUpdatedNotify(info);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -122,7 +122,6 @@ private:
     QVariant doActionMerge(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize);
 
 protected:
-    QTime time;   // time eslape
     FileInfoPointer targetInfo { nullptr };   // target file infor pointer
     CountWriteSizeType countWriteType { CountWriteSizeType::kCustomizeType };   // get write size type
     long copyTid = { -1 };   // 使用 /pric/[pid]/task/[tid]/io 文件中的的 writeBytes 字段的值作为判断已写入数据的依据


### PR DESCRIPTION
Modify the calculation method so that only the running status is counted as the write time

Log: The transfer of big data files is paused for about 5 minutes before resuming the transfer. The system's displayed transfer speed does not match the actual speed
Bug: https://pms.uniontech.com/bug-view-256437.html