### PR TITLE
fix bugs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.34) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 28 Feb 2025 17:33:52 +0800
+
 dde-file-manager (6.5.33) unstable; urgency=medium
 
   * revert a commit for CI

--- a/examples/dfm-extension-example/mymenuplugin.cpp
+++ b/examples/dfm-extension-example/mymenuplugin.cpp
@@ -142,7 +142,22 @@ bool MyMenuPlugin::buildEmptyAreaMenu(DFMExtMenu *main, const std::string &curre
         }
     });
 
-    main->addAction(action);
+    // TODO: add interface id()
+    auto actions = main->actions();
+    auto it = std::find_if(actions.cbegin(), actions.cend(), [](const DFMExtAction *action) {
+        const std::string &text = action->text();
+        return (text.find("刷新") == 0) || (text.find("Refresh") == 0);
+    });
+
+    if (it != actions.cend()) {
+        auto separator = m_proxy->createAction();
+        separator->setSeparator(true);
+        main->insertAction(*it, separator);
+        main->insertAction(*it, action);
+    } else {
+        main->addAction(action);
+    }
+
     return true;
 }
 

--- a/src/plugins/common/dfmplugin-bookmark/bookmarkcallback.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/bookmarkcallback.cpp
@@ -48,7 +48,7 @@ void BookmarkCallBack::contextMenuHandle(quint64 windowId, const QUrl &url, cons
     menu->addSeparator();
 
     auto renameAct = menu->addAction(QObject::tr("Rename"), [url, windowId]() {
-        dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_TriggerEdit", windowId, url);
+        QTimer::singleShot(200, [url, windowId] { dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_TriggerEdit", windowId, url); });
     });
     renameAct->setEnabled(bEnabled);
 

--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -403,6 +403,8 @@ void BookMarkManager::getMountInfo(const QUrl &url, QString &mountPoint, QString
 
 void BookMarkManager::saveSortedItemsToConfigFile(const QList<QUrl> &order)
 {
+    Q_ASSERT(!order.isEmpty());
+
     QVariantList sorted;
     int index = 0;
     for (auto url : order) {
@@ -415,7 +417,8 @@ void BookMarkManager::saveSortedItemsToConfigFile(const QList<QUrl> &order)
         index++;
     }
 
-    Application::genericSetting()->setValue(kConfigGroupQuickAccess, kConfigKeyName, sorted);
+    if (!sorted.isEmpty())
+        Application::genericSetting()->setValue(kConfigGroupQuickAccess, kConfigKeyName, sorted);
 }
 
 void BookMarkManager::saveQuickAccessToSortedItems(const QVariantList &list)

--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.h
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.h
@@ -57,8 +57,6 @@ public:
 
 private:
     explicit BookMarkManager(QObject *parent = nullptr);
-    void update(const QVariant &value);
-    void removeAllBookMarkSidebarItems();
 
     void getMountInfo(const QUrl &url, QString &mountPoint, QString &localUrl);
     void saveSortedItemsToConfigFile(const QList<QUrl> &order);
@@ -70,9 +68,6 @@ private:
     void addBookmarkToDConfig(const QVariantMap &data);
     void renameBookmarkToDConfig(const QString &oldName, const QString &newName);
     void updateBookmarkUrlToDconfig(const QUrl &oldUrl, const QUrl &newUrl);
-
-private slots:
-    void onFileEdited(const QString &group, const QString &key, const QVariant &value);
 
 private:
     QMap<QUrl, BookmarkData> quickAccessDataMap = {};

--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.h
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.h
@@ -21,7 +21,6 @@ struct BookmarkData
 {
     QDateTime created;
     QDateTime lastModified;
-    QString locateUrl;
     QString deviceUrl;
     QString name;
     QUrl url;
@@ -58,7 +57,7 @@ public:
 private:
     explicit BookMarkManager(QObject *parent = nullptr);
 
-    void getMountInfo(const QUrl &url, QString &mountPoint, QString &localUrl);
+    void getMountInfo(const QUrl &url, QString &mountPoint);
     void saveSortedItemsToConfigFile(const QList<QUrl> &order);
     void saveQuickAccessToSortedItems(const QVariantList &list);
 

--- a/src/plugins/common/dfmplugin-bookmark/events/bookmarkeventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/events/bookmarkeventreceiver.cpp
@@ -30,13 +30,12 @@ void BookMarkEventReceiver::handleRenameFile(quint64 windowId, const QMap<QUrl, 
     }
 }
 
-void BookMarkEventReceiver::handleSidebarOrderChanged(quint64 winId, const QString &group)
+void BookMarkEventReceiver::handleSidebarOrderChanged(quint64 winId, const QString &group, const QList<QUrl> &urls)
 {
     if (group != "Group_Common")
         return;
 
-    auto items = dpfSlotChannel->push("dfmplugin_sidebar", "slot_Group_UrlList", winId, group);
-    BookMarkManager::instance()->saveSortedItemsToConfigFile(items.value<QList<QUrl>>());
+    BookMarkManager::instance()->saveSortedItemsToConfigFile(urls);
 }
 
 BookMarkEventReceiver::BookMarkEventReceiver(QObject *parent)

--- a/src/plugins/common/dfmplugin-bookmark/events/bookmarkeventreceiver.h
+++ b/src/plugins/common/dfmplugin-bookmark/events/bookmarkeventreceiver.h
@@ -21,7 +21,7 @@ public:
 
 public Q_SLOTS:
     void handleRenameFile(quint64 windowId, const QMap<QUrl, QUrl> &renamedUrls, bool result, const QString &errorMsg);
-    void handleSidebarOrderChanged(quint64 winId, const QString &group);
+    void handleSidebarOrderChanged(quint64 winId, const QString &group, const QList<QUrl> &urls);
 
 private:
     explicit BookMarkEventReceiver(QObject *parent = nullptr);

--- a/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
@@ -97,7 +97,9 @@ bool UserShareHelper::share(const ShareInfo &info)
 
     if (isValidShare(info)) {
         const auto &&name = info.value(ShareInfoKeys::kName).toString();
-        if (name.startsWith("-") || name.endsWith(" ")) {
+        // 是否包含了非法字符：%<>*?|/\\+=;:,\"，且不能以 "-" 和空格开头，或者空格结尾
+        QRegularExpression regex(R"(^(?![ -])[^%<>*?|/\\+=;:,"]*$(?<! ))");
+        if (!regex.match(name).hasMatch()) {
             DialogManagerInstance->showErrorDialog(tr("The share name must not contain %1, and cannot start with a dash (-) or whitespace, or end with whitespace.").arg("%<>*?|/\\+=;:,\""), "");
             return false;
         }

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -47,7 +47,6 @@ DFMBASE_USE_NAMESPACE
 namespace ConstDef {
 static constexpr int kKeyWidth { 80 };
 static constexpr int kWidgetFixedWidth { 195 };
-static constexpr char kShareNameRegx[] { "^[^\\[\\]\"'/\\\\:|<>+=;,?*\r\n\t]*$" };
 static constexpr char kShareFileDir[] { "/var/lib/samba/usershares" };
 }
 
@@ -180,8 +179,9 @@ void ShareControlWidget::setupShareSwitcher()
 void ShareControlWidget::setupShareNameEditor()
 {
     shareNameEditor = new QLineEdit(this);
+    static constexpr char kShareNameRegx[] { R"(^(?![ -])[^%<>*?|/\\+=;:,"]*+ ?$)" };
 
-    QValidator *validator = new QRegularExpressionValidator(QRegularExpression(ConstDef::kShareNameRegx), this);
+    QValidator *validator = new QRegularExpressionValidator(QRegularExpression(kShareNameRegx), this);
     shareNameEditor->setValidator(validator);
 
     connect(shareNameEditor, &QLineEdit::textChanged, this, [=](const QString &text) {

--- a/src/plugins/common/dfmplugin-tag/events/tageventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-tag/events/tageventreceiver.cpp
@@ -128,12 +128,10 @@ QStringList TagEventReceiver::handleGetTags(const QUrl &url)
     return rec;
 }
 
-void TagEventReceiver::handleSidebarOrderChanged(quint64 winId, const QString &group)
+void TagEventReceiver::handleSidebarOrderChanged(quint64 winId, const QString &group, QList<QUrl> urls)
 {
-    if (group != "Tag")
+    if (group != "Group_Tag")
         return;
-    auto items = dpfSlotChannel->push("dfmplugin_sidebar", "slot_Group_UrlList", winId, group);
-    auto urls = items.value<QList<QUrl>>();
 
     QVariantList lst;
     for (auto &url : urls) {

--- a/src/plugins/common/dfmplugin-tag/events/tageventreceiver.h
+++ b/src/plugins/common/dfmplugin-tag/events/tageventreceiver.h
@@ -27,7 +27,7 @@ public slots:
     void handleRestoreFromTrashResult(const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls,
                                       const QVariantList &customInfos, bool ok, const QString &errMsg);
     QStringList handleGetTags(const QUrl &url);
-    void handleSidebarOrderChanged(quint64 winId, const QString &group);
+    void handleSidebarOrderChanged(quint64 winId, const QString &group, QList<QUrl> urls);
 
 private:
     explicit TagEventReceiver(QObject *parent = nullptr);

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -571,7 +571,7 @@ void TagManager::contenxtMenuHandle(quint64 windowId, const QUrl &url, const QPo
 
     // tag action
     menu->addAction(QObject::tr("Rename"), [url, windowId]() {
-        dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_TriggerEdit", windowId, url);
+        QTimer::singleShot(200, [url, windowId] { dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_TriggerEdit", windowId, url); });
     });
 
     menu->addAction(QObject::tr("Remove"), [url]() {

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -77,14 +77,8 @@ QVariant ComputerModel::data(const QModelIndex &index, int role) const
             return "";
 
         QString &&itemName = item->info->displayName();
-        if (itemName != item->itemName) {
-            QVariantMap map {
-                { "Property_Key_DisplayName", itemName },
-                { "Property_Key_Editable", item->info->renamable() }
-            };
-            dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", item->info->urlOf(UrlInfoType::kUrl), map);
+        if (itemName != item->itemName)
             item->itemName = itemName;
-        }
         return itemName;
     }
 

--- a/src/plugins/filemanager/dfmplugin-recent/recent.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/recent.cpp
@@ -42,7 +42,7 @@ DFM_LOG_REISGER_CATEGORY(DPRECENT_NAMESPACE)
 void Recent::initialize()
 {
     UrlRoute::regScheme(RecentHelper::scheme(), "/", RecentHelper::icon(), true, tr("Recent"));
-    //注册Scheme为"recent"的扩展的文件信息 本地默认文件的
+    // 注册Scheme为"recent"的扩展的文件信息 本地默认文件的
     InfoFactory::regClass<RecentFileInfo>(RecentHelper::scheme());
     WatcherFactory::regClass<RecentFileWatcher>(RecentHelper::scheme());
     DirIteratorFactory::regClass<RecentDirIterator>(RecentHelper::scheme());

--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -29,7 +29,6 @@ void SideBarEventReceiver::bindEvents()
     static constexpr char kCurrentEventSpace[] { DPF_MACRO_TO_STR(DPSIDEBAR_NAMESPACE) };
 
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_ContextMenu_SetEnable", this, &SideBarEventReceiver::handleSetContextMenuEnable);
-    dpfSlotChannel->connect(kCurrentEventSpace, "slot_Group_UrlList", this, &SideBarEventReceiver::handleGetGroupItems);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Item_Add", this, &SideBarEventReceiver::handleItemAdd);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Item_Remove", this, &SideBarEventReceiver::handleItemRemove);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Item_Update", this, &SideBarEventReceiver::handleItemUpdate);
@@ -69,26 +68,6 @@ void SideBarEventReceiver::handleSidebarUpdateSelection(quint64 winId)
 void SideBarEventReceiver::handleSetContextMenuEnable(bool enable)
 {
     SideBarHelper::contextMenuEnabled = enable;
-}
-
-QList<QUrl> SideBarEventReceiver::handleGetGroupItems(quint64 winId, const QString &group)
-{
-    if (group.isEmpty())
-        return {};
-
-    SideBarWidget *wid { nullptr };
-    for (auto sb : SideBarHelper::allSideBar()) {
-        if (FMWindowsIns.findWindowId(sb) == winId) {
-            wid = sb;
-            break;
-        }
-    }
-
-    if (wid)
-        return wid->findItemUrlsByGroupName(group);
-
-    fmDebug() << "cannot find sidebarwidget for winid: " << winId << group;
-    return {};
 }
 
 bool SideBarEventReceiver::handleItemAdd(const QUrl &url, const QVariantMap &properties)

--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.h
@@ -21,7 +21,6 @@ public:
 
 public slots:
     void handleSetContextMenuEnable(bool enable);
-    QList<QUrl> handleGetGroupItems(quint64 winId, const QString &group);
 
     bool handleItemAdd(const QUrl &url, const QVariantMap &properties);
     bool handleItemRemove(const QUrl &url);

--- a/src/plugins/filemanager/dfmplugin-sidebar/sidebar.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/sidebar.h
@@ -21,7 +21,6 @@ class SideBar : public dpf::Plugin
 
     // slot events
     DPF_EVENT_REG_SLOT(slot_ContextMenu_SetEnable)   // TODO(xust) tmp solution, using GroupPolicy instead.
-    DPF_EVENT_REG_SLOT(slot_Group_UrlList)
     DPF_EVENT_REG_SLOT(slot_Item_Add)
     DPF_EVENT_REG_SLOT(slot_Item_Remove)
     DPF_EVENT_REG_SLOT(slot_Item_Update)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -267,7 +267,7 @@ QWidget *SideBarItemDelegate::createEditor(QWidget *parent, const QStyleOptionVi
     SideBarItem *tgItem = sidebarModel->itemFromIndex(index);
     if (!tgItem)
         return nullptr;
-    auto sourceInfo = InfoFactory::create<FileInfo>(tgItem->url());
+    auto sourceInfo = InfoFactory::create<FileInfo>(tgItem->url(), Global::CreateFileInfoType::kCreateFileInfoSync);
     if (!sourceInfo)
         return nullptr;
     if (!sourceInfo->exists())

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -35,6 +35,7 @@ public:
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 
     bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
+
 public Q_SLOTS:
     void onEditorTextChanged(const QString &text, const FileInfoPointer &info) const;
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -77,9 +77,17 @@ void SideBarViewPrivate::notifyOrderChanged()
     if (draggedGroup.isEmpty())
         return;
 
-    QTimer::singleShot(0, this, [=] {   // this must be invoked after items are sorted finished
+    QTimer::singleShot(0, this, [this] {   // this must be invoked after items are sorted finished
+        QList<QUrl> ret;
+        QList<SideBarItem *> items { q->model()->subItems(draggedGroup) };
+        std::for_each(items.begin(), items.end(), [&ret](SideBarItem *item) {
+            if (!item)
+                return;
+            ret.append(item->url());
+        });
+
         quint64 winId = FMWindowsIns.findWindowId(q);
-        dpfSignalDispatcher->publish("dfmplugin_sidebar", "signal_Sidebar_Sorted", winId, draggedGroup);
+        dpfSignalDispatcher->publish("dfmplugin_sidebar", "signal_Sidebar_Sorted", winId, draggedGroup, ret);
         draggedGroup = "";
     });
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -458,7 +458,7 @@ void SideBarView::startDrag(Qt::DropActions supportedActions)
 
 QModelIndex SideBarView::indexAt(const QPoint &p) const
 {
-    return QTreeView::indexAt(p);
+    return DTreeView::indexAt(p);
 }
 
 bool SideBarView::onDropData(QList<QUrl> srcUrls, QUrl dstUrl, Qt::DropAction action) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -370,7 +370,7 @@ void SideBarView::dropEvent(QDropEvent *event)
     fmDebug() << "source: " << event->mimeData()->urls();
     fmDebug() << "target item: " << item->group() << "|" << item->text() << "|" << item->url();
     fmDebug() << "item->itemInfo().finalUrl: " << item->itemInfo().finalUrl;
-
+    fmDebug() << "item flags:" << item->flags();
     // wayland环境下QCursor::pos()在此场景中不能获取正确的光标当前位置，代替方案为直接使用QDropEvent::pos()
     // QDropEvent::pos() 实际上就是drop发生时光标在该widget坐标系中的position (mapFromGlobal(QCursor::pos()))
     // 但rc本来就是由event->pos()计算item得出的Rect，这样判断似乎就没有意义了（虽然原来的逻辑感觉也没什么意义）
@@ -440,7 +440,7 @@ void SideBarView::dropEvent(QDropEvent *event)
             parentPtr = parentPtr->parentWidget();
         }
         if (curWindow)
-            qApp->setActiveWindow(curWindow);
+            curWindow->activateWindow();
 
         event->accept();
     } else {
@@ -612,12 +612,12 @@ void SideBarView::setPreviousIndex(const QModelIndex &index)
     d->previous = index;
 }
 
-bool SideBarView::isDropTarget(const QModelIndex &index)
+bool SideBarView::isDropTarget(const QModelIndex &index) const
 {
     return index == d->currentHoverIndex;
 }
 
-bool SideBarView::isSideBarItemDragged()
+bool SideBarView::isSideBarItemDragged() const
 {
     return d->isItemDragged;
 }
@@ -699,7 +699,7 @@ Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *
     return action;
 }
 
-bool SideBarView::isAccepteDragEvent(QDropEvent *event)
+bool SideBarView::isAccepteDragEvent(QDropEvent *event) const
 {
     SideBarItem *item = itemAt(event->position().toPoint());
     if (!item) {

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -35,8 +35,8 @@ public:
     QVariantMap groupExpandState() const;
     QModelIndex previousIndex() const;
     void setPreviousIndex(const QModelIndex &index);
-    bool isDropTarget(const QModelIndex &index);
-    bool isSideBarItemDragged();
+    bool isDropTarget(const QModelIndex &index) const;
+    bool isSideBarItemDragged() const;
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;
@@ -49,7 +49,7 @@ protected:
 
     bool onDropData(QList<QUrl> srcUrls, QUrl dstUrl, Qt::DropAction action) const;
     Qt::DropAction canDropMimeData(SideBarItem *item, const QMimeData *data, Qt::DropActions actions) const;
-    bool isAccepteDragEvent(QDropEvent *event);
+    bool isAccepteDragEvent(QDropEvent *event) const;
 
 private:
     inline QString dragEventUrls() const;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -192,20 +192,6 @@ void SideBarWidget::updateItemVisiable(const QVariantMap &states)
     sidebarView->updateSeparatorVisibleState();
 }
 
-QList<QUrl> SideBarWidget::findItemUrlsByGroupName(const QString &group) const
-{
-    Q_ASSERT(kSidebarModelIns);
-    QList<QUrl> ret;
-    QList<SideBarItem *> items { kSidebarModelIns->subItems(group) };
-    std::for_each(items.begin(), items.end(), [&ret](SideBarItem *item) {
-        if (!item)
-            return;
-        ret.append(item->url());
-    });
-
-    return ret;
-}
-
 QList<QUrl> SideBarWidget::findItemUrlsByVisibleControlKey(const QString &key) const
 {
     QList<QUrl> ret;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.h
@@ -42,7 +42,6 @@ public:
     void editItem(const QUrl &url);
     void setItemVisiable(const QUrl &url, bool visible);
     void updateItemVisiable(const QVariantMap &states);
-    QList<QUrl> findItemUrlsByGroupName(const QString &group) const;
     QList<QUrl> findItemUrlsByVisibleControlKey(const QString &key) const;
     void updateSelection();
     void saveStateWhenClose();

--- a/src/tools/upgrade/units/bookmarkupgradeunit.cpp
+++ b/src/tools/upgrade/units/bookmarkupgradeunit.cpp
@@ -30,7 +30,6 @@ static constexpr char kKeyIndex[] { "index" };
 static constexpr char kKeydefaultItem[] { "defaultItem" };
 static constexpr char kKeyCreated[] { "created" };
 static constexpr char kKeyLastModi[] { "lastModified" };
-static constexpr char kKeyLocateUrl[] { "locateUrl" };
 static constexpr char kKeyMountPoint[] { "mountPoint" };
 
 static QString kConfigurationPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager.json";
@@ -41,7 +40,6 @@ QVariantMap BookmarkData::serialize()
     QVariantMap v;
     v.insert(kKeyCreated, created.toString(Qt::ISODate));
     v.insert(kKeyLastModi, lastModified.toString(Qt::ISODate));
-    v.insert(kKeyLocateUrl, locateUrl);
     v.insert(kKeyMountPoint, deviceUrl);
     v.insert(kKeyName, name);
     v.insert(kKeyUrl, url);

--- a/src/tools/upgrade/units/bookmarkupgradeunit.h
+++ b/src/tools/upgrade/units/bookmarkupgradeunit.h
@@ -18,7 +18,6 @@ struct BookmarkData
 {
     QDateTime created;
     QDateTime lastModified;
-    QString locateUrl;
     QString deviceUrl;
     QString name;
     QString transName;


### PR DESCRIPTION
## Summary by Sourcery

This pull request fixes several bugs and introduces enhancements related to bookmark management, sidebar interactions, and text encoding. It removes the unused `locateUrl` field, improves the reliability of bookmark renaming, and enhances the text preview plugin.

Bug Fixes:
- Fixes a bug where the display name of computer items in the sidebar was not being updated when the item was renamed.
- Fixes a crash when renaming a bookmark.
- Fixes a bug where the active window was not being activated when dropping a file onto the sidebar.

Enhancements:
- Removes the `locateUrl` field from the bookmark data structure, simplifying the bookmark management logic.
- Improves text encoding detection for text preview plugin.
- Delays the execution of the `slot_Item_TriggerEdit` signal to avoid issues with the sidebar item not being ready for editing.