### PR TITLE
refactor: simplify window drag handling in TabBar

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/tabbar.h
@@ -73,8 +73,9 @@ private:
     void updateTabsState();
     void updateAddTabButtonState();
 
-    inline int getTabAreaWidth() const {
-        return width() - 10- tabAddButton->width();
+    inline int getTabAreaWidth() const
+    {
+        return width() - 10 - tabAddButton->width();
     }
 
     QGraphicsScene *scene { nullptr };
@@ -91,10 +92,9 @@ private:
     int currentIndex { -1 };
     int historyWidth { 0 };
 
-    QPoint dragStartPosition;
     bool isDragging { false };
 };
 
-} // namespace dfmplugin_titlebar
+}   // namespace dfmplugin_titlebar
 
-#endif // TABBAR_H
+#endif   // TABBAR_H


### PR DESCRIPTION
- Remove direct window drag implementation from TabBar
- Let mouse events propagate to parent window when dragging
- Clean up mouse event handlers
- Fix code formatting and alignment
- Remove unused dragStartPosition variable

This change improves the window dragging behavior by delegating the responsibility to the parent window instead of handling it directly in TabBar.

Log: as title