### PR TITLE
fix: expand support for long filenames on more filesystems

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.97) unstable; urgency=medium
+
+  * fix bugs
+  * Implementation of some features
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 16 Oct 2025 20:40:06 +0800
+
 dde-file-manager (6.5.96) unstable; urgency=medium
 
   * fix bugs

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1235,7 +1235,7 @@ QString FileUtils::normalPathToTrash(const QString &normal)
 bool FileUtils::supportLongName(const QUrl &url)
 {
     const static QList<QString> datas {
-        "vfat", "exfat", "ntfs", "fuseblk", "fuse.dlnfs"
+        "vfat", "exfat", "ntfs", "ntfs3", "fuseblk", "fuse.dlnfs", "udf"
     };
 
     const QString &fileSystem = dfmio::DFMUtils::fsTypeFromUrl(url);


### PR DESCRIPTION
Added "ntfs3" and "udf" to the list of filesystems supporting long filenames in FileUtils::supportLongName(). This change enables proper long filename handling on these commonly used filesystem types that were previously excluded.

The modification was necessary because:
1. The modern ntfs3 driver is increasingly being used alongside traditional ntfs
2. UDF filesystem is widely used for optical media and supports long filenames
3. Ensures consistent behavior across all major filesystems that support long filenames

Log: Added support for long filenames on ntfs3 and udf filesystems

Influence:
1. Test file operations with long names on ntfs3 formatted drives
2. Verify long filename support on UDF formatted optical media
3. Check file manager behavior when handling files with complex/long names
4. Validate filename display and editing across different filesystems

feat: 扩展更多文件系统对长文件名的支持

在FileUtils::supportLongName()的文件系统列表中新增"ntfs3"和"udf"支持，这 些常见文件系统类型之前未被包含在内但仍确实支持长文件名。

修改的必要性在于：
1. 现代的ntfs3驱动正逐渐替代传统的ntfs
2. UDF文件系统广泛用于光介质并支持长文件名
3. 确保所有支持长文件名的主流文件系统行为一致

Log: 新增对ntfs3和udf文件系统的长文件名支持

Influence:
1. 在ntfs3格式驱动器上测试长文件名文件操作
2. 验证UDF格式光介质上的长文件名支持
3. 检查文件管理器处理复杂/长文件名时的行为
4. 验证不同文件系统间的文件名显示和编辑

Bug: https://pms.uniontech.com/bug-view-336709.html

## Summary by Sourcery

Enhancements:
- Add "ntfs3" and "udf" to the list of filesystems that support long filenames