### PR TITLE
feat: add comprehensive unit tests for dirshare plugin

### DIFF
--- a/autotests/plugins/dfmplugin-dirshare/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-dirshare/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Use DFM enhanced test utilities to create plugin test
-dfm_create_plugin_test_enhanced("dfmplugin-dirshare" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-dirshare") 
+dfm_create_plugin_test_enhanced("dfmplugin-dirshare" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-dirshare")

--- a/autotests/plugins/dfmplugin-dirshare/test_dirshare.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_dirshare.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "dirshare.h"
+#include "utils/usersharehelper.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QWidget>
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+using namespace dfmplugin_dirshare;
+
+using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+Q_DECLARE_METATYPE(CustomViewExtensionView)
+
+class UT_DirShare : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = new DirShare();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete ins;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    DirShare *ins { nullptr };
+};
+
+TEST_F(UT_DirShare, Initialize)
+{
+    stub.set_lamda(&DirShare::bindEvents, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(ins->initialize());
+}
+
+TEST_F(UT_DirShare, Start)
+{
+    stub.set_lamda(&DirShare::bindScene, [] { __DBG_STUB_INVOKE__ });
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, CustomViewExtensionView, const QString &&, const int &&);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_TRUE(ins->start());
+}
+
+TEST_F(UT_DirShare, CreateShareControlWidget)
+{
+    EXPECT_EQ(nullptr, ins->createShareControlWidget(QUrl("smb://1.2.3.4")));
+
+    stub.set_lamda(&UserShareHelper::needDisableShareWidget, [] { __DBG_STUB_INVOKE__ return true; });
+    bool canShare = false;
+    stub.set_lamda(&UserShareHelper::canShare, [&] { __DBG_STUB_INVOKE__ return canShare; });
+
+    EXPECT_EQ(nullptr, ins->createShareControlWidget(QUrl::fromLocalFile("/home")));
+    canShare = true;
+    EXPECT_NO_FATAL_FAILURE(QScopedPointer<QWidget>(ins->createShareControlWidget(QUrl::fromLocalFile("/home"))));
+}
+
+TEST_F(UT_DirShare, BindScene)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push1)(const QString &, const QString &, QString);
+    auto menu_contains_event_caller = static_cast<Push1>(&dpf::EventChannelManager::push);
+    bool contains = true;
+    stub.set_lamda(menu_contains_event_caller, [&] { __DBG_STUB_INVOKE__ return contains; });
+
+    typedef QVariant (dpf::EventChannelManager::*Push2)(const QString &, const QString &, QString, const QString &);
+    auto menu_bind_event_caller = static_cast<Push1>(&dpf::EventChannelManager::push);
+    stub.set_lamda(menu_bind_event_caller, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene("sss"));
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene(""));
+
+    typedef bool (dpf::EventDispatcherManager::*Subscribe)(const QString &, const QString &, DirShare *, decltype(&DirShare::bindSceneOnAdded));
+    auto sub = static_cast<Subscribe>(&dpf::EventDispatcherManager::subscribe);
+    stub.set_lamda(sub, [] { __DBG_STUB_INVOKE__ return true; });
+
+    contains = false;
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene("sss"));
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene(""));
+}
+
+TEST_F(UT_DirShare, BindSceneOnAdded)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->waitToBind.insert("Hello"));
+    EXPECT_TRUE(ins->waitToBind.count() == 1);
+
+    typedef bool (dpf::EventDispatcherManager::*Unsubscribe)(const QString &, const QString &, DirShare *, decltype(&DirShare::bindSceneOnAdded));
+    auto unsub = static_cast<Unsubscribe>(&dpf::EventDispatcherManager::unsubscribe);
+    stub.set_lamda(unsub, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&DirShare::bindScene, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ins->bindSceneOnAdded("Hello"));
+    EXPECT_NO_FATAL_FAILURE(ins->bindSceneOnAdded("World"));
+}
+
+TEST_F(UT_DirShare, BindEvents)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->bindEvents());
+}
+
+TEST_F(UT_DirShare, OnShareStateChanged)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->onShareStateChanged(""));
+
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QUrl);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins->onShareStateChanged("/home"));
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_dirsharemenuscene.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_dirsharemenuscene.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "dirsharemenu/dirsharemenuscene.h"
+#include "private/dirsharemenuscene_p.h"
+#include "utils/usersharehelper.h"
+
+#include <dfm-base/interfaces/abstractmenuscene.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-framework/dpf.h>
+
+#include <QMenu>
+#include <QAction>
+#include <QUrl>
+#include <QStandardPaths>
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_DirShareMenuScene : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        scene = qobject_cast<DirShareMenuScene *>(DirShareMenuCreator().create());
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    DirShareMenuScene *scene { nullptr };
+};
+
+TEST_F(UT_DirShareMenuScene, Name)
+{
+    EXPECT_TRUE("DirShareMenu" == scene->name());
+    EXPECT_FALSE(scene->name().isEmpty());
+}
+
+TEST_F(UT_DirShareMenuScene, Initialize)
+{
+    QVariantHash params;
+    EXPECT_FALSE(scene->initialize(params));
+
+    QList<QUrl> selectedUrls;
+    QUrl nonFileUrl("smb://1.2.3.4");
+    selectedUrls.append(nonFileUrl);
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(selectedUrls));
+    EXPECT_FALSE(scene->initialize(params));
+
+    params.clear();
+    selectedUrls.clear();
+    selectedUrls.append(QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)));
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(selectedUrls));
+    EXPECT_TRUE(scene->initialize(params));
+    EXPECT_NO_FATAL_FAILURE(scene->initialize(params));
+}
+
+TEST_F(UT_DirShareMenuScene, Create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu *menu = new QMenu;
+    EXPECT_FALSE(scene->create(menu));
+
+    QList<QUrl> selectedUrls;
+    selectedUrls.append(QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)));
+    QVariantHash params;
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(selectedUrls));
+
+    bool shared = false;
+    stub.set_lamda(&UserShareHelper::isShared, [&] { __DBG_STUB_INVOKE__ return shared; });
+    stub.set_lamda(&UserShareHelper::canShare, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&UserShareHelper::needDisableShareWidget, [] { __DBG_STUB_INVOKE__ return false; });
+
+    EXPECT_NO_FATAL_FAILURE(scene->initialize(params));
+    EXPECT_TRUE(scene->create(menu));
+    EXPECT_FALSE(menu->actions().isEmpty());
+    EXPECT_TRUE(menu->actions().first()->property(ActionPropertyKey::kActionID).toString() == "add-share");
+
+    shared = true;
+    delete menu;
+    menu = new QMenu;
+    EXPECT_TRUE(scene->create(menu));
+    EXPECT_FALSE(menu->actions().isEmpty());
+    EXPECT_TRUE(menu->actions().first()->property(ActionPropertyKey::kActionID).toString() == "remove-share");
+
+    delete menu;
+}
+
+TEST_F(UT_DirShareMenuScene, UpdateState)
+{
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(nullptr));
+
+    QMenu *menu = new QMenu;
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(menu));
+    delete menu;
+}
+
+TEST_F(UT_DirShareMenuScene, Triggered)
+{
+    EXPECT_FALSE(scene->triggered(nullptr));
+
+    QAction *addAct = new QAction;
+    addAct->setProperty(ActionPropertyKey::kActionID, "add-share");
+    scene->d->predicateAction.insert("add-share", addAct);
+
+    QAction *delAct = new QAction;
+    delAct->setProperty(ActionPropertyKey::kActionID, "remove-share");
+    scene->d->predicateAction.insert("remove-act", delAct);
+
+    scene->d->selectFiles.append(QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)));
+
+    stub.set_lamda(&DirShareMenuScenePrivate::addShare, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::removeShareByPath, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(scene->triggered(addAct));
+    EXPECT_TRUE(scene->triggered(delAct));
+
+    delete addAct;
+    delete delAct;
+}
+
+TEST_F(UT_DirShareMenuScene, Scene)
+{
+    QAction *addAct = new QAction;
+    addAct->setProperty(ActionPropertyKey::kActionID, "add-share");
+    scene->d->predicateAction.insert("add-share", addAct);
+
+    QAction *delAct = new QAction;
+    delAct->setProperty(ActionPropertyKey::kActionID, "remove-share");
+
+    EXPECT_FALSE(scene->scene(nullptr));
+    EXPECT_TRUE(scene == scene->scene(addAct));
+    EXPECT_TRUE(nullptr == scene->scene(delAct));
+}
+
+TEST_F(UT_DirShareMenuScene, DirShareMenuScenePrivate_addShare)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QList<QUrl>, QVariantHash &);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(scene->d->addShare(QUrl()));
+    EXPECT_NO_FATAL_FAILURE(scene->d->addShare(QUrl::fromLocalFile("/")));
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_sharecontrolwidget.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_sharecontrolwidget.cpp
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "widget/sharecontrolwidget.h"
+#include "utils/usersharehelper.h"
+#include "dfmplugin_dirshare_global.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.h>
+
+#include <QLineEdit>
+#include <QDir>
+#include <QFileInfo>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QTextBrowser>
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+
+class UT_ShareControlWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        widget = new ShareControlWidget(QUrl::fromLocalFile("/home"));
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete widget;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    ShareControlWidget *widget { nullptr };
+};
+
+TEST_F(UT_ShareControlWidget, SetOption)
+{
+    EXPECT_NO_FATAL_FAILURE(ShareControlWidget::setOption(widget, {}));
+}
+
+TEST_F(UT_ShareControlWidget, ValidateShareName)
+{
+    widget->shareNameEditor->clear();
+    EXPECT_FALSE(widget->validateShareName());
+
+    stub.set_lamda(&DialogManager::showErrorDialog, [] { __DBG_STUB_INVOKE__ });
+    widget->shareNameEditor->setText(".");
+    EXPECT_FALSE(widget->validateShareName());
+    widget->shareNameEditor->setText("..");
+    EXPECT_FALSE(widget->validateShareName());
+
+    widget->shareNameEditor->setText("Hello");
+    bool isShared = true;
+    stub.set_lamda(&UserShareHelper::isShared, [&] { __DBG_STUB_INVOKE__ return isShared; });
+    QString name = "Hello";
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [&] { __DBG_STUB_INVOKE__ return name; });
+    EXPECT_TRUE(widget->validateShareName());
+
+    typedef QFileInfoList (QDir::*EntryInfoList)(QDir::Filters, QDir::SortFlags) const;
+    auto entryInfoList = static_cast<EntryInfoList>(&QDir::entryInfoList);
+    stub.set_lamda(entryInfoList, [] { __DBG_STUB_INVOKE__ return QList<QFileInfo> { QFileInfo() }; });
+    stub.set_lamda(&QFileInfo::fileName, [] { __DBG_STUB_INVOKE__ return "hello"; });
+    bool writable = false;
+    stub.set_lamda(&QFileInfo::isWritable, [&] { __DBG_STUB_INVOKE__ return writable; });
+    int execRet = QDialog::Rejected;
+    stub.set_lamda(VADDR(QDialog, exec), [&] { __DBG_STUB_INVOKE__ return execRet; });
+    widget->shareNameEditor->setText("Hello");
+    isShared = false;
+    EXPECT_FALSE(widget->validateShareName());
+
+    execRet = QDialog::Accepted;
+    writable = true;
+    EXPECT_TRUE(widget->validateShareName());
+}
+
+TEST_F(UT_ShareControlWidget, UpdateShare)
+{
+    stub.set_lamda(&ShareControlWidget::shareFolder, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(widget->updateShare());
+}
+
+TEST_F(UT_ShareControlWidget, ShareFolder)
+{
+    QSignalBlocker b4(widget->shareSwitcher);
+    QSignalBlocker b3(widget->sharePermissionSelector);
+    QSignalBlocker b2(widget->shareAnonymousSelector);
+    QSignalBlocker b1(widget->shareNameEditor);
+
+    widget->shareSwitcher->setChecked(false);
+    EXPECT_NO_FATAL_FAILURE(widget->shareFolder());
+
+    bool validName = false;
+    stub.set_lamda(&ShareControlWidget::validateShareName, [&] { __DBG_STUB_INVOKE__ return validName; });
+    widget->shareSwitcher->setChecked(true);
+    EXPECT_NO_FATAL_FAILURE(widget->shareFolder());
+    EXPECT_EQ(false, widget->shareSwitcher->isChecked());
+    EXPECT_EQ(false, widget->sharePermissionSelector->isEnabled());
+    EXPECT_EQ(false, widget->shareAnonymousSelector->isEnabled());
+
+    validName = true;
+    // disable anonymous
+    widget->shareAnonymousSelector->setCurrentIndex(0);
+    stub.set_lamda(&UserShareHelper::share, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_NO_FATAL_FAILURE(widget->shareFolder());
+    EXPECT_EQ(false, widget->shareSwitcher->isChecked());
+    EXPECT_EQ(false, widget->sharePermissionSelector->isEnabled());
+    EXPECT_EQ(false, widget->shareAnonymousSelector->isEnabled());
+
+    // enable anonymous
+    widget->shareAnonymousSelector->setCurrentIndex(1);
+}
+
+TEST_F(UT_ShareControlWidget, UnshareFolder)
+{
+    stub.set_lamda(&UserShareHelper::removeShareByPath, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(widget->unshareFolder());
+}
+
+TEST_F(UT_ShareControlWidget, UpdateWidgetStatus)
+{
+    QSignalBlocker b1(widget->shareSwitcher);
+    QSignalBlocker b2(widget->sharePermissionSelector);
+    QSignalBlocker b3(widget->shareAnonymousSelector);
+    QSignalBlocker b4(widget->shareNameEditor);
+
+    widget->url = QUrl::fromLocalFile("/home");
+    EXPECT_NO_FATAL_FAILURE(widget->updateWidgetStatus("/"));
+
+    QVariantMap share;
+    stub.set_lamda(&UserShareHelper::shareInfoByPath, [&] { __DBG_STUB_INVOKE__ return share; });
+    EXPECT_NO_FATAL_FAILURE(widget->updateWidgetStatus("/home"));
+    EXPECT_EQ(false, widget->shareSwitcher->isChecked());
+    EXPECT_EQ(false, widget->sharePermissionSelector->isEnabled());
+    EXPECT_EQ(false, widget->shareAnonymousSelector->isEnabled());
+
+    share.insert(ShareInfoKeys::kName, "hello");
+    share.insert(ShareInfoKeys::kPath, "/home");
+    stub.set_lamda(&UserShareHelper::whoShared, [] { __DBG_STUB_INVOKE__ return 1000; });
+    EXPECT_NO_FATAL_FAILURE(widget->updateWidgetStatus("/home"));
+    //    EXPECT_EQ(true, widget->sharePermissionSelector->isEnabled());
+    //    EXPECT_EQ(true, widget->shareAnonymousSelector->isEnabled());
+}
+
+TEST_F(UT_ShareControlWidget, OnSambapasswordSet)
+{
+    QSignalBlocker b1(widget->shareSwitcher);
+    QSignalBlocker b2(widget->sharePermissionSelector);
+    QSignalBlocker b3(widget->shareAnonymousSelector);
+    QSignalBlocker b4(widget->shareNameEditor);
+
+    EXPECT_NO_FATAL_FAILURE(widget->onSambaPasswordSet(true));
+    EXPECT_TRUE(widget->isSharePasswordSet);
+}
+
+TEST_F(UT_ShareControlWidget, ShowMoreInfo)
+{
+    EXPECT_NO_FATAL_FAILURE(widget->showMoreInfo(true));
+    EXPECT_FALSE(widget->m_shareNotes->isHidden());
+    EXPECT_TRUE(widget->refreshIp);
+    EXPECT_TRUE(widget->refreshIp->isActive());
+    EXPECT_NO_FATAL_FAILURE(widget->showMoreInfo(false));
+    EXPECT_TRUE(widget->m_shareNotes->isHidden());
+    EXPECT_FALSE(widget->refreshIp->isActive());
+}
+
+TEST_F(UT_ShareControlWidget, UserShareOperation)
+{
+    QSignalBlocker b1(widget->shareSwitcher);
+    QSignalBlocker b2(widget->sharePermissionSelector);
+    QSignalBlocker b3(widget->shareAnonymousSelector);
+    QSignalBlocker b4(widget->shareNameEditor);
+
+    stub.set_lamda(&ShareControlWidget::showSharePasswordSettingsDialog, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&ShareControlWidget::shareFolder, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&ShareControlWidget::unshareFolder, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&ShareControlWidget::showMoreInfo, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(widget->userShareOperation(false));
+    EXPECT_NO_FATAL_FAILURE(widget->userShareOperation(true));
+}
+
+TEST_F(UT_ShareControlWidget, ShowSharePasswordSettingsDialog)
+{
+    widget->setProperty("UserSharePwdSettingDialogShown", true);
+    EXPECT_NO_FATAL_FAILURE(widget->showSharePasswordSettingsDialog());
+
+    widget->setProperty("UserSharePwdSettingDialogShown", false);
+    stub.set_lamda(VADDR(QDialog, show), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserSharePasswordSettingDialog::onButtonClicked, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::currentUserName, [] { __DBG_STUB_INVOKE__ return "test"; });
+    stub.set_lamda(&UserShareHelper::setSambaPasswd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(widget->showSharePasswordSettingsDialog());
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_sharewatchermanager.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_sharewatchermanager.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "utils/sharewatchermanager.h"
+
+#include <dfm-base/file/local/localfilewatcher.h>
+
+using namespace dfmplugin_dirshare;
+
+class UT_ShareWatcherManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        manager = new ShareWatcherManager;
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete manager;
+    }
+
+private:
+    stub_ext::StubExt stub;
+
+    ShareWatcherManager *manager { nullptr };
+};
+
+TEST_F(UT_ShareWatcherManager, Add)
+{
+    EXPECT_TRUE(manager->watchers.count() == 0);
+    EXPECT_TRUE(manager->add("/"));
+    EXPECT_NO_FATAL_FAILURE(manager->add("/"));
+    EXPECT_TRUE(manager->watchers.count() == 1);
+}
+
+TEST_F(UT_ShareWatcherManager, Remove)
+{
+    EXPECT_NO_FATAL_FAILURE(manager->add("/"));
+    EXPECT_TRUE(manager->watchers.count() == 1);
+    EXPECT_NO_FATAL_FAILURE(manager->remove("/"));
+    EXPECT_TRUE(manager->watchers.count() == 0);
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_usersharehelper.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_usersharehelper.cpp
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "utils/usersharehelper.h"
+#include "utils/sharewatchermanager.h"
+#include "dfmplugin_dirshare_global.h"
+
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-framework/event/event.h>
+
+#include <QStandardPaths>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QDBusMessage>
+#include <QSettings>
+#include <QProcess>
+
+#define DeclareDBusCallFunc_Full()                                         \
+    typedef QDBusMessage (QDBusAbstractInterface::*Call)(const QString &,  \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &)
+
+#define DeclareDBusCallFunc_Custom(params...) \
+    typedef QDBusMessage (QDBusAbstractInterface::*Call)(params)
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+
+class UT_UserShareHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_UserShareHelper, Instance)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelper::instance());
+    EXPECT_EQ(UserShareHelper::instance(), UserShareHelper::instance());
+}
+
+TEST_F(UT_UserShareHelper, CanShare)
+{
+    EXPECT_FALSE(UserShareHelperInstance->canShare(nullptr));
+
+    bool isProtocolFile = true;
+    stub.set_lamda(&DeviceProxyManager::isFileOfProtocolMounts, [&] { __DBG_STUB_INVOKE__ return isProtocolFile; });
+    auto info = InfoFactory::create<SyncFileInfo>(QUrl::fromLocalFile("/home"));
+    EXPECT_TRUE(info);
+
+    EXPECT_FALSE(UserShareHelperInstance->canShare(info));
+
+    isProtocolFile = false;
+    bool isBurnFile = true;
+    stub.set_lamda(&DeviceProxyManager::isFileFromOptical, [&] { __DBG_STUB_INVOKE__ return isBurnFile; });
+    EXPECT_FALSE(UserShareHelperInstance->canShare(info));
+
+    isBurnFile = false;
+    EXPECT_TRUE(UserShareHelperInstance->canShare(info));
+}
+
+TEST_F(UT_UserShareHelper, NeedDisableShareWidget)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->needDisableShareWidget(nullptr));
+    EXPECT_FALSE(UserShareHelperInstance->needDisableShareWidget(nullptr));
+}
+
+TEST_F(UT_UserShareHelper, Share)
+{
+    bool serviceRunning = false;
+    stub.set_lamda(&UserShareHelper::isSambaServiceRunning, [&] { __DBG_STUB_INVOKE__ return serviceRunning; });
+    bool startSmbResult = false;
+    stub.set_lamda(&UserShareHelper::startSambaServiceAsync, [&](void *, StartSambaFinished finished) {
+        __DBG_STUB_INVOKE__
+        serviceRunning = startSmbResult;
+        if (finished) finished(startSmbResult, "");
+    });
+
+    EXPECT_FALSE(UserShareHelperInstance->share({}));
+
+    startSmbResult = true;
+    EXPECT_FALSE(UserShareHelperInstance->share({}));
+    EXPECT_TRUE(serviceRunning);
+
+    QString execPath;
+    stub.set_lamda(&QStandardPaths::findExecutable, [&] { __DBG_STUB_INVOKE__ return execPath; });
+    stub.set_lamda(&DialogManager::showErrorDialog, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_FALSE(UserShareHelperInstance->share({}));
+
+    execPath = "this is where net command located";
+    stub.set_lamda(&UserShareHelper::getOldShareByNewShare, [] { __DBG_STUB_INVOKE__ return QVariantMap(); });
+    bool isValidShare = false;
+    stub.set_lamda(&UserShareHelper::isValidShare, [&] { __DBG_STUB_INVOKE__ return isValidShare; });
+    EXPECT_TRUE(UserShareHelperInstance->share({}));
+
+    isValidShare = true;
+    QVariantMap shareInfo { { ShareInfoKeys::kName, "-" } };
+    EXPECT_FALSE(UserShareHelperInstance->share(shareInfo));
+
+    shareInfo.insert(ShareInfoKeys::kName, "hello");
+    shareInfo.insert(ShareInfoKeys::kWritable, true);
+    shareInfo.insert(ShareInfoKeys::kAnonymous, true);
+    stub.set_lamda(&UserShareHelper::readPort, [] { __DBG_STUB_INVOKE__ return 139; });
+    int cmdResult = -1;
+    stub.set_lamda(&UserShareHelper::runNetCmd, [&] { __DBG_STUB_INVOKE__ return cmdResult; });
+    stub.set_lamda(&UserShareHelper::removeShareByPath, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_FALSE(UserShareHelperInstance->share(shareInfo));
+
+    cmdResult = 0;
+    EXPECT_TRUE(UserShareHelperInstance->share(shareInfo));
+}
+
+TEST_F(UT_UserShareHelper, IsUserSharepasswordSet)
+{
+    DeclareDBusCallFunc_Custom(const QString &, const QString &);
+    auto call = static_cast<Call>(&QDBusAbstractInterface::call);
+    stub.set_lamda(call, [] { __DBG_STUB_INVOKE__ return QDBusMessage(); });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->isUserSharePasswordSet("test"));
+}
+
+TEST_F(UT_UserShareHelper, SetSambaPasswd)
+{
+    DeclareDBusCallFunc_Custom(const QString &, const QString &, const QString &);
+    auto call = static_cast<Call>(&QDBusAbstractInterface::call);
+    stub.set_lamda(call, [] { __DBG_STUB_INVOKE__ return QDBusMessage(); });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->setSambaPasswd("test", "test"));
+}
+
+TEST_F(UT_UserShareHelper, RemoveShareByPath)
+{
+    QString shareName;
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [&] { __DBG_STUB_INVOKE__ return shareName; });
+    stub.set_lamda(&UserShareHelper::removeShareByShareName, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->removeShareByPath("/"));
+}
+
+TEST_F(UT_UserShareHelper, ReadPort)
+{
+    int port = 0;
+    stub.set_lamda(static_cast<QVariant (QSettings::*)(QAnyStringView) const>(&QSettings::value), [&] { __DBG_STUB_INVOKE__ return QVariant(port); });
+    EXPECT_EQ(0, UserShareHelperInstance->readPort());
+    port = 100;
+    EXPECT_EQ(port, UserShareHelperInstance->readPort());
+}
+
+TEST_F(UT_UserShareHelper, ShareInfos)
+{
+    EXPECT_EQ(UserShareHelperInstance->sharedInfos.count(), UserShareHelperInstance->shareInfos().count());
+}
+
+TEST_F(UT_UserShareHelper, ShareInfoByPath)
+{
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [] { __DBG_STUB_INVOKE__ return ""; });
+    stub.set_lamda(&UserShareHelper::shareInfoByShareName, [] { __DBG_STUB_INVOKE__ return QVariantMap { { ShareInfoKeys::kName, "hello" } }; });
+    EXPECT_TRUE(UserShareHelperInstance->shareInfoByPath("/").value(ShareInfoKeys::kName).toString() == "hello");
+}
+
+TEST_F(UT_UserShareHelper, ShareInfoByShareName)
+{
+    EXPECT_TRUE(UserShareHelperInstance->shareInfoByShareName("").isEmpty());
+    UserShareHelperInstance->sharedInfos.insert("hello", QVariantMap { { ShareInfoKeys::kName, "hello" } });
+    EXPECT_TRUE(UserShareHelperInstance->shareInfoByShareName("hello").value(ShareInfoKeys::kName).toString() == "hello");
+    UserShareHelperInstance->sharedInfos.clear();
+}
+
+TEST_F(UT_UserShareHelper, ShareNameByPath)
+{
+    EXPECT_TRUE(UserShareHelperInstance->shareNameByPath("/").isEmpty());
+
+    UserShareHelperInstance->sharePathToShareName.insert("/", QStringList { "hello", "world" });
+    EXPECT_EQ("world", UserShareHelperInstance->shareNameByPath("/"));
+    UserShareHelperInstance->sharePathToShareName.clear();
+}
+
+TEST_F(UT_UserShareHelper, WhoShared)
+{
+    stub.set_lamda(&QFileInfo::ownerId, [] { __DBG_STUB_INVOKE__ return 1000; });
+    EXPECT_EQ(1000, UserShareHelperInstance->whoShared("hello"));
+}
+
+TEST_F(UT_UserShareHelper, IsShared)
+{
+    UserShareHelperInstance->sharePathToShareName.insert("/", QStringList { "hello", "world" });
+    EXPECT_TRUE(UserShareHelperInstance->isShared("/"));
+    EXPECT_FALSE(UserShareHelperInstance->isShared("/home"));
+    UserShareHelperInstance->sharePathToShareName.clear();
+}
+
+TEST_F(UT_UserShareHelper, CurrentUserName)
+{
+    EXPECT_TRUE(!UserShareHelperInstance->currentUserName().isEmpty());
+}
+
+TEST_F(UT_UserShareHelper, IsSambaServiceRunning)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->isSambaServiceRunning());
+}
+
+TEST_F(UT_UserShareHelper, SharedIP)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->sharedIP());
+    EXPECT_FALSE(UserShareHelperInstance->sharedIP().isEmpty());
+}
+
+TEST_F(UT_UserShareHelper, HandleSetPassword)
+{
+    stub.set_lamda(&UserShareHelper::setSambaPasswd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleSetPassword("1234"));
+}
+
+TEST_F(UT_UserShareHelper, ReadShareInfos)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->readShareInfos(false));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->readShareInfos(true));
+}
+
+TEST_F(UT_UserShareHelper, OnShareChanged)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareChanged("/"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareChanged("/:tmp"));
+}
+
+TEST_F(UT_UserShareHelper, OnShareFileDeleted)
+{
+    stub.set_lamda(&UserShareHelper::onShareChanged, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::removeShareWhenShareFolderDeleted, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareFileDeleted("/var/lib/samba/usershares/hello"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareFileDeleted("/home/test"));
+}
+
+TEST_F(UT_UserShareHelper, OnShareMoved)
+{
+    stub.set_lamda(&UserShareHelper::onShareFileDeleted, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::onShareChanged, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareMoved("a", "b"));
+}
+
+TEST_F(UT_UserShareHelper, InitConnect)
+{
+    delete UserShareHelperInstance->pollingSharesTimer;
+    UserShareHelperInstance->pollingSharesTimer = nullptr;
+    EXPECT_TRUE(UserShareHelperInstance->pollingSharesTimer == nullptr);
+
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->initConnect());
+    EXPECT_TRUE(UserShareHelperInstance->pollingSharesTimer);
+}
+
+TEST_F(UT_UserShareHelper, InitMonitorPath)
+{
+    ShareInfoList lst;
+    lst.append(QVariantMap { {} });
+    stub.set_lamda(&UserShareHelper::shareInfos, [&] { __DBG_STUB_INVOKE__ return lst; });
+    stub.set_lamda(&ShareWatcherManager::add, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->initMonitorPath());
+}
+
+TEST_F(UT_UserShareHelper, RemoveShareWhenShareFolderDeleted)
+{
+    QString name;
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [&] { __DBG_STUB_INVOKE__ return name; });
+    stub.set_lamda(&UserShareHelper::removeShareByShareName, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->removeShareWhenShareFolderDeleted("/"));
+
+    name = "hello";
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->removeShareWhenShareFolderDeleted("/"));
+}
+
+TEST_F(UT_UserShareHelper, GetOldShareByNewShare)
+{
+    UserShareHelperInstance->sharePathToShareName.insert("hello", QStringList { "a", "B" });
+    UserShareHelperInstance->sharePathToShareName.insert("world", QStringList { "c", "d" });
+
+    stub.set_lamda(&UserShareHelper::shareInfoByShareName, [] { __DBG_STUB_INVOKE__ return QVariantMap(); });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->getOldShareByNewShare(QVariantMap { { ShareInfoKeys::kName, "hello" },
+                                                                                         { ShareInfoKeys::kPath, "world" } }));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->getOldShareByNewShare(QVariantMap {}));
+
+    UserShareHelperInstance->sharePathToShareName.clear();
+}
+
+TEST_F(UT_UserShareHelper, RunNetCmd) { }
+
+TEST_F(UT_UserShareHelper, HandleErrorWhenShareFailed)
+{
+    stub.set_lamda(&DialogManager::showErrorDialog, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, ""));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "is already a valid system user name"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "as we are restricted to only sharing directories we own."));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "contains invalid characters"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "net usershare add: failed to add share Error was"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "gethostname failed  net usershare add: cannot convert name"));
+}
+
+TEST_F(UT_UserShareHelper, MakeInfoByFileContent)
+{
+    QMap<QString, QString> fileContent { { "sharename", "hello" },
+                                         { "path", "/home" },
+                                         { "usershare_acl", "acl" } };
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->makeInfoByFileContent(fileContent));
+    QVariantMap share = UserShareHelperInstance->makeInfoByFileContent(fileContent);
+    EXPECT_TRUE(share.value(ShareInfoKeys::kName, "").toString() == "hello");
+}
+
+TEST_F(UT_UserShareHelper, ValidShareInfoCount)
+{
+    stub.set_lamda(&UserShareHelper::isValidShare, [] { __DBG_STUB_INVOKE__ return true; });
+    UserShareHelperInstance->sharedInfos.clear();
+    UserShareHelperInstance->sharedInfos.insert("hello", QVariantMap());
+    EXPECT_EQ(1, UserShareHelperInstance->validShareInfoCount());
+    UserShareHelperInstance->sharedInfos.clear();
+}
+
+TEST_F(UT_UserShareHelper, StartSmbService) { }
+
+TEST_F(UT_UserShareHelper, SetSmbdAutoStart)
+{
+    DeclareDBusCallFunc_Custom(const QString &);
+    auto call = static_cast<Call>(&QDBusAbstractInterface::call);
+    stub.set_lamda(call, [] { __DBG_STUB_INVOKE__ return QDBusMessage(); });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->setSmbdAutoStart());
+    EXPECT_FALSE(UserShareHelperInstance->setSmbdAutoStart());
+}
+
+TEST_F(UT_UserShareHelper, IsValidShare)
+{
+    EXPECT_TRUE(UserShareHelperInstance->isValidShare(QVariantMap { { ShareInfoKeys::kName, "hello" },
+                                                                    { ShareInfoKeys::kPath, "/" } }));
+
+    EXPECT_FALSE(UserShareHelperInstance->isValidShare(QVariantMap { { ShareInfoKeys::kName, "world" },
+                                                                     { ShareInfoKeys::kPath, "/where/not/exists" } }));
+}
+
+TEST_F(UT_UserShareHelper, EmitShareCountChanged)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(const QString &, const QString &, int);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->emitShareCountChanged(10));
+}
+
+TEST_F(UT_UserShareHelper, EmitShareAdded)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(const QString &, const QString &, QString);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->emitShareAdded("/home/xxxx"));
+}
+
+TEST_F(UT_UserShareHelper, EmitShareRemoved)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(const QString &, const QString &, QString);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->emitShareAdded("/home/xxxx"));
+}


### PR DESCRIPTION
1. Added unit tests for DirShare class covering initialization, start,
widget creation, and event binding
2. Implemented tests for DirShareMenuScene including menu creation,
state updates, and action triggers
3. Created ShareControlWidget tests for share validation, widget status
updates, and user operations
4. Added ShareWatcherManager tests for watcher management functionality
5. Implemented comprehensive UserShareHelper tests covering share
operations, validation, and error handling
6. Tests use stubext for mocking and gtest framework for assertions
7. Covers core functionality including share creation, removal,
validation, and UI interactions

Influence:
1. Verify all unit tests pass with make test
2. Test share functionality with different file paths and permissions
3. Validate menu scene behavior with various file selections
4. Check share control widget interactions and validation logic
5. Test watcher manager add/remove operations
6. Verify error handling in share operations

feat: 为目录共享插件添加全面单元测试

1. 为 DirShare 类添加单元测试，覆盖初始化、启动、控件创建和事件绑定
2. 实现 DirShareMenuScene 测试，包括菜单创建、状态更新和动作触发
3. 创建 ShareControlWidget 测试，用于分享验证、控件状态更新和用户操作
4. 添加 ShareWatcherManager 测试，用于监视器管理功能
5. 实现全面的 UserShareHelper 测试，覆盖分享操作、验证和错误处理
6. 测试使用 stubext 进行模拟和 gtest 框架进行断言
7. 覆盖核心功能包括分享创建、删除、验证和 UI 交互

Influence:
1. 验证所有单元测试通过 make test
2. 使用不同文件路径和权限测试分享功能
3. 验证菜单场景在各种文件选择下的行为
4. 检查分享控制控件的交互和验证逻辑
5. 测试监视器管理器的添加/删除操作
6. 验证分享操作中的错误处理
