### PR TITLE
fix: Mobile devices in ext4 format, copy file synchronization takes too long

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1322,8 +1322,7 @@ void FileOperateBaseWorker::determineCountProcessType()
         isTargetFileLocal = FileOperationsUtils::isFileOnDisk(targetOrgUrl);
         isTargetFileExBlock = false;
         fmDebug("Target block device: \"%s\", Root Path: \"%s\"", device.toStdString().data(), qPrintable(rootPath));
-        const bool isFileSystemTypeExt = DFMUtils::fsTypeFromUrl(targetOrgUrl).startsWith("ext");
-        if (!isFileSystemTypeExt) {
+        if (!isTargetFileLocal) {
             blocakTargetRootPath = rootPath;
             QProcess process;
             process.start("lsblk", { "-niro", "MAJ:MIN,HOTPLUG,LOG-SEC", device }, QIODevice::ReadOnly);


### PR DESCRIPTION
Modify the ext series files and perform copying and synchronization once (in secure copy mode)

Log:  Mobile devices in ext4 format, copy file synchronization takes too long
Bug: https://pms.uniontech.com/bug-view-261177.html