### PR TITLE
fix: Update SIGTERM handling in dde-file-manager

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -217,7 +217,8 @@ static void handleSIGTERM(int sig)
     if (qApp) {
         // Don't use headless if SIGTERM, cause system shutdown blocked
         qApp->setProperty("SIGTERM", true);
-        qApp->quit();
+        // 重启或关闭系统时，信号处理会阻塞进程
+        QTimer::singleShot(0, qApp, &QApplication::quit);
     }
 }
 


### PR DESCRIPTION
- Modified the SIGTERM signal handling to use a delayed quit via QTimer, preventing process blocking during system shutdown or restart.

Log: Improve application shutdown behavior on SIGTERM signal.
Bug: https://pms.uniontech.com/bug-view-314295.html

## Summary by Sourcery

Bug Fixes:
- Delay application quit on SIGTERM by 2 seconds via QTimer::singleShot to avoid shutdown blocking.