### PR TITLE
fix: Correct optical usage display issue​​

### DIFF
--- a/src/dfm-base/base/application/application.cpp
+++ b/src/dfm-base/base/application/application.cpp
@@ -22,7 +22,8 @@ Q_GLOBAL_STATIC_WITH_ARGS(Settings, asGlobal, ("deepin/dde-file-manager/dde-file
 Q_GLOBAL_STATIC_WITH_ARGS(Settings, gosGlobal, ("deepin/dde-file-manager.obtusely", Settings::kGenericConfig))
 Q_GLOBAL_STATIC_WITH_ARGS(Settings, aosGlobal, ("deepin/dde-file-manager/dde-file-manager.obtusely", Settings::kGenericConfig))
 
-Q_GLOBAL_STATIC_WITH_ARGS(Settings, dpGlobal, ("", "", "/tmp/.config/deepin/dde-file-manager/dde-file-manager.dp"))
+static constexpr char DP_GLOBAL_FILE[] { "/tmp/.config/deepin/dde-file-manager/dde-file-manager.dp" };
+Q_GLOBAL_STATIC_WITH_ARGS(Settings, dpGlobal, ("", "", DP_GLOBAL_FILE))
 
 // blumia: since dde-desktop now also do show file selection dialog job, thus dde-desktop should share the same config file
 //         with dde-file-manager, so we use GenericConfig with specify path to simulate AppConfig.
@@ -297,6 +298,11 @@ Settings *Application::dataPersistence()
 #ifndef DFM_NO_FILE_WATCHER
         dpGlobal->setWatchChanges(true);
 #endif
+        // By default, files created under /tmp have a permission mode of 644,
+        // which prevents new users from accessing the file after creation.
+        // This restricts usage updates under new user accounts.
+        QFile f(DP_GLOBAL_FILE);
+        f.setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ReadGroup | QFile::WriteGroup | QFile::ReadOther | QFile::WriteOther);
     }
 
     return dpGlobal;


### PR DESCRIPTION
Optical usage data is stored in /tmp/...../dde-file-manager.dp, which is created when the first dde-file-managerinstance launches. However, since files in /tmpdefault to ​​644 permissions​​, new users cannot access or update this file, leading to incorrect optical usage reporting.

Log:​​ Fixed optical usage display inaccuracies caused by permission restrictions.

Bug: https://pms.uniontech.com/bug-view-305641.html Change-Id: I156c858f87d2fde55d8da147378b88563d802fac (cherry picked from commit fa654a8d51226efe1a3c68a77685f10a11f81df7)

## Summary by Sourcery

Correct file permissions of the optical usage data file in /tmp to ensure new users can access and update it, and centralize its path definition in a constant.

Bug Fixes:
- Fix incorrect optical usage reporting by granting read/write permissions on the data persistence file for all users.

Enhancements:
- Extract the optical usage data file path into a constexpr constant.