### PR TITLE
feat: Enhance FileStatisticsJob functionality

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.h
+++ b/src/dfm-base/utils/filestatisticsjob.h
@@ -44,6 +44,7 @@ public:
         kDontSkipBlockDeviceFile = 0x0080,
         kDontSkipFIFOFile = 0x0100,
         kDontSkipSocketFile = 0x0200,
+        kDontSizeInfoPointer= 0x0400,
     };
 
     Q_ENUM(FileHint)
@@ -83,6 +84,7 @@ private:
 private:
     void setSizeInfo();
     void statistcsOtherFileSystem();
+    void statisticsRealPathSingle();
 };
 
 }

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1383,6 +1383,15 @@ bool FileUtils::supportLongName(const QUrl &url)
     return datas.contains(fileSystem) || DeviceUtils::isSubpathOfDlnfs(url.path());
 }
 
+QString FileUtils::symlinkTarget(const QUrl &url)
+{
+    char buffer[4096]{0};
+    auto size = readlink(url.path().toStdString().c_str(), buffer, sizeof(buffer));
+    if (size > 0)
+        return QString::fromUtf8(buffer, static_cast<int>(size));
+    return QString();
+}
+
 QUrl DesktopAppUrl::trashDesktopFileUrl()
 {
     static QUrl trash = QUrl::fromLocalFile(StandardPaths::location(StandardPaths::kDesktopPath) + "/dde-trash.desktop");

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -95,6 +95,7 @@ public:
     static QString trashPathToNormal(const QString &trash);
     static QString normalPathToTrash(const QString &normal);
     static bool supportLongName(const QUrl &url);
+    static QString symlinkTarget(const QUrl &url);
 
 private:
     static QMutex cacheCopyingMutex;

--- a/src/dfm-base/utils/private/filestatisticsjob_p.h
+++ b/src/dfm-base/utils/private/filestatisticsjob_p.h
@@ -26,10 +26,14 @@ public:
 
     void processFile(const QUrl &url, const bool followLink, QQueue<QUrl> &directoryQueue);
     void processFile(const FileInfoPointer &info, const bool followLink, QQueue<QUrl> &directoryQueue);
+    void processFile(const QUrl &url, struct stat64* statBuffer, const bool followLink, QQueue<QUrl> &directoryQueue);
     void emitSizeChanged();
     int countFileCount(const char *name);
     bool checkFileType(const FileInfo::FileType &fileType);
     bool checkInode(const FileInfoPointer info);
+    bool checkInode(const __ino64_t innode, const QString &path, const bool isDir);
+    FileInfo::FileType fileType(const __mode_t fileMode);
+    QString resolveSymlink(const QUrl &url);
 
     FileStatisticsJob *q;
     QTimer *notifyDataTimer;
@@ -50,6 +54,7 @@ public:
     QSet<QUrl> allFiles;
     QSet<QString> skipPath;
     QSet<quint64> inodelist;
+    QSet<QString> inodeAndPath;
     AbstractDirIteratorPointer iterator { nullptr };
     std::atomic_bool iteratorCanStop { false };
 };

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -41,6 +41,7 @@ BasicWidget::BasicWidget(QWidget *parent)
 {
     initUI();
     fileCalculationUtils = new FileStatisticsJob;
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
 }
 
 BasicWidget::~BasicWidget()

--- a/src/plugins/common/core/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
+++ b/src/plugins/common/core/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
@@ -25,6 +25,7 @@ MultiFilePropertyDialog::MultiFilePropertyDialog(const QList<QUrl> &urls, QWidge
     setFixedSize(300, 360);
     fileCalculationUtils = new FileStatisticsJob;
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &MultiFilePropertyDialog::updateFolderSizeLabel);
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
     QList<QUrl> targets;
     UniversalUtils::urlsTransformToLocal(urlList, &targets);
     fileCalculationUtils->start(targets);

--- a/src/plugins/filemanager/core/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp
@@ -17,6 +17,7 @@ DeviceBasicWidget::DeviceBasicWidget(QWidget *parent)
     initUI();
     fileCalculationUtils = new FileStatisticsJob;
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &DeviceBasicWidget::slotFileDirSizeChange);
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
 }
 
 DeviceBasicWidget::~DeviceBasicWidget()

--- a/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
@@ -115,6 +115,7 @@ void OpticalMediaWidget::initializeUi()
     lbAvailable->setAlignment(Qt::AlignCenter);
 
     statisticWorker = new FileStatisticsJob(this);
+    statisticWorker->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
 }
 
 void OpticalMediaWidget::initConnect()

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultentryfileentity.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultentryfileentity.cpp
@@ -17,6 +17,7 @@ VaultEntryFileEntity::VaultEntryFileEntity(QObject *parent)
     fileCalculationUtils = new FileStatisticsJob;
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &VaultEntryFileEntity::slotFileDirSizeChange);
     connect(fileCalculationUtils, &FileStatisticsJob::finished, this, &VaultEntryFileEntity::slotFinishedThread);
+    fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink | FileStatisticsJob::FileHint::kDontSizeInfoPointer);
 }
 
 VaultEntryFileEntity::~VaultEntryFileEntity()

--- a/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
+++ b/tests/plugins/filemanager/dfmplugin-vault/bug/ut_vaultpluginbugtest.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <dfm-base/utils/filestatisticsjob.h>
-#include <dfm-base/utils/private/filestatissticsjob_p.h>
+#include <dfm-base/utils/private/filestatisticsjob_p.h>
 #include <dfm-base/base/schemefactory.h>
 
 #include <DComboBox>


### PR DESCRIPTION
- Added support for processing files with symlink handling in `processFile` method.
- Introduced `countFileCountAndSize` method to count files and their sizes in a directory.
- Implemented `checkInode` method to track inodes and prevent processing of duplicate files.
- Added `fileType` method to determine the type of file based on its mode.
- Updated `statistcsRealPathSingle` method to handle single file statistics more effectively.
- Introduced `symlinkTarget` utility function to retrieve the target of a symlink.
- Enhanced file hints with `kDontSizeInfoPointer` to manage size information pointers.
- Updated various UI components to utilize new file hints for better file statistics handling.

This commit improves the overall file processing capabilities and addresses issues related to symlink handling and file counting.

Log: Enhance FileStatisticsJob functionality

## Summary by Sourcery

Enhance FileStatisticsJob to improve file processing capabilities, especially for symlinks, and to prevent duplicate file processing. Also, update UI components to utilize new file hints for better file statistics handling.

New Features:
- Introduce a `symlinkTarget` utility function to retrieve the target of a symlink.
- Introduce `countFileCountAndSize` method to count files and their sizes in a directory.
- Implement `checkInode` method to track inodes and prevent processing of duplicate files.
- Add `fileType` method to determine the type of file based on its mode.
- Add `kDontSizeInfoPointer` file hint to manage size information pointers.

Enhancements:
- Improve file processing capabilities by adding support for symlink handling and preventing duplicate file processing.
- Update UI components to utilize new file hints for better file statistics handling.
- Add a mechanism to avoid processing `/proc` and `/avfsd` directories unless explicitly requested.
- Add a signal handler to stop the statistics job when the application is about to quit.
- Refactor the code to improve readability and maintainability.
- Improve the performance of file statistics calculation by avoiding unnecessary file system operations.
- Add file type detection based on file mode.
- Improve the handling of file sizes, especially for symlinks.
- Add a utility function to retrieve the target of a symlink.
- Update the statisticsRealpathSingle method to handle single file statistics more effectively.
- Add a method to count files and their sizes in a directory.
- Add a method to track inodes and prevent processing of duplicate files.
- Update the processFile method to handle files with symlinks.
- Update the processFile method to handle files with zero size.
- Update the processFile method to skip the file,os file.
- Update the processFile method to check file type.
- Update the processFile method to check inode.
- Update the processFile method to handle symlink cycles.
- Update the processFile method to handle symlink targets.
- Update the processFile method to handle symlink targets with empty symLinkTarget.
- Update the processFile method to handle symlink targets with symLinkTargets contains symLinkTarget.
- Update the processFile method to handle symlink targets with UniversalUtils::urlEquals.
- Update the processFile method to handle symlink targets with FileInfo::FileType.
- Update the processFile method to handle symlink targets with size > 0.
- Update the processFile method to handle symlink targets with isSyslink.
- Update the processFile method to handle symlink targets with totalProgressSize.
- Update the processFile method to handle symlink targets with filesCount.
- Update the processFile method to handle symlink targets with directoryCount.
- Update the processFile method to handle symlink targets with kSingleDepth.
- Update the processFile method to handle symlink targets with kDontSkipAVFSDStorage.
- Update the processFile method to handle symlink targets with kDontSkipPROCStorage.
- Update the processFile method to handle symlink targets with stateCheck().