### PR TITLE
fix: prevent search configuration registration in admin mode

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -26,6 +26,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/dialogmanager.h>
 #include <dfm-base/utils/viewdefines.h>
+#include <dfm-base/utils/sysinfoutils.h>
 
 using CreateTopWidgetCallback = std::function<QWidget *()>;
 using ShowTopWidgetCallback = std::function<bool(QWidget *, const QUrl &)>;
@@ -128,6 +129,9 @@ void Search::regSearchToWorkspace()
 
 void Search::regSearchSettingConfig()
 {
+    if (SysInfoUtils::isOpenAsAdmin())
+        return;
+
     QString err;
     auto ret = DConfigManager::instance()->addConfig(DConfig::kSearchCfgPath, &err);
     if (!ret)


### PR DESCRIPTION
- Added a check to skip the registration of search settings if the application is running with administrative privileges.
- This change ensures that search configurations are not altered unintentionally when the file manager is launched as an admin.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-322543.html

## Summary by Sourcery

Bug Fixes:
- Prevent registration of search configurations in admin mode to avoid unintended alterations