### PR TITLE
fix: enhance file trashing logic in FileUtils

### DIFF
--- a/src/apps/dde-file-manager/pkexec/com.deepin.pkexec.dde-file-manager.policy
+++ b/src/apps/dde-file-manager/pkexec/com.deepin.pkexec.dde-file-manager.policy
@@ -6,12 +6,12 @@
   <vendor>LinuxDeepin</vendor>
   <vendor_url>https://www.deepin.com/</vendor_url>
   <action id="com.deepin.pkexec.dde-file-manager">
-    <message>Authentication is required to view the folder</message>
-    <message xml:lang="zh_CN">查看文件夹需要输入密码</message>
-    <message xml:lang="zh_HK">查看文件夾需要輸入密碼</message>
-    <message xml:lang="zh_TW">查看資料夾需要輸入密碼</message>
-    <message xml:lang="ug">ھۆججەت قىسقۇچنى كۆرۈش ئۈچۈن پارول كىرگۈزۈشىڭىز كېرەك</message>
-    <message xml:lang="bo">ཡིག་ཁུག་ལ་ལྟ་བར་གསང་ཨང་འཇུག་དགོས།</message>
+    <message>Authentication is required to open it as administrator</message>
+    <message xml:lang="zh_CN">以管理员身份打开需要认证</message>
+    <message xml:lang="zh_HK">以管理員身份開啟需要驗證</message>
+    <message xml:lang="zh_TW">以管理員身分開啟需要認證</message>
+    <message xml:lang="ug">باشقۇرغۇچى ھوقۇقى بىلەن ئېچىش ئۈچۈن دەلىللەش كېرەك</message>
+    <message xml:lang="bo">དྲ་ངོས་སྤྱད་ནས་སྤྱོད་མཁན་གྱི་གོ་གནས་ཀྱིས་ཁ་ཕྱེ་བར་དམིགས་བསལ་བཀའ་འཁྲོལ་དགོས་པ།</message>
     <icon_name>folder</icon_name>
     <defaults>
       <allow_any>no</allow_any>
@@ -22,12 +22,12 @@
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
   <action id="com.deepin.pkexec.dde-file-manager-pkexec">
-    <message>Authentication is required to view the folder</message>
-    <message xml:lang="zh_CN">查看文件夹需要输入密码</message>
-    <message xml:lang="zh_HK">查看文件夾需要輸入密碼</message>
-    <message xml:lang="zh_TW">查看資料夾需要輸入密碼</message>
-    <message xml:lang="ug">ھۆججەت قىسقۇچنى كۆرۈش ئۈچۈن پارول كىرگۈزۈشىڭىز كېرەك</message>
-    <message xml:lang="bo">ཡིག་ཁུག་ལ་ལྟ་བར་གསང་ཨང་འཇུག་དགོས།</message>
+    <message>Authentication is required to open it as administrator</message>
+    <message xml:lang="zh_CN">以管理员身份打开需要认证</message>
+    <message xml:lang="zh_HK">以管理員身份開啟需要驗證</message>
+    <message xml:lang="zh_TW">以管理員身分開啟需要認證</message>
+    <message xml:lang="ug">باشقۇرغۇچى ھوقۇقى بىلەن ئېچىش ئۈچۈن دەلىللەش كېرەك</message>
+    <message xml:lang="bo">དྲ་ངོས་སྤྱད་ནས་སྤྱོད་མཁན་གྱི་གོ་གནས་ཀྱིས་ཁ་ཕྱེ་བར་དམིགས་བསལ་བཀའ་འཁྲོལ་དགོས་པ།</message>
     <icon_name>folder</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1438,7 +1438,7 @@ bool FileUtils::fileCanTrash(const QUrl &url)
     if (alltotrash)
         return info->canAttributes(CanableInfoType::kCanTrash);
 
-    return ProtocolUtils::isLocalFile(url);
+    return ProtocolUtils::isLocalFile(url) && info->canAttributes(CanableInfoType::kCanTrash);
 }
 
 QUrl FileUtils::bindUrlTransform(const QUrl &url)

--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -175,7 +175,7 @@ void UniversalUtils::blockShutdown(QDBusReply<QDBusUnixFileDescriptor> &replay)
                                 QDBusConnection::systemBus());
 
     QList<QVariant> arg;
-    arg << QString("shutdown:sleep:")   // what
+    arg << QString("shutdown:sleep")   // what
         << qApp->applicationDisplayName()   // who
         << QObject::tr("Files are being processed")   // why
         << QString("block");   // mode


### PR DESCRIPTION
- Updated the fileCanTrash function to ensure that a file can only be trashed if it is a local file and has the appropriate attributes.
- This change improves the reliability of the trashing functionality by adding an additional check for file attributes.

Log: Refine file trashing conditions for better accuracy.
Bug: https://pms.uniontech.com/bug-view-309791.html

## Summary by Sourcery

Bug Fixes:
- Enhance file trashing conditions to prevent trashing files that do not meet specific criteria by adding an additional attribute check