### PR TITLE
fix bugs

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -117,6 +117,7 @@ enum ItemRoles {
     kItemGroupHeaderKey = Qt::UserRole + 40,
     kItemGroupDisplayIndex = Qt::UserRole + 41,
     kItemGroupExpandedRole = Qt::UserRole + 42,
+    kItemGroupFileCount = Qt::UserRole + 43,
     kItemUnknowRole = Qt::UserRole + 999
 };
 

--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -181,7 +181,6 @@ public:
         kIsRoot = 7,   // 是否是根文件
         kIsBundle = 8,   // 是否是二进制文件
         kIsDragCompressFileFormat = 9,   // 是否可以追加压缩
-        kIsPrivate = 10,   // 是否是私有文件
         kCustomerFileIs = 50,   // 其他用户使用
         kUnknowFileIsInfo = 255,
     };

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -920,17 +920,6 @@ bool AsyncFileInfoPrivate::isExecutable() const
     return isExecutable;
 }
 
-bool AsyncFileInfoPrivate::isPrivate() const
-{
-    const QString &path = const_cast<AsyncFileInfoPrivate *>(this)->path();
-    const QString &name = fileName();
-
-    static DFMBASE_NAMESPACE::Match match("PrivateFiles");
-
-    QReadLocker locker(&const_cast<AsyncFileInfoPrivate *>(this)->lock);
-    return match.match(path, name);
-}
-
 bool AsyncFileInfoPrivate::canDelete() const
 {
     if (SystemPathUtil::instance()->isSystemPath(filePath()))
@@ -971,9 +960,6 @@ bool AsyncFileInfoPrivate::canRename() const
 
 bool AsyncFileInfoPrivate::canFetch() const
 {
-    if (isPrivate())
-        return false;
-
     bool isArchive = false;
     if (q->exists())
         isArchive = DFMBASE_NAMESPACE::MimeTypeDisplayManager::instance()->supportArchiveMimetypes().contains(DMimeDatabase().mimeTypeForFile(q->fileUrl()).name());

--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -93,7 +93,6 @@ public:
     QString symLinkTarget() const;
     QUrl redirectedFileUrl() const;
     bool isExecutable() const;
-    bool isPrivate() const;
     bool canDelete() const;
     bool canTrash() const;
     bool canRename() const;

--- a/src/dfm-base/file/local/private/syncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/syncfileinfo_p.h
@@ -84,7 +84,6 @@ public:
     QString symLinkTarget() const;
     QUrl redirectedFileUrl() const;
     bool isExecutable() const;
-    bool isPrivate() const;
     bool canDelete() const;
     bool canTrash() const;
     bool canRename() const;

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -226,8 +226,6 @@ bool SyncFileInfo::isAttributes(const OptInfoType type) const
         return d->filePath() == "/";
     case FileIsType::kIsBundle:
         return QFileInfo(url.path()).isBundle();
-    case FileIsType::kIsPrivate:
-        return d->isPrivate();
     default:
         return FileInfo::isAttributes(type);
     }
@@ -948,17 +946,6 @@ bool SyncFileInfoPrivate::isExecutable() const
     return isExecutable;
 }
 
-bool SyncFileInfoPrivate::isPrivate() const
-{
-    const QString &path = const_cast<SyncFileInfoPrivate *>(this)->path();
-    const QString &name = fileName();
-
-    static DFMBASE_NAMESPACE::Match match("PrivateFiles");
-
-    QMutexLocker locker(&lock);
-    return match.match(path, name);
-}
-
 bool SyncFileInfoPrivate::canDelete() const
 {
     if (SystemPathUtil::instance()->isSystemPath(filePath()))
@@ -999,9 +986,6 @@ bool SyncFileInfoPrivate::canRename() const
 
 bool SyncFileInfoPrivate::canFetch() const
 {
-    if (isPrivate())
-        return false;
-
     bool isArchive = false;
     if (q->exists())
         isArchive = DFMBASE_NAMESPACE::MimeTypeDisplayManager::instance()->supportArchiveMimetypes().contains(DMimeDatabase().mimeTypeForFile(q->fileUrl()).name());

--- a/src/dfm-base/interfaces/fileinfo.cpp
+++ b/src/dfm-base/interfaces/fileinfo.cpp
@@ -391,8 +391,7 @@ bool dfmbase::FileInfo::canAttributes(const CanableInfoType type) const
 {
     switch (type) {
     case FileCanType::kCanFetch:
-        return isAttributes(OptInfoType::kIsDir)
-                && !isAttributes(OptInfoType::kIsPrivate);
+        return isAttributes(OptInfoType::kIsDir);
     case FileCanType::kCanDrop:
         return dptr->canDrop();
     case FileCanType::kCanDrag:
@@ -655,10 +654,6 @@ QString dfmbase::FileInfoPrivate::suffix() const
  */
 bool DFMBASE_NAMESPACE::FileInfoPrivate::canDrop() const
 {
-    if (q->isAttributes(OptInfoType::kIsPrivate)) {
-        return false;
-    }
-
     if (!q->isAttributes(OptInfoType::kIsSymLink)) {
         const bool isDesktop = q->nameOf(NameInfoType::kMimeTypeName) == Global::Mime::kTypeAppXDesktop;
         return (q->isAttributes(OptInfoType::kIsDir) && q->isAttributes(OptInfoType::kIsWritable)) || isDesktop;

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1354,66 +1354,6 @@ float codecConfidenceForData(const QTextCodec *codec, const QByteArray &data, co
 }
 #endif
 
-Match::Match(const QString &group)
-{
-    for (const QString &key : Application::instance()->genericObtuselySetting()->keys(group)) {
-        const QString &value = Application::instance()->genericObtuselySetting()->value(group, key).toString();
-
-        int last_dir_split = value.lastIndexOf(QDir::separator());
-
-        if (last_dir_split >= 0) {
-            QString path = value.left(last_dir_split);
-
-            if (path.startsWith("~/")) {
-                path.replace(0, 1, QDir::homePath());
-            }
-
-            patternList << qMakePair(path, value.mid(last_dir_split + 1));
-        } else {
-            patternList << qMakePair(QString(), value);
-        }
-    }
-}
-
-bool Match::match(const QString &path, const QString &name)
-{
-    // 这里可能会析构 先复制一份再循环
-    const QList<QPair<QString, QString>> patternListNew = patternList;
-    for (auto pattern : patternListNew) {
-        QRegularExpression re(QString(), QRegularExpression::MultilineOption);
-
-        if (!pattern.first.isEmpty()) {
-            re.setPattern(pattern.first);
-
-            if (!re.isValid()) {
-                qCWarning(logDFMBase) << re.errorString();
-                continue;
-            }
-
-            if (!re.match(path).hasMatch()) {
-                continue;
-            }
-        }
-
-        if (pattern.second.isEmpty()) {
-            return true;
-        }
-
-        re.setPattern(pattern.second);
-
-        if (!re.isValid()) {
-            qCWarning(logDFMBase) << re.errorString();
-            continue;
-        }
-
-        if (re.match(name).hasMatch()) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 QString FileUtils::findIconFromXdg(const QString &iconName)
 {
     // NOTE: qtxdg-dev-tools only Qt5 supported now!

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -106,16 +106,6 @@ public:
     static QUrl homeDesktopFileUrl();
 };
 
-class Match
-{
-public:
-    explicit Match(const QString &group);
-    bool match(const QString &path, const QString &name);
-
-private:
-    QList<QPair<QString, QString>> patternList;
-};
-
 }
 
 typedef QSharedPointer<DFMBASE_NAMESPACE::FileUtils::FilesSizeInfo> SizeInfoPointer;

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/filegroupdata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/filegroupdata.cpp
@@ -46,7 +46,7 @@ FileGroupData::~FileGroupData()
 
 QString FileGroupData::getHeaderText() const
 {
-    return QString("%1 (%2)").arg(displayName).arg(fileCount);
+    return displayName;
 }
 
 void FileGroupData::addFile(const FileItemDataPointer &file)

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/modelitemwrapper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/modelitemwrapper.cpp
@@ -40,6 +40,7 @@ ModelItemWrapper::ModelItemWrapper(const FileGroupData *groupData)
         groupValues[Global::kItemIsGroupHeaderType] = true;
         groupValues[Global::kItemDisplayRole] = groupData->getHeaderText();
         groupValues[Global::kItemNameRole] = groupData->getHeaderText();
+        groupValues[Global::kItemGroupFileCount] = groupData->fileCount;
         groupValues[Global::kItemGroupHeaderKey] = groupData->groupKey;
         groupValues[Global::kItemGroupDisplayIndex] = groupData->displayIndex;
         groupValues[Global::kItemGroupExpandedRole] = groupData->isExpanded;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -147,7 +147,7 @@ protected:
     // Group rendering helper methods
     void paintGroupBackground(QPainter *painter, const QStyleOptionViewItem &option) const;
     void paintExpandButton(QPainter *painter, const QRect &buttonRect, bool isExpanded) const;
-    void paintGroupText(QPainter *painter, const QRect &textRect, const QString &text, const QStyleOptionViewItem &option) const;
+    void paintGroupText(QPainter *painter, const QRect &textRect, const QString &text, int count, const QStyleOptionViewItem &option) const;
 
     // Group layout calculation methods
 


### PR DESCRIPTION
## Summary by Sourcery

Add file count display in group headers and remove private file filtering

New Features:
- Expose and propagate a new ItemRole for group file counts to the UI delegate
- Render file count next to group titles with themable fonts and colors

Bug Fixes:
- Remove the Match-based private file filtering and associated isPrivate checks across SyncFileInfo, AsyncFileInfo, and FileInfo

Enhancements:
- Refactor group header text painting to use DFontSizeManager fonts, dynamic elision, and theme-aware opacity