### PR TITLE
为文管文件选择对话框增加保存上次访问路径的功能

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -721,15 +721,17 @@ void FileDialog::done(int r)
         d->eventLoop->exit(r);
     }
 
-    if (r != QDialog::Accepted || d->hideOnAccept)
-        hide();
-
     emit finished(r);
     if (r == QDialog::Accepted) {
         emit accepted();
     } else if (r == QDialog::Rejected) {
         emit rejected();
     }
+
+    if (d->hideOnAccept && r == QDialog::Accepted)
+        hide();
+    else
+        close();
 }
 
 int FileDialog::exec()

--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -55,12 +55,15 @@ FileDialogPrivate::FileDialogPrivate(FileDialog *qq)
 
     QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
     lastVisitedDir = qtSets.value("FileDialog/lastVisited").toUrl();
+
+    delaySaveTimer = new QTimer(this);
+    delaySaveTimer->setInterval(3000);
+    connect(delaySaveTimer, &QTimer::timeout, this, &FileDialogPrivate::saveLastVisited);
 }
 
 FileDialogPrivate::~FileDialogPrivate()
 {
-    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
-    qtSets.setValue("FileDialog/lastVisited", lastVisitedDir.toString());
+    saveLastVisited();
 }
 
 void FileDialogPrivate::handleSaveAcceptBtnClicked()
@@ -209,6 +212,18 @@ bool FileDialogPrivate::checkFileSuffix(const QString &filename, QString &suffix
     }
 
     return false;
+}
+
+void FileDialogPrivate::setLastVisited(const QUrl &dir)
+{
+    lastVisitedDir = dir;
+    delaySaveTimer->start();
+}
+
+void FileDialogPrivate::saveLastVisited()
+{
+    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
+    qtSets.setValue("FileDialog/lastVisited", lastVisitedDir.toString());
 }
 
 /*!

--- a/src/plugins/filedialog/core/views/filedialog_p.h
+++ b/src/plugins/filedialog/core/views/filedialog_p.h
@@ -47,7 +47,7 @@ private:
 
     bool isFileView { false };
     bool lastIsFileView { false };
-    bool hideOnAccept { true };
+    bool hideOnAccept { false };
     FileDialogStatusBar *statusBar { nullptr };
     QEventLoop *eventLoop { nullptr };
     QFileDialog::FileMode fileMode { QFileDialog::AnyFile };

--- a/src/plugins/filedialog/core/views/filedialog_p.h
+++ b/src/plugins/filedialog/core/views/filedialog_p.h
@@ -36,6 +36,10 @@ public:
     void handleOpenAcceptBtnClicked();
     void handleOpenNewWindow(const QUrl &url);
     bool checkFileSuffix(const QString &filename, QString &suffix);
+    void setLastVisited(const QUrl &dir);
+
+public Q_SLOTS:
+    void saveLastVisited();
 
 private:
     static constexpr int kDefaultWindowWidth { 960 };
@@ -57,6 +61,7 @@ private:
     QFileDialog::Options options;
     QUrl currentUrl;
     QUrl lastVisitedDir;
+    QTimer *delaySaveTimer { nullptr };
 
     static QStringList cleanFilterList(const QString &filter)
     {


### PR DESCRIPTION
## Summary by Sourcery

Implements saving and restoring the last visited directory in the file dialog. This enhancement improves user experience by automatically navigating to the previously used directory when the file dialog is opened.

Enhancements:
- Implements saving and restoring the last visited directory in the file dialog.
- Introduces a delay timer to save the last visited directory, reducing the frequency of write operations.
- Modifies the dialog to close instead of hide when accepted, unless hideOnAccept is enabled.
- Adds a setLastVisited method to update the last visited directory and start the delay timer.