### PR TITLE
fix: unify mime type handling using QMimeTypeDatabase

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp
@@ -21,7 +21,7 @@ UnknowFilePreview::UnknowFilePreview(QObject *parent)
     : AbstractBasePreview(parent)
 {
     qCDebug(logLibFilePreview) << "UnknowFilePreview: initializing unknown file preview widget";
-    
+
     contentView = new QWidget();
     contentView->setFixedSize(590, 260);
     iconLabel = new QLabel(contentView);
@@ -62,14 +62,14 @@ UnknowFilePreview::UnknowFilePreview(QObject *parent)
 
     fileCalculationUtils = new FileStatisticsJob;
     connect(fileCalculationUtils, &FileStatisticsJob::dataNotify, this, &UnknowFilePreview::updateFolderSizeCount);
-    
+
     qCDebug(logLibFilePreview) << "UnknowFilePreview: initialization completed";
 }
 
 UnknowFilePreview::~UnknowFilePreview()
 {
     qCDebug(logLibFilePreview) << "UnknowFilePreview: destructor called";
-    
+
     if (contentView) {
         contentView->deleteLater();
     }
@@ -82,7 +82,7 @@ UnknowFilePreview::~UnknowFilePreview()
 bool UnknowFilePreview::setFileUrl(const QUrl &url)
 {
     qCInfo(logLibFilePreview) << "UnknowFilePreview: setting file URL:" << url.toString();
-    
+
     this->url = url;
     const FileInfoPointer info = InfoFactory::create<FileInfo>(url);
 
@@ -112,9 +112,9 @@ void UnknowFilePreview::setFileInfo(const FileInfoPointer &info)
         qCWarning(logLibFilePreview) << "UnknowFilePreview: null file info provided";
         return;
     }
-    
+
     qCDebug(logLibFilePreview) << "UnknowFilePreview: setting file info for:" << info->nameOf(NameInfoType::kFileName);
-    
+
     if (fileCalculationUtils) {
         fileCalculationUtils->stop();
     }
@@ -134,10 +134,10 @@ void UnknowFilePreview::setFileInfo(const FileInfoPointer &info)
     if (info->isAttributes(OptInfoType::kIsFile) || info->isAttributes(OptInfoType::kIsSymLink)) {
         QString sizeText = info->displayOf(DisPlayInfoType::kSizeDisplayName);
         QString typeText = info->displayOf(DisPlayInfoType::kMimeTypeDisplayName);
-        
+
         sizeLabel->setText(QObject::tr("Size: %1").arg(sizeText));
         typeLabel->setText(QObject::tr("Type: %1").arg(typeText));
-        
+
         qCDebug(logLibFilePreview) << "UnknowFilePreview: file info set - size:" << sizeText << "type:" << typeText;
     } else if (fileCalculationUtils && info->isAttributes(OptInfoType::kIsDir)) {
         qCInfo(logLibFilePreview) << "UnknowFilePreview: starting directory size calculation for:" << info->urlOf(UrlInfoType::kUrl).toString();
@@ -149,11 +149,12 @@ void UnknowFilePreview::setFileInfo(const FileInfoPointer &info)
 void UnknowFilePreview::updateFolderSizeCount(qint64 size, int filesCount, int directoryCount)
 {
     QString sizeText = FileUtils::formatSize(size);
-    int totalItems = filesCount + directoryCount;
-    
-    qCInfo(logLibFilePreview) << "UnknowFilePreview: folder size calculation completed - size:" << sizeText 
+    // 同“属性”对话框一致，不统计目录本身
+    int totalItems = filesCount + (directoryCount > 1 ? directoryCount - 1 : 0);
+
+    qCInfo(logLibFilePreview) << "UnknowFilePreview: folder size calculation completed - size:" << sizeText
                               << "files:" << filesCount << "directories:" << directoryCount << "total:" << totalItems;
-    
+
     sizeLabel->setText(QObject::tr("Size: %1").arg(sizeText));
     typeLabel->setText(QObject::tr("Items: %1").arg(totalItems));
 }

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -786,14 +786,6 @@ QString AsyncFileInfoPrivate::iconName() const
 
 QString AsyncFileInfoPrivate::mimeTypeName() const
 {
-    // At present, there is no dfmio library code. For temporary repair
-    // local file use the method on v20 to obtain mimeType
-    if (ProtocolUtils::isRemoteFile(q->fileUrl())) {
-        auto contentType = asyncAttribute(FileInfo::FileInfoAttributeID::kStandardContentType).toString();
-        if (contentType.isEmpty())
-            contentType = asyncAttribute(FileInfo::FileInfoAttributeID::kStandardFastContentType).toString();
-        return contentType;
-    }
     return q->fileMimeType().name();
 }
 

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -819,11 +819,6 @@ QString SyncFileInfoPrivate::iconName() const
 
 QString SyncFileInfoPrivate::mimeTypeName() const
 {
-    // At present, there is no dfmio library code. For temporary repair
-    // local file use the method on v20 to obtain mimeType
-    if (ProtocolUtils::isRemoteFile(q->fileUrl())) {
-        return this->attribute(DFileInfo::AttributeID::kStandardContentType).toString();
-    }
     return q->fileMimeType().name();
 }
 

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -302,13 +302,8 @@ QString dfmbase::FileInfo::displayOf(const DisPlayInfoType type) const
         return url.path();
     case DisPlayInfoType::kMimeTypeDisplayName:
         return MimeTypeDisplayManager::instance()->displayName(nameOf(FileNameInfoType::kMimeTypeName));
-    case DisPlayInfoType::kFileTypeDisplayName: {
-
-        int mimeDisplayNum = static_cast<int>(MimeTypeDisplayManager::
-                                                      instance()
-                                                              ->displayNameToEnum(const_cast<FileInfo *>(this)->fileMimeType().name()));
-        return QString("%1.").arg(mimeDisplayNum, 2, 10, QChar('0')).append(nameOf(FileNameInfoType::kSuffix));
-    }
+    case DisPlayInfoType::kFileTypeDisplayName:
+        return MimeTypeDisplayManager::instance()->fullMimeName(nameOf(FileNameInfoType::kMimeTypeName));
     case DisPlayInfoType::kFileDisplayPinyinName:
         if (pinyinName.isEmpty()) {
             const QString &displayName = this->displayOf(DisplayInfoType::kFileDisplayName);

--- a/src/dfm-base/mimetype/dmimedatabase.cpp
+++ b/src/dfm-base/mimetype/dmimedatabase.cpp
@@ -73,7 +73,7 @@ QMimeType DMimeDatabase::mimeTypeForFile(const FileInfoPointer &fileInfo, QMimeD
         }
     }
 
-    if (isMatchExtension || ProtocolUtils::isRemoteFile(QUrl::fromLocalFile(path))) {
+    if (isMatchExtension) {
         result = QMimeDatabase::mimeTypeForFile(fileInfo->pathOf(PathInfoType::kFilePath), QMimeDatabase::MatchExtension);
     } else {
         result = QMimeDatabase::mimeTypeForFile(fileInfo->pathOf(PathInfoType::kFilePath), mode);
@@ -157,7 +157,7 @@ QMimeType DMimeDatabase::mimeTypeForFile(const QFileInfo &fileInfo, QMimeDatabas
             isMatchExtension = blackList.contains(filePath);
         }
     }
-    if (isMatchExtension || ProtocolUtils::isRemoteFile(QUrl::fromLocalFile(path))) {
+    if (isMatchExtension) {
         result = QMimeDatabase::mimeTypeForFile(fileInfo, QMimeDatabase::MatchExtension);
     } else {
         result = QMimeDatabase::mimeTypeForFile(fileInfo, mode);

--- a/src/dfm-base/mimetype/mimetypedisplaymanager.h
+++ b/src/dfm-base/mimetype/mimetypedisplaymanager.h
@@ -27,8 +27,6 @@ public:
     QStringList supportArchiveMimetypes() const;
     QStringList supportVideoMimeTypes() const;
     QStringList supportAudioMimeTypes() const;
-    QString fastDisplayTypeFromPath(const QString &filePath) const;
-    QString fastMimeTypeName(const QString &filePath) const;
     QString accurateDisplayTypeFromPath(const QString &filePath) const;
     QString accurateLocalMimeTypeName(const QString &filePath) const;
 
@@ -38,7 +36,6 @@ private:
     void initData();
     void loadSupportMimeTypes();
     QStringList readlines(const QString &path);
-    QMimeType fastDetermineMimeType(const QString &filePath) const;
     QMimeType accurateLocalMimeType(const QString &filePath) const;
 
 private:
@@ -54,9 +51,6 @@ private:
     QStringList imageMimeTypes;
     QStringList executableMimeTypes;
     QStringList backupMimeTypes;
-
-    mutable int contentBasedFallbackCount = 0;
-    static const int kMaxContentBasedFallback = 1000;
 };
 
 }


### PR DESCRIPTION
Removed separate mime type handling logic for remote files and simplified mime type detection to consistently use QMimeTypeDatabase across the codebase. This eliminates inconsistencies between local and remote file type displays.

Key changes:
1. Removed special mime type handling for remote files in AsyncFileInfoPrivate and SyncFileInfoPrivate
2. Simplified file type display generation to use full MIME names directly
3. Removed fastDetermineMimeType and related methods that were causing inconsistencies
4. Updated DMimeDatabase to remove remote file special cases
5. Consolidated file type display logic to rely solely on QMimeTypeDatabase

Log: Fixed inconsistent file type display between local and remote files

Influence:
1. Verify file type display consistency across local and remote files
2. Test various file types to ensure correct MIME type detection
3. Check performance impact of removing fastDetermineMimeType
4. Validate archive, video and audio file type recognition

fix: 统一使用QMimeTypeDatabase处理文件类型

移除远程文件的特殊处理逻辑，简化mime类型检测，保持代码库中一致使用
QMimeTypeDatabase。消除了本地和远程文件类型显示不一致的问题。

主要变更：
1. 移除AsyncFileInfoPrivate和SyncFileInfoPrivate中对远程文件的特殊处理
2. 简化文件类型显示生成逻辑，直接使用完整MIME名称
3. 移除导致不一致的fastDetermineMimeType及相关方法
4. 更新DMimeDatabase，删除远程文件的特殊处理
5. 将所有文件类型显示逻辑统一为仅依赖QMimeTypeDatabase

Log: 修复了本地和远程文件类型显示不一致的问题

Influence:
1. 验证本地和远程文件类型显示的一致性
2. 测试多种文件类型确保正确识别MIME类型
3. 检查移除fastDetermineMimeType后的性能影响
4. 验证压缩包、视频和音频文件的类型识别

Bug: https://pms.uniontech.com/bug-view-336115.html

## Summary by Sourcery

Unify MIME type detection and display by removing legacy special-case logic and consistently using QMimeTypeDatabase across the codebase to fix inconsistent file type displays.

Bug Fixes:
- Fix inconsistent file type display between local and remote files

Enhancements:
- Remove deprecated fastDetermineMimeType and related fast display methods from MimeTypeDisplayManager
- Eliminate remote-file-specific MIME handling in AsyncFileInfoPrivate, SyncFileInfoPrivate, and DMimeDatabase
- Refactor FileInfo display logic to use full MIME names from QMimeTypeDatabase for file type display