### PR TITLE
fix: Add background fill for file dialog status bar

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -1085,6 +1085,7 @@ void FileDialog::initializeUi()
 
     // init status bar
     d->statusBar = new FileDialogStatusBar(this);
+    d->statusBar->setAutoFillBackground(true);
 #ifdef ENABLE_TESTING
     dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
                          qobject_cast<QWidget *>(d->statusBar), AcName::kAcFDStautsBar);


### PR DESCRIPTION
Enable auto-fill background for the file dialog status bar to improve visual consistency and appearance.

Log: UI enhancement for file dialog status bar

## Summary by Sourcery

Enhancements:
- Enable auto-fill background for the file dialog status bar.