### PR TITLE
fix: Accessing Windows shared files through SMB command in dde-file-manager may result in mounting failure

### DIFF
--- a/src/dfm-base/utils/networkutils.h
+++ b/src/dfm-base/utils/networkutils.h
@@ -28,6 +28,8 @@ public:
     bool parseIp(const QString &mpt, QString &ip, QString &port);
     bool parseIp(const QString &mpt, QString &ip, QStringList &ports);
     bool checkFtpOrSmbBusy(const QUrl &url);
+    // if network mount，get network mount
+    static QMap<QString, QString> cifsMountHostInfo();
 
 protected:
     explicit NetworkUtils(QObject *parent = nullptr);

--- a/src/dfm-base/utils/networkutils.h
+++ b/src/dfm-base/utils/networkutils.h
@@ -22,9 +22,11 @@ public:
     static NetworkUtils *instance();
 
     bool checkNetConnection(const QString &host, const QString &port, int msecs = 3000);
+    bool checkNetConnection(const QString &host, QStringList ports, int msecs = 3000);
     void doAfterCheckNet(const QString &host, const QStringList &ports,
                          std::function<void(bool)> callback = nullptr, int msecs = 3000);
     bool parseIp(const QString &mpt, QString &ip, QString &port);
+    bool parseIp(const QString &mpt, QString &ip, QStringList &ports);
     bool checkFtpOrSmbBusy(const QUrl &url);
 
 protected:

--- a/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/commonmounthelper.cpp
+++ b/src/plugins/daemon/daemonplugin-mountcontrol/mounthelpers/commonmounthelper.cpp
@@ -50,7 +50,7 @@ QVariantMap CommonMountHelper::unmount(const QString &path, const QVariantMap &o
             continue;
 
         const QString &descPath = mnt_fs_get_target(fs);
-        const QString &stdPath = descPath.startsWith("/") ? descPath : descPath + "/";
+        const QString &stdPath = descPath.endsWith("/") ? descPath : descPath + "/";
         if (stdPath.startsWith(path))
             unmountTargets << descPath;
     }

--- a/tests/dfm-base/base/device/private/ut_devicehelper.cpp
+++ b/tests/dfm-base/base/device/private/ut_devicehelper.cpp
@@ -289,7 +289,9 @@ TEST_F(UT_DeviceHelper, CheckNetworkConnection)
     EXPECT_TRUE(DeviceHelper::checkNetworkConnection(""));
 
     bool checkNetworkConnection_invoked = false;
-    stub.set_lamda(&NetworkUtils::checkNetConnection, [&] { __DBG_STUB_INVOKE__ checkNetworkConnection_invoked = true; return true; });
+    typedef bool (NetworkUtils::*CheckFunc)(const QString &, const QString &, int );
+        auto check = static_cast<CheckFunc>(&NetworkUtils::checkNetConnection);
+        stub.set_lamda(check, [&]() { __DBG_STUB_INVOKE__ checkNetworkConnection_invoked = true; return true; });
     EXPECT_TRUE(DeviceHelper::checkNetworkConnection("smb://1.2.3.4/hello"));
     EXPECT_TRUE(DeviceHelper::checkNetworkConnection("ftp://1.2.3.4"));
     EXPECT_TRUE(DeviceHelper::checkNetworkConnection("sftp://1.2.3.4"));


### PR DESCRIPTION
Add ping for port 139

Log: Accessing Windows shared files through SMB command in dde-file-manager may result in mounting failure
Bug: https://pms.uniontech.com/bug-view-262127.html