### PR TITLE
Revert "fix: dialog's memory not relased after accepted/rejected"

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -721,6 +721,7 @@ void FileDialog::done(int r)
         d->eventLoop->exit(r);
     }
 
+    // DO NOT CLOSE the dialog here, may cause QFileDialog::getExsitingDirectory returns an empty path if CLOSE
     if (r != QDialog::Accepted || d->hideOnAccept)
         hide();
 

--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -721,17 +721,15 @@ void FileDialog::done(int r)
         d->eventLoop->exit(r);
     }
 
+    if (r != QDialog::Accepted || d->hideOnAccept)
+        hide();
+
     emit finished(r);
     if (r == QDialog::Accepted) {
         emit accepted();
     } else if (r == QDialog::Rejected) {
         emit rejected();
     }
-
-    if (d->hideOnAccept && r == QDialog::Accepted)
-        hide();
-    else
-        close();
 }
 
 int FileDialog::exec()

--- a/src/plugins/filedialog/core/views/filedialog_p.h
+++ b/src/plugins/filedialog/core/views/filedialog_p.h
@@ -47,7 +47,7 @@ private:
 
     bool isFileView { false };
     bool lastIsFileView { false };
-    bool hideOnAccept { false };
+    bool hideOnAccept { true };
     FileDialogStatusBar *statusBar { nullptr };
     QEventLoop *eventLoop { nullptr };
     QFileDialog::FileMode fileMode { QFileDialog::AnyFile };


### PR DESCRIPTION
This reverts commit 0a300ca282637985770140fc2b54517989f96a6d.

## Summary by Sourcery

Reverts commit 0a300ca282637985770140fc2b54517989f96a6d, which was intended to fix an issue where the dialog's memory was not being released after being accepted or rejected. This change restores the previous behavior of the FileDialog.