### PR TITLE
fix: Update horizontal offset calculation in file view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1988,6 +1988,8 @@ void FileView::paintEvent(QPaintEvent *event)
         return;
     }
 
+    if (d->horizontalOffset == 0)
+        d->updateHorizontalOffset();
     DListView::paintEvent(event);
 
     if (d->isShowViewSelectBox) {


### PR DESCRIPTION
Ensure horizontal offset is properly initialized when painting the file view, preventing potential rendering issues.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-302669.html
