### PR TITLE
fix bugs

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -29,7 +29,7 @@ enum class ViewMode {
 };
 
 enum class DirectoryLoadStrategy : uint8_t {
-    kCreateNew, // 默认策略：每次切换目录时立即清空视图
+    kCreateNew,   // 默认策略：每次切换目录时立即清空视图
     kPreserve   // 保留策略：保留现有视图内容，直到新目录数据加载完成后再更新视图
 };
 
@@ -40,7 +40,8 @@ inline constexpr char kSupportTreeMode[] { "Custom_Key_SupportTreeMode" };
 inline constexpr char kDefaultViewMode[] { "Custom_Key_DefaultViewMode" };
 inline constexpr char kDefaultListHeight[] { "Custom_Key_DefaultListHeight" };
 inline constexpr char kAllowChangeListHeight[] { "Custom_Key_AllowChangeListHeight" };
-} // namespace ViewCustomKeys
+inline constexpr char kViewModeUrlCallback[] { "Custom_Key_ViewModeUrlCallback" };
+}   // namespace ViewCustomKeys
 
 enum class TransparentStatus : uint8_t {
     kDefault,
@@ -210,7 +211,7 @@ inline constexpr char kDfmDBName[] { "dfmruntime.db" };
 namespace DataPersistence {
 // groups
 inline constexpr char kReportGroup[] { "Report" };
-//keys
+// keys
 inline constexpr char kDesktopStartUpReportKey[] { "DesktopStartUp" };
 inline constexpr char kDesktopLaunchTime[] { "DesktopLaunchTime" };
 inline constexpr char kDesktopDrawWallpaperTime[] { "DrawWallPaperTime" };

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -103,6 +103,28 @@ QUrl SearchHelper::setSearchWinId(const QUrl &searchUrl, const QString &winId)
     return url;
 }
 
+QUrl SearchHelper::viewModelUrl(const QUrl &url)
+{
+    if (url.scheme() != scheme() || !url.hasQuery())
+        return url;
+
+    // 解析原始查询参数
+    QUrlQuery urlQuery(url.query());
+    QString urlValue = urlQuery.queryItemValue("url");
+
+    // 创建新的URL对象
+    QUrl newUrl(url);
+
+    if (!urlValue.isEmpty()) {
+        // 只保留url参数
+        QUrlQuery newQuery;
+        newQuery.addQueryItem("url", urlValue);
+        newUrl.setQuery(newQuery);
+    }
+
+    return newUrl;
+}
+
 QUrl SearchHelper::fromSearchFile(const QString &filePath)
 {
     QUrl url;

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.h
@@ -37,6 +37,7 @@ public:
     static QUrl setSearchKeyword(const QUrl &searchUrl, const QString &keyword);
     static QUrl setSearchTargetUrl(const QUrl &searchUrl, const QUrl &targetUrl);
     static QUrl setSearchWinId(const QUrl &searchUrl, const QString &winId);
+    static QUrl viewModelUrl(const QUrl &url);
 
     static QUrl fromSearchFile(const QString &filePath);
     static QUrl fromSearchFile(const QUrl &targetUrl, const QString &keyword, const QString &winId);

--- a/src/plugins/filemanager/dfmplugin-titlebar/dfmplugin_titlebar_global.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dfmplugin_titlebar_global.h
@@ -72,6 +72,7 @@ enum DPCErrorCode {
 };
 
 using SeprateUrlCallback = std::function<QList<QVariantMap>(const QUrl &)>;
+using ViewModeUrlCallback = std::function<QUrl(const QUrl)>;
 
 // item of CrumbBar
 struct CrumbData
@@ -152,5 +153,6 @@ DPTITLEBAR_END_NAMESPACE
 Q_DECLARE_METATYPE(QList<QVariantMap> *);
 Q_DECLARE_METATYPE(QUrl *);
 Q_DECLARE_METATYPE(QString *);
+Q_DECLARE_METATYPE(DPTITLEBAR_NAMESPACE::ViewModeUrlCallback);
 
 #endif   // DFMPLUGIN_TITLEBAR_GLOBAL_H

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.cpp
@@ -14,6 +14,8 @@
 
 #include <dfm-base/utils/universalutils.h>
 
+#include <dfm-framework/event/eventhelper.h>
+
 using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
 DFMGLOBAL_USE_NAMESPACE
@@ -34,14 +36,15 @@ bool TitleBarEventReceiver::handleCustomRegister(const QString &scheme, const QV
 
     bool keepAddressBar { properties.value(CustomKey::kKeepAddressBar).toBool() };
     bool hideDetailSpaceBtn { properties.value(CustomKey::kHideDetailSpaceBtn).toBool() };
-    bool hideListViewBtn = properties.contains(ViewCustomKeys::kSupportListMode) &&
-                            !properties.value(ViewCustomKeys::kSupportListMode).toBool();
-    bool hideIconViewBtn = properties.contains(ViewCustomKeys::kSupportIconMode) &&
-                            !properties.value(ViewCustomKeys::kSupportIconMode).toBool();
-    bool hideTreeViewBtn = properties.contains(ViewCustomKeys::kSupportTreeMode) &&
-                            !properties.value(ViewCustomKeys::kSupportTreeMode).toBool();
-    bool hideListHeightOpt = properties.contains(ViewCustomKeys::kAllowChangeListHeight) &&
-                            !properties.value(ViewCustomKeys::kAllowChangeListHeight).toBool();
+    bool hideListViewBtn = properties.contains(ViewCustomKeys::kSupportListMode)
+            && !properties.value(ViewCustomKeys::kSupportListMode).toBool();
+    bool hideIconViewBtn = properties.contains(ViewCustomKeys::kSupportIconMode)
+            && !properties.value(ViewCustomKeys::kSupportIconMode).toBool();
+    bool hideTreeViewBtn = properties.contains(ViewCustomKeys::kSupportTreeMode)
+            && !properties.value(ViewCustomKeys::kSupportTreeMode).toBool();
+    bool hideListHeightOpt = properties.contains(ViewCustomKeys::kAllowChangeListHeight)
+            && !properties.value(ViewCustomKeys::kAllowChangeListHeight).toBool();
+    ViewModeUrlCallback modelViewUrlCallback = DPF_NAMESPACE::paramGenerator<ViewModeUrlCallback>(properties.value(ViewCustomKeys::kViewModeUrlCallback));
 
     int state { OptionButtonManager::kDoNotHide };
     if (hideListViewBtn)
@@ -65,6 +68,9 @@ bool TitleBarEventReceiver::handleCustomRegister(const QString &scheme, const QV
 
     if (keepAddressBar)
         TitleBarHelper::registerKeepTitleStatusScheme(scheme);
+
+    if (modelViewUrlCallback)
+        TitleBarHelper::registerViewModelUrlCallback(scheme, modelViewUrlCallback);
 
     return true;
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
@@ -39,6 +39,14 @@ public:
     static void registerKeepTitleStatusScheme(const QString &scheme);
     static bool checkKeepTitleStatus(const QUrl &url);
 
+    static void registerViewModelUrlCallback(const QString &scheme, ViewModeUrlCallback callback);
+    static ViewModeUrlCallback viewModelUrlCallback(const QUrl &url);
+
+    // FileViewState unified access methods
+    static QVariant getFileViewStateValue(const QUrl &url, const QString &key, const QVariant &defaultValue = QVariant());
+    static void setFileViewStateValue(const QUrl &url, const QString &key, const QVariant &value);
+    static QUrl transformViewModeUrl(const QUrl &url);
+
 public:
     static bool newWindowAndTabEnabled;
     static bool searchEnabled;
@@ -49,6 +57,7 @@ private:
     static QString getDisplayName(const QString &name);
     static QMap<quint64, TitleBarWidget *> kTitleBarMap;
     static QList<QString> kKeepTitleStatusSchemeList;
+    static QMap<QString, ViewModeUrlCallback> kViewModeUrlCallbackMap;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -6,6 +6,7 @@
 #include "views/optionbuttonbox.h"
 #include "events/titlebareventcaller.h"
 #include "utils/optionbuttonmanager.h"
+#include "utils/titlebarhelper.h"
 #include "views/sortbybutton.h"
 #include "views/viewoptionsbutton.h"
 
@@ -77,9 +78,8 @@ void OptionButtonBoxPrivate::setViewMode(ViewMode mode)
 
 void OptionButtonBoxPrivate::loadViewMode(const QUrl &url)
 {
-    QUrl tmpUrl = url.adjusted(QUrl::RemoveQuery);
-    auto defaultViewMode = static_cast<int>(TitleBarEventCaller::sendGetDefualtViewMode(tmpUrl.scheme()));
-    auto viewMode = static_cast<ViewMode>(Application::appObtuselySetting()->value("FileViewState", tmpUrl).toMap().value("viewMode", defaultViewMode).toInt());
+    auto defaultViewMode = static_cast<int>(TitleBarEventCaller::sendGetDefualtViewMode(url.scheme()));
+    auto viewMode = static_cast<ViewMode>(TitleBarHelper::getFileViewStateValue(url, "viewMode", defaultViewMode).toInt());
     if (viewMode == ViewMode::kTreeMode && !DConfigManager::instance()->value(kViewDConfName, kTreeViewEnable, true).toBool()) {
         fmInfo() << "Tree view is disabled in config, switching to list mode";
         viewMode = ViewMode::kListMode;
@@ -114,7 +114,7 @@ void OptionButtonBoxPrivate::switchMode(ViewMode mode)
 
 void OptionButtonBoxPrivate::onViewModeChanged(int mode)
 {
-    if (Application::appObtuselySetting()->value("FileViewState", currentUrl).toMap().contains("viewMode")) {
+    if (!TitleBarHelper::getFileViewStateValue(currentUrl, "viewMode").isNull()) {
         loadViewMode(currentUrl);
     } else {
         auto viewMode = static_cast<ViewMode>(mode);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -5,6 +5,7 @@
 #include "views/private/viewoptionswidget_p.h"
 #include "views/viewoptionswidget.h"
 #include "utils/optionbuttonmanager.h"
+#include "utils/titlebarhelper.h"
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/application/application.h>
@@ -180,9 +181,7 @@ void ViewOptionsWidgetPrivate::initConnect()
 
     connect(iconSizeSlider, &DSlider::valueChanged, this, [this](int value) {
         fmDebug() << "iconSizeSlider value changed: " << value;
-        QVariantMap map = Application::appObtuselySetting()->value("FileViewState", fileUrl).toMap();
-        map["iconSizeLevel"] = value;
-        Application::appObtuselySetting()->setValue("FileViewState", fileUrl, map);
+        TitleBarHelper::setFileViewStateValue(fileUrl, "iconSizeLevel", value);
         Application::appObtuselySetting()->sync();
         fmDebug() << "Icon size level saved to settings for URL:" << fileUrl.toString();
     });
@@ -199,9 +198,7 @@ void ViewOptionsWidgetPrivate::initConnect()
     });
     connect(gridDensitySlider, &DSlider::valueChanged, this, [this](int value) {
         fmDebug() << "gridDensitySlider value changed: " << value;
-        QVariantMap map = Application::appObtuselySetting()->value("FileViewState", fileUrl).toMap();
-        map["gridDensityLevel"] = value;
-        Application::appObtuselySetting()->setValue("FileViewState", fileUrl, map);
+        TitleBarHelper::setFileViewStateValue(fileUrl, "gridDensityLevel", value);
         Application::appObtuselySetting()->sync();
         fmDebug() << "Grid density level saved to settings for URL:" << fileUrl.toString();
     });
@@ -218,9 +215,7 @@ void ViewOptionsWidgetPrivate::initConnect()
     });
     connect(listHeightSlider, &DSlider::valueChanged, this, [this](int value) {
         fmDebug() << "listHeightSlider value changed: " << value;
-        QVariantMap map = Application::appObtuselySetting()->value("FileViewState", fileUrl).toMap();
-        map["listHeightLevel"] = value;
-        Application::appObtuselySetting()->setValue("FileViewState", fileUrl, map);
+        TitleBarHelper::setFileViewStateValue(fileUrl, "listHeightLevel", value);
         Application::appObtuselySetting()->sync();
         fmDebug() << "List height level saved to settings for URL:" << fileUrl.toString();
     });
@@ -245,24 +240,27 @@ void ViewOptionsWidgetPrivate::setUrl(const QUrl &url)
 {
     fmDebug() << "Setting URL for view options:" << url.toString();
     fileUrl = url;
-    QVariantMap map = Application::appObtuselySetting()->value("FileViewState", fileUrl).toMap();
+    
     QVariant defaultIconSize = Application::instance()->appAttribute(Application::kIconSizeLevel).toInt();
+    QVariant iconSizeValue = TitleBarHelper::getFileViewStateValue(fileUrl, "iconSizeLevel", defaultIconSize);
     iconSizeSlider->blockSignals(true);
-    iconSizeSlider->setValue(map.value("iconSizeLevel", defaultIconSize).toInt());
+    iconSizeSlider->setValue(iconSizeValue.toInt());
     iconSizeSlider->blockSignals(false);
-    fmDebug() << "iconSizeLevel: " << map.value("iconSizeLevel", defaultIconSize).toInt();
+    fmDebug() << "iconSizeLevel: " << iconSizeValue.toInt();
 
     QVariant defaultGridDensity = Application::instance()->appAttribute(Application::kGridDensityLevel).toInt();
+    QVariant gridDensityValue = TitleBarHelper::getFileViewStateValue(fileUrl, "gridDensityLevel", defaultGridDensity);
     gridDensitySlider->blockSignals(true);
-    gridDensitySlider->setValue(map.value("gridDensityLevel", defaultGridDensity).toInt());
+    gridDensitySlider->setValue(gridDensityValue.toInt());
     gridDensitySlider->blockSignals(false);
-    fmDebug() << "gridDensityLevel: " << map.value("gridDensityLevel", defaultGridDensity).toInt();
+    fmDebug() << "gridDensityLevel: " << gridDensityValue.toInt();
 
     QVariant defaultListHeight = Application::instance()->appAttribute(Application::kListHeightLevel).toInt();
+    QVariant listHeightValue = TitleBarHelper::getFileViewStateValue(fileUrl, "listHeightLevel", defaultListHeight);
     listHeightSlider->blockSignals(true);
-    listHeightSlider->setValue(map.value("listHeightLevel", defaultListHeight).toInt());
+    listHeightSlider->setValue(listHeightValue.toInt());
     listHeightSlider->blockSignals(false);
-    fmDebug() << "listHeightLevel: " << map.value("listHeightLevel", defaultListHeight).toInt();
+    fmDebug() << "listHeightLevel: " << listHeightValue.toInt();
 }
 
 void ViewOptionsWidgetPrivate::switchMode(ViewMode mode)

--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -95,12 +95,13 @@ using CreateTopWidgetCallback = std::function<QWidget *()>;
 using ShowTopWidgetCallback = std::function<bool(QWidget *, const QUrl &)>;
 using FileViewFilterCallback = std::function<bool(dfmbase::SortFileInfo *, QVariant)>;
 using FileViewRoutePrehaldler = std::function<void(quint64 winId, const QUrl &, std::function<void()>)>;
+using ViewModeUrlCallback = std::function<QUrl(const QUrl)>;
 
 struct CustomTopWidgetInfo
 {
     QString scheme;
     bool keepShow { false };   // always show
-    bool keepTop { false };    // top of all topWidget
+    bool keepTop { false };   // top of all topWidget
     CreateTopWidgetCallback createTopWidgetCb { nullptr };
     ShowTopWidgetCallback showTopWidgetCb { nullptr };
 
@@ -123,9 +124,12 @@ struct CustomViewProperty
     dfmbase::Global::ViewMode defaultViewMode { dfmbase::Global::ViewMode::kNoneMode };
     int defaultListHeight { -1 };
     bool allowChangeListHeight { true };
+    ViewModeUrlCallback viewModelUrlCallback { nullptr };
 
     CustomViewProperty() = default;
-    inline CustomViewProperty(const QVariantMap &map) {
+    inline CustomViewProperty(const QVariantMap &map)
+        : viewModelUrlCallback(DPF_NAMESPACE::paramGenerator<ViewModeUrlCallback>(map[DFMGLOBAL_NAMESPACE::ViewCustomKeys::kViewModeUrlCallback]))
+    {
         supportIconMode = map.contains(DFMGLOBAL_NAMESPACE::ViewCustomKeys::kSupportIconMode) ? map[DFMGLOBAL_NAMESPACE::ViewCustomKeys::kSupportIconMode].toBool() : true;
         supportListMode = map.contains(DFMGLOBAL_NAMESPACE::ViewCustomKeys::kSupportListMode) ? map[DFMGLOBAL_NAMESPACE::ViewCustomKeys::kSupportListMode].toBool() : true;
         supportTreeMode = map.contains(DFMGLOBAL_NAMESPACE::ViewCustomKeys::kSupportTreeMode) ? map[DFMGLOBAL_NAMESPACE::ViewCustomKeys::kSupportTreeMode].toBool() : true;
@@ -156,6 +160,7 @@ Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::CreateTopWidgetCallback);
 Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::ShowTopWidgetCallback);
 Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::FileViewFilterCallback);
 Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::FileViewRoutePrehaldler);
+Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::ViewModeUrlCallback);
 Q_DECLARE_METATYPE(QString *)
 Q_DECLARE_METATYPE(QVariant *)
 Q_DECLARE_METATYPE(QDir::Filters)

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -82,6 +82,7 @@ public slots:
 
     void handleRegisterLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);
     void handleRegisterFocusFileViewDisabled(const QString &scheme);
+
 private:
     explicit WorkspaceEventReceiver(QObject *parent = nullptr);
 };

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -660,9 +660,9 @@ QList<ItemRoles> FileViewModel::getColumnRoles() const
     QList<ItemRoles> roles;
     bool customOnly = WorkspaceEventSequence::instance()->doFetchCustomColumnRoles(dirRootUrl, &roles);
 
-    const QVariantMap &map = DFMBASE_NAMESPACE::Application::appObtuselySetting()->value("FileViewState", dirRootUrl).toMap();
-    if (map.contains("headerList")) {
-        QVariantList headerList = map.value("headerList").toList();
+    QVariant headerListValue = WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "headerList");
+    if (!headerListValue.isNull()) {
+        QVariantList headerList = headerListValue.toList();
 
         for (ItemRoles role : roles) {
             if (!headerList.contains(role))
@@ -701,9 +701,9 @@ ItemRoles FileViewModel::columnToRole(int column) const
     QList<ItemRoles> roles;
     bool customOnly = WorkspaceEventSequence::instance()->doFetchCustomColumnRoles(dirRootUrl, &roles);
 
-    const QVariantMap &map = DFMBASE_NAMESPACE::Application::appObtuselySetting()->value("FileViewState", dirRootUrl).toMap();
-    if (map.contains("headerList")) {
-        QVariantList headerList = map.value("headerList").toList();
+    QVariant headerListValue = WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "headerList");
+    if (!headerListValue.isNull()) {
+        QVariantList headerList = headerListValue.toList();
         if (headerList.length() > column)
             return ItemRoles(headerList.at(column).toInt());
 
@@ -1125,9 +1125,8 @@ void FileViewModel::initFilterSortWork()
     }
 
     // get sort config
-    QMap<QString, QVariant> valueMap = Application::appObtuselySetting()->value("FileViewState", dirRootUrl).toMap();
-    Qt::SortOrder order = static_cast<Qt::SortOrder>(valueMap.value("sortOrder", Qt::SortOrder::AscendingOrder).toInt());
-    ItemRoles role = static_cast<ItemRoles>(valueMap.value("sortRole", kItemFileDisplayNameRole).toInt());
+    Qt::SortOrder order = static_cast<Qt::SortOrder>(WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "sortOrder", Qt::SortOrder::AscendingOrder).toInt());
+    ItemRoles role = static_cast<ItemRoles>(WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "sortRole", kItemFileDisplayNameRole).toInt());
 
     fmDebug() << "Sort configuration - order:" << (order == Qt::AscendingOrder ? "Ascending" : "Descending") << "role:" << role << "for URL:" << dirRootUrl.toString();
 

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
 #include <dfm-base/utils/universalutils.h>
 
 #include <dfm-framework/dpf.h>
@@ -553,4 +554,25 @@ FileView *WorkspaceHelper::findFileViewByWindowID(const quint64 windowID)
     }
     fmDebug() << "No workspace widget found for window ID:" << windowID;
     return {};
+}
+
+QUrl WorkspaceHelper::transformViewModeUrl(const QUrl &url) const
+{
+    auto callback = findCustomViewProperty(url.scheme()).viewModelUrlCallback;
+    return callback ? callback(url) : url;
+}
+
+QVariant WorkspaceHelper::getFileViewStateValue(const QUrl &url, const QString &key, const QVariant &defaultValue) const
+{
+    QUrl viewModeUrl = transformViewModeUrl(url);
+    QMap<QString, QVariant> valueMap = Application::appObtuselySetting()->value("FileViewState", viewModeUrl).toMap();
+    return valueMap.value(key, defaultValue);
+}
+
+void WorkspaceHelper::setFileViewStateValue(const QUrl &url, const QString &key, const QVariant &value)
+{
+    QUrl viewModeUrl = transformViewModeUrl(url);
+    QVariantMap map = Application::appObtuselySetting()->value("FileViewState", viewModeUrl).toMap();
+    map[key] = value;
+    Application::appObtuselySetting()->setValue("FileViewState", viewModeUrl, map);
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.h
@@ -103,6 +103,11 @@ public:
     void registerFocusFileViewDisabled(const QString &scheme);
     bool isFocusFileViewDisabled(const QString &scheme) const;
 
+    // FileViewState unified access methods
+    QVariant getFileViewStateValue(const QUrl &url, const QString &key, const QVariant &defaultValue = QVariant()) const;
+    void setFileViewStateValue(const QUrl &url, const QString &key, const QVariant &value);
+    QUrl transformViewModeUrl(const QUrl &url) const;
+
     void registerLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);
     DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy getLoadStrategy(const QString &scheme);
     static QMap<quint64, QPair<QUrl, QUrl>> kSelectionAndRenameFile;   // ###: for creating new file.

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2544,11 +2544,7 @@ void FileView::openIndex(const QModelIndex &index)
 
 void FileView::setFileViewStateValue(const QUrl &url, const QString &key, const QVariant &value)
 {
-    QVariantMap map = Application::appObtuselySetting()->value("FileViewState", url).toMap();
-
-    map[key] = value;
-
-    Application::appObtuselySetting()->setValue("FileViewState", url, map);
+    WorkspaceHelper::instance()->setFileViewStateValue(url, key, value);
 }
 
 void FileView::saveViewModeState()

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -206,7 +206,7 @@ void FileViewPrivate::initContentLabel()
         palette.setColor(QPalette::Text, color);
         contentLabel->setPalette(palette);
         QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
-                         contentLabel, [this](DGuiApplicationHelper::ColorType themeType){
+                         contentLabel, [this](DGuiApplicationHelper::ColorType themeType) {
                              QColor textColor = (themeType == DGuiApplicationHelper::ColorType::LightType)
                                      ? QColor(0, 0, 0, 102)
                                      : QColor(255, 255, 255, 102);
@@ -268,7 +268,7 @@ void FileViewPrivate::loadViewMode(const QUrl &url)
 
     if (parentViewMode != -1) {
         currentViewMode = static_cast<Global::ViewMode>(parentViewMode);
-    } else if (savedViewMode != -1 && WorkspaceHelper::instance()->isViewModeSupported(url.scheme(), static_cast<Global::ViewMode>(savedViewMode))) {  // saved view mode in old version may not be supported
+    } else if (savedViewMode != -1 && WorkspaceHelper::instance()->isViewModeSupported(url.scheme(), static_cast<Global::ViewMode>(savedViewMode))) {   // saved view mode in old version may not be supported
         currentViewMode = static_cast<Global::ViewMode>(savedViewMode);
         fmDebug() << "Using saved view mode:" << savedViewMode;
     } else {
@@ -289,8 +289,7 @@ void FileViewPrivate::loadViewMode(const QUrl &url)
 
 QVariant FileViewPrivate::fileViewStateValue(const QUrl &url, const QString &key, const QVariant &defalutValue)
 {
-    QMap<QString, QVariant> valueMap = Application::appObtuselySetting()->value("FileViewState", url).toMap();
-    return valueMap.value(key, defalutValue);
+    return WorkspaceHelper::instance()->getFileViewStateValue(url, key, defalutValue);
 }
 
 void FileViewPrivate::updateHorizontalOffset()

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -114,6 +114,9 @@ public:
     // Resource limits
     double maxUsagePercentage { 0.5 };   // Default to 50% of available watches
     int maxWatches { -1 };   // Will be determined at runtime
+    
+    // Resource limit tracking
+    bool resourceLimitReached { false };   // Flag to track if watch limit has been reached
 };
 
 SERVICETEXTINDEX_END_NAMESPACE


### PR DESCRIPTION
## Summary by Sourcery

Unify file view state storage and custom view mode URL transformation across plugins, and improve FSMonitor's handling of resource limits

New Features:
- Introduce ViewModeUrlCallback with registration and URL transformation support for custom view mode handling
- Add centralized FileViewState persistence API via getFileViewStateValue and setFileViewStateValue in TitleBarHelper and WorkspaceHelper

Bug Fixes:
- Ensure FSMonitor emits resourceLimitReached signal only once when watch limit is first reached

Enhancements:
- Refactor multiple plugin components (TitleBar, Workspace, Search, ViewOptionsWidget, OptionButtonBox, FileViewModel, FileView) to use unified FileViewState helpers and view mode URL callbacks
- Enhance FSMonitor to track resourceLimitReached flag, reset it on start, and skip processing once watch limits are reached

Chores:
- Adjust whitespace and comments in global definitions for consistency