### PR TITLE
fix: After editing the file, full-text search can find two files with the same path

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -142,6 +142,7 @@ int TraversalDirThreadManager::iteratorOneByOne(const QElapsedTimer &timere)
     timer->restart();
 
     QList<FileInfoPointer> childrenList;   // 当前遍历出来的所有文件
+    QList<QUrl> urls;
     while (dirIterator->hasNext()) {
         if (stopFlag)
             break;
@@ -150,6 +151,9 @@ int TraversalDirThreadManager::iteratorOneByOne(const QElapsedTimer &timere)
         const auto &fileUrl = dirIterator->next();
         if (!fileUrl.isValid())
             continue;
+        if (urls.contains(fileUrl))
+            continue;
+        urls.append(fileUrl);
         auto fileInfo = dirIterator->fileInfo();
         if (fileUrl.isValid() && !fileInfo)
             fileInfo = InfoFactory::create<FileInfo>(fileUrl);


### PR DESCRIPTION
Filter through the iterator once

Log: After editing the file, full-text search can find two files with the same path
Bug: https://pms.uniontech.com/bug-view-260593.html