### PR TITLE
refactor: simplify custom tab item removal logic

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
@@ -71,12 +71,7 @@ void CustomTabSettingWidget::addCustomItem(DSettingsOption *opt, const QUrl &url
             [=] {
                 if (removeRow(delBtn)) {
                     auto itemList = opt->value().toStringList();
-                    for (int i = 1; i < itemList.size(); ++i) {
-                        if (url.toString() == itemList[i]) {
-                            itemList.removeAt(i);
-                            break;
-                        }
-                    }
+                    itemList.removeOne(url.toString());
                     opt->setValue(itemList);
                     updateAddItemLabel(itemList.size() < 4);
                 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -519,8 +519,7 @@ void TitleBarWidget::onTabCreated()
 void TitleBarWidget::onTabRemoved(int oldIndex, int nextIndex)
 {
     TitleBarEventCaller::sendTabRemoved(this, tabBar()->tabUniqueId(oldIndex), tabBar()->tabUniqueId(nextIndex));
-    if (!tabBar()->isInactiveTab(oldIndex))
-        curNavWidget->removeNavStackAt(oldIndex);
+    curNavWidget->removeNavStackAt(oldIndex);
 }
 
 void TitleBarWidget::onTabMoved(int from, int to)


### PR DESCRIPTION
1. Replace manual loop-based removal with QList::removeOne() for better
readability
2. Remove redundant inactive tab check in tab removal handling
3. Simplify code by using built-in Qt container methods
4. Maintain same functionality with cleaner implementation

Influence:
1. Test custom tab item removal functionality
2. Verify tab removal works correctly for both active and inactive tabs
3. Check that navigation stack is properly cleaned up
4. Ensure no regression in tab management features

refactor: 简化自定义标签页项移除逻辑

1. 使用 QList::removeOne() 替换手动循环移除，提高代码可读性
2. 移除标签页移除处理中的冗余非活动标签检查
3. 使用 Qt 内置容器方法简化代码实现
4. 保持相同功能的同时提供更清晰的实现

Influence:
1. 测试自定义标签页项移除功能
2. 验证活动和非活动标签页的移除功能正常工作
3. 检查导航栈是否正确清理
4. 确保标签管理功能无回归问题

## Summary by Sourcery

Simplify custom tab removal logic by leveraging Qt container methods and removing redundant conditions to improve code readability while preserving existing functionality.

Enhancements:
- Replace manual loop-based URL removal with QList::removeOne in CustomTabSettingWidget
- Remove unnecessary inactive tab check in TitleBarWidget::onTabRemoved