### PR TITLE
chore: bump version to 6.5.48.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.48.1) unstable; urgency=medium
+
+  * test for search
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 08 May 2025 09:48:07 +0800
+
 dde-file-manager (6.5.47.4) unstable; urgency=medium
 
   * enable full-text default


### PR DESCRIPTION
as title

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog with new version number