### PR TITLE
feat: [desktop] new organize mode

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.desktop.json
+++ b/assets/configs/org.deepin.dde.file-manager.desktop.json
@@ -12,7 +12,7 @@
 			"description": "It's used to control whether the auto align on desktop is enabled.",
 			"permissions": "readwrite",
 			"visibility": "public"
-		},
+                },
 		"maskLogoUri": {
 			"value": "",
 			"serial": 0,

--- a/assets/configs/org.deepin.dde.file-manager.desktop.organizer.json
+++ b/assets/configs/org.deepin.dde.file-manager.desktop.organizer.json
@@ -45,6 +45,17 @@
 			"description": "Prompt dialog for turning on/off hidden collections.",
 			"permissions": "readwrite",
 			"visibility": "public"
-		}
+                },
+                "organizeAction": {
+                        "value": 0,
+                        "serial": 0,
+                        "flags": [],
+                        "name": "Organize action",
+                        "name[zh_CN]": "整理动作",
+                        "description[zh_CN]": "单次整理（0）或自动整理（1），当选择单次整理时，整理行为仅在用户触发整理时发生，新建的文件不会被整理到集合中",
+                        "description": "Single-time organization (0) or automatic organization (1): When single-time organization is selected, the organization action only occurs when triggered by the user, and newly created files will not be organized into the collection.",
+                        "permissions": "readwrite",
+                        "visibility": "public"
+                }
 	}
 }

--- a/src/plugins/desktop/ddplugin-organizer/config/configpresenter.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/config/configpresenter.cpp
@@ -238,6 +238,17 @@ void ConfigPresenter::setEnabledTypeCategories(ItemCategories flags)
     conf->sync();
 }
 
+OrganizeAction ConfigPresenter::organizeAction() const
+{
+    int val = DConfigManager::instance()->value(kConfName, "organizeAction", 0).toInt();
+    return val == 0 ? kOnTrigger : kAlways;
+}
+
+bool ConfigPresenter::organizeOnTriggered() const
+{
+    return OrganizeAction() == kOnTrigger;
+}
+
 CollectionStyle ConfigPresenter::normalStyle(const QString &key) const
 {
     if (key.isEmpty())

--- a/src/plugins/desktop/ddplugin-organizer/config/configpresenter.h
+++ b/src/plugins/desktop/ddplugin-organizer/config/configpresenter.h
@@ -61,6 +61,10 @@ public:
 public:
     ItemCategories enabledTypeCategories() const;
     void setEnabledTypeCategories(ItemCategories flags);
+
+    OrganizeAction organizeAction() const;
+    bool organizeOnTriggered() const;
+
 signals:
     // use Qt::QueuedConnection
     void changeEnableState(bool e);
@@ -71,6 +75,8 @@ signals:
     void changeDisplaySize(int);
     void newCollection(const QList<QUrl> &);
     void showOptionWindow();
+    void reorganizeDesktop();
+
 public slots:
 protected:
     explicit ConfigPresenter(QObject *parent = nullptr);

--- a/src/plugins/desktop/ddplugin-organizer/menus/organizermenu_defines.h
+++ b/src/plugins/desktop/ddplugin-organizer/menus/organizermenu_defines.h
@@ -10,7 +10,8 @@
 namespace ddplugin_organizer {
 
 namespace ActionID {
-inline constexpr char kOrganizeDesktop[] = "organize-desktop";
+inline constexpr char kOrganizeEnable[] = "organize-enable";
+inline constexpr char kOrganizeTrigger[] = "organize-trigger";
 inline constexpr char kOrganizeOptions[] = "organize-options";
 inline constexpr char kOrganizeBy[] = "organize-by";
 inline constexpr char kOrganizeByType[] = "organize-by-type";
@@ -19,7 +20,7 @@ inline constexpr char kOrganizeByTimeModified[] = "organize-by-time-modified";
 inline constexpr char kOrganizeByTimeCreated[] = "organize-by-time-created";
 inline constexpr char kOrganizeByCustom[] = "custom-collection";
 inline constexpr char kCreateACollection[] = "create-a-collection";
-} // namespace ActionID
+}   // namespace ActionID
 
 namespace CollectionMenuParams {
 inline constexpr char kOnColletion[] = "OnColletion";
@@ -27,4 +28,4 @@ inline constexpr char kColletionView[] = "ColletionView";
 }
 }
 
-#endif // ORGANIZERMENU_DEFINES_H
+#endif   // ORGANIZERMENU_DEFINES_H

--- a/src/plugins/desktop/ddplugin-organizer/mode/collectiondataprovider.h
+++ b/src/plugins/desktop/ddplugin-organizer/mode/collectiondataprovider.h
@@ -30,7 +30,6 @@ public:
     virtual void addPreItems(const QString &targetKey, const QList<QUrl> &urls, int targetIndex);
     virtual bool checkPreItem(const QUrl &url, QString &key, int &index);
     virtual bool takePreItem(const QUrl &url, QString &key, int &index);
-protected:
     virtual QString replace(const QUrl &oldUrl, const QUrl &newUrl) = 0;
     virtual QString append(const QUrl &) = 0;
     virtual QString prepend(const QUrl &) = 0;
@@ -40,6 +39,7 @@ protected:
 signals:
     void nameChanged(const QString &key, const QString &name);
     void itemsChanged(const QString &key);
+
 protected:
     QHash<QString, CollectionBaseDataPtr> collections;
     QHash<QString, QPair<int, QList<QUrl>>> preCollectionItems;
@@ -47,4 +47,4 @@ protected:
 
 }
 
-#endif // COLLECTIONDATAPROVIDER_H
+#endif   // COLLECTIONDATAPROVIDER_H

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmode_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmode_p.h
@@ -40,7 +40,7 @@ public slots:
     void updateHolderSurfaceIndex(QWidget *surface);
 
 public:
-    void restore(const QList<CollectionBaseDataPtr> &cfgs);
+    void restore(const QList<CollectionBaseDataPtr> &cfgs, bool reorganized = false);
     FileClassifier *classifier = nullptr;
     QHash<QString, CollectionHolderPointer> holders;
     NormalizedModeBroker *broker = nullptr;

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp
@@ -37,17 +37,18 @@ inline const char kTypeSuffixApp[] = "desktop";
         *tablePtr = tablePtr->fromList(QString(suffix).split(','));    \
     }
 TypeClassifierPrivate::TypeClassifierPrivate(TypeClassifier *qq)
-    : q(qq) {
-          //todo(zy) 类型后缀支持可配置
-          InitSuffixTable(docSuffix, kTypeSuffixDoc)
-                  InitSuffixTable(picSuffix, kTypeSuffixPic)
-                          InitSuffixTable(muzSuffix, kTypeSuffixMuz)
-                                  InitSuffixTable(vidSuffix, kTypeSuffixVid)
-                                          InitSuffixTable(appSuffix, kTypeSuffixApp)
-          //InitSuffixTable(appMimeType, kTypeMimeApp)
-      }
+    : q(qq)
+{
+    //todo(zy) 类型后缀支持可配置
+    InitSuffixTable(docSuffix, kTypeSuffixDoc);
+    InitSuffixTable(picSuffix, kTypeSuffixPic);
+    InitSuffixTable(muzSuffix, kTypeSuffixMuz);
+    InitSuffixTable(vidSuffix, kTypeSuffixVid);
+    InitSuffixTable(appSuffix, kTypeSuffixApp);
+    //InitSuffixTable(appMimeType, kTypeMimeApp);
+}
 
-      TypeClassifierPrivate::~TypeClassifierPrivate()
+TypeClassifierPrivate::~TypeClassifierPrivate()
 {
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.h
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.h
@@ -27,13 +27,15 @@ public:
     void detachLayout() override;
 
 public slots:
-    void rebuild();
+    void rebuild(bool reorganize = false);
     void onFileRenamed(const QUrl &oldUrl, const QUrl &newUrl);
     void onFileInserted(const QModelIndex &parent, int first, int last);
     void onFileAboutToBeRemoved(const QModelIndex &parent, int first, int last);
     void onFileDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles);
+    void onReorganizeDesktop();
 
 protected slots:
+    bool filterDropData(int viewIndex, const QMimeData *mimeData, const QPoint &viewPoint) override;
     bool filterDataRested(QList<QUrl> *urls) override;
     bool filterDataInserted(const QUrl &url) override;
     bool filterDataRenamed(const QUrl &oldUrl, const QUrl &newUrl) override;

--- a/src/plugins/desktop/ddplugin-organizer/options/optionswindow.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/optionswindow.cpp
@@ -121,6 +121,17 @@ bool OptionsWindow::initialize()
     contentLayout->addWidget(d->sizeSlider);
     contentLayout->addSpacing(10);
 
+    // enable desktop organizer
+    d->enableOrganize = new SwitchWidget(tr("Enable desktop organizer"), this);
+    d->enableOrganize->setChecked(CfgPresenter->isEnable());
+    d->enableOrganize->setFixedHeight(48);
+    d->enableOrganize->setRoundEdge(SwitchWidget::kBoth);
+    contentLayout->addWidget(d->enableOrganize);
+    connect(d->enableOrganize, &SwitchWidget::checkedChanged, this, [](bool check) {
+        CfgPresenter->changeEnableState(check);
+    });
+    contentLayout->addSpacing(10);
+
     // organization
     d->organization = new OrganizationGroup(d->contentWidget);
     d->organization->reset();

--- a/src/plugins/desktop/ddplugin-organizer/options/optionswindow_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/options/optionswindow_p.h
@@ -27,6 +27,7 @@ public:
     void setAutoArrange(bool on);
     void enableChanged(bool enable);
     void autoArrangeChanged(bool on);
+
 public:
     QVBoxLayout *mainLayout = nullptr;
     DTK_WIDGET_NAMESPACE::DTitlebar *titlebar = nullptr;
@@ -34,11 +35,13 @@ public:
     QWidget *contentWidget = nullptr;
     QVBoxLayout *contentLayout = nullptr;
     SwitchWidget *autoArrange = nullptr;
+    SwitchWidget *enableOrganize = nullptr;
     OrganizationGroup *organization = nullptr;
     SizeSlider *sizeSlider = nullptr;
+
 private:
     OptionsWindow *q;
 };
 
 }
-#endif // OPTIONSWINDOW_P_H
+#endif   // OPTIONSWINDOW_P_H

--- a/src/plugins/desktop/ddplugin-organizer/organizer_defines.h
+++ b/src/plugins/desktop/ddplugin-organizer/organizer_defines.h
@@ -22,6 +22,11 @@ enum OrganizerMode {
     kCustom
 };
 
+enum OrganizeAction {
+    kOnTrigger,
+    kAlways
+};
+
 enum Classifier {
     kType = 0,
     kTimeCreated,

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
@@ -90,7 +90,7 @@ public:
     QModelIndex findIndex(const QString &key, bool matchStart, const QModelIndex &current, bool reverseOrder, bool excludeCurrent) const;
 
     void updateDFMMimeData(QDropEvent *event);
-    bool checkTargetEnable(const QUrl &targetUrl);
+    bool checkTargetEnable(QDropEvent *event, const QUrl &targetUrl);
 
 private:
     void updateRowCount(const int &viewHeight, const int &itemHeight);


### PR DESCRIPTION
1. add more dconfigs;
2. files are inserted into desktop not into collection on created;
3. new menu action: organize desktop, renamed action: Organize desktop -
> enable desktop organizition;
4. organize files on file renamed;
5. drag files from canvas to collections;
6. drag files from collections to canvas;

Log: as contents.

Task: https://pms.uniontech.com/task-view-354097.html