### PR TITLE
fix: no permission to execute dde-file-manager on NixOS

### DIFF
--- a/src/apps/dde-file-manager/CMakeLists.txt
+++ b/src/apps/dde-file-manager/CMakeLists.txt
@@ -56,7 +56,7 @@ install(FILES dde-open.desktop DESTINATION share/applications)
 
 # pkexec
 install(FILES pkexec/com.deepin.pkexec.dde-file-manager.policy DESTINATION share/polkit-1/actions/)
-install(FILES pkexec/dde-file-manager-pkexec DESTINATION bin)
+install(PROGRAMS pkexec/dde-file-manager-pkexec DESTINATION bin)
 
 # manual
 install(DIRECTORY assets/dde-file-manager DESTINATION share/deepin-manual/manual-assets/application)

--- a/src/dfm-base/CMakeLists.txt
+++ b/src/dfm-base/CMakeLists.txt
@@ -184,7 +184,7 @@ install(FILES ${DLNFS_SCRIPT_LAUNCHER} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X
 set(DFM_DLNFS_SCRIPT_LAUNCHER
     ${AssetsPath}/scripts/dde-file-manager
     ${AssetsPath}/scripts/file-manager.sh)
-install(FILES ${DFM_DLNFS_SCRIPT_LAUNCHER} DESTINATION bin)
+install(PROGRAMS ${DFM_DLNFS_SCRIPT_LAUNCHER} DESTINATION bin)
 
 set(Mimetypes "${ShareDir}/mimetypes")
 FILE(GLOB MIMETYPE_FILES ${AssetsPath}/mimetypes/*)


### PR DESCRIPTION
log: In the new version of cmake, install FILES will automatically delete the executable permission, so the PERMISSIONS field must be declared.
A better way is use PROGRAMS form, it is identical to the FILES form except that the default permissions for the installed file also include OWNER_EXECUTE, GROUP_EXECUTE, and WORLD_EXECUTE. This form is intended to install programs that are not targets, such as shell scripts. Use the TARGETS form to install targets built within the project.

https://cmake.org/cmake/help/latest/command/install.html