### PR TITLE
fix: adjust highlight rectangle width in ElideTextLayout

### DIFF
--- a/src/dfm-base/utils/elidetextlayout.cpp
+++ b/src/dfm-base/utils/elidetextlayout.cpp
@@ -530,9 +530,11 @@ void ElideTextLayout::drawTextWithHighlight(QPainter *painter, const QTextLine &
                                - line.cursorToX(lineStartPos + highlightStart);
             
             // 绘制高亮文本
-            QRectF highlightRect(rect.x() + keywordXPos, rect.y(), keywordWidth, rect.height());
+            QRectF highlightRect(rect.x() + keywordXPos, rect.y(), keywordWidth + 1, rect.height()); // 宽度加1防止误差导致绘制异常
+            QString highlightText(lineText.mid(highlightStart, highlightLength));
+            painter->drawRect(highlightRect);
             painter->drawText(highlightRect,
-                             lineText.mid(highlightStart, highlightLength),
+                             highlightText,
                              QTextOption(document->defaultTextOption().alignment()));
         }
         


### PR DESCRIPTION
- Modified the width of the highlight rectangle in `drawTextWithHighlight` to prevent rendering issues by adding an extra pixel.
- Updated the text drawing logic to use a separate variable for the highlighted text, improving code clarity.

Log: This commit addresses a rendering issue in the text layout by ensuring the highlight rectangle is drawn correctly, enhancing the visual output of highlighted text.
Bug: https://pms.uniontech.com/bug-view-315991.html

## Summary by Sourcery

Fix highlight rectangle width to prevent rendering issues and refactor text drawing logic for clarity in ElideTextLayout.

Bug Fixes:
- Adjust highlight rectangle width by adding an extra pixel to prevent drawing anomalies.

Enhancements:
- Introduce a separate variable for highlighted text in drawTextWithHighlight to improve code clarity.