### PR TITLE
refactor: improve filesystem monitoring and network FS detection

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
@@ -45,9 +45,6 @@ AddressBarPrivate::AddressBarPrivate(AddressBar *qq)
 
 void AddressBarPrivate::initializeUi()
 {
-    // 左侧Action按钮 设置
-    q->addAction(&indicatorAction, QLineEdit::LeadingPosition);
-
     // Clear text button
     q->setClearButtonEnabled(true);
 
@@ -72,8 +69,6 @@ void AddressBarPrivate::initializeUi()
 
 void AddressBarPrivate::initConnect()
 {
-    connect(&indicatorAction, &QAction::triggered, this, &AddressBarPrivate::onIndicatorTriggerd);
-
     connect(&animation, &QVariantAnimation::valueChanged,
             q, QOverload<>::of(&AddressBar::update));
 
@@ -244,11 +239,6 @@ void AddressBarPrivate::onTravelCompletionListFinished()
     }
 }
 
-void AddressBarPrivate::onIndicatorTriggerd()
-{
-    onReturnPressed();
-}
-
 void AddressBarPrivate::requestCompleteByUrl(const QUrl &url)
 {
     if (!crumbController || !crumbController->isSupportedScheme(url.scheme())) {
@@ -412,14 +402,6 @@ void AddressBarPrivate::onCompletionHighlighted(const QString &highlightedComple
         isClearSearch = false;
         q->setSelection(q->text().length() - selectBeginPos, q->text().length());
     }
-}
-
-void AddressBarPrivate::updateIndicatorIcon()
-{
-    QIcon indicatorIcon;
-    QString scope = "go-right";
-    indicatorIcon = QIcon::fromTheme(scope);
-    indicatorAction.setIcon(indicatorIcon);
 }
 
 void AddressBarPrivate::onCompletionModelCountChanged()
@@ -658,7 +640,6 @@ void AddressBar::paintEvent(QPaintEvent *e)
 void AddressBar::showEvent(QShowEvent *event)
 {
     d->timer.start();
-    d->updateIndicatorIcon();
     d->updateHistory();
     return QLineEdit::showEvent(event);
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.h
@@ -44,4 +44,4 @@ Q_SIGNALS:
 
 }
 
-#endif   //AddressBar_H
+#endif   // AddressBar_H

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/addressbar_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/addressbar_p.h
@@ -44,7 +44,6 @@ class AddressBarPrivate : public QObject
     QTimer timer;
     QVariantAnimation animation;
     QString placeholderText { tr("Enter address") };
-    QAction indicatorAction;
     QAction clearAction;
     QString completerBaseString;
     QString lastEditedString;
@@ -90,7 +89,6 @@ public Q_SLOTS:
     void onCompletionModelCountChanged();
     void appendToCompleterModel(const QStringList &stringList);
     void onTravelCompletionListFinished();
-    void onIndicatorTriggerd();
 
 protected:
     virtual bool eventFilterHide(AddressBar *addressbar, QHideEvent *event);


### PR DESCRIPTION
1. Enhanced network filesystem detection by:
   - Adding more network FS types (nfs4, webdav, ceph, etc.)
   - Auto-rejecting all FUSE-based filesystems
   - Making pattern matching case-insensitive
2. Fixed formatting and whitespace issues
3. Marked network FS types list as TODO for DConfig integration
4. Added missing braces for single-line if statements
5. Better variable naming (kNetworkFsTypes instead of networkFsTypes)
6. Improved code readability and consistency

refactor: 改进文件系统监控和网络文件系统检测

1. 增强网络文件系统检测:
   - 添加更多网络FS类型(nfs4, webdav, ceph等)
   - 自动拒绝所有基于FUSE的文件系统
   - 使模式匹配不区分大小写
2. 修复格式问题和空白字符
3. 标记网络FS类型列表以待DConfig集成
4. 为单行if语句添加缺失的大括号
5. 更好的变量命名(kNetworkFsTypes替代networkFsTypes)
6. 提高代码可读性和一致性

## Summary by Sourcery

Improve FSMonitorPrivate::isExternalMount by broadening network filesystem detection (with case-insensitive matching and FUSE rejection), renaming and annotating the network FS type list for future configuration, cleaning up code style, and adding comprehensive unit tests.

Enhancements:
- Reject all FUSE-based filesystems and match filesystem types case-insensitively in isExternalMount
- Extend and rename the network filesystem types list to kNetworkFsTypes (including nfs4, webdav, ceph, etc.) and mark it for DConfig integration
- Add missing braces to single-line if statements and apply formatting/whitespace fixes for readability

Tests:
- Add extensive unit tests for isExternalMount covering empty path, invalid/not-ready storage, FUSE, NFS, CIFS, various network and local filesystems, non-local file URLs, and case-insensitive matching