### PR TITLE
fix: log initialization bug due to incorrect startup order

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.32) unstable; urgency=medium
+
+  * fix bugs 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 21 Feb 2025 15:53:18 +0800
+
 dde-file-manager (6.5.31) unstable; urgency=medium
 
   * fix bugs

--- a/src/apps/dde-file-dialog-wayland/main.cpp
+++ b/src/apps/dde-file-dialog-wayland/main.cpp
@@ -39,11 +39,15 @@ static constexpr char kDialogCoreLibName[] { "libfiledialog-core-plugin.so" };
 static constexpr char kDFMCorePluginName[] { "dfmplugin-core" };
 static constexpr char kDFMCoreLibName[] { "libdfm-core-plugin.so" };
 
-static void initLog()
+static void initLogFilter()
 {
 #ifdef DTKCORE_CLASS_DConfigFile
     LoggerRules::instance().initLoggerRules();
 #endif
+}
+
+static void initLogSetting()
+{
     dpfLogManager->applySuggestedLogSettings();
 }
 
@@ -174,9 +178,13 @@ static void handleSIGTERM(int sig)
 int main(int argc, char *argv[])
 {
     initEnv();
-    initLog();
+    initLogFilter();
 
     DApplication a(argc, argv);
+
+    // BUG-278055
+    initLogSetting();
+
     a.setOrganizationName(ORGANIZATION_NAME);
     a.setQuitOnLastWindowClosed(false);
     a.setProperty("GTK", true);

--- a/src/apps/dde-file-dialog-x11/main.cpp
+++ b/src/apps/dde-file-dialog-x11/main.cpp
@@ -39,11 +39,15 @@ static constexpr char kDialogCoreLibName[] { "libfiledialog-core-plugin.so" };
 static constexpr char kDFMCorePluginName[] { "dfmplugin-core" };
 static constexpr char kDFMCoreLibName[] { "libdfm-core-plugin.so" };
 
-static void initLog()
+static void initLogFilter()
 {
 #ifdef DTKCORE_CLASS_DConfigFile
     LoggerRules::instance().initLoggerRules();
 #endif
+}
+
+static void initLogSetting()
+{
     dpfLogManager->applySuggestedLogSettings();
 }
 
@@ -171,9 +175,13 @@ static void handleSIGTERM(int sig)
 int main(int argc, char *argv[])
 {
     initEnv();
-    initLog();
+    initLogFilter();
 
     DApplication a(argc, argv);
+
+    // BUG-278055
+    initLogSetting();
+
     a.setOrganizationName(ORGANIZATION_NAME);
     a.setQuitOnLastWindowClosed(false);
     a.setProperty("GTK", true);   // see: FileDialogHandle::winId()

--- a/src/apps/dde-file-dialog/main.cpp
+++ b/src/apps/dde-file-dialog/main.cpp
@@ -39,11 +39,15 @@ static constexpr char kDialogCoreLibName[] { "libfiledialog-core-plugin.so" };
 static constexpr char kDFMCorePluginName[] { "dfmplugin-core" };
 static constexpr char kDFMCoreLibName[] { "libdfm-core-plugin.so" };
 
-static void initLog()
+static void initLogFilter()
 {
 #ifdef DTKCORE_CLASS_DConfigFile
     LoggerRules::instance().initLoggerRules();
 #endif
+}
+
+static void initLogSetting()
+{
     dpfLogManager->applySuggestedLogSettings();
 }
 
@@ -171,9 +175,13 @@ static void handleSIGTERM(int sig)
 int main(int argc, char *argv[])
 {
     initEnv();
-    initLog();
+    initLogFilter();
 
     DApplication a(argc, argv);
+
+    // BUG-278055
+    initLogSetting();
+
     a.setOrganizationName(ORGANIZATION_NAME);
     a.setQuitOnLastWindowClosed(false);
     a.setWindowIcon(QIcon::fromTheme("dde-file-manager"));

--- a/src/apps/dde-file-manager-daemon/main.cpp
+++ b/src/apps/dde-file-manager-daemon/main.cpp
@@ -37,11 +37,15 @@ using namespace GlobalDConfDefines::BaseConfig;
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
-static void initLog()
+static void initLogFilter()
 {
 #ifdef DTKCORE_CLASS_DConfigFile
     LoggerRules::instance().initLoggerRules();
 #endif
+}
+
+static void initLogSetting()
+{
     dpfLogManager->applySuggestedLogSettings();
 }
 
@@ -111,8 +115,12 @@ DWIDGET_USE_NAMESPACE
 
 int main(int argc, char *argv[])
 {
-    initLog();
+    initLogFilter();
     DApplication a(argc, argv);
+
+    // BUG-278055
+    initLogSetting();
+
     a.setOrganizationName(ORGANIZATION_NAME);
     {
         // load translation

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -217,11 +217,15 @@ static void initEnv()
         setEnvForRoot();
 }
 
-static void initLog()
+static void initLogFilter()
 {
 #ifdef DTKCORE_CLASS_DConfigFile
     LoggerRules::instance().initLoggerRules();
 #endif
+}
+
+static void initLogSetting()
+{
     dpfLogManager->applySuggestedLogSettings();
 }
 
@@ -279,7 +283,7 @@ int main(int argc, char *argv[])
     initEnv();
 
     // Warning: set log filter must before QApplication inited
-    initLog();
+    initLogFilter();
 
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     // Fixed the locale codec to utf-8
@@ -287,6 +291,9 @@ int main(int argc, char *argv[])
 #endif
 
     SingleApplication a(argc, argv);
+
+    // BUG-278055
+    initLogSetting();
 
     a.setOrganizationName(ORGANIZATION_NAME);
     a.loadTranslator();


### PR DESCRIPTION
This commit resolves an issue with the DTKLOG initialization where the logging system attempted to access QDBus interfaces before the QCoreApplication object was fully constructed. This premature access resulted in DBus service errors, specifically:
"Error org.freedesktop.DBus.Error.UnknownObject: No such object path XXX".

Changes made:
- Adjusted the initialization order to ensure that QCoreApplication is fully constructed before any logging operations that require DBus access.
- Renamed the log initialization function for clarity and to reflect its new purpose.
- Added checks to prevent DBus access during the initialization phase of the application.

Log: This fix enhances the stability of the logging system and prevents errors related to DBus service availability during application startup.

Bug: https://pms.uniontech.com/bug-view-278055.html