### PR TITLE
fix: Cannot completely delete directories with subdirectories and subfiles

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -143,7 +143,7 @@ void FileStatisticsJobPrivate::processFile(const FileInfoPointer &fileInfo, cons
             }
 
             const auto &symLinkTargetUrl = QUrl::fromLocalFile(info->pathOf(PathInfoType::kSymLinkTarget));
-            if (sizeInfo->allFiles.contains(symLinkTargetUrl) || fileStatistics.contains(symLinkTargetUrl)) {
+            if (allFiles.contains(symLinkTargetUrl) || fileStatistics.contains(symLinkTargetUrl)) {
                 return;
             }
             fileStatistics << symLinkTargetUrl;
@@ -179,7 +179,7 @@ void FileStatisticsJobPrivate::processFile(const FileInfoPointer &fileInfo, cons
             auto isSyslink = info->isAttributes(OptInfoType::kIsSymLink);
             if (isSyslink) {
                 const auto &symLinkTargetUrl = QUrl::fromLocalFile(info->pathOf(PathInfoType::kSymLinkTarget));
-                if (sizeInfo->allFiles.contains(symLinkTargetUrl) || fileStatistics.contains(symLinkTargetUrl)) {
+                if (allFiles.contains(symLinkTargetUrl) || fileStatistics.contains(symLinkTargetUrl)) {
                     return;
                 }
                 fileStatistics << symLinkTargetUrl;
@@ -433,10 +433,11 @@ void FileStatisticsJob::statistcsOtherFileSystem()
                 return;
             }
             // The files counted are not counted
-            if (d->sizeInfo->allFiles.contains(url))
+            if (d->allFiles.contains(url))
                 continue;
 
             d->sizeInfo->allFiles << url;
+            d->allFiles.insert(url);
             FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
 
             if (!info) {
@@ -460,7 +461,7 @@ void FileStatisticsJob::statistcsOtherFileSystem()
 
                 const auto &symLinkTargetUrl = QUrl::fromLocalFile(info->pathOf(PathInfoType::kSymLinkTarget));
                 // The files counted are not counted
-                if (d->fileStatistics.contains(symLinkTargetUrl) || d->sizeInfo->allFiles.contains(symLinkTargetUrl))
+                if (d->fileStatistics.contains(symLinkTargetUrl) || d->allFiles.contains(symLinkTargetUrl))
                     continue;
 
                 info = InfoFactory::create<FileInfo>(symLinkTargetUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
@@ -483,6 +484,7 @@ void FileStatisticsJob::statistcsOtherFileSystem()
             d->fileHints = d->fileHints | kDontSkipAVFSDStorage | kDontSkipPROCStorage;
             d->processFile(url, followLink, directory_queue);
             d->sizeInfo->allFiles << url;
+            d->allFiles.insert(url);
             d->fileHints = save_file_hints;
 
             if (!d->stateCheck()) {
@@ -515,11 +517,12 @@ void FileStatisticsJob::statistcsOtherFileSystem()
         while (d->iterator->hasNext()) {
             QUrl url = d->iterator->next();
             // The files counted are not counted
-            if (d->sizeInfo->allFiles.contains(url))
+            if (d->allFiles.contains(url))
                 continue;
 
             d->processFile(url, followLink, directory_queue);
             d->sizeInfo->allFiles << url;
+            d->allFiles.insert(url);
 
             if (!d->stateCheck()) {
                 d->setState(kStoppedState);

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -21,7 +21,7 @@ public:
         qint64 totalSize { 0 };
         quint16 dirSize { 0 };
         quint32 fileCount { 0 };
-        QSet<QUrl> allFiles;
+        QList<QUrl> allFiles;
     };
 
 public:

--- a/src/dfm-base/utils/private/filestatissticsjob_p.h
+++ b/src/dfm-base/utils/private/filestatissticsjob_p.h
@@ -47,6 +47,7 @@ public:
     QAtomicInt directoryCount { 0 };
     SizeInfoPointer sizeInfo { nullptr };
     QSet<QUrl> fileStatistics;
+    QSet<QUrl> allFiles;
     QSet<QString> skipPath;
     QSet<quint64> inodelist;
     AbstractDirIteratorPointer iterator { nullptr };

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -251,8 +251,7 @@ bool AbstractWorker::statisticsFilesSize()
 
     if (isSourceFileLocal) {
         const SizeInfoPointer &fileSizeInfo = FileOperationsUtils::statisticsFilesSize(sourceUrls, true);
-        for (const auto &url : fileSizeInfo->allFiles)
-            allFilesList.append(url);
+        allFilesList = fileSizeInfo->allFiles;
         sourceFilesTotalSize = fileSizeInfo->totalSize;
         workData->dirSize = fileSizeInfo->dirSize;
         sourceFilesCount = fileSizeInfo->fileCount;
@@ -555,8 +554,7 @@ void AbstractWorker::onStatisticsFilesSizeFinish()
     sourceFilesTotalSize = statisticsFilesSizeJob->totalProgressSize();
     workData->dirSize = sizeInfo->dirSize;
     sourceFilesCount = sizeInfo->fileCount;
-    for (const auto &url : sizeInfo->allFiles)
-        allFilesList.append(url);
+    allFilesList = sizeInfo->allFiles;
 }
 
 void AbstractWorker::onStatisticsFilesSizeUpdate(qint64 size)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -120,7 +120,7 @@ void FileOperationsUtils::statisticFilesSize(const QUrl &url,
 
         // url record
         if (isRecordUrl && flag != FTS_DP)
-            sizeInfo->allFiles.insert(curUrl);
+            sizeInfo->allFiles.append(curUrl);
 
         // file counted
         if (flag == FTS_F || flag == FTS_SL || flag == FTS_SLNONE)


### PR DESCRIPTION
QSET did not add URLs in an orderly manner during the complete deletion, resulting in files remaining in the directory but still being deleted

Log: Cannot completely delete directories with subdirectories and subfiles