### PR TITLE
fix: Add tooltip support for elided display names in ComputerItemDelegate

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.h
@@ -28,6 +28,7 @@ public:
     virtual void setEditorData(QWidget *editor, const QModelIndex &index) const override;
     virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
     virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    virtual bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 
     void closeEditor(ComputerView *view);
 

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -167,6 +167,9 @@ QVariant ComputerModel::data(const QModelIndex &index, int role) const
     case kDeviceDescriptionRole:
         return item->info ? item->info->description() : "";
 
+    case kDisplayNameIsElidedRole:
+        return item->isElided;
+
     default:
         return {};
     }
@@ -186,6 +189,9 @@ bool ComputerModel::setData(const QModelIndex &index, const QVariant &value, int
         return true;
     } else if (role == DataRoles::kItemIsEditingRole) {
         item.isEditing = value.toBool();
+        return true;
+    } else if (role == DataRoles::kDisplayNameIsElidedRole) {
+        item.isElided = value.toBool();
         return true;
     }
     return false;

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.h
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.h
@@ -43,6 +43,7 @@ public:
         kActionListRole,   // return the action list that item should have
         kItemIsEditingRole,   // bool: if an item is renaming
         kDeviceDescriptionRole,
+        kDisplayNameIsElidedRole // bool
     };
     Q_ENUM(DataRoles)
 

--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.h
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.h
@@ -36,6 +36,7 @@ struct ComputerItemData
     int groupId;
     QWidget *widget { nullptr };
     bool isEditing = false;
+    bool isElided = false;
     DFMEntryFileInfoPointer info { nullptr };
 };
 


### PR DESCRIPTION
Implement tooltip functionality to show full display names when they are elided in the file manager. This includes updates to the ComputerItemDelegate to handle help events and modifications to the ComputerModel to track elided state.

Log: Enhance user experience with tooltips for truncated names
Bug: https://pms.uniontech.com/bug-view-307235.html

## Summary by Sourcery

Implements tooltips to display the full name of elided items in the file manager, enhancing user experience by providing complete information when names are truncated.

Bug Fixes:
- Adds tooltip support for elided display names in ComputerItemDelegate to show the full name when it's truncated.
- Fixes a bug where elided display names did not show the full name on hover.