### PR TITLE
fix: Copying a directory will cause the soft connection to point to an absolute path

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -518,7 +518,8 @@ bool FileOperateBaseWorker::createSystemLink(const DFileInfoPointer &fromInfo, c
 
     do {
         actionForlink = AbstractJobHandler::SupportAction::kNoAction;
-        if (localFileHandler->createSystemLink(newFromInfo->uri(), toInfo->uri())) {
+        auto target = QUrl::fromLocalFile(newFromInfo->attribute(DFileInfo::AttributeID::kStandardSymlinkTarget).toString());
+        if (localFileHandler->createSystemLink(target, toInfo->uri())) {
             return true;
         }
         actionForlink = doHandleErrorAndWait(fromInfo->uri(), toInfo->uri(),


### PR DESCRIPTION
Read the link file's pointing path as the new link's pointing path

Log: Copying a directory will cause the soft connection to point to an absolute path
Bug: https://bbs.deepin.org/post/279799 https://pms.uniontech.com/bug-view-277349.html