### PR TITLE
fix bugs

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewanimationhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewanimationhelper.cpp
@@ -72,6 +72,11 @@ void ViewAnimationHelper::aboutToPlay()
         return;
     }
 
+    if (view->isGroupedView()) {
+        fmDebug() << "Animation disabled in grpuped view";
+        return;
+    }
+
     fmDebug() << "Preparing animation - capturing current state";
     oldVisiableRect = view->viewport()->rect();
     oldVisiableRect.moveTop(view->verticalOffset());
@@ -95,6 +100,11 @@ void ViewAnimationHelper::playViewAnimation()
 
     if (playingAnim) {
         fmDebug() << "Animation already playing, skipping play request";
+        return;
+    }
+
+    if (view->isGroupedView()) {
+        fmDebug() << "Animation disabled in grpuped view";
         return;
     }
 
@@ -147,6 +157,11 @@ void ViewAnimationHelper::playAnimationWithWidthChange(int deltaWidth)
 {
     if (!initialized) {
         fmDebug() << "Animation not initialized, skipping width change animation";
+        return;
+    }
+
+    if (view->isGroupedView()) {
+        fmDebug() << "Animation disabled in grpuped view";
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -141,6 +141,9 @@ protected:
     // Pure virtual method for group header height - must be implemented by subclasses
     virtual int getGroupHeaderHeight(const QStyleOptionViewItem &option) const = 0;
 
+    // Virtual method for group header background rect - can be overridden by subclasses
+    virtual QRectF getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const;
+
     // Group rendering helper methods
     void paintGroupBackground(QPainter *painter, const QStyleOptionViewItem &option) const;
     void paintExpandButton(QPainter *painter, const QRect &buttonRect, bool isExpanded) const;
@@ -160,8 +163,6 @@ protected:
 private:
     // Group rendering constants
     QSize m_expandButtonSize = QSize(16, 16);
-    int m_leftMargin = 12;
-    int m_rightMargin = 12;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -244,6 +244,10 @@ bool FileView::setRootUrl(const QUrl &url)
     resetSelectionModes();
     updateListHeaderView();
 
+    // Adjust header layout margins based on grouping state for list/tree mode
+    // This handles both initialization and directory switching scenarios
+    d->adjustHeaderLayoutMargin(model()->groupingStrategy());
+
     // dir already traversal
     if (model()->currentState() == ModelState::kIdle)
         updateSelectedUrl();
@@ -820,6 +824,10 @@ void FileView::setGroup(const QString &strategyName, const Qt::SortOrder order)
         setFileViewStateValue(url, "groupStrategy", strategyName);
         setFileViewStateValue(url, "groupingOrder", static_cast<int>(order));
     }
+
+    // Dynamically adjust header layout margins based on grouped view state
+    // For list/tree mode: remove bottom margin when in grouped view to eliminate gap above first group-header
+    d->adjustHeaderLayoutMargin(strategyName);
 }
 
 void FileView::setViewSelectState(bool isSelect)

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1033,13 +1033,17 @@ QRect FileView::calcVisualRect(int widgetWidth, int index) const
     rect.setSize(itemSize);
 
     // 计算水平居中偏移，仅当行数大于1时才应用
-    int totalItems = model()->rowCount();
-    int rowCount = (totalItems + columnCount - 1) / columnCount;   // 向上取整
-    if (rowCount > 1) {   // 计算可用宽度（减去左右边距）
-        int availableWidth = widgetWidth - 2 * iconHorizontalMargin;
-        int totalItemsWidth = columnCount * itemSize.width() + (columnCount - 1) * 2 * iconViewSpacing;
-        int horizontalOffset = (availableWidth - totalItemsWidth) / 2;
-        rect.moveLeft(rect.left() + horizontalOffset);
+    // In group mode, don't apply horizontal centering to keep group headers left-aligned
+    if (!isGroupedView()) {
+        int totalItems = model()->rowCount();
+        int rowCount = (totalItems + columnCount - 1) / columnCount;   // 向上取整
+        if (rowCount > 1) {
+            // 计算可用宽度（减去左右边距）
+            int availableWidth = widgetWidth - 2 * iconHorizontalMargin;
+            int totalItemsWidth = columnCount * itemSize.width() + (columnCount - 1) * 2 * iconViewSpacing;
+            int horizontalOffset = (availableWidth - totalItemsWidth) / 2;
+            rect.moveLeft(rect.left() + horizontalOffset);
+        }
     }
 
     rect.moveTop(rect.top() - verticalOffset());

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -915,6 +915,34 @@ int IconItemDelegate::getGroupHeaderHeight(const QStyleOptionViewItem &option) c
     return 32;
 }
 
+QRectF IconItemDelegate::getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const
+{
+    // In icon mode, the group header should span the full viewport width with 10px margins on both sides
+    // We need to get the viewport widget to calculate the correct rect
+    FileView *view = parent() ? parent()->parent() : nullptr;
+    if (!view) {
+        // Fallback: use option.rect if we can't get the view
+        return option.rect;
+    }
+
+    // Get viewport content margins (set by updateViewportContentsMargins in icon mode)
+    QMargins viewportMargins = view->viewport()->contentsMargins();
+
+    // Calculate the full width rect spanning from viewport left edge + 10px to right edge - 10px
+    QRectF rect = option.rect;
+
+    // Reset left to viewport left edge + viewport left margin + 10px
+    int viewportLeft = -viewportMargins.left();
+    rect.setLeft(viewportLeft + 10);
+
+    // Set right to viewport right edge - viewport right margin - 10px
+    int viewportWidth = view->viewport()->width();
+    int viewportRight = viewportLeft + viewportWidth - viewportMargins.right();
+    rect.setRight(viewportRight - 10);
+
+    return rect;
+}
+
 bool IconItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)
 {
     // // Handle group header clicks

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.h
@@ -79,6 +79,7 @@ private:
 
     // Group functionality implementation
     int getGroupHeaderHeight(const QStyleOptionViewItem &option) const override;
+    QRectF getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const override;
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 
     Q_DECLARE_PRIVATE_D(d, IconItemDelegate)

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -773,6 +773,22 @@ int ListItemDelegate::getGroupHeaderHeight(const QStyleOptionViewItem &option) c
     return BaseItemDelegate::sizeHint(fileItemOption, QModelIndex()).height();
 }
 
+QRectF ListItemDelegate::getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const
+{
+    FileView *view = parent()->parent();
+    if (!view)
+        return option.rect;
+
+    // Use the same layout calculation as paintItemBackground for consistency
+    int totalWidth = view->getHeaderViewWidth() - (kListModeLeftMargin + kListModeRightMargin);
+
+    QRectF rect = option.rect;
+    rect.setLeft(rect.left() + kListModeLeftMargin);
+    rect.setWidth(totalWidth);
+
+    return rect;
+}
+
 bool ListItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)
 {
     // Handle group header clicks

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
@@ -65,6 +65,7 @@ private:
 
     // Group functionality implementation
     int getGroupHeaderHeight(const QStyleOptionViewItem &option) const override;
+    QRectF getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const override;
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 
     bool expandable { false };

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -302,8 +302,12 @@ void FileViewPrivate::updateHorizontalOffset()
 {
     horizontalOffset = 0;
     if (q->isIconViewMode()) {
-
-
+        // In group mode, don't apply horizontal offset to keep group headers left-aligned
+        if (q->isGroupedView()) {
+            columnCountByCalc = 1;  // Set to 1 to indicate single column for group mode
+            return;
+        }
+        
         int contentWidth = q->maximumViewportSize().width();
         int itemWidth = q->itemSizeHint().width() + q->spacing() * 2;
         int itemColumn = 0;
@@ -311,14 +315,12 @@ void FileViewPrivate::updateHorizontalOffset()
             fmDebug() << "Invalid item width, skipping offset calculation";
             return;
         }
+        
         // 根据qt虚函数去计算当前的itemColumn（每行绘制的个数）
         int startLeftPx = q->visualRect(q->model()->index(0, 0, q->rootIndex())).left();
         int rowCount = q->model()->rowCount(q->rootIndex());
         int maxColumnCount = qCeil(contentWidth / (60 + q->spacing() * 2)) + 2;   // 60是item最小宽度
-        // group绘制时，设置分组为正常显示，才能正常计算出每一行绘制多少个item
-        if (!q->model()->index(0,0,q->rootIndex()).data(Global::ItemRoles::kItemGroupHeaderKey).toString().isEmpty()) {
-            q->model()->updateHorizontalOffset(true);
-        }
+        
         for (int i = 1; i < qMax(maxColumnCount, rowCount); i++) {
             int itemLeft = q->visualRect(q->model()->index(i, 0, q->rootIndex())).left();
             // NOTE：如果实际item数量不足以绘制到第二行，qt将不会在位置计算中加上边距，
@@ -328,9 +330,6 @@ void FileViewPrivate::updateHorizontalOffset()
                 break;
             }
         }
-
-        // 关闭更新状态
-        q->model()->updateHorizontalOffset(false);
 
         columnCountByCalc = itemColumn;
         // 如果itemColumn为0或itemColumn大于等于实际item数量，则说明当前只有一行，则水平偏移量为默认偏移

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
@@ -109,6 +109,7 @@ class FileViewPrivate
     QVariant fileViewStateValue(const QUrl &url, const QString &key, const QVariant &defalutValue);
 
     void updateHorizontalOffset();
+    void adjustHeaderLayoutMargin(const QString &strategyName);
 };
 
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve layout and rendering for grouped views by adjusting header margins, aligning group headers, customizing group background rendering, and disabling animations in grouped mode.

Bug Fixes:
- Prevent horizontal offset and centering calculations in grouped icon views to keep group headers left-aligned
- Disable view animations in grouped views to avoid unintended visual effects

Enhancements:
- Add adjustHeaderLayoutMargin to dynamically set header widget bottom margin based on grouping state in list and tree modes
- Introduce getGroupHeaderBackgroundRect in BaseItemDelegate with overrides in icon and list delegates to calculate proper group header widths
- Render group header backgrounds with rounded corners and antialiasing via QPainterPath
- Standardize expand button and group text margins for consistent layout