### PR TITLE
chore: bump version 6.5.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.42) unstable; urgency=medium
+
+  * fix bugs 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 21 Mar 2025 15:24:59 +0800
+
 dde-file-manager (6.5.41) unstable; urgency=medium
 
   * fix bugs 


### PR DESCRIPTION
6.5.42

Log: 6.5.42

## Summary by Sourcery

Chores:
- Bump version to 6.5.42.