### PR TITLE
fix: Add NFS file detection and update file watcher logic

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -961,7 +961,6 @@ bool FileUtils::containsCopyingFileUrl(const QUrl &url)
     return copyingUrl.contains(url);
 }
 
-// TODO: remove it!
 void FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType type, const QUrl &url)
 {
     if (!url.isValid())
@@ -1001,18 +1000,6 @@ void FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType type,
         return;
     }
 }
-// fix 多线程排序时，该处的全局变量在compareByString函数中可能导致软件崩溃
-// QCollator sortCollator;
-class DCollator : public QCollator
-{
-public:
-    DCollator()
-        : QCollator()
-    {
-        setNumericMode(true);
-        setCaseSensitivity(Qt::CaseInsensitive);
-    }
-};
 
 QString FileUtils::symlinkTarget(const QUrl &url)
 {
@@ -1203,16 +1190,15 @@ bool FileUtils::fileCanTrash(const QUrl &url)
         // Use more reliable path comparison to handle symlinks and mount points
         QString normalizedOriginalHome = QDir::cleanPath(originalHomePath);
         QString normalizedFilePath = QDir::cleanPath(canonicalFilePath);
-        
+
         // Ensure proper path boundary comparison
         if (!normalizedOriginalHome.endsWith('/')) {
             normalizedOriginalHome += '/';
         }
-        
+
         // Check if file is within the original user's home directory
-        bool isInHomeDir = (normalizedFilePath.startsWith(normalizedOriginalHome) || 
-                           normalizedFilePath == normalizedOriginalHome.chopped(1));
-        
+        bool isInHomeDir = (normalizedFilePath.startsWith(normalizedOriginalHome) || normalizedFilePath == normalizedOriginalHome.chopped(1));
+
         if (isInHomeDir) {
             // 文件位于原始用户的主目录中。
             // 这是 GIO 会拒绝的“领域冲突”场景。

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -971,6 +971,8 @@ void FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType type,
             return true;
         if (ProtocolUtils::isFTPFile(url))
             return true;
+        if (ProtocolUtils::isNFSFile(url))
+            return true;
 
         return false;
     };
@@ -982,7 +984,7 @@ void FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType type,
     if (!urlParent.isValid())
         return;
 
-    AbstractFileWatcherPointer watcher = WatcherFactory::create<AbstractFileWatcher>(DFMIO::DFMUtils::directParentUrl(url));
+    AbstractFileWatcherPointer watcher = WatcherFactory::create<AbstractFileWatcher>(urlParent);
     if (!watcher)
         return;
 

--- a/src/dfm-base/utils/protocolutils.cpp
+++ b/src/dfm-base/utils/protocolutils.cpp
@@ -89,6 +89,15 @@ bool isLocalFile(const QUrl &url)
     return true;
 }
 
+bool isNFSFile(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    static const QString nfsMatch { R"((^/run/user/\d+/gvfs/nfs|^/root/.gvfs/nfs))" };
+    return hasMatch(url.path(), nfsMatch);
+}
+
 }   // namespace ProtocolUtils
 
 DFMBASE_END_NAMESPACE

--- a/src/dfm-base/utils/protocolutils.h
+++ b/src/dfm-base/utils/protocolutils.h
@@ -15,6 +15,7 @@ bool isGphotoFile(const QUrl &url);
 bool isFTPFile(const QUrl &url);
 bool isSFTPFile(const QUrl &url);
 bool isSMBFile(const QUrl &url);
+bool isNFSFile(const QUrl &url);
 }   // namespace ProtocolUtils
 
 DFMBASE_END_NAMESPACE


### PR DESCRIPTION
## Summary by Sourcery

Add NFS file detection and refine file watcher logic.

New Features:
- Add ProtocolUtils::isNFSFile to detect NFS-mounted file URLs

Enhancements:
- Exclude NFS file URLs from manual file change notifications
- Instantiate file watchers with the direct parent URL instead of using DFMUtils::directParentUrl
- Remove obsolete DCollator class and related TODO comments