### PR TITLE
fix: Enhance server connection history management

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -125,6 +125,7 @@ void ConnectToServerDialog::onCurrentTextChanged(const QString &string)
         serverComboBox->completer()->setModel(new QStringListModel());
 
         SearchHistroyManager::instance()->clearHistory(supportedSchemes);
+        SearchHistroyManager::instance()->clearIPHistory();
     }
 }
 
@@ -161,6 +162,7 @@ void ConnectToServerDialog::onCurrentInputChanged(const QString &server)
         serverComboBox->clearEditText();
         serverComboBox->completer()->setModel(new QStringListModel());
         SearchHistroyManager::instance()->clearHistory(supportedSchemes);
+        SearchHistroyManager::instance()->clearIPHistory();
         Application::appObtuselySetting()->sync();
     }
 
@@ -294,6 +296,7 @@ void ConnectToServerDialog::initServerDatas()
 
     if (!hosts.isEmpty()) {
         onCurrentInputChanged(hosts.last());
+        serverComboBox->setCurrentText(hosts.last());
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.cpp
@@ -140,3 +140,8 @@ void SearchHistroyManager::clearHistory(const QStringList &schemeFilters)
         Application::appObtuselySetting()->setValue(kConfigGroupName, kConfigSearchHistroy, historyList);
     }
 }
+
+void SearchHistroyManager::clearIPHistory()
+{
+    Application::appObtuselySetting()->setValue(kConfigGroupName, kConfigIPHistroy, {});
+}

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.h
@@ -25,6 +25,7 @@ public:
     void writeIntoIPHistory(const QString &ipAddr);
     bool removeSearchHistory(QString keyword);
     void clearHistory(const QStringList &schemeFilters = QStringList());
+    void clearIPHistory();
 
 private:
     explicit SearchHistroyManager(QObject *parent = nullptr);


### PR DESCRIPTION
Improve the handling of server connection history by:
- Adding a method to clear IP connection history
- Automatically setting the last connected server in the server connection dialog
- Ensuring a clean history state when changing server types

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-304081.html

## Summary by Sourcery

Improves server connection history management by adding a method to clear IP connection history, automatically setting the last connected server in the server connection dialog, and ensuring a clean history state when changing server types.

Bug Fixes:
- Fixes a bug related to server connection history management.
- Ensures a clean history state when changing server types by clearing the IP history.