### PR TITLE
fix: Optimized translations (ja and lo)

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/polkit/com.deepin.filemanager.vault.policy
+++ b/src/plugins/filemanager/dfmplugin-vault/polkit/com.deepin.filemanager.vault.policy
@@ -11,6 +11,8 @@
     <message xml:lang="zh_CN">创建文件保险箱需要认证</message>
     <message xml:lang="zh_HK">創建文件保險箱需要認證</message>
     <message xml:lang="zh_TW">創建文件保險箱需要認證</message>
+    <message xml:lang="lo">ການຢືນຢັນຕ້ອງການເພື່ອສ້າງກະຕຸກເອກະສານ</message>
+    <message xml:lang="ja">ファイルボールトを作成するには認証が必要です</message>
     <icon_name>dde-file-manager</icon_name>
     <defaults>
       <allow_any>no</allow_any>
@@ -24,6 +26,8 @@
     <message xml:lang="zh_CN">删除文件保险箱需要认证</message>
     <message xml:lang="zh_HK">刪除文件保險箱需要認證</message>
     <message xml:lang="zh_TW">刪除文件保險箱需要認證</message>
+    <message xml:lang="lo">ການຢືນຢັນຕ້ອງການເພື່ອລຶບກະຕຸກເອກະສານ</message>
+    <message xml:lang="ja">ファイルボールトを削除するには認証が必要です</message>
     <icon_name>dde-file-manager</icon_name>
     <defaults>
       <allow_any>no</allow_any>
@@ -37,6 +41,8 @@
     <message xml:lang="zh_CN">找回保险箱密码需要认证</message>
     <message xml:lang="zh_HK">找回保險箱密碼需要認證</message>
     <message xml:lang="zh_TW">找回保險箱密碼需要認證</message>
+    <message xml:lang="lo">ການຢືນຢັນຕ້ອງການເພື່ອກູ້ລະຫັດຜ່ານກະຕຸກ</message>
+    <message xml:lang="ja">ボールトのパスワードを取得するには認証が必要です</message>
     <icon_name>dde-file-manager</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/translations/dde-file-manager_ja.ts
+++ b/translations/dde-file-manager_ja.ts
@@ -1406,7 +1406,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="326"/>
         <source>Delete File Vault</source>
-        <translation>FileVaultを削除</translation>
+        <translation>ファイル金庫を削除</translation>
     </message>
     <message>
         <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="9"/>
@@ -5324,7 +5324,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-myshares/menu/mysharemenuscene.cpp" line="126"/>
         <source>P&amp;roperties</source>
-        <translation>プロパティ(R)</translation>
+        <translation>プロパティ(&amp;R)</translation>
     </message>
 </context>
 <context>
@@ -5601,7 +5601,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/common/dfmplugin-propertydialog/menu/propertymenuscene.cpp" line="34"/>
         <source>P&amp;roperties</source>
-        <translation>プロパティ(R)</translation>
+        <translation>プロパティ(&amp;R)</translation>
     </message>
 </context>
 <context>
@@ -5919,7 +5919,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="168"/>
         <source>P&amp;roperties</source>
-        <translation>プロパティ(R)</translation>
+        <translation>プロパティ(&amp;R)</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-smbbrowser/menu/smbbrowsermenuscene.cpp" line="169"/>
@@ -6734,7 +6734,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="241"/>
         <source>Failed to unlock file vault</source>
-        <translation>FileVaultのロック解除に失敗しました</translation>
+        <translation>文件保险箱のロック解除に失敗しました</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp" line="245"/>
@@ -6817,7 +6817,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="50"/>
         <source>Unlock File Vault</source>
-        <translation>FileVaultのロックを解除</translation>
+        <translation>文件保険箱のロックを解除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp" line="56"/>
@@ -6886,7 +6886,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="52"/>
         <source>Encrypt File Vault</source>
-        <translation>FileVaultを暗号化</translation>
+        <translation>ファイル保険箱を暗号化</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp" line="56"/>
@@ -6967,12 +6967,12 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="46"/>
         <source>Set Vault Password</source>
-        <translation>FileVaultのパスワードを設定</translation>
+        <translation>文件保険箱のパスワードを設定</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="49"/>
         <source>Encryption method</source>
-        <translation>暗号化方法</translation>
+        <translation>暗号化方式</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp" line="51"/>
@@ -7148,7 +7148,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="29"/>
         <source>Delete File Vault</source>
-        <translation >FileVaultを削除</translation>
+        <translation >文件保険箱を削除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="67"/>
@@ -7196,12 +7196,12 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="84"/>
         <source>Delete</source>
-        <translation >Delete</translation>
+        <translation >削除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="89"/>
         <source>Delete File Vault</source>
-        <translation >FileVaultを削除</translation>
+        <translation >文件保険箱を削除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp" line="108"/>
@@ -7234,12 +7234,12 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="95"/>
         <source>Delete</source>
-        <translation >Delete</translation>
+        <translation >削除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="100"/>
         <source>Delete File Vault</source>
-        <translation >FileVaultを削除</translation>
+        <translation >文件保険箱を削除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp" line="118"/>
@@ -7272,7 +7272,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp" line="76"/>
         <source>Delete File Vault</source>
-        <translation>ファイルボルトを削除</translation>
+        <translation>ファイル ヴォルトを削除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp" line="49"/>

--- a/translations/dde-file-manager_lo.ts
+++ b/translations/dde-file-manager_lo.ts
@@ -2129,7 +2129,7 @@ Enter user and password for %1</source>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="326"/>
         <location filename="../dde-file-manager/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp" line="326"/>
         <source>Delete File Vault</source>
-        <translation>ລກມລົງ File Vault</translation>
+        <translation>ລຶບຕູ້ນິລະໄພເອກະສານ</translation>
     </message>
     <message>
         <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="9"/>
@@ -2431,7 +2431,7 @@ Enter user and password for %1</source>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp" line="311"/>
         <location filename="../dde-file-manager/src/plugins/filemanager/dfmplugin-vault/fileutils/vaultfileinfo.cpp" line="311"/>
         <source>File Vault</source>
-        <translation>ឯកសារសម្រាប់ការលាក់មួយ</translation>
+        <translation>ຕູ້ນິລະໄພເອກະສານ</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
log:

bug: https://pms.uniontech.com/bug-view-329997.html

## Summary by Sourcery

Refine and standardize Japanese and Lao translations in the file manager plugin, focusing on File Vault interface strings to enhance clarity and localization quality.

Enhancements:
- Improve consistency and accuracy of Japanese translations for File Vault UI labels and menu accelerators
- Optimize Lao translations for File Vault terminology