### PR TITLE
feat: Support Qt 6.10

### DIFF
--- a/src/plugins/desktop/ddplugin-background/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-background/CMakeLists.txt
@@ -25,6 +25,17 @@ include(DFMPluginConfig)
 
 add_library(${BIN_NAME} SHARED ${SRC_FILES})
 
+find_package(Qt6 REQUIRED COMPONENTS Core Gui)
+target_link_libraries(${BIN_NAME} 
+    PUBLIC
+    Qt6::Core
+    Qt6::Gui
+)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+    target_link_libraries(${BIN_NAME} PRIVATE Qt6::GuiPrivate)
+endif()
+
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DESKTOP_DIR})
 

--- a/src/plugins/desktop/ddplugin-canvas/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-canvas/CMakeLists.txt
@@ -25,6 +25,17 @@ add_library(${BIN_NAME}
     ${EXT_FILES}
 )
 
+find_package(Qt6 REQUIRED COMPONENTS Core Gui)
+target_link_libraries(${BIN_NAME} 
+    PUBLIC
+    Qt6::Core
+    Qt6::Gui
+)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+    target_link_libraries(${BIN_NAME} PRIVATE Qt6::GuiPrivate)
+endif()
+
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DESKTOP_DIR})
 

--- a/src/plugins/desktop/ddplugin-core/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-core/CMakeLists.txt
@@ -50,6 +50,17 @@ add_library(${BIN_NAME}
     ${EXT_FILES}
 )
 
+find_package(Qt6 REQUIRED COMPONENTS Core Gui)
+target_link_libraries(${BIN_NAME} 
+    PUBLIC
+    Qt6::Core
+    Qt6::Gui
+)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+    target_link_libraries(${BIN_NAME} PRIVATE Qt6::GuiPrivate)
+endif()
+
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DESKTOP_DIR})
 

--- a/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-organizer/CMakeLists.txt
@@ -44,6 +44,17 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Dtk6::Gui
 )
 
+find_package(Qt6 REQUIRED COMPONENTS Core Gui)
+target_link_libraries(${BIN_NAME} 
+    PUBLIC
+    Qt6::Core
+    Qt6::Gui
+)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+    target_link_libraries(${BIN_NAME} PRIVATE Qt6::GuiPrivate)
+endif()
+
 install(TARGETS ${BIN_NAME}
     LIBRARY DESTINATION ${DFM_PLUGIN_DESKTOP_CORE_DIR}
 )

--- a/src/plugins/desktop/ddplugin-wallpapersetting/CMakeLists.txt
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/CMakeLists.txt
@@ -31,6 +31,17 @@ add_library(${BIN_NAME}
     ${QRCS}
 )
 
+find_package(Qt6 REQUIRED COMPONENTS Core Gui)
+target_link_libraries(${BIN_NAME} 
+    PUBLIC
+    Qt6::Core
+    Qt6::Gui
+)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
+    target_link_libraries(${BIN_NAME} PRIVATE Qt6::GuiPrivate)
+endif()
+
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_DESKTOP_DIR})
 

--- a/src/plugins/filemanager/dfmplugin-workspace/CMakeLists.txt
+++ b/src/plugins/filemanager/dfmplugin-workspace/CMakeLists.txt
@@ -19,6 +19,17 @@ add_library(${BIN_NAME}
     ${WORKSPACE_FILES}
 )
 
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
+target_link_libraries(${BIN_NAME}
+    PUBLIC
+    Qt6::Core
+    Qt6::Widgets
+)
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
+    find_package(Qt6 REQUIRED COMPONENTS WidgetsPrivate)
+    target_link_libraries(${BIN_NAME} PRIVATE Qt6::WidgetsPrivate)
+endif()
+
 set_target_properties(${BIN_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_FILEMANAGER_DIR})
 


### PR DESCRIPTION
Ensure Qt gui and widget private headers can be found out

Log: Fix build on Qt 6.10

## Summary by Sourcery

Link Qt6 Core and Gui/Widgets modules in desktop and filemanager plugins and conditionally include GuiPrivate/WidgetsPrivate headers for Qt 6.10+ to fix build failures.

Bug Fixes:
- Fix build on Qt 6.10 by including private Qt6 GUI and Widgets components

Enhancements:
- Add public linkage to Qt6::Core and Qt6::Gui or Qt6::Widgets in plugins
- Conditionally link Qt6::GuiPrivate or Qt6::WidgetsPrivate when using Qt 6.10 or newer