### PR TITLE
fix: remove unnecessary highlight rectangle drawing in ElideTextLayout

### DIFF
--- a/src/dfm-base/utils/elidetextlayout.cpp
+++ b/src/dfm-base/utils/elidetextlayout.cpp
@@ -532,7 +532,6 @@ void ElideTextLayout::drawTextWithHighlight(QPainter *painter, const QTextLine &
             // 绘制高亮文本
             QRectF highlightRect(rect.x() + keywordXPos, rect.y(), keywordWidth + 1, rect.height()); // 宽度加1防止误差导致绘制异常
             QString highlightText(lineText.mid(highlightStart, highlightLength));
-            painter->drawRect(highlightRect);
             painter->drawText(highlightRect,
                              highlightText,
                              QTextOption(document->defaultTextOption().alignment()));


### PR DESCRIPTION
- Eliminated the drawing of the highlight rectangle in the `drawTextWithHighlight` method to streamline the rendering process.
- This change improves the visual output by focusing on the text drawing without the additional rectangle, enhancing clarity in the highlighted text display.

Log: remove unnecessary highlight rectangle drawing