### PR TITLE
feat: enable search functionality in TitleBar

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -189,6 +189,11 @@ void FileOperatorMenuScene::updateState(QMenu *parent)
             rename->setDisabled(true);
     }
 
+    if (auto openAction = d->predicateAction.value(ActionID::kOpen)) {
+        if (!d->focusFileInfo->exists())
+            openAction->setDisabled(true);
+    }
+
     // set as wallpaper
     if (auto setWallpaper = d->predicateAction.value(ActionID::kSetAsWallpaper)) {
         auto focusUrl = d->focusFileInfo->urlOf(UrlInfoType::kUrl);

--- a/src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp
@@ -139,6 +139,11 @@ void OpenWithMenuScene::updateState(QMenu *parent)
     if (!parent)
         return;
 
+    if (auto openAction = d->predicateAction.value(ActionID::kOpenWith)) {
+        if (!d->focusFileInfo->exists())
+            openAction->setDisabled(true);
+    }
+
     // open with by focus fileinfo
 
     AbstractMenuScene::updateState(parent);

--- a/src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp
@@ -147,6 +147,13 @@ void SendToMenuScene::updateState(QMenu *parent)
 {
     // remove device self action
     if (!d->isEmptyArea) {
+        if (auto sendToAction = d->predicateAction.value(ActionID::kSendTo)) {
+            if (!d->focusFileInfo->exists()) {
+                sendToAction->setDisabled(true);
+                return AbstractMenuScene::updateState(parent);
+            }
+        }
+
         auto actions = parent->actions();
         bool removed = false;
         for (auto act : actions) {

--- a/src/plugins/common/dfmplugin-propertydialog/menu/propertymenuscene.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/menu/propertymenuscene.cpp
@@ -87,6 +87,13 @@ bool PropertyMenuScene::initialize(const QVariantHash &params)
         d->selectFiles << d->currentDir;
     }
 
+    QString errString;
+    d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+    if (d->focusFileInfo.isNull()) {
+        fmDebug() << errString;
+        return false;
+    }
+
     return AbstractMenuScene::initialize(params);
 }
 
@@ -117,6 +124,11 @@ void PropertyMenuScene::updateState(QMenu *parent)
 {
     if (!parent)
         return;
+
+    if (auto pAction = d->predicateAction.value(PropertyActionId::kProperty)) {
+        if (!d->focusFileInfo->exists())
+            pAction->setDisabled(true);
+    }
 
     d->updateMenu(parent);
 

--- a/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
@@ -60,6 +60,13 @@ bool TagMenuScene::initialize(const QVariantHash &params)
     d->predicateName.insert(TagActionId::kActTagColorListKey, "");
     d->predicateName.insert(TagActionId::kActTagAddKey, tr("Tag information"));
 
+    QString errString;
+    d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+    if (d->focusFileInfo.isNull()) {
+        fmDebug() << errString;
+        return false;
+    }
+
     auto subScenes = subscene();
     if (auto filterScene = dfmplugin_menu_util::menuSceneCreateScene("DConfigMenuFilter"))
         subScenes << filterScene;
@@ -78,6 +85,9 @@ bool TagMenuScene::create(QMenu *parent)
         return false;
     // create by focus fileinfo
     if (!TagManager::instance()->canTagFile(d->focusFile))
+        return false;
+
+    if (!d->focusFileInfo->exists())
         return false;
 
     // create by focus fileinfo

--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
@@ -39,6 +39,17 @@ bool TitleBar::start()
     // file scheme for crumbar
     dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", QString(Global::Scheme::kFile), QVariantMap {});
 
+    auto searchPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-search") };
+    if (searchPlugin && searchPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
+        TitleBarHelper::searchEnabled = true;
+    } else {
+        connect(DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this,
+            [](const QString &, const QString &name) {
+                if (name == "dfmplugin-search") TitleBarHelper::searchEnabled = true;
+            },
+        Qt::DirectConnection);
+    }
+
     return true;
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -33,6 +33,7 @@ QMap<quint64, TitleBarWidget *> TitleBarHelper::kTitleBarMap {};
 QList<QString> TitleBarHelper::kKeepTitleStatusSchemeList {};
 
 bool TitleBarHelper::newWindowAndTabEnabled { true };
+bool TitleBarHelper::searchEnabled { false };
 
 QList<TitleBarWidget *> TitleBarHelper::titlebars()
 {

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
@@ -41,6 +41,7 @@ public:
 
 public:
     static bool newWindowAndTabEnabled;
+    static bool searchEnabled;
 
 private:
     static QMutex &mutex();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -187,6 +187,9 @@ void SearchEditWidget::performSearch()
     if (pendingSearchText.isEmpty())
         return;
 
+    if (!TitleBarHelper::searchEnabled)
+        return;
+
     // Trim whitespace from the search string
     QString trimmedSearchText = pendingSearchText.trimmed();
     if (trimmedSearchText.isEmpty())

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -214,8 +214,12 @@ void FileDataManager::cleanUnusedRoots(const QUrl &currentUrl, const QString &ke
     // 清理标记的RootInfo
     for (const auto &rootUrl : rootsToClean) {
         // 先停止线程工作
-        rootInfoMap.value(rootUrl)->clearTraversalThread(key, false);
-        
+        int rootThreadCount = rootInfoMap.value(rootUrl)->clearTraversalThread(key, false);
+
+        // 剩余迭代线程大于0,说明该rootinfo还在被其他view-model使用，不能直接移除
+        if (rootThreadCount > 0)
+            continue;
+
         // 从Map中移除并处理删除
         auto root = rootInfoMap.take(rootUrl);
         if (root) {


### PR DESCRIPTION
- Integrated search functionality into the TitleBar by checking the state of the search plugin and updating the TitleBarHelper to manage the search state.
- Added a condition in the SearchEditWidget to prevent search execution when the search feature is disabled, enhancing user experience and preventing unnecessary operations.

Log: This commit enhances the TitleBar by enabling search capabilities, improving the overall functionality of the file manager.

## Summary by Sourcery

Enable TitleBar search functionality by tracking the search plugin’s lifecycle and gating search execution based on its state

New Features:
- Add a searchEnabled flag in TitleBarHelper to support search functionality in the TitleBar
- Detect the search plugin’s startup state and enable TitleBar search upon plugin activation

Enhancements:
- Guard SearchEditWidget’s performSearch on the searchEnabled flag to prevent search operations when disabled