### PR TITLE
fix: enhance click handling in CanvasView and CollectionView

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.h
@@ -79,6 +79,7 @@ public Q_SLOTS:
     void refresh(bool silent);
     void selectAll() override;
     void toggleSelect();
+
 protected Q_SLOTS:
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
     void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
@@ -91,7 +92,6 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *events) override;
-    void mouseDoubleClickEvent(QMouseEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void paintEvent(QPaintEvent *event) override;
     void contextMenuEvent(QContextMenuEvent *event) override;

--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview_p.h
@@ -30,6 +30,11 @@ class CanvasViewPrivate : public QObject
 {
     Q_OBJECT
 public:
+    enum class ClickedAction : uint8_t {
+        kClicked = 0,
+        kDoubleClicked
+    };
+
     struct CanvasInfo
     {
         CanvasInfo() { }
@@ -58,6 +63,8 @@ public:
     QString visualItem(const QPoint &gridPos) const;
     bool itemGridpos(const QString &item, QPoint &gridPos) const;
     bool isWaterMaskOn();
+    void openIndexByClicked(const ClickedAction action, const QModelIndex &index);
+    void openIndex(const QModelIndex &index);
 
 public:
     QModelIndex findIndex(const QString &key, bool matchStart, const QModelIndex &current, bool reverseOrder, bool excludeCurrent) const;

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
@@ -86,7 +86,6 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
-    void mouseDoubleClickEvent(QMouseEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     void contextMenuEvent(QContextMenuEvent *event) override;

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
@@ -40,6 +40,11 @@ class CollectionViewPrivate : public QObject
 {
     Q_OBJECT
 public:
+    enum class ClickedAction : uint8_t {
+        kClicked = 0,
+        kDoubleClicked
+    };
+
     explicit CollectionViewPrivate(const QString &uuid, CollectionDataProvider *dataProvider, CollectionView *qq, QObject *parent = nullptr);
     ~CollectionViewPrivate();
 
@@ -92,6 +97,8 @@ public:
     void updateDFMMimeData(QDropEvent *event);
     void redoFiles();
     bool checkTargetEnable(QDropEvent *event, const QUrl &targetUrl);
+    void openIndexByClicked(const ClickedAction action, const QModelIndex &index);
+    void openIndex(const QModelIndex &index);
 
 private:
     void updateRowCount(const int &viewHeight, const int &itemHeight);


### PR DESCRIPTION
- Introduced a new enum `ClickedAction` to differentiate between single and double click actions.
- Added methods `openIndexByClicked` and `openIndex` to handle file opening based on click actions, improving user interaction.
- Refactored mouse event handling to streamline the process of committing data and opening files, enhancing overall responsiveness.

Log: This commit improves the click handling mechanism in both CanvasView and CollectionView, providing a more intuitive user experience when interacting with items.
Bug: https://pms.uniontech.com/bug-view-315191.html

## Summary by Sourcery

Centralize and enhance click interactions in CanvasView and CollectionView by introducing a ClickedAction enum and dedicated openIndex methods, connecting click signals to unified handlers, and refactoring mouse event logic to commit editor data before selecting or opening files.

Enhancements:
- Introduce ClickedAction enum and new openIndexByClicked/openIndex methods in CanvasViewPrivate and CollectionViewPrivate to unify file-opening logic.
- Connect clicked and doubleClicked signals to openIndexByClicked for configurable single/double-click behavior.
- Refactor mousePressEvent in both views to commit active editor data before initiating drag selection or handling item clicks.
- Remove legacy mouseDoubleClickEvent overrides in both views and rely on the centralized click-handling mechanism.