### PR TITLE
fix: When restoring files with long file names from trash, the prompt window icon and file size display error for replacing existing files

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -786,7 +786,6 @@ void FileOperateBaseWorker::initCopyWay()
 
 QUrl FileOperateBaseWorker::trashInfo(const DFileInfoPointer &fromInfo)
 {
-
     auto parentPath = parentUrl(fromInfo->uri()).path();
     if (!parentPath.endsWith("files"))
         return QUrl();

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -173,8 +173,11 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
             }
         }
         DFileInfoPointer fileInfo { new DFileInfo(url) };
+
         // read trash info
         QUrl trashInfoUrl { fileInfo->attribute(DFileInfo::AttributeID::kStandardTargetUri).toString().replace("/files/", "/info/") + ".trashinfo" };
+        QUrl trashUrl = QUrl(fileInfo->attribute(DFileInfo::AttributeID::kStandardTargetUri).toString());
+        fileInfo.reset(new DFileInfo(trashUrl));
         const QString &trashInfoCache { DFMIO::DFile(trashInfoUrl).readAll() };
         emitCurrentTaskNotify(url, restoreInfo->uri());
         bool ok = false;


### PR DESCRIPTION
 Create a fileinfo using the scheme of trash, retrieve the restored original path, and recreate the fileinfo

Log: When restoring files with long file names from trash, the prompt window icon and file size display error for replacing existing files
Bug: https://pms.uniontech.com/bug-view-259587.html