### PR TITLE
fix: After enabling HTTP and HTTPS system proxies, ignore hosts configuration is invalid

### DIFF
--- a/src/dfm-base/utils/networkutils.h
+++ b/src/dfm-base/utils/networkutils.h
@@ -21,8 +21,8 @@ class NetworkUtils : public QObject
 public:
     static NetworkUtils *instance();
 
-    bool checkNetConnection(const QString &host, const QString &port, int msecs = 3000);
-    bool checkNetConnection(const QString &host, QStringList ports, int msecs = 3000);
+    bool checkNetConnection(const QString &host, const QString &port, int msecs = 1000);
+    bool checkNetConnection(const QString &host, QStringList ports, int msecs = 1000);
     void doAfterCheckNet(const QString &host, const QStringList &ports,
                          std::function<void(bool)> callback = nullptr, int msecs = 3000);
     bool parseIp(const QString &mpt, QString &ip, QString &port);


### PR DESCRIPTION
After starting the HTTP and HTTPS system proxies, directly check whether a proxy is needed or not

Log: After enabling HTTP and HTTPS system proxies, ignore hosts configuration is invalid
Bug: https://pms.uniontech.com/bug-view-264417.html