### PR TITLE
fix: [search]Checked 'Show hidden files' and searched for hidden files

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -291,7 +291,7 @@ bool SearchHelper::isHiddenFile(const QString &fileName, QHash<QString, QSet<QSt
     if (filters[fileParentPath].isEmpty()) {
         QFile file(hiddenFileConfig);
         // 判断.hidden文件中的内容是否为空，空则表示该路径下没有隐藏文件
-        if (file.isReadable() && file.size() > 0) {
+        if (file.size() > 0) {
             if (!file.open(QFile::ReadOnly))
                 return false;
 


### PR DESCRIPTION
When reading the. hidden file, QFile's isReadable returned false

Log: Checked 'Show hidden files' and searched for hidden files
Bug: https://pms.uniontech.com/bug-view-273907.html