### PR TITLE
fix: show-item call dbus interface to launch dfm

### DIFF
--- a/assets/scripts/dde-file-manager
+++ b/assets/scripts/dde-file-manager
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+f="${1#file://}"
+
+# dde-file-manager --show-item xxx
+if [[ "$1" == "--show-item" ]]; then
+    dbus-send --print-reply --dest=org.freedesktop.FileManager1 /org/freedesktop/FileManager1 org.freedesktop.FileManager1.ShowItems "array:string:${@:2}" "string:"
+# dde-file-manager /path/to/xxx or file:///path/to/xxx
+elif [ -e "$f" ]; then
+    dbus-send --print-reply --dest=org.freedesktop.FileManager1 /org/freedesktop/FileManager1 org.freedesktop.FileManager1.ShowItems "array:string:$f" "string:"
+else
+    exec /usr/libexec/dde-file-manager "$@"
+fi
+

--- a/assets/scripts/file-manager.sh
+++ b/assets/scripts/file-manager.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+exec /usr/libexec/dde-file-manager $@

--- a/debian/dde-file-manager.install
+++ b/debian/dde-file-manager.install
@@ -1,4 +1,6 @@
 usr/bin/dde-file-manager
+usr/bin/file-manager.sh
+usr/libexec/dde-file-manager
 usr/bin/dde-file-manager-pkexec
 usr/bin/dde-file-manager-daemon
 usr/bin/dde-file-manager-server

--- a/src/apps/dde-file-manager/CMakeLists.txt
+++ b/src/apps/dde-file-manager/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(
     ${DtkWidget_LIBRARIES}
     )
 
-install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
 
 # sh
 install(FILES dde-property-dialog DESTINATION bin)

--- a/src/dfm-base/CMakeLists.txt
+++ b/src/dfm-base/CMakeLists.txt
@@ -171,6 +171,11 @@ install(FILES ${DLNFS_SCRIPT} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/deepin/dde
 set(DLNFS_SCRIPT_LAUNCHER ${AssetsPath}/scripts/99dfm-dlnfs-automount)
 install(FILES ${DLNFS_SCRIPT_LAUNCHER} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d)
 
+set(DFM_DLNFS_SCRIPT_LAUNCHER
+    ${AssetsPath}/scripts/dde-file-manager
+    ${AssetsPath}/scripts/file-manager.sh)
+install(FILES ${DFM_DLNFS_SCRIPT_LAUNCHER} DESTINATION bin)
+
 set(Mimetypes "${ShareDir}/mimetypes")
 FILE(GLOB MIMETYPE_FILES ${AssetsPath}/mimetypes/*)
 install(FILES ${MIMETYPE_FILES} DESTINATION ${Mimetypes})


### PR DESCRIPTION
- 增加一个脚本处理 dde-file-manager --show-item 这种情况适配 AM
- 增加 file-manager.sh 方便覆盖 dbus 的调用
- 原二进制移动到 /usr/libexec

其他应用直接通过进程的方式调用
`dde-file-manager $file_path` 或者 `dde-file-manager --show-item $file_path` 则通过脚本转发到 `dbus` 服务，这种能被 `AM` 正常识别

Issue: https://github.com/linuxdeepin/developer-center/issues/8749, https://github.com/linuxdeepin/developer-center/issues/8789