### PR TITLE
fix: enable smooth transformation for collection item rendering

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -801,9 +801,11 @@ QRectF CanvasItemDelegate::paintIcon(QPainter *painter, const QIcon &icon, const
 
     // 使用QRectF和drawPixmap的重载版本来正确处理缩放
     QRectF targetRect(x, y, w, h);
+    painter->save();
     painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
     painter->drawPixmap(targetRect, px, px.rect());
-    
+    painter->restore();
+
     return targetRect;
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -826,7 +826,10 @@ QRect CollectionItemDelegate::paintIcon(QPainter *painter, const QIcon &icon, co
 
     // 使用QRectF和drawPixmap的重载版本来正确处理缩放
     QRect targetRect(x, y, w, h);
+    painter->save();
+    painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
     painter->drawPixmap(targetRect, px, px.rect());
+    painter->restore();
 
     return targetRect;
 }


### PR DESCRIPTION
Added QPainter::SmoothPixmapTransform hint to the paintIcon method in both CanvasItemDelegate and CollectionItemDelegate to enhance the visual quality of icons during scaling operations. This change ensures that icons are rendered smoothly, improving the overall appearance in the desktop environment.

Log:

## Summary by Sourcery

Enhancements:
- Enable QPainter::SmoothPixmapTransform hint in CanvasItemDelegate and CollectionItemDelegate to improve icon scaling quality