### PR TITLE
fix: optimize icon scaling for high DPI displays

### DIFF
--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
@@ -218,8 +218,7 @@ void DetailView::setDetailIcon(const QUrl &url)
     if (icon.isNull())
         icon = info->fileIcon();
 
-    QPixmap px = icon.pixmap(targetSize);
-    px.setDevicePixelRatio(qApp->devicePixelRatio());
+    QPixmap px = icon.pixmap(targetSize, qApp->devicePixelRatio());
     iconLabel->setPixmap(px);
     iconLabel->setAlignment(Qt::AlignCenter);
 }


### PR DESCRIPTION
The previous implementation first created a pixmap at the target size
and then manually set the device pixel ratio, which could result in
blurry icons on high DPI displays. The new approach uses QIcon::pixmap()
with the device pixel ratio parameter directly, which ensures proper
high DPI scaling by generating the pixmap at the correct resolution from
the start.

This change improves icon rendering quality on high DPI screens by
leveraging Qt's built-in high DPI support instead of manual scaling
operations.

Influence:
1. Test file detail views on high DPI displays to verify icon clarity
2. Verify icon rendering on standard DPI displays remains unchanged
3. Check various file types and sizes to ensure consistent icon quality
4. Test with different scaling factors (125%, 150%, 200%)
5. Verify icon alignment and centering functionality

fix: 优化高DPI显示下的图标缩放

之前的实现先创建目标尺寸的像素图，然后手动设置设备像素比，这可能导致高
DPI显示器上图标模糊。新方法直接使用QIcon::pixmap()并传入设备像素比参数，
从一开始就确保正确的高DPI缩放，生成正确分辨率的像素图。

此更改通过利用Qt内置的高DPI支持而不是手动缩放操作，提高了高DPI屏幕上的图
标渲染质量。

Influence:
1. 在高DPI显示器上测试文件详情视图，验证图标清晰度
2. 验证标准DPI显示器上的图标渲染保持不变
3. 检查不同类型的文件和尺寸，确保图标质量一致
4. 测试不同的缩放比例（125%、150%、200%）
5. 验证图标对齐和居中功能

BUG: https://pms.uniontech.com/bug-view-336237.html

## Summary by Sourcery

Bug Fixes:
- Fix blurry icons on high DPI displays by generating pixmaps at the appropriate resolution instead of setting the device pixel ratio manually.