### PR TITLE
fix: disable selection background during drag operations

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -845,7 +845,8 @@ QRectF CanvasItemDelegate::paintEmblems(QPainter *painter, const QRectF &rect, c
 
 void CanvasItemDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const
 {
-    bool isSelected = (option.state & QStyle::State_Selected) && option.showDecorationSelected;
+    bool isDragMode = (static_cast<QPaintDevice *>(parent()->viewport()) != painter->device());
+    bool isSelected = !isDragMode && (option.state & QStyle::State_Selected) && option.showDecorationSelected;
     if (!isSelected)
         return;
 

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -870,7 +870,8 @@ QRectF CollectionItemDelegate::paintEmblems(QPainter *painter, const QRectF &rec
 
 void CollectionItemDelegate::paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const
 {
-    bool isSelected = (option.state & QStyle::State_Selected) && option.showDecorationSelected;
+    bool isDragMode = (static_cast<QPaintDevice *>(parent()->viewport()) != painter->device());
+    bool isSelected = !isDragMode && (option.state & QStyle::State_Selected) && option.showDecorationSelected;
     if (!isSelected)
         return;
 


### PR DESCRIPTION
Fixed an issue where selected items would show their selection
background during drag operations. Added a check to detect drag mode
by comparing the painter device with the parent viewport. When in drag
mode, the selection background painting is now properly disabled to
provide a cleaner visual appearance during drag operations.

Log: Fixed selection background display issue during drag operations

Influence:
1. Test selecting items and verify selection background appears normally
2. Test dragging selected items and verify selection background
disappears during drag
3. Test dropping items and verify selection background reappears
correctly
4. Verify both canvas and organizer views behave consistently

fix: 修复拖拽操作期间选中项背景显示问题

修复了在拖拽操作期间选中项会显示选中背景的问题。通过比较绘制设备与父视口
来检测拖拽模式，当处于拖拽模式时，现在正确禁用选中背景的绘制，以在拖拽操
作期间提供更清晰的视觉外观。

Log: 修复了拖拽操作期间选中背景显示问题

Influence:
1. 测试选中项目并验证选中背景正常显示
2. 测试拖拽选中项目并验证拖拽期间选中背景消失
3. 测试放置项目并验证选中背景正确重新显示
4. 验证画布视图和整理器视图行为一致

BUG: https://pms.uniontech.com/bug-view-339783.html

## Summary by Sourcery

Bug Fixes:
- Suppress selection background when dragging selected items in canvas and organizer views