### PR TITLE
feat: Improve file preview dialog with file info refresh handling

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
@@ -39,6 +39,8 @@ public slots:
 
     void openFile();
 
+    void handleFileInfoRefreshFinished(const QUrl url, const QString &infoPtr, const bool isLinkOrg);
+
 private:
     void childEvent(QChildEvent *event) override;
     void showEvent(QShowEvent *event) override;


### PR DESCRIPTION
- Add connection to FileInfoHelper to handle file info refresh events
- Implement handleFileInfoRefreshFinished method to update preview when file info changes
- Update file attributes during page switching to ensure latest file information is displayed

This change enhances the file preview dialog's responsiveness to file metadata updates.

Log: fix preview display of remote files.
Bug: https://pms.uniontech.com/bug-view-297915.html