### PR TITLE
fix: enhance NPDeviceAliasManager with protocol URL conversion and new protocol support

### DIFF
--- a/src/dfm-base/base/device/devicealiasmanager.h
+++ b/src/dfm-base/base/device/devicealiasmanager.h
@@ -84,6 +84,8 @@ private:
      */
     explicit NPDeviceAliasManager(QObject *parent = nullptr);
 
+    QUrl convertToProtocolUrl(const QUrl &url) const;
+
     mutable QReadWriteLock rwLock;
 };
 

--- a/src/dfm-base/utils/protocolutils.cpp
+++ b/src/dfm-base/utils/protocolutils.cpp
@@ -98,6 +98,24 @@ bool isNFSFile(const QUrl &url)
     return hasMatch(url.path(), nfsMatch);
 }
 
+bool isDavFile(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    static const QString davMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=false|^/root/.gvfs/dav.*ssl=false))" };
+    return hasMatch(url.path(), davMatch);
+}
+
+bool isDavsFile(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    static const QString davsMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=true|^/root/.gvfs/dav.*ssl=true))" };
+    return hasMatch(url.path(), davsMatch);
+}
+
 }   // namespace ProtocolUtils
 
 DFMBASE_END_NAMESPACE

--- a/src/dfm-base/utils/protocolutils.h
+++ b/src/dfm-base/utils/protocolutils.h
@@ -16,6 +16,8 @@ bool isFTPFile(const QUrl &url);
 bool isSFTPFile(const QUrl &url);
 bool isSMBFile(const QUrl &url);
 bool isNFSFile(const QUrl &url);
+bool isDavFile(const QUrl &url);
+bool isDavsFile(const QUrl &url);
 }   // namespace ProtocolUtils
 
 DFMBASE_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-computer/fileentity/protocolentryfileentity.h
+++ b/src/plugins/filemanager/dfmplugin-computer/fileentity/protocolentryfileentity.h
@@ -31,8 +31,6 @@ public:
     virtual void refresh() override;
     virtual QUrl targetUrl() const override;
     virtual bool renamable() const override;
-
-    QUrl netSourceUrl() const;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-computer/menu/computermenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/menu/computermenuscene.cpp
@@ -179,6 +179,8 @@ void ComputerMenuScene::updateState(QMenu *parent)
     case AbstractEntryFileEntity::kOrderGPhoto2:
     case AbstractEntryFileEntity::kOrderFiles: {
         keeped = QStringList { kOpenInNewWin, kOpenInNewTab, kUnmount, kProperty };
+        if (d->info->renamable())
+            keeped << kRename;
     } break;
     case AbstractEntryFileEntity::kOrderApps:
         keeped = QStringList { kOpen };

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
@@ -81,7 +81,8 @@ void computer_sidebar_event_calls::callItemAdd(const QUrl &vEntryUrl)
         { "Property_Key_CallbackFindMe", QVariant::fromValue(FindMeCallback(sidebarUrlEquals)) },
         { "Property_Key_CallbackRename", QVariant::fromValue(RenameCallback(sidebarItemRename)) },
         { "Property_Key_VisiableControl", "mounted_share_dirs" },
-        { "Property_Key_VisiableDisplayName", QObject::tr("Mounted sharing folders") }
+        { "Property_Key_VisiableDisplayName", QObject::tr("Mounted sharing folders") },
+        { "Property_Key_Editable", info->renamable() }
         //        { "Property_Key_ReportName", reportName }
     };
     auto stdSmb = vEntryUrl.path().remove("." + QString(kVEntrySuffix));
@@ -462,6 +463,7 @@ void computer_sidebar_event_calls::sidebarItemRename(quint64 windowId, const QUr
 
         smbUrl.setScheme("vsmb");
         dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", smbUrl, map);
+        dpfSlotChannel->push("dfmplugin_titlebar", "slot_Crumb_Update", info->urlOf(UrlInfoType::kUrl));
     }
     dpfSlotChannel->push(kComputerEventNS, kCptSlotRefresh);
 }


### PR DESCRIPTION
- Introduced a new method `convertToProtocolUrl` in NPDeviceAliasManager to handle URL validation and conversion based on the protocol.
- Updated alias management methods to utilize the new URL conversion logic, ensuring consistent handling of protocol URLs.
- Added support for DAV and DAVS protocols in ProtocolUtils, improving the overall network protocol handling capabilities.

Log: These enhancements streamline the alias management process and expand the supported network protocols in the file manager.
Bug: https://pms.uniontech.com/bug-view-331315.html
