### PR TITLE
fix: optimize search edit widget layout and mode switching

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -103,9 +103,6 @@ void SearchEditWidget::setSearchMode(SearchMode mode)
     if (advancedButton->isChecked() || searchEdit->hasFocus())
         return;
 
-    if (currentMode == mode)
-        return;
-
     currentMode = mode;
     updateSearchWidgetLayout();
 }
@@ -717,7 +714,10 @@ void SearchEditWidget::updateSearchWidgetLayout()
         searchButton->setVisible(true);
         advancedButton->setVisible(false);
     } else {
-        setFixedWidth(currentMode == SearchMode::kExtraLarge ? kSearchEditMaxWidth : kSearchEditMediumWidth);
+        int width = kSearchEditMediumWidth;
+        if (currentMode == SearchMode::kExtraLarge)
+            width = (parentWidget()->width() - kWidthThresholdExpand) + kSearchEditMediumWidth;
+        setFixedWidth(qMin(width, kSearchEditMaxWidth));
         searchEdit->setVisible(true);
         searchButton->setVisible(false);
         advancedButton->setVisible(searchEdit->hasFocus() || !searchEdit->text().isEmpty());


### PR DESCRIPTION
1. Remove redundant mode check in setSearchMode() to ensure layout updates are always processed
2. Improve search edit width calculation

Log: fix search ui issue
Bug: https://pms.uniontech.com/bug-view-297463.html