### PR TITLE
fix: Remove unnecessary background color update method in AdvanceSearchBar

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
@@ -152,7 +152,7 @@ void AdvanceSearchBarPrivate::initUI()
     q->setWidget(this);
     q->setFrameShape(QFrame::NoFrame);
     q->setAutoFillBackground(true);   // 允许自动填充背景
-    updateBackgroundColor();
+    q->setBackgroundRole(QPalette::Base);
     // 启用横向滚动条
     q->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     // 禁用竖向滚动条
@@ -161,7 +161,6 @@ void AdvanceSearchBarPrivate::initUI()
 
 void AdvanceSearchBarPrivate::initConnection()
 {
-    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &AdvanceSearchBarPrivate::updateBackgroundColor);
     connect(resetBtn, &DCommandLinkButton::pressed, q, &AdvanceSearchBar::onResetButtonPressed);
 
     for (int i = 0; i < kLabelCount; i++) {
@@ -294,20 +293,6 @@ void AdvanceSearchBarPrivate::saveOptions(QMap<int, QVariant> &options)
     currentSearchUrl = url;
     options[AdvanceSearchBarPrivate::kCurrentUrl] = currentSearchUrl;
     filterInfoCache[currentSearchUrl] = options;
-}
-
-void AdvanceSearchBarPrivate::updateBackgroundColor()
-{
-    QPalette palette = q->palette();
-
-    QColor bgColor;
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType)
-        bgColor.setRgb(255, 255, 255);
-    else
-        bgColor.setRgb(40, 40, 40);
-
-    palette.setColor(QPalette::Window, bgColor);
-    q->setPalette(palette);
 }
 
 bool AdvanceSearchBarPrivate::shouldVisiableByFilterRule(FileInfo *info, QVariant data)

--- a/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar_p.h
+++ b/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar_p.h
@@ -73,9 +73,6 @@ public:
     static bool shouldVisiableByFilterRule(DFMBASE_NAMESPACE::FileInfo *info, QVariant data);
     static FileFilter parseFilterData(const QMap<int, QVariant> &data);
 
-public Q_SLOTS:
-    void updateBackgroundColor();
-
 public:
     QBoxLayout *mainLayout;
     DLabel *asbLabels[kLabelCount];


### PR DESCRIPTION
This commit simplifies the AdvanceSearchBar by:
- Removing the updateBackgroundColor() method
- Removing the theme change connection
- Using setBackgroundRole() instead of manual palette manipulation

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-306481.html

## Summary by Sourcery

Bug Fixes:
- Removes unnecessary background color update method.