### PR TITLE
fix: Adjust search edit widget right margin

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -292,7 +292,7 @@ void SearchEditWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
 
-    int rightMargin = 60;
+    int rightMargin = 70;
 
     int spinnerX = event->size().width() - spinner->size().width() - rightMargin;
     int spinnerY = (event->size().height() - spinner->size().height()) / 2;


### PR DESCRIPTION
Increase right margin from 60 to 70 pixels to improve layout spacing and visual alignment in the search edit widget.

Log: Refine search bar UI spacing
Bug: https://pms.uniontech.com/bug-view-305941.html

## Summary by Sourcery

Bug Fixes:
- Increase right margin from 60 to 70 pixels to improve layout spacing and visual alignment in the search edit widget.