### PR TITLE
fix: dde-file-manager crash

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/files/recentiterateworker.cpp
@@ -48,6 +48,9 @@ void RecentIterateWorker::onRecentFileChanged(const QList<QUrl> &cachedUrls)
         if (location.isEmpty())
             continue;
 
+        if (stopped)
+            return;
+
         const QUrl &url { QUrl(location) };
         if (DeviceUtils::isLowSpeedDevice(url))
             continue;

--- a/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.cpp
@@ -176,11 +176,6 @@ RecentManager::RecentManager(QObject *parent)
 
 RecentManager::~RecentManager()
 {
-    if (watcher)
-        watcher->stopWatcher();
-    iteratorWorker->stop();
-    workerThread.quit();
-    workerThread.wait(15000);
 }
 
 void RecentManager::init()
@@ -194,6 +189,17 @@ void RecentManager::init()
             &RecentManager::onUpdateRecentFileInfo);
     connect(iteratorWorker, &RecentIterateWorker::deleteExistRecentUrls, this,
             &RecentManager::onDeleteExistRecentUrls);
+    connect(qApp, &QApplication::aboutToQuit, this, [this](){
+        if (watcher) {
+            watcher->stopWatcher();
+            watcher->disconnect(this);
+        }
+        iteratorWorker->stop();
+        if (workerThread.isRunning()) {
+            workerThread.quit();
+            workerThread.wait();
+        }
+    });
 
     workerThread.start();
 


### PR DESCRIPTION
Recent deconstruction, The RecentIterateWorker thread is still processing issues

Log: dde-file-manager crash
Bug: https://pms.uniontech.com/bug-view-257663.html