### PR TITLE
fix: enhance root management in FileDataManager and FileViewModel

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -593,6 +593,7 @@ void FileViewModel::stopTraversWork(const QUrl &newUrl)
     if (dirLoadStrategy == DirectoryLoadStrategy::kPreserve && canUsePreserveStrategy) {
         // stop work but do not clean current data
         FileDataManager::instance()->stopRootWork(dirRootUrl, currentKey);
+        FileDataManager::instance()->cleanUnusedRoots(dirRootUrl, currentKey);
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -102,7 +102,7 @@ void FileDataManager::stopRootWork(const QUrl &rootUrl, const QString &key)
 
     auto rootInfoKeys = rootInfoMap.keys();
     for (const auto &rootInfo : rootInfoKeys) {
-        if (rootInfo.path().startsWith(rootPath) || rootInfo.path() == rootUrl.path()) {
+        if (UniversalUtils::urlEqualsWithQuery(rootInfo, rootUrl) || (rootInfo.path() != rootPath && rootInfo.path().startsWith(rootPath))) {
             rootInfoMap.value(rootInfo)->disconnect();
             rootInfoMap.value(rootInfo)->clearTraversalThread(key, false);
         }


### PR DESCRIPTION
- Updated `stopRootWork` in `FileDataManager` to improve URL comparison logic for better root management.
- Added a call to `cleanUnusedRoots` in `stopTraversWork` of `FileViewModel` to ensure unused roots are cleaned up effectively.

Log: This commit improves the handling of root management in the file manager, enhancing memory efficiency and ensuring proper cleanup of unused resources.

## Summary by Sourcery

Refine root lifecycle management in FileDataManager and FileViewModel to ensure accurate URL matching and automatic cleanup of unused roots

Bug Fixes:
- Use Unified URL comparison in stopRootWork to correctly identify roots based on full URL including query
- Adjust path matching in stopRootWork to avoid prematurely stopping traversal on nested directories
- Add cleanUnusedRoots call after stopRootWork in FileViewModel to purge unused root entries