### PR TITLE
fix: The screen recording file is stored in the "Video" directory, but clicking on "Open Folder" in the banner notification will redirect to the main directory

### DIFF
--- a/assets/scripts/dde-file-manager
+++ b/assets/scripts/dde-file-manager
@@ -7,7 +7,7 @@
 args=""
 current_path=$(pwd)
 for arg in "$@"; do
-    if [[ $arg =~ "." ]] || [[ $arg =~ ".." ]] || [[ $arg =~ "~/" ]]; then
+    if [[ $arg == "." ]] || [[ $arg == ".." ]] || [[ $arg == *"/." ]] || [[ $arg == *"/.." ]] || [[ $arg =~ "./" ]] || [[ $arg =~ "../" ]] || [[ $arg =~ "~/" ]]; then
         name=${arg##*/}
         path=${arg%/*}"/"
         if [[ $name == "." ]] || [[ $name == ".." ]]; then
@@ -20,7 +20,7 @@ for arg in "$@"; do
             path=$(echo "$path" | sed "s|~/|$home_path/|g")
             cd $current_path
         fi
-        cd $path
+        cd "$path"
         path=$(pwd)"/"
         cd $current_path
         absolute_path=$path$name


### PR DESCRIPTION
The dde file manager script CD did not include ""

Log: The screen recording file is stored in the "Video" directory, but clicking on "Open Folder" in the banner notification will redirect to the main directory
Bug: https://pms.uniontech.com/bug-view-261441.html