### PR TITLE
fix: Cut and Copy - After copying 50 shortcuts from the desktop to another directory, the screen will go black and the dde-desktop will crash

### DIFF
--- a/src/plugins/desktop/core/ddplugin-canvas/canvasmanager.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/canvasmanager.cpp
@@ -641,7 +641,7 @@ void CanvasManager::onTrashStateChanged()
     auto idx = d->sourceModel->index(trash);
     if (idx.isValid()) {
         if (auto file = d->sourceModel->fileInfo(idx)) {
-            file->refresh();
+            file->updateAttributes();
             emit d->sourceModel->dataChanged(idx, idx);
         }
     }

--- a/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/model/fileinfomodel.cpp
@@ -80,7 +80,7 @@ void FileInfoModelPrivate::insertData(const QUrl &url)
         if (auto cur = fileMap.value(url)) {
             lk.unlock();
             fmInfo() << "the file to insert is existed" << url;
-            cur->refresh(); // refresh fileinfo.
+            cur->updateAttributes(); // refresh fileinfo.
             const QModelIndex &index = q->index(url);
             emit q->dataChanged(index, index);
             return;
@@ -167,7 +167,7 @@ void FileInfoModelPrivate::replaceData(const QUrl &oldUrl, const QUrl &newUrl)
                 lk.unlock();
 
                 // refresh file
-                cur->refresh();
+                cur->updateAttributes();
                 fmInfo() << "move file" << oldUrl << "to overwritte" << newUrl;
             } else {
                 fileList.replace(position, newUrl);
@@ -177,7 +177,7 @@ void FileInfoModelPrivate::replaceData(const QUrl &oldUrl, const QUrl &newUrl)
 
                 // refresh file because an old info cahe may exist.
                 if (cachedInfo == newInfo)
-                    newInfo->refresh();
+                    newInfo->updateAttributes();
 
                 emit q->dataReplaced(oldUrl, newUrl);
             }
@@ -395,7 +395,7 @@ void FileInfoModel::updateFile(const QUrl &url)
 void FileInfoModel::refreshAllFile()
 {
     for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor)
-        itor.value()->refresh();
+        itor.value()->updateAttributes();
 
     emit dataChanged(createIndex(0, 0), createIndex(rowCount(rootIndex()) - 1, 0));
 }

--- a/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
@@ -380,7 +380,7 @@ void CollectionModel::refresh(const QModelIndex &parent, bool global, int ms, bo
 void CollectionModel::update()
 {
     for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor)
-        itor.value()->refresh();
+        itor.value()->updateAttributes();
 
     emit dataChanged(createIndex(0, 0), createIndex(rowCount(rootIndex()) - 1, 0));
 }


### PR DESCRIPTION

It can't be replicated, and the test can't be replicated either. Only the crash caused by calling the refresh interface of syncfileinfo in coredump

Log: Cut and Copy - After copying 50 shortcuts from the desktop to another directory, the screen will go black and the dde-desktop will crash
Bug: https://pms.uniontech.com/bug-view-275145.html