### PR TITLE
fix: Improve media file properties display logic

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -239,9 +239,7 @@ void RightValueWidget::mouseReleaseEvent(QMouseEvent *event)
 
 void RightValueWidget::showEvent(QShowEvent *event)
 {
-    if (!document()->toPlainText().isEmpty())
-        this->setFixedHeight(static_cast<int>(document()->size().height()) + 2);
-
+    setFixedHeight(static_cast<int>(document()->size().height()) + 2);
     QTextEdit::showEvent(event);
 }
 


### PR DESCRIPTION
This commit enhances the media file properties display by:
- Refactoring visibility and height adjustment for media resolution and duration labels
- Adding more robust handling of media metadata for videos, images, and audio files
- Ensuring labels are only shown when valid metadata is available

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-288209.html
