### PR TITLE
fix: Unable to delete selected path after choosing path in key saving…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -46,7 +46,6 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
     filePathEdit->setDirectoryUrl(QDir::homePath());
     filePathEdit->setFileMode(DFileDialog::ExistingFiles);
     filePathEdit->setNameFilters({ QString("KEY file(*.key)") });
-    filePathEdit->lineEdit()->setReadOnly(true);
     filePathEdit->hide();
 
     defaultFilePathEdit = new QLineEdit(this);


### PR DESCRIPTION
… dialog

The dialog was set to read-only, now modified to be editable

bug: https://pms.uniontech.com/bug-view-309893.html

## Summary by Sourcery

Bug Fixes:
- Fix an issue where the file path edit field was read-only, preventing users from editing the selected path when retrieving a vault key