### PR TITLE
fix(connecttoserverdialog): improve history management

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -110,22 +110,6 @@ void ConnectToServerDialog::onButtonClicked(const int &index)
     close();
 }
 
-void ConnectToServerDialog::onCurrentTextChanged(const QString &string)
-{
-    if (string == serverComboBox->itemText(serverComboBox->count() - 1)) {
-        QSignalBlocker blocker(serverComboBox);
-        Q_UNUSED(blocker)
-
-        serverComboBox->clear();
-        serverComboBox->addItem(tr("Clear History"));
-        serverComboBox->clearEditText();
-        serverComboBox->completer()->setModel(new QStringListModel());
-
-        SearchHistroyManager::instance()->clearHistory(supportedSchemes);
-        SearchHistroyManager::instance()->clearIPHistory();
-    }
-}
-
 void ConnectToServerDialog::doDeleteCollection(const QString &text, int row)
 {
     QString deletedItem = text;
@@ -152,6 +136,9 @@ void ConnectToServerDialog::onCurrentInputChanged(const QString &server)
         QSignalBlocker blocker(serverComboBox);
         Q_UNUSED(blocker)
         serverComboBox->clear();
+        // After clearing history, show a disabled "No history" placeholder
+        serverComboBox->addItem(tr("No history"));
+        serverComboBox->model()->setData(serverComboBox->model()->index(serverComboBox->count() - 1, 0), 0, Qt::UserRole - 1);
         serverComboBox->clearEditText();
         serverComboBox->completer()->setModel(new QStringListModel());
         SearchHistroyManager::instance()->clearHistory(supportedSchemes);
@@ -293,8 +280,14 @@ void ConnectToServerDialog::initServerDatas()
 
     completer->setModel(new QStringListModel(hosts, completer));
     if (!hosts.isEmpty()) {
+        // Add a clear-history action as the last item (customData true)
         serverComboBox->addItem(tr("Clear History"), true);
         onCurrentInputChanged(hosts.last());
+    } else {
+        // No history: show a disabled placeholder so dropdown shows a hint
+        serverComboBox->addItem(tr("No history"));
+        serverComboBox->model()->setData(serverComboBox->model()->index(serverComboBox->count() - 1, 0), 0, Qt::UserRole - 1);
+        serverComboBox->clearEditText();
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.h
@@ -36,7 +36,6 @@ public:
 public slots:
     void collectionOperate();
     void onButtonClicked(const int &index);
-    void onCurrentTextChanged(const QString &string);
     void doDeleteCollection(const QString &text, int row = -1);
     void onCurrentInputChanged(const QString &text);
     void onCollectionViewClicked(const QModelIndex &index);


### PR DESCRIPTION
- Removed the `onCurrentTextChanged` method as it was no longer needed.
- Updated the logic for displaying server history, adding a "No history" placeholder when no entries are available.
- Enhanced the handling of the "Clear History" action in the server combo box for better user experience.

Log: These changes streamline the dialog's functionality and improve the clarity of the server history management.
Bug: https://pms.uniontech.com/bug-view-334261.html

## Summary by Sourcery

Simplify and improve server history management in ConnectToServerDialog by removing an obsolete handler, introducing a "No history" placeholder for empty histories, and refining the clear history action behavior.

Enhancements:
- Display a disabled "No history" placeholder when the server history list is empty
- Append a "Clear History" entry to the server combo box for non-empty histories
- Refresh the placeholder and clear the combo box contents immediately after clearing history

Chores:
- Remove the unused onCurrentTextChanged slot and its implementation