### PR TITLE
fix: Mount Windows FTP and right-click to enter the shared directory The attribute size is displayed as 0

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -1048,7 +1048,7 @@ FileInfo::FileType AsyncFileInfoPrivate::fileType() const
     const QByteArray &nativeFilePath = QFile::encodeName(absoluteFilePath);
     QT_STATBUF statBuffer;
     auto fileMode = attribute(DFileInfo::AttributeID::kUnixMode).toUInt();
-    if (fileMode <= 0 || QT_STAT(nativeFilePath.constData(), &statBuffer) != 0)
+    if (fileMode <= 0 && QT_STAT(nativeFilePath.constData(), &statBuffer) != 0)
         return fileType;
     fileMode = fileMode <= 0 ? statBuffer.st_mode : fileMode;
     if (S_ISDIR(fileMode))

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -653,7 +653,7 @@ FileInfo::FileType SyncFileInfoPrivate::updateFileType()
     const QByteArray &nativeFilePath = QFile::encodeName(absoluteFilePath);
     QT_STATBUF statBuffer;
     auto fileMode = attribute(DFileInfo::AttributeID::kUnixMode).toUInt();
-    if (fileMode <= 0 || QT_STAT(nativeFilePath.constData(), &statBuffer) != 0)
+    if (fileMode <= 0 && QT_STAT(nativeFilePath.constData(), &statBuffer) != 0)
         return fileType;
     fileMode = fileMode <= 0 ? statBuffer.st_mode : fileMode;
     if (S_ISDIR(fileMode))


### PR DESCRIPTION
Windows FTP cannot retrieve Unix properties using Gio, so it can only be obtained through stat to determine if it was written incorrectly

Log: Mount Windows FTP and right-click to enter the shared directory. The attribute size is displayed as 0
Bug: https://pms.uniontech.com/bug-view-275191.html