### PR TITLE
fix: improve network device mounting logic

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -708,7 +708,7 @@ void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType
                                                 { "sftp", "22" },
                                                 { "nfs", "2049" } };
     QString host = u.host();
-    QString port = defaultPort.value(u.scheme(), "21");
+    QString port = defaultPort.value(u.scheme());
 
     static QRegularExpression regUrl(R"((\w+)://([^/:]+)(:\d*)?)");
     auto match = regUrl.match(address);
@@ -728,7 +728,9 @@ void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType
     };
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
-    QStringList ports { port };
+    QStringList ports;
+    if (!port.isEmpty())
+        ports.append(port);
     static const QStringList &defaultSmbPorts { "445", "139" };
     if (u.scheme() == "smb" && defaultSmbPorts.contains(port))
         ports = defaultSmbPorts;

--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -81,6 +81,11 @@ void NetworkUtils::doAfterCheckNet(const QString &host, const QStringList &ports
         watcher->deleteLater();
     });
     watcher->setFuture(QtConcurrent::run([host, ports, msecs]() {
+        if (ports.isEmpty()) {
+            qCInfo(logDFMBase) << "port not specified, skip network check. " << host;
+            return true; // skip check if ports are empty.
+        }
+
         for (const auto &port : ports) {
             qApp->processEvents();
             if (NetworkUtils::instance()->checkNetConnection(host, port, msecs))


### PR DESCRIPTION
- Fix network device mounting by handling empty default ports
- Skip network connection check when port is not specified
- Optimize port handling for network mount operations
- Improve SMB port handling logic

Log: fix network device mounting when port is not specified in URL

Bug: https://pms.uniontech.com/bug-view-286637.html
