### PR TITLE
fix: Add XDG_DATA_DIRS to pkexec environment capture

### DIFF
--- a/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
+++ b/src/apps/dde-file-manager/pkexec/dde-file-manager-pkexec
@@ -10,20 +10,21 @@ set -e
 function run_pkexec() {
     # 使用一个临时文件来传递所有必要的环境变量，而不仅仅是会话类型
     local TEMP_ENV_FILE="/tmp/.dde-fm-env-$$"
-    
+
     echo "Capturing environment before elevating..."
     # 捕获 DISPLAY, XAUTHORITY, 和 XDG_SESSION_TYPE
     echo "export DISPLAY='$DISPLAY'" > "$TEMP_ENV_FILE"
     echo "export XAUTHORITY='$XAUTHORITY'" >> "$TEMP_ENV_FILE"
     echo "export XDG_SESSION_TYPE='$XDG_SESSION_TYPE'" >> "$TEMP_ENV_FILE"
-    
+    echo "export XDG_DATA_DIRS='$XDG_DATA_DIRS'" >> "$TEMP_ENV_FILE"
+
     # [NOTE] xhost 仍然保留，作为一种备用授权机制
     xhost +SI:localuser:root &>/dev/null
-    
+
     echo "run in pkexec: $@"
     # 将 uid 和临时环境文件路径作为最后两个参数传递，确保解析的稳定性
     pkexec --disable-internal-agent "$0" "$@" "$(id -u)" "$TEMP_ENV_FILE"
-    
+
     # 清理
     rm -f "$TEMP_ENV_FILE"
     xhost -SI:localuser:root &>/dev/null
@@ -42,7 +43,7 @@ function run_app() {
     local user_name
     user_name=$(getent passwd "$uid" | cut -d: -f1)
     echo "Running as root for user: $user_name (UID: $uid)"
-    
+
     # 从临时文件中加载关键环境变量
     if [ -f "$TEMP_ENV_FILE" ]; then
         echo "Loading environment from $TEMP_ENV_FILE"
@@ -53,11 +54,11 @@ function run_app() {
         echo "Error: Temp env file not found! GUI application will likely fail." >&2
         # 不再硬编码，让它自然失败会暴露出更准确的错误
     fi
-    
+
     # 正确设置 D-Bus 和运行时目录，这是连接用户桌面的关键
     export XDG_RUNTIME_DIR="/run/user/$uid"
     export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
-    
+
     # 根据会话类型设置环境
     if [ "$XDG_SESSION_TYPE" == "x11" ]; then
         # DISPLAY 和 XAUTHORITY 已通过 source 加载
@@ -77,7 +78,7 @@ function run_app() {
     # [NOTE] 假设 dde-file-manager 是最终执行的程序
     echo "Starting dde-file-manager with args: ${app_args[*]} and CWD: $(pwd)"
     file-manager.sh "${app_args[@]}" -w "$(pwd)"
-  
+
 }
 
 # --- Main script logic ---

--- a/src/plugins/common/dfmplugin-utils/shred/fileshredworker.h
+++ b/src/plugins/common/dfmplugin-utils/shred/fileshredworker.h
@@ -27,8 +27,8 @@ Q_SIGNALS:
 
 private:
     int countFilesInDirectory(const QString &dirPath);
-    void processDirectory(const QString &dirPath);
-    bool executeShredCommandBatch(const QStringList &filePaths);
+    bool processDirectory(const QString &dirPath, QString &msg);
+    bool executeShredCommandBatch(const QStringList &filePaths, QString &msg);
     void parseShredOutput(const QString &output);
     bool isPipe(const QString &path) const;
     int calculateProgress(int processedFiles, int totalFiles, int currentFileProgress = 0);

--- a/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
@@ -33,7 +33,8 @@ ProgressWidget::ProgressWidget(QWidget *parent)
 void ProgressWidget::setValue(int value, const QString &fileName)
 {
     progress->start();
-    progress->setValue(value);
+    if (value > progress->value())
+        progress->setValue(value);
     if (!fileName.isEmpty())
         infoLable->setText(tr("Shredding file \" %1 \"").arg(fileName));
 }

--- a/src/plugins/common/dfmplugin-utils/shred/progressdialog.h
+++ b/src/plugins/common/dfmplugin-utils/shred/progressdialog.h
@@ -9,6 +9,8 @@
 
 #include <DDialog>
 
+#include <QStackedWidget>
+
 DWIDGET_BEGIN_NAMESPACE
 class DWaterProgress;
 class DLabel;
@@ -35,7 +37,9 @@ class ShredFailedWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit ShredFailedWidget(const QString &reason, QWidget *parent = Q_NULLPTR);
+    explicit ShredFailedWidget(QWidget *parent = Q_NULLPTR);
+
+    void setMessage(const QString &msg);
 
 private:
     DTK_WIDGET_NAMESPACE::DLabel *infoLabel { Q_NULLPTR };
@@ -64,6 +68,7 @@ private:
 
     ProgressWidget *proWidget { Q_NULLPTR };
     ShredFailedWidget *failedWidget { Q_NULLPTR };
+    QStackedWidget *stackedWidget { Q_NULLPTR };
 };
 }
 

--- a/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "shredfilemodel.h"
+
+#include <dfm-base/base/schemefactory.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+ShredFileModel::ShredFileModel(QObject *parent)
+    : QAbstractItemModel(parent)
+{
+}
+
+QModelIndex ShredFileModel::index(int row, int column, const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+
+    if (row >= rowCount() || row < 0)
+        return QModelIndex();
+    return createIndex(row, column, &urlList[row]);
+}
+
+QModelIndex ShredFileModel::parent(const QModelIndex &child) const
+{
+    Q_UNUSED(child);
+    return QModelIndex();
+}
+
+int ShredFileModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return urlList.count();
+}
+
+int ShredFileModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+    return 1;
+}
+
+QVariant ShredFileModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || urlList.count() <= index.row()) {
+        fmWarning() << "ComputerModel::data invalid index row:" << index.row() << "items count:" << urlList.count();
+        return {};
+    }
+
+    const auto &url = urlList[index.row()];
+    auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto);
+    if (!info || !info->exists()) {
+        fmWarning() << "The file is invalid: " << url;
+        return {};
+    }
+
+    switch (role) {
+    case Qt::DisplayRole:
+        return info->displayOf(DisPlayInfoType::kFileDisplayName);
+    case Qt::DecorationRole:
+        return info->fileIcon();
+    default:
+        return {};
+    }
+}
+
+void ShredFileModel::setFileList(const QList<QUrl> &fileList)
+{
+    beginResetModel();
+    urlList = fileList;
+    endResetModel();
+}

--- a/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.h
+++ b/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SHREDFILEMODEL_H
+#define SHREDFILEMODEL_H
+
+#include "dfmplugin_utils_global.h"
+
+#include <QAbstractItemModel>
+
+namespace dfmplugin_utils {
+
+class ShredFileModel : public QAbstractItemModel
+{
+    Q_OBJECT
+public:
+    explicit ShredFileModel(QObject *parent = nullptr);
+
+    QModelIndex index(int row, int column,
+                      const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &child) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    void setFileList(const QList<QUrl> &fileList);
+
+private:
+    QList<QUrl> urlList;
+};
+}
+
+#endif   // SHREDFILEMODEL_H

--- a/src/plugins/common/dfmplugin-utils/shred/shredmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredmenuscene.cpp
@@ -91,6 +91,13 @@ bool ShredMenuScene::create(QMenu *parent)
     if (!parent || d->isEmptyArea)
         return false;
 
+    if (UrlRoute::isVirtual(d->currentDir)) {
+        QUrl targetUrl;
+        UniversalUtils::urlTransformToLocal(d->currentDir, &targetUrl);
+        if (targetUrl.scheme() != Global::Scheme::kFile)
+            return false;
+    }
+
     if (d->focusFileInfo.isNull() || !ShredUtils::instance()->isValidFile(d->focusFile))
         return false;
 

--- a/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
@@ -5,6 +5,7 @@
 #include "shredutils.h"
 #include "progressdialog.h"
 #include "fileshredworker.h"
+#include "shredfilemodel.h"
 
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/fileutils.h>
@@ -17,11 +18,9 @@
 #include <DTipLabel>
 #include <DDialog>
 #include <DFrame>
+#include <DListView>
 
-#include <QListWidget>
 #include <QStandardPaths>
-#include <QFileInfo>
-#include <QStorageInfo>
 #include <QRegularExpression>
 #include <QApplication>
 #include <QVBoxLayout>
@@ -210,19 +209,27 @@ bool ShredUtils::confirmAndDisplayFiles(const QList<QUrl> &fileList)
     DFrame *frame = new DFrame(&dialog);
     QVBoxLayout *layout = new QVBoxLayout(frame);
     layout->setContentsMargins(4, 4, 4, 4);
-    QListWidget *listWidget = new QListWidget(frame);
-    listWidget->setFrameShape(QFrame::NoFrame);
-    layout->addWidget(listWidget);
 
-    for (const auto &url : fileList) {
-        auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto);
-        if (!info->exists())
-            continue;
+    DListView *view = new DListView(frame);
+    view->setFixedHeight(200);
+    view->setEditTriggers(QListView::NoEditTriggers);
+    view->setTextElideMode(Qt::ElideMiddle);
+    view->setIconSize(QSize(24, 24));
+    view->setResizeMode(QListView::Adjust);
+    view->setMovement(QListView::Static);
+    view->setSelectionMode(QListView::NoSelection);
+    view->setFrameShape(QFrame::NoFrame);
+    view->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    view->setBackgroundType(DStyledItemDelegate::BackgroundType::RoundedBackground);
+    view->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
+    view->setViewportMargins(0, 0, 0, 0);
+    view->setItemSpacing(1);
+    view->setUniformItemSizes(true);
 
-        QListWidgetItem *item = new QListWidgetItem(info->fileIcon(), info->displayOf(DisPlayInfoType::kFileDisplayName));
-        item->setSizeHint(QSize(item->sizeHint().width(), 35));   // 设置item高度
-        listWidget->addItem(item);
-    }
+    ShredFileModel *model = new ShredFileModel(view);
+    model->setFileList(fileList);
+    view->setModel(model);
+    layout->addWidget(view);
 
     dialog.addContent(frame);
     dialog.addButton(tr("Cancel"));

--- a/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
@@ -71,19 +71,17 @@ void ShredUtils::initDconfig()
 
 bool ShredUtils::isValidFile(const QUrl &file)
 {
-    // 获取真实路径(解析软链接)
     auto info = InfoFactory::create<FileInfo>(file);
-    QString realPath = info->pathOf(FileInfo::FilePathInfoType::kCanonicalPath);
-    if (realPath.isEmpty())
-        realPath = file.toLocalFile();
+    if (!info) return false;
 
-    if (DevProxyMng->isFileOfExternalBlockMounts(realPath))
+    QString filePath = info->pathOf(FileInfo::FilePathInfoType::kAbsoluteFilePath);
+    if (DevProxyMng->isFileOfExternalBlockMounts(filePath))
         return true;
 
     // 如果是数据盘路径，移除前缀后再判断
     QString homePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
-    realPath = FileUtils::bindPathTransform(realPath, false);
-    if (!realPath.startsWith(homePath) || realPath == homePath)
+    filePath = FileUtils::bindPathTransform(filePath, false);
+    if (!filePath.startsWith(homePath) || filePath == homePath)
         return false;
 
     // 检查是否为特殊目录
@@ -99,8 +97,8 @@ bool ShredUtils::isValidFile(const QUrl &file)
     };
 
     // 检查路径是否为受保护目录（只检查目录本身，不包括子目录）
-    if (protectedDirs.contains(realPath)) {
-        fmWarning() << "Cannot shred protected directory: " << realPath;
+    if (protectedDirs.contains(filePath)) {
+        fmWarning() << "Cannot shred protected directory: " << filePath;
         return false;
     }
 

--- a/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
@@ -128,8 +128,7 @@ void ShredUtils::shredfile(const QList<QUrl> &fileList, quint64 winId)
     });
 
     // Create progress dialog
-    auto window = FMWindowsIns.findWindowById(winId);
-    ProgressDialog *progressDialog = new ProgressDialog(window);
+    ProgressDialog *progressDialog = new ProgressDialog();
     progressDialog->setAttribute(Qt::WA_DeleteOnClose);
 
     // Setup signal connections
@@ -142,7 +141,7 @@ void ShredUtils::shredfile(const QList<QUrl> &fileList, quint64 winId)
             });
         } else {
             progressDialog->handleShredResult(false, message);
-            progressDialog->exec();
+            progressDialog->raise();
         }
     });
 


### PR DESCRIPTION
This ensures the elevated dde-file-manager process has access to the
user's data directories for proper application integration and theming.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-332907.html

## Summary by Sourcery

Bug Fixes:
- Include XDG_DATA_DIRS in the environment forwarded by the pkexec wrapper for dde-file-manager