### PR TITLE
fix: improve final URL resolution in sidebar item updates

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
@@ -119,6 +119,8 @@ private:
 
     QString reportName(const QUrl &url);
 
+    QUrl findFinalUrl(DFMEntryFileInfoPointer info) const;
+
 private:
     bool isItemQueryFinished { false };
     ComputerDataList initedDatas;


### PR DESCRIPTION
- Added a new method `findFinalUrl` to enhance the determination of the final URL for sidebar items, ensuring accurate mapping against existing URLs.
- Updated the `updateSidebarItem` and `makeSidebarItem` methods to utilize the new `findFinalUrl` method, improving the handling of virtual URLs for optical drives.

Log: Refine final URL handling in sidebar item management.
Bug: https://pms.uniontech.com/zentao/bug-view-301303.html

## Summary by Sourcery

Improve the final URL resolution for sidebar items, especially for optical drives, by introducing a dedicated method to determine the correct URL to use for mapping and identification.

Bug Fixes:
- Ensure accurate mapping of sidebar items against existing URLs, particularly for optical drives with both mount point and virtual URLs.
- Fixes a bug where the incorrect URL was being used for sidebar items, leading to issues with file information and business logic.