### PR TITLE
fix: update file opening logic in LocalFileHandler

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -295,7 +295,7 @@ bool LocalFileHandler::openFiles(const QList<QUrl> &fileUrls)
     if (!pathList.empty()) {
         result = d->doOpenFiles(pathList);
     } else {
-        result = true;
+        result = d->invalidPath.isEmpty();
     }
 
     return result;


### PR DESCRIPTION
Change the return value in LocalFileHandler::openFiles to check for empty invalidPath instead of always returning true when no paths are provided. This improves error handling during file opening operations.

Log: Enhance file opening validation
Bug: https://pms.uniontech.com/bug-view-307117.html

## Summary by Sourcery

Bug Fixes:
- Fix error handling during file opening operations by validating invalid paths.