### PR TITLE
fix: When renaming files in bulk, the focus is not on the "Find" input box

### DIFF
--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -198,11 +198,11 @@ QMap<QString, QString> NetworkUtils::cifsMountHostInfo()
                 continue;
             // net work mount must start with //
             QString srcHostAndPort = mnt_fs_get_source(fs);
-            if (!srcHostAndPort.contains(QRegExp("^//")))
+            if (!srcHostAndPort.contains(QRegularExpression("^//")))
                 continue;
 
             const QString &mountPath = mnt_fs_get_target(fs);
-            srcHostAndPort = srcHostAndPort.replace(QRegExp("^//"), "");
+            srcHostAndPort = srcHostAndPort.replace(QRegularExpression("^//"), "");
             srcHostAndPort = srcHostAndPort.left(srcHostAndPort.indexOf("/"));
             table.insert(mountPath, srcHostAndPort);
         }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/renamebar.cpp
@@ -75,6 +75,12 @@ void RenameBar::setVisible(bool visible)
             }
         }
     }
+    if (visible) {
+        QLineEdit *lineEdit { std::get<1>(d->replaceOperatorItems) };
+        if (lineEdit)
+            lineEdit->setFocus();
+    }
+
     return QFrame::setVisible(visible);
 }
 


### PR DESCRIPTION
When renamebar is displayed, set the focus of the first lineedit

Log: When renaming files in bulk, the focus is not on the "Find" input box
Bug: https://pms.uniontech.com/bug-view-263817.html