### PR TITLE
fix: validate URL in SideBarManager context menu

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarmanager.cpp
@@ -42,6 +42,9 @@ void SideBarManager::runContextMenu(SideBarItem *item, quint64 windowId, const Q
         return;
 
     auto url = item->url();
+    if (!url.isValid())
+        return;
+
     auto info = item->itemInfo();
     if (info.contextMenuCb) {
         info.contextMenuCb(windowId, url, globalPos);


### PR DESCRIPTION
- Added a check to ensure the URL is valid before proceeding with the context menu actions in the SideBarManager.
- This prevents potential errors when handling invalid URLs, enhancing the robustness of the context menu functionality.

Log: Improve error handling in SideBarManager for better user experience.
Bug: https://pms.uniontech.com/bug-view-313887.html

## Summary by Sourcery

Bug Fixes:
- Prevent potential errors by checking URL validity before running context menu actions in SideBarManager