### PR TITLE
preview & search with space

### DIFF
--- a/src/apps/config.h.in
+++ b/src/apps/config.h.in
@@ -74,6 +74,12 @@
 #    warning "cmake unseting definition DFM_THUMBNAIL_TOOL"
 #endif
 
+#ifndef DFM_PREVIEW_TOOL
+#    define DFM_PREVIEW_TOOL "${CMAKE_INSTALL_FULL_LIBEXECDIR}/dde-file-manager-preview"
+#elif
+#    warning "cmake unseting definition DFM_PREVIEW_TOOL"
+#endif
+
 #ifndef VERSION
 #    define VERSION "@VERSION@"
 #endif

--- a/src/plugins/common/dfmplugin-fileoperations/CMakeLists.txt
+++ b/src/plugins/common/dfmplugin-fileoperations/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(dfmplugin-fileoperations)
 
+configure_file(
+    "${APP_SOURCE_DIR}/config.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+    )
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # 设置二进制文件名

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -1548,14 +1548,14 @@ void FileOperationsEventReceiver::handleOperationFilesPreview(const quint64 wind
     QString selectListStr;
     QString dirListStr;
 
-    for (auto url : selectUrls) {
+    for (const auto &url : selectUrls) {
         selectListStr.append(url.toString());
         selectListStr.append(";");
     }
     if (!selectListStr.isEmpty())
         selectListStr.chop(1);
 
-    for (auto url : dirUrls) {
+    for (const auto &url : dirUrls) {
         dirListStr.append(url.toString());
         dirListStr.append(";");
     }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -1545,25 +1545,39 @@ void FileOperationsEventReceiver::handleOperationFilesPreview(const quint64 wind
     if (selectUrls.isEmpty() || dirUrls.isEmpty())
         return;
 
-    QString selectListStr;
-    QString dirListStr;
+    // Create temporary file
+    // 使用QTemporaryFile的autoRemove = false，避免进程关闭后文件被删除
+    QTemporaryFile tempFile;
+    tempFile.setAutoRemove(false);
+    if (!tempFile.open()) {
+        fmWarning() << "Failed to create temporary file for preview data";
+        return;
+    }
 
+    // Write data to temporary file in JSON format
+    QJsonObject data;
+    data["windowId"] = QString::number(windowId);
+
+    QJsonArray selectUrlsArray;
     for (const auto &url : selectUrls) {
-        selectListStr.append(url.toString());
-        selectListStr.append(";");
+        selectUrlsArray.append(url.toString());
     }
-    if (!selectListStr.isEmpty())
-        selectListStr.chop(1);
+    data["selectUrls"] = selectUrlsArray;
 
+    QJsonArray dirUrlsArray;
     for (const auto &url : dirUrls) {
-        dirListStr.append(url.toString());
-        dirListStr.append(";");
+        dirUrlsArray.append(url.toString());
     }
-    if (!dirListStr.isEmpty())
-        dirListStr.chop(1);
+    data["dirUrls"] = dirUrlsArray;
 
+    QJsonDocument doc(data);
+    tempFile.write(doc.toJson());
+    QString tempFileName = tempFile.fileName();
+    tempFile.close();
+
+    // Pass temporary file path as argument
     QStringList args;
-    args << QString::number(windowId) << selectListStr << dirListStr;
+    args << tempFileName;
     QString cmd(DFM_PREVIEW_TOOL);
     QProcess::startDetached(cmd, args);
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -7,6 +7,8 @@
 #include "fileoperationsevent/fileoperationseventhandler.h"
 #include "fileoperations/operationsstackproxy.h"
 
+#include "config.h"   //cmake
+
 #include <dfm-base/utils/hidefilehelper.h>
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/file/local/localfilehandler.h>
@@ -1562,7 +1564,7 @@ void FileOperationsEventReceiver::handleOperationFilesPreview(const quint64 wind
 
     QStringList args;
     args << QString::number(windowId) << selectListStr << dirListStr;
-    QString cmd("/usr/libexec/dde-file-manager-preview");
+    QString cmd(DFM_PREVIEW_TOOL);
     QProcess::startDetached(cmd, args);
 }
 

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.cpp
@@ -52,13 +52,16 @@ QString DFMSearcher::realSearchPath(const QUrl &url)
 
 SearchQuery DFMSearcher::createSearchQuery() const
 {
+    // Static regular expressions to avoid recreation
+    static const QRegularExpression kWhitespacePattern("\\s");
+    static const QRegularExpression kWhitespaceDelimiter("\\s+");
+
     // Create search query
-    if (!keyword.contains(' '))
+    if (!keyword.contains(kWhitespacePattern))
         return SearchFactory::createQuery(keyword, SearchQuery::Type::Simple);
 
-    // If contains spaces, use boolean query
-    QStringList keywords;
-    keywords = keyword.split(' ', Qt::SkipEmptyParts);
+    // If contains any whitespace characters, use boolean query
+    QStringList keywords = keyword.split(kWhitespaceDelimiter, Qt::SkipEmptyParts);
     SearchQuery query = SearchFactory::createQuery(keywords, SearchQuery::Type::Boolean);
     // Set boolean operator to AND
     query.setBooleanOperator(SearchQuery::BooleanOperator::AND);


### PR DESCRIPTION
## Summary by Sourcery

Enable support for spaces in preview and search workflows by switching to JSON-based IPC for file previews and enhancing keyword parsing and search query generation to recognize any whitespace

Enhancements:
- Switch preview application to read window ID and URL lists from a JSON-formatted temporary file instead of positional string arguments
- Serialize and write preview data as JSON in FileOperationsEventReceiver and launch the preview tool using a QTemporaryFile
- Decode percent-encoded keywords and split on all whitespace characters in RootInfo to correctly handle multi-word queries
- Use regular expressions to detect whitespace and perform boolean AND queries for multi-word search terms in DFMSearcher

Build:
- Add CMake configure_file step to generate config.h in the file operations plugin