### PR TITLE
refactor: Implement tab state management with unique IDs

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
@@ -96,9 +96,22 @@ void TitleBarEventCaller::sendCheckAddressInputStr(QWidget *sender, QString *str
     dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_InputAdddressStr_Check", id, str);
 }
 
-void TitleBarEventCaller::sendTabChanged(quint64 windowId, int tabIndex)
+void TitleBarEventCaller::sendTabChanged(QWidget *sender, const QString &uniqueId)
 {
-    dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Changed", windowId, tabIndex);
+    quint64 windowId = TitleBarHelper::windowId(sender);
+    dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Changed", windowId, uniqueId);
+}
+
+void TitleBarEventCaller::sendTabCreated(QWidget *sender, const QString &uniqueId)
+{
+    quint64 windowId = TitleBarHelper::windowId(sender);
+    dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Created", windowId, uniqueId);
+}
+
+void TitleBarEventCaller::sendTabRemoved(QWidget *sender, const QString &removedId, const QString &nextId)
+{
+    quint64 windowId = TitleBarHelper::windowId(sender);
+    dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Tab_Removed", windowId, removedId, nextId);
 }
 
 ViewMode TitleBarEventCaller::sendGetDefualtViewMode(const QString &scheme)

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
@@ -29,7 +29,9 @@ public:
     static void sendStopSearch(QWidget *sender);
     static void sendShowFilterView(QWidget *sender, bool visible);
     static void sendCheckAddressInputStr(QWidget *sender, QString *str);
-    static void sendTabChanged(quint64 windowId, int tabIndex);
+    static void sendTabChanged(QWidget *sender, const QString &uniqueId);
+    static void sendTabCreated(QWidget *sender, const QString &uniqueId);
+    static void sendTabRemoved(QWidget *sender, const QString &removedId, const QString &nextId);
     static DFMGLOBAL_NAMESPACE::ViewMode sendGetDefualtViewMode(const QString &scheme);
     static DFMGLOBAL_NAMESPACE::ItemRoles sendCurrentSortRole(QWidget *sender);
     static void sendSetSort(QWidget *sender, DFMGLOBAL_NAMESPACE::ItemRoles role);

--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.h
@@ -23,6 +23,9 @@ class TitleBar : public dpf::Plugin
     DPF_EVENT_REG_SIGNAL(signal_FilterView_Show)
     DPF_EVENT_REG_SIGNAL(signal_InputAdddressStr_Check)
     DPF_EVENT_REG_SIGNAL(signal_Share_SetPassword)
+    DPF_EVENT_REG_SIGNAL(signal_Tab_Created)
+    DPF_EVENT_REG_SIGNAL(signal_Tab_Removed)
+    DPF_EVENT_REG_SIGNAL(signal_Tab_Changed)
 
     // slot events
     DPF_EVENT_REG_SLOT(slot_Custom_Register)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -142,6 +142,11 @@ void OptionButtonBox::setViewMode(int mode)
     d->switchMode(static_cast<ViewMode>(mode));
 }
 
+ViewMode OptionButtonBox::viewMode() const
+{
+    return d->currentMode;
+}
+
 void OptionButtonBox::updateOptionButtonBox(int parentWidth)
 {
     // If the current url scheme has no button visibility state set, do not hide buttons

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.h
@@ -13,16 +13,6 @@
 
 namespace dfmplugin_titlebar {
 
-class ActionButton : public QToolButton
-{
-    Q_OBJECT
-
-public:
-    explicit ActionButton(QWidget *parent = nullptr);
-    void setAction(QAction *action);
-    QAction *action() const;
-};
-
 class ViewOptionsButton;
 class OptionButtonBoxPrivate;
 class OptionButtonBox : public QWidget
@@ -41,6 +31,7 @@ public:
     void setViewOptionsButton(ViewOptionsButton *button);
 
     void setViewMode(int mode);
+    DFMBASE_NAMESPACE::Global::ViewMode viewMode() const;
     void updateOptionButtonBox(int parentWidth);
 
 public slots:

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/tab_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/tab_p.h
@@ -48,6 +48,8 @@ public:
     bool checked = false;
     bool borderLeft = false;
     bool canDrag = false;
+
+    QString uniqueId;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -77,6 +77,17 @@ void SearchEditWidget::deactivateEdit()
         updateSearchEditWidget(parentWidget()->width());
 }
 
+bool SearchEditWidget::isAdvancedButtonChecked() const
+{
+    return advancedButton->isChecked();
+}
+
+void SearchEditWidget::setAdvancedButtonChecked(bool checked)
+{
+    advancedButton->setVisible(checked);
+    advancedButton->setChecked(checked);
+}
+
 void SearchEditWidget::setAdvancedButtonVisible(bool visible)
 {
     advancedButton->setVisible(visible);
@@ -105,6 +116,11 @@ void SearchEditWidget::setSearchMode(SearchMode mode)
 
     currentMode = mode;
     updateSearchWidgetLayout();
+}
+
+void SearchEditWidget::setText(const QString &text)
+{
+    searchEdit->setText(text);
 }
 
 void SearchEditWidget::onUrlChanged(const QUrl &url)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
@@ -48,11 +48,16 @@ public:
     void startSpinner();
     void stopSpinner();
 
+    bool isAdvancedButtonChecked() const;
+    void setAdvancedButtonChecked(bool checked);
     void setAdvancedButtonVisible(bool visible);
     bool completerViewVisible();
 
     void updateSearchEditWidget(int parentWidth);
     void setSearchMode(SearchMode mode);
+
+    QString text() const;
+    void setText(const QString &text);
 
 public Q_SLOTS:
     void onUrlChanged(const QUrl &url);
@@ -86,8 +91,6 @@ private:
 
     int showClearSearchHistory();
     void clearSearchHistory();
-
-    QString text() const;
 
     void setCompleter(QCompleter *c);
     void clearCompleterModel();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
@@ -269,6 +269,16 @@ void Tab::setShowCloseButton(bool show)
     }
 }
 
+void Tab::setUniqueId(const QString &id)
+{
+    d->uniqueId = id;
+}
+
+QString Tab::uniqueId() const
+{
+    return d->uniqueId;
+}
+
 void Tab::onFileRootUrlChanged(const QUrl &url)
 {
     setCurrentUrl(url);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tab.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tab.h
@@ -51,6 +51,9 @@ public:
     
     void setShowCloseButton(bool show);
 
+    void setUniqueId(const QString &id);
+    QString uniqueId() const;
+
 public slots:
     void onFileRootUrlChanged(const QUrl &url);
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
@@ -46,11 +46,11 @@ public Q_SLOTS:
     void activatePreviousTab();
 
 Q_SIGNALS:
-    void currentChanged(const int &index);
-    void tabCloseRequested(const int &index, const bool &remainState = false);
+    void currentChanged(int oldIndex, int newIndex);
+    void tabCloseRequested(int index, bool remainState = false);
     void requestNewWindow(const QUrl &url);
-    void newTabCreated();
-    void tabRemoved(int index);
+    void newTabCreated(const QString &uniqueId);
+    void tabRemoved(int oldIndex, int nextIndex);
     void tabMoved(int from, int to);
     void tabAddButtonClicked();
 
@@ -93,6 +93,8 @@ private:
     int historyWidth { 0 };
 
     bool isDragging { false };
+
+    int nextTabUniqueId { 0 };
 };
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -66,15 +66,18 @@ private:
     void showCrumbBar();
     bool eventFilter(QObject *watched, QEvent *event) override;
 
+    void saveTitleBarState(const QString &uniqueId);
+    void restoreTitleBarState(const QString &uniqueId);
+
 signals:
     void currentUrlChanged(const QUrl &url);
 
 private slots:
     void onAddressBarJump();
-    void onTabCreated();
-    void onTabRemoved(int index);
+    void onTabCreated(const QString &uniqueId);
+    void onTabRemoved(int oldIndex, int nextIndex);
     void onTabMoved(int from, int to);
-    void onTabCurrentChanged(int tabIndex);
+    void onTabCurrentChanged(int oldIndex, int newIndex);
     void onTabCloseRequested(int index, bool remainState);
     void onTabAddButtonClicked();
     void quitSearch();
@@ -97,6 +100,14 @@ private:
     int splitterStartValue { -1 };
     int splitterEndValue { -1 };
     bool isSplitterAnimating { false };
+
+    struct TitleBarState {
+        DFMBASE_NAMESPACE::Global::ViewMode viewMode { DFMBASE_NAMESPACE::Global::ViewMode::kIconMode };
+        bool advancedSearchChecked { false };
+        QString searchText { "" };
+    };
+
+    QMap<QString, TitleBarState> titleBarStateMap;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -46,6 +46,12 @@ void WorkspaceEventReceiver::initConnection()
     // signal event
     dpfSignalDispatcher->subscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged",
                                    WorkspaceHelper::instance(), &WorkspaceHelper::trashStateChanged);
+    dpfSignalDispatcher->subscribe("dfmplugin_titlebar", "signal_Tab_Created",
+                                   WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabCreated);
+    dpfSignalDispatcher->subscribe("dfmplugin_titlebar", "signal_Tab_Removed",
+                                   WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabRemoved);
+    dpfSignalDispatcher->subscribe("dfmplugin_titlebar", "signal_Tab_Changed",
+                                   WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleTabChanged);
 
     // slot event
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_RegisterFileView",
@@ -362,7 +368,7 @@ QList<QUrl> WorkspaceEventReceiver::handleGetSelectedUrls(const quint64 windowID
 {
     WorkspaceWidget *workspaceWidget = WorkspaceHelper::instance()->findWorkspaceByWindowId(windowID);
     if (workspaceWidget) {
-        auto view = workspaceWidget->currentViewPtr();
+        auto view = workspaceWidget->currentView();
         if (view)
             return view->selectedUrlList();
         else
@@ -406,4 +412,25 @@ void WorkspaceEventReceiver::handleAboutToChangeViewWidth(const quint64 windowID
 bool WorkspaceEventReceiver::handleCheckMountedDevPath(const QUrl &url)
 {
     return FileDataManager::instance()->isMountedDevPath(url);
+}
+
+void WorkspaceEventReceiver::handleTabCreated(const quint64 windowId, const QString &uniqueId)
+{
+    auto workspace = WorkspaceHelper::instance()->findWorkspaceByWindowId(windowId);
+    if (workspace)
+        workspace->createNewPage(uniqueId);
+}
+
+void WorkspaceEventReceiver::handleTabRemoved(const quint64 windowId, const QString &removedId, const QString &nextId)
+{
+    auto workspace = WorkspaceHelper::instance()->findWorkspaceByWindowId(windowId);
+    if (workspace)
+        workspace->removePage(removedId, nextId);
+}
+
+void WorkspaceEventReceiver::handleTabChanged(const quint64 windowId, const QString &uniqueId)
+{
+    auto workspace = WorkspaceHelper::instance()->findWorkspaceByWindowId(windowId);
+    if (workspace)
+        workspace->setCurrentPage(uniqueId);
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -79,6 +79,10 @@ public slots:
 
     bool handleCheckMountedDevPath(const QUrl &url);
 
+    void handleTabCreated(const quint64 windowId, const QString &uniqueId);
+    void handleTabRemoved(const quint64 windowId, const QString &removedId, const QString &nextId);
+    void handleTabChanged(const quint64 windowId, const QString &uniqueId);
+
 private:
     explicit WorkspaceEventReceiver(QObject *parent = nullptr);
 };

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "workspacepage.h"
+#include "fileview.h"
+#include "enterdiranimationwidget.h"
+#include "events/workspaceeventcaller.h"
+#include "utils/workspacehelper.h"
+#include "utils/customtopwidgetinterface.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/interfaces/abstractbaseview.h>
+#include <dfm-base/dfm_event_defines.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QVBoxLayout>
+#include <QStackedLayout>
+
+DPWORKSPACE_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace GlobalDConfDefines::ConfigPath;
+using namespace GlobalDConfDefines::AnimationConfig;
+
+WorkspacePage::WorkspacePage(QWidget *parent)
+    : QWidget(parent)
+{
+    initUI();
+}
+
+void WorkspacePage::setUrl(const QUrl &url)
+{
+    auto curView = currentViewPtr();
+    if (curView) {
+        if (UniversalUtils::urlEquals(url, curView->rootUrl())
+            && !dpfHookSequence->run("dfmplugin_workspace", "hook_Allow_Repeat_Url", url, curView->rootUrl()))
+            return;
+
+        bool animEnable = DConfigManager::instance()->value(kAnimationDConfName, kAnimationEnterEnable, true).toBool();
+        if (animEnable) 
+            playDisappearAnimation(curView);
+
+        FileView *view = qobject_cast<FileView *>(curView->widget());
+        if (view)
+            view->stopWork();
+    }
+
+    auto lastUrl = currentPageUrl;
+    currentPageUrl = url;
+
+    // NOTE: In the function `initCustomTopWidgets` the `cd` event may be
+    // called causing this function to reentrant!!!
+    if (currentPageUrl != url)
+        return;
+
+    QString scheme { url.scheme() };
+
+    // do not play appear animation when create first view.
+    canPlayAppearAnimation = !views.isEmpty();
+
+    if (!views.contains(scheme)) {
+        QString error;
+        ViewPtr fileView = ViewFactory::create<AbstractBaseView>(url, &error);
+        if (!fileView) {
+            fmWarning() << "Cannot create view for " << url << "Reason: " << error;
+
+            // reset to last view and notify other plugins return to last dir.
+            currentPageUrl = lastUrl;
+            setCurrentView(currentPageUrl);
+            auto windowID = WorkspaceHelper::instance()->windowId(this);
+            dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, windowID, lastUrl);
+            return;
+        }
+
+        views.insert(scheme, fileView);
+        viewStackLayout->addWidget(fileView->widget());
+    }
+
+    setCurrentView(url);
+}
+
+QUrl WorkspacePage::currentUrl() const
+{
+    return currentPageUrl;
+}
+
+WorkspacePage::ViewPtr WorkspacePage::currentViewPtr()
+{
+    if (currentViewScheme.isEmpty()) {
+        qDebug() << "Can not find current view, currentViewScheme is empty";
+        return nullptr;
+    }
+
+    return views[currentViewScheme];
+}
+
+void WorkspacePage::viewStateChanged()
+{
+    if (!canPlayAppearAnimation)
+        return;
+
+    if (!enterAnim)
+        return;
+
+    if (!appearAnimDelayTimer) {
+        appearAnimDelayTimer = new QTimer(this);
+        appearAnimDelayTimer->setInterval(100);
+        appearAnimDelayTimer->setSingleShot(true);
+        connect(appearAnimDelayTimer, &QTimer::timeout, this, &WorkspacePage::onAnimDelayTimeout);
+    }
+
+    auto view = views[currentViewScheme];
+    if (!view)
+        return;
+
+    auto contentWidget = view->contentWidget();
+    if (!contentWidget)
+        contentWidget = view->widget();
+
+    if (!contentWidget) {
+        enterAnim->stopAndHide();
+        return;
+    }
+
+    auto globalPos = contentWidget->mapToGlobal(QPoint(0, 0));
+    auto localPos = mapFromGlobal(globalPos);
+    enterAnim->move(localPos);
+    enterAnim->resetWidgetSize(contentWidget->size());
+
+    appearAnimDelayTimer->start();
+}
+
+void WorkspacePage::setCustomTopWidgetVisible(const QString &scheme, bool visible)
+{
+    if (topWidgets.contains(scheme)) {
+        topWidgets[scheme]->setVisible(visible);
+    } else {
+        auto interface = WorkspaceHelper::instance()->createTopWidgetByScheme(scheme);
+        if (interface) {
+            TopWidgetPtr topWidgetPtr = QSharedPointer<QWidget>(interface->create(this));
+            if (topWidgetPtr) {
+                widgetLayout->insertWidget(0, topWidgetPtr.get());
+                topWidgets.insert(scheme, topWidgetPtr);
+                topWidgetPtr->setVisible(visible);
+            }
+        }
+    }
+}
+
+bool WorkspacePage::getCustomTopWidgetVisible(const QString &scheme)
+{
+    if (topWidgets.contains(scheme)) {
+        return topWidgets[scheme]->isVisible();
+    }
+    return false;
+}
+
+void WorkspacePage::onAnimDelayTimeout()
+{
+    if (!enterAnim)
+        return;
+
+    auto view = views[currentViewScheme];
+    if (!view || view->viewState() != AbstractBaseView::ViewState::kViewIdle) {
+        appearAnimDelayTimer->start();
+        return;
+    }
+
+    auto contentWidget = view->contentWidget();
+    if (!contentWidget)
+        contentWidget = view->widget();
+
+    if (!contentWidget) {
+        enterAnim->stopAndHide();
+        return;
+    }
+
+    QPixmap curDirPix = contentWidget->grab();
+    if (curDirPix.isNull()) {
+        enterAnim->stopAndHide();
+        return;
+    }
+
+    auto globalPos = contentWidget->mapToGlobal(QPoint(0, 0));
+    auto localPos = mapFromGlobal(globalPos);
+
+    enterAnim->resize(contentWidget->size());
+    enterAnim->move(localPos);
+
+    enterAnim->setAppearPixmap(curDirPix);
+    enterAnim->playAppear();
+}
+
+void WorkspacePage::initUI()
+{
+    viewStackLayout = new QStackedLayout;
+    viewStackLayout->setSpacing(0);
+    viewStackLayout->setContentsMargins(0, 0, 0, 0);
+
+    widgetLayout = new QVBoxLayout;
+    widgetLayout->addLayout(viewStackLayout, 1);
+    widgetLayout->setSpacing(0);
+    widgetLayout->setContentsMargins(0, 0, 0, 0);
+
+    setLayout(widgetLayout);
+}
+
+void WorkspacePage::initCustomTopWidgets(const QUrl &url)
+{
+    QString scheme { url.scheme() };
+
+    for (auto widget : topWidgets.values()) {
+        if (topWidgets.value(scheme) != widget)
+            widget->hide();
+    }
+
+    auto interface = WorkspaceHelper::instance()->createTopWidgetByUrl(url);
+    if (interface == nullptr)
+        return;
+
+    if (!interface->parent())
+        interface->setParent(this);
+
+    if (topWidgets.contains(scheme)) {
+        bool showUrl { interface->isShowFromUrl(topWidgets[scheme].data(), url) };
+        fmDebug() << interface->isKeepShow() << showUrl;
+        topWidgets[scheme]->setVisible(interface && (showUrl || interface->isKeepShow()));
+        fmDebug() << topWidgets[scheme]->contentsMargins();
+    } else {
+        TopWidgetPtr topWidgetPtr = QSharedPointer<QWidget>(interface->create());
+        if (topWidgetPtr) {
+            widgetLayout->insertWidget(0, topWidgetPtr.get());
+            topWidgets.insert(scheme, topWidgetPtr);
+            topWidgetPtr->setVisible(interface->isShowFromUrl(topWidgets[scheme].data(), url) || interface->isKeepShow());
+        }
+    }
+}
+
+void WorkspacePage::setCurrentView(const QUrl &url)
+{
+    currentViewScheme = url.scheme();
+    auto view = views[currentViewScheme];
+    if (!view)
+        return;
+
+    viewStackLayout->setCurrentWidget(view->widget());
+
+    if (canPlayAppearAnimation && enterAnim)
+        enterAnim->raise();
+
+    initCustomTopWidgets(url);
+
+    view->setRootUrl(url);
+
+    if (view->viewState() != AbstractBaseView::ViewState::kViewBusy)
+        viewStateChanged();
+}
+
+void WorkspacePage::playDisappearAnimation(ViewPtr view)
+{
+    if (!view)
+        return;
+
+    auto contentWidget = view->contentWidget();
+    if (!contentWidget)
+        contentWidget = view->widget();
+
+    if (contentWidget) {
+        if (!enterAnim)
+            enterAnim = new EnterDirAnimationWidget(this);
+
+        auto globalPos = contentWidget->mapToGlobal(QPoint(0, 0));
+        auto localPos = mapFromGlobal(globalPos);
+        enterAnim->move(localPos);
+        enterAnim->resetWidgetSize(contentWidget->size());
+
+        QPixmap preDirPix = contentWidget->grab();
+        enterAnim->setDisappearPixmap(preDirPix);
+        enterAnim->show();
+        enterAnim->raise();
+
+        enterAnim->playDisappear();
+    }
+}

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef WORKSPACEPAGE_H
+#define WORKSPACEPAGE_H
+
+#include "dfmplugin_workspace_global.h"
+
+#include <dfm-base/interfaces/abstractframe.h>
+#include <dfm-base/dfm_global_defines.h>
+
+#include <QWidget>
+
+namespace DFMBASE_NAMESPACE {
+class AbstractBaseView;
+}   // namespace dfmbase
+
+QT_BEGIN_NAMESPACE
+class QHBoxLayout;
+class QVBoxLayout;
+class QStackedLayout;
+QT_END_NAMESPACE
+
+namespace dfmplugin_workspace {
+
+class FileView;
+class EnterDirAnimationWidget;
+class WorkspacePage : public QWidget
+{
+    Q_OBJECT
+
+    using ViewPtr = DFMBASE_NAMESPACE::AbstractBaseView *;
+    using TopWidgetPtr = QSharedPointer<QWidget>;
+
+public:
+    explicit WorkspacePage(QWidget *parent = nullptr);
+
+    void setUrl(const QUrl &url);
+    QUrl currentUrl() const;
+    ViewPtr currentViewPtr();
+    void viewStateChanged();
+
+    void setCustomTopWidgetVisible(const QString &scheme, bool visible);
+    bool getCustomTopWidgetVisible(const QString &scheme);
+
+public Q_SLOTS:
+    void onAnimDelayTimeout();
+
+private:
+    void initUI();
+    void initCustomTopWidgets(const QUrl &url);
+    void setCurrentView(const QUrl &url);
+    void playDisappearAnimation(ViewPtr view);
+
+    QVBoxLayout *widgetLayout { nullptr };
+    QStackedLayout *viewStackLayout { nullptr };
+
+    EnterDirAnimationWidget *enterAnim { nullptr };
+    QTimer *appearAnimDelayTimer { nullptr };
+    bool canPlayAppearAnimation { false };
+
+    QUrl currentPageUrl {};
+    QString currentViewScheme {};
+
+    QMap<QString, ViewPtr> views {};
+    QMap<QString, TopWidgetPtr> topWidgets {};
+};
+
+} // namespace dfmplugin_workspace
+
+#endif // WORKSPACEPAGE_H

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacewidget.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacewidget.h
@@ -33,30 +33,28 @@ QT_END_NAMESPACE
 
 namespace dfmplugin_workspace {
 
-class TabBar;
-class FileView;
-class EnterDirAnimationWidget;
+class WorkspacePage;
 class WorkspaceWidget : public DFMBASE_NAMESPACE::AbstractFrame
 {
     Q_OBJECT
-    using ViewPtr = DFMBASE_NAMESPACE::AbstractBaseView *;
-    using TopWidgetPtr = QSharedPointer<QWidget>;
-
 public:
     explicit WorkspaceWidget(QFrame *parent = nullptr);
 
-    ViewPtr currentViewPtr() const;
     DFMBASE_NAMESPACE::Global::ViewMode currentViewMode() const;
     void setCurrentUrl(const QUrl &url) override;
     QUrl currentUrl() const override;
 
-    DFMBASE_NAMESPACE::AbstractBaseView *currentView();
+    DFMBASE_NAMESPACE::AbstractBaseView *currentView() const;
 
     void setCustomTopWidgetVisible(const QString &scheme, bool visible);
     bool getCustomTopWidgetVisible(const QString &scheme);
 
     QRectF viewVisibleGeometry();
     QRectF itemRect(const QUrl &url, const DFMGLOBAL_NAMESPACE::ItemRoles role);
+
+    void createNewPage(const QString &uniqueId);
+    void removePage(const QString &removedId, const QString &nextId);
+    void setCurrentPage(const QString &uniqueId);
 
 public slots:
     void onCreateNewWindow();
@@ -68,25 +66,15 @@ protected:
     void showEvent(QShowEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
 
-public slots:
-    void initUiForSizeMode();
-    void onAnimDelayTimeout();
-
 private:
     void initializeUi();
     void initViewLayout();
-    void initCustomTopWidgets(const QUrl &url);
-    void setCurrentView(const QUrl &url);
 
-    QUrl workspaceUrl;
-    QVBoxLayout *widgetLayout { nullptr };
+    QHBoxLayout *widgetLayout { nullptr };
     QStackedLayout *viewStackLayout { nullptr };
-    QMap<QString, ViewPtr> views;
-    QMap<QString, TopWidgetPtr> topWidgets;
-    EnterDirAnimationWidget *enterAnim { nullptr };
-    QTimer *appearAnimDelayTimer { nullptr };
 
-    bool canPlayAppearAnimation { false };
+    QMap<QString, WorkspacePage *> pages;
+    QString currentPageId;
 };
 
 }


### PR DESCRIPTION
This commit refactors the tab management system to use unique IDs instead of indices, and adds state persistence for tabs. Key changes include:

- Add unique ID management for tabs with getter/setter methods
- Refactor TabBar signals to use unique IDs and handle tab state changes
- Add TitleBarState struct to store view mode, search state and text per tab
- Implement state save/restore when switching between tabs
- Refactor WorkspaceWidget to use page-based management with unique IDs
- Update event system to handle tab creation, removal and changes with unique IDs

The changes improve tab state management by:
1. Making tab identification more robust using unique IDs
2. Preserving view mode, search state and text when switching tabs
3. Better handling of tab lifecycle events through the workspace
4. Cleaner separation of concerns between tab bar and workspace components

Log: refactor tab manage
Task: https://pms.uniontech.com/story-view-37823.html