### PR TITLE
fix: Fixed the issue that there is no mark function in the right-clic…

### DIFF
--- a/src/dfm-base/qrc/configure/dde-file-manager.default.json
+++ b/src/dfm-base/qrc/configure/dde-file-manager.default.json
@@ -38,7 +38,8 @@
     "AnythingMonitorFilterPath": {
         "WhiteList":[
             "/media",
-            "/home"
+            "/home",
+            "/run/media"
         ],
         "BlackList": [
             "~/.local/share/Trash"


### PR DESCRIPTION
…k menu of files in the immutable system mobile disk.

After mounting the USB drive in an immutable system, the tag cannot be displayed due to path mismatch.

log: Fixed the issue that there is no mark function in the right-click menu of files in the immutable system mobile disk.

bug: https://pms.uniontech.com/bug-view-285659.html