### PR TITLE
fix: Search for the specified restore file, select the restore file, the trash file does not disappear in real time, and clicking restore again will result in an error

### DIFF
--- a/src/dfm-base/utils/watchercache.cpp
+++ b/src/dfm-base/utils/watchercache.cpp
@@ -75,6 +75,8 @@ QSharedPointer<AbstractFileWatcher> WatcherCache::getCacheWatcher(const QUrl &ur
 void WatcherCache::cacheWatcher(const QUrl &url, const QSharedPointer<AbstractFileWatcher> &watcher)
 {
     Q_D(WatcherCache);
+    if (watcher.isNull())
+        return;
     connect(watcher.data(), &AbstractFileWatcher::fileDeleted, this, &WatcherCache::fileDelete);
     d->watchers.insert(url, watcher);
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -95,6 +95,7 @@ FileView::FileView(const QUrl &url, QWidget *parent)
 
 FileView::~FileView()
 {
+    disconnect();
     disconnect(model(), &FileViewModel::stateChanged, this, &FileView::onModelStateChanged);
     disconnect(selectionModel(), &QItemSelectionModel::selectionChanged, this, &FileView::onSelectionChanged);
 

--- a/src/plugins/filemanager/dfmplugin-search/watcher/searchfilewatcher.h
+++ b/src/plugins/filemanager/dfmplugin-search/watcher/searchfilewatcher.h
@@ -28,6 +28,7 @@ private:
     void onFileDeleted(const QUrl &url);
     void onFileAttributeChanged(const QUrl &url);
     void onFileRenamed(const QUrl &fromUrl, const QUrl &toUrl);
+    void onFileCreate(const QUrl &url);
 
     SearchFileWatcherPrivate *dptr;
 };


### PR DESCRIPTION
Add kDeleeFileNotifySearch and kRenameFileNotifySearch for personal leave in operations such as restore, delete, move to the trash, cut, and clean trash

Log: Search for the specified restore file, select the restore file, the trash file does not disappear in real time, and clicking restore again will result in an error
Bug: https://pms.uniontech.com/bug-view-251715.html