### PR TITLE
fix: The maximize button does not display properly

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -152,6 +152,7 @@ void FileManagerWindowPrivate::loadWindowState()
     if ((FMWindowsIns.windowIdList().isEmpty()) && ((windowState & kNetWmStateMaximizedHorz) != 0 && (windowState & kNetWmStateMaximizedVert) != 0)) {
         // make window to be maximized.
         // the following calling is copyed from QWidget::showMaximized()
+        q->titlebar()->setVisible(true);
         q->setWindowState((q->windowState() & ~(Qt::WindowMinimized | Qt::WindowFullScreen))
                           | Qt::WindowMaximized);
     } else {


### PR DESCRIPTION
Maximizing the document management, then closing and reopening cannot display the maximize button properly

Log: as title

Bug: https://pms.uniontech.com/bug-view-262201.html