### PR TITLE
test: add comprehensive unit tests for tag plugin

### DIFF
--- a/autotests/plugins/dfmplugin-tag/test_anythingmonitorfilter.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_anythingmonitorfilter.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/anythingmonitorfilter.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/utils/fileutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QFile>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_AnythingMonitorFilter : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = &AnythingMonitorFilter::instance();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+    AnythingMonitorFilter *ins;
+};
+
+TEST_F(UT_AnythingMonitorFilter, whetherFilterCurrentPath)
+{
+    EXPECT_TRUE(ins->whetherFilterCurrentPath("/media"));
+    EXPECT_TRUE(!ins->whetherFilterCurrentPath("~/.local/share/Trash"));
+}

--- a/autotests/plugins/dfmplugin-tag/test_filetagcache.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_filetagcache.cpp
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/utils/private/filetagcache_p.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QVariantMap>
+
+using namespace dfmplugin_tag;
+
+class UT_FileTagCacheController : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // Stub QThread operations to avoid thread issues in tests
+        stub.set_lamda(ADDR(QThread, start), [](QThread*, QThread::Priority) {
+            __DBG_STUB_INVOKE__
+            // Prevent thread from starting
+        });
+
+        stub.set_lamda(ADDR(QThread, quit), [](QThread*) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(static_cast<bool (QThread::*)(QDeadlineTimer)>(&QThread::wait), [] {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        controller = &FileTagCacheController::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    FileTagCacheController *controller = nullptr;
+};
+
+TEST_F(UT_FileTagCacheController, instance)
+{
+    // Test singleton instance
+    FileTagCacheController *instance1 = &FileTagCacheController::instance();
+    FileTagCacheController *instance2 = &FileTagCacheController::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFile_Empty)
+{
+    // Test getting tags for empty file path
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+
+    QStringList tags = controller->getTagsByFile("");
+
+    EXPECT_TRUE(tags.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFile_ValidFile)
+{
+    // Test getting tags for valid file
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Tag1" << "Tag2";
+        return tags;
+    });
+
+    QStringList tags = controller->getTagsByFile("/home/user/test.txt");
+
+    EXPECT_EQ(tags.size(), 2);
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFiles_Empty)
+{
+    // Test getting tags for empty file list
+    QStringList paths;
+
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+
+    QStringList tags = controller->getTagsByFiles(paths);
+
+    EXPECT_TRUE(tags.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFiles_MultipleFiles)
+{
+    // Test getting tags for multiple files
+    QStringList paths;
+    paths << "/home/user/file1.txt" << "/home/user/file2.txt";
+
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Tag1" << "Tag2";
+        return tags;
+    });
+
+    QStringList tags = controller->getTagsByFiles(paths);
+
+    EXPECT_EQ(tags.size(), 2);
+}
+
+TEST_F(UT_FileTagCacheController, getCacheTagsColor_Empty)
+{
+    // Test getting colors for empty tag list
+    QStringList tags;
+
+    stub.set_lamda(&FileTagCache::getTagsColor, [](const FileTagCache*, const QStringList&) -> QMap<QString, QColor> {
+        __DBG_STUB_INVOKE__
+        return QMap<QString, QColor>();
+    });
+
+    QMap<QString, QColor> colors = controller->getCacheTagsColor(tags);
+
+    EXPECT_TRUE(colors.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getCacheTagsColor_ValidTags)
+{
+    // Test getting colors for valid tags
+    QStringList tags;
+    tags << "Tag1" << "Tag2";
+
+    stub.set_lamda(&FileTagCache::getTagsColor, [](const FileTagCache*, const QStringList&) -> QMap<QString, QColor> {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> colors;
+        colors["Tag1"] = QColor("#ffa503");
+        colors["Tag2"] = QColor("#ff1c49");
+        return colors;
+    });
+
+    QMap<QString, QColor> colors = controller->getCacheTagsColor(tags);
+
+    EXPECT_EQ(colors.size(), 2);
+    EXPECT_TRUE(colors.contains("Tag1"));
+    EXPECT_TRUE(colors.contains("Tag2"));
+}
+
+TEST_F(UT_FileTagCacheController, findChildren_Empty)
+{
+    // Test finding children for empty path
+    stub.set_lamda(&FileTagCache::findChildren, [](const FileTagCache*, const QString&) -> QHash<QString, QStringList> {
+        __DBG_STUB_INVOKE__
+        return QHash<QString, QStringList>();
+    });
+
+    QHash<QString, QStringList> children = controller->findChildren("");
+
+    EXPECT_TRUE(children.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, findChildren_ValidPath)
+{
+    // Test finding children for valid path
+    stub.set_lamda(&FileTagCache::findChildren, [](const FileTagCache*, const QString&) -> QHash<QString, QStringList> {
+        __DBG_STUB_INVOKE__
+        QHash<QString, QStringList> children;
+        QStringList tags;
+        tags << "Tag1";
+        children["/home/user/subdir/file.txt"] = tags;
+        return children;
+    });
+
+    QHash<QString, QStringList> children = controller->findChildren("/home/user");
+
+    EXPECT_FALSE(children.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getTagsByFiles_SingleFile)
+{
+    // Test getting tags for a single file (common tags scenario)
+    QStringList paths;
+    paths << "/home/user/test.txt";
+
+    stub.set_lamda(&FileTagCache::getTagsByFiles, [](const FileTagCache*, const QStringList&) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Important" << "Work";
+        return tags;
+    });
+
+    QStringList tags = controller->getTagsByFiles(paths);
+
+    EXPECT_FALSE(tags.isEmpty());
+}
+
+TEST_F(UT_FileTagCacheController, getCacheTagsColor_MixedColors)
+{
+    // Test getting colors with different color formats
+    QStringList tags;
+    tags << "Orange" << "Red" << "Blue";
+
+    stub.set_lamda(&FileTagCache::getTagsColor, [](const FileTagCache*, const QStringList&) -> QMap<QString, QColor> {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> colors;
+        colors["Orange"] = QColor("#ffa503");
+        colors["Red"] = QColor("#ff1c49");
+        colors["Blue"] = QColor("#0000ff");
+        return colors;
+    });
+
+    QMap<QString, QColor> colors = controller->getCacheTagsColor(tags);
+
+    EXPECT_EQ(colors.size(), 3);
+    EXPECT_TRUE(colors["Orange"].isValid());
+    EXPECT_TRUE(colors["Red"].isValid());
+    EXPECT_TRUE(colors["Blue"].isValid());
+}
+
+TEST_F(UT_FileTagCacheController, findChildren_NestedPaths)
+{
+    // Test finding children in nested directory structure
+    stub.set_lamda(&FileTagCache::findChildren, [](const FileTagCache*, const QString&) -> QHash<QString, QStringList> {
+        __DBG_STUB_INVOKE__
+        QHash<QString, QStringList> children;
+        children["/home/user/dir1/file1.txt"] = QStringList() << "Tag1";
+        children["/home/user/dir2/file2.txt"] = QStringList() << "Tag2";
+        children["/home/user/dir1/subdir/file3.txt"] = QStringList() << "Tag1" << "Tag2";
+        return children;
+    });
+
+    QHash<QString, QStringList> children = controller->findChildren("/home/user");
+
+    EXPECT_EQ(children.size(), 3);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tag.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tag.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "tag.h"
+#include "utils/tagmanager.h"
+#include "utils/taghelper.h"
+#include "utils/filetagcache.h"
+#include "widgets/tagwidget.h"
+#include "widgets/private/tagwidget_p.h"
+#include "data/tagproxyhandle.h"
+
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <gtest/gtest.h>
+
+#include <QPaintEvent>
+#include <QPainter>
+#include "qdbusabstractinterface.h"
+#include <QDBusPendingCall>
+
+using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_tag;
+using namespace dpf;
+using namespace QDBus;
+Q_DECLARE_METATYPE(CustomViewExtensionView)
+
+class TagTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&TagManager::getAllTags, []() {
+            __DBG_STUB_INVOKE__
+            return QMap<QString, QColor>();
+        });
+        stub.set_lamda(&QDBusAbstractInterface::asyncCallWithArgumentList, []() {
+            return QDBusPendingCall::fromError(QDBusError());
+        });
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+protected:
+    stub_ext::StubExt stub;
+    Tag ins;
+};
+
+TEST_F(TagTest, Start)
+{
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, CustomViewExtensionView, int &);
+    typedef QVariant (EventChannelManager::*Push2)(const QString &, const QString &, CustomViewExtensionView, QString &, int &);
+    typedef QVariant (EventChannelManager::*Push3)(const QString &, const QString &, QString, QStringList &);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    auto push2 = static_cast<Push2>(&EventChannelManager::push);
+    auto push3 = static_cast<Push3>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(push3, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(&FileTagCacheController::initLoadTagInfos, []() {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_TRUE(ins.start());
+}
+
+TEST_F(TagTest, createTagWidget)
+{
+    auto func = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() -> bool { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::getTagsByUrls, []() {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+    EXPECT_TRUE(ins.createTagWidgetForPropertyDialog(QUrl("file://hello/world")));
+}
+
+TEST_F(TagTest, initialize)
+{
+    bool isRegister = false;
+    stub.set_lamda(&TagProxyHandle::connectToService, [&isRegister]() {
+        __DBG_STUB_INVOKE__
+        isRegister = true;
+        return true;
+    });
+    ins.initialize();
+    EXPECT_TRUE(isRegister);
+}
+
+TEST_F(TagTest, onWindowOpened)
+{
+    bool isRun = false;
+    FileManagerWindow w(QUrl::fromLocalFile("/home"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [&w, &isRun] {
+        isRun = true;
+        return &w;
+    });
+    stub.set_lamda(&Tag::installToSideBar, [] {});
+    ins.onWindowOpened(1);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagTest, onAllPluginsStarted)
+{
+    bool isRun = false;
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [&isRun] {
+        isRun = true;
+        return QVariant();
+    });
+
+    ins.onAllPluginsStarted();
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagTest, installToSideBar)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::getAllTags, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        QMap<QString, QColor> map;
+        map.insert("red", QColor("red"));
+        return map;
+    });
+
+    stub.set_lamda(&TagHelper::createSidebarItemInfo, []() { return QVariantMap(); });
+    ins.installToSideBar();
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagTest, onMenuSceneAdded)
+{
+    stub.set_lamda(&TagManager::getAllTags, []() {
+        __DBG_STUB_INVOKE__
+        return QMap<QString, QColor>();
+    });
+    ins.menuScenes.insert("TagMenu");
+    ins.onMenuSceneAdded("TagMenu");
+    EXPECT_TRUE(!ins.subscribedEvent);
+}
+
+TEST_F(TagTest, regTagCrumbToTitleBar)
+{
+    bool isCall { false };
+
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString, QVariantMap &&);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    ins.regTagCrumbToTitleBar();
+
+    EXPECT_TRUE(isCall);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagbutton.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagbutton.cpp
@@ -1,0 +1,207 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagbutton.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPixmap>
+#include <QSignalSpy>
+
+using namespace dfmplugin_tag;
+
+class UT_TagButton : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        color = QColor("#ffa503");
+        button = new TagButton(color);
+    }
+
+    virtual void TearDown() override
+    {
+        delete button;
+        button = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagButton *button = nullptr;
+    QColor color;
+};
+
+TEST_F(UT_TagButton, constructor)
+{
+    // Test constructor
+    EXPECT_NE(button, nullptr);
+    EXPECT_EQ(button->color(), color);
+}
+
+TEST_F(UT_TagButton, setRadiusF)
+{
+    // Test setting radius as float
+    EXPECT_NO_THROW(button->setRadiusF(20.0));
+}
+
+TEST_F(UT_TagButton, setRadius)
+{
+    // Test setting radius as size_t
+    EXPECT_NO_THROW(button->setRadius(20));
+}
+
+TEST_F(UT_TagButton, setCheckable)
+{
+    // Test setting checkable
+    EXPECT_NO_THROW(button->setCheckable(true));
+    EXPECT_NO_THROW(button->setCheckable(false));
+}
+
+TEST_F(UT_TagButton, setChecked)
+{
+    // Test setting checked state
+    button->setCheckable(true);
+
+    QSignalSpy spy(button, &TagButton::checkedChanged);
+
+    button->setChecked(true);
+    EXPECT_TRUE(button->isChecked());
+    EXPECT_EQ(spy.count(), 1);
+
+    button->setChecked(false);
+    EXPECT_FALSE(button->isChecked());
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(UT_TagButton, setCheckedWhenNotCheckable)
+{
+    // Test setting checked when not checkable
+    button->setCheckable(false);
+
+    button->setChecked(true);
+    EXPECT_FALSE(button->isChecked());
+}
+
+TEST_F(UT_TagButton, isChecked)
+{
+    // Test isChecked
+    button->setCheckable(true);
+
+    EXPECT_FALSE(button->isChecked());
+
+    button->setChecked(true);
+    EXPECT_TRUE(button->isChecked());
+}
+
+TEST_F(UT_TagButton, color)
+{
+    // Test getting color
+    QColor buttonColor = button->color();
+
+    EXPECT_EQ(buttonColor, color);
+}
+
+TEST_F(UT_TagButton, enterEvent)
+{
+    // Test enter event
+    QSignalSpy spy(button, &TagButton::enter);
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    QEvent event(QEvent::Enter);
+#else
+    QEnterEvent event(QPointF(0, 0), QPointF(0, 0), QPointF(0, 0));
+#endif
+
+    EXPECT_NO_THROW(button->enterEvent(&event));
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagButton, leaveEvent)
+{
+    // Test leave event
+    QSignalSpy spy(button, &TagButton::leave);
+
+    QEvent event(QEvent::Leave);
+
+    EXPECT_NO_THROW(button->leaveEvent(&event));
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagButton, mousePressEvent)
+{
+    // Test mouse press event
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    EXPECT_NO_THROW(button->mousePressEvent(&event));
+}
+
+TEST_F(UT_TagButton, mouseReleaseEvent)
+{
+    // Test mouse release event
+    button->setCheckable(true);
+
+    QSignalSpy clickSpy(button, &TagButton::click);
+
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    EXPECT_NO_THROW(button->mouseReleaseEvent(&event));
+    EXPECT_EQ(clickSpy.count(), 1);
+    EXPECT_TRUE(button->isChecked());
+}
+
+TEST_F(UT_TagButton, paintEvent)
+{
+    // Test paint event
+    button->setRadius(20);
+
+    QPixmap pixmap(100, 100);
+    QPainter painter(&pixmap);
+
+    QPaintEvent event(QRect(0, 0, 100, 100));
+
+    // Paint in normal state
+    EXPECT_NO_THROW(button->paintEvent(&event));
+
+    // Paint in checked state
+    button->setCheckable(true);
+    button->setChecked(true);
+    EXPECT_NO_THROW(button->paintEvent(&event));
+}
+
+TEST_F(UT_TagButton, signals)
+{
+    // Test all signals
+    button->setCheckable(true);
+    button->setRadius(20);
+
+    QSignalSpy clickSpy(button, &TagButton::click);
+    QSignalSpy enterSpy(button, &TagButton::enter);
+    QSignalSpy leaveSpy(button, &TagButton::leave);
+    QSignalSpy checkedSpy(button, &TagButton::checkedChanged);
+
+    // Trigger enter
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    QEvent enterEvent(QEvent::Enter);
+#else
+    QEnterEvent enterEvent(QPointF(0, 0), QPointF(0, 0), QPointF(0, 0));
+#endif
+    button->enterEvent(&enterEvent);
+    EXPECT_EQ(enterSpy.count(), 1);
+
+    // Trigger leave
+    QEvent leaveEvent(QEvent::Leave);
+    button->leaveEvent(&leaveEvent);
+    EXPECT_EQ(leaveSpy.count(), 1);
+
+    // Trigger click
+    QMouseEvent releaseEvent(QEvent::MouseButtonRelease, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    button->mouseReleaseEvent(&releaseEvent);
+    EXPECT_EQ(clickSpy.count(), 1);
+    EXPECT_EQ(checkedSpy.count(), 1);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagcolorlistwidget.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagcolorlistwidget.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagbutton.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+#include <QSignalSpy>
+
+using namespace dfmplugin_tag;
+
+class TagColorListWidgetTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&TagHelper::defualtColors, []() {
+            __DBG_STUB_INVOKE__
+            return QList<QColor>() << QColor("red");
+        });
+        ins = new TagColorListWidget();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (ins) {
+            delete ins;
+            ins = nullptr;
+        }
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagColorListWidget *ins;
+};
+
+TEST_F(TagColorListWidgetTest, checkedColorList)
+{
+    stub.set_lamda(&TagButton::isChecked, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    EXPECT_FALSE(ins->checkedColorList().isEmpty());
+}
+
+TEST_F(TagColorListWidgetTest, exclusive)
+{
+    EXPECT_FALSE(ins->exclusive());
+}
+
+TEST_F(TagColorListWidgetTest, ToolTipText)
+{
+    stub.set_lamda(&DLabel::isVisible, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&QLabel::setText, [](QLabel *, QString text) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(text == "tag");
+    });
+    ins->setToolTipText("tag");
+    stub.set_lamda(&QLabel::setText, [](QLabel *, QString text) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(text == " ");
+    });
+    ins->clearToolTipText();
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagcrumbedit.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagcrumbedit.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcrumbedit.h"
+
+#include <gtest/gtest.h>
+
+#include <QMouseEvent>
+#include <QTextDocument>
+#include <qabstracttextdocumentlayout.h>
+
+DWIDGET_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class UT_TagCrumbEdit : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        edit = new TagCrumbEdit();
+    }
+
+    virtual void TearDown() override
+    {
+        delete edit;
+        edit = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagCrumbEdit *edit = nullptr;
+};
+
+TEST_F(UT_TagCrumbEdit, constructor)
+{
+    // Test constructor
+    EXPECT_NE(edit, nullptr);
+}
+
+TEST_F(UT_TagCrumbEdit, isEditing)
+{
+    // Test isEditing - should be false by default
+    bool editing = edit->isEditing();
+
+    EXPECT_FALSE(editing);
+}
+
+TEST_F(UT_TagCrumbEdit, mouseDoubleClickEvent)
+{
+    // Test mouse double click event
+    QMouseEvent event(QEvent::MouseButtonDblClick, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+
+    // Stub the base class method to prevent actual editing
+    stub.set_lamda(VADDR(DCrumbEdit, mouseDoubleClickEvent), [](DCrumbEdit*, QMouseEvent*) {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_NO_THROW(edit->mouseDoubleClickEvent(&event));
+
+    // After double click event completes, isEditing should be false again
+    EXPECT_FALSE(edit->isEditing());
+}
+
+TEST_F(UT_TagCrumbEdit, documentMargins)
+{
+    // Test that document margins are set correctly in constructor
+    QTextDocument *doc = edit->document();
+
+    EXPECT_NE(doc, nullptr);
+    // Document margin should be increased by 5
+    EXPECT_GT(doc->documentMargin(), 0);
+}
+
+TEST_F(UT_TagCrumbEdit, viewportMargins)
+{
+    // Test viewport margins
+    QMargins margins = edit->viewportMargins();
+
+    EXPECT_EQ(margins.left(), 0);
+    EXPECT_EQ(margins.right(), 0);
+    EXPECT_EQ(margins.top(), 0);
+    EXPECT_EQ(margins.bottom(), 0);
+}
+
+TEST_F(UT_TagCrumbEdit, scrollBarPolicy)
+{
+    // Test scroll bar policy
+    Qt::ScrollBarPolicy vPolicy = edit->verticalScrollBarPolicy();
+
+    EXPECT_EQ(vPolicy, Qt::ScrollBarAlwaysOff);
+}
+
+TEST_F(UT_TagCrumbEdit, updateHeight)
+{
+    // Test height update when document size changes
+    stub.set_lamda(&QTextDocument::size, [](const QTextDocument*) -> QSizeF {
+        __DBG_STUB_INVOKE__
+        return QSizeF(100, 50);
+    });
+
+    // Trigger document size change
+    QTextDocument *doc = edit->document();
+    if (doc) {
+        QAbstractTextDocumentLayout *layout = doc->documentLayout();
+        if (layout) {
+            emit layout->documentSizeChanged(QSizeF(100, 50));
+        }
+    }
+
+    // Height should be updated based on document size
+    EXPECT_GT(edit->height(), 0);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagdiriterator.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagdiriterator.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "files/tagdiriterator.h"
+#include "files/private/tagdiriterator_p.h"
+#include "utils/tagmanager.h"
+#include "utils/taghelper.h"
+
+#include <dfm-base/base/schemefactory.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QDir>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class TagDirIteratorTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+
+        stub.set_lamda(&TagManager::getFilesByTag, []() {
+            __DBG_STUB_INVOKE__
+            return QStringList() << QString("红色");
+        });
+        iter = new TagDirIterator(QUrl::fromLocalFile("/home/"), {}, QDir::AllEntries);
+        d = iter->d.data();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete iter;
+        iter = nullptr;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagDirIterator *iter { nullptr };
+    TagDirIteratorPrivate *d { nullptr };
+};
+
+TEST_F(TagDirIteratorTest, Next)
+{
+    EXPECT_FALSE(iter->next().isValid());
+}
+
+TEST_F(TagDirIteratorTest, HasNext)
+{
+    EXPECT_FALSE(iter->hasNext());
+}
+
+TEST_F(TagDirIteratorTest, FileName)
+{
+    EXPECT_TRUE(iter->fileName() == "");
+}
+
+TEST_F(TagDirIteratorTest, FileUrl)
+{
+    EXPECT_FALSE(iter->fileUrl().isValid());
+}
+
+TEST_F(TagDirIteratorTest, FileInfo)
+{
+    EXPECT_TRUE(iter->fileInfo() == nullptr);
+}
+
+TEST_F(TagDirIteratorTest, Url)
+{
+    EXPECT_TRUE(iter->url().isValid());
+}
+
+TEST_F(TagDirIteratorTest, loadTagsUrls)
+{
+    stub.set_lamda(&TagManager::getAllTags, []() {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> map;
+        map.insert("红色", QColor("red"));
+        return map;
+    });
+    d->loadTagsUrls(TagHelper::rootUrl());
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagdirmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagdirmenuscene.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "menu/tagdirmenuscene.h"
+#include "menu/private/tagdirmenuscene_p.h"
+
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/utils/sysinfoutils.h>
+#include <gtest/gtest.h>
+
+#include <QMenu>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QProcess>
+#include <DDesktopServices>
+#include <DGuiApplicationHelper>
+#include <dtkwidget_global.h>
+
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class TagDirMenuSceneTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        auto creator = new TagDirMenuCreator();
+        scene = static_cast<dfmplugin_tag::TagDirMenuScene *>(creator->create());
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    TagDirMenuScene *scene { nullptr };
+    TagDirMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(TagDirMenuSceneTest, name)
+{
+    EXPECT_TRUE(scene->name() == "TagDirMenu");
+}
+
+TEST_F(TagDirMenuSceneTest, initialize)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile("/hello/world"),
+                       QUrl::fromLocalFile("/i/can/eat/glass/without/hurt") };
+    EXPECT_TRUE(scene->initialize({ { "currentDir", true } }));
+    EXPECT_TRUE(scene->initialize({ { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true } }));
+    EXPECT_TRUE(scene->initialize({ { "isEmptyArea", true } }));
+    EXPECT_TRUE(scene->initialize({ { "indexFlags", true } }));
+}
+
+TEST_F(TagDirMenuSceneTest, create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu menu;
+    EXPECT_TRUE(scene->create(&menu));
+}
+
+TEST_F(TagDirMenuSceneTest, triggered)
+{
+    auto act = new QAction("hello");
+    act->setProperty(TagActionId::kOpenFileLocation, "hello");
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true }, { "onCollection", true } }));
+    EXPECT_FALSE(scene->triggered(act));
+}
+
+TEST_F(TagDirMenuSceneTest, updateMenu)
+{
+    QMenu menu;
+    menu.addSeparator();
+    auto act = menu.addAction("Open file location");
+    act->setProperty(ActionPropertyKey::kActionID, TagActionId::kOpenFileLocation);
+
+    d->isEmptyArea = false;
+    EXPECT_NO_FATAL_FAILURE(d->updateMenu(&menu));
+
+    d->isEmptyArea = true;
+    EXPECT_NO_FATAL_FAILURE(d->updateMenu(&menu));
+}
+
+TEST_F(TagDirMenuSceneTest, updateState)
+{
+    QMenu menu;
+    bool isRun = false;
+    stub.set_lamda(&TagDirMenuScenePrivate::updateMenu, [&isRun] { isRun = true; });
+    scene->updateState(&menu);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagDirMenuSceneTest, scene)
+{
+    EXPECT_EQ(nullptr, scene->scene(nullptr));
+
+    auto act = new QAction("hello");
+    d->predicateAction.insert("hello", act);
+    EXPECT_STREQ(scene->scene(act)->metaObject()->className(),
+                 "dfmplugin_tag::TagDirMenuScene");
+
+    d->predicateAction.clear();
+    scene->scene(act);
+    delete act;
+    act = nullptr;
+}
+
+TEST_F(TagDirMenuSceneTest, openFileLocation)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(SysInfoUtils::isRootUser, [] { return true; });
+
+    typedef bool (*StartFunc)(const QString &, const QStringList &, const QString &, qint64 *pid);
+    auto func = static_cast<StartFunc>(QProcess::startDetached);
+    st.set_lamda(func, [] { return true; });
+
+    EXPECT_TRUE(d->openFileLocation("/home"));
+
+    st.reset(SysInfoUtils::isRootUser);
+    st.set_lamda(SysInfoUtils::isRootUser, [] { return false; });
+    auto func2 = qOverload<const QString &, const QString &>(&DDesktopServices::showFileItem);
+    st.set_lamda(func2, [] { return true; });
+    EXPECT_TRUE(d->openFileLocation("/home"));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tageditor.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tageditor.cpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tageditor.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <dfm-base/utils/windowutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <DCrumbEdit>
+
+DWIDGET_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class UT_TagEditor : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&dfmbase::WindowUtils::isWayLand, []() -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        stub.set_lamda(&TagManager::getTagsColor, [](TagManager *, const QStringList &) -> QMap<QString, QColor> {
+            __DBG_STUB_INVOKE__
+            QMap<QString, QColor> map;
+            map["Tag1"] = QColor("#ffa503");
+            return map;
+        });
+
+        stub.set_lamda(&TagManager::assignColorToTags, [](TagManager *, const QStringList &) -> QMap<QString, QColor> {
+            __DBG_STUB_INVOKE__
+            QMap<QString, QColor> map;
+            map["NewTag"] = QColor("#ffa503");
+            return map;
+        });
+
+        stub.set_lamda(&TagManager::setTagsForFiles, [](TagManager *, const QStringList &, const QList<QUrl> &) -> bool {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        editor = new TagEditor();
+    }
+
+    virtual void TearDown() override
+    {
+        if (editor) {
+            editor->deleteLater();
+            editor = nullptr;
+        }
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagEditor *editor = nullptr;
+};
+
+TEST_F(UT_TagEditor, constructor)
+{
+    // Test constructor
+    EXPECT_NE(editor, nullptr);
+}
+
+TEST_F(UT_TagEditor, setFocusOutSelfClosing)
+{
+    // Test setting focus out self closing
+    EXPECT_NO_THROW(editor->setFocusOutSelfClosing(true));
+    EXPECT_NO_THROW(editor->setFocusOutSelfClosing(false));
+}
+
+TEST_F(UT_TagEditor, setFilesForTagging)
+{
+    // Test setting files for tagging
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/home/user/test1.txt");
+    files << QUrl::fromLocalFile("/home/user/test2.txt");
+
+    EXPECT_NO_THROW(editor->setFilesForTagging(files));
+}
+
+TEST_F(UT_TagEditor, setDefaultCrumbs)
+{
+    // Test setting default crumbs
+    QStringList list;
+    list << "Tag1"
+         << "Tag2";
+
+    stub.set_lamda(&DCrumbEdit::clear, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    typedef bool (DCrumbEdit::*InsertCrumb)(const DCrumbTextFormat &, int);
+    stub.set_lamda(static_cast<InsertCrumb>(&DCrumbEdit::insertCrumb), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_NO_THROW(editor->setDefaultCrumbs(list));
+}
+
+TEST_F(UT_TagEditor, onFocusOut)
+{
+    // Test focus out slot
+    editor->setFocusOutSelfClosing(true);
+
+    stub.set_lamda(&DCrumbEdit::toPlainText, [] {
+        __DBG_STUB_INVOKE__
+        return "NewTag";
+    });
+
+    typedef bool (DCrumbEdit::*AppendCrumb)(const QString &);
+    stub.set_lamda(static_cast<AppendCrumb>(&DCrumbEdit::appendCrumb), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DCrumbEdit::crumbList, [](const DCrumbEdit *) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList list;
+        list << "NewTag";
+        return list;
+    });
+
+    stub.set_lamda(&DCrumbEdit::clear, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    typedef bool (DCrumbEdit::*InsertCrumb)(const DCrumbTextFormat &, int);
+    stub.set_lamda(static_cast<InsertCrumb>(&DCrumbEdit::insertCrumb), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool closed = false;
+    stub.set_lamda(&TagEditor::close, [&closed] {
+        __DBG_STUB_INVOKE__
+        closed = true;
+        return true;
+    });
+
+    EXPECT_NO_THROW(editor->onFocusOut());
+    EXPECT_TRUE(closed);
+}
+
+TEST_F(UT_TagEditor, filterInput)
+{
+    // Test filter input
+    stub.set_lamda(&TagHelper::crumbEditInputFilter, [](TagHelper *, DCrumbEdit *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    EXPECT_NO_THROW(editor->filterInput());
+}
+
+TEST_F(UT_TagEditor, keyPressEvent)
+{
+    // Test key press event - ESC key
+    stub.set_lamda(&DCrumbEdit::crumbList, [](const DCrumbEdit *) -> QStringList {
+        __DBG_STUB_INVOKE__
+        return QStringList();
+    });
+
+    stub.set_lamda(&DCrumbEdit::clear, [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    bool closed = false;
+    stub.set_lamda(&TagEditor::close, [&closed] {
+        __DBG_STUB_INVOKE__
+        closed = true;
+        return true;
+    });
+
+    QKeyEvent escEvent(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    EXPECT_NO_THROW(editor->keyPressEvent(&escEvent));
+    EXPECT_TRUE(closed);
+}
+
+TEST_F(UT_TagEditor, constructorWithInTagDir)
+{
+    // Test constructor with inTagDir parameter
+    stub.set_lamda(&dfmbase::WindowUtils::isWayLand, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    TagEditor *tagDirEditor = nullptr;
+    EXPECT_NO_THROW(tagDirEditor = new TagEditor(nullptr, true));
+    EXPECT_NE(tagDirEditor, nullptr);
+
+    if (tagDirEditor) {
+        tagDirEditor->deleteLater();
+    }
+}

--- a/autotests/plugins/dfmplugin-tag/test_tageventcaller.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tageventcaller.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/events/tageventcaller.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QRect>
+
+using namespace dfmplugin_tag;
+DPF_USE_NAMESPACE
+
+Q_DECLARE_METATYPE(QRectF *)
+Q_DECLARE_METATYPE(QPoint *)
+
+TEST(UT_TagEventCaller, sendOpenWindow)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef bool (EventDispatcherManager::*FuncType)(EventType, QUrl);
+    stub.set_lamda(static_cast<FuncType>(&EventDispatcherManager::publish), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    TagEventCaller::sendOpenWindow(QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, sendOpenTab)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef bool (EventDispatcherManager::*FuncType)(EventType, quint64, const QUrl &);
+    stub.set_lamda(static_cast<FuncType>(&EventDispatcherManager::publish), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    TagEventCaller::sendOpenTab(0, QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, sendCheckTabAddable)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return true;
+    });
+    TagEventCaller::sendCheckTabAddable(0);
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, getCollectionView)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return QVariant();
+    });
+
+    TagEventCaller::getCollectionView("");
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, sendOpenFiles)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef bool (EventDispatcherManager::*FuncType)(EventType, quint64, const QList<QUrl> &);
+    stub.set_lamda(static_cast<FuncType>(&EventDispatcherManager::publish), [&isCall] {
+        isCall = true;
+        return true;
+    });
+
+    TagEventCaller::sendOpenFiles(0, QList<QUrl>() << QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, getCollectionVisualRect)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString, const QUrl &);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return QVariant();
+    });
+    TagEventCaller::getCollectionVisualRect("", QUrl());
+
+    EXPECT_TRUE(isCall);
+}
+
+TEST(UT_TagEventCaller, getCollectionIconRect)
+{
+    bool isCall { false };
+
+    stub_ext::StubExt stub;
+    typedef QVariant (EventChannelManager::*FuncType)(const QString &, const QString &, QString, QRect &);
+    stub.set_lamda(static_cast<FuncType>(&EventChannelManager::push), [&isCall] {
+        isCall = true;
+        return QVariant();
+    });
+    TagEventCaller::getCollectionIconRect("", QRect());
+
+    EXPECT_TRUE(isCall);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tageventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tageventreceiver.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/events/tageventreceiver.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-framework/event/event.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QPainter>
+#include <QPixmap>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_tag;
+Q_DECLARE_METATYPE(QDir::Filters);
+class TagEventReceiverTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+    }
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TagEventReceiverTest, handleFileCutResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::removeTagsOfFiles, []() { return true; });
+    auto func = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() -> bool { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::addTagsForFiles, []() { return true; });
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///")));
+    stub.set_lamda(&InfoFactory::create<FileInfo>, [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    TagEventReceiver::instance()->handleFileCutResult(QList<QUrl>() << QUrl("/"), QList<QUrl>(), true, QString());
+    TagEventReceiver::instance()->handleFileCutResult(QList<QUrl>() << QUrl("/"), QList<QUrl>() << QUrl("/"), true, QString());
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleHideFilesResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::hideFiles, []() {});
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+    TagEventReceiver::instance()->handleHideFilesResult(1, QList<QUrl>() << QUrl("/"), true);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleFileRemoveResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::removeTagsOfFiles, []() { return true; });
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///")));
+    stub.set_lamda(&InfoFactory::create<FileInfo>, [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    TagEventReceiver::instance()->handleWindowUrlChanged(1, QUrl("tag:/"));
+    TagEventReceiver::instance()->handleFileRemoveResult(QList<QUrl>() << QUrl("/"), true, QString());
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleFileRenameResult)
+{
+    bool isRun = false;
+    stub.set_lamda(&TagManager::removeTagsOfFiles, []() { return true; });
+    stub.set_lamda(&TagManager::addTagsForFiles, []() { return true; });
+
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return QStringList() << "red";
+    });
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///")));
+    stub.set_lamda(&InfoFactory::create<FileInfo>, [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    QMap<QUrl, QUrl> map;
+    map.insert(QUrl("/"), QUrl("/"));
+    TagEventReceiver::instance()->handleFileRenameResult(1, map, true, QString());
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagEventReceiverTest, handleGetTags)
+{
+    stub.set_lamda(&TagManager::getTagsByUrls, []() {
+        __DBG_STUB_INVOKE__
+        return QStringList() << "red";
+    });
+    EXPECT_TRUE(!TagEventReceiver::instance()->handleGetTags(QUrl("/")).isEmpty());
+}
+
+TEST_F(TagEventReceiverTest, handleSidebarOrderChanged)
+{
+    EXPECT_NO_THROW(TagEventReceiver::instance()->handleSidebarOrderChanged(1, QString("Group_Tag"), QList<QUrl>()));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagfilehelper.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagfilehelper.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "utils/tagfilehelper.h"
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QRect>
+
+using namespace dfmplugin_tag;
+
+class TagFileHelperTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = TagFileHelper::instance();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagFileHelper *ins;
+};
+
+TEST_F(TagFileHelperTest, openFileInPlugin)
+{
+    EXPECT_TRUE(!ins->openFileInPlugin(1, QList<QUrl>() << QUrl("file:/test")));
+    EXPECT_TRUE(!ins->openFileInPlugin(1, QList<QUrl>()));
+    EXPECT_TRUE(ins->openFileInPlugin(1, QList<QUrl>() << QUrl("tag:/test")));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagfileinfo.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagfileinfo.cpp
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo_p.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+
+#include <dfm-base/base/schemefactory.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <QIcon>
+#include <QFile>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagFileInfo : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testUrl.setScheme("tag");
+        testUrl.setPath("/TestTag");
+        fileInfo = new TagFileInfo(testUrl);
+    }
+
+    virtual void TearDown() override
+    {
+        delete fileInfo;
+        fileInfo = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagFileInfo *fileInfo = nullptr;
+    QUrl testUrl;
+};
+
+TEST_F(UT_TagFileInfo, constructor)
+{
+    // Test constructor
+    EXPECT_NE(fileInfo, nullptr);
+}
+
+TEST_F(UT_TagFileInfo, exists_RootUrl)
+{
+    // Test exists for root URL
+    QUrl rootUrl;
+    rootUrl.setScheme("tag");
+
+    TagFileInfo rootInfo(rootUrl);
+
+    stub.set_lamda(VADDR(FileInfo, urlOf), [](const FileInfo*, UrlInfoType) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        return url;
+    });
+
+    bool result = rootInfo.exists();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, exists_TagExists)
+{
+    // Test exists when tag exists in system
+    stub.set_lamda(&TagManager::instance, []() -> TagManager* {
+        __DBG_STUB_INVOKE__
+        static TagManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&TagManager::getAllTags, [](TagManager*) -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        TagManager::TagColorMap map;
+        map["TestTag"] = QColor("#ffa503");
+        return map;
+    });
+
+    stub.set_lamda(&TagFileInfo::tagName, [](const TagFileInfo*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    bool result = fileInfo->exists();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, exists_TagNotExists)
+{
+    // Test exists when tag doesn't exist
+    stub.set_lamda(&TagManager::instance, []() -> TagManager* {
+        __DBG_STUB_INVOKE__
+        static TagManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&TagManager::getAllTags, [](TagManager*) -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return TagManager::TagColorMap(); // Empty map
+    });
+
+    stub.set_lamda(&TagFileInfo::tagName, [](const TagFileInfo*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "NonExistentTag";
+    });
+
+    bool result = fileInfo->exists();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagFileInfo, permissions)
+{
+    // Test permissions
+    QFile::Permissions perms = fileInfo->permissions();
+
+    // Should have read and write permissions
+    EXPECT_TRUE(perms & QFile::ReadOwner);
+    EXPECT_TRUE(perms & QFile::WriteOwner);
+    EXPECT_TRUE(perms & QFile::ReadUser);
+    EXPECT_TRUE(perms & QFile::WriteUser);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Readable)
+{
+    // Test is readable attribute
+    bool result = fileInfo->isAttributes(OptInfoType::kIsReadable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Writable)
+{
+    // Test is writable attribute
+    bool result = fileInfo->isAttributes(OptInfoType::kIsWritable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Executable)
+{
+    // Test is executable attribute
+    bool result = fileInfo->isAttributes(OptInfoType::kIsExecutable);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, isAttributes_Default)
+{
+    // Test other attributes fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, isAttributes), [](const ProxyFileInfo*, OptInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = fileInfo->isAttributes(OptInfoType::kIsHidden);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagFileInfo, canAttributes_CanDrop)
+{
+    // Test can drop attribute
+    bool result = fileInfo->canAttributes(CanableInfoType::kCanDrop);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagFileInfo, canAttributes_Default)
+{
+    // Test other can attributes fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, canAttributes), [](const ProxyFileInfo*, CanableInfoType) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = fileInfo->canAttributes(CanableInfoType::kCanDelete);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagFileInfo, nameOf_FileName)
+{
+    // Test getting file name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString name = fileInfo->nameOf(NameInfoType::kFileName);
+
+    EXPECT_EQ(name, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, nameOf_FileCopyName)
+{
+    // Test getting file copy name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString name = fileInfo->nameOf(NameInfoType::kFileCopyName);
+
+    EXPECT_EQ(name, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, nameOf_Default)
+{
+    // Test other name types fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, nameOf), [](const ProxyFileInfo*, NameInfoType) -> QString {
+        __DBG_STUB_INVOKE__
+        return "DefaultName";
+    });
+
+    QString name = fileInfo->nameOf(NameInfoType::kCompleteBaseName);
+
+    EXPECT_EQ(name, "DefaultName");
+}
+
+TEST_F(UT_TagFileInfo, displayOf_FileDisplayName)
+{
+    // Test getting file display name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString display = fileInfo->displayOf(DisPlayInfoType::kFileDisplayName);
+
+    EXPECT_EQ(display, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, displayOf_Default)
+{
+    // Test other display types fallback to parent
+    stub.set_lamda(VADDR(ProxyFileInfo, displayOf), [](const ProxyFileInfo*, DisPlayInfoType) -> QString {
+        __DBG_STUB_INVOKE__
+        return "DefaultDisplay";
+    });
+
+    QString display = fileInfo->displayOf(DisPlayInfoType::kSizeDisplayName);
+
+    EXPECT_EQ(display, "DefaultDisplay");
+}
+
+TEST_F(UT_TagFileInfo, fileType)
+{
+    // Test file type
+    FileInfo::FileType type = fileInfo->fileType();
+
+    EXPECT_EQ(type, FileInfo::FileType::kDirectory);
+}
+
+TEST_F(UT_TagFileInfo, fileIcon)
+{
+    // Test file icon
+    QIcon icon = fileInfo->fileIcon();
+
+    EXPECT_FALSE(icon.isNull());
+}
+
+TEST_F(UT_TagFileInfo, tagName)
+{
+    // Test getting tag name
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate*) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QString name = fileInfo->tagName();
+
+    EXPECT_EQ(name, "TestTag");
+}
+
+TEST_F(UT_TagFileInfo, multipleInstances)
+{
+    // Test creating multiple instances
+    QUrl url1;
+    url1.setScheme("tag");
+    url1.setPath("/Tag1");
+
+    QUrl url2;
+    url2.setScheme("tag");
+    url2.setPath("/Tag2");
+
+    TagFileInfo info1(url1);
+    TagFileInfo info2(url2);
+
+    stub.set_lamda(&TagFileInfoPrivate::fileName, [](const TagFileInfoPrivate* d) -> QString {
+        __DBG_STUB_INVOKE__
+        // Return different names based on the object
+        return "Tag1"; // Simplified for testing
+    });
+
+    EXPECT_NO_THROW(info1.tagName());
+    EXPECT_NO_THROW(info2.tagName());
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagfilewatcher.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagfilewatcher.cpp
@@ -1,0 +1,377 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/files/tagfilewatcher.h"
+#include "plugins/common/dfmplugin-tag/files/private/tagfilewatcher_p.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <dfm-base/utils/universalutils.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QSignalSpy>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagFileWatcher : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        testUrl.setScheme("tag");
+        testUrl.setPath("/TestTag");
+
+        // Stub initialization methods
+        stub.set_lamda(&TagFileWatcherPrivate::initFileWatcher, [](TagFileWatcherPrivate*) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&TagFileWatcherPrivate::initConnect, [](TagFileWatcherPrivate*) {
+            __DBG_STUB_INVOKE__
+        });
+
+        watcher = new TagFileWatcher(testUrl);
+    }
+
+    virtual void TearDown() override
+    {
+        delete watcher;
+        watcher = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagFileWatcher *watcher = nullptr;
+    QUrl testUrl;
+};
+
+TEST_F(UT_TagFileWatcher, constructor)
+{
+    // Test constructor
+    EXPECT_NE(watcher, nullptr);
+}
+
+TEST_F(UT_TagFileWatcher, setEnabledSubfileWatcher)
+{
+    // Test setEnabledSubfileWatcher (currently does nothing)
+    QUrl subfileUrl = QUrl::fromLocalFile("/home/user/test.txt");
+
+    EXPECT_NO_THROW(watcher->setEnabledSubfileWatcher(subfileUrl, true));
+    EXPECT_NO_THROW(watcher->setEnabledSubfileWatcher(subfileUrl, false));
+}
+
+TEST_F(UT_TagFileWatcher, onTagRemoved_MatchingTag)
+{
+    // Test when the removed tag matches the watcher's tag
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper*, const QString&) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        url.setPath("/TestTag");
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl&, const QUrl&) -> bool {
+        __DBG_STUB_INVOKE__
+        return true; // URLs match
+    });
+
+    watcher->onTagRemoved("TestTag");
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onTagRemoved_DifferentTag)
+{
+    // Test when the removed tag doesn't match
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper*, const QString&) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        url.setPath("/OtherTag");
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl&, const QUrl&) -> bool {
+        __DBG_STUB_INVOKE__
+        return false; // URLs don't match
+    });
+
+    watcher->onTagRemoved("OtherTag");
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_SingleFile)
+{
+    // Test when a single file is tagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_MultipleFiles)
+{
+    // Test when multiple files are tagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/file1.txt"] = tags;
+    fileAndTags["/home/user/file2.txt"] = tags;
+    fileAndTags["/home/user/file3.txt"] = tags;
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 3);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_DifferentTag)
+{
+    // Test when files are tagged with different tag
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "OtherTag"; // Different tag
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesUntagged_SingleFile)
+{
+    // Test when a single file is untagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesUntagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesUntagged_MultipleFiles)
+{
+    // Test when multiple files are untagged
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileDeleted);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/file1.txt"] = tags;
+    fileAndTags["/home/user/file2.txt"] = tags;
+
+    watcher->onFilesUntagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 2);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesHidden_SingleFile)
+{
+    // Test when a single file is hidden
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileAttributeChanged);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesHidden(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesHidden_DifferentTag)
+{
+    // Test when files with different tags are hidden
+    QSignalSpy spy(watcher, &AbstractFileWatcher::fileAttributeChanged);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "OtherTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    watcher->onFilesHidden(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, onFilesTagged_EmptyMap)
+{
+    // Test with empty file and tags map
+    QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    QVariantMap fileAndTags; // Empty map
+
+    watcher->onFilesTagged(fileAndTags);
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TagFileWatcher, signals)
+{
+    // Test that all signals can be emitted without crashing
+    QSignalSpy subfileCreatedSpy(watcher, &AbstractFileWatcher::subfileCreated);
+    QSignalSpy fileDeletedSpy(watcher, &AbstractFileWatcher::fileDeleted);
+    QSignalSpy fileAttributeChangedSpy(watcher, &AbstractFileWatcher::fileAttributeChanged);
+
+    stub.set_lamda(&TagHelper::instance, []() -> TagHelper* {
+        __DBG_STUB_INVOKE__
+        static TagHelper helper;
+        return &helper;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper*, const QUrl&) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, [](const TagHelper*, const QString&) -> QUrl {
+        __DBG_STUB_INVOKE__
+        QUrl url;
+        url.setScheme("tag");
+        url.setPath("/TestTag");
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl&, const QUrl&) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QVariantMap fileAndTags;
+    QStringList tags;
+    tags << "TestTag";
+    fileAndTags["/home/user/test.txt"] = tags;
+
+    // Trigger different signals
+    watcher->onFilesTagged(fileAndTags);
+    watcher->onFilesUntagged(fileAndTags);
+    watcher->onFilesHidden(fileAndTags);
+    watcher->onTagRemoved("TestTag");
+
+    EXPECT_GT(subfileCreatedSpy.count() + fileDeletedSpy.count() + fileAttributeChangedSpy.count(), 0);
+}

--- a/autotests/plugins/dfmplugin-tag/test_taghelper.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_taghelper.cpp
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/widgets/tageditor.h"
+
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <QPainter>
+#include <QPixmap>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        helper = TagHelper::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagHelper *helper = nullptr;
+};
+
+TEST_F(UT_TagHelper, instance)
+{
+    // Test singleton instance
+    TagHelper *instance1 = TagHelper::instance();
+    TagHelper *instance2 = TagHelper::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_TagHelper, scheme)
+{
+    // Test scheme method
+    EXPECT_EQ(TagHelper::scheme(), "tag");
+}
+
+TEST_F(UT_TagHelper, rootUrl)
+{
+    // Test rootUrl static method
+    QUrl root = TagHelper::rootUrl();
+
+    EXPECT_EQ(root.scheme(), "tag");
+    EXPECT_EQ(root.path(), "/");
+}
+
+TEST_F(UT_TagHelper, commonUrls_Empty)
+{
+    // Test with empty URL list
+    QList<QUrl> urls;
+    QList<QUrl> result = TagHelper::commonUrls(urls);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_TagHelper, commonUrls_NoTransform)
+{
+    // Test when URLs don't need transformation
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/home/user/test.txt");
+
+    // Stub bindUrlTransform to return the same URL
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1 == url2;
+    });
+
+    QList<QUrl> result = TagHelper::commonUrls(urls);
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), urls.first());
+}
+
+TEST_F(UT_TagHelper, commonUrls_WithTransform)
+{
+    // Test when URLs need transformation
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/media/mount/test.txt");
+
+    QUrl transformedUrl = QUrl::fromLocalFile("/home/user/test.txt");
+
+    // Stub bindUrlTransform to return a different URL
+    stub.set_lamda(&FileUtils::bindUrlTransform, [transformedUrl](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return transformedUrl;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;   // URLs are different
+    });
+
+    QList<QUrl> result = TagHelper::commonUrls(urls);
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first(), transformedUrl);
+}
+
+TEST_F(UT_TagHelper, defualtColors)
+{
+    // Test default colors list
+    QList<QColor> colors = helper->defualtColors();
+
+    // Should have 8 default colors based on initTagColorDefines
+    EXPECT_EQ(colors.size(), 8);
+
+    // Verify at least one color is valid
+    EXPECT_TRUE(colors.first().isValid());
+}
+
+TEST_F(UT_TagHelper, qureyColorByColorName_Valid)
+{
+    // Test querying color by valid color name
+    QColor color = helper->qureyColorByColorName("Orange");
+
+    EXPECT_TRUE(color.isValid());
+    EXPECT_EQ(color.name().toLower(), "#ffa503");
+}
+
+TEST_F(UT_TagHelper, qureyColorByColorName_Invalid)
+{
+    // Test querying color by invalid color name
+    QColor color = helper->qureyColorByColorName("InvalidColor");
+
+    EXPECT_FALSE(color.isValid());
+}
+
+TEST_F(UT_TagHelper, qureyColorByDisplayName_Valid)
+{
+    // Test querying color by valid display name
+    QColor color = helper->qureyColorByDisplayName(QObject::tr("Orange"));
+
+    EXPECT_TRUE(color.isValid());
+}
+
+TEST_F(UT_TagHelper, qureyColorByDisplayName_Invalid)
+{
+    // Test querying color by invalid display name
+    QColor color = helper->qureyColorByDisplayName("InvalidDisplayName");
+
+    EXPECT_FALSE(color.isValid());
+}
+
+TEST_F(UT_TagHelper, qureyColorNameByColor_Valid)
+{
+    // Test querying color name by valid color
+    QColor color("#ffa503");
+    QString colorName = helper->qureyColorNameByColor(color);
+
+    EXPECT_EQ(colorName, "Orange");
+}
+
+TEST_F(UT_TagHelper, qureyColorNameByColor_Invalid)
+{
+    // Test querying color name by invalid color
+    QColor color("#123456");   // Non-existent color
+    QString colorName = helper->qureyColorNameByColor(color);
+
+    EXPECT_TRUE(colorName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, qureyIconNameByColorName_Valid)
+{
+    // Test querying icon name by valid color name
+    QString iconName = helper->qureyIconNameByColorName("Orange");
+
+    EXPECT_EQ(iconName, "dfm_tag_orange");
+}
+
+TEST_F(UT_TagHelper, qureyIconNameByColorName_Invalid)
+{
+    // Test querying icon name by invalid color name
+    QString iconName = helper->qureyIconNameByColorName("InvalidColor");
+
+    EXPECT_TRUE(iconName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, qureyIconNameByColor_Valid)
+{
+    // Test querying icon name by valid color
+    QColor color("#ffa503");
+    QString iconName = helper->qureyIconNameByColor(color);
+
+    EXPECT_EQ(iconName, "dfm_tag_orange");
+}
+
+TEST_F(UT_TagHelper, qureyIconNameByColor_Invalid)
+{
+    // Test querying icon name by invalid color
+    QColor color("#123456");
+    QString iconName = helper->qureyIconNameByColor(color);
+
+    EXPECT_TRUE(iconName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, qureyDisplayNameByColor_Valid)
+{
+    // Test querying display name by valid color
+    QColor color("#ffa503");
+    QString displayName = helper->qureyDisplayNameByColor(color);
+
+    EXPECT_EQ(displayName, QObject::tr("Orange"));
+}
+
+TEST_F(UT_TagHelper, qureyDisplayNameByColor_Invalid)
+{
+    // Test querying display name by invalid color
+    QColor color("#123456");
+    QString displayName = helper->qureyDisplayNameByColor(color);
+
+    EXPECT_TRUE(displayName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, qureyColorNameByDisplayName_Valid)
+{
+    // Test querying color name by valid display name
+    QString colorName = helper->qureyColorNameByDisplayName(QObject::tr("Orange"));
+
+    EXPECT_EQ(colorName, "Orange");
+}
+
+TEST_F(UT_TagHelper, qureyColorNameByDisplayName_Invalid)
+{
+    // Test querying color name by invalid display name
+    QString colorName = helper->qureyColorNameByDisplayName("InvalidDisplayName");
+
+    EXPECT_TRUE(colorName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, getTagNameFromUrl_Valid)
+{
+    // Test extracting tag name from valid tag URL
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/MyTag");
+
+    QString tagName = helper->getTagNameFromUrl(tagUrl);
+
+    EXPECT_EQ(tagName, "MyTag");
+}
+
+TEST_F(UT_TagHelper, getTagNameFromUrl_Invalid)
+{
+    // Test extracting tag name from non-tag URL
+    QUrl fileUrl = QUrl::fromLocalFile("/home/user/test.txt");
+
+    QString tagName = helper->getTagNameFromUrl(fileUrl);
+
+    EXPECT_TRUE(tagName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, makeTagUrlByTagName)
+{
+    // Test creating tag URL from tag name
+    QString tagName = "MyTag";
+    QUrl tagUrl = helper->makeTagUrlByTagName(tagName);
+
+    EXPECT_EQ(tagUrl.scheme(), "tag");
+    EXPECT_EQ(tagUrl.path(), "/MyTag");
+}
+
+TEST_F(UT_TagHelper, getColorNameByTag_DefaultTag)
+{
+    // Test getting color name for default tag
+    QString colorName = helper->getColorNameByTag(QObject::tr("Orange"));
+
+    EXPECT_EQ(colorName, "Orange");
+}
+
+TEST_F(UT_TagHelper, getColorNameByTag_CustomTag)
+{
+    // Test getting color name for custom tag (should return random color)
+    QString colorName = helper->getColorNameByTag("CustomTag");
+
+    // Should return one of the default color names
+    EXPECT_FALSE(colorName.isEmpty());
+}
+
+TEST_F(UT_TagHelper, isDefualtTag_DefaultTag)
+{
+    // Test checking if tag is default tag
+    bool isDefault = helper->isDefualtTag(QObject::tr("Orange"));
+
+    EXPECT_TRUE(isDefault);
+}
+
+TEST_F(UT_TagHelper, isDefualtTag_CustomTag)
+{
+    // Test checking if custom tag is default tag
+    bool isDefault = helper->isDefualtTag("CustomTag");
+
+    EXPECT_FALSE(isDefault);
+}
+
+TEST_F(UT_TagHelper, paintTags)
+{
+    // Test painting tags
+    QPixmap pixmap(100, 100);
+    QPainter painter(&pixmap);
+    QRectF rect(0, 0, 100, 100);
+    QList<QColor> colors;
+    colors << QColor("#ffa503") << QColor("#ff1c49");
+
+    EXPECT_NO_THROW(helper->paintTags(&painter, rect, colors));
+
+    // Rect should be modified (right side moved left)
+    EXPECT_LT(rect.right(), 100);
+}
+
+TEST_F(UT_TagHelper, createSidebarItemInfo)
+{
+    // Test creating sidebar item info
+    QString tagName = "TestTag";
+
+    // Stub TagManager::instance to avoid initialization issues
+    stub.set_lamda(&TagManager::instance, []() -> TagManager * {
+        __DBG_STUB_INVOKE__
+        static TagManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&TagManager::getTagIconName, [](TagManager *, const QString &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "dfm_tag_orange";
+    });
+
+    QVariantMap infoMap = helper->createSidebarItemInfo(tagName);
+
+    EXPECT_FALSE(infoMap.isEmpty());
+    EXPECT_TRUE(infoMap.contains("Property_Key_Url"));
+    EXPECT_TRUE(infoMap.contains("Property_Key_DisplayName"));
+    EXPECT_EQ(infoMap["Property_Key_DisplayName"].toString(), tagName);
+}
+
+TEST_F(UT_TagHelper, showTagEdit)
+{
+    typedef void (*fptr)(TagEditor *, int x, int y);
+    fptr p = (fptr)(&TagEditor::show);
+
+    bool flag = false;
+    stub.set_lamda(&TagManager::getTagsByUrls, []() { __DBG_STUB_INVOKE__ return QStringList(); });
+    stub.set_lamda(p, [&flag]() {
+        __DBG_STUB_INVOKE__
+        flag = true;
+    });
+
+    helper->showTagEdit(QRectF(), QRectF(), QList<QUrl>() << QUrl("tag:/test"), true);
+    EXPECT_TRUE(flag);
+}
+
+TEST_F(UT_TagHelper, crumbEditInputFilter_NullEdit)
+{
+    // Test crumb edit input filter with null pointer
+    EXPECT_NO_THROW(helper->crumbEditInputFilter(nullptr));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagmanager.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagmanager.cpp
@@ -1,0 +1,598 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+#include "plugins/common/dfmplugin-tag/utils/filetagcache.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+#include "plugins/common/dfmplugin-tag/files/tagfileinfo.h"
+#include "plugins/common/dfmplugin-tag/utils/anythingmonitorfilter.h"
+#include "plugins/common/dfmplugin-tag/events/tageventcaller.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/file/local/desktopfileinfo.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <QPainter>
+#include <QPixmap>
+#include <QMenu>
+#include <QDBusVariant>
+
+using namespace dfmplugin_tag;
+DFMBASE_USE_NAMESPACE
+
+class UT_TagManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = TagManager::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagManager *ins = nullptr;
+};
+
+TEST_F(UT_TagManager, instance)
+{
+    // Test singleton instance
+    TagManager *instance1 = TagManager::instance();
+    TagManager *instance2 = TagManager::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_TagManager, scheme)
+{
+    // Test scheme method
+    EXPECT_EQ(TagManager::scheme(), "tag");
+}
+
+TEST_F(UT_TagManager, rootUrl)
+{
+    // Test rootUrl static method
+    QUrl root = TagManager::rootUrl();
+
+    EXPECT_EQ(root.scheme(), "tag");
+    EXPECT_EQ(root.path(), "/");
+}
+
+TEST_F(UT_TagManager, canTagFile)
+{
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    stub.set_lamda(&InfoFactory::create<FileInfo>, [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+    stub.set_lamda(&TagManager::localFileCanTagFilter, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_FALSE(ins->canTagFile(QUrl()));
+    EXPECT_TRUE(ins->canTagFile(QUrl("file:/hello/world")));
+    EXPECT_FALSE(ins->canTagFile(FileInfoPointer()));
+    EXPECT_TRUE(ins->canTagFile(info));
+}
+
+TEST_F(UT_TagManager, registerTagColor_NewTag)
+{
+    // Test registering new tag color
+    QString tagName = "NewTestTag";
+    QString color = "#123456";
+
+    bool result = ins->registerTagColor(tagName, color);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, registerTagColor_ExistingTag)
+{
+    // Test registering existing tag color
+    QString tagName = "ExistingTag";
+    QString color1 = "#123456";
+    QString color2 = "#654321";
+
+    ins->registerTagColor(tagName, color1);
+    bool result = ins->registerTagColor(tagName, color2);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, getTagIconName_EmptyTag)
+{
+    // Test with empty tag name
+    QString iconName = ins->getTagIconName("");
+
+    EXPECT_TRUE(iconName.isEmpty());
+}
+
+TEST_F(UT_TagManager, getTagIconName_ValidTag)
+{
+    // Test with valid tag name
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["TestTag"] = QVariant("#ffa503");
+        return map;
+    });
+
+    stub.set_lamda(&TagHelper::qureyIconNameByColor, [](const TagHelper *, const QColor &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "dfm_tag_orange";
+    });
+
+    QString iconName = ins->getTagIconName("TestTag");
+
+    EXPECT_EQ(iconName, "dfm_tag_orange");
+}
+
+TEST_F(UT_TagManager, getAllTags)
+{
+    // Test getting all tags
+    stub.set_lamda(&TagProxyHandle::getAllTags, [](TagProxyHandle *) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["Tag1"] = QVariant(QColor("#ffa503"));
+        map["Tag2"] = QVariant(QColor("#ff1c49"));
+        return map;
+    });
+
+    TagManager::TagColorMap tags = ins->getAllTags();
+
+    EXPECT_EQ(tags.size(), 2);
+    EXPECT_TRUE(tags.contains("Tag1"));
+    EXPECT_TRUE(tags.contains("Tag2"));
+}
+
+TEST_F(UT_TagManager, getTagsColor_Empty)
+{
+    // Test with empty tag list
+    QStringList tags;
+    TagManager::TagColorMap result = ins->getTagsColor(tags);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_TagManager, getTagsColor_ValidTags)
+{
+    // Test with valid tags
+    QStringList tags;
+    tags << "Tag1"
+         << "Tag2";
+
+    stub.set_lamda(&TagProxyHandle::getTagsColor, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        map["Tag1"] = QVariant("#ffa503");
+        map["Tag2"] = QVariant("#ff1c49");
+        return map;
+    });
+
+    TagManager::TagColorMap result = ins->getTagsColor(tags);
+
+    EXPECT_EQ(result.size(), 2);
+    EXPECT_TRUE(result.contains("Tag1"));
+    EXPECT_EQ(result["Tag1"].name().toLower(), "#ffa503");
+}
+
+TEST_F(UT_TagManager, getTagsByUrls_Empty)
+{
+    // Test with empty URL list
+    QList<QUrl> urls;
+    QStringList tags = ins->getTagsByUrls(urls);
+
+    EXPECT_TRUE(tags.isEmpty());
+}
+
+TEST_F(UT_TagManager, getTagsByUrls_ValidUrls)
+{
+    // Test with valid URLs
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/home/user/test.txt");
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [&urls](const QList<QUrl> &, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = urls;
+        return true;
+    });
+
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1 == url2;
+    });
+
+    stub.set_lamda(&FileTagCacheController::getTagsByFiles, [](FileTagCacheController *, const QStringList &) -> QStringList {
+        __DBG_STUB_INVOKE__
+        QStringList tags;
+        tags << "Tag1"
+             << "Tag2";
+        return tags;
+    });
+
+    QStringList tags = ins->getTagsByUrls(urls);
+
+    EXPECT_EQ(tags.size(), 2);
+}
+
+TEST_F(UT_TagManager, getFilesByTag_EmptyTag)
+{
+    // Test with empty tag
+    QStringList files = ins->getFilesByTag("");
+
+    EXPECT_TRUE(files.isEmpty());
+}
+
+TEST_F(UT_TagManager, getFilesByTag_ValidTag)
+{
+    // Test with valid tag
+    stub.set_lamda(&TagProxyHandle::getFilesThroughTag, [](TagProxyHandle *, const QStringList &) -> QVariantMap {
+        __DBG_STUB_INVOKE__
+        QVariantMap map;
+        QStringList files;
+        files << "/home/user/file1.txt"
+              << "/home/user/file2.txt";
+        map["TestTag"] = QVariant(files);
+        return map;
+    });
+
+    QStringList files = ins->getFilesByTag("TestTag");
+
+    EXPECT_EQ(files.size(), 2);
+}
+
+TEST_F(UT_TagManager, setTagsForFiles_EmptyFiles)
+{
+    // Test with empty file list
+    QStringList tags;
+    tags << "Tag1";
+    QList<QUrl> files;
+
+    bool result = ins->setTagsForFiles(tags, files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, addTagsForFiles)
+{
+    stub.set_lamda(&TagHelper::qureyColorByDisplayName, []() { __DBG_STUB_INVOKE__ return QColor("red"); });
+    stub.set_lamda(&TagProxyHandle::addTags, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, []() { __DBG_STUB_INVOKE__ return false; });
+
+    EXPECT_FALSE(ins->addTagsForFiles(QStringList(), QList<QUrl>()));
+    EXPECT_FALSE(ins->addTagsForFiles(QStringList() << QString("test"), QList<QUrl>() << QUrl("file:///test")));
+
+    stub.set_lamda(&TagProxyHandle::addTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(ins->addTagsForFiles(QStringList() << QString("test"), QList<QUrl>() << QUrl("file:///test")));
+}
+
+TEST_F(UT_TagManager, removeTagsOfFiles_EmptyTags)
+{
+    // Test with empty tag list
+    QList<QString> tags;
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/home/user/test.txt");
+
+    bool result = ins->removeTagsOfFiles(tags, files);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, removeTagsOfFiles_ValidData)
+{
+    // Test with valid tags and files
+    QList<QString> tags;
+    tags << "Tag1";
+    QList<QUrl> files;
+    files << QUrl::fromLocalFile("/home/user/test.txt");
+
+    stub.set_lamda(&UniversalUtils::urlsTransformToLocal, [&files](const QList<QUrl> &, QList<QUrl> *realUrls) -> bool {
+        __DBG_STUB_INVOKE__
+        *realUrls = files;
+        return true;
+    });
+
+    stub.set_lamda(&FileUtils::bindUrlTransform, [](const QUrl &url) -> QUrl {
+        __DBG_STUB_INVOKE__
+        return url;
+    });
+
+    stub.set_lamda(&UniversalUtils::urlEquals, [](const QUrl &url1, const QUrl &url2) -> bool {
+        __DBG_STUB_INVOKE__
+        return url1 == url2;
+    });
+
+    stub.set_lamda(&TagProxyHandle::deleteFileTags, [](TagProxyHandle *, const QMap<QString, QVariant> &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->removeTagsOfFiles(tags, files);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, pasteHandle_TagScheme_CutAction)
+{
+    // Test paste with cut action - should return true without processing
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+
+    stub.set_lamda(&ClipBoard::instance, []() -> ClipBoard * {
+        __DBG_STUB_INVOKE__
+        static ClipBoard clipboard;
+        return &clipboard;
+    });
+
+    stub.set_lamda(&ClipBoard::clipboardAction, [](ClipBoard *) -> ClipBoard::ClipboardAction {
+        __DBG_STUB_INVOKE__
+        return ClipBoard::kCutAction;
+    });
+
+    bool result = ins->pasteHandle(0, QList<QUrl>(), tagUrl);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, pasteHandle)
+{
+    EXPECT_FALSE(ins->pasteHandle(1, QList<QUrl>(), QUrl("file:///test")));
+    stub.set_lamda(&TagManager::addTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&ClipBoard::clipboardAction, []() { __DBG_STUB_INVOKE__ return ClipBoard::kCutAction; });
+
+    EXPECT_TRUE(ins->pasteHandle(1, QList<QUrl>(), QUrl("tag:///test")));
+
+    stub.set_lamda(&ClipBoard::clipboardAction, []() { __DBG_STUB_INVOKE__ return ClipBoard::kCopyAction; });
+    EXPECT_TRUE(ins->pasteHandle(1, QList<QUrl>(), QUrl("tag:///test")));
+    EXPECT_TRUE(ins->pasteHandle(1, QList<QUrl>(), QUrl("tag:///test")));
+}
+
+TEST_F(UT_TagManager, fileDropHandle)
+{
+    stub.set_lamda(&InfoFactory::create<TagFileInfo>, []() {
+        return nullptr;
+    });
+    EXPECT_TRUE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), TagManager::rootUrl()));
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::setTagsForFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), TagManager::rootUrl()));
+    EXPECT_FALSE(ins->fileDropHandle(QList<QUrl>() << QUrl("file:///test"), QUrl("file:///test")));
+}
+
+TEST_F(UT_TagManager, fileDropHandleWithAction)
+{
+    // Test file drop with action
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+
+    QList<QUrl> fromUrls;
+    Qt::DropAction action = Qt::CopyAction;
+
+    stub.set_lamda(&TagManager::fileDropHandle, [](TagManager *, const QList<QUrl> &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->fileDropHandleWithAction(fromUrls, tagUrl, &action);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(action, Qt::IgnoreAction);
+}
+
+TEST_F(UT_TagManager, sepateTitlebarCrumb_TagUrl)
+{
+    // Test separate titlebar crumb with tag URL
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+
+    QList<QVariantMap> mapGroup;
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    stub.set_lamda(&TagManager::getTagIconName, [](const TagManager *, const QString &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "dfm_tag_orange";
+    });
+
+    bool result = ins->sepateTitlebarCrumb(tagUrl, &mapGroup);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(mapGroup.size(), 1);
+}
+
+TEST_F(UT_TagManager, sepateTitlebarCrumb_NonTagUrl)
+{
+    // Test separate titlebar crumb with non-tag URL
+    QUrl fileUrl = QUrl::fromLocalFile("/home/user/test.txt");
+    QList<QVariantMap> mapGroup;
+
+    bool result = ins->sepateTitlebarCrumb(fileUrl, &mapGroup);
+
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(mapGroup.isEmpty());
+}
+
+TEST_F(UT_TagManager, deleteTags)
+{
+    stub.set_lamda(&TagManager::deleteTagData, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagHelper::makeTagUrlByTagName, []() { __DBG_STUB_INVOKE__ return QUrl(); });
+
+    EXPECT_NO_THROW(ins->deleteTags(QStringList() << QString("test")));
+}
+
+TEST_F(UT_TagManager, changeTagColor_EmptyTag)
+{
+    // Test changing color with empty tag name
+    bool result = ins->changeTagColor("", "#123456");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagManager, changeTagColor_ValidTag)
+{
+    // Test changing color with valid tag
+    stub.set_lamda(&TagHelper::qureyColorByColorName, [](const TagHelper *, const QString &) -> QColor {
+        __DBG_STUB_INVOKE__
+        return QColor("#ffa503");
+    });
+
+    stub.set_lamda(&TagProxyHandle::changeTagsColor, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->changeTagColor("TestTag", "Orange");
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, changeTagName)
+{
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagManager::getAllTags, []() { __DBG_STUB_INVOKE__ return TagManager::TagColorMap(); });
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_FALSE(ins->changeTagName(QString(), QString()));
+    EXPECT_TRUE(ins->changeTagName(QString("test"), QString("red")));
+}
+
+TEST_F(UT_TagManager, changeTagName_ValidTag)
+{
+    // Test changing tag name
+    stub.set_lamda(&TagManager::getAllTags, [](TagManager *) -> TagManager::TagColorMap {
+        __DBG_STUB_INVOKE__
+        return TagManager::TagColorMap();
+    });
+
+    stub.set_lamda(&TagProxyHandle::changeTagNamesWithFiles, [](TagProxyHandle *, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = ins->changeTagName("OldTag", "NewTag");
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagManager, hideFiles)
+{
+    bool isCall = false;
+    QObject::connect(ins, &TagManager::filesHidden, [&isCall]() {
+        isCall = true;
+    });
+    ins->hideFiles(QList<QString>() << "red", QList<QUrl>() << QUrl("/test"));
+    EXPECT_TRUE(isCall);
+}
+
+TEST_F(UT_TagManager, paintListTagsHandle)
+{
+    DFMGLOBAL_USE_NAMESPACE
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    QPainter painter;
+    QRectF rect;
+    // overload func
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ins->paintListTagsHandle(1, info, &painter, &rect));
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_FALSE(ins->paintListTagsHandle(1, info, &painter, &rect));
+    EXPECT_FALSE(ins->paintListTagsHandle(kItemFileDisplayNameRole, info, &painter, &rect));
+}
+
+TEST_F(UT_TagManager, paintListTagsHandle2)
+{
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    auto func = static_cast<bool (TagManager::*)(const FileInfoPointer &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ins->addIconTagsHandle(info, nullptr));
+    stub.set_lamda(func, []() { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_FALSE(ins->addIconTagsHandle(info, nullptr));
+}
+
+TEST_F(UT_TagManager, assignColorToTags)
+{
+    stub.set_lamda(&TagManager::getAllTags, []() { __DBG_STUB_INVOKE__ return TagManager::TagColorMap(); });
+    stub.set_lamda(&TagManager::getTagsColor, []() { __DBG_STUB_INVOKE__ return TagManager::TagColorMap(); });
+    stub.set_lamda(&TagManager::registerTagColor, []() { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&TagHelper::qureyColorByColorName, []() { __DBG_STUB_INVOKE__ return QColor("red"); });
+    stub.set_lamda(&TagHelper::getColorNameByTag, []() { __DBG_STUB_INVOKE__ return QString("test"); });
+
+    EXPECT_TRUE(ins->assignColorToTags(QStringList() << QString("test")).contains("test"));
+}
+
+TEST_F(UT_TagManager, contenxtMenuHandle)
+{
+    // Test context menu handle - stub to prevent actual menu display
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/TestTag");
+    QPoint globalPos(100, 100);
+
+    stub.set_lamda(&TagEventCaller::sendCheckTabAddable, [](quint64) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "TestTag";
+    });
+
+    bool isCall = false;
+    stub.set_lamda((QAction * (QMenu::*)(const QPoint &, QAction *)) ADDR(QMenu, exec), [&]() {
+        isCall = true;
+        return nullptr;
+    });
+
+    // Note: This method creates and shows a menu, which involves GUI
+    // In actual unit tests, we would stub DMenu::exec to prevent showing
+    // For now, we just verify the method can be called
+    EXPECT_NO_THROW(TagManager::contenxtMenuHandle(0, tagUrl, globalPos));
+    EXPECT_TRUE(isCall);
+}
+
+TEST_F(UT_TagManager, renameHandle)
+{
+    // Test rename handle
+    QUrl tagUrl;
+    tagUrl.setScheme("tag");
+    tagUrl.setPath("/OldTag");
+
+    stub.set_lamda(&TagHelper::getTagNameFromUrl, [](const TagHelper *, const QUrl &) -> QString {
+        __DBG_STUB_INVOKE__
+        return "OldTag";
+    });
+
+    stub.set_lamda(&TagManager::changeTagName, [](TagManager *, const QString &, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_NO_THROW(TagManager::renameHandle(0, tagUrl, "NewTag"));
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagmenuscene.cpp
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "menu/private/tagmenuscene_p.h"
+#include "menu/tagmenuscene.h"
+#include "utils/taghelper.h"
+#include "utils/tagmanager.h"
+#include "widgets/tagcolorlistwidget.h"
+
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/base/schemefactory.h>
+
+#include <gtest/gtest.h>
+
+#include <QMenu>
+#include <QPaintEvent>
+#include <QWidgetAction>
+#include <QPainter>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class TagMenuSceneTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        auto creator = new TagMenuCreator();
+        scene = static_cast<dfmplugin_tag::TagMenuScene *>(creator->create());
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    TagMenuScene *scene { nullptr };
+    TagMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(TagMenuSceneTest, name)
+{
+    EXPECT_TRUE(scene->name() == "TagMenu");
+}
+
+TEST_F(TagMenuSceneTest, initialize)
+{
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    stub.set_lamda(&InfoFactory::create<FileInfo>, [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+    QList<QUrl> urls { QUrl::fromLocalFile("/hello/world"),
+                       QUrl::fromLocalFile("/i/can/eat/glass/without/hurt") };
+    EXPECT_TRUE(scene->initialize({ { "currentDir", true } }));
+    EXPECT_TRUE(scene->initialize(
+            { { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true } }));
+    EXPECT_EQ(d->onDesktop, true);
+    EXPECT_TRUE(scene->initialize({ { "isEmptyArea", true } }));
+    EXPECT_TRUE(scene->initialize({ { "indexFlags", true } }));
+}
+
+TEST_F(TagMenuSceneTest, create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu menu;
+    d->focusFile = QUrl("file:///test");
+    d->focusFileInfo.reset(new FileInfo(d->focusFile));
+    stub.set_lamda(&TagManager::getTagsByUrls, [] {
+        __DBG_STUB_INVOKE__
+        return QList<QString>() << "red";
+    });
+    stub.set_lamda(VADDR(FileInfo, exists), [] { __DBG_STUB_INVOKE__ return true; });
+    auto func = static_cast<bool (TagManager::*)(const QUrl &) const>(&TagManager::canTagFile);
+    stub.set_lamda(func, []() -> bool { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(scene->create(&menu));
+}
+
+TEST_F(TagMenuSceneTest, triggered)
+{
+    auto act = new QAction("hello");
+    stub.set_lamda(&TagHelper::showTagEdit, [] { __DBG_STUB_INVOKE__ });
+    act->setProperty(ActionPropertyKey::kActionID, "hello");
+    scene->d->predicateAction.insert(TagActionId::kActTagAddKey, act);
+    scene->d->focusFile.setUrl("/hello");
+
+    FileInfoPointer info(new FileInfo(QUrl("file:///test")));
+    stub.set_lamda(&InfoFactory::create<FileInfo>, [info](const QUrl &url, const Global::CreateFileInfoType type, QString *errorString) {
+        return info;
+    });
+
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true }, { "onCollection", true } }));
+    EXPECT_FALSE(scene->triggered(act));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true }, { "onCollection", false } }));
+    EXPECT_FALSE(scene->triggered(act));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", true } }));
+    EXPECT_FALSE(scene->triggered(act));
+    EXPECT_TRUE(scene->initialize({ { "onDesktop", false } }));
+    EXPECT_FALSE(scene->triggered(act));
+}
+
+TEST_F(TagMenuSceneTest, scene)
+{
+    EXPECT_EQ(nullptr, scene->scene(nullptr));
+
+    auto act = new QAction("hello");
+    d->predicateAction.insert("hello", act);
+    EXPECT_STREQ(scene->scene(act)->metaObject()->className(),
+                 "dfmplugin_tag::TagMenuScene");
+
+    d->predicateAction.clear();
+    scene->scene(act);
+    delete act;
+    act = nullptr;
+}
+
+TEST_F(TagMenuSceneTest, onHoverChanged)
+{
+    scene->d->selectFiles << QUrl::fromLocalFile("/test");
+    stub.set_lamda(&TagManager::getTagsByUrls,
+                   []() { __DBG_STUB_INVOKE__ return QStringList(); });
+    bool flag = false;
+    TagColorListWidget *tagWidget = new TagColorListWidget();
+    stub.set_lamda(&TagMenuScene::getMenuListWidget, [tagWidget]() {
+        __DBG_STUB_INVOKE__
+        return tagWidget;
+    });
+    stub.set_lamda(&TagColorListWidget::setToolTipText,
+                   [&flag]() { __DBG_STUB_INVOKE__ flag = true; });
+    stub.set_lamda(&TagManager::getTagsColor, []() {
+        __DBG_STUB_INVOKE__
+        QMap<QString, QColor> map;
+        map["red"] = QColor("red");
+        return map;
+    });
+    scene->onHoverChanged(QColor("red"));
+    EXPECT_TRUE(flag);
+    delete tagWidget;
+    tagWidget = nullptr;
+}
+
+TEST_F(TagMenuSceneTest, onColorClicked)
+{
+    TagColorListWidget *tagWidget = new TagColorListWidget();
+    stub.set_lamda(&TagMenuScene::getMenuListWidget, [tagWidget]() {
+        __DBG_STUB_INVOKE__
+        return tagWidget;
+    });
+
+    bool flag = false;
+    stub.set_lamda(&TagManager::addTagsForFiles, [&flag]() {
+        __DBG_STUB_INVOKE__ flag = true;
+        return true;
+    });
+    stub.set_lamda(&TagManager::removeTagsOfFiles, [&flag]() {
+        __DBG_STUB_INVOKE__ flag = true;
+        return true;
+    });
+    scene->onColorClicked(QColor("red"));
+    EXPECT_TRUE(flag);
+    delete tagWidget;
+    tagWidget = nullptr;
+}
+
+TEST_F(TagMenuSceneTest, getSurfaceRect)
+{
+    QWidget *w = new QWidget();
+    QWidget w2;
+    w2.setFixedSize(10, 10);
+    w2.setProperty("WidgetName", QString("organizersurface"));
+    w->setParent(&w2);
+    EXPECT_TRUE(d->getSurfaceRect(w) == w2.rect());
+}
+
+TEST_F(TagMenuSceneTest, getMenuListWidget)
+{
+    bool isRun = false;
+    d->predicateAction.insert(TagActionId::kActTagColorListKey, new QWidgetAction(scene));
+    stub.set_lamda(&QWidgetAction::defaultWidget, [&isRun]() {
+        __DBG_STUB_INVOKE__
+        isRun = true;
+        return nullptr;
+    });
+    scene->getMenuListWidget();
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagMenuSceneTest, createColorListAction)
+{
+    QMenu m;
+    bool isRun = false;
+    stub.set_lamda(&TagManager::getTagsByUrls, [&isRun]() {
+        isRun = true;
+        return QStringList() << "red";
+    });
+    stub.set_lamda(&TagHelper::isDefualtTag, []() { return true; });
+    stub.set_lamda(&TagHelper::qureyColorByDisplayName, []() { return QColor("red"); });
+    scene->createColorListAction(&m);
+    EXPECT_TRUE(isRun);
+}
+
+TEST_F(TagMenuSceneTest, updateState)
+{
+    QMenu m;
+    bool isRun = false;
+    stub.set_lamda(&QMenu::removeAction, [&isRun]() { isRun = true; });
+    scene->updateState(&m);
+    EXPECT_TRUE(isRun);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagpainter.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagpainter.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/tagpainter.h"
+
+#include <gtest/gtest.h>
+
+#include <QPainter>
+#include <QPixmap>
+#include <QTextFormat>
+
+using namespace dfmplugin_tag;
+
+class UT_TagPainter : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        painter = new TagPainter();
+    }
+
+    virtual void TearDown() override
+    {
+        delete painter;
+        painter = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagPainter *painter = nullptr;
+};
+
+TEST_F(UT_TagPainter, constructor)
+{
+    // Test constructor
+    EXPECT_NE(painter, nullptr);
+}
+
+TEST_F(UT_TagPainter, drawObject)
+{
+    // Test drawing object
+    QPixmap pixmap(100, 100);
+    QPainter qpainter(&pixmap);
+    QRectF rect(0, 0, 100, 100);
+    QTextDocument doc;
+    int posInDocument = 0;
+    QTextFormat format;
+
+    // drawObject is virtual, test it doesn't crash
+    EXPECT_NO_THROW(painter->drawObject(&qpainter, rect, &doc, posInDocument, format));
+}
+
+TEST_F(UT_TagPainter, intrinsicSize)
+{
+    // Test intrinsic size calculation
+    QTextDocument doc;
+    int posInDocument = 0;
+    QTextFormat format;
+
+    QSizeF size = painter->intrinsicSize(&doc, posInDocument, format);
+
+    // Size should be non-negative
+    EXPECT_GE(size.width(), 0);
+    EXPECT_GE(size.height(), 0);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagproxyhandle.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagproxyhandle.cpp
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/data/tagproxyhandle.h"
+#include "plugins/common/dfmplugin-tag/data/private/tagproxyhandle_p.h"
+
+#include <gtest/gtest.h>
+
+#include <QDBusVariant>
+#include <QDBusReply>
+#include <QDBusPendingReply>
+#include <QVariantMap>
+
+using namespace dfmplugin_tag;
+
+class UT_TagProxyHandle : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        handle = TagProxyHandle::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    TagProxyHandle *handle = nullptr;
+};
+
+TEST_F(UT_TagProxyHandle, instance)
+{
+    // Test singleton instance
+    TagProxyHandle *instance1 = TagProxyHandle::instance();
+    TagProxyHandle *instance2 = TagProxyHandle::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_TagProxyHandle, isValid_True)
+{
+    // Test isValid when DBus is running
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = handle->isValid();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_TagProxyHandle, isValid_False)
+{
+    // Test isValid when DBus is not running
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = handle->isValid();
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_TagProxyHandle, connectToService)
+{
+    // Test connecting to service
+    bool result = false;
+
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    EXPECT_NO_THROW(result = handle->connectToService());
+}
+
+TEST_F(UT_TagProxyHandle, getAllTags_Empty)
+{
+    // Test getting all tags when none exist
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return false; // DBus not running
+    });
+
+    QVariantMap tags = handle->getAllTags();
+
+    // Result depends on DBus availability
+    EXPECT_NO_THROW(tags);
+}
+
+TEST_F(UT_TagProxyHandle, getTagsColor_Empty)
+{
+    // Test getting tags color with empty list
+    QStringList emptyTags;
+    QVariantMap result = handle->getTagsColor(emptyTags);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getTagsThroughFile_Empty)
+{
+    // Test getting tags through file with empty file list
+    QStringList emptyFiles;
+    QVariantMap result = handle->getTagsThroughFile(emptyFiles);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getSameTagsOfDiffFiles_Empty)
+{
+    // Test getting same tags of different files with empty list
+    QStringList emptyFiles;
+    QVariant result = handle->getSameTagsOfDiffFiles(emptyFiles);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getFilesThroughTag_Empty)
+{
+    // Test getting files through tag with empty tag list
+    QStringList emptyTags;
+    QVariantMap result = handle->getFilesThroughTag(emptyTags);
+
+    // Should handle empty input gracefully
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, getAllFileWithTags)
+{
+    // Test getting all files with tags
+    QVariantHash result;
+
+    stub.set_lamda(&TagProxyHandlePrivate::isDBusRuning, [](TagProxyHandlePrivate*) -> bool {
+        __DBG_STUB_INVOKE__
+        return false; // DBus not running
+    });
+
+    EXPECT_NO_THROW(result = handle->getAllFileWithTags());
+}
+
+TEST_F(UT_TagProxyHandle, addTags_Empty)
+{
+    // Test adding tags with empty map
+    QVariantMap emptyTags;
+    bool result = handle->addTags(emptyTags);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, addTagsForFiles_Empty)
+{
+    // Test adding tags for files with empty map
+    QVariantMap emptyMap;
+    bool result = handle->addTagsForFiles(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, changeTagsColor_Empty)
+{
+    // Test changing tags color with empty map
+    QVariantMap emptyMap;
+    bool result = handle->changeTagsColor(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, changeTagNamesWithFiles_Empty)
+{
+    // Test changing tag names with empty map
+    QVariantMap emptyMap;
+    bool result = handle->changeTagNamesWithFiles(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, changeFilePaths_Empty)
+{
+    // Test changing file paths with empty map
+    QVariantMap emptyMap;
+    bool result = handle->changeFilePaths(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, deleteTags_Empty)
+{
+    // Test deleting tags with empty map
+    QVariantMap emptyMap;
+    bool result = handle->deleteTags(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, deleteFiles_Empty)
+{
+    // Test deleting files with empty map
+    QVariantMap emptyMap;
+    bool result = handle->deleteFiles(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, deleteFileTags_Empty)
+{
+    // Test deleting file tags with empty map
+    QMap<QString, QVariant> emptyMap;
+    bool result = handle->deleteFileTags(emptyMap);
+
+    // Should handle empty input
+    EXPECT_NO_THROW(result);
+}
+
+TEST_F(UT_TagProxyHandle, signals)
+{
+    // Test that signals can be connected
+    bool filesTaggedEmitted = false;
+    bool filesUntaggedEmitted = false;
+    bool newTagsAddedEmitted = false;
+    bool tagsColorChangedEmitted = false;
+    bool tagsDeletedEmitted = false;
+    bool tagsNameChangedEmitted = false;
+    bool tagServiceRegisteredEmitted = false;
+
+    QObject::connect(handle, &TagProxyHandle::filesTagged,
+        [&filesTaggedEmitted](const QVariantMap&) {
+            filesTaggedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::filesUntagged,
+        [&filesUntaggedEmitted](const QVariantMap&) {
+            filesUntaggedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::newTagsAdded,
+        [&newTagsAddedEmitted](const QVariantMap&) {
+            newTagsAddedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagsColorChanged,
+        [&tagsColorChangedEmitted](const QVariantMap&) {
+            tagsColorChangedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagsDeleted,
+        [&tagsDeletedEmitted](const QStringList&) {
+            tagsDeletedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagsNameChanged,
+        [&tagsNameChangedEmitted](const QVariantMap&) {
+            tagsNameChangedEmitted = true;
+        });
+
+    QObject::connect(handle, &TagProxyHandle::tagServiceRegistered,
+        [&tagServiceRegisteredEmitted]() {
+            tagServiceRegisteredEmitted = true;
+        });
+
+    // Emit signals to test connections
+    emit handle->filesTagged(QVariantMap());
+    emit handle->filesUntagged(QVariantMap());
+    emit handle->newTagsAdded(QVariantMap());
+    emit handle->tagsColorChanged(QVariantMap());
+    emit handle->tagsDeleted(QStringList());
+    emit handle->tagsNameChanged(QVariantMap());
+    emit handle->tagServiceRegistered();
+
+    EXPECT_TRUE(filesTaggedEmitted);
+    EXPECT_TRUE(filesUntaggedEmitted);
+    EXPECT_TRUE(newTagsAddedEmitted);
+    EXPECT_TRUE(tagsColorChangedEmitted);
+    EXPECT_TRUE(tagsDeletedEmitted);
+    EXPECT_TRUE(tagsNameChangedEmitted);
+    EXPECT_TRUE(tagServiceRegisteredEmitted);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagtextformat.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagtextformat.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/utils/tagtextformat.h"
+
+#include <gtest/gtest.h>
+
+#include <QColor>
+
+using namespace dfmplugin_tag;
+
+class TagTextFormatTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        ins = new TagTextFormat(1, QList<QColor>() << QColor("red"), QColor("red"));
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (ins) {
+            delete ins;
+            ins = nullptr;
+        }
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagTextFormat *ins;
+};
+
+TEST_F(TagTextFormatTest, colors)
+{
+    EXPECT_TRUE(ins->colors().contains(QColor("red")));
+}
+
+TEST_F(TagTextFormatTest, borderColor)
+{
+    EXPECT_TRUE(ins->borderColor() == QColor("red"));
+}
+
+TEST_F(TagTextFormatTest, diameter)
+{
+    EXPECT_TRUE(ins->diameter() == kTagDiameter);
+}

--- a/autotests/plugins/dfmplugin-tag/test_tagwidget.cpp
+++ b/autotests/plugins/dfmplugin-tag/test_tagwidget.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagwidget.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcrumbedit.h"
+#include "plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.h"
+#include "plugins/common/dfmplugin-tag/utils/tagmanager.h"
+#include "plugins/common/dfmplugin-tag/utils/taghelper.h"
+
+#include <gtest/gtest.h>
+
+#include <QUrl>
+#include <QColor>
+#include <DCrumbEdit>
+
+DWIDGET_USE_NAMESPACE
+using namespace dfmplugin_tag;
+
+class TagWidgetTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&TagManager::getTagsColor, []() -> QMap<QString, QColor> {
+            __DBG_STUB_INVOKE__
+            QMap<QString, QColor> map;
+            map["red"] = QColor("red");
+            return map;
+        });
+        stub.set_lamda(&TagManager::getTagsByUrls, []() {
+            __DBG_STUB_INVOKE__
+            return QStringList();
+        });
+        stub.set_lamda(&TagManager::getAllTags, []() {
+            __DBG_STUB_INVOKE__
+            return QMap<QString, QColor>();
+        });
+        ins = new TagWidget(QUrl("file://hello/world"));
+        ins->initialize();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        if (ins) {
+            delete ins;
+            ins = nullptr;
+        }
+    }
+
+private:
+    stub_ext::StubExt stub;
+    TagWidget *ins;
+};
+
+TEST_F(TagWidgetTest, loadTags)
+{
+    stub.set_lamda(&TagColorListWidget::setCheckedColorList, [](TagColorListWidget *, const QList<QColor> &colorNames) {
+        __DBG_STUB_INVOKE__
+        qInfo() << "455555555" << colorNames;
+        EXPECT_TRUE(colorNames.contains(QColor("red")));
+    });
+    stub.set_lamda(&TagHelper::isDefualtTag, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    ins->loadTags(QUrl("file://hello/world"));
+}
+
+TEST_F(TagWidgetTest, shouldShow)
+{
+    EXPECT_TRUE(ins->shouldShow(QUrl("file://hello/world")));
+}
+
+TEST_F(TagWidgetTest, onCrumbListChanged)
+{
+    stub.set_lamda(&TagManager::setTagsForFiles, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(&TagCrumbEdit::property, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(&TagWidget::loadTags, [](TagWidget *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(url.isValid());
+    });
+    ins->onCrumbListChanged();
+}
+
+TEST_F(TagWidgetTest, onCheckedColorChanged)
+{
+    stub.set_lamda(&TagWidget::loadTags, [](TagWidget *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(url.isValid());
+    });
+    stub.set_lamda(&TagColorListWidget::checkedColorList, [] {
+        __DBG_STUB_INVOKE__
+        return QList<QColor>();
+    });
+    ins->onCheckedColorChanged(QColor("red"));
+}
+
+TEST_F(TagWidgetTest, onTagChanged)
+{
+    stub.set_lamda(&TagWidget::loadTags, [](TagWidget *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(url.isValid());
+    });
+    QVariantMap map;
+    map[QUrl("file://hello/world").path()] = "";
+    ins->onTagChanged(map);
+}
+
+TEST_F(TagWidgetTest, updateCrumbsColor)
+{
+    auto func = static_cast<bool (TagCrumbEdit::*)(const DCrumbTextFormat &, int)>(&TagCrumbEdit::insertCrumb);
+    stub.set_lamda(func, [](TagCrumbEdit *, const DCrumbTextFormat format, int) {
+        __DBG_STUB_INVOKE__
+        EXPECT_TRUE(format.text() == "red");
+        return true;
+    });
+    ins->updateCrumbsColor(QMap<QString, QColor>());
+    QMap<QString, QColor> map;
+    map["red"] = QColor("red");
+    ins->updateCrumbsColor(map);
+}

--- a/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/files/private/tagdiriterator_p.cpp
@@ -43,7 +43,7 @@ void TagDirIteratorPrivate::loadTagsUrls(const QUrl &url)
         for (const QString &path : pathList) {
             QUrl tagUrl = QUrl::fromLocalFile(path);
             const FileInfoPointer &info = InfoFactory::create<FileInfo>(tagUrl);
-            if (!info->exists())
+            if (!info || !info->exists())
                 continue;
 
             tagNodes.insert(tagUrl, info);


### PR DESCRIPTION
Added comprehensive unit test coverage for the tag plugin module
including:
1. TagManager functionality testing (tag creation, deletion, color
management)
2. FileTagCache testing for tag storage and retrieval
3. TagEditor UI component testing
4. TagButton and TagColorListWidget widget testing
5. TagFileInfo and TagFileWatcher file system integration testing
6. Event handling and D-Bus communication testing
7. Menu scene and context menu testing
8. Tag painting and text formatting testing

The tests cover core tag management operations, UI interactions,
file system integration, and event handling to ensure robust tag
functionality.

Influence:
1. Verify tag creation and deletion operations work correctly
2. Test tag color assignment and management
3. Validate file tagging and untagging functionality
4. Test tag filtering and search capabilities
5. Verify UI components render and interact properly
6. Test D-Bus communication with tag service
7. Validate menu integration and context actions
8. Test file system watcher functionality for tag changes

test: 为标签插件添加全面的单元测试

为标签插件模块添加了全面的单元测试覆盖，包括：
1. TagManager功能测试（标签创建、删除、颜色管理）
2. FileTagCache标签存储和检索测试
3. TagEditor UI组件测试
4. TagButton和TagColorListWidget控件测试
5. TagFileInfo和TagFileWatcher文件系统集成测试
6. 事件处理和D-Bus通信测试
7. 菜单场景和上下文菜单测试
8. 标签绘制和文本格式化测试

测试涵盖了核心标签管理操作、UI交互、文件系统集成和事件处理，确保标签功能
的健壮性。

Influence:
1. 验证标签创建和删除操作是否正确工作
2. 测试标签颜色分配和管理功能
3. 验证文件标记和取消标记功能
4. 测试标签过滤和搜索能力
5. 验证UI组件是否正确渲染和交互
6. 测试与标签服务的D-Bus通信
7. 验证菜单集成和上下文操作
8. 测试文件系统监视器的标签变更功能

## Summary by Sourcery

Add a null check for FileInfo in TagDirIterator and introduce extensive unit test coverage across the tag plugin, including core tag management, UI components, file system integration, and event handling modules

Bug Fixes:
- Guard against null FileInfo in TagDirIterator when loading tag URLs

Tests:
- Add TagManager unit tests for tag creation, deletion, color assignments, file tagging, and D-Bus interactions
- Add FileTagCacheController tests for retrieving and caching file tags and colors
- Add TagHelper tests for color lookups, URL transformations, icon and display name queries
- Add TagFileWatcher and TagFileInfo tests for file system monitoring and tag existence checks
- Add TagProxyHandle tests for D-Bus requests and signal emissions
- Add TagEditor, TagButton, TagWidget, TagCrumbEdit, TagColorListWidget, TagPainter, TagTextFormat, AnythingMonitorFilter, TagFileHelper tests for UI widgets and helper utilities
- Add TagMenuScene and TagDirMenuScene tests for context and directory menu behavior
- Add TagEventCaller and TagEventReceiver tests for publishing and handling tag-related events
- Add Tag and TagDirIterator integration tests for plugin startup and directory iteration