### PR TITLE
fix: The problem of incorrect scrollbars in the content area when adjusting the window size in grid view

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -1192,7 +1192,9 @@ bool FileView::edit(const QModelIndex &index, QAbstractItemView::EditTrigger tri
 
 void FileView::resizeEvent(QResizeEvent *event)
 {
+    d->isResizeEvent = true;
     DListView::resizeEvent(event);
+    d->isResizeEvent = false;
 
     updateHorizontalOffset();
 
@@ -1456,14 +1458,16 @@ void FileView::updateGeometries()
 #ifdef DTKWIDGET_CLASS_DSizeMode
         iconVerticalTopMargin = DSizeModeHelper::element(kCompactIconVerticalTopMargin, kIconVerticalTopMargin);
 #endif
-        resizeContents(contentsSize().width(), contentsSize().height() + iconVerticalTopMargin);
+        if (!d->isResizeEvent
+                || (d->isResizeEvent && d->lastContentHeight > 0 && d->lastContentHeight != contentsSize().height()))
+            resizeContents(contentsSize().width(), contentsSize().height() + iconVerticalTopMargin);
+        d->lastContentHeight = contentsSize().height();
     }
     if (!d->headerView || !d->allowedAdjustColumnSize) {
         return DListView::updateGeometries();
     }
 
     resizeContents(d->headerView->length(), contentsSize().height());
-
     DListView::updateGeometries();
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.h
@@ -64,6 +64,8 @@ class FileViewPrivate
     int horizontalOffset { 0 };
     int cachedViewWidth { -1 };
     bool isShowViewSelectBox { false };
+    bool isResizeEvent { false };
+    int lastContentHeight { 0 };
 
     QList<QUrl> preSelectionUrls;
     QTimer *preSelectTimer { nullptr };


### PR DESCRIPTION
When adjusting the window size, I kept increasing the contentsize

Log: The problem of incorrect scrollbars in the content area when adjusting the window size in grid view
Bug: https://pms.uniontech.com/bug-view-253883.html