### PR TITLE
fix: clear visibleTreeChildren in FileSortWorker on data reset

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -241,6 +241,8 @@ void FileSortWorker::handleTraversalFinish(const QString &key, bool noDataProduc
 
     // If no data was produced during traversal, clear the existing data
     if (noDataProduced) {
+        visibleTreeChildren.clear();
+
         QWriteLocker childLock(&childrenDataLocker);
         childrenDataMap.clear();
         
@@ -783,6 +785,7 @@ bool FileSortWorker::handleAddChildren(const QString &key,
 
     // Clear old data when receiving first batch of items in kPreserve mode
     if (isFirstBatch) {
+        visibleTreeChildren.clear();
         // Clear the existing children data when we're about to insert the first batch
         QWriteLocker lk(&childrenDataLocker);
         childrenDataMap.clear();


### PR DESCRIPTION
- Added logic to clear `visibleTreeChildren` in `handleTraversalFinish` and `handleAddChildren` methods when no data is produced or when receiving the first batch of items, ensuring a clean state for subsequent operations.

Log: This commit addresses potential data inconsistencies by ensuring that `visibleTreeChildren` is cleared appropriately during data resets in the file manager's sorting worker.

## Summary by Sourcery

Improve data management in FileSortWorker by clearing visibleTreeChildren during data reset scenarios

Bug Fixes:
- Ensure clean state of visibleTreeChildren when no data is produced during file traversal
- Clear visibleTreeChildren when receiving the first batch of items to prevent data inconsistencies