### PR TITLE
perf: [desktop-fileinfo] The cpu usage is high when the mouse clicks …

### DIFF
--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -121,10 +121,7 @@ QStringList DesktopFileInfo::desktopCategories() const
 QIcon DesktopFileInfo::fileIcon()
 {
     if (Q_LIKELY(!d->icon.isNull())) {
-        if (Q_LIKELY(!d->icon.availableSizes().isEmpty()))
-            return d->icon;
-
-        d->icon = QIcon();
+        return d->icon;
     }
 
     const QString &iconName = this->nameOf(NameInfoType::kIconName);


### PR DESCRIPTION
…the desktop icon

1. When the icon of a desktop file is in svg format and the mouse moves over the file, QIcon is frequently invoked to create an object, resulting in high cpu usage.
2. svg availableSizes returns a null value, causing the cache QIcon to be emptied, resulting in not only a rebuild, but also a high cpu utilization.
3. Remove the judgment of availableSizes.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-289327.html