### PR TITLE
fix: optimize FileDialogMenuScene action handling

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menuscene/action_defines.h
+++ b/src/plugins/common/dfmplugin-menu/menuscene/action_defines.h
@@ -55,6 +55,10 @@ inline constexpr char kSendToBluetooth[] = "send-to-bluetooth";
 
 // Separator
 inline constexpr char kSeparator[] = "separator-line";
+
+// ViewMenu
+inline constexpr char kDisplayAs[] = "display-as";
+inline constexpr char kSortBy[] = "sort-by";
 }
 }
 

--- a/src/plugins/filedialog/filedialogplugin-core/menus/filedialogmenuscene.h
+++ b/src/plugins/filedialog/filedialogplugin-core/menus/filedialogmenuscene.h
@@ -12,6 +12,7 @@
 
 namespace filedialog_core {
 
+class FileDialogMenuScenePrivate;
 class FileDialogMenuCreator : public DFMBASE_NAMESPACE::AbstractSceneCreator
 {
 public:
@@ -29,12 +30,14 @@ public:
     QString name() const override;
     bool initialize(const QVariantHash &params) override;
     void updateState(QMenu *parent) override;
-
+    bool actionFilter(AbstractMenuScene *caller, QAction *action) override;
+    
 private:
     QString findSceneName(QAction *act) const;
     void filterAction(QMenu *parent, bool isSubMenu);
 
 private:
+    QScopedPointer<FileDialogMenuScenePrivate> d;
     AbstractMenuScene *workspaceScene { nullptr };
 };
 

--- a/src/plugins/filedialog/filedialogplugin-core/private/filedialogmenuscene_p.h
+++ b/src/plugins/filedialog/filedialogplugin-core/private/filedialogmenuscene_p.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FILEDIALOGMENUSCENE_P_H
+#define FILEDIALOGMENUSCENE_P_H
+
+#include "filedialogplugin_core_global.h"
+
+#include <dfm-base/interfaces/private/abstractmenuscene_p.h>
+
+namespace filedialog_core {
+
+class FileDialogMenuScene;
+class FileDialogMenuScenePrivate : public DFMBASE_NAMESPACE::AbstractMenuScenePrivate
+{
+    Q_OBJECT
+    friend class FileDialogMenuScene;
+public:
+    explicit FileDialogMenuScenePrivate(FileDialogMenuScene *qq);
+
+private:
+    FileDialogMenuScene *q { nullptr };
+};
+
+}
+
+#endif   // FILEDIALOGMENUSCENE_P_H

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -501,7 +501,7 @@ void TabBar::updateScreen()
 
     // update tabAddButton position
     if (tabAddButton) {
-        int btnX = lastX + 10;
+        int btnX = count() > 1 ? lastX + 10 : 10;
         int btnY = (height() - tabAddButton->height()) / 2;
         QRect rect(btnX, btnY, tabAddButton->size().width(), tabAddButton->size().height());
         if (playTabAnimation) {
@@ -543,6 +543,7 @@ void TabBar::updateTabsState()
     for (Tab *tab : tabList) {
         tab->setShowCloseButton(tabCount > 1);
         tab->setCanDrag(tabCount > 1);
+        tab->setVisible(tabCount > 1);
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/menus/workspacemenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/menus/workspacemenuscene.cpp
@@ -198,6 +198,9 @@ void WorkspaceMenuScene::updateState(DMenu *parent)
 
 bool WorkspaceMenuScene::triggered(QAction *action)
 {
+    if (filterActionBySubscene(this, action))
+        return true;
+
     if (d->isEmptyArea)
         return emptyMenuTriggered(action);
 


### PR DESCRIPTION
- Replace triggered() with actionFilter() for better action handling
- Use ActionID constants from dfmplugin_menu namespace
- Remove redundant destructor implementation
- Add proper member variables in private class
- Fix window ID handling in initialization

Log: fix open action in filedialog
Bug: https://pms.uniontech.com/bug-view-288621.html