### PR TITLE
fix: improve symlink handling in cut operation

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -286,9 +286,9 @@ bool DoCutFilesWorker::checkSymLink(const DFileInfoPointer &fileInfo)
     bool ok = createSystemLink(fileInfo, newTargetInfo, true, false, &skip);
     if (!ok && !skip)
         return false;
-    ok = deleteFile(sourceUrl, QUrl(), &skip);
-    if (!ok && !skip)
-        return false;
+
+    if (ok && !skip)
+        cutAndDeleteFiles.append(fileInfo);
 
     completeSourceFiles.append(sourceUrl);
     completeTargetFiles.append(newTargetInfo->uri());

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -349,7 +349,8 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const DFileInfoPointer &fromInfo, 
         ok = createSystemLink(fromInfo, toInfo, workData->jobFlags.testFlag(AbstractJobHandler::JobFlag::kCopyFollowSymlink), true, skip);
         if (ok) {
             workData->zeroOrlinkOrDirWriteSize += FileUtils::getMemoryPageSize();
-            cutAndDeleteFiles.append(fromInfo);
+            if (!skip || !*skip)
+                cutAndDeleteFiles.append(fromInfo);
         }
     } else if (fromInfo->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool()) {
         ok = checkAndCopyDir(fromInfo, toInfo, skip);


### PR DESCRIPTION
Modify symlink handling in DoCutFilesWorker to defer deletion until after successful link creation:

- Replace immediate deletion with deferred deletion via cutAndDeleteFiles list
- Only add symlink to deletion list if creation was successful
- Maintain existing completion tracking behavior

This change prevents premature deletion of symlinks and ensures atomic cut operations for symbolic links.

Log: improve symlink handling during cut operations
Bug: https://pms.uniontech.com/bug-view-278451.html