### PR TITLE
6.5.87

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.87) unstable; urgency=medium
+
+  * fix bugs 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 14 Aug 2025 13:57:38 +0800
+
 dde-file-manager (6.5.86) unstable; urgency=medium
 
   * add translations

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileselectionmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileselectionmodel.cpp
@@ -82,14 +82,14 @@ void FileSelectionModel::updateSelecteds()
 
 void FileSelectionModel::select(const QItemSelection &selection, QItemSelectionModel::SelectionFlags command)
 {
-    if (!command.testFlag(NoUpdate))
-        d->selectedList.clear();
-
     if (command != QItemSelectionModel::SelectionFlags(Current | Rows | ClearAndSelect)) {
         if (d->timer.isActive()) {
             d->timer.stop();
             updateSelecteds();
         }
+
+        if (!command.testFlag(NoUpdate))
+            d->selectedList.clear();
 
         d->currentCommand = command;
 
@@ -97,6 +97,9 @@ void FileSelectionModel::select(const QItemSelection &selection, QItemSelectionM
 
         return;
     }
+
+    if (!command.testFlag(NoUpdate))
+        d->selectedList.clear();
 
     if (selection.isEmpty()) {
         d->firstSelectedIndex = QModelIndex();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Invoke d->selectedList.clear() in both non-current and current selection paths only when the NoUpdate flag is not present to fix inconsistent selection state clearing.