### PR TITLE
修复 smb 聚合入口（侧边栏）右键菜单异常的问题

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.h
@@ -36,6 +36,7 @@ void callForgetPasswd(const QString &stdSmb);
 
 void sidebarMenuCall(quint64 winId, const QUrl &url, const QPoint &pos);
 void sidebarItemClicked(quint64 winId, const QUrl &url);
+bool sidebarUrlEquals(const QUrl &item, const QUrl &target);
 
 }   // namespace computer_sidebar_event_calls
 

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/typedefines.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/typedefines.h
@@ -40,5 +40,7 @@ using ContextMenuCallback = std::function<void(quint64 windowId, const QUrl &url
 Q_DECLARE_METATYPE(ContextMenuCallback)
 using ItemClickedActionCallback = std::function<void(quint64 windowId, const QUrl &url)>;
 Q_DECLARE_METATYPE(ItemClickedActionCallback);
+using FindMeCallback = std::function<bool(const QUrl &itemUrl, const QUrl &targetUrl)>;
+Q_DECLARE_METATYPE(FindMeCallback);
 
 #endif   // TYPEDEFINES_H


### PR DESCRIPTION
1. sidebar url has been changed since 7.12 commit, the item url changed
from 'smb://xxxxx/xxx' to 'vsmb://xxxx/xxx', when obtain the mounted smb
by the new url, not work. convert 'vsmb' to 'smb' when trigger from
sidebar.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-264711.html
