### PR TITLE
fix: [title-bar] The downward arrow exhibits aliasing artifacts

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
@@ -351,7 +351,7 @@ void UrlPushButton::paintEvent(QPaintEvent *event)
         updateWidth();
     }
     QPainter painter(this);
-    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform | QPainter::TextAntialiasing);
 
     // 绘制悬停或菜单状态
     if (d->hoverFlag || d->popupVisible()) {


### PR DESCRIPTION
-- After scaling, the downward arrow exhibits aliasing artifacts. 
-- Add 'SmoothPixmapTransform' and 'TextAntialiasing' flags.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-318145.html

## Summary by Sourcery

Bug Fixes:
- Add SmoothPixmapTransform and TextAntialiasing render hints alongside Antialiasing in the title-bar URL push button to fix scaling aliasing artifacts.