### PR TITLE
fix: After mounting the SMB folder, shutting down the network and clicking on the "Trash" directory will cause the file manager to freeze

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-core/utils/corehelper.cpp
@@ -6,6 +6,7 @@
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/fileutils.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -37,6 +38,11 @@ void CoreHelper::cd(quint64 windowId, const QUrl &url)
 
     fmInfo() << "cd to " << url;
     window->cd(url);
+
+    if (UniversalUtils::urlEquals(url, FileUtils::trashRootUrl())) {
+        window->setWindowTitle(QCoreApplication::translate("PathManager", "Trash"));
+        return;
+    }
 
     QUrl titleUrl { url };
     QList<QUrl> urls {};

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
@@ -8,6 +8,8 @@
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/fileutils.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -83,8 +85,13 @@ QList<CrumbData> CrumbInterface::seprateUrl(const QUrl &url)
         QStringList pathList { curUrl.path().split("/") };
         QString displayText = pathList.isEmpty() ? "" : pathList.last();
         if (curUrl.scheme() == Global::Scheme::kTrash) {
-            auto info = InfoFactory::create<FileInfo>(curUrl);
-            displayText = info ? info->displayOf(DisPlayInfoType::kFileDisplayName) : displayText;
+            if (UniversalUtils::urlEquals(curUrl, FileUtils::trashRootUrl())) {
+                displayText = QCoreApplication::translate("PathManager", "Trash");
+            } else {
+                auto info = InfoFactory::create<FileInfo>(curUrl);
+                displayText = info ? info->displayOf(DisPlayInfoType::kFileDisplayName) : displayText;
+            }
+
         }
         CrumbData data { curUrl, displayText};
         if (UrlRoute::isRootUrl(curUrl))

--- a/src/plugins/filemanager/core/dfmplugin-trash/private/trashdiriterator_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/private/trashdiriterator_p.h
@@ -32,6 +32,7 @@ private:
     QUrl currentUrl;
     QMap<QString, QString> fstabMap;
     FileInfoPointer fileInfo{nullptr};
+    std::atomic_bool once{ false };
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-trash/trashdiriterator.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trashdiriterator.cpp
@@ -58,6 +58,10 @@ bool TrashDirIterator::hasNext() const
         return has;
 
     if (d->dEnumerator) {
+        if (!d->once)
+            TrashHelper::instance()->onTrashNotEmptyState();
+
+        d->once = true;
         const QUrl &urlNext = d->dEnumerator->next();
         d->fileInfo = InfoFactory::create<FileInfo>(urlNext);
         if (d->fileInfo) {

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.cpp
@@ -104,12 +104,7 @@ bool TrashHelper::showTopWidget(QWidget *w, const QUrl &url)
 {
     Q_UNUSED(w)
 
-    auto rootUrl = TrashHelper::rootUrl();
-    if (UniversalUtils::urlEquals(url, rootUrl) && !FileUtils::trashIsEmpty()) {
-        return true;
-    } else {
-        return false;
-    }
+    return false;
 }
 
 QUrl TrashHelper::transToTrashFile(const QString &filePath)
@@ -313,6 +308,20 @@ void TrashHelper::onTrashEmptyState() {
     isTrashEmpty = FileUtils::trashIsEmpty();
     if (!isTrashEmpty)
         return;
+    const QList<quint64> &windowIds = FMWindowsIns.windowIdList();
+    for (const quint64 winId : windowIds) {
+        auto window = FMWindowsIns.findWindowById(winId);
+        if (window) {
+            const QUrl &url = window->currentUrl();
+            if (url.scheme() == scheme())
+                TrashEventCaller::sendShowEmptyTrash(winId, !isTrashEmpty);
+        }
+    }
+}
+
+void TrashHelper::onTrashNotEmptyState()
+{
+    isTrashEmpty = false;
     const QList<quint64> &windowIds = FMWindowsIns.windowIdList();
     for (const quint64 winId : windowIds) {
         auto window = FMWindowsIns.findWindowById(winId);

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.h
@@ -69,6 +69,7 @@ public:
     bool customColumnRole(const QUrl &rootUrl, QList<DFMGLOBAL_NAMESPACE::ItemRoles> *roleList);
     bool customRoleDisplayName(const QUrl &url, const DFMGLOBAL_NAMESPACE::ItemRoles role, QString *displayName);
     void onTrashEmptyState();
+    void onTrashNotEmptyState();
 
 private:
     void onTrashStateChanged();


### PR DESCRIPTION
When the network is disconnected, the main thread creates trash:///, which will query the root nodes of all trashes, causing a lag. The monitor that starts trash:/// lags

Log: After mounting the SMB folder, shutting down the network and clicking on the "Trash" directory will cause the file manager to freeze
Bug: https://pms.uniontech.com/bug-view-260029.html