### PR TITLE
fix: Ensure plain text rendering in file preview and property dialogs

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp
@@ -25,6 +25,7 @@ UnknowFilePreview::UnknowFilePreview(QObject *parent)
     iconLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     nameLabel = new QLabel(contentView);
     nameLabel->setObjectName("NameLabel");
+    nameLabel->setTextFormat(Qt::PlainText);
     nameLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     QFont font;
     font.setWeight(QFont::DemiBold);

--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -125,7 +125,7 @@ void KeyValueLabel::setRightValue(QString value, Qt::TextElideMode elideMode, Qt
         fontW = fontMinWidth;
     QString elideNote = fontM.elidedText(value, elideMode, fontW);
     rightValueEdit->setCompleteText(value);
-    rightValueEdit->setText(elideNote);
+    rightValueEdit->setPlainText(elideNote);
     if (toolTipVisibility) {
         if (elideNote != value)
             rightValueEdit->setToolTip(value);

--- a/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.h
+++ b/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.h
@@ -38,7 +38,7 @@ public:
     bool share(const QVariantMap &info);
     bool isUserSharePasswordSet(const QString &username);
     void setSambaPasswd(const QString &userName, const QString &passwd);
-    void removeShareByPath(const QString &path);
+    bool removeShareByPath(const QString &path);
     int readPort();
     ShareInfoList shareInfos();
     ShareInfo shareInfoByPath(const QString &path);
@@ -73,7 +73,7 @@ private:
     void initConnect();
     void initMonitorPath();
 
-    void removeShareByShareName(const QString &name, bool silent = false);
+    bool removeShareByShareName(const QString &name, bool silent = false);
     void removeShareWhenShareFolderDeleted(const QString &deletedPath);
     ShareInfo getOldShareByNewShare(const ShareInfo &newShare);
 

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -447,12 +447,6 @@ bool ShareControlWidget::validateShareName()
             }
 
             if (dlg.exec() != DDialog::Accepted) {
-                if (isShared) {
-                    QString filePath = url.path();
-                    auto shareName = UserShareHelperInstance->shareNameByPath(filePath);
-                    shareNameEditor->setText(shareName);
-                    shareSwitcher->setChecked(isShared);
-                }
                 shareNameEditor->setFocus();
                 return false;
             }
@@ -465,24 +459,18 @@ bool ShareControlWidget::validateShareName()
 
 void ShareControlWidget::updateShare()
 {
-    if (!isUpdating)
-        shareFolder();
-    return;
+    shareFolder();
 }
 
 void ShareControlWidget::shareFolder()
 {
-    bool isShared = UserShareHelperInstance->isShared(url.path());
     if (!shareSwitcher->isChecked())
         return;
-    isUpdating = true;
+
     if (!validateShareName()) {
-        if (!isShared) {
-            shareSwitcher->setChecked(false);
-            sharePermissionSelector->setEnabled(false);
-            shareAnonymousSelector->setEnabled(false);
-        }
-        isUpdating = false;
+        shareSwitcher->setChecked(false);
+        sharePermissionSelector->setEnabled(false);
+        shareAnonymousSelector->setEnabled(false);
         return;
     }
 
@@ -526,7 +514,6 @@ void ShareControlWidget::shareFolder()
         sharePermissionSelector->setEnabled(false);
         shareAnonymousSelector->setEnabled(false);
     }
-    isUpdating = false;
 }
 
 void ShareControlWidget::unshareFolder()

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
@@ -94,7 +94,6 @@ private:
     QTimer *timer { Q_NULLPTR };
 
     QUrl url;
-    bool isUpdating { false };
     FileInfoPointer info { Q_NULLPTR };
     AbstractFileWatcherPointer watcher { Q_NULLPTR };
 };

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
@@ -46,7 +46,7 @@ protected:
     void setupShareNameEditor();
     void setupSharePermissionSelector();
     void setupShareAnonymousSelector();
-    QHBoxLayout* setupNetworkPath();
+    QHBoxLayout *setupNetworkPath();
     QHBoxLayout *setupUserName();
     QHBoxLayout *setupSharePassword();
     void setupShareNotes();
@@ -56,8 +56,8 @@ protected:
 
 protected Q_SLOTS:
     void updateShare();
-    void shareFolder();
-    void unshareFolder();
+    bool shareFolder();
+    bool unshareFolder();
     void updateWidgetStatus(const QString &filePath);
     void updateFile(const QUrl &oldOne, const QUrl &newOne);
     void onSambaPasswordSet(bool result);
@@ -88,7 +88,7 @@ private:
     bool isSharePasswordSet { false };
     QTimer *refreshIp { Q_NULLPTR };
 
-    //QTimer *m_jobTimer;
+    // QTimer *m_jobTimer;
     QString selfIp;
 
     QTimer *timer { Q_NULLPTR };

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -90,8 +90,8 @@ void NameTextEdit::slotTextChanged()
         text.chop(1);
     }
 
-    if (text.count() != old_text.count()) {
-        this->setText(text);
+    if (text.size() != old_text.size()) {
+        this->setPlainText(text);
     }
 
     QTextCursor cursor = this->textCursor();
@@ -138,7 +138,7 @@ void NameTextEdit::showAlertMessage(const QString &text, int duration)
     if (!tooltip) {
         tooltip = createTooltip();
         tooltip->setBackgroundColor(palette().color(backgroundRole()));
-        QTimer::singleShot(duration, this, [ = ] {
+        QTimer::singleShot(duration, this, [=] {
             if (tooltip) {
                 tooltip->hide();
                 tooltip->deleteLater();
@@ -223,7 +223,7 @@ void EditStackedWidget::initUI()
 
 void EditStackedWidget::initTextShowFrame(QString fileName)
 {
-    auto originalFileName = fileName; // 存储原始文件名
+    auto originalFileName = fileName;   // 存储原始文件名
     QRect rect(QPoint(0, 0), QSize(200, 66));
     QStringList labelTexts;
     ElideTextLayout layout(fileName);
@@ -250,6 +250,7 @@ void EditStackedWidget::initTextShowFrame(QString fileName)
     QVBoxLayout *textShowLayout = new QVBoxLayout;
     for (const auto &labelText : labelTexts) {
         DLabel *fileNameLabel = new DLabel(labelText, textShowFrame);
+        fileNameLabel->setTextFormat(Qt::PlainText);
         fileNameLabel->setAlignment(Qt::AlignHCenter);
         textHeight += fileNameLabel->fontInfo().pixelSize() + 10;
 


### PR DESCRIPTION
- Set text format to plain text in UnknowFilePreview name label
- Use setPlainText instead of setText in KeyValueLabel and NameTextEdit
- Add plain text format to file name labels in EditStackedWidget

This change prevents potential HTML or rich text rendering issues in various file management UI components.

Log:

Bug: https://bbs.deepin.org/post/284207