### PR TITLE
fix: [desktop] when menu pops up, the input method can still be used 

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/canvasview.cpp
@@ -349,6 +349,8 @@ void CanvasView::contextMenuEvent(QContextMenuEvent *event)
     bool isEmptyArea = !index.isValid();
     Qt::ItemFlags flags;
 
+    if (WindowUtils::isWayLand())
+        setAttribute(Qt::WA_InputMethodEnabled, false);
     if (isEmptyArea) {
         d->menuProxy->showEmptyAreaMenu(flags, gridPos);
     } else {
@@ -359,6 +361,8 @@ void CanvasView::contextMenuEvent(QContextMenuEvent *event)
         flags = model()->flags(index);
         d->menuProxy->showNormalMenu(index, flags, gridPos);
     }
+    if (WindowUtils::isWayLand())
+        setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
 void CanvasView::startDrag(Qt::DropActions supportedActions)


### PR DESCRIPTION


1. When the wayland menu pops up, there is no focus on seizing, causing the input method to not disappear.
2. In the Wayland mode, when the menu pops up, the input method is disabled

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-259639.html