### PR TITLE
fix: [propertydialog] optimize media info parsing with background worker

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -733,7 +733,7 @@ void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType
     auto func = std::bind(DeviceManagerPrivate::askForPasswdWhenMountNetworkDevice, _1, _2, _3, address);
 
     auto wrappedCb = [=](bool ok, const OperationErrorInfo &err, const QString &msg) {
-        Q_EMIT mountNetworkDeviceResult(ok, err.code, msg);
+        Q_EMIT mountNetworkDeviceResult(ok, err.code, err.code == DeviceError::kNoError ? msg : err.message);
         if (cb) cb(ok, err, msg);
         QApplication::restoreOverrideCursor();
     };

--- a/src/plugins/common/dfmplugin-propertydialog/utils/mediainfofetchworker.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/mediainfofetchworker.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "mediainfofetchworker.h"
+
+#include <QProcess>
+#include <QStandardPaths>
+#include <QRegularExpression>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+
+MediaInfoFetchWorker::MediaInfoFetchWorker(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void MediaInfoFetchWorker::getDuration(const QString &filePath)
+{
+    if (!hasFFmpeg())
+        return;
+
+    QProcess ffmpeg;
+    ffmpeg.start("ffmpeg", {"-i", filePath});
+    bool finished = ffmpeg.waitForFinished(5000); // 5秒超时
+    if (!finished) {
+        Q_EMIT durationReady("");
+        return;
+    }
+
+    QByteArray output = ffmpeg.readAllStandardError();
+    QRegularExpression re("Duration:\\s+(\\d+:\\d+:\\d+)");
+    QRegularExpressionMatch match = re.match(output);
+
+    if (!match.hasMatch())
+        return;
+
+    QString duration = match.captured(1);
+    Q_EMIT durationReady(duration);
+}
+
+bool MediaInfoFetchWorker::hasFFmpeg()
+{
+    QString ffmpegPath = QStandardPaths::findExecutable("ffmpeg");
+    return !ffmpegPath.isEmpty();
+}

--- a/src/plugins/common/dfmplugin-propertydialog/utils/mediainfofetchworker.h
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/mediainfofetchworker.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MEDIAINFOFETCHWORKER_H
+#define MEDIAINFOFETCHWORKER_H
+#include "dfmplugin_propertydialog_global.h"
+
+#include <QObject>
+
+namespace dfmplugin_propertydialog {
+class MediaInfoFetchWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MediaInfoFetchWorker(QObject *parent = nullptr);
+
+public Q_SLOTS:
+    void getDuration(const QString &filePath);
+
+Q_SIGNALS:
+    void durationReady(const QString &duration);
+
+private:
+    bool hasFFmpeg();
+};
+} // namespace dfmplugin_propertydialog
+
+#endif   // MEDIAINFOFETCHWORKER_H

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
@@ -14,6 +14,7 @@
 #include <DCheckBox>
 
 namespace dfmplugin_propertydialog {
+class MediaInfoFetchWorker;
 class BasicWidget : public DTK_WIDGET_NAMESPACE::DArrowLineDrawer
 {
     Q_OBJECT
@@ -73,6 +74,9 @@ private:
     QFrame *frameMain { nullptr };
     QGridLayout *layoutMain { nullptr };
     QUrl currentUrl;
+
+    QThread *fetchThread { nullptr };
+    MediaInfoFetchWorker *infoFetchWorker { nullptr };
 };
 }
 #endif   // BASICWIDGET_H

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.cpp
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.cpp
@@ -14,6 +14,8 @@
 #include "datas/enterdirreportdata.h"
 #include "datas/desktopstartupreportdata.h"
 
+#include "config.h"
+
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/device/private/devicehelper.h>
 #include <dfm-base/base/application/application.h>
@@ -33,7 +35,6 @@ DFMBASE_USE_NAMESPACE
 ReportLogWorker::ReportLogWorker(QObject *parent)
     : QObject(parent)
 {
-
 }
 
 ReportLogWorker::~ReportLogWorker()
@@ -58,6 +59,8 @@ bool ReportLogWorker::init()
         new EnterDirReportData,
         new DesktopStartUpReportData
     };
+
+    commonData.insert("app_version", VERSION);
 
     std::for_each(datas.cbegin(), datas.cend(), [this](ReportDataInterface *dat) { registerLogData(dat->type(), dat); });
 


### PR DESCRIPTION
 - Move time-consuming media parsing to MediaInfoFetchWorker
 - Handle ffmpeg calls in background thread
 - Update UI asynchronously via Qt signal-slot
 - Add error handling for ffmpeg execution
 - Maintain existing metadata fallback mechanism

Log: optimize media info parsing with background worker
Bug: https://pms.uniontech.com/bug-view-300637.html