### PR TITLE
fix: [filedialog] Not filter the new file in open mode.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1528,13 +1528,18 @@ bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool by
     auto item = childData(sortInfo->fileUrl());
     if (item && !nameFilters.isEmpty() && !item->data(Global::ItemRoles::kItemFileIsDirRole).toBool()) {
         QRegularExpression re("", QRegularExpression::CaseInsensitiveOption);
+        bool hasMatched { false };
         for (int i = 0; i < nameFilters.size(); ++i) {
             QString pattern = QRegularExpression::wildcardToRegularExpression(nameFilters.at(i));
             re.setPattern(pattern);
             if (re.match(item->data(kItemNameRole).toString()).hasMatch()) {
                 item->setAvailableState(true);
+                hasMatched = true;
+                break;
             }
         }
+        if (!hasMatched)
+            item->setAvailableState(false);
     }
 
     // 处理继承


### PR DESCRIPTION
1. When open the file dialog in open mode, not filter the new file.
2. Add logic code to setAvailabelState(fales) for the new file.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-305719.html

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where new files were not being filtered in the file dialog when in open mode.