### PR TITLE
fix: improve URL push button font handling

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/urlpushbutton_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/urlpushbutton_p.h
@@ -50,6 +50,7 @@ private:
     bool isSubDir(int x) const;
     QColor foregroundColor() const;
     bool popupVisible() const;
+    void adjustButtonFont();
 
     void requestCompleteByUrl(const QUrl &url);
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.h
@@ -56,6 +56,7 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void changeEvent(QEvent *event) override;
 };
 
 }   // namespace dfmplugin_titlebar


### PR DESCRIPTION
1. Added adjustButtonFont() method to dynamically adjust font size based
on available vertical space
2. Moved font adjustment logic from paintEvent to changeEvent for better
performance
3. Implemented minimum font size constraints (8pt minimum, max 3pt
reduction)
4. Improved font metrics calculations for better text rendering
5. Removed redundant font updates in paintEvent

Log: Improved URL navigation button text display with dynamic font
sizing

Influence:
1. Test URL button with different font sizes in system settings
2. Verify text rendering in buttons with limited vertical space
3. Check font adjustment behavior when resizing window
4. Test with long URLs to ensure proper text clipping
5. Verify minimum font size enforcement
Bug: https://pms.uniontech.com/bug-view-333353.html

## Summary by Sourcery

Enhance URL push button font handling by adding dynamic font sizing with minimum size constraints, relocating adjustment logic to changeEvent for efficiency, and removing unnecessary updates in paintEvent

New Features:
- Introduce adjustButtonFont to automatically reduce font size based on button height, respecting an 8pt minimum and three-point max reduction

Bug Fixes:
- Remove redundant font updates in paintEvent to streamline rendering

Enhancements:
- Trigger font adjustment in changeEvent on FontChange instead of paintEvent to boost performance
- Refine font metrics usage by consistently applying the adjusted font in rendering routines