### PR TITLE
fix: fix non-reproducible builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ include(install_dbus_service)
 include(GNUInstallDirs)
 include(DFMInstallDirs)
 
+# Skip build rpath for reproducible release build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(CMAKE_SKIP_BUILD_RPATH TRUE)
+endif()
+
 # sub directories
 add_subdirectory(src/apps)
 add_subdirectory(src/dfm-base)

--- a/src/apps/config.h.in
+++ b/src/apps/config.h.in
@@ -9,13 +9,21 @@
 //  #define DFM_PLUGIN_PATH xxx
 
 #ifndef DFM_BUILD_DIR
-#    define DFM_BUILD_DIR "${DFM_BUILD_DIR}"
+#   ifdef QT_DEBUG
+#        define DFM_BUILD_DIR "${DFM_BUILD_DIR}"
+#   else
+#        define DFM_BUILD_DIR "/nonexistent"
+#   endif
 #elif
 #    warning "cmake unseting definition DFM_BUILD_DIR"
 #endif
 
 #ifndef DFM_BUILD_PLUGIN_DIR
-#    define DFM_BUILD_PLUGIN_DIR "${DFM_BUILD_PLUGIN_DIR}"
+#   ifdef QT_DEBUG
+#       define DFM_BUILD_PLUGIN_DIR "${DFM_BUILD_PLUGIN_DIR}"
+#   else
+#        define DFM_BUILD_PLUGIN_DIR "/nonexistent"
+#   endif
 #elif
 #    warning "cmake unseting definition DFM_BUILD_PLUGIN_DIR"
 #endif


### PR DESCRIPTION
1. Skip build rpath when the build type is set to "Release" to ensure reproducible builds.
2. Define macros like DFM_BUILD_DIR to "/nonexistent" in release builds to avoid including build paths in source code.

## Summary by Sourcery

Ensure reproducible builds by skipping build RPATH in Release mode and defining build-directory macros to a non-existent path in Release builds.

Bug Fixes:
- Skip build RPATH when the build type is set to Release to avoid embedding local paths.
- Define DFM_BUILD_DIR and related macros as "/nonexistent" in Release builds to prevent inclusion of source build paths.