### PR TITLE
fix: Enhance emblem management logic in EmblemManager

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
@@ -46,7 +46,13 @@ bool EmblemManager::paintEmblems(int role, const FileInfoPointer &info, QPainter
     if (!helper->isExtEmblemProhibited(info, url)) {
         // add gio embelm icons
         helper->pending(info);
-        emblems.append(helper->gioEmblemIcons(url));
+        const auto &gioEmblems = helper->gioEmblemIcons(url);
+        if (emblems.isEmpty()) {
+            emblems = gioEmblems;
+        } else if (emblems.size() < gioEmblems.size()) {
+            // Ensure that the custom emblems do not affect the display position by the system emblems
+            emblems.append(gioEmblems.mid(emblems.size()));
+        }
 
         // add custom emblem icons
         EmblemEventSequence::instance()->doFetchCustomEmblems(url, &emblems);

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -94,31 +94,28 @@ void OpenWithDialogListItem::initUiForSizeMode()
     setFixedSize(220, 50);
 #endif
     iconLabel->setFixedSize(size, size);
-    updateLabelIcon(iconName, size);
+    updateLabelIcon(size);
 }
 
-void OpenWithDialogListItem::updateLabelIcon(const QString &iconName, int size)
+void OpenWithDialogListItem::updateLabelIcon(int size)
 {
+    const QStringList iconCandidates = { iconName, "application-x-desktop" };
     const QSize iconSize(size, size);
     const qreal dpr = qApp->devicePixelRatio();
+    const bool isLightTheme = (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType);
 
-    DDciIcon dciIcon = DDciIcon::fromTheme(iconName);
-    if (!dciIcon.isNull()) {
-        iconLabel->setPixmap(dciIcon.pixmap(dpr, size,
-                                            DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType
-                                                    ? DDciIcon::Light
-                                                    : DDciIcon::Dark));
-        return;
+    for (const QString &candidate : iconCandidates) {
+        DDciIcon dciIcon = DDciIcon::fromTheme(candidate);
+        if (!dciIcon.isNull()) {
+            iconLabel->setPixmap(dciIcon.pixmap(dpr, size, isLightTheme ? DDciIcon::Light : DDciIcon::Dark));
+            return;
+        }
+        QIcon icon = QIcon::fromTheme(candidate);
+        if (!icon.isNull()) {
+            iconLabel->setPixmap(icon.pixmap(iconSize, dpr));
+            return;
+        }
     }
-
-    QIcon icon = QIcon::fromTheme(iconName);
-    if (!icon.isNull()) {
-        iconLabel->setPixmap(icon.pixmap(iconSize, dpr));
-        return;
-    }
-
-    if (iconName != "application-x-desktop")
-        updateLabelIcon("application-x-desktop", size);
 }
 
 QString OpenWithDialogListItem::text() const

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.h
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.h
@@ -52,7 +52,7 @@ public slots:
     void initUiForSizeMode();
 
 private:
-    void updateLabelIcon(const QString &iconName, int size);
+    void updateLabelIcon(int size);
 
     QString iconName;
     DIconButton *checkButton;


### PR DESCRIPTION
- Updated the `paintEmblems` method to improve the handling of GIO emblem icons.
- Ensured that custom emblems do not interfere with the display order of system emblems by appending only the necessary icons.
- This change optimizes the emblem display logic, enhancing the visual representation of file icons.

Log: Improve emblem management for better icon display consistency.
Bug: https://pms.uniontech.com/bug-view-312355.html

## Summary by Sourcery

Improve the emblem management logic in EmblemManager to optimize the display of file icons and ensure proper handling of GIO emblem icons.

Bug Fixes:
- Fixed the issue with custom emblems potentially interfering with the display order of system emblems by modifying the appending logic for GIO emblem icons.

Enhancements:
- Enhanced the `paintEmblems` method to more intelligently handle and append GIO emblem icons while preserving the original display order.