### PR TITLE
refactor

### DIFF
--- a/include/dfm-base/base/urlroute.h
+++ b/include/dfm-base/base/urlroute.h
@@ -40,8 +40,9 @@ public:
 
 class UrlRoute
 {
-    static QHash<QString, SchemeNode> kSchemeInfos;   // info cache
-    static QMultiMap<int, QString> kSchemeRealTree;   // index cache
+private:
+    static QHash<QString, SchemeNode> &schemeInfos();   // info cache
+    static QMultiMap<int, QString> &schemeRealTree();   // index cache
 public:
     static bool regScheme(const QString &scheme,
                           const QString &root,

--- a/include/dfm-base/utils/threadcontainer.h
+++ b/include/dfm-base/utils/threadcontainer.h
@@ -344,6 +344,22 @@ public:
         QMutexLocker lk(&mutex);
         myHash.remove(key);
     }
+
+    inline QList<DKey> removeIf(std::function<bool(const DKey &, const DValue &)> predicate)
+    {
+        QMutexLocker lk(&mutex);
+        QList<DKey> removedKeys;
+        for (auto it = myHash.begin(); it != myHash.end();) {
+            if (predicate(it.key(), it.value())) {
+                removedKeys.append(it.key());
+                it = myHash.erase(it);   // erase返回下一个有效的迭代器
+            } else {
+                ++it;
+            }
+        }
+        return removedKeys;
+    }
+
     /*!
      * \brief contains map中是否包含key对应的键值对
      *

--- a/include/dfm-base/utils/threadcontainer.h
+++ b/include/dfm-base/utils/threadcontainer.h
@@ -23,7 +23,7 @@ class DThreadList : public QSharedData
 {
 public:
     DThreadList<T>()
-        : myList(new QList<T>) {}
+        : myList(new QList<T>) { }
     ~DThreadList()
     {
         QMutexLocker lk(&mutex);
@@ -38,10 +38,6 @@ public:
      *
      * \return
      */
-    inline void push_back(const T &t)
-    {
-        myList->push_back(t);
-    }
     inline void push_backByLock(const T &t)
     {
         QMutexLocker lk(&mutex);
@@ -78,10 +74,6 @@ public:
      *
      * \return const QList<T> &获取链表
      */
-    inline const QList<T> &list()
-    {
-        return *myList;
-    }
     inline const QList<T> &listByLock()
     {
         QMutexLocker lk(&mutex);
@@ -97,10 +89,6 @@ public:
     inline void removeAllByLock(const T &t)
     {
         QMutexLocker lk(&mutex);
-        myList->removeAll(t);
-    }
-    inline void removeAll(const T &t)
-    {
         myList->removeAll(t);
     }
     /*!
@@ -123,10 +111,6 @@ public:
      *
      * \return bool 是否包含模板
      */
-    inline bool contains(const T &t)
-    {
-        return myList->contains(t);
-    }
     inline bool containsByLock(const T &t)
     {
         QMutexLocker lk(&mutex);
@@ -163,6 +147,7 @@ public:
      */
     inline int size() const
     {
+        QMutexLocker lk(&mutex);
         return myList->size();
     }
     /*!
@@ -174,29 +159,10 @@ public:
      */
     inline const T &at(int i) const
     {
+        QMutexLocker lk(&mutex);
         return myList->at(i);
     }
-    /*!
-     * \brief first 如果链表为空，返回一个nullptr，否则返回第一个的地址
-     *
-     * \param
-     *
-     * \return T * 返回第一个地址
-     */
-    inline const T &first()
-    {
-        QMutexLocker lk(&mutex);
-        if (myList->isEmpty())
-            return nullptr;
-        return myList->first();
-    }
-    inline T takeByLock()
-    {
-        QMutexLocker lk(&mutex);
-        if (myList->isEmpty())
-            return nullptr;
-        return myList->takeFirst();
-    }
+
     /*!
      * \brief count 链表的总个数
      *
@@ -223,14 +189,6 @@ public:
     {
         QMutexLocker lk(&mutex);
         return myList->indexOf(t, from);
-    }
-    void lock()
-    {
-        mutex.lock();
-    }
-    void unlock()
-    {
-        mutex.unlock();
     }
 
 private:
@@ -301,30 +259,7 @@ public:
         QMutexLocker lk(&mutex);
         return myMap.contains(key);
     }
-    /*!
-     * \brief begin 当前map的开始迭代器
-     *
-     * \param null
-     *
-     * \return QMap<Key, Value>::iterator 当前map的开始迭代器
-     */
-    inline typename QMap<DKey, DValue>::iterator begin()
-    {
-        QMutexLocker lk(&mutex);
-        return myMap.begin();
-    }
-    /*!
-     * \brief begin 当前map的结束迭代器
-     *
-     * \param null
-     *
-     * \return QMap<Key, Value>::iterator 当前map的结束迭代器
-     */
-    inline typename QMap<DKey, DValue>::iterator end()
-    {
-        QMutexLocker lk(&mutex);
-        return myMap.end();
-    }
+
     /*!
      * \brief erase 去掉map中当前的迭代器
      *

--- a/src/dfm-base/utils/infocache.cpp
+++ b/src/dfm-base/utils/infocache.cpp
@@ -97,7 +97,7 @@ void InfoCache::removeCache(const QUrl url)
  */
 bool InfoCache::cacheDisable(const QString &scheme)
 {
-    return d->disableCahceSchemes.contains(scheme);
+    return d->disableCahceSchemes.containsByLock(scheme);
 }
 /*!
  * \brief setCacheDisbale 设置scheme是否可以缓存
@@ -110,11 +110,11 @@ bool InfoCache::cacheDisable(const QString &scheme)
  */
 void InfoCache::setCacheDisbale(const QString &scheme, bool disable)
 {
-    if (!d->disableCahceSchemes.contains(scheme) && disable) {
+    if (!d->disableCahceSchemes.containsByLock(scheme) && disable) {
         d->disableCahceSchemes.push_backByLock(scheme);
         return;
     }
-    if (d->disableCahceSchemes.contains(scheme) && !disable) {
+    if (d->disableCahceSchemes.containsByLock(scheme) && !disable) {
         d->disableCahceSchemes.removeOneByLock(scheme);
         return;
     }
@@ -146,13 +146,13 @@ void InfoCache::cacheInfo(const QUrl url, const FileInfoPointer info)
             return;
     }
 
-    //获取监视器，监听当前的file的改变 当没有缓存加入监视器后，这里的watcher就会析构，如果启动了就要停止监控，这个是代理
-    // 代理就将启动的缓存了监视关闭了。本来没有缓存的监视器监视就没有意义
-    // if (!WatcherCache::instance().cacheDisable(url.scheme())) {
-    //     auto parentUrl = UrlRoute::urlParent(url);
-    //     auto parentPath = parentUrl.path();
-    //     if (parentPath != QDir::separator() && !parentPath.endsWith(QDir::separator()))
-    //         parentUrl.setPath(parentPath + QDir::separator());
+    // 获取监视器，监听当前的file的改变 当没有缓存加入监视器后，这里的watcher就会析构，如果启动了就要停止监控，这个是代理
+    //  代理就将启动的缓存了监视关闭了。本来没有缓存的监视器监视就没有意义
+    //  if (!WatcherCache::instance().cacheDisable(url.scheme())) {
+    //      auto parentUrl = UrlRoute::urlParent(url);
+    //      auto parentPath = parentUrl.path();
+    //      if (parentPath != QDir::separator() && !parentPath.endsWith(QDir::separator()))
+    //          parentUrl.setPath(parentPath + QDir::separator());
 
     //     auto watcher = WatcherFactory::create<AbstractFileWatcher>(parentUrl);
     //     if (watcher) {
@@ -313,7 +313,7 @@ void InfoCache::addWatcherTimeInfo(const QList<QUrl> &urls)
     if (d->timeToUrlWatcherMap.count() <= kCacheFileWatcherCount)
         return;
 
-             // 超出限制移除先进入的watcher
+    // 超出限制移除先进入的watcher
     auto it = d->timeToUrlWatcherMap.begin();
     while (d->urlTimeSortWatcherHash.size() > kCacheFileWatcherCount
            && it != d->timeToUrlWatcherMap.end()) {
@@ -456,9 +456,7 @@ FileInfoPointer InfoCacheController::getCacheInfo(const QUrl &url)
 }
 
 InfoCacheController::InfoCacheController(QObject *parent)
-    : QObject(parent), thread(new QThread), worker(new CacheWorker), removeTimer(new QTimer)
-    , threadUpdate(new QThread)
-    , workerUpdate(new TimeToUpdateCache)
+    : QObject(parent), thread(new QThread), worker(new CacheWorker), removeTimer(new QTimer), threadUpdate(new QThread), workerUpdate(new TimeToUpdateCache)
 {
     init();
 }
@@ -487,7 +485,6 @@ void InfoCacheController::init()
 
 TimeToUpdateCache::~TimeToUpdateCache()
 {
-
 }
 
 void TimeToUpdateCache::updateInfoTime(const QUrl url)
@@ -509,11 +506,11 @@ void TimeToUpdateCache::updateWatcherTime(const QList<QUrl> &urls, const bool ad
     InfoCache::instance().updateSortTimeWatcherWorker(urls, add);
 }
 
-TimeToUpdateCache::TimeToUpdateCache(QObject *parent) : QObject (parent)
+TimeToUpdateCache::TimeToUpdateCache(QObject *parent)
+    : QObject(parent)
 {
-
 }
 
 }
 
-//开线程移除缓存和同步缓存操作
+// 开线程移除缓存和同步缓存操作

--- a/src/dfm-base/utils/watchercache.cpp
+++ b/src/dfm-base/utils/watchercache.cpp
@@ -56,7 +56,7 @@ WatcherCache &WatcherCache::instance()
 QSharedPointer<AbstractFileWatcher> WatcherCache::getCacheWatcher(const QUrl &url)
 {
     Q_D(WatcherCache);
-    emit updateWatcherTime({url}, true);
+    emit updateWatcherTime({ url }, true);
     return d->watchers.value(url);
 }
 /*!
@@ -79,7 +79,7 @@ void WatcherCache::cacheWatcher(const QUrl &url, const QSharedPointer<AbstractFi
         return;
     connect(watcher.data(), &AbstractFileWatcher::fileDeleted, this, &WatcherCache::fileDelete);
     d->watchers.insert(url, watcher);
-    emit updateWatcherTime({url}, true);
+    emit updateWatcherTime({ url }, true);
 }
 /*!
  * \brief removCacheWatcher 根据Url移除当前缓存的watcher
@@ -100,7 +100,7 @@ void WatcherCache::removeCacheWatcher(const QUrl &url, const bool isEmit)
     emit fileDelete(url);
     d->watchers.remove(url);
     if (isEmit)
-        emit updateWatcherTime({url}, false);
+        emit updateWatcherTime({ url }, false);
 }
 
 void WatcherCache::removeCacheWatcherByParent(const QUrl &parent)
@@ -123,16 +123,16 @@ void WatcherCache::removeCacheWatcherByParent(const QUrl &parent)
 
 bool WatcherCache::cacheDisable(const QString &scheme)
 {
-    return d->disableCahceSchemes.contains(scheme);
+    return d->disableCahceSchemes.containsByLock(scheme);
 }
 
 void WatcherCache::setCacheDisbale(const QString &scheme, bool disbale)
 {
-    if (!d->disableCahceSchemes.contains(scheme) && disbale) {
+    if (!d->disableCahceSchemes.containsByLock(scheme) && disbale) {
         d->disableCahceSchemes.push_backByLock(scheme);
         return;
     }
-    if (d->disableCahceSchemes.contains(scheme) && !disbale) {
+    if (d->disableCahceSchemes.containsByLock(scheme) && !disbale) {
         d->disableCahceSchemes.removeOneByLock(scheme);
         return;
     }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1107,7 +1107,7 @@ bool FileOperateBaseWorker::canWriteFile(const QUrl &url) const
 
 void FileOperateBaseWorker::setAllDirPermisson()
 {
-    for (auto info : dirPermissonList.list()) {
+    for (auto info : dirPermissonList.listByLock()) {
         if (info->permission && supportSetPermission)
             localFileHandler->setPermissions(info->target, info->permission);
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -166,6 +166,7 @@ private:
     QStringList connectedTokens;
 
     QStringList keyWords {};
+    std::atomic_bool isDying { false };
 };
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -157,7 +157,7 @@ private:
 
     QQueue<QPair<QUrl, EventType>> watcherEvent {};
     QMutex watcherEventMutex;
-    QAtomicInteger<bool> processFileEventRuning = false;
+    std::atomic_bool processFileEventRuning { false };
 
     QList<TraversalThreadPointer> discardedThread {};
     QList<QSharedPointer<QThread>> threads {};

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1851,12 +1851,12 @@ bool FileSortWorker::isDefaultHiddenFile(const QUrl &fileUrl)
             auto blkInfo = DevProxyMng->queryBlockInfo(blk);
             const QStringList &mountPoints = blkInfo.value(DeviceProperty::kMountPoints).toStringList();
             for (const auto &mpt : mountPoints) {
-                defaultHiddenUrls.push_back(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
-                defaultHiddenUrls.push_back(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
             }
         }
     });
-    return defaultHiddenUrls.contains(fileUrl);
+    return defaultHiddenUrls.containsByLock(fileUrl);
 }
 
 QUrl FileSortWorker::parantUrl(const QUrl &url)


### PR DESCRIPTION
## Summary by Sourcery

Improve thread safety and container management by enforcing mutex-locked operations, modernizing atomic flags, and converting static data structures to function-local singletons.

Enhancements:
- Retire unsafe direct access in DThreadList and DThreadMap and consolidate operations into mutex-protected methods
- Add removeIf utility in DThreadHash for conditional key removal under lock
- Convert UrlRoute static maps into function-local singleton getters to ensure safe initialization
- Standardize InfoCache and WatcherCache to use lock-protected container operations and employ removeIf for watcher cleanup
- Replace QAtomicInteger with std::atomic_bool and add isDying flag in RootInfo for robust concurrent event handling
- Update FileSortWorker and FileOperateBaseWorker to invoke lock-protected list access methods

Chores:
- Apply minor formatting and initializer-list style cleanups throughout codebase