### PR TITLE
Add support for heif thumbnails

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,7 +48,8 @@ Build-Depends:
  libxcb-xfixes0-dev (>= 1.10~),
  libopenjp2-7-dev,
  liblcms2-dev,
- libdeepin-service-framework-dev
+ libdeepin-service-framework-dev,
+ libheif-dev
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org
 
@@ -95,7 +96,8 @@ Conflicts: dde-file-manager-preview,
  dde-file-manager-preview-plugins,
  dde-file-manager-plugins,
  dde-file-manager-daemon-plugins,
- dde-file-manager-common-plugins
+ dde-file-manager-common-plugins,
+ libheif1
 Recommends: avfs, samba, deepin-anything-server
 Description: File manager front end
  File manager front-end of Deepin OS

--- a/debian/control
+++ b/debian/control
@@ -96,8 +96,7 @@ Conflicts: dde-file-manager-preview,
  dde-file-manager-preview-plugins,
  dde-file-manager-plugins,
  dde-file-manager-daemon-plugins,
- dde-file-manager-common-plugins,
- libheif1
+ dde-file-manager-common-plugins
 Recommends: avfs, samba, deepin-anything-server
 Description: File manager front end
  File manager front-end of Deepin OS

--- a/src/dfm-base/dfm-base.cmake
+++ b/src/dfm-base/dfm-base.cmake
@@ -7,6 +7,7 @@ find_package(dfm${DTK_VERSION_MAJOR}-burn REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(gio REQUIRED gio-unix-2.0 IMPORTED_TARGET)
 pkg_check_modules(mount REQUIRED mount IMPORTED_TARGET)
+pkg_check_modules(LIBHEIF REQUIRED libheif)
 
 pkg_search_module(X11 REQUIRED x11 IMPORTED_TARGET)
 if(${QT_VERSION_MAJOR} EQUAL "6")
@@ -100,6 +101,7 @@ target_link_libraries(${BIN_NAME}
         PkgConfig::X11
         poppler-cpp
         ${DFM_EXTRA_LIBRARIES}
+        ${LIBHEIF_LIBRARIES}
 )
 
 target_include_directories(${BIN_NAME} 
@@ -111,6 +113,9 @@ target_include_directories(${BIN_NAME}
         ${DFM_MOUNT_HEADERS}
         ${DFM_BURN_HEADERS}
     )
+
+include_directories(${LIBHEIF_INCLUDE_DIRS})
+link_directories(${LIBHEIF_LIBRARY_DIRS})
 
 set(ShareDir ${CMAKE_INSTALL_PREFIX}/share/dde-file-manager) # also use for install
 target_compile_definitions(

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -322,7 +322,7 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
     	} else {
         	qCWarning(logDFMBase) << "thumbnail: native HEIF decoding failed for:" << filePath;
     	}
-	}
+    }
 
     const QString &suffix = mimeType.replace("image/", "");
 


### PR DESCRIPTION
This PR adds support for thumbnail creation of heif and heic images

## Summary by Sourcery

Integrate libheif to enable native HEIF/HEIC thumbnail creation by adding a decoding function and updating the build configuration to link libheif.

New Features:
- Add native support for generating HEIF/HEIC thumbnails using libheif

Enhancements:
- Implement decodeHeifThumbnail in ThumbnailCreators to decode, scale, and return HEIF images
- Add fallback to existing imageThumbnailCreator when native HEIF decoding fails

Build:
- Include and link against libheif in CMake build configuration