### PR TITLE
ix: Fixed the issue that the file manager failed to move the symbolic link file.

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -107,7 +107,7 @@ void FileOperateBaseWorker::setTargetPermissions(const QUrl &fromUrl, const QUrl
                                   fromInfo->timeOf(TimeInfoType::kLastModified).value<QDateTime>());
     QFileDevice::Permissions permissions = fromInfo->permissions();
     QString path = fromInfo->urlOf(UrlInfoType::kUrl).path();
-    //权限为0000时，源文件已经被删除，无需修改新建的文件的权限为0000
+    // 权限为0000时，源文件已经被删除，无需修改新建的文件的权限为0000
     if (permissions != 0000 && !FileUtils::isMtpFile(toInfo->urlOf(UrlInfoType::kUrl)))
         localFileHandler->setPermissions(toInfo->urlOf(UrlInfoType::kUrl), permissions);
 }
@@ -518,7 +518,13 @@ bool FileOperateBaseWorker::createSystemLink(const DFileInfoPointer &fromInfo, c
 
     do {
         actionForlink = AbstractJobHandler::SupportAction::kNoAction;
-        auto target = QUrl::fromLocalFile(newFromInfo->attribute(DFileInfo::AttributeID::kStandardSymlinkTarget).toString());
+
+        DFileInfo::AttributeID attributeId = newFromInfo->attribute(DFileInfo::AttributeID::kStandardIsSymlink).toBool()
+                ? DFileInfo::AttributeID::kStandardSymlinkTarget
+                : DFileInfo::AttributeID::kStandardFilePath;
+
+        auto target = QUrl::fromLocalFile(newFromInfo->attribute(attributeId).toString());
+
         if (localFileHandler->createSystemLink(target, toInfo->uri())) {
             return true;
         }


### PR DESCRIPTION
fix: Fixed the issue that the file manager failed to move the symbolic link file.

When moving a symbolic file created by the file manager to a different path or desktop, it will fail and the file will be deleted.

log: Regular documents take your own address directly.
bug: https://pms.uniontech.com/bug-view-278751.html
Influence: Movement of symbolic link files of dfm.