### PR TITLE
fix: [device] do not poweroff if device's media is flash_sd

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -800,13 +800,14 @@ QStringList DeviceManager::detachBlockDev(const QString &id, CallbackType2 cb)
     bool isOptical = me.value(DeviceProperty::kOpticalDrive).toBool();
     bool canPowerOff = me.value(DeviceProperty::kCanPowerOff).toBool();
 
-    auto func = [this, id, isOptical, canPowerOff, cb](bool allUnmounted, const OperationErrorInfo &err) {
+    auto media = me.value(DeviceProperty::kMedia).toString();
+    auto func = [this, id, isOptical, canPowerOff, cb, media](bool allUnmounted, const OperationErrorInfo &err) {
         if (allUnmounted) {
             QThread::msleep(500);   // make a short delay to eject/powerOff, other wise may raise a
                     // 'device busy' error.
             if (isOptical)
                 ejectBlockDevAsync(id, {}, cb);
-            else if (canPowerOff)
+            else if (canPowerOff && media != "flash_sd")   // do not detach SD driver.
                 powerOffBlockDevAsync(id, {}, cb);
             else if (cb)
                 cb(true, err);


### PR DESCRIPTION
never poweroff SD card reader.

Log: as title.

Task: https://pms.uniontech.com/task-view-358453.html
Bug: https://pms.uniontech.com/bug-view-195467.html
