### PR TITLE
fix: highlight expand arrow when item is drop target

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/treeitempaintproxy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/treeitempaintproxy.cpp
@@ -78,7 +78,8 @@ void TreeItemPaintProxy::drawExpandArrow(QPainter *painter, const QRectF &rect, 
 
     painter->save();
     bool isSelected = (opt.state & QStyle::State_Selected) && opt.showDecorationSelected;
-    if (isSelected) {
+    bool isDropTarget = view()->isDragTarget(index);
+    if (isSelected || isDropTarget) {
         painter->setPen(opt.palette.color(QPalette::Active, QPalette::HighlightedText));
     } else {
         painter->setPen(opt.palette.color(QPalette::Active, QPalette::Text));


### PR DESCRIPTION
The expand arrow in tree view items was not being highlighted when an
item was a drag-and-drop target, making it difficult for users to see
where files would be dropped during drag operations. This fix updates
the painting logic to highlight the expand arrow with the same color
scheme used for selected items when the item is a valid drop target.

Log: Tree view expand arrows now highlight during drag-and-drop
operations

Influence:
1. Drag files over tree view items and verify expand arrows change color
2. Test with both selected and non-selected items as drop targets
3. Verify arrow color returns to normal when drag leaves the item
4. Check that normal selection highlighting still works correctly

fix: 在项目为拖放目标时高亮展开箭头

树视图项目中的展开箭头在项目成为拖放目标时未被高亮显示，导致用户在拖拽操
作期间难以看清文件将被放置的位置。此修复更新了绘制逻辑，当项目是有效的拖
放目标时，使用与选中项目相同的配色方案高亮展开箭头。

Log: 树视图展开箭头现在在拖放操作期间会高亮显示

Influence:
1. 将文件拖拽到树视图项目上，验证展开箭头颜色变化
2. 测试选中和未选中项目作为拖放目标的情况
3. 验证拖拽离开项目时箭头颜色恢复正常
4. 检查正常的选择高亮功能是否仍然正常工作

## Summary by Sourcery

Bug Fixes:
- Ensure expand arrows use the highlighted text color when an item is a drag-and-drop target