### PR TITLE
feat: Implement network protocol device alias management

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.mount.json
+++ b/assets/configs/org.deepin.dde.file-manager.mount.json
@@ -34,6 +34,17 @@
             "description":"Display device capacity as disk size (0) or file system size (1). The remaining values are treated as 0.",
             "permissions":"readwrite",
             "visibility":"public"
+        },
+        "aliasSupportedProtocolList": {
+            "value":["smb", "ftp", "sftp"],
+            "serial":0,
+            "flags":[],
+            "name":"Network protocol device alias",
+            "name[zh_CN]":"网络协议设备别名",
+            "description[zh_CN]":"配置支持别名设置的网络协议",
+            "description":"Configures network protocols that support alias settings",
+            "permissions":"readwrite",
+            "visibility":"private"
         }
     }
 }

--- a/include/dfm-base/interfaces/abstractentryfileentity.h
+++ b/include/dfm-base/interfaces/abstractentryfileentity.h
@@ -60,6 +60,7 @@ public:
     virtual inline bool renamable() const { return false; }
     virtual inline QVariantHash extraProperties() const { return datas; }
     virtual inline void setExtraProperty(const QString &key, const QVariant &val) { datas[key] = val; }
+    virtual inline QString editDisplayText() const { return displayName(); };
 
 protected:
     QUrl entryUrl {};

--- a/src/dfm-base/base/device/devicealiasmanager.cpp
+++ b/src/dfm-base/base/device/devicealiasmanager.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "devicealiasmanager.h"
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <QUrl>
+
+using namespace dfmbase;
+DFMBASE_USE_NAMESPACE
+
+inline constexpr char kCfgName[] { "org.deepin.dde.file-manager.mount" };
+inline constexpr char kNPDAlias[] { "aliasSupportedProtocolList" };
+
+inline constexpr char kSchemeSupportedList[] { "hideMyDirectories" };
+inline constexpr char kNPAliasGroupName[] { "NetworkProtocolDeviceAlias" };
+inline constexpr char kAliasItemName[] { "Items" };
+inline constexpr char kSchemeKey[] { "scheme" };
+inline constexpr char kDevicesKey[] { "devices" };
+inline constexpr char kHostKey[] { "host" };
+inline constexpr char kAliasKey[] { "alias" };
+
+// NPDeviceAliasManager implementation
+NPDeviceAliasManager::NPDeviceAliasManager(QObject *parent)
+    : QObject(parent)
+{
+    qCDebug(logDFMBase) << "EntryEntityAliasManager initialized";
+}
+
+NPDeviceAliasManager *NPDeviceAliasManager::instance()
+{
+    static NPDeviceAliasManager ins;
+    return &ins;
+}
+
+QString NPDeviceAliasManager::getAlias(const QUrl &protocolUrl) const
+{
+    if (!canSetAlias(protocolUrl))
+        return "";
+
+    const auto &itemList = Application::genericSetting()->value(kNPAliasGroupName, kAliasItemName).toList();
+    for (const auto &item : std::as_const(itemList)) {
+        const auto &map = item.toMap();
+        const auto &scheme = map.value(kSchemeKey).toString();
+        if (scheme != protocolUrl.scheme())
+            continue;
+
+        const auto &deviceList = map.value(kDevicesKey).toList();
+        for (const auto &dev : std::as_const(deviceList)) {
+            const auto &devMap = dev.toMap();
+            const auto &host = devMap.value(kHostKey).toString();
+            if (host == protocolUrl.host())
+                return devMap.value(kAliasKey).toString();
+        }
+    }
+
+    return "";
+}
+
+/**
+ * @brief Set or remove alias for a protocol device.
+ * @param protocolUrl QUrl, the protocol device url (e.g. smb://10.10.10.10)
+ * @param alias QString, the alias to set. If empty, remove the alias entry.
+ * @return true if set/remove succeeded, false otherwise.
+ */
+bool NPDeviceAliasManager::setAlias(const QUrl &protocolUrl, const QString &alias)
+{
+    if (!canSetAlias(protocolUrl))
+        return false;
+
+    auto itemList = Application::genericSetting()->value(kNPAliasGroupName, kAliasItemName).toList();
+    bool modified = false;
+
+    // Iterate over protocol schemes
+    for (int i = 0; i < itemList.size(); ++i) {
+        QVariantMap map = itemList[i].toMap();
+        const QString scheme = map.value(kSchemeKey).toString();
+        if (scheme != protocolUrl.scheme())
+            continue;
+
+        QList<QVariant> deviceList = map.value(kDevicesKey).toList();
+        bool found = false;
+
+        // Search for the device by host
+        for (int j = 0; j < deviceList.size(); ++j) {
+            QVariantMap devMap = deviceList[j].toMap();
+            const QString host = devMap.value(kHostKey).toString();
+            const QString &oldAlias = devMap.value(kAliasKey).toString();
+            if (host == protocolUrl.host()) {
+                found = true;
+                if (alias.isEmpty() || alias == host) {
+                    // Remove the device entry if alias is empty
+                    deviceList.removeAt(j);
+                    qCInfo(logDFMBase) << "Alias removed for" << protocolUrl.toString();
+                } else if (alias == oldAlias) {
+                    return true;
+                } else {
+                    // Set or update the alias
+                    devMap[kAliasKey] = alias;
+                    deviceList[j] = devMap;
+                    qCInfo(logDFMBase) << "Alias set for" << protocolUrl.toString() << ":" << alias;
+                }
+                modified = true;
+                break;
+            }
+        }
+
+        // If not found and alias is not empty, add new device entry
+        if (!found && !alias.isEmpty()) {
+            QVariantMap newDev;
+            newDev[kHostKey] = protocolUrl.host();
+            newDev[kAliasKey] = alias;
+            deviceList.append(newDev);
+            qCInfo(logDFMBase) << "Alias added for" << protocolUrl.toString() << ":" << alias;
+            modified = true;
+        }
+
+        // Update the device list in the map
+        map[kDevicesKey] = deviceList;
+        itemList[i] = map;
+        // Only one scheme group should match, so break
+        break;
+    }
+
+    // If scheme group not found and alias is not empty, add new group
+    if (!modified && !alias.isEmpty()) {
+        QVariantMap newMap;
+        newMap[kSchemeKey] = protocolUrl.scheme();
+        QVariantMap newDev;
+        newDev[kHostKey] = protocolUrl.host();
+        newDev[kAliasKey] = alias;
+        newMap[kDevicesKey] = QVariantList { newDev };
+        itemList.append(newMap);
+        qCInfo(logDFMBase) << "Alias group and device added for" << protocolUrl.toString() << ":" << alias;
+        modified = true;
+    }
+
+    if (modified)
+        Application::genericSetting()->setValue(kNPAliasGroupName, kAliasItemName, itemList);
+
+    return true;
+}
+
+void NPDeviceAliasManager::removeAlias(const QUrl &protocolUrl)
+{
+    setAlias(protocolUrl, QString());
+}
+
+bool NPDeviceAliasManager::hasAlias(const QUrl &protocolUrl) const
+{
+    return !getAlias(protocolUrl).isEmpty();
+}
+
+bool NPDeviceAliasManager::canSetAlias(const QUrl &protocolUrl) const
+{
+    if (!protocolUrl.isValid() || protocolUrl.host().isEmpty())
+        return false;
+
+    const auto &list = DConfigManager::instance()->value(kCfgName, kNPDAlias).toStringList();
+    return list.contains(protocolUrl.scheme(), Qt::CaseInsensitive);
+}

--- a/src/dfm-base/base/device/devicealiasmanager.h
+++ b/src/dfm-base/base/device/devicealiasmanager.h
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEVICEALIASMANAGER_H
+#define DEVICEALIASMANAGER_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QObject>
+
+namespace dfmbase {
+
+/**
+ * @brief Network protocol device alias manager
+ *
+ * This class manages aliases for network protocol devices (SMB, FTP, SFTP, etc.).
+ * It provides persistent storage using Application::genericSetting() and uses
+ * separated protocol identifiers (scheme:host:port) as unique keys.
+ */
+class NPDeviceAliasManager : public QObject
+{
+    Q_OBJECT
+public:
+    /**
+     * @brief Get the singleton instance
+     * @return Pointer to the singleton instance
+     */
+    static NPDeviceAliasManager *instance();
+
+    /**
+     * @brief Get alias for a protocol URL
+     * @param protocolUrl The protocol URL (e.g., "smb://10.10.10.10/share")
+     * @return The alias string, empty if no alias is set
+     */
+    QString getAlias(const QUrl &protocolUrl) const;
+
+    /**
+     * @brief Set alias for a protocol URL
+     * @param protocolUrl The protocol URL to set alias for
+     * @param alias The alias string to set. If empty, the alias will be removed.
+     * @return true if the operation succeeded, false if URL is invalid or unsupported
+     *
+     * @details This method will:
+     * - Add a new alias entry if it doesn't exist
+     * - Update existing alias if it already exists
+     * - Remove alias entry if alias string is empty
+     * - Persist changes to application settings
+     */
+    bool setAlias(const QUrl &protocolUrl, const QString &alias);
+
+    /**
+     * @brief Remove alias for a protocol URL
+     * @param protocolUrl The protocol URL to remove alias for
+     *
+     * @details This is a convenience method that calls setAlias() with an empty string.
+     * The operation will persist changes to application settings.
+     */
+    void removeAlias(const QUrl &protocolUrl);
+
+    /**
+     * @brief Check if a protocol URL has an alias
+     * @param protocolUrl The protocol URL to check
+     * @return true if alias exists, false otherwise
+     */
+    bool hasAlias(const QUrl &protocolUrl) const;
+
+    /**
+     * @brief Check if alias can be set for the given protocol URL
+     * @param protocolUrl The protocol URL to validate
+     * @return true if the URL is valid and scheme is supported for alias setting, false otherwise
+     *
+     * @details This method validates:
+     * - URL is valid and has a non-empty host
+     * - Protocol scheme is in the supported list (smb, ftp, sftp, etc.)
+     */
+    bool canSetAlias(const QUrl &protocolUrl) const;
+
+private:
+    /**
+     * @brief Private constructor for singleton pattern
+     * @param parent Parent QObject
+     */
+    explicit NPDeviceAliasManager(QObject *parent = nullptr);
+};
+
+}
+
+#endif   // DEVICEALIASMANAGER_H

--- a/src/dfm-base/file/entry/entryfileinfo.cpp
+++ b/src/dfm-base/file/entry/entryfileinfo.cpp
@@ -106,6 +106,11 @@ QString EntryFileInfo::displayName() const
     return d->entity ? d->entity->displayName() : "";
 }
 
+QString EntryFileInfo::editDisplayText() const
+{
+    return d->entity ? d->entity->editDisplayText() : "";
+}
+
 quint64 EntryFileInfo::sizeTotal() const
 {
     return d->entity ? d->entity->sizeTotal() : 0;

--- a/src/dfm-base/file/entry/entryfileinfo.h
+++ b/src/dfm-base/file/entry/entryfileinfo.h
@@ -23,6 +23,7 @@ public:
 
     bool renamable() const;
     QString displayName() const;
+    QString editDisplayText() const;
     quint64 sizeTotal() const;
     quint64 sizeUsage() const;
     quint64 sizeFree() const;

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -162,7 +162,7 @@ int FileUtils::supportedMaxLength(const QString &fileSystem)
         { "reiserfs", 15 },   // man 8 mkreiserfs said its max length is 16, but after tested, only 15 chars are accepted.
         { "xfs", 12 }   // https://github.com/edward6/reiser4progs/blob/master/include/reiser4/types.h fs_hint_t
     };
-    return datas.value(fileSystem.toLower(), 11);
+    return datas.value(fileSystem.toLower(), 40);
 }
 
 QString FileUtils::preprocessingFileName(QString name)

--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
@@ -256,7 +256,8 @@ DockItemData DockItemDataManager::buildBlockItem(const QVariantMap &data)
         .iconName = iconName,
         .totalSize = data.value(GlobalServerDefines::DeviceProperty::kSizeTotal).toULongLong(),
         .usedSize = data.value(GlobalServerDefines::DeviceProperty::kSizeUsed).toULongLong(),
-        .sortKey = QString("00%1_00%2").arg(iconName).arg(displayName)
+        .sortKey = QString("00%1_00%2").arg(iconName).arg(displayName),
+        .isProtocolDevice = false
     };
 }
 
@@ -280,7 +281,8 @@ DockItemData DockItemDataManager::buildProtocolItem(const QVariantMap &data)
         .iconName = iconName,
         .totalSize = data.value(GlobalServerDefines::DeviceProperty::kSizeTotal).toULongLong(),
         .usedSize = data.value(GlobalServerDefines::DeviceProperty::kSizeUsed).toULongLong(),
-        .sortKey = QString("01%1_00%2").arg(iconName).arg(displayName)
+        .sortKey = QString("01%1_00%2").arg(iconName).arg(displayName),
+        .isProtocolDevice = true
     };
 }
 

--- a/src/external/dde-dock-plugins/disk-mount/device/typedefines.h
+++ b/src/external/dde-dock-plugins/disk-mount/device/typedefines.h
@@ -23,6 +23,7 @@ struct DockItemData
     quint64 totalSize;
     quint64 usedSize;
     QString sortKey;
+    bool isProtocolDevice;
 };
 Q_DECLARE_METATYPE(DockItemData)
 

--- a/src/external/dde-dock-plugins/disk-mount/utils/dockutils.h
+++ b/src/external/dde-dock-plugins/disk-mount/utils/dockutils.h
@@ -25,6 +25,7 @@ bool parseSmbInfo(const QString &id, QString *host, QString *share, int *port = 
 namespace device_utils {
 QString blockDeviceName(const QVariantMap &data);
 QString protocolDeviceName(const QVariantMap &data);
+QString protocolDeviceAlias(const QString &scheme, const QString &host);
 
 QString blockDeviceIcon(const QVariantMap &data);
 QString protocolDeviceIcon(const QVariantMap &data);

--- a/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.h
@@ -22,6 +22,7 @@ public:
 protected:
     void mouseReleaseEvent(QMouseEvent *) override;
     void resizeEvent(QResizeEvent *e) override;
+    void showEvent(QShowEvent *e) override;
 
 public Q_SLOTS:
     void updateUsage(quint64 usedSize);
@@ -32,6 +33,7 @@ Q_SIGNALS:
 private:
     void initUI();
     void openDevice();
+    void updateDeviceName();
     static void setTextColor(QWidget *obj, int themeType, double alpha);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-computer/computer.h
+++ b/src/plugins/filemanager/dfmplugin-computer/computer.h
@@ -29,6 +29,7 @@ class Computer : public dpf::Plugin
     DPF_EVENT_REG_SIGNAL(signal_ShortCut_CtrlT)
     DPF_EVENT_REG_SIGNAL(signal_ReportLog_MenuData)
     DPF_EVENT_REG_SIGNAL(signal_View_Refreshed)
+    DPF_EVENT_REG_SIGNAL(signal_Item_Renamed)
 
     // hook
     DPF_EVENT_REG_HOOK(hook_View_ItemListFilter)

--- a/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.h
+++ b/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.h
@@ -33,6 +33,7 @@ public:
     void onMenuRequest(quint64 winId, const QUrl &url, bool triggerFromSidebar);
     void doRename(quint64 winId, const QUrl &url, const QString &name);
     void doSetAlias(DFMEntryFileInfoPointer info, const QString &alias);
+    bool doSetProtocolDeviceAlias(DFMEntryFileInfoPointer info, const QString &alias);
 
     void mountDevice(quint64 winId, const DFMEntryFileInfoPointer info, ActionAfterMount act = kEnterDirectory);
     void mountDevice(quint64 winId, const QString &id, const QString &shellId, ActionAfterMount act = kEnterDirectory);
@@ -51,7 +52,7 @@ public:
 
 Q_SIGNALS:
     void requestRename(quint64 winId, const QUrl &url);
-    void updateItemAlias(const QUrl &url);
+    void updateItemAlias(const QUrl &url, const QString &alias, bool isProtocol);
 
 private:
     explicit ComputerController(QObject *parent = nullptr);

--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -9,6 +9,7 @@
 
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/application/application.h>
+#include <dfm-base/base/device/devicealiasmanager.h>
 
 #include <DApplication>
 #include <DPaletteHelper>
@@ -129,9 +130,11 @@ QWidget *ComputerItemDelegate::createEditor(QWidget *parent, const QStyleOptionV
     editor->setTextMargins(0, topMargin, 0, 0);
     editor->setAlignment(Qt::AlignTop | Qt::AlignLeft);
 
-    QRegularExpression regx(kRegPattern);
-    QValidator *validator = new QRegularExpressionValidator(regx, editor);
-    editor->setValidator(validator);
+    if (!NPDeviceAliasManager::instance()->canSetAlias(index.data(ComputerModel::kRealUrlRole).toUrl())) {
+        QRegularExpression regx(kRegPattern);
+        QValidator *validator = new QRegularExpressionValidator(regx, editor);
+        editor->setValidator(validator);
+    }
 
     int maxLengthWhenRename = index.data(ComputerModel::kDeviceNameMaxLengthRole).toInt();
     connect(editor, &QLineEdit::textChanged, this, [maxLengthWhenRename, editor](const QString &text) {
@@ -166,7 +169,7 @@ void ComputerItemDelegate::setEditorData(QWidget *editor, const QModelIndex &ind
 {
     auto currEditor = qobject_cast<QLineEdit *>(editor);
     if (currEditor)
-        currEditor->setText(index.data(Qt::DisplayRole).toString());
+        currEditor->setText(index.data(ComputerModel::kEditDisplayTextRole).toString());
 }
 
 void ComputerItemDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const

--- a/src/plugins/filemanager/dfmplugin-computer/events/computereventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/events/computereventcaller.cpp
@@ -135,4 +135,9 @@ void ComputerEventCaller::sendErase(const QString &dev)
     dpfSlotChannel->push("dfmplugin_burn", "slot_Erase", dev);
 }
 
+void ComputerEventCaller::sendItemRenamed(const QUrl &url, const QString &name)
+{
+    dpfSignalDispatcher->publish(EventNameSpace::kComputerEventSpace, "signal_Item_Renamed", url, name);
+}
+
 }

--- a/src/plugins/filemanager/dfmplugin-computer/events/computereventcaller.h
+++ b/src/plugins/filemanager/dfmplugin-computer/events/computereventcaller.h
@@ -32,6 +32,7 @@ public:
     static void sendCtrlTOnItem(quint64 winId, const QUrl &url);
     static void sendShowPropertyDialog(const QList<QUrl> &urls);
     static void sendErase(const QString &dev);
+    static void sendItemRenamed(const QUrl &url, const QString &name);
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-computer/fileentity/protocolentryfileentity.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/fileentity/protocolentryfileentity.cpp
@@ -15,11 +15,13 @@
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/base/device/devicealiasmanager.h>
 
 #include <QRegularExpression>
 
 using namespace dfmplugin_computer;
 using namespace GlobalServerDefines;
+DFMBASE_USE_NAMESPACE
 
 /*!
  * \class ProtocolEntryFileEntity
@@ -39,13 +41,26 @@ ProtocolEntryFileEntity::ProtocolEntryFileEntity(const QUrl &url)
 QString ProtocolEntryFileEntity::displayName() const
 {
     QString displayName = datas.value(DeviceProperty::kDisplayName).toString();
+    const auto &alias = NPDeviceAliasManager::instance()->getAlias(targetUrl());
 
     QString host, share;
     bool isSmb = dfmbase::DeviceUtils::parseSmbInfo(displayName, host, share);
-    if (isSmb)
-        displayName = tr("%1 on %2").arg(share).arg(host);
+    if (isSmb) {
+        if (alias.isEmpty())
+            displayName = tr("%1 on %2").arg(share, host);
+        else
+            displayName = tr("%1 on %2").arg(share, alias);
+    } else if (order() == AbstractEntryFileEntity::kOrderFtp && !alias.isEmpty()) {
+        displayName.replace(targetUrl().host(), alias);
+    }
 
     return displayName;
+}
+
+QString ProtocolEntryFileEntity::editDisplayText() const
+{
+    const auto &alias = NPDeviceAliasManager::instance()->getAlias(targetUrl());
+    return alias.isEmpty() ? targetUrl().host() : alias;
 }
 
 QIcon ProtocolEntryFileEntity::icon() const
@@ -135,7 +150,11 @@ QUrl ProtocolEntryFileEntity::targetUrl() const
 
     target.setScheme(DFMBASE_NAMESPACE::Global::Scheme::kFile);
     target.setPath(mpt);
-    if (DFMBASE_NAMESPACE::ProtocolUtils::isSMBFile(target))
-        return DFMBASE_NAMESPACE::DeviceUtils::getSambaFileUriFromNative(target);
-    return target;
+    auto url = DeviceUtils::parseNetSourceUrl(target);
+    return url.isValid() ? url : target;
+}
+
+bool ProtocolEntryFileEntity::renamable() const
+{
+    return DFMBASE_NAMESPACE::NPDeviceAliasManager::instance()->canSetAlias(targetUrl());
 }

--- a/src/plugins/filemanager/dfmplugin-computer/fileentity/protocolentryfileentity.h
+++ b/src/plugins/filemanager/dfmplugin-computer/fileentity/protocolentryfileentity.h
@@ -19,6 +19,7 @@ public:
 
     // EntryFileEntity interface
     virtual QString displayName() const override;
+    virtual QString editDisplayText() const override;
     virtual QIcon icon() const override;
     virtual bool exists() const override;
     virtual bool showProgress() const override;
@@ -29,6 +30,9 @@ public:
     virtual quint64 sizeUsage() const override;
     virtual void refresh() override;
     virtual QUrl targetUrl() const override;
+    virtual bool renamable() const override;
+
+    QUrl netSourceUrl() const;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-computer/menu/computermenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/menu/computermenuscene.cpp
@@ -167,6 +167,9 @@ void ComputerMenuScene::updateState(QMenu *parent)
         if (d->info->targetUrl().isValid())
             keeped << kUnmount;
 
+        if (d->info->renamable())
+            keeped << kRename;
+
         auto id = d->info->extraProperty(DeviceProperty::kId).toString();
         if (id.contains(QRegularExpression("^smb|^ftp|^sftp|^dav")) || ProtocolUtils::isSMBFile(QUrl(id)))
             keeped << kLogoutAndForget;

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -179,6 +179,9 @@ QVariant ComputerModel::data(const QModelIndex &index, int role) const
     case kDisplayNameIsElidedRole:
         return item->isElided;
 
+    case kEditDisplayTextRole:
+        return item->info ? item->info->editDisplayText() : "";
+
     default:
         return {};
     }
@@ -257,6 +260,21 @@ int ComputerModel::findSplitter(const QString &group)
     if (iter != items.cend())
         return iter - items.cbegin();
     return -1;
+}
+
+ComputerItemData ComputerModel::findItemData(const QUrl &target)
+{
+    auto iter = std::find_if(items.cbegin(), items.cend(), [=](const ComputerItemData &item) {
+        return UniversalUtils::urlEquals(item.url, target);
+    });
+    if (iter != items.cend())
+        return *iter;
+    return {};
+}
+
+const QList<ComputerItemData> &ComputerModel::itemList()
+{
+    return items;
 }
 
 void ComputerModel::initConnect()

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.h
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.h
@@ -43,7 +43,8 @@ public:
         kActionListRole,   // return the action list that item should have
         kItemIsEditingRole,   // bool: if an item is renaming
         kDeviceDescriptionRole,
-        kDisplayNameIsElidedRole // bool
+        kDisplayNameIsElidedRole,   // bool
+        kEditDisplayTextRole   // string
     };
     Q_ENUM(DataRoles)
 
@@ -61,6 +62,8 @@ protected:
     int findItem(const QUrl &target);
     int findItemByClearDeviceId(const QString &id);
     int findSplitter(const QString &group);
+    ComputerItemData findItemData(const QUrl &target);
+    const QList<ComputerItemData> &itemList();
 
     void initConnect();
 

--- a/src/plugins/filemanager/dfmplugin-computer/views/computerview.h
+++ b/src/plugins/filemanager/dfmplugin-computer/views/computerview.h
@@ -68,6 +68,7 @@ private Q_SLOTS:
     void cdTo(const QModelIndex &index);
     void onMenuRequest(const QPoint &pos);
     void onRenameRequest(quint64 winId, const QUrl &url);
+    void onUpdateItemAlias(const QUrl &url, const QString &alias, bool isProtocol);
     void handleDisksVisible();
     void handleUserDirVisible();
     void handle3rdEntriesVisible();

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -763,6 +763,7 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
         { "Property_Key_Group", visableKey == kItemVisiableControlKeys[3] ? "Group_Network" : "Group_Device" },
         { "Property_Key_SubGroup", subGroup },
         { "Property_Key_DisplayName", info->displayName() },
+        { "Property_Key_EditDisplayText", info->editDisplayText() },
         { "Property_Key_Icon", QIcon::fromTheme(iconName) },
         { "Property_Key_FinalUrl", findFinalUrl(info) },
         { "Property_Key_QtItemFlags", QVariant::fromValue(flags) },
@@ -773,7 +774,8 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
         { "Property_Key_CallbackFindMe", QVariant::fromValue(findMeCb) },
         { "Property_Key_VisiableControl", visableKey },
         { "Property_Key_VisiableDisplayName", visableName },
-        { "Property_Key_ReportName", reportName }
+        { "Property_Key_ReportName", reportName },
+        { "Property_Key_Editable", info->renamable() }
     };
 }
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/dfmplugin_sidebar_global.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/dfmplugin_sidebar_global.h
@@ -46,6 +46,9 @@ inline constexpr char kSubGroup[] { "Property_Key_SubGroup" };
 // value is string, as display
 inline constexpr char kDisplayName[] { "Property_Key_DisplayName" };
 
+// value is string, for edit display
+inline constexpr char kEditDisplayText[] { "Property_Key_EditDisplayText" };
+
 // value is QIcon, as display
 inline constexpr char kIcon[] { "Property_Key_Icon" };
 
@@ -100,6 +103,7 @@ struct ItemInfo
     QString group;
     QString subGroup;
     QString displayName;
+    QString editDisplayText;
     QIcon icon;
     QUrl finalUrl;
     Qt::ItemFlags flags;
@@ -120,6 +124,7 @@ struct ItemInfo
           group { map[PropertyKey::kGroup].toString() },
           subGroup { map[PropertyKey::kSubGroup].toString() },
           displayName { map[PropertyKey::kDisplayName].toString() },
+          editDisplayText { map[PropertyKey::kEditDisplayText].toString() },
           icon { qvariant_cast<QIcon>(map[PropertyKey::kIcon]) },
           finalUrl { map[PropertyKey::kFinalUrl].toUrl() },
           flags { qvariant_cast<Qt::ItemFlags>(map[PropertyKey::kQtItemFlags]) },

--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -75,8 +75,9 @@ bool SideBarEventReceiver::handleItemAdd(const QUrl &url, const QVariantMap &pro
     // TODO(zhangs): use model direct
     ItemInfo info { url, properties };
     if (SideBarInfoCacheMananger::instance()->contains(info)) {
-        fmInfo() << "item already added to sidebar." << url;
-        return false;
+        fmInfo() << "item already added to sidebar, update it." << url;
+        handleItemUpdate(url, properties);
+        return true;
     }
 
     SideBarItem *item = SideBarHelper::createItemByInfo(info);
@@ -158,6 +159,8 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
         info.subGroup = properties[PropertyKey::kSubGroup].toString();
     if (properties.contains(PropertyKey::kDisplayName))
         info.displayName = properties[PropertyKey::kDisplayName].toString();
+    if (properties.contains(PropertyKey::kEditDisplayText))
+        info.editDisplayText = properties[PropertyKey::kEditDisplayText].toString();
     if (properties.contains(PropertyKey::kIcon))
         info.icon = qvariant_cast<QIcon>(properties[PropertyKey::kIcon]);
     if (properties.contains(PropertyKey::kFinalUrl))

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -14,6 +14,7 @@
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/dbusservice/global_server_defines.h>
 #include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/base/device/devicealiasmanager.h>
 
 #ifdef DTKWIDGET_CLASS_DSizeMode
 #    include <DSizeMode>
@@ -268,24 +269,34 @@ QWidget *SideBarItemDelegate::createEditor(QWidget *parent, const QStyleOptionVi
     SideBarItem *tgItem = sidebarModel->itemFromIndex(index);
     if (!tgItem)
         return nullptr;
-    auto sourceInfo = InfoFactory::create<FileInfo>(tgItem->url(), Global::CreateFileInfoType::kCreateFileInfoSync);
-    if (!sourceInfo)
-        return nullptr;
-    if (!sourceInfo->exists())
-        return nullptr;
     QWidget *editor = DStyledItemDelegate::createEditor(parent, option, index);
     QLineEdit *qle = nullptr;
     if ((qle = dynamic_cast<QLineEdit *>(editor))) {
-        QRegularExpression regx(GlobalPrivate::kRegPattern);
-        QValidator *validator = new QRegularExpressionValidator(regx, qle);
-        qle->setValidator(validator);
+        if (!NPDeviceAliasManager::instance()->canSetAlias(tgItem->targetUrl())) {
+            QRegularExpression regx(GlobalPrivate::kRegPattern);
+            QValidator *validator = new QRegularExpressionValidator(regx, qle);
+            qle->setValidator(validator);
+        }
 
-        connect(qle, &QLineEdit::textChanged, this, [this, sourceInfo](const QString &text) {
-            onEditorTextChanged(text, sourceInfo);
+        connect(qle, &QLineEdit::textChanged, this, [this, tgItem](const QString &text) {
+            onEditorTextChanged(text, tgItem);
         });
     }
 
     return editor;
+}
+
+void SideBarItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
+{
+    auto currEditor = qobject_cast<QLineEdit *>(editor);
+    if (currEditor && index.isValid()) {
+        DStandardItem *item = qobject_cast<const SideBarModel *>(index.model())->itemFromIndex(index);
+        SideBarItem *sidebarItem = static_cast<SideBarItem *>(item);
+        if (sidebarItem) {
+            const auto &info = sidebarItem->itemInfo();
+            currEditor->setText(info.editDisplayText.isEmpty() ? info.displayName : info.editDisplayText);
+        }
+    }
 }
 
 void SideBarItemDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -353,24 +364,28 @@ bool SideBarItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, 
     return QStyledItemDelegate::editorEvent(event, model, option, index);
 }
 
-void SideBarItemDelegate::onEditorTextChanged(const QString &text, const FileInfoPointer &info) const
+void SideBarItemDelegate::onEditorTextChanged(const QString &text, SideBarItem *item) const
 {
     QLineEdit *editor = qobject_cast<QLineEdit *>(sender());
     if (!editor)
         return;
 
-    int maxLen = INT_MAX;
+    int maxLen = 40;
     bool useCharCount = false;
-    const QString &fs = info->extraProperties()[GlobalServerDefines::DeviceProperty::kFileSystem].toString();
-    if (fs.isEmpty()) {
-        const auto &url = info->urlOf(FileInfo::FileUrlInfoType::kUrl);
-        if (url.isLocalFile()) {
-            maxLen = NAME_MAX;
-            const auto &path = url.path();
-            useCharCount = path.isEmpty() ? false : FileUtils::supportLongName(url);
+
+    auto info = InfoFactory::create<FileInfo>(item->url(), Global::CreateFileInfoType::kCreateFileInfoSync);
+    if (info && info->exists()) {
+        const QString &fs = info->extraProperties()[GlobalServerDefines::DeviceProperty::kFileSystem].toString();
+        if (fs.isEmpty()) {
+            const auto &url = info->urlOf(FileInfo::FileUrlInfoType::kUrl);
+            if (url.isLocalFile()) {
+                maxLen = NAME_MAX;
+                const auto &path = url.path();
+                useCharCount = path.isEmpty() ? false : FileUtils::supportLongName(url);
+            }
+        } else {
+            maxLen = FileUtils::supportedMaxLength(fs);
         }
-    } else {
-        maxLen = FileUtils::supportedMaxLength(fs);
     }
 
     QString dstText = text;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -15,6 +15,7 @@ DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 DPSIDEBAR_BEGIN_NAMESPACE
 
+class SideBarItem;
 class SideBarItemDelegate : public DStyledItemDelegate
 {
     Q_OBJECT
@@ -29,6 +30,7 @@ public:
     QWidget *createEditor(QWidget *parent,
                           const QStyleOptionViewItem &option,
                           const QModelIndex &index) const override;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
     void updateEditorGeometry(QWidget *editor,
                               const QStyleOptionViewItem &option,
                               const QModelIndex &index) const override;
@@ -37,7 +39,7 @@ public:
     bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 
 public Q_SLOTS:
-    void onEditorTextChanged(const QString &text, const FileInfoPointer &info) const;
+    void onEditorTextChanged(const QString &text, SideBarItem *item) const;
 
 private:
     void drawIcon(const QStyleOptionViewItem &option, QPainter *painter, const QModelIndex &index,

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/info/protocolvirtualentryentity.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/info/protocolvirtualentryentity.h
@@ -23,6 +23,7 @@ public:
 
     // AbstractEntryFileEntity interface
     virtual QString displayName() const override;
+    virtual QString editDisplayText() const override;
     virtual QIcon icon() const override;
     virtual bool exists() const override;
     virtual bool showProgress() const override;
@@ -30,6 +31,7 @@ public:
     virtual bool showUsageSize() const override;
     virtual dfmbase::AbstractEntryFileEntity::EntryOrder order() const override;
     virtual QUrl targetUrl() const override;
+    virtual bool renamable() const override;
 };
 
 DPSMBBROWSER_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/menu/virtualentrymenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/menu/virtualentrymenuscene.cpp
@@ -35,6 +35,7 @@ static constexpr char kAggregatedForgetUnmountAll[] { "aggregated-forget" };
 // computer's actions
 static constexpr char kCptActMount[] { "computer-mount" };
 static constexpr char kCptActLogoutAndForget[] { "computer-logout-and-forget-passwd" };
+static constexpr char kCptActRename[] { "computer-rename" };
 static constexpr char kCptActProperty[] { "computer-property" };
 
 // static constexpr char kCptActOpen[] { "computer-open" };
@@ -143,9 +144,9 @@ void VirtualEntryMenuScene::updateState(QMenu *parent)
     QStringList visibleActions;
     if (d->aggregatedEntrySelected)
         visibleActions << kAggregatedUnmountAll << kAggregatedForgetUnmountAll
-                       << kVirtualEntryRemove;
+                       << kVirtualEntryRemove << kCptActRename;
     else if (d->seperatedEntrySelected)
-        visibleActions << kCptActMount << kVirtualEntryRemove << kCptActProperty;
+        visibleActions << kCptActMount << kVirtualEntryRemove << kCptActRename << kCptActProperty;
 
     if (!visibleActions.isEmpty())
         d->setActionVisible(visibleActions, parent);

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/protocoldevicedisplaymanager.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/protocoldevicedisplaymanager.h
@@ -29,6 +29,7 @@ public:
     // hook computer event
     bool hookItemInsert(const QUrl &entryUrl);
     bool hookItemsFilter(QList<QUrl> *entryUrls);
+    void handleItemRenamed(const QUrl &entryUrl, const QString &name);
 
 protected Q_SLOTS:
     void onDevMounted(const QString &id, const QString &mpt);

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.h
@@ -36,6 +36,7 @@ void callForgetPasswd(const QString &stdSmb);
 
 void sidebarMenuCall(quint64 winId, const QUrl &url, const QPoint &pos);
 void sidebarItemClicked(quint64 winId, const QUrl &url);
+void sidebarItemRename(quint64 windowId, const QUrl &url, const QString &name);
 bool sidebarUrlEquals(const QUrl &item, const QUrl &target);
 
 }   // namespace computer_sidebar_event_calls

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/typedefines.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/typedefines.h
@@ -42,5 +42,7 @@ using ItemClickedActionCallback = std::function<void(quint64 windowId, const QUr
 Q_DECLARE_METATYPE(ItemClickedActionCallback);
 using FindMeCallback = std::function<bool(const QUrl &itemUrl, const QUrl &targetUrl)>;
 Q_DECLARE_METATYPE(FindMeCallback);
+using RenameCallback = std::function<void(quint64 windowId, const QUrl &url, const QString &name)>;
+Q_DECLARE_METATYPE(RenameCallback);
 
 #endif   // TYPEDEFINES_H

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.cpp
@@ -189,3 +189,13 @@ void TitleBarEventReceiver::handleOpenNewTabTriggered(quint64 windowId, const QU
     fmDebug() << "Opening new tab for window id:" << windowId << "URL:" << url.toString();
     w->openNewTab(url);
 }
+
+void TitleBarEventReceiver::handleUpdateCrumb(const QUrl &url)
+{
+    auto titlebarWidges = TitleBarHelper::titlebars();
+    for (auto w : titlebarWidges) {
+        auto crumbBar = w->titleCrumbBar();
+        if (crumbBar)
+            crumbBar->onUrlChanged(crumbBar->lastUrl());
+    }
+}

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventreceiver.h
@@ -38,6 +38,7 @@ public slots:
     void handleCloseTabs(const QUrl &url);
     void handleSetTabAlias(const QUrl &url, const QString &name);
     void handleOpenNewTabTriggered(quint64 windowId, const QUrl &url);
+    void handleUpdateCrumb(const QUrl &url);
 
 private:
     explicit TitleBarEventReceiver(QObject *parent = nullptr);

--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
@@ -131,6 +131,8 @@ void TitleBar::bindEvents()
                             TitleBarEventReceiver::instance(), &TitleBarEventReceiver::handleCloseTabs);
     dpfSlotChannel->connect(curSpace, "slot_Tab_SetAlias",
                             TitleBarEventReceiver::instance(), &TitleBarEventReceiver::handleSetTabAlias);
+    dpfSlotChannel->connect(curSpace, "slot_Crumb_Update",
+                            TitleBarEventReceiver::instance(), &TitleBarEventReceiver::handleUpdateCrumb);
 }
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.h
@@ -41,6 +41,7 @@ class TitleBar : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_Tab_Addable)
     DPF_EVENT_REG_SLOT(slot_Tab_Close)
     DPF_EVENT_REG_SLOT(slot_Tab_SetAlias)
+    DPF_EVENT_REG_SLOT(slot_Crumb_Update)
 
     // hook events
     DPF_EVENT_REG_HOOK(hook_Crumb_Seprate)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -78,6 +78,11 @@ TabBar *TitleBarWidget::tabBar() const
     return bottomBar;
 }
 
+CrumbBar *TitleBarWidget::titleCrumbBar() const
+{
+    return crumbBar;
+}
+
 void TitleBarWidget::openNewTab(const QUrl &url)
 {
     if (!tabBar()->tabAddable()) {

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -34,6 +34,7 @@ public:
     NavWidget *navWidget() const;
     DTitlebar *titleBar() const;
     TabBar *tabBar() const;
+    CrumbBar *titleCrumbBar() const;
     void openNewTab(const QUrl &url);
 
     void showSearchFilterButton(bool visible);


### PR DESCRIPTION
- Added NPDeviceAliasManager for managing aliases of network protocol devices (smb, ftp, sftp).
- Integrated alias functionality into the file manager, allowing users to set and retrieve aliases for network devices.
- Updated display names in the file manager to reflect aliases where applicable.
- Enhanced user experience by allowing renaming of protocol devices and updating the sidebar accordingly.

Log: This feature improves the usability of network protocol devices in the file manager.
Task: https://pms.uniontech.com/story-view-39191.html
