### PR TITLE
fix: Add tooltip and cursor for collection menu button

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp
@@ -60,6 +60,8 @@ CollectionTitleBarPrivate::CollectionTitleBarPrivate(const QString &uuid, Collec
 
     menuBtn = new OptionButton(q);
     menuBtn->setFixedSize(kMenuBtnWidth, kMenuBtnHeight);
+    menuBtn->setCursor(Qt::ArrowCursor);
+    menuBtn->setToolTip(tr("Collection size"));
 
     mainLayout = new QHBoxLayout(q);
     mainLayout->setContentsMargins(8, 2, 8, 2);


### PR DESCRIPTION
- Set cursor to arrow for collection menu button
- Add tooltip to provide context for the collection size button

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-303313.html
