### PR TITLE
fix: [upgrade] Some configurations are always replaced with duplicates

### DIFF
--- a/src/tools/upgrade/units/dconfigupgradeunit.h
+++ b/src/tools/upgrade/units/dconfigupgradeunit.h
@@ -26,6 +26,11 @@ private:
     bool upgradeRecentConfigs();
     bool upgradeSearchConfigs();
     void clearDiskHidden();
+    void addOldGenericSettings();
+    bool checkOldGeneric(const QString &key);
+
+private:
+    QStringList oldGenericSettings;
 };
 }
 

--- a/src/tools/upgrade/utils/upgradeutils.h
+++ b/src/tools/upgrade/utils/upgradeutils.h
@@ -10,6 +10,7 @@
 namespace dfm_upgrade {
 namespace UpgradeUtils {
 QVariant genericAttribute(const QString &key);
+void addOldGenericAttribute(const QJsonArray &array);
 QVariant applicationAttribute(const QString &key);
 bool backupFile(const QString &sourceFile, const QString &backupDirPath);
 }


### PR DESCRIPTION
Add a configuration item "OldAttributes" to store the names of configurations that have already been upgraded, so that if the configuration is included, there is no need to migrate the data again.

Log: as title