### PR TITLE
chore: bump version to 6.5.85

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.85) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 13 Aug 2025 17:25:09 +0800
+
 dde-file-manager (6.5.84) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
6.5.85

Log:

## Summary by Sourcery

Chores:
- Bump Debian package version to 6.5.85