### PR TITLE
fix: refresh desktop icon cache after installing deb package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -75,7 +75,8 @@ Depends:
  libdde-file-manager (=${binary:Version}),
  libqt6sql6-sqlite,
  qt6-translations-l10n,
- libimageeditor6 | hello
+ libimageeditor6 | hello,
+ qtxdg-dev-tools
 Conflicts: dde-workspace (<< 2.90.5), dde-file-manager-oem, dde-desktop-plugins
 Replaces: dde-file-manager-oem, dde-file-manager (<< 6.0.1), dde-desktop-plugins
 Recommends: qt5dxcb-plugin, deepin-screensaver, dcc-wallpapersetting-plugin

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -35,6 +35,8 @@ public:
     static bool isDesktopFile(const QUrl &url);
     static bool isDesktopFileSuffix(const QUrl &url);
     static bool isDesktopFileInfo(const FileInfoPointer &info);
+    static void refreshIconCache();
+    static QString findIconFromXdg(const QString &iconName);
 
     static bool isTrashDesktopFile(const QUrl &url);
     static bool isComputerDesktopFile(const QUrl &url);

--- a/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel_p.h
@@ -24,6 +24,7 @@ public:
     explicit FileInfoModelPrivate(FileInfoModel *qq);
     void doRefresh();
     QIcon fileIcon(FileInfoPointer info);
+    void checkAndRefreshDesktopIcon(const FileInfoPointer &info, int retryCount = 5);
 
 public slots:
     void resetData(const QList<QUrl> &urls);


### PR DESCRIPTION
Due to QTBUG-112257, when installing a deb package, desktop files may be installed before their icon resources. Qt caches the null icon on first draw and won't update even after icon resources are installed. Add icon cache refresh mechanism to ensure proper icon display.

Log:

Bug: https://pms.uniontech.com/bug-view-294839.html###