### PR TITLE
fix: handle URL fragments in SMB browser navigation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
@@ -131,7 +131,7 @@ bool SmbBrowserEventReceiver::hookCopyFilePath(quint64, const QList<QUrl> &urlLi
         for (const auto &url : std::as_const(urlList)) {
             QUrl orgUrl;
             if (getOriginalUri(url, &orgUrl))
-                pathList << orgUrl.toString();
+                pathList << QUrl::fromPercentEncoding(orgUrl.toString().toUtf8());
         }
     }
 


### PR DESCRIPTION
Fixed URL fragment handling in SMB browser navigation by properly
processing URL fragments when accessing network shares. Previously,
URLs containing fragments (after #) were not correctly handled, causing
navigation issues. The changes include:
1. Modified fragment handling to append fragment content to the path
before mounting
2. Added URL decoding for mount source to handle encoded characters
3. Fixed URL construction after mounting to ensure proper scheme and
path assignment

Log: Fixed SMB share navigation with URL fragments

Influence:
1. Test accessing SMB shares with URLs containing fragments
2. Verify navigation to specific subdirectories using fragment notation
3. Test mounting and browsing shares with special characters in paths
4. Verify error handling when mount operations fail
5. Check history removal functionality for failed mount attempts

fix: 修复SMB浏览器导航中URL片段处理问题

修复了SMB浏览器导航中URL片段的处理问题，通过正确处理访问网络共享时的URL
片段。之前包含片段（#号后内容）的URL未能正确解析，导致导航问题。具体修改
包括：
1. 修改片段处理逻辑，在挂载前将片段内容附加到路径中
2. 添加挂载源的URL解码以处理编码字符
3. 修复挂载后的URL构造，确保正确的方案和路径分配

Log: 修复带URL片段的SMB共享导航问题

Influence:
1. 测试使用包含片段的URL访问SMB共享
2. 验证使用片段表示法导航到特定子目录
3. 测试包含特殊字符路径的共享挂载和浏览
4. 验证挂载操作失败时的错误处理
5. 检查失败挂载尝试的历史记录清除功能

BUG: https://pms.uniontech.com/bug-view-337999.html

## Summary by Sourcery

Fix SMB browser navigation to correctly handle URL fragments, encoded characters, and post-mount URL construction.

Bug Fixes:
- Extract URL fragments and append them to the mount path before mounting SMB shares
- URL-decode the mount source to support encoded characters in share paths
- Construct post-mount URLs with the correct scheme and updated path
- Update error handling and history cleanup to use adjusted URLs on mount failure
- Decode original URIs when copying file paths in the SMB browser event receiver