### PR TITLE
fix: find unlocked device by crypttab

### DIFF
--- a/src/services/diskencrypt/core/cryptsetup.cpp
+++ b/src/services/diskencrypt/core/cryptsetup.cpp
@@ -556,17 +556,18 @@ int crypt_setup::csDecrypt(const QString &dev, const QString &passphrase, const 
                          name.toStdString().c_str());
     }
 
+    bool resumeOnly = flags & CRYPT_REQUIREMENT_ONLINE_REENCRYPT;
     auto shift = crypt_get_data_offset(cdev);
     struct crypt_params_reencrypt encArgs
     {
         .mode = CRYPT_REENCRYPT_DECRYPT,
         .direction = CRYPT_REENCRYPT_FORWARD,
-        .resilience = "datashift-checksum",
+        .resilience = resumeOnly ? nullptr : "datashift-checksum",
         .hash = "sha256",
         .data_shift = shift,
         .max_hotzone_size = 0,
         .device_size = 0,
-        .flags = CRYPT_REENCRYPT_MOVE_FIRST_SEGMENT
+        .flags = resumeOnly ? CRYPT_REENCRYPT_RESUME_ONLY : CRYPT_REENCRYPT_MOVE_FIRST_SEGMENT
     };
 
     auto name = activeName.toStdString();


### PR DESCRIPTION
when decryption interrupted, encrypt header in device is lost, so udisks
doesn't know this is a encrypted device

Log: as above.

## Summary by Sourcery

Improve device unlocking and encryption header handling for encrypted devices, particularly when decryption is interrupted

Bug Fixes:
- Add fallback mechanism to find unlocked encrypted devices by checking crypttab when udisks fails to identify the device
- Enhance device encryption status detection by checking for detached header files
- Improve cryptsetup decryption to handle interrupted reencryption scenarios

Enhancements:
- Extend device identification methods to use multiple matching strategies like PARTUUID, UUID, and device path
- Add support for resuming interrupted encryption operations