### PR TITLE
perf: optimize search index directory checks

### DIFF
--- a/autotests/plugins/dfmplugin-search/main.cpp
+++ b/autotests/plugins/dfmplugin-search/main.cpp
@@ -9,5 +9,3 @@
 #include "dfm_test_main.h"
 
 DFM_TEST_MAIN(dfmplugin_search)
-
-

--- a/autotests/services/textindex/test_indexutility.cpp
+++ b/autotests/services/textindex/test_indexutility.cpp
@@ -119,7 +119,7 @@ private:
 
 TEST_F(UT_IndexUtility, IsIndexWithAnything_FileNameIndexReady_ReturnsTrue)
 {
-    bool result = IndexUtility::isIndexWithAnything("/home/test/document.txt");
+    bool result = IndexUtility::isIndexWithAnything("/home/test");
 
     EXPECT_TRUE(result);
 }

--- a/autotests/services/textindex/test_systemdcpuutils.cpp
+++ b/autotests/services/textindex/test_systemdcpuutils.cpp
@@ -60,6 +60,10 @@ protected:
             if (mockProcessTimedOut) {
                 return false;
             }
+            // If process crashed, waitForFinished still returns true (process finished, but crashed)
+            if (mockProcessCrashed) {
+                return true;
+            }
             return mockProcessSuccess;
         });
 

--- a/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
@@ -24,6 +24,8 @@ set(QRC_FILE
     resources/images.qrc
 )
 
+find_package(Dtk6 COMPONENTS Gui REQUIRED)
+
 qt_add_resources(QRC_RESOURCES ${QRC_FILE})
 
 add_library(${BIN_NAME}
@@ -36,8 +38,11 @@ add_library(${BIN_NAME}
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DESKTOP_DIR})
 
-# Use default plugin configuration
-dfm_apply_default_plugin_config(${BIN_NAME})
+target_link_libraries(${BIN_NAME} PRIVATE
+    DFM6::base
+    DFM6::framework
+    Dtk6::Gui
+)
 
 install(TARGETS ${BIN_NAME}
     LIBRARY DESTINATION ${DFM_PLUGIN_DESKTOP_CORE_DIR}

--- a/src/services/textindex/utils/indextraverseutils.cpp
+++ b/src/services/textindex/utils/indextraverseutils.cpp
@@ -151,6 +151,9 @@ QMap<QString, QString> fstabBindInfo()
             }
             endfsent();
         }
+    } else {
+        // Clear table when fstab file doesn't exist or can't be accessed
+        table.clear();
     }
 
     return table;


### PR DESCRIPTION
Modified two frequently called directory checking functions to use static variables for caching:
1. isDefaultIndexedDirectory() now stores default directories in a static const variable to avoid repeated queries
2. isPathInContentIndexDirectory() was refactored to check content index availability first and also cache the directory list These changes avoid repeated expensive calls to DFMSEARCH::Global methods and improve performance

perf: 优化搜索索引目录检查

修改了两个高频调用的目录检查函数以使用静态变量进行缓存：
1. isDefaultIndexedDirectory() 现在将默认目录存储在静态常量变量中以避免 重复查询
2. isPathInContentIndexDirectory() 重构为先检查内容索引可用性并缓存目录 列表
这些更改避免了重复调用 DFMSEARCH::Global 方法的开销并提升了性能

## Summary by Sourcery

Cache directory lists in static variables and optimize content index checks to reduce expensive global method calls

Enhancements:
- Cache default indexed directories in isDefaultIndexedDirectory to avoid repeated global queries
- Refactor isPathInContentIndexDirectory to early-return if content index is unavailable and use cached directory prefixes for matching