### PR TITLE
chore: bump version to 6.5.59

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.59) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liuyangming <zhangsheng@uniontech.com>  Fri, 06 Jun 2025 12:23:30 +0800
+
 dde-file-manager (6.5.58) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
6.5.69

Log:

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect new version 6.5.69