### PR TITLE
fix: update size policy for tag widget and detail view

### DIFF
--- a/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
@@ -16,6 +16,7 @@
 #endif
 
 #include <QVBoxLayout>
+#include <QSizePolicy>
 
 DWIDGET_USE_NAMESPACE
 DTK_USE_NAMESPACE
@@ -48,6 +49,8 @@ void TagWidgetPrivate::initializeUI()
     colorListWidget->setMaximumHeight(30);
     colorListWidget->setObjectName("tagActionWidget");
     colorListWidget->setToolTipVisible(false);
+
+    colorListWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
     crumbEdit = new TagCrumbEdit(q);
     crumbEdit->setObjectName("tagCrumbEdit");
@@ -85,6 +88,6 @@ void TagWidgetPrivate::initUiForSizeMode()
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
     mainLayout->setContentsMargins(DSizeModeHelper::element(5, 10), 6, 10, 10);
-    colorListWidget->setFixedWidth(214);
+    colorListWidget->setMaximumWidth(214);
 #endif
 }

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
@@ -68,6 +68,7 @@ bool DetailView::insertCustomControl(int index, QWidget *widget)
 
     if (widget) {
         widget->setParent(this);
+        widget->setMaximumWidth(scrollArea->width() - vLayout->contentsMargins().right());
         QFrame *frame = new QFrame(this);
         DPushButton *btn = new DPushButton(frame);
         btn->setEnabled(false);


### PR DESCRIPTION
- Set size policy for colorListWidget in TagWidgetPrivate to ensure proper layout behavior.
- Adjust maximum width for inserted custom controls in DetailView to enhance UI responsiveness.

Log: Improve widget sizing and layout consistency
Bug: https://pms.uniontech.com/zentao/bug-view-271627.html

## Summary by Sourcery

Improve widget sizing and layout consistency by adjusting the size policy for the tag widget and the maximum width for inserted custom controls in the detail view.

Bug Fixes:
- Fixes an issue where the color list widget in the tag widget did not have a proper size policy, leading to layout issues.
- Adjusts the maximum width for inserted custom controls in the detail view to enhance UI responsiveness.