### PR TITLE
feat: use system palette for tag editor colors

### DIFF
--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
@@ -116,8 +116,8 @@ void TagEditor::initializeParameters()
     setMargin(0);
     setFixedWidth(140);
     setFocusPolicy(Qt::StrongFocus);
-    setBorderColor(QColor { "#ffffff" });
-    setBackgroundColor(QColor { "#ffffff" });
+    setBorderColor(palette().color(QPalette::Base));
+    setBackgroundColor(palette().color(QPalette::Base));
     setWindowFlags(Qt::FramelessWindowHint);
     setAttribute(Qt::WA_DeleteOnClose);
 }


### PR DESCRIPTION
Changed tag editor border and background colors from hardcoded white to
use the system palette's Base color. This improves theme compatibility
by allowing the tag editor to adapt to different system themes instead
of always using white.

Influence:
1. Test tag editor appearance in different system themes
2. Verify tag editor visibility and contrast in dark/light modes
3. Check that tag editor blends properly with surrounding UI elements
4. Ensure text readability remains good across different themes

feat: 使用系统调色板设置标签编辑器颜色

将标签编辑器的边框和背景颜色从硬编码的白色改为使用系统调色板的Base颜色。
这提高了主题兼容性，使标签编辑器能够适应不同的系统主题，而不是始终使用
白色。

Influence:
1. 在不同系统主题下测试标签编辑器的外观
2. 验证标签编辑器在深色/浅色模式下的可见性和对比度
3. 检查标签编辑器是否与周围UI元素正确融合
4. 确保在不同主题下文本可读性保持良好

Bug: https://pms.uniontech.com/bug-view-336117.html

## Summary by Sourcery

Adopt the system color palette for tag editor visuals to replace hardcoded white and enhance theme adaptability

New Features:
- Use system palette Base color for tag editor border and background instead of hardcoded white

Bug Fixes:
- Fix tag editor color mismatch issue (bug 336117)

Enhancements:
- Improve theme compatibility and visual integration of the tag editor across light and dark modes