### PR TITLE
fix: adjust size calculation for symbolic links in file statistics

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -203,7 +203,7 @@ void FileStatisticsJobPrivate::processFile(const FileInfoPointer &fileInfo, cons
 
             auto size = info->size();
             if (size > 0) {
-                totalSize += size;
+                totalSize += isSyslink ? 0 : size;
                 emitSizeChanged();
             }
             // fix bug 30548 ,以为有些文件大小为0,文件夹为空，size也为零，重新计算显示大小


### PR DESCRIPTION
- Updated the size calculation in processFile to skip adding size for symbolic links.
- Ensured that the total size only includes actual file sizes, improving accuracy in statistics.

This change addresses bug 30548 by preventing the inclusion of sizes from symbolic links, which can lead to misleading total size calculations in file statistics.

Log: adjust size calculation for symbolic links in file statistics
Bug: https://pms.uniontech.com/bug-view-295865.html