### PR TITLE
fix: Open multiple trash windows, window A enters the trash folder, window B deletes or restores the folder, window A returns to the computer path

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -403,6 +403,7 @@ QUrl FileUtils::trashRootUrl()
     QUrl url;
     url.setScheme(DFMBASE_NAMESPACE::Global::Scheme::kTrash);
     url.setPath("/");
+    url.setHost("");
     return url;
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
@@ -159,6 +159,7 @@ void Trash::followEvents()
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles", TrashHelper::instance(), &TrashHelper::customColumnRole);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Model_FetchCustomRoleDisplayName", TrashHelper::instance(), &TrashHelper::customRoleDisplayName);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_PasteFiles", TrashFileHelper::instance(), &TrashFileHelper::blockPaste);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_Tab_FileDeleteNotCdComputer", TrashFileHelper::instance(), &TrashFileHelper::handleNotCdComputer);
 
     // hook events, file operation
     dpfHookSequence->follow("dfmplugin_fileoperations", "hook_Operation_CutToFile", TrashFileHelper::instance(), &TrashFileHelper::cutFile);

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -165,3 +165,16 @@ bool TrashFileHelper::handleIsSubFile(const QUrl &parent, const QUrl &sub)
 
     return sub.path().contains(parent.path());
 }
+
+bool TrashFileHelper::handleNotCdComputer(const QUrl &url, QUrl *cdUrl)
+{
+    if (url.scheme() != scheme())
+        return false;
+
+    if (!cdUrl)
+        return false;
+
+    // 回收站中只能最上层目录可以删除和还原，那么它们的父目录都是回收站
+    *cdUrl = FileUtils::trashRootUrl();
+    return true;
+}

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.h
@@ -39,10 +39,11 @@ public:
     bool disableOpenWidgetWidget(const QUrl &url, bool *result);
     bool handleCanTag(const QUrl &url, bool *canTag);
     bool handleIsSubFile(const QUrl &parent, const QUrl &sub);
+    bool handleNotCdComputer(const QUrl &url, QUrl *cdUrl);
 
 private:
     explicit TrashFileHelper(QObject *parent = nullptr);
 };
 DPTRASH_END_NAMESPACE
-
+Q_DECLARE_METATYPE(QUrl *);
 #endif   // TRASHFILEHELPER_H

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.cpp
@@ -192,9 +192,12 @@ void TabBar::closeTab(quint64 winId, const QUrl &url)
         if (closeable || DFMBASE_NAMESPACE::UniversalUtils::urlEquals(curUrl, url) || url.isParentOf(curUrl)) {
             if (count() == 1) {
                 QUrl redirectToWhenDelete;
-                if (isMountedDevPath(url) || url.scheme() != Global::Scheme::kFile) {
+                if (isMountedDevPath(url)) {
                     redirectToWhenDelete = kGotoWhenDevRemoved;
-                } else {   // redirect to upper directory
+                } else if (dpfHookSequence->run("dfmplugin_workspace", "hook_Tab_FileDeleteNotCdComputer", curUrl, &redirectToWhenDelete)) {
+                    if (!redirectToWhenDelete.isValid())
+                        redirectToWhenDelete = kGotoWhenDevRemoved;
+                } else if (url.scheme() == Global::Scheme::kFile){   // redirect to upper directory
                     QString localPath = url.path();
                     do {
                         QStringList pathFragment = localPath.split("/");
@@ -225,6 +228,8 @@ void TabBar::closeTab(quint64 winId, const QUrl &url)
                         if (kGvfsMpts.contains(localPath))
                             redirectToWhenDelete = kGotoWhenDevRemoved;
                     }
+                } else {
+                    redirectToWhenDelete = kGotoWhenDevRemoved;
                 }
 
                 dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, winId, redirectToWhenDelete);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/tabbar.h
@@ -100,4 +100,6 @@ private:
 
 }
 
+Q_DECLARE_METATYPE(QUrl*);
+
 #endif   // TABBAR_H

--- a/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/workspace.h
@@ -86,6 +86,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_HOOK(hook_Tab_SetTabName)
     DPF_EVENT_REG_HOOK(hook_Tab_Closeable)
     DPF_EVENT_REG_HOOK(hook_Tab_Allow_Repeat_Url)
+    DPF_EVENT_REG_HOOK(hook_Tab_FileDeleteNotCdComputer)
 
     DPF_EVENT_REG_HOOK(hook_DragDrop_CheckDragDropAction)
     DPF_EVENT_REG_HOOK(hook_DragDrop_FileDragMove)


### PR DESCRIPTION
Add hook event to determine whether to jump to the computer interface

Log: Open multiple trash windows, window A enters the trash folder, window B deletes or restores the folder, window A returns to the computer path
Bug: https://pms.uniontech.com/bug-view-270855.html