### PR TITLE
fix: After selecting "Cancel" when revoking, attempting to do so again will skip the previous operation's revocation

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -1488,9 +1488,8 @@ void FileOperationsEventReceiver::handleOperationUndoDeletes(const quint64 windo
     DoDeleteErrorType erType { DoDeleteErrorType::kNoErrror };
     auto handle = doDeleteFile(windowId, sources, flags, handleCallback, false, erType);
     if (!handle && erType == DoDeleteErrorType::kNullPtr) {
-        auto re = op;
-        re.insert("stackBack", false);
-        dpfSignalDispatcher->publish(GlobalEventType::kSaveOperator, re);
+        // 此次ctrl+z回撤失败，重新保存这次操作
+        dpfSignalDispatcher->publish(GlobalEventType::kSaveOperator, op);
         return;
     }
     connect(handle.get(), &AbstractJobHandler::requestSaveRedoOperation, this,

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/fulltext/fulltextsearcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/fulltext/fulltextsearcher.cpp
@@ -278,7 +278,6 @@ bool FullTextSearcherPrivate::createIndex(const QString &path)
         writer->close();
 
         fmInfo() << "create index spending: " << timer.elapsed();
-        status.storeRelease(AbstractSearcher::kCompleted);
         return true;
     } catch (const LuceneException &e) {
         fmWarning() << QString::fromStdWString(e.getError());

--- a/src/plugins/server/core/serverplugin-core/operationsstackmanagerdbus.cpp
+++ b/src/plugins/server/core/serverplugin-core/operationsstackmanagerdbus.cpp
@@ -19,17 +19,7 @@ void OperationsStackManagerDbus::SaveOperations(const QVariantMap &values)
     while (fileOperations.size() >= kMaxStep)
         fileOperations.pop_front();
 
-    bool back = true;
-    auto op = values;
-    if (op.contains("stackBack")) {
-        back = values.value("stackBack", true).toBool();
-        op.remove("stackBack");
-    }
-    if (back) {
-        fileOperations.push(op);
-    } else {
-        fileOperations.push_front(op);
-    }
+    fileOperations.push(values);
 }
 
 void OperationsStackManagerDbus::CleanOperations()
@@ -50,17 +40,7 @@ void OperationsStackManagerDbus::SaveRedoOperations(const QVariantMap &values)
     while (redoFileOperations.size() >= kMaxStep)
         redoFileOperations.pop_front();
 
-    bool back = true;
-    auto op = values;
-    if (op.contains("stackBack")) {
-        back = values.value("stackBack", true).toBool();
-        op.remove("stackBack");
-    }
-    if (back) {
-        redoFileOperations.push(op);
-    } else {
-        redoFileOperations.push_front(op);
-    }
+    redoFileOperations.push(values);
 }
 
 QVariantMap OperationsStackManagerDbus::RevocationRedoOperations()


### PR DESCRIPTION
The stack order of the save file operation is incorrect

Log: After selecting "Cancel" when revoking, attempting to do so again will skip the previous operation's revocation
Bug: https://pms.uniontech.com/bug-view-257853.html