### PR TITLE
fix: [workspace]In list mode, holding down Ctrl and dragging files from the desktop to the Trash compressed folder cannot be successfully added, and files cannot be deleted

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/trash.cpp
@@ -170,6 +170,8 @@ void Trash::followEvents()
 
     dpfHookSequence->follow("dfmplugin_utils", "hook_OpenWith_DisabledOpenWithWidget", TrashFileHelper::instance(), &TrashFileHelper::disableOpenWidgetWidget);
 
+    dpfHookSequence->follow("dfmplugin_utils", "hook_AppendCompress_Prohibit", TrashFileHelper::instance(),
+                            &TrashFileHelper::handleNotAllowedAppendCompress);
     // register to tag
     auto searchPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-tag") };
     if (searchPlugin && searchPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -178,3 +178,12 @@ bool TrashFileHelper::handleNotCdComputer(const QUrl &url, QUrl *cdUrl)
     *cdUrl = FileUtils::trashRootUrl();
     return true;
 }
+
+bool TrashFileHelper::handleNotAllowedAppendCompress(const QList<QUrl> &fromUrls, const QUrl &toUrl)
+{
+    Q_UNUSED(fromUrls);
+    if (FileUtils::isTrashFile(toUrl))
+        return true;
+
+    return false;
+}

--- a/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-trash/utils/trashfilehelper.h
@@ -40,6 +40,7 @@ public:
     bool handleCanTag(const QUrl &url, bool *canTag);
     bool handleIsSubFile(const QUrl &parent, const QUrl &sub);
     bool handleNotCdComputer(const QUrl &url, QUrl *cdUrl);
+    bool handleNotAllowedAppendCompress(const QList<QUrl> &fromUrls, const QUrl &toUrl);
 
 private:
     explicit TrashFileHelper(QObject *parent = nullptr);


### PR DESCRIPTION
The Trash does not support adding. Change the status here to unavailable

Log: In list mode, holding down Ctrl and dragging files from the desktop to the Trash compressed folder cannot be successfully added, and files cannot be deleted
Bug: https://pms.uniontech.com/bug-view-278153.html