### PR TITLE
fix: Ignore "Not Authorized Dismissed" error when ejecting devices

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
@@ -375,13 +375,13 @@ void ComputerController::actEject(const QUrl &url)
     if (url.path().endsWith(SuffixInfo::kBlock)) {
         id = ComputerUtils::getBlockDevIdByUrl(url);
         DevMngIns->detachBlockDev(id, [](bool ok, const DFMMOUNT::OperationErrorInfo &err) {
-            if (!ok)
+            if (!ok && err.code != DFMMOUNT::DeviceError::kUDisksErrorNotAuthorizedDismissed)
                 DialogManagerInstance->showErrorDialogWhenOperateDeviceFailed(DFMBASE_NAMESPACE::DialogManager::kUnmount, err);
         });
     } else if (url.path().endsWith(SuffixInfo::kProtocol)) {
         id = ComputerUtils::getProtocolDevIdByUrl(url);
         DevMngIns->unmountProtocolDevAsync(id, {}, [=](bool ok, const DFMMOUNT::OperationErrorInfo &err) {
-            if (!ok) {
+            if (!ok  && err.code != DFMMOUNT::DeviceError::kUDisksErrorNotAuthorizedDismissed) {
                 fmInfo() << "unmount protocol device failed: " << id << err.message << err.code;
                 DialogManagerInstance->showErrorDialogWhenOperateDeviceFailed(DFMBASE_NAMESPACE::DialogManager::kUnmount, err);
             }


### PR DESCRIPTION
Modify device ejection logic to suppress specific authorization dismissal errors during unmount operations, preventing unnecessary error dialogs for user-cancelled actions.

Log: Improve device ejection error handling
Bug: https://pms.uniontech.com/bug-view-305945.html

## Summary by Sourcery

Bug Fixes:
- Prevent unnecessary error dialogs from appearing when a user cancels a device ejection.