### PR TITLE
fix: adjust text padding in desktop organizer view

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -45,7 +45,7 @@ using namespace ddplugin_organizer;
 
 #define EDITOR_SHOW_SUFFIX "_d_whether_show_suffix"
 
-const int CollectionItemDelegate::kTextPadding = 2;
+const int CollectionItemDelegate::kTextPadding = 4;
 const int CollectionItemDelegate::kIconSpacing = 2;
 const int CollectionItemDelegate::kIconTopSpacing = 4;
 const int CollectionItemDelegate::kIconBackRadius = 18;

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -1140,7 +1140,19 @@ void CollectionViewPrivate::updateColumnCount(const int &viewWidth, const int &i
         cellWidth = viewWidth;
         columnCount = 1;
     } else {
-        cellWidth = itemWidth;
+        int margin = (availableWidth - columnCount * itemWidth) / (columnCount + 1) / 2;
+        cellWidth = itemWidth + 2 * margin;
+
+        // update viewMargins
+        int leftViewMargin = viewMargins.left() + margin;
+        int rightViewMargin = viewMargins.right() + margin;
+        int unUsedWidth = viewWidth - leftViewMargin - rightViewMargin - columnCount * cellWidth;
+        // try to divide equally
+        leftViewMargin += unUsedWidth / 2;
+        rightViewMargin += unUsedWidth - unUsedWidth / 2;
+
+        viewMargins.setLeft(leftViewMargin);
+        viewMargins.setRight(rightViewMargin);
     }
 
     if (Q_UNLIKELY(cellWidth < 1)) {


### PR DESCRIPTION
Increased text padding from 2px to 4px in CollectionItemDelegate to prevent text truncation in desktop organizer view. The previous padding value was too tight, causing longer text labels to be cut off and not fully visible to users.

Log: Fixed issue with text truncation in desktop organizer view

Influence:
1. Verify all text labels display completely in desktop organizer view
2. Check text alignment and spacing with various label lengths
3. Test with different system font sizes and locales
4. Verify layout stability after text padding adjustment

fix: 调整桌面整理视图中的文本内边距

将CollectionItemDelegate中的文本内边距从2px增加到4px，修复了桌面整理视图 中文本被截断的问题。原先的内边距设置过小，导致较长的文本标签无法完全显示
给用户。

Log: 修复桌面整理视图下文字无法被显示完整的问题

Influence:
1. 验证桌面整理视图中所有文本标签都能完整显示
2. 检查不同长度文本的对齐和间距
3. 测试不同系统字体大小和语言环境下的显示效果
4. 验证调整文本内边距后的布局稳定性

## Summary by Sourcery

Bug Fixes:
- Increase text padding from 2px to 4px to prevent truncation of long text labels in the desktop organizer view