### PR TITLE
fix: [fileview] Content label font size does not change.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -28,6 +28,9 @@
 #include <QScrollBar>
 #include <QVBoxLayout>
 
+inline constexpr int kContentLabelMinWidth { 145 };
+inline constexpr int kContentLabelMinHeight { 60 };
+
 DFMBASE_USE_NAMESPACE
 DFMGLOBAL_USE_NAMESPACE
 using namespace dfmplugin_workspace;
@@ -173,6 +176,8 @@ void FileViewPrivate::initContentLabel()
 {
     if (!contentLabel) {
         contentLabel = new QLabel(q);
+        contentLabel->setMinimumSize(kContentLabelMinWidth, kContentLabelMinHeight);
+        contentLabel->setAlignment(Qt::AlignCenter);
 
         QColor color = (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::ColorType::LightType)
                 ? QColor(0, 0, 0, 102)
@@ -190,10 +195,7 @@ void FileViewPrivate::initContentLabel()
                              contentLabel->setPalette(labelPalette);
                          });
 
-        auto font = contentLabel->font();
-        font.setFamily("SourceHanSansSC-Light");
-        font.setPixelSize(14);
-        contentLabel->setFont(font);
+        DFontSizeManager::instance()->bind(contentLabel, DFontSizeManager::SizeType::T6);
 
         contentLabel.setCenterIn(q);
         contentLabel->setStyleSheet(q->styleSheet());


### PR DESCRIPTION
-- Conten label font size does not change with the system font size. -- UI adjuset.
-- Change size of content label by DFontSizeManager.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-313387.html

## Summary by Sourcery

Adjust the content label in the file view to use system font sizing and improve its layout

Bug Fixes:
- Fix the content label font size to dynamically change with the system font size using DFontSizeManager

Enhancements:
- Set minimum size for the content label
- Center-align the content label