### PR TITLE
fix: Button display is incomplete

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -288,8 +288,8 @@ void OpenWithDialog::initUI()
     setToDefaultCheckBox->setChecked(true);
     cancelButton = new DPushButton(tr("Cancel", "button"));
     chooseButton = new DSuggestButton(tr("Confirm", "button"));
-    cancelButton->setFixedWidth(78);
-    chooseButton->setFixedWidth(78);
+    cancelButton->setMinimumWidth(78);
+    chooseButton->setMinimumWidth(78);
     chooseButton->setFocus();
 
     QVBoxLayout *contentLayout = new QVBoxLayout;


### PR DESCRIPTION
log: The issue arises because the fixed width of the “Confirm” button (78 pixels) is insufficient to fully display text in certain languages. Changing `setFixedWidth(78)` to `setMinimumWidth(78)` allows the button to automatically expand based on text length, preventing text truncation.

bug: https://pms.uniontech.com/bug-view-324353.html

## Summary by Sourcery

Bug Fixes:
- Replace fixed width with minimum width for Cancel and Confirm buttons to prevent text truncation