### PR TITLE
fix bugs

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1177,11 +1177,14 @@ bool FileUtils::fileCanTrash(const QUrl &url)
 {
     // gio does not support root user to move ordinary user files to trash
     auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+    if (SysInfoUtils::isRootUser()) {
+        int ownerId = info.isNull() ? -1 : info->extendAttributes(FileInfo::FileExtendedInfoType::kOwnerId).toInt();
+        if (ownerId != 0)
+            return false;
+    }
+
     if (!info)
         return false;
-
-    if (SysInfoUtils::isRootUser())
-        return info->canAttributes(CanableInfoType::kCanTrash);
 
     bool alltotrash = DConfigManager::instance()->value(kDefaultCfgPath, kFileAllTrash).toBool();
     if (alltotrash)

--- a/src/dfm-base/utils/sysinfoutils.h
+++ b/src/dfm-base/utils/sysinfoutils.h
@@ -11,28 +11,25 @@
 #include <QMimeData>
 
 namespace dfmbase {
+namespace SysInfoUtils {
+QString getUser();
+QStringList getAllUsersOfHome();
+QString getHostName();
+QString getOriginalUserHome();
+int getUserId();
+float getMemoryUsage(int pid);
 
-class SysInfoUtils
-{
+bool isRootUser();
+bool isServerSys();
+bool isDesktopSys();
+bool isOpenAsAdmin();
+bool isDeveloperModeEnabled();
+bool isProfessional();
+bool isDeepin23();
+bool isSameUser(const QMimeData *data);
 
-public:
-    static QString getUser();
-    static QStringList getAllUsersOfHome();
-    static QString getHostName();
-    static int getUserId();
-    static float getMemoryUsage(int pid);
-
-    static bool isRootUser();
-    static bool isServerSys();
-    static bool isDesktopSys();
-    static bool isOpenAsAdmin();
-    static bool isDeveloperModeEnabled();
-    static bool isProfessional();
-    static bool isDeepin23();
-    static bool isSameUser(const QMimeData *data);
-
-    static void setMimeDataUserId(QMimeData *data);
-};
-}
+void setMimeDataUserId(QMimeData *data);
+}   // namespace SysInfoUtils
+}   // namespace dfmbase
 
 #endif   // SYSINFOUTILS_H

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -345,6 +345,7 @@ void ComputerModel::onItemRemoved(const QUrl &url)
         removeOrphanGroup();
     } else {
         fmDebug() << "target item not found" << url;
+        return;
     }
 
     emit requestHandleItemVisible();

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -515,6 +515,10 @@ void ComputerModel::removeOrphanGroup()
 
     for (int i = aboutToRemovedGroup.count() - 1; i >= 0; i--) {
         int removeAt { aboutToRemovedGroup.at(i) };
+        auto groupName = items.at(removeAt).itemName;
+        auto groupRemoved = ComputerItemWatcherInstance->removeGroup(groupName);
+        fmInfo() << groupName << "removed? (true if group exists.)" << groupRemoved;
+
         beginRemoveRows(QModelIndex(), removeAt, removeAt);
         items.removeAt(removeAt);
         endRemoveRows();

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
@@ -42,7 +42,7 @@ public:
 
     void startQueryItems(bool async = true);
 
-    void addDevice(const QString &groupName, const QUrl &url, int shape, bool addToSidebar = false);
+    void addDevice(const QString &groupName, const QUrl &url, int shape = ComputerItemData::kLargeItem, bool addToSidebar = true);
     void removeDevice(const QUrl &url);
 
     QVariantMap makeSidebarItem(DFMEntryFileInfoPointer info);
@@ -51,6 +51,8 @@ public:
     void addSidebarItem(const QUrl &url, const QVariantMap &data);
     void removeSidebarItem(const QUrl &url);
     void handleSidebarItemsVisiable();
+
+    bool removeGroup(const QString &groupName);
 
     void insertUrlMapper(const QString &devId, const QUrl &mntUrl);
     void clearAsyncThread();
@@ -130,8 +132,8 @@ private:
     QMap<QString, int> groupIds;
 
     QMultiMap<QUrl, QUrl> routeMapper;
-    QPointer<QFutureWatcher<ComputerDataList>> fw{ nullptr };
-    QList<QUrl> pendingSidebarDevUrls;  // Store pending device URLs to execute makeSidebarItem in main thread
+    QPointer<QFutureWatcher<ComputerDataList>> fw { nullptr };
+    QList<QUrl> pendingSidebarDevUrls;   // Store pending device URLs to execute makeSidebarItem in main thread
 };
 }
 #endif   // COMPUTERITEMWATCHER_H

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
@@ -201,7 +201,7 @@ private:
 
     bool checkFilters(const SortInfoPointer &sortInfo, const bool byInfo = false);
     bool isDefaultHiddenFile(const QUrl &fileUrl);
-    QUrl parantUrl(const QUrl &url);
+    QUrl makeParentUrl(const QUrl &url);
     int8_t getDepth(const QUrl &url);
     int findRealShowIndex(const QUrl &preItemUrl);
     int indexOfVisibleChild(const QUrl &itemUrl);


### PR DESCRIPTION
## Summary by Sourcery

Refactor system info utilities into a namespace, tighten file trash validation for root/admin contexts, and clean up device watcher logic by standardizing add/remove methods and introducing group removal.

New Features:
- Introduce SysInfoUtils::getOriginalUserHome to retrieve the invoking user's home directory when running with elevated privileges
- Add ComputerItemWatcher::removeGroup to allow explicit removal of device groups