### PR TITLE
fix: Unable to delete selected path after choosing path in key saving dialog

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -46,7 +46,6 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
     filePathEdit->setDirectoryUrl(QDir::homePath());
     filePathEdit->setFileMode(DFileDialog::ExistingFiles);
     filePathEdit->setNameFilters({ QString("KEY file(*.key)") });
-    filePathEdit->lineEdit()->setReadOnly(true);
     filePathEdit->hide();
 
     defaultFilePathEdit = new QLineEdit(this);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -106,7 +106,7 @@ void FileOperatorHelper::openFilesByMode(const FileView *view, const QList<QUrl>
             if (fileInfoPtr->isAttributes(OptInfoType::kIsDir)) {
                 QUrl dirUrl = url;
                 if (fileInfoPtr->isAttributes(OptInfoType::kIsSymLink))
-                    dirUrl = QUrl::fromLocalFile(fileInfoPtr->pathOf(PathInfoType::kSymLinkTarget));
+                    dirUrl = QUrl::fromLocalFile(QDir(fileInfoPtr->pathOf(PathInfoType::kSymLinkTarget)).absolutePath());
 
                 auto flag = !DConfigManager::instance()->value(kViewDConfName,
                                                                kOpenFolderWindowsInASeparateProcess, true)


### PR DESCRIPTION
fix: Unable to delete selected path after choosing path in key saving dialog
fix: update directory URL handling in FileOperatorHelper

## Summary by Sourcery

Improve file path handling and dialog interaction in file-related components

Bug Fixes:
- Fix directory URL handling for symlinked directories to use absolute paths
- Enable editing of file path in key saving dialog

Enhancements:
- Improve path resolution for symlinked directories in file operations