### PR TITLE
fix: Add recent file proxy to enhance file management functionality

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/canvasmanager.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/canvasmanager.cpp
@@ -10,6 +10,7 @@
 #include "desktoputils/ddpugin_eventinterface_helper.h"
 #include "menu/canvasmenuscene.h"
 #include "menu/canvasbasesortmenuscene.h"
+#include "recentproxy/canvasrecentproxy.h"
 
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
 
@@ -18,6 +19,7 @@
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/dfm_event_defines.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -90,6 +92,7 @@ void CanvasManager::init()
     CanvasCoreSubscribe(signal_DesktopFrame_WindowBuilded, &CanvasManager::onCanvasBuild);
     CanvasCoreSubscribe(signal_DesktopFrame_GeometryChanged, &CanvasManager::onGeometryChanged);
     CanvasCoreSubscribe(signal_DesktopFrame_AvailableGeometryChanged, &CanvasManager::onGeometryChanged);
+
     dpfSignalDispatcher->subscribe("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged", this, &CanvasManager::onTrashStateChanged);
 
     // update grid by font changed
@@ -108,6 +111,11 @@ void CanvasManager::init()
 
     d->initModel();
     d->initSetting();
+
+    // 处理桌面文件以文件管理器的最近使用文件的联动
+    d->recentFileProxy = new CanvasRecentProxy(this);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kMoveToTrashResult, d->recentFileProxy, &CanvasRecentProxy::handleReloadRecentFiles);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kDeleteFilesResult, d->recentFileProxy, &CanvasRecentProxy::handleReloadRecentFiles);
 }
 
 void CanvasManager::update()

--- a/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
@@ -20,6 +20,7 @@
 #include "broker/canvasmodelbroker.h"
 #include "broker/canvasviewbroker.h"
 #include "broker/canvasgridbroker.h"
+#include "recentproxy/canvasrecentproxy.h"
 
 namespace ddplugin_canvas {
 
@@ -63,6 +64,7 @@ public:
     CanvasSelectionModel *selectionModel = nullptr;
     CanvasSelectionHook *selectionHook = nullptr;
     CanvasViewHook *viewHook = nullptr;
+    CanvasRecentProxy* recentFileProxy = nullptr;
     QMap<QString, CanvasViewPointer> viewMap;
 public:
     FileInfoModelBroker *sourceModelBroker = nullptr;

--- a/src/plugins/desktop/ddplugin-canvas/recentproxy/canvasrecentproxy.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/recentproxy/canvasrecentproxy.cpp
@@ -1,0 +1,32 @@
+#include "canvasrecentproxy.h"
+#include <QDBusMessage>
+#include <QDBusConnection>
+#include <QDBusError>
+#include <QVariant>
+#include <QDBusPendingCall>
+#include <QUrl>
+
+namespace ddplugin_canvas {
+
+void CanvasRecentProxy::handleReloadRecentFiles(const QList<QUrl> &srcUrls, bool ok, const QString &errMsg)
+{
+    Q_UNUSED(errMsg);
+    if (!ok || !srcUrls.isEmpty())
+        return;
+
+    QDBusMessage message = QDBusMessage::createMethodCall("org.deepin.Filemanager.Daemon",
+                                                          "/org/deepin/Filemanager/Daemon/RecentManager",
+                                                          "org.deepin.Filemanager.Daemon.RecentManager",
+                                                          "Reload");
+    QDBusConnection::sessionBus().asyncCall(message);
+}
+
+CanvasRecentProxy::CanvasRecentProxy(QObject *parent)
+    : QObject(parent)
+{
+}
+
+CanvasRecentProxy::~CanvasRecentProxy()
+{
+}
+} // namespace ddplugin_canvas

--- a/src/plugins/desktop/ddplugin-canvas/recentproxy/canvasrecentproxy.h
+++ b/src/plugins/desktop/ddplugin-canvas/recentproxy/canvasrecentproxy.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef CANVASRECENTPROXY_H
+#define CANVASRECENTPROXY_H
+
+#include <QObject>
+
+namespace ddplugin_canvas {
+
+class CanvasRecentProxy : public QObject
+{
+    Q_OBJECT
+public:
+    explicit CanvasRecentProxy(QObject *parent = nullptr);
+    ~CanvasRecentProxy() override;
+
+public slots:
+    void handleReloadRecentFiles(const QList<QUrl> &srcUrls, bool ok, const QString &errMsg);
+};
+
+} // namespace ddplugin_canvas
+
+#endif // CANVASRECENTPROXY_H


### PR DESCRIPTION
- Introduce CanvasRecentProxy in CanvasManager to support recent files management.
- Subscribe to events related to file deletion and moving to trash, to update the recent files list in real-time.

bug: https://pms.uniontech.com/bug-view-309675.html

## Summary by Sourcery

Enhance file management by adding a recent file proxy to the canvas manager to track and update recent files list in real-time

New Features:
- Introduce CanvasRecentProxy to manage recent files in the desktop canvas plugin

Bug Fixes:
- Implement real-time tracking of recent files after file operations

Enhancements:
- Subscribe to file deletion and trash events to dynamically update the recent files list