### PR TITLE
chore: bump version to 6.5.92

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.92) unstable; urgency=medium
+
+  * fix bugs 
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 11 Sep 2025 20:50:42 +0800
+
 dde-file-manager (6.5.91) unstable; urgency=medium
 
  * fix bugs


### PR DESCRIPTION
6.5.92

Log: bump version to 6.5.92

## Summary by Sourcery

Chores:
- Update debian/changelog version to 6.5.92