### PR TITLE
fix: the frontend logic of decrypt device.

### DIFF
--- a/assets/rules/99-dfm-encrypt.rules
+++ b/assets/rules/99-dfm-encrypt.rules
@@ -1,0 +1,1 @@
+ENV{DM_NAME}=="usec-overlay-mid-*",ENV{UDISKS_IGNORE}="1"

--- a/debian/dde-file-manager-services-plugins.install
+++ b/debian/dde-file-manager-services-plugins.install
@@ -7,3 +7,4 @@ usr/share/dbus-1/system-services/*.service
 usr/share/dbus-1/system.d/org.deepin.filemanager.diskencrypt.conf
 etc/systemd/system/deepin-service-group@.service.d/*
 etc/polkit-1/localauthority/10-vendor.d/99-dde-file-manager-encrypt.pkla
+run/udev/rules.d/*.rules

--- a/src/dfm-base/base/device/private/devicehelper.cpp
+++ b/src/dfm-base/base/device/private/devicehelper.cpp
@@ -123,6 +123,7 @@ QVariantMap DeviceHelper::loadBlockInfo(const BlockDevAutoPtr &dev)
     datas[kConnectionBus] = getNullStrIfNotValid(Property::kDriveConnectionBus);
     datas[kDriveModel] = getNullStrIfNotValid(Property::kDriveModel);
     datas[kPreferredDevice] = getNullStrIfNotValid(Property::kBlockPreferredDevice);
+    datas[kSymlinks] = dev->getProperty(dfmmount::Property::kBlockSymlinks).toStringList();
 
     auto config = dev->getProperty(Property::kBlockConfiguration).toMap();
     if (!config.isEmpty()) {

--- a/src/dfm-base/dbusservice/global_server_defines.h
+++ b/src/dfm-base/dbusservice/global_server_defines.h
@@ -81,6 +81,7 @@ inline constexpr char kUDisks2Size[] { "UDisks2Size" };
 inline constexpr char kDriveModel[] { "DriveModel" };
 inline constexpr char kPreferredDevice[] { "PreferredDevice" };
 inline constexpr char kConfiguration[] { "Configuration" };
+inline constexpr char kSymlinks[] { "Symlinks" };
 }   // namespace DeviceProperty
 
 /*!

--- a/src/services/diskencrypt/CMakeLists.txt
+++ b/src/services/diskencrypt/CMakeLists.txt
@@ -61,6 +61,7 @@ install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_NAME}.json DESTINATION share/deepin-service-manager/other/)
 install(FILES org.deepin.filemanager.diskencrypt.conf DESTINATION share/dbus-1/system.d/)
 install(FILES org.deepin.Filemanager.DiskEncrypt.service DESTINATION share/dbus-1/system-services/)
+install(FILES ${CMAKE_SOURCE_DIR}/assets/rules/99-dfm-encrypt.rules DESTINATION /run/udev/rules.d)
 
 set(PolicyDir "${CMAKE_INSTALL_PREFIX}/share/polkit-1/actions")
 install(FILES polkit/policy/org.deepin.filemanager.diskencrypt.policy

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -52,7 +52,8 @@ inline const QStringList kDisabledEncryptPath {
     "/",
     "/boot",
     "/boot/efi",
-    "/recovery"
+    "/recovery",
+    "/sysroot"
 };
 
 enum EncryptOperationStatus {
@@ -105,27 +106,6 @@ enum SecKeyType {
     kTpm,
 };
 
-struct DeviceEncryptParam
-{
-    QString devID;
-    QString devDesc;
-    QString jobType;
-    QString devPreferPath;
-    QString devUnlockName;
-    QString key;
-    QString exportPath;
-    SecKeyType secType;
-
-    QString uuid;
-    QString newKey;
-    QString deviceDisplayName;
-    QString mountPoint;
-    QString backingDevUUID;
-    QString clearDevUUID;
-    QString prefferDevName;
-    bool validateByRecKey;
-};
-
 enum EncryptState {
     kStatusNotEncrypted = 0,
     kStatusFinished = 1,
@@ -138,6 +118,29 @@ enum EncryptState {
 Q_ENUMS(EncryptState)
 Q_DECLARE_FLAGS(EncryptStates, EncryptState)
 Q_DECLARE_OPERATORS_FOR_FLAGS(EncryptStates)
+
+struct DeviceEncryptParam
+{
+    QString devID;
+    QString devDesc;
+    QString jobType;
+    QString devPreferPath;
+    QString devUnlockName;
+    QString key;
+    QString exportPath;
+    EncryptStates states;
+    SecKeyType secType;
+
+    QString uuid;
+    QString newKey;
+    QString deviceDisplayName;
+    QString mountPoint;
+    QString backingDevUUID;
+    QString clearDevUUID;
+    QString prefferDevName;
+    bool validateByRecKey;
+};
+
 }
 
 #endif   // GLOBALTYPESDEFINE_H

--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -133,6 +133,7 @@ void crypttab_helper::saveCryptItems(const QList<CryptItem> &items)
         contents.append(line);
     }
     auto data = contents.join('\n').toLocal8Bit();
+    data.append('\n');
 
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         qWarning() << "cannot open crypttab for write!";

--- a/src/services/diskencrypt/workers/dminitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/dminitencryptworker.cpp
@@ -56,7 +56,7 @@ void DMInitEncryptWorker::run()
 
     auto phyPtr = blockdev_helper::createDevPtr(phyDevPath);
     auto source = phyPtr
-            ? phyPtr->getProperty(dfmmount::Property::kPartitionUUID).toString()
+            ? "PARTUUID=" + phyPtr->getProperty(dfmmount::Property::kPartitionUUID).toString()
             : phyDevPath;
     crypttab_helper::insertCryptItem({ activeDmName,
                                        source,

--- a/src/services/diskencrypt/workers/resumeencryptworker.cpp
+++ b/src/services/diskencrypt/workers/resumeencryptworker.cpp
@@ -58,6 +58,12 @@ void ResumeEncryptWorker::run()
         return;
     }
 
+    auto status = crypt_setup_helper::encryptStatus(m_jobArgs.devPath);
+    if (!(status & disk_encrypt::EncryptState::kStatusEncrypt)) {
+        qInfo() << "device is not under encrypting, give up." << m_jobArgs.devPath;
+        return;
+    }
+
     m_args.insert(disk_encrypt::encrypt_param_keys::kKeyDevice, m_jobArgs.devPath);
     m_args.insert(disk_encrypt::encrypt_param_keys::kKeyDeviceName, m_jobArgs.devName);
 


### PR DESCRIPTION
- fix the condition what devices can be decrypted, the backend should be
done later.
- add udev rules to hide the usec-overlay-mid-* devices

Log: as above.
