### PR TITLE
style: update selected item background and border colors

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -849,8 +849,8 @@ void CanvasItemDelegate::paintBackground(QPainter *painter, const QStyleOptionVi
     if (!isSelected)
         return;
 
-    QColor backgroundColor(0, 0, 0, qRound(255 * 0.15));
-    QColor borderColor(255, 255, 255, qRound(255 * 0.1));
+    QColor backgroundColor(33, 33, 33, qRound(255 * 0.25));
+    QColor borderColor(241, 241, 241, qRound(255 * 0.25));
     QRect backgroundRect = iconRect.adjusted(-kIconBackgroundMargin, -kIconBackgroundMargin, kIconBackgroundMargin, kIconBackgroundMargin);
 
     painter->save();

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -874,8 +874,8 @@ void CollectionItemDelegate::paintBackground(QPainter *painter, const QStyleOpti
     if (!isSelected)
         return;
 
-    QColor backgroundColor(0, 0, 0, qRound(255 * 0.15));
-    QColor borderColor(255, 255, 255, qRound(255 * 0.1));
+    QColor backgroundColor(33, 33, 33, qRound(255 * 0.25));
+    QColor borderColor(241, 241, 241, qRound(255 * 0.25));
     QRect backgroundRect = iconRect.adjusted(-kIconBackgroundMargin, -kIconBackgroundMargin, kIconBackgroundMargin, kIconBackgroundMargin);
 
     painter->save();


### PR DESCRIPTION
Changed the visual styling for selected items in both canvas and
organizer views. Updated the background color from semi-transparent
black to a darker gray with higher opacity (33,33,33 at 25% opacity
instead of 0,0,0 at 15% opacity). Also changed the border color from
semi-transparent white to a light gray with higher opacity (241,241,241
at 25% opacity instead of 255,255,255 at 10% opacity).

These changes improve the visual contrast and selection feedback for
users, making selected items more distinguishable while maintaining a
cohesive design language across the application.

Log: Improved visual appearance of selected items with better contrast

Influence:
1. Test item selection in canvas view to verify new background and
border colors
2. Test item selection in organizer view to ensure consistent styling
3. Verify selection visibility under different background conditions
4. Check that the selection indicator remains clearly visible but not
overly prominent
5. Test selection behavior with various item types and arrangements

style: 更新选中项的背景和边框颜色

修改了画布视图和组织器视图中选中项的视觉样式。将背景颜色从半透明黑
色更新为更深灰色且更高不透明度（从0,0,0 15%不透明度改为33,33,33 25%
不透明度）。同时将边框颜色从半透明白色更新为浅灰色且更高不透明度（从
255,255,255 10%不透明度改为241,241,241 25%不透明度）。

这些更改提高了视觉对比度和选中反馈，使选中项更容易区分，同时在整个应用程
序中保持统一的设计语言。

Log: 优化选中项的视觉外观，提供更好的对比度

Influence:
1. 测试画布视图中的项目选中效果，验证新的背景和边框颜色
2. 测试组织器视图中的项目选中效果，确保样式一致性
3. 验证在不同背景条件下的选中可见性
4. 检查选中指示器保持清晰可见但不过于突出
5. 测试不同类型和排列方式的项目选中行为

BUG: https://pms.uniontech.com/bug-view-338851.html

## Summary by Sourcery

Enhancements:
- Update selected item background from semi-transparent black to darker gray (#212121) at 25% opacity and border from semi-transparent white to light gray (#F1F1F1) at 25% opacity in canvas and organizer views for better contrast.