### PR TITLE
refactor: remove unused whiteProcess and isValidInvoker methods from …

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -325,6 +325,7 @@ int main(int argc, char *argv[])
     a.setApplicationDisplayName(a.translate("Application", "File Manager"));
     a.setApplicationVersion(BUILD_VERSION);
     a.setProductIcon(QIcon::fromTheme("dde-file-manager"));
+    a.setWindowIcon(QIcon::fromTheme("dde-file-manager"));
     a.setApplicationAcknowledgementPage("https://www.deepin.org/acknowledgments/" + qApp->applicationName());
     a.setApplicationDescription(a.translate("Application", "File Manager is a powerful and "
                                                            "easy-to-use file management tool, "

--- a/src/services/accesscontrol/utils.cpp
+++ b/src/services/accesscontrol/utils.cpp
@@ -19,12 +19,6 @@
 
 SERVICEACCESSCONTROL_USE_NAMESPACE
 
-const QStringList Utils::whiteProcess()
-{
-    static const QStringList processList { "/usr/bin/dmcg", "/usr/bin/dde-file-manager"};
-    return processList;
-}
-
 const QString Utils::devConfigPath()
 {
     static const QString path { "/etc/deepin/devAccessConfig.json" };
@@ -74,15 +68,6 @@ bool Utils::isValidVaultPolicy(const QVariantMap &policy)
     if (policy.value(kPolicyType).toInt() < 0 || policy.value(kVaultHideState).toInt() < 0)
         return false;
     return true;
-}
-
-bool Utils::isValidInvoker(uint pid, QString &invokerPath)
-{
-    QFileInfo f(QString("/proc/%1/exe").arg(pid));
-    if (!f.exists())
-        return false;
-    invokerPath = f.canonicalFilePath();
-    return whiteProcess().contains(invokerPath);
 }
 
 void Utils::saveDevPolicy(const QVariantMap &policy)

--- a/src/services/accesscontrol/utils.h
+++ b/src/services/accesscontrol/utils.h
@@ -44,8 +44,6 @@ using VaultPolicyType = QMap<QString, int>;
 class Utils
 {
 public:
-    static const QStringList whiteProcess();
-
     static const QString devConfigPath();
     static const QString valultConfigPath();
     static int accessMode(const QString &mps);
@@ -53,7 +51,6 @@ public:
 
     static bool isValidDevPolicy(const QVariantMap &policy, const QString &realInvoker);
     static bool isValidVaultPolicy(const QVariantMap &policy);
-    static bool isValidInvoker(uint pid, QString &invokerPath);
 
     static void saveDevPolicy(const QVariantMap &policy);
     static void loadDevPolicy(DevPolicyType *devPolicies);


### PR DESCRIPTION
…Utils

- Deleted the whiteProcess method as it was not utilized in the codebase.
- Removed the isValidInvoker method to streamline the Utils class and eliminate unnecessary complexity.

Log: This commit cleans up the Utils class by removing unused methods, enhancing code maintainability and readability.

## Summary by Sourcery

Remove unused helper methods from the Utils class

Enhancements:
- Delete the unused whiteProcess method
- Remove the obsolete isValidInvoker method