### PR TITLE
fix: prevent duplicate sidebar item updates

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -75,9 +75,8 @@ bool SideBarEventReceiver::handleItemAdd(const QUrl &url, const QVariantMap &pro
     // TODO(zhangs): use model direct
     ItemInfo info { url, properties };
     if (SideBarInfoCacheMananger::instance()->contains(info)) {
-        fmInfo() << "item already added to sidebar, update it." << url;
-        handleItemUpdate(url, properties);
-        return true;
+        fmInfo() << "item already added to sidebar." << url;
+        return false;
     }
 
     SideBarItem *item = SideBarHelper::createItemByInfo(info);


### PR DESCRIPTION
1. Changed behavior when detecting duplicate sidebar items
2. Previously would update existing item, now simply returns false
3. Removed redundant update call that could cause UI flickering
4. Log message updated to be more accurate

Log: Fixed issue where duplicate sidebar items would cause unnecessary
updates

Influence:
1. Test adding duplicate items to sidebar - should not cause updates
2. Verify sidebar stability when adding existing items
3. Check for any UI flickering when managing sidebar items
4. Ensure all sidebar operations work as expected

fix: 防止侧边栏项目重复更新

1. 修改检测到重复侧边栏项目时的行为
2. 之前会更新现有项目，现在直接返回false
3. 移除了可能导致UI闪烁的冗余更新调用
4. 更新日志信息使其更准确

Log: 修复了重复侧边栏项目导致不必要更新的问题

Influence:
1. 测试向侧边栏添加重复项目 - 不应触发更新
2. 验证添加现有项目时的侧边栏稳定性
3. 检查管理侧边栏项目时是否有UI闪烁
4. 确保所有侧边栏操作正常工作

Bug: https://pms.uniontech.com/bug-view-335293.html

## Summary by Sourcery

Prevent duplicate sidebar items from causing unnecessary updates by returning false instead of updating existing entries, removing redundant update calls, and updating the log message for accuracy

Bug Fixes:
- Prevent duplicate sidebar items from triggering handleItemUpdate and return false
- Remove redundant update call that caused UI flickering
- Update log message for duplicate sidebar items to reflect the new behavior