### PR TITLE
fix: Copy and paste the file to the root directory of FTP mount with an error message. After switching directories, an unknown file will be generated upon return

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/rootinfo.cpp
@@ -9,6 +9,7 @@
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/device/deviceutils.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -231,7 +232,7 @@ void RootInfo::doWatcherEvent()
             if (!adds.isEmpty())
                 addChildren(adds);
             if (!updates.isEmpty())
-                updateChildren(updates); 
+                updateChildren(updates);
             if (!removes.isEmpty())
                 removeChildren(removes);
 
@@ -426,6 +427,8 @@ void RootInfo::addChildren(const QList<QUrl> &urlList)
 
     for (auto url : urlList) {
         url.setPath(url.path());
+        if (DeviceUtils::isFtp(url) && !DFMIO::DFile(url).exists())
+            continue;
 
         auto child = fileInfo(url);
 


### PR DESCRIPTION
Received FTP creation information, but FTP remote creation failed as the file does not exist. Modify to check if a file exists when adding a child

Log: Copy and paste the file to the root directory of FTP mount with an error message. After switching directories, an unknown file will be generated upon return
Bug: https://pms.uniontech.com/bug-view-269893.html