### PR TITLE
fix: [diskencrypt] Can not enter system.

### DIFF
--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -209,8 +209,11 @@ void crypttab_helper::updateInitramfs()
     // QtConcurrent::run([]{
     auto fd = inhibit_helper::inhibit("Updating initramfs...");
     qInfo() << "start update initramfs...";
-    system("update-initramfs -u");
-    qInfo() << "initramfs updated.";
+    int ret = std::system("sudo -E /sbin/update-initramfs -u");
+    if (ret != 0)
+        qCritical() << "sudo -E /sbin/update-initramfs -u failed! error code : " << ret ;
+    else
+        qInfo() << "initramfs updated.";
     // });
 }
 


### PR DESCRIPTION
-- When home disk encrypt, can not enter system.
-- The 'update-initramfs -u' exec failed, so system can
   not unlock home disk.
-- The purpose of the current modification is to retain environment variables.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-318097.html

## Summary by Sourcery

Fix the update-initramfs invocation in the disk encryption service to ensure it runs with proper privileges, captures errors, and logs failures so the system can unlock the encrypted home disk.

Bug Fixes:
- Log an error when the update-initramfs command fails to prevent silent failures unlocking the home disk.

Enhancements:
- Invoke update-initramfs with sudo -E using the full /sbin path and capture its return code.