### PR TITLE
chore: bump version to 6.5.52

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.52) unstable; urgency=medium
+
+  * new search
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 21 May 2025 20:01:04 +0800
+
 dde-file-manager (6.5.51) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
6.5.52

Log: 6.5.52

## Summary by Sourcery

Build:
- Update Debian changelog to reflect version 6.5.52