### PR TITLE
fix: Refreshing remote directory after network outage caused document management to freeze

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -810,7 +810,7 @@ void TaskWidget::leaveEvent(QEvent *event)
 {
     onMouseHover(false);
 
-    return QWidget::enterEvent(event);
+    return QWidget::leaveEvent(event);
 }
 
 void TaskWidget::paintEvent(QPaintEvent *event)

--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1086,9 +1086,9 @@ bool LocalFileHandlerPrivate::doOpenFiles(const QList<QUrl> &urls, const QString
 
     bool openResult = doOpenFiles(openInfos, openMineTypes);
 
-    bool openMount = doOpenFiles(mountOpenInfos, openMineTypes);
+    bool openMount = doOpenFiles(mountOpenInfos, mountMineTypes);
 
-    bool openCmd = doOpenFiles(cmdOpenInfos, cmdOpenInfos);
+    bool openCmd = doOpenFiles(cmdOpenInfos, cmdMineTypes);
 
     if (openResult || openMount || openCmd)
         return true;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -44,7 +44,7 @@ RootInfo::~RootInfo()
     for (const auto &thread : discardedThread) {
         thread->disconnect();
         thread->stop();
-        thread->wait();
+        thread->exit();
     }
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -263,6 +263,10 @@ QList<QUrl> FileView::selectedUrlList() const
 
 void FileView::refresh()
 {
+    if (NetworkUtils::instance()->checkFtpOrSmbBusy(rootUrl())) {
+        DialogManager::instance()->showUnableToVistDir(rootUrl().path());
+        return;
+    }
     model()->refresh();
 }
 


### PR DESCRIPTION
Check if remote access is available once during refresh

Log: Refreshing remote directory after network outage caused document management to freeze
Bug: https://pms.uniontech.com/bug-view-262929.html