### PR TITLE
refactor: improve text line height calculation for file names

### DIFF
--- a/src/apps/dde-desktop/main.cpp
+++ b/src/apps/dde-desktop/main.cpp
@@ -44,6 +44,7 @@ Q_LOGGING_CATEGORY(logAppDesktop, "org.deepin.dde.filemanager.desktop")
 DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace dde_desktop;
+using namespace GlobalDConfDefines::ConfigPath;
 
 #ifdef DFM_ORGANIZATION_NAME
 #    define ORGANIZATION_NAME DFM_ORGANIZATION_NAME
@@ -198,7 +199,7 @@ static void checkUpgrade(DApplication *app)
 static bool isDesktopEnable()
 {
     bool enable = !(dfmbase::DConfigManager::instance()->value(
-                                                               dfmbase::kDefaultCfgPath,
+                                                               kDefaultCfgPath,
                                                                "dd.disabled",
                                                                false)
                             .toBool());
@@ -207,7 +208,7 @@ static bool isDesktopEnable()
 
 static void autoReleaseMemory()
 {
-    bool autoRelease = dfmbase::DConfigManager::instance()->value(dfmbase::kDefaultCfgPath, "dfm.memory.autorelease", true).toBool();
+    bool autoRelease = dfmbase::DConfigManager::instance()->value(kDefaultCfgPath, "dfm.memory.autorelease", true).toBool();
     if (!autoRelease)
         return;
 

--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -570,4 +570,22 @@ void UniversalUtils::boardCastPastData(const QUrl &sourcPath, const QUrl &target
     fileMonitor.asyncCallWithArgumentList(QStringLiteral("PrepareSendData"), data);
 }
 
+int UniversalUtils::getTextLineHeight(const QModelIndex &index, const QFontMetrics &fontMetrics)
+{
+    auto text = index.data(Global::ItemRoles::kItemFileDisplayNameRole).toString();
+    return getTextLineHeight(text, fontMetrics);
+}
+
+int UniversalUtils::getTextLineHeight(const QString &text, const QFontMetrics &fontMetrics)
+{
+    if (text.isEmpty())
+        return fontMetrics.height();
+
+    auto textRect = fontMetrics.boundingRect(text);
+    if (textRect.height() <= 0)
+        return fontMetrics.height();
+
+    return textRect.height();
+}
+
 }

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -10,6 +10,8 @@
 #include <QString>
 #include <QtDBus/QDBusReply>
 #include <QtDBus/QDBusUnixFileDescriptor>
+#include <QFontMetrics>
+#include <QModelIndex>
 
 namespace dfmbase {
 
@@ -54,6 +56,9 @@ public:
     static QString covertUrlToLocalPath(const QString &url);
     static void boardCastPastData(const QUrl &sourcPath, const QUrl &targetPath,
                                   const QList<QUrl> &files);
+
+    static int getTextLineHeight(const QModelIndex &index, const QFontMetrics &fontMetrics);
+    static int getTextLineHeight(const QString &text, const QFontMetrics &fontMetrics);
 };
 
 }

--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -16,6 +16,7 @@
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/iconutils.h>
 #include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/utils/universalutils.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -60,9 +61,10 @@ ElideTextLayout *CanvasItemDelegatePrivate::createTextlayout(const QModelIndex &
     bool showSuffix = Application::instance()->genericAttribute(Application::kShowedFileSuffix).toBool();
     QString name = showSuffix ? index.data(Global::ItemRoles::kItemFileDisplayNameRole).toString()
                               : index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString();
+    int lineHeight = UniversalUtils::getTextLineHeight(index, q->parent()->fontMetrics());
     ElideTextLayout *layout = new ElideTextLayout(name);
     layout->setAttribute(ElideTextLayout::kWrapMode, (uint)QTextOption::WrapAtWordBoundaryOrAnywhere);
-    layout->setAttribute(ElideTextLayout::kLineHeight, textLineHeight);
+    layout->setAttribute(ElideTextLayout::kLineHeight, lineHeight);
     layout->setAttribute(ElideTextLayout::kAlignment, Qt::AlignHCenter);
 
     if (painter) {

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -18,6 +18,7 @@
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/iconutils.h>
+#include <dfm-base/utils/universalutils.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -65,8 +66,9 @@ ElideTextLayout *CollectionItemDelegatePrivate::createTextlayout(const QModelInd
     QString name = showSuffix ? index.data(Global::ItemRoles::kItemFileDisplayNameRole).toString()
                               : index.data(Global::ItemRoles::kItemFileBaseNameOfRenameRole).toString();
     ElideTextLayout *layout = new ElideTextLayout(name);
+    int lineHeight = UniversalUtils::getTextLineHeight(index, q->parent()->fontMetrics());
     layout->setAttribute(ElideTextLayout::kWrapMode, (uint)QTextOption::WrapAtWordBoundaryOrAnywhere);
-    layout->setAttribute(ElideTextLayout::kLineHeight, textLineHeight);
+    layout->setAttribute(ElideTextLayout::kLineHeight, lineHeight);
     layout->setAttribute(ElideTextLayout::kAlignment, Qt::AlignHCenter);
     if (painter) {
         layout->setAttribute(ElideTextLayout::kFont, painter->font());

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewdrawhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewdrawhelper.cpp
@@ -8,6 +8,8 @@
 #include "models/fileviewmodel.h"
 #include "utils/itemdelegatehelper.h"
 
+#include <dfm-base/utils/universalutils.h>
+
 #include <QPainter>
 
 using namespace dfmbase;
@@ -150,7 +152,7 @@ void ViewDrawHelper::drawDragText(QPainter *painter, const QModelIndex &index, q
     painter->setPen(Qt::white);
 
     QString fileName = view->model()->data(index, ItemRoles::kItemFileDisplayNameRole).toString();
-    int textLineHeight = view->fontMetrics().height();
+    int textLineHeight = UniversalUtils::getTextLineHeight(fileName, view->fontMetrics());
     QRectF boundingRect(kDragIconOutline + (dragIconSize - textWidth) / 2, dragIconSize + kDragIconOutline, textWidth, textLineHeight * 2);
     QTextOption::WrapMode wordWrap(QTextOption::WrapAtWordBoundaryOrAnywhere);
     Qt::TextElideMode mode(Qt::ElideLeft);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
@@ -12,6 +12,7 @@
 #include "events/workspaceeventsequence.h"
 
 #include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/utils/universalutils.h>
 
 #include <QPainter>
 #include <QDebug>
@@ -63,9 +64,10 @@ void ExpandedItem::paintEvent(QPaintEvent *)
                     INT_MAX);
 
     QString str = delegate->displayFileName(index);
+    int lineHeight = UniversalUtils::getTextLineHeight(str, delegate->parent()->parent()->fontMetrics());
 
     QScopedPointer<ElideTextLayout> layout(ItemDelegateHelper::createTextLayout(str, QTextOption::WrapAtWordBoundaryOrAnywhere,
-                                                                                pa.fontMetrics().height(), Qt::AlignCenter, &pa));
+                                                                                lineHeight, Qt::AlignCenter, &pa));
     layout->setAttribute(ElideTextLayout::kBackgroundRadius, kIconModeRectRadius);
 
     const FileInfoPointer &info = delegate->parent()->parent()->model()->fileInfo(index);


### PR DESCRIPTION
- Replace fixed fontMetrics.height() with dynamic text height calculation
- Add new methods to calculate text line height based on actual content
- Update text layout in Canvas, Collection and Icon delegates
- Unify configuration path usage with GlobalDConfDefines namespace

The text layout will now better adapt to different fonts and file names, providing more precise vertical spacing and improved visual appearance.

Log: fix file name display issue
Task: https://pms.uniontech.com/task-view-370431.html