### PR TITLE
Develop/snipe 25

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
@@ -200,7 +200,13 @@ VaultState FileEncryptHandle::state(const QString &encryptBaseDir) const
             lockBaseDir += "/cryfs.config";
 
         if (QFile::exists(lockBaseDir)) {
-            QUrl mountDirUrl = QUrl::fromLocalFile(PathManager::vaultUnlockPath());
+
+            QString realPath = QFileInfo(PathManager::vaultUnlockPath()).canonicalFilePath();
+            if (realPath.isEmpty())
+                return kEncrypted;
+
+            QUrl mountDirUrl = QUrl::fromLocalFile(realPath);
+
             const QString &fsType = DFMIO::DFMUtils::fsTypeFromUrl(mountDirUrl);
             if (fsType == "fuse.cryfs")
                 d->curState = kUnlocked;

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -399,20 +399,24 @@ bool CifsMountHelper::rmdir(const QString &path)
 
 bool CifsMountHelper::mkdirMountRootPath()
 {
-    auto mntRoot = mountRoot();
+    auto mntRoot = mountRoot();   // 获取挂载根目录
     if (mntRoot.isEmpty()) {
         fmWarning() << "cifs: mount root is empty";
         return false;
     }
 
-    auto dir = opendir(mntRoot.toStdString().c_str());
-    if (!dir) {
-        int ret = ::mkdir(mntRoot.toStdString().c_str(), 0755);
-        fmInfo() << "mkdir mntRoot: " << mntRoot << "failed: " << strerror(errno) << errno;
-        return ret == 0;
-    } else {
-        closedir(dir);
+    QDir dir;
+    if (dir.exists(mntRoot)) {
+        fmInfo() << "cifs: mount root already exists: " << mntRoot;
         return true;
+    }
+
+    if (dir.mkpath(mntRoot)) {
+        fmInfo() << "cifs: mount root created successfully: " << mntRoot;
+        return true;
+    } else {
+        fmWarning() << "cifs: failed to create mount root: " << mntRoot;
+        return false;
     }
 }
 

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -200,7 +200,7 @@ CifsMountHelper::MountStatus CifsMountHelper::checkMount(const QString &path, QS
     if (fs) {
         mpt = mnt_fs_get_target(fs);
         fmDebug() << "find mounted at: " << mpt << path;
-        if (!mpt.contains(QRegularExpression("^/media/.*/smbmounts/")))
+        if (!mpt.contains(QRegularExpression("^(?:/run/media|/media)/.*")))
             return kNotMountByDaemon;
 
         QString fsType = mnt_fs_get_fstype(fs);


### PR DESCRIPTION
fix: Fixed the transparent encryption of the vault. Unlocking failed when the safe was opened again after the screen was locked.
    
    When using g_unix_mount_get_fs_type to obtain a symbolic link, it is not resolved into a real path, resulting in an error in obtaining the file mount type.
    Therefore, convert the symbolic link into a real file path before using it.
    
    log: Get the mount type of the vault
    bug: https://pms.uniontech.com/bug-view-278715.html
fix: Fix the problem of directory creation failure when samba mount.
    
    When smb mounts and creates directories, the ::mkdir system call is used. However, if the directory has multiple levels and needs to be created recursively, mkdir cannot meet the requirement, resulting in a failure in directory creation. Use Qt's mkpath instead.
    
    log: To avoid wood creation failure use Qt's mkpath.
    bug: https://pms.uniontech.com/bug-view-277301.html
