### PR TITLE
chore: Update version to 6.5.51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.51) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 15 May 2025 20:27:26 +0800
+
 dde-file-manager (6.5.50) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
update version

Log: update version

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.5.51