### PR TITLE
fix: Text clipped in propertity dialog

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -8,6 +8,7 @@
 #include <QMenu>
 #include <QClipboard>
 #include <QApplication>
+#include <QAbstractTextDocumentLayout>
 
 #include <dtkwidget_global.h>
 #ifdef DTKWIDGET_CLASS_DSizeMode
@@ -40,7 +41,9 @@ void KeyValueLabel::initUI()
 {
     leftValueLabel = new DLabel(this);
     rightValueEdit = new RightValueWidget(this);
+    auto layout = rightValueEdit->document()->documentLayout();
     connect(rightValueEdit, &RightValueWidget::clicked, this, &KeyValueLabel::valueAreaClicked);
+    connect(layout, &QAbstractTextDocumentLayout::documentSizeChanged, this, &KeyValueLabel::adjustHeight);
     rightValueEdit->setMinimumWidth(130);
     glayout = new QGridLayout;
     glayout->setContentsMargins(0, 0, 0, 0);
@@ -154,7 +157,10 @@ void KeyValueLabel::setLeftRightValue(QString leftValue, QString rightValue, Qt:
 
 void KeyValueLabel::adjustHeight()
 {
-    rightValueEdit->setFixedHeight(static_cast<int>(rightValueEdit->document()->size().height()) + 2);
+    qreal docHeight = rightValueEdit->document()->size().height();
+    QMargins margins = rightValueEdit->contentsMargins();
+    int totalHeight = qCeil(docHeight) + margins.top() + margins.bottom();
+    rightValueEdit->setFixedHeight(totalHeight);
 }
 
 /*!

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -45,7 +45,6 @@ DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 
 namespace ConstDef {
-static constexpr int kKeyWidth { 80 };
 static constexpr int kWidgetFixedWidth { 195 };
 static constexpr char kShareFileDir[] { "/var/lib/samba/usershares" };
 }
@@ -61,16 +60,9 @@ SectionKeyLabel::SectionKeyLabel(const QString &text, QWidget *parent, Qt::Windo
     : QLabel(text, parent, f)
 {
     setObjectName("SectionKeyLabel");
-#ifdef DTKWIDGET_CLASS_DSizeMode
-    setFixedWidth(DSizeModeHelper::element(ConstDef::kKeyWidth, ConstDef::kKeyWidth));
-    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this]() {
-        this->setFixedWidth(DSizeModeHelper::element(ConstDef::kKeyWidth, ConstDef::kKeyWidth));
-    });
-#else
-    setFixedWidth(ConstDef::kKeyWidth);
-#endif
     DFontSizeManager::instance()->bind(this, DFontSizeManager::SizeType::T7, QFont::Medium);
     setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 }
 
 ShareControlWidget::ShareControlWidget(const QUrl &url, bool disableState, QWidget *parent)
@@ -124,6 +116,7 @@ void ShareControlWidget::setupUi(bool disableState)
     basicInfoFrameLay->setContentsMargins(0, 0, 0, 0);
     basicInfoFrameLay->setContentsMargins(20, 0, 10, 0);
     basicInfoFrameLay->setVerticalSpacing(6);
+    basicInfoFrameLay->setHorizontalSpacing(6);
 
     setupShareSwitcher();
     basicInfoFrameLay->addRow(" ", shareSwitcher);

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -32,8 +32,8 @@
 #include <QImageReader>
 
 static constexpr int kSpacingHeight { 2 };
-static constexpr int kLeftContentsMargins { 0 };
-static constexpr int kRightContentsMargins { 5 };
+static constexpr int kLeftContentsMargins { 10 };
+static constexpr int kRightContentsMargins { 10 };
 static constexpr int kFrameWidth { 360 };
 static constexpr int kItemWidth { 340 };
 static constexpr int kLeftWidgetWidth { 70 };
@@ -121,10 +121,10 @@ KeyValueLabel *BasicWidget::createValueLabel(QFrame *frame, QString leftValue)
 {
     KeyValueLabel *res = new KeyValueLabel(frame);
     res->setLeftFontSizeWeight(DFontSizeManager::SizeType::T7, QFont::Weight::Medium);
-    res->setLeftValue(leftValue, Qt::ElideMiddle, Qt::AlignLeft, true);
+    res->setLeftValue(leftValue, Qt::ElideMiddle, Qt::AlignLeft | Qt::AlignVCenter, true);
     res->setRightFontSizeWeight(DFontSizeManager::SizeType::T8, QFont::Light);
-    res->leftWidget()->setFixedWidth(kLeftWidgetWidth);
-    res->rightWidget()->setFixedWidth(kRightWidgetWidth);
+    res->leftWidget()->setMinimumWidth(kLeftWidgetWidth);
+    res->rightWidget()->setMinimumWidth(kRightWidgetWidth);
     return res;
 }
 
@@ -150,7 +150,7 @@ void BasicWidget::basicExpand(const QUrl &url)
         case kFieldReplace: {
             for (BasicFieldExpandEnum k : filterEnumList) {
                 QPair<QString, QString> field = expand.value(k);
-                fieldMap.value(k)->setLeftValue(field.first, Qt::ElideMiddle, Qt::AlignLeft, true);
+                fieldMap.value(k)->setLeftValue(field.first, Qt::ElideMiddle, Qt::AlignLeft | Qt::AlignVCenter, true);
                 fieldMap.value(k)->setRightValue(field.second, Qt::ElideMiddle, Qt::AlignVCenter, true);
             }
         } break;
@@ -463,7 +463,6 @@ void BasicWidget::imageExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::Attribu
 
     const QString &imgSizeStr = QString::number(width) + "x" + QString::number(height);
     fileMediaResolution->setRightValue(imgSizeStr, Qt::ElideNone, Qt::AlignVCenter, true);
-    fileMediaResolution->adjustHeight();
 }
 
 void BasicWidget::videoExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties)
@@ -478,7 +477,6 @@ void BasicWidget::videoExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::Attribu
     int height = properties[DFileInfo::AttributeExtendID::kExtendMediaHeight].toInt();
     const QString &videoResolutionStr = QString::number(width) + "x" + QString::number(height);
     fileMediaResolution->setRightValue(videoResolutionStr, Qt::ElideNone, Qt::AlignVCenter, true);
-    fileMediaResolution->adjustHeight();
 
     int duration = properties[DFileInfo::AttributeExtendID::kExtendMediaDuration].toInt();
     if (duration != 0) {
@@ -486,14 +484,12 @@ void BasicWidget::videoExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::Attribu
         t = t.addMSecs(duration);
         const QString &durationStr = t.toString("hh:mm:ss");
         fileMediaDuration->setRightValue(durationStr, Qt::ElideNone, Qt::AlignVCenter, true);
-        fileMediaDuration->adjustHeight();
     } else {
         QString localFile = url.toLocalFile();
         connect(infoFetchWorker, &MediaInfoFetchWorker::durationReady,
                 this, [this](const QString &duration) {
                     if (!duration.isEmpty()) {
                         fileMediaDuration->setRightValue(duration);
-                        fileMediaDuration->adjustHeight();
                     } else {
                         fileMediaDuration->setVisible(false);
                     }
@@ -518,14 +514,12 @@ void BasicWidget::audioExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::Attribu
         t = t.addMSecs(duration);
         const QString &durationStr = t.toString("hh:mm:ss");
         fileMediaDuration->setRightValue(durationStr, Qt::ElideNone, Qt::AlignVCenter, true);
-        fileMediaDuration->adjustHeight();
     } else {
         QString localFile = url.toLocalFile();
         connect(infoFetchWorker, &MediaInfoFetchWorker::durationReady,
                 this, [this](const QString &duration) {
                     if (!duration.isEmpty()) {
                         fileMediaDuration->setRightValue(duration);
-                        fileMediaDuration->adjustHeight();
                     } else {
                         fileMediaDuration->setVisible(false);
                     }


### PR DESCRIPTION
as title

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-322127.html

## Summary by Sourcery

Fix text clipping in property dialog by adjusting margins, alignments, widths, and dynamic label resizing; improve layout flexibility and spacing.

Bug Fixes:
- Adjust property dialog contents margins, alignments, and minimum widths to prevent truncated text.
- Refine KeyValueLabel height calculation to include document size and margins for correct text rendering.

Enhancements:
- Remove manual adjustHeight calls and connect label height to documentSizeChanged for automatic resizing.
- Replace fixed width constraints with size policies and minimum width settings for more adaptable layouts.
- Add consistent horizontal spacing in share control widget to align elements properly.