### PR TITLE
fix dconfig bugs

### DIFF
--- a/src/services/textindex/fsmonitor/fseventcontroller.h
+++ b/src/services/textindex/fsmonitor/fseventcontroller.h
@@ -33,6 +33,7 @@ private Q_SLOTS:
     void onFilesDeleted(const QStringList &paths);
     void onFilesModified(const QStringList &paths);
     void onFlushFinished();
+    void onConfigChanged();
 
 private:
     void clearCollections();

--- a/src/services/textindex/private/textindexdbus_p.h
+++ b/src/services/textindex/private/textindexdbus_p.h
@@ -9,6 +9,7 @@
 #include "task/taskmanager.h"
 #include "textindexadaptor.h"
 #include "fsmonitor/fseventcontroller.h"
+#include "utils/textindexconfig.h"
 
 #include <FileUtils.h>
 #include <FilterIndexReader.h>
@@ -47,10 +48,17 @@ public:
     bool canSilentlyRefreshIndex(const QString &path) const;
 
 private:
+    void handleConfigChanged();
+    void initializeSupportedExtensions();
+
+private:
     TextIndexDBus *q { nullptr };
     TextIndexAdaptor *adapter { nullptr };
     TaskManager *taskManager { nullptr };
     FSEventController *fsEventController { nullptr };
+    
+    // Store current supported file extensions for comparison
+    QStringList m_currentSupportedExtensions;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE


### PR DESCRIPTION
## Summary by Sourcery

Add dynamic configuration support for the text indexing service by reacting to TextIndexConfig changes at runtime.

Enhancements:
- Register TextIndexConfig change handlers in TextIndexDBus to update supported file extensions and trigger index updates
- Initialize supported file extensions on startup in TextIndexDBus
- Register TextIndexConfig change handler in FSEventController to adjust event collection interval
- Update FSEventCollector’s collection interval when auto-index update interval changes in configuration