### PR TITLE
fix: Fixed the issue where changing the password only responded the f…

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -626,7 +626,7 @@ void ShareControlWidget::showSharePasswordSettingsDialog()
     dialog->show();
     dialog->moveToCenter();
     dialog->setAttribute(Qt::WA_DeleteOnClose);
-    QObject::connect(dialog, &UserSharePasswordSettingDialog::finished, dialog, &UserSharePasswordSettingDialog::onButtonClicked);
+    QObject::connect(dialog, &UserSharePasswordSettingDialog::buttonClicked, dialog, &UserSharePasswordSettingDialog::onButtonClicked);
     this->setProperty("UserSharePwdSettingDialogShown", true);
     QObject::connect(dialog, &UserSharePasswordSettingDialog::inputPassword, [=](const QString &password) {
         QString userName = UserShareHelperInstance->currentUserName();


### PR DESCRIPTION
…irst time

- Replaced the finished signal with the buttonClicked signal to trigger close(), resolving the issue where the close event was not properly triggered due to the event filter in QDialogPrivate::close().
- By emitting the buttonClicked signal before the event filter is installed, ensured that the closeEvent is triggered correctly.

log: Fixed the issue where the closeEvent was not properly triggered when closing the dialog.

Bug: https://pms.uniontech.com/bug-view-303377.html