### PR TITLE
fix: prevent negative free space calculation

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -632,7 +632,7 @@ qint64 DeviceUtils::deviceBytesFree(const QUrl &url)
     auto map = DevProxyMng->queryDeviceInfoByPath(devicePath, true);
     if (map.contains(kSizeFree) && map.value(kSizeFree, 0).toLongLong() > 0)
         return map.value(kSizeFree, 0).toLongLong();
-    if (map.contains(kSizeTotal) && map.contains(kSizeUsed))
+    if (map.contains(kSizeTotal) && map.contains(kSizeUsed) && map.value(kSizeTotal, 0).toLongLong() > 0)
         return map.value(kSizeTotal, 0).toLongLong() - map.value(kSizeUsed, 0).toLongLong();
 
     return DFMIO::DFMUtils::deviceBytesFree(url);


### PR DESCRIPTION
Fixed a potential issue where device free space could be calculated as
negative when total size is zero. Added a check to ensure total size is
greater than zero before performing the subtraction calculation.

Influence:
1. Test with devices that have zero total size to verify no negative
free space values
2. Verify normal free space calculation still works correctly for valid
devices
3. Check that DFMUtils::deviceBytesFree fallback is properly called when
conditions are not met

fix: 防止空闲空间计算出现负值

修复了当设备总大小为0时，空闲空间可能被计算为负值的潜在问题。在进行减法
计算前添加了总大小必须大于零的检查条件。

Influence:
1. 测试总大小为0的设备，验证不会出现负的空闲空间值
2. 验证正常设备的空闲空间计算仍然正确工作
3. 检查当条件不满足时，DFMUtils::deviceBytesFree回退机制是否正确调用

BUG: https://pms.uniontech.com/bug-view-337817.html

## Summary by Sourcery

Bug Fixes:
- Ensure total size is greater than zero before subtracting used space to avoid negative free space values