### PR TITLE
fix: [desktop] crash in some case.

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -224,6 +224,10 @@ void NormalizedModePrivate::connectCollectionSignals(CollectionHolderPointer col
                 });
         dpfSignalDispatcher->subscribe("ddplugin_background", "signal_Background_BackgroundSetted",
                                        collection->widget(), &CollectionWidget::cacheSnapshot);
+        connect(collection->widget(), &QWidget::destroyed, this, [](QObject *obj) {
+            dpfSignalDispatcher->unsubscribe("ddplugin_background", "signal_Background_BackgroundSetted",
+                                             obj, &CollectionWidget::cacheSnapshot);
+        });
     }
 }
 


### PR DESCRIPTION
1. uncheck an organized collection;
2. change the wallpaper;
3. crash.

the event is not unsubscribed when collection removed at step 1, when
the wallpaper event emitted, the event handler executed with nullptr,
cause crash.
unsubscribe signal when collection destroyed.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-271449.html
