### PR TITLE
fix: update dde-shell app name to org.deepin.dde-shell

### DIFF
--- a/src/dfm-base/base/device/private/discdevicescanner.cpp
+++ b/src/dfm-base/base/device/private/discdevicescanner.cpp
@@ -20,7 +20,7 @@
 #include <unistd.h>
 
 static constexpr int kTimerInterval { 3000 };
-static const char kDesktopAppName[] { "dde-shell" };
+static const char kDesktopAppName[] { "org.deepin.dde-shell" };
 static constexpr char kBlockDeviceIdPrefix[] { "/org/freedesktop/UDisks2/block_devices/" };
 
 using namespace dfmbase;

--- a/src/plugins/common/core/dfmplugin-menu/menuscene/dconfighiddenmenuscene.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/menuscene/dconfighiddenmenuscene.cpp
@@ -70,7 +70,7 @@ void DConfigHiddenMenuScene::updateActionHidden(QMenu *parent)
 {
     static const QMap<QString, QString> appKeyMap {
         { "dde-file-manager", "dfm.menu.action.hidden" },
-        { "dde-shell", "dd.menu.action.hidden" },
+        { "org.deepin.dde-shell", "dd.menu.action.hidden" },
         { "dde-select-dialog-x11", "dfd.menu.action.hidden" },
         { "dde-select-dialog-wayland", "dfd.menu.action.hidden" },
         { "dde-file-dialog", "dfd.menu.action.hidden" },

--- a/src/plugins/common/core/dfmplugin-menu/utils/menuhelper.cpp
+++ b/src/plugins/common/core/dfmplugin-menu/utils/menuhelper.cpp
@@ -62,7 +62,7 @@ bool isHiddenMenu(const QString &app)
         }
     }
 
-    if (app == "dde-desktop" || app == "dde-shell")
+    if (app == "dde-desktop" || app == "org.deepin.dde-shell")
         return isHiddenDesktopMenu();
 
     return false;


### PR DESCRIPTION
- Update dde-shell app name in discdevicescanner.cpp
- Update dde-shell app name in dconfighiddenmenuscene.cpp
- Update dde-shell app name in menuhelper.cpp

This change aligns with the new standardized application naming convention.

Log: