### PR TITLE
fix: Adjust icon positioning in ComputerItemDelegate

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -329,9 +329,14 @@ void ComputerItemDelegate::drawDeviceIcon(QPainter *painter, const QStyleOptionV
 {
     const auto &icon = index.data(Qt::ItemDataRole::DecorationRole).value<QIcon>();
     const int IconSize = view->iconSize().width();
-    int y = option.rect.y() + (sizeHint(option, index).height() - IconSize) / 2;
+    const int topMargin = (sizeHint(option, index).height() - IconSize) / 2;
+
+    QRect iconRect = option.rect;
+    iconRect.setSize(view->iconSize());
+    iconRect.moveTopLeft(iconRect.topLeft() + QPoint(kIconLeftMargin, topMargin));
+
     auto pm = getScaledPixmap(icon, IconSize, painter);
-    painter->drawPixmap(option.rect.x() + kIconLeftMargin, y, pm);
+    painter->drawPixmap(iconRect, pm);
 }
 
 void ComputerItemDelegate::drawDeviceLabelAndFs(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const


### PR DESCRIPTION
Refactor the icon drawing logic in ComputerItemDelegate to improve the positioning of device icons. The new implementation calculates the top margin for better alignment and uses a QRect for drawing the icon, enhancing visual consistency in the file manager.

Log: Improve icon rendering in file manager
Bug: https://pms.uniontech.com/bug-view-308487.html

## Summary by Sourcery

Enhancements:
- Improve the positioning of device icons in ComputerItemDelegate by calculating the top margin for better alignment and using a QRect for drawing the icon.