### PR TITLE
chore: dde-desktop depends libimageeditor6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -73,7 +73,8 @@ Depends:
  ${misc:Depends}, 
  libdde-file-manager (=${binary:Version}),
  libqt6sql6-sqlite,
- qt6-translations-l10n
+ qt6-translations-l10n,
+ libimageeditor6
 Conflicts: dde-workspace (<< 2.90.5), dde-file-manager-oem, dde-desktop-plugins
 Replaces: dde-file-manager-oem, dde-file-manager (<< 6.0.1), dde-desktop-plugins
 Recommends: qt5dxcb-plugin, deepin-screensaver, dcc-wallpapersetting-plugin


### PR DESCRIPTION
As title.

Log: Add new depends libimageeditor6.