### PR TITLE
fix(folderviewdelegate): improve icon rendering to prevent blur

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/folderviewdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/folderviewdelegate.cpp
@@ -117,13 +117,17 @@ void FolderViewDelegate::paintItemIcon(QPainter *painter, const QStyleOptionView
 
     QStyleOptionViewItem opt = option;
 
-    // draw icon
+    // draw icon (avoid scaling to prevent blur, honor device pixel ratio)
     QRect iconRect = opt.rect.adjusted(kIconLeftPadding, 0, 0, 0);
     iconRect.setSize({ kFolderIconSize, kFolderIconSize });
     iconRect.moveTop(iconRect.top() + (opt.rect.bottom() - iconRect.bottom()) / 2);
 
-    const auto &px = createCustomOpacityPixmap(icon.pixmap(iconRect.size()), 1.0f);
-    painter->drawPixmap(iconRect, px);
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+    QPixmap px = icon.pixmap(iconRect.size() * dpr);
+    px.setDevicePixelRatio(dpr);
+
+    // Draw at top-left without stretching to avoid resampling blur
+    painter->drawPixmap(iconRect.topLeft(), px);
 }
 
 QPixmap FolderViewDelegate::createCustomOpacityPixmap(const QPixmap &px, float opacity) const

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -196,15 +196,21 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
         // Store the state-based visibility
         d->listViewEnabled = !(state & OptionButtonManager::kHideListViewBtn);
         d->iconViewEnabled = !(state & OptionButtonManager::kHideIconViewBtn);
-        d->treeViewEnabled = d->treeViewButton && !(state & OptionButtonManager::kHideTreeViewBtn);
+        // 判断是否需要禁用树视图按钮
+        const bool needDisableTreeBtn = state & OptionButtonManager::kHideTreeViewBtn;
+        // 保持按钮可见，但根据需要禁用它
+        d->treeViewEnabled = d->treeViewButton;
         d->sortByEnabled = !(state & OptionButtonManager::kHideDetailSpaceBtn);
         d->viewOptionsEnabled = !(state & OptionButtonManager::kHideDetailSpaceBtn);
 
         // Apply the state visibility
         d->listViewButton->setHidden(!d->listViewEnabled);
         d->iconViewButton->setHidden(!d->iconViewEnabled);
-        if (d->treeViewButton)
-            d->treeViewButton->setHidden(!d->treeViewEnabled);
+        if (d->treeViewButton) {
+            // 不隐藏按钮，只是在需要时禁用它
+            d->treeViewButton->setHidden(false);
+            d->treeViewButton->setEnabled(!needDisableTreeBtn);
+        }
         d->sortByButton->setHidden(!d->sortByEnabled);
         d->viewOptionsButton->setVisible(d->viewOptionsEnabled);
 
@@ -223,8 +229,11 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
         d->sortByEnabled = true;
         d->viewOptionsEnabled = true;
 
-        if (d->treeViewButton)
+        if (d->treeViewButton) {
             d->treeViewButton->setHidden(false);
+            // 正常状态下，确保启用树视图按钮
+            d->treeViewButton->setEnabled(true);
+        }
         d->listViewButton->setHidden(false);
         d->iconViewButton->setHidden(false);
         d->sortByButton->setHidden(false);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.cpp
@@ -80,6 +80,26 @@ void ItemDelegateHelper::paintIcon(QPainter *painter, const QIcon &icon, const P
         painter->setRenderHints(painter->renderHints() | QPainter::Antialiasing | QPainter::SmoothPixmapTransform, true);
 
         auto iconStyle { IconUtils::getIconStyle(opts.rect.size().toSize().width()) };
+        
+        // 计算可用的图像绘制区域（减去阴影和边框）
+        QRectF availableRect = opts.rect;
+        availableRect.adjust(iconStyle.shadowRange, iconStyle.shadowRange, -iconStyle.shadowRange, -iconStyle.shadowRange);
+        availableRect.adjust(iconStyle.stroke, iconStyle.stroke, -iconStyle.stroke, -iconStyle.stroke);
+        
+        // 计算缩略图的最佳显示尺寸 - 如果小于可用区域则放大铺满
+        qreal scaleX = availableRect.width() / w;
+        qreal scaleY = availableRect.height() / h;
+        qreal scale = qMin(scaleX, scaleY);
+        
+        // 如果原图小于可用区域，则等比放大；否则保持原逻辑
+        if (scale > 1.0) {
+            w *= scale;
+            h *= scale;
+            // 重新计算居中位置
+            x = opts.rect.x() + (opts.rect.width() - w) / 2.0;
+            y = opts.rect.y() + (opts.rect.height() - h) / 2.0;
+        }
+        
         QRect backgroundRect { qRound(x), qRound(y), qRound(w), qRound(h) };
         QRect imageRect { backgroundRect };
 


### PR DESCRIPTION
- Updated the icon drawing logic to honor the device pixel ratio, ensuring that icons are rendered at the correct size without scaling, which prevents blurriness.
- Adjusted the drawing method to place the icon at the top-left of its designated area without stretching.

bug: https://pms.uniontech.com/bug-view-318129.html

 fix(itemdelegatehelper): enhance icon scaling logic for better rendering
    
    - Improved the icon rendering logic to calculate the available drawing area, adjusting for shadows and borders.
    - Implemented scaling logic to ensure icons are proportionally enlarged when the original size is smaller than the available area, enhancing visual presentation.
    
    bug: https://pms.uniontech.com/bug-view-320581.html

