### PR TITLE
fix(commandparser): enhance tab opening logic with active window check

### DIFF
--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -364,7 +364,8 @@ void CommandParser::openWindowWithUrl(const QUrl &url)
     }
 
     auto flag = !DConfigManager::instance()->value(kViewDConfName, kOpenFolderWindowsInASeparateProcess, true).toBool();
-    if (Application::appAttribute(Application::kOpenInNewTab).toBool() && !FMWindowsIns.windowIdList().isEmpty()) {
+    auto actWinId = FMWindowsIns.lastActivedWindowId();
+    if (Application::appAttribute(Application::kOpenInNewTab).toBool() && actWinId > 0) {
         auto activeWindow = [](FileManagerWindow *w) {
             if (w->isMinimized())
                 w->setWindowState(w->windowState() & ~Qt::WindowMinimized);
@@ -379,11 +380,8 @@ void CommandParser::openWindowWithUrl(const QUrl &url)
             }
         }
 
-        auto winId = FMWindowsIns.lastActivedWindowId();
-        if (winId <= 0)
-            winId = FMWindowsIns.windowIdList().last();
-        dpfSignalDispatcher->publish(GlobalEventType::kOpenNewTab, winId, url);
-        auto window = FMWindowsIns.findWindowById(winId);
+        dpfSignalDispatcher->publish(GlobalEventType::kOpenNewTab, actWinId, url);
+        auto window = FMWindowsIns.findWindowById(actWinId);
         if (window)
             activeWindow(window);
     } else {


### PR DESCRIPTION
- Updated the logic for opening new tabs to utilize the last active window ID, ensuring that new tabs are opened in the correct context.
- Removed redundant checks for window ID, streamlining the tab opening process and improving overall performance.

Log: These changes improve the user experience by ensuring that new tabs are opened in the most relevant window, enhancing navigation within the file manager.
Bug: https://pms.uniontech.com/bug-view-335179.html

## Summary by Sourcery

Enhance tab opening logic to use the last active window ID and remove redundant window ID checks

Bug Fixes:
- Ensure new tabs open in the correct window context by validating the last active window ID

Enhancements:
- Streamline the tab opening process by removing fallback logic and redundant window ID checks