### PR TITLE
fix: update hover state logic in CustomDIconButton

### DIFF
--- a/src/dfm-base/widgets/dfmcustombuttons/customiconbutton.cpp
+++ b/src/dfm-base/widgets/dfmcustombuttons/customiconbutton.cpp
@@ -40,17 +40,27 @@ void CustomDIconButton::paintEvent(QPaintEvent *event)
     DStyleOptionButton opt;
     initStyleOption(&opt);
 
-    if (isEnabled() && underMouse() && !isDown() && !isChecked()) {
+    if (isEnabled() && !isChecked()) {
         bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
-        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
-                                      : QColor(0, 0, 0, 26);
-        
         DStyleHelper dstyle(style());
         const int radius = dstyle.pixelMetric(DStyle::PM_FrameRadius);
-        
-        painter.setPen(Qt::NoPen);
-        painter.setBrush(hoverColor);
-        painter.drawRoundedRect(rect(), radius, radius);
+
+        QColor bgColor;
+        if (isDown()) {
+            // 按下状态 - 20%不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 51)
+                                  : QColor(0, 0, 0, 51);
+        } else if (underMouse()) {
+            // 悬浮状态 - 10%不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 26)
+                                  : QColor(0, 0, 0, 26);
+        }
+
+        if (bgColor.isValid()) {
+            painter.setPen(Qt::NoPen);
+            painter.setBrush(bgColor);
+            painter.drawRoundedRect(rect(), radius, radius);
+        }
     }
 
     DStyleHelper dstyle(style());


### PR DESCRIPTION
- Modified the hover state condition in CustomDIconButton to remove the check for the button being pressed, allowing for a more responsive hover effect when the button is enabled and the mouse is over it.

Log: https://pms.uniontech.com/bug-view-312657.html

## Summary by Sourcery

Bug Fixes:
- Modify hover state condition to remove unnecessary check for button press, enabling a more responsive hover effect