### PR TITLE
fix: fix copy file path using wrong URL list method

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -213,7 +213,7 @@ void FileOperatorHelper::copyFiles(const FileView *view)
 
 void FileOperatorHelper::copyFilePath(const FileView *view)
 {
-    QList<QUrl> selectedUrls = view->selectedTreeViewUrlList();
+    const QList<QUrl> &selectedUrls = view->selectedUrlList();
     dpfSignalDispatcher->publish(GlobalEventType::kCopyFilePath, selectedUrls);
 }
 


### PR DESCRIPTION
The copyFilePath function was incorrectly using
selectedTreeViewUrlList() instead of selectedUrlList() for retrieving
selected file URLs. This caused the wrong URL list to be used when
copying file paths, potentially leading to incorrect file paths being
copied to clipboard.

The change replaces selectedTreeViewUrlList() with selectedUrlList() to
ensure the correct list of selected file URLs is used for copying file
paths operation.

Log: Fixed issue where copying file paths might use incorrect selection

Influence:
1. Test copying file paths from file manager with single file selection
2. Test copying file paths with multiple file selections
3. Verify copied paths are correct and match the actual selected files
4. Test in both tree view and list view modes to ensure consistency

fix: 修复复制文件路径使用错误URL列表方法的问题

copyFilePath函数错误地使用了selectedTreeViewUrlList()而不是
selectedUrlList()来获取选中的文件URL。这导致在复制文件路径时使用了错误的
URL列表，可能造成复制到剪贴板的文件路径不正确。

此次修改将selectedTreeViewUrlList()替换为selectedUrlList()，确保复制文件
路径操作使用正确的选中文件URL列表。

Log: 修复了复制文件路径可能使用错误选择项的问题

Influence:
1. 测试在文件管理器中选中单个文件时复制文件路径
2. 测试选中多个文件时复制文件路径
3. 验证复制的路径是否正确且与实际选中的文件匹配
4. 在树形视图和列表视图模式下测试以确保一致性

BUG: https://pms.uniontech.com/bug-view-338193.html

## Summary by Sourcery

Bug Fixes:
- Fix copyFilePath retrieving selected file URLs with the wrong method, preventing incorrect file paths from being copied to the clipboard