### PR TITLE
refactor: remove completeFileInfo methods and implement doCompleteSortInfo for file information retrieval

### DIFF
--- a/include/dfm-base/interfaces/sortfileinfo.h
+++ b/include/dfm-base/interfaces/sortfileinfo.h
@@ -63,11 +63,6 @@ public:
     bool isInfoCompleted() const;
     bool needsCompletion() const;
 
-    // 新增：文件信息补全接口（一次性获取所有信息）
-    bool completeFileInfo();  // 同步补全
-    QFuture<bool> completeFileInfoAsync();  // 异步补全
-    QFuture<bool> completeFileInfoAsync(CompletionCallback callback);  // 异步补全带回调
-
 private:
     QScopedPointer<SortFileInfoPrivate> d;
 };

--- a/src/dfm-base/interfaces/private/sortfileinfo_p.h
+++ b/src/dfm-base/interfaces/private/sortfileinfo_p.h
@@ -17,9 +17,6 @@ public:
     explicit SortFileInfoPrivate(SortFileInfo *qq);
     ~SortFileInfoPrivate();
 
-    // 内部补全方法
-    bool doCompleteFileInfo();
-
 public:
     SortFileInfo *const q;   // SortFileInfo实例对象
     QUrl url;

--- a/src/dfm-base/interfaces/sortfileinfo.cpp
+++ b/src/dfm-base/interfaces/sortfileinfo.cpp
@@ -183,53 +183,6 @@ bool SortFileInfo::needsCompletion() const
     return !isInfoCompleted();
 }
 
-// 新增：文件信息补全接口
-bool SortFileInfo::completeFileInfo()
-{
-    if (isInfoCompleted()) {
-        return true;  // 已经完成，无需重复获取
-    }
-    return d->doCompleteFileInfo();
-}
-
-QFuture<bool> SortFileInfo::completeFileInfoAsync()
-{
-    if (isInfoCompleted()) {
-        // 如果已经完成，返回一个立即完成的 Future
-        QPromise<bool> promise;
-        promise.start();
-        promise.addResult(true);
-        promise.finish();
-        return promise.future();
-    }
-    
-    return QtConcurrent::run([this]() {
-        return d->doCompleteFileInfo();
-    });
-}
-
-QFuture<bool> SortFileInfo::completeFileInfoAsync(CompletionCallback callback)
-{
-    if (isInfoCompleted()) {
-        if (callback) {
-            callback(true);
-        }
-        QPromise<bool> promise;
-        promise.start();
-        promise.addResult(true);
-        promise.finish();
-        return promise.future();
-    }
-    
-    return QtConcurrent::run([this, callback]() {
-        bool success = d->doCompleteFileInfo();
-        if (callback) {
-            callback(success);
-        }
-        return success;
-    });
-}
-
 SortFileInfoPrivate::SortFileInfoPrivate(SortFileInfo *qq)
     : q(qq)
 {
@@ -239,50 +192,5 @@ SortFileInfoPrivate::~SortFileInfoPrivate()
 {
 }
 
-bool SortFileInfoPrivate::doCompleteFileInfo()
-{
-    if (!url.isLocalFile()) {
-        return false;
-    }
-    
-    struct stat64 statBuffer;
-    const QString filePath = url.path();
-    
-    if (::stat64(filePath.toUtf8().constData(), &statBuffer) != 0) {
-        return false;
-    }
-    
-    QMutexLocker locker(&mutex);
-    
-    // 一次性设置所有从 stat64 获取的信息
-    
-    // 基础信息
-    filesize = statBuffer.st_size;
-    file = S_ISREG(statBuffer.st_mode);
-    dir = S_ISDIR(statBuffer.st_mode);
-    symLink = S_ISLNK(statBuffer.st_mode);
-    
-    // 权限信息
-    readable = statBuffer.st_mode & S_IRUSR;
-    writeable = statBuffer.st_mode & S_IWUSR;
-    executable = statBuffer.st_mode & S_IXUSR;
-    
-    // 时间信息
-    lastRead = statBuffer.st_atime;
-    lastModifed = statBuffer.st_mtime;
-    create = statBuffer.st_ctime;
-    
-    // 隐藏文件检查
-    QString fileName = url.fileName();
-    hide = fileName.startsWith('.');
-    
-    // 设置 MIME 类型显示名称（这个不需要额外的文件系统调用）
-    displayType = MimeTypeDisplayManager::instance()->displayTypeFromPath(url.path());
-    
-    // 标记所有信息已完成
-    infoCompleted = true;
-    
-    return true;
-}
 
 }

--- a/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.h
+++ b/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.h
@@ -41,6 +41,7 @@ signals:
 
 private:
     SearchDirIteratorPrivate *const d { nullptr };
+    void doCompleteSortInfo(SortInfoPointer sortInfo);
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp
@@ -331,9 +331,6 @@ bool AdvanceSearchBarPrivate::shouldVisiableByFilterRule(SortFileInfo *info, QVa
         }
     }
 
-    if (!info->completeFileInfo())
-        return false;
-
     if (filter.comboValid[kFileType]) {
         QString fileTypeStr = info->displayType();
         if (!fileTypeStr.startsWith(filter.typeString))

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -323,6 +323,8 @@ bool SearchHelper::isHiddenFile(const QString &fileName, QHash<QString, QSet<QSt
 
 bool SearchHelper::allowRepeatUrl(const QUrl &cur, const QUrl &pre)
 {
+    if (UniversalUtils::urlEqualsWithQuery(cur, pre))
+        return false;
     if (cur.scheme() == scheme() && pre.scheme() == scheme())
         return true;
     return false;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
@@ -174,7 +174,6 @@ private:
                   const AbstractSortFilter::SortScenarios sort);
     bool sortInfoUpdateByFileInfo(const FileInfoPointer fileInfo);
 
-private:
     void switchTreeView();
     void switchListView();
     QList<QUrl> sortAllTreeFilesByParent(const QUrl &dir, const bool reverse = false);
@@ -194,7 +193,6 @@ private:
     void removeVisibleChildren(const int startPos, const int size);
     void createAndInsertItemData(const int8_t depth, const SortInfoPointer child, const FileInfoPointer info);
 
-private:
     int insertSortList(const QUrl &needNode, const QList<QUrl> &list,
                        AbstractSortFilter::SortScenarios sort);
     bool lessThan(const QUrl &left, const QUrl &right, AbstractSortFilter::SortScenarios sort);
@@ -211,6 +209,7 @@ private:
                             const InsertOpt opt = InsertOpt::kInsertOptAppend, const int endPos = -1);
     bool checkAndUpdateFileInfoUpdate();
     void checkAndSortBytMimeType(const QUrl &url);
+    void doCompleteFileInfo(SortInfoPointer sortInfo);
 
 private:
     QUrl current;


### PR DESCRIPTION
- Removed the completeFileInfo and related asynchronous methods from SortFileInfo, simplifying the interface.
- Introduced doCompleteSortInfo in SearchDirIterator and FileSortWorker to handle file information retrieval directly.
- Updated relevant areas to utilize the new method for improved file information management.

Log: This refactor streamlines file information handling by consolidating retrieval logic and removing redundant methods.
Bug: https://pms.uniontech.com/bug-view-320215.html

## Summary by Sourcery

Streamline file information retrieval by removing the legacy `completeFileInfo` API from `SortFileInfo` and consolidating stat logic into new direct methods in both search and workspace components.

Enhancements:
- Remove deprecated synchronous and asynchronous `completeFileInfo` methods from `SortFileInfo` and its private implementation
- Introduce `doCompleteFileInfo` in `FileSortWorker` to synchronously populate file metadata via `stat64`
- Introduce `doCompleteSortInfo` in `SearchDirIterator` to inline file info completion during search
- Update all call sites to replace `completeFileInfo` invocations with the new direct completion methods, removing redundant includes and callbacks