### PR TITLE
fix: unify hover and pressed state color handling for buttons

### DIFF
--- a/src/dfm-base/widgets/dfmcustombuttons/customdtoolbutton.cpp
+++ b/src/dfm-base/widgets/dfmcustombuttons/customdtoolbutton.cpp
@@ -28,11 +28,22 @@ CustomDToolButton::CustomDToolButton(QWidget *parent)
 void CustomDToolButton::initStyleOption(QStyleOptionToolButton *option) const
 {
     DToolButton::initStyleOption(option);
-    if (underMouse()) {
+    if (isEnabled()) {
         bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
-        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
-                                        : QColor(0, 0, 0, 26);
-        option->palette.setColor(QPalette::Button, hoverColor);
+        DStyleHelper dstyle(style());
+        const int radius = dstyle.pixelMetric(DStyle::PM_FrameRadius);
+
+        QColor bgColor;
+        if (isDown()) {
+            // 按下状态 - 20%不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 51)
+                                  : QColor(0, 0, 0, 51);
+        } else if (underMouse()) {
+            // 悬浮状态 - 10%不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 26)
+                                  : QColor(0, 0, 0, 26);
+        }
+        option->palette.setColor(QPalette::Button, bgColor);
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
@@ -168,8 +168,16 @@ void SortByButton::paintEvent(QPaintEvent *event)
 
         bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
 
-        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
-                                        : QColor(0, 0, 0, 26);
+        QColor hoverColor;
+        if (isDown()) {
+            // 按下状态 - 20%不透明度
+            hoverColor = isDarkTheme ? QColor(255, 255, 255, 51)
+                                     : QColor(0, 0, 0, 51);
+        } else {
+            // 悬浮状态 - 10%不透明度
+            hoverColor = isDarkTheme ? QColor(255, 255, 255, 26)
+                                     : QColor(0, 0, 0, 26);
+        }
 
         option.palette.setBrush(QPalette::Button, hoverColor);
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
@@ -91,9 +91,17 @@ void ViewOptionsButton::paintEvent(QPaintEvent *event)
         option.state |= QStyle::State_MouseOver;
 
         bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
-
-        QColor hoverColor = isDarkTheme ? QColor(255, 255, 255, 15)
-                                        : QColor(0, 0, 0, 26);
+        
+        QColor hoverColor;
+        if (isDown()) {
+            // 按下状态 - 20%不透明度
+            hoverColor = isDarkTheme ? QColor(255, 255, 255, 51)
+                                     : QColor(0, 0, 0, 51);
+        } else {
+            // 悬浮状态 - 10%不透明度
+            hoverColor = isDarkTheme ? QColor(255, 255, 255, 26)
+                                     : QColor(0, 0, 0, 26);
+        }
 
         option.palette.setBrush(QPalette::Button, hoverColor);
     } else {


### PR DESCRIPTION
- Refactored color handling logic for hover and pressed states in CustomDToolButton, SortByButton, and ViewOptionsButton.
- Improved code readability and maintainability by consolidating repeated logic.
- Enhanced visual feedback for button interactions based on theme type.

Log: This change ensures consistent button behavior across different components, improving user experience.

bug: https://pms.uniontech.com/bug-view-313923.html

## Summary by Sourcery

Unify hover and pressed state color handling across button components to ensure consistent theme-aware visual feedback and improve code maintainability

Bug Fixes:
- Fix inconsistent hover and pressed state colors for CustomDToolButton, SortByButton, and ViewOptionsButton

Enhancements:
- Unify theme-aware opacity logic for hover (10%) and pressed (20%) states across button components