### PR TITLE
fix: Update desktop file handling logic

### DIFF
--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -256,10 +256,6 @@ bool DesktopFileInfo::canAttributes(const CanableInfoType type) const
             return false;
 
         return ProxyFileInfo::canAttributes(type);
-    case FileCanType::kCanRename:
-        if (!isAttributes(OptInfoType::kIsWritable))
-            return false;
-        return ProxyFileInfo::canAttributes(type);
     default:
         return ProxyFileInfo::canAttributes(type);
     }

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -259,7 +259,9 @@ bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)
 {
     Q_ASSERT(info);
     const QString &suffix = info->nameOf(NameInfoType::kSuffix);
-    if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop) {
+    if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop
+        || info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
+        || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool()) {
         const QUrl &url = info->urlOf(UrlInfoType::kUrl);
         QMimeType type = info->fileMimeType();
         if (!type.isValid())

--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -217,7 +217,7 @@ QList<QIcon> EmblemHelper::systemEmblems(const FileInfoPointer &info) const
 
     // feat: story 1477
     // For desktop files hide all system emblem icons
-    if (FileUtils::isDesktopFileSuffix(info->fileUrl()))
+    if (FileUtils::isDesktopFileInfo(info))
         return {};
 
     QList<QIcon> emblems;


### PR DESCRIPTION
- Removed redundant renaming check in DesktopFileInfo::canAttributes.
- Enhanced isDesktopFileInfo function to include additional checks for desktop file identification.
- Updated emblem visibility logic to utilize the new isDesktopFileInfo function for better clarity.

Log: These changes streamline the handling of desktop files and improve the accuracy of file type checks.
Bug: https://pms.uniontech.com/bug-view-332599.html

## Summary by Sourcery

Streamline desktop file handling by removing redundant rename checks, enhancing desktop file detection logic, and updating emblem visibility to leverage the improved detection.

Enhancements:
- Remove redundant rename check in DesktopFileInfo::canAttributes
- Extend FileUtils::isDesktopFileInfo to detect desktop files by location and local device attributes
- Update emblem helper to use isDesktopFileInfo for hiding system emblems on desktop files