### PR TITLE
fix: Using command to open file path in dde-fil-manager, incorrect path opened during execution

### DIFF
--- a/assets/scripts/dde-file-manager
+++ b/assets/scripts/dde-file-manager
@@ -5,11 +5,31 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 args=""
+current_path=$(pwd)
 for arg in "$@"; do
+    if [[ $arg =~ "." ]] || [[ $arg =~ ".." ]] || [[ $arg =~ "~/" ]]; then
+        name=${arg##*/}
+        path=${arg%/*}"/"
+        if [[ $name == "." ]] || [[ $name == ".." ]]; then
+            name=""
+            path=$path$name
+        fi
+        if [[ $path =~ "~/" ]]; then
+            cd ~/
+            home_path=$(pwd)
+            path=$(echo "$path" | sed "s|~/|$home_path/|g")
+            cd $current_path
+        fi
+        cd $path
+        path=$(pwd)"/"
+        cd $current_path
+        absolute_path=$path$name
+        arg=$(echo "$absolute_path" | sed 's/ /*||*/g')
+    fi
     args+="$arg,"
 done
-
 args=${args%,}
+echo $args
 
 dbus-send --print-reply --dest=org.freedesktop.FileManager1 /org/freedesktop/FileManager1 org.freedesktop.FileManager1.Open array:string:"$args"
 

--- a/src/apps/dde-file-manager/singleapplication.cpp
+++ b/src/apps/dde-file-manager/singleapplication.cpp
@@ -153,7 +153,9 @@ void SingleApplication::readData()
         if (arg.isEmpty())
             continue;
 
-        arguments << QString::fromLocal8Bit(arg);
+        QString argstr = QString::fromLocal8Bit(arg);
+        argstr = argstr.replace("*||*", " ");
+        arguments << argstr;
     }
 
     CommandParser::instance().process(arguments);

--- a/src/plugins/server/serverplugin-filemanager1/filemanager1dbus.cpp
+++ b/src/plugins/server/serverplugin-filemanager1/filemanager1dbus.cpp
@@ -30,11 +30,15 @@ FileManager1DBus::FileManager1DBus(QObject *parent)
 void FileManager1DBus::ShowFolders(const QStringList &URIs, const QString &StartupId)
 {
     Q_UNUSED(StartupId)
+    QStringList URIsArgs;
+    for (auto arg : URIs) {
+        URIsArgs.append(arg.replace(" ", "*||*"));
+    }
 
-    if (QProcess::startDetached("file-manager.sh", QStringList() << "--raw" << URIs))
+    if (QProcess::startDetached("file-manager.sh", QStringList() << "--raw" << URIsArgs))
         return;
 
-    QProcess::startDetached("dde-file-manager", QStringList() << "--raw" << URIs);
+    QProcess::startDetached("dde-file-manager", QStringList() << "--raw" << URIsArgs);
 }
 
 /*!
@@ -44,13 +48,16 @@ void FileManager1DBus::ShowFolders(const QStringList &URIs, const QString &Start
 void FileManager1DBus::ShowItemProperties(const QStringList &URIs, const QString &StartupId)
 {
     Q_UNUSED(StartupId)
-
+    QStringList URIsArgs;
+    for (auto arg : URIs) {
+        URIsArgs.append(arg.replace(" ", "*||*"));
+    }
     if (QProcess::startDetached("file-manager.sh", QStringList() << "--raw"
-                                                                 << "-p" << URIs))
+                                                                 << "-p" << URIsArgs))
         return;
 
     QProcess::startDetached("dde-file-manager", QStringList() << "--raw"
-                                                              << "-p" << URIs);
+                                                              << "-p" << URIsArgs);
 }
 
 /*!
@@ -63,16 +70,23 @@ void FileManager1DBus::ShowItemProperties(const QStringList &URIs, const QString
 void FileManager1DBus::ShowItems(const QStringList &URIs, const QString &StartupId)
 {
     Q_UNUSED(StartupId)
-
-    if (QProcess::startDetached("file-manager.sh", QStringList() << "--show-item" << URIs << "--raw"))
+    QStringList URIsArgs;
+    for (auto arg : URIs) {
+        URIsArgs.append(arg.replace(" ", "*||*"));
+    }
+    if (QProcess::startDetached("file-manager.sh", QStringList() << "--show-item" << URIsArgs << "--raw"))
         return;
 
-    QProcess::startDetached("dde-file-manager", QStringList() << "--show-item" << URIs << "--raw");
+    QProcess::startDetached("dde-file-manager", QStringList() << "--show-item" << URIsArgs << "--raw");
 }
 
 void FileManager1DBus::Trash(const QStringList &URIs)
 {
-    QJsonArray srcArray = QJsonArray::fromStringList(URIs);
+    QStringList URIsArgs;
+    for (auto arg : URIs) {
+        URIsArgs.append(arg.replace(" ", "*||*"));
+    }
+    QJsonArray srcArray = QJsonArray::fromStringList(URIsArgs);
 
     QJsonObject paramObj;
     paramObj.insert("sources", srcArray);
@@ -87,8 +101,12 @@ void FileManager1DBus::Trash(const QStringList &URIs)
 
 void FileManager1DBus::Open(const QStringList &Args)
 {
-    if (QProcess::startDetached("file-manager.sh", QStringList() << Args))
+    QStringList URIsArgs;
+    for (auto arg : Args) {
+        URIsArgs.append(arg.replace(" ", "*||*"));
+    }
+    if (QProcess::startDetached("file-manager.sh", QStringList() << URIsArgs))
         return;
 
-    QProcess::startDetached("dde-file-manager", QStringList() << Args);
+    QProcess::startDetached("dde-file-manager", QStringList() << URIsArgs);
 }


### PR DESCRIPTION
Processing command line paths containing./,../,~/ Path processing of spaces

Log: Using command to open file path in dde-fil-manager, incorrect path opened during execution
Bug: https://pms.uniontech.com/bug-view-260195.html