### PR TITLE
fix: Switching directory lag，add stop check in file info creation loop

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -218,6 +218,8 @@ QList<SortInfoPointer> TraversalDirThreadManager::iteratorAll()
 void TraversalDirThreadManager::createFileInfo(const QList<SortInfoPointer> &list)
 {
     for (const SortInfoPointer &sortInfo : list) {
+        if (stopFlag)
+            return;
         const QUrl &url = sortInfo->fileUrl();
         InfoFactory::create<FileInfo>(url);
     }


### PR DESCRIPTION
Add a stop condition check in TraversalDirThreadManager::createFileInfo to properly handle interruption requests during file info creation process.

- Add stopFlag check in the file info creation loop
- Early return when stopFlag is set to prevent unnecessary operations
- Improve responsiveness when canceling directory traversal

This change ensures the traversal operation can be stopped promptly when requested by the user or system.

Log: Switching directory lag
Bug: https://bbs.deepin.org/post/281034