### PR TITLE
fix:  enable smooth transformation for canvas icon rendering

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -801,6 +801,7 @@ QRectF CanvasItemDelegate::paintIcon(QPainter *painter, const QIcon &icon, const
 
     // 使用QRectF和drawPixmap的重载版本来正确处理缩放
     QRectF targetRect(x, y, w, h);
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
     painter->drawPixmap(targetRect, px, px.rect());
     
     return targetRect;


### PR DESCRIPTION
Desktop icons may appear jagged under partial scaling, add QPainter::SmoothPixmapTransform hint when drawing canvas icons to improve visual quality during scaling operations. This ensures smoother appearance of scaled icons in the desktop canvas view.

Log: enable smooth transformation for canvas icon rendering

## Summary by Sourcery

Bug Fixes:
- Enable QPainter::SmoothPixmapTransform for canvas icon rendering to fix jagged appearance under partial scaling.