### PR TITLE
fix: Error in displaying file name after deleting the. hidden file that appears in the hidden file

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -184,9 +184,6 @@ void RootInfo::doFileDeleted(const QUrl &url)
 {
     enqueueEvent(QPair<QUrl, EventType>(url, kRmFile));
     metaObject()->invokeMethod(this, QT_STRINGIFY(doThreadWatcherEvent), Qt::QueuedConnection);
-
-    if (UniversalUtils::urlEquals(hiddenFileUrl, url))
-        Q_EMIT watcherUpdateHideFile(url);
 }
 
 void RootInfo::dofileMoved(const QUrl &fromUrl, const QUrl &toUrl)
@@ -199,13 +196,6 @@ void RootInfo::dofileMoved(const QUrl &fromUrl, const QUrl &toUrl)
         info->refresh();
 
     dofileCreated(toUrl);
-
-    // TODO(lanxs) TODO(xust) .hidden file's attribute changed signal not emitted in removable disks (vfat/exfat).
-    // but renamed from a .goutputstream_xxx file
-    // NOTE: GlobalEventType::kHideFiles event is watched in fileview, but this can be used to notify update view
-    // when the file is modified in other way.
-    if (UniversalUtils::urlEquals(hiddenFileUrl, toUrl))
-        Q_EMIT watcherUpdateHideFile(toUrl);
 }
 
 void RootInfo::dofileCreated(const QUrl &url)
@@ -535,6 +525,9 @@ void RootInfo::removeChildren(const QList<QUrl> &urlList)
 
     if (removeChildren.count() > 0)
         emit watcherRemoveFiles(removeChildren);
+
+    if (removeUrls.contains(hiddenFileUrl))
+        Q_EMIT watcherUpdateHideFile(hiddenFileUrl);
 }
 
 bool RootInfo::containsChild(const QUrl &url)


### PR DESCRIPTION
The signal sequence for sending hidden files is incorrect, resulting in deletion without sending the removefinish signal

Log: Error in displaying file name after deleting the. hidden file that appears in the hidden file
Bug: https://pms.uniontech.com/bug-view-260035.html