### PR TITLE
fix: Fixed the problem of missing address bar input completion.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/crumbinterface.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/crumbinterface.cpp
@@ -102,7 +102,7 @@ void CrumbInterface::requestCompletionList(const QUrl &url)
         folderCompleterJobPointer->setParent(nullptr);
     }
     folderCompleterJobPointer = new TraversalDirThread(url, QStringList(),
-                                                       QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot, QDirIterator::NoIteratorFlags);
+                                                       QDir::Hidden | QDir::NoDotAndDotDot, QDirIterator::NoIteratorFlags);
     folderCompleterJobPointer->setQueryAttributes("standard::standard::name");
     folderCompleterJobPointer->setParent(this);
     if (folderCompleterJobPointer.isNull())


### PR DESCRIPTION
Remove the Dirs filter condition, otherwise when it is a symbolic link, its type is not a directory and it will be skipped directly. Reference dolphin and nemo also do not filter directories of symbolic link type.

log: Fixed the problem of missing address bar input completion.

https://pms.uniontech.com/bug-view-277429.html