### PR TITLE
feat: add UpdateDeviceUsage method for device management

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.Daemon.DeviceManager.xml
+++ b/assets/dbus/org.deepin.Filemanager.Daemon.DeviceManager.xml
@@ -92,5 +92,8 @@
       <arg name="id" type="s" direction="in"/>
       <arg name="reload" type="b" direction="in"/>
     </method>
+    <method name="UpdateDeviceUsage">
+      <arg name="id" type="s" direction="in"/>
+    </method>
   </interface>
 </node>

--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -974,6 +974,11 @@ void DeviceManager::retryMount(const QString &id, DFMMOUNT::DeviceType type, int
     QTimer::singleShot(5000, this, [id, type, timeout] { DeviceManager::instance()->doAutoMount(id, type, timeout); });
 }
 
+void DeviceManager::updateDeviceUsage(const QString &id)
+{
+    d->watcher->updateDevUsage(id);
+}
+
 DeviceManagerPrivate::DeviceManagerPrivate(DeviceManager *qq)
     : watcher(new DeviceWatcher(qq)), discScanner(new DiscDeviceScanner(qq)), q(qq)
 {

--- a/src/dfm-base/base/device/devicemanager.h
+++ b/src/dfm-base/base/device/devicemanager.h
@@ -97,6 +97,8 @@ public:
 
     void retryMount(const QString &id, DFMMOUNT::DeviceType type, int timeout);
 
+    void updateDeviceUsage(const QString &id);
+
 Q_SIGNALS:
     // device watch
     void devSizeChanged(const QString &id, qint64 total, qint64 avai);

--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -88,6 +88,19 @@ void DeviceProxyManager::reloadOpticalInfo(const QString &id)
         DevMngIns->getBlockDevInfo(id, true);
 }
 
+void DeviceProxyManager::updateDeviceUsage(const QString &id)
+{
+    if (d->isDBusRuning() && d->devMngDBus) {
+        auto &&reply = d->devMngDBus->UpdateDeviceUsage(id);
+        reply.waitForFinished();
+        if (reply.isError()) {
+             qWarning() << "update device usage failed. err: " << reply.error().message();
+        }
+    } else {
+        DevMngIns->updateDeviceUsage(id);
+    }
+}
+
 bool DeviceProxyManager::initService()
 {
     d->initConnection();

--- a/src/dfm-base/base/device/deviceproxymanager.h
+++ b/src/dfm-base/base/device/deviceproxymanager.h
@@ -41,6 +41,7 @@ public:
 
     // device operation
     void reloadOpticalInfo(const QString &id);
+    void updateDeviceUsage(const QString &id);
 
     bool initService();
     bool isDBusRuning();

--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -633,6 +633,16 @@ qint64 DeviceUtils::deviceBytesFree(const QUrl &url)
     return DFMIO::DFMUtils::deviceBytesFree(url);
 }
 
+void DeviceUtils::updateDeviceUsage(const QUrl &url)
+{
+    auto devicePath = bindPathTransform(url.path(), true);
+    auto map = DevProxyMng->queryDeviceInfoByPath(devicePath, false);
+    if (!map.contains(kId))
+        return;
+
+    DevProxyMng->updateDeviceUsage(map.value(kId).toString());
+}
+
 bool DeviceUtils::isUnmountSamba(const QUrl &url)
 {
     if (!ProtocolUtils::isSMBFile(url))

--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -73,6 +73,7 @@ public:
 
     static QString fileSystemType(const QUrl &url);
     static qint64 deviceBytesFree(const QUrl &url);
+    static void updateDeviceUsage(const QUrl &url);
     static bool isUnmountSamba(const QUrl &url);
     // If toDevice is true, convert the path to the device name
     // otherwise convert the path to the mount point name

--- a/src/dfm-base/base/device/private/devicewatcher.cpp
+++ b/src/dfm-base/base/device/private/devicewatcher.cpp
@@ -259,6 +259,23 @@ void DeviceWatcher::saveOpticalDevUsage(const QString &id, const QVariantMap &da
     DevProxyMng->reloadOpticalInfo(id);
 }
 
+void DeviceWatcher::updateDevUsage(const QString &id)
+{
+    if (d->allBlockInfos.contains(id)) {
+        auto item = d->allBlockInfos[id];
+        d->queryUsageOfItem(item, dfmmount::DeviceType::kBlockDevice);
+        return;
+    }
+
+    if (d->allProtocolInfos.contains(id)) {
+        auto item = d->allProtocolInfos[id];
+        d->queryUsageOfItem(item, dfmmount::DeviceType::kProtocolDevice);
+        return;
+    }
+
+    qCWarning(logDFMBase) << "cannot find device info, id = " << id;
+}
+
 void DeviceWatcher::startWatch()
 {
     if (d->isWatching) {

--- a/src/dfm-base/base/device/private/devicewatcher.h
+++ b/src/dfm-base/base/device/private/devicewatcher.h
@@ -43,6 +43,8 @@ public:
     void updateOpticalDevUsage(const QString &id, const QString &mpt);
     void saveOpticalDevUsage(const QString &id, const QVariantMap &data);
 
+    void updateDevUsage(const QString &id);
+
 private Q_SLOTS:
     void onBlkDevAdded(const QString &id);
     void onBlkDevRemoved(const QString &id);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "dodeletefilesworker.h"
+#include "fileoperations/fileoperationutils/fileoperationsutils.h"
+#include <dfm-base/base/device/deviceutils.h>
 #include <dfm-base/base/schemefactory.h>
 
 #include <QUrl>
@@ -26,6 +28,14 @@ bool DoDeleteFilesWorker::doWork()
         return false;
 
     deleteAllFiles();
+
+    if (!isSourceFileLocal) {
+        auto syncDir = FileOperationsUtils::parentUrl(sourceUrls.first());
+        qDebug() << "sync mnt device data after delete files, dir = " << syncDir;
+        QProcess::startDetached("sync", {"-f", syncDir.path()});
+
+        DeviceUtils::updateDeviceUsage(syncDir);
+    }
 
     // 完成
     endWork();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -65,6 +65,7 @@ class FileOperationsUtils
     friend class DoMoveToTrashFilesWorker;
     friend class DoCleanTrashFilesWorker;
     friend class DoRestoreTrashFilesWorker;
+    friend class DoDeleteFilesWorker;
     friend class FileOperateBaseWorker;
     friend class ErrorMessageAndAction;
 

--- a/src/plugins/daemon/core/devicemanagerdbus.cpp
+++ b/src/plugins/daemon/core/devicemanagerdbus.cpp
@@ -170,3 +170,8 @@ QVariantMap DeviceManagerDBus::QueryProtocolDeviceInfo(QString id, bool reload)
 {
     return DevMngIns->getProtocolDevInfo(id, reload);
 }
+
+void DeviceManagerDBus::UpdateDeviceUsage(QString id)
+{
+    DevMngIns->updateDeviceUsage(id);
+}

--- a/src/plugins/daemon/core/devicemanagerdbus.h
+++ b/src/plugins/daemon/core/devicemanagerdbus.h
@@ -51,6 +51,8 @@ public slots:
     QStringList GetProtocolDevicesIdList();
     QVariantMap QueryProtocolDeviceInfo(QString id, bool reload);
 
+    void UpdateDeviceUsage(QString id);
+
 private:
     void initialize();
     void initConnection();


### PR DESCRIPTION
- Introduced a new method `UpdateDeviceUsage` in the D-Bus interface to allow for updating device usage information.
- Implemented the corresponding logic in `DeviceManager`, `DeviceProxyManager`, and `DeviceWatcher` to handle device usage updates.
- Enhanced `DeviceUtils` to facilitate device usage updates after file deletion operations.

Log: Improve device management capabilities by tracking usage updates.
Bug: https://pms.uniontech.com/zentao/bug-view-304551.html

## Summary by Sourcery

Introduces the UpdateDeviceUsage method to the D-Bus interface for updating device usage information and implements the corresponding logic across DeviceManager, DeviceProxyManager, and DeviceWatcher. It also enhances DeviceUtils to facilitate device usage updates after file deletion operations.

New Features:
- Introduces the UpdateDeviceUsage method in the D-Bus interface to allow updating device usage information.
- Implements logic in DeviceManager, DeviceProxyManager, and DeviceWatcher to handle device usage updates.
- Enhances DeviceUtils to facilitate device usage updates after file deletion operations, specifically after file deletion operations.