### PR TITLE
fix: centralize symlink resolution logic in FileUtils

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -509,7 +509,7 @@ void AsyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> 
     auto typeAll = types;
     if (typeAll.isEmpty()) {
         if (isAttributes(OptInfoType::kIsSymLink)) {
-            auto target = pathOf(PathInfoType::kSymLinkTarget);
+            auto target = FileUtils::resolveSymlink(fileUrl());
             if (!target.isEmpty() && target != filePath()) {
                 FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(target));
                 if (info)

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -533,7 +533,7 @@ void SyncFileInfo::updateAttributes(const QList<FileInfo::FileInfoAttributeID> &
     auto typeAll = types;
     if (typeAll.isEmpty()) {
         if (isAttributes(OptInfoType::kIsSymLink)) {
-            auto target = d->symLinkTarget();
+            auto target = FileUtils::resolveSymlink(fileUrl());
             if (!target.isEmpty() && target != filePath()) {
                 FileInfoPointer info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(target));
                 if (info)

--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -338,27 +338,10 @@ FileInfo::FileType FileStatisticsJobPrivate::fileType(const __mode_t fileMode)
     return fileType;
 }
 
-QString FileStatisticsJobPrivate::resolveSymlink(const QUrl &url)
-{
-    QSet<QString> visited;
-    QString target = FileUtils::symlinkTarget(url);
-    while (!target.isEmpty()) {
-        if (visited.contains(target))
-            return QString();   // Cycle detected: return empty
-        visited.insert(target);
-        QUrl newUrl = QUrl::fromLocalFile(target);
-        QString nextTarget = FileUtils::symlinkTarget(newUrl);
-        if (nextTarget.isEmpty())
-            break;
-        target = nextTarget;
-    }
-    return target;
-}
-
 void FileStatisticsJobPrivate::processDirectory(const QUrl &url, bool followLink, QQueue<QUrl> &directoryQueue)
 {
     totalProgressSize += FileUtils::getMemoryPageSize();
-    QString target = resolveSymlink(url);
+    QString target = FileUtils::resolveSymlink(url);
     if (!target.isEmpty() && !followLink) {
         ++directoryCount;
         return;
@@ -377,7 +360,7 @@ void FileStatisticsJobPrivate::processDirectory(const QUrl &url, bool followLink
 
 void FileStatisticsJobPrivate::processRegularFile(const QUrl &url, struct stat64 *statBuffer, bool followLink)
 {
-    QString target = resolveSymlink(url);
+    QString target = FileUtils::resolveSymlink(url);
     bool isSymlink = !target.isEmpty();
     if (isSymlink && !followLink) {
         ++filesCount;

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1127,6 +1127,22 @@ QString FileUtils::symlinkTarget(const QUrl &url)
     return QString();
 }
 
+QString FileUtils::resolveSymlink(const QUrl &url) {
+    QSet<QString> visited;
+    QString target = symlinkTarget(url);
+    while (!target.isEmpty()) {
+        if (visited.contains(target))
+            return QString();   // Cycle detected: return empty
+        visited.insert(target);
+        QUrl newUrl = QUrl::fromLocalFile(target);
+        QString nextTarget = symlinkTarget(newUrl);
+        if (nextTarget.isEmpty())
+            break;
+        target = nextTarget;
+    }
+    return target;
+}
+
 bool FileUtils::isSymbol(const QChar ch)
 {
     // 如果是高代理项，不应该单独判断

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -97,6 +97,7 @@ public:
     static bool isFullWidthChar(const QChar ch, QChar &normalized);
     static QString makeQString(const QString::const_iterator &it, uint unicode);
     static QString symlinkTarget(const QUrl &url);
+    static QString resolveSymlink(const QUrl &url);
 
 private:
     static QMutex cacheCopyingMutex;

--- a/src/dfm-base/utils/private/filestatisticsjob_p.h
+++ b/src/dfm-base/utils/private/filestatisticsjob_p.h
@@ -33,7 +33,6 @@ public:
     bool checkInode(const FileInfoPointer info);
     bool checkInode(const __ino64_t innode, const QString &path);
     FileInfo::FileType fileType(const __mode_t fileMode);
-    QString resolveSymlink(const QUrl &url);
     void processDirectory(const QUrl &url, bool followLink, QQueue<QUrl> &directoryQueue);
     void processRegularFile(const QUrl &url, struct stat64 *statBuffer, bool followLink);
 


### PR DESCRIPTION
- Moved resolveSymlink method from FileStatisticsJobPrivate to FileUtils as a static method.
- Updated all usages to call FileUtils::resolveSymlink instead of local implementations.
- Simplifies codebase and ensures consistent symlink resolution across modules.
- Removed redundant resolveSymlink declaration from FileStatisticsJobPrivate.

This change ensures consistent and robust symlink resolution throughout the project.

Log: centralize symlink resolution logic in FileUtils
Bug: https://pms.uniontech.com/bug-view-318199.html

## Summary by Sourcery

Centralize symlink resolution logic by moving resolveSymlink into FileUtils and updating all call sites accordingly.

Enhancements:
- Relocate resolveSymlink implementation from FileStatisticsJobPrivate to FileUtils as a static method
- Update all modules to use FileUtils::resolveSymlink for symlink resolution
- Remove redundant resolveSymlink declaration and implementation from FileStatisticsJobPrivate