### PR TITLE
fix: add libappimage integration for thumbnails

### DIFF
--- a/cmake/DFMLibraryConfig.cmake
+++ b/cmake/DFMLibraryConfig.cmake
@@ -13,6 +13,7 @@ function(dfm_configure_base_library target_name)
     find_package(dfm${DTK_VERSION_MAJOR}-io REQUIRED)
     find_package(dfm${DTK_VERSION_MAJOR}-mount REQUIRED)
     find_package(dfm${DTK_VERSION_MAJOR}-burn REQUIRED)
+    find_package(libappimage REQUIRED)
     find_package(PkgConfig REQUIRED)
     
     # System dependencies
@@ -76,6 +77,7 @@ function(dfm_configure_base_library target_name)
             poppler-cpp
             ${LIBHEIF_LIBRARIES}
             ${DFM_EXTRA_LIBRARIES}  
+            libappimage
     )
     
     # Include directories
@@ -151,7 +153,7 @@ endfunction()
 # Function to get library dependencies for testing
 function(dfm_get_library_test_dependencies lib_name result_var)
     if(lib_name STREQUAL "dfm-base")
-        set(${result_var} "Qt6::Core;Qt6::Widgets;Qt6::Gui;Qt6::Concurrent;Qt6::DBus;Qt6::Sql;Qt6::Network;Dtk6::Core;Dtk6::Widget;Dtk6::Gui;dfm6-io;dfm6-mount;dfm6-burn;PkgConfig::mount;PkgConfig::gio;PkgConfig::X11;poppler-cpp;${LIBHEIF_LIBRARIES}" PARENT_SCOPE)
+        set(${result_var} "Qt6::Core;Qt6::Widgets;Qt6::Gui;Qt6::Concurrent;Qt6::DBus;Qt6::Sql;Qt6::Network;Dtk6::Core;Dtk6::Widget;Dtk6::Gui;dfm6-io;dfm6-mount;dfm6-burn;PkgConfig::mount;PkgConfig::gio;PkgConfig::X11;poppler-cpp;${LIBHEIF_LIBRARIES};libappimage" PARENT_SCOPE)
     elseif(lib_name STREQUAL "dfm-framework")
         set(${result_var} "Qt6::Core;Qt6::Concurrent;Dtk6::Core;${CMAKE_DL_LIBS}" PARENT_SCOPE)
     elseif(lib_name STREQUAL "dfm-extension")

--- a/debian/control
+++ b/debian/control
@@ -49,7 +49,8 @@ Build-Depends:
  libopenjp2-7-dev,
  liblcms2-dev,
  libdeepin-service-framework-dev,
- libheif-dev
+ libheif-dev,
+ libappimage-dev
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org
 


### PR DESCRIPTION
Added libappimage library integration to improve AppImage thumbnail generation performance and reliability by:
1. Added libappimage dependency in CMake configs
2. Included libappimage-dev in debian control file
3. Reimplemented appimageThumbnailCreator to use libappimage API
4. Removed slow extraction process and now reads .DirIcon directly from AppImage
5. Added proper memory cleanup with QScopedPointer

The change significantly improves performance since we no longer need to fully extract AppImage files just to access their icons. This also makes thumbnail generation more reliable as it depends on standardized AppImage features rather than searching arbitrary extracted files.

Log: Improved AppImage thumbnail generation performance and reliability

Influence:
1. Test thumbnail generation for various AppImage files
2. Verify handling of AppImages with/without .DirIcon
3. Check memory usage during thumbnail generation
4. Verify thumbnail quality after scaling
5. Test with different sized AppImage icons

fix: 添加libappimage集成支持缩略图生成

新增libappimage库集成以提升AppImage缩略图生成性能和可靠性：
1. 在CMake配置中添加libappimage依赖
2. 在debian控制文件中添加libappimage-dev依赖
3. 重构appimageThumbnailCreator使用libappimage API
4. 移除缓慢的解压过程，直接从AppImage读取.DirIcon
5. 使用QScopedPointer添加正确的内存清理

这一改动显著提升了性能，因为我们不再需要完整解压AppImage文件来获取图标。
同时还提高了可靠性，因为新的实现依赖于标准化的AppImage特性而不再是搜索解
压后的任意文件。

Log: 提升AppImage缩略图生成性能和可靠性

Influence:
1. 测试各种AppImage文件的缩略图生成
2. 验证有/无.DirIcon的AppImage处理
3. 检查缩略图生成期间的内存使用情况
4. 验证缩放后的缩略图质量
5. 测试不同尺寸AppImage图标的效果

Bug: https://pms.uniontech.com/bug-view-337795.html

## Summary by Sourcery

Integrate libappimage to improve AppImage thumbnail generation by reading .DirIcon directly, replace extraction-based logic, and update build configurations.

Enhancements:
- Reimplement AppImage thumbnail creation to use libappimage API for direct .DirIcon retrieval instead of full extraction
- Ensure proper memory cleanup of the icon buffer using QScopedPointer
- Remove temporary extraction logic and associated QProcess steps

Build:
- Add libappimage to CMake find_package and link targets
- Include libappimage-dev dependency in Debian control file