### PR TITLE
6.5.101

### DIFF
--- a/assets/dev/dfm6-base/dfm6-base.pc.in
+++ b/assets/dev/dfm6-base/dfm6-base.pc.in
@@ -2,7 +2,8 @@ Name: @BIN_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: dfm6-io dfm6-mount dfm6-burn Qt6Core Qt6Widgets Qt6Gui Qt6Concurrent Qt6DBus Qt6Sql Qt6Network dtk6core dtk6gui dtk6widget libappimage libheif poppler-cpp gio-unix-2.0 mount x11
+Requires: dfm6-io dfm6-mount dfm6-burn Qt6Core Qt6Widgets Qt6Gui Qt6Concurrent Qt6DBus Qt6Sql Qt6Network dtk6core dtk6gui dtk6widget gio-unix-2.0 mount x11
+Requires.private: libappimage libheif poppler-cpp
 Cflags: -I"@CMAKE_INSTALL_FULL_INCLUDEDIR@"
 Libs: -L"@CMAKE_INSTALL_FULL_LIBDIR@" -l@BIN_NAME@
 Libs.private: -L"@CMAKE_INSTALL_FULL_LIBDIR@" -l@BIN_NAME@

--- a/assets/dev/dfm6-base/dfm6-baseConfig.cmake.in
+++ b/assets/dev/dfm6-base/dfm6-baseConfig.cmake.in
@@ -6,14 +6,13 @@ find_dependency(dfm6-mount)
 find_dependency(dfm6-burn)
 find_dependency(Qt6 COMPONENTS Core Widgets Gui Concurrent DBus Sql Network)
 find_dependency(Dtk6 COMPONENTS Core Widget Gui)
-find_dependency(libappimage)
 
 # 添加 PkgConfig 依赖
 find_dependency(PkgConfig)
 pkg_check_modules(gio REQUIRED IMPORTED_TARGET gio-unix-2.0)
 pkg_check_modules(mount REQUIRED IMPORTED_TARGET mount)
-pkg_check_modules(LIBHEIF REQUIRED libheif)
 pkg_search_module(X11 REQUIRED IMPORTED_TARGET x11)
+
 
 set(@BIN_NAME@_INCLUDE_DIR @CMAKE_INSTALL_FULL_INCLUDEDIR@)
 set(@BIN_NAME@_LIBRARIES @BIN_NAME@)

--- a/cmake/DFMLibraryConfig.cmake
+++ b/cmake/DFMLibraryConfig.cmake
@@ -56,7 +56,9 @@ function(dfm_configure_base_library target_name)
     endif()
     
     # Link libraries
-    target_link_libraries(${target_name} 
+    # PUBLIC: Dependencies exposed in public API (headers)
+    # PRIVATE: Internal implementation dependencies
+    target_link_libraries(${target_name}
         PUBLIC
             Qt${QT_VERSION_MAJOR}::Core
             Qt${QT_VERSION_MAJOR}::Widgets
@@ -74,9 +76,10 @@ function(dfm_configure_base_library target_name)
             PkgConfig::mount
             PkgConfig::gio
             PkgConfig::X11
+            ${DFM_EXTRA_LIBRARIES}
+        PRIVATE
             poppler-cpp
             ${LIBHEIF_LIBRARIES}
-            ${DFM_EXTRA_LIBRARIES}  
             libappimage
     )
     
@@ -153,6 +156,7 @@ endfunction()
 # Function to get library dependencies for testing
 function(dfm_get_library_test_dependencies lib_name result_var)
     if(lib_name STREQUAL "dfm-base")
+        # For testing, we need both public and private dependencies
         set(${result_var} "Qt6::Core;Qt6::Widgets;Qt6::Gui;Qt6::Concurrent;Qt6::DBus;Qt6::Sql;Qt6::Network;Dtk6::Core;Dtk6::Widget;Dtk6::Gui;dfm6-io;dfm6-mount;dfm6-burn;PkgConfig::mount;PkgConfig::gio;PkgConfig::X11;poppler-cpp;${LIBHEIF_LIBRARIES};libappimage" PARENT_SCOPE)
     elseif(lib_name STREQUAL "dfm-framework")
         set(${result_var} "Qt6::Core;Qt6::Concurrent;Dtk6::Core;${CMAKE_DL_LIBS}" PARENT_SCOPE)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.101) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 31 Oct 2025 14:49:31 +0800
+
 dde-file-manager (6.5.100) unstable; urgency=medium
 
   * fix bugs 


### PR DESCRIPTION
## Summary by Sourcery

Refactor CMake build configuration to separate public and private dependency scopes, adjust test dependency listing accordingly, and bump the project version to 6.5.101.

Enhancements:
- Clarify PUBLIC vs PRIVATE dependencies in CMake target_link_libraries and move EXTRA_LIBRARIES to public scope
- Include both public and private libraries in the dfm_get_library_test_dependencies function

Chores:
- Bump package version to 6.5.101 in Debian changelog and configuration templates