### PR TITLE
fix: Fix source folder still exists after choosing merge when cutting…

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -225,9 +225,9 @@ void DoCutFilesWorker::onUpdateProgress()
 void DoCutFilesWorker::endWork()
 {
     // delete all cut source files
-    bool skip { false };
     for (const auto &info : cutAndDeleteFiles) {
-        if (!deleteFile(info->uri(), targetOrgUrl, &skip)) {
+        bool ret = localFileHandler->deleteFile(info->uri());
+        if (!ret) {
             fmWarning() << "delete file error, so do not delete other files!!!!";
             break;
         }
@@ -263,14 +263,17 @@ bool DoCutFilesWorker::doMergDir(const DFileInfoPointer &fromInfo, const DFileIn
         const QUrl &url = iterator->next();
         DFileInfoPointer info(new DFileInfo(url));
         info->initQuerier();
-        bool ok = doCutFile(info, toInfo, skip);
-        if (!ok && (!skip || !*skip)) {
+        bool skip = false;
+        bool ok = doCutFile(info, toInfo, &skip);
+        if (!ok && !skip) {
             return false;
         }
 
         if (!ok)
             continue;
     }
+
+    cutAndDeleteFiles.append(fromInfo);
 
     return true;
 }


### PR DESCRIPTION
… and pasting folders

- Use local skip variable to prevent one file's skip from affecting entire merge chain
- Add source folder to deletion list after successful merge
- Resolve issue where source folder remains after cut-merge operation

log: Fix source folder still exists after choosing merge when cutting and pasting folders
bug: https://pms.uniontech.com/bug-view-298937.html