### PR TITLE
fix: dde-file-manager crash

### DIFF
--- a/src/dfm-base/file/local/localfileiconprovider.cpp
+++ b/src/dfm-base/file/local/localfileiconprovider.cpp
@@ -41,13 +41,9 @@ QIcon LocalFileIconProviderPrivate::fileSystemIcon(const QString &path) const
 
 QIcon LocalFileIconProviderPrivate::fromTheme(QString iconName) const
 {
+    assert(QThread::currentThread() == qApp->thread());
     QIcon icon;
-    {
-        static QMutex mut;
-        QMutexLocker lk(&mut);
-        icon = QIcon::fromTheme(iconName);
-    }
-
+    icon = QIcon::fromTheme(iconName);
 
     if (Q_LIKELY(!icon.isNull()))
         return icon;
@@ -115,7 +111,7 @@ QIcon LocalFileIconProvider::icon(const QString &path, const QIcon &feedback) co
     return icon;
 }
 
-QIcon LocalFileIconProvider::icon(FileInfo *info, const QIcon &feedback)
+QIcon LocalFileIconProvider::icon(FileInfoPointer info, const QIcon &feedback)
 {
     QIcon icon = d->fromTheme(info->nameOf(NameInfoType::kIconName));
 

--- a/src/dfm-base/file/local/localfileiconprovider.h
+++ b/src/dfm-base/file/local/localfileiconprovider.h
@@ -27,7 +27,7 @@ public:
     QIcon icon(const QString &path) const;
     QIcon icon(const QFileInfo &info, const QIcon &feedback) const;
     QIcon icon(const QString &path, const QIcon &feedback) const;
-    QIcon icon(FileInfo *info, const QIcon &feedback = QIcon());
+    QIcon icon(FileInfoPointer info, const QIcon &feedback = QIcon());
 
 private:
     QScopedPointer<LocalFileIconProviderPrivate> d;

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -560,7 +560,8 @@ void SyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &
     // 更新fileicon
     if (typeAll.contains(FileInfoAttributeID::kStandardIcon)) {
         typeAll.removeOne(FileInfoAttributeID::kStandardIcon);
-        d->updateIcon();
+        QWriteLocker wlk(&d->iconLock);
+        d->fileIcon = QIcon();
     }
 
     // 更新mediaInfo
@@ -680,7 +681,8 @@ FileInfo::FileType SyncFileInfoPrivate::updateFileType()
 
 QIcon SyncFileInfoPrivate::updateIcon()
 {
-    QIcon icon = LocalFileIconProvider::globalProvider()->icon(q);
+    assert(QThread::currentThread() == qApp->thread());
+    QIcon icon = LocalFileIconProvider::globalProvider()->icon(q->sharedFromThis());
     if (q->isAttributes(OptInfoType::kIsSymLink)) {
         const auto &&target = symLinkTarget();
         if (!target.isEmpty() && target != filePath()) {

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -765,6 +765,7 @@ QString SyncFileInfoPrivate::completeSuffix() const
 
 QString SyncFileInfoPrivate::iconName() const
 {
+    assert(QThread::currentThread() == qApp->thread());
     QString iconNameValue;
     if (SystemPathUtil::instance()->isSystemPath(filePath()))
         iconNameValue = SystemPathUtil::instance()->systemPathIconNameByPath(filePath());

--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -151,7 +151,7 @@ void ClipBoard::setUrlsToClipboard(const QList<QUrl> &list, ClipBoard::Clipboard
             }
             // TODO lanxs::目前缩略图还没有处理，等待处理完成了在修改
             // 多文件时只显示文件图标, 一个文件时显示缩略图(如果有的话)
-            QIcon icon = LocalFileIconProvider::globalProvider()->icon(info.data());
+            QIcon icon = LocalFileIconProvider::globalProvider()->icon(info);
             FileInfo::FileType fileType = MimeTypeDisplayManager::
                                                   instance()
                                                           ->displayNameToEnum(info->nameOf(NameInfoType::kMimeTypeName));

--- a/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.h
+++ b/src/plugins/filemanager/core/dfmplugin-recent/utils/recentmanager.h
@@ -89,6 +89,7 @@ public slots:
 private slots:
     void onUpdateRecentFileInfo(const QUrl &url, const QString &originPath, qint64 readTime);
     void onDeleteExistRecentUrls(const QList<QUrl> &urls);
+    void onStopRecentWatcherThread();
 
 private:
     QThread workerThread;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.h
@@ -146,7 +146,7 @@ private:
     bool canCache { false };
 
     std::atomic_bool cancelWatcherEvent { false };
-    QFuture<void> watcherEventFuture;
+    QList<QFuture<void>> watcherEventFutures;
 
     QQueue<QPair<QUrl, EventType>> watcherEvent {};
     QMutex watcherEventMutex;

--- a/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
+++ b/tests/plugins/filemanager/core/dfmplugin-workspace/models/ut_rootinfo.cpp
@@ -333,19 +333,25 @@ TEST_F(UT_RootInfo, DoThreadWatcherEvent)
 
     rootInfoObj->processFileEventRuning = true;
     rootInfoObj->doThreadWatcherEvent();
-    rootInfoObj->watcherEventFuture.waitForFinished();
+    for (auto &future : rootInfoObj->watcherEventFutures) {
+        future.waitForFinished();
+    }
     EXPECT_FALSE(calledDoWatcherEvent);
 
     rootInfoObj->processFileEventRuning = false;
     rootInfoObj->cancelWatcherEvent = true;
     rootInfoObj->doThreadWatcherEvent();
-    rootInfoObj->watcherEventFuture.waitForFinished();
+    for (auto &future : rootInfoObj->watcherEventFutures) {
+        future.waitForFinished();
+    }
     EXPECT_FALSE(calledDoWatcherEvent);
 
     rootInfoObj->processFileEventRuning = false;
     rootInfoObj->cancelWatcherEvent = false;
     rootInfoObj->doThreadWatcherEvent();
-    rootInfoObj->watcherEventFuture.waitForFinished();
+    for (auto &future : rootInfoObj->watcherEventFutures) {
+        future.waitForFinished();
+    }
     EXPECT_TRUE(calledDoWatcherEvent);
 }
 


### PR DESCRIPTION
From them crashes, a global lock is added when calling from them, and FileinfoPointer is used as a parameter here

Log: dde-file-manager crash
Bug: https://pms.uniontech.com/bug-view-258661.html