### PR TITLE
fix: add null checks for dialog in FileDialogHandle methods

### DIFF
--- a/src/plugins/filedialog/core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandle.cpp
@@ -145,9 +145,13 @@ void FileDialogHandle::selectFile(const QString &filename)
 {
     D_D(FileDialogHandle);
 
+    if (!d->dialog)
+        return;
+
     CoreHelper::delayInvokeProxy(
-            [d, filename] {
-                d->dialog->selectFile(filename);
+            [dialog = d->dialog, filename] {
+                if (dialog)
+                    dialog->selectFile(filename);
             },
             d->dialog->internalWinId(), this);
 }
@@ -165,9 +169,13 @@ void FileDialogHandle::selectUrl(const QUrl &url)
 {
     D_D(FileDialogHandle);
 
+    if (!d->dialog)
+        return;
+
     CoreHelper::delayInvokeProxy(
-            [d, url] {
-                d->dialog->selectUrl(url);
+            [dialog = d->dialog, url] {
+                if (dialog)
+                    dialog->selectUrl(url);
             },
             d->dialog->internalWinId(), this);
 }
@@ -185,9 +193,13 @@ void FileDialogHandle::addDisableUrlScheme(const QString &scheme)
 {
     D_D(FileDialogHandle);
 
+    if (!d->dialog)
+        return;
+
     CoreHelper::delayInvokeProxy(
-            [d, scheme] {
-                d->dialog->urlSchemeEnable(scheme, false);
+            [dialog = d->dialog, scheme] {
+                if (dialog)
+                    dialog->urlSchemeEnable(scheme, false);
             },
             d->dialog->internalWinId(), this);
 }
@@ -292,9 +304,13 @@ void FileDialogHandle::setFilter(QDir::Filters filters)
 {
     D_D(FileDialogHandle);
 
+    if (!d->dialog)
+        return;
+
     CoreHelper::delayInvokeProxy(
-            [d, filters]() {
-                d->dialog->setFilter(filters);
+            [dialog = d->dialog, filters]() {
+                if (dialog)
+                    dialog->setFilter(filters);
             },
             d->dialog->internalWinId(), this);
 }
@@ -323,9 +339,13 @@ void FileDialogHandle::setFileMode(QFileDialog::FileMode mode)
 {
     D_D(FileDialogHandle);
 
+    if (!d->dialog)
+        return;
+
     CoreHelper::delayInvokeProxy(
-            [d, mode]() {
-                d->dialog->setFileMode(mode);
+            [dialog = d->dialog, mode]() {
+                if (dialog)
+                    dialog->setFileMode(mode);
             },
             d->dialog->internalWinId(), this);
 }
@@ -333,10 +353,15 @@ void FileDialogHandle::setFileMode(QFileDialog::FileMode mode)
 void FileDialogHandle::setAcceptMode(QFileDialog::AcceptMode mode)
 {
     D_D(FileDialogHandle);
+    
+    if (!d->dialog)
+        return;
+    
     isSetAcceptMode = true;
     CoreHelper::delayInvokeProxy(
-            [d, mode]() {
-                d->dialog->setAcceptMode(mode);
+            [dialog = d->dialog, mode]() {
+                if (dialog)
+                    dialog->setAcceptMode(mode);
             },
             d->dialog->internalWinId(), this);
 }


### PR DESCRIPTION
- Implemented null checks for the dialog in multiple methods of FileDialogHandle to prevent potential crashes when the dialog is not initialized.
- Updated the lambda functions in `selectFile`, `selectUrl`, `addDisableUrlScheme`, `setFilter`, `setFileMode`, and `setAcceptMode` to ensure safe access to the dialog.

Log: Enhance stability by ensuring dialog existence before invoking methods.

## Summary by Sourcery

Bug Fixes:
- Adds null checks to prevent crashes when the dialog is not initialized.