### PR TITLE
fix: After upgraded to version 1071, dde-file-manager monitor failed and memory continued to grow

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -112,7 +112,8 @@ enum CreateFileInfoType : uint8_t {
     kCreateFileInfoSync = 1,
     kCreateFileInfoAsync = 2,
     kCreateFileInfoSyncAndCache = 3,   // create file info Synchronize and cache file info
-    kCreateFileInfoAsyncAndCache = 4   // create file info Asynchronous and cache file info
+    kCreateFileInfoAsyncAndCache = 4,   // create file info Asynchronous and cache file info
+    kCreateFileInfoAutoNoCache = 5,   // auto can not cache file info, virtual schema will synchronize create file info
 };
 
 namespace Mime {

--- a/include/dfm-base/utils/infocache.h
+++ b/include/dfm-base/utils/infocache.h
@@ -68,7 +68,7 @@ private:
     void cacheInfo(const QUrl url, const FileInfoPointer info);
     void disconnectWatcher(const QMap<QUrl, FileInfoPointer> infos);
     void removeCaches(const QList<QUrl> urls);
-    void updateSortTimeWorker(const QUrl url);
+    bool updateSortTimeWorker(const QUrl url);
     void timeRemoveCache();
     void removeInfosTimeWorker(const QList<QUrl> urls);
 

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -73,8 +73,6 @@ FileInfoPointer LocalDirIteratorPrivate::fileInfo(const QSharedPointer<DFileInfo
     if (infoTrans) {
         infoTrans->setExtendedAttributes(ExtInfoType::kFileIsHid, isHidden);
         infoTrans->setExtendedAttributes(ExtInfoType::kFileCdRomDevice, isCdRomDevice);
-        emit InfoCacheController::instance().removeCacheFileInfo({url});
-        emit InfoCacheController::instance().cacheFileInfo(url, infoTrans);
     } else {
         qCWarning(logDFMBase) << "info is nullptr url = " << url;
     }

--- a/src/dfm-base/utils/private/infocache_p.h
+++ b/src/dfm-base/utils/private/infocache_p.h
@@ -31,7 +31,7 @@ class InfoCachePrivate
     QReadWriteLock copyLock;
 
     // 时间排序url,利用map的有序性，来处理时间到了要移除的url
-    QMap<QUrl, QString> urlTimeSortMap;
+    QHash<QUrl, QString> urlTimeSortHash;
     QMap<QString, QUrl> timeToUrlMap;
 
     std::atomic_bool cacheWorkerStoped { false };

--- a/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
@@ -105,6 +105,7 @@ SearchDirIterator::SearchDirIterator(const QUrl &url,
     : AbstractDirIterator(url, nameFilters, filters, flags),
       d(new SearchDirIteratorPrivate(url, this))
 {
+    setProperty("fileInfoNoCache", true);
 }
 
 SearchDirIterator::~SearchDirIterator()
@@ -156,7 +157,7 @@ const FileInfoPointer SearchDirIterator::fileInfo() const
     if (!d->currentFileUrl.isValid())
         return nullptr;
 
-    return InfoFactory::create<FileInfo>(d->currentFileUrl);
+    return InfoFactory::create<FileInfo>(d->currentFileUrl, Global::CreateFileInfoType::kCreateFileInfoAutoNoCache);
 }
 
 QUrl SearchDirIterator::url() const

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/fulltext/fulltextsearcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/fulltext/fulltextsearcher.cpp
@@ -114,7 +114,8 @@ void FullTextSearcherPrivate::doIndexTask(const IndexReaderPtr &reader, const In
         if (is_dir) {
             doIndexTask(reader, writer, fn, type);
         } else {
-            auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(fn));
+            auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(fn),
+                                                      Global::CreateFileInfoType::kCreateFileInfoSync);
             if (!info) continue;
 
             QString suffix = info->nameOf(NameInfoType::kSuffix);
@@ -196,7 +197,8 @@ bool FullTextSearcherPrivate::checkUpdate(const IndexReaderPtr &reader, const QS
             return true;
         } else {
             DocumentPtr doc = searcher->doc(topDocs->scoreDocs[0]->doc);
-            auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(file));
+            auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(file),
+                                                      Global::CreateFileInfoType::kCreateFileInfoSync);
             if (!info)
                 return false;
 
@@ -236,7 +238,8 @@ DocumentPtr FullTextSearcherPrivate::fileDocument(const QString &file)
     doc->add(newLucene<Field>(L"path", file.toStdWString(), Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
 
     // file last modified time
-    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(file));
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(file),
+                                              Global::CreateFileInfoType::kCreateFileInfoSync);
     const QDateTime &modifyTime { info->timeOf(TimeInfoType::kLastModified).toDateTime() };
     const QString &modifyEpoch { QString::number(modifyTime.toSecsSinceEpoch()) };
     doc->add(newLucene<Field>(L"modified", modifyEpoch.toStdWString(), Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
@@ -355,7 +358,8 @@ bool FullTextSearcherPrivate::doSearch(const QString &path, const QString &keywo
 
             if (!resultPath.empty()) {
                 const QUrl &url = QUrl::fromLocalFile(StringUtils::toUTF8(resultPath).c_str());
-                auto info = InfoFactory::create<FileInfo>(url);
+                auto info = InfoFactory::create<FileInfo>(url,
+                                                          Global::CreateFileInfoType::kCreateFileInfoSync);
                 // delete invalid index
                 if (!info || !info->exists()) {
                     indexDocs(writer, url.path(), kDeleteIndex);


### PR DESCRIPTION
Connect the signal of info time record and process the searched fileinfo without adding it to the cache

Log: After upgraded to version 1071, dde-file-manager monitor failed and memory continued to grow
Bug: https://pms.uniontech.com/bug-view-268167.html