### PR TITLE
chore: bump version to 6.5.88

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-file-manager (6.5.88) unstable; urgency=medium
+
+  * fix bugs
+  * new strategy for file copy
+  * new features
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 21 Aug 2025 21:39:30 +0800
+
 dde-file-manager (6.5.87) unstable; urgency=medium
 
   * fix bugs 


### PR DESCRIPTION
6.5.88

Log:

## Summary by Sourcery

Chores:
- Update version number in debian/changelog to 6.5.88