### PR TITLE
refactor: improve SMB share password dialog layout handling

### DIFF
--- a/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp
+++ b/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp
@@ -29,12 +29,12 @@ UserSharePasswordSettingDialog::UserSharePasswordSettingDialog(QWidget *parent)
 {
     setTitle(tr("Enter a password to protect shared folders"));
     setIcon(QIcon::fromTheme("dialog-password-publicshare"));
-    installEventFilter(this);
     initializeUi();
 }
 
 void UserSharePasswordSettingDialog::initializeUi()
 {
+    setMinimumWidth(380);
     QStringList buttonTexts;
     buttonTexts.append(QObject::tr("Cancel", "button"));
     buttonTexts.append(QObject::tr("Confirm", "button"));
@@ -93,12 +93,11 @@ void UserSharePasswordSettingDialog::onButtonClicked(const int &index)
     close();
 }
 
-bool UserSharePasswordSettingDialog::eventFilter(QObject *object, QEvent *event)
+void UserSharePasswordSettingDialog::changeEvent(QEvent *event)
 {
-    if (event->type() == QEvent::FontChange || event->type() == QEvent::Show) {
-        // 当字体大小变化或窗口显示时，调整窗口大小以适应内容
+    if (event->type() == QEvent::FontChange) {
         adjustSize();
-        return true;
     }
-    return DDialog::eventFilter(object, event);
+
+    DDialog::changeEvent(event);
 }

--- a/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.h
+++ b/src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.h
@@ -27,7 +27,7 @@ public Q_SLOTS:
     void onButtonClicked(const int &index);
 
 protected:
-    bool eventFilter(QObject *object, QEvent *event) override;
+    void changeEvent(QEvent *event) override;
 
 private:
     DTK_WIDGET_NAMESPACE::DPasswordEdit *passwordEdit;


### PR DESCRIPTION
1. Removed event filter and replaced with changeEvent for font change
handling
2. Set minimum width to 380 pixels to ensure proper dialog layout
3. Simplified window resize logic to only respond to font changes
4. Removed redundant show event handling since minimum width ensures
proper sizing

Log: Improved SMB share password dialog layout consistency

Influence:
1. Test dialog appearance with different system font sizes
2. Verify dialog maintains minimum width of 380px
3. Check password input field remains properly visible
4. Test dialog buttons layout and functionality
5. Confirm dialog resizes appropriately when fonts change

refactor: 改进 SMB 共享密码对话框布局处理

1. 移除事件过滤器，改用 changeEvent 处理字体变化
2. 设置最小宽度为 380 像素以确保对话框布局正确
3. 简化窗口调整大小逻辑，仅响应字体变化
4. 移除冗余的显示事件处理，最小宽度已确保正确尺寸

Log: 优化 SMB 共享密码对话框布局一致性

Influence:
1. 测试不同系统字体大小下的对话框显示效果
2. 验证对话框保持最小宽度 380 像素
3. 检查密码输入字段保持正常可见
4. 测试对话框按钮布局和功能
5. 确认字体变化时对话框能正确调整大小

## Summary by Sourcery

Refactor the SMB share password dialog to improve layout consistency by enforcing a minimum width, consolidating resize logic, and switching to changeEvent-based font change handling

Enhancements:
- Replace event filter with changeEvent override to respond to font changes
- Set minimum dialog width to 380 pixels for consistent layout
- Remove redundant show event handling and simplify resize logic