### PR TITLE
chore: Update version to 6.5.50

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.50) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Wed, 14 May 2025 16:41:55 +0800
+
 dde-file-manager (6.5.49) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
update version

Log: update version

## Summary by Sourcery

Chores:
- Update version number to 6.5.50 in debian/changelog