### PR TITLE
fix: handle null pointer in executable script check

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -808,6 +808,8 @@ bool LocalFileHandlerPrivate::isExecutableScript(const QString &path)
     QStringList targetList;
     targetList.append(path);
     while (isSymLink) {
+        if (!info)
+            return false;
         pathValue = info->pathOf(PathInfoType::kSymLinkTarget);
         pathValue = pathValue.endsWith(QDir::separator()) && pathValue != QDir::separator() ? QString(pathValue).left(pathValue.length() - 1)
                                                                                             : pathValue;


### PR DESCRIPTION
Added null pointer check for info object in isExecutableScript method to prevent crashes when dereferencing potentially null pointers during symbolic link resolution.

The change ensures graceful failure when encountering invalid symbolic links instead of causing application crashes.

Influence:
1. Test with various symbolic links including broken ones
2. Verify behavior with non-existent files
3. Check handling of files with insufficient permissions

fix: 修复可执行脚本检测中的空指针问题

在isExecutableScript方法中添加了对info对象的空指针检查，防止在解析符号链
接时对可能为空指针的对象进行解引用导致的崩溃。

该变更确保了当遇到无效符号链接时能够优雅地失败，而不是导致应用程序崩溃。

Influence:
1. 测试各种符号链接，包括损坏的链接
2. 验证对不存在的文件的行为
3. 检查对权限不足文件的处理

Bug: https://pms.uniontech.com/bug-view-337839.html
Bug: https://pms.uniontech.com/bug-view-337879.html

## Summary by Sourcery

Bug Fixes:
- Prevent null pointer dereference in isExecutableScript when resolving broken or invalid symbolic links