### PR TITLE
refactor: replace QReadWriteLock with QMutex in AsyncFileInfo

### DIFF
--- a/src/dfm-base/file/local/private/asyncfileinfo_p.h
+++ b/src/dfm-base/file/local/private/asyncfileinfo_p.h
@@ -21,8 +21,8 @@
 #include <QFuture>
 #include <QQueue>
 #include <QMimeType>
-#include <QReadWriteLock>
-#include <QReadLocker>
+#include <QMutex>
+#include <QMutexLocker>
 
 namespace dfmbase {
 class AsyncFileInfoPrivate
@@ -42,18 +42,18 @@ public:
     QMap<DFileInfo::AttributeExtendID, QVariant> attributesExtend;   // 缓存的fileinfo 扩展信息
     QList<DFileInfo::AttributeExtendID> extendIDs;
     QMimeType mimeType;
-    QReadWriteLock lock;
+    mutable QMutex lock;
     QReadWriteLock iconLock;
     QIcon fileIcon;
     QSharedPointer<InfoDataFuture> mediaFuture { nullptr };
     InfoHelperUeserDataPointer fileCountFuture { nullptr };
     InfoHelperUeserDataPointer updateFileCountFuture { nullptr };
     QMap<FileInfo::FileInfoAttributeID, QVariant> cacheAsyncAttributes;
-    QReadWriteLock notifyLock;
+    mutable QMutex notifyLock;
     QMultiMap<QUrl, QString> notifyUrls;
     quint64 tokenKey { 0 };
     AsyncFileInfo *const q;
-    QReadWriteLock changesLock;
+    mutable QMutex changesLock;
     QList<FileInfo::FileInfoAttributeID> changesAttributes;
 
 public:


### PR DESCRIPTION
Changed synchronization mechanism from QReadWriteLock to QMutex across AsyncFileInfo implementation
Reasons:
1. Simplify locking strategy with single mutex type
2. Reduce potential deadlock risks from mixed lock types
3. Improve thread safety by using more conservative locking
4. Eliminate unnecessary read lock/unlock patterns Key technical changes:
1. Replaced all QReadWriteLock/QReadLocker/QWriteLocker with QMutex/ QMutexLocker
2. Added mutex protection for dfmFileInfo access
3. Simplified lock management in complex operations
4. Removed redundant temporary file info copies

Influence:
1. Test file operations under heavy concurrent access
2. Verify thumbnail generation stability
3. Check performance impact on directory scanning
4. Validate media info attribute updates
5. Confirm notification URL handling correctness
6. Test symlink target resolution
7. Verify executable permission checks

refactor: 在 AsyncFileInfo 中将 QReadWriteLock 替换为 QMutex

变更同步机制，在整个 AsyncFileInfo 实现中将 QReadWriteLock 替换为 QMutex 原因：
1. 使用单一锁类型简化锁定策略
2. 减少混合锁类型导致的潜在死锁风险
3. 通过更保守的锁机制提高线程安全性
4. 消除不必要的读锁/解锁模式 关键技术变更：
1. 将所有 QReadWriteLock/QReadLocker/QWriteLocker 替换为 QMutex/ QMutexLocker
2. 为 dfmFileInfo 访问添加互斥锁保护
3. 简化复杂操作中的锁管理
4. 移除冗余的临时文件信息拷贝

Influence:
1. 在高并发访问下测试文件操作
2. 验证缩略图生成的稳定性
3. 检查对目录扫描的性能影响
4. 验证媒体信息属性更新
5. 确认通知URL处理的正确性
6. 测试符号链接目标解析
7. 验证可执行权限检查

## Summary by Sourcery

Replace QReadWriteLock with QMutex in AsyncFileInfo to simplify locking and improve thread safety

Enhancements:
- Swap all QReadWriteLock/QReadLocker/QWriteLocker usages for QMutex/QMutexLocker in AsyncFileInfo
- Add mutex protection around dfmFileInfo access for safer concurrent operations
- Consolidate complex lock/unlock patterns under a single mutex to streamline lock management
- Remove redundant temporary copies of dfmFileInfo to reduce unnecessary data duplication