### PR TITLE
fix: Improve slider tooltip interaction in view options

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -357,8 +357,12 @@ void ViewOptionsWidget::hideEvent(QHideEvent *event)
 template<typename Func>
 void ViewOptionsWidgetPrivate::connectSliderTip(Dtk::Widget::DSlider *slider, Func getValueList)
 {
-    connect(slider, &DTK_WIDGET_NAMESPACE::DSlider::sliderMoved, this, [this, slider, getValueList](int pos){
-        auto valList = (viewDefines.*getValueList)();
+    auto valList = (viewDefines.*getValueList)();
+    connect(slider, &DSlider::sliderMoved, this, [this, slider, valList](int pos){
         showSliderTips(slider, pos, valList);
+    });
+    connect(slider, &DSlider::sliderPressed, this, [ this, slider, valList ]{
+        int position = slider->slider()->sliderPosition();
+        showSliderTips(slider, position, valList);
     });
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1524,14 +1524,15 @@ void FileView::mouseReleaseEvent(QMouseEvent *event)
 
     d->selectHelper->release();
 
+    if (!QScroller::hasScroller(this))
+        return DListView::mouseReleaseEvent(event);
+
     if (WindowUtils::keyCtrlIsPressed()
         && d->lastMousePressedIndex.isValid()
         && d->lastMousePressedIndex == indexAt(event->pos())) {
         selectionModel()->select(d->lastMousePressedIndex, QItemSelectionModel::Deselect);
     }
 
-    if (!QScroller::hasScroller(this))
-        return DListView::mouseReleaseEvent(event);
 }
 
 void FileView::dragEnterEvent(QDragEnterEvent *event)


### PR DESCRIPTION
Enhance slider tooltip behavior by:
- Showing tooltip when slider is first pressed
- Retrieving value list before connecting signals
- Ensuring tooltip appears on initial slider interaction

This change provides a more consistent and immediate tooltip experience for view option sliders.

Log: Improve slider tooltip interaction in view options
Bug: https://pms.uniontech.com/bug-view-298295.html

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the slider tooltip in view options did not appear on the initial slider interaction.