### PR TITLE
refactor: optimize icon painting with QIcon::paint

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.10) UNRELEASED; urgency=medium
+
+  * desktop adapt to Qt6.8
+
+ -- zhangsheng <zhangsheng@uniontech.com>  Thu, 21 Nov 2024 17:11:48 +0800
+
 dde-file-manager (6.5.9) unstable; urgency=medium
 
   * fix dav mount issue.

--- a/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/core/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -305,7 +305,8 @@ QSize CanvasItemDelegate::paintDragIcon(QPainter *painter, const QStyleOptionVie
     return paintIcon(painter, indexOption.icon,
                      { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
                        QIcon::Off, isThumnailIconIndex(index) })
-            .size().toSize();
+            .size()
+            .toSize();
 }
 
 int CanvasItemDelegate::textLineHeight() const
@@ -779,7 +780,7 @@ QRectF CanvasItemDelegate::paintIcon(QPainter *painter, const QIcon &icon, const
 
         return backgroundRect;
     }
-    painter->drawPixmap(QPointF(x, y), px);
+    icon.paint(painter, opts.rect.toRect());
     // return rect before scale
     return QRectF(x, y, w, h);
 }

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -805,7 +805,7 @@ QRect CollectionItemDelegate::paintIcon(QPainter *painter, const QIcon &icon, co
         return backgroundRect;
     }
 
-    painter->drawPixmap(qRound(x), qRound(y), px);
+    icon.paint(painter, opts.rect.toRect());
 
     // return rect before scale
     return QRect(qRound(x), qRound(y), w, h);

--- a/src/plugins/filemanager/core/dfmplugin-workspace/utils/itemdelegatehelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/utils/itemdelegatehelper.cpp
@@ -87,6 +87,7 @@ void ItemDelegateHelper::paintIcon(QPainter *painter, const QIcon &icon, const P
         painter->restore();
 
     } else {
+        //TODO(zhangs): use icon.paint() after Qt6.8
         painter->drawPixmap(qRound(x), qRound(y), px);
     }
 }


### PR DESCRIPTION
- Replace drawPixmap with QIcon::paint in CanvasItemDelegate
- Replace drawPixmap with QIcon::paint in CollectionItemDelegate
- Add TODO note for future update in ItemDelegateHelper
- Fix code formatting and line breaks

This change improves icon rendering by using the more efficient QIcon::paint method instead of manual pixmap drawing.

Log: paint icon