### PR TITLE
fix: fix loading indicator tip display issue

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2497,7 +2497,7 @@ void FileView::updateLoadingIndicator()
     if (state == ModelState::kBusy) {
         QString tip;
 
-        const FileInfoPointer &fileInfo = model()->fileInfo(rootIndex());
+        FileInfoPointer fileInfo = InfoFactory::create<FileInfo>(rootUrl());
         if (fileInfo)
             tip = fileInfo->viewOfTip(ViewInfoType::kLoading);
 


### PR DESCRIPTION
Changed the way to get file info for loading indicator
tip from using model()->fileInfo(rootIndex()) to
InfoFactory::create<FileInfo>(rootUrl()). This ensures the correct file
information is retrieved when displaying loading status tips, preventing
potential null pointer issues and incorrect tip display during file
operations.

The previous method might return invalid file info in certain scenarios,
particularly when the model is busy or during navigation operations.
Using InfoFactory with rootUrl() provides a more reliable way to create
file info objects specifically for loading indicator purposes.

Log: Fixed loading indicator tip display issue

Influence:
1. Test file loading indicator in various scenarios (large directories,
network locations)
2. Verify loading tips display correctly during navigation operations
3. Check that loading indicator properly shows during file operations
4. Test with different file types and locations to ensure consistent
behavior

fix: 修复加载指示器提示显示问题

将获取加载指示器提示的文件信息方式从 model()->fileInfo(rootIndex()) 改为
InfoFactory::create<FileInfo>(rootUrl())。这确保了在显示加载状态提示时能
够正确获取文件信息，防止在文件操作过程中出现潜在的空指针问题和错误的提示
显示。

先前的方法在某些场景下可能返回无效的文件信息，特别是在模型繁忙或导航操作
期间。使用 InfoFactory 配合 rootUrl() 为加载指示器目的提供了更可靠的文件
对象创建方式。

Log: 修复加载指示器提示显示问题

Influence:
1. 在各种场景下测试文件加载指示器（大目录、网络位置）
2. 验证导航操作期间加载提示是否正确显示
3. 检查文件操作期间加载指示器是否正常显示
4. 测试不同文件类型和位置以确保行为一致

BUG: https://pms.uniontech.com/bug-view-339749.html

## Summary by Sourcery

Bug Fixes:
- Use InfoFactory::create<FileInfo>(rootUrl()) instead of model()->fileInfo(rootIndex()) to retrieve file info for loading indicator