### PR TITLE
fix: Error in Destructuring and Exiting Iteration Thread

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -46,7 +46,7 @@ public:
     bool initThreadOfFileData(const QString &key,
                               DFMGLOBAL_NAMESPACE::ItemRoles role, Qt::SortOrder order, bool isMixFileAndFolder);
     void startWork(const QString &key, const bool getCache = false);
-    int clearTraversalThread(const QString &key, const bool isRefresh = false);
+    int clearTraversalThread(const QString &key, const bool isRefresh);
 
     void reset();
 

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -173,12 +173,12 @@ TEST_F(UT_RootInfo, ClearTraversalThread)
     bool getCache = rootInfoObj->initThreadOfFileData(key, role, order, false);
 
     QString unexistKey("unexistThreadKey");
-    int threadCount = rootInfoObj->clearTraversalThread(unexistKey);
+    int threadCount = rootInfoObj->clearTraversalThread(unexistKey, false);
     EXPECT_EQ(threadCount, 1);
     EXPECT_EQ(rootInfoObj->discardedThread.count(), 0);
     EXPECT_FALSE(calledThreadQuit);
 
-    threadCount = rootInfoObj->clearTraversalThread(key);
+    threadCount = rootInfoObj->clearTraversalThread(key, false);
     EXPECT_EQ(threadCount, 0);
     EXPECT_EQ(rootInfoObj->discardedThread.count(), 1);
     EXPECT_TRUE(calledThreadQuit);


### PR DESCRIPTION
Modify that only cached iteration threads bind this exit signal

Log: Error in Destructuring and Exiting Iteration Thread
Bug: https://pms.uniontech.com/bug-view-259807.html https://pms.uniontech.com/bug-view-259807.html