### PR TITLE
fix: update file attributes when inserting new items

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
@@ -97,6 +97,7 @@ void FileInfoModelPrivate::insertData(const QUrl &url)
         return;
     }
 
+    itemInfo->updateAttributes();
     q->beginInsertRows(q->rootIndex(), row, row);
     {
         QWriteLocker lk(&lock);


### PR DESCRIPTION
FileInfoModel was not updating file attributes when inserting new file items into the model, which could lead to displaying stale information due to fileinfo caching.

The change adds itemInfo->updateAttributes() call before inserting new items to ensure fresh file attributes are retrieved. This is particularly important since fileinfo maintains a cache and we need to ensure the displayed information matches the current file state.

Influence:
1. Test file creation scenarios where attributes might be cached
2. Verify UI updates correctly reflect current file attributes
3. Check performance impact for large number of file inserts

fix: 插入新项时更新文件属性

FileInfoModel在模型中新插入文件项时没有更新文件属性，由于fileinfo缓存机
制可能导致显示过时信息。

该修改在插入新项前添加了itemInfo->updateAttributes()调用，确保获取到最新 的文件属性。这一修改特别重要，因为fileinfo维护了缓存，我们需要确保显示的
信息与文件当前状态一致。

Influence:
1. 测试文件创建场景下可能存在缓存的情况
2. 验证UI是否正确反映当前文件属性
3. 检查大量文件插入时的性能影响

Bug: https://pms.uniontech.com/bug-view-336651.html