### PR TITLE
fix: Create new text in the SMB server, double-click to open the text editor and edit the text

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -883,7 +883,7 @@ bool FileOperationsEventReceiver::handleOperationOpenFiles(const quint64 windowI
                 dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kMoveToTrash, windowId, fileHandler.getInvalidPath(), AbstractJobHandler::JobFlag::kNoHint, nullptr);
         } else {
             // deal open file with custom dialog
-            dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", windowId, fileHandler.getInvalidPath());
+            dpfSlotChannel->push("dfmplugin_utils", "slot_OpenWith_ShowDialog", windowId, urls);
             ok = true;
         }
     }


### PR DESCRIPTION
The mimetype method for reading files is inconsistent, and the parameters passed in using openwithdialog are incorrect

Log: Create new text in the SMB server, double-click to open the text editor and edit the text
Bug: https://pms.uniontech.com/bug-view-267705.html