### PR TITLE
fix: add null check for filterSortWorker in onRemoveFinish

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -1052,7 +1052,7 @@ void FileViewModel::onRemoveFinish()
 
     endRemoveRows();
 
-    if (filterSortWorker->childrenCount() <= 0 && UniversalUtils::urlEquals(rootUrl(), FileUtils::trashRootUrl()))
+    if (filterSortWorker && filterSortWorker->childrenCount() <= 0 && UniversalUtils::urlEquals(rootUrl(), FileUtils::trashRootUrl()))
         WorkspaceEventCaller::sendModelFilesEmpty();
 }
 


### PR DESCRIPTION
Added null pointer check for filterSortWorker before accessing its
childrenCount method in onRemoveFinish function. This prevents potential
crashes when filterSortWorker might be null during trash directory
operations.

Influence:
1. Test emptying trash bin to ensure no crashes occur
2. Verify trash directory operations work correctly after deletion
3. Check that empty state notifications are properly triggered

fix: 在onRemoveFinish中添加对filterSortWorker的空指针检查

在onRemoveFinish函数中访问filterSortWorker的childrenCount方法前添加了空
指针检查。这可以防止在回收站目录操作期间filterSortWorker可能为空时导致的
潜在崩溃。

Influence:
1. 测试清空回收站功能，确保不会发生崩溃
2. 验证删除后回收站目录操作正常工作
3. 检查空状态通知是否正确触发

BUG: https://pms.uniontech.com/bug-view-337887.html

## Summary by Sourcery

Bug Fixes:
- Add null pointer check before accessing filterSortWorker in onRemoveFinish to avoid potential crashes when it is null