### PR TITLE
fix: [smb] file counts not calculated.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/utils/computerutils.cpp
@@ -311,7 +311,7 @@ QWidget *ComputerUtils::devicePropertyDialog(const QUrl &url)
     DeviceInfo devInfo;
     devInfo.icon = info->fileIcon();
     devInfo.deviceUrl = info->urlOf(UrlInfoType::kUrl);
-    devInfo.mountPoint = info->targetUrl();
+    devInfo.mountPoint = QUrl::fromLocalFile(info->extraProperty(GlobalServerDefines::DeviceProperty::kMountPoint).toString());
     devInfo.deviceName = info->displayName();
     devInfo.deviceType = ComputerUtils::deviceTypeInfo(info);
     devInfo.fileSystem = info->extraProperty(GlobalServerDefines::DeviceProperty::kFileSystem).toString();


### PR DESCRIPTION
targetUrl of smb file returns the original smb path: smb://x.x.x.x/xxxx
which cannot be used to iterate files, the real local mountpoint should
be used.

Log: fix issue about device file counts calculate.

Bug: https://pms.uniontech.com/bug-view-265891.html
