### PR TITLE
fix: Setting "Open folder window in separate process" to check/uncheck is opposite to the actual situation

### DIFF
--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -255,9 +255,9 @@ void CommandParser::openInHomeDirectory()
 {
     QString homePath = StandardPaths::location(StandardPaths::StandardLocation::kHomePath);
     QUrl url = QUrl::fromUserInput(homePath);
-    auto flag = !DConfigManager::instance()->
+    auto flag = DConfigManager::instance()->
             value(kViewDConfName,
-                  kOpenFolderWindowsInASeparateProcess, false).toBool();
+                  kOpenFolderWindowsInASeparateProcess, true).toBool();
     dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, url, flag);
 }
 
@@ -298,9 +298,9 @@ void CommandParser::openInUrls()
         argumentUrls.append(url);
     }
     if (argumentUrls.isEmpty()) {
-        auto flag = !DConfigManager::instance()->
+        auto flag = DConfigManager::instance()->
                 value(kViewDConfName,
-                      kOpenFolderWindowsInASeparateProcess, false).toBool();
+                      kOpenFolderWindowsInASeparateProcess, true).toBool();
         dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, QUrl(), flag);
     }
     for (const QUrl &url : argumentUrls)
@@ -321,9 +321,9 @@ void CommandParser::openWindowWithUrl(const QUrl &url)
             dpfSignalDispatcher->publish(GlobalEventType::kLoadPlugins, QStringList() << name);
         });
     }
-    auto flag = DConfigManager::instance()->
+    auto flag = !DConfigManager::instance()->
             value(kViewDConfName,
-                  kOpenFolderWindowsInASeparateProcess, false).toBool();
+                  kOpenFolderWindowsInASeparateProcess, true).toBool();
     flag = flag ? false : isSet("n") || isSet("s") || isSet("sessionfile");
     dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, url, flag);
 }

--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -325,13 +325,13 @@ void SettingBackend::initWorkspaceSettingConfig()
                      { "trigger", QVariant(Application::kRestoreViewMode) } });
     ins->addCheckBoxConfig(LV2_GROUP_VIEW ".03_open_folder_windows_in_aseparate_process",
                            tr("Open folder windows in a separate process"),
-                           false);
+                           true);
     addSettingAccessor(
             LV2_GROUP_VIEW ".03_open_folder_windows_in_aseparate_process",
             []() {
                 return DConfigManager::instance()->value(kViewDConfName,
                                                          kOpenFolderWindowsInASeparateProcess,
-                                                         false);
+                                                         true);
             },
             [](const QVariant &val) {
                 DConfigManager::instance()->setValue(kViewDConfName,

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -203,9 +203,9 @@ bool FileOperatorMenuScene::triggered(QAction *action)
             if (infoPtr && infoPtr->isAttributes(OptInfoType::kIsSymLink))
                 cdUrl = QUrl::fromLocalFile(infoPtr->pathOf(PathInfoType::kSymLinkTarget));
 
-            auto flag = DConfigManager::instance()->
+            auto flag = !DConfigManager::instance()->
                     value(kViewDConfName,
-                          kOpenFolderWindowsInASeparateProcess, false).toBool();
+                          kOpenFolderWindowsInASeparateProcess, true).toBool();
 
             if ((flag && FileManagerWindowsManager::instance().containsCurrentUrl(cdUrl)) ||
                     Application::instance()->appAttribute(Application::kAllwayOpenOnNewWindow).toBool()) {

--- a/src/plugins/filemanager/core/dfmplugin-computer/events/computereventcaller.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/events/computereventcaller.cpp
@@ -55,9 +55,9 @@ void ComputerEventCaller::cdTo(quint64 winId, const QUrl &url)
     }
 
     DFMBASE_USE_NAMESPACE
-    auto flag = DConfigManager::instance()->
+    auto flag = !DConfigManager::instance()->
             value(kViewDConfName,
-                  kOpenFolderWindowsInASeparateProcess, false).toBool();
+                  kOpenFolderWindowsInASeparateProcess, true).toBool();
     if ((flag && FileManagerWindowsManager::instance().containsCurrentUrl(url))
             || Application::appAttribute(Application::ApplicationAttribute::kAllwayOpenOnNewWindow).toBool())
         sendEnterInNewWindow(url, !flag);

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -262,9 +262,9 @@ void SideBarWidget::onItemActived(const QModelIndex &index)
     }
 
     QApplication::restoreOverrideCursor();
-    auto flag = DConfigManager::instance()->
+    auto flag = !DConfigManager::instance()->
             value(kViewDConfName,
-                  kOpenFolderWindowsInASeparateProcess, false).toBool();
+                  kOpenFolderWindowsInASeparateProcess, true).toBool();
 
     auto target = item->targetUrl();
     if (flag && FileManagerWindowsManager::instance().containsCurrentUrl(target, window())) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -105,9 +105,9 @@ void FileOperatorHelper::openFilesByMode(const FileView *view, const QList<QUrl>
                 if (fileInfoPtr->isAttributes(OptInfoType::kIsSymLink))
                     dirUrl = QUrl::fromLocalFile(fileInfoPtr->pathOf(PathInfoType::kSymLinkTarget));
 
-                auto flag = DConfigManager::instance()->
+                auto flag = !DConfigManager::instance()->
                         value(kViewDConfName,
-                              kOpenFolderWindowsInASeparateProcess, false).toBool();
+                              kOpenFolderWindowsInASeparateProcess, true).toBool();
                 if (mode == DirOpenMode::kOpenNewWindow ||
                         (flag && FileManagerWindowsManager::instance().containsCurrentUrl(dirUrl, view->window()))) {
                     WorkspaceEventCaller::sendOpenWindow({ dirUrl }, !flag);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -147,20 +147,18 @@ void BaseItemDelegate::hideAllIIndexWidget()
 void BaseItemDelegate::hideNotEditingIndexWidget()
 {
 }
-// Cannot call this interface simultaneously as it will cause editwidget to destruct
-// and crash on the second call to handle the signal
+// Repeated reentry of this function will cause a crash
 void BaseItemDelegate::commitDataAndCloseActiveEditor()
 {
     QWidget *editor = parent()->indexWidget(d->editingIndex);
 
     if (!editor)
         return;
-    {
-        QMutexLocker lk(&d->commitDataMutex);
-        if (d->commitDataCurentWidget == editor)
-            return;
-        d->commitDataCurentWidget = editor;
-    }
+
+    if (d->commitDataCurentWidget == editor)
+        return;
+    d->commitDataCurentWidget = editor;
+
 
     QMetaObject::invokeMethod(this, "_q_commitDataAndCloseEditor",
                               Qt::DirectConnection, Q_ARG(QWidget *, editor));

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/baseitemdelegate_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/baseitemdelegate_p.h
@@ -37,7 +37,6 @@ public:
     mutable QLineEdit *editor = nullptr;
 
     AbstractItemPaintProxy *paintProxy { nullptr };
-    QMutex commitDataMutex;
     QWidget *commitDataCurentWidget { nullptr };
 
     BaseItemDelegate *q_ptr;


### PR DESCRIPTION
Requirement modification

Log: Setting "Open folder window in separate process" to check/uncheck is opposite to the actual situation
Bug: https://pms.uniontech.com/bug-view-263787.html