### PR TITLE
fix: correct tooltip position detection with horizontal scroll

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -36,6 +36,7 @@
 #include <QToolTip>
 #include <QMouseEvent>
 #include <QPainterPath>
+#include <QScrollBar>
 
 #include <linux/limits.h>
 
@@ -212,11 +213,20 @@ bool ListItemDelegate::helpEvent(QHelpEvent *event, QAbstractItemView *view, con
         const QList<QRect> &geometries = paintGeomertys(option, index);
 
         QString tooltip {};
+        // 获取横向滚动偏移量，用于修正tooltip位置检测
+        int horizontalOffset = 0;
+        if (view)
+            horizontalOffset = view->horizontalScrollBar()->value();
+
         // 从1开始是为了排除掉icon区域
         for (int i = d->paintProxy->iconRectIndex() + 1; i < geometries.length() && i <= columnRoleList.length(); ++i) {
             const QRect &rect = geometries.at(i);
 
-            if (rect.left() <= event->x() && rect.right() >= event->x()) {
+            // 考虑横向滚动偏移量调整rect位置
+            QRect adjustedRect = rect;
+            adjustedRect.translate(-horizontalOffset, 0);
+
+            if (adjustedRect.left() <= event->x() && adjustedRect.right() >= event->x()) {
                 const QString &tipStr = index.data(columnRoleList[i - d->paintProxy->iconRectIndex() - 1]).toString();
 
                 if (option.fontMetrics.horizontalAdvance(tipStr) > rect.width()) {


### PR DESCRIPTION
The tooltip position detection in list item delegate was not accounting
for horizontal scroll offset, causing incorrect tooltip display
when items were scrolled horizontally. Added QScrollBar include and
horizontal offset calculation to adjust the detection rectangle position
based on current scroll position.

Log: Fixed tooltip display issue when horizontally scrolling file list

Influence:
1. Open file manager with wide columns that require horizontal scrolling
2. Scroll horizontally and hover over truncated text in list view
3. Verify tooltips appear correctly aligned with visible text content
4. Test with various scroll positions to ensure consistent behavior

fix: 修复水平滚动时工具提示位置检测问题

列表项委托中的工具提示位置检测未考虑水平滚动偏移量，导致在水平滚动项目时
工具提示显示不正确。添加了QScrollBar包含和水平偏移量计算，根据当前滚动位
置调整检测矩形位置。

Log: 修复水平滚动文件列表时工具提示显示问题

Influence:
1. 打开需要水平滚动的宽列文件管理器
2. 水平滚动并在列表视图中悬停截断的文本
3. 验证工具提示是否正确与可见文本内容对齐
4. 测试各种滚动位置以确保一致的行为

Bug: https://pms.uniontech.com/bug-view-335813.html

## Summary by Sourcery

Bug Fixes:
- Fix tooltip display when horizontally scrolling file list by accounting for horizontal scroll offset in detection rectangle