### PR TITLE
test: add unit tests for dfmplugin-myshares components

### DIFF
--- a/autotests/plugins/dfmplugin-myshares/test_mysharemenuscene.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_mysharemenuscene.cpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "menu/mysharemenuscene.h"
+#include "private/mysharemenuscene_p.h"
+#include "events/shareeventscaller.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/abstractmenuscene.h>
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
+#include <QMenu>
+#include <QAction>
+#include <QVariantHash>
+#include <QList>
+#include <QUrl>
+#include <QScopedPointer>
+
+using namespace dfmplugin_myshares;
+DFMBASE_USE_NAMESPACE
+
+        class UT_MyShareMenuScene : public testing::Test
+{
+public:
+    virtual void SetUp() override
+    {
+        scene = new MyShareMenuScene();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+        scene = nullptr;
+    }
+
+    stub_ext::StubExt stub;
+    MyShareMenuScene *scene { nullptr };
+};
+
+TEST_F(UT_MyShareMenuScene, Name)
+{
+    EXPECT_EQ("MyShareMenu", scene->name());
+}
+
+TEST_F(UT_MyShareMenuScene, Initialize)
+{
+    EXPECT_TRUE(scene->initialize({}));
+    EXPECT_NO_FATAL_FAILURE(scene->initialize({}));
+}
+
+TEST_F(UT_MyShareMenuScene, Create)
+{
+    QMenu *menu = new QMenu;
+    EXPECT_TRUE(scene->create(menu));
+    EXPECT_NO_FATAL_FAILURE(scene->create(menu));
+    delete menu;
+}
+
+TEST_F(UT_MyShareMenuScene, UpdateState)
+{
+    QMenu *menu = new QMenu;
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(menu));
+    delete menu;
+}
+
+TEST_F(UT_MyShareMenuScene, Triggered)
+{
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(nullptr));
+    auto act = new QAction("Hello");
+    act->setProperty("actionID", "Hello");
+    EXPECT_FALSE(scene->triggered(act));
+    EXPECT_NO_FATAL_FAILURE(scene->triggered(act));
+
+    stub.set_lamda(&MyShareMenuScenePrivate::triggered, [] { __DBG_STUB_INVOKE__ return false; });
+    scene->d->predicateAction.insert("Hello", act);
+    EXPECT_FALSE(scene->triggered(act));
+    delete act;
+    scene->d->predicateAction.clear();
+}
+
+TEST_F(UT_MyShareMenuScene, Scene)
+{
+    EXPECT_TRUE(scene->scene(nullptr) == nullptr);
+    EXPECT_NO_FATAL_FAILURE(scene->scene(nullptr));
+
+    QAction *act = new QAction("Hello");
+    scene->d->predicateAction.insert("Hello", act);
+    EXPECT_TRUE(scene->scene(act));
+    EXPECT_NO_FATAL_FAILURE(scene->scene(act));
+    EXPECT_STREQ(scene->scene(act)->metaObject()->className(), "dfmplugin_myshares::MyShareMenuScene");
+
+    delete act;
+    act = new QAction("World");
+    EXPECT_NO_FATAL_FAILURE(scene->scene(act));
+    EXPECT_TRUE(scene->scene(nullptr) == nullptr);
+    delete act;
+}
+
+class UT_MyShareMenuCreator : public testing::Test
+{
+public:
+    virtual void SetUp() override {}
+    virtual void TearDown() override { stub.clear(); }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_MyShareMenuCreator, Name)
+{
+    EXPECT_EQ("MyShareMenu", MyShareMenuCreator::name());
+}
+
+TEST_F(UT_MyShareMenuCreator, Create)
+{
+    MyShareMenuCreator creator;
+    auto scene = creator.create();
+    EXPECT_TRUE(scene);
+    EXPECT_STREQ(scene->metaObject()->className(), "dfmplugin_myshares::MyShareMenuScene");
+    delete scene;
+}
+
+class UT_MyShareMenuScenePrivate : public testing::Test
+{
+public:
+    virtual void SetUp() override
+    {
+        scene = new MyShareMenuScene();
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+        scene = nullptr;
+    }
+
+    stub_ext::StubExt stub;
+    MyShareMenuScene *scene { nullptr };
+    MyShareMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(UT_MyShareMenuScenePrivate, CreateFileMenu)
+{
+    d->isEmptyArea = true;
+    EXPECT_NO_FATAL_FAILURE(d->createFileMenu(nullptr));
+
+    d->isEmptyArea = false;
+    EXPECT_NO_FATAL_FAILURE(d->createFileMenu(nullptr));
+
+    auto menu = new QMenu;
+    EXPECT_NO_FATAL_FAILURE(d->createFileMenu(menu));
+
+    d->selectFiles.append(QUrl::fromLocalFile("/Hello/World"));
+    EXPECT_NO_FATAL_FAILURE(d->createFileMenu(menu));
+
+    delete menu;
+}
+
+TEST_F(UT_MyShareMenuScenePrivate, Triggered)
+{
+    d->predicateAction.clear();
+    EXPECT_FALSE(d->triggered("Test"));
+
+    stub.set_lamda(ShareEventsCaller::sendOpenDirs, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ShareEventsCaller::sendCancelSharing, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(ShareEventsCaller::sendShowProperty, [] { __DBG_STUB_INVOKE__ });
+
+    d->predicateAction.insert("test", nullptr);
+    EXPECT_FALSE(d->triggered("test"));
+
+    d->predicateAction.insert(MySharesActionId::kOpenShareFolder, nullptr);
+    d->predicateAction.insert(MySharesActionId::kOpenShareInNewWin, nullptr);
+    d->predicateAction.insert(MySharesActionId::kOpenShareInNewTab, nullptr);
+    d->predicateAction.insert(MySharesActionId::kCancleSharing, nullptr);
+    d->predicateAction.insert(MySharesActionId::kShareProperty, nullptr);
+
+    EXPECT_TRUE(d->triggered(MySharesActionId::kOpenShareFolder));
+    EXPECT_TRUE(d->triggered(MySharesActionId::kOpenShareInNewWin));
+    EXPECT_TRUE(d->triggered(MySharesActionId::kOpenShareInNewTab));
+    EXPECT_TRUE(d->triggered(MySharesActionId::kShareProperty));
+
+    EXPECT_FALSE(d->triggered(MySharesActionId::kCancleSharing));
+    d->selectFiles.append(QUrl::fromLocalFile("/hello/world"));
+    EXPECT_TRUE(d->triggered(MySharesActionId::kCancleSharing));
+}

--- a/autotests/plugins/dfmplugin-myshares/test_myshares.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_myshares.cpp
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+#include "addr_any.h"
+
+#include "myshares.h"
+#include "utils/shareutils.h"
+#include "utils/sharefilehelper.h"
+#include "events/shareeventhelper.h"
+#include "dfmplugin_myshares_global.h"
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QPoint>
+#include <QMenu>
+#include <QAction>
+#include <QSignalSpy>
+#include <QScopedPointer>
+#include <QFileInfo>
+
+using namespace dfmplugin_myshares;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_MyShares : public testing::Test
+{
+public:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { }
+    MyShares ins;
+};
+
+// NOTE! if you want to simplify your stub for events,
+// just stub the 'QVariant EventChannel::send(const QVariantList &params)'
+// but you will see a lots of error message in console.
+// so if you do not want to see them, stub the `push` directly like me did.
+// so does to 'follow/subscribe...'
+TEST_F(UT_MyShares, Start)
+{
+    stub_ext::StubExt stub;
+
+    typedef void (MyShares::*SubFunc1)(const QString &);   // type of MyShares::onShareAdded, MyShares::onShareRemoved
+    typedef bool (EventDispatcherManager::*Subscribe)(const QString &, const QString &, MyShares *, SubFunc1);
+    auto subscribe = static_cast<Subscribe>(&EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, QString);
+    typedef QVariant (EventChannelManager::*Push2)(const QString &, const QString &, QString, QString &&);
+
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    auto push2 = static_cast<Push2>(&EventChannelManager::push);
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    stub.set_lamda(&MyShares::followEvents, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_TRUE(ins.start());
+}
+
+static bool stubRegistScene(const QString &, DFMBASE_NAMESPACE::AbstractSceneCreator *creator)
+{
+    if (creator)
+        delete creator;
+    return true;
+}
+
+TEST_F(UT_MyShares, Initialize)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(&MyShares::beMySubScene, [] { __DBG_STUB_INVOKE__ });
+
+    // AddrAny any;
+    // std::map<std::string, void *> result;
+    // any.get_local_func_addr_symtab("^dfmplugin_menu_util", result);
+    // auto regScene = result.at("dfmplugin_menu_util::menuSceneRegisterScene(QString const&, dfmbase::AbstractSceneCreator*)");
+    // if (regScene)
+    //     stub.set(regScene, stubRegistScene);
+
+    EXPECT_NO_FATAL_FAILURE(ins.initialize());
+}
+
+TEST_F(UT_MyShares, Stop)
+{
+    EXPECT_NO_FATAL_FAILURE(ins.stop());
+}
+
+// complete protected/private functions' ut
+TEST_F(UT_MyShares, OnWindowOpened)
+{
+    stub_ext::StubExt stub;
+
+    DFMBASE_USE_NAMESPACE
+    FileManagerWindow *win = new FileManagerWindow(QUrl());
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [win] { __DBG_STUB_INVOKE__ return win; });
+
+    // run else block first.
+    stub.set_lamda(&FileManagerWindow::sideBar, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    stub.set_lamda(&FileManagerWindow::titleBar, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(0));
+
+    // run if true block
+    stub.set_lamda(&FileManagerWindow::sideBar, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<AbstractFrame *>(1); });   // this lambda's  _  return  value is only used to work in 'if' block and will never and should never be used.
+    stub.set_lamda(&FileManagerWindow::titleBar, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<AbstractFrame *>(1); });   // this lambda's  _  return  value is only used to work in 'if' block and will never and should never be used.
+    stub.set_lamda(&MyShares::addToSidebar, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&MyShares::regMyShareToSearch, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(0));
+
+    delete win;
+}
+
+TEST_F(UT_MyShares, OnShareAdded)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(&MyShares::addToSidebar, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ins.onShareAdded(""));
+}
+
+TEST_F(UT_MyShares, OnShareRemoved)
+{
+    typedef QVariant (EventChannelManager::*Push3)(const QString &, const QString &);
+    typedef QVariant (EventChannelManager::*Push4)(const QString &, const QString &, QUrl);
+
+    stub_ext::StubExt stub;
+    auto push3 = static_cast<Push3>(&EventChannelManager::push);
+    stub.set_lamda(push3, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    auto push4 = static_cast<Push4>(&EventChannelManager::push);
+    stub.set_lamda(push4, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(ins.onShareRemoved(""));
+    EXPECT_NO_FATAL_FAILURE(ins.onShareRemoved("whatever/path"));
+    EXPECT_NO_FATAL_FAILURE(ins.onShareRemoved("what/a/good/day"));
+}
+
+TEST_F(UT_MyShares, AddToSideBar)
+{
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*Push3)(const QString &, const QString &);
+    auto push3 = static_cast<Push3>(&EventChannelManager::push);
+    stub.set_lamda(push3, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.addToSidebar());
+    stub.clear();
+
+    stub.set_lamda(push3, [] {
+        ShareInfoList lst { ShareInfo() };
+        __DBG_STUB_INVOKE__ return QVariant::fromValue<ShareInfoList>(lst);
+    });
+
+    typedef QVariant (EventChannelManager::*Push5)(const QString &, const QString &, QUrl, QVariantMap &);
+    auto push5 = static_cast<Push5>(&EventChannelManager::push);
+    stub.set_lamda(push5, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.addToSidebar());
+}
+
+TEST_F(UT_MyShares, RegMyShareToSearch)
+{
+    stub_ext::StubExt stub;
+
+    typedef QVariant (EventChannelManager::*Push5)(const QString &, const QString &, QString, QVariantMap &);
+    auto push5 = static_cast<Push5>(&EventChannelManager::push);
+    stub.set_lamda(push5, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.regMyShareToSearch());
+}
+
+static bool stubContains(const QString &)
+{
+    return true;
+}
+
+static bool stubBind(const QString &, const QString &)
+{
+    return true;
+}
+
+TEST_F(UT_MyShares, BeMySubScene)
+{
+    stub_ext::StubExt stub;
+
+    // test else branch first.
+    typedef void (MyShares::*SubFunc1)(const QString &);   // type of MyShares::onShareAdded, MyShares::onShareRemoved
+    typedef bool (EventDispatcherManager::*Subscribe)(const QString &, const QString &, MyShares *, SubFunc1);
+    auto subscribe = static_cast<Subscribe>(&EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe, [] { __DBG_STUB_INVOKE__ return true; });
+    ins.eventSubscribed = false;
+    EXPECT_NO_FATAL_FAILURE(ins.beMySubScene("hello"));
+
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, QString);
+    typedef QVariant (EventChannelManager::*Push2)(const QString &, const QString &, QString, const QString &);
+    auto pushContains = static_cast<Push1>(&EventChannelManager::push);
+    auto pushBind = static_cast<Push2>(&EventChannelManager::push);
+    stub.set_lamda(pushContains, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(pushBind, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(ins.beMySubScene("hello"));
+}
+
+TEST_F(UT_MyShares, BeMySubOnAdded)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(&MyShares::beMySubScene, [](void *, const QString &) { __DBG_STUB_INVOKE__ });
+
+    typedef void (MyShares::*SubFunc1)(const QString &);   // type of MyShares::onShareAdded, MyShares::onShareRemoved
+    typedef bool (EventDispatcherManager::*Subscribe)(const QString &, const QString &, MyShares *, SubFunc1);
+    auto unsubscribe = static_cast<Subscribe>(&EventDispatcherManager::unsubscribe);
+    stub.set_lamda(unsubscribe, [] { __DBG_STUB_INVOKE__ return true; });
+
+    ins.waitToBind.clear();
+    ins.waitToBind.insert("hello");
+    EXPECT_NO_FATAL_FAILURE(ins.beMySubOnAdded("hello"));
+}
+
+Q_DECLARE_METATYPE(QList<QUrl> *);
+TEST_F(UT_MyShares, HookEvent)
+{
+    stub_ext::StubExt stub;
+
+    typedef bool (ShareEventHelper::*HookFunc1)(quint64, const QList<QUrl> &);   // type of ShareEventHelper::blockDelete/blockMoveToTrash
+    typedef bool (EventSequenceManager::*HookType1)(const QString &, const QString &, ShareEventHelper *, HookFunc1);
+
+    typedef bool (ShareEventHelper::*HookFunc2)(quint64, const QUrl &);   // type of ShareEventHelper::blockPaste, hookSendChangeCurrentUrl
+    typedef bool (EventSequenceManager::*HookType2)(const QString &, const QString &, ShareEventHelper *, HookFunc2);
+
+    typedef bool (ShareEventHelper::*HookFunc3)(const QList<QUrl> &);   // type of ShareEventHelper::hookSendOpenWindow
+    typedef bool (EventSequenceManager::*HookType3)(const QString &, const QString &, ShareEventHelper *, HookFunc3);
+
+    typedef bool (ShareUtils::*HookFunc4)(const QList<QUrl> &, QList<QUrl> *);   // type of ShareUtils::urlsToLocal
+    typedef bool (EventSequenceManager::*HookType4)(const QString &, const QString &, ShareUtils *, HookFunc4);
+
+    typedef bool (ShareFileHelper::*HookFunc5)(quint64, const QList<QUrl> &);
+    typedef bool (EventSequenceManager::*HookType5)(const QString &, const QString &, ShareFileHelper *, HookFunc5);
+
+    auto follow1 = static_cast<HookType1>(&EventSequenceManager::follow);
+    stub.set_lamda(follow1, [] { __DBG_STUB_INVOKE__ return true; });
+
+    auto follow2 = static_cast<HookType2>(&EventSequenceManager::follow);
+    stub.set_lamda(follow2, [] { __DBG_STUB_INVOKE__ return true; });
+
+    auto follow3 = static_cast<HookType3>(&EventSequenceManager::follow);
+    stub.set_lamda(follow3, [] { __DBG_STUB_INVOKE__ return true; });
+
+    auto follow4 = static_cast<HookType4>(&EventSequenceManager::follow);
+    stub.set_lamda(follow4, [] { __DBG_STUB_INVOKE__ return true; });
+
+    auto follow5 = static_cast<HookType5>(&EventSequenceManager::follow);
+    stub.set_lamda(follow5, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(ins.followEvents());
+}

--- a/autotests/plugins/dfmplugin-myshares/test_shareeventhelper.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_shareeventhelper.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "events/shareeventhelper.h"
+#include "events/shareeventscaller.h"
+#include "utils/shareutils.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <dfm-base/dfm_global_defines.h>
+
+#include <QUrl>
+#include <QList>
+
+using namespace dfmplugin_myshares;
+
+class UT_ShareEventHelper : public testing::Test
+{
+public:
+    virtual void SetUp() override {}
+    virtual void TearDown() override { stub.clear(); }
+
+    stub_ext::StubExt stub;
+};
+
+using namespace dfmplugin_myshares;
+
+TEST_F(UT_ShareEventHelper, BlockPaste)
+{
+    EXPECT_TRUE(ShareEventHelper::instance()->blockPaste(0, {}, QUrl("usershare:///hello")));
+    EXPECT_FALSE(ShareEventHelper::instance()->blockPaste(0, {}, QUrl("file:///world")));
+}
+
+TEST_F(UT_ShareEventHelper, BlockDelete)
+{
+    stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(ShareEventHelper::instance()->blockDelete(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
+
+    stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ShareEventHelper::instance()->blockDelete(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
+}
+
+TEST_F(UT_ShareEventHelper, BlockMoveToTrash)
+{
+    stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(ShareEventHelper::instance()->blockMoveToTrash(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
+
+    stub.set_lamda(&ShareEventHelper::containsShareUrl, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ShareEventHelper::instance()->blockMoveToTrash(0, { QUrl("usershare:///hello") }, QUrl("usershare:///hello")));
+}
+
+TEST_F(UT_ShareEventHelper, HookSendOpenWindow)
+{
+    stub.set_lamda(ShareEventsCaller::sendOpenDirs, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_FALSE(ShareEventHelper::instance()->hookSendOpenWindow({}));
+    EXPECT_FALSE(ShareEventHelper::instance()->hookSendOpenWindow({ QUrl::fromLocalFile("/hello") }));
+    EXPECT_FALSE(ShareEventHelper::instance()->hookSendOpenWindow({ QUrl("usershare:///") }));
+    EXPECT_TRUE(ShareEventHelper::instance()->hookSendOpenWindow({ QUrl("usershare:///hello") }));
+    EXPECT_TRUE(ShareEventHelper::instance()->hookSendOpenWindow({ QUrl("usershare:///hello"), QUrl::fromLocalFile("/hello") }));
+}
+
+TEST_F(UT_ShareEventHelper, HookSendChangeCurrentUrl)
+{
+    stub.set_lamda(ShareEventsCaller::sendOpenDirs, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_FALSE(ShareEventHelper::instance()->hookSendChangeCurrentUrl(0, QUrl::fromLocalFile("/hello/world")));
+    EXPECT_FALSE(ShareEventHelper::instance()->hookSendChangeCurrentUrl(0, QUrl("usershare:///")));
+    EXPECT_TRUE(ShareEventHelper::instance()->hookSendChangeCurrentUrl(0, QUrl("usershare:///hello/world")));
+    EXPECT_TRUE(ShareEventHelper::instance()->hookSendChangeCurrentUrl(12345, QUrl("usershare:///hello/world")));
+}
+
+TEST_F(UT_ShareEventHelper, ContainsShareUrl)
+{
+    QList<QUrl> urls;
+    EXPECT_FALSE(ShareEventHelper::instance()->containsShareUrl(urls));
+
+    urls = { QUrl("usershare:///hello/world"), QUrl::fromLocalFile("/hello/c++") };
+    EXPECT_TRUE(ShareEventHelper::instance()->containsShareUrl(urls));
+
+    urls = { QUrl::fromLocalFile("/this/is/local/file") };
+    EXPECT_FALSE(ShareEventHelper::instance()->containsShareUrl(urls));
+}

--- a/autotests/plugins/dfmplugin-myshares/test_shareeventscaller.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_shareeventscaller.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "events/shareeventscaller.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QList>
+#include <QVariantHash>
+
+using namespace dfmplugin_myshares;
+DFMBASE_USE_NAMESPACE
+
+        class UT_ShareEventsCaller : public testing::Test
+{
+public:
+    virtual void SetUp() override {}
+    virtual void TearDown() override { stub.clear(); }
+
+    stub_ext::StubExt stub;
+};
+
+using namespace dfmplugin_myshares;
+using namespace dpf;
+DFMBASE_USE_NAMESPACE
+
+TEST_F(UT_ShareEventsCaller, SendOpenDirs)
+{
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendOpenDirs(0, {}, ShareEventsCaller::OpenMode::kOpenInCurrentWindow));
+
+    typedef bool (EventDispatcherManager::*Publish1)(int, QUrl);
+    typedef bool (EventDispatcherManager::*Publish2)(int, quint64, QUrl &);
+
+    auto publish1 = static_cast<Publish1>(&EventDispatcherManager::publish);
+    stub.set_lamda(publish1, [] { __DBG_STUB_INVOKE__ return true; });
+    auto publish2 = static_cast<Publish2>(&EventDispatcherManager::publish);
+    stub.set_lamda(publish2, [] { __DBG_STUB_INVOKE__ return true; });
+
+    QList<QUrl> urls { QUrl("usershare:///test") };
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendOpenDirs(0, urls, ShareEventsCaller::OpenMode::kOpenInCurrentWindow));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendOpenDirs(0, urls, ShareEventsCaller::OpenMode::kOpenInNewWindow));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendOpenDirs(0, urls, ShareEventsCaller::OpenMode::kOpenInNewTab));
+
+    urls << QUrl("usershare:///hello");
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendOpenDirs(0, urls, ShareEventsCaller::OpenMode::kOpenInNewTab));
+}
+
+TEST_F(UT_ShareEventsCaller, SendCancelSharing)
+{
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendCancelSharing(QUrl()));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendCancelSharing(QUrl("file:///")));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendCancelSharing(QUrl("usershare:///hello")));
+}
+
+TEST_F(UT_ShareEventsCaller, SendShowProperty)
+{
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QList<QUrl>);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendShowProperty({ QUrl() }));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendShowProperty({ QUrl("file:///") }));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendShowProperty({ QUrl("file:///"), QUrl("usershare:///hello") }));
+}
+
+TEST_F(UT_ShareEventsCaller, SendSwitchDisplayMode)
+{
+    typedef bool (EventDispatcherManager::*Publish)(int, quint64, int &&);
+    auto publish = static_cast<Publish>(&EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendSwitchDisplayMode(0, Global::ViewMode::kNoneMode));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendSwitchDisplayMode(0, Global::ViewMode::kIconMode));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendSwitchDisplayMode(1, Global::ViewMode::kListMode));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendSwitchDisplayMode(1, Global::ViewMode::kExtendMode));
+    EXPECT_NO_FATAL_FAILURE(ShareEventsCaller::sendSwitchDisplayMode(1, Global::ViewMode::kAllViewMode));
+}

--- a/autotests/plugins/dfmplugin-myshares/test_sharefilehelper.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_sharefilehelper.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "utils/sharefilehelper.h"
+#include "utils/shareutils.h"
+#include "events/shareeventscaller.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <QUrl>
+#include <QList>
+
+using namespace dfmplugin_myshares;
+
+class UT_ShareFileHelper : public testing::Test
+{
+    // Test interface
+protected:
+    virtual void SetUp() override {}
+    virtual void TearDown() override {}
+};
+
+TEST_F(UT_ShareFileHelper, OpenFileInPlugin)
+{
+    QList<QUrl> inputs;
+    EXPECT_FALSE(ShareFileHelper::instance()->openFileInPlugin(0, inputs));
+
+    inputs = { QUrl::fromLocalFile("/") };
+    EXPECT_FALSE(ShareFileHelper::instance()->openFileInPlugin(0, inputs));
+    inputs.clear();
+
+    stub_ext::StubExt stub;
+    stub.set_lamda(ShareEventsCaller::sendOpenDirs, [](quint64, const QList<QUrl>, ShareEventsCaller::OpenMode) {});
+    inputs = { ShareUtils::makeShareUrl("/hello") };
+    EXPECT_TRUE(ShareFileHelper::instance()->openFileInPlugin(0, inputs));
+}

--- a/autotests/plugins/dfmplugin-myshares/test_sharefileinfo.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_sharefileinfo.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "fileinfo/sharefileinfo.h"
+#include "private/sharefileinfo_p.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+#include <QVariantMap>
+#include <QScopedPointer>
+
+using namespace dfmplugin_myshares;
+DFMBASE_USE_NAMESPACE
+
+class UT_ShareFileInfo : public testing::Test
+{
+    // Test interface
+protected:
+    virtual void SetUp() override
+    {
+        conStub.set_lamda(&ShareFileInfo::setProxy, [] { __DBG_STUB_INVOKE__ });
+        conStub.set_lamda(InfoFactory::create<FileInfo>, [] { __DBG_STUB_INVOKE__ return nullptr; });
+        typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
+        auto pushAddr = static_cast<Push>(&dpf::EventChannelManager::push);
+        conStub.set_lamda(pushAddr, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+        info = new ShareFileInfo(QUrl("share:///test"));
+        auto d = dynamic_cast<ShareFileInfoPrivate *>(info->d.data());
+        d->info = { { "shareName", "test" },
+                    { "path", "/test" },
+                    { "comment", "" },
+                    { "acl", "" },
+                    { "guestEnable", "" },
+                    { "writable", "" } };
+    }
+
+    virtual void TearDown() override
+    {
+        conStub.clear();
+        delete info;
+        info = nullptr;
+    }
+
+    stub_ext::StubExt conStub;
+    ShareFileInfo *info { nullptr };
+};
+
+TEST_F(UT_ShareFileInfo, RedirectedFileUrl)
+{
+    EXPECT_TRUE(info->urlOf(UrlInfoType::kRedirectedFileUrl) == QUrl::fromLocalFile("/test"));
+}
+
+TEST_F(UT_ShareFileInfo, FileDisplayName)
+{
+    conStub.set_lamda(UrlRoute::isRootUrl, [] { return false; });
+    EXPECT_EQ(info->displayOf(DisPlayInfoType::kFileDisplayName), "test");
+}
+
+TEST_F(UT_ShareFileInfo, FileName)
+{
+    EXPECT_TRUE(info->nameOf(NameInfoType::kFileName) == "test");
+}
+
+TEST_F(UT_ShareFileInfo, IsDir)
+{
+    EXPECT_NO_FATAL_FAILURE(info->isAttributes(OptInfoType::kIsDir));
+}
+
+TEST_F(UT_ShareFileInfo, CanRename)
+{
+    EXPECT_FALSE(info->canAttributes(CanableInfoType::kCanRename));
+}
+
+TEST_F(UT_ShareFileInfo, CanDrag)
+{
+    EXPECT_FALSE(info->canAttributes(CanableInfoType::kCanDrag));
+}
+
+TEST_F(UT_ShareFileInfo, IsWritable)
+{
+    EXPECT_NO_FATAL_FAILURE(info->isAttributes(OptInfoType::kIsWritable));
+}
+
+TEST_F(UT_ShareFileInfo, Refresh)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(&ShareFileInfoPrivate::refresh, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(info->refresh());
+}
+
+class UT_ShareFileInfoPrivate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        info = new ShareFileInfo(QUrl("share:///test"));
+        d = dynamic_cast<ShareFileInfoPrivate *>(info->d.data());
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete info;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    ShareFileInfo *info { nullptr };
+    ShareFileInfoPrivate *d { nullptr };
+};
+
+TEST_F(UT_ShareFileInfoPrivate, Refresh)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariantMap(); });
+    EXPECT_NO_FATAL_FAILURE(d->refresh());
+}

--- a/autotests/plugins/dfmplugin-myshares/test_shareiterator.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_shareiterator.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "iterator/shareiterator.h"
+#include "private/shareiterator_p.h"
+#include "utils/shareutils.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-framework/event/event.h>
+
+#include <QUrl>
+#include <QStringList>
+#include <QDir>
+#include <QDirIterator>
+#include <QVariantMap>
+#include <QScopedPointer>
+
+using namespace dfmplugin_myshares;
+DFMBASE_USE_NAMESPACE
+
+class UT_ShareIterator : public testing::Test
+{
+public:
+    virtual void SetUp() override
+    {
+        it = new ShareIterator(QUrl("usershare:///"), {}, QDir::AllDirs, QDirIterator::NoIteratorFlags);
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete it;
+        it = nullptr;
+    }
+
+    stub_ext::StubExt stub;
+    ShareIterator *it { nullptr };
+};
+
+DFMBASE_USE_NAMESPACE
+
+TEST_F(UT_ShareIterator, Next)
+{
+    EXPECT_FALSE(it->next().isValid());
+
+    it->d->shares.append(QVariantMap());
+    EXPECT_TRUE(it->next().path().isEmpty());
+
+    it->d->shares.append({ { "path", "/hello/world" } });
+    EXPECT_TRUE(it->next().path() == "/hello/world");
+}
+
+TEST_F(UT_ShareIterator, HasNext)
+{
+    it->d->shares.clear();
+    EXPECT_FALSE(it->hasNext());
+    it->d->shares.append(QVariantMap());
+    EXPECT_TRUE(it->hasNext());
+}
+
+TEST_F(UT_ShareIterator, FileName)
+{
+    it->d->currentInfo.insert("shareName", "Test");
+    EXPECT_TRUE(it->fileName() == "Test");
+}
+
+TEST_F(UT_ShareIterator, FileUrl)
+{
+    it->d->currentInfo = { { "", "" } };
+    EXPECT_TRUE(it->fileUrl().path().isEmpty());
+
+    it->d->currentInfo = { { "path", "/hello/world" } };
+    EXPECT_TRUE(it->fileUrl().isValid());
+    EXPECT_EQ(it->fileUrl().path(), QString("/hello/world"));
+}
+
+TEST_F(UT_ShareIterator, FileInfo)
+{
+    stub.set_lamda(InfoFactory::create<FileInfo>, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    EXPECT_TRUE(it->fileInfo() == nullptr);
+}
+
+TEST_F(UT_ShareIterator, Url)
+{
+    EXPECT_TRUE(it->url().path() == "/");
+    EXPECT_TRUE(it->url().scheme() == "usershare");
+}

--- a/autotests/plugins/dfmplugin-myshares/test_shareutils.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_shareutils.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "utils/shareutils.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <dfm-base/dfm_global_defines.h>
+
+#include <QUrl>
+#include <QIcon>
+#include <QString>
+#include <QObject>
+
+using namespace dfmplugin_myshares;
+
+class UT_ShareUtils : public testing::Test
+{
+    // Test interface
+protected:
+    virtual void SetUp() override {}
+    virtual void TearDown() override {}
+};
+
+TEST_F(UT_ShareUtils, Scheme)
+{
+    EXPECT_EQ("usershare", ShareUtils::scheme());
+}
+
+TEST_F(UT_ShareUtils, Icon)
+{
+    //    EXPECT_EQ("folder-publicshare", ShareUtils::icon().themeName());
+    EXPECT_NO_FATAL_FAILURE(ShareUtils::icon().themeName());
+}
+
+TEST_F(UT_ShareUtils, DisplayName)
+{
+    EXPECT_EQ(QObject::tr("My Shares"), ShareUtils::displayName());
+}
+
+TEST_F(UT_ShareUtils, RootUrl)
+{
+    EXPECT_EQ("usershare", ShareUtils::rootUrl().scheme());
+    EXPECT_EQ("/", ShareUtils::rootUrl().path());
+}
+
+TEST_F(UT_ShareUtils, MakeShareUrl)
+{
+    QString path = "/hello/world";
+    auto url = ShareUtils::makeShareUrl(path);
+    EXPECT_EQ("usershare", url.scheme());
+    EXPECT_EQ(path, url.path());
+
+    path = "this/is/share/url";
+    url = ShareUtils::makeShareUrl(path);
+    EXPECT_EQ(path, url.path());
+}
+
+TEST_F(UT_ShareUtils, ConvertToLocalUrl)
+{
+    auto localUrl = QUrl::fromLocalFile("");
+    EXPECT_FALSE(ShareUtils::convertToLocalUrl(localUrl).isValid());
+
+    auto testUrl = ShareUtils::makeShareUrl("/hello/world");
+    localUrl = ShareUtils::convertToLocalUrl(testUrl);
+    EXPECT_EQ("file", localUrl.scheme());
+    EXPECT_EQ(testUrl.path(), localUrl.path());
+}
+
+TEST_F(UT_ShareUtils, UrlsToLocal)
+{
+    QList<QUrl> outputs, inputs;
+
+    inputs = { ShareUtils::makeShareUrl("/hello"), ShareUtils::makeShareUrl("/world") };
+    outputs.clear();
+}

--- a/autotests/plugins/dfmplugin-myshares/test_sharewatcher.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_sharewatcher.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "watcher/sharewatcher.h"
+#include "private/sharewatcher_p.h"
+#include "dfmplugin_myshares_global.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/abstractfilewatcher.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QSignalSpy>
+#include <QScopedPointer>
+#include <memory>
+
+using namespace dfmplugin_myshares;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_ShareWatcher : public testing::Test
+{
+public:
+    virtual void SetUp() override
+    {
+        watcher = new ShareWatcher(QUrl("usershare:///"));
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete watcher;
+        watcher = nullptr;
+    }
+
+    stub_ext::StubExt stub;
+    ShareWatcher *watcher { nullptr };
+};
+
+TEST_F(UT_ShareWatcher, ShareAdded)
+{
+    EXPECT_NO_FATAL_FAILURE(watcher->shareAdded("hello"));
+    EXPECT_NO_FATAL_FAILURE(watcher->shareAdded("world"));
+}
+
+TEST_F(UT_ShareWatcher, ShareRemoved)
+{
+    EXPECT_NO_FATAL_FAILURE(watcher->shareRemoved("hello"));
+    EXPECT_NO_FATAL_FAILURE(watcher->shareRemoved("world"));
+}
+
+class UT_ShareWatcherPrivate : public testing::Test
+{
+public:
+    virtual void SetUp() override
+    {
+        watcher = new ShareWatcher(QUrl("usershare:///"));
+        d = dynamic_cast<ShareWatcherPrivate *>(watcher->d.data());
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete watcher;
+        watcher = nullptr;
+    }
+
+    stub_ext::StubExt stub;
+    ShareWatcher *watcher { nullptr };
+    ShareWatcherPrivate *d { nullptr };
+};
+
+TEST_F(UT_ShareWatcherPrivate, Start)
+{
+    typedef void (ShareWatcher::*Callback)(const QString &);
+    typedef bool (EventDispatcherManager::*Subscribe)(const QString &, const QString &, ShareWatcher *, Callback);
+    auto subscribe = static_cast<Subscribe>(&EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_TRUE(d->start());
+    EXPECT_NO_FATAL_FAILURE(d->start());
+}
+
+TEST_F(UT_ShareWatcherPrivate, Stop)
+{
+    typedef void (ShareWatcher::*Callback)(const QString &);
+    typedef bool (EventDispatcherManager::*Unsubscribe)(const QString &, const QString &, ShareWatcher *, Callback);
+    auto unsubscribe = static_cast<Unsubscribe>(&EventDispatcherManager::unsubscribe);
+    stub.set_lamda(unsubscribe, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_TRUE(d->stop());
+    EXPECT_NO_FATAL_FAILURE(d->stop());
+}


### PR DESCRIPTION
1. Introduced unit tests for various components of the dfmplugin-myshares, including MyShareMenuScene, MyShares, ShareEventHelper, ShareFileHelper, ShareFileInfo, ShareIterator, ShareUtils, and ShareWatcher.
2. Implemented tests for functionalities such as menu scene interactions, share management, event handling, and file operations.
3. Enhanced test coverage to ensure critical functionalities are well-tested, improving code reliability and facilitating future development.

Log: These additions aim to provide a robust testing framework for the dfmplugin-myshares, ensuring that all components function as expected.

## Summary by Sourcery

Add comprehensive unit tests for dfmplugin-myshares plugin to validate core functionality, UI interactions, file information handling, event flows, and utility methods.

Tests:
- Add tests for MyShares including start/initialize/stop workflows, window events, share addition/removal, sidebar and search registration, and event hooks
- Add tests for MyShareMenuScene and MyShareMenuCreator covering lifecycle methods, menu creation, state updates, action triggering, and private menu logic
- Add tests for ShareFileInfo covering URL redirection, display and name retrieval, attribute checks, and refresh behavior
- Add tests for ShareWatcher covering shareAdded/shareRemoved notifications and private start/stop subscriptions
- Add tests for ShareIterator covering iteration flow, file name and URL retrieval, and fileInfo creation
- Add tests for ShareEventsCaller covering sendOpenDirs, sendCancelSharing, sendShowProperty, and sendSwitchDisplayMode communication
- Add tests for ShareEventHelper covering blockPaste/delete/moveToTrash hooks, open window and URL change hooks, and share URL detection
- Add tests for ShareUtils covering scheme resolution, icon/display name retrieval, root URL, share URL construction, and local URL conversion
- Add tests for ShareFileHelper covering openFileInPlugin behavior with various input scenarios