### PR TITLE
chore: Update version to 6.5.45

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.45) unstable; urgency=medium
+
+ * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 10 Apr 2025 19:50:17 +0800
+
 dde-file-manager (6.5.44) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
update version

Log: update version

## Summary by Sourcery

Chores:
- Bump project version number in the Debian changelog