### PR TITLE
fix: Fixed the issue of failing to rename multiple files simultaneously

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
@@ -7,6 +7,7 @@
 #include "utils/fileoperatorhelper.h"
 #include <dfm-base/interfaces/abstractjobhandler.h>
 #include "workspacewidget.h"
+#include "workspacepage.h"
 #include "views/fileview.h"
 
 #include <QComboBox>
@@ -329,14 +330,16 @@ void RenameBar::initConnect()
 
 QList<QUrl> RenameBar::getSelectFiles()
 {
-    auto widget = qobject_cast<WorkspaceWidget *>(parentWidget());
-    if (widget) {
-        auto view = dynamic_cast<FileView *>(widget->currentView());
-        if (view)
-            return view->selectedUrlList();
-    }
+    WorkspacePage* page = qobject_cast<WorkspacePage *>(parentWidget());
+    if (!page)
+        return {};
 
-    return {};
+    FileView* view = dynamic_cast<FileView *>(page->currentViewPtr());
+    if (!view)
+        return {};
+
+    return view->selectedUrlList();
+
 }
 
 


### PR DESCRIPTION
- Adjusted the method for obtaining selected files. The original method failed to convert to a WorkspaceWidget due to the parent object not being a WorkspaceWidget, resulting in a null pointer.

log: Fixed the failure issue in multi-file renaming scenarios, ensuring the rename operation executes successfully.

Bug: https://pms.uniontech.com/bug-view-303255.html