### PR TITLE
fix: [desktop] the view setting dialog lost focus

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/options/organizationgroup.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/organizationgroup.cpp
@@ -99,7 +99,8 @@ QLayout *OrganizationGroup::buildTypeLayout()
     for (QWidget *wid : list) {
         wid->setFixedHeight(kCheckEntryHeight);
         gridLayout->addWidget(wid, row, col, Qt::AlignTop);
-        wid->setVisible(true);   // requiring widget to be visible when layout calculates sizehint.
+        // this line makes the setting widget lose focus, Commenting this line seems to have no effect
+        // wid->setVisible(true);   // requiring widget to be visible when layout calculates sizehint.
         ++index;
         row = index / 3;
         col = index % 3;


### PR DESCRIPTION
as title.

Log: as title.

Bug: https://pms.uniontech.com/bug-view-271953.html
