### PR TITLE
fix: updateInitramfs not finished before reboot

### DIFF
--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -158,12 +158,12 @@ void crypttab_helper::saveCryptItems(const QList<CryptItem> &items)
 
 void crypttab_helper::updateInitramfs()
 {
-    QtConcurrent::run([]{
-        auto fd = inhibit_helper::inhibit("Updating initramfs...");
-        qInfo() << "start update initramfs...";
-        system("update-initramfs -u");
-        qInfo() << "initramfs updated.";
-    });
+    // QtConcurrent::run([]{
+    auto fd = inhibit_helper::inhibit("Updating initramfs...");
+    qInfo() << "start update initramfs...";
+    system("update-initramfs -u");
+    qInfo() << "initramfs updated.";
+    // });
 }
 
 bool crypttab_helper::removeCryptItem(const QString &activeName)


### PR DESCRIPTION
system cannot be launched in this case, missing crypttab to unlock device in init phase.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-307535.html

## Summary by Sourcery

Bug Fixes:
- Ensure crypttab is present in initramfs to unlock encrypted devices during boot.