### PR TITLE
fix: update package version dependencies in control file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.104) unstable; urgency=medium
+
+  * Upgrade compatibility issues
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 07 Nov 2025 15:36:58 +0800
+
 dde-file-manager (6.5.103) unstable; urgency=medium
 
   * Upgrade compatibility issues

--- a/debian/control.in
+++ b/debian/control.in
@@ -88,15 +88,15 @@ Depends:
  libtss2-tcti-pcap0,
  libtss2-tcti-tabrmd0@PROFESSIONAL_DEPS@
 Replaces: dde-file-manager-oem,
- dde-desktop (<< 6.5.101),
+ dde-desktop (<< 6.5.102),
  dde-file-manager-preview,
  dde-file-manager-preview-plugins,
  dde-file-manager-plugins,
  dde-file-manager-daemon-plugins,
  dde-file-manager-common-plugins,
- dde-file-manager-services-plugins (<< 6.5.101)
-Breaks: dde-desktop (<< 6.5.101),
- dde-file-manager-services-plugins (<< 6.5.101)
+ dde-file-manager-services-plugins (<< 6.5.102)
+Breaks: dde-desktop (<< 6.5.102),
+ dde-file-manager-services-plugins (<< 6.5.102)
 Conflicts: dde-file-manager-preview,
  dde-file-manager-preview-plugins,
  dde-file-manager-plugins,


### PR DESCRIPTION
Updated the version constraints in debian/control.in to reflect new compatibility requirements. Changed all version requirements from 6.5.101 to 6.5.102 for dde-desktop and dde-file-manager-services-plugins packages. Also updated the changelog to document this change.

These changes were necessary because:
1. The newer version introduces breaking changes that require updated package dependencies
2. Ensures smooth upgrades and avoids conflicts during package installation
3. Maintains consistency across the dependency chain

Log:
Updated package dependency versions to ensure compatibility

Influence:
1. Verify successful installation on systems with dde-desktop 6.5.102+
2. Test upgrade scenarios from previous versions
3. Check for conflicts with other dependent packages
4. Verify functionality of all dependent features

fix: 更新控制文件中的软件包版本依赖项

更新了debian/control.in中的版本限制以反映新的兼容性要求。将所有针对dde-
desktop和dde-file-manager-services-plugins软件包的版本要求从6.5.101更改 为6.5.102。同时更新了变更日志以记录此更改。

这些更改是必要的，因为：
1. 新版本引入了重大变更，需要更新软件包依赖项
2. 确保平滑升级并避免软件包安装期间的冲突
3. 保持依赖链的一致性

Log:
更新了软件包依赖版本以确保兼容性

Influence:
1. 验证在装有dde-desktop 6.5.102+的系统上的成功安装
2. 测试从先前版本的升级场景
3. 检查与其他依赖包的冲突
4. 验证所有依赖功能的正常运行

## Summary by Sourcery

Update Debian packaging to require version 6.5.102 of core DDE packages and reflect the change in the changelog

Bug Fixes:
- Bump dde-desktop and dde-file-manager-services-plugins dependencies from 6.5.101 to 6.5.102 in debian/control.in

Documentation:
- Update debian/changelog to document the new dependency version