### PR TITLE
fix: The password cannot be entered on the disk password change dialog

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
@@ -73,7 +73,7 @@ void DPCConfirmWidget::initUI()
     DFontSizeManager *fontManager = DFontSizeManager::instance();
     fontManager->bind(titleLabel, DFontSizeManager::T5, QFont::Medium);
 
-    QRegularExpression regx("[^\\x4e00-\\x9fa5]+");
+    QRegularExpression regx("^[^\u4e00-\u9fa5]+");
     // 创建验证器
     QValidator *validator = new QRegularExpressionValidator(regx, this);
 


### PR DESCRIPTION
as title

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-309491.html

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where passwords containing Chinese characters could not be entered in the disk password change dialog.