### PR TITLE
fix: wrong args when resume encrypt

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -137,7 +137,7 @@ void EventsHandler::resumeEncrypt(const QString &device)
                          kDaemonBusPath,
                          kDaemonBusIface,
                          QDBusConnection::systemBus());
-    iface.asyncCall("ResumeEncryption", device);
+    iface.asyncCall("ResumeEncryption", QVariantMap());
 }
 
 void EventsHandler::onInitEncryptFinished(const QVariantMap &result)

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -313,6 +313,9 @@ void DiskEncryptSetupPrivate::onResumeEncryptFinished()
     auto code = worker->exitCode();
     auto args = worker->args();
 
+    if (code == -disk_encrypt::kIgnoreRequest)
+        return;
+
     using namespace disk_encrypt::encrypt_param_keys;
     if (args.value(kKeyDevice).toString().isEmpty())
         return;

--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -144,7 +144,7 @@ void crypttab_helper::saveCryptItems(const QList<CryptItem> &items)
     f.flush();
     f.close();
 
-    // updateInitramfs();
+    updateInitramfs();
 }
 
 void crypttab_helper::updateInitramfs()

--- a/src/services/diskencrypt/workers/fstabinitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/fstabinitencryptworker.cpp
@@ -54,7 +54,7 @@ job_file_helper::JobDescArgs FstabInitEncryptWorker::initJobArgs(const QString &
 
     args.device = "PARTUUID=" + ptr->getProperty(dfmmount::Property::kPartitionUUID).toString();
     args.volume = "dm-" + dev.mid(5);
-    args.cipher = common_helper::encryptCipher();
+    args.cipher = common_helper::encryptCipher() + "-xts-plain64";
     args.keySze = "256";
 
     args.devPath = dev;


### PR DESCRIPTION
- cannot resume reencrypt after cancled.
- report error after user cancle the resume work.
- not compelet encrypt cipher saved in job file.
- update initramfs when crypttab file changed.

Log: as above.
