### PR TITLE
fix: [workspace]Aggregation drag and drop - Single window selects 100 files in the current directory and drags them to the main directory, resulting in file refresh exception

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -1357,8 +1357,8 @@ void FileView::dragLeaveEvent(QDragLeaveEvent *event)
 void FileView::dropEvent(QDropEvent *event)
 {
     setViewSelectState(false);
-    if (d->dragDropHelper->drop(event))
-        return;
+    d->dragDropHelper->drop(event);
+    setState(NoState);
 }
 
 QModelIndex FileView::indexAt(const QPoint &pos) const


### PR DESCRIPTION
The No state state of the view is not set in the dropevent event

Log: Aggregation drag and drop - Single window selects 100 files in the current directory and drags them to the main directory, resulting in file refresh exception
Bug: https://pms.uniontech.com/bug-view-274993.html