### PR TITLE
refactor: improve file selection logic in RenameBar

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
@@ -330,7 +330,7 @@ void RenameBar::initConnect()
 
 QList<QUrl> RenameBar::getSelectFiles()
 {
-    WorkspacePage* page = qobject_cast<WorkspacePage *>(parentWidget());
+    WorkspacePage* page = findPage();
     if (!page)
         return {};
 
@@ -340,6 +340,19 @@ QList<QUrl> RenameBar::getSelectFiles()
 
     return view->selectedUrlList();
 
+}
+
+WorkspacePage *RenameBar::findPage()
+{
+    auto parent = parentWidget();
+    while (parent) {
+        if (auto page = qobject_cast<WorkspacePage *>(parent))
+            return page;
+
+        parent = parent->parentWidget();
+    }
+
+    return nullptr;
 }
 
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.h
@@ -11,6 +11,7 @@
 
 namespace dfmplugin_workspace {
 
+class WorkspacePage;
 class RenameBarPrivate;
 class RenameBar : public QFrame
 {
@@ -55,6 +56,7 @@ protected:
 private:
     void initConnect();
     QList<QUrl> getSelectFiles();
+    WorkspacePage *findPage();
 
 private:
     QSharedPointer<RenameBarPrivate> d { nullptr };


### PR DESCRIPTION
- Replaced the direct parent widget cast with a new method `findPage` to enhance the robustness of file selection.
- The `findPage` method traverses the widget hierarchy to locate the `WorkspacePage`, ensuring better compatibility and reducing potential errors.

Log: Streamline file selection process in RenameBar for improved reliability.
Bug: https://pms.uniontech.com/bug-view-309489.html

## Summary by Sourcery

Enhancements:
- Refactor the file selection logic in RenameBar by introducing a new method, findPage, to traverse the widget hierarchy and locate the WorkspacePage.