### PR TITLE
fix: Fixed The dde-file-manager-service service cannot be started after deepin-service-manager security hardening.     

### DIFF
--- a/debian/dde-file-manager-services-plugins.install
+++ b/debian/dde-file-manager-services-plugins.install
@@ -3,3 +3,4 @@ usr/share/deepin-service-manager/system/*.json
 
 usr/share/dbus-1/system.d/*.conf
 usr/share/dbus-1/system-services/*.service
+etc/systemd/system/deepin-service-group@.service.d/*

--- a/debian/rules
+++ b/debian/rules
@@ -22,3 +22,9 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	dh_auto_build -- -j8
+
+override_dh_auto_install:
+	dh_auto_install --destdir=debian/tmp
+	
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -107,7 +107,7 @@ void FileOperateBaseWorker::setTargetPermissions(const QUrl &fromUrl, const QUrl
                                   fromInfo->timeOf(TimeInfoType::kLastModified).value<QDateTime>());
     QFileDevice::Permissions permissions = fromInfo->permissions();
     QString path = fromInfo->urlOf(UrlInfoType::kUrl).path();
-    //权限为0000时，源文件已经被删除，无需修改新建的文件的权限为0000
+    // 权限为0000时，源文件已经被删除，无需修改新建的文件的权限为0000
     if (permissions != 0000 && !FileUtils::isMtpFile(toInfo->urlOf(UrlInfoType::kUrl)))
         localFileHandler->setPermissions(toInfo->urlOf(UrlInfoType::kUrl), permissions);
 }
@@ -518,7 +518,13 @@ bool FileOperateBaseWorker::createSystemLink(const DFileInfoPointer &fromInfo, c
 
     do {
         actionForlink = AbstractJobHandler::SupportAction::kNoAction;
-        auto target = QUrl::fromLocalFile(newFromInfo->attribute(DFileInfo::AttributeID::kStandardSymlinkTarget).toString());
+
+        DFileInfo::AttributeID attributeId = newFromInfo->attribute(DFileInfo::AttributeID::kStandardIsSymlink).toBool()
+                ? DFileInfo::AttributeID::kStandardSymlinkTarget
+                : DFileInfo::AttributeID::kStandardFilePath;
+
+        auto target = QUrl::fromLocalFile(newFromInfo->attribute(attributeId).toString());
+
         if (localFileHandler->createSystemLink(target, toInfo->uri())) {
             return true;
         }

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -4,4 +4,5 @@ add_subdirectory(accesscontrol)
 add_subdirectory(sharecontrol)
 add_subdirectory(anything)
 add_subdirectory(mountcontrol)
-
+# 安全加固
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deepin-service-group@.service.d DESTINATION /etc/systemd/system/)

--- a/src/services/deepin-service-group@.service.d/dde-file-manage-service-override.conf
+++ b/src/services/deepin-service-group@.service.d/dde-file-manage-service-override.conf
@@ -1,0 +1,6 @@
+# 由于设备管理器对于系统资源的访问，安全加固时需要放开一些权限
+[Service]
+DevicePolicy=
+PrivateDevices=no
+PrivateNetwork=no
+RestrictAddressFamilies=


### PR DESCRIPTION
fix: Fixed The dde-file-manager-service service cannot be started after deepin-service-manager security hardening.
    
After deepin-service-manager security hardening, some services of the document management system begin to fail to start abnormally.
    
log: Add the appropriate permissions for dde-file-manager-service-plugin.
bug: https://pms.uniontech.com/bug-view-275217.html#google_vignette
Influence: Check whether the file management service process is started normally.