### PR TITLE
fix: The option to open folder windows in a separate process is not selected by default in the settings

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.view.json
+++ b/assets/configs/org.deepin.dde.file-manager.view.json
@@ -14,7 +14,7 @@
             "visibility":"private"
         },
         "dfm.open.in.single.process": {
-            "value":false,
+            "value":true,
             "serial":0,
             "flags":[],
             "name":"Open folder windows in a separate process",


### PR DESCRIPTION
Modify the default value of JSON

Log: The option to open folder windows in a separate process is not selected by default in the settings
Bug: https://pms.uniontech.com/bug-view-265519.html