### PR TITLE
fix: Add protocol device unmount failure handling

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -860,9 +860,11 @@ void DeviceManager::detachAllProtoDevs()
 
 void DeviceManager::detachProtoDev(const QString &id)
 {
-    unmountProtocolDevAsync(id, {}, [id](bool ok, const OperationErrorInfo &err) {
-        if (!ok)
+    unmountProtocolDevAsync(id, {}, [this, id](bool ok, const OperationErrorInfo &err) {
+        if (!ok) {
             qCWarning(logDFMBase) << "unmount protocol device failed: " << id << err.message << err.code;
+            emit protocolDevUnmountAsyncFailed(id, err.code);
+        }
     });
 }
 

--- a/src/dfm-base/base/device/devicemanager.h
+++ b/src/dfm-base/base/device/devicemanager.h
@@ -114,10 +114,11 @@ Q_SIGNALS:
     void blockDevFsRemoved(const QString &id);
     void blockDevMountResult(const QString &id, bool result);
 
-    // these 3 signals is designed only for dock's opeartion.
+    // these 4 signals is designed only for dock's opeartion.
     void blockDevUnmountAsyncFailed(const QString &id, DFMMOUNT::DeviceError err);
     void blockDevEjectAsyncFailed(const QString &id, DFMMOUNT::DeviceError err);
     void blockDevPoweroffAysncFailed(const QString &id, DFMMOUNT::DeviceError err);
+    void protocolDevUnmountAsyncFailed(const QString &id, DFMMOUNT::DeviceError err);
 
     void protocolDevAdded(const QString &id);
     void protocolDevRemoved(const QString &id, const QString &oldMpt);

--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
@@ -156,9 +156,11 @@ void DockItemDataManager::playSoundOnDevPlugInOut(bool in)
 void DockItemDataManager::sendNotification(const QString &id, const QString &operation)
 {
     qCInfo(logAppDock) << "eject failed: " << id << operation;
-    if (!blocks.contains(id))
+    if (!blocks.contains(id) && !protocols.contains(id))
         return;
-    QString devName = blocks.value(id).displayName;
+    QString devName = blocks.contains(id)
+            ? blocks.value(id).displayName
+            : protocols.value(id).displayName;
     qCInfo(logAppDock) << "device" << devName << operation << "failed";
 
     QMap<QString, QString> texts {

--- a/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
@@ -88,7 +88,6 @@ void DeviceList::initUI()
     setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     verticalScrollBar()->setSingleStep(7);
-    viewport()->setAutoFillBackground(false);
     content->setAutoFillBackground(false);
     setWidgetResizable(true);
     setMaximumHeight(420);

--- a/src/plugins/daemon/core/devicemanagerdbus.cpp
+++ b/src/plugins/daemon/core/devicemanagerdbus.cpp
@@ -65,6 +65,9 @@ void DeviceManagerDBus::initConnection()
     connect(DevMngIns, &DeviceManager::blockDevPoweroffAysncFailed, this, [this](auto deviceId) {
         emit NotifyDeviceBusy(deviceId, DeviceBusyAction::kPowerOff);
     });
+    connect(DevMngIns, &DeviceManager::protocolDevUnmountAsyncFailed, this, [this](auto deviceId) {
+        emit NotifyDeviceBusy(deviceId, DeviceBusyAction::kUnmount);
+    });
 
     connect(DevMngIns, &DeviceManager::devSizeChanged, this, &DeviceManagerDBus::SizeUsedChanged);
     connect(DevMngIns, &DeviceManager::blockDriveAdded, this, &DeviceManagerDBus::BlockDriveAdded);


### PR DESCRIPTION
- Enhance DeviceManager to emit a signal when protocol device unmount fails
- Update DockItemDataManager to handle protocol device notifications
- Add new signal `protocolDevUnmountAsyncFailed` in DeviceManager
- Modify device busy notification in DeviceManagerDBus to support protocol devices

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-303343.html
