### PR TITLE
feat: Add slider configuration with custom value list

### DIFF
--- a/include/dfm-base/settingdialog/settingjsongenerator.h
+++ b/include/dfm-base/settingdialog/settingjsongenerator.h
@@ -59,6 +59,7 @@ public:
     bool addComboboxConfig(const QString &key, const QString &name, const QVariantMap &options, QVariant defaultVal = QVariant());
     bool addSliderConfig(const QString &key, const QString &name, int maxVal, int minVal, int defaultVal = 0);
     bool addSliderConfig(const QString &key, const QString &name, const QString &leftIcon, const QString &rightIcon, int maxVal, int minVal, int defaultVal = 0);
+    bool addSliderConfig(const QString &key, const QString &name, const QString &leftIcon, const QString &rightIcon, int maxVal, int minVal, QVariantList valueList, int defaultVal = 0);
 
 protected:
     SettingJsonGenerator();

--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -335,6 +335,7 @@ void SettingBackend::initWorkspaceSettingConfig()
                         "dfm_viewoptions_maxicon",
                         iconSizeLevelMax,
                         iconSizeLevelMin,
+                        viewDefines.getIconSizeList(),
                         5);
     int iconGridDensityLevelMax = viewDefines.iconGridDensityCount() - 1;
     int iconGridDensityLevelMin = 0;
@@ -344,6 +345,7 @@ void SettingBackend::initWorkspaceSettingConfig()
                         "dfm_viewoptions_maxgrid",
                         iconGridDensityLevelMax,
                         iconGridDensityLevelMin,
+                        viewDefines.getIconGridDensityList(),
                         2);
     int listHeightLevelMax = viewDefines.listHeightCount() - 1;
     int listHeightLevelMin = 0;
@@ -353,6 +355,7 @@ void SettingBackend::initWorkspaceSettingConfig()
                         "dfm_viewoptions_maxlist",
                         listHeightLevelMax,
                         listHeightLevelMin,
+                        viewDefines.getListHeightList(),
                         1);
     QStringList viewModeValues { tr("Icon"), tr("List") };
     QVariantList viewModeKeys { 1, 2 };

--- a/src/dfm-base/base/configs/settingjsongenerator.cpp
+++ b/src/dfm-base/base/configs/settingjsongenerator.cpp
@@ -227,6 +227,18 @@ bool SettingJsonGenerator::addSliderConfig(const QString &key,
                                            int minVal,
                                            int defaultVal)
 {
+    return addSliderConfig(key, name, leftIcon, rightIcon, maxVal, minVal, {}, defaultVal);
+}
+
+bool SettingJsonGenerator::addSliderConfig(const QString &key,
+                                           const QString &name,
+                                           const QString &leftIcon,
+                                           const QString &rightIcon,
+                                           int maxVal,
+                                           int minVal,
+                                           QVariantList valueList,
+                                           int defaultVal)
+{
     QVariantMap config {
         { "key", key.mid(key.lastIndexOf(".") + 1) },
         { "name", name },
@@ -235,7 +247,8 @@ bool SettingJsonGenerator::addSliderConfig(const QString &key,
         { "min", minVal},
         { "default", defaultVal },
         { "left-icon", leftIcon },
-        { "right-icon", rightIcon }
+        { "right-icon", rightIcon },
+        { "values", valueList}
     };
     return addConfig(key, config);
 }

--- a/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
@@ -21,6 +21,7 @@
 #include <DSlider>
 #include <DLabel>
 
+#include <QToolTip>
 #include <QWindow>
 #include <QFile>
 #include <QFrame>
@@ -338,6 +339,25 @@ QPair<QWidget *, QWidget *> SettingDialog::createSliderWithSideIcon(QObject *opt
     }
     slider->setValue(option->value().toInt());
     slider->setIconSize(QSize(20, 20));
+
+    QVariantList valList = option->data("values").toList();
+    if (!valList.isEmpty()) {
+        QObject::connect(slider, &DSlider::sliderMoved, slider, [ = ](int position) {
+            if (position >= valList.count())
+                return;
+            int stepLength = (slider->slider()->width() - 28) / option->data("max").toInt();
+            QPoint pos = slider->slider()->mapToGlobal(QPoint(4 + position * stepLength, -48));
+            QToolTip::showText(pos, valList.at(position).toString(), slider);
+        });
+        QObject::connect(slider, &DSlider::sliderPressed, slider, [ = ]{
+            int position = slider->slider()->sliderPosition();
+            if (position >= valList.count())
+                return;
+            int stepLength = (slider->slider()->width() - 28) / option->data("max").toInt();
+            QPoint pos = slider->slider()->mapToGlobal(QPoint(4 + position * stepLength, -48));
+            QToolTip::showText(pos, valList.at(position).toString(), slider);
+        });
+    }
 
     option->connect(slider, &DSlider::valueChanged,
     option, [ = ](int value) {

--- a/src/dfm-base/utils/viewdefines.cpp
+++ b/src/dfm-base/utils/viewdefines.cpp
@@ -4,6 +4,8 @@
 
 #include "viewdefines.h"
 
+#include <QVariant>
+
 DFMBASE_USE_NAMESPACE
 
 ViewDefines::ViewDefines()
@@ -26,6 +28,11 @@ int ViewDefines::indexOfIconSize(int size) const
     return iconSizeList.indexOf(size);
 }
 
+QVariantList ViewDefines::getIconSizeList() const
+{
+    return transToVariantList(iconSizeList);
+}
+
 int ViewDefines::iconGridDensityCount() const
 {
     return iconGridDensityList.size();
@@ -41,6 +48,11 @@ int ViewDefines::indexOfIconGridDensity(int density) const
     return iconGridDensityList.indexOf(density);
 }
 
+QVariantList ViewDefines::getIconGridDensityList() const
+{
+    return transToVariantList(iconGridDensityList);
+}
+
 int ViewDefines::listHeightCount() const
 {
     return listHeightList.size();
@@ -54,6 +66,11 @@ int ViewDefines::listHeight(int index) const
 int ViewDefines::indexOfListHeight(int height) const
 {
     return listHeightList.indexOf(height);
+}
+
+QVariantList ViewDefines::getListHeightList() const
+{
+    return transToVariantList(listHeightList);
 }
 
 void ViewDefines::initDefines()
@@ -81,5 +98,14 @@ void ViewDefines::initDefines()
 
     // init list height
     listHeightList = { 24, 32, 48 };
+}
+
+QVariantList ViewDefines::transToVariantList(const QList<int> list) const
+{
+    QVariantList ret {};
+    for (int val : list)
+        ret.append(QVariant(QString::number(val)));
+
+    return ret;
 }
 

--- a/src/dfm-base/utils/viewdefines.h
+++ b/src/dfm-base/utils/viewdefines.h
@@ -28,14 +28,18 @@ public:
     int iconSizeCount() const;
     int iconSize(int index) const;
     int indexOfIconSize(int size) const;
+    QVariantList getIconSizeList() const;
     int iconGridDensityCount() const;
     int iconGridDensity(int index) const;
     int indexOfIconGridDensity(int density) const;
+    QVariantList getIconGridDensityList() const;
     int listHeightCount() const;
     int listHeight(int index) const;
     int indexOfListHeight(int height) const;
+    QVariantList getListHeightList() const;
 private:
     void initDefines();
+    QVariantList transToVariantList(const QList<int> list) const;
 
     QList<int> iconSizeList {};
     QList<int> iconGridDensityList {};


### PR DESCRIPTION
- Extend SettingJsonGenerator to support slider configs with custom value lists
- Update SettingBackend to use new slider configuration method for icon size, grid density, and list height
- Modify SettingDialog to display tooltips for slider values
- Add helper method in ViewDefines to convert integer lists to variant lists

This change improves the flexibility of slider configurations and provides more informative user interactions.

Log: display tips of slider type settings.
Bug: https://pms.uniontech.com/bug-view-298295.html