### PR TITLE
fix: update highlight color in item delegates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.74) unstable; urgency=medium
+
+  * fix bugs
+  * add timeout for filemanager.service
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 03 Jul 2025 20:11:15 +0800
+
 dde-file-manager (6.5.73) unstable; urgency=medium
 
   * Revert 4a3e8474a4bd3b3

--- a/src/apps/dde-file-manager-daemon/dbusservice/dde-file-manager.service
+++ b/src/apps/dde-file-manager-daemon/dbusservice/dde-file-manager.service
@@ -12,6 +12,7 @@ Before=dde-session-initialized.target
 Type=dbus
 BusName=org.deepin.Filemanager.Daemon
 ExecStart=/usr/bin/dde-file-manager-daemon
+TimeoutStopSec=10
 
 [Install]
 WantedBy=graphical-session.target

--- a/src/plugins/filedialog/core/core.cpp
+++ b/src/plugins/filedialog/core/core.cpp
@@ -28,6 +28,14 @@ bool Core::start()
 
     connect(dpfListener, &dpf::Listener::pluginsStarted, this, &Core::onAllPluginsStarted);
 
+    bool connected = QDBusConnection::systemBus().connect("org.freedesktop.login1",
+                                                          "/org/freedesktop/login1",
+                                                          "org.freedesktop.login1.Manager",
+                                                          "PrepareForShutdown",
+                                                          this,
+                                                          SLOT(exitOnShutdown(bool)));
+    fmDebug() << "login1::PrepareForShutdown connected:" << connected;
+
     return true;
 }
 
@@ -117,6 +125,27 @@ void Core::enterHighPerformanceMode()
                                QDBusConnection::systemBus());
     // Pull up the CPU frequency for 3s
     daemonIface.asyncCall("LockCpuFreq", "performance", 3);
+}
+
+void Core::exitOnShutdown(bool shutdown)
+{
+    if (shutdown) {
+        fmInfo() << "PrepareForShutdown is emitted, exit...";
+        // 设置一个5秒的看门狗定时器。
+        // 如果5秒后我们还“活着”，就强制退出。
+        const int watchdogTimeout = 5000;
+        QTimer::singleShot(watchdogTimeout, [=]() {
+            // 如果这段代码被执行，说明优雅退出失败了。
+            // 记录一条日志是至关重要的，这样你就知道是看门狗触发了退出。
+            fmWarning() << "Graceful shutdown timed out after" << watchdogTimeout << "ms. Forcing exit with _Exit(0).";
+
+            // 立即终止进程
+            ::_Exit(0);
+        });
+
+        // 尝试正常、优雅地退出
+        qApp->quit();
+    }
 }
 
 }   // namespace filedialog_core

--- a/src/plugins/filedialog/core/core.h
+++ b/src/plugins/filedialog/core/core.h
@@ -25,6 +25,7 @@ private slots:
     void bindScene(const QString &parentScene);
     void bindSceneOnAdded(const QString &newScene);
     void enterHighPerformanceMode();
+    void exitOnShutdown(bool);
 
 private:
     QSet<QString> waitToBind;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -671,7 +671,7 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
                                                                                 lineHeight, Qt::AlignCenter, painter));
     layout->setHighlightEnabled(!isSelected);
     layout->setHighlightKeywords(parent()->parent()->model()->getKeyWords());
-    layout->setHighlightColor(opt.palette.color(QPalette::Active, QPalette::Highlight));
+    layout->setHighlightColor(QColor("#0081FF"));
 
     labelRect.setLeft(labelRect.left() + kIconModeRectRadius);
     labelRect.setWidth(labelRect.width() - kIconModeRectRadius);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -168,7 +168,7 @@ void ListItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) 
 bool ListItemDelegate::eventFilter(QObject *object, QEvent *event)
 {
     if (event->type() == QEvent::Show) {
-        //在此处处理的逻辑是因为默认QAbstractItemView的QLineEdit重命名会被SelectAll
+        // 在此处处理的逻辑是因为默认QAbstractItemView的QLineEdit重命名会被SelectAll
         if (!setEditorData(qobject_cast<ListItemEditor *>(object)))
             return false;
     } else if (event->type() == QEvent::KeyPress) {
@@ -346,7 +346,7 @@ void ListItemDelegate::setItemMinimumHeightByHeightLevel(int level)
     d->currentHeightLevel = level;
     updateItemSizeHint();
     int iconHeight = d->itemSizeHint.height() * 0.75;
-    parent()->parent()->setIconSize(QSize(iconHeight, iconHeight)); // 设置 iconSize 为行高的 0.75
+    parent()->parent()->setIconSize(QSize(iconHeight, iconHeight));   // 设置 iconSize 为行高的 0.75
 }
 
 int ListItemDelegate::minimumHeightLevel() const
@@ -522,8 +522,8 @@ void ListItemDelegate::paintFileName(QPainter *painter, const QStyleOptionViewIt
 
     const QString previewContent = index.data(kItemFileContentPreviewRole).toString();
     // 检查是否支持并需要显示内容预览
-    bool showContentPreview = d->paintProxy && d->paintProxy->supportContentPreview() && !previewContent.isEmpty() && index != editingIndex() &&
-            d->itemSizeHint.height() >= d->viewDefines.listHeight(d->viewDefines.listHeightCount() - 1); // 检查是否为最大高度
+    bool showContentPreview = d->paintProxy && d->paintProxy->supportContentPreview() && !previewContent.isEmpty() && index != editingIndex()
+            && d->itemSizeHint.height() >= d->viewDefines.listHeight(d->viewDefines.listHeightCount() - 1);   // 检查是否为最大高度
 
     QRectF textRect = rect;
     if (showContentPreview) {
@@ -546,13 +546,13 @@ void ListItemDelegate::paintFileName(QPainter *painter, const QStyleOptionViewIt
 
         nameLayout->setHighlightEnabled(!isSelected);
         nameLayout->setHighlightKeywords(parent()->parent()->model()->getKeyWords());
-        nameLayout->setHighlightColor(option.palette.color(QPalette::Active, QPalette::Highlight));
+        nameLayout->setHighlightColor(QColor("#0081FF"));
         nameLayout->layout(textRect, Qt::ElideRight, painter);
 
         // 绘制文件内容预览(下半部分)
         painter->save();
         QFont previewFont = painter->font();
-        previewFont.setPointSize(previewFont.pointSize() - 2);  // Reduce font size by 2
+        previewFont.setPointSize(previewFont.pointSize() - 2);   // Reduce font size by 2
 
         QRectF contentRect = rect;
         int contentHeight = QFontMetrics(previewFont).height();
@@ -572,7 +572,7 @@ void ListItemDelegate::paintFileName(QPainter *painter, const QStyleOptionViewIt
 
         contentLayout->setHighlightEnabled(!isSelected);
         contentLayout->setHighlightKeywords(parent()->parent()->model()->getKeyWords());
-        contentLayout->setHighlightColor(option.palette.color(QPalette::Active, QPalette::Highlight));
+        contentLayout->setHighlightColor(QColor("#0081FF"));
         contentLayout->layout(contentRect, Qt::ElideRight, painter);
         painter->restore();
     } else {
@@ -589,7 +589,7 @@ void ListItemDelegate::paintFileName(QPainter *painter, const QStyleOptionViewIt
 
         layout->setHighlightEnabled(!isSelected);
         layout->setHighlightKeywords(parent()->parent()->model()->getKeyWords());
-        layout->setHighlightColor(option.palette.color(QPalette::Active, QPalette::Highlight));
+        layout->setHighlightColor(QColor("#0081FF"));
         layout->layout(textRect, Qt::ElideRight, painter);
     }
 }


### PR DESCRIPTION
- Changed the highlight color for file names in both IconItemDelegate and ListItemDelegate to a consistent blue (#0081FF).
- Improved code readability by adjusting comment formatting and ensuring consistent spacing.

Log: This update enhances the visual consistency of highlighted items across different views in the file manager.

Bug: https://pms.uniontech.com/bug-view-317495.html

## Summary by Sourcery

Unify file name highlight color across delegates to a consistent blue (#0081FF) and enhance code readability by standardizing comment formatting and spacing.

Bug Fixes:
- Consistently apply #0081FF highlight color for file names in ListItemDelegate and IconItemDelegate.

Enhancements:
- Refactor comment formatting and spacing for improved code readability.