### PR TITLE
fix: desktop cannot launcheed by dde-hsell

### DIFF
--- a/src/external/dde-shell-plugins/panel-desktop/package/metadata.json
+++ b/src/external/dde-shell-plugins/panel-desktop/package/metadata.json
@@ -2,6 +2,7 @@
     "Plugin": {
         "Version": "1.0",
         "Id": "org.deepin.ds.desktop",
-        "ContainmentType": "Panel"
+        "ContainmentType": "Panel",
+        "Category": "DDE"
     }
 }


### PR DESCRIPTION
due to default Category is `DDE`, add `DDE` to meta json of desktop

log: as title