### PR TITLE
fix: lost dxcb in dde-file-manager-pkexec

### DIFF
--- a/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
+++ b/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
@@ -54,7 +54,7 @@ function run_app() {
         # Set environment variables based on session type
         if [ "$ORIGINAL_SESSION_TYPE" == "x11" ]; then
             export DISPLAY=:0
-            export QT_QPA_PLATFORM=xcb
+            export QT_QPA_PLATFORM=dxcb;xcb
             export GDK_BACKEND=x11
             export XDG_SESSION_TYPE=x11
         else


### PR DESCRIPTION
add dxcb to `QT_QPA_PLATFORM`

Log:

Bug: https://pms.uniontech.com/bug-view-306457.html

## Summary by Sourcery

Bug Fixes:
- Include 'dxcb' in the QT_QPA_PLATFORM variable for dde-file-manager-pkexec to resolve the lost plugin issue.