### PR TITLE
fix: update path handling in isMptOfDevice method

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -147,10 +147,7 @@ bool DeviceProxyManager::isFileFromOptical(const QString &filePath)
 bool DeviceProxyManager::isMptOfDevice(const QString &filePath, QString &id)
 {
     d->initMounts();
-    QString path = filePath.endsWith("/") ? filePath : filePath + "/";
-    if (path == "/")
-        path = "/sysroot/";
-
+    const QString &path = filePath.endsWith("/") ? filePath : filePath + "/";
     QReadLocker lk(&d->lock);
     id = d->allMounts.key(path, "");
     return !id.isEmpty();

--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -147,7 +147,10 @@ bool DeviceProxyManager::isFileFromOptical(const QString &filePath)
 bool DeviceProxyManager::isMptOfDevice(const QString &filePath, QString &id)
 {
     d->initMounts();
-    const QString &path = filePath.endsWith("/") ? filePath : filePath + "/";
+    QString path = filePath.endsWith("/") ? filePath : filePath + "/";
+    if (path == "/")
+        path = "/sysroot/";
+
     QReadLocker lk(&d->lock);
     id = d->allMounts.key(path, "");
     return !id.isEmpty();

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -223,6 +223,7 @@ void EditStackedWidget::initUI()
 
 void EditStackedWidget::initTextShowFrame(QString fileName)
 {
+    auto originalFileName = fileName; // 存储原始文件名
     QRect rect(QPoint(0, 0), QSize(200, 66));
     QStringList labelTexts;
     ElideTextLayout layout(fileName);
@@ -281,6 +282,12 @@ void EditStackedWidget::initTextShowFrame(QString fileName)
     }
     this->setCurrentIndex(1);
     this->setFixedHeight(textShowFrame->height());
+
+    // 对于多行显示的情况，给整个frame添加tooltip
+    if (labelTexts.join("") != originalFileName) {
+        textShowFrame->setToolTip(originalFileName);
+        textShowFrame->setCursor(Qt::PointingHandCursor);
+    }
 }
 
 void EditStackedWidget::renameFile()

--- a/src/plugins/desktop/ddplugin-canvas/menu/canvasbasesortmenuscene.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/menu/canvasbasesortmenuscene.cpp
@@ -275,6 +275,7 @@ QMap<QString, QStringList> CanvasBaseSortMenuScenePrivate::secondaryMenuRule()
         QStringList sendToList;
         sendToList << "create-system-link";
         sendToList << "send-to-desktop";
+        sendToList << "send-to-bluetooth";
         sendToList << sendToRule();
 
         ret.insert("send-to",

--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
@@ -331,12 +331,13 @@ QUrl ComputerUtils::convertToDevUrl(const QUrl &url)
 
     QUrl converted = url;
     QList<QUrl> urls {};
-    bool ok = UniversalUtils::urlsTransformToLocal({ converted }, &urls);
+    UniversalUtils::urlsTransformToLocal({ converted }, &urls);
 
-    if (ok && !urls.isEmpty())
+    if (!urls.isEmpty())
         converted = urls.first();
     else
         converted = QUrl();
+
     QString devId;
     if (converted.scheme() == Global::Scheme::kFile && DevProxyMng->isMptOfDevice(converted.path(), devId)) {
         if (devId.startsWith(kBlockDeviceIdPrefix))

--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
@@ -338,6 +338,21 @@ QUrl ComputerUtils::convertToDevUrl(const QUrl &url)
     else
         converted = QUrl();
 
+    // in immutable env, the root's mpt is not '/'
+    // so find device url of the root dir by checking all blocks
+    if (converted.scheme() == Global::Scheme::kFile && converted.path() == "/") {
+        auto devIds = DevProxyMng->getAllBlockIds();
+        for ( auto id : devIds) {
+            QUrl devUrl(makeBlockDevUrl(id));
+            auto entryInfo = new EntryFileInfo(devUrl);
+            if (!UniversalUtils::urlEquals(converted, entryInfo->targetUrl()))
+                continue;
+
+            fmDebug() << "convert url from" << url << "to" << devUrl;
+            return devUrl;
+        };
+    }
+
     QString devId;
     if (converted.scheme() == Global::Scheme::kFile && DevProxyMng->isMptOfDevice(converted.path(), devId)) {
         if (devId.startsWith(kBlockDeviceIdPrefix))


### PR DESCRIPTION
- Changed the declaration of `path` from `const QString &` to `QString` to allow modification.
- Added a condition to set `path` to `/sysroot/` if it is equal to `/`.
- Removed the unused `bool ok` variable and simplified the condition to check if `urls` is not empty before assigning the first URL to `converted`.

Log: fix property display with wrong view
Bug: https://pms.uniontech.com/bug-view-299363.html