### PR TITLE
fix: The tags are not displayed in the search view

### DIFF
--- a/src/dfm-base/utils/elidetextlayout.cpp
+++ b/src/dfm-base/utils/elidetextlayout.cpp
@@ -48,7 +48,7 @@ QString ElideTextLayout::text() const
 QList<QPair<int, int>> ElideTextLayout::findKeywordMatches(const QString &text) const
 {
     QList<QPair<int, int>> matches;
-    
+
     // 查找所有关键词的匹配位置
     for (const QString &keyword : highlightKeywords) {
         if (keyword.isEmpty())
@@ -64,14 +64,14 @@ QList<QPair<int, int>> ElideTextLayout::findKeywordMatches(const QString &text) 
             startPos = keywordPos + 1; // 允许重叠匹配
         }
     }
-    
+
     // 按位置排序所有匹配
     std::sort(matches.begin(), matches.end());
-    
+
     // 合并重叠的匹配区域
     for (int i = 0; i < matches.size() - 1; ) {
         if (matches[i].first + matches[i].second > matches[i+1].first) {
-            int newEnd = std::max(matches[i].first + matches[i].second, 
+            int newEnd = std::max(matches[i].first + matches[i].second,
                                 matches[i+1].first + matches[i+1].second);
             matches[i].second = newEnd - matches[i].first;
             matches.removeAt(i+1);
@@ -79,7 +79,7 @@ QList<QPair<int, int>> ElideTextLayout::findKeywordMatches(const QString &text) 
             i++;
         }
     }
-    
+
     return matches;
 }
 
@@ -88,121 +88,121 @@ int ElideTextLayout::determineElidePosition(const QString &elideText, const QStr
     // 如果两个文本相同，则没有省略发生
     if (elideText == originalText)
         return -1;
-    
+
     // 标准省略符号
     QString ellipsis = "…";
     QString threeDotsEllipsis = "...";
-    
+
     // 检查省略文本是否包含标准省略符号
     bool hasEllipsis = elideText.contains(ellipsis) || elideText.contains(threeDotsEllipsis);
-    
+
     if (elideMode == Qt::ElideRight) {
         // 右侧省略：从前向后找到最后一个匹配的字符
         int i = 0;
-        while (i < elideText.length() && i < originalText.length() && 
+        while (i < elideText.length() && i < originalText.length() &&
                elideText.at(i) == originalText.at(i)) {
             i++;
         }
-        
+
         // 如果找到了省略符号，返回省略符号的位置
         if (hasEllipsis) {
             int ellipsisPos = elideText.indexOf(ellipsis, i - 1);
             if (ellipsisPos != -1)
                 return ellipsisPos;
-                
+
             ellipsisPos = elideText.indexOf(threeDotsEllipsis, i - 1);
             if (ellipsisPos != -1)
                 return ellipsisPos;
         }
-        
+
         // 没有找到明确的省略符号，返回不匹配的起始位置
         return i;
-    } 
+    }
     else if (elideMode == Qt::ElideLeft) {
         // 左侧省略：从后向前找到最后一个匹配的字符
         int elideLen = elideText.length();
         int originalLen = originalText.length();
         int i = 0;
-        
-        while (i < elideLen && i < originalLen && 
+
+        while (i < elideLen && i < originalLen &&
                elideText.at(elideLen - 1 - i) == originalText.at(originalLen - 1 - i)) {
             i++;
         }
-        
+
         // 如果找到了省略符号，返回省略符号后的位置
         if (hasEllipsis) {
             int ellipsisPos = elideText.indexOf(ellipsis);
             if (ellipsisPos != -1)
                 return ellipsisPos + ellipsis.length();
-                
+
             ellipsisPos = elideText.indexOf(threeDotsEllipsis);
             if (ellipsisPos != -1)
                 return ellipsisPos + threeDotsEllipsis.length();
         }
-        
+
         // 没有找到明确的省略符号，返回不匹配的起始位置
         return elideLen - i;
-    } 
+    }
     else if (elideMode == Qt::ElideMiddle) {
         // 中间省略：需要从两端开始匹配
         int leftMatchLen = 0;  // 左侧匹配长度
         int rightMatchLen = 0; // 右侧匹配长度
-        
+
         // 计算左侧匹配长度
-        while (leftMatchLen < elideText.length() && leftMatchLen < originalText.length() && 
+        while (leftMatchLen < elideText.length() && leftMatchLen < originalText.length() &&
                elideText.at(leftMatchLen) == originalText.at(leftMatchLen)) {
             leftMatchLen++;
         }
-        
+
         // 计算右侧匹配长度
         int elideLen = elideText.length();
         int originalLen = originalText.length();
-        while (rightMatchLen < elideLen - leftMatchLen && rightMatchLen < originalLen - leftMatchLen && 
+        while (rightMatchLen < elideLen - leftMatchLen && rightMatchLen < originalLen - leftMatchLen &&
                elideText.at(elideLen - 1 - rightMatchLen) == originalText.at(originalLen - 1 - rightMatchLen)) {
             rightMatchLen++;
         }
-        
+
         // 如果找到了省略符号，返回省略符号的位置
         if (hasEllipsis) {
             int ellipsisPos = elideText.indexOf(ellipsis, leftMatchLen);
             if (ellipsisPos != -1 && ellipsisPos <= elideLen - rightMatchLen)
                 return ellipsisPos;
-                
+
             ellipsisPos = elideText.indexOf(threeDotsEllipsis, leftMatchLen);
             if (ellipsisPos != -1 && ellipsisPos <= elideLen - rightMatchLen)
                 return ellipsisPos;
         }
-        
+
         // 没有找到明确的省略符号，返回左侧匹配的末尾位置
         return leftMatchLen;
-    } 
-    
+    }
+
     // 默认情况（不应该到达这里）
     return 0;
 }
 
 QList<QPair<int, int>> ElideTextLayout::calculateElideHighlightMatches(
-    const QString &elideText, 
-    int elidePos, 
-    Qt::TextElideMode elideMode, 
+    const QString &elideText,
+    int elidePos,
+    Qt::TextElideMode elideMode,
     const QList<QPair<int, int>> &originalMatches,
     int lineStartPos) const
 {
     QList<QPair<int, int>> matches;
-    
+
     // 首先处理完整匹配 - 在省略后的文本中查找关键词
     matches = findKeywordMatches(elideText);
-    
+
     // 特殊处理：检查被省略号截断的关键词部分
     if (elideMode == Qt::ElideRight && elidePos > 0) {
         // 右侧省略：检查每个原始匹配项是否在省略处被截断
         for (const auto &match : originalMatches) {
             int matchStart = match.first;
             int matchLength = match.second;
-            
+
             // 计算在省略前文本(elideText)中对应的位置
             int elideTextStartPos = lineStartPos;
-            
+
             // 如果匹配项开始在可见区域内但结束在省略区域
             if (matchStart >= elideTextStartPos && matchStart < elideTextStartPos + elidePos &&
                 matchStart + matchLength > elideTextStartPos + elidePos) {
@@ -219,11 +219,11 @@ QList<QPair<int, int>> ElideTextLayout::calculateElideHighlightMatches(
         // 左侧省略：检查每个原始匹配项是否在省略处被截断
         int originalLineStart = lineStartPos;
         int visibleStartInOriginal = originalLineStart + elidePos + 1;
-        
+
         for (const auto &match : originalMatches) {
             int matchStart = match.first;
             int matchEnd = matchStart + match.second;
-            
+
             // 如果匹配项开始在省略区域但结束在可见区域
             if (matchStart < visibleStartInOriginal && matchEnd > visibleStartInOriginal) {
                 // 计算可见部分的长度
@@ -236,15 +236,15 @@ QList<QPair<int, int>> ElideTextLayout::calculateElideHighlightMatches(
         // 计算在原始文本中前半部分对应的区域
         int originalLineStart = lineStartPos;
         int firstVisiblePartLength = elidePos;
-        
+
         // 估算原始文本中省略的部分长度（这是近似值）
         int ellipsisInOriginalPos = originalLineStart + firstVisiblePartLength;
-        
+
         // 检查每个原始匹配
         for (const auto &match : originalMatches) {
             int matchStart = match.first;
             int matchEnd = matchStart + match.second;
-            
+
             // 检查是否跨越了前半部分的末尾
             if (matchStart < ellipsisInOriginalPos && matchEnd > ellipsisInOriginalPos) {
                 // 添加前半部分的可见匹配
@@ -252,19 +252,19 @@ QList<QPair<int, int>> ElideTextLayout::calculateElideHighlightMatches(
                 if (visibleLengthInFirstPart > 0) {
                     matches.append(qMakePair(matchStart - originalLineStart, visibleLengthInFirstPart));
                 }
-                
+
                 // 这里我们不添加后半部分，因为难以准确计算位置映射
                 // 如果需要，可以在详细了解Qt的elide实现后添加更精确的处理
             }
         }
     }
-    
+
     // 对匹配进行排序和合并
     std::sort(matches.begin(), matches.end());
-    
+
     for (int i = 0; i < matches.size() - 1; ) {
         if (matches[i].first + matches[i].second > matches[i+1].first) {
-            int newEnd = std::max(matches[i].first + matches[i].second, 
+            int newEnd = std::max(matches[i].first + matches[i].second,
                               matches[i+1].first + matches[i+1].second);
             matches[i].second = newEnd - matches[i].first;
             matches.removeAt(i+1);
@@ -272,7 +272,7 @@ QList<QPair<int, int>> ElideTextLayout::calculateElideHighlightMatches(
             i++;
         }
     }
-    
+
     return matches;
 }
 
@@ -296,17 +296,17 @@ QList<QRectF> ElideTextLayout::layout(const QRectF &rect, Qt::TextElideMode elid
     QString elideText;
     QString curText = text();
     bool paintLineWithHighlight = enableHighlight && highlightColor.isValid() && !highlightKeywords.isEmpty();
-    
+
     // 预处理整个文本中的所有关键词匹配位置
     QList<QPair<int, int>> allMatches; // 保存所有匹配位置: <开始位置, 长度>
     if (paintLineWithHighlight) {
         allMatches = findKeywordMatches(curText);
     }
-    
+
     // 一个更新后的匹配列表，用于处理elideText情况
     QList<QPair<int, int>> currentMatches = allMatches;
 
-    auto processLine = [this, &ret, painter, &lastLineRect, background, textLineHeight, &curText, textLines, 
+    auto processLine = [this, &ret, painter, &lastLineRect, background, textLineHeight, &curText, textLines,
                         paintLineWithHighlight, &currentMatches](QTextLine &line) {
         QRectF lRect = line.naturalTextRect();
         lRect.setHeight(textLineHeight);
@@ -323,18 +323,18 @@ QList<QRectF> ElideTextLayout::layout(const QRectF &rect, Qt::TextElideMode elid
             if (background.style() != Qt::NoBrush) {
                 lastLineRect = drawLineBackground(painter, lRect, lastLineRect, background);
             }
-            
+
             // 获取当前行的文本范围
             int lineStart = line.textStart();
             int lineEnd = lineStart + line.textLength();
-            
+
             // 检查当前行是否需要高亮显示（检查是否有任何关键词与当前行有重叠）
             bool needHighlight = false;
             if (paintLineWithHighlight) {
                 for (const auto &match : currentMatches) {
                     int matchStart = match.first;
                     int matchEnd = matchStart + match.second;
-                    
+
                     // 如果匹配区域与当前行有任何重叠
                     if (matchEnd > lineStart && matchStart < lineEnd) {
                         needHighlight = true;
@@ -371,28 +371,28 @@ QList<QRectF> ElideTextLayout::layout(const QRectF &rect, Qt::TextElideMode elid
                     QFontMetrics fm(lay->font());
                     QString originalText = text().mid(line.textStart());
                     elideText = fm.elidedText(originalText, elideMode, qRound(size.width()));
-                    
+
                     // 判断文本是否被省略以及省略位置
                     bool isElided = elideText != originalText;
                     int elidePos = 0;
-                    
+
                     if (isElided) {
                         // 使用改进的方法确定省略位置
                         elidePos = determineElidePosition(elideText, originalText, elideMode);
                         if (elidePos < 0) // 如果没有省略（虽然不太可能发生）
                             elidePos = 0;
                     }
-                    
+
                     curText = elideText;
-                    
+
                     // 如果有省略，需要处理高亮匹配位置
                     if (isElided && paintLineWithHighlight) {
                         // 重新计算省略文本中的高亮匹配位置
                         currentMatches = calculateElideHighlightMatches(
-                            elideText, 
-                            elidePos, 
-                            elideMode, 
-                            allMatches, 
+                            elideText,
+                            elidePos,
+                            elideMode,
+                            allMatches,
                             line.textStart()
                         );
                     }
@@ -495,40 +495,40 @@ QRectF ElideTextLayout::drawLineBackground(QPainter *painter, const QRectF &curL
     return lastLineRect;
 }
 
-void ElideTextLayout::drawTextWithHighlight(QPainter *painter, const QTextLine &line, const QString &lineText, 
+void ElideTextLayout::drawTextWithHighlight(QPainter *painter, const QTextLine &line, const QString &lineText,
                                            const QRectF &rect, int lineStartPos, const QList<QPair<int, int>> &allMatches)
 {
     // 1. 先绘制整行普通文本
-    painter->drawText(rect, lineText, QTextOption(document->defaultTextOption().alignment()));
-    
+    line.draw(painter, QPoint(0, 0));
+
     // 2. 仅在匹配区域上绘制高亮文本
     if (!allMatches.isEmpty()) {
         painter->save();
         painter->setPen(highlightColor);
-        
+
         int lineEnd = lineStartPos + lineText.length();
-        
+
         for (const auto &match : allMatches) {
             int matchStart = match.first;
             int matchEnd = matchStart + match.second;
-            
+
             // 跳过与当前行无关的匹配
             if (matchEnd <= lineStartPos || matchStart >= lineEnd)
                 continue;
-            
+
             // 计算此行中要高亮的部分
             int highlightStart = qMax(matchStart, lineStartPos) - lineStartPos;
             int highlightEnd = qMin(matchEnd, lineEnd) - lineStartPos;
             int highlightLength = highlightEnd - highlightStart;
-            
+
             if (highlightLength <= 0)
                 continue;
-            
+
             // 计算高亮区域在当前行的X坐标位置
             qreal keywordXPos = line.cursorToX(lineStartPos + highlightStart) - line.cursorToX(lineStartPos);
-            qreal keywordWidth = line.cursorToX(lineStartPos + highlightStart + highlightLength) 
+            qreal keywordWidth = line.cursorToX(lineStartPos + highlightStart + highlightLength)
                                - line.cursorToX(lineStartPos + highlightStart);
-            
+
             // 绘制高亮文本
             QRectF highlightRect(rect.x() + keywordXPos, rect.y(), keywordWidth + 1, rect.height()); // 宽度加1防止误差导致绘制异常
             QString highlightText(lineText.mid(highlightStart, highlightLength));
@@ -536,7 +536,7 @@ void ElideTextLayout::drawTextWithHighlight(QPainter *painter, const QTextLine &
                              highlightText,
                              QTextOption(document->defaultTextOption().alignment()));
         }
-        
+
         painter->restore();
     }
 }


### PR DESCRIPTION
Directly using painter for drawing fails to trigger TagPainter::drawObject

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-317171.html

## Summary by Sourcery

Use QTextLine::draw to render highlighted text and trigger TagPainter::drawObject, restoring tag display in the search view; also clean up whitespace and standardize formatting in ElideTextLayout.

Bug Fixes:
- Restore tag rendering in the search view by replacing QPainter::drawText with QTextLine::draw in drawTextWithHighlight.

Enhancements:
- Remove trailing spaces and align argument formatting across elidetextlayout.cpp for consistent code style.