### PR TITLE
feat: add copy file path shortcut support

### DIFF
--- a/include/dfm-base/dfm_event_defines.h
+++ b/include/dfm-base/dfm_event_defines.h
@@ -53,6 +53,7 @@ enum GlobalEventType {
     kCleanTrash,
     kWriteCustomToClipboard,
     kHideFiles,
+    kCopyFilePath,
 
     // file operations finieshed!
     kOpenFilesResult = 1000,

--- a/src/dfm-base/shortcut/shortcut.cpp
+++ b/src/dfm-base/shortcut/shortcut.cpp
@@ -31,6 +31,7 @@ Shortcut::Shortcut(QObject *parent)
                       << ShortcutItem(tr("Cut"), "Ctrl + X ")
                       << ShortcutItem(tr("Paste"), "Ctrl + V ")
                       << ShortcutItem(tr("Rename"), "F2 ")
+                      << ShortcutItem(tr("Copy file path"), "Ctrl + Shift + C ")
                       << ShortcutItem(tr("Open in terminal"), "Shift + T ")
                       << ShortcutItem(tr("Undo"), "Ctrl + Z ")
                       << ShortcutItem(tr("Redo"), "Ctrl + Y ");

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations.cpp
@@ -305,6 +305,9 @@ void FileOperations::initEventHandle()
     dpfSignalDispatcher->subscribe(GlobalEventType::kRedo,
                                    FileOperationsEventReceiver::instance(),
                                    &FileOperationsEventReceiver::handleRecoveryOperationRedoRecovery);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kCopyFilePath,
+                                   FileOperationsEventReceiver::instance(),
+                                   &FileOperationsEventReceiver::handleCopyFilePath);
 
     dpfSlotChannel->connect("dfmplugin_fileoperations",
                             "slot_Operation_FilesPreview",

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -210,6 +210,7 @@ public slots:
                                      const QList<QUrl> &selectUrls,
                                      const QList<QUrl> &dirUrls);
     bool handleIsSubFile(const QUrl &parent, const QUrl &sub);
+    void handleCopyFilePath(const QList<QUrl> &urlList);
 
 private:
     enum class RenameTypes {

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/fileoperatorproxy.cpp
@@ -215,6 +215,12 @@ void FileOperatorProxy::copyFiles(const CanvasView *view)
     dpfSignalDispatcher->publish(GlobalEventType::kWriteUrlsToClipboard, view->winId(), ClipBoard::ClipboardAction::kCopyAction, urls);
 }
 
+void FileOperatorProxy::copyFilePath(const CanvasView *view)
+{
+    auto urls = view->selectionModel()->selectedUrls();
+    dpfSignalDispatcher->publish(GlobalEventType::kCopyFilePath, urls);
+}
+
 void FileOperatorProxy::cutFiles(const CanvasView *view)
 {
     auto urls = view->selectionModel()->selectedUrls();

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/fileoperatorproxy.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/fileoperatorproxy.h
@@ -25,6 +25,7 @@ public:
     void touchFile(const CanvasView *view, const QPoint pos, const QUrl &source);
     void touchFolder(const CanvasView *view, const QPoint pos);
     void copyFiles(const CanvasView *view);
+    void copyFilePath(const CanvasView *view);
     void cutFiles(const CanvasView *view);
     void pasteFiles(const CanvasView *view, const QPoint pos = QPoint(0, 0));
     void openFiles(const CanvasView *view);

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/shortcutoper.cpp
@@ -163,6 +163,9 @@ bool ShortcutOper::keyPressed(QKeyEvent *event)
         } else if (key == Qt::Key_N) {
             FileOperatorProxyIns->touchFolder(view, view->d->gridAt(QCursor::pos()));
             return true;
+        } else if (key == Qt::Key_C) {
+            FileOperatorProxyIns->copyFilePath(view);
+            return true;
         }
     }
 

--- a/src/plugins/desktop/ddplugin-organizer/utils/fileoperator.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/utils/fileoperator.cpp
@@ -141,6 +141,12 @@ void FileOperator::copyFiles(const CollectionView *view)
     dpfSignalDispatcher->publish(GlobalEventType::kWriteUrlsToClipboard, view->winId(), ClipBoard::ClipboardAction::kCopyAction, urls);
 }
 
+void FileOperator::copyFilePath(const CollectionView *view)
+{
+    auto &&urls = d->getSelectedUrls(view);
+    dpfSignalDispatcher->publish(GlobalEventType::kCopyFilePath, urls);
+}
+
 void FileOperator::cutFiles(const CollectionView *view)
 {
     auto &&urls = d->getSelectedUrls(view);

--- a/src/plugins/desktop/ddplugin-organizer/utils/fileoperator.h
+++ b/src/plugins/desktop/ddplugin-organizer/utils/fileoperator.h
@@ -29,6 +29,7 @@ public:
     void setDataProvider(CollectionDataProvider *provider);
 
     void copyFiles(const CollectionView *view);
+    void copyFilePath(const CollectionView *view);
     void cutFiles(const CollectionView *view);
     void pasteFiles(const CollectionView *view, const QString &targetColletion);
     void openFiles(const CollectionView *view);

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -684,6 +684,11 @@ void CollectionViewPrivate::copyFiles()
     FileOperatorIns->copyFiles(q);
 }
 
+void CollectionViewPrivate::copyFilePath()
+{
+    FileOperatorIns->copyFilePath(q);
+}
+
 void CollectionViewPrivate::cutFiles()
 {
     FileOperatorIns->cutFiles(q);
@@ -2028,6 +2033,9 @@ void CollectionView::keyPressEvent(QKeyEvent *event)
     case (Qt::ControlModifier | Qt::ShiftModifier): {
         if (event->key() == Qt::Key_I) {
             d->toggleSelect();
+            return;
+        } else if (event->key() == Qt::Key_C) {
+            d->copyFilePath();
             return;
         }
     } break;

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
@@ -86,6 +86,7 @@ public:
     void clearClipBoard();
     void selectCollection();
     void copyFiles();
+    void copyFilePath();
     void cutFiles();
     void pasteFiles();
     void undoFiles();

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.h
@@ -28,6 +28,7 @@ public Q_SLOTS:
 
     bool hookTitleBarAddrHandle(QUrl *url);
     bool hookAllowRepeatUrl(const QUrl &cur, const QUrl &pre);
+    bool hookCopyFilePath(quint64, const QList<QUrl> &urlList, const QUrl &rootUrl);
 
 private:
     bool getOriginalUri(const QUrl &in, QUrl *out);

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/smbbrowser.cpp
@@ -156,6 +156,7 @@ void SmbBrowser::followEvents()
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Show_Addr", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookTitleBarAddrHandle);
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Copy_Addr", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookTitleBarAddrHandle);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Allow_Repeat_Url", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookAllowRepeatUrl);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_CopyFilePath", SmbBrowserEventReceiver::instance(), &SmbBrowserEventReceiver::hookCopyFilePath);
 }
 
 void SmbBrowser::updateNeighborToSidebar()

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -211,6 +211,12 @@ void FileOperatorHelper::copyFiles(const FileView *view)
                                  selectedUrls);
 }
 
+void FileOperatorHelper::copyFilePath(const FileView *view)
+{
+    QList<QUrl> selectedUrls = view->selectedTreeViewUrlList();
+    dpfSignalDispatcher->publish(GlobalEventType::kCopyFilePath, selectedUrls);
+}
+
 void FileOperatorHelper::cutFiles(const FileView *view)
 {
     const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(view->rootUrl());

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.h
@@ -29,6 +29,7 @@ public:
     void openFilesByApp(const FileView *view, const QList<QUrl> &urls, const QList<QString> &apps);
     void renameFile(const FileView *view, const QUrl &oldUrl, const QUrl &newUrl);
     void copyFiles(const FileView *view);
+    void copyFilePath(const FileView *view);
     void cutFiles(const FileView *view);
     void pasteFiles(const FileView *view);
     void undoFiles(const FileView *view);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/shortcuthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/shortcuthelper.cpp
@@ -238,6 +238,9 @@ bool ShortcutHelper::processKeyPressEvent(QKeyEvent *event)
         case Qt::Key_I:
             fmDebug() << "Ctrl+Shift+I pressed - reverse selection";
             return reverseSelect();
+        case Qt::Key_C:
+            copyFilePath();
+            return true;
         }
         break;
     case Qt::AltModifier:
@@ -309,6 +312,22 @@ void ShortcutHelper::copyFiles()
         return;
     }
     FileOperatorHelperIns->copyFiles(view);
+}
+
+void ShortcutHelper::copyFilePath()
+{
+    const QList<QUrl> &selectUrls = view->selectedUrlList();
+    if (selectUrls.isEmpty()) {
+        fmDebug() << "Copy file path operation canceled - no files selected";
+        return;
+    }
+
+    auto windowId = WorkspaceHelper::instance()->windowId(view);
+    if (dpfHookSequence->run(kCurrentEventSpace, "hook_ShortCut_CopyFilePath", windowId, selectUrls, view->rootUrl())) {
+        fmDebug() << "Copy file path handled by hook";
+        return;
+    }
+    FileOperatorHelperIns->copyFilePath(view);
 }
 
 void ShortcutHelper::cutFiles()

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/shortcuthelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/shortcuthelper.h
@@ -29,6 +29,7 @@ public:
 protected slots:
     void acitonTriggered();
     void copyFiles();
+    void copyFilePath();
     void cutFiles();
     void pasteFiles();
     void undoFiles();

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.h
@@ -87,6 +87,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_HOOK(hook_DragDrop_FileCanMove)
 
     DPF_EVENT_REG_HOOK(hook_ShortCut_CopyFiles)
+    DPF_EVENT_REG_HOOK(hook_ShortCut_CopyFilePath)
     DPF_EVENT_REG_HOOK(hook_ShortCut_CutFiles)
     DPF_EVENT_REG_HOOK(hook_ShortCut_PasteFiles)
     DPF_EVENT_REG_HOOK(hook_ShortCut_DeleteFiles)


### PR DESCRIPTION
Added new shortcut Ctrl+Shift+C to copy file paths to clipboard for both
local and network files. The implementation includes:
1. Added new global event type kCopyFilePath
2. Implemented file path copying logic in file operations plugin
3. Added shortcut support in desktop canvas, organizer, and workspace
views
4. Added network file path handling for SMB, FTP, SFTP, DAV, and NFS
protocols
5. Integrated with existing clipboard system

Log: Added Ctrl+Shift+C shortcut to copy file paths

Influence:
1. Test Ctrl+Shift+C shortcut in file manager with local files
2. Test with network shares (SMB, FTP, SFTP)
3. Verify multiple file selection path copying
4. Check clipboard content format (paths separated by newlines)
5. Test with empty selection (should do nothing)
6. Verify path accuracy for both local and network files

feat: 添加复制文件路径快捷键支持

新增 Ctrl+Shift+C 快捷键用于将文件路径复制到剪贴板，支持本地和网络文件。
实现包括：
1. 新增全局事件类型 kCopyFilePath
2. 在文件操作插件中实现文件路径复制逻辑
3. 在桌面画布、整理器和工作区视图中添加快捷键支持
4. 添加对 SMB、FTP、SFTP、DAV 和 NFS 协议的网络文件路径处理
5. 与现有剪贴板系统集成

Log: 新增 Ctrl+Shift+C 快捷键用于复制文件路径

Influence:
1. 在文件管理器中测试 Ctrl+Shift+C 快捷键（本地文件）
2. 测试网络共享文件（SMB、FTP、SFTP）
3. 验证多文件选择的路径复制功能
4. 检查剪贴板内容格式（路径以换行符分隔）
5. 测试空选择情况（应无操作）
6. 验证本地和网络文件路径的准确性

STORY: https://pms.uniontech.com/story-view-39637.html
