### PR TITLE
fix: adjust list item editor height calculation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -119,14 +119,8 @@ QWidget *ListItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
     d->editingIndex = index;
     d->editor = new ListItemEditor(parent);
-
-    const FileInfoPointer &fileInfo = this->parent()->fileInfo(index);
-
-    if (fileInfo && fileInfo->urlOf(UrlInfoType::kUrl).scheme() == "search") {
-        d->editor->setFixedHeight(GlobalPrivate::kListEditorHeight * 2 - 10);
-    } else {
-        d->editor->setFixedHeight(GlobalPrivate::kListEditorHeight);
-    }
+    auto size = sizeHint(option, index);
+    d->editor->setFixedHeight(size.height());
 
     connect(static_cast<ListItemEditor *>(d->editor), &ListItemEditor::inputFocusOut, this, &ListItemDelegate::editorFinished);
 


### PR DESCRIPTION
The editor height for list items was previously hardcoded with special
handling for search scheme items. This has been replaced with a more
robust approach using the sizeHint method to dynamically calculate the
appropriate height based on the actual item size.

This change ensures consistent editor sizing across different file
types and schemes, eliminating the need for special case handling and
improving maintainability.

Influence:
1. Test file renaming in list view for regular files
2. Test file renaming in list view for search results
3. Verify editor height matches the item height in all cases
4. Check that editor positioning remains correct
5. Test with different file types and schemes

fix: 调整列表项编辑器高度计算

之前列表项的编辑器高度是硬编码的，并对搜索方案项有特殊处理。现在改为使用
sizeHint 方法动态计算基于实际项目大小的合适高度。

此变更确保不同文件类型和方案间的编辑器尺寸一致性，消除了特殊案例处理的需
求并提高了可维护性。

Influence:
1. 测试列表视图中常规文件的重命名功能
2. 测试列表视图中搜索结果文件的重命名功能
3. 验证编辑器高度在所有情况下与项目高度匹配
4. 检查编辑器定位是否保持正确
5. 测试不同文件类型和方案

BUG: https://pms.uniontech.com/bug-view-335481.html

## Summary by Sourcery

Adjust the list item editor height calculation to use the delegate's sizeHint dynamically instead of hardcoded values with special search-item handling.

Bug Fixes:
- Ensure editor height always matches item height across all file types and schemes.

Enhancements:
- Remove hardcoded height logic and special-case handling for search-scheme items in favor of sizeHint-based sizing.