### PR TITLE
fix: improve final URL determination in sidebar item creation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -725,12 +725,24 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
         AbstractEntryFileEntity::kOrderMTP
     };
 
+    // 光驱的url对应挂载点和虚拟url两个值，传虚拟url到侧边栏便于创建对应文件信息做实际业务逻辑判断
+    QUrl finalUrl = info->targetUrl().isValid() ? info->targetUrl() : QUrl();
+    if (routeMapper.contains(info->fileUrl())) {
+        const QList<QUrl> &urls { routeMapper.values(info->fileUrl()) };
+        for (auto url : urls) {
+            if (!UniversalUtils::urlEquals(finalUrl, url)) {
+                finalUrl = url;
+                break;
+            }
+        }
+    }
+
     return {
         { "Property_Key_Group", visableKey == kItemVisiableControlKeys[3] ? "Group_Network" : "Group_Device" },
         { "Property_Key_SubGroup", subGroup },
         { "Property_Key_DisplayName", info->displayName() },
         { "Property_Key_Icon", QIcon::fromTheme(iconName) },
-        { "Property_Key_FinalUrl", info->targetUrl().isValid() ? info->targetUrl() : QUrl() },
+        { "Property_Key_FinalUrl", finalUrl },
         { "Property_Key_QtItemFlags", QVariant::fromValue(flags) },
         { "Property_Key_Ejectable", ejectableOrders.contains(info->order()) || netShareSchemes.contains(netShareUrl.scheme()) },
         { "Property_Key_CallbackItemClicked", QVariant::fromValue(cdCb) },

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -661,7 +661,10 @@ Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *
     if (!itemInfo || !itemInfo->canAttributes(CanableInfoType::kCanDrop)) {
         return Qt::IgnoreAction;
     }
-    if (itemInfo->fileType() == FileInfo::FileType::kDirectory) {
+
+    // do not check the permissions when the dir is not a real dir
+    if (itemInfo->fileType() == FileInfo::FileType::kDirectory
+        && UniversalUtils::urlEquals(targetItemUrl, itemInfo->urlOf(UrlInfoType::kOriginalUrl))) {
         // when the dir not have writeable and executable permissions, then can not drop
         if (!itemInfo->isAttributes(OptInfoType::kIsExecutable) || !itemInfo->isAttributes(OptInfoType::kIsWritable))
             return Qt::IgnoreAction;


### PR DESCRIPTION
- Enhanced the logic in `makeSidebarItem` to ensure the correct final URL is set for sidebar items by checking against a list of mapped URLs.
- Updated the `canDropMimeData` method to avoid permission checks for non-real directories, improving drag-and-drop functionality.

Log: Refine URL handling and drag-and-drop checks in sidebar functionality.
Bug: https://pms.uniontech.com/zentao/bug-view-301303.html

## Summary by Sourcery

Improve the sidebar functionality by refining URL handling for sidebar items and updating drag-and-drop checks.

Bug Fixes:
- Ensure the correct final URL is set for sidebar items by checking against a list of mapped URLs.
- Avoid permission checks for non-real directories in `canDropMimeData`, improving drag-and-drop functionality.