### PR TITLE
feat: add ExtensionMonitor for managing OEM menu extensions

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menu.cpp
+++ b/src/plugins/common/dfmplugin-menu/menu.cpp
@@ -18,6 +18,7 @@
 #include "extendmenuscene/extendmenu/dcustomactionparser.h"
 #include "oemmenuscene/oemmenuscene.h"
 #include "oemmenuscene/oemmenu.h"
+#include "oemmenuscene/extensionmonitor.h"
 #include "templatemenuscene/templatemenuscene.h"
 #include "templatemenuscene/templatemenu.h"
 
@@ -228,6 +229,9 @@ void Menu::initialize()
 
 bool Menu::start()
 {
+    const auto &appName = qApp->applicationName();
+    if (appName == "org.deepin.dde-shell" || appName == "dde-desktop")
+        ExtensionMonitor::instance()->start();
     return true;
 }
 

--- a/src/plugins/common/dfmplugin-menu/oemmenuscene/extensionmonitor.cpp
+++ b/src/plugins/common/dfmplugin-menu/oemmenuscene/extensionmonitor.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "extensionmonitor.h"
+
+#include <dfm-base/file/local/localfilewatcher.h>
+
+#include <QDir>
+#include <QFile>
+#include <QStandardPaths>
+
+using namespace dfmplugin_menu;
+DFMBASE_USE_NAMESPACE
+
+static const char *const kOemMenuExtensionsPath = "/usr/share/deepin/dde-file-manager/oem-menuextensions";
+
+ExtensionMonitor::ExtensionMonitor(QObject *parent)
+    : QObject(parent)
+{
+    // Get XDG_DATA_HOME path
+    QString xdgDataHome = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+    QString oemDataPath = xdgDataHome + "/deepin/dde-file-manager/oem-menuextensions";
+
+    extensionMap.insert(kOemMenuExtensionsPath, oemDataPath);
+}
+
+ExtensionMonitor *ExtensionMonitor::instance()
+{
+    static ExtensionMonitor ins;
+    return &ins;
+}
+
+void ExtensionMonitor::start()
+{
+    QTimer::singleShot(5000, this, [this] {
+        copyInitialFiles();
+        setupFileWatchers();
+    });
+}
+
+void ExtensionMonitor::setupFileWatchers()
+{
+    for (const auto &path : extensionMap.keys()) {
+        auto watcher = new LocalFileWatcher(QUrl::fromLocalFile(path), this);
+        if (watcher) {
+            connect(watcher, &LocalFileWatcher::subfileCreated,
+                    this, &ExtensionMonitor::onFileAdded);
+            connect(watcher, &LocalFileWatcher::fileDeleted,
+                    this, &ExtensionMonitor::onFileDeleted);
+            watcher->startWatcher();
+        }
+    }
+}
+
+void ExtensionMonitor::checkAndMkpath(const QString &path)
+{
+    // Create directory if it doesn't exist
+    QDir dir(path);
+    if (!dir.exists())
+        dir.mkpath(".");
+}
+
+void ExtensionMonitor::copyInitialFiles()
+{
+    for (auto iter = extensionMap.cbegin(); iter != extensionMap.cend(); ++iter) {
+        processExtensionDirectory(iter.key(), iter.value());
+    }
+}
+
+void ExtensionMonitor::processExtensionDirectory(const QString &sourcePath, const QString &targetPath)
+{
+    checkAndMkpath(targetPath);
+    QDir sourceDir(sourcePath);
+    QDir targetDir(targetPath);
+    QStringList desktopFiles = sourceDir.entryList(QStringList() << "*.desktop", QDir::Files);
+    for (const auto &file : std::as_const(desktopFiles)) {
+        QString sourceFile = sourceDir.filePath(file);
+        QString targetFile = targetDir.filePath(file);
+        if (QFile::exists(targetFile))
+            continue;
+
+        if (!QFile::copy(sourceFile, targetFile))
+            fmWarning() << "Failed to copy file:" << sourceFile << "to" << targetFile;
+    }
+}
+
+void ExtensionMonitor::onFileAdded(const QUrl &url)
+{
+    QString sourceFile = url.toLocalFile();
+    // Only handle .desktop files
+    if (!sourceFile.endsWith(".desktop"))
+        return;
+
+    QFileInfo fileInfo(sourceFile);
+    QString targetPath = extensionMap.value(fileInfo.absolutePath());
+    checkAndMkpath(targetPath);
+    QString targetFile = QDir(targetPath).filePath(fileInfo.fileName());
+    if (!QFile::copy(sourceFile, targetFile))
+        fmWarning() << "Failed to copy file:" << sourceFile << "to" << targetFile;
+}
+
+void ExtensionMonitor::onFileDeleted(const QUrl &url)
+{
+    QString sourceFile = url.toLocalFile();
+    // Only handle .desktop files
+    if (!sourceFile.endsWith(".desktop"))
+        return;
+
+    QFileInfo fileInfo(sourceFile);
+    QString targetPath = extensionMap.value(fileInfo.absolutePath());
+    QString targetFile = QDir(targetPath).filePath(fileInfo.fileName());
+    if (!QFile::exists(targetFile))
+        return;
+
+    if (!QFile::remove(targetFile))
+        fmWarning() << "Failed to remove file:" <<  targetFile;
+}

--- a/src/plugins/common/dfmplugin-menu/oemmenuscene/extensionmonitor.h
+++ b/src/plugins/common/dfmplugin-menu/oemmenuscene/extensionmonitor.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef EXTENSIONMONITOR_H
+#define EXTENSIONMONITOR_H
+
+#include "dfmplugin_menu_global.h"
+
+#include <QObject>
+#include <QMap>
+
+namespace dfmplugin_menu {
+
+class ExtensionMonitor : public QObject
+{
+    Q_OBJECT
+public:
+    static ExtensionMonitor *instance();
+    void start();
+
+private:
+    explicit ExtensionMonitor(QObject *parent = nullptr);
+    void setupFileWatchers();
+    void checkAndMkpath(const QString &path);
+    void copyInitialFiles();
+    void processExtensionDirectory(const QString &sourcePath, const QString &targetPath);
+
+private Q_SLOTS:
+    void onFileAdded(const QUrl &url);
+    void onFileDeleted(const QUrl &url);
+
+private:
+    QMap<QString, QString> extensionMap;
+};
+}
+
+#endif   // EXTENSIONMONITOR_H


### PR DESCRIPTION
- Introduced the ExtensionMonitor class to monitor and manage OEM menu extensions in the file manager.
- Implemented functionality to copy initial .desktop files from a source directory to a target directory.
- Added file watcher capabilities to handle the addition and deletion of .desktop files dynamically.
- Ensured proper directory creation and file management for a seamless user experience.

Log: This commit enhances the file manager's support for OEM menu extensions, improving the management and responsiveness of extension files.

## Summary by Sourcery

Implement ExtensionMonitor to manage OEM menu extensions dynamically in the file manager, enabling automatic copying and synchronization of .desktop files between system and user directories.

New Features:
- Introduced ExtensionMonitor class to handle OEM menu extensions for file manager applications
- Added dynamic file watching and synchronization for .desktop files between system and user directories

Enhancements:
- Improved file extension management with automatic directory creation and file copying
- Enhanced file watcher capabilities to handle .desktop file additions and deletions