### PR TITLE
fix: [filecopy]optimize local file copy using copy_file_range

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -78,53 +78,6 @@ void DoCopyFileWorker::doFileCopy(const DFileInfoPointer fromInfo, const DFileIn
     workData->completeFileCount++;
 }
 
-void DoCopyFileWorker::doMemcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *dest, char *source, size_t size)
-{
-    size_t copySize = size;
-    char *destStart = dest;
-    char *sourceStart = source;
-    size_t everyCopySize = kMaxBufferLength;
-    while (copySize > 0 && !isStopped()) {
-        if (Q_UNLIKELY(!stateCheck())) {
-            break;
-        }
-        everyCopySize = copySize >= everyCopySize ? everyCopySize : copySize;
-
-        AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
-
-        do {
-            action = AbstractJobHandler::SupportAction::kNoAction;
-            if (!memcpy(destStart, sourceStart, everyCopySize)) {
-                auto lastError = strerror(errno);
-                fmWarning() << "file memcpy error, url from: " << fromInfo->uri()
-                            << " url to: " << toInfo->uri()
-                            << " error code: " << errno << " error msg: " << lastError;
-
-                action = doHandleErrorAndWait(fromInfo->uri(), toInfo->uri(),
-                                              AbstractJobHandler::JobErrorType::kWriteError,
-                                              true, lastError);
-            }
-        } while (action == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
-
-        checkRetry();
-
-        if (!actionOperating(action, static_cast<qint64>(copySize), nullptr)) {
-            if (action == AbstractJobHandler::SupportAction::kSkipAction)
-                emit skipCopyLocalBigFile(fromInfo->uri());
-            return;
-        }
-
-        copySize -= everyCopySize;
-        destStart += everyCopySize;
-        sourceStart += everyCopySize;
-
-        if (memcpySkipUrl.isValid() && memcpySkipUrl == fromInfo->uri())
-            return;
-
-        workData->currentWriteSize += static_cast<int64_t>(everyCopySize);
-    }
-}
-
 bool DoCopyFileWorker::doDfmioFileCopy(const DFileInfoPointer fromInfo,
                                        const DFileInfoPointer toInfo, bool *skip)
 {
@@ -205,6 +158,49 @@ void DoCopyFileWorker::syncBlockFile(const DFileInfoPointer toInfo)
         syncfs(tofd);
         close(tofd);
     }
+}
+
+/*!
+ * \brief DoCopyFileWorker::openFile
+ * \param fromInfo
+ * \param toInfo
+ * \param flags
+ * \param skip
+ * \param isSource
+ * \return
+ */
+int DoCopyFileWorker::openFileBySys(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
+                                    const int flags, bool *skip, const bool isSource)
+{
+    int fd = -1;
+    AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
+    auto openUrl = isSource ? fromInfo->uri() : toInfo->uri();
+    do {
+        action = AbstractJobHandler::SupportAction::kNoAction;
+        if (flags & O_CREAT) {
+            fd = open(openUrl.path().toStdString().c_str(), flags, 0666);
+        } else {
+            fd = open(openUrl.path().toStdString().c_str(), flags);
+        }
+        if (fd < 0) {
+            auto lastError = strerror(errno);
+            fmWarning() << "file open error, url from: " << fromInfo->uri()
+                       << " url to: " << toInfo->uri() << " open flag: " << flags
+                       << " open url : " << openUrl << " error msg: " << lastError;
+            action = doHandleErrorAndWait(fromInfo->uri(), toInfo->uri(),
+                                          AbstractJobHandler::JobErrorType::kOpenError,
+                                          !isSource, lastError);
+        }
+    } while (action == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
+    checkRetry();
+    auto fileSize = fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
+    if (!actionOperating(action, fileSize <= 0 ? FileUtils::getMemoryPageSize() : fileSize, skip)) {
+        close(fd);
+        return -1;
+    }
+    if (isSource && fileSize > 100 * 1024 * 1024)
+        readahead(fd, 0, static_cast<size_t>(fileSize));
+    return fd;
 }
 
 // copy thread using
@@ -298,6 +294,90 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFilePractically(const DFileInfo
     if (skip && *skip)
         FileUtils::notifyFileChangeManual(DFMBASE_NAMESPACE::Global::FileNotifyType::kFileAdded, toInfo->uri());
 
+    return NextDo::kDoCopyNext;
+}
+
+/*!
+ * \brief DoCopyFileWorker::doCopyFileByRange
+ * \param fromInfo
+ * \param toInfo
+ * \param skip
+ * \return
+ */
+DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFileByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip)
+{
+    if (isStopped())
+        return NextDo::kDoCopyErrorAddCancel;
+    // emit current task url
+    emit currentTask(fromInfo->uri(), toInfo->uri());
+    // open source file
+    int sourcFd = openFileBySys(fromInfo, toInfo, O_RDONLY, skip);
+    if (sourcFd < 0)
+        return NextDo::kDoCopyErrorAddCancel;
+    FinallyUtil releaseSc([&] {
+        close(sourcFd);
+    });
+    int targetFd = openFileBySys(fromInfo, toInfo, O_CREAT | O_WRONLY | O_TRUNC, skip, false);
+    if (targetFd < 0) {
+        return NextDo::kDoCopyErrorAddCancel;
+    }
+    FinallyUtil releaseTg([&] {
+        close(targetFd);
+    });
+    // 源文件大小如果为0
+    auto fromSize = fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
+    if (fromSize <= 0) {
+        // 对文件加权
+        setTargetPermissions(fromInfo->uri(), toInfo->uri());
+        workData->zeroOrlinkOrDirWriteSize += FileUtils::getMemoryPageSize();
+        FileUtils::notifyFileChangeManual(DFMBASE_NAMESPACE::Global::FileNotifyType::kFileAdded, toInfo->uri());
+        if (workData->exBlockSyncEveryWrite || DeviceUtils::isSamba(toInfo->uri()))
+            syncfs(targetFd);
+        return NextDo::kDoCopyNext;
+    }
+    // 循环读取和写入文件，拷贝
+    auto toIsSmb = DeviceUtils::isSamba(toInfo->uri());
+    size_t blockSize = static_cast<size_t>(fromSize > kMaxBufferLength ? kMaxBufferLength : fromSize);
+    off_t offset_in = 0;
+    off_t offset_out = 0;
+    ssize_t result = -1;
+    AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
+    do {
+        if (Q_UNLIKELY(!stateCheck()))
+            return NextDo::kDoCopyErrorAddCancel;
+        do {
+            if (Q_UNLIKELY(!stateCheck()))
+                return NextDo::kDoCopyErrorAddCancel;
+            result = copy_file_range(sourcFd, &offset_in, targetFd, &offset_out, blockSize, 0);
+            if (result < 0) {
+                auto lastError = strerror(errno);
+                fmWarning() << "copy file range error, url from: " << fromInfo->uri()
+                           << " url to: " << toInfo->uri() << " error msg: " << lastError;
+                action = doHandleErrorAndWait(fromInfo->uri(), toInfo->uri(),
+                                              AbstractJobHandler::JobErrorType::kWriteError,
+                                              false, lastError);
+                offset_in = qMin(offset_in, offset_out);
+                offset_out = offset_in;
+            } else {
+                workData->currentWriteSize += result;
+            }
+        } while (action == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
+        checkRetry();
+        if (!actionOperating(action, fromSize - offset_out, skip))
+            return  NextDo::kDoCopyErrorAddCancel;
+        // 执行同步策略
+        if (workData->exBlockSyncEveryWrite || toIsSmb)
+            syncfs(targetFd);
+    } while (offset_out != fromSize);
+    // 执行同步策略
+    if (workData->exBlockSyncEveryWrite  || toIsSmb)
+        syncfs(targetFd);
+    // 对文件加权
+    setTargetPermissions(fromInfo->uri(), toInfo->uri());
+    if (!stateCheck())
+        return NextDo::kDoCopyErrorAddCancel;
+    if (skip && *skip)
+        FileUtils::notifyFileChangeManual(DFMBASE_NAMESPACE::Global::FileNotifyType::kFileAdded, toInfo->uri());
     return NextDo::kDoCopyNext;
 }
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -59,10 +59,11 @@ public:
     // normal copy
     NextDo doCopyFilePractically(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo,
                                  bool *skip);
+    // normal copy
+    NextDo doCopyFileByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo,
+                             bool *skip);
     // small file copy
     void doFileCopy(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
-    // big file copy in system device
-    void doMemcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *dest, char *source, size_t size);
     // copy file by dfmio
     bool doDfmioFileCopy(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
 signals:
@@ -117,6 +118,8 @@ private:   // file copy
     void checkRetry();
     bool isStopped();
     void syncBlockFile(const DFileInfoPointer toInfo);
+    int openFileBySys(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
+                      const int flags, bool *skip, const bool isSource = true);
 public:
     static void progressCallback(int64_t current, int64_t total, void *progressData);
 

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -642,7 +642,7 @@ bool FileOperateBaseWorker::checkAndCopyFile(const DFileInfoPointer fromInfo, co
         }
         if (fromSize > bigFileSize) {
             bigFileCopy = true;
-            auto result = doCopyLocalBigFile(fromInfo, toInfo, skip);
+            auto result = doCopyLocalByRange(fromInfo, toInfo, skip);
             bigFileCopy = false;
             return result;
         }
@@ -889,172 +889,15 @@ bool FileOperateBaseWorker::doCopyLocalFile(const DFileInfoPointer fromInfo, con
     return true;
 }
 
-bool FileOperateBaseWorker::doCopyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip)
+bool FileOperateBaseWorker::doCopyLocalByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip)
 {
     waitThreadPoolOver();
-    // open file
-    auto fromFd = doOpenFile(fromInfo, toInfo, false, O_RDONLY, skip);
-    if (fromFd < 0)
-        return false;
-    auto toFd = doOpenFile(fromInfo, toInfo, true, O_CREAT | O_RDWR, skip);
-    if (toFd < 0) {
-        close(fromFd);
-        return false;
-    }
-    // resize target file
-    if (!doCopyLocalBigFileResize(fromInfo, toInfo, toFd, skip)) {
-        close(fromFd);
-        close(toFd);
-        return false;
-    }
-    // mmap file
-    auto fromPoint = doCopyLocalBigFileMap(fromInfo, toInfo, fromFd, PROT_READ, skip);
-    if (!fromPoint) {
-        close(fromFd);
-        close(toFd);
-        return false;
-    }
-    auto toPoint = doCopyLocalBigFileMap(fromInfo, toInfo, toFd, PROT_WRITE, skip);
-    if (!toPoint) {
-        munmap(fromPoint, static_cast<size_t>(fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong()));
-        close(fromFd);
-        close(toFd);
-        return false;
-    }
-    // memcpy file in other thread
-    memcpyLocalBigFile(fromInfo, toInfo, fromPoint, toPoint);
-    // wait copy
-    waitThreadPoolOver();
-    // clear
-    doCopyLocalBigFileClear(static_cast<size_t>(fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong()), fromFd, toFd, fromPoint, toPoint);
-    // set permissions
-    setTargetPermissions(fromInfo->uri(), toInfo->uri());
-    return true;
-}
+    const QString &targetUrl = toInfo->uri().toString();
 
-bool FileOperateBaseWorker::doCopyLocalBigFileResize(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int toFd, bool *skip)
-{
-    AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
-    __off_t length = fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
-    do {
-        action = AbstractJobHandler::SupportAction::kNoAction;
-        if (-1 == ftruncate(toFd, length)) {
-            auto lastError = strerror(errno);
-            fmWarning() << "file resize error, url from: " << fromInfo->uri()
-                        << " url to: " << toInfo->uri() << " open flag: " << O_RDONLY
-                        << " error code: " << errno << " error msg: " << lastError;
-
-            action = doHandleErrorAndWait(fromInfo->uri(), toInfo->uri(),
-                                          AbstractJobHandler::JobErrorType::kResizeError, true, lastError);
-        }
-    } while (action == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
-
-    checkRetry();
-
-    if (!actionOperating(action, length <= 0 ? FileUtils::getMemoryPageSize() : length, skip))
-        return false;
-
-    return true;
-}
-
-char *FileOperateBaseWorker::doCopyLocalBigFileMap(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int fd, const int per, bool *skip)
-{
-    AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
-    void *point = nullptr;
-    auto fromSize = fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
-    do {
-        action = AbstractJobHandler::SupportAction::kNoAction;
-        point = mmap(nullptr, static_cast<size_t>(fromSize),
-                     per, MAP_SHARED, fd, 0);
-        if (!point || point == MAP_FAILED) {
-            auto lastError = strerror(errno);
-            fmWarning() << "file mmap error, url from: " << fromInfo->uri()
-                        << " url to: " << fromInfo->uri()
-                        << " error code: " << errno << " error msg: " << lastError;
-
-            action = doHandleErrorAndWait(fromInfo->uri(), toInfo->uri(),
-                                          AbstractJobHandler::JobErrorType::kOpenError, fd == PROT_WRITE, lastError);
-        }
-    } while (action == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
-
-    checkRetry();
-
-    if (!actionOperating(action, fromSize <= 0 ? FileUtils::getMemoryPageSize() : fromSize, skip))
-        return nullptr;
-
-    return static_cast<char *>(point);
-}
-
-void FileOperateBaseWorker::memcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *fromPoint, char *toPoint)
-{
-    auto fromSize = fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
-    auto offset = fromSize / threadCount;
-    char *fromPointStart = fromPoint;
-    char *toPointStart = toPoint;
-    for (int i = 0; i < threadCount; i++) {
-        offset = (i == (threadCount - 1) ? fromSize - (threadCount - 1) * offset : offset);
-
-        char *tempfFromPointStart = fromPointStart;
-        char *tempfToPointStart = toPointStart;
-        size_t tempOffet = static_cast<size_t>(offset);
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-        QtConcurrent::run(threadPool.data(), threadCopyWorker[i].data(),
-                          static_cast<void (DoCopyFileWorker::*)(const DFileInfoPointer fromInfo,
-                                                                 const DFileInfoPointer toInfo,
-                                                                 char *dest, char *source, size_t size)>(&DoCopyFileWorker::doMemcpyLocalBigFile),
-                          fromInfo, toInfo, tempfToPointStart, tempfFromPointStart, tempOffet);
-#else
-        QtConcurrent::run(threadPool.data(), [this, i, fromInfo, toInfo, tempfToPointStart, tempfFromPointStart, tempOffet]() {
-            threadCopyWorker[i]->doMemcpyLocalBigFile(fromInfo, toInfo, tempfToPointStart, tempfFromPointStart, tempOffet);
-        });
-#endif
-
-        fromPointStart += offset;
-        toPointStart += offset;
-    }
-}
-
-void FileOperateBaseWorker::doCopyLocalBigFileClear(const size_t size,
-                                                    const int fromFd, const int toFd, char *fromPoint, char *toPoint)
-{
-    munmap(fromPoint, size);
-    munmap(toPoint, size);
-    close(fromFd);
-    close(toFd);
-}
-
-int FileOperateBaseWorker::doOpenFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo,
-                                      const bool isTo, const int openFlag, bool *skip)
-{
-    AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
-    emitCurrentTaskNotify(fromInfo->uri(), toInfo->uri());
-    int fd = -1;
-    do {
-        QUrl url = isTo ? toInfo->uri() : fromInfo->uri();
-        std::string path = url.path().toStdString();
-        fd = open(path.c_str(), openFlag, 0666);
-        action = AbstractJobHandler::SupportAction::kNoAction;
-        if (fd < 0) {
-            auto lastError = strerror(errno);
-            fmWarning() << "file open error, url from: " << fromInfo->uri()
-                        << " url to: " << fromInfo->uri() << " open flag: " << openFlag
-                        << " error code: " << errno << " error msg: " << lastError;
-
-            action = doHandleErrorAndWait(fromInfo->uri(), toInfo->uri(),
-                                          AbstractJobHandler::JobErrorType::kOpenError, isTo, lastError);
-        }
-    } while (action == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
-
-    checkRetry();
-
-    auto fromSize = fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
-    if (!actionOperating(action, fromSize <= 0 ? FileUtils::getMemoryPageSize() : fromSize, skip)) {
-        if (fd >= 0)
-            close(fd);
-        return -1;
-    }
-
-    return fd;
+    FileUtils::cacheCopyingFileUrl(targetUrl);
+    DoCopyFileWorker::NextDo nextDo = threadCopyWorker[0]->doCopyFileByRange(fromInfo, toInfo, skip);
+    FileUtils::removeCopyingFileUrl(targetUrl);
+    return nextDo != DoCopyFileWorker::NextDo::kDoCopyNext;
 }
 
 bool FileOperateBaseWorker::doCopyOtherFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip)

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -97,16 +97,7 @@ private:
     QUrl createNewTargetUrl(const DFileInfoPointer &toInfo, const QString &fileName);
     bool doCopyLocalFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
     bool doCopyOtherFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
-    bool doCopyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
-
-private:   // do copy local big file
-    bool doCopyLocalBigFileResize(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int toFd, bool *skip);
-    char *doCopyLocalBigFileMap(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, int fd, const int per, bool *skip);
-    void memcpyLocalBigFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, char *fromPoint, char *toPoint);
-    void doCopyLocalBigFileClear(const size_t size, const int fromFd,
-                                 const int toFd, char *fromPoint, char *toPoint);
-    int doOpenFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, const bool isTo,
-                   const int openFlag, bool *skip);
+    bool doCopyLocalByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
 
 protected Q_SLOTS:
     void emitErrorNotify(const QUrl &from, const QUrl &to, const AbstractJobHandler::JobErrorType &error,


### PR DESCRIPTION
Replace mmap-based big file copy with copy_file_range system call for better performance and reliability. The changes include:

- Remove mmap-based file copy implementation (doMemcpyLocalBigFile)
- Add new doCopyFileByRange method using copy_file_range syscall
- Add openFileBySys helper method for file descriptor operations
- Rename doCopyLocalBigFile to doCopyLocalByRange for clarity
- Simplify file copy logic by removing manual memory management

This change improves file copy performance by:
1. Using kernel-level copy_file_range for efficient data transfer
2. Avoiding memory mapping overhead for large files
3. Reducing memory usage by removing manual buffer management

Log: When copying large files, the swap partition is heavily used and the UI interface lags severely
Bug: https://pms.uniontech.com/bug-view-273191.html