### PR TITLE
fix: prevent closing last tab with middle mouse button

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -862,7 +862,7 @@ void TabBar::mousePressEvent(QMouseEvent *e)
 {
     if (e->button() == Qt::MiddleButton) {
         int index = tabAt(e->pos());
-        if (-1 != index)
+        if (-1 != index && count() > 1)
             Q_EMIT tabCloseRequested(index);
     }
 


### PR DESCRIPTION
Previously, the middle mouse button click would close any tab including
the last one, which could leave the file manager without any tabs open.
This change adds a check to ensure there is always at least one tab
remaining by preventing the closure of the last tab via middle click.

The fix adds a condition to verify that the tab count is greater
than 1 before allowing middle-click closure, ensuring user interface
consistency and preventing accidental loss of all tabs.

Influence:
1. Test middle-click on tabs when multiple tabs are open - should close
the clicked tab
2. Test middle-click on the last remaining tab - should not close it
3. Verify normal tab closure functionality through other methods (close
button, keyboard shortcuts) remains unaffected
4. Check that new tab creation and tab switching behaviors work
correctly

fix: 防止使用鼠标中键关闭最后一个标签页

之前，鼠标中键点击会关闭包括最后一个标签页在内的任何标签页，这可能导致文
件管理器没有打开的标签页。此更改添加了一个检查，确保在通过中键关闭标签页
之前标签页数量大于1，从而始终保留至少一个标签页，确保用户界面一致性并防
止意外关闭所有标签页。

该修复添加了一个条件来验证标签页数量大于1才允许中键关闭，确保用户界面一
致性并防止意外丢失所有标签页。

Influence:
1. 测试在多个标签页打开时中键点击标签页 - 应关闭被点击的标签页
2. 测试在最后一个标签页上使用中键点击 - 不应关闭它
3. 验证通过其他方法（关闭按钮、键盘快捷键）的正常标签页关闭功能不受影响
4. 检查新建标签页和标签页切换行为是否正常工作

BUG: https://pms.uniontech.com/bug-view-337639.html

## Summary by Sourcery

Bug Fixes:
- Add a check to only emit tabCloseRequested on middle-click when more than one tab is present