### PR TITLE
feat: add item visibility control for computer view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -81,6 +81,9 @@ ComputerItemDelegate::~ComputerItemDelegate()
 
 void ComputerItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
+    if (!index.data(ComputerModel::kItemVisibleRole).toBool())
+        return;
+
     painter->setRenderHint(QPainter::RenderHint::Antialiasing);
 
     ComputerItemData::ShapeType type = ComputerItemData::ShapeType(index.data(ComputerModel::DataRoles::kItemShapeTypeRole).toInt());

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -182,6 +182,9 @@ QVariant ComputerModel::data(const QModelIndex &index, int role) const
     case kEditDisplayTextRole:
         return item->info ? item->info->editDisplayText() : "";
 
+    case kItemVisibleRole:
+        return item->isVisible;
+
     default:
         return {};
     }
@@ -209,6 +212,9 @@ bool ComputerModel::setData(const QModelIndex &index, const QVariant &value, int
         return true;
     } else if (role == DataRoles::kDisplayNameIsElidedRole) {
         item.isElided = value.toBool();
+        return true;
+    } else if (role == DataRoles::kItemVisibleRole) {
+        item.isVisible = value.toBool();
         return true;
     }
     return false;

--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.h
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.h
@@ -44,7 +44,8 @@ public:
         kItemIsEditingRole,   // bool: if an item is renaming
         kDeviceDescriptionRole,
         kDisplayNameIsElidedRole,   // bool
-        kEditDisplayTextRole   // string
+        kEditDisplayTextRole,   // string
+        kItemVisibleRole
     };
     Q_ENUM(DataRoles)
 

--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.h
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerdatastruct.h
@@ -37,6 +37,7 @@ struct ComputerItemData
     QWidget *widget { nullptr };
     bool isEditing = false;
     bool isElided = false;
+    bool isVisible = true;
     DFMEntryFileInfoPointer info { nullptr };
 };
 

--- a/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
@@ -129,6 +129,15 @@ void ComputerView::setStatusBarHandler(ComputerStatusBar *sb)
     dp->statusBar = sb;
 }
 
+void ComputerView::setRowHidden(int row, bool hide)
+{
+    // 更新item的可见性状态，避免view隐藏了但绘制时仍然绘制该item的问题
+    // 在某些性能较差的机器上，通过view隐藏item后，若在delegate中进行了
+    // 设值操作（model()->data()），可能会绘制本该隐藏的item，造成显示问题
+    model()->setData(model()->index(row, 0), !hide, ComputerModel::DataRoles::kItemVisibleRole);
+    DListView::setRowHidden(row, hide);
+}
+
 void ComputerView::showEvent(QShowEvent *event)
 {
     QApplication::restoreOverrideCursor();

--- a/src/plugins/filemanager/dfmplugin-computer/views/computerview.h
+++ b/src/plugins/filemanager/dfmplugin-computer/views/computerview.h
@@ -46,6 +46,7 @@ public:
     virtual bool eventFilter(QObject *watched, QEvent *event) override;
 
     void setStatusBarHandler(ComputerStatusBar *sb);
+    void setRowHidden(int row, bool hide);
 
 public Q_SLOTS:
     void handleComputerItemVisible();


### PR DESCRIPTION
Added visibility control mechanism for computer view items to prevent
display issues when hiding rows. The changes include:
1. Added kItemVisibleRole to ComputerModel data roles
2. Added isVisible field to ComputerItemData structure
3. Implemented data() and setData() methods for visibility role in
ComputerModel
4. Modified ComputerItemDelegate::paint() to skip painting invisible
items
5. Overrode ComputerView::setRowHidden() to synchronize model visibility
state with view state

This fix addresses rendering issues on low-performance machines where
hidden items might still be painted due to timing issues between view
state changes and delegate painting operations.

Log: Added item visibility synchronization between model and view

Influence:
1. Test hiding and showing computer view items
2. Verify that hidden items are not painted or displayed
3. Test performance on low-end machines to ensure no ghost items appear
4. Verify that item visibility state is properly synchronized between
model and view
5. Test various item types (drives, devices, etc.) with visibility
toggling

feat: 为计算机视图添加项目可见性控制

添加了计算机视图项目的可见性控制机制，以防止隐藏行时出现显示问题。变更
包括：
1. 在ComputerModel数据角色中添加kItemVisibleRole
2. 在ComputerItemData结构中添加isVisible字段
3. 在ComputerModel中实现可见性角色的data()和setData()方法
4. 修改ComputerItemDelegate::paint()以跳过绘制不可见项目
5. 重写ComputerView::setRowHidden()以同步模型可见性状态与视图状态

此修复解决了在低性能机器上由于视图状态变化和委托绘制操作之间的时序问题，
可能导致隐藏项目仍然被绘制的渲染问题。

Log: 添加模型与视图之间的项目可见性同步

Influence:
1. 测试隐藏和显示计算机视图项目
2. 验证隐藏的项目不会被绘制或显示
3. 在低端机器上测试性能，确保不会出现幽灵项目
4. 验证项目可见性状态在模型和视图之间正确同步
5. 测试各种项目类型（驱动器、设备等）的可见性切换

BUG: https://pms.uniontech.com/bug-view-336949.html

## Summary by Sourcery

Add a model-level visibility mechanism for computer view items and synchronize it with the view to prevent hidden rows from being drawn.

New Features:
- Introduce kItemVisibleRole in ComputerModel to track visibility.
- Add isVisible flag to ComputerItemData to store item visibility state.

Enhancements:
- Implement data() and setData() to handle the visibility role.
- Update ComputerItemDelegate::paint() to skip invisible items.
- Override ComputerView::setRowHidden() to update model visibility alongside the view.