### PR TITLE
fix(filepreviewdialog): add save and restore center position functionality

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
@@ -55,6 +55,10 @@ private:
     void updateTitle();
     QString generalKey(const QString &key);
 
+    // 保存/恢复中心位置，保证切换视图后窗口仍居中到之前的位置
+    void saveCenterPos();
+    void restoreCenterPos();
+
     QList<QUrl> fileList;
 
     DTK_WIDGET_NAMESPACE::DFloatingButton *closeBtn { Q_NULLPTR };
@@ -68,6 +72,8 @@ private:
     quint64 currentWinID { 0 };
     DFMBASE_NAMESPACE::AbstractBasePreview *preview { nullptr };
     DFMBASE_NAMESPACE::DialogManager *dialogManager { nullptr };
+    // 在切换视图前记录中心点, 切换后恢复
+    QPoint previousCenter { 0, 0 };
 };
 }
 #endif

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -139,6 +139,7 @@ void ConnectToServerDialog::onCurrentInputChanged(const QString &server)
         // After clearing history, show a disabled "No history" placeholder
         serverComboBox->addItem(tr("No history"));
         serverComboBox->model()->setData(serverComboBox->model()->index(serverComboBox->count() - 1, 0), 0, Qt::UserRole - 1);
+        serverComboBox->setCurrentIndex(-1);
         serverComboBox->clearEditText();
         serverComboBox->completer()->setModel(new QStringListModel());
         SearchHistroyManager::instance()->clearHistory(supportedSchemes);
@@ -287,6 +288,7 @@ void ConnectToServerDialog::initServerDatas()
         // No history: show a disabled placeholder so dropdown shows a hint
         serverComboBox->addItem(tr("No history"));
         serverComboBox->model()->setData(serverComboBox->model()->index(serverComboBox->count() - 1, 0), 0, Qt::UserRole - 1);
+        serverComboBox->setCurrentIndex(-1);
         serverComboBox->clearEditText();
     }
 }


### PR DESCRIPTION
- Implemented methods to save and restore the window's center position when switching views, ensuring a consistent user experience.
- Updated the UI initialization and page switching logic to incorporate these new methods, enhancing usability when navigating through file previews.

Log: These changes improve the user interface by maintaining the window's position, making it more user-friendly during file preview transitions.
Bug: https://pms.uniontech.com/bug-view-334307.html
