### PR TITLE
fix: adjust titlebar button sizes for compact mode

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -387,19 +387,19 @@ void TitleBarWidget::updateUiForSizeMode()
 
     auto optionBtn = topBar->findChild<DWindowOptionButton *>("DTitlebarDWindowOptionButton");
     if (optionBtn)
-        optionBtn->setFixedSize(50, 40);
+        optionBtn->setFixedSize(40, 40);
 
     auto closeBtn = topBar->findChild<DWindowCloseButton *>("DTitlebarDWindowCloseButton");
     if (closeBtn)
-        closeBtn->setFixedSize(50, 40);
+        closeBtn->setFixedSize(40, 40);
 
     auto minBtn = topBar->findChild<DWindowMinButton *>("DTitlebarDWindowMinButton");
     if (minBtn)
-        minBtn->setFixedSize(50, 40);
+        minBtn->setFixedSize(40, 40);
 
     auto maxBtn = topBar->findChild<DWindowMaxButton *>("DTitlebarDWindowMaxButton");
     if (maxBtn)
-        maxBtn->setFixedSize(50, 40);
+        maxBtn->setFixedSize(40, 40);
 }
 
 void TitleBarWidget::showAddrsssBar(const QUrl &url)


### PR DESCRIPTION
Changed the fixed width of titlebar buttons from 50px to 40px in compact
size mode to better match the overall compact design theme and improve
visual consistency across different UI elements.

Log: Adjusted titlebar button sizes in compact mode for better visual
consistency

Influence:
1. Verify window control buttons (minimize, maximize, close) display
correctly in compact mode
2. Check that all buttons maintain proper spacing and alignment
3. Test button functionality remains unchanged after size adjustment
4. Ensure button icons are properly centered within the new dimensions
5. Verify the changes apply correctly when switching between normal and
compact modes

fix: 调整紧凑模式下标题栏按钮尺寸

将紧凑模式下标题栏按钮的固定宽度从50像素调整为40像素，以更好地匹配整体紧
凑设计主题，并提高不同UI元素之间的视觉一致性。

Log: 调整了紧凑模式下标题栏按钮尺寸以提升视觉一致性

Influence:
1. 验证窗口控制按钮（最小化、最大化、关闭）在紧凑模式下正确显示
2. 检查所有按钮是否保持适当的间距和对齐
3. 测试按钮功能在尺寸调整后保持不变
4. 确保按钮图标在新的尺寸内正确居中
5. 验证在正常模式和紧凑模式之间切换时更改正确应用

BUG: https://pms.uniontech.com/bug-view-307179.html

## Summary by Sourcery

Bug Fixes:
- Reduce fixed width of minimize, maximize, close, and options buttons from 50px to 40px in compact mode for proper alignment and consistency