### PR TITLE
chore: update translations

### DIFF
--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -5,27 +5,27 @@ filters:
   - filter_type: file
     source_file: translations/dde-file-manager.ts
     file_format: QT
-    source_language: en_US
+    source_language: en
     translation_files_expression: translations/dde-file-manager_<lang>.ts
   - filter_type: file
     source_file: translations/dde-computer-desktop/desktop.ts
     file_format: QT
-    source_language: en_US
+    source_language: en
     translation_files_expression: translations/dde-computer-desktop/desktop_<lang>.ts
   - filter_type: file
     source_file: translations/dde-file-manager-desktop/desktop.ts
     file_format: QT
-    source_language: en_US
+    source_language: en
     translation_files_expression: translations/dde-file-manager-desktop/desktop_<lang>.ts
   - filter_type: file
     source_file: translations/dde-home-desktop/desktop.ts
     file_format: QT
-    source_language: en_US
+    source_language: en
     translation_files_expression: translations/dde-home-desktop/desktop_<lang>.ts
   - filter_type: file
     source_file: translations/dde-trash-desktop/desktop.ts
     file_format: QT
-    source_language: en_US
+    source_language: en
     translation_files_expression: translations/dde-trash-desktop/desktop_<lang>.ts
 settings:
   pr_branch_name: transifex_update_<br_unique_id>

--- a/translations/dde-file-manager.ts
+++ b/translations/dde-file-manager.ts
@@ -67,7 +67,7 @@
         <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp" line="668"/>
         <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp" line="782"/>
         <source>Can&apos;t access file!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
update translations

Log: update translations

## Summary by Sourcery

Chores:
- Normalize source_language entries from en_US to en in .tx/transifex.yaml filters