### PR TITLE
fix: optimize search edit widget signal connection

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -22,9 +22,7 @@
 #include <DSpinner>
 #include <DDialog>
 #include <DGuiApplicationHelper>
-#ifdef DTKWIDGET_CLASS_DSizeMode
 #include <DSizeMode>
-#endif
 
 #include <QHBoxLayout>
 #include <QResizeEvent>
@@ -154,7 +152,7 @@ void SearchEditWidget::onReturnPressed()
     startSpinner();
 }
 
-void SearchEditWidget::onTextChanged(const QString &text)
+void SearchEditWidget::onTextEdited(const QString &text)
 {
     lastEditedString = text;
     if (text.isEmpty()) {
@@ -367,7 +365,7 @@ void SearchEditWidget::initUI()
 void SearchEditWidget::initConnect()
 {
     connect(searchButton, &DIconButton::clicked, this, &SearchEditWidget::expandSearchEdit);
-    connect(searchEdit, &DSearchEdit::textChanged, this, &SearchEditWidget::onTextChanged, Qt::QueuedConnection);
+    connect(searchEdit, &DSearchEdit::textEdited, this, &SearchEditWidget::onTextEdited, Qt::QueuedConnection);
     connect(searchEdit, &DSearchEdit::returnPressed, this, &SearchEditWidget::onReturnPressed);
     connect(searchEdit, &DSearchEdit::searchAborted, this, [this]() {
         stopSpinner();

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.h
@@ -58,7 +58,7 @@ public Q_SLOTS:
     void onPauseButtonClicked();
     void onAdvancedButtonClicked();
     void onReturnPressed();
-    void onTextChanged(const QString &text);
+    void onTextEdited(const QString &text);
     void onClearSearchHistory(quint64 winId);
     void onDConfigValueChanged(const QString &config, const QString &key);
 


### PR DESCRIPTION
fix: optimize search edit widget signal connection

- Change textChanged signal to textEdited to avoid unnecessary signal emissions
- Remove redundant DTK macro check for DSizeMode header
- Fix signal-slot connection to prevent potential text processing issues

Log: This commit fixes the search widget's behavior by using textEdited instead of textChanged signal, which only triggers when user actually types or modifies the text, avoiding unnecessary signal emissions from programmatic text changes.