### PR TITLE
chore: update changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.77) unstable; urgency=medium
+
+  * fix bugs. 
+
+ -- Liuyangming <liuyangming@uniontech.com>  Wed, 16 Jul 2025 10:17:07 +0800
+
 dde-file-manager (6.5.76) unstable; urgency=medium
 
   * fix some bugs.


### PR DESCRIPTION
update version to 6.5.77

Log: update changelog

## Summary by Sourcery

Update Debian changelog to reflect version bump to 6.5.77

Chores:
- Bump version to 6.5.77 in debian/changelog
- Update changelog entry for the new release