### PR TITLE
chore: update changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.64) unstable; urgency=medium
+
+  * fix some bugs.
+
+ -- Liuyangming <liuyangming@uniontech.com>  Wed, 18 Jun 2025 11:28:55 +0800
+
 dde-file-manager (6.5.63) unstable; urgency=medium
 
   * unknown


### PR DESCRIPTION
update version to 6.5.64

Log: update changelog

## Summary by Sourcery

Update Debian packaging changelog and bump version to 6.5.64

Chores:
- Bump Debian package version to 6.5.64
- Update changelog entries