### PR TITLE
chore: bump version to 6.5.98

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.98) unstable; urgency=medium
+
+  * fix bugs 
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 23 Oct 2025 19:58:38 +0800
+
 dde-file-manager (6.5.97) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
6.5.98

Log:

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.5.98