### PR TITLE
fix: Fixed the issue of not entering the username and password during…

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -1077,7 +1077,9 @@ MountPassInfo DeviceManagerPrivate::askForPasswdWhenMountNetworkDevice(const QSt
     DFMMOUNT::MountPassInfo info;
     QApplication::restoreOverrideCursor();
 
-    if (dlg.exec() == QDialog::Rejected) {
+    // 将对话框手动关闭，以及用户取消输入都作为取消操作
+    if(dlg.exec() != QDialog::Accepted)
+    {
         info.cancelled = true;
         QApplication::setOverrideCursor(Qt::WaitCursor);
         return info;

--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -1078,8 +1078,7 @@ MountPassInfo DeviceManagerPrivate::askForPasswdWhenMountNetworkDevice(const QSt
     QApplication::restoreOverrideCursor();
 
     // 将对话框手动关闭，以及用户取消输入都作为取消操作
-    if(dlg.exec() != QDialog::Accepted)
-    {
+    if(dlg.exec() != QDialog::Accepted) {
         info.cancelled = true;
         QApplication::setOverrideCursor(Qt::WaitCursor);
         return info;


### PR DESCRIPTION
… mount, and directly closing the authentication window, prompting for incorrect information.

Use the cancel operation of the user manually closing the window and clicking the dialog box as a cancel operation. Close the dialog box directly after cancel.

log: Fixed the issue of not entering the username and password during mount, and directly closing the authentication window, prompting for incorrect information.

Bug: https://pms.uniontech.com/bug-view-301791.html