### PR TITLE
fix: Dragging files from the trash to a USB drive for undo can cause dde-file-manager to freeze

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -84,7 +84,9 @@ JobHandlePointer TrashFileEventReceiver::doMoveToTrash(const quint64 windowId, c
     if (nullDirDelete || !FileUtils::fileCanTrash(sourceFirst) || !dfmio::DFMUtils::supportTrash(sourceFirst)) {
         if (DialogManagerInstance->showDeleteFilesDialog(sources, true) != QDialog::Accepted)
             return nullptr;
-        handle = copyMoveJob->deletes(sources, flags);
+        handle = copyMoveJob->deletes(sources, flags, isInit);
+        if (!isInit)
+            return handle;
     } else {
         // check url permission
         QList<QUrl> urlsCanTrash = sources;


### PR DESCRIPTION
Error in passing parameters during complete deletion

Log: Dragging files from the trash to a USB drive for undo can cause dde-file-manager to freeze
Bug: https://pms.uniontech.com/bug-view-259887.html