### PR TITLE
fix: Add file deletion signal for file operations

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
@@ -146,8 +146,7 @@ bool DoCleanTrashFilesWorker::clearTrashFile(const FileInfoPointer &trashInfo)
             action = doHandleErrorAndWait(fileUrl, AbstractJobHandler::JobErrorType::kDeleteTrashFileError,
                                           false, localFileHandler->errorString());
         } else {
-            dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Delete",
-                                         fileUrl);
+            emit fileDeleted(fileUrl);
         }
 
     } while (isStopped() && action == AbstractJobHandler::SupportAction::kRetryAction);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -177,8 +177,7 @@ bool DoCutFilesWorker::doCutFile(const DFileInfoPointer &fromInfo, const DFileIn
             orignalUrl.setPath(orignalUrl.path().replace(tmpFileName, orignalName));
         }
         if (toInfo)
-            dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Rename",
-                                         orignalUrl, toInfo->uri());
+            emit fileRenamed(orignalUrl, toInfo->uri());
         return true;
     }
 
@@ -210,8 +209,7 @@ bool DoCutFilesWorker::doCutFile(const DFileInfoPointer &fromInfo, const DFileIn
         auto orignalName = QUrl::toPercentEncoding(tmpFileName);
         orignalUrl.setPath(orignalUrl.path().replace(tmpFileName, orignalName));
     }
-    dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Rename",
-                                 orignalUrl, toInfo->uri());
+    emit fileRenamed(orignalUrl, toInfo->uri());
     return true;
 }
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -99,7 +99,7 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
         if (action != AbstractJobHandler::SupportAction::kNoAction)
             return false;
 
-        dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Delete", url);
+        emit fileDeleted(url);
     }
     return true;
 }
@@ -134,6 +134,7 @@ bool DoDeleteFilesWorker::deleteFilesOnOtherDevice()
             return false;
         completeTargetFiles.append(url);
         completeSourceFiles.append(url);
+        emit fileDeleted(url);
     }
     return true;
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.h
@@ -50,6 +50,10 @@ protected slots:
     void handleError(const JobInfoPointer jobInfo);
     void handleRetryErrorSuccess(const quint64 Id);
 
+    void handleFileRenamed(const QUrl &old, const QUrl &cur);
+    void handleFileDeleted(const QUrl &url);
+    void handleFileAdded(const QUrl &url);
+
 protected:
     void start();
     explicit AbstractJob(AbstractWorker *doWorker, QObject *parent = nullptr);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -98,6 +98,10 @@ signals:   // update proccess timer use
     void retryErrSuccess(const quint64 id);
     void requestTaskDailog();
 
+    void fileRenamed(const QUrl &old, const QUrl &cur);
+    void fileDeleted(const QUrl &url);
+    void fileAdded(const QUrl &url);
+
 public:
     void doOperateWork(AbstractJobHandler::SupportActions actions, AbstractJobHandler::JobErrorType error = AbstractJobHandler::JobErrorType::kNoError, const quint64 id = 0);
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1054,8 +1054,7 @@ bool FileOperateBaseWorker::doCopyFile(const DFileInfoPointer &fromInfo, const D
     }
 
     if (result)
-        dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Add",
-                                     newTargetInfo->uri());
+        emit fileAdded(newTargetInfo->uri());
 
     if (targetInfo == toInfo) {
         completeSourceFiles.append(fromInfo->uri());

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/domovetotrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/domovetotrashfilesworker.cpp
@@ -131,8 +131,7 @@ bool DoMoveToTrashFilesWorker::doMoveToTrash()
                 completeSourceFiles.append(urlSource);
                 auto targetTash = trashTargetUrl(trashUrl);
                 if (targetTash.isValid())
-                    dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Rename",
-                                                 urlSource, targetTash);
+                    emit fileRenamed(urlSource, targetTash);
                 continue;
             } else {
                 // pause and emit error msg

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -199,7 +199,7 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
             }
             if (!completeTargetFiles.contains(restoreInfo->uri()))
                 completeTargetFiles.append(restoreInfo->uri());
-            dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Rename", fileUrl, newTargetInfo->uri());
+            emit fileRenamed(fileUrl, newTargetInfo->uri());
         } else {
             auto errorCode = fileHandler.errorCode();
             switch (errorCode) {


### PR DESCRIPTION
Publish a signal when a file is deleted to improve file operation tracking and notifications

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-303605.html
