### PR TITLE
fix: Add thread-safe handling for speedtimer in file operations

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -194,6 +194,7 @@ public:
     QSharedPointer<QThreadPool> threadPool { nullptr };
     static std::atomic_bool bigFileCopy;
     QAtomicInteger<qint64> bigFileSize { 0 };   // bigger than this is big file
+    QMutex speedTimerMutex;
     QElapsedTimer *speedtimer { nullptr };   // time eslape
     std::atomic_int64_t elapsed { 0 };
     std::atomic_int64_t deleteFirstFileSize{ false };

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -76,9 +76,12 @@ void FileOperateBaseWorker::emitSpeedUpdatedNotify(const qint64 &writSize)
 {
     JobInfoPointer info(new QMap<quint8, QVariant>);
     qint64 elTime = 1;
-    if (speedtimer) {
-        elTime = speedtimer->elapsed() == 0 ? 1 : speedtimer->elapsed();
-        elTime += elapsed;
+    {
+        QMutexLocker locker(&speedTimerMutex);
+        if (speedtimer) {
+            elTime = speedtimer->elapsed() == 0 ? 1 : speedtimer->elapsed();
+            elTime += elapsed;
+        }
     }
 
     qint64 speed = currentState == AbstractJobHandler::JobState::kRunningState


### PR DESCRIPTION
Introduce mutex-based synchronization for speedtimer access in AbstractWorker to prevent potential race conditions and ensure thread-safe operations during file copying and speed calculations.

Key changes:
- Add QMutex for protecting speedtimer access
- Wrap speedtimer operations with mutex locks
- Improve thread-safety in pause and speed update methods

Log: Enhance file operation thread safety
Bug: https://pms.uniontech.com/bug-view-307579.html

## Summary by Sourcery

Ensure thread-safe access to the speedtimer in AbstractWorker by introducing a mutex. This prevents potential race conditions during file operations and speed calculations.

Bug Fixes:
- Fix potential race conditions when accessing the speedtimer in AbstractWorker by using a mutex to protect access to it.
- Ensure thread-safe operations during file copying and speed calculations by synchronizing speedtimer access with mutex locks.
- Improve thread-safety in pause and speed update methods by using mutex locks.