### PR TITLE
fix: [daemon/anything] segmentation fault

### DIFF
--- a/src/plugins/daemon/daemonplugin-anything/anythingserver.h
+++ b/src/plugins/daemon/daemonplugin-anything/anythingserver.h
@@ -9,6 +9,7 @@
 
 #include <dfm-framework/dpf.h>
 #include <QProcess>
+#include <QSemaphore>
 
 DAEMONPANYTHING_BEGIN_NAMESPACE
 
@@ -35,16 +36,23 @@ class AnythingMonitorThread : public QThread
 {
     Q_OBJECT
 public:
-    explicit AnythingMonitorThread(QProcess *server, bool *stopped) : QThread(nullptr)
+    explicit AnythingMonitorThread(bool *stopped) : QThread(nullptr)
     {
-        this->server = server;
         this->stopped = stopped;
     }
 
     void run() override;
 
+    bool waitStartResult()
+    {
+        start();
+        sem.acquire();
+        return started;
+    }
+
 private:
-    QProcess *server;
+    QSemaphore sem;
+    bool started;
     bool *stopped;
 };
 


### PR DESCRIPTION
Before the fix, QProcess was created in the main thread and used in the child thread, which triggered Qt warning logs and caused dde-file-manager-daemon to crash. The solution is to complete the creation and use of QProcess in the child thread.

Log: fix segmentation fault