### PR TITLE
refactor: enhance search options configuration in DFMSearcher

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.55) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 27 May 2025 20:43:59 +0800
+
 dde-file-manager (6.5.54) unstable; urgency=medium
 
   * remove libutpm2

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.h
@@ -42,6 +42,10 @@ private:
     bool isEngineReady() const;
     bool isValidSearchParameters() const;
     DFMSEARCH::SearchOptions configureSearchOptions(const QString &transformedPath) const;
+    void configureHiddenFilesOption(DFMSEARCH::SearchOptions &options, const QString &transformedPath) const;
+    void configureRealtimeSearchOptions(DFMSEARCH::SearchOptions &options, const QString &transformedPath) const;
+    bool shouldExcludeIndexedPaths(const QString &transformedPath) const;
+    void setExcludedPathsForRealtime(DFMSEARCH::SearchOptions &options) const;
     bool validateSearchType(const QString &transformedPath, DFMSEARCH::SearchOptions &options);
     void executeSearch();
 


### PR DESCRIPTION
- Introduced methods to configure hidden files and realtime search options, improving the clarity and modularity of the search options setup.
- Added logic to determine when to exclude indexed paths based on the search context, ensuring more efficient search operations.
- Updated the main search configuration method to incorporate these enhancements, leading to better handling of search parameters.

Log: This commit refines the search options configuration in DFMSearcher, promoting cleaner code and enhancing the search functionality by addressing hidden files and indexed path exclusions.

## Summary by Sourcery

Refactor DFMSearcher to modularize search option configuration and enhance search behavior by handling hidden files, excluding indexed paths, and falling back to realtime search when the filename index is unavailable

Enhancements:
- Extract hidden-file handling into configureHiddenFilesOption to set includeHidden correctly
- Extract realtime-specific setup into configureRealtimeSearchOptions and setExcludedPathsForRealtime
- Add shouldExcludeIndexedPaths to determine when to skip indexed paths during realtime searches
- Update getSearchMethod to warn and fall back to realtime when the filename index directory is not available