### PR TITLE
fix(dialogmanager): simplify error message handling in showErrorDialo…

### DIFF
--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -150,11 +150,8 @@ void DialogManager::showErrorDialogWhenOperateDeviceFailed(OperateType type, DFM
             errMsg = tr("Authentication failed");
         else if (static_cast<int>(err.code) == ENOENT)
             errMsg = tr("No such file or directory");
-        else if (err.code >= DeviceError::kGIOError
-                 && err.code <= DeviceError::kGIOErrorMessageTooLarge)
-            errMsg = err.message;
         else
-            errMsg = tr("Error occured while mounting device");
+            errMsg = tr("Authentication failed");
 
         if (err.message.contains("Operation not permitted.")) {   // TASK(222725)
             errMsg = tr("The device has been blocked and you do not have permission to access it. "


### PR DESCRIPTION
…gWhenOperateDeviceFailed

- Removed redundant error handling for DeviceError::kGIOError range.
- Streamlined the error message assignment to improve code readability and maintainability.

Log: This change enhances the clarity of error handling in the dialog manager, making it easier to understand and maintain.

bug: https://pms.uniontech.com/bug-view-304437.html

## Summary by Sourcery

Simplify the error message logic in showErrorDialogWhenOperateDeviceFailed by removing the redundant GIO error range branch and consolidating the default error message

Enhancements:
- Remove the DeviceError::kGIOError range check to eliminate redundant error handling
- Default unmatched errors to the existing authentication failure message to streamline assignment