### PR TITLE
fix: handle comma escaping in CIFS password decryption

### DIFF
--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -271,7 +271,10 @@ QString CifsMountHelper::decryptPasswd(const QString &passwd)
 {
     QByteArray encodedByteArray = passwd.toUtf8();
     QByteArray decodedByteArray = QByteArray::fromBase64(encodedByteArray);
-    return QString::fromUtf8(decodedByteArray);
+    auto pwd = QString::fromUtf8(decodedByteArray);
+    if (pwd.contains(","))
+        pwd.replace(",", ",,");
+    return pwd;
 }
 
 uint CifsMountHelper::invokerUid()


### PR DESCRIPTION
Fixed password decryption issue where commas in passwords were not
properly escaped when mounting CIFS shares. The decryptPasswd function
now replaces single commas with double commas to prevent parsing errors
in mount commands.

Log: Fixed CIFS mount password handling for passwords containing commas

Influence:
1. Test CIFS mount with passwords containing commas
2. Verify mount success with various special characters in passwords
3. Test backward compatibility with passwords without commas
4. Check mount command parameters for proper comma escaping
5. Validate password decryption and encryption consistency

fix: 修复 CIFS 密码解密中的逗号转义处理

修复了密码解密问题，当密码包含逗号时在挂载 CIFS 共享时未能正确转义。
decryptPasswd 函数现在将单个逗号替换为双逗号，以防止挂载命令中的解析
错误。

Log: 修复了包含逗号的 CIFS 挂载密码处理问题

Influence:
1. 测试包含逗号的密码的 CIFS 挂载功能
2. 验证包含各种特殊字符的密码的挂载成功率
3. 测试无逗号密码的向后兼容性
4. 检查挂载命令参数中的逗号转义是否正确
5. 验证密码解密和加密的一致性

Bug: https://pms.uniontech.com/bug-view-314589.html

## Summary by Sourcery

Bug Fixes:
- Replace single commas with double commas in decryptPasswd to handle passwords containing commas