### PR TITLE
perf: optimize file deletion and protocol matching performance

### DIFF
--- a/src/dfm-base/utils/protocolutils.cpp
+++ b/src/dfm-base/utils/protocolutils.cpp
@@ -9,11 +9,10 @@ DFMBASE_BEGIN_NAMESPACE
 
 namespace ProtocolUtils {
 
-static bool hasMatch(const QString &txt, const QString &rex)
+// Helper function: match with cached compiled regex
+static bool hasMatch(const QString &txt, const QRegularExpression &re)
 {
-    QRegularExpression re(rex);
-    QRegularExpressionMatch match = re.match(txt);
-    return match.hasMatch();
+    return re.match(txt).hasMatch();
 }
 
 bool isRemoteFile(const QUrl &url)
@@ -22,7 +21,7 @@ bool isRemoteFile(const QUrl &url)
         return false;
 
     // TODO(xust) smbmounts path might be changed in the future.
-    static const QString gvfsMatch { R"((^/run/user/\d+/gvfs/|^/root/.gvfs/|^/(?:run/)?media/[\s\S]*/smbmounts))" };
+    static const QRegularExpression gvfsMatch { R"((^/run/user/\d+/gvfs/|^/root/.gvfs/|^/(?:run/)?media/[\s\S]*/smbmounts))" };
     return hasMatch(url.toLocalFile(), gvfsMatch);
 }
 
@@ -31,7 +30,7 @@ bool isMTPFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
-    static const QString gvfsMatch { R"(^/run/user/\d+/gvfs/mtp:host|^/root/.gvfs/mtp:host)" };
+    static const QRegularExpression gvfsMatch { R"(^/run/user/\d+/gvfs/mtp:host|^/root/.gvfs/mtp:host)" };
     return hasMatch(url.toLocalFile(), gvfsMatch);
 }
 
@@ -40,7 +39,7 @@ bool isGphotoFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
-    static const QString gvfsMatch { R"(^/run/user/\d+/gvfs/gphoto2:host|^/root/.gvfs/gphoto2:host)" };
+    static const QRegularExpression gvfsMatch { R"(^/run/user/\d+/gvfs/gphoto2:host|^/root/.gvfs/gphoto2:host)" };
     return hasMatch(url.toLocalFile(), gvfsMatch);
 }
 
@@ -49,7 +48,7 @@ bool isFTPFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
-    static const QString smbMatch { R"((^/run/user/\d+/gvfs/s?ftp|^/root/.gvfs/s?ftp))" };
+    static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/s?ftp|^/root/.gvfs/s?ftp))" };
     return hasMatch(url.path(), smbMatch);
 }
 
@@ -58,7 +57,7 @@ bool isSFTPFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
-    static const QString smbMatch { R"((^/run/user/\d+/gvfs/sftp|^/root/.gvfs/sftp))" };
+    static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/sftp|^/root/.gvfs/sftp))" };
     return hasMatch(url.path(), smbMatch);
 }
 
@@ -69,7 +68,7 @@ bool isSMBFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kSmb)
         return true;
     // TODO(xust) smbmounts path might be changed in the future.
-    static const QString smbMatch { R"((^/run/user/\d+/gvfs/smb|^/root/.gvfs/smb|^/(?:run/)?media/[\s\S]*/smbmounts))" };
+    static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/smb|^/root/.gvfs/smb|^/(?:run/)?media/[\s\S]*/smbmounts))" };
     return hasMatch(url.path(), smbMatch);
 }
 
@@ -94,7 +93,7 @@ bool isNFSFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
-    static const QString nfsMatch { R"((^/run/user/\d+/gvfs/nfs|^/root/.gvfs/nfs))" };
+    static const QRegularExpression nfsMatch { R"((^/run/user/\d+/gvfs/nfs|^/root/.gvfs/nfs))" };
     return hasMatch(url.path(), nfsMatch);
 }
 
@@ -103,7 +102,7 @@ bool isDavFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
-    static const QString davMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=false|^/root/.gvfs/dav.*ssl=false))" };
+    static const QRegularExpression davMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=false|^/root/.gvfs/dav.*ssl=false))" };
     return hasMatch(url.path(), davMatch);
 }
 
@@ -112,7 +111,7 @@ bool isDavsFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
-    static const QString davsMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=true|^/root/.gvfs/dav.*ssl=true))" };
+    static const QRegularExpression davsMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=true|^/root/.gvfs/dav.*ssl=true))" };
     return hasMatch(url.path(), davsMatch);
 }
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -227,11 +227,13 @@ void DoCutFilesWorker::endWork()
     // delete all cut source files
     if (localFileHandler) {
         for (const auto &info : cutAndDeleteFiles) {
-            bool ret = localFileHandler->deleteFile(info->uri());
+            const auto &uri = info->uri();
+            bool ret = localFileHandler->deleteFile(uri);
             if (!ret) {
-                fmWarning() << "Failed to delete source file after cut - file:" << info->uri() << "error:" << localFileHandler->errorString();
+                fmWarning() << "Failed to delete source file after cut - file:" << uri << "error:" << localFileHandler->errorString();
                 continue;
             }
+            FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileDeleted, uri);
         }
     }
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -7,7 +7,6 @@
 
 #include <QUrl>
 
-
 DPFILEOPERATIONS_USE_NAMESPACE
 DoDeleteFilesWorker::DoDeleteFilesWorker(QObject *parent)
     : AbstractWorker(parent)
@@ -70,7 +69,7 @@ bool DoDeleteFilesWorker::deleteAllFiles()
 bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 {
     fmDebug() << "Deleting files on non-removable device - file count:" << allFilesList.count();
-    
+
     if (allFilesList.count() == 1 && isConvert) {
         auto info = InfoFactory::create<FileInfo>(allFilesList.first(), Global::CreateFileInfoType::kCreateFileInfoSync);
         if (info) {
@@ -84,7 +83,6 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
         if (!stateCheck())
             return false;
         const QUrl &url = *it;
-        auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         emitCurrentTaskNotify(url, QUrl());
         do {
             action = AbstractJobHandler::SupportAction::kNoAction;
@@ -116,7 +114,7 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 
         emit fileDeleted(url);
     }
-    
+
     fmInfo() << "Completed deletion on non-removable device - deleted count:" << deleteFilesCount;
     return true;
 }
@@ -127,7 +125,7 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 bool DoDeleteFilesWorker::deleteFilesOnOtherDevice()
 {
     fmDebug() << "Deleting files on other device - source count:" << sourceUrls.count();
-    
+
     bool ok = true;
     if (sourceUrls.count() == 1 && isConvert) {
         auto info = InfoFactory::create<FileInfo>(sourceUrls.first(), Global::CreateFileInfoType::kCreateFileInfoSync);
@@ -136,7 +134,7 @@ bool DoDeleteFilesWorker::deleteFilesOnOtherDevice()
             fmDebug() << "Single file deletion on other device - size:" << deleteFirstFileSize;
         }
     }
-    
+
     for (auto &url : sourceUrls) {
         const auto &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         if (!info) {
@@ -161,13 +159,13 @@ bool DoDeleteFilesWorker::deleteFilesOnOtherDevice()
             fmWarning() << "Failed to delete item:" << url;
             return false;
         }
-        
+
         completeTargetFiles.append(url);
         completeSourceFiles.append(url);
         emit fileDeleted(url);
         fmDebug() << "Successfully deleted item:" << url;
     }
-    
+
     fmInfo() << "Completed deletion on other device - processed count:" << sourceUrls.count();
     return true;
 }
@@ -191,6 +189,7 @@ bool DoDeleteFilesWorker::deleteFileOnOtherDevice(const QUrl &url)
             action = doHandleErrorAndWait(url, AbstractJobHandler::JobErrorType::kDeleteFileError,
                                           localFileHandler->errorString());
         } else {
+            FileUtils::notifyFileChangeManual(DFMGLOBAL_NAMESPACE::FileNotifyType::kFileDeleted, url);
             fmDebug() << "Successfully deleted file on other device:" << url;
         }
     } while (!isStopped() && action == AbstractJobHandler::SupportAction::kRetryAction);
@@ -246,7 +245,7 @@ bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer &dir)
         const QUrl &url = iterator->next();
         childCount++;
 
-        const auto &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);;
+        const auto &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         if (!info) {
             fmCritical() << "Failed to create file info for directory child - URL:" << url;
             // pause and emit error msg
@@ -292,7 +291,7 @@ DoDeleteFilesWorker::doHandleErrorAndWait(const QUrl &from,
                                           const QString &errorMsg)
 {
     fmWarning() << "Delete error - file:" << from << "error:" << static_cast<int>(error) << "message:" << errorMsg;
-    
+
     setStat(AbstractJobHandler::JobState::kPauseState);
     emitErrorNotify(from, QUrl(), error, false, 0, errorMsg);
 


### PR DESCRIPTION
1. In LocalFileHandler, implemented fast path deletion using direct unlink/rmdir calls before falling back to DOperator for better performance
2. Added proper error handling with errno checks during file deletion
3. Optimized ProtocolUtils by caching compiled regular expressions instead of recreating them on each call
4. Removed redundant file info creation in delete operations
5. Improved logging and debug messages for better troubleshooting

Influence:
1. Test deleting files (regular files, symlinks, directories) to verify both fast and slow paths work correctly
2. Verify performance improvement when deleting large numbers of files
3. Test error cases like permission denied and non-existent files
4. Verify protocol detection (SMB, FTP, MTP etc.) still works correctly after regex optimization
5. Check memory usage after protocol utils changes

perf: 优化文件删除和协议匹配性能

1. 在 LocalFileHandler 中实现了快速删除路径，先尝试直接使用 unlink/rmdir 系统调用，失败后才回退到 DOperator 处理
2. 添加了完善的错误处理，在文件删除时检查 errno 值
3. 优化 ProtocolUtils，通过缓存编译后的正则表达式提升性能，避免每次调用 都重新编译
4. 移除了删除操作中多余的文件信息创建
5. 改进日志和调试信息，便于问题排查

Influence:
1. 测试删除文件(普通文件、符号链接、目录)验证快速路径和慢速路径都能正常 工作
2. 验证删除大量文件时的性能提升
3. 测试权限错误和文件不存在等异常情况
4. 验证协议检测(SMB、FTP、MTP等)在正则优化后仍然正常
5. 检查协议工具修改后的内存使用情况