### PR TITLE
refactor: remove unused updateIndicatorIcon method

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/addressbar_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/addressbar_p.h
@@ -85,7 +85,6 @@ public Q_SLOTS:
     void onReturnPressed();
     void insertCompletion(const QString &completion);
     void onCompletionHighlighted(const QString &highlightedCompletion);
-    void updateIndicatorIcon();
     void onCompletionModelCountChanged();
     void appendToCompleterModel(const QStringList &stringList);
     void onTravelCompletionListFinished();


### PR DESCRIPTION
1. Removed the deprecated updateIndicatorIcon slot from AddressBarPrivate class
2. This method was no longer being used in the component's functionality
3. Cleaning up unused code improves maintainability and reduces potential confusion
4. No impact on existing features as the method was already unused in the codebase

refactor: 移除未使用的updateIndicatorIcon方法

1. 从AddressBarPrivate类中移除了废弃的updateIndicatorIcon槽
2. 该方法在组件功能中已不再使用
3. 清理未使用的代码提高了可维护性并减少了潜在的混淆
4. 对现有功能无影响，因为该方法已在代码库中未使用

## Summary by Sourcery

Enhancements:
- Remove the deprecated updateIndicatorIcon slot from AddressBarPrivate