### PR TITLE
fix: The shortcut file "bensound sunny. mp3" in the music directory cannot be moved to the trash

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -81,7 +81,14 @@ JobHandlePointer TrashFileEventReceiver::doMoveToTrash(const quint64 windowId, c
                 && !info->isAttributes(OptInfoType::kIsSymLink)
                 && !info->isAttributes(OptInfoType::kIsWritable);
     }
-    if (nullDirDelete || !FileUtils::fileCanTrash(sourceFirst) || !dfmio::DFMUtils::supportTrash(sourceFirst)) {
+    const auto &sourceInfo = InfoFactory::create<FileInfo>(sourceFirst);
+    bool canTrash = false;
+    auto filesource = FileUtils::bindUrlTransform(sourceFirst);
+    if (sourceInfo)
+        canTrash = sourceInfo->isAttributes(OptInfoType::kIsSymLink)
+                && filesource.path().startsWith(StandardPaths::location(StandardPaths::StandardLocation::kHomePath));
+    if (nullDirDelete || !FileUtils::fileCanTrash(sourceFirst) ||
+            (!dfmio::DFMUtils::supportTrash(sourceFirst) && !canTrash)) {
         if (DialogManagerInstance->showDeleteFilesDialog(sources, true) != QDialog::Accepted)
             return nullptr;
         handle = copyMoveJob->deletes(sources, flags);


### PR DESCRIPTION
Determine if there is an interface issue that supports the trash operation, and supplement the judgment. If it is a linked file and it is in the main directory, it can be deleted

Log: The shortcut file "bensound sunny. mp3" in the music directory cannot be moved to the recycle bin
Bug: https://pms.uniontech.com/bug-view-259171.html