### PR TITLE
Fixed The dde-file-manager-service service cannot be started after deepin-service-manager security hardening.

### DIFF
--- a/debian/dde-file-manager-services-plugins.install
+++ b/debian/dde-file-manager-services-plugins.install
@@ -3,3 +3,4 @@ usr/share/deepin-service-manager/system/*.json
 
 usr/share/dbus-1/system.d/*.conf
 usr/share/dbus-1/system-services/*.service
+etc/systemd/system/deepin-service-group@.service.d/*

--- a/debian/rules
+++ b/debian/rules
@@ -22,3 +22,9 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	dh_auto_build -- -j8
+
+override_dh_auto_install:
+	dh_auto_install --destdir=debian/tmp
+	
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -4,4 +4,5 @@ add_subdirectory(accesscontrol)
 add_subdirectory(sharecontrol)
 add_subdirectory(anything)
 add_subdirectory(mountcontrol)
-
+# 安全加固
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deepin-service-group@.service.d DESTINATION /etc/systemd/system/)

--- a/src/services/deepin-service-group@.service.d/dde-file-manage-service-override.conf
+++ b/src/services/deepin-service-group@.service.d/dde-file-manage-service-override.conf
@@ -1,0 +1,6 @@
+# 开放下列安全加固选项给文件管理服务
+[Service]
+DevicePolicy=
+PrivateDevices=no
+PrivateNetwork=no
+RestrictAddressFamilies=


### PR DESCRIPTION
fix: Fixed The dde-file-manager-service service cannot be started after deepin-service-manager security hardening.
    
After deepin-service-manager security hardening, some services of the document management system begin to fail to start abnormally.
    
log: Add the appropriate permissions for dde-file-manager-service-plugin.
bug: https://pms.uniontech.com/bug-view-275217.html\#google_vignette
