### PR TITLE
fix: [fsearch] FSearch may not search failed.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/fsearch/fsearcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/fsearch/fsearcher.cpp
@@ -7,6 +7,7 @@
 #include "utils/searchhelper.h"
 
 #include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/device/deviceutils.h>
 
 #include <QDebug>
 
@@ -37,6 +38,12 @@ bool FSearcher::isSupport(const QUrl &url)
         return false;
 
     auto path = UrlRoute::urlToPath(url);
+
+    QString host, share;
+    bool isSmb = dfmbase::DeviceUtils::parseSmbInfo(path, host, share);
+    if (isSmb)
+        return false;
+
     return FSearchHandler::checkPathSearchable(path);
 }
 


### PR DESCRIPTION
1. When there are too many smb directory files, FSearch may not be able to find them.
2. Use dir iterator to search in smb.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-263391.html