### PR TITLE
fix: enhance file copy logic for same device checks

### DIFF
--- a/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/core/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -643,7 +643,7 @@ bool FileOperateBaseWorker::checkAndCopyFile(const DFileInfoPointer fromInfo, co
         while (bigFileCopy && !isStopped()) {
             QThread::msleep(10);
         }
-        if (fromSize > bigFileSize) {
+        if (fromSize > bigFileSize && FileUtils::isSameDevice(fromInfo->uri(), targetUrl)) {
             bigFileCopy = true;
             auto result = doCopyLocalByRange(fromInfo, toInfo, skip);
             bigFileCopy = false;


### PR DESCRIPTION
- Updated the check in checkAndCopyFile to ensure that big file copy logic only triggers if the source and target are on the same device.
- Added a condition to verify device equality using FileUtils::isSameDevice before initiating the big file copy process.

This change improves the file copy operation by preventing unnecessary delays and ensuring that the big file copy logic is only applied when copying files across different devices, enhancing overall performance and reliability.

Log: enhance file copy logic for same device checks