### PR TITLE
fix: Adjust header view resizing on event filter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.76) unstable; urgency=medium
+
+  * fix some bugs.
+
+ -- Liuyangming <liuyangming@uniontech.com>  Thu, 10 Jul 2025 19:56:22 +0800
+
 dde-file-manager (6.5.75) unstable; urgency=medium
 
   * Revert a bug commit

--- a/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/mediawork.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/mediawork.cpp
@@ -17,6 +17,9 @@ void MediaWork::createMediaPlayer()
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     connect(mediaPlayer, &QMediaPlayer::stateChanged, this, &MediaWork::playerStateChanged);
 #else
+    // Qt6需要显式设置音频输出
+    audioOutput = new QAudioOutput(this);
+    mediaPlayer->setAudioOutput(audioOutput);
     connect(mediaPlayer, &QMediaPlayer::playbackStateChanged, this, &MediaWork::playerStateChanged);
 #endif
     connect(mediaPlayer, &QMediaPlayer::mediaStatusChanged, this, &MediaWork::playerStatusChanged);

--- a/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/mediawork.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/mediawork.h
@@ -7,6 +7,9 @@
 
 #include <QObject>
 #include <QMediaPlayer>
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+#include <QAudioOutput>
+#endif
 
 namespace plugin_filepreview {
 class MediaWork : public QObject
@@ -41,7 +44,10 @@ Q_SIGNALS:
     void playerPositionChanged(qint64 duration);
 
 private:
-    QMediaPlayer *mediaPlayer;
+    QMediaPlayer *mediaPlayer { nullptr };
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    QAudioOutput *audioOutput { nullptr };
+#endif
 };
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2021,6 +2021,10 @@ bool FileView::eventFilter(QObject *obj, QEvent *event)
         break;
     }
 
+    if (obj == d->headerWidget && event->type() == QEvent::Resize) {
+            d->headerView->adjustSize();
+    }
+
     return DListView::eventFilter(obj, event);
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
@@ -69,10 +69,10 @@ void HeaderView::updateColumnWidth()
             break;
         }
 
-    for (; j > 0; --j) {
-        int logicalIndex = this->logicalIndex(j);
-        if (isSectionHidden(logicalIndex))
-            continue;
+        for (; j > 0; --j) {
+            int logicalIndex = this->logicalIndex(j);
+            if (isSectionHidden(logicalIndex))
+                continue;
 
             resizeSection(logicalIndex, model->getColumnWidth(j) + kRightPadding + kListModeRightMargin + 2 * kColumnPadding);
             break;


### PR DESCRIPTION
Changes:
- Added handling for the QEvent::Resize event in FileView to adjust the header view size dynamically.
- Cleaned up the loop structure in HeaderView's updateColumnWidth method for better readability.

Log: These updates improve the responsiveness of the file manager's header view during resizing events, enhancing user experience.
Bug: https://pms.uniontech.com/bug-view-320153.html

## Summary by Sourcery

Improve header view responsiveness by handling resize events in FileView and refactoring the column width update logic for clarity.

Bug Fixes:
- Handle QEvent::Resize in FileView to dynamically adjust header view size

Enhancements:
- Refactor HeaderView::updateColumnWidth loop structure for improved readability