### PR TITLE
chore: Update version to 6.5.46

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.46) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 17 Apr 2025 13:12:52 +0800
+
 dde-file-manager (6.5.45) unstable; urgency=medium
 
  * fix bugs


### PR DESCRIPTION
update version

Log: update version

## Summary by Sourcery

Chores:
- Bump project version number in the Debian changelog