### PR TITLE
fix: introduce canonicalMountPoint method for mount point normalization

### DIFF
--- a/src/dfm-base/base/device/private/deviceproxymanager_p.h
+++ b/src/dfm-base/base/device/private/deviceproxymanager_p.h
@@ -35,6 +35,7 @@ public:
     bool isDBusRuning();
     void initConnection();
     void initMounts();
+    QString canonicalMountPoint(const QString &mpt) const;
 
     void connectToDBus();
     void connectToAPI();


### PR DESCRIPTION
- Added a new method `canonicalMountPoint` in `DeviceProxyManagerPrivate` to standardize mount point formatting by ensuring it ends with a trailing slash and resolves to the canonical file path if it exists.
- Updated existing calls to mount point handling in `initMounts` and `addMounts` to utilize the new method, improving code consistency and readability.

Log: as above.

Bug: https://pms.uniontech.com/bug-view-307049.html

## Summary by Sourcery

Enhancements:
- Introduce a canonicalMountPoint method for mount point normalization.