### PR TITLE
fix: add tooltip functionality to tab in file manager

### DIFF
--- a/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
+++ b/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
@@ -61,7 +61,7 @@ void BasicStatusBarPrivate::initLayout()
     q->clearLayoutAndAnchors();
     layout->addWidget(tip);
     layout->setSpacing(0);
-    layout->setContentsMargins(0, 0, 4, 0);
+    layout->setContentsMargins(0, 0, 4, 1);
 }
 
 void BasicStatusBarPrivate::calcFolderContains(const QList<QUrl> &folderList)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tab.cpp
@@ -187,6 +187,7 @@ void Tab::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidg
         }
     }
 
+    setToolTip(tabName != str ? tabName : "");
     DPalette pal = DPaletteHelper::instance()->palette(widget);
     QColor color;
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -510,6 +510,18 @@ int TabBar::count() const
 
 void TabBar::handleTabAnimationFinished(const int index)
 {
+    // Fix for tab hover issue: After tab removal animation completes,
+    // check if mouse cursor is over any tab and update hover state accordingly.
+    // This ensures that when a tab is closed and other tabs move to new positions,
+    // the hover state is correctly updated for the tab now under the mouse cursor.
+    for (Tab *tab : tabList) {
+        auto rect = tab->geometry();
+        auto pos = mapFromGlobal(QCursor::pos());
+        if (rect.contains(pos)) {
+            tab->setHovered(true);
+            break;
+        }
+    }
 }
 
 void TabBar::updateTabsState()


### PR DESCRIPTION
- Implemented tooltip display for tabs in the file manager, showing the tab name when it differs from the default string.
- This enhancement improves user experience by providing additional context for open tabs.

Log: The addition of tooltips helps users identify tabs more easily, enhancing navigation within the file manager.
Bug: https://pms.uniontech.com/bug-view-321049.html

## Summary by Sourcery

Enhancements:
- Display tab name as tooltip when it differs from the default string