### PR TITLE
fix: Trash select all files, right-click to view properties, inaccurate total file count

### DIFF
--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -249,8 +249,8 @@ public:
         kStandardFileExists = 20,   // bool
         kStandardIsLocalDevice = 21,   // bool
         kStandardIsCdRomDevice = 22,   // bool
-        kStandardFileType = 22,   // FileInfo::FileType
-        kOriginalUri = 23, // original uri
+        kStandardFileType = 23,   // FileInfo::FileType
+        kOriginalUri = 24, // original uri
 
         kEtagValue = 40,   // string
 

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -533,16 +533,6 @@ void AsyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> 
         d->updateThumbnail(url);
     }
 
-    // 更新fileicon
-    if (typeAll.contains(FileInfoAttributeID::kStandardIcon)) {
-        typeAll.removeOne(FileInfoAttributeID::kStandardIcon);
-        // 再在缓存和正在查询都不调用，缓存时会去调用
-        if (!d->cacheingAttributes && !d->queringAttribute) {
-            QWriteLocker wlk(&d->iconLock);
-            d->fileIcon = QIcon();
-        }
-    }
-
     // 更新filecount
     if (typeAll.contains(FileInfoAttributeID::kFileCount)) {
         typeAll.removeOne(FileInfoAttributeID::kFileCount);
@@ -1057,7 +1047,7 @@ FileInfo::FileType AsyncFileInfoPrivate::fileType() const
     const QString &absoluteFilePath = filePath();
     const QByteArray &nativeFilePath = QFile::encodeName(absoluteFilePath);
     QT_STATBUF statBuffer;
-    auto fileMode = attribute(DFileInfo::AttributeID::kStandardType).toUInt();
+    auto fileMode = attribute(DFileInfo::AttributeID::kUnixMode).toUInt();
     if (fileMode <= 0 || QT_STAT(nativeFilePath.constData(), &statBuffer) != 0)
         return fileType;
     fileMode = fileMode <= 0 ? statBuffer.st_mode : fileMode;


### PR DESCRIPTION
The key value for the unix:: mode and filetype in gio corresponding to st_mode in stat is incorrect

Log: Trash select all files, right-click to view properties, inaccurate total file count
Bug: https://pms.uniontech.com/bug-view-270935.html