### PR TITLE
chore: Update cmake minimum version requirement

### DIFF
--- a/examples/dfm-extension-example/CMakeLists.txt
+++ b/examples/dfm-extension-example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 
 # 设置项目名称
 project(dfm-extension-example)

--- a/examples/dfmplugin-encrypt-manager-demo/CMakeLists.txt
+++ b/examples/dfmplugin-encrypt-manager-demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(encryptManagerDemo)
 

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/CMakeLists.txt
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(dfmplugin-disk-encrypt LANGUAGES CXX)
 set(BIN_NAME dfm-disk-encrypt-plugin)

--- a/src/plugins/filemanager/dfmplugin-encrypt-manager/CMakeLists.txt
+++ b/src/plugins/filemanager/dfmplugin-encrypt-manager/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(dfmplugin-encrypt-manager)
 set(BIN_NAME dfm-encrypt-plugin)

--- a/src/services/diskencrypt/CMakeLists.txt
+++ b/src/services/diskencrypt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 set(BIN_NAME "deepin-diskencrypt-service")
 project(${BIN_NAME})


### PR DESCRIPTION
Cannot build on archlinux because cmake has dropped compatibility below
3.5.

Log:

## Summary by Sourcery

Build:
- Update cmake_minimum_required to version 3.10 in all example and plugin CMakeLists.txt to address build failures on newer systems.