### PR TITLE
fix: refine search widget layout behavior

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -727,7 +727,7 @@ void SearchEditWidget::handleLeaveEvent(QEvent *e)
 
 void SearchEditWidget::updateSearchWidgetLayout()
 {
-    if (currentMode == SearchMode::kCollapsed) {
+    if (currentMode == SearchMode::kCollapsed && searchEdit->text().isEmpty()) {
         setFixedWidth(searchButton->width());
         searchEdit->setVisible(false);
         searchButton->setVisible(true);


### PR DESCRIPTION
- Updated the layout logic in SearchEditWidget to ensure the search edit field is only collapsed when it is empty, improving user experience by preventing unnecessary visibility changes.

Log: fix bug.
Bug: https://pms.uniontech.com/bug-view-309619.html

## Summary by Sourcery

Bug Fixes:
- Prevent unnecessary visibility changes in the search widget by ensuring the search edit field is only collapsed when no text is present