### PR TITLE
6.5.79

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.79) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 17 Jul 2025 21:45:19 +0800
+
 dde-file-manager (6.5.78) unstable; urgency=medium
 
   * auto tests and fix bugs

--- a/src/plugins/filemanager/dfmplugin-myshares/myshares.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/myshares.cpp
@@ -25,6 +25,7 @@
 #include <DMenu>
 
 DWIDGET_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
 
 using ContextMenuCallback = std::function<void(quint64 windowId, const QUrl &url, const QPoint &globalPos)>;
 Q_DECLARE_METATYPE(QList<QUrl> *)
@@ -94,17 +95,19 @@ void MyShares::onWindowOpened(quint64 winId)
     if (window->sideBar())
         addToSidebar();
     else
-        connect(window, &FileManagerWindow::sideBarInstallFinished, this, [this] { addToSidebar(); }, Qt::DirectConnection);
+        connect(
+                window, &FileManagerWindow::sideBarInstallFinished, this, [this] { addToSidebar(); }, Qt::DirectConnection);
 
     auto searchPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-search") };
     if (searchPlugin && searchPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
         regMyShareToSearch();
     } else {
-        connect(DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this, [this](const QString &iid, const QString &name) {
-            Q_UNUSED(iid)
-            if (name == "dfmplugin-search")
-                regMyShareToSearch();
-        },
+        connect(
+                DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this, [this](const QString &iid, const QString &name) {
+                    Q_UNUSED(iid)
+                    if (name == "dfmplugin-search")
+                        regMyShareToSearch();
+                },
                 Qt::DirectConnection);
     }
 }
@@ -209,6 +212,11 @@ void MyShares::doInitialize()
 
     dpfSignalDispatcher->subscribe("dfmplugin_dirshare", "signal_Share_ShareAdded", this, &MyShares::onShareAdded);
     dpfSignalDispatcher->subscribe("dfmplugin_dirshare", "signal_Share_ShareRemoved", this, &MyShares::onShareRemoved);
+
+    QVariantMap property;
+    property[ViewCustomKeys::kSupportTreeMode] = false;
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetCustomViewProperty", ShareUtils::scheme(), property);
+    dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", ShareUtils::scheme(), property);
 
     followEvents();
     bindWindows();

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1870,7 +1870,7 @@ bool FileSortWorker::isDefaultHiddenFile(const QUrl &fileUrl)
 
 QUrl FileSortWorker::makeParentUrl(const QUrl &url)
 {
-    if (!currentSupportTreeView || !istree || !url.isLocalFile())
+    if (!currentSupportTreeView || !istree)
         return current;
 
     auto parent = url.adjusted(QUrl::RemoveFilename | QUrl::StripTrailingSlash);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.h
@@ -47,7 +47,6 @@ public:
     void setFilterData(quint64 windowId, const QUrl &url, const QVariant &data);
     void setFilterCallback(quint64 windowId, const QUrl &url, const FileViewFilterCallback callback);
     void setWorkspaceMenuScene(const QString &scheme, const QString &scene);
-    void setDefaultViewMode(const QString &scheme, const DFMBASE_NAMESPACE::Global::ViewMode mode);
     void setSelectionMode(const quint64 windowID, const QAbstractItemView::SelectionMode &mode);
     void setEnabledSelectionModes(const quint64 windowID, const QList<QAbstractItemView::SelectionMode> &modes);
     void setViewDragEnabled(const quint64 windowID, const bool enable);
@@ -106,8 +105,8 @@ public:
 
     void registerLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);
     DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy getLoadStrategy(const QString &scheme);
-    static QMap<quint64, QPair<QUrl, QUrl>> kSelectionAndRenameFile;   //###: for creating new file.
-    static QMap<quint64, QPair<QUrl, QUrl>> kSelectionFile;   //###: rename a file which must be existance.
+    static QMap<quint64, QPair<QUrl, QUrl>> kSelectionAndRenameFile;   // ###: for creating new file.
+    static QMap<quint64, QPair<QUrl, QUrl>> kSelectionFile;   // ###: rename a file which must be existance.
 
 public Q_SLOTS:
     void installWorkspaceWidgetToWindow(const quint64 windowID);


### PR DESCRIPTION
## Summary by Sourcery

Prepare release 6.5.79 by updating MyShares plugin view properties, cleaning up WorkspaceHelper API, fixing parent URL logic, polishing code formatting, and updating packaging information

Bug Fixes:
- Fix FileSortWorker::makeParentUrl to drop local file check and rely only on tree view flags

Enhancements:
- Import DFMGLOBAL namespace into MyShares plugin
- Disable tree mode and register custom titlebar for ShareUtils scheme via slot channel

Build:
- Bump version to 6.5.79 and update Debian changelog

Chores:
- Remove deprecated setDefaultViewMode from WorkspaceHelper
- Reformat connect calls to multiline style for improved readability