### PR TITLE
修复无法从文管停止U盘安全扫描的问题

### DIFF
--- a/src/dfm-base/base/device/private/defendercontroller.cpp
+++ b/src/dfm-base/base/device/private/defendercontroller.cpp
@@ -15,7 +15,7 @@
 
 // Need to consider stopping multiple directory scans at the same time,
 // and extend the timeout period appropriately
-static const int kMaxDBusTimeout = 1000;
+static const int kMaxDBusTimeout = 25 * 1000;
 
 static const char *const kDefenderServiceName = "com.deepin.defender.daemonservice";
 static const char *const kDefenderServicePath = "/com/deepin/defender/daemonservice";


### PR DESCRIPTION
1. executable file has been moved from /usr/bin to /lib/exec, deepin-
defender should add the new executable to whitelist;
2. the timeout for checking if path already removed from scanning list,
changed from 1s to 25s.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-264713.html
