### PR TITLE
fix: Enhance file handling with network checks

### DIFF
--- a/src/dfm-base/mimetype/dmimedatabase.cpp
+++ b/src/dfm-base/mimetype/dmimedatabase.cpp
@@ -5,6 +5,7 @@
 #include "dmimedatabase.h"
 
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/networkutils.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/device/deviceutils.h>
 #include <dfm-base/utils/protocolutils.h>
@@ -100,6 +101,14 @@ QMimeType DMimeDatabase::mimeTypeForFile(const QString &fileName, QMimeDatabase:
     if (!inod.isEmpty() && inodMimetypeCache.contains(inod)) {
         return inodMimetypeCache.value(inod);
     }
+
+    QUrl url = QUrl::fromLocalFile(fileName);
+    if (!ProtocolUtils::isLocalFile(url) && NetworkUtils::instance()->checkFtpOrSmbBusy(url))
+        return QMimeType();
+    auto link = FileUtils::symlinkTarget(url);
+    if (!link.isEmpty() && NetworkUtils::instance()->checkFtpOrSmbBusy(QUrl::fromLocalFile(link)))
+        return QMimeType();
+
     return mimeTypeForFile(QFileInfo(fileName), mode, inod, isGvfs);
 }
 

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/utils/finallyutil.h>
 #include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/utils/networkutils.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/application/application.h>
@@ -353,6 +354,13 @@ bool FileUtils::isCdRomDevice(const QUrl &url)
 
 bool FileUtils::trashIsEmpty()
 {
+    const auto &cifsHost = NetworkUtils::cifsMountHostInfo();
+    if (!cifsHost.isEmpty()) {
+        const auto &mountPoint = cifsHost.constKeyValueBegin()->first;
+        if (NetworkUtils::instance()->checkFtpOrSmbBusy(QUrl::fromLocalFile(mountPoint)))
+            return true;
+    }
+
     // not use cache, because some times info unreliable, such as watcher inited temporality
     auto info = InfoFactory::create<FileInfo>(trashRootUrl(), Global::CreateFileInfoType::kCreateFileInfoSync);
     if (info) {

--- a/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
@@ -11,6 +11,7 @@
 
 #include <QObject>
 #include <QSharedPointer>
+#include <QTimer>
 
 namespace dfmbase {
 class AbstractFileWatcher;
@@ -33,10 +34,12 @@ private slots:
 private:
     explicit TrashCoreEventSender(QObject *parent = nullptr);
     void initTrashWatcher();
+    bool checkAndStartWatcher();
 
 private:
     QSharedPointer<DFMBASE_NAMESPACE::AbstractFileWatcher> trashFileWatcher = nullptr;
     bool isEmpty { false };
+    QTimer timer;
 };
 
 }


### PR DESCRIPTION
- Added network utility checks in DMimeDatabase to handle FTP and SMB file access.
- Updated FileUtils to verify CIFS mount status before checking if the trash is empty.
- Improved TrashCoreEventSender to manage file watcher initialization based on network availability.

Log: Strengthen file operations by integrating network status checks for better reliability.
Bug: https://pms.uniontech.com/bug-view-303915.html
Bug: https://pms.uniontech.com/bug-view-299425.html

## Summary by Sourcery

Improve file handling reliability by adding network-aware checks for FTP, SMB, and CIFS file operations

New Features:
- Integrate network utility checks in file handling components

Bug Fixes:
- Prevent file operations on busy network shares
- Handle network-related file access edge cases

Enhancements:
- Add network availability checks before file operations
- Implement dynamic file watcher initialization based on network status