### PR TITLE
fix: ensure bookmark items are always editable

### DIFF
--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -262,7 +262,10 @@ void BookMarkManager::addBookMarkItem(const QUrl &url, const QString &bookmarkNa
             { "Property_Key_VisiableControl", "hidden_me" },
             { "Property_Key_ReportName", kConfigGroupBookmark },
             { "Property_Key_CallbackContextMenu", QVariant::fromValue(contextMenuCb) },
-            { "Property_Key_CallbackRename", QVariant::fromValue(renameCb) }
+            { "Property_Key_CallbackRename", QVariant::fromValue(renameCb) },
+            // 确保非默认书签逻辑可编辑和视图上的默认可编辑（上面的flags标志）一致，否则会出现不对书签进行修改的情况下，
+            // 从新窗口打开的操作导致后续的视图可编辑标志都被移除，从而书签变的无法编辑
+            { "Property_Key_Editable", true }
         };
     }
 


### PR DESCRIPTION
When adding bookmark items to the sidebar, set Property_Key_Editable to true to ensure consistency with the Qt::ItemIsEditable flag. This fixes an issue where bookmark items could not be edited after being opened in a new window.

- The root cause was that bookmark items were created with Qt::ItemIsEditable flag but with isEditable property defaulting to false. When opening in a new window, SideBarModel::updateRow would check isEditable and remove the Qt::ItemIsEditable flag, making the item non-editable in all windows.

bug: https://pms.uniontech.com/bug-view-333141.html

## Summary by Sourcery

Bug Fixes:
- Ensure bookmark items are always editable by adding the Property_Key_Editable flag when creating items