### PR TITLE
fix: rename loading indicator to loading spinner in FileViewStatusBar

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
@@ -19,7 +19,7 @@ using namespace dfmplugin_workspace;
 
 FileViewStatusBar::FileViewStatusBar(QWidget *parent)
     : BasicStatusBar(parent),
-      loadingIndicator(nullptr),
+      loadingSpinner(nullptr),
       scaleSlider(nullptr),
       stretchWidget(nullptr),
       centerContainer(nullptr)
@@ -27,7 +27,7 @@ FileViewStatusBar::FileViewStatusBar(QWidget *parent)
     fmInfo() << "Creating FileViewStatusBar";
 
     initScalingSlider();
-    initLoadingIndicator();
+    initLoadingSpinner();
     setCustomLayout();
 
     fmDebug() << "FileViewStatusBar initialization completed";
@@ -82,9 +82,9 @@ void FileViewStatusBar::showLoadingIncator(const QString &tip)
 {
     fmInfo() << "Showing loading indicator with tip:" << (tip.isEmpty() ? "Loading..." : tip);
 
-    if (loadingIndicator) {
-        loadingIndicator->setVisible(true);
-        loadingIndicator->play();
+    if (loadingSpinner) {
+        loadingSpinner->setVisible(true);
+        loadingSpinner->start();
         fmDebug() << "Loading indicator started playing";
     } else {
         fmWarning() << "Cannot show loading indicator: loadingIndicator is null";
@@ -97,9 +97,9 @@ void FileViewStatusBar::hideLoadingIncator()
 {
     fmInfo() << "Hiding loading indicator";
 
-    if (loadingIndicator) {
-        loadingIndicator->stop();
-        loadingIndicator->setVisible(false);
+    if (loadingSpinner) {
+        loadingSpinner->stop();
+        loadingSpinner->setVisible(false);
         fmDebug() << "Loading indicator stopped and hidden";
     } else {
         fmWarning() << "Cannot hide loading indicator: loadingIndicator is null";
@@ -125,22 +125,13 @@ void FileViewStatusBar::initScalingSlider()
     fmDebug() << "Scaling slider initialized with width: 120, range: 0-1";
 }
 
-void FileViewStatusBar::initLoadingIndicator()
+void FileViewStatusBar::initLoadingSpinner()
 {
     fmDebug() << "Initializing loading indicator";
 
-    QStringList seq;
-
-    for (int i = 1; i != 91; ++i)
-        seq.append(QString(":/images/images/Spinner/Spinner%1.png").arg(i, 2, 10, QChar('0')));
-
-    loadingIndicator = new DPictureSequenceView(this);
-    loadingIndicator->setFixedSize(18, 18);
-    loadingIndicator->setPictureSequence(seq, true);
-    loadingIndicator->setSpeed(20);
-    loadingIndicator->hide();
-
-    fmDebug() << "Loading indicator initialized with" << seq.size() << "frames, size: 18x18, speed: 20";
+    loadingSpinner = new DSpinner(this);
+    loadingSpinner->setFixedSize(16, 16);
+    loadingSpinner->hide();
 }
 
 DTipLabel *FileViewStatusBar::findTipLabel() const
@@ -180,8 +171,8 @@ void FileViewStatusBar::setCustomLayout()
     centerLayout->setSpacing(5);
     fmDebug() << "Created center layout with spacing: 5";
 
-    // Add loadingIndicator to the center container
-    centerLayout->addWidget(loadingIndicator);
+    // Add loadingSpinner to the center container
+    centerLayout->addWidget(loadingSpinner);
     fmDebug() << "Added loading indicator to center layout";
 
     // Find the tip label from base class

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.h
@@ -9,7 +9,7 @@
 #include <dfm-base/dfm_base_global.h>
 #include <dfm-base/widgets/dfmstatusbar/basicstatusbar.h>
 
-#include <dpicturesequenceview.h>
+#include <DSpinner>
 #include <dslider.h>
 #include <DTipLabel>
 
@@ -36,10 +36,10 @@ protected:
 
 private:
     void initScalingSlider();
-    void initLoadingIndicator();
+    void initLoadingSpinner();
     void setCustomLayout();
 
-    DPictureSequenceView *loadingIndicator { nullptr };
+    DSpinner *loadingSpinner { nullptr };
     DSlider *scaleSlider { nullptr };
     QWidget *stretchWidget { nullptr };
     QWidget *centerContainer { nullptr };


### PR DESCRIPTION
- Updated variable names and method references from loadingIndicator to loadingSpinner for clarity.
- Replaced DPictureSequenceView with DSpinner to enhance loading animation functionality.
- Adjusted initialization and visibility handling for the new loading spinner.

Log: This change improves code readability and aligns the component's naming with its functionality.
Bug: https://pms.uniontech.com/bug-view-327573.html

## Summary by Sourcery

Update FileViewStatusBar to use a dedicated spinner widget and align naming with functionality

Enhancements:
- Rename loadingIndicator variables and methods to loadingSpinner for clarity
- Replace DPictureSequenceView animation with DSpinner and update its initialization and show/hide logic