### PR TITLE
fix: Fixed the issue where desktop application shortcuts could not be…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -125,10 +125,12 @@ bool DragDropHelper::dragMove(QDragMoveEvent *event)
         return true;
     }
 
-
+    
+    // Allow application shortcuts on the desktop to be moved to the Recycle Bin.
+    bool bTrash = FileUtils::isTrashFile(toUrl.toString());
     for (const QUrl &url : fromUrls) {
         FileInfoPointer info = InfoFactory::create<FileInfo>(url);
-        if (event->dropAction() == Qt::DropAction::MoveAction && !info->canAttributes(CanableInfoType::kCanRename) && !dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileCanMove", url)) {
+        if (!bTrash && event->dropAction() == Qt::DropAction::MoveAction && !info->canAttributes(CanableInfoType::kCanRename) && !dpfHookSequence->run("dfmplugin_workspace", "hook_DragDrop_FileCanMove", url)) {
             view->setViewSelectState(false);
             event->ignore();
             return true;


### PR DESCRIPTION
… deleted by dragging them to the Recycle Bin window of the file manager

During the dragging process, the desktop application shortcut cannot be deleted due to its non-renameable attribute. When determining whether it can be dragged, determine whether it is dragged to the Recycle Bin. If it is dragged to the Recycle Bin, it can be deleted by dragging.

log: Fixed the issue where desktop application shortcuts could not be deleted by dragging them to the Recycle Bin window of the file manager

bug: https://pms.uniontech.com/bug-view-285659.html