### PR TITLE
fix: Prevent editing state persistence in collection view

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/view/collectionframe.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionframe.cpp
@@ -569,6 +569,7 @@ void CollectionFrame::mouseReleaseEvent(QMouseEvent *event)
                 d->frameState = CollectionFramePrivate::NormalShowState;
                 setGeometry(result);
                 d->updateStretchRect();
+                if (d->collView) d->collView->setProperty(kCollectionPropertyEditing, false);
                 Q_EMIT geometryChanged();
                 Q_EMIT editingStatusChanged(false);
             };


### PR DESCRIPTION
Ensure that the collection view's editing property is reset when the collection frame's geometry changes, preventing unintended editing states from persisting.

Log: fix UI interaction bug
Bug: https://pms.uniontech.com/bug-view-306615.html

## Summary by Sourcery

Bug Fixes:
- Prevents the collection view's editing state from persisting after the collection frame's geometry changes.