### PR TITLE
fix: wrong require names in dfm6-base.pc

### DIFF
--- a/assets/dev/dfm6-base/dfm6-base.pc.in
+++ b/assets/dev/dfm6-base/dfm6-base.pc.in
@@ -2,7 +2,7 @@ Name: @BIN_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: dfm6-io dfm6-mount dfm6-burn Qt6Core Qt6Widgets Qt6Gui Qt6Concurrent Qt6DBus Qt6Sql Qt6Network dtkcore6 dtkgui6 dtkwidget6
+Requires: dfm6-io dfm6-mount dfm6-burn Qt6Core Qt6Widgets Qt6Gui Qt6Concurrent Qt6DBus Qt6Sql Qt6Network dtk6core dtk6gui dtk6widget
 Cflags: -I"@CMAKE_INSTALL_FULL_INCLUDEDIR@"
 Libs: -L"@CMAKE_INSTALL_FULL_LIBDIR@" -l@BIN_NAME@
 Libs.private: -L"@CMAKE_INSTALL_FULL_LIBDIR@" -l@BIN_NAME@


### PR DESCRIPTION
change require name:
dtkcore6 -> dtk6core
dtkgui6 -> dtk6gui
dtkwidget6 -> dtk6widget

Log: wrong require names in dfm6-base.pc

## Summary by Sourcery

Bug Fixes:
- Fix incorrect library names in dfm6-base.pc, changing 'dtkcore6' to 'dtk6core', 'dtkgui6' to 'dtk6gui', and 'dtkwidget6' to 'dtk6widget'.