### PR TITLE
修复设置对话框标题栏图标缺失问题

### DIFF
--- a/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
@@ -184,6 +184,8 @@ SettingDialog::SettingDialog(QWidget *parent)
         SettingBackend::instance()->setToSettings(dtkSettings);
         updateSettings(dtkSettings);
     }
+
+    setIcon(QIcon::fromTheme("dde-file-manager"));
 }
 
 void SettingDialog::setItemVisiable(const QString &key, bool visiable)


### PR DESCRIPTION
as title.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-254501.html
