### PR TITLE
fix: When copying files from a cloud desktop virtual machine to a local UOS terminal, two document management pop ups will pop up

### DIFF
--- a/include/dfm-base/interfaces/abstractjobhandler.h
+++ b/include/dfm-base/interfaces/abstractjobhandler.h
@@ -248,6 +248,7 @@ Q_SIGNALS:   // 发送给任务调用者使用的信号
     void workerFinish();
     void requestRemoveTaskWidget();
     void requestSaveRedoOperation(const QString &token, const qint64 deleteFirstFileSize);
+    void requestTaskDailog();
 Q_SIGNALS:   // 发送给任务使用的信号
     /*!
      * \brief userAction 用户当前动作

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
@@ -40,6 +40,7 @@ bool DoCopyFilesWorker::doWork()
     // 深信服远程下载
     if (sourceUrls.isEmpty() && workData->jobFlags.testFlag(DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag::kCopyRemote)) {
         sourceUrls = dfmbase::ClipBoard::instance()->getRemoteUrls();
+        emit requestTaskDailog();
         fmInfo() << "remote copy source urls list:" << sourceUrls;
     }
     // The endcopy interface function has been called here

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/filecopymovejob.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/filecopymovejob.h
@@ -45,7 +45,10 @@ public:
                          = DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag::kNoHint,
                          const bool isInit = true);
     JobHandlePointer cleanTrash(const QList<QUrl> &sources);
-    void initArguments(const JobHandlePointer handler);
+    void initArguments(const JobHandlePointer handler,
+                       const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags =
+            DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag::kNoHint);
+    void startAddTaskTimer(const JobHandlePointer handler, const bool isRemote);
 
 private:
     bool getOperationsAndDialogService();

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -672,4 +672,5 @@ void AbstractWorker::initHandleConnects(const JobHandlePointer handle)
     connect(this, &AbstractWorker::removeTaskWidget, handle.get(), &AbstractJobHandler::requestRemoveTaskWidget, Qt::QueuedConnection);
     connect(this, &AbstractWorker::speedUpdatedNotify, handle.get(), &AbstractJobHandler::onSpeedUpdated, Qt::QueuedConnection);
     connect(this, &AbstractWorker::currentTaskNotify, handle.get(), &AbstractJobHandler::onCurrentTask, Qt::QueuedConnection);
+    connect(this, &AbstractWorker::requestTaskDailog, handle.get(), &AbstractJobHandler::requestTaskDailog, Qt::QueuedConnection);
 }

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -94,6 +94,7 @@ signals:   // update proccess timer use
     void startWork();
     void errorNotify(const JobInfoPointer jobInfo);
     void retryErrSuccess(const quint64 id);
+    void requestTaskDailog();
 
 public:
     void doOperateWork(AbstractJobHandler::SupportActions actions, AbstractJobHandler::JobErrorType error = AbstractJobHandler::JobErrorType::kNoError, const quint64 id = 0);


### PR DESCRIPTION
If it is a cloud desktop copy, dde-file-manager do not display a progress bar

Log: When copying files from a cloud desktop virtual machine to a local UOS terminal, two document management pop ups will pop up
Bug: https://pms.uniontech.com/bug-view-262263.html