### PR TITLE
refactor: improve third-party device handling in computer view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.cpp
@@ -291,6 +291,16 @@ QList<QVariantMap> ComputerUtils::allPreDefineItemCustomDatas()
     return list;
 }
 
+bool ComputerUtils::isNativeDevice(const QString &suffix)
+{
+    static QStringList suffixList { SuffixInfo::kUserDir,
+                                    SuffixInfo::kBlock,
+                                    SuffixInfo::kProtocol,
+                                    "vault",
+                                    "ventry" };
+    return suffixList.contains(suffix);
+}
+
 QString ComputerUtils::deviceTypeInfo(DFMEntryFileInfoPointer info)
 {
     DFMBASE_USE_NAMESPACE
@@ -363,7 +373,7 @@ QUrl ComputerUtils::convertToDevUrl(const QUrl &url)
     // so find device url of the root dir by checking all blocks
     if (converted.scheme() == Global::Scheme::kFile) {
         auto devIds = DevProxyMng->getAllBlockIds();
-        for ( auto id : devIds) {
+        for (auto id : devIds) {
             QUrl devUrl(makeBlockDevUrl(id));
             DFMEntryFileInfoPointer entryInfo(new EntryFileInfo(devUrl));
             if (UniversalUtils::urlEquals(converted, entryInfo->targetUrl())) {

--- a/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.h
+++ b/src/plugins/filemanager/dfmplugin-computer/utils/computerutils.h
@@ -80,6 +80,7 @@ public:
     static QStringList allValidBlockUUIDs();
     static QList<QUrl> blkDevUrlByUUIDs(const QStringList &uuids);
     static QList<QVariantMap> allPreDefineItemCustomDatas();
+    static bool isNativeDevice(const QString &suffix);
 
 public:
     static bool contextMenuEnabled;   // TODO(xust) tmp solution, using GroupPolicy instead.

--- a/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
@@ -383,15 +383,10 @@ void ComputerView::handleUserDirVisible()
 void ComputerView::handle3rdEntriesVisible()
 {
     bool hide3rdEntries = ComputerItemWatcher::hide3rdEntries();
-    const static QStringList kNativaSuffixes { SuffixInfo::kUserDir,
-                                               SuffixInfo::kBlock,
-                                               SuffixInfo::kProtocol,
-                                               "vault",
-                                               "ventry" };
 
     for (int i = 0; i < model()->rowCount(); ++i) {
         QString currSuffix = model()->data(model()->index(i, 0), ComputerModel::kSuffixRole).toString();
-        if (kNativaSuffixes.contains(currSuffix))
+        if (ComputerUtils::isNativeDevice(currSuffix))
             continue;
 
         int shape = model()->data(model()->index(i, 0), ComputerModel::kItemShapeTypeRole).toInt();

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -674,6 +674,10 @@ void ComputerItemWatcher::removeDevice(const QUrl &url)
     auto ret = std::find_if(initedDatas.cbegin(), initedDatas.cend(), [url](const ComputerItemData &item) { return UniversalUtils::urlEquals(url, item.url); });
     if (ret != initedDatas.cend())
         initedDatas.removeAt(ret - initedDatas.cbegin());
+
+    ret = std::find_if(thirdItemList.cbegin(), thirdItemList.cend(), [url](const ComputerItemData &item) { return UniversalUtils::urlEquals(url, item.url); });
+    if (ret != thirdItemList.cend())
+        thirdItemList.removeAt(ret - thirdItemList.cbegin());
 }
 
 QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
@@ -819,6 +823,8 @@ void ComputerItemWatcher::startQueryItems(bool async)
             if (!fw)
                 return;
             initedDatas = fw->result();
+            for (const auto &item : std::as_const(thirdItemList))
+                cacheItem(item);
             afterQueryFunc();
             fw->deleteLater();
             fw = nullptr;
@@ -832,6 +838,8 @@ void ComputerItemWatcher::startQueryItems(bool async)
     }
 
     initedDatas = items();
+    for (const auto &item : std::as_const(thirdItemList))
+        cacheItem(item);
     afterQueryFunc();
 }
 
@@ -881,6 +889,8 @@ void ComputerItemWatcher::onDeviceAdded(const QUrl &devUrl, int groupId, Compute
     Q_EMIT itemAdded(data);
 
     cacheItem(data);
+    if (!ComputerUtils::isNativeDevice(info->nameOf(NameInfoType::kSuffix)))
+        thirdItemList << data;
 
     if (needSidebarItem && !disksHiddenByDConf().contains(devUrl))
         addSidebarItem(info);

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.h
@@ -126,6 +126,7 @@ private:
 private:
     bool isItemQueryFinished { false };
     ComputerDataList initedDatas;
+    ComputerDataList thirdItemList;
     QHash<QUrl, QVariantMap> sidebarInfos;
     QHash<QUrl, QVariantMap> computerInfos;
     QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher> appEntryWatcher { nullptr };


### PR DESCRIPTION
1. Extract native device suffix check into reusable utility function
2. Fix third-party device removal from cache list
3. Ensure third-party devices are properly cached during initialization
4. Maintain third-party device list separately for better management

The changes improve the handling of third-party devices in the computer
view by:
- Creating a centralized isNativeDevice() function to avoid code
duplication
- Fixing an issue where third-party devices weren't properly removed
from cache
- Ensuring third-party devices are correctly cached during item query
- Separating third-party device tracking for better maintainability

Influence:
1. Verify third-party devices display correctly in computer view
2. Test hiding/showing third-party entries functionality
3. Check device addition and removal operations
4. Verify native devices are not affected by third-party device settings
5. Test sidebar integration with third-party devices

refactor: 优化计算机视图中第三方设备处理

1. 将本地设备后缀检查提取为可重用的工具函数
2. 修复第三方设备从缓存列表中移除的问题
3. 确保初始化期间正确缓存第三方设备
4. 单独维护第三方设备列表以便更好管理

改进计算机视图中第三方设备的处理：
- 创建集中化的 isNativeDevice() 函数避免代码重复
- 修复第三方设备未正确从缓存中移除的问题
- 确保在项目查询期间正确缓存第三方设备
- 分离第三方设备跟踪以提高可维护性

Influence:
1. 验证第三方设备在计算机视图中正确显示
2. 测试隐藏/显示第三方设备条目的功能
3. 检查设备添加和移除操作
4. 验证本地设备不受第三方设备设置影响
5. 测试第三方设备与侧边栏的集成

BUG: https://pms.uniontech.com/bug-view-340065.html

## Summary by Sourcery

Extract native device detection into a reusable utility, track third-party devices separately in the watcher, and fix caching and removal logic for third-party entries in the computer view.

New Features:
- Automatically track added non-native devices in thirdItemList on device addition

Bug Fixes:
- Correct removal of third-party devices from cache in removeDevice
- Ensure third-party devices are re-cached during initialization and item queries

Enhancements:
- Add ComputerUtils::isNativeDevice utility to centralize native device suffix checks
- Introduce thirdItemList in ComputerItemWatcher to manage third-party devices independently
- Use isNativeDevice in ComputerView to filter native devices when toggling third-party entries