### PR TITLE
fix: Unable to drag and move files to desktop trash icon

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
@@ -478,7 +478,8 @@ Qt::ItemFlags FileInfoModel::flags(const QModelIndex &index) const
         if (file->canAttributes(CanableInfoType::kCanRename))
             flags |= Qt::ItemIsEditable;
 
-        if (file->isAttributes(OptInfoType::kIsWritable))
+        // use can drop attribute,if error modify the fileinfo candrop attribute
+        if (file->canAttributes(CanableInfoType::kCanDrop))
             flags |= Qt::ItemIsDropEnabled;
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -419,9 +419,10 @@ Qt::ItemFlags FileViewModel::flags(const QModelIndex &index) const
     if (index.data(kItemFileCanRenameRole).toBool())
         flags |= Qt::ItemIsEditable;
 
-    if (index.data(kItemFileIsWritableRole).toBool())
+    if (index.data(kItemFileCanDropRole).toBool())
         flags |= Qt::ItemIsDropEnabled;
 
+    // use can drop attribute,if error modify the fileinfo candrop attribute
     if (index.data(kItemFileCanDragRole).toBool())
         flags |= Qt::ItemIsDragEnabled;
 


### PR DESCRIPTION
Use the candrop attribute to retrieve and judge the flags when modifying the drop

Log: Unable to drag and move files to desktop trash icon
Bug: https://pms.uniontech.com/bug-view-257727.html