### PR TITLE
fix: Fixed the issue that the file manager failed to move the symbolic link file.

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -518,7 +518,7 @@ bool FileOperateBaseWorker::createSystemLink(const DFileInfoPointer &fromInfo, c
 
     do {
         actionForlink = AbstractJobHandler::SupportAction::kNoAction;
-        auto target = QUrl::fromLocalFile(newFromInfo->attribute(DFileInfo::AttributeID::kStandardSymlinkTarget).toString());
+        auto target = QUrl::fromLocalFile(newFromInfo->attribute(DFileInfo::AttributeID::kStandardFilePath).toString());
         if (localFileHandler->createSystemLink(target, toInfo->uri())) {
             return true;
         }

--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -913,7 +913,7 @@ void FileDialog::handleEnterPressed()
         }
     }
 
-    if (!exit)
+    if (!exit && d->acceptMode == QFileDialog::AcceptOpen)
         statusBar()->acceptButton()->animateClick();
 }
 


### PR DESCRIPTION
fix: Fixed the issue that the file manager failed to move the symbolic link file.

When moving a symbolic file created by the file manager to a different path or desktop, it will fail and the file will be deleted.

log: Regular documents take your own address directly.
bug: https://pms.uniontech.com/bug-view-278751.html
Influence: Movement of symbolic link files of dfm.