### PR TITLE
fix: optimize file grouping UI painting logic

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
@@ -32,7 +32,7 @@ static constexpr int kSortToolHMargin { 6 };
 static constexpr int kSortToolVMargin { 9 };
 static constexpr char kItemRole[] = "item-role";
 
-namespace GroupStrategty {
+namespace GroupStrategy {
 inline constexpr char kNoGroup[] { "NoGroupStrategy" };
 inline constexpr char kName[] { "Name" };
 inline constexpr char kSize[] { "Size" };
@@ -41,21 +41,21 @@ inline constexpr char kCreatedTime[] { "CreatedTime" };
 inline constexpr char kType[] { "Type" };
 inline constexpr char kCustomPath[] { "CustomPath" };
 inline constexpr char kCustomTime[] { "CustomTime" };
-}   // namespace GroupStrategty
+}   // namespace GroupStrategy
 
 // TODO: This is workaround
 static QString roleToGroupingStrategy(const DFMGLOBAL_NAMESPACE::ItemRoles &role)
 {
     static const QHash<DFMGLOBAL_NAMESPACE::ItemRoles, QString> kMapping = {
-        { kItemFileDisplayNameRole, GroupStrategty::kName },
-        { kItemFileLastModifiedRole, GroupStrategty::kModifiedTime },
-        { kItemFileCreatedRole, GroupStrategty::kCreatedTime },
-        { kItemFileSizeRole, GroupStrategty::kSize },
-        { kItemFileMimeTypeRole, GroupStrategty::kType },
-        { kItemFileOriginalPath, GroupStrategty::kCustomPath },
-        { kItemFilePathRole, GroupStrategty::kCustomPath },
-        { kItemFileDeletionDate, GroupStrategty::kCustomTime },
-        { kItemFileLastReadRole, GroupStrategty::kCustomTime }
+        { kItemFileDisplayNameRole, GroupStrategy::kName },
+        { kItemFileLastModifiedRole, GroupStrategy::kModifiedTime },
+        { kItemFileCreatedRole, GroupStrategy::kCreatedTime },
+        { kItemFileSizeRole, GroupStrategy::kSize },
+        { kItemFileMimeTypeRole, GroupStrategy::kType },
+        { kItemFileOriginalPath, GroupStrategy::kCustomPath },
+        { kItemFilePathRole, GroupStrategy::kCustomPath },
+        { kItemFileDeletionDate, GroupStrategy::kCustomTime },
+        { kItemFileLastReadRole, GroupStrategy::kCustomTime }
     };
 
     return kMapping.value(role, "NoGroupStrategy");

--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -48,8 +48,8 @@ enum class ModelState : uint8_t {
 };
 
 enum class GroupingState : uint8_t {
-    kIdle,       // 未在分组或分组已完成
-    kGrouping    // 正在执行分组操作
+    kIdle,   // 未在分组或分组已完成
+    kGrouping   // 正在执行分组操作
 };
 #ifdef DTKWIDGET_CLASS_DSizeMode
 inline constexpr int kCompactIconViewSpacing { 0 };
@@ -88,7 +88,7 @@ inline constexpr int kMaxTabCount { 8 };
 // view select box
 inline constexpr int kSelectBoxLineWidth { 2 };
 
-namespace GroupStrategty {
+namespace GroupStrategy {
 inline constexpr char kNoGroup[] { "NoGroupStrategy" };
 inline constexpr char kName[] { "Name" };
 inline constexpr char kSize[] { "Size" };
@@ -97,7 +97,7 @@ inline constexpr char kCreatedTime[] { "CreatedTime" };
 inline constexpr char kType[] { "Type" };
 inline constexpr char kCustomPath[] { "CustomPath" };
 inline constexpr char kCustomTime[] { "CustomTime" };
-}   // namespace GroupStrategty
+}   // namespace GroupStrategy
 namespace PropertyKey {
 inline constexpr char kScheme[] { "Property_Key_Scheme" };
 inline constexpr char kKeepShow[] { "Property_Key_KeepShow" };

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
@@ -687,20 +687,20 @@ bool GroupingEngine::isGroupVisibleWithConversion(const QString &groupKey,
 
     // Check if this is one of the built-in strategies that only check for non-empty lists
     // These strategies' isGroupVisible simply returns !infos.isEmpty()
-    if (strategyName == GroupStrategty::kName
-        || strategyName == GroupStrategty::kSize
-        || strategyName == GroupStrategty::kType
-        || strategyName == GroupStrategty::kModifiedTime
-        || strategyName == GroupStrategty::kCreatedTime
-        || strategyName == GroupStrategty::kCustomPath
-        || strategyName == GroupStrategty::kCustomTime) {
+    if (strategyName == GroupStrategy::kName
+        || strategyName == GroupStrategy::kSize
+        || strategyName == GroupStrategy::kType
+        || strategyName == GroupStrategy::kModifiedTime
+        || strategyName == GroupStrategy::kCreatedTime
+        || strategyName == GroupStrategy::kCustomPath
+        || strategyName == GroupStrategy::kCustomTime) {
         fmDebug() << "GroupingEngine: Fast path for built-in strategy" << strategyName
                   << "- skipping file info conversion";
         return !groupFiles.isEmpty();
     }
 
     // For NoGroupStrategy, it always returns false (groups are not visible in no-group mode)
-    if (strategyName == GroupStrategty::kNoGroup) {
+    if (strategyName == GroupStrategy::kNoGroup) {
         fmDebug() << "GroupingEngine: NoGroupStrategy always returns false for group visibility";
         return false;
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingfactory.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingfactory.cpp
@@ -18,21 +18,21 @@ AbstractGroupStrategy *GroupingFactory::createStrategy(const QString &strategyNa
 {
     fmDebug() << "GroupingFactory: Creating strategy for name:" << strategyName;
 
-    if (strategyName == GroupStrategty::kNoGroup) {
+    if (strategyName == GroupStrategy::kNoGroup) {
         return new NoGroupStrategy(parent);
-    } else if (strategyName == GroupStrategty::kName) {
+    } else if (strategyName == GroupStrategy::kName) {
         return new NameGroupStrategy(parent);
-    } else if (strategyName == GroupStrategty::kSize) {
+    } else if (strategyName == GroupStrategy::kSize) {
         return new SizeGroupStrategy(parent);
-    } else if (strategyName == GroupStrategty::kModifiedTime) {
+    } else if (strategyName == GroupStrategy::kModifiedTime) {
         return new TimeGroupStrategy(TimeGroupStrategy::kModificationTime, parent);
-    } else if (strategyName == GroupStrategty::kCreatedTime) {
+    } else if (strategyName == GroupStrategy::kCreatedTime) {
         return new TimeGroupStrategy(TimeGroupStrategy::kCreationTime, parent);
-    } else if (strategyName == GroupStrategty::kType) {
+    } else if (strategyName == GroupStrategy::kType) {
         return new TypeGroupStrategy(parent);
-    } else if (strategyName == GroupStrategty::kCustomPath) {
+    } else if (strategyName == GroupStrategy::kCustomPath) {
         return new PathGroupStrategy(parent);
-    } else if (strategyName == GroupStrategty::kCustomTime) {
+    } else if (strategyName == GroupStrategy::kCustomTime) {
         return new TimeGroupStrategy(TimeGroupStrategy::kCustomTime);
     } else {
         fmWarning() << "GroupingFactory: Unknown strategy name:" << strategyName;

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/namegroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/namegroupstrategy.cpp
@@ -104,7 +104,7 @@ bool NameGroupStrategy::isGroupVisible(const QString &groupKey, const QList<File
 
 QString NameGroupStrategy::getStrategyName() const
 {
-    return GroupStrategty::kName;
+    return GroupStrategy::kName;
 }
 
 QString NameGroupStrategy::classifyFirstCharacter(const QChar &ch) const

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/nogroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/nogroupstrategy.cpp
@@ -59,7 +59,7 @@ bool NoGroupStrategy::isGroupVisible(const QString &groupKey, const QList<FileIn
 QString NoGroupStrategy::getStrategyName() const
 {
     // Return localized strategy name
-    return GroupStrategty::kNoGroup;
+    return GroupStrategy::kNoGroup;
 }
 
 DPWORKSPACE_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/pathgroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/pathgroupstrategy.cpp
@@ -118,7 +118,7 @@ bool PathGroupStrategy::isGroupVisible(const QString &groupKey, const QList<File
 
 QString PathGroupStrategy::getStrategyName() const
 {
-    return GroupStrategty::kCustomPath;
+    return GroupStrategy::kCustomPath;
 }
 
 QString PathGroupStrategy::classifyByPath(const QString &path) const

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/sizegroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/sizegroupstrategy.cpp
@@ -105,7 +105,7 @@ bool SizeGroupStrategy::isGroupVisible(const QString &groupKey, const QList<File
 
 QString SizeGroupStrategy::getStrategyName() const
 {
-    return GroupStrategty::kSize;
+    return GroupStrategy::kSize;
 }
 
 QString SizeGroupStrategy::classifyBySize(qint64 size) const

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/timegroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/timegroupstrategy.cpp
@@ -165,11 +165,11 @@ bool TimeGroupStrategy::isGroupVisible(const QString &groupKey, const QList<File
 QString TimeGroupStrategy::getStrategyName() const
 {
     if (m_timeType == kModificationTime) {
-        return GroupStrategty::kModifiedTime;
+        return GroupStrategy::kModifiedTime;
     } else if (m_timeType == kCreationTime) {
-        return GroupStrategty::kCreatedTime;
+        return GroupStrategy::kCreatedTime;
     } else {
-        return GroupStrategty::kCustomTime;
+        return GroupStrategy::kCustomTime;
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/typegroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/typegroupstrategy.cpp
@@ -111,7 +111,7 @@ bool TypeGroupStrategy::isGroupVisible(const QString &groupKey, const QList<File
 
 QString TypeGroupStrategy::getStrategyName() const
 {
-    return GroupStrategty::kType;
+    return GroupStrategy::kType;
 }
 
 QString TypeGroupStrategy::mapMimeTypeToGroup(const QString &mimeType) const

--- a/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
@@ -207,42 +207,42 @@ bool SortAndDisplayMenuScene::triggered(QAction *action)
             // group by none
             if (actionId == ActionID::kGroupByNone) {
                 fmInfo() << "Setting group by none";
-                d->groupByStrategy(GroupStrategty::kNoGroup);
+                d->groupByStrategy(GroupStrategy::kNoGroup);
                 return true;
             }
 
             // group by name
             if (actionId == ActionID::kGroupByName) {
                 fmInfo() << "Grouping by name";
-                d->groupByStrategy(GroupStrategty::kName);
+                d->groupByStrategy(GroupStrategy::kName);
                 return true;
             }
 
             // group by time modified
             if (actionId == ActionID::kGroupByModified) {
                 fmInfo() << "Grouping by time modified";
-                d->groupByStrategy(GroupStrategty::kModifiedTime);
+                d->groupByStrategy(GroupStrategy::kModifiedTime);
                 return true;
             }
 
             // group by time created
             if (actionId == ActionID::kGroupByCreated) {
                 fmInfo() << "Grouping by time created";
-                d->groupByStrategy(GroupStrategty::kCreatedTime);   // TimeStrategy handles both
+                d->groupByStrategy(GroupStrategy::kCreatedTime);   // TimeStrategy handles both
                 return true;
             }
 
             // group by size
             if (actionId == ActionID::kGroupBySize) {
                 fmInfo() << "Grouping by size";
-                d->groupByStrategy(GroupStrategty::kSize);
+                d->groupByStrategy(GroupStrategy::kSize);
                 return true;
             }
 
             // group by type
             if (actionId == ActionID::kGroupByType) {
                 fmInfo() << "Grouping by type";
-                d->groupByStrategy(GroupStrategty::kType);
+                d->groupByStrategy(GroupStrategy::kType);
                 return true;
             }
         }
@@ -432,22 +432,22 @@ void SortAndDisplayMenuScenePrivate::updateEmptyAreaActionState()
     QString currentStrategy = view->model()->groupingStrategy();
     fmDebug() << "Current grouping strategy:" << currentStrategy;
 
-    if (currentStrategy == GroupStrategty::kNoGroup) {
+    if (currentStrategy == GroupStrategy::kNoGroup) {
         predicateAction[ActionID::kGroupByNone]->setChecked(true);
         fmDebug() << "Set group by none action as checked";
-    } else if (currentStrategy == GroupStrategty::kName) {
+    } else if (currentStrategy == GroupStrategy::kName) {
         predicateAction[ActionID::kGroupByName]->setChecked(true);
         fmDebug() << "Set group by name action as checked";
-    } else if (currentStrategy == GroupStrategty::kModifiedTime) {
+    } else if (currentStrategy == GroupStrategy::kModifiedTime) {
         predicateAction[ActionID::kGroupByModified]->setChecked(true);
         fmDebug() << "Set group by time modified action as checked";
-    } else if (currentStrategy == GroupStrategty::kCreatedTime) {
+    } else if (currentStrategy == GroupStrategy::kCreatedTime) {
         predicateAction[ActionID::kGroupByCreated]->setChecked(true);
         fmDebug() << "Set group by time created action as checked";
-    } else if (currentStrategy == GroupStrategty::kSize) {
+    } else if (currentStrategy == GroupStrategy::kSize) {
         predicateAction[ActionID::kGroupBySize]->setChecked(true);
         fmDebug() << "Set group by size action as checked";
-    } else if (currentStrategy == GroupStrategty::kType) {
+    } else if (currentStrategy == GroupStrategy::kType) {
         predicateAction[ActionID::kGroupByType]->setChecked(true);
         fmDebug() << "Set group by type action as checked";
     } else {

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -1250,7 +1250,7 @@ void FileViewModel::initFilterSortWork()
     Qt::SortOrder order = static_cast<Qt::SortOrder>(WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "sortOrder", Qt::SortOrder::AscendingOrder).toInt());
     ItemRoles role = static_cast<ItemRoles>(WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "sortRole", kItemFileDisplayNameRole).toInt());
     // get group config
-    QString groupStrategy = WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "groupStrategy", GroupStrategty::kNoGroup).toString();
+    QString groupStrategy = WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "groupStrategy", GroupStrategy::kNoGroup).toString();
     Qt::SortOrder groupOrder = static_cast<Qt::SortOrder>(WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, "groupingOrder", Qt::AscendingOrder).toInt());
     const QString &expandsionKey = QString("groupExpansion.%1").arg(groupStrategy);
     const auto &expansionStates = WorkspaceHelper::instance()->getFileViewStateValue(dirRootUrl, expandsionKey).toHash();

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -402,13 +402,6 @@ QVariant FileViewModel::data(const QModelIndex &index, int role) const
         return {};
     }
 
-    // TODO: ui bug
-    // // 分组时可能耗时很久，此时若返回数据会导致界面异常
-    // if (groupingState() == GroupingState::kGrouping) {
-    //     fmDebug() << "Current grouping state is grouping, ignore data";
-    //     return {};
-    // }
-
     const QModelIndex &parentIndex = index.parent();
 
     if (filterSortWorker.isNull())

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -108,7 +108,7 @@ FileSortWorker::GroupingOpt FileSortWorker::setGroupArguments(const Qt::SortOrde
     if (!currentStrategy) {
         return FileSortWorker::GroupingOpt::kGroupingOptNone;
     }
-    isCurrentGroupingEnabled = !(currentStrategy->getStrategyName() == GroupStrategty::kNoGroup);
+    isCurrentGroupingEnabled = !(currentStrategy->getStrategyName() == GroupStrategy::kNoGroup);
     groupExpansionStates.clear();
     for (const auto &key : expandStates.keys()) {
         groupExpansionStates.insert(key, expandStates.value(key).toBool());
@@ -283,7 +283,7 @@ Qt::SortOrder FileSortWorker::getSortOrder() const
 QString FileSortWorker::getGroupStrategyName() const
 {
     if (!currentStrategy) {
-        return GroupStrategty::kNoGroup;
+        return GroupStrategy::kNoGroup;
     }
 
     return currentStrategy->getStrategyName();

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/workspacehelper.cpp
@@ -330,7 +330,7 @@ void WorkspaceHelper::setGroupingStrategy(quint64 windowId, const QString &strat
         // Always set the strategy first (including "NoGroupStrategy")
         if (oldStrategy == strategyName) {
             // User clicked the same strategy - toggle sort order (unless it's NoGroupStrategy)
-            if (strategyName != GroupStrategty::kNoGroup) {
+            if (strategyName != GroupStrategy::kNoGroup) {
                 order = (order == Qt::AscendingOrder) ? Qt::DescendingOrder : Qt::AscendingOrder;
                 fmInfo() << "Toggling grouping order for strategy:" << strategyName
                          << "to" << (order == Qt::AscendingOrder ? "Ascending" : "Descending");

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1313,7 +1313,7 @@ bool FileView::isGroupedView() const
 {
     const auto strategyName = model()->groupingStrategy();
 
-    if (strategyName.isEmpty() || strategyName == GroupStrategty::kNoGroup)
+    if (strategyName.isEmpty() || strategyName == GroupStrategy::kNoGroup)
         return false;
 
     return true;
@@ -2181,8 +2181,8 @@ void FileView::paintEvent(QPaintEvent *event)
     // 从一种分组策略切换到另一种分组策略时允许绘制,保持流畅性
     if (model()->groupingState() == GroupingState::kGrouping) {
         QString currentStrategy = model()->groupingStrategy();
-        bool isFromNoGroupToGrouped = (d->previousGroupStrategy == GroupStrategty::kNoGroup
-                                       && currentStrategy != GroupStrategty::kNoGroup);
+        bool isFromNoGroupToGrouped = (d->previousGroupStrategy == GroupStrategy::kNoGroup
+                                       && currentStrategy != GroupStrategy::kNoGroup);
         if (isFromNoGroupToGrouped) {
             fmDebug() << "Skipping paint during initial grouping from none to:" << currentStrategy;
             return;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -368,7 +368,7 @@ void FileViewPrivate::adjustHeaderLayoutMargin(const QString &strategyName)
         return;
 
     // Determine margin based on grouping state
-    bool isGrouped = strategyName != GroupStrategty::kNoGroup;
+    bool isGrouped = strategyName != GroupStrategy::kNoGroup;
     int bottomMargin = isGrouped ? 0 : 10;
 
     headerLayout->setContentsMargins(0, 0, 0, bottomMargin);
@@ -382,7 +382,7 @@ void FileViewPrivate::adjustIconModeSpacing(const QString &strategyName)
         return;
 
     // Determine margin based on grouping state
-    bool isGrouped = strategyName != GroupStrategty::kNoGroup;
+    bool isGrouped = strategyName != GroupStrategy::kNoGroup;
     // In grouped icon mode, set spacing=0 to let delegate control spacing via sizeHint
     if (isGrouped) {
         q->setSpacing(0);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
@@ -90,6 +90,7 @@ class FileViewPrivate
 
     bool itemsExpandable { false };
     std::atomic_bool isShowSmbMountError { false };
+    QString previousGroupStrategy { GroupStrategty::kNoGroup };
 
     explicit FileViewPrivate(FileView *qq);
     int iconModeColumnCount(int itemWidth = 0) const;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
@@ -90,7 +90,7 @@ class FileViewPrivate
 
     bool itemsExpandable { false };
     std::atomic_bool isShowSmbMountError { false };
-    QString previousGroupStrategy { GroupStrategty::kNoGroup };
+    QString previousGroupStrategy { GroupStrategy::kNoGroup };
 
     explicit FileViewPrivate(FileView *qq);
     int iconModeColumnCount(int itemWidth = 0) const;


### PR DESCRIPTION
1. Removed commented-out TODO section about grouping state check
2. Added tracking of previous grouping strategy in FileView
3. Improved paint event handling during grouping operations
4. Now only skips painting when switching from no-grouping to grouping state
5. Maintains painting during group-to-group strategy changes for better UX

Log: Fixed UI painting issues during file grouping operations

Influence:
1. Test switching between different grouping strategies
2. Verify UI responsiveness during grouping operations
3. Check visual transitions when toggling grouping on/off
4. Validate stability when rapidly changing grouping modes
5. Confirm no visual artifacts appear during grouping animations

fix: 优化文件分组时的UI绘制逻辑

1. 移除了关于分组状态检查的注释代码
2. 在FileView中添加了对之前分组策略的跟踪
3. 改进了分组操作期间的绘制事件处理
4. 现在仅在从无分组切换到分组状态时跳过绘制
5. 在分组策略间切换时保持绘制以获得更好的用户体验

Log: 修复了文件分组操作期间的UI绘制问题

Influence:
1. 测试不同分组策略间的切换
2. 验证分组操作期间的UI响应速度
3. 检查分组开关时的视觉过渡效果
4. 验证快速更改分组模式时的稳定性
5. 确认分组动画期间不会出现视觉异常

## Summary by Sourcery

Optimize UI painting during file grouping by tracking previous grouping state and refining paintEvent logic to only skip rendering during the initial grouping transition while allowing smooth repaints for subsequent strategy changes

Bug Fixes:
- Fix UI painting issues during file grouping operations

Enhancements:
- Track previous grouping strategy in FileView to distinguish initial grouping from strategy changes
- Refine paintEvent to skip rendering only when switching from no grouping to grouping and allow painting during group-to-group transitions

Chores:
- Remove obsolete commented-out grouping state check in FileViewModel