### PR TITLE
fix: sync file info creation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -103,7 +103,7 @@ void FileOperatorHelper::openFilesByMode(const FileView *view, const QList<QUrl>
                          .toBool();
     QList<QUrl> dirListOpenInNewWindow {};
     for (const QUrl &url : urls) {
-        const FileInfoPointer &fileInfoPtr = InfoFactory::create<FileInfo>(url);
+        const FileInfoPointer &fileInfoPtr = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         if (fileInfoPtr) {
             if (!fileInfoPtr->exists()) {
                 // show alert


### PR DESCRIPTION
1. Changed file info creation from default async mode to sync mode when opening files
2. This prevents race conditions where file operations fail due to incomplete async loading on removable devices
3. Mobile environments often have stricter resource constraints which can exacerbate async timing issues
4. Synchronous loading ensures file info is fully available before proceeding with operations

Log:

## Summary by Sourcery

Bug Fixes:
- Use synchronous FileInfo creation instead of asynchronous to ensure file info is fully loaded before use