### PR TITLE
fix: prevent double free crashes in preview dialogs

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/utils/previewdialogmanager.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/utils/previewdialogmanager.cpp
@@ -23,8 +23,20 @@ PreviewDialogManager *PreviewDialogManager::instance()
 
 void PreviewDialogManager::onPreviewDialogClose()
 {
-    filePreviewDialog->deleteLater();
-    filePreviewDialog = nullptr;
+    if (filePreviewDialog) {
+        // Disconnect all signals to prevent any further interactions
+        filePreviewDialog->disconnect();
+        
+        // Use single shot timer to ensure proper cleanup order
+        // This allows the dialog's closeEvent to complete its cleanup first
+        QTimer::singleShot(0, this, [this]() {
+            if (filePreviewDialog) {
+                filePreviewDialog->deleteLater();
+                filePreviewDialog = nullptr;
+            }
+        });
+    }
+    
     qCInfo(logLibFilePreview) << "PreviewDialogManager: preview dialog closed, starting exit timer";
     exitTimer->start(60000);
 }

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
@@ -29,8 +29,12 @@ TextPreview::TextPreview(QObject *parent)
 TextPreview::~TextPreview()
 {
     fmInfo() << "Text preview: TextPreview instance destroyed";
-    if (textBrowser)
+    if (textBrowser) {
+        // Set parent to nullptr first to prevent recursive destruction issues
+        textBrowser->setParent(nullptr);
         textBrowser->deleteLater();
+        textBrowser = nullptr;
+    }
 }
 
 bool TextPreview::setFileUrl(const QUrl &url)


### PR DESCRIPTION
Fixed double free crashes caused by improper dialog cleanup sequences in preview dialogs management. The main changes include:

1. Added guarded nullptr checks before deleting dialogs
2. Implemented QTimer::singleShot in PreviewDialogManager to ensure proper cleanup sequence
3. Added signal disconnection before deletion to prevent stray signals
4. Modified TextPreview destructor to set parent to nullptr before deletion
5. Added explicit nulling of pointers after deletion

These changes ensure safer cleanup of dialog objects by preventing:
- Double deletion when events trigger during cleanup
- Use-after-free scenarios
- Recursive destruction issues
- Stray signals causing crashes after deletion

Log: Fixed crashes when closing file preview dialogs

Influence:
1. Test closing preview dialogs repeatedly
2. Verify no crashes occur during rapid open/close operations
3. Check memory usage remains stable after multiple preview cycles
4. Verify all preview types (text/images/etc) cleanup properly

fix: 修复预览对话框的双重释放崩溃问题

对预览对话框管理中的对话框清理顺序进行了修复，主要更改包括：

1. 在删除对话框前添加了空指针保护检查
2. 在PreviewDialogManager中使用QTimer::singleShot确保正确的清理顺序
3. 删除前断开所有信号连接以防止残留信号
4. 修改TextPreview析构函数，在删除前先将父对象设为nullptr
5. 删除后显式将指针置空

这些更改通过以下方式确保对话框对象的安全清理：
- 防止清理过程中事件触发导致的双重删除
- 防止释放后使用的场景
- 避免递归销毁问题
- 防止删除后残留信号导致的崩溃

Log: 修复关闭文件预览对话框时出现的崩溃问题

Influence:
1. 测试重复关闭预览对话框
2. 验证在快速打开/关闭操作期间不会发生崩溃
3. 检查多次预览循环后内存使用保持稳定
4. 验证所有预览类型(文本/图片等)都能正确清理

## Summary by Sourcery

Prevent double-free crashes in preview dialogs by enhancing cleanup logic to defer deletion, disconnect signals, and nullify pointers.

Bug Fixes:
- Add nullptr guards before deleting dialogs in PreviewDialogManager
- Use QTimer::singleShot to defer dialog deletion until after the closeEvent completes
- Disconnect all signals from preview dialog instances prior to deletion
- Detach TextPreview’s textBrowser from its parent before deleting to avoid recursive destruction
- Nullify dialog and widget pointers after deletion to eliminate stale references