### PR TITLE
refactor: improve string handling in SmbBrowser

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
@@ -62,13 +62,13 @@ bool SmbBrowser::start()
     registScheme(Global::Scheme::kDavs);
     registScheme(Global::Scheme::kNfs);
 
-    dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterMenuScene", Global::Scheme::kSmb, SmbBrowserMenuCreator::name());
-    dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterMenuScene", Global::Scheme::kNetwork, SmbBrowserMenuCreator::name());
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterMenuScene", QString(Global::Scheme::kSmb), SmbBrowserMenuCreator::name());
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterMenuScene", QString(Global::Scheme::kNetwork), SmbBrowserMenuCreator::name());
 
     QVariantMap property;
     property[ViewCustomKeys::kSupportTreeMode] = false;
-    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetCustomViewProperty", Global::Scheme::kNetwork, property);
-    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetCustomViewProperty", Global::Scheme::kSmb, property);
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetCustomViewProperty", QString(Global::Scheme::kNetwork), property);
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetCustomViewProperty", QString(Global::Scheme::kSmb), property);
 
     ProtocolDeviceDisplayManager::instance();
     registerNetworkAccessPrehandler();


### PR DESCRIPTION
- Updated the SmbBrowser plugin to use QString for scheme parameters in menu registration and view property settings, enhancing type consistency and clarity in the code.
- This change ensures better handling of string types across the plugin's interactions with the workspace.

Log: This commit refines the SmbBrowser implementation by standardizing the use of QString for scheme-related operations, improving code quality and maintainability.

## Summary by Sourcery

Enhancements:
- Updated method calls to convert scheme constants to QString for better type handling