### PR TITLE
fix: Fixed an issue where the properties dialog displayed abnormally

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -71,18 +71,19 @@ BasicWidget::~BasicWidget()
 
 int BasicWidget::expansionPreditHeight()
 {
-    int itemCount = fieldMap.size() + (hideCheckBox ? 0 : 1);
-    int allSpaceHeight = (itemCount - 1) * kSpacingHeight;
-
+    int itemCount = hideCheckBox ? 0 : 1;
     int allItemHeight { 0 };
     QMultiMap<BasicFieldExpandEnum, DFMBASE_NAMESPACE::KeyValueLabel *>::const_iterator itr = fieldMap.begin();
     for (; itr != fieldMap.end(); ++itr) {
-        if (itr.value())
+        if (itr.value() && itr.value()->isVisible()) {
             allItemHeight += itr.value()->height();
+            ++itemCount;
+        }
     }
     if (hideFile)
         allItemHeight += (hideCheckBox ? 0 : hideFile->height());
 
+    int allSpaceHeight = (itemCount - 1) * kSpacingHeight;
     return allSpaceHeight + allItemHeight;
 }
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -255,6 +255,8 @@ int FilePropertyDialog::initalHeightOfView()
 void FilePropertyDialog::processHeight(int height)
 {
     Q_UNUSED(height)
+    if (!isShown)
+        return;
 
     QRect rect = geometry();
     int screenHeight = WindowUtils::cursorScreen()->availableSize().height();
@@ -333,6 +335,7 @@ void FilePropertyDialog::showEvent(QShowEvent *event)
 {
     DDialog::showEvent(event);
 
+    isShown = true;
     QVBoxLayout *vlayout = qobject_cast<QVBoxLayout *>(scrollArea->widget()->layout());
     if (vlayout) {
         if (vlayout->count() > 0) {

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
@@ -69,6 +69,7 @@ protected:
     virtual void keyPressEvent(QKeyEvent *event) override;
 
 private:
+    bool isShown { false };
     QScrollArea *scrollArea { nullptr };
     BasicWidget *basicWidget { nullptr };
     PermissionManagerWidget *permissionManagerWidget { nullptr };


### PR DESCRIPTION
- Updated the height calculation in BasicWidget to correctly account for visible items, ensuring accurate layout adjustments.
- Introduced a new boolean member `isShown` in FilePropertyDialog to manage visibility state, preventing unnecessary processing when the dialog is not displayed.

Log: Enhance layout handling and visibility management in property dialogs.
Bug: https://pms.uniontech.com/bug-view-308243.html

## Summary by Sourcery

Fixes an issue where the properties dialog displayed abnormally by improving layout handling and visibility management in property dialogs. The height calculation in BasicWidget is updated to correctly account for visible items. A new boolean member `isShown` is introduced in FilePropertyDialog to manage visibility state, preventing unnecessary processing when the dialog is not displayed.

Bug Fixes:
- Fixes an issue where the properties dialog displayed abnormally.
- Updates the height calculation in BasicWidget to correctly account for visible items, ensuring accurate layout adjustments.
- Introduces a new boolean member `isShown` in FilePropertyDialog to manage visibility state, preventing unnecessary processing when the dialog is not displayed.