### PR TITLE
fix: Refine search edit widget focus handling

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -674,7 +674,6 @@ void SearchEditWidget::handleFocusInEvent(QFocusEvent *e)
 void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
 {
     if (e->reason() == Qt::PopupFocusReason
-        || e->reason() == Qt::OtherFocusReason
         || e->reason() == Qt::ActiveWindowFocusReason) {
         e->accept();
         if (!searchEdit->text().isEmpty())


### PR DESCRIPTION
- Removed Qt::OtherFocusReason condition in focus out event
- Simplified focus event handling logic

Log: Improve search edit widget focus behavior
Bug: https://pms.uniontech.com/bug-view-302585.html
