### PR TITLE
Fix: Unified hover styles for buttons in the sidebar and title bar.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/custombutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/custombutton.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "custombutton.h"
+
+#include <DGuiApplicationHelper>
+#include <DStylePainter>
+#include <DStyle>
+#include <DStyleOption>
+
+#include <QPaintEvent>
+#include <QPainter>
+#include <QStyleOptionToolButton>
+#include <QStylePainter>
+#include <QPainterPath>
+
+DWIDGET_USE_NAMESPACE
+
+CustomDIconButton::CustomDIconButton(QWidget *parent)
+    : DIconButton(parent)
+{
+    setFlat(true);
+}
+
+CustomDIconButton::CustomDIconButton(DStyle::StandardPixmap iconType, QWidget *parent)
+    : DIconButton(iconType, parent)
+{
+    setFlat(true);
+}
+
+void CustomDIconButton::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event)
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+    
+    DStyleOptionButton opt;
+    initStyleOption(&opt);
+
+    if (isEnabled() && underMouse() && !isDown() && !isChecked()) {
+        bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
+                                      : QColor(0, 0, 0, 26);
+        
+        DStyleHelper dstyle(style());
+        const int radius = dstyle.pixelMetric(DStyle::PM_FrameRadius);
+        
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(hoverColor);
+        painter.drawRoundedRect(rect(), radius, radius);
+    }
+
+    DStyleHelper dstyle(style());
+    dstyle.drawControl(DStyle::CE_IconButton, &opt, &painter, this);
+}
+
+CustomDToolButton::CustomDToolButton(QWidget *parent)
+    : DToolButton(parent)
+{
+}
+
+void CustomDToolButton::initStyleOption(QStyleOptionToolButton *option) const
+{
+    DToolButton::initStyleOption(option);
+    if (underMouse()) {
+        bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
+                                        : QColor(0, 0, 0, 26);
+        option->palette.setColor(QPalette::Button, hoverColor);
+    }
+}
+
+void CustomDToolButton::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event)
+    QStylePainter p(this);
+    QStyleOptionToolButton opt;
+    initStyleOption(&opt);
+    p.drawComplexControl(QStyle::CC_ToolButton, opt);
+}

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/custombutton.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/custombutton.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef CUSTOMBUTTON_H
+#define CUSTOMBUTTON_H
+
+#include <DIconButton>
+#include <DToolButton>
+#include <DStyle>
+
+class CustomDIconButton : public DTK_NAMESPACE::Widget::DIconButton
+{
+    Q_OBJECT
+public:
+    explicit CustomDIconButton(QWidget *parent = nullptr);
+    explicit CustomDIconButton(DTK_NAMESPACE::Widget::DStyle::StandardPixmap iconType, QWidget *parent = nullptr);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+};
+
+class CustomDToolButton : public DTK_NAMESPACE::Widget::DToolButton
+{
+    Q_OBJECT
+public:
+    explicit CustomDToolButton(QWidget *parent = nullptr);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void initStyleOption(QStyleOptionToolButton *option) const override;
+};
+
+#endif   // CUSTOMBUTTON_H

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/navwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/navwidget.cpp
@@ -5,6 +5,7 @@
 #include "views/private/navwidget_p.h"
 #include "views/navwidget.h"
 #include "events/titlebareventcaller.h"
+#include "views/custombutton.h"
 
 #include <dfm-base/base/device/deviceproxymanager.h>
 
@@ -157,12 +158,12 @@ void NavWidget::onNewWindowOpended()
 
 void NavWidget::initializeUi()
 {
-    d->navBackButton = new DIconButton(DStyle::SP_ArrowLeave, this);
+    d->navBackButton = new CustomDIconButton(DStyle::SP_ArrowLeave, this);
     d->navBackButton->setFlat(true);
     d->navBackButton->setDisabled(true);
     d->navBackButton->setToolTip(tr("back"));
 
-    d->navForwardButton = new DIconButton(DStyle::SP_ArrowEnter, this);
+    d->navForwardButton = new CustomDIconButton(DStyle::SP_ArrowEnter, this);
     d->navForwardButton->setFlat(true);
     d->navForwardButton->setDisabled(true);
     d->navForwardButton->setToolTip(tr("forward"));

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -8,6 +8,7 @@
 #include "utils/optionbuttonmanager.h"
 #include "views/sortbybutton.h"
 #include "views/viewoptionsbutton.h"
+#include "views/custombutton.h"
 
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
@@ -219,7 +220,7 @@ void OptionButtonBox::initializeUi()
     setContentsMargins(5, 0, 5, 0);
     d->buttonGroup = new QButtonGroup(this);
 
-    d->iconViewButton = new DToolButton;
+    d->iconViewButton = new CustomDToolButton;
     d->iconViewButton->setCheckable(true);
     d->iconViewButton->setChecked(true);
     d->iconViewButton->setIcon(QIcon::fromTheme("dfm_viewlist_icons"));
@@ -227,7 +228,7 @@ void OptionButtonBox::initializeUi()
     d->iconViewButton->setToolTip(tr("Icon view"));
     d->iconViewButton->setIconSize(buttonIconSize);
 
-    d->listViewButton = new DToolButton;
+    d->listViewButton = new CustomDToolButton;
     d->listViewButton->setCheckable(true);
     d->listViewButton->setIcon(QIcon::fromTheme("dfm_viewlist_details"));
     d->listViewButton->setFixedSize(buttonSize);
@@ -237,7 +238,7 @@ void OptionButtonBox::initializeUi()
     d->buttonGroup->addButton(d->listViewButton);
 
     if (DConfigManager::instance()->value(kViewDConfName, kTreeViewEnable, true).toBool()) {
-        d->treeViewButton = new DToolButton;
+        d->treeViewButton = new CustomDToolButton;
         d->treeViewButton->setCheckable(true);
         d->treeViewButton->setIcon(QIcon::fromTheme("dfm_viewlist_tree"));
         d->treeViewButton->setFixedSize(buttonSize);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -8,6 +8,7 @@
 #include "events/titlebareventcaller.h"
 #include "views/completerview.h"
 #include "views/completerviewdelegate.h"
+#include "views/custombutton.h"
 #include "models/completerviewmodel.h"
 
 #include <dfm-base/utils/fileutils.h>
@@ -21,10 +22,13 @@
 #include <DSearchEdit>
 #include <DSpinner>
 #include <DDialog>
+#include <DGuiApplicationHelper>
+#include <DPalette>
 
 #include <QHBoxLayout>
 #include <QResizeEvent>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 DPTITLEBAR_USE_NAMESPACE
@@ -341,7 +345,7 @@ void SearchEditWidget::initUI()
     layout->setSpacing(0);
 
     // search button
-    searchButton = new DIconButton(this);
+    searchButton = new CustomDIconButton(this);
     searchButton->setIcon(QIcon::fromTheme("dfm_search_button"));
     searchButton->setFixedSize(kToolButtonSize, kToolButtonSize);
     searchButton->setIconSize(QSize(kToolButtonIconSize, kToolButtonIconSize));
@@ -357,7 +361,7 @@ void SearchEditWidget::initUI()
     searchEdit->lineEdit()->setFocusPolicy(Qt::ClickFocus);
 
     // advanced search button
-    advancedButton = new DToolButton(this);
+    advancedButton = new CustomDToolButton(this);
     advancedButton->setIcon(QIcon::fromTheme("dfm_view_filter"));
     advancedButton->setFixedSize(kToolButtonSize, kToolButtonSize);
     advancedButton->setFocusPolicy(Qt::NoFocus);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
@@ -165,6 +165,14 @@ void SortByButton::paintEvent(QPaintEvent *event)
         QStyleOptionToolButton option;
         QToolButton::initStyleOption(&option);
         option.state |= QStyle::State_MouseOver;
+
+        bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+
+        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
+                                        : QColor(0, 0, 0, 26);
+
+        option.palette.setBrush(QPalette::Button, hoverColor);
+
         option.rect.adjust(1, 1, -1, -1);
         painter.drawComplexControl(QStyle::CC_ToolButton, option);
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
@@ -188,9 +188,9 @@ void Tab::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidg
     // draw backgound
     if (d->hovered) {
         if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
-            color = QColor(235, 235, 235, 204);
+            color = QColor(0, 0, 0, 26);
         else
-            color = QColor(30, 30, 30, 204);
+            color = QColor(255, 255, 255, 15);
         painter->fillRect(boundingRect(), color);
 
     } else {

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -4,6 +4,7 @@
 
 #include "tabbar.h"
 #include "tab.h"
+#include "custombutton.h"
 #include "titlebarwidget.h"
 #include "dfmplugin_titlebar_global.h"
 #include "utils/titlebarhelper.h"
@@ -453,7 +454,7 @@ void TabBar::initializeUI()
     setScene(scene);
     scene->installEventFilter(this);
 
-    tabAddButton = new DIconButton(DStyle::SP_IncreaseElement, this);
+    tabAddButton = new CustomDIconButton(DStyle::SP_IncreaseElement, this);
     tabAddButton->setObjectName("NewTabButton");
     tabAddButton->setFixedSize(kToolButtonSize, kToolButtonSize);
     tabAddButton->setFlat(true);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
@@ -9,10 +9,13 @@
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
+#include <DGuiApplicationHelper>
+
 #include <QStylePainter>
 #include <QStyleOptionToolButton>
 #include <QTimer>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_titlebar;
@@ -81,10 +84,20 @@ void ViewOptionsButton::paintEvent(QPaintEvent *event)
 
     QStyleOptionToolButton option;
     QToolButton::initStyleOption(&option);
-    if (d->hoverFlag || d->popupVisible())
+
+    if (d->hoverFlag || d->popupVisible()) {
         option.state |= QStyle::State_MouseOver;
-    else
+
+        bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+
+        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
+                                        : QColor(0, 0, 0, 26);
+
+        option.palette.setBrush(QPalette::Button, hoverColor);
+    } else {
         option.state &= ~QStyle::State_MouseOver;
+    }
+
     painter.drawComplexControl(QStyle::CC_ToolButton, option);
 }
 


### PR DESCRIPTION
Rewrote the hover styles for DIconButton and DToolButton to ensure consistent hover styles in the title bar.

Log: Unified hover styles for buttons in the sidebar and title bar.

Bug: https://pms.uniontech.com/bug-view-296765.html