### PR TITLE
fix: The top path label of the dde-file-manager is "copy path", and " file://" is not omitted

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/crumbbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/crumbbar.cpp
@@ -156,7 +156,7 @@ void CrumbBarPrivate::writeUrlToClipboard(const QUrl &url)
     if (copyPath.isEmpty())
         return;
 
-    QGuiApplication::clipboard()->setText(copyPath);
+    QGuiApplication::clipboard()->setText(copyPath.replace(QString(Global::Scheme::kFile) + "://", ""));
 }
 
 void CrumbBarPrivate::initUI()


### PR DESCRIPTION
Remove file://

Log: The top path label of the dde-file-manager is "copy path", and "file://" is not omitted
Bug: https://pms.uniontech.com/bug-view-256983.html