### PR TITLE
fix: [UI] Task widget show error in hower.

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -575,7 +575,6 @@ QWidget *TaskWidget::createConflictWidget()
 
     QHBoxLayout *hLayout = new QHBoxLayout;
     hLayout->addLayout(conflictMainLayout);
-    hLayout->addStretch();
     conflictWidget->setLayout(hLayout);
     conflictWidget->setMaximumWidth(565);
 


### PR DESCRIPTION
-- Remove the stretch.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-304085.html

## Summary by Sourcery

Bug Fixes:
- Fixed layout issue in task widget conflict dialog