### PR TITLE
fix: Improve file trash permission check for root user

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1279,14 +1279,11 @@ bool FileUtils::fileCanTrash(const QUrl &url)
 {
     // gio does not support root user to move ordinary user files to trash
     auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
-    if (SysInfoUtils::isRootUser()) {
-        int ownerId = info.isNull() ? -1 : info->extendAttributes(FileInfo::FileExtendedInfoType::kOwnerId).toInt();
-        if (ownerId != 0)
-            return false;
-    }
-
     if (!info)
         return false;
+
+    if (SysInfoUtils::isRootUser())
+        return info->canAttributes(CanableInfoType::kCanTrash);
 
     bool alltotrash = DConfigManager::instance()->value(kDefaultCfgPath, kFileAllTrash).toBool();
     if (alltotrash)


### PR DESCRIPTION
Refactor the fileCanTrash method to simplify root user file trash permissions:
- Remove manual owner ID check
- Use canAttributes method to determine trash permissions for root user
- Maintain existing logic for non-root users

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-306427.html

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where root users were unable to trash files.