### PR TITLE
fix: fix view options widget layout and sizing issues

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -33,7 +33,7 @@ using namespace GlobalDConfDefines::BaseConfig;
 
 static constexpr int kViewOptionsButtonIconSize { 16 };
 static constexpr int kViewOptionsMargin { 10 };
-static constexpr int kViewOptionsSpacing { 10 };
+static constexpr int kViewOptionsWidth { 180 };
 static constexpr int kViewOptionsSingleSpacing { 5 };
 static constexpr int kViewOptionsFrameMargin { 6 };
 static constexpr int kViewOptionsFrameHeight { 40 };
@@ -55,9 +55,11 @@ void ViewOptionsWidgetPrivate::initializeUi()
     // Title
     QVBoxLayout *mainLayout = new QVBoxLayout(q);
     mainLayout->setContentsMargins(kViewOptionsMargin, kViewOptionsMargin, kViewOptionsMargin, kViewOptionsMargin);
+    mainLayout->setSizeConstraint(QLayout::SetFixedSize);
     title = new DLabel(tr("View Options"), q);
     DFontSizeManager::instance()->bind(title, DFontSizeManager::T6, QFont::Normal);
     title->setAlignment(Qt::AlignCenter);
+    title->setFixedWidth(kViewOptionsWidth);
     mainLayout->addWidget(title);
 
     // Icon size
@@ -297,16 +299,6 @@ void ViewOptionsWidgetPrivate::switchMode(ViewMode mode)
     iconSizeFrame->setVisible(iconVisible);
     gridDensityFrame->setVisible(iconVisible);
     listHeightFrame->setVisible(listVisible);
-    int widgetHeight = kViewOptionsMargin + kViewOptionsFrameHeight + kViewOptionsSpacing + title->fontMetrics().height();
-    int singleHeight = kViewOptionsFrameHeight + iconSizeTitle->fontMetrics().height() + kViewOptionsSingleSpacing + kViewOptionsSpacing;
-    if (iconVisible) {
-        widgetHeight += 2 * singleHeight;
-    }
-    if (listVisible) {
-        widgetHeight += singleHeight;
-    }
-    q->setFixedHeight(widgetHeight);
-    fmDebug() << "View options widget height set to:" << widgetHeight;
 }
 
 void ViewOptionsWidgetPrivate::showSliderTips(Dtk::Widget::DSlider *slider, int pos, const QVariantList &valList)


### PR DESCRIPTION
Fixed the view options widget layout by replacing static height
calculations with a fixed width approach. The previous implementation
used complex height calculations based on content visibility that caused
layout issues. Now using QLayout::SetFixedSize constraint and setting a
fixed width of 180 pixels for better consistency and stability.

The changes include:
1. Replaced spacing constant with width constant for consistent sizing
2. Added SetFixedSize layout constraint to prevent unwanted resizing
3. Set fixed width for title label to match overall widget width
4. Removed manual height calculations that were causing layout problems

Log: Fixed view options widget layout stability and sizing

Influence:
1. Test view options widget appearance in different view modes
2. Verify widget maintains consistent width and proper layout
3. Check that all controls remain accessible and properly aligned
4. Test widget behavior when switching between icon and list view modes

fix: 修复视图选项控件布局和尺寸问题

修复了视图选项控件的布局问题，使用固定宽度方法替代了原有的静态高度计算。
之前的实现基于内容可见性使用复杂的计算高度，这会导致布局问题。现在使用
QLayout::SetFixedSize布局约束并设置180像素的固定宽度，以获得更好的一致性
和稳定性。

更改包括：
1. 使用宽度常量替换间距常量以实现一致的尺寸
2. 添加SetFixedSize布局约束以防止不必要的调整大小
3. 为标题标签设置固定宽度以匹配整体控件宽度
4. 移除了导致布局问题的手动高度计算

Log: 修复视图选项控件的布局稳定性和尺寸问题

Influence:
1. 在不同视图模式下测试视图选项控件的外观
2. 验证控件保持一致的宽度和正确的布局
3. 检查所有控件是否保持可访问性和正确对齐
4. 测试在图标和列表视图模式之间切换时的控件行为

Bug: https://pms.uniontech.com/bug-view-335515.html

## Summary by Sourcery

Improve the view options widget layout by replacing manual height-based sizing with a fixed width and layout constraint to ensure consistent and stable dimensions.

Bug Fixes:
- Fix view options widget layout instability by removing manual height calculations

Enhancements:
- Use fixed width (180px) and SetFixedSize constraint to maintain consistent widget sizing
- Replace spacing constant with width constant for consistent sizing