### PR TITLE
fix: resolve file name truncation issue in icon view with tags

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
@@ -181,7 +181,7 @@ QRectF ExpandedItem::textGeometry(int width) const
                         INT_MAX);
 
         QString str = delegate->displayFileName(index);
-        const QList<QRectF> &lines = delegate->calFileNameRect(str, labelRect, option.textElideMode);
+        const QList<QRectF> &lines = delegate->calcFileNameRect(index, labelRect, option.textElideMode);
 
         textBounding = GlobalPrivate::boundingRect(lines);
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.h
@@ -59,7 +59,7 @@ public:
     QWidget *expandedItem() override;
 
     QString displayFileName(const QModelIndex &index) const;
-    QList<QRectF> calFileNameRect(const QString &name, const QRectF &rect, Qt::TextElideMode elideMode) const;
+    QList<QRectF> calcFileNameRect(const QModelIndex &index, const QRectF &rect, Qt::TextElideMode elideMode) const;
 
 private slots:
     void editorFinished();


### PR DESCRIPTION
Modified the file name calculation logic in icon view mode to properly handle tagged files by passing the full model index instead of just file name string to calFileNameRect. This allows the layout system to consider tag markers when calculating text boundaries.

Added hook call to workspace event sequence to apply tag layout modifications, matching the canvas implementation behavior. This ensures consistent text layout between workspace and canvas views.

Log: Fixed issue where file names with tags were incorrectly truncated in icon view

Influence:
1. Verify tagged files display complete names in icon view
2. Check file name layout matches canvas view behavior
3. Test with various length filenames and combinations of tags
4. Verify selection highlighting still works correctly
5. Test with different zoom levels/dpi settings

fix: 修复图标视图下带标记文件名显示不全的问题

修改了图标视图模式下文件名计算的逻辑，原先仅传递文件名字符串，现改为传递
完整的模型索引给calFileNameRect。这使得布局系统能够在计算文本边界时考虑
标记符号的影响。

添加了工作区事件序列的钩子调用以应用标记布局修改，与画布视图的行为保持一
致，确保工作区和画布视图的文本布局一致性。

Log: 修复了图标视图中带标记文件名被错误截断的问题

Influence:
1. 验证带标记文件在图标视图下能完整显示名称
2. 检查文件名布局是否与画布视图行为一致
3. 测试不同长度文件名和各种标记组合的情况
4. 验证选中高亮仍能正常显示
5. 测试不同缩放级别/DPI设置下的显示效果

Bug: https://pms.uniontech.com/bug-view-338177.html

## Summary by Sourcery

Update file name geometry calculation in icon view to use the model index, allowing tag layout modifications via WorkspaceEventSequence and aligning file name rendering with canvas view to prevent tag truncation.

Bug Fixes:
- Resolve file name truncation issue for tagged files in icon view.

Enhancements:
- Unify text layout logic between icon and canvas views by passing the full QModelIndex to calFileNameRect and invoking WorkspaceEventSequence::doIconItemLayoutText.