### PR TITLE
fix: Update crypttab handling to merge configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ dde-file-manager-lib/test_shutil/property/oneProperty.pro
 *.tar.gz
 *.log
 *.substvars
+
+# clangd cache files
+.cache/clangd/

--- a/src/services/accesscontrol/plugin.cpp
+++ b/src/services/accesscontrol/plugin.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "accesscontroldbus.h"
+#include <QDBusInterface>
+#include <QtConcurrent>
 
 static AccessControlDBus *accessControlServer = nullptr;
 
@@ -10,6 +12,19 @@ extern "C" int DSMRegister(const char *name, void *data)
 {
     (void)data;
     accessControlServer = new AccessControlDBus(name);
+
+    // deepin-service-manager 无法在启动时将加密服务拉起，即便加密服务设置了常驻
+    // 但加密服务需要在启动时被拉起来，以便能够合并/更新 crypttab 文件
+    // 在此处拉起有点脏但暂时没有更好的方法达到目的
+    auto r = QtConcurrent::run([] {
+        QDBusInterface iface("org.deepin.Filemanager.DiskEncrypt",
+                             "/org/deepin/Filemanager/DiskEncrypt",
+                             "org.deepin.Filemanager.DiskEncrypt",
+                             QDBusConnection::systemBus());
+        iface.call("IsTaskEmpty");
+    });
+    Q_UNUSED(r);
+
     return 0;
 }
 

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -201,7 +201,7 @@ void DiskEncryptSetupPrivate::initialize()
     QtConcurrent::run([] {
         filesystem_helper::remountBoot();
         common_helper::createDFMDesktopEntry();
-        crypttab_helper::updateCryptTab();
+        crypttab_helper::mergeCryptTab();
     });
     job_file_helper::checkJobs();
     resumeEncryption();

--- a/src/services/diskencrypt/dbus/diskencryptsetup.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.h
@@ -10,6 +10,8 @@
 
 #include <qdbusservice.h>
 
+// see https://github.com/linuxdeepin/deepin-service-manager/blob/master/develop-guide.md for more information
+
 class DiskEncryptSetupPrivate;
 class DiskEncryptSetup : public QDBusService, public QDBusContext
 {

--- a/src/services/diskencrypt/helpers/crypttabhelper.h
+++ b/src/services/diskencrypt/helpers/crypttabhelper.h
@@ -16,15 +16,21 @@ struct CryptItem
     QString source;
     QString keyFile;
     QStringList options;
+
+    bool operator==(const CryptItem &other) const
+    {
+        return target == other.target && source == other.source && keyFile == other.keyFile && options == other.options;
+    }
 };
 
-QList<CryptItem> cryptItems();
-void saveCryptItems(const QList<CryptItem> &items);
+QList<CryptItem> cryptItems(const QString &crypttabFile = QString());
+void saveCryptItems(const QList<CryptItem> &items, bool doUpdateInitramfs = true);
 
 bool addCryptOption(const QString &activeName, const QString &opt);
 bool removeCryptItem(const QString &activeName);
 bool insertCryptItem(const CryptItem &item);
 bool updateCryptTab();
+bool mergeCryptTab();
 
 void updateInitramfs();
 }   // namespace crypttab_helper


### PR DESCRIPTION
- Introduced a new function `mergeCryptTab` to combine current and backup crypttab configurations, avoiding duplicates.
- Enhanced `cryptItems` function to accept a file path for flexibility.
- Updated `saveCryptItems` to conditionally call `updateInitramfs`.

Log: Improve crypttab management for better configuration handling.

Bug: https://pms.uniontech.com/bug-view-314847.html

## Summary by Sourcery

Introduce a mechanism to merge `/etc/crypttab` with a backup configuration (`/boot/usec-crypt/config/crypttab`) during initialization, ensuring unique entries based on target and content.

Bug Fixes:
- Prevent potential loss or duplication of crypttab entries by merging configurations instead of overwriting (fixes https://pms.uniontech.com/bug-view-314847.html).

Enhancements:
- Refactor `cryptItems` to read from a specified file path.
- Modify `saveCryptItems` to conditionally trigger an initramfs update.