### PR TITLE
chore: add dfm-trash script for trash handling

### DIFF
--- a/debian/dde-desktop.install
+++ b/debian/dde-desktop.install
@@ -7,3 +7,4 @@ usr/share/dbus-1/services/com.deepin.dde.desktop.service
 usr/share/dbus-1/services/org.freedesktop.FileManager.service
 usr/share/dde-shell/*/*.json
 usr/lib/*/dde-shell/*.so
+usr/bin/dfm-trash.sh

--- a/src/external/dde-shell-plugins/panel-desktop/CMakeLists.txt
+++ b/src/external/dde-shell-plugins/panel-desktop/CMakeLists.txt
@@ -43,6 +43,7 @@ ds_install_package(PACKAGE org.deepin.ds.desktop TARGET ds-panel-desktop)
 install(FILES data/com.deepin.dde.desktop.service DESTINATION share/dbus-1/services)
 
 # computer and trash
+install(FILES data/applications/dfm-trash.sh DESTINATION bin/)
 install(FILES data/applications/dde-computer.desktop DESTINATION share/applications/)
 install(FILES data/applications/dde-trash.desktop DESTINATION share/applications/)
 install(FILES data/applications/dde-home.desktop DESTINATION share/applications/)

--- a/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-trash.desktop
+++ b/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-trash.desktop
@@ -2,7 +2,7 @@
 Actions=clean-trash;
 Categories=System;
 Comment=Open trash.
-Exec=xdg-open trash:///
+Exec=dfm-trash.sh %F
 GenericName=Open Trash.
 Icon=user-trash
 Name=Trash

--- a/src/external/dde-shell-plugins/panel-desktop/data/applications/dfm-trash.sh
+++ b/src/external/dde-shell-plugins/panel-desktop/data/applications/dfm-trash.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# 检查是否没有传入任何文件
+if [ $# -eq 0 ]; then
+    exec xdg-open trash:///
+    exit 0
+fi
+
+# 将传入的文件路径转换为 JSON 数组格式
+SOURCES_JSON=""
+for file in "$@"; do
+    if [[ -n "$SOURCES_JSON" ]]; then
+        SOURCES_JSON="$SOURCES_JSON,"
+    fi
+    # 对路径进行 JSON 转义
+    ESCAPED_FILE=$(printf '%s' "$file" | jq -R .)
+    SOURCES_JSON="$SOURCES_JSON$ESCAPED_FILE"
+done
+
+# 构建完整的 JSON
+JSON_DATA="{\"action\":\"trash\",\"params\":{\"sources\":[$SOURCES_JSON]}}"
+
+# 执行主脚本
+exec file-manager.sh --event "$JSON_DATA"


### PR DESCRIPTION
Added dfm-trash.sh script to handle trash operations with file
parameters support. The script replaces direct xdg-open call in dde-
trash.desktop to properly handle file arguments when moving files to
trash. The script checks if files are provided and converts them to JSON
format for file-manager.sh event processing.

Log: Updated trash desktop entry to use dfm-trash.sh script for better
file handling

Influence:
1. Test clicking trash icon without files - should open trash folder
2. Test dragging files to trash - should move files to trash properly
3. Verify script handles special characters in file paths correctly
4. Test with multiple files selected for trash operation
5. Verify JSON data format is correctly generated and passed to file
manager

chore: 添加 dfm-trash 脚本用于回收站处理

新增 dfm-trash.sh 脚本来处理带文件参数的回收站操作。该脚本替换了 dde-
trash.desktop 中的直接 xdg-open 调用，以便在将文件移动到回收站时正确
处理文件参数。脚本会检查是否提供了文件，并将其转换为 JSON 格式供 file-
manager.sh 事件处理。

Log: 更新回收站桌面条目以使用 dfm-trash.sh 脚本实现更好的文件处理

Influence:
1. 测试点击回收站图标（无文件）- 应打开回收站文件夹
2. 测试拖拽文件到回收站 - 应正确将文件移动到回收站
3. 验证脚本是否正确处理文件路径中的特殊字符
4. 测试选择多个文件进行回收站操作
5. 验证 JSON 数据格式是否正确生成并传递给文件管理器

BUG: https://pms.uniontech.com/bug-view-338323.html
BUG: https://pms.uniontech.com/bug-view-336485.html

## Summary by Sourcery

Add a dedicated trash handling script and update the desktop entry and build configuration to provide proper file-parameter support and JSON-based event dispatch for trash operations

New Features:
- Add dfm-trash.sh script to handle trash operations with file arguments

Enhancements:
- Replace direct xdg-open call in dde-trash.desktop to invoke dfm-trash.sh
- Serialize provided file paths into JSON and dispatch via file-manager.sh

Build:
- Install dfm-trash.sh via CMakeLists.txt