### PR TITLE
feat: make side preview panel width resizable

### DIFF
--- a/autotests/plugins/dfmplugin-detailspace/test_detailspacewidget.cpp
+++ b/autotests/plugins/dfmplugin-detailspace/test_detailspacewidget.cpp
@@ -107,14 +107,14 @@ TEST_F(DetailSpaceWidgetTest, Constructor_DefaultConstruction_ObjectCreatedSucce
  */
 TEST_F(DetailSpaceWidgetTest, InitUiForSizeMode_Called_SetsCorrectWidth)
 {
-    int detailWidth = 290;
+    int expectedWidth = 300;
     bool setFixedWidthCalled = false;
     int receivedWidth = 0;
 
-    // Mock detailWidth method
-    stub.set_lamda(ADDR(DetailSpaceWidget, detailWidth), [detailWidth](DetailSpaceWidget *) {
+    // Mock clampWidth to provide a deterministic preferred width
+    stub.set_lamda(ADDR(DetailSpaceWidget, clampWidth), [expectedWidth](DetailSpaceWidget *, int) {
         __DBG_STUB_INVOKE__
-        return detailWidth;
+        return expectedWidth;
     });
 
     // Mock setFixedWidth method
@@ -128,7 +128,7 @@ TEST_F(DetailSpaceWidgetTest, InitUiForSizeMode_Called_SetsCorrectWidth)
     widget->initUiForSizeMode();
 
     EXPECT_TRUE(setFixedWidthCalled);
-    EXPECT_EQ(receivedWidth, detailWidth);
+    EXPECT_EQ(receivedWidth, expectedWidth);
 }
 
 /**

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailspacewidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailspacewidget.cpp
@@ -12,8 +12,11 @@
 #    include <DSizeMode>
 #endif
 
+#include <QCursor>
 #include <QHBoxLayout>
-#include <QApplication>
+#include <QMouseEvent>
+
+#include <algorithm>
 
 using namespace dfmplugin_detailspace;
 
@@ -21,8 +24,12 @@ DetailSpaceWidget::DetailSpaceWidget(QFrame *parent)
     : AbstractFrame(parent)
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
-    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, &DetailSpaceWidget::initUiForSizeMode);
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged,
+            this, &DetailSpaceWidget::initUiForSizeMode);
 #endif
+
+    setMouseTracking(true);
+    preferredWidth = defaultDetailWidth();
 
     initUiForSizeMode();
     initializeUi();
@@ -30,14 +37,19 @@ DetailSpaceWidget::DetailSpaceWidget(QFrame *parent)
 
 void DetailSpaceWidget::initUiForSizeMode()
 {
-    setFixedWidth(detailWidth());
+    if (!userResized)
+        preferredWidth = defaultDetailWidth();
+
+    preferredWidth = clampWidth(preferredWidth);
+    applyPreferredWidth();
 }
 
 void DetailSpaceWidget::setCurrentUrl(const QUrl &url)
 {
     quint64 winId = DetailSpaceHelper::findWindowIdByDetailSpace(this);
     if (winId) {
-        QList<QUrl> urls = dpfSlotChannel->push("dfmplugin_workspace", "slot_View_GetSelectedUrls", winId).value<QList<QUrl>>();
+        QList<QUrl> urls = dpfSlotChannel->push("dfmplugin_workspace", "slot_View_GetSelectedUrls", winId)
+                                   .value<QList<QUrl>>();
         if (!urls.isEmpty()) {
             setCurrentUrl(urls.first(), 0);
             return;
@@ -62,6 +74,11 @@ QUrl DetailSpaceWidget::currentUrl() const
     return detailSpaceUrl;
 }
 
+int DetailSpaceWidget::detailWidth() const
+{
+    return preferredWidth > 0 ? preferredWidth : defaultDetailWidth();
+}
+
 bool DetailSpaceWidget::insterExpandControl(const int &index, QWidget *widget)
 {
     return detailView->insertCustomControl(index, widget);
@@ -72,6 +89,159 @@ void DetailSpaceWidget::removeControls()
     detailView->removeControl();
 }
 
+void DetailSpaceWidget::prepareForAnimation(bool show)
+{
+    animationInProgress = true;
+    resizing = false;
+    updateCursorShape(false);
+
+    if (show) {
+        setFixedWidth(0);
+        setMinimumWidth(0);
+        setMaximumWidth(detailWidth());
+    } else {
+        setPreferredWidth(width(), false);
+        setMinimumWidth(0);
+        setMaximumWidth(width());
+    }
+}
+
+void DetailSpaceWidget::handleAnimationFinished(bool show)
+{
+    animationInProgress = false;
+    if (!show)
+        setVisible(false);
+
+    applyPreferredWidth();
+}
+
+void DetailSpaceWidget::resetWidthRange()
+{
+    setMinimumWidth(minDetailWidth());
+    setMaximumWidth(maxDetailWidth());
+}
+
+bool DetailSpaceWidget::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == detailView) {
+        switch (event->type()) {
+        case QEvent::MouseButtonPress:
+            return handleMousePress(static_cast<QMouseEvent *>(event), mapFromChild(static_cast<QMouseEvent *>(event)));
+        case QEvent::MouseMove:
+            if (handleMouseMove(static_cast<QMouseEvent *>(event), mapFromChild(static_cast<QMouseEvent *>(event))))
+                return true;
+            break;
+        case QEvent::MouseButtonRelease:
+            return handleMouseRelease(static_cast<QMouseEvent *>(event), mapFromChild(static_cast<QMouseEvent *>(event)));
+        case QEvent::Leave:
+            if (!resizing && !animationInProgress)
+                updateCursorShape(false);
+            break;
+        default:
+            break;
+        }
+    }
+
+    return AbstractFrame::eventFilter(watched, event);
+}
+
+void DetailSpaceWidget::mousePressEvent(QMouseEvent *event)
+{
+    if (handleMousePress(event, event->pos()))
+        return;
+
+    AbstractFrame::mousePressEvent(event);
+}
+
+void DetailSpaceWidget::mouseMoveEvent(QMouseEvent *event)
+{
+    if (handleMouseMove(event, event->pos()))
+        return;
+
+    AbstractFrame::mouseMoveEvent(event);
+}
+
+void DetailSpaceWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (handleMouseRelease(event, event->pos()))
+        return;
+
+    AbstractFrame::mouseReleaseEvent(event);
+}
+
+void DetailSpaceWidget::leaveEvent(QEvent *event)
+{
+    if (!resizing && !animationInProgress)
+        updateCursorShape(false);
+
+    AbstractFrame::leaveEvent(event);
+}
+
+bool DetailSpaceWidget::handleMousePress(QMouseEvent *event, const QPoint &localPos)
+{
+    if (!event || animationInProgress)
+        return false;
+
+    if (event->button() != Qt::LeftButton)
+        return false;
+
+    if (!isOnResizeArea(localPos))
+        return false;
+
+    resizing = true;
+    resizeStartGlobalX = eventGlobalX(event);
+    resizeStartWidth = width();
+    updateCursorShape(true);
+    event->accept();
+    return true;
+}
+
+bool DetailSpaceWidget::handleMouseMove(QMouseEvent *event, const QPoint &localPos)
+{
+    if (!event)
+        return false;
+
+    if (resizing) {
+        int newWidth = clampWidth(resizeStartWidth + (resizeStartGlobalX - eventGlobalX(event)));
+        if (newWidth != width()) {
+            setFixedWidth(newWidth);
+            resetWidthRange();
+        }
+        event->accept();
+        return true;
+    }
+
+    if (animationInProgress)
+        return false;
+
+    updateCursorShape(isOnResizeArea(localPos));
+    return false;
+}
+
+bool DetailSpaceWidget::handleMouseRelease(QMouseEvent *event, const QPoint &localPos)
+{
+    if (!event || event->button() != Qt::LeftButton)
+        return false;
+
+    if (!resizing)
+        return false;
+
+    resizing = false;
+
+    int newWidth = clampWidth(width());
+    int delta = resizeStartWidth - newWidth;
+    setFixedWidth(newWidth);
+    resetWidthRange();
+    setPreferredWidth(newWidth, true);
+
+    if (delta != 0)
+        notifyWorkspaceWidthDelta(delta);
+
+    updateCursorShape(isOnResizeArea(localPos));
+    event->accept();
+    return true;
+}
+
 void DetailSpaceWidget::initializeUi()
 {
     setAutoFillBackground(true);
@@ -80,11 +250,31 @@ void DetailSpaceWidget::initializeUi()
     QHBoxLayout *rvLayout = new QHBoxLayout(this);
     rvLayout->setContentsMargins(0, 0, 0, 0);
     detailView = new DetailView(this);
+    detailView->setMouseTracking(true);
+    detailView->installEventFilter(this);
     rvLayout->addWidget(detailView, 1);
     setLayout(rvLayout);
 }
 
-int DetailSpaceWidget::detailWidth()
+void DetailSpaceWidget::initConnect()
+{
+}
+
+void DetailSpaceWidget::applyPreferredWidth()
+{
+    preferredWidth = clampWidth(preferredWidth > 0 ? preferredWidth : defaultDetailWidth());
+    setFixedWidth(preferredWidth);
+    resetWidthRange();
+}
+
+void DetailSpaceWidget::setPreferredWidth(int width, bool fromUser)
+{
+    preferredWidth = clampWidth(width);
+    if (fromUser)
+        userResized = true;
+}
+
+int DetailSpaceWidget::defaultDetailWidth() const
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
     return DSizeModeHelper::element(260, 290);
@@ -92,3 +282,72 @@ int DetailSpaceWidget::detailWidth()
     return 290;
 #endif
 }
+
+int DetailSpaceWidget::minDetailWidth() const
+{
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    return DSizeModeHelper::element(220, 240);
+#else
+    return 240;
+#endif
+}
+
+int DetailSpaceWidget::maxDetailWidth() const
+{
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    return DSizeModeHelper::element(460, 520);
+#else
+    return 520;
+#endif
+}
+
+int DetailSpaceWidget::clampWidth(int width) const
+{
+    return std::clamp(width, minDetailWidth(), maxDetailWidth());
+}
+
+bool DetailSpaceWidget::isOnResizeArea(const QPoint &pos) const
+{
+    return pos.x() >= 0 && pos.x() <= kResizeHandleWidth;
+}
+
+void DetailSpaceWidget::updateCursorShape(bool inResizeArea)
+{
+    bool useResizeCursor = (resizing || inResizeArea) && !animationInProgress;
+    if (useResizeCursor) {
+        setCursor(Qt::SizeHorCursor);
+        if (detailView)
+            detailView->setCursor(Qt::SizeHorCursor);
+    } else {
+        unsetCursor();
+        if (detailView)
+            detailView->unsetCursor();
+    }
+}
+
+void DetailSpaceWidget::notifyWorkspaceWidthDelta(int delta)
+{
+    quint64 winId = DetailSpaceHelper::findWindowIdByDetailSpace(this);
+    if (!winId)
+        return;
+
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_View_AboutToChangeViewWidth", winId, delta);
+}
+
+QPoint DetailSpaceWidget::mapFromChild(const QMouseEvent *event) const
+{
+    if (!detailView || !event)
+        return {};
+
+    return detailView->mapTo(this, event->pos());
+}
+
+int DetailSpaceWidget::eventGlobalX(const QMouseEvent *event) const
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    return static_cast<int>(event->globalPosition().x());
+#else
+    return event->globalPos().x();
+#endif
+}
+*** End of File

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailspacewidget.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailspacewidget.h
@@ -8,7 +8,11 @@
 #include "dfmplugin_detailspace_global.h"
 #include <dfm-base/interfaces/abstractframe.h>
 
+#include <QPoint>
 #include <QUrl>
+
+class QMouseEvent;
+class QEvent;
 
 namespace dfmplugin_detailspace {
 
@@ -23,23 +27,55 @@ public:
     void setCurrentUrl(const QUrl &url) override;
     void setCurrentUrl(const QUrl &url, int widgetFilter);
     QUrl currentUrl() const override;
+    int detailWidth() const;
 
     bool insterExpandControl(const int &index, QWidget *widget);
 
     void removeControls();
 
-    int detailWidth();
+    void prepareForAnimation(bool show);
+    void handleAnimationFinished(bool show);
+    void resetWidthRange();
 
 private slots:
     void initUiForSizeMode();
 
 private:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+
+    bool handleMousePress(QMouseEvent *event, const QPoint &localPos);
+    bool handleMouseMove(QMouseEvent *event, const QPoint &localPos);
+    bool handleMouseRelease(QMouseEvent *event, const QPoint &localPos);
+
     void initializeUi();
     void initConnect();
+    void applyPreferredWidth();
+    void setPreferredWidth(int width, bool fromUser);
+    int defaultDetailWidth() const;
+    int minDetailWidth() const;
+    int maxDetailWidth() const;
+    int clampWidth(int width) const;
+    bool isOnResizeArea(const QPoint &pos) const;
+    void updateCursorShape(bool inResizeArea);
+    void notifyWorkspaceWidthDelta(int delta);
+    QPoint mapFromChild(const QMouseEvent *event) const;
+    int eventGlobalX(const QMouseEvent *event) const;
 
 private:
     QUrl detailSpaceUrl;
     DetailView *detailView { nullptr };
+    bool resizing { false };
+    bool animationInProgress { false };
+    int resizeStartGlobalX { 0 };
+    int resizeStartWidth { 0 };
+    int preferredWidth { 0 };
+    bool userResized { false };
+
+    static constexpr int kResizeHandleWidth { 8 };
 };
 
 }


### PR DESCRIPTION
## Summary by Sourcery

Enable the detail space side panel to be interactively resized by the user, with enforced width limits, persistence of user adjustments, animation integration, and workspace notifications for width changes.

New Features:
- Allow users to resize the detail side panel by dragging its edge

Enhancements:
- Add mouse event filtering and handling to track and apply panel width changes with min/max constraints
- Introduce preferredWidth and userResized state to remember and apply user‐adjusted widths
- Integrate resizing behavior with show/hide animations and update the workspace about width deltas
- Update cursor shape to indicate resizable area when hovering over the panel edge

Tests:
- Adjust unit test to stub clampWidth instead of detailWidth and verify preferred width application