### PR TITLE
refactor: improve menu helper functions and update related logic

### DIFF
--- a/src/plugins/common/dfmplugin-menu/CMakeLists.txt
+++ b/src/plugins/common/dfmplugin-menu/CMakeLists.txt
@@ -31,6 +31,8 @@ target_link_libraries(${BIN_NAME}
     DFM6::framework
 )
 
+target_compile_definitions(${BIN_NAME} PRIVATE MENU_CHECK_FOCUSONLY)
+
 # 安装库文件
 install(TARGETS
     ${BIN_NAME}

--- a/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -110,7 +110,7 @@ bool FileOperatorMenuScene::create(QMenu *parent)
         return true;
 
     QAction *tempAction { nullptr };
-    if (Helper::showOpenAction(d->selectFiles)) {
+    if (Helper::canOpenSelectedItems(d->selectFiles)) {
         tempAction = parent->addAction(d->predicateName.value(ActionID::kOpen));
         d->predicateAction[ActionID::kOpen] = tempAction;
         tempAction->setProperty(ActionPropertyKey::kActionID, QString(ActionID::kOpen));

--- a/src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp
@@ -103,7 +103,7 @@ bool OpenWithMenuScene::create(QMenu *parent)
     if (d->selectFiles.isEmpty() || !d->focusFile.isValid())
         return false;
 
-    if (!Helper::showOpenAction(d->selectFiles))
+    if (!Helper::canOpenSelectedItems(d->selectFiles))
         return false;
 
     if (d->isFocusOnDDEDesktopFile || d->isSystemPathIncluded)

--- a/src/plugins/common/dfmplugin-menu/utils/menuhelper.h
+++ b/src/plugins/common/dfmplugin-menu/utils/menuhelper.h
@@ -15,7 +15,7 @@ namespace Helper {
 bool isHiddenExtMenu(const QUrl &dirUrl);
 bool isHiddenMenu(const QString &app);
 bool isHiddenDesktopMenu();
-bool showOpenAction(const QList<QUrl> &urlList);
+bool canOpenSelectedItems(const QList<QUrl> &urlList);
 }   //  namespace Helper
 }   //  namespace dfmplugin_menu
 #endif   // MENUHELPER_H


### PR DESCRIPTION
- Renamed `showOpenAction` to `canOpenSelectedItems` for better clarity on its purpose.
- Enhanced the `canOpenSelectedItems` function to optimize directory checks and improve performance by limiting the number of URLs scanned.
- Updated references in menu scene files to use the new function name, ensuring consistency across the codebase.
- Adjusted comments for better understanding of the logic.

Log: This commit refines the menu helper functionality by improving the naming and efficiency of the item-checking logic, leading to a more intuitive and performant user experience in the menu operations.

## Summary by Sourcery

Refactor menu helper functions to improve performance and code clarity when checking selected items for opening

Enhancements:
- Optimized the URL scanning logic to limit the number of URLs checked and improve performance
- Renamed function to more clearly describe its purpose of checking if selected items can be opened

Chores:
- Updated function references across multiple menu scene files
- Adjusted comments to better explain the logic