### PR TITLE
fix: dde-file-manager crash, search crash

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
@@ -159,9 +159,7 @@ void CrumbInterface::onUpdateChildren(QList<QUrl> children)
     QStringList list;
 
     for (const auto &child : children) {
-        auto info = InfoFactory::create<FileInfo>(child);
-        if (info)
-            list.append(info->nameOf(NameInfoType::kFileName));
+        list.append(child.fileName());
     }
     emit completionFound(list);
 }

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventcaller.cpp
@@ -6,6 +6,7 @@
 #include "utils/searchhelper.h"
 
 #include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -34,7 +35,8 @@ void SearchEventCaller::sendStartSpinner(quint64 winId)
 
 void SearchEventCaller::sendStopSpinner(quint64 winId)
 {
-    dpfSlotChannel->push("dfmplugin_titlebar", "slot_Spinner_Stop", winId);
+    if (dfmbase::FileManagerWindowsManager::instance().findWindowById(winId))
+        dpfSlotChannel->push("dfmplugin_titlebar", "slot_Spinner_Stop", winId);
 }
 
 }


### PR DESCRIPTION
if window not exists, don't send sendStopSpinner event

Log: dde-file-manager crash, search crash
Bug: https://pms.uniontech.com/task-view-358757.html