### PR TITLE
fix: update delete confirmation dialog icon logic

### DIFF
--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -469,7 +469,8 @@ int DialogManager::showNormalDeleteConfirmDialog(const QList<QUrl> &urls)
     }
 
     QFontMetrics fm(d.font());
-    d.setIcon(QIcon::fromTheme("user-trash-full-opened"));
+    const auto &icon = FileUtils::trashIsEmpty() ? QIcon::fromTheme("user-trash") : QIcon::fromTheme("user-trash-full");
+    d.setIcon(icon);
 
     QString deleteFileName = tr("Do you want to delete %1?");
     QString deleteFileItems = tr("Do you want to delete the selected %1 items?");


### PR DESCRIPTION
Refactor the icon setting in the delete confirmation dialog to dynamically choose between an empty or full trash icon based on the state of the trash. This improves user feedback when confirming deletions.

Log: as above.
Bug: https://pms.uniontech.com/bug-view-292229.html

## Summary by Sourcery

Bug Fixes:
- Fixes the delete confirmation dialog to display the correct trash icon.