### PR TITLE
fix: optimize frame management and desktop organization

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -239,6 +239,7 @@ QHBoxLayout *ShareControlWidget::setupNetworkPath()
     });
 
     QHBoxLayout *hBoxLine = new QHBoxLayout(this);
+    hBoxLine->setSpacing(0);
     hBoxLine->setContentsMargins(0, 0, 2, 0);
     hBoxLine->addWidget(netScheme);
     hBoxLine->addWidget(networkAddrLabel);

--- a/src/plugins/desktop/ddplugin-organizer/framemanager.h
+++ b/src/plugins/desktop/ddplugin-organizer/framemanager.h
@@ -23,7 +23,7 @@ public:
     ~FrameManager() override;
     bool initialize();
     void layout();
-    void turnOn(bool build = true);
+    void turnOn();
     void turnOff();
 
     bool organizerEnabled();

--- a/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
@@ -41,6 +41,7 @@ public slots:
     void switchToCustom();
     void switchToNormalized(int cf);
     void showOptionWindow();
+    void onOrganizered();
 
 protected:
     QWidget *findView(QWidget *root) const;


### PR DESCRIPTION
- Remove unnecessary code in enableChanged function
- Add onOrganizered slot to handle desktop organization
- Update turnOn function to remove build parameter
- Connect reorganizeDesktop signal to onOrganizered slot
- Move desktop organization logic from enableChanged to onOrganizered

Log: optimize frame management and desktop organization
Bug: https://pms.uniontech.com/bug-view-310149.html

## Summary by Sourcery

Optimize frame management and desktop organization by refactoring the desktop plugin's organization logic and signal handling

New Features:
- Add onOrganizered slot to handle desktop organization more explicitly

Bug Fixes:
- Remove unnecessary code in enableChanged function that was saving profiles conditionally

Enhancements:
- Simplify turnOn function by removing build parameter and associated logic
- Improve desktop organization workflow by introducing a new onOrganizered slot