### PR TITLE
chore: fix build failed

### DIFF
--- a/src/plugins/common/dfmplugin-preview/pluginpreviews/music-preview/musicmessageview.cpp
+++ b/src/plugins/common/dfmplugin-preview/pluginpreviews/music-preview/musicmessageview.cpp
@@ -255,9 +255,9 @@ void MusicMessageView::characterEncodingTransform(MediaMeta &meta, void *obj)
 {
     TagLib::Tag *tag = static_cast<TagLib::Tag *>(obj);
     bool encode = true;
-    encode &= tag->title().isNull() ? true : tag->title().isLatin1();
-    encode &= tag->artist().isNull() ? true : tag->artist().isLatin1();
-    encode &= tag->album().isNull() ? true : tag->album().isLatin1();
+    encode &= tag->title().isEmpty() ? true : tag->title().isLatin1();
+    encode &= tag->artist().isEmpty() ? true : tag->artist().isLatin1();
+    encode &= tag->album().isEmpty() ? true : tag->album().isLatin1();
 
     QByteArray detectByte;
     QByteArray detectCodec;


### PR DESCRIPTION
The `String::isNull` of taglib is deprecated

Log: as title