### PR TITLE
fix: unify icon state handling in file manager UI

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -272,8 +272,6 @@ void FileManagerWindowPrivate::connectAnimationSignals()
         bool expanded = curSplitterAnimation->endValue().toInt() > 1;
         if (expanded)
             resetSideBarSize();
-        sideBar->setVisible(expanded);
-        sidebarSep->setVisible(expanded);
         delete curSplitterAnimation;
         curSplitterAnimation = nullptr;
     });

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -378,7 +378,6 @@ void SideBarItemDelegate::onEditorTextChanged(const QString &text, const FileInf
 
 void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option, QPainter *painter, const QRect &itemRect, bool isEjectable, QSize iconSize, QIcon::Mode iconMode, QPalette::ColorGroup cg) const
 {
-
     if (option.state & QStyle::State_Selected) {
         painter->setPen(option.palette.color(cg, QPalette::HighlightedText));
     } else {
@@ -390,8 +389,7 @@ void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option, QPainter 
     QPointF iconTopLeft = itemRect.topLeft() + QPointF(iconDx, iconDy);
     QRect iconRect(iconTopLeft.toPoint(), iconSize);
 
-    QIcon::State state = (option.state & QStyle::State_Open) ? QIcon::On : QIcon::Off;
-    option.icon.paint(painter, iconRect, option.decorationAlignment, iconMode, state);
+    option.icon.paint(painter, iconRect, option.decorationAlignment, iconMode, QIcon::On);
 
     // draw ejectable device icon
     if (isEjectable) {
@@ -408,7 +406,7 @@ void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option, QPainter 
         QPoint ejectIconTopLeft = itemRect.bottomRight() + QPoint(0 - ejectIconSize.width() * 2, 0 - (itemRect.height() + ejectIconSize.height()) / 2);
         QPoint ejectIconBottomRight = ejectIconTopLeft + QPoint(ejectIconSize.width(), ejectIconSize.height());
         QIcon ejectIcon = QIcon::fromTheme("media-eject-symbolic");
-        auto px { ejectIcon.pixmap(iconSize, pixmapMode, state) };
+        auto px { ejectIcon.pixmap(iconSize, pixmapMode, QIcon::On) };
         QStyle *style { option.widget ? option.widget->style() : QApplication::style() };
         style->drawItemPixmap(painter, QRect(ejectIconTopLeft, ejectIconBottomRight), Qt::AlignCenter, px);
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/dfmplugin_titlebar_global.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dfmplugin_titlebar_global.h
@@ -31,7 +31,7 @@ inline constexpr int kItemHeight { 30 };
 inline constexpr int kItemMargin { 8 };
 inline constexpr int kCompleterMaxHeight { 260 };
 inline constexpr int kToolButtonSize { 30 };
-inline constexpr int kToolButtonIconSize { 14 };
+inline constexpr int kToolButtonIconSize { 16 };
 inline constexpr int kMaxTabCount { 8 };
 inline constexpr int kFolderItemHeight { 26 };
 inline constexpr int kFolderIconSize { 16 };

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -218,6 +218,7 @@ void SearchEditWidget::insertCompletion(const QString &completion)
 
     if (completion == QObject::tr("Clear search history")) {
         isClearSearch = true;
+        onReturnPressed();
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
@@ -344,7 +344,7 @@ void UrlPushButton::paintEvent(QPaintEvent *event)
         QRect iconRect(QPoint(0, 0), iconSize);
         iconRect.moveCenter(borderRect.center());
         iconRect.moveLeft(kBorderWidth);
-        icon().paint(&painter, iconRect, Qt::AlignCenter);
+        icon().paint(&painter, iconRect, Qt::AlignCenter, QIcon::Normal, QIcon::On);
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1391,8 +1391,9 @@ void FileView::resizeEvent(QResizeEvent *event)
 
     if (isIconViewMode()) {
         updateViewportContentsMargins(itemSizeHint());
-        if (model()->currentState() == ModelState::kIdle)
+        if (model()->currentState() == ModelState::kIdle && event->size().width() != event->oldSize().width()) {
             d->animationHelper->playViewAnimation();
+        }
     }
 
     verticalScrollBar()->setFixedHeight(rect().height() - d->statusBar->height() - (d->headerView ? d->headerView->height() : 0));


### PR DESCRIPTION
1. Set QIcon::On state for icons in sidebar and titlebar
2. Remove redundant QIcon::State calculation in SideBarItemDelegate
3. Adjust tool button icon size from 14px to 16px for better visual consistency
4. Fix icon state in UrlPushButton to ensure proper icon display

This change ensures consistent icon states and sizes across the file manager UI,
improving visual coherence and following the design specifications.

Log: fix ui issue
Bug: https://pms.uniontech.com/bug-view-289893.html