### PR TITLE
fix: Fix incorrect prompt message in vault password retrieval authori…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultdefine.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultdefine.h
@@ -81,7 +81,7 @@ inline constexpr char kRootProxy[] { "pkexec deepin-vault-authenticateProxy" };
 // NOTE: Not DBus! This is polkit policy (from com.deepin.filemanager.vault.policy)
 inline constexpr char kPolkitVaultCreate[] { "com.deepin.filemanager.daemon.VaultManager.Create" };
 inline constexpr char kPolkitVaultRemove[] { "com.deepin.filemanager.daemon.VaultManager.Remove" };
-
+inline constexpr char kPolkitVaultRetrieve[] { "com.deepin.filemanager.vault.VerifyKey.RetrievePassword" };
 inline constexpr int kBuffterMaxLine { 1024 };   //! shell命令输出每行最大的字符个数
 
 inline const QString kVaultBasePath(QDir::homePath() + QString("/.config/Vault"));   //!! 获取保险箱创建的目录地址

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -152,7 +152,7 @@ void RetrievePasswordView::buttonClicked(int index, const QString &text)
         break;
     case 1:
         //! 用户权限认证(异步授权)
-        VaultUtils::instance().showAuthorityDialog(kPolkitVaultRemove);
+        VaultUtils::instance().showAuthorityDialog(kPolkitVaultRetrieve);
         connect(&VaultUtils::instance(), &VaultUtils::resultOfAuthority,
                 this, &RetrievePasswordView::slotCheckAuthorizationFinished);
         break;


### PR DESCRIPTION
…zation dialog

- Added new polkit policy constant `kPolkitVaultRetrieve` for password retrieval authorization
- Updated RetrievePasswordView to use the new polkit policy when requesting authorization

log: Fix incorrect authentication prompt message for vault password retrieval

bug: https://pms.uniontech.com/bug-view-300099.html