### PR TITLE
fix: [workspace]After mounting SFTP, the network was disconnected and the dde-file-manager window froze, making it impossible to open a new dde-file-manager window

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1340,6 +1340,8 @@ QString FileUtils::normalPathToTrash(const QString &normal)
 
 bool FileUtils::supportLongName(const QUrl &url)
 {
+    if (isGvfsFile(url))
+        return false;
     const static QList<QString> datas {
         "vfat", "exfat", "ntfs", "fuseblk", "fuse.dlnfs", "ulnfs"
     };

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -17,6 +17,8 @@
 #include <dfm-base/utils/clipboard.h>
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/networkutils.h>
+#include <dfm-base/utils/dialogmanager.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -308,10 +310,17 @@ void FileViewHelper::handleCommitData(QWidget *editor) const
         return;
     }
 
+
     const auto &index = itemDelegate()->editingIndex();
     const FileInfoPointer &fileInfo = parent()->model()->fileInfo(index);
 
     if (!fileInfo) {
+        return;
+    }
+
+    // check network
+    if (NetworkUtils::instance()->checkFtpOrSmbBusy(fileInfo->urlOf(UrlInfoType::kUrl))) {
+        DialogManager::instance()->showUnableToVistDir(fileInfo->urlOf(UrlInfoType::kUrl).path());
         return;
     }
 
@@ -342,6 +351,7 @@ void FileViewHelper::handleCommitData(QWidget *editor) const
 
     QUrl oldUrl = fileInfo->getUrlByType(UrlInfoType::kGetUrlByNewFileName, fileInfo->nameOf(NameInfoType::kFileName));
     QUrl newUrl = fileInfo->getUrlByType(UrlInfoType::kGetUrlByNewFileName, newFileName);
+
     //Todo(yanghao): tag
     FileOperatorHelperIns->renameFile(this->parent(), oldUrl, newUrl);
 }


### PR DESCRIPTION
When double clicking with the mouse, execute the supportLongName function to first determine if it is a network file, and check out the network before performing the renaming

Log: After mounting SFTP, the network was disconnected and the dde-file-manager window froze, making it impossible to open a new dde-file-manager window
Bug: https://pms.uniontech.com/bug-view-276323.html