### PR TITLE
fix: info and debug level logs are still printed when the debug mode …

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.62) unstable; urgency=medium
+
+  * fix info and debug level logs are still printed
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 12 Jun 2025 20:36:48 +0800
+
 dde-file-manager (6.5.61) unstable; urgency=medium
 
   * fix some bugs.

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -202,7 +202,7 @@ static bool pluginsLoad()
         return false;
     }
     if (!corePlugin->fileName().contains(kLibCore)) {
-        qCCritical(logAppFileManager) << "pluginsLoad: Core plugin library mismatch, expected:" << kLibCore 
+        qCCritical(logAppFileManager) << "pluginsLoad: Core plugin library mismatch, expected:" << kLibCore
                                       << "actual:" << corePlugin->fileName();
         return false;
     }
@@ -405,6 +405,10 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppFileManager) << "main: Application started successfully, PID:" << a.applicationPid();
     int ret { a.exec() };
+
+    // Immediately disable all debug logging after event loop ends to prevent unwanted debug output during shutdown
+    qCInfo(logAppFileManager) << "main: Reset log rules:" << LoggerRules::instance().rules();
+    LoggerRules::instance().setRules(LoggerRules::instance().rules());
 
     mo->unRegisterDBus();
     a.closeServer();


### PR DESCRIPTION
…is not enabled.

- Added logging to reset log rules immediately after the event loop ends to prevent unwanted debug output during shutdown.
- Improved clarity of error messages related to core plugin library mismatches.

Log: This update improves the maintainability of logging practices in the dde-file-manager application.

Bug: https://pms.uniontech.com/bug-view-319599.html

## Summary by Sourcery

Reset log rules after the application event loop to suppress unwanted debug output during shutdown and clean up plugin mismatch logging.

Bug Fixes:
- Prevent info and debug logs from being printed after the event loop ends by resetting log rules immediately.

Enhancements:
- Remove trailing whitespace from core plugin library mismatch log statement for clarity.