### PR TITLE
fix: Use the QList insert method to perform a validation check, and u…

### DIFF
--- a/src/plugins/common/core/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/core/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -186,10 +186,10 @@ bool BookMarkManager::addBookMark(const QList<QUrl> &urls)
             sortedUrls.append(url);
             addBookMarkItem(url, info.fileName());
 
-            //add data to dconfig
+            // add data to dconfig
             newData.remove(kKeydefaultItem);   // bookmark data in dconfig dont have keys : `defaultItem` and `index`
             newData.remove(kKeyIndex);
-            newData.insert(kKeyUrl, url.toEncoded());   //here must be encoded and keep compatibility
+            newData.insert(kKeyUrl, url.toEncoded());   // here must be encoded and keep compatibility
             newData.insert(kKeyLocateUrl, url.path().toUtf8().toBase64());
             addBookmarkToDConfig(newData);
         }
@@ -302,7 +302,11 @@ void BookMarkManager::initData()
     const QList<BookmarkData> &defPreDefInitOrder { DefaultItemManager::instance()->defaultPreDefInitOrder() };
     for (const auto &data : defPreDefInitOrder) {
         quickAccessDataMap[data.url] = data;
-        sortedUrls.insert(data.index, data.url);
+
+        if (sortedUrls.size() < data.index || data.index < 0)
+            sortedUrls.append(data.url);
+        else
+            sortedUrls.insert(data.index, data.url);
     }
 }
 
@@ -525,7 +529,7 @@ void BookMarkManager::renameBookmarkToDConfig(const QString &oldName, const QStr
     for (int i = 0; i < list.size(); ++i) {
         QVariantMap map = list.at(i).toMap();
         if (map.value(kKeyName).toString() == oldName) {
-            map[kKeyName] = newName;   //update name
+            map[kKeyName] = newName;   // update name
             map[kKeyLastModi] = QDateTime::currentDateTime().toString(Qt::ISODate);
             list.replace(i, map);
             DConfigManager::instance()->setValue(kConfName, kconfBookmark, list);
@@ -540,7 +544,7 @@ void BookMarkManager::updateBookmarkUrlToDconfig(const QUrl &oldUrl, const QUrl 
     for (int i = 0; i < list.size(); ++i) {
         QVariantMap map = list.at(i).toMap();
         if (map.value(kKeyUrl).toString() == oldUrl.toEncoded()) {
-            map[kKeyUrl] = newUrl.toEncoded();   //update url, here must be encoded
+            map[kKeyUrl] = newUrl.toEncoded();   // update url, here must be encoded
             map[kKeyLastModi] = QDateTime::currentDateTime().toString(Qt::ISODate);
             map[kKeyLocateUrl] = newUrl.path().toUtf8().toBase64();
             list.replace(i, map);

--- a/src/plugins/common/dfmplugin-tag/menu/tagdirmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagdirmenuscene.cpp
@@ -71,7 +71,12 @@ void TagDirMenuScenePrivate::updateMenu(QMenu *menu)
         // insert 'OpenFileLocation' action
         if (openLocalAct) {
             actions.removeOne(openLocalAct);
-            actions.insert(1, openLocalAct);
+
+            if (actions.size() < 1)
+                actions.append(openLocalAct);
+            else
+                actions.insert(1, openLocalAct);
+
             menu->addActions(actions);
         }
     }

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/extensionlibmenuscene.cpp
@@ -120,7 +120,10 @@ void ExtensionLibMenuScene::updateState(QMenu *parent)
             if (actions.contains(befor) && actionIndex != -1) {
                 actions.removeAt(actionIndex);
                 int beforIndex { actions.indexOf(befor) };
-                actions.insert(beforIndex, action);
+                if (actions.size() < beforIndex || beforIndex < 0)
+                    actions.append(action);
+                else
+                    actions.insert(beforIndex, action);
             }
         }
         parent->addActions(actions);

--- a/src/plugins/desktop/ddplugin-organizer/mode/custom/customdatahandler.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/custom/customdatahandler.cpp
@@ -9,15 +9,12 @@
 using namespace ddplugin_organizer;
 
 CustomDataHandler::CustomDataHandler(QObject *parent)
-    : CollectionDataProvider(parent)
-    , ModelDataHandler()
+    : CollectionDataProvider(parent), ModelDataHandler()
 {
-
 }
 
 CustomDataHandler::~CustomDataHandler()
 {
-
 }
 
 void CustomDataHandler::check(const QSet<QUrl> &vaild)
@@ -133,7 +130,10 @@ void CustomDataHandler::insert(const QUrl &url, const QString &key, const int in
         base->key = key;
         base->items << url;
     } else {
-        it.value()->items.insert(index, url);
+        if (it.value()->items.size() < index || index < 0)
+            it.value()->items.append(url);
+        else
+            it.value()->items.insert(index, url);
     }
 
     emit itemsChanged(key);
@@ -143,10 +143,9 @@ bool CustomDataHandler::acceptInsert(const QUrl &url)
 {
     // todo(wcl) 新建流程
 
-
     for (auto iter = collections.begin(); iter != collections.end(); ++iter) {
         if (iter.value()->items.contains(url)) {
-           return true;
+            return true;
         }
     }
 
@@ -171,7 +170,7 @@ bool CustomDataHandler::acceptRename(const QUrl &oldUrl, const QUrl &newUrl)
 {
     for (auto iter = collections.begin(); iter != collections.end(); ++iter) {
         if (iter.value()->items.contains(oldUrl)
-                || iter.value()->items.contains(newUrl))
+            || iter.value()->items.contains(newUrl))
             return true;
     }
 

--- a/src/plugins/filemanager/core/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/models/computermodel.cpp
@@ -298,7 +298,10 @@ void ComputerModel::onItemAdded(const ComputerItemData &data)
         }
 
         beginInsertRows(QModelIndex(), row, row);
-        items.insert(row, data);
+        if (items.size() < row || row < 0)
+            items.append(data);
+        else
+            items.insert(row, data);
         endInsertRows();
     }
 
@@ -449,7 +452,12 @@ void ComputerModel::addGroup(const ComputerItemData &data)
                 insertAt = i + 1;
         }
         beginInsertRows(QModelIndex(), insertAt, insertAt);
-        items.insert(insertAt, data);
+
+        if (insertAt > items.size() || insertAt < 0)
+            items.append(data);
+        else
+            items.insert(insertAt, data);
+
         endInsertRows();
     } else {   // append it, maybe someday vault will take the 3rd position.
         beginInsertRows(QModelIndex(), items.count(), items.count());

--- a/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -473,7 +473,11 @@ void ComputerItemWatcher::cacheItem(const ComputerItemData &in)
         if (ComputerItemWatcher::typeCompare(in, item))
             break;
     }
-    initedDatas.insert(insertAt, in);
+
+    if (initedDatas.size() < insertAt || insertAt < 0)
+        initedDatas.append(in);
+    else
+        initedDatas.insert(insertAt, in);
 }
 
 QString ComputerItemWatcher::reportName(const QUrl &url)

--- a/src/plugins/filemanager/core/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
@@ -78,7 +78,12 @@ bool SideBarInfoCacheMananger::insertItemInfoCache(SideBarInfoCacheMananger::Ind
         return false;
 
     CacheInfoList &cache = cacheInfoMap[info.group];
-    cache.insert(i, info);
+
+    if (cache.size() < i || i < 0)
+        cache.append(info);
+    else
+        cache.insert(i, info);
+
     bindedInfos[info.url] = info;
 
     return true;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -163,7 +163,8 @@ void FileViewModel::doExpand(const QModelIndex &index)
     const QUrl &url = index.data(kItemUrlRole).toUrl();
     RootInfo *expandRoot = FileDataManager::instance()->fetchRoot(url);
 
-    connect(expandRoot, &RootInfo::requestCloseTab, this, [](const QUrl &url) { WorkspaceHelper::instance()->closeTab(url); }, Qt::QueuedConnection);
+    connect(
+            expandRoot, &RootInfo::requestCloseTab, this, [](const QUrl &url) { WorkspaceHelper::instance()->closeTab(url); }, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::getSourceData, expandRoot, &RootInfo::handleGetSourceData, Qt::QueuedConnection);
     connect(expandRoot, &RootInfo::sourceDatas, filterSortWorker.data(), &FileSortWorker::handleSourceChildren, Qt::QueuedConnection);
     connect(expandRoot, &RootInfo::iteratorLocalFiles, filterSortWorker.data(), &FileSortWorker::handleIteratorLocalChildren, Qt::QueuedConnection);
@@ -207,7 +208,7 @@ FileInfoPointer FileViewModel::fileInfo(const QModelIndex &index) const
         return nullptr;
 
     const QModelIndex &parentIndex = index.parent();
-    FileItemDataPointer item{ nullptr };
+    FileItemDataPointer item { nullptr };
     if (!parentIndex.isValid()) {
         item = filterSortWorker->rootData();
     } else {
@@ -584,8 +585,14 @@ QList<ItemRoles> FileViewModel::getColumnRoles() const
 
         int customCount = roles.count();
         for (auto role : defualtColumnRoleList) {
-            if (!roles.contains(role))
-                roles.insert(roles.length() - customCount, role);
+            if (!roles.contains(role)) {
+                int index = roles.length() - customCount;
+
+                if (index > roles.size() || index < 0)
+                    roles.append(role);
+                else
+                    roles.insert(index, role);
+            }
         }
     }
 
@@ -857,7 +864,8 @@ void FileViewModel::connectRootAndFilterSortWork(RootInfo *root, const bool refr
             return;
         root->addConnectToken(token);
     }
-    connect(root, &RootInfo::requestCloseTab, this, [](const QUrl &url) { WorkspaceHelper::instance()->closeTab(url); }, Qt::QueuedConnection);
+    connect(
+            root, &RootInfo::requestCloseTab, this, [](const QUrl &url) { WorkspaceHelper::instance()->closeTab(url); }, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::getSourceData, root, &RootInfo::handleGetSourceData, Qt::QueuedConnection);
     connect(root, &RootInfo::sourceDatas, filterSortWorker.data(), &FileSortWorker::handleSourceChildren, Qt::QueuedConnection);
     connect(root, &RootInfo::iteratorLocalFiles, filterSortWorker.data(), &FileSortWorker::handleIteratorLocalChildren, Qt::QueuedConnection);
@@ -915,7 +923,8 @@ void FileViewModel::initFilterSortWork()
     connect(filterSortWorker.data(), &FileSortWorker::removeRows, this, &FileViewModel::onRemove, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::removeFinish, this, &FileViewModel::onRemoveFinish, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::dataChanged, this, &FileViewModel::onDataChanged, Qt::QueuedConnection);
-    connect(filterSortWorker.data(), &FileSortWorker::requestFetchMore, this, [this]() {
+    connect(
+            filterSortWorker.data(), &FileSortWorker::requestFetchMore, this, [this]() {
         canFetchFiles = true;
         fetchingUrl = rootUrl();
         RootInfo *root = FileDataManager::instance()->fetchRoot(dirRootUrl);
@@ -924,12 +933,16 @@ void FileViewModel::initFilterSortWork()
     connect(filterSortWorker.data(), &FileSortWorker::updateRow, this, &FileViewModel::onFileUpdated, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::selectAndEditFile, this, &FileViewModel::selectAndEditFile, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::requestSetIdel, this, &FileViewModel::onWorkFinish, Qt::QueuedConnection);
-    connect(filterSortWorker.data(), &FileSortWorker::requestCursorWait, this, [this]{
-        startCursorTimer();
-    }, Qt::QueuedConnection);
-    connect(filterSortWorker.data(), &FileSortWorker::reqUestCloseCursor, this, [this]{
-        closeCursorTimer();
-    }, Qt::QueuedConnection);
+    connect(
+            filterSortWorker.data(), &FileSortWorker::requestCursorWait, this, [this] {
+                startCursorTimer();
+            },
+            Qt::QueuedConnection);
+    connect(
+            filterSortWorker.data(), &FileSortWorker::reqUestCloseCursor, this, [this] {
+                closeCursorTimer();
+            },
+            Qt::QueuedConnection);
     connect(this, &FileViewModel::requestChangeHiddenFilter, filterSortWorker.data(), &FileSortWorker::onToggleHiddenFiles, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestChangeFilters, filterSortWorker.data(), &FileSortWorker::handleFilters, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestChangeNameFilters, filterSortWorker.data(), &FileSortWorker::HandleNameFilters, Qt::QueuedConnection);
@@ -974,11 +987,12 @@ void FileViewModel::discardFilterSortObjects()
         discardedObjects.append(discardedThread);
         filterSortThread.reset();
 
-        connect(discardedThread.data(), &QThread::finished, this, [this, discardedWorker, discardedThread] {
-            discardedObjects.removeAll(discardedWorker);
-            discardedObjects.removeAll(discardedThread);
-            discardedThread->disconnect();
-        },
+        connect(
+                discardedThread.data(), &QThread::finished, this, [this, discardedWorker, discardedThread] {
+                    discardedObjects.removeAll(discardedWorker);
+                    discardedObjects.removeAll(discardedThread);
+                    discardedThread->disconnect();
+                },
                 Qt::QueuedConnection);
 
         discardedThread->quit();

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/filesortworker.cpp
@@ -20,6 +20,17 @@ using namespace dfmplugin_workspace;
 using namespace dfmbase::Global;
 using namespace dfmio;
 
+namespace {
+template<class T>
+void insertToList(QList<T> &list, int index, const T &t)
+{
+    if (index < 0 || index > list.size())
+        list.append(t);
+    else
+        list.insert(index, t);
+}
+}   // namespace
+
 FileSortWorker::FileSortWorker(const QUrl &url, const QString &key, FileViewFilterCallback callfun, const QStringList &nameFilters, const QDir::Filters filters, const QDirIterator::IteratorFlags flags, QObject *parent)
     : QObject(parent), current(url), nameFilters(nameFilters), filters(filters), flags(flags), filterCallback(callfun), currentKey(key)
 {
@@ -519,7 +530,9 @@ bool FileSortWorker::handleUpdateFile(const QUrl &url)
                     offset = childrenCount();
             }
         }
-        subVisibleList.insert(subIndex, sortInfo->fileUrl());
+
+        insertToList(subVisibleList, subIndex, sortInfo->fileUrl());
+
         visibleTreeChildren.insert(parentUrl, subVisibleList);
 
         // kItemDisplayRole 是不进行排序的
@@ -538,7 +551,8 @@ bool FileSortWorker::handleUpdateFile(const QUrl &url)
         Q_EMIT insertRows(showIndex, 1);
         {
             QWriteLocker lk(&locker);
-            visibleChildren.insert(showIndex, sortInfo->fileUrl());
+
+            insertToList(visibleChildren, showIndex, sortInfo->fileUrl());
         }
         added = true;
 
@@ -995,7 +1009,8 @@ bool FileSortWorker::addChild(const SortInfoPointer &sortInfo,
                 offset = childrenCount();
         }
     }
-    subVisibleList.insert(subIndex, sortInfo->fileUrl());
+
+    insertToList(subVisibleList, subIndex, sortInfo->fileUrl());
     visibleTreeChildren.insert(parentUrl, subVisibleList);
 
     // kItemDisplayRole 是不进行排序的
@@ -1014,7 +1029,7 @@ bool FileSortWorker::addChild(const SortInfoPointer &sortInfo,
     Q_EMIT insertRows(showIndex, 1);
     {
         QWriteLocker lk(&locker);
-        visibleChildren.insert(showIndex, sortInfo->fileUrl());
+        insertToList(visibleChildren, showIndex, sortInfo->fileUrl());
     }
 
     if (sort == AbstractSortFilter::SortScenarios::kSortScenariosWatcherAddFile)
@@ -1170,7 +1185,7 @@ QList<QUrl> FileSortWorker::sortTreeFiles(const QList<QUrl> &children, const boo
                 sortIndex = sortList.count();
             }
         }
-        sortList.insert(sortIndex, url);
+        insertToList(sortList, sortIndex, url);
     }
 
     if (sortList.isEmpty())

--- a/src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene.cpp
@@ -105,7 +105,11 @@ void SearchMenuScenePrivate::updateMenu(QMenu *menu)
         if (openLocalAct) {
             openLocalAct->setVisible(true);
             actions.removeOne(openLocalAct);
-            actions.insert(1, openLocalAct);
+
+            if (actions.size() < 1)
+                actions.append(openLocalAct);
+            else
+                actions.insert(1, openLocalAct);
             menu->addActions(actions);
         }
     }

--- a/src/plugins/filemanager/qml/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
+++ b/src/plugins/filemanager/qml/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
@@ -78,7 +78,12 @@ bool SideBarInfoCacheMananger::insertItemInfoCache(SideBarInfoCacheMananger::Ind
         return false;
 
     CacheInfoList &cache = cacheInfoMap[info.group];
-    cache.insert(i, info);
+
+    if(cache.size() < i || i < 0)
+        cache.append(info);
+    else
+        cache.insert(i, info);
+
     bindedInfos[info.url] = info;
 
     return true;

--- a/src/plugins/filemanager/qml/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/qml/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -613,8 +613,13 @@ QList<ItemRoles> FileViewModel::getColumnRoles() const
 
         int customCount = roles.count();
         for (auto role : defualtColumnRoleList) {
-            if (!roles.contains(role))
-                roles.insert(roles.length() - customCount, role);
+            if (!roles.contains(role)) {
+                int index = roles.length() - customCount;
+                if(index > roles.size() || index < 0)
+                    roles.append(role);
+                else 
+                    roles.insert(index, role);
+            }
         }
     }
 

--- a/src/tools/upgrade/units/bookmarkupgradeunit.cpp
+++ b/src/tools/upgrade/units/bookmarkupgradeunit.cpp
@@ -90,7 +90,7 @@ bool BookMarkUpgradeUnit::upgrade()
 {
     qCInfo(logToolUpgrade) << "upgrading";
     const QVariantList &quickAccessItems = initData();
-    doUpgrade(quickAccessItems);   //generate quick access field to configuration
+    doUpgrade(quickAccessItems);   // generate quick access field to configuration
 
     return true;
 }
@@ -116,7 +116,7 @@ QVariantList BookMarkUpgradeUnit::initData() const
     for (const BookmarkData &data : defPreDefInitOrder) {
         BookmarkData temData = data;
         const QVariantMap &item = temData.serialize();
-        if (data.index >= 0)
+        if (data.index >= 0 && data.index <= quickAccessItemList.size())
             quickAccessItemList.insert(data.index, item);
         else
             quickAccessItemList.append(item);
@@ -141,9 +141,9 @@ QVariantList BookMarkUpgradeUnit::initData() const
 
     auto parseUrlFromOrderData = [](const QString &src) {
         QString bookmarkOrderItem = src;
-        bookmarkOrderItem.remove(0, 9);   //remove `bookmark:`
+        bookmarkOrderItem.remove(0, 9);   // remove `bookmark:`
         QUrl url(bookmarkOrderItem);
-        QString urlString = url.toString(QUrl::RemoveFragment | QUrl::RemoveQuery);   //remove ?# or #
+        QString urlString = url.toString(QUrl::RemoveFragment | QUrl::RemoveQuery);   // remove ?# or #
         return urlString;
     };
     // 2. sort the bookmark data to `sortedBookmarkOrderList` according to `bookmarkDataList`


### PR DESCRIPTION
…se append instead of insert when the index value is greater than the size of the list

In Qt6, when the size of the list is exceeded, the insert operation of QList will trigger an assertion crash To avoid the crash, if the size bigger than list's size, use append instead.

The following are included: bookmark, tagdirmenu, workspace ..

log: The insert method of Qlist is compatible.
bug: https://pms.uniontech.com/bug-view-284723.html