### PR TITLE
Fix: [Vault] Can not open vault.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
@@ -197,7 +197,7 @@ bool VaultEventReceiver::changeUrlEventFilter(quint64 windowId, const QUrl &url)
     if (url.scheme() == VaultHelper::instance()->scheme()) {
         fmDebug() << "Vault: Processing vault URL change";
         VaultHelper::instance()->appendWinID(windowId);
-        const VaultState &state = VaultHelper::instance()->state(PathManager::vaultLockPath());
+        const VaultState &state = VaultHelper::instance()->state(PathManager::vaultLockPath(), false);
         fmDebug() << "Vault: Current vault state:" << static_cast<int>(state);
 
         if (VaultState::kNotExisted == state) {

--- a/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
@@ -191,14 +191,14 @@ bool FileEncryptHandle::createDirIfNotExist(QString path)
     return true;
 }
 
-VaultState FileEncryptHandle::state(const QString &encryptBaseDir) const
+VaultState FileEncryptHandle::state(const QString &encryptBaseDir, bool useCache) const
 {
     if (encryptBaseDir.isEmpty()) {
         fmWarning() << "Vault: not set the base dir!";
         return kUnknow;
     }
 
-    if (!(d->curState == kUnknow || d->curState == kEncrypted))
+    if (useCache && !(d->curState == kUnknow || d->curState == kEncrypted))
         return d->curState;
 
     const QString &cryfsBinary = QStandardPaths::findExecutable("cryfs");

--- a/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.h
@@ -25,7 +25,7 @@ public:
     bool unlockVault(const QString &lockBaseDir, const QString &unlockFileDir, const QString &DSecureString);
     bool lockVault(QString unlockFileDir, bool isForced);
     bool createDirIfNotExist(QString path);
-    VaultState state(const QString &encryptBaseDir) const;
+    VaultState state(const QString &encryptBaseDir, bool useCache = true) const;
     bool updateState(VaultState curState);
 
     EncryptType encryptAlgoTypeOfGroupPolicy();

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
@@ -130,7 +130,7 @@ void VaultHelper::siderItemClicked(quint64 windowId, const QUrl &url)
     QApplication::restoreOverrideCursor();
     VaultHelper::instance()->appendWinID(windowId);
 
-    switch (instance()->state(PathManager::vaultLockPath())) {
+    switch (instance()->state(PathManager::vaultLockPath(), false)) {
     case VaultState::kNotExisted: {
         fmInfo() << "Vault: Vault not existed, showing create dialog";
         VaultHelper::instance()->createVaultDialog();
@@ -156,9 +156,9 @@ void VaultHelper::siderItemClicked(quint64 windowId, const QUrl &url)
     }
 }
 
-VaultState VaultHelper::state(const QString &baseDir) const
+VaultState VaultHelper::state(const QString &baseDir, bool useCache) const
 {
-    return FileEncryptHandle::instance()->state(baseDir);
+    return FileEncryptHandle::instance()->state(baseDir, useCache);
 }
 
 bool VaultHelper::updateState(VaultState curState)

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.h
@@ -41,7 +41,7 @@ public:
 
     QUrl pathToVaultVirtualUrl(const QString &path);
 
-    VaultState state(const QString &baseDir) const;
+    VaultState state(const QString &baseDir, bool useCache = true) const;
     bool updateState(VaultState curState);
 
     /*!


### PR DESCRIPTION
-- Delete the vault , then recovery vault, can not open the vault. 
-- When the safe is deleted, it records the deletion status.
   At this point, even if the control center restores it,
   the safe still retains the deletion status, making it impossible to unlock.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-338697.html

## Summary by Sourcery

Ensure vault state checks reflect current status post-recovery rather than stale cache by introducing an optional cache flag and disabling caching in critical paths.

Bug Fixes:
- Bypass cached vault state when opening or handling vault URLs to correctly detect a restored vault

Enhancements:
- Add optional useCache parameter to state() methods in VaultHelper and FileEncryptHandle to control caching behavior