### PR TITLE
fix: Ensure plain text rendering in file preview and property dialogs

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -125,7 +125,7 @@ void KeyValueLabel::setRightValue(QString value, Qt::TextElideMode elideMode, Qt
         fontW = fontMinWidth;
     QString elideNote = fontM.elidedText(value, elideMode, fontW);
     rightValueEdit->setCompleteText(value);
-    rightValueEdit->setText(elideNote);
+    rightValueEdit->setPlainText(elideNote);
     if (toolTipVisibility) {
         if (elideNote != value)
             rightValueEdit->setToolTip(value);

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -90,8 +90,8 @@ void NameTextEdit::slotTextChanged()
         text.chop(1);
     }
 
-    if (text.count() != old_text.count()) {
-        this->setText(text);
+    if (text.size() != old_text.size()) {
+        this->setPlainText(text);
     }
 
     QTextCursor cursor = this->textCursor();
@@ -249,6 +249,7 @@ void EditStackedWidget::initTextShowFrame(QString fileName)
     QVBoxLayout *textShowLayout = new QVBoxLayout;
     for (const auto &labelText : labelTexts) {
         DLabel *fileNameLabel = new DLabel(labelText, textShowFrame);
+        fileNameLabel->setTextFormat(Qt::PlainText);
         fileNameLabel->setAlignment(Qt::AlignHCenter);
         textHeight += fileNameLabel->fontInfo().pixelSize() + 10;
 

--- a/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.cpp
+++ b/src/plugins/common/dfmplugin-preview/filepreview/views/unknowfilepreview.cpp
@@ -25,6 +25,7 @@ UnknowFilePreview::UnknowFilePreview(QObject *parent)
     iconLabel->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     nameLabel = new QLabel(contentView);
     nameLabel->setObjectName("NameLabel");
+    nameLabel->setTextFormat(Qt::PlainText);
     nameLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     QFont font;
     font.setWeight(QFont::DemiBold);


### PR DESCRIPTION
Set text format to plain text in UnknowFilePreview name label Use setPlainText instead of setText in KeyValueLabel and NameTextEdit Add plain text format to file name labels in EditStackedWidget This change prevents potential HTML or rich text rendering issues in various file management UI components.

Log:

Bug: https://bbs.deepin.org/post/284207