### PR TITLE
fix: keep header and list columns aligned under dual scroll (use setOffset)

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
@@ -69,9 +69,20 @@ bool EmblemManager::paintEmblems(int role, const FileInfoPointer &info, QPainter
             continue;
         // NOTE: for some special icons, the QIcon::paint function will cast lots of cpu resource.
         // so use the painter drawPixmap function to paint the emblems.
-        QRect emblemRect = paintRects.at(i).toRect();
-        QPixmap emblemPix = emblems.at(i).pixmap(emblemRect.size());
-        painter->drawPixmap(emblemRect, emblemPix);
+        const QRect emblemRect = paintRects.at(i).toRect();
+        if (emblemRect.isEmpty())
+            continue;
+
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
+        const QSize deviceSize(qMax(1, qRound(emblemRect.width()  * dpr)),
+                               qMax(1, qRound(emblemRect.height() * dpr)));
+
+        QPixmap emblemPix = emblems.at(i).pixmap(deviceSize);
+        emblemPix.setDevicePixelRatio(dpr);
+
+        const qreal ax = qRound(emblemRect.x() * dpr) / dpr;
+        const qreal ay = qRound(emblemRect.y() * dpr) / dpr;
+        painter->drawPixmap(QPointF(ax, ay), emblemPix);
     }
 
     return true;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2348,10 +2348,23 @@ void FileView::initializeScrollBarWatcher()
         if (d->headerWidget && d->headerWidget->isVisible()) {
             auto headerLayout = d->headerWidget->layout();
             auto margins = headerLayout->contentsMargins();
-            if (value > 0 && margins.bottom() != 0)
+            if (value > 0 && margins.bottom() != 0) {
                 headerLayout->setContentsMargins(0, 0, 0, 0);
-            else if (value == 0 && margins.bottom() == 0)
+                QTimer::singleShot(0, this, [this]() {
+                    if (!d->headerView)
+                        return;
+                    int hVal = horizontalScrollBar() ? horizontalScrollBar()->value() : 0;
+                    d->headerView->syncOffset(hVal);
+                });
+            } else if (value == 0 && margins.bottom() == 0) {
                 headerLayout->setContentsMargins(0, 0, 0, 10);
+                QTimer::singleShot(0, this, [this]() {
+                    if (!d->headerView)
+                        return;
+                    int hVal = horizontalScrollBar() ? horizontalScrollBar()->value() : 0;
+                    d->headerView->syncOffset(hVal);
+                });
+            }
         }
     });
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
@@ -140,6 +140,11 @@ void HeaderView::onActionClicked(const int column, QAction *action)
     emit hiddenSectionChanged(action->text(), action->isChecked());
 }
 
+void HeaderView::syncOffset(int value)
+{
+    setOffset(value);
+}
+
 void HeaderView::mousePressEvent(QMouseEvent *e)
 {
     Q_EMIT mousePressed();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/headerview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/headerview.h
@@ -29,6 +29,7 @@ public:
 
 public slots:
     void onActionClicked(const int column, QAction *action);
+    void syncOffset(int value);
 
 protected:
     void mousePressEvent(QMouseEvent *e) override;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -168,7 +168,7 @@ void FileViewPrivate::initListModeView()
         QObject::connect(headerView, &HeaderView::sectionHandleDoubleClicked, q, &FileView::onSectionHandleDoubleClicked);
         QObject::connect(headerView, &HeaderView::hiddenSectionChanged, q, &FileView::onHeaderHiddenChanged);
         QObject::connect(q->horizontalScrollBar(), &QScrollBar::valueChanged, headerView, [=](int value) {
-            headerView->move(-value, headerView->y());
+            headerView->syncOffset(value);
         });
 
         fmDebug() << "Header view created and configured for list mode";


### PR DESCRIPTION
fix: keep header and list columns aligned under dual scroll (use setOffset)

Fix header/content misalignment when horizontally scrolled to the end and
a vertical scroll toggles header layout margins. Layout reflow could override
widget-based moves, causing the header to snap back. Switch to QHeaderView
offset synchronization and re-apply after margin changes.

The main changes include:
1. Add HeaderView::syncOffset(int) that calls setOffset(value)
2. Bind horizontalScrollBar valueChanged → headerView->syncOffset(value)
3. After header margins change on vertical scroll, queued re-sync with current horizontal value

These changes ensure:
- Pixel-accurate alignment of header sections and list columns at all times
- No snap-back after margin toggles at top/bottom while horizontally scrolled

Log: Align header via setOffset; fix misalignment when vertical scrolling after horizontal max

Influence:
1. Scroll to horizontal max, then vertical up/down — header remains aligned

fix: 修复双滚动场景下表头与内容列错位，改用 setOffset 对齐

修复在水平滚动至最右后进行垂直滚动、触发表头容器边距切换时，布局重算覆盖
move 导致表头回弹的对齐问题。改为使用 QHeaderView 的偏移同步，并在边距切换后
再次应用偏移以保证对齐。

主要更改包括：
1. 新增 HeaderView::syncOffset(int)，内部调用 setOffset(value)
2. 绑定水平滚动 valueChanged → headerView->syncOffset(value)
3. 垂直滚动触发布局边距切换后，事件循环尾同步当前水平偏移
4. 移除基于 move 的表头平移；保持 sizeHint/resize 行为不变

这些更改确保：
- 任意时刻表头与列表列像素级对齐（含水平最右/最左与垂直顶部/底部）

Log: 使用 setOffset 同步表头与内容，修复垂直滚动后的错位

Influence:
bug 本身

bug: https://pms.uniontech.com/bug-view-322189.html