### PR TITLE
fix: handle file renaming conflict gracefully

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -367,7 +367,15 @@ DFileInfoPointer DoCutFilesWorker::trySameDeviceRename(const DFileInfoPointer &s
         isCutMerge = false;
         result = doMergDir(sourceInfo, newTargetInfo, skip);
     } else {
-        result = renameFileByHandler(sourceInfo, newTargetInfo, skip);
+        if (newTargetInfo->exists()) {
+            result = deleteFile(newTargetInfo->uri(), newTargetInfo->uri(), skip);
+            if (result) {
+                *skip = false;   // deleteFile拷贝成功会设置skip为true，正确的删除后设置skip为false
+                result = renameFileByHandler(sourceInfo, newTargetInfo, skip);
+            }
+        } else {
+            result = renameFileByHandler(sourceInfo, newTargetInfo, skip);
+        }
     }
 
     if (result) {


### PR DESCRIPTION
Changed the file cut operation logic to handle conflicts when renaming to an existing filename. Instead of directly attempting the rename operation, it now:
1. Checks if target file exists
2. If exists, deletes the existing file first
3. Then performs the rename operation
4. Resets skip flag properly after deletion
5. Otherwise continues with normal rename operation

This fixes issues where file cutting operations would fail when trying to overwrite existing files.

Log: Fixed file cutting failure when target filename exists

Influence:
1. Test cutting files to locations with existing files
2. Verify successful overwrite of existing files
3. Test cases where target files don't exist
4. Verify skip flag behavior during rename operations

fix: 优雅处理文件重命名冲突

修改了剪切文件的处理逻辑，当重命名到已存在的文件名时：
1. 先检查目标文件是否存在
2. 如果存在则先删除现有文件
3. 然后执行重命名操作
4. 在删除后正确重置skip标记
5. 否则正常执行重命名操作

这解决了当尝试覆盖现有文件时文件剪切操作会失败的问题。

Log: 修复目标文件名存在时文件剪切失败的问题

Influence:
1. 测试剪切文件到已存在文件的路径
2. 验证成功覆盖现有文件的功能
3. 测试目标文件不存在的情况
4. 验证重命名操作中的skip标记行为

Bug: https://pms.uniontech.com/bug-view-337471.html

## Summary by Sourcery

Gracefully handle file renaming conflicts in the cut operation by deleting existing targets and properly resetting the skip flag before performing the rename.

Bug Fixes:
- Delete existing target file before renaming to prevent copy failures when overwriting
- Reset skip flag after deletion to ensure subsequent rename executes correctly

Tests:
- Add tests for cutting files into locations with existing files and verifying overwrite behavior
- Add tests for cutting files when the target does not exist and verifying skip flag behavior