### PR TITLE
fix: remove unnecessary directory write permission check for rename

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -971,9 +971,6 @@ bool AsyncFileInfoPrivate::canRename() const
     bool canRename = false;
     canRename = SysInfoUtils::isRootUser();
     if (!canRename) {
-        // dir can not write, will can not rename
-        if (this->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() && !this->attribute(DFileInfo::AttributeID::kAccessCanWrite).toBool())
-            return false;
         return this->attribute(DFileInfo::AttributeID::kAccessCanRename).toBool();
     }
 

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -996,10 +996,6 @@ bool SyncFileInfoPrivate::canRename() const
     bool canRename = false;
     canRename = SysInfoUtils::isRootUser();
     if (!canRename) {
-        // dir can not write, can not rename
-        if (this->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool() && !this->attribute(DFileInfo::AttributeID::kAccessCanWrite).toBool())
-            return false;
-
         return this->attribute(DFileInfo::AttributeID::kAccessCanRename).toBool();
     }
 


### PR DESCRIPTION
1. Removed redundant write permission check when determining rename capability for directories
2. The behavior now consistently relies on kAccessCanRename attribute for all file types
3. This simplifies permission logic and prevents false negatives where renaming might be allowed despite write restrictions

Bug: https://pms.uniontech.com/bug-view-335921.html

fix: 移除重命名操作中不必要的目录写权限检查

1. 删除在确定目录重命名能力时多余的写权限检查
2. 现在统一对所有文件类型使用kAccessCanRename属性判断重命名能力
3. 这简化了权限逻辑，避免了因写权限限制导致的误判问题

## Summary by Sourcery

Simplify directory rename permission logic by removing redundant write permission checks and relying solely on the kAccessCanRename attribute for all file types.

Bug Fixes:
- Eliminate cases where directories lacking write permission but allowed to rename were incorrectly blocked.

Enhancements:
- Unify rename capability checks in SyncFileInfoPrivate and AsyncFileInfoPrivate to use only kAccessCanRename.