### PR TITLE
fix: [file-dialog] optimize extension name search to prevent dialog sticking

### DIFF
--- a/src/plugins/filedialog/filedialogplugin-core/utils/corehelper.cpp
+++ b/src/plugins/filedialog/filedialogplugin-core/utils/corehelper.cpp
@@ -157,15 +157,15 @@ QString CoreHelper::findExtensioName(const QString &fileName, const QStringList 
             }
         }
 
-        if (newNameFilterExtension.isEmpty())
-            fmInfo() << "Cannot find extension name";
-
         QRegExp re(newNameFilterExtension, Qt::CaseInsensitive, QRegExp::Wildcard);
         if (re.exactMatch(fileNameExtension)) {   //原扩展名与新扩展名不匹配？
             fmInfo() << "Set new filter rules:" << newNameFilters;
             // TODO(liuyangming):
             // getFileView()->setNameFilters(newNameFilters); //这里传递回去的有可能是一个正则表达式，它决定哪些文件不被置灰
         }
+
+        if (!newNameFilterExtension.isEmpty())
+            break;
     }
     return newNameFilterExtension;
 }


### PR DESCRIPTION
When searching for extension names in accept mode, the dialog would continue
iterating through all filters even after finding a match, causing potential
performance issues and UI sticking. Break the loop once a valid extension
is found.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-305621.html

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the file dialog could become stuck in accept mode by breaking the loop after finding a new extension.