### PR TITLE
fix: 大量数据搜索性能问题

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -45,12 +45,6 @@ void SearchEventReceiver::handleShowAdvanceSearchBar(quint64 winId, bool visible
     SearchEventCaller::sendShowAdvanceSearchBar(winId, visible);
 }
 
-void SearchEventReceiver::handleUrlChanged(quint64 winId, const QUrl &u)
-{
-    if (u.scheme() != SearchHelper::scheme())
-        SearchEventReceiver::handleStopSearch(winId);
-}
-
 void SearchEventReceiver::handleAddressInputStr(quint64 windId, QString *str)
 {
     if (str->startsWith("search:?") && !str->contains("winId=")) {

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.h
@@ -24,7 +24,6 @@ public slots:
     void handleSearch(quint64 winId, const QString &keyword);
     void handleStopSearch(quint64 winId);
     void handleShowAdvanceSearchBar(quint64 winId, bool visible);
-    void handleUrlChanged(quint64 winId, const QUrl &u);
     void handleAddressInputStr(quint64 windId, QString *str);
     void handleFileAdd(const QUrl &url);
     void handleFileDelete(const QUrl &url);

--- a/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator_p.h
+++ b/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator_p.h
@@ -16,11 +16,39 @@
 #include <QUrl>
 #include <QMutex>
 #include <QScopedPointer>
+#include <QWaitCondition>
+#include <atomic>
 #include <mutex>
 
 DFMBASE_USE_NAMESPACE
 
 namespace dfmplugin_search {
+
+// 双缓冲搜索结果管理器
+class SearchResultBuffer
+{
+public:
+    SearchResultBuffer() = default;
+    ~SearchResultBuffer() = default;
+
+    // 生产者：更新搜索结果（主线程调用）
+    void updateResults(const DFMSearchResultMap &newResults);
+
+    // 消费者：获取当前搜索结果快照（子线程调用）
+    DFMSearchResultMap getResults() const;
+
+    // 消费者：获取并清空当前搜索结果（子线程调用）
+    DFMSearchResultMap consumeResults();
+
+    // 检查是否有数据
+    bool isEmpty() const;
+
+private:
+    mutable DFMSearchResultMap bufferA;
+    mutable DFMSearchResultMap bufferB;
+    std::atomic<bool> useBufferA { true };
+    mutable QMutex writerMutex;   // 只保护写操作
+};
 
 class SearchDirIterator;
 class SearchDirIteratorPrivate : public QObject
@@ -40,21 +68,22 @@ public Q_SLOTS:
     void onSearchStoped(const QString &id);
 
 public:
-    QUrl fileUrl;                           // 搜索URL
-    QUrl currentFileUrl;                    // 当前处理的URL
-    QString currentFileContent;             // 当前处理的文件内容
-    QString taskId;                         // 搜索任务ID
-    quint64 winId;                          // 窗口ID
+    QUrl fileUrl;   // 搜索URL
+    QUrl currentFileUrl;   // 当前处理的URL
+    QString currentFileContent;   // 当前处理的文件内容
+    QString taskId;   // 搜索任务ID
+    quint64 winId;   // 窗口ID
 
-    bool searchFinished = false;            // 搜索是否完成
-    bool searchStoped = false;              // 搜索是否停止
+    std::atomic<bool> searchFinished { false };   // 搜索是否完成(原子操作保证线程安全)
+    std::atomic<bool> searchStoped { false };   // 搜索是否停止(原子操作保证线程安全)
 
-    DFMSearchResultMap childrens;    // 搜索结果集
-    QScopedPointer<LocalFileWatcher> searchRootWatcher;  // 文件监视器
-    mutable QMutex mutex;                   // 互斥锁
-    std::once_flag searchOnceFlag;          // 一次性标志
-    SearchDirIterator *q = nullptr;         // 指向父类的指针
+    SearchResultBuffer resultBuffer;   // 双缓冲搜索结果
+    QScopedPointer<LocalFileWatcher> searchRootWatcher;   // 文件监视器
+    std::once_flag searchOnceFlag;   // 一次性标志
+    SearchDirIterator *q = nullptr;   // 指向父类的指针
     QWaitCondition resultWaitCond;
+    mutable QMutex waitMutex;   // 只用于等待条件的轻量级锁
+    std::atomic<bool> hasConsumedResults { false };   // 标记结果是否已被消费(原子操作保证线程安全)
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -178,8 +178,6 @@ void Search::bindEvents()
                                    SearchEventReceiverIns, &SearchEventReceiver::handleStopSearch);
     dpfSignalDispatcher->subscribe("dfmplugin_titlebar", "signal_FilterView_Show",
                                    SearchEventReceiverIns, &SearchEventReceiver::handleShowAdvanceSearchBar);
-    dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl,
-                                   SearchEventReceiverIns, &SearchEventReceiver::handleUrlChanged);
     dpfSignalDispatcher->subscribe("dfmplugin_titlebar", "signal_InputAdddressStr_Check",
                                    SearchEventReceiverIns, &SearchEventReceiver::handleAddressInputStr);
 

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander.cpp
@@ -27,9 +27,6 @@ SimplifiedSearchWorker::SimplifiedSearchWorker(QObject *parent)
       isRunning(false),
       finishedSearcherCount(0)
 {
-    // 设置定时检查结果的计时器
-    resultTimer.setInterval(50);   // 50ms定时更新UI
-    connect(&resultTimer, &QTimer::timeout, this, &SimplifiedSearchWorker::onCheckResults);
 }
 
 SimplifiedSearchWorker::~SimplifiedSearchWorker()
@@ -62,16 +59,12 @@ void SimplifiedSearchWorker::startSearch()
 
     // 创建搜索器并启动搜索
     createSearchers();
-
-    // 启动结果更新计时器
-    resultTimer.start();
 }
 
 void SimplifiedSearchWorker::stopSearch()
 {
     isRunning = false;
-    // 停止计时器
-    resultTimer.stop();
+
     cleanupSearchers();
 }
 
@@ -222,14 +215,6 @@ void SimplifiedSearchWorker::mergeResults(AbstractSearcher *searcher)
                 resultMap.insert(url, it.value());
             }
         }
-    }
-}
-
-void SimplifiedSearchWorker::onCheckResults()
-{
-    // 定时检查结果并通知UI更新
-    if (isRunning && !resultMap.isEmpty()) {
-        emit resultsUpdated(taskId);
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander_p.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander_p.h
@@ -35,11 +35,11 @@ public:
     Q_INVOKABLE void setTaskId(const QString &id) { taskId = id; }
     Q_INVOKABLE void setSearchUrl(const QUrl &url) { searchUrl = url; }
     Q_INVOKABLE void setKeyword(const QString &keyword) { searchKeyword = keyword; }
-    
+
     // 获取结果
     Q_INVOKABLE DFMSearchResultMap getResults();
     Q_INVOKABLE QList<QUrl> getResultUrls();
-    
+
     // 控制搜索流程
     Q_INVOKABLE void startSearch();
     Q_INVOKABLE void stopSearch();
@@ -54,7 +54,6 @@ protected:
 private slots:
     void onSearcherFinished();
     void onSearcherUnearthed();
-    void onCheckResults();
 
 private:
     void createSearchers();
@@ -66,14 +65,13 @@ private:
     QString taskId;
     QUrl searchUrl;
     QString searchKeyword;
-    
+
     QList<AbstractSearcher *> searchers;
     DFMSearchResultMap resultMap;
-    
+
     QReadWriteLock rwLock;
     QMutex mutex;
-    QTimer resultTimer;
-    
+
     bool isRunning { false };
     int finishedSearcherCount { 0 };
 };
@@ -97,10 +95,10 @@ private slots:
 private:
     TaskCommander *q { nullptr };
     QString taskId { "" };
-    
+
     QThread workerThread;
     SimplifiedSearchWorker *searchWorker { nullptr };
-    
+
     bool deleted { false };
 };
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -247,9 +247,6 @@ void TitleBarHelper::handleSearch(QWidget *sender, const QString &text)
     if (curTitleBar)
         currentUrl = curTitleBar->currentUrl();
 
-    if (currentUrl.isLocalFile())
-        QDir::setCurrent(currentUrl.toLocalFile());
-
     if (currentUrl.isValid()) {
         bool isDisableSearch = dpfSlotChannel->push("dfmplugin_search", "slot_Custom_IsDisableSearch", currentUrl).toBool();
         if (isDisableSearch) {

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -61,7 +61,6 @@ bool FileViewHelper::isTransparent(const QModelIndex &index) const
 {
     FileInfoPointer file = fileInfo(index);
     if (!file.get()) {
-        fmDebug() << "No file info available for transparency check at index:" << index.row();
         return false;
     }
 
@@ -114,10 +113,10 @@ QWidget *FileViewHelper::indexWidget(const QModelIndex &index) const
 
 int FileViewHelper::selectedIndexsCount() const
 {
-    //When using the FileView selection model
-    //please be careful not to call it directly.
-    //It needs to be strongly converted, otherwise it will call the QT native selection model
-    //causing data errors and affecting performance
+    // When using the FileView selection model
+    // please be careful not to call it directly.
+    // It needs to be strongly converted, otherwise it will call the QT native selection model
+    // causing data errors and affecting performance
     return parent()->selectedIndexCount();
 }
 
@@ -404,7 +403,7 @@ void FileViewHelper::handleCommitData(QWidget *editor) const
     fmDebug() << "Committing file rename from:" << originalName << "to:" << newFileName;
     fmDebug() << "Old URL:" << oldUrl.toString() << "New URL:" << newUrl.toString();
 
-    //Todo(yanghao): tag
+    // Todo(yanghao): tag
     FileOperatorHelperIns->renameFile(this->parent(), oldUrl, newUrl);
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -11,7 +11,7 @@
 #include <QElapsedTimer>
 #include <QDebug>
 
-typedef QList<QSharedPointer<DFMBASE_NAMESPACE::SortFileInfo>>& SortInfoList;
+typedef QList<QSharedPointer<DFMBASE_NAMESPACE::SortFileInfo>> &SortInfoList;
 
 using namespace dfmbase;
 using namespace dfmplugin_workspace;
@@ -93,9 +93,9 @@ void TraversalDirThreadManager::start()
 
     running = true;
     if (this->sortRole != dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault
-            && dirIterator->oneByOne()) {
+        && dirIterator->oneByOne()) {
         fmDebug() << "Setting QueryAttributes for sorted one-by-one iteration";
-        dirIterator->setProperty("QueryAttributes","standard::name,standard::type,standard::size,\
+        dirIterator->setProperty("QueryAttributes", "standard::name,standard::type,standard::size,\
                                   standard::size,standard::is-symlink,standard::symlink-target,access::*,time::*");
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Improve search performance and thread safety by revamping result synchronization: add a double-buffered result buffer with atomic flags, replace polling with condition-variable signaling, and optimize result consumption path.

Bug Fixes:
- Fix potential loss of unconsumed search results when search completes before client consumption

Enhancements:
- Introduce SearchResultBuffer double-buffering with atomic control for non-blocking search result updates
- Refactor SearchDirIteratorPrivate to use condition variables and atomic flags for efficient inter-thread synchronization
- Remove QTimer-based polling in SimplifiedSearchWorker, replacing it with direct result signaling
- Optimize sortFileInfoList to snapshot and consume results with minimal locking