### PR TITLE
fix: add cancellation checks to prevent thread crashes

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.h
@@ -15,8 +15,15 @@
 #include <QHash>
 #include <QString>
 #include <QList>
+#include <functional>
 
 DPWORKSPACE_BEGIN_NAMESPACE
+
+/**
+ * @brief Callback function type for checking if operation should be canceled
+ * @return true if the operation should be canceled, false otherwise
+ */
+using CancellationCheckCallback = std::function<bool()>;
 
 /**
  * @brief Core engine for file grouping operations
@@ -179,6 +186,12 @@ public:
      */
     void setUpdateChildrenRange(int pos, int count);
 
+    /**
+     * @brief Set the cancellation check callback
+     * @param callback The callback function to check for cancellation
+     */
+    void setCancellationCheckCallback(CancellationCheckCallback callback);
+
 private:
     /**
      * @brief Perform the actual grouping algorithm
@@ -289,6 +302,15 @@ private:
      */
     std::optional<int> findNewAnchorPos(const QUrl &oldAnchorUrl, const FileGroupData *group) const;
 
+    /**
+     * @brief Check if the operation should be canceled
+     * @return true if operation should be canceled, false otherwise
+     */
+    inline bool shouldCancel() const
+    {
+        return m_cancellationCheck && m_cancellationCheck();
+    }
+
 private:
     // Configuration
     QUrl m_rootUrl;
@@ -300,6 +322,8 @@ private:
     UpdateMode m_updateMode { UpdateMode::kNoGrouping };
     QList<QUrl> m_visibleChildrenForUpdate;
     QPair<int, int> m_visibleChildrenRangeForUpdate;
+    // Cancellation callback
+    CancellationCheckCallback m_cancellationCheck;
 };
 
 DPWORKSPACE_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -68,6 +68,10 @@ FileSortWorker::FileSortWorker(const QUrl &url, const QString &key, FileViewFilt
 
     // Initialize grouping engine
     groupingEngine = std::make_unique<GroupingEngine>(current, this);
+    // Set cancellation callback to allow GroupingEngine to check our cancel state
+    groupingEngine->setCancellationCheckCallback([this]() -> bool {
+        return this->isCanceled;
+    });
 
     fmDebug() << "FileSortWorker: Grouping engine initialized";
 }
@@ -2343,7 +2347,7 @@ void FileSortWorker::applyGrouping(const QList<FileItemDataPointer> &files)
     Q_ASSERT(currentStrategy);
     Q_ASSERT(groupingEngine);
 
-    if (files.isEmpty())
+    if (files.isEmpty() || isCanceled)
         return;
 
     emit requestCursorWait();


### PR DESCRIPTION
Added cancellation checks throughout the GroupingEngine operations to prevent crashes when threads are forcibly stopped. The changes include:
1. Added shouldCancel() checks before all major operations
2. Introduced CancellationCheckCallback mechanism
3. Modified FileSortWorker to connect its cancellation state with GroupingEngine
4. Added early termination paths when cancellation is detected
5. Improved logging for cancellation events

These changes prevent the application from crashing when users cancel operations abruptly or close windows during intensive file operations.

Log: Added safe cancellation handling for file grouping operations

Influence:
1. Test canceling file operations during grouping
2. Verify no crashes occur when closing windows during file processing
3. Check termination logs appear correctly
4. Test performance impact of additional cancellation checks

fix: 添加取消检查防止线程崩溃

在GroupingEngine操作中添加取消检查以防止线程被强制停止导致的崩溃。主要变
更包括：
1. 在所有主要操作前添加shouldCancel()检查
2. 引入CancellationCheckCallback机制
3. 修改FileSortWorker以连接其取消状态与GroupingEngine
4. 添加检测到取消时的提前终止路径
5. 改进取消事件的日志记录

这些变更防止了在用户突然取消操作或关闭窗口时应用程序崩溃的问题。

Log: 为文件分组操作添加安全的取消处理功能

Influence:
1. 测试在文件分组过程中取消操作
2. 验证在处理文件时关闭窗口不会导致崩溃
3. 检查终止日志是否正确显示
4. 测试额外取消检查的性能影响

Bug: https://pms.uniontech.com/bug-view-337661.html

## Summary by Sourcery

Add cancellation support to file grouping operations to prevent thread crashes by introducing a cancellation callback, integrating it into FileSortWorker, and adding early exit checks with logging.

New Features:
- Add a CancellationCheckCallback in GroupingEngine to enable cancellation checks
- Expose cancellation callback integration in FileSortWorker to propagate cancellation state

Bug Fixes:
- Prevent application crashes when threads are forcibly stopped or operations are canceled

Enhancements:
- Insert shouldCancel() checks before all major grouping steps with early termination paths
- Improve logging to record cancellation events during grouping and file operations