### PR TITLE
fix: update file statistics job to handle symlinks correctly, delete wrong files

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -260,6 +260,7 @@ bool AbstractWorker::statisticsFilesSize()
         connect(statisticsFilesSizeJob.data(), &DFMBASE_NAMESPACE::FileStatisticsJob::finished,
                 this, &AbstractWorker::onStatisticsFilesSizeFinish, Qt::DirectConnection);
         connect(statisticsFilesSizeJob.data(), &DFMBASE_NAMESPACE::FileStatisticsJob::sizeChanged, this, &AbstractWorker::onStatisticsFilesSizeUpdate, Qt::DirectConnection);
+        statisticsFilesSizeJob->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink);
         statisticsFilesSizeJob->start(sourceUrls);
     }
     return true;


### PR DESCRIPTION
- Added a hint to the FileStatisticsJob to avoid following symbolic links during size calculations.
- This change ensures that the size statistics are accurate and do not include the sizes of files pointed to by symlinks.

This enhancement improves the reliability of file size statistics when deleting files, preventing unintended size calculations from symlinked files.

Log: update file statistics job to handle symlinks correctly, delete wrong files
Bug: https://pms.uniontech.com/bug-view-300669.html