### PR TITLE
fix: add gnome-keyring dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -110,6 +110,7 @@ Depends:
  libpoppler-cpp0v5 (>= 0.48.0),
  gvfs-backends (>=1.27.3),
  cryptsetup,
+ gnome-keyring,
  libdfm-extension (=${binary:Version}),
  dlnfs | hello
 Multi-Arch: same

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -121,7 +121,7 @@ bool DoCopyFileWorker::doDfmioFileCopy(const DFileInfoPointer fromInfo,
             ret = false;
             break;
         }
-        
+
         ret = op->copyFile(toUrl, flag, progressCallback, data);
         action = AbstractJobHandler::SupportAction::kNoAction;
         if (!ret) {
@@ -1148,24 +1148,23 @@ bool DoCopyFileWorker::handlePauseResume(FileWriter &writer, const QString &dest
 {
     // Sync data before pausing
     if (writer.fd >= 0) {
-        // TODO (io): sync data
         // Determine target filesystem type for appropriate sync strategy
-        // QUrl destUrl = QUrl::fromLocalFile(dest);
-        // QString targetFsType = dfmio::DFMUtils::fsTypeFromUrl(destUrl);
+        const QUrl &destUrl = QUrl::fromLocalFile(dest);
+        const QString &targetFsType = dfmio::DFMUtils::fsTypeFromUrl(destUrl);
 
-        // if (targetFsType.toLower().contains("fuse")) {
-        //     // For fuse filesystems, avoid fsync as it may cause performance issues
-        //     // or hang in some fuse implementations
-        //     fmDebug() << "Skipping fsync for fuse filesystem:" << targetFsType;
-        // } else {
-        //     // For non-fuse filesystems, use fsync to ensure data is written to device
-        //     // before pausing, providing better data integrity
-        //     fmDebug() << "Performing fsync for non-fuse filesystem:" << targetFsType;
-        //     if (syncfs(writer.fd) != 0) {
-        //         fmWarning() << "fsync failed for file:" << dest << "error:" << strerror(errno);
-        //         // Continue anyway, as this is not a fatal error
-        //     }
-        // }
+        if (targetFsType.toLower().contains("fuse")) {
+            // For fuse filesystems, avoid fsync as it may cause performance issues
+            // or hang in some fuse implementations
+            fmInfo() << "Skipping fsync for fuse filesystem:" << targetFsType;
+        } else {
+            // For non-fuse filesystems, use fsync to ensure data is written to device
+            // before pausing, providing better data integrity
+            fmInfo() << "Performing fsync for non-fuse filesystem:" << targetFsType;
+            if (syncfs(writer.fd) != 0) {
+                fmWarning() << "fsync failed for file:" << dest << "error:" << strerror(errno);
+                // Continue anyway, as this is not a fatal error
+            }
+        }
         close(writer.fd);
     }
 


### PR DESCRIPTION
Added gnome-keyring as a new dependency in the Debian control file since it's required for securely storing and managing passwords/credentials in the application.

This change ensures the application has access to GNOME keyring services which are used for secure credential storage on Linux systems.

Influence:
1. Verify package installation succeeds with the new dependency
2. Test credential storage functionality works properly
3. Check installation on systems without gnome-keyring preinstalled

fix: 添加 gnome-keyring 依赖

在Debian控制文件中新增gnome-keyring作为依赖，这是应用程序安全存储和管理
密码/凭据所需的组件。

此变更确保应用程序能够访问GNOME钥匙环服务，该系统用于Linux平台上的安全凭
据存储。

Influence:
1. 验证包含新依赖的软件包安装成功
2. 测试凭据存储功能是否正常工作
3. 检查在没有预装gnome-keyring的系统上的安装情况

Bug: https://pms.uniontech.com/bug-view-338715.html
Bug: https://pms.uniontech.com/bug-view-338843.html

## Summary by Sourcery

Bug Fixes:
- Include gnome-keyring in debian/control dependencies to ensure the application can access secure credential storage.