### PR TITLE
feat: implement view mode switching enhancements

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -964,6 +964,7 @@ void FileViewModel::initFilterSortWork()
     connect(this, &FileViewModel::requestCollapseItem, filterSortWorker.data(), &FileSortWorker::handleCloseExpand, Qt::QueuedConnection);
     connect(this, &FileViewModel::requestTreeView, filterSortWorker.data(), &FileSortWorker::handleSwitchTreeView, Qt::QueuedConnection);
     connect(filterSortWorker.data(), &FileSortWorker::requestUpdateView, this, &FileViewModel::onUpdateView, Qt::QueuedConnection);
+    connect(filterSortWorker.data(), &FileSortWorker::aboutToSwitchToListView, this, &FileViewModel::aboutToSwitchToListView, Qt::QueuedConnection);
     connect(Application::instance(), &Application::appAttributeChanged, filterSortWorker.data(), &FileSortWorker::onAppAttributeChanged, Qt::QueuedConnection);
 
     filterSortThread->start();

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -120,6 +120,8 @@ Q_SIGNALS:
     void requestCollapseItem(const QString &key, const QUrl &parent);
     void requestTreeView(const bool isTree);
 
+    void aboutToSwitchToListView(const QList<QUrl> &allShowList);
+
 public Q_SLOTS:
     void onFileThumbUpdated(const QUrl &url, const QString &thumb);
     void onFileUpdated(int show);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1067,6 +1067,9 @@ void FileSortWorker::switchListView()
 {
     // 移除depthMap和visibleTreeChildren
     auto allShowList = visibleTreeChildren.value(current);
+    // 保持选中
+    Q_EMIT aboutToSwitchToListView(allShowList);
+
     visibleTreeChildren.clear();
     depthMap.clear();
     depthMap.insertMulti(-1, current);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
@@ -92,6 +92,7 @@ signals:
 signals:
     void requestUpdateTimerStart();
     void requestSortByMimeType();
+    void aboutToSwitchToListView(const QList<QUrl> &allShowList);
 
 public slots:
     // Receive all local files of iteration of iterator thread, perform filtering and sorting

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
@@ -160,6 +160,32 @@ void SelectHelper::resortSelectFiles()
     selectedFiles.clear();
 }
 
+void SelectHelper::filterSelectedFiles(const QList<QUrl> &urlList)
+{
+    if (selectedFiles.isEmpty() || urlList.isEmpty())
+        return;
+
+    QList<QUrl> filteredUrls;
+
+    // 遍历当前已选中的文件
+    for (const QUrl &url : selectedFiles) {
+        // 如果当前 URL 在传入的列表中存在，则保留
+        if (urlList.contains(url)) {
+            filteredUrls.append(url);
+        }
+    }
+
+    // 更新 selectedFiles
+    selectedFiles = filteredUrls;
+
+    // 如果当前选中的文件不在过滤后的列表中，则更新 currentSelectedFile
+    if (!selectedFiles.isEmpty() && !selectedFiles.contains(currentSelectedFile)) {
+        currentSelectedFile = selectedFiles.first();
+    } else if (selectedFiles.isEmpty()) {
+        currentSelectedFile = QUrl();
+    }
+}
+
 void SelectHelper::caculateSelection(const QRect &rect, QItemSelection *selection)
 {
     if (view->isIconViewMode()) {

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
@@ -32,6 +32,7 @@ public:
 
     void saveSelectedFilesList(const QUrl &current, const QList<QUrl> &urls);
     void resortSelectFiles();
+    void filterSelectedFiles(const QList<QUrl> &urlList);
 
 private:
     void caculateSelection(const QRect &rect, QItemSelection *selection);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -149,6 +149,7 @@ public slots:
     void onWidgetUpdate();
 
     void onRenameProcessStarted();
+    void onAboutToSwitchListView(const QList<QUrl> &allShowList);
 
 protected:
     void wheelEvent(QWheelEvent *event) override;
@@ -237,6 +238,8 @@ private:
     bool cdUp();
     QModelIndex iconIndexAt(const QPoint &pos, const QSize &itemSize) const;
     bool expandOrCollapseItem(const QModelIndex &index, const QPoint &pos);
+
+    void recordSelectedUrls();
 };
 
 }


### PR DESCRIPTION
- Added a new signal `aboutToSwitchToListView` in `FileSortWorker` to notify when switching to list view, allowing for better management of selected files.
- Implemented `filterSelectedFiles` in `SelectHelper` to maintain the selection state during view mode changes.
- Updated `FileView` to handle the new signal and filter selected files accordingly, ensuring a smoother user experience when changing views.

Log: Enhance file view management during mode switching for improved user experience.
Bug: https://pms.uniontech.com/zentao/bug-view-308425.html

## Summary by Sourcery

Enhance file view management during view mode switching to improve user experience and maintain file selection state

New Features:
- Implement a mechanism to preserve file selection state when switching between different view modes

Enhancements:
- Add a new signal to notify before switching to list view
- Improve file selection handling during view mode transitions