### PR TITLE
chore: update package dependencies and changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.103) unstable; urgency=medium
+
+  * Upgrade compatibility issues
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 07 Nov 2025 13:40:17 +0800
+
 dde-file-manager (6.5.102) unstable; urgency=medium
 
   * fix bugs

--- a/debian/control
+++ b/debian/control
@@ -88,15 +88,15 @@ Depends:
  libtss2-tcti-pcap0,
  libtss2-tcti-tabrmd0
 Replaces: dde-file-manager-oem,
- dde-desktop (<< 6.5.101),
+ dde-desktop (<< 6.5.102),
  dde-file-manager-preview,
  dde-file-manager-preview-plugins,
  dde-file-manager-plugins,
  dde-file-manager-daemon-plugins,
  dde-file-manager-common-plugins,
- dde-file-manager-services-plugins (<< 6.5.101)
-Breaks: dde-desktop (<< 6.5.101),
- dde-file-manager-services-plugins (<< 6.5.101)
+ dde-file-manager-services-plugins (<< 6.5.102)
+Breaks: dde-desktop (<< 6.5.102),
+ dde-file-manager-services-plugins (<< 6.5.102)
 Conflicts: dde-file-manager-preview,
  dde-file-manager-preview-plugins,
  dde-file-manager-plugins,


### PR DESCRIPTION
1. Updated Debian changelog with new version 6.5.103
2. Modified dependency version requirements from 6.5.101 to 6.5.102
3. Added compatibility upgrade note in changelog
4. Updated both Depends and Breaks sections to reflect new version requirements

These changes are necessary for maintaining proper package versioning dependencies and ensuring smooth upgrades between package versions. The modification ensures that incompatible packages (dde-desktop and dde-file-manager-services-plugins) below version 6.5.102 will be automatically replaced during upgrade.

Influence:
1. Verify package installation and upgrade scenarios
2. Test compatibility with dependent packages
3. Check package manager resolution behavior during upgrades

chore: 更新包依赖关系和变更日志

1. 在Debian变更日志中添加新版本6.5.103记录
2. 将依赖版本要求从6.5.101修改为6.5.102
3. 在变更日志中添加了兼容性升级说明
4. 更新了Depends和Breaks部分以反映新的版本要求

这些变更是为了维护正确的包版本依赖关系，确保包版本间能顺利升级。修改
确保低于6.5.102版本的不兼容包（dde-desktop和dde-file-manager-services- plugins）在升级过程中会被自动替换。

Influence:
1. 验证包安装和升级场景
2. 测试与依赖包的兼容性
3. 检查升级过程中包管理器的解决行为

## Summary by Sourcery

Update Debian packaging to version 6.5.103, bump dependency requirements to 6.5.102, and include compatibility upgrade note to ensure incompatible packages are replaced during upgrades.

Build:
- Bump control file Depends and Breaks requirements from version 6.5.101 to 6.5.102

Documentation:
- Update Debian changelog entry to 6.5.103 and add compatibility upgrade note