### PR TITLE
fix: [translations] lost dtk translations

### DIFF
--- a/src/external/dde-shell-plugins/panel-desktop/main.cpp
+++ b/src/external/dde-shell-plugins/panel-desktop/main.cpp
@@ -233,6 +233,8 @@ public:
         DGuiApplicationHelper::loadTranslator(QStringLiteral("dde-file-manager"),
                                               desktop::translationDir(),
                                               { QLocale::system() });
+        if (qApp)
+            qApp->loadTranslator();
 
         // DBus
         {


### PR DESCRIPTION
use `qApp->loadTranslator()` load dtk translations

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-277419.html