### PR TITLE
fix: handle virtual root URLs in tab validation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -44,7 +44,7 @@ struct Tab
     QUrl tabUrl;
     QString tabAlias;
     QString uniqueId;
-    QVariant userData;
+    QVariantMap userData;
     bool isInactive { false };
 };
 
@@ -584,7 +584,7 @@ int TabBar::createTab()
     return index;
 }
 
-int TabBar::createInactiveTab(const QUrl &url, const QVariant &userData)
+int TabBar::createInactiveTab(const QUrl &url, const QVariantMap &userData)
 {
     QSignalBlocker blk(this);
     int index = addTab("");
@@ -691,15 +691,15 @@ QString TabBar::tabUniqueId(int index) const
     return d->tabInfo(index).uniqueId;
 }
 
-QVariant TabBar::tabUserData(int index) const
+QVariant TabBar::tabUserData(int index, const QString &key) const
 {
-    return d->tabInfo(index).userData;
+    return d->tabInfo(index).userData.value(key);
 }
 
-void TabBar::setTabUserData(int index, const QVariant &userData)
+void TabBar::setTabUserData(int index, const QString &key, const QVariant &userData)
 {
-    d->updateTabInfo(index, [&userData](Tab &tab) {
-        tab.userData = userData;
+    d->updateTabInfo(index, [&](Tab &tab) {
+        tab.userData[key] = userData;
     });
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
@@ -22,7 +22,7 @@ public:
     ~TabBar() override;
 
     int createTab();
-    int createInactiveTab(const QUrl &url, const QVariant &userData = {});
+    int createInactiveTab(const QUrl &url, const QVariantMap &userData = {});
     void removeTab(int index, int selectIndex = -1);
     void setCurrentUrl(const QUrl &url);
     void closeTab(const QUrl &url);
@@ -32,8 +32,8 @@ public:
     QString tabAlias(int index) const;
     void setTabAlias(int index, const QString &alias);
     QString tabUniqueId(int index) const;
-    QVariant tabUserData(int index) const;
-    void setTabUserData(int index, const QVariant &userData);
+    QVariant tabUserData(int index, const QString &key) const;
+    void setTabUserData(int index, const QString &key, const QVariant &userData);
     bool isInactiveTab(int index) const;
 
 public Q_SLOTS:


### PR DESCRIPTION
Added special handling for virtual root URLs like 'computer:///' in tab
validation logic. Previously, these URLs would trigger the "Directory
not found" error dialog even though they represent valid virtual
locations. The fix checks if a URL is both virtual and a root URL,
allowing these special cases to pass validation without error.

The issue occurred because the file info check fails for virtual root
URLs that don't correspond to physical directories. This ensures proper
handling of system-level virtual directories that should remain as fixed
tabs.

Influence:
1. Test opening and closing tabs with virtual URLs like 'computer:///'
2. Verify that "Directory not found" dialog doesn't appear for valid
virtual roots
3. Test regular file paths still trigger the dialog when directories
are missing
4. Verify tab behavior with mixed virtual and physical directory paths

fix: 修复虚拟根URL在标签页验证中的处理问题

在标签页验证逻辑中添加了对虚拟根URL（如'computer:///'）的特殊处理。之前
这些URL会触发"目录未找到"错误对话框，尽管它们代表有效的虚拟位置。修复后
检查URL是否为虚拟且为根URL，允许这些特殊情况通过验证而不报错。

问题的原因是文件信息检查对于不对应物理目录的虚拟根URL会失败。这确保了对
应该保持为固定标签页的系统级虚拟目录的正确处理。

Influence:
1. 测试使用虚拟URL（如'computer:///'）打开和关闭标签页
2. 验证有效的虚拟根目录不会出现"目录未找到"对话框
3. 测试常规文件路径在目录缺失时仍能正确触发对话框
4. 验证混合虚拟和物理目录路径的标签页行为

## Summary by Sourcery

Bug Fixes:
- Allow virtual root URLs (e.g., computer:///) to pass fixed tab validation without triggering the error dialog