### PR TITLE
chore: start MountControl service by `Resident`

### DIFF
--- a/src/services/mountcontrol/dde-filemanager-mountcontrol.json
+++ b/src/services/mountcontrol/dde-filemanager-mountcontrol.json
@@ -2,7 +2,7 @@
     "name": "org.deepin.Filemanager.MountControl",
     "libPath": "libdde-filemanager-mountcontrol.so",
     "group": "app",
-    "policyStartType": "OnDemand",
+    "policyStartType": "Resident",
     "pluginType": "qt",
     "idleTime": 1,
     "policy": [


### PR DESCRIPTION
DNetworkMounter::isDaemonMountEnable check failed from dfm-mount

log: start MountControl service by `Resident`