### PR TITLE
fix: limit cache check to file scheme only

### DIFF
--- a/src/plugins/desktop/ddplugin-background/backgrounddde.cpp
+++ b/src/plugins/desktop/ddplugin-background/backgrounddde.cpp
@@ -16,7 +16,7 @@ BackgroundDDE::BackgroundDDE(QObject *parent)
 {
     fmDebug() << "create org.deepin.dde.Appearance1";
     interface = new InterFace("org.deepin.dde.Appearance1", "/org/deepin/dde/Appearance1",
-                          QDBusConnection::sessionBus(), this);
+                              QDBusConnection::sessionBus(), this);
     interface->setTimeout(200);
     fmDebug() << "create org.deepin.dde.Appearance1 end";
 
@@ -44,7 +44,7 @@ QString BackgroundDDE::getBackgroundFromDDE(const QString &screen)
 
     if (reply.error().type() != QDBusError::NoError) {
         fmWarning() << "Get background failed by DDE_DBus"
-                   << reply.error().type() << reply.error().name() << reply.error().message();
+                    << reply.error().type() << reply.error().name() << reply.error().message();
     } else {
         path = reply.argumentAt<0>();
     }
@@ -88,7 +88,7 @@ QString BackgroundDDE::getBackgroundFromConfig(const QString &screen)
                             }
 
                             int workspaceIndex = wpIndex.left(index).toInt();
-                            QString screenName = wpIndex.mid(index+1);
+                            QString screenName = wpIndex.mid(index + 1);
                             if (workspaceIndex != currentWorkspaceIndex || screenName != screen) {
                                 continue;
                             }

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.cpp
@@ -26,7 +26,7 @@ TitleBarEventReceiver *TitleBarEventReceiver::instance()
 bool TitleBarEventReceiver::handleCustomRegister(const QString &scheme, const QVariantMap &properties)
 {
     Q_ASSERT(!scheme.isEmpty());
-    if (CrumbManager::instance()->isRegisted(scheme)) {
+    if (CrumbManager::instance()->isRegistered(scheme)) {
         fmWarning() << "Crumb sechme " << scheme << "has been resigtered!";
         return false;
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/crumbmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/crumbmanager.cpp
@@ -17,15 +17,15 @@ CrumbManager *CrumbManager::instance()
 
 void CrumbManager::registerCrumbCreator(const CrumbManager::KeyType &scheme, const CrumbManager::CrumbCreator &creator)
 {
-    if (isRegisted(scheme))
+    if (isRegistered(scheme))
         return;
 
     creators.insert(scheme, creator);
 }
 
-bool CrumbManager::isRegisted(const KeyType &KeyType) const
+bool CrumbManager::isRegistered(const KeyType &scheme) const
 {
-    return creators.contains(KeyType) ? true : false;
+    return creators.contains(scheme) ? true : false;
 }
 
 CrumbInterface *CrumbManager::createControllerByUrl(const QUrl &url)

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/crumbmanager.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/crumbmanager.h
@@ -30,7 +30,7 @@ public:
     static CrumbManager *instance();
 
     void registerCrumbCreator(const KeyType &scheme, const CrumbCreator &creator);
-    bool isRegisted(const KeyType &scheme) const;
+    bool isRegistered(const KeyType &scheme) const;
     CrumbInterface *createControllerByUrl(const QUrl &url);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
@@ -280,7 +280,7 @@ void UrlPushButton::setCrumbDatas(const QList<CrumbData> &datas, bool stacked)
     } else {
         const CrumbData &data = datas.first();
         // 本地文件显示下拉选项
-        d->subDirVisible = (ProtocolUtils::isLocalFile(data.url) && CrumbManager::instance()->isRegisted(data.url.scheme()));
+        d->subDirVisible = (!ProtocolUtils::isRemoteFile(data.url) && CrumbManager::instance()->isRegistered(data.url.scheme()));
         if (data.iconName.isEmpty()) {
             setText(data.displayText);
         } else {

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -188,7 +188,8 @@ bool FileDataManager::checkNeedCache(const QUrl &url)
         return true;
 
     // mounted dir should cache files in FileDataManager
-    if ((!ProtocolUtils::isLocalFile(url)))
+    // The purpose is only to judge nonlocal disk files, some schme should not use it to judge, so it is limited to file.
+    if (url.scheme() == Global::Scheme::kFile && (!ProtocolUtils::isLocalFile(url)))
         return true;
 
     return false;


### PR DESCRIPTION
Previously, the cache check logic was applied to all URLs, which could cause incorrect behavior for some schemes. Now restrict the mounted dir cache check to file:// scheme only to ensure proper handling of non-local files.

Also fixes code indentation in backgrounddde.cpp.

Log:

Bug: https://pms.uniontech.com/bug-view-296071.html