### PR TITLE
fix: Fix file name too long and unable to download files properly

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -662,6 +662,16 @@ bool FileDialog::hideOnAccept() const
     return d->hideOnAccept;
 }
 
+QUrl FileDialog::getcurrenturl() const
+{
+    return d->currentUrl;
+}
+
+bool FileDialog::checkFileSuffix(const QString &filename, QString &suffix)
+{
+    return d->checkFileSuffix(filename, suffix);
+}
+
 void FileDialog::accept()
 {
     done(QDialog::Accepted);
@@ -913,6 +923,7 @@ void FileDialog::handleUrlChanged(const QUrl &url)
     emit initialized();
     dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetNameFilter", internalWinId(), curNameFilters);
     dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetAlwaysOpenInCurrentWindow", internalWinId());
+    d->currentUrl = url;
 }
 
 void FileDialog::onViewSelectionChanged(const quint64 windowID, const QItemSelection &selected, const QItemSelection &deselected)

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
@@ -87,6 +87,8 @@ public:
     void setHideOnAccept(bool enable);
     bool hideOnAccept() const;
 
+    QUrl getcurrenturl() const;
+    bool checkFileSuffix(const QString &filename, QString &suffix);
     FileDialogStatusBar *statusBar() const;
 
 Q_SIGNALS:

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog_p.h
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog_p.h
@@ -53,6 +53,7 @@ private:
     QString currentInputName;
     bool allowMixedSelection { false };
     QFileDialog::Options options;
+    QUrl currentUrl;
 };
 
 }

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.cpp
@@ -208,6 +208,12 @@ void FileDialogStatusBar::onWindowTitleChanged(const QString &title)
 void FileDialogStatusBar::onFileNameTextEdited(const QString &text)
 {
     QString dstText = DFMBASE_NAMESPACE::FileUtils::preprocessingFileName(text);
+    QString suffix { "" };
+    mainWindow->checkFileSuffix(dstText, suffix);
+    int maxLength = NAME_MAX - suffix.length() - 1;
+    while (DFMBASE_NAMESPACE::FileUtils::getFileNameLength(mainWindow->getcurrenturl(), dstText) > maxLength) {
+        dstText.chop(1);
+    }
     if (text != dstText) {
         int currPos = fileNameEdit->lineEdit()->cursorPosition();
         fileNameEdit->setText(dstText);


### PR DESCRIPTION
A file name that is too long will cause automatic deletion

Log: Limit the input length of the input box, automatically truncate the last digit if the length is too long

Bug: https://pms.uniontech.com/bug-view-259793.html