### PR TITLE
fix: [filecopy]When copying large files, the swap partition is heavily used and the UI interface lags severely

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -59,10 +59,12 @@ public:
     // normal copy
     NextDo doCopyFilePractically(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo,
                                  bool *skip);
+    // normal copy
+    NextDo doCopyFileByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo,
+                             bool *skip);
     // small file copy
     void doFileCopy(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
-    // big file copy in system device
-    void doMemcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *dest, char *source, size_t size);
+
     // copy file by dfmio
     bool doDfmioFileCopy(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
 signals:
@@ -117,6 +119,8 @@ private:   // file copy
     void checkRetry();
     bool isStopped();
     void syncBlockFile(const DFileInfoPointer toInfo);
+    int openFileBySys(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
+                      const int flags, bool *skip, const bool isSource = true);
 public:
     static void progressCallback(int64_t current, int64_t total, void *progressData);
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -97,16 +97,7 @@ private:
     QUrl createNewTargetUrl(const DFileInfoPointer &toInfo, const QString &fileName);
     bool doCopyLocalFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
     bool doCopyOtherFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
-    bool doCopyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
-
-private:   // do copy local big file
-    bool doCopyLocalBigFileResize(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int toFd, bool *skip);
-    char *doCopyLocalBigFileMap(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int fd, const int per, bool *skip);
-    void memcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *fromPoint, char *toPoint);
-    void doCopyLocalBigFileClear(const size_t size, const int fromFd,
-                                 const int toFd, char *fromPoint, char *toPoint);
-    int doOpenFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, const bool isTo,
-                   const int openFlag, bool *skip);
+    bool doCopyLocalByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
 
 protected Q_SLOTS:
     void emitErrorNotify(const QUrl &from, const QUrl &to, const AbstractJobHandler::JobErrorType &error,


### PR DESCRIPTION
Modify the copying method to remove mmap and use copy_file_range

Log: When copying large files, the swap partition is heavily used and the UI interface lags severely
Bug: https://pms.uniontech.com/bug-view-273191.html