### PR TITLE
fix: In the file manager, name the file with "." and the file manager will crash

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/baseitemdelegate_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/baseitemdelegate_p.h
@@ -12,6 +12,7 @@
 #include <QModelIndex>
 #include <QSize>
 #include <QtGlobal>
+#include <QMutex>
 
 QT_BEGIN_NAMESPACE
 class QLineEdit;
@@ -36,6 +37,8 @@ public:
     mutable QLineEdit *editor = nullptr;
 
     AbstractItemPaintProxy *paintProxy { nullptr };
+    QMutex commitDataMutex;
+    QWidget *commitDataCurentWidget { nullptr };
 
     BaseItemDelegate *q_ptr;
     Q_DECLARE_PUBLIC(BaseItemDelegate)


### PR DESCRIPTION
Calling this slot function _q_commitDataAndCloseEditor will submit the edited content and perform the destruction of the editorwidget. If executed simultaneously, the first execution is completed before executing the deconstruction, and the second execution will crash. When it is executing, it is no longer processed.

Log: In the file manager, name the file with "." and the file manager will crash
Bug: https://pms.uniontech.com/bug-view-263687.html