### PR TITLE
fix: Simplify collection view cell width calculation

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -1100,19 +1100,7 @@ void CollectionViewPrivate::updateColumnCount(const int &viewWidth, const int &i
         cellWidth = viewWidth;
         columnCount = 1;
     } else {
-        int margin = (availableWidth - columnCount * itemWidth) / (columnCount + 1) / 2;
-        cellWidth = itemWidth + 2 * margin;
-
-        // update viewMargins
-        int leftViewMargin = viewMargins.left() + margin;
-        int rightViewMargin = viewMargins.right() + margin;
-        int unUsedWidth = viewWidth - leftViewMargin - rightViewMargin - columnCount * cellWidth;
-        // try to divide equally
-        leftViewMargin += unUsedWidth / 2;
-        rightViewMargin += unUsedWidth - unUsedWidth / 2;
-
-        viewMargins.setLeft(leftViewMargin);
-        viewMargins.setRight(rightViewMargin);
+        cellWidth = itemWidth;
     }
 
     if (Q_UNLIKELY(cellWidth < 1)) {


### PR DESCRIPTION
- Simplified cell width calculation in collection view
- Removed complex margin and view margin adjustment logic
- Set cell width directly to item width when multiple columns are present

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-303333.html
