### PR TITLE
fix bus

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.cpp
@@ -8,11 +8,11 @@
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/application/application.h>
+#include <dfm-base/utils/chinese2pinyin.h>
 
 #include <QVBoxLayout>
 #include <QStandardItemModel>
 #include <QKeyEvent>
-#include <dfm-base/utils/chinese2pinyin.h>
 
 DWIDGET_USE_NAMESPACE
 using namespace dfmplugin_titlebar;
@@ -166,7 +166,13 @@ void FolderListWidget::setFolderList(const QList<CrumbData> &datas, bool stacked
     setFixedWidth(width);
 
     int folderCount = dataNum > kMaxFolderCount ? kMaxFolderCount : dataNum;
-    setFixedHeight(kFolderListItemMargin * 2 + kFolderItemHeight * folderCount);
+    if (dataNum > 1) {
+        d->folderView->setViewportMargins(kItemMargin, kItemMargin, kItemMargin, kItemMargin);
+        setFixedHeight(kItemMargin * 2 + kFolderItemHeight * folderCount);
+    } else {
+        d->folderView->setViewportMargins(kItemMargin, kItemMargin * 3 / 2, kItemMargin, kItemMargin * 3 / 2);
+        setFixedHeight(kItemMargin * 3 + kFolderItemHeight * folderCount);
+    }
 }
 
 void FolderListWidget::keyPressEvent(QKeyEvent *event)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.h
@@ -30,6 +30,10 @@ Q_SIGNALS:
 protected:
     void keyPressEvent(QKeyEvent *event) override;
     void hideEvent(QHideEvent *event) override;
+
+private:
+    bool matchText(const QString &source, const QString &input) const;
+    bool findAndSelectMatch(const QString &text, int startRow) const;
 };
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
@@ -17,6 +17,7 @@
 #include <QPainter>
 #include <QStyleOptionButton>
 #include <QMouseEvent>
+#include <QStylePainter>
 
 using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
@@ -144,7 +145,13 @@ void SortByButton::paintEvent(QPaintEvent *event)
     opt.initFrom(this);
 
     if (d->hoverFlag || d->menu->isVisible()) {
-        style()->drawControl(QStyle::CE_PushButton, &opt, &painter, this);
+        QStylePainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing);
+        QStyleOptionToolButton option;
+        QToolButton::initStyleOption(&option);
+        option.state |= QStyle::State_MouseOver;
+        option.rect.adjust(1, 1, -1, -1);
+        painter.drawComplexControl(QStyle::CC_ToolButton, option);
     }
 
     // Draw left icon

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
@@ -167,14 +167,8 @@ void Tab::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidg
     pen.setWidth(1);
 
     QFont font;
-    if (isChecked()) {
-        font.setBold(true);
-    } else {
-        font.setBold(false);
-    }
-
     int tabMargin = 10;
-    int blueSquareWidth = isChecked() ? 5 : 0;
+    int blueSquareWidth = isChecked() ? 6 : 0;
     int blueSquareMargin = isChecked() ? 4 : 0;
     int buttonSize = (d->hovered && d->showCloseButton) ? 16 : 0;
     int buttonMargin = (d->hovered && d->showCloseButton) ? 4 : 0;
@@ -205,8 +199,12 @@ void Tab::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidg
     }
 
     if (isChecked()) {
+        painter->save();
         QColor blueColor = pal.color(QPalette::Active, QPalette::Highlight);
-        painter->fillRect(QRect((d->width - fm.horizontalAdvance(str) - textMargin) / 2, (d->height - blueSquareWidth) / 2, blueSquareWidth, blueSquareWidth), blueColor);
+        painter->setPen(Qt::NoPen);
+        painter->setBrush(blueColor);
+        painter->drawRoundedRect(QRect((d->width - fm.horizontalAdvance(str) - textMargin) / 2, (d->height - blueSquareWidth) / 2, blueSquareWidth, blueSquareWidth), 1, 1);
+        painter->restore();
     }
 
     // draw text

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -227,6 +227,7 @@ void TitleBarWidget::initializeUi()
     bottomBar = new TabBar;
     bottomBar->installEventFilter(this);
     topBarCustomLayout->addWidget(bottomBar, 1);
+    topBarCustomLayout->addSpacing(10);
 
     // nav
     curNavWidget = new NavWidget;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
@@ -111,7 +111,7 @@ QColor UrlPushButtonPrivate::foregroundColor() const
     QColor color = q->palette().color(q->foregroundRole());
 
     // 根据活动状态调整透明度
-    int alpha = active ? 255 : 128;
+    int alpha = active ? 178 : 89;
     if (!active) {
         alpha -= alpha / 4;
     }
@@ -349,7 +349,7 @@ void UrlPushButton::paintEvent(QPaintEvent *event)
     }
 
     QFont adjustedFont(font());
-    adjustedFont.setBold(d->subDir.isEmpty());
+    // adjustedFont.setBold(d->subDir.isEmpty());
     painter.setFont(adjustedFont);
 
     const int buttonWidth = width();


### PR DESCRIPTION
fix: Fix the problem of deformation of the crumb menu.
    
    The rounded corner set by the system is too large. When it is displayed only one item, it cannot be completely drawn to the corner, causing the lower part of the window to abnormal. Compatible treatment will increase height when there is only one item.
    
    Log: Fix the problem of deformation of the crumb menu.
    
    Bug: https://pms.uniontech.com/bug-view-296751.html