### PR TITLE
refactor: enhance disk identification logic in DeviceUtils

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -379,9 +379,11 @@ QString DeviceUtils::nameOfBuiltInDisk(const QVariantMap &datas)
     // get system disk name if there is no alias
     if (DeviceUtils::isSystemDisk(clearInfo.isEmpty() ? datas : clearInfo))
         return QObject::tr("System Disk");
+
+    if (DeviceUtils::isDataDisk(clearInfo.isEmpty() ? datas : clearInfo))
+        return QObject::tr("Data Disk");
+
     if (!canPowerOff && !mountPoint.isEmpty()) {
-        if (label.startsWith("_dde_data"))
-            return QObject::tr("Data Disk");
         if (label.startsWith("_dde_"))
             return datas.value(kIdLabel).toString().mid(5);
     }
@@ -737,7 +739,7 @@ bool DeviceUtils::isDataDisk(const QVariantHash &devInfo)
 
     // 检查标签是否为数据盘标识
     QString label = devInfo.value(kIdLabel).toString();
-    return label.startsWith("_dde_data");
+    return label.startsWith("_dde_data") || label.startsWith("_dde_home");
 }
 
 bool DeviceUtils::isDataDisk(const QVariantMap &devInfo)

--- a/src/plugins/filemanager/dfmplugin-computer/fileentity/blockentryfileentity.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/fileentity/blockentryfileentity.cpp
@@ -269,7 +269,7 @@ bool BlockEntryFileEntity::showSizeAndProgress() const
 
 QUrl BlockEntryFileEntity::mountPoint() const
 {
-    auto mptList = getProperty(DeviceProperty::kMountPoints).toStringList();
+    const auto &mptList = getProperty(DeviceProperty::kMountPoints).toStringList();
     QUrl target;
 
     if (mptList.isEmpty())


### PR DESCRIPTION
- Added support for identifying disks labeled with "_dde_home" as data disks.
- Improved the name retrieval for built-in disks by explicitly checking for data disks.

Log: This commit refines the disk identification logic, ensuring that disks with the new label are correctly recognized, enhancing the overall functionality of the device utility methods.

## Summary by Sourcery

Extend disk identification to treat `_dde_home` labels as data disks, adjust built-in disk naming logic to check for data disks earlier, and refine mount point retrieval to use const references.

Enhancements:
- Recognize disks labeled with `_dde_home` as data disks
- Prioritize data disk detection in built-in disk naming for accurate labels
- Use const references for mount point list retrieval to avoid unnecessary copies