### PR TITLE
fix bugs

### DIFF
--- a/src/dfm-framework/event/eventdispatcher.cpp
+++ b/src/dfm-framework/event/eventdispatcher.cpp
@@ -17,15 +17,19 @@ bool EventDispatcher::dispatch()
 
 bool EventDispatcher::dispatch(const QVariantList &params)
 {
-    if (std::any_of(filterList.begin(), filterList.end(), [params](const EventHandler<Listener> &h) {
-            return h.handler(params).toBool();
+    auto filtersCopy = filterList;
+    auto handlersCopy = handlerList;
+
+    if (std::any_of(filtersCopy.begin(), filtersCopy.end(), [params](const EventHandler<Listener> &h) {
+            return h.handler && h.handler(params).toBool();
         })) {
         return false;
     }
 
-    std::for_each(handlerList.begin(), handlerList.end(), [params](const EventHandler<Listener> &h) {
-        h.handler(params);
-    });
+    for (const auto &h : handlersCopy) {
+        if (h.handler)
+            h.handler(params);
+    }
 
     return true;
 }

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
@@ -151,7 +151,7 @@ void SmbBrowser::followEvents()
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Tab_SetTabName", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookSetTabName);
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Show_Addr", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookTitleBarAddrHandle);
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Copy_Addr", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookTitleBarAddrHandle);
-    dpfHookSequence->follow("dfmplugin_workspace", "hook_Tab_Allow_Repeat_Url", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookAllowRepeatUrl);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_Allow_Repeat_Url", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookAllowRepeatUrl);
 }
 
 void SmbBrowser::updateNeighborToSidebar()


### PR DESCRIPTION
## Summary by Sourcery

Fixes a bug in the event dispatcher that could cause crashes due to handlers being called after they are destroyed. Also fixes a typo in the name of a hook.

Bug Fixes:
- Fixes a crash in the event dispatcher by copying the handler list before dispatching events, preventing modification during iteration.
- Fixes a crash in the event dispatcher by checking if the handler is valid before calling it, preventing calls to destroyed handlers.
- Fixes a typo in the name of the 'hook_Tab_Allow_Repeat_Url' hook to 'hook_Allow_Repeat_Url' in the SMB browser plugin, ensuring the hook is correctly followed.