### PR TITLE
fix: correct background rendering in ListItemEditor

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemeditor.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemeditor.cpp
@@ -125,7 +125,11 @@ void ListItemEditor::init()
     setObjectName("ListItemDelegate_Editor");
 
     setFrame(false);
-    setAttribute(Qt::WA_TranslucentBackground);
+    // fix bug-309553
+    // 重新设置调色板颜色值，使得背景色正确渲染，而不是保持透明状态。
+    auto p = palette();
+    p.setColor(QPalette::Button, p.color(QPalette::Button));
+    setPalette(p);
     setContentsMargins(0, 0, 0, 0);
     connect(this, &ListItemEditor::textChanged, this, &ListItemEditor::onEditorTextChanged, Qt::UniqueConnection);
 }


### PR DESCRIPTION
- Updated the ListItemEditor to reset the palette color values, ensuring the background color is rendered correctly instead of remaining transparent. This addresses bug-309553 related to background display issues.

Log: Improve background rendering in ListItemEditor for better visual consistency.
Bug: https://pms.uniontech.com/bug-view-309553.html

## Summary by Sourcery

Bug Fixes:
- Corrected the background color rendering in ListItemEditor by explicitly setting the palette color, preventing the editor from remaining transparent