### PR TITLE
Improve performance of full-text index updates after renaming

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.cpp
@@ -177,7 +177,7 @@ void TextIndexClient::startTask(TaskType type, const QStringList &paths)
 bool TextIndexClient::isSupportedTaskType(const QString &type)
 {
     static const QStringList supportedTypes = {
-        "create", "update", "create-file-list", "update-file-list", "remove-file-list"
+        "create", "update", "create-file-list", "update-file-list", "remove-file-list", "move-file-list"
     };
     return supportedTypes.contains(type);
 }
@@ -185,16 +185,17 @@ bool TextIndexClient::isSupportedTaskType(const QString &type)
 TextIndexClient::TaskType TextIndexClient::stringToTaskType(const QString &type)
 {
     static const QMap<QString, TaskType> typeMap = {
-        {"create", TaskType::Create},
-        {"update", TaskType::Update},
-        {"create-file-list", TaskType::CreateFileList},
-        {"update-file-list", TaskType::UpdateFileList},
-        {"remove-file-list", TaskType::RemoveFileList}
+        { "create", TaskType::Create },
+        { "update", TaskType::Update },
+        { "create-file-list", TaskType::CreateFileList },
+        { "update-file-list", TaskType::UpdateFileList },
+        { "remove-file-list", TaskType::RemoveFileList },
+        { "move-file-list", TaskType::MoveFileList }
     };
-    
+
     if (!typeMap.contains(type)) {
         fmWarning() << "Unknown task type string:" << type;
-        return TaskType::Create; // 默认返回类型
+        return TaskType::Create;   // 默认返回类型
     }
     return typeMap.value(type);
 }
@@ -204,9 +205,9 @@ void TextIndexClient::onDBusTaskFinished(const QString &type, const QString &pat
     // 检查是否为支持的类型
     if (!isSupportedTaskType(type))
         return;
-    
+
     TaskType taskType = stringToTaskType(type);
-    
+
     if (success) {
         emit taskFinished(taskType, path, true);
     } else {
@@ -219,7 +220,7 @@ void TextIndexClient::onDBusTaskProgressChanged(const QString &type, const QStri
     // 检查是否为支持的类型
     if (!isSupportedTaskType(type))
         return;
-    
+
     TaskType taskType = stringToTaskType(type);
     emit taskProgressChanged(taskType, path, count, total);
 }

--- a/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/textindexclient.h
@@ -25,7 +25,8 @@ public:
         Update,
         CreateFileList,
         UpdateFileList,
-        RemoveFileList
+        RemoveFileList,
+        MoveFileList,
     };
     Q_ENUM(TaskType)
 
@@ -81,10 +82,10 @@ private:
     void handleIndexExistsReply(QDBusPendingCallWatcher *watcher);
     void handleServiceTestReply(QDBusPendingCallWatcher *watcher);
     void handleGetLastUpdateTimeReply(QDBusPendingCallWatcher *watcher);
-    
+
     // 工具方法：将字符串转换为TaskType
     TaskType stringToTaskType(const QString &type);
-    
+
     // 工具方法：检查任务类型是否支持
     bool isSupportedTaskType(const QString &type);
 

--- a/src/services/textindex/fsmonitor/fseventcollector.h
+++ b/src/services/textindex/fsmonitor/fseventcollector.h
@@ -77,18 +77,28 @@ public:
     QStringList createdFiles() const;
     QStringList deletedFiles() const;
     QStringList modifiedFiles() const;
+    
+    // Get current moved files mapping (fromPath -> toPath)
+    QHash<QString, QString> movedFiles() const;
 
     // Get current count of collected events
     int createdFilesCount() const;
     int deletedFilesCount() const;
     int modifiedFilesCount() const;
     int totalEventsCount() const;
+    
+    // Get count of moved files
+    int movedFilesCount() const;
 
 Q_SIGNALS:
     // Emitted when collection interval expires with batched events
     void filesCreated(const QStringList &paths);
     void filesDeleted(const QStringList &paths);
     void filesModified(const QStringList &paths);
+    
+    // Emitted when files/directories are moved/renamed (fromPath -> toPath mapping)
+    void filesMoved(const QHash<QString, QString> &movedPaths);
+    
     void flushFinished();
 
     // Emitted when maximum event count is reached

--- a/src/services/textindex/fsmonitor/fseventcollector_p.h
+++ b/src/services/textindex/fsmonitor/fseventcollector_p.h
@@ -10,6 +10,7 @@
 #include <QTimer>
 #include <QSet>
 #include <QDateTime>
+#include <QHash>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
@@ -106,6 +107,9 @@ public:
     QSet<QString> createdFilesList;
     QSet<QString> deletedFilesList;
     QSet<QString> modifiedFilesList;
+    
+    // New: Track moved/renamed files separately for efficient index updates
+    QHash<QString, QString> movedFilesList; // fromPath -> toPath mapping
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/fsmonitor/fseventcontroller.cpp
+++ b/src/services/textindex/fsmonitor/fseventcontroller.cpp
@@ -192,7 +192,7 @@ void FSEventController::onFilesMoved(const QHash<QString, QString> &movedPaths)
     }
 
     fmInfo() << "FS event: Files moved -" << movedPaths.size() << "items";
-    
+
     // Merge the moved paths into our collection
     for (auto it = movedPaths.constBegin(); it != movedPaths.constEnd(); ++it) {
         m_collectedMovedFiles.insert(it.key(), it.value());
@@ -208,8 +208,8 @@ void FSEventController::onFlushFinished()
     fmInfo() << "FS event: Flush finished, processing events";
 
     // Check if we have any events to process
-    if (m_collectedCreatedFiles.isEmpty() && m_collectedModifiedFiles.isEmpty() && 
-        m_collectedDeletedFiles.isEmpty() && m_collectedMovedFiles.isEmpty()) {
+    if (m_collectedCreatedFiles.isEmpty() && m_collectedModifiedFiles.isEmpty()
+        && m_collectedDeletedFiles.isEmpty() && m_collectedMovedFiles.isEmpty()) {
         fmInfo() << "No file system events to process";
         return;
     }
@@ -219,14 +219,14 @@ void FSEventController::onFlushFinished()
              << "Deleted:" << m_collectedDeletedFiles.size()
              << "Moved:" << m_collectedMovedFiles.size();
 
-    // Process regular file changes (create, modify, delete)
-    if (!m_collectedCreatedFiles.isEmpty() || !m_collectedModifiedFiles.isEmpty() || !m_collectedDeletedFiles.isEmpty()) {
-        emit requestProcessFileChanges(m_collectedCreatedFiles, m_collectedModifiedFiles, m_collectedDeletedFiles);
-    }
-    
     // Process file moves separately for optimization
     if (!m_collectedMovedFiles.isEmpty()) {
         emit requestProcessFileMoves(m_collectedMovedFiles);
+    }
+
+    // Process regular file changes (create, modify, delete)
+    if (!m_collectedCreatedFiles.isEmpty() || !m_collectedModifiedFiles.isEmpty() || !m_collectedDeletedFiles.isEmpty()) {
+        emit requestProcessFileChanges(m_collectedCreatedFiles, m_collectedModifiedFiles, m_collectedDeletedFiles);
     }
 
     clearCollections();
@@ -243,17 +243,17 @@ void FSEventController::clearCollections()
 void FSEventController::onConfigChanged()
 {
     const int newIntervalSecs = TextIndexConfig::instance().autoIndexUpdateInterval();
-    
+
     if (newIntervalSecs != m_collectorIntervalSecs) {
-        fmInfo() << "FSEventController: Collection interval changed from" 
+        fmInfo() << "FSEventController: Collection interval changed from"
                  << m_collectorIntervalSecs << "to" << newIntervalSecs << "seconds";
-        
+
         m_collectorIntervalSecs = newIntervalSecs;
-        
+
         // Update the collector's interval if it exists
         if (m_fsEventCollector) {
             m_fsEventCollector->setCollectionInterval(m_collectorIntervalSecs);
-            fmInfo() << "FSEventController: Updated FSEventCollector collection interval to" 
+            fmInfo() << "FSEventController: Updated FSEventCollector collection interval to"
                      << m_collectorIntervalSecs << "seconds";
         }
     }

--- a/src/services/textindex/fsmonitor/fseventcontroller.h
+++ b/src/services/textindex/fsmonitor/fseventcontroller.h
@@ -32,6 +32,7 @@ private Q_SLOTS:
     void onFilesCreated(const QStringList &paths);
     void onFilesDeleted(const QStringList &paths);
     void onFilesModified(const QStringList &paths);
+    void onFilesMoved(const QHash<QString, QString> &movedPaths);
     void onFlushFinished();
     void onConfigChanged();
 
@@ -42,6 +43,9 @@ Q_SIGNALS:
     void requestProcessFileChanges(const QStringList &createdFiles,
                                    const QStringList &modifiedFiles,
                                    const QStringList &deletedFiles);
+    
+    void requestProcessFileMoves(const QHash<QString, QString> &movedFiles);
+    
     void monitoring(bool start);
     void requestSlientStart();
 
@@ -58,6 +62,7 @@ private:
     QStringList m_collectedCreatedFiles;
     QStringList m_collectedDeletedFiles;
     QStringList m_collectedModifiedFiles;
+    QHash<QString, QString> m_collectedMovedFiles;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -511,8 +511,10 @@ void FSMonitorPrivate::handleFileDeleted(const QString &path, const QString &nam
         watchedDirectories.remove(fullPath);
     } else {
         // Regular file deleted
-        logDebug(QString("File deleted: %1/%2").arg(path, name));
-        Q_EMIT q_ptr->fileDeleted(path, name);
+        if (!name.isEmpty()) {
+            logDebug(QString("File deleted: %1/%2").arg(path, name));
+            Q_EMIT q_ptr->fileDeleted(path, name);
+        }
     }
 }
 

--- a/src/services/textindex/task/indextask.h
+++ b/src/services/textindex/task/indextask.h
@@ -23,7 +23,8 @@ public:
         Update,   // 更新索引
         CreateFileList,   // 基于文件列表创建索引
         UpdateFileList,   // 基于文件列表更新索引
-        RemoveFileList   // 基于文件列表删除索引
+        RemoveFileList,   // 基于文件列表删除索引
+        MoveFileList   // 基于文件移动列表更新索引路径
     };
     Q_ENUM(Type)
 

--- a/src/services/textindex/task/moveprocessor.cpp
+++ b/src/services/textindex/task/moveprocessor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,7 +28,7 @@ bool FileMoveProcessor::processFileMove(const QString &fromPath, const QString &
         TopDocsPtr searchResult = m_searcher->search(pathQuery, 1);
         if (!searchResult || searchResult->totalHits == 0) {
             fmDebug() << "File not found in index, skipping:" << fromPath;
-            return true; // Not an error, file might not be indexed
+            return true;   // Not an error, file might not be indexed
         }
 
         DocumentPtr doc = m_searcher->doc(searchResult->scoreDocs[0]->doc);
@@ -65,9 +65,9 @@ bool FileMoveProcessor::processFileMove(const QString &fromPath, const QString &
 }
 
 // DirectoryMoveProcessor implementation
-DirectoryMoveProcessor::DirectoryMoveProcessor(const SearcherPtr &searcher, 
-                                             const IndexWriterPtr &writer, 
-                                             const IndexReaderPtr &reader)
+DirectoryMoveProcessor::DirectoryMoveProcessor(const SearcherPtr &searcher,
+                                               const IndexWriterPtr &writer,
+                                               const IndexReaderPtr &reader)
     : m_searcher(searcher), m_writer(writer), m_reader(reader)
 {
 }
@@ -86,7 +86,7 @@ bool DirectoryMoveProcessor::processDirectoryMove(const QString &fromPath, const
         TopDocsPtr allDocs = m_searcher->search(prefixQuery, m_reader->maxDoc());
         if (!allDocs || allDocs->totalHits == 0) {
             fmDebug() << "No documents found for directory move:" << fromPath;
-            return true; // Not an error, directory might be empty or not indexed
+            return true;   // Not an error, directory might be empty or not indexed
         }
 
         fmInfo() << "Found" << allDocs->totalHits << "documents to update for directory move:" << fromPath;
@@ -94,7 +94,7 @@ bool DirectoryMoveProcessor::processDirectoryMove(const QString &fromPath, const
         // Batch update all matching documents
         for (int32_t i = 0; i < allDocs->totalHits; ++i) {
             if (!running.isRunning()) {
-                return false; // Interrupted
+                return false;   // Interrupted
             }
 
             if (!allDocs->scoreDocs || !allDocs->scoreDocs[i]) {
@@ -123,9 +123,9 @@ bool DirectoryMoveProcessor::processDirectoryMove(const QString &fromPath, const
     }
 }
 
-bool DirectoryMoveProcessor::updateSingleDocumentPath(const DocumentPtr &doc, 
-                                                     const QString &normalizedFromPath, 
-                                                     const QString &toPath)
+bool DirectoryMoveProcessor::updateSingleDocumentPath(const DocumentPtr &doc,
+                                                      const QString &normalizedFromPath,
+                                                      const QString &toPath)
 {
     try {
         String oldPathValue = doc->get(L"path");
@@ -133,9 +133,9 @@ bool DirectoryMoveProcessor::updateSingleDocumentPath(const DocumentPtr &doc,
 
         // Calculate new path
         QString newPath = PathCalculator::calculateNewPathForDirectoryMove(oldPath, normalizedFromPath, toPath);
-        
+
         if (newPath == oldPath) {
-            return true; // No change needed
+            return true;   // No change needed
         }
 
         // Create new document with updated path
@@ -158,4 +158,4 @@ bool DirectoryMoveProcessor::updateSingleDocumentPath(const DocumentPtr &doc,
         fmWarning() << "Failed to update single document path:" << e.what();
         return false;
     }
-} 
+}

--- a/src/services/textindex/task/moveprocessor.cpp
+++ b/src/services/textindex/task/moveprocessor.cpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "moveprocessor.h"
+#include "utils/docutils.h"
+#include "utils/indexutility.h"
+
+#include <QFileInfo>
+
+SERVICETEXTINDEX_USE_NAMESPACE
+using namespace Lucene;
+
+// FileMoveProcessor implementation
+FileMoveProcessor::FileMoveProcessor(const SearcherPtr &searcher, const IndexWriterPtr &writer)
+    : m_searcher(searcher), m_writer(writer)
+{
+}
+
+bool FileMoveProcessor::processFileMove(const QString &fromPath, const QString &toPath)
+{
+    try {
+        fmDebug() << "Processing file move:" << fromPath << "->" << toPath;
+
+        TermQueryPtr pathQuery = newLucene<TermQuery>(
+                newLucene<Term>(L"path", fromPath.toStdWString()));
+
+        TopDocsPtr searchResult = m_searcher->search(pathQuery, 1);
+        if (!searchResult || searchResult->totalHits == 0) {
+            fmDebug() << "File not found in index, skipping:" << fromPath;
+            return true; // Not an error, file might not be indexed
+        }
+
+        DocumentPtr doc = m_searcher->doc(searchResult->scoreDocs[0]->doc);
+        if (!doc) {
+            fmWarning() << "Failed to retrieve document for:" << fromPath;
+            return false;
+        }
+
+        // Create new document with updated path
+        DocumentPtr newDoc = DocUtils::copyFieldsExcept(doc, L"path");
+        if (!newDoc) {
+            fmWarning() << "Failed to copy document fields for:" << fromPath;
+            return false;
+        }
+
+        // Add new path field
+        newDoc->add(newLucene<Field>(L"path", toPath.toStdWString(),
+                                     Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
+
+        // Update document in index
+        TermPtr oldTerm = newLucene<Term>(L"path", fromPath.toStdWString());
+        m_writer->updateDocument(oldTerm, newDoc);
+
+        fmDebug() << "Updated file document path:" << fromPath << "->" << toPath;
+        return true;
+    } catch (const LuceneException &e) {
+        fmWarning() << "File move processing failed with Lucene exception:" << fromPath
+                    << QString::fromStdWString(e.getError());
+        return false;
+    } catch (const std::exception &e) {
+        fmWarning() << "File move processing failed:" << fromPath << e.what();
+        return false;
+    }
+}
+
+// DirectoryMoveProcessor implementation
+DirectoryMoveProcessor::DirectoryMoveProcessor(const SearcherPtr &searcher, 
+                                             const IndexWriterPtr &writer, 
+                                             const IndexReaderPtr &reader)
+    : m_searcher(searcher), m_writer(writer), m_reader(reader)
+{
+}
+
+bool DirectoryMoveProcessor::processDirectoryMove(const QString &fromPath, const QString &toPath, TaskState &running)
+{
+    try {
+        fmDebug() << "Processing directory move:" << fromPath << "->" << toPath;
+
+        QString normalizedFromPath = PathCalculator::normalizeDirectoryPath(fromPath);
+
+        // Create prefix query to find all documents under this directory
+        PrefixQueryPtr prefixQuery = newLucene<PrefixQuery>(
+                newLucene<Term>(L"path", normalizedFromPath.toStdWString()));
+
+        TopDocsPtr allDocs = m_searcher->search(prefixQuery, m_reader->maxDoc());
+        if (!allDocs || allDocs->totalHits == 0) {
+            fmDebug() << "No documents found for directory move:" << fromPath;
+            return true; // Not an error, directory might be empty or not indexed
+        }
+
+        fmInfo() << "Found" << allDocs->totalHits << "documents to update for directory move:" << fromPath;
+
+        // Batch update all matching documents
+        for (int32_t i = 0; i < allDocs->totalHits; ++i) {
+            if (!running.isRunning()) {
+                return false; // Interrupted
+            }
+
+            if (!allDocs->scoreDocs || !allDocs->scoreDocs[i]) {
+                continue;
+            }
+
+            DocumentPtr doc = m_searcher->doc(allDocs->scoreDocs[i]->doc);
+            if (!doc) {
+                continue;
+            }
+
+            if (!updateSingleDocumentPath(doc, normalizedFromPath, toPath)) {
+                fmWarning() << "Failed to update document in directory move";
+                // Continue with other documents
+            }
+        }
+
+        return true;
+    } catch (const LuceneException &e) {
+        fmWarning() << "Directory move processing failed with Lucene exception:" << fromPath
+                    << QString::fromStdWString(e.getError());
+        return false;
+    } catch (const std::exception &e) {
+        fmWarning() << "Directory move processing failed:" << fromPath << e.what();
+        return false;
+    }
+}
+
+bool DirectoryMoveProcessor::updateSingleDocumentPath(const DocumentPtr &doc, 
+                                                     const QString &normalizedFromPath, 
+                                                     const QString &toPath)
+{
+    try {
+        String oldPathValue = doc->get(L"path");
+        QString oldPath = QString::fromStdWString(oldPathValue);
+
+        // Calculate new path
+        QString newPath = PathCalculator::calculateNewPathForDirectoryMove(oldPath, normalizedFromPath, toPath);
+        
+        if (newPath == oldPath) {
+            return true; // No change needed
+        }
+
+        // Create new document with updated path
+        DocumentPtr newDoc = DocUtils::copyFieldsExcept(doc, L"path");
+        if (!newDoc) {
+            return false;
+        }
+
+        // Add new path field
+        newDoc->add(newLucene<Field>(L"path", newPath.toStdWString(),
+                                     Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
+
+        // Update document in index
+        TermPtr oldTerm = newLucene<Term>(L"path", oldPathValue);
+        m_writer->updateDocument(oldTerm, newDoc);
+
+        fmDebug() << "Updated document path:" << oldPath << "->" << newPath;
+        return true;
+    } catch (const std::exception &e) {
+        fmWarning() << "Failed to update single document path:" << e.what();
+        return false;
+    }
+} 

--- a/src/services/textindex/task/moveprocessor.h
+++ b/src/services/textindex/task/moveprocessor.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MOVEPROCESSOR_H
+#define MOVEPROCESSOR_H
+
+#include "service_textindex_global.h"
+#include "utils/taskstate.h"
+
+#include <lucene++/LuceneHeaders.h>
+#include <QString>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+/**
+ * @brief Processor for handling single file move operations in index
+ */
+class FileMoveProcessor
+{
+public:
+    FileMoveProcessor(const Lucene::SearcherPtr &searcher, const Lucene::IndexWriterPtr &writer);
+
+    /**
+     * @brief Process single file move operation
+     * @param fromPath Source file path
+     * @param toPath Target file path
+     * @return true if processed successfully, false otherwise
+     */
+    bool processFileMove(const QString &fromPath, const QString &toPath);
+
+private:
+    Lucene::SearcherPtr m_searcher;
+    Lucene::IndexWriterPtr m_writer;
+};
+
+/**
+ * @brief Processor for handling directory move operations in index
+ */
+class DirectoryMoveProcessor
+{
+public:
+    DirectoryMoveProcessor(const Lucene::SearcherPtr &searcher, 
+                          const Lucene::IndexWriterPtr &writer, 
+                          const Lucene::IndexReaderPtr &reader);
+
+    /**
+     * @brief Process directory move operation using prefix query
+     * @param fromPath Source directory path
+     * @param toPath Target directory path
+     * @param running Task state for interruption checking
+     * @return true if processed successfully, false if interrupted or failed
+     */
+    bool processDirectoryMove(const QString &fromPath, const QString &toPath, TaskState &running);
+
+private:
+    /**
+     * @brief Update single document path within directory move
+     * @param doc Document to update
+     * @param normalizedFromPath Normalized source directory path
+     * @param toPath Target directory path
+     * @return true if updated successfully, false otherwise
+     */
+    bool updateSingleDocumentPath(const Lucene::DocumentPtr &doc, 
+                                 const QString &normalizedFromPath, 
+                                 const QString &toPath);
+
+    Lucene::SearcherPtr m_searcher;
+    Lucene::IndexWriterPtr m_writer;
+    Lucene::IndexReaderPtr m_reader;
+};
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif // MOVEPROCESSOR_H 

--- a/src/services/textindex/task/taskhandler.cpp
+++ b/src/services/textindex/task/taskhandler.cpp
@@ -5,6 +5,7 @@
 #include "taskhandler.h"
 #include "fileprovider.h"
 #include "progressnotifier.h"
+#include "moveprocessor.h"
 #include "utils/scopeguard.h"
 #include "utils/docutils.h"
 #include "utils/indexutility.h"
@@ -882,6 +883,11 @@ TaskHandler TaskHandlers::MoveFileListHandler(const QHash<QString, QString> &mov
 
             SearcherPtr searcher = newLucene<IndexSearcher>(reader);
 
+            // Create processors for different move types using the new separate classes
+            FileMoveProcessor fileMoveProcessor(searcher, writer);
+            DirectoryMoveProcessor directoryMoveProcessor(searcher, writer, reader);
+
+            // Process each move operation
             for (auto it = movedFiles.constBegin(); it != movedFiles.constEnd(); ++it) {
                 if (!running.isRunning()) {
                     result.interrupted = true;
@@ -891,128 +897,16 @@ TaskHandler TaskHandlers::MoveFileListHandler(const QHash<QString, QString> &mov
                 const QString &fromPath = it.key();
                 const QString &toPath = it.value();
 
-                // 检查是否是目录移动（通过检查是否存在子路径）
-                bool isDirectoryMove = false;
-                QFileInfo toFileInfo(toPath);
-                if (toFileInfo.exists() && toFileInfo.isDir()) {
-                    isDirectoryMove = true;
+                bool success = false;
+                if (PathCalculator::isDirectoryMove(toPath)) {
+                    success = directoryMoveProcessor.processDirectoryMove(fromPath, toPath, running);
+                } else {
+                    success = fileMoveProcessor.processFileMove(fromPath, toPath);
                 }
 
-                if (isDirectoryMove) {
-                    // 目录移动：使用前缀查询找到所有子文件并批量更新
-                    fmDebug() << "Processing directory move:" << fromPath << "->" << toPath;
-
-                    QString normalizedFromPath = fromPath;
-                    if (!normalizedFromPath.endsWith('/')) {
-                        normalizedFromPath += '/';
-                    }
-
-                    // 创建前缀查询，查找所有以该目录路径开头的文档
-                    PrefixQueryPtr prefixQuery = newLucene<PrefixQuery>(
-                            newLucene<Term>(L"path", normalizedFromPath.toStdWString()));
-
-                    TopDocsPtr allDocs = searcher->search(prefixQuery, reader->maxDoc());
-                    if (allDocs && allDocs->totalHits > 0) {
-                        fmInfo() << "Found" << allDocs->totalHits << "documents to update for directory move:" << fromPath;
-
-                        // 批量更新所有匹配的文档
-                        for (int32_t i = 0; i < allDocs->totalHits; ++i) {
-                            if (!running.isRunning()) {
-                                result.interrupted = true;
-                                break;
-                            }
-
-                            if (!allDocs->scoreDocs || !allDocs->scoreDocs[i]) {
-                                continue;
-                            }
-
-                            DocumentPtr doc = searcher->doc(allDocs->scoreDocs[i]->doc);
-                            if (!doc) {
-                                continue;
-                            }
-
-                            String oldPathValue = doc->get(L"path");
-                            QString oldPath = QString::fromStdWString(oldPathValue);
-
-                            // 计算新路径
-                            QString newPath = oldPath;
-                            if (oldPath.startsWith(normalizedFromPath)) {
-                                newPath = toPath + "/" + oldPath.mid(normalizedFromPath.length());
-                            } else if (oldPath == fromPath) {
-                                newPath = toPath;
-                            }
-
-                            if (newPath != oldPath) {
-                                // 创建新文档，复制所有字段但更新路径
-                                DocumentPtr newDoc = newLucene<Document>();
-                                
-                                // 复制除路径外的所有字段
-                                Collection<FieldablePtr> fields = doc->getFields();
-                                for (Collection<FieldablePtr>::iterator fieldIt = fields.begin(); fieldIt != fields.end(); ++fieldIt) {
-                                    FieldablePtr fieldable = *fieldIt;
-                                    String fieldName = fieldable->name();
-                                    
-                                    if (fieldName != L"path") {
-                                        // 复制其他字段
-                                        newDoc->add(newLucene<Field>(fieldName, fieldable->stringValue(),
-                                                                   fieldable->isStored() ? Field::STORE_YES : Field::STORE_NO,
-                                                                   fieldable->isIndexed() ? (fieldable->isTokenized() ? Field::INDEX_ANALYZED : Field::INDEX_NOT_ANALYZED) : Field::INDEX_NO));
-                                    }
-                                }
-
-                                // 添加新的路径字段
-                                newDoc->add(newLucene<Field>(L"path", newPath.toStdWString(),
-                                                             Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
-
-                                // 删除旧文档并添加新文档
-                                TermPtr oldTerm = newLucene<Term>(L"path", oldPathValue);
-                                writer->updateDocument(oldTerm, newDoc);
-
-                                fmDebug() << "Updated document path:" << oldPath << "->" << newPath;
-                            }
-                        }
-                    }
-                } else {
-                    // 文件移动：直接更新单个文档
-                    fmDebug() << "Processing file move:" << fromPath << "->" << toPath;
-
-                    TermQueryPtr pathQuery = newLucene<TermQuery>(
-                            newLucene<Term>(L"path", fromPath.toStdWString()));
-
-                    TopDocsPtr result = searcher->search(pathQuery, 1);
-                    if (result && result->totalHits > 0) {
-                        DocumentPtr doc = searcher->doc(result->scoreDocs[0]->doc);
-                        if (doc) {
-                            // 创建新文档，复制所有字段但更新路径
-                            DocumentPtr newDoc = newLucene<Document>();
-                            
-                            // 复制除路径外的所有字段
-                            Collection<FieldablePtr> fields = doc->getFields();
-                            for (Collection<FieldablePtr>::iterator fieldIt = fields.begin(); fieldIt != fields.end(); ++fieldIt) {
-                                FieldablePtr fieldable = *fieldIt;
-                                String fieldName = fieldable->name();
-                                
-                                if (fieldName != L"path") {
-                                    // 复制其他字段
-                                    newDoc->add(newLucene<Field>(fieldName, fieldable->stringValue(),
-                                                               fieldable->isStored() ? Field::STORE_YES : Field::STORE_NO,
-                                                               fieldable->isIndexed() ? (fieldable->isTokenized() ? Field::INDEX_ANALYZED : Field::INDEX_NOT_ANALYZED) : Field::INDEX_NO));
-                                }
-                            }
-
-                            // 添加新的路径字段
-                            newDoc->add(newLucene<Field>(L"path", toPath.toStdWString(),
-                                                         Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
-
-                            // 更新文档
-                            TermPtr oldTerm = newLucene<Term>(L"path", fromPath.toStdWString());
-                            writer->updateDocument(oldTerm, newDoc);
-
-                            fmDebug() << "Updated file document path:" << fromPath << "->" << toPath;
-                        }
-                    } else {
-                        fmDebug() << "File not found in index, skipping:" << fromPath;
-                    }
+                if (!success && !running.isRunning()) {
+                    result.interrupted = true;
+                    break;
                 }
 
                 reporter.increment();

--- a/src/services/textindex/task/taskhandler.h
+++ b/src/services/textindex/task/taskhandler.h
@@ -39,6 +39,7 @@ TaskHandler RemoveFileListHandler(const QStringList &fileList);   // 待实现�
 // 创建文件提供者
 std::unique_ptr<FileProvider> createFileProvider(const QString &path);
 std::unique_ptr<FileProvider> createFileListProvider(const QStringList &fileList);
+TaskHandler MoveFileListHandler(const QHash<QString, QString> &movedFiles);
 }
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/task/taskmanager.h
+++ b/src/services/textindex/task/taskmanager.h
@@ -21,6 +21,7 @@ struct TaskQueueItem
     QString path;
     QStringList pathList;   // 当传入多个路径时使用
     QStringList fileList;   // 仅在文件列表类型任务中使用
+    QHash<QString, QString> movedFiles;  // 仅在移动任务中使用 (fromPath -> toPath)
     bool silent { false };
 };
 
@@ -35,6 +36,8 @@ public:
     bool startTask(IndexTask::Type type, const QString &path, bool silent = false);
 
     bool startFileListTask(IndexTask::Type type, const QStringList &fileList, bool silent = false);
+
+    bool startFileMoveTask(const QHash<QString, QString> &movedFiles, bool silent = false);
 
     bool hasRunningTask() const;
     void stopCurrentTask();

--- a/src/services/textindex/textindexdbus.cpp
+++ b/src/services/textindex/textindexdbus.cpp
@@ -44,6 +44,8 @@ void TextIndexDBusPrivate::initConnect()
 
     QObject::connect(fsEventController, &FSEventController::requestProcessFileChanges,
                      q, &TextIndexDBus::ProcessFileChanges);
+    QObject::connect(fsEventController, &FSEventController::requestProcessFileMoves,
+                     q, &TextIndexDBus::ProcessFileMoves);
     QObject::connect(fsEventController, &FSEventController::monitoring,
                      q, [this](bool start) {
                          handleMonitoring(start);
@@ -228,6 +230,21 @@ bool TextIndexDBus::ProcessFileChanges(const QStringList &createdFiles,
     }
 
     return tasksQueued;
+}
+
+bool TextIndexDBus::ProcessFileMoves(const QHash<QString, QString> &movedFiles)
+{
+    if (movedFiles.isEmpty()) {
+        fmInfo() << "No file moves to process";
+        return false;
+    }
+
+    fmInfo() << "Processing" << movedFiles.size() << "moved files";
+    
+    // 启动文件移动任务
+    bool taskQueued = d->taskManager->startFileMoveTask(movedFiles, true);
+    
+    return taskQueued;
 }
 
 void TextIndexDBusPrivate::initializeSupportedExtensions()

--- a/src/services/textindex/textindexdbus.h
+++ b/src/services/textindex/textindexdbus.h
@@ -10,6 +10,7 @@
 #include <QObject>
 #include <QDBusContext>
 #include <QStringList>
+#include <QHash>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 class TextIndexDBusPrivate;
@@ -37,6 +38,7 @@ public Q_SLOTS:
     bool IndexDatabaseExists();
     QString GetLastUpdateTime();
     bool ProcessFileChanges(const QStringList &createdFiles, const QStringList &modifiedFiles, const QStringList &deletedFiles);
+    bool ProcessFileMoves(const QHash<QString, QString> &movedFiles);
 
 Q_SIGNALS:
     void TaskFinished(const QString &type, const QString &path, bool success);

--- a/src/services/textindex/utils/docutils.h
+++ b/src/services/textindex/utils/docutils.h
@@ -11,6 +11,8 @@
 
 #include <optional>
 
+#include <lucene++/LuceneHeaders.h>
+
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
 class DTextEncoding;
@@ -70,6 +72,15 @@ std::optional<QString> extractHtmlContent(const QString &filePath);
  * @return Encoding name (detected for text files, UTF-8 for non-text files)
  */
 QString getFileEncoding(const QString &filePath);
+
+/**
+ * @brief Copy all fields from source document except the specified excluded field
+ * @param sourceDoc Source document to copy from
+ * @param excludeFieldName Field name to exclude from copying
+ * @return New document with copied fields
+ */
+Lucene::DocumentPtr copyFieldsExcept(const Lucene::DocumentPtr &sourceDoc, 
+                                    const Lucene::String &excludeFieldName);
 
 }   // namespace DocUtils
 

--- a/src/services/textindex/utils/indexutility.cpp
+++ b/src/services/textindex/utils/indexutility.cpp
@@ -165,4 +165,35 @@ bool isCompatibleVersion()
 
 }   // namespace IndexUtility
 
+namespace PathCalculator {
+
+QString calculateNewPathForDirectoryMove(const QString &oldPath, 
+                                       const QString &fromDirPath, 
+                                       const QString &toDirPath)
+{
+    if (oldPath.startsWith(fromDirPath)) {
+        return toDirPath + "/" + oldPath.mid(fromDirPath.length());
+    } else if (oldPath == fromDirPath.chopped(1)) { // Remove trailing slash for comparison
+        return toDirPath;
+    }
+    return oldPath; // No change needed
+}
+
+QString normalizeDirectoryPath(const QString &dirPath)
+{
+    QString normalized = dirPath;
+    if (!normalized.endsWith('/')) {
+        normalized += '/';
+    }
+    return normalized;
+}
+
+bool isDirectoryMove(const QString &toPath)
+{
+    QFileInfo toFileInfo(toPath);
+    return toFileInfo.exists() && toFileInfo.isDir();
+}
+
+}   // namespace PathCalculator
+
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/utils/indexutility.h
+++ b/src/services/textindex/utils/indexutility.h
@@ -25,6 +25,35 @@ void saveIndexStatus(const QDateTime &lastUpdateTime, int version);
 
 }   // namespace IndexUtility
 
+namespace PathCalculator {
+
+/**
+ * @brief Calculate new path for directory move operation
+ * @param oldPath Original file path
+ * @param fromDirPath Source directory path (normalized with trailing slash)
+ * @param toDirPath Target directory path
+ * @return New calculated path
+ */
+QString calculateNewPathForDirectoryMove(const QString &oldPath, 
+                                       const QString &fromDirPath, 
+                                       const QString &toDirPath);
+
+/**
+ * @brief Normalize directory path by ensuring it ends with '/'
+ * @param dirPath Directory path to normalize
+ * @return Normalized directory path
+ */
+QString normalizeDirectoryPath(const QString &dirPath);
+
+/**
+ * @brief Detect if the move operation is a directory move
+ * @param toPath Target path to check
+ * @return true if it's a directory move, false for file move
+ */
+bool isDirectoryMove(const QString &toPath);
+
+}   // namespace PathCalculator
+
 SERVICETEXTINDEX_END_NAMESPACE
 
 #endif   // INDEXUTILITY_H


### PR DESCRIPTION
## Summary by Sourcery

Add dedicated support for tracking and processing file and directory move operations to dramatically speed up index updates on renames by updating paths in-place rather than reindexing content.

New Features:
- Support a new ‘move-file-list’ index task type with corresponding TaskHandler to update index entries for moved files and directories
- Enhance FS event collector and controller to track and emit ‘filesMoved’ events separately
- Expose ProcessFileMoves over DBus and integrate move handling into the TextIndex client plugin
- Introduce PathCalculator utilities for directory move path calculation and DocUtils::copyFieldsExcept helper for document cloning

Enhancements:
- Optimize index updates on rename by applying targeted field updates via FileMoveProcessor and DirectoryMoveProcessor instead of full delete-and-create
- Extend TaskManager to queue and execute file move tasks alongside existing create/update/remove tasks
- Separate file move processing in event controller for clearer event handling flow