### PR TITLE
refactor: [sercurity] AccessControlDBus::Chmod

### DIFF
--- a/src/plugins/daemon/daemonplugin-accesscontrol/accesscontroldbus.cpp
+++ b/src/plugins/daemon/daemonplugin-accesscontrol/accesscontroldbus.cpp
@@ -260,17 +260,17 @@ void AccessControlDBus::ChangeDiskPassword(const QString &oldPwd, const QString 
 
 bool AccessControlDBus::Chmod(const QString &path, uint mode)
 {
+    if (!checkAuthentication("com.deepin.filemanager.daemon.AccessControlManager.Chmod")) {
+        fmWarning() << "authenticate failed to change permission of" << path;
+        return false;
+    }
+
     if (path.isEmpty())
         return false;
 
     QFile f(path);
     if (!f.exists()) {
         fmWarning() << "file not exists" << path;
-        return false;
-    }
-
-    if (!checkAuthentication("com.deepin.filemanager.daemon.AccessControlManager.Chmod")) {
-        fmWarning() << "authenticate failed to change permission of" << path;
         return false;
     }
 


### PR DESCRIPTION
There is a file existence check issue in there. If the file doesn't exist, then the call exists early without authenticating.

Log: sercurity