### PR TITLE
fix bugs

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -43,9 +43,9 @@ DoCopyFileWorker::~DoCopyFileWorker()
 // main thread using
 void DoCopyFileWorker::pause()
 {
-    if (state == kPasued || state == kStoped)
+    if (state == kPaused || state == kStopped)
         return;
-    state = kPasued;
+    state = kPaused;
 }
 // main thread using
 void DoCopyFileWorker::resume()
@@ -56,7 +56,7 @@ void DoCopyFileWorker::resume()
 // main thread using// main thread using
 void DoCopyFileWorker::stop()
 {
-    state = kStoped;
+    state = kStopped;
     waitCondition->wakeAll();
     auto fileOpsAll = fileOps.listByLock();
     for (auto op : fileOpsAll) {
@@ -382,7 +382,7 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFileByRange(const DFileInfoPoin
 
 bool DoCopyFileWorker::stateCheck()
 {
-    if (state == kPasued)
+    if (state == kPaused)
         workerWait();
 
     return state == kNormal;
@@ -856,7 +856,7 @@ void DoCopyFileWorker::checkRetry()
 
 bool DoCopyFileWorker::isStopped()
 {
-    return state == kStoped;
+    return state == kStopped;
 }
 
 /*!

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -30,8 +30,8 @@ class DoCopyFileWorker : public QObject
 public:
     enum : u_int8_t {
         kNormal,
-        kPasued,
-        kStoped,
+        kPaused,
+        kStopped,
     };
 
     enum class NextDo: u_int8_t {

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1230,7 +1230,7 @@ void FileOperateBaseWorker::determineCountProcessType()
                         if (targetIsRemovable) {
                             workData->exBlockSyncEveryWrite = FileOperationsUtils::blockSync();
                             workData->expandDiskSync = FileOperationsUtils::expandDiskSync();
-                            countWriteType = workData->exBlockSyncEveryWrite ? CountWriteSizeType::kCustomizeType
+                            countWriteType = !workData->expandDiskSync || workData->exBlockSyncEveryWrite ? CountWriteSizeType::kCustomizeType
                                                                              : CountWriteSizeType::kWriteBlockType;
                             targetDeviceStartSectorsWritten = workData->exBlockSyncEveryWrite ? 0 : getSectorsWritten();
 

--- a/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
@@ -32,13 +32,20 @@ private slots:
     void sendTrashStateChangedAdd();
 
 private:
+    enum class TrashState {
+        Unknown,    // Initial state, not yet determined
+        Empty,      // Trash is empty
+        NotEmpty    // Trash contains files
+    };
+
     explicit TrashCoreEventSender(QObject *parent = nullptr);
     void initTrashWatcher();
     bool checkAndStartWatcher();
+    void ensureTrashStateInitialized();
 
 private:
     QSharedPointer<DFMBASE_NAMESPACE::AbstractFileWatcher> trashFileWatcher = nullptr;
-    bool isEmpty { false };
+    TrashState trashState { TrashState::Unknown };
     QTimer timer;
 };
 

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.h
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.h
@@ -81,12 +81,19 @@ private:
     void onTrashStateChanged();
 
 private:
+    enum class TrashState {
+        Unknown,    // Initial state, not yet determined
+        Empty,      // Trash is empty
+        NotEmpty    // Trash contains files
+    };
+
     explicit TrashHelper(QObject *parent = nullptr);
     void initEvent();
+    void ensureTrashStateInitialized();
 
 private:
     DFMBASE_NAMESPACE::LocalFileWatcher *trashFileWatcher { nullptr };
-    bool isTrashEmpty;
+    TrashState trashState { TrashState::Unknown };
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -95,8 +95,8 @@ void TraversalDirThreadManager::start()
     if (this->sortRole != dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault
         && dirIterator->oneByOne()) {
         fmDebug() << "Setting QueryAttributes for sorted one-by-one iteration";
-        dirIterator->setProperty("QueryAttributes", "standard::name,standard::type,standard::is-file,standard::is-dir,\
-                                  standard::size,standard::is-symlink,standard::symlink-target,access::*,time::*");
+        dirIterator->setProperty("QueryAttributes", "standard::name,standard::type,standard::is-file,standard::is-dir,"
+                                                    "standard::size,standard::is-symlink,standard::symlink-target,access::*,time::*");
     }
 
     auto local = dirIterator.dynamicCast<LocalDirIterator>();


### PR DESCRIPTION
## Summary by Sourcery

Improve trash event handling by lazy-initializing trash state and centralizing change detection, fix file copy worker state and chunk calculations, refine write-count logic, and apply minor formatting cleanup.

Bug Fixes:
- Guard DoCopyFileWorker.pause against redundant calls and correct doCopyFileByRange to use a dedicated remaining-data variable.
- Prevent redundant trash state signals and UI updates by ensuring actual state changes before emission.

Enhancements:
- Introduce TrashState enum with ensureTrashStateInitialized and debug logging in TrashCoreEventSender and TrashHelper to replace blocking initial checks.
- Refine write-count determination in FileOperateBaseWorker to properly combine expandDiskSync and exBlockSyncEveryWrite flags.

Chores:
- Break up a long QueryAttributes string literal in TraversalDirThreadManager for readability.