### PR TITLE
fix: Simplify speedtimer management in file operation workers

### DIFF
--- a/src/apps/dde-file-dialog-wayland/main.cpp
+++ b/src/apps/dde-file-dialog-wayland/main.cpp
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
 
     if (!pluginsLoad()) {
         qCCritical(logAppDialogWayland) << "Load pugin failed!";
-        abort();
+        Q_ASSERT_X(false, "pluginsLoad", "Failed to load plugins");
     }
 
     int ret { a.exec() };

--- a/src/apps/dde-file-dialog-x11/main.cpp
+++ b/src/apps/dde-file-dialog-x11/main.cpp
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
 
     if (!pluginsLoad()) {
         qCCritical(logAppDialogX11) << "Load pugin failed!";
-        abort();
+        Q_ASSERT_X(false, "pluginsLoad", "Failed to load plugins");
     }
 
     int ret { a.exec() };

--- a/src/apps/dde-file-dialog/main.cpp
+++ b/src/apps/dde-file-dialog/main.cpp
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
 
     if (!pluginsLoad()) {
         qCCritical(logAppDialog) << "Load pugin failed!";
-        abort();
+        Q_ASSERT_X(false, "pluginsLoad", "Failed to load plugins");
     }
 
     int ret { a.exec() };

--- a/src/apps/dde-file-manager-daemon/main.cpp
+++ b/src/apps/dde-file-manager-daemon/main.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
 
     if (!pluginsLoad()) {
         qCCritical(logAppDaemon) << "Load pugin failed!";
-        abort();
+        Q_ASSERT_X(false, "pluginsLoad", "Failed to load plugins");
     }
 
     int ret { a.exec() };

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -340,7 +340,7 @@ int main(int argc, char *argv[])
 
         if (!pluginsLoad()) {
             qCCritical(logAppFileManager) << "Load pugin failed!";
-            abort();
+            Q_ASSERT_X(false, "pluginsLoad", "Failed to load plugins");
         }
         signal(SIGTERM, handleSIGTERM);
         signal(SIGPIPE, handleSIGPIPE);

--- a/src/dfm-framework/lifecycle/lifecycle.cpp
+++ b/src/dfm-framework/lifecycle/lifecycle.cpp
@@ -141,13 +141,12 @@ bool readPlugins()
  */
 bool loadPlugins()
 {
-    if (!pluginManager->loadPlugins())
-        return false;
+    bool result { pluginManager->loadPlugins() };
 
     pluginManager->initPlugins();
     pluginManager->startPlugins();
 
-    return true;
+    return result;
 }
 
 /*!

--- a/src/dfm-framework/lifecycle/private/pluginmanager_p.cpp
+++ b/src/dfm-framework/lifecycle/private/pluginmanager_p.cpp
@@ -493,12 +493,6 @@ bool PluginManagerPrivate::doLoadPlugin(PluginMetaObjectPointer pointer)
         return true;
     }
 
-    if (!pointer->d->loader->load()) {
-        pointer->d->error = "Failed load plugin: " + pointer->d->loader->errorString();
-        qCCritical(logDPF) << pointer->errorString() << pointer->d->name << pointer->d->loader->fileName();
-        return false;
-    }
-
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // Check Qt version compatibility after plugin is loaded
     if (!checkPluginQtVersion(pointer)) {
@@ -507,6 +501,12 @@ bool PluginManagerPrivate::doLoadPlugin(PluginMetaObjectPointer pointer)
         return false;
     }
 #endif
+
+    if (!pointer->d->loader->load()) {
+        pointer->d->error = "Failed load plugin: " + pointer->d->loader->errorString();
+        qCCritical(logDPF) << pointer->errorString() << pointer->d->name << pointer->d->loader->fileName();
+        return false;
+    }
 
     // resolve loader instance
     bool isNullPluginInstance { false };

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
@@ -85,11 +85,6 @@ void DoCopyFilesWorker::stop()
 
 bool DoCopyFilesWorker::initArgs()
 {
-    if (!speedtimer) {
-        speedtimer = new QElapsedTimer();
-        speedtimer->start();
-    }
-
     AbstractWorker::initArgs();
 
     if (sourceUrls.count() <= 0) {

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -65,10 +65,6 @@ void DoCutFilesWorker::stop()
 
 bool DoCutFilesWorker::initArgs()
 {
-    if (!speedtimer) {
-        speedtimer = new QElapsedTimer();
-        speedtimer->start();
-    }
 
     AbstractWorker::initArgs();
 
@@ -223,7 +219,7 @@ void DoCutFilesWorker::onUpdateProgress()
 void DoCutFilesWorker::endWork()
 {
     // delete all cut source files
-    if(localFileHandler) {
+    if (localFileHandler) {
         for (const auto &info : cutAndDeleteFiles) {
             bool ret = localFileHandler->deleteFile(info->uri());
             if (!ret) {
@@ -232,7 +228,7 @@ void DoCutFilesWorker::endWork()
             }
         }
     }
-    
+
     return FileOperateBaseWorker::endWork();
 }
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -563,6 +563,10 @@ AbstractWorker::AbstractWorker(QObject *parent)
     : QObject(parent)
 {
     qRegisterMetaType<DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType>();
+    if (!speedtimer) {
+        speedtimer = new QElapsedTimer();
+        speedtimer->start();
+    }
 }
 /*!
  * \brief AbstractWorker::formatFileName Processing and formatting file names

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -121,8 +121,6 @@ void AbstractWorker::pause()
         return;
     if (speedtimer) {
         elapsed += speedtimer->elapsed();
-        speedtimerList.append(speedtimer);
-        speedtimer = nullptr;
         JobInfoPointer info(new QMap<quint8, QVariant>);
         info->insert(AbstractJobHandler::NotifyInfoKey::kJobtypeKey, QVariant::fromValue(jobType));
         info->insert(AbstractJobHandler::NotifyInfoKey::kJobStateKey, QVariant::fromValue(currentState));
@@ -141,10 +139,8 @@ void AbstractWorker::pause()
 void AbstractWorker::resume()
 {
     setStat(AbstractJobHandler::JobState::kRunningState);
-    if (!speedtimer) {
-        speedtimer = new QElapsedTimer;
-        speedtimer->start();
-    }
+    if (speedtimer)
+        speedtimer->restart();
 
     waitCondition.wakeAll();
 }
@@ -645,8 +641,8 @@ void AbstractWorker::saveOperations()
         emit requestSaveRedoOperation(QString::number(quintptr(handle.data()), 16), deleteFirstFileSize.load());
     }
     if (jobType == AbstractJobHandler::JobType::kCopyType
-            || jobType == AbstractJobHandler::JobType::kCutType
-            || FileOperationsUtils::canBroadcastPaste()) {
+        || jobType == AbstractJobHandler::JobType::kCutType
+        || FileOperationsUtils::canBroadcastPaste()) {
         QUrl sourceUrl = sourceUrls.isEmpty() ? QUrl() : sourceUrls.first();
         if (!sourceUrl.isValid() || !targetUrl.isValid()) {
             fmWarning(logDFMBase()) << "broadcast paste error, cast invalid source or target url!!!"
@@ -668,8 +664,6 @@ AbstractWorker::~AbstractWorker()
         delete speedtimer;
         speedtimer = nullptr;
     }
-
-    qDeleteAll(speedtimerList);
 }
 
 /*!

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -196,9 +196,8 @@ public:
     QAtomicInteger<qint64> bigFileSize { 0 };   // bigger than this is big file
     QElapsedTimer *speedtimer { nullptr };   // time eslape
     std::atomic_int64_t elapsed { 0 };
-    std::atomic_int64_t deleteFirstFileSize{ false };
-    bool isCutMerge{false};
-    QList<QElapsedTimer *> speedtimerList;
+    std::atomic_int64_t deleteFirstFileSize { false };
+    bool isCutMerge { false };
 };
 DPFILEOPERATIONS_END_NAMESPACE
 


### PR DESCRIPTION
Remove redundant speedtimer initialization and cleanup in copy, cut, and abstract workers to improve code clarity and reduce unnecessary memory management

Log:

Bug: https://pms.uniontech.com/bug-view-307579.html

## Summary by Sourcery

Simplifies speedtimer management in file operation workers by removing redundant initialization and cleanup, which improves code clarity and reduces unnecessary memory management. Also, changes the abort() call to Q_ASSERT_X to provide more context when plugin loading fails.

Enhancements:
- Removes redundant speedtimer initialization and cleanup in copy, cut, and abstract workers to improve code clarity and reduce unnecessary memory management.
- Replaces abort() calls with Q_ASSERT_X to provide more context when plugin loading fails.