### PR TITLE
fix: Prevent palette flickering during sidebar item expansion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.39) unstable; urgency=medium
+
+  * Prevent UI flickering during sidebar expansion, improve Unicode sorting in file comparison, simplify file info creation and speedtimer management, ensure proper initialization, and replace abort() with Q_ASSERT_X for plugin loading failures. 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 12 Mar 2025 20:26:26 +0800
+
 dde-file-manager (6.5.38) unstable; urgency=medium
 
   * fix bug

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -14,6 +14,7 @@
 #include <QModelIndex>
 #include <QUrl>
 #include <QDropEvent>
+#include <QPalette>
 
 DPSIDEBAR_BEGIN_NAMESPACE
 
@@ -31,15 +32,16 @@ class SideBarViewPrivate : public QObject
     QModelIndex currentHoverIndex;
     bool isItemDragged = false;
     QList<QUrl> urlsForDragEvent;
-    qint64 lastOpTime;   //上次操作的时间（ms）
+    qint64 lastOpTime;   // 上次操作的时间（ms）
     QUrl draggedUrl;
     QString draggedGroup;
     QVariantMap groupExpandState;
     QUrl sidebarUrl;
     DFMBASE_NAMESPACE::DFMMimeData dfmMimeData;
+    QPalette originPalette;
 
     explicit SideBarViewPrivate(SideBarView *qq);
-    bool checkOpTime();   //检查当前操作与上次操作的时间间隔
+    bool checkOpTime();   // 检查当前操作与上次操作的时间间隔
     void notifyOrderChanged();
     void updateDFMMimeData(const QDropEvent *event);
     bool checkTargetEnable(const QUrl &targetUrl);
@@ -49,6 +51,10 @@ class SideBarViewPrivate : public QObject
 private Q_SLOTS:
     void currentChanged(const QModelIndex &curIndex);
     void onItemDoubleClicked(const QModelIndex &index);
+
+private:
+    void setTransparentPalette();
+    void restorePalette();
 };
 
 DPSIDEBAR_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -72,6 +72,18 @@ void SideBarViewPrivate::onItemDoubleClicked(const QModelIndex &index)
     q->onChangeExpandState(index, !q->isExpanded(index));
 }
 
+void SideBarViewPrivate::setTransparentPalette()
+{
+    QPalette treePal = q->palette();
+    treePal.setColor(QPalette::Base, Qt::transparent);
+    q->setPalette(treePal);
+}
+
+void SideBarViewPrivate::restorePalette()
+{
+    q->setPalette(originPalette);
+}
+
 void SideBarViewPrivate::notifyOrderChanged()
 {
     if (draggedGroup.isEmpty())
@@ -221,14 +233,11 @@ SideBarView::SideBarView(QWidget *parent)
 
     viewport()->setAttribute(Qt::WA_TranslucentBackground);
     viewport()->setAutoFillBackground(false);
-    QPalette treePal = palette();
-    treePal.setColor(QPalette::Base, Qt::transparent);
-    treePal.setColor(QPalette::Window, Qt::transparent);
-    setPalette(treePal);
 
     connect(this, &DTreeView::clicked, d, &SideBarViewPrivate::currentChanged);
     connect(this, &DTreeView::doubleClicked, d, &SideBarViewPrivate::onItemDoubleClicked);
 
+    d->originPalette = palette();
     d->lastOpTime = 0;
 
     setStyle(new SidebarViewStyle(style()));
@@ -811,9 +820,12 @@ void SideBarView::onChangeExpandState(const QModelIndex &index, bool expand)
     if (!item)
         return;
 
-    this->setExpanded(index, expand);
-
     SideBarItemSeparator *groupItem = dynamic_cast<SideBarItemSeparator *>(item);
+
+    d->setTransparentPalette();
+    setExpanded(index, expand);
+    d->restorePalette();
+
     if (groupItem) {
         groupItem->setExpanded(expand);
         const QVariantMap &gMap = SideBarHelper::groupExpandRules();


### PR DESCRIPTION
Implement transparent palette handling during sidebar item expansion to prevent visual artifacts. Store the original palette and temporarily set a transparent background when expanding/collapsing items.

Log: Improve sidebar view rendering stability

Bug: https://pms.uniontech.com/bug-view-307543.html
Bug: https://pms.uniontech.com/bug-view-307537.html

## Summary by Sourcery

Implements transparent palette handling during sidebar item expansion and collapsing to prevent visual artifacts such as flickering. It stores the original palette and temporarily sets a transparent background when expanding/collapsing items.

Bug Fixes:
- Fixes palette flickering during sidebar item expansion.
- Fixes palette flickering during sidebar item collapsing.