### PR TITLE
fix: After installing VM Tools on a VMware virtual machine, files andcontent cannot be copied between the virtual machine and the physical machine

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -61,7 +61,8 @@ void onClipboardDataChanged()
         clipboardAction = ClipBoard::kRemoteCopiedAction;
         return;
     }
-    const QByteArray &data = mimeData->data(kGnomeCopyKey);
+    QByteArray data = mimeData->data(kGnomeCopyKey);
+    data = data.replace(QString(kGnomeCopyKey) + "\n", "");
 
     if (data.startsWith("cut")) {
         clipboardAction = ClipBoard::kCutAction;
@@ -70,7 +71,11 @@ void onClipboardDataChanged()
     } else {
         clipboardAction = ClipBoard::kUnknownAction;
     }
-    clipboardFileUrls << mimeData->urls();
+
+    for (const auto &url : mimeData->urls()) {
+        if (url.isValid() && !url.scheme().isEmpty())
+            clipboardFileUrls << url;
+    }
 }
 }   // namespace GlobalData
 


### PR DESCRIPTION
Rules for adapting the values written on the new gnome clipboard

Log: After installing VM Tools on a VMware virtual machine, files and content cannot be copied between the virtual machine and the physical machine
Bug: https://pms.uniontech.com/bug-view-256725.html