### PR TITLE
fix: After checking the box, the document management selection window will not be able to enter any directory when a new window is opened

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -912,6 +912,7 @@ void FileDialog::handleUrlChanged(const QUrl &url)
     }
     emit initialized();
     dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetNameFilter", internalWinId(), curNameFilters);
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetAlwaysOpenInCurrentWindow", internalWinId());
 }
 
 void FileDialog::onViewSelectionChanged(const quint64 windowID, const QItemSelection &selected, const QItemSelection &deselected)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -106,6 +106,8 @@ void WorkspaceEventReceiver::initConnection()
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleGetViewFilter);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_ClosePersistentEditor",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleClosePersistentEditor);
+    dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_SetAlwaysOpenInCurrentWindow",
+                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleSetAlwaysOpenInCurrentWindow);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Model_SetCustomFilterData",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleSetCustomFilterData);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Model_SetCustomFilterCallback",
@@ -416,5 +418,10 @@ bool WorkspaceEventReceiver::handleRegisterRoutePrehandle(const QString &scheme,
 void WorkspaceEventReceiver::handleRegisterDataCache(const QString &scheme)
 {
     //    FileModelManager::instance()->registerDataCache(scheme);
+}
+
+void WorkspaceEventReceiver::handleSetAlwaysOpenInCurrentWindow(const quint64 windowID)
+{
+    WorkspaceHelper::instance()->setAlwaysOpenInCurrentWindow(windowID);
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -78,6 +78,7 @@ public slots:
     void handleSetCustomFilterCallback(quint64 windowID, const QUrl &url, const QVariant callback);
     bool handleRegisterRoutePrehandle(const QString &scheme, const FileViewRoutePrehaldler &prehandler);
     void handleRegisterDataCache(const QString &scheme);
+    void handleSetAlwaysOpenInCurrentWindow(const quint64 windowID);
 
 private:
     explicit WorkspaceEventReceiver(QObject *parent = nullptr);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -422,6 +422,13 @@ QList<QUrl> WorkspaceHelper::filterUndoFiles(const QList<QUrl> &urlList) const
     return urls;
 }
 
+void WorkspaceHelper::setAlwaysOpenInCurrentWindow(const quint64 windowID)
+{
+    FileView *view = findFileViewByWindowID(windowID);
+    if (view)
+        view->setAlwaysOpenInCurrentWindow(true);
+}
+
 void WorkspaceHelper::installWorkspaceWidgetToWindow(const quint64 windowID)
 {
     WorkspaceWidget *widget = nullptr;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/workspacehelper.h
@@ -100,6 +100,8 @@ public:
     void setUndoFiles(const QList<QUrl> &files);
     QList<QUrl> filterUndoFiles(const QList<QUrl> &urlList) const;
 
+    void setAlwaysOpenInCurrentWindow(const quint64 windowID);
+
     static QMap<quint64, QPair<QUrl, QUrl>> kSelectionAndRenameFile;   //###: for creating new file.
     static QMap<quint64, QPair<QUrl, QUrl>> kSelectionFile;   //###: rename a file which must be existance.
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -66,6 +66,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_View_SetReadOnly)
     DPF_EVENT_REG_SLOT(slot_View_SetFilter)
     DPF_EVENT_REG_SLOT(slot_View_GetFilter)
+    DPF_EVENT_REG_SLOT(slot_View_SetAlwaysOpenInCurrentWindow)
 
     DPF_EVENT_REG_SLOT(slot_Model_SetCustomFilterData)
     DPF_EVENT_REG_SLOT(slot_Model_SetCustomFilterCallback)


### PR DESCRIPTION
Set filedailog to only open in the current window

Log: After checking the box, the document management selection window will not be able to enter any directory when a new window is opened
Bug: https://pms.uniontech.com/bug-view-255979.html