### PR TITLE
fix: adjust tab bar layout margins for left button visibility

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -23,6 +23,7 @@
 #include <DPlatformWindowHandle>
 
 #include <QMouseEvent>
+#include <QBoxLayout>
 
 #include <unistd.h>
 #include <functional>
@@ -79,6 +80,7 @@ public:
 public:
     TabBar *q;
     DIconButton *addBtn { nullptr };
+    DIconButton *leftBtn { nullptr };
     QTabBar *tabBar { nullptr };
 
     int nextTabUniqueId { 0 };
@@ -110,7 +112,7 @@ void TabBarPrivate::initUI()
     addBtn->setFocusPolicy(Qt::NoFocus);
     addBtn->installEventFilter(q);
 
-    auto leftBtn = q->findChild<DIconButton *>("leftButton");
+    leftBtn = q->findChild<DIconButton *>("leftButton");
     Q_ASSERT(leftBtn);
     leftBtn->setFocusPolicy(Qt::NoFocus);
     leftBtn->setFixedSize(30, 30);
@@ -843,6 +845,14 @@ bool TabBar::eventFilter(QObject *obj, QEvent *e)
                 return true;
             }
         }
+    } else if (obj == d->leftBtn && e->type() == QEvent::Show) {
+        auto margin = layout()->contentsMargins();
+        margin.setLeft(4);
+        layout()->setContentsMargins(margin);
+    } else if (obj == d->leftBtn && e->type() == QEvent::Hide) {
+        auto margin = layout()->contentsMargins();
+        margin.setLeft(0);
+        layout()->setContentsMargins(margin);
     }
 
     return DTabBar::eventFilter(obj, e);


### PR DESCRIPTION
Fixed layout margin adjustment when left navigation button is shown or
hidden. Previously, the left button's visibility changes caused layout
issues. Now properly adjusts the left margin to 4px when button is shown
and resets to 0 when hidden to maintain proper spacing and alignment.

Log: Fixed tab bar layout alignment when navigation button visibility
changes

Influence:
1. Test tab bar layout with left navigation button visible
2. Test tab bar layout when left navigation button is hidden
3. Verify proper spacing and alignment in both states
4. Check that tab switching and add button functionality remains
unaffected

fix: 调整标签栏布局边距以适应左侧按钮可见性

修复了左侧导航按钮显示或隐藏时的布局边距调整问题。之前左侧按钮的可见性变
化会导致布局问题。现在在按钮显示时正确将左边距调整为4像素，隐藏时重置为
0，以保持适当的间距和对齐。

Log: 修复导航按钮可见性变化时的标签栏布局对齐问题

Influence:
1. 测试左侧导航按钮可见时的标签栏布局
2. 测试左侧导航按钮隐藏时的标签栏布局
3. 验证两种状态下的间距和对齐是否正确
4. 检查标签切换和添加按钮功能是否不受影响

BUG: https://pms.uniontech.com/bug-view-337321.html
