### PR TITLE
feat: add new helper function to manage open actions for files

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -17,6 +17,8 @@
 
 namespace dfmbase {
 namespace Global {
+inline constexpr int kOpenNewWindowMaxCount = 50;
+
 enum class ViewMode {
     kNoneMode = 0x00,
     kIconMode = 0x01,

--- a/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "utils/menuhelper.h"
 #include "private/fileoperatormenuscene_p.h"
 #include "action_defines.h"
 #include "menuutils.h"
@@ -108,9 +109,12 @@ bool FileOperatorMenuScene::create(QMenu *parent)
     if (d->isEmptyArea)
         return true;
 
-    QAction *tempAction = parent->addAction(d->predicateName.value(ActionID::kOpen));
-    d->predicateAction[ActionID::kOpen] = tempAction;
-    tempAction->setProperty(ActionPropertyKey::kActionID, QString(ActionID::kOpen));
+    QAction *tempAction { nullptr };
+    if (Helper::showOpenAction(d->selectFiles)) {
+        tempAction = parent->addAction(d->predicateName.value(ActionID::kOpen));
+        d->predicateAction[ActionID::kOpen] = tempAction;
+        tempAction->setProperty(ActionPropertyKey::kActionID, QString(ActionID::kOpen));
+    }
 
     if (d->selectFiles.count() == 1) {
         auto focusFileInfo = d->focusFileInfo;

--- a/src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp
@@ -6,6 +6,7 @@
 #include "action_defines.h"
 #include "private/openwithmenuscene_p.h"
 #include "menuutils.h"
+#include "utils/menuhelper.h"
 
 #include <dfm-base/mimetype/mimesappsmanager.h>
 #include <dfm-base/base/schemefactory.h>
@@ -100,6 +101,9 @@ AbstractMenuScene *OpenWithMenuScene::scene(QAction *action) const
 bool OpenWithMenuScene::create(QMenu *parent)
 {
     if (d->selectFiles.isEmpty() || !d->focusFile.isValid())
+        return false;
+
+    if (!Helper::showOpenAction(d->selectFiles))
         return false;
 
     if (d->isFocusOnDDEDesktopFile || d->isSystemPathIncluded)

--- a/src/plugins/common/dfmplugin-menu/utils/menuhelper.cpp
+++ b/src/plugins/common/dfmplugin-menu/utils/menuhelper.cpp
@@ -9,6 +9,7 @@
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/base/schemefactory.h>
 
 #include <dfm-io/dfmio_utils.h>
 
@@ -82,6 +83,23 @@ bool isHiddenDesktopMenu()
 #endif
 
     return Application::appObtuselySetting()->value("ApplicationAttribute", "DisableDesktopContextMenu", false).toBool();
+}
+
+bool showOpenAction(const QList<QUrl> &urlList)
+{
+    if (urlList.count() > DFMGLOBAL_NAMESPACE::kOpenNewWindowMaxCount) {
+        int dirCount { 0 };
+        for (auto url : urlList) {
+            auto info = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto);
+            if (info && info->isAttributes(OptInfoType::kIsDir))
+                ++dirCount;
+
+            if (dirCount > DFMGLOBAL_NAMESPACE::kOpenNewWindowMaxCount)
+                return false;
+        }
+    }
+
+    return true;
 }
 
 }   //  namespace Helper

--- a/src/plugins/common/dfmplugin-menu/utils/menuhelper.h
+++ b/src/plugins/common/dfmplugin-menu/utils/menuhelper.h
@@ -15,6 +15,7 @@ namespace Helper {
 bool isHiddenExtMenu(const QUrl &dirUrl);
 bool isHiddenMenu(const QString &app);
 bool isHiddenDesktopMenu();
+bool showOpenAction(const QList<QUrl> &urlList);
 }   //  namespace Helper
 }   //  namespace dfmplugin_menu
 #endif   // MENUHELPER_H

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp
@@ -195,12 +195,12 @@ void FileBaseInfoView::basicFill(const QUrl &url)
 
     if (fileInterviewTime && fileInterviewTime->RightValue().isEmpty()) {
         auto lastRead = info->timeOf(TimeInfoType::kLastRead).value<QDateTime>();
-        lastRead.isValid() ? fileInterviewTime->setRightValue(lastRead.toString(FileUtils::dateTimeFormat()), Qt::ElideMiddle, Qt::AlignLeft, true, 150)
+        lastRead.isValid() ? fileInterviewTime->setRightValue(getDateTimeFormatStr(lastRead), Qt::ElideMiddle, Qt::AlignLeft, true, 150)
                            : fileInterviewTime->setVisible(false);
     }
     if (fileChangeTime && fileChangeTime->RightValue().isEmpty()) {
         auto lastModified = info->timeOf(TimeInfoType::kLastModified).value<QDateTime>();
-        lastModified.isValid() ? fileChangeTime->setRightValue(lastModified.toString(FileUtils::dateTimeFormat()), Qt::ElideMiddle, Qt::AlignLeft, true, 150)
+        lastModified.isValid() ? fileChangeTime->setRightValue(getDateTimeFormatStr(lastModified), Qt::ElideMiddle, Qt::AlignLeft, true, 150)
                                : fileChangeTime->setVisible(false);
     }
 
@@ -293,6 +293,14 @@ void FileBaseInfoView::audioExtenInfoReceiver(const QStringList &properties)
 {
     const QStringList pr = properties;
     emit sigAudioExtenInfo(pr);
+}
+
+QString FileBaseInfoView::getDateTimeFormatStr(const QDateTime &time) const
+{
+    if (time.toMSecsSinceEpoch() == 0)
+        return "-";
+
+    return time.toString(FileUtils::dateTimeFormat());
 }
 
 void FileBaseInfoView::slotImageExtenInfo(const QStringList &properties)

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.h
@@ -32,6 +32,7 @@ private:
     void imageExtenInfoReceiver(const QStringList &properties);
     void videoExtenInfoReceiver(const QStringList &properties);
     void audioExtenInfoReceiver(const QStringList &properties);
+    QString getDateTimeFormatStr(const QDateTime &time) const;
 
 signals:
     void sigImageExtenInfo(const QStringList &properties);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacewidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacewidget.cpp
@@ -273,5 +273,10 @@ void WorkspaceWidget::onCreateNewWindow()
             urlList << url;
     }
 
+    if (urlList.count() > DFMGLOBAL_NAMESPACE::kOpenNewWindowMaxCount) {
+        qWarning() << "Too much windows to open is not supported!";
+        return;
+    }
+
     WorkspaceEventCaller::sendOpenWindow(urlList);
 }


### PR DESCRIPTION
- Introduced `showOpenAction` in `menuhelper` to determine if the number of directories to open exceeds a defined limit, enhancing user experience by preventing excessive window openings.
- Updated `FileOperatorMenuScene` and `OpenWithMenuScene` to utilize the new helper function for conditional action display based on selected files.
- Added a constant `kOpenNewWindowMaxCount` to define the maximum number of new windows that can be opened, improving control over file operations.

Log: This commit enhances file opening logic and user interface responsiveness by managing the number of open windows effectively.
Bug: https://pms.uniontech.com/zentao/bug-view-288167.html

## Summary by Sourcery

Enhance file opening logic by introducing a mechanism to limit the number of new windows opened when selecting multiple files

New Features:
- Add a new helper function `showOpenAction` to manage the number of directories that can be opened in new windows

Enhancements:
- Implement a constant `kOpenNewWindowMaxCount` to control the maximum number of new windows that can be opened
- Update file opening logic to prevent excessive window creation