### PR TITLE
fix: Unable to open multiple files with invalid links

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -276,12 +276,14 @@ bool LocalFileHandler::openFiles(const QList<QUrl> &fileUrls)
 
     QList<QUrl> pathList;
     bool result = false;
-
+    d->invalidPath.clear();
     for (QUrl &fileUrl : urls) {
         FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(fileUrl);
+        QUrl sourceUrl = fileUrl;
         QStringList targetList;
         targetList.append(fileUrl.path());
         FileInfoPointer fileInfoLink = fileInfo;
+
         while (fileInfoLink->isAttributes(OptInfoType::kIsSymLink)) {
             QString targetLink = fileInfoLink->pathOf(PathInfoType::kSymLinkTarget);
             targetLink = targetLink.endsWith(QDir::separator()) && targetLink != QDir::separator() ? QString(targetLink).left(targetLink.length() - 1)
@@ -304,6 +306,7 @@ bool LocalFileHandler::openFiles(const QList<QUrl> &fileUrls)
                 d->lastEvent = DialogManagerInstance->showBreakSymlinkDialog(fileInfoLink->nameOf(
                                                                                      NameInfoType::kFileName),
                                                                              fileInfo->urlOf(UrlInfoType::kUrl));
+                d->invalidPath << sourceUrl;
                 return d->lastEvent == DFMBASE_NAMESPACE::GlobalEventType::kUnknowType;
             }
         }
@@ -1204,6 +1207,11 @@ QString LocalFileHandler::errorString()
 DFMIOErrorCode LocalFileHandler::errorCode()
 {
     return d->lastError.code();
+}
+
+QList<QUrl> LocalFileHandler::getInvalidPath()
+{
+    return d->invalidPath;
 }
 
 GlobalEventType LocalFileHandler::lastEventType()

--- a/src/dfm-base/file/local/localfilehandler.h
+++ b/src/dfm-base/file/local/localfilehandler.h
@@ -47,7 +47,6 @@ public:
     bool deleteFile(const QUrl &url);
     bool deleteFileRecursive(const QUrl &url);
     bool setFileTime(const QUrl &url, const QDateTime &accessDateTime, const QDateTime &lastModifiedTime);
-
     bool renameFilesBatch(const QMap<QUrl, QUrl> &urls, QMap<QUrl, QUrl> &successUrls);
     bool doHiddenFileRemind(const QString &name, bool *checkRule = nullptr);
 
@@ -55,6 +54,7 @@ public:
     GlobalEventType lastEventType();
     QString errorString();
     DFMIOErrorCode errorCode();
+    QList<QUrl> getInvalidPath();
 
 private:
     QScopedPointer<LocalFileHandlerPrivate> d;

--- a/src/dfm-base/file/local/localfilehandler_p.h
+++ b/src/dfm-base/file/local/localfilehandler_p.h
@@ -66,6 +66,7 @@ public:
     LocalFileHandler *q { nullptr };
     DFMIOError lastError;
     GlobalEventType lastEvent = GlobalEventType::kUnknowType;
+    QList<QUrl> invalidPath;   //BUG:https://pms.uniontech.com/bug-view-259909.html,记录无效链接路径
 };
 
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -869,15 +869,16 @@ bool FileOperationsEventReceiver::handleOperationOpenFiles(const quint64 windowI
         DFMBASE_NAMESPACE::GlobalEventType lastEvent = fileHandler.lastEventType();
         if (lastEvent != DFMBASE_NAMESPACE::GlobalEventType::kUnknowType) {
             if (lastEvent == DFMBASE_NAMESPACE::GlobalEventType::kDeleteFiles)
-                dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kDeleteFiles, windowId, urls, AbstractJobHandler::JobFlag::kNoHint, nullptr);
+                dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kDeleteFiles, windowId, fileHandler.getInvalidPath(), AbstractJobHandler::JobFlag::kNoHint, nullptr);
             else if (lastEvent == DFMBASE_NAMESPACE::GlobalEventType::kMoveToTrash)
-                dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kMoveToTrash, windowId, urls, AbstractJobHandler::JobFlag::kNoHint, nullptr);
+                dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kMoveToTrash, windowId, fileHandler.getInvalidPath(), AbstractJobHandler::JobFlag::kNoHint, nullptr);
         } else {
             // deal open file with custom dialog
-            dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", windowId, urls);
+            dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", windowId, fileHandler.getInvalidPath());
             ok = true;
         }
     }
+
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kOpenFilesResult, windowId, urls, ok, error);
     return ok;
 }


### PR DESCRIPTION
Clicking to confirm the deletion of invalid links will delete all files and prevent them from opening properly

Log: Open multiple files normally, open other files, delete only invalid links
Bug: https://pms.uniontech.com/bug-view-259909.html