### PR TITLE
fix: filter shared files by user group in UserShareHelper

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
@@ -348,6 +348,9 @@ void UserShareHelper::readShareInfos(bool sendSignal)
     QDir d(ShareConfig::kShareConfigPath);
     QFileInfoList shareList = d.entryInfoList(QDir::Files | QDir::Hidden);
     for (const auto &fileInfo : shareList) {
+        if (fileInfo.groupId() != SysInfoUtils::getUserId())
+            continue;
+
         QString filePath = fileInfo.absoluteFilePath();
         QFile file(filePath);
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {


### PR DESCRIPTION
Update the readShareInfos method in UserShareHelper to only process files that belong to the current user group. This change enhances security by preventing access to shared files not owned by the user.

Log: as above.
Bug: https://pms.uniontech.com/bug-view-298951.html

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where users could access shared files not owned by their user group.