### PR TITLE
fix: [sidebar] Crash in make sidebar items.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
@@ -131,6 +131,7 @@ private:
 
     QMultiMap<QUrl, QUrl> routeMapper;
     QPointer<QFutureWatcher<ComputerDataList>> fw{ nullptr };
+    QList<QUrl> pendingSidebarDevUrls;  // Store pending device URLs to execute makeSidebarItem in main thread
 };
 }
 #endif   // COMPUTERITEMWATCHER_H


### PR DESCRIPTION
-- Calling QIcon::fromTheme in a child thread caused sporadic program crashes. -- Added the iconName interface to avoid frequent use of QIcon::fromTheme for retrieving icon names.

Log: fix issue
Task: https://pms.uniontech.com/task-view-378323.html

## Summary by Sourcery

Defer sidebar item creation to the main thread to prevent sporadic crashes caused by calling QIcon::fromTheme in child threads.

Bug Fixes:
- Delay makeSidebarItem execution until after background queries complete to avoid thread-safety issues with QIcon::fromTheme.

Enhancements:
- Introduce pendingSidebarDevUrls to collect device URLs for main-thread sidebar item processing.