### PR TITLE
fix: The application name on the dde-desktop cannot be renamed

### DIFF
--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -258,6 +258,10 @@ bool DesktopFileInfo::canAttributes(const CanableInfoType type) const
             return false;
 
         return ProxyFileInfo::canAttributes(type);
+    case FileCanType::kCanRename:
+        if (!isAttributes(OptInfoType::kIsWritable))
+            return false;
+        return ProxyFileInfo::canAttributes(type);
     default:
         return ProxyFileInfo::canAttributes(type);
     }

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -78,7 +78,8 @@ bool FileOperatorMenuScene::initialize(const QVariantHash &params)
 
     if (!d->isEmptyArea) {
         QString errString;
-        d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+        d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile,
+                                                                            Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
         if (d->focusFileInfo.isNull()) {
             fmDebug() << errString;
             return false;
@@ -174,6 +175,10 @@ void FileOperatorMenuScene::updateState(QMenu *parent)
         if ((!d->treeSelectedUrls.isEmpty() && d->selectFiles.count() != d->treeSelectedUrls.count())
             || !d->focusFileInfo->canAttributes(CanableInfoType::kCanRename)
             || !d->indexFlags.testFlag(Qt::ItemIsEditable))
+            rename->setDisabled(true);
+
+        if (d->focusFileInfo && FileUtils::isDesktopFileInfo(d->focusFileInfo)
+                && !d->focusFileInfo->canAttributes(CanableInfoType::kCanRename))
             rename->setDisabled(true);
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-workspace/menus/workspacemenuscene.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/menus/workspacemenuscene.cpp
@@ -170,12 +170,19 @@ bool WorkspaceMenuScene::create(DMenu *parent)
 void WorkspaceMenuScene::updateState(DMenu *parent)
 {
     auto currentWidget = WorkspaceHelper::instance()->findWorkspaceByWindowId(d->windowId);
+    bool renameEnabled = true;
+    if (d->focusFileInfo && FileUtils::isDesktopFileInfo(d->focusFileInfo)
+            && !d->focusFileInfo->canAttributes(CanableInfoType::kCanRename))
+        renameEnabled = false;
     if (currentWidget && !currentWidget->canAddNewTab()) {
         auto actions = parent->actions();
         for (auto act : actions) {
             const auto &actId = act->property(ActionPropertyKey::kActionID);
-            if (dfmplugin_menu::ActionID::kOpenInNewTab == actId)
+            if (dfmplugin_menu::ActionID::kOpenInNewTab == actId) {
                 act->setEnabled(false);
+            } else if (!renameEnabled && dfmplugin_menu::ActionID::kRename == actId){
+                act->setEnabled(renameEnabled);
+            }
         }
     }
 


### PR DESCRIPTION
Desktop files on the desktop are hard linked and can be renamed based on whether the file is writable

Log: The application name on the dde-desktop cannot be renamed
Bug: https://pms.uniontech.com/bug-view-256967.html