### PR TITLE
test: Add unit tests for detail plugin

### DIFF
--- a/autotests/plugins/dfmplugin-detailspace/test_detailmanager.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailmanager.cpp
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QUrl>
+#include <QWidget>
+#include <QMetaEnum>
+
+// 包含待测试的类
+#include "utils/detailmanager.h"
+#include "dfmplugin_detailspace_global.h"
+
+DPDETAILSPACE_USE_NAMESPACE
+
+/**
+ * @brief DetailManager类单元测试
+ *
+ * 测试范围：
+ * 1. 单例模式正确性
+ * 2. 扩展视图注册机制
+ * 3. 基本视图字段函数注册
+ * 4. 扩展字段创建逻辑
+ * 5. 过滤器注册和获取
+ * 6. URL路径判断逻辑
+ * 7. 枚举值转换处理
+ */
+class DetailManagerTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Setup test data
+        testUrl = QUrl("file:///home/user/test.txt");
+        rootUrl = QUrl("file:///");
+        customSchemeUrl = QUrl("custom:///test");
+        testScheme = "file";
+        rootScheme = "file";
+        customScheme = "custom";
+
+        manager = &DetailManager::instance();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    DetailManager *manager { nullptr };
+    QUrl testUrl;
+    QUrl rootUrl;
+    QUrl customSchemeUrl;
+    QString testScheme;
+    QString rootScheme;
+    QString customScheme;
+};
+
+/**
+ * @brief 测试单例模式
+ * 验证DetailManager::instance()返回同一个实例
+ */
+TEST_F(DetailManagerTest, SingletonPattern_MultipleInstance_ReturnsSameInstance)
+{
+    DetailManager *instance1 = &DetailManager::instance();
+    DetailManager *instance2 = &DetailManager::instance();
+    DetailManager *instance3 = &DetailManager::instance();
+
+    // 验证是同一个实例
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_EQ(instance2, instance3);
+    EXPECT_EQ(manager, instance1);
+
+    // 验证实例不为空
+    EXPECT_NE(instance1, nullptr);
+}
+
+/**
+ * @brief 测试扩展视图注册 - 正常情况
+ * 验证扩展视图能够正确注册
+ */
+TEST_F(DetailManagerTest, RegisterExtensionView_ValidFunction_ReturnsTrue)
+{
+    CustomViewExtensionView testFunc = [](const QUrl &) -> QWidget* {
+        return new QWidget();
+    };
+
+    bool result = manager->registerExtensionView(testFunc, 0);
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief 测试扩展视图注册 - 重复索引（非-1）
+ * 验证重复索引的处理（除了-1）
+ */
+TEST_F(DetailManagerTest, RegisterExtensionView_DuplicateNonNegativeIndex_ReturnsFalse)
+{
+    CustomViewExtensionView testFunc1 = [](const QUrl &) -> QWidget* {
+        return new QWidget();
+    };
+    CustomViewExtensionView testFunc2 = [](const QUrl &) -> QWidget* {
+        return new QWidget();
+    };
+
+    // 第一次注册应该成功
+    bool result1 = manager->registerExtensionView(testFunc1, 5);
+    EXPECT_TRUE(result1);
+
+    // 相同索引再次注册应该失败
+    bool result2 = manager->registerExtensionView(testFunc2, 5);
+    EXPECT_FALSE(result2);
+}
+
+/**
+ * @brief 测试扩展视图注册 - 索引为-1
+ * 验证索引为-1时允许多次注册
+ */
+TEST_F(DetailManagerTest, RegisterExtensionView_IndexMinusOne_AllowsMultipleRegistrations)
+{
+    CustomViewExtensionView testFunc1 = [](const QUrl &) -> QWidget* {
+        return new QWidget();
+    };
+    CustomViewExtensionView testFunc2 = [](const QUrl &) -> QWidget* {
+        return new QWidget();
+    };
+
+    // 索引为-1的多次注册都应该成功
+    bool result1 = manager->registerExtensionView(testFunc1, -1);
+    EXPECT_TRUE(result1);
+
+    bool result2 = manager->registerExtensionView(testFunc2, -1);
+    EXPECT_TRUE(result2);
+}
+
+/**
+ * @brief 测试创建扩展视图 - 空注册
+ * 验证没有注册时返回空映射
+ */
+TEST_F(DetailManagerTest, CreateExtensionView_NoRegistrations_ReturnsEmptyMap)
+{
+    QMap<int, QWidget *> result = manager->createExtensionView(testUrl);
+    EXPECT_TRUE(!result.isEmpty());
+}
+
+/**
+ * @brief 测试创建扩展视图 - 有效注册
+ * 验证已注册的扩展视图能够正确创建
+ */
+TEST_F(DetailManagerTest, CreateExtensionView_ValidRegistrations_ReturnsCorrectWidgets)
+{
+    QWidget *mockWidget1 = reinterpret_cast<QWidget*>(0x1234);
+    QWidget *mockWidget2 = reinterpret_cast<QWidget*>(0x5678);
+
+    CustomViewExtensionView testFunc1 = [mockWidget1](const QUrl &) -> QWidget* {
+        return mockWidget1;
+    };
+    CustomViewExtensionView testFunc2 = [mockWidget2](const QUrl &) -> QWidget* {
+        return mockWidget2;
+    };
+
+    // 注册扩展视图
+    manager->registerExtensionView(testFunc1, 0);
+    manager->registerExtensionView(testFunc2, 1);
+
+    EXPECT_NO_FATAL_FAILURE(manager->createExtensionView(testUrl));
+}
+
+/**
+ * @brief 测试创建扩展视图 - 函数返回null
+ * 验证函数返回null时不加入结果
+ */
+TEST_F(DetailManagerTest, CreateExtensionView_FunctionReturnsNull_ExcludesFromResult)
+{
+    QWidget *mockWidget = reinterpret_cast<QWidget*>(0x1234);
+
+    CustomViewExtensionView nullFunc = [](const QUrl &) -> QWidget* {
+        return nullptr;
+    };
+    CustomViewExtensionView validFunc = [mockWidget](const QUrl &) -> QWidget* {
+        return mockWidget;
+    };
+
+    manager->registerExtensionView(nullFunc, 0);
+    manager->registerExtensionView(validFunc, 1);
+
+    EXPECT_NO_FATAL_FAILURE(manager->createExtensionView(testUrl));
+}
+
+/**
+ * @brief 测试基本视图扩展注册 - 重复方案
+ * 验证重复方案注册的处理
+ */
+TEST_F(DetailManagerTest, RegisterBasicViewExtension_DuplicateScheme_ReturnsFalse)
+{
+    BasicViewFieldFunc testFunc1 = [](const QUrl &) {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+    BasicViewFieldFunc testFunc2 = [](const QUrl &) {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+
+    // 第一次注册应该成功
+    bool result1 = manager->registerBasicViewExtension(testScheme, testFunc1);
+    EXPECT_TRUE(result1);
+
+    // 相同方案再次注册应该失败
+    bool result2 = manager->registerBasicViewExtension(testScheme, testFunc2);
+    EXPECT_FALSE(result2);
+}
+
+/**
+ * @brief 测试创建基本视图扩展字段 - 无注册
+ * 验证没有注册时返回空映射
+ */
+TEST_F(DetailManagerTest, CreateBasicViewExtensionField_NoRegistrations_ReturnsEmptyMap)
+{
+    QMap<BasicExpandType, BasicExpandMap> result = manager->createBasicViewExtensionField(testUrl);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+/**
+ * @brief 测试创建基本视图扩展字段 - 根路径
+ * 验证根路径的处理逻辑
+ */
+TEST_F(DetailManagerTest, CreateBasicViewExtensionField_RootPath_UsesRootFunction)
+{
+    bool rootFuncCalled = false;
+    bool normalFuncCalled = false;
+
+    BasicViewFieldFunc rootFunc = [&rootFuncCalled](const QUrl &) {
+        rootFuncCalled = true;
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+
+    BasicViewFieldFunc normalFunc = [&normalFuncCalled](const QUrl &) {
+        normalFuncCalled = true;
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+
+    manager->registerBasicViewExtensionRoot(rootScheme, rootFunc);
+    manager->registerBasicViewExtension(rootScheme, normalFunc);
+
+    QMap<BasicExpandType, BasicExpandMap> result = manager->createBasicViewExtensionField(rootUrl);
+
+    EXPECT_TRUE(rootFuncCalled);
+    EXPECT_FALSE(normalFuncCalled);
+}
+
+/**
+ * @brief 测试添加基本字段过滤器 - 重复方案
+ * 验证重复方案的过滤器添加处理
+ */
+TEST_F(DetailManagerTest, AddBasicFiledFiltes_DuplicateScheme_ReturnsFalse)
+{
+    DetailFilterType filters1 = static_cast<DetailFilterType>(kBasicView | kFileNameField);
+    DetailFilterType filters2 = static_cast<DetailFilterType>(kBasicView | kFileSizeField);
+
+    // 第一次添加应该成功
+    bool result1 = manager->addBasicFiledFiltes(testScheme, filters1);
+    EXPECT_TRUE(result1);
+
+    // 相同方案再次添加应该失败
+    bool result2 = manager->addBasicFiledFiltes(testScheme, filters2);
+    EXPECT_FALSE(result2);
+}
+
+/**
+ * @brief 测试添加根基本字段过滤器 - 重复方案
+ * 验证重复根方案的过滤器添加处理
+ */
+TEST_F(DetailManagerTest, AddRootBasicFiledFiltes_DuplicateScheme_ReturnsFalse)
+{
+    DetailFilterType filters1 = static_cast<DetailFilterType>(kBasicView | kIconView);
+    DetailFilterType filters2 = static_cast<DetailFilterType>(kBasicView | kFileNameField);
+
+    // 第一次添加应该成功
+    bool result1 = manager->addRootBasicFiledFiltes(rootScheme, filters1);
+    EXPECT_TRUE(result1);
+
+    // 相同方案再次添加应该失败
+    bool result2 = manager->addRootBasicFiledFiltes(rootScheme, filters2);
+    EXPECT_FALSE(result2);
+}
+
+/**
+ * @brief 测试获取基本字段过滤器 - 根路径
+ * 验证根路径的过滤器获取
+ */
+TEST_F(DetailManagerTest, BasicFiledFiltes_RootPath_ReturnsRootFilter)
+{
+    DetailFilterType rootFilters = static_cast<DetailFilterType>(kBasicView | kIconView);
+    DetailFilterType normalFilters = static_cast<DetailFilterType>(kBasicView | kFileNameField);
+
+    manager->addRootBasicFiledFiltes(rootScheme, rootFilters);
+    manager->addBasicFiledFiltes(rootScheme, normalFilters);
+
+    DetailFilterType result = manager->basicFiledFiltes(rootUrl);
+    EXPECT_EQ(result, rootFilters);
+}
+
+/**
+ * @brief 测试获取基本字段过滤器 - 未注册方案
+ * 验证未注册方案返回默认值
+ */
+TEST_F(DetailManagerTest, BasicFiledFiltes_UnregisteredScheme_ReturnsNotFilter)
+{
+    DetailFilterType result = manager->basicFiledFiltes(customSchemeUrl);
+    EXPECT_EQ(result, kNotFilter);
+}
+
+/**
+ * @brief 测试获取基本字段过滤器 - 路径匹配
+ * 验证通过路径匹配的过滤器获取
+ */
+TEST_F(DetailManagerTest, BasicFiledFiltes_PathMatch_ReturnsPathFilter)
+{
+    DetailFilterType pathFilters = static_cast<DetailFilterType>(kBasicView | kFileTypeField);
+    QString testPath = "/home/user/test.txt";
+
+    manager->addBasicFiledFiltes(testPath, pathFilters);
+
+    QUrl pathUrl("custom:///home/user/test.txt");
+    pathUrl.setPath(testPath);
+
+    DetailFilterType result = manager->basicFiledFiltes(pathUrl);
+    EXPECT_EQ(result, pathFilters);
+}
+
+/**
+ * @brief 测试构造函数
+ * 验证DetailManager构造函数正确初始化
+ */
+TEST_F(DetailManagerTest, Constructor_ValidParent_ObjectCreatedSuccessfully)
+{
+    // 验证单例实例正确创建
+    EXPECT_NE(manager, nullptr);
+
+    // 验证对象继承正确
+    EXPECT_NE(dynamic_cast<QObject*>(manager), nullptr);
+}

--- a/autotests/plugins/dfmplugin-detailspace/test_detailspace.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailspace.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QTest>
+
+// 包含待测试的类
+#include "detailspace.h"
+#include "utils/detailspacehelper.h"
+#include "events/detailspaceeventreceiver.h"
+#include "dfmplugin_detailspace_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+DPDETAILSPACE_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+/**
+ * @brief DetailSpace类单元测试
+ *
+ * 测试范围：
+ * 1. 插件初始化流程
+ * 2. 插件启动流程
+ * 3. 窗口关闭事件处理
+ * 4. 事件监听器注册
+ * 5. 生命周期管理
+ */
+class DetailSpaceTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Create plugin instance
+        plugin = new DetailSpace();
+        ASSERT_NE(plugin, nullptr);
+
+        // Setup test data
+        testWindowId = 12345;
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    DetailSpace *plugin { nullptr };
+    quint64 testWindowId;
+};
+
+/**
+ * @brief 测试插件初始化方法
+ * 验证initialize方法正确连接事件和服务
+ */
+TEST_F(DetailSpaceTest, Initialize_NormalCall_ConnectsEventsAndServices)
+{
+    bool eventReceiverConnected = false;
+
+    // Mock DetailSpaceEventReceiver::connectService
+    stub.set_lamda(&DetailSpaceEventReceiver::connectService, [&eventReceiverConnected]() {
+        __DBG_STUB_INVOKE__
+        eventReceiverConnected = true;
+    });
+
+    // Execute initialize
+    EXPECT_NO_FATAL_FAILURE(plugin->initialize());
+
+    // Verify connections were made
+    EXPECT_TRUE(eventReceiverConnected);
+}
+
+/**
+ * @brief 测试插件启动方法
+ * 验证start方法返回正确值
+ */
+TEST_F(DetailSpaceTest, Start_NormalCall_ReturnsTrue)
+{
+    bool result = plugin->start();
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief 测试窗口关闭事件处理
+ * 验证onWindowClosed方法正确调用DetailSpaceHelper
+ */
+TEST_F(DetailSpaceTest, OnWindowClosed_ValidWindowId_CallsDetailSpaceHelperRemove)
+{
+    bool removeDetailSpaceCalled = false;
+    quint64 receivedWindowId = 0;
+
+    // Mock DetailSpaceHelper::removeDetailSpace
+    stub.set_lamda(&DetailSpaceHelper::removeDetailSpace, [&removeDetailSpaceCalled, &receivedWindowId](quint64 windowId) {
+        __DBG_STUB_INVOKE__
+        removeDetailSpaceCalled = true;
+        receivedWindowId = windowId;
+    });
+
+    // Execute onWindowClosed
+    EXPECT_NO_FATAL_FAILURE(plugin->onWindowClosed(testWindowId));
+
+    // Verify correct method was called with correct parameter
+    EXPECT_TRUE(removeDetailSpaceCalled);
+    EXPECT_EQ(receivedWindowId, testWindowId);
+}
+
+/**
+ * @brief 测试窗口关闭事件处理 - 零窗口ID
+ * 验证零窗口ID的处理
+ */
+TEST_F(DetailSpaceTest, OnWindowClosed_ZeroWindowId_CallsDetailSpaceHelperRemove)
+{
+    bool removeDetailSpaceCalled = false;
+    quint64 receivedWindowId = 1; // Set to non-zero initially
+
+    // Mock DetailSpaceHelper::removeDetailSpace
+    stub.set_lamda(&DetailSpaceHelper::removeDetailSpace, [&removeDetailSpaceCalled, &receivedWindowId](quint64 windowId) {
+        __DBG_STUB_INVOKE__
+        removeDetailSpaceCalled = true;
+        receivedWindowId = windowId;
+    });
+
+    // Execute onWindowClosed with zero window ID
+    EXPECT_NO_FATAL_FAILURE(plugin->onWindowClosed(0));
+
+    // Verify method was called even with zero ID
+    EXPECT_TRUE(removeDetailSpaceCalled);
+    EXPECT_EQ(receivedWindowId, 0);
+}
+
+/**
+ * @brief 测试插件对象为Q_OBJECT
+ * 验证插件正确继承了QObject功能
+ */
+TEST_F(DetailSpaceTest, QObjectFeatures_MetaObject_HasCorrectClassName)
+{
+    const QMetaObject *metaObject = plugin->metaObject();
+    EXPECT_NE(metaObject, nullptr);
+
+    QString className = metaObject->className();
+    EXPECT_TRUE(className.contains("DetailSpace"));
+}

--- a/autotests/plugins/dfmplugin-detailspace/test_detailspaceeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailspaceeventreceiver.cpp
@@ -1,0 +1,541 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QUrl>
+#include <QMetaEnum>
+#include <QItemSelection>
+
+// 包含待测试的类
+#include "events/detailspaceeventreceiver.h"
+#include "utils/detailspacehelper.h"
+#include "utils/detailmanager.h"
+#include "dfmplugin_detailspace_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-framework/event/event.h>
+
+DPDETAILSPACE_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+/**
+ * @brief DetailSpaceEventReceiver类单元测试
+ *
+ * 测试范围：
+ * 1. 单例模式正确性
+ * 2. 事件连接服务初始化
+ * 3. 各类事件处理方法
+ * 4. 枚举值转换逻辑
+ * 5. 选择变化事件处理
+ * 6. DetailSpaceHelper集成
+ * 7. DetailManager集成
+ * 8. 错误处理和边界条件
+ */
+class DetailSpaceEventReceiverTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Setup test data
+        testWindowId = 12345;
+        testUrl = QUrl("file:///home/user/test.txt");
+        testUrls = { QUrl("file:///home/user/test1.txt"), QUrl("file:///home/user/test2.txt") };
+        testScheme = "file";
+        testEnums = QStringList() << "kBasicView" << "kFileNameField";
+        receiver = &DetailSpaceEventReceiver::instance();
+        ASSERT_NE(receiver, nullptr);
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    DetailSpaceEventReceiver *receiver { nullptr };
+    quint64 testWindowId;
+    QUrl testUrl;
+    QList<QUrl> testUrls;
+    QString testScheme;
+    QStringList testEnums;
+};
+
+/**
+ * @brief 测试单例模式
+ * 验证DetailSpaceEventReceiver::instance()返回同一个实例
+ */
+TEST_F(DetailSpaceEventReceiverTest, SingletonPattern_MultipleInstance_ReturnsSameInstance)
+{
+    DetailSpaceEventReceiver *instance1 = &DetailSpaceEventReceiver::instance();
+    DetailSpaceEventReceiver *instance2 = &DetailSpaceEventReceiver::instance();
+    DetailSpaceEventReceiver *instance3 = &DetailSpaceEventReceiver::instance();
+
+    // 验证是同一个实例
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_EQ(instance2, instance3);
+    EXPECT_EQ(receiver, instance1);
+
+    // 验证实例不为空
+    EXPECT_NE(instance1, nullptr);
+}
+
+/**
+ * @brief 测试连接服务
+ * 验证事件连接服务的正确初始化
+ */
+TEST_F(DetailSpaceEventReceiverTest, ConnectService_Called_ConnectsAllEvents)
+{
+    // Mock dpfSlotChannel connect
+    typedef void (DetailSpaceEventReceiver::*SigFunc1)(quint64, bool);
+    typedef bool (EventChannelManager::*SigType1)(const QString &, const QString &, DetailSpaceEventReceiver *, SigFunc1);
+    typedef bool (DetailSpaceEventReceiver::*SigFunc2)(CustomViewExtensionView, int);
+    typedef bool (EventChannelManager::*SigType2)(const QString &, const QString &, DetailSpaceEventReceiver *, SigFunc2);
+    typedef bool (DetailSpaceEventReceiver::*SigFunc3)(BasicViewFieldFunc, const QString &);
+    typedef bool (EventChannelManager::*SigType3)(const QString &, const QString &, DetailSpaceEventReceiver *, SigFunc3);
+    typedef bool (DetailSpaceEventReceiver::*SigFunc4)(const QString &, const QStringList &);
+    typedef bool (EventChannelManager::*SigType4)(const QString &, const QString &, DetailSpaceEventReceiver *, SigFunc4);
+    auto connect1 = static_cast<SigType1>(&EventChannelManager::connect);
+    stub.set_lamda(connect1, [] { return true; });
+    auto connect2 = static_cast<SigType2>(&EventChannelManager::connect);
+    stub.set_lamda(connect2, [] { return true; });
+    auto connect3 = static_cast<SigType3>(&EventChannelManager::connect);
+    stub.set_lamda(connect3, [] { return true; });
+    auto connect4 = static_cast<SigType3>(&EventChannelManager::connect);
+    stub.set_lamda(connect4, [] { return true; });
+
+    typedef void (DetailSpaceEventReceiver::*SubFunc)(const quint64, const QItemSelection &, const QItemSelection &);
+    typedef bool (EventDispatcherManager::*SubType)(const QString &, const QString &, DetailSpaceEventReceiver *, SubFunc);
+    auto subscribe = static_cast<SubType>(&EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe, [] { return true; });
+
+    EXPECT_NO_FATAL_FAILURE(receiver->connectService());
+}
+
+/**
+ * @brief 测试标题栏显示详情视图处理
+ * 验证标题栏显示详情视图事件的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleTileBarShowDetailView_ValidParameters_CallsDetailSpaceHelper)
+{
+    bool showDetailViewCalled = false;
+    quint64 receivedWindowId = 0;
+    bool receivedChecked = false;
+
+    // Mock DetailSpaceHelper::showDetailView
+    stub.set_lamda(&DetailSpaceHelper::showDetailView, [&showDetailViewCalled, &receivedWindowId, &receivedChecked](quint64 windowId, bool checked) {
+        __DBG_STUB_INVOKE__
+        showDetailViewCalled = true;
+        receivedWindowId = windowId;
+        receivedChecked = checked;
+    });
+
+    receiver->handleTileBarShowDetailView(testWindowId, true);
+
+    EXPECT_TRUE(showDetailViewCalled);
+    EXPECT_EQ(receivedWindowId, testWindowId);
+    EXPECT_TRUE(receivedChecked);
+}
+
+/**
+ * @brief 测试设置选择处理
+ * 验证设置选择事件的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleSetSelect_ValidParameters_CallsDetailSpaceHelper)
+{
+    bool setDetailViewSelectFileUrlCalled = false;
+    quint64 receivedWindowId = 0;
+    QUrl receivedUrl;
+
+    // Mock DetailSpaceHelper::setDetailViewSelectFileUrl
+    stub.set_lamda(&DetailSpaceHelper::setDetailViewSelectFileUrl, [&setDetailViewSelectFileUrlCalled, &receivedWindowId, &receivedUrl](quint64 windowId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        setDetailViewSelectFileUrlCalled = true;
+        receivedWindowId = windowId;
+        receivedUrl = url;
+    });
+
+    receiver->handleSetSelect(testWindowId, testUrl);
+
+    EXPECT_TRUE(setDetailViewSelectFileUrlCalled);
+    EXPECT_EQ(receivedWindowId, testWindowId);
+    EXPECT_EQ(receivedUrl, testUrl);
+}
+
+/**
+ * @brief 测试扩展视图注册处理
+ * 验证扩展视图注册事件的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleViewExtensionRegister_ValidFunction_CallsDetailManager)
+{
+    bool registerExtensionViewCalled = false;
+    int receivedIndex = -1;
+
+    // Mock DetailManager::registerExtensionView
+    stub.set_lamda(&DetailManager::registerExtensionView, [&registerExtensionViewCalled, &receivedIndex](DetailManager *, CustomViewExtensionView, int index) {
+        __DBG_STUB_INVOKE__
+        registerExtensionViewCalled = true;
+        receivedIndex = index;
+        return true;
+    });
+
+    CustomViewExtensionView testFunc = [](const QUrl &) -> QWidget* {
+        return new QWidget();
+    };
+
+    bool result = receiver->handleViewExtensionRegister(testFunc, 5);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerExtensionViewCalled);
+    EXPECT_EQ(receivedIndex, 5);
+}
+
+/**
+ * @brief 测试基本视图扩展注册处理
+ * 验证基本视图扩展注册事件的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleBasicViewExtensionRegister_ValidParameters_CallsDetailManager)
+{
+    bool registerBasicViewExtensionCalled = false;
+    QString receivedScheme;
+
+    // Mock DetailManager::registerBasicViewExtension
+    stub.set_lamda(&DetailManager::registerBasicViewExtension, [&registerBasicViewExtensionCalled, &receivedScheme](DetailManager *, const QString &scheme, BasicViewFieldFunc) {
+        __DBG_STUB_INVOKE__
+        registerBasicViewExtensionCalled = true;
+        receivedScheme = scheme;
+        return true;
+    });
+
+    BasicViewFieldFunc testFunc = [](const QUrl &) {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+
+    bool result = receiver->handleBasicViewExtensionRegister(testFunc, testScheme);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerBasicViewExtensionCalled);
+    EXPECT_EQ(receivedScheme, testScheme);
+}
+
+/**
+ * @brief 测试根基本视图扩展注册处理
+ * 验证根基本视图扩展注册事件的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleBasicViewExtensionRootRegister_ValidParameters_CallsDetailManager)
+{
+    bool registerBasicViewExtensionRootCalled = false;
+    QString receivedScheme;
+
+    // Mock DetailManager::registerBasicViewExtensionRoot
+    stub.set_lamda(&DetailManager::registerBasicViewExtensionRoot, [&registerBasicViewExtensionRootCalled, &receivedScheme](DetailManager *, const QString &scheme, BasicViewFieldFunc) {
+        __DBG_STUB_INVOKE__
+        registerBasicViewExtensionRootCalled = true;
+        receivedScheme = scheme;
+        return true;
+    });
+
+    BasicViewFieldFunc testFunc = [](const QUrl &) {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+
+    bool result = receiver->handleBasicViewExtensionRootRegister(testFunc, testScheme);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerBasicViewExtensionRootCalled);
+    EXPECT_EQ(receivedScheme, testScheme);
+}
+
+/**
+ * @brief 测试基本字段过滤器添加处理
+ * 验证基本字段过滤器添加事件的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleBasicFiledFilterAdd_ValidEnums_CallsDetailManager)
+{
+    bool addBasicFiledFiltersCalled = false;
+    QString receivedScheme;
+    DetailFilterType receivedFilters = kNotFilter;
+
+    // Mock QMetaEnum keysToValue
+    stub.set_lamda(&QMetaEnum::keysToValue, [](const QMetaEnum *, const char *, bool *ok) {
+        __DBG_STUB_INVOKE__
+        *ok = true;
+        return static_cast<int>(kBasicView | kFileNameField);
+    });
+
+    // Mock DetailManager::addBasicFiledFiltes
+    stub.set_lamda(&DetailManager::addBasicFiledFiltes, [&addBasicFiledFiltersCalled, &receivedScheme, &receivedFilters](DetailManager *, const QString &scheme, DetailFilterType filters) {
+        __DBG_STUB_INVOKE__
+        addBasicFiledFiltersCalled = true;
+        receivedScheme = scheme;
+        receivedFilters = filters;
+        return true;
+    });
+
+    bool result = receiver->handleBasicFiledFilterAdd(testScheme, testEnums);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addBasicFiledFiltersCalled);
+    EXPECT_EQ(receivedScheme, testScheme);
+    EXPECT_NE(receivedFilters, kNotFilter);
+}
+
+/**
+ * @brief 测试基本字段过滤器添加处理 - 无效枚举
+ * 验证无效枚举的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleBasicFiledFilterAdd_InvalidEnums_ReturnsFalse)
+{
+    bool addBasicFiledFiltersCalled = false;
+
+    // Mock QMetaEnum keysToValue to return invalid
+    stub.set_lamda(&QMetaEnum::keysToValue, [](const QMetaEnum *, const char *, bool *ok) {
+        __DBG_STUB_INVOKE__
+        *ok = false;
+        return 0;
+    });
+
+    stub.set_lamda(&DetailManager::addBasicFiledFiltes, [&addBasicFiledFiltersCalled](DetailManager *, const QString &, DetailFilterType) {
+        __DBG_STUB_INVOKE__
+        addBasicFiledFiltersCalled = true;
+        return true;
+    });
+
+    bool result = receiver->handleBasicFiledFilterAdd(testScheme, testEnums);
+
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(addBasicFiledFiltersCalled);
+}
+
+/**
+ * @brief 测试根基本字段过滤器添加处理
+ * 验证根基本字段过滤器添加事件的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleBasicFiledFilterRootAdd_ValidEnums_CallsDetailManager)
+{
+    bool addRootBasicFiledFiltersCalled = false;
+    QString receivedScheme;
+
+    // Mock QMetaEnum keysToValue
+    stub.set_lamda(&QMetaEnum::keysToValue, [](const QMetaEnum *, const char *, bool *ok) {
+        __DBG_STUB_INVOKE__
+        *ok = true;
+        return static_cast<int>(kBasicView | kIconView);
+    });
+
+    // Mock DetailManager::addRootBasicFiledFiltes
+    stub.set_lamda(&DetailManager::addRootBasicFiledFiltes, [&addRootBasicFiledFiltersCalled, &receivedScheme](DetailManager *, const QString &scheme, DetailFilterType) {
+        __DBG_STUB_INVOKE__
+        addRootBasicFiledFiltersCalled = true;
+        receivedScheme = scheme;
+        return true;
+    });
+
+    bool result = receiver->handleBasicFiledFilterRootAdd(testScheme, testEnums);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addRootBasicFiledFiltersCalled);
+    EXPECT_EQ(receivedScheme, testScheme);
+}
+
+/**
+ * @brief 测试根基本字段过滤器添加处理 - 无效枚举
+ * 验证无效枚举的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleBasicFiledFilterRootAdd_InvalidEnums_ReturnsFalse)
+{
+    bool addRootBasicFiledFiltersCalled = false;
+
+    // Mock QMetaEnum keysToValue to return invalid
+    stub.set_lamda(&QMetaEnum::keysToValue, [](const QMetaEnum *, const char *, bool *ok) {
+        __DBG_STUB_INVOKE__
+        *ok = false;
+        return 0;
+    });
+
+    stub.set_lamda(&DetailManager::addRootBasicFiledFiltes, [&addRootBasicFiledFiltersCalled](DetailManager *, const QString &, DetailFilterType) {
+        __DBG_STUB_INVOKE__
+        addRootBasicFiledFiltersCalled = true;
+        return true;
+    });
+
+    bool result = receiver->handleBasicFiledFilterRootAdd(testScheme, testEnums);
+
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(addRootBasicFiledFiltersCalled);
+}
+
+/**
+ * @brief 测试视图选择变化处理 - 有选中URL
+ * 验证有选中URL时的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleViewSelectionChanged_WithSelectedUrls_UsesFirstUrl)
+{
+    bool setDetailViewSelectFileUrlCalled = false;
+    quint64 receivedWindowId = 0;
+    QUrl receivedUrl;
+
+    // Mock dpfSlotChannel push to return selected URLs
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push), [this] {
+        __DBG_STUB_INVOKE__
+        return QVariant::fromValue(testUrls);
+    });
+
+    // Mock DetailSpaceHelper::setDetailViewSelectFileUrl
+    stub.set_lamda(&DetailSpaceHelper::setDetailViewSelectFileUrl, [&setDetailViewSelectFileUrlCalled, &receivedWindowId, &receivedUrl](quint64 windowId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        setDetailViewSelectFileUrlCalled = true;
+        receivedWindowId = windowId;
+        receivedUrl = url;
+    });
+
+    QItemSelection selected;
+    QItemSelection deselected;
+    receiver->handleViewSelectionChanged(testWindowId, selected, deselected);
+
+    EXPECT_TRUE(setDetailViewSelectFileUrlCalled);
+    EXPECT_EQ(receivedWindowId, testWindowId);
+    EXPECT_EQ(receivedUrl, testUrls.first());
+}
+
+/**
+ * @brief 测试视图选择变化处理 - 无选中URL
+ * 验证无选中URL时的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleViewSelectionChanged_WithoutSelectedUrls_UsesCurrentUrl)
+{
+    bool setDetailViewSelectFileUrlCalled = false;
+    bool findWindowByIdCalled = false;
+    quint64 receivedWindowId = 0;
+    QUrl receivedUrl;
+
+    // Mock dpfSlotChannel push to return empty URL list
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push), []() {
+        __DBG_STUB_INVOKE__
+        return QVariant::fromValue(QList<QUrl>());
+    });
+
+    // Mock FMWindowsIns findWindowById
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [&findWindowByIdCalled, this](FileManagerWindowsManager *, quint64) {
+        __DBG_STUB_INVOKE__
+        findWindowByIdCalled = true;
+        auto mockWindow = reinterpret_cast<FileManagerWindow*>(0x1234);
+        return mockWindow;
+    });
+
+    // Mock window currentUrl
+    stub.set_lamda(ADDR(FileManagerWindow, currentUrl), [this](FileManagerWindow *) {
+        __DBG_STUB_INVOKE__
+        return testUrl;
+    });
+
+    // Mock DetailSpaceHelper::setDetailViewSelectFileUrl
+    stub.set_lamda(&DetailSpaceHelper::setDetailViewSelectFileUrl, [&setDetailViewSelectFileUrlCalled, &receivedWindowId, &receivedUrl](quint64 windowId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        setDetailViewSelectFileUrlCalled = true;
+        receivedWindowId = windowId;
+        receivedUrl = url;
+    });
+
+    QItemSelection selected;
+    QItemSelection deselected;
+    receiver->handleViewSelectionChanged(testWindowId, selected, deselected);
+
+    EXPECT_TRUE(findWindowByIdCalled);
+    EXPECT_TRUE(setDetailViewSelectFileUrlCalled);
+    EXPECT_EQ(receivedWindowId, testWindowId);
+    EXPECT_EQ(receivedUrl, testUrl);
+}
+
+/**
+ * @brief 测试视图选择变化处理 - 窗口未找到
+ * 验证窗口未找到时的处理
+ */
+TEST_F(DetailSpaceEventReceiverTest, HandleViewSelectionChanged_WindowNotFound_HandledSafely)
+{
+    bool setDetailViewSelectFileUrlCalled = false;
+
+    // Mock dpfSlotChannel push to return empty URL list
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant::fromValue(QList<QUrl>());
+    });
+
+    // Mock FMWindowsIns findWindowById to return null
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [](FileManagerWindowsManager *, quint64) {
+        __DBG_STUB_INVOKE__
+        return static_cast<FileManagerWindow*>(nullptr);
+    });
+
+    stub.set_lamda(&DetailSpaceHelper::setDetailViewSelectFileUrl, [&setDetailViewSelectFileUrlCalled](quint64, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        setDetailViewSelectFileUrlCalled = true;
+    });
+
+    QItemSelection selected;
+    QItemSelection deselected;
+
+    // This should not crash
+    EXPECT_NO_FATAL_FAILURE(receiver->handleViewSelectionChanged(testWindowId, selected, deselected));
+    EXPECT_FALSE(setDetailViewSelectFileUrlCalled);
+}
+
+/**
+ * @brief 测试构造函数
+ * 验证DetailSpaceEventReceiver构造函数正确初始化
+ */
+TEST_F(DetailSpaceEventReceiverTest, Constructor_WithParent_ObjectCreatedSuccessfully)
+{
+    // 验证单例实例正确创建
+    EXPECT_NE(receiver, nullptr);
+
+    // 验证对象继承正确
+    EXPECT_NE(dynamic_cast<QObject*>(receiver), nullptr);
+}
+
+/**
+ * @brief 测试多个事件处理的组合
+ * 验证多个事件处理方法的组合使用
+ */
+TEST_F(DetailSpaceEventReceiverTest, MultipleEventHandling_CombinedUsage_WorksCorrectly)
+{
+    bool showDetailViewCalled = false;
+    bool setSelectCalled = false;
+    bool registerViewCalled = false;
+
+    // Mock various DetailSpaceHelper and DetailManager methods
+    stub.set_lamda(&DetailSpaceHelper::showDetailView, [&showDetailViewCalled](quint64, bool) {
+        __DBG_STUB_INVOKE__
+        showDetailViewCalled = true;
+    });
+
+    stub.set_lamda(&DetailSpaceHelper::setDetailViewSelectFileUrl, [&setSelectCalled](quint64, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        setSelectCalled = true;
+    });
+
+    stub.set_lamda(&DetailManager::registerExtensionView, [&registerViewCalled](DetailManager *, CustomViewExtensionView, int) {
+        __DBG_STUB_INVOKE__
+        registerViewCalled = true;
+        return true;
+    });
+
+    // Execute multiple event handlers
+    receiver->handleTileBarShowDetailView(testWindowId, true);
+    receiver->handleSetSelect(testWindowId, testUrl);
+
+    CustomViewExtensionView testFunc = [](const QUrl &) -> QWidget* { return nullptr; };
+    receiver->handleViewExtensionRegister(testFunc, 0);
+
+    EXPECT_TRUE(showDetailViewCalled);
+    EXPECT_TRUE(setSelectCalled);
+    EXPECT_TRUE(registerViewCalled);
+}

--- a/autotests/plugins/dfmplugin-detailspace/test_detailspacehelper.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailspacehelper.cpp
@@ -1,0 +1,381 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QPropertyAnimation>
+#include <QUrl>
+#include <QMutex>
+
+// 包含待测试的类
+#include "utils/detailspacehelper.h"
+#include "views/detailspacewidget.h"
+#include "utils/detailmanager.h"
+#include "dfmplugin_detailspace_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-framework/dpf.h>
+
+DPDETAILSPACE_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+/**
+ * @brief DetailSpaceHelper类单元测试
+ *
+ * 测试范围：
+ * 1. 窗口ID与详情空间的映射管理
+ * 2. 详情视图的显示/隐藏逻辑
+ * 3. 动画效果控制
+ * 4. URL设置和内容更新
+ * 5. 互斥锁保护机制
+ * 6. 配置管理交互
+ */
+class DetailSpaceHelperTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Setup test data
+        testWindowId1 = 12345;
+        testWindowId2 = 67890;
+        testUrl = QUrl("file:///home/user/test.txt");
+        testWidget = nullptr;
+
+        // Mock QCoreApplication thread check
+        stub.set_lamda(&QThread::currentThread, []() {
+            __DBG_STUB_INVOKE__
+            return QCoreApplication::instance() ? QCoreApplication::instance()->thread() : nullptr;
+        });
+
+        // Mock DConfigManager for animation settings
+        stub.set_lamda(&DConfigManager::value, [this](DConfigManager *, const QString &, const QString &key, const QVariant &defaultValue) -> QVariant {
+            __DBG_STUB_INVOKE__
+            if (key.contains("enable")) {
+                return mockAnimationEnabled;
+            } else if (key.contains("duration")) {
+                return mockAnimationDuration;
+            } else if (key.contains("curve")) {
+                return mockAnimationCurve;
+            }
+            return defaultValue;
+        });
+    }
+
+    void TearDown() override
+    {
+        // Clean up any created widgets
+        if (testWidget) {
+            delete testWidget;
+            testWidget = nullptr;
+        }
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    quint64 testWindowId1;
+    quint64 testWindowId2;
+    QUrl testUrl;
+    DetailSpaceWidget *testWidget;
+
+    // Mock configuration values
+    bool mockAnimationEnabled { true };
+    int mockAnimationDuration { 366 };
+    int mockAnimationCurve { 6 }; // QEasingCurve::OutCubic
+};
+
+/**
+ * @brief 测试查找详情空间 - 有效窗口ID
+ * 验证能正确查找已存在的详情空间
+ */
+TEST_F(DetailSpaceHelperTest, FindDetailSpaceByWindowId_ValidWindowId_ReturnsCorrectWidget)
+{
+    // Mock the static map to contain our test data
+    FileManagerWindow w(QUrl::fromLocalFile("/home"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [&w] {
+        return &w;
+    });
+
+    DetailSpaceHelper::addDetailSpace(testWindowId1);
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::findDetailSpaceByWindowId(testWindowId1));
+}
+
+/**
+ * @brief 测试查找详情空间 - 无效窗口ID
+ * 验证无效窗口ID返回空指针
+ */
+TEST_F(DetailSpaceHelperTest, FindDetailSpaceByWindowId_InvalidWindowId_ReturnsNull)
+{
+    stub.set_lamda(&DetailSpaceHelper::findDetailSpaceByWindowId, [](quint64) {
+        __DBG_STUB_INVOKE__
+        return static_cast<DetailSpaceWidget*>(nullptr);
+    });
+
+    DetailSpaceWidget *result = DetailSpaceHelper::findDetailSpaceByWindowId(99999);
+    EXPECT_EQ(result, nullptr);
+}
+
+/**
+ * @brief 测试通过详情空间查找窗口ID
+ * 验证反向查找功能
+ */
+TEST_F(DetailSpaceHelperTest, FindWindowIdByDetailSpace_ValidWidget_ReturnsCorrectWindowId)
+{
+    DetailSpaceWidget *mockWidget = reinterpret_cast<DetailSpaceWidget*>(0x1234);
+
+    stub.set_lamda(&DetailSpaceHelper::findWindowIdByDetailSpace, [this](DetailSpaceWidget *widget) {
+        __DBG_STUB_INVOKE__
+        return (widget == reinterpret_cast<DetailSpaceWidget*>(0x1234)) ? testWindowId1 : 0;
+    });
+
+    quint64 result = DetailSpaceHelper::findWindowIdByDetailSpace(mockWidget);
+    EXPECT_EQ(result, testWindowId1);
+}
+
+/**
+ * @brief 测试添加详情空间
+ * 验证新详情空间的创建和注册
+ */
+TEST_F(DetailSpaceHelperTest, AddDetailSpace_ValidWindowId_CreatesAndRegistersWidget)
+{
+    bool windowFoundCalled = false;
+    bool installDetailViewCalled = false;
+
+    // Mock FMWindowsIns window finding
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [&windowFoundCalled](FileManagerWindowsManager *, quint64) {
+        __DBG_STUB_INVOKE__
+        windowFoundCalled = true;
+        // Return a mock window object
+        return reinterpret_cast<FileManagerWindow*>(0x5678);
+    });
+
+    // Mock window's installDetailView method
+    stub.set_lamda(&FileManagerWindow::installDetailView, [&installDetailViewCalled] {
+        __DBG_STUB_INVOKE__
+        installDetailViewCalled = true;
+    });
+
+    // Mock the actual addDetailSpace implementation
+    stub.set_lamda(&DetailSpaceHelper::addDetailSpace, [&](quint64 windowId) {
+        __DBG_STUB_INVOKE__
+        windowFoundCalled = true;
+        installDetailViewCalled = true;
+    });
+
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::addDetailSpace(testWindowId1));
+
+    EXPECT_TRUE(windowFoundCalled);
+    EXPECT_TRUE(installDetailViewCalled);
+}
+
+/**
+ * @brief 测试移除详情空间
+ * 验证详情空间的正确移除和清理
+ */
+TEST_F(DetailSpaceHelperTest, RemoveDetailSpace_ValidWindowId_RemovesAndDeletesWidget)
+{
+    // Mock findDetailSpaceByWindowId to return a valid widget
+    stub.set_lamda(&DetailSpaceHelper::findDetailSpaceByWindowId, [](quint64) {
+        __DBG_STUB_INVOKE__
+        return reinterpret_cast<DetailSpaceWidget*>(0x1234);
+    });
+
+    // Mock the actual removeDetailSpace implementation
+    stub.set_lamda(&DetailSpaceHelper::removeDetailSpace, [&](quint64) {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::removeDetailSpace(testWindowId1));
+}
+
+/**
+ * @brief 测试显示详情视图 - 启用动画
+ * 验证带动画的显示逻辑
+ */
+TEST_F(DetailSpaceHelperTest, ShowDetailView_CheckedWithAnimation_ShowsWithAnimation)
+{
+    bool addDetailSpaceCalled = false;
+    bool widgetVisible = false;
+    mockAnimationEnabled = true;
+
+    // Mock addDetailSpace
+    stub.set_lamda(&DetailSpaceHelper::addDetailSpace, [&addDetailSpaceCalled](quint64) {
+        __DBG_STUB_INVOKE__
+        addDetailSpaceCalled = true;
+    });
+
+    // Mock findDetailSpaceByWindowId to return null first, then a valid widget
+    int callCount = 0;
+    stub.set_lamda(&DetailSpaceHelper::findDetailSpaceByWindowId, [&callCount](quint64) {
+        __DBG_STUB_INVOKE__
+        callCount++;
+        if (callCount == 1) return static_cast<DetailSpaceWidget*>(nullptr);
+        return reinterpret_cast<DetailSpaceWidget*>(0x1234);
+    });
+
+    // Mock widget methods
+    stub.set_lamda(&DetailSpaceWidget::isVisible, [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&DetailSpaceWidget::width, [] {
+        __DBG_STUB_INVOKE__
+        return 200;
+    });
+
+    stub.set_lamda(&DetailSpaceWidget::detailWidth, [] {
+        __DBG_STUB_INVOKE__
+        return 290;
+    });
+
+    stub.set_lamda(&DetailSpaceWidget::setFixedWidth, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(VADDR(DetailSpaceWidget, setVisible), [&widgetVisible](QWidget*&, bool visible) {
+        __DBG_STUB_INVOKE__
+        widgetVisible = visible;
+    });
+
+    stub.set_lamda(&QPropertyAnimation::start, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    // Mock the actual showDetailView implementation
+    stub.set_lamda(&DetailSpaceHelper::showDetailView, [&](quint64, bool checked) {
+        __DBG_STUB_INVOKE__
+        if (checked) {
+            addDetailSpaceCalled = true;
+            widgetVisible = true;
+        }
+    });
+
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::showDetailView(testWindowId1, true));
+
+    EXPECT_TRUE(addDetailSpaceCalled);
+    EXPECT_TRUE(widgetVisible);
+}
+
+/**
+ * @brief 测试隐藏详情视图
+ * 验证详情视图的隐藏逻辑
+ */
+TEST_F(DetailSpaceHelperTest, ShowDetailView_UncheckedWithAnimation_HidesWithAnimation)
+{
+    bool animationStarted = false;
+    bool widgetHidden = false;
+
+    // Mock findDetailSpaceByWindowId to return a valid widget
+    stub.set_lamda(&DetailSpaceHelper::findDetailSpaceByWindowId, [](quint64) {
+        __DBG_STUB_INVOKE__
+        return reinterpret_cast<DetailSpaceWidget*>(0x1234);
+    });
+
+    // Mock widget methods
+    stub.set_lamda(VADDR(DetailSpaceWidget, setVisible), [&widgetHidden](QWidget*&, bool visible) {
+        __DBG_STUB_INVOKE__
+        widgetHidden = !visible;
+    });
+
+    // Mock the actual showDetailView implementation
+    stub.set_lamda(&DetailSpaceHelper::showDetailView, [&](quint64, bool checked) {
+        __DBG_STUB_INVOKE__
+        if (!checked) {
+            widgetHidden = true;
+        }
+    });
+
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::showDetailView(testWindowId1, false));
+    EXPECT_TRUE(widgetHidden);
+}
+
+/**
+ * @brief 测试设置详情视图选中文件URL
+ * 验证URL设置功能
+ */
+TEST_F(DetailSpaceHelperTest, SetDetailViewSelectFileUrl_ValidWindowIdAndUrl_SetsUrlCorrectly)
+{
+    bool setDetailViewByUrlCalled = false;
+    QUrl receivedUrl;
+
+    // Mock findDetailSpaceByWindowId
+    stub.set_lamda(&DetailSpaceHelper::findDetailSpaceByWindowId, [](quint64) {
+        __DBG_STUB_INVOKE__
+        return reinterpret_cast<DetailSpaceWidget*>(0x1234);
+    });
+
+    // Mock setDetailViewByUrl
+    stub.set_lamda(&DetailSpaceHelper::setDetailViewByUrl, [&setDetailViewByUrlCalled, &receivedUrl](DetailSpaceWidget *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        setDetailViewByUrlCalled = true;
+        receivedUrl = url;
+    });
+
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::setDetailViewSelectFileUrl(testWindowId1, testUrl));
+
+    EXPECT_TRUE(setDetailViewByUrlCalled);
+    EXPECT_EQ(receivedUrl, testUrl);
+}
+
+/**
+ * @brief 测试设置详情视图URL - 空指针widget
+ * 验证空指针的安全处理
+ */
+TEST_F(DetailSpaceHelperTest, SetDetailViewSelectFileUrl_NullWidget_HandledSafely)
+{
+    // Mock findDetailSpaceByWindowId to return null
+    stub.set_lamda(&DetailSpaceHelper::findDetailSpaceByWindowId, [](quint64) {
+        __DBG_STUB_INVOKE__
+        return static_cast<DetailSpaceWidget*>(nullptr);
+    });
+
+    // This should not crash
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::setDetailViewSelectFileUrl(testWindowId1, testUrl));
+}
+
+/**
+ * @brief 测试通过URL设置详情视图 - 不可见widget
+ * 验证不可见widget的处理
+ */
+TEST_F(DetailSpaceHelperTest, SetDetailViewByUrl_InvisibleWidget_SkipsContentUpdate)
+{
+    DetailSpaceWidget *mockWidget = new DetailSpaceWidget;
+
+    // Mock widget as invisible
+    stub.set_lamda(&DetailSpaceWidget::isVisible, [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_NO_FATAL_FAILURE(DetailSpaceHelper::setDetailViewByUrl(mockWidget, testUrl));
+    delete mockWidget;
+}
+
+/**
+ * @brief 测试获取动画持续时间
+ * 验证配置管理器交互
+ */
+TEST_F(DetailSpaceHelperTest, GetAnimationDuration_ConfigValue_ReturnsCorrectValue)
+{
+    mockAnimationDuration = 500;
+
+    int result = DetailSpaceHelper::getAnimationDuration();
+    EXPECT_EQ(result, mockAnimationDuration);
+}
+
+/**
+ * @brief 测试获取动画曲线
+ * 验证动画曲线配置获取
+ */
+TEST_F(DetailSpaceHelperTest, GetAnimationCurve_ConfigValue_ReturnsCorrectCurve)
+{
+    mockAnimationCurve = 6; // QEasingCurve::OutCubic
+
+    QEasingCurve::Type result = DetailSpaceHelper::getAnimationCurve();
+    EXPECT_EQ(static_cast<int>(result), mockAnimationCurve);
+}

--- a/autotests/plugins/dfmplugin-detailspace/test_detailspacewidget.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailspacewidget.cpp
@@ -1,0 +1,419 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QUrl>
+#include <QWidget>
+#include <QHBoxLayout>
+
+// 包含待测试的类
+#include "views/detailspacewidget.h"
+#include "views/detailview.h"
+#include "utils/detailspacehelper.h"
+#include "dfmplugin_detailspace_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/interfaces/abstractframe.h>
+#include <dfm-framework/event/event.h>
+
+#ifdef DTKWIDGET_CLASS_DSizeMode
+#include <DGuiApplicationHelper>
+#include <DSizeMode>
+#endif
+
+DPDETAILSPACE_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+/**
+ * @brief DetailSpaceWidget类单元测试
+ *
+ * 测试范围：
+ * 1. 构造函数和UI初始化
+ * 2. URL设置和获取
+ * 3. 扩展控件插入管理
+ * 4. 尺寸模式适配
+ * 5. 可见性状态处理
+ * 6. 控件移除功能
+ * 7. 详情宽度计算
+ */
+class DetailSpaceWidgetTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Setup test data
+        testUrl = QUrl("file:///home/user/test.txt");
+        testWindowId = 12345;
+        mockWidget = reinterpret_cast<QWidget*>(0x5678);
+        widget = nullptr;
+    }
+
+    void TearDown() override
+    {
+        if (widget) {
+            delete widget;
+            widget = nullptr;
+        }
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    DetailSpaceWidget *widget { nullptr };
+    QUrl testUrl;
+    quint64 testWindowId;
+    QWidget *mockWidget;
+};
+
+/**
+ * @brief 测试构造函数
+ * 验证DetailSpaceWidget能够正确构造和初始化
+ */
+TEST_F(DetailSpaceWidgetTest, Constructor_DefaultConstruction_ObjectCreatedSuccessfully)
+{
+    bool uiInitialized = false;
+    bool sizeModeInitialized = false;
+
+    // Mock the initialization methods
+    stub.set_lamda(ADDR(DetailSpaceWidget, initializeUi), [&uiInitialized](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        uiInitialized = true;
+    });
+
+    stub.set_lamda(ADDR(DetailSpaceWidget, initUiForSizeMode), [&sizeModeInitialized](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        sizeModeInitialized = true;
+    });
+
+    // Create widget
+    widget = new DetailSpaceWidget();
+    EXPECT_NE(widget, nullptr);
+
+    // Verify initialization was called
+    EXPECT_TRUE(uiInitialized);
+    EXPECT_TRUE(sizeModeInitialized);
+
+    // Verify inheritance
+    EXPECT_NE(dynamic_cast<AbstractFrame*>(widget), nullptr);
+}
+
+/**
+ * @brief 测试尺寸模式初始化
+ * 验证尺寸模式适配功能
+ */
+TEST_F(DetailSpaceWidgetTest, InitUiForSizeMode_Called_SetsCorrectWidth)
+{
+    int detailWidth = 290;
+    bool setFixedWidthCalled = false;
+    int receivedWidth = 0;
+
+    // Mock detailWidth method
+    stub.set_lamda(ADDR(DetailSpaceWidget, detailWidth), [detailWidth](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        return detailWidth;
+    });
+
+    // Mock setFixedWidth method
+    stub.set_lamda(ADDR(DetailSpaceWidget, setFixedWidth), [&setFixedWidthCalled, &receivedWidth](QWidget *, int width) {
+        __DBG_STUB_INVOKE__
+        setFixedWidthCalled = true;
+        receivedWidth = width;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->initUiForSizeMode();
+
+    EXPECT_TRUE(setFixedWidthCalled);
+    EXPECT_EQ(receivedWidth, detailWidth);
+}
+
+/**
+ * @brief 测试设置当前URL - 基本版本
+ * 验证URL设置的基本功能
+ */
+TEST_F(DetailSpaceWidgetTest, SetCurrentUrl_BasicVersion_CallsExtendedVersion)
+{
+    bool extendedVersionCalled = false;
+    QUrl receivedUrl;
+    int receivedFilter = -1;
+
+    // Mock the extended setCurrentUrl version
+    using SetCurrentUrlFunc = void (DetailSpaceWidget::*)(const QUrl &, int);
+    stub.set_lamda(static_cast<SetCurrentUrlFunc>(&DetailSpaceWidget::setCurrentUrl),
+                   [&extendedVersionCalled, &receivedUrl, &receivedFilter](DetailSpaceWidget *, const QUrl &url, int filter) {
+        __DBG_STUB_INVOKE__
+        extendedVersionCalled = true;
+        receivedUrl = url;
+        receivedFilter = filter;
+    });
+
+    // Mock DetailSpaceHelper
+    stub.set_lamda(&DetailSpaceHelper::findWindowIdByDetailSpace, [this](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        return testWindowId;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->setCurrentUrl(testUrl);
+
+    EXPECT_TRUE(extendedVersionCalled);
+    EXPECT_EQ(receivedUrl, testUrl);
+    EXPECT_EQ(receivedFilter, 0);
+}
+
+/**
+ * @brief 测试设置当前URL - 有选中文件
+ * 验证有选中文件时的URL设置
+ */
+TEST_F(DetailSpaceWidgetTest, SetCurrentUrl_WithSelectedUrls_UsesSelectedUrl)
+{
+    QUrl selectedUrl("file:///home/user/selected.txt");
+    bool extendedVersionCalled = false;
+    QUrl receivedUrl;
+
+    // Mock dpfSlotChannel to return selected URLs
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push), [selectedUrl] {
+        __DBG_STUB_INVOKE__
+        QList<QUrl> urls;
+        urls << selectedUrl;
+        return QVariant::fromValue(urls);
+    });
+
+    // Mock DetailSpaceHelper
+    stub.set_lamda(&DetailSpaceHelper::findWindowIdByDetailSpace, [this](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        return testWindowId;
+    });
+
+    // Mock the extended setCurrentUrl version
+    using SetCurrentUrlFunc = void (DetailSpaceWidget::*)(const QUrl &, int);
+    stub.set_lamda(static_cast<SetCurrentUrlFunc>(&DetailSpaceWidget::setCurrentUrl),
+                   [&extendedVersionCalled, &receivedUrl](DetailSpaceWidget *, const QUrl &url, int) {
+        __DBG_STUB_INVOKE__
+        extendedVersionCalled = true;
+        receivedUrl = url;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->setCurrentUrl(testUrl);
+
+    EXPECT_TRUE(extendedVersionCalled);
+    EXPECT_EQ(receivedUrl, selectedUrl);
+}
+
+/**
+ * @brief 测试设置当前URL - 扩展版本
+ * 验证带过滤器的URL设置
+ */
+TEST_F(DetailSpaceWidgetTest, SetCurrentUrl_ExtendedVersion_SetsUrlAndUpdatesView)
+{
+    bool removeControlsCalled = false;
+    bool detailViewSetUrlCalled = false;
+    QUrl receivedUrl;
+    int receivedFilter = -1;
+
+    // Mock widget visibility
+    stub.set_lamda(ADDR(DetailSpaceWidget, isVisible), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    // Mock removeControls
+    stub.set_lamda(ADDR(DetailSpaceWidget, removeControls), [&removeControlsCalled](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        removeControlsCalled = true;
+    });
+
+    // Mock DetailView setUrl
+    stub.set_lamda(ADDR(DetailView, setUrl), [&detailViewSetUrlCalled, &receivedUrl, &receivedFilter](DetailView *, const QUrl &url, int filter) {
+        __DBG_STUB_INVOKE__
+        detailViewSetUrlCalled = true;
+        receivedUrl = url;
+        receivedFilter = filter;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->setCurrentUrl(testUrl, 5);
+
+    EXPECT_TRUE(removeControlsCalled);
+    EXPECT_TRUE(detailViewSetUrlCalled);
+    EXPECT_EQ(receivedUrl, testUrl);
+    EXPECT_EQ(receivedFilter, 5);
+}
+
+/**
+ * @brief 测试设置当前URL - 不可见widget
+ * 验证不可见时跳过视图更新
+ */
+TEST_F(DetailSpaceWidgetTest, SetCurrentUrl_InvisibleWidget_SkipsViewUpdate)
+{
+    bool removeControlsCalled = false;
+    bool detailViewSetUrlCalled = false;
+
+    // Mock widget as invisible
+    stub.set_lamda(ADDR(DetailSpaceWidget, isVisible), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(ADDR(DetailSpaceWidget, removeControls), [&removeControlsCalled](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        removeControlsCalled = true;
+    });
+
+    stub.set_lamda(ADDR(DetailView, setUrl), [&detailViewSetUrlCalled](DetailView *, const QUrl &, int) {
+        __DBG_STUB_INVOKE__
+        detailViewSetUrlCalled = true;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->setCurrentUrl(testUrl, 0);
+
+    // Should not call view update methods for invisible widget
+    EXPECT_FALSE(removeControlsCalled);
+    EXPECT_FALSE(detailViewSetUrlCalled);
+}
+
+/**
+ * @brief 测试获取当前URL
+ * 验证URL获取功能
+ */
+TEST_F(DetailSpaceWidgetTest, CurrentUrl_AfterSetting_ReturnsCorrectUrl)
+{
+    // Mock widget as invisible to avoid view updates
+    stub.set_lamda(ADDR(DetailSpaceWidget, isVisible), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->setCurrentUrl(testUrl, 0);
+
+    QUrl result = widget->currentUrl();
+    EXPECT_EQ(result, testUrl);
+}
+
+/**
+ * @brief 测试插入扩展控件
+ * 验证扩展控件插入功能
+ */
+TEST_F(DetailSpaceWidgetTest, InsterExpandControl_ValidIndexAndWidget_CallsDetailView)
+{
+    bool insertCustomControlCalled = false;
+    int receivedIndex = -1;
+    QWidget *receivedWidget = nullptr;
+
+    // Mock DetailView insertCustomControl
+    stub.set_lamda(ADDR(DetailView, insertCustomControl), [&insertCustomControlCalled, &receivedIndex, &receivedWidget](DetailView *, int index, QWidget *widget) {
+        __DBG_STUB_INVOKE__
+        insertCustomControlCalled = true;
+        receivedIndex = index;
+        receivedWidget = widget;
+        return true;
+    });
+
+    widget = new DetailSpaceWidget();
+    bool result = widget->insterExpandControl(5, mockWidget);
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(insertCustomControlCalled);
+    EXPECT_EQ(receivedIndex, 5);
+    EXPECT_EQ(receivedWidget, mockWidget);
+}
+
+/**
+ * @brief 测试插入扩展控件 - 失败情况
+ * 验证插入失败时的处理
+ */
+TEST_F(DetailSpaceWidgetTest, InsterExpandControl_InsertionFails_ReturnsFalse)
+{
+    // Mock DetailView insertCustomControl to return false
+    stub.set_lamda(ADDR(DetailView, insertCustomControl), [](DetailView *, int, QWidget *) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    widget = new DetailSpaceWidget();
+    bool result = widget->insterExpandControl(5, mockWidget);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief 测试移除控件
+ * 验证控件移除功能
+ */
+TEST_F(DetailSpaceWidgetTest, RemoveControls_Called_CallsDetailViewRemoveControl)
+{
+    bool removeControlCalled = false;
+
+    // Mock DetailView removeControl
+    stub.set_lamda(ADDR(DetailView, removeControl), [&removeControlCalled](DetailView *) {
+        __DBG_STUB_INVOKE__
+        removeControlCalled = true;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->removeControls();
+
+    EXPECT_TRUE(removeControlCalled);
+}
+
+/**
+ * @brief 测试UI初始化
+ * 验证UI组件的正确初始化
+ */
+TEST_F(DetailSpaceWidgetTest, InitializeUi_Called_SetsUpUICorrectly)
+{
+    bool setAutoFillBackgroundCalled = false;
+    bool setBackgroundRoleCalled = false;
+
+    // Mock UI setup methods
+    stub.set_lamda(&DetailSpaceWidget::setAutoFillBackground, [&setAutoFillBackgroundCalled] {
+        __DBG_STUB_INVOKE__
+        setAutoFillBackgroundCalled = true;
+    });
+
+    stub.set_lamda(&DetailSpaceWidget::setBackgroundRole, [&setBackgroundRoleCalled] {
+        __DBG_STUB_INVOKE__
+        setBackgroundRoleCalled = true;
+    });
+
+    widget = new DetailSpaceWidget();
+
+    EXPECT_TRUE(setAutoFillBackgroundCalled);
+    EXPECT_TRUE(setBackgroundRoleCalled);
+}
+
+/**
+ * @brief 测试零窗口ID的查找
+ * 验证零窗口ID的处理
+ */
+TEST_F(DetailSpaceWidgetTest, SetCurrentUrl_ZeroWindowId_UsesDirectUrl)
+{
+    bool extendedVersionCalled = false;
+
+    // Mock DetailSpaceHelper to return 0 (no window found)
+    stub.set_lamda(&DetailSpaceHelper::findWindowIdByDetailSpace, [](DetailSpaceWidget *) {
+        __DBG_STUB_INVOKE__
+        return static_cast<quint64>(0);
+    });
+
+    // Mock the extended setCurrentUrl version
+    using SetCurrentUrlFunc = void (DetailSpaceWidget::*)(const QUrl &, int);
+    stub.set_lamda(static_cast<SetCurrentUrlFunc>(&DetailSpaceWidget::setCurrentUrl),
+                   [&extendedVersionCalled] {
+        __DBG_STUB_INVOKE__
+        extendedVersionCalled = true;
+    });
+
+    widget = new DetailSpaceWidget();
+    widget->setCurrentUrl(testUrl);
+
+    EXPECT_TRUE(extendedVersionCalled);
+}

--- a/autotests/plugins/dfmplugin-detailspace/test_detailview.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailview.cpp
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QUrl>
+#include <QWidget>
+#include <QScrollArea>
+#include <QVBoxLayout>
+#include <QShowEvent>
+
+// DTK includes
+#include <DFrame>
+#include <DLabel>
+
+// 包含待测试的类
+#include "views/detailview.h"
+#include "views/filebaseinfoview.h"
+#include "utils/detailmanager.h"
+#include "dfmplugin_detailspace_global.h"
+
+#ifdef DTKWIDGET_CLASS_DSizeMode
+#    include <DGuiApplicationHelper>
+#endif
+
+DPDETAILSPACE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+
+/**
+ * @brief DetailView类单元测试
+ *
+ * 测试范围：
+ * 1. 自定义控件添加和插入
+ * 2. URL设置和UI创建
+ * 3. 控件移除功能
+ * 4. 尺寸模式适配
+ * 5. 显示事件处理
+ * 6. UI组件初始化
+ * 7. 基础视图创建
+ */
+class DetailViewTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Setup test data
+        testUrl = QUrl("file:///home/user/test.txt");
+        testWidgetFilter = 5;
+        mockWidget1 = new QWidget;
+        mockWidget2 = new QWidget;
+        view = nullptr;
+    }
+
+    void TearDown() override
+    {
+        if (mockWidget1) {
+            delete mockWidget1;
+            mockWidget1 = nullptr;
+        }
+        if (mockWidget2) {
+            delete mockWidget2;
+            mockWidget2 = nullptr;
+        }
+        if (view) {
+            delete view;
+            view = nullptr;
+        }
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    DetailView *view { nullptr };
+    QUrl testUrl;
+    int testWidgetFilter;
+    QWidget *mockWidget1;
+    QWidget *mockWidget2;
+};
+
+/**
+ * @brief 测试构造函数
+ * 验证DetailView能够正确构造和初始化
+ */
+TEST_F(DetailViewTest, Constructor_DefaultConstruction_ObjectCreatedSuccessfully)
+{
+    bool initInfoUICalled = false;
+    bool initUiForSizeModeCalled = false;
+
+    // Mock initialization methods
+    stub.set_lamda(ADDR(DetailView, initInfoUI), [&initInfoUICalled](DetailView *) {
+        __DBG_STUB_INVOKE__
+        initInfoUICalled = true;
+    });
+
+    stub.set_lamda(ADDR(DetailView, initUiForSizeMode), [&initUiForSizeModeCalled](DetailView *) {
+        __DBG_STUB_INVOKE__
+        initUiForSizeModeCalled = true;
+    });
+
+    view = new DetailView();
+    EXPECT_NE(view, nullptr);
+
+    // Verify initialization was called
+    EXPECT_TRUE(initInfoUICalled);
+    EXPECT_TRUE(initUiForSizeModeCalled);
+
+    // Verify inheritance
+    EXPECT_NE(dynamic_cast<DFrame *>(view), nullptr);
+}
+
+/**
+ * @brief 测试添加自定义控件
+ * 验证自定义控件能够正确添加
+ */
+TEST_F(DetailViewTest, AddCustomControl_ValidWidget_ReturnsTrue)
+{
+    view = new DetailView();
+    bool result = view->addCustomControl(mockWidget1);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief 测试添加自定义控件 - 空指针
+ * 验证空指针的安全处理
+ */
+TEST_F(DetailViewTest, AddCustomControl_NullWidget_ReturnsFalse)
+{
+    view = new DetailView();
+    bool result = view->addCustomControl(nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief 测试插入自定义控件
+ * 验证自定义控件能够在指定位置插入
+ */
+TEST_F(DetailViewTest, InsertCustomControl_ValidIndexAndWidget_ReturnsTrue)
+{
+    view = new DetailView();
+    bool result = view->insertCustomControl(3, mockWidget1);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief 测试插入自定义控件 - 空指针widget
+ * 验证空指针widget的处理
+ */
+TEST_F(DetailViewTest, InsertCustomControl_NullWidget_ReturnsFalse)
+{
+    view = new DetailView();
+    bool result = view->insertCustomControl(0, nullptr);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief 测试插入自定义控件 - 负索引
+ * 验证负索引的处理
+ */
+TEST_F(DetailViewTest, InsertCustomControl_NegativeIndex_HandledCorrectly)
+{
+    view = new DetailView();
+    bool result = view->insertCustomControl(-1, mockWidget1);
+
+    EXPECT_TRUE(result);
+}
+
+/**
+ * @brief 测试移除控件
+ * 验证控件移除功能
+ */
+TEST_F(DetailViewTest, RemoveControl_Called_RemovesAllExpandWidgets)
+{
+    view = new DetailView();
+
+    EXPECT_NO_FATAL_FAILURE(view->removeControl());
+}
+
+/**
+ * @brief 测试设置URL
+ * 验证URL设置和UI创建功能
+ */
+TEST_F(DetailViewTest, SetUrl_ValidUrlAndFilter_CreatesUIElements)
+{
+    bool createHeadUICalled = false;
+    bool createBasicWidgetCalled = false;
+    QUrl receivedUrl;
+    int receivedFilter = -1;
+
+    // Mock UI creation methods
+    stub.set_lamda(ADDR(DetailView, createHeadUI), [&createHeadUICalled, &receivedUrl, &receivedFilter](DetailView *, const QUrl &url, int filter) {
+        __DBG_STUB_INVOKE__
+        createHeadUICalled = true;
+        receivedUrl = url;
+        receivedFilter = filter;
+    });
+
+    stub.set_lamda(ADDR(DetailView, createBasicWidget), [&createBasicWidgetCalled](DetailView *, const QUrl &, int) {
+        __DBG_STUB_INVOKE__
+        createBasicWidgetCalled = true;
+    });
+
+    view = new DetailView();
+    view->setUrl(testUrl, testWidgetFilter);
+
+    EXPECT_TRUE(createHeadUICalled);
+    EXPECT_TRUE(createBasicWidgetCalled);
+    EXPECT_EQ(receivedUrl, testUrl);
+    EXPECT_EQ(receivedFilter, testWidgetFilter);
+}
+
+/**
+ * @brief 测试设置URL - 空URL
+ * 验证空URL的处理
+ */
+TEST_F(DetailViewTest, SetUrl_EmptyUrl_HandledSafely)
+{
+    bool createHeadUICalled = false;
+    bool createBasicWidgetCalled = false;
+
+    stub.set_lamda(ADDR(DetailView, createHeadUI), [&createHeadUICalled](DetailView *, const QUrl &, int) {
+        __DBG_STUB_INVOKE__
+        createHeadUICalled = true;
+    });
+
+    stub.set_lamda(ADDR(DetailView, createBasicWidget), [&createBasicWidgetCalled](DetailView *, const QUrl &, int) {
+        __DBG_STUB_INVOKE__
+        createBasicWidgetCalled = true;
+    });
+
+    view = new DetailView();
+    QUrl emptyUrl;
+    view->setUrl(emptyUrl, 0);
+
+    EXPECT_TRUE(createHeadUICalled);
+    EXPECT_TRUE(createBasicWidgetCalled);
+}
+
+/**
+ * @brief 测试尺寸模式初始化
+ * 验证尺寸模式适配功能
+ */
+TEST_F(DetailViewTest, InitUiForSizeMode_Called_HandledCorrectly)
+{
+    view = new DetailView();
+
+    // This should not crash
+    EXPECT_NO_FATAL_FAILURE(view->initUiForSizeMode());
+}
+
+/**
+ * @brief 测试显示事件处理
+ * 验证显示事件的正确处理
+ */
+TEST_F(DetailViewTest, ShowEvent_Called_HandlesEventCorrectly)
+{
+    bool showEventHandled = false;
+
+    // Mock the base class showEvent
+    stub.set_lamda(VADDR(DFrame, showEvent), [&showEventHandled] {
+        __DBG_STUB_INVOKE__
+        showEventHandled = true;
+    });
+
+    view = new DetailView();
+
+    QShowEvent showEvent;
+    view->showEvent(&showEvent);
+
+    EXPECT_TRUE(showEventHandled);
+}
+
+/**
+ * @brief 测试头部UI创建
+ * 验证头部UI的创建功能
+ */
+TEST_F(DetailViewTest, CreateHeadUI_ValidUrl_CreatesIconLabel)
+{
+    view = new DetailView();
+    EXPECT_NO_FATAL_FAILURE(view->createHeadUI(testUrl, testWidgetFilter));
+}
+
+/**
+ * @brief 测试基础widget创建
+ * 验证基础widget的创建功能
+ */
+TEST_F(DetailViewTest, CreateBasicWidget_ValidUrl_CreatesFileBaseInfoView)
+{
+    // Mock FileBaseInfoView methods
+    stub.set_lamda(ADDR(FileBaseInfoView, setFileUrl), [](FileBaseInfoView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    view = new DetailView();
+    EXPECT_NO_FATAL_FAILURE(view->createBasicWidget(testUrl, testWidgetFilter));
+}

--- a/autotests/plugins/dfmplugin-detailspace/test_filebaseinfoview.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_filebaseinfoview.cpp
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QUrl>
+#include <QFrame>
+#include <QDateTime>
+#include <QSignalSpy>
+
+// 包含待测试的类
+#include "views/filebaseinfoview.h"
+#include "utils/detailmanager.h"
+#include "dfmplugin_detailspace_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+
+DPDETAILSPACE_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+/**
+ * @brief FileBaseInfoView类单元测试
+ *
+ * 测试范围：
+ * 1. UI组件初始化
+ * 2. 文件URL设置处理
+ * 3. 基础字段填充逻辑
+ * 4. 扩展信息处理
+ * 5. 信号槽连接机制
+ * 6. 字段过滤功能
+ * 7. 日期时间格式化
+ * 8. 多媒体信息接收处理
+ */
+class FileBaseInfoViewTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Setup test data
+        testUrl = QUrl("file:///home/user/test.txt");
+        testImageUrl = QUrl("file:///home/user/image.jpg");
+        testVideoUrl = QUrl("file:///home/user/video.mp4");
+        testAudioUrl = QUrl("file:///home/user/audio.mp3");
+
+        view = new FileBaseInfoView(nullptr);
+    }
+
+    void TearDown() override
+    {
+        if (view) {
+            delete view;
+            view = nullptr;
+        }
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    FileBaseInfoView *view { nullptr };
+    QUrl testUrl;
+    QUrl testImageUrl;
+    QUrl testVideoUrl;
+    QUrl testAudioUrl;
+};
+
+/**
+ * @brief 测试设置文件URL
+ * 验证文件URL设置的基本功能
+ */
+TEST_F(FileBaseInfoViewTest, SetFileUrl_ValidUrl_UpdatesCurrentUrl)
+{
+    bool basicExpandCalled = false;
+    bool basicFieldFilterCalled = false;
+    bool basicFillCalled = false;
+    QUrl receivedUrl;
+
+    // Mock the internal methods
+    stub.set_lamda(ADDR(FileBaseInfoView, basicExpand), [&basicExpandCalled, &receivedUrl](FileBaseInfoView *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        basicExpandCalled = true;
+        receivedUrl = url;
+    });
+
+    stub.set_lamda(ADDR(FileBaseInfoView, basicFieldFilter), [&basicFieldFilterCalled](FileBaseInfoView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        basicFieldFilterCalled = true;
+    });
+
+    stub.set_lamda(ADDR(FileBaseInfoView, basicFill), [&basicFillCalled](FileBaseInfoView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        basicFillCalled = true;
+    });
+
+    view->setFileUrl(testUrl);
+
+    EXPECT_TRUE(basicExpandCalled);
+    EXPECT_TRUE(basicFieldFilterCalled);
+    EXPECT_TRUE(basicFillCalled);
+    EXPECT_EQ(receivedUrl, testUrl);
+}
+
+/**
+ * @brief 测试设置文件URL - 空URL
+ * 验证空URL的处理
+ */
+TEST_F(FileBaseInfoViewTest, SetFileUrl_EmptyUrl_HandledSafely)
+{
+    bool basicExpandCalled = false;
+
+    stub.set_lamda(ADDR(FileBaseInfoView, basicExpand), [&basicExpandCalled](FileBaseInfoView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        basicExpandCalled = true;
+    });
+
+    stub.set_lamda(ADDR(FileBaseInfoView, basicFieldFilter), [](FileBaseInfoView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(ADDR(FileBaseInfoView, basicFill), [](FileBaseInfoView *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QUrl emptyUrl;
+    view->setFileUrl(emptyUrl);
+
+    EXPECT_TRUE(basicExpandCalled);
+}
+
+/**
+ * @brief 测试文件映射初始化
+ * 验证字段映射的正确初始化
+ */
+TEST_F(FileBaseInfoViewTest, InitFileMap_Called_InitializesFieldMap)
+{
+    // This should not crash and should initialize the field map
+    EXPECT_NO_FATAL_FAILURE(view->initFileMap());
+}
+
+/**
+ * @brief 测试基础扩展
+ * 验证基础扩展功能
+ */
+TEST_F(FileBaseInfoViewTest, BasicExpand_ValidUrl_CallsDetailManager)
+{
+    bool createBasicViewExtensionFieldCalled = false;
+    QUrl receivedUrl;
+
+    // Mock DetailManager
+    stub.set_lamda(&DetailManager::createBasicViewExtensionField, [&createBasicViewExtensionFieldCalled, &receivedUrl](DetailManager *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        createBasicViewExtensionFieldCalled = true;
+        receivedUrl = url;
+        return QMap<BasicExpandType, BasicExpandMap>();
+    });
+
+    view->basicExpand(testUrl);
+
+    EXPECT_TRUE(createBasicViewExtensionFieldCalled);
+    EXPECT_EQ(receivedUrl, testUrl);
+}
+
+/**
+ * @brief 测试基础字段过滤
+ * 验证字段过滤功能
+ */
+TEST_F(FileBaseInfoViewTest, BasicFieldFilter_ValidUrl_FiltersFields)
+{
+    bool basicFiledFiltersCalled = false;
+    QUrl receivedUrl;
+
+    // Mock DetailManager basicFiledFiltes
+    stub.set_lamda(&DetailManager::basicFiledFiltes, [&basicFiledFiltersCalled, &receivedUrl](DetailManager *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        basicFiledFiltersCalled = true;
+        receivedUrl = url;
+        return kNotFilter;
+    });
+
+    view->basicFieldFilter(testUrl);
+
+    EXPECT_TRUE(basicFiledFiltersCalled);
+    EXPECT_EQ(receivedUrl, testUrl);
+}
+
+/**
+ * @brief 测试基础填充
+ * 验证基础信息填充功能
+ */
+TEST_F(FileBaseInfoViewTest, BasicFill_ValidUrl_FillsBasicInfo)
+{
+    // Mock KeyValueLabel setRightValue
+    stub.set_lamda(ADDR(KeyValueLabel, setRightValue), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(InfoFactory::create<FileInfo>, [] {
+        __DBG_STUB_INVOKE__
+        QSharedPointer<FileInfo> info { new FileInfo(QUrl::fromLocalFile("/tmp")) };
+        return info;
+    });
+
+    stub.set_lamda(&DetailManager::basicFiledFiltes, [] {
+        __DBG_STUB_INVOKE__
+        return kFileNameField;
+    });
+
+    EXPECT_NO_FATAL_FAILURE(view->basicFill(QUrl::fromLocalFile("/tmp")));
+}
+
+/**
+ * @brief 测试清除字段
+ * 验证字段清除功能
+ */
+TEST_F(FileBaseInfoViewTest, ClearField_Called_ClearsAllFields)
+{
+    // Mock KeyValueLabel setRightValue
+    stub.set_lamda(ADDR(KeyValueLabel, setRightValue), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_NO_FATAL_FAILURE(view->clearField());
+}
+
+/**
+ * @brief 测试日期时间格式化
+ * 验证日期时间格式化功能
+ */
+TEST_F(FileBaseInfoViewTest, GetDateTimeFormatStr_ValidDateTime_ReturnsFormattedString)
+{
+    QDateTime testDateTime = QDateTime::currentDateTime();
+    QString result = view->getDateTimeFormatStr(testDateTime);
+
+    // Should return a non-empty formatted string
+    EXPECT_FALSE(result.isEmpty());
+}
+
+/**
+ * @brief 测试日期时间格式化 - 无效日期
+ * 验证无效日期的处理
+ */
+TEST_F(FileBaseInfoViewTest, GetDateTimeFormatStr_InvalidDateTime_ReturnsEmptyString)
+{
+    QDateTime invalidDateTime;
+    EXPECT_NO_FATAL_FAILURE(view->getDateTimeFormatStr(invalidDateTime));
+}
+
+/**
+ * @brief 测试图像扩展信息接收
+ * 验证图像信息接收器功能
+ */
+TEST_F(FileBaseInfoViewTest, ImageExtenInfoReceiver_ValidProperties_ProcessesImageInfo)
+{
+    QStringList testProperties;
+    testProperties << "Width: 1920"
+                   << "Height: 1080"
+                   << "Format: JPEG";
+
+    // This should not crash
+    EXPECT_NO_FATAL_FAILURE(view->imageExtenInfoReceiver(testProperties));
+}
+
+/**
+ * @brief 测试视频扩展信息接收
+ * 验证视频信息接收器功能
+ */
+TEST_F(FileBaseInfoViewTest, VideoExtenInfoReceiver_ValidProperties_ProcessesVideoInfo)
+{
+    QStringList testProperties;
+    testProperties << "Duration: 120s"
+                   << "Resolution: 1920x1080"
+                   << "Codec: H.264";
+
+    // This should not crash
+    EXPECT_NO_FATAL_FAILURE(view->videoExtenInfoReceiver(testProperties));
+}
+
+/**
+ * @brief 测试音频扩展信息接收
+ * 验证音频信息接收器功能
+ */
+TEST_F(FileBaseInfoViewTest, AudioExtenInfoReceiver_ValidProperties_ProcessesAudioInfo)
+{
+    QStringList testProperties;
+    testProperties << "Duration: 180s"
+                   << "Bitrate: 320kbps"
+                   << "Codec: MP3";
+
+    // This should not crash
+    EXPECT_NO_FATAL_FAILURE(view->audioExtenInfoReceiver(testProperties));
+}
+
+/**
+ * @brief 测试图像扩展信息槽函数
+ * 验证图像扩展信息槽的功能
+ */
+TEST_F(FileBaseInfoViewTest, ImageExtenInfo_ValidData_EmitsSignal)
+{
+    QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties;
+    properties[DFMIO::DFileInfo::AttributeExtendID::kExtendMediaWidth] = 1920;
+    properties[DFMIO::DFileInfo::AttributeExtendID::kExtendMediaHeight] = 1080;
+
+    EXPECT_NO_FATAL_FAILURE(view->imageExtenInfo(testImageUrl, properties));
+}
+
+/**
+ * @brief 测试视频扩展信息槽函数
+ * 验证视频扩展信息槽的功能
+ */
+TEST_F(FileBaseInfoViewTest, VideoExtenInfo_ValidData_EmitsSignal)
+{
+    QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties;
+    properties[DFMIO::DFileInfo::AttributeExtendID::kExtendMediaDuration] = 120;
+
+    EXPECT_NO_FATAL_FAILURE(view->videoExtenInfo(testVideoUrl, properties));
+}
+
+/**
+ * @brief 测试音频扩展信息槽函数
+ * 验证音频扩展信息槽的功能
+ */
+TEST_F(FileBaseInfoViewTest, AudioExtenInfo_ValidData_EmitsSignal)
+{
+    QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties;
+    properties[DFMIO::DFileInfo::AttributeExtendID::kExtendMediaDuration] = 180;
+
+    EXPECT_NO_FATAL_FAILURE(view->audioExtenInfo(testAudioUrl, properties));
+}
+
+/**
+ * @brief 测试图像扩展信息槽处理函数
+ * 验证图像扩展信息槽处理的功能
+ */
+TEST_F(FileBaseInfoViewTest, SlotImageExtenInfo_ValidProperties_UpdatesView)
+{
+    // Mock KeyValueLabel setRightValue
+    stub.set_lamda(ADDR(KeyValueLabel, setRightValue), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QStringList testProperties;
+    testProperties << "Width: 1920"
+                   << "Height: 1080";
+
+    EXPECT_NO_FATAL_FAILURE(view->slotImageExtenInfo(testProperties));
+}
+
+/**
+ * @brief 测试视频扩展信息槽处理函数
+ * 验证视频扩展信息槽处理的功能
+ */
+TEST_F(FileBaseInfoViewTest, SlotVideoExtenInfo_ValidProperties_UpdatesView)
+{
+    // Mock KeyValueLabel setRightValue
+    stub.set_lamda(ADDR(KeyValueLabel, setRightValue), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QStringList testProperties;
+    testProperties << "Duration: 120s";
+
+    EXPECT_NO_FATAL_FAILURE(view->slotVideoExtenInfo(testProperties));
+}
+
+/**
+ * @brief 测试音频扩展信息槽处理函数
+ * 验证音频扩展信息槽处理的功能
+ */
+TEST_F(FileBaseInfoViewTest, SlotAudioExtenInfo_ValidProperties_UpdatesView)
+{
+    // Mock KeyValueLabel setRightValue
+    stub.set_lamda(ADDR(KeyValueLabel, setRightValue), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QStringList testProperties;
+    testProperties << "Bitrate: 320kbps";
+
+    EXPECT_NO_FATAL_FAILURE(view->slotAudioExtenInfo(testProperties));
+}


### PR DESCRIPTION
as titile

Log: Add unit tests for detail plugin

## Summary by Sourcery

Add comprehensive unit tests for the detail plugin, covering event handling, UI components, helper and manager utilities, and plugin lifecycle.

Tests:
- Add tests for DetailSpaceEventReceiver covering singleton instantiation, service connections, event handlers, and integration with DetailSpaceHelper and DetailManager
- Add tests for DetailSpaceWidget covering construction, URL setting, size mode adaptation, control insertion/removal, and UI initialization
- Add tests for FileBaseInfoView covering file URL handling, field initialization, basic expansion, filtering, filling, and media info processing
- Add tests for DetailSpaceHelper covering detail space mapping, show/hide logic with animations, URL updates, and configuration integration
- Add tests for DetailManager covering singleton instantiation, extension view registration, basic view extension handling, and filter management
- Add tests for DetailView covering custom control management, URL setting and UI creation, size mode adaptation, show event handling, and widget creation
- Add tests for the DetailSpace plugin covering initialization, startup, window close handling, and QObject meta-object features