### PR TITLE
fix bugs

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
@@ -162,8 +162,8 @@ void UserShareHelper::setSambaPasswd(const QString &userName, const QString &pas
 
     // Write credentials to pipe and close write end immediately
     ssize_t written = write(pipefd[1], credentials.constData(), credentials.size());
-    close(pipefd[1]);  // Close write end immediately after writing
-    
+    close(pipefd[1]);   // Close write end immediately after writing
+
     if (written != credentials.size()) {
         fmInfo() << "Failed to write credentials to pipe, written:" << written << "expected:" << credentials.size();
         close(pipefd[0]);
@@ -188,7 +188,7 @@ void UserShareHelper::setSambaPasswd(const QString &userName, const QString &pas
 
     // Close read end (D-Bus service will have its own copy)
     close(pipefd[0]);
-    
+
     Q_EMIT sambaPasswordSet(success);
 }
 
@@ -400,7 +400,7 @@ void UserShareHelper::readShareInfos(bool sendSignal)
         QMap<QString, QString> info;
         QTextStream stream(&file);
         while (!stream.atEnd()) {
-            QString line = stream.readLine().trimmed();
+            QString line = stream.readLine();
             if (!line.isEmpty() && line.contains("=")) {
                 int idx = line.indexOf("=");
                 QString key = line.mid(0, idx);

--- a/src/plugins/filemanager/dfmplugin-myshares/events/shareeventscaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/events/shareeventscaller.cpp
@@ -17,19 +17,25 @@ void ShareEventsCaller::sendOpenDirs(quint64 winId, const QList<QUrl> &urls, Sha
     if (urls.count() == 0)
         return;
 
+    QList<QUrl> convertedUrls = urls;
+    for (auto &url : convertedUrls) {
+        auto u = ShareUtils::convertToLocalUrl(url);
+        url = u.isValid() ? u : url;
+    }
+
     if (urls.count() > 1) {
-        for (const auto &url : urls)
+        for (auto url : convertedUrls)
             dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, url);
     } else {
         switch (mode) {
         case ShareEventsCaller::OpenMode::kOpenInCurrentWindow:
-            dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, winId, urls.first());
+            dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, winId, convertedUrls.first());
             break;
         case ShareEventsCaller::OpenMode::kOpenInNewWindow:
-            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, urls.first());
+            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewWindow, convertedUrls.first());
             break;
         case ShareEventsCaller::OpenMode::kOpenInNewTab:
-            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewTab, winId, urls.first());
+            dpfSignalDispatcher->publish(GlobalEventType::kOpenNewTab, winId, convertedUrls.first());
             break;
         }
     }

--- a/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/fileinfo/sharefileinfo.cpp
@@ -29,8 +29,10 @@ QString ShareFileInfo::displayOf(const DisPlayInfoType type) const
         if (UrlRoute::isRootUrl(url))
             return QObject::tr("My Shares");
 
-        if (DisPlayInfoType::kFileDisplayName == type)
-            return d->fileName();
+        auto name = d->fileName();
+        if (name.isEmpty())
+            name = ProxyFileInfo::displayOf(type);
+        return name;
     }
     return ProxyFileInfo::displayOf(type);
 }

--- a/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
@@ -5,9 +5,12 @@
 #include "shareiterator.h"
 #include "private/shareiterator_p.h"
 #include "utils/shareutils.h"
+#include "fileinfo/sharefileinfo.h"
 
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/file/local/localdiriterator.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -16,8 +19,10 @@ DFMBASE_USE_NAMESPACE
 
 ShareIterator::ShareIterator(const QUrl &url, const QStringList &nameFilters, QDir::Filters filters, QDirIterator::IteratorFlags flags)
     : AbstractDirIterator(url, nameFilters, filters, flags),
-      d(new ShareIteratorPrivate(this))
+      d(new ShareIteratorPrivate(this, url))
 {
+    if (!UniversalUtils::urlEquals(url, ShareUtils::rootUrl()))
+        d->proxy = new LocalDirIterator(ShareUtils::convertToLocalUrl(url), nameFilters, filters, flags);
 }
 
 ShareIterator::~ShareIterator()
@@ -26,6 +31,9 @@ ShareIterator::~ShareIterator()
 
 QUrl ShareIterator::next()
 {
+    if (d->proxy)
+        return QUrl::fromLocalFile(d->proxy->next().path());
+
     if (d->shares.isEmpty())
         return {};
 
@@ -36,16 +44,25 @@ QUrl ShareIterator::next()
 
 bool ShareIterator::hasNext() const
 {
+    if (d->proxy)
+        return d->proxy->hasNext();
+
     return !d->shares.isEmpty();
 }
 
 QString ShareIterator::fileName() const
 {
+    if (d->proxy)
+        return d->proxy->fileName();
+
     return d->currentInfo.value(ShareInfoKeys::kName).toString();
 }
 
 QUrl ShareIterator::fileUrl() const
 {
+    if (d->proxy)
+        return d->proxy->fileUrl().path();
+
     return QUrl::fromLocalFile(d->currentInfo.value(ShareInfoKeys::kPath).toString());
 }
 
@@ -56,13 +73,17 @@ const FileInfoPointer ShareIterator::fileInfo() const
 
 QUrl ShareIterator::url() const
 {
+    if (d->rootUrl.isValid())
+        return d->rootUrl;
+
     return ShareUtils::rootUrl();
 }
 
-ShareIteratorPrivate::ShareIteratorPrivate(ShareIterator *qq)
+ShareIteratorPrivate::ShareIteratorPrivate(ShareIterator *qq, const QUrl &url)
     : q(qq)
 {
     shares = dpfSlotChannel->push("dfmplugin_dirshare", "slot_Share_AllShareInfos").value<QList<QVariantMap>>();
+    rootUrl = url;
 }
 
 ShareIteratorPrivate::~ShareIteratorPrivate()

--- a/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/iterator/shareiterator.cpp
@@ -32,7 +32,7 @@ ShareIterator::~ShareIterator()
 QUrl ShareIterator::next()
 {
     if (d->proxy)
-        return QUrl::fromLocalFile(d->proxy->next().path());
+        return ShareUtils::makeShareUrl(d->proxy->next().path());
 
     if (d->shares.isEmpty())
         return {};
@@ -61,9 +61,9 @@ QString ShareIterator::fileName() const
 QUrl ShareIterator::fileUrl() const
 {
     if (d->proxy)
-        return d->proxy->fileUrl().path();
+        return ShareUtils::makeShareUrl(d->proxy->fileUrl().path());
 
-    return QUrl::fromLocalFile(d->currentInfo.value(ShareInfoKeys::kPath).toString());
+    return ShareUtils::makeShareUrl(d->currentInfo.value(ShareInfoKeys::kPath).toString());
 }
 
 const FileInfoPointer ShareIterator::fileInfo() const

--- a/src/plugins/filemanager/dfmplugin-myshares/myshares.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/myshares.cpp
@@ -15,6 +15,7 @@
 
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
 
+#include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
@@ -24,6 +25,7 @@
 #include <DMenu>
 
 DWIDGET_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
 
 using ContextMenuCallback = std::function<void(quint64 windowId, const QUrl &url, const QPoint &globalPos)>;
 Q_DECLARE_METATYPE(QList<QUrl> *)
@@ -210,6 +212,11 @@ void MyShares::doInitialize()
 
     dpfSignalDispatcher->subscribe("dfmplugin_dirshare", "signal_Share_ShareAdded", this, &MyShares::onShareAdded);
     dpfSignalDispatcher->subscribe("dfmplugin_dirshare", "signal_Share_ShareRemoved", this, &MyShares::onShareRemoved);
+
+    QVariantMap property;
+    property[ViewCustomKeys::kSupportTreeMode] = false;
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_SetCustomViewProperty", ShareUtils::scheme(), property);
+    dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", ShareUtils::scheme(), property);
 
     followEvents();
     bindWindows();

--- a/src/plugins/filemanager/dfmplugin-myshares/private/shareiterator_p.h
+++ b/src/plugins/filemanager/dfmplugin-myshares/private/shareiterator_p.h
@@ -7,6 +7,12 @@
 
 #include "dfmplugin_myshares_global.h"
 
+#include <QUrl>
+
+namespace dfmbase {
+class LocalDirIterator;
+}
+
 namespace dfmplugin_myshares {
 
 class ShareIterator;
@@ -15,13 +21,17 @@ class ShareIteratorPrivate
     friend class ShareIterator;
 
 public:
-    explicit ShareIteratorPrivate(ShareIterator *qq);
+    explicit ShareIteratorPrivate(ShareIterator *qq, const QUrl &url);
     ~ShareIteratorPrivate();
 
 private:
+    dfmbase::LocalDirIterator *proxy { nullptr };
+
     ShareIterator *q { nullptr };
     ShareInfoList shares;
     ShareInfo currentInfo;
+
+    QUrl rootUrl;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-myshares/watcher/sharewatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-myshares/watcher/sharewatcher.cpp
@@ -24,7 +24,7 @@ ShareWatcher::~ShareWatcher()
 
 void ShareWatcher::shareAdded(const QString &path)
 {
-    const auto &url = QUrl::fromLocalFile(path);
+    auto &&url = ShareUtils::makeShareUrl(path);
     auto info = InfoFactory::create<FileInfo>(url);
     if (info)
         info->refresh();   // make sure that the cache can be updated if share's name updated.
@@ -33,7 +33,7 @@ void ShareWatcher::shareAdded(const QString &path)
 
 void ShareWatcher::shareRemoved(const QString &path)
 {
-    Q_EMIT fileDeleted(QUrl::fromLocalFile(path));
+    Q_EMIT fileDeleted(ShareUtils::makeShareUrl(path));
 }
 
 ShareWatcherPrivate::ShareWatcherPrivate(const QUrl &fileUrl, ShareWatcher *qq)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -104,7 +104,7 @@ FileSortWorker::GroupingOpt FileSortWorker::setGroupArguments(const Qt::SortOrde
     if (!currentStrategy) {
         return FileSortWorker::GroupingOpt::kGroupingOptNone;
     }
-    isCurrentGroupingEnabled = (currentStrategy->getStrategyName() == GroupStrategty::kNoGroup) ? false : true;
+    isCurrentGroupingEnabled = !(currentStrategy->getStrategyName() == GroupStrategty::kNoGroup);
     groupExpansionStates.clear();
     for (const auto &key : expandStates.keys()) {
         groupExpansionStates.insert(key, expandStates.value(key).toBool());
@@ -653,6 +653,9 @@ void FileSortWorker::handleReGrouping(const Qt::SortOrder order, const QString &
     auto opt = setGroupArguments(order, strategy, expansionStates);
     if (opt == GroupingOpt::kGroupingOptNone) {
         clearGroupedData();
+        if (!currentIsGroupingMode()) {
+            handleRefresh();
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Fix various bugs and improve URL handling in the MyShares plugin by integrating local directory iteration for non-root share URLs, correcting event dispatching, refining file info display, and adjusting UI properties.

Bug Fixes:
- Use LocalDirIterator proxy for non-root share URLs in ShareIterator to properly iterate directories
- Convert share URLs to local URLs in ShareEventsCaller before publishing open/change events
- Correct read/write flow and line parsing in UserShareHelper to avoid trimming issues
- Emit share URLs via ShareUtils::makeShareUrl in ShareWatcher instead of converting from local file paths

Enhancements:
- Fall back to ProxyFileInfo display in ShareFileInfo when the share name is empty
- Disable tree view and register custom view/titlebar properties for the MyShares plugin in the UI