### PR TITLE
fix: [select-dialog] Double-click to unable to open the file

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/dbus/filedialogmanagerdbus.h
+++ b/src/plugins/filedialog/filedialogplugin-core/dbus/filedialogmanagerdbus.h
@@ -36,6 +36,7 @@ public slots:
 private:
     void onDialogDestroy();
     void onAppExit();
+    void initEventsFilter();
 
     QMap<QDBusObjectPath, QObject *> curDialogObjectMap;
     bool lastWindowClosed { false };

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -218,7 +218,6 @@ FileDialog::FileDialog(const QUrl &url, QWidget *parent)
     initializeUi();
     initConnect();
     initEventsConnect();
-    initEventsFilter();
 }
 
 FileDialog::~FileDialog()
@@ -1081,32 +1080,6 @@ void FileDialog::initEventsConnect()
 {
     dpfSignalDispatcher->subscribe("dfmplugin_workspace", "signal_View_RenameStartEdit", this, &FileDialog::handleRenameStartAcceptBtn);
     dpfSignalDispatcher->subscribe("dfmplugin_workspace", "signal_View_RenameEndEdit", this, &FileDialog::handleRenameEndAcceptBtn);
-}
-
-void FileDialog::initEventsFilter()
-{
-    dpfSignalDispatcher->installGlobalEventFilter(this, [this](DPF_NAMESPACE::EventType type, const QVariantList &params) -> bool {
-        if (type == GlobalEventType::kOpenFiles) {
-            onAcceptButtonClicked();
-            return true;
-        }
-
-        if (type == GlobalEventType::kOpenNewWindow && params.size() > 0) {
-            d->handleOpenNewWindow(params.at(0).toUrl());
-            return true;
-        }
-
-        static QList<DPF_NAMESPACE::EventType> filterTypeGroup { GlobalEventType::kOpenNewTab,
-                                                                 GlobalEventType::kOpenAsAdmin,
-                                                                 GlobalEventType::kOpenFilesByApp,
-                                                                 GlobalEventType::kCreateSymlink,
-                                                                 GlobalEventType::kOpenInTerminal,
-                                                                 GlobalEventType::kHideFiles };
-        if (filterTypeGroup.contains(type))
-            return true;
-
-        return false;
-    });
 }
 
 /*!

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.h
@@ -105,9 +105,9 @@ public Q_SLOTS:
     int exec();
     void open();
     void reject();
+    void onAcceptButtonClicked();
 
 private Q_SLOTS:
-    void onAcceptButtonClicked();
     void onRejectButtonClicked();
     void onCurrentInputNameChanged();
     void updateAcceptButtonState();
@@ -127,7 +127,6 @@ private:
     void initializeUi();
     void initConnect();
     void initEventsConnect();
-    void initEventsFilter();
     void updateViewState();
     void adjustPosition(QWidget *w);
     QString modelCurrentNameFilter() const;


### PR DESCRIPTION
When there are two choice boxes, double-click the file cannot be opened.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-261287.html