### PR TITLE
fix: replace QReadWriteLock with QMutex in SyncFileInfo

### DIFF
--- a/src/dfm-base/file/local/private/syncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/syncfileinfo_p.h
@@ -39,8 +39,7 @@ public:
     QMap<DFileInfo::AttributeExtendID, QVariant> attributesExtend;   // 缓存的fileinfo 扩展信息
     QList<DFileInfo::AttributeExtendID> extendIDs;
     QMimeType mimeType;
-    QReadWriteLock lock;
-    QMutex mutex;
+    mutable QMutex lock;
     QReadWriteLock iconLock;
     QIcon fileIcon;
     QVariant isLocalDevice = true;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -95,7 +95,7 @@ void TraversalDirThreadManager::start()
     if (this->sortRole != dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault
         && dirIterator->oneByOne()) {
         fmDebug() << "Setting QueryAttributes for sorted one-by-one iteration";
-        dirIterator->setProperty("QueryAttributes", "standard::name,standard::type,standard::size,\
+        dirIterator->setProperty("QueryAttributes", "standard::name,standard::type,standard::is-file,standard::is-dir,\
                                   standard::size,standard::is-symlink,standard::symlink-target,access::*,time::*");
     }
 


### PR DESCRIPTION
1. Changed QReadWriteLock to mutable QMutex in SyncFileInfoPrivate for thread safety
2. Added QMutexLocker in all critical sections that access shared resources
3. Split icon operation into separate lock scope using QWriteLocker
4. Fixed potential null pointer issues in media info operations
5. Simplified attribute access by removing redundant checks and consolidating locks

The changes were necessary to:
- Prevent potential race conditions during file operations
- Ensure thread safety when accessing file attributes
- Resolve issues with file information syncing
- Improve code consistency by using single lock type (QMutex)
- Fix rare crashes caused by concurrent access to file properties

fix: 在 SyncFileInfo 中使用 QMutex 替换 QReadWriteLock

1. 在 SyncFileInfoPrivate 中将 QReadWriteLock 改为 mutable QMutex 以保证 线程安全
2. 在所有访问共享资源的关键部分添加 QMutexLocker
3. 使用 QWriteLocker 将图标操作分离到独立的锁作用域
4. 修复媒体信息操作中潜在的空指针问题
5. 通过移除冗余检查和统一锁类型来简化属性访问

这些变更是为了解决以下问题:
- 防止文件操作期间潜在的竞争条件
- 确保访问文件属性时的线程安全
- 解决文件信息同步问题
- 通过使用单一锁类型(QMutex)提高代码一致性
- 修复由并发访问文件属性引起的罕见崩溃

## Summary by Sourcery

Improve thread safety in SyncFileInfo by replacing QReadWriteLock with QMutex, enforcing QMutexLocker in all critical sections, isolating icon operations into their own lock scope, simplifying attribute and media-info access with consolidated locks and null checks, and extend directory traversal to include additional file attribute queries

Bug Fixes:
- Fix rare crashes and race conditions by adding proper mutex locking and null-pointer checks in media-info and custom-attribute access

Enhancements:
- Replace per-instance QReadWriteLock with a single mutable QMutex in SyncFileInfoPrivate and wrap all resource access in QMutexLocker
- Isolate file-icon resets in a dedicated QWriteLocker scope on iconLock
- Consolidate attribute and media-info retrieval logic to remove redundant checks and prevent null-pointer access
- Extend TraversalDirThreadManager to request 'standard::is-file' and 'standard::is-dir' attributes for sorted iteration