### PR TITLE
refactor: replace QLabel with DCommandLinkButton for add directory

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
@@ -33,14 +33,14 @@ void CustomTabSettingWidget::setOption(QObject *opt)
 {
     auto option = qobject_cast<DSettingsOption *>(opt);
     const auto &itemList = option->value().toStringList();
-    updateAddItemLabel(itemList.size() < 4);
+    addItemBtn->setEnabled(itemList.size() < 4);
 
     for (const auto &item : itemList) {
         addCustomItem(option, item);
     }
 
     using namespace std::placeholders;
-    connect(addItemLabel, &QLabel::linkActivated, this, std::bind(&CustomTabSettingWidget::handleAddCustomItem, this, option));
+    connect(addItemBtn, &DCommandLinkButton::clicked, this, std::bind(&CustomTabSettingWidget::handleAddCustomItem, this, option));
     connect(option, &DSettingsOption::valueChanged, this, &CustomTabSettingWidget::handleOptionChanged);
 }
 
@@ -50,12 +50,11 @@ void CustomTabSettingWidget::initUI()
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setVerticalSpacing(10);
 
-    addItemLabel = new QLabel(this);
-    addItemLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    updateAddItemLabel(true);
+    addItemBtn = new DCommandLinkButton(tr("Add Directory"), this);
+    addItemBtn->setEnabled(true);
 
     mainLayout->addWidget(new QLabel(tr("Custom Directory"), this), 0, 0);
-    mainLayout->addWidget(addItemLabel, 0, 1);
+    mainLayout->addWidget(addItemBtn, 0, 1);
     mainLayout->setColumnStretch(0, 1);
     mainLayout->setColumnStretch(1, 0);
 }
@@ -73,7 +72,7 @@ void CustomTabSettingWidget::addCustomItem(DSettingsOption *opt, const QUrl &url
                     auto itemList = opt->value().toStringList();
                     itemList.removeOne(url.toString());
                     opt->setValue(itemList);
-                    updateAddItemLabel(itemList.size() < 4);
+                    addItemBtn->setEnabled(itemList.size() < 4);
                 }
             });
 
@@ -114,7 +113,7 @@ void CustomTabSettingWidget::handleAddCustomItem(Dtk::Core::DSettingsOption *opt
     opt->setValue(itemList);
 
     if (itemList.size() > 3)
-        updateAddItemLabel(false);
+        addItemBtn->setEnabled(false);
 }
 
 void CustomTabSettingWidget::handleOptionChanged(const QVariant &value)
@@ -130,16 +129,7 @@ void CustomTabSettingWidget::handleOptionChanged(const QVariant &value)
             addCustomItem(opt, item);
         }
     }
-    updateAddItemLabel(itemList.size() < 4);
-}
-
-void CustomTabSettingWidget::updateAddItemLabel(bool enable)
-{
-    QString color = enable ? "#0082fa" : "#c7ddf7";
-    QString format = "<a href='Add'><span style=' text-decoration: none; color:%1;'>%2</span></a>";
-
-    addItemLabel->setText(format.arg(color, tr("Add Directory")));
-    addItemLabel->setEnabled(enable);
+    addItemBtn->setEnabled(itemList.size() < 4);
 }
 
 void CustomTabSettingWidget::clearCustomItems()

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.h
@@ -7,6 +7,8 @@
 
 #include "dfmplugin_titlebar_global.h"
 
+#include <DCommandLinkButton>
+
 #include <QWidget>
 
 class QLabel;
@@ -34,12 +36,11 @@ private:
     QUrl selectCustomDirectory();
     void handleAddCustomItem(Dtk::Core::DSettingsOption *opt);
     void handleOptionChanged(const QVariant &value);
-    void updateAddItemLabel(bool enable);
     void clearCustomItems();
     bool removeRow(QWidget *w);
 
 private:
-    QLabel *addItemLabel { nullptr };
+    DTK_WIDGET_NAMESPACE::DCommandLinkButton *addItemBtn { nullptr };
     QGridLayout *mainLayout { nullptr };
 };
 }


### PR DESCRIPTION
Changed the "Add Directory" control from a styled QLabel to a
DCommandLinkButton for better UI consistency and improved user
experience. The QLabel was previously styled as a clickable link with
manual color management, which has been replaced with the standard
DCommandLinkButton component that provides native styling and behavior.

Log: Changed "Add Directory" from text link to button style

Influence:
1. Verify "Add Directory" button appears correctly in custom tab
settings
2. Test button enable/disable state when adding/removing directories
(max 4 items)
3. Confirm button click functionality works to add new directories
4. Check visual consistency with other DCommandLinkButton components in
the application
5. Verify button is properly disabled when maximum directory limit is
reached

refactor: 将添加目录控件从 QLabel 替换为 DCommandLinkButton

将"添加目录"控件从样式化的QLabel更改为DCommandLinkButton，以提高UI一致性
和用户体验。之前使用QLabel模拟可点击链接并手动管理颜色样式，现已替换为标
准DCommandLinkButton组件，提供原生样式和行为。

Log: 将"添加目录"从文本链接改为按钮样式

Influence:
1. 验证自定义标签设置中"添加目录"按钮显示正确
2. 测试添加/删除目录时按钮的启用/禁用状态（最多4个项目）
3. 确认按钮点击功能正常，可以添加新目录
4. 检查与应用程序中其他DCommandLinkButton组件的视觉一致性
5. 验证达到最大目录限制时按钮正确禁用

BUG: https://pms.uniontech.com/bug-view-338863.html

## Summary by Sourcery

Refactor the "Add Directory" UI in CustomTabSettingWidget by swapping out a styled QLabel link for a DCommandLinkButton, consolidating enable/disable logic, and updating signal connections to improve UI consistency and maintainability.

Enhancements:
- Replace the manually styled QLabel link with a native DCommandLinkButton for the "Add Directory" control
- Remove the custom updateAddItemLabel method and apply enable/disable logic directly on the DCommandLinkButton
- Switch signal handling from QLabel::linkActivated to DCommandLinkButton::clicked for adding directories