### PR TITLE
chore: bump version to 6.5.86

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.86) unstable; urgency=medium
+
+  * add translations
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 13 Aug 2025 17:29:08 +0800
+
 dde-file-manager (6.5.85) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
6.5.86

Log:

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.5.86