### PR TITLE
fix: Create a new non-text document, after Ctrl+Z, Ctrl+Y cannot be undone

### DIFF
--- a/include/dfm-base/interfaces/abstractjobhandler.h
+++ b/include/dfm-base/interfaces/abstractjobhandler.h
@@ -245,7 +245,7 @@ Q_SIGNALS:   // 发送给任务调用者使用的信号
     void requestShowTipsDialog(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType type, const QList<QUrl> list);
     void workerFinish();
     void requestRemoveTaskWidget();
-    void requestSaveRedoOperation(const QString &token, const bool moreThanZero);
+    void requestSaveRedoOperation(const QString &token, const qint64 deleteFirstFileSize);
 Q_SIGNALS:   // 发送给任务使用的信号
     /*!
      * \brief userAction 用户当前动作

--- a/src/dfm-base/file/local/localfilehandler.h
+++ b/src/dfm-base/file/local/localfilehandler.h
@@ -30,7 +30,7 @@ public:
     LocalFileHandler();
     ~LocalFileHandler();
 
-    bool touchFile(const QUrl &url, const QUrl &tempUrl = QUrl());
+    QUrl touchFile(const QUrl &url, const QUrl &tempUrl = QUrl());
     bool mkdir(const QUrl &dir);
     bool rmdir(const QUrl &url);
     bool renameFile(const QUrl &url, const QUrl &newUrl, const bool needCheck = true);

--- a/src/dfm-base/file/local/localfilehandler_p.h
+++ b/src/dfm-base/file/local/localfilehandler_p.h
@@ -47,13 +47,14 @@ public:
     bool addExecutableFlagAndExecuse(const QString &path, int flag);
     bool isFileWindowsUrlShortcut(const QString &path);
     QString getInternetShortcutUrl(const QString &path);
-    void loadTemplateInfo(const QUrl &url, const QUrl &templateUrl = QUrl());
+    QUrl loadTemplateInfo(const QUrl &url, const QUrl &templateUrl = QUrl());
 
     bool doOpenFile(const QUrl &url, const QString &desktopFile = QString());
     bool doOpenFiles(const QList<QUrl> &urls, const QString &desktopFile = QString());
     bool doOpenFiles(const QMultiMap<QString, QString> &infos, const QMap<QString, QString> &mimeTypes);
 
     void setError(DFMIOError error);
+    QUrl loadTemplateUrl(const QString &suffix);
 
     static void addRecentFile(const QString &filePath, const DesktopFile &desktopFile, const QString &mimetype);
     static void asyncAddRecentFile(const QString &desktop, const QList<QString> urls,

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -63,10 +63,10 @@ bool DoDeleteFilesWorker::deleteAllFiles()
  */
 bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 {
-    if (allFilesList.count() == 1) {
+    if (allFilesList.count() == 1 && isConvert) {
         auto info = InfoFactory::create<FileInfo>(allFilesList.first(), Global::CreateFileInfoType::kCreateFileInfoSync);
-        if (info && info->isAttributes(OptInfoType::kIsFile) && info->size() > 0)
-            moreThanZero = true;
+        if (info)
+            deleteFirstFileSize = info->size();
     }
 
     AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
@@ -108,10 +108,10 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 bool DoDeleteFilesWorker::deleteFilesOnOtherDevice()
 {
     bool ok = true;
-    if (sourceUrls.count() == 1) {
+    if (sourceUrls.count() == 1 && isConvert) {
         auto info = InfoFactory::create<FileInfo>(sourceUrls.first(), Global::CreateFileInfoType::kCreateFileInfoSync);
-        if (info && info->isAttributes(OptInfoType::kIsFile) && info->size() > 0)
-            moreThanZero = true;
+        if (info)
+            deleteFirstFileSize = info->size();
     }
     for (auto &url : sourceUrls) {
         const auto &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -603,7 +603,7 @@ void AbstractWorker::saveOperations()
     }
 
     if (handle && isConvert && !completeSourceFiles.isEmpty()) {
-        emit requestSaveRedoOperation(QString::number(quintptr(handle.data()),16), moreThanZero);
+        emit requestSaveRedoOperation(QString::number(quintptr(handle.data()),16), deleteFirstFileSize.load());
     }
 }
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -88,7 +88,7 @@ signals:
 
     void requestShowTipsDialog(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType type, const QList<QUrl> &list);
     void workerFinish();
-    void requestSaveRedoOperation(const QString &token, const bool moreThanZero);
+    void requestSaveRedoOperation(const QString &token, const qint64 deleteFirstFileSize);
 signals:   // update proccess timer use
     void startUpdateProgressTimer();
     void startWork();
@@ -187,7 +187,7 @@ public:
     QAtomicInteger<qint64> bigFileSize { 0 };   // bigger than this is big file
     QElapsedTimer *speedtimer{ nullptr };   // time eslape
     std::atomic_int64_t elapsed { 0 };
-    std::atomic_bool moreThanZero{ false };
+    std::atomic_int64_t deleteFirstFileSize{ false };
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -263,10 +263,13 @@ bool FileOperationsEventReceiver::redo(const quint64 windowId, const QVariantMap
             return true;
         return doMkdir(windowId, sources.first(), QVariant(), nullptr, true);
     case kTouchFile:
+    {
         if (sources.isEmpty())
             return true;
-        doTouchFilePractically(windowId, sources.first());
+        QUrl templateUrl = ret.value("templateurl", QUrl()).toUrl();
+        doTouchFilePractically(windowId, sources.first(), templateUrl);
         break;
+    }
     default:
         return false;
     }
@@ -706,7 +709,7 @@ void FileOperationsEventReceiver::saveFileOperation(const QList<QUrl> &sourcesUr
                                                     const QList<QUrl> &redoSourcesUrls,
                                                     const QList<QUrl> &redoTargetUrls,
                                                     const GlobalEventType redo,
-                                                    const bool isUndo)
+                                                    const bool isUndo, const QUrl &templateUrl)
 {
     // save operation by dbus
     QVariantMap values;
@@ -716,6 +719,8 @@ void FileOperationsEventReceiver::saveFileOperation(const QList<QUrl> &sourcesUr
     values.insert("redoevent", QVariant::fromValue(static_cast<uint16_t>(redo)));
     values.insert("redosources", QUrl::toStringList(redoSourcesUrls));
     values.insert("redotargets", QUrl::toStringList(redoTargetUrls));
+    if (templateUrl.isValid() && !UniversalUtils::urlEquals(templateUrl, sourcesUrls.first()) )
+        values.insert("templateurl", templateUrl.toString());
     if (!isUndo) {
         dpfSignalDispatcher->publish(GlobalEventType::kSaveOperator, values);
     } else {
@@ -1111,16 +1116,17 @@ bool FileOperationsEventReceiver::doTouchFilePractically(const quint64 windowId,
     QString error;
 
     DFMBASE_NAMESPACE::LocalFileHandler fileHandler;
-    bool ok = fileHandler.touchFile(url, tempUrl);
-    if (!ok) {
+    auto templateUrl = fileHandler.touchFile(url, tempUrl);
+    if (!templateUrl.isValid()) {
         error = fileHandler.errorString();
         dialogManager->showErrorDialog(tr("Failed to create the file"), error);
     }
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kTouchFileResult,
-                                 windowId, QList<QUrl>() << url, ok, error);
-    saveFileOperation({ url }, {}, GlobalEventType::kDeleteFiles, { url }, {}, GlobalEventType::kTouchFile);
+                                 windowId, QList<QUrl>() << url, templateUrl.isValid(), error);
+    if (templateUrl.isValid())
+        saveFileOperation({ url }, {}, GlobalEventType::kDeleteFiles, { url }, {}, GlobalEventType::kTouchFile, false, templateUrl);
 
-    return ok;
+    return templateUrl.isValid();
 }
 
 QString FileOperationsEventReceiver::handleOperationTouchFile(const quint64 windowId,
@@ -1436,7 +1442,7 @@ void FileOperationsEventReceiver::handleRecoveryOperationRedoRecovery(const quin
 }
 
 // ctrl + z 执行后保存当前的redo操作
-void FileOperationsEventReceiver::handleSaveRedoOpt(const QString &token, const bool moreThanZero)
+void FileOperationsEventReceiver::handleSaveRedoOpt(const QString &token, const qint64 fileSize)
 {
     QVariantMap ret;
     {
@@ -1453,8 +1459,15 @@ void FileOperationsEventReceiver::handleSaveRedoOpt(const QString &token, const 
     GlobalEventType redoEventType = static_cast<GlobalEventType>(ret.value("redoevent").value<uint16_t>());
     QList<QUrl> redoSources = QUrl::fromStringList(ret.value("redosources").toStringList());
     QList<QUrl> redoTargets = QUrl::fromStringList(ret.value("redotargets").toStringList());
-    if (redoEventType != GlobalEventType::kTouchFile || !moreThanZero)
-        saveFileOperation(redoSources, redoTargets, redoEventType, undoSources, undoTargets, undoEventType, true);
+    QUrl templateUrl = ret.value("templateurl", QUrl()).toUrl();
+    qint64 compare = 0;
+    if (templateUrl.isValid()) {
+        auto info = InfoFactory::create<FileInfo>(templateUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
+        if (info)
+            compare = info->size();
+    }
+    if (redoEventType != GlobalEventType::kTouchFile || fileSize == compare)
+        saveFileOperation(redoSources, redoTargets, redoEventType, undoSources, undoTargets, undoEventType, true, templateUrl);
 }
 
 void FileOperationsEventReceiver::handleOperationUndoDeletes(const quint64 windowId, const QList<QUrl> &sources, const AbstractJobHandler::JobFlags flags, AbstractJobHandler::OperatorHandleCallback handleCallback, const QVariantMap &op)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -189,7 +189,7 @@ public slots:
     void handleOperationCleanByUrls(const QList<QUrl> &urls);
     void handleRecoveryOperationRedoRecovery(const quint64 windowId,
                                                    DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle);
-    void handleSaveRedoOpt(const QString &token, const bool moreThanZero);
+    void handleSaveRedoOpt(const QString &token, const qint64 fileSize);
     void handleOperationUndoDeletes(const quint64 windowId,
                                     const QList<QUrl> &sources,
                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
@@ -266,7 +266,7 @@ private:
                            DFMBASE_NAMESPACE::GlobalEventType type,
                            const QList<QUrl> &redoSourcesUrls, const QList<QUrl> &redoTargetUrls,
                            const dfmbase::GlobalEventType redo,
-                           const bool isUndo = false);
+                           const bool isUndo = false, const QUrl &templateUrl = QUrl());
     QUrl checkTargetUrl(const QUrl &url);
 
 private:

--- a/tests/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/ut_fileoperationseventreceiver.cpp
+++ b/tests/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/ut_fileoperationseventreceiver.cpp
@@ -222,7 +222,7 @@ TEST_F(UT_FileOperationsEventReceiver, testHandleOperationTouchFile)
 
     stub_ext::StubExt stub;
     stub.set_lamda(&DialogManager::showErrorDialog,[]{});
-    stub.set_lamda(&LocalFileHandler::touchFile, []{return false;});
+    stub.set_lamda(&LocalFileHandler::touchFile, []{return QUrl();});
     typedef bool (EventDispatcherManager::*PublishFun)(dpf::EventType, quint64, const QList<QUrl> &, bool &,QString &);
     auto publishFun = static_cast<PublishFun>(&EventDispatcherManager::publish);
     stub.set_lamda(publishFun, [] {return true;});
@@ -595,7 +595,7 @@ TEST_F(UT_FileOperationsEventReceiver, testDoTouchFilePractically)
     EXPECT_TRUE(op != nullptr);
     QUrl url = QUrl::fromLocalFile(QDir::currentPath());
     stub_ext::StubExt stub;
-    stub.set_lamda(&LocalFileHandler::touchFile, []{return false;});
+    stub.set_lamda(&LocalFileHandler::touchFile, []{return QUrl();});
     stub.set_lamda(&DialogManager::showErrorDialog, []{});
     typedef bool (EventDispatcherManager::*PublishFun)(dpf::EventType, quint64, QList<QUrl> &, bool &, QString &);
     auto publishFun = static_cast<PublishFun>(&EventDispatcherManager::publish);


### PR DESCRIPTION
Template URL not saved

Log: Create a new non-text document, after Ctrl+Z, Ctrl+Y cannot be undone
Bug: https://pms.uniontech.com/bug-view-257805.html