### PR TITLE
fix: dde-filemanager crash when search in trash and close the window

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -46,7 +46,8 @@ RootInfo::~RootInfo()
     for (const auto &thread : discardedThread) {
         thread->disconnect();
         thread->stop();
-        thread->exit();
+        thread->quit();
+        thread->wait();
     }
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.cpp
@@ -40,6 +40,13 @@ WorkspaceWidget::WorkspaceWidget(QFrame *parent)
     initConnect();
 }
 
+WorkspaceWidget::~WorkspaceWidget()
+{
+    while(viewStackLayout->currentWidget()) {
+        viewStackLayout->currentWidget()->setParent(nullptr);
+    }
+}
+
 WorkspaceWidget::ViewPtr WorkspaceWidget::currentViewPtr() const
 {
     auto scheme = currentUrl().scheme();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/workspacewidget.h
@@ -43,6 +43,7 @@ class WorkspaceWidget : public DFMBASE_NAMESPACE::AbstractFrame
 
 public:
     explicit WorkspaceWidget(QFrame *parent = nullptr);
+    ~WorkspaceWidget() override;
 
     ViewPtr currentViewPtr() const;
     DFMBASE_NAMESPACE::Global::ViewMode currentViewMode() const;


### PR DESCRIPTION
double free fileview,set current view parent null when free workspacewidget

Log: dde-filemanager crash when search in trash and close the window