### PR TITLE
fix: remove pending URL handling in EmblemHelper

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
@@ -356,7 +356,6 @@ void FilePreviewDialog::switchToPage(int index)
                 int newPerviewHeight = preview->contentWidget()->size().height();
                 setFixedSize(newPerviewWidth, newPerviewHeight + statusBar->height());
                 playCurrentPreviewFile();
-                moveToCenter();
                 qCInfo(logLibFilePreview) << "FilePreviewDialog: successfully reused preview for file:" << fileList.at(index).toString();
                 return;
             }
@@ -428,7 +427,6 @@ void FilePreviewDialog::switchToPage(int index)
     int newPerviewHeight = preview->contentWidget()->size().height();
     setFixedSize(newPerviewWidth, newPerviewHeight + statusBar->height());
     updateTitle();
-    moveToCenter();
     
     qCInfo(logLibFilePreview) << "FilePreviewDialog: successfully switched to page" << index << "for file:" << fileList.at(index).toString();
 }

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -271,13 +271,6 @@ void EmblemHelper::pending(const FileInfoPointer &info)
     if (!info)
         return;
     
-    const QUrl &url = info->urlOf(UrlInfoType::kUrl);
-    
-    // 避免重复请求同一个URL
-    if (pendingUrls.contains(url))
-        return;
-        
-    pendingUrls.insert(url);
     emit requestProduce(info);
 }
 
@@ -302,9 +295,6 @@ bool EmblemHelper::isExtEmblemProhibited(const FileInfoPointer &info, const QUrl
 
 void EmblemHelper::onEmblemChanged(const QUrl &url, const Product &product)
 {
-    // 从pending集合中移除已处理的URL
-    pendingUrls.remove(url);
-    
     productQueue[url] = product;
     if (product.isEmpty())
         return;
@@ -321,7 +311,6 @@ bool EmblemHelper::onUrlChanged(quint64 windowId, const QUrl &url)
     Q_UNUSED(url);
 
     clearEmblem();
-    pendingUrls.clear();  // 清空pending请求缓存
     emit requestClear();
 
     return false;

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.h
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.h
@@ -76,7 +76,6 @@ private:
     GioEmblemWorker *worker { new GioEmblemWorker };
     ProductQueue productQueue;
     QThread workerThread;
-    QSet<QUrl> pendingUrls;  // 添加pending请求缓存
 };
 
 DPEMBLEM_END_NAMESPACE


### PR DESCRIPTION
- Eliminated the pending URL cache from EmblemHelper, simplifying the request handling logic.
- Removed unnecessary checks and operations related to pending URLs, enhancing code clarity and maintainability.

Log: This change streamlines the emblem processing workflow by focusing on direct requests without caching.
Bug: https://pms.uniontech.com/bug-view-327231.html

## Summary by Sourcery

Remove the pending URL cache and related logic from EmblemHelper to streamline emblem processing workflow

Bug Fixes:
- Eliminate stale pending URL handling to address bug #327231

Enhancements:
- Simplify request handling by removing the pendingUrls set and its associated checks and operations