### PR TITLE
fix: Copy the file from FTP to the desktop and prompt that the file already exists on the desktop, but it does not actually exist on the desktop

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -141,7 +141,7 @@ bool DoCutFilesWorker::doCutFile(const DFileInfoPointer &fromInfo, const DFileIn
     bool ok = false;
     // 获取trashinfourl
     QUrl trashInfoUrl;
-    QString fileName = fromInfo->attribute(DFileInfo::AttributeID::kStandardCopyName).toString();
+    QString fileName = fromInfo->attribute(DFileInfo::AttributeID::kStandardFileName).toString();
     bool isTrashFile = FileUtils::isTrashFile(fromInfo->uri());
     if (isTrashFile) {
         trashInfoUrl= trashInfo(fromInfo);
@@ -225,7 +225,7 @@ bool DoCutFilesWorker::checkSymLink(const DFileInfoPointer &fileInfo)
     const QUrl &sourceUrl = fileInfo->uri();
     bool skip = false;
     DFileInfoPointer newTargetInfo = doCheckFile(fileInfo, targetInfo,
-                                                 fileInfo->attribute(DFileInfo::AttributeID::kStandardCopyName).toString(), &skip);
+                                                 fileInfo->attribute(DFileInfo::AttributeID::kStandardFileName).toString(), &skip);
     if (newTargetInfo.isNull())
         return skip;
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -304,7 +304,7 @@ bool FileOperateBaseWorker::copyFileFromTrash(const QUrl &urlSource, const QUrl 
                 }
             }
             DFileInfoPointer newTargetInfo = doCheckFile(fileinfoNext, toInfo,
-                                                         fileinfoNext->attribute(DFileInfo::AttributeID::kStandardCopyName).toString(),
+                                                         fileinfoNext->attribute(DFileInfo::AttributeID::kStandardFileName).toString(),
                                                          &ok);
             if (newTargetInfo.isNull())
                 continue;
@@ -1164,7 +1164,7 @@ bool FileOperateBaseWorker::doCopyFile(const DFileInfoPointer &fromInfo, const D
 {
     bool result = false;
     DFileInfoPointer newTargetInfo = doCheckFile(fromInfo, toInfo,
-                                                 fromInfo->attribute(DFileInfo::AttributeID::kStandardCopyName).toString(), skip);
+                                                 fromInfo->attribute(DFileInfo::AttributeID::kStandardFileName).toString(), skip);
     if (newTargetInfo.isNull())
         return result;
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/docopyfromtrashfilesworker.cpp
@@ -101,7 +101,7 @@ bool DoCopyFromTrashFilesWorker::doOperate()
         emitCurrentTaskNotify(url, targetFileUrl);
 
         bool ok = false;
-        DFileInfoPointer newTargetInfo = doCheckFile(fileInfo, targetInfo, fileInfo->attribute(DFileInfo::AttributeID::kStandardCopyName).toString(), &ok);
+        DFileInfoPointer newTargetInfo = doCheckFile(fileInfo, targetInfo, fileInfo->attribute(DFileInfo::AttributeID::kStandardFileName).toString(), &ok);
 
         if (newTargetInfo.isNull())
             continue;

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -183,7 +183,7 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
         bool ok = false;
         DFileInfoPointer newTargetInfo = doCheckFile(fileInfo,
                                                      targetInfo,
-                                                     fileInfo->attribute(DFileInfo::AttributeID::kStandardCopyName).toString(), &ok);
+                                                     fileInfo->attribute(DFileInfo::AttributeID::kStandardFileName).toString(), &ok);
         if (newTargetInfo.isNull()) {
             handleSourceFiles.append(fileUrl);
             continue;
@@ -271,7 +271,7 @@ DFileInfoPointer DoRestoreTrashFilesWorker::checkRestoreInfo(const QUrl &url)
             }
         } else {
             restoreFileUrl = DFMIO::DFMUtils::buildFilePath(this->targetUrl.toString().toStdString().c_str(),
-                                                            fileInfo->attribute(DFileInfo::AttributeID::kStandardCopyName).toString()
+                                                            fileInfo->attribute(DFileInfo::AttributeID::kStandardFileName).toString()
                                                             .toStdString().c_str(), nullptr);
         }
 


### PR DESCRIPTION
Using the kstandardcopyname attribute of dfileinfo to obtain a null value resulted in using the kstandardfilename attribute of dfileinfo

Log: Copy the file from FTP to the desktop and prompt that the file already exists on the desktop, but it does not actually exist on the desktop
Bug: https://pms.uniontech.com/bug-view-262105.html