### PR TITLE
feat: add AppImage thumbnail support and update related logic

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -129,6 +129,7 @@ inline constexpr char kTypeAppMxf[] { "application/mxf" };
 inline constexpr char kTypeAppVMAsf[] { "application/vnd.ms-asf" };
 inline constexpr char kTypeAppCRRMedia[] { "application/cnd.rn-realmedia" };
 inline constexpr char kTypeAppVRRMedia[] { "application/vnd.rn-realmedia" };
+inline constexpr char kTypeAppAppimage[] { "application/vnd.appimage" };
 inline constexpr char kTypeTextHtml[] { "text/html" };
 inline constexpr char kTypeAppXhtmlXml[] { "application/xhtml+xml" };
 inline constexpr char kTypeTextXPython[] { "text/x-python" };

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.h
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.h
@@ -20,6 +20,7 @@ QImage audioThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::Thumb
 QImage imageThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage djvuThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage pdfThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
+QImage appimageThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 }   // namespace ThumbnailCreators
 }   // namespace dfmbase
 

--- a/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
@@ -32,6 +32,7 @@ ThumbnailFactory::ThumbnailFactory(QObject *parent)
     registerThumbnailCreator("image/*", ThumbnailCreators::imageThumbnailCreator);
     registerThumbnailCreator("audio/*", ThumbnailCreators::audioThumbnailCreator);
     registerThumbnailCreator("video/*", ThumbnailCreators::videoThumbnailCreator);
+    registerThumbnailCreator(Mime::kTypeAppAppimage, ThumbnailCreators::appimageThumbnailCreator);
 
     init();
 }

--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -53,6 +53,8 @@ void ThumbnailHelper::initSizeLimit()
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeImagePipeg), 1024 * 1024 * 30);
     // High file limit size only for FLAC files.
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAudioFlac), INT64_MAX);
+
+    sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAppAppimage), INT64_MAX);
 }
 
 const QStringList &ThumbnailHelper::defaultThumbnailDirs()
@@ -111,6 +113,10 @@ bool ThumbnailHelper::checkMimeTypeSupport(const QMimeType &mime)
                  || mimeName == Mime::kTypeAppCRRMedia
                  || mimeName == Mime::kTypeAppMxf))
         return checkStatus(Application::kPreviewDocumentFile);
+
+    // appimage 是可执行程序包，应该显示图标
+    if (mimeName == Mime::kTypeAppAppimage)
+        return true;
 
     return false;
 }

--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -431,6 +431,10 @@ bool CanvasItemDelegate::isThumnailIconIndex(const QModelIndex &index) const
 
     FileInfoPointer info { parent()->model()->fileInfo(index) };
     if (info) {
+        // appimage 不显示缩略图底板
+        if (info->nameOf(NameInfoType::kMimeTypeName) == Global::Mime::kTypeAppAppimage)
+            return false;
+
         const auto &attribute { info->extendAttributes(ExtInfoType::kFileThumbnail) };
         if (attribute.isValid() && !attribute.value<QIcon>().isNull())
             return true;

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -424,6 +424,10 @@ bool CollectionItemDelegate::isThumnailIconIndex(const QModelIndex &index) const
 
     FileInfoPointer info { parent()->model()->fileInfo(index) };
     if (info) {
+        // appimage 不显示缩略图底板
+        if (info->nameOf(NameInfoType::kMimeTypeName) == Global::Mime::kTypeAppAppimage)
+            return false;
+
         const auto &attribute { info->extendAttributes(ExtInfoType::kFileThumbnail) };
         if (attribute.isValid() && !attribute.value<QIcon>().isNull())
             return true;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -67,6 +67,10 @@ bool BaseItemDelegate::isThumnailIconIndex(const QModelIndex &index) const
 
     FileInfoPointer info { parent()->fileInfo(index) };
     if (info) {
+        // appimage 不显示缩略图底板
+        if (info->nameOf(NameInfoType::kMimeTypeName) == Global::Mime::kTypeAppAppimage)
+            return false;
+
         const auto &attribute { info->extendAttributes(ExtInfoType::kFileThumbnail) };
         if (attribute.isValid() && !attribute.value<QIcon>().isNull())
             return true;


### PR DESCRIPTION
- Introduced a new function `appimageThumbnailCreator` to handle the creation of thumbnails for AppImage files.
- Updated `ThumbnailFactory` to register the new AppImage thumbnail creator.
- Enhanced `ThumbnailHelper` to support AppImage MIME type and size limits.
- Added necessary logging for better debugging and error handling during AppImage processing.

This change improves the application's ability to generate thumbnails for AppImage files, enhancing user experience with better visual representation of these file types.

Log: add AppImage thumbnail support and update related logic

## Summary by Sourcery

Add end-to-end support for generating and displaying thumbnails of AppImage files by introducing a dedicated thumbnail creator, registering it, updating helper limits and MIME support, and adjusting delegates to handle AppImage items correctly.

New Features:
- Support thumbnail generation for AppImage files

Enhancements:
- Register AppImage thumbnail creator in ThumbnailFactory
- Extend ThumbnailHelper to enforce MIME type and size limits for AppImage
- Skip thumbnail overlays for AppImage items in Canvas, Collection, and Workspace delegates
- Enhance debug and warning logs during AppImage processing