### PR TITLE
fix: optimize memory management in vault password operations

### DIFF
--- a/src/plugins/daemon/daemonplugin-vault/vaultcontrol.cpp
+++ b/src/plugins/daemon/daemonplugin-vault/vaultcontrol.cpp
@@ -297,8 +297,7 @@ QString VaultControl::passwordFromKeyring()
     }
 
     secret_value_unref(value_read);
-    g_hash_table_unref(attributes);
-    g_object_unref(service);
+    g_hash_table_destroy(attributes);
 
     fmWarning() << "Vault Daemon: Read password end!";
 


### PR DESCRIPTION
- Replace g_hash_table_unref with g_hash_table_destroy for attributes cleanup
- Use Q_NULLPTR instead of nullptr for better Qt compatibility
- Improve SecretValue creation with secret_value_new_full
- Remove redundant g_object_unref for service cleanup
- Use baPassword.data() instead of constData() for string conversion

This commit fixes potential memory leaks and improves memory management in vault password related operations.

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-278715.html