### PR TITLE
fix: The top bar of the trash has become a separate window

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-trash/trashdiriterator.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trashdiriterator.cpp
@@ -59,7 +59,7 @@ bool TrashDirIterator::hasNext() const
 
     if (d->dEnumerator) {
         if (!d->once)
-            TrashHelper::instance()->onTrashNotEmptyState();
+            TrashHelper::instance()->trashNotEmpty();
 
         d->once = true;
         const QUrl &urlNext = d->dEnumerator->next();

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.cpp
@@ -319,6 +319,11 @@ void TrashHelper::onTrashEmptyState() {
     }
 }
 
+void TrashHelper::trashNotEmpty()
+{
+    emit trashNotEmptyState();
+}
+
 void TrashHelper::onTrashNotEmptyState()
 {
     isTrashEmpty = false;
@@ -345,4 +350,5 @@ void TrashHelper::initEvent()
     bool resutl = dpfSignalDispatcher->subscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged", this, &TrashHelper::onTrashStateChanged);
     if (!resutl)
         fmWarning() << "subscribe signal_TrashCore_TrashStateChanged from dfmplugin_trashcore is failed.";
+    connect(this, &TrashHelper::trashNotEmptyState, this, &TrashHelper::onTrashNotEmptyState, Qt::QueuedConnection);
 }

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashhelper.h
@@ -69,7 +69,13 @@ public:
     bool customColumnRole(const QUrl &rootUrl, QList<DFMGLOBAL_NAMESPACE::ItemRoles> *roleList);
     bool customRoleDisplayName(const QUrl &url, const DFMGLOBAL_NAMESPACE::ItemRoles role, QString *displayName);
     void onTrashEmptyState();
+    void trashNotEmpty();
+
+private Q_SLOTS:
     void onTrashNotEmptyState();
+
+Q_SIGNALS:
+    void trashNotEmptyState();
 
 private:
     void onTrashStateChanged();


### PR DESCRIPTION
Trash is not an empty event sent in a child thread, causing show to execute in the child thread

Log: The top bar of the trash has become a separate window
Bug: https://pms.uniontech.com/bug-view-263093.html