### PR TITLE
fix: fix QAbstractItemModelPrivate crash during destruction

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
@@ -31,6 +31,34 @@ WorkspacePage::WorkspacePage(QWidget *parent)
     initUI();
 }
 
+WorkspacePage::~WorkspacePage()
+{
+    fmInfo() << "Destroying WorkspacePage";
+
+    // 显式清理 views,确保析构顺序可控
+    // 注意: 必须先从 layout 移除,再 delete,避免 Qt 父子关系的二次删除
+    for (auto it = views.begin(); it != views.end(); ) {
+        QString scheme = it.key();
+        ViewPtr view = it.value();
+
+        fmDebug() << "Cleaning up view for scheme:" << scheme;
+
+        // 先从 layout 移除
+        if (view && view->widget()) {
+            viewStackLayout->removeWidget(view->widget());
+        }
+
+        // 删除 view (会触发 FileView::~FileView)
+        if (view) {
+            delete view;
+        }
+
+        it = views.erase(it);
+    }
+
+    fmDebug() << "WorkspacePage destruction completed";
+}
+
 void WorkspacePage::setUrl(const QUrl &url)
 {
     fmInfo() << "WorkspacePage setUrl called with url:" << url;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.h
@@ -35,6 +35,7 @@ class WorkspacePage : public QWidget
 
 public:
     explicit WorkspacePage(QWidget *parent = nullptr);
+    ~WorkspacePage() override;
 
     void setUrl(const QUrl &url);
     QUrl currentUrl() const;
@@ -53,9 +54,9 @@ private:
     void setCurrentView(const QUrl &url);
     void playDisappearAnimation(ViewPtr view);
 
-    QWidget *topContainer { nullptr };     // 顶部容器
-    QVBoxLayout *topLayout { nullptr };    // 顶部布局
-    QWidget *viewContainer { nullptr };    // 视图容器
+    QWidget *topContainer { nullptr };   // 顶部容器
+    QVBoxLayout *topLayout { nullptr };   // 顶部布局
+    QWidget *viewContainer { nullptr };   // 视图容器
 
     QVBoxLayout *widgetLayout { nullptr };
     QStackedLayout *viewStackLayout { nullptr };
@@ -67,11 +68,11 @@ private:
     QUrl currentPageUrl {};
     QString currentViewScheme {};
 
-    QMap<QString, ViewPtr> views {};
-    QMap<QString, TopWidgetPtr> topWidgets {};
+    QHash<QString, ViewPtr> views {};
+    QHash<QString, TopWidgetPtr> topWidgets {};
     int highPriorityTopWidgetsCount { 0 };
 };
 
-} // namespace dfmplugin_workspace
+}   // namespace dfmplugin_workspace
 
-#endif // WORKSPACEPAGE_H
+#endif   // WORKSPACEPAGE_H


### PR DESCRIPTION
1. Modified FileView destructor to properly unbind model before base class destruction
2. Improved model cleanup sequence in FileView::setModel()
3. Added explicit WorkspacePage destructor with ordered view cleanup
4. Changed QMap to QHash for better performance in WorkspacePage

The changes prevent crashes during widget destruction by:
- Ensuring proper cleanup order between QAbstractItemView and its model
- Explicitly managing persistent model indices lifecycle
- Controlling destruction sequence of views in WorkspacePage
- Using QHash instead of QMap for view storage where ordering isn't needed

Log: Fixed crash during file manager destruction when closing windows

Influence:
1. Test file manager window creation and destruction multiple times
2. Verify automatic cleanup when switching between folders rapidly
3. Monitor memory usage during repeated window open/close cycles
4. Check stability when loading custom models in file view

fix: 修复 QAbstractItemModelPrivate 析构时的崩溃问题

1. 修改 FileView 析构函数，确保在基类析构前正确解绑 model
2. 改进 FileView::setModel() 中的模型清理顺序
3. 为 WorkspacePage 添加显式析构函数并实现有序的 view 清理
4. 将 WorkspacePage 中的 QMap 改为 QHash 以提高性能

这些修改通过以下方式防止控件析构时的崩溃：
- 确保 QAbstractItemView 和其 model 之间的正确清理顺序
- 显式管理持久模型索引的生命周期
- 控制 WorkspacePage 中视图的析构顺序
- 在不需要排序的场景使用 QHash 替代 QMap

Log: 修复了文件管理器关闭窗口时崩溃的问题

Influence:
1. 测试多次创建和销毁文件管理器窗口
2. 验证在快速切换文件夹时的自动清理功能
3. 监测重复打开/关闭窗口时的内存使用情况
4. 检查在文件视图中加载自定义模型时的稳定性

## Summary by Sourcery

Prevent crashes during widget destruction by ensuring proper model unbinding in FileView and controlled view cleanup in WorkspacePage, and enhance performance by replacing QMap with QHash.

New Features:
- Add explicit WorkspacePage destructor to orderly remove and delete views from the layout

Bug Fixes:
- Fix crash in FileView destructor by disconnecting signals and unbinding the model before base class destruction

Enhancements:
- Refine FileView::setModel to unbind and delete the old model safely before setting a new one
- Replace QMap with QHash in WorkspacePage for faster view and widget storage