### PR TITLE
fix: After installing VM Tools on V23 VMware virtual machine, files and content cannot be copied between virtual machine and physical machine

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -61,14 +61,14 @@ void onClipboardDataChanged()
         clipboardAction = ClipBoard::kRemoteCopiedAction;
         return;
     }
-    QByteArray data = mimeData->data(kGnomeCopyKey);
-    data = data.replace(QString(kGnomeCopyKey) + "\n", "");
-
-    if (data.startsWith("cut")) {
+    const QString &data = mimeData->data(kGnomeCopyKey);
+    const static QRegExp regCut("cut\nfile://"), regCopy("copy\nfile://");
+    if (data.contains(regCut)) {
         clipboardAction = ClipBoard::kCutAction;
-    } else if (data.startsWith("copy")) {
+    } else if (data.contains(regCopy)) {
         clipboardAction = ClipBoard::kCopyAction;
     } else {
+        qCWarning(logDFMBase) << "wrang kGnomeCopyKey data = " << data;
         clipboardAction = ClipBoard::kUnknownAction;
     }
 


### PR DESCRIPTION
Error in writing clipboard string judgment

Log: After installing VM Tools on V23 VMware virtual machine, files and content cannot be copied between virtual machine and physical machine
Bug: https://pms.uniontech.com/bug-view-256725.html