### PR TITLE
修复只读分区访问前的提权请求缺失问题。

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp
@@ -93,7 +93,8 @@ void ComputerEventReceiver::dirAccessPrehandler(quint64, const QUrl &url, std::f
             break;
         }
         // only handle mounts by udisks
-        if (!path.startsWith("/media/")) {
+        QRegularExpression udisksPrefixRegx(R"(^(/run/media/|/media/))");
+        if (!path.contains(udisksPrefixRegx)) {
             //            fmInfo() << "not udisks mount path, ignore prehandle" << url;
             break;
         }


### PR DESCRIPTION
V25 修改了默认的挂载父路径，此处未同步变更。

## Summary by Sourcery

Fixes a privilege escalation issue when accessing read-only partitions by updating the default mount path. Also, ensures that encryption is enabled before proceeding with decryption jobs.

Bug Fixes:
- Fixes a privilege escalation issue when accessing read-only partitions by updating the default mount path from "/media/" to "/run/media/" to match the new default mount path.
- Ensures that encryption is enabled before proceeding with decryption jobs, allowing the feature to be hot-switched without relaunching dde-file-manager.