### PR TITLE
fix: update error message translation in file operations

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -665,7 +665,7 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doReadFile(const DFileInfoPointer &fr
                             toInfo->uri(),
                             AbstractJobHandler::JobErrorType::kCanNotAccessFile,
                             true,
-                            "Can't access file!");
+                            tr("Can't access file!"));
                 } while (actionForCheck == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
                 if (actionForCheck != AbstractJobHandler::SupportAction::kNoAction) {
                     if (skip)
@@ -779,7 +779,7 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doWriteFileErrorRetry(const DFileInfo
                 toInfo->uri(),
                 AbstractJobHandler::JobErrorType::kCanNotAccessFile,
                 true,
-                "Can't access file!");
+                tr("Can't access file!"));
     } while (actionForWrite == AbstractJobHandler::SupportAction::kRetryAction && !isStopped());
     if (actionForWrite != AbstractJobHandler::SupportAction::kNoAction) {
         actionOperating(actionForWrite, fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong() - (currentPos + readSize - surplusSize), skip);


### PR DESCRIPTION
Replaced hardcoded error messages with translatable strings in the DoCopyFileWorker class to improve localization support. This change ensures that error messages are properly translated based on the user's language settings.

Log: as above.
Bug: https://pms.uniontech.com/bug-view-303435.html

## Summary by Sourcery

Enhancements:
- Replaces hardcoded error messages with translatable strings to improve localization support.