### PR TITLE
拔掉屏幕时的集合按需重新布局

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmode_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/normalizedmode_p.h
@@ -31,6 +31,8 @@ public:
     void checkPastedFiles(const QList<QUrl> &urls);
     void connectCollectionSignals(CollectionHolderPointer collection);
 
+    bool tryPlaceRect(QRect &item, const QList<QRect> &inSeats, const QSize &table);
+
 public slots:
     void onSelectFile(QList<QUrl> &urls, int flag);
     void onClearSelection();


### PR DESCRIPTION
some collections might be overlapped

Log: fix layout issue.

Bug: https://pms.uniontech.com/bug-view-261891.html
