### PR TITLE
fix: trim trailing slashes from symbolic link targets in SyncFileInfo

### DIFF
--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -888,6 +888,9 @@ QString SyncFileInfoPrivate::symLinkTarget() const
         symLinkTarget.prepend(currPath);
     }
 
+    if (symLinkTarget.endsWith("/"))
+        symLinkTarget.chop(1);
+
     return symLinkTarget;
 }
 


### PR DESCRIPTION
- Added a check to remove trailing slashes from the symbolic link target string in the symLinkTarget method.
- This change ensures that the returned path is consistent and avoids potential issues with path handling.

Log: This fix improves the handling of symbolic link targets by ensuring they do not end with a trailing slash.
Bug: https://pms.uniontech.com/bug-view-318153.html

## Summary by Sourcery

Bug Fixes:
- Trim trailing slashes from symbolic link targets in SyncFileInfo to ensure consistent path handling