### PR TITLE
fix: prevent permission changes on system library directories

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -7,6 +7,7 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/file/local/localfilehandler.h>
 #include <dfm-base/utils/sysinfoutils.h>
+#include <dfm-base/utils/systempathutil.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -285,6 +286,10 @@ bool PermissionManagerWidget::canChmod(const FileInfoPointer &info)
 
     // Check if file exists
     if (!info->exists())
+        return false;
+
+    // 禁止对库目录进行权限修改
+    if (SystemPathUtil::instance()->isSystemPath(info->pathOf(PathInfoType::kAbsoluteFilePath)))
         return false;
 
     // Root user can always chmod


### PR DESCRIPTION
Added check to block permission modifications on system library
directories using SystemPathUtil. This prevents users from accidentally
changing permissions on critical system paths which could lead to system
instability or security issues. The root user is still allowed to modify
permissions as before.

Log: Disabled permission modification for system library directories in
property dialog

Influence:
1. Test permission dialog on system directories (like /usr, /bin) -
should show disabled controls
2. Verify root user can still modify permissions on system paths
3. Test regular user permission changes on non-system directories still
work normally
4. Check that system path detection works correctly for various library
locations

fix: 禁止对系统库目录进行权限修改

添加了对系统库目录的检查，使用 SystemPathUtil 阻止权限修改。这可以防止用
户意外更改关键系统路径的权限，避免导致系统不稳定或安全问题。root 用户仍
然可以像以前一样修改权限。

Log: 在属性对话框中禁用了对系统库目录的权限修改功能

Influence:
1. 测试系统目录（如 /usr、/bin）的权限对话框 - 应显示禁用状态的控制项
2. 验证 root 用户仍可修改系统路径的权限
3. 测试普通用户对非系统目录的权限修改功能正常
4. 检查系统路径检测对各种库目录位置是否正确工作

Bug: https://pms.uniontech.com/bug-view-335859.html

## Summary by Sourcery

Prevent non-root users from changing permissions on critical system library directories by disabling the chmod controls based on SystemPathUtil, while allowing root to retain full permission modification capabilities.

Bug Fixes:
- Block permission modifications on system library directories for non-root users

Enhancements:
- Integrate SystemPathUtil to detect system paths in the permission dialog