### PR TITLE
fix: initialize search widget layout state on creation

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -364,6 +364,7 @@ void SearchEditWidget::initUI()
     cpItemDelegate = new CompleterViewDelegate(completerView);
 
     initUiForSizeMode();
+    updateSearchWidgetLayout();
 }
 
 void SearchEditWidget::initConnect()


### PR DESCRIPTION
Add updateSearchWidgetLayout() call in initUI() to ensure the search widget's layout is properly initialized when the widget is created.

Log: initialize search widget layout state on creation