### PR TITLE
fix: Simplify file permission checks in LocalFileHandler

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -763,11 +763,8 @@ bool LocalFileHandlerPrivate::isFileExecutable(const QString &path)
     if (kinValidateType.contains(info->nameOf(NameInfoType::kSuffix)))
         return false;
 
-    QFile::Permissions permissions { info->permissions() };
-    bool isExeUser = permissions & QFile::Permission::ExeUser;
-    bool isReadUser = permissions & QFile::Permission::ReadUser;
-
-    return isExeUser && isReadUser;
+    return info->isAttributes(FileInfo::FileIsType::kIsExecutable)
+            && info->isAttributes(FileInfo::FileIsType::kIsReadable);
 }
 
 bool LocalFileHandlerPrivate::openExcutableScriptFile(const QString &path, int flag)


### PR DESCRIPTION
- Replaced manual permission checks with attribute-based checks for executable and readable file types.
- Improved code clarity and maintainability by utilizing existing methods in FileInfo.

Log: Streamline file permission validation for better readability and efficiency.

Bug: https://pms.uniontech.com/bug-view-315769.html

## Summary by Sourcery

Enhancements:
- Simplify executable file permission checks in LocalFileHandler by replacing manual bitmask operations with FileInfo attribute-based methods