### PR TITLE
fix: fix recent file location opening and search box clearing

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -159,7 +159,9 @@ void SearchEditWidget::onUrlChanged(const QUrl &url)
 
     lastSearchTime = 0;
     lastExecutedSearchText.clear();
-    searchEdit->setText("");
+    searchEdit->clearEdit();
+    if (delayTimer && delayTimer->isActive())
+        delayTimer->stop();
     advancedButton->setVisible(false);
     advancedButton->setChecked(false);
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -261,6 +261,9 @@ void TabBarPrivate::handleTabClicked(int index)
 
 void TabBarPrivate::handleIndexChanged(int index)
 {
+    if (currentTabIndex == index)
+        return;
+
     const auto &tab = tabInfo(index);
     if (tab.isInactive) {
         Q_EMIT q->requestCreateView(tab.uniqueId);


### PR DESCRIPTION
1. Fix openFileLocation function to handle root user case properly by
using dde-file-manager with --show-item flag
2. Add SysInfoUtils import to check for root user permissions
3. Replace searchEdit->setText("") with clearEdit() to properly clear
search box and stop delay timer
4. Add current tab index check in tabbar to prevent unnecessary view
creation when clicking same tab
5. Fix code formatting in recentmanager.cpp

Log: Fixed issue where opening file location from recent files didn't
work correctly for root users

Influence:
1. Test opening file location from recent files as regular user
2. Test opening file location from recent files as root user
3. Verify search box clears properly when switching directories
4. Check that clicking same tab doesn't trigger unnecessary view
recreation
5. Verify recent file removal dialog works correctly

fix: 修复最近文件打开位置和搜索框清除问题

1. 修复 openFileLocation 函数，正确处理 root 用户情况，使用 dde-file-
manager 的 --show-item 参数
2. 添加 SysInfoUtils 导入以检查 root 用户权限
3. 将 searchEdit->setText("") 替换为 clearEdit() 以正确清除搜索框并停止
延迟计时器
4. 在标签栏中添加当前标签索引检查，防止点击相同标签时不必要的视图创建
5. 修复 recentmanager.cpp 中的代码格式

Log: 修复了 root 用户从最近文件打开文件位置功能不正常的问题

Influence:
1. 测试普通用户从最近文件打开文件位置功能
2. 测试 root 用户从最近文件打开文件位置功能
3. 验证切换目录时搜索框是否正确清除
4. 检查点击相同标签是否不会触发不必要的视图重建
5. 验证最近文件删除对话框工作正常

## Summary by Sourcery

Fix file location opening behavior for root and non-root users, ensure the search box clears correctly on directory changes, and avoid redundant view creation when reselecting the same tab.

Bug Fixes:
- Handle root user case in openFileLocation by invoking dde-file-manager with --show-item
- Replace searchEdit->setText("") with clearEdit() and stop the delay timer to properly clear the search box
- Add a check in the tab bar to skip view creation when clicking on the currently active tab

Enhancements:
- Import SysInfoUtils and use DDesktopServices for consistent file location handling

Chores:
- Reformat code in recentmanager.cpp for consistent styling