### PR TITLE
fix: Make save path input read-only and disable clear button

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -564,6 +564,7 @@ void ConnectToServerDialog::updateUiState()
     const QString &currUrlStr = getCurrentUrlString();
     int row = model->findItem(currUrlStr);
     collectionServerView->setCurrentIndex(model->index(row));
+    getButton(kConnectButton)->setEnabled(!serverComboBox->currentText().isEmpty());
 }
 
 QString ConnectToServerDialog::schemeWithSlash(const QString &scheme) const

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
@@ -76,6 +76,8 @@ void VaultActiveSaveKeyFileView::initUI()
     selectfileSavePathEdit = new DFileChooserEdit(this);
     DFontSizeManager::instance()->bind(otherPathRadioBtn, DFontSizeManager::T8, QFont::Medium);
     selectfileSavePathEdit->lineEdit()->setPlaceholderText(tr("Select a path"));
+    selectfileSavePathEdit->lineEdit()->setReadOnly(true);
+    selectfileSavePathEdit->lineEdit()->setClearButtonEnabled(false);
     filedialog = new DFileDialog(this, QDir::homePath(), QString("pubKey.key"));
     filedialog->setAcceptMode(QFileDialog::AcceptMode::AcceptSave);
     filedialog->setDefaultSuffix(QString("key"));


### PR DESCRIPTION
- Set the save path input field to read-only to prevent user modifications.
- Disabled the clear button for the save path input to enhance user experience and prevent accidental deletions.

Log: Improve user interface for vault active save key file view.
Bug: https://pms.uniontech.com/bug-view-315533.html

## Summary by Sourcery

Bug Fixes:
- Make save path input read-only and disable clear button in the vault active save key file view to improve UX and prevent accidental deletions.