### PR TITLE
fix: correct Lao translation for "Disks" term

### DIFF
--- a/translations/dde-file-manager_lo.ts
+++ b/translations/dde-file-manager_lo.ts
@@ -40,7 +40,7 @@
     <message>
         <location filename="../src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp" line="148"/>
         <source>Disks</source>
-        <translation>ແຜ່ນໄດສ്രິບ</translation>
+        <translation>ລາຍຊື່ດິສກ໌</translation>
     </message>
 </context>
 <context>
@@ -4222,7 +4222,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp" line="375"/>
         <source>Disks</source>
-        <translation>ឌីសខាងលីច</translation>
+        <translation>ລາຍຊື່ດິສກ໌</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fixed incorrect Lao translations for the term "Disks" in two locations
within the file manager. The previous translations were using Khmer
script instead of proper Lao script, which could cause confusion for
Lao language users. Updated both instances to use the correct Lao term
"ລາຍຊດສກ" (disk list) consistently throughout the application.

Log: Fixed Lao language translation for disk-related terms

Influence:
1. Verify that "Disks" is now displayed correctly in Lao language
interface
2. Check both locations where disk terminology appears in the file
manager
3. Test with Lao language settings to ensure proper rendering
4. Confirm consistency across different parts of the application
5. Validate that the translation matches Lao language standards

fix: 修正老挝语中"磁盘"术语的翻译

修复了文件管理器中两处"Disks"术语的错误老挝语翻译。之前的翻译使用了高棉
文字符而非正确的老挝文字符，这可能会给老挝语用户造成混淆。已将两个实例统
一更新为正确的老挝语术语"ລາຍຊດສກ"（磁盘列表），确保在整个应用程序中保持
一致。

Log: 修复了磁盘相关术语的老挝语翻译

Influence:
1. 验证老挝语界面中"Disks"现在是否正确显示
2. 检查文件管理器中出现磁盘术语的两个位置
3. 使用老挝语设置测试以确保正确渲染
4. 确认应用程序不同部分的一致性
5. 验证翻译是否符合老挝语标准

BUG: https://pms.uniontech.com/bug-view-338519.html

## Summary by Sourcery

Bug Fixes:
- Use correct Lao script for the term 'Disks' in file manager translations