### PR TITLE
fix(desktop,workspace): defer context menu handling to prevent UI blocking

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.h
@@ -105,6 +105,9 @@ protected:
     void changeEvent(QEvent *event) override;
 
 private:
+    void onContextMenuEvent(QContextMenuEvent *event);
+
+private:
     CanvasViewPrivate *d;
 };
 

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
@@ -100,6 +100,9 @@ protected:
     void scrollContentsBy(int dx, int dy) override;
 
 private:
+    void onContextMenuEvent(QContextMenuEvent *event);
+
+private:
     QSharedPointer<CollectionViewPrivate> d = nullptr;
 };
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -255,6 +255,7 @@ private:
     void focusOnView();
 
     bool isGroupHeader(const QModelIndex &index) const;
+    void onContextMenuEvent(QContextMenuEvent *event);
 };
 
 }


### PR DESCRIPTION
Move context menu event processing to asynchronous handlers to improve responsiveness and prevent UI freezing during menu operations.

Changes:
- Extract context menu logic from `contextMenuEvent()` to `onContextMenuEvent()`
- Use `QTimer::singleShot(10ms)` to defer menu processing
- Add `FinallyUtil` RAII wrapper for proper cleanup and state restoration
- Block signals and disable updates during menu processing
- Apply changes to CanvasView, CollectionView, and FileView

Benefits:
- Prevents UI blocking during context menu operations
- Ensures proper cleanup of event objects and widget state
- Improves user experience with more responsive interface
- Reduces risk of crashes during complex menu operations

Log: defer context menu handling to prevent UI blocking
Bug: https://pms.uniontech.com/bug-view-328095.html https://pms.uniontech.com/bug-view-303395.html

## Summary by Sourcery

Defer context menu event handling in FileView, CanvasView, and CollectionView by scheduling the processing asynchronously and extracting the logic into separate onContextMenuEvent methods wrapped with RAII cleanup to prevent UI blocking and ensure proper cleanup of event objects and widget state.

Bug Fixes:
- Prevent UI freezing and potential crashes during complex context menu operations

Enhancements:
- Defer context menu processing via QTimer::singleShot in FileView, CanvasView, and CollectionView to improve responsiveness
- Extract context menu logic into onContextMenuEvent methods and introduce FinallyUtil RAII wrapper for automatic state restoration and event cleanup
- Block signals and disable widget updates during context menu handling to avoid UI glitches