### PR TITLE
fix: The right-click menu of the dock bar icon displays dde desktop

### DIFF
--- a/src/apps/dde-desktop/CMakeLists.txt
+++ b/src/apps/dde-desktop/CMakeLists.txt
@@ -51,5 +51,6 @@ install(FILES data/applications/dfm-open.sh DESTINATION bin/)
 install(FILES data/applications/dde-computer.desktop DESTINATION share/applications/)
 install(FILES data/applications/dde-trash.desktop DESTINATION share/applications/)
 install(FILES data/applications/dde-home.desktop DESTINATION share/applications/)
+install(FILES data/applications/dde-desktop.desktop DESTINATION share/applications)
 
 

--- a/src/apps/dde-desktop/data/applications/dde-desktop.desktop
+++ b/src/apps/dde-desktop/data/applications/dde-desktop.desktop
@@ -1,0 +1,21 @@
+[Desktop Entry]
+Categories=System;
+Comment=Show the desktop
+Exec=dde-desktop
+GenericName=Desktop
+Icon=dde-file-manager
+Name=Desktop
+OnlyShowIn=Deepin;DDE
+Terminal=false
+Type=Application
+X-AppStream-Ignore=true
+X-Deepin-AppID=dde-desktop
+
+# Translations:
+# Do not manually modify!
+GenericName[da]=Desktop
+GenericName[de]=Desktop
+GenericName[zh_CN]=桌面
+
+Name[zh_CN]=桌面
+


### PR DESCRIPTION
Add dde-desktop.desktop file to translate dde-desktop

Log: The right-click menu of the dock bar icon displays dde desktop
Bug: https://pms.uniontech.com/bug-view-251773.html