### PR TITLE
fix: Update device list and item widgets with DTK font management

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.h
@@ -21,6 +21,7 @@ public:
 
 protected:
     void mouseReleaseEvent(QMouseEvent *) override;
+    void resizeEvent(QResizeEvent *e) override;
 
 public Q_SLOTS:
     void updateUsage(quint64 usedSize);
@@ -32,12 +33,12 @@ private:
     void initUI();
     void openDevice();
     static void setTextColor(QWidget *obj, int themeType, double alpha);
-    static void setTextFont(QWidget *widget, int pixelSize, int weight);
 
 private:
     DockItemData data;
 
     QLabel *sizeLabel { nullptr };
+    QLabel *nameLabel { nullptr };
     QProgressBar *sizeProgress { nullptr };
 };
 

--- a/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.h
@@ -20,6 +20,9 @@ class DeviceList : public QScrollArea
 public:
     explicit DeviceList(QWidget *parent = nullptr);
 
+protected:
+    void showEvent(QShowEvent *e) override;
+
 private Q_SLOTS:
     void addDevice(const DockItemData &item);
     void removeDevice(const QString &id);
@@ -36,6 +39,7 @@ private:
     DockItemDataManager *manager { nullptr };
     QMap<QString, QWidget *> deviceItems;
     QMap<QString, QString> sortKeys;
+    QWidget *headerWidget { nullptr };
 };
 
 #endif   // DEVICELIST_H

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/searchhistroymanager.cpp
@@ -24,6 +24,17 @@ inline constexpr char kKeyLastAccessed[] { "lastAccessed" };
 
 inline constexpr char kprotocolIPRegExp[] { R"(^((smb)|(ftp)|(sftp))(://)((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})(\.((2(5[0-5]|[0-4]\d))|[0-1]?\d{1,2})){3}/*$)" };
 
+namespace {
+QString trimTrailingSlashes(const QString &input)
+{
+    QString trimmed = input;
+    while (trimmed.endsWith("/")) {
+        trimmed.chop(1);
+    }
+    return trimmed;
+}
+}
+
 SearchHistroyManager *SearchHistroyManager::instance()
 {
     static SearchHistroyManager instance;
@@ -42,13 +53,14 @@ SearchHistroyManager::SearchHistroyManager(QObject *parent)
 
 void SearchHistroyManager::handleMountNetworkResult(const QString &address, bool ret, dfmmount::DeviceError err, const QString &)
 {
-    if (!isValidMount(address, ret, err)) {
+    auto addr = trimTrailingSlashes(address);
+    if (!isValidMount(addr, ret, err)) {
         // Remove the address only if it was in the cache, as before.
-        ipAddressCache.removeOne(address);
+        ipAddressCache.removeOne(addr);
         return;
     }
-    ipAddressCache.removeOne(address);
-    writeIntoIPHistory(address);
+    ipAddressCache.removeOne(addr);
+    writeIntoIPHistory(addr);
 }
 
 bool SearchHistroyManager::isValidMount(const QString &address, bool ret, dfmmount::DeviceError err)
@@ -110,10 +122,11 @@ void SearchHistroyManager::writeIntoSearchHistory(QString keyword)
 
 void SearchHistroyManager::addIPHistoryCache(const QString &address)
 {
-    if (ipAddressCache.contains(address))
+    auto addr = trimTrailingSlashes(address);
+    if (ipAddressCache.contains(addr))
         return;
 
-    ipAddressCache << address;
+    ipAddressCache << addr;
 }
 
 void SearchHistroyManager::writeIntoIPHistory(const QString &ipAddr)


### PR DESCRIPTION
- Replace manual font setting with DFontSizeManager
- Add dynamic text eliding for device names
- Improve height calculation for device list
- Remove deprecated font setting method
- Use DTK namespace macros for better readability

Log: Modernize font and text handling in device list widgets
Bug: https://pms.uniontech.com/bug-view-306497.html

## Summary by Sourcery

Modernizes font and text handling in device list widgets by using DTK font management and adding dynamic text eliding for device names. It also improves height calculation for the device list.

Enhancements:
- Replaces manual font setting with DFontSizeManager.
- Adds dynamic text eliding for device names.
- Improves height calculation for device list.
- Uses DTK namespace macros for better readability.
- Removes deprecated font setting method.
- Trims trailing slashes from network addresses to ensure consistent handling of network paths in search history.