### PR TITLE
fix: optimize extension name search to prevent dialog sticking

### DIFF
--- a/src/plugins/filedialog/core/utils/corehelper.cpp
+++ b/src/plugins/filedialog/core/utils/corehelper.cpp
@@ -159,9 +159,6 @@ QString CoreHelper::findExtensioName(const QString &fileName, const QStringList 
             }
         }
 
-        if (newNameFilterExtension.isEmpty())
-            fmInfo() << "Cannot find extension name";
-
         QRegularExpression re(QRegularExpression::wildcardToRegularExpression(newNameFilterExtension),
                               QRegularExpression::CaseInsensitiveOption);
         if (re.match("^" + fileNameExtension + "$").hasMatch()) {   //原扩展名与新扩展名不匹配？
@@ -169,6 +166,9 @@ QString CoreHelper::findExtensioName(const QString &fileName, const QStringList 
             // TODO(liuyangming):
             // getFileView()->setNameFilters(newNameFilters); //这里传递回去的有可能是一个正则表达式，它决定哪些文件不被置灰
         }
+
+        if (!newNameFilterExtension.isEmpty())
+            break;
     }
     return newNameFilterExtension;
 }


### PR DESCRIPTION
When searching for extension names in accept mode, the dialog would continue iterating through all filters even after finding a match, causing potential performance issues and UI sticking. Break the loop once a valid extension is found.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-305621.html

## Summary by Sourcery

Bug Fixes:
- Prevent dialog from sticking by breaking the loop after finding a valid extension name.