### PR TITLE
Fix incomplete tab display after sidebar collapse.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -371,8 +371,8 @@ void SearchEditWidget::initUI()
 
     layout->addWidget(searchButton);
     layout->addWidget(searchEdit);
+    layout->addSpacing(10);
     layout->addWidget(advancedButton);
-
     // pause button
     pauseButton = new DIconButton(searchEdit);
     pauseButton->setFixedSize(QSize(16, 16));

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -109,6 +109,9 @@ void TitleBarWidget::handleSplitterAnimation(const QVariant &position)
         isSplitterAnimating = false;
     }
 
+    tabBar()->updateGeometry();
+    tabBar()->adjustSize();
+
     int newWidth = qMax(0, 95 - position.toInt());
     if (newWidth == placeholder->width())
         return;


### PR DESCRIPTION
 fix: Fix incomplete tab display after sidebar collapse.
    
    - Ensure tab bar updates its geometry and size during splitter movement.
    
    log: Update tab bar geometry during splitter animation.
    
    bug: https://pms.uniontech.com/bug-view-298505.html

fix: Adjust search edit widget layout spacing
    
    - Added 10-pixel spacing between search button and advanced button
    
    Log: Adjust search edit widget layout spacing
    Bug: https://pms.uniontech.com/bug-view-298487.html
