### PR TITLE
fix: Improve device URL conversion for root directory

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
@@ -338,18 +338,17 @@ QUrl ComputerUtils::convertToDevUrl(const QUrl &url)
     else
         converted = QUrl();
 
-    // in immutable env, the root's mpt is not '/'
+    // in immutable env, some dir can't find mpt by path(eg: '/')
     // so find device url of the root dir by checking all blocks
-    if (converted.scheme() == Global::Scheme::kFile && converted.path() == "/") {
+    if (converted.scheme() == Global::Scheme::kFile) {
         auto devIds = DevProxyMng->getAllBlockIds();
         for ( auto id : devIds) {
             QUrl devUrl(makeBlockDevUrl(id));
             auto entryInfo = new EntryFileInfo(devUrl);
-            if (!UniversalUtils::urlEquals(converted, entryInfo->targetUrl()))
-                continue;
-
-            fmDebug() << "convert url from" << url << "to" << devUrl;
-            return devUrl;
+            if (UniversalUtils::urlEquals(converted, entryInfo->targetUrl())) {
+                fmDebug() << "convert url from" << url << "to" << devUrl;
+                return devUrl;
+            }
         };
     }
 


### PR DESCRIPTION
Enhance root directory device URL detection by:
- Modifying the conversion logic to handle cases where the root path cannot be directly mapped
- Iterating through all block devices to find the correct device URL
- Simplifying the URL comparison and conversion process

This change improves the robustness of device URL detection, especially in immutable environments.

Log: fix property display issue
Bug: https://pms.uniontech.com/bug-view-296637.html