### PR TITLE
fix: [ulnfs] Prioritize the mounting method for long file names

### DIFF
--- a/assets/scripts/dfm-dlnfs-automount
+++ b/assets/scripts/dfm-dlnfs-automount
@@ -13,7 +13,10 @@ query_dconfig="dde-dconfig --get -a org.deepin.dde.file-manager -r org.deepin.dd
 dlnfs_enable=`$query_dconfig dfm.mount.dlnfs`
 echo "dfm_INFO: dlnfs mount status: $dlnfs_enable"
 
-if [ "$dlnfs_enable" == "true" ]; then
+ulnfs_enable=`$query_dconfig dfm.mount.ulnfs`
+echo "dfm_INFO: ulnfs mount status: $ulnfs_enable"
+
+if [ "$dlnfs_enable" == "true" ] && [ "$ulnfs_enable" != "true" ]; then
     default_paths=`$query_dconfig dfm.mount.dlnfs.defaults`
     echo "dfm_INFO: default mount paths: $default_paths"
 


### PR DESCRIPTION
Do not mount dlnfs while enabling ulnfs

Log: [ulnfs] Prioritize the mounting method for long file names
Task: https://pms.uniontech.com/task-view-359649.html