### PR TITLE
chore: bump version to 6.5.91

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.91) unstable; urgency=medium
+
+ * fix bugs
+ * new features
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 04 Sep 2025 21:31:26 +0800
+
 dde-file-manager (6.5.90) unstable; urgency=medium
 
  * fix bugs


### PR DESCRIPTION
6.5.91

Log:

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.5.91