### PR TITLE
fix: When entering a file name or renaming, no prompt message is displayed after entering special characters

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/itemeditor.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/itemeditor.cpp
@@ -120,6 +120,7 @@ void ItemEditor::showAlertMessage(const QString &text, int duration)
         tooltip->setBackgroundColor(palette().color(backgroundRole()));
         QTimer::singleShot(duration, this, [this] {
             if (tooltip) {
+                tooltip->setParent(nullptr);
                 tooltip->hide();
                 tooltip->deleteLater();
                 tooltip = nullptr;
@@ -132,7 +133,11 @@ void ItemEditor::showAlertMessage(const QString &text, int duration)
         label->adjustSize();
     }
 
-    QPoint pos = textEditor->mapToGlobal(QPoint(textEditor->width() / 2, textEditor->height()));
+    if (!this->window())
+        return;
+
+    QPoint pos = textEditor->mapTo(this->window(), QPoint(textEditor->width() / 2, textEditor->height()));
+    tooltip->setParent(this->window());
     tooltip->show(pos.x(), pos.y());
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemeditor.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemeditor.cpp
@@ -151,6 +151,7 @@ void IconItemEditor::showAlertMessage(const QString &text, int duration)
         d->tooltip->setBackgroundColor(palette().color(backgroundRole()));
         QTimer::singleShot(duration, this, [d] {
             if (d->tooltip) {
+                d->tooltip->setParent(nullptr);
                 d->tooltip->hide();
                 d->tooltip->deleteLater();
                 d->tooltip = nullptr;
@@ -163,8 +164,13 @@ void IconItemEditor::showAlertMessage(const QString &text, int duration)
         label->adjustSize();
     }
 
-    QPoint pos = this->mapToGlobal(QPoint(this->width() / 2, this->height()));
-    d->tooltip->show(pos.x(), pos.y());
+    if (!this->window())
+        return;
+
+    QPoint pos = this->mapTo(this->window(), QPoint(this->width() / 2 + 16, this->height()));
+    d->tooltip->setParent(this->window());
+    d->tooltip->show(pos.x(),
+                     pos.y());
 }
 
 void IconItemEditor::popupEditContentMenu()

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemeditor.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemeditor.cpp
@@ -49,6 +49,7 @@ void ListItemEditor::showAlertMessage(const QString &text, int duration)
         tooltip->setBackgroundColor(palette().color(backgroundRole()));
         QTimer::singleShot(duration, this, [this] {
             if (tooltip) {
+                tooltip->setParent(nullptr);
                 tooltip->hide();
                 tooltip->deleteLater();
                 tooltip = nullptr;
@@ -61,7 +62,10 @@ void ListItemEditor::showAlertMessage(const QString &text, int duration)
         label->adjustSize();
     }
 
-    QPoint pos = this->mapToGlobal(QPoint(this->width() / 2, this->height()));
+    if (!this->window())
+        return;
+    QPoint pos = this->mapTo(this->window(), QPoint(this->width() / 2, this->height()));
+    tooltip->setParent(this->window());
     tooltip->show(pos.x(), pos.y());
 }
 


### PR DESCRIPTION
The lack of a parent window in the tooltip resulted in loss of focus

Log: When entering a file name or renaming, no prompt message is displayed after entering special characters
Bug: https://pms.uniontech.com/bug-view-267147.html