### PR TITLE
fix: update bookmark item editable property on rename

### DIFF
--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -558,6 +558,7 @@ void BookMarkManager::fileRenamed(const QUrl &oldUrl, const QUrl &newUrl)
 
             QVariantMap map {
                 { "Property_Key_Url", newUrl },
+                { "Property_Key_Editable", true }
             };
             dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", oldUrl, map);
 


### PR DESCRIPTION
When a bookmark is renamed, the sidebar item needs to be updated with
the correct editable property. Previously, only the URL was updated
during rename operations, which could cause the sidebar item to
lose its editable state. This change ensures that the bookmark item
maintains its editable property when renamed by explicitly setting
Property_Key_Editable to true during the update process.

Influence:
1. Test renaming bookmarks and verify sidebar items remain editable
2. Check that bookmark functionality works correctly after rename
operations
3. Verify no regression in sidebar item display and behavior

fix: 重命名书签时更新可编辑属性

当书签被重命名时，侧边栏项目需要更新正确的可编辑属性。之前重命名操作仅
更新了URL，这可能导致侧边栏项目失去可编辑状态。此更改通过在更新过程中显
式将Property_Key_Editable设置为true，确保书签项目在重命名时保持其可编辑
属性。

Influence:
1. 测试重命名书签并验证侧边栏项目保持可编辑
2. 检查重命名操作后书签功能是否正常工作
3. 验证侧边栏项目显示和行为无回归问题

BUG: https://pms.uniontech.com/bug-view-338177.html

## Summary by Sourcery

Bug Fixes:
- Ensure sidebar bookmark items retain their editable state after rename operations.