### PR TITLE
fix: The sorting function of the right-click menu and the header sorting function are inconsistent

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
@@ -221,8 +221,11 @@ void SortAndDisplayMenuScenePrivate::sortByRole(int role)
 {
     auto itemRole = static_cast<Global::ItemRoles>(role);
     Qt::SortOrder order = view->model()->sortOrder();
+    auto oldRole = view->model()->sortRole();
+    order = oldRole != role ? Qt::AscendingOrder
+                            : order == Qt::AscendingOrder ? Qt::DescendingOrder : Qt::AscendingOrder;
 
-    view->setSort(itemRole, order == Qt::AscendingOrder ? Qt::DescendingOrder : Qt::AscendingOrder);
+    view->setSort(itemRole, order);
 }
 
 void SortAndDisplayMenuScenePrivate::updateEmptyAreaActionState()


### PR DESCRIPTION
Modify the judgment of right-click sorting

Log: The sorting function of the right-click menu and the header sorting function are inconsistent
Bug: https://pms.uniontech.com/bug-view-271259.html