### PR TITLE
fix: Fix the problem of directory creation failure when samba mount.

### DIFF
--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -399,20 +399,24 @@ bool CifsMountHelper::rmdir(const QString &path)
 
 bool CifsMountHelper::mkdirMountRootPath()
 {
-    auto mntRoot = mountRoot();
+    auto mntRoot = mountRoot();   // 获取挂载根目录
     if (mntRoot.isEmpty()) {
         fmWarning() << "cifs: mount root is empty";
         return false;
     }
 
-    auto dir = opendir(mntRoot.toStdString().c_str());
-    if (!dir) {
-        int ret = ::mkdir(mntRoot.toStdString().c_str(), 0755);
-        fmInfo() << "mkdir mntRoot: " << mntRoot << "failed: " << strerror(errno) << errno;
-        return ret == 0;
-    } else {
-        closedir(dir);
+    QDir dir;
+    if (dir.exists(mntRoot)) {
+        fmInfo() << "cifs: mount root already exists: " << mntRoot;
         return true;
+    }
+
+    if (dir.mkpath(mntRoot)) {
+        fmInfo() << "cifs: mount root created successfully: " << mntRoot;
+        return true;
+    } else {
+        fmWarning() << "cifs: failed to create mount root: " << mntRoot;
+        return false;
     }
 }
 


### PR DESCRIPTION
When smb mounts and creates directories, the ::mkdir system call is used. However, if the directory has multiple levels and needs to be created recursively, mkdir cannot meet the requirement, resulting in a failure in directory creation. Use Qt's mkpath instead.

log: To avoid wood creation failure use Qt's mkpath.
bug: https://pms.uniontech.com/bug-view-310627.html

## Summary by Sourcery

Improve directory creation for Samba mount points by replacing system mkdir with Qt's mkpath for recursive directory creation

Bug Fixes:
- Fix directory creation failure when creating multi-level directories during Samba mount by using Qt's mkpath instead of system mkdir

Enhancements:
- Enhance mount root directory creation logic to handle recursive directory creation more robustly