### PR TITLE
fix: adjust file view auto scroll margin

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -79,7 +79,7 @@ FileView::FileView(const QUrl &url, QWidget *parent)
     setDragDropOverwriteMode(true);
     setDragEnabled(true);
     setAutoScroll(true);
-    setAutoScrollMargin(100);
+    setAutoScrollMargin(32);
 //  TODO (search): perf
 //  setLayoutMode(QListView::Batched);
 #ifdef QT_SCROLL_WHEEL_ANI


### PR DESCRIPTION
Changed the autoScrollMargin value from 100 to 32 pixels for better scrolling behavior in the file view. The previous value was too large and caused premature triggering of auto-scroll during normal operations.

The adjustment provides a more balanced scrolling experience where auto- scroll activates at a more appropriate distance from view edges. This prevents unwanted scrolling during regular file operations while still maintaining smooth navigation when dragging items near view boundaries.

Influence:
1. Test dragging files near edges of file view
2. Verify auto-scroll activates at appropriate distances
3. Check scrolling behavior remains smooth during drag operations
4. Confirm normal scrolling and navigation still works properly

fix: 调整文件视图自动滚动边距

将autoScrollMargin值从100像素调整为32像素以获得更好的文件视图滚动行为。
先前的值过大，在正常操作期间会导致自动滚动过早触发。

此调整提供了更平衡的滚动体验，自动滚动会在距离视图边缘更合适的位置激活。
防止在日常文件操作中出现不必要的滚动，同时仍保持拖拽项目到视图边界附近时
的平滑导航。

Influence:
1. 测试在文件视图边缘附近拖拽文件
2. 验证自动滚动在适当距离处激活
3. 检查拖拽操作期间滚动行为保持平滑
4. 确认常规滚动和导航功能仍然正常工作