### PR TITLE
fix: Improve device mount error handling and cursor state management

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
@@ -185,8 +185,9 @@ QString ErrorMessageAndAction::errorToStringByCause(const QUrl &url, const Abstr
     case AbstractJobHandler::JobErrorType::kOpenError:
         return tr("Failed to open the file %1, cause: %2").arg(url.path(), errorMsg);
     case AbstractJobHandler::JobErrorType::kReadError:
-    case AbstractJobHandler::JobErrorType::kCreateParentDirError:
         return tr("Failed to read the file %1, cause: %2").arg(url.path(), errorMsg);
+    case AbstractJobHandler::JobErrorType::kCreateParentDirError:
+        return tr("Restore failed, original path could not be found");
     case AbstractJobHandler::JobErrorType::kWriteError:
         return tr("Failed to write the file %1, cause: %2").arg(url.path(), errorMsg);
     case AbstractJobHandler::JobErrorType::kMkdirError:

--- a/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
@@ -346,8 +346,8 @@ void ComputerController::mountDevice(quint64 winId, const QString &id, const QSt
     ComputerUtils::setCursorState(true);
     DevMngIns->mountBlockDevAsync(id, {}, [=](bool ok, const DFMMOUNT::OperationErrorInfo &err, const QString &mpt) {
         if (!ok) {
+            ComputerUtils::setCursorState();
             if (err.code == DFMMOUNT::DeviceError::kUDisksErrorNotAuthorizedDismissed) {
-                ComputerUtils::setCursorState();
                 return;
             }
             fmInfo() << "mount device failed: " << id << err.message << err.code;

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
@@ -101,6 +101,7 @@ void travers_prehandler::networkAccessPrehandler(quint64 winId, const QUrl &url,
         } else if (ok || err.code == DFMMOUNT::DeviceError::kGIOErrorAlreadyMounted) {
             if (isSmb) onSmbRootMounted(mountSource, after);
         } else {
+            QApplication::restoreOverrideCursor();
             onMountFailed(err);
         }
     });


### PR DESCRIPTION
Refactored device mount error handling in two plugins:
- In ComputerController, moved cursor state reset before early return
- In SMB browser, added cursor restoration on mount failure

This change ensures proper UI feedback and cursor state during device mounting operations.

Log: fix cursor state issue
Bug: https://pms.uniontech.com/bug-view-306077.html

## Summary by Sourcery

Improves device mount error handling by ensuring the cursor state is properly managed and restored in case of mount failures. This prevents the cursor from getting stuck in a busy state and provides better UI feedback.

Bug Fixes:
- Resets cursor state before early return in ComputerController to avoid getting stuck in busy state.
- Restores cursor in SMB browser on mount failure to provide proper UI feedback.