### PR TITLE
chore: correct typos in variable names and methods

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -211,7 +211,7 @@ DLabel *KeyValueLabel::leftWidget()
     return leftValueLabel;
 }
 
-void KeyValueLabel::setLeftVauleLabelFixedWidth(int width)
+void KeyValueLabel::setLeftValueLabelFixedWidth(int width)
 {
     leftValueLabel->setFixedWidth(width);
 }

--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h
@@ -94,7 +94,7 @@ public:
 
     RightValueWidget *rightWidget();
 
-    void setLeftVauleLabelFixedWidth(int width);
+    void setLeftValueLabelFixedWidth(int width);
 
 Q_SIGNALS:
     void valueAreaClicked();

--- a/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
@@ -38,13 +38,13 @@ void FileInfoModelPrivate::doRefresh()
 QIcon FileInfoModelPrivate::fileIcon(FileInfoPointer info)
 {
     using namespace dfmbase::Global;
-    const auto &vaule = info->extendAttributes(ExtInfoType::kFileThumbnail);
-    if (!vaule.isValid()) {
+    const auto &value = info->extendAttributes(ExtInfoType::kFileThumbnail);
+    if (!value.isValid()) {
         ThumbnailFactory::instance()->joinThumbnailJob(info->urlOf(UrlInfoType::kUrl), Global::kLarge);
         // make sure the thumbnail is generated only once
         info->setExtendedAttributes(ExtInfoType::kFileThumbnail, QIcon());
     } else {
-        const auto &thumbIcon = vaule.value<QIcon>();
+        const auto &thumbIcon = value.value<QIcon>();
         if (!thumbIcon.isNull())
             return thumbIcon;
     }

--- a/src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
@@ -44,7 +44,7 @@ void DevicePropertyDialog::iniUI()
 
     basicInfo = new KeyValueLabel(this);
     basicInfo->setLeftFontSizeWeight(DFontSizeManager::SizeType::T7, QFont::DemiBold);
-    basicInfo->setLeftVauleLabelFixedWidth(150);
+    basicInfo->setLeftValueLabelFixedWidth(150);
 
     devicesProgressBar = new DColoredProgressBar();
     devicesProgressBar->addThreshold(0, QColor(0xFF0080FF));

--- a/src/plugins/filemanager/dfmplugin-vault/dbus/vaultdbusutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/dbus/vaultdbusutils.cpp
@@ -24,11 +24,11 @@ VaultDBusUtils *VaultDBusUtils::instance()
     return &ins;
 }
 
-QVariant VaultDBusUtils::vaultManagerDBusCall(QString function, const QVariant &vaule)
+QVariant VaultDBusUtils::vaultManagerDBusCall(QString function, const QVariant &value)
 {
-    fmDebug() << "Vault: Calling vault manager DBus method:" << function << "with value:" << vaule;
+    fmDebug() << "Vault: Calling vault manager DBus method:" << function << "with value:" << value;
 
-    QVariant value;
+    QVariant result;
     QDBusInterface sessionManagerIface(kFileManagerDBusDaemonName,
                                        kFileManagerVaultDBusPath,
                                        kFileManagerVaultDBusInterfaces,
@@ -37,21 +37,21 @@ QVariant VaultDBusUtils::vaultManagerDBusCall(QString function, const QVariant &
     if (sessionManagerIface.isValid()) {
         fmDebug() << "Vault: DBus interface is valid, proceeding with call";
 
-        if (vaule.isNull()) {
+        if (value.isNull()) {
             QDBusPendingCall call = sessionManagerIface.asyncCall(function);
             call.waitForFinished();
             if (!call.isError()) {
                 QDBusReply<quint64> reply = call.reply();
-                value = QVariant::fromValue(reply.value());
-                fmDebug() << "Vault: DBus call successful, returned value:" << value;
+                result = QVariant::fromValue(reply.value());
+                fmDebug() << "Vault: DBus call successful, returned value:" << result;
             } else {
                 fmWarning() << "Vault: DBus call failed for method" << function << "error:" << call.error().message();
             }
         } else {
-            QDBusPendingCall call = sessionManagerIface.asyncCall(function, vaule);
+            QDBusPendingCall call = sessionManagerIface.asyncCall(function, value);
             call.waitForFinished();
             if (call.isError()) {
-                value = call.error().message();
+                result = call.error().message();
                 fmWarning() << "Vault: DBus call failed for method" << function << "error:" << call.error().message();
             } else {
                 fmDebug() << "Vault: DBus call successful for method" << function;
@@ -61,7 +61,7 @@ QVariant VaultDBusUtils::vaultManagerDBusCall(QString function, const QVariant &
         fmWarning() << "Vault: DBus interface is not valid for vault manager";
     }
 
-    return value;
+    return result;
 }
 
 void VaultDBusUtils::lockEventTriggered(QObject *obj, const char *cslot)

--- a/src/plugins/filemanager/dfmplugin-vault/dbus/vaultdbusutils.h
+++ b/src/plugins/filemanager/dfmplugin-vault/dbus/vaultdbusutils.h
@@ -18,7 +18,7 @@ class VaultDBusUtils : public QObject
 public:
     static VaultDBusUtils *instance();
 
-    static QVariant vaultManagerDBusCall(QString function, const QVariant &vaule = {});
+    static QVariant vaultManagerDBusCall(QString function, const QVariant &value = {});
 
     static void lockEventTriggered(QObject *obj, const char *cslot = nullptr);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -431,9 +431,9 @@ QVariant FileViewModel::data(const QModelIndex &index, int role) const
     }
 
     if (itemData->data(ItemRoles::kItemUrlRole).toUrl().scheme() == "group-header") {
-        QVariant groupHeaderVaule = filterSortWorker->groupHeaderData(index.row(), role);
-        if (groupHeaderVaule.isValid())
-            return groupHeaderVaule;
+        QVariant groupHeaderValue = filterSortWorker->groupHeaderData(index.row(), role);
+        if (groupHeaderValue.isValid())
+            return groupHeaderValue;
     }
 
     return itemData->data(columnRole);


### PR DESCRIPTION
1. Fixed typo from "setLeftVauleLabelFixedWidth" to "setLeftValueLabelFixedWidth" in KeyValueLabel class
2. Fixed typo from "vaule" to "value" in multiple files including file thumbnail handling and DBus call methods
3. Updated all references to these corrected names throughout the codebase

The changes were made to improve code consistency and readability by fixing obvious spelling mistakes in variable names and method signatures. While these typos didn't affect functionality, they were misleading and could cause confusion during maintenance.

Influence:
1. Verify UI elements using KeyValueLabel still render correctly
2. Test file thumbnail generation and display functionality
3. Verify vault DBus operations work as expected
4. Check file grouping headers are displayed properly

chore: 修正变量名和方法中的拼写错误

1. 修正 KeyValueLabel 类中的 "setLeftVauleLabelFixedWidth" 为 "setLeftValueLabelFixedWidth"
2. 在多处文件中修正 "vaule" 为 "value"，包括文件缩略图处理和 DBus 调用 方法
3. 更新代码库中所有对这些修正名称的引用

这些改动是为了通过修正变量名和方法签名中的明显拼写错误来提高代码的一致性
和可读性。虽然这些拼写错误不影响功能，但它们具有误导性，可能在维护时引起
混淆。

Influence:
1. 验证使用 KeyValueLabel 的 UI 元素仍然正确渲染
2. 测试文件缩略图生成和显示功能
3. 验证保险箱 DBus 操作正常工作
4. 检查文件分组标题是否正确显示

## Summary by Sourcery

Correct typos in variable names and method signatures by standardising the spelling of "value" across multiple components and renaming the KeyValueLabel method for consistency.

Enhancements:
- Standardise spelling of "value" by replacing incorrect "vaule" in variables and parameters across VaultDBusUtils, FileInfoModel, and FileViewModel
- Rename KeyValueLabel::setLeftVauleLabelFixedWidth to setLeftValueLabelFixedWidth and update all its usages