### PR TITLE
fix: Enhance tooltip functionality for device items in file manager

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.h
@@ -12,6 +12,7 @@
 
 namespace dfmplugin_computer {
 
+struct DeviceItemInfo;
 class ComputerView;
 class ComputerItemDelegate : public QStyledItemDelegate
 {
@@ -28,6 +29,7 @@ public:
     virtual void setEditorData(QWidget *editor, const QModelIndex &index) const override;
     virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
     virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 
     void closeEditor(ComputerView *view);
 
@@ -45,6 +47,10 @@ private:
     QPixmap renderBlurShadow(const QSize &sz, const QColor &color, int blurRadius) const;
     QPixmap renderBlurShadow(const QPixmap &pm, int blurRadius) const;
     QColor getProgressTotalColor() const;
+
+    DeviceItemInfo calculateDeviceLabelInfo(const QStyleOptionViewItem &option, const QModelIndex &index, const QFont &font) const;
+    void showLargeItemToolTip(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index);
+    void showSmallItemToolTip(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index);
 
 private:
     ComputerView *view { nullptr };


### PR DESCRIPTION
- Introduce a new structure, DeviceItemInfo, to encapsulate device label information.
- Implement tooltip support for both small and large device items, improving user experience by displaying device names on hover.
- Refactor device label drawing logic to utilize the new structure for better maintainability and clarity.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-307235.html

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where device names were not fully displayed, especially when truncated in the file manager's device list.