### PR TITLE
fix: update translations of lo

### DIFF
--- a/translations/dde-computer-desktop/desktop_lo.ts
+++ b/translations/dde-computer-desktop/desktop_lo.ts
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>Computer</source>
+        <translation>ຄុែងຄំណតៃ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Comment" line="0"/>
+        <source>Show basic info of the computer.</source>
+        <translation>បង្ហាញព័ត៌មានមូលដ្ឋាននៃកុំពិនិត្យ</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-file-manager-desktop/desktop_lo.ts
+++ b/translations/dde-file-manager-desktop/desktop_lo.ts
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]Comment" line="0"/>
+        <source>Browse the file system</source>
+        <translation>ຄົ້ນຫາລະບົບແຟ້ມ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Deepin File Manager</source>
+        <translation>ຕູ້ຈັດການແຟ້ມ Deepin</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>File Manager</source>
+        <translation>ຕູ້ຈັດການແຟ້ມ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Action new-window]Name" line="0"/>
+        <source>New Window</source>
+        <translation>ຫນ້າຕ່າງໃໝ່</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-file-manager_lo.ts
+++ b/translations/dde-file-manager_lo.ts
@@ -1,0 +1,7452 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>AccessControlDBus</name>
+    <message>
+        <location filename="../src/services/accesscontrol/accesscontroldbus.cpp" line="49"/>
+        <source>Invalid args</source>
+        <translation>លានសម្រាប់មិនត្រឹមត្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/services/accesscontrol/accesscontroldbus.cpp" line="50"/>
+        <source>Invalid invoker</source>
+        <translation>ຜູ້ກຳນຳໃຊ້ບໍ່ຖືກນຳໃຊ້ຢ່າງຖືກອະນັບຮັບ</translation>
+    </message>
+</context>
+<context>
+    <name>Application</name>
+    <message>
+        <location filename="../src/apps/dde-file-manager/main.cpp" line="353"/>
+        <source>File Manager</source>
+        <translation>ຫຼຸບຸດແ ഍ືບຸດໃນລະບຸບ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager/main.cpp" line="358"/>
+        <source>File Manager is a powerful and easy-to-use file management tool, featured with searching, copying, trash, compression/decompression, file property and other useful functions.</source>
+        <translation>ຕົວຈັດການໄຟລ໌ແມ່ນເຄື່ອງມືຈັດການໄຟລ໌ທີ່ມີພະລັງງານແລະໃຊ້ງານງ່າຍ, ມີຟັງຊັນຄົ້ນຫາ, ສຳເນົາ, ຖັງຂີ້ເຫຍື້ອ, ບີບອັດ/ເປີດບີບອັດ, ຄຸນສົມບັດໄຟລ໌ ແລະຟັງຊັນອື່ນໆທີ່ມີປະໂຫຍດ.</translation>
+    </message>
+</context>
+<context>
+    <name>DMInitEncryptWorker</name>
+    <message>
+        <location filename="../src/services/diskencrypt/workers/dminitencryptworker.cpp" line="49"/>
+        <source>Initialize encryption </source>
+        <translation>ເລີ່ມຕົ້ນການລັບລາຍການ</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceList</name>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp" line="148"/>
+        <source>Disks</source>
+        <translation>ແຜ່ນໄດສ്രິບ</translation>
+    </message>
+</context>
+<context>
+    <name>DiskMountPlugin</name>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/diskmountplugin.cpp" line="38"/>
+        <source>Disk</source>
+        <translation>ດິສກ</translation>
+    </message>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/diskmountplugin.cpp" line="85"/>
+        <source>Open</source>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/diskmountplugin.cpp" line="92"/>
+        <source>Eject all</source>
+        <translation>ຖອດທີ່ທີ່ທີ່ທີ່</translation>
+    </message>
+</context>
+<context>
+    <name>DoCopyFileWorker</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp" line="668"/>
+        <source>Can&apos;t access file!</source>
+        <translation>ບໍ່ສາມາດເຂົ້າເຖິງຟາຍໄດ້!</translation>
+    </message>
+</context>
+<context>
+    <name>DockItemDataManager</name>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp" line="163"/>
+        <source>The device has been safely removed</source>
+        <translation>ອົບຮົມໄດ້ຖືກຖອດອອກຢ່າງປອດໄພ</translation>
+    </message>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp" line="180"/>
+        <source>eject</source>
+        <translation>ຖອດອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp" line="181"/>
+        <source>unmount</source>
+        <translation>ຖອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp" line="182"/>
+        <source>remove</source>
+        <translation>ລູກອົບຮົມ</translation>
+    </message>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp" line="184"/>
+        <source>Operation failed</source>
+        <translation>ການດຳເນີນງານລີກສິ່ງຜົນບໍ່ສົ່ງເຖິງຄວາມຮັບຜົນງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp" line="185"/>
+        <source>Device (%1) is busy, cannot %2 now.</source>
+        <translation>ອຸປະກອນ (%1) ເປັນໄປບານ, ເທັນທີ້ %2 ເບີ້ບໍ່ໄດ້.</translation>
+    </message>
+</context>
+<context>
+    <name>FileDialogHandle</name>
+    <message>
+        <location filename="../src/plugins/filedialog/core/dbus/filedialoghandle.cpp" line="588"/>
+        <source>All Files </source>
+        <translation>ທີ່ທີ່ທີ່ທີ່ທີ່</translation>
+    </message>
+</context>
+<context>
+    <name>FileOperateBaseWorker</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp" line="686"/>
+        <source>The file name or the path is too long!</source>
+        <translation>ຊື່ໄຸດຕໍ້ອຸບຸດ ຫື path ເຂັ້ມຂ຺້ນເກີ້ນ!</translation>
+    </message>
+</context>
+<context>
+    <name>FstabDecryptWorker</name>
+    <message>
+        <location filename="../src/services/diskencrypt/workers/fstabdecryptworker.cpp" line="27"/>
+        <source>Decrypting </source>
+        <translation>ອະຄະນະການລັກສະນະລະບອດ</translation>
+    </message>
+</context>
+<context>
+    <name>FstabInitEncryptWorker</name>
+    <message>
+        <location filename="../src/services/diskencrypt/workers/fstabinitencryptworker.cpp" line="24"/>
+        <source>Initialize encryption </source>
+        <translation>ເລີ່ມຕົ້ນການລັບລາຍການ</translation>
+    </message>
+</context>
+<context>
+    <name>MimeTypeDisplayManager</name>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="780"/>
+        <source>Unknown</source>
+        <translation>ບໍ່ແນ່ນອນ</translation>
+    </message>
+</context>
+<context>
+    <name>NormalDecryptWorker</name>
+    <message>
+        <location filename="../src/services/diskencrypt/workers/normaldecryptworker.cpp" line="22"/>
+        <source>Decrypting </source>
+        <translation>ການຖອດລັບ</translation>
+    </message>
+</context>
+<context>
+    <name>NormalInitEncryptWorker</name>
+    <message>
+        <location filename="../src/services/diskencrypt/workers/normalinitencryptworker.cpp" line="23"/>
+        <source>Initialize encryption </source>
+        <translation>ເລີ່ມຕົ້ນການລັບລາຍການ</translation>
+    </message>
+</context>
+<context>
+    <name>PathManager</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-trashcore/trashfileinfo.cpp" line="238"/>
+        <source>Trash</source>
+        <translation>ຖານະພະຍາດ</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/dfm-base/base/device/devicemanager.cpp" line="1105"/>
+        <source>need authorization to access</source>
+        <translation>ຕ້ອງມີການອະນັບເອງເພື່ອເຂົ້າເຖິງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/devicemanager.cpp" line="1112"/>
+        <source>Authentication Required
+Enter user and password for %1</source>
+        <translation>ຕ້ອງມີການອະນັບເອງ
+ປ້ອງກັນຜູ້ пользователя ແລະ ཀໍລາດສະຫຼຎສື ຈື %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/devicemanager.cpp" line="1184"/>
+        <source>Can&apos;t verify the identity of %1.</source>
+        <translation>ບໍ່ສາມາດຢຸດທີ້ຕີດຕໍ້ອຸບຸດ %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/devicemanager.cpp" line="1185"/>
+        <source>This happens when you log in to a computer the first time.</source>
+        <translation>ນີ້ເກີດຂຶ້ນໃນເວລາທີ້ງເທີງຄຸມມືໃຫ້ອຸປະກອນເປັນຄັ້ງທີ້ງຫົນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/devicemanager.cpp" line="1186"/>
+        <source>The identity sent by the remote computer is</source>
+        <translation>ຕີດຕໍ້ອຸບຸດທີ້ງແໜ້ອອອນໄດ້ສຈງມາແມ່ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/devicemanager.cpp" line="1188"/>
+        <source>If you want to be absolutely sure it is safe to continue, contact the system administrator.</source>
+        <translation>ຖ້າທ່ານຢາກແນ່ໃຈວ່າມັນປອດໄພເພື່ອຈັດການຕໍ່, ອີງຕໍ່ລະບົບຜູ້ດູແລລະບົບ.</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/libdfm-preview/filepreview.cpp" line="80"/>
+        <source>System Disk</source>
+        <translation>ລະບົບໄົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/deviceutils.cpp" line="386"/>
+        <source>Data Disk</source>
+        <translation>ຂໍ້ນຫຸ່ງສືບສວນຂໍ້ນຫຸ່ງຂໍ້ນຫຸ່ງຂໍ້ນຫຸ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/deviceutils.cpp" line="437"/>
+        <source>Blank %1 Disc</source>
+        <translation>Disc བໍ້ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/deviceutils.cpp" line="437"/>
+        <source>Unknown</source>
+        <translation>មិនស្គ្រាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/deviceutils.cpp" line="447"/>
+        <source>%1 Drive</source>
+        <translation>ດຣາຍ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/deviceutils.cpp" line="396"/>
+        <source>%1 Encrypted</source>
+        <translation>&apos;%1 បាញេស&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/deviceutils.cpp" line="474"/>
+        <source>%1 Volume</source>
+        <translation>ບໍລິເວນ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/private/devicehelper.cpp" line="285"/>
+        <source>Scanning the device, stop it?</source>
+        <translation>កំពិតរាស់, ຢາបូរ៉ាត?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/private/devicehelper.cpp" line="292"/>
+        <source>Unmount failed</source>
+        <translation>យកចេញមិនបាន</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/private/devicehelper.cpp" line="292"/>
+        <source>Cannot stop scanning device</source>
+        <translation>ບໍ່ສາມາດຢຸດການສະແກນອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/device/private/devicehelper.cpp" line="417"/>
+        <source>%1 on %2</source>
+        <translation>&apos;%1 នៅលើ %2&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="203"/>
+        <source>Home</source>
+        <translation>ບ້ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="205"/>
+        <source>Desktop</source>
+        <translation>ផ្ទៃតុ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="207"/>
+        <source>Videos</source>
+        <translation>ວີດີໂອ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="209"/>
+        <source>Music</source>
+        <translation>មូសឿច</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="211"/>
+        <source>Pictures</source>
+        <translation>ຮູບພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="213"/>
+        <source>Documents</source>
+        <translation>ເອກະສານ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="215"/>
+        <source>Downloads</source>
+        <translation>ການດາວໂນດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="217"/>
+        <source>Trash</source>
+        <translation>គ្រូងស្លាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/standardpaths.cpp" line="219"/>
+        <source>Recent</source>
+        <translation>ចុងក្រោយ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/settingsdialog/settingdialog.cpp" line="215"/>
+        <source>Auto mount</source>
+        <translation>ອັດຕະໂມດ ഴུ་ཁོངས</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/settingsdialog/settingdialog.cpp" line="241"/>
+        <source>Open after auto mount</source>
+        <translation>ອັດຕະໂມດ ഴུ་ཁོངས ഥິག വັນ ലິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskdialog.cpp" line="151"/>
+        <source>%1 tasks in progress</source>
+        <translation>%1 ការងារកំពុងដំណើរ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="787"/>
+        <source>%1 item</source>
+        <translation>%1 ធាតុ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="788"/>
+        <source>%1 items</source>
+        <translation>%1 ធាតុ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/file/local/localfilehandler.cpp" line="1336"/>
+        <source>Unable to find the original file</source>
+        <translation>មិនអាចស្វែងរកឯកសារបង្កើតបានទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/file/local/asyncfileinfo.cpp" line="442"/>
+        <source>File has been moved or deleted</source>
+        <translation>ឯកសារត្រូវបានផ្លាស់ទីឬលើកចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/file/local/asyncfileinfo.cpp" line="448"/>
+        <source>You do not have permission to access this folder</source>
+        <translation>អ្នកមិនមែនមានសិទ្ធិចុងក្រោយសម្រាប់ចុចចឹងទៅតាមបណ្តាតាននេះទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/file/local/asyncfileinfo.cpp" line="451"/>
+        <source>You do not have permission to traverse files in it</source>
+        <translation>ທ່ານບໍ່ມີສິດໃນການເດີນທາງໄຟລ໌ໃນນັ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/interfaces/fileinfo.cpp" line="443"/>
+        <source>Folder is empty</source>
+        <translation>ថតុប្រជែលទើបទឺំទួច</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/interfaces/fileinfo.cpp" line="445"/>
+        <source>Loading...</source>
+        <translation>ກຳລັງໂຫຼດ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="66"/>
+        <source>Executable</source>
+        <translation>អានុវត្តកម្ម</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="7"/>
+        <source>Use the file chooser dialog of File Manager</source>
+        <translation>ໃຊ້ປ້ອງກັນການເລືອກໄຟລ໌ຂອງຕົວຈັດການໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="8"/>
+        <source>Ask for my confirmation when deleting files</source>
+        <translation>សូមស្វែងយកការបញ្ជាក់របស់ខ្លឹមពេលលើងយកឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="9"/>
+        <source>Index external storage device after connected to computer</source>
+        <translation>បញ្ជូនឧបកម្មផ្ទុកទិន្នន័យខាងក្រៅទៅកុំព្យុតបន្ទាប់ពីបញ្ជាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="10"/>
+        <source>Auto index internal disk</source>
+        <translation>ຈັດຝາກດິສກິນເຕີນອິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="11"/>
+        <source>Full-Text search</source>
+        <translation>ស្ទាត់ស្រាល់ពីចំណើនពេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="12"/>
+        <source>Built-in disks</source>
+        <translation>ດິສກິນເຕີນອິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="13"/>
+        <source>Computer</source>
+        <translation>កុំព្យុត</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="14"/>
+        <source>Computers in LAN</source>
+        <translation>កុំព្យុតក្នុង LAN</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="19"/>
+        <source>Loop partitions</source>
+        <translation>រូបរាងចង្អៀតបង្វាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="20"/>
+        <source>Mounted sharing folders</source>
+        <translation>ផ្នែកចែកចាយដែលបានត្រូវតា</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="22"/>
+        <source>My shares</source>
+        <translation>ການແບ່ງປັນຂອງຂ້ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="23"/>
+        <source>Network</source>
+        <translation>តំបន់បណ្តាត៉ា</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="24"/>
+        <source>Mounted partitions and discs</source>
+        <translation>រូបរាងចង្អៀតនិងភ្នំមេដែលបានត្រូវតា</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="25"/>
+        <source>Partitions</source>
+        <translation>រូបរាងចង្អៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="27"/>
+        <source>Quick access</source>
+        <translation>ການເຂົ້າເຖິງໄວ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="29"/>
+        <source>Tag</source>
+        <translation>ຖະແຫຼ່ງຂໍ້າງສໍາຄັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="30"/>
+        <source>Added tags</source>
+        <translation>ຖຳນອົງກອບຖຳນອົງກອບໄດ້ເພີ່ມ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="32"/>
+        <source>Vault</source>
+        <translation>ບົວລຸງຄຳລາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="34"/>
+        <source>Keep showing the mounted Samba shares</source>
+        <translation>ຕໍ່ສະຫຼຫກຳນົດ Samba ഭຳະນາໄື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="37"/>
+        <source>Merge the entries of Samba shared folders</source>
+        <translation>ກຳນົດເຂົ້າ Samba ഭຳະນາໄື້ນ ഍່ງກຳນົດເຂົ້າແບບຮ່ວມກຳນົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="38"/>
+        <source>Show item counts and sizes in the path of mounted MTP devices</source>
+        <translation>ສະແໜ່ງແບບສະແລງສະຫຼຫຂໍ້າງ പັນທະນານື້ອງ ഭຳະນາໄື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="39"/>
+        <source>Extend filename characters</source>
+        <translation>ຍາການນັ້ນຄຳບຳບັນທົງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="40"/>
+        <source>Hide built-in disks on the Computer page</source>
+        <translation>ປັນການສະແໜ່ງແບບບົວລຸງແບບເນີ້ນຂໍ້າງໃນຫຼຸດ່າງຄຳແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="41"/>
+        <source>Hide loop partitions on the Computer page</source>
+        <translation>ປັນການສະແໜ່ງແບບບົວລຸງແບບເນີ້ນຂໍ້າງໃນຫຼຸດ່າງຄຳແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="42"/>
+        <source>Show crumb bar clickable area</source>
+        <translation>ສະແດງເຂດທີ່ສາມາດຄລິກໄດ້ຂອງບໍ່ລິ່ງຄ່ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="43"/>
+        <source>Show file system on disk icon</source>
+        <translation>ສະແໜ່ງແບບສະແລງລະບົບໄື້ນໃນບົວລຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="45"/>
+        <source>Compressed file preview</source>
+        <translation>ສະແໜ່ງແບບສະແລງຂໍ້າງທົດບົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="46"/>
+        <source>Document preview</source>
+        <translation>ສະແໜ່ງແບບສະແລງເອກະສານ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="47"/>
+        <source>Image preview</source>
+        <translation>ຂ picture preview</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="48"/>
+        <source>The remote environment shows thumbnail previews</source>
+        <translation>ສະພາບແວດລ້ອມໄລຍະໄກສະແດງຮູບພາບນ້ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="49"/>
+        <source>Text preview</source>
+        <translation>ການສະແດງເນື້ອໃນຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="50"/>
+        <source>Video preview</source>
+        <translation>ການສະແດງຮູບເງິນວີດີໂອ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="52"/>
+        <source>Default icon size:</source>
+        <translation>גודל значкаเริ่มต้น:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="44"/>
+        <source>Music preview</source>
+        <translation>ตัวอย่างเพลง</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="51"/>
+        <source>Show hidden files in search results</source>
+        <translation>แสดงไฟล์ซ่อนในผลการค้นหา</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="53"/>
+        <source>Extra small</source>
+        <translation>สุดยิ่งเล็ก</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="54"/>
+        <source>Small</source>
+        <translation>เล็ก</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="55"/>
+        <source>Medium</source>
+        <translation>ปานกลาง</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="56"/>
+        <source>Large</source>
+        <translation>ใหญ่</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="57"/>
+        <source>Extra large</source>
+        <translation>ໃຫຍ່ຫຼວງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="58"/>
+        <source>Mix sorting of files and folders</source>
+        <translation>ผสมผสานการจัดเรียงไฟล์และโฟลเดอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="59"/>
+        <source>Default view:</source>
+        <translation>มุมมองเริ่มต้น:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="60"/>
+        <source>Show hidden files</source>
+        <translation>แสดงไฟล์ซ่อน</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="61"/>
+        <source>Show file extensions</source>
+        <translation>បង្ហាញូសែតឈ្មោះឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="62"/>
+        <source>Open from default window:</source>
+        <translation>เปิดจากหน้าต่างเริ่มต้น:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="63"/>
+        <source>Open in new tab:</source>
+        <translation>ច័កចូលក្នុងតារាក្នុងថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="64"/>
+        <source>Always open folder in new window</source>
+        <translation>រួមទាំងច័កចូលថតិកានៅក្នុងរបាយកម្មថ្មីជានីមិនចុះ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="65"/>
+        <source>Open file:</source>
+        <translation>ច័កចូលឯកសារ:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="66"/>
+        <source>Click</source>
+        <translation>ចូលចូលចូល</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="67"/>
+        <source>Double click</source>
+        <translation>ចូលចូលចូលលើពីចំនុចពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="68"/>
+        <source>Advanced</source>
+        <translation>ជុះជុះ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="69"/>
+        <source>Dialog</source>
+        <translation>ការសន្ទនា</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="70"/>
+        <source>Index</source>
+        <translation>ดัชนี</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="71"/>
+        <source>Items on sidebar pane</source>
+        <translation>ធាតុនៅលើផ្នែកខណ្ឌរបស់វិធីសាស្ត្រ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="72"/>
+        <source>Mount</source>
+        <translation>ត្រូវបានតម្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="73"/>
+        <source>Other</source>
+        <translation>ផ្សេងទៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="74"/>
+        <source>Preview</source>
+        <translation>មុតសម្បត្តិ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="75"/>
+        <source>Basic</source>
+        <translation>ພື້ນຖານ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="76"/>
+        <source>View</source>
+        <translation>ເບ຺່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="77"/>
+        <source>Hidden files</source>
+        <translation>ເອກະສານທີ່ຖັນໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="78"/>
+        <source>New window and tab</source>
+        <translation>หน้าต่างและแท็บใหม่</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-fedora-trans.cpp" line="79"/>
+        <source>Open behavior</source>
+        <translation>ການກ່ຽວຂ້ອງກັບການເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-manully-trans.cpp" line="24"/>
+        <source>Icon</source>
+        <translation>ສີມີບອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-manully-trans.cpp" line="25"/>
+        <source>List</source>
+        <translation>ບັນຊີລາຍຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-manully-trans.cpp" line="27"/>
+        <source>Current Directory</source>
+        <translation>ເົ້າທີ່ມັນຕົວຈິງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-manully-trans.cpp" line="29"/>
+        <source>Turning on the thumbnail preview may cause the remote directory to load slowly or the operation to freeze</source>
+        <translation>ການເປີດເບິ່ງຮູບແບບຂອງຮູບພາບນ້ອຍອາດຈະເຮັດໃຫ້ບັນຊີລາຍຊື່ໄລຍະໄກໂດດເຊື່ອງຊ້າຫຼືການດຳເນີນງານຖືກຄັດຕິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-manully-trans.cpp" line="30"/>
+        <source>Switching the entry display may lead to failed mounting</source>
+        <translation>ການປ່ຽນແປງການສະແດງຕຳແໜ່ງອາດຈະເຮັດໃຫ້ການຕິດຕັ້ງບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp" line="37"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="44"/>
+        <source>Stop</source>
+        <comment>button</comment>
+        <translation>ຢາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/fileutils.cpp" line="695"/>
+        <source>Shortcut</source>
+        <translation>ລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/fileutils.cpp" line="1059"/>
+        <source>This system wallpaper is locked. Please contact your admin.</source>
+        <translation>ຮູບພາບຂອງຣະບບນີ້ຖືກລັກສະນະ. ກະລຸນາຕິດຕໍ່ຜູ້ດູແລຂອງທ່ານ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.cpp" line="127"/>
+        <source> (copy)</source>
+        <comment>this should be translated in Noun version rather Verb, the first space should be ignore if translate to Chinese</comment>
+        <translation> &apos; (ລາຍການຄຳແບບ)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.cpp" line="128"/>
+        <source> (copy %1)</source>
+        <comment>this should be translated in Noun version rather Verb, the first space should be ignore if translate to Chinese</comment>
+        <translation> &apos; (ລາຍການຄຳແບບ %1)&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/universalutils.cpp" line="82"/>
+        <source>dde-file-manager</source>
+        <translation>dde-file-manager</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/universalutils.cpp" line="180"/>
+        <source>Files are being processed</source>
+        <translation>ཡົດທືນກັນກຳນຳໃຊ້ງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/universalutils.cpp" line="213"/>
+        <source>Bit</source>
+        <translation>ບີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="143"/>
+        <source>Access denied</source>
+        <translation>ການເຂົ້າເຖິງຖືກປິດກັ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp" line="38"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>ຢັນທົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/bookmarkcallback.cpp" line="40"/>
+        <source>Open in new window</source>
+        <translation>ເປີດໃນໜ້າຕ່າງໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/bookmarkcallback.cpp" line="43"/>
+        <source>Open in new tab</source>
+        <translation>ເປີດໃນຕາເວັນໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/bookmarkcallback.cpp" line="50"/>
+        <source>Rename</source>
+        <translation>ປັບປຸງຄີ້ງຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/bookmarkcallback.cpp" line="55"/>
+        <source>Remove from quick access</source>
+        <translation>ລຸບອອກຈາກການເຂົ້າເຖິງໄວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/bookmarkcallback.cpp" line="60"/>
+        <source>Properties</source>
+        <translation>ຄັນພື່ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="52"/>
+        <source>New Folder</source>
+        <translation>ບ່ອນເກັບໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="55"/>
+        <source>New Text</source>
+        <translation>ຂໍ້ຄວາມໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="59"/>
+        <source>Document</source>
+        <translation>ເອກະສານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="63"/>
+        <source>Spreadsheet</source>
+        <translation>ຕາຕ຾້ນຄື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="67"/>
+        <source>Presentation</source>
+        <translation>ການສະແດງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="71"/>
+        <source>New File</source>
+        <translation>קובץ חדש</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp" line="199"/>
+        <source>Create symlink</source>
+        <translation>ສ້າງ symlink</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/oemmenuscene/oemmenu.cpp" line="541"/>
+        <source>Compress</source>
+        <translation>ກmprɛss</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="145"/>
+        <source>Write only</source>
+        <translation>כתוב בלבד</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="147"/>
+        <source>Read only</source>
+        <translation>קריאה בלבד</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="149"/>
+        <source>Read-write</source>
+        <translation>קריאה וכתיבה</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="156"/>
+        <source>Owner</source>
+        <translation>ឡូwner</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="160"/>
+        <source>Group</source>
+        <translation>קבוצה</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="164"/>
+        <source>Others</source>
+        <translation>אחרים</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="108"/>
+        <source>Burn</source>
+        <comment>button</comment>
+        <translation>ışpak</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="119"/>
+        <source>Disc name:</source>
+        <translation>ຊື່ດີ້ວ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="188"/>
+        <source>Write speed:</source>
+        <translation>מהירות כתיבה:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="191"/>
+        <source>Maximum</source>
+        <translation>מקסימום</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="198"/>
+        <source>Allow files to be added later</source>
+        <translation>אפשר להוסיף קבצים מאוחר יותר</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="208"/>
+        <source>Verify data</source>
+        <translation>אמת נתונים</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="212"/>
+        <source>Eject</source>
+        <translation>ထုတ်ယုတ်</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/menus/sendtodiscmenuscene.cpp" line="183"/>
+        <source>Add to disc</source>
+        <translation>ເພີ່ມເຂົ້າໃນດີ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="35"/>
+        <source>Are you sure you want to erase all data on the disc?</source>
+        <translation>តុប្រាកដ ថាគឺជាទំនាក់ទំនងការលើងឹមអត្តសញ្ញាណរបស់អ្នក។</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="38"/>
+        <source>Erase</source>
+        <comment>button</comment>
+        <translation>លើងឹម</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="47"/>
+        <source>This action cannot be undone</source>
+        <translation>ການດຳເນີນການນີ້ບໍ່ສາມາດຍົກເລີກໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="61"/>
+        <source>How do you want to use this disc?</source>
+        <translation>ဒီดိսကို ဘယ်လိုအသုံးပြုရမလဲ?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="64"/>
+        <source>Burn image</source>
+        <comment>button</comment>
+        <translation>ចាក់រូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="65"/>
+        <source>Burn files</source>
+        <comment>button</comment>
+        <translation>ចាក់ឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="121"/>
+        <source>%1 is a duplicate file.</source>
+        <translation>%1 သည် ဒီဇျောက်ဖျက်ဖိုင်တစ်ခုဖြစ်သည်။</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="124"/>
+        <source>Insufficient disc space.</source>
+        <translation>មានជម្ងាយអាចរ៉ាប់របស់ឌិសមិនគ្រប់គ្រាន់។</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="127"/>
+        <source>Lost connection to drive.</source>
+        <translation>ချက်ချင်းချိတ်ဆက်မှုကျော်ကွက်ပြီး ဆုံးရှုပါသည်။</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="130"/>
+        <source>The CD/DVD drive is not ready. Try another disc.</source>
+        <translation>CD/DVD ချက်ချင်းချိတ်ဆက်မှုကျော်ကွက်ပြီး ဆုံးရှုပါသည်။</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="133"/>
+        <source>The CD/DVD drive is busy. Exit the program using the drive, and insert the drive again.</source>
+        <translation>ປ່ອນດີ້ວ CD/DVD ອິດສະຫຼັບ. ລ້າງໂປແກຼມທີ່ໃຊ້ດີ້ວ, ແລ້ວໃສ່ດີ້ວອີກຄັ້ງ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="137"/>
+        <source>Invalid volume name</source>
+        <translation>မမှန်ကန်တဲ့ အမည်ပေးခြင်း</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp" line="140"/>
+        <source>Unknown error</source>
+        <translation>ស្តុចស្រាល់មិនស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="295"/>
+        <source>Close</source>
+        <comment>button</comment>
+        <translation>ປິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp" line="39"/>
+        <source>Open</source>
+        <comment>button</comment>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp" line="138"/>
+        <source>Size: %1</source>
+        <translation>ຂະແຫ້ອງ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp" line="139"/>
+        <source>Type: %1</source>
+        <translation>ປະເພດ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp" line="145"/>
+        <source>Size: 0</source>
+        <translation>ຂະແຫ້ອງ: 0</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp" line="158"/>
+        <source>Items: %1</source>
+        <translation>ອີtem: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="298"/>
+        <source>Orange</source>
+        <translation>អូរ៉ងែ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="299"/>
+        <source>Red</source>
+        <translation>ສີແດງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="300"/>
+        <source>Purple</source>
+        <translation>ສີບ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="301"/>
+        <source>Navy-blue</source>
+        <translation>ນີ້ວບື</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="302"/>
+        <source>Azure</source>
+        <translation>ອົສາສາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="303"/>
+        <source>Green</source>
+        <translation>ខែខោន</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="304"/>
+        <source>Yellow</source>
+        <translation>ເນີ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/taghelper.cpp" line="305"/>
+        <source>Gray</source>
+        <translation>ស្តុច</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp" line="578"/>
+        <source>Remove</source>
+        <translation>លើកចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="330"/>
+        <source>Rename</source>
+        <comment>button</comment>
+        <translation>Rename</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/utils/corehelper.cpp" line="73"/>
+        <source>This file will be hidden if the file name starts with &apos;.&apos;. Do you want to hide it?</source>
+        <translation>ຟາຍນີ້ຈະຖືກດັບຖ້າຊື່ຟາຍເລີ່ມຕົ້ນດ້ວຍ &apos;.&apos; . ທ່ານຕ້ອງການດັບມັນບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/utils/corehelper.cpp" line="74"/>
+        <source>Hide</source>
+        <comment>button</comment>
+        <translation>លាក់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/utils/corehelper.cpp" line="104"/>
+        <source>%1 already exists, do you want to replace it?</source>
+        <translation>%1 រួមទៅហើយ, តើអ្នកចង់ប្រេបជាមួយវាទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/utils/corehelper.cpp" line="107"/>
+        <source>Replace</source>
+        <comment>button</comment>
+        <translation>ແທນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.cpp" line="24"/>
+        <source>Unmount</source>
+        <translation>ដកេះដាច់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.cpp" line="36"/>
+        <source>Safely Remove</source>
+        <translation>ដកេះដាច់យ៉ាងសីតា</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.cpp" line="44"/>
+        <source>Format</source>
+        <translation>ປຸນແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.cpp" line="48"/>
+        <source>Clear saved password and unmount</source>
+        <translation>ລກງລະຫື່ຜ່ອນແລະ དismount</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.cpp" line="52"/>
+        <source>Open</source>
+        <translation>បុក</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.cpp" line="56"/>
+        <source>Erase</source>
+        <translation>ລົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="224"/>
+        <source>Cannot access</source>
+        <translation>មិនអាចចឹងចំណោមទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="299"/>
+        <source>User directory</source>
+        <translation>ບ່ອນຈັດເກັບຜູ້ໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="303"/>
+        <source>Local disk</source>
+        <translation>ດີ້ວທ້ອງຖິ່ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="305"/>
+        <source>Removable disk</source>
+        <translation>តួប្រព័ន្ធដែលអាចដកេះដាច់បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="307"/>
+        <source>DVD</source>
+        <translation>ឌ៏វ්‍යුහාතුරු</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="310"/>
+        <source>Network shared directory</source>
+        <translation>ບ່ອນຈັດເກັບແບ່ງຮ່ວມເຄືອຂ່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="312"/>
+        <source>Android mobile device</source>
+        <translation>අන්ඩ්‍රොයිඩ ളුහුපාති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="315"/>
+        <source>Apple mobile device</source>
+        <translation>අපڵි ളුහුපාති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp" line="320"/>
+        <source>Unknown device</source>
+        <translation>තහවුලින් ളුහුපාති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp" line="236"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation>හිරින්මාන්තිරාන්</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp" line="239"/>
+        <source>Do you want to remove this item?</source>
+        <translation>මෙම ളුහුපාතිය കිහිපයකුට കිහිපයක් രුකුවුලු നුවන්තිරාන් പැවිත්රන්න් യිතුරාන්?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp" line="241"/>
+        <source>Do yout want to remove %1 items?</source>
+        <translation>මෙම ളුහුපාතිය %1 ളුහුපාතිය പැවිත්රන්න් യිතුරාන්?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp" line="242"/>
+        <source>It does not delete the original files</source>
+        <translation>ມັນບໍ່ໄດ້ລົບຟາຍລ໌ຕົ້ນສະບັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp" line="309"/>
+        <source>Clear recent history</source>
+        <translation>මාරිගුණෙන් നැගිලි ളිස්තිය വැඩේහැඳිනි ളිස්තිය വැඩේහැඳිනි ളිස්තිය വැඩේහැඳිනි ളිස්තිය വැඩේහැඳිනි ളිස්තිය</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp" line="326"/>
+        <source>Source path</source>
+        <translation>ທິດສະດີແຫ່ງຕົ້ນສະບັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp" line="93"/>
+        <source>New window</source>
+        <translation>ປະຈຸງ້ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp" line="97"/>
+        <source>New tab</source>
+        <translation>ແ្វូបថ្មិតថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp" line="103"/>
+        <source>Connect to Server</source>
+        <translation>මාරිගුණෙන් വැඩේහැඳිනි ളිස්තිය വැඩේහැඳිනි ളිස්තිය വැඩේහැඳිනි ളිස්තිය</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp" line="107"/>
+        <source>Set share password</source>
+        <translation>ຕັ້ງຄຳສັ່ງຜ່ານການແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp" line="112"/>
+        <source>Change disk password</source>
+        <translation>ປັບປຸງລະຫັດແຜ່ນສະບັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp" line="117"/>
+        <source>Settings</source>
+        <translation>ຕຳໍງໍ້າງຄຳຕິດຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp" line="296"/>
+        <source>Copy path</source>
+        <translation>ສ້າງລິ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp" line="318"/>
+        <source>Edit address</source>
+        <translation>ແກ້ໄຂທີ່ຢົງຢົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.cpp" line="127"/>
+        <source>Unable to open items in the trash, please restore it first</source>
+        <translation>ບໍ່ສາມາດເປັນເປື່ອນໄດ້ຈາກອີtemໃນຖາງຂยะ, ངອຍຕ້ອນໄດ້ຮັບຮູ້ຂອງມັນກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp" line="74"/>
+        <source>Empty Trash</source>
+        <translation>ເປັນເປື່ອນຖາງຂยะ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp" line="174"/>
+        <source>Location</source>
+        <translation>ທີ່ຕົວຢົງຢົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="67"/>
+        <source>Replace Text</source>
+        <translation>ປ່ຽນຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="67"/>
+        <source>Add Text</source>
+        <translation>ເພີ່ມເອຬາສິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="67"/>
+        <source>Custom Text</source>
+        <translation>ຂໍ້ຄວາມປັບແຕ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="74"/>
+        <source>Find</source>
+        <translation>ຊອກຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="77"/>
+        <source>Required</source>
+        <translation>ຂຳນຳພາກ່ຽວຂໍ້າງຄຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="83"/>
+        <source>Replace</source>
+        <translation>ແທນທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="85"/>
+        <source>Optional</source>
+        <translation>ບໍ່ບໍ່ສາມາດເລືອກໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="93"/>
+        <source>Add</source>
+        <translation>ເພີ່ມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="101"/>
+        <source>Before file name</source>
+        <translation>ລិපි ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="101"/>
+        <source>After file name</source>
+        <translation>ລិපි ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="109"/>
+        <source>File name</source>
+        <translation>ລិපි ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="116"/>
+        <source>Start at</source>
+        <translation>ເລື່ອງເລີ່ມຈາກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp" line="127"/>
+        <source>Tips: Sort by selected file order</source>
+        <translation>&apos;ແපළ: ശ්‍ර්‍ති ഭ ഊී ശ්‍ර්‍ති&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.cpp" line="30"/>
+        <source>My Shares</source>
+        <translation>ຂໍ້ານ້າຂ້ອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="163"/>
+        <source>Free Space %1</source>
+        <translation>སྤྱོད་པའི་%1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/fileinfo/searchfileinfo.cpp" line="76"/>
+        <source>Search</source>
+        <translation>ຄີກ ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/fileinfo/searchfileinfo.cpp" line="99"/>
+        <source>No results</source>
+        <translation>ຜູ່ມີ ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/fileinfo/searchfileinfo.cpp" line="101"/>
+        <source>Searching...</source>
+        <translation>ຄີກ ഭ ഊී ശ්‍ර්‍ති...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="259"/>
+        <source>Create Vault</source>
+        <translation>ສ້າງ ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="263"/>
+        <source>Unlock</source>
+        <translation>ເປັນເອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="279"/>
+        <source>Lock</source>
+        <translation>ປັບລິມະບົດ ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="285"/>
+        <source>Auto lock</source>
+        <translation>ອັດຕະລະຍະ ഭ ഊී ശ්‍ර්‍ති</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="289"/>
+        <source>Never</source>
+        <translation>ບໍ່ເຄີຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="298"/>
+        <source>5 minutes</source>
+        <translation>5 ເຈົ້ານຳພາ ലະງື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="305"/>
+        <source>10 minutes</source>
+        <translation>10 ເຈົ້ານຳພາ ലະງື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="312"/>
+        <source>20 minutes</source>
+        <translation>20 ཕື້ນນົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="326"/>
+        <source>Delete File Vault</source>
+        <translation>ລກມລົງ File Vault</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="9"/>
+        <source>File not found</source>
+        <translation>ລກງື້ນ ലໍານົບ ഠື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="10"/>
+        <source>File already exists</source>
+        <translation>ລກງື້ນ ലັງຄື പ້ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="11"/>
+        <source>File is a directory</source>
+        <translation>ລກງື້ນ ഺ້າງສະຖານະ ലໍານົບ ഠື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="12"/>
+        <source>File is not a directory</source>
+        <translation>ລກງື້ນ ലັງຄື ലະງື້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="13"/>
+        <source>File is a directory that isn&apos;t empty</source>
+        <translation>ລກງື້ນ ഺ້າງສະຖານະ ലໍານົບ ഠື້ນ ലະບາດ ലོང</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="14"/>
+        <source>File is not a regular file</source>
+        <translation>ລກງື້ນ ലັງຄື ലະງື້ນ ലະບາດ ലོང</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="15"/>
+        <source>File is not a symbolic link</source>
+        <translation>ຄໍ້ານ ലະງື້ງ ഺ້າງສະຖານະ ലໍານົບ ഠື້ມຼື ലະບາດ ലོང</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="16"/>
+        <source>File cannot be mounted</source>
+        <translation>ລກງື້ມ ലະບາດ ലོང ഠື້ມຼື ലໍ ലະບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="17"/>
+        <source>Filename has too many characters</source>
+        <translation>ຊື່ຟາຍລ໌ມີຕົວອັກສອນຫຼາຍເກີນໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="18"/>
+        <source>Filename is invalid or contains invalid characters</source>
+        <translation>ລກງື້ນີ້ ലິຂະໂດຍຜູ້ໃຊ້ງານ ലັງຄື ലໍ ലະບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="19"/>
+        <source>File contains too many symbolic links</source>
+        <translation>ລກງື້ນ ലິຂະໂ dod ലະງື້ມ ലະບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="20"/>
+        <source>No space left on drive</source>
+        <translation>ບໍ່ມີທີ່ວ່າງໃນດີວ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="21"/>
+        <source>Invalid argument</source>
+        <translation>ការផ្តល់ argument មិនត្រឹមត្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="22"/>
+        <source>Permission denied</source>
+        <translation>មិនមានសិទ្ធិស័ក្តូប</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="23"/>
+        <source>Operation (or one of its parameters) not supported</source>
+        <translation>តុប្ចង់ (ឬមួយរបស់តុប្ចង់) មិនត្រូវបានគាំទាវ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="24"/>
+        <source>File isn&apos;t mounted</source>
+        <translation>ឯកសារមិនត្រូវបានចងភាពឡើង</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="25"/>
+        <source>File is already mounted</source>
+        <translation>ឯកសារស្វែងរកបានចងភាពឡើងហើយ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="26"/>
+        <source>File was closed</source>
+        <translation>ຟາຍລ໌ຖືກປິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="27"/>
+        <source>Operation was cancelled</source>
+        <translation>ការប្រព្រាយត្រូវបានបញ្ចាក់ចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="28"/>
+        <source>Operations are still pending</source>
+        <translation>ការប្រព្រាយនៅតែមានការរង្វើការតាមដាន</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="29"/>
+        <source>File is read-only</source>
+        <translation>ឯកសារមិនអាចកែបែងបានទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="32"/>
+        <source>Failed to open the file</source>
+        <translation>មិនអាចបុរាណឯកសារឡើយ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="33"/>
+        <source>Target Trash File Not exist</source>
+        <translation>ឯកសារចាក់ចោលដែលត្រូវបានកំណត់មិនមាន</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="30"/>
+        <source>Operation timed out</source>
+        <translation>ការប្រព្រាយបានផ្លាស់ប្តូរលើពេលវេលា</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="31"/>
+        <source>File is busy</source>
+        <translation>ឯកសារកំពុងត្រូវបានប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="391"/>
+        <source>Device disconnected</source>
+        <translation>ឧបករណ៍ត្រូវបានបំបាក</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/auditlogjob.cpp" line="152"/>
+        <source>ID=%1, DateTime=%2, Burner=%3, DiscType=%4, Result=%5, User=%6, FileName=%7, FileSize=%8, FileType=%9</source>
+        <translation>ID=%1, ថ្ខបរ៉ែ=%2, ប្រភេទភ្នំ=%3, ប្រភេទឌីស=%4, លទ្ធភាព=%5, អ្នកប្រើប្រាស់=%6, ឈ្មោះឯកសារ=%7, ទៅរាប=%8, ប្រភេទឯកសារ=%9</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/auditlogjob.cpp" line="155"/>
+        <source>Success</source>
+        <translation>Thành công</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/auditlogjob.cpp" line="155"/>
+        <source>Failed</source>
+        <translation>Thất bại</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp" line="247"/>
+        <source>Sidebar</source>
+        <translation>Thanh bên</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="25"/>
+        <source>or</source>
+        <translation>hoặc</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp" line="385"/>
+        <source>Clear search history</source>
+        <translation>Xóa lịch sử tìm kiếm</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="354"/>
+        <source>Unknow</source>
+        <translation>មិនស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp" line="254"/>
+        <source>search</source>
+        <translation>tìm kiếm</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp" line="269"/>
+        <source>advanced search</source>
+        <translation>tìm kiếm nâng cao</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="405"/>
+        <source>Cannot generate random number by TPM</source>
+        <translation>Không thể tạo số ngẫu nhiên bằng TPM</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="408"/>
+        <source>No available encrypt algorithm.</source>
+        <translation>មិនមានអាល gorithm សម្បូរសម្រាប់ប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="411"/>
+        <source>TPM encrypt failed.</source>
+        <translation>Việc mã hóa TPM đã thất bại.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="414"/>
+        <source>TPM is locked.</source>
+        <translation>TPM đã bị khóa.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="479"/>
+        <source>Confirm encrypt %1?</source>
+        <translation>Xác nhận mã hóa %1?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="482"/>
+        <source>The current partition is about to be encrypted and cannot be canceled during the encryption process, please confirm the encryption.</source>
+        <translation>Phầnition hiện tại sắp được mã hóa và không thể hủy bỏ trong suốt quá trình mã hóa, vui lòng xác nhận mã hóa.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="489"/>
+        <source>* After encrypting the partition, the system cannot be rolled back to a lower version, please confirm the encryption</source>
+        <translation>* ຫຼັງຈາກການເຂົ້າລະຫັດສ່ວນ, ສະພາບການບໍ່ສາມາດຍ້າຍກັບໄປສູ່ຮູບແບບທີ່ຕ່ໍາກວ່າ, ສະແດງຄວາມຍືນຍັນການເຂົ້າລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="500"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="501"/>
+        <source>Confirm and Reboot</source>
+        <translation>បញ្ជាក់និងចេញប្រព័ន្ធដំណើរការឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="502"/>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="512"/>
+        <source>Decrypt %1?</source>
+        <translation>ស្មាន់សំបូរ %1?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="513"/>
+        <source>Decryption can take a long time, so make sure power is connected until the decryption is complete.</source>
+        <translation>ການຖອນລະຫັດສາມາດໃຊ້ເວລາດົນ, ສະນັ້ນໃຫ້ແນ່ໃຈວ່າໄຟຟ້າຖືກເຊື່ອມຕໍ່ເຖິງການຖອນລະຫັດສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/services/diskencrypt/helpers/abrecoveryhelper.cpp" line="65"/>
+        <source>Updating grub...</source>
+        <translation>កំពុងផ្លាស់ប្តូរ grub...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp" line="311"/>
+        <source>File Vault</source>
+        <translation>ឯកសារសម្រាប់ការលាក់មួយ</translation>
+    </message>
+</context>
+<context>
+    <name>ResumeEncryptWorker</name>
+    <message>
+        <location filename="../src/services/diskencrypt/workers/resumeencryptworker.cpp" line="64"/>
+        <source>Encrypting </source>
+        <translation>ການເຂົ້າລະຫັດ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_canvas::CanvasMenuScene</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="122"/>
+        <source>Sort by</source>
+        <translation>ຈັດລໍາດັບໂດຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="127"/>
+        <source>Icon size</source>
+        <translation>ຂະໜາດສິ່ງທີ່ສະແດງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="128"/>
+        <source>Auto arrange</source>
+        <translation>ຈັດແບບອັດຕາໂມດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="123"/>
+        <source>Display Settings</source>
+        <translation>ການຕັ້ງຄ່າສະແດງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="124"/>
+        <source>Refresh</source>
+        <translation>ຮັບຄວາມແມ່ນຄືກັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="133"/>
+        <source>Wallpaper and Screensaver</source>
+        <translation>ຮູບພາບແລະຮູບພາບການປິດຕົວຮັກສາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="138"/>
+        <source>Personalization</source>
+        <translation>Personalization</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="135"/>
+        <source>Set Wallpaper</source>
+        <translation>Set Wallpaper</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="144"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="145"/>
+        <source>Time modified</source>
+        <translation>Time modified</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="146"/>
+        <source>Time created</source>
+        <translation>Time created</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="147"/>
+        <source>Size</source>
+        <translation>Size</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="148"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="152"/>
+        <source>Tiny</source>
+        <translation>Tiny</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="153"/>
+        <source>Small</source>
+        <translation>Small</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="154"/>
+        <source>Medium</source>
+        <translation>Medium</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="155"/>
+        <source>Large</source>
+        <translation>Large</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp" line="156"/>
+        <source>Super large</source>
+        <translation>Super large</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_canvas::ItemEditor</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/delegate/itemeditor.cpp" line="261"/>
+        <source>%1 are not allowed</source>
+        <translation>&apos;%1 are not allowed&apos;</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_canvas::RenameDialog</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="275"/>
+        <source>Rename %1 Files</source>
+        <translation>Rename %1 Files</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_canvas::RenameDialogPrivate</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="66"/>
+        <source>Mode:</source>
+        <translation>&apos;Mode:&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="68"/>
+        <source>Replace Text</source>
+        <translation>ແປແທນຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="68"/>
+        <source>Add Text</source>
+        <translation>เพิ่ม ཡིང་</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="68"/>
+        <source>Custom Text</source>
+        <translation>ຂໍ້ຄວາມປະເພດເອິ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="73"/>
+        <source>Find:</source>
+        <translation>ຊອກ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="76"/>
+        <source>Required</source>
+        <translation>ຕ້ອງການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="80"/>
+        <source>Replace:</source>
+        <translation>ແປແທນ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="82"/>
+        <source>Optional</source>
+        <translation>ເປັນເງື່ອນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="87"/>
+        <source>Add:</source>
+        <translation>ເພີ່ມ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="94"/>
+        <source>Location:</source>
+        <translation>ສະຖານທີ່:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="96"/>
+        <source>Before file name</source>
+        <translation>ກ່ອນຊື່ຟາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="96"/>
+        <source>After file name</source>
+        <translation>ຫຼັງຊື່ຟາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="101"/>
+        <source>File name:</source>
+        <translation>ཡིགໄຊ້ຊື່:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/utils/renamedialog.cpp" line="107"/>
+        <source>Start at:</source>
+        <translation>ຮອດຕົວຈາກ:</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_canvas::WaterMaskFrame</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/watermask/watermaskframe.cpp" line="132"/>
+        <source>Not authorized</source>
+        <translation>ບໍ່ມີອື້ໜົມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/watermask/watermaskframe.cpp" line="140"/>
+        <source>In trial period</source>
+        <translation>ໃນໄລຍະກວດສອບ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_canvas::WatermaskSystem</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/watermask/watermasksystem.cpp" line="286"/>
+        <source>Not authorized</source>
+        <translation>ບໍ່ມີການອະນັບຍະພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-canvas/watermask/watermasksystem.cpp" line="292"/>
+        <source>In trial period</source>
+        <translation>ໃນໄລຍະລອບ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::AlertHideAllDialog</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/alerthidealldialog.cpp" line="37"/>
+        <source>The hortcut key &quot;%1&quot; to show collection</source>
+        <translation>ປຸ່ມລັດ &quot;%1&quot; ເພື່ອສະແດງການລວບລວມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/alerthidealldialog.cpp" line="45"/>
+        <source>No prompt</source>
+        <translation>ບໍ່ມີການແຈ້ງເຕືອນ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::CollectionItemDelegate</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp" line="107"/>
+        <source>Tiny</source>
+        <translation>ນ້ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp" line="108"/>
+        <source>Small</source>
+        <translation>່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp" line="109"/>
+        <source>Medium</source>
+        <translation>ກາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp" line="110"/>
+        <source>Large</source>
+        <translation>ໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp" line="111"/>
+        <source>Super large</source>
+        <translation>ໃຫຍ່ຫຼວງຫຼາຍ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::CollectionTitleBarPrivate</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp" line="64"/>
+        <source>Collection size</source>
+        <translation>ຂະໜາດກົ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp" line="137"/>
+        <source>Large area</source>
+        <translation>ຂະໍ້າງະຫວຼາງໃຫຍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp" line="135"/>
+        <source>Small area</source>
+        <translation>ຂະໍ້າງະຫວຼາງ່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp" line="136"/>
+        <source>Middle area</source>
+        <translation>ພື້ນທີ່ກາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp" line="162"/>
+        <source>Rename</source>
+        <translation>ປ່ຽນຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp" line="171"/>
+        <source>Delete</source>
+        <translation>ລືມເອົາ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::CustomMode</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/custommode.cpp" line="365"/>
+        <source>New Collection</source>
+        <translation>ກົ້ນໃໝ່</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::ExtendCanvasScene</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="234"/>
+        <source>Organize desktop</source>
+        <translation>រៀបចំ desktop</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="233"/>
+        <source>Enable desktop organization</source>
+        <translation>បុកមូលដ្ឋានរៀបចំ desktop</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="235"/>
+        <source>Desktop Settings</source>
+        <translation>ການຕັ້ງຄ່າຕົ້ນຕໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="236"/>
+        <source>Organize by</source>
+        <translation>ຈັດການໂດຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="239"/>
+        <source>Custom collection</source>
+        <translation>ກົ້ນທີ່ກຳນົດເອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="240"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="241"/>
+        <source>Time accessed</source>
+        <translation>ເວລາທີ່ເຂົ້າເຖິງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="242"/>
+        <source>Time modified</source>
+        <translation>ពេលត្រូវបានកែប្រែប</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="243"/>
+        <source>Time created</source>
+        <translation>ពេលបង្កើតឡើង</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/menus/extendcanvasscene.cpp" line="245"/>
+        <source>Create a collection</source>
+        <translation>បង្កើតកoleksi</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::FrameManagerPrivate</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/framemanager.cpp" line="156"/>
+        <source>To disable the One-Click Hide feature, invoke the &quot;Desktop Settings&quot; window in the desktop context menu and turn off the &quot;One-Click Hide Collection&quot;.</source>
+        <translation>ដើម្បីបុកមូលដ្ឋានម្ហៃចុចលើម្តងលាក់ (One-Click Hide), ចុចលើ &quot;Desktop Settings&quot; នៅក្នុងផ្នែករបស់ desktop ហើយបុកមូលដ្ឋាន &quot;One-Click Hide Collection&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/framemanager.cpp" line="166"/>
+        <source>Desktop organizer</source>
+        <translation>រៀបចំ desktop</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/framemanager.cpp" line="169"/>
+        <source>Shortcut &quot;%1&quot; to show collections</source>
+        <translation>ប្រភេទលាក់ &quot;%1&quot; ដើម្បីបង្ហាញកoleksi</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/framemanager.cpp" line="171"/>
+        <source>Close</source>
+        <translation>ປິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/framemanager.cpp" line="171"/>
+        <source>No more prompts</source>
+        <translation>ບ້ານບ້ານບ້ານບ້ານບ້ານ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::ItemEditor</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp" line="256"/>
+        <source>%1 are not allowed</source>
+        <translation>%1 ບໍ່ສາມາດໃຊ້ໄດ້</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::MethodComBox</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp" line="34"/>
+        <source>Type</source>
+        <translation>ປະເພຼຸກ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::OptionsWindow</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/optionswindow.cpp" line="91"/>
+        <source>Desktop Settings</source>
+        <translation>ການຕັ້ງຄ່າຕົ້ນຕໍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/optionswindow.cpp" line="110"/>
+        <source>Auto arrange icons</source>
+        <translation>ອັດຕະອື່ນຈົດການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/optionswindow.cpp" line="130"/>
+        <source>Enable desktop organizer</source>
+        <translation>ເປີດການຈັດຂະແໜງການຕົວຈິງ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::OrganizationGroup</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/organizationgroup.cpp" line="39"/>
+        <source>Organize desktop</source>
+        <translation>ຈັດການ desktop</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/organizationgroup.cpp" line="115"/>
+        <source>Organize by</source>
+        <translation>ຈັດການໂດຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/organizationgroup.cpp" line="158"/>
+        <source>Hide all collections with one click</source>
+        <translation>ໜຶ່ງຄລ຿ກ ཁຳບ ཀົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/organizationgroup.cpp" line="218"/>
+        <source>Hide/Show Collection Shortcuts</source>
+        <translation>ກຳນີ້/ກຳອອກ ཁຳບ ཀົງ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::RenameDialog</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="276"/>
+        <source>Rename %1 Files</source>
+        <translation>ປັບຊື່ &apos;%1&apos; ད້າວ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::RenameDialogPrivate</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="66"/>
+        <source>Mode:</source>
+        <translation>ຮູບແບບ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="68"/>
+        <source>Replace Text</source>
+        <translation>ປ່ຽນຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="68"/>
+        <source>Add Text</source>
+        <translation>ເພີ່ມເອື່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="68"/>
+        <source>Custom Text</source>
+        <translation>ຂໍ້ຄວາມທີ່ກຳນົດເອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="73"/>
+        <source>Find:</source>
+        <translation>ຄົ້ນຫາ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="76"/>
+        <source>Required</source>
+        <translation>ຈຳເປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="80"/>
+        <source>Replace:</source>
+        <translation>ແທນທີ່:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="82"/>
+        <source>Optional</source>
+        <translation>ເປັນເລືອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="87"/>
+        <source>Add:</source>
+        <translation>ເພີ່ມ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="94"/>
+        <source>Location:</source>
+        <translation>위치:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="96"/>
+        <source>Before file name</source>
+        <translation>ຊື່ໄົບຸນກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="96"/>
+        <source>After file name</source>
+        <translation>ຊື່ໄົບຸນຫຼັງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="101"/>
+        <source>File name:</source>
+        <translation>ຊື່ໄົບຸນ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/utils/renamedialog.cpp" line="107"/>
+        <source>Start at:</source>
+        <translation>ເລື່ອງຈາກ:</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::SizeSlider</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/sizeslider.cpp" line="87"/>
+        <source>Icon size</source>
+        <translation>ຂະໜາດສິນນະເຍີ</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::TypeClassifier</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp" line="68"/>
+        <source>Apps</source>
+        <translation>ໂປແກຼມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp" line="69"/>
+        <source>Documents</source>
+        <translation>ເອກະສານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp" line="70"/>
+        <source>Pictures</source>
+        <translation>ຮູບພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp" line="71"/>
+        <source>Videos</source>
+        <translation>ວົງການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp" line="72"/>
+        <source>Music</source>
+        <translation>ດີມີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp" line="73"/>
+        <source>Folders</source>
+        <translation>ຖົວທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp" line="74"/>
+        <source>Other</source>
+        <translation>ອື໅້ນໍ້</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_organizer::TypeMethodGroup</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/methodgroup/typemethodgroup.cpp" line="20"/>
+        <source>Apps</source>
+        <translation>ໂປແກຼມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/methodgroup/typemethodgroup.cpp" line="21"/>
+        <source>Documents</source>
+        <translation>ເອກະສານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/methodgroup/typemethodgroup.cpp" line="22"/>
+        <source>Pictures</source>
+        <translation>ຮູບພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/methodgroup/typemethodgroup.cpp" line="23"/>
+        <source>Videos</source>
+        <translation>ວີດີໂອ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/methodgroup/typemethodgroup.cpp" line="24"/>
+        <source>Music</source>
+        <translation>ດີມີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-organizer/options/methodgroup/typemethodgroup.cpp" line="25"/>
+        <source>Folders</source>
+        <translation>ຟາຍລ໌</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_wallpapersetting::WallpaperSettings</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="1055"/>
+        <source>Loading wallpapers...</source>
+        <translation>ກຳລັງໂຫຼດພາບເຄື່ອງມື...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="1057"/>
+        <source>Loading screensavers...</source>
+        <translation>ກຳລັງໂຫຼດພາບເຄື່ອງມືເບີ່ມ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="1117"/>
+        <source>Custom Screensaver</source>
+        <translation>ພາບເຄື່ອງມືເບີ່ມເອີ້ນເອົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="1118"/>
+        <source>Apply</source>
+        <comment>button</comment>
+        <translation>ປະຕິບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="1193"/>
+        <source>This system wallpaper is locked. Please contact your admin.</source>
+        <translation>ພາບເຄື່ອງມືຂອງລະບົບນີ້ຖືກກັກ. ກະລຸນາຕິດຕໍ່ຜູ້ດູແລຂອງທ່ານ.</translation>
+    </message>
+</context>
+<context>
+    <name>ddplugin_wallpapersetting::WallpaperSettingsPrivate</name>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="137"/>
+        <source>Wallpaper</source>
+        <translation>ພາບເຄື່ອງມື</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="147"/>
+        <source>Screensaver</source>
+        <translation>ພັນທິບົດພາບສົ໊ນຄັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="368"/>
+        <source>Desktop</source>
+        <comment>button</comment>
+        <translation>ຕົວຈິງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="369"/>
+        <source>Lock Screen</source>
+        <comment>button</comment>
+        <translation>ລຒກຄະແນັງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="370"/>
+        <source>Both</source>
+        <translation>ທັງສອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="570"/>
+        <source>Wallpaper Slideshow</source>
+        <translation>ພາບພົວພັນຫຼ່າຍກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="611"/>
+        <source>When login</source>
+        <translation>ເມື່ອເຂົ້າສູ່ລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="613"/>
+        <source>When wakeup</source>
+        <translation>ເມື່ອຕື່ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="651"/>
+        <source>Require a password on wakeup</source>
+        <translation>ຕ້ອງການລະຫັດຜ່ານເມື່ອຕື່ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="683"/>
+        <source>Never</source>
+        <translation>ບໍ່ເຄີຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/desktop/ddplugin-wallpapersetting/wallpapersettings.cpp" line="685"/>
+        <source>Wait:</source>
+        <translation>ກີ້ລັບ: </translation>
+    </message>
+</context>
+<context>
+    <name>dfm_upgrade::ProcessDialog</name>
+    <message>
+        <location filename="../src/tools/upgrade/dialog/processdialog.cpp" line="30"/>
+        <source>File Manager will be updated to a new version, during which the tasks in progress will be terminated. Do you want to update now?</source>
+        <translation>ບົດບາດຈັດການຈະຖືກປັບປຸງເຖິງສະຖານະການໃຫ້ມີລັກສະນະໃຫ້ແກ້ວຫນ້ອຍ, དັ້ນແລ້ວການເຮັດວຽກທີ່ກຳລັງດີຈະຖືກຢັ້ງຢົນ. ངີ່ບໍ່ຢາກປັບປຸງໃຫ້ພວກມັນຫຼືບໍ່?</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/upgrade/dialog/processdialog.cpp" line="32"/>
+        <source>The desktop services will be updated to a new version, during which the tasks in progress will be terminated. Do you want to update now?</source>
+        <translation>ບົດບາດທີ່ໃຫ້ແກ້ວຫນ້ອຍຈະຖືກປັບປຸງເຖິງສະຖານະການໃຫ້ມີລັກສະນະໃຫ້ແກ້ວຫນ້ອຍ, དັ້ນແລ້ວການເຮັດວຽກທີ່ກຳລັງດີຈະຖືກຢັ້ງຢົນ. ངີ່ບໍ່ຢາກປັບປຸງໃຫ້ພວກມັນຫຼືບໍ່?</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/upgrade/dialog/processdialog.cpp" line="33"/>
+        <source>Update</source>
+        <comment>button</comment>
+        <translation>ປັບປຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/tools/upgrade/dialog/processdialog.cpp" line="34"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລິກ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::BasicStatusBarPrivate</name>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="25"/>
+        <source>%1 item</source>
+        <translation>%1 ད຾້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="26"/>
+        <source>%1 items</source>
+        <translation>%1 항목</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="27"/>
+        <source>%1 item selected</source>
+        <translation>&apos;%1 ຕົວເລື່ອນທີ່ເລືອກ&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="28"/>
+        <source>%1 items selected</source>
+        <translation>%1 개의 아이템 선택됨</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="29"/>
+        <source>%1 folder selected (contains %2)</source>
+        <translation>%1 폴더 선택됨 (내부에 %2 포함)</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="30"/>
+        <source>%1 folders selected (contains %2)</source>
+        <translation>%1 개의 폴더 선택됨 (내부에 %2 포함)</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="31"/>
+        <source>%1 file selected (%2)</source>
+        <translation>%1 개의 파일 선택됨 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="32"/>
+        <source>%1 files selected (%2)</source>
+        <translation>%1 개의 파일 선택됨 (%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp" line="33"/>
+        <source>%1 folder selected</source>
+        <translation>%1 개의 폴더 선택됨</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::DialogManager</name>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="57"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>확인</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="83"/>
+        <source>Operating failed</source>
+        <translation>운영 실패</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="84"/>
+        <source>Mount failed</source>
+        <translation>마운트 실패</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="85"/>
+        <source>Unmount failed</source>
+        <translation>언마운트 실패</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="91"/>
+        <source>Unmounting device now...</source>
+        <translation>장치 언마운트 중...</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="94"/>
+        <source>Mounting device now...</source>
+        <translation>장치 마운트 중...</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="97"/>
+        <source>Erasing device now...</source>
+        <translation>장치 지우기 중...</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="100"/>
+        <source>Making filesystem for device now...</source>
+        <translation>กำลังสร้างระบบไฟล์สำหรับอุปกรณ์...</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="103"/>
+        <source>Locking device now...</source>
+        <translation>กำลังล็อคอุปกรณ์...</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="106"/>
+        <source>Unlocking device now...</source>
+        <translation>กำลังปลดล็อคอุปกรณ์...</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="130"/>
+        <source>The device is busy now</source>
+        <translation>ອຸປະກອນກຳລັງທຳງານອຢູ່</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="142"/>
+        <source>Anonymous mount is not allowed</source>
+        <translation>ไม่อนุญาตให้ติดตามแบบไม่ anonymous</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="144"/>
+        <source>Wrong password</source>
+        <translation>รหัสผ่านผิด</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="148"/>
+        <source>Cannot create the mountpoint: the file name is too long</source>
+        <translation>ไม่สามารถสร้าง mountpoint ได้: ชื่อไฟล์ยาวเกินไป</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="150"/>
+        <source>Authentication failed</source>
+        <translation>การตรวจสอบความถูกต้องล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="152"/>
+        <source>No such file or directory</source>
+        <translation>ไม่มีไฟล์หรือไดเรกทอรี</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="157"/>
+        <source>Error occured while mounting device</source>
+        <translation>ຂໍ້ຜິດພາດເກີດຂຶ້ນເມື່ອຕິດຕັ້ງອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="160"/>
+        <source>The device has been blocked and you do not have permission to access it. Please configure its connection policy in Security Center or contact your administrator.</source>
+        <translation>ອຸປະກອນໄດ້ຖືກກັກຂັງແລ້ວ ແລະ ທ່ານບໍ່ມີສິດເຂົ້າເຖິງມັນ. ກະລຸນາຕັ້ງຄ່ານະໂຍບາຍການເຊື່ອມຕໍ່ຂອງມັນໃນການຈັດການຄວາມປອດໄພ ຫຼື ຕິດຕໍ່ຜູ້ດູແລ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="165"/>
+        <source>The device is busy, cannot remove now</source>
+        <translation>อุปกรณ์กำลังทำงานอยู่ ไม่สามารถถอดออกได้ในขณะนี้</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="187"/>
+        <source>You do not have permission to operate file/folder!</source>
+        <translation>ທ່ານບໍ່ມີສິດທີ່ຈະດຳເນີນການເຊີນຟາຍ/ບ່ອນເກັບຂໍ້ມູນ!</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="204"/>
+        <source>Sorry, you don&apos;t have permission to operate the following %1 file/folder(s)!</source>
+        <translation>ຂໍອະໄພ, ທ່ານບໍ່ມີສິດທີ່ຈະດຳເນີນການເຊີນຟາຍ/ບ່ອນເກັບຂໍ້ມູນຕໍ່ໄປນີ້ %1!</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="233"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ตกลง</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="240"/>
+        <source>Operation failed!</source>
+        <translation>ຈະນຳເຄື່ອງມືນີ້ນຳໃຊ້ບໍ່ໄດ້!</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="241"/>
+        <source>Target folder is inside the source folder!</source>
+        <translation>ບ່ອນເກັບຂໍ້ມູນທີ່ຕິດຕໍ່ກັບຢູ່ພາຍໃຕ້ບ່ອນເກັບຂໍ້ມູນຕົ້ນສະບັບ!</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="303"/>
+        <source>The passphrase is needed to access encrypted data on %1.</source>
+        <translation>ລາຍລະອຽດໃນການເຄື່ອນໄຫວຂໍ້ມູນທີ່ຖືກເຂົ້າກັບ %1 ຕ້ອງການລາຍລະອຽດການເຂົ້າເຖິງ.</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="311"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="312"/>
+        <source>Format</source>
+        <comment>button</comment>
+        <translation>ຮູບແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="313"/>
+        <source>To access the device, you must format the disk first. Are you sure you want to format it now?</source>
+        <translation>ເພື່ອເຂົ້າເຖິງອຸປະກອນ, ທ່ານຕ້ອງຮູບແບບດິສກກ່ອນ. ທ່ານແນ່ໃຈບໍວ່າຕ້ອງການຮູບແບບມັນໃນເວລານີ້?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="327"/>
+        <source>Do you want to run %1 or display its content?</source>
+        <translation>ທ່ານຕ້ອງການໃຫ້ %1 ແລ້ວເຮັດວຽກ ຫຼື ຕ້ອງການເບິ່ງເນື້ອໃນມັນ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="328"/>
+        <source>It is an executable text file.</source>
+        <translation>ມັນແມ່ນຟາຍຂໍ້ຄວາມທີ່ສາມາດໃຊ້ງານໄດ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="332"/>
+        <source>Run</source>
+        <comment>button</comment>
+        <translation>ເຮັດວຽກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="333"/>
+        <source>Run in terminal</source>
+        <comment>button</comment>
+        <translation>ເປັນຜົນໄດ້ຮັບໃຊ້ໃນປະຈຸມາດຕອບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="334"/>
+        <source>Display</source>
+        <comment>button</comment>
+        <translation>ສ້າງລິ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="357"/>
+        <source>Do you want to run %1?</source>
+        <translation>ທີ່ທີ່ທີ່ນີ້ແມ່ນບົດຮັບໃຊ້ໄດ້. ངີ້ຢາກເປັນຜົນໄດ້ຮັບໃຊ້ມືຖືນີ້ບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="358"/>
+        <source>It is an executable file.</source>
+        <translation>ມືຖືນີ້ແມ່ນບົດຮັບໃຊ້ໄດ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="375"/>
+        <source>Cannot move the selected %1 items to the trash. Do you want to permanently delete them?</source>
+        <translation>ບໍ່ສາມາດຍ້າຍຂໍ້ມູນທີ່ເລືອກ %1 ໄປຍັງຖົງຂີ້ເຫຼືອ. ທ່ານຕ້ອງການລົບຖາວອນເຂົ້າໃນມັນບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="376"/>
+        <source>Permanently delete %1 items?</source>
+        <translation>ທ່ານຕ້ອງການລົບຖາວອນ %1 ຂໍ້ມູນບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="406"/>
+        <source>Cannot move &quot;%1&quot; to the trash. Do you want to permanently delete it?</source>
+        <translation>ບໍ່ສາມາດຍ້າຍ &quot;%1&quot; ໄປຍັງຖົງຂີ້ເຫຼືອ. ທ່ານຕ້ອງການລົບຖາວອນມັນບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="382"/>
+        <source>Delete</source>
+        <comment>button</comment>
+        <translation>Delete</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="407"/>
+        <source>Permanently delete %1?</source>
+        <translation>ຂໍ້ມູນ %1 ຈະຖືກລົບຢ່າງຖາວອນ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="413"/>
+        <source>This action cannot be undone</source>
+        <translation>ການດຳເນີນການນີ້ບໍ່ສາມາດຍົກເລີກໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="426"/>
+        <source>Are you sure you want to empty %1 item?</source>
+        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການລ້າງຂໍ້ມູນ %1 ອີງ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="427"/>
+        <source>Are you sure you want to empty %1 items?</source>
+        <translation>ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການລ້າງຂໍ້ມູນ %1 ອີງ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="436"/>
+        <source>Empty</source>
+        <translation>Empty</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="475"/>
+        <source>Do you want to delete %1?</source>
+        <translation>ທ່ານຕ້ອງການລົບ %1 ບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="476"/>
+        <source>Do you want to delete the selected %1 items?</source>
+        <translation>ທ່ານຕ້ອງການລົບຂໍ້ມູນ %1 ອີງທີ່ເລືອກແມ່ນບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="507"/>
+        <source>Failed to restore %1 file, the target folder is read-only</source>
+        <translation>ບໍ່ສາມາດກັບຄືນຂໍ້ມູນ %1 ຕົວຢ່າງໄຟລ໌ໄດ້, ຕົວຢ່າງໄຟລ໌ເປົ້າໝາຍແມ່ນອ່ານພຽງແຕ່</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="509"/>
+        <source>Failed to restore %1 files, the target folder is read-only</source>
+        <translation>ບໍ່ສາມາດກັບຄືນຂໍ້ມູນ %1 ຕົວຢ່າງໄຟລ໌ໄດ້, ຕົວຢ່າງໄຟລ໌ເປົ້າໝາຍແມ່ນອ່ານພຽງແຕ່</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="522"/>
+        <source>After revocation, it will be completely deleted %1, do you want to delete it completely?</source>
+        <translation>ຫຼັງຈາກການຍົກເລີກ, ມັນຈະຖືກລົບຢ່າງສິ້ນເຖິງ %1, ທ່ານຕ້ອງການລົບມັນຢ່າງສິ້ນເຖິງບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="525"/>
+        <source>These %1 contents will be completely deleted after revocation. Do you want to delete them completely?</source>
+        <translation>ເນື້ອໃນ %1 ນີ້ຈະຖືກລົບຢ່າງສິ້ນເຖິງຫຼັງຈາກການຍົກເລີກ. ທ່ານຕ້ອງການລົບມັນຢ່າງສິ້ນເຖິງບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="550"/>
+        <source>This operation cannot be reversed.</source>
+        <translation>ການດຳເນີນການນີ້ບໍ່ສາມາດຍົກເລີກໄດ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="566"/>
+        <source>&quot;%1&quot; already exists, please use another name.</source>
+        <translation>&quot;%1&quot; ທຳມະດາມີຢູ່ແລ້ວ, ກະລຸນາໃຊ້ຊື່ອື່ນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="580"/>
+        <source>Device or resource busy</source>
+        <translation>ອຸປະກອນຫຼືຂໍ້ມູນກຳລັງຖືກໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="593"/>
+        <source>This file will be hidden if the file name starts with &apos;.&apos;. Do you want to hide it?</source>
+        <translation>ប្រសិនបើឈ្មោះឯកសារចាប់ដោយ &apos;.&apos; នោះឯកសារនេះនឹងត្រូវលាក់ចេញ។ តើអ្នកចង់លាក់ចេញឯកសារនេះទេ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="594"/>
+        <source>Hide</source>
+        <translation>ເຊີນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="595"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="618"/>
+        <source>Unable to access %1</source>
+        <translation>មិនអាចប្រទះបាននឹង %1 ទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="635"/>
+        <source>%1 that this shortcut refers to has been changed or moved</source>
+        <translation>ឯកសារដែលតែងតាំងនេះចង់ចំនុចភ្លេចរបស់វាបានផ្លាស់ប្តូរឬផ្លាស់ទីតាំង។</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="639"/>
+        <source>Do you want to delete this shortcut？</source>
+        <translation>ທ່ານຕ້ອງການລົບລິ້ງນີ້ບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="664"/>
+        <source>This file is not executable, do you want to add the execute permission and run?</source>
+        <translation>ໄຟລ໌ນີ້ບໍ່ແມ່ນໄຟລ໌ທີ່ເຮັດໄດ້, ທ່ານຕ້ອງການເພີ່ມສິດເຮັດໄດ້ແລະເຮັດ?</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/dialogmanager.cpp" line="676"/>
+        <source>The selected files contain system file/directory, and it cannot be deleted</source>
+        <translation>ឯកសារនិងថ្នាក់ថ្នាក់ដែលត្រូវបានជ្រើនជាងមិនអាចលាក់ចេញបានទេពីប្រព័ន្ធដោយសារតែជាកម្រិតស្តុចស្តាល់ប៉ុណ្ណោះ។</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::MimeTypeDisplayManager</name>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="30"/>
+        <source>Directory</source>
+        <translation>ບ່ອນຈັດເກັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="31"/>
+        <source>Application</source>
+        <translation>កម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="32"/>
+        <source>Video</source>
+        <translation>វិដេអីដេ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="33"/>
+        <source>Audio</source>
+        <translation>សំឡេង</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="34"/>
+        <source>Image</source>
+        <translation>រូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="35"/>
+        <source>Archive</source>
+        <translation>រុបួច</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="36"/>
+        <source>Text</source>
+        <translation>ຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="37"/>
+        <source>Executable</source>
+        <translation>ිකිකිරෙකිරි</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="38"/>
+        <source>Backup file</source>
+        <translation>වැනි མැබිණියෙනි</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/mimetype/mimetypedisplaymanager.cpp" line="39"/>
+        <source>Unknown</source>
+        <translation>තහනමියෙනි</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::MountAskPasswordDialog</name>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="34"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍល់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="34"/>
+        <source>Connect</source>
+        <comment>button</comment>
+        <translation>ເຊັ່ມຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="38"/>
+        <source>Log in as</source>
+        <translation>ចុះឤិកដោយ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="44"/>
+        <source>Anonymous</source>
+        <translation>ບໍ່ຮູ້ຈັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="49"/>
+        <source>Registered user</source>
+        <translation>ចុះឤិកបាន</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="64"/>
+        <source>Username</source>
+        <translation>អ្នកប្រើប្រាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="72"/>
+        <source>Domain</source>
+        <translation>ស្ថានភិបាល</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="80"/>
+        <source>Password</source>
+        <translation>លំដាប់លេខ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp" line="93"/>
+        <source>Remember password</source>
+        <translation>ចងចុចលំដាប់លេខ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::MountSecretDiskAskPasswordDialog</name>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp" line="33"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp" line="33"/>
+        <source>Unlock</source>
+        <comment>button</comment>
+        <translation>ເປີດລໍກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp" line="37"/>
+        <source>Input password to decrypt the disk</source>
+        <translation>ລើងុកលំដាប់ដើម្បីចំណាសរដ្ឋាន</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::RightValueWidget</name>
+    <message>
+        <location filename="../src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp" line="279"/>
+        <source>Copy complete info</source>
+        <translation>ສ້າງລິ້ງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::SettingBackend</name>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="244"/>
+        <source>Always open folder in new window</source>
+        <translation>បុរាណបើកថ្លេកថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="263"/>
+        <source>Open file:</source>
+        <translation>បើកឯកសារ:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="264"/>
+        <source>Click</source>
+        <translation>ចុច</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="265"/>
+        <source>Double click</source>
+        <translation>ចុចពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="269"/>
+        <source>New window and tab</source>
+        <translation>ថ្លេកថ្មីនិងទម្រង់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="271"/>
+        <source>Open from default window:</source>
+        <translation>បើកពីថ្លេកលំដាប់លំនៅ:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="273"/>
+        <source>Computer</source>
+        <translation>មេូទ្រុក</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="274"/>
+        <source>Home</source>
+        <translation>ផ្ទៃដើម</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="275"/>
+        <source>Desktop</source>
+        <translation>តុប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="276"/>
+        <source>Videos</source>
+        <translation>វីដេអូ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="277"/>
+        <source>Music</source>
+        <translation>មូសឿក</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="278"/>
+        <source>Pictures</source>
+        <translation>រូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="279"/>
+        <source>Documents</source>
+        <translation>ឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="280"/>
+        <source>Downloads</source>
+        <translation>ดาวน์โหลด</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="292"/>
+        <source>Open in new tab:</source>
+        <translation>เปิดในแท็บใหม่:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="294"/>
+        <source>Current Directory</source>
+        <translation>ไดเรกทอรีปัจจุบัน</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="315"/>
+        <source>Files and folders</source>
+        <translation>ไฟล์และโฟลเดอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="317"/>
+        <source>Show hidden files</source>
+        <translation>แสดงไฟล์ซ่อน</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="320"/>
+        <source>Show file extensions</source>
+        <translation>แสดงนามสกุลไฟล์</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="322"/>
+        <source>Mix sorting of files and folders</source>
+        <translation>ผสมผสานการเรียงลำดับไฟล์และโฟลเดอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="330"/>
+        <source>Workspace</source>
+        <translation>พื้นที่ทำงาน</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="331"/>
+        <source>View</source>
+        <translation>ເບິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="348"/>
+        <source>Default icon grid density:</source>
+        <translation>ຄວາມກົ່ງຕົງຂອງຮູບສັນນິ້ວຄ່ອຍເລີ່ມຕົ້ນ:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="358"/>
+        <source>Default list height:</source>
+        <translation>ความสูงเริ่มต้นของรายการ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="368"/>
+        <source>Tree</source>
+        <translation>ต้นไม้</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="372"/>
+        <source>Default view:</source>
+        <translation>รูปแบบการดูเริ่มต้น:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="365"/>
+        <source>Icon</source>
+        <translation>ไอคอน</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="247"/>
+        <source>Activate existing window when reopening folder</source>
+        <translation>เปิดใช้งานหน้าต่างที่มีอยู่เมื่อเปิดซ้ำโฟลเดอร์</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="338"/>
+        <source>Default icon size:</source>
+        <translation>ຂະໜາດຮູບສັນນິ້ວເລີ່ມຕົ້ນ:</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="365"/>
+        <source>List</source>
+        <translation>ບັນຊີ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="378"/>
+        <source>Restore default view mode for all directories</source>
+        <translation>ជំនួសទីតាំងទៅលើ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="379"/>
+        <source>Restore default view mode</source>
+        <translation>ກັບຄືນຮູບແບບເບິ່ງເລີ່ມຕົ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="383"/>
+        <source>Thumbnail preview</source>
+        <translation>ផ្ទាំងភាពយន្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="386"/>
+        <source>Compressed file preview</source>
+        <translation>ການສະແດງຕົວຢ່າງໄຟລ໌ທີ່ຖືກບັນທຶກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="389"/>
+        <source>Text preview</source>
+        <translation>ខ្លឹមសារលំដាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="391"/>
+        <source>Document preview</source>
+        <translation>ການສະແດງເອກະສານຕົວຢ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="393"/>
+        <source>Image preview</source>
+        <translation>ການສະແດງຮູບພາບຕົວຢ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="395"/>
+        <source>Video preview</source>
+        <translation>ການສະແດງວິດີໂອຕົວຢ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="397"/>
+        <source>Music preview</source>
+        <translation>ການທົດສອບສຽງເພງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="400"/>
+        <source>The remote environment shows thumbnail previews</source>
+        <translation>បរិស្ថានចំណុចបំបាកបង្ហាញផ្ទាំងភាពយន្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="401"/>
+        <source>Turning on the thumbnail preview may cause the remote directory to load slowly or the operation to freeze</source>
+        <translation>ການເປີດການທົດສອບຮູບນ້ອຍອາດຈະເຮັດໃຫ້ເຊື້ອຂໍ້ມູນໄລຍະໄປມາຊ້າຂຶ້ນຫຼືການດຳເນີນການຢຸດນັ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="410"/>
+        <source>Advanced</source>
+        <translation>ຂັ້ນສູງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="412"/>
+        <source>Mount</source>
+        <translation>ຕິດຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="415"/>
+        <source>Auto mount</source>
+        <translation>ອັອໂມດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="420"/>
+        <source>Open after auto mount</source>
+        <translation>ອັອໂມດຫັນເປັນເປັນບູຮ່ຫຼັງຈາກອັອໂມດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="425"/>
+        <source>Merge the entries of Samba shared folders</source>
+        <translation>ກັບອົງປະກອບຂອງເຄື່ອງມູນ Samba ഷ້້ອງການ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="427"/>
+        <source>Switching the entry display may lead to failed mounting</source>
+        <translation>ການປ່ຽນແປງການສະແດງຕົວຊີ້ແຈງຂໍ້ມູນອາດຈະເຮັດໃຫ້ການຕິດຕັ້ງບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="432"/>
+        <source>Use the file chooser dialog of File Manager</source>
+        <translation>ນີ້ນັ້ນໃຊ້ກ диалог выбора файла ഷ້ອງການຈັດການ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/base/configs/settingbackend.cpp" line="434"/>
+        <source>Ask for my confirmation when deleting files</source>
+        <translation>ຂໍຄວາມຢືນຢັນຂອງຂ້ອຍເມື່ອລົບໄຟລ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::Shortcut</name>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="17"/>
+        <source>Item</source>
+        <translation>ສິ່ງຂອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="18"/>
+        <source>Select to the first item</source>
+        <translation>ເລືອກໄປຍັງສິ່ງຂອງທຳອິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="19"/>
+        <source>Select to the last item</source>
+        <translation>ເລືອກສັ່ງເຖິງອົງປະກອບທີ່ເລືອກເປັນຄຳທີ່ເລືອກເປັນຄຳທີ່ເລືອກເປັນຄຳທີ່ເລືອກເປັນຄຳທີ່ເລືອກເປັນຄຳທີ່ເລືອກເປັນຄຳທີ່ເລືອກເປັນຄຳທີ່ເລືອກເປັນຄຳທີ່ເລືອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="20"/>
+        <source>Select leftwards</source>
+        <translation>ເລືອກໄປທາງຊ້າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="21"/>
+        <source>Select rightwards</source>
+        <translation>ເລືອກທີ່ນຳຂວາງຄຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="22"/>
+        <source>Select to upper row</source>
+        <translation>ເລືອກສັ່ງເຖິງແຖບທີ່ເທິງຂ້າງເທິງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="23"/>
+        <source>Select to lower row</source>
+        <translation>ເລືອກສັ່ງເຖິງແຖບທີ່ເທິງຂ້າງລຸ່ມ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="24"/>
+        <source>Reverse selection</source>
+        <translation>ການເລືອກສັ່ງເຖິງທາງຕ້ານກັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="25"/>
+        <source>Open</source>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="26"/>
+        <source>To parent directory</source>
+        <translation>ទុក្ករណាយចូលទៅក្នុងថ្លៃូរីមុខ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="27"/>
+        <source>Permanently delete</source>
+        <translation>លិចលើសគ្រប់គ្រាន់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="28"/>
+        <source>Delete file</source>
+        <translation>លិចឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="29"/>
+        <source>Select all</source>
+        <translation>ເລືອກທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="30"/>
+        <source>Copy</source>
+        <translation>ចិត្តចំណាយ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="31"/>
+        <source>Cut</source>
+        <translation>ຕັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="32"/>
+        <source>Paste</source>
+        <translation>ត្រូវតាំង</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="33"/>
+        <source>Rename</source>
+        <translation>ປ່ຽນຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="34"/>
+        <source>Open in terminal</source>
+        <translation>ເປີດໃນ terminal</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="35"/>
+        <source>Undo</source>
+        <translation>បង្លាក់ចែកតាមដើរត្រឡប់ក្រោយ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="36"/>
+        <source>Redo</source>
+        <translation>ធ្វើឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="38"/>
+        <source>New/Search</source>
+        <translation>ថ្មី/ស្វែងរក</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="39"/>
+        <source>New window</source>
+        <translation>ថ្មីរបាយកម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="40"/>
+        <source>New folder</source>
+        <translation>ການສ້າງບ່ອນເກັບຮັກສາໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="41"/>
+        <source>Search</source>
+        <translation>ຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="42"/>
+        <source>New tab</source>
+        <translation>ແ្វូបញ្ចា</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="43"/>
+        <source>View</source>
+        <translation>ເບິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="44"/>
+        <source>Item information</source>
+        <translation>ធាតុព័ត៌មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="45"/>
+        <source>Help</source>
+        <translation>ជួយ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="46"/>
+        <source>Keyboard shortcuts</source>
+        <translation>ຄົັນທີ້ນຸມ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="47"/>
+        <source>Switch display status</source>
+        <translation>ປ່ຽນສະຖານະການສະແດງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="48"/>
+        <source>Hide item</source>
+        <translation>ກັບຄຳບຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="49"/>
+        <source>Input in address bar</source>
+        <translation>ປ້ອນໃນຄ່ອງທີ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="50"/>
+        <source>Switch to icon view</source>
+        <translation>ປັນໄປແບບພາບພາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="51"/>
+        <source>Switch to list view</source>
+        <translation>ປັນໄປແບບຕຳໍ້</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="52"/>
+        <source>Switch to tree view</source>
+        <translation>ປັນໄປແບບຕຳໍ້ຕຳໍ້</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="53"/>
+        <source>Others</source>
+        <translation>ອື່ນໆ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="54"/>
+        <source>Close</source>
+        <translation>ປິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="55"/>
+        <source>Close current tab</source>
+        <translation>ກັບຄຳບຳປະຫວັງປະຫວັງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="56"/>
+        <source>Back</source>
+        <translation>ກັບໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="57"/>
+        <source>Forward</source>
+        <translation>ກ່ວາ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="58"/>
+        <source>Switch to next tab</source>
+        <translation>ប្តូរទៅតារបន្ទាក់បន្ទាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="59"/>
+        <source>Switch to previous tab</source>
+        <translation>ប្តូរទៅតារបន្ទាក់មុន</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="60"/>
+        <source>Next file</source>
+        <translation>ឯកសាស់បន្ទាក់បន្ទាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="61"/>
+        <source>Previous file</source>
+        <translation>ໄຟລ໌ກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="62"/>
+        <source>Switch tab by specified number between 1 to 8</source>
+        <translation>ប្តូរទៅតារបន្ទាក់ដោយចំណាក់លំនាំពី 1 ទៅដល់ 8</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::SystemPathUtil</name>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="102"/>
+        <source>Home</source>
+        <translation>ផ្ទៃដី</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="103"/>
+        <source>Desktop</source>
+        <translation>តុប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="104"/>
+        <source>Videos</source>
+        <translation>វិដែ오</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="105"/>
+        <source>Music</source>
+        <translation>មូសិក</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="106"/>
+        <source>Pictures</source>
+        <translation>រូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="107"/>
+        <source>Documents</source>
+        <translation>ឯកសារ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="108"/>
+        <source>Downloads</source>
+        <translation>ទាញយក</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="109"/>
+        <source>Trash</source>
+        <translation>ການລົບຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="110"/>
+        <source>System Disk</source>
+        <translation>រាជប្រព័ន្ធ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/utils/systempathutil.cpp" line="111"/>
+        <source>Recent</source>
+        <translation>ថ្មិនមេ recent</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::TaskWidget</name>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="213"/>
+        <source>create source file %1 Info failed in show conflict Info function!</source>
+        <translation>ການສ້າງໄຟລ໌ປະຈຳ %1 ຂໍ້ມູນບໍ່ສາມາດສ້າງໄດ້ໃນການຝັງຂໍ້ມູນຂໍ້ຂັດແຍ່ງ!</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="223"/>
+        <source>create target file %1 Info failed in show conflict Info function!</source>
+        <translation>ບໍ່ສາມາດສ້າງໄຟລ໌ປະຈຳ %1 ຂໍ້ມູນບໍ່ສາມາດສ້າງໄດ້ໃນການຝັງຂໍ້ມູນຂໍ້ຂັດແຍ່ງ!</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="777"/>
+        <source>Time modified: %1</source>
+        <translation>ពេលបង្កើតប្រសើរ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="782"/>
+        <source>Original folder</source>
+        <translation>ថ្នាំងសារបើកដំបូង</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="789"/>
+        <source>Contains: %1</source>
+        <translation>មាន: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="792"/>
+        <source>Original file</source>
+        <translation>ឯកសារបើកដំបូង</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="793"/>
+        <source>Size: %1</source>
+        <translation>ຂະໜາດ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="782"/>
+        <source>Target folder</source>
+        <translation>ថ្នាំងសារបែបទាំងនេះ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="448"/>
+        <source>In data statistics ...</source>
+        <translation>កំពុងស្គាល់ទូរទសកម្មទិន្នន័យ...</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="792"/>
+        <source>Target file</source>
+        <translation>ឯកសារបែបទាំងនេះ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="385"/>
+        <source>Syncing data</source>
+        <translation>ການສະແດງຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="386"/>
+        <source>Please wait</source>
+        <translation>សូមព្រមិនភ្លេច</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="597"/>
+        <source>Keep both</source>
+        <comment>button</comment>
+        <translation>រក្សាឆ្នាំងទាំងពីរ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="600"/>
+        <source>Skip</source>
+        <comment>button</comment>
+        <translation>ហើយចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="605"/>
+        <source>Replace</source>
+        <comment>button</comment>
+        <translation>ប្រេស</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="630"/>
+        <source>Do not ask again</source>
+        <translation>ຢ່າຖາມອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="659"/>
+        <source>Retry</source>
+        <comment>button</comment>
+        <translation>ພະຍາຍາມອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/taskdialog/taskwidget.cpp" line="665"/>
+        <source>Merge</source>
+        <comment>button</comment>
+        <translation>ປະສົມ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmbase::UserSharePasswordSettingDialog</name>
+    <message>
+        <location filename="../src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp" line="29"/>
+        <source>Enter a password to protect shared folders</source>
+        <translation>ປ້ອນລະຫັດຜ່ານເພື່ອປົກປ້ອງບ່ອນເກັບຮັກສາທີ່ແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp" line="53"/>
+        <source>Set a password on the shared folder for non-anonymous access</source>
+        <translation>ຕັ້ງລະຫັດຜ່ານໃສ່ບ່ອນເກັບຮັກສາເພື່ອການເຂົ້າເຖິງບໍ່ເປັນທີ່ລົງທຶນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_avfsbrowser::AvfsMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp" line="143"/>
+        <source>Open</source>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp" line="144"/>
+        <source>Copy</source>
+        <translation>ຄໍາຮ້ອງຂອງຂ້ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp" line="145"/>
+        <source>Properties</source>
+        <translation>លក្ខណៈ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_bookmark::BookMarkManager</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp" line="339"/>
+        <source>Sorry, unable to locate your quick access directory, remove it?</source>
+        <translation>សម្រេចចិត្ត, មិនអាចរកឃើញទីភ្លាក់រហ័សរបស់អ្នកទេ, លើងវិញក៏បាន</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp" line="341"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ប ង្កាំង</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp" line="342"/>
+        <source>Remove</source>
+        <comment>button</comment>
+        <translation>ລຶບ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_bookmark::BookmarkMenuScene</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/menu/bookmarkmenuscene.cpp" line="58"/>
+        <source>Pin to quick access</source>
+        <translation>ទីភាពទាន់ទៅទីភ្លាក់រហ័ស</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-bookmark/menu/bookmarkmenuscene.cpp" line="59"/>
+        <source>Remove from quick access</source>
+        <translation>ຖືກຕ້ອງຈາກການເຂົ້າເຖິງໄວ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::AbstractBurnJob</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="86"/>
+        <source>Burning disc %1, please wait...</source>
+        <translation>ចាក់ប្រហាក់រលក %1, សូមកាត់ការរងេច...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="87"/>
+        <source>Writing data...</source>
+        <translation>កំពូលទុកទិន្នន៓ាយូរៗ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="90"/>
+        <source>Verifying data...</source>
+        <translation>ກຳລັງຢືນຢັນຂໍ້ມູນ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="164"/>
+        <source>Data verification successful.</source>
+        <translation>ການຢືນຢັນຂໍ້ມູນສຳເລັດ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="172"/>
+        <source>Burn process completed</source>
+        <translation>ការសរសៃបាក់ប៉ុន្តេបានបញ្ចប់។</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="214"/>
+        <source>The device was not safely unmounted</source>
+        <translation>ອຸປະກອນບໍ່ໄດ້ຖືກຕັ້ງອອກຢ່າງປອດໄພ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="214"/>
+        <source>Disk is busy, cannot unmount now</source>
+        <translation>រាវ់ខ្សាច់មានការសកម្មភាពកំពូលក៏ដោយមិនអាចចាកេះសម្រេចបានដោយភ្លាស់ទៅលើពេលនេះ។</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::BurnEventReceiver</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp" line="98"/>
+        <source>Unable to burn. Not enough free space on the target disk.</source>
+        <translation>មិនអាចសរសៃបាក់ប៉ុន្តេបានទេ។រាវ់ខ្សាច់ដែលជំនុះជំនុះមានតែចំនួនទូទំស់មិនគ្រប់គ្រាន់។</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp" line="240"/>
+        <source>Mount error: unsupported image format</source>
+        <translation>មេរ៉ាក្លេក់: ទម្រង់រូបភាពមិនទាន់គាំទាវបាន។</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::BurnISOFilesJob</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="423"/>
+        <source>The file name or the path is too long. Please shorten the file name or the path and try again.</source>
+        <translation>ຊື່ຟາຍລ໌ ຫຼື ລົ້ນທາງເຂົ້າມາກຳລັງຍາວເກີນໄປ. ກະລຸນາສັ້ນຊື່ຟາຍລ໌ ຫຼື ລົ້ນທາງເຂົ້າມາ ແລະ ພະຍາຍາມອີກຄັ້ງ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::BurnJobManager</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="225"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="240"/>
+        <source>Disc erase failed</source>
+        <translation>ការលាយល់រាវ់ខ្សាច់បានបរាជ័យ។</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="244"/>
+        <source>Burn process failed</source>
+        <translation>ការសរសៃបាក់ប៉ុន្តេបានបរាជ័យ។</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="247"/>
+        <source>Data verification failed</source>
+        <translation>ການກວດສອບຂໍ້ມູນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="250"/>
+        <source>%1: %2</source>
+        <translation>%1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="266"/>
+        <source>Show details</source>
+        <translation>បង្ហាញលេខລະង់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="270"/>
+        <source>Hide details</source>
+        <translation>ດັດຊີ່ລາຍລະອຽດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="271"/>
+        <source>Error</source>
+        <translation>ຂໍ້ຜິດພາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="280"/>
+        <source>Show details</source>
+        <comment>button</comment>
+        <translation>ສະແດງລາຍລະອຽດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="281"/>
+        <source>Confirm</source>
+        <comment>button</comment>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="296"/>
+        <source>View Image File</source>
+        <comment>button</comment>
+        <translation>ເບິ່ງໄຟລ໌ຮູບພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="315"/>
+        <source>Image successfully created</source>
+        <translation>ຮູບພາບຖືກສ້າງສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp" line="350"/>
+        <source>Image creation failed</source>
+        <translation>ການສ້າງຮູບພາບບໍ່ສຳເລັດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::BurnOptDialog</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="141"/>
+        <source>Advanced settings</source>
+        <translation>ການຕັ້ງຄ່າຂັ້ນສູງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="165"/>
+        <source>File system: </source>
+        <translation>ລະບົບໄຟລ໌: </translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="168"/>
+        <source>ISO9660 Only</source>
+        <translation>ISO9660 ແນ່ນອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="169"/>
+        <source>ISO9660/Joliet (For Windows)</source>
+        <translation>ISO9660/Joliet (ສຳລັບ Windows)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="170"/>
+        <source>ISO9660/Rock Ridge (For Unix)</source>
+        <translation>ISO9660/Rock Ridge (ສຳລັບ Unix)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="180"/>
+        <source>%1 (Compatible with Windows CD/DVD mode)</source>
+        <translation>%1 (ສຳເລັດກັບຮູບແບບ CD/DVD Windows)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="315"/>
+        <source>Device error</source>
+        <translation>ຂໍ້ຜິດພາດຂອງອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp" line="315"/>
+        <source>Optical device %1 doesn&apos;t exist</source>
+        <translation>ອຸປະກອນຮູບພາບ %1 ບໍ່ມີ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::BurnUDFFilesJob</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="520"/>
+        <source>The file name or the path is too long. Please shorten the file name or the path and try again.</source>
+        <translation>ຊື່ຟາຍລ໌ ຫຼື ເສັ້ນທາງແມ່ນຍາວເກີນໄປ. ກະລຸນາຍາວຂຶ້ນໃຫ້ສັ້ນຂຶ້ນ ຫຼື ຍາວຂຶ້ນໃຫ້ສັ້ນຂຶ້ນ ແລ້ວພະຍາຍາມອີກຄັ້ງ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::DumpISOImageJob</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="570"/>
+        <source>Creating an ISO image</source>
+        <translation>ການສ້າງຮູບຮ່າງ ISO</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="571"/>
+        <source>to %1</source>
+        <translation>ໄປ %1</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::DumpISOOptDialog</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp" line="57"/>
+        <source>Create ISO Image</source>
+        <comment>button</comment>
+        <translation>ສ້າງຮູບຮ່າງ ISO</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp" line="70"/>
+        <source>Save as Image File</source>
+        <translation>ບັນທຶກເປັນຟາຍລ໌ຮູບຮ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp" line="81"/>
+        <source>All files in the disc will be packaged and created as an ISO image file.</source>
+        <translation>ຟາຍລ໌ທັງໝົດໃນດີສກຈະຖືກເຊື່ອມຕໍ່ ແລະ ສ້າງເປັນຟາຍລ໌ຮູບຮ່າງ ISO.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp" line="92"/>
+        <source>Save the ISO image here:</source>
+        <translation>ບັນທຶກຮູບຮ່າງ ISO ທີ່ນີ້:</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_burn::EraseJob</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-burn/utils/burnjob.cpp" line="362"/>
+        <source>Erasing disc %1, please wait...</source>
+        <translation>ກຳລັງລົບດີສກ %1, ກະລຸນາລໍຖ້າ...</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_computer::AppEntryFileEntity</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/fileentity/appentryfileentity.cpp" line="58"/>
+        <source>Double click to open it</source>
+        <translation>ກົດຄັ້ງທີສອງເພື່ອເປີດມັນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_computer::Computer</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/computer.cpp" line="60"/>
+        <source>Computer</source>
+        <translation>ຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/computer.cpp" line="184"/>
+        <source>Computer display items</source>
+        <translation>ສິ່ງຂອງທີ່ສະແດງໃນຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/computer.cpp" line="186"/>
+        <source>Hide built-in disks on the Computer page</source>
+        <translation>ເຊື່ອງດິສກທີ່ຕິດຕັ້ງຢູ່ໃນໜ້າຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/computer.cpp" line="189"/>
+        <source>Hide loop partitions on the Computer page</source>
+        <translation>ເຊື່ອງພາທິຊັນ loop ໃນໜ້າຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/computer.cpp" line="191"/>
+        <source>Show file system on disk icon</source>
+        <translation>ສະແດງລະບົບຟາຍລ໌ໃນສັນຍາລັກດິສ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/computer.cpp" line="195"/>
+        <source>Hide My Directories on the Computer page</source>
+        <translation>ເຊື່ອງໄດເຣັກທໍຣີຂອງຂ້ອຍໃນໜ້າຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/computer.cpp" line="211"/>
+        <source>Hide 3rd party entries on the Computer page</source>
+        <translation>ເຊື່ອງລາຍການຈາກພາກສ່ວນທີສາມໃນໜ້າຄອມພິວເຕີ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_computer::ComputerController</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="325"/>
+        <source>Unlock device failed</source>
+        <translation>បុកឧបករណ៍បរាជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="325"/>
+        <source>Wrong password</source>
+        <translation>លំដាប់ល័ខណ្ឌខុស</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="178"/>
+        <source>Rename failed</source>
+        <translation>ផ្លាស់ប្តូរឈ្មោះបរាជ័យ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="178"/>
+        <source>The device is busy and cannot be renamed now</source>
+        <translation>ອຸປະກອນນີ້ມີການດຳເນີນການແລ້ວ ແລະ ບໍ່ສາມາດປ່ຽນຊື່ໄດ້ໃນເວລານີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="561"/>
+        <source>Format failed</source>
+        <translation>ການຕັ້ງຄ່າບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="561"/>
+        <source>The device is busy and cannot be formatted now</source>
+        <translation>ឧបករណ៍នៅឡើងហើយមិនអាចរាងកាយបានទៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="720"/>
+        <source>Mount error</source>
+        <translation>ទំរូតបញ្ហាពីមុខ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp" line="720"/>
+        <source>Cannot access %1</source>
+        <translation>មិនអាចចុះមុខទៀតនូវ %1</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_computer::ComputerEventReceiver</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp" line="46"/>
+        <source>Computer</source>
+        <translation>ឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp" line="230"/>
+        <source>%1 is read-only. Do you want to enable read and write permissions for it?</source>
+        <translation>&apos;%1 ແມ່ນອ່ານພຽງແຕ່. ທ່ານຕ້ອງການເປີດໃຊ້ສິດອ່ານແລະຂຽນສຳລັບມັນບໍ?&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp" line="231"/>
+        <source>Once enabled, read/write permission will be granted permanently</source>
+        <translation>បន្ទាប់ពីបួលបានប្រើប្រាស់ទៀត, អាននូវការសរសេរនឹងត្រូវបានផ្តល់ជាពេលវេលាប្រសិនបូរិសត្ត</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp" line="233"/>
+        <source>Cancel</source>
+        <translation>ប៉ាន់ស្យូប</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp" line="234"/>
+        <source>Enable Now</source>
+        <translation>ເປີດໃຊ້ໃນເວລານີ້</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_computer::ComputerItemWatcher</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp" line="370"/>
+        <source>My Directories</source>
+        <translation>ສ່ວນທີ່ຂ້ອຍມີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp" line="375"/>
+        <source>Disks</source>
+        <translation>ឌីសខាងលីច</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_computer::DeviceBasicWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="33"/>
+        <source>Basic info</source>
+        <translation>ຂໍ້ມູນພື້ນຖານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="41"/>
+        <source>Device type</source>
+        <translation>ប្រភេទឧបករណ៍</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="44"/>
+        <source>Total space</source>
+        <translation>พื้นที่សរុប</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="47"/>
+        <source>File system</source>
+        <translation>ប្រព័ន្ធគេម្ភារី</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="50"/>
+        <source>Contains</source>
+        <translation>មាន</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="54"/>
+        <source>Free space</source>
+        <translation>พื้นที่ទទេ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="105"/>
+        <source>%1 items</source>
+        <translation>%1 ລາຍການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp" line="105"/>
+        <source>%1 item</source>
+        <translation>%1 ລາຍການ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_computer::ProtocolEntryFileEntity</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp" line="200"/>
+        <source>%1 on %2</source>
+        <translation>%1 ຢູ່ເທິງ %2</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <source>Name</source>
+        <translation>ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <source>Size</source>
+        <translation>ទំហំ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <source>Resolution</source>
+        <translation>ຄວາມລະອຽດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <source>Duration</source>
+        <translation>ລະດັບເວລາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <source>Accessed</source>
+        <translation>ເຂົ້າໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <source>Modified</source>
+        <translation>ແກນແປງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_dirshare::DirShareMenuScene</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/dirsharemenu/dirsharemenuscene.cpp" line="61"/>
+        <source>Share folder</source>
+        <translation>ແບ່ງປັນໂົ໕ເຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/dirsharemenu/dirsharemenuscene.cpp" line="62"/>
+        <source>Cancel sharing</source>
+        <translation>ຍົກເລີກແບ່ງປັນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_dirshare::ShareControlWidget</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="110"/>
+        <source>Sharing</source>
+        <translation>ການແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="168"/>
+        <source>Share this folder</source>
+        <translation>ແບ່ງປັນໄຟລ໌ນີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="131"/>
+        <source>Share name</source>
+        <translation>ຊື່ແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="133"/>
+        <source>Permission</source>
+        <translation>ອະutorизации</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="135"/>
+        <source>Anonymous</source>
+        <translation>ອຸນຊະນາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="199"/>
+        <source>Read and write</source>
+        <translation>ການເອ່ນчит້າງແລະຂຽນຂໍ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="199"/>
+        <source>Read only</source>
+        <translation>ອ່ານພຽງແຕ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="212"/>
+        <source>Not allow</source>
+        <translation>ບໍ່ອະນຸມີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="212"/>
+        <source>Allow</source>
+        <translation>ອະນຸມີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="147"/>
+        <source>Network path</source>
+        <translation>ທີ່ສະຖານທີ່ເນັ້ນເຄຼຸນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="226"/>
+        <source>Copy</source>
+        <translation>ສ້າງລິ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="148"/>
+        <source>Username</source>
+        <translation>ຊື່ຜູ້ໃຊ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="292"/>
+        <source>None</source>
+        <translation>ບໍ່ມີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="294"/>
+        <source>Set password</source>
+        <translation>ຕຼ້ມຕຼ້ນລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="295"/>
+        <source>Change password</source>
+        <translation>ແກ້ໄຂລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="149"/>
+        <source>Share password</source>
+        <translation>ລະຫັດແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="313"/>
+        <source>This password will be applied to all shared folders, and users without the password can only access shared folders that allow anonymous access. </source>
+        <translation>ລະຫັດຜ່ານນີ້ຈະຖືກປັບໃຫ້ເຂົ້າກັບທຸກໄຟລ໌ທີ່ແບ່ງປັນ, ຜູ້ໃຊ້ທີ່ບໍ່ມີລະຫັດຜ່ານສາມາດເຂົ້າເຖິງໄຟລ໌ທີ່ແບ່ງປັນທີ່ອະນຸຍາດໃຫ້ເຂົ້າເຖິງໂດຍບໍ່ມີຊື່ຜູ້ໃຊ້ເທົ່ານັ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="416"/>
+        <source>The share name must not be two dots (..) or one dot (.)</source>
+        <translation>ຊື່ແບ່ງປັນບໍ່ຄວາມຳນີ້ (..) ചີ້ນີ້ (.) ഺ້າງຢ່າງໃດກໍ່ໄດ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="434"/>
+        <source>The share name is used by another user.</source>
+        <translation>ຊື່ແບ່ງປັນນີ້ຖືກນຳໃຊ້ໂດຍຜູ້ໃຊ້ອຶ່ງອຶ່ງອຶ່ງອຶ່ງອຶ່ງອຶ່ງອຶ່ງ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="435"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="437"/>
+        <source>The share name already exists. Do you want to replace the shared folder?</source>
+        <translation>ຊື່ແບ່ງປັນນີ້ມັນມີແລ້ວ. ངຈທີ່ຢາກແທນທີ່ແບ່ງປັນໄດ້?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="438"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="439"/>
+        <source>Replace</source>
+        <comment>button</comment>
+        <translation>ແທນທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp" line="594"/>
+        <source>The shared name is too long and will be truncated.</source>
+        <translation>ຊື່ແບ່ງປັນມັນຍຼາງເກີ່ງລຈມລັກສະນະຈະຖືກກັນຍ່າງ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_dirshare::UserShareHelper</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="91"/>
+        <source>Kindly Reminder</source>
+        <translation>ນຳສະໜູ້ນໍາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="91"/>
+        <source>Please firstly install samba to continue</source>
+        <translation>ຂໍຂ້ອຍຂ້າງເທິງຕິດຕັ້ງ samba ແລ້ວຈຶ່ງຈະດຳເນີນຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="103"/>
+        <source>The share name must not contain %1, and cannot start with a dash (-) or whitespace, or end with whitespace.</source>
+        <translation>ຊື່ແບ່ງປັນບໍ່ຄວາມຳນີ້ %1, ບໍ່ສາມາດຂຶ້ນດ້ວຍລູກສະແດງ (-) ຫຼືຊ່ອງວ່າງ, ຫຼືລົງດ້ວຍຊ່ອງວ່າງ.</translation>
+    </message>  
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="513"/>
+        <source>Share folder can&apos;t be named after the current username</source>
+        <translation>ບໍ່ສາມາດຕັ້ງຊື່ໄຟລ໌ແບ່ງປັນເປັນຊື່ຜູ້ໃຊ້ປັດຈຸບັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="519"/>
+        <source>To protect the files, you cannot share this folder.</source>
+        <translation>ການແບ່ງປັນຈະບໍ່ສາມາດເຮັດໄດ້, ກະລຸນາຕັ້ງຄ່າການປົກປ້ອງໄຟລ໌ກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="545"/>
+        <source>Sharing failed</source>
+        <translation>ການແບ່ງປັນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="548"/>
+        <source>SMB port is banned, please check the firewall strategy.</source>
+        <translation>ທາງເລືອກ SMB ໄດ້ຖືກຂ້າງເທິງ, ກະລຸນາກວດເບີບກົດລະບຽບກັນໄຟເວີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp" line="557"/>
+        <source>The computer name is too long</source>
+        <translation>ຊື່ຄອມພິວເຕີຍາວເກີນໄປ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::ChgPassphraseDialog</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="18"/>
+        <source>passphrase</source>
+        <translation>ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="20"/>
+        <source>PIN</source>
+        <translation>ລະຫັດ PIN</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="58"/>
+        <source>Modify %1</source>
+        <translation>ແກ້ໄຂ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="69"/>
+        <source>Please enter %1 again</source>
+        <translation>ກະລຸນາປ້ອນ %1 ອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="72"/>
+        <source>New %1</source>
+        <translation>%1 ໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="73"/>
+        <source>Repeat %1</source>
+        <translation>ປ້ອນ %1 ອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="79"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="80"/>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="103"/>
+        <source>%1 cannot be empty</source>
+        <translation>%1 ບໍ່ສາມາດວ່າງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="112"/>
+        <source>Recovery key</source>
+        <translation>ключа восстановления</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="119"/>
+        <source>Recovery key is not valid!</source>
+        <translation>ключа восстановления недействителен!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="147"/>
+        <source>At least 8 bits, contains 3 types of A-Z, a-z, 0-9 and symbols</source>
+        <translation>Минимум 8 битов, содержит три типа заглавных букв, строчных букв, цифр и символов</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="153"/>
+        <source>%1 inconsistency</source>
+        <translation>несовпадение %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="180"/>
+        <source>Validate with %1</source>
+        <translation>Проверить с помощью %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="181"/>
+        <source>Please input recovery key</source>
+        <translation>Пожалуйста, введите ключ восстановления</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="184"/>
+        <source>Old %1</source>
+        <translation>Старый %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="187"/>
+        <source>Validate with recovery key</source>
+        <translation>Проверить с помощью ключа восстановления</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::DecryptParamsInputDialog</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="54"/>
+        <source>Please input recovery key to decrypt device</source>
+        <translation>Пожалуйста, введите ключ восстановления для разблокировки устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="55"/>
+        <source>Validate with %1</source>
+        <translation>ຕົວຢ່າງດ້ວຍ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="55"/>
+        <source>PIN</source>
+        <translation>ПИН-код</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="55"/>
+        <source>passphrase</source>
+        <translation>парольная фраза</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="60"/>
+        <source>Please input %1 to decrypt device</source>
+        <translation>Пожалуйста, введите %1 для разблокировки устройства</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="61"/>
+        <source>Validate with recovery key</source>
+        <translation>Проверить с помощью ключа восстановления</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="85"/>
+        <source>Passphrase</source>
+        <translation>Парольная фраза</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="87"/>
+        <source>Recovery key</source>
+        <translation>ກຸ່ມລະຫັດສໍານັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="88"/>
+        <source>%1 cannot be empty!</source>
+        <translation>&apos;%1 ບໍ່ສາມາດວ່າງໄດ້!&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="94"/>
+        <source>Recovery key is not valid!</source>
+        <translation>សម្រាប់ស្វែងយកឡើងវិញមិនត្រឹមត្រូវទេ！</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="111"/>
+        <source>Decrypt device</source>
+        <translation>ស្វែងយកឧបាសក្តានដោយឡើងវិញ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="119"/>
+        <source>Confirm</source>
+        <translation>ຢັນທະນານືນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::DiskEncryptMenuScene</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="167"/>
+        <source>Unlock encrypted partition</source>
+        <translation>ounlock encrypted partition</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="171"/>
+        <source>Cancel partition encryption</source>
+        <translation>ຍົກເລີກການລະບົບກັນຂໍ້ມູນຂອງພັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="175"/>
+        <source>passphrase</source>
+        <translation>passphrase</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="176"/>
+        <source>Changing the encryption %1</source>
+        <translation>ການລັບລະບັບກັນຂໍ້ມູນພັກ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="180"/>
+        <source>Continue partition encryption</source>
+        <translation>ຕໍ່ເນື່ອງການລະບົບກັນຂໍ້ມູນພັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="184"/>
+        <source>Continue partition decryption</source>
+        <translation>ຕໍ່ເນື່ອງການຖືກລະບົບກັນຂໍ້ມູນພັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="188"/>
+        <source>Enable partition encryption</source>
+        <translation>ເປີດການລະບົບກັນຂໍ້ມູນພັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="262"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="263"/>
+        <source>Cannot resolve passphrase from TPM</source>
+        <translation>ບໍ່ສາມາດແຈ້ງລະຫັດຜ່ານຈາກ TPM</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="295"/>
+        <source>PIN error</source>
+        <translation>PIN error</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="328"/>
+        <source>Change passphrase failed</source>
+        <translation>ເປັນພroblems തອບສະໜອງລະຫັດຜ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="571"/>
+        <source>Unlock device failed</source>
+        <translation>ຈັດການປົ່ງອອກຂອງອື້ໄມໃຫມ່ບໍ່ສັ່ງເທິງເປັນພroblems</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="572"/>
+        <source>Wrong passphrase</source>
+        <translation>ລະຫັດຜ່ອນຜິດພາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="592"/>
+        <source>Mount device failed</source>
+        <translation>ການຕິດຕັ້ງປົ່ງອອກຂອງອື້ໄມໃຫມ່ບໍ່ສັ່ງເທິງເປັນພroblems</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="641"/>
+        <source>unmount</source>
+        <translation>ປົ່ງອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="641"/>
+        <source>lock</source>
+        <translation>ປົ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="642"/>
+        <source>Encrypt failed</source>
+        <translation>ການລັບລະບັບບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="643"/>
+        <source>Cannot %1 device %2</source>
+        <translation>ບໍ່ສາມາດ %1 ອຸປະກອນ %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="728"/>
+        <source>Reboot to continue encrypt</source>
+        <translation>ຮັບປະກັນເພື່ອສຳເລັດການລັບລະບັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="729"/>
+        <source>Reboot to finish decrypt</source>
+        <translation>ຮັບປະກັນເພື່ອສຳເລັດການຖອນລະບຸລັອກ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::EncryptParamsInputDialog</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="118"/>
+        <source>Unlock type</source>
+        <translation>ປະເພດການປົ່ງອອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="138"/>
+        <source>Unlocked by passphrase</source>
+        <translation>ປົ່ງອອກໂດຍລະຫັດຜ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="139"/>
+        <source>Use TPM+PIN to unlock on this computer (recommended)</source>
+        <translation>ໃຊ້ TPM+PIN ເພື່ອເປີດລັອກໃນຄອມພິວເຕີນີ້ (ຖືກຕ້ອງການ)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="140"/>
+        <source>Automatic unlocking on this computer by TPM</source>
+        <translation>ປົກກະຕິການປົ່ງອອກໂດຍTPMໃນຄື່ງນີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="167"/>
+        <source>In special cases such as forgetting the password or the encryption hardware is damaged, you can decrypt the encrypted partition with the recovery key, please export it to a non-encrypted partition and keep it in a safe place!</source>
+        <translation>ໃນຄວາມສະເພາະທີ່ມີຄວາມເສຍຫາຍເຊັ່ນ: ລືມລະບຸລັອກຫຼືອຸປະກອນການລະບຸລັອກຖືກເຄື່ອນໄຫວ, ທ່ານສາມາດຖອນລະບຸລັອກຈາກພາກສ່ວນທີ່ຖືກລະບຸລັອກດ້ວຍກຳລັງຄຳກັ່ນຕອງ, ກະລຸນາສົ່ງອອກມັນໄປຫາພາກສ່ວນທີ່ບໍ່ຖືກລະບຸລັອກແລະເກັບຮັກສາໃນບ່ອນທີ່ປອດໄພ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="182"/>
+        <source>Please select a non-encrypted partition as the key file export path.</source>
+        <translation>ກະລຸນາເລືອກພາກສ່ວນທີ່ບໍ່ຖືກລະບຸລັອກເປັນທາງເອີ້ນອອກຂອງຟາຍລະບຸລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="206"/>
+        <source>Passphrase</source>
+        <translation>ລະບຸລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="208"/>
+        <source>%1 cannot be empty</source>
+        <translation>%1 ບໍ່ສາມາດວ່າງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="238"/>
+        <source>At least 8 bits, contains 3 types of A-Z, a-z, 0-9 and symbols</source>
+        <translation>ຢ່າງໜ້ອຍ 8 ຕົວອັກສອນ, ສະທ້ອນໃຫ້ເຫັນ 3 ພຶດທະນີຂອງ A-Z, a-z, 0-9 ແລະ ສັນຍານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="244"/>
+        <source>%1 inconsistency</source>
+        <translation>&apos;%1 ບໍ່ສອດຄ່ອງ&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="255"/>
+        <source>Recovery key export path cannot be empty!</source>
+        <translation>ທາງເອີ້ນອອກຂອງກຳລັງຄຳກັ່ນຕອງບໍ່ສາມາດວ່າງໄດ້!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="261"/>
+        <source>Recovery key export path is not exists!</source>
+        <translation>ທາງເອີ້ນອອກຂອງກຳລັງຄຳກັ່ນຕອງບໍ່ມີຢູ່!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="281"/>
+        <source>Please export to an external device such as a non-encrypted partition or USB flash drive.</source>
+        <translation>ກະລຸນາສົ່ງອອກໄປຍັງອຸປະກອນນອກເຊັ່ນ: ພາກສ່ວນທີ່ບໍ່ຖືກລະບຸລັອກ ຫຼື ແບັ້ງ USB</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="287"/>
+        <source>This partition is read-only, please export to a writable partition</source>
+        <translation>ພາກສ່ວນນີ້ແມ່ນຂໍ້ມູນທີ່ອ່ານໄດ້ເທົ່ານັ້ນ, ກະລຸນາສົ່ງອອກໄປຍັງພາກສ່ວນທີ່ສາມາດຂຽນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="301"/>
+        <source>The partition is encrypted, please export to a non-encrypted partition or external device such as a USB flash drive.</source>
+        <translation>ພາກສ່ວນຖືກລັບລະບົບ, ກະລຸນາສົ່ງອອກໄປຫາພາກສ່ວນທີ່ບໍ່ຖືກລັບລະບົບ ຫຼືອຸປະກອນນອກເຊັ່ນ: ອຸປະກອນ USB</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="361"/>
+        <source>Please continue to encrypt partition %1</source>
+        <translation>ກະລຸນາຕໍ່ເນື່ອງການລັບລະບົບພາກສ່ວນ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="362"/>
+        <source>Next</source>
+        <translation>ຕໍ່ໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="362"/>
+        <source>Confirm encrypt</source>
+        <translation>ຢືນຢັນການລັບລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="366"/>
+        <source>Export Recovery Key</source>
+        <translation>ສົ່ງອອກຄ່ານຳໃຊ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="367"/>
+        <source>Previous</source>
+        <translation>ກ່ອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="375"/>
+        <source>Set %1</source>
+        <translation>ນិយོད %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="376"/>
+        <source>Repeat %1</source>
+        <translation>повторите %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="378"/>
+        <source>Please enter the %1 again</source>
+        <translation>សូមປេញបរិច្ចាគ %1 ម្តងទៀត</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="383"/>
+        <source>passphrase</source>
+        <translation> passphrase</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="387"/>
+        <source>Access to the partition will be unlocked using a passphrase.</source>
+        <translation>ການເຂົ້າເຖິງພາກສ່ວນຈະຖືກປັດສະວັດດ້ວຍລະຫັດຜ່ານ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="391"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="395"/>
+        <source>Access to the partition will be unlocked using the TPM security chip and PIN.</source>
+        <translation>ການເຂົ້າເຖິງພາກສ່ວນຈະຖືກປັດສະວັດດ້ວຍຊິບຄວາມປອດໄພ TPM ແລະ ລະຫັດ PIN.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="399"/>
+        <source>Access to the partition will be automatically unlocked using the TPM security chip, no passphrase checking is required.</source>
+        <translation>ການເຂົ້າເຖິງພາກສ່ວນຈະຖືກປັດສະວັດອັດໂມມັດດ້ວຍຊິບຄວາມປອດໄພ TPM, ບໍ່ຕ້ອງການການກວດສອບລະຫັດຜ່ານ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="461"/>
+        <source>TPM is locked and cannot be used for partition encryption. Please cancel the TPM password or choose another unlocking method.</source>
+        <translation>TPM ຖືກລໍກັ້ນ ແລະ ບໍ່ສາມາດໃຊ້ໄດ້ສຳລັບການລັບລະບົບພາກສ່ວນ. ກະລຸນາຍົກເລີກລະຫັດຜ່ານ TPM ຫຼືເລືອກວິທີການປັດສະວັດອື່ນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="463"/>
+        <source>TPM error</source>
+        <translation>TPM 오шибка</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="468"/>
+        <source>TPM status error!</source>
+        <translation>TPM статус ошибки!</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::EncryptProgressDialog</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="56"/>
+        <source>Confirm</source>
+        <translation>ຢັນທີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="65"/>
+        <source>Re-export the recovery key</source>
+        <translation>ສົ່ງອອກຄ່ານຳໃຊ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="69"/>
+        <source>*Recovery key saving failed, please re-save the recovery key to a non-encrypted partition and keep it in a safe place!</source>
+        <translation>*ການບັນທຶກຄ່ານຳໃຊ້ຄືນບໍ່ສຳເລັດ, ກະລຸນາບັນທຶກຄ່ານຳໃຊ້ຄືນໃໝ່ໃນພາກສ່ວນທີ່ບໍ່ຖືກລັບລະບົບ ແລະ ລ້ອງເກັບມ້ຽນໃນບ່ອນທີ່ປອດໄພ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="88"/>
+        <source>Error</source>
+        <translation>ຜົນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="149"/>
+        <source>Recovery key export path cannot be empty!</source>
+        <translation>ທາງເລືອກສົ່ງອອກຄ່ານຳໃຊ້ຄືນບໍ່ສາມາດເປັນຄ່າເປົ່າໄດ້!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="155"/>
+        <source>Recovery key export path is not exists!</source>
+        <translation>ທາງເລືອກສົ່ງອອກຄ່ານຳໃຊ້ຄືນບໍ່ມີຢູ່!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="162"/>
+        <source>This partition is read-only, please export to a writable partition</source>
+        <translation>ພາກສ່ວນນີ້ແມ່ນພຽງແຕ່ອ່ານໄດ້, ກະລຸນາສົ່ງອອກໄປຫາພາກສ່ວນທີ່ສາມາດຂຽນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="177"/>
+        <source>The partition is encrypted, please export to a non-encrypted partition or external device such as a USB flash drive.</source>
+        <translation>ບ້ານການເຊື່ອມຕໍ່ຖືກລັບລະບັບ, ກະລຸນາສົ່ງອອກໄປບ້ານທີ່ບໍ່ຖືກລັບລະບັບຫຼືອຸປະກອນພາຍນອກເຊັ່ນ: ແຄຟ໌ USB</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="194"/>
+        <source>Cannot create recovery key file!</source>
+        <translation>ບໍ່ສາມາດສ້າງໄຟລ໌ຄຳແນະນຳກັບຄືນໄດ້!</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::EventsHandler</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="211"/>
+        <source>Encrypt done</source>
+        <translation>ການລັບລະບັບສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="212"/>
+        <source>Device %1 has been encrypted</source>
+        <translation>ອຸປະກອນ %1 ໄດ້ຖືກລັບລະບັບແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="217"/>
+        <source>Encrypt failed</source>
+        <translation>ການລັບລະບັບບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="218"/>
+        <source>Device %1 encrypt failed, please see log for more information.(%2)</source>
+        <translation>ການລັບລະບັບອຸປະກອນ %1 ບໍ່ສຳເລັດ, ກະລຸນາເບິ່ງລ່າງຂໍ້ມູນສຳລັບຂໍ້ມູນເພີ່ມເຕີມ.(%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="329"/>
+        <source>%1 is under encrypting...</source>
+        <translation>%1 ກຳລັງລັບລະບັບ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="330"/>
+        <source>The encrypting process may have system lag, please minimize the system operation</source>
+        <translation>ການລັບລະບັບອາດຈະເຮັດໃຫ້ລະບົບຊ້າ, ກະລຸນາປະຢັດການດຳເນີນການລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="350"/>
+        <source>%1 is under decrypting...</source>
+        <translation>&apos;%1 ກຳລັງຖືກຖອນລະບັບ...&apos;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="351"/>
+        <source>The decrypting process may have system lag, please minimize the system operation</source>
+        <translation>ການຖອນລະບັບອາດຈະເຮັດໃຫ້ລະບົບຊ້າ, ກະລຸນາປະຢັດການດຳເນີນການລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="381"/>
+        <source>Error</source>
+        <translation>ຂໍ້ຜິດພາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="381"/>
+        <source>TPM status is abnormal, please use the recovery key to unlock it</source>
+        <translation>ສະພາບຂອງ TPM ບໍ່ປົກກະຕິ, ກະລຸນາໃຊ້ຄຳແນະນຳກັບຄືນເພື່ອເປີດລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="412"/>
+        <source>Wrong PIN</source>
+        <translation>PIN ผิด</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="414"/>
+        <source>Wrong passphrase</source>
+        <translation>รหัสผ่านผิด</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="416"/>
+        <source>TPM error</source>
+        <translation>ข้อผิดพลาด TPM</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="418"/>
+        <source>Please use recovery key to unlock device.</source>
+        <translation>ກະລຸນາໃຊ້ຄຳແນະນຳກັບຄືນເພື່ອເປີດອຸປະກອນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="485"/>
+        <source>Preencrypt done</source>
+        <translation>การเข้ารหัสล่วงหน้าเสร็จสิ้น</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="486"/>
+        <source>Device %1 has been preencrypt, please reboot to finish encryption.</source>
+        <translation>устройство %1 ได้รับการเข้ารหัสล่วงหน้าแล้ว โปรดเริ่มต้น зановоเพื่อสิ้นสุดการเข้ารหัส</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="494"/>
+        <source>Preencrypt failed</source>
+        <translation>ການລັບລະບັບເບື້ອງຕົ້ນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="495"/>
+        <source>Device %1 preencrypt failed, please see log for more information.(%2)</source>
+        <translation>การเข้ารหัสล่วงหน้าสำหรับустройство %1 ล้มเหลว โปรดดูที่บันทึกเพื่อข้อมูลเพิ่มเติม(%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="516"/>
+        <source>Decrypt done</source>
+        <translation>การถอดรหัสเสร็จสิ้น</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="517"/>
+        <source>Device %1 has been decrypted</source>
+        <translation>ອຸປະກອນ %1 ໄດ້ຖືກຖອນລະບັບແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="525"/>
+        <source>Decrypt disk</source>
+        <translation>ຖອນລະບັບດິສກ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="526"/>
+        <source>Wrong passpharse or PIN</source>
+        <translation>ລະຫັດຜ່ານຫຼື PIN ບໍ່ຖືກຕ້ອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="530"/>
+        <source>Decrypt failed</source>
+        <translation>การถอดรหัสล้มเหลว</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="531"/>
+        <source>Device %1 is under encrypting, please decrypt after encryption finished.</source>
+        <translation>ອຸປະກອນ %1 ແມ່ນຢູ່ໃນຂະບວນການລັບລະຫັດ, ກະລຸນາກຳຈັດການລັບລະຫັດຫຼັງຈາກການລັບລະຫັດສິ້ນສຸດ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="537"/>
+        <source>Device %1 Decrypt failed, please see log for more information.(%2)</source>
+        <translation>การถอดรหัสสำหรับустройство %1ล้มเหลว โปรดดูที่บันทึกเพื่อข้อมูลเพิ่มเติม(%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="565"/>
+        <source>passphrase</source>
+        <translation>ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="568"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="575"/>
+        <source>Change %1 done</source>
+        <translation>ການປ່ຽນ %1 ແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="576"/>
+        <source>%1&apos;s %2 has been changed</source>
+        <translation>%1 ຂອງ %2 ໄດ້ຖືກປ່ຽນແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="583"/>
+        <source>Change %1 failed</source>
+        <translation>ການປ່ຽນ %1 ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="584"/>
+        <source>Wrong %1</source>
+        <translation>លំដាប់លេខ %1 មិនត្រឹមត្រូវ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="590"/>
+        <source>Device %1 change %2 failed, please see log for more information.(%3)</source>
+        <translation>ການປ່ຽນ %2 ຂອງອຸປະກອນ %1 ບໍ່ສຳເລັດ, ກະລຸນາເບິ່ງລູກສຳລັບຂໍ້ມູນເພີ່ມເຕີມ. (%3)</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="622"/>
+        <source>Device is not fully decrypted, please finish decryption before access.</source>
+        <translation>ອຸປະກອນບໍ່ໄດ້ຖືກລັບລະຫັດຢ່າງສົມບູນ, ກະລຸນາສຳເລັດການລັບລະຫັດກ່ອນກ່ອນທີ່ຈະເຂົ້າເຖິງ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="630"/>
+        <source>Unlocking device failed</source>
+        <translation>រារំណ័យឧបកម្មបានបរាលៗ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="631"/>
+        <source>Please click the right disk menu &quot;Continue partition encryption&quot; to complete partition encryption.</source>
+        <translation>ກະລຸນາຄລິກໃສ່ເມນູດິສກຂ້າງທີ່ຖືກຕ້ອງ &quot;ຕໍ່ໄປກັບການລັບລະຫັດພາກສ່ວນ&quot; ເພື່ອສຳເລັດການລັບລະຫັດພາກສ່ວນ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::UnlockPartitionDialog</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="55"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="56"/>
+        <source>Unlock</source>
+        <translation>ສະເໜີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="85"/>
+        <source>Unlock encryption partition</source>
+        <translation>ສະເໜີການລັບລະຫັດພາກສ່ວນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="89"/>
+        <source>Unlock by recovery key</source>
+        <translation>ສະເໜີໂດຍໃຊ້ກຳລັງກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="95"/>
+        <source>Unlock by passphrase</source>
+        <translation>រារំណ័យតាមលំដាប់លេខសម្របស្រាប់ចំណុចចែកចំណត</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="96"/>
+        <source>Unlock by PIN</source>
+        <translation>ເປີດໃຊ້ງານດ້ວຍລະຫັດ PIN</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="98"/>
+        <source>Please enter the 24-digit recovery key</source>
+        <translation>ກະລຸນາປ້ອນລະຫັດກູ້ຄືນ 24 ຕົວເລກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="106"/>
+        <source>Please input passphrase to unlock device</source>
+        <translation>ກະລຸນາປ້ອນລະຫັດຜ່ານເພື່ອເປີດໃຊ້ງານອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="110"/>
+        <source>Please input PIN to unlock device</source>
+        <translation>ກະລຸນາປ້ອນລະຫັດ PIN ເພື່ອເປີດໃຊ້ງານອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="124"/>
+        <source>Recovery key is not valid!</source>
+        <translation>ລະຫັດກູ້ຄືນບໍ່ຖືກຕ້ອງ!</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_fileoperations::ErrorMessageAndAction</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="30"/>
+        <source>Copying %1</source>
+        <translation>ກ່າວຄືນ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="31"/>
+        <source>to %1</source>
+        <translation>ໄປຍັງ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="34"/>
+        <source>Deleting %1</source>
+        <translation>ລຶບ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="36"/>
+        <source>Moving %1</source>
+        <translation>ຍ້າຍ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="40"/>
+        <source>Trashing %1</source>
+        <translation>ສົ່ງໄປທີ່ຖັງຂີ້ເຫຼືອ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="42"/>
+        <source>Restoring %1</source>
+        <translation>ກູ້ຄືນ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="114"/>
+        <source>Permission error</source>
+        <translation>ຂໍ້ຜິດພາດໃນສິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="116"/>
+        <source>The action is denied</source>
+        <translation>ການດຳເນີນການຖືກປະຕິເສດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="118"/>
+        <source>Target file %1 already exists</source>
+        <translation>ໄຟລ໌ເປົ້າໝາຍ %1 ທຳມະດາມີຢູ່ແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="120"/>
+        <source>Target directory %1 already exists</source>
+        <translation>ບ່ອນຈອງເປົ້າໝາຍ %1 ທຳມະດາມີຢູ່ແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="122"/>
+        <source>Failed to open the file %1</source>
+        <translation>ບឹងເປັນເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="124"/>
+        <source>Failed to read the file %1</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="126"/>
+        <source>Failed to write the file %1</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="129"/>
+        <source>Failed to create the directory %1</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="132"/>
+        <source>Failed to delete the file %1</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="134"/>
+        <source>Failed to move the file %1 to trash</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="136"/>
+        <source>Failed to move the file %1</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="138"/>
+        <source>Original file %1 does not exist</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="140"/>
+        <source>Failed, the file size of %1 must be less than 4 GB</source>
+        <translation>ບໍ່ສາມາດເຮັດການຂ້າມຕົວຟາຍລ໌, ຄວາມເປັນເຫດ: %1. ກະລຸນາພະຍາຍາມອີກຄັ້ງ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="142"/>
+        <source>Not enough free space on the target disk</source>
+        <translation>ບໍ່ມີພື້ນທີ່ເປົ່າພຽງພໍໃນດິສກ໌ເປົ້າໝາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="144"/>
+        <source>File %1 integrity was damaged</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="146"/>
+        <source>The target device is read only</source>
+        <translation>ບឹងເປົ້າໄປບ່ອນເປົ້າ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="148"/>
+        <source>Target folder is inside the source folder</source>
+        <translation>ບ່ອນທີ່ຈະເກັບຂໍ້ມູນເປົ້າໝາຍ ແມ່ນຢູ່ໃນບ່ອນທີ່ມາຂອງຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="150"/>
+        <source>The action is not supported</source>
+        <translation>ການດຳເນີນການນີ້ບໍ່ໄດ້ຮັບການສະໜັບສະໜູນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="152"/>
+        <source>You do not have permission to traverse files in %1</source>
+        <translation>ທ່ານບໍ່ມີສິດໃນການເຂົ້າເຖິງຟາຍລ໌ໃນ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="154"/>
+        <source>Restore failed, original path could not be found</source>
+        <translation>การกู้คืนล้มเหลว ไม่พบตำแหน่งต้นทาง</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="156"/>
+        <source>Unknown error</source>
+        <translation>ข้อผิดพลาดที่ไม่รู้จัก</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="158"/>
+        <source>Failed to parse the url of trash</source>
+        <translation>ล้มเหลวในการวิเคราะห์ URL ของขยะ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="160"/>
+        <source>Restore failed: the original file does not exist</source>
+        <translation>การกู้คืนล้มเหลว: ไฟล์ต้นทางไม่มีอยู่</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="163"/>
+        <source>Copy or Cut File failed! Retry copy this file again!</source>
+        <translation>ບໍ່ສາມາດເຮັດການຂ້າມຕົວຟາຍລ໌, ຄວາມເປັນເຫດ: %1. ກະລຸນາພະຍາຍາມອີກຄັ້ງ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="165"/>
+        <source>Can&apos;t access file!</source>
+        <translation>ไม่สามารถเข้าถึงไฟล์!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="186"/>
+        <source>Failed to open the file %1, cause: %2</source>
+        <translation>ล้มเหลวในการเปิดไฟล์ %1 เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="188"/>
+        <source>Failed to read the file %1, cause: %2</source>
+        <translation>ล้มเหลวในการอ่านไฟล์ %1 เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="192"/>
+        <source>Failed to write the file %1, cause: %2</source>
+        <translation>ล้มเหลวในการเขียนไฟล์ %1 เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="194"/>
+        <source>Failed to create the directory %1, cause: %2</source>
+        <translation>ล้มเหลวในการสร้างไดเรกторี %1 เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="197"/>
+        <source>Failed to delete the file %1, cause: %2</source>
+        <translation>ล้มเหลวในการลบไฟล์ %1 เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="199"/>
+        <source>Failed to move the file %1 to trash, cause: %2</source>
+        <translation>ล้มเหลวในการย้ายไฟล์ %1 ไปขยะ เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="201"/>
+        <source>Failed to move the file %1, cause: %2</source>
+        <translation>ล้มเหลวในการย้ายไฟล์ %1 เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="209"/>
+        <source>File %1 integrity was damaged, cause: %2</source>
+        <translation>ความสมบูรณ์ของไฟล์ %1 ถูกทำลาย เหตุผล: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="219"/>
+        <source>Failed to create symlink, cause: %1</source>
+        <translation>ล้มเหลวในการสร้าง symlink เหตุผล: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="221"/>
+        <source>Copy or Cut File failed, cause: %1</source>
+        <translation>ບໍ່ສາມາດເຮັດການຂ້າມຕົວຟາຍລ໌, ຄວາມເປັນເຫດ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="223"/>
+        <source>Copy or Cut File failed, cause: %1. Retry copy this file again!</source>
+        <translation>ບໍ່ສາມາດເຮັດການຂ້າມຕົວຟາຍລ໌, ຄວາມເປັນເຫດ: %1. ກະລຸນາພະຍາຍາມອີກຄັ້ງ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="225"/>
+        <source>Copy or Cut File failed, cause: %1.</source>
+        <translation>ບໍ່ສາມາດເຮັດການຂ້າມຕົວຟາຍລ໌, ຄວາມເປັນເຫດ: %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="242"/>
+        <source>%1 already exists in target folder</source>
+        <translation>%1 ໄດ້ມີຢູ່ໃນບ່ອນທີ່ຈະເກັບຂໍ້ມູນແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="246"/>
+        <source>Original path %1</source>
+        <translation>ທາງເລີ່ມຕົ້ນ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="247"/>
+        <source>Target path %1</source>
+        <translation>ທາງເປົ້າໝາຍ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp" line="262"/>
+        <source>Original path %1 Target path %2</source>
+        <translation>ທາງເລີ່ມຕົ້ນ %1 ທາງເປົ້າໝາຍ %2</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_fileoperations::FileOperationsEventReceiver</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="350"/>
+        <source>Rename file error</source>
+        <translation>ຂໍ້ຜິດພາດໃນການປ່ຽນຊື່ຟາຍລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="641"/>
+        <source>Failed to create the directory</source>
+        <translation>ບໍ່ສາມາດສ້າງເຄື່ອງມືໄດເລີ່ມຕົ້ນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="1169"/>
+        <source>Failed to create the file</source>
+        <translation>ບໍ່ສາມາດສ້າງໄຟລ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="1247"/>
+        <source>link file error</source>
+        <translation>ຂໍ້ຜິດພາດໄຟລລິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp" line="1286"/>
+        <source>Failed to modify file permissions</source>
+        <translation>ບໍ່ສາມາດແກ້ໄຂການອະນຸຍາດໄຟລ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_filepreview::PreviewDialogManager</name>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/libdfm-preview/utils/previewdialogmanager.cpp" line="92"/>
+        <source>Unable to find the original file</source>
+        <translation>ບໍ່ສາມາດຊອກຫາໄຟລຕົ້ນສະບັບເດີມ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_menu::ClipBoardMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp" line="34"/>
+        <source>&amp;Paste</source>
+        <translation>ຍ້າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp" line="35"/>
+        <source>Cu&amp;t</source>
+        <translation>ຕັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp" line="36"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;ຍ້າຍ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_menu::FileOperatorMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp" line="44"/>
+        <source>&amp;Open</source>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp" line="45"/>
+        <source>Rena&amp;me</source>
+        <translation>ປ່ຽນຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp" line="46"/>
+        <source>&amp;Delete</source>
+        <translation>ລົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp" line="47"/>
+        <source>Empty Trash</source>
+        <translation>ຄວບຄຸມຖານສັງກົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp" line="48"/>
+        <source>Set as wallpaper</source>
+        <translation>ຕິດຕັ້ງເປັນພາບພົວພົນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_menu::NewCreateMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/newcreatemenuscene.cpp" line="33"/>
+        <source>New folder</source>
+        <translation>ສ້າງເຄື່ອງມືໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/newcreatemenuscene.cpp" line="34"/>
+        <source>New document</source>
+        <translation>ເອົ້າອົງປະການໃຫ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/newcreatemenuscene.cpp" line="35"/>
+        <source>Office Text</source>
+        <translation>ສົ້ງສີ່ງສົ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/newcreatemenuscene.cpp" line="36"/>
+        <source>Spreadsheets</source>
+        <translation>ຕາຕະໂນ້ມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/newcreatemenuscene.cpp" line="37"/>
+        <source>Presentation</source>
+        <translation>ປະສັງນາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/newcreatemenuscene.cpp" line="38"/>
+        <source>Plain Text</source>
+        <translation>ເລື່ອງງົ້າ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_menu::OpenDirMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/opendirmenuscene.cpp" line="32"/>
+        <source>Open as administrator</source>
+        <translation>ເປີດໃນວົງການຂັ້ນຕອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/opendirmenuscene.cpp" line="33"/>
+        <source>Select all</source>
+        <translation>ເລືອກທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/opendirmenuscene.cpp" line="34"/>
+        <source>Open in new window</source>
+        <translation>ເປີດໃນປະຈຸມົນໃຫ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/opendirmenuscene.cpp" line="35"/>
+        <source>Open in new tab</source>
+        <translation>ເປີດໃນຕາດ່ຽວໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/opendirmenuscene.cpp" line="36"/>
+        <source>Open in terminal</source>
+        <translation>ເປີດໃນຕຳຕົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/opendirmenuscene.cpp" line="37"/>
+        <source>Reverse select</source>
+        <translation>ປະເສີມເລືອກຕົວທີ່ຖືກເລືອກຂ້າງກັບ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_menu::OpenWithMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp" line="39"/>
+        <source>Open with</source>
+        <translation>ເປີດດ້ວຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/openwithmenuscene.cpp" line="40"/>
+        <source>Select default program</source>
+        <translation>ເລືອກໂປຼແກຼມເລີ່ມຕົ້ນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_menu::SendToMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp" line="263"/>
+        <source>Send to</source>
+        <translation>ສົ່ງໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp" line="264"/>
+        <source>Bluetooth</source>
+        <translation>Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp" line="265"/>
+        <source>Create link</source>
+        <translation>ສ້າງລິ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/sendtomenuscene.cpp" line="266"/>
+        <source>Send to desktop</source>
+        <translation>ສົ່ງໄປຫາເົ້ນຫນຸ້ນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_menu::ShareMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-menu/menuscene/sharemenuscene.cpp" line="117"/>
+        <source>Share</source>
+        <translation>ແບ່ງປັນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_myshares::MyShareMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-myshares/menu/mysharemenuscene.cpp" line="122"/>
+        <source>&amp;Open</source>
+        <translation>&amp;ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-myshares/menu/mysharemenuscene.cpp" line="123"/>
+        <source>Open in new window</source>
+        <translation>ເປີດໃນຫນ້າຕ່າງໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-myshares/menu/mysharemenuscene.cpp" line="124"/>
+        <source>Open in new tab</source>
+        <translation>ເປີດໃນແຖບໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-myshares/menu/mysharemenuscene.cpp" line="125"/>
+        <source>Cancel sharing</source>
+        <translation>ຍົກເລິກການແບ່ງປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-myshares/menu/mysharemenuscene.cpp" line="126"/>
+        <source>P&amp;roperties</source>
+        <translation>ຄຸນສົມບັດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_myshares::MyShares</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-myshares/myshares.cpp" line="202"/>
+        <source>My Shares</source>
+        <translation>ການແບ່ງປັນຂອງຂ້ອຍ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_optical::OpticalMediaWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="107"/>
+        <source>It does not support burning UDF discs</source>
+        <translation>ບໍ່ຮອງຮັບການເຜົາແຜ່ນ UDF</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="113"/>
+        <source>Save as Image File</source>
+        <translation>ບັນທຶກເປັນໄຟລ໌ຮູບພາບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="114"/>
+        <source>Burn</source>
+        <translation>ເຜົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="168"/>
+        <source>%1 burning is not supported</source>
+        <translation>ບໍ່ຮອງຮັບການເຜົາ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="172"/>
+        <source>1. It is not %1 disc;
+2. The version of this file system does not support adding files yet.</source>
+        <translation>1. ມັນບໍ່ແມ່ນແຜ່ນ %1;
+2. ລຸ້ນຂອງລະບົບໄຟລ໌ນີ້ຍັງບໍ່ຮອງຮັບການເພີ່ມໄຟລ໌.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="219"/>
+        <source>Mounting failed</source>
+        <translation>ຕິດຕັ້ງບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="264"/>
+        <source>No files to burn</source>
+        <translation>ບໍ່ມີໄຟລ໌ທີ່ຈະເຜົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp" line="289"/>
+        <source>Unable to burn. Not enough free space on the target disk.</source>
+        <translation>ບໍ່ສາມາດເຜົາໄດ້. ເນື້ອທີ່ວ່າງໃນດິສກ໌ເປົ້າໝາຍບໍ່ພຽງພໍ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::BasicWidget</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="95"/>
+        <source>Basic info</source>
+        <translation>ຂໍ້ມູນພື້ນຖານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="103"/>
+        <source>Size</source>
+        <translation>ຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="104"/>
+        <source>Contains</source>
+        <translation>ມີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="105"/>
+        <source>Type</source>
+        <translation>ປະເພດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="106"/>
+        <source>Location</source>
+        <translation>ສະຖານທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="107"/>
+        <source>Created</source>
+        <translation>ສ້າງຂຶ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="108"/>
+        <source>Accessed</source>
+        <translation>ເຂົ້າເຖິງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="109"/>
+        <source>Modified</source>
+        <translation>ເຄື່ອງມືທີ່ຖືກແກນແນວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="113"/>
+        <source>Hide this file</source>
+        <translation>ກໍານືນໄດ້ນີ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="116"/>
+        <source>Resolution</source>
+        <translation>ຄວາມຊັນຕະນາຄັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="117"/>
+        <source>Duration</source>
+        <translation>ເວລາປະຕິບັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="325"/>
+        <source>%1 item</source>
+        <translation>%1 ລາຍການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp" line="421"/>
+        <source>%1 items</source>
+        <translation>%1 ລາຍການ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::CloseAllDialog</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp" line="50"/>
+        <source>Close all</source>
+        <translation>ປິດທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp" line="80"/>
+        <source>Total size: %1, %2 files</source>
+        <translation>&apos;ລວມຂະໜາດ: %1, %2 ເອົາໃຫ້&apos;</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::ComputerInfoThread</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="306"/>
+        <source>For Secrets Security</source>
+        <translation>ສໍາລັບຄວາມປອດໄພຂໍ້ມູນລັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="313"/>
+        <source>For Government</source>
+        <translation>ສໍາລັບລັດຖະບານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="315"/>
+        <source>For Enterprise</source>
+        <translation>ສໍາລັບວິສາຫະກິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="343"/>
+        <source>Bit</source>
+        <translation>ບິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="400"/>
+        <source>Available</source>
+        <translation>ມີອາດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::ComputerPropertyDialog</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="54"/>
+        <source>Computer</source>
+        <translation>ຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="69"/>
+        <source>Basic Info</source>
+        <translation>ຂໍ້ານා ལາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="75"/>
+        <source>Computer name</source>
+        <translation>ຊື່ຄອມພິວເຕີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="80"/>
+        <source>Version</source>
+        <translation>ຮຶ່ງແວersion</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="85"/>
+        <source>Edition</source>
+        <translation>ຮຶ່ງແວersion</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="90"/>
+        <source>OS build</source>
+        <translation>OS ཀ່ານວາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="95"/>
+        <source>Type</source>
+        <translation>ປະເພຼັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="100"/>
+        <source>Processor</source>
+        <translation>ປະເຊືອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp" line="105"/>
+        <source>Memory</source>
+        <translation>ຄວາມຈຳ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::MultiFilePropertyDialog</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp" line="52"/>
+        <source>Multiple Files</source>
+        <translation>ໄຟລ໌ຫຼາຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp" line="56"/>
+        <source>Basic info</source>
+        <translation>ຂໍ້ມູນພື້ນຖານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp" line="61"/>
+        <source>Total size</source>
+        <translation>ຂະໜາດລວມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp" line="68"/>
+        <source>Number of files</source>
+        <translation>ຈຳນວນໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp" line="75"/>
+        <source>Time accessed</source>
+        <translation>ເວລາເຂົ້າເຖິງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp" line="81"/>
+        <source>Time modified</source>
+        <translation>ເວລາແກ້ໄຂ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp" line="147"/>
+        <source>%1 file(s), %2 folder(s)</source>
+        <translation>%1 ໄຟລ໌, %2 ໂຟນເດີ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::NameTextEdit</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp" line="132"/>
+        <source>%1 are not allowed</source>
+        <translation>%1 ບໍ່ອະນຸຍາດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::PermissionManagerWidget</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="95"/>
+        <source>Allow to execute as program</source>
+        <translation>ອະນຸຍາດໃຫ້ເປີດເປັນໂປຣເຈັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp" line="139"/>
+        <source>Permissions</source>
+        <translation>ສິດສະອາດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_propertydialog::PropertyMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-propertydialog/menu/propertymenuscene.cpp" line="34"/>
+        <source>P&amp;roperties</source>
+        <translation>Properties</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_recent::Recent</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/recent.cpp" line="45"/>
+        <source>Recent</source>
+        <translation>ថ្មិន</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_recent::RecentEventReceiver</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/events/recenteventreceiver.cpp" line="89"/>
+        <source>Path</source>
+        <translation>ເສັ້ນທາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/events/recenteventreceiver.cpp" line="94"/>
+        <source>Last access</source>
+        <translation>ເຂົ້າເຖິງຄັ້ງຫຼ້າສຸດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/events/recenteventreceiver.cpp" line="118"/>
+        <source>Recent</source>
+        <translation>ໃໝ່ໆ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_recent::RecentMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/menus/recentmenuscene.cpp" line="180"/>
+        <source>Remove</source>
+        <translation>ລຶບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/menus/recentmenuscene.cpp" line="181"/>
+        <source>Open file location</source>
+        <translation>ເປີດຕຳແໜ່ງໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/menus/recentmenuscene.cpp" line="182"/>
+        <source>Path</source>
+        <translation>ເສັ້ນທາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-recent/menus/recentmenuscene.cpp" line="183"/>
+        <source>Last access</source>
+        <translation>ເຂົ້າເຖິງຄັ້ງຫຼ້າສຸດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_search::AdvanceSearchBarPrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="58"/>
+        <source>Search:</source>
+        <translation>ຄົ້ນຫາ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="59"/>
+        <source>File Type:</source>
+        <translation>ປະເພດໄຟລ໌:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="60"/>
+        <source>File Size:</source>
+        <translation>ຂະໜາດໄຟລ໌:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="61"/>
+        <source>Time Modified:</source>
+        <translation>ເວລາປັບປຸງ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="62"/>
+        <source>Time Accessed:</source>
+        <translation>ເວລາເຂົ້າເຖິງ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="63"/>
+        <source>Time Created:</source>
+        <translation>ເວລາបង្កើត</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="65"/>
+        <source>Reset</source>
+        <translation>ລົບຄົນຄືກັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="86"/>
+        <source>All subdirectories</source>
+        <translation>ទាំងអត្តសញ្ញាណទាំងអស់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="87"/>
+        <source>Current directory</source>
+        <translation>ទិកន័យបច្ចុប្បន្ន</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="93"/>
+        <source>Application</source>
+        <translation>កម្មវិធី</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="94"/>
+        <source>Video</source>
+        <translation>វិដែโอ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="95"/>
+        <source>Audio</source>
+        <translation>អាវូដី</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="96"/>
+        <source>Image</source>
+        <translation>រូបភាព</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="97"/>
+        <source>Archive</source>
+        <translation>ການບັນທຶກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="98"/>
+        <source>Text</source>
+        <translation>ຂໍ້ຄວາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="99"/>
+        <source>Executable</source>
+        <translation>អាចបញ្ចុចបាន</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="100"/>
+        <source>Backup file</source>
+        <translation>ឯកសារសន្ធឹកសន្ធាប់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="112"/>
+        <source>Today</source>
+        <translation>ថ្ងៃនេះ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="113"/>
+        <source>Yesterday</source>
+        <translation>ຜ້ານວັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="114"/>
+        <source>This week</source>
+        <translation>ນີ້ອັນག ൥</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="115"/>
+        <source>Last week</source>
+        <translation>ຜ້ານອັນག ൥</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="116"/>
+        <source>This month</source>
+        <translation>ນີ້ເດືອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="117"/>
+        <source>Last month</source>
+        <translation>ຜ້ານເດືອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="118"/>
+        <source>This year</source>
+        <translation>ນີ້ປີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/topwidget/advancesearchbar.cpp" line="119"/>
+        <source>Last year</source>
+        <translation>ຜ້ານປີ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_search::CheckBoxWidthTextIndex</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="296"/>
+        <source>Index update completed, last update time: %1</source>
+        <translation>ການອັບເດດດັດສະນີສຳເລັດ, ເວລາອັບເດດລ້າສຸດ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="297"/>
+        <source>Update index now</source>
+        <translation>ອັບເດດດັດສະນີຕອນນີ້</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_search::Search</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/search.cpp" line="49"/>
+        <source>Search</source>
+        <translation>ຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/search.cpp" line="152"/>
+        <source>Full-Text search</source>
+        <translation>ຄົ້ນຫາທົ່ວໄລຍະ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_search::SearchHelper</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp" line="190"/>
+        <source>Path</source>
+        <translation>ທີ່ແຈງທີ່</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_search::SearchMenuScene</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene.cpp" line="171"/>
+        <source>Open file location</source>
+        <translation>ເປີດຕຳແໜ່ງໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene.cpp" line="172"/>
+        <source>Select all</source>
+        <translation>ເລືອກທັງໝົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene.cpp" line="173"/>
+        <source>Path</source>
+        <translation>ເສັ້ນທາງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_search::TextIndexStatusBar</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="172"/>
+        <source>Index update failed, please</source>
+        <translation>ອັບເດດດັດສະນີບໍ່ສຳເລັດ, ກະລຸນາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="173"/>
+        <source>try updating again</source>
+        <translation>ລອງອັບເດດອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="184"/>
+        <source>Enable to search file contents. Indexing may take a few minutes</source>
+        <translation>ສາມາດຄົ້ນຫາເນື້ອໃນໄຟລ໌ໄດ້. ການສ້າງດັດສະນີອາດຈະໃຊ້ເວລາບາງນິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="198"/>
+        <source>Building index</source>
+        <translation>ກຳລັງສ້າງດັດສະນີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="204"/>
+        <source>Building index, %1 files indexed</source>
+        <translation>ກຳລັງສ້າງດັດສະນີ, ໄຟລ໌ %1 ຖືກສ້າງດັດສະນີແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-search/utils/checkboxwidthtextindex.cpp" line="209"/>
+        <source>Building index, %1/%2 items indexed</source>
+        <translation>ກຳລັງສ້າງດັດສະນີ, %1/%2 ລາຍການຖືກສ້າງດັດສະນີແລ້ວ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_sidebar::SideBarWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp" line="409"/>
+        <source>Quick access</source>
+        <translation>ເຂົ້າເຖິງດ່ວນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp" line="410"/>
+        <source>Partitions</source>
+        <translation>ພາທິຊັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp" line="411"/>
+        <source>Network</source>
+        <translation>ເຄືອຂ່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp" line="412"/>
+        <source>Tag</source>
+        <translation>ແທັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp" line="413"/>
+        <source>Other</source>
+        <translation>ផ្សេងៗ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp" line="414"/>
+        <source>Unknown Group</source>
+        <translation>ກຸ່ມບໍ່ຮູ້ຈັກ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_smbbrowser::SmbBrowserMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="165"/>
+        <source>&amp;Open</source>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="166"/>
+        <source>Open in new window</source>
+        <translation>បុកໃນរបាលថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="167"/>
+        <source>Open in new tab</source>
+        <translation>បុកໃນតារាក៍ថ្មី</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="168"/>
+        <source>P&amp;roperties</source>
+        <translation>លាតេង</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="169"/>
+        <source>Mount</source>
+        <translation>ភ្នំង</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="170"/>
+        <source>Unmount</source>
+        <translation>ចែកចេញ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_smbbrowser::VirtualEntryMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/menu/virtualentrymenuscene.cpp" line="191"/>
+        <source>Unmount</source>
+        <translation>ចែកចេញ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/menu/virtualentrymenuscene.cpp" line="192"/>
+        <source>Clear saved password and unmount</source>
+        <translation>លើងុយលំលំពាស់ដោយភ្លាម</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/menu/virtualentrymenuscene.cpp" line="193"/>
+        <source>Remove</source>
+        <translation>ລຶບ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_tag::Tag</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <source>Tag</source>
+        <translation>តែងតាំង</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_tag::TagDirMenuScene</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/menu/tagdirmenuscene.cpp" line="93"/>
+        <source>Open file location</source>
+        <translation>បើកទីតាំងឯកសារ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_tag::TagEditor</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp" line="97"/>
+        <source>Input tag info, such as work, family. A comma is used between two tags.</source>
+        <translation>ໃສ່ຂໍ້ມູນແທັກ, ເຊັ່ນ ວຽກ, ຄອບຄົວ. ໃຊ້ຈຸດທົດ (,) ເພື່ອແບ່ງລະຫວ່າງແທັກສອງອັນ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_tag::TagMenuScene</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp" line="61"/>
+        <source>Tag information</source>
+        <translation>ຂໍ້ມູນແທັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp" line="198"/>
+        <source>Remove tag &quot;%1&quot;</source>
+        <translation>ລຶບແທັກ &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp" line="200"/>
+        <source>Add tag &quot;%1&quot;</source>
+        <translation>ເພີ່ມແທັກ &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_tag::TagWidgetPrivate</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp" line="40"/>
+        <source>Tag</source>
+        <translation>ແທັກ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::AddressBarPrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/private/addressbar_p.h" line="46"/>
+        <source>Enter address</source>
+        <translation>បញ្ចូលទីតាំង</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::ConnectToServerDialog</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="70"/>
+        <source>Connect to Server</source>
+        <translation>ភ្នំងទៅមេសាស់</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="118"/>
+        <source>Clear History</source>
+        <translation>ລិст ളුපිරියා ൊන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="234"/>
+        <source>Unfavorite</source>
+        <translation> favorites ളුපිරියා ൊන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="309"/>
+        <source>Error</source>
+        <translation>තាម ളුපිරියා ൊන්න</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="310"/>
+        <source>Unable to favorite illegitimate url!</source>
+        <translation>ບໍ່ສາມາດທີ່ມັກລາຍການທີ່ບໍ່ຖືກຕ້ອງ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="367"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="368"/>
+        <source>Connect</source>
+        <comment>button</comment>
+        <translation>ເຊື່ອມຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="411"/>
+        <source>Charset Encoding</source>
+        <translation>ການເຂົ້າລະຫັດຊຸດຕົວອັກສອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="416"/>
+        <source>Default</source>
+        <translation>ຄ່າເລີ່ມຕົ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="475"/>
+        <source>My Favorites</source>
+        <translation>ລາຍການທີ່ມັກຂອງຂ້ອຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="462"/>
+        <source>No favorites yet</source>
+        <translation>ຍັງບໍ່ມີລາຍການທີ່ມັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp" line="234"/>
+        <source>Favorite</source>
+        <translation>ທີ່ມັກ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::DPCConfirmWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="69"/>
+        <source>Change disk password</source>
+        <translation>ປ່ຽນລະຫັດຜ່ານດິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="89"/>
+        <source>Current password:</source>
+        <translation>ລະຫັດຜ່ານປັດຈຸບັນ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="90"/>
+        <source>New password:</source>
+        <translation>ລະຫັດຜ່ານໃໝ່:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="91"/>
+        <source>Repeat password:</source>
+        <translation>ປ້ອນລະຫັດຜ່ານອີກຄັ້ງ:</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="104"/>
+        <source>Save</source>
+        <comment>button</comment>
+        <translation>ບຶອົບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="106"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="177"/>
+        <source>Passwords do not match</source>
+        <translation>ລະຫັດຜ່ອນບໍ່ຄີດກັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="194"/>
+        <source>New password should differ from the current one</source>
+        <translation>ລະຫັດຜ່ອນໃຫ້ມີການແຕ່ງແນ່ຈາກລະຫັດຜ່ອນປະຫຼົນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="249"/>
+        <source>Minimum of 8 characters. At least 3 types: 0-9, a-z, A-Z and symbols. Different from the username.</source>
+        <translation>ຢ່າງນ້ອຍ 8 ຕົວອັກສອນ. ຕ້ອງມີຢ່າງນ້ອຍ 3 ປະເພດ: 0-9, a-z, A-Z ແລະ ສັນຍາລັກ. ຕ້ອງແຕກຕ່າງຈາກຊື່ຜູ້ໃຊ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="285"/>
+        <source>Password must be no more than %1 characters</source>
+        <translation>ລະຫັດຜ່ານຕ້ອງບໍ່ເກີນ %1 ຕົວອັກສອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="294"/>
+        <source>Password cannot be empty</source>
+        <translation>ລະຫັດຜ່ານບໍ່ສາມາດປ່ອຍໃຫ້ວ່າງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp" line="340"/>
+        <source>Wrong password</source>
+        <translation>ລະຫັດຜ່ານຜິດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::DPCProgressWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcprogresswidget.cpp" line="49"/>
+        <source>Changing disk password...</source>
+        <translation>ກຳລັງປ່ຽນລະຫັດຜ່ານດິດ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcprogresswidget.cpp" line="56"/>
+        <source>The window cannot be closed during the process</source>
+        <translation>ບໍ່ສາມາດປິດວິນໂດໃນຂະນະທີ່ກຳລັງດຳເນີນການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcprogresswidget.cpp" line="116"/>
+        <source>Passwords of disks are different</source>
+        <translation>ລະຫັດຜ່ານຂອງດິດແຕກຕ່າງກັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcprogresswidget.cpp" line="119"/>
+        <source>Unable to get the encrypted disk list</source>
+        <translation>ບໍ່ສາມາດຮັບລາຍຊື່ດິດທີ່ຖືກລະຫັດໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcprogresswidget.cpp" line="123"/>
+        <source>Initialization failed</source>
+        <translation>ການເລີ່ມຕົ້ນລົ້ມເຫຼວ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::DPCResultWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcresultwidget.cpp" line="29"/>
+        <source>Disk password changed</source>
+        <translation>ປ່ຽນລະຫັດຜ່ານດິດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcresultwidget.cpp" line="32"/>
+        <source>Failed to change the disk password</source>
+        <translation>ປ່ຽນລະຫັດຜ່ານດິດບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcresultwidget.cpp" line="58"/>
+        <source>Close</source>
+        <comment>button</comment>
+        <translation>ປິດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::NavWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/navwidget.cpp" line="165"/>
+        <source>back</source>
+        <translation>ກັບຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/navwidget.cpp" line="170"/>
+        <source>forward</source>
+        <translation>ໄປຫນ້າ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::OptionButtonBox</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp" line="264"/>
+        <source>Icon view</source>
+        <translation>ເບິ່ງໄອຄອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp" line="271"/>
+        <source>List view</source>
+        <translation>ເບິ່ງແບບລາຍການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp" line="282"/>
+        <source>Tree view</source>
+        <translation>ເບິ່ງແບບຕົ້ນໄມ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp" line="304"/>
+        <source>Sort by</source>
+        <translation>ຈັດລຽງຕາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp" line="310"/>
+        <source>View options</source>
+        <translation>ຕົວເລືອກການເບິ່ງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::SortByButtonPrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp" line="98"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp" line="103"/>
+        <source>Time modified</source>
+        <translation>ເວລາທີ່ຖືກແກ້ໄຂ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp" line="108"/>
+        <source>Time created</source>
+        <translation>ເວລາທີ່ສ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp" line="113"/>
+        <source>Size</source>
+        <translation>ទំហំ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp" line="118"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_titlebar::ViewOptionsWidgetPrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp" line="56"/>
+        <source>View Options</source>
+        <translation>ຕົວເລືອກການເບິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp" line="70"/>
+        <source>Icon size</source>
+        <translation>ຂະໜາດໄອຄອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp" line="103"/>
+        <source>Grid density</source>
+        <translation>ຄວາມໜາແນ້ນຕາຕະລາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp" line="136"/>
+        <source>List height</source>
+        <translation>ຄວາມສູງລາຍການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp" line="163"/>
+        <source>Display preview</source>
+        <translation>hiển thị xem trước</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_trash::EmptyTrashWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/views/emptyTrashWidget.cpp" line="25"/>
+        <source>Trash</source>
+        <translation>Thùng rác</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/views/emptyTrashWidget.cpp" line="33"/>
+        <source>Empty</source>
+        <translation>ວ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/views/emptyTrashWidget.cpp" line="34"/>
+        <source>Empty Trash</source>
+        <translation>Rỗng Thùng rác</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_trash::TrashHelper</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp" line="274"/>
+        <source>Source Path</source>
+        <translation>Đường dẫn nguồn</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp" line="279"/>
+        <source>Time deleted</source>
+        <translation>Thời gian xóa</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_trash::TrashMenuScenePrivate</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/menus/trashmenuscene.cpp" line="204"/>
+        <source>Restore</source>
+        <translation>Khôi phục</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/menus/trashmenuscene.cpp" line="205"/>
+        <source>Restore all</source>
+        <translation>Khôi phục tất cả</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/menus/trashmenuscene.cpp" line="206"/>
+        <source>Empty trash</source>
+        <translation>Rỗng thùng rác</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/menus/trashmenuscene.cpp" line="207"/>
+        <source>Source path</source>
+        <translation>Đường dẫn nguồn</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-trash/menus/trashmenuscene.cpp" line="208"/>
+        <source>Time deleted</source>
+        <translation>Thời gian xóa</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_trashcore::TrashCore</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-trashcore/trashcore.cpp" line="22"/>
+        <source>Trash</source>
+        <translation>ຖັງຂີ້ເຫຍື້ອ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_trashcore::TrashPropertyDialog</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-trashcore/views/trashpropertydialog.cpp" line="30"/>
+        <source>Trash</source>
+        <translation>ຖັງຂີ້ເຫຍື້ອ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-trashcore/views/trashpropertydialog.cpp" line="75"/>
+        <source>item</source>
+        <translation>ລາຍການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-trashcore/views/trashpropertydialog.cpp" line="77"/>
+        <source>items</source>
+        <translation>ລາຍການ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-trashcore/views/trashpropertydialog.cpp" line="79"/>
+        <source>Contains %1 %2</source>
+        <translation>ມີ %1 %2</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_utils::BluetoothTransDialog</name>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="39"/>
+        <source>Bluetooth File Transfer</source>
+        <translation>ການສົ່ງໄຟລ໌ຜ່ານ Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="40"/>
+        <source>File Transfer Successful</source>
+        <translation>ສົ່ງໄຟລ໌ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="41"/>
+        <source>File Transfer Failed</source>
+        <translation>ສົ່ງໄຟລ໌ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="43"/>
+        <source>Sending files to &quot;&lt;b style=&quot;font-weight: 550;&quot;&gt;%1&lt;/b&gt;&quot;</source>
+        <translation>ກຳລັງສົ່ງໄຟລ໌ໄປຫາ &quot;&lt;b style=&quot;font-weight: 550;&quot;&gt;%1&lt;/b&gt;&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="44"/>
+        <source>Failed to send files to &quot;&lt;b style=&quot;font-weight: 550;&quot;&gt;%1&lt;/b&gt;&quot;</source>
+        <translation>ສົ່ງໄຟລ໌ໄປຫາ &quot;&lt;b style=&quot;font-weight: 550;&quot;&gt;%1&lt;/b&gt;&quot; ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="45"/>
+        <source>Sent to &quot;&lt;b style=&quot;font-weight: 550;&quot;&gt;%1&lt;/b&gt;&quot; successfully</source>
+        <translation>ສົ່ງໄຟລ໌ໄປຫາ &quot;&lt;b style=&quot;font-weight: 550;&quot;&gt;%1&lt;/b&gt;&quot; ສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="46"/>
+        <source>Select a Bluetooth device to receive files</source>
+        <translation>ເລືອກອຸປະກອນ Bluetooth ເພື່ອຮັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="47"/>
+        <source>Cannot find the connected Bluetooth device</source>
+        <translation>ບໍ່ສາມາດຊອກຫາອຸປະກອນ Bluetooth ທີ່ເຊື່ອມຕໍ່ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="48"/>
+        <source>Waiting to be received...</source>
+        <translation>ກຳລັງລໍຖ້າການຮັບ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="49"/>
+        <source>Go to Bluetooth Settings</source>
+        <translation>ໄປທີ່ການຕັ້ງຄ່າ Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="50"/>
+        <source>%1/%2 Sent</source>
+        <translation>ສົ່ງແລ້ວ %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="51"/>
+        <source>Error: the Bluetooth device is disconnected</source>
+        <translation>ຜິດພາດ: ອຸປະກອນ Bluetooth ຖືກຕັດການເຊື່ອມຕໍ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="52"/>
+        <source>Unable to send the file more than 2 GB</source>
+        <translation>ບໍ່ສາມາດສົ່ງໄຟລ໌ທີ່ໃຫຍ່ກວ່າ 2 GB ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="53"/>
+        <source>Unable to send 0 KB files</source>
+        <translation>ບໍ່ສາມາດສົ່ງໄຟລ໌ທີ່ມີຂະໜາດ 0 KB ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="54"/>
+        <source>File doesn&apos;t exist</source>
+        <translation>ບໍ່ພົບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="55"/>
+        <source>Transferring folders is not supported</source>
+        <translation>ບໍ່ຮອງຮັບການສົ່ງໂຟນເດີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="57"/>
+        <source>Next</source>
+        <comment>button</comment>
+        <translation>ຖັດໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="58"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="59"/>
+        <source>Done</source>
+        <comment>button</comment>
+        <translation>ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="60"/>
+        <source>Retry</source>
+        <comment>button</comment>
+        <translation>ລອງໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="61"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="160"/>
+        <source>File sending request timed out</source>
+        <translation>ຄຳຮ້ອງສົ່ງໄຟລ໌ໝົດເວລາ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="162"/>
+        <source>The service is busy and unable to process the request</source>
+        <translation>ບໍລິການກຳລັງຫວ່າງ ແລະບໍ່ສາມາດດຳເນີນການຄຳຮ້ອງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="212"/>
+        <source>Failed to save public key file: The public key is empty.</source>
+        <translation>ບໍ່ສາມາດບັນທຶກໄຟລ໌ກະແຈສາທາລະນະໄດ້: ກະແຈສາທາລະນະຫວ່າງເປົ່າ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="220"/>
+        <source>Failed to save public key file: %1</source>
+        <translation>ບໍ່ສາມາດບັນທຶກໄຟລ໌ກະແຈສາທາລະນະໄດ້: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="294"/>
+        <source>Failed to create config dir: %1</source>
+        <translation>ບໍ່ສາມາດສ້າງໄດເຣການຕັ້ງຄ່າໄດ້: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="322"/>
+        <source>Failed to create rsa private key file: %1</source>
+        <translation>ບໍ່ສາມາດສ້າງໄຟລ໌ກະແຈສ່ວນຕົວ RSA ໄດ້: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="333"/>
+        <source>Failed to create rsa ciphertext file: %1</source>
+        <translation>ບໍ່ສາມາດສ້າງໄຟລ໌ຂໍ້ມູນລັບ RSA ໄດ້: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="344"/>
+        <source>Failed to create hint file: %1</source>
+        <translation>ບໍ່ສາມາດສ້າງໄຟລ໌ຄຳແນະນຳໄດ້: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="376"/>
+        <source>Failed to save hint info: %1</source>
+        <translation>ບໍ່ສາມາດບັນທຶກຂໍ້ມູນຄຳແນະນຳໄດ້: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp" line="731"/>
+        <source>Save password failed: %1</source>
+        <translation>ບັນທຶກລະຫັດຜ່ານບໍ່ສຳເລັດ: %1</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::PasswordRecoveryView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/passwordrecoveryview.cpp" line="29"/>
+        <source>Keep it safe</source>
+        <translation>ຮັກສາໃຫ້ປອດໄພ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/passwordrecoveryview.cpp" line="43"/>
+        <source>Go to Unlock</source>
+        <comment>button</comment>
+        <translation>ໄປທີ່ການປົດລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/passwordrecoveryview.cpp" line="43"/>
+        <source>Close</source>
+        <comment>button</comment>
+        <translation>ປິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/passwordrecoveryview.cpp" line="48"/>
+        <source>Verification Successful</source>
+        <translation>ການຢືນຢັນສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/passwordrecoveryview.cpp" line="53"/>
+        <source>Vault password: %1</source>
+        <translation>ລະຫັດຜ່ານຫ້ອງເກັບໄຟລ໌: %1</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::RecoveryKeyView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="60"/>
+        <source>Unlock by Key</source>
+        <translation>ປົດລັອກໂດຍກະແຈ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="33"/>
+        <source>Input the 32-digit recovery key</source>
+        <translation>ໃສ່ກະແຈກູ້ຄືນ 32 ຕົວເລກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="55"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="55"/>
+        <source>Unlock</source>
+        <comment>button</comment>
+        <translation>ປົດລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="121"/>
+        <source>Wrong recovery key</source>
+        <translation>ກະແຈກູ້ຄືນຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="241"/>
+        <source>Failed to unlock file vault</source>
+        <translation>ບໍ່ສາມາດປົດລັອກຫ້ອງເກັບໄຟລ໌ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="245"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::RetrievePasswordView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="41"/>
+        <source>By key in the default path</source>
+        <translation>ໂດຍກະແຈໃນເສັ້ນທາງຄ່າເລີ່ມຕົ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="42"/>
+        <source>By key in the specified path</source>
+        <translation>ໂດຍກະແຈໃນເສັ້ນທາງທີ່ກຳນົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="45"/>
+        <source>Select a path</source>
+        <translation>ເລືອກເສັ້ນທາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="103"/>
+        <source>Unable to get the key file</source>
+        <translation>ບໍ່ສາມາດໄດ້ຮັບໄຟລ໌ກະແຈ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="131"/>
+        <source>Verification failed</source>
+        <translation>ການຢືນຢັນບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="144"/>
+        <source>Back</source>
+        <comment>button</comment>
+        <translation>ກັບຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="144"/>
+        <source>Verify Key</source>
+        <comment>button</comment>
+        <translation>ກວດສອບກະແຈ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp" line="149"/>
+        <source>Retrieve Password</source>
+        <translation>ກູ້ຄືນລະຫັດຜ່ານ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::ServiceManager</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/servicemanager.cpp" line="26"/>
+        <source>Location</source>
+        <translation>ສະຖານທີ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/servicemanager.cpp" line="49"/>
+        <source>Time locked</source>
+        <translation>ເວລາທີ່ຖືກລັອກ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::UnlockView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="45"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="45"/>
+        <source>Unlock</source>
+        <comment>button</comment>
+        <translation>ປົດລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="50"/>
+        <source>Unlock File Vault</source>
+        <translation>ປົດລັອກຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="56"/>
+        <source>Forgot password?</source>
+        <translation>ລືມລະຫັດຜ່ານບໍ?</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="56"/>
+        <source>Key unlock</source>
+        <translation>ປົດລັອກດ້ວຍກະແຈ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="63"/>
+        <source>Password</source>
+        <translation>ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="97"/>
+        <source>Password hint: %1</source>
+        <translation>ຄຳແນະນຳລະຫັດຜ່ານ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="120"/>
+        <source>Can&apos;t unlock the vault under the networking!</source>
+        <translation>ບໍ່ສາມາດປົດລັອກຫ້ອງເກັບໄຟລ໌ໃນຂະນະທີ່ເຊື່ອມຕໍ່ອິນເຕີເນັດ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="130"/>
+        <source>Please try again %1 minutes later</source>
+        <translation>ກະລຸນາລອງອີກຄັ້ງຫຼັງຈາກ %1 ນາທີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="163"/>
+        <source>Wrong password, please try again %1 minutes later</source>
+        <translation>ລະຫັດຜ່ານຜິດ, ກະລຸນາລອງອີກຄັ້ງຫຼັງຈາກ %1 ນາທີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="167"/>
+        <source>Wrong password, one chance left</source>
+        <translation>ລະຫັດຜ່ານຜິດ, ເຫຼືອອີກ 1 ໂອກາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="170"/>
+        <source>Wrong password, %1 chances left</source>
+        <translation>ລະຫັດຜ່ານຜິດ, ເຫຼືອອີກ %1 ໂອກາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="222"/>
+        <source>Wrong password</source>
+        <translation>ລະຫັດຜ່ານຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="231"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="236"/>
+        <source>Failed to unlock file vault, error code is %1</source>
+        <translation>ບໍ່ສາມາດປົດລັອກຫ້ອງເກັບໄຟລ໌ໄດ້, ລະຫັດຂໍ້ຜິດພາດແມ່ນ %1</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultActiveFinishedView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="52"/>
+        <source>Encrypt File Vault</source>
+        <translation>ເຂົ້າລະຫັດຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="56"/>
+        <source>Click &apos;Encrypt&apos; and input the user password.</source>
+        <translation>ກົດ &apos;ເຂົ້າລະຫັດ&apos; ແລະ ໃສ່ລະຫັດຜ່ານຂອງຜູ້ໃຊ້.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="69"/>
+        <source>Encrypting...</source>
+        <translation>ກຳລັງເຂົ້າລະຫັດ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="183"/>
+        <source>The setup is complete</source>
+        <translation>ການຕັ້ງຄ່າສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="196"/>
+        <source>Close</source>
+        <translation>ປິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="81"/>
+        <source>Encrypt</source>
+        <translation>ເຂົ້າລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="184"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultActiveSaveKeyFileView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="51"/>
+        <source>Save Recovery Key</source>
+        <translation>ບັນທຶກກະແຈກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="58"/>
+        <source>Keep the key safe to retrieve the vault password later</source>
+        <translation>ຮັກສາກະແຈໃຫ້ປອດໄພເພື່ອກູ້ລະຫັດຫ້ອງເກັບໄຟລ໌ໃນພາຍຫຼັງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="64"/>
+        <source>Save to default path</source>
+        <translation>ບັນທຶກໄປທີ່ເສັ້ນທາງຄ່າເລີ່ມຕົ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="69"/>
+        <source>Save to other locations</source>
+        <translation>ບັນທຶກໄປທີ່ສະຖານທີ່ອື່ນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="71"/>
+        <source>No permission, please reselect</source>
+        <translation>ບໍ່ມີສິດ, ກະລຸນາເລືອກໃໝ່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="78"/>
+        <source>Select a path</source>
+        <translation>ເລືອກເສັ້ນທາງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="95"/>
+        <source>Next</source>
+        <translation>ຖັດໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp" line="105"/>
+        <source>The default path is invisible to other users, and the path information will not be shown.</source>
+        <translation>ເສັ້ນທາງຄ່າເລີ່ມຕົ້ນຈະບໍ່ມີໃຫ້ຜູ້ໃຊ້ອື່ນເຫັນ ແລະ ຂໍ້ມູນເສັ້ນທາງຈະບໍ່ຖືກສະແດງ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultActiveSetUnlockMethodView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="46"/>
+        <source>Set Vault Password</source>
+        <translation>ຕັ້ງລະຫັດຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="49"/>
+        <source>Encryption method</source>
+        <translation>ວິທີການເຂົ້າລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="51"/>
+        <source>Key encryption</source>
+        <translation>ການເຂົ້າລະຫັດດ້ວຍກະແຈ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="52"/>
+        <source>Transparent encryption</source>
+        <translation>ການເຂົ້າລະຫັດແບບໂປ່ງໃສ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="57"/>
+        <source>Password</source>
+        <translation>ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="60"/>
+        <source>≥ 8 chars, contains A-Z, a-z, 0-9, and symbols</source>
+        <translation>ຢ່າງນ້ອຍ 8 ຕົວອັກສອນ, ປະກອບມີ A-Z, a-z, 0-9 ແລະ ສັນຍາລັກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="63"/>
+        <source>Repeat password</source>
+        <translation>ປ້ອນລະຫັດຜ່ານອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="66"/>
+        <source>Input the password again</source>
+        <translation>ປ້ອນລະຫັດຜ່ານອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="69"/>
+        <source>Password hint</source>
+        <translation>ຄຳແນະນຳລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="72"/>
+        <source>Optional</source>
+        <translation>ທາງເລືອກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="76"/>
+        <source>The file vault will be automatically unlocked when accessed, without verifying the password. Files in it will be inaccessible under other user accounts. </source>
+        <translation>ຫ້ອງເກັບໄຟລ໌ຈະຖືກເປີດອັດຕະໂນມັດເມື່ອເຂົ້າເຖິງ, ໂດຍບໍ່ຕ້ອງກວດສອບລະຫັດຜ່ານ. ໄຟລ໌ທີ່ຢູ່ໃນນັ້ນຈະບໍ່ສາມາດເຂົ້າເຖິງໄດ້ຈາກບັນຊີຜູ້ໃຊ້ອື່ນ.</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="85"/>
+        <source>Next</source>
+        <translation>ຖັດໄປ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="246"/>
+        <source>Passwords do not match</source>
+        <translation>ລະຫັດຜ່ານບໍ່ກົງກັນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultActiveStartView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp" line="31"/>
+        <source>File Vault</source>
+        <translation>ຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp" line="34"/>
+        <source>Create your secure private space</source>
+        <translation>ສ້າງພື້ນທີ່ສ່ວນຕົວທີ່ປອດໄພຂອງທ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp" line="34"/>
+        <source>Advanced encryption technology</source>
+        <translation>ເທັກໂນໂລຊີການເຂົ້າລະຫັດທີ່ທັນສະໄໝ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp" line="34"/>
+        <source>Convenient and easy to use</source>
+        <translation>ສະດວກ ແລະ ໃຊ້ງານງ່າຍ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp" line="41"/>
+        <source>Create</source>
+        <translation>ສ້າງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultActiveView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/vaultcreatepage.cpp" line="64"/>
+        <source>Failed to create vault: %1</source>
+        <translation>ສ້າງຫ້ອງເກັບໄຟລ໌ບໍ່ສຳເລັດ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/vaultcreatepage.cpp" line="170"/>
+        <source>Failed to create vault: Get encryption method failed!</source>
+        <translation>ສ້າງຫ້ອງເກັບໄຟລ໌ບໍ່ສຳເລັດ: ດຶງວິທີການເຂົ້າລະຫັດບໍ່ສຳເລັດ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/vaultcreatepage.cpp" line="186"/>
+        <source>Failed to create vault: Unknown encryption method!</source>
+        <translation>ສ້າງຫ້ອງເກັບໄຟລ໌ບໍ່ສຳເລັດ: ວິທີການເຂົ້າລະຫັດບໍ່ຮູ້ຈັກ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/vaultcreatepage.cpp" line="199"/>
+        <source>Failed to create vault: Retrieved password is empty!</source>
+        <translation>ສ້າງຫ້ອງເກັບໄຟລ໌ບໍ່ສຳເລັດ: ລະຫັດຜ່ານທີ່ດຶງມາວ່າງເປົ່າ!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/vaultcreatepage.cpp" line="247"/>
+        <source>Auto generate password failed!</source>
+        <translation>ສ້າງລະຫັດຜ່ານອັດຕະໂນມັດບໍ່ສຳເລັດ!</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultEntryFileEntity</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaultentryfileentity.cpp" line="31"/>
+        <source>File Vault</source>
+        <translation>ຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultEventReceiver</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp" line="216"/>
+        <source>Vault</source>
+        <translation>ຫ້ອງເກັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp" line="216"/>
+        <source>Vault not available because cryfs not installed!</source>
+        <translation>ບໍ່ສາມາດໃຊ້ງານຫ້ອງເກັບໄດ້ ເນື່ອງຈາກບໍ່ໄດ້ຕິດຕັ້ງ cryfs!</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultHelper</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="152"/>
+        <source>Vault</source>
+        <translation>ຫ້ອງເກັບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="152"/>
+        <source>Vault not available because cryfs not installed!</source>
+        <translation>ບໍ່ສາມາດໃຊ້ງານຫ້ອງເກັບໄດ້ ເນື່ອງຈາກບໍ່ໄດ້ຕິດຕັ້ງ cryfs!</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="565"/>
+        <source>A task is in progress, so it cannot perform your operation</source>
+        <translation>ມີວຽກງານກຳລັງດຳເນີນຢູ່ ດັ່ງນັ້ນບໍ່ສາມາດດຳເນີນການຂອງທ່ານໄດ້</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultPropertyDialog</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/vaultpropertyview/vaultpropertydialog.cpp" line="73"/>
+        <source>File Vault</source>
+        <translation>ຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultRemoveByNoneWidget</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="24"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="24"/>
+        <source>Delete</source>
+        <translation>ລຶບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="29"/>
+        <source>Delete File Vault</source>
+        <translation>ລຶບຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="67"/>
+        <source>Failed to delete file vault</source>
+        <translation>ລຶບຫ້ອງເກັບໄຟລ໌ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="71"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="84"/>
+        <source>Once deleted, the files in it will be permanently deleted</source>
+        <translation>ເມື່ອລຶບແລ້ວ ໄຟລ໌ທັງໝົດຂ້າງໃນຈະຖືກລຶບຖາວອນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultRemoveByPasswordView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="31"/>
+        <source>Once deleted, the files in it will be permanently deleted</source>
+        <translation>ເມື່ອລຶບແລ້ວ ໄຟລ໌ທັງໝົດຂ້າງໃນຈະຖືກລຶບຖາວອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="36"/>
+        <source>Password</source>
+        <translation>ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="48"/>
+        <source>Key delete</source>
+        <translation>ລຶບດ້ວຍຄີ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="67"/>
+        <source>Password hint: %1</source>
+        <translation>ຄຳແນະນຳລະຫັດຜ່ານ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="84"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="84"/>
+        <source>Delete</source>
+        <translation>ລຶບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="89"/>
+        <source>Delete File Vault</source>
+        <translation>ລຶບຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="108"/>
+        <source>Wrong password</source>
+        <translation>ລະຫັດຜ່ານຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="206"/>
+        <source>Failed to delete file vault</source>
+        <translation>ລຶບຫ້ອງເກັບໄຟລ໌ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="210"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultRemoveByRecoverykeyView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="27"/>
+        <source>Input the 32-digit recovery key</source>
+        <translation>ໃສ່ຄີກູ້ຄືນ 32 ຕົວເລກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="95"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="95"/>
+        <source>Delete</source>
+        <translation>ລຶບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="100"/>
+        <source>Delete File Vault</source>
+        <translation>ລຶບຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="118"/>
+        <source>Wrong recovery key</source>
+        <translation>ຄີກູ້ຄືນຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="191"/>
+        <source>Failed to delete file vault</source>
+        <translation>ລຶບຫ້ອງເກັບໄຟລ໌ບໍ່ສຳເລັດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="195"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultRemoveProgressView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp" line="39"/>
+        <source>Removing...</source>
+        <translation>ກຳລັງລຶບ...</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp" line="71"/>
+        <source>OK</source>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp" line="76"/>
+        <source>Delete File Vault</source>
+        <translation>ລຶບຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp" line="49"/>
+        <source>Deleted successfully</source>
+        <translation>ລຶບສຳເລັດແລ້ວ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_vault::VaultVisibleManager</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaultvisiblemanager.cpp" line="52"/>
+        <source>File Vault</source>
+        <translation>ຫ້ອງເກັບໄຟລ໌</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::FileOperatorHelper</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp" line="118"/>
+        <source>Failed to open %1, which may be moved or renamed</source>
+        <translation>ບໍ່ສາມາດເປີດ %1, ທີ່ອາດຈະຖືກຢືດຫຼັງຫຼາຍຫຼືຊື່ຖືກປ່ຽນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::FileView</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp" line="2219"/>
+        <source>Mount error</source>
+        <translation>ຜິດພາດໃນການເມາທ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp" line="2220"/>
+        <source>Server login credentials are invalid. Please uninstall and remount</source>
+        <translation>ຂໍ້ມູນການເຂົ້າລະບົບເຊີບເວີບໍ່ຖືກຕ້ອງ. ກະລຸນາຖອນການຕິດຕັ້ງແລະເມາທ໌ໃໝ່</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::FileViewModel</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp" line="734"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp" line="736"/>
+        <source>Time modified</source>
+        <translation>ເວລາປັບປຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp" line="738"/>
+        <source>Time created</source>
+        <translation>ເວລາສ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp" line="740"/>
+        <source>Size</source>
+        <translation>ຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp" line="742"/>
+        <source>Type</source>
+        <translation>ປະເພດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::FileViewStatusBar</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp" line="93"/>
+        <source>Loading...</source>
+        <translation>ກຳລັງໂຫຼດ...</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::IconItemEditor</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/iconitemeditor.cpp" line="262"/>
+        <source>%1 are not allowed</source>
+        <translation>%1 ບໍ່ອະນຸຍາດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::ListItemEditor</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/views/listitemeditor.cpp" line="109"/>
+        <source>%1 are not allowed</source>
+        <translation>%1 ບໍ່ອະນຸຍາດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::SortAndDisplayMenuScene</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="39"/>
+        <source>Sort by</source>
+        <translation>ຈັດລຽງຕາມ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="40"/>
+        <source>Display as</source>
+        <translation>ສະແດງເປັນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="43"/>
+        <source>Name</source>
+        <translation>ຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="44"/>
+        <source>Time modified</source>
+        <translation>ເວລາປັບປຸງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="45"/>
+        <source>Time created</source>
+        <translation>ເວລາສ້າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="46"/>
+        <source>Size</source>
+        <translation>ຂະໜາດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="47"/>
+        <source>Type</source>
+        <translation>ປະເພດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="50"/>
+        <source>Icon</source>
+        <translation>ໄອຄອນ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="51"/>
+        <source>List</source>
+        <translation>ລາຍຊື່</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp" line="52"/>
+        <source>Tree</source>
+        <translation>ຕົ້ນໄມ້</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_workspace::WorkspaceMenuScene</name>
+    <message>
+        <location filename="../src/plugins/filemanager/dfmplugin-workspace/menus/workspacemenuscene.cpp" line="59"/>
+        <source>Refresh</source>
+        <translation>ຣີເຟຣຊ໌</translation>
+    </message>
+</context>
+<context>
+    <name>filedialog_core::FileDialog</name>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialog.cpp" line="1025"/>
+        <source>Save</source>
+        <comment>button</comment>
+        <translation>ບັນທຶກ</translation>
+    </message>
+</context>
+<context>
+    <name>filedialog_core::FileDialogStatusBar</name>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialogstatusbar.cpp" line="51"/>
+        <source>Save</source>
+        <comment>button</comment>
+        <translation>ບັນທຶກ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialogstatusbar.cpp" line="51"/>
+        <source>Open</source>
+        <comment>button</comment>
+        <translation>ເປີດ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialogstatusbar.cpp" line="59"/>
+        <source>Save File</source>
+        <comment>button</comment>
+        <translation>ບັນທຶກໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialogstatusbar.cpp" line="59"/>
+        <source>Open File</source>
+        <comment>button</comment>
+        <translation>ເປີດໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialogstatusbar.cpp" line="241"/>
+        <source>File Name</source>
+        <translation>ຊື່ໄຟລ໌</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialogstatusbar.cpp" line="242"/>
+        <source>Format</source>
+        <translation>ຮູບແບບ</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/filedialog/core/views/filedialogstatusbar.cpp" line="272"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+</context>
+<context>
+    <name>plugin_filepreview::DDciIconPreview</name>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="279"/>
+        <source>Available sizes: </source>
+        <translation>ຂະໜາດທີ່ມີ: </translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="281"/>
+        <source>Custom Size</source>
+        <translation>ຂະໜາດກຳນົດເອງ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="308"/>
+        <source>Device Pixel Ratio: </source>
+        <translation>ອັດຕາສ່ວນພິກເຊວອຸປະກອນ: </translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="330"/>
+        <source>Theme: </source>
+        <translation>ຮູບແບບ: </translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="332"/>
+        <source>Light</source>
+        <translation>ແສງສວ່າງ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="332"/>
+        <source>Dark</source>
+        <translation>ມືດ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="336"/>
+        <source>Mode: </source>
+        <translation>ໂໝດ: </translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="338"/>
+        <source>Normal</source>
+        <translation>ປົກກະຕິ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="338"/>
+        <source>Disabled</source>
+        <translation>ປິດໃຊ້ງານ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="338"/>
+        <source>Hovered</source>
+        <translation>ຊີ້ເມົາ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="338"/>
+        <source>Pressed</source>
+        <translation>ກົດ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="342"/>
+        <source>Palette</source>
+        <translation>ຈານສີ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="344"/>
+        <source>Current mode icon does not support the palette</source>
+        <translation>ໄອຄອນໂໝດປັດຈຸບັນບໍ່ຮອງຮັບຈານສີ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="363"/>
+        <source>Foreground:</source>
+        <translation>ພື້ນຫນ້າ:</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="378"/>
+        <source>Background:</source>
+        <translation>ພື້ນຫຼັງ:</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="391"/>
+        <source>Highlight:</source>
+        <translation>ເນັ້ນສີ:</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="403"/>
+        <source>HighlightForeground:</source>
+        <translation>ເນັ້ນສີພື້ນຫນ້າ:</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="419"/>
+        <source>Background Color: </source>
+        <translation>ສີພື້ນຫຼັງ: </translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="421"/>
+        <source>White</source>
+        <translation>ຂາວ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="421"/>
+        <source>Black</source>
+        <translation>ດຳ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="421"/>
+        <source>Transparent</source>
+        <translation>ໂປ່ງໃສ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp" line="421"/>
+        <source>Custom</source>
+        <translation>ກຳນົດເອງ</translation>
+    </message>
+</context>
+<context>
+    <name>plugin_filepreview::EncryptionPage</name>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp" line="36"/>
+        <source>Encrypted file, please enter the password</source>
+        <translation>ໄຟລ໌ຖືກລະຫັດ, ກະລຸນາໃສ່ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp" line="42"/>
+        <source>Password</source>
+        <translation>ລະຫັດຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp" line="47"/>
+        <source>OK</source>
+        <comment>button</comment>
+        <translation>ຕົກລົງ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp" line="90"/>
+        <source>Wrong password</source>
+        <translation>ລະຫັດຜ່ານຜິດ</translation>
+    </message>
+</context>
+<context>
+    <name>plugin_filepreview::MusicMessageView</name>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp" line="61"/>
+        <source>Artist:</source>
+        <translation>ສິລິປິນ:</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp" line="73"/>
+        <source>Album:</source>
+        <translation>ອະລະບັ້ມ:</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp" line="138"/>
+        <source>unknown artist</source>
+        <translation>ບໍ່ຮູ້ສິລິປິນ</translation>
+    </message>
+    <message>
+        <location filename="../src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp" line="142"/>
+        <source>unknown album</source>
+        <translation>ບໍ່ຮູ້ອະລະບັ້ມ</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-home-desktop/desktop_lo.ts
+++ b/translations/dde-home-desktop/desktop_lo.ts
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Home</source>
+        <translation>ໜ້າຫຼັກ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Comment" line="0"/>
+        <source>Open home directory</source>
+        <translation>ເປີດໄຟລ໌ໜ້າຫຼັກ</translation>
+    </message>
+</context>
+</TS>

--- a/translations/dde-trash-desktop/desktop_lo.ts
+++ b/translations/dde-trash-desktop/desktop_lo.ts
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>Open Trash.</source>
+        <translation>ເປີດຖັງຂີ້ເຫຍື້ອ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Comment" line="0"/>
+        <source>Open trash.</source>
+        <translation>ເປີດຖັງຂີ້ເຫຍື້ອ</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Trash</source>
+        <translation>ຖັງຂີ້ເຫຍື້ອ</translation>
+    </message>
+</context>
+</TS>

--- a/translations/disk-encrypt-plugin/disk-encrypt_lo.ts
+++ b/translations/disk-encrypt-plugin/disk-encrypt_lo.ts
@@ -1,0 +1,789 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="374"/>
+        <source>Cannot generate random number by TPM</source>
+        <translation>ບໍ່ສາມາດສ້າງຕົວເລກສຸ່ມດ້ວຍ TPM ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="377"/>
+        <source>No available encrypt algorithm.</source>
+        <translation>ບໍ່ມີຂັ້ນຕອນການເຂົ້າລະຫັດທີ່ມີຢູ່.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="380"/>
+        <source>TPM encrypt failed.</source>
+        <translation>ການເຂົ້າລະຫັດ TPM ລົ້ມເຫລວ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="383"/>
+        <source>TPM is locked.</source>
+        <translation>TPM ຖືກລັອກ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="411"/>
+        <source>Confirm encrypt %1?</source>
+        <translation>ຢືນຢັນການເຂົ້າລະຫັດ %1?</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="414"/>
+        <source>The current partition is about to be encrypted and cannot be canceled during the encryption process, please confirm the encryption.</source>
+        <translation>ພາກສ່ວນປັດຈຸບັນຈະຖືກເຂົ້າລະຫັດ ແລະ ບໍ່ສາມາດຍົກເລີກໄດ້ໃນລະຫວ່າງຂະບວນການເຂົ້າລະຫັດ, ກະລຸນາຢືນຢັນການເຂົ້າລະຫັດ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="421"/>
+        <source>* After encrypting the partition, the system cannot be rolled back to a lower version, please confirm the encryption</source>
+        <translation>* ຫຼັງຈາກເຂົ້າລະຫັດພາກສ່ວນແລ້ວ, ລະບົບບໍ່ສາມາດກັບຄືນໄປສູ່ເວີຊັນຕ່ຳກວ່າໄດ້, ກະລຸນາຢືນຢັນການເຂົ້າລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="432"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="447"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="433"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="448"/>
+        <source>Confirm and Reboot</source>
+        <translation>ຢືນຢັນ ແລະ ຣີບູດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="434"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="448"/>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="444"/>
+        <source>Decrypt %1?</source>
+        <translation>ຖອດລະຫັດ %1?</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="445"/>
+        <source>Decryption can take a long time, so make sure power is connected until the decryption is complete.</source>
+        <translation>ການຖອດລະຫັດອາດໃຊ້ເວລາດົນ, ຈຶ່ງກະລຸນາໃຫ້ແນ່ໃຈວ່າມີກະແສໄຟຟ້າຈົນກວ່າການຖອດລະຫັດຈະສຳເລັດ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::ChgPassphraseDialog</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="18"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="52"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="93"/>
+        <source>passphrase</source>
+        <translation>ຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="20"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="54"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="95"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="109"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="168"/>
+        <source>Recovery key</source>
+        <translation>ກະແຈກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="171"/>
+        <source>Validate with %1</source>
+        <translation>ກວດສອບດ້ວຍ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="172"/>
+        <source>Please input recovery key</source>
+        <translation>ກະລຸນາປ້ອນກະແຈກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="174"/>
+        <source>Old %1</source>
+        <translation>ເກົ່າ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="70"/>
+        <source>New %1</source>
+        <translation>ໃໝ່ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="56"/>
+        <source>Modify %1</source>
+        <translation>ແກ້ໄຂ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="67"/>
+        <source>Please enter %1 again</source>
+        <translation>ກະລຸນາປ້ອນ %1 ອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="71"/>
+        <source>Repeat %1</source>
+        <translation>ຊ້ຳ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="77"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="78"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp" line="311"/>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="101"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="107"/>
+        <source>%1 cannot be empty</source>
+        <translation>%1 ບໍ່ສາມາດເປັນຄ່າວ່າງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="115"/>
+        <source>Recovery key is not valid!</source>
+        <translation>ກະແຈກູ້ຄືນບໍ່ຖືກຕ້ອງ!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="140"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="178"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="180"/>
+        <source>At least 8 bits, contains 3 types of A-Z, a-z, 0-9 and symbols</source>
+        <translation>ຢ່າງໜ້ອຍ 8 ຕົວອັກສອນ, ມີ 3 ປະເພດຂອງ A-Z, a-z, 0-9 ແລະ ສັນຍາລັກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="145"/>
+        <source>%1 inconsistency</source>
+        <translation>%1 ບໍ່ກົມກືນກັນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp" line="177"/>
+        <source>Validate with recovery key</source>
+        <translation>ກວດສອບດ້ວຍກະແຈກູ້ຄືນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::DecryptParamsInputDialog</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="52"/>
+        <source>Validate with %1</source>
+        <translation>ກວດສອບດ້ວຍ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="52"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="56"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="79"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="52"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="56"/>
+        <source>passphrase</source>
+        <translation>ຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="56"/>
+        <source>Please input %1 to decrypt device</source>
+        <translation>ກະລຸນາປ້ອນ %1 ເພື່ອຖອດລະຫັດອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="103"/>
+        <source>Decrypt device</source>
+        <translation>ຖອດລະຫັດອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="51"/>
+        <source>Please input recovery key to decrypt device</source>
+        <translation>ກະລຸນາປ້ອນກະແຈກູ້ຄືນເພື່ອຖອດລະຫັດອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="57"/>
+        <source>Validate with recovery key</source>
+        <translation>ກວດສອບດ້ວຍກະແຈກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="79"/>
+        <source>Passphrase</source>
+        <translation>ຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="81"/>
+        <source>Recovery key</source>
+        <translation>ກະແຈກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="82"/>
+        <source>%1 cannot be empty!</source>
+        <translation>%1 ບໍ່ສາມາດເປັນຄ່າວ່າງໄດ້!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="87"/>
+        <source>Recovery key is not valid!</source>
+        <translation>ກະແຈກູ້ຄືນບໍ່ຖືກຕ້ອງ!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="111"/>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::DiskEncryptMenuScene</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="148"/>
+        <source>Unlock encrypted partition</source>
+        <translation>ປົດລັອກພາກສ່ວນທີ່ເຂົ້າລະຫັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="152"/>
+        <source>Cancel partition encryption</source>
+        <translation>ຍົກເລີກການເຂົ້າລະຫັດພາກສ່ວນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="156"/>
+        <source>passphrase</source>
+        <translation>ຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="157"/>
+        <source>Changing the encryption %1</source>
+        <translation>ການປ່ຽນແປງການເຂົ້າລະຫັດ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="161"/>
+        <source>Continue partition encryption</source>
+        <translation>ສືບຕໍ່ການເຂົ້າລະຫັດພາກສ່ວນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="165"/>
+        <source>Continue partition decryption</source>
+        <translation>ສືບຕໍ່ການຖອດລະຫັດພາກສ່ວນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="169"/>
+        <source>Enable partition encryption</source>
+        <translation>ເປີດໃຊ້ການເຂົ້າລະຫັດພາກສ່ວນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="225"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="248"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="269"/>
+        <source>Error</source>
+        <translation>ຂໍ້ຜິດພາດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="226"/>
+        <source>Cannot resolve passphrase from TPM</source>
+        <translation>ບໍ່ສາມາດແກ້ໄຂຄຳຜ່ານຈາກ TPM ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="248"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="269"/>
+        <source>PIN error</source>
+        <translation>ຂໍ້ຜິດພາດ PIN</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="276"/>
+        <source>Change passphrase failed</source>
+        <translation>ການປ່ຽນຄຳຜ່ານລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="525"/>
+        <source>Unlock device failed</source>
+        <translation>ການປົດລັອກອຸປະກອນລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="526"/>
+        <source>Wrong passphrase</source>
+        <translation>ຄຳຜ່ານຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="544"/>
+        <source>Mount device failed</source>
+        <translation>ການຕິດຕັ້ງອຸປະກອນລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="587"/>
+        <source>unmount</source>
+        <translation>ຖອດຕິດຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="587"/>
+        <source>lock</source>
+        <translation>ລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="588"/>
+        <source>Encrypt failed</source>
+        <translation>ການເຂົ້າລະຫັດລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="589"/>
+        <source>Cannot %1 device %2</source>
+        <translation>ບໍ່ສາມາດ %1 ອຸປະກອນ %2 ໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="673"/>
+        <source>Reboot to continue encrypt</source>
+        <translation>ຣີບູດເພື່ອສືບຕໍ່ການເຂົ້າລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="674"/>
+        <source>Reboot to finish decrypt</source>
+        <translation>ຣີບູດເພື່ອສຳເລັດການຖອດລະຫັດ</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::EncryptParamsInputDialog</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="130"/>
+        <source>Unlocked by passphrase</source>
+        <translation>ປົດລັອກດ້ວຍຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="157"/>
+        <source>In special cases such as forgetting the password or the encryption hardware is damaged, you can decrypt the encrypted partition with the recovery key, please export it to a non-encrypted partition and keep it in a safe place!</source>
+        <translation>ໃນກໍລະນີພິເສດເຊັ່ນລືມລະຫັດຜ່ານ ຫຼື ຮາດແວເຂົ້າລະຫັດເສຍຫາຍ, ທ່ານສາມາດຖອດລະຫັດພາກສ່ວນທີ່ເຂົ້າລະຫັດແລ້ວດ້ວຍກະແຈກູ້ຄືນ, ກະລຸນາສົ່ງອອກໄປຍັງພາກສ່ວນທີ່ບໍ່ເຂົ້າລະຫັດ ແລະ ເກັບໄວ້ໃນບ່ອນທີ່ປອດໄພ!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="172"/>
+        <source>Please select a non-encrypted partition as the key file export path.</source>
+        <translation>ກະລຸນາເລືອກພາກສ່ວນທີ່ບໍ່ເຂົ້າລະຫັດເປັນເສັ້ນທາງສົ່ງອອກໄຟລ໌ກະແຈ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="192"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="339"/>
+        <source>Passphrase</source>
+        <translation>ຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="194"/>
+        <source>%1 cannot be empty</source>
+        <translation>%1 ບໍ່ສາມາດເປັນຄ່າວ່າງໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="225"/>
+        <source>%1 inconsistency</source>
+        <translation>%1 ບໍ່ກົມກືນກັນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="236"/>
+        <source>Recovery key export path cannot be empty!</source>
+        <translation>ເສັ້ນທາງສົ່ງອອກກະແຈກູ້ຄືນບໍ່ສາມາດເປັນຄ່າວ່າງໄດ້!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="241"/>
+        <source>Recovery key export path is not exists!</source>
+        <translation>ເສັ້ນທາງສົ່ງອອກກະແຈກູ້ຄືນບໍ່ມີຢູ່!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="248"/>
+        <source>Please export to an external device such as a non-encrypted partition or USB flash drive.</source>
+        <translation>ກະລຸນາສົ່ງອອກໄປຍັງອຸປະກອນພາຍນອກເຊັ່ນພາກສ່ວນທີ່ບໍ່ເຂົ້າລະຫັດ ຫຼື ຍູສບີແຟລຊ໌ດຣາຍ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="253"/>
+        <source>This partition is read-only, please export to a writable partition</source>
+        <translation>ພາກສ່ວນນີ້ເປັນອ່ານຢ່າງດຽວ, ກະລຸນາສົ່ງອອກໄປຍັງພາກສ່ວນທີ່ຂຽນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="265"/>
+        <source>The partition is encrypted, please export to a non-encrypted partition or external device such as a USB flash drive.</source>
+        <translation>ພາກສ່ວນນີ້ເຂົ້າລະຫັດແລ້ວ, ກະລຸນາສົ່ງອອກໄປຍັງພາກສ່ວນທີ່ບໍ່ເຂົ້າລະຫັດ ຫຼື ອຸປະກອນພາຍນອກເຊັ່ນຍູສບີແຟລຊ໌ດຣາຍ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="421"/>
+        <source>TPM is locked and cannot be used for partition encryption. Please cancel the TPM password or choose another unlocking method.</source>
+        <translation>TPM ຖືກລັອກ ແລະ ບໍ່ສາມາດໃຊ້ໄດ້ສຳລັບການເຂົ້າລະຫັດພາກສ່ວນ. ກະລຸນາຍົກເລີກລະຫັດຜ່ານ TPM ຫຼື ເລືອກວິທີການປົດລັອກອື່ນ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="423"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="426"/>
+        <source>TPM error</source>
+        <translation>ຂໍ້ຜິດພາດ TPM</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="426"/>
+        <source>TPM status error!</source>
+        <translation>ຂໍ້ຜິດພາດສະຖານະ TPM!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="317"/>
+        <source>Next</source>
+        <translation>ຕໍ່ໄປ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="316"/>
+        <source>Please continue to encrypt partition %1</source>
+        <translation>ກະລຸນາສືບຕໍ່ເຂົ້າລະຫັດພາກສ່ວນ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="321"/>
+        <source>Previous</source>
+        <translation>ກ່ອນໜ້າ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="320"/>
+        <source>Export Recovery Key</source>
+        <translation>ສົ່ງອອກກະແຈກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="329"/>
+        <source>Set %1</source>
+        <translation>ຕັ້ງຄ່າ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="330"/>
+        <source>Repeat %1</source>
+        <translation>ຊ້ຳ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="336"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="337"/>
+        <source>passphrase</source>
+        <translation>ຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="340"/>
+        <source>Access to the partition will be unlocked using a passphrase.</source>
+        <translation>ການເຂົ້າເຖິງພາກສ່ວນຈະຖືກປົດລັອກດ້ວຍຄຳຜ່ານ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="347"/>
+        <source>Access to the partition will be unlocked using the TPM security chip and PIN.</source>
+        <translation>ການເຂົ້າເຖິງພາກສ່ວນຈະຖືກປົດລັອກດ້ວຍຊິບຄວາມປອດໄພ TPM ແລະ PIN.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="350"/>
+        <source>Access to the partition will be automatically unlocked using the TPM security chip, no passphrase checking is required.</source>
+        <translation>ການເຂົ້າເຖິງພາກສ່ວນຈະຖືກປົດລັອກອັດຕະໂນມັດດ້ວຍຊິບຄວາມປອດໄພ TPM, ບໍ່ຈຳເປັນຕ້ອງກວດສອບຄຳຜ່ານ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="332"/>
+        <source>Please enter the %1 again</source>
+        <translation>ກະລຸນາປ້ອນ %1 ອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="110"/>
+        <source>Unlock type</source>
+        <translation>ປະເພດການປົດລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="131"/>
+        <source>Use TPM+PIN to unlock on this computer (recommended)</source>
+        <translation>ໃຊ້ TPM+PIN ເພື່ອປົດລັອກໃນຄອມພິວເຕີນີ້ (ແນະນຳ)</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="132"/>
+        <source>Automatic unlocking on this computer by TPM</source>
+        <translation>ການປົດລັອກອັດຕະໂນມັດໃນຄອມພິວເຕີນີ້ດ້ວຍ TPM</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="220"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="331"/>
+        <source>At least 8 bits, contains 3 types of A-Z, a-z, 0-9 and symbols</source>
+        <translation>ຢ່າງໜ້ອຍ 8 ຕົວອັກສອນ, ມີ 3 ປະເພດຂອງ A-Z, a-z, 0-9 ແລະ ສັນຍາລັກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="317"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="322"/>
+        <source>Confirm encrypt</source>
+        <translation>ຢືນຢັນການເຂົ້າລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="343"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="344"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="346"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::EncryptProgressDialog</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="54"/>
+        <source>Confirm</source>
+        <translation>ຢືນຢັນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="63"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="77"/>
+        <source>Re-export the recovery key</source>
+        <translation>ສົ່ງອອກກະແຈກູ້ຄືນອີກຄັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="67"/>
+        <source>*Recovery key saving failed, please re-save the recovery key to a non-encrypted partition and keep it in a safe place!</source>
+        <translation>*ການບັນທຶກກະແຈກູ້ຄືນລົ້ມເຫລວ, ກະລຸນາບັນທຶກກະແຈກູ້ຄືນອີກຄັ້ງໄປຍັງພາກສ່ວນທີ່ບໍ່ເຂົ້າລະຫັດ ແລະ ເກັບໄວ້ໃນບ່ອນທີ່ປອດໄພ!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="82"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="183"/>
+        <source>Error</source>
+        <translation>ຂໍ້ຜິດພາດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="143"/>
+        <source>Recovery key export path cannot be empty!</source>
+        <translation>ເສັ້ນທາງສົ່ງອອກກະແຈກູ້ຄືນບໍ່ສາມາດເປັນຄ່າວ່າງໄດ້!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="148"/>
+        <source>Recovery key export path is not exists!</source>
+        <translation>ເສັ້ນທາງສົ່ງອອກກະແຈກູ້ຄືນບໍ່ມີຢູ່!</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="154"/>
+        <source>This partition is read-only, please export to a writable partition</source>
+        <translation>ພາກສ່ວນນີ້ເປັນອ່ານຢ່າງດຽວ, ກະລຸນາສົ່ງອອກໄປຍັງພາກສ່ວນທີ່ຂຽນໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="167"/>
+        <source>The partition is encrypted, please export to a non-encrypted partition or external device such as a USB flash drive.</source>
+        <translation>ພາກສ່ວນນີ້ເຂົ້າລະຫັດແລ້ວ, ກະລຸນາສົ່ງອອກໄປຍັງພາກສ່ວນທີ່ບໍ່ເຂົ້າລະຫັດ ຫຼື ອຸປະກອນພາຍນອກເຊັ່ນຍູສບີແຟລຊ໌ດຣາຍ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp" line="183"/>
+        <source>Cannot create recovery key file!</source>
+        <translation>ບໍ່ສາມາດສ້າງໄຟລ໌ກະແຈກູ້ຄືນໄດ້!</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::EventsHandler</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="424"/>
+        <source>Preencrypt done</source>
+        <translation>ການເຂົ້າລະຫັດກ່ອນສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="425"/>
+        <source>Device %1 has been preencrypt, please reboot to finish encryption.</source>
+        <translation>ອຸປະກອນ %1 ໄດ້ເຂົ້າລະຫັດກ່ອນແລ້ວ, ກະລຸນາຣີບູດເພື່ອສຳເລັດການເຂົ້າລະຫັດ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="431"/>
+        <source>Preencrypt failed</source>
+        <translation>ການເຂົ້າລະຫັດກ່ອນລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="432"/>
+        <source>Device %1 preencrypt failed, please see log for more information.(%2)</source>
+        <translation>ອຸປະກອນ %1 ການເຂົ້າລະຫັດກ່ອນລົ້ມເຫລວ, ກະລຸນາເບິ່ງລັອກສຳລັບຂໍ້ມູນເພີ່ມເຕີມ.(%2)</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="460"/>
+        <source>Wrong passpharse or PIN</source>
+        <translation>ຄຳຜ່ານ ຫຼື PIN ຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="496"/>
+        <source>passphrase</source>
+        <translation>ຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="499"/>
+        <source>PIN</source>
+        <translation>PIN</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="506"/>
+        <source>Change %1 done</source>
+        <translation>ການປ່ຽນ %1 ສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="507"/>
+        <source>%1&apos;s %2 has been changed</source>
+        <translation>%2 ຂອງ %1 ໄດ້ຖືກປ່ຽນແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="512"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="517"/>
+        <source>Change %1 failed</source>
+        <translation>ການປ່ຽນ %1 ລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="513"/>
+        <source>Wrong %1</source>
+        <translation>%1 ຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="518"/>
+        <source>Device %1 change %2 failed, please see log for more information.(%3)</source>
+        <translation>ອຸປະກອນ %1 ການປ່ຽນ %2 ລົ້ມເຫລວ, ກະລຸນາເບິ່ງລັອກສຳລັບຂໍ້ມູນເພີ່ມເຕີມ.(%3)</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="180"/>
+        <source>Encrypt done</source>
+        <translation>ການເຂົ້າລະຫັດສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="181"/>
+        <source>Device %1 has been encrypted</source>
+        <translation>ອຸປະກອນ %1 ໄດ້ເຂົ້າລະຫັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="185"/>
+        <source>Encrypt failed</source>
+        <translation>ການເຂົ້າລະຫັດລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="186"/>
+        <source>Device %1 encrypt failed, please see log for more information.(%2)</source>
+        <translation>ອຸປະກອນ %1 ການເຂົ້າລະຫັດລົ້ມເຫລວ, ກະລຸນາເບິ່ງລັອກສຳລັບຂໍ້ມູນເພີ່ມເຕີມ.(%2)</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="285"/>
+        <source>%1 is under encrypting...</source>
+        <translation>%1 ກຳລັງເຂົ້າລະຫັດ...</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="286"/>
+        <source>The encrypting process may have system lag, please minimize the system operation</source>
+        <translation>ຂະບວນການເຂົ້າລະຫັດອາດມີການຊ້າຂອງລະບົບ, ກະລຸນາຫຼຸດຜ່ອນການດຳເນີນງານລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="305"/>
+        <source>%1 is under decrypting...</source>
+        <translation>%1 ກຳລັງຖອດລະຫັດ...</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="306"/>
+        <source>The decrypting process may have system lag, please minimize the system operation</source>
+        <translation>ຂະບວນການຖອດລະຫັດອາດມີການຊ້າຂອງລະບົບ, ກະລຸນາຫຼຸດຜ່ອນການດຳເນີນງານລະບົບ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="331"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="546"/>
+        <source>Error</source>
+        <translation>ຂໍ້ຜິດພາດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="452"/>
+        <source>Decrypt done</source>
+        <translation>ການຖອດລະຫັດສຳເລັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="453"/>
+        <source>Device %1 has been decrypted</source>
+        <translation>ອຸປະກອນ %1 ໄດ້ຖອດລະຫັດແລ້ວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="459"/>
+        <source>Decrypt disk</source>
+        <translation>ຖອດລະຫັດດິສ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="463"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="468"/>
+        <source>Decrypt failed</source>
+        <translation>ການຖອດລະຫັດລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="464"/>
+        <source>Device %1 is under encrypting, please decrypt after encryption finished.</source>
+        <translation>ອຸປະກອນ %1 ກຳລັງເຂົ້າລະຫັດ, ກະລຸນາຖອດລະຫັດຫຼັງຈາກການເຂົ້າລະຫັດສຳເລັດ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="469"/>
+        <source>Device %1 Decrypt failed, please see log for more information.(%2)</source>
+        <translation>ອຸປະກອນ %1 ການຖອດລະຫັດລົ້ມເຫລວ, ກະລຸນາເບິ່ງລັອກສຳລັບຂໍ້ມູນເພີ່ມເຕີມ.(%2)</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="547"/>
+        <source>Device is not fully decrypted, please finish decryption before access.</source>
+        <translation>ອຸປະກອນບໍ່ໄດ້ຖອດລະຫັດສົມບູນ, ກະລຸນາສຳເລັດການຖອດລະຫັດກ່ອນເຂົ້າເຖິງ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="554"/>
+        <source>Unlocking device failed</source>
+        <translation>ການປົດລັອກອຸປະກອນລົ້ມເຫລວ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="555"/>
+        <source>Please click the right disk menu &quot;Continue partition encryption&quot; to complete partition encryption.</source>
+        <translation>ກະລຸນາຄລິກເມນູດິສຂວາ &quot;ສືບຕໍ່ການເຂົ້າລະຫັດພາກສ່ວນ&quot; ເພື່ອສຳເລັດການເຂົ້າລະຫັດພາກສ່ວນ.</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="331"/>
+        <source>TPM status is abnormal, please use the recovery key to unlock it</source>
+        <translation>ສະຖານະ TPM ຜິດປົກກະຕິ, ກະລຸນາໃຊ້ກະແຈກູ້ຄືນເພື່ອປົດລັອກມັນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="357"/>
+        <source>Wrong PIN</source>
+        <translation>PIN ຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="359"/>
+        <source>Wrong passphrase</source>
+        <translation>ຄຳຜ່ານຜິດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="361"/>
+        <source>TPM error</source>
+        <translation>ຂໍ້ຜິດພາດ TPM</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="363"/>
+        <source>Please use recovery key to unlock device.</source>
+        <translation>ກະລຸນາໃຊ້ກະແຈກູ້ຄືນເພື່ອປົດລັອກອຸປະກອນ.</translation>
+    </message>
+</context>
+<context>
+    <name>dfmplugin_diskenc::UnlockPartitionDialog</name>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="51"/>
+        <source>Cancel</source>
+        <translation>ຍົກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="52"/>
+        <source>Unlock</source>
+        <translation>ປົດລັອກ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="81"/>
+        <source>Unlock encryption partition</source>
+        <translation>ປົດລັອກພາກສ່ວນທີ່ເຂົ້າລະຫັດ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="85"/>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="88"/>
+        <source>Unlock by recovery key</source>
+        <translation>ປົດລັອກດ້ວຍກະແຈກູ້ຄືນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="90"/>
+        <source>Unlock by passphrase</source>
+        <translation>ປົດລັອກດ້ວຍຄຳຜ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="91"/>
+        <source>Unlock by PIN</source>
+        <translation>ປົດລັອກດ້ວຍ PIN</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="93"/>
+        <source>Please input recovery key to unlock device</source>
+        <translation>ກະລຸນາປ້ອນກະແຈກູ້ຄືນເພື່ອປົດລັອກອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="99"/>
+        <source>Please input passphrase to unlock device</source>
+        <translation>ກະລຸນາປ້ອນຄຳຜ່ານເພື່ອປົດລັອກອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="102"/>
+        <source>Please input PIN to unlock device</source>
+        <translation>ກະລຸນາປ້ອນ PIN ເພື່ອປົດລັອກອຸປະກອນ</translation>
+    </message>
+    <message>
+        <location filename="../../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp" line="115"/>
+        <source>Recovery key is not valid!</source>
+        <translation>ກະແຈກູ້ຄືນບໍ່ຖືກຕ້ອງ!</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
log:

## Summary by Sourcery

Add Lao locale translations for the disk encryption plugin and core desktop entry components

Documentation:
- Add Lao translations for disk-encrypt-plugin UI messages
- Add Lao desktop entry translations for file manager, trash, home and computer components