### PR TITLE
fix: Prevent scroll wheel events in permission combo boxes

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.h
@@ -50,6 +50,7 @@ private:
 
 protected:
     void paintEvent(QPaintEvent *evt) override;
+    bool eventFilter(QObject *object, QEvent *event) override;
 
 private slots:
     void onComboBoxChanged();


### PR DESCRIPTION
- Added event filter to owner, group, and other combo boxes
- Redirect wheel events to parent widget to prevent unintended scrolling
- Improved user interaction in permission management dialog

Log:

Bug: https://pms.uniontech.com/bug-view-303565.html