### PR TITLE
Revert org.freedesktop.ScreenSaver

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskdialog.h
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.h
@@ -49,9 +49,6 @@ protected:
     void keyPressEvent(QKeyEvent *event) override;
 
 private:
-    void checkAllTasksPaused();
-
-private:
     QListWidget *taskListWidget { nullptr };
     QMap<JobHandlePointer, QListWidgetItem *> taskItems;
     DTitlebar *titlebar { nullptr };

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.h
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.h
@@ -52,7 +52,7 @@ private:
     QListWidget *taskListWidget { nullptr };
     QMap<JobHandlePointer, QListWidgetItem *> taskItems;
     DTitlebar *titlebar { nullptr };
-    uint32_t m_inhibitCookie { 0 };
+    QDBusReply<QDBusUnixFileDescriptor> replyBlokShutDown;
     static int kMaxHeight;
 };
 

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -262,9 +262,6 @@ void TaskWidget::onHandlerTaskStateChange(const JobInfoPointer JobInfo)
     if (isCurPaused == isPauseState) {
         return;
     }
-
-    bool oldPauseState = isPauseState;   // 保存旧状态
-
     if (state == kPausedState) {
         isPauseState = true;
         btnPause->setIcon(QIcon::fromTheme("dfm_task_start"));
@@ -279,11 +276,6 @@ void TaskWidget::onHandlerTaskStateChange(const JobInfoPointer JobInfo)
         variantPause.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kPauseAction);
         btnPause->setProperty(kBtnPropertyActionName, variantPause);
         progress->start();
-    }
-
-    // 只有在暂停状态发生变化时才发出信号
-    if (oldPauseState != isPauseState) {
-        emit pausedStateChange();
     }
 }
 /*!

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.h
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.h
@@ -43,17 +43,6 @@ class TaskWidget : public QWidget
 Q_SIGNALS:
     void buttonClicked(AbstractJobHandler::SupportActions actions);
     void heightChanged(int height);
-    void pausedStateChange();
-
-public:
-    // 允许TaskDialog访问暂停状态
-    friend class TaskDialog;
-    
-Q_SIGNALS:
-    /*!
-     * \brief closed 当前进度窗口关闭时，发送关闭信号
-     */
-    void closed();
 public Q_SLOTS:
     void parentClose();
 private Q_SLOTS:

--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -23,7 +23,6 @@
 #include <QDBusConnectionInterface>
 #include <QRegularExpression>
 #include <DUtil>
-#include <QDBusInterface>
 
 #ifdef COMPILE_ON_V2X
 #    define SYSTEM_SYSTEMINFO_SERVICE "org.deepin.dde.SystemInfo1"
@@ -156,6 +155,33 @@ bool UniversalUtils::isLogined()
 bool UniversalUtils::inMainThread()
 {
     return QThread::currentThread() == QCoreApplication::instance()->thread();
+}
+
+/*!
+ * \brief FileUtils::blockShutdown 调用dbus去设置阻塞睡眠
+ * \param replay 输入参数，dbus回复
+ */
+void UniversalUtils::blockShutdown(QDBusReply<QDBusUnixFileDescriptor> &replay)
+{
+    qCInfo(logDFMBase) << "Creating DBus inhibitor to block system shutdown";
+    if (replay.value().isValid()) {
+        qCWarning(logDFMBase) << "Shutdown block already active, skipping new request";
+        return;
+    }
+
+    QDBusInterface loginManager("org.freedesktop.login1",
+                                "/org/freedesktop/login1",
+                                "org.freedesktop.login1.Manager",
+                                QDBusConnection::systemBus());
+
+    QList<QVariant> arg;
+    arg << QString("shutdown:sleep")   // what
+        << qApp->applicationDisplayName()   // who
+        << QObject::tr("Files are being processed")   // why
+        << QString("block");   // mode
+
+    replay = loginManager.callWithArgumentList(QDBus::Block, "Inhibit", arg);
+    qCInfo(logDFMBase) << "System shutdown block created successfully";
 }
 
 qint64 UniversalUtils::computerMemory()
@@ -508,62 +534,6 @@ int UniversalUtils::getTextLineHeight(const QString &text, const QFontMetrics &f
         return fontHeight;
 
     return qMax(fontHeight, tightHeight);
-}
-
-/*!
- * \brief UniversalUtils::inhibitStandby Inhibit system standby using ScreenSaver interface
- * \param reason Human-readable reason for inhibiting standby
- * \return Cookie for uninhibiting, 0 if failed
- */
-uint32_t UniversalUtils::inhibitStandby(const QString &reason)
-{
-    qCInfo(logDFMBase) << "Creating ScreenSaver inhibitor to prevent system standby";
-
-    QDBusInterface iface("org.freedesktop.ScreenSaver",
-                         "/org/freedesktop/ScreenSaver",
-                         "org.freedesktop.ScreenSaver",
-                         QDBusConnection::sessionBus());
-
-    if (!iface.isValid()) {
-        qCWarning(logDFMBase) << "ScreenSaver DBus interface is not available";
-        return 0;
-    }
-
-    QDBusReply<uint32_t> reply = iface.call("Inhibit", qApp->applicationName(), "Files are being processed");
-
-    if (reply.isValid() && reply.value() > 0) {
-        qCInfo(logDFMBase) << "ScreenSaver inhibit successful, cookie:" << reply.value();
-        return reply.value();
-    }
-
-    qCWarning(logDFMBase) << "Failed to create ScreenSaver inhibit:" << reply.error().message();
-    return 0;
-}
-
-/*!
- * \brief UniversalUtils::uninhibitStandby Release ScreenSaver inhibit using cookie
- * \param cookie Cookie returned from inhibitStandby
- */
-void UniversalUtils::uninhibitStandby(uint32_t cookie)
-{
-    if (cookie == 0) {
-        qCDebug(logDFMBase) << "Invalid cookie for uninhibitStandby, skipping";
-        return;
-    }
-
-    qCInfo(logDFMBase) << "Releasing ScreenSaver inhibit, cookie:" << cookie;
-
-    QDBusInterface iface("org.freedesktop.ScreenSaver",
-                         "/org/freedesktop/ScreenSaver",
-                         "org.freedesktop.ScreenSaver",
-                         QDBusConnection::sessionBus());
-
-    if (iface.isValid()) {
-        iface.call("UnInhibit", cookie);
-        qCInfo(logDFMBase) << "ScreenSaver inhibit released successfully";
-    } else {
-        qCWarning(logDFMBase) << "ScreenSaver DBus interface not available for release";
-    }
 }
 
 }

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -24,11 +24,7 @@ public:
     static QString userLoginState();
     static quint32 currentLoginUser();
     static bool isLogined();
-
-    // New ScreenSaver-based standby inhibition
-    static uint32_t inhibitStandby(const QString &reason = QString());
-    static void uninhibitStandby(uint32_t cookie);
-
+    static void blockShutdown(QDBusReply<QDBusUnixFileDescriptor> &replay);
     static qint64 computerMemory();
     static void computerInformation(QString &cpuinfo, QString &systemType, QString &Edition, QString &version);
     static double sizeFormat(qint64 size, QString &unit);


### PR DESCRIPTION
## Summary by Sourcery

Switch shutdown and sleep inhibition from the org.freedesktop.ScreenSaver D-Bus interface to systemd login1 Manager Inhibit calls and simplify TaskDialog shutdown handling

Enhancements:
- Add UniversalUtils::blockShutdown to create a systemd login1 inhibitor for blocking shutdown and suspend
- Remove obsolete inhibitStandby/uninhibitStandby methods and ScreenSaver-based pause-state logic in TaskDialog and TaskWidget
- Simplify TaskDialog to invoke blockShutdown once and automatically release the inhibitor on dialog close

Chores:
- Clean up removed QDBusInterface include and stale pausedStateChange signal and related members