### PR TITLE
fix: Batch renaming, "Renaming" option, shortcut key Enter not effective

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -972,6 +972,8 @@ void FileView::onSelectionChanged(const QItemSelection &selected, const QItemSel
 {
     delayUpdateStatusBar();
 
+    emit selectUrlChanged(selectedUrlList());
+
     quint64 winId = WorkspaceHelper::instance()->windowId(this);
     WorkspaceEventCaller::sendViewSelectionChanged(winId, selected, deselected);
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
@@ -172,6 +172,7 @@ protected:
 Q_SIGNALS:
     void reqOpenNewWindow(const QList<QUrl> &urls);
     void viewStateChanged();
+    void selectUrlChanged(const QList<QUrl> &urls);
 
 private slots:
     void loadViewState(const QUrl &url);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/renamebar_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/renamebar_p.h
@@ -83,6 +83,7 @@ public:
     DTuple<QPushButton *, QPushButton *, QHBoxLayout *, QFrame *> buttonsArea {};
 
     DSuggestButton *renameBtn { nullptr };
+    bool connectInitOnce { false };
 
 public slots:
     void onRenamePatternChanged(const int &index) noexcept;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
@@ -61,6 +61,23 @@ void RenameBar::storeUrlList(const QList<QUrl> &list) noexcept
     d->urlList = list;
 }
 
+void RenameBar::setVisible(bool visible)
+{
+    Q_D(RenameBar);
+    if (!d->connectInitOnce) {
+        auto widget = qobject_cast<WorkspaceWidget *>(parentWidget());
+        if (widget) {
+            auto view = dynamic_cast<FileView *>(widget->currentView());
+            if (view)
+            {
+                d->connectInitOnce = true;
+                QObject::connect(view, &FileView::selectUrlChanged, this, &RenameBar::onSelectUrlChanged);
+            }
+        }
+    }
+    return QFrame::setVisible(visible);
+}
+
 void RenameBar::onVisibleChanged(bool value) noexcept
 {
     Q_D(RenameBar);
@@ -269,6 +286,15 @@ void RenameBar::hideRenameBar()
     reset();
     if (parentWidget())
         parentWidget()->setFocus();
+}
+
+void RenameBar::onSelectUrlChanged(const QList<QUrl> &urls)
+{
+    if (!isVisible())
+        return;
+
+    if (urls.isEmpty())
+        emit clickCancelButton();
 }
 
 void RenameBar::initConnect()

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
@@ -13,6 +13,8 @@
 #include <QPushButton>
 #include <QLineEdit>
 #include <QStackedWidget>
+#include <QApplication>
+#include <QKeyEvent>
 
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_workspace;
@@ -265,6 +267,8 @@ void RenameBar::hideRenameBar()
 {
     setVisible(false);
     reset();
+    if (parentWidget())
+        parentWidget()->setFocus();
 }
 
 void RenameBar::initConnect()
@@ -301,4 +305,18 @@ QList<QUrl> RenameBar::getSelectFiles()
     }
 
     return {};
+}
+
+
+void dfmplugin_workspace::RenameBar::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+        if (qApp->focusObject() == d->renameBtn
+                && d->renameBtn->focusPolicy() == Qt::FocusPolicy::TabFocus)
+            emit clickRenameButton();
+        if (qApp->focusObject() == std::get<0>(d->buttonsArea)
+                && std::get<0>(d->buttonsArea)->focusPolicy() == Qt::FocusPolicy::TabFocus)
+            emit clickCancelButton();
+    }
+    return QFrame::keyPressEvent(event);
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.h
@@ -44,6 +44,10 @@ private slots:
     void eventDispatcher();
     void hideRenameBar();
 
+    // QWidget interface
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
+
 private:
     void initConnect();
     QList<QUrl> getSelectFiles();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.h
@@ -24,6 +24,9 @@ public:
 
     void storeUrlList(const QList<QUrl> &list) noexcept;
 
+public Q_SLOTS:
+    void setVisible(bool visible) override;
+
 signals:
     void requestReplaceOperator();
     void clickCancelButton();
@@ -43,6 +46,7 @@ private slots:
     void onCustomOperatorSNNumberChanged();
     void eventDispatcher();
     void hideRenameBar();
+    void onSelectUrlChanged(const QList<QUrl> &urls);
 
     // QWidget interface
 protected:


### PR DESCRIPTION
Add the enter key to renameBar for processing

Log: Batch renaming, "Renaming" option, shortcut key Enter not effective
Bug: https://pms.uniontech.com/bug-view-260431.html