### PR TITLE
refactor: move spinner start logic to TitleBarHelper

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -254,6 +254,7 @@ void TitleBarHelper::handleSearchPressed(QWidget *sender, const QString &text)
     }
 
     fmInfo() << "search :" << text;
+    curTitleBar->startSpinner();
     TitleBarEventCaller::sendSearch(sender, text);
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -163,7 +163,6 @@ void SearchEditWidget::onReturnPressed()
     }
 
     TitleBarHelper::handleSearchPressed(this, text);
-    startSpinner();
 }
 
 void SearchEditWidget::onTextEdited(const QString &text)


### PR DESCRIPTION
Move the search spinner start logic from SearchEditWidget to TitleBarHelper for better code organization and control flow. This change ensures the spinner activation is handled in the same place as other search-related operations.

Log: improve UI appearance
Bug: https://pms.uniontech.com/bug-view-291637.html