### PR TITLE
feat: Enhance FileStatisticsJob functionality

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.h
+++ b/src/dfm-base/utils/filestatisticsjob.h
@@ -44,6 +44,7 @@ public:
         kDontSkipBlockDeviceFile = 0x0080,
         kDontSkipFIFOFile = 0x0100,
         kDontSkipSocketFile = 0x0200,
+        kDontSizeInfoPointer= 0x0400,
     };
 
     Q_ENUM(FileHint)
@@ -83,6 +84,7 @@ private:
 private:
     void setSizeInfo();
     void statistcsOtherFileSystem();
+    void statisticsRealPathSingle();
 };
 
 }

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1123,6 +1123,15 @@ QString FileUtils::makeQString(const QString::const_iterator &it, uint unicode)
     return *it;
 }
 
+QString FileUtils::symlinkTarget(const QUrl &url)
+{
+    char buffer[4096]{0};
+    auto size = readlink(url.path().toStdString().c_str(), buffer, sizeof(buffer));
+    if (size > 0)
+        return QString::fromUtf8(buffer, static_cast<int>(size));
+    return QString();
+}
+
 bool FileUtils::isSymbol(const QChar ch)
 {
     // 如果是高代理项，不应该单独判断

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -97,7 +97,7 @@ public:
 
     static bool isFullWidthChar(const QChar ch, QChar &normalized);
     static QString makeQString(const QString::const_iterator &it, uint unicode);
-
+    static QString symlinkTarget(const QUrl &url);
 private:
     static QMutex cacheCopyingMutex;
     static QSet<QUrl> copyingUrl;

--- a/src/dfm-base/utils/private/filestatisticsjob_p.h
+++ b/src/dfm-base/utils/private/filestatisticsjob_p.h
@@ -26,10 +26,16 @@ public:
 
     void processFile(const QUrl &url, const bool followLink, QQueue<QUrl> &directoryQueue);
     void processFile(const FileInfoPointer &info, const bool followLink, QQueue<QUrl> &directoryQueue);
+    void processFile(const QUrl &url, struct stat64* statBuffer, const bool followLink, QQueue<QUrl> &directoryQueue);
     void emitSizeChanged();
     int countFileCount(const char *name);
     bool checkFileType(const FileInfo::FileType &fileType);
     bool checkInode(const FileInfoPointer info);
+    bool checkInode(const __ino64_t innode, const QString &path);
+    FileInfo::FileType fileType(const __mode_t fileMode);
+    QString resolveSymlink(const QUrl &url);
+    void processDirectory(const QUrl &url, bool followLink, QQueue<QUrl> &directoryQueue);
+    void processRegularFile(const QUrl &url, struct stat64 *statBuffer, bool followLink);
 
     FileStatisticsJob *q;
     QTimer *notifyDataTimer;
@@ -50,6 +56,7 @@ public:
     QSet<QUrl> allFiles;
     QSet<QString> skipPath;
     QSet<quint64> inodelist;
+    QSet<QString> inodeAndPath;
     AbstractDirIteratorPointer iterator { nullptr };
     std::atomic_bool iteratorCanStop { false };
 };

--- a/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
@@ -144,6 +144,7 @@ void OpticalMediaWidget::initializeUi()
     lbAvailable->setAlignment(Qt::AlignCenter);
 
     statisticWorker = new FileStatisticsJob(this);
+    statisticWorker->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
 }
 
 void OpticalMediaWidget::initConnect()

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultentryfileentity.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultentryfileentity.cpp
@@ -17,6 +17,7 @@ VaultEntryFileEntity::VaultEntryFileEntity(QObject *parent)
     fileCalculationUtils = new FileStatisticsJob;
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &VaultEntryFileEntity::slotFileDirSizeChange);
     connect(fileCalculationUtils, &FileStatisticsJob::finished, this, &VaultEntryFileEntity::slotFinishedThread);
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
 }
 
 VaultEntryFileEntity::~VaultEntryFileEntity()

--- a/src/plugins/filemanager/dfmplugin-vault/views/vaultpropertyview/basicwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/vaultpropertyview/basicwidget.cpp
@@ -25,6 +25,7 @@ BasicWidget::BasicWidget(QWidget *parent)
     initUI();
     fileCalculationUtils = new FileStatisticsJob;
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &BasicWidget::slotFileCountAndSizeChange);
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
 }
 
 BasicWidget::~BasicWidget()

--- a/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
+++ b/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <dfm-base/utils/filestatisticsjob.h>
-#include <dfm-base/utils/private/filestatissticsjob_p.h>
+#include <dfm-base/utils/private/filestatisticsjob_p.h>
 #include <dfm-base/base/schemefactory.h>
 
 #include <DComboBox>


### PR DESCRIPTION
- Added support for processing files with symlink handling in `processFile` method.
- Introduced `countFileCountAndSize` method to count files and their sizes in a directory.
- Implemented `checkInode` method to track inodes and prevent processing of duplicate files.
- Added `fileType` method to determine the type of file based on its mode.
- Updated `statistcsRealPathSingle` method to handle single file statistics more effectively.
- Introduced `symlinkTarget` utility function to retrieve the target of a symlink.
- Enhanced file hints with `kDontSizeInfoPointer` to manage size information pointers.
- Updated various UI components to utilize new file hints for better file statistics handling.

This commit improves the overall file processing capabilities and addresses issues related to symlink handling and file counting.

Log: Enhance FileStatisticsJob functionality

## Summary by Sourcery

Enhance FileStatisticsJob to improve file processing capabilities, including symlink handling and file counting, and update UI components to utilize new file hints for better file statistics handling.

New Features:
- Add support for processing files with symlink handling in `processFile` method.
- Introduce `countFileCountAndSize` method to count files and their sizes in a directory.
- Implement `checkInode` method to track inodes and prevent processing of duplicate files.
- Add `fileType` method to determine the type of file based on its mode.
- Update `statistcsRealPathSingle` method to handle single file statistics more effectively.
- Introduce `symlinkTarget` utility function to retrieve the target of a symlink.
- Enhance file hints with `kDontSizeInfoPointer` to manage size information pointers.
- Update various UI components to utilize new file hints for better file statistics handling.