### PR TITLE
fix: optimize system path related functions

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -356,20 +356,24 @@ bool FileUtils::isSameFile(const QUrl &url1, const QUrl &url2, const Global::Cre
     if (!info1 || !info2)
         return false;
 
-    struct stat statFromInfo;
-    struct stat statToInfo;
-
     const QString &path1 = info1->pathOf(PathInfoType::kAbsoluteFilePath);
     const QString &path2 = info2->pathOf(PathInfoType::kAbsoluteFilePath);
-    int fromStat = stat(path1.toLocal8Bit().data(), &statFromInfo);
-    int toStat = stat(path2.toLocal8Bit().data(), &statToInfo);
-    if (0 == fromStat && 0 == toStat) {
+
+    return isSameFile(path1, path2);
+}
+
+bool FileUtils::isSameFile(const QString &path1, const QString &path2) 
+{
+    struct stat stat1;
+    struct stat stat2;
+    int ret1 = stat(path1.toLocal8Bit().data(), &stat1);
+    int ret2 = stat(path2.toLocal8Bit().data(), &stat2);
+    if (0 == ret1 && 0 == ret2) {
         // 通过inode判断是否是同一个文件
-        if (statFromInfo.st_ino == statToInfo.st_ino
-            && statFromInfo.st_dev == statToInfo.st_dev) {   //! 需要判断设备号
-            return true;
-        }
+        return (stat1.st_ino == stat2.st_ino
+            && stat1.st_dev == stat2.st_dev);   //! 需要判断设备号
     }
+
     return false;
 }
 

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -45,6 +45,7 @@ public:
     static bool isSameDevice(const QUrl &url1, const QUrl &url2);
     static bool isSameFile(const QUrl &url1, const QUrl &url2,
                            const Global::CreateFileInfoType infoCache = Global::CreateFileInfoType::kCreateFileInfoAuto);
+    static bool isSameFile(const QString &path1, const QString &path2);
     static bool isLocalDevice(const QUrl &url);
     static bool isCdRomDevice(const QUrl &url);
     static bool trashIsEmpty();

--- a/src/dfm-base/utils/systempathutil.h
+++ b/src/dfm-base/utils/systempathutil.h
@@ -35,9 +35,9 @@ private:
     ~SystemPathUtil();
     void initialize();
     void mkPath(const QString &path);
-    void cleanPath(QString *path) const;
     bool checkContainsSystemPathByFileInfo(const QList<QUrl> &urlList);
     bool checkContainsSystemPathByFileUrl(const QList<QUrl> &urlList);
+    QString findSystemPathKey(const QString &path) const;
 
 public:
     void loadSystemPaths();

--- a/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionparser.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionparser.cpp
@@ -373,8 +373,19 @@ bool DCustomActionParser::parseFile(QList<DCustomActionData> &childrenActions, Q
 void DCustomActionParser::initWatcher()
 {
     static const QStringList &kPaths { { "/usr/etc/deepin/context-menus" },
-                                       { "/etc/deepin/context-menus" },
-                                       { "/usr/share/applications/context-menus" } };
+                                       { "/etc/deepin/context-menus" } };
+
+    // Add directories from XDG_DATA_DIRS environment variable
+    const QByteArray xdgDataDirs = qgetenv("XDG_DATA_DIRS");
+    if (!xdgDataDirs.isEmpty()) {
+        const QStringList dataDirs = QString::fromLocal8Bit(xdgDataDirs).split(':');
+        for (const QString &dir : dataDirs) {
+            QString path = dir + "/applications/context-menus";
+            if (!kPaths.contains(path) && QDir(path).exists())
+                menuPaths.append(path);
+        }
+    }
+
     std::for_each(kPaths.begin(), kPaths.end(), [this](const QString &path) {
         if (QDir(path).exists())
             menuPaths.append(path);

--- a/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
@@ -9,7 +9,6 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/fileutils.h>
 
-
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_tag;
 

--- a/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
@@ -9,6 +9,7 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/fileutils.h>
 
+
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_tag;
 


### PR DESCRIPTION
- Remove redundant cleanPath function and its usage
- Add new helper function findSystemPathKey to centralize path key lookup logic
- Refactor systemPathDisplayNameByPath, systemPathIconNameByPath and isSystemPath to use consistent path comparison logic
- Add new FileUtils::isSameFile overload for string paths
- Improve system path detection by checking file node identity

This change reduces code duplication and makes the system path handling more consistent and robust by using proper file node comparison instead of simple string matching.

Log: optimize system path related functions
Bug: https://pms.uniontech.com/bug-view-286421.html