### PR TITLE
修复分区加密相关的问题

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.DiskEncrypt.xml
+++ b/assets/dbus/org.deepin.Filemanager.DiskEncrypt.xml
@@ -61,6 +61,10 @@
       <arg type="i" direction="out"/>
       <arg name="dev" type="s" direction="in"/>
     </method>
+    <method name="HolderDevice">
+      <arg type="s" direction="out"/>
+      <arg name="dev" type="s" direction="in"/>
+    </method>
     <method name="IsTaskEmpty">
       <arg type="b" direction="out"/>
     </method>

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -140,6 +140,18 @@ void EventsHandler::resumeEncrypt(const QString &device)
     iface.asyncCall("ResumeEncryption", QVariantMap());
 }
 
+QString EventsHandler::holderDevice(const QString &device)
+{
+    QDBusInterface iface(kDaemonBusName,
+                         kDaemonBusPath,
+                         kDaemonBusIface,
+                         QDBusConnection::systemBus());
+    QDBusReply<QString> reply = iface.call("HolderDevice", device);
+    if (reply.isValid())
+        return reply.value();
+    return device;
+}
+
 void EventsHandler::onInitEncryptFinished(const QVariantMap &result)
 {
     QApplication::restoreOverrideCursor();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -310,7 +310,8 @@ void EventsHandler::onEncryptProgress(const QString &dev, const QString &devName
     }
     auto dlg = encryptDialogs.value(dev);
     dlg->updateProgress(progress);
-    dlg->show();
+    if (!dlg->isVisible())
+        dlg->show();
 
     // when start encrypt, delete the inputs widget.
     if (encryptInputs.contains(dev))
@@ -331,7 +332,8 @@ void EventsHandler::onDecryptProgress(const QString &dev, const QString &devName
 
     auto dlg = decryptDialogs.value(dev);
     dlg->updateProgress(progress);
-    dlg->show();
+    if (!dlg->isVisible())
+        dlg->show();
 }
 
 bool EventsHandler::onAcquireDevicePwd(const QString &dev, QString *pwd, bool *cancelled)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -137,7 +137,7 @@ void EventsHandler::resumeEncrypt(const QString &device)
                          kDaemonBusPath,
                          kDaemonBusIface,
                          QDBusConnection::systemBus());
-    iface.asyncCall("ResumeEncryption", QVariantMap());
+    iface.asyncCall("ResumeEncryption", QVariantMap{{encrypt_param_keys::kKeyDevice, device}});
 }
 
 QString EventsHandler::holderDevice(const QString &device)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -23,6 +23,7 @@ public:
     bool isUnderOperating(const QString &device);
     int deviceEncryptStatus(const QString &device);
     void resumeEncrypt(const QString &device);
+    QString holderDevice(const QString &device);
     bool onAcquireDevicePwd(const QString &dev, QString *pwd, bool *giveup);
     void autoStartDFM();
 

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -38,7 +38,8 @@ void EncryptProgressDialog::updateProgress(double progress)
     if (val < 0) val = 0;
     this->progress->setValue(val);
     clearButtons();
-    setCloseButtonVisible(false);
+    if (closeButtonVisible())
+        setCloseButtonVisible(false);
 }
 
 void EncryptProgressDialog::showResultPage(bool success, const QString &title, const QString &message)

--- a/src/services/diskencrypt/core/cryptsetup.cpp
+++ b/src/services/diskencrypt/core/cryptsetup.cpp
@@ -765,7 +765,7 @@ int crypt_setup::csActivateDevice(const QString &dev, const QString &activateNam
                                          CRYPT_ANY_SLOT,
                                          passphrase.toStdString().c_str(),
                                          passphrase.length(),
-                                         CRYPT_ACTIVATE_NO_JOURNAL);
+                                         CRYPT_ACTIVATE_SHARED);
         if (r < 0) {
             qWarning() << "cannot activate device!" << dev << r;
             return -disk_encrypt::kErrorActive;
@@ -865,7 +865,7 @@ int crypt_setup::csActivateDeviceByVolume(const QString &dev, const QString &act
                                          activateName.toStdString().c_str(),
                                          volume.data(),
                                          volume.length(),
-                                         0);
+                                         CRYPT_ACTIVATE_SHARED);
         if (r < 0) {
             qWarning() << "cannot activate device!" << dev << r;
             return -disk_encrypt::kErrorActive;

--- a/src/services/diskencrypt/core/cryptsetup.cpp
+++ b/src/services/diskencrypt/core/cryptsetup.cpp
@@ -28,13 +28,13 @@ static const int kDefaultPassphraseLen { 0 };
 
 FILE_ENCRYPT_USE_NS
 
-int crypt_setup::csInitEncrypt(const QString &dev, CryptPreProcessor *processor)
+int crypt_setup::csInitEncrypt(const QString &dev, const QString &displayName, CryptPreProcessor *processor)
 {
     int r = crypt_setup_helper::initiable(dev);
     if (r < 0) return r;
 
     QString fileHeader;
-    r = crypt_setup_helper::initEncryptHeaderFile(dev, processor, &fileHeader);
+    r = crypt_setup_helper::initEncryptHeaderFile(dev, displayName, processor, &fileHeader);
     if (r < 0) return r;
 
     r = crypt_setup_helper::initDeviceHeader(dev, fileHeader);
@@ -78,7 +78,7 @@ int crypt_setup_helper::initiable(const QString &dev)
     return disk_encrypt::kSuccess;
 }
 
-int crypt_setup_helper::initEncryptHeaderFile(const QString &dev,
+int crypt_setup_helper::initEncryptHeaderFile(const QString &dev, const QString &displayName,
                                               crypt_setup::CryptPreProcessor *processor,
                                               QString *fileHeader)
 {
@@ -158,6 +158,12 @@ int crypt_setup_helper::initEncryptHeaderFile(const QString &dev,
     if (r < 0) {
         qWarning() << "cannot add empty keyslot!" << dev << r;
         return -disk_encrypt::kErrorAddKeyslot;
+    }
+
+    if (!displayName.isEmpty()) {
+        r = crypt_set_label(cdev, displayName.toStdString().c_str(), nullptr);
+        if (r < 0)
+            qWarning() << "cannot set label on" << dev << displayName << r;
     }
 
     struct crypt_params_luks2 luksArgs

--- a/src/services/diskencrypt/core/cryptsetup.h
+++ b/src/services/diskencrypt/core/cryptsetup.h
@@ -9,6 +9,9 @@
 
 FILE_ENCRYPT_BEGIN_NS
 
+static constexpr char kUSecBootRoot[] { "/boot/usec-crypt" };
+static constexpr char kUSecDetachHeaderPrefix[] { "dm-decrypt-backup-" };
+
 namespace crypt_setup {
 struct CryptPreProcessor
 {
@@ -32,16 +35,17 @@ int csSetLabel(const QString &dev, const QString &label);
 
 namespace crypt_setup_helper {
 int initiable(const QString &dev);
-int initFileHeader(const QString &dev, crypt_setup::CryptPreProcessor *processor, QString *fileHeader = nullptr);
+int createHeaderFile(const QString &dev, QString *headerPath);
+int initEncryptHeaderFile(const QString &dev, crypt_setup::CryptPreProcessor *processor, QString *fileHeader = nullptr);
 int initDeviceHeader(const QString &dev, const QString &fileHeader);
-int backupHeaderFile(const QString &dev, QString *fileHeader = nullptr);
+int genDetachHeaderPath(const QString &dev, QString *name = nullptr);
+int backupDetachHeader(const QString &dev, QString *fileHeader = nullptr);
 int headerStatus(const QString &fileHeader);
+int encryptStatus(const QString &dev);
 int setToken(const QString &dev, const QString &token);
 int getToken(const QString &dev, QString *token);
 int onEncrypting(uint64_t size, uint64_t offset, void *usrptr);
 int onDecrypting(uint64_t size, uint64_t offset, void *usrptr);
-int createHeaderFile(const QString &dev, QString *headerPath);
-int encryptStatus(const QString &dev);
 
 enum HeaderStatus {
     kInvalidHeader = -1,

--- a/src/services/diskencrypt/core/cryptsetup.h
+++ b/src/services/diskencrypt/core/cryptsetup.h
@@ -22,7 +22,7 @@ struct CryptPreProcessor
     QByteArray volumeKey;
 };
 
-int csInitEncrypt(const QString &dev, CryptPreProcessor *processor = nullptr);
+int csInitEncrypt(const QString &dev, const QString &displayName, CryptPreProcessor *processor = nullptr);
 int csResumeEncrypt(const QString &dev, const QString &activeName, const QString &displayName);
 int csDecrypt(const QString &dev, const QString &passphrase,
               const QString &displayName, const QString &activeName = QString());
@@ -36,7 +36,7 @@ int csSetLabel(const QString &dev, const QString &label);
 namespace crypt_setup_helper {
 int initiable(const QString &dev);
 int createHeaderFile(const QString &dev, QString *headerPath);
-int initEncryptHeaderFile(const QString &dev, crypt_setup::CryptPreProcessor *processor, QString *fileHeader = nullptr);
+int initEncryptHeaderFile(const QString &dev, const QString &displayName, crypt_setup::CryptPreProcessor *processor, QString *fileHeader = nullptr);
 int initDeviceHeader(const QString &dev, const QString &fileHeader);
 int genDetachHeaderPath(const QString &dev, QString *name = nullptr);
 int backupDetachHeader(const QString &dev, QString *fileHeader = nullptr);

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -326,6 +326,7 @@ void DiskEncryptSetupPrivate::onInitEncryptFinished()
 
     auto args = worker->args();
     auto code = worker->exitCode();
+    qInfo() << "device encryption initialized." << code << args;
     if (code == disk_encrypt::kSuccess) {
         // system("udevadm trigger");
         resumeEncryption();

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -160,6 +160,11 @@ int DiskEncryptSetup::DeviceStatus(const QString &dev)
     // return disk_encrypt::kStatusNotEncrypted;
 }
 
+QString DiskEncryptSetup::HolderDevice(const QString &dev)
+{
+    return dm_setup_helper::findHolderDev(dev);
+}
+
 bool DiskEncryptSetup::IsTaskEmpty()
 {
     return !job_file_helper::hasJobFile();

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -77,7 +77,7 @@ void DiskEncryptSetup::ResumeEncryption(const QVariantMap &args)
         qWarning() << "the resume args is not valid!";
         return;
     }
-    m_dptr->resumeEncryption();
+    m_dptr->resumeEncryption(args);
 }
 
 void DiskEncryptSetup::Decryption(const QVariantMap &args)
@@ -203,9 +203,9 @@ void DiskEncryptSetupPrivate::initialize()
     resumeEncryption();
 }
 
-void DiskEncryptSetupPrivate::resumeEncryption()
+void DiskEncryptSetupPrivate::resumeEncryption(const QVariantMap &args)
 {
-    auto worker = new ResumeEncryptWorker({});
+    auto worker = new ResumeEncryptWorker(args);
     initThreadConnection(worker);
     connect(worker, &ResumeEncryptWorker::requestAuthInfo,
             qptr, &DiskEncryptSetup::WaitAuthInput);

--- a/src/services/diskencrypt/dbus/diskencryptsetup.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.h
@@ -29,6 +29,7 @@ public Q_SLOTS:
 
     QString TpmToken(const QString &dev);
     int DeviceStatus(const QString &dev);
+    QString HolderDevice(const QString &dev);
 
     bool IsTaskEmpty();
     bool IsTaskRunning();

--- a/src/services/diskencrypt/dbus/diskencryptsetup_p.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup_p.h
@@ -26,6 +26,8 @@ class DiskEncryptSetupPrivate : public QObject
     bool validateDecryptArgs(const QVariantMap &args);
     bool validateChgPwdArgs(const QVariantMap &args);
 
+    QString resolveDeviceByDetachHeaderName(const QString &fileName);
+
     FILE_ENCRYPT_NS::BaseEncryptWorker *createInitWorker(const QString &type, const QVariantMap &args);
     FILE_ENCRYPT_NS::BaseEncryptWorker *createDecryptWorker(const QString &type, const QVariantMap &args);
 

--- a/src/services/diskencrypt/dbus/diskencryptsetup_p.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup_p.h
@@ -19,7 +19,7 @@ class DiskEncryptSetupPrivate : public QObject
 
     explicit DiskEncryptSetupPrivate(DiskEncryptSetup *parent);
     void initialize();
-    void resumeEncryption();
+    void resumeEncryption(const QVariantMap &args = QVariantMap());
     bool checkAuth(const QString &action);
     bool validateInitArgs(const QVariantMap &args);
     bool validateResumeArgs(const QVariantMap &args);

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -123,21 +123,16 @@ struct DeviceEncryptParam
 {
     QString devID;
     QString devDesc;
+    QString devPhy;
     QString jobType;
     QString devPreferPath;
-    QString devUnlockName;
     QString key;
+    QString newKey;
     QString exportPath;
     EncryptStates states;
     SecKeyType secType;
-
-    QString uuid;
-    QString newKey;
     QString deviceDisplayName;
     QString mountPoint;
-    QString backingDevUUID;
-    QString clearDevUUID;
-    QString prefferDevName;
     bool validateByRecKey;
 };
 

--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -165,3 +165,20 @@ void crypttab_helper::updateInitramfs()
         qInfo() << "initramfs updated.";
     });
 }
+
+bool crypttab_helper::removeCryptItem(const QString &activeName)
+{
+    bool removed = false;
+    auto items = cryptItems();
+    for (int i = items.count() - 1; i >= 0; --i) {
+        if (items[i].target == activeName) {
+            items.removeAt(i);
+            removed = true;
+            break;
+        }
+    }
+
+    if (removed)
+        saveCryptItems(items);
+    return true;
+}

--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -158,8 +158,10 @@ void crypttab_helper::saveCryptItems(const QList<CryptItem> &items)
 
 void crypttab_helper::updateInitramfs()
 {
-    auto fd = inhibit_helper::inhibit("Updating initramfs...");
-    qInfo() << "start update initramfs...";
-    system("update-initramfs -u");
-    qInfo() << "initramfs updated.";
+    QtConcurrent::run([]{
+        auto fd = inhibit_helper::inhibit("Updating initramfs...");
+        qInfo() << "start update initramfs...";
+        system("update-initramfs -u");
+        qInfo() << "initramfs updated.";
+    });
 }

--- a/src/services/diskencrypt/helpers/crypttabhelper.h
+++ b/src/services/diskencrypt/helpers/crypttabhelper.h
@@ -22,6 +22,7 @@ QList<CryptItem> cryptItems();
 void saveCryptItems(const QList<CryptItem> &items);
 
 bool addCryptOption(const QString &activeName, const QString &opt);
+bool removeCryptItem(const QString &activeName);
 bool insertCryptItem(const CryptItem &item);
 bool updateCryptTab();
 

--- a/src/services/diskencrypt/helpers/filesystemhelper.cpp
+++ b/src/services/diskencrypt/helpers/filesystemhelper.cpp
@@ -8,6 +8,7 @@
 #include <dfm-base/utils/finallyutil.h>
 
 #include <QFile>
+#include <QDir>
 
 #include <sys/stat.h>
 #include <fstab.h>
@@ -177,4 +178,9 @@ void filesystem_helper::remountBoot()
                   MS_REMOUNT,
                   nullptr);
     qInfo() << "/boot remounted:" << r;
+
+    const QString path = "/boot/usec-crypt";
+    auto ok = QDir().mkpath(path);
+    qInfo() << path << "created:" << ok
+            << "dir exists:" << QFile(path).exists();
 }

--- a/src/services/diskencrypt/helpers/filesystemhelper.cpp
+++ b/src/services/diskencrypt/helpers/filesystemhelper.cpp
@@ -145,7 +145,7 @@ bool filesystem_helper::moveFsForward(const QString &dev)
     }
 
     ::remove(logFile.fileName().toStdString().c_str());
-    ::system("udevadm trigger");
+    // ::system("udevadm trigger");
     return true;
 }
 

--- a/src/services/diskencrypt/helpers/jobfilehelper.cpp
+++ b/src/services/diskencrypt/helpers/jobfilehelper.cpp
@@ -84,10 +84,11 @@ int job_file_helper::createDecryptJobFile(JobDescArgs &args)
     return 0;
 }
 
-int job_file_helper::loadDecryptJobFile(JobDescArgs *args)
-{
-    return 0;
-}
+// int job_file_helper::loadDecryptJobFile(JobDescArgs *args)
+// {
+//     // TODO: this function is not needed for now.
+//     return 0;
+// }
 
 int job_file_helper::removeJobFile(const QString &jobFile)
 {

--- a/src/services/diskencrypt/helpers/jobfilehelper.h
+++ b/src/services/diskencrypt/helpers/jobfilehelper.h
@@ -43,7 +43,7 @@ int createUSecRoot();
 int createEncryptJobFile(JobDescArgs &args);
 int createDecryptJobFile(JobDescArgs &args);
 int loadEncryptJobFile(JobDescArgs *args, const QString &dev = QString());
-int loadDecryptJobFile(JobDescArgs *args = nullptr);
+// int loadDecryptJobFile(JobDescArgs *args = nullptr);
 int removeJobFile(const QString &jobFile);
 void checkJobs();
 

--- a/src/services/diskencrypt/workers/dmdecryptworker.cpp
+++ b/src/services/diskencrypt/workers/dmdecryptworker.cpp
@@ -66,7 +66,7 @@ void DMDecryptWorker::run()
         return;
     }
 
-    system("udevadm trigger");
+    // system("udevadm trigger");
 
     RetOnFail(dm_setup::dmSuspendDevice(usecName), ESuspend);
     qInfo() << usecName << "suspended.";
@@ -86,7 +86,7 @@ void DMDecryptWorker::run()
     RetOnFail(dm_setup::dmResumeDevice(usecName), EResume);
     qInfo() << usecName << "resumed.";
 
-    system("udevadm trigger");
+    // system("udevadm trigger");
 
     auto midName = usecName.replace("overlay", "overlay-mid");
     if (!QFile("/dev/mapper/" + midName).exists()) {

--- a/src/services/diskencrypt/workers/dminitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/dminitencryptworker.cpp
@@ -58,7 +58,7 @@ void DMInitEncryptWorker::run()
     auto source = phyPtr
             ? "PARTUUID=" + phyPtr->getProperty(dfmmount::Property::kPartitionUUID).toString()
             : phyPath;
-    crypttab_helper::insertCryptItem({ unlockName, source, "none", { "luks", "initramfs" } });
+    crypttab_helper::insertCryptItem({ unlockName, source, "none", { "luks", "initramfs", "keyscript=/lib/usec-crypt-kit/usec-askpass" } });
 
     // now we can do encrypt on phyDevPath
     auto jobArgs = initJobArgs(phyPath, unlockName);

--- a/src/services/diskencrypt/workers/dminitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/dminitencryptworker.cpp
@@ -69,7 +69,7 @@ void DMInitEncryptWorker::run()
     const char *argv[] = { _dev.c_str(), _topName.c_str(), _midName.c_str() };
     crypt_setup::CryptPreProcessor proc { .argc = 3, .argv = argv, .proc = detachPhyDevice };
 
-    int r = crypt_setup::csInitEncrypt(phyPath, &proc);
+    int r = crypt_setup::csInitEncrypt(phyPath, jobArgs.devName, &proc);
     if (r < 0) {
         qWarning() << EInitEnc + phyPath << r;
         job_file_helper::removeJobFile(jobArgs.jobFile);

--- a/src/services/diskencrypt/workers/dminitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/dminitencryptworker.cpp
@@ -12,15 +12,14 @@
 
 #include <sys/mount.h>
 
-
-#define RetOnFail(ret, msg) \
-    {                       \
-        int r = ret;        \
-        if (r < 0) {        \
-            setExitCode(r); \
+#define RetOnFail(ret, msg)    \
+    {                          \
+        int r = ret;           \
+        if (r < 0) {           \
+            setExitCode(r);    \
             qWarning() << msg; \
-            return;         \
-        }                   \
+            return;            \
+        }                      \
     }
 
 #define ESuspend QString("error when SUSPEND dm device ")

--- a/src/services/diskencrypt/workers/normalinitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/normalinitencryptworker.cpp
@@ -28,7 +28,8 @@ void NormalInitEncryptWorker::run()
         return;
     }
 
-    int r = crypt_setup::csInitEncrypt(devPath);
+    int r = crypt_setup::csInitEncrypt(devPath,
+                                       m_args.value(disk_encrypt::encrypt_param_keys::kKeyDeviceName).toString());
     if (r < 0) {
         setExitCode(r);
         return;

--- a/src/services/diskencrypt/workers/resumeencryptworker.h
+++ b/src/services/diskencrypt/workers/resumeencryptworker.h
@@ -46,6 +46,8 @@ protected:
     void updateCryptTab();
     void saveRecoveryKey();
 
+    void loadJobFromDevice();
+
 private:
     bool m_ignoreFlag { false };
     AuthInfo m_authArgs;


### PR DESCRIPTION
- **fix: missing keyscript option in crypttab**
- **fix: complete the unfinishedJob function**
- **fix: using cookie when resume dm device**
- **fix: make /boot/usec-crypt path if not exist**
- **fix: cannot continue decrypt after interrupted**
- **fix: cannot continue encrypt in some case**

## Summary by Sourcery

Fixes issues related to partition encryption, including missing keyscript options, incomplete functions, and problems with resuming encryption/decryption after interruption. Also improves device handling and header management.

Bug Fixes:
- Adds the missing keyscript option in crypttab to ensure proper key handling during boot.
- Completes the unfinishedJob function to ensure proper resumption of interrupted encryption tasks.
- Uses cookies when resuming DM devices to ensure synchronization and prevent issues.
- Creates the /boot/usec-crypt path if it does not exist, ensuring that the detached headers can be stored.
- Fixes an issue where decryption could not continue after being interrupted.
- Fixes an issue where encryption could not continue in some cases.

Enhancements:
- Improves device identification by using PARTUUID to resolve device paths, making the process more robust.
- Adds support for resuming encryption operations with arguments, allowing for more flexible control.
- Updates initramfs in a separate thread to avoid blocking the main thread.
- Adds a HolderDevice method to retrieve the holder device for a given device.