### PR TITLE
test: add unit tests for SMB browser plugin components

### DIFF
--- a/autotests/plugins/dfmplugin-smbbrowser/test_protocoldevicedisplaymanager.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_protocoldevicedisplaymanager.cpp
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "displaycontrol/protocoldevicedisplaymanager.h"
+#include "displaycontrol/protocoldevicedisplaymanager_p.h"
+#include "displaycontrol/datahelper/virtualentrydbhandler.h"
+#include "displaycontrol/info/protocolvirtualentryentity.h"
+#include "displaycontrol/menu/virtualentrymenuscene.h"
+#include "displaycontrol/utilities/protocoldisplayutilities.h"
+#include "typedefines.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/base/device/deviceutils.h>
+
+#include <dfm-framework/event/event.h>
+
+#include <QObject>
+#include <QUrl>
+#include <QVariant>
+#include <QString>
+#include <QList>
+
+DPSMBBROWSER_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_ProtocolDeviceDisplayManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&ProtocolDeviceDisplayManagerPrivate::init, [] { __DBG_STUB_INVOKE__ });
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ProtocolDeviceDisplayManager, Instance)
+{
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance());
+    EXPECT_EQ(ProtocolDeviceDisplayManager::instance(), ProtocolDeviceDisplayManager::instance());
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, DisplayMode)
+{
+    EXPECT_EQ(SmbDisplayMode::kSeperate, ProtocolDeviceDisplayManager::instance()->displayMode());
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->displayMode = SmbDisplayMode::kAggregation);
+    EXPECT_EQ(SmbDisplayMode::kAggregation, ProtocolDeviceDisplayManager::instance()->displayMode());
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->displayMode = SmbDisplayMode::kSeperate);
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, IsShowOfflineItem)
+{
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->isShowOfflineItem());
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->showOffline = true);
+    EXPECT_TRUE(ProtocolDeviceDisplayManager::instance()->isShowOfflineItem());
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->showOffline = false);
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, HookItemInsert)
+{
+    bool support = false;
+
+    typedef bool (ProtocolDeviceDisplayManagerPrivate::*IsSupportVEntry)(const QUrl &);
+    auto func = static_cast<IsSupportVEntry>(&ProtocolDeviceDisplayManagerPrivate::isSupportVEntry);
+    stub.set_lamda(func, [&] { __DBG_STUB_INVOKE__ return support; });
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->hookItemInsert(QUrl::fromLocalFile("/home")));
+    support = true;
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->hookItemInsert(QUrl::fromLocalFile("/home")));
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->displayMode = SmbDisplayMode::kAggregation);
+    stub.set_lamda(ui_ventry_calls::addAggregatedItemForSeperatedOnlineItem, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_TRUE(ProtocolDeviceDisplayManager::instance()->hookItemInsert(QUrl::fromLocalFile("/home")));
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, HookItemsFilter)
+{
+    SmbDisplayMode mode = SmbDisplayMode::kSeperate;
+    stub.set_lamda(&ProtocolDeviceDisplayManager::displayMode, [&] { __DBG_STUB_INVOKE__ return mode; });
+    stub.set_lamda(&ProtocolDeviceDisplayManager::isShowOfflineItem, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(ui_ventry_calls::addSeperatedOfflineItems, [] { __DBG_STUB_INVOKE__ });
+    QList<QUrl> lst;
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->hookItemsFilter(&lst));
+
+    mode = SmbDisplayMode::kAggregation;
+    stub.set_lamda(&ProtocolDeviceDisplayManagerPrivate::removeAllSmb, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ui_ventry_calls::addAggregatedItems, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_TRUE(ProtocolDeviceDisplayManager::instance()->hookItemsFilter(&lst));
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, OnDevMounted)
+{
+    bool isSamba = false;
+    stub.set_lamda(&ProtocolUtils::isSMBFile, [&] { __DBG_STUB_INVOKE__ return isSamba; });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevMounted("1234", "1234"));
+
+    isSamba = true;
+    bool showOffline = false;
+    stub.set_lamda(&ProtocolDeviceDisplayManager::isShowOfflineItem, [&] { __DBG_STUB_INVOKE__ return showOffline; });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevMounted("1234", "1234"));
+
+    showOffline = true;
+    stub.set_lamda(computer_sidebar_event_calls::callItemRemove, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&VirtualEntryDbHandler::saveAggregatedAndSperated, [] { __DBG_STUB_INVOKE__ });
+    typedef QString (*GetName)(const QUrl &);
+    auto f = static_cast<GetName>(protocol_display_utilities::getDisplayNameOf);
+    stub.set_lamda(f, [] { __DBG_STUB_INVOKE__ return "Hello"; });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevMounted("1234", "1234"));
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, OnDevUnmounted)
+{
+    bool isSamba = false;
+    stub.set_lamda(&ProtocolUtils::isSMBFile, [&] { __DBG_STUB_INVOKE__ return isSamba; });
+    bool showOffline = true;
+    stub.set_lamda(&ProtocolDeviceDisplayManager::isShowOfflineItem, [&] { __DBG_STUB_INVOKE__ return showOffline; });
+    SmbDisplayMode mode = SmbDisplayMode::kSeperate;
+    stub.set_lamda(&ProtocolDeviceDisplayManager::displayMode, [&] { __DBG_STUB_INVOKE__ return mode; });
+
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevUnmounted("1234"));
+
+    isSamba = true;
+    showOffline = true;
+    mode = SmbDisplayMode::kSeperate;
+    typedef QString (*GetStdSmbPath)(const QString &);
+    auto func = static_cast<GetStdSmbPath>(protocol_display_utilities::getStandardSmbPath);
+    stub.set_lamda(func, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4"; });
+    bool hasOffline = false;
+    stub.set_lamda(&VirtualEntryDbHandler::hasOfflineEntry, [&] { __DBG_STUB_INVOKE__ return hasOffline; });
+    stub.set_lamda(computer_sidebar_event_calls::callItemAdd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevUnmounted("1234"));
+    hasOffline = true;
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevUnmounted("1234"));
+
+    mode = SmbDisplayMode::kAggregation;
+    showOffline = true;
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevUnmounted("1234"));
+
+    showOffline = false;
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://2.3.4.5" }; });
+    stub.set_lamda(protocol_display_utilities::getStandardSmbPaths, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://2.3.4.5" }; });
+    stub.set_lamda(computer_sidebar_event_calls::callItemRemove, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevUnmounted("smb://1.2.3.4"));
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDevUnmounted("smb://2.3.4.5"));
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, OnDConfigChanged)
+{
+    stub.set_lamda(&DConfigManager::value, [] { __DBG_STUB_INVOKE__ return false; });
+    stub.set_lamda(&ProtocolDeviceDisplayManagerPrivate::onShowOfflineChanged, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDConfigChanged("aaa", "bbb"));
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onDConfigChanged("org.deepin.dde.file-manager", "dfm.samba.permanent"));
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->d->showOffline);
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, OnJsonConfigChanged)
+{
+    stub.set_lamda(&ProtocolDeviceDisplayManagerPrivate::onDisplayModeChanged, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onJsonConfigChanged("a", "b", "c"));
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onJsonConfigChanged("GenericAttribute", "MergeTheEntriesOfSambaSharedFolders", "c"));
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onJsonConfigChanged("GenericAttribute", "MergeTheEntriesOfSambaSharedFolders", true));
+    EXPECT_EQ(SmbDisplayMode::kAggregation, ProtocolDeviceDisplayManager::instance()->d->displayMode);
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManager, OnMenuSceneAdded)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString, const QString &);
+    auto func = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(func, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onMenuSceneAdded("hello"));
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->onMenuSceneAdded("ComputerMenu"));
+}
+
+class UT_ProtocolDeviceDisplayManagerPrivate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&DConfigManager::value, [] { __DBG_STUB_INVOKE__ return false; });
+
+        typedef QVariant (Settings::*Value)(const QString &, const QString &, const QVariant &) const;
+        auto func = static_cast<Value>(&Settings::value);
+        stub.set_lamda(func, [] { __DBG_STUB_INVOKE__ return true; });
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ProtocolDeviceDisplayManagerPrivate, Init)
+{
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance());
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->init());
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManagerPrivate, OnDisplayModeChanged)
+{
+    stub.set_lamda(computer_sidebar_event_calls::callComputerRefresh, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->onDisplayModeChanged());
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManagerPrivate, OnShowOfflineChanged)
+{
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4", "smb://2.3.4.5" }; });
+    ProtocolDeviceDisplayManager::instance()->d->showOffline = true;
+    stub.set_lamda(&VirtualEntryDbHandler::saveAggregatedAndSperated, [] { __DBG_STUB_INVOKE__ });
+
+    typedef QString (*GetName)(const QString &);
+    auto f = static_cast<GetName>(protocol_display_utilities::getDisplayNameOf);
+    stub.set_lamda(f, [] { __DBG_STUB_INVOKE__ return "Hello"; });
+
+    f = static_cast<GetName>(protocol_display_utilities::getStandardSmbPath);
+    stub.set_lamda(f, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4"; });
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->onShowOfflineChanged());
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManagerPrivate, IsSupportVEntry)
+{
+    ProtocolDeviceDisplayManager::instance()->d->showOffline = false;
+    ProtocolDeviceDisplayManager::instance()->d->displayMode = SmbDisplayMode::kSeperate;
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->d->isSupportVEntry(QUrl::fromLocalFile("/home")));
+
+    ProtocolDeviceDisplayManager::instance()->d->showOffline = true;
+    stub.set_lamda(&ProtocolUtils::isSMBFile, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->d->isSupportVEntry(QUrl::fromLocalFile("/home")));
+
+    stub.set_lamda(&ProtocolUtils::isSMBFile, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_FALSE(ProtocolDeviceDisplayManager::instance()->d->isSupportVEntry(QUrl::fromLocalFile("/home")));
+
+    EXPECT_TRUE(ProtocolDeviceDisplayManager::instance()->d->isSupportVEntry(QUrl("entry:///home.protodev")));
+}
+
+TEST_F(UT_ProtocolDeviceDisplayManagerPrivate, RemoveAllSmb)
+{
+    bool support = false;
+    typedef bool (ProtocolDeviceDisplayManagerPrivate::*Support)(const QUrl &);
+    auto func = static_cast<Support>(&ProtocolDeviceDisplayManagerPrivate::isSupportVEntry);
+    stub.set_lamda(func, [&] { __DBG_STUB_INVOKE__ return support; });
+    QList<QUrl> urls { QUrl::fromLocalFile("/home") };
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->removeAllSmb(&urls));
+    EXPECT_TRUE(urls.count() == 1);
+
+    support = true;
+    EXPECT_NO_FATAL_FAILURE(ProtocolDeviceDisplayManager::instance()->d->removeAllSmb(&urls));
+    EXPECT_TRUE(urls.count() == 0);
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_protocoldisplayutilities.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_protocoldisplayutilities.cpp
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "displaycontrol/utilities/protocoldisplayutilities.h"
+#include "displaycontrol/datahelper/virtualentrydbhandler.h"
+#include "displaycontrol/protocoldevicedisplaymanager.h"
+#include "displaycontrol/info/protocolvirtualentryentity.h"
+
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/file/entry/entryfileinfo.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-framework/event/event.h>
+#include <dfm-base/base/schemefactory.h>
+
+#include <QString>
+#include <QUrl>
+#include <QVariantMap>
+#include <QList>
+
+DPSMBBROWSER_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_ProtocolDisplayUtilities : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ProtocolDeviceDisplayManager::instance();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ProtocolDisplayUtilities, PDU_MakeVEntry)
+{
+    QString uri = "smb://1.2.3.4/hello/world";
+    QUrl url;
+    url.setScheme("entry");
+    url.setPath(uri + ".ventry");
+
+    EXPECT_EQ(url, protocol_display_utilities::makeVEntryUrl(uri));
+    url.setScheme("file");
+    EXPECT_NE(url, protocol_display_utilities::makeVEntryUrl(uri));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, PDU_GetMountedSmb)
+{
+    stub.set_lamda(&DeviceProxyManager::getAllProtocolIds, [] {
+        __DBG_STUB_INVOKE__
+        return QStringList { "smb://1.2.3.4/hello", "ftp://1.2.3.4" };
+    });
+
+    QStringList ret = protocol_display_utilities::getMountedSmb();
+    EXPECT_TRUE(ret.count() == 1);
+    EXPECT_TRUE(ret.first() == "smb://1.2.3.4/hello");
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, PDU_GetStandardSmbPaths)
+{
+    QString (*getStdSmbPath_QString)(const QString &) = protocol_display_utilities::getStandardSmbPath;
+    stub.set_lamda(getStdSmbPath_QString, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4/hello"; });
+
+    QStringList cases { "1234", "12344", "smb" };
+    EXPECT_EQ(cases.count(), protocol_display_utilities::getStandardSmbPaths(cases).count());
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, PDU_GetSmbHostPath)
+{
+    QString (*getStdSmbPath_QString)(const QString &) = protocol_display_utilities::getStandardSmbPath;
+    stub.set_lamda(getStdSmbPath_QString, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4/hello"; });
+
+    EXPECT_EQ("smb://1.2.3.4", protocol_display_utilities::getSmbHostPath("xxxx"));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, PDU_GetStandardSmbPath)
+{
+    QUrl u("entry://smb://1.2.3.4/hello.ventry");
+    EXPECT_EQ("", protocol_display_utilities::getStandardSmbPath(u));
+
+    u.setPath("smb://1.2.3.4/hello.protodev");
+    QString (*getStdSmbPath_QString)(const QString &) = protocol_display_utilities::getStandardSmbPath;
+    stub.set_lamda(getStdSmbPath_QString, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4/hello"; });
+    EXPECT_EQ("smb://1.2.3.4/hello", protocol_display_utilities::getStandardSmbPath(u));
+    stub.clear();
+
+    EXPECT_EQ("1234", protocol_display_utilities::getStandardSmbPath("1234"));
+
+    stub.set_lamda(DeviceUtils::parseSmbInfo, [] { __DBG_STUB_INVOKE__ return false; });
+    QString input("file:///media/user/smbmounts/hello world");
+    EXPECT_EQ(input, protocol_display_utilities::getStandardSmbPath(input));
+
+    QString smbPort = "";
+    stub.set_lamda(DeviceUtils::parseSmbInfo, [&](const QString &, QString &host, QString &share, QString *port) {
+        __DBG_STUB_INVOKE__
+        host = "1.2.3.4";
+        share = "smb";
+        if (port) *port = smbPort;
+        return true;
+    });
+    EXPECT_EQ("smb://1.2.3.4/smb/", protocol_display_utilities::getStandardSmbPath(input));
+    smbPort = "448";
+    EXPECT_EQ("smb://1.2.3.4:448/smb/", protocol_display_utilities::getStandardSmbPath(input));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, PDU_GetDisplayNameOf)
+{
+    EntryEntityFactor::registCreator<ProtocolVirtualEntryEntity>(kComputerProtocolSuffix);
+    QString name("share on 1.2.3.4");
+    stub.set_lamda(&EntryFileInfo::displayName, [&] { __DBG_STUB_INVOKE__ return name; });
+    EXPECT_EQ(name, protocol_display_utilities::getDisplayNameOf("smb://1.2.3.4/share"));
+    EXPECT_EQ(name, protocol_display_utilities::getDisplayNameOf(QUrl("entry://smb://1.2.3.4/share.ventry")));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, PDU_HasMountedShareOf)
+{
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] {
+        __DBG_STUB_INVOKE__
+        return QStringList { "smb://1.2.3.4/share" };
+    });
+    EXPECT_TRUE(protocol_display_utilities::hasMountedShareOf("smb://1.2.3.4"));
+    EXPECT_FALSE(protocol_display_utilities::hasMountedShareOf("smb://2.3.4.5"));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, CSEC_CallItemAdd)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push1)(const QString &, const QString &,
+                                                        QString, const QUrl &, int &&, bool &&);
+    auto push1 = static_cast<Push1>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    typedef QVariant (dpf::EventChannelManager::*Push2)(const QString &, const QString &,
+                                                        QUrl, QVariantMap &);
+    auto push2 = static_cast<Push2>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(computer_sidebar_event_calls::callItemAdd(QUrl("entry://smb://1.2.3.4/smb.ventry")));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, CSEC_CallItemRemove)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push1)(const QString &, const QString &,
+                                                        QUrl);
+    auto push1 = static_cast<Push1>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(computer_sidebar_event_calls::callItemRemove(QUrl("entry://smb://1.2.3.4/smb.ventry")));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, CSEC_CallComputerRefresh)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push1)(const QString &, const QString &,
+                                                        QUrl);
+    auto push1 = static_cast<Push1>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    typedef QVariant (dpf::EventChannelManager::*Push2)(const QString &, const QString &);
+    auto push2 = static_cast<Push2>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    stub.set_lamda(&VirtualEntryDbHandler::allSmbIDs, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4/hello" }; });
+    EXPECT_NO_FATAL_FAILURE(computer_sidebar_event_calls::callComputerRefresh());
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, CSEC_CallForgetPasswd)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push1)(const QString &, const QString &,
+                                                        QString);
+    auto push1 = static_cast<Push1>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(computer_sidebar_event_calls::callForgetPasswd("smb://1.2.3.4/hello"));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, CSEC_SidebarMenuCall) { }
+
+TEST_F(UT_ProtocolDisplayUtilities, UVC_AddAggregatedItemForSeperatedOnlineItem)
+{
+    QString (*getStdSmbPath_QUrl)(const QUrl &) = protocol_display_utilities::getStandardSmbPath;
+    stub.set_lamda(getStdSmbPath_QUrl, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4/hello"; });
+    stub.set_lamda(protocol_display_utilities::getSmbHostPath, [] { __DBG_STUB_INVOKE__ return ""; });
+    EXPECT_NO_FATAL_FAILURE(ui_ventry_calls::addAggregatedItemForSeperatedOnlineItem(QUrl("entry://smb://1.2.3.4/share.ventry")));
+
+    stub.set_lamda(protocol_display_utilities::getSmbHostPath, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4"; });
+    stub.set_lamda(computer_sidebar_event_calls::callItemAdd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ui_ventry_calls::addAggregatedItemForSeperatedOnlineItem(QUrl("entry://smb://1.2.3.4/share.ventry")));
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, UVC_AddAggregatedItems)
+{
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4/hello" }; });
+    stub.set_lamda(protocol_display_utilities::getStandardSmbPaths, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4/hello" }; });
+    stub.set_lamda(&VirtualEntryDbHandler::allSmbIDs, [] { __DBG_STUB_INVOKE__ return QStringList { "" }; });
+    stub.set_lamda(computer_sidebar_event_calls::callItemAdd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ui_ventry_calls::addAggregatedItems());
+}
+
+TEST_F(UT_ProtocolDisplayUtilities, UVC_AddSeperatedOfflineItems)
+{
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4/hello" }; });
+    stub.set_lamda(protocol_display_utilities::getStandardSmbPaths, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4/hello" }; });
+    stub.set_lamda(&VirtualEntryDbHandler::allSmbIDs, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://2.3.4.5/share" }; });
+    stub.set_lamda(computer_sidebar_event_calls::callItemAdd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ui_ventry_calls::addSeperatedOfflineItems());
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_protocolvirtualentryentity.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_protocolvirtualentryentity.cpp
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "displaycontrol/info/protocolvirtualentryentity.h"
+#include "displaycontrol/datahelper/virtualentrydbhandler.h"
+
+#include <dfm-base/interfaces/abstractentryfileentity.h>
+
+#include <QUrl>
+#include <QString>
+#include <QIcon>
+#include <QVariantMap>
+
+DPSMBBROWSER_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class ProtocolVirtualEntryEntityTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        stub.clear();
+
+        entity = nullptr;
+
+        // 创建测试URL
+        testUrl = QUrl("smb://192.168.1.100/share.ventry");
+        testUrlWithSuffix = QUrl("smb://192.168.1.200/test.ventry");
+        testUrlWithoutSuffix = QUrl("smb://192.168.1.300/plain");
+
+        // Mock数据
+        mockDisplayName = "Test Virtual Entry";
+        mockFullSmbPath = "smb://192.168.1.100/share/full/path";
+        mockVEntryDbHandler = nullptr;
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        delete entity;
+        entity = nullptr;
+    }
+
+protected:
+    ProtocolVirtualEntryEntity *entity;
+    stub_ext::StubExt stub;
+
+    QUrl testUrl;
+    QUrl testUrlWithSuffix;
+    QUrl testUrlWithoutSuffix;
+
+    QString mockDisplayName;
+    QString mockFullSmbPath;
+    VirtualEntryDbHandler *mockVEntryDbHandler;
+};
+
+TEST_F(ProtocolVirtualEntryEntityTest, Constructor_ValidUrl_EntityCreated)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    EXPECT_NE(entity, nullptr);
+    EXPECT_EQ(entity->entryUrl, testUrl);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, Constructor_EmptyUrl_EntityCreated)
+{
+    QUrl emptyUrl;
+    entity = new ProtocolVirtualEntryEntity(emptyUrl);
+
+    EXPECT_NE(entity, nullptr);
+    EXPECT_EQ(entity->entryUrl, emptyUrl);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, DisplayName_CachedValue_ReturnsCachedName)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    // 模拟已缓存的显示名称
+    entity->datas.insert("ventry_display_name", mockDisplayName);
+
+    QString displayName = entity->displayName();
+
+    EXPECT_EQ(displayName, mockDisplayName);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, DisplayName_EmptyCacheValidDbHandler_ReturnsDbName)
+{
+    // 打桩VirtualEntryDbHandler::instance
+    static VirtualEntryDbHandler mockHandler;
+    mockVEntryDbHandler = &mockHandler;
+
+    stub.set_lamda(VirtualEntryDbHandler::instance, [&]() -> VirtualEntryDbHandler * {
+        __DBG_STUB_INVOKE__
+        return mockVEntryDbHandler;
+    });
+
+    // 打桩getDisplayNameOf方法
+    stub.set_lamda(ADDR(VirtualEntryDbHandler, getDisplayNameOf), [&](VirtualEntryDbHandler *, const QUrl &url) -> QString {
+        __DBG_STUB_INVOKE__
+        EXPECT_EQ(url, testUrl);
+        return mockDisplayName;
+    });
+
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    QString displayName = entity->displayName();
+
+    EXPECT_EQ(displayName, mockDisplayName);
+    // 验证结果被缓存
+    EXPECT_EQ(entity->datas.value("ventry_display_name").toString(), mockDisplayName);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, DisplayName_EmptyCacheEmptyDbResult_ReturnsEmptyString)
+{
+    // 打桩VirtualEntryDbHandler::instance
+    static VirtualEntryDbHandler mockHandler;
+    mockVEntryDbHandler = &mockHandler;
+
+    stub.set_lamda(VirtualEntryDbHandler::instance, [&]() -> VirtualEntryDbHandler * {
+        __DBG_STUB_INVOKE__
+        return mockVEntryDbHandler;
+    });
+
+    // 打桩getDisplayNameOf返回空字符串
+    stub.set_lamda(ADDR(VirtualEntryDbHandler, getDisplayNameOf), [&](VirtualEntryDbHandler *, const QUrl &url) -> QString {
+        __DBG_STUB_INVOKE__
+        return QString();
+    });
+
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    QString displayName = entity->displayName();
+
+    EXPECT_TRUE(displayName.isEmpty());
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, DisplayName_MultipleCalls_UsesCache)
+{
+    // 打桩VirtualEntryDbHandler::instance
+    static VirtualEntryDbHandler mockHandler;
+    mockVEntryDbHandler = &mockHandler;
+
+    stub.set_lamda(VirtualEntryDbHandler::instance, [&]() -> VirtualEntryDbHandler * {
+        __DBG_STUB_INVOKE__
+        return mockVEntryDbHandler;
+    });
+
+    int dbCallCount = 0;
+    stub.set_lamda(ADDR(VirtualEntryDbHandler, getDisplayNameOf), [&](VirtualEntryDbHandler *, const QUrl &url) -> QString {
+        __DBG_STUB_INVOKE__
+        dbCallCount++;
+        return mockDisplayName;
+    });
+
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    // 多次调用displayName
+    QString displayName1 = entity->displayName();
+    QString displayName2 = entity->displayName();
+    QString displayName3 = entity->displayName();
+
+    EXPECT_EQ(displayName1, mockDisplayName);
+    EXPECT_EQ(displayName2, mockDisplayName);
+    EXPECT_EQ(displayName3, mockDisplayName);
+    EXPECT_EQ(dbCallCount, 1);   // 数据库只应该被调用一次
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, Icon_AnyUrl_ReturnsRemoteFolderIcon)
+{
+    // 打桩QIcon::fromTheme
+    QIcon mockIcon;
+    stub.set_lamda(static_cast<QIcon (*)(const QString &)>(QIcon::fromTheme), [&](const QString &name) -> QIcon {
+        __DBG_STUB_INVOKE__
+        return mockIcon;
+    });
+
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    QIcon icon = entity->icon();
+
+    EXPECT_TRUE(icon.isNull());   // 验证图标获取
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, Icon_DifferentUrls_AlwaysReturnsSameIcon)
+{
+    // 打桩QIcon::fromTheme
+    QIcon mockIcon;
+    stub.set_lamda(static_cast<QIcon (*)(const QString &)>(QIcon::fromTheme), [&](const QString &name) -> QIcon {
+        __DBG_STUB_INVOKE__
+        EXPECT_EQ(name, "folder-remote");
+        return mockIcon;
+    });
+
+    ProtocolVirtualEntryEntity entity1(testUrl);
+    ProtocolVirtualEntryEntity entity2(testUrlWithSuffix);
+    ProtocolVirtualEntryEntity entity3(testUrlWithoutSuffix);
+
+    QIcon icon1 = entity1.icon();
+    QIcon icon2 = entity2.icon();
+    QIcon icon3 = entity3.icon();
+
+    // 所有实体都应该返回相同类型的图标
+    EXPECT_TRUE(true);   // 主要验证不会崩溃
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, Exists_AnyUrl_AlwaysReturnsTrue)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    bool exists = entity->exists();
+
+    EXPECT_TRUE(exists);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, Exists_EmptyUrl_AlwaysReturnsTrue)
+{
+    QUrl emptyUrl;
+    entity = new ProtocolVirtualEntryEntity(emptyUrl);
+
+    bool exists = entity->exists();
+
+    EXPECT_TRUE(exists);   // 虚拟条目总是存在
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, ShowProgress_AnyUrl_AlwaysReturnsFalse)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    bool showProgress = entity->showProgress();
+
+    EXPECT_FALSE(showProgress);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, ShowTotalSize_AnyUrl_AlwaysReturnsFalse)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    bool showTotalSize = entity->showTotalSize();
+
+    EXPECT_FALSE(showTotalSize);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, ShowUsageSize_AnyUrl_AlwaysReturnsFalse)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    bool showUsageSize = entity->showUsageSize();
+
+    EXPECT_FALSE(showUsageSize);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, Order_AnyUrl_ReturnsOrderSmb)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    AbstractEntryFileEntity::EntryOrder order = entity->order();
+
+    EXPECT_EQ(order, AbstractEntryFileEntity::EntryOrder::kOrderSmb);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, Order_DifferentUrls_AlwaysReturnsSameOrder)
+{
+    ProtocolVirtualEntryEntity entity1(testUrl);
+    ProtocolVirtualEntryEntity entity2(testUrlWithSuffix);
+    ProtocolVirtualEntryEntity entity3(testUrlWithoutSuffix);
+
+    AbstractEntryFileEntity::EntryOrder order1 = entity1.order();
+    AbstractEntryFileEntity::EntryOrder order2 = entity2.order();
+    AbstractEntryFileEntity::EntryOrder order3 = entity3.order();
+
+    EXPECT_EQ(order1, AbstractEntryFileEntity::EntryOrder::kOrderSmb);
+    EXPECT_EQ(order2, AbstractEntryFileEntity::EntryOrder::kOrderSmb);
+    EXPECT_EQ(order3, AbstractEntryFileEntity::EntryOrder::kOrderSmb);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, TargetUrl_RootPath_ReturnsOriginalUrl)
+{
+    QUrl rootUrl("smb://192.168.1.100/.ventry");
+
+    entity = new ProtocolVirtualEntryEntity(rootUrl);
+
+    EXPECT_NO_FATAL_FAILURE(entity->targetUrl());
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, TargetUrl_EmptyPath_ReturnsOriginalUrl)
+{
+    QUrl emptyPathUrl("smb://192.168.1.100.ventry");
+
+    entity = new ProtocolVirtualEntryEntity(emptyPathUrl);
+
+    QUrl targetUrl = entity->targetUrl();
+
+    // 对于空路径，应该返回处理后的URL
+    EXPECT_TRUE(targetUrl.isValid() || targetUrl.isEmpty());
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, TargetUrl_NonRootPath_ReturnsFullSmbPath)
+{
+    QUrl nonRootUrl("smb://192.168.1.100/share/subfolder.ventry");
+
+    // 打桩VirtualEntryDbHandler::instance
+    static VirtualEntryDbHandler mockHandler;
+    mockVEntryDbHandler = &mockHandler;
+
+    stub.set_lamda(VirtualEntryDbHandler::instance, [&]() -> VirtualEntryDbHandler * {
+        __DBG_STUB_INVOKE__
+        return mockVEntryDbHandler;
+    });
+
+    // 打桩getFullSmbPath方法
+    stub.set_lamda(ADDR(VirtualEntryDbHandler, getFullSmbPath), [&](VirtualEntryDbHandler *, const QString &path) {
+        __DBG_STUB_INVOKE__
+        return mockFullSmbPath;
+    });
+
+    entity = new ProtocolVirtualEntryEntity(nonRootUrl);
+
+    QUrl targetUrl = entity->targetUrl();
+
+    EXPECT_EQ(targetUrl.toString(), mockFullSmbPath);
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, TargetUrl_SuffixRemoval_CorrectlyRemovesSuffix)
+{
+    QUrl urlWithSuffix("smb://192.168.1.100/test.ventry");
+
+    // 打桩VirtualEntryDbHandler::instance
+    static VirtualEntryDbHandler mockHandler;
+    mockVEntryDbHandler = &mockHandler;
+
+    stub.set_lamda(VirtualEntryDbHandler::instance, [&]() -> VirtualEntryDbHandler * {
+        __DBG_STUB_INVOKE__
+        return mockVEntryDbHandler;
+    });
+
+    // 打桩getFullSmbPath方法
+    stub.set_lamda(ADDR(VirtualEntryDbHandler, getFullSmbPath), [&](VirtualEntryDbHandler *, const QString &path) -> QString {
+        __DBG_STUB_INVOKE__
+        // 验证后缀被正确移除
+        return mockFullSmbPath;
+    });
+
+    entity = new ProtocolVirtualEntryEntity(urlWithSuffix);
+
+    QUrl targetUrl = entity->targetUrl();
+
+    EXPECT_FALSE(targetUrl.toString().contains(".ventry"));   // 后缀应该被移除
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, MultipleMethodCalls_SameInstance_AllMethodsWork)
+{
+    // 打桩所有可能的外部调用
+    static VirtualEntryDbHandler mockHandler;
+    mockVEntryDbHandler = &mockHandler;
+
+    stub.set_lamda(VirtualEntryDbHandler::instance, [&]() -> VirtualEntryDbHandler * {
+        __DBG_STUB_INVOKE__
+        return mockVEntryDbHandler;
+    });
+
+    stub.set_lamda(ADDR(VirtualEntryDbHandler, getDisplayNameOf), [&](VirtualEntryDbHandler *, const QUrl &url) -> QString {
+        __DBG_STUB_INVOKE__
+        return mockDisplayName;
+    });
+
+    stub.set_lamda(ADDR(VirtualEntryDbHandler, getFullSmbPath), [&] {
+        __DBG_STUB_INVOKE__
+        return mockFullSmbPath;
+    });
+
+    stub.set_lamda(static_cast<QIcon (*)(const QString &)>(QIcon::fromTheme), [&](const QString &name) -> QIcon {
+        __DBG_STUB_INVOKE__
+        return QIcon();
+    });
+
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    // 调用所有公共方法
+    QString displayName = entity->displayName();
+    QIcon icon = entity->icon();
+    bool exists = entity->exists();
+    bool showProgress = entity->showProgress();
+    bool showTotalSize = entity->showTotalSize();
+    bool showUsageSize = entity->showUsageSize();
+    AbstractEntryFileEntity::EntryOrder order = entity->order();
+    QUrl targetUrl = entity->targetUrl();
+
+    // 验证所有调用都成功
+    EXPECT_EQ(displayName, mockDisplayName);
+    EXPECT_TRUE(exists);
+    EXPECT_FALSE(showProgress);
+    EXPECT_FALSE(showTotalSize);
+    EXPECT_FALSE(showUsageSize);
+    EXPECT_EQ(order, AbstractEntryFileEntity::EntryOrder::kOrderSmb);
+    EXPECT_FALSE(targetUrl.isEmpty());
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, InheritanceInterface_AbstractEntityInterface_AllMethodsImplemented)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    // 验证继承的接口都有正确的实现
+    AbstractEntryFileEntity *baseEntity = entity;
+
+    EXPECT_NE(baseEntity, nullptr);
+
+    // 通过基类指针调用虚函数
+    EXPECT_NO_THROW(baseEntity->displayName());
+    EXPECT_NO_THROW(baseEntity->icon());
+    EXPECT_NO_THROW(baseEntity->exists());
+    EXPECT_NO_THROW(baseEntity->showProgress());
+    EXPECT_NO_THROW(baseEntity->showTotalSize());
+    EXPECT_NO_THROW(baseEntity->showUsageSize());
+    EXPECT_NO_THROW(baseEntity->order());
+    EXPECT_NO_THROW(baseEntity->targetUrl());
+}
+
+TEST_F(ProtocolVirtualEntryEntityTest, DataMemberAccess_PublicDataMember_DataAccessible)
+{
+    entity = new ProtocolVirtualEntryEntity(testUrl);
+
+    // 访问公共数据成员
+    EXPECT_TRUE(entity->datas.isEmpty());   // 初始时应该为空
+
+    // 添加测试数据
+    entity->datas.insert("test_key", "test_value");
+    EXPECT_EQ(entity->datas.value("test_key").toString(), "test_value");
+
+    // 清空数据
+    entity->datas.clear();
+    EXPECT_TRUE(entity->datas.isEmpty());
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowser.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowser.cpp
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "smbbrowser.h"
+#include "utils/smbbrowserutils.h"
+#include "events/traversprehandler.h"
+#include "events/smbbrowsereventreceiver.h"
+#include "displaycontrol/protocoldevicedisplaymanager.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <plugins/common/dfmplugin-menu/menu_eventinterface_helper.h>
+
+#include <QMenu>
+#include <QAction>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_smbbrowser;
+
+class UT_SmbBrowser : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+
+private:
+    stub_ext::StubExt stub;
+    SmbBrowser ins;
+};
+
+TEST_F(UT_SmbBrowser, Initialize)
+{
+    stub.set_lamda(smb_browser_utils::bindSetting, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&SmbBrowser::bindWindows, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&SmbBrowser::followEvents, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ins.initialize());
+}
+
+TEST_F(UT_SmbBrowser, Start)
+{
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, QString);
+    typedef QVariant (EventChannelManager::*Push2)(const QString &, const QString &, QString, QString &&);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    auto push2 = static_cast<Push2>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    stub.set_lamda(ProtocolDeviceDisplayManager::instance, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    EXPECT_NO_FATAL_FAILURE(ins.start());
+}
+
+TEST_F(UT_SmbBrowser, ContextmenuHandle)
+{
+    auto exec_QPoint_QAction = static_cast<QAction *(QMenu::*)(const QPoint &, QAction *)>(&QMenu::exec);
+    QAction *act = new QAction("hello");
+    stub.set_lamda(exec_QPoint_QAction, [=] { __DBG_STUB_INVOKE__ return act; });
+
+    typedef bool (dpf::EventDispatcherManager::*Publish)(const QString &, const QString &, QString, QList<QUrl> &);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(SmbBrowser::contextMenuHandle(0, QUrl("network:///"), QPoint()));
+    EXPECT_NO_FATAL_FAILURE(SmbBrowser::contextMenuHandle(0, QUrl(), QPoint()));
+    delete act;
+}
+
+TEST_F(UT_SmbBrowser, OnWindowOpened)
+{
+    DFMBASE_USE_NAMESPACE
+    FileManagerWindow *win = new FileManagerWindow(QUrl::fromLocalFile("/hello/world"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [win] { __DBG_STUB_INVOKE__ return win; });
+    stub.set_lamda(&FileManagerWindow::sideBar, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<AbstractFrame *>(1); });
+    stub.set_lamda(&SmbBrowser::updateNeighborToSidebar, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(1));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(2));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(3));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(-10086));
+
+    stub.set_lamda(&FileManagerWindow::sideBar, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(1));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(2));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(3));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(-10086));
+    delete win;
+}
+
+TEST_F(UT_SmbBrowser, UpdateNeighborToSidebar)
+{
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, int, QUrl &&, QVariantMap &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.updateNeighborToSidebar());
+}
+
+TEST_F(UT_SmbBrowser, RegisterNetworkAccessPrehandler)
+{
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QString, PrehandlerFunc &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_NO_FATAL_FAILURE(ins.registerNetworkAccessPrehandler());
+}
+
+TEST_F(UT_SmbBrowser, REgisterNetworkToSearch)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString, QVariantMap &&);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(ins.registerNetworkToSearch());
+}
+
+TEST_F(UT_SmbBrowser, BindWindows)
+{
+    stub.set_lamda(&SmbBrowser::onWindowOpened, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList, [] { __DBG_STUB_INVOKE__ return QList<quint64> { 1, 2, 3 }; });
+    EXPECT_NO_FATAL_FAILURE(ins.bindWindows());
+}
+
+TEST_F(UT_SmbBrowser, FollowEvents)
+{
+    typedef bool (dpf::EventSequenceManager::*Follow1)(const QString &, const QString &,
+                                                       SmbBrowserEventReceiver *, decltype(&SmbBrowserEventReceiver::detailViewIcon));
+    auto follow1 = static_cast<Follow1>(&dpf::EventSequenceManager::follow);
+    stub.set_lamda(follow1, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef bool (dpf::EventSequenceManager::*Follow2)(const QString &, const QString &,
+                                                       SmbBrowserEventReceiver *, decltype(&SmbBrowserEventReceiver::cancelDelete));
+    auto follow2 = static_cast<Follow2>(&dpf::EventSequenceManager::follow);
+    stub.set_lamda(follow2, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(ins.followEvents());
+}
+
+TEST_F(UT_SmbBrowser, bug_181151_registerNetworkToSearch)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString, QVariantMap &);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [](EventChannelManager *&, const QString &, const QString &, QString, QVariantMap &property) {
+        EXPECT_TRUE(property.contains("Property_Key_DisableSearch"));
+        EXPECT_TRUE(property["Property_Key_DisableSearch"].toBool() == true);
+        __DBG_STUB_INVOKE__ return QVariant();
+    });
+
+    ins.registerNetworkToSearch();
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowsereventcaller.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowsereventcaller.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "events/smbbrowsereventcaller.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+
+DPSMBBROWSER_USE_NAMESPACE
+
+class UT_SmbBrowserEventCaller : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SmbBrowserEventCaller, SendOpenWindow)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(dpf::EventType, QUrl);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendOpenWindow({}));
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendOpenWindow(QUrl::fromLocalFile("/")));
+}
+
+TEST_F(UT_SmbBrowserEventCaller, SendOpenTab)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(dpf::EventType, quint64, const QUrl &);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendOpenTab(0, {}));
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendOpenTab(0, QUrl::fromLocalFile("/")));
+}
+
+TEST_F(UT_SmbBrowserEventCaller, SendCheckTabAddable)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendCheckTabAddable(0));
+    EXPECT_TRUE(SmbBrowserEventCaller::sendCheckTabAddable(0));
+}
+
+TEST_F(UT_SmbBrowserEventCaller, SendChangeCurrentUrl)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(dpf::EventType, quint64, const QUrl &);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendChangeCurrentUrl(0, {}));
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendChangeCurrentUrl(0, QUrl::fromLocalFile("/")));
+}
+
+TEST_F(UT_SmbBrowserEventCaller, SendShowPropertyDialog)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QList<QUrl>, QVariantHash &&);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendShowPropertyDialog({}));
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventCaller::sendShowPropertyDialog(QUrl::fromLocalFile("/")));
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowsereventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowsereventreceiver.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "events/smbbrowsereventreceiver.h"
+
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/systempathutil.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/dfm_global_defines.h>
+
+#include <QUrl>
+#include <QString>
+#include <QList>
+#include <QRegularExpression>
+#include <QObject>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_smbbrowser;
+
+class UT_SmbBrowserEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SmbBrowserEventReceiver, Instance)
+{
+    EXPECT_NO_FATAL_FAILURE(SmbBrowserEventReceiver::instance());
+}
+
+TEST_F(UT_SmbBrowserEventReceiver, DetailViewIcon)
+{
+    QString icon;
+    EXPECT_FALSE(SmbBrowserEventReceiver::instance()->detailViewIcon(QUrl::fromLocalFile("/"), &icon));
+    EXPECT_FALSE(SmbBrowserEventReceiver::instance()->detailViewIcon({}, nullptr));
+
+    QUrl u("network:///");
+    QString retIcon;
+    DFMBASE_USE_NAMESPACE
+    stub.set_lamda(&SystemPathUtil::systemPathIconName, [&] { __DBG_STUB_INVOKE__ return retIcon; });
+    EXPECT_FALSE(SmbBrowserEventReceiver::instance()->detailViewIcon(u, &icon));
+    retIcon = "test";
+    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->detailViewIcon(u, &icon));
+    EXPECT_EQ(icon, retIcon);
+}
+
+TEST_F(UT_SmbBrowserEventReceiver, CancelDelete)
+{
+    EXPECT_FALSE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl::fromLocalFile("/") }, QUrl("usershare:///hello")));
+    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("smb://1.2.3.4/hello") }, QUrl("usershare:///hello")));
+    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("ftp://1.2.3.4/hello") }, QUrl("usershare:///hello")));
+    EXPECT_TRUE(SmbBrowserEventReceiver::instance()->cancelDelete(0, QList<QUrl> { QUrl("sftp://1.2.3.4/hello") }, QUrl("usershare:///hello")));
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowsermenuscene.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowsermenuscene.cpp
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "menu/smbbrowsermenuscene.h"
+#include "private/smbbrowsermenuscene_p.h"
+#include "actioniddefines.h"
+#include "events/smbbrowsereventcaller.h"
+#include "utils/smbbrowserutils.h"
+#include "displaycontrol/utilities/protocoldisplayutilities.h"
+
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <plugins/common/dfmplugin-menu/menu_eventinterface_helper.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QMenu>
+#include <QAction>
+#include <QVariantHash>
+#include <QDir>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_smbbrowser;
+
+class UT_SmbBrowserMenuScene : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        scene = new SmbBrowserMenuScene();
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    SmbBrowserMenuScene *scene { nullptr };
+    SmbBrowserMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(UT_SmbBrowserMenuScene, Name)
+{
+    EXPECT_TRUE(scene->name() == "SmbBrowserMenu");
+}
+
+TEST_F(UT_SmbBrowserMenuScene, Initialize)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile("/hello/world"), QUrl::fromLocalFile("/i/can/eat/glass/without/hurt") };
+    EXPECT_FALSE(scene->initialize({ { "isEmptyArea", true } }));
+    EXPECT_FALSE(scene->initialize({ { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+    urls.takeFirst();
+    EXPECT_NO_FATAL_FAILURE(scene->initialize({ { "isEmptyArea", false },
+                                                { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+}
+
+TEST_F(UT_SmbBrowserMenuScene, Create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu menu;
+    EXPECT_NO_FATAL_FAILURE(scene->create(&menu));
+}
+
+TEST_F(UT_SmbBrowserMenuScene, UpdateState)
+{
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(nullptr));
+    QMenu menu;
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(&menu));
+}
+
+TEST_F(UT_SmbBrowserMenuScene, Triggered)
+{
+    DFMBASE_USE_NAMESPACE
+
+    EXPECT_FALSE(scene->triggered(nullptr));
+
+    auto act = new QAction("hello");
+    act->setProperty(ActionPropertyKey::kActionID, "hello");
+    d->predicateAction.insert("hello", act);
+    EXPECT_FALSE(scene->triggered(act));
+
+    d->selectFiles.append(QUrl::fromLocalFile("/hello/world"));
+
+    QList<bool> arg1 { false, true };
+    QList<dfmmount::DeviceError> arg2 { dfmmount::DeviceError::kNoError, dfmmount::DeviceError::kGIOErrorAlreadyMounted };
+    QList<QString> arg3 { "/hello/world", "" };
+    stub.set_lamda(&DeviceManager::mountNetworkDeviceAsync, [&](void *, const QString &, CallbackType1 cb, int) {
+        __DBG_STUB_INVOKE__
+        DFMMOUNT::OperationErrorInfo errInfo { arg2.first() };
+        cb(arg1.first(), errInfo, arg3.first());
+    });
+    stub.set_lamda(&DialogManager::showErrorDialogWhenOperateDeviceFailed, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(act));
+
+    arg1.takeFirst();
+    act->setProperty(ActionPropertyKey::kActionID, "open-smb");
+    d->predicateAction.insert("open-smb", act);
+    typedef bool (dpf::EventDispatcherManager::*Publish1)(int, quint64, QUrl &);
+    auto publish1 = static_cast<Publish1>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish1, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(act));
+
+    act->setProperty(ActionPropertyKey::kActionID, "open-smb-in-new-win");
+    d->predicateAction.insert("open-smb-in-new-win", act);
+    typedef bool (dpf::EventDispatcherManager::*Publish2)(int, QUrl);
+    auto publish2 = static_cast<Publish2>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish2, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(act));
+    delete act;
+}
+
+TEST_F(UT_SmbBrowserMenuScene, Scene)
+{
+    EXPECT_EQ(nullptr, scene->scene(nullptr));
+
+    auto act = new QAction("hello");
+    d->predicateAction.insert("hello", act);
+    EXPECT_STREQ(scene->scene(act)->metaObject()->className(), "dfmbase::AbstractMenuScene");
+
+    d->predicateAction.clear();
+    EXPECT_NO_FATAL_FAILURE(scene->scene(act));
+    delete act;
+    act = nullptr;
+}
+
+class UT_SmbBrowserMenuCreator : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+
+private:
+    stub_ext::StubExt stub;
+    SmbBrowserMenuCreator creator;
+};
+
+TEST_F(UT_SmbBrowserMenuCreator, Name)
+{
+    EXPECT_TRUE(SmbBrowserMenuCreator::name() == "SmbBrowserMenu");
+}
+
+TEST_F(UT_SmbBrowserMenuCreator, Create)
+{
+    auto scene = creator.create();
+    EXPECT_TRUE(scene != nullptr);
+    EXPECT_STREQ("dfmbase::AbstractMenuScene", scene->metaObject()->className());
+    EXPECT_NO_FATAL_FAILURE(delete scene);
+}
+
+class UT_SmbBrowserMenuScenePrivate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        scene = new SmbBrowserMenuScene();
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    SmbBrowserMenuScene *scene { nullptr };
+    SmbBrowserMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(UT_SmbBrowserMenuScenePrivate, ActUnmount)
+{
+    d->url = QUrl("smb://1.2.3.4/hello");
+    stub.set_lamda(smb_browser_utils::getDeviceIdByStdSmb, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4/hello"; });
+    stub.set_lamda(&dfmbase::DeviceManager::unmountProtocolDevAsync,
+                   [](void *, const QString &, const QVariantMap &, dfmbase::CallbackType2 cb) {
+                       __DBG_STUB_INVOKE__
+                       DFMMOUNT::OperationErrorInfo info;
+                       cb(false, info);
+                   });
+    stub.set_lamda(&dfmbase::DialogManager::showErrorDialogWhenOperateDeviceFailed, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(d->actUnmount());
+}
+
+TEST_F(UT_SmbBrowserMenuScenePrivate, ActMount)
+{
+    d->url = QUrl("smb://1.2.3.4/hello");
+    stub.set_lamda(&dfmbase::DeviceManager::mountNetworkDeviceAsync,
+                   [](void *, const QString &, dfmbase::CallbackType1 cb, int) {
+                       __DBG_STUB_INVOKE__
+                       cb(false, DFMMOUNT::OperationErrorInfo(), "");
+                   });
+    stub.set_lamda(&dfmbase::DialogManager::showErrorDialogWhenOperateDeviceFailed, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(d->actMount());
+}
+
+TEST_F(UT_SmbBrowserMenuScenePrivate, ActProperties)
+{
+    d->url = QUrl("smb://1.2.3.4/hello");
+    stub.set_lamda(smb_browser_utils::getDeviceIdByStdSmb, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4/hello"; });
+
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QList<QUrl>, QVariantHash &&);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(d->actProperties());
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowserutils.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_smbbrowserutils.cpp
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "utils/smbbrowserutils.h"
+#include "displaycontrol/utilities/protocoldisplayutilities.h"
+
+#include <dfm-base/settingdialog/settingjsongenerator.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/base/configs/settingbackend.cpp>
+
+#include <QUrl>
+#include <QIcon>
+#include <QMutex>
+#include <QDBusInterface>
+#include <QDBusPendingCall>
+
+using namespace dfmplugin_smbbrowser;
+
+class UT_SmbBrowserUtils : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_SmbBrowserUtils, NetworkScheme)
+{
+    EXPECT_TRUE(smb_browser_utils::networkScheme() == "network");
+}
+
+TEST_F(UT_SmbBrowserUtils, NetNeighborRootUrl)
+{
+    QUrl u;
+    u.setScheme("network");
+    u.setPath("/");
+    u.setHost("");
+    auto rootUrl = smb_browser_utils::netNeighborRootUrl();
+    EXPECT_EQ(rootUrl, u);
+    EXPECT_EQ(rootUrl.path(), "/");
+    EXPECT_EQ(rootUrl.scheme(), "network");
+}
+
+TEST_F(UT_SmbBrowserUtils, Icon)
+{
+    //    EXPECT_TRUE(ins->icon().themeName() == "network-server-symbolic");
+    EXPECT_NO_FATAL_FAILURE(smb_browser_utils::icon().themeName());
+}
+
+TEST_F(UT_SmbBrowserUtils, IsSmbMounted)
+{
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList(); });
+    stub.set_lamda(protocol_display_utilities::getStandardSmbPaths, [] { __DBG_STUB_INVOKE__ return QStringList(); });
+
+    EXPECT_FALSE(smb_browser_utils::isSmbMounted("smb://1.2.3.4/hello"));
+    EXPECT_FALSE(smb_browser_utils::isSmbMounted("smb://1.2.3.4/itsme/"));
+}
+
+TEST_F(UT_SmbBrowserUtils, GetDeviceIdByStdSmb)
+{
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList {
+                                                                       "file:///media/user/smbmounts/smb-share:host=1.2.3.4,share=hello"
+                                                                   }; });
+
+    QString (*getStdSmbPath_QString)(const QString &) = protocol_display_utilities::getStandardSmbPath;
+    stub.set_lamda(getStdSmbPath_QString, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4/hello/"; });
+
+    EXPECT_EQ("file:///media/user/smbmounts/smb-share:host=1.2.3.4,share=hello", smb_browser_utils::getDeviceIdByStdSmb("smb://1.2.3.4/hello"));
+    EXPECT_EQ("ftp://1.2.3.4", smb_browser_utils::getDeviceIdByStdSmb("ftp://1.2.3.4"));
+}
+
+TEST_F(UT_SmbBrowserUtils, IsServiceRuninig)
+{
+    EXPECT_FALSE(smb_browser_utils::isServiceRuning(""));
+    EXPECT_FALSE(smb_browser_utils::isServiceRuning("net"));
+    EXPECT_FALSE(smb_browser_utils::isServiceRuning("dde-file-manager"));
+
+    stub.set_lamda(&QDBusInterface::isValid, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(smb_browser_utils::isServiceRuning("smb"));
+    EXPECT_FALSE(smb_browser_utils::isServiceRuning("nmb"));
+
+    stub.reset(&QDBusInterface::isValid);
+    EXPECT_NO_FATAL_FAILURE(smb_browser_utils::isServiceRuning("smb"));
+    EXPECT_NO_FATAL_FAILURE(smb_browser_utils::isServiceRuning("nmb"));
+}
+
+TEST_F(UT_SmbBrowserUtils, StartService)
+{
+    EXPECT_FALSE(smb_browser_utils::startService(""));
+    EXPECT_FALSE(smb_browser_utils::startService("hello"));
+    EXPECT_FALSE(smb_browser_utils::startService("xxx..."));
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    //    stub.set_lamda(&QDBusAbstractInterface::asyncCall, [] { __DBG_STUB_INVOKE__ return QDBusPendingCall::fromError(QDBusError()); });
+    typedef QDBusPendingCall (QDBusAbstractInterface::*AsyncCall)(const QString &method,
+                                                                  const QVariant &arg1,
+                                                                  const QVariant &arg2,
+                                                                  const QVariant &arg3,
+                                                                  const QVariant &arg4,
+                                                                  const QVariant &arg5,
+                                                                  const QVariant &arg6,
+                                                                  const QVariant &arg7,
+                                                                  const QVariant &arg8);
+    stub.set_lamda(static_cast<AsyncCall>(&QDBusAbstractInterface::asyncCall), []() { __DBG_STUB_INVOKE__ return QDBusPendingCall::fromError(QDBusError()); });
+#else
+    stub.set_lamda(&QDBusAbstractInterface::doAsyncCall, [] { __DBG_STUB_INVOKE__ return QDBusPendingCall::fromError(QDBusError()); });
+#endif
+
+    stub.set_lamda(&QDBusPendingCall::waitForFinished, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&QDBusPendingCall::isValid, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(smb_browser_utils::startService("smb"));
+    EXPECT_TRUE(smb_browser_utils::startService("nmb"));
+    EXPECT_FALSE(smb_browser_utils::startService("nmbd"));
+}
+
+TEST_F(UT_SmbBrowserUtils, EnableServiceAsync)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    typedef QDBusPendingCall (QDBusAbstractInterface::*AsyncCall)(const QString &method,
+                                                                  const QVariant &arg1,
+                                                                  const QVariant &arg2,
+                                                                  const QVariant &arg3,
+                                                                  const QVariant &arg4,
+                                                                  const QVariant &arg5,
+                                                                  const QVariant &arg6,
+                                                                  const QVariant &arg7,
+                                                                  const QVariant &arg8);
+    stub.set_lamda(static_cast<AsyncCall>(&QDBusAbstractInterface::asyncCall), []() { __DBG_STUB_INVOKE__ return QDBusPendingCall::fromError(QDBusError()); });
+#else
+    stub.set_lamda(&QDBusAbstractInterface::doAsyncCall, [] { __DBG_STUB_INVOKE__ return QDBusPendingCall::fromError(QDBusError()); });
+#endif
+    EXPECT_NO_FATAL_FAILURE(smb_browser_utils::enableServiceAsync());
+}
+
+TEST_F(UT_SmbBrowserUtils, CheckAndEnableService)
+{
+    bool serviceRunning = true;
+    stub.set_lamda(smb_browser_utils::isServiceRuning, [&] { __DBG_STUB_INVOKE__ return serviceRunning; });
+    EXPECT_TRUE(smb_browser_utils::checkAndEnableService("smbd"));
+
+    serviceRunning = false;
+    bool startServiceResult = true;
+    stub.set_lamda(smb_browser_utils::startService, [&] { __DBG_STUB_INVOKE__ return startServiceResult; });
+    stub.set_lamda(smb_browser_utils::enableServiceAsync, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_TRUE(smb_browser_utils::checkAndEnableService("smb"));
+
+    startServiceResult = false;
+    EXPECT_FALSE(smb_browser_utils::checkAndEnableService("sb"));
+}
+
+TEST_F(UT_SmbBrowserUtils, BindSetting)
+{
+    Application app;
+    using GetOptFunc = std::function<QVariant()>;
+    using SaveOptFunc = std::function<void(const QVariant &)>;
+    auto accessor = static_cast<void (SettingBackend::*)(const QString &, GetOptFunc, SaveOptFunc)>(&SettingBackend::addSettingAccessor);
+    stub.set_lamda(accessor, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(smb_browser_utils::bindSetting());
+}
+
+TEST_F(UT_SmbBrowserUtils, NodeMutex)
+{
+    EXPECT_NO_FATAL_FAILURE(smb_browser_utils::nodesMutex());
+}
+
+TEST_F(UT_SmbBrowserUtils, ShareNodes)
+{
+    EXPECT_NO_FATAL_FAILURE(smb_browser_utils::shareNodes());
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_smbsharefileinfo.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_smbsharefileinfo.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "fileinfo/smbsharefileinfo.h"
+#include "private/smbsharefileinfo_p.h"
+#include "utils/smbbrowserutils.h"
+#include "typedefines.h"
+
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/mimetype/mimetypedisplaymanager.h>
+
+#include <QUrl>
+#include <QIcon>
+#include <QMutex>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_smbbrowser;
+
+class UT_SmbShareFileInfo : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        info = new SmbShareFileInfo(QUrl::fromLocalFile("/hello/world"));
+        d = info->d.data();
+        d->node = { "/hello/world", "HelloWorld", "folder-remote" };
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete info;
+        info = nullptr;
+    }
+
+private:
+    stub_ext::StubExt stub;
+
+    SmbShareFileInfo *info { nullptr };
+    SmbShareFileInfoPrivate *d { nullptr };
+};
+
+TEST_F(UT_SmbShareFileInfo, FileName)
+{
+    EXPECT_NO_FATAL_FAILURE(info->nameOf(dfmbase::NameInfoType::kFileName));
+    EXPECT_TRUE(info->nameOf(dfmbase::NameInfoType::kFileName) == "HelloWorld");
+}
+
+TEST_F(UT_SmbShareFileInfo, FileDisplayName)
+{
+    EXPECT_NO_FATAL_FAILURE(info->displayOf(dfmbase::DisPlayInfoType::kFileDisplayName));
+    EXPECT_TRUE(info->displayOf(dfmbase::DisPlayInfoType::kFileDisplayName) == "HelloWorld");
+}
+
+TEST_F(UT_SmbShareFileInfo, FileIcon)
+{
+    EXPECT_NO_FATAL_FAILURE(info->fileIcon());
+}
+
+TEST_F(UT_SmbShareFileInfo, IsDir)
+{
+    EXPECT_TRUE(info->isAttributes(dfmbase::OptInfoType::kIsDir));
+}
+
+TEST_F(UT_SmbShareFileInfo, IsReadable)
+{
+    EXPECT_TRUE(info->isAttributes(dfmbase::OptInfoType::kIsReadable));
+}
+
+TEST_F(UT_SmbShareFileInfo, IsWritable)
+{
+    EXPECT_TRUE(info->isAttributes(dfmbase::OptInfoType::kIsWritable));
+}
+
+TEST_F(UT_SmbShareFileInfo, CanDrag)
+{
+    EXPECT_FALSE(info->canAttributes(dfmbase::CanableInfoType::kCanDrag));
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_smbshareiterator.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_smbshareiterator.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "iterator/smbshareiterator.h"
+#include "private/smbshareiterator_p.h"
+#include "utils/smbbrowserutils.h"
+#include "typedefines.h"
+
+#include <dfm-io/denumerator.h>
+#include <dfm-io/dfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <QUrl>
+#include <QStringList>
+#include <QDir>
+#include <QDirIterator>
+#include <QMutex>
+
+using namespace dfmplugin_smbbrowser;
+
+class UT_SmbShareIterator : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        iter = new SmbShareIterator(QUrl::fromLocalFile("/"), {}, QDir::AllEntries);
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete iter;
+        iter = nullptr;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    SmbShareIterator *iter { nullptr };
+};
+
+TEST_F(UT_SmbShareIterator, Next)
+{
+    iter->d->rootUrl.setPort(448);
+    EXPECT_NO_FATAL_FAILURE(iter->next());
+    EXPECT_FALSE(iter->next().isValid());
+}
+
+TEST_F(UT_SmbShareIterator, HasNext)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->hasNext());
+    EXPECT_TRUE(iter->hasNext());
+}
+
+TEST_F(UT_SmbShareIterator, FileName)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->fileName());
+    EXPECT_TRUE(iter->fileName() == "");
+}
+
+TEST_F(UT_SmbShareIterator, FileUrl)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->fileUrl());
+    EXPECT_FALSE(iter->fileUrl().isValid());
+}
+
+TEST_F(UT_SmbShareIterator, FileInfo)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->fileInfo());
+    EXPECT_TRUE(iter->fileInfo() == nullptr);
+}
+
+TEST_F(UT_SmbShareIterator, Url)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->url());
+    EXPECT_FALSE(iter->url().isValid());
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_traversprehandler.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_traversprehandler.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "events/traversprehandler.h"
+#include "utils/smbbrowserutils.h"
+#include "displaycontrol/utilities/protocoldisplayutilities.h"
+#include "displaycontrol/datahelper/virtualentrydbhandler.h"
+#include "displaycontrol/protocoldevicedisplaymanager.h"
+
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/localfilewatcher.h>
+#include <dfm-base/file/local/localdiriterator.h>
+
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+#include <QString>
+#include <QTimer>
+#include <QDBusInterface>
+#include <QNetworkInterface>
+#include <functional>
+
+DPSMBBROWSER_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_TraversPrehandler : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_TraversPrehandler, NetworkAccessPrehandler)
+{
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::networkAccessPrehandler(0, QUrl::fromLocalFile("/"), nullptr));
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::networkAccessPrehandler(0, {}, nullptr));
+
+    stub.set_lamda(travers_prehandler::doChangeCurrentUrl, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(travers_prehandler::onSmbRootMounted, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&dfmbase::DialogManager::showErrorDialogWhenOperateDeviceFailed, [] { __DBG_STUB_INVOKE__ });
+
+    int type = 0;
+    stub.set_lamda(&dfmbase::DeviceManager::mountNetworkDeviceAsync, [&](void *, const QString &, dfmbase::CallbackType1 cb, int) {
+        if (type == 0 && cb)
+            cb(false, DFMMOUNT::OperationErrorInfo(), "/");
+        else if (type == 1 && cb)
+            cb(true, DFMMOUNT::OperationErrorInfo(), "");
+        else if (type == 2 && cb)
+            cb(false, DFMMOUNT::OperationErrorInfo(), "");
+    });
+
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::networkAccessPrehandler(0, QUrl("smb://1.2.3.4/hello/world"), nullptr));
+    type = 1;
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::networkAccessPrehandler(0, QUrl("smb://1.2.3.4/hello/world"), nullptr));
+    type = 2;
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::networkAccessPrehandler(0, QUrl("smb://1.2.3.4/hello/world"), nullptr));
+}
+
+TEST_F(UT_TraversPrehandler, SmbAccessPrehandler)
+{
+    QUrl u;
+    u.setScheme("smb");
+    u.setHost("localhost");
+
+    bool serviceValid = false;
+    stub.set_lamda(smb_browser_utils::checkAndEnableService, [&] { __DBG_STUB_INVOKE__ return serviceValid; });
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(travers_prehandler::networkAccessPrehandler, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::smbAccessPrehandler(0, QUrl("smb://localhost/share"), nullptr));
+    serviceValid = true;
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::smbAccessPrehandler(0, QUrl("smb://localhost/share"), nullptr));
+}
+
+TEST_F(UT_TraversPrehandler, DoChangeCurrentUrl)
+{
+    DFMBASE_USE_NAMESPACE
+    UrlRoute::regScheme("file", "/");
+    InfoFactory::regClass<SyncFileInfo>("file");
+    DirIteratorFactory::regClass<LocalDirIterator>("file");
+    WatcherFactory::regClass<LocalFileWatcher>("file");
+
+    typedef bool (dpf::EventDispatcherManager::*Publish)(dpf::EventType, quint64, QUrl &);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, quint64, const QUrl &);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::doChangeCurrentUrl(0, "", "", {}));
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::doChangeCurrentUrl(0, "/home", "", QUrl::fromLocalFile("/")));
+}
+
+TEST_F(UT_TraversPrehandler, OnSmbRootMounted)
+{
+    bool showOffline = false;
+    int mode = 0;
+    stub.set_lamda(&ProtocolDeviceDisplayManager::isShowOfflineItem, [&] { __DBG_STUB_INVOKE__ return showOffline; });
+    stub.set_lamda(&ProtocolDeviceDisplayManager::displayMode, [&] { __DBG_STUB_INVOKE__ return SmbDisplayMode(mode); });
+    stub.set_lamda(&VirtualEntryDbHandler::saveData, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(protocol_display_utilities::makeVEntryUrl, [] { __DBG_STUB_INVOKE__ return QUrl(); });
+    stub.set_lamda(computer_sidebar_event_calls::callItemAdd, [] { __DBG_STUB_INVOKE__ });
+
+    auto after = [] {};
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::onSmbRootMounted("", after));
+    showOffline = true;
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::onSmbRootMounted("", after));
+    mode = 1;
+    EXPECT_NO_FATAL_FAILURE(travers_prehandler::onSmbRootMounted("", after));
+}
+
+class UT_PrehandlerUtils : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_PrehandlerUtils, SplitMountSource)
+{
+    EXPECT_EQ("hello", prehandler_utils::splitMountSource("hello"));
+    QString sub;
+    EXPECT_EQ("smb://1.2.3.4/hello", prehandler_utils::splitMountSource("smb://1.2.3.4/hello/", &sub));
+    EXPECT_TRUE(sub.isEmpty());
+
+    sub.clear();
+    EXPECT_EQ("smb://1.2.3.4/hello", prehandler_utils::splitMountSource("smb://1.2.3.4/hello/world", &sub));
+    EXPECT_EQ("world", sub);
+
+    sub.clear();
+    EXPECT_NE("smb://1.2.3.4/helloworld", prehandler_utils::splitMountSource("smb://1.2.3.4/hello/", &sub));
+    EXPECT_NE("smb://1.2.3.4worldhello", prehandler_utils::splitMountSource("smb://1.2.3.4/hello/world", &sub));
+
+    sub.clear();
+    EXPECT_TRUE(prehandler_utils::splitMountSource("").isEmpty());
+    EXPECT_NO_FATAL_FAILURE(prehandler_utils::splitMountSource("", nullptr));
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_virtualentrydata.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_virtualentrydata.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "displaycontrol/datahelper/virtualentrydata.h"
+
+#include <QString>
+#include <QUrl>
+#include <QVariantMap>
+#include <QDateTime>
+
+DPSMBBROWSER_USE_NAMESPACE
+
+class UT_VirtualEntryData : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VirtualEntryData, AllInOne)
+{
+    VirtualEntryData d1, d2;
+    EXPECT_NO_FATAL_FAILURE(d1 = d2);
+
+    EXPECT_NO_FATAL_FAILURE(d1.setDisplayName("hello"));
+    EXPECT_NO_FATAL_FAILURE(d1.setKey("key"));
+    EXPECT_NO_FATAL_FAILURE(d1.setHost("1.2.3.4"));
+    EXPECT_NO_FATAL_FAILURE(d1.setProtocol("smb"));
+    EXPECT_NO_FATAL_FAILURE(d1.setPort(139));
+    EXPECT_NO_FATAL_FAILURE(d1.setTargetPath("path"));
+    EXPECT_EQ(d1.getDisplayName(), "hello");
+    EXPECT_EQ(d1.getHost(), "1.2.3.4");
+    EXPECT_EQ(d1.getProtocol(), "smb");
+    EXPECT_EQ(d1.getPort(), 139);
+    EXPECT_EQ(d1.getKey(), "key");
+    EXPECT_EQ(d1.getTargetPath(), "path");
+
+    VirtualEntryData d3("smb://1.2.3.4");
+    EXPECT_EQ(d3.getDisplayName(), "1.2.3.4");
+    EXPECT_EQ(d3.getHost(), "1.2.3.4");
+    EXPECT_EQ(d3.getProtocol(), "smb");
+    EXPECT_EQ(d3.getPort(), -1);
+
+    VirtualEntryData d4(d3);
+    EXPECT_EQ(d4.getDisplayName(), "1.2.3.4");
+    EXPECT_EQ(d4.getHost(), "1.2.3.4");
+    EXPECT_EQ(d4.getProtocol(), "smb");
+    EXPECT_EQ(d4.getPort(), -1);
+}

--- a/autotests/plugins/dfmplugin-smbbrowser/test_virtualentrydbhandler.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_virtualentrydbhandler.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "displaycontrol/datahelper/virtualentrydbhandler.h"
+#include "displaycontrol/datahelper/virtualentrydata.h"
+#include "displaycontrol/utilities/protocoldisplayutilities.h"
+
+#include <QVariantMap>
+#include <QString>
+#include <QUrl>
+#include <QStandardPaths>
+#include <QDir>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+DPSMBBROWSER_USE_NAMESPACE
+
+class VirtualEntryDbHandler_Stub : public QObject
+{
+public:
+    explicit VirtualEntryDbHandler_Stub(QObject *parent = nullptr)
+        : QObject(parent)
+    {
+        __DBG_STUB_INVOKE__
+    }
+};
+
+using namespace dfmplugin_smbbrowser;
+
+class UT_VirtualEntryDBHandler : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        VirtualEntryDbHandler::instance()->handler = new dfmbase::SqliteHandle("test");
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    static void SetUpTestCase()
+    {
+        DFMBASE_USE_NAMESPACE
+
+        // stub for Constructor
+        glob_stub().set(stub_ext::StubExt::get_ctor_addr<VirtualEntryDbHandler>(),
+                        stub_ext::StubExt::get_ctor_addr<VirtualEntryDbHandler_Stub>());
+
+        // stub for SqliteHandle::remove
+        typedef bool (SqliteHandle::*Remove1)(const VirtualEntryData &);
+        auto remove1 = static_cast<Remove1>(&SqliteHandle::remove<VirtualEntryData>);
+        glob_stub().set_lamda(remove1, [] { __DBG_STUB_INVOKE__ return true; });
+
+        typedef bool (SqliteHandle::*Remove2)(const Expression::Expr &);
+        auto remove2 = static_cast<Remove2>(&SqliteHandle::remove<VirtualEntryData>);
+        glob_stub().set_lamda(remove2, [] { __DBG_STUB_INVOKE__ return true; });
+
+        glob_stub().set_lamda(&SqliteHandle::insert<VirtualEntryData>, [] { __DBG_STUB_INVOKE__ return 0; });
+        glob_stub().set_lamda(&SqliteHandle::query<VirtualEntryData>, [] { __DBG_STUB_INVOKE__ return SqliteQueryable<VirtualEntryData>("test", "test"); });
+        glob_stub().set_lamda(&SqliteHandle::dropTable<VirtualEntryData>, [] { __DBG_STUB_INVOKE__ return true; });
+
+        typedef bool (SqliteHandle::*CreateTable)(const SqliteConstraint &, const SqliteConstraint &);
+        auto createTable = static_cast<CreateTable>(&SqliteHandle::createTable<VirtualEntryData>);
+        glob_stub().set_lamda(createTable, [] { __DBG_STUB_INVOKE__ return true; });
+    }
+
+    static void TearDownTestCase()
+    {
+        glob_stub().clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+
+    static stub_ext::StubExt &glob_stub()
+    {
+        static stub_ext::StubExt s;
+        return s;
+    }
+};
+
+TEST_F(UT_VirtualEntryDBHandler, Instance)
+{
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance());
+}
+
+TEST_F(UT_VirtualEntryDBHandler, ClearData)
+{
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->clearData());
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->clearData("smb://1.2.3.4/hello"));
+}
+
+TEST_F(UT_VirtualEntryDBHandler, RemoveData)
+{
+    stub.set_lamda(&VirtualEntryDbHandler::allSmbIDs,
+                   [](void *, QStringList *, QStringList *seperated) {
+                       __DBG_STUB_INVOKE__
+                       *seperated = QStringList { "smb://1.2.3.4/hello" };
+                       return QStringList {};
+                   });
+    stub.set_lamda(&protocol_display_utilities::getSmbHostPath, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4"; });
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->removeData("smb://1.2.3.4/hello"));
+}
+
+TEST_F(UT_VirtualEntryDBHandler, SaveAggregatedAndSeperated)
+{
+    stub.set_lamda(&protocol_display_utilities::getSmbHostPath, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4"; });
+    stub.set_lamda(&VirtualEntryDbHandler::saveData, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->saveAggregatedAndSperated("smb://1.2.3.4", "1.2.3.4"));
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->saveAggregatedAndSperated("", ""));
+}
+
+TEST_F(UT_VirtualEntryDBHandler, SaveData)
+{
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->saveData(VirtualEntryData()));
+}
+
+TEST_F(UT_VirtualEntryDBHandler, HasOfflineEntry)
+{
+    QStringList offlineEntry {};
+    stub.set_lamda(&VirtualEntryDbHandler::allSmbIDs, [&] { __DBG_STUB_INVOKE__ return offlineEntry; });
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->hasOfflineEntry("test"));
+    EXPECT_FALSE(VirtualEntryDbHandler::instance()->hasOfflineEntry("test"));
+
+    offlineEntry << "smb://1.2.3.4/hello";
+    EXPECT_TRUE(VirtualEntryDbHandler::instance()->hasOfflineEntry("smb://1.2.3.4/hello"));
+}
+
+TEST_F(UT_VirtualEntryDBHandler, AllSmbIDs)
+{
+    stub.set_lamda(&VirtualEntryDbHandler::virtualEntries,
+                   [] { __DBG_STUB_INVOKE__ return QList<QSharedPointer<VirtualEntryData>>(); });
+}
+
+TEST_F(UT_VirtualEntryDBHandler, GetDisplayNameOf)
+{
+    QUrl u;
+    u.setScheme("entry");
+    u.setPath("smb://1.2.3.4.ventry");
+    EXPECT_EQ("1.2.3.4", VirtualEntryDbHandler::instance()->getDisplayNameOf(u));
+    u = "entry://smb://1.2.3.4/hello.ventry";
+    EXPECT_EQ("", VirtualEntryDbHandler::instance()->getDisplayNameOf(u));
+}
+
+TEST_F(UT_VirtualEntryDBHandler, VirtualEntries)
+{
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->virtualEntries());
+    EXPECT_TRUE(VirtualEntryDbHandler::instance()->virtualEntries().count() == 0);
+}
+
+TEST_F(UT_VirtualEntryDBHandler, CheckDBExists)
+{
+    delete VirtualEntryDbHandler::instance()->handler;
+    stub.set_lamda(&dfmbase::SqliteConnectionPool::openConnection, [] { __DBG_STUB_INVOKE__ return QSqlDatabase(); });
+    bool dbValid = false;
+    stub.set_lamda(&QSqlDatabase::isValid, [&] { __DBG_STUB_INVOKE__ return dbValid; });
+    EXPECT_FALSE(VirtualEntryDbHandler::instance()->checkDbExists());
+
+    dbValid = true;
+    stub.set_lamda(&QSqlDatabase::close, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_TRUE(VirtualEntryDbHandler::instance()->checkDbExists());
+}
+
+TEST_F(UT_VirtualEntryDBHandler, CreateTable)
+{
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryDbHandler::instance()->createTable());
+    EXPECT_TRUE(VirtualEntryDbHandler::instance()->createTable());
+}
+
+// #include "ut_virtualentrydbhandler.moc"

--- a/autotests/plugins/dfmplugin-smbbrowser/test_virtualentrymenuscene.cpp
+++ b/autotests/plugins/dfmplugin-smbbrowser/test_virtualentrymenuscene.cpp
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "displaycontrol/menu/virtualentrymenuscene.h"
+#include "displaycontrol/menu/virtualentrymenuscene_p.h"
+#include "displaycontrol/datahelper/virtualentrydbhandler.h"
+#include "displaycontrol/utilities/protocoldisplayutilities.h"
+
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/widgets/filemanagerwindow.h>
+#include <dfm-base/interfaces/abstractmenuscene.h>
+
+#include <dfm-framework/event/event.h>
+
+#include <QMenu>
+#include <QAction>
+#include <QUrl>
+#include <QVariantHash>
+#include <QList>
+
+DPSMBBROWSER_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class UT_VirtualEntryMenuScene : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        scene = new VirtualEntryMenuScene();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    VirtualEntryMenuScene *scene { nullptr };
+};
+
+TEST_F(UT_VirtualEntryMenuScene, Name)
+{
+    EXPECT_EQ("VirtualEntry", scene->name());
+    EXPECT_NE("XXX", scene->name());
+}
+
+TEST_F(UT_VirtualEntryMenuScene, Initialize)
+{
+    QVariantHash params;
+    EXPECT_FALSE(scene->initialize(params));
+
+    QList<QUrl> urls { QUrl::fromLocalFile("/home") };
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(urls));
+
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto f = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(f, [] { __DBG_STUB_INVOKE__ return QVariant::fromValue<AbstractMenuScene *>(nullptr); });
+    EXPECT_FALSE(scene->initialize(params));
+
+    QUrl u;
+    u.setScheme("entry");
+    u.setPath("smb://1.2.3.4/share/.ventry");
+    urls = { u };
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(urls));
+    EXPECT_TRUE(scene->initialize(params));
+    EXPECT_EQ("smb://1.2.3.4/share/", scene->d->stdSmb);
+    EXPECT_TRUE(scene->d->seperatedEntrySelected);
+
+    u.setPath("smb://1.2.3.4.ventry");
+    urls = { u };
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(urls));
+    EXPECT_TRUE(scene->initialize(params));
+    EXPECT_EQ("smb://1.2.3.4", scene->d->stdSmb);
+    EXPECT_TRUE(scene->d->aggregatedEntrySelected);
+
+    u.setPath("/home.protodev");
+    urls = { u };
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(urls));
+    typedef QString (*GetPath)(const QString &);
+    auto ff = static_cast<GetPath>(protocol_display_utilities::getStandardSmbPath);
+    stub.set_lamda(ff, [] { __DBG_STUB_INVOKE__ return "hello"; });
+    EXPECT_FALSE(scene->initialize(params));
+
+    stub.set_lamda(ff, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4"; });
+    EXPECT_TRUE(scene->initialize(params));
+}
+
+TEST_F(UT_VirtualEntryMenuScene, Create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu menu;
+    scene->d->aggregatedEntrySelected = true;
+    bool hasMounted = false;
+    stub.set_lamda(protocol_display_utilities::hasMountedShareOf, [&] { __DBG_STUB_INVOKE__ return hasMounted; });
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::insertActionBefore, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_TRUE(scene->create(&menu));
+
+    scene->d->aggregatedEntrySelected = false;
+    scene->d->seperatedEntrySelected = true;
+    EXPECT_TRUE(scene->create(&menu));
+}
+
+TEST_F(UT_VirtualEntryMenuScene, UpdateState)
+{
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(nullptr));
+
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::setActionVisible, [] { __DBG_STUB_INVOKE__ });
+    QMenu menu;
+    scene->d->aggregatedEntrySelected = true;
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(&menu));
+
+    scene->d->aggregatedEntrySelected = false;
+    scene->d->seperatedEntrySelected = true;
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(&menu));
+}
+
+TEST_F(UT_VirtualEntryMenuScene, Triggered)
+{
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(nullptr));
+
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::actUnmountAggregatedItem, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::actForgetAggregatedItem, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::actRemoveVirtualEntry, [] { __DBG_STUB_INVOKE__ });
+
+    QAction act;
+    act.setProperty("actionID", "aggregated-unmount");
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(&act));
+
+    act.setProperty("actionID", "aggregated-forget");
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(&act));
+
+    act.setProperty("actionID", "virtual-entry-remove");
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(&act));
+}
+
+TEST_F(UT_VirtualEntryMenuScene, Scene)
+{
+    EXPECT_NO_FATAL_FAILURE(scene->scene(nullptr));
+    EXPECT_EQ(nullptr, scene->scene(nullptr));
+
+    QAction act;
+    scene->d->predicateAction.insert("test", &act);
+    EXPECT_EQ(scene, scene->scene(&act));
+
+    QAction act2;
+    EXPECT_NO_FATAL_FAILURE(scene->scene(&act2));
+}
+
+class UT_VirtualEntryMenuScenePrivate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        scene = new VirtualEntryMenuScene();
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    VirtualEntryMenuScene *scene { nullptr };
+    VirtualEntryMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, SetActionVisiable)
+{
+    EXPECT_NO_FATAL_FAILURE(d->setActionVisible(QStringList(), nullptr));
+
+    QMenu m;
+    m.addAction("hello");
+    EXPECT_NO_FATAL_FAILURE(d->setActionVisible(QStringList(), &m));
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, InsertActionBefore)
+{
+    QMenu m;
+    auto act = m.addAction("hello");
+    act->setProperty(ActionPropertyKey::kActionID, "hello");
+
+    EXPECT_NO_FATAL_FAILURE(d->insertActionBefore("test", "hello", &m));
+    EXPECT_TRUE(m.actions().count() == 2);
+
+    EXPECT_NO_FATAL_FAILURE(d->insertActionBefore("test", "xxx", &m));
+    EXPECT_TRUE(m.actions().count() == 3);
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, HookCptActions)
+{
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::actCptForget, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::actCptMount, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(d->hookCptActions(nullptr));
+
+    QAction act;
+    act.setProperty(ActionPropertyKey::kActionID, "computer-logout-and-forget-passwd");
+    EXPECT_NO_FATAL_FAILURE(d->hookCptActions(&act));
+    act.setProperty(ActionPropertyKey::kActionID, "computer-mount");
+    EXPECT_NO_FATAL_FAILURE(d->hookCptActions(&act));
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, ActUnmountAggregatedItem)
+{
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4" }; });
+    typedef QString (*GetPath)(const QString &);
+    auto f = static_cast<GetPath>(protocol_display_utilities::getStandardSmbPath);
+    stub.set_lamda(f, [] { __DBG_STUB_INVOKE__ return "smb://1.2.3.4"; });
+    stub.set_lamda(&DialogManager::showErrorDialogWhenOperateDeviceFailed, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::tryRemoveAggregatedEntry, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::gotoDefaultPageOnUnmount, [] { __DBG_STUB_INVOKE__ });
+
+    bool unmountResult = false;
+    stub.set_lamda(&DeviceManager::unmountProtocolDevAsync, [&](void *, const QString &, const QVariantMap &, CallbackType2 cb) {
+        __DBG_STUB_INVOKE__
+        if (cb) cb(unmountResult, DFMMOUNT::OperationErrorInfo());
+    });
+
+    EXPECT_NO_FATAL_FAILURE(d->actUnmountAggregatedItem(false));
+    unmountResult = true;
+    EXPECT_NO_FATAL_FAILURE(d->actUnmountAggregatedItem(true));
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, ActForgetAggregatedItem)
+{
+    stub.set_lamda(computer_sidebar_event_calls::callForgetPasswd, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::actUnmountAggregatedItem, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(d->actForgetAggregatedItem());
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, ActMountSeperatedItem)
+{
+    bool unmountResult = false;
+    stub.set_lamda(&DeviceManager::mountNetworkDeviceAsync, [&](void *, const QString &, CallbackType1 cb, int) {
+        __DBG_STUB_INVOKE__
+        if (cb) cb(unmountResult, DFMMOUNT::OperationErrorInfo(), "");
+    });
+    stub.set_lamda(&DialogManager::showErrorDialogWhenOperateDeviceFailed, [] { __DBG_STUB_INVOKE__ });
+
+    d->stdSmb = "smb://1.2.3.4/share///";
+    EXPECT_NO_FATAL_FAILURE(d->actMountSeperatedItem());
+}
+TEST_F(UT_VirtualEntryMenuScenePrivate, ActRemoveVirtualEntry) { }
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, ActCptMount)
+{
+    stub.set_lamda(&VirtualEntryMenuScenePrivate::actMountSeperatedItem, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(d->actCptMount());
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, ActCptForget)
+{
+    stub.set_lamda(&VirtualEntryDbHandler::removeData, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(d->actCptForget());
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, GotoDefaultPageOnUnmount)
+{
+    stub.set_lamda(&Application::appAttribute, [] { __DBG_STUB_INVOKE__ return QUrl::fromLocalFile("/home"); });
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList, [] { __DBG_STUB_INVOKE__ return QList<quint64> { 1 }; });
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<FileManagerWindow *>(1); });
+    stub.set_lamda(&FileManagerWindow::currentUrl, [] { __DBG_STUB_INVOKE__ return QUrl::fromLocalFile("/home"); });
+    typedef bool (dpf::EventDispatcherManager::*Publish)(dpf::EventType, quint64, QUrl &);
+    auto f = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(f, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(d->gotoDefaultPageOnUnmount());
+    d->stdSmb = "file:///home";
+    EXPECT_NO_FATAL_FAILURE(d->gotoDefaultPageOnUnmount());
+}
+
+TEST_F(UT_VirtualEntryMenuScenePrivate, TryRemoveAggregatedEntry)
+{
+    stub.set_lamda(&VirtualEntryDbHandler::removeData, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(protocol_display_utilities::getMountedSmb, [] { __DBG_STUB_INVOKE__ return QStringList { "smb://1.2.3.4" }; });
+    stub.set_lamda(protocol_display_utilities::makeVEntryUrl, [] { __DBG_STUB_INVOKE__ return QUrl(); });
+    stub.set_lamda(computer_sidebar_event_calls::callItemRemove, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryMenuScenePrivate::tryRemoveAggregatedEntry("smb://1.2.3.4", ""));
+    EXPECT_NO_FATAL_FAILURE(VirtualEntryMenuScenePrivate::tryRemoveAggregatedEntry("smb://3.4.5.6", ""));
+}


### PR DESCRIPTION
1. Introduced comprehensive unit tests for various components of the SMB browser plugin, including ProtocolDeviceDisplayManager, ProtocolDisplayUtilities, and VirtualEntryDBHandler.
2. Implemented tests for functionalities such as display mode handling, virtual entry management, and SMB share file information.
3. Enhanced test coverage for menu scene interactions and event handling within the SMB browser context.

Log: These additions aim to improve code reliability and facilitate future development by ensuring critical functionalities are well-tested.

## Summary by Sourcery

Introduce comprehensive unit tests for the SMB browser plugin to validate core functionality across entities, display managers, menu scenes, utilities, database handlers, event handling, prehandlers, file iterators, and the main browser component.

Tests:
- ProtocolVirtualEntryEntity tests cover construction, display name caching, icon retrieval, existence and ordering, target URL resolution, and inheritance compliance
- ProtocolDeviceDisplayManager tests cover singleton access, display modes, offline item visibility, item insertion/filtering, mount/unmount events, and configuration change handling
- ProtocolDisplayUtilities and smbbrowserutils tests cover VEntry URL creation, mounted share detection, path normalization, display name lookup, event call helpers, service management, and settings binding
- VirtualEntryMenuScene and SmbBrowserMenuScene tests cover initialization, menu construction, state updates, action triggering, and scene lookup
- VirtualEntryDbHandler tests cover instance access, clearing and removing data, saving aggregated entries, offline entry checks, database existence, and table creation
- TraversPrehandler tests cover network and SMB access handlers, URL change publishing, root mount handling, and mount source splitting utilities
- SmbBrowser tests cover initialization, startup event binding, context menu handling, window opening logic, neighbor sidebar updates, and event registration
- SmbBrowserEventCaller and SmbBrowserEventReceiver tests cover event dispatch and reception for window/tab opening, property dialogs, icon lookup, and delete cancellation
- SmbShareFileInfo and SmbShareIterator tests validate file information retrieval, attribute flags, iterator navigation, and file info object creation
- VirtualEntryData tests cover setter/getter functionality, assignment, and URL-based construction