### PR TITLE
docs: update README build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,44 +9,52 @@ Deepin File Manager is a file management tool independently developed by Deepin 
 _The **master** branch is current development branch, build dependencies may change without updating README.md. Please refer to `./debian/control` for an accurate list of build dependencies_
 
 - cmake,
+- doxygen,
 - debhelper (>=9),
 - pkg-config,
-- dh-systemd,
-- qtbase5-dev,
-- qtbase5-private-dev,
-- qtmultimedia5-dev,
 - libffmpegthumbnailer-dev,
-- libqt5svg5-dev,
-- libpolkit-agent-1-dev, 
-- libpolkit-qt5-1-dev,
-- libdtkwidget-dev,
-- libdtkgui-dev,
-- libdtkcore-dev,
-- libdtkcore5-bin,
-- qttools5-dev-tools,
-- dde-dock-dev(>=4.8.4.1),
-- libdframeworkdbus-dev,
+- libpolkit-agent-1-dev,
+- dde-tray-loader-dev,
 - libtag1-dev,
 - libdmr-dev,
 - libicu-dev,
+- libxcb-ewmh-dev,
 - libdeepin-pdfium-dev,
-- libqt5xdg-dev,
-- libgio-qt-dev,
-- libdfm-io-dev,
-- libdfm-mount-dev,
-- libdfm-burn-dev,
 - libssl-dev,
 - libgtest-dev,
 - libgmock-dev,
-- libgsettings-qt-dev,
 - liblucene++-dev,
 - libdocparser-dev,
 - libboost-filesystem-dev,
 - libsecret-1-dev,
-- libkf5codecs-dev,
 - libpoppler-cpp-dev,
 - libcryptsetup-dev,
-- deepin-desktop-base | deepin-desktop-server | deepin-desktop-device
+- libpcre2-dev,
+- libdde-shell-dev (>= 0.0.10),
+- deepin-desktop-base | deepin-desktop-server | deepin-desktop-device,
+- qt6-base-dev,
+- qt6-base-private-dev,
+- qt6-svg-dev,
+- qt6-multimedia-dev,
+- qt6-tools-dev,
+- qt6-tools-dev-tools,
+- qt6-declarative-dev,
+- qt6-5compat-dev,
+- libdtk6widget-dev,
+- libdtk6gui-dev,
+- libdtk6core-dev,
+- libdtk6core-bin,
+- libdtk6declarative-dev,
+- libdfm6-io-dev,
+- libdfm6-mount-dev,
+- libdfm6-burn-dev,
+- libdfm6-search-dev,
+- libpolkit-qt6-1-dev,
+- libxcb-xfixes0-dev (>= 1.10~),
+- libopenjp2-7-dev,
+- liblcms2-dev,
+- libdeepin-service-framework-dev,
+- libheif-dev
 
 ## Installation
 
@@ -76,6 +84,14 @@ $ sudo cmake --build build --target install
 ```
 
 The executable binary file could be found at `/usr/bin/dde-file-manager`
+
+### Build Debian package
+
+A debian folder is provided to build the package under the deepin linux desktop distribution. To build the package, use the following command:
+
+```shell
+$ dpkg-buildpackage -uc -us -nc -b # build binary package(s)
+```
 
 ## Usage
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -9,44 +9,52 @@
 _当前的开发分支为**master**，编译依赖可能会在没有更新本说明的情况下发生变化，请参考`./debian/control`以获取构建依赖项列表_
 
   * cmake,
+* doxygen,
 * debhelper (>=9),
 * pkg-config,
-* dh-systemd,
-* qtbase5-dev,
-* qtbase5-private-dev,
-* qtmultimedia5-dev,
 * libffmpegthumbnailer-dev,
-* libqt5svg5-dev,
-* libpolkit-agent-1-dev, 
-* libpolkit-qt5-1-dev,
-* libdtkwidget-dev,
-* libdtkgui-dev,
-* libdtkcore-dev,
-* libdtkcore5-bin,
-* qttools5-dev-tools,
-* dde-dock-dev(>=4.8.4.1),
-* libdframeworkdbus-dev,
+* libpolkit-agent-1-dev,
+* dde-tray-loader-dev,
 * libtag1-dev,
 * libdmr-dev,
 * libicu-dev,
+* libxcb-ewmh-dev,
 * libdeepin-pdfium-dev,
-* libqt5xdg-dev,
-* libgio-qt-dev,
-* libdfm-io-dev,
-* libdfm-mount-dev,
-* libdfm-burn-dev,
 * libssl-dev,
 * libgtest-dev,
 * libgmock-dev,
-* libgsettings-qt-dev,
 * liblucene++-dev,
 * libdocparser-dev,
 * libboost-filesystem-dev,
 * libsecret-1-dev,
-* libkf5codecs-dev,
 * libpoppler-cpp-dev,
 * libcryptsetup-dev,
-* deepin-desktop-base | deepin-desktop-server | deepin-desktop-device
+* libpcre2-dev,
+* libdde-shell-dev (>= 0.0.10),
+* deepin-desktop-base | deepin-desktop-server | deepin-desktop-device,
+* qt6-base-dev,
+* qt6-base-private-dev,
+* qt6-svg-dev,
+* qt6-multimedia-dev,
+* qt6-tools-dev,
+* qt6-tools-dev-tools,
+* qt6-declarative-dev,
+* qt6-5compat-dev,
+* libdtk6widget-dev,
+* libdtk6gui-dev,
+* libdtk6core-dev,
+* libdtk6core-bin,
+* libdtk6declarative-dev,
+* libdfm6-io-dev,
+* libdfm6-mount-dev,
+* libdfm6-burn-dev,
+* libdfm6-search-dev,
+* libpolkit-qt6-1-dev,
+* libxcb-xfixes0-dev (>= 1.10~),
+* libopenjp2-7-dev,
+* liblcms2-dev,
+* libdeepin-service-framework-dev,
+* libheif-dev
 
 ## 安装
 
@@ -76,6 +84,14 @@ $ sudo cmake --build build --target install
 ```
 
 可执行程序为 `/usr/bin/dde-file-manager`
+
+### 构建 Debian 包
+
+为在 deepin 桌面发行版进行此软件包的构建，我们还提供了一个 debian 目录。若要构建软件包，可参照下面的命令进行构建：
+
+```shell
+$ dpkg-buildpackage -uc -us -nc -b # 构建二进制包
+```
 
 ## 使用
 


### PR DESCRIPTION
1. Updated build dependencies list to reflect Qt6 migration
2. Removed obsolete Qt5 dependencies
3. Added new Qt6 and DTK6 related dependencies
4. Added miscellaneous new dependencies (doxygen, libheif-dev etc)
5. Added build package instruction section for Debian
6. Maintained parallel changes in both English and Chinese READMEs

Log: Updated README files with current build requirements and package instructions

Influence:
1. Developers should use the updated dependency list when setting up build environments
2. Package maintainers should verify the new dpkg-buildpackage instructions
3. Test building the package with new Qt6 dependencies
4. Verify all new dependencies are available in repositories

docs: 更新README构建依赖说明

1. 更新构建依赖列表以反映迁移到Qt6的变更
2. 移除过时的Qt5相关依赖
3. 新增Qt6和DTK6相关依赖
4. 添加杂项新依赖（doxygen、libheif-dev等）
5. 新增Debian系统下构建包的说明章节
6. 保持中英文README文件的同步更新

Log: 更新README文件中的构建需求说明和打包指南

Influence:
1. 开发者设置构建环境时应使用更新后的依赖列表
2. 软件包维护者应验证新的dpkg-buildpackage指令
3. 使用新的Qt6依赖测试构建软件包
4. 验证所有新依赖项是否能在仓库中找到

## Summary by Sourcery

Update README files to reflect Qt6 migration by removing Qt5 dependencies, adding new Qt6, DTK6, and miscellaneous build packages, and include Debian package build instructions.

Documentation:
- Sync English and Chinese READMEs to remove obsolete Qt5 dependencies and list new Qt6, DTK6, and miscellaneous packages
- Add a "Build Debian package" section with dpkg-buildpackage instructions