### PR TITLE
feat: add first batch handling in RootInfo and FileViewModel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.48.3) unstable; urgency=medium
+
+  * test for search
+  * 
+
+ -- Liuyangming <liuyangming@uniontech.com>  Thu, 08 May 2025 14:01:51 +0800
+
 dde-file-manager (6.5.48.2) unstable; urgency=medium
 
   * test for search

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -838,6 +838,7 @@ void FileViewModel::executeLoad()
         
         // 获取目标URL的RootInfo，准备数据获取
         RootInfo *newRoot = FileDataManager::instance()->fetchRoot(dirRootUrl);
+        newRoot->setFirstBatch(true);
         
         // 连接信号，使当前filterSortWorker监听新RootInfo的数据
         connectRootAndFilterSortWork(newRoot, true);

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -116,7 +116,6 @@ void RootInfo::startWork(const QString &key, const bool getCache)
         return handleGetSourceData(key);
 
     traversaling = true;
-    isFirstBatch = true;
     {
         QWriteLocker lk(&childrenLock);
         childrenUrlList.clear();
@@ -174,6 +173,11 @@ int RootInfo::clearTraversalThread(const QString &key, const bool isRefresh)
 
     this->isRefresh = isRefresh;
     return traversalThreads.count();
+}
+
+void RootInfo::setFirstBatch(bool first)
+{
+    isFirstBatch = first;
 }
 
 void RootInfo::reset()

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -47,6 +47,7 @@ public:
                               DFMGLOBAL_NAMESPACE::ItemRoles role, Qt::SortOrder order, bool isMixFileAndFolder);
     void startWork(const QString &key, const bool getCache = false);
     int clearTraversalThread(const QString &key, const bool isRefresh);
+    void setFirstBatch(bool first);
 
     void reset();
 
@@ -138,7 +139,7 @@ private:
     QMap<QString, QSharedPointer<DirIteratorThread>> traversalThreads;
     std::atomic_bool traversalFinish { false };
     std::atomic_bool traversaling { false };
-    std::atomic_bool isFirstBatch { true };
+    std::atomic_bool isFirstBatch { false };
 
     QReadWriteLock childrenLock;
     QList<QUrl> childrenUrlList {};


### PR DESCRIPTION
- Introduced a new method `setFirstBatch` in `RootInfo` to manage the first batch state.
- Updated `FileViewModel` to set the first batch flag when loading a new root, ensuring proper data handling during initial loads.

Log: This commit enhances the file manager's data loading process by implementing first batch handling, improving state management during data retrieval.

## Summary by Sourcery

Implement first batch handling mechanism in file manager's data loading process

New Features:
- Added `setFirstBatch` method to RootInfo to manage first batch state

Enhancements:
- Updated file view model to explicitly set first batch flag when loading a new root
- Modified initial state of first batch flag in RootInfo