### PR TITLE
fix: Simplify vault locking mechanism and improve configuration handling

### DIFF
--- a/src/plugins/daemon/vault/vaultcontrol.cpp
+++ b/src/plugins/daemon/vault/vaultcontrol.cpp
@@ -335,19 +335,22 @@ int VaultControl::unlockVault(const QString &basedir, const QString &mountdir, c
 
 int VaultControl::lockVault(const QString &unlockFileDir, bool isForced)
 {
-    CryfsVersionInfo version = versionString();
+    /*
+     * NOTE: When unmount the vault using the cryfs-unmount command,
+     * the valut will be unmounted normally even if it is busy (file copy)
+     */
+    // CryfsVersionInfo version = versionString();
+    // if (version.isVaild() && !version.isOlderThan(CryfsVersionInfo(0, 10, 0))) {
+    //     fusermountBinary = QStandardPaths::findExecutable("cryfs-unmount");
+    //     arguments << unlockFileDir;
+    // } else {
     QString fusermountBinary;
     QStringList arguments;
-    if (version.isVaild() && !version.isOlderThan(CryfsVersionInfo(0, 10, 0))) {
-        fusermountBinary = QStandardPaths::findExecutable("cryfs-unmount");
-        arguments << unlockFileDir;
+    fusermountBinary = QStandardPaths::findExecutable("fusermount");
+    if (isForced) {
+        arguments << "-zu" << unlockFileDir;
     } else {
-        fusermountBinary = QStandardPaths::findExecutable("fusermount");
-        if (isForced) {
-            arguments << "-zu" << unlockFileDir;
-        } else {
-            arguments << "-u" << unlockFileDir;
-        }
+        arguments << "-u" << unlockFileDir;
     }
     if (fusermountBinary.isEmpty()) return -1;
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/vaultcreatepage.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/vaultcreatepage.cpp
@@ -179,6 +179,12 @@ Result VaultActiveView::createVault()
 
 bool VaultActiveView::handleKeyModeEncryption()
 {
+    {
+        // save configure
+        VaultConfig config;
+        config.set(kConfigNodeName, kConfigKeyUseUserPassWord, QVariant("Yes"));
+        config.set(kConfigNodeName, kConfigKeyEncryptionMethod, QVariant(kConfigValueMethodKey));
+    }
     auto ret = OperatorCenter::getInstance()->savePasswordAndPasswordHint(encryptInfo.password, encryptInfo.hint);
     if (!ret.result) {
         activeVaultFinishedWidget->encryptFinished(false, ret.message);
@@ -190,9 +196,6 @@ bool VaultActiveView::handleKeyModeEncryption()
         activeVaultFinishedWidget->encryptFinished(false, ret.message);
         return false;
     }
-    VaultConfig config;
-    config.set(kConfigNodeName, kConfigKeyUseUserPassWord, QVariant("Yes"));
-    config.set(kConfigNodeName, kConfigKeyEncryptionMethod, QVariant(kConfigValueMethodKey));
     activeVaultFinishedWidget->setProgressValue(20);
 
     //! 获取密钥字符串


### PR DESCRIPTION
- Removed outdated version checks and comments in the lockVault function for clarity.
- Streamlined the logic for determining the fusermount binary and arguments based on the forced flag.
- Moved configuration saving for encryption settings to a more appropriate location in handleKeyModeEncryption.

Log: Enhance code readability and maintainability in vault control and creation processes.
Bug: https://pms.uniontech.com/bug-view-316335.html

## Summary by Sourcery

Simplify vault locking by removing deprecated version checks and unifying fusermount usage, and relocate encryption configuration saving to an earlier stage in key-based vault creation.

Bug Fixes:
- Ensure encryption settings are saved before password operations to prevent configuration loss

Enhancements:
- Remove outdated CryFS version checks and comments in lockVault
- Streamline fusermount argument handling for forced and standard unmounts
- Move encryption configuration saving to the start of handleKeyModeEncryption