### PR TITLE
feat: Migrate to pcre2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Build-Depends:
  libsecret-1-dev,
  libpoppler-cpp-dev,
  libcryptsetup-dev,
- libpcre3-dev,
+ libpcre2-dev,
  libdde-shell-dev (>= 0.0.10),
  deepin-desktop-base | deepin-desktop-server | deepin-desktop-device,
  qt6-base-dev,

--- a/src/dfm-base/dfm-base.cmake
+++ b/src/dfm-base/dfm-base.cmake
@@ -16,6 +16,7 @@ set(XCB_DEFINITIONS ${PC_XCB_CFLAGS_OTHER})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(XCB DEFAULT_MSG XCB_LIBRARIES XCB_INCLUDE_DIRS)
 
+pkg_search_module(X11 REQUIRED x11 IMPORTED_TARGET)
 if(${QT_VERSION_MAJOR} EQUAL "6")
     qt_add_resources(QRC_RESOURCES ${QRC_FILES})
     set(DFM_EXTRA_LIBRARIES "")
@@ -24,7 +25,6 @@ else()
     find_package(KF5Codecs REQUIRED)
     find_package(Qt5 COMPONENTS X11Extras REQUIRED)
     pkg_search_module(gsettings REQUIRED gsettings-qt IMPORTED_TARGET)
-    pkg_search_module(X11 REQUIRED x11 IMPORTED_TARGET)
     set(DFM_EXTRA_LIBRARIES
         Qt${QT_VERSION_MAJOR}::X11Extras
         PkgConfig::gsettings
@@ -105,6 +105,7 @@ target_link_libraries(${BIN_NAME}
         dfm${DTK_VERSION_MAJOR}-burn
         PkgConfig::mount
         PkgConfig::gio
+        PkgConfig::X11
         poppler-cpp
         ${XCB_LIBRARIES}
         xcb-xfixes

--- a/src/plugins/desktop/ddplugin-core/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-core/CMakeLists.txt
@@ -51,6 +51,7 @@ set(CORE_FILES
 set(BIN_NAME dd-core-plugin)
 
 find_package(Qt6 COMPONENTS Core Widgets Gui REQUIRED)
+find_package(DDEShell REQUIRED)
 
 add_library(${BIN_NAME}
     SHARED
@@ -72,6 +73,7 @@ target_link_libraries(${BIN_NAME}
     Qt6::Core
     Qt6::Widgets
     Qt6::Gui
+    Dde::Shell
 )
 
 install(TARGETS ${BIN_NAME}

--- a/src/plugins/filemanager/dfmplugin-search/CMakeLists.txt
+++ b/src/plugins/filemanager/dfmplugin-search/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
 pkg_check_modules(Docparser REQUIRED IMPORTED_TARGET docparser)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
-pkg_check_modules(PCRE REQUIRED libpcre)
+pkg_check_modules(PCRE REQUIRED libpcre2-8)
 
 # use TextIndex interface
 set(DBUS_INTERFACE_FILE "${CMAKE_SOURCE_DIR}/assets/dbus/org.deepin.Filemanager.TextIndex.xml")

--- a/src/services/textindex/CMakeLists.txt
+++ b/src/services/textindex/CMakeLists.txt
@@ -33,7 +33,7 @@ qt6_add_dbus_adaptor(SRC_FILES ${TextIndex_XML}
 pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
 pkg_check_modules(Docparser REQUIRED IMPORTED_TARGET docparser)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
-pkg_check_modules(PCRE REQUIRED libpcre)
+pkg_check_modules(PCRE REQUIRED libpcre2-8)
 
 add_library(${PROJECT_NAME}
     SHARED

--- a/tests/plugins/filemanager/dfmplugin-search/CMakeLists.txt
+++ b/tests/plugins/filemanager/dfmplugin-search/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Boost REQUIRED
 pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
 pkg_check_modules(Docparser REQUIRED IMPORTED_TARGET docparser)
 pkg_check_modules(GLIB REQUIRED glib-2.0)
-pkg_check_modules(PCRE REQUIRED libpcre)
+pkg_check_modules(PCRE REQUIRED libpcre2-8)
 
 # UT文件
 file(GLOB_RECURSE UT_CXX_FILE


### PR DESCRIPTION
Log: Many distributions have dropped pcre1 and suggest that developers migrate pcre1 to pcre2

## Summary by Sourcery

Migrate the project from PCRE1 to PCRE2 library for regular expression handling

New Features:
- Upgrade to PCRE2 library to support modern regex processing

Enhancements:
- Update regex compilation and matching functions to PCRE2 API
- Modify CMake configuration to use libpcre2-8 instead of libpcre

Chores:
- Update build dependencies to use PCRE2