### PR TITLE
fix: manage dynamic memory for task dialog items and improve action creation in menus

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -215,6 +215,7 @@ void TaskDialog::removeTask()
     QListWidgetItem *item = taskItems.value(jobHandler);
     taskListWidget->removeItemWidget(item);
     taskListWidget->takeItem(taskListWidget->row(item));
+    delete item;  // 显式删除动态分配的对象
     taskItems.remove(jobHandler);
     setTitle(taskListWidget->count());
     if (taskListWidget->count() == 0) {
@@ -233,7 +234,8 @@ void TaskDialog::closeEvent(QCloseEvent *event)
     while (it != taskItems.end()) {
         it.key()->operateTaskJob(AbstractJobHandler::SupportAction::kStopAction);
         taskListWidget->removeItemWidget(it.value());
-        taskListWidget->takeItem(taskListWidget->row(it.value()));
+        QListWidgetItem *item = taskListWidget->takeItem(taskListWidget->row(it.value()));
+        delete item;  // 显式删除动态分配的对象
         it = taskItems.erase(it);
     }
     emit closed();

--- a/src/plugins/common/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/extendmenuscene/extendmenuscene.cpp
@@ -121,13 +121,13 @@ bool ExtendMenuScenePrivate::insertIntoExistedSubActions(QAction *action, QMap<Q
 
     auto separatPos = cacheActionsSeparator.value(action, DCustomActionDefines::kNone);
     if (separatPos & DCustomActionDefines::kTop) {
-        QAction *separator = new QAction;
+        QAction *separator = new QAction(action->parent());
         separator->setSeparator(true);
         subActions.insert(actPos, separator);
         actPos++;   // separator inserted before action, the pos grows.
     }
     if (separatPos & DCustomActionDefines::kBottom) {
-        QAction *separator = new QAction;
+        QAction *separator = new QAction(action->parent());
         separator->setSeparator(true);
         subActions.insert(actPos + 1, separator);
     }

--- a/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
@@ -92,12 +92,12 @@ bool TagMenuScene::create(QMenu *parent)
 
     // create by focus fileinfo
     d->tagNames = TagManager::instance()->getTagsByUrls({ FileUtils::bindUrlTransform(d->focusFile) });
-    QAction *colorListAction = createColorListAction();
+    QAction *colorListAction = createColorListAction(parent);
     colorListAction->setProperty(ActionPropertyKey::kActionID, QString(TagActionId::kActTagColorListKey));
     parent->addAction(colorListAction);
     d->predicateAction.insert(TagActionId::kActTagColorListKey, colorListAction);
 
-    QAction *tagAction = createTagAction();
+    QAction *tagAction = createTagAction(parent);
     tagAction->setProperty(ActionPropertyKey::kActionID, QString(TagActionId::kActTagAddKey));
     parent->addAction(tagAction);
     d->predicateAction.insert(TagActionId::kActTagAddKey, tagAction);
@@ -235,18 +235,18 @@ TagColorListWidget *TagMenuScene::getMenuListWidget() const
     return nullptr;
 }
 
-QAction *TagMenuScene::createTagAction() const
+QAction *TagMenuScene::createTagAction(QMenu *parent) const
 {
-    QAction *action = new QAction;
+    QAction *action = new QAction(parent);
     action->setText(d->predicateName.value(TagActionId::kActTagAddKey));
 
     return action;
 }
 
-QAction *TagMenuScene::createColorListAction() const
+QAction *TagMenuScene::createColorListAction(QMenu *parent) const
 {
-    TagColorListWidget *colorListWidget = new TagColorListWidget;
-    QWidgetAction *action = new QWidgetAction(nullptr);
+    TagColorListWidget *colorListWidget = new TagColorListWidget(parent);
+    QWidgetAction *action = new QWidgetAction(parent);
 
     action->setDefaultWidget(colorListWidget);
     // get tags by focus fileinfo

--- a/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.h
+++ b/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.h
@@ -47,8 +47,8 @@ private:
 
     TagColorListWidget *getMenuListWidget() const;
 
-    QAction *createTagAction() const;
-    QAction *createColorListAction() const;
+    QAction *createTagAction(QMenu *parent) const;
+    QAction *createColorListAction(QMenu *parent) const;
     QWidget *findDesktopView(QWidget *root) const;
 };
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -15,6 +15,7 @@
 #include <QUrl>
 #include <QDropEvent>
 #include <QPalette>
+#include <QStyle>
 
 DPSIDEBAR_BEGIN_NAMESPACE
 
@@ -39,6 +40,7 @@ class SideBarViewPrivate : public QObject
     QUrl sidebarUrl;
     DFMBASE_NAMESPACE::DFMMimeData dfmMimeData;
     QPalette originPalette;
+    QStyle *style = nullptr;
 
     explicit SideBarViewPrivate(SideBarView *qq);
     bool checkOpTime();   // 检查当前操作与上次操作的时间间隔

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -260,7 +260,16 @@ SideBarView::SideBarView(QWidget *parent)
     d->originPalette = palette();
     d->lastOpTime = 0;
 
-    setStyle(new SidebarViewStyle(style()));
+    d->style = new SidebarViewStyle(style());
+    setStyle(d->style);
+}
+
+SideBarView::~SideBarView()
+{
+    if (d->style) {
+        delete d->style;
+        d->style = nullptr;
+    }
 }
 
 SideBarModel *SideBarView::model() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -24,6 +24,7 @@ class SideBarView : public DTreeView
 
 public:
     explicit SideBarView(QWidget *parent = nullptr);
+    ~SideBarView() override;
     virtual SideBarModel *model() const;
     QModelIndex indexAt(const QPoint &p) const override;
     SideBarItem *itemAt(const QPoint &pt) const;

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
@@ -392,7 +392,7 @@ void secret_utils::forgetPasswordInSession(const QString &host)
     }
 
     // 在会话集合中搜索密码
-    GHashTable_autoptr query = g_hash_table_new_full(g_str_hash,
+    GHashTable *query = g_hash_table_new_full(g_str_hash,
                                                      g_str_equal,
                                                      g_free,
                                                      g_free);
@@ -410,12 +410,15 @@ void secret_utils::forgetPasswordInSession(const QString &host)
         fmWarning() << "Error searching in session collection:" << error->message;
         g_object_unref(sessionCollection);
         g_object_unref(service);
+        if (query)
+            g_hash_table_unref(query);
         return;
     }
 
-    while (items) {
-        SecretItem *item = reinterpret_cast<SecretItem *>(items->data);
-        items = items->next;
+    GList *gList = items;
+    while (gList) {
+        SecretItem *item = reinterpret_cast<SecretItem *>(gList->data);
+        gList = gList->next;
         char *label = secret_item_get_label(item);
         fmInfo() << "Remove saved item:" << QString(label);
         secret_item_delete(item, nullptr, nullptr, nullptr);
@@ -423,4 +426,6 @@ void secret_utils::forgetPasswordInSession(const QString &host)
     }
     g_object_unref(sessionCollection);
     g_object_unref(service);
+    if (query)
+        g_hash_table_unref(query);
 }


### PR DESCRIPTION
- Added explicit deletion of dynamically allocated QListWidgetItem objects in TaskDialog to prevent memory leaks.
- Updated action creation methods in TagMenuScene to accept a parent QMenu, ensuring proper parent-child relationships for QAction and QWidgetAction.
- Enhanced SideBarView to include a destructor for proper cleanup of dynamically allocated SidebarViewStyle.

These changes improve memory management and ensure proper widget hierarchy in the UI components.

Log: fix some memory leak issue
Bug: https://pms.uniontech.com/bug-view-324097.html

## Summary by Sourcery

Improve dynamic memory management and widget ownership across multiple UI components and utility functions to prevent memory leaks and enforce proper parent-child relationships

Bug Fixes:
- Fix memory leaks by explicitly unref'ing GHashTable in secret_utils, deleting QListWidgetItem in TaskDialog, and cleaning up SidebarViewStyle in SideBarView destructor

Enhancements:
- Refactor TagMenuScene and ExtendMenuScene to accept a parent QMenu for QAction and separator creation to ensure proper widget ownership
- Set EmblemIconWorker parent in ExtensionEmblemManager to guarantee automatic deletion when its worker thread finishes