### PR TITLE
修复双重释放导致的崩溃问题，修复原问题单。

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp
@@ -63,7 +63,7 @@ TypeClassifier::TypeClassifier(QObject *parent)
 
     // all datas shoud be accepted.
     auto filter = new GeneralModelFilter();
-    // filter->installFilter(QSharedPointer<ModelDataHandler>(this));
+    filter->installFilter(this);
     handler = filter;
 
     // get enable items

--- a/src/plugins/desktop/ddplugin-organizer/models/generalmodelfilter.h
+++ b/src/plugins/desktop/ddplugin-organizer/models/generalmodelfilter.h
@@ -15,16 +15,19 @@ class GeneralModelFilter : public ModelDataHandler
 {
 public:
     explicit GeneralModelFilter();
-    bool installFilter(const QSharedPointer<ModelDataHandler> &filter);
-    void removeFilter(const QSharedPointer<ModelDataHandler> &filter);
+    virtual ~GeneralModelFilter();
+    bool installFilter(ModelDataHandler *filter);
+    void removeFilter(ModelDataHandler *filter);
     bool acceptInsert(const QUrl &url) override;
     QList<QUrl> acceptReset(const QList<QUrl> &urls) override;
     bool acceptRename(const QUrl &oldUrl, const QUrl &newUrl) override;
     bool acceptUpdate(const QUrl &url, const QVector<int> &roles = {}) override;
+
 protected:
-    QList<QSharedPointer<ModelDataHandler>> modelFilters;
+    QList<ModelDataHandler *> modelFilters;
+    QList<ModelDataHandler *> defaultFilters;
 };
 
 }
 
-#endif // GENERALMODELFILTER_H
+#endif   // GENERALMODELFILTER_H


### PR DESCRIPTION
TypeClassifier instance was deleted in NormalizeMode, GeneralModelFilter
was deleted in TypeClassifier, when TypeClassifier instance passed into
GeneralModelFilter as a smart pointer, the managed instance will be also
deleted when the ref-count reduced to zero. but TypeClassifier is not a
`QEnabledFromThis` instance. and `Double free` occured.

the GeneralModelFilter only need manager nude pointer, though it's more
safe to manage a smart pointer.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-264655.html
