### PR TITLE
fix: clear desktop selection when collection view gets focus

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
@@ -474,6 +474,10 @@ void CanvasView::focusOutEvent(QFocusEvent *event)
 {
     d->dodgeOper->stopDelayDodge();
     d->dodgeOper->updatePrepareDodgeValue(event);
+
+    if (selectionModel()) 
+        selectionModel()->clearSelection();
+    
     QAbstractItemView::focusOutEvent(event);
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -421,6 +421,14 @@ QPixmap CollectionViewPrivate::polymerizePixmap(QModelIndexList indexs) const
     return pixmap;
 }
 
+void CollectionView::focusOutEvent(QFocusEvent *event)
+{
+    if (selectionModel()) 
+        selectionModel()->clearSelection();
+
+    QAbstractItemView::focusOutEvent(event);
+}
+
 bool CollectionViewPrivate::checkClientMimeData(QDragEnterEvent *event) const
 {
     if (DFileDragClient::checkMimeData(event->mimeData())) {

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
@@ -96,6 +96,7 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     void focusInEvent(QFocusEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
 
     void scrollContentsBy(int dx, int dy) override;
 


### PR DESCRIPTION
- add selection clearing in CanvasView's focusOutEvent
- add selection clearing in CollectionView's focusOutEvent

log: When switching focus between desktop and collection view, clear previous selection to avoid showing multiple highlighted items across different views.

bug: https://pms.uniontech.com/bug-view-300259.htm