### PR TITLE
Fix: Adjust the close button and the calculation method of text display.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -282,7 +282,7 @@ void TitleBarHelper::showConnectToServerDialog(quint64 windowId)
     ConnectToServerDialog *dialog = new ConnectToServerDialog(window->currentUrl(), window);
     dialog->show();
     dialog->setAttribute(Qt::WA_DeleteOnClose);
-    QObject::connect(dialog, &ConnectToServerDialog::finished, dialog, &ConnectToServerDialog::onButtonClicked);
+    QObject::connect(dialog, &DDialog::buttonClicked, dialog, &ConnectToServerDialog::onButtonClicked);
     window->setProperty("ConnectToServerDialogShown", true);
     QObject::connect(dialog, &ConnectToServerDialog::closed, [window] {
         window->setProperty("ConnectToServerDialogShown", false);
@@ -299,7 +299,7 @@ void TitleBarHelper::showUserSharePasswordSettingDialog(quint64 windowId)
     UserSharePasswordSettingDialog *dialog = new UserSharePasswordSettingDialog(window);
     dialog->show();
     dialog->setAttribute(Qt::WA_DeleteOnClose);
-    QObject::connect(dialog, &UserSharePasswordSettingDialog::finished, dialog, &UserSharePasswordSettingDialog::onButtonClicked);
+    QObject::connect(dialog, &UserSharePasswordSettingDialog::buttonClicked, dialog, &UserSharePasswordSettingDialog::onButtonClicked);
     QObject::connect(dialog, &UserSharePasswordSettingDialog::inputPassword, [=](const QString &password) {
         dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Share_SetPassword", password);
     });


### PR DESCRIPTION
Because the distance between the text and the button is not fixed, it will overlap when the adjustment is adjusted to the critical state. Adjust the calculation method to ensure that text and buttons do not overlap.

log: Adjust the close button and the calculation method of text display
       Guarantee text in the middle

Bug: https://pms.uniontech.com/bug-view-298489.html

 fix: Cannot reconnect to server after unmounting FTP without closing file manager
    
    When using finished signal to trigger close(), the close event was being filtered
    by QDialogPrivate::close()'s event filter. Changed to use buttonClicked signal
    instead which is emitted before the filter is installed.
    
 log: This fixes the issue where closeEvent was not being triggered properly when
    closing the dialog.
    
 bug: https://pms.uniontech.com/bug-view-301837.html
