### PR TITLE
fix: Fixed the issue that deleting a valut and creating a new one fai…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
@@ -305,7 +305,8 @@ int FileEncryptHandlerPrivate::runVaultProcess(QString lockBaseDir, QString unlo
     }
     arguments << lockBaseDir << unlockFileDir;
 
-    process->setEnvironment({ "CRYFS_FRONTEND=noninteractive" });
+    setEnviroment(QPair<QString, QString>("CRYFS_FRONTEND", "noninteractive"));
+
     process->start(cryfsBinary, arguments);
     process->waitForStarted();
     process->write(DSecureString.toUtf8());
@@ -344,7 +345,8 @@ int FileEncryptHandlerPrivate::runVaultProcess(QString lockBaseDir, QString unlo
     }
     arguments << QString("--cipher") << encryptTypeMap.value(type) << QString("--blocksize") << QString::number(blockSize) << lockBaseDir << unlockFileDir;
 
-    process->setEnvironment({ "CRYFS_FRONTEND=noninteractive" });
+    setEnviroment(QPair<QString, QString>("CRYFS_FRONTEND", "noninteractive"));
+
     process->start(cryfsBinary, arguments);
     process->waitForStarted();
     process->write(DSecureString.toUtf8());
@@ -556,4 +558,15 @@ EncryptType FileEncryptHandlerPrivate::encryptAlgoTypeOfGroupPolicy()
     }
 
     return type;
+}
+
+void FileEncryptHandlerPrivate::setEnviroment(const QPair<QString, QString> &value)
+{
+    // Just append enviroment value, not replace.
+    if (!process)
+        return;
+
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert(value.first, value.second);
+    process->setProcessEnvironment(env);
 }

--- a/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle_p.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle_p.h
@@ -63,6 +63,7 @@ private:
     bool isSupportAlgoName(const QString &algoName);
     void syncGroupPolicyAlgoName();
     EncryptType encryptAlgoTypeOfGroupPolicy();
+    void setEnviroment(const QPair<QString, QString> &value);
 
 private:
     QProcess *process { nullptr };


### PR DESCRIPTION
   fix: Fixed the issue that deleting a valut and creating a new one failed.
    
    When using QProcess pointer variables, changing the environment variables will have an effect on the entire life cycle,
    and thus will also be affected when other processes are started. Each change to the environment variables appends the system environment variables instead of replacing them.
    
    In this bug, starting cryfs when mounted on a directory will change the environment variables, resulting in the loss of some system environment variables when using cryfs-unmount.
    
    log: The lack of environment variables causes cryfs-unmount to be unable to find the corresponding path, resulting in the failure of folder unmount.
    
    bug: https://pms.uniontech.com/bug-view-284441.html
    Influence: The normal use of the vault.