### PR TITLE
fix: Prevent infinite loop in canDrop method of FileInfoPrivate

### DIFF
--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -648,8 +648,14 @@ bool DFMBASE_NAMESPACE::FileInfoPrivate::canDrop() const
 
     FileInfoPointer info = nullptr;
     QString linkTargetPath = q->pathOf(PathInfoType::kSymLinkTarget);
-
+    QSet<QString> targetPaths {};
     do {
+        if (targetPaths.contains(linkTargetPath)) {
+            return false;
+        } else {
+            targetPaths.insert(linkTargetPath);
+        }
+
         const QUrl &targetUrl = QUrl::fromLocalFile(linkTargetPath);
 
         if (targetUrl == q->fileUrl()) {


### PR DESCRIPTION
- Added a QSet to track visited symbolic link targets in the canDrop method.
- Implemented a check to avoid revisiting the same link target, preventing potential infinite loops.

Log: Enhance robustness of file drop validation by managing symbolic link targets.

## Summary by Sourcery

Bug Fixes:
- Added a mechanism to detect and prevent revisiting the same symbolic link target in the canDrop method