### PR TITLE
fix: [Search] The clear search dialog show multiple times.

### DIFF
--- a/src/dfm-base/base/application/application.cpp
+++ b/src/dfm-base/base/application/application.cpp
@@ -276,7 +276,7 @@ Settings *Application::dataPersistence()
     return dpGlobal;
 }
 
-void Application::appAttributeTrigger(TriggerAttribute ta)
+void Application::appAttributeTrigger(TriggerAttribute ta, quint64 winId)
 {
     switch (ta) {
     case kRestoreViewMode: {
@@ -307,7 +307,7 @@ void Application::appAttributeTrigger(TriggerAttribute ta)
         break;
         }
     case kClearSearchHistory:
-        Q_EMIT instance()->clearSearchHistory();
+        Q_EMIT instance()->clearSearchHistory(winId);
         break;
     }
 }

--- a/src/dfm-base/base/application/application.h
+++ b/src/dfm-base/base/application/application.h
@@ -93,7 +93,7 @@ public:
 
     static Settings *dataPersistence();
 
-    static void appAttributeTrigger(TriggerAttribute ta);
+    static void appAttributeTrigger(TriggerAttribute ta, quint64 winId);
 
 Q_SIGNALS:
     void appAttributeChanged(ApplicationAttribute aa, const QVariant &value);
@@ -111,7 +111,7 @@ Q_SIGNALS:
 
     void genericSettingCreated(Settings *settings);
     void appSettingCreated(Settings *settings);
-    void clearSearchHistory();
+    void clearSearchHistory(quint64 winId);
 
 protected:
     Application(ApplicationPrivate *dd, QObject *parent = nullptr);

--- a/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
@@ -11,6 +11,7 @@
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/utils/windowutils.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
 
 #include <dtkcore_global.h>
 #include <DSettingsOption>
@@ -134,10 +135,12 @@ void SettingDialog::loadSettings(const QString & /*templateFile*/)
 QPointer<QCheckBox> SettingDialog::kAutoMountCheckBox = nullptr;
 QPointer<QCheckBox> SettingDialog::kAutoMountOpenCheckBox = nullptr;
 QSet<QString> SettingDialog::kHiddenSettingItems {};
+quint64 SettingDialog::parentWid { 0 };
 
 SettingDialog::SettingDialog(QWidget *parent)
     : DSettingsDialog(parent)
 {
+    parentWid = FMWindowsIns.findWindowId(parent);
     // TODO(xust): move to server plugin.
     widgetFactory()->registerWidget("mountCheckBox", &SettingDialog::createAutoMountCheckBox);
     widgetFactory()->registerWidget("openCheckBox", &SettingDialog::createAutoMountOpenCheckBox);
@@ -296,7 +299,7 @@ QPair<QWidget *, QWidget *> SettingDialog::createPushButton(QObject *opt)
     layout->addWidget(button, 0, Qt::AlignRight);
 
     connect(button, &DPushButton::clicked, option, [=] {
-        Application::appAttributeTrigger(static_cast<Application::TriggerAttribute>(attributeType));
+        Application::appAttributeTrigger(static_cast<Application::TriggerAttribute>(attributeType), parentWid);
     });
 
     return qMakePair(new QLabel(desc), rightWidget);

--- a/src/dfm-base/dialogs/settingsdialog/settingdialog.h
+++ b/src/dfm-base/dialogs/settingsdialog/settingdialog.h
@@ -43,6 +43,7 @@ private:
     static QPointer<QCheckBox> kAutoMountOpenCheckBox;
     static QSet<QString> kHiddenSettingItems;
     QPointer<DSettings> dtkSettings;
+    static quint64 parentWid;
 };
 }
 #endif   // DFMSETTINGDIALOG_H

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/addressbar.cpp
@@ -365,8 +365,12 @@ int AddressBarPrivate::showClearSearchHistory()
     return code;
 }
 
-void AddressBarPrivate::onClearSearchHistory()
+void AddressBarPrivate::onClearSearchHistory(quint64 winId)
 {
+    quint64 id = FMWindowsIns.findWindowId(q);
+    if (id != winId)
+        return;
+
     auto result = showClearSearchHistory();
     if (result == DDialog::Accepted)
         q->clearSearchHistory();

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/private/addressbar_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/private/addressbar_p.h
@@ -110,7 +110,7 @@ public Q_SLOTS:
     void onDConfigValueChanged(const QString &config, const QString &key);
     void filterHistory(const QString &text);
     int showClearSearchHistory();
-    void onClearSearchHistory();
+    void onClearSearchHistory(quint64 winId);
 
 protected:
     virtual bool eventFilterResize(AddressBar *addressbar, QResizeEvent *event);


### PR DESCRIPTION
Add the window id, let the parent window get the signal and clear the search history.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-259865.html