### PR TITLE
fix build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.75) unstable; urgency=medium
+
+  * Revert a bug commit
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 04 Jul 2025 18:13:12 +0800
+
 dde-file-manager (6.5.74) unstable; urgency=medium
 
   * fix bugs

--- a/include/dfm-base/base/urlroute.h
+++ b/include/dfm-base/base/urlroute.h
@@ -40,8 +40,9 @@ public:
 
 class UrlRoute
 {
-    static QHash<QString, SchemeNode> kSchemeInfos;   // info cache
-    static QMultiMap<int, QString> kSchemeRealTree;   // index cache
+private:
+    static QHash<QString, SchemeNode> &schemeInfos();   // info cache
+    static QMultiMap<int, QString> &schemeRealTree();   // index cache
 public:
     static bool regScheme(const QString &scheme,
                           const QString &root,

--- a/include/dfm-base/utils/threadcontainer.h
+++ b/include/dfm-base/utils/threadcontainer.h
@@ -344,6 +344,22 @@ public:
         QMutexLocker lk(&mutex);
         myHash.remove(key);
     }
+
+    inline QList<DKey> removeIf(std::function<bool(const DKey &, const DValue &)> predicate)
+    {
+        QMutexLocker lk(&mutex);
+        QList<DKey> removedKeys;
+        for (auto it = myHash.begin(); it != myHash.end();) {
+            if (predicate(it.key(), it.value())) {
+                removedKeys.append(it.key());
+                it = myHash.erase(it);   // erase返回下一个有效的迭代器
+            } else {
+                ++it;
+            }
+        }
+        return removedKeys;
+    }
+
     /*!
      * \brief contains map中是否包含key对应的键值对
      *

--- a/include/dfm-base/utils/threadcontainer.h
+++ b/include/dfm-base/utils/threadcontainer.h
@@ -23,7 +23,7 @@ class DThreadList : public QSharedData
 {
 public:
     DThreadList<T>()
-        : myList(new QList<T>) {}
+        : myList(new QList<T>) { }
     ~DThreadList()
     {
         QMutexLocker lk(&mutex);
@@ -38,10 +38,6 @@ public:
      *
      * \return
      */
-    inline void push_back(const T &t)
-    {
-        myList->push_back(t);
-    }
     inline void push_backByLock(const T &t)
     {
         QMutexLocker lk(&mutex);
@@ -78,10 +74,6 @@ public:
      *
      * \return const QList<T> &获取链表
      */
-    inline const QList<T> &list()
-    {
-        return *myList;
-    }
     inline const QList<T> &listByLock()
     {
         QMutexLocker lk(&mutex);
@@ -97,10 +89,6 @@ public:
     inline void removeAllByLock(const T &t)
     {
         QMutexLocker lk(&mutex);
-        myList->removeAll(t);
-    }
-    inline void removeAll(const T &t)
-    {
         myList->removeAll(t);
     }
     /*!
@@ -123,10 +111,6 @@ public:
      *
      * \return bool 是否包含模板
      */
-    inline bool contains(const T &t)
-    {
-        return myList->contains(t);
-    }
     inline bool containsByLock(const T &t)
     {
         QMutexLocker lk(&mutex);
@@ -163,6 +147,7 @@ public:
      */
     inline int size() const
     {
+        QMutexLocker lk(&mutex);
         return myList->size();
     }
     /*!
@@ -174,29 +159,10 @@ public:
      */
     inline const T &at(int i) const
     {
+        QMutexLocker lk(&mutex);
         return myList->at(i);
     }
-    /*!
-     * \brief first 如果链表为空，返回一个nullptr，否则返回第一个的地址
-     *
-     * \param
-     *
-     * \return T * 返回第一个地址
-     */
-    inline const T &first()
-    {
-        QMutexLocker lk(&mutex);
-        if (myList->isEmpty())
-            return nullptr;
-        return myList->first();
-    }
-    inline T takeByLock()
-    {
-        QMutexLocker lk(&mutex);
-        if (myList->isEmpty())
-            return nullptr;
-        return myList->takeFirst();
-    }
+
     /*!
      * \brief count 链表的总个数
      *
@@ -223,14 +189,6 @@ public:
     {
         QMutexLocker lk(&mutex);
         return myList->indexOf(t, from);
-    }
-    void lock()
-    {
-        mutex.lock();
-    }
-    void unlock()
-    {
-        mutex.unlock();
     }
 
 private:
@@ -301,30 +259,7 @@ public:
         QMutexLocker lk(&mutex);
         return myMap.contains(key);
     }
-    /*!
-     * \brief begin 当前map的开始迭代器
-     *
-     * \param null
-     *
-     * \return QMap<Key, Value>::iterator 当前map的开始迭代器
-     */
-    inline typename QMap<DKey, DValue>::iterator begin()
-    {
-        QMutexLocker lk(&mutex);
-        return myMap.begin();
-    }
-    /*!
-     * \brief begin 当前map的结束迭代器
-     *
-     * \param null
-     *
-     * \return QMap<Key, Value>::iterator 当前map的结束迭代器
-     */
-    inline typename QMap<DKey, DValue>::iterator end()
-    {
-        QMutexLocker lk(&mutex);
-        return myMap.end();
-    }
+
     /*!
      * \brief erase 去掉map中当前的迭代器
      *

--- a/src/dfm-base/utils/infocache.cpp
+++ b/src/dfm-base/utils/infocache.cpp
@@ -97,7 +97,7 @@ void InfoCache::removeCache(const QUrl url)
  */
 bool InfoCache::cacheDisable(const QString &scheme)
 {
-    return d->disableCahceSchemes.contains(scheme);
+    return d->disableCahceSchemes.containsByLock(scheme);
 }
 /*!
  * \brief setCacheDisbale 设置scheme是否可以缓存
@@ -110,11 +110,11 @@ bool InfoCache::cacheDisable(const QString &scheme)
  */
 void InfoCache::setCacheDisbale(const QString &scheme, bool disable)
 {
-    if (!d->disableCahceSchemes.contains(scheme) && disable) {
+    if (!d->disableCahceSchemes.containsByLock(scheme) && disable) {
         d->disableCahceSchemes.push_backByLock(scheme);
         return;
     }
-    if (d->disableCahceSchemes.contains(scheme) && !disable) {
+    if (d->disableCahceSchemes.containsByLock(scheme) && !disable) {
         d->disableCahceSchemes.removeOneByLock(scheme);
         return;
     }
@@ -146,13 +146,13 @@ void InfoCache::cacheInfo(const QUrl url, const FileInfoPointer info)
             return;
     }
 
-    //获取监视器，监听当前的file的改变 当没有缓存加入监视器后，这里的watcher就会析构，如果启动了就要停止监控，这个是代理
-    // 代理就将启动的缓存了监视关闭了。本来没有缓存的监视器监视就没有意义
-    // if (!WatcherCache::instance().cacheDisable(url.scheme())) {
-    //     auto parentUrl = UrlRoute::urlParent(url);
-    //     auto parentPath = parentUrl.path();
-    //     if (parentPath != QDir::separator() && !parentPath.endsWith(QDir::separator()))
-    //         parentUrl.setPath(parentPath + QDir::separator());
+    // 获取监视器，监听当前的file的改变 当没有缓存加入监视器后，这里的watcher就会析构，如果启动了就要停止监控，这个是代理
+    //  代理就将启动的缓存了监视关闭了。本来没有缓存的监视器监视就没有意义
+    //  if (!WatcherCache::instance().cacheDisable(url.scheme())) {
+    //      auto parentUrl = UrlRoute::urlParent(url);
+    //      auto parentPath = parentUrl.path();
+    //      if (parentPath != QDir::separator() && !parentPath.endsWith(QDir::separator()))
+    //          parentUrl.setPath(parentPath + QDir::separator());
 
     //     auto watcher = WatcherFactory::create<AbstractFileWatcher>(parentUrl);
     //     if (watcher) {
@@ -313,7 +313,7 @@ void InfoCache::addWatcherTimeInfo(const QList<QUrl> &urls)
     if (d->timeToUrlWatcherMap.count() <= kCacheFileWatcherCount)
         return;
 
-             // 超出限制移除先进入的watcher
+    // 超出限制移除先进入的watcher
     auto it = d->timeToUrlWatcherMap.begin();
     while (d->urlTimeSortWatcherHash.size() > kCacheFileWatcherCount
            && it != d->timeToUrlWatcherMap.end()) {
@@ -456,9 +456,7 @@ FileInfoPointer InfoCacheController::getCacheInfo(const QUrl &url)
 }
 
 InfoCacheController::InfoCacheController(QObject *parent)
-    : QObject(parent), thread(new QThread), worker(new CacheWorker), removeTimer(new QTimer)
-    , threadUpdate(new QThread)
-    , workerUpdate(new TimeToUpdateCache)
+    : QObject(parent), thread(new QThread), worker(new CacheWorker), removeTimer(new QTimer), threadUpdate(new QThread), workerUpdate(new TimeToUpdateCache)
 {
     init();
 }
@@ -487,7 +485,6 @@ void InfoCacheController::init()
 
 TimeToUpdateCache::~TimeToUpdateCache()
 {
-
 }
 
 void TimeToUpdateCache::updateInfoTime(const QUrl url)
@@ -509,11 +506,11 @@ void TimeToUpdateCache::updateWatcherTime(const QList<QUrl> &urls, const bool ad
     InfoCache::instance().updateSortTimeWatcherWorker(urls, add);
 }
 
-TimeToUpdateCache::TimeToUpdateCache(QObject *parent) : QObject (parent)
+TimeToUpdateCache::TimeToUpdateCache(QObject *parent)
+    : QObject(parent)
 {
-
 }
 
 }
 
-//开线程移除缓存和同步缓存操作
+// 开线程移除缓存和同步缓存操作

--- a/src/dfm-base/utils/watchercache.cpp
+++ b/src/dfm-base/utils/watchercache.cpp
@@ -56,7 +56,7 @@ WatcherCache &WatcherCache::instance()
 QSharedPointer<AbstractFileWatcher> WatcherCache::getCacheWatcher(const QUrl &url)
 {
     Q_D(WatcherCache);
-    emit updateWatcherTime({url}, true);
+    emit updateWatcherTime({ url }, true);
     return d->watchers.value(url);
 }
 /*!
@@ -79,7 +79,7 @@ void WatcherCache::cacheWatcher(const QUrl &url, const QSharedPointer<AbstractFi
         return;
     connect(watcher.data(), &AbstractFileWatcher::fileDeleted, this, &WatcherCache::fileDelete);
     d->watchers.insert(url, watcher);
-    emit updateWatcherTime({url}, true);
+    emit updateWatcherTime({ url }, true);
 }
 /*!
  * \brief removCacheWatcher 根据Url移除当前缓存的watcher
@@ -100,7 +100,7 @@ void WatcherCache::removeCacheWatcher(const QUrl &url, const bool isEmit)
     emit fileDelete(url);
     d->watchers.remove(url);
     if (isEmit)
-        emit updateWatcherTime({url}, false);
+        emit updateWatcherTime({ url }, false);
 }
 
 void WatcherCache::removeCacheWatcherByParent(const QUrl &parent)
@@ -123,16 +123,16 @@ void WatcherCache::removeCacheWatcherByParent(const QUrl &parent)
 
 bool WatcherCache::cacheDisable(const QString &scheme)
 {
-    return d->disableCahceSchemes.contains(scheme);
+    return d->disableCahceSchemes.containsByLock(scheme);
 }
 
 void WatcherCache::setCacheDisbale(const QString &scheme, bool disbale)
 {
-    if (!d->disableCahceSchemes.contains(scheme) && disbale) {
+    if (!d->disableCahceSchemes.containsByLock(scheme) && disbale) {
         d->disableCahceSchemes.push_backByLock(scheme);
         return;
     }
-    if (d->disableCahceSchemes.contains(scheme) && !disbale) {
+    if (d->disableCahceSchemes.containsByLock(scheme) && !disbale) {
         d->disableCahceSchemes.removeOneByLock(scheme);
         return;
     }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -378,7 +378,7 @@ bool FileOperateBaseWorker::copyAndDeleteFile(const DFileInfoPointer &fromInfo, 
         }
         if (ok)
             cutAndDeleteFiles.append(fromInfo);
-        OperatorsFileUtils::instance()->delayRemoveCopyingFile(url);
+        FileUtils::removeCopyingFileUrl(url);
     }
 
     toInfo->initQuerier();
@@ -910,7 +910,7 @@ bool FileOperateBaseWorker::doCopyLocalByRange(const DFileInfoPointer fromInfo, 
 
     FileUtils::cacheCopyingFileUrl(targetUrl);
     DoCopyFileWorker::NextDo nextDo = copyOtherFileWorker->doCopyFileByRange(fromInfo, toInfo, skip);
-    OperatorsFileUtils::instance()->delayRemoveCopyingFile(targetUrl);
+    FileUtils::removeCopyingFileUrl(targetUrl);
     return nextDo == DoCopyFileWorker::NextDo::kDoCopyNext;
 }
 
@@ -938,7 +938,7 @@ bool FileOperateBaseWorker::doCopyOtherFile(const DFileInfoPointer fromInfo, con
     }
     if (ok)
         syncFiles.append(targetUrl);
-    OperatorsFileUtils::instance()->delayRemoveCopyingFile(targetUrl);
+    FileUtils::removeCopyingFileUrl(targetUrl);
 
     return ok;
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1107,7 +1107,7 @@ bool FileOperateBaseWorker::canWriteFile(const QUrl &url) const
 
 void FileOperateBaseWorker::setAllDirPermisson()
 {
-    for (auto info : dirPermissonList.list()) {
+    for (auto info : dirPermissonList.listByLock()) {
         if (info->permission && supportSetPermission)
             localFileHandler->setPermissions(info->target, info->permission);
     }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -76,27 +76,6 @@ private:
     static QSet<QString> fileNameUsing;
     static QMutex mutex;
 };
-
-class OperatorsFileUtils : public QObject {
-    Q_OBJECT
-    explicit OperatorsFileUtils(QObject *parent = nullptr)
-        : QObject(parent) {}
-public:
-    ~OperatorsFileUtils() override {}
-
-    void delayRemoveCopyingFile(const QUrl &url) {
-        QTimer::singleShot(500, this, [url](){
-            dfmbase::FileUtils::removeCopyingFileUrl(url);
-        });
-    }
-
-    static OperatorsFileUtils *instance() {
-        static OperatorsFileUtils in;
-        return &in;
-    }
-
-};
-
 DPFILEOPERATIONS_END_NAMESPACE
 
 #endif   // FILEOPERATIONSUTILS_H

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -166,6 +166,7 @@ private:
     QStringList connectedTokens;
 
     QStringList keyWords {};
+    std::atomic_bool isDying { false };
 };
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -157,7 +157,7 @@ private:
 
     QQueue<QPair<QUrl, EventType>> watcherEvent {};
     QMutex watcherEventMutex;
-    QAtomicInteger<bool> processFileEventRuning = false;
+    std::atomic_bool processFileEventRuning { false };
 
     QList<TraversalThreadPointer> discardedThread {};
     QList<QSharedPointer<QThread>> threads {};

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1851,12 +1851,12 @@ bool FileSortWorker::isDefaultHiddenFile(const QUrl &fileUrl)
             auto blkInfo = DevProxyMng->queryBlockInfo(blk);
             const QStringList &mountPoints = blkInfo.value(DeviceProperty::kMountPoints).toStringList();
             for (const auto &mpt : mountPoints) {
-                defaultHiddenUrls.push_back(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
-                defaultHiddenUrls.push_back(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
             }
         }
     });
-    return defaultHiddenUrls.contains(fileUrl);
+    return defaultHiddenUrls.containsByLock(fileUrl);
 }
 
 QUrl FileSortWorker::parantUrl(const QUrl &url)

--- a/src/services/sharecontrol/sharecontroldbus.cpp
+++ b/src/services/sharecontrol/sharecontroldbus.cpp
@@ -46,7 +46,7 @@ ShareControlDBus::~ShareControlDBus()
 bool ShareControlDBus::CloseSmbShareByShareName(const QString &name, bool show)
 {
     fmInfo() << "[ShareControlDBus::CloseSmbShareByShareName] Request to close SMB share:" << name << "show:" << show;
-    
+
     if (!show) {
         fmInfo() << "[ShareControlDBus::CloseSmbShareByShareName] Show parameter is false, operation skipped for share:" << name;
         return true;
@@ -68,9 +68,9 @@ bool ShareControlDBus::CloseSmbShareByShareName(const QString &name, bool show)
     QString sharePath = "/var/lib/samba/usershares/";
     QString filePath = QString("%1%2").arg(sharePath).arg(name.toLower());   // 文件名小写
     QFileInfo info(filePath);
-    
+
     fmInfo() << "[ShareControlDBus::CloseSmbShareByShareName] Checking share file permissions - path:" << filePath << "caller UID:" << suid << "file owner UID:" << info.ownerId();
-    
+
     if ((suid != 0 && suid != info.ownerId())   // 对比文件属主与调用总线进程属主;
         || info.isSymLink()   // 禁止使用符合链接
         || !info.absoluteFilePath().startsWith(sharePath)) {   // 禁止使用../等
@@ -91,17 +91,17 @@ bool ShareControlDBus::CloseSmbShareByShareName(const QString &name, bool show)
     } else {
         fmCritical() << "[ShareControlDBus::CloseSmbShareByShareName] Failed to close SMB share:" << name << "process output:" << p.readAll() << "stderr:" << p.readAllStandardError();
     }
-    
+
     fmDebug() << "[ShareControlDBus::CloseSmbShareByShareName] Command output for share:" << name << "stdout:" << p.readAllStandardOutput() << "stderr:" << p.readAllStandardError();
     return ret;
 }
 
 bool ShareControlDBus::SetUserSharePassword(const QDBusUnixFileDescriptor &credentialsFd)
 {
-    fmInfo() << "[ShareControlDBus::SetUserSharePassword] Request to set password for user:" << name;
-    
+    fmInfo() << "[ShareControlDBus::SetUserSharePassword] Request to set password";
+
     if (!checkAuthentication()) {
-        fmWarning() << "[ShareControlDBus::SetUserSharePassword] Authentication failed for user:" << name;
+        fmWarning() << "[ShareControlDBus::SetUserSharePassword] Authentication failed";
         return false;
     }
 
@@ -154,7 +154,7 @@ bool ShareControlDBus::SetUserSharePassword(const QDBusUnixFileDescriptor &crede
     QStringList args;
     args << "-a" << username << "-s";
     QProcess p;
-    fmInfo() << "[ShareControlDBus::SetUserSharePassword] Executing smbpasswd command for user:" << name;
+    fmInfo() << "[ShareControlDBus::SetUserSharePassword] Executing smbpasswd command";
     p.start("smbpasswd", args);
     if (!p.waitForStarted()) {
         fmInfo() << "Failed to start smbpasswd process";
@@ -167,21 +167,22 @@ bool ShareControlDBus::SetUserSharePassword(const QDBusUnixFileDescriptor &crede
     p.closeWriteChannel();
 
     bool r = p.waitForFinished();
-    
+
     if (r) {
-        fmInfo() << "[ShareControlDBus::SetUserSharePassword] Successfully set password for user:" << name;
+        fmInfo() << "[ShareControlDBus::SetUserSharePassword] Successfully set password";
     } else {
-        fmCritical() << "[ShareControlDBus::SetUserSharePassword] Failed to set password for user:" << name;
+        fmCritical() << "[ShareControlDBus::SetUserSharePassword] Failed to set password";
     }
-    
-    fmDebug() << "[ShareControlDBus::SetUserSharePassword] smbpasswd output for user:" << name << "stdout:" << p.readAllStandardOutput() << "stderr:" << p.readAllStandardError();
+
+    fmDebug() << "[ShareControlDBus::SetUserSharePassword] smbpasswd output. stdout:"
+              << p.readAllStandardOutput() << "stderr:" << p.readAllStandardError();
     return r;
 }
 
 bool ShareControlDBus::EnableSmbServices()
 {
     fmInfo() << "[ShareControlDBus::EnableSmbServices] Request to enable SMB services";
-    
+
     if (!checkAuthentication()) {
         fmWarning() << "[ShareControlDBus::EnableSmbServices] Authentication failed for enabling SMB services";
         return false;
@@ -205,7 +206,7 @@ bool ShareControlDBus::EnableSmbServices()
     } else {
         fmCritical() << "[ShareControlDBus::EnableSmbServices] Failed to enable nmbd service";
     }
-    
+
     fmInfo() << "[ShareControlDBus::EnableSmbServices] SMB services enablement completed with result:" << ret;
     return ret;
 }
@@ -213,16 +214,16 @@ bool ShareControlDBus::EnableSmbServices()
 bool ShareControlDBus::IsUserSharePasswordSet(const QString &username)
 {
     fmInfo() << "[ShareControlDBus::IsUserSharePasswordSet] Checking if password is set for user:" << username;
-    
+
     QProcess p;
     p.start("pdbedit", { "-L" });
     auto ret = p.waitForFinished();
-    
+
     if (!ret) {
         fmCritical() << "[ShareControlDBus::IsUserSharePasswordSet] Failed to execute pdbedit command for user:" << username;
         return false;
     }
-    
+
     QStringList resultLines = QString::fromUtf8(p.readAllStandardOutput()).split('\n');
     bool isPasswordSet = false;
     foreach (const QString &line, resultLines) {


### PR DESCRIPTION
## Summary by Sourcery

Enforce proper locking in thread-safe containers and improve concurrency control, refactor static caches in UrlRoute, simplify file operation cleanup, and clean up formatting across modules.

Enhancements:
- Remove unsafe direct-access methods from DThreadList and replace them with lock-based variants; add a locked removeIf function to DThreadHash.
- Refactor UrlRoute’s static scheme caches into function‐local static containers and update all references accordingly.
- Introduce std::atomic flags with compare_exchange logic in RootInfo to guard concurrent watcher events.
- Eliminate the OperatorsFileUtils helper and invoke FileUtils::removeCopyingFileUrl directly in file operation workers.
- Update WatcherCache to use the new removeIf API and lock‐based list operations for disabling caches.
- Convert InfoCache and FileSortWorker to use ByLock collection methods for thread safety.

Chores:
- Clean up whitespace, initializer lists, and formatting inconsistencies across multiple files.