### PR TITLE
Optimize file name sorting

### DIFF
--- a/src/dfm-base/utils/sortutils.cpp
+++ b/src/dfm-base/utils/sortutils.cpp
@@ -44,7 +44,8 @@ bool compareStringForFileName(const QString &str1, const QString &str2)
     };
 
     auto getCharType = [](uint unicode) -> CharType {
-        if (QChar(unicode).isDigit()) return NumberType;
+        // 使用静态 QChar 函数，它们可以安全地处理32位Unicode码点
+        if (QChar::isDigit(unicode)) return NumberType;
         // isNumber() 辅助函数可以处理全角数字，但 QChar::isDigit 更高效
         // 我们的 isNumber 仍需在 numberStr 中使用
 
@@ -125,9 +126,10 @@ bool compareStringForFileName(const QString &str1, const QString &str2)
 
                 // 规则3平局决胜: a A b B
                 if (QChar::isLetter(unicode1) && QChar::isLetter(unicode2)) {
-                    if (QChar(unicode1).toLower() == QChar(unicode2).toLower()) {
-                        if (QChar(unicode1).isLower() != QChar(unicode2).isLower()) {
-                            return QChar(unicode1).isLower() ? -1 : 1;
+                    if (QChar::toLower(unicode1) == QChar::toLower(unicode2)) {
+                        // 如果小写形式相同，小写字母排在前面
+                        if (QChar::isLower(unicode1) != QChar::isLower(unicode2)) {
+                            return QChar::isLower(unicode1) ? -1 : 1;
                         }
                     }
                 }

--- a/src/tools/upgrade/units/tagdbupgradeunit.cpp
+++ b/src/tools/upgrade/units/tagdbupgradeunit.cpp
@@ -224,6 +224,11 @@ bool TagDbUpgradeUnit::checkOldDatabase()
                                                   kTagOldDbName1,
                                                   nullptr);
 
+    if (!QFile(dbPath1).exists()) {
+        qCDebug(logToolUpgrade) << "No old tag data, no compatibility issues";
+        return true;
+    }
+
     QSqlDatabase db1 { SqliteConnectionPool::instance().openConnection(dbPath1) };
     if (!db1.isValid() || db1.isOpenError()) {
         qCDebug(logToolUpgrade) << "Main database not accessible:" << dbPath1;


### PR DESCRIPTION
## Summary by Sourcery

Exclude home directory entries from sort info population, enhance filename comparison using static QChar methods for Unicode safety and performance, and handle absent old tag database gracefully during upgrades.

Bug Fixes:
- Treat missing old tag database file as a non-error condition in the upgrade routine.

Enhancements:
- Add detection to skip sort info filling for home directory entries to preserve display names.
- Use static QChar::isDigit and QChar::toLower methods in filename comparison for safer and more efficient Unicode handling.
- Refine letter tie-breaker logic to leverage QChar static functions directly.