### PR TITLE
fix: enhance SmbShareFileInfo with node update mechanism

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/fileinfo/smbsharefileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/fileinfo/smbsharefileinfo.cpp
@@ -69,6 +69,7 @@ QIcon SmbShareFileInfo::fileIcon()
     if (isSmbRoot)
         return QIcon::fromTheme("network-server");
 
+    d->checkAndUpdateNode();
     return QIcon::fromTheme(d->node.iconType);
 }
 
@@ -106,13 +107,6 @@ bool SmbShareFileInfo::canAttributes(const CanableInfoType type) const
 SmbShareFileInfoPrivate::SmbShareFileInfoPrivate(SmbShareFileInfo *qq)
     : q(qq)
 {
-    {
-        QMutexLocker locker(&smb_browser_utils::nodesMutex());
-        node = smb_browser_utils::shareNodes().value(q->fileUrl());
-#if 0
-        fmDebug() << node;
-#endif
-    }
 }
 
 SmbShareFileInfoPrivate::~SmbShareFileInfoPrivate()
@@ -128,7 +122,16 @@ bool SmbShareFileInfoPrivate::canDrop() const
     return true;
 }
 
-QString SmbShareFileInfoPrivate::fileName() const
+void SmbShareFileInfoPrivate::checkAndUpdateNode()
 {
+    if (node.url.isEmpty()) {
+        QMutexLocker locker(&smb_browser_utils::nodesMutex());
+        node = smb_browser_utils::shareNodes().value(q->fileUrl());
+    }
+}
+
+QString SmbShareFileInfoPrivate::fileName()
+{
+    checkAndUpdateNode();
     return node.displayName;
 }

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/private/smbsharefileinfo_p.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/private/smbsharefileinfo_p.h
@@ -20,10 +20,11 @@ public:
     virtual ~SmbShareFileInfoPrivate();
 
     bool canDrop() const;
+    void checkAndUpdateNode();
 
 private:
     SmbShareNode node;
-    QString fileName() const;
+    QString fileName();
     SmbShareFileInfo *const q;
 };
 


### PR DESCRIPTION
- Added a new method `checkAndUpdateNode` to ensure the SmbShareNode is updated with the latest information when the file name is accessed.
- Integrated this method into `fileIcon` and `fileName` functions to improve data consistency and responsiveness.

Log: These changes enhance the functionality of the SmbShareFileInfo class by ensuring that the node data is always current, improving the user experience when interacting with SMB shares.
Bug: https://pms.uniontech.com/bug-view-320609.html

## Summary by Sourcery

Ensure SmbShareFileInfo always refreshes its underlying node data before returning file names or icons to improve data consistency and responsiveness

New Features:
- Add checkAndUpdateNode method to SmbShareFileInfoPrivate for refreshing SMB share node data

Bug Fixes:
- Fix stale SMB share node data when accessing file name or icon to address bug #320609

Enhancements:
- Invoke checkAndUpdateNode in fileIcon and fileName to ensure the node’s display name and icon stay current