### PR TITLE
fix: improve title bar status management and URL handling

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -26,6 +26,10 @@ enum class ViewMode {
     kAllViewMode = kIconMode | kListMode | kExtendMode
 };
 
+inline constexpr int kIconSizeMax { 512 };
+inline constexpr int kIconSizeMin { 24 };
+inline constexpr int kIconSizeStep { 8 };
+
 enum class TransparentStatus : uint8_t {
     kDefault,
     kTransparent,

--- a/include/dfm-base/settingdialog/settingjsongenerator.h
+++ b/include/dfm-base/settingdialog/settingjsongenerator.h
@@ -57,6 +57,7 @@ public:
     bool addCheckBoxConfig(const QString &key, const QString &text, bool defaultVal = true);
     bool addComboboxConfig(const QString &key, const QString &name, const QStringList &options, int defaultVal = 0);
     bool addComboboxConfig(const QString &key, const QString &name, const QVariantMap &options, QVariant defaultVal = QVariant());
+    bool addSliderConfig(const QString &key, const QString &name, int maxVal, int minVal, int defaultVal = 0);
 
 protected:
     SettingJsonGenerator();

--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -300,14 +300,13 @@ void SettingBackend::initWorkspaceSettingConfig()
     ins->addGroup(TOP_GROUP_WORKSPACE, tr("Workspace"));
     ins->addGroup(LV2_GROUP_VIEW, tr("View"));
 
-    ins->addComboboxConfig(LV2_GROUP_VIEW ".00_icon_size",
-                           tr("Default size:"),
-                           QStringList { tr("Extra small"),
-                                         tr("Small"),
-                                         tr("Medium"),
-                                         tr("Large"),
-                                         tr("Extra large") },
-                           1);
+    int iconSizeLevelMax = (Global::kIconSizeMax - Global::kIconSizeMin) / Global::kIconSizeStep;
+    int iconSizeLevelMin = 0;
+    ins->addSliderConfig(LV2_GROUP_VIEW ".00_icon_size",
+                        tr("Default size:"),
+                        iconSizeLevelMax,
+                        iconSizeLevelMin,
+                        5);
     QStringList viewModeValues { tr("Icon"), tr("List") };
     QVariantList viewModeKeys { 1, 2 };
     if (DConfigManager::instance()->value(kViewDConfName, kTreeViewEnable, true).toBool()) {

--- a/src/dfm-base/base/configs/settingjsongenerator.cpp
+++ b/src/dfm-base/base/configs/settingjsongenerator.cpp
@@ -212,6 +212,23 @@ bool SettingJsonGenerator::addComboboxConfig(const QString &key, const QString &
     return addConfig(key, config);
 }
 
+bool SettingJsonGenerator::addSliderConfig(const QString &key,
+                                           const QString &name,
+                                           int maxVal,
+                                           int minVal,
+                                           int defaultVal)
+{
+    QVariantMap config {
+        { "key", key.mid(key.lastIndexOf(".") + 1) },
+        { "name", name },
+        { "type", "slider" },
+        { "max", maxVal},
+        { "min", minVal},
+        { "default", defaultVal }
+    };
+    return addConfig(key, config);
+}
+
 void SettingJsonGenerator::mergeGroups()
 {
     auto merge = [](const QMap<QString, QString> &from, QMap<QString, QString> &into) {

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/events/titlebareventreceiver.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/events/titlebareventreceiver.cpp
@@ -52,9 +52,11 @@ bool TitleBarEventReceiver::handleCustomRegister(const QString &scheme, const QV
     CrumbManager::instance()->registerCrumbCreator(scheme, [=]() {
         CrumbInterface *interface = new CrumbInterface();
         interface->setSupportedScheme(scheme);
-        interface->setKeepAddressBar(keepAddressBar);
         return interface;
     });
+
+    if (keepAddressBar)
+        TitleBarHelper::registerKeepTitleStatusScheme(scheme);
 
     return true;
 }

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.cpp
@@ -21,19 +21,9 @@ CrumbInterface::CrumbInterface(QObject *parent)
 {
 }
 
-void CrumbInterface::setKeepAddressBar(bool keep)
-{
-    keepAddr = keep;
-}
-
 void CrumbInterface::setSupportedScheme(const QString &scheme)
 {
     curScheme = scheme;
-}
-
-bool CrumbInterface::isKeepAddressBar()
-{
-    return keepAddr;
 }
 
 bool CrumbInterface::isSupportedScheme(const QString &scheme)
@@ -46,21 +36,11 @@ void CrumbInterface::processAction(CrumbInterface::ActionType type)
     switch (type) {
     case kEscKeyPressed:
     case kClearButtonPressed:
-        emit hideAddressBar(keepAddr);
+        emit hideAddressBar();
         break;
     case kAddressBarLostFocus:
-        if (!keepAddr)
-            emit hideAddressBar(keepAddr);
+        emit hideAddressBar();
         break;
-    }
-}
-
-void CrumbInterface::crumbUrlChangedBehavior(const QUrl &url)
-{
-    if (keepAddr) {
-        emit keepAddressBar(url);
-    } else {
-        emit hideAddrAndUpdateCrumbs(url);
     }
 }
 

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/crumbinterface.h
@@ -28,19 +28,16 @@ public:
 
     explicit CrumbInterface(QObject *parent = nullptr);
 
-    void setKeepAddressBar(bool keep);
     void setSupportedScheme(const QString &scheme);
-    bool isKeepAddressBar();
     bool isSupportedScheme(const QString &scheme);
 
     void processAction(ActionType type);
-    void crumbUrlChangedBehavior(const QUrl &url);
     FAKE_VIRTUAL QList<CrumbData> seprateUrl(const QUrl &url);
     void requestCompletionList(const QUrl &url);
     void cancelCompletionListTransmission();
 
 signals:
-    void hideAddressBar(bool cd);
+    void hideAddressBar();
     void pauseSearch();
     void keepAddressBar(const QUrl &url);
     void hideAddrAndUpdateCrumbs(const QUrl &url);
@@ -52,7 +49,6 @@ private slots:
 
 private:
     QString curScheme;
-    bool keepAddr { false };
     QPointer<DFMBASE_NAMESPACE::TraversalDirThread> folderCompleterJobPointer;
 };
 

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -30,6 +30,7 @@ using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
 
 QMap<quint64, TitleBarWidget *> TitleBarHelper::kTitleBarMap {};
+QList<QString> TitleBarHelper::kKeepTitleStatusSchemeList {};
 
 bool TitleBarHelper::newWindowAndTabEnabled { true };
 
@@ -309,6 +310,18 @@ void TitleBarHelper::showDiskPasswordChangingDialog(quint64 windowId)
     QObject::connect(dialog, &DiskPasswordChangingDialog::closed, [=] {
         window->setProperty("DiskPwdChangingDialogShown", false);
     });
+}
+
+void TitleBarHelper::registerKeepTitleStatusScheme(const QString &scheme)
+{
+    if (!kKeepTitleStatusSchemeList.contains(scheme))
+        kKeepTitleStatusSchemeList.append(scheme);
+}
+
+bool TitleBarHelper::checkKeepTitleStatus(const QUrl &url)
+{
+    auto scheme = url.scheme();
+    return kKeepTitleStatusSchemeList.contains(scheme);
 }
 
 QMutex &TitleBarHelper::mutex()

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/utils/titlebarhelper.h
@@ -35,6 +35,9 @@ public:
     static void showUserSharePasswordSettingDialog(quint64 windowId);
     static void showDiskPasswordChangingDialog(quint64 windowId);
 
+    static void registerKeepTitleStatusScheme(const QString &scheme);
+    static bool checkKeepTitleStatus(const QUrl &url);
+
 public:
     static bool newWindowAndTabEnabled;
 
@@ -43,6 +46,7 @@ private:
     static void handleSettingMenuTriggered(quint64 windowId, int action);
     static QString getDisplayName(const QString &name);
     static QMap<quint64, TitleBarWidget *> kTitleBarMap;
+    static QList<QString> kKeepTitleStatusSchemeList;
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/crumbbar.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/crumbbar.h
@@ -34,14 +34,13 @@ public:
 
 Q_SIGNALS:
     void showAddressBarText(const QString &text);
-    void hideAddressBar(bool cd);
+    void hideAddressBar();
     void selectedUrl(const QUrl &url);
     void editUrl(const QUrl &url);
 
 public Q_SLOTS:
     void onUrlChanged(const QUrl &url);
     void onKeepAddressBar(const QUrl &url);
-    void onHideAddrAndUpdateCrumbs(const QUrl &url);
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -56,6 +55,9 @@ protected:
     void enterEvent(QEvent *event) override;
 #endif
     void leaveEvent(QEvent *event) override;
+
+private:
+    void onHideAddrAndUpdateCrumbs(const QUrl &url);
 };
 
 }

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/searcheditwidget.h
@@ -42,7 +42,7 @@ class SearchEditWidget : public QWidget
 public:
     explicit SearchEditWidget(QWidget *parent = nullptr);
 
-    void activateEdit();
+    void activateEdit(bool setAdvanceBtn = true);
     void deactivateEdit();
 
     void startSpinner();
@@ -55,6 +55,7 @@ public:
     void setSearchMode(SearchMode mode);
 
 public Q_SLOTS:
+    void onUrlChanged(const QUrl &url);
     void onPauseButtonClicked();
     void onAdvancedButtonClicked();
     void onReturnPressed();

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -298,11 +298,9 @@ void TitleBarWidget::initConnect()
         addressBar->setFocus();
         addressBar->setText(text);
     });
-    connect(crumbBar, &CrumbBar::hideAddressBar, this, [this](bool cd) {
+    connect(crumbBar, &CrumbBar::hideAddressBar, this, [this] {
         addressBar->hide();
         crumbBar->show();
-        if (cd)
-            TitleBarEventCaller::sendCd(this, crumbBar->lastUrl());
     });
     connect(crumbBar, &CrumbBar::selectedUrl, this, [this](const QUrl &url) {
         TitleBarEventCaller::sendCd(this, url);
@@ -330,6 +328,7 @@ void TitleBarWidget::initConnect()
     connect(searchEditWidget, &SearchEditWidget::clearButtonClicked, this, [this]() {
         TitleBarEventCaller::sendCd(this, crumbBar->lastUrl());
     });
+    connect(this, &TitleBarWidget::currentUrlChanged, searchEditWidget, &SearchEditWidget::onUrlChanged);
 
     connect(bottomBar, &TabBar::newTabCreated, this, &TitleBarWidget::onTabCreated);
     connect(bottomBar, &TabBar::tabRemoved, this, &TitleBarWidget::onTabRemoved);
@@ -414,11 +413,8 @@ bool TitleBarWidget::eventFilter(QObject *watched, QEvent *event)
     if (watched == addressBar) {
         switch (event->type()) {
         case QEvent::Hide:
-            if (!crumbBar->controller()->isKeepAddressBar()) {
-                showCrumbBar();
-                return true;
-            }
-            break;
+            showCrumbBar();
+            return true;
         default:
             break;
         }

--- a/src/plugins/filemanager/core/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -30,9 +30,6 @@ static constexpr int kViewOptionsSpacing { 10 };
 static constexpr int kViewOptionsSingleSpacing { 5 };
 static constexpr int kViewOptionsFrameMargin { 6 };
 static constexpr int kViewOptionsFrameHeight { 40 };
-static constexpr int kViewOptionsMinIconSize { 24 };
-static constexpr int kViewOptionsMaxIconSize { 512 };
-static constexpr int kViewOptionsIconSizeStep { 8 };
 static constexpr int kViewOptionsMinGridDensity { 60 };
 static constexpr int kViewOptionsMaxGridDensity { 150 };
 static constexpr int kViewOptionsGridDensityStep { 10 };
@@ -78,7 +75,7 @@ void ViewOptionsWidgetPrivate::initializeUi()
     iconSizeSliderLayout->setContentsMargins(kViewOptionsFrameMargin, kViewOptionsFrameMargin,
                                              kViewOptionsFrameMargin, kViewOptionsFrameMargin);
     iconSizeSlider = new DSlider(Qt::Horizontal, iconSizeWidget);
-    int iconSizeRange = (kViewOptionsMaxIconSize - kViewOptionsMinIconSize) / kViewOptionsIconSizeStep;
+    int iconSizeRange = (Global::kIconSizeMax - Global::kIconSizeMin) / Global::kIconSizeStep;
     iconSizeSlider->setMaximum(iconSizeRange);
     iconSizeSlider->setMinimum(0);
     iconSizeSlider->setValue(Application::instance()->appAttribute(Application::kIconSizeLevel).toInt());

--- a/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -6,6 +6,7 @@
 #define DFMPLUGIN_WORKSPACE_GLOBAL_H
 
 #include <dfm-base/dfm_log_defines.h>
+#include <dfm-base/dfm_global_defines.h>
 #include <dfm-framework/event/eventhelper.h>
 
 #include <dtkwidget_config.h>
@@ -40,7 +41,7 @@ inline QList<int> iconSizeList()
     static const QList<int> sizes = []() {
         QList<int> list;
         list.reserve(62);  // 预分配内存，避免多次重新分配
-        for (int size = 24; size <= 512; size += 8) {
+        for (int size = dfmbase::Global::kIconSizeMin; size <= dfmbase::Global::kIconSizeMax; size += dfmbase::Global::kIconSizeStep) {
             list.append(size);
         }
         return list;

--- a/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/models/fileitemdata.cpp
@@ -97,8 +97,16 @@ QVariant FileItemData::data(int role) const
         assert(qApp->thread() == QThread::currentThread());
         if (info.isNull()) {
             const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url);
-            if (info)
+            if (info) {
                 info->customData(kItemFileRefreshIcon);
+                
+                if (info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() &&
+                    !info->extendAttributes(ExtInfoType::kFileNeedUpdate).toBool()) {
+                    updateOnce = true;
+                    info->setExtendedAttributes(ExtInfoType::kFileNeedUpdate, false);
+                    info->updateAttributes();
+                }
+            }
         } else if (!updateOnce) {
             updateOnce = true;
             info->setExtendedAttributes(ExtInfoType::kFileNeedUpdate, false);

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -77,7 +77,7 @@ void Search::onWindowOpened(quint64 windId)
 void Search::regSearchCrumbToTitleBar()
 {
     QVariantMap property;
-    property["Property_Key_KeepAddressBar"] = false;
+    property["Property_Key_KeepAddressBar"] = true;
     dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", SearchHelper::scheme(), property);
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Crumb_RedirectUrl",
                             SearchHelper::instance(), &SearchHelper::crumbRedirectUrl);


### PR DESCRIPTION
- Move address bar status control from CrumbInterface to TitleBarHelper
- Add scheme-based title status management in TitleBarHelper
- Simplify address bar hide/show signal mechanism
- Enhance search functionality with URL change integration
- Improve source URL handling in CrumbBar
- Add keyword extraction from URL query for search widget
- Make search scheme keep address bar by default

This refactoring improves code organization by centralizing title bar status management and enhances URL handling for better search integration.

Log: fix search editor issue