### PR TITLE
chore: remove libtpm2 dependency from dde-file-manager

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.54) unstable; urgency=medium
+
+  * remove libutpm2
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 22 May 2025 15:11:36 +0800
+
 dde-file-manager (6.5.53) unstable; urgency=medium
 
   * fix bugs

--- a/debian/control
+++ b/debian/control
@@ -84,7 +84,6 @@ Depends:
  tpm2-abrmd,
  libtss2-tcti-pcap0,
  libtss2-tcti-tabrmd0,
- libutpm2,
  libusec-recoverykey | hello
 Replaces: dde-file-manager-oem, dde-desktop (<< 6.0.1),
  dde-file-manager-preview,


### PR DESCRIPTION
- Updated changelog to reflect the removal of libtpm2.
- Cleaned up control file by removing libutpm2 from the dependencies.

Log: This commit simplifies the dependency management for dde-file-manager by removing the unnecessary libtpm2 package.

## Summary by Sourcery

Simplify dde-file-manager packaging by removing the libtpm2 dependency and updating the changelog.

Build:
- Remove libtpm2 from dependencies in debian/control
- Update debian/changelog to reflect removal of libtpm2 dependency