### PR TITLE
fix: highlight text correctly for drop target items

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -519,7 +519,8 @@ void ListItemDelegate::paintItemColumn(QPainter *painter, const QStyleOptionView
     double columnX = iconRect.right();
 
     bool isSelected = (opt.state & QStyle::State_Selected) && opt.showDecorationSelected;
-    if (isSelected)
+    bool isDropTarget = parent()->isDropTarget(index);
+    if (isSelected || isDropTarget)
         painter->setPen(opt.palette.color(QPalette::Active, QPalette::HighlightedText));
 
     // 绘制那些需要显示的项
@@ -560,7 +561,7 @@ void ListItemDelegate::paintItemColumn(QPainter *painter, const QStyleOptionView
             textRect.setHeight(d->textLineHeight);
             textRect.moveTop(((columnRect.height() - textRect.height()) / 2) + columnRect.top());
 
-            if (!isSelected)
+            if (!isSelected && !isDropTarget)
                 painter->setPen(opt.palette.color(cGroup, QPalette::Text));
 
             if (data.canConvert<QString>()) {
@@ -582,7 +583,9 @@ void ListItemDelegate::paintFileName(QPainter *painter, const QStyleOptionViewIt
         return;
 
     bool isSelected = (option.state & QStyle::State_Selected) && option.showDecorationSelected;
-    painter->setPen(option.palette.color(isSelected ? QPalette::BrightText : QPalette::Text));
+    bool isDropTarget = parent()->isDropTarget(index);
+    const auto itemColor = option.palette.color((isSelected || isDropTarget) ? QPalette::BrightText : QPalette::Text);
+    painter->setPen(itemColor);
 
     const QString previewContent = index.data(kItemFileContentPreviewRole).toString();
     // 检查是否支持并需要显示内容预览


### PR DESCRIPTION
Fixed text color rendering for file items that are drop targets in list
view. Previously, only selected items had proper highlight text color,
but drop target items were not visually distinguished with appropriate
text coloring. Now both selected and drop target items use the
highlighted text color scheme for better visual feedback during drag-
and-drop operations.

The changes include:
1. Added drop target detection using parent()->isDropTarget(index)
2. Check both selection and drop target states for text color selection
3. Applied consistent text coloring logic across different paint methods

Log: Fixed text color for drag-and-drop target items to improve visual
feedback

Influence:
1. Test drag-and-drop operations in file manager list view
2. Verify text colors change appropriately when items become drop
targets
3. Check that both selected and drop target items have consistent
highlighting
4. Test with different color themes to ensure proper contrast
5. Verify text remains readable in all states

fix: 修复拖放目标项的文本高亮显示

修复了列表视图中作为拖放目标的文件项的文本颜色渲染问题。之前只有选中的项
有正确的高亮文本颜色，但拖放目标项没有用适当的文本颜色进行视觉区分。现在
选中项和拖放目标项都使用高亮文本颜色方案，为拖放操作提供更好的视觉反馈。

修改包括：
1. 添加了使用 parent()->isDropTarget(index) 检测拖放目标
2. 同时检查选中状态和拖放目标状态来选择文本颜色
3. 在不同的绘制方法中应用一致的文本颜色逻辑

Log: 修复拖放目标项的文本颜色显示问题，提升视觉反馈效果

Influence:
1. 测试文件管理器列表视图中的拖放操作
2. 验证当项目成为拖放目标时文本颜色是否正确变化
3. 检查选中项和拖放目标项是否具有一致的高亮效果
4. 使用不同颜色主题测试，确保适当的对比度
5. 验证各种状态下文本的可读性

Bug: https://pms.uniontech.com/bug-view-336245.html

## Summary by Sourcery

Enable highlight text color for both selected and drop target file items to improve visual feedback during drag
and-drop operations in the list view

Bug Fixes:
- Apply highlighted text color to drop target items to match selected item highlighting

Enhancements:
- Add drop target state detection and unify text coloring logic across paint methods