### PR TITLE
refactor: simplify splitter animation handling

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
@@ -97,7 +97,6 @@ void TitleBar::onWindowOpened(quint64 windId)
     connect(window, &FileManagerWindow::reqCloseCurrentTab, titleBarWidget, &TitleBarWidget::handleHotketCloseCurrentTab);
     connect(window, &FileManagerWindow::reqActivateTabByIndex, titleBarWidget, &TitleBarWidget::handleHotketActivateTab);
     connect(window, &FileManagerWindow::windowSplitterWidthChanged, titleBarWidget, &TitleBarWidget::handleSplitterAnimation);
-    connect(window, &FileManagerWindow::aboutToPlaySplitterAnimation, titleBarWidget, &TitleBarWidget::handleAboutToPlaySplitterAnim);
 
     if (qAppName() == "dde-file-manager") {
         connect(window, &FileManagerWindow::workspaceInstallFinished, titleBarWidget,

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -104,20 +104,11 @@ void TitleBarWidget::openCustomFixedTabs()
 
 void TitleBarWidget::handleSplitterAnimation(const QVariant &position)
 {
-    int newWidth = qMax(0, 95 - splitterEndValue);
-    if (position == splitterEndValue)
-        splitterEndValue = -1;
-
+    int newWidth = qMax(0, 95 - position.toInt());
     if (newWidth == placeholder->width())
         return;
 
     placeholder->setFixedWidth(newWidth);
-}
-
-void TitleBarWidget::handleAboutToPlaySplitterAnim(int startValue, int endValue)
-{
-    Q_UNUSED(startValue);
-    splitterEndValue = endValue;
 }
 
 void TitleBarWidget::handleHotkeyCtrlF()

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -41,7 +41,6 @@ public:
     void showSearchFilterButton(bool visible);
     void setViewModeState(int mode);
     void handleSplitterAnimation(const QVariant &position);
-    void handleAboutToPlaySplitterAnim(int startValue, int endValue);
 
     int calculateRemainingWidth() const;
 
@@ -100,7 +99,6 @@ private:
     QWidget *placeholder { nullptr };
 
     bool searchButtonSwitchState { false };
-    int splitterEndValue { -1 };
 
     struct TitleBarState
     {


### PR DESCRIPTION
Removed the splitter animation pre-processing logic and simplified the
splitter width calculation. The previous implementation used a two-
step approach with handleAboutToPlaySplitterAnim to cache the end value
and handleSplitterAnimation to calculate the width. Now the width is
calculated directly from the current position parameter, making the code
more straightforward and reducing state management complexity.

Influence:
1. Test window splitter functionality to ensure smooth animation
2. Verify that the title bar placeholder width adjusts correctly during
splitter movement
3. Check that all splitter-related interactions work as expected
4. Test with different splitter positions to ensure width calculations
are accurate

refactor: 简化分隔条动画处理逻辑

移除了分隔条动画的预处理逻辑并简化了分隔条宽度计算。之前的实现使
用两步法，先通过handleAboutToPlaySplitterAnim缓存结束值，再通过
handleSplitterAnimation计算宽度。现在直接根据当前位置参数计算宽度，使代
码更加简洁，减少了状态管理的复杂性。

Influence:
1. 测试窗口分隔条功能，确保动画流畅
2. 验证标题栏占位符宽度在分隔条移动时正确调整
3. 检查所有分隔条相关交互是否正常工作
4. 使用不同的分隔条位置测试，确保宽度计算准确

## Summary by Sourcery

Simplify splitter animation logic by removing pre-processing and state management, and computing placeholder width directly from the current splitter position.

Enhancements:
- Remove handleAboutToPlaySplitterAnim slot and splitterEndValue member variable
- Simplify handleSplitterAnimation to calculate width directly from the position parameter
- Remove connection to the aboutToPlaySplitterAnimation signal