### PR TITLE
Fix: [filedialog] Set file dialolg stay on top.

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -1152,7 +1152,7 @@ bool FileDialog::eventFilter(QObject *watched, QEvent *event)
 
 void FileDialog::initializeUi()
 {
-    setWindowFlags(Qt::WindowCloseButtonHint | Qt::WindowTitleHint | Qt::Dialog);
+    setWindowFlags(Qt::WindowCloseButtonHint | Qt::WindowTitleHint | Qt::Dialog | Qt::WindowStaysOnTopHint);
 
     // init status bar
     d->statusBar = new FileDialogStatusBar(this);


### PR DESCRIPTION
-- set file dialog stary on top.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-336589.html

## Summary by Sourcery

Bug Fixes:
- Add WindowStaysOnTopHint flag to the file dialog window flags to fix it being hidden behind other windows