### PR TITLE
fix: Improve tag widget dynamic height and scrolling behavior

### DIFF
--- a/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
@@ -17,8 +17,6 @@
 
 #include <QVBoxLayout>
 
-static constexpr int kTagWidgetHeight { 114 };
-
 DWIDGET_USE_NAMESPACE
 DTK_USE_NAMESPACE
 
@@ -80,8 +78,6 @@ void TagWidgetPrivate::initializeUI()
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, &TagWidgetPrivate::initUiForSizeMode);
 #else
     mainLayout->setContentsMargins(10, 10, 10, 10);
-    crumbEdit->setMaximumHeight(100);
-    q->setFixedHeight(kTagWidgetHeight);
 #endif
 }
 
@@ -89,8 +85,6 @@ void TagWidgetPrivate::initUiForSizeMode()
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
     mainLayout->setContentsMargins(DSizeModeHelper::element(5, 10), 6, 10, 10);
-    crumbEdit->setMaximumHeight(DSizeModeHelper::element(50, 50));
     colorListWidget->setFixedWidth(214);
-    q->setFixedHeight(DSizeModeHelper::element(kTagWidgetHeight, kTagWidgetHeight));
 #endif
 }

--- a/src/plugins/common/dfmplugin-tag/widgets/tagcrumbedit.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagcrumbedit.cpp
@@ -4,6 +4,8 @@
 
 #include "tagcrumbedit.h"
 
+#include <QAbstractTextDocumentLayout>
+
 DWIDGET_USE_NAMESPACE
 using namespace dfmplugin_tag;
 
@@ -13,6 +15,13 @@ TagCrumbEdit::TagCrumbEdit(QWidget *parent)
     auto doc = QTextEdit::document();
     doc->setDocumentMargin(doc->documentMargin() + 5);
     setViewportMargins(0, 0, 0, 0);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    edit = qobject_cast<QTextEdit *>(this);
+    if (edit) {
+        auto layout = edit->document()->documentLayout();
+        connect(layout, &QAbstractTextDocumentLayout::documentSizeChanged, this, &TagCrumbEdit::updateHeight);
+    }
 }
 
 bool TagCrumbEdit::isEditing()
@@ -25,4 +34,12 @@ void TagCrumbEdit::mouseDoubleClickEvent(QMouseEvent *event)
     isEditByDoubleClick = true;
     DCrumbEdit::mouseDoubleClickEvent(event);
     isEditByDoubleClick = false;
+}
+
+void TagCrumbEdit::updateHeight()
+{
+    qreal docHeight = edit->document()->size().height();
+    QMargins margins = edit->contentsMargins();
+    int totalHeight = qCeil(docHeight) + margins.top() + margins.bottom();
+    setFixedHeight(totalHeight);
 }

--- a/src/plugins/common/dfmplugin-tag/widgets/tagcrumbedit.h
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagcrumbedit.h
@@ -23,7 +23,10 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent *event) override;
 
 private:
+    void updateHeight();
+
     bool isEditByDoubleClick { false };
+    QTextEdit *edit { nullptr };
 };
 
 }


### PR DESCRIPTION
- Add dynamic height calculation for tag crumb edit widget
- Disable vertical scrollbar for better UI consistency
- Remove fixed height constraints in tag widget
- Connect document layout size changes to update widget height dynamically

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-306291.html

## Summary by Sourcery

Improves the tag widget by dynamically calculating the height of the tag crumb edit widget based on its content, and by disabling the vertical scrollbar for better UI consistency.

Bug Fixes:
- Fixes an issue where the tag widget height was not dynamically adjusted based on content, leading to inconsistent UI behavior.
- Disables the vertical scrollbar in the tag crumb edit widget for improved UI consistency.
- Removes fixed height constraints in the tag widget to allow for dynamic height adjustment based on content.