### PR TITLE
fix: prevent dialog crash caused by thread safety issues

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.h
+++ b/src/dfm-base/file/local/localfilehandler.h
@@ -33,7 +33,7 @@ public:
     QUrl touchFile(const QUrl &url, const QUrl &tempUrl = QUrl());
     bool mkdir(const QUrl &dir);
     bool rmdir(const QUrl &url);
-    bool renameFile(const QUrl &url, const QUrl &newUrl, const bool needCheck = true);
+    bool renameFile(const QUrl &url, const QUrl &newUrl, const bool needCheck);
     bool openFile(const QUrl &file);
     bool openFiles(const QList<QUrl> &files);
     bool openFileByApp(const QUrl &file, const QString &appDesktop);

--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -27,6 +27,7 @@ static const QString kUserTrashFullOpened = "user-trash-full-opened";
 
 DialogManager *DialogManager::instance()
 {
+    Q_ASSERT(qApp->thread() == QThread::currentThread());
     static DialogManager ins;
     return &ins;
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -144,7 +144,7 @@ bool DoCutFilesWorker::doCutFile(const DFileInfoPointer &fromInfo, const DFileIn
     QString fileName = fromInfo->attribute(DFileInfo::AttributeID::kStandardFileName).toString();
     bool isTrashFile = FileUtils::isTrashFile(fromInfo->uri());
     if (isTrashFile) {
-        trashInfoUrl= trashInfo(fromInfo);
+        trashInfoUrl = trashInfo(fromInfo);
         fileName = fileOriginName(trashInfoUrl);
     }
     DFileInfoPointer toInfo = doRenameFile(fromInfo, targetPathInfo, fileName, &ok, skip);
@@ -155,7 +155,8 @@ bool DoCutFilesWorker::doCutFile(const DFileInfoPointer &fromInfo, const DFileIn
         if (fromInfo->attribute(DFileInfo::AttributeID::kStandardIsFile).toBool()) {
             workData->blockRenameWriteSize += fromSize;
             workData->currentWriteSize += (fromSize > 0
-                                           ? fromSize : FileUtils::getMemoryPageSize());
+                                                   ? fromSize
+                                                   : FileUtils::getMemoryPageSize());
             if (fromSize <= 0)
                 workData->zeroOrlinkOrDirWriteSize += FileUtils::getMemoryPageSize();
         } else {
@@ -224,7 +225,7 @@ void DoCutFilesWorker::onUpdateProgress()
 void DoCutFilesWorker::endWork()
 {
     // delete all cut source files
-    bool skip{false};
+    bool skip { false };
     for (const auto &info : cutAndDeleteFiles) {
         if (!deleteFile(info->uri(), targetOrgUrl, &skip)) {
             fmWarning() << "delete file error, so do not delete other files!!!!";
@@ -318,7 +319,7 @@ bool DoCutFilesWorker::renameFileByHandler(const DFileInfoPointer &sourceInfo, c
     if (localFileHandler) {
         const QUrl &sourceUrl = sourceInfo->uri();
         const QUrl &targetUrl = targetInfo->uri();
-        return localFileHandler->renameFile(sourceUrl, targetUrl);
+        return localFileHandler->renameFile(sourceUrl, targetUrl, false);
     }
     return false;
 }
@@ -338,7 +339,7 @@ DFileInfoPointer DoCutFilesWorker::doRenameFile(const DFileInfoPointer &sourceIn
         if (isCutMerge) {
             newTargetInfo->initQuerier();
             isCutMerge = false;
-            result = doMergDir( sourceInfo, newTargetInfo, skip);
+            result = doMergDir(sourceInfo, newTargetInfo, skip);
         } else {
             result = renameFileByHandler(sourceInfo, newTargetInfo);
         }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -991,7 +991,7 @@ bool FileOperationsEventReceiver::handleOperationRenameFile(const quint64 window
     }
 
     DFMBASE_NAMESPACE::LocalFileHandler fileHandler;
-    ok = fileHandler.renameFile(oldUrl, newUrl);
+    ok = fileHandler.renameFile(oldUrl, newUrl, true);
     if (!ok) {
         error = fileHandler.errorString();
         dialogManager->showRenameBusyErrDialog();


### PR DESCRIPTION
1. Add thread assertion in DialogManager singleton:
   - Ensure DialogManager is only accessed from main thread
   - Add Q_ASSERT check for thread safety

2. Fix rename file operation issues:
   - Make needCheck parameter explicit in LocalFileHandler::renameFile
   - Pass correct needCheck flag in different rename scenarios:
     * Set to false for cut operations
     * Set to true for direct rename operations

3. Code style improvements:
   - Fix spacing in variable initialization
   - Improve code formatting for better readability

This fixes potential crashes when showing dialogs from non-main threads and improves rename operation reliability.

Log: fix crash