### PR TITLE
fix(filedialog): adjust default view mode handling in FileDialogHandleDBus

### DIFF
--- a/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
@@ -81,7 +81,9 @@ void FileDialogHandleDBus::setFilter(int filters)
 
 void FileDialogHandleDBus::setViewMode(int mode)
 {
-    FileDialogHandle::setViewMode(static_cast<QFileDialog::ViewMode>(mode));
+    // 打开文件对话框时（QFileDialog），视图模式默认为 Detail（列表模式），与文管自身的逻辑冲突
+    // 文管会根据url获取其配置的视图模式进行显示
+    // FileDialogHandle::setViewMode(static_cast<QFileDialog::ViewMode>(mode));
 }
 
 int FileDialogHandleDBus::viewMode() const


### PR DESCRIPTION
- Updated the setViewMode method to comment out the default view mode setting, aligning it with the file manager's logic that retrieves the view mode based on the URL configuration.
- This change resolves a conflict between the default view mode and the file manager's intended behavior.

Log: This adjustment improves consistency in the file dialog's view mode display, enhancing user experience when opening file dialogs.
Bug: https://pms.uniontech.com/bug-view-311137.html

## Summary by Sourcery

Bug Fixes:
- Remove the default view mode setting in setViewMode to resolve conflicts with the file manager’s intended behavior.