### PR TITLE
fix: improve protocol device name detection

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.cpp
@@ -165,13 +165,18 @@ void DeviceItem::openDevice()
 
 void DeviceItem::updateDeviceName()
 {
+    static QStringList schemeList { "ftp", "sftp", "nfs", "dav", "davs" };
+
     QString devName = data.displayName;
     if (data.isProtocolDevice) {
         QString host, share, alias;
         int port;
         if (smb_utils::parseSmbInfo(data.targetFileUrl.toString(), &host, &share, &port)) {
             alias = device_utils::protocolDeviceAlias("smb", host);
-        } else if (data.id.startsWith("ftp") || data.id.startsWith("sftp")) {
+        } else if (std::any_of(schemeList.cbegin(), schemeList.cend(),
+                               [this](const QString &scheme) {
+                                   return data.id.startsWith(scheme);
+                               })) {
             QUrl url(data.id);
             host = url.host();
             alias = device_utils::protocolDeviceAlias(url.scheme(), url.host());


### PR DESCRIPTION
Enhanced protocol device name detection to support multiple network
protocols beyond just FTP/SFTP. Added support for FTP, SFTP, NFS, DAV,
and DAVs protocols by checking against a predefined scheme list instead
of hardcoded string comparisons.

The previous implementation only handled SMB and basic FTP/SFTP
protocols. This change extends protocol detection to include additional
network file sharing protocols, making the device mounting feature more
comprehensive and consistent across different protocol types.

Log: Improved network device name display for multiple protocols

Influence:
1. Test mounting devices using FTP, SFTP, NFS, DAV, and DAVs protocols
2. Verify device names display correctly for all supported protocols
3. Check that SMB device names still work as before
4. Test with mixed protocol devices to ensure proper detection
5. Verify protocol device aliases are correctly generated

fix: 改进协议设备名称检测

增强协议设备名称检测功能，支持除FTP/SFTP之外的多种网络协议。通过预定义
方案列表检查替代硬编码字符串比较，新增对FTP、SFTP、NFS、DAV和DAVs协议的
支持。

之前的实现仅处理SMB和基本FTP/SFTP协议。此更改扩展了协议检测范围，包含更
多网络文件共享协议，使设备挂载功能在不同协议类型间更加全面和一致。

Log: 改进了多种协议的网络设备名称显示

Influence:
1. 测试使用FTP、SFTP、NFS、DAV和DAVs协议挂载设备
2. 验证所有支持协议的设备名称显示正确
3. 检查SMB设备名称仍能正常工作
4. 测试混合协议设备的正确检测
5. 验证协议设备别名是否正确生成

BUG: https://pms.uniontech.com/bug-view-338087.html

## Summary by Sourcery

Improve protocol-based device name detection by using a centralized list of supported network schemes (FTP, SFTP, NFS, DAV, DAVs) and generating consistent aliases for each protocol.

New Features:
- Add support for NFS, DAV, and DAVs protocols in protocol device name detection

Enhancements:
- Replace hardcoded FTP/SFTP checks with a predefined protocol scheme list for scalable detection