### PR TITLE
fix: Modify the auto-index internal disk option in search settings

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -124,7 +124,7 @@ void Search::regSearchSettingConfig()
     if (SearchHelper::anythingInterface().isValid()) {
         SettingJsonGenerator::instance()->addCheckBoxConfig(SearchSettings::kIndexInternal,
                                                             tr("Auto index internal disk"),
-                                                            false);
+                                                            true);
         SettingBackend::instance()->addSettingAccessor(
                 SearchSettings::kIndexInternal,
                 []() {


### PR DESCRIPTION
- Change the default value of the "Auto index internal disk" option from false to true

Bug: https://pms.uniontech.com/bug-view-309903.html

## Summary by Sourcery

Bug Fixes:
- Change the default value of the 'Auto index internal disk' option from false to true to improve search functionality