### PR TITLE
fix(ddplugin-organizer): ensure new files are organized when organize…

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -516,7 +516,10 @@ bool NormalizedMode::initialize(CollectionModel *m)
     // creating if there already are files.
     if (!model->files().isEmpty()) {
         fmDebug() << "Found existing files, triggering rebuild";
-        rebuild();
+        // 这里使用 rebuild(true) 而不是 rebuild() 是为了确保所有文件都被重新整理
+        // 因为当取消了分类之后再创建使用的是上次分类的文件，这样会导致新建的文件没有被整理
+        // 所以确保每次重建的时候都是重新刷新了model中的文件
+        rebuild(true);
     }
 
     return true;


### PR DESCRIPTION
…r restarts

- Change rebuild() to rebuild(true) in NormalizedMode::initialize method
- Ensure organizer processes all files in "reorganize" mode when restarting
- Fix issue where new files were ignored in organizeOnTriggered mode
- Resolve user workflow: first organize → disable organizer → create new files → re-organize, where new files were not included

bug:  https://pms.uniontech.com/bug-view-319227.html

## Summary by Sourcery

Force a full rebuild when initializing the organizer to ensure new and existing files are processed on restart

Bug Fixes:
- Call rebuild(true) instead of rebuild() in NormalizedMode::initialize to trigger a complete rebuild on startup
- Include newly added files in reorganize and organizeOnTriggered workflows after restarting the organizer