### PR TITLE
fix: [UI] Adjust font for disks label.

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
@@ -141,7 +141,7 @@ QWidget *DeviceList::createHeader()
     headerWidget->setLayout(headerLay);
 
     QLabel *title = new QLabel(tr("Disks"), this);
-    DFontSizeManager::instance()->bind(title, DFontSizeManager::T3, QFont::Medium);
+    DFontSizeManager::instance()->bind(title, DFontSizeManager::T5, QFont::DemiBold);
     lay->addWidget(title);
 
     auto line = DeviceItem::createSeparateLine(1);


### PR DESCRIPTION
-- Adjust font for disks label.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-313149.html

## Summary by Sourcery

Bug Fixes:
- Fixed the font styling for the disks label to improve readability