### PR TITLE
fix: enable drag-and-drop in file view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -154,7 +154,6 @@ void FileView::setViewMode(Global::ViewMode mode)
         d->initHorizontalOffset = false;
         setUniformItemSizes(false);
         setResizeMode(QListView::Adjust);
-        setMovement(QListView::Static);
         setOrientation(QListView::LeftToRight, true);
 #ifdef DTKWIDGET_CLASS_DSizeMode
         setSpacing(DSizeModeHelper::element(kCompactIconViewSpacing, kIconViewSpacing));
@@ -2521,8 +2520,7 @@ void FileView::setDefaultViewMode()
 
 void FileView::setListViewMode()
 {
-    setMovement(QListView::Static);
-    setUniformItemSizes(false);
+    setUniformItemSizes(true);
     setResizeMode(QListView::Fixed);
     setOrientation(QListView::TopToBottom, false);
     setSpacing(kListViewSpacing);


### PR DESCRIPTION
Removed setMovement(QListView::Static) calls that were preventing drag- and-drop operations in both icon view and list view modes. Also modified setUniformItemSizes(true) for list view mode to ensure consistent item sizing.

The changes address an issue where drag-and-drop functionality was completely disabled due to the Static movement setting. This was preventing users from dragging files between folders or onto the desktop. The item sizing adjustment in list view mode ensures better visual consistency during drag operations.

Log: Fixed drag-and-drop functionality in file manager views

Influence:
1. Test dragging files between folders in icon view
2. Verify dragging files to desktop works correctly
3. Check list view maintains consistent item sizes during drag
4. Confirm drag operations work with multiple selection
5. Verify visual feedback during drag operations

fix: 修复文件视图中的拖拽功能

移除了在图标视图和列表视图模式中阻止拖拽操作的
setMovement(QListView::Static)调用。同时修改了列表视图模式的
setUniformItemSizes(true)以确保一致的项大小。

这些更改解决了由于Static移动设置导致拖拽功能完全禁用的问题，该问题阻止用
户在文件夹之间或桌面上拖拽文件。列表视图模式中的项大小调整确保了在拖拽操
作期间更好的视觉一致性。

Log: 修复了文件管理器视图中的拖拽功能

Influence:
1. 测试在图标视图中拖拽文件到不同文件夹
2. 验证拖拽文件到桌面的功能正常工作
3. 检查列表视图在拖拽过程中保持一致的项大小
4. 确认拖拽操作在多选情况下正常工作
5. 验证拖拽操作期间的视觉反馈

PMS: BUG-336077

## Summary by Sourcery

Re-enable drag-and-drop functionality in file views by removing static movement restrictions and improve visual consistency in list view with uniform item sizing.

Bug Fixes:
- Restore drag-and-drop in icon and list views by removing setMovement(QListView::Static) calls.

Enhancements:
- Enable uniform item sizes in list view mode for consistent visuals during drag operations.