### PR TITLE
fix: support full-text index on mounted block devices

### DIFF
--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -6,6 +6,7 @@
 #include "utils/textindexconfig.h"
 
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
 
 #include <dfm-search/dsearch_global.h>
 
@@ -337,7 +338,8 @@ bool FSMonitorPrivate::shouldExcludePath(const QString &path) const
     }
 
     // Check if path is on external mount
-    if (isExternalMount(path)) {
+    // Note: Block devices allowed to be mounted via udisks
+    if (!DevProxyMng->isFileOfExternalBlockMounts(path) && isExternalMount(path)) {
         fmDebug() << "FSMonitor: Excluding external mount:" << path;
         return true;
     }


### PR DESCRIPTION
Added support for creating full-text indexes on mounted block devices by modifying the path exclusion logic in FSMonitor. The change adds a check to allow indexing if the path is on a block device that was mounted via udisks, while still excluding regular external mounts.

Log: Added ability to create full-text indexes on mounted block devices

Influence:
1. Test full-text index creation on external block devices
2. Verify indexing still excludes regular external mounts
3. Check search functionality on mounted block devices
4. Verify system stability when indexing large block devices

fix: 支持在挂载的块设备上创建全文索引

通过修改FSMonitor中的路径排除逻辑，新增了对挂载块设备上创建全文索引的支
持。该修改添加了一个检查条件，允许对通过udisks挂载的块设备路径进行索引，
同时仍排除常规的外部挂载。

Log: 新增在挂载块设备上创建全文索引的能力

Influence:
1. 测试在外部块设备上创建全文索引的功能
2. 验证索引功能仍会排除常规的外部挂载
3. 检查在挂载块设备上的搜索功能
4. 验证在索引大型块设备时的系统稳定性

Bug: https://pms.uniontech.com/bug-view-338691.html

## Summary by Sourcery

Allow full-text indexing on block devices mounted via UDisks by updating FSMonitor’s exclusion logic

New Features:
- Support full-text index creation on block devices mounted via UDisks

Enhancements:
- Refine shouldExcludePath to only reject non-UDisks external mounts and include the device proxy manager