### PR TITLE
fix: Remove unnecessary sizeHint method in DiskPluginItem

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/widgets/diskpluginitem.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/diskpluginitem.cpp
@@ -91,8 +91,3 @@ void DiskPluginItem::resizeEvent(QResizeEvent *e)
 
     updateIcon();
 }
-
-QSize DiskPluginItem::sizeHint() const
-{
-    return QSize(26, 26);
-}

--- a/src/external/dde-dock-plugins/disk-mount/widgets/diskpluginitem.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/diskpluginitem.h
@@ -24,7 +24,6 @@ public slots:
 protected:
     void paintEvent(QPaintEvent *e) override;
     void resizeEvent(QResizeEvent *e) override;
-    QSize sizeHint() const override;
 
 private:
     Dock::DisplayMode displayMode;


### PR DESCRIPTION
Remove the sizeHint method from DiskPluginItem, which was providing a fixed size of 26x26 pixels. This allows the item to use the default size hint behavior.

Log: Cleanup of redundant size hint method
Bug: https://pms.uniontech.com/bug-view-281043.html