### PR TITLE
fix: Update crypttab handling in mergeCryptTab and ResumeEncryptWorker

### DIFF
--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -128,9 +128,10 @@ bool crypttab_helper::mergeCryptTab()
     if (merged) {
         // updateInitramfs 会在 updateCryptTab 中调用
         saveCryptItems(currentItems, false);
-        updateCryptTab();
     }
 
+    // 更新加密设备配置文件
+    updateCryptTab();
     return merged;
 }
 

--- a/src/services/diskencrypt/workers/resumeencryptworker.cpp
+++ b/src/services/diskencrypt/workers/resumeencryptworker.cpp
@@ -183,7 +183,7 @@ void ResumeEncryptWorker::updateCryptTab()
 {
     if (m_authArgs.tpmToken.isEmpty())
         return;
-    crypttab_helper::addCryptOption(m_jobArgs.clearDev, "tpm2-device=auto");
+    crypttab_helper::addCryptOption(m_jobArgs.volume, "tpm2-device=auto");
 }
 
 void ResumeEncryptWorker::saveRecoveryKey()


### PR DESCRIPTION
- Moved the call to `updateCryptTab` in `mergeCryptTab` to ensure the encrypted device configuration file is updated after merging.
- Corrected the argument in `addCryptOption` from `clearDev` to `volume` in `ResumeEncryptWorker` to properly set the TPM device option.

Log: Improve crypttab management and ensure correct options are applied for encryption tasks.

## Summary by Sourcery

Update crypttab handling by ensuring the configuration file is refreshed after merging entries and by correcting the TPM device option target in encryption resume tasks.

Bug Fixes:
- Use the correct volume identifier when adding the TPM2 device option in ResumeEncryptWorker

Enhancements:
- Always invoke updateCryptTab after merging crypttab entries