### PR TITLE
fix: enable desktop file preview in preview application

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.18) unstable; urgency=medium
+
+  * fix bugs 
+
+ -- zhangsheng <zhangsheng@uniontech.com>  Fri, 20 Dec 2024 13:11:12 +0800
+
 dde-file-manager (6.5.17) unstable; urgency=medium
 
   *fix  disk-encrypt blocked

--- a/src/apps/dde-file-manager-preview/libdfm-preview/filepreview.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/filepreview.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/file/local/asyncfileinfo.h>
 #include <dfm-base/file/local/localdiriterator.h>
 #include <dfm-base/file/local/localfilewatcher.h>
+#include <dfm-base/file/local/desktopfileinfo.h>
 
 #include <QSurfaceFormat>
 
@@ -25,7 +26,8 @@ static FilePreview *filePreviewIns = nullptr;
 extern "C" {
 #endif
 
-int initFilePreview() {
+int initFilePreview()
+{
     filePreviewIns = new FilePreview;
     filePreviewIns->initialize();
     filePreviewIns->start();
@@ -57,6 +59,8 @@ void FilePreview::initialize()
     }
 
     UrlRoute::regScheme(Global::Scheme::kFile, "/");
+    InfoFactory::regInfoTransFunc<FileInfo>(Global::Scheme::kFile, DesktopFileInfo::convert);
+    UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/", QIcon(), false, QObject::tr("System Disk"));
     UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
     InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
     InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
@@ -77,7 +81,7 @@ bool FilePreview::start()
 
 void FilePreview::showFilePreview(quint64 windowId, const QList<QUrl> &selecturls, const QList<QUrl> dirUrl)
 {
-    if(isPreviewEnabled())
+    if (isPreviewEnabled())
         PreviewDialogManager::instance()->showPreviewDialog(windowId, selecturls, dirUrl);
 }
 

--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -6,6 +6,7 @@
 #include <dfm-base/utils/desktopfile.h>
 #include <dfm-base/utils/properties.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/protocolutils.h>
 #include <dfm-base/base/schemefactory.h>
 
 #include <QDir>
@@ -284,4 +285,17 @@ QMap<QString, QVariant> DesktopFileInfo::desktopFileInfo(const QUrl &fileUrl)
     map["DeepinVendor"] = desktopFile.desktopDeepinVendor();
 
     return map;
+}
+
+QSharedPointer<FileInfo> DesktopFileInfo::convert(QSharedPointer<FileInfo> fileInfo)
+{
+    const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
+    // invoking suffix/mimeTypeName might cost huge time
+    if (ProtocolUtils::isRemoteFile(url))
+        return fileInfo;
+
+    if (FileUtils::isDesktopFileInfo(fileInfo))
+        return FileInfoPointer(new DFMBASE_NAMESPACE::DesktopFileInfo(url, fileInfo));
+
+    return fileInfo;
 }

--- a/src/dfm-base/file/local/desktopfileinfo.h
+++ b/src/dfm-base/file/local/desktopfileinfo.h
@@ -37,6 +37,7 @@ public:
     virtual bool canAttributes(const FileCanType type) const override;
     virtual void updateAttributes(const QList<FileInfoAttributeID> &types = {}) override;
     static QMap<QString, QVariant> desktopFileInfo(const QUrl &fileUrl);
+    static QSharedPointer<FileInfo> convert(QSharedPointer<FileInfo> fileInfo);
 
 private:
     QSharedPointer<DesktopFileInfoPrivate> d = nullptr;

--- a/src/plugins/common/dfmplugin-utils/global/virtualglobalplugin.cpp
+++ b/src/plugins/common/dfmplugin-utils/global/virtualglobalplugin.cpp
@@ -4,35 +4,11 @@
 
 #include "virtualglobalplugin.h"
 
-#include <dfm-base/base/schemefactory.h>
-#include <dfm-base/dfm_global_defines.h>
-#include <dfm-base/file/local/desktopfileinfo.h>
-#include <dfm-base/base/standardpaths.h>
-#include <dfm-base/mimetype/dmimedatabase.h>
-#include <dfm-base/utils/fileutils.h>
-
 using namespace dfmplugin_utils;
-DFMBASE_USE_NAMESPACE
-
-static QSharedPointer<dfmbase::FileInfo> transFileInfo(QSharedPointer<dfmbase::FileInfo> fileInfo)
-{
-    // no translate for gvfs file, invoking suffix/mimeTypeName might cost huge time
-    if (fileInfo->urlOf(UrlInfoType::kUrl).path().contains(QRegularExpression(DFMBASE_NAMESPACE::Global::Regex::kGvfsRoot)))
-        return fileInfo;
-
-    if (FileUtils::isDesktopFileInfo(fileInfo)) {
-        const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
-        return FileInfoPointer(new DFMBASE_NAMESPACE::DesktopFileInfo(url, fileInfo));
-    }
-
-    return fileInfo;
-}
 
 void VirtualGlobalPlugin::initialize()
 {
     eventReceiver->initEventConnect();
-
-    DFMBASE_NAMESPACE::InfoFactory::regInfoTransFunc<DFMBASE_NAMESPACE::FileInfo>(DFMBASE_NAMESPACE::Global::Scheme::kFile, transFileInfo);
 }
 
 bool VirtualGlobalPlugin::start()

--- a/src/plugins/desktop/ddplugin-core/core.cpp
+++ b/src/plugins/desktop/ddplugin-core/core.cpp
@@ -52,6 +52,7 @@ DFM_LOG_REISGER_CATEGORY(DDPCORE_NAMESPACE)
 static void registerFileSystem()
 {
     UrlRoute::regScheme(Global::Scheme::kFile, "/");
+    InfoFactory::regInfoTransFunc<FileInfo>(Global::Scheme::kFile, DesktopFileInfo::convert);
     UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
     InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
     InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);

--- a/src/plugins/filemanager/dfmplugin-core/core.cpp
+++ b/src/plugins/filemanager/dfmplugin-core/core.cpp
@@ -52,6 +52,7 @@ void Core::initialize()
     UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/", QIcon(), false, QObject::tr("System Disk"));
     // 注册Scheme为"file"的扩展的文件信息 本地默认文件的
     InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+    InfoFactory::regInfoTransFunc<FileInfo>(Global::Scheme::kFile, DesktopFileInfo::convert);
     InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
     DirIteratorFactory::regClass<LocalDirIterator>(Global::Scheme::kFile);
     WatcherFactory::regClass<LocalFileWatcher>(Global::Scheme::kFile);


### PR DESCRIPTION
Register desktop file info converter for file scheme in preview application to properly handle and display .desktop files. Move the converter registration from virtual global plugin to core components for consistent desktop file handling across applications.

Log:

Bug: https://pms.uniontech.com/bug-view-293749.html