### PR TITLE
fix: After enabling the long file name function, delete files to the trash. Right click on the attribute window and there is marked information that can be edited

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
@@ -168,6 +168,20 @@ void Trash::followEvents()
     dpfHookSequence->follow("dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin", TrashFileHelper::instance(), &TrashFileHelper::openFileInPlugin);
 
     dpfHookSequence->follow("dfmplugin_utils", "hook_OpenWith_DisabledOpenWithWidget", TrashFileHelper::instance(), &TrashFileHelper::disableOpenWidgetWidget);
+
+    // register to tag
+    auto searchPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-tag") };
+    if (searchPlugin && searchPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
+        dpfHookSequence->follow("dfmplugin_tag", "hook_CanTaged", TrashFileHelper::instance(), &TrashFileHelper::handleCanTag);
+    } else {
+        connect(
+                DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this, [](const QString &iid, const QString &name) {
+                    Q_UNUSED(iid)
+                    if (name == "dfmplugin-tag")
+                        dpfHookSequence->follow("dfmplugin_tag", "hook_CanTaged", TrashFileHelper::instance(), &TrashFileHelper::handleCanTag);
+                },
+                Qt::DirectConnection);
+    }
 }
 
 void Trash::bindWindows()

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -141,3 +141,14 @@ bool TrashFileHelper::disableOpenWidgetWidget(const QUrl &url, bool *result)
 
     return true;
 }
+
+bool TrashFileHelper::handleCanTag(const QUrl &url, bool *canTag)
+{
+    if (url.scheme() == scheme() || FileUtils::isTrashFile(url)) {
+        if (canTag)
+            *canTag = false;
+        return true;
+    }
+
+    return false;
+}

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.h
@@ -37,6 +37,7 @@ public:
     bool openFileInPlugin(quint64 windowId, const QList<QUrl> urls);
     bool blockPaste(quint64 winId, const QList<QUrl> &fromUrls, const QUrl &to);
     bool disableOpenWidgetWidget(const QUrl &url, bool *result);
+    bool handleCanTag(const QUrl &url, bool *canTag);
 
 private:
     explicit TrashFileHelper(QObject *parent = nullptr);


### PR DESCRIPTION
All trash files cannot be marked. Register the hook_cantag function and return a tag that is not allowed

Log:  After enabling the long file name function, delete files to the trash. Right click on the attribute window and there is marked information that can be edited
Bug: https://pms.uniontech.com/bug-view-260621.html