### PR TITLE
fix: update mouse hover background color in SideBarItemDelegate

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -461,11 +461,11 @@ void SideBarItemDelegate::drawDciIcon(const QStyleOptionViewItem &option, QPaint
 
 void SideBarItemDelegate::drawMouseHoverBackground(QPainter *painter, const DPalette &palette, const QRect &r, const QColor &widgetColor) const
 {
-    auto mouseHoverColor = palette.color(DPalette::ColorGroup::Active, DPalette::ColorType::ObviousBackground);
+    QColor mouseHoverColor;
     if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType)
-        mouseHoverColor = DGuiApplicationHelper::adjustColor(widgetColor, 0, 0, 5, 0, 0, 0, 0);
+        mouseHoverColor = QColor(255, 255, 255, 25);  // 白色，10%透明度
     else
-        mouseHoverColor = mouseHoverColor.lighter();
+        mouseHoverColor = QColor(0, 0, 0, 25);  // 黑色，10%透明度
 
     painter->setBrush(mouseHoverColor);
     painter->setPen(Qt::NoPen);


### PR DESCRIPTION
- Changed the mouse hover background color logic to use fixed RGBA values for better consistency across themes. The new implementation provides a 10% transparency effect for both dark and light themes, enhancing the visual feedback during mouse hover events.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-307543.html

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent mouse hover background color across themes by using fixed RGBA values.