### PR TITLE
fix: Fixed the issue that deleting a valut and creating a new one fai…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.h
@@ -113,6 +113,7 @@ private:
     bool secondSaveSaltAndCiphertext(const QString &ciphertext, const QString &salt, const char *vaultVersion);
     bool statisticsFilesInDir(const QString &dirPath, int *filesCount);
     void removeDir(const QString &dirPath, int filesCount, int *removedFileCount, int *removedDirCount);
+    void unmountLockPathAndUnLockPath();
 
 public:
     /*!


### PR DESCRIPTION
…led.

The process of creating the vault will start the cryfs process, and the cryfs process will occupy the files in the creation directory, resulting in the deletion of the vault not all the files are deleted, resulting in the failure to create the vault again in the original path.

log: During the deletion process, unmount the vaultLockPath and vaultUnlockPath first to prevent unsuccessful deletion.

bug: https://pms.uniontech.com/bug-view-284441.html
Influence: Creation and deletion of 'Vault'.