### PR TITLE
feat: add selected icon background highlight

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -46,6 +46,7 @@ const int CanvasItemDelegate::kTextPadding = 4;
 const int CanvasItemDelegate::kIconSpacing = 2;
 const int CanvasItemDelegate::kIconBackRadius = 18;
 const int CanvasItemDelegate::kIconRectRadius = 4;
+const int CanvasItemDelegate::kIconBackgroundMargin = 4;
 
 CanvasItemDelegatePrivate::CanvasItemDelegatePrivate(CanvasItemDelegate *qq)
     : q(qq)
@@ -132,8 +133,9 @@ void CanvasItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
     // get item paint geomerty
     // the method to get rect for each element is equal to paintGeomertys(option, index);
     {
-        // draw icon
+        // draw icon and background
         const QRect rIcon = iconRect(option.rect);
+        paintBackground(painter, indexOption, rIcon);
         paintIcon(painter, indexOption.icon,
                   { rIcon,
                     Qt::AlignCenter,
@@ -607,7 +609,7 @@ QRect CanvasItemDelegate::labelRect(const QRect &paintRect, const QRect &usedRec
 {
     QRect lable = paintRect;
     // label rect is under the icon.
-    lable.setTop(usedRect.bottom());
+    lable.setTop(usedRect.bottom() + kIconBackgroundMargin);
 
     // minus text padding at left and right.
     lable.setWidth(paintRect.width() - 2 * kTextPadding);
@@ -839,6 +841,29 @@ QRectF CanvasItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect, c
         });
     }
     return rect;
+}
+
+void CanvasItemDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const
+{
+    bool isSelected = (option.state & QStyle::State_Selected) && option.showDecorationSelected;
+    if (!isSelected)
+        return;
+
+    QColor backgroundColor(0, 0, 0, qRound(255 * 0.15));
+    QColor borderColor(255, 255, 255, qRound(255 * 0.1));
+    QRect backgroundRect = iconRect.adjusted(-kIconBackgroundMargin, -kIconBackgroundMargin, kIconBackgroundMargin, kIconBackgroundMargin);
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing);
+
+    QPainterPath path;
+    path.addRoundedRect(backgroundRect, kIconRectRadius, kIconRectRadius);
+    painter->fillPath(path, backgroundColor);
+
+    painter->setPen(borderColor);
+    painter->drawPath(path);
+
+    painter->restore();
 }
 
 void CanvasItemDelegatePrivate::extendLayoutText(const FileInfoPointer &info, dfmbase::ElideTextLayout *layout)

--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.h
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.h
@@ -66,6 +66,7 @@ protected:
     static QRectF paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
     static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info);
 
+    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const;
     void paintLabel(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rLabel) const;
     void drawNormlText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRectF &rText) const;
     void drawHighlightText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rText) const;
@@ -90,6 +91,7 @@ public:
     static const int kIconSpacing;
     static const int kIconBackRadius;
     static const int kIconRectRadius;
+    static const int kIconBackgroundMargin;
 
 private:
     CanvasItemDelegatePrivate *const d = nullptr;

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -50,6 +50,7 @@ const int CollectionItemDelegate::kIconSpacing = 2;
 const int CollectionItemDelegate::kIconTopSpacing = 4;
 const int CollectionItemDelegate::kIconBackRadius = 18;
 const int CollectionItemDelegate::kIconRectRadius = 4;
+const int CollectionItemDelegate::kIconBackgroundMargin = 4;
 
 CollectionItemDelegatePrivate::CollectionItemDelegatePrivate(CollectionItemDelegate *qq)
     : q(qq)
@@ -151,8 +152,9 @@ void CollectionItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem
     // get item paint geomerty
     // the method to get rect for each element is equal to paintGeomertys(option, index);
     {
-        // draw icon
+        // draw icon and background
         const QRect rIcon = iconRect(option.rect);
+        paintBackground(painter, indexOption, rIcon);
         paintIcon(painter, indexOption.icon,
                   { rIcon,
                     Qt::AlignCenter,
@@ -608,7 +610,7 @@ QRect CollectionItemDelegate::labelRect(const QRect &paintRect, const QRect &use
 {
     QRect lable = paintRect;
     // label rect is under the icon.
-    lable.setTop(usedRect.bottom());
+    lable.setTop(usedRect.bottom() + kIconBackgroundMargin);
 
     // minus text padding at left and right.
     lable.setWidth(paintRect.width() - 2 * kTextPadding);
@@ -864,6 +866,29 @@ QRectF CollectionItemDelegate::paintEmblems(QPainter *painter, const QRectF &rec
         });
     }
     return rect;
+}
+
+void CollectionItemDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const
+{
+    bool isSelected = (option.state & QStyle::State_Selected) && option.showDecorationSelected;
+    if (!isSelected)
+        return;
+
+    QColor backgroundColor(0, 0, 0, qRound(255 * 0.15));
+    QColor borderColor(255, 255, 255, qRound(255 * 0.1));
+    QRect backgroundRect = iconRect.adjusted(-kIconBackgroundMargin, -kIconBackgroundMargin, kIconBackgroundMargin, kIconBackgroundMargin);
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing);
+
+    QPainterPath path;
+    path.addRoundedRect(backgroundRect, kIconRectRadius, kIconRectRadius);
+    painter->fillPath(path, backgroundColor);
+
+    painter->setPen(borderColor);
+    painter->drawPath(path);
+
+    painter->restore();
 }
 
 void CollectionItemDelegate::paintLabel(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rLabel) const

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.h
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.h
@@ -62,6 +62,7 @@ protected:
     static QRect paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
     static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info);
 
+    void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const;
     void paintLabel(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rLabel) const;
     void drawNormlText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRectF &rText) const;
     void drawHighlightText(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rText) const;
@@ -87,6 +88,7 @@ public:
     static const int kIconBackRadius;
     static const int kIconRectRadius;
     static const int kIconTopSpacing;
+    static const int kIconBackgroundMargin;
 
 private:
     CollectionItemDelegatePrivate *const d = nullptr;


### PR DESCRIPTION
Added background highlight for selected icons in canvas view. The
changes include:
1. Added new paintBackground method to draw a semi-transparent
background behind selected icons
2. Introduced kIconBackgroundMargin constant for consistent spacing
3. Adjusted label positioning to account for the new background margin
4. The background uses a dark semi-transparent fill with a light border
for better visual feedback

Log: Added visual highlight effect for selected icons on desktop

Influence:
1. Test icon selection by clicking on desktop icons
2. Verify the background highlight appears only for selected items
3. Check that the highlight properly surrounds the icon with consistent
margins
4. Test multiple icon selection to ensure all selected items show the
highlight
5. Verify the highlight disappears when items are deselected
6. Test with different icon sizes and layouts

feat: 为选中图标添加背景高亮效果

在画布视图中为选中的图标添加背景高亮效果。具体改动包括：
1. 新增paintBackground方法用于绘制选中图标背后的半透明背景
2. 引入kIconBackgroundMargin常量确保间距一致性
3. 调整标签位置以适应新的背景边距
4. 背景使用深色半透明填充和浅色边框，提供更好的视觉反馈

Log: 在桌面选中图标时添加视觉高亮效果

Influence:
1. 测试点击桌面图标的选择功能
2. 验证背景高亮仅出现在选中项目上
3. 检查高亮效果是否以一致边距正确环绕图标
4. 测试多选图标时所有选中项是否都显示高亮
5. 验证取消选择时高亮效果是否消失
6. 测试不同图标尺寸和布局下的显示效果

STORY: https://pms.uniontech.com/story-view-39633.html
