### PR TITLE
TreeModel for "MyShare"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.80) unstable; urgency=medium
+
+  * fix tree view issues in MyShares plugin
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 18 Jul 2025 09:44:55 +0800
+
 dde-file-manager (6.5.79) unstable; urgency=medium
 
   * fix bugs

--- a/src/plugins/filemanager/dfmplugin-myshares/events/shareeventscaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/events/shareeventscaller.cpp
@@ -17,25 +17,19 @@ void ShareEventsCaller::sendOpenDirs(quint64 winId, const QList<QUrl> &urls, Sha
     if (urls.count() == 0)
         return;
 
-    QList<QUrl> convertedUrls = urls;
-    for (auto &url : convertedUrls) {
-        auto u = ShareUtils::convertToLocalUrl(url);
-        url = u.isValid() ? u : url;
-    }
-
     if (urls.count() > 1) {
-        for (auto url : convertedUrls)
+        for (const auto &url : urls)
             dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, url);
     } else {
         switch (mode) {
         case ShareEventsCaller::OpenMode::kOpenInCurrentWindow:
-            dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, winId, convertedUrls.first());
+            dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, winId, urls.first());
             break;
         case ShareEventsCaller::OpenMode::kOpenInNewWindow:
-            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, convertedUrls.first());
+            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, urls.first());
             break;
         case ShareEventsCaller::OpenMode::kOpenInNewTab:
-            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewTab, winId, convertedUrls.first());
+            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewTab, winId, urls.first());
             break;
         }
     }

--- a/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.cpp
@@ -29,10 +29,8 @@ QString ShareFileInfo::displayOf(const DisPlayInfoType type) const
         if (UrlRoute::isRootUrl(url))
             return QObject::tr("My Shares");
 
-        auto name = d->fileName();
-        if (name.isEmpty())
-            name = ProxyFileInfo::displayOf(type);
-        return name;
+        if (DisPlayInfoType::kFileDisplayName == type)
+            return d->fileName();
     }
     return ProxyFileInfo::displayOf(type);
 }

--- a/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
@@ -5,12 +5,9 @@
 #include "shareiterator.h"
 #include "private/shareiterator_p.h"
 #include "utils/shareutils.h"
-#include "fileinfo/sharefileinfo.h"
 
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
-#include <dfm-base/utils/universalutils.h>
-#include <dfm-base/file/local/localdiriterator.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -19,10 +16,8 @@ DFMBASE_USE_NAMESPACE
 
 ShareIterator::ShareIterator(const QUrl &url, const QStringList &nameFilters, QDir::Filters filters, QDirIterator::IteratorFlags flags)
     : AbstractDirIterator(url, nameFilters, filters, flags),
-      d(new ShareIteratorPrivate(this, url))
+      d(new ShareIteratorPrivate(this))
 {
-    if (!UniversalUtils::urlEquals(url, ShareUtils::rootUrl()))
-        d->proxy = new LocalDirIterator(ShareUtils::convertToLocalUrl(url), nameFilters, filters, flags);
 }
 
 ShareIterator::~ShareIterator()
@@ -31,9 +26,6 @@ ShareIterator::~ShareIterator()
 
 QUrl ShareIterator::next()
 {
-    if (d->proxy)
-        return QUrl::fromLocalFile(d->proxy->next().path());
-
     if (d->shares.isEmpty())
         return {};
 
@@ -44,25 +36,16 @@ QUrl ShareIterator::next()
 
 bool ShareIterator::hasNext() const
 {
-    if (d->proxy)
-        return d->proxy->hasNext();
-
     return !d->shares.isEmpty();
 }
 
 QString ShareIterator::fileName() const
 {
-    if (d->proxy)
-        return d->proxy->fileName();
-
     return d->currentInfo.value(ShareInfoKeys::kName).toString();
 }
 
 QUrl ShareIterator::fileUrl() const
 {
-    if (d->proxy)
-        return d->proxy->fileUrl().path();
-
     return QUrl::fromLocalFile(d->currentInfo.value(ShareInfoKeys::kPath).toString());
 }
 
@@ -73,17 +56,13 @@ const FileInfoPointer ShareIterator::fileInfo() const
 
 QUrl ShareIterator::url() const
 {
-    if (d->rootUrl.isValid())
-        return d->rootUrl;
-
     return ShareUtils::rootUrl();
 }
 
-ShareIteratorPrivate::ShareIteratorPrivate(ShareIterator *qq, const QUrl &url)
+ShareIteratorPrivate::ShareIteratorPrivate(ShareIterator *qq)
     : q(qq)
 {
     shares = dpfSlotChannel->push("dfmplugin_dirshare", "slot_Share_AllShareInfos").value<QList<QVariantMap>>();
-    rootUrl = url;
 }
 
 ShareIteratorPrivate::~ShareIteratorPrivate()

--- a/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
@@ -32,7 +32,7 @@ ShareIterator::~ShareIterator()
 QUrl ShareIterator::next()
 {
     if (d->proxy)
-        return ShareUtils::makeShareUrl(d->proxy->next().path());
+        return QUrl::fromLocalFile(d->proxy->next().path());
 
     if (d->shares.isEmpty())
         return {};
@@ -61,9 +61,9 @@ QString ShareIterator::fileName() const
 QUrl ShareIterator::fileUrl() const
 {
     if (d->proxy)
-        return ShareUtils::makeShareUrl(d->proxy->fileUrl().path());
+        return d->proxy->fileUrl().path();
 
-    return ShareUtils::makeShareUrl(d->currentInfo.value(ShareInfoKeys::kPath).toString());
+    return QUrl::fromLocalFile(d->currentInfo.value(ShareInfoKeys::kPath).toString());
 }
 
 const FileInfoPointer ShareIterator::fileInfo() const

--- a/src/plugins/filemanager/dfmplugin-myshares/myshares.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/myshares.cpp
@@ -15,7 +15,6 @@
 
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
 
-#include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
@@ -25,7 +24,6 @@
 #include <DMenu>
 
 DWIDGET_USE_NAMESPACE
-DFMGLOBAL_USE_NAMESPACE
 
 using ContextMenuCallback = std::function<void(quint64 windowId, const QUrl &url, const QPoint &globalPos)>;
 Q_DECLARE_METATYPE(QList<QUrl> *)
@@ -212,11 +210,6 @@ void MyShares::doInitialize()
 
     dpfSignalDispatcher->subscribe("dfmplugin_dirshare", "signal_Share_ShareAdded", this, &MyShares::onShareAdded);
     dpfSignalDispatcher->subscribe("dfmplugin_dirshare", "signal_Share_ShareRemoved", this, &MyShares::onShareRemoved);
-
-    QVariantMap property;
-    property[ViewCustomKeys::kSupportTreeMode] = false;
-    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetCustomViewProperty", ShareUtils::scheme(), property);
-    dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", ShareUtils::scheme(), property);
 
     followEvents();
     bindWindows();

--- a/src/plugins/filemanager/dfmplugin-myshares/private/shareiterator_p.h
+++ b/src/plugins/filemanager/dfmplugin-myshares/private/shareiterator_p.h
@@ -7,12 +7,6 @@
 
 #include "dfmplugin_myshares_global.h"
 
-#include <QUrl>
-
-namespace dfmbase {
-class LocalDirIterator;
-}
-
 namespace dfmplugin_myshares {
 
 class ShareIterator;
@@ -21,17 +15,13 @@ class ShareIteratorPrivate
     friend class ShareIterator;
 
 public:
-    explicit ShareIteratorPrivate(ShareIterator *qq, const QUrl &url);
+    explicit ShareIteratorPrivate(ShareIterator *qq);
     ~ShareIteratorPrivate();
 
 private:
-    dfmbase::LocalDirIterator *proxy { nullptr };
-
     ShareIterator *q { nullptr };
     ShareInfoList shares;
     ShareInfo currentInfo;
-
-    QUrl rootUrl;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-myshares/watcher/sharewatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/watcher/sharewatcher.cpp
@@ -24,7 +24,7 @@ ShareWatcher::~ShareWatcher()
 
 void ShareWatcher::shareAdded(const QString &path)
 {
-    auto &&url = ShareUtils::makeShareUrl(path);
+    const auto &url = QUrl::fromLocalFile(path);
     auto info = InfoFactory::create<FileInfo>(url);
     if (info)
         info->refresh();   // make sure that the cache can be updated if share's name updated.
@@ -33,7 +33,7 @@ void ShareWatcher::shareAdded(const QString &path)
 
 void ShareWatcher::shareRemoved(const QString &path)
 {
-    Q_EMIT fileDeleted(ShareUtils::makeShareUrl(path));
+    Q_EMIT fileDeleted(QUrl::fromLocalFile(path));
 }
 
 ShareWatcherPrivate::ShareWatcherPrivate(const QUrl &fileUrl, ShareWatcher *qq)


### PR DESCRIPTION
## Summary by Sourcery

Streamline the MyShares plugin by removing proxy-based directory iteration and manual URL conversions, unify URL handling to use local file URLs, and re-enable tree-mode support.

New Features:
- Enable tree-mode support in the MyShares view

Enhancements:
- Remove LocalDirIterator proxy from ShareIterator and simplify ShareIteratorPrivate constructor
- Update ShareEventsCaller to dispatch events with original QUrls instead of converted URLs
- Change fileUrl and ShareWatcher to use QUrl::fromLocalFile for path-based URLs
- Simplify ShareFileInfo display logic to handle file display names directly