### PR TITLE
fix: Prevent empty menu action sorting in disk encrypt menu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.38) unstable; urgency=medium
+
+  * fix bug
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 11 Mar 2025 18:54:03 +0800
+
 dde-file-manager (6.5.37) unstable; urgency=medium
 
   * Optimize file dialog and fix issues including extension search, directory size display, font handling, tag widget behavior, partition access, icon rendering, and sorting enhancements with full-width character and directory support.

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -561,6 +561,9 @@ void DiskEncryptMenuScene::sortActions(QMenu *parent)
 {
     Q_ASSERT(parent);
     QList<QAction *> acts = parent->actions();
+    if (acts.isEmpty())
+        return;
+
     QAction *before { acts.last() };
     for (int i = 0; i < acts.count(); ++i) {
         auto act = acts.at(i);


### PR DESCRIPTION
Add a guard condition to skip sorting when the menu has no actions, preventing potential null pointer access or unnecessary processing.

Log:

Bug: https://pms.uniontech.com/bug-view-307533.html

## Summary by Sourcery

Bug Fixes:
- Add a guard condition to skip sorting when the menu has no actions, preventing potential null pointer access or unnecessary processing.