### PR TITLE
fix: [lnfs] maintain two mounting methods for long file names

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -112,7 +112,29 @@
             "permissions":"readwrite",
             "visibility":"private"
         },
-        "dfm.mount.lnfs": {
+        "dfm.mount.ulnfs": {
+            "value":false,
+            "serial":0,
+            "flags":[],
+            "name":"Extend characters of file names by ulnfs",
+            "name[zh_CN]":"扩展文件名字符数",
+            "description[zh_CN]":"扩展文件名字符数需重启后才能生效",
+            "description":"To extend characters of file names, you should restart to make the configuration effective.",
+            "permissions":"readwrite",
+            "visibility":"private"
+        },
+        "dfm.mount.ulnfs.defaults": {
+            "value":["$HOME"],
+            "serial":0,
+            "flags":[],
+            "name":"Dirs that support long file names by ulnfs",
+            "name[zh_CN]":"启用长文件名扩展的目录",
+            "description[zh_CN]":"默认启用长文件名扩展的目录",
+            "description":"Dirs that support long file names by default.",
+            "permissions":"readwrite",
+            "visibility":"private"
+        },
+        "dfm.mount.dlnfs": {
             "value":false,
             "serial":0,
             "flags":[],
@@ -120,6 +142,17 @@
             "name[zh_CN]":"扩展文件名字符数",
             "description[zh_CN]":"扩展文件名字符数需重启后才能生效",
             "description":"To extend characters of file names, you should restart to make the configuration effective.",
+            "permissions":"readwrite",
+            "visibility":"private"
+        },
+        "dfm.mount.dlnfs.defaults": {
+            "value":["$HOME/Desktop", "$HOME/Music", "$HOME/Pictures", "$HOME/Downloads", "$HOME/Videos", "$HOME/Documents"],
+            "serial":0,
+            "flags":[],
+            "name":"Dirs that support long file names",
+            "name[zh_CN]":"启用长文件名扩展的目录",
+            "description[zh_CN]":"默认启用长文件名扩展的目录",
+            "description":"Dirs that support long file names by default.",
             "permissions":"readwrite",
             "visibility":"private"
         },

--- a/assets/scripts/dfm-ulnfs-automount
+++ b/assets/scripts/dfm-ulnfs-automount
@@ -10,22 +10,53 @@ echo "dfm_INFO: user: $USER, uid: `id -u`, home: $HOME"
 
 query_dconfig="dde-dconfig --get -a org.deepin.dde.file-manager -r org.deepin.dde.file-manager -k "
 # obtain the config of ulnfs mount enable 
-ulnfs_enable=`$query_dconfig dfm.mount.lnfs`
+ulnfs_enable=`$query_dconfig dfm.mount.ulnfs`
 echo "dfm_INFO: ulnfs mount status: $ulnfs_enable"
 
 if [ "$ulnfs_enable" == "true" ]; then
-    default_paths=("$HOME")
-    echo "dfm_INFO: default mount paths: $default_paths"
-    gdbus call -y \
-        -d com.deepin.filemanager.daemon \
-        -o /com/deepin/filemanager/daemon/MountControl \
-        -m com.deepin.filemanager.daemon.MountControl.Mount \
-        "${default_paths}" \
-        "{'fsType': <'ulnfs'>}" \
-        -t 1    
 
-    step_time=$(date "+%Y-%m-%d %H:%M:%S.%3N")
-    echo -e "dfm_INFO: finished mount ${path} at [${step_time}]\n"    
+    default_paths=`$query_dconfig dfm.mount.ulnfs.defaults`
+    echo "dfm_INFO: default mount paths: $default_paths"
+
+    formats='"[ " ]'
+    for path in $default_paths
+    do
+        contains=$(echo $formats | grep -F "${path}")
+        if [ "$contains" != "" ]; then
+            continue
+        fi
+
+        # remove quotes and commas
+        path=${path//'"'/}
+        path=${path//','/}
+        abs_path=$path
+
+        env_path=`echo $path | grep -o '\$[^/]*'` # env_path = $HOME
+
+        if [ "$env_path" != "" ]; then
+            env_var=${env_path//'$'/}  # env_var = HOME
+            abs_env_path=`echo ${!env_var}` # abs_env_path = /home/$USER
+            abs_path=${path/$env_path/$abs_env_path}  #path = /home/xxxx/xxxx
+        fi
+
+        echo "dfm_INFO: ========================= $path [$abs_path]"
+        if [ ! -d $abs_path ]; then
+            echo "dfm_WARNING: $abs_path do not exist"
+            continue
+        fi
+
+        gdbus call -y \
+            -d com.deepin.filemanager.daemon \
+            -o /com/deepin/filemanager/daemon/MountControl \
+            -m com.deepin.filemanager.daemon.MountControl.Mount \
+            "${abs_path}" \
+            "{'fsType': <'ulnfs'>}" \
+            -t 1    
+
+        step_time=$(date "+%Y-%m-%d %H:%M:%S.%3N")
+        echo -e "dfm_INFO: finished mount ${abs_path} at [${step_time}]\n"    
+    done
+   
 fi
 
 end_time=$(date "+%Y-%m-%d %H:%M:%S.%3N")

--- a/src/dfm-base/CMakeLists.txt
+++ b/src/dfm-base/CMakeLists.txt
@@ -165,16 +165,27 @@ FILE(GLOB SCHEMA_FILES ${AssetsPath}/gschema/*)
 install(FILES ${SCHEMA_FILES} DESTINATION share/glib-2.0/schemas)
 install(CODE "execute_process(COMMAND glib-compile-schemas ${CMAKE_INSTALL_PREFIX}/share/glib-2.0/schemas)")
 
-set(LNFS_SCRIPT ${AssetsPath}/scripts/dfm-ulnfs-automount)
-install(FILES ${LNFS_SCRIPT} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/deepin/dde-file-manager)
+set(DLNFS_SCRIPT ${AssetsPath}/scripts/dfm-dlnfs-automount)
+install(FILES ${DLNFS_SCRIPT} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/deepin/dde-file-manager)
 
-set(LNFS_SCRIPT_LAUNCHER ${AssetsPath}/scripts/99dfm-ulnfs-automount)
-install(FILES ${LNFS_SCRIPT_LAUNCHER} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d)
+set(DLNFS_SCRIPT_LAUNCHER ${AssetsPath}/scripts/99dfm-dlnfs-automount)
+install(FILES ${DLNFS_SCRIPT_LAUNCHER} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d)
 
-set(DFM_LNFS_SCRIPT_LAUNCHER
+set(DFM_DLNFS_SCRIPT_LAUNCHER
     ${AssetsPath}/scripts/dde-file-manager
     ${AssetsPath}/scripts/file-manager.sh)
-install(FILES ${DFM_LNFS_SCRIPT_LAUNCHER} DESTINATION bin)
+install(FILES ${DFM_DLNFS_SCRIPT_LAUNCHER} DESTINATION bin)
+
+set(ULNFS_SCRIPT ${AssetsPath}/scripts/dfm-ulnfs-automount)
+install(FILES ${ULNFS_SCRIPT} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/deepin/dde-file-manager)
+
+set(ULNFS_SCRIPT_LAUNCHER ${AssetsPath}/scripts/99dfm-ulnfs-automount)
+install(FILES ${ULNFS_SCRIPT_LAUNCHER} DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d)
+
+set(DFM_ULNFS_SCRIPT_LAUNCHER
+    ${AssetsPath}/scripts/dde-file-manager
+    ${AssetsPath}/scripts/file-manager.sh)
+install(FILES ${DFM_ULNFS_SCRIPT_LAUNCHER} DESTINATION bin)
 
 set(Mimetypes "${ShareDir}/mimetypes")
 FILE(GLOB MIMETYPE_FILES ${AssetsPath}/mimetypes/*)

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1340,7 +1340,7 @@ QString FileUtils::normalPathToTrash(const QString &normal)
 bool FileUtils::supportLongName(const QUrl &url)
 {
     const static QList<QString> datas {
-        "vfat", "exfat", "ntfs", "fuseblk", "fuse.dlnfs"
+        "vfat", "exfat", "ntfs", "fuseblk", "fuse.dlnfs", "ulnfs"
     };
 
     const QString &fileSystem = dfmio::DFMUtils::fsTypeFromUrl(url);


### PR DESCRIPTION
It can be mounted through both ULNFS and DLNFS

Log: [lnfs] maintain two mounting methods for long file names
Task: https://pms.uniontech.com/task-view-359649.html