### PR TITLE
fix: improve splitter animation handling

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -272,7 +272,10 @@ void FileManagerWindowPrivate::connectAnimationSignals()
         bool expanded = curSplitterAnimation->endValue().toInt() > 1;
         if (expanded)
             resetSideBarSize();
-        splitter->handle(1)->setEnabled(expanded);
+        // set the handle to be disabled when the side bar is collapsed
+        // because if do not disable the handle, the splitter can be dragged by pressed window left boarder.
+        if (auto handle = splitter->handle(1))
+            handle->setEnabled(expanded);
         delete curSplitterAnimation;
         curSplitterAnimation = nullptr;
     });

--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -272,6 +272,7 @@ void FileManagerWindowPrivate::connectAnimationSignals()
         bool expanded = curSplitterAnimation->endValue().toInt() > 1;
         if (expanded)
             resetSideBarSize();
+        splitter->handle(1)->setEnabled(expanded);
         delete curSplitterAnimation;
         curSplitterAnimation = nullptr;
     });

--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
@@ -79,6 +79,7 @@ void TitleBar::onWindowOpened(quint64 windId)
     connect(window, &FileManagerWindow::reqCloseCurrentTab, titleBarWidget, &TitleBarWidget::handleHotketCloseCurrentTab);
     connect(window, &FileManagerWindow::reqActivateTabByIndex, titleBarWidget, &TitleBarWidget::handleHotketActivateTab);
     connect(window, &FileManagerWindow::windowSplitterWidthChanged, titleBarWidget, &TitleBarWidget::handleSplitterAnimation);
+    connect(window, &FileManagerWindow::aboutToPlaySplitterAnimation, titleBarWidget, &TitleBarWidget::handleAboutToPlaySplitterAnim);
 }
 
 void TitleBar::onWindowClosed(quint64 windId)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -438,6 +438,8 @@ bool TitleBarWidget::eventFilter(QObject *watched, QEvent *event)
         }
     }
 
+    // if the splitter is animating, do not process the resize event of tabbar
+    // otherwise, the tabbar width will be changed twice(once by the resizeEvent and once by placeholder size changed)
     if (watched == bottomBar && event->type() == QEvent::Resize) {
         if (isSplitterAnimating)
             return true;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -41,6 +41,7 @@ public:
     void showSearchFilterButton(bool visible);
     void setViewModeState(int mode);
     void handleSplitterAnimation(const QVariant &position);
+    void handleAboutToPlaySplitterAnim(int startValue, int endValue);
 
     int calculateRemainingWidth() const;
 
@@ -93,6 +94,9 @@ private:
     QWidget *placeholder { nullptr };
 
     bool searchButtonSwitchState { false };
+    int splitterStartValue { -1 };
+    int splitterEndValue { -1 };
+    bool isSplitterAnimating { false };
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -16,6 +16,8 @@
 #include <QVBoxLayout>
 #include <QStandardItemModel>
 #include <QKeyEvent>
+#include <QApplication>
+#include <QScreen>
 
 DWIDGET_USE_NAMESPACE
 using namespace dfmplugin_titlebar;
@@ -290,7 +292,32 @@ void ViewOptionsWidget::exec(const QPoint &pos, DFMBASE_NAMESPACE::Global::ViewM
 {
     d->setUrl(url);
     d->switchMode(mode);
-    move(pos);
+    
+    // Calculate appropriate display position to ensure widget stays within screen bounds
+    QPoint showPos = pos;
+    QRect screenRect = QApplication::screenAt(pos)->availableGeometry();
+    
+    // Check right boundary
+    if (pos.x() + width() > screenRect.right()) {
+        showPos.setX(screenRect.right() - width());
+    }
+    
+    // Check left boundary 
+    if (showPos.x() < screenRect.left()) {
+        showPos.setX(screenRect.left());
+    }
+    
+    // Check bottom boundary
+    if (pos.y() + height() > screenRect.bottom()) {
+        showPos.setY(screenRect.bottom() - height());
+    }
+    
+    // Check top boundary
+    if (showPos.y() < screenRect.top()) {
+        showPos.setY(screenRect.top());
+    }
+    
+    move(showPos);
     show();
 
     QEventLoop eventLoop;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -68,6 +68,7 @@ FileView::FileView(const QUrl &url, QWidget *parent)
     : DListView(parent), d(new FileViewPrivate(this))
 {
     Q_UNUSED(url);
+    setMinimumHeight(10);
     setDragDropMode(QAbstractItemView::DragDrop);
     setDropIndicatorShown(false);
     setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacewidget.cpp
@@ -318,7 +318,7 @@ void WorkspaceWidget::initViewLayout()
     viewStackLayout->setContentsMargins(0, 0, 0, 0);
 
     widgetLayout = new QVBoxLayout;
-    widgetLayout->addLayout(viewStackLayout, 1);
+    widgetLayout->addLayout(viewStackLayout, 0);
     widgetLayout->setSpacing(0);
     widgetLayout->setContentsMargins(0, 0, 0, 0);
     setLayout(widgetLayout);
@@ -366,7 +366,7 @@ void WorkspaceWidget::initCustomTopWidgets(const QUrl &url)
     } else {
         TopWidgetPtr topWidgetPtr = QSharedPointer<QWidget>(interface->create());
         if (topWidgetPtr) {
-            widgetLayout->insertWidget(0, topWidgetPtr.get());
+            widgetLayout->insertWidget(0, topWidgetPtr.get(), 1, Qt::AlignTop);
             topWidgets.insert(scheme, topWidgetPtr);
             topWidgetPtr->setVisible(interface->isShowFromUrl(topWidgets[scheme].data(), url) || interface->isKeepShow());
         }


### PR DESCRIPTION
1. Add handle enable/disable during splitter animation to prevent user interference
2. Add animation state tracking in titlebar to avoid unnecessary UI updates
3. Optimize placeholder width updates to prevent redundant resizing
4. Add animation start/end value tracking for better state management

Log: fix animation issue
Bug: https://pms.uniontech.com/bug-view-292639.html