### PR TITLE
fix: Right click on the Python script, specify the installed PyCharm Community Edition as the opening method, and click on 'Not Effective'

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -361,7 +361,9 @@ void OpenWithDialog::initData()
     }
 
     const QString &defaultApp = MimesAppsManager::instance()->getDefaultAppByMimeType(mimeType);
-    const QStringList &recommendApps = MimesAppsManager::instance()->getRecommendedAppsByQio(mimeType);
+    const QStringList &recommendApps = curUrl.isValid() || !urlList.isEmpty() ?
+                MimesAppsManager::instance()->getRecommendedApps(curUrl.isValid() ? curUrl : urlList.first())
+              : MimesAppsManager::instance()->getRecommendedAppsByQio(mimeType);
 
     for (int i = 0; i < recommendApps.count(); ++i) {
         const DesktopFile &desktopInfo = MimesAppsManager::instance()->DesktopObjs.value(recommendApps.at(i));
@@ -437,6 +439,7 @@ void OpenWithDialog::useOtherApplication()
 
     targetDesktopFileName = targetDesktopFileName.arg(QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation)).arg(qApp->applicationName()).arg(mimeType.name().replace("/", "-"));
 
+    QString iconName;
     if (filePath.endsWith(".desktop")) {
         auto list = recommandLayout->parentWidget()->findChildren<OpenWithDialog *>();
         auto ret = std::any_of(list.begin(), list.end(), [filePath](const OpenWithDialog *w) {
@@ -448,8 +451,14 @@ void OpenWithDialog::useOtherApplication()
 
         Properties desktop(filePath, "Desktop Entry");
 
-        if (desktop.value("MimeType").toString().isEmpty())
+        // 目前发现有些.desktop文件没有遵循规则写入MimeType
+        // 但是这里又是用户自己选中的这个app，那么这里就只判断是否是application
+        if (desktop.value("Type").toString() != "Application") {
+            qCWarning(logDFMBase()) << filePath << " is not Application!!";
             return;
+        }
+
+        iconName = desktop.value("Icon").toString();
 
         if (!QFile::link(filePath, targetDesktopFileName))
             return;
@@ -484,7 +493,8 @@ void OpenWithDialog::useOtherApplication()
         }
     }
 
-    OpenWithDialogListItem *item = createItem(QIcon::fromTheme("application-x-desktop"), info.fileName(), targetDesktopFileName);
+    OpenWithDialogListItem *item = createItem(QIcon::fromTheme(iconName.isEmpty() ? "application-x-desktop" : iconName),
+                                              info.fileName(), targetDesktopFileName);
 
     int otherLayoutSizeHintHeight = otherLayout->sizeHint().height();
     otherLayout->addWidget(item);


### PR DESCRIPTION
The .desktop file does not have a MimeType field, modify the judgment criteria

Log: Right click on the Python script, specify the installed PyCharm Community Edition as the opening method, and click on 'Not Effective'
Bug: https://pms.uniontech.com/bug-view-231359.html