### PR TITLE
修复几个加密相关的问题

### DIFF
--- a/src/services/diskencrypt/core/cryptsetup.cpp
+++ b/src/services/diskencrypt/core/cryptsetup.cpp
@@ -219,7 +219,7 @@ int crypt_setup_helper::initFileHeader(const QString &dev,
                                  0,
                                  key.data(),
                                  &keySize,
-                                 nullptr,   // use null so that volume key can be get dirrectly from cdev rather than calculate by passphrase
+                                 nullptr,   // use null so that volume key can be get directly from cdev rather than calculate by passphrase
                                  kDefaultPassphraseLen);
         if (r < 0) {
             qWarning() << "cannot get volume key!" << dev << r;

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -283,8 +283,8 @@ BaseEncryptWorker *DiskEncryptSetupPrivate::createDecryptWorker(const QString &t
 
 void DiskEncryptSetupPrivate::initThreadConnection(const QThread *thread)
 {
-    connect(thread, &QThread::started, this, [this] { jobRunning = true; });
-    connect(thread, &QThread::finished, this, [this] { jobRunning = false; });
+    connect(thread, &QThread::started, this, &DiskEncryptSetupPrivate::onLongTimeJobStarted);
+    connect(thread, &QThread::finished, this, &DiskEncryptSetupPrivate::onLongTimeJobStopped);
 }
 
 void DiskEncryptSetupPrivate::onInitEncryptFinished()
@@ -362,4 +362,18 @@ void DiskEncryptSetupPrivate::onPassphraseChanged()
                                 { kKeyDeviceName, args.value(kKeyDeviceName).toString() },
                                 { kKeyOperationResult, code } };
     Q_EMIT qptr->ChangePassResult(result);
+}
+
+void DiskEncryptSetupPrivate::onLongTimeJobStarted()
+{
+    jobRunning = true;
+    qptr->lockTimer(true);
+    qInfo() << "auto quit timer is locked.";
+}
+
+void DiskEncryptSetupPrivate::onLongTimeJobStopped()
+{
+    jobRunning = false;
+    qptr->lockTimer(false);
+    qInfo() << "auto quite timer is unlocked";
 }

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -11,6 +11,7 @@
 #include "helpers/notificationhelper.h"
 #include "helpers/crypttabhelper.h"
 #include "helpers/commonhelper.h"
+#include "helpers/filesystemhelper.h"
 
 #include <dfm-mount/dmount.h>
 
@@ -183,6 +184,7 @@ DiskEncryptSetupPrivate::DiskEncryptSetupPrivate(DiskEncryptSetup *parent)
 void DiskEncryptSetupPrivate::initialize()
 {
     QtConcurrent::run([] {
+        filesystem_helper::remountBoot();
         common_helper::createDFMDesktopEntry();
         crypttab_helper::updateCryptTab();
     });

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -186,6 +186,7 @@ void DiskEncryptSetupPrivate::initialize()
         common_helper::createDFMDesktopEntry();
         crypttab_helper::updateCryptTab();
     });
+    job_file_helper::checkJobs();
     resumeEncryption();
 }
 

--- a/src/services/diskencrypt/dbus/diskencryptsetup_p.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup_p.h
@@ -36,6 +36,9 @@ public Q_SLOTS:
     void onResumeEncryptFinished();
     void onDecryptFinished();
     void onPassphraseChanged();
+
+    void onLongTimeJobStarted();
+    void onLongTimeJobStopped();
 };
 
 #endif   // DISKENCRYPTSETUP_P_H

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -24,7 +24,7 @@ static QString toBase64(const QString rawstr)
 }
 
 inline constexpr char kUSecConfigDir[] { "/etc/usec-crypt" };
-inline constexpr char kReencryptDesktopFile[] { "/usr/share/applications/dfm-reencrypt.desktop" };
+inline constexpr char kReencryptDesktopFile[] { "/usr/local/share/applications/dfm-reencrypt.desktop" };
 inline constexpr char kRebootFlagFilePrefix[] { "/tmp/dfm_encrypt_reboot_flag_" };
 
 namespace job_type {

--- a/src/services/diskencrypt/helpers/commonhelper.cpp
+++ b/src/services/diskencrypt/helpers/commonhelper.cpp
@@ -10,6 +10,7 @@
 #include <QFile>
 #include <QLibrary>
 #include <QRandomGenerator>
+#include <QDir>
 
 #include <DConfig>
 
@@ -17,6 +18,13 @@ FILE_ENCRYPT_USE_NS
 
 void common_helper::createDFMDesktopEntry()
 {
+    const QString &kLocalShareApps  = "/usr/local/share/applications";
+    QDir d(kLocalShareApps);
+    if (!d.exists()) {
+        auto ok = d.mkpath(kLocalShareApps);
+        qInfo() << kLocalShareApps << "dir created?" << ok;
+    }
+
     QFile f(disk_encrypt::kReencryptDesktopFile);
     if (f.exists())
         return;

--- a/src/services/diskencrypt/helpers/cryptsetupcompabilityhelper.cpp
+++ b/src/services/diskencrypt/helpers/cryptsetupcompabilityhelper.cpp
@@ -24,7 +24,7 @@ CryptSetupCompabilityHelper *CryptSetupCompabilityHelper::instance()
 CryptSetupCompabilityHelper::CryptSetupCompabilityHelper(QObject *parent)
     : QObject { parent }
 {
-    m_libCryptsetup = new QLibrary("cryptsetup", this);
+    m_libCryptsetup = new QLibrary("libcryptsetup.so.12", this);
     if (!m_libCryptsetup->load()) {
         qWarning() << "cannot load cryptsetup!";
         return;

--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -107,6 +107,9 @@ QList<crypttab_helper::CryptItem> crypttab_helper::cryptItems()
     QList<CryptItem> ret;
 
     for (auto item : items) {
+        if (item.isEmpty())
+            continue;
+
         auto fields = QString(item).split(QRegularExpression(R"( |\t)"), Qt::SkipEmptyParts);
         if (fields.count() < 4) {
             qInfo() << "found invalid crypt line" << item;
@@ -155,10 +158,8 @@ void crypttab_helper::saveCryptItems(const QList<CryptItem> &items)
 
 void crypttab_helper::updateInitramfs()
 {
-    QtConcurrent::run([] {
-        auto fd = inhibit_helper::inhibit("Updating initramfs...");
-        qInfo() << "start update initramfs...";
-        system("update-initramfs -u");
-        qInfo() << "initramfs updated.";
-    });
+    auto fd = inhibit_helper::inhibit("Updating initramfs...");
+    qInfo() << "start update initramfs...";
+    system("update-initramfs -u");
+    qInfo() << "initramfs updated.";
 }

--- a/src/services/diskencrypt/helpers/filesystemhelper.h
+++ b/src/services/diskencrypt/helpers/filesystemhelper.h
@@ -13,6 +13,8 @@ bool shrinkFileSystem_ext(const QString &device);
 bool expandFileSystem_ext(const QString &device);
 
 bool moveFsForward(const QString &dev);
+
+void remountBoot();
 }   // namespace filesystem_helper
 
 FILE_ENCRYPT_END_NS

--- a/src/services/diskencrypt/helpers/jobfilehelper.cpp
+++ b/src/services/diskencrypt/helpers/jobfilehelper.cpp
@@ -15,7 +15,7 @@ inline constexpr char kUSecOtherConfig[] { "/etc/usec-crypt/encrypt_%1.json" };
 
 FILE_ENCRYPT_USE_NS
 
-int job_file_helper::createEncryptJobFile(const JobDescArgs &args)
+int job_file_helper::createEncryptJobFile(JobDescArgs &args)
 {
     createUSecRoot();
 
@@ -47,13 +47,15 @@ int job_file_helper::createEncryptJobFile(const JobDescArgs &args)
         return -disk_encrypt::kErrorOpenFileFailed;
     }
 
+    args.jobFile = fileName;
+
     f.write(doc.toJson());
     f.flush();
     f.close();
     return 0;
 }
 
-int job_file_helper::createDecryptJobFile(const JobDescArgs &args)
+int job_file_helper::createDecryptJobFile(JobDescArgs &args)
 {
     createUSecRoot();
 

--- a/src/services/diskencrypt/helpers/jobfilehelper.h
+++ b/src/services/diskencrypt/helpers/jobfilehelper.h
@@ -45,6 +45,7 @@ int createDecryptJobFile(const JobDescArgs &args);
 int loadEncryptJobFile(JobDescArgs *args, const QString &dev = QString());
 int loadDecryptJobFile(JobDescArgs *args = nullptr);
 int removeJobFile(const QString &jobFile);
+void checkJobs();
 
 bool hasJobFile();
 QStringList validJobTypes();

--- a/src/services/diskencrypt/helpers/jobfilehelper.h
+++ b/src/services/diskencrypt/helpers/jobfilehelper.h
@@ -40,8 +40,8 @@ struct JobDescArgs
 };
 
 int createUSecRoot();
-int createEncryptJobFile(const JobDescArgs &args);
-int createDecryptJobFile(const JobDescArgs &args);
+int createEncryptJobFile(JobDescArgs &args);
+int createDecryptJobFile(JobDescArgs &args);
 int loadEncryptJobFile(JobDescArgs *args, const QString &dev = QString());
 int loadDecryptJobFile(JobDescArgs *args = nullptr);
 int removeJobFile(const QString &jobFile);

--- a/src/services/diskencrypt/workers/dminitencryptworker.h
+++ b/src/services/diskencrypt/workers/dminitencryptworker.h
@@ -19,7 +19,7 @@ public:
 protected:
     void run() override;
 
-    job_file_helper::JobDescArgs initJobArgs(const QString &phyDev);
+    job_file_helper::JobDescArgs initJobArgs(const QString &phyDev, const QString &unlockName);
     static int detachPhyDevice(int argc, const char *argv[]);
 };
 FILE_ENCRYPT_END_NS

--- a/src/services/diskencrypt/workers/fstabdecryptworker.cpp
+++ b/src/services/diskencrypt/workers/fstabdecryptworker.cpp
@@ -39,9 +39,10 @@ void FstabDecryptWorker::run()
         setExitCode(-disk_encrypt::kErrorUnknown);
         return;
     }
-    job_file_helper::createDecryptJobFile({ .device = "PARTUUID=" + partUUID,
-                                            .devPath = devPath,
-                                            .devType = disk_encrypt::job_type::TypeFstab });
+    job_file_helper::JobDescArgs jobArgs {.device = "PARTUUID=" + partUUID,
+                                           .devPath = devPath,
+                                           .devType = disk_encrypt::job_type::TypeFstab };
+    job_file_helper::createDecryptJobFile(jobArgs);
     auto clearUUID = clearDeviceUUID(devPath);
     if (!clearUUID.isEmpty())
         fstab_helper::setFstabPassno("UUID=" + clearUUID, 0);

--- a/src/services/diskencrypt/workers/fstabinitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/fstabinitencryptworker.cpp
@@ -40,7 +40,8 @@ void FstabInitEncryptWorker::run()
 
     fstab_helper::setFstabTimeout(devPath, devUUID);
     common_helper::createRebootFlagFile(devPath);
-    job_file_helper::createEncryptJobFile(initJobArgs(devPath));
+    auto jobArgs = initJobArgs(devPath);
+    job_file_helper::createEncryptJobFile(jobArgs);
     setExitCode(-disk_encrypt::kRebootRequired);
 
     qInfo() << "fstab device encrypt job created, request for reboot.";

--- a/src/services/diskencrypt/workers/normalinitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/normalinitencryptworker.cpp
@@ -34,7 +34,8 @@ void NormalInitEncryptWorker::run()
         return;
     }
 
-    job_file_helper::createEncryptJobFile(initJobArgs(blkPtr));
+    auto jobArgs = initJobArgs(blkPtr);
+    job_file_helper::createEncryptJobFile(jobArgs);
     setExitCode(disk_encrypt::kSuccess);
     qInfo() << "normal device encryption inited." << devPath;
 }

--- a/src/services/diskencrypt/workers/resumeencryptworker.cpp
+++ b/src/services/diskencrypt/workers/resumeencryptworker.cpp
@@ -50,14 +50,13 @@ void ResumeEncryptWorker::ignoreAuthRequest()
 
 void ResumeEncryptWorker::run()
 {
-    qInfo() << "about to resume encryption...";
-
     job_file_helper::loadEncryptJobFile(&m_jobArgs);
     if (m_jobArgs.jobFile.isEmpty()) {
         qInfo() << "no unfinished reencrypt job.";
         return;
     }
 
+    qInfo() << "about to resume encryption...";
     auto fd = inhibit_helper::inhibit(tr("Encrypting ") + m_jobArgs.devPath);
 
     auto status = crypt_setup_helper::encryptStatus(m_jobArgs.devPath);


### PR DESCRIPTION
- **fix: validate encrypt jobs on launch**
- **fix: encrypt service auto quit while working**
- **fix: system crash after dm device suspended.**

## Summary by Sourcery

This pull request addresses several encryption-related issues, including validating encryption jobs on launch, preventing the encryption service from quitting prematurely, and resolving a system crash after DM device suspension.

Bug Fixes:
- Fixes an issue where encryption jobs were not validated on launch.
- Fixes an issue where the encryption service would automatically quit while working.
- Fixes a system crash that occurred after a DM device was suspended.