### PR TITLE
fix: [file-size] Directory size display shows incorret values

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -54,6 +54,7 @@ BasicWidget::BasicWidget(QWidget *parent)
 {
     initUI();
     fileCalculationUtils = new FileStatisticsJob;
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink);
 
     infoFetchWorker->moveToThread(fetchThread);
     fetchThread->start();

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
@@ -24,6 +24,7 @@ MultiFilePropertyDialog::MultiFilePropertyDialog(const QList<QUrl> &urls, QWidge
     initHeadUi();
     setFixedSize(300, 360);
     fileCalculationUtils = new FileStatisticsJob;
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink);
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &MultiFilePropertyDialog::updateFolderSizeLabel);
     QList<QUrl> targets;
     UniversalUtils::urlsTransformToLocal(urlList, &targets);


### PR DESCRIPTION
--The size of linkd files is being incorrectly added to parent directory's total size.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-307399.html

## Summary by Sourcery

Bug Fixes:
- Configures the file size calculation utility to not follow symbolic links, thus preventing the size of linked files from being incorrectly added to the parent directory's total size.