### PR TITLE
fix bugs

### DIFF
--- a/src/apps/config.h.in
+++ b/src/apps/config.h.in
@@ -80,6 +80,12 @@
 #    warning "cmake unseting definition DFM_PREVIEW_TOOL"
 #endif
 
+#ifndef DFM_FILE_MANAGER_BINARY
+#    define DFM_FILE_MANAGER_BINARY "${CMAKE_INSTALL_FULL_LIBEXECDIR}/dde-file-manager"
+#elif
+#    warning "cmake unseting definition DFM_FILE_MANAGER_BINARY"
+#endif
+
 #ifndef VERSION
 #    define VERSION "@VERSION@"
 #endif

--- a/src/apps/dde-file-manager-preview/filepreview/main.cpp
+++ b/src/apps/dde-file-manager-preview/filepreview/main.cpp
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "previewsingleapplication.h"
+
+#include <dfm-base/utils/windowutils.h>
+
 #include <QProcessEnvironment>
+
 #ifdef DFM_ORGANIZATION_NAME
 #    define ORGANIZATION_NAME DFM_ORGANIZATION_NAME
 #else
@@ -12,6 +16,11 @@
 
 int main(int argc, char *argv[])
 {
+    // 管理员模式可能丢失 QT_QPA_PLATFORM
+    if (DFMBASE_NAMESPACE::WindowUtils::isX11() && qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "dxcb");
+    }
+
     // singlentan process
     PreviewSingleApplication app(argc, argv);
 

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/dfm_plugin_defines.h>
 #include <dfm-base/utils/sysinfoutils.h>
 #include <dfm-base/utils/loggerrules.h>
+#include <dfm-base/utils/windowutils.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/dpf.h>
@@ -65,6 +66,11 @@ static constexpr int kTimerInterval { 60 * 1000 };   // 1 min
  */
 static void setEnvForRoot()
 {
+    // 管理员模式可能丢失 QT_QPA_PLATFORM
+    if (DFMBASE_NAMESPACE::WindowUtils::isX11() && qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "dxcb");
+    }
+
     QProcess p1;
     QProcess p2;
 
@@ -254,8 +260,14 @@ static void initEnv()
         setenv("QT_IM_MODULE", "fcitx", 1);
     }
 
-    if (SysInfoUtils::isOpenAsAdmin())
+    if (SysInfoUtils::isOpenAsAdmin()) {
+        qCInfo(logAppFileManager) << "initEnv: Running as admin, printing all environment variables:";
+        QStringList envVars = QProcess::systemEnvironment();
+        for (const QString &envVar : envVars) {
+            qCInfo(logAppFileManager) << "ENV:" << envVar;
+        }
         setEnvForRoot();
+    }
 }
 
 static void initLogFilter()

--- a/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
+++ b/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
@@ -17,9 +17,17 @@ function get_scale_factor() {
 }
 
 function run_pkexec() {
+        # 创建临时文件保存原始会话类型
+        TEMP_SESSION_FILE="/tmp/.dde-fm-session-$$"
+        echo "$XDG_SESSION_TYPE" > "$TEMP_SESSION_FILE"
+        
         xhost +SI:localuser:root
         echo "run in pkexec: $@"
-        pkexec --disable-internal-agent "$@" `id -u`
+        pkexec --disable-internal-agent "$@" `id -u` "$TEMP_SESSION_FILE"
+        
+        # 清理临时文件
+        rm -f "$TEMP_SESSION_FILE"
+        
         xhost -SI:localuser:root
         xhost
 }
@@ -29,13 +37,26 @@ function run_app() {
         user_name=$(logname)
         uid=$(id -u "$user_name")
         echo "runner uid: $uid"
+        
+        # 获取原始会话类型
+        ORIGINAL_SESSION_TYPE=""
+        TEMP_SESSION_FILE="$2"  # 第二个参数是临时文件路径
+        if [ -f "$TEMP_SESSION_FILE" ]; then
+            ORIGINAL_SESSION_TYPE=$(cat "$TEMP_SESSION_FILE")
+            echo "Read original session type: $ORIGINAL_SESSION_TYPE"
+        else
+            ORIGINAL_SESSION_TYPE="$XDG_SESSION_TYPE"
+            echo "Using current session type: $ORIGINAL_SESSION_TYPE"
+        fi
+        
         export XDG_RUNTIME_DIR=/run/user/$uid
         
         # Set environment variables based on session type
-        if [ "$XDG_SESSION_TYPE" == "x11" ]; then
+        if [ "$ORIGINAL_SESSION_TYPE" == "x11" ]; then
             export DISPLAY=:0
             export QT_QPA_PLATFORM=xcb
             export GDK_BACKEND=x11
+            export XDG_SESSION_TYPE=x11
         else
             export WAYLAND_DISPLAY=wayland-0
             export DISPLAY=:0

--- a/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
+++ b/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
@@ -30,12 +30,21 @@ function run_app() {
         uid=$(id -u "$user_name")
         echo "runner uid: $uid"
         export XDG_RUNTIME_DIR=/run/user/$uid
-        export WAYLAND_DISPLAY=wayland-0
-        export DISPLAY=:0
-        export QT_WAYLAND_SHELL_INTEGRATION=kwayland-shell
-        export XDG_SESSION_TYPE=wayland
-        export QT_QPA_PLATFORM=
-        export GDK_BACKEND=x11
+        
+        # Set environment variables based on session type
+        if [ "$XDG_SESSION_TYPE" == "x11" ]; then
+            export DISPLAY=:0
+            export QT_QPA_PLATFORM=xcb
+            export GDK_BACKEND=x11
+        else
+            export WAYLAND_DISPLAY=wayland-0
+            export DISPLAY=:0
+            export QT_WAYLAND_SHELL_INTEGRATION=kwayland-shell
+            export XDG_SESSION_TYPE=wayland
+            export QT_QPA_PLATFORM=
+            export GDK_BACKEND=x11
+        fi
+        
         export $(dbus-launch)
 
         scale_factor=$(get_scale_factor)
@@ -44,19 +53,15 @@ function run_app() {
             export QT_SCALE_FACTOR=$scale_factor
         fi
 
-        dde-file-manager "$1" -w "$(pwd)"
+        file-manager.sh "$1" -w "$(pwd)"
 }
 
 echo "run dde-file-manager in $XDG_SESSION_TYPE"
-if [ "$XDG_SESSION_TYPE" == "x11" ];then
-        pkexec dde-file-manager "$@" -w `pwd`
-else
-        echo "current file: $0"
-        if [ x$(id -u) != "x0" ];then
-                run_pkexec "$0" "$@"
-                exit 0
-        fi
-
-        echo "run app: $@"
-        run_app "$@"
+echo "current file: $0"
+if [ x$(id -u) != "x0" ];then
+        run_pkexec "$0" "$@"
+        exit 0
 fi
+
+echo "run app: $@"
+run_app "$@"

--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -85,7 +85,7 @@ QUrl LocalFileHandler::touchFile(const QUrl &url, const QUrl &tempUrl /*= QUrl()
 
     bool success = oper->touchFile();
     if (!success) {
-        qCWarning(logDFMBase) << "LocalFileHandler::touchFile: Failed to create file:" << url 
+        qCWarning(logDFMBase) << "LocalFileHandler::touchFile: Failed to create file:" << url
                               << "Error:" << oper->lastError().errorMsg();
         d->setError(oper->lastError());
         return QUrl();
@@ -99,7 +99,7 @@ QUrl LocalFileHandler::touchFile(const QUrl &url, const QUrl &tempUrl /*= QUrl()
     }
 
     auto templateUrl = d->loadTemplateInfo(url, tempUrl);
-    qCInfo(logDFMBase) << "LocalFileHandler::touchFile: Successfully created file:" << url 
+    qCInfo(logDFMBase) << "LocalFileHandler::touchFile: Successfully created file:" << url
                        << "Template:" << (tempUrl.isValid() ? tempUrl.toString() : "none");
     FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileAdded, url);
 
@@ -122,7 +122,7 @@ bool LocalFileHandler::mkdir(const QUrl &dir)
 
     bool success = oper->makeDirectory();
     if (!success) {
-        qCWarning(logDFMBase) << "LocalFileHandler::mkdir: Failed to create directory:" << dir 
+        qCWarning(logDFMBase) << "LocalFileHandler::mkdir: Failed to create directory:" << dir
                               << "Error:" << oper->lastError().errorMsg();
         d->setError(oper->lastError());
         return false;
@@ -154,13 +154,13 @@ bool LocalFileHandler::rmdir(const QUrl &url)
 
     QString targetTrash = oper->trashFile();
     if (targetTrash.isEmpty()) {
-        qCWarning(logDFMBase) << "LocalFileHandler::rmdir: Failed to move directory to trash:" << url 
+        qCWarning(logDFMBase) << "LocalFileHandler::rmdir: Failed to move directory to trash:" << url
                               << "Error:" << oper->lastError().errorMsg();
         d->setError(oper->lastError());
         return false;
     }
 
-    qCInfo(logDFMBase) << "LocalFileHandler::rmdir: Successfully moved directory to trash:" << url 
+    qCInfo(logDFMBase) << "LocalFileHandler::rmdir: Successfully moved directory to trash:" << url
                        << "Trash location:" << targetTrash;
 
     FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileDeleted, url);
@@ -205,11 +205,11 @@ bool LocalFileHandler::renameFile(const QUrl &url, const QUrl &newUrl, const boo
 
             bool success = oper->renameFile(newName);
             if (success) {
-                qCInfo(logDFMBase) << "LocalFileHandler::renameFile: Successfully renamed MTP file:" << url 
+                qCInfo(logDFMBase) << "LocalFileHandler::renameFile: Successfully renamed MTP file:" << url
                                    << "to:" << newUrl;
                 return true;
             } else {
-                qCWarning(logDFMBase) << "LocalFileHandler::renameFile: Failed to rename MTP file:" << url 
+                qCWarning(logDFMBase) << "LocalFileHandler::renameFile: Failed to rename MTP file:" << url
                                       << "to:" << newUrl << "Error:" << oper->lastError().errorMsg();
             }
         }
@@ -235,7 +235,7 @@ bool LocalFileHandler::renameFile(const QUrl &url, const QUrl &newUrl, const boo
 
         FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(newUrl);
         fileInfo->refresh();
-        qCInfo(logDFMBase) << "LocalFileHandler::renameFile: Successfully renamed file using system API:" 
+        qCInfo(logDFMBase) << "LocalFileHandler::renameFile: Successfully renamed file using system API:"
                            << sourceFile << "to:" << targetFile;
         return true;
     }
@@ -250,7 +250,7 @@ bool LocalFileHandler::renameFile(const QUrl &url, const QUrl &newUrl, const boo
 
     bool success = oper->renameFile(newUrl);
     if (!success) {
-        qCWarning(logDFMBase) << "LocalFileHandler::renameFile: Failed to rename file:" << url 
+        qCWarning(logDFMBase) << "LocalFileHandler::renameFile: Failed to rename file:" << url
                               << "to:" << newUrl << "Error:" << oper->lastError().errorMsg();
         d->setError(oper->lastError());
         return false;
@@ -262,7 +262,7 @@ bool LocalFileHandler::renameFile(const QUrl &url, const QUrl &newUrl, const boo
     FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileDeleted, url);
     FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileAdded, newUrl);
 
-    qCInfo(logDFMBase) << "LocalFileHandler::renameFile: Successfully renamed file using dfmio:" 
+    qCInfo(logDFMBase) << "LocalFileHandler::renameFile: Successfully renamed file using dfmio:"
                        << url << "to:" << newUrl;
 
     return true;
@@ -306,7 +306,7 @@ bool LocalFileHandler::openFiles(const QList<QUrl> &fileUrls)
 
         // 1. Handle symlinks
         auto resolvedUrl = d->resolveSymlink(fileUrl);
-        if (!resolvedUrl) {  // If resolution fails, continue to next file
+        if (!resolvedUrl) {   // If resolution fails, continue to next file
             qCDebug(logDFMBase) << "LocalFileHandler::openFiles: Failed to resolve symlink for:" << fileUrl;
             continue;
         }
@@ -369,12 +369,12 @@ bool LocalFileHandler::openFilesByApp(const QList<QUrl> &fileUrls, const QString
         return ok;
     }
 
-    qCDebug(logDFMBase) << "LocalFileHandler::openFilesByApp: Opening" << fileUrls.size() 
+    qCDebug(logDFMBase) << "LocalFileHandler::openFilesByApp: Opening" << fileUrls.size()
                         << "files with app:" << desktopFile;
 
     GDesktopAppInfo *appInfo = g_desktop_app_info_new_from_filename(desktopFile.toLocal8Bit().constData());
     if (!appInfo) {
-        qCWarning(logDFMBase) << "LocalFileHandler::openFilesByApp: Failed to create GDesktopAppInfo from:" 
+        qCWarning(logDFMBase) << "LocalFileHandler::openFilesByApp: Failed to create GDesktopAppInfo from:"
                               << desktopFile << "Check if file exists and PATH is correct";
         return false;
     }
@@ -400,7 +400,7 @@ bool LocalFileHandler::openFilesByApp(const QList<QUrl> &fileUrls, const QString
     g_object_unref(appInfo);
 
     if (ok) {
-        qCInfo(logDFMBase) << "LocalFileHandler::openFilesByApp: Successfully opened files with app:" 
+        qCInfo(logDFMBase) << "LocalFileHandler::openFilesByApp: Successfully opened files with app:"
                            << desktopFile << "Files count:" << fileUrls.size();
         // workaround since DTK apps doesn't support the recent file spec.
         // spec: https://www.freedesktop.org/wiki/Specifications/desktop-bookmark-spec/
@@ -409,7 +409,7 @@ bool LocalFileHandler::openFilesByApp(const QList<QUrl> &fileUrls, const QString
         QString mimetype = d->getFileMimetype(fileUrls.first());
         d->addRecentFile(desktopFile, fileUrls, mimetype);
     } else {
-        qCWarning(logDFMBase) << "LocalFileHandler::openFilesByApp: Failed to open files with app:" 
+        qCWarning(logDFMBase) << "LocalFileHandler::openFilesByApp: Failed to open files with app:"
                               << desktopFile;
     }
 
@@ -435,13 +435,13 @@ bool LocalFileHandler::createSystemLink(const QUrl &sourcefile, const QUrl &link
 
     bool success = oper->createLink(link);
     if (!success) {
-        qCWarning(logDFMBase) << "LocalFileHandler::createSystemLink: Failed to create link from:" << sourcefile 
+        qCWarning(logDFMBase) << "LocalFileHandler::createSystemLink: Failed to create link from:" << sourcefile
                               << "to:" << link << "Error:" << oper->lastError().errorMsg();
         d->setError(oper->lastError());
         return false;
     }
 
-    qCInfo(logDFMBase) << "LocalFileHandler::createSystemLink: Successfully created system link from:" 
+    qCInfo(logDFMBase) << "LocalFileHandler::createSystemLink: Successfully created system link from:"
                        << sourcefile << "to:" << link;
     FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileAdded, link);
 
@@ -455,7 +455,7 @@ bool LocalFileHandler::createSystemLink(const QUrl &sourcefile, const QUrl &link
  */
 bool LocalFileHandler::setPermissions(const QUrl &url, QFileDevice::Permissions permissions)
 {
-    qCDebug(logDFMBase) << "LocalFileHandler::setPermissions: Setting permissions for:" << url 
+    qCDebug(logDFMBase) << "LocalFileHandler::setPermissions: Setting permissions for:" << url
                         << "Permissions:" << QString::number(static_cast<uint16_t>(permissions), 8);
 
     QSharedPointer<DFMIO::DFile> dfile { new DFMIO::DFile(url) };
@@ -468,21 +468,21 @@ bool LocalFileHandler::setPermissions(const QUrl &url, QFileDevice::Permissions 
     // eg. bug-199607: Copy MTP folder to local, folder permissions wrong
     // reason: `dfm-io` uses gio to query the `unix::mode` field to get file permissions, but this field is not available in MTP file
     if (0 == permissions) {
-        qCDebug(logDFMBase) << "LocalFileHandler::setPermissions: Skipping permission setting for:" << url 
+        qCDebug(logDFMBase) << "LocalFileHandler::setPermissions: Skipping permission setting for:" << url
                             << "Permissions value is 0 (likely from MTP or unsupported filesystem)";
         return true;
     }
 
     bool success = dfile->setPermissions(DFMIO::DFile::Permissions(uint16_t(permissions)));
     if (!success) {
-        qCWarning(logDFMBase) << "LocalFileHandler::setPermissions: Failed to set permissions for:" << url 
+        qCWarning(logDFMBase) << "LocalFileHandler::setPermissions: Failed to set permissions for:" << url
                               << "Permissions:" << QString::number(static_cast<uint16_t>(permissions), 8)
                               << "Error:" << dfile->lastError().errorMsg();
         d->setError(dfile->lastError());
         return false;
     }
 
-    qCDebug(logDFMBase) << "LocalFileHandler::setPermissions: Successfully set permissions for:" << url 
+    qCDebug(logDFMBase) << "LocalFileHandler::setPermissions: Successfully set permissions for:" << url
                         << "Permissions:" << QString::number(static_cast<uint16_t>(permissions), 8);
     return true;
 }
@@ -590,14 +590,14 @@ bool LocalFileHandler::deleteFile(const QUrl &url)
 
     bool success = dOperator->deleteFile();
     if (!success) {
-        qCWarning(logDFMBase) << "LocalFileHandler::deleteFile: Failed to delete file:" << url 
+        qCWarning(logDFMBase) << "LocalFileHandler::deleteFile: Failed to delete file:" << url
                               << "Error:" << dOperator->lastError().errorMsg();
         d->setError(dOperator->lastError());
         return false;
     }
-    
+
     FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileDeleted, url);
-    qCInfo(logDFMBase) << "LocalFileHandler::deleteFile: Successfully deleted file:" << url;
+    qCWarning(logDFMBase) << "LocalFileHandler::deleteFile: Successfully deleted file:" << url;
 
     return true;
 }
@@ -612,7 +612,7 @@ bool LocalFileHandler::deleteFileRecursive(const QUrl &url)
     }
 
     if (SystemPathUtil::instance()->isSystemPath(url.toLocalFile())) {
-        qCCritical(logDFMBase) << "LocalFileHandler::deleteFileRecursive: CRITICAL - Attempted to delete system path:" 
+        qCCritical(logDFMBase) << "LocalFileHandler::deleteFileRecursive: CRITICAL - Attempted to delete system path:"
                                << url << "Operation aborted for safety";
         abort();
     }
@@ -659,7 +659,7 @@ bool LocalFileHandler::deleteFileRecursive(const QUrl &url)
         } else {
             itemSuccess = deleteFile(urlNext);
         }
-        
+
         if (itemSuccess) {
             deletedCount++;
         } else {
@@ -667,7 +667,7 @@ bool LocalFileHandler::deleteFileRecursive(const QUrl &url)
         }
     }
 
-    qCDebug(logDFMBase) << "LocalFileHandler::deleteFileRecursive: Deleted" << deletedCount 
+    qCDebug(logDFMBase) << "LocalFileHandler::deleteFileRecursive: Deleted" << deletedCount
                         << "items from directory:" << url;
 
     bool dirDeleted = deleteFile(url);
@@ -676,7 +676,7 @@ bool LocalFileHandler::deleteFileRecursive(const QUrl &url)
     } else {
         qCWarning(logDFMBase) << "LocalFileHandler::deleteFileRecursive: Failed to delete directory after clearing contents:" << url;
     }
-    
+
     return succ && dirDeleted;
 }
 /*!

--- a/src/dfm-base/utils/windowutils.cpp
+++ b/src/dfm-base/utils/windowutils.cpp
@@ -9,11 +9,51 @@
 #include <QApplication>
 #include <QScreen>
 
+bool DFMBASE_NAMESPACE::WindowUtils::isX11()
+{
+    if (QGuiApplication::platformName() == "xcb") {
+        return true;
+    }
+
+    // 检查DISPLAY环境变量
+    const char *display = std::getenv("DISPLAY");
+    if (!display || display[0] == '\0') {
+        return false;
+    }
+
+    // 检查XDG_SESSION_TYPE环境变量
+    const char *session_type = std::getenv("XDG_SESSION_TYPE");
+    if (session_type && strcmp(session_type, "x11") == 0) {
+        return true;
+    }
+
+    // 如果DISPLAY存在但XDG_SESSION_TYPE不是wayland，可能是X11
+    if (session_type && strcmp(session_type, "wayland") != 0) {
+        return true;
+    }
+
+    return false;
+}
+
 bool DFMBASE_NAMESPACE::WindowUtils::isWayLand()
 {
-    //! This function can only be called after QApplication to return a valid value, before it will return a null value
-    Q_ASSERT(qApp);
-    return QApplication::platformName() == "wayland";
+    if (QGuiApplication::platformName() == "wayland") {
+        return true;
+    }
+
+    // 方法1：检查WAYLAND_DISPLAY环境变量
+    const char *wayland_display = std::getenv("WAYLAND_DISPLAY");
+    if (wayland_display && wayland_display[0] != '\0') {
+        return true;
+    }
+
+    // 方法2：检查XDG_SESSION_TYPE环境变量
+    const char *session_type = std::getenv("XDG_SESSION_TYPE");
+    if (session_type && strcmp(session_type, "wayland") == 0) {
+        return true;
+    }
+
+    return false;
 }
 
 bool DFMBASE_NAMESPACE::WindowUtils::keyShiftIsPressed()

--- a/src/dfm-base/utils/windowutils.h
+++ b/src/dfm-base/utils/windowutils.h
@@ -18,6 +18,8 @@ namespace dfmbase {
 class WindowUtils
 {
 public:
+    static bool isX11();
+
     static bool isWayLand();
 
     static bool keyShiftIsPressed();

--- a/src/plugins/daemon/filemanager1/CMakeLists.txt
+++ b/src/plugins/daemon/filemanager1/CMakeLists.txt
@@ -8,20 +8,20 @@ configure_file(
     )
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(FILEMANGER1_XML ${DFM_DBUS_XML_DIR}/org.freedesktop.FileManager1.xml)
+set(FILEMANAGER1_XML ${DFM_DBUS_XML_DIR}/org.freedesktop.FileManager1.xml)
 
 FILE(GLOB_RECURSE SRC_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/*.json"
-    "${FILEMANGER1_XML}"
+    "${FILEMANAGER1_XML}"
     )
 
 find_package(Qt6 COMPONENTS
     DBus
     REQUIRED)
 
-qt6_add_dbus_adaptor(SRC_FILES ${FILEMANGER1_XML}
+qt6_add_dbus_adaptor(SRC_FILES ${FILEMANAGER1_XML}
     filemanager1dbus.h FileManager1DBus)
 
 add_library(${PROJECT_NAME}

--- a/src/plugins/daemon/filemanager1/CMakeLists.txt
+++ b/src/plugins/daemon/filemanager1/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(dfmdaemon-filemanager1-plugin)
 
+configure_file(
+    "${APP_SOURCE_DIR}/config.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+    )
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(FILEMANGER1_XML ${DFM_DBUS_XML_DIR}/org.freedesktop.FileManager1.xml)
 
@@ -26,6 +31,11 @@ add_library(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DAEMON_DIR})
+
+target_include_directories(${PROJECT_NAME}
+    PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    )
 
 target_link_libraries(${PROJECT_NAME}
     DFM6::base

--- a/src/plugins/daemon/filemanager1/filemanager1dbus.cpp
+++ b/src/plugins/daemon/filemanager1/filemanager1dbus.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "config.h"   //cmake
 #include "daemonplugin_filemanager1_global.h"
 #include "filemanager1dbus.h"
 
@@ -40,8 +41,8 @@ void FileManager1DBus::ShowFolders(const QStringList &URIs, const QString &Start
         return;
     }
 
-    if (QProcess::startDetached("dde-file-manager", QStringList() << "--raw" << URIs)) {
-        fmDebug() << "[FileManager1DBus] ShowFolders launched via dde-file-manager";
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, QStringList() << "--raw" << URIs)) {
+        fmDebug() << "[FileManager1DBus] ShowFolders launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for ShowFolders request";
     }
@@ -62,9 +63,9 @@ void FileManager1DBus::ShowItemProperties(const QStringList &URIs, const QString
         return;
     }
 
-    if (QProcess::startDetached("dde-file-manager", QStringList() << "--raw"
-                                                                  << "-p" << URIs)) {
-        fmDebug() << "[FileManager1DBus] ShowItemProperties launched via dde-file-manager";
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, QStringList() << "--raw"
+                                                                       << "-p" << URIs)) {
+        fmDebug() << "[FileManager1DBus] ShowItemProperties launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for ShowItemProperties request";
     }
@@ -87,8 +88,8 @@ void FileManager1DBus::ShowItems(const QStringList &URIs, const QString &Startup
         return;
     }
 
-    if (QProcess::startDetached("dde-file-manager", QStringList() << "--show-item" << URIs << "--raw")) {
-        fmDebug() << "[FileManager1DBus] ShowItems launched via dde-file-manager";
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, QStringList() << "--show-item" << URIs << "--raw")) {
+        fmDebug() << "[FileManager1DBus] ShowItems launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for ShowItems request";
     }
@@ -115,10 +116,10 @@ void FileManager1DBus::Trash(const QStringList &URIs)
         return;
     }
 
-    if (QProcess::startDetached("dde-file-manager",
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY,
                                 QStringList() << "--event"
                                               << doc.toJson())) {
-        fmDebug() << "[FileManager1DBus] Trash operation launched via dde-file-manager";
+        fmDebug() << "[FileManager1DBus] Trash operation launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for Trash request";
     }
@@ -150,8 +151,8 @@ void FileManager1DBus::Open(const QStringList &URIs)
         return;
     }
 
-    if (QProcess::startDetached("dde-file-manager", processedArgs)) {
-        fmDebug() << "[FileManager1DBus] Open operation launched via dde-file-manager";
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, processedArgs)) {
+        fmDebug() << "[FileManager1DBus] Open operation launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for Open request";
     }


### PR DESCRIPTION
## Summary by Sourcery

Fix file manager plugin invocation paths and restore Qt platform plugin when running as root

Bug Fixes:
- Use the DFM_FILE_MANAGER_BINARY constant instead of hardcoded "dde-file-manager" in FileManager1DBus invocations
- Restore QT_QPA_PLATFORM to "dxcb" when running the preview and main applications as root under xcb to prevent missing platform plugins

Enhancements:
- Update debug logs to reflect launching via the binary constant

Build:
- Configure and include a generated config.h in the filemanager1 CMake build for DFM_FILE_MANAGER_BINARY definition