### PR TITLE
fix: Add file creation time to canvas sorting options

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/model/canvasproxymodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/canvasproxymodel.cpp
@@ -299,6 +299,7 @@ bool CanvasProxyModelPrivate::lessThan(const QUrl &left, const QUrl &right) cons
     };
 
     switch (fileSortRole) {
+    case kItemFileCreatedRole:
     case kItemFileLastModifiedRole:
     case kItemFileMimeTypeRole:
     case kItemFileDisplayNameRole: {


### PR DESCRIPTION
Extend the canvas sorting functionality by adding support for sorting files by creation time. This change introduces the kItemFileCreatedRole to the existing sorting switch statement, enabling users to sort files based on their creation timestamp.

Log: fix files sort issue
Bug: https://pms.uniontech.com/bug-view-305661.html

## Summary by Sourcery

Enhancements:
- Extends the canvas sorting functionality to include sorting by file creation time.