### PR TITLE
fix: fix build on gcc 15

### DIFF
--- a/include/dfm-extension/emblemicon/dfmextemblemiconlayout.h
+++ b/include/dfm-extension/emblemicon/dfmextemblemiconlayout.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <memory>
+#include <cstdint>
 
 BEGEN_DFMEXT_NAMESPACE
 


### PR DESCRIPTION
Add cstdint in src/plugins/desktop/desktoputils/widgetutil.h

Log: Need include cstdint for gcc 15

## Summary by Sourcery

Bug Fixes:
- Include <cstdint> in header to fix compilation on GCC 15