### PR TITLE
Revert "Fix: [filedialog] Set file dialolg stay on top."

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -1152,7 +1152,7 @@ bool FileDialog::eventFilter(QObject *watched, QEvent *event)
 
 void FileDialog::initializeUi()
 {
-    setWindowFlags(Qt::WindowCloseButtonHint | Qt::WindowTitleHint | Qt::Dialog | Qt::WindowStaysOnTopHint);
+    setWindowFlags(Qt::WindowCloseButtonHint | Qt::WindowTitleHint | Qt::Dialog);
 
     // init status bar
     d->statusBar = new FileDialogStatusBar(this);


### PR DESCRIPTION
Reverts linuxdeepin/dde-file-manager#3210

## Summary by Sourcery

Enhancements:
- Remove Qt::WindowStaysOnTopHint from FileDialog initialization