### PR TITLE
fix: Improve network device mount history management

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -733,7 +733,7 @@ void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType
     auto func = std::bind(DeviceManagerPrivate::askForPasswdWhenMountNetworkDevice, _1, _2, _3, address);
 
     auto wrappedCb = [=](bool ok, const OperationErrorInfo &err, const QString &msg) {
-        Q_EMIT mountNetworkDeviceResult(ok, err.code, err.code == DeviceError::kNoError ? msg : err.message);
+        Q_EMIT mountNetworkDeviceResult(address, ok, err.code, err.code == DeviceError::kNoError ? msg : err.message);
         if (cb) cb(ok, err, msg);
         QApplication::restoreOverrideCursor();
     };

--- a/src/dfm-base/base/device/devicemanager.h
+++ b/src/dfm-base/base/device/devicemanager.h
@@ -127,7 +127,7 @@ Q_SIGNALS:
 
     void opticalDiscWorkStateChanged(const QString &id, const QString &dev, bool working);
 
-    void mountNetworkDeviceResult(bool ret, DFMMOUNT::DeviceError err, const QString &msg);
+    void mountNetworkDeviceResult(const QString &address, bool ret, DFMMOUNT::DeviceError err, const QString &msg);
 
     void blockDevMountedManually(const QString &id, const QString &mpt);
 

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.cpp
@@ -113,7 +113,7 @@ void ReportLogEventReceiver::handleBlockMountData(const QString &id, bool result
     ReportLogManager::instance()->reportBlockMountData(id, result);
 }
 
-void ReportLogEventReceiver::handleMountNetworkResult(bool ret, dfmmount::DeviceError err, const QString &msg)
+void ReportLogEventReceiver::handleMountNetworkResult(const QString &, bool ret, dfmmount::DeviceError err, const QString &msg)
 {
     ReportLogManager::instance()->reportNetworkMountData(ret, err, msg);
 }

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.h
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogeventreceiver.h
@@ -25,7 +25,7 @@ public:
 
 public Q_SLOTS:
     void handleBlockMountData(const QString &id, bool result);
-    void handleMountNetworkResult(bool ret, DFMMOUNT::DeviceError err, const QString &msg);
+    void handleMountNetworkResult(const QString &address, bool ret, DFMMOUNT::DeviceError err, const QString &msg);
     void handleDesktopStartupData(const QString &key, const QVariant &data);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -53,7 +53,6 @@ DWIDGET_USE_NAMESPACE
 
 static constexpr char kConnectServer[] { "ConnectServer" };
 static constexpr char kUrl[] { "URL" };
-static constexpr char kprotocolIPRegExp[] { R"(^((smb)|(ftp)|(sftp))(://)((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}$)" };
 static const int kMaxHistoryItems = 10;
 static constexpr char kGBKCharset[] { "gbk" };
 static constexpr char kUTF8CharSet[] { "utf8" };
@@ -71,9 +70,6 @@ ConnectToServerDialog::ConnectToServerDialog(const QUrl &url, QWidget *parent)
     setWindowTitle(tr("Connect to Server"));
     initializeUi();
     initConnect();
-
-    protocolIPRegExp.setPattern(kprotocolIPRegExp);
-    protocolIPRegExp.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
 }
 
 void ConnectToServerDialog::collectionOperate()
@@ -102,13 +98,11 @@ void ConnectToServerDialog::onButtonClicked(const int &index)
             QDir::setCurrent(currentUrl.toLocalFile());
         QDir::setCurrent(currentDir);
 
+        // add search history list
+        SearchHistroyManager::instance()->addIPHistoryCache(url);
+
         QWidget *fileWindow = qobject_cast<QWidget *>(parent());
         TitleBarHelper::handleJumpToPressed(fileWindow, url);
-
-        // add search history list
-        SearchHistroyManager::instance()->writeIntoSearchHistory(url);
-        if (protocolIPRegExp.match(url).hasMatch())
-            SearchHistroyManager::instance()->writeIntoIPHistory(url);
     }
     close();
 }
@@ -294,10 +288,8 @@ void ConnectToServerDialog::initServerDatas()
 
     completer->setModel(new QStringListModel(hosts));
 
-    if (!hosts.isEmpty()) {
+    if (!hosts.isEmpty())
         onCurrentInputChanged(hosts.last());
-        serverComboBox->setCurrentText(hosts.last());
-    }
 }
 
 QStringList ConnectToServerDialog::updateCollections(const QString &newUrlStr, bool insertWhenNoExist)

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.h
@@ -10,7 +10,6 @@
 #include <DDialog>
 #include <DFrame>
 #include <QUrl>
-#include <QRegularExpression>
 
 DWIDGET_BEGIN_NAMESPACE
 class DIconButton;
@@ -66,7 +65,6 @@ private:
         kConnectButton
     };
 
-    QRegularExpression protocolIPRegExp;   // smb://ip, ftp://ip, sftp://ip
     QUrl currentUrl;
     QStringList supportedSchemes;
     DTK_WIDGET_NAMESPACE::DComboBox *serverComboBox { nullptr };

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.h
@@ -7,7 +7,10 @@
 
 #include "dfmplugin_titlebar_global.h"
 
+#include <dfm-mount/base/dmount_global.h>
+
 #include <QObject>
+#include <QRegularExpression>
 
 namespace dfmplugin_titlebar {
 
@@ -22,13 +25,19 @@ public:
     QStringList getSearchHistroy();
     QList<IPHistroyData> getIPHistory();
     void writeIntoSearchHistory(QString keyword);
-    void writeIntoIPHistory(const QString &ipAddr);
+    void addIPHistoryCache(const QString &address);
     bool removeSearchHistory(QString keyword);
     void clearHistory(const QStringList &schemeFilters = QStringList());
     void clearIPHistory();
 
 private:
     explicit SearchHistroyManager(QObject *parent = nullptr);
+    void handleMountNetworkResult(const QString &address, bool ret, DFMMOUNT::DeviceError err, const QString &msg);
+    bool isValidMount(const QString &address, bool ret, dfmmount::DeviceError err);
+    void writeIntoIPHistory(const QString &ipAddr);
+
+    QRegularExpression protocolIPRegExp;   // smb://ip, ftp://ip, sftp://ip
+    QStringList ipAddressCache;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
@@ -106,7 +106,7 @@ void AddressBarPrivate::initConnect()
 void AddressBarPrivate::initData()
 {
     ipRegExp.setPattern(R"(^((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}$)");
-    protocolIPRegExp.setPattern(R"(^((smb)|(ftp)|(sftp))(://)((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}$)");
+    protocolIPRegExp.setPattern(R"(^((smb)|(ftp)|(sftp))(://)((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}/*$)");
     protocolIPRegExp.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
 
     // 设置补全组件
@@ -360,15 +360,10 @@ void AddressBarPrivate::onReturnPressed()
     // add search history list
     if (!dfmbase::FileUtils::isLocalFile(UrlRoute::fromUserInput(text))) {
         if (protocolIPRegExp.match(text).hasMatch()) {
-            IPHistroyData data(text, QDateTime::currentDateTime());
-            if (ipHistroyList.contains(data)) {
-                // update
-                int index = ipHistroyList.indexOf(data);
-                ipHistroyList.replace(index, data);
-            } else {
-                ipHistroyList << data;
+            while (text.endsWith("/")) {
+                text.chop(1);
             }
-            SearchHistroyManager::instance()->writeIntoIPHistory(text);
+            SearchHistroyManager::instance()->addIPHistoryCache(text);
         }
     }
 


### PR DESCRIPTION
Enhance the handling of network device mount history by:
- Adding a new signal parameter for network device mount results
- Implementing a caching mechanism for IP addresses during mount attempts
- Updating the IP history writing process to occur after successful mount

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-304089.html

## Summary by Sourcery

Improves network device mount history management by introducing a caching mechanism for IP addresses during mount attempts and updating the IP history writing process to occur after successful mount.

Bug Fixes:
- Fixes an issue where network device mount history was not being properly managed, leading to incorrect or incomplete history records.
- Fixes a bug where the IP history was written before a successful mount, leading to incorrect entries in the history.