### PR TITLE
fix: [UI] The icon for the device removal function is incorrect.

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
@@ -217,7 +217,7 @@ void DockItemDataManager::notify(const QString &title, const QString &msg)
     QVariantList args;
     args << QString("dde-file-manager")
          << static_cast<uint>(0)
-         << QString("media-eject")
+         << QString("drive-removable-dock")
          << title
          << msg
          << QStringList()


### PR DESCRIPTION
-- Change the icon for the device removal function to 'drive-removable-dock'.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-313213.html

## Summary by Sourcery

Bug Fixes:
- Replace the incorrect 'media-eject' icon with the more appropriate 'drive-removable-dock' icon for device removal