### PR TITLE
fix: optimize PPTX thumbnail and MIME type handling

### DIFF
--- a/autotests/services/mountcontrol/test_cifsmounthelper.cpp
+++ b/autotests/services/mountcontrol/test_cifsmounthelper.cpp
@@ -330,18 +330,13 @@ TEST_F(UT_CifsMountHelper, Unmount_MountNotExist_ReturnsError)
 
 TEST_F(UT_CifsMountHelper, Unmount_NotOwnerWithoutAuth_ReturnsError)
 {
-    // Test unmount when not owner and no auth
+    // Test unmount when not owner - the method directly returns error without separate auth check
     QString path = "smb://192.168.1.100/share";
     QVariantMap opts;
 
     stub.set_lamda(&CifsMountHelper::checkMount, [](CifsMountHelper *, const QString &, QString &) {
         __DBG_STUB_INVOKE__
         return CifsMountHelper::kNotOwner;
-    });
-
-    stub.set_lamda(&CifsMountHelper::checkAuth, [](CifsMountHelper *) {
-        __DBG_STUB_INVOKE__
-        return false;
     });
 
     QVariantMap result = getHelper()->unmount(path, opts);

--- a/autotests/services/mountcontrol/test_mountcontroldbus.cpp
+++ b/autotests/services/mountcontrol/test_mountcontroldbus.cpp
@@ -141,7 +141,10 @@ TEST_F(UT_MountControlDBus, Mount_NoFsTypeSpecified_ReturnsError)
     QString path = "smb://example.com/share";
     QVariantMap opts;
     // Don't specify fsType
-
+    stub.set_lamda(&MountControlDBus::checkAuthentication, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
     QVariantMap result = getDBus()->Mount(path, opts);
 
     EXPECT_FALSE(result.value(MountReturnField::kResult).toBool());
@@ -157,6 +160,10 @@ TEST_F(UT_MountControlDBus, Mount_UnsupportedFsType_ReturnsError)
     QVariantMap opts;
     opts.insert(MountOptionsField::kFsType, "nfs");
 
+    stub.set_lamda(&MountControlDBus::checkAuthentication, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
     QVariantMap result = getDBus()->Mount(path, opts);
 
     EXPECT_FALSE(result.value(MountReturnField::kResult).toBool());
@@ -181,6 +188,10 @@ TEST_F(UT_MountControlDBus, Mount_SupportedFsType_CallsHelper)
 
     addMockHelper("cifs", mockHelper);
 
+    stub.set_lamda(&MountControlDBus::checkAuthentication, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
     QVariantMap result = getDBus()->Mount(path, opts);
 
     EXPECT_TRUE(mockHelper->mountCalled);
@@ -199,7 +210,10 @@ TEST_F(UT_MountControlDBus, Unmount_NoFsTypeSpecified_ReturnsError)
     QString path = "smb://example.com/share";
     QVariantMap opts;
     // Don't specify fsType
-
+    stub.set_lamda(&MountControlDBus::checkAuthentication, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
     QVariantMap result = getDBus()->Unmount(path, opts);
 
     EXPECT_FALSE(result.value(MountReturnField::kResult).toBool());
@@ -214,7 +228,10 @@ TEST_F(UT_MountControlDBus, Unmount_UnsupportedFsType_ReturnsError)
     QString path = "nfs://example.com/share";
     QVariantMap opts;
     opts.insert(MountOptionsField::kFsType, "nfs");
-
+    stub.set_lamda(&MountControlDBus::checkAuthentication, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
     QVariantMap result = getDBus()->Unmount(path, opts);
 
     EXPECT_FALSE(result.value(MountReturnField::kResult).toBool());
@@ -237,7 +254,10 @@ TEST_F(UT_MountControlDBus, Unmount_SupportedFsType_CallsHelper)
     };
 
     addMockHelper("cifs", mockHelper);
-
+    stub.set_lamda(&MountControlDBus::checkAuthentication, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
     QVariantMap result = getDBus()->Unmount(path, opts);
 
     EXPECT_TRUE(mockHelper->unmountCalled);

--- a/autotests/services/sharecontrol/test_sharecontrol.cpp
+++ b/autotests/services/sharecontrol/test_sharecontrol.cpp
@@ -13,6 +13,12 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QTemporaryFile>
+#include <QDataStream>
+
+// System headers for mocking system calls
+#include <unistd.h>
+#include <cstring>
+#include <algorithm>
 
 // Include the classes under test
 #include "sharecontroldbus.h"
@@ -26,6 +32,9 @@ class UT_ShareControlDBus : public testing::Test
 protected:
     virtual void SetUp() override
     {
+        // Reset read call counter for each test
+        readCallCount = 0;
+        
         // Mock QDBusContext::message to prevent crashes
         stub.set_lamda(&QDBusContext::message, [](const QDBusContext *) -> const QDBusMessage& {
             __DBG_STUB_INVOKE__
@@ -47,6 +56,7 @@ protected:
 protected:
     ShareControlDBus *shareControlDBus = nullptr;
     stub_ext::StubExt stub;
+    int readCallCount = 0;  // Track read system call count
 };
 
 class UT_PolicyKitHelper : public testing::Test
@@ -212,7 +222,34 @@ TEST_F(UT_ShareControlDBus, SetUserSharePassword_AuthenticationFailed_ReturnsFal
         return false;
     });
 
-    bool result = shareControlDBus->SetUserSharePassword("testuser", "testpassword");
+    // Create a mock file descriptor - should be valid but authentication will fail first
+    QDBusUnixFileDescriptor mockFd;
+    stub.set_lamda(&QDBusUnixFileDescriptor::isValid, [](const QDBusUnixFileDescriptor *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = shareControlDBus->SetUserSharePassword(mockFd);
+    EXPECT_FALSE(result);
+}
+
+// Test SetUserSharePassword with invalid file descriptor
+TEST_F(UT_ShareControlDBus, SetUserSharePassword_InvalidFileDescriptor_ReturnsFalse)
+{
+    // Mock successful authentication
+    stub.set_lamda(&PolicyKitHelper::checkAuthorization, [](PolicyKitHelper *, const QString &, const QString &) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    // Create an invalid file descriptor
+    QDBusUnixFileDescriptor mockFd;
+    stub.set_lamda(&QDBusUnixFileDescriptor::isValid, [](const QDBusUnixFileDescriptor *) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = shareControlDBus->SetUserSharePassword(mockFd);
     EXPECT_FALSE(result);
 }
 
@@ -225,6 +262,39 @@ TEST_F(UT_ShareControlDBus, SetUserSharePassword_Success_ReturnsTrue)
         return true;
     });
 
+    // Create a mock file descriptor
+    QDBusUnixFileDescriptor mockFd;
+    stub.set_lamda(&QDBusUnixFileDescriptor::isValid, [](const QDBusUnixFileDescriptor *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&QDBusUnixFileDescriptor::fileDescriptor, [](const QDBusUnixFileDescriptor *) {
+        __DBG_STUB_INVOKE__
+        return 0;   // Mock valid file descriptor
+    });
+
+    // Mock read system call to simulate reading credentials from pipe
+    stub.set_lamda(read, [this](int, void *buf, size_t count) -> ssize_t {
+        __DBG_STUB_INVOKE__
+        this->readCallCount++;
+        
+        if (this->readCallCount == 1) {
+            // First call: return serialized credentials data
+            QByteArray data;
+            QDataStream stream(&data, QIODevice::WriteOnly);
+            stream << QString("testuser") << QString("testpassword");
+            
+            // Copy data to buffer (ensure we don't exceed buffer size)
+            size_t dataSize = std::min(static_cast<size_t>(data.size()), count);
+            memcpy(buf, data.constData(), dataSize);
+            return static_cast<ssize_t>(dataSize);
+        } else {
+            // Subsequent calls: return 0 to indicate end of file
+            return 0;
+        }
+    });
+
     // Mock password decryption
     stub.set_lamda(&dfmbase::FileUtils::decryptString, [](const QString &) {
         __DBG_STUB_INVOKE__
@@ -235,6 +305,11 @@ TEST_F(UT_ShareControlDBus, SetUserSharePassword_Success_ReturnsTrue)
     using ProcessStartFunc = void (QProcess::*)(const QString &, const QStringList &, QIODevice::OpenMode);
     stub.set_lamda(static_cast<ProcessStartFunc>(&QProcess::start), [](QProcess *, const QString &, const QStringList &, QIODevice::OpenMode) {
         __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(&QProcess::waitForStarted, [](QProcess *, int) {
+        __DBG_STUB_INVOKE__
+        return true;
     });
 
     using ProcessWriteFunc = qint64 (QProcess::*)(const char *);
@@ -253,7 +328,7 @@ TEST_F(UT_ShareControlDBus, SetUserSharePassword_Success_ReturnsTrue)
         return true;
     });
 
-    bool result = shareControlDBus->SetUserSharePassword("testuser", "testpassword");
+    bool result = shareControlDBus->SetUserSharePassword(mockFd);
     EXPECT_TRUE(result);
 }
 
@@ -367,7 +442,7 @@ TEST_F(UT_PolicyKitHelper, Instance_Singleton_ReturnsSameInstance)
 {
     PolicyKitHelper *instance1 = PolicyKitHelper::instance();
     PolicyKitHelper *instance2 = PolicyKitHelper::instance();
-    
+
     EXPECT_EQ(instance1, instance2);
     EXPECT_NE(instance1, nullptr);
 }
@@ -384,12 +459,90 @@ TEST_F(UT_PolicyKitHelper, CheckAuthorization_ValidParameters_CallsPolkitQt)
     // Mock PolkitQt1::Authority::instance()->checkAuthorizationSync
     // Note: This is a complex mock as it involves PolkitQt1 namespace
     // In a real scenario, you might need to create a wrapper interface for testing
-    
+
     PolicyKitHelper *helper = PolicyKitHelper::instance();
     // This test would require more complex mocking of PolkitQt1 classes
     // For now, we test the basic parameter validation
     bool result = helper->checkAuthorization("test.action", "org.test.service");
     // The actual result depends on the system's PolicyKit configuration
     // In unit tests, this should be mocked
-    (void)result; // Suppress unused variable warning
+    (void)result;   // Suppress unused variable warning
+}
+
+// Test isValidUsername method (private method testing through reflection or making it protected for testing)
+class TestableShareControlDBus : public ShareControlDBus
+{
+public:
+    TestableShareControlDBus(const char *name)
+        : ShareControlDBus(name) { }
+
+    // Expose private method for testing
+    bool testIsValidUsername(const QString &username) const
+    {
+        return isValidUsername(username);
+    }
+};
+
+class UT_ShareControlDBus_Username : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Mock QDBusContext::message to prevent crashes
+        stub.set_lamda(&QDBusContext::message, [](const QDBusContext *) -> const QDBusMessage & {
+            __DBG_STUB_INVOKE__
+            static QDBusMessage msg = QDBusMessage::createMethodCall("org.test.service", "/test", "org.test.Interface", "testMethod");
+            return msg;
+        });
+
+        shareControlDBus = new TestableShareControlDBus("test_sharecontrol_username");
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete shareControlDBus;
+        shareControlDBus = nullptr;
+    }
+
+protected:
+    TestableShareControlDBus *shareControlDBus = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ShareControlDBus_Username, IsValidUsername_ValidUsernames_ReturnsTrue)
+{
+    EXPECT_TRUE(shareControlDBus->testIsValidUsername("testuser"));
+    EXPECT_TRUE(shareControlDBus->testIsValidUsername("user123"));
+    EXPECT_TRUE(shareControlDBus->testIsValidUsername("test_user"));
+    EXPECT_TRUE(shareControlDBus->testIsValidUsername("user-name"));
+    EXPECT_TRUE(shareControlDBus->testIsValidUsername("a"));
+    EXPECT_TRUE(shareControlDBus->testIsValidUsername("user_123-test"));
+}
+
+TEST_F(UT_ShareControlDBus_Username, IsValidUsername_InvalidUsernames_ReturnsFalse)
+{
+    // Empty username
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername(""));
+
+    // Too long username (over 32 characters)
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("this_is_a_very_long_username_that_exceeds_32_characters"));
+
+    // Starting with hyphen (command injection prevention)
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("-testuser"));
+
+    // Containing double hyphens (command injection prevention)
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test--user"));
+
+    // Containing invalid characters
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test user"));   // space
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test@user"));   // @
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test$user"));   // $
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test&user"));   // &
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test|user"));   // |
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test;user"));   // ;
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test'user"));   // '
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test\"user"));   // "
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test\\user"));   // \
+    EXPECT_FALSE(shareControlDBus->testIsValidUsername("test/user"));  // /
 }

--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -130,7 +130,7 @@ bool ThumbnailHelper::checkMimeTypeSupport(const QMimeType &mime)
     if (Q_LIKELY(mimeList.contains(Mime::kTypeAppPdf)
                  || mimeName == Mime::kTypeAppCRRMedia
                  || mimeName == Mime::kTypeAppMxf)
-        || mimeName == Mime::kTypeAppPptx) {
+        || mimeList.contains(Mime::kTypeAppPptx)) {
         bool supported = checkStatus(Application::kPreviewDocumentFile);
         return supported;
     }

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -40,7 +40,6 @@ class SideBarViewPrivate : public QObject
     QUrl sidebarUrl;
     DFMBASE_NAMESPACE::DFMMimeData dfmMimeData;
     QPalette originPalette;
-    QStyle *style = nullptr;
 
     explicit SideBarViewPrivate(SideBarView *qq);
     bool checkOpTime();   // 检查当前操作与上次操作的时间间隔

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -260,16 +260,11 @@ SideBarView::SideBarView(QWidget *parent)
     d->originPalette = palette();
     d->lastOpTime = 0;
 
-    d->style = new SidebarViewStyle(style());
-    setStyle(d->style);
+    setStyle(new SidebarViewStyle(style()));
 }
 
 SideBarView::~SideBarView()
 {
-    if (d->style) {
-        delete d->style;
-        d->style = nullptr;
-    }
 }
 
 SideBarModel *SideBarView::model() const


### PR DESCRIPTION
1. Changed PPTX mime type check from direct comparison to list containment for better consistency
2. Enhanced thumbnail creation logic to support inherited MIME types (like WPS documents)
3. Added parent MIME type checking before falling back to pattern matching
4. Improved logging for better debugging of thumbnail generation process
5. The changes ensure better compatibility with document types that inherit from standard formats

feat: 优化PPTX缩略图和MIME类型处理

1. 将PPTX的MIME类型检查从直接比较改为列表包含方式以提高一致性
2. 增强缩略图创建逻辑以支持继承的MIME类型(如WPS文档)
3. 在回退到模式匹配之前添加了父MIME类型检查
4. 改进日志记录以更好地调试缩略图生成过程
5. 这些变更确保了与从标准格式继承的文档类型的更好兼容性

## Summary by Sourcery

Optimize thumbnail generation by improving MIME type handling for PPTX and inherited document types and enhancing debug logging.

Enhancements:
- Switch PPTX MIME type check to list containment for consistency
- Add support for parent MIME types in thumbnail creation before pattern matching
- Enhance logging in the thumbnail generation process for better debugging