### PR TITLE
fix: [image-preview] The gif preview dialog to large.

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -31,8 +31,7 @@ ImageView::ImageView(const QString &fileName, const QByteArray &format, QWidget 
 
 void ImageView::setFile(const QString &fileName, const QByteArray &format)
 {
-    const QSize &dsize = DFMBASE_NAMESPACE::WindowUtils::cursorScreen()->geometry().size();
-    qreal device_pixel_ratio = this->devicePixelRatioF();
+    const QSize &dsize = DFMBASE_NAMESPACE::WindowUtils::cursorScreen()->size();
 
     if (format == QByteArrayLiteral("gif")) {
         if (movie) {
@@ -43,10 +42,11 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
         }
         setMovie(movie);
         movie->start();
-        sourceImageSize = QSize(qMin(static_cast<int>(dsize.width() * 0.7 * device_pixel_ratio), movie->frameRect().size().width()),
-                                qMin(static_cast<int>(dsize.height() * 0.7 * device_pixel_ratio), movie->frameRect().size().height()));
-        setFixedSize(sourceImageSize);
-        movie->setScaledSize(sourceImageSize);
+        sourceImageSize = movie->frameRect().size();
+        QSize showSize = QSize(qMin(static_cast<int>(dsize.width() * 0.7), sourceImageSize.width()),
+                               qMin(static_cast<int>(dsize.height() * 0.7), sourceImageSize.height()));
+        setFixedSize(showSize);
+        movie->setScaledSize(showSize);
         return;
     } else {
         setMovie(nullptr);
@@ -67,11 +67,9 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
         setPixmap(QPixmap());
         return;
     }
-
-    QPixmap pixmap = QPixmap::fromImageReader(&reader).scaled(QSize(qMin(static_cast<int>(dsize.width() * 0.7 * device_pixel_ratio), sourceImageSize.width()),
-                                                                    qMin(static_cast<int>(dsize.height() * 0.7 * device_pixel_ratio), sourceImageSize.height())),
-                                                              Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmap.setDevicePixelRatio(device_pixel_ratio);
+    QSize showSize = QSize(qMin(static_cast<int>(dsize.width() * 0.7), sourceImageSize.width()),
+                           qMin(static_cast<int>(dsize.height() * 0.7), sourceImageSize.height()));
+    QPixmap pixmap = QPixmap::fromImageReader(&reader).scaled(showSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     setPixmap(pixmap);
 }
 


### PR DESCRIPTION
-- Adjust the size of preview dialog.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-325521.html

## Summary by Sourcery

Fix oversized image preview dialogs by adjusting screen size retrieval and removing device pixel ratio scaling in size calculations.

Bug Fixes:
- Use cursorScreen()->size() instead of geometry() to retrieve screen dimensions
- Cap GIF and static image previews at 70% of screen size without device pixel ratio scaling to prevent overly large dialogs