### PR TITLE
fix: update Japanese translations for delete action in file manager

### DIFF
--- a/translations/dde-file-manager_ja.ts
+++ b/translations/dde-file-manager_ja.ts
@@ -1941,7 +1941,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/desktop/ddplugin-organizer/view/collectiontitlebar.cpp" line="171"/>
         <source>Delete</source>
-        <translation>Delete</translation>
+        <translation>削除</translation>
     </message>
 </context>
 <context>
@@ -7143,7 +7143,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="24"/>
         <source>Delete</source>
-        <translation >Delete</translation>
+        <translation>削除</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp" line="29"/>


### PR DESCRIPTION
- Changed the translation for the "Delete" action to "削除" in two locations within the Japanese translation file.
- This update ensures that the user interface accurately reflects the intended meaning in Japanese, enhancing user experience for Japanese-speaking users.

Log: These changes improve the localization of the file manager, making it more accessible and user-friendly for Japanese users.

bug: https://pms.uniontech.com/bug-view-332073.html

## Summary by Sourcery

Bug Fixes:
- Correct the Japanese translation of the “Delete” action to “削除” in two file manager contexts.