### PR TITLE
fix: During the cutting process, merging directories became a copy and delete operation

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
@@ -36,12 +36,13 @@ protected:
     void endWork() override;
 
     bool cutFiles();
-    bool doCutFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &targetPathInfo);
+    bool doCutFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &targetPathInfo, bool *skip);
     DFileInfoPointer doRenameFile(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetPathInfo,
-                                 const QString fileName, bool *ok);
+                                 const QString fileName, bool *ok, bool *skip);
     bool renameFileByHandler(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetInfo);
 
     void emitCompleteFilesUpdatedNotify(const qint64 &writCount);
+    bool doMergDir(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo, bool *skip);
 
 private:
     bool checkSymLink(const DFileInfoPointer &fromInfo);

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -193,6 +193,7 @@ public:
     QElapsedTimer *speedtimer{ nullptr };   // time eslape
     std::atomic_int64_t elapsed { 0 };
     std::atomic_int64_t deleteFirstFileSize{ false };
+    bool isCutMerge{false};
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -589,6 +589,9 @@ DFileInfoPointer FileOperateBaseWorker::doCheckNewFile(const DFileInfoPointer &f
         const QVariant &var = doActionMerge(fromInfo, newTargetInfo, isCountSize);
         if (var.isValid())
             return var.toBool() ? newTargetInfo : nullptr;
+        newTargetInfo->initQuerier();
+        if (jobType == AbstractJobHandler::JobType::kCutType && newTargetInfo)
+            isCutMerge = true;
         break;
     }
     case AbstractJobHandler::SupportAction::kSkipAction: {
@@ -712,6 +715,7 @@ bool FileOperateBaseWorker::checkAndCopyDir(const DFileInfoPointer &fromInfo, co
 
         const QUrl &url = iterator->next();
         DFileInfoPointer info(new DFileInfo(url));
+        info->initQuerier();
         bool ok = doCopyFile(info, toInfo, skip);
         if (!ok && (!skip || !*skip)) {
             return false;


### PR DESCRIPTION
Modify the logic to iterate the directory and rename all files in the source directory when cutting the merged directory

Log: During the cutting process, merging directories became a copy and delete operation
Bug: https://pms.uniontech.com/bug-view-276025.html