### PR TITLE
fix: [diskencrypt] Show Tpm item in tpm lockout mode.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -135,7 +135,7 @@ QWidget *EncryptParamsInputDialog::createPasswordPage()
                         tr("Use TPM+PIN to unlock on this computer (recommended)"),
                         tr("Automatic unlocking on this computer by TPM") });
 
-    if (tpm_utils::checkTPM() != 0) {
+    if (tpm_utils::checkTPM() != 0 || tpm_utils::checkTPMLockoutStatus() != 0) {
         // encType->setItemData(kTPMAndPIN, QVariant(0), Qt::UserRole - 1);
         // encType->setItemData(kTPMOnly, QVariant(0), Qt::UserRole - 1);
         encType->removeItem(1);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -56,6 +56,11 @@ int tpm_utils::checkTPM()
     return dpfSlotChannel->push("dfmplugin_encrypt_manager", "slot_TPMIsAvailablePro").toInt();
 }
 
+int tpm_utils::checkTPMLockoutStatus()
+{
+    return dpfSlotChannel->push("dfmplugin_encrypt_manager", "slot_CheckTPMLockoutPro").toInt();
+}
+
 int tpm_utils::getRandomByTPM(int size, QString *output)
 {
     return dpfSlotChannel->push("dfmplugin_encrypt_manager", "slot_GetRandomByTPMPro", size, output).toInt();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -18,6 +18,7 @@ namespace dfmplugin_diskenc {
 
 namespace tpm_utils {
 int checkTPM();
+int checkTPMLockoutStatus();
 int getRandomByTPM(int size, QString *output);
 int isSupportAlgoByTPM(const QString &algoName, bool *support);
 int encryptByTPM(const QVariantMap &map);

--- a/src/plugins/filemanager/dfmplugin-encrypt-manager/encryptmanager.h
+++ b/src/plugins/filemanager/dfmplugin-encrypt-manager/encryptmanager.h
@@ -24,6 +24,7 @@ class EncryptManager : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_EncryptByTPM)
     DPF_EVENT_REG_SLOT(slot_DecryptByTPM)
     DPF_EVENT_REG_SLOT(slot_TPMIsAvailablePro)
+    DPF_EVENT_REG_SLOT(slot_CheckTPMLockoutPro)
     DPF_EVENT_REG_SLOT(slot_GetRandomByTPMPro)
     DPF_EVENT_REG_SLOT(slot_IsTPMSupportAlgoPro)
     DPF_EVENT_REG_SLOT(slot_EncryptByTPMPro)

--- a/src/plugins/filemanager/dfmplugin-encrypt-manager/events/eventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-encrypt-manager/events/eventreceiver.cpp
@@ -73,6 +73,11 @@ int EventReceiver::tpmIsAvailableProcess()
     return tpm.checkTPMAvailbableByTools();
 }
 
+int EventReceiver::tpmCheckLockoutStatusProcess()
+{
+    return TPMWork::checkTPMLockoutStatusByTools();
+}
+
 int EventReceiver::getRandomByTpmProcess(int size, QString *output)
 {
     TPMWork tpm;
@@ -227,6 +232,7 @@ void EventReceiver::initConnection()
     dpfSlotChannel->connect("dfmplugin_encrypt_manager", "slot_DecryptByTPM", this, &EventReceiver::decryptByTpm);
 
     dpfSlotChannel->connect("dfmplugin_encrypt_manager", "slot_TPMIsAvailablePro", this, &EventReceiver::tpmIsAvailableProcess);
+    dpfSlotChannel->connect("dfmplugin_encrypt_manager", "slot_CheckTPMLockoutPro", this, &EventReceiver::tpmCheckLockoutStatusProcess);
     dpfSlotChannel->connect("dfmplugin_encrypt_manager", "slot_GetRandomByTPMPro", this, &EventReceiver::getRandomByTpmProcess);
     dpfSlotChannel->connect("dfmplugin_encrypt_manager", "slot_IsTPMSupportAlgoPro", this, &EventReceiver::isTpmSupportAlgoProcess);
     dpfSlotChannel->connect("dfmplugin_encrypt_manager", "slot_EncryptByTPMPro", this, &EventReceiver::encryptByTpmProcess);

--- a/src/plugins/filemanager/dfmplugin-encrypt-manager/events/eventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-encrypt-manager/events/eventreceiver.h
@@ -27,6 +27,7 @@ public Q_SLOTS:
     bool decryptByTpm(const QString &keyPin, const QString &dirPath, QString *pwd);
 
     int tpmIsAvailableProcess();
+    int tpmCheckLockoutStatusProcess();
     int getRandomByTpmProcess(int size, QString *output);
     int isTpmSupportAlgoProcess(const QString &algoName, bool *support);
     int encryptByTpmProcess(const QVariantMap &encryptParams);

--- a/src/plugins/filemanager/dfmplugin-encrypt-manager/tpm/tpmwork.h
+++ b/src/plugins/filemanager/dfmplugin-encrypt-manager/tpm/tpmwork.h
@@ -30,6 +30,7 @@ public:
     bool decrypt(const QString &keyPin, const QString &dirPath, QString *psw);
 
     int checkTPMAvailbableByTools();
+    static int checkTPMLockoutStatusByTools();
     int getRandomByTools(int size, QString *output);
     int isSupportAlgoByTools(const QString &algoName, bool *support);
     int encryptByTools(const TpmEncryptArgs &params);


### PR DESCRIPTION
-- When tpm enter lockout mode, should not show tpm item. -- Add logic code to judge the lockout mode.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-318079.html

## Summary by Sourcery

Add support for checking TPM lockout status and hide related UI options when TPM enters lockout mode

New Features:
- Implement TPMWork::checkTPMLockoutStatusByTools to retrieve the TPM "inLockout" property from tpm2_getcap output
- Add a new event slot slot_CheckTPMLockoutPro and EventReceiver::tpmCheckLockoutStatusProcess
- Expose tpm_utils::checkTPMLockoutStatus for callers to query TPM lockout status

Bug Fixes:
- Prevent displaying the TPM encryption option when TPM is unavailable or in lockout mode

Enhancements:
- Register the new lockout status slot in the EncryptManager plugin
- Integrate the lockout status check in the encryption parameters dialog to conditionally remove TPM options