### PR TITLE
fix: Handle symbolic links correctly when deleting files recursively

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -572,6 +572,12 @@ bool LocalFileHandler::deleteFileRecursive(const QUrl &url)
         return false;
     }
 
+    // 首先检查是否是符号链接，如果是则只删除链接本身
+    if (info->isAttributes(OptInfoType::kIsSymLink)) {
+        qCInfo(logDFMBase) << "Delete symbolic link: " << url;
+        return deleteFile(url);
+    }
+
     if (!info->isAttributes(OptInfoType::kIsDir))
         return deleteFile(url);
 


### PR DESCRIPTION
- Added specific handling for symbolic links in the
LocalFileHandler::deleteFileRecursive method
- When a symbolic link is detected, only the link itself is deleted, not
the target file it points to
- Added appropriate log message when deleting symbolic links
- Fixed the bug where burn module would delete the target files of
symbolic links in staging directory

This change ensures that when cleaning up temporary staging directories
during disc burning operations,
symbolic links are properly handled by only removing the link itself
without affecting the original
target files.
 This prevents data loss when users include symbolic links
in the burn staging area.

Log: Handle symbolic links correctly when deleting files recursively
Change-Id: I0f28a906f3ecefd18ed5108bb455733e145b9fc8

Bug: https://pms.uniontech.com/bug-view-311869.html

## Summary by Sourcery

Modify file deletion logic to correctly handle symbolic links by only removing the link itself instead of its target

New Features:
- Add specific handling for symbolic links in the LocalFileHandler::deleteFileRecursive method

Bug Fixes:
- Fix a critical bug in file deletion that would incorrectly delete the target files of symbolic links during recursive file operations

Chores:
- Add logging for symbolic link deletion