### PR TITLE
fix: add clean trash action to desktop shortcut

### DIFF
--- a/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-trash.desktop
+++ b/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-trash.desktop
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Actions=clean-trash;
 Categories=System;
 Comment=Open trash.
 Exec=dfm-open.sh trash:///
@@ -166,3 +167,11 @@ Name[zh_CN]=回收站
 Name[zh_HK]=回收站
 Name[zh_TW]=回收站
 
+[Desktop Action clean-trash]
+Exec=dde-file-manager --event "{\"action\":\"cleantrash\"}"
+Name=Clean Trash
+
+# Translations:
+# Do not manually modify!
+Name[zh_CN]=清空
+Name[zh_HK]=清空


### PR DESCRIPTION
Add a "Clean Trash" action to the dde-trash desktop shortcut:

- Add Actions entry to support right-click menu
- Add clean-trash action with command to empty trash
- Include translations for Chinese (Simplified and HK)
- Use dde-file-manager --event to trigger trash cleaning

This change allows users to empty the trash directly from the desktop shortcut's context menu.

Log: add clean trash action to desktop shortcut
Bug: https://pms.uniontech.com/bug-view-256085.html