### PR TITLE
fix: [disk-encrypt] Not show recovery key dialog.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -6,6 +6,7 @@
 #include "diskencryptmenuscene.h"
 #include "gui/decryptparamsinputdialog.h"
 #include "gui/chgpassphrasedialog.h"
+#include "gui/unlockpartitiondialog.h"
 #include "events/eventshandler.h"
 #include "utils/encryptutils.h"
 
@@ -235,7 +236,12 @@ void DiskEncryptMenuScene::decryptDevice(const DeviceEncryptParam &param)
             dialog_utils::showDialog(tr("Error"),
                                      tr("Cannot resolve passphrase from TPM"),
                                      dialog_utils::DialogType::kError);
-            return;
+            UnlockPartitionDialog dlg(UnlockPartitionDialog::kRec);
+            int ret = dlg.exec();
+            if (ret != QDialog::Accepted)
+                return;
+
+            inputs.key = dlg.getUnlockKey().second;
         }
         doDecryptDevice(inputs);
         return;


### PR DESCRIPTION
-- When decrypt by tpm and tpm is unavailable, the recovery key dialog not show. -- Add logic to show the revovery key dialog.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-319493.html

## Summary by Sourcery

Bug Fixes:
- Show an UnlockPartitionDialog to collect the recovery key after a TPM decryption error