### PR TITLE
fix bugs

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -240,7 +240,10 @@ void RightValueWidget::setCompleteText(const QString &text)
 void RightValueWidget::mouseReleaseEvent(QMouseEvent *event)
 {
     QTextEdit::mouseReleaseEvent(event);
-    Q_EMIT clicked();
+    // Only emit clicked signal when Ctrl key is pressed
+    if (event->modifiers() & Qt::ControlModifier) {
+        Q_EMIT clicked();
+    }
 }
 
 void RightValueWidget::showEvent(QShowEvent *event)

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
@@ -46,7 +46,9 @@ public slots:
 
     void slotFileCountAndSizeChange(qint64 size, int filesCount, int directoryCount);
 
-    void slotFileHide(int state);
+    void slotFileHide(Qt::CheckState state);
+
+    void slotOpenFileLocation();
 
     void imageExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties);
     void videoExtenInfo(const QUrl &url, QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties);
@@ -59,7 +61,7 @@ private:
     DFMBASE_NAMESPACE::KeyValueLabel *fileSize { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *fileCount { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *fileType { nullptr };
-    DFMBASE_NAMESPACE::KeyValueLabel *filePosition { nullptr };
+    DFMBASE_NAMESPACE::KeyValueLabel *fileLocation { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *fileCreated { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *fileModified { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *fileAccessed { nullptr };

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -1140,19 +1140,7 @@ void CollectionViewPrivate::updateColumnCount(const int &viewWidth, const int &i
         cellWidth = viewWidth;
         columnCount = 1;
     } else {
-        int margin = (availableWidth - columnCount * itemWidth) / (columnCount + 1) / 2;
-        cellWidth = itemWidth + 2 * margin;
-
-        // update viewMargins
-        int leftViewMargin = viewMargins.left() + margin;
-        int rightViewMargin = viewMargins.right() + margin;
-        int unUsedWidth = viewWidth - leftViewMargin - rightViewMargin - columnCount * cellWidth;
-        // try to divide equally
-        leftViewMargin += unUsedWidth / 2;
-        rightViewMargin += unUsedWidth - unUsedWidth / 2;
-
-        viewMargins.setLeft(leftViewMargin);
-        viewMargins.setRight(rightViewMargin);
+        cellWidth = itemWidth;
     }
 
     if (Q_UNLIKELY(cellWidth < 1)) {

--- a/src/services/textindex/utils/indexutility.h
+++ b/src/services/textindex/utils/indexutility.h
@@ -7,6 +7,9 @@
 #include "service_textindex_global.h"
 
 #include <QFileInfo>
+#include <QMutex>
+
+#include <dconfig.h>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
@@ -38,6 +41,28 @@ bool checkFileSize(const QFileInfo &fileInfo);
  * @return true if file type is supported and meets size requirements, false otherwise
  */
 bool isSupportedFile(const QString &path);
+
+class AnythingConfigWatcher : public QObject
+{
+    Q_OBJECT
+public:
+    static AnythingConfigWatcher *instance();
+    ~AnythingConfigWatcher() override;
+
+    QStringList defaultAnythingIndexPaths();
+    QStringList defaultAnythingIndexPathsRealtime();
+
+private slots:
+    void handleConfigChanged(const QString &key);
+
+private:
+    explicit AnythingConfigWatcher(QObject *parent = nullptr);
+
+private:
+    DTK_CORE_NAMESPACE::DConfig *cfg { nullptr };
+    QMutex mu;
+    QStringList defaultIndexPath;
+};
 
 }   // namespace IndexUtility
 


### PR DESCRIPTION
## Summary by Sourcery

Fix various UI handling bugs in the property dialog and collection view, improve click behavior for file locations, and add a configuration watcher for dynamic indexing paths in the text index service.

New Features:
- Add slotOpenFileLocation to open the file's folder via DBus or fallback when clicking the location label
- Implement AnythingConfigWatcher singleton to monitor DConf indexing_paths and provide up-to-date default index directories

Bug Fixes:
- Rename filePosition to fileLocation and update related mappings and variable names
- Replace DCheckBox::stateChanged with checkStateChanged and adjust slotFileHide to use Qt::CheckState
- Emit key-value label clicked signal only when Ctrl is pressed

Enhancements:
- Simplify collection view column width calculation by removing custom margin adjustments