### PR TITLE
fix: streamline trash state management in TrashCoreEventSender

### DIFF
--- a/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
@@ -41,7 +41,6 @@ private:
     explicit TrashCoreEventSender(QObject *parent = nullptr);
     void initTrashWatcher();
     bool checkAndStartWatcher();
-    void ensureTrashStateInitialized();
 
 private:
     QSharedPointer<DFMBASE_NAMESPACE::AbstractFileWatcher> trashFileWatcher = nullptr;


### PR DESCRIPTION
- Removed the ensureTrashStateInitialized method to simplify the logic for determining the trash state.
- Updated sendTrashStateChangedDel and sendTrashStateChangedAdd methods to directly check the trash state, improving efficiency and clarity.
- Ensured that state changes are only signaled when necessary, enhancing performance and reducing unnecessary signals.

Log: These changes improve the management of trash state updates, leading to a more efficient handling of trash events in the file manager.
Bug: https://pms.uniontech.com/bug-view-332183.html

## Summary by Sourcery

Streamline trash state management in TrashCoreEventSender by removing the lazy initialization method and updating state-change methods to perform direct checks and emit signals only on actual state transitions.

Enhancements:
- Remove ensureTrashStateInitialized and replace lazy initialization with direct calls to FileUtils::trashIsEmpty in sendTrashStateChanged methods
- Update sendTrashStateChangedDel and sendTrashStateChangedAdd to include Unknown state in transition checks and avoid emitting redundant state-change signals