### PR TITLE
fix: add missing group-by action to context menus

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menuscene/action_defines.h
+++ b/src/plugins/common/dfmplugin-menu/menuscene/action_defines.h
@@ -59,6 +59,7 @@ inline constexpr char kSeparator[] = "separator-line";
 // ViewMenu
 inline constexpr char kDisplayAs[] = "display-as";
 inline constexpr char kSortBy[] = "sort-by";
+inline constexpr char kGroupBy[] = "group-by";
 }
 }
 

--- a/src/plugins/filedialog/core/menus/filedialogmenuscene.cpp
+++ b/src/plugins/filedialog/core/menus/filedialogmenuscene.cpp
@@ -89,10 +89,10 @@ QString FileDialogMenuScene::findSceneName(QAction *act) const
 
 void FileDialogMenuScene::filterAction(QMenu *parent, bool isSubMenu)
 {
-    static const QStringList whiteActIdList { ActionID::kNewFolder, ActionID::kNewDoc, 
-                                              ActionID::kDisplayAs, ActionID::kSortBy,
-                                              ActionID::kOpen, ActionID::kRename, 
-                                              ActionID::kDelete, ActionID::kCopy, 
+    static const QStringList whiteActIdList { ActionID::kNewFolder, ActionID::kNewDoc,
+                                              ActionID::kDisplayAs, ActionID::kSortBy, ActionID::kGroupBy,
+                                              ActionID::kOpen, ActionID::kRename,
+                                              ActionID::kDelete, ActionID::kCopy,
                                               ActionID::kCut, ActionID::kPaste };
     static const QStringList whiteSceneList { "NewCreateMenu", "ClipBoardMenu", "OpenDirMenu", "FileOperatorMenu",
                                               "OpenWithMenu", "ShareMenu", "SortAndDisplayMenu" };

--- a/src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-avfsbrowser/menu/avfsmenuscene.cpp
@@ -19,6 +19,7 @@ using namespace dfmplugin_avfsbrowser;
 DFMBASE_USE_NAMESPACE
 
 static constexpr char k3rdSortBy[] { "sort-by" };
+static constexpr char k3rdGroupBy[] { "group-by" };
 static constexpr char k3rdDisplayAs[] { "display-as" };
 static constexpr char k3rdOpenWith[] { "open-with" };
 
@@ -70,6 +71,8 @@ bool AvfsMenuScene::create(QMenu *parent)
             d->predicateAction[k3rdDisplayAs] = act;
         else if (key == k3rdSortBy)
             d->predicateAction[k3rdSortBy] = act;
+        else if (key == k3rdGroupBy)
+            d->predicateAction[k3rdGroupBy] = act;
         else if (key == k3rdOpenWith)
             d->predicateAction[k3rdOpenWith] = act;
         parent->removeAction(act);
@@ -90,8 +93,9 @@ bool AvfsMenuScene::create(QMenu *parent)
 
         parent->addSeparator();
     } else {
-        parent->addAction(d->predicateAction[k3rdSortBy]);
         parent->addAction(d->predicateAction[k3rdDisplayAs]);
+        parent->addAction(d->predicateAction[k3rdSortBy]);
+        parent->addAction(d->predicateAction[k3rdGroupBy]);
         parent->addSeparator();
     }
 

--- a/src/plugins/filemanager/dfmplugin-optical/menus/opticalmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/menus/opticalmenuscene.cpp
@@ -98,6 +98,7 @@ void OpticalMenuScene::updateState(QMenu *parent)
     static const QStringList whiteEmptyActIdList {
         "display-as",
         "sort-by",
+        "group-by",
         "open-as-administrator",
         "open-in-terminal",
         "paste",

--- a/src/plugins/filemanager/dfmplugin-optical/menus/packetwritingmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/menus/packetwritingmenuscene.cpp
@@ -130,6 +130,7 @@ void PacketWritingMenuScene::updateState(QMenu *parent)
     static const QStringList whiteEmptyActIdList {
         "display-as",
         "sort-by",
+        "group-by",
         "open-as-administrator",
         "open-in-terminal",
         "paste",

--- a/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
@@ -38,6 +38,7 @@ QStringList VaultMenuScenePrivate::emptyMenuActionRule()
         "separator-line",
         "display-as",
         "sort-by",
+        "group-by",
         "refresh",
         "separator-line",
         "paste",


### PR DESCRIPTION
Added kGroupBy action ID constant in action_defines.h Included group-by action in white lists for:
1. FileDialogMenuScene
2. AvfsMenuScene
3. OpticalMenuScene
4. PacketWritingMenuScene
5. VaultMenuScene

This fixes an issue where the group-by functionality was missing from context menus in certain scenarios, ensuring consistent grouping options are available across all file management contexts.

Log: Added missing group-by action to context menus

Bug: https://pms.uniontech.com/bug-view-336265.html
Bug: https://pms.uniontech.com/bug-view-336271.html

Influence:
1. Test right-click menus in various file management scenarios
2. Verify group-by option appears consistently
3. Check menu ordering and separators remain correct
4. Confirm group-by functionality works as expected

fix: 修复右键菜单缺少分组功能的问题

在 action_defines.h 中添加了 kGroupBy 动作ID常量
将 group-by 动作添加到以下场景的白名单中:
1. FileDialogMenuScene
2. AvfsMenuScene
3. OpticalMenuScene
4. PacketWritingMenuScene
5. VaultMenuScene

修复了在某些场景下右键菜单缺少分组功能的问题，确保所有文件管理场景中都能
提供一致的分组选项。

Log: 修复右键菜单缺少分组功能的问题

Influence:
1. 在各种文件管理场景中测试右键菜单
2. 验证分组选项是否一致显示
3. 检查菜单排序和分隔符是否正确
4. 确认分组功能正常工作

## Summary by Sourcery

Restore missing group-by functionality by defining the action ID and whitelisting it in context menus across multiple file management scenes

New Features:
- Introduce kGroupBy action ID constant in action_defines.h

Bug Fixes:
- Add group-by option to context menus in FileDialogMenuScene, AvfsMenuScene, OpticalMenuScene, PacketWritingMenuScene, and VaultMenuScene to reinstate grouping functionality