### PR TITLE
6.5.96

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.96) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 10 Oct 2025 20:14:00 +0800
+
 dde-file-manager (6.5.95) unstable; urgency=medium
 
   * fix bugs

--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
@@ -16,7 +16,6 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-framework/dpf.h>
 #include <dfm-base/base/application/application.h>
-#include <dfm-base/utils/finallyutil.h>
 
 #include <QPainter>
 #include <QDebug>
@@ -362,12 +361,30 @@ void CanvasView::paintEvent(QPaintEvent *event)
 
 void CanvasView::contextMenuEvent(QContextMenuEvent *event)
 {
-    // 先处理选中事件，选中事件处理完成后再处理ContextMenuEvent
-    // 在处理ContextMenuEvent设置了updateenable为false，不然刷新全部
-    QContextMenuEvent *e = new QContextMenuEvent(*event);
-    QTimer::singleShot(0, this, [this, e]{
-        onContextMenuEvent(e);
-    });
+    if (CanvasViewMenuProxy::disableMenu())
+        return;
+
+    QPoint gridPos = d->gridAt(event->pos());
+    itemDelegate()->revertAndcloseEditor();
+
+    const QModelIndex &index = indexAt(event->pos());
+    bool isEmptyArea = !index.isValid();
+    Qt::ItemFlags flags;
+
+    if (WindowUtils::isWayLand())
+        setAttribute(Qt::WA_InputMethodEnabled, false);
+    if (isEmptyArea) {
+        d->menuProxy->showEmptyAreaMenu(flags, gridPos);
+    } else {
+        // menu focus is on the index that is not selected
+        if (!selectionModel()->isSelected(index))
+            selectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
+
+        flags = model()->flags(index);
+        d->menuProxy->showNormalMenu(index, flags, gridPos);
+    }
+    if (WindowUtils::isWayLand())
+        setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
 void CanvasView::startDrag(Qt::DropActions supportedActions)
@@ -473,48 +490,6 @@ void CanvasView::changeEvent(QEvent *event)
     }
 
     QAbstractItemView::changeEvent(event);
-}
-
-void CanvasView::onContextMenuEvent(QContextMenuEvent *event)
-{
-    FinallyUtil util([this, event]{
-        setUpdatesEnabled(true);
-        blockSignals(false);
-        if (event)
-            delete event;
-    });
-    blockSignals(true);
-    setUpdatesEnabled(false);
-    if (CanvasViewMenuProxy::disableMenu())
-        return;
-
-    QPoint gridPos = d->gridAt(event->pos());
-    itemDelegate()->revertAndcloseEditor();
-
-    const QModelIndex &index = indexAt(event->pos());
-    bool isEmptyArea = !index.isValid();
-    Qt::ItemFlags flags;
-
-    if (WindowUtils::isWayLand())
-        setAttribute(Qt::WA_InputMethodEnabled, false);
-    if (isEmptyArea) {
-        d->menuProxy->showEmptyAreaMenu(flags, gridPos);
-    } else {
-        // menu focus is on the index that is not selected
-        if (!selectionModel()->isSelected(index))
-            selectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
-
-        const QUrl &url = model()->fileUrl(index);
-        if (NetworkUtils::instance()->checkFtpOrSmbBusy(url)) {
-            DialogManager::instance()->showUnableToVistDir(url.path());
-            return;
-        }
-
-        flags = model()->flags(index);
-        d->menuProxy->showNormalMenu(index, flags, gridPos);
-    }
-    if (WindowUtils::isWayLand())
-        setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
 void CanvasView::setScreenNum(const int screenNum)

--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.h
@@ -105,9 +105,6 @@ protected:
     void changeEvent(QEvent *event) override;
 
 private:
-    void onContextMenuEvent(QContextMenuEvent *event);
-
-private:
     CanvasViewPrivate *d;
 };
 

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -2103,12 +2103,27 @@ void CollectionView::keyPressEvent(QKeyEvent *event)
 
 void CollectionView::contextMenuEvent(QContextMenuEvent *event)
 {
-    // 先处理选中事件，选中事件处理完成后再处理ContextMenuEvent
-    // 在处理ContextMenuEvent设置了updateenable为false，不然刷新全部
-    QContextMenuEvent *e = new QContextMenuEvent(*event);
-    QTimer::singleShot(0, this, [this, e]{
-        onContextMenuEvent(e);
-    });
+    if (this->property(kCollectionPropertyEditing).toBool())
+        return;
+    if (CollectionViewMenu::disableMenu())
+        return;
+
+    const QModelIndex &index = indexAt(event->pos());
+    itemDelegate()->revertAndcloseEditor();
+
+    if (!index.isValid())
+        d->menuProxy->emptyAreaMenu();
+    else {
+        // menu focus is on the index that is not selected
+        if (!selectionModel()->isSelected(index)) {
+            selectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
+            d->currentSelectionStartIndex = QModelIndex();
+        }
+
+        d->menuProxy->normalMenu(index, model()->flags(index), d->pointToPos(event->pos()));
+    }
+
+    event->accept();
 }
 
 void CollectionView::startDrag(Qt::DropActions supportedActions)
@@ -2271,39 +2286,6 @@ void CollectionView::scrollContentsBy(int dx, int dy)
 
     // just update viewport.
     QAbstractItemView::scrollContentsBy(dx, dy);
-}
-
-void CollectionView::onContextMenuEvent(QContextMenuEvent *event)
-{
-    FinallyUtil util([this, event]{
-        setUpdatesEnabled(true);
-        blockSignals(false);
-        if (event)
-            delete event;
-    });
-    blockSignals(true);
-    setUpdatesEnabled(false);
-    if (this->property(kCollectionPropertyEditing).toBool())
-        return;
-    if (CollectionViewMenu::disableMenu())
-        return;
-
-    const QModelIndex &index = indexAt(event->pos());
-    itemDelegate()->revertAndcloseEditor();
-
-    if (!index.isValid())
-        d->menuProxy->emptyAreaMenu();
-    else {
-        // menu focus is on the index that is not selected
-        if (!selectionModel()->isSelected(index)) {
-            selectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
-            d->currentSelectionStartIndex = QModelIndex();
-        }
-
-        d->menuProxy->normalMenu(index, model()->flags(index), d->pointToPos(event->pos()));
-    }
-
-    event->accept();
 }
 
 bool CollectionView::edit(const QModelIndex &index, QAbstractItemView::EditTrigger trigger, QEvent *event)

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.h
@@ -100,9 +100,6 @@ protected:
     void scrollContentsBy(int dx, int dy) override;
 
 private:
-    void onContextMenuEvent(QContextMenuEvent *event);
-
-private:
     QSharedPointer<CollectionViewPrivate> d = nullptr;
 };
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1893,12 +1893,57 @@ void FileView::keyboardSearch(const QString &search)
 
 void FileView::contextMenuEvent(QContextMenuEvent *event)
 {
-    // 先处理选中事件，选中事件处理完成后再处理ContextMenuEvent
-    // 在处理ContextMenuEvent设置了updateenable为false，不然刷新全部
-    QContextMenuEvent *e = new QContextMenuEvent(*event);
-    QTimer::singleShot(0,this,[this, e](){
-        onContextMenuEvent(e);
-    });
+    // if the left btn is pressed and the rect large enough, means the view state is draggingSelectState.
+    // and don't show menu in the draggingSelectState.
+    if (d->mouseLeftPressed && (abs(d->mouseMoveRect.width()) > kMinMoveLenght || abs(d->mouseMoveRect.height()) > kMinMoveLenght)) {
+        fmDebug() << "Context menu blocked due to drag selection state";
+        return;
+    }
+
+    if (NetworkUtils::instance()->checkFtpOrSmbBusy(rootUrl())) {
+        fmWarning() << "Cannot show context menu: FTP or SMB is busy for URL:" << rootUrl().toString();
+        DialogManager::instance()->showUnableToVistDir(rootUrl().path());
+        return;
+    }
+
+    if (FileViewMenuHelper::disableMenu()) {
+        fmDebug() << "Context menu disabled by helper";
+        return;
+    }
+
+    d->viewMenuHelper->setWaitCursor();
+    const QModelIndex &index = indexAt(event->pos());
+    if (itemDelegate()->editingIndex().isValid() && itemDelegate()->editingIndex() == index) {
+        fmDebug() << "Setting focus due to editing index";
+        setFocus(Qt::FocusReason::OtherFocusReason);
+    }
+
+    if (d->fileViewHelper->isEmptyArea(event->pos())) {
+        fmDebug() << "Showing context menu for empty area";
+        BaseItemDelegate *de = itemDelegate();
+        if (de)
+            de->hideNotEditingIndexWidget();
+        clearSelection();
+
+        d->viewMenuHelper->showEmptyAreaMenu();
+    } else {
+        if (!isSelected(index)) {
+            fmDebug() << "Item not selected, clearing selection and selecting clicked item";
+            itemDelegate()->hideNotEditingIndexWidget();
+            clearSelection();
+
+            if (!index.isValid()) {
+                fmDebug() << "Invalid index, showing empty area menu";
+                d->viewMenuHelper->showEmptyAreaMenu();
+                d->viewMenuHelper->reloadCursor();
+                return;
+            }
+
+            selectionModel()->select(index, QItemSelectionModel::Select);
+        }
+
+        d->viewMenuHelper->showNormalMenu(index, model()->flags(index));
+    }
 }
 
 QModelIndex FileView::moveCursor(QAbstractItemView::CursorAction cursorAction, Qt::KeyboardModifiers modifiers)
@@ -2683,66 +2728,3 @@ void FileView::onGroupHeaderClicked(const QModelIndex &index)
         d->selectHelper->handleGroupHeaderClick(index, QApplication::keyboardModifiers());
     }
 }
-
-void FileView::onContextMenuEvent(QContextMenuEvent *event)
-{
-    FinallyUtil util([this, event]{
-        setUpdatesEnabled(true);
-        blockSignals(false);
-        delete event;
-    });
-    blockSignals(true);
-    setUpdatesEnabled(false);
-    // if the left btn is pressed and the rect large enough, means the view state is draggingSelectState.
-    // and don't show menu in the draggingSelectState.
-    if (d->mouseLeftPressed && (abs(d->mouseMoveRect.width()) > kMinMoveLenght || abs(d->mouseMoveRect.height()) > kMinMoveLenght)) {
-        fmDebug() << "Context menu blocked due to drag selection state";
-        return;
-    }
-
-    if (NetworkUtils::instance()->checkFtpOrSmbBusy(rootUrl())) {
-        fmWarning() << "Cannot show context menu: FTP or SMB is busy for URL:" << rootUrl().toString();
-        DialogManager::instance()->showUnableToVistDir(rootUrl().path());
-        return;
-    }
-
-    if (FileViewMenuHelper::disableMenu()) {
-        fmDebug() << "Context menu disabled by helper";
-        return;
-    }
-
-    d->viewMenuHelper->setWaitCursor();
-    const QModelIndex &index = indexAt(event->pos());
-    if (itemDelegate()->editingIndex().isValid() && itemDelegate()->editingIndex() == index) {
-        fmDebug() << "Setting focus due to editing index";
-        setFocus(Qt::FocusReason::OtherFocusReason);
-    }
-
-    if (d->fileViewHelper->isEmptyArea(event->pos())) {
-        fmDebug() << "Showing context menu for empty area";
-        BaseItemDelegate *de = itemDelegate();
-        if (de)
-            de->hideNotEditingIndexWidget();
-        clearSelection();
-
-        d->viewMenuHelper->showEmptyAreaMenu();
-    } else {
-        if (!isSelected(index)) {
-            fmDebug() << "Item not selected, clearing selection and selecting clicked item";
-            itemDelegate()->hideNotEditingIndexWidget();
-            clearSelection();
-
-            if (!index.isValid()) {
-                fmDebug() << "Invalid index, showing empty area menu";
-                d->viewMenuHelper->showEmptyAreaMenu();
-                d->viewMenuHelper->reloadCursor();
-                return;
-            }
-
-            selectionModel()->select(index, QItemSelectionModel::Select);
-        }
-
-        d->viewMenuHelper->showNormalMenu(index, model()->flags(index));
-    }
-}
-

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -255,7 +255,6 @@ private:
     void focusOnView();
 
     bool isGroupHeader(const QModelIndex &index) const;
-    void onContextMenuEvent(QContextMenuEvent *event);
 };
 
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor context menu handling across multiple views to simplify and unify logic, add guards and helper checks, and remove deferred event processing.

Enhancements:
- Inline context menu logic in FileView, CanvasView, and CollectionView and remove the `onContextMenuEvent` defer methods
- Block context menu during drag-selection and when helper disables menus across all views
- Add FTP/SMB busy check and warning in FileView before showing the context menu
- Unify empty-area vs normal-item menu display and selection logic in all views
- Handle Wayland input method toggling and revert editors in CanvasView context menus