### PR TITLE
feat: video thumbnail support qt6

### DIFF
--- a/src/apps/dde-file-manager/dragmonitor.cpp
+++ b/src/apps/dde-file-manager/dragmonitor.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "dragmonitor.h"
 
 #include <QCoreApplication>

--- a/src/apps/dde-file-manager/dragmonitor.h
+++ b/src/apps/dde-file-manager/dragmonitor.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef DRAGMONITER_H
 #define DRAGMONITER_H
 

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -99,19 +99,21 @@ QImage ThumbnailCreators::videoThumbnailCreatorLib(const QString &filePath, Thum
     Q_UNUSED(size)
 
     QImage img;
-// TODO: libimageviewer.so build wiht qt5, wait qt6 version...
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     static QLibrary lib("libimageviewer.so");
+#else
+    static QLibrary lib("libimageviewer6.so");
+#endif
+
     if (lib.isLoaded() || lib.load()) {
         typedef void (*GetMovieCover)(const QUrl &, const QString &, QImage *);
         GetMovieCover func = reinterpret_cast<GetMovieCover>(lib.resolve("getMovieCover"));
 
         if (func)
             func(QUrl::fromLocalFile(filePath), filePath, &img);
+    } else {
+        qCWarning(logDFMBase) << "thumbnail: cannot load " << lib.fileName() << "error: " << lib.errorString();
     }
-#else
-    qCWarning(logDFMBase) << "libimageviewer.so is not Qt6";
-#endif
 
     return img;
 }

--- a/src/plugins/desktop/core/ddplugin-canvas/dragmonitor.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/dragmonitor.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "dragmonitor.h"
 
 #include <QCoreApplication>

--- a/src/plugins/desktop/core/ddplugin-canvas/dragmonitor.h
+++ b/src/plugins/desktop/core/ddplugin-canvas/dragmonitor.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef DRAGMONITER_H
 #define DRAGMONITER_H
 


### PR DESCRIPTION
The dependency package libimageeditor has been updated to support Qt6, update the name of the dynamic library found in Qt6 to `libimageviewer6.so`.

Log: Video thumbnail support Qt6.
Influence: thumbnail