### PR TITLE
fix: implement less intrusive standby prevention

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -93,21 +93,21 @@ void TaskDialog::initUI()
     moveToCenter();
 }
 /*!
- * \brief TaskDialog::blockShutdown 调用dbus处理任务中，阻止系统进入休眠或关机，避免文件损坏
+ * \brief TaskDialog::blockShutdown 调用ScreenSaver接口阻止系统进入待机，避免文件传输中断
  */
 void TaskDialog::blockShutdown()
 {
-    UniversalUtils::blockShutdown(replyBlokShutDown);
-    int fd = -1;
-    if (replyBlokShutDown.isValid()) {
-        fd = replyBlokShutDown.value().fileDescriptor();
+    if (m_inhibitCookie > 0) {
+        qCDebug(logDFMBase) << "System standby already inhibited, cookie:" << m_inhibitCookie;
+        return;
     }
 
-    if (fd > 0) {
-        QObject::connect(this, &TaskDialog::closed, this, [this]() {
-            QDBusReply<QDBusUnixFileDescriptor> tmp = replyBlokShutDown;   //::close(fd);
-            replyBlokShutDown = QDBusReply<QDBusUnixFileDescriptor>();
-        });
+    m_inhibitCookie = UniversalUtils::inhibitStandby(QObject::tr("Files are being processed"));
+    
+    if (m_inhibitCookie > 0) {
+        qCInfo(logDFMBase) << "System standby inhibited successfully, cookie:" << m_inhibitCookie;
+    } else {
+        qCWarning(logDFMBase) << "Failed to inhibit system standby";
     }
 }
 /*!
@@ -230,6 +230,13 @@ void TaskDialog::removeTask()
  */
 void TaskDialog::closeEvent(QCloseEvent *event)
 {
+    // Release system standby inhibit
+    if (m_inhibitCookie > 0) {
+        UniversalUtils::uninhibitStandby(m_inhibitCookie);
+        m_inhibitCookie = 0;
+        qCInfo(logDFMBase) << "System standby inhibit released on dialog close";
+    }
+
     QMap<JobHandlePointer, QListWidgetItem *>::iterator it = taskItems.begin();
     while (it != taskItems.end()) {
         it.key()->operateTaskJob(AbstractJobHandler::SupportAction::kStopAction);
@@ -254,4 +261,9 @@ void TaskDialog::keyPressEvent(QKeyEvent *event)
 
 TaskDialog::~TaskDialog()
 {
+    // Ensure system standby inhibit is released
+    if (m_inhibitCookie > 0) {
+        UniversalUtils::uninhibitStandby(m_inhibitCookie);
+        qCInfo(logDFMBase) << "System standby inhibit released in destructor";
+    }
 }

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.h
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.h
@@ -52,7 +52,7 @@ private:
     QListWidget *taskListWidget { nullptr };
     QMap<JobHandlePointer, QListWidgetItem *> taskItems;
     DTitlebar *titlebar { nullptr };
-    QDBusReply<QDBusUnixFileDescriptor> replyBlokShutDown;
+    uint32_t m_inhibitCookie { 0 };
     static int kMaxHeight;
 };
 

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -24,7 +24,11 @@ public:
     static QString userLoginState();
     static quint32 currentLoginUser();
     static bool isLogined();
-    static void blockShutdown(QDBusReply<QDBusUnixFileDescriptor> &replay);
+
+    // New ScreenSaver-based standby inhibition
+    static uint32_t inhibitStandby(const QString &reason = QString());
+    static void uninhibitStandby(uint32_t cookie);
+
     static qint64 computerMemory();
     static void computerInformation(QString &cpuinfo, QString &systemType, QString &Edition, QString &version);
     static double sizeFormat(qint64 size, QString &unit);


### PR DESCRIPTION
1. Replaced DBus-based shutdown blocker with ScreenSaver interface for standby inhibition
2. The new solution prevents system standby without showing notifications to users
3. Added proper cleanup handlers to release inhibition when dialog closes or objects destruct
4. Uses cookie-based tracking instead of file descriptor approach
5. Better logging for debugging purposes
6. Solves the issue where previous implementation showed blocking notifications unnecessarily

Bug: https://pms.uniontech.com/bug-view-331105.html
Bug: https://pms.uniontech.com/bug-view-331113.html
Bug: https://pms.uniontech.com/bug-view-331115.html

fix: 实现更无感的待机阻止方案

1. 使用ScreenSaver接口替代基于DBus的关机阻止方案
2. 新方案无需显示通知即可阻止系统待机
3. 添加了适当的清理处理程序在对话框关闭或对象销毁时释放阻止
4. 使用基于cookie的追踪方式替代文件描述符方案
5. 添加了更好的日志记录用于调试
6. 解决了之前实现中会不必要地显示阻止通知的问题

## Summary by Sourcery

Implement less intrusive system standby prevention using the org.freedesktop.ScreenSaver D-Bus interface with cookie-based tracking, and ensure proper inhibition cleanup in TaskDialog.

New Features:
- Add UniversalUtils::inhibitStandby and uninhibitStandby methods using the ScreenSaver D-Bus Inhibit/UnInhibit calls

Bug Fixes:
- Prevent unnecessary blocking notifications by using the ScreenSaver interface

Enhancements:
- Replace login1-based shutdown blocker with ScreenSaver inhibition to avoid user notifications
- Switch from file descriptor tracking to cookie-based standby inhibition
- Ensure inhibition is released on dialog close and in the destructor
- Improve logging around standby inhibition operations

Chores:
- Remove deprecated DBus-based blockShutdown implementation and associated file descriptor logic