### PR TITLE
feat: add grouping state management in file view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -46,6 +46,11 @@ enum class ModelState : uint8_t {
     kIdle,
     kBusy
 };
+
+enum class GroupingState : uint8_t {
+    kIdle,       // 未在分组或分组已完成
+    kGrouping    // 正在执行分组操作
+};
 #ifdef DTKWIDGET_CLASS_DSizeMode
 inline constexpr int kCompactIconViewSpacing { 0 };
 inline constexpr int kCompactIconModeColumnPadding { 5 };

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -61,6 +61,7 @@ public:
     void toggleGroupExpansion(const QString &groupKey);
 
     ModelState currentState() const;
+    GroupingState groupingState() const;
     FileInfoPointer fileInfo(const QModelIndex &index) const;
     QList<QUrl> getChildrenUrls() const;
     QModelIndex getIndexByUrl(const QUrl &url) const;
@@ -115,6 +116,7 @@ public:
 
 Q_SIGNALS:
     void stateChanged();
+    void groupingStateChanged();
     void renameFileProcessStarted();
     void selectAndEditFile(const QUrl &url);
     void traverPrehandle(const QUrl &url, const QModelIndex &index, FileView *view);
@@ -170,6 +172,7 @@ private:
     void discardFilterSortObjects();
 
     void changeState(ModelState newState);
+    void changeGroupingState(GroupingState newState);
     void closeCursorTimer();
     void startCursorTimer();
 
@@ -177,6 +180,7 @@ private:
     QUrl fetchingUrl;
 
     ModelState state { ModelState::kIdle };
+    GroupingState groupingStateValue { GroupingState::kIdle };
     bool readOnly { false };
     bool canFetchFiles { false };
     FileItemData *itemRootData { nullptr };

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -667,6 +667,8 @@ void FileSortWorker::handleReGrouping(const Qt::SortOrder order, const QString &
         if (!currentIsGroupingMode()) {
             handleRefresh();
         }
+        // 通知分组完成(实际上是取消分组)
+        emit groupingFinished();
         return;
     }
 
@@ -674,6 +676,7 @@ void FileSortWorker::handleReGrouping(const Qt::SortOrder order, const QString &
     if (allFiles.isEmpty()) {
         fmDebug() << "FileSortWorker: No files to group";
         clearGroupedData();
+        emit groupingFinished();
         return;
     }
 
@@ -688,6 +691,9 @@ void FileSortWorker::handleReGrouping(const Qt::SortOrder order, const QString &
 
     fmInfo() << "FileSortWorker: Grouping completed - created" << groupedModelData.groups.size()
              << "groups with" << groupedModelData.getItemCount() << "total items";
+
+    // 通知分组完成
+    emit groupingFinished();
 }
 
 void FileSortWorker::handleGroupingChanged()

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
@@ -128,6 +128,7 @@ signals:
 
     // Grouping-related signals
     void groupDataChanged();
+    void groupingFinished();   // 分组操作完成信号
     void groupExpansionChanged(const QString &strategy, const QString &key, bool state);
 
     // Note that the slot functions here are executed in asynchronous threads,

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -828,6 +828,11 @@ void FileView::setGroup(const QString &strategyName, const Qt::SortOrder order)
     d->adjustIconModeSpacing(strategyName);
 }
 
+GroupingState FileView::groupingState()
+{
+    return model()->groupingState();
+}
+
 void FileView::setViewSelectState(bool isSelect)
 {
     d->isShowViewSelectBox = isSelect;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -88,6 +88,7 @@ public:
     void setEnabledSelectionModes(const QList<SelectionMode> &modes);
     void setSort(const DFMGLOBAL_NAMESPACE::ItemRoles role, const Qt::SortOrder order);
     void setGroup(const QString &strategyName, const Qt::SortOrder order = Qt::AscendingOrder);
+    GroupingState groupingState();
 
     void setViewSelectState(bool isSelect);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -271,7 +271,9 @@ void IconItemDelegate::updateItemSizeHint()
 
     // In grouped icon mode with spacing=0, add virtual margins to regular file items
     // This allows group-headers to have 0 spacing while files maintain 10px spacing between each other
-    if (parent()->parent()->isGroupedView() && parent()->parent()->spacing() == 0) {
+    if ((parent()->parent()->isGroupedView()
+         && parent()->parent()->spacing() == 0)
+        || parent()->parent()->groupingState() == GroupingState::kGrouping) {
         // Add 10px virtual margins on all sides (total 20px for width and height)
         // This creates the effect of 10px spacing between items when spacing=0
         width += (kIconViewSpacing * 2);   // 10px left + 10px right


### PR DESCRIPTION
Added GroupingState enum and state management mechanisms to prevent UI issues during long grouping operations. Changes include:
1. Introduced GroupingState enum with kIdle/kGrouping states
2. Added groupingState tracking in FileViewModel
3. Modified FileSortWorker to emit groupingFinished signal
4. Updated FileView to expose grouping state
5. Prevent data updates during grouping operations to avoid UI glitches
6. Adjusted IconItemDelegate sizing logic during grouping

Log: Added grouping state tracking to improve UI stability during file grouping operations

Influence:
1. Test grouping operations on large directories
2. Verify UI remains responsive during grouping
3. Check icon spacing calculations during grouping
4. Test cancellation of grouping operations
5. Verify proper state transitions between grouping/idle

feat: 在文件视图中添加分组状态管理

添加了GroupingState枚举和状态管理机制以防止长时间分组操作期间的UI问题。
变更包括：
1. 引入带有kIdle/kGrouping状态的GroupingState枚举
2. 在FileViewModel中添加分组状态跟踪
3. 修改FileSortWorker以发出groupingFinished信号
4. 更新FileView以暴露分组状态
5. 分组操作期间阻止数据更新以避免UI问题
6. 调整IconItemDelegate在分组期间的大小计算逻辑

Log: 添加分组状态跟踪以提升文件分组操作时的UI稳定性

Influence:
1. 测试在大目录上的分组操作
2. 验证分组期间UI保持响应
3. 检查分组期间的图标间距计算
4. 测试分组操作的取消功能
5. 验证分组/空闲状态之间的正确转换

## Summary by Sourcery

Add grouping state management to improve UI stability during file grouping operations

New Features:
- Introduce GroupingState enum and tracking in FileViewModel and FileView
- Have FileSortWorker emit groupingFinished to drive grouping state transitions

Enhancements:
- Prevent data updates and adjust icon delegate spacing during grouping to avoid UI glitches