### PR TITLE
fix: remove animation delay for detail view hiding

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
@@ -71,9 +71,8 @@ void ViewOptionsButton::setVisible(bool visible)
         fmDebug() << "Display preview is disabled in config, skipping preview visibility change";
         return;
     }
-    QTimer::singleShot(200, [this, visible]() {
-        Q_EMIT displayPreviewVisibleChanged(visible);
-    });
+
+    Q_EMIT displayPreviewVisibleChanged(visible);
 }
 
 ViewOptionsButton::~ViewOptionsButton() = default;
@@ -91,7 +90,7 @@ void ViewOptionsButton::paintEvent(QPaintEvent *event)
         option.state |= QStyle::State_MouseOver;
 
         bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
-        
+
         QColor hoverColor;
         if (isDown()) {
             // 按下状态 - 20%不透明度


### PR DESCRIPTION
Removed the animation and delayed hiding logic when hiding the detail
view. The code now directly hides the widget without any animation
effects or timing delays. This change simplifies the hiding process and
improves responsiveness.

Also removed the 200ms delay when emitting the
displayPreviewVisibleChanged signal. The signal is now emitted
immediately when visibility changes, providing more immediate feedback.

Log: Fixed delayed response when hiding detail view and preview options

Influence:
1. Test hiding detail view - should hide immediately without animation
2. Test toggling preview options - changes should take effect
immediately
3. Verify no visual glitches or timing issues during view transitions
4. Check that all view state changes respond instantly

fix: 移除详情视图隐藏的动画延迟

移除了隐藏详情视图时的动画和延迟逻辑。代码现在直接隐藏组件，没有任何动画
效果或时间延迟。这一改动简化了隐藏过程并提高了响应性。

同时移除了发射 displayPreviewVisibleChanged 信号时的200毫秒延迟。现在当
可见性改变时会立即发射信号，提供更及时的反馈。

Log: 修复了隐藏详情视图和预览选项时的延迟响应问题

Influence:
1. 测试隐藏详情视图 - 应该立即隐藏，没有动画效果
2. 测试切换预览选项 - 更改应该立即生效
3. 验证视图转换过程中没有视觉故障或时序问题
4. 检查所有视图状态更改都能立即响应

BUG: https://pms.uniontech.com/bug-view-338931.html

## Summary by Sourcery

Simplify the detail view hiding process and preview option toggling by removing all animations and delays, ensuring immediate UI response

Bug Fixes:
- Remove animation and delayed hiding logic for the detail view to make it hide immediately
- Eliminate the 200ms QTimer delay and emit displayPreviewVisibleChanged signal immediately