### PR TITLE
fix: Improve resource management in BasicWidget and TraversalDirThreadManager

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -48,7 +48,6 @@ using namespace dfmplugin_propertydialog;
 
 BasicWidget::BasicWidget(QWidget *parent)
     : DArrowLineDrawer(parent),
-      fetchThread(new QThread),
       infoFetchWorker(new MediaInfoFetchWorker)
 
 {
@@ -56,16 +55,17 @@ BasicWidget::BasicWidget(QWidget *parent)
     fileCalculationUtils = new FileStatisticsJob;
     fileCalculationUtils->setFileHints(FileStatisticsJob::FileHint::kNoFollowSymlink);
 
-    infoFetchWorker->moveToThread(fetchThread);
-    fetchThread->start();
+    connect(&fetchThread, &QThread::finished, infoFetchWorker, &QObject::deleteLater);
+    infoFetchWorker->moveToThread(&fetchThread);
+    fetchThread.start();
 }
 
 BasicWidget::~BasicWidget()
 {
     fileCalculationUtils->deleteLater();
-    if (fetchThread->isRunning()) {
-        fetchThread->quit();
-        fetchThread->wait(5000);
+    if (fetchThread.isRunning()) {
+        fetchThread.quit();
+        fetchThread.wait(5000);
     }
 }
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
@@ -75,7 +75,7 @@ private:
     QGridLayout *layoutMain { nullptr };
     QUrl currentUrl;
 
-    QThread *fetchThread { nullptr };
+    QThread fetchThread;
     MediaInfoFetchWorker *infoFetchWorker { nullptr };
 };
 }

--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
@@ -365,7 +365,7 @@ QUrl ComputerUtils::convertToDevUrl(const QUrl &url)
         auto devIds = DevProxyMng->getAllBlockIds();
         for ( auto id : devIds) {
             QUrl devUrl(makeBlockDevUrl(id));
-            auto entryInfo = new EntryFileInfo(devUrl);
+            DFMEntryFileInfoPointer entryInfo(new EntryFileInfo(devUrl));
             if (UniversalUtils::urlEquals(converted, entryInfo->targetUrl())) {
                 fmDebug() << "convert url from" << url << "to" << devUrl;
                 return devUrl;

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -288,7 +288,7 @@ void ConnectToServerDialog::initServerDatas()
         processUrl(urlStr, opt);
     }
 
-    completer->setModel(new QStringListModel(hosts));
+    completer->setModel(new QStringListModel(hosts, completer));
 
     if (!hosts.isEmpty())
         onCurrentInputChanged(hosts.last());

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -173,10 +173,7 @@ int TraversalDirThreadManager::iteratorOneByOne(const QElapsedTimer &timere)
     if (!future)
         Q_EMIT iteratorInitFinished();
 
-    if (!timer)
-        timer = new QElapsedTimer();
-
-    timer->restart();
+    timer.restart();
 
     QList<FileInfoPointer> childrenList;   // 当前遍历出来的所有文件
     QSet<QUrl> urls;
@@ -211,9 +208,9 @@ int TraversalDirThreadManager::iteratorOneByOne(const QElapsedTimer &timere)
         childrenList.append(fileInfo);
         filecount++;
 
-        if (timer->elapsed() > timeCeiling || childrenList.count() > countCeiling) {
+        if (timer.elapsed() > timeCeiling || childrenList.count() > countCeiling) {
             emit updateChildrenManager(childrenList, traversalToken);
-            timer->restart();
+            timer.restart();
             childrenList.clear();
         }
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.h
@@ -27,7 +27,7 @@ class TraversalDirThreadManager : public TraversalDirThread
     Qt::SortOrder sortOrder { Qt::AscendingOrder };
     dfmio::DEnumerator::SortRoleCompareFlag sortRole { dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault };
     bool isMixDirAndFile { false };
-    QElapsedTimer *timer = Q_NULLPTR;
+    QElapsedTimer timer;
     int timeCeiling = 200;
     int countCeiling = 500;
     dfmio::DEnumeratorFuture *future { nullptr };


### PR DESCRIPTION
- Added a connection to ensure the infoFetchWorker is deleted when the fetchThread finishes in BasicWidget.
- Changed timer from a pointer to a direct instance in TraversalDirThreadManager, simplifying memory management and improving performance.
- Updated the model initialization in ConnectToServerDialog to correctly associate the completer with its model.

Log: These changes enhance resource management and stability across multiple components.
Bug: https://pms.uniontech.com/bug-view-324105.html

## Summary by Sourcery

Improve resource management and component stability by replacing raw pointers with smart pointers or direct instances, adding proper cleanup connections, and correcting model ownership associations.

Enhancements:
- Connect fetchThread finished signal to infoFetchWorker deleteLater and explicitly delete fetchThread in BasicWidget to ensure proper cleanup
- Replace QElapsedTimer pointer with a direct instance in TraversalDirThreadManager to simplify memory management and boost performance
- Use DFMEntryFileInfoPointer smart pointer instead of raw EntryFileInfo pointer in ComputerUtils to improve ownership handling
- Set QStringListModel parent to the completer in ConnectToServerDialog to correctly associate model ownership