### PR TITLE
fix: adjust fast directory scan condition in FSMonitorWorker

### DIFF
--- a/src/services/textindex/fsmonitor/fsmonitorworker.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitorworker.cpp
@@ -100,7 +100,7 @@ void FSMonitorWorker::tryFastDirectoryScan()
         }
 
         const QString currentStatus = status.value();
-        if (currentStatus != "monitoring" && currentStatus != "closed") {
+        if (currentStatus != "monitoring") {
             fmWarning() << "FSMonitorWorker: Cannot use fast directory scan, index status is:" << currentStatus;
             return {};
         }


### PR DESCRIPTION
- Modified the condition for using fast directory scan to only check if the index status is not "monitoring", simplifying the logic.
- This change improves the clarity of status checks and ensures that the warning is logged appropriately when the index is not in a monitoring state.

Log: This commit refines the condition for fast directory scanning in FSMonitorWorker, enhancing the clarity of status checks.

## Summary by Sourcery

Refine the fast directory scan logic in FSMonitorWorker to only require the index not be in “monitoring” status and ensure warnings are logged correctly

Bug Fixes:
- Remove redundant “closed” status check when determining fast directory scan eligibility

Enhancements:
- Simplify and clarify index status checks and associated warning messages