### PR TITLE
fix: [filedialog] The name filter show error.

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/views/filedialog.cpp
@@ -376,10 +376,14 @@ void FileDialog::setNameFilters(const QStringList &filters)
 {
     d->nameFilters = filters;
 
-    if (testOption(QFileDialog::HideNameFilterDetails)) {
+    QVariant isGtk = qApp->property("GTK");
+    if (isGtk.isValid() && isGtk.toBool()) {
         statusBar()->setComBoxItems(CoreHelper::stripFilters(filters));
     } else {
-        statusBar()->setComBoxItems(filters);
+        if (testOption(QFileDialog::HideNameFilterDetails))
+            statusBar()->setComBoxItems(CoreHelper::stripFilters(filters));
+        else
+            statusBar()->setComBoxItems(filters);
     }
 
     if (modelCurrentNameFilter().isEmpty())


### PR DESCRIPTION
When gtk show file selecet dialog, the name filter show the details text.

Log: fix issue
Bug: https://pms.uniontech.com//bug-view-286169.html