### PR TITLE
fix: resolve race condition causing dynamic_cast crash in FileInfoHelper

### DIFF
--- a/src/dfm-base/utils/fileinfohelper.h
+++ b/src/dfm-base/utils/fileinfohelper.h
@@ -51,10 +51,12 @@ Q_SIGNALS:
     // 第二个参数表示，当前是链接文件的原文件更新完成
     void fileRefreshFinished(const QUrl url, const QString &infoPtr, const bool isLinkOrg);
     void fileRefreshRequest(QSharedPointer<FileInfo> dfileInfo);
+    void requestCheckInfoRefresh(QSharedPointer<FileInfo> dfileInfo);
     void smbSeverMayModifyPassword(const QUrl &url);
 private Q_SLOTS:
     void aboutToQuit();
     void handleFileRefresh(QSharedPointer<FileInfo> dfileInfo);
+    void handleCheckInfoRefresh(QSharedPointer<FileInfo> dfileInfo);
 
 private:
     void checkInfoRefresh(QSharedPointer<FileInfo> dfileInfo);


### PR DESCRIPTION
- Add signal-slot mechanism to eliminate cross-thread race condition
- Move checkInfoRefresh operations from worker thread to main thread
- Add requestCheckInfoRefresh signal and handleCheckInfoRefresh slot
- Ensure all FileInfo object lifecycle management occurs in main thread
- Fix Use-After-Free issue where FileInfo objects were prematurely deleted while still being accessed by handleFileRefresh in main thread

This resolves crashes with stack trace showing dynamic_cast failure in FileInfoHelper::handleFileRefresh when AsyncFileInfo objects were destroyed by concurrent checkInfoRefresh calls from worker threads.

The fix ensures thread-safe access to qureingInfo and needQureingInfo containers by serializing all operations through Qt's event loop using queued connections.

Log:

## Summary by Sourcery

Serialize FileInfo refresh and queue operations through the main thread using Qt’s queued signals to eliminate cross-thread race conditions.

Bug Fixes:
- Stop dynamic_cast crashes by deferring checkInfoRefresh calls to the main thread via a queued signal.
- Prevent Use-After-Free of FileInfo objects by serializing their lifecycle management.

Enhancements:
- Introduce requestCheckInfoRefresh signal and handleCheckInfoRefresh slot for queued refresh handling.
- Move all checkInfoRefresh logic and queue modifications out of the worker thread into the main thread.
- Add assertion to ensure handleCheckInfoRefresh runs on the main thread.