### PR TITLE
fix: add checkKeyOnly method to RootInfo for key validation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.65) unstable; urgency=medium
+
+  * fix some bugs. 
+
+ -- Liuyangming <liuyangming@uniontech.com>  Wed, 18 Jun 2025 18:40:08 +0800
+
 dde-file-manager (6.5.64) unstable; urgency=medium
 
   * fix some bugs.

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -290,6 +290,16 @@ QStringList RootInfo::getKeyWords() const
     return keyWords;
 }
 
+bool RootInfo::checkKeyOnly(const QString &key) const
+{
+    for (auto threadKey : traversalThreads.keys()) {
+        if (threadKey != key)
+            return false;
+    }
+
+    return true;
+}
+
 void RootInfo::doFileDeleted(const QUrl &url)
 {
     fmDebug() << "File deleted event for URL:" << url.toString();

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -62,6 +62,8 @@ public:
     bool canDelete() const;
     QStringList getKeyWords() const;
 
+    bool checkKeyOnly(const QString &key) const;
+
 Q_SIGNALS:
     void iteratorLocalFiles(const QString &key,
                             const QList<SortInfoPointer> children,

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -121,7 +121,8 @@ void FileDataManager::stopRootWork(const QUrl &rootUrl, const QString &key)
     auto rootInfoKeys = rootInfoMap.keys();
     for (const auto &rootInfo : rootInfoKeys) {
         if (UniversalUtils::urlEqualsWithQuery(rootInfo, rootUrl) || (rootInfo.path() != rootPath && rootInfo.path().startsWith(rootPath))) {
-            rootInfoMap.value(rootInfo)->disconnect();
+            if (rootInfoMap.value(rootInfo)->checkKeyOnly(key))
+                rootInfoMap.value(rootInfo)->disconnect();
             rootInfoMap.value(rootInfo)->clearTraversalThread(key, false);
         }
     }


### PR DESCRIPTION
- Introduced a new method checkKeyOnly in RootInfo to verify if the provided key is the only key in traversalThreads.
- Updated FileDataManager to utilize checkKeyOnly for disconnecting root info based on key validation.

Log: This enhancement improves key management in the file manager by ensuring that operations are only performed when the specified key is validated.
Bug: https://pms.uniontech.com/bug-view-320213.html

## Summary by Sourcery

Validate key-only traversal threads via checkKeyOnly in RootInfo and apply it in FileDataManager to avoid premature disconnections

New Features:
- Add checkKeyOnly method to RootInfo to verify that a key is the only active traversal thread

Bug Fixes:
- Prevent unintended root disconnections in FileDataManager by only disconnecting when the specified key is sole thread