### PR TITLE
chore: release version 6.5.93

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.93) unstable; urgency=medium
+
+ * fix bugs
+ * new features 
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 18 Sep 2025 20:40:14 +0800
+
 dde-file-manager (6.5.92) unstable; urgency=medium
 
   * fix bugs 


### PR DESCRIPTION
as title

Log: release version

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.5.93 release