### PR TITLE
fix: prevent JSON arguments being processed as paths

### DIFF
--- a/assets/scripts/dde-file-manager
+++ b/assets/scripts/dde-file-manager
@@ -93,7 +93,9 @@ build_dbus_args() {
         local processed_arg="$arg"
         
         # 如果不是选项，且不是URL，且看起来像本地路径，则规范化
-        if [[ ! "$arg" =~ ^- ]] && [[ -n "$arg" ]] && ! is_url "$arg"; then
+        # 排除JSON格式的字符串（以{开头或[开头的结构化数据）
+        if [[ ! "$arg" =~ ^- ]] && [[ -n "$arg" ]] && ! is_url "$arg" && \
+           [[ ! "$arg" =~ ^\{.*\}$ ]] && [[ ! "$arg" =~ ^\[.*\]$ ]]; then
             processed_arg=$(get_canonical_path "$arg")
         fi
         


### PR DESCRIPTION
1. Modified path processing logic to exclude JSON formatted strings
2. Added checks for arguments starting with { or [ indicating JSON content
3. This prevents JSON data from being incorrectly interpreted as file paths
4. Fix was necessary as JSON parameters were getting path-normalized leading to errors

Log:
Bug: https://pms.uniontech.com/bug-view-325529.html

## Summary by Sourcery

Bug Fixes:
- Exclude JSON-formatted strings (arguments beginning with '{' or '[') from path processing to avoid normalization errors