### PR TITLE
fix bugs

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
@@ -171,7 +171,10 @@ DoCleanTrashFilesWorker::doHandleErrorAndWait(const QUrl &from,
 {
     setStat(AbstractJobHandler::JobState::kPauseState);
     emitErrorNotify(from, QUrl(), error, isTo, 0, errorMsg);
-    waitCondition.wait(&mutex);
+    {
+        QMutexLocker locker(&mutex);
+        waitCondition.wait(&mutex);
+    }
 
     return currentAction;
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
@@ -67,9 +67,6 @@ bool DoCopyFilesWorker::doWork()
         return false;
     }
 
-    // sync
-    syncFilesToDevice();
-
     // end
     fmInfo() << "Copy operation completed successfully";
     endWork();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -16,7 +16,6 @@
 #include <QStorageInfo>
 #include <QQueue>
 
-
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/stat.h>
@@ -49,9 +48,6 @@ bool DoCutFilesWorker::doWork()
         endWork();
         return false;
     }
-
-    // sync
-    syncFilesToDevice();
 
     // 完成
     fmInfo() << "Cut operation completed successfully";

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -296,7 +296,10 @@ DoDeleteFilesWorker::doHandleErrorAndWait(const QUrl &from,
     setStat(AbstractJobHandler::JobState::kPauseState);
     emitErrorNotify(from, QUrl(), error, false, 0, errorMsg);
 
-    waitCondition.wait(&mutex);
+    {
+        QMutexLocker locker(&mutex);
+        waitCondition.wait(&mutex);
+    }
 
     fmDebug() << "Error handling completed - action:" << static_cast<int>(currentAction);
     return currentAction;

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -269,11 +269,12 @@ bool AbstractWorker::statisticsFilesSize()
     return true;
 }
 /*!
- * \brief AbstractWorker::copyWait Blocking waiting for task
+ * \brief AbstractWorker::workerWait Blocking waiting for task
  * \return Is it running
  */
 bool AbstractWorker::workerWait()
 {
+    QMutexLocker locker(&mutex);
     waitCondition.wait(&mutex);
 
     return currentState == AbstractJobHandler::JobState::kRunningState;
@@ -670,6 +671,9 @@ void AbstractWorker::saveOperations()
 
 AbstractWorker::~AbstractWorker()
 {
+    // Ensure all waiting threads are woken up before destruction
+    waitCondition.wakeAll();
+
     if (statisticsFilesSizeJob) {
         statisticsFilesSizeJob->stop();
         statisticsFilesSizeJob->wait();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -102,6 +102,11 @@ void AbstractWorker::doOperateWork(AbstractJobHandler::SupportActions actions, A
  */
 void AbstractWorker::stop()
 {
+    // Perform sync before stopping if needed for external devices
+    if (needsSyncBeforeStop()) {
+        performSyncBeforeStop();
+    }
+
     setStat(AbstractJobHandler::JobState::kStopState);
     if (statisticsFilesSizeJob)
         statisticsFilesSizeJob->stop();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -88,13 +88,6 @@ void AbstractWorker::doOperateWork(AbstractJobHandler::SupportActions actions, A
     if (id == quintptr(this)) {
         return resume();
     }
-
-    for (auto worker : threadCopyWorker) {
-        if (id == quintptr(worker.data())) {
-            worker->operateAction(currentAction);
-            return;
-        }
-    }
 }
 
 /*!
@@ -458,20 +451,12 @@ void AbstractWorker::resumeAllThread()
     resume();
     if (copyOtherFileWorker)
         copyOtherFileWorker->resume();
-    for (auto worker : threadCopyWorker) {
-        worker->resume();
-    }
 }
 
 void AbstractWorker::resumeThread(const QList<quint64> &errorIds)
 {
     if (!errorIds.contains(quintptr(this)) && (!copyOtherFileWorker || !errorIds.contains(quintptr(copyOtherFileWorker.data()))))
         resume();
-
-    for (auto worker : threadCopyWorker) {
-        if (!errorIds.contains(quintptr(worker.data())))
-            worker->resume();
-    }
 }
 
 void AbstractWorker::pauseAllThread()
@@ -479,18 +464,12 @@ void AbstractWorker::pauseAllThread()
     pause();
     if (copyOtherFileWorker)
         copyOtherFileWorker->pause();
-    for (auto worker : threadCopyWorker) {
-        worker->pause();
-    }
 }
 
 void AbstractWorker::stopAllThread()
 {
     if (copyOtherFileWorker)
         copyOtherFileWorker->stop();
-    for (auto worker : threadCopyWorker) {
-        worker->stop();
-    }
     stop();
 }
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -120,8 +120,8 @@ protected:
                                  const bool allUsErrorMsg = false);
 
     // Sync before stop for external devices
-    virtual bool needsSyncBeforeStop() const { return false; }
-    virtual void performSyncBeforeStop() { }
+    virtual bool needsSync() const { return false; }
+    virtual void performSync() { }
 
 protected slots:
     virtual bool doWork();
@@ -147,6 +147,8 @@ protected:
     void resume();
     void getAction(AbstractJobHandler::SupportActions actions);
     QUrl parentUrl(const QUrl &url);
+    void syncFilesToDevice();
+
     static dfmbase::FileInfo::FileType fileType(const DFileInfoPointer &info);
 
 public:

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -118,6 +118,10 @@ protected:
     virtual void emitErrorNotify(const QUrl &from, const QUrl &to, const AbstractJobHandler::JobErrorType &error,
                                  const bool isTo = false, const quint64 id = 0, const QString &errorMsg = QString(),
                                  const bool allUsErrorMsg = false);
+    
+    // Sync before stop for external devices
+    virtual bool needsSyncBeforeStop() const { return false; }
+    virtual void performSyncBeforeStop() {}
 
 protected slots:
     virtual bool doWork();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -118,10 +118,10 @@ protected:
     virtual void emitErrorNotify(const QUrl &from, const QUrl &to, const AbstractJobHandler::JobErrorType &error,
                                  const bool isTo = false, const quint64 id = 0, const QString &errorMsg = QString(),
                                  const bool allUsErrorMsg = false);
-    
+
     // Sync before stop for external devices
     virtual bool needsSyncBeforeStop() const { return false; }
-    virtual void performSyncBeforeStop() {}
+    virtual void performSyncBeforeStop() { }
 
 protected slots:
     virtual bool doWork();
@@ -188,7 +188,6 @@ public:
 
     QWaitCondition waitCondition;
     QMutex mutex;
-    QVector<QSharedPointer<DoCopyFileWorker>> threadCopyWorker;
     int threadCount { 8 };
     std::atomic_bool retry { false };
     QSharedPointer<QThreadPool> threadPool { nullptr };

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -91,8 +91,6 @@ signals:
     void requestShowTipsDialog(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType type, const QList<QUrl> &list);
     void workerFinish();
     void requestSaveRedoOperation(const QString &token, const qint64 deleteFirstFileSize);
-signals:   // update proccess timer use
-    void startUpdateProgressTimer();
     void startWork();
     void errorNotify(const JobInfoPointer jobInfo);
     void retryErrSuccess(const quint64 id);
@@ -152,7 +150,6 @@ public:
 
 public:
     QSharedPointer<DFMBASE_NAMESPACE::FileStatisticsJob> statisticsFilesSizeJob { nullptr };   // statistics file info async
-    QSharedPointer<QThread> updateProgressThread { nullptr };   // update progress timer thread
     QSharedPointer<UpdateProgressTimer> updateProgressTimer { nullptr };   // update progress timer
 
     JobHandlePointer handle { nullptr };   // handle

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -318,6 +318,8 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFileWithDirectIO(const DFileInf
         while (bytesWritten < actualBytesToWrite && !isStopped()) {
             ssize_t written = write(writer.fd, buffer + bytesWritten,
                                     actualBytesToWrite - bytesWritten);
+            // TODO (io): direct is ineffective if use mounted by fuse
+            // fdatasync(writer.fd);
             if (written < 0) {
                 if (errno == EINTR) {
                     continue;
@@ -1136,6 +1138,7 @@ bool DoCopyFileWorker::handlePauseResume(FileWriter &writer, const QString &dest
 {
     // Sync data before pausing
     if (writer.fd >= 0) {
+        // TODO (io): sync data
         // Determine target filesystem type for appropriate sync strategy
         // QUrl destUrl = QUrl::fromLocalFile(dest);
         // QString targetFsType = dfmio::DFMUtils::fsTypeFromUrl(destUrl);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -318,8 +318,7 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFileWithDirectIO(const DFileInf
         while (bytesWritten < actualBytesToWrite && !isStopped()) {
             ssize_t written = write(writer.fd, buffer + bytesWritten,
                                     actualBytesToWrite - bytesWritten);
-            // TODO (io): direct is ineffective if use mounted by fuse
-            // fdatasync(writer.fd);
+
             if (written < 0) {
                 if (errno == EINTR) {
                     continue;

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -40,6 +40,10 @@ DoCopyFileWorker::DoCopyFileWorker(const QSharedPointer<WorkerData> &data, QObje
 
 DoCopyFileWorker::~DoCopyFileWorker()
 {
+    // Ensure all waiting threads are woken up before destruction
+    if (waitCondition) {
+        waitCondition->wakeAll();
+    }
 }
 // main thread using
 void DoCopyFileWorker::pause()
@@ -549,8 +553,8 @@ bool DoCopyFileWorker::stateCheck()
 
 void DoCopyFileWorker::workerWait()
 {
+    QMutexLocker locker(mutex.data());
     waitCondition->wait(mutex.data());
-    mutex->unlock();
 }
 
 bool DoCopyFileWorker::actionOperating(const AbstractJobHandler::SupportAction action, const qint64 size, bool *skip)

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -1003,13 +1003,6 @@ void FileOperateBaseWorker::emitCurrentTaskNotify(const QUrl &from, const QUrl &
     AbstractWorker::emitCurrentTaskNotify(from, to);
 }
 
-void FileOperateBaseWorker::skipMemcpyBigFile(const QUrl url)
-{
-    for (const auto &worker : threadCopyWorker) {
-        worker->skipMemcpyBigFile(url);
-    }
-}
-
 QVariant FileOperateBaseWorker::checkLinkAndSameUrl(const DFileInfoPointer &fromInfo,
                                                     const DFileInfoPointer &newTargetInfo,
                                                     const bool isCountSize)

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -70,7 +70,10 @@ AbstractJobHandler::SupportAction FileOperateBaseWorker::doHandleErrorAndWait(co
     // 发送错误处理 阻塞自己
     emitErrorNotify(urlFrom, urlTo, error, isTo, quintptr(this), errorMsg, errorMsgAll);
     pause();
-    waitCondition.wait(&mutex);
+    {
+        QMutexLocker locker(&mutex);
+        waitCondition.wait(&mutex);
+    }
     if (isStopped())
         return AbstractJobHandler::SupportAction::kCancelAction;
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -58,7 +58,6 @@ public:
     qint64 getTidWriteSize();
     qint64 getSectorsWritten();
     void readAheadSourceFile(const DFileInfoPointer &fileInfo);
-    void syncFilesToDevice();
     AbstractJobHandler::SupportAction doHandleErrorAndWait(const QUrl &from, const QUrl &to,
                                                            const AbstractJobHandler::JobErrorType &error,
                                                            const bool isTo = false,
@@ -68,8 +67,8 @@ public:
     void emitSpeedUpdatedNotify(const qint64 &writSize);
 
     // Sync before stop overrides
-    bool needsSyncBeforeStop() const override;
-    void performSyncBeforeStop() override;
+    bool needsSync() const override;
+    void performSync() override;
 
     bool deleteFile(const QUrl &fromUrl, const QUrl &toUrl, bool *result, const bool force = false);
     bool deleteDir(const QUrl &fromUrl, const QUrl &toUrl, bool *result, const bool force = false);
@@ -129,7 +128,6 @@ protected:
     DirPermissonList dirPermissonList;   // dir set Permisson list
     QFuture<void> syncResult;
     QString blocakTargetRootPath;
-    QList<QUrl> syncFiles;
 
     QList<DFileInfoPointer> cutAndDeleteFiles;
 };

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -106,7 +106,6 @@ protected Q_SLOTS:
                          const bool isTo = false, const quint64 id = 0, const QString &errorMsg = QString(),
                          const bool allUsErrorMsg = false) override;
     virtual void emitCurrentTaskNotify(const QUrl &from, const QUrl &to) override;
-    void skipMemcpyBigFile(const QUrl url);
 
 private:
     QVariant

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -67,6 +67,10 @@ public:
     // notify
     void emitSpeedUpdatedNotify(const qint64 &writSize);
 
+    // Sync before stop overrides
+    bool needsSyncBeforeStop() const override;
+    void performSyncBeforeStop() override;
+
     bool deleteFile(const QUrl &fromUrl, const QUrl &toUrl, bool *result, const bool force = false);
     bool deleteDir(const QUrl &fromUrl, const QUrl &toUrl, bool *result, const bool force = false);
     bool copyFileFromTrash(const QUrl &urlSource, const QUrl &urlTarget, dfmio::DFile::CopyFlag flag);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -27,12 +27,10 @@ extern "C" {
 DPFILEOPERATIONS_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 
-QSet<QString> FileOperationsUtils::fileNameUsing = {};
 inline constexpr char kFileOperations[] { "org.deepin.dde.file-manager.operations" };
 inline constexpr char kFileBigSize[] { "file.operation.bigfilesize" };
 inline constexpr char kBlockEverySync[] { "file.operation.blockeverysync" };
 inline constexpr char kBroadcastPaste[] { "file.operation.broadcastpastevent" };
-QMutex FileOperationsUtils::mutex;
 
 /*!
  * \brief FileOperationsUtils::statisticsFilesSize 使用c库统计文件大小
@@ -185,4 +183,3 @@ bool FileOperationsUtils::canBroadcastPaste()
     // 组策略中配置
     return DConfigManager::instance()->value(kFileOperations, kBroadcastPaste, false).toBool();
 }
-

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -20,21 +20,15 @@ class UpdateProgressTimer : public QObject
     friend class AbstractWorker;
     friend class DoCopyFilesWorker;
     explicit UpdateProgressTimer(QObject *parent = nullptr)
-        : QObject(parent) {}
+        : QObject(parent) { }
+
+signals:
+    void updateProgressNotify();
+
+public slots:
     void stopTimer()
     {
         isStop = true;
-    }
-signals:
-    void updateProgressNotify();
-private slots:
-    void handleTimeOut()
-    {
-        if (Q_UNLIKELY(isStop)) {
-            timer->stop();
-        } else {
-            emit updateProgressNotify();
-        }
     }
 
     void doStartTime()
@@ -43,6 +37,16 @@ private slots:
             timer = new QTimer(this);
         connect(timer, &QTimer::timeout, this, &UpdateProgressTimer::handleTimeOut, Qt::ConnectionType(Qt::DirectConnection | Qt::UniqueConnection));
         timer->start(500);
+    }
+
+private slots:
+    void handleTimeOut()
+    {
+        if (Q_UNLIKELY(isStop)) {
+            timer->stop();
+        } else {
+            emit updateProgressNotify();
+        }
     }
 
 private:
@@ -71,10 +75,6 @@ private:
     static bool blockSync();
     static QUrl parentUrl(const QUrl &url);
     static bool canBroadcastPaste();
-
-private:
-    static QSet<QString> fileNameUsing;
-    static QMutex mutex;
 };
 DPFILEOPERATIONS_END_NAMESPACE
 


### PR DESCRIPTION
## Summary by Sourcery

Fix thread-safety and cross-thread timer issues in the file operations plugin, simplify worker threading logic, add robust external device sync, and improve child process handling in burn jobs.

Bug Fixes:
- Guard waitCondition.wait() calls with QMutexLocker in multiple workers to prevent deadlocks.
- Use QMetaObject::invokeMethod to stop and start the progress timer across threads instead of direct calls.
- Properly wait for and log child process exit status in burnjob to avoid zombie processes.

Enhancements:
- Remove per-worker threadCopyWorker loops and eliminate dedicated updateProgressThread by running UpdateProgressTimer in the main thread.
- Introduce AbstractWorker.syncFilesToDevice with needsSync/performSync hooks and implement single syncfs call in FileOperateBaseWorker for external devices.
- Refactor UpdateProgressTimer by consolidating signals/slots and removing duplicate methods.
- Clean up unused static members and redundant sync calls in file operations utilities and workers.