### PR TITLE
fix: enhance file shredding functionality with local URL transformation

### DIFF
--- a/src/plugins/common/dfmplugin-utils/shred/shredmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredmenuscene.cpp
@@ -11,6 +11,7 @@
 #include <dfm-base/base/standardpaths.h>
 #include <dfm-base/dfm_menu_defines.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
 
 #include <QMenu>
 
@@ -124,8 +125,20 @@ bool ShredMenuScene::triggered(QAction *action)
         return AbstractMenuScene::triggered(action);
 
     QString id = d->predicateAction.key(action);
-    if (id == ShredActionId::kFileShredKey)
-        ShredUtils::instance()->shredfile(d->selectFiles, d->windowId);
+    if (id == ShredActionId::kFileShredKey) {
+        if (d->focusFile.scheme() != Global::Scheme::kFile) {
+            QList<QUrl> localUrlList;
+            std::transform(d->selectFiles.cbegin(), d->selectFiles.cend(), std::back_inserter(localUrlList),
+                           [](const QUrl &url) {
+                               QUrl target;
+                               UniversalUtils::urlTransformToLocal(url, &target);
+                               return target;
+                           });
+            ShredUtils::instance()->shredfile(localUrlList, d->windowId);
+        } else {
+            ShredUtils::instance()->shredfile(d->selectFiles, d->windowId);
+        }
+    }
 
     return true;
 }

--- a/src/plugins/common/dfmplugin-utils/shred/shredutils.h
+++ b/src/plugins/common/dfmplugin-utils/shred/shredutils.h
@@ -22,9 +22,7 @@ public:
     bool isShredEnabled();
     void initDconfig();
     bool isValidFile(const QUrl &file);
-
     void shredfile(const QList<QUrl> &fileList, quint64 winId);
-    void updateVaultMenuConfig();
 
     static QPair<QWidget *, QWidget *> createShredSettingItem(QObject *opt);
 

--- a/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
@@ -63,6 +63,7 @@ QStringList VaultMenuScenePrivate::normalMenuActionRule()
         "delete",
         "reverse-select",
         "separator-line",
+        "file-shred",
         "send-to",
         "property"
     };


### PR DESCRIPTION
- Updated `ShredMenuScene` to handle file shredding for both local and remote files by transforming URLs to local format when necessary.
- Refactored `ShredUtils` to utilize `InfoFactory` for obtaining canonical file paths, improving file validation.
- Removed obsolete `updateVaultMenuConfig` method from `ShredUtils` to streamline the codebase.
- Added "file-shred" action to the vault menu for better integration.

Log: These changes improve the file shredding process, ensuring compatibility with various file schemes and enhancing user experience in the file manager.

## Summary by Sourcery

Enhance file shredding to handle both local and remote file schemes by converting URLs to local paths, refactor file path resolution to use InfoFactory, remove deprecated menu config method, and integrate the file-shred action into the vault menu.

New Features:
- Support shredding of remote files by transforming their URLs to local paths
- Add 'file-shred' action to the vault menu for direct integration

Enhancements:
- Use InfoFactory to obtain canonical file paths in ShredUtils

Chores:
- Remove obsolete updateVaultMenuConfig method from ShredUtils