### PR TITLE
fix: correct tab selection logic when deleting non-last tabs

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -617,14 +617,14 @@ void TabBar::removeTab(int index, int selectIndex)
             newIndex = curIndex;
         } else if (curIndex == index) {
             // Delete current tab, select next tab (if last tab then select previous)
-            newIndex = (index == count() - 1) ? qMax(index - 1, 0) : index;
+            newIndex = (index == count() - 1) ? qMax(index - 1, 0) : index + 1;
         } else {
             // Current tab is after deleted tab, decrease index by 1
             newIndex = curIndex - 1;
         }
     }
 
-    Q_EMIT tabHasRemoved(index, newIndex);
+    Q_EMIT tabAboutToRemove(index, newIndex);
     setCurrentIndex(newIndex);
     DTabBar::removeTab(index);
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
@@ -46,7 +46,7 @@ Q_SIGNALS:
     void requestNewWindow(const QUrl &url);
     void newTabCreated();
     void requestCreateView(const QString &uniqueId);
-    void tabHasRemoved(int oldIndex, int nextIndex);
+    void tabAboutToRemove(int oldIndex, int nextIndex);
 
 protected:
     void paintTab(QPainter *painter, int index, const QStyleOptionTab &option) const override;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -353,7 +353,7 @@ void TitleBarWidget::initConnect()
 
     connect(bottomBar, &TabBar::newTabCreated, this, &TitleBarWidget::onTabCreated);
     connect(bottomBar, &TabBar::requestCreateView, this, &TitleBarWidget::handleCreateView);
-    connect(bottomBar, &TabBar::tabHasRemoved, this, &TitleBarWidget::onTabRemoved);
+    connect(bottomBar, &TabBar::tabAboutToRemove, this, &TitleBarWidget::onTabAboutToRemove);
     connect(bottomBar, &TabBar::tabMoved, this, &TitleBarWidget::onTabMoved);
     connect(bottomBar, &TabBar::currentTabChanged, this, &TitleBarWidget::onTabCurrentChanged);
     connect(bottomBar, &TabBar::tabCloseRequested, this, &TitleBarWidget::onTabCloseRequested);
@@ -512,7 +512,7 @@ void TitleBarWidget::onTabCreated()
     curNavWidget->addHistroyStack();
 }
 
-void TitleBarWidget::onTabRemoved(int oldIndex, int nextIndex)
+void TitleBarWidget::onTabAboutToRemove(int oldIndex, int nextIndex)
 {
     TitleBarEventCaller::sendTabRemoved(this, tabBar()->tabUniqueId(oldIndex), tabBar()->tabUniqueId(nextIndex));
     curNavWidget->removeNavStackAt(oldIndex);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -77,7 +77,7 @@ private slots:
     void onAddressBarJump();
     void onTabCreated();
     void handleCreateView(const QString &uniqueId);
-    void onTabRemoved(int oldIndex, int nextIndex);
+    void onTabAboutToRemove(int oldIndex, int nextIndex);
     void onTabMoved(int from, int to);
     void onTabCurrentChanged(int oldIndex, int newIndex);
     void onTabCloseRequested(int index);


### PR DESCRIPTION
Fixed tab selection logic when deleting a tab that is not the last tab.
Previously when deleting a non-last tab, the selection would incorrectly
stay on the same index instead of moving to the next tab. Also renamed
the signal from tabHasRemoved to tabAboutToRemove to better reflect when
it's emitted (before tab removal).

The changes include:
1. Fixed newIndex calculation for non-last tab deletion to select index
+ 1 instead of index
2. Renamed signal from tabHasRemoved to tabAboutToRemove to indicate
it's emitted before removal
3. Updated all related signal connections and slot names accordingly

Influence:
1. Test deleting middle tabs to verify selection moves to next tab
2. Test deleting last tab to verify selection moves to previous tab
3. Verify tab removal events are properly handled in title bar
4. Test tab switching behavior after deletion operations

fix: 修复删除非最后标签页时的选择逻辑

修复了删除非最后标签页时的选择逻辑。之前删除非最后标签页时，选择会错误地
停留在相同索引而不是移动到下一个标签页。同时将信号从tabHasRemoved重命名
为tabAboutToRemove以更好地反映其发射时机（在标签页移除之前）。

变更包括：
1. 修复非最后标签页删除时的新索引计算，选择index + 1而不是index
2. 将信号从tabHasRemoved重命名为tabAboutToRemove，表明在移除前发射
3. 更新所有相关的信号连接和槽函数名称

Influence:
1. 测试删除中间标签页，验证选择是否移动到下一个标签页
2. 测试删除最后标签页，验证选择是否移动到前一个标签页
3. 验证标签页移除事件在标题栏中正确处理
4. 测试删除操作后的标签页切换行为

## Summary by Sourcery

Correct the tab deletion behavior by selecting the next tab when a non-last tab is removed, and rename the removal signal to better indicate its pre-removal timing

Bug Fixes:
- Fix tab selection logic when deleting a non-last tab to move to the next tab

Enhancements:
- Rename tabHasRemoved signal to tabAboutToRemove to reflect emission before tab removal
- Update all related signal-slot connections and slot handler names accordingly