### PR TITLE
Fix: When recovering password through a specified file, after selecti…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -46,7 +46,6 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
     filePathEdit->setDirectoryUrl(QDir::homePath());
     filePathEdit->setFileMode(DFileDialog::ExistingFiles);
     filePathEdit->setNameFilters({ QString("KEY file(*.key)") });
-    filePathEdit->lineEdit()->setReadOnly(true);
     filePathEdit->hide();
 
     defaultFilePathEdit = new QLineEdit(this);


### PR DESCRIPTION
…ng and opening a key file, attempting to select a key file again results in a grayed-out "Open" button.

- The state management of externally set dialogs is incorrect. The solution is to use the dialog internally constructed by DFileChooseDialog itself, letting DFileChooseDialog manage the dialog's state and lifecycle.

Bug： https://pms.uniontech.com/bug-view-310167.html

## Summary by Sourcery

Fix the state management issue in the key file selection dialog for password recovery

Bug Fixes:
- Resolve an issue where the 'Open' button becomes grayed out after initially selecting a key file during password recovery

Enhancements:
- Modify the file path edit control to improve dialog state management