### PR TITLE
fix: Copying files from cloud desktop cannot be copied to the local machine

### DIFF
--- a/include/dfm-base/interfaces/abstractjobhandler.h
+++ b/include/dfm-base/interfaces/abstractjobhandler.h
@@ -34,7 +34,7 @@ public:
         kRevocation = 0x200,   // 拷贝时不处理文件名称
         kCopyRemote = 0x400,   // 深信服远程拷贝
         kRedo = 0x800,   // 重新执行（ctrl + Y）
-        kCountProgressCustomize = 0x800,   // 强制使用自己统计进度
+        kCountProgressCustomize = 0x1000,   // 强制使用自己统计进度
     };
     Q_ENUM(JobFlag)
     Q_DECLARE_FLAGS(JobFlags, JobFlag)
@@ -280,6 +280,7 @@ private:
 }   // namespace dfmbase
 
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::SupportActions)
+Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag)
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags)
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType)
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback);

--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -50,7 +50,7 @@ void onClipboardDataChanged()
         return;
     }
     if (mimeData->hasFormat(kRemoteCopyKey)) {
-        qCInfo(logDFMBase) << "clipboard use other !";
+        qCWarning(logDFMBase) << "clipboard use other !";
         clipboardAction = ClipBoard::kRemoteAction;
         remoteCurrentCount++;
         return;
@@ -61,6 +61,12 @@ void onClipboardDataChanged()
         clipboardAction = ClipBoard::kRemoteCopiedAction;
         return;
     }
+    // 没有文件拷贝
+    if (!mimeData->hasFormat(kGnomeCopyKey)) {
+        qCWarning(logDFMBase) << "no kGnomeCopyKey target in mimedata formats!";
+        clipboardAction = ClipBoard::kUnknownAction;
+        return;
+    }
     const QString &data = mimeData->data(kGnomeCopyKey);
     const static QRegExp regCut("cut\nfile://"), regCopy("copy\nfile://");
     if (data.contains(regCut)) {
@@ -68,7 +74,7 @@ void onClipboardDataChanged()
     } else if (data.contains(regCopy)) {
         clipboardAction = ClipBoard::kCopyAction;
     } else {
-        qCWarning(logDFMBase) << "wrang kGnomeCopyKey data = " << data;
+        qCWarning(logDFMBase) << "wrong kGnomeCopyKey data = " << data;
         clipboardAction = ClipBoard::kUnknownAction;
     }
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations.cpp
@@ -45,38 +45,38 @@ void FileOperations::initEventHandle()
     dpfSignalDispatcher->subscribe(GlobalEventType::kCopy,
                                    FileOperationsEventReceiver::instance(),
                                    static_cast<void (FileOperationsEventReceiver::*)(const quint64, const QList<QUrl>, const QUrl,
-                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(&FileOperationsEventReceiver::handleOperationCopy));
     dpfSignalDispatcher->subscribe(GlobalEventType::kCutFile,
                                    FileOperationsEventReceiver::instance(),
                                    static_cast<void (FileOperationsEventReceiver::*)(const quint64, const QList<QUrl>,
-                                                                                     const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                     const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(&FileOperationsEventReceiver::handleOperationCut));
     dpfSignalDispatcher->subscribe(GlobalEventType::kRestoreFromTrash,
                                    TrashFileEventReceiver::instance(),
                                    static_cast<void (TrashFileEventReceiver::*)(const quint64, const QList<QUrl>, const QUrl,
-                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(&TrashFileEventReceiver::handleOperationRestoreFromTrash));
     dpfSignalDispatcher->subscribe(GlobalEventType::kCopyFromTrash,
                                    TrashFileEventReceiver::instance(),
                                    static_cast<void (TrashFileEventReceiver::*)(const quint64, const QList<QUrl>&, const QUrl&,
-                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(&TrashFileEventReceiver::handleOperationCopyFromTrash));
     dpfSignalDispatcher->subscribe(GlobalEventType::kCopyFromTrash,
                                    TrashFileEventReceiver::instance(),
                                    static_cast<void (TrashFileEventReceiver::*)(const quint64, const QList<QUrl>&, const QUrl&,
-                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback, const QVariant,
                                                                                 AbstractJobHandler::OperatorCallback)>(&TrashFileEventReceiver::handleOperationCopyFromTrash));
     dpfSignalDispatcher->subscribe(GlobalEventType::kMoveToTrash,
                                    TrashFileEventReceiver::instance(),
                                    static_cast<void (TrashFileEventReceiver::*)(const quint64, const QList<QUrl>,
-                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(&TrashFileEventReceiver::handleOperationMoveToTrash));
     dpfSignalDispatcher->subscribe(GlobalEventType::kDeleteFiles,
                                    FileOperationsEventReceiver::instance(),
                                    static_cast<void (FileOperationsEventReceiver::*)(const quint64, const QList<QUrl>,
-                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(&FileOperationsEventReceiver::handleOperationDeletes));
     dpfSignalDispatcher->subscribe(GlobalEventType::kCleanTrash,
                                    TrashFileEventReceiver::instance(),
@@ -86,31 +86,31 @@ void FileOperations::initEventHandle()
     dpfSignalDispatcher->subscribe(GlobalEventType::kCopy,
                                    FileOperationsEventReceiver::instance(),
                                    static_cast<void (FileOperationsEventReceiver::*)(const quint64, const QList<QUrl>,
-                                                                                     const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                     const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback, const QVariant,
                                                                                      AbstractJobHandler::OperatorCallback)>(&FileOperationsEventReceiver::handleOperationCopy));
     dpfSignalDispatcher->subscribe(GlobalEventType::kCutFile,
                                    FileOperationsEventReceiver::instance(),
                                    static_cast<void (FileOperationsEventReceiver::*)(const quint64, const QList<QUrl>,
-                                                                                     const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                     const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback, const QVariant,
                                                                                      AbstractJobHandler::OperatorCallback)>(&FileOperationsEventReceiver::handleOperationCut));
     dpfSignalDispatcher->subscribe(GlobalEventType::kRestoreFromTrash,
                                    TrashFileEventReceiver::instance(),
                                    static_cast<void (TrashFileEventReceiver::*)(const quint64, const QList<QUrl>, const QUrl,
-                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback, const QVariant,
                                                                                 AbstractJobHandler::OperatorCallback)>(&TrashFileEventReceiver::handleOperationRestoreFromTrash));
     dpfSignalDispatcher->subscribe(GlobalEventType::kMoveToTrash,
                                    TrashFileEventReceiver::instance(),
                                    static_cast<void (TrashFileEventReceiver::*)(const quint64, const QList<QUrl>,
-                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback, const QVariant,
                                                                                 AbstractJobHandler::OperatorCallback)>(&TrashFileEventReceiver::handleOperationMoveToTrash));
     dpfSignalDispatcher->subscribe(GlobalEventType::kDeleteFiles,
                                    FileOperationsEventReceiver::instance(),
                                    static_cast<void (FileOperationsEventReceiver::*)(const quint64, const QList<QUrl>,
-                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback, const QVariant,
                                                                                      AbstractJobHandler::OperatorCallback)>(&FileOperationsEventReceiver::handleOperationDeletes));
     dpfSignalDispatcher->subscribe(GlobalEventType::kCleanTrash,
@@ -151,13 +151,13 @@ void FileOperations::initEventHandle()
                                    static_cast<bool (FileOperationsEventReceiver::*)(const quint64,
                                                                                      const QUrl,
                                                                                      const QUrl,
-                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags)>(&FileOperationsEventReceiver::handleOperationRenameFile));
+                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag)>(&FileOperationsEventReceiver::handleOperationRenameFile));
     dpfSignalDispatcher->subscribe(GlobalEventType::kRenameFile,
                                    FileOperationsEventReceiver::instance(),
                                    static_cast<void (FileOperationsEventReceiver::*)(const quint64,
                                                                                      const QUrl,
                                                                                      const QUrl,
-                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+                                                                                     const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                                      const QVariant,
                                                                                      AbstractJobHandler::OperatorCallback)>(&FileOperationsEventReceiver::handleOperationRenameFile));
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -41,12 +41,12 @@ public slots:
     void handleOperationCopy(const quint64 windowId,
                              const QList<QUrl> sources,
                              const QUrl target,
-                             const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                             const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                              DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle);
     void handleOperationCopy(const quint64 windowId,
                              const QList<QUrl> sources,
                              const QUrl target,
-                             const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                             const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                              DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle,
                              const QVariant custom,
                              DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
@@ -54,24 +54,24 @@ public slots:
     void handleOperationCut(const quint64 windowId,
                             const QList<QUrl> sources,
                             const QUrl target,
-                            const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                            const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                             DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle);
 
     void handleOperationCut(const quint64 windowId,
                             const QList<QUrl> sources,
                             const QUrl target,
-                            const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                            const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                             DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle,
                             const QVariant custom,
                             DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
 
     void handleOperationDeletes(const quint64 windowId,
                                 const QList<QUrl> sources,
-                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle);
     void handleOperationDeletes(const quint64 windowId,
                                 const QList<QUrl> sources,
-                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle,
                                 const QVariant custom,
                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
@@ -95,11 +95,11 @@ public slots:
     bool handleOperationRenameFile(const quint64 windowId,
                                    const QUrl oldUrl,
                                    const QUrl newUrl,
-                                   const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags);
+                                   const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags);
     void handleOperationRenameFile(const quint64 windowId,
                                    const QUrl oldUrl,
                                    const QUrl newUrl,
-                                   const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                   const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                    const QVariant custom,
                                    DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
 
@@ -197,13 +197,13 @@ public slots:
     void handleSaveRedoOpt(const QString &token, const qint64 fileSize);
     void handleOperationUndoDeletes(const quint64 windowId,
                                     const QList<QUrl> &sources,
-                                    const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                    const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                     DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback,
                                     const QVariantMap &op);
     void handleOperationUndoCut(const quint64 windowId,
                                 const QList<QUrl> &sources,
                                 const QUrl target,
-                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                 DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback,
                                 const QVariantMap &op);
 private:

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.cpp
@@ -212,7 +212,7 @@ TrashFileEventReceiver *TrashFileEventReceiver::instance()
     return &receiver;
 }
 
-void TrashFileEventReceiver::handleOperationMoveToTrash(const quint64 windowId, const QList<QUrl> sources, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+void TrashFileEventReceiver::handleOperationMoveToTrash(const quint64 windowId, const QList<QUrl> sources, const AbstractJobHandler::JobFlag flags,
                                                         DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback)
 {
     auto handle = doMoveToTrash(windowId, sources, flags, handleCallback);
@@ -220,7 +220,7 @@ void TrashFileEventReceiver::handleOperationMoveToTrash(const quint64 windowId, 
 }
 
 void TrashFileEventReceiver::handleOperationRestoreFromTrash(const quint64 windowId, const QList<QUrl> sources, const QUrl target,
-                                                             const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                                             const AbstractJobHandler::JobFlag flags,
                                                              DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback)
 {
     auto handle = doRestoreFromTrash(windowId, sources, target, flags, handleCallback);
@@ -235,7 +235,7 @@ void TrashFileEventReceiver::handleOperationCleanTrash(const quint64 windowId, c
 
 void TrashFileEventReceiver::handleOperationMoveToTrash(const quint64 windowId,
                                                         const QList<QUrl> sources,
-                                                        const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                                        const AbstractJobHandler::JobFlag flags,
                                                         DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback,
                                                         const QVariant custom,
                                                         DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback)
@@ -254,7 +254,7 @@ void TrashFileEventReceiver::handleOperationMoveToTrash(const quint64 windowId,
 
 void TrashFileEventReceiver::handleOperationRestoreFromTrash(const quint64 windowId,
                                                              const QList<QUrl> sources, const QUrl target,
-                                                             const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                                             const AbstractJobHandler::JobFlag flags,
                                                              DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback,
                                                              const QVariant custom,
                                                              DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback)
@@ -286,7 +286,7 @@ void TrashFileEventReceiver::handleOperationCleanTrash(const quint64 windowId, c
 }
 
 void TrashFileEventReceiver::handleOperationCopyFromTrash(const quint64 windowId, const QList<QUrl> &sources, const QUrl &target,
-                                                          const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                                          const AbstractJobHandler::JobFlag flags,
                                                           DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback)
 {
     auto handle = doCopyFromTrash(windowId, sources, target, flags, handleCallback);
@@ -295,7 +295,7 @@ void TrashFileEventReceiver::handleOperationCopyFromTrash(const quint64 windowId
 
 void TrashFileEventReceiver::handleOperationCopyFromTrash(const quint64 windowId,
                                                           const QList<QUrl> &sources, const QUrl &target,
-                                                          const AbstractJobHandler::JobFlags flags,
+                                                          const AbstractJobHandler::JobFlag flags,
                                                           AbstractJobHandler::OperatorHandleCallback handleCallback,
                                                           const QVariant custom,
                                                           AbstractJobHandler::OperatorCallback callback)
@@ -343,7 +343,7 @@ void TrashFileEventReceiver::handleSaveRedoOpt(const QString &token, const bool 
 
 void TrashFileEventReceiver::handleOperationUndoMoveToTrash(const quint64 windowId,
                                                             const QList<QUrl> &sources,
-                                                            const AbstractJobHandler::JobFlags flags,
+                                                            const AbstractJobHandler::JobFlag flags,
                                                             AbstractJobHandler::OperatorHandleCallback handleCallback,
                                                             const QVariantMap &op)
 {
@@ -363,7 +363,7 @@ void TrashFileEventReceiver::handleOperationUndoMoveToTrash(const quint64 window
     FileOperationsEventHandler::instance()->handleJobResult(AbstractJobHandler::JobType::kMoveToTrashType, handle);
 }
 
-void TrashFileEventReceiver::handleOperationUndoRestoreFromTrash(const quint64 windowId, const QList<QUrl> &sources, const QUrl &target, const AbstractJobHandler::JobFlags flags, AbstractJobHandler::OperatorHandleCallback handleCallback, const QVariantMap &op)
+void TrashFileEventReceiver::handleOperationUndoRestoreFromTrash(const quint64 windowId, const QList<QUrl> &sources, const QUrl &target, const AbstractJobHandler::JobFlag flags, AbstractJobHandler::OperatorHandleCallback handleCallback, const QVariantMap &op)
 {
     auto handle = doRestoreFromTrash(windowId, sources, target, flags, handleCallback, false);
     if (!handle)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/trashfileeventreceiver.h
@@ -36,22 +36,22 @@ Q_SIGNALS:
 public slots:
     void handleOperationMoveToTrash(const quint64 windowId,
                                     const QList<QUrl> sources,
-                                    const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                    const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                     DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle);
     void handleOperationMoveToTrash(const quint64 windowId,
                                     const QList<QUrl> sources,
-                                    const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                    const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                     DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle,
                                     const QVariant custom,
                                     DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
 
     void handleOperationRestoreFromTrash(const quint64 windowId,
                                          const QList<QUrl> sources, const QUrl target,
-                                         const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                         const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                          DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle);
     void handleOperationRestoreFromTrash(const quint64 windowId,
                                          const QList<QUrl> sources, const QUrl target,
-                                         const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                         const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                          DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle,
                                          const QVariant custom,
                                          DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
@@ -68,23 +68,23 @@ public slots:
 
     void handleOperationCopyFromTrash(const quint64 windowId,
                                       const QList<QUrl> &sources, const QUrl &target,
-                                      const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                      const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                       DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle);
     void handleOperationCopyFromTrash(const quint64 windowId,
                                       const QList<QUrl> &sources, const QUrl &target,
-                                      const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                      const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                       DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handle,
                                       const QVariant custom,
                                       DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callback);
     void handleSaveRedoOpt(const QString &token, const bool moreThanZero);
     void handleOperationUndoMoveToTrash(const quint64 windowId,
                                         const QList<QUrl> &sources,
-                                        const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                        const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                         DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback,
                                         const QVariantMap &op);
     void handleOperationUndoRestoreFromTrash(const quint64 windowId,
                                             const QList<QUrl> &sources, const QUrl &target,
-                                            const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,
+                                            const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag flags,
                                             DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback handleCallback,
                                             const QVariantMap &op);
 private slots:

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
@@ -173,7 +173,7 @@ bool ClipBoardMenuScene::triggered(QAction *action)
             fmInfo() << "Remote Assistance Copy: set Current Url to Clipboard";
             ClipBoard::setCurUrlToClipboardForRemote(d->currentDir);
         } else if (ClipBoard::kRemoteAction == action) {
-            dpfSignalDispatcher->publish(GlobalEventType::kCopy, d->windowId, selectedUrlsTemp, d->currentDir, AbstractJobHandler::JobFlag::kCopyRemote, nullptr, nullptr, QVariant(), nullptr);
+            dpfSignalDispatcher->publish(GlobalEventType::kCopy, d->windowId, selectedUrlsTemp, d->currentDir, AbstractJobHandler::JobFlag::kCopyRemote, nullptr);
         } else {
             fmWarning() << "clipboard action:" << action << "    urls:" << selectedUrlsTemp;
         }

--- a/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
@@ -205,7 +205,7 @@ void FileOperatorProxy::pasteFiles(const CanvasView *view, const QPoint pos)
 
     if (ClipBoard::kRemoteAction == action) {
         dpfSignalDispatcher->publish(GlobalEventType::kCopy, view->winId(), urls, view->model()->rootUrl(),
-                                     AbstractJobHandler::JobFlag::kCopyRemote, nullptr, nullptr, QVariant(), nullptr);
+                                     AbstractJobHandler::JobFlag::kCopyRemote, nullptr);
         return;
     }
 

--- a/src/plugins/desktop/ddplugin-organizer/utils/fileoperator.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/utils/fileoperator.cpp
@@ -158,7 +158,7 @@ void FileOperator::pasteFiles(const CollectionView *view, const QString &targetC
 
     if (ClipBoard::kRemoteAction == action) {
         dpfSignalDispatcher->publish(GlobalEventType::kCopy, view->winId(), urls, view->model()->rootUrl(),
-                                     AbstractJobHandler::JobFlag::kCopyRemote, nullptr, nullptr, QVariant(), nullptr);
+                                     AbstractJobHandler::JobFlag::kCopyRemote, nullptr);
         return;
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -234,8 +234,7 @@ void FileOperatorHelper::pasteFiles(const FileView *view)
                                      sourceUrls,
                                      view->rootUrl(),
                                      AbstractJobHandler::JobFlag::kCopyRemote,
-                                     nullptr, nullptr,
-                                     QVariant(), nullptr);
+                                     nullptr);
     } else {
         fmWarning() << "Unknown clipboard past action:" << action << " urls:" << sourceUrls;
     }

--- a/tests/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/ut_fileoperationseventreceiver.cpp
+++ b/tests/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/ut_fileoperationseventreceiver.cpp
@@ -407,7 +407,7 @@ TEST_F(UT_FileOperationsEventReceiver, testRevocation)
     EXPECT_TRUE(op->revocation(0, ret, handle));
 
     stub_ext::StubExt stub;
-    stub.set_lamda(static_cast<void (FileOperationsEventReceiver::*)(quint64, const QList<QUrl>, const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+    stub.set_lamda(static_cast<void (FileOperationsEventReceiver::*)(quint64, const QList<QUrl>, const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(
                        &FileOperationsEventReceiver::handleOperationCut), []{});
     ret.insert("targets", {});
@@ -416,19 +416,19 @@ TEST_F(UT_FileOperationsEventReceiver, testRevocation)
     ret.insert("targets", {QUrl()});
     EXPECT_TRUE(op->revocation(0, ret, handle));
 
-    stub.set_lamda(static_cast<void (FileOperationsEventReceiver::*)(quint64, const QList<QUrl>, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+    stub.set_lamda(static_cast<void (FileOperationsEventReceiver::*)(quint64, const QList<QUrl>, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(
                        &FileOperationsEventReceiver::handleOperationDeletes), []{});
     ret.insert("event", GlobalEventType::kDeleteFiles);
     EXPECT_TRUE(op->revocation(0, ret, handle));
 
-    stub.set_lamda(static_cast<void (TrashFileEventReceiver::*)(quint64, const QList<QUrl>, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+    stub.set_lamda(static_cast<void (TrashFileEventReceiver::*)(quint64, const QList<QUrl>, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(
                        &TrashFileEventReceiver::handleOperationMoveToTrash), []{});
     ret.insert("event", GlobalEventType::kMoveToTrash);
     EXPECT_TRUE(op->revocation(0, ret, handle));
 
-    stub.set_lamda(static_cast<void (TrashFileEventReceiver::*)(quint64, const QList<QUrl>,const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags,
+    stub.set_lamda(static_cast<void (TrashFileEventReceiver::*)(quint64, const QList<QUrl>,const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag,
                                                                      DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback)>(
                        &TrashFileEventReceiver::handleOperationRestoreFromTrash), []{});
     ret.insert("event", GlobalEventType::kRestoreFromTrash);
@@ -438,7 +438,7 @@ TEST_F(UT_FileOperationsEventReceiver, testRevocation)
     ret.insert("event", GlobalEventType::kRenameFile);
     EXPECT_TRUE(op->revocation(0, ret, handle));
 
-    stub.set_lamda(static_cast<bool (FileOperationsEventReceiver::*)(const quint64, const QUrl, const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags)>(
+    stub.set_lamda(static_cast<bool (FileOperationsEventReceiver::*)(const quint64, const QUrl, const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag)>(
                        &FileOperationsEventReceiver::handleOperationRenameFile), []{ return true; });
     ret.insert("targets", {QUrl()});
     EXPECT_TRUE(op->revocation(0, ret, handle));


### PR DESCRIPTION
When modifying a copy, check if remotecopy comes first, modify the three additional parameters when sending events, and modify Jobflags without using event passing parameters

Log: Copying files from cloud desktop cannot be copied to the local machine
Bug: https://pms.uniontech.com/bug-view-259847.html