### PR TITLE
fix: open the last visited path in dialog

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -55,12 +55,15 @@ FileDialogPrivate::FileDialogPrivate(FileDialog *qq)
 
     QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
     lastVisitedDir = qtSets.value("FileDialog/lastVisited").toUrl();
+
+    delaySaveTimer = new QTimer(this);
+    delaySaveTimer->setInterval(3000);
+    connect(delaySaveTimer, &QTimer::timeout, this, &FileDialogPrivate::saveLastVisited);
 }
 
 FileDialogPrivate::~FileDialogPrivate()
 {
-    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
-    qtSets.setValue("FileDialog/lastVisited", lastVisitedDir.toString());
+    saveLastVisited();
 }
 
 void FileDialogPrivate::handleSaveAcceptBtnClicked()
@@ -209,6 +212,18 @@ bool FileDialogPrivate::checkFileSuffix(const QString &filename, QString &suffix
     }
 
     return false;
+}
+
+void FileDialogPrivate::setLastVisited(const QUrl &dir)
+{
+    lastVisitedDir = dir;
+    delaySaveTimer->start();
+}
+
+void FileDialogPrivate::saveLastVisited()
+{
+    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
+    qtSets.setValue("FileDialog/lastVisited", lastVisitedDir.toString());
 }
 
 /*!

--- a/src/plugins/filedialog/core/views/filedialog_p.h
+++ b/src/plugins/filedialog/core/views/filedialog_p.h
@@ -36,6 +36,10 @@ public:
     void handleOpenAcceptBtnClicked();
     void handleOpenNewWindow(const QUrl &url);
     bool checkFileSuffix(const QString &filename, QString &suffix);
+    void setLastVisited(const QUrl &dir);
+
+public Q_SLOTS:
+    void saveLastVisited();
 
 private:
     static constexpr int kDefaultWindowWidth { 960 };
@@ -57,6 +61,7 @@ private:
     QFileDialog::Options options;
     QUrl currentUrl;
     QUrl lastVisitedDir;
+    QTimer *delaySaveTimer { nullptr };
 
     static QStringList cleanFilterList(const QString &filter)
     {


### PR DESCRIPTION
- fix memleak, the destructor of FileDialog is never invoked;
- add timer to delay save the lastVisitedUrl;

Log: as above.

## Summary by Sourcery

Fixes a memory leak in the FileDialog by using a QScopedPointer for the dialog. Adds a timer to delay saving the last visited URL.

Bug Fixes:
- Fixes a memory leak where the FileDialog destructor was not being called.

Enhancements:
- Delays saving the last visited URL using a timer.