### PR TITLE
Develop/new search

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.TextIndex.xml
+++ b/assets/dbus/org.deepin.Filemanager.TextIndex.xml
@@ -22,11 +22,11 @@
     </method>
     <method name="CreateIndexTask">
       <arg type="b" direction="out"/>
-      <arg name="path" type="s" direction="in"/>
+      <arg name="paths" type="as" direction="in"/>
     </method>
     <method name="UpdateIndexTask">
       <arg type="b" direction="out"/>
-      <arg name="path" type="s" direction="in"/>
+      <arg name="paths" type="as" direction="in"/>
     </method>
     <method name="StopCurrentTask">
       <arg type="b" direction="out"/>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.49.2) unstable; urgency=medium
+
+  * test for search 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Mon, 12 May 2025 17:12:35 +0800
+
 dde-file-manager (6.5.49.1) unstable; urgency=medium
 
   * test for search

--- a/src/plugins/daemon/core/CMakeLists.txt
+++ b/src/plugins/daemon/core/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(Qt6 COMPONENTS
     REQUIRED)
 
 find_package(Dtk6 COMPONENTS Core REQUIRED)
+find_package(dfm6-search REQUIRED)
 
 # DBus: DeviceManager
 qt6_generate_dbus_interface(
@@ -61,6 +62,7 @@ target_link_libraries(${PROJECT_NAME}
     Qt6::DBus
     Qt6::Concurrent
     Dtk6::Core
+    dfm6-search
 )
 
 #install library file

--- a/src/plugins/daemon/core/textindexcontroller.cpp
+++ b/src/plugins/daemon/core/textindexcontroller.cpp
@@ -5,6 +5,8 @@
 
 #include "textindex_interface.h"
 
+#include <dfm-search/dsearch_global.h>
+
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 DFMBASE_USE_NAMESPACE
@@ -202,13 +204,12 @@ void TextIndexController::startIndexTask(bool isCreate)
     }
 
     QDBusPendingReply<bool> pendingTask;
-    // TODO (search): dconfig
     if (isCreate) {
         fmInfo() << "[TextIndex] Starting CREATE task for root directory";
-        pendingTask = interface->CreateIndexTask(QDir::homePath());
+        pendingTask = interface->CreateIndexTask(DFMSEARCH::Global::defaultIndexedDirectory());
     } else {
         fmInfo() << "[TextIndex] Starting UPDATE task for root directory";
-        pendingTask = interface->UpdateIndexTask(QDir::homePath());
+        pendingTask = interface->UpdateIndexTask(DFMSEARCH::Global::defaultIndexedDirectory());
     }
 
     pendingTask.waitForFinished();

--- a/src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp
@@ -4,6 +4,8 @@
 
 #include "searchmanager/searchmanager.h"
 
+#include <dfm-search/dsearch_global.h>
+
 #include <QVBoxLayout>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -177,11 +179,10 @@ CheckBoxWidthTextIndex::CheckBoxWidthTextIndex(QWidget *parent)
     connect(statusBar, &TextIndexStatusBar::resetIndex, this, [this]() {
         auto client = TextIndexClient::instance();
         bool exitsts = client->indexExists().has_value() && client->indexExists().value();
-        // TODO (search): dfm-search
         if (exitsts) {
-            client->startTask(TextIndexClient::TaskType::Update, QDir::homePath());
+            client->startTask(TextIndexClient::TaskType::Update, DFMSEARCH::Global::defaultIndexedDirectory());
         } else {
-            client->startTask(TextIndexClient::TaskType::Create, QDir::homePath());
+            client->startTask(TextIndexClient::TaskType::Create, DFMSEARCH::Global::defaultIndexedDirectory());
         }
         statusBar->setStatus(TextIndexStatusBar::Status::Indexing);
     });
@@ -252,8 +253,8 @@ void CheckBoxWidthTextIndex::initStatusBar()
 
 bool CheckBoxWidthTextIndex::shouldHandleIndexEvent(const QString &path, TextIndexClient::TaskType type) const
 {
-    // TODO (search): dfm-search
-    return checkBox->isChecked() && path == QDir::homePath() && type != TextIndexClient::TaskType::Remove;
+    bool isIndexedPath = DFMSEARCH::Global::defaultIndexedDirectory().contains(path);
+    return checkBox->isChecked() && isIndexedPath && type != TextIndexClient::TaskType::Remove;
 }
 
 }   // namespace dfmplugin_search

--- a/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.cpp
@@ -114,13 +114,6 @@ std::optional<bool> TextIndexClient::indexExists()
     return pendingExists.value();
 }
 
-void TextIndexClient::startTask(TaskType type, const QString &path)
-{
-    QStringList paths;
-    paths << path;
-    startTask(type, paths);
-}
-
 void TextIndexClient::startTask(TaskType type, const QStringList &paths)
 {
     if (!ensureInterface()) {
@@ -140,10 +133,10 @@ void TextIndexClient::startTask(TaskType type, const QStringList &paths)
     QDBusPendingReply<bool> pendingTask;
     switch (type) {
     case TaskType::Create:
-        pendingTask = interface->CreateIndexTask(paths.first());   // Create只支持单路径
+        pendingTask = interface->CreateIndexTask(paths);
         break;
     case TaskType::Update:
-        pendingTask = interface->UpdateIndexTask(paths.first());   // Update只支持单路径
+        pendingTask = interface->UpdateIndexTask(paths);
         break;
     default:
         fmWarning() << "Unknown task type:" << static_cast<int>(type);

--- a/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.h
@@ -36,7 +36,6 @@ public:
     static TextIndexClient *instance();
 
     // 异步方法，通过信号返回结果
-    void startTask(TaskType type, const QString &path);
     void startTask(TaskType type, const QStringList &paths);
 
     // 返回值：

--- a/src/services/textindex/fsmonitor/fseventcollector.h
+++ b/src/services/textindex/fsmonitor/fseventcollector.h
@@ -43,8 +43,8 @@ public:
 
     ~FSEventCollector() override;
 
-    // Initialize the collector with monitor root path
-    bool initialize(const QString &rootPath = QDir::homePath());
+    // Initialize the collector with monitor root paths
+    bool initialize(const QStringList &rootPaths);
 
     // Start collecting events
     bool start();

--- a/src/services/textindex/fsmonitor/fseventcollector_p.h
+++ b/src/services/textindex/fsmonitor/fseventcollector_p.h
@@ -20,7 +20,7 @@ public:
     ~FSEventCollectorPrivate();
 
     // Initialize the collector with monitor root path
-    bool init(const QString &rootPath);
+    bool init(const QStringList &rootPaths);
 
     // Start collecting events
     bool startCollecting();
@@ -94,8 +94,8 @@ public:
     // Collection interval in milliseconds (default: 180000ms = 3 minutes)
     int collectionIntervalMs { 180000 };
 
-    // Root path being monitored
-    QString rootPath;
+    // Root paths being monitored
+    QStringList rootPaths;
 
     // Maximum event count before auto-flush (default: 10000)
     int maxEvents { 10000 };

--- a/src/services/textindex/fsmonitor/fseventcontroller.cpp
+++ b/src/services/textindex/fsmonitor/fseventcontroller.cpp
@@ -91,7 +91,6 @@ void FSEventController::setEnabledNow(bool enabled)
 void FSEventController::startFSMonitoring()
 {
     if (!m_fsEventCollector) {
-        fmWarning() << "Cannot start FS monitoring: FSEventCollector not initialized";
         return;
     }
 
@@ -100,9 +99,14 @@ void FSEventController::startFSMonitoring()
         return;
     }
 
-    // Initialize with home directory (same as text index)
-    // TODO (search): dconfig
-    bool success = m_fsEventCollector->initialize(QDir::homePath());
+    // Initialize with default indexed directories
+    QStringList indexedDirs = DFMSEARCH::Global::defaultIndexedDirectory();
+    if (indexedDirs.isEmpty()) {
+        fmWarning() << "No default indexed directories found";
+        return;
+    }
+
+    bool success = m_fsEventCollector->initialize(indexedDirs);
     if (!success) {
         fmWarning() << "Failed to initialize FSEventCollector";
         return;
@@ -118,7 +122,7 @@ void FSEventController::startFSMonitoring()
         return;
     }
 
-    fmInfo() << "FS monitoring started successfully";
+    fmInfo() << "FS monitoring started successfully with" << indexedDirs.size() << "directories";
 }
 
 void FSEventController::stopFSMonitoring()

--- a/src/services/textindex/fsmonitor/fsmonitor.h
+++ b/src/services/textindex/fsmonitor/fsmonitor.h
@@ -42,8 +42,8 @@ public:
     // Singleton access
     static FSMonitor &instance();
 
-    // Initialize monitoring with root path (defaults to user's home directory)
-    bool initialize(const QString &rootPath = QDir::homePath());
+    // Initialize monitoring with root paths
+    bool initialize(const QStringList &rootPaths);
 
     // Start monitoring
     bool start();

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -26,8 +26,9 @@ public:
     FSMonitorPrivate(FSMonitor *qq);
     ~FSMonitorPrivate();
 
-    // Initializes the monitor with the root path
-    bool init(const QString &rootPath);
+    // Initialize the monitor with root paths
+    bool init(const QStringList &rootPaths);
+    bool init(const QString &rootPath);  // For backward compatibility
 
     // Start monitoring using DFileSystemWatcher
     bool startMonitoring();
@@ -96,7 +97,7 @@ public:
     QThread workerThread;
     FSMonitorWorker *worker { nullptr };
 
-    QString rootPath;
+    QStringList rootPaths;
     QSet<QString> watchedDirectories;
     QSet<QString> blacklistedPaths;
     bool active { false };

--- a/src/services/textindex/task/fileprovider.cpp
+++ b/src/services/textindex/task/fileprovider.cpp
@@ -39,8 +39,10 @@ void FileSystemProvider::traverse(TaskState &state, const FileHandler &handler)
         QString currentPath = dirQueue.dequeue();
 
         // 检查是否是系统目录或绑定目录
-        if (bindPathTable.contains(currentPath) || IndexTraverseUtils::shouldSkipDirectory(currentPath))
-            continue;
+        if (!IndexUtility::isDefaultIndexedDirectory(currentPath)) {
+            if (bindPathTable.contains(currentPath) || IndexTraverseUtils::shouldSkipDirectory(currentPath))
+                continue;
+        }
 
         // 检查路径长度和深度限制
         if (currentPath.size() > FILENAME_MAX - 1 || currentPath.count('/') > 20)

--- a/src/services/textindex/task/fileprovider.h
+++ b/src/services/textindex/task/fileprovider.h
@@ -28,6 +28,7 @@ public:
     // 遍历文件并处理
     virtual void traverse(TaskState &state, const FileHandler &handler) = 0;
     virtual qint64 totalCount() { return 0; }
+    virtual QString name() { return ""; }
 };
 
 // 文件系统遍历提供者
@@ -36,6 +37,7 @@ class FileSystemProvider : public FileProvider
 public:
     explicit FileSystemProvider(const QString &rootPath);
     void traverse(TaskState &state, const FileHandler &handler) override;
+    QString name() override { return "FileSystemProvider"; }
 
 private:
     QString m_rootPath;
@@ -48,6 +50,7 @@ public:
     explicit DirectFileListProvider(const DFMSEARCH::SearchResultList &files);
     void traverse(TaskState &state, const FileHandler &handler) override;
     qint64 totalCount() override;
+    QString name() override { return "DirectFileListProvider"; }
 
 private:
     DFMSEARCH::SearchResultList m_fileList;
@@ -59,6 +62,7 @@ class MixedPathListProvider : public FileProvider
 public:
     explicit MixedPathListProvider(const QStringList &pathList);
     void traverse(TaskState &state, const FileHandler &handler) override;
+    QString name() override { return "MixedPathListProvider"; }
 
 private:
     QStringList m_pathList;

--- a/src/services/textindex/task/taskhandler.h
+++ b/src/services/textindex/task/taskhandler.h
@@ -21,6 +21,7 @@ struct HandlerResult
 {
     bool success { false };
     bool interrupted { false };
+    bool useAnything { false };
 };
 
 using TaskHandler = std::function<HandlerResult(const QString &path, TaskState &state)>;

--- a/src/services/textindex/task/taskmanager.h
+++ b/src/services/textindex/task/taskmanager.h
@@ -19,6 +19,7 @@ struct TaskQueueItem
 {
     IndexTask::Type type;
     QString path;
+    QStringList pathList;   // 当传入多个路径时使用
     QStringList fileList;   // 仅在文件列表类型任务中使用
     bool silent { false };
 };
@@ -30,10 +31,9 @@ public:
     explicit TaskManager(QObject *parent = nullptr);
     ~TaskManager();
 
-    // 原有的基于路径的任务启动方法
+    bool startTask(IndexTask::Type type, const QStringList &pathList, bool silent = false);
     bool startTask(IndexTask::Type type, const QString &path, bool silent = false);
 
-    // 新增的基于文件列表的任务启动方法
     bool startFileListTask(IndexTask::Type type, const QStringList &fileList, bool silent = false);
 
     bool hasRunningTask() const;

--- a/src/services/textindex/textindexdbus.cpp
+++ b/src/services/textindex/textindexdbus.cpp
@@ -76,22 +76,17 @@ void TextIndexDBusPrivate::handleSlientStart()
             pathsToProcess = configuredDirs;   // Assuming configuredDirs is a QStringList or compatible
         }
 
-        for (const QString &path : std::as_const(pathsToProcess)) {
-            if (!canSilentlyRefreshIndex(path)) {
-                fmWarning() << "Unable to refresh the index because there is already a current task for: " << path;
-                continue;   // Skip to the next path
-            }
+        if (!canSilentlyRefreshIndex(pathsToProcess.first())) {
+            fmWarning() << "Unable to refresh the index because there is already a current task for: " << pathsToProcess.first();
+            return;
+        }
 
-            fmInfo() << "Start a task silently for: " << path;
-            // The decision to create or update is based on q->IndexDatabaseExists().
-            // This implies IndexDatabaseExists() is either a global check,
-            // or its state is relevant for any path being considered.
-            // This retains the original logic for choosing task type, now applied per path.
-            if (q->IndexDatabaseExists()) {   // update
-                taskManager->startTask(IndexTask::Type::Update, path, true);
-            } else {   // create
-                taskManager->startTask(IndexTask::Type::Create, path, true);
-            }
+        fmInfo() << "Start a task silently for: " << pathsToProcess;
+
+        if (q->IndexDatabaseExists()) {   // update
+            taskManager->startTask(IndexTask::Type::Update, pathsToProcess, true);
+        } else {   // create
+            taskManager->startTask(IndexTask::Type::Create, pathsToProcess, true);
         }
     });
 }
@@ -145,14 +140,14 @@ void TextIndexDBus::SetEnabled(bool enabled)
     d->fsEventController->setEnabled(enabled);
 }
 
-bool TextIndexDBus::CreateIndexTask(const QString &path)
+bool TextIndexDBus::CreateIndexTask(const QStringList &paths)
 {
-    return d->taskManager->startTask(IndexTask::Type::Create, path);
+    return d->taskManager->startTask(IndexTask::Type::Create, paths);
 }
 
-bool TextIndexDBus::UpdateIndexTask(const QString &path)
+bool TextIndexDBus::UpdateIndexTask(const QStringList &paths)
 {
-    return d->taskManager->startTask(IndexTask::Type::Update, path);
+    return d->taskManager->startTask(IndexTask::Type::Update, paths);
 }
 
 bool TextIndexDBus::StopCurrentTask()

--- a/src/services/textindex/textindexdbus.h
+++ b/src/services/textindex/textindexdbus.h
@@ -30,8 +30,8 @@ public Q_SLOTS:
     void Init();
     bool IsEnabled();
     void SetEnabled(bool enabled);
-    bool CreateIndexTask(const QString &path);
-    bool UpdateIndexTask(const QString &path);
+    bool CreateIndexTask(const QStringList &paths);
+    bool UpdateIndexTask(const QStringList &paths);
     bool StopCurrentTask();
     bool HasRunningTask();
     bool IndexDatabaseExists();


### PR DESCRIPTION
## Summary by Sourcery

Enable multi-path indexing across the entire TextIndex service by extending core task management, filesystem monitoring, D-Bus interfaces, and client integrations to handle lists of directories instead of single paths.

New Features:
- Support starting and queuing index tasks across multiple directories via TaskManager overloads that accept QStringList
- Extend D-Bus interface for CreateIndexTask and UpdateIndexTask to accept arrays of paths and propagate multi-path indexing to TextIndexClient and daemon controller

Bug Fixes:
- Validate empty and invalid directories before starting tasks in TaskManager

Enhancements:
- Update FSMonitor and FSEventCollector to initialize, monitor, and process multiple root directories
- Adjust TaskQueueItem to retain primary path and full pathList, and include multi-path details in logs
- Introduce a useAnything flag in HandlerResult and adapt file providers to short-circuit redundant indexing when using DirectFileListProvider
- Modify Filemanager plugin to use DFMSEARCH::Global::defaultIndexedDirectory instead of hardcoded home path

Build:
- Add dfm6-search dependency to daemon plugin CMakeLists