### PR TITLE
feat: Support three height levels for list view mode

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/optionbuttonbox.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/optionbuttonbox.h
@@ -12,6 +12,7 @@
 #include <QWidget>
 
 namespace dfmplugin_titlebar {
+
 class ActionButton : public QToolButton
 {
     Q_OBJECT
@@ -40,6 +41,7 @@ public:
     void setViewOptionsButton(ViewOptionsButton *button);
 
     void setViewMode(int mode);
+    void updateOptionButtonBox(int parentWidth);
 
 public slots:
     void onUrlChanged(const QUrl &url);
@@ -48,6 +50,12 @@ private:
     void initializeUi();
     void initConnect();
     void initUiForSizeMode();
+    void updateFixedWidth();
+
+    void switchToCompactMode();
+    void switchToNormalMode();
+
+    static constexpr int kCompactModeThreshold = 600;
 };
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/private/optionbuttonbox_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/private/optionbuttonbox_p.h
@@ -30,6 +30,7 @@ class OptionButtonBoxPrivate : public QObject
 
 public:
     explicit OptionButtonBoxPrivate(OptionButtonBox *parent);
+    void updateCompactButton();
 
 public slots:
     void setViewMode(ViewMode mode);
@@ -49,6 +50,8 @@ private:
     SortByButton *sortByButton { nullptr };
     ViewOptionsButton *viewOptionsButton { nullptr };
     QHBoxLayout *hBoxLayout { nullptr };
+    DTK_WIDGET_NAMESPACE::DToolButton *compactButton { nullptr };
+    bool isCompactMode { false };
 
     ViewMode currentMode { ViewMode::kIconMode };
     QUrl currentUrl;

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -218,7 +218,7 @@ void TitleBarWidget::initializeUi()
     searchEditWidget->setMaximumWidth(kSearchEditMaxWidth);
 
     // option button
-    optionButtonBox = new OptionButtonBox;
+    optionButtonBox = new OptionButtonBox(this);
     optionButtonBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 #ifdef ENABLE_TESTING
     dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
@@ -417,7 +417,9 @@ void TitleBarWidget::resizeEvent(QResizeEvent *event)
     AbstractFrame::resizeEvent(event);
     
     int totalWidth = width();
-    
+
+    optionButtonBox->updateOptionButtonBox(totalWidth);
+
     // Calculate the total width of other fixed-width components
     int fixedWidth = curNavWidget->width() + optionButtonBox->width() + kSpacing * 5;
     

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -180,7 +180,10 @@ void ViewOptionsWidgetPrivate::initConnect()
 
     connect(iconSizeSlider, &DSlider::valueChanged, this, [this](int value) {
         fmDebug() << "iconSizeSlider value changed: " << value;
-        Application::instance()->setAppAttribute(Application::kIconSizeLevel, value);
+        QVariantMap map = Application::appObtuselySetting()->value("FileViewState", fileUrl).toMap();
+        map["iconSizeLevel"] = value;
+        Application::appObtuselySetting()->setValue("FileViewState", fileUrl, map);
+        Application::appObtuselySetting()->sync();
     });
     connect(iconSizeSlider, &DSlider::iconClicked, this, [this](DSlider::SliderIcons icon, bool checked) {
         if (icon == DSlider::LeftIcon) {
@@ -195,7 +198,10 @@ void ViewOptionsWidgetPrivate::initConnect()
     });
     connect(gridDensitySlider, &DSlider::valueChanged, this, [this](int value) {
         fmDebug() << "gridDensitySlider value changed: " << value;
-        Application::instance()->setAppAttribute(Application::kGridDensityLevel, value);
+        QVariantMap map = Application::appObtuselySetting()->value("FileViewState", fileUrl).toMap();
+        map["gridDensityLevel"] = value;
+        Application::appObtuselySetting()->setValue("FileViewState", fileUrl, map);
+        Application::appObtuselySetting()->sync();
     });
     connect(gridDensitySlider, &DSlider::iconClicked, this, [this](DSlider::SliderIcons icon, bool checked) {
         if (icon == DSlider::LeftIcon) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -61,6 +61,12 @@ inline QList<int> iconGridWidth()
     return widths;
 }
 
+inline QList<int> listHeight()
+{
+    static const QList<int> heights { 24, 32, 48 };
+    return heights;
+}
+
 inline QList<int> iconWidth()
 {
     return { 44, 36, 28, 28, 28, 28, 28, 32 };

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -134,6 +134,16 @@ int BaseItemDelegate::minimumWidthLevel() const
     return -1;
 }
 
+void BaseItemDelegate::setItemMinimumHeightByHeightLevel(int level)
+{
+    Q_UNUSED(level)
+}
+
+int BaseItemDelegate::minimumHeightLevel() const
+{
+    return -1;
+}
+
 QModelIndexList BaseItemDelegate::hasWidgetIndexs() const
 {
     Q_D(const BaseItemDelegate);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/baseitemdelegate.h
@@ -90,6 +90,18 @@ public:
     virtual void setItemMinimumWidthByWidthLevel(int level);
 
     /**
+     * @brief minimumHeightLevel return minimum height level
+     * @return Return minimum height level if level is vaild, otherwise return -1
+     */
+    virtual int minimumHeightLevel() const;
+
+    /**
+     * @brief setItemMinimumHeightByHeightLevel set item minimum height level
+     * @param level
+     */
+    virtual void setItemMinimumHeightByHeightLevel(int level);
+
+    /**
      * @brief hasWidgetIndexs
      * @return
      */

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.h
@@ -136,6 +136,7 @@ public slots:
     void onRowCountChanged();
     void trashStateChanged();
     void onHeaderViewSectionChanged(const QUrl &url);
+    void onAppAttributeChanged(const QString &group, const QString &key, const QVariant &value);
 
     void onSelectAndEdit(const QUrl &url);
 
@@ -192,7 +193,7 @@ private slots:
     void onDefaultViewModeChanged(int mode);
     void onIconSizeChanged(int sizeIndex);
     void onItemWidthLevelChanged(int level);
-    
+    void onItemHeightLevelChanged(int level);
 private:
     void initializeModel();
     void initializeDelegate();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -275,7 +275,6 @@ int IconItemDelegate::increaseIcon()
     Q_D(const IconItemDelegate);
 
     int newLevel = setIconSizeByIconSizeLevel(d->currentIconSizeIndex + 1);
-    Application::instance()->setAppAttribute(Application::kIconSizeLevel, newLevel);
     return newLevel;
 }
 
@@ -284,7 +283,6 @@ int IconItemDelegate::decreaseIcon()
     Q_D(const IconItemDelegate);
 
     int newLevel = setIconSizeByIconSizeLevel(d->currentIconSizeIndex - 1);
-    Application::instance()->setAppAttribute(Application::kIconSizeLevel, newLevel);
     return newLevel;
 }
 
@@ -631,9 +629,7 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
     QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(displayName, QTextOption::WrapAtWordBoundaryOrAnywhere,
                                                                                 d->textLineHeight, Qt::AlignCenter, painter));
 
-    // labelRect.setLeft(labelRect.left() + kIconModeRectRadius);
-    // labelRect.setWidth(labelRect.width() - kIconModeRectRadius);
-    qWarning() << "!!!!!!!!!!!!!!abelRect" << labelRect.width();
+    
     const FileInfoPointer &info = parent()->fileInfo(index);
     WorkspaceEventSequence::instance()->doIconItemLayoutText(info, layout.data());
     if (!singleSelected && isSelectedOpt) {

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -46,8 +46,7 @@ using namespace dfmplugin_workspace;
 ListItemDelegate::ListItemDelegate(FileViewHelper *parent)
     : BaseItemDelegate(*new ListItemDelegatePrivate(this), parent)
 {
-    parent->parent()->setIconSize(QSize(kListViewIconSize,
-                                        kListViewIconSize));
+    setItemMinimumHeightByHeightLevel(1);
 }
 
 ListItemDelegate::~ListItemDelegate()
@@ -314,7 +313,7 @@ void ListItemDelegate::updateItemSizeHint()
     Q_D(ListItemDelegate);
 
     d->textLineHeight = parent()->parent()->fontMetrics().height();
-    d->itemSizeHint = QSize(-1, qMax(int(parent()->parent()->iconSize().height() * 1.33), d->textLineHeight));
+    d->itemSizeHint = QSize(-1, qMax(int(listHeight().at(d->currentHeightLevel)), d->textLineHeight));
 }
 
 QRectF ListItemDelegate::itemIconRect(const QRectF &itemRect) const
@@ -335,6 +334,28 @@ QRect ListItemDelegate::getRectOfItem(RectOfItemType type, const QModelIndex &in
     if (d->paintProxy)
         return d->paintProxy->rectByType(type, index).toRect();
     return QRect();
+}
+
+void ListItemDelegate::setItemMinimumHeightByHeightLevel(int level)
+{
+    Q_D(ListItemDelegate);
+
+    if (d->currentHeightLevel == level)
+        return;
+
+    if (level < 0 || level >= listHeight().length())
+        return;
+
+    d->currentHeightLevel = level;
+    updateItemSizeHint();
+    int iconHeight = d->itemSizeHint.height() * 0.75;
+    parent()->parent()->setIconSize(QSize(iconHeight, iconHeight)); // 设置 iconSize 为行高的 0.75
+}
+
+int ListItemDelegate::minimumHeightLevel() const
+{
+    Q_D(const ListItemDelegate);
+    return d->currentHeightLevel;
 }
 
 /*!

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/listitemdelegate.h
@@ -32,6 +32,9 @@ public:
     QRectF itemIconRect(const QRectF &itemRect) const override;
     QRect getRectOfItem(RectOfItemType type, const QModelIndex &index) const override;
 
+    void setItemMinimumHeightByHeightLevel(int level) override;
+    int minimumHeightLevel() const override;
+
 protected:
     bool eventFilter(QObject *object, QEvent *event) override;
     bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -87,6 +87,7 @@ void FileViewPrivate::initIconModeView()
         statusBar->setScalingVisible(true);
         q->setIconSize(QSize(iconSizeList()[currentIconSizeLevel],
                              iconSizeList()[currentIconSizeLevel]));
+        QSignalBlocker blocker(statusBar->scalingSlider());
         statusBar->scalingSlider()->setValue(currentIconSizeLevel);
     }
 
@@ -96,6 +97,9 @@ void FileViewPrivate::initIconModeView()
 
 void FileViewPrivate::initListModeView()
 {
+    if (q->itemDelegate())
+        q->itemDelegate()->setItemMinimumHeightByHeightLevel(currentListHeightLevel);
+
     if (!emptyInteractionArea) {
         emptyInteractionArea = new QWidget(q);
         QVBoxLayout *headerLayout = new QVBoxLayout;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/fileview_p.h
@@ -58,6 +58,7 @@ class FileViewPrivate
     DFMBASE_NAMESPACE::Global::ViewMode currentViewMode = DFMBASE_NAMESPACE::Global::ViewMode::kIconMode;
     int currentIconSizeLevel = 1;
     int currentGridDensityLevel = 1;
+    int currentListHeightLevel = 1;
     bool isAlwaysOpenInCurrentWindow { false };
     // move cursor later selecte index when pressed key shift
     QModelIndex lastCursorIndex;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/private/listitemdelegate_p.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/private/listitemdelegate_p.h
@@ -20,6 +20,8 @@ public:
     explicit ListItemDelegatePrivate(ListItemDelegate *qq);
     virtual ~ListItemDelegatePrivate();
 
+    int currentHeightLevel { 1 };
+
     Q_DECLARE_PUBLIC(ListItemDelegate)
 };
 


### PR DESCRIPTION
Add support for three different height levels (24px, 32px, 48px) in list view mode:

1. Add global definition for list heights
2. Add height level related interfaces in BaseItemDelegate
3. Implement height setting functionality in ListItemDelegate
4. Add height level state management in FileView
5. Update height settings storage method
6. Set icon size to 75% of row height

The height level can be changed through the slider in view options, and the setting will be preserved across sessions.

Log: Support three height levels for list view mode