### PR TITLE
chore: bump version to 6.5.47.4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.47.4) unstable; urgency=medium
+
+  * enable full-text default
+
+ -- Zhang Shedng <zhangsheng@uniontech.com>  Wed, 07 May 2025 18:22:26 +0800
+
 dde-file-manager (6.5.47.3) unstable; urgency=medium
 
   * enhance real-time search


### PR DESCRIPTION
as title

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog with new version number