### PR TITLE
Revert "fix(ddplugin-organizer): ensure new files are organized when organizer restarts"

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -526,10 +526,7 @@ bool NormalizedMode::initialize(CollectionModel *m)
     // creating if there already are files.
     if (!model->files().isEmpty()) {
         fmDebug() << "Found existing files, triggering rebuild";
-        // 这里使用 rebuild(true) 而不是 rebuild() 是为了确保所有文件都被重新整理
-        // 因为当取消了分类之后再创建使用的是上次分类的文件，这样会导致新建的文件没有被整理
-        // 所以确保每次重建的时候都是重新刷新了model中的文件
-        rebuild(true);
+        rebuild();
     }
 
     return true;


### PR DESCRIPTION
This reverts commit 5e6a76e00ab3fe414667ec7213e7eac5b3d8a340.

The Bug that fixed by this PR has been solved by other way.

## Summary by Sourcery

Chores:
- Revert the use of rebuild(true) back to rebuild() in NormalizedMode