### PR TITLE
fix: adjust window flags

### DIFF
--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
@@ -25,9 +25,9 @@ TagEditor::TagEditor(QWidget *const parent, bool inTagDir)
 
     // NOTE: in wayland you must specify the window flags manually
     if (dfmbase::WindowUtils::isWayLand())
-        setWindowFlags(windowFlags() | Qt::Tool | Qt::FramelessWindowHint);
+        setWindowFlags(windowFlags() | Qt::ToolTip | Qt::FramelessWindowHint);
     else
-        setWindowFlags(Qt::Tool);
+        setWindowFlags(Qt::ToolTip);
 }
 
 void TagEditor::setFocusOutSelfClosing(bool value) noexcept


### PR DESCRIPTION
Changed window flags from Qt::Tool to Qt::ToolTip for better
compatibility in Wayland environments
The Qt::Tool flag causes issues in Wayland display servers where windows
may not receive proper focus
Using Qt::ToolTip provides better window management behavior while
maintaining the desired popup characteristics

Log: Fixed tag editor window behavior in Wayland environments

Influence:
1. Test tag editor display and focus behavior in Wayland
2. Verify tag editor still functions correctly in X11 environments
3. Check that editor windows don't interfere with other windows
4. Confirm that focus handling works properly when interacting with
tag editor

fix: 调整窗口标志

将窗口标志从 Qt::Tool 改为 Qt::ToolTip 以改善在 Wayland 环境中的兼容性
Qt::Tool 标志在 Wayland 显示服务器中会导致窗口无法正确获得焦点的问题
使用 Qt::ToolTip 可以在保持所需弹窗特性的同时提供更好的窗口管理行为

Log: 修复了 Wayland 环境中标签编辑器窗口的行为问题

Influence:
1. 测试 Wayland 环境中标签编辑器的显示和焦点行为
2. 验证标签编辑器在 X11 环境中仍然正常工作
3. 检查编辑器窗口不会干扰其他窗口
4. 确认与标签编辑器交互时的焦点处理正常

Bug: https://pms.uniontech.com/bug-view-335851.html

## Summary by Sourcery

Replace Qt::Tool with Qt::ToolTip for TagEditor windows to fix focus and compatibility issues in Wayland environments while preserving popup behavior.

Bug Fixes:
- Fix TagEditor windows failing to receive focus under Wayland

Enhancements:
- Use Qt::ToolTip flag for TagEditor on both Wayland and X11 to maintain consistent popup characteristics
- Retain frameless window hint on Wayland for a clean floating appearance