### PR TITLE
chore: Bump version to 6.5.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.44) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Wed, 02 Apr 2025 15:53:07 +0800
+
 dde-file-manager (6.5.43) unstable; urgency=medium
 
   * Feature additions (view mode switching, FileStatisticsJob)


### PR DESCRIPTION
Bump version to 6.5.44

Log: Bump version to 6.5.44

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect the new version number