### PR TITLE
fix: add blacklist filter for third-party plugins in file manager

### DIFF
--- a/assets/log/viewer/dde-file-manager.json
+++ b/assets/log/viewer/dde-file-manager.json
@@ -4,14 +4,7 @@
 	"submodules": [{
 			"name": "dde-file-manager",
 			"filter": "",
-			"exec": "/usr/bin/dde-file-manager",
-			"logType": "journal",
-			"logPath": ""
-		},
-		{
-			"name": "dde-desktop",
-			"filter": "",
-			"exec": "/usr/bin/dde-desktop",
+			"exec": "/usr/libexec/dde-file-manager",
 			"logType": "journal",
 			"logPath": ""
 		},
@@ -37,9 +30,9 @@
 			"logPath": ""
 		},
 		{
-			"name": "dde-file-manager-server",
+			"name": "dde-file-manager-daemon",
 			"filter": "",
-			"exec": "/usr/bin/dde-file-manager-server",
+			"exec": "/usr/bin/dde-file-manager-daemon",
 			"logType": "journal",
 			"logPath": ""
 		}

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -118,27 +118,37 @@ static bool lazyLoadFilterForHeadless(const QString &name)
     return false;
 }
 
-static QStringList buildBlackNames()
+static bool blackListFilter(const QString &name)
 {
-    QStringList blackNames { DConfigManager::instance()->value(kPluginsDConfName, "filemanager.blackList").toStringList() };
-    const QStringList &disableNames { DConfigManager::instance()->value(kPluginsDConfName, "filemanager.disablelist").toStringList() };
+    static QStringList blackNames { DConfigManager::instance()->value(kPluginsDConfName, "filemanager.blackList").toStringList() };
+    static bool isAdmin = SysInfoUtils::isOpenAsAdmin();
+    static std::once_flag flag;
+    std::call_once(flag, [] {
 #ifndef ENABLE_SMB_IN_ADMIN
-    /*
-     * NOTE(xust): the secret manager cannot be launched in WAYLAND ADMIN mode,
-     * which cause file-manager freeze when mount samba (dfm-mount using secret-manager
-     * to save/get the password of samba by sync).
-     * and the Admin mode is designed for operate files those normal user cannot write
-     * and should be the smallest dfm, so remove the smb-browser plugin in Admin mode
-     * */
-    if (SysInfoUtils::isOpenAsAdmin() && !blackNames.contains("dfmplugin-smbbrowser"))
-        blackNames << "dfmplugin-smbbrowser";
+        /*
+         * NOTE(xust): the secret manager cannot be launched in WAYLAND ADMIN mode,
+         * which cause file-manager freeze when mount samba (dfm-mount using secret-manager
+         * to save/get the password of samba by sync).
+         * and the Admin mode is designed for operate files those normal user cannot write
+         * and should be the smallest dfm, so remove the smb-browser plugin in Admin mode
+         * */
+        if (isAdmin && !blackNames.contains("dfmplugin-smbbrowser"))
+            blackNames << "dfmplugin-smbbrowser";
 #endif
-
-    std::copy_if(disableNames.begin(), disableNames.end(), std::back_inserter(blackNames), [blackNames](const QString &name) {
-        return !blackNames.contains(name);
+        static QStringList disableNames { DConfigManager::instance()->value(kPluginsDConfName, "filemanager.disablelist").toStringList() };
+        std::copy_if(disableNames.begin(), disableNames.end(), std::back_inserter(blackNames),
+                     [](const QString &name) {
+                         return !blackNames.contains(name);
+                     });
+        qCDebug(logAppFileManager) << "build all blacknames:" << blackNames;
     });
-    qCDebug(logAppFileManager) << "build all blacknames:" << blackNames;
-    return blackNames;
+
+    if (blackNames.contains(name))
+        return true;
+
+    // Disable all third-party plugins when running the file manager as administrator
+    static const QStringList &kAllNames { DFMBASE_NAMESPACE::Plugins::Utils::filemanagerAllPlugins() };
+    return isAdmin && !kAllNames.contains(name);
 }
 
 static bool pluginsLoad()
@@ -162,7 +172,8 @@ static bool pluginsLoad()
 #endif
 
     qCInfo(logAppFileManager) << "Using plugins dir:" << pluginsDirs;
-    DPF_NAMESPACE::LifeCycle::initialize({ kFmPluginInterface, kCommonPluginInterface }, pluginsDirs, buildBlackNames());
+    DPF_NAMESPACE::LifeCycle::initialize({ kFmPluginInterface, kCommonPluginInterface }, pluginsDirs);
+    DPF_NAMESPACE::LifeCycle::setBlackListFilter(blackListFilter);
     DPF_NAMESPACE::LifeCycle::registerQtVersionInsensitivePlugins(Plugins::Utils::filemanagerAllPlugins());
     // disbale lazy load if enbale headless
     bool enableHeadless { DConfigManager::instance()->value(kDefaultCfgPath, "dfm.headless", false).toBool() };

--- a/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
@@ -378,19 +378,23 @@ int FileEncryptHandlerPrivate::runVaultProcess(QString lockBaseDir, QString unlo
  */
 int FileEncryptHandlerPrivate::lockVaultProcess(QString unlockFileDir, bool isForced)
 {
-    CryfsVersionInfo version = versionString();
+    /*
+     * NOTE: When unmount the vault using the cryfs-unmount command,
+     * the valut will be unmounted normally even if it is busy (file copy)
+     */
+    // CryfsVersionInfo version = versionString();
+    // if (version.isVaild() && !version.isOlderThan(CryfsVersionInfo(0, 10, 0))) {
+    //     fusermountBinary = QStandardPaths::findExecutable("cryfs-unmount");
+    //     arguments << unlockFileDir;
+    // } else {
+
     QString fusermountBinary;
     QStringList arguments;
-    if (version.isVaild() && !version.isOlderThan(CryfsVersionInfo(0, 10, 0))) {
-        fusermountBinary = QStandardPaths::findExecutable("cryfs-unmount");
-        arguments << unlockFileDir;
+    fusermountBinary = QStandardPaths::findExecutable("fusermount");
+    if (isForced) {
+        arguments << "-zu" << unlockFileDir;
     } else {
-        fusermountBinary = QStandardPaths::findExecutable("fusermount");
-        if (isForced) {
-            arguments << "-zu" << unlockFileDir;
-        } else {
-            arguments << "-u" << unlockFileDir;
-        }
+        arguments << "-u" << unlockFileDir;
     }
     if (fusermountBinary.isEmpty()) return static_cast<int>(ErrorCode::kFusermountNotExist);
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -43,11 +43,9 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
 
     filePathEdit = new DFileChooserEdit(this);
     filePathEdit->lineEdit()->setPlaceholderText(tr("Select a path"));
-    fileDialog = new DFileDialog(this, QDir::homePath());
     filePathEdit->setDirectoryUrl(QDir::homePath());
     filePathEdit->setFileMode(DFileDialog::ExistingFiles);
     filePathEdit->setNameFilters({ QString("KEY file(*.key)") });
-    filePathEdit->setFileDialog(fileDialog);
     filePathEdit->lineEdit()->setReadOnly(true);
     filePathEdit->hide();
 
@@ -187,7 +185,6 @@ void RetrievePasswordView::onComboBoxIndex(int index)
         funLayout->addWidget(filePathEdit, 1, 0, 1, 2);
         defaultFilePathEdit->hide();
         filePathEdit->show();
-        fileDialog->setWindowFlags(Qt::WindowStaysOnTopHint);
         if (QFile::exists(filePathEdit->text()))
             emit sigBtnEnabled(1, true);
         else if (!filePathEdit->text().isEmpty() && filePathEdit->lineEdit()->placeholderText() != QString(tr("Unable to get the key file"))) {

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.h
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.h
@@ -110,7 +110,6 @@ private:
     QString validationResults;
 
     QGridLayout *funLayout { nullptr };
-    DTK_WIDGET_NAMESPACE::DFileDialog *fileDialog { nullptr };
 };
 }
 #endif   // VAULTRETRIEVEPASSWORD_H


### PR DESCRIPTION
- Introduced a new `blackListFilter` function to disable all third-party plugins when the file manager is run as an administrator.
- Integrated the blacklist filter into the plugin loading process to enhance security and control over plugin usage.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-309923.html

## Summary by Sourcery

Enhance file manager plugin security by adding a blacklist filter that disables third-party plugins when the application is run with administrator privileges

New Features:
- Implement a blacklist filter mechanism to control plugin loading based on administrator access

Bug Fixes:
- Prevent potential security risks by disabling third-party plugins when running as an administrator

Enhancements:
- Add security control for plugin loading in file manager to prevent unauthorized third-party plugin execution