### PR TITLE
fix： some issues

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.61) unstable; urgency=medium
+
+  * fix some bugs.
+
+ -- Liuyangming <liuyangming@uniontech.com>  Thu, 12 Jun 2025 19:10:11 +0800
+
 dde-file-manager (6.5.60) unstable; urgency=medium
 
   * fix a full-text index update problem

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -102,6 +102,7 @@ void Search::regSearchToWorkspace()
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterFileView", SearchHelper::scheme());
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterMenuScene", SearchHelper::scheme(), SearchMenuCreator::name());
     dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_RegisterLoadStrategy", SearchHelper::scheme(), DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy::kPreserve);
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterFocusFileViewDisabled", SearchHelper::scheme());
 
     QVariantMap propertise {
         { DFMGLOBAL_NAMESPACE::ViewCustomKeys::kSupportTreeMode, false },

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -70,6 +70,8 @@ void WorkspaceEventReceiver::initConnection()
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleCheckSchemeViewIsFileView);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_RefreshDir",
                             WorkspaceHelper::instance(), &WorkspaceHelper::handleRefreshDir);
+    dpfSlotChannel->connect(kCurrentEventSpace, "slot_RegisterFocusFileViewDisabled",
+                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleRegisterFocusFileViewDisabled);
 
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_SetCustomViewProperty",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleSetCustomViewProperty);
@@ -427,4 +429,9 @@ void WorkspaceEventReceiver::handleTabChanged(const quint64 windowId, const QStr
 void WorkspaceEventReceiver::handleRegisterLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy)
 {
     WorkspaceHelper::instance()->registerLoadStrategy(scheme, strategy);
+}
+
+void WorkspaceEventReceiver::handleRegisterFocusFileViewDisabled(const QString &scheme)
+{
+    WorkspaceHelper::instance()->registerFocusFileViewDisabled(scheme);
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -81,6 +81,7 @@ public slots:
     void handleTabChanged(const quint64 windowId, const QString &uniqueId);
 
     void handleRegisterLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);
+    void handleRegisterFocusFileViewDisabled(const QString &scheme);
 private:
     explicit WorkspaceEventReceiver(QObject *parent = nullptr);
 };

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -585,9 +585,9 @@ SortInfoPointer RootInfo::sortFileInfo(const FileInfoPointer &info)
     sortInfo->setReadable(info->isAttributes(OptInfoType::kIsReadable));
     sortInfo->setWriteable(info->isAttributes(OptInfoType::kIsWritable));
     sortInfo->setExecutable(info->isAttributes(OptInfoType::kIsExecutable));
-    sortInfo->setLastReadTime(info->timeOf(TimeInfoType::kLastRead).toLongLong());
-    sortInfo->setLastModifiedTime(info->timeOf(TimeInfoType::kLastModified).toLongLong());
-    sortInfo->setCreateTime(info->timeOf(TimeInfoType::kCreateTime).toLongLong());
+    sortInfo->setLastReadTime(info->timeOf(TimeInfoType::kLastRead).value<QDateTime>().toSecsSinceEpoch());
+    sortInfo->setLastModifiedTime(info->timeOf(TimeInfoType::kLastModified).value<QDateTime>().toSecsSinceEpoch());
+    sortInfo->setCreateTime(info->timeOf(TimeInfoType::kCreateTime).value<QDateTime>().toSecsSinceEpoch());
     sortInfo->setDisplayType(info->displayOf(DisPlayInfoType::kMimeTypeDisplayName));
     sortInfo->setInfoCompleted(true);
     return sortInfo;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1110,9 +1110,9 @@ bool FileSortWorker::sortInfoUpdateByFileInfo(const FileInfoPointer fileInfo)
     sortInfo->setReadable(fileInfo->isAttributes(OptInfoType::kIsReadable));
     sortInfo->setWriteable(fileInfo->isAttributes(OptInfoType::kIsWritable));
     sortInfo->setExecutable(fileInfo->isAttributes(OptInfoType::kIsExecutable));
-    sortInfo->setLastReadTime(fileInfo->timeOf(TimeInfoType::kLastRead).toLongLong());
-    sortInfo->setLastModifiedTime(fileInfo->timeOf(TimeInfoType::kLastModified).toLongLong());
-    sortInfo->setCreateTime(fileInfo->timeOf(TimeInfoType::kCreateTime).toLongLong());
+    sortInfo->setLastReadTime(fileInfo->timeOf(TimeInfoType::kLastRead).value<QDateTime>().toSecsSinceEpoch());
+    sortInfo->setLastModifiedTime(fileInfo->timeOf(TimeInfoType::kLastModified).value<QDateTime>().toSecsSinceEpoch());
+    sortInfo->setCreateTime(fileInfo->timeOf(TimeInfoType::kCreateTime).value<QDateTime>().toSecsSinceEpoch());
     sortInfo->setDisplayType(fileInfo->displayOf(DisPlayInfoType::kMimeTypeDisplayName));
     fileInfo->fileMimeType();
 
@@ -1595,6 +1595,10 @@ QVariant FileSortWorker::data(const SortInfoPointer &info, Global::ItemRoles rol
         return QVariant();
 
     switch (role) {
+    case kItemFileLastReadRole: {
+        auto lastRead = QDateTime::fromSecsSinceEpoch(info->lastReadTime());
+        return lastRead.isValid() ? lastRead.toString(FileUtils::dateTimeFormat()) : "-";
+    }
     case kItemFileLastModifiedRole: {
         auto lastModified = QDateTime::fromSecsSinceEpoch(info->lastModifiedTime());
         return lastModified.isValid() ? lastModified.toString(FileUtils::dateTimeFormat()) : "-";

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -433,6 +433,16 @@ void WorkspaceHelper::aboutToChangeViewWidth(const quint64 windowID, int deltaWi
         view->aboutToChangeWidth(deltaWidth);
 }
 
+void WorkspaceHelper::registerFocusFileViewDisabled(const QString &scheme)
+{
+    focusFileViewDisabledScheme.append(scheme);
+}
+
+bool WorkspaceHelper::isFocusFileViewDisabled(const QString &scheme) const
+{
+    return focusFileViewDisabledScheme.contains(scheme);
+}
+
 void WorkspaceHelper::registerLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy)
 {
     loadStrategyMap[scheme] = strategy;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.h
@@ -101,6 +101,9 @@ public:
 
     void aboutToChangeViewWidth(const quint64 windowID, int deltaWidth);
 
+    void registerFocusFileViewDisabled(const QString &scheme);
+    bool isFocusFileViewDisabled(const QString &scheme) const;
+
     void registerLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);
     DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy getLoadStrategy(const QString &scheme);
     static QMap<quint64, QPair<QUrl, QUrl>> kSelectionAndRenameFile;   //###: for creating new file.
@@ -129,6 +132,7 @@ private:
     QList<QString> registeredFileViewScheme {};
     QMap<QString, CustomViewProperty> customViewPropertyMap {};
     QMap<QString, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy> loadStrategyMap {};
+    QList<QString> focusFileViewDisabledScheme {};
     QList<QUrl> undoFiles {};
 
     Q_DISABLE_COPY(WorkspaceHelper)

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -65,7 +65,7 @@ using namespace GlobalDConfDefines::BaseConfig;
 FileView::FileView(const QUrl &url, QWidget *parent)
     : DListView(parent), d(new FileViewPrivate(this))
 {
-    Q_UNUSED(url);
+    d->url = url;
     setMinimumHeight(10);
     setDragDropMode(QAbstractItemView::DragDrop);
     setDropIndicatorShown(false);
@@ -210,6 +210,8 @@ void FileView::setDelegate(Global::ViewMode mode, BaseItemDelegate *view)
 
 bool FileView::setRootUrl(const QUrl &url)
 {
+    d->url = url;
+
     clearSelection();
     selectionModel()->clear();
     d->statusBar->itemCounted(0);
@@ -2057,6 +2059,12 @@ void FileView::rowsAboutToBeRemoved(const QModelIndex &parent, int start, int en
     DListView::rowsAboutToBeRemoved(parent, start, end);
 }
 
+void FileView::showEvent(QShowEvent *event)
+{
+    DListView::showEvent(event);
+    focusOnView();
+}
+
 void FileView::initializeModel()
 {
     FileViewModel *viewModel = new FileViewModel(this);
@@ -2466,4 +2474,13 @@ void FileView::saveViewModeState()
 
     setFileViewStateValue(url, "iconSizeLevel", d->statusBar->scalingSlider()->value());
     setFileViewStateValue(url, "viewMode", static_cast<int>(d->currentViewMode));
+}
+
+void FileView::focusOnView()
+{
+    if (WorkspaceHelper::instance()->isFocusFileViewDisabled(d->url.scheme()))
+        return;
+
+    if (isVisible())
+        setFocus();
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -176,6 +176,7 @@ protected:
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
 
     void rowsAboutToBeRemoved(const QModelIndex &parent, int start, int end) override;
+    void showEvent(QShowEvent *event) override;
 
 Q_SIGNALS:
     void reqOpenNewWindow(const QList<QUrl> &urls);
@@ -239,6 +240,8 @@ private:
     bool expandOrCollapseItem(const QModelIndex &index, const QPoint &pos);
 
     void recordSelectedUrls();
+
+    void focusOnView();
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.h
@@ -30,6 +30,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SIGNAL(signal_ReportLog_Commit)
 
     // slot events
+    DPF_EVENT_REG_SLOT(slot_RegisterFocusFileViewDisabled)
     DPF_EVENT_REG_SLOT(slot_RegisterFileView)
     DPF_EVENT_REG_SLOT(slot_RegisterMenuScene)
     DPF_EVENT_REG_SLOT(slot_FindMenuScene)


### PR DESCRIPTION
- feat: add focus file view disable functionality to workspace
- fix: update time retrieval methods in RootInfo and FileSortWorker

Log: fix some issues

## Summary by Sourcery

Implement per-scheme control to disable auto-focusing file views and fix time conversion logic for file metadata.

New Features:
- Allow disabling auto-focus of file views on a per-scheme basis

Bug Fixes:
- Correct file timestamps in RootInfo and FileSortWorker to use seconds-since-epoch

Enhancements:
- Add a display role for last-read time and format it consistently
- Register and handle the focus-disable slot in workspace and search plugins