### PR TITLE
fix(filemanager): enhance window management and tab opening logic

### DIFF
--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -251,7 +251,7 @@ void SettingBackend::initBasicSettingConfig()
                            tr("Activate existing window when reopening folder"),
                            false);
     addSettingAccessor(
-            LV2_GROUP_OPEN_ACTION ".01_open_folder_windows_in_aseparate_process",
+            LV2_GROUP_OPEN_ACTION ".02_open_folder_windows_in_aseparate_process",
             []() {
                 return !(DConfigManager::instance()->value(kViewDConfName,
                                                            kOpenFolderWindowsInASeparateProcess,


### PR DESCRIPTION
- Improved the logic for opening new tabs and managing active windows in the file manager.
- Introduced a streamlined approach to activate existing windows or create new ones based on user settings.
- Updated signal dispatching for better responsiveness when opening new tabs or windows.

Log: These changes enhance the user experience by ensuring that the file manager effectively manages window states and tab interactions, leading to a more intuitive workflow.

## Summary by Sourcery

Refine the file manager’s window and tab management to use a consistent flag-based approach, activate windows on tab/window open, and update the related configuration key.

Enhancements:
- Streamline tab and window opening logic to respect the open-in-new-tab attribute and separate-process setting
- Automatically activate and restore (un-minimize) existing or newly created windows when opening tabs or windows
- Fallback to the last active or most recently created window when no active window ID is available

Chores:
- Bump the config accessor key for the open-folder-windows-in-a-separate-process setting from .01 to .02