### PR TITLE
refactor: streamline search settings configuration by removing obsolete index options

### DIFF
--- a/src/dfm-base/qrc/configure/global-setting-template-fedora.js
+++ b/src/dfm-base/qrc/configure/global-setting-template-fedora.js
@@ -161,18 +161,6 @@
                   "name": "Index",
                   "options": [
                     {
-                            "key": "index_internal",
-                            "text": "Auto index internal disk",
-                            "type": "checkbox",
-                            "default": true
-                    },
-                    {
-                            "key": "index_external",
-                            "text": "Index external storage device after connected to computer",
-                            "type": "checkbox",
-                            "default": false
-                    },
-                    {
                             "key": "index_search",
                             "text": "Full-Text search",
                             "type": "checkbox",

--- a/src/dfm-base/qrc/configure/global-setting-template-pro.js
+++ b/src/dfm-base/qrc/configure/global-setting-template-pro.js
@@ -161,18 +161,6 @@
                   "name": "Index",
                   "options": [
                     {
-                            "key": "index_internal",
-                            "text": "Auto index internal disk",
-                            "type": "checkbox",
-                            "default": true
-                    },
-                    {
-                            "key": "index_external",
-                            "text": "Index external storage device after connected to computer",
-                            "type": "checkbox",
-                            "default": false
-                    },
-                    {
                             "key": "index_search",
                             "text": "Full-Text search",
                             "type": "checkbox",

--- a/src/dfm-base/qrc/configure/global-setting-template.js
+++ b/src/dfm-base/qrc/configure/global-setting-template.js
@@ -167,18 +167,6 @@
                   "name": "Index",
                   "options": [
                     {
-                            "key": "index_internal",
-                            "text": "Auto index internal disk",
-                            "type": "checkbox",
-                            "default": true
-                    },
-                    {
-                            "key": "index_external",
-                            "text": "Index external storage device after connected to computer",
-                            "type": "checkbox",
-                            "default": false
-                    },
-                    {
                             "key": "index_search",
                             "text": "Full-Text search",
                             "type": "checkbox",

--- a/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
+++ b/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
@@ -39,9 +39,7 @@ inline constexpr char kCurmbDisplayText[] {"CrumbData_Key_DisplayText"};
 
 namespace SearchSettings {
 inline constexpr char kGroupSearch[] { SEARCH_SETTING_GROUP };
-inline constexpr char kIndexInternal[] { SEARCH_SETTING_GROUP ".00_index_internal" };
-inline constexpr char kIndexExternal[] { SEARCH_SETTING_GROUP ".01_index_external" };
-inline constexpr char kFulltextSearch[] { SEARCH_SETTING_GROUP ".02_fulltext_search" };
+inline constexpr char kFulltextSearch[] { SEARCH_SETTING_GROUP ".00_fulltext_search" };
 }
 
 namespace DConfig {

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -132,31 +132,6 @@ void Search::regSearchSettingConfig()
         fmWarning() << "cannot regist dconfig of search plugin:" << err;
 
     SettingJsonGenerator::instance()->addGroup(SearchSettings::kGroupSearch, tr("Search"));
-    if (SearchHelper::anythingInterface().isValid()) {
-        SettingJsonGenerator::instance()->addCheckBoxConfig(SearchSettings::kIndexInternal,
-                                                            tr("Auto index internal disk"),
-                                                            true);
-        SettingBackend::instance()->addSettingAccessor(
-                SearchSettings::kIndexInternal,
-                []() {
-                    return SearchHelper::anythingInterface().property("autoIndexInternal");
-                },
-                [](const QVariant &val) {
-                    SearchHelper::anythingInterface().setProperty("autoIndexInternal", val);
-                });
-
-        SettingJsonGenerator::instance()->addCheckBoxConfig(SearchSettings::kIndexExternal,
-                                                            tr("Index external storage device after connected to computer"),
-                                                            false);
-        SettingBackend::instance()->addSettingAccessor(
-                SearchSettings::kIndexExternal,
-                []() {
-                    return SearchHelper::anythingInterface().property("autoIndexExternal");
-                },
-                [](const QVariant &val) {
-                    SearchHelper::anythingInterface().setProperty("autoIndexExternal", val);
-                });
-    }
 
     QString textIndexKey { SearchSettings::kFulltextSearch };
     DialogManager::instance()->registerSettingWidget("checkBoxWidthTextIndex", &SearchHelper::createCheckBoxWidthTextIndex);


### PR DESCRIPTION
- Removed internal and external indexing options from the search settings configuration.
- Updated the fulltext search setting to use a new index key for better organization.
- This change simplifies the search settings, focusing on essential configurations for improved clarity and maintainability.

Log: This commit refines the search settings configuration by eliminating outdated options, enhancing the overall structure and usability of the search functionality.
Bug: https://pms.uniontech.com/bug-view-313489.html

## Summary by Sourcery

Simplify search settings configuration by removing obsolete indexing options and reorganizing the configuration structure

Enhancements:
- Streamline search settings by removing internal and external indexing configuration options

Chores:
- Reorganize search settings index keys for improved clarity