### PR TITLE
fix: truncate the excessively long shared name

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.h
@@ -12,6 +12,7 @@
 
 #include <DLabel>
 #include <DTipLabel>
+#include <DLineEdit>
 #include <DCommandLinkButton>
 #include <DArrowLineDrawer>
 #include <QUrl>
@@ -61,6 +62,7 @@ protected Q_SLOTS:
     void updateWidgetStatus(const QString &filePath);
     void updateFile(const QUrl &oldOne, const QUrl &newOne);
     void onSambaPasswordSet(bool result);
+    void onShareNameChanged(const QString &name);
 
 private:
     void showMoreInfo(bool showMore);
@@ -71,7 +73,7 @@ private:
     QVBoxLayout *mainLayout { Q_NULLPTR };
     QFrame *moreInfoFrame { Q_NULLPTR };
     QCheckBox *shareSwitcher { Q_NULLPTR };
-    QLineEdit *shareNameEditor { Q_NULLPTR };
+    DTK_WIDGET_NAMESPACE::DLineEdit *shareNameEditor { Q_NULLPTR };
     QComboBox *sharePermissionSelector { Q_NULLPTR };
     QComboBox *shareAnonymousSelector { Q_NULLPTR };
 


### PR DESCRIPTION
if byte size of share name larger than 150, alert the info and truncate the name.
and set default share name if the editor is empty when share triggered.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-302169.html

## Summary by Sourcery

Fixes a bug where the share name could be excessively long, causing issues. It truncates the share name if it exceeds 150 bytes and displays an alert message. It also sets a default share name if the editor is empty when sharing is triggered.

Bug Fixes:
- Truncates the share name if it exceeds 150 bytes.
- Sets a default share name if the editor is empty when sharing is triggered.