### PR TITLE
fix: improve tag editor height adjustment and layout management

### DIFF
--- a/src/plugins/common/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionparser.cpp
+++ b/src/plugins/common/dfmplugin-menu/extendmenuscene/extendmenu/dcustomactionparser.cpp
@@ -112,7 +112,7 @@ bool DCustomActionParser::loadDir(const QStringList &dirPaths)
         return false;
 
     actionEntry.clear();
-
+    QStringList cfgList;
     topActionCount = 0;
     for (auto dirPath : dirPaths) {
 
@@ -122,6 +122,11 @@ bool DCustomActionParser::loadDir(const QStringList &dirPaths)
 
         //以时间先后遍历
         for (const QFileInfo &actionFileInfo : dir.entryInfoList({ "*.conf" }, QDir::Files, QDir::Time)) {
+            const auto &cfgName = actionFileInfo.fileName();
+            if (cfgList.contains(cfgName))
+                continue;
+
+            cfgList << cfgName;
             //解析文件字段
             QSettings actionSetting(actionFileInfo.filePath(), customFormat);
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))

--- a/src/plugins/common/dfmplugin-propertydialog/menu/propertymenuscene.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/menu/propertymenuscene.cpp
@@ -87,11 +87,13 @@ bool PropertyMenuScene::initialize(const QVariantHash &params)
         d->selectFiles << d->currentDir;
     }
 
-    QString errString;
-    d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
-    if (d->focusFileInfo.isNull()) {
-        fmDebug() << errString;
-        return false;
+    if (!d->isEmptyArea) {
+        QString errString;
+        d->focusFileInfo = DFMBASE_NAMESPACE::InfoFactory::create<FileInfo>(d->focusFile, Global::CreateFileInfoType::kCreateFileInfoAuto, &errString);
+        if (d->focusFileInfo.isNull()) {
+            fmDebug() << errString;
+            return false;
+        }
     }
 
     return AbstractMenuScene::initialize(params);
@@ -126,7 +128,7 @@ void PropertyMenuScene::updateState(QMenu *parent)
         return;
 
     if (auto pAction = d->predicateAction.value(PropertyActionId::kProperty)) {
-        if (!d->focusFileInfo->exists())
+        if (!d->isEmptyArea && !d->focusFileInfo->exists())
             pAction->setDisabled(true);
     }
 

--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
@@ -8,6 +8,8 @@
 
 #include <dfm-base/utils/windowutils.h>
 
+#include <QAbstractTextDocumentLayout>
+
 DWIDGET_USE_NAMESPACE
 using namespace dfmplugin_tag;
 
@@ -94,6 +96,7 @@ void TagEditor::initializeWidgets()
     crumbEdit = new DCrumbEdit;
     promptLabel = new QLabel(tr("Input tag info, such as work, family. A comma is used between two tags."));
     totalLayout = new QVBoxLayout;
+    totalLayout->setSizeConstraint(QLayout::SetFixedSize);
     backgroundFrame = new QFrame;
 }
 
@@ -104,6 +107,7 @@ void TagEditor::initializeParameters()
     crumbEdit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     crumbEdit->setCrumbReadOnly(true);
     crumbEdit->setCrumbRadius(2);
+    setupEditHeight();
 
     promptLabel->setFixedWidth(140);
     promptLabel->setWordWrap(true);
@@ -140,6 +144,24 @@ void TagEditor::initializeConnect()
             if (!crumbEdit->property("updateCrumbsColor").toBool())
                 processTags();
         });
+    }
+}
+
+void TagEditor::setupEditHeight()
+{
+    QTextEdit *edit = qobject_cast<QTextEdit *>(crumbEdit);
+    if (edit) {
+        auto doc = edit->document();
+        doc->setDocumentMargin(doc->documentMargin() + 5);
+        auto layout = edit->document()->documentLayout();
+        connect(layout, &QAbstractTextDocumentLayout::documentSizeChanged,
+                this, [this, edit] {
+                    qreal docHeight = edit->document()->size().height();
+                    QMargins margins = edit->contentsMargins();
+                    int totalHeight = qCeil(docHeight) + margins.top() + margins.bottom();
+                    edit->setFixedHeight(totalHeight);
+                    QTimer::singleShot(0, this, &TagEditor::resizeWithContent);
+                });
     }
 }
 

--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.h
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.h
@@ -46,6 +46,7 @@ private:
     void initializeParameters();
     void initializeLayout();
     void initializeConnect();
+    void setupEditHeight();
 
     void processTags();
     void updateCrumbsColor(const QMap<QString, QColor> &tagsColor);


### PR DESCRIPTION
- Added a new method `setupEditHeight` to dynamically adjust the height of the tag editor based on content size.
- Set a fixed size constraint for the layout to enhance the visual consistency of the tag editor.
- Updated the header file to declare the new method for better encapsulation and maintainability.

Log: This commit enhances the tag editor's usability by ensuring it resizes appropriately to its content, improving the overall user experience.
Bug: https://pms.uniontech.com/bug-view-322139.html

## Summary by Sourcery

Implement dynamic resizing for the TagEditor and enforce a fixed layout size constraint to improve its visual consistency and usability.

New Features:
- Introduce setupEditHeight method to automatically adjust the tag editor’s height based on its content size.

Enhancements:
- Apply QLayout::SetFixedSize constraint to the editor’s layout for consistent sizing.
- Declare the new setupEditHeight method in the header for better encapsulation and maintainability.