### PR TITLE
fix: improve icon cache refresh mechanism

### DIFF
--- a/examples/dfm-extension-example/dfm-extension-example.cpp
+++ b/examples/dfm-extension-example/dfm-extension-example.cpp
@@ -6,8 +6,12 @@
 
 #include "mymenuplugin.h"
 #include "myemblemiconplugin.h"
-#include "mywindowplugin.h"
-#include "myfileplugin.h"
+#ifdef DFMEXT_INTERFACE_Window
+#    include "mywindowplugin.h"
+#endif
+#ifdef DFMEXT_INTERFACE_File
+#    include "myfileplugin.h"
+#endif
 
 // 右键菜单的扩展
 static DFMEXT::DFMExtMenuPlugin *myMenu { nullptr };

--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -113,7 +113,7 @@ public:
         kFileIsHid = 6,   // 是否是隐藏文件
         kFileLocalDevice = 7,   // 文件是本地文件
         kFileCdRomDevice = 8,   // 文件是光驱
-        kFileThumbnail = 9,     // 文件缩略图
+        kFileThumbnail = 9,   // 文件缩略图
         kCustomerStartExtended = 50,   // 其他用户使用
         kFileNeedUpdate = 51,   // 文件信息需要在显示更新
         kFileNeedTransInfo = 52,   // 文件信息需要转换为desktopfileinfo
@@ -193,7 +193,7 @@ public:
         kCanTrash = 1,   // 可以移动到回收站
         kCanRename = 2,   // 可以重命名
         kCanRedirectionFileUrl = 3,   // 可以重定向
-        kCanMoveOrCopy = 4,   // 可以移动或者拷贝
+        kCanMoveOrCopy = 4,   // 可以拷贝(若需要可以移动使用,则使用kCanRename去判断)
         kCanDrop = 5,   // 可以Drop
         kCanDrag = 6,   // 可以drag
         kCanDragCompress = 7,   // 可以压缩
@@ -250,7 +250,7 @@ public:
         kStandardIsLocalDevice = 21,   // bool
         kStandardIsCdRomDevice = 22,   // bool
         kStandardFileType = 23,   // FileInfo::FileType
-        kOriginalUri = 24, // original uri
+        kOriginalUri = 24,   // original uri
 
         kEtagValue = 40,   // string
 

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -215,6 +215,11 @@ bool AsyncFileInfo::canAttributes(const CanableInfoType type) const
         if (ProtocolUtils::isGphotoFile(url))
             return false;
         return true;
+    case FileCanType::kCanMoveOrCopy:
+        // file can not read or dir can not execte，will can not copy
+        if (!d->asyncAttribute(FileInfo::FileInfoAttributeID::kAccessCanRead).toBool() || (d->asyncAttribute(FileInfo::FileInfoAttributeID::kStandardIsDir).toBool() && !d->asyncAttribute(FileInfo::FileInfoAttributeID::kAccessCanExecute).toBool()))
+            return false;
+        return FileInfo::canAttributes(type);
     default:
         return FileInfo::canAttributes(type);
     }
@@ -948,8 +953,12 @@ bool AsyncFileInfoPrivate::canRename() const
 
     bool canRename = false;
     canRename = SysInfoUtils::isRootUser();
-    if (!canRename)
+    if (!canRename) {
+        // dir can not write, will can not rename
+        if (this->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() && !this->attribute(DFileInfo::AttributeID::kAccessCanWrite).toBool())
+            return false;
         return this->attribute(DFileInfo::AttributeID::kAccessCanRename).toBool();
+    }
 
     return canRename;
 }

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -240,6 +240,11 @@ bool SyncFileInfo::canAttributes(const CanableInfoType type) const
         if (ProtocolUtils::isGphotoFile(url))
             return false;
         return true;
+    case FileCanType::kCanMoveOrCopy:
+        // file can not read or dir can not execte
+        if (!d->attribute(DFileInfo::AttributeID::kAccessCanRead).toBool() || (d->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() && !d->attribute(DFileInfo::AttributeID::kAccessCanExecute).toBool()))
+            return false;
+        return FileInfo::canAttributes(type);
     default:
         return FileInfo::canAttributes(type);
     }
@@ -973,8 +978,13 @@ bool SyncFileInfoPrivate::canRename() const
 
     bool canRename = false;
     canRename = SysInfoUtils::isRootUser();
-    if (!canRename)
+    if (!canRename) {
+        // dir can not write, can not rename
+        if (this->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() && !this->attribute(DFileInfo::AttributeID::kAccessCanWrite).toBool())
+            return false;
+
         return this->attribute(DFileInfo::AttributeID::kAccessCanRename).toBool();
+    }
 
     return canRename;
 }

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -275,9 +275,7 @@ bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)
 void FileUtils::refreshIconCache()
 {
     // https://bugreports.qt.io/browse/QTBUG-112257
-    QString currentTheme = QIcon::themeName();
-    QIcon::setThemeName(QString());
-    QIcon::setThemeName(currentTheme);
+    QIcon::setThemeSearchPaths(QIcon::themeSearchPaths());
 }
 
 bool FileUtils::isTrashDesktopFile(const QUrl &url)
@@ -454,7 +452,7 @@ QMap<QUrl, QUrl> FileUtils::fileBatchReplaceText(const QList<QUrl> &originUrls, 
 
         bool isDesktopApp = info->nameOf(NameInfoType::kMimeTypeName).contains(Global::Mime::kTypeAppDesktop);
 
-        ///###: symlink is also processed here.
+        /// ###: symlink is also processed here.
         const QString &suffix = info->nameOf(NameInfoType::kSuffix).isEmpty()
                 ? QString()
                 : QString(".") + info->nameOf(NameInfoType::kSuffix);
@@ -542,14 +540,14 @@ QMap<QUrl, QUrl> FileUtils::fileBatchAddText(const QList<QUrl> &originUrls, cons
 
 QMap<QUrl, QUrl> FileUtils::fileBatchCustomText(const QList<QUrl> &originUrls, const QPair<QString, QString> &pair)
 {
-    if (originUrls.isEmpty() || pair.first.isEmpty() || pair.second.isEmpty()) {   //###: here, jundge whether there are fileUrls in originUrls.
+    if (originUrls.isEmpty() || pair.first.isEmpty() || pair.second.isEmpty()) {   // ###: here, jundge whether there are fileUrls in originUrls.
         return QMap<QUrl, QUrl> {};
     }
 
     unsigned long long serialNumber { pair.second.toULongLong() };
     unsigned long long index { 0 };
 
-    if (serialNumber == ULONG_LONG_MAX) {   //##: Maybe, this value will be equal to the max value of the type of unsigned long long
+    if (serialNumber == ULONG_LONG_MAX) {   // ##: Maybe, this value will be equal to the max value of the type of unsigned long long
         index = serialNumber - originUrls.size();
     } else {
         index = serialNumber;
@@ -739,7 +737,7 @@ QString FileUtils::nonExistSymlinkFileName(const QUrl &fileUrl, const QUrl &pare
             if (parentDir.exists(linkBaseName)) {
                 ++number;
             } else {
-                //链接文件失效后exists会返回false，通过lstat再次判断链接文件本身是否存在
+                // 链接文件失效后exists会返回false，通过lstat再次判断链接文件本身是否存在
                 auto strLinkPath = parentDir.filePath(linkBaseName).toStdString();
                 struct stat st;
                 if ((lstat(strLinkPath.c_str(), &st) == 0) && S_ISLNK(st.st_mode))
@@ -1010,8 +1008,8 @@ void FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType type,
         return;
     }
 }
-//fix 多线程排序时，该处的全局变量在compareByString函数中可能导致软件崩溃
-//QCollator sortCollator;
+// fix 多线程排序时，该处的全局变量在compareByString函数中可能导致软件崩溃
+// QCollator sortCollator;
 class DCollator : public QCollator
 {
 public:
@@ -1235,7 +1233,7 @@ QString FileUtils::nonExistFileName(FileInfoPointer fromInfo, FileInfoPointer ta
     QString fileBaseName = fromInfo->nameOf(NameInfoType::kCompleteBaseName);
     QString suffix = fromInfo->nameOf(NameInfoType::kSuffix);
     QString fileName = fromInfo->nameOf(NameInfoType::kFileName);
-    //在7z分卷压缩后的名称特殊处理7z.003
+    // 在7z分卷压缩后的名称特殊处理7z.003
     const QString &reg = ".7z.[0-9]{3,10}$";
     if (fileName.contains(QRegularExpression(reg))) {
         const int &index = fileName.indexOf(QRegularExpression(reg));
@@ -1360,8 +1358,8 @@ QUrl DesktopAppUrl::homeDesktopFileUrl()
 }
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-///###: Do not modify it.
-///###: it's auxiliary.
+/// ###: Do not modify it.
+/// ###: it's auxiliary.
 float codecConfidenceForData(const QTextCodec *codec, const QByteArray &data, const QLocale::Country &country)
 {
     qreal hepCount = 0;

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1278,7 +1278,7 @@ int FileUtils::dirFfileCount(const QUrl &url)
 bool FileUtils::fileCanTrash(const QUrl &url)
 {
     // gio does not support root user to move ordinary user files to trash
-    auto info = InfoFactory::create<FileInfo>(url);
+    auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (SysInfoUtils::isRootUser()) {
         int ownerId = info.isNull() ? -1 : info->extendAttributes(FileInfo::FileExtendedInfoType::kOwnerId).toInt();
         if (ownerId != 0)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -225,8 +225,8 @@ SideBarModel *SideBarView::model() const
 
 void SideBarView::mousePressEvent(QMouseEvent *event)
 {
-    //频繁点击操作与网络或挂载设备的加载效率低两个因素的共同作用下 会导致侧边栏可能出现显示错误
-    //暂时抛去部分频繁点击来规避这个问题
+    // 频繁点击操作与网络或挂载设备的加载效率低两个因素的共同作用下 会导致侧边栏可能出现显示错误
+    // 暂时抛去部分频繁点击来规避这个问题
     if (!d->checkOpTime())
         return;
 
@@ -365,7 +365,7 @@ void SideBarView::dropEvent(QDropEvent *event)
 
     // wayland环境下QCursor::pos()在此场景中不能获取正确的光标当前位置，代替方案为直接使用QDropEvent::pos()
     // QDropEvent::pos() 实际上就是drop发生时光标在该widget坐标系中的position (mapFromGlobal(QCursor::pos()))
-    //但rc本来就是由event->pos()计算item得出的Rect，这样判断似乎就没有意义了（虽然原来的逻辑感觉也没什么意义）
+    // 但rc本来就是由event->pos()计算item得出的Rect，这样判断似乎就没有意义了（虽然原来的逻辑感觉也没什么意义）
     QPoint pt = event->position().toPoint();   // mapFromGlobal(QCursor::pos());
     QRect rc = visualRect(indexAt(event->position().toPoint()));
     if (!rc.contains(pt)) {
@@ -653,8 +653,8 @@ Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *
         if (!fileInfo->isAttributes(OptInfoType::kIsReadable)) {
             return Qt::IgnoreAction;
         }
-        //部分文件不能复制或剪切，需要在拖拽时忽略
-        if (!fileInfo->canAttributes(CanableInfoType::kCanMoveOrCopy)) {
+        // 部分文件不能复制或剪切，需要在拖拽时忽略
+        if (!fileInfo->canAttributes(CanableInfoType::kCanMoveOrCopy) && !fileInfo->canAttributes(CanableInfoType::kCanRename)) {
             return Qt::IgnoreAction;
         }
     }


### PR DESCRIPTION
* Replace theme name reset with theme search paths refresh
* Fix the issue where theme icons not updating properly after cache refresh

This fixes the icon cache refresh issue reported in QTBUG-112257 where theme icons were not properly following theme changes.

Log:

Bug: https://pms.uniontech.com/bug-view-298373.html