### PR TITLE
feat: add animated title bar for video preview

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/titlebarwidget.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/titlebarwidget.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "titlebarwidget.h"
+
+#include <QPainter>
+#include <QLinearGradient>
+#include <QFontMetrics>
+#include <QResizeEvent>
+#include <QEasingCurve>
+
+using namespace plugin_filepreview;
+
+TitleBarWidget::TitleBarWidget(QWidget *parent)
+    : QWidget(parent)
+    , m_text()
+    , m_autoHideTimer(nullptr)
+    , m_fadeAnimation(nullptr)
+    , m_opacity(1.0)
+{
+    fmDebug() << "Title bar widget: initializing TitleBarWidget";
+
+    initializeComponents();
+    setupAnimation();
+
+    // Set fixed height and transparent background
+    setFixedHeight(kTitleBarHeight);
+    setAttribute(Qt::WA_TranslucentBackground);
+
+    // Enable mouse tracking for hover events
+    setMouseTracking(true);
+
+    fmDebug() << "Title bar widget: TitleBarWidget initialization completed";
+}
+
+TitleBarWidget::~TitleBarWidget()
+{
+    fmDebug() << "Title bar widget: destroying TitleBarWidget";
+
+    if (m_autoHideTimer) {
+        m_autoHideTimer->stop();
+        m_autoHideTimer->deleteLater();
+    }
+
+    if (m_fadeAnimation) {
+        m_fadeAnimation->stop();
+        m_fadeAnimation->deleteLater();
+    }
+}
+
+void TitleBarWidget::setText(const QString &text)
+{
+    if (m_text != text) {
+        m_text = text;
+        update(); // Trigger repaint
+        fmDebug() << "Title bar widget: text updated to:" << text;
+    }
+}
+
+QString TitleBarWidget::text() const
+{
+    return m_text;
+}
+
+void TitleBarWidget::startAutoHideTimer()
+{
+    if (!m_autoHideTimer) {
+        fmWarning() << "Title bar widget: auto-hide timer not initialized";
+        return;
+    }
+
+    fmDebug() << "Title bar widget: starting auto-hide timer";
+    m_autoHideTimer->start(kAutoHideDelay);
+}
+
+void TitleBarWidget::stopAutoHideTimer()
+{
+    if (m_autoHideTimer && m_autoHideTimer->isActive()) {
+        fmDebug() << "Title bar widget: stopping auto-hide timer";
+        m_autoHideTimer->stop();
+    }
+}
+
+void TitleBarWidget::showAnimated()
+{
+    if (!m_fadeAnimation) {
+        fmWarning() << "Title bar widget: fade animation not initialized";
+        return;
+    }
+
+    fmDebug() << "Title bar widget: starting show animation";
+
+    // Stop any running animation
+    if (m_fadeAnimation->state() == QAbstractAnimation::Running) {
+        m_fadeAnimation->stop();
+    }
+
+    // Show widget and animate to full opacity
+    setVisible(true);
+    m_fadeAnimation->setStartValue(m_opacity);
+    m_fadeAnimation->setEndValue(1.0);
+    m_fadeAnimation->start();
+}
+
+void TitleBarWidget::hideAnimated()
+{
+    if (!m_fadeAnimation) {
+        fmWarning() << "Title bar widget: fade animation not initialized";
+        return;
+    }
+
+    fmDebug() << "Title bar widget: starting hide animation";
+
+    // Stop any running animation
+    if (m_fadeAnimation->state() == QAbstractAnimation::Running) {
+        m_fadeAnimation->stop();
+    }
+
+    // Animate to transparent
+    m_fadeAnimation->setStartValue(m_opacity);
+    m_fadeAnimation->setEndValue(0.0);
+    m_fadeAnimation->start();
+}
+
+qreal TitleBarWidget::opacity() const
+{
+    return m_opacity;
+}
+
+void TitleBarWidget::setOpacity(qreal opacity)
+{
+    if (qFuzzyCompare(m_opacity, opacity)) {
+        return;
+    }
+
+    m_opacity = qBound(0.0, opacity, 1.0);
+    update(); // Trigger repaint with new opacity
+}
+
+void TitleBarWidget::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    // Create gradient background (30% black to transparent, top to bottom)
+    QLinearGradient gradient(0, 0, 0, height());
+    gradient.setColorAt(0.0, QColor(0, 0, 0, static_cast<int>(76 * m_opacity))); // 30% of 255 = 76
+    gradient.setColorAt(1.0, QColor(0, 0, 0, 0)); // Fully transparent
+
+    // Fill the background with gradient
+    painter.fillRect(rect(), QBrush(gradient));
+
+    // Draw centered text if available
+    if (!m_text.isEmpty()) {
+        painter.setPen(QColor(255, 255, 255, static_cast<int>(255 * m_opacity))); // White text with opacity
+
+        // Use default font but ensure it's readable
+        QFont font = painter.font();
+        painter.setFont(font);
+
+        QFontMetrics fontMetrics(font);
+        QRect textRect = fontMetrics.boundingRect(m_text);
+
+        // Calculate centered position
+        int x = (width() - textRect.width()) / 2;
+        int y = (height() + fontMetrics.ascent()) / 2;
+
+        // Draw text with eliding if too long
+        QString elidedText = fontMetrics.elidedText(m_text, Qt::ElideRight, width() - 20); // 10px margin on each side
+        painter.drawText(x, y, elidedText);
+    }
+}
+
+void TitleBarWidget::resizeEvent(QResizeEvent *event)
+{
+    fmDebug() << "Title bar widget: resizing to" << event->size();
+
+    QWidget::resizeEvent(event);
+    update(); // Repaint with new size
+}
+
+void TitleBarWidget::initializeComponents()
+{
+    // Initialize auto-hide timer
+    m_autoHideTimer = new QTimer(this);
+    m_autoHideTimer->setSingleShot(true);
+    connect(m_autoHideTimer, &QTimer::timeout, this, &TitleBarWidget::hideAnimated);
+
+    fmDebug() << "Title bar widget: components initialized";
+}
+
+void TitleBarWidget::setupAnimation()
+{
+    // Initialize fade animation
+    m_fadeAnimation = new QPropertyAnimation(this, "opacity", this);
+    m_fadeAnimation->setDuration(kFadeAnimationDuration);
+    m_fadeAnimation->setEasingCurve(QEasingCurve::InOutQuad);
+
+    fmDebug() << "Title bar widget: animation setup completed";
+}

--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/titlebarwidget.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/titlebarwidget.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TITLEBARWIDGET_H
+#define TITLEBARWIDGET_H
+
+#include "preview_plugin_global.h"
+
+#include <QWidget>
+#include <QTimer>
+#include <QPropertyAnimation>
+#include <QEnterEvent>
+#include <QPainter>
+#include <QLinearGradient>
+#include <QFontMetrics>
+
+namespace plugin_filepreview {
+
+/**
+ * @brief Custom title bar widget with gradient background and auto-hide functionality
+ * 
+ * Features:
+ * - Gradient background from 30% black (top) to transparent (bottom)
+ * - Auto-hide after 3 seconds
+ * - Fade in/out animation (1 second duration)
+ * - Mouse hover interaction
+ * - Centered text display
+ */
+class TitleBarWidget : public QWidget
+{
+    Q_OBJECT
+    Q_PROPERTY(qreal opacity READ opacity WRITE setOpacity)
+
+public:
+    explicit TitleBarWidget(QWidget *parent = nullptr);
+    virtual ~TitleBarWidget();
+
+    /**
+     * @brief Set the title text to display
+     * @param text The title text
+     */
+    void setText(const QString &text);
+
+    /**
+     * @brief Get current title text
+     * @return Current title text
+     */
+    QString text() const;
+
+    /**
+     * @brief Start the auto-hide timer (3 seconds delay)
+     */
+    void startAutoHideTimer();
+
+    /**
+     * @brief Stop the auto-hide timer
+     */
+    void stopAutoHideTimer();
+
+    /**
+     * @brief Show the title bar with fade-in animation
+     */
+    void showAnimated();
+
+    /**
+     * @brief Hide the title bar with fade-out animation
+     */
+    void hideAnimated();
+
+    /**
+     * @brief Get current opacity value
+     * @return Opacity value (0.0 - 1.0)
+     */
+    qreal opacity() const;
+
+    /**
+     * @brief Set opacity value for animation
+     * @param opacity Opacity value (0.0 - 1.0)
+     */
+    void setOpacity(qreal opacity);
+
+protected:
+    /**
+     * @brief Paint the gradient background and centered text
+     * @param event Paint event
+     */
+    void paintEvent(QPaintEvent *event) override;
+
+    /**
+     * @brief Handle resize event - update geometry
+     * @param event Resize event
+     */
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    /**
+     * @brief Initialize the widget components
+     */
+    void initializeComponents();
+
+    /**
+     * @brief Setup fade animation
+     */
+    void setupAnimation();
+
+    QString m_text;                      ///< Title text to display
+    QTimer *m_autoHideTimer;             ///< Timer for auto-hide functionality
+    QPropertyAnimation *m_fadeAnimation; ///< Animation for fade in/out effects
+    qreal m_opacity;                     ///< Current opacity value
+    
+    static constexpr int kTitleBarHeight = 40;     ///< Fixed height of title bar
+    static constexpr int kAutoHideDelay = 3000;    ///< Auto-hide delay in milliseconds
+    static constexpr int kFadeAnimationDuration = 500; ///< Fade animation duration in milliseconds
+};
+
+}
+
+#endif // TITLEBARWIDGET_H

--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videopreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videopreview.cpp
@@ -19,7 +19,7 @@ VideoPreview::VideoPreview(QObject *parent)
     : AbstractBasePreview(parent)
 {
     fmInfo() << "Video preview: VideoPreview instance created";
-    
+
     setlocale(LC_NUMERIC, "C");
 
     playerWidget = new VideoWidget(this);
@@ -28,14 +28,14 @@ VideoPreview::VideoPreview(QObject *parent)
 
     connect(&playerWidget->engine(), &dmr::PlayerEngine::stateChanged, this, &VideoPreview::sigPlayState);
     connect(&playerWidget->engine(), &dmr::PlayerEngine::elapsedChanged, this, &VideoPreview::elapsedChanged);
-    
+
     fmDebug() << "Video preview: VideoPreview initialization completed";
 }
 
 VideoPreview::~VideoPreview()
 {
     fmInfo() << "Video preview: VideoPreview instance destroyed";
-    
+
     if (statusBar) {
         statusBar->hide();
         statusBar->deleteLater();
@@ -47,19 +47,19 @@ VideoPreview::~VideoPreview()
         disconnect(&playerWidget->engine(), &dmr::PlayerEngine::elapsedChanged, this, &VideoPreview::elapsedChanged);
         playerWidget.data()->deleteLater();
     }
-    
+
     fmDebug() << "Video preview: VideoPreview cleanup completed";
 }
 
 bool VideoPreview::setFileUrl(const QUrl &url)
 {
     fmInfo() << "Video preview: setting file URL:" << url;
-    
+
     if (!url.isLocalFile()) {
         fmWarning() << "Video preview: URL is not a local file:" << url;
         return false;
     }
-    
+
     const QString filePath = url.toLocalFile();
     if (!QFileInfo::exists(filePath)) {
         fmWarning() << "Video preview: file does not exist:" << filePath;
@@ -80,9 +80,8 @@ bool VideoPreview::setFileUrl(const QUrl &url)
     }
 
     fmDebug() << "Video preview: movie info parsed successfully - title:" << info.title << "duration:" << info.duration;
-    
-    playerWidget->title->setText(info.title);
-    playerWidget->title->adjustSize();
+
+    playerWidget->titleBar->setText(info.title);
     statusBar->slider->setMaximum(static_cast<int>(info.duration));
     videoUrl = QUrl::fromLocalFile(filePath);
 
@@ -120,6 +119,11 @@ void VideoPreview::play()
     if (playerWidget && videoUrl.isValid()) {
         fmDebug() << "Video preview: starting playback for:" << videoUrl;
         playerWidget->playFile(videoUrl);
+
+        // Start the title bar auto-hide timer when playback begins
+        if (playerWidget->titleBar) {
+            playerWidget->titleBar->startAutoHideTimer();
+        }
     } else {
         fmWarning() << "Video preview: cannot play - invalid player widget or URL:" << videoUrl;
     }

--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videowidget.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videowidget.cpp
@@ -10,18 +10,20 @@
 DWIDGET_USE_NAMESPACE
 using namespace plugin_filepreview;
 VideoWidget::VideoWidget(VideoPreview *preview)
-    : dmr::PlayerWidget(nullptr), p(preview), title(new QLabel(this))
+    : dmr::PlayerWidget(nullptr), p(preview), titleBar(new TitleBarWidget(this))
 {
+    fmDebug() << "Video widget: initializing VideoWidget with custom title bar";
+
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
-    QPalette pa;
-    pa.setColor(QPalette::WindowText, Qt::white);
-
-    title->setPalette(pa);
-
-    DAnchorsBase::setAnchor(title, Qt::AnchorHorizontalCenter, this, Qt::AnchorHorizontalCenter);
+    // Position title bar at the top of the widget
+    titleBar->move(0, 0);
+    titleBar->setVisible(true);
+    titleBar->raise(); // Ensure title bar is above video content
 
     engine().setBackendProperty("keep-open", "yes");
+
+    fmDebug() << "Video widget: VideoWidget initialization completed";
 }
 
 QSize VideoWidget::sizeHint() const
@@ -56,3 +58,39 @@ void VideoWidget::showEvent(QShowEvent *event)
 
     return dmr::PlayerWidget::showEvent(event);
 }
+
+void VideoWidget::resizeEvent(QResizeEvent *event)
+{
+    dmr::PlayerWidget::resizeEvent(event);
+
+    // Update title bar size and position
+    if (titleBar) {
+        titleBar->setGeometry(0, 0, width(), titleBar->height());
+    }
+}
+
+void VideoWidget::enterEvent(QEnterEvent *event)
+{
+    dmr::PlayerWidget::enterEvent(event);
+
+    fmDebug() << "Video widget: mouse entered video widget";
+
+    // When mouse enters the video widget, check if it's in title bar area
+    if (titleBar) {
+        titleBar->stopAutoHideTimer();
+        titleBar->showAnimated();
+    }
+}
+
+void VideoWidget::leaveEvent(QEvent *event)
+{
+    dmr::PlayerWidget::leaveEvent(event);
+
+    fmDebug() << "Video widget: mouse left video widget";
+
+    // When mouse leaves the video widget, start auto-hide timer
+    if (titleBar) {
+        titleBar->hideAnimated();
+    }
+}
+

--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videowidget.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videowidget.h
@@ -6,10 +6,13 @@
 #define PLAYERWIDGET_H
 
 #include "preview_plugin_global.h"
+#include "titlebarwidget.h"
 
 #include <danchors.h>
 
 #include <QLabel>
+#include <QMouseEvent>
+#include <QEnterEvent>
 
 #include <player_widget.h>
 #include <player_engine.h>
@@ -27,10 +30,16 @@ public:
 
     void mouseReleaseEvent(QMouseEvent *event) override;
 
+    void enterEvent(QEnterEvent *event) override;
+
+    void leaveEvent(QEvent *event) override;
+
     void showEvent(QShowEvent *event) override;
 
+    void resizeEvent(QResizeEvent *event) override;
+
     VideoPreview *p;
-    QLabel *title;
+    TitleBarWidget *titleBar;
     QUrl videoUrl;
 };
 }


### PR DESCRIPTION
1. Added new TitleBarWidget class with gradient background and fade
animations
2. Replaced simple QLabel title with new animated title bar widget
3. Implemented auto-hide functionality with 3-second timer
4. Added mouse hover interaction to show/hide title bar
5. Improved visual appearance with gradient background and centered text
6. Enhanced user experience with smooth fade in/out animations

Log: Added animated title bar with auto-hide feature for video preview

Influence:
1. Test video preview with different file types and titles
2. Verify title bar auto-hides after 3 seconds of inactivity
3. Check mouse hover behavior shows/hides title bar correctly
4. Test fade animations for smooth transitions
5. Verify title text display and eliding for long titles
6. Check title bar positioning and sizing during resize
7. Test playback controls interaction with title bar visibility

feat: 为视频预览添加动画标题栏

1. 新增 TitleBarWidget 类，支持渐变背景和淡入淡出动画
2. 使用新的动画标题栏替换简单的 QLabel 标题
3. 实现自动隐藏功能，3秒后自动隐藏
4. 添加鼠标悬停交互显示/隐藏标题栏
5. 改进视觉效果，使用渐变背景和居中文本
6. 通过平滑的淡入淡出动画提升用户体验

Log: 为视频预览新增带自动隐藏功能的动画标题栏

Influence:
1. 测试不同文件类型和标题的视频预览
2. 验证标题栏在3秒无操作后自动隐藏
3. 检查鼠标悬停行为是否正确显示/隐藏标题栏
4. 测试淡入淡出动画的平滑过渡效果
5. 验证标题文本显示和长标题的省略处理
6. 检查调整大小时标题栏的定位和尺寸
7. 测试播放控制与标题栏可见性的交互

BUG: https://pms.uniontech.com/bug-view-337489.html

## Summary by Sourcery

Introduce a custom animated title bar in video preview to display titles with a gradient background, fade-in/out animations, and auto-hide behavior triggered by inactivity and mouse hover.

New Features:
- Add TitleBarWidget with gradient background, centered text, and fade animations
- Implement auto-hide timer to hide the title bar after 3 seconds of inactivity
- Enable show/hide of the title bar on mouse hover events

Enhancements:
- Replace QLabel title with TitleBarWidget and start auto-hide timer when playback begins
- Adjust title bar geometry on widget resize and ensure it overlays video content