### PR TITLE
fix: After cutting and pasting the SMB remote connection file, Ctrl+Zundo will cause display errors

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -246,7 +246,7 @@ void RootInfo::doWatcherEvent()
             if (emptyLoopCount >= 5)
                 break;
 
-            QThread::msleep(10);
+            QThread::msleep(20);
             if (adds.isEmpty() && updates.isEmpty() && removes.isEmpty())
                 oldtime = timer.elapsed();
 
@@ -303,6 +303,7 @@ void RootInfo::doWatcherEvent()
             removes.append(fileUrl);
         }
     }
+    processFileEventRuning = false;
 
     // 处理添加文件
     if (!removes.isEmpty())
@@ -311,7 +312,6 @@ void RootInfo::doWatcherEvent()
         addChildren(adds);
     if (!updates.isEmpty())
         updateChildren(updates);
-    processFileEventRuning = false;
 }
 
 void RootInfo::doThreadWatcherEvent()


### PR DESCRIPTION
Timing issue, thread processFileEventRunning flag set too late for processing file information

Log: After cutting and pasting the SMB remote connection file, Ctrl+Z undo will cause display errors
Bug: https://pms.uniontech.com/bug-view-258017.html https://pms.uniontech.com/bug-view-259321.html