### PR TITLE
feat: dde-file-manager Open Out of Drive Folder Load Time Optimization

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -338,6 +338,13 @@ public:
         return qSharedPointerDynamicCast<T>(info);
     }
 
+    static void cacheFileInfo(const QSharedPointer<FileInfo> &info) {
+        if (InfoCacheController::instance().cacheDisable(info->fileUrl().scheme()))
+            return;
+        emit InfoCacheController::instance().removeCacheFileInfo({info->fileUrl()});
+        emit InfoCacheController::instance().cacheFileInfo(info->fileUrl(), info);
+    }
+
 private:
     static InfoFactory &instance();   // 获取全局实例
     explicit InfoFactory() {}

--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -94,6 +94,7 @@ enum ItemRoles {
     kItemTreeViewDepthRole = Qt::UserRole + 34,
     kItemTreeViewExpandedRole = Qt::UserRole + 35,
     kItemTreeViewCanExpandRole = Qt::UserRole + 36, // item can expand
+    kItemUpdateAndTransFileInfoRole = Qt::UserRole + 37,
     kItemUnknowRole = Qt::UserRole + 999
 };
 

--- a/include/dfm-base/interfaces/abstractdiriterator.h
+++ b/include/dfm-base/interfaces/abstractdiriterator.h
@@ -121,6 +121,15 @@ public:
     {
         return {};
     }
+    virtual void setQueryAttributes(const QString &attributes) {
+        queryFileAttributes = attributes;
+    }
+    virtual QString queryAttributes() const
+    {
+        return queryFileAttributes;
+    }
+private:
+    QString queryFileAttributes; // isempty or * is query all file attributes
 };
 
 }

--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -115,6 +115,8 @@ public:
         kFileCdRomDevice = 8,   // 文件是光驱
         kFileThumbnail = 9,     // 文件缩略图
         kCustomerStartExtended = 50,   // 其他用户使用
+        kFileNeedUpdate = 51,   // 文件信息需要在显示更新
+        kFileNeedTransInfo = 52,   // 文件信息需要转换为desktopfileinfo
         kUnknowExtendedInfo = 255,
     };
     /*!

--- a/src/dfm-base/file/local/asyncfileinfo.h
+++ b/src/dfm-base/file/local/asyncfileinfo.h
@@ -63,7 +63,7 @@ public:
     void setNotifyUrl(const QUrl &url, const QString &infoPtr);
     void removeNotifyUrl(const QUrl &url, const QString &infoPtr);
     // less 0,cache fialed, equeal 0,another cache, bigger 0 cache success
-    int cacheAsyncAttributes();
+    int cacheAsyncAttributes(const QString &attributes = QString());
     bool asyncQueryDfmFileInfo(int ioPriority = 0, initQuerierAsyncCallback func = nullptr, void *userData = nullptr);
     int errorCodeFromDfmio() const;
 };

--- a/src/dfm-base/file/local/localdiriterator.h
+++ b/src/dfm-base/file/local/localdiriterator.h
@@ -48,6 +48,9 @@ public:
     DFMIO::DEnumeratorFuture *asyncIterator();
     // get all sub file's fileinfo
     virtual QList<FileInfoPointer> fileInfos() const override;
+
+    // AbstractDirIterator interface
+    virtual void setQueryAttributes(const QString &attributes) override;
 };
 }
 

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -103,7 +103,7 @@ public:
     QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> mediaInfo(DFileInfo::MediaType type, QList<DFileInfo::AttributeExtendID> ids);
 
     FileInfo::FileType fileType() const;
-    int cacheAllAttributes();
+    int cacheAllAttributes(const QString &attributes = QString());
     bool inserAsyncAttribute(const FileInfo::FileInfoAttributeID id, const QVariant &value);
     void fileMimeTypeAsync(QMimeDatabase::MatchMode mode = QMimeDatabase::MatchDefault);
     QMimeType mimeTypes(const QString &filePath, QMimeDatabase::MatchMode mode = QMimeDatabase::MatchDefault,

--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -108,6 +108,13 @@ void FileStatisticsJobPrivate::processFile(const QUrl &url, const bool followLin
 {
     FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
 
+    processFile(info, followLink, directoryQueue);
+}
+
+void FileStatisticsJobPrivate::processFile(const FileInfoPointer &fileInfo, const bool followLink, QQueue<QUrl> &directoryQueue)
+{
+    auto info = fileInfo;
+    auto url = fileInfo->fileUrl();
     if (!info) {
         qCWarning(logDFMBase) << "Url not yet supported: " << url;
         return;
@@ -279,7 +286,7 @@ bool FileStatisticsJobPrivate::checkInode(const FileInfoPointer info)
             }
             return false;
         }
-        inodelist.append(fileInode);
+        inodelist.insert(fileInode);
     }
     return true;
 }
@@ -502,6 +509,8 @@ void FileStatisticsJob::statistcsOtherFileSystem()
             qCWarning(logDFMBase) << "Failed on create dir iterator, for url:" << directory_url;
             continue;
         }
+        d->iterator->setQueryAttributes("standard::name,standard::type,standard::size,\
+                                        standard::size,standard::is-symlink,standard::symlink-target,access::*,unix::inode");
         d->iteratorCanStop = true;
         while (d->iterator->hasNext()) {
             QUrl url = d->iterator->next();

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -21,7 +21,7 @@ public:
         qint64 totalSize { 0 };
         quint16 dirSize { 0 };
         quint32 fileCount { 0 };
-        QList<QUrl> allFiles;
+        QSet<QUrl> allFiles;
     };
 
 public:

--- a/src/dfm-base/utils/private/filestatissticsjob_p.h
+++ b/src/dfm-base/utils/private/filestatissticsjob_p.h
@@ -25,6 +25,7 @@ public:
     bool stateCheck();
 
     void processFile(const QUrl &url, const bool followLink, QQueue<QUrl> &directoryQueue);
+    void processFile(const FileInfoPointer &info, const bool followLink, QQueue<QUrl> &directoryQueue);
     void emitSizeChanged();
     int countFileCount(const char *name);
     bool checkFileType(const FileInfo::FileType &fileType);
@@ -45,9 +46,9 @@ public:
     QAtomicInt filesCount { 0 };
     QAtomicInt directoryCount { 0 };
     SizeInfoPointer sizeInfo { nullptr };
-    QList<QUrl> fileStatistics;
-    QList<QString> skipPath;
-    QList<quint64> inodelist;
+    QSet<QUrl> fileStatistics;
+    QSet<QString> skipPath;
+    QSet<quint64> inodelist;
     AbstractDirIteratorPointer iterator { nullptr };
     std::atomic_bool iteratorCanStop { false };
 };

--- a/src/dfm-base/utils/traversaldirthread.cpp
+++ b/src/dfm-base/utils/traversaldirthread.cpp
@@ -65,6 +65,15 @@ void TraversalDirThread::stopAndDeleteLater()
     }
 }
 
+void TraversalDirThread::setQueryAttributes(const QString &fileAttributes)
+{
+    if (fileInfoQueryAttributes == fileAttributes)
+        return;
+    fileInfoQueryAttributes = fileAttributes;
+    if (fileInfoQueryAttributes.isEmpty() && fileInfoQueryAttributes != "*")
+        dirIterator->setQueryAttributes(fileInfoQueryAttributes);
+}
+
 void TraversalDirThread::run()
 {
     if (dirIterator.isNull())

--- a/src/dfm-base/utils/traversaldirthread.h
+++ b/src/dfm-base/utils/traversaldirthread.h
@@ -25,6 +25,7 @@ protected:
     QDirIterator::IteratorFlags flags;
     QList<QUrl> childrenList;   // 当前遍历出来的所有文件
     bool stopFlag = false;
+    QString fileInfoQueryAttributes;
 
 public:
     explicit TraversalDirThread(const QUrl &url, const QStringList &nameFilters = QStringList(),
@@ -35,6 +36,7 @@ public:
     void stop();
     void quit();
     void stopAndDeleteLater();
+    void setQueryAttributes(const QString &fileAttributes);
 
 Q_SIGNALS:
     void updateChildren(QList<QUrl> children);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -251,7 +251,8 @@ bool AbstractWorker::statisticsFilesSize()
 
     if (isSourceFileLocal) {
         const SizeInfoPointer &fileSizeInfo = FileOperationsUtils::statisticsFilesSize(sourceUrls, true);
-        allFilesList = fileSizeInfo->allFiles;
+        for (const auto &url : fileSizeInfo->allFiles)
+            allFilesList.append(url);
         sourceFilesTotalSize = fileSizeInfo->totalSize;
         workData->dirSize = fileSizeInfo->dirSize;
         sourceFilesCount = fileSizeInfo->fileCount;
@@ -554,7 +555,8 @@ void AbstractWorker::onStatisticsFilesSizeFinish()
     sourceFilesTotalSize = statisticsFilesSizeJob->totalProgressSize();
     workData->dirSize = sizeInfo->dirSize;
     sourceFilesCount = sizeInfo->fileCount;
-    allFilesList = sizeInfo->allFiles;
+    for (const auto &url : sizeInfo->allFiles)
+        allFilesList.append(url);
 }
 
 void AbstractWorker::onStatisticsFilesSizeUpdate(qint64 size)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -120,7 +120,7 @@ void FileOperationsUtils::statisticFilesSize(const QUrl &url,
 
         // url record
         if (isRecordUrl && flag != FTS_DP)
-            sizeInfo->allFiles.append(curUrl);
+            sizeInfo->allFiles.insert(curUrl);
 
         // file counted
         if (flag == FTS_F || flag == FTS_SL || flag == FTS_SLNONE)

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileprovider.cpp
@@ -79,6 +79,7 @@ void FileProvider::refresh(QDir::Filters filters)
     }
 
     traversalThread = new TraversalDirThread(rootUrl, QStringList(), filters, QDirIterator::NoIteratorFlags);
+    traversalThread->setQueryAttributes("standard::standard::name");
     connect(traversalThread, &TraversalDirThread::updateChildren, this, &FileProvider::reset);
     connect(traversalThread, &TraversalDirThread::finished, this, &FileProvider::traversalFinished);
 

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
@@ -124,6 +124,7 @@ void CrumbInterface::requestCompletionList(const QUrl &url)
     }
     folderCompleterJobPointer = new TraversalDirThread(url, QStringList(),
                                                        QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot, QDirIterator::NoIteratorFlags);
+    folderCompleterJobPointer->setQueryAttributes("standard::standard::name");
     folderCompleterJobPointer->setParent(this);
     if (folderCompleterJobPointer.isNull())
         return;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.h
@@ -33,6 +33,8 @@ public:
     void setExpanded(bool b);
     void setDepth(const int8_t depth);
 
+    void transFileInfo();
+
 private:
     bool isDir() const;
 
@@ -45,6 +47,7 @@ private:
     std::atomic_int8_t depth { 0 };
     std::atomic_bool expanded { false };
     std::atomic_int subFileCount{ 0 }; // sub file count,not contain hide file
+    mutable std::atomic_bool updateOnce { true };
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -811,9 +811,6 @@ void FileViewModel::onDConfigChanged(const QString &config, const QString &key)
 
 void FileViewModel::onSetCursorWait()
 {
-    if (currentState() != ModelState::kBusy)
-        return;
-
     if (QApplication::overrideCursor() && QApplication::overrideCursor()->shape() == Qt::CursorShape::WaitCursor)
         return;
 
@@ -927,6 +924,12 @@ void FileViewModel::initFilterSortWork()
     connect(filterSortWorker.data(), &FileSortWorker::updateRow, this, &FileViewModel::onFileUpdated, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::selectAndEditFile, this, &FileViewModel::selectAndEditFile, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::requestSetIdel, this, &FileViewModel::onWorkFinish, Qt::QueuedConnection);
+    connect(filterSortWorker.data(), &FileSortWorker::requestCursorWait, this, [this]{
+        startCursorTimer();
+    }, Qt::QueuedConnection);
+    connect(filterSortWorker.data(), &FileSortWorker::reqUestCloseCursor, this, [this]{
+        closeCursorTimer();
+    }, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestChangeHiddenFilter, filterSortWorker.data(), &FileSortWorker::onToggleHiddenFiles, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestChangeFilters, filterSortWorker.data(), &FileSortWorker::handleFilters, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestChangeNameFilters, filterSortWorker.data(), &FileSortWorker::HandleNameFilters, Qt::QueuedConnection);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -32,6 +32,8 @@ FileSortWorker::FileSortWorker(const QUrl &url, const QString &key, FileViewFilt
     connect(&FileInfoHelper::instance(), &FileInfoHelper::fileRefreshFinished, this,
             &FileSortWorker::handleFileInfoUpdated, Qt::QueuedConnection);
     currentSupportTreeView = WorkspaceHelper::instance()->supportTreeView(current.scheme());
+    connect(this, &FileSortWorker::requestSortByMimeType, this, &FileSortWorker::handleSortByMimeType,
+            Qt::QueuedConnection);
 }
 
 FileSortWorker::~FileSortWorker()
@@ -129,6 +131,7 @@ FileItemDataPointer FileSortWorker::childData(const int index)
 void FileSortWorker::cancel()
 {
     isCanceled = true;
+    mimeSorting = false;
 }
 
 int FileSortWorker::getChildShowIndex(const QUrl &url)
@@ -224,7 +227,7 @@ void FileSortWorker::handleFilters(QDir::Filters filters)
 void FileSortWorker::HandleNameFilters(const QStringList &filters)
 {
     nameFilters = filters;
-    QMap<QUrl, FileItemDataPointer>::iterator itr = childrenDataMap.begin();
+    QHash<QUrl, FileItemDataPointer>::iterator itr = childrenDataMap.begin();
     for (; itr != childrenDataMap.end(); ++itr) {
         checkNameFilters(itr.value());
     }
@@ -434,10 +437,17 @@ void FileSortWorker::handleResort(const Qt::SortOrder order, const ItemRoles sor
         return;
 
     auto opt = setSortAgruments(order, sortRole, /*istree ? false :*/ isMixDirAndFile);
+
     switch (opt) {
     case FileSortWorker::SortOpt::kSortOptOtherChanged:
+        emit requestCursorWait();
+        mimeSorting = this->sortRole == DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault;
+        waitUpdatedFiles.clear();
+        if (!checkAndUpdateFileInfoUpdate())
+            return;
         return resortCurrent(false);
     case FileSortWorker::SortOpt::kSortOptOnlyOrderChanged:
+        emit requestCursorWait();
         return resortCurrent(true);
     default:
         return;
@@ -494,14 +504,14 @@ bool FileSortWorker::handleUpdateFile(const QUrl &url)
 
         // 插入到每个目录下的显示目录
         auto subVisibleList = visibleTreeChildren.take(parentUrl);
-        auto offset = subVisibleList.length();
+        auto offset = subVisibleList.count();
         if (orgSortRole != Global::ItemRoles::kItemDisplayRole)
             offset = insertSortList(sortInfo->fileUrl(), subVisibleList, AbstractSortFilter::SortScenarios::kSortScenariosWatcherAddFile);
         auto subIndex = offset;
         // 根目录下的offset计算不一样
         if (UniversalUtils::urlEquals(parentUrl, current)) {
-            if (offset >= subVisibleList.length() || offset == 0) {
-                offset = offset >= subVisibleList.length() ? childrenCount() : 0;
+            if (offset >= subVisibleList.count() || offset == 0) {
+                offset = offset >= subVisibleList.count() ? childrenCount() : 0;
             } else {
                 auto tmpUrl = offset >= subVisibleList.length() ? QUrl() : subVisibleList.at(offset);
                 offset = getChildShowIndex(tmpUrl);
@@ -604,8 +614,11 @@ void FileSortWorker::handleFileInfoUpdated(const QUrl &url, const QString &infoP
     if (!fileInfo || QString::number(quintptr(fileInfo.data()), 16) != infoPtr)
         return;
 
-    fileInfo->customData(Global::ItemRoles::kItemFileRefreshIcon);
+    itemdata->transFileInfo();
 
+    fileInfo = itemdata->fileInfo();
+    fileInfo->customData(Global::ItemRoles::kItemFileRefreshIcon);
+    checkAndSortBytMimeType(fileInfo->fileUrl());
     sortInfoUpdateByFileInfo(fileInfo);
 
     if (fileInfoRefresh.contains(url))
@@ -631,6 +644,13 @@ void FileSortWorker::handleUpdateRefreshFiles()
         return;
     handleUpdateFiles(fileInfoRefresh);
     fileInfoRefresh.clear();
+}
+
+void FileSortWorker::handleSortByMimeType()
+{
+    if (isCanceled)
+        return;
+    resortCurrent(false);
 }
 
 void FileSortWorker::handleCloseExpand(const QString &key, const QUrl &parent)
@@ -718,7 +738,7 @@ bool FileSortWorker::handleAddChildren(const QString &key,
     auto childUrls = visibleTreeChildren.take(parentUrl);
     auto startPos = findStartPos(parentUrl);
     auto posOffset = childUrls.length();
-    QMap<QUrl, SortInfoPointer> tmpChildren = this->children.take(parentUrl);
+    QHash<QUrl, SortInfoPointer> tmpChildren = this->children.take(parentUrl);
     // 辅助或者fileinfo
     int index = 0;
     int infosSize = childInfos.count();
@@ -848,6 +868,7 @@ void FileSortWorker::resortCurrent(const bool reverse)
     }
 
     resortVisibleChildren(visibleList);
+    emit reqUestCloseCursor();
 }
 
 QList<QUrl> FileSortWorker::filterFilesByParent(const QUrl &dir, const bool byInfo)
@@ -1122,8 +1143,8 @@ QList<QUrl> FileSortWorker::sortTreeFiles(const QList<QUrl> &children, const boo
 
     QList<QUrl> sortList;
     int sortIndex = 0;
-    QMap<QUrl, SortInfoPointer> sortInfos = reverse && !isMixDirAndFile ? this->children.value(parentUrl)
-                                                                        : QMap<QUrl, SortInfoPointer>();
+    QHash<QUrl, SortInfoPointer> sortInfos = reverse && !isMixDirAndFile ? this->children.value(parentUrl)
+                                                                         : QHash<QUrl, SortInfoPointer>();
     bool firstFile = false;
     for (const auto &url : children) {
         if (isCanceled)
@@ -1666,4 +1687,50 @@ int FileSortWorker::setVisibleChildren(const int startPos, const QList<QUrl> &fi
     visibleChildren = visibleList;
 
     return visibleList.length();
+}
+
+bool FileSortWorker::checkAndUpdateFileInfoUpdate()
+{
+    if (sortRole != DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault || !mimeSorting)
+        return true;
+
+    QList<FileItemDataPointer> items;
+    {
+        QReadLocker lk(&childrenDataLocker);
+        items = childrenDataMap.values();
+    }
+
+    for (auto item : items) {
+        if (!mimeSorting) {
+            waitUpdatedFiles.clear();
+            if (isCanceled)
+                emit reqUestCloseCursor();
+            return !isCanceled;
+        }
+        auto info = item->fileInfo();
+        if (info.isNull() || !info->extendAttributes(ExtInfoType::kFileNeedTransInfo).toBool())
+            continue;
+        if (!info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool())
+            waitUpdatedFiles.insert(info->fileUrl());
+        item->data(Global::ItemRoles::kItemUpdateAndTransFileInfoRole);
+    }
+
+    if (!waitUpdatedFiles.isEmpty())
+        return false;
+
+    return true;
+}
+
+void FileSortWorker::checkAndSortBytMimeType(const QUrl &url)
+{
+    Q_ASSERT(QThread::currentThread() != qApp->thread());
+    if (!mimeSorting || isCanceled)
+        return;
+    if (waitUpdatedFiles.contains(url))
+        waitUpdatedFiles.remove(url);
+
+    if (waitUpdatedFiles.count() <= 0) {
+        mimeSorting = false;
+        emit requestSortByMimeType();
+    }
 }

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.h
@@ -83,12 +83,15 @@ signals:
     void getSourceData(const QString &key);
 
     void requestUpdateView();
+    void requestCursorWait();
+    void reqUestCloseCursor();
 
     // Note that the slot functions here are executed in asynchronous threads,
     // so the link can only be Qt:: QueuedConnection,
     // which cannot be directly called elsewhere, but can only be triggered by signals
 signals:
     void requestUpdateTimerStart();
+    void requestSortByMimeType();
 
 public slots:
     // Receive all local files of iteration of iterator thread, perform filtering and sorting
@@ -133,6 +136,7 @@ public slots:
     void handleClearThumbnail();
     void handleFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg);
     void handleUpdateRefreshFiles();
+    void handleSortByMimeType();
 
     // treeview solts
 public slots:
@@ -201,16 +205,18 @@ private:
     int indexOfVisibleChild(const QUrl &itemUrl);
     int setVisibleChildren(const int startPos, const QList<QUrl> &filterUrls,
                             const InsertOpt opt = InsertOpt::kInsertOptAppend, const int endPos = -1);
+    bool checkAndUpdateFileInfoUpdate();
+    void checkAndSortBytMimeType(const QUrl &url);
 
 private:
     QUrl current;
     QStringList nameFilters {};
     QDir::Filters filters { QDir::NoFilter };
     QDirIterator::IteratorFlags flags { QDirIterator::NoIteratorFlags };
-    QMap<QUrl, QMap<QUrl, SortInfoPointer>> children {};
+    QHash<QUrl, QHash<QUrl, SortInfoPointer>> children {};
     QReadWriteLock childrenDataLocker;
-    QMap<QUrl, FileItemDataPointer> childrenDataMap {};
-    QMap<QUrl, FileItemDataPointer> childrenDataLastMap {};
+    QHash<QUrl, FileItemDataPointer> childrenDataMap {};
+    QHash<QUrl, FileItemDataPointer> childrenDataLastMap {};
     QList<QUrl> visibleChildren {};
     QReadWriteLock locker;
     AbstractSortFilterPointer sortAndFilter { nullptr };
@@ -224,12 +230,14 @@ private:
     std::atomic_bool isCanceled { false };
     bool isMixDirAndFile { false };
     char placeholderMemory[4];
-    QMap<QUrl, QList<QUrl>> visibleTreeChildren{};
+    QHash<QUrl, QList<QUrl>> visibleTreeChildren{};
     QMultiMap<int8_t, QUrl> depthMap;
     std::atomic_bool istree;
     std::atomic_bool currentSupportTreeView {false};
     QList<QUrl> fileInfoRefresh;
     QTimer *updateRefresh {nullptr};
+    std::atomic_bool mimeSorting{ false };
+    QSet<QUrl> waitUpdatedFiles;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/mastered/masteredmediadiriterator.cpp
@@ -112,8 +112,6 @@ const FileInfoPointer MasteredMediaDirIterator::fileInfo() const
         infoTrans->setExtendedAttributes(ExtInfoType::kFileIsHid, isHidden);
         infoTrans->setExtendedAttributes(ExtInfoType::kFileLocalDevice, false);
         infoTrans->setExtendedAttributes(ExtInfoType::kFileCdRomDevice, false);
-        emit InfoCacheController::instance().removeCacheFileInfo({ url });
-        emit InfoCacheController::instance().cacheFileInfo(url, infoTrans);
     } else {
         fmWarning() << "MasteredMediaFileInfo: info is nullptr, url = " << url;
         //bug 64941, DVD+RW 只擦除文件系统部分信息，而未擦除全部，有垃圾数据，所以需要判断文件的有效性

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/iterator/iteratorsearcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/iterator/iteratorsearcher.cpp
@@ -81,6 +81,9 @@ void IteratorSearcher::doSearch()
         if (!iterator)
             continue;
 
+        iterator->setQueryAttributes("standard::name,standard::type,standard::size,\
+                                     standard::size,standard::is-symlink,standard::symlink-target,access::*,time::*");
+
         // 仅在过滤目录下进行搜索时，过滤目录下的内容才能被检索
         if (dfmbase::FileUtils::isLocalFile(url)) {
             QRegExp reg(kFilterFolders);
@@ -111,8 +114,9 @@ void IteratorSearcher::doSearch()
             if (match.hasMatch()) {
                 const auto &fileUrl = info->urlOf(UrlInfoType::kUrl);
                 {
+                    info->updateAttributes();
                     QMutexLocker lk(&mutex);
-                    allResults << fileUrl;
+                    allResults << fileUrl;                   
                 }
 
                 //推送

--- a/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileiterator.cpp
@@ -84,16 +84,13 @@ const FileInfoPointer VaultFileIterator::fileInfo() const
         infoTrans->setExtendedAttributes(ExtInfoType::kFileIsHid, isHidden);
         infoTrans->setExtendedAttributes(ExtInfoType::kFileLocalDevice, false);
         infoTrans->setExtendedAttributes(ExtInfoType::kFileCdRomDevice, false);
-        emit InfoCacheController::instance().removeCacheFileInfo({url});
-        emit InfoCacheController::instance().cacheFileInfo(url, infoTrans);
+        InfoFactory::cacheFileInfo(infoTrans);
     } else {
         fmWarning() << "Vault: info is nullptr, url = " << url;
         return  InfoFactory::create<FileInfo>(fileUrl());
     }
 
     FileInfoPointer vaultInfo(new VaultFileInfo(fileUrl(), infoTrans));
-    emit InfoCacheController::instance().removeCacheFileInfo({fileUrl()});
-    emit InfoCacheController::instance().cacheFileInfo(fileUrl(), vaultInfo);
     return vaultInfo;
 }
 


### PR DESCRIPTION
When iterating on files outside the disk, the search for file information decreases, and other information is only queried when it needs to be displayed

Log: dde-file-manager Open Out of Drive Folder Load Time Optimization
Task: https://pms.uniontech.com/task-view-359087.html