### PR TITLE
fix: When there are multiple lines of files in the document management system, only the last line will be displayed. When selected, a slider will be displayed, and other lines will not be displayed

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -260,6 +260,12 @@ int FileViewHelper::verticalOffset() const
     return parent()->verticalOffset();
 }
 
+bool FileViewHelper::isLastIndex(const QModelIndex &index)
+{
+    int rowCount = parent()->model()->rowCount(parent()->rootIndex());
+    return index.row() + 1 == rowCount;
+}
+
 int FileViewHelper::caculateListItemIndex(const QSize &itemSize, const QPoint &pos)
 {
     if (pos.y() % (itemSize.height() + kListViewSpacing * 2) < kListViewSpacing)

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.h
@@ -41,6 +41,7 @@ public:
     bool isEmptyArea(const QPoint &pos);
     QSize viewContentSize() const;
     int verticalOffset() const;
+    bool isLastIndex(const QModelIndex &index);
 
     static int caculateListItemIndex(const QSize &itemSize, const QPoint &pos);
     static int caculateIconItemIndex(const FileView *view, const QSize &itemSize, const QPoint &pos);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.cpp
@@ -204,3 +204,13 @@ QRectF ExpandedItem::iconGeometry() const
 
     return iconRect;
 }
+
+void ExpandedItem::setDifferenceOfLastRow(const int diff)
+{
+    this->diff = diff < 0 ? 0 : diff;
+}
+
+int ExpandedItem::getDifferenceOfLastRow() const
+{
+    return diff;
+}

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/expandedItem.h
@@ -42,6 +42,8 @@ public:
     void setOption(QStyleOptionViewItem opt);
     QRectF textGeometry(int width = -1) const;
     QRectF iconGeometry() const;
+    void setDifferenceOfLastRow(const int diff);
+    int getDifferenceOfLastRow() const;
 
 private:
     QPixmap iconPixmap;
@@ -52,6 +54,7 @@ private:
     qreal opacity { 1 };
     bool canDeferredDelete { true };
     IconItemDelegate *delegate { nullptr };
+    int diff { 0 };
 };
 }
 


### PR DESCRIPTION
Modify the sizehint of iconitemdelegate and set the maximum height when there is an extension in the last one

Log: When there are multiple lines of files in the document management system, only the last line will be displayed. When selected, a slider will be displayed, and other lines will not be displayed
Bug: https://pms.uniontech.com/bug-view-260623.html