### PR TITLE
fix: The right-click menu of the taskbar's trash is missing the 'clear' option

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.operations.json
+++ b/assets/configs/org.deepin.dde.file-manager.operations.json
@@ -29,7 +29,7 @@
             "serial":0,
             "flags":[],
             "name":"Broadcast file past event result",
-            "name[zh_CN]":"上报文件粘贴事假结果",
+            "name[zh_CN]":"上报文件粘贴事件结果",
             "description[zh_CN]":"打开此配置，上报粘贴事件的结果到指定位置",
             "description":"Open this configuration and report the results of the paste event to the specified location.",
             "permissions":"readwrite",

--- a/src/apps/dde-desktop/data/applications/dde-trash.desktop
+++ b/src/apps/dde-desktop/data/applications/dde-trash.desktop
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Actions=clean-trash;
 Categories=System;
 Comment=Open trash.
 Exec=dfm-open.sh trash:///
@@ -166,3 +167,11 @@ Name[zh_CN]=回收站
 Name[zh_HK]=回收站
 Name[zh_TW]=回收站
 
+[Desktop Action clean-trash]
+Exec=dde-file-manager --event "{\"action\":\"cleantrash\"}"
+Name=Clean Trash
+
+# Translations:
+# Do not manually modify!
+Name[zh_CN]=清空
+Name[zh_HK]=清空

--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -365,7 +365,8 @@ void CommandParser::processEvent()
         { "copy", GlobalEventType::kCopy },
         { "move", GlobalEventType::kCutFile },
         { "delete", GlobalEventType::kDeleteFiles },
-        { "trash", GlobalEventType::kMoveToTrash }
+        { "trash", GlobalEventType::kMoveToTrash },
+        { "cleantrash", GlobalEventType::kCleanTrash },
     };
 
     if (!eventMap.contains(argsInfo.action))
@@ -397,6 +398,13 @@ void CommandParser::processEvent()
                 || FileUtils::isTrashFile(srcUrls.first()))
             return;
         dpfSignalDispatcher->publish(GlobalEventType::kMoveToTrash, 0, srcUrls, AbstractJobHandler::JobFlag::kNoHint, nullptr);
+        break;
+    }
+    case GlobalEventType::kCleanTrash: {
+        dpfSignalDispatcher->publish(GlobalEventType::kCleanTrash,
+                                     0,
+                                     QList<QUrl>(),
+                                     AbstractJobHandler::DeleteDialogNoticeType::kEmptyTrash, nullptr);
         break;
     }
     default:

--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -42,6 +42,10 @@
 #    define DDE_LOCKSERVICE_SERVICE "org.deepin.dde.LockService1"
 #    define DDE_LOCKSERVICE_PATH "/org/deepin/dde/LockService1"
 #    define DDE_LOCKSERVICE_INTERFACE "org.deepin.dde.LockService1"
+
+#    define DESKTOP_FILEMONITOR_SERVICE "org.deepin.dde.desktop.filemonitor"
+#    define DESKTOP_FILEMONITOR_PATH "/org/deepin/dde/desktop/filemonitor"
+#    define DESKTOP_FILEMONITOR_INTERFACE "org.deepin.dde.desktop.filemonitor"
 #else
 #    define APP_MANAGER_SERVICE "com.deepin.SessionManager"
 #    define APP_MANAGER_PATH "/com/deepin/StartManager"


### PR DESCRIPTION
Add desktop actions in the desktop file and clean trash event handling in dde-file-manager

Log: The right-click menu of the taskbar's trash is missing the 'clear' option
Bug: https://pms.uniontech.com/bug-view-268949.html