### PR TITLE
fix: Resolved the issue where the prompt message was incomplete durin…

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -1151,7 +1151,6 @@ int DeviceManagerPrivate::askForUserChoice(const QString &message, const QString
     askForChoice.setTitle(title);
     askForChoice.setMessage(newMsg);
     askForChoice.addButtons(choices);
-    askForChoice.setMaximumWidth(480);
 
     return askForChoice.exec();
 }


### PR DESCRIPTION
…g the first SFTP access

- Remove maximum width setting in device choice dialog
- This change allows the dialog to adjust its width dynamically based on content

log: Improve dialog width flexibility in device choice prompt

bug: https://pms.uniontech.com/bug-view-303591.html