### PR TITLE
feat: add support for WebDAV and NFS protocols

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -93,7 +93,7 @@ enum ItemRoles {
     kItemCreateFileInfoRole = Qt::UserRole + 33,
     kItemTreeViewDepthRole = Qt::UserRole + 34,
     kItemTreeViewExpandedRole = Qt::UserRole + 35,
-    kItemTreeViewCanExpandRole = Qt::UserRole + 36, // item can expand
+    kItemTreeViewCanExpandRole = Qt::UserRole + 36,   // item can expand
     kItemUpdateAndTransFileInfoRole = Qt::UserRole + 37,
     kItemUnknowRole = Qt::UserRole + 999
 };
@@ -169,6 +169,8 @@ inline constexpr char kDesktop[] { "desktop" };
 inline constexpr char kMtp[] { "mtp" };
 inline constexpr char kAfc[] { "afc" };
 inline constexpr char kDav[] { "dav" };
+inline constexpr char kDavs[] { "davs" };
+inline constexpr char kNfs[] { "nfs" };
 inline constexpr char kEntry[] { "entry" };
 inline constexpr char kBurn[] { "burn" };
 inline constexpr char kComputer[] { "computer" };

--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -701,7 +701,8 @@ void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType
 
     static QMap<QString, QString> defaultPort { { "smb", "445" },
                                                 { "ftp", "21" },
-                                                { "sftp", "22" } };
+                                                { "sftp", "22" },
+                                                { "nfs", "2049" } };
     QString host = u.host();
     QString port = defaultPort.value(u.scheme(), "21");
 
@@ -1052,7 +1053,8 @@ MountPassInfo DeviceManagerPrivate::askForPasswdWhenMountNetworkDevice(const QSt
     dlg.setDomain(domainDefault);
     dlg.setUser(userDefault);
 
-    if (uri.startsWith(Global::Scheme::kFtp) || uri.startsWith(Global::Scheme::kSFtp))
+    QStringList noDomainSchemes { Global::Scheme::kSFtp, Global::Scheme::kFtp, Global::Scheme::kDav, Global::Scheme::kDavs };
+    if (noDomainSchemes.contains(QUrl(uri).scheme()))
         dlg.setDomainLineVisible(false);
 
     DFMMOUNT::MountPassInfo info;

--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -653,6 +653,10 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
     QString reportName = "Unknown Disk";
     QString subGroup = Global::Scheme::kComputer;
 
+    QStringList netShareSchemes { Global::Scheme::kSmb, Global::Scheme::kFtp, Global::Scheme::kSFtp,
+                                  Global::Scheme::kDav, Global::Scheme::kDavs, Global::Scheme::kNfs };
+    QUrl netShareUrl = QUrl(info->extraProperty(DeviceProperty::kId).toString());
+
     if (info->extraProperty(DeviceProperty::kIsLoopDevice).toBool()) {
         visableKey = kItemVisiableControlKeys[1];
         visableName = kItemVisiableControlNames[1];
@@ -660,7 +664,9 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
         visableKey = kItemVisiableControlKeys[0];
         visableName = kItemVisiableControlNames[0];
         reportName = info->targetUrl().path() == "/" ? "System Disk" : "Data Disk";
-    } else if (info->order() == AbstractEntryFileEntity::kOrderSmb || info->order() == AbstractEntryFileEntity::kOrderFtp) {
+    } else if (info->order() == AbstractEntryFileEntity::kOrderSmb
+               || info->order() == AbstractEntryFileEntity::kOrderFtp
+               || netShareSchemes.contains(netShareUrl.scheme())) {
         visableKey = kItemVisiableControlKeys[3];
         visableName = kItemVisiableControlNames[3];
         reportName = "Sharing Folders";
@@ -668,6 +674,8 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
             subGroup = Global::Scheme::kSmb;
         else if (info->order() == AbstractEntryFileEntity::kOrderFtp)
             subGroup = Global::Scheme::kFtp;
+        else
+            subGroup = netShareUrl.scheme();
     } else {
         visableKey = kItemVisiableControlKeys[2];
         visableName = kItemVisiableControlNames[2];
@@ -704,7 +712,7 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
         { "Property_Key_Icon", QIcon::fromTheme(iconName) },
         { "Property_Key_FinalUrl", info->targetUrl().isValid() ? info->targetUrl() : QUrl() },
         { "Property_Key_QtItemFlags", QVariant::fromValue(flags) },
-        { "Property_Key_Ejectable", ejectableOrders.contains(info->order()) },
+        { "Property_Key_Ejectable", ejectableOrders.contains(info->order()) || netShareSchemes.contains(netShareUrl.scheme()) },
         { "Property_Key_CallbackItemClicked", QVariant::fromValue(cdCb) },
         { "Property_Key_CallbackContextMenu", QVariant::fromValue(contextMenuCb) },
         { "Property_Key_CallbackRename", QVariant::fromValue(renameCb) },

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -365,7 +365,10 @@ void ConnectToServerDialog::initializeUi()
         schemeComboBox = new DComboBox(this);
         supportedSchemes << QString("%1://").arg(Scheme::kSmb)
                          << QString("%1://").arg(Scheme::kFtp)
-                         << QString("%1://").arg(Scheme::kSFtp);
+                         << QString("%1://").arg(Scheme::kSFtp)
+                         << QString("%1://").arg(Scheme::kDav)
+                         << QString("%1://").arg(Scheme::kDavs)
+                         << QString("%1://").arg(Scheme::kNfs);
         schemeComboBox->addItems(supportedSchemes);
         schemeComboBox->setFixedWidth(100);
 

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
@@ -82,7 +82,7 @@ QList<CrumbData> CrumbInterface::seprateUrl(const QUrl &url)
 
     for (int count = urls.size() - 1; count >= 0; count--) {
         QUrl curUrl { urls.at(count) };
-        QStringList pathList { curUrl.path().split("/") };
+        QStringList pathList { curUrl.path().split("/", QString::SkipEmptyParts) };
         QString displayText = pathList.isEmpty() ? "" : pathList.last();
         if (curUrl.scheme() == Global::Scheme::kTrash) {
             if (UniversalUtils::urlEquals(curUrl, FileUtils::trashRootUrl())) {
@@ -91,9 +91,8 @@ QList<CrumbData> CrumbInterface::seprateUrl(const QUrl &url)
                 auto info = InfoFactory::create<FileInfo>(curUrl);
                 displayText = info ? info->displayOf(DisPlayInfoType::kFileDisplayName) : displayText;
             }
-
         }
-        CrumbData data { curUrl, displayText};
+        CrumbData data { curUrl, displayText };
         if (UrlRoute::isRootUrl(curUrl))
             data.iconName = UrlRoute::icon(curUrl.scheme()).name();
         list.append(data);

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
@@ -96,7 +96,12 @@ bool SmbBrowserEventReceiver::hookTitleBarAddrHandle(QUrl *url)
 
 bool SmbBrowserEventReceiver::hookAllowRepeatUrl(const QUrl &cur, const QUrl &pre)
 {
-    QStringList allowReEnterScehmes { Global::Scheme::kSmb, Global::Scheme::kSFtp, Global::Scheme::kFtp };
+    QStringList allowReEnterScehmes { Global::Scheme::kSmb,
+                                      Global::Scheme::kSFtp,
+                                      Global::Scheme::kFtp,
+                                      Global::Scheme::kDav,
+                                      Global::Scheme::kDavs,
+                                      Global::Scheme::kNfs };
     return allowReEnterScehmes.contains(cur.scheme()) && allowReEnterScehmes.contains(pre.scheme());
 }
 
@@ -125,7 +130,7 @@ bool SmbBrowserEventReceiver::getOriginalUri(const QUrl &in, QUrl *out)
 
     // is gvfs: since mtp/gphoto... scheme are not supported path lookup, only handle ftp/sftp/smb
     // use GIO to obtain the original URI
-    if (path.contains(QRegularExpression(R"(((^/run/user/[0-9]*/gvfs)|(^/root/.gvfs))/(ftp|sftp|smb))"))) {
+    if (path.contains(QRegularExpression(R"(((^/run/user/[0-9]*/gvfs)|(^/root/.gvfs))/(ftp|sftp|smb|dav|davs|nfs))"))) {
         SyncFileInfo f(in);
         QUrl u = f.urlOf(dfmbase::FileInfo::FileUrlInfoType::kOriginalUrl);
         if (u.isValid() && out) {

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
@@ -30,7 +30,12 @@ DFMBASE_USE_NAMESPACE
 void travers_prehandler::networkAccessPrehandler(quint64 winId, const QUrl &url, std::function<void()> after)
 {
     const auto &&scheme = url.scheme();
-    static const QStringList &kSupportedSchemes { Global::Scheme::kSmb, Global::Scheme::kFtp, Global::Scheme::kSFtp };
+    static const QStringList &kSupportedSchemes { Global::Scheme::kSmb,
+                                                  Global::Scheme::kFtp,
+                                                  Global::Scheme::kSFtp,
+                                                  Global::Scheme::kNfs,
+                                                  Global::Scheme::kDav,
+                                                  Global::Scheme::kDavs };
     if (!kSupportedSchemes.contains(scheme))
         return;
 

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.h
@@ -11,6 +11,14 @@
 
 namespace dfmplugin_smbbrowser {
 
+/**
+ * @brief The SmbBrowser class
+ * this plugin is not only for handle samba shares
+ * but also for usual schemes such as ftp/sftp/nfs/dav
+ * TODO RENAME this plugin someday!
+ * NetShareAccessHandler might be a good name.
+ */
+
 class SmbBrowser : public dpf::Plugin
 {
     Q_OBJECT


### PR DESCRIPTION
Add support for WebDAV (dav/davs) and NFS network protocols in file
manager. This includes:

- Add new protocol schemes 'dav', 'davs' and 'nfs' to global defines
- Register new protocols in SmbBrowser plugin for handling network
shares
- Add default port (2049) for NFS protocol
- Update mount dialog to support new protocols without domain field
- Update network access pre-handlers for new protocols
- Refactor SmbBrowser plugin initialization code for better
maintainability

Log: SmbBrowser plugin now handles all network share protocols (SMB/FTP/
SFTP/WebDAV/NFS)

Task: https://pms.uniontech.com/task-view-366623.html
