### PR TITLE
feat: enhance search menu with path grouping options

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
+++ b/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
@@ -25,7 +25,9 @@ DFM_LOG_USE_CATEGORY(DPSEARCH_NAMESPACE)
 
 namespace SearchActionId {
 inline constexpr char kOpenFileLocation[] { "open-file-location" };
-inline constexpr char kSrtPath[] { "sort-by-path" };
+inline constexpr char kSortByPath[] { "sort-by-path" };
+// group by actions
+inline constexpr char kGroupByPath[] { "group-by-path" };
 }
 
 namespace CustomKey {

--- a/src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene_p.h
+++ b/src/plugins/filemanager/dfmplugin-search/menus/searchmenuscene_p.h
@@ -24,6 +24,8 @@ private:
     void createAction(QMenu *menu, const QString &actName, bool isSubAct = false, bool checkable = false);
     void updateMenu(QMenu *menu);
     void updateSortMenu(QMenu *menu);
+    void updateGroupSubMenu(QMenu *menu);
+    void groupByRole(const QString &strategy);
     bool openFileLocation(const QString &path);
     void disableSubScene(DFMBASE_NAMESPACE::AbstractMenuScene *scene, const QString &sceneName);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/pathgroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/pathgroupstrategy.cpp
@@ -54,6 +54,9 @@ QString PathGroupStrategy::getGroupKey(const FileInfoPointer &info) const
 
     QString path = info->urlOf(UrlInfoType::kCustomerStartUrl).path();
     if (path.isEmpty()) {
+        path = info->urlOf(UrlInfoType::kUrl).path();
+    }
+    if (path.isEmpty()) {
         fmWarning() << "PathGroupStrategy: Empty file path for" << info->urlOf(UrlInfoType::kUrl).toString();
         return "other";
     }


### PR DESCRIPTION
1. Renamed kSrtPath to kSortByPath for better clarity
2. Added new kGroupByPath action ID for path-based grouping
3. Implemented updateGroupSubMenu function to manage group-by-path menu entries
4. Added logic to insert path grouping above modified time grouping
5. Removed group-by-created-time option when path grouping is available
6. Implemented groupByRole method to handle group strategy changes
7. Updated PathGroupStrategy to handle empty customer URLs fallback to regular URLs

Log: Added "Group by Path" option in search results context menu

Influence:
1. Test right-click menu in search results for new "Group by Path" option
2. Verify sorting by path still works correctly
3. Check grouping behavior changes when selecting different grouping options
4. Verify fallback to regular URL when customer URL is empty
5. Test menu item positioning and checked states

feat: 增强搜索菜单的路径分组功能

1. 将 kSrtPath 重命名为 kSortByPath 以提高可读性
2. 新增 kGroupByPath 动作ID用于路径分组功能
3. 实现 updateGroupSubMenu 函数来管理按路径分组的菜单项
4. 添加逻辑将在修改时间分组上方插入路径分组选项
5. 路径分组可用时移除按创建时间分组选项
6. 实现 groupByRole 方法处理分组策略变更
7. 更新 PathGroupStrategy 处理空客户URL回退到常规URL的情况

Log: 在搜索结果右键菜单中添加"按路径分组"选项

Influence:
1. 测试搜索结果右键菜单中的新"按路径分组"选项
2. 验证按路径排序功能是否正常工作
3. 检查选择不同分组选项时的分组行为变化
4. 验证客户URL为空时回退到常规URL的处理
5. 测试菜单项位置和选中状态

## Summary by Sourcery

Add "Group by Path" option to search results context menu, rename sort-by-path action for clarity, and enhance path grouping strategy

New Features:
- Add "Group by Path" action and integrate it into search results context menu
- Implement updateGroupSubMenu to position path grouping above modified-time grouping and remove created-time option
- Introduce groupByRole method to apply custom path grouping strategy

Enhancements:
- Rename kSrtPath to kSortByPath and update corresponding menu logic
- Update PathGroupStrategy to fallback to standard URL when customer URL is empty