### PR TITLE
chore: add license headers to AppLaunchUtils files

### DIFF
--- a/src/dfm-base/utils/applaunchutils.cpp
+++ b/src/dfm-base/utils/applaunchutils.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "applaunchutils.h"
 #include "applaunchutils_p.h"
 

--- a/src/dfm-base/utils/applaunchutils.h
+++ b/src/dfm-base/utils/applaunchutils.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef APPLAUNCHUTILS_H
 #define APPLAUNCHUTILS_H
 
@@ -21,7 +24,7 @@ public:
 
     // 添加启动策略，优先级数字越小优先级越高
     void addStrategy(AppLaunchFunc launcher, int priority);
-    
+
     // 启动应用
     bool launchApp(const QString &desktopFile, const QStringList &filePaths);
 
@@ -34,4 +37,4 @@ private:
 
 DFMBASE_END_NAMESPACE
 
-#endif // APPLAUNCHUTILS_H
+#endif   // APPLAUNCHUTILS_H

--- a/src/dfm-base/utils/applaunchutils_p.h
+++ b/src/dfm-base/utils/applaunchutils_p.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef APPLAUNCHUTILS_P_H
 #define APPLAUNCHUTILS_P_H
 
@@ -9,7 +12,8 @@
 DFMBASE_BEGIN_NAMESPACE
 
 // DBus service names for V2X
-struct DBusServiceNames {
+struct DBusServiceNames
+{
     static constexpr const char *kService = "org.desktopspec.ApplicationManager1";
     static constexpr const char *kPathPrefix = "/org/desktopspec/ApplicationManager1";
     static constexpr const char *kInterface = "org.desktopspec.ApplicationManager1.Application";
@@ -44,4 +48,4 @@ private:
 
 DFMBASE_END_NAMESPACE
 
-#endif // APPLAUNCHUTILS_P_H 
+#endif   // APPLAUNCHUTILS_P_H


### PR DESCRIPTION
Add SPDX license headers to AppLaunchUtils implementation files:
- Add GPL-3.0-or-later license header to applaunchutils.cpp
- Add GPL-3.0-or-later license header to applaunchutils.h
- Add GPL-3.0-or-later license header to applaunchutils_p.h
- Fix code formatting in private header

Log: This ensures proper license compliance and consistent code style.