### PR TITLE
fix:[touch] Can not mul-select by touch.

### DIFF
--- a/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/core/dfmplugin-workspace/views/fileview.cpp
@@ -1217,6 +1217,8 @@ void FileView::mousePressEvent(QMouseEvent *event)
             && indexAt(event->pos()).isValid()) {
         d->isTouchDrag = true;
         d->mousePressPosForTouch = event->pos();
+    } else {
+        d->isTouchDrag = false;
     }
 
     if (event->buttons().testFlag(Qt::LeftButton)) {
@@ -1325,6 +1327,7 @@ void FileView::mouseMoveEvent(QMouseEvent *event)
 void FileView::mouseReleaseEvent(QMouseEvent *event)
 {
     d->pressedStartWithExpand = false;
+    d->isTouchDrag = false;
 
     if (event->buttons() & Qt::LeftButton) {
         d->mouseMoveRect = QRect(-1, -1, 1, 1);


### PR DESCRIPTION
-- Not clear the touch drag state, so can not mul-select.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-318545.html

## Summary by Sourcery

Bug Fixes:
- Reset isTouchDrag flag on non-touch press and on mouse release to enable multi-select by touch