### PR TITLE
fix: update VaultActiveSaveKeyFileView to allow file path selection

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
@@ -68,7 +68,6 @@ void VaultActiveSaveKeyFileView::initUI()
 
     selectfileSavePathEdit = new DFileChooserEdit(this);
     DFontSizeManager::instance()->bind(otherPathRadioBtn, DFontSizeManager::T8, QFont::Medium);
-    selectfileSavePathEdit->lineEdit()->setReadOnly(true);
     selectfileSavePathEdit->lineEdit()->setPlaceholderText(tr("Select a path"));
     filedialog = new DFileDialog(this, QDir::homePath(), QString("pubKey.key"));
     filedialog->setAcceptMode(QFileDialog::AcceptMode::AcceptSave);


### PR DESCRIPTION
- Removed the read-only restriction on the file path edit field in VaultActiveSaveKeyFileView, enabling users to select a save path for the vault key file.
- Commented out the error handling logic in UnlockView to potentially simplify the user experience during password input.

bug: https://pms.uniontech.com/bug-view-309893.html

## Summary by Sourcery

Bug Fixes:
- Removed the read-only restriction on the file path edit field, allowing users to manually select and specify a save location for vault key files