### PR TITLE
fix: Clicking on the directory with ',' on the dde-desktop will bring up two dde-file-manager windows

### DIFF
--- a/assets/scripts/dde-file-manager
+++ b/assets/scripts/dde-file-manager
@@ -28,6 +28,9 @@ for arg in "$@"; do
         arg=$(echo "$absolute_path" | sed 's/ /*||*/g')
     fi
 
+    # array:string:"$args"中','是切分符号，所以传入dbus是要被切分
+    arg=$(echo "$arg" | sed 's/,/*|||*/g')
+
     if [[ $arg == "-h" ]] || [[ $arg == "-v" ]]; then
         isDbus="false"
         break;

--- a/src/plugins/server/serverplugin-filemanager1/filemanager1dbus.cpp
+++ b/src/plugins/server/serverplugin-filemanager1/filemanager1dbus.cpp
@@ -103,7 +103,7 @@ void FileManager1DBus::Open(const QStringList &Args)
 {
     QStringList URIsArgs;
     for (auto arg : Args) {
-        URIsArgs.append(arg.replace(" ", "*||*"));
+        URIsArgs.append(arg.replace("*|||*", ",").replace(" ", "*||*"));
     }
     if (QProcess::startDetached("file-manager.sh", QStringList() << URIsArgs))
         return;


### PR DESCRIPTION
﻿In the dde-file-manager script, in the “array: string: "$args"” parameter, ',' is a delimiter, modify script escape ',' is' * | | |* '. Convert it back into dbus.

Log: Clicking on the directory with ',' on the dde-desktop will bring up two dde-file-manager windows
Bug: https://pms.uniontech.com/bug-view-265899.html