### PR TITLE
fix: fix editor background transparency issue in file manager

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -132,6 +132,10 @@ QWidget *ComputerItemDelegate::createEditor(QWidget *parent, const QStyleOptionV
     editor->setFrame(false);
     editor->setTextMargins(0, topMargin, 0, 0);
     editor->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+    // 重新设置调色板颜色值，使得背景色正确渲染，而不是保持透明状态。
+    auto p = editor->palette();
+    p.setColor(QPalette::Button, p.color(QPalette::Button));
+    editor->setPalette(p);
 
     if (!NPDeviceAliasManager::instance()->canSetAlias(index.data(ComputerModel::kRealUrlRole).toUrl())) {
         QRegularExpression regx(kRegPattern);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -280,6 +280,11 @@ QWidget *SideBarItemDelegate::createEditor(QWidget *parent, const QStyleOptionVi
     if (!tgItem)
         return nullptr;
     QWidget *editor = DStyledItemDelegate::createEditor(parent, option, index);
+    // 重新设置调色板颜色值，使得背景色正确渲染，而不是保持透明状态。
+    auto p = editor->palette();
+    p.setColor(QPalette::Button, p.color(QPalette::Button));
+    editor->setPalette(p);
+
     QLineEdit *qle = nullptr;
     if ((qle = dynamic_cast<QLineEdit *>(editor))) {
         if (!NPDeviceAliasManager::instance()->canSetAlias(tgItem->targetUrl())) {


### PR DESCRIPTION
Fixed editor background transparency issue in computer and sidebar item
delegates by explicitly setting the palette color. The editor widgets
were showing transparent backgrounds instead of the proper button color,
which made text editing difficult to see.

The fix involves explicitly setting the Button color in the palette to
ensure the background renders correctly rather than staying transparent.
This improves the visual appearance and usability of rename/edit
operations in both computer view and sidebar.

Log: Fixed transparent background issue when editing item names in file
manager

Influence:
1. Test renaming computer items to verify background displays correctly
2. Test renaming sidebar items to ensure proper background rendering
3. Verify text visibility during editing operations
4. Check that the fix applies to both computer view and sidebar
5. Test with different themes to ensure consistent behavior

fix: 修复文件管理器编辑器背景透明问题

修复了计算机和侧边栏项目委托中的编辑器背景透明问题，通过显式设置调色板颜
色。编辑器小部件之前显示透明背景而不是正确的按钮颜色，这使得文本编辑难以
看清。

该修复通过显式设置调色板中的按钮颜色来确保背景正确渲染而不是保持透明状
态。这改善了计算机视图和侧边栏中重命名/编辑操作的视觉外观和可用性。

Log: 修复文件管理器编辑项目名称时背景透明的问题

Influence:
1. 测试重命名计算机项目以验证背景正确显示
2. 测试重命名侧边栏项目以确保背景正确渲染
3. 验证编辑操作期间的文本可见性
4. 检查修复是否同时适用于计算机视图和侧边栏
5. 使用不同主题测试以确保一致的行为

BUG: https://pms.uniontech.com/bug-view-334259.html

## Summary by Sourcery

Fix transparent editor backgrounds in file manager's computer and sidebar views by explicitly setting the button color in editor palettes

Bug Fixes:
- Explicitly set QPalette::Button color for editors in sidebar item delegate to prevent transparent background
- Explicitly set QPalette::Button color for editors in computer item delegate to prevent transparent background