### PR TITLE
fix: prevent tab close on invalid middle click

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -850,8 +850,11 @@ bool TabBar::eventFilter(QObject *obj, QEvent *e)
 
 void TabBar::mousePressEvent(QMouseEvent *e)
 {
-    if (e->button() == Qt::MiddleButton)
-        Q_EMIT tabCloseRequested(tabAt(e->pos()));
+    if (e->button() == Qt::MiddleButton) {
+        int index = tabAt(e->pos());
+        if (-1 != index)
+            Q_EMIT tabCloseRequested(index);
+    }
 
     DTabBar::mousePressEvent(e);
 }


### PR DESCRIPTION
Added index validation before emitting tabCloseRequested signal when
middle mouse button is clicked. Previously, clicking middle button on
empty tab bar area would emit signal with invalid index (-1), which
could cause issues.

Now checks if tab index is valid (-1 means no tab at click position)
before requesting tab closure. This prevents potential crashes or
unexpected behavior when clicking middle button on empty tab bar areas.

fix: 修复无效中键点击关闭标签页问题

在鼠标中键点击时添加索引验证，确保只在有效标签页位置触发关闭信号。之前在
中键点击标签栏空白区域时会发出无效索引(-1)的关闭信号，可能导致问题。

现在在请求关闭标签页前会检查索引是否有效(-1表示点击位置没有标签页)，防止
在标签栏空白区域点击中键时出现潜在崩溃或意外行为。

BUG: https://pms.uniontech.com/bug-view-336827.html

## Summary by Sourcery

Bug Fixes:
- Add index validation before emitting tabCloseRequested on middle-click to avoid invalid -1 index and prevent unintended behavior on empty tab bar areas.