### PR TITLE
fix: handle mount point changes in crumb bar

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.h
+++ b/src/dfm-base/base/device/deviceproxymanager.h
@@ -57,6 +57,8 @@ Q_SIGNALS:
     void devSizeChanged(const QString &id, qint64 total, qint64 avai);
     void mountPointAboutToAdded(QStringView mpt);
     void mountPointAboutToRemoved(QStringView mpt);
+    void mountPointAdded(QStringView mpt);
+    void mountPointRemoved(QStringView mpt);
 
     void blockDevPropertyChanged(const QString &id, const QString &property, const QVariant &val);
     void blockDriveAdded();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
@@ -14,6 +14,7 @@
 #include <dfm-base/base/standardpaths.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
 #include <dfm-base/utils/fileutils.h>
 
 #include <dfm-framework/event/event.h>
@@ -156,6 +157,12 @@ void CrumbBarPrivate::initConnections()
                        setClickableAreaEnabled(enabled);
                    });
     }
+
+    q->connect(DevProxyMng, &DeviceProxyManager::mountPointAdded, q,
+               [this](const QStringView &mpt) {
+                   if (lastUrl.path() == mpt)
+                       q->onUrlChanged(lastUrl);
+               });
 }
 
 void CrumbBarPrivate::appendWidget(QWidget *widget, int stretch)


### PR DESCRIPTION
Fixed an issue where the crumb bar would not update properly when
a mount point was about to be added. Added a connection to the
DeviceProxyManager's mountPointAboutToAdded signal to refresh the crumb
bar when the current directory matches the mount point being added.

This ensures that the breadcrumb navigation correctly reflects the
current file system state when external devices are mounted, preventing
stale path displays.

Influence:
1. Test mounting external devices while viewing directories
2. Verify crumb bar updates correctly when mount points change
3. Check that navigation remains accurate after device connections
4. Test with various storage devices and mount scenarios

fix: 处理挂载点变化时的面包屑栏更新

修复了当挂载点即将添加时面包屑栏无法正确更新的问题。添加了与
DeviceProxyManager的mountPointAboutToAdded信号的连接，当当前目录与即将添
加的挂载点匹配时刷新面包屑栏。

这确保了当外部设备挂载时，面包屑导航能正确反映当前文件系统状态，防止显示
过时的路径信息。

Influence:
1. 测试在查看目录时挂载外部设备
2. 验证挂载点变化时面包屑栏是否正确更新
3. 检查设备连接后导航是否保持准确
4. 使用各种存储设备和挂载场景进行测试

BUG: https://pms.uniontech.com/bug-view-338073.html

## Summary by Sourcery

Refresh the breadcrumb navigation when external devices are mounted by restructuring the signal emission in DeviceProxyManager and having CrumbBar listen for mountPointAboutToAdded to update when relevant mount points change.

New Features:
- Add CrumbBar connection to DeviceProxyManager's mountPointAboutToAdded signal to refresh UI on mount additions

Bug Fixes:
- Ensure crumb bar updates correctly when new external mount points are added

Enhancements:
- Move mountPointAboutToAdded signal emission in DeviceProxyManager to after updating mount lists to prevent potential deadlocks