### PR TITLE
fix: assign itemFileDisplayName to displayName when suffix comparison fails

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -626,10 +626,10 @@ QString ListItemDelegate::getCorrectDisplayName(QPainter *painter, const QModelI
 
             displayName = textList.join('\n');
 
-            auto tmpFileName = fileName;
+            auto tmpFileName = displayName;
             // get error suffix, so show the file displayname
             if (tmpFileName.append(suffix) != itemFileDisplayName.toString()) {
-                fileName = itemFileDisplayName.toString();
+                displayName = itemFileDisplayName.toString();
                 break;
             }
 


### PR DESCRIPTION
- Updated getCorrectDisplayName to set displayName (instead of fileName) to itemFileDisplayName when the display name with suffix does not match.
- Ensures the correct display name is shown in the file list, especially for files with error suffixes or special display names.

Log: assign itemFileDisplayName to displayName when suffix comparison fails

## Summary by Sourcery

Bug Fixes:
- Assign itemFileDisplayName to displayName when suffix comparison fails to ensure the correct name is shown in the file list