### PR TITLE
fix:  crash due to null pointer dereference

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp
@@ -228,7 +228,7 @@ bool SendToMenuScene::triggered(QAction *action)
         } else {
             if (actId.startsWith(ActionID::kSendToRemovablePrefix)) {
                 fmDebug() << "send files to: " << action->data().toUrl() << ", " << d->selectFiles;
-                dpfSignalDispatcher->publish(GlobalEventType::kCopy, QApplication::activeWindow()->winId(), d->selectFiles, action->data().toUrl(), AbstractJobHandler::JobFlag::kNoHint, nullptr);
+                dpfSignalDispatcher->publish(GlobalEventType::kCopy, d->windowId, d->selectFiles, action->data().toUrl(), AbstractJobHandler::JobFlag::kNoHint, nullptr);
                 return true;
             }
         }

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -363,8 +363,6 @@ void BasicWidget::basicFill(const QUrl &url)
                 audioExtenInfo(url, mediaAttributes);
         }
     }
-
-    
 }
 
 void BasicWidget::initFileMap()
@@ -421,8 +419,8 @@ void BasicWidget::slotFileCountAndSizeChange(qint64 size, int filesCount, int di
 void BasicWidget::slotFileHide(int state)
 {
     Q_UNUSED(state)
-    quint64 winIDs = QApplication::activeWindow()->winId();
-    PropertyEventCall::sendFileHide(winIDs, { currentUrl });
+    auto winID = qApp->activeWindow() ? qApp->activeWindow()->winId() : 0;
+    PropertyEventCall::sendFileHide(winID, { currentUrl });
 }
 
 void BasicWidget::closeEvent(QCloseEvent *event)
@@ -488,13 +486,13 @@ void BasicWidget::videoExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::Attribu
         fileMediaDuration->setVisible(true);
     } else {
         QString localFile = url.toLocalFile();
-        connect(infoFetchWorker, &MediaInfoFetchWorker::durationReady, 
-            this, [this](const QString &duration){
-                if (!duration.isEmpty()) {
-                    fileMediaDuration->setRightValue(duration);
-                    fileMediaDuration->setVisible(true);
-                }
-            });
+        connect(infoFetchWorker, &MediaInfoFetchWorker::durationReady,
+                this, [this](const QString &duration) {
+                    if (!duration.isEmpty()) {
+                        fileMediaDuration->setRightValue(duration);
+                        fileMediaDuration->setVisible(true);
+                    }
+                });
 
         QMetaObject::invokeMethod(infoFetchWorker, "getDuration",
                                   Qt::QueuedConnection, Q_ARG(QString, localFile));
@@ -522,13 +520,13 @@ void BasicWidget::audioExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::Attribu
         fileMediaDuration->setVisible(true);
     } else {
         QString localFile = url.toLocalFile();
-        connect(infoFetchWorker, &MediaInfoFetchWorker::durationReady, 
-            this, [this](const QString &duration){
-                if (!duration.isEmpty()) {
-                    fileMediaDuration->setRightValue(duration);
-                    fileMediaDuration->setVisible(true);
-                }
-            });
+        connect(infoFetchWorker, &MediaInfoFetchWorker::durationReady,
+                this, [this](const QString &duration) {
+                    if (!duration.isEmpty()) {
+                        fileMediaDuration->setRightValue(duration);
+                        fileMediaDuration->setVisible(true);
+                    }
+                });
 
         QMetaObject::invokeMethod(infoFetchWorker, "getDuration",
                                   Qt::QueuedConnection, Q_ARG(QString, localFile));

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -54,6 +54,7 @@ FilePropertyDialog::FilePropertyDialog(QWidget *parent)
 #ifdef DTKGUI_VERSION_STR
     platformWindowHandle->setWindowEffect(DPlatformWindowHandle::EffectScene::EffectNoStart);
 #endif
+    qApp->installEventFilter(this);
 }
 
 FilePropertyDialog::~FilePropertyDialog()
@@ -187,6 +188,23 @@ void FilePropertyDialog::setFileIcon(QLabel *fileIcon, FileInfoPointer fileInfo)
         }
         fileIcon->setPixmap(fileInfo->fileIcon().pixmap(128, 128));
     }
+}
+
+bool FilePropertyDialog::eventFilter(QObject *object, QEvent *event)
+{
+    // 检查是否是ComboBox上的滚轮事件
+    if (object->inherits("QComboBox") && event->type() == QEvent::Wheel) {
+        // 确保ComboBox是我们对话框的后代
+        QWidget *widget = qobject_cast<QWidget *>(object);
+        if (widget && isAncestorOf(widget)) {
+            // 将事件重定向到滚动区域
+            QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(event);
+            QCoreApplication::sendEvent(this, wheelEvent);
+            return true;
+        }
+    }
+
+    return DDialog::eventFilter(object, event);
 }
 
 void FilePropertyDialog::selectFileUrl(const QUrl &url)
@@ -326,7 +344,7 @@ void FilePropertyDialog::showEvent(QShowEvent *event)
         }
         vlayout->addStretch();
     }
-    
+
     QTimer::singleShot(0, this, [this]() {
         processHeight(contentHeight());
     });

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
@@ -61,6 +61,7 @@ private:
     void setFileIcon(QLabel *fileIcon, FileInfoPointer fileInfo);
 
 protected:
+    bool eventFilter(QObject *object, QEvent *event) override;
     virtual void mousePressEvent(QMouseEvent *event) override;
     virtual void resizeEvent(QResizeEvent *event) override;
     virtual void showEvent(QShowEvent *event) override;

--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -266,10 +266,11 @@ void PermissionManagerWidget::toggleFileExecutable(bool isChecked)
     if (info.isNull())
         return;
 
+    auto winID = qApp->activeWindow() ? qApp->activeWindow()->winId() : 0;
     if (isChecked) {
-        PropertyEventCall::sendSetPermissionManager(qApp->activeWindow()->winId(), selectUrl, info->permissions() | QFile::ExeOwner | QFile::ExeUser | QFile::ExeGroup | QFile::ExeOther);
+        PropertyEventCall::sendSetPermissionManager(winID, selectUrl, info->permissions() | QFile::ExeOwner | QFile::ExeUser | QFile::ExeGroup | QFile::ExeOther);
     } else {
-        PropertyEventCall::sendSetPermissionManager(qApp->activeWindow()->winId(), selectUrl, info->permissions() & ~(QFile::ExeOwner | QFile::ExeUser | QFile::ExeGroup | QFile::ExeOther));
+        PropertyEventCall::sendSetPermissionManager(winID, selectUrl, info->permissions() & ~(QFile::ExeOwner | QFile::ExeUser | QFile::ExeGroup | QFile::ExeOther));
     }
 }
 
@@ -340,7 +341,8 @@ void PermissionManagerWidget::onComboBoxChanged()
     ownerFlags |= (permissions & QFile::ExeOwner);
     groupFlags |= (permissions & QFile::ExeGroup);
     otherFlags |= (permissions & QFile::ExeOther);
-    PropertyEventCall::sendSetPermissionManager(qApp->activeWindow()->winId(), selectUrl, QFileDevice::Permissions(ownerFlags) | QFileDevice::Permissions(groupFlags) | QFileDevice::Permissions(otherFlags));
+    auto winID = qApp->activeWindow() ? qApp->activeWindow()->winId() : 0;
+    PropertyEventCall::sendSetPermissionManager(winID, selectUrl, QFileDevice::Permissions(ownerFlags) | QFileDevice::Permissions(groupFlags) | QFileDevice::Permissions(otherFlags));
 
     infoBytes = info->pathOf(PathInfoType::kAbsoluteFilePath).toUtf8();
     stat(infoBytes.data(), &fileStat);

--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -22,7 +22,6 @@
 #include <QComboBox>
 #include <QCheckBox>
 #include <QFormLayout>
-#include <QWheelEvent>
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -156,17 +155,14 @@ void PermissionManagerWidget::initUI()
     DLabel *owner = new DLabel(QObject::tr("Owner"), this);
     DFontSizeManager::instance()->bind(owner, DFontSizeManager::SizeType::T7, QFont::Medium);
     ownerComboBox = new QComboBox(this);
-    ownerComboBox->installEventFilter(this);
 
     DLabel *group = new DLabel(QObject::tr("Group"), this);
     DFontSizeManager::instance()->bind(group, DFontSizeManager::SizeType::T7, QFont::Medium);
     groupComboBox = new QComboBox(this);
-    groupComboBox->installEventFilter(this);
 
     DLabel *other = new DLabel(QObject::tr("Others"), this);
     DFontSizeManager::instance()->bind(other, DFontSizeManager::SizeType::T7, QFont::Medium);
     otherComboBox = new QComboBox(this);
-    otherComboBox->installEventFilter(this);
 
     executableCheckBox = new QCheckBox(this);
     executableCheckBox->setText(tr("Allow to execute as program"));
@@ -310,17 +306,6 @@ void PermissionManagerWidget::paintEvent(QPaintEvent *evt)
 {
     setExecText();
     DArrowLineDrawer::paintEvent(evt);
-}
-
-bool PermissionManagerWidget::eventFilter(QObject *object, QEvent *event)
-{
-    if (object->inherits("QComboBox") && event->type() == QEvent::Wheel) {
-        QWheelEvent *wheelEvent = static_cast<QWheelEvent *>(event);
-        QCoreApplication::sendEvent(this, wheelEvent);
-        return true;
-    }
-
-    return DArrowLineDrawer::eventFilter(object, event);
 }
 
 void PermissionManagerWidget::onComboBoxChanged()

--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.h
@@ -50,7 +50,6 @@ private:
 
 protected:
     void paintEvent(QPaintEvent *evt) override;
-    bool eventFilter(QObject *object, QEvent *event) override;
 
 private slots:
     void onComboBoxChanged();

--- a/src/plugins/desktop/ddplugin-background/backgrounddefault.h
+++ b/src/plugins/desktop/ddplugin-background/backgrounddefault.h
@@ -18,6 +18,7 @@ class BackgroundDefault : public QWidget
 public:
     explicit BackgroundDefault(const QString &screenName, QWidget *parent = nullptr);
     void setPixmap(const QPixmap &pix);
+
 protected:
     void paintEvent(QPaintEvent *event) override;
 
@@ -27,11 +28,10 @@ private:
     int painted = 3;
     QString screen;
     QPixmap pixmap;
-    QPixmap noScalePixmap;
 };
 
 DDP_BACKGROUND_END_NAMESPACE
 
 typedef QSharedPointer<ddplugin_background::BackgroundDefault> BackgroundWidgetPointer;
 
-#endif // BACKGROUNDDEFAULT_H
+#endif   // BACKGROUNDDEFAULT_H


### PR DESCRIPTION
This commit addresses a critical bug that caused the application to crash when attempting to dereference a null pointer. This issue occurred in several locations where the code did not properly check for null pointers before accessing their members.

Log: This fix enhances the stability of the application and prevents unexpected crashes, improving overall user experience.

Bug: https://pms.uniontech.com/bug-view-305073.html