### PR TITLE
fix: use file count instead of total items count in status bar

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -893,6 +893,15 @@ QStringList FileViewModel::getKeyWords()
     return {};
 }
 
+int FileViewModel::getFileOnlyCount() const
+{
+    if (!filterSortWorker) {
+        return 0;
+    }
+
+    return filterSortWorker->getFileItemCount();
+}
+
 void FileViewModel::setDirectoryLoadStrategy(DirectoryLoadStrategy strategy)
 {
     fmDebug() << "Setting directory load strategy:" << static_cast<int>(strategy) << "for URL:" << dirRootUrl.toString();

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -97,6 +97,9 @@ public:
 
     QStringList getKeyWords();
 
+    // Get file-only count for status bar (excludes group headers)
+    int getFileOnlyCount() const;
+
     // 设置目录加载策略
     void setDirectoryLoadStrategy(DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);
     DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy directoryLoadStrategy() const;

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -168,6 +168,17 @@ int FileSortWorker::childrenCount()
     }
 }
 
+int FileSortWorker::getFileItemCount()
+{
+    if (!isCurrentGroupingEnabled) {
+        // Traditional mode: use original logic (same as childrenCount)
+        return childrenCountInternal();
+    } else {
+        // Grouping mode: return only file items count (excludes group headers)
+        return groupedModelData.getFileItemCount();
+    }
+}
+
 QVariant FileSortWorker::groupHeaderData(const int index, const int role)
 {
     // Grouping mode: use flattened data mapping

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
@@ -82,6 +82,7 @@ public:
                                   const QVariantHash &expandStates);
 
     int childrenCount();
+    int getFileItemCount();
     QVariant groupHeaderData(const int index, const int role);
     FileItemDataPointer childData(const int index);
     FileItemDataPointer childData(const QUrl &url);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2389,8 +2389,10 @@ void FileView::updateStatusBar()
     int count = selectedIndexCount();
 
     if (count == 0) {
-        d->statusBar->itemCounted(model()->rowCount(rootIndex()));
-        fmDebug() << "Status bar updated: no selection, total items:" << model()->rowCount(rootIndex()) << "for URL:" << rootUrl().toString();
+        // Use file-only count for status bar (excludes group headers in grouped mode)
+        int totalCount = model()->getFileOnlyCount();
+        d->statusBar->itemCounted(totalCount);
+        fmDebug() << "Status bar updated: no selection, total items:" << totalCount << "for URL:" << rootUrl().toString();
         return;
     }
 


### PR DESCRIPTION
The status bar was displaying incorrect counts when grouping was enabled because it included group headers in the total. This change ensures only actual file items are counted by:
1. Adding getFileOnlyCount() method to FileViewModel that returns filtered count
2. Implementing getFileItemCount() in FileSortWorker to separate file items from group headers
3. Modifying FileView to use the new method when updating status bar

Log: Fixed status bar count to exclude group headers in grouped view

Influence:
1. Test status bar count displays correctly in both grouped and non- grouped views
2. Verify counts update properly when files are added/removed
3. Check count remains accurate when switching grouping modes

fix: 状态栏统计使用文件数量而非总项目数

之前状态栏在分组视图下显示的总数不正确，因为它包含了分组标题。本次修改确
保仅统计实际文件：
1. 在FileViewModel中添加getFileOnlyCount()方法返回过滤后的数量
2. 在FileSortWorker中实现getFileItemCount()分离文件项和分组标题
3. 修改FileView在更新状态栏时使用新方法

Log: 修复分组视图下状态栏统计包含分组标题的问题

Influence:
1. 测试分组和非分组视图下状态栏数量显示是否正确
2. 验证文件增删时计数是否正确更新
3. 检查切换分组模式时计数是否保持准确

Bug: https://pms.uniontech.com/bug-view-336905.html