### PR TITLE
fix: implement unified grouping strategy mapping

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/sortbybutton_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/sortbybutton_p.h
@@ -25,8 +25,6 @@ public:
     void setItemSortRoles();
     void setItemGroupRoles();
     void sort();
-    QString findObjNameByGroupStrategy(const QString &strategy);
-    QString findStrategyByObjName(const QString &objName);
 
 private slots:
     void menuTriggered(QAction *action);
@@ -41,7 +39,6 @@ private:
     QMenu *menu { nullptr };
     QMenu *groupMenu { nullptr };
     bool iconClicked { false };   // Add iconClicked state
-    QHash<QString, QString> objNamesToGroupStrategies;
 };
 }   // namespace dfmplugin_titlebar
 


### PR DESCRIPTION
Removed hardcoded object name to group strategy mapping and replaced it with a more flexible role-based approach. The changes include:
1. Deleted unused mapping functions and hash table
2. Added roleToGroupingStrategy helper function for direct role-to- strategy conversion
3. Modified menu setup to create group actions dynamically based on available roles
4. Updated group strategy selection logic to use role properties directly

This refactoring aligns the grouping mechanism with the view's behavior and removes temporary workarounds, providing a cleaner implementation that's easier to maintain.

Influence:
1. Verify all grouping options work correctly in different views
2. Test grouping strategy persistence across sessions
3. Check menu item states synchronization with current grouping
4. Test edge cases with unknown roles

refactor: 实现统一的组策略映射方案

移除了硬编码的对象名到组策略映射，改用基于角色更灵活的解决方案。变更
包括：
1. 删除未使用的映射函数和哈希表
2. 添加roleToGroupingStrategy辅助函数实现角色到策略的直接转换
3. 修改菜单设置逻辑，基于可用角色动态创建分组操作
4. 更新组策略选择逻辑直接使用角色属性

此次重构使分组机制与视图行为保持一致，移除了临时解决方案，提供了更清晰且
易于维护的实现。

Influence:
1. 验证所有分组选项在不同视图中正常工作
2. 测试分组策略在会话间的持久性
3. 检查菜单项状态与当前分组的同步
4. 测试包含未知角色的边界情况

Bug: https://pms.uniontech.com/bug-view-336613.html