### PR TITLE
feat: enhance SortInfo with additional time attributes and display type

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.58) unstable; urgency=medium
+
+  * fix bugs
+  * 
+
+ -- Liuyangming <liuyangming@uniontech.com>  Thu, 05 Jun 2025 21:14:11 +0800
+
 dde-file-manager (6.5.57) unstable; urgency=medium
 
   * fix bugs 

--- a/include/dfm-base/interfaces/sortfileinfo.h
+++ b/include/dfm-base/interfaces/sortfileinfo.h
@@ -29,7 +29,7 @@ public:
     void setWriteable(const bool writeable);
     void setExecutable(const bool executable);
     void setLastReadTime(const qint64 time);
-    void setLastModifedTime(const qint64 time);
+    void setLastModifiedTime(const qint64 time);
     void setCreateTime(const qint64 time);
     void setDisplayType(const QString &displayType);
 
@@ -43,7 +43,7 @@ public:
     bool isWriteable() const;
     bool isExecutable() const;
     qint64 lastReadTime() const;
-    qint64 lastModifedTime() const;
+    qint64 lastModifiedTime() const;
     qint64 createTime() const;
     QString displayType() const;
     

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -250,7 +250,7 @@ QList<SortInfoPointer> LocalDirIterator::sortFileInfoList()
         tmp->setWriteable(sortInfo->isWriteable);
         tmp->setExecutable(sortInfo->isExecutable);
         tmp->setLastReadTime(sortInfo->lastRead);
-        tmp->setLastModifedTime(sortInfo->lastModifed);
+        tmp->setLastModifiedTime(sortInfo->lastModifed);
         tmp->setCreateTime(sortInfo->create);
         tmp->setDisplayType(MimeTypeDisplayManager::instance()->displayTypeFromPath(sortInfo->url.path()));
         wsortlist.append(tmp);

--- a/src/dfm-base/interfaces/sortfileinfo.cpp
+++ b/src/dfm-base/interfaces/sortfileinfo.cpp
@@ -64,7 +64,7 @@ void SortFileInfo::setLastReadTime(const qint64 time)
     d->lastRead = time;
 }
 
-void SortFileInfo::setLastModifedTime(const qint64 time)
+void SortFileInfo::setLastModifiedTime(const qint64 time)
 {
     d->lastModifed = time;
 }
@@ -139,7 +139,7 @@ qint64 SortFileInfo::lastReadTime() const
     return d->lastRead;
 }
 
-qint64 SortFileInfo::lastModifedTime() const
+qint64 SortFileInfo::lastModifiedTime() const
 {
     return d->lastModifed;
 }

--- a/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
+++ b/src/dfm-base/mimetype/mimetypedisplaymanager.cpp
@@ -82,7 +82,7 @@ void MimeTypeDisplayManager::initData()
         "tgz", "tbz2", "txz", "ace", "apk", "arc", "arj", "cab", "lzh", "lha", "lz", "lz4", "lzma", "lzo", "rz", "z", "zst",
         "dmg", "img", "pk3", "pk4", "udf", "wim", "zap", "zpaq", "cpio", "pea", "sit", "sitx", "zoo", "zipx", "tlz", "uue",
         "xar", "alz", "egg", "ar", "par", "par2", "xpi", "crx", "taz", "tar.lzma", "tar.zst", "tar.lz", "tar.lz4", "shar", "vhd", "vmdk",
-        "pkg", "hfs", "ipsw", "dar", "bz", "tbz", "qcow", "qcow2", "pacman", "msi", "ova", "gem", "whl", "nupkg", "cab"
+        "pkg", "hfs", "ipsw", "dar", "bz", "tbz", "qcow", "qcow2", "pacman", "ova", "gem", "whl", "nupkg", "cab"
     };
     for (const QString &ext : archiveExts) extensionMap[ext.toLower()] = FileInfo::FileType::kArchives;
     
@@ -99,6 +99,8 @@ void MimeTypeDisplayManager::initData()
         "jsx", "tsx", "clj", "cljs", "cljc", "coffee", "elm", "f", "f90", "fs", "fsx", "lisp", "ml", "mli", "nim", "pas", "pp", "prolog", "rs", "sass", "scss", "vb", "asm", "s",
         "d", "jl", "rkt", "scm", "zig", "m", "mm", "v", "ada", "adb", "bb", "bmx", "cgis", "class", "cls", "cob", "cobol", "gd", "bat", "ps1", "psm1", "vbs", "wsf", "ahk", "au3",
         "apex", "cfc", "cfm", "e", "elm", "gml", "hx", "ino", "jade", "litcoffee", "mak", "monkey", "mq4", "mq5", "nsi", "nsh", "pde", "sol", "tcl", "xqy", "zsh", "vue", "svelte",
+        // Shell scripts and related
+        "pyw", "ksh", "csh", "tcsh",
         // Config and system files
         "ini", "conf", "cfg", "yaml", "yml", "toml", "sh", "bash", "zsh", "fish", "plist", "po", "pot",
         "bashrc", "profile", "zshrc", "gitconfig", "editorconfig", "vimrc", "gitignore", "env", "properties", "config",
@@ -109,12 +111,11 @@ void MimeTypeDisplayManager::initData()
     };
     for (const QString &ext : docExts) extensionMap[ext.toLower()] = FileInfo::FileType::kDocuments;
     
-    // Executables (scripts and specific executable formats)
+    // Executables (specific binary executable formats only, not scripts)
     QStringList execExts = {
-        "appimage", "run", "exe", "com", "bat", "cmd", "msi", "pyc", "pyo", "ps1", "flatpakref", "snap",
-        "app", "bin", "deb", "rpm", "apk", "out", "elf", "so", "o", "a", "dll", "sys", "scr", "ocx", "pyd", "dylib", "bundle",
-        "jar", "war", "ear", "vbs", "msc", "cpl", "gadget", "msp", "action", "workflow", "xbe", "nexe", "wasm", "pex",
-        "pyw", "pl", "rb", "php", "sh", "bash", "zsh", "fish", "ksh", "csh", "tcsh", "js", "ts", "py"
+        "appimage", "run", "exe", "com", "msi", "pyc", "pyo", "flatpakref", "snap",
+        "app", "bin", "out", "elf", "so", "o", "a", "dll", "sys", "scr", "ocx", "pyd", "dylib", "bundle",
+        "msc", "cpl", "gadget", "msp", "action", "workflow", "xbe", "nexe", "wasm", "pex"
     };
     for (const QString &ext : execExts) extensionMap[ext.toLower()] = FileInfo::FileType::kExecutable;
 

--- a/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/file/local/localfilewatcher.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/mimetype/mimetypedisplaymanager.h>
 
 #include <QUuid>
 
@@ -178,6 +179,7 @@ QList<QSharedPointer<SortFileInfo>> SearchDirIterator::sortFileInfoList()
         auto sortInfo = QSharedPointer<SortFileInfo>(new SortFileInfo());
         sortInfo->setUrl(it.key());
         sortInfo->setHighlightContent(it->highlightedContent());
+        sortInfo->setDisplayType(MimeTypeDisplayManager::instance()->displayTypeFromPath(it.key().path()));
         result.append(sortInfo);
     }
     d->childrens.clear();

--- a/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
@@ -349,7 +349,7 @@ bool AdvanceSearchBarPrivate::shouldVisiableByFilterRule(SortFileInfo *info, QVa
     }
 
     if (filter.comboValid[kDateRange]) {
-        QDateTime filemtime = QDateTime::fromSecsSinceEpoch(info->lastModifedTime());
+        QDateTime filemtime = QDateTime::fromSecsSinceEpoch(info->lastModifiedTime());
         if (filemtime < filter.dateRangeStart || filemtime > filter.dateRangeEnd)
             return false;
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -585,6 +585,10 @@ SortInfoPointer RootInfo::sortFileInfo(const FileInfoPointer &info)
     sortInfo->setReadable(info->isAttributes(OptInfoType::kIsReadable));
     sortInfo->setWriteable(info->isAttributes(OptInfoType::kIsWritable));
     sortInfo->setExecutable(info->isAttributes(OptInfoType::kIsExecutable));
+    sortInfo->setLastReadTime(info->timeOf(TimeInfoType::kLastRead).toLongLong());
+    sortInfo->setLastModifedTime(info->timeOf(TimeInfoType::kLastModified).toLongLong());
+    sortInfo->setCreateTime(info->timeOf(TimeInfoType::kCreateTime).toLongLong());
+    sortInfo->setDisplayType(info->displayOf(DisPlayInfoType::kMimeTypeDisplayName));
     return sortInfo;
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -586,7 +586,7 @@ SortInfoPointer RootInfo::sortFileInfo(const FileInfoPointer &info)
     sortInfo->setWriteable(info->isAttributes(OptInfoType::kIsWritable));
     sortInfo->setExecutable(info->isAttributes(OptInfoType::kIsExecutable));
     sortInfo->setLastReadTime(info->timeOf(TimeInfoType::kLastRead).toLongLong());
-    sortInfo->setLastModifedTime(info->timeOf(TimeInfoType::kLastModified).toLongLong());
+    sortInfo->setLastModifiedTime(info->timeOf(TimeInfoType::kLastModified).toLongLong());
     sortInfo->setCreateTime(info->timeOf(TimeInfoType::kCreateTime).toLongLong());
     sortInfo->setDisplayType(info->displayOf(DisPlayInfoType::kMimeTypeDisplayName));
     return sortInfo;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1111,7 +1111,7 @@ bool FileSortWorker::sortInfoUpdateByFileInfo(const FileInfoPointer fileInfo)
     sortInfo->setWriteable(fileInfo->isAttributes(OptInfoType::kIsWritable));
     sortInfo->setExecutable(fileInfo->isAttributes(OptInfoType::kIsExecutable));
     sortInfo->setLastReadTime(fileInfo->timeOf(TimeInfoType::kLastRead).toLongLong());
-    sortInfo->setLastModifedTime(fileInfo->timeOf(TimeInfoType::kLastModified).toLongLong());
+    sortInfo->setLastModifiedTime(fileInfo->timeOf(TimeInfoType::kLastModified).toLongLong());
     sortInfo->setCreateTime(fileInfo->timeOf(TimeInfoType::kCreateTime).toLongLong());
     sortInfo->setDisplayType(fileInfo->displayOf(DisPlayInfoType::kMimeTypeDisplayName));
     fileInfo->fileMimeType();
@@ -1596,7 +1596,7 @@ QVariant FileSortWorker::data(const SortInfoPointer &info, Global::ItemRoles rol
 
     switch (role) {
     case kItemFileLastModifiedRole: {
-        auto lastModified = QDateTime::fromSecsSinceEpoch(info->lastModifedTime());
+        auto lastModified = QDateTime::fromSecsSinceEpoch(info->lastModifiedTime());
         return lastModified.isValid() ? lastModified.toString(FileUtils::dateTimeFormat()) : "-";
     }
     case kItemFileCreatedRole: {


### PR DESCRIPTION
- Added methods to set last read time, last modified time, creation time, and display type in the SortInfo class.
- Updated SearchDirIterator to utilize the new display type method for improved file information sorting.

Log: This commit enhances the SortInfo class by introducing additional time attributes and display type for better file metadata management.

## Summary by Sourcery

Enhance file metadata sorting by extending SortInfo with timestamp attributes and display type, and update SearchDirIterator to populate display type for SortFileInfo

New Features:
- Add methods in SortInfo to set last read time, last modified time, and creation time
- Introduce a new display type attribute in SortInfo for MIME type names
- Use MimeTypeDisplayManager in SearchDirIterator to assign display type to SortFileInfo instances

Enhancements:
- Improve file information sorting by incorporating additional time-based metadata