### PR TITLE
fix: improve video preview title bar text positioning

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/titlebarwidget.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/titlebarwidget.cpp
@@ -165,11 +165,11 @@ void TitleBarWidget::paintEvent(QPaintEvent *event)
         QRect textRect = fontMetrics.boundingRect(m_text);
 
         // Calculate centered position
-        int x = (width() - textRect.width()) / 2;
+        int x = qMax((width() - textRect.width()) / 2, 40);
         int y = (height() + fontMetrics.ascent()) / 2;
 
         // Draw text with eliding if too long
-        QString elidedText = fontMetrics.elidedText(m_text, Qt::ElideRight, width() - 20); // 10px margin on each side
+        QString elidedText = fontMetrics.elidedText(m_text, Qt::ElideMiddle, width() - 80); // 40px margin on each side
         painter.drawText(x, y, elidedText);
     }
 }


### PR DESCRIPTION
1. Changed text positioning calculation to ensure minimum 40px left
margin
2. Updated text eliding mode from right to middle for better readability
3. Increased margin space from 20px to 80px to accommodate control
buttons
4. Used qMax to prevent text from overlapping with left-side controls

Log: Improved video preview title bar text display with better spacing
and eliding

Influence:
1. Test video preview with short filenames to verify centering
2. Test with long filenames to ensure proper middle eliding
3. Verify text doesn't overlap with control buttons on either side
4. Check different window sizes to ensure responsive layout
5. Test with various filename lengths and special characters

fix: 改进视频预览标题栏文本定位

1. 修改文本定位计算以确保最小40像素左边距
2. 将文本省略模式从右侧改为中间以提高可读性
3. 将边距空间从20像素增加到80像素以适应控制按钮
4. 使用qMax防止文本与左侧控件重叠

Log: 优化视频预览标题栏文本显示，改善间距和省略效果

Influence:
1. 测试短文件名视频预览，验证居中效果
2. 测试长文件名，确保正确的中间省略处理
3. 验证文本不会与两侧控制按钮重叠
4. 检查不同窗口大小下的响应式布局
5. 测试各种文件名长度和特殊字符

BUG: https://pms.uniontech.com/bug-view-339221.html

## Summary by Sourcery

Improve video preview title bar text layout by enforcing minimum margins, preventing overlap with controls, and switching to middle eliding for long filenames.

Bug Fixes:
- Prevent title text from overlapping controls by enforcing a 40px minimum left margin and expanding margins to 80px for responsive layouts.

Enhancements:
- Switch text eliding mode from right to middle to enhance readability of long filenames.