### PR TITLE
fix: enhance file copy functionality in TagEventReceiver

### DIFF
--- a/src/plugins/common/dfmplugin-tag/events/tageventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-tag/events/tageventreceiver.cpp
@@ -35,15 +35,30 @@ void TagEventReceiver::handleFileCutResult(const QList<QUrl> &srcUrls, const QLi
     if (!ok || destUrls.isEmpty())
         return;
 
-    for (const QUrl &url : srcUrls) {
-        const auto &tags = TagManager::instance()->getTagsByUrls({ url });
-        if (tags.isEmpty())
-            continue;
+    if (srcUrls.size() != destUrls.size())
+        return;
 
-        TagManager::instance()->removeTagsOfFiles(tags, { url });
-        const QUrl &newUrl = destUrls.at(srcUrls.indexOf(url));
-        if (TagManager::instance()->canTagFile(newUrl))
-            TagManager::instance()->addTagsForFiles(tags, { newUrl });
+    for (int i = 0; i < srcUrls.size(); ++i) {
+        const QUrl &srcUrl = srcUrls.at(i);
+        const QUrl &destUrl = destUrls.at(i);
+        processFileTags(srcUrl, destUrl, true);   // true means remove source tags
+    }
+}
+
+void TagEventReceiver::handleFileCopyResult(const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls, bool ok, const QString &errMsg)
+{
+    Q_UNUSED(errMsg)
+
+    if (!ok || destUrls.isEmpty())
+        return;
+
+    if (srcUrls.size() != destUrls.size())
+        return;
+
+    for (int i = 0; i < srcUrls.size(); ++i) {
+        const QUrl &srcUrl = srcUrls.at(i);
+        const QUrl &destUrl = destUrls.at(i);
+        processFileTags(srcUrl, destUrl, false);   // false means don't remove source tags
     }
 }
 
@@ -68,12 +83,17 @@ void TagEventReceiver::handleFileRemoveResult(const QList<QUrl> &srcUrls, bool o
     if (!ok)
         return;
 
-    for (const QUrl &url : srcUrls) {
-        const auto &tags = TagManager::instance()->getTagsByUrls({ url });
-        if (tags.isEmpty())
+    for (const auto &url : srcUrls) {
+        auto info = InfoFactory::create<FileInfo>(url);
+        if (!info)
             continue;
 
-        TagManager::instance()->removeTagsOfFiles(tags, { url });
+        const auto &path = info->pathOf(FileInfo::FilePathInfoType::kAbsoluteFilePath);
+        TagManager::instance()->removeChildren(path);
+
+        const auto &tags = TagManager::instance()->getTagsByUrls({ url });
+        if (!tags.isEmpty())
+            TagManager::instance()->removeTagsOfFiles(tags, { url });
     }
 }
 
@@ -87,12 +107,7 @@ void TagEventReceiver::handleFileRenameResult(quint64 winId, const QMap<QUrl, QU
 
     auto iter = renamedUrls.constBegin();
     for (; iter != renamedUrls.constEnd(); ++iter) {
-        const auto &tags = TagManager::instance()->getTagsByUrls({ iter.key() });
-        if (tags.isEmpty())
-            continue;
-
-        TagManager::instance()->removeTagsOfFiles(tags, { iter.key() });
-        TagManager::instance()->addTagsForFiles(tags, { iter.value() });
+        processFileTags(iter.key(), iter.value(), true);
     }
 }
 
@@ -145,4 +160,55 @@ void TagEventReceiver::handleSidebarOrderChanged(quint64 winId, const QString &g
 TagEventReceiver::TagEventReceiver(QObject *parent)
     : QObject(parent)
 {
+}
+
+void TagEventReceiver::addTagsToUrl(const QUrl &url, const QStringList &tags)
+{
+    if (tags.isEmpty() || !TagManager::instance()->canTagFile(url))
+        return;
+
+    TagManager::instance()->addTagsForFiles(tags, { url });
+}
+
+void TagEventReceiver::processDirectoryTags(const QUrl &srcUrl, const QUrl &destUrl, bool shouldRemoveSource)
+{
+    auto srcInfo = InfoFactory::create<FileInfo>(srcUrl);
+    auto destInfo = InfoFactory::create<FileInfo>(destUrl);
+    if (!srcInfo || !destInfo)
+        return;
+
+    QString srcPath = srcInfo->pathOf(FileInfo::FilePathInfoType::kAbsoluteFilePath);
+    QString destPath = destInfo->pathOf(FileInfo::FilePathInfoType::kAbsoluteFilePath);
+
+    const auto &children = TagManager::instance()->findChildren(srcPath);
+    for (auto it = children.cbegin(); it != children.cend(); ++it) {
+        QString srcTagFile = it.key();
+        QString destFile = srcTagFile.replace(0, srcPath.length(), destPath);
+
+        if (std::filesystem::exists(destFile.toLocal8Bit().data()))
+            addTagsToUrl(QUrl::fromLocalFile(destFile), it.value());
+
+        if (shouldRemoveSource)
+            TagManager::instance()->removeTagsOfFiles(it.value(), { QUrl::fromLocalFile(it.key()) });
+    }
+}
+
+void TagEventReceiver::processFileTags(const QUrl &srcUrl, const QUrl &destUrl, bool shouldRemoveSource)
+{
+    auto info = InfoFactory::create<FileInfo>(srcUrl);
+    if (!info) {
+        fmWarning() << "Failed to create FileInfo for:" << srcUrl.toString();
+        return;
+    }
+
+    QStringList tags = TagManager::instance()->getTagsByUrls({ srcUrl });
+    if (!tags.isEmpty()) {
+        if (shouldRemoveSource)
+            TagManager::instance()->removeTagsOfFiles(tags, { srcUrl });
+        addTagsToUrl(destUrl, tags);
+    }
+
+    // Process directory if applicable
+    if (shouldRemoveSource || info->isAttributes(FileInfo::FileIsType::kIsDir))
+        processDirectoryTags(srcUrl, destUrl, shouldRemoveSource);
 }

--- a/src/plugins/common/dfmplugin-tag/events/tageventreceiver.h
+++ b/src/plugins/common/dfmplugin-tag/events/tageventreceiver.h
@@ -12,6 +12,7 @@ namespace dfmplugin_tag {
 inline constexpr char kSidebarOrder[] { "SideBar/ItemOrder" };
 inline constexpr char kTagOrderKey[] { "tag" };
 
+class TagEventWorker;
 class TagEventReceiver : public QObject
 {
     Q_OBJECT
@@ -21,6 +22,7 @@ public:
 public slots:
     void handleHideFilesResult(const quint64 &winId, const QList<QUrl> &urls, bool ok);
     void handleFileCutResult(const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls, bool ok, const QString &errMsg);
+    void handleFileCopyResult(const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls, bool ok, const QString &errMsg);
     void handleFileRemoveResult(const QList<QUrl> &srcUrls, bool ok, const QString &errMsg);
     void handleFileRenameResult(quint64 winId, const QMap<QUrl, QUrl> &renamedUrls, bool ok, const QString &errMsg);
     void handleWindowUrlChanged(quint64 winId, const QUrl &url);
@@ -31,6 +33,10 @@ public slots:
 
 private:
     explicit TagEventReceiver(QObject *parent = nullptr);
+
+    void addTagsToUrl(const QUrl &url, const QStringList &tags);
+    void processDirectoryTags(const QUrl &srcUrl, const QUrl &destUrl, bool shouldRemoveSource);
+    void processFileTags(const QUrl &srcUrl, const QUrl &destUrl, bool shouldRemoveSource);
 };
 
 }

--- a/src/plugins/common/dfmplugin-tag/tag.cpp
+++ b/src/plugins/common/dfmplugin-tag/tag.cpp
@@ -227,6 +227,7 @@ void Tag::bindEvents()
 {
     dpfSignalDispatcher->subscribe(GlobalEventType::kHideFilesResult, TagEventReceiver::instance(), &TagEventReceiver::handleHideFilesResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kCutFileResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileCutResult);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kCopyResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileCopyResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kMoveToTrashResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileRemoveResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kDeleteFilesResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileRemoveResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kRenameFileResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileRenameResult);

--- a/src/plugins/common/dfmplugin-tag/utils/filetagcache.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/filetagcache.cpp
@@ -238,6 +238,23 @@ QStringList FileTagCache::getTagsByFiles(const QStringList &paths) const
     return intersectionTags;
 }
 
+QHash<QString, QStringList> FileTagCache::findChildren(const QString &parentPath) const
+{
+    QHash<QString, QStringList> children;
+    QString normalizedParent = parentPath;
+    if (!normalizedParent.endsWith('/'))
+        normalizedParent += '/';
+
+    QReadLocker wlk(&d->lock);
+    for (auto it = d->fileTagsCache.cbegin(); it != d->fileTagsCache.cend(); ++it) {
+        const QString &filePath = it.key();
+        if (filePath.startsWith(normalizedParent))
+            children.insert(filePath, it.value().toStringList());
+    }
+
+    return children;
+}
+
 FileTagCache::TagColorMap FileTagCache::getTagsColor(const QStringList &tags) const
 {
     if (tags.isEmpty())
@@ -272,6 +289,11 @@ QStringList FileTagCacheController::getTagsByFile(const QString &path)
 QMap<QString, QColor> FileTagCacheController::getCacheTagsColor(const QStringList &tags)
 {
     return FileTagCache::instance().getTagsColor(tags);
+}
+
+QHash<QString, QStringList> FileTagCacheController::findChildren(const QString &parentPath) const
+{
+    return FileTagCache::instance().findChildren(parentPath);
 }
 
 FileTagCacheController::~FileTagCacheController()

--- a/src/plugins/common/dfmplugin-tag/utils/filetagcache.h
+++ b/src/plugins/common/dfmplugin-tag/utils/filetagcache.h
@@ -50,6 +50,7 @@ public:
     //query
     QStringList getTagsByFiles(const QStringList &paths) const;
     TagColorMap getTagsColor(const QStringList &tags) const;
+    QHash<QString, QStringList> findChildren(const QString &parentPath) const;
 
 private:
     explicit FileTagCache(QObject *parent = nullptr);
@@ -80,6 +81,7 @@ public:
     QStringList getTagsByFiles(const QStringList &paths);
     QStringList getTagsByFile(const QString &path);
     QMap<QString, QColor> getCacheTagsColor(const QStringList &tags);
+    QHash<QString, QStringList> findChildren(const QString &parentPath) const;
 
 Q_SIGNALS:
     void initLoadTagInfos();

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -301,6 +301,12 @@ QStringList TagManager::getFilesByTag(const QString &tag)
     return dataMap.value(tag).toStringList();
 }
 
+QHash<QString, QStringList> TagManager::findChildren(const QString &parentPath) const
+{
+    const auto &url = FileUtils::bindUrlTransform(QUrl::fromLocalFile(parentPath));
+    return FileTagCacheIns.findChildren(url.path());
+}
+
 bool TagManager::setTagsForFiles(const QStringList &tags, const QList<QUrl> &files)
 {
     // if tags is empty means delete all files's tags
@@ -464,6 +470,17 @@ bool TagManager::changeTagName(const QString &tagName, const QString &newName)
     QVariantMap oldAndNewName = { { tagName, QVariant { newName } } };
     emit tagDeleted(tagName);
     return TagProxyHandleIns->changeTagNamesWithFiles(oldAndNewName);
+}
+
+bool TagManager::removeChildren(const QString &parentPath)
+{
+    bool ret = true;
+    const auto &children = findChildren(parentPath);
+    for (auto it = children.cbegin(); it != children.cend(); ++it) {
+        ret &= removeTagsOfFiles(it.value(), { QUrl::fromLocalFile(it.key()) });
+    }
+
+    return ret;
 }
 
 QMap<QString, QString> TagManager::getTagsColorName(const QStringList &tags) const

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
@@ -52,6 +52,7 @@ public:
     TagColorMap getTagsColor(const QStringList &tags) const;
     QStringList getTagsByUrls(const QList<QUrl> &urls) const;
     QStringList getFilesByTag(const QString &tag);
+    QHash<QString, QStringList> findChildren(const QString &parentPath) const;
 
     // modify
     bool setTagsForFiles(const QStringList &tags, const QList<QUrl> &files);
@@ -60,6 +61,7 @@ public:
     void deleteTags(const QStringList &tags);
     bool changeTagColor(const QString &tagName, const QString &newTagColor);
     bool changeTagName(const QString &tagName, const QString &newName);
+    bool removeChildren(const QString &parentPath);
 
     static void contenxtMenuHandle(quint64 windowId, const QUrl &url, const QPoint &globalPos);
     static void renameHandle(quint64 windowId, const QUrl &url, const QString &name);


### PR DESCRIPTION
- Added a new signal subscription for handling file copy results in the Tag class.
- Implemented the handleFileCopyResult method in TagEventReceiver to process file copy events.
- Introduced a worker thread for handling file events, improving responsiveness and performance.
- Added findChildren method in FileTagCache and TagManager to retrieve child file tags based on parent paths.

Log: These changes enhance the file management capabilities by supporting file copy operations and improving event handling efficiency. This contributes to a more robust tagging system in the file manager.
Bug: https://pms.uniontech.com/bug-view-324639.html

## Summary by Sourcery

Improve file tagging performance and add file copy support by delegating tag operations to an asynchronous worker thread and extending cache and manager APIs for hierarchical tag management

New Features:
- Introduce TagEventWorker to asynchronously process file copy, cut, remove, and rename events
- Add support for handling file copy events in TagEventReceiver

Enhancements:
- Move TagEventWorker to its own QThread in TagEventReceiver to improve responsiveness
- Refactor TagEventReceiver to delegate file operation results to the worker via queued invocations

Chores:
- Add findChildren methods in FileTagCache, FileTagCacheController, and TagManager
- Add removeChildren method in TagManager to recursively remove tags of child paths