### PR TITLE
fix: Update disk detection logic in DeviceUtils

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -678,7 +678,7 @@ QString DeviceUtils::bindPathTransform(const QString &path, bool toDevice)
 bool DeviceUtils::isBuiltInDisk(const QVariantHash &devInfo)
 {
     // 如果是可移除设备，则不是内置磁盘
-    if (devInfo.value(kCanPowerOff).toBool())
+    if (devInfo.value(kCanPowerOff).toBool() && !isSiblingOfRoot(devInfo))
         return false;
 
     // 如果是光驱设备，则不是内置磁盘
@@ -732,7 +732,7 @@ bool DeviceUtils::isSystemDisk(const QVariantMap &devInfo)
 bool DeviceUtils::isDataDisk(const QVariantHash &devInfo)
 {
     // 如果是可移除设备，则不是数据盘
-    if (devInfo.value(kCanPowerOff).toBool())
+    if (devInfo.value(kCanPowerOff).toBool() && !isSiblingOfRoot(devInfo))
         return false;
 
     // 如果是根目录，则不是数据盘


### PR DESCRIPTION
- Enhanced the `isBuiltInDisk` and `isDataDisk` functions to include a check for sibling relationships with the root device when determining if a device is removable.
- This change ensures that removable devices that are siblings of the root are correctly identified as non-built-in and non-data disks.

Log: Improves accuracy in disk type detection.
Bug: https://pms.uniontech.com/bug-view-323581.html

## Summary by Sourcery

Bug Fixes:
- Fix misclassification of removable disks that are siblings of the root by excluding them in isBuiltInDisk and isDataDisk checks