### PR TITLE
fix: dialog not center in wayland

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -220,6 +220,10 @@ bool BurnJobManager::deleteStagingDir(const QUrl &url)
 void BurnJobManager::showOpticalJobCompletionDialog(const QString &msg, const QString &icon)
 {
     DDialog d(qApp->activeWindow());
+    if (WindowUtils::isWayLand()) {
+        d.setWindowFlags(Qt::WindowStaysOnTopHint);
+        d.setParent(nullptr);
+    }
     d.setIcon(QIcon::fromTheme(icon));
     d.setTitle(msg);
     d.addButton(tr("OK", "button"), true, DDialog::ButtonRecommend);
@@ -233,6 +237,10 @@ void BurnJobManager::showOpticalJobCompletionDialog(const QString &msg, const QS
 void BurnJobManager::showOpticalJobFailureDialog(int type, const QString &err, const QStringList &details)
 {
     DDialog d(qApp->activeWindow());
+    if (WindowUtils::isWayLand()) {
+        d.setWindowFlags(Qt::WindowStaysOnTopHint);
+        d.setParent(nullptr);
+    }
     d.setIcon(QIcon::fromTheme("dialog-error"));
     QString failureType;
     switch (type) {
@@ -289,6 +297,10 @@ void BurnJobManager::showOpticalJobFailureDialog(int type, const QString &err, c
 void BurnJobManager::showOpticalDumpISOSuccessDialog(const QUrl &imageUrl)
 {
     DDialog d(qApp->activeWindow());
+    if (WindowUtils::isWayLand()) {
+        d.setWindowFlags(Qt::WindowStaysOnTopHint);
+        d.setParent(nullptr);
+    }
     d.setFixedSize(400, 242);
     d.setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
     d.setIcon(QIcon::fromTheme("media-optical").pixmap(32, 32));
@@ -334,6 +346,10 @@ void BurnJobManager::showOpticalDumpISOSuccessDialog(const QUrl &imageUrl)
 void BurnJobManager::showOpticalDumpISOFailedDialog()
 {
     DDialog d(qApp->activeWindow());
+    if (WindowUtils::isWayLand()) {
+        d.setWindowFlags(Qt::WindowStaysOnTopHint);
+        d.setParent(nullptr);
+    }
     d.setFixedSize(400, 242);
     d.setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
     d.setIcon(QIcon::fromTheme("media-optical").pixmap(32, 32));


### PR DESCRIPTION
kwin controls the position of windows, if a window owns a parent window,
then it cannot be moved by `move` function, might be a bug in kwin-
wayland, do some workaround.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-286669.html
