### PR TITLE
fix: fix non-reproducible builds

### DIFF
--- a/cmake/DFMPluginConfig.cmake
+++ b/cmake/DFMPluginConfig.cmake
@@ -13,6 +13,11 @@ function(dfm_apply_default_plugin_config target_name)
         DFM6::framework
     )
     
+    # Skip build rpath for reproducible release build
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        set_target_properties(${target_name} PROPERTIES SKIP_BUILD_RPATH TRUE)
+    endif()
+    
     message(STATUS "DFM: Default plugin configuration applied successfully")
 endfunction()
 

--- a/cmake/DFMServiceConfig.cmake
+++ b/cmake/DFMServiceConfig.cmake
@@ -14,6 +14,11 @@ function(dfm_apply_default_service_config target_name)
         Qt6::DBus
     )
     
+    # Skip build rpath for reproducible release build
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        set_target_properties(${target_name} PROPERTIES SKIP_BUILD_RPATH TRUE)
+    endif()
+    
     message(STATUS "DFM: Default service configuration applied successfully")
 endfunction()
 

--- a/src/apps/config.h.in
+++ b/src/apps/config.h.in
@@ -9,13 +9,21 @@
 //  #define DFM_PLUGIN_PATH xxx
 
 #ifndef DFM_BUILD_DIR
-#    define DFM_BUILD_DIR "${DFM_BUILD_DIR}"
+#   ifdef QT_DEBUG
+#        define DFM_BUILD_DIR "${DFM_BUILD_DIR}"
+#   else
+#        define DFM_BUILD_DIR "."
+#   endif
 #elif
 #    warning "cmake unseting definition DFM_BUILD_DIR"
 #endif
 
 #ifndef DFM_BUILD_PLUGIN_DIR
-#    define DFM_BUILD_PLUGIN_DIR "${DFM_BUILD_PLUGIN_DIR}"
+#   ifdef QT_DEBUG
+#       define DFM_BUILD_PLUGIN_DIR "${DFM_BUILD_PLUGIN_DIR}"
+#   else
+#        define DFM_BUILD_PLUGIN_DIR "."
+#   endif
 #elif
 #    warning "cmake unseting definition DFM_BUILD_PLUGIN_DIR"
 #endif

--- a/src/apps/dde-file-dialog-wayland/CMakeLists.txt
+++ b/src/apps/dde-file-dialog-wayland/CMakeLists.txt
@@ -15,6 +15,11 @@ set(SRCS
 find_package(Qt6 COMPONENTS Core)
 add_executable(${PROJECT_NAME} ${SRCS})
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME}
     DFM6::base

--- a/src/apps/dde-file-dialog-x11/CMakeLists.txt
+++ b/src/apps/dde-file-dialog-x11/CMakeLists.txt
@@ -15,6 +15,11 @@ set(SRCS
 find_package(Qt6 COMPONENTS Core)
 add_executable(${PROJECT_NAME} ${SRCS})
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME}
     DFM6::base

--- a/src/apps/dde-file-dialog/CMakeLists.txt
+++ b/src/apps/dde-file-dialog/CMakeLists.txt
@@ -14,6 +14,11 @@ set(SRCS
 find_package(Qt6 COMPONENTS Core)
 add_executable(${PROJECT_NAME} ${SRCS})
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME}
     DFM6::base

--- a/src/apps/dde-file-manager-daemon/CMakeLists.txt
+++ b/src/apps/dde-file-manager-daemon/CMakeLists.txt
@@ -20,6 +20,11 @@ target_include_directories(${PROJECT_NAME}
         ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME}
     DFM6::base

--- a/src/apps/dde-file-manager-preview/filepreview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/filepreview/CMakeLists.txt
@@ -21,6 +21,11 @@ add_executable(${BIN_NAME}
     ${FILEPREVIEW_FILES}
 )
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${BIN_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${BIN_NAME} PRIVATE
     Qt6::Core
     Dtk6::Widget

--- a/src/apps/dde-file-manager-preview/libdfm-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/CMakeLists.txt
@@ -20,6 +20,11 @@ add_definitions(-DVERSION=\"${VERSION}\")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ./)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${PROJECT_NAME}
     DFM6::base
     DFM6::framework

--- a/src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/CMakeLists.txt
@@ -21,6 +21,11 @@ add_library(${BIN_NAME}
 
 set_target_properties(${BIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${BIN_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${BIN_NAME}
     DFM6::base
     DFM6::framework

--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/CMakeLists.txt
@@ -20,6 +20,11 @@ add_library(${BIN_NAME}
 
 set_target_properties(${BIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${BIN_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${BIN_NAME}
     DFM6::base
     DFM6::framework

--- a/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/CMakeLists.txt
@@ -25,6 +25,11 @@ add_library(${BIN_NAME}
 
 set_target_properties(${BIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${BIN_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${BIN_NAME}
     DFM6::base
     DFM6::framework

--- a/src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/CMakeLists.txt
@@ -20,6 +20,11 @@ add_library(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${PROJECT_NAME}
     DFM6::base
     DFM6::framework

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/CMakeLists.txt
@@ -21,6 +21,11 @@ add_library(${BIN_NAME}
 
 set_target_properties(${BIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${BIN_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${BIN_NAME}
     DFM6::base
     DFM6::framework

--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/CMakeLists.txt
@@ -25,6 +25,11 @@ add_library(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY  ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         ${libdmr_INCLUDE_DIRS}

--- a/src/apps/dde-file-manager/CMakeLists.txt
+++ b/src/apps/dde-file-manager/CMakeLists.txt
@@ -38,6 +38,11 @@ target_include_directories(${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}
     )
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME}
     Qt6::Widgets

--- a/src/external/dde-shell-plugins/panel-desktop/CMakeLists.txt
+++ b/src/external/dde-shell-plugins/panel-desktop/CMakeLists.txt
@@ -30,6 +30,11 @@ target_include_directories(${PROJECT_NAME}
         ${Qt6Widgets_PRIVATE_INCLUDE_DIRS}
 )
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${PROJECT_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${PROJECT_NAME} PRIVATE
     Dde::Shell
     DFM6::base

--- a/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
@@ -38,6 +38,11 @@ add_library(${BIN_NAME}
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DESKTOP_DIR})
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${BIN_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${BIN_NAME} PRIVATE
     DFM6::base
     DFM6::framework

--- a/src/tools/upgrade/CMakeLists.txt
+++ b/src/tools/upgrade/CMakeLists.txt
@@ -43,6 +43,11 @@ find_package(Qt6 COMPONENTS Core REQUIRED)
 
 configure_upgrade_library(${BIN_NAME})
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set_target_properties(${BIN_NAME} PROPERTIES SKIP_BUILD_RPATH TRUE)
+endif()
+
 target_link_libraries(${BIN_NAME}
     DFM6::base
     DFM6::framework


### PR DESCRIPTION
1. Set the SKIP_BUILD_RPATH property for build targets in release builds to ensure reproducible builds.
2. Define macros like DFM_BUILD_DIR to "." in release builds to avoid including build paths in source code.

## Summary by Sourcery

Ensure Release builds are reproducible by disabling embedded RPATH and normalizing build path defines

Build:
- Disable build RPATH for all targets in Release builds to avoid embedding absolute paths
- Define build directory macros (e.g. DFM_BUILD_DIR) as "." in Release builds to prevent inclusion of build paths in source code