### PR TITLE
fix bugs

### DIFF
--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -543,7 +543,7 @@ void BookMarkManager::fileRenamed(const QUrl &oldUrl, const QUrl &newUrl)
     QVariantList list = Application::genericSetting()->value(kConfigGroupQuickAccess, kConfigKeyName).toList();
     for (int i = 0; i < list.size(); ++i) {
         QVariantMap map = list.at(i).toMap();
-        if (map.value(kKeyName).toString() == quickAccessDataMap.value(oldUrl).name) {
+        if (quickAccessDataMap.contains(oldUrl) && oldUrl == map.value(kKeyUrl).toUrl()) {
             map[kKeyUrl] = newUrl;
             list[i] = map;
 

--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -306,7 +306,7 @@ bool BookMarkManager::bookMarkRename(const QUrl &url, const QString &newName)
     QVariantList list = Application::genericSetting()->value(kConfigGroupQuickAccess, kConfigKeyName).toList();
     for (int i = 0; i < list.size(); ++i) {
         QVariantMap map = list.at(i).toMap();
-        if (map.value(kKeyName).toString() == quickAccessDataMap[url].name) {
+        if (quickAccessDataMap.contains(url) && url == map.value(kKeyUrl).toUrl()) {
             QString oldName = quickAccessDataMap[url].name;
             map[kKeyName] = newName;
             map[kKeyLastModi] = QDateTime::currentDateTime().toString(Qt::ISODate);

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.cpp
@@ -153,7 +153,8 @@ bool DFMSearcher::isValidSearchParameters() const
 bool DFMSearcher::validateSearchType(const QString &transformedPath, SearchOptions &options)
 {
     if (engine->searchType() == SearchType::Content) {
-        if (!DFMSEARCH::Global::isPathInFileNameIndexDirectory(transformedPath)) {
+        if (DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()
+            && !DFMSEARCH::Global::isPathInFileNameIndexDirectory(transformedPath)) {
             fmInfo() << "Full-text search is currently only supported for Indexed, current path not indexed: " << transformedPath;
             return false;
         } else {
@@ -179,7 +180,7 @@ SearchOptions DFMSearcher::configureSearchOptions(const QString &transformedPath
     options.setCaseSensitive(false);
 
     configureHiddenFilesOption(options, transformedPath);
-    
+
     if (options.method() == SearchMethod::Realtime) {
         configureRealtimeSearchOptions(options, transformedPath);
     }
@@ -201,7 +202,7 @@ void DFMSearcher::configureHiddenFilesOption(SearchOptions &options, const QStri
 void DFMSearcher::configureRealtimeSearchOptions(SearchOptions &options, const QString &transformedPath) const
 {
     options.setResultFoundEnabled(true);
-    
+
     // 判断是否需要排除索引路径
     if (shouldExcludeIndexedPaths(transformedPath)) {
         setExcludedPathsForRealtime(options);
@@ -214,13 +215,12 @@ bool DFMSearcher::shouldExcludeIndexedPaths(const QString &transformedPath) cons
     if (DFMSEARCH::Global::isHiddenPathOrInHiddenDir(transformedPath)) {
         return false;
     }
-    
+
     // 当索引目录不可用时，不排除索引路径
-    if (engine->searchType() == SearchType::FileName && 
-        !DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()) {
+    if (engine->searchType() == SearchType::FileName && !DFMSEARCH::Global::isFileNameIndexDirectoryAvailable()) {
         return false;
     }
-    
+
     // 其他情况下，排除索引路径以避免重复搜索
     return true;
 }


### PR DESCRIPTION
## Summary by Sourcery

Fix bookmark rename and file rename operations to correctly match and update entries by URL and avoid invalid map access.

Bug Fixes:
- Guard against missing entries by checking quickAccessDataMap.contains() before accessing in bookMarkRename and fileRenamed.
- Match bookmark entries by URL (kKeyUrl) instead of name when renaming bookmarks and files.