### PR TITLE
fix: [dragdrophelper] Files cannot be dragged to a USB drive, but can be copied and cut

### DIFF
--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -193,7 +193,7 @@ public:
         kCanTrash = 1,   // 可以移动到回收站
         kCanRename = 2,   // 可以重命名
         kCanRedirectionFileUrl = 3,   // 可以重定向
-        kCanMoveOrCopy = 4,   // 可以移动或者拷贝
+        kCanMoveOrCopy = 4,   // 可以拷贝，可以移动使用kCanRename去判断
         kCanDrop = 5,   // 可以Drop
         kCanDrag = 6,   // 可以drag
         kCanDragCompress = 7,   // 可以压缩

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -221,6 +221,13 @@ bool AsyncFileInfo::canAttributes(const CanableInfoType type) const
         if (FileUtils::isGphotoFile(url))
             return false;
         return true;
+    case FileCanType::kCanMoveOrCopy:
+        // file can not read or dir can not execte，will can not copy
+        if (!d->asyncAttribute(FileInfo::FileInfoAttributeID::kAccessCanRead).toBool() ||
+                (d->asyncAttribute(FileInfo::FileInfoAttributeID::kStandardIsDir).toBool() &&
+                 !d->asyncAttribute(FileInfo::FileInfoAttributeID::kAccessCanExecute).toBool()))
+            return false;
+        return FileInfo::canAttributes(type);
     default:
         return FileInfo::canAttributes(type);
     }
@@ -951,8 +958,13 @@ bool AsyncFileInfoPrivate::canRename() const
 
     bool canRename = false;
     canRename = SysInfoUtils::isRootUser();
-    if (!canRename)
+    if (!canRename) {
+        // dir can not write, will can not rename
+        if (this->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() &&
+                !this->attribute(DFileInfo::AttributeID::kAccessCanWrite).toBool())
+            return false;
         return this->attribute(DFileInfo::AttributeID::kAccessCanRename).toBool();
+    }
 
     return canRename;
 }

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -239,6 +239,13 @@ bool SyncFileInfo::canAttributes(const CanableInfoType type) const
         if (FileUtils::isGphotoFile(url))
             return false;
         return true;
+    case FileCanType::kCanMoveOrCopy:
+        // file can not read or dir can not execte
+        if (!d->attribute(DFileInfo::AttributeID::kAccessCanRead).toBool() ||
+                (d->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() &&
+                 !d->attribute(DFileInfo::AttributeID::kAccessCanExecute).toBool()))
+            return false;
+        return FileInfo::canAttributes(type);
     default:
         return FileInfo::canAttributes(type);
     }
@@ -960,8 +967,14 @@ bool SyncFileInfoPrivate::canRename() const
 
     bool canRename = false;
     canRename = SysInfoUtils::isRootUser();
-    if (!canRename)
+    if (!canRename) {
+        // dir can not write, can not rename
+        if (this->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() &&
+                !this->attribute(DFileInfo::AttributeID::kAccessCanWrite).toBool())
+            return false;
+
         return this->attribute(DFileInfo::AttributeID::kAccessCanRename).toBool();
+    }
 
     return canRename;
 }

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -654,7 +654,8 @@ Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *
             return Qt::IgnoreAction;
         }
         //部分文件不能复制或剪切，需要在拖拽时忽略
-        if (!fileInfo->canAttributes(CanableInfoType::kCanMoveOrCopy)) {
+        if (!fileInfo->canAttributes(CanableInfoType::kCanMoveOrCopy) &&
+                !fileInfo->canAttributes(CanableInfoType::kCanRename)) {
             return Qt::IgnoreAction;
         }
     }


### PR DESCRIPTION
Modify the values of canrename and canmovecopy in file information, and add judgments for copyaction and canmovecopy

Log: Files cannot be dragged to a USB drive, but can be copied and cut
Bug: https://pms.uniontech.com/bug-view-275437.html