### PR TITLE
fix: The secondary option of "Send to" in the right-click menu of the file includes mounting points such as data disks

### DIFF
--- a/src/plugins/common/core/dfmplugin-menu/menuscene/sendtomenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/sendtomenuscene.cpp
@@ -125,7 +125,7 @@ bool SendToMenuScene::create(QMenu *parent)
             QString mpt = data.value(DeviceProperty::kMountPoint).toString();
             QString devDesc = data.value(DeviceProperty::kDevice).toString();
 
-            if (data.value(DeviceProperty::kOptical).toBool()) {
+            if (data.value(DeviceProperty::kOptical).toBool() || DeviceUtils::isSystemDisk(data)) {
                 continue;   // this should be added in burn plugin.
             } else {
                 QAction *act = menuSendTo->addAction(label);


### PR DESCRIPTION
Check if adding is a system disk

Log: The secondary option of "Send to" in the right-click menu of the file includes mounting points such as data disks
Bug: https://pms.uniontech.com/bug-view-256797.html