### PR TITLE
fix: prevent cutting files without rename permission

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.h
@@ -6,7 +6,6 @@
 #define DOCUTFILESWORKER_H
 
 #include "dfmplugin_fileoperations_global.h"
-#include "fileoperations/fileoperationutils/abstractworker.h"
 #include "fileoperations/fileoperationutils/fileoperatebaseworker.h"
 
 #include <dfm-base/interfaces/abstractjobhandler.h>
@@ -37,9 +36,9 @@ protected:
 
     bool cutFiles();
     bool doCutFile(const DFileInfoPointer &fromInfo, const DFileInfoPointer &targetPathInfo, bool *skip);
-    DFileInfoPointer doRenameFile(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetPathInfo,
-                                 const QString fileName, bool *ok, bool *skip);
-    bool renameFileByHandler(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetInfo);
+    bool renameFileByHandler(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetInfo, bool *skip);
+    DFileInfoPointer trySameDeviceRename(const DFileInfoPointer &sourceInfo, const DFileInfoPointer &targetPathInfo,
+                                         const QString fileName, bool *ok, bool *skip);
 
     void emitCompleteFilesUpdatedNotify(const qint64 &writCount);
     bool doMergDir(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo, bool *skip);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -158,8 +158,6 @@ bool FileOperateBaseWorker::checkDiskSpaceAvailable(const QUrl &fromUrl,
     AbstractJobHandler::SupportAction action = AbstractJobHandler::SupportAction::kNoAction;
 
     do {
-        action = AbstractJobHandler::SupportAction::kNoAction;
-
         qint64 freeBytes = DeviceUtils::deviceBytesFree(targetOrgUrl);
         action = AbstractJobHandler::SupportAction::kNoAction;
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -92,9 +92,9 @@ protected:
     QUrl trashInfo(const DFileInfoPointer &fromInfo);
     QString fileOriginName(const QUrl &trashInfoUrl);
     void removeTrashInfo(const QUrl &trashInfoUrl);
+    void setSkipValue(bool *skip, AbstractJobHandler::SupportAction action);
 
 private:
-    void setSkipValue(bool *skip, AbstractJobHandler::SupportAction action);
     void initSignalCopyWorker();
     bool actionOperating(const AbstractJobHandler::SupportAction action, const qint64 size, bool *skip);
     QUrl createNewTargetUrl(const DFileInfoPointer &toInfo, const QString &fileName);

--- a/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
@@ -130,11 +130,6 @@ void ClipBoardMenuScene::updateState(QMenu *parent)
             if (!d->focusFileInfo->isAttributes(OptInfoType::kIsReadable) && !d->focusFileInfo->isAttributes(OptInfoType::kIsSymLink))
                 copy->setDisabled(true);
         }
-
-        if (auto cut = d->predicateAction.value(ActionID::kCut)) {
-            if (!d->focusFileInfo->canAttributes(CanableInfoType::kCanRename))
-                cut->setDisabled(true);
-        }
     }
 
     AbstractMenuScene::updateState(parent);

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.cpp
@@ -141,6 +141,8 @@ void GroupedModelData::rebuildFlattenedItems()
 
 void GroupedModelData::clear()
 {
+    QMutexLocker locker(&m_mutex);
+
     groups.clear();
     flattenedItems.clear();
     groupExpansionStates.clear();

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -2000,14 +2000,8 @@ QVariant FileSortWorker::data(const SortInfoPointer &info, Global::ItemRoles rol
             return info->customData("fast_mime_type");
         }
         QString type;
-        if (ProtocolUtils::isRemoteFile(info->fileUrl())) {
-            // For remote files, use fast extension-based detection
-            type = SortUtils::fastMimeType(info->fileUrl());
-        } else {
-            // For local files, use accurate content-based detection for proper sorting
-            type = SortUtils::accurateLocalMimeType(info->fileUrl());
-        }
-
+        // For local files, use accurate content-based detection for proper sorting
+        type = SortUtils::accurateLocalMimeType(info->fileUrl());
         const_cast<SortInfoPointer &>(info)->setCustomData("fast_mime_type", type);
         return type;
     }


### PR DESCRIPTION
1. Modified the renameFileByHandler function to properly handle permission errors during file cutting operations
2. Added permission checks before attempting cut operations
3. Improved error handling flow by propagating permission errors to UI level
4. Removed disabled state toggle from menu UI since backend now properly blocks unauthorized cuts
5. Separated same-device rename logic into trySameDeviceRename for cleaner code structure
6. Added explicit permission checking before attempting any rename operations

The changes ensure that files without rename permission cannot be cut through any interface (menu or drag-drop), resolving the security issue where files could be moved despite lacking proper permissions.

Bug: https://pms.uniontech.com/bug-view-335159.html

fix: 修复没有重命名权限的文件被剪切的问题

1. 修改renameFileByHandler函数以正确处理文件剪切时的权限错误
2. 在进行剪切操作前添加权限检查
3. 改进错误处理流程，将权限错误传递到UI层面
4. 移除菜单UI中的禁用状态切换，因为后端现已正确拦截未授权剪切
5. 将相同设备重命名逻辑分离到trySameDeviceRename函数中使代码结构更清晰
6. 在尝试任何重命名操作前添加明确的权限检查

这些更改确保没有重命名权限的文件不能通过任何界面(菜单或拖放)被剪切，解决
了由于缺乏适当权限却仍能移动文件的安全问题。

## Summary by Sourcery

Enforce rename permissions on file cut operations, propagate permission errors to the UI, and refactor cut logic by separating same-device renames and standardizing fallback behavior.

Bug Fixes:
- Prevent unauthorized file cuts by adding explicit permission checks before rename operations and blocking actions when permission is denied

Enhancements:
- Extract same-device rename logic into trySameDeviceRename and centralize copy-and-delete fallback for cross-device moves
- Improve error handling in renameFileByHandler to surface permission errors and support retry/skip actions
- Remove menu UI disable toggle for cut action since permission enforcement now occurs backend-side
- Add setSkipValue helper in FileOperateBaseWorker to streamline skip flag handling