### PR TITLE
fix: correct return value logic in doCopyLocalByRange

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -909,7 +909,7 @@ bool FileOperateBaseWorker::doCopyLocalByRange(const DFileInfoPointer fromInfo, 
     FileUtils::cacheCopyingFileUrl(targetUrl);
     DoCopyFileWorker::NextDo nextDo = threadCopyWorker[0]->doCopyFileByRange(fromInfo, toInfo, skip);
     FileUtils::removeCopyingFileUrl(targetUrl);
-    return nextDo != DoCopyFileWorker::NextDo::kDoCopyNext;
+    return nextDo == DoCopyFileWorker::NextDo::kDoCopyNext;
 }
 
 bool FileOperateBaseWorker::doCopyOtherFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip)


### PR DESCRIPTION
- Fix inverted return condition for copy operation success
- Return true when NextDo is kDoCopyNext indicating successful copy
- Maintain consistent success/failure state with other copy methods

This change fixes a logical error where the copy success state was incorrectly inverted, ensuring proper flow control in range-based file copy operations.

Log: correct return value logic in doCopyLocalByRange
Bug: https://pms.uniontech.com/bug-view-290241.html