### PR TITLE
fix: [default-app] Setting the default open application is invalid

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -520,8 +520,15 @@ void OpenWithDialog::openFileByApp()
 
     const QString &app = checkedItem->property("app").toString();
 
-    if (setToDefaultCheckBox->isChecked())
+    if (setToDefaultCheckBox->isChecked()) {
+        if (!urlList.isEmpty()) {
+            dfmio::DFileInfo info(urlList.at(0));
+            QString gioContentType { info.attribute(dfmio::DFileInfo::AttributeID::kStandardContentType).toString() };
+            if (!gioContentType.isEmpty() && gioContentType != mimeType.name())
+                MimesAppsManager::instance()->setDefautlAppForTypeByGio(gioContentType, app);
+        }
         MimesAppsManager::instance()->setDefautlAppForTypeByGio(mimeType.name(), app);
+    }
     //Todo(yanghao): open file by app
 
     QList<QString> apps;


### PR DESCRIPTION
1. Some wps file Settings do not open the application by default
2. The MiMetypes obtained through the QMimedatabase and ‘gio info’ are inconsistent.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-302743.html