### PR TITLE
refacor: Update the order of the workspace menu scene

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/menus/workspacemenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/menus/workspacemenuscene.cpp
@@ -114,6 +114,10 @@ bool WorkspaceMenuScene::initialize(const QVariantHash &params)
             currentScene.append(shareScene);
     }
 
+    // the scene added by binding must be initializeed after 'defalut scene'.
+    currentScene.append(subScene);
+
+    // 为了能在扩展菜单中获得所有actions, 扩展菜单场景必须在其他场景之后
     if (!d->isDDEDesktopFileIncluded) {
         // oem menu
         if (auto oemScene = dfmplugin_menu_util::menuSceneCreateScene(kOemMenuSceneName))
@@ -130,8 +134,6 @@ bool WorkspaceMenuScene::initialize(const QVariantHash &params)
     if (auto actionIconManagerScene = dfmplugin_menu_util::menuSceneCreateScene(kActionIconMenuSceneName))
         currentScene.append(actionIconManagerScene);
 
-    // the scene added by binding must be initializeed after 'defalut scene'.
-    currentScene.append(subScene);
     setSubscene(currentScene);
 
     // 初始化所有子场景


### PR DESCRIPTION
Update the order of the workspace menu scene

log: Update the order of the workspace menu scene

## Summary by Sourcery

Enhancements:
- Add subscene to currentScene immediately after the default scene instead of at the end to include all extension menu actions