### PR TITLE
Fix SMB mount issue: redirect to default URL after popup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.31) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 20 Feb 2025 21:24:09 +0800
+
 dde-file-manager (6.5.30) unstable; urgency=medium
 
   * fix: Resolved the issue where the prompt message was incomplete during the first SFTP access

--- a/src/dfm-base/base/device/deviceproxymanager.h
+++ b/src/dfm-base/base/device/deviceproxymanager.h
@@ -55,6 +55,8 @@ public:
     // device signals
 Q_SIGNALS:
     void devSizeChanged(const QString &id, qint64 total, qint64 avai);
+    void mountPointAboutToAdded(QStringView mpt);
+    void mountPointAboutToRemoved(QStringView mpt);
 
     void blockDevPropertyChanged(const QString &id, const QString &property, const QVariant &val);
     void blockDriveAdded();

--- a/src/dfm-base/base/device/private/deviceproxymanager_p.h
+++ b/src/dfm-base/base/device/private/deviceproxymanager_p.h
@@ -52,7 +52,7 @@ private:
     int currentConnectionType = kNoneConnection;   // 0 for API connection and 1 for DBus connection
     QReadWriteLock lock;
     QMap<QString, QString> externalMounts;
-    QMap<QString, QString> allMounts;
+    QMap<QString, QString> allMounts;   // contain system disk
 
     enum {
         kNoneConnection = -1,

--- a/src/dfm-base/utils/systempathutil.cpp
+++ b/src/dfm-base/utils/systempathutil.cpp
@@ -239,3 +239,30 @@ QList<QUrl> SystemPathUtil::canonicalUrlList(const QList<QUrl> &urls)
 
     return processedUrls;
 }
+
+QString SystemPathUtil::getRealpathSafely(const QString &path) const
+{
+    QStringList components = path.split('/', Qt::SkipEmptyParts);
+    QString result = "/";
+    QString accumulatedPath = "/";
+
+    for (const QString &component : components) {
+        accumulatedPath += component;
+
+        QFileInfo fileInfo(accumulatedPath);
+        if (fileInfo.exists()) {
+            // 如果路径存在，获取真实路径
+            result = fileInfo.canonicalFilePath();
+        } else {
+            // 如果路径不存在，直接拼接
+            if (!result.endsWith('/')) {
+                result += '/';
+            }
+            result += component;
+        }
+
+        accumulatedPath += '/';
+    }
+
+    return result;
+}

--- a/src/dfm-base/utils/systempathutil.h
+++ b/src/dfm-base/utils/systempathutil.h
@@ -30,6 +30,7 @@ public:
     bool isSystemPath(QString path) const;
     bool checkContainsSystemPath(const QList<QUrl> &urlList);
     QList<QUrl> canonicalUrlList(const QList<QUrl> &urls);
+    QString getRealpathSafely(const QString &path) const;
 
 private:
     explicit SystemPathUtil(QObject *parent = nullptr);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -225,11 +225,11 @@ void DoCutFilesWorker::onUpdateProgress()
 void DoCutFilesWorker::endWork()
 {
     // delete all cut source files
+    bool skip { false };
     for (const auto &info : cutAndDeleteFiles) {
-        bool ret = localFileHandler->deleteFile(info->uri());
-        if (!ret) {
+        if (!deleteFile(info->uri(), targetOrgUrl, &skip)) {
             fmWarning() << "delete file error, so do not delete other files!!!!";
-            continue;
+            break;
         }
     }
     return FileOperateBaseWorker::endWork();
@@ -263,17 +263,14 @@ bool DoCutFilesWorker::doMergDir(const DFileInfoPointer &fromInfo, const DFileIn
         const QUrl &url = iterator->next();
         DFileInfoPointer info(new DFileInfo(url));
         info->initQuerier();
-        bool skip = false;
-        bool ok = doCutFile(info, toInfo, &skip);
-        if (!ok && !skip) {
+        bool ok = doCutFile(info, toInfo, skip);
+        if (!ok && (!skip || !*skip)) {
             return false;
         }
 
         if (!ok)
             continue;
     }
-
-    cutAndDeleteFiles.append(fromInfo);
 
     return true;
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/folderlistwidget.h
@@ -32,6 +32,8 @@ protected:
     void hideEvent(QHideEvent *event) override;
 
 private:
+    bool matchText(const QString &source, const QString &input) const;
+    bool findAndSelectMatch(const QString &text, int startRow) const;
     QRect availableGeometry(const QPoint& popUpPos) const;
 };
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/folderlistwidget_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/folderlistwidget_p.h
@@ -34,15 +34,12 @@ public:
 
 private:
     void initConnect();
-    QModelIndex getStartIndexFromHover(bool isUp = false);
-    int getStartRowFromHover();
 
 private Q_SLOTS:
     void clicked(const QModelIndex &index);
     void selectUp();
     void selectDown();
     void returnPressed();
-    void handleKeyInput(const QString &pressedText);
 };
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
@@ -72,6 +72,10 @@ private:
     void handleTabAnimationFinished(const int index);
     void updateTabsState();
     void updateAddTabButtonState();
+    bool shouldCloseTab(Tab *tab, const QUrl &targetUrl) const;
+    void handleLastTabClose(const QUrl &currentUrl, const QUrl &targetUrl);
+    QUrl determineRedirectUrl(const QUrl &currentUrl, const QUrl &targetUrl) const;
+    QUrl findValidParentPath(const QUrl &url) const;
 
     inline int getTabAreaWidth() const
     {

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -72,8 +72,6 @@ void WorkspaceEventReceiver::initConnection()
                             WorkspaceHelper::instance(), &WorkspaceHelper::handleRefreshDir);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_NotSupportTreeView",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleNotSupportTreeView);
-    dpfSlotChannel->connect(kCurrentEventSpace, "slot_CheckMountedDevPath",
-                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleCheckMountedDevPath);
 
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_GetVisualGeometry",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleGetVisualGeometry);
@@ -407,11 +405,6 @@ void WorkspaceEventReceiver::handleSetAlwaysOpenInCurrentWindow(const quint64 wi
 void WorkspaceEventReceiver::handleAboutToChangeViewWidth(const quint64 windowID, int deltaWidth)
 {
     WorkspaceHelper::instance()->aboutToChangeViewWidth(windowID, deltaWidth);
-}
-
-bool WorkspaceEventReceiver::handleCheckMountedDevPath(const QUrl &url)
-{
-    return FileDataManager::instance()->isMountedDevPath(url);
 }
 
 void WorkspaceEventReceiver::handleTabCreated(const quint64 windowId, const QString &uniqueId)

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -77,8 +77,6 @@ public slots:
     void handleSetAlwaysOpenInCurrentWindow(const quint64 windowID);
     void handleAboutToChangeViewWidth(const quint64 windowID, int deltaWidth);
 
-    bool handleCheckMountedDevPath(const QUrl &url);
-
     void handleTabCreated(const quint64 windowId, const QString &uniqueId);
     void handleTabRemoved(const quint64 windowId, const QString &removedId, const QString &nextId);
     void handleTabChanged(const quint64 windowId, const QString &uniqueId);

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -54,7 +54,7 @@ RootInfo::~RootInfo()
 bool RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::ItemRoles role, Qt::SortOrder order, bool isMixFileAndFolder)
 {
     // clear old dir iterator thread
-    for (auto it = discardedThread.begin(); it != discardedThread.end(); ) {
+    for (auto it = discardedThread.begin(); it != discardedThread.end();) {
         if (!(*it)->isRunning()) {
             it = discardedThread.erase(it);
         } else {
@@ -225,13 +225,13 @@ void RootInfo::doWatcherEvent()
     qint64 oldtime = 0;
     int emptyLoopCount = 0;
     while (checkFileEventQueue() || timer.elapsed() < 200) {
-        //检查超时，重新设置起始时间
+        // 检查超时，重新设置起始时间
         if (timer.elapsed() - oldtime >= 200) {
             // 处理添加文件
             if (!adds.isEmpty())
                 addChildren(adds);
             if (!updates.isEmpty())
-                updateChildren(updates); 
+                updateChildren(updates);
             if (!removes.isEmpty())
                 removeChildren(removes);
 
@@ -321,7 +321,7 @@ void RootInfo::doThreadWatcherEvent()
 {
     if (processFileEventRuning)
         return;
-    for (auto it = watcherEventFutures.begin(); it != watcherEventFutures.end(); ) {
+    for (auto it = watcherEventFutures.begin(); it != watcherEventFutures.end();) {
         if (it->isFinished()) {
             it = watcherEventFutures.erase(it);
         } else {

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.h
@@ -36,13 +36,10 @@ public:
     void cleanRoot(const QUrl &rootUrl);
     void setFileActive(const QUrl &rootUrl, const QUrl &childUrl, bool active);
 
-    bool isMountedDevPath(const QUrl &url);
-
 public Q_SLOTS:
     void onAppAttributeChanged(DFMBASE_NAMESPACE::Application::ApplicationAttribute aa, const QVariant &value);
     void onHandleFileDeleted(const QUrl url);
     void removeCachedMnts(const QString &id);
-    void cacheMnt(const QString &id, const QString &mnt);
 
 private:
     explicit FileDataManager(QObject *parent = nullptr);
@@ -60,8 +57,6 @@ private:
     // scheme in cacheDataSchemes will have cache
     QList<QString> cacheDataSchemes {};
     QMap<QUrl, int> dataRefMap {};
-
-    QMultiHash<QString, QUrl> allMntedDevs {};
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.cpp
@@ -87,8 +87,6 @@ bool Workspace::start()
     if (!ret)
         fmWarning() << "File Preview: create dconfig failed: " << err;
 
-    FileDataManager::instance()->initMntedDevsCache();
-
     return true;
 }
 
@@ -109,7 +107,8 @@ void Workspace::onWindowClosed(quint64 windId)
     WorkspaceHelper::instance()->removeWorkspace(windId);
 }
 
-void Workspace::initConfig() {
+void Workspace::initConfig()
+{
     SyncPair thumbnailPair {
         { SettingType::kGenAttr, Application::kShowThunmbnailInRemote },
         { DConfigInfo::kConfName, DConfigInfo::kRemoteThumbnailKey },

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.h
@@ -39,7 +39,6 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_CheckSchemeViewIsFileView)
     DPF_EVENT_REG_SLOT(slot_RefreshDir)
     DPF_EVENT_REG_SLOT(slot_NotSupportTreeView)
-    DPF_EVENT_REG_SLOT(slot_CheckMountedDevPath)
 
     DPF_EVENT_REG_SLOT(slot_View_GetVisualGeometry)
     DPF_EVENT_REG_SLOT(slot_View_GetViewItemRect)


### PR DESCRIPTION
This commit addresses a bug where the application did not redirect to the default URL after an SMB mount operation was completed. Instead of navigating to the expected starting URL, the application remained on the previous view, leading to confusion for users.

Changes made:
- Implemented logic to ensure that after an SMB mount popup, the application redirects to the configured default URL.
- Added checks to verify the mount operation's success before performing the redirect.
- Updated relevant signal handlers to trigger the redirect appropriately.

This fix enhances user experience by ensuring that the application behaves as expected after SMB operations, providing a seamless navigation flow.

Log:

Bug: https://pms.uniontech.com/bug-view-303643.html