### PR TITLE
chore: add LICENSE to filegroupdata.cpp

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/groups/filegroupdata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/filegroupdata.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #include "filegroupdata.h"
 
 #include <dfm-base/dfm_global_defines.h>


### PR DESCRIPTION
add LICENSE to filegroupdata.cpp

Log:

## Summary by Sourcery

Chores:
- Add SPDX license header to filegroupdata.cpp