### PR TITLE
fix: improve window position restoration accuracy

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
@@ -514,9 +514,8 @@ void FilePreviewDialog::saveCenterPos()
         return;
     }
 
-    // 使用 frameGeometry 来考虑窗口装饰
-    QRect fg = frameGeometry();
-    previousCenter = fg.center();
+    QRectF rectF = geometry();
+    previousCenter = rectF.center();
     qCDebug(logLibFilePreview) << "FilePreviewDialog: saved center position:" << previousCenter;
 }
 
@@ -527,12 +526,13 @@ void FilePreviewDialog::restoreCenterPos()
         return;
     }
 
-    // 计算新的左上角位置以保持中心点不变
-    QSize s = size();
-    QPoint newTopLeft(previousCenter.x() - s.width() / 2, previousCenter.y() - s.height() / 2);
+    // 计算新的左上角位置以保持中心点不变，使用浮点数计算保持精度
+    QSizeF sizeF = size();
+    QPointF newTopLeftF(previousCenter.x() - sizeF.width() / 2.0, previousCenter.y() - sizeF.height() / 2.0);
+    QPoint newTopLeft = newTopLeftF.toPoint();
 
     // 限制窗口位置到记录中心所在屏幕的可用区域，避免跨屏显示
-    QScreen *scr = QGuiApplication::screenAt(previousCenter);
+    QScreen *scr = QGuiApplication::screenAt(previousCenter.toPoint());
     QRect avail;
     if (scr) {
         avail = scr->availableGeometry();
@@ -541,6 +541,7 @@ void FilePreviewDialog::restoreCenterPos()
     }
 
     if (!avail.isNull()) {
+        QSize s = size();
         // 如果窗口大小大于可用区域，则将窗口居中显示在该屏幕内
         if (s.width() > avail.width() || s.height() > avail.height()) {
             QPoint centered(avail.center().x() - s.width() / 2, avail.center().y() - s.height() / 2);

--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
@@ -73,7 +73,7 @@ private:
     DFMBASE_NAMESPACE::AbstractBasePreview *preview { nullptr };
     DFMBASE_NAMESPACE::DialogManager *dialogManager { nullptr };
     // 在切换视图前记录中心点, 切换后恢复
-    QPoint previousCenter { 0, 0 };
+    QPointF previousCenter { 0.0, 0.0 };
 };
 }
 #endif


### PR DESCRIPTION
Changed from using frameGeometry to geometry for center position
calculation to get more accurate window positioning. Updated
previousCenter from QPoint to QPointF to maintain precision during
calculations. The restoration logic now uses floating-point arithmetic
to avoid integer rounding errors that could cause slight window position
shifts when switching between preview views.

Influence:
1. Test window position restoration when switching between different
file previews
2. Verify window centers correctly on screens with different scaling
factors
3. Test multi-monitor scenarios to ensure proper screen detection
4. Check window positioning when resizing preview dialog
5. Validate that window stays within available screen boundaries

fix: 提高窗口位置恢复的精确度

从使用 frameGeometry 改为使用 geometry 进行中心位置计算，以获得更准确的
窗口定位。将 previousCenter 从 QPoint 更新为 QPointF，以在计算过程中保持
精度。恢复逻辑现在使用浮点运算，避免在切换预览视图时因整数舍入误差导致的
窗口位置轻微偏移。

Influence:
1. 测试在不同文件预览间切换时的窗口位置恢复
2. 验证窗口在不同缩放因子的屏幕上正确居中
3. 测试多显示器场景下的屏幕检测是否正确
4. 检查调整预览对话框大小时的位置保持
5. 验证窗口是否保持在可用屏幕边界内

## Summary by Sourcery

Improve window positioning precision by switching to floating-point geometry and center point storage

Enhancements:
- Use geometry() and QPointF for precise center calculations instead of frameGeometry and QPoint
- Compute restoration top-left with QSizeF and QPointF to prevent integer rounding errors and enforce screen boundary constraints