### PR TITLE
fix: ensure Qt resources are properly loaded

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.10.2) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Mon, 23 Dec 2024 17:10:08 +0800
+
 dde-file-manager (6.5.10.1) unstable; urgency=medium
 
   * update to 6.5.10.1

--- a/src/plugins/desktop/ddplugin-organizer/ddplugin-organizer.cmake
+++ b/src/plugins/desktop/ddplugin-organizer/ddplugin-organizer.cmake
@@ -1,3 +1,6 @@
+# qt_add_resources works only if you have previously used find_package to find the Qt
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core)
+
 # 指定资源文件
 set(QRC_FILE
     resources/images.qrc
@@ -15,7 +18,6 @@ add_library(${BIN_NAME}
     ${QRC_RESOURCES}
 )
 
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core)
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DESKTOP_DIR})
 

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -224,6 +224,10 @@ void NormalizedModePrivate::connectCollectionSignals(CollectionHolderPointer col
                 });
         dpfSignalDispatcher->subscribe("ddplugin_background", "signal_Background_BackgroundSetted",
                                        collection->widget(), &CollectionWidget::cacheSnapshot);
+        connect(collection->widget(), &QWidget::destroyed, this, [](QObject *obj) {
+            dpfSignalDispatcher->unsubscribe("ddplugin_background", "signal_Background_BackgroundSetted",
+                                             obj, &CollectionWidget::cacheSnapshot);
+        });
     }
 }
 


### PR DESCRIPTION
Move find_package(Qt Core) before qt_add_resources since Qt resource compilation requires Qt components to be found first.

Log:

Bug: https://pms.uniontech.com/bug-view-292585.html