### PR TITLE
fix: Improve symlink resolution and file handling

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -95,7 +95,7 @@ QUrl DeviceUtils::getSambaFileUriFromNative(const QUrl &url)
     //  /root/.gvfs/smb-share...../helloworld.txt
     //  /media/user/smbmounts/smb-share...../helloworld.txt
     //  ======>  helloworld.txt
-    static const QRegularExpression prefix(R"(^/run/user/.*/gvfs/[^/]*/|^/root/.gvfs/[^/]*/|^/(?:run/)?media/.*/smbmounts/[^/]*)");
+    static const QRegularExpression prefix(R"(^/run/user/.*/gvfs/[^/]*/|^/root/.gvfs/[^/]*/|^/(?:run/)?media/.*/smbmounts/[^/]*/)");
     QString fileName = fullPath.remove(prefix);
     fileName.chop(1);   // remove last '/'.
 

--- a/src/dfm-base/utils/applaunchutils.cpp
+++ b/src/dfm-base/utils/applaunchutils.cpp
@@ -181,7 +181,9 @@ bool AppLaunchUtils::launchApp(const QString &desktopFile, const QStringList &ur
     localPaths.reserve(urlStrs.size());
     std::transform(urlStrs.begin(), urlStrs.end(), std::back_inserter(localPaths),
                    [](const QString &urlStr) -> QString {
-                       return QUrl(urlStr).toLocalFile();
+                       auto url = QUrl(urlStr);
+                       auto localPath = url.isLocalFile() ? QUrl(urlStr).toLocalFile() : urlStr;
+                       return localPath;
                    });
 
     for (const auto &strategy : d->strategies) {


### PR DESCRIPTION
- Fixed symlink resolution for SMB files by checking symlink target
- Updated device utils regex to correctly handle SMB file paths
- Modified app launch utils to handle non-local file URLs
- Added protocol utils check for SMB file existence during symlink resolution

Log: Improvements to file handling and symlink resolution
Bug: https://pms.uniontech.com/bug-view-298567.html