### PR TITLE
fix: 2 permission management appear in the Properties dialog box

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.cpp
@@ -86,8 +86,6 @@ void PropertyDialogUtil::showFilePropertyDialog(const QList<QUrl> &urls, const Q
                 filePropertyDialogs.value(url)->show();
                 filePropertyDialogs.value(url)->activateWindow();
             }
-            if (filePropertyDialogs.contains(url))
-                filePropertyDialogs.value(url)->show();
         }
 
         if (urls.count() >= 2) {

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -139,9 +139,7 @@ void FilePropertyDialog::filterControlView()
     }
 
     if ((controlFilter & PropertyFilterType::kPermission) < 1) {
-        showPermission = true;
-    } else {
-        showPermission = false;
+        createPermissionManagerWidget(currentFileUrl);
     }
 }
 
@@ -301,10 +299,6 @@ void FilePropertyDialog::resizeEvent(QResizeEvent *event)
 
 void FilePropertyDialog::showEvent(QShowEvent *event)
 {
-    if (showPermission) {
-        createPermissionManagerWidget(currentFileUrl);
-    }
-
     DDialog::showEvent(event);
 }
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
@@ -71,7 +71,7 @@ private:
     QScrollArea *scrollArea { nullptr };
     BasicWidget *basicWidget { nullptr };
     PermissionManagerWidget *permissionManagerWidget { nullptr };
-    QLabel *fileIcon {nullptr};
+    QLabel *fileIcon { nullptr };
     EditStackedWidget *editStackWidget { nullptr };
     QFrame *textShowFrame { nullptr };
     DTK_WIDGET_NAMESPACE::DIconButton *editButton { nullptr };
@@ -79,8 +79,7 @@ private:
     QUrl currentFileUrl {};
     int extendedHeight { 0 };
     DTK_WIDGET_NAMESPACE::DPlatformWindowHandle *platformWindowHandle { nullptr };
-    FileInfoPointer currentInfo{ nullptr };
-    bool showPermission { true };
+    FileInfoPointer currentInfo { nullptr };
 };
 }
 #endif   // FILEPROPERTYVIEW_H


### PR DESCRIPTION
The showevent creates a PermissionManagerWidget each time it is triggered.

Log: fix bug

Bug: https://pms.uniontech.com/bug-view-292289.html