### PR TITLE
feat: Add device mount crumb parsing for media directory

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -62,7 +62,7 @@ SectionKeyLabel::SectionKeyLabel(const QString &text, QWidget *parent, Qt::Windo
     setObjectName("SectionKeyLabel");
     DFontSizeManager::instance()->bind(this, DFontSizeManager::SizeType::T7, QFont::Medium);
     setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
-    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
 }
 
 ShareControlWidget::ShareControlWidget(const QUrl &url, bool disableState, QWidget *parent)

--- a/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.h
@@ -32,6 +32,7 @@ public Q_SLOTS:
 
 protected:
     bool parseCifsMountCrumb(const QUrl &url, QList<QVariantMap> *mapGroup);
+    bool parseDevMountCrumb(const QUrl &url, QList<QVariantMap> *mapGroup);
     static bool askForConfirmChmod(const QString &devName);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -263,6 +263,7 @@ void OptionButtonBox::initializeUi()
     d->iconViewButton->setFixedSize(buttonSize);
     d->iconViewButton->setToolTip(tr("Icon view"));
     d->iconViewButton->setIconSize(buttonIconSize);
+    d->iconViewButton->setFocusPolicy(Qt::NoFocus);
 
     d->listViewButton = new CustomDToolButton;
     d->listViewButton->setCheckable(true);
@@ -270,6 +271,7 @@ void OptionButtonBox::initializeUi()
     d->listViewButton->setFixedSize(buttonSize);
     d->listViewButton->setToolTip(tr("List view"));
     d->listViewButton->setIconSize(buttonIconSize);
+    d->listViewButton->setFocusPolicy(Qt::NoFocus);
     d->buttonGroup->addButton(d->iconViewButton);
     d->buttonGroup->addButton(d->listViewButton);
 
@@ -281,6 +283,7 @@ void OptionButtonBox::initializeUi()
         d->treeViewButton->setFixedSize(buttonSize);
         d->treeViewButton->setToolTip(tr("Tree view"));
         d->treeViewButton->setIconSize(buttonIconSize);
+        d->treeViewButton->setFocusPolicy(Qt::NoFocus);
         d->buttonGroup->addButton(d->treeViewButton);
     } else {
         fmDebug() << "Tree view is disabled in configuration";


### PR DESCRIPTION
- Introduced a new method `parseDevMountCrumb` to handle device mounts specifically for paths under the `/media` directory.
- Enhanced crumb data generation by including device icons and display text based on device type.
- Updated `handleSepateTitlebarCrumb` to also consider device mount crumbs alongside CIFS mounts.

Log: This change improves the user experience by providing more accurate and relevant breadcrumb navigation for mounted devices.
Bug: https://pms.uniontech.com/bug-view-326657.html

## Summary by Sourcery

Enable breadcrumb navigation for devices mounted in the /media directory by introducing a dedicated parsing routine that detects block devices, constructs crumb entries for the mount point and subdirectories, and enriches them with appropriate icons and labels.

New Features:
- Add parseDevMountCrumb method to generate breadcrumbs for devices mounted under /media

Enhancements:
- Integrate device mount crumb parsing into handleSepateTitlebarCrumb alongside CIFS mounts
- Assign device-specific icons and display text based on device type when building breadcrumb data