### PR TITLE
fix: enhance drag-and-drop functionality in file manager

### DIFF
--- a/src/plugins/filemanager/dfmplugin-optical/optical.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/optical.cpp
@@ -142,6 +142,7 @@ void Optical::addCustomTopWidget()
     QVariantMap map {
         { "Property_Key_Scheme", Global::Scheme::kBurn },
         { "Property_Key_KeepShow", false },
+        { "Property_Key_KeepTop", false },
         { "Property_Key_CreateTopWidgetCallback", QVariant::fromValue(createCallback) },
         { "Property_Key_ShowTopWidgetCallback", QVariant::fromValue(showCallback) }
     };

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -105,6 +105,7 @@ void Search::regSearchToWorkspace()
     QVariantMap map {
         { "Property_Key_Scheme", SearchHelper::scheme() },
         { "Property_Key_KeepShow", false },
+        { "Property_Key_KeepTop", true },
         { "Property_Key_CreateTopWidgetCallback", QVariant::fromValue(createCallback) },
         { "Property_Key_ShowTopWidgetCallback", QVariant::fromValue(showCallback) }
     };

--- a/src/plugins/filemanager/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/trash.cpp
@@ -143,6 +143,7 @@ void Trash::addCustomTopWidget()
     QVariantMap map {
         { "Property_Key_Scheme", TrashHelper::scheme() },
         { "Property_Key_KeepShow", false },
+        { "Property_Key_KeepTop", false },
         { "Property_Key_CreateTopWidgetCallback", QVariant::fromValue(createCallback) },
         { "Property_Key_ShowTopWidgetCallback", QVariant::fromValue(showCallback) }
     };

--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -85,6 +85,7 @@ inline constexpr int kSelectBoxLineWidth { 2 };
 namespace PropertyKey {
 inline constexpr char kScheme[] { "Property_Key_Scheme" };
 inline constexpr char kKeepShow[] { "Property_Key_KeepShow" };
+inline constexpr char kKeepTop[] { "Property_Key_KeepTop" };
 inline constexpr char kCreateTopWidgetCallback[] { "Property_Key_CreateTopWidgetCallback" };
 inline constexpr char kShowTopWidgetCallback[] { "Property_Key_ShowTopWidgetCallback" };
 }
@@ -98,6 +99,7 @@ struct CustomTopWidgetInfo
 {
     QString scheme;
     bool keepShow { false };   // always show
+    bool keepTop { false };    // top of all topWidget
     CreateTopWidgetCallback createTopWidgetCb { nullptr };
     ShowTopWidgetCallback showTopWidgetCb { nullptr };
 
@@ -105,6 +107,7 @@ struct CustomTopWidgetInfo
     inline CustomTopWidgetInfo(const QVariantMap &map)
         : scheme { map[PropertyKey::kScheme].toString() },
           keepShow { map[PropertyKey::kKeepShow].toBool() },
+          keepTop { map[PropertyKey::kKeepTop].toBool() },
           createTopWidgetCb { DPF_NAMESPACE::paramGenerator<CreateTopWidgetCallback>(map[PropertyKey::kCreateTopWidgetCallback]) },
           showTopWidgetCb { DPF_NAMESPACE::paramGenerator<ShowTopWidgetCallback>(map[PropertyKey::kShowTopWidgetCallback]) }
     {

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -342,6 +342,7 @@ void WorkspaceEventReceiver::handleRegisterCustomTopWidget(const QVariantMap &da
             new CustomTopWidgetInterface
         };
         interface->setKeepShow(info.keepShow);
+        interface->setKeepTop(info.keepTop);
         interface->registeCreateTopWidgetCallback(info.createTopWidgetCb);
         interface->registeCreateTopWidgetCallback(info.showTopWidgetCb);
         return interface;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/customtopwidgetinterface.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/customtopwidgetinterface.cpp
@@ -37,6 +37,16 @@ bool CustomTopWidgetInterface::isKeepShow() const
     return keepShow;
 }
 
+void CustomTopWidgetInterface::setKeepTop(bool keep)
+{
+    keepTop = keep;
+}
+
+bool CustomTopWidgetInterface::isKeepTop() const
+{
+    return keepTop;
+}
+
 void CustomTopWidgetInterface::registeCreateTopWidgetCallback(const ShowTopWidgetCallback &func)
 {
     showTopWidgetFunc = func;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/customtopwidgetinterface.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/customtopwidgetinterface.h
@@ -25,11 +25,14 @@ public:
     bool isShowFromUrl(QWidget *w, const QUrl &url);
     void setKeepShow(bool keep);
     bool isKeepShow() const;
+    void setKeepTop(bool keep);
+    bool isKeepTop() const;
     void registeCreateTopWidgetCallback(const CreateTopWidgetCallback &func);
     void registeCreateTopWidgetCallback(const ShowTopWidgetCallback &func);
 
 private:
     bool keepShow { false };
+    bool keepTop { false };
     CreateTopWidgetCallback createTopWidgetFunc;
     ShowTopWidgetCallback showTopWidgetFunc;
 };

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.h
@@ -46,6 +46,9 @@ private:
     bool checkTargetEnable(const QUrl &targetUrl) const;
     Qt::DropAction checkAction(Qt::DropAction srcAction, bool sameUser);
 
+    bool checkDragEnable(const QUrl &dragUrl, const QUrl &targetUrl) const;
+    bool checkMoveEnable(const QUrl &dragUrl, const QUrl &toUrl) const;
+
     FileView *view { nullptr };
     QList<QUrl> currentDragUrls;
     QList<QUrl> currentDragSourceUrls;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1091,6 +1091,9 @@ void FileView::onShowFileSuffixChanged(bool isShow)
 void FileView::updateHorizontalOffset()
 {
     d->updateHorizontalOffset();
+
+    // Update editor positions after horizontal offset changes
+    updateEditorGeometries();
 }
 
 void FileView::updateView()

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.h
@@ -53,6 +53,10 @@ private:
     void setCurrentView(const QUrl &url);
     void playDisappearAnimation(ViewPtr view);
 
+    QWidget *topContainer { nullptr };     // 顶部容器
+    QVBoxLayout *topLayout { nullptr };    // 顶部布局
+    QWidget *viewContainer { nullptr };    // 视图容器
+
     QVBoxLayout *widgetLayout { nullptr };
     QStackedLayout *viewStackLayout { nullptr };
 
@@ -65,6 +69,7 @@ private:
 
     QMap<QString, ViewPtr> views {};
     QMap<QString, TopWidgetPtr> topWidgets {};
+    int highPriorityTopWidgetsCount { 0 };
 };
 
 } // namespace dfmplugin_workspace

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.cpp
@@ -79,6 +79,7 @@ bool Workspace::start()
             return new RenameBar();
         });
         interface->setKeepShow(false);
+        interface->setKeepTop(false);
         return interface;
     });
 


### PR DESCRIPTION
- Refactor dragEnter and dragMove methods to improve handling of drag-and-drop events.
- Introduce checks for desktop files to allow deletion to trash while restricting move and copy actions based on file attributes.
- Ensure proper event handling for various file types to enhance user experience.

Log: Improve drag-and-drop behavior in file manager
Bug: https://pms.uniontech.com/zentao/bug-view-285659.html

## Summary by Sourcery

Improves drag-and-drop functionality in the file manager by refining event handling for various file types, including desktop files, to allow deletion to trash while restricting move and copy actions based on file attributes.

Bug Fixes:
- Fixes an issue where drag-and-drop operations were not properly handled for desktop files, especially regarding deletion to trash and restrictions on move/copy actions.
- Addresses a bug related to file attributes affecting drag-and-drop behavior, ensuring a smoother user experience.