### PR TITLE
chore: update version to 6.5.96

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.96) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Fri, 10 Oct 2025 19:36:32 +0800
+
 dde-file-manager (6.5.95) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
update version

Log: update version to 6.5.96

## Summary by Sourcery

Build:
- Bump version to 6.5.96 in debian/changelog