### PR TITLE
chore: update to 6.0.53

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,13 @@
+dde-file-manager (6.0.53) unstable; urgency=medium
+
+  * 6.0.53,to support AM interface and video wallpaper
+  * 
+
+ -- lvwujun <lvwujun@uniontech.com>  Wed, 26 Jun 2024 9:57:50 +0800
+
 dde-file-manager (6.0.52) unstable; urgency=medium
 
-  * 6.0.52,to support am show-item
+  * 6.0.52,to support AM show-item
   * 
 
  -- lvwujun <lvwujun@uniontech.com>  Fri, 31 May 2024 15:26:50 +0800


### PR DESCRIPTION
mark as 6.0.53 to support am interface and video wallpaper

Log: update the baseline version
Bug: no