### PR TITLE
fix: When a computer is selected, the computer name is not displayed …

### DIFF
--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -498,14 +498,16 @@ int UniversalUtils::getTextLineHeight(const QModelIndex &index, const QFontMetri
 
 int UniversalUtils::getTextLineHeight(const QString &text, const QFontMetrics &fontMetrics)
 {
+    const int fontHeight = fontMetrics.height();
     if (text.isEmpty())
-        return fontMetrics.height();
+        return fontHeight;
 
-    auto textRect = fontMetrics.boundingRect(text);
-    if (textRect.height() <= 0)
-        return fontMetrics.height();
+    const QRect textRect = fontMetrics.boundingRect(text);
+    const int tightHeight = textRect.height();
+    if (tightHeight <= 0)
+        return fontHeight;
 
-    return textRect.height();
+    return qMax(fontHeight, tightHeight);
 }
 
 /*!


### PR DESCRIPTION
log: 选中（蓝色高亮）时，标签文本的每行高度取自“文本紧边界”而不是字体的完整行高，一些语种（如老挝语）的下加字/下行部件比紧边界更低，导致背景和绘制区域把下沿裁掉。最小修复就是保证把行高统一取“至少为字体行高”，避免被裁切。

bug: https://pms.uniontech.com/bug-view-329957.html