### PR TITLE
fix(viewoptionswidget): bind font size and update label color

### DIFF
--- a/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp
+++ b/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp
@@ -16,6 +16,7 @@
 #include <QProcess>
 #include <QDBusReply>
 #include <QVBoxLayout>
+#include <QEvent>
 
 DFMBASE_USE_NAMESPACE
 using namespace dfmbase;
@@ -28,6 +29,7 @@ UserSharePasswordSettingDialog::UserSharePasswordSettingDialog(QWidget *parent)
 {
     setTitle(tr("Enter a password to protect shared folders"));
     setIcon(QIcon::fromTheme("dialog-password-publicshare"));
+    installEventFilter(this);
     initializeUi();
 }
 
@@ -89,4 +91,14 @@ void UserSharePasswordSettingDialog::onButtonClicked(const int &index)
         Q_EMIT inputPassword(password);
     }
     close();
+}
+
+bool UserSharePasswordSettingDialog::eventFilter(QObject *object, QEvent *event)
+{
+    if (event->type() == QEvent::FontChange || event->type() == QEvent::Show) {
+        // 当字体大小变化或窗口显示时，调整窗口大小以适应内容
+        adjustSize();
+        return true;
+    }
+    return DDialog::eventFilter(object, event);
 }

--- a/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.h
+++ b/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.h
@@ -26,6 +26,9 @@ Q_SIGNALS:
 public Q_SLOTS:
     void onButtonClicked(const int &index);
 
+protected:
+    bool eventFilter(QObject *object, QEvent *event) override;
+
 private:
     DTK_WIDGET_NAMESPACE::DPasswordEdit *passwordEdit;
     QWidget *content;

--- a/src/dfm-base/utils/thumbnail/private/thumbnailworker_p.h
+++ b/src/dfm-base/utils/thumbnail/private/thumbnailworker_p.h
@@ -24,10 +24,6 @@ public:
     bool checkFileStable(const QUrl &url);
     void startDelayWork();
 
-    QUrl setCheckCount(const QUrl &url, int count);
-    int checkCount(const QUrl &url);
-    QUrl clearCheckCount(const QUrl &url);
-
     ThumbnailWorker *q { nullptr };
     DMimeDatabase mimeDb;
     QMap<QString, ThumbnailWorker::ThumbnailCreator> creators;
@@ -36,6 +32,7 @@ public:
     std::atomic_bool isStoped = false;
     QTimer *delayTimer { nullptr };
     ThumbnailWorker::ThumbnailTaskMap delayTaskMap;
+    QMap<QUrl, int> urlCheckCountMap;  // 用于跟踪URL的重试次数
 };
 
 }   // namespace dfmbase

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -686,3 +686,10 @@ void TabBar::mousePressEvent(QMouseEvent *e)
 
     DTabBar::mousePressEvent(e);
 }
+
+void TabBar::resizeEvent(QResizeEvent *e)
+{
+    // 临时修改方案：通过调用setIconSize()，更新内部的layoutDirty标识，强制重新刷新标签页布局
+    setIconSize(iconSize());
+    DTabBar::resizeEvent(e);
+}

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
@@ -55,6 +55,7 @@ protected:
 
     bool eventFilter(QObject *obj, QEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
+    void resizeEvent(QResizeEvent *e) override;
 
 private:
     TabBarPrivate *const d;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -94,16 +94,10 @@ void TitleBarWidget::openNewTab(const QUrl &url)
 
 void TitleBarWidget::handleSplitterAnimation(const QVariant &position)
 {
-    if (position == splitterEndValue) {
-        splitterStartValue = -1;
+    int newWidth = qMax(0, 95 - splitterEndValue);
+    if (position == splitterEndValue)
         splitterEndValue = -1;
-        isSplitterAnimating = false;
-    }
 
-    tabBar()->updateGeometry();
-    tabBar()->adjustSize();
-
-    int newWidth = qMax(0, 95 - position.toInt());
     if (newWidth == placeholder->width())
         return;
 
@@ -112,8 +106,7 @@ void TitleBarWidget::handleSplitterAnimation(const QVariant &position)
 
 void TitleBarWidget::handleAboutToPlaySplitterAnim(int startValue, int endValue)
 {
-    isSplitterAnimating = true;
-    splitterStartValue = startValue;
+    Q_UNUSED(startValue);
     splitterEndValue = endValue;
 }
 
@@ -441,13 +434,6 @@ bool TitleBarWidget::eventFilter(QObject *watched, QEvent *event)
         default:
             break;
         }
-    }
-
-    // if the splitter is animating, do not process the resize event of tabbar
-    // otherwise, the tabbar width will be changed twice(once by the resizeEvent and once by placeholder size changed)
-    if (watched == bottomBar && event->type() == QEvent::Resize) {
-        if (isSplitterAnimating)
-            return true;
     }
 
     return false;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -97,9 +97,7 @@ private:
     QWidget *placeholder { nullptr };
 
     bool searchButtonSwitchState { false };
-    int splitterStartValue { -1 };
     int splitterEndValue { -1 };
-    bool isSplitterAnimating { false };
 
     struct TitleBarState
     {

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -138,6 +138,7 @@ void ViewOptionsWidgetPrivate::initializeUi()
     QFrame *listHeightLabelFrame = new QFrame(q);
     listHeightLabelFrame->setFixedWidth(10);
     listHeightTitle = new DLabel(tr("List height"), q);
+    DFontSizeManager::instance()->bind(listHeightTitle, DFontSizeManager::T10, QFont::Normal);
     listHeightLabelLayout->addWidget(listHeightLabelFrame);
     listHeightLabelLayout->addWidget(listHeightTitle);
     listHeightLayout->addLayout(listHeightLabelLayout);
@@ -182,6 +183,7 @@ void ViewOptionsWidgetPrivate::initializeUi()
         pa.setColor(DPalette::WindowText, textColor);
         iconSizeTitle->setPalette(pa);
         gridDensityTitle->setPalette(pa);
+        listHeightTitle->setPalette(pa);
     };
     updateLabelColor();
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,

--- a/src/plugins/filemanager/dfmplugin-workspace/views/headerview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/headerview.h
@@ -38,6 +38,8 @@ protected:
     void leaveEvent(QEvent *e) override;
     void contextMenuEvent(QContextMenuEvent *event) override;
     void paintEvent(QPaintEvent *e) override;
+    void paintSection(QPainter *painter, const QRect &rect, int logicalIndex) const override;
+    bool event(QEvent *e) override;
 
 Q_SIGNALS:
     void mousePressed();
@@ -47,6 +49,8 @@ Q_SIGNALS:
 
 private:
     FileViewModel *viewModel() const;
+    QString sectionElidedName(int logicalIndex, int availableWidth) const;
+    QString sectionName(int logicalIndex) const;
 
     FileView *view { nullptr };
     int firstVisibleColumn = -1;


### PR DESCRIPTION
- Bound the font size of the list height label to ensure consistent text rendering.
- Updated the palette of the list height label to match the theme, enhancing visual coherence in the UI.

Log: These changes improve the appearance and usability of the view options widget by ensuring that the list height label is properly styled and visible in different themes.
Bug: https://pms.uniontech.com/bug-view-334305.html
