### PR TITLE
 eorganize test plugins and improve workspace tests

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.operations.json
+++ b/assets/configs/org.deepin.dde.file-manager.operations.json
@@ -34,6 +34,17 @@
             "description":"Open this configuration and report the results of the paste event to the specified location.",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "file.operation.expanddisksync": {
+            "value":true,
+            "serial":0,
+            "flags":[],
+            "name":"Expand Disk Sync",
+            "name[zh_CN]":"扩展磁盘同步",
+            "description[zh_CN]":"对拷贝到扩展磁盘上的文件执行同步",
+            "description":"Perform synchronization on files copied to the extended disk",
+            "permissions":"readwrite",
+            "visibility":"private"
         }
     }
 }

--- a/autotests/plugins/CMakeLists.txt
+++ b/autotests/plugins/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_subdirectory(dfmplugin-burn)
-add_subdirectory(dfmplugin-search)
 
 # Common plugins unit tests
 add_subdirectory(dfmplugin-utils)
@@ -11,6 +9,7 @@ add_subdirectory(dfmplugin-emblem)
 add_subdirectory(dfmplugin-fileoperations)
 add_subdirectory(dfmplugin-bookmark)
 add_subdirectory(dfmplugin-dirshare)
+add_subdirectory(dfmplugin-burn)
 
 # FileManager plugins unit tests
 add_subdirectory(dfmplugin-vault)
@@ -26,6 +25,7 @@ add_subdirectory(dfmplugin-core)
 add_subdirectory(dfmplugin-detailspace)
 add_subdirectory(dfmplugin-avfsbrowser)
 add_subdirectory(dfmplugin-computer)
+add_subdirectory(dfmplugin-search)
 if(DFM_TEST_ENABLE_DISKENCRYPT)
     add_subdirectory(dfmplugin-encrypt-manager)
     add_subdirectory(dfmplugin-disk-encrypt-entry)

--- a/autotests/plugins/dfmplugin-workspace/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-workspace/CMakeLists.txt
@@ -1,4 +1,33 @@
 cmake_minimum_required(VERSION 3.10)
 
-# Use DFM enhanced test utilities to create plugin test
-dfm_create_plugin_test_enhanced("dfmplugin-workspace" "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-worksapce")
+set(test_name "test-dfmplugin-workspace")
+set(plugin_path "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-workspace")
+
+# Find test files
+file(GLOB_RECURSE UT_CXX_FILE FILES_MATCHING PATTERN "*.cpp" "*.h")
+
+# Get all worksapce plugin files (like the source does)
+file(GLOB_RECURSE WORKSPACE_FILES
+    "${plugin_path}/*.h"
+    "${plugin_path}/*.cpp"
+)
+
+# Create test executable with precise file control
+dfm_create_test_executable(${test_name}
+    SOURCES ${UT_CXX_FILE} ${WORKSPACE_FILES}
+)
+
+# Apply plugin-specific configuration using shared dependencies
+dfm_configure_plugin_dependencies(${test_name} "dfmplugin-workspace" ${plugin_path})
+
+# Define macro to disable Qt private class usage in unit tests
+target_compile_definitions(${test_name} PRIVATE DFM_UNIT_TEST_DISABLE_QT_PRIVATE)
+
+# Include necessary paths to resolve relative includes
+target_include_directories(${test_name} PRIVATE
+    "${plugin_path}"
+    "${DFM_SOURCE_DIR}/plugins/filemanager"
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
+message(STATUS "DFM: Created enhanced filemanager workspace plugin test: ${test_name}")

--- a/autotests/plugins/dfmplugin-workspace/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-workspace/CMakeLists.txt
@@ -6,7 +6,7 @@ set(plugin_path "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-workspace")
 # Find test files
 file(GLOB_RECURSE UT_CXX_FILE FILES_MATCHING PATTERN "*.cpp" "*.h")
 
-# Get all worksapce plugin files (like the source does)
+# Get all workspace plugin files (like the source does)
 file(GLOB_RECURSE WORKSPACE_FILES
     "${plugin_path}/*.h"
     "${plugin_path}/*.cpp"

--- a/autotests/plugins/dfmplugin-workspace/test_keywordextractor.cpp
+++ b/autotests/plugins/dfmplugin-workspace/test_keywordextractor.cpp
@@ -1,0 +1,558 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "stubext.h"
+
+#include "utils/keywordextractor.h"
+#include <dfm-base/base/application/application.h>
+
+#include <QUrl>
+#include <QUrlQuery>
+#include <QDebug>
+
+using namespace dfmplugin_workspace;
+
+class KeywordExtractorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Initialize test environment
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+// ============== SimpleKeywordStrategy Tests ==============
+
+class SimpleKeywordStrategyTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        strategy = new SimpleKeywordStrategy();
+    }
+
+    void TearDown() override
+    {
+        delete strategy;
+        stub.clear();
+    }
+
+    SimpleKeywordStrategy *strategy = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(SimpleKeywordStrategyTest, ExtractKeywords_ValidKeyword_ReturnsKeyword)
+{
+    // Test extracting keywords from a simple keyword
+    QString testKeyword = "test";
+    QStringList result = strategy->extractKeywords(testKeyword);
+    
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), testKeyword);
+}
+
+TEST_F(SimpleKeywordStrategyTest, ExtractKeywords_EmptyKeyword_ReturnsEmpty)
+{
+    // Test extracting keywords from empty string
+    QString emptyKeyword = "";
+    QStringList result = strategy->extractKeywords(emptyKeyword);
+    
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(SimpleKeywordStrategyTest, ExtractKeywords_ComplexKeyword_ReturnsOriginal)
+{
+    // Test that complex keywords are returned as-is
+    QString complexKeyword = "complex_keyword_123";
+    QStringList result = strategy->extractKeywords(complexKeyword);
+    
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), complexKeyword);
+}
+
+TEST_F(SimpleKeywordStrategyTest, CanHandle_AnyKeyword_ReturnsTrue)
+{
+    // Test that SimpleKeywordStrategy can handle any keyword (fallback)
+    EXPECT_TRUE(strategy->canHandle("simple"));
+    EXPECT_TRUE(strategy->canHandle("complex keyword"));
+    EXPECT_TRUE(strategy->canHandle("*.txt"));
+    EXPECT_TRUE(strategy->canHandle(""));
+}
+
+TEST_F(SimpleKeywordStrategyTest, Priority_ReturnsLowestPriority)
+{
+    // Test that SimpleKeywordStrategy has the lowest priority
+    EXPECT_EQ(strategy->priority(), 100);
+}
+
+// ============== BooleanKeywordStrategy Tests ==============
+
+class BooleanKeywordStrategyTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        strategy = new BooleanKeywordStrategy();
+    }
+
+    void TearDown() override
+    {
+        delete strategy;
+        stub.clear();
+    }
+
+    BooleanKeywordStrategy *strategy = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(BooleanKeywordStrategyTest, ExtractKeywords_MultipleWords_ReturnsSeparateKeywords)
+{
+    // Test extracting keywords from multiple words separated by spaces
+    QString multiKeyword = "hello world test";
+    QStringList result = strategy->extractKeywords(multiKeyword);
+    
+    EXPECT_EQ(result.size(), 3);
+    EXPECT_TRUE(result.contains("hello"));
+    EXPECT_TRUE(result.contains("world"));
+    EXPECT_TRUE(result.contains("test"));
+}
+
+TEST_F(BooleanKeywordStrategyTest, ExtractKeywords_TabSeparated_ReturnsSeparateKeywords)
+{
+    // Test extracting keywords from tab-separated words
+    QString tabKeyword = "hello\tworld\ttest";
+    QStringList result = strategy->extractKeywords(tabKeyword);
+    
+    EXPECT_EQ(result.size(), 3);
+    EXPECT_TRUE(result.contains("hello"));
+    EXPECT_TRUE(result.contains("world"));
+    EXPECT_TRUE(result.contains("test"));
+}
+
+TEST_F(BooleanKeywordStrategyTest, ExtractKeywords_MixedWhitespace_ReturnsSeparateKeywords)
+{
+    // Test extracting keywords from mixed whitespace
+    QString mixedKeyword = "hello \t world\n\r test";
+    QStringList result = strategy->extractKeywords(mixedKeyword);
+    
+    EXPECT_EQ(result.size(), 3);
+    EXPECT_TRUE(result.contains("hello"));
+    EXPECT_TRUE(result.contains("world"));
+    EXPECT_TRUE(result.contains("test"));
+}
+
+TEST_F(BooleanKeywordStrategyTest, ExtractKeywords_EmptyKeyword_ReturnsEmpty)
+{
+    // Test extracting keywords from empty string
+    QString emptyKeyword = "";
+    QStringList result = strategy->extractKeywords(emptyKeyword);
+    
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(BooleanKeywordStrategyTest, ExtractKeywords_OnlyWhitespace_ReturnsEmpty)
+{
+    // Test extracting keywords from whitespace only
+    QString whitespaceKeyword = "   \t\n  ";
+    QStringList result = strategy->extractKeywords(whitespaceKeyword);
+    
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(BooleanKeywordStrategyTest, CanHandle_WithWhitespace_ReturnsTrue)
+{
+    // Test that BooleanKeywordStrategy can handle keywords with whitespace
+    EXPECT_TRUE(strategy->canHandle("hello world"));
+    EXPECT_TRUE(strategy->canHandle("test\ttab"));
+    EXPECT_TRUE(strategy->canHandle("new\nline"));
+}
+
+TEST_F(BooleanKeywordStrategyTest, CanHandle_NoWhitespace_ReturnsFalse)
+{
+    // Test that BooleanKeywordStrategy cannot handle keywords without whitespace
+    EXPECT_FALSE(strategy->canHandle("singleword"));
+    EXPECT_FALSE(strategy->canHandle(""));
+}
+
+TEST_F(BooleanKeywordStrategyTest, Priority_ReturnsHighPriority)
+{
+    // Test that BooleanKeywordStrategy has high priority
+    EXPECT_EQ(strategy->priority(), 10);
+}
+
+// ============== WildcardKeywordStrategy Tests ==============
+
+class WildcardKeywordStrategyTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        strategy = new WildcardKeywordStrategy();
+    }
+
+    void TearDown() override
+    {
+        delete strategy;
+        stub.clear();
+    }
+
+    WildcardKeywordStrategy *strategy = nullptr;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(WildcardKeywordStrategyTest, ExtractKeywords_AsteriskWildcard_ReturnsPatternAndSegments)
+{
+    // Test extracting keywords from asterisk wildcard pattern
+    QString wildcardKeyword = "file*.txt";
+    QStringList result = strategy->extractKeywords(wildcardKeyword);
+    
+    EXPECT_GE(result.size(), 1);
+    EXPECT_EQ(result.first(), wildcardKeyword); // Original pattern should be first
+    EXPECT_TRUE(result.contains("file"));
+    EXPECT_TRUE(result.contains("txt"));
+}
+
+TEST_F(WildcardKeywordStrategyTest, ExtractKeywords_QuestionMarkWildcard_ReturnsPatternAndSegments)
+{
+    // Test extracting keywords from question mark wildcard pattern
+    QString wildcardKeyword = "test?.doc";
+    QStringList result = strategy->extractKeywords(wildcardKeyword);
+    
+    EXPECT_GE(result.size(), 1);
+    EXPECT_EQ(result.first(), wildcardKeyword); // Original pattern should be first
+    EXPECT_TRUE(result.contains("test"));
+    EXPECT_TRUE(result.contains("doc"));
+}
+
+TEST_F(WildcardKeywordStrategyTest, ExtractKeywords_MixedWildcards_ReturnsPatternAndSegments)
+{
+    // Test extracting keywords from mixed wildcard pattern
+    QString wildcardKeyword = "data*file?.backup";
+    QStringList result = strategy->extractKeywords(wildcardKeyword);
+    
+    EXPECT_GE(result.size(), 1);
+    EXPECT_EQ(result.first(), wildcardKeyword); // Original pattern should be first
+    EXPECT_TRUE(result.contains("data"));
+    EXPECT_TRUE(result.contains("file"));
+    EXPECT_TRUE(result.contains("backup"));
+}
+
+TEST_F(WildcardKeywordStrategyTest, ExtractKeywords_OnlyWildcards_ReturnsOnlyPattern)
+{
+    // Test extracting keywords from only wildcards
+    QString wildcardKeyword = "**??*";
+    QStringList result = strategy->extractKeywords(wildcardKeyword);
+    
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), wildcardKeyword); // Only original pattern
+}
+
+TEST_F(WildcardKeywordStrategyTest, ExtractKeywords_EmptyKeyword_ReturnsEmpty)
+{
+    // Test extracting keywords from empty string
+    QString emptyKeyword = "";
+    QStringList result = strategy->extractKeywords(emptyKeyword);
+    
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(WildcardKeywordStrategyTest, ExtractKeywords_DeduplicatesResults)
+{
+    // Test that duplicate segments are removed
+    QString wildcardKeyword = "test*test?.test";
+    QStringList result = strategy->extractKeywords(wildcardKeyword);
+    
+    EXPECT_EQ(result.first(), wildcardKeyword); // Original pattern first
+    // Count occurrences of "test" - should only appear once after the original pattern
+    int testCount = 0;
+    for (int i = 1; i < result.size(); ++i) {
+        if (result[i] == "test") {
+            testCount++;
+        }
+    }
+    EXPECT_EQ(testCount, 1);
+}
+
+TEST_F(WildcardKeywordStrategyTest, CanHandle_WithAsterisk_ReturnsTrue)
+{
+    // Test that WildcardKeywordStrategy can handle asterisk wildcards
+    EXPECT_TRUE(strategy->canHandle("*.txt"));
+    EXPECT_TRUE(strategy->canHandle("file*"));
+    EXPECT_TRUE(strategy->canHandle("*"));
+}
+
+TEST_F(WildcardKeywordStrategyTest, CanHandle_WithQuestionMark_ReturnsTrue)
+{
+    // Test that WildcardKeywordStrategy can handle question mark wildcards
+    EXPECT_TRUE(strategy->canHandle("file?.doc"));
+    EXPECT_TRUE(strategy->canHandle("?test"));
+    EXPECT_TRUE(strategy->canHandle("?"));
+}
+
+TEST_F(WildcardKeywordStrategyTest, CanHandle_NoWildcards_ReturnsFalse)
+{
+    // Test that WildcardKeywordStrategy cannot handle keywords without wildcards
+    EXPECT_FALSE(strategy->canHandle("normalfile.txt"));
+    EXPECT_FALSE(strategy->canHandle("test"));
+    EXPECT_FALSE(strategy->canHandle(""));
+}
+
+TEST_F(WildcardKeywordStrategyTest, Priority_ReturnsMediumPriority)
+{
+    // Test that WildcardKeywordStrategy has medium priority
+    EXPECT_EQ(strategy->priority(), 20);
+}
+
+// ============== KeywordExtractor Tests ==============
+
+TEST_F(KeywordExtractorTest, Constructor_InitializesStrategies)
+{
+    // Test that constructor properly initializes strategies
+    KeywordExtractor extractor;
+    const auto &strategies = extractor.getStrategies();
+    
+    EXPECT_EQ(strategies.size(), 3);
+    
+    // Check that strategies are sorted by priority
+    EXPECT_EQ(strategies[0]->priority(), 10); // BooleanKeywordStrategy
+    EXPECT_EQ(strategies[1]->priority(), 20); // WildcardKeywordStrategy
+    EXPECT_EQ(strategies[2]->priority(), 100); // SimpleKeywordStrategy
+}
+
+TEST_F(KeywordExtractorTest, ExtractFromUrl_ValidUrlWithKeyword_ReturnsExtractedKeywords)
+{
+    // Test extracting keywords from URL with keyword parameter
+    KeywordExtractor extractor;
+    QUrl testUrl("file:///search?keyword=hello%20world");
+    
+    QStringList result = extractor.extractFromUrl(testUrl);
+    
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_TRUE(result.contains("hello"));
+    EXPECT_TRUE(result.contains("world"));
+}
+
+TEST_F(KeywordExtractorTest, ExtractFromUrl_UrlWithoutKeyword_ReturnsEmpty)
+{
+    // Test extracting keywords from URL without keyword parameter
+    KeywordExtractor extractor;
+    QUrl testUrl("file:///search?other=value");
+    
+    QStringList result = extractor.extractFromUrl(testUrl);
+    
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(KeywordExtractorTest, ExtractFromUrl_UrlWithEncodedKeyword_ReturnsDecodedKeywords)
+{
+    // Test extracting keywords from URL with percent-encoded keyword
+    KeywordExtractor extractor;
+    QUrl testUrl("file:///search?keyword=test%2Dfile");
+    
+    QStringList result = extractor.extractFromUrl(testUrl);
+    
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), "test-file");
+}
+
+TEST_F(KeywordExtractorTest, ExtractFromKeyword_SimpleKeyword_UsesSimpleStrategy)
+{
+    // Test extracting keywords using simple strategy
+    KeywordExtractor extractor;
+    QString simpleKeyword = "test";
+    
+    QStringList result = extractor.extractFromKeyword(simpleKeyword);
+    
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), simpleKeyword);
+}
+
+TEST_F(KeywordExtractorTest, ExtractFromKeyword_BooleanKeyword_UsesBooleanStrategy)
+{
+    // Test extracting keywords using boolean strategy
+    KeywordExtractor extractor;
+    QString booleanKeyword = "hello world";
+    
+    QStringList result = extractor.extractFromKeyword(booleanKeyword);
+    
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_TRUE(result.contains("hello"));
+    EXPECT_TRUE(result.contains("world"));
+}
+
+TEST_F(KeywordExtractorTest, ExtractFromKeyword_WildcardKeyword_UsesWildcardStrategy)
+{
+    // Test extracting keywords using wildcard strategy
+    KeywordExtractor extractor;
+    QString wildcardKeyword = "*.txt";
+    
+    QStringList result = extractor.extractFromKeyword(wildcardKeyword);
+    
+    EXPECT_GE(result.size(), 1);
+    EXPECT_EQ(result.first(), wildcardKeyword);
+    EXPECT_TRUE(result.contains("txt"));
+}
+
+TEST_F(KeywordExtractorTest, ExtractFromKeyword_EmptyKeyword_ReturnsEmpty)
+{
+    // Test extracting keywords from empty string
+    KeywordExtractor extractor;
+    QString emptyKeyword = "";
+    
+    QStringList result = extractor.extractFromKeyword(emptyKeyword);
+    
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(KeywordExtractorTest, RegisterStrategy_ValidStrategy_AddsToList)
+{
+    // Test registering a new strategy
+    KeywordExtractor extractor;
+    auto initialCount = extractor.getStrategies().size();
+    
+    auto newStrategy = QSharedPointer<KeywordExtractionStrategy>(new SimpleKeywordStrategy());
+    extractor.registerStrategy(newStrategy);
+    
+    EXPECT_EQ(extractor.getStrategies().size(), initialCount + 1);
+}
+
+TEST_F(KeywordExtractorTest, RegisterStrategy_NullStrategy_DoesNotAdd)
+{
+    // Test registering null strategy
+    KeywordExtractor extractor;
+    auto initialCount = extractor.getStrategies().size();
+    
+    extractor.registerStrategy(QSharedPointer<KeywordExtractionStrategy>());
+    
+    EXPECT_EQ(extractor.getStrategies().size(), initialCount);
+}
+
+TEST_F(KeywordExtractorTest, RegisterStrategy_SortsStrategiesByPriority)
+{
+    // Test that strategies are sorted by priority after registration
+    KeywordExtractor extractor;
+    
+    // Create a custom strategy with very high priority
+    class HighPriorityStrategy : public KeywordExtractionStrategy {
+    public:
+        QStringList extractKeywords(const QString &) const override { return {}; }
+        bool canHandle(const QString &) const override { return false; }
+        int priority() const override { return 1; } // Very high priority
+    };
+    
+    auto highPriorityStrategy = QSharedPointer<KeywordExtractionStrategy>(new HighPriorityStrategy());
+    extractor.registerStrategy(highPriorityStrategy);
+    
+    const auto &strategies = extractor.getStrategies();
+    EXPECT_EQ(strategies.first()->priority(), 1); // Should be first
+}
+
+// ============== KeywordExtractorManager Tests ==============
+
+class KeywordExtractorManagerTest : public ::testing::Test
+{
+protected:
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(KeywordExtractorManagerTest, Instance_ReturnsSameInstance)
+{
+    // Test that instance() returns the same singleton instance
+    auto &instance1 = KeywordExtractorManager::instance();
+    auto &instance2 = KeywordExtractorManager::instance();
+    
+    EXPECT_EQ(&instance1, &instance2);
+}
+
+TEST_F(KeywordExtractorManagerTest, Extractor_ReturnsValidExtractor)
+{
+    // Test that extractor() returns a valid extractor
+    auto &manager = KeywordExtractorManager::instance();
+    auto &extractor = manager.extractor();
+    
+    // Test that the extractor works by checking its strategies
+    const auto &strategies = extractor.getStrategies();
+    EXPECT_GT(strategies.size(), 0);
+}
+
+TEST_F(KeywordExtractorManagerTest, Extractor_ReturnsSameExtractor)
+{
+    // Test that extractor() returns the same extractor instance
+    auto &manager = KeywordExtractorManager::instance();
+    auto &extractor1 = manager.extractor();
+    auto &extractor2 = manager.extractor();
+    
+    EXPECT_EQ(&extractor1, &extractor2);
+}
+
+// ============== Integration Tests ==============
+
+class KeywordExtractorIntegrationTest : public ::testing::Test
+{
+protected:
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(KeywordExtractorIntegrationTest, EndToEnd_ComplexScenarios)
+{
+    // Test end-to-end scenarios with different keyword types
+    auto &manager = KeywordExtractorManager::instance();
+    auto &extractor = manager.extractor();
+    
+    // Test simple keyword
+    auto simpleResult = extractor.extractFromKeyword("document");
+    EXPECT_EQ(simpleResult.size(), 1);
+    EXPECT_EQ(simpleResult.first(), "document");
+    
+    // Test boolean keyword
+    auto booleanResult = extractor.extractFromKeyword("hello world test");
+    EXPECT_EQ(booleanResult.size(), 3);
+    
+    // Test wildcard keyword
+    auto wildcardResult = extractor.extractFromKeyword("*.pdf");
+    EXPECT_GE(wildcardResult.size(), 1);
+    EXPECT_EQ(wildcardResult.first(), "*.pdf");
+    
+    // Test URL extraction
+    QUrl testUrl("file:///search?keyword=test%20file");
+    auto urlResult = extractor.extractFromUrl(testUrl);
+    EXPECT_EQ(urlResult.size(), 2);
+    EXPECT_TRUE(urlResult.contains("test"));
+    EXPECT_TRUE(urlResult.contains("file"));
+}
+
+TEST_F(KeywordExtractorIntegrationTest, PriorityHandling_SelectsCorrectStrategy)
+{
+    // Test that the correct strategy is selected based on priority
+    auto &extractor = KeywordExtractorManager::instance().extractor();
+    
+    // Wildcard should take precedence over boolean for "test *.txt"
+    // (assuming wildcard has higher priority than boolean for this specific case)
+    QString mixedKeyword = "test*.txt file";
+    auto result = extractor.extractFromKeyword(mixedKeyword);
+    
+    // Should use wildcard strategy because it contains '*'
+    EXPECT_GE(result.size(), 1);
+    EXPECT_EQ(result.first(), mixedKeyword); // Wildcard strategy puts original pattern first
+} 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.84) unstable; urgency=medium
+
+  * fix bugs
+	* autotests 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 08 Aug 2025 15:26:36 +0800
+
 dde-file-manager (6.5.83) unstable; urgency=medium
 
   * enable symlinks for template menu files

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -120,6 +120,8 @@ private:   // file copy
     void syncBlockFile(const DFileInfoPointer toInfo);
     int openFileBySys(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,
                       const int flags, bool *skip, const bool isSource = true);
+    bool shouldSyncToDevice(const DFileInfoPointer &toInfo) const;
+    bool shouldSyncToDevice(bool toIsSmb) const;
 public:
     static void progressCallback(int64_t current, int64_t total, void *progressData);
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1229,6 +1229,7 @@ void FileOperateBaseWorker::determineCountProcessType()
 
                         if (targetIsRemovable) {
                             workData->exBlockSyncEveryWrite = FileOperationsUtils::blockSync();
+                            workData->expandDiskSync = FileOperationsUtils::expandDiskSync();
                             countWriteType = workData->exBlockSyncEveryWrite ? CountWriteSizeType::kCustomizeType
                                                                              : CountWriteSizeType::kWriteBlockType;
                             targetDeviceStartSectorsWritten = workData->exBlockSyncEveryWrite ? 0 : getSectorsWritten();
@@ -1258,8 +1259,7 @@ void FileOperateBaseWorker::determineCountProcessType()
 
 void FileOperateBaseWorker::syncFilesToDevice()
 {
-
-    if (isTargetFileLocal)
+    if (isTargetFileLocal || !workData->expandDiskSync)
         return;
 
     fmInfo() << "start sync all file to extend block device!!!!! target : " << targetUrl;

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -32,6 +32,7 @@ inline constexpr char kFileOperations[] { "org.deepin.dde.file-manager.operation
 inline constexpr char kFileBigSize[] { "file.operation.bigfilesize" };
 inline constexpr char kBlockEverySync[] { "file.operation.blockeverysync" };
 inline constexpr char kBroadcastPaste[] { "file.operation.broadcastpastevent" };
+inline constexpr char kExpandDiskSync[] { "file.operation.expanddisksync" };
 QMutex FileOperationsUtils::mutex;
 
 /*!
@@ -184,4 +185,10 @@ bool FileOperationsUtils::canBroadcastPaste()
 {
     // 组策略中配置
     return DConfigManager::instance()->value(kFileOperations, kBroadcastPaste, false).toBool();
+}
+
+bool FileOperationsUtils::expandDiskSync()
+{
+    // 组策略中配置
+    return DConfigManager::instance()->value(kFileOperations, kExpandDiskSync, true).toBool();
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -71,6 +71,7 @@ private:
     static bool blockSync();
     static QUrl parentUrl(const QUrl &url);
     static bool canBroadcastPaste();
+    static bool expandDiskSync();
 
 private:
     static QSet<QString> fileNameUsing;

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
@@ -58,6 +58,7 @@ public:
     std::atomic_bool exBlockSyncEveryWrite { false };
     std::atomic_bool isFsTypeVfat { false };
     std::atomic_bool isBlockDevice { false };
+    std::atomic_bool expandDiskSync { true };
     std::atomic_bool copyFileRange { false };
     std::atomic_int64_t currentWriteSize { 0 };
     QAtomicInteger<qint64> zeroOrlinkOrDirWriteSize { 0 };   // The copy size is 0. The write statistics size of the linked file and directory

--- a/src/plugins/desktop/ddplugin-background/backgroundservice.h
+++ b/src/plugins/desktop/ddplugin-background/backgroundservice.h
@@ -33,7 +33,7 @@ protected slots:
 
 protected:
     int getCurrentWorkspaceIndex();
-    int currentWorkspaceIndex = 1;   // worksapce index is started with 1.
+    int currentWorkspaceIndex = 1;   // workspace index is started with 1.
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     WMInter *wmInter = nullptr;
 #endif

--- a/src/plugins/filemanager/dfmplugin-detailspace/events/detailspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/events/detailspaceeventreceiver.h
@@ -31,7 +31,7 @@ public slots:
     bool handleBasicFiledFilterAdd(const QString &scheme, const QStringList &enums);
     bool handleBasicFiledFilterRootAdd(const QString &scheme, const QStringList &enums);
 
-    // worksapce
+    // workspace
     void handleViewSelectionChanged(const quint64 windowID, const QItemSelection &selected, const QItemSelection &deselected);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-workspace/views/cansetdragtextedit.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/cansetdragtextedit.cpp
@@ -4,7 +4,9 @@
 
 #include "cansetdragtextedit.h"
 
+#ifndef DFM_UNIT_TEST_DISABLE_QT_PRIVATE
 #include <private/qtextedit_p.h>
+#endif
 
 using namespace dfmplugin_workspace;
 
@@ -20,6 +22,13 @@ CanSetDragTextEdit::CanSetDragTextEdit(const QString &text, QWidget *parent)
 
 void CanSetDragTextEdit::setDragEnabled(const bool &bdrag)
 {
+#ifndef DFM_UNIT_TEST_DISABLE_QT_PRIVATE
     QTextEditPrivate *dd = reinterpret_cast<QTextEditPrivate *>(qGetPtrHelper(d_ptr));
     dd->control->setDragEnabled(bdrag);
+#else
+    // Fallback implementation for unit tests
+    // Use the public API which may have limited functionality
+    setAcceptDrops(bdrag);
+    Q_UNUSED(bdrag)
+#endif
 }


### PR DESCRIPTION
- test: reorganize test plugins and improve workspace tests
- feat: add expand disk sync configuration option

## Summary by Sourcery

Introduce a new expandDiskSync option to control disk sync behavior in file operations, refactor sync logic for clarity and performance, reorganize plugin testing setup to enhance workspace test configuration, and add comprehensive KeywordExtractor unit tests.

New Features:
- Add expandDiskSync configuration option to control whether disk sync is performed during file operations

Enhancements:
- Abstract sync condition into shouldSyncToDevice methods in DoCopyFileWorker and refactor syncFilesToDevice logic in FileOperateBaseWorker
- Refactor workspace plugin CMake configuration to precisely gather test files, configure dependencies, and disable Qt private class usage in unit tests
- Add fallback implementation for CanSetDragTextEdit when Qt private APIs are disabled
- Reorder plugin subdirectories in autotests CMakeLists for consistent test builds

Tests:
- Add extensive unit tests for KeywordExtractor and its strategies under dfmplugin-workspace
- Integrate new workspace tests into plugin test CMake configuration