### PR TITLE
fix: cannot correctly recoganize fstab partitions

### DIFF
--- a/src/dfm-base/dbusservice/global_server_defines.h
+++ b/src/dfm-base/dbusservice/global_server_defines.h
@@ -80,6 +80,7 @@ inline constexpr char kConnectionBus[] { "ConnectionBus" };
 inline constexpr char kUDisks2Size[] { "UDisks2Size" };
 inline constexpr char kDriveModel[] { "DriveModel" };
 inline constexpr char kPreferredDevice[] { "PreferredDevice" };
+inline constexpr char kConfiguration[] { "Configuration" };
 }   // namespace DeviceProperty
 
 /*!

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -51,25 +51,6 @@ QString config_utils::cipherType()
     return cipher;
 }
 
-bool fstab_utils::isFstabItem(const QString &mpt)
-{
-    if (mpt.isEmpty())
-        return false;
-
-    bool fstabed { false };
-    struct fstab *fs;
-    setfsent();
-    while ((fs = getfsent()) != nullptr) {
-        QString path = fs->fs_file;
-        if (mpt == path) {
-            fstabed = true;
-            break;
-        }
-    }
-    endfsent();
-    return fstabed;
-}
-
 int tpm_utils::checkTPM()
 {
     return dpfSlotChannel->push("dfmplugin_encrypt_manager", "slot_TPMIsAvailablePro").toInt();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -55,10 +55,6 @@ namespace recovery_key_utils {
 QString formatRecoveryKey(const QString &raw);
 }
 
-namespace fstab_utils {
-bool isFstabItem(const QString &mpt);
-}   // namespace fstab_utils
-
 namespace device_utils {
 int encKeyType(const QString &dev);
 void cacheToken(const QString &device, const QVariantMap &token);


### PR DESCRIPTION
- remove the isFstabItem function;
- add Block::Configuration filed in device properties;
- initialize param.initOnly with true if
Block::Configuration.contains("fstab");

Log: fix partition encrypt issue.

Bug: https://pms.uniontech.com/bug-view-292155.html
