### PR TITLE
fix: improve folder list UI appearance

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.cpp
@@ -24,7 +24,7 @@ static constexpr int kFolderListItemMargin { 6 };
 FolderListWidgetPrivate::FolderListWidgetPrivate(FolderListWidget *qq)
     : QObject(qq), q(qq)
 {
-    q->resize(172, kItemMargin * 2 + kFolderItemHeight * 8);
+    q->resize(172, kFolderListItemMargin * 2 + kFolderItemHeight * 8);
     q->setMouseTracking(true);
     layout = new QVBoxLayout(qq);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -126,7 +126,7 @@ void FolderListWidgetPrivate::selectDown()
 FolderListWidget::FolderListWidget(QWidget *parent)
     : DBlurEffectWidget(parent), d(new FolderListWidgetPrivate(this))
 {
-    setWindowFlag(Qt::Popup);
+    setWindowFlags(Qt::Popup | Qt::FramelessWindowHint);
     setBlurEnabled(true);
     setMode(DBlurEffectWidget::GaussianBlur);
 }
@@ -165,13 +165,7 @@ void FolderListWidget::setFolderList(const QList<CrumbData> &datas, bool stacked
     setFixedWidth(width);
 
     int folderCount = dataNum > kMaxFolderCount ? kMaxFolderCount : dataNum;
-    if (dataNum > 1) {
-        d->folderView->setViewportMargins(kItemMargin, kItemMargin, kItemMargin, kItemMargin);
-        setFixedHeight(kItemMargin * 2 + kFolderItemHeight * folderCount);
-    } else {
-        d->folderView->setViewportMargins(kItemMargin, kItemMargin * 3 / 2, kItemMargin, kItemMargin * 3 / 2);
-        setFixedHeight(kItemMargin * 3 + kFolderItemHeight * folderCount);
-    }
+    setFixedHeight(kFolderListItemMargin * 2 + kFolderItemHeight * folderCount);
 }
 
 void FolderListWidget::keyPressEvent(QKeyEvent *event)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/folderviewdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/folderviewdelegate.cpp
@@ -4,6 +4,8 @@
 
 #include "folderviewdelegate.h"
 
+#include <DStyle>
+
 #include <QPainter>
 #include <QCompleter>
 #include <QApplication>
@@ -39,7 +41,11 @@ void FolderViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         painter->save();
         painter->setBrush(option.palette.brush(cg, QPalette::Highlight));
         painter->setPen(Qt::NoPen);
-        painter->drawRoundedRect(option.rect, 8, 8);
+        // get window radius
+        int radius = 12;
+        if (auto view = dynamic_cast<QAbstractItemView *>(parent()))
+            radius = DStyle::pixelMetric(view->style(), DStyle::PM_FrameRadius, &opt, view);
+        painter->drawRoundedRect(option.rect, radius, radius);
         painter->restore();
     }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -33,6 +33,7 @@
 inline constexpr int kTabHeightScaling { 24 };
 inline constexpr int kCloseButtonBigSize { 36 };
 inline constexpr int kCloseButtonSmallSize { 30 };
+inline constexpr int kTabMaxWidth { 240 };
 
 DFMBASE_USE_NAMESPACE
 DPTITLEBAR_USE_NAMESPACE
@@ -520,10 +521,10 @@ void TabBar::updateScreen()
 
 QSize TabBar::tabSizeHint(const int &index)
 {
-    int averageWidth = qMin(120, historyWidth / count());
+    int averageWidth = qMin(kTabMaxWidth, historyWidth / count());
 
     if (index == count() - 1)
-        return (QSize(qMin(120, historyWidth - averageWidth * (count() - 1)), height()));
+        return (QSize(qMin(kTabMaxWidth, historyWidth - averageWidth * (count() - 1)), height()));
     else
         return (QSize(averageWidth, height()));
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewanimationhelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewanimationhelper.h
@@ -8,6 +8,8 @@
 #include <QObject>
 #include <QMap>
 #include <QRect>
+#include <QPixmap>
+#include <QModelIndex>
 
 QT_BEGIN_NAMESPACE
 class QTimer;
@@ -52,6 +54,7 @@ private:
     void paintPixmaps(const QMap<QModelIndex, QRect> &indexRects);
     void createPixmapsForVisiableRect();
     void resetAnimation();
+    void resetExpandItem();
 
 private:
     bool initialized { false };
@@ -63,6 +66,9 @@ private:
     QMap<QModelIndex, QRect> newIndexRectMap {};
     QMap<QModelIndex, QRect> oldIndexRectMap {};
     QMap<QModelIndex, QPixmap> indexPixmaps {};
+    QModelIndex expandItemIndex {};
+    QPixmap expandItemPixmap {};
+    QPoint expandItemOffset {};
 
     QTimer *delayTimer { nullptr };
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -219,6 +219,11 @@ QModelIndex BaseItemDelegate::expandedIndex()
     return QModelIndex();
 }
 
+QWidget *BaseItemDelegate::expandedItem()
+{
+    return nullptr;
+}
+
 FileViewHelper *BaseItemDelegate::parent() const
 {
     return dynamic_cast<FileViewHelper *>(QStyledItemDelegate::parent());

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -135,6 +135,7 @@ public:
     virtual bool itemExpanded();
     virtual QRect expandItemRect();
     virtual QModelIndex expandedIndex();
+    virtual QWidget *expandedItem();
 
     QModelIndex editingIndex() const;
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -402,6 +402,12 @@ QModelIndex IconItemDelegate::expandedIndex()
     return d->expandedIndex;
 }
 
+QWidget *IconItemDelegate::expandedItem()
+{
+    Q_D(IconItemDelegate);
+    return d->expandedItem;
+}
+
 QString IconItemDelegate::displayFileName(const QModelIndex &index) const
 {
     bool showSuffix { Application::instance()->genericAttribute(Application::kShowedFileSuffix).toBool() };

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.h
@@ -56,6 +56,7 @@ public:
     bool itemExpanded() override;
     QRect expandItemRect() override;
     QModelIndex expandedIndex() override;
+    QWidget *expandedItem() override;
 
     QString displayFileName(const QModelIndex &index) const;
     QList<QRectF> calFileNameRect(const QString &name, const QRectF &rect, Qt::TextElideMode elideMode) const;


### PR DESCRIPTION
- Add Qt::FramelessWindowHint to folder list window for better visual style
- Unify margin constant naming to kFolderListItemMargin
- Simplify folder list height calculation logic
- Use system style radius for folder item highlight through DStyle

Log: fix UI issue
Bug: https://pms.uniontech.com/bug-view-289873.html