### PR TITLE
fix: handle missing recent file initialization

### DIFF
--- a/src/plugins/daemon/daemon-recentdaemon/recentmanager.cpp
+++ b/src/plugins/daemon/daemon-recentdaemon/recentmanager.cpp
@@ -11,6 +11,8 @@
 
 #include <QCoreApplication>
 #include <QTimer>
+#include <QFileInfo>
+#include <QFile>
 
 SERVERRECENTMANAGER_BEGIN_NAMESPACE
 
@@ -78,6 +80,20 @@ void RecentManager::finalize()
 void RecentManager::startWatch()
 {
     auto uri { QUrl::fromLocalFile(xbelPath()) };
+    QString localPath = uri.toLocalFile();
+
+    if (!QFileInfo(localPath).exists()) {
+        // Create empty xbel file if not exists
+        QFile file(localPath);
+        if (file.open(QIODevice::WriteOnly)) {
+            fmInfo() << "Created empty recent file:" << localPath;
+            file.close();
+        } else {
+            fmWarning() << "Failed to create recent file:" << localPath;
+            return;
+        }
+    }
+
     watcher = WatcherFactory::create<AbstractFileWatcher>(uri);
     fmDebug() << "Start watch recent file: " << uri;
     // fileAttributeChanged 可能被高频率发送


### PR DESCRIPTION
When the recent file manager starts, it now properly handles the case where the xbel file doesn't exist. This fix:

- Add existence check for xbel file
- Create empty xbel file if not exists
- Add proper error handling and logging
- Ensure file watcher starts correctly

This ensures the recent file manager works properly on first run or when the xbel file is missing.

Log:

Bug: https://pms.uniontech.com/bug-view-296569.html