### PR TITLE
chore: bump version to 6.5.66

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.66) unstable; urgency=medium
+
+  * fix bugs
+  * enhance logging
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 20 Jun 2025 14:26:49 +0800
+
 dde-file-manager (6.5.65) unstable; urgency=medium
 
   * fix some bugs. 


### PR DESCRIPTION
6.5.66

Log:

## Summary by Sourcery

Chores:
- Update debian/changelog entry for version 6.5.66