### PR TITLE
refactor: streamline text layout handling in ElideTextLayout

### DIFF
--- a/src/dfm-base/utils/elidetextlayout.cpp
+++ b/src/dfm-base/utils/elidetextlayout.cpp
@@ -218,7 +218,7 @@ QList<QPair<int, int>> ElideTextLayout::calculateElideHighlightMatches(
     } else if (elideMode == Qt::ElideLeft && elidePos > 0) {
         // 左侧省略：检查每个原始匹配项是否在省略处被截断
         int originalLineStart = lineStartPos;
-        int visibleStartInOriginal = originalLineStart + elideText.length() - elidePos;
+        int visibleStartInOriginal = originalLineStart + elidePos + 1;
         
         for (const auto &match : originalMatches) {
             int matchStart = match.first;
@@ -538,31 +538,6 @@ void ElideTextLayout::drawTextWithHighlight(QPainter *painter, const QTextLine &
         
         painter->restore();
     }
-}
-
-void ElideTextLayout::drawTextWithHighlight(QPainter *painter, const QTextLine &line, const QString &lineText, const QRectF &rect)
-{
-    // 创建一个临时的匹配列表，仅包含当前行内的匹配
-    QList<QPair<int, int>> lineMatches;
-    int lineStartPos = line.textStart();
-    
-    // 查找当前行所有关键词的所有匹配位置
-    for (const QString &keyword : highlightKeywords) {
-        if (keyword.isEmpty())
-            continue;
-
-        int startPos = 0;
-        while (startPos < lineText.length()) {
-            int keywordPos = lineText.indexOf(keyword, startPos, Qt::CaseInsensitive);
-            if (keywordPos == -1)
-                break;
-
-            lineMatches.append(qMakePair(lineStartPos + keywordPos, keyword.length()));
-            startPos = keywordPos + 1;
-        }
-    }
-    
-    drawTextWithHighlight(painter, line, lineText, rect, lineStartPos, lineMatches);
 }
 
 void ElideTextLayout::initLayoutOption(QTextLayout *lay)

--- a/src/dfm-base/utils/elidetextlayout.h
+++ b/src/dfm-base/utils/elidetextlayout.h
@@ -64,7 +64,6 @@ public:
 
 protected:
     QRectF drawLineBackground(QPainter *painter, const QRectF &curLineRect, QRectF lastLineRect, const QBrush &brush) const;
-    void drawTextWithHighlight(QPainter *painter, const QTextLine &line, const QString &lineText, const QRectF &rect);
     void drawTextWithHighlight(QPainter *painter, const QTextLine &line, const QString &lineText, 
                               const QRectF &rect, int lineStartPos, const QList<QPair<int, int>> &allMatches);
     virtual void initLayoutOption(QTextLayout *lay);

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventcaller.cpp
@@ -101,3 +101,8 @@ void WorkspaceEventCaller::sendCloseTab(const QUrl &url)
 {
     dpfSlotChannel->push("dfmplugin_titlebar", "slot_Tab_Close", url);
 }
+
+void WorkspaceEventCaller::sendViewModeChanged(quint64 windowId, Global::ViewMode mode)
+{
+    dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::kSwitchViewMode, windowId, static_cast<int>(mode));
+}

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventcaller.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventcaller.h
@@ -43,6 +43,8 @@ public:
 
     static bool sendCheckTabAddable(quint64 windowId);
     static void sendCloseTab(const QUrl &url);
+
+    static void sendViewModeChanged(quint64 windowId, DFMGLOBAL_NAMESPACE::ViewMode mode);
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
@@ -8,6 +8,7 @@
 #include "views/fileview.h"
 #include "models/fileviewmodel.h"
 #include "utils/workspacehelper.h"
+#include "events/workspaceeventcaller.h"
 
 #include <dfm-base/dfm_menu_defines.h>
 #include <dfm-base/dfm_global_defines.h>
@@ -101,19 +102,19 @@ bool SortAndDisplayMenuScene::triggered(QAction *action)
         {
             // display as icon
             if (actionId == ActionID::kDisplayIcon) {
-                dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::kSwitchViewMode, d->windowId, int(Global::ViewMode::kIconMode));
+                WorkspaceEventCaller::sendViewModeChanged(d->windowId, DFMGLOBAL_NAMESPACE::ViewMode::kIconMode);
                 return true;
             }
 
             // display as list
             if (actionId == ActionID::kDisplayList) {
-                dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::kSwitchViewMode, d->windowId, int(Global::ViewMode::kListMode));
+                WorkspaceEventCaller::sendViewModeChanged(d->windowId, DFMGLOBAL_NAMESPACE::ViewMode::kListMode);
                 return true;
             }
 
             // display as tree
             if (actionId == ActionID::kDisplayTree) {
-                dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::kSwitchViewMode, d->windowId, int(Global::ViewMode::kTreeMode));
+                WorkspaceEventCaller::sendViewModeChanged(d->windowId, DFMGLOBAL_NAMESPACE::ViewMode::kTreeMode);
                 return true;
             }
         }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
@@ -74,8 +74,9 @@ void ExpandedItem::paintEvent(QPaintEvent *)
     if (!info)
         return;
 
+    QStringList textList {};
     WorkspaceEventSequence::instance()->doIconItemLayoutText(info, layout.data());
-    const QList<QRectF> lines = layout->layout(labelRect, option.textElideMode, &pa, option.palette.brush(QPalette::Normal, QPalette::Highlight));
+    const QList<QRectF> lines = layout->layout(labelRect, option.textElideMode, &pa, option.palette.brush(QPalette::Normal, QPalette::Highlight), &textList);
 
     textBounding = GlobalPrivate::boundingRect(lines).toRect();
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -553,6 +553,11 @@ void FileView::delayUpdateStatusBar()
 void FileView::viewModeChanged(quint64 windowId, int viewMode)
 {
     Global::ViewMode mode = static_cast<Global::ViewMode>(viewMode);
+    if (currentViewMode() == mode) {
+        qWarning() << "Current view mode equal to the new view mode that switched by global event. Don't need to do anything.";
+        return;
+    }
+
     if (mode == Global::ViewMode::kIconMode || mode == Global::ViewMode::kListMode || mode == Global::ViewMode::kTreeMode) {
         setViewMode(mode);
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -659,7 +659,8 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
         labelRect.setHeight(labelRect.height() > normalHeight ? normalHeight : labelRect.height());
     }
 
-    layout->layout(labelRect, opt.textElideMode, painter, background);
+    QStringList textList {};
+    layout->layout(labelRect, opt.textElideMode, painter, background, &textList);
 }
 
 QSize IconItemDelegate::iconSizeByIconSizeLevel() const

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -16,6 +16,7 @@
 #include "utils/fileviewmenuhelper.h"
 #include "utils/viewanimationhelper.h"
 #include "utils/fileviewhelper.h"
+#include "events/workspaceeventcaller.h"
 
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
@@ -250,6 +251,9 @@ void FileViewPrivate::loadViewMode(const QUrl &url)
 
     if (currentViewMode == Global::ViewMode::kTreeMode && !DConfigManager::instance()->value(kViewDConfName, kTreeViewEnable, true).toBool())
         currentViewMode = Global::ViewMode::kListMode;
+
+    auto winId = WorkspaceHelper::instance()->windowId(q);
+    WorkspaceEventCaller::sendViewModeChanged(winId, currentViewMode);
 }
 
 QVariant FileViewPrivate::fileViewStateValue(const QUrl &url, const QString &key, const QVariant &defalutValue)


### PR DESCRIPTION
- Adjusted the calculation of visible text start position in `calculateElideHighlightMatches` to improve accuracy in text elision.
- Removed the redundant `drawTextWithHighlight` method, consolidating functionality to enhance code clarity and maintainability.
- Updated related method signatures to accommodate changes in text layout processing.

Log: This commit refines the text layout handling in `ElideTextLayout`, improving the accuracy of text elision and simplifying the code structure.
Bug: https://pms.uniontech.com/bug-view-314849.html

## Summary by Sourcery

Refactor the text layout handling in ElideTextLayout to improve text elision accuracy and code clarity

Enhancements:
- Improved calculation of visible text start position in text elision
- Simplified text layout processing by removing redundant methods

Chores:
- Updated method signatures to streamline text layout processing