### PR TITLE
fix: change RenameBar from QFrame to QScrollArea

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
@@ -33,7 +33,10 @@ RenameBarPrivate::RenameBarPrivate(RenameBar *const qPtr)
 
 void RenameBarPrivate::initUI()
 {
-    mainLayout = new QHBoxLayout(q_ptr);
+    QWidget *widget = new QWidget(q_ptr);
+    q_ptr->setWidget(widget);
+
+    mainLayout = new QHBoxLayout(widget);
     comboBox = new QComboBox;
     stackWidget = new QStackedWidget;
 
@@ -187,8 +190,8 @@ void RenameBarPrivate::layoutItems() noexcept
     mainLayout->addWidget(frame);
     stackWidget->setCurrentIndex(0);
 
-    q_ptr->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum));
-    q_ptr->setLayout(mainLayout);
+    // q_ptr->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+    // q_ptr->setLayout(mainLayout);
 }
 
 void RenameBarPrivate::setRenameBtnStatus(const bool &value) noexcept

--- a/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
@@ -21,10 +21,14 @@ DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_workspace;
 
 RenameBar::RenameBar(QWidget *parent)
-    : QFrame(parent), d(new RenameBarPrivate(this))
+    : QScrollArea(parent), d(new RenameBarPrivate(this))
 {
-    setMinimumHeight(44);
-    setMinimumWidth(900);
+    setWidgetResizable(true);
+    setFrameShape(QFrame::NoFrame);
+    setAutoFillBackground(true);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    setFixedHeight(52);
     initConnect();
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.h
@@ -8,12 +8,13 @@
 #include "dfmplugin_workspace_global.h"
 
 #include <QFrame>
+#include <QScrollArea>
 
 namespace dfmplugin_workspace {
 
 class WorkspacePage;
 class RenameBarPrivate;
-class RenameBar : public QFrame
+class RenameBar : public QScrollArea
 {
     Q_OBJECT
     Q_DISABLE_COPY(RenameBar)


### PR DESCRIPTION
- Updated the RenameBar class to inherit from QScrollArea instead of QFrame, enhancing its functionality for scrolling content.
- Adjusted the initialization of the RenameBar to set widget properties for better layout management and user experience.

Log: Refactor RenameBar for improved usability and layout handling.
Bug: https://pms.uniontech.com/bug-view-310545.html

## Summary by Sourcery

Refactor RenameBar to use QScrollArea instead of QFrame for improved layout and scrolling capabilities

Bug Fixes:
- Enhance RenameBar's layout handling and widget properties to provide better user experience

Enhancements:
- Modify RenameBar to inherit from QScrollArea, improving content management and scrolling functionality