### PR TITLE
fix: Simplify file info creation in search directory iterator

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
@@ -105,7 +105,6 @@ SearchDirIterator::SearchDirIterator(const QUrl &url,
     : AbstractDirIterator(url, nameFilters, filters, flags),
       d(new SearchDirIteratorPrivate(url, this))
 {
-    setProperty("FileInfoNoCache", true);
 }
 
 SearchDirIterator::~SearchDirIterator()
@@ -157,8 +156,7 @@ const FileInfoPointer SearchDirIterator::fileInfo() const
     if (!d->currentFileUrl.isValid())
         return nullptr;
 
-    return InfoFactory::create<FileInfo>(d->currentFileUrl,
-                                         Global::CreateFileInfoType::kCreateFileInfoAutoNoCache);
+    return InfoFactory::create<FileInfo>(d->currentFileUrl);
 }
 
 QUrl SearchDirIterator::url() const


### PR DESCRIPTION
Remove unnecessary file info caching properties and use default file info creation method for search results.

Log: Optimize file info handling
Bug: https://pms.uniontech.com/bug-view-307337.html

## Summary by Sourcery

Enhancements:
- Optimize file info handling by removing unnecessary caching properties.