### PR TITLE
fix: improve CanvasSelectionModel clear logic to handle sync clearing

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.cpp
@@ -37,7 +37,13 @@ void CanvasSelectionModel::clearSelectedCache()
 
 void CanvasSelectionModel::clear()
 {
-    if (hook)
+    // 检查是否是由collectview的SelectionSyncHelper触发的清除
+    bool isSyncClearing = property("syncHelperClearing").toBool();
+    
+    // 一般的，在canvasview存在多选的时候，在collectview中点击选择会触发canvasselectionmodel的clear
+    // 从而导致hook->clear()被调用，进一步collectionview的selectionModel()->clear()被调用，就会存在collectview不能设置选中文件
+    // 所以需要区分开来，如果是syncHelper触发的清除，则不调用hook->clear()
+    if (!isSyncClearing && hook)
         hook->clear();
 
     QItemSelectionModel::clear();
@@ -63,3 +69,11 @@ void CanvasSelectionModel::selectAll()
     QItemSelection allIndex(m->index(0, 0), m->index(row - 1, 0));
     select(allIndex, QItemSelectionModel::ClearAndSelect);
 }
+
+void CanvasSelectionModel::hookClear()
+{
+    if (hook)
+        hook->clear();
+}
+
+

--- a/src/plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.h
+++ b/src/plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.h
@@ -24,6 +24,7 @@ public:
     QModelIndexList selectedIndexesCache() const;
     QList<QUrl> selectedUrls() const;
     void selectAll();
+    void hookClear();
 public slots:
     void clearSelectedCache();
     void clear() override;

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/clickselector.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/clickselector.cpp
@@ -34,6 +34,8 @@ void ClickSelector::click(const QModelIndex &index)
             continuesSelect(index);
         else
             singleSelect(index);
+
+        view->selectionModel()->hookClear();
     }
     //! update whole view area is low performance
     //view->update();

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -466,7 +466,7 @@ bool NormalizedMode::initialize(CollectionModel *m)
 
     // sync selection
     d->selectionHelper->setInnerModel(d->selectionModel);
-    //d->selectionHelper->setExternalModel(canvasSelectionShell->selectionModel());
+    d->selectionHelper->setExternalModel(canvasSelectionShell->selectionModel());
     d->selectionHelper->setShell(canvasSelectionShell);
     d->selectionHelper->setEnabled(true);
 

--- a/src/plugins/desktop/ddplugin-organizer/mode/selectionsynchelper.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/selectionsynchelper.cpp
@@ -63,11 +63,13 @@ void SelectionSyncHelper::clearExteralSelection()
     if (!enabled || !external || !external->hasSelection())
         return;
 
+    external->setProperty("syncHelperClearing", true);
     // disconnect to prevent signal recursion
     disconnect(external, &QItemSelectionModel::selectionChanged, this, &SelectionSyncHelper::clearInnerSelection);
 
     // clear canvas selection if any selection was operated in collection.
     external->clear();
+    external->setProperty("syncHelperClearing", false);
 
     connect(external, &QItemSelectionModel::selectionChanged, this, &SelectionSyncHelper::clearInnerSelection);
 }


### PR DESCRIPTION
- Added a check in CanvasSelectionModel::clear() to differentiate between regular clear calls and those triggered by SelectionSyncHelper, preventing unintended clearing of selections.
- Introduced a new method hookClear() to encapsulate the hook clearing logic, ensuring it can be called independently.
- Updated ClickSelector to utilize the new hookClear() method for better selection management.

bug：https://pms.uniontech.com/bug-view-300259.html

## Summary by Sourcery

Improve selection management in CanvasSelectionModel to prevent unintended clearing of selections during synchronization between canvas and collection views

New Features:
- Created a property-based flag to identify selection clearing triggered by SelectionSyncHelper

Bug Fixes:
- Fixed an issue where clearing selections in the collection view could incorrectly clear selections in the canvas view by introducing a sync clearing flag

Enhancements:
- Added a mechanism to differentiate between regular and sync-triggered clear operations
- Introduced a new hookClear() method to provide more flexible selection management