### PR TITLE
6.5.99

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.99) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 24 Oct 2025 10:38:03 +0800
+
 dde-file-manager (6.5.98) unstable; urgency=medium
 
   * fix bugs 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -402,11 +402,12 @@ QVariant FileViewModel::data(const QModelIndex &index, int role) const
         return {};
     }
 
-    // 分组时可能耗时很久，此时若返回数据会导致界面异常
-    if (groupingState() == GroupingState::kGrouping) {
-        fmDebug() << "Current grouping state is grouping, ignore data";
-        return {};
-    }
+    // TODO: ui bug
+    // // 分组时可能耗时很久，此时若返回数据会导致界面异常
+    // if (groupingState() == GroupingState::kGrouping) {
+    //     fmDebug() << "Current grouping state is grouping, ignore data";
+    //     return {};
+    // }
 
     const QModelIndex &parentIndex = index.parent();
 
@@ -1357,7 +1358,7 @@ void FileViewModel::changeGroupingState(GroupingState newState)
 
     groupingStateValue = newState;
     fmDebug() << "Grouping state changed to:" << (newState == GroupingState::kGrouping ? "Grouping" : "Idle") << "for URL:" << dirRootUrl.toString();
-    Q_EMIT groupingStateChanged();
+    Q_EMIT groupingStateChanged(groupingStateValue);
 }
 
 void FileViewModel::closeCursorTimer()

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -116,7 +116,7 @@ public:
 
 Q_SIGNALS:
     void stateChanged();
-    void groupingStateChanged();
+    void groupingStateChanged(GroupingState);
     void renameFileProcessStarted();
     void selectAndEditFile(const QUrl &url);
     void traverPrehandle(const QUrl &url, const QModelIndex &index, FileView *view);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2296,6 +2296,7 @@ void FileView::initializeConnect()
     connect(model(), &FileViewModel::dataChanged, this, &FileView::updateOneView);
     connect(model(), &FileViewModel::renameFileProcessStarted, this, &FileView::onRenameProcessStarted);
     connect(model(), &FileViewModel::aboutToSwitchToListView, this, &FileView::onAboutToSwitchListView);
+
     connect(selectionModel(), &QItemSelectionModel::selectionChanged, this, &FileView::onSelectionChanged);
 
     connect(this, &DListView::rowCountChanged, this, &FileView::onRowCountChanged, Qt::QueuedConnection);


### PR DESCRIPTION
## Summary by Sourcery

Emit grouping state changes with the current state parameter, temporarily disable the grouping data guard to address a UI issue, and update the signal signature and related emits accordingly.

Enhancements:
- Comment out the early return in FileViewModel::data during grouping to avoid UI glitches
- Emit groupingStateChanged with the new GroupingState parameter when the state changes

Chores:
- Add a missing line break in FileView connection setup