### PR TITLE
6.5.75

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.75) unstable; urgency=medium
+
+  * Revert a bug commit
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 04 Jul 2025 18:13:12 +0800
+
 dde-file-manager (6.5.74) unstable; urgency=medium
 
   * fix bugs

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -378,7 +378,7 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const DFileInfoPointer &fromInfo, 
         }
         if (ok)
             cutAndDeleteFiles.append(fromInfo);
-        OperatorsFileUtils::instance()->delayRemoveCopyingFile(url);
+        FileUtils::removeCopyingFileUrl(url);
     }
 
     toInfo->initQuerier();
@@ -910,7 +910,7 @@ bool FileOperateBaseWorker::doCopyLocalByRange(const DFileInfoPointer fromInfo, 
 
     FileUtils::cacheCopyingFileUrl(targetUrl);
     DoCopyFileWorker::NextDo nextDo = copyOtherFileWorker->doCopyFileByRange(fromInfo, toInfo, skip);
-    OperatorsFileUtils::instance()->delayRemoveCopyingFile(targetUrl);
+    FileUtils::removeCopyingFileUrl(targetUrl);
     return nextDo == DoCopyFileWorker::NextDo::kDoCopyNext;
 }
 
@@ -938,7 +938,7 @@ bool FileOperateBaseWorker::doCopyOtherFile(const DFileInfoPointer fromInfo, con
     }
     if (ok)
         syncFiles.append(targetUrl);
-    OperatorsFileUtils::instance()->delayRemoveCopyingFile(targetUrl);
+    FileUtils::removeCopyingFileUrl(targetUrl);
 
     return ok;
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -76,27 +76,6 @@ private:
     static QSet<QString> fileNameUsing;
     static QMutex mutex;
 };
-
-class OperatorsFileUtils : public QObject {
-    Q_OBJECT
-    explicit OperatorsFileUtils(QObject *parent = nullptr)
-        : QObject(parent) {}
-public:
-    ~OperatorsFileUtils() override {}
-
-    void delayRemoveCopyingFile(const QUrl &url) {
-        QTimer::singleShot(500, this, [url](){
-            dfmbase::FileUtils::removeCopyingFileUrl(url);
-        });
-    }
-
-    static OperatorsFileUtils *instance() {
-        static OperatorsFileUtils in;
-        return &in;
-    }
-
-};
-
 DPFILEOPERATIONS_END_NAMESPACE
 
 #endif   // FILEOPERATIONSUTILS_H


### PR DESCRIPTION
## Summary by Sourcery

Refactor file operations to remove the asynchronous delay wrapper and call removeCopyingFileUrl directly

Enhancements:
- Remove the OperatorsFileUtils class and its delayed removal logic
- Replace all delayed removeCopyingFileUrl calls in FileOperateBaseWorker with direct synchronous calls