### PR TITLE
fix: adjust button box width based on URL visibility state

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.cpp
@@ -122,7 +122,7 @@ bool ShortcutOper::keyPressed(QKeyEvent *event)
             CanvasIns->onChangeIconLevel(true);
             return true;
         case Qt::Key_H:
-            swichHidden();
+            switchHidden();
             return true;
         case Qt::Key_I:
             FileOperatorProxyIns->showFilesProperty(view);
@@ -243,7 +243,7 @@ void ShortcutOper::clearClipBoard()
     }
 }
 
-void ShortcutOper::swichHidden()
+void ShortcutOper::switchHidden()
 {
     bool isShowedHiddenFiles = Application::instance()->genericAttribute(Application::kShowedHiddenFiles).toBool();
     Application::instance()->setGenericAttribute(Application::kShowedHiddenFiles, !isShowedHiddenFiles);

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.h
@@ -24,7 +24,7 @@ protected slots:
     void tabToFirst();
     void showMenu();
     void clearClipBoard();
-    void swichHidden();
+    void switchHidden();
     void previewFiles();
 
 protected:

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -201,6 +201,7 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
     if (parent() && qobject_cast<QWidget *>(parent())) {
         if (OptionButtonManager::instance()->hasVsibleState(d->currentUrl.scheme())
             && OptionButtonManager::instance()->optBtnVisibleState(d->currentUrl.scheme()) == OptionButtonManager::kHideAllBtn) {
+            setFixedWidth(0);
             return;
         }
         if (qobject_cast<QWidget *>(parent())->width() <= kCompactModeThreshold) {


### PR DESCRIPTION
- Added logic to set the fixed width of the OptionButtonBox to 0 when all buttons are hidden based on the current URL's scheme. This change improves the layout responsiveness of the button box in the file manager.

Log: Enhance the visual behavior of the OptionButtonBox when no buttons are visible.
Bug: https://pms.uniontech.com/bug-view-309487.html

## Summary by Sourcery

Improve the layout responsiveness of the OptionButtonBox in the file manager by adjusting its width based on URL visibility state

Bug Fixes:
- Fix the OptionButtonBox width when no buttons are visible for a specific URL scheme, ensuring better visual layout

Enhancements:
- Modify the OptionButtonBox to dynamically set its width to 0 when all buttons are hidden
- Correct the spelling of 'switchHidden' method from 'swichHidden'