### PR TITLE
chore: bump version to 6.5.94

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.94) unstable; urgency=medium
+
+  * feat: file grouping
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 25 Sep 2025 21:32:46 +0800
+
 dde-file-manager (6.5.93) unstable; urgency=medium
 
  * fix bugs


### PR DESCRIPTION
6.5.94

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog to version 6.5.94