### PR TITLE
feat: add urlEqualsWithQuery function and enhance file management

### DIFF
--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -361,6 +361,24 @@ bool UniversalUtils::urlEquals(const QUrl &url1, const QUrl &url2)
     return false;
 }
 
+bool UniversalUtils::urlEqualsWithQuery(const QUrl &url1, const QUrl &url2)
+{
+    if (!url1.isValid() || !url2.isValid())
+        return false;
+    if (url1 == url2)
+        return true;
+
+    auto path1 { url1.path() }, path2 { url2.path() };
+    if (!path1.endsWith("/"))
+        path1.append("/");
+    if (!path2.endsWith("/"))
+        path2.append("/");
+
+    if (url1.scheme() == url2.scheme() && path1 == path2 && url1.host() == url2.host() && url1.query() == url2.query())
+        return true;
+    return false;
+}
+
 bool UniversalUtils::urlsTransformToLocal(const QList<QUrl> &sourceUrls, QList<QUrl> *targetUrls)
 {
     Q_ASSERT(targetUrls);

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -38,6 +38,7 @@ public:
     static QVariantHash convertFromQMap(const QVariantMap map);
 
     static bool urlEquals(const QUrl &url1, const QUrl &url2);
+    static bool urlEqualsWithQuery(const QUrl &url1, const QUrl &url2);
     static bool urlsTransformToLocal(const QList<QUrl> &sourceUrls, QList<QUrl> *targetUrls);
     static bool urlTransformToLocal(const QUrl &sourceUrl, QUrl *targetUrls);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -73,7 +73,7 @@ public:
     DFMGLOBAL_NAMESPACE::ItemRoles columnToRole(int column) const;
     QString roleDisplayString(int role) const;
 
-    void stopTraversWork();
+    void stopTraversWork(const QUrl &newUrl);
 
     void updateFile(const QUrl &url);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.h
@@ -34,6 +34,8 @@ public:
     // self = false, will clean children
     void cleanRoot(const QUrl &rootUrl, const QString &key, const bool refresh = false, const bool self = true);
     void cleanRoot(const QUrl &rootUrl);
+    // 清理不再需要的RootInfo对象，保留当前URL和其直接子目录的RootInfo
+    void cleanUnusedRoots(const QUrl &currentUrl, const QString &key);
     void stopRootWork(const QUrl &rootUrl, const QString &key);
     void setFileActive(const QUrl &rootUrl, const QUrl &childUrl, bool active);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -303,9 +303,9 @@ void FileView::setModel(QAbstractItemModel *model)
     DListView::setModel(model);
 }
 
-void FileView::stopWork()
+void FileView::stopWork(const QUrl &newUrl)
 {
-    model()->stopTraversWork();
+    model()->stopTraversWork(newUrl);
 }
 
 void FileView::dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles)

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -66,7 +66,7 @@ public:
     void setDelegate(DFMBASE_NAMESPACE::Global::ViewMode mode, BaseItemDelegate *view);
     FileViewModel *model() const;
     void setModel(QAbstractItemModel *model) override;
-    void stopWork();
+    void stopWork(const QUrl &newUrl);
 
     void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                      const QVector<int> &roles = QVector<int>()) override;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
@@ -45,7 +45,7 @@ void WorkspacePage::setUrl(const QUrl &url)
 
         FileView *view = qobject_cast<FileView *>(curView->widget());
         if (view)
-            view->stopWork();
+            view->stopWork(url);
     }
 
     auto lastUrl = currentPageUrl;


### PR DESCRIPTION
- Implemented `urlEqualsWithQuery` in `UniversalUtils` to compare URLs including their query parameters.
- Updated `stopTraversWork` method in `FileViewModel` to accept a new URL parameter for improved directory load strategy handling.
- Introduced `cleanUnusedRoots` in `FileDataManager` to manage and clean up unused `RootInfo` objects based on the current URL, enhancing memory management.

Log: This commit enhances URL comparison functionality and improves file management efficiency in the file manager.
Bug: https://pms.uniontech.com/bug-view-315971.html

## Summary by Sourcery

Add URL comparison with query support and automatic cleanup of unused file manager roots, and refine traversal workflow to leverage these improvements for more efficient directory loading and memory management.

New Features:
- Add urlEqualsWithQuery util method for full URL comparison including query parameters
- Implement cleanUnusedRoots in FileDataManager to remove stale root entries based on the current URL

Enhancements:
- Extend stopTraversWork to accept a newUrl and conditionally preserve data for same-scheme directory loads
- Invoke cleanUnusedRoots in FileViewModel after traversal finishes under the preserve strategy to purge outdated roots