### PR TITLE
fix: When taking a screenshot, select "Specify Save Location" and choose another directory (not the current directory). Changing the file name has no effect and the file name is highlighted. However, you still need to click on the file name again with the mouse to enter it

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -334,7 +334,7 @@ void FileDialog::selectUrl(const QUrl &url)
         return;
 
     CoreEventsCaller::sendSelectFiles(this->internalWinId(), { url });
-    setCurrentInputName(QFileInfo(url.path()).fileName());
+    setCurrentInputName(url.fileName());
 }
 
 QList<QUrl> FileDialog::selectedUrls() const
@@ -549,17 +549,22 @@ void FileDialog::setCurrentInputName(const QString &name)
         return;
     }
 
-    statusBar()->lineEdit()->setText(name);
+    auto current = statusBar()->lineEdit()->text();
+    if (current.isEmpty())
+        current = name;
+
+    statusBar()->lineEdit()->setText(current);
 
     DFMBASE_NAMESPACE::DMimeDatabase db;
 
-    const QString &suffix = db.suffixForFileName(name);
+    const QString &suffix = db.suffixForFileName(current);
 
     if (suffix.isEmpty()) {
         statusBar()->lineEdit()->lineEdit()->selectAll();
     } else {
-        statusBar()->lineEdit()->lineEdit()->setSelection(0, name.length() - suffix.length() - 1);
+        statusBar()->lineEdit()->lineEdit()->setSelection(0, current.length() - suffix.length() - 1);
     }
+    statusBar()->lineEdit()->lineEdit()->setFocus();
 }
 
 void FileDialog::addCustomWidget(FileDialog::CustomWidgetType type, const QString &data)

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialogstatusbar.cpp
@@ -476,6 +476,8 @@ bool FileDialogStatusBar::eventFilter(QObject *watched, QEvent *event)
         QTimer::singleShot(500, this, [this]() {
             fileNameEdit->setFocus();
         });
+    } else if (event->type() == QEvent::FocusOut) {
+        fileNameEdit->lineEdit()->setSelection(0, 0);
     }
 
     return false;


### PR DESCRIPTION
Focus setting issue, set the edit box to focus when highlighted

Log: When taking a screenshot, select "Specify Save Location" and choose another directory (not the current directory). Changing the file name has no effect and the file name is highlighted. However, you still need to click on the file name again with the mouse to enter it
Bug: https://pms.uniontech.com/bug-view-273811.html