### PR TITLE
fix: Update palette for permission manager widget

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -229,6 +229,14 @@ void PermissionManagerWidget::updateBackgroundColor()
 
     palette.setColor(QPalette::Window, bgColor);
     setPalette(palette);
+
+    // 此处需要设置一下combobox的弹出列表的调色板，否则会带上自定义的背景色
+    if (ownerComboBox && groupComboBox && otherComboBox)
+    {
+        ownerComboBox->view()->setPalette(palette);
+        groupComboBox->view()->setPalette(palette);
+        otherComboBox->view()->setPalette(palette);
+    }
 }
 
 QString PermissionManagerWidget::getPermissionString(int enumFlag)


### PR DESCRIPTION
- Added functionality to set the palette for owner, group, and other combo boxes in the PermissionManagerWidget, ensuring consistent background color across all components.

Log: https://pms.uniontech.com/bug-view-310613.html

## Summary by Sourcery

Bug Fixes:
- Fixed inconsistent background color for owner, group, and other combo boxes in the PermissionManagerWidget by setting their view palettes