### PR TITLE
fix: Improve custom action command argument handling

### DIFF
--- a/src/plugins/common/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
+++ b/src/plugins/common/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionbuilder.cpp
@@ -314,6 +314,9 @@ QPair<QString, QStringList> DCustomActionBuilder::makeCommand(const QString &cmd
                 rets << args;
                 args.clear();
             } else {
+                // NOTE:https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html
+                if (arg.contains("%%"))
+                    arg = arg.replace("%%", "%");
                 rets << arg;
             }
         }
@@ -332,6 +335,9 @@ QPair<QString, QStringList> DCustomActionBuilder::makeCommand(const QString &cmd
                 rets << args;
                 args.clear();
             } else {
+                // NOTE:https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html
+                if (arg.contains("%%"))
+                    arg = arg.replace("%%", "%");
                 rets << arg;
             }
         }


### PR DESCRIPTION
This commit enhances the command argument processing in the custom action builder by:
- Adding support for escaping percent signs in command arguments according to the freedesktop.org desktop entry specification
- Replacing "%%" with "%" to correctly handle special command argument variables

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-303741.html
