### PR TITLE
fix(progressdialog): update setValue method to improve file shredding messages

### DIFF
--- a/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
@@ -30,13 +30,16 @@ ProgressWidget::ProgressWidget(QWidget *parent)
     setLayout(mainLay);
 }
 
-void ProgressWidget::setValue(int value, const QString &fileName)
+void ProgressWidget::setValue(int value, const QString &msg)
 {
     progress->start();
     if (value > progress->value())
         progress->setValue(value);
-    if (!fileName.isEmpty())
-        infoLable->setText(tr("Shredding file \" %1 \"").arg(fileName));
+
+    if (value < 100 && !msg.isEmpty())
+        infoLable->setText(tr("Shredding file \" %1 \"").arg(msg));
+    else if (value == 100)
+        infoLable->setText(msg);
 }
 
 void ProgressWidget::stopProgress()

--- a/src/plugins/common/dfmplugin-utils/shred/progressdialog.h
+++ b/src/plugins/common/dfmplugin-utils/shred/progressdialog.h
@@ -24,7 +24,7 @@ class ProgressWidget : public QWidget
 
 public:
     explicit ProgressWidget(QWidget *parent = Q_NULLPTR);
-    void setValue(int value, const QString &fileName);
+    void setValue(int value, const QString &msg);
     void stopProgress();
 
 private:


### PR DESCRIPTION
- Renamed the parameter in setValue from fileName to msg for clarity.
- Updated the logic to display shredding messages based on the progress value, enhancing user feedback during file shredding operations.

Log: These changes improve the user experience by providing more relevant messages during the shredding process, ensuring users are informed of the operation's status.
Bug: https://pms.uniontech.com/bug-view-335151.html

## Summary by Sourcery

Improve shredding progress dialog by renaming the parameter and refining displayed messages based on progress value to enhance user feedback.

Bug Fixes:
- Rename setValue parameter from fileName to msg for clarity
- Show the "Shredding file" message only when progress is below 100% and display the final message when progress reaches 100%