### PR TITLE
feat: add PPTX thumbnail support in ThumbnailCreators

### DIFF
--- a/assets/mimetypes/text.mimetype
+++ b/assets/mimetypes/text.mimetype
@@ -31,6 +31,7 @@ application/vnd.ms-htmlhelp
 application/x-zerosize
 application/vnd.openxmlformats-officedocument.wordprocessingml.document
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+application/vnd.openxmlformats-officedocument.presentationml.presentation
 application/vnd.oasis.opendocument.text
 application/vnd.oasis.opendocument.presentation
 application/vnd.oasis.opendocument.spreadsheet

--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -140,6 +140,7 @@ inline constexpr char kTypeCdImage[] { "application/x-cd-image" };
 inline constexpr char kTypeISO9660Image[] { "application/x-iso9660-image" };
 inline constexpr char kTypeAppXml[] { "application/xml" };
 inline constexpr char kTypeAppPdf[] { "application/pdf" };
+inline constexpr char kTypeAppPptx[] { "application/vnd.openxmlformats-officedocument.presentationml.presentation" };
 inline constexpr char kTypeAppMxf[] { "application/mxf" };
 inline constexpr char kTypeAppVMAsf[] { "application/vnd.ms-asf" };
 inline constexpr char kTypeAppCRRMedia[] { "application/cnd.rn-realmedia" };

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.h
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.h
@@ -21,6 +21,7 @@ QImage imageThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::Thumb
 QImage djvuThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage pdfThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage appimageThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
+QImage pptxThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 }   // namespace ThumbnailCreators
 }   // namespace dfmbase
 

--- a/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
@@ -33,6 +33,7 @@ ThumbnailFactory::ThumbnailFactory(QObject *parent)
     registerThumbnailCreator("audio/*", ThumbnailCreators::audioThumbnailCreator);
     registerThumbnailCreator("video/*", ThumbnailCreators::videoThumbnailCreator);
     registerThumbnailCreator(Mime::kTypeAppAppimage, ThumbnailCreators::appimageThumbnailCreator);
+    registerThumbnailCreator(Mime::kTypeAppPptx, ThumbnailCreators::pptxThumbnailCreator);
 
     init();
 }

--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -41,8 +41,9 @@ void ThumbnailHelper::initSizeLimit()
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAppVRRMedia), INT64_MAX);
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAppVMAsf), INT64_MAX);
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAppMxf), INT64_MAX);
+    sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAppPptx), INT64_MAX);
 
-    //images
+    // images
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeImageIef), 1024 * 1024 * 80);
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeImageTiff), 1024 * 1024 * 80);
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeImageXTMultipage), 1024 * 1024 * 80);
@@ -111,7 +112,8 @@ bool ThumbnailHelper::checkMimeTypeSupport(const QMimeType &mime)
 
     if (Q_LIKELY(mimeList.contains(Mime::kTypeAppPdf)
                  || mimeName == Mime::kTypeAppCRRMedia
-                 || mimeName == Mime::kTypeAppMxf))
+                 || mimeName == Mime::kTypeAppMxf)
+        || mimeName == Mime::kTypeAppPptx)
         return checkStatus(Application::kPreviewDocumentFile);
 
     // appimage 是可执行程序包，应该显示图标


### PR DESCRIPTION
- Introduced a new function `pptxThumbnailCreator` to generate thumbnails for PPTX files.
- Updated `thumbnailcreators.h` to declare the new function.
- Registered the PPTX thumbnail creator in `thumbnailfactory.cpp`.
- Added MIME type handling for PPTX files in `dfm_global_defines.h` and `thumbnailhelper.cpp`.

Log: This commit enhances the thumbnail generation capabilities by adding support for PPTX files, allowing users to view thumbnails for presentation documents.

## Summary by Sourcery

Add support for generating PPTX thumbnails by implementing a new thumbnail creator, registering it, and updating MIME type and size limit handling

New Features:
- Implement pptxThumbnailCreator to extract and load embedded thumbnails from PPTX files
- Declare and register the PPTX thumbnail creator in the thumbnail creators interface and factory
- Add PPTX MIME type constant to global definitions and include it in thumbnail helper MIME handling
- Configure ThumbnailHelper to support PPTX files with an unlimited size limit