### PR TITLE
fix: Keyword search, the search box for the second keyword keeps circling and cannot be found

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
@@ -68,7 +68,9 @@ void WorkspaceWidget::setCurrentUrl(const QUrl &url)
     auto curView = currentViewPtr();
     if (curView) {
         if (UniversalUtils::urlEquals(url, curView->rootUrl()) &&
-                UniversalUtils::urlEquals(url, tabBar->currentTab()->getCurrentUrl()))
+                UniversalUtils::urlEquals(url, tabBar->currentTab()->getCurrentUrl()) &&
+                !dpfHookSequence->run("dfmplugin_workspace", "hook_Tab_Allow_Repeat_Url",
+                                      url, tabBar->currentTab()->getCurrentUrl()))
             return;
 
         FileView *view = qobject_cast<FileView *>(curView->widget());

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -85,6 +85,7 @@ class Workspace : public dpf::Plugin
 
     DPF_EVENT_REG_HOOK(hook_Tab_SetTabName)
     DPF_EVENT_REG_HOOK(hook_Tab_Closeable)
+    DPF_EVENT_REG_HOOK(hook_Tab_Allow_Repeat_Url)
 
     DPF_EVENT_REG_HOOK(hook_DragDrop_CheckDragDropAction)
     DPF_EVENT_REG_HOOK(hook_DragDrop_FileDragMove)

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -186,6 +186,8 @@ void Search::bindEvents()
                             SearchHelper::instance(), &SearchHelper::customRoleDisplayName);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_PasteFiles",
                             SearchHelper::instance(), &SearchHelper::blockPaste);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_Tab_Allow_Repeat_Url",
+                            SearchHelper::instance(), &SearchHelper::allowRepeatUrl);
     dpfHookSequence->follow("dfmplugin_detailspace", "hook_Icon_Fetch",
                             SearchHelper::instance(), &SearchHelper::searchIconName);
 

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -314,6 +314,13 @@ bool SearchHelper::isHiddenFile(const QString &fileName, QHash<QString, QSet<QSt
             : isHiddenFile(fileParentPath, filters, searchPath);
 }
 
+bool SearchHelper::allowRepeatUrl(const QUrl &cur, const QUrl &pre)
+{
+    if (cur.scheme() == scheme() && pre.scheme() == scheme())
+        return true;
+    return false;
+}
+
 QDBusInterface &SearchHelper::anythingInterface()
 {
     static QDBusInterface interface("com.deepin.anything",

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.h
@@ -60,6 +60,7 @@ public:
                 + QLatin1String(")\\z");
     }
     bool isHiddenFile(const QString &fileName, QHash<QString, QSet<QString>> &filters, const QString &searchPath);
+    bool allowRepeatUrl(const QUrl &cur, const QUrl &pre);
 
     static QDBusInterface &anythingInterface();
 private:


### PR DESCRIPTION
Add hook events to handle duplicate URL issues

Log: Keyword search, the search box for the second keyword keeps circling and cannot be found
Bug: https://pms.uniontech.com/bug-view-267087.html