### PR TITLE
fix: [disk-encrypt] Can not decrypt disk by TPM.

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.diskencrypt.json
+++ b/assets/configs/org.deepin.dde.file-manager.diskencrypt.json
@@ -34,6 +34,105 @@
             "description":"It's used to control whether to enable partition encryption feature in dde-file-manager.",
             "permissions":"readwrite",
             "visibility":"public"
+        },
+        "enableUseTpmConfigAlgo": {
+            "value": false,
+            "serial":0,
+            "flags":["global"],
+            "name":"Use tpm algo form dconfig",
+            "name[zh_CN]":"从配置文件获取tpm算法",
+            "description[zh_CN]":"从配置文件获取tpm算法",
+            "description":"Use tpm algo form dconfig",
+            "permissions":"readwrite",
+            "visibility":"public"
+        },
+        "tpmSessionHashAlgoName": {
+            "value": "sm3_256",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Session哈希算法",
+            "name[zh_CN]": "Session哈希算法",
+            "description": "Session哈希算法，可选算法有(sha256,sm3_256)",
+            "description[zh_CN]": "Session哈希算法，可选算法有(sha256,sm3_256)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tpmSessionKeyAlgoName": {
+            "value": "sm4",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Session秘钥算法",
+            "name[zh_CN]": "Session秘钥算法",
+            "description": "Session秘钥算法，可选算法有(sm4,aes)",
+            "description[zh_CN]": "Session秘钥算法，可选算法有(sm4,aes)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tpmPrimaryHashAlgoName": {
+            "value": "sm3_256",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "主钥哈希算法",
+            "name[zh_CN]": "主钥哈希算法",
+            "description": "主钥哈希算法，可选算法有(sha256,sm3_256)",
+            "description[zh_CN]": "主钥哈希算法，可选算法有(sha256,sm3_256)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tpmPrimaryKeyAlgoName": {
+            "value": "sm4_128cfb",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "主钥秘钥算法",
+            "name[zh_CN]": "主钥秘钥算法",
+            "description": "主钥秘钥算法，可选算法有(sm4,rsa)",
+            "description[zh_CN]": "主钥秘钥算法，可选算法有(sm4,rsa)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tpmMinorHashAlgoName": {
+            "value": "sm3_256",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "次钥哈希算法",
+            "name[zh_CN]": "次钥哈希算法",
+            "description": "次钥哈希算法，可选算法有(sha256, sm3_256)",
+            "description[zh_CN]": "次钥哈希算法，可选算法有(sha256, sm3_256)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tpmMinorKeyAlgoName": {
+            "value": "sm4_128cfb",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "次钥秘钥算法",
+            "name[zh_CN]": "次钥秘钥算法",
+            "description": "次钥秘钥算法，可选算法有(sm4, aes 等)",
+            "description[zh_CN]": "次钥秘钥算法，可选算法有(sm4, aes 等)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tpmPcr": {
+            "value": "0,7",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "寄存器ID",
+            "name[zh_CN]": "寄存器ID",
+            "description": "寄存器ID，取值范围(5~27)",
+            "description[zh_CN]": "寄存器ID，取值范围(5~27)",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "tpmPcrBank": {
+            "value": "sm3_256",
+            "serial": 0,
+            "flags": ["global"],
+            "name": "寄存器哈希算法",
+            "name[zh_CN]": "寄存器哈希算法",
+            "description": "寄存器哈希算法，取值范围(sm3_256,sha256)",
+            "description[zh_CN]": "寄存器哈希算法，取值范围(sm3_256,sha256)",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/debian/control
+++ b/debian/control
@@ -83,6 +83,7 @@ Depends:
  tpm2-abrmd,
  libtss2-tcti-pcap0,
  libtss2-tcti-tabrmd0,
+ libutpm2,
  libusec-recoverykey | hello
 Replaces: dde-file-manager-oem, dde-desktop (<< 6.0.1),
  dde-file-manager-preview,

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
@@ -21,7 +21,7 @@ enum TPMModuleEncType {
     kUnknow = 0,
     kUseTpmAndPcr,
     kUseTpmAndPin,
-    kUseTpmAndPrcAndPin
+    kUseTpmAndPcrAndPin
 };
 
 inline constexpr char kDaemonBusName[] { "org.deepin.Filemanager.DiskEncrypt" };
@@ -33,21 +33,23 @@ inline constexpr char kComputerMenuSceneName[] { "ComputerMenu" };
 
 inline constexpr int kPasswordSize { 14 };
 inline const QString kGlobalTPMConfigPath("/tmp/dfm-encrypt");
+
 inline constexpr char kTPMSessionHashAlgo[] { "sha256" };
 inline constexpr char kTPMSessionKeyAlgo[] { "aes" };
 inline constexpr char kTPMPrimaryHashAlgo[] { "sha256" };
 inline constexpr char kTPMPrimaryKeyAlgo[] { "rsa" };
 inline constexpr char kTPMMinorHashAlgo[] { "sha256" };
 inline constexpr char kTPMMinorKeyAlgo[] { "aes" };
+
 inline constexpr char kTCMSessionHashAlgo[] { "sm3_256" };
 inline constexpr char kTCMSessionKeyAlgo[] { "sm4" };
 inline constexpr char kTCMPrimaryHashAlgo[] { "sm3_256" };
 inline constexpr char kTCMPrimaryKeyAlgo[] { "sm4" };
 inline constexpr char kTCMMinorHashAlgo[] { "sm3_256" };
 inline constexpr char kTCMMinorKeyAlgo[] { "sm4" };
-inline constexpr char kConfigKeySessionHashAlgo[] { "session_hash_algo" };
-inline constexpr char kConfigKeySessionKeyAlgo[] { "session_key_algo" };
-inline constexpr char kConfigKeyPriHashAlgo[] { "primary_hash_algo" };
-inline constexpr char kConfigKeyPriKeyAlgo[] { "primary_key_algo" };
+
+inline constexpr char kPcr[] { "0,7" };
+inline constexpr char kTPMPcrBank[] { "sha256" };
+inline constexpr char kTCMPcrBank[] { "sm3_256" };
 
 #endif   // DFMPLUGIN_DISK_ENCRYPT_GLOBAL_H

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -392,18 +392,6 @@ bool EncryptParamsInputDialog::encryptByTpm(const QString &deviceName)
             btn->setEnabled(true);
     });
 
-    QString sessionHashAlgo, sessionKeyAlgo, primaryHashAlgo, primaryKeyAlgo, minorHashAlgo, minorKeyAlgo;
-    bool checkAlgo = tpm_passphrase_utils::getAlgorithm(&sessionHashAlgo,
-                                                        &sessionKeyAlgo,
-                                                        &primaryHashAlgo,
-                                                        &primaryKeyAlgo,
-                                                        &minorHashAlgo,
-                                                        &minorKeyAlgo);
-    if (!checkAlgo) {
-        qCritical() << "TPM algo choice failed!";
-        return false;
-    }
-
     DSpinner spinner(this);
     spinner.setFixedSize(50, 50);
     spinner.move((width() - spinner.width()) / 2, (height() - spinner.height()) / 2);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -427,21 +427,25 @@ void DiskEncryptMenuScene::doChangePassphrase(const DeviceEncryptParam &param)
 
 QString DiskEncryptMenuScene::generateTPMConfig()
 {
-    QString sessionHashAlgo, sessionKeyAlgo, primaryHashAlgo, primaryKeyAlgo, minorHashAlgo, minorKeyAlgo;
-    if (!tpm_passphrase_utils::getAlgorithm(&sessionHashAlgo, &sessionKeyAlgo, &primaryHashAlgo, &primaryKeyAlgo, &minorHashAlgo, &minorKeyAlgo)) {
+    QString sessionHashAlgo, sessionKeyAlgo, primaryHashAlgo, primaryKeyAlgo, minorHashAlgo, minorKeyAlgo, pcr, pcrbank;
+    if (!tpm_passphrase_utils::getAlgorithm(&sessionHashAlgo, &sessionKeyAlgo,
+                                            &primaryHashAlgo, &primaryKeyAlgo,
+                                            &minorHashAlgo, &minorKeyAlgo,
+                                            &pcr, &pcrbank)) {
         qWarning() << "cannot choose algorithm for tpm";
-        primaryHashAlgo = "sha256";
-        primaryKeyAlgo = "ecc";
+        return "";
     }
 
     QJsonObject tpmParams;
     tpmParams = { { "keyslot", "1" },
-                  { "session-key-alg", sessionKeyAlgo },
                   { "session-hash-alg", sessionHashAlgo },
-                  { "primary-key-alg", primaryKeyAlgo },
+                  { "session-key-alg", sessionKeyAlgo },
                   { "primary-hash-alg", primaryHashAlgo },
-                  { "pcr", "0,7" },
-                  { "pcr-bank", primaryHashAlgo } };
+                  { "primary-key-alg", primaryKeyAlgo },
+                  { "minor-hash-alg", minorHashAlgo },
+                  { "minor-key-alg", minorKeyAlgo },
+                  { "pcr", pcr },
+                  { "pcr-bank", pcrbank } };
     return QJsonDocument(tpmParams).toJson();
 }
 

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -35,9 +35,11 @@ enum TPMError {
     kTPMMissingAlog,
 };
 
+bool tpmSupportInterAlgo();
+bool tpmSupportSMAlgo();
 bool getAlgorithm(QString *sessionHashAlgo, QString *sessionKeyAlgo,
                   QString *primaryHashAlgo, QString *primaryKeyAlgo,
-                  QString *minorHashAlgo, QString *minorKeyAlgo);
+                  QString *minorHashAlgo, QString *minorKeyAlgo, QString *pcr, QString *pcrbank);
 int genPassphraseFromTPM(const QString &dev, const QString &pin, QString *passphrase);
 QString getPassphraseFromTPM(const QString &dev, const QString &pin);
 
@@ -49,6 +51,11 @@ namespace config_utils {
 bool exportKeyEnabled();
 QString cipherType();
 bool enableEncrypt();
+bool enableAlgoFromDConfig();
+bool tpmAlgoFromDConfig(QString *sessionHash, QString *sessionKey,
+                        QString *primaryHash, QString *primaryKey,
+                        QString *minorHash, QString *minorKey,
+                        QString *pcr, QString *pcrBank);
 }   // namespace config_utils
 
 namespace recovery_key_utils {


### PR DESCRIPTION
-- The libutpm2 not install, so add the depands.
-- Set the pcr to 0,7.
-- Optimizing the algo of obtaining for tpm.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-316269.html

## Summary by Sourcery

Enable TPM-based disk decryption by properly managing PCR settings and algorithm parameters, with optional sourcing from DConfig to fix decryption failures.

New Features:
- Support configurable PCR indices and bank values in TPM operations.
- Allow algorithm parameters to be loaded from Deepin’s DConfig for dynamic TPM configuration.
- Add helper functions to detect available TPM algorithms for both standard and SM suites.

Bug Fixes:
- Fix disk decryption failure by correcting PCR/index handling and ensuring proper algorithm selection.

Enhancements:
- Refactor getAlgorithm to include PCR parameters and drop ini-based persistence, centralizing parameters in token.json.
- Simplify TPM passphrase generation and decryption logic by consolidating property maps.