### PR TITLE
fix: adjust scroll behavior in different view modes

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -100,6 +100,7 @@ inline constexpr int kLeftPadding { 10 };
 inline constexpr int kRightPadding { 10 };
 inline constexpr int kListModeLeftMargin { 10 };
 inline constexpr int kListModeRightMargin { 10 };
+inline constexpr int kListModeBottomMargin { 16 };
 inline constexpr int kColumnPadding { 10 };
 inline constexpr int kMinMoveLenght { 3 };
 inline constexpr int kIconHorizontalMargin { 15 };   // 水平Margin的宽度

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1579,6 +1579,7 @@ QRect FileView::visualRect(const QModelIndex &index) const
 
     if (isListViewMode() || isTreeViewMode()) {
         rect = DListView::visualRect(index);
+        rect.moveLeft(rect.left() - horizontalScrollBar()->value());
     } else {
         rect = DListView::visualRect(index);
         if (!d->initHorizontalOffset) {
@@ -1616,6 +1617,7 @@ QList<ItemRoles> FileView::getColumnRoles() const
 
 void FileView::updateGeometries()
 {
+    int totalHeight = 0;
     if (isIconViewMode()) {
         int iconVerticalTopMargin = 0;
 #ifdef DTKWIDGET_CLASS_DSizeMode
@@ -1624,13 +1626,22 @@ void FileView::updateGeometries()
         if (!d->isResizeEvent
             || (d->isResizeEvent && d->lastContentHeight > 0 && d->lastContentHeight != contentsSize().height()))
             resizeContents(contentsSize().width(), contentsSize().height() + iconVerticalTopMargin);
-        d->lastContentHeight = contentsSize().height();
+
+        totalHeight = contentsSize().height();
+        d->lastContentHeight = totalHeight;
+    } else {
+        int rowCount = model()->rowCount(rootIndex());
+        int listHeight = rowCount * itemSizeHint().height() + kListModeBottomMargin;
+        int contentHeight = contentsSize().height();
+
+        totalHeight = listHeight > contentHeight ? listHeight : contentHeight;
     }
+
     if (!d->headerView || !d->allowedAdjustColumnSize) {
         return DListView::updateGeometries();
     }
 
-    resizeContents(d->headerView->length(), contentsSize().height());
+    resizeContents(d->headerView->length(), totalHeight);
     DListView::updateGeometries();
 }
 


### PR DESCRIPTION
1. Set verticalOffset to 0 in icon mode since vertical scrolling is not needed
2. Add horizontal scroll offset adjustment for list/tree mode
3. Calculate correct content height for list/tree mode to ensure proper scrolling

Log: fix list view issue
Bug: https://pms.uniontech.com/bug-view-291285.html