### PR TITLE
feat: increase titlebar buttons width to 50px

### DIFF
--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -360,12 +360,12 @@ void SettingBackend::initWorkspaceSettingConfig()
         viewModeValues.append(tr("Tree"));
         viewModeKeys.append(8);
     }
-    ins->addComboboxConfig(LV2_GROUP_VIEW ".02_view_mode",
+    ins->addComboboxConfig(LV2_GROUP_VIEW ".03_view_mode",
                            tr("Default view:"),
                            { { "values", viewModeValues },
                              { "keys", viewModeKeys } },
                            1);
-    ins->addConfig(LV2_GROUP_VIEW ".03_restore_view_mode",
+    ins->addConfig(LV2_GROUP_VIEW ".04_restore_view_mode",
                    { { "key", "03_restore_view_mode" },
                      { "desc", tr("Restore default view mode for all directories") },
                      { "text", tr("Restore default view mode") },

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -375,19 +375,19 @@ void TitleBarWidget::updateUiForSizeMode()
 
     auto optionBtn = topBar->findChild<DWindowOptionButton *>("DTitlebarDWindowOptionButton");
     if (optionBtn)
-        optionBtn->setFixedSize(40, 40);
+        optionBtn->setFixedSize(50, 40);
 
     auto closeBtn = topBar->findChild<DWindowCloseButton *>("DTitlebarDWindowCloseButton");
     if (closeBtn)
-        closeBtn->setFixedSize(40, 40);
+        closeBtn->setFixedSize(50, 40);
 
     auto minBtn = topBar->findChild<DWindowMinButton *>("DTitlebarDWindowMinButton");
     if (minBtn)
-        minBtn->setFixedSize(40, 40);
+        minBtn->setFixedSize(50, 40);
 
     auto maxBtn = topBar->findChild<DWindowMaxButton *>("DTitlebarDWindowMaxButton");
     if (maxBtn)
-        maxBtn->setFixedSize(40, 40);
+        maxBtn->setFixedSize(50, 40);
 }
 
 void TitleBarWidget::showAddrsssBar(const QUrl &url)


### PR DESCRIPTION
Adjust the width of titlebar buttons (option, close, minimize, maximize)
from 40px to 50px while maintaining the height at 40px to improve
clickable area and user interaction.

Log: increase titlebar buttons width to 50px
Bug: https://pms.uniontech.com/bug-view-297327.html