### PR TITLE
fix: The application failed to launch in debug mode

### DIFF
--- a/src/apps/config.h.in
+++ b/src/apps/config.h.in
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <QObject>
+
 // config.h.in platfrom plugin output
 // set(DFM_PLUGIN_PATH) in cmake
 // if setting new definition, please use:


### PR DESCRIPTION
During the preprocessing stage, the QT_DEBUG macro could not be recognized, resulting in failure to obtain the correct plugin path.

Log: fix issue

## Summary by Sourcery

Bug Fixes:
- Recognize the QT_DEBUG macro during preprocessing to derive the correct plugin path in debug builds