### PR TITLE
fix: [title-bar] The right distance is too small on title bar

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -129,7 +129,7 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
         if (d->detailButton->isChecked())
             d->detailButton->click();
 
-        if (state & OptionButtonManager::kHideAllBtn)
+        if (state == OptionButtonManager::kHideAllBtn)
             setContentsMargins(0, 0, 0, 0);
         else
             setContentsMargins(5, 0, 15, 0);


### PR DESCRIPTION
1. UI change, the right distance is too small on title bar.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-253175.html