### PR TITLE
feat: Add slider tooltips for view options

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/viewoptionswidget_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/viewoptionswidget_p.h
@@ -55,11 +55,15 @@ public:
     explicit ViewOptionsWidgetPrivate(ViewOptionsWidget *qq);
     virtual ~ViewOptionsWidgetPrivate();
 
+    template<typename Func>
+    void connectSliderTip(DTK_WIDGET_NAMESPACE::DSlider *slider, Func getValueList);
+
 private:
     void initializeUi();
     void initConnect();
     void setUrl(const QUrl &url);
     void switchMode(ViewMode mode);
+    void showSliderTips(DTK_WIDGET_NAMESPACE::DSlider *slider, int pos, const QVariantList &valList);
 
     QList<QString> getStringListByIntList(const QList<int> &intList);
 };


### PR DESCRIPTION
Enhance the ViewOptionsWidget by adding dynamic tooltips to sliders:
- Implement showSliderTips method to display current value when moving sliders
- Add tooltip support for icon size, grid density, and list height sliders
- Use QToolTip to show precise values during slider interaction

This improvement provides users with more precise feedback when adjusting view settings.

Log: Add slider tooltips for view options
Bug: https://pms.uniontech.com/bug-view-298295.html

## Summary by Sourcery

New Features:
- Implement dynamic tooltips for the icon size, grid density, and list height sliders in the ViewOptionsWidget, displaying the current value while the slider is being moved.