### PR TITLE
fix: fix canvas view item hit detection

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
@@ -306,14 +306,22 @@ WId CanvasView::winId() const
 QModelIndex CanvasView::baseIndexAt(const QPoint &point) const
 {
     auto checkRect = [](const QList<QRect> &listRect, const QPoint &point) -> bool {
+        if (listRect.isEmpty())
+            return false;
+
         // icon rect
-        if (listRect.size() > 0 && listRect.at(0).contains(point))
+        QRect iconRect = listRect.at(0);
+        if (iconRect.contains(point))
             return true;
 
         if (listRect.size() > 1) {
             QRect identify = listRect.at(1);
             if (identify.contains(point))
                 return true;
+
+            // 检查图标和文本的包围区域
+            QRect combinedRect = iconRect.united(identify);
+            return combinedRect.contains(point);
         }
         return false;
     };


### PR DESCRIPTION
1. Added empty list check to prevent index out of bounds error
2. Improved hit detection logic by checking combined area of icon and
text
3. Fixed potential crash when listRect is empty
4. Enhanced item selection accuracy by considering both icon and text
bounds

Influence:
1. Test clicking on canvas items to verify proper selection
2. Verify edge cases with empty item lists
3. Test clicking near boundaries between icon and text areas
4. Confirm no crashes occur with various item configurations

fix: 修复画布视图项目点击检测问题

1. 添加空列表检查防止索引越界错误
2. 通过检查图标和文本的合并区域改进点击检测逻辑
3. 修复当列表为空时可能的崩溃问题
4. 通过考虑图标和文本边界提高项目选择准确性

Influence:
1. 测试点击画布项目以验证正确选择
2. 验证空项目列表的边缘情况
3. 测试点击图标和文本区域边界附近
4. 确认各种项目配置下不会发生崩溃

BUG: https://pms.uniontech.com/bug-view-337885.html

## Summary by Sourcery

Fix canvas view item hit detection to prevent crashes and improve selection accuracy.

Bug Fixes:
- Add empty list check to prevent index out-of-bounds and potential crashes on empty item lists

Enhancements:
- Improve hit detection logic by checking combined area of icon and text bounds for more accurate item selection