### PR TITLE
[filetype]The interface does not support displaying file types for unconventional file types

### DIFF
--- a/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
+++ b/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
@@ -30,6 +30,10 @@ void MimeTypeDisplayManager::initData()
     displayNamesMap[FileInfo::FileType::kExecutable] = tr("Executable");
     displayNamesMap[FileInfo::FileType::kBackups] = tr("Backup file");
     displayNamesMap[FileInfo::FileType::kUnknown] = tr("Unknown");
+    displayNamesMap[FileInfo::FileType::kCharDevice] = tr("CharDevice");
+    displayNamesMap[FileInfo::FileType::kFIFOFile] = tr("FIFO File");
+    displayNamesMap[FileInfo::FileType::kSocketFile] = tr("Socket File");
+    displayNamesMap[FileInfo::FileType::kBlockDevice] = tr("Block Device");
 
     defaultIconNames[FileInfo::FileType::kDirectory] = "folder";
     defaultIconNames[FileInfo::FileType::kDesktopApplication] = "application-default-icon";
@@ -73,6 +77,14 @@ FileInfo::FileType MimeTypeDisplayManager::displayNameToEnum(const QString &mime
         return FileInfo::FileType::kArchives;
     } else if (backupMimeTypes.contains(mimeType)) {
         return FileInfo::FileType::kBackups;
+    } else if (mimeType == "inode/chardevice") {
+        return FileInfo::FileType::kCharDevice;
+    } else if (mimeType == "inode/socket") {
+        return FileInfo::FileType::kSocketFile;
+    } else if (mimeType == "inode/blockdevice") {
+        return FileInfo::FileType::kBlockDevice;
+    } else if (mimeType == "inode/fifo") {
+        return FileInfo::FileType::kFIFOFile;
     } else {
         return FileInfo::FileType::kUnknown;
     }

--- a/translations/dde-file-manager.ts
+++ b/translations/dde-file-manager.ts
@@ -2880,6 +2880,26 @@
         <source>Unknown</source>
         <translation>Unknown</translation>
     </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="33"/>
+        <source>CharDevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="34"/>
+        <source>FIFO File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="35"/>
+        <source>Socket File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="36"/>
+        <source>Block Device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>dfmbase::MountAskPasswordDialog</name>

--- a/translations/dde-file-manager_bo.ts
+++ b/translations/dde-file-manager_bo.ts
@@ -2880,6 +2880,26 @@
         <source>Unknown</source>
         <translation>མི་ཤེས་པ།</translation>
     </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="33"/>
+        <source>CharDevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="34"/>
+        <source>FIFO File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="35"/>
+        <source>Socket File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="36"/>
+        <source>Block Device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>dfmbase::MountAskPasswordDialog</name>

--- a/translations/dde-file-manager_ug.ts
+++ b/translations/dde-file-manager_ug.ts
@@ -2880,6 +2880,26 @@
         <source>Unknown</source>
         <translation>نامەلۇم</translation>
     </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="33"/>
+        <source>CharDevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="34"/>
+        <source>FIFO File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="35"/>
+        <source>Socket File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="36"/>
+        <source>Block Device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>dfmbase::MountAskPasswordDialog</name>

--- a/translations/dde-file-manager_zh_CN.ts
+++ b/translations/dde-file-manager_zh_CN.ts
@@ -2880,6 +2880,26 @@
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="33"/>
+        <source>CharDevice</source>
+        <translation>字符设备</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="34"/>
+        <source>FIFO File</source>
+        <translation>管道</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="35"/>
+        <source>Socket File</source>
+        <translation>套接字</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="36"/>
+        <source>Block Device</source>
+        <translation>块设备</translation>
+    </message>
 </context>
 <context>
     <name>dfmbase::MountAskPasswordDialog</name>

--- a/translations/dde-file-manager_zh_HK.ts
+++ b/translations/dde-file-manager_zh_HK.ts
@@ -2880,6 +2880,26 @@
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="33"/>
+        <source>CharDevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="34"/>
+        <source>FIFO File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="35"/>
+        <source>Socket File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="36"/>
+        <source>Block Device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>dfmbase::MountAskPasswordDialog</name>

--- a/translations/dde-file-manager_zh_TW.ts
+++ b/translations/dde-file-manager_zh_TW.ts
@@ -2880,6 +2880,26 @@
         <source>Unknown</source>
         <translation>未知</translation>
     </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="33"/>
+        <source>CharDevice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="34"/>
+        <source>FIFO File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="35"/>
+        <source>Socket File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="36"/>
+        <source>Block Device</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>dfmbase::MountAskPasswordDialog</name>


### PR DESCRIPTION
Display file types for adding block devices, sockets, FIFO, and char

Log: The interface does not support displaying file types for unconventional file types
Bug: https://pms.uniontech.com/bug-view-278893.html