### PR TITLE
fix: report disc erase error.

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -43,6 +43,12 @@ void BurnJobManager::startEraseDisc(const QString &dev)
     initBurnJobConnect(job);
     connect(qobject_cast<EraseJob *>(job), &EraseJob::eraseFinished, this, [job, this](bool result) {
         startAuditLogForEraseDisc(job->currentDeviceInfo(), result);
+        if (!result) {
+            DialogManagerInstance->showErrorDialog(tr("Erase failed"),
+                                                   tr("Unable to complete disc erasure. "
+                                                      "This may be due to read/write limitations or the disc media status. "
+                                                      "Please check the relevant settings and try again."));
+        }
     });
     job->start();
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -142,8 +142,8 @@ bool DoCutFilesWorker::doCutFile(const DFileInfoPointer &fromInfo, const DFileIn
     DFileInfoPointer toInfo = nullptr;
     bool success = false;
 
-    const bool isSameDevice = DFMIO::DFMUtils::deviceNameFromUrl(fromInfo->uri()) == DFMIO::DFMUtils::deviceNameFromUrl(targetOrgUrl);
-
+    // 检查是否再同一个挂载点下，不再就执行copyAndDeleteFile
+    const bool isSameDevice = DFMIO::DFMUtils::mountPathFromUrl(fromInfo->uri()) == DFMIO::DFMUtils::mountPathFromUrl(targetOrgUrl);
     if (isSameDevice) {
         // Same device: try to rename directly. This is the fast path for moving files.
         bool renameOk = false;


### PR DESCRIPTION
see https://github.com/linuxdeepin/util-dfm/pull/214/files

Log: as above.

Bug: https://pms.uniontech.com/bug-view-330507.html

## Summary by Sourcery

Bug Fixes:
- Display an error dialog if disc erase operation fails to report the error to the user.