### PR TITLE
fix: simplify hidden files toggle logic in ShortcutOper

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.cpp
@@ -245,12 +245,8 @@ void ShortcutOper::clearClipBoard()
 
 void ShortcutOper::swichHidden()
 {
-    auto model = view->model();
-    Q_ASSERT(model);
-
-    bool show = model->showHiddenFiles();
-    model->setShowHiddenFiles(!show);
-    model->refresh(model->rootIndex());
+    bool isShowedHiddenFiles = Application::instance()->genericAttribute(Application::kShowedHiddenFiles).toBool();
+    Application::instance()->setGenericAttribute(Application::kShowedHiddenFiles, !isShowedHiddenFiles);
 }
 
 void ShortcutOper::previewFiles()


### PR DESCRIPTION
- Replaced the model-based approach for toggling hidden files visibility with a direct attribute manipulation using Application's generic attributes.
- This change streamlines the code and enhances maintainability by reducing dependencies on the view model.

Log: Improve the clarity and efficiency of the hidden files toggle functionality.
Bug: https://pms.uniontech.com/bug-view-309633.html

## Summary by Sourcery

Simplify the hidden files toggle mechanism in ShortcutOper by directly manipulating application-level attributes instead of using the model-based approach.

Bug Fixes:
- Refactored the hidden files visibility toggle to use a more direct and maintainable method of changing file visibility settings.

Enhancements:
- Reduced dependencies on the view model by using Application's generic attributes for managing hidden files visibility.