### PR TITLE
6.5.73

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.73) unstable; urgency=medium
+
+  * Revert 4a3e8474a4bd3b3
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 03 Jul 2025 16:10:58 +0800
+
 dde-file-manager (6.5.72) unstable; urgency=medium
 
   * update translations

--- a/src/tools/upgrade/units/tagdbupgradeunit.cpp
+++ b/src/tools/upgrade/units/tagdbupgradeunit.cpp
@@ -224,11 +224,6 @@ bool TagDbUpgradeUnit::checkOldDatabase()
                                                   kTagOldDbName1,
                                                   nullptr);
 
-    if (!QFile(dbPath1).exists()) {
-        qCDebug(logToolUpgrade) << "No old tag data, no compatibility issues";
-        return true;
-    }
-
     QSqlDatabase db1 { SqliteConnectionPool::instance().openConnection(dbPath1) };
     if (!db1.isValid() || db1.isOpenError()) {
         qCDebug(logToolUpgrade) << "Main database not accessible:" << dbPath1;


### PR DESCRIPTION
## Summary by Sourcery

Remove the early-exit check for a missing old tag database so the upgrade process always attempts the conversion and update the Debian changelog for version 6.5.73

Bug Fixes:
- Ensure tag database upgrade does not prematurely exit when the old database file is absent

Chores:
- Update Debian changelog for version 6.5.73