### PR TITLE
fix: ensure valid splitter state in saveWindowState function

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -327,6 +327,8 @@ void FileManagerWindowPrivate::saveWindowState()
     QVariantMap state;
     // fix bug 30932,获取全屏属性，必须是width全屏和height全屏属性都满足，才判断是全屏
     if ((states & kNetWmStateMaximizedHorz) == 0 || (states & kNetWmStateMaximizedVert) == 0) {
+        if (!splitter || splitter->sizes().isEmpty())
+            return;
         int sideBarWidth = splitter->sizes().at(0);
         int minWidth = std::max(sideBarWidth, kMinimumLeftWidth) + kMinimumRightWidth + splitter->handleWidth();
         state["width"] = std::max(q->size().width(), minWidth);


### PR DESCRIPTION
- Added a check to verify that the splitter is not null and has sizes before proceeding with the window state saving logic. This prevents potential errors when the splitter is not properly initialized.

Log: Improve robustness of window state saving by validating splitter state.
Bug: https://pms.uniontech.com/bug-view-312107.html

## Summary by Sourcery

Bug Fixes:
- Prevent potential errors when saving window state by checking if the splitter is null or has no sizes before accessing its properties