### PR TITLE
fix: fix incorrect drag preview scaling on high DPI displays

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -775,21 +775,19 @@ QMimeData *TabBar::createMimeDataFromTab(int index, const QStyleOptionTab &optio
 
 QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option, QPoint *hotspot) const
 {
-    const qreal ratio = qApp->devicePixelRatio();
     auto winid = FMWindowsIns.findWindowId(this);
     auto window = FMWindowsIns.findWindowById(winid);
     if (!window)
         return DTabBar::createDragPixmapFromTab(index, option, hotspot);
 
-    int width = window->width() * ratio;
-    int height = window->height() * ratio;
+    int width = window->width();
+    int height = window->height();
     QImage screenshotImage(width, height, QImage::Format_ARGB32_Premultiplied);
-    screenshotImage.setDevicePixelRatio(ratio);
     window->render(&screenshotImage, QPoint(), QRegion(0, 0, width, height));
 
     // scaled image to smaller.
-    int scaledWidth = width * ratio / 5;
-    int scaledHeight = height * ratio / 5;
+    int scaledWidth = width / 5;
+    int scaledHeight = height / 5;
     auto scaledImage = screenshotImage.scaled(scaledWidth, scaledHeight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
     QImage backgroundImage(scaledWidth + 10, scaledHeight + 10, QImage::Format_ARGB32_Premultiplied);
@@ -806,7 +804,7 @@ QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option
     QPainterPath rectPath;
     QPainterPath roundedRectPath;
     rectPath.addRect(0, 0, scaledWidth + 10, scaledHeight + 10);
-    roundedRectPath.addRoundedRect(QRect(0, 0, scaledWidth / ratio + 10, scaledHeight / ratio + 10), 6, 6);
+    roundedRectPath.addRoundedRect(QRect(0, 0, scaledWidth + 10, scaledHeight + 10), 6, 6);
     rectPath -= roundedRectPath;
 
     painter.setCompositionMode(QPainter::CompositionMode_Source);


### PR DESCRIPTION
Fixed incorrect scaling calculations in tab drag preview generation
that caused visual artifacts on high DPI displays. Removed unnecessary
device pixel ratio multiplications and divisions since QImage dimensions
already account for DPI scaling. The window screenshot and scaling
operations now use consistent pixel values without redundant ratio
adjustments.

Log: Fixed tab drag preview display issues on high DPI screens

Influence:
1. Test dragging tabs on high DPI displays to verify preview renders
correctly
2. Verify drag preview appearance on standard DPI displays remains
unchanged
3. Check that preview image scaling and rounded corners display properly
4. Test with different window sizes to ensure consistent preview
generation

fix: 修复高DPI显示器上标签页拖动预览缩放不正确的问题

修复了标签页拖动预览生成中不正确的缩放计算，该问题在高DPI显示器上导致视
觉伪影。移除了不必要的设备像素比乘除运算，因为QImage尺寸已经考虑了DPI缩
放。窗口截图和缩放操作现在使用一致的像素值，无需冗余的比例调整。

Log: 修复高DPI屏幕上标签页拖动预览显示问题

Influence:
1. 在高DPI显示器上测试拖动标签页，验证预览渲染正确
2. 验证标准DPI显示器上的拖动预览外观保持不变
3. 检查预览图像缩放和圆角显示是否正常
4. 使用不同窗口大小测试，确保预览生成一致

## Summary by Sourcery

Correct tab drag preview scaling by removing redundant high DPI device pixel ratio adjustments and using consistent pixel values for screenshot and scaling operations.

Bug Fixes:
- Fix incorrect tab drag preview scaling on high DPI displays by removing redundant device pixel ratio multiplications and divisions.

Enhancements:
- Use consistent pixel values for window screenshots, image scaling, and rounded corners without redundant DPI ratio adjustments.