### PR TITLE
fix: enhance URL handling in tag management

### DIFF
--- a/src/plugins/common/dfmplugin-tag/tag.cpp
+++ b/src/plugins/common/dfmplugin-tag/tag.cpp
@@ -24,6 +24,7 @@
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/utils/universalutils.h>
 
 #include <QRectF>
 #include <QDBusConnection>
@@ -121,23 +122,28 @@ void Tag::onAllPluginsStarted()
 QWidget *Tag::createTagWidgetForPropertyDialog(const QUrl &url)
 {
     fmDebug() << "Creating tag widget for property dialog, URL:" << url.toString();
+    QUrl realUrl;
+    UniversalUtils::urlTransformToLocal(url, &realUrl);
 
-    if (!TagManager::instance()->canTagFile(url)) {
+    if (!TagManager::instance()->canTagFile(realUrl)) {
         fmDebug() << "Cannot tag file:" << url.toString();
         return nullptr;
     }
 
-    auto tagWidget = new TagWidget(url);
+    auto tagWidget = new TagWidget(realUrl);
     tagWidget->initialize();
     return tagWidget;
 }
 
 QWidget *Tag::createTagWidgetForDetailView(const QUrl &url)
 {
-    if (!TagManager::instance()->canTagFile(url))
+    QUrl realUrl;
+    UniversalUtils::urlTransformToLocal(url, &realUrl);
+
+    if (!TagManager::instance()->canTagFile(realUrl))
         return nullptr;
 
-    TagWidget *tagWidget = new TagWidget(url);
+    TagWidget *tagWidget = new TagWidget(realUrl);
     tagWidget->setLayoutHorizontally(true);
     tagWidget->initialize();
     tagWidget->setFrameShape(QFrame::NoFrame);

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -303,13 +303,15 @@ QStringList TagManager::getFilesByTag(const QString &tag)
 
 bool TagManager::setTagsForFiles(const QStringList &tags, const QList<QUrl> &files)
 {
-
     // if tags is empty means delete all files's tags
     if (files.isEmpty())
         return false;
 
+    QList<QUrl> realUrls;
+    UniversalUtils::urlsTransformToLocal(files, &realUrls);
+
     // set tags for mult files
-    QStringList mutualTagNames = TagManager::instance()->getTagsByUrls(files);
+    QStringList mutualTagNames = TagManager::instance()->getTagsByUrls(realUrls);
     // for deleting.
     QStringList dirtyTagNames;
     for (const QString &tag : mutualTagNames)
@@ -318,9 +320,9 @@ bool TagManager::setTagsForFiles(const QStringList &tags, const QList<QUrl> &fil
 
     bool result = false;
     if (!dirtyTagNames.isEmpty())
-        result = TagManager::instance()->removeTagsOfFiles(dirtyTagNames, files) || result;
+        result = TagManager::instance()->removeTagsOfFiles(dirtyTagNames, realUrls) || result;
 
-    for (const QUrl &url : TagHelper::commonUrls(files)) {
+    for (const QUrl &url : TagHelper::commonUrls(realUrls)) {
         QStringList tagsOfFile = TagManager::instance()->getTagsByUrls({ url });
         QStringList newTags;
 

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -275,12 +275,14 @@ QStringList TagManager::getTagsByUrls(const QList<QUrl> &urls) const
 {
     // single path:  get all tags of path
     // mult paths:  get same tags of paths
-
     if (urls.isEmpty())
         return {};
 
+    QList<QUrl> realUrls;
+    UniversalUtils::urlsTransformToLocal(urls, &realUrls);
+
     QStringList paths;
-    for (const auto &url : TagHelper::commonUrls(urls)) {
+    for (const auto &url : TagHelper::commonUrls(realUrls)) {
         paths.append(url.path());
     }
 
@@ -338,9 +340,12 @@ bool TagManager::setTagsForFiles(const QStringList &tags, const QList<QUrl> &fil
 
 bool TagManager::addTagsForFiles(const QList<QString> &tags, const QList<QUrl> &files)
 {
+
     if (tags.isEmpty() || files.isEmpty())
         return false;
 
+    QList<QUrl> urls;
+    UniversalUtils::urlsTransformToLocal(files, &urls);
     // tag --- color
     QMap<QString, QVariant> tagWithColor {};
     for (const QString &tagName : tags) {
@@ -352,7 +357,7 @@ bool TagManager::addTagsForFiles(const QList<QString> &tags, const QList<QUrl> &
     QVariant checkTagResult { TagProxyHandleIns->addTags(tagWithColor) };
     if (checkTagResult.toBool()) {
         QVariantMap infos;
-        for (const auto &f : TagHelper::commonUrls(files))
+        for (const auto &f : TagHelper::commonUrls(urls))
             infos[f.path()] = QVariant(tags);
 
         if (TagProxyHandleIns->addTagsForFiles(infos))
@@ -370,9 +375,12 @@ bool TagManager::removeTagsOfFiles(const QList<QString> &tags, const QList<QUrl>
     if (tags.isEmpty() || files.isEmpty())
         return false;
 
+    QList<QUrl> urls;
+    UniversalUtils::urlsTransformToLocal(files, &urls);
+
     QMap<QString, QVariant> fileWithTag;
 
-    for (const QUrl &url : TagHelper::commonUrls(files)) {
+    for (const QUrl &url : TagHelper::commonUrls(urls)) {
         fileWithTag[UrlRoute::urlToPath(url)] = QVariant(tags);
     }
 
@@ -430,15 +438,6 @@ void TagManager::deleteTags(const QStringList &tags)
             emit tagDeleted(tag);
         }
     }
-}
-
-void TagManager::deleteFiles(const QList<QUrl> &urls)
-{
-    QStringList paths;
-    for (const auto &temp : TagHelper::commonUrls(urls))
-        paths.append(temp.toString());
-
-    this->deleteTagData(paths, DeleteOpts::kFiles);
 }
 
 bool TagManager::changeTagColor(const QString &tagName, const QString &newTagColor)

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
@@ -58,7 +58,6 @@ public:
     bool addTagsForFiles(const QList<QString> &tags, const QList<QUrl> &files);
     bool removeTagsOfFiles(const QList<QString> &tags, const QList<QUrl> &files);
     void deleteTags(const QStringList &tags);
-    void deleteFiles(const QList<QUrl> &urls);
     bool changeTagColor(const QString &tagName, const QString &newTagColor);
     bool changeTagName(const QString &tagName, const QString &newName);
 

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
@@ -20,6 +20,7 @@ using namespace dfmplugin_utils;
 OpenWithWidget::OpenWithWidget(QWidget *parent)
     : DArrowLineDrawer(parent)
 {
+    MimesAppsManager::instance()->initMimeTypeApps();
     initUI();
 }
 

--- a/src/plugins/filemanager/dfmplugin-optical/menus/opticalmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/menus/opticalmenuscene.cpp
@@ -89,6 +89,8 @@ void OpticalMenuScene::updateState(QMenu *parent)
         "stage-file-to-burning",
         "set-as-wallpaper",
         "mount-image",
+        "tag-color-list",
+        "tag-add"
         ""   // for oem
     };
     static const QStringList whiteEmptyActIdList {
@@ -104,7 +106,8 @@ void OpticalMenuScene::updateState(QMenu *parent)
     };
     static const QStringList whiteSceneList { "NewCreateMenu", "ClipBoardMenu", "OpenDirMenu", "FileOperatorMenu",
                                               "OpenWithMenu", "ShareMenu", "SortAndDisplayMenu", "PropertyMenu",
-                                              "BookmarkMenu", "SendToMenu", "SendToDiscMenu", "OemMenu", "WorkspaceMenu" };
+                                              "BookmarkMenu", "SendToMenu", "SendToDiscMenu", "OemMenu", "WorkspaceMenu",
+                                              "TagMenu" };
 
     auto actions = parent->actions();
     std::for_each(actions.begin(), actions.end(), [this](QAction *act) {


### PR DESCRIPTION
- Integrated UniversalUtils for URL transformation to local paths in TagManager and Tag widget creation methods.
- Updated methods to ensure accurate tagging functionality by using transformed URLs.
- Removed unused deleteFiles method from TagManager.

Log: Improve tag management by ensuring correct URL resolution for tagging operations.

Bug: https://pms.uniontech.com/bug-view-307125.html

## Summary by Sourcery

Improve tag management by ensuring correct URL resolution for tagging operations. This involves transforming URLs to local paths before performing tagging operations, ensuring accurate functionality.