### PR TITLE
6.5.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.41) unstable; urgency=medium
+
+  * fix bugs 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 20 Mar 2025 21:20:03 +0800
+
 dde-file-manager (6.5.40) unstable; urgency=medium
 
   * Enhance URL determination, fix UI errors, improve file operations, update translations, and implement features like mount point normalization, drag-and-drop enhancements, and file copy synchronization with range support, alongside various UI and localization improvements. 

--- a/src/plugins/filedialog/core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandle.cpp
@@ -30,7 +30,7 @@ public:
     explicit FileDialogHandlePrivate(FileDialogHandle *qq)
         : q_ptr(qq) { }
 
-    QScopedPointer<FileDialog> dialog;
+    QPointer<FileDialog> dialog;
     QStringList lastFilterGroup;
     QString lastFilter;
 
@@ -43,7 +43,7 @@ FileDialogHandle::FileDialogHandle(QWidget *parent)
     : QObject(parent),
       d_ptr(new FileDialogHandlePrivate(this))
 {
-    d_func()->dialog.reset(qobject_cast<FileDialog *>(FMWindowsIns.createWindow({}, true)));
+    d_func()->dialog = qobject_cast<FileDialog *>(FMWindowsIns.createWindow({}, true));
     if (!d_func()->dialog) {
         fmCritical() << "File Dialog: Create window failed";
         abort();
@@ -57,14 +57,14 @@ FileDialogHandle::FileDialogHandle(QWidget *parent)
     //! see bug#22564
     // d_func()->dialog->hide();
 
-    connect(d_func()->dialog.data(), &FileDialog::accepted, this, &FileDialogHandle::accepted);
-    connect(d_func()->dialog.data(), &FileDialog::rejected, this, &FileDialogHandle::rejected);
-    connect(d_func()->dialog.data(), &FileDialog::finished, this, &FileDialogHandle::finished);
-    connect(d_func()->dialog.data(), &FileDialog::selectionFilesChanged,
+    connect(d_func()->dialog, &FileDialog::accepted, this, &FileDialogHandle::accepted);
+    connect(d_func()->dialog, &FileDialog::rejected, this, &FileDialogHandle::rejected);
+    connect(d_func()->dialog, &FileDialog::finished, this, &FileDialogHandle::finished);
+    connect(d_func()->dialog, &FileDialog::selectionFilesChanged,
             this, &FileDialogHandle::selectionFilesChanged);
-    connect(d_func()->dialog.data(), &FileDialog::currentUrlChanged,
+    connect(d_func()->dialog, &FileDialog::currentUrlChanged,
             this, &FileDialogHandle::currentUrlChanged);
-    connect(d_func()->dialog.data(), &FileDialog::selectedNameFilterChanged,
+    connect(d_func()->dialog, &FileDialog::selectedNameFilterChanged,
             this, &FileDialogHandle::selectedNameFilterChanged);
 
     auto window = qobject_cast<FileDialog *>(FMWindowsIns.findWindowById(d_func()->dialog->internalWinId()));
@@ -95,7 +95,7 @@ QWidget *FileDialogHandle::widget() const
 {
     D_DC(FileDialogHandle);
 
-    return d->dialog.data();
+    return d->dialog;
 }
 
 void FileDialogHandle::setDirectory(const QString &directory)
@@ -304,9 +304,9 @@ void FileDialogHandle::setViewMode(QFileDialog::ViewMode mode)
     D_D(FileDialogHandle);
 
     if (mode == QFileDialog::Detail)
-        CoreEventsCaller::sendViewMode(d->dialog.data(), DFMBASE_NAMESPACE::Global::ViewMode::kListMode);
+        CoreEventsCaller::sendViewMode(d->dialog, DFMBASE_NAMESPACE::Global::ViewMode::kListMode);
     else
-        CoreEventsCaller::sendViewMode(d->dialog.data(), DFMBASE_NAMESPACE::Global::ViewMode::kIconMode);
+        CoreEventsCaller::sendViewMode(d->dialog, DFMBASE_NAMESPACE::Global::ViewMode::kIconMode);
 }
 
 QFileDialog::ViewMode FileDialogHandle::viewMode() const
@@ -487,12 +487,12 @@ void FileDialogHandle::show()
 {
     D_D(FileDialogHandle);
     if (d->dialog) {
-        addDefaultSettingForWindow(d->dialog.data());
+        addDefaultSettingForWindow(d->dialog);
         d->dialog->updateAsDefaultSize();
         d->dialog->moveCenter();
         setWindowStayOnTop();
         fmDebug() << QString("Select Dialog Info: befor show size is (%1, %2)").arg(d->dialog->width()).arg(d->dialog->height());
-        FMWindowsIns.showWindow(d->dialog.data());
+        FMWindowsIns.showWindow(d->dialog);
         fmDebug() << QString("Select Dialog Info: after show size is (%1, %2)").arg(d->dialog->width()).arg(d->dialog->height());
     }
 }

--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -55,15 +55,12 @@ FileDialogPrivate::FileDialogPrivate(FileDialog *qq)
 
     QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
     lastVisitedDir = qtSets.value("FileDialog/lastVisited").toUrl();
-
-    delaySaveTimer = new QTimer(this);
-    delaySaveTimer->setInterval(3000);
-    connect(delaySaveTimer, &QTimer::timeout, this, &FileDialogPrivate::saveLastVisited);
 }
 
 FileDialogPrivate::~FileDialogPrivate()
 {
-    saveLastVisited();
+    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
+    qtSets.setValue("FileDialog/lastVisited", lastVisitedDir.toString());
 }
 
 void FileDialogPrivate::handleSaveAcceptBtnClicked()
@@ -212,18 +209,6 @@ bool FileDialogPrivate::checkFileSuffix(const QString &filename, QString &suffix
     }
 
     return false;
-}
-
-void FileDialogPrivate::setLastVisited(const QUrl &dir)
-{
-    lastVisitedDir = dir;
-    delaySaveTimer->start();
-}
-
-void FileDialogPrivate::saveLastVisited()
-{
-    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
-    qtSets.setValue("FileDialog/lastVisited", lastVisitedDir.toString());
 }
 
 /*!

--- a/src/plugins/filedialog/core/views/filedialog_p.h
+++ b/src/plugins/filedialog/core/views/filedialog_p.h
@@ -36,10 +36,6 @@ public:
     void handleOpenAcceptBtnClicked();
     void handleOpenNewWindow(const QUrl &url);
     bool checkFileSuffix(const QString &filename, QString &suffix);
-    void setLastVisited(const QUrl &dir);
-
-public Q_SLOTS:
-    void saveLastVisited();
 
 private:
     static constexpr int kDefaultWindowWidth { 960 };
@@ -61,7 +57,6 @@ private:
     QFileDialog::Options options;
     QUrl currentUrl;
     QUrl lastVisitedDir;
-    QTimer *delaySaveTimer { nullptr };
 
     static QStringList cleanFilterList(const QString &filter)
     {


### PR DESCRIPTION
## Summary by Sourcery

Refactor FileDialogHandle to use QPointer instead of QScopedPointer for the dialog member, and remove the delay save timer for last visited directory, saving it directly in the destructor.

Enhancements:
- Replace QScopedPointer with QPointer for FileDialog in FileDialogHandle to avoid potential issues with object ownership and lifetime.
- Remove the delay save timer and save the last visited directory in the destructor for immediate persistence.