### PR TITLE
refactor: [treeland] remove QT_WAYLAND_SHELL_INTEGRATION

### DIFF
--- a/src/apps/dde-desktop/main.cpp
+++ b/src/apps/dde-desktop/main.cpp
@@ -32,13 +32,12 @@
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QDBusConnectionInterface>
+#include <QSurfaceFormat>
 
 #include <iostream>
 #include <algorithm>
 #include <unistd.h>
 #include <malloc.h>
-#include <dfm-base/utils/windowutils.h>
-#include <QSurfaceFormat>
 
 Q_LOGGING_CATEGORY(logAppDesktop, "org.deepin.dde.filemanager.desktop")
 
@@ -240,6 +239,11 @@ static void waitingForKwin()
 
 bool first_check_wayland_env()
 {
+#ifdef COMPILE_ON_V23
+    if (qEnvironmentVariable("DDE_CURRENT_COMPOSITOR") == "TreeLand")
+        return false;
+#endif
+
     auto e = QProcessEnvironment::systemEnvironment();
     QString XDG_SESSION_TYPE = e.value(QStringLiteral("XDG_SESSION_TYPE"));
     QString WAYLAND_DISPLAY = e.value(QStringLiteral("WAYLAND_DISPLAY"));
@@ -252,7 +256,7 @@ bool first_check_wayland_env()
 }
 int main(int argc, char *argv[])
 {
-    if(first_check_wayland_env()) {
+    if (first_check_wayland_env()) {
         qputenv("QT_WAYLAND_SHELL_INTEGRATION", "kwayland-shell");
         setenv("PULSE_PROP_media.role", "video", 1);
 #ifndef __x86_64__
@@ -261,6 +265,7 @@ int main(int argc, char *argv[])
         format.setDefaultFormat(format);
 #endif
     }
+
     initLog();
     QString mainTime = QDateTime::currentDateTime().toString();
     DApplication a(argc, argv);


### PR DESCRIPTION
Using QT_WAYLAND_SHELL_INTEGRATION in treeland will cause the process to crash!

Log: refactor

Bug: https://doc.uniontech.com/sheets/Ee32MwLdL8INZzA2/MODOC