### PR TITLE
fix: optimize view mode reset logic in Application

### DIFF
--- a/src/dfm-base/base/application/application.cpp
+++ b/src/dfm-base/base/application/application.cpp
@@ -309,20 +309,27 @@ void Application::appAttributeTrigger(TriggerAttribute ta, quint64 winId)
         auto defaultViewMode = appAttribute(Application::kViewMode).toInt();
         auto settings = appObtuselySetting();
 
-        const QStringList &keys = settings->keyList("FileViewState");
-        const QStringList &defaultKeys = settings->defaultConfigkeyList("FileViewState");
+        const QString &kGroupName = "FileViewState";
+        const QString &kViewModeKey = "viewMode";
+
+        const QStringList &keys = settings->keyList(kGroupName);
+        const QStringList &defaultKeys = settings->defaultConfigkeyList(kGroupName);
         for (const QString &url : keys) {
+            auto map = settings->value(kGroupName, url).toMap();
+
             if (defaultKeys.contains(url)) {
-                auto defaultMap = settings->defaultConfigValue("FileViewState", url).toMap();
-                if (defaultMap.contains("viewMode") && defaultMap["viewMode"] != defaultViewMode)
+                auto defaultMap = settings->defaultConfigValue(kGroupName, url).toMap();
+                if (defaultMap.contains(kViewModeKey) && defaultMap[kViewModeKey] != defaultViewMode) {
+                    map.insert(kViewModeKey, defaultMap.value(kViewModeKey));
+                    settings->setValue(kGroupName, url, map);
                     continue;
+                }
             }
 
-            auto map = settings->value("FileViewState", url).toMap();
-            if (map.contains("viewMode")) {
-                qCDebug(logDFMBase) << "Set " << url << "viewMode to " << defaultViewMode;
-                map["viewMode"] = defaultViewMode;
-                settings->setValue("FileViewState", url, map);
+            if (map.contains(kViewModeKey)) {
+                qCDebug(logDFMBase) << "Remove " << url << "viewMode";
+                map.remove(kViewModeKey);
+                settings->setValue(kGroupName, url, map);
             }
         }
 


### PR DESCRIPTION
- Extract constant strings for group name and key
- Preserve default view mode settings from default config
- Remove custom view mode settings instead of overwriting them
- Improve code readability with better variable names and structure

Log: fix set view mode issue
Bug: https://pms.uniontech.com/bug-view-271763.html