### PR TITLE
fix: dde-file-manager copy crash,prevent memory leak in speed timer handling

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -121,7 +121,7 @@ void AbstractWorker::pause()
         return;
     if (speedtimer) {
         elapsed += speedtimer->elapsed();
-        delete speedtimer;
+        speedtimerList.append(speedtimer);
         speedtimer = nullptr;
         JobInfoPointer info(new QMap<quint8, QVariant>);
         info->insert(AbstractJobHandler::NotifyInfoKey::kJobtypeKey, QVariant::fromValue(jobType));
@@ -667,6 +667,8 @@ AbstractWorker::~AbstractWorker()
         delete speedtimer;
         speedtimer = nullptr;
     }
+
+    qDeleteAll(speedtimerList);
 }
 
 /*!

--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -194,6 +194,7 @@ public:
     std::atomic_int64_t elapsed { 0 };
     std::atomic_int64_t deleteFirstFileSize{ false };
     bool isCutMerge{false};
+    QList<QElapsedTimer *> speedtimerList;
 };
 DPFILEOPERATIONS_END_NAMESPACE
 


### PR DESCRIPTION
Fix memory management of QElapsedTimer objects in AbstractWorker:

- Store deleted timers in speedtimerList instead of immediate deletion
- Add cleanup of timer list in destructor using qDeleteAll
- Maintain existing pause/resume functionality

This change prevents potential memory leaks when pausing/resuming file operations while properly managing timer resources.

Log: dde-file-manager copy crash
Bug: https://pms.uniontech.com/bug-view-279983.html