### PR TITLE
fix: Copy ISO and compressed files from the external device/smb to the local device, and the icon may display a probability error

### DIFF
--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -551,6 +551,12 @@ void SyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &
         ThumbnailFactory::instance()->joinThumbnailJob(url, Global::kLarge);
     }
 
+    // 更新fileicon
+    if (typeAll.contains(FileInfoAttributeID::kStandardIcon)) {
+        QWriteLocker wlk(&d->iconLock);
+        d->fileIcon = QIcon();
+    }
+
     // 更新mediaInfo
     if (typeAll.contains(FileInfoAttributeID::kFileMediaInfo)) {
         typeAll.removeOne(FileInfoAttributeID::kFileMediaInfo);


### PR DESCRIPTION
When updating local fileinfo, it was not set to empty

Log: Copy ISO and compressed files from the external device/smb to the local device, and the icon may display a probability error
Bug: https://pms.uniontech.com/bug-view-274169.html