### PR TITLE
fix: Delete the file and recall it with Ctrl+Z, displaying an error pop-up window in dde-file-dailog

### DIFF
--- a/src/dfm-base/file/local/localfileiconprovider.cpp
+++ b/src/dfm-base/file/local/localfileiconprovider.cpp
@@ -28,6 +28,7 @@ QIcon LocalFileIconProviderPrivate::fileSystemIcon(const QString &path) const
     QIcon icon;
 
     DFMIO::DFileInfo info(path);
+    info.initQuerier();
     if (!info.exists())
         return icon;
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
@@ -36,15 +36,16 @@ protected:
     void endWork() override;
 
     bool cutFiles();
-    bool doCutFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo);
-    bool doRenameFile(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetPathInfo, FileInfoPointer &toInfo, const QString fileName, bool *ok);
-    bool renameFileByHandler(const FileInfoPointer &sourceInfo, const FileInfoPointer &targetInfo);
+    bool doCutFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &targetPathInfo);
+    DFileInfoPointer doRenameFile(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetPathInfo,
+                                 const QString fileName, bool *ok);
+    bool renameFileByHandler(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetInfo);
 
     void emitCompleteFilesUpdatedNotify(const qint64 &writCount);
 
 private:
-    bool checkSymLink(const FileInfoPointer &fromInfo);
-    bool checkSelf(const FileInfoPointer &fromInfo);
+    bool checkSymLink(const DFileInfoPointer &fromInfo);
+    bool checkSelf(const DFileInfoPointer &fromInfo);
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -137,6 +137,8 @@ protected:
     void pause();
     void resume();
     void getAction(AbstractJobHandler::SupportActions actions);
+    QUrl parentUrl(const QUrl &url);
+    static dfmbase::FileInfo::FileType fileType(const DFileInfoPointer &info);
 
 public:
     virtual ~AbstractWorker();
@@ -165,7 +167,7 @@ public:
     QList<QUrl> completeSourceFiles;   // List of all copied files
     QList<QUrl> completeTargetFiles;   // List of all complete target files
     QVariantList completeCustomInfos;
-    QList<FileInfoPointer> precompleteTargetFileInfo;   // list prepare complete target file info
+    QList<DFileInfoPointer> precompleteTargetFileInfo;   // list prepare complete target file info
     bool isSourceFileLocal { false };   // source file on local device
     bool isTargetFileLocal { false };   // target file on local device
     bool supportSetPermission { true };    // source file on mtp

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -57,14 +57,14 @@ public:
     void skipMemcpyBigFile(const QUrl url);
     void operateAction(const AbstractJobHandler::SupportAction action);
     // normal copy
-    NextDo doCopyFilePractically(const FileInfoPointer fromInfo, const FileInfoPointer toInfo,
+    NextDo doCopyFilePractically(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo,
                                  bool *skip);
     // small file copy
-    void doFileCopy(FileInfoPointer fromInfo, FileInfoPointer toInfo);
+    void doFileCopy(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
     // big file copy in system device
-    void doMemcpyLocalBigFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, char *dest, char *source, size_t size);
+    void doMemcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *dest, char *source, size_t size);
     // copy file by dfmio
-    bool doDfmioFileCopy(FileInfoPointer fromInfo, FileInfoPointer toInfo, bool *skip);
+    bool doDfmioFileCopy(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
 signals:
     void ErrorFinished();
     void CompleteSize(const int size);
@@ -84,38 +84,39 @@ private:   // file copy
                                                            const bool isTo = false,
                                                            const QString &errorMsg = QString());
 
-    void readAheadSourceFile(const FileInfoPointer &fileInfo);
-    bool createFileDevices(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    void readAheadSourceFile(const DFileInfoPointer &fileInfo);
+    bool createFileDevices(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                            QSharedPointer<DFMIO::DFile> &fromeFile, QSharedPointer<DFMIO::DFile> &toFile,
                            bool *skip);
-    bool createFileDevice(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                          const FileInfoPointer &needOpenInfo, QSharedPointer<DFMIO::DFile> &file,
+    bool createFileDevice(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
+                          const DFileInfoPointer &needOpenInfo, QSharedPointer<DFMIO::DFile> &file,
                           bool *skip);
-    bool openFiles(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool openFiles(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                    const QSharedPointer<DFMIO::DFile> &fromeFile, const QSharedPointer<DFMIO::DFile> &toFile,
                    bool *skip);
-    bool openFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool openFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                   const QSharedPointer<DFMIO::DFile> &file, const DFMIO::DFile::OpenFlags &flags,
                   bool *skip);
-    bool resizeTargetFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool resizeTargetFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                           const QSharedPointer<DFMIO::DFile> &file, bool *skip);
-    NextDo doReadFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    NextDo doReadFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                       const QSharedPointer<DFMIO::DFile> &fromDevice,
                       char *data, const qint64 &blockSize, qint64 &readSize, bool *skip);
-    NextDo doWriteFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    NextDo doWriteFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                        const QSharedPointer<DFMIO::DFile> &toDevice, const QSharedPointer<DFMIO::DFile> &fromDevice,
                        const char *data, const qint64 readSize, bool *skip);
-    NextDo doWriteFileErrorRetry(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    NextDo doWriteFileErrorRetry(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                                  const QSharedPointer<DFMIO::DFile> &toDevice, const QSharedPointer<DFMIO::DFile> &fromDevice, const qint64 readSize, bool *skip,
                                  const qint64 currentPos,
                                  const qint64 &surplusSize, qint64 &curWrite);
     void setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo);
+    void setTargetPermissions(const QUrl &fromUrl, const QUrl &toUrl);
     bool verifyFileIntegrity(const qint64 &blockSize, const ulong &sourceCheckSum,
-                             const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+                             const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                              QSharedPointer<DFMIO::DFile> &toFile);
     void checkRetry();
     bool isStopped();
-    void syncBlockFile(const FileInfoPointer toInfo);
+    void syncBlockFile(const DFileInfoPointer toInfo);
 public:
     static void progressCallback(int64_t current, int64_t total, void *progressData);
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "errormessageandaction.h"
-#include <dfm-base/base/urlroute.h>
+#include "fileoperationsutils.h"
 #include <dfm-base/base/schemefactory.h>
 
 #include <QUrl>
@@ -28,20 +28,20 @@ void ErrorMessageAndAction::srcAndDestString(const QUrl &from, const QUrl &to, Q
         return;
     if (AbstractJobHandler::JobType::kCopyType == jobType) {
         *sorceMsg = QString(tr("Copying %1")).arg(from.path());
-        *toMsg = QString(tr("to %1")).arg(UrlRoute::urlParent(to).path());
+        *toMsg = QString(tr("to %1")).arg(FileOperationsUtils::parentUrl(to).path());
         errorSrcAndDestString(from, to, sorceMsg, toMsg, error);
     } else if (AbstractJobHandler::JobType::kDeleteType == jobType) {
         *sorceMsg = QString(tr("Deleting %1")).arg(from.path());
     } else if (AbstractJobHandler::JobType::kCutType == jobType) {
         *sorceMsg = QString(tr("Moving %1")).arg(from.path());
-        *toMsg = QString(tr("to %1")).arg(UrlRoute::urlParent(to).path());
+        *toMsg = QString(tr("to %1")).arg(FileOperationsUtils::parentUrl(to).path());
         errorSrcAndDestString(from, to, sorceMsg, toMsg, error);
     } else if (AbstractJobHandler::JobType::kMoveToTrashType == jobType) {
         *sorceMsg = QString(tr("Trashing %1")).arg(from.path());
     } else if (AbstractJobHandler::JobType::kRestoreType == jobType) {
         *sorceMsg = QString(tr("Restoring %1")).arg(from.path());
         if (to.isValid())
-            *toMsg = QString(tr("to %1")).arg(UrlRoute::urlParent(to).path());
+            *toMsg = QString(tr("to %1")).arg(FileOperationsUtils::parentUrl(to).path());
     } else if (AbstractJobHandler::JobType::kCleanTrashType == jobType) {
         *sorceMsg = QString(tr("Deleting %1")).arg(from.path());
     }
@@ -243,23 +243,23 @@ void ErrorMessageAndAction::errorSrcAndDestString(const QUrl &from,
         static QFontMetrics metrics(label.font());
         static Qt::TextElideMode em = Qt::TextElideMode::ElideMiddle;
         int pre = metrics.width(tr("Original path %1").arg(from.path()));
-        int last = metrics.width(tr("Target path %1").arg(UrlRoute::urlParent(to).path()));
+        int last = metrics.width(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()));
         static int total = 350;
         if (pre > total / 2 && last > total / 2) {
             *toMsg = metrics.elidedText(tr("Original path %1").arg(from.path()), em, total / 2)
-                    + " " + metrics.elidedText(tr("Target path %1").arg(UrlRoute::urlParent(to).path()), em, total / 2);
+                    + " " + metrics.elidedText(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()), em, total / 2);
             return;
         }
         if (pre + last > total) {
             *toMsg = pre > total / 2
                     ? metrics.elidedText(tr("Original path %1").arg(from.path()), em, total - last)
-                            + " " + tr("Target path %1").arg(UrlRoute::urlParent(to).path())
+                            + " " + tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path())
                     : tr("Original path %1").arg(from.path())
-                            + " " + metrics.elidedText(tr("Target path %1").arg(UrlRoute::urlParent(to).path()), em, total - pre);
+                            + " " + metrics.elidedText(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()), em, total - pre);
             return;
         }
         *toMsg = QString(tr("Original path %1 Target path %2"))
-                         .arg(from.path(), UrlRoute::urlParent(to).path());
+                         .arg(from.path(), FileOperationsUtils::parentUrl(to).path());
     }
     return;
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -39,22 +39,25 @@ public:
     };
 
 public:
-    bool doCheckFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, const QString &fileName,
-                     FileInfoPointer &newTargetInfo, bool *skip);
-    bool doCheckNewFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                        FileInfoPointer &newTargetInfo, QString &fileNewName,
-                        bool *skip, bool isCountSize = false);
+    DFileInfoPointer doCheckFile(const DFileInfoPointer &fromInfo,
+                                 const DFileInfoPointer &toInfo,
+                                 const QString &fileName,
+                                 bool *skip);
+    DFileInfoPointer doCheckNewFile(const DFileInfoPointer &fromInfo,
+                                    const DFileInfoPointer &toInfo,
+                                    QString &fileNewName,
+                                    bool *skip, bool isCountSize = false);
     bool checkFileSize(qint64 size, const QUrl &fromUrl,
                        const QUrl &toUrl, bool *skip);
     bool checkDiskSpaceAvailable(const QUrl &fromUrl, const QUrl &toUrl, bool *skip);
     bool checkTotalDiskSpaceAvailable(const QUrl &fromUrl, const QUrl &toUrl, bool *skip);
-    void setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo);
+    void setTargetPermissions(const QUrl &fromUrl, const QUrl &toUrl);
     void setAllDirPermisson();
     void determineCountProcessType();
     qint64 getWriteDataSize();
     qint64 getTidWriteSize();
     qint64 getSectorsWritten();
-    void readAheadSourceFile(const FileInfoPointer &fileInfo);
+    void readAheadSourceFile(const DFileInfoPointer &fileInfo);
     void syncFilesToDevice();
     AbstractJobHandler::SupportAction doHandleErrorAndWait(const QUrl &from, const QUrl &to,
                                                            const AbstractJobHandler::JobErrorType &error,
@@ -68,21 +71,21 @@ public:
     bool deleteDir(const QUrl &fromUrl, const QUrl &toUrl, bool *result, const bool force = false);
     bool copyFileFromTrash(const QUrl &urlSource, const QUrl &urlTarget, dfmio::DFile::CopyFlag flag);
 
-    bool copyAndDeleteFile(const FileInfoPointer &fromInfo, const FileInfoPointer &targetPathInfo, const FileInfoPointer &toInfo,
+    bool copyAndDeleteFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &targetPathInfo, const DFileInfoPointer &toInfo,
                            bool *result);
-    bool createSystemLink(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
+    bool createSystemLink(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                           const bool followLink, const bool doCopy,
                           bool *result);
     bool canWriteFile(const QUrl &url) const;
 
-    bool doCopyFile(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, bool *skip);
-    bool checkAndCopyFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip);
-    bool checkAndCopyDir(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo, bool *skip);
+    bool doCopyFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo, bool *skip);
+    bool checkAndCopyFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
+    bool checkAndCopyDir(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo, bool *skip);
 
 protected:
     void waitThreadPoolOver();
     void initCopyWay();
-    QUrl trashInfo(const FileInfoPointer &fromInfo);
+    QUrl trashInfo(const DFileInfoPointer &fromInfo);
     QString fileOriginName(const QUrl &trashInfoUrl);
     void removeTrashInfo(const QUrl &trashInfoUrl);
 
@@ -91,21 +94,18 @@ private:
     void initThreadCopy();
     void initSignalCopyWorker();
     bool actionOperating(const AbstractJobHandler::SupportAction action, const qint64 size, bool *skip);
-    bool createNewTargetInfo(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo,
-                             FileInfoPointer &newTargetInfo, const QUrl &fileNewUrl,
-                             bool *skip, bool isCountSize = false);
-    QUrl createNewTargetUrl(const FileInfoPointer &toInfo, const QString &fileName);
-    bool doCopyLocalFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo);
-    bool doCopyOtherFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip);
-    bool doCopyLocalBigFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, bool *skip);
+    QUrl createNewTargetUrl(const DFileInfoPointer &toInfo, const QString &fileName);
+    bool doCopyLocalFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
+    bool doCopyOtherFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
+    bool doCopyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
 
 private:   // do copy local big file
-    bool doCopyLocalBigFileResize(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, int toFd, bool *skip);
-    char *doCopyLocalBigFileMap(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, int fd, const int per, bool *skip);
-    void memcpyLocalBigFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, char *fromPoint, char *toPoint);
+    bool doCopyLocalBigFileResize(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int toFd, bool *skip);
+    char *doCopyLocalBigFileMap(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int fd, const int per, bool *skip);
+    void memcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *fromPoint, char *toPoint);
     void doCopyLocalBigFileClear(const size_t size, const int fromFd,
                                  const int toFd, char *fromPoint, char *toPoint);
-    int doOpenFile(const FileInfoPointer fromInfo, const FileInfoPointer toInfo, const bool isTo,
+    int doOpenFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, const bool isTo,
                    const int openFlag, bool *skip);
 
 protected Q_SLOTS:
@@ -117,12 +117,17 @@ protected Q_SLOTS:
 
 private:
     QVariant
-    checkLinkAndSameUrl(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize);
-    QVariant doActionReplace(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize);
-    QVariant doActionMerge(const FileInfoPointer &fromInfo, const FileInfoPointer &newTargetInfo, const bool isCountSize);
+    checkLinkAndSameUrl(const DFileInfoPointer &fromInfo,
+                        const DFileInfoPointer &newTargetInfo,
+                        const bool isCountSize);
+    QVariant doActionReplace(const DFileInfoPointer &fromInfo,
+                             const DFileInfoPointer &newTargetInfo,
+                             const bool isCountSize);
+    QVariant doActionMerge(const DFileInfoPointer &fromInfo,
+                           const DFileInfoPointer &newTargetInfo, const bool isCountSize);
 
 protected:
-    FileInfoPointer targetInfo { nullptr };   // target file infor pointer
+    DFileInfoPointer targetInfo { nullptr };   // target file infor pointer
     CountWriteSizeType countWriteType { CountWriteSizeType::kCustomizeType };   // get write size type
     long copyTid = { -1 };   // 使用 /pric/[pid]/task/[tid]/io 文件中的的 writeBytes 字段的值作为判断已写入数据的依据
     qint64 targetDeviceStartSectorsWritten { 0 };   // 记录任务开始时目标磁盘设备已写入扇区数
@@ -135,7 +140,7 @@ protected:
     QList<QUrl> syncFiles;
 
     std::atomic_int threadCopyFileCount { 0 };
-    QList<FileInfoPointer> cutAndDeleteFiles;
+    QList<DFileInfoPointer> cutAndDeleteFiles;
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -167,3 +167,14 @@ bool FileOperationsUtils::blockSync()
     bool sync = DConfigManager::instance()->value(kFileOperations, kBlockEverySync).toBool();
     return sync;
 }
+
+QUrl FileOperationsUtils::parentUrl(const QUrl &url)
+{
+    auto parent = url.adjusted(QUrl::StripTrailingSlash);
+    parent = parent.adjusted(QUrl::RemoveFilename);
+    parent = parent.adjusted(QUrl::StripTrailingSlash);
+    if (parent.isParentOf(url))
+        return parent;
+
+    return QUrl();
+}

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -66,6 +66,7 @@ class FileOperationsUtils
     friend class DoCleanTrashFilesWorker;
     friend class DoRestoreTrashFilesWorker;
     friend class FileOperateBaseWorker;
+    friend class ErrorMessageAndAction;
 
 private:
     static SizeInfoPointer statisticsFilesSize(const QList<QUrl> &files, const bool &isRecordUrl = false);
@@ -75,6 +76,7 @@ private:
     static bool isFileOnDisk(const QUrl &url);
     static qint64 bigFileSize();
     static bool blockSync();
+    static QUrl parentUrl(const QUrl &url);
 
 private:
     static QSet<QString> fileNameUsing;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
@@ -11,11 +11,14 @@
 
 #include <QSharedPointer>
 #include <QQueue>
+#include <dfm-io/dfileinfo.h>
 
 #include <fcntl.h>
 
 DPFILEOPERATIONS_BEGIN_NAMESPACE
 DFMBASE_USE_NAMESPACE
+
+typedef QSharedPointer<dfmio::DFileInfo> DFileInfoPointer;
 class WorkerData
 {
 public:

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.h
@@ -33,7 +33,9 @@ protected:
 
 protected:
     bool doOperate();
-    bool createParentDir(const FileInfoPointer &trashInfo, const FileInfoPointer &restoreInfo, FileInfoPointer &targetFileInfo, bool *result);
+    DFileInfoPointer createParentDir(const DFileInfoPointer &trashInfo,
+                                     const DFileInfoPointer &restoreInfo,
+                                     bool *result);
 
 private:
     QAtomicInteger<qint64> completeFilesCount { 0 };

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.h
@@ -38,8 +38,8 @@ protected:
     bool translateUrls();
     bool doRestoreTrashFiles();
     //check disk space available before do move job
-    bool createParentDir(const FileInfoPointer &trashInfo, const FileInfoPointer &restoreInfo, FileInfoPointer &targetFileInfo, bool *result);
-    bool checkRestoreInfo(const QUrl &url, FileInfoPointer &restoreInfo);
+    DFileInfoPointer createParentDir(const QUrl &fromUrl, const DFileInfoPointer &restoreInfo, bool *result);
+    DFileInfoPointer checkRestoreInfo(const QUrl &url);
 
 private:
     bool mergeDir(const QUrl &urlSource, const QUrl &urlTarget, dfmio::DFile::CopyFlag flag);

--- a/tests/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperations/copyfiles/ut_docopyfilesworker.cpp
+++ b/tests/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperations/copyfiles/ut_docopyfilesworker.cpp
@@ -88,7 +88,7 @@ TEST_F(UT_DoCopyFilesWorker, testInitArgs)
     stub.set_lamda(VADDR(SyncFileInfo, exists), []{ __DBG_STUB_INVOKE__ return true;});
     EXPECT_TRUE(worker.initArgs());
 
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
     worker.precompleteTargetFileInfo.append(targetInfo);
     worker.endWork();
 }
@@ -120,7 +120,7 @@ TEST_F(UT_DoCopyFilesWorker, testCopyFiles)
                 return AbstractJobHandler::SupportAction::kNoAction;});
     EXPECT_FALSE(worker.copyFiles());
 
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
     worker.targetInfo = targetInfo;
     stub.set_lamda(VADDR(SyncFileInfo, isAttributes), []{ __DBG_STUB_INVOKE__ return true;});
     stub.set_lamda(&FileUtils::isHigherHierarchy, []{ __DBG_STUB_INVOKE__ return true;});

--- a/tests/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperations/fileoperationutils/ut_docopyfileworker.cpp
+++ b/tests/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperations/fileoperationutils/ut_docopyfileworker.cpp
@@ -73,8 +73,8 @@ TEST_F(UT_DoCopyFileWorker, testDoCopyFilePractically)
 
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
 
     bool skip{false};
     worker.resume();
@@ -143,8 +143,8 @@ TEST_F(UT_DoCopyFileWorker, testDoDfmioFileCopy)
     worker.stop();
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     EXPECT_FALSE(worker.doDfmioFileCopy(sorceInfo, targetInfo, nullptr));
 
     bool skip{false};
@@ -228,7 +228,7 @@ TEST_F(UT_DoCopyFileWorker, testReadAheadSourceFile)
     DoCopyFileWorker worker(data);
     QProcess::execute("touch sourceUrl.txt");
 
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     worker.readAheadSourceFile(sorceInfo);
 
     stub_ext::StubExt stub;
@@ -245,8 +245,8 @@ TEST_F(UT_DoCopyFileWorker, testCreateFileDevice)
 
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     bool skip{false};
     QSharedPointer<DFMIO::DFile> file{nullptr};
     stub_ext::StubExt stub;
@@ -266,8 +266,8 @@ TEST_F(UT_DoCopyFileWorker, testResizeTargetFile)
     DoCopyFileWorker worker(data);
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     bool skip{false};
     QSharedPointer<DFMIO::DFile> file{new DFile(sorceUrl)};
     stub_ext::StubExt stub;
@@ -288,8 +288,8 @@ TEST_F(UT_DoCopyFileWorker, testDoReadFile)
     DoCopyFileWorker worker(data);
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     bool skip{false};
 
     worker.stop();
@@ -345,8 +345,8 @@ TEST_F(UT_DoCopyFileWorker, testDoWriteFile)
     DoCopyFileWorker worker(data);
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     bool skip{false};
     worker.stop();
     QSharedPointer<DFMIO::DFile> file{new DFile(sorceUrl)};
@@ -396,8 +396,8 @@ TEST_F(UT_DoCopyFileWorker, testVerifyFileIntegrity)
     DoCopyFileWorker worker(data);
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     bool skip{false};
     worker.stop();
     QSharedPointer<DFMIO::DFile> file{new DFile(sorceUrl)};
@@ -452,7 +452,7 @@ TEST_F(UT_DoCopyFileWorker, testSyncBlockFile)
     worker.syncBlockFile(nullptr);
 
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
 
     stub_ext::StubExt stub;
     stub.set(&::open, OpenFunc);

--- a/tests/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperations/trashfiles/ut_docopyfromtrashfilesworker.cpp
+++ b/tests/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperations/trashfiles/ut_docopyfromtrashfilesworker.cpp
@@ -121,14 +121,14 @@ TEST_F(UT_DoCopyFromTrashFilesWorker, testDoOperate)
     EXPECT_TRUE(worker.doOperate());
 
     worker.targetUrl = QUrl::fromLocalFile(QDir::currentPath());
-    stub.set_lamda(&DoCopyFromTrashFilesWorker::createParentDir, []{ __DBG_STUB_INVOKE__ return false;});
+    stub.set_lamda(&DoCopyFromTrashFilesWorker::createParentDir, []{ __DBG_STUB_INVOKE__ return nullptr;});
     EXPECT_FALSE(worker.doOperate());
 
     stub.set(&DoCopyFromTrashFilesWorker::createParentDir, createParentDirFunc);
     EXPECT_TRUE(worker.doOperate());
 
     stub.set(&DoCopyFromTrashFilesWorker::createParentDir, createParentDirFunc1);
-    stub.set_lamda(&DoCopyFromTrashFilesWorker::doCheckFile, []{ __DBG_STUB_INVOKE__ return false;});
+    stub.set_lamda(&DoCopyFromTrashFilesWorker::doCheckFile, []{ __DBG_STUB_INVOKE__ return nullptr;});
     EXPECT_TRUE(worker.doOperate());
 
     stub.set(&DoCopyFromTrashFilesWorker::doCheckFile, doCheckFileFunc);
@@ -145,26 +145,26 @@ TEST_F(UT_DoCopyFromTrashFilesWorker, testCreateParentDir)
     stub_ext::StubExt stub;
     auto sorceUrl = QUrl::fromLocalFile(QDir::currentPath() + "/sourceUrl.txt");
     auto targetUrl = QUrl::fromLocalFile(QDir::currentPath() + "/targetUrl.txt");
-    auto targetInfo = InfoFactory::create<FileInfo>(targetUrl);
-    auto sorceInfo = InfoFactory::create<FileInfo>(sorceUrl);
+    DFileInfoPointer targetInfo(new DFileInfo(targetUrl));
+    DFileInfoPointer sorceInfo(new DFileInfo(sorceUrl));
     stub.set_lamda(&UrlRoute::urlParent, []{ __DBG_STUB_INVOKE__ return QUrl();});
     FileInfoPointer newTargetInfo(nullptr);
     bool skip{false};
-    EXPECT_FALSE(worker.createParentDir(sorceInfo, targetInfo, newTargetInfo, &skip));
+    EXPECT_FALSE(worker.createParentDir(sorceInfo, targetInfo, &skip));
 
     auto tmpUrl = targetUrl;
     tmpUrl.setScheme("trash");
     stub.set_lamda(&UrlRoute::urlParent, [tmpUrl]{ __DBG_STUB_INVOKE__ return tmpUrl;});
-    EXPECT_FALSE(worker.createParentDir(sorceInfo, targetInfo, newTargetInfo, &skip));
+    EXPECT_FALSE(worker.createParentDir(sorceInfo, targetInfo, &skip));
 
     tmpUrl = QUrl::fromLocalFile(QDir::currentPath());
     stub.set_lamda(&UrlRoute::urlParent, [tmpUrl]{ __DBG_STUB_INVOKE__ return tmpUrl;});
-    EXPECT_TRUE(worker.createParentDir(sorceInfo, targetInfo, newTargetInfo, &skip));
+    EXPECT_TRUE(worker.createParentDir(sorceInfo, targetInfo, &skip));
 
     stub.set_lamda(&DoCopyFromTrashFilesWorker::doHandleErrorAndWait, []{ __DBG_STUB_INVOKE__
                 return AbstractJobHandler::SupportAction::kCancelAction;});
     tmpUrl = QUrl::fromLocalFile(QDir::currentPath() +QDir::separator() + "testDir_DoCopyFromTrashFilesWorker");
     stub.set_lamda(&UrlRoute::urlParent, [tmpUrl]{ __DBG_STUB_INVOKE__ return tmpUrl;});
     stub.set_lamda(&LocalFileHandler::mkdir, []{ __DBG_STUB_INVOKE__ return false;});
-    EXPECT_FALSE(worker.createParentDir(sorceInfo, targetInfo, newTargetInfo, &skip));
+    EXPECT_FALSE(worker.createParentDir(sorceInfo, targetInfo, &skip));
 }


### PR DESCRIPTION
Failure to load the trashcore plugin resulted in no trashinfo creation failure. Use dfileinfo to read data during restore

Log: Delete the file and recall it with Ctrl+Z, displaying an error pop-up window in dde-file-dailog
Bug: https://pms.uniontech.com/bug-view-254735.html