### PR TITLE
fix: add delayed removal of copying file URLs via OperatorsFileUtils

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -378,7 +378,7 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const DFileInfoPointer &fromInfo, 
         }
         if (ok)
             cutAndDeleteFiles.append(fromInfo);
-        FileUtils::removeCopyingFileUrl(url);
+        OperatorsFileUtils::instance()->delayRemoveCopyingFile(url);
     }
 
     toInfo->initQuerier();
@@ -910,7 +910,7 @@ bool FileOperateBaseWorker::doCopyLocalByRange(const DFileInfoPointer fromInfo, 
 
     FileUtils::cacheCopyingFileUrl(targetUrl);
     DoCopyFileWorker::NextDo nextDo = copyOtherFileWorker->doCopyFileByRange(fromInfo, toInfo, skip);
-    FileUtils::removeCopyingFileUrl(targetUrl);
+    OperatorsFileUtils::instance()->delayRemoveCopyingFile(targetUrl);
     return nextDo == DoCopyFileWorker::NextDo::kDoCopyNext;
 }
 
@@ -938,7 +938,7 @@ bool FileOperateBaseWorker::doCopyOtherFile(const DFileInfoPointer fromInfo, con
     }
     if (ok)
         syncFiles.append(targetUrl);
-    FileUtils::removeCopyingFileUrl(targetUrl);
+    OperatorsFileUtils::instance()->delayRemoveCopyingFile(targetUrl);
 
     return ok;
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -83,6 +83,27 @@ private:
     static QSet<QString> fileNameUsing;
     static QMutex mutex;
 };
+
+class OperatorsFileUtils : public QObject {
+    Q_OBJECT
+    explicit OperatorsFileUtils(QObject *parent = nullptr)
+        : QObject(parent) {}
+public:
+    ~OperatorsFileUtils() override {}
+
+    void delayRemoveCopyingFile(const QUrl &url) {
+        QTimer::singleShot(500, this, [url](){
+            dfmbase::FileUtils::removeCopyingFileUrl(url);
+        });
+    }
+
+    static OperatorsFileUtils *instance() {
+        static OperatorsFileUtils in;
+        return &in;
+    }
+
+};
+
 DPFILEOPERATIONS_END_NAMESPACE
 
 #endif   // FILEOPERATIONSUTILS_H


### PR DESCRIPTION
- Introduced OperatorsFileUtils singleton class to handle delayed removal of copying file URLs.
- Replaced direct calls to FileUtils::removeCopyingFileUrl with OperatorsFileUtils::delayRemoveCopyingFile in FileOperateBaseWorker.
- Utilized QTimer to delay the removal by 500ms, ensuring safer file operation handling.

Log: add delayed removal of copying file URLs via OperatorsFileUtils
Bug: https://pms.uniontech.com/bug-view-310043.html

## Summary by Sourcery

Introduce delayed removal of copying file URLs to prevent potential race conditions during file operations.

New Features:
- Add OperatorsFileUtils singleton to encapsulate delayed removal logic
- Implement delayRemoveCopyingFile method using a 500ms QTimer before calling removeCopyingFileUrl

Enhancements:
- Replace direct calls to FileUtils::removeCopyingFileUrl in FileOperateBaseWorker with OperatorsFileUtils::delayRemoveCopyingFile for all copying operations