### PR TITLE
fix: update trash widget state on tab switch

### DIFF
--- a/src/plugins/filemanager/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/trash.cpp
@@ -13,6 +13,7 @@
 
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/dfm_event_defines.h>
 
 #include <dfm-base/utils/systempathutil.h>
 
@@ -154,6 +155,7 @@ void Trash::addCustomTopWidget()
 void Trash::followEvents()
 {
     dpfSignalDispatcher->subscribe("dfmplugin_workspace", "signal_Model_EmptyDir", TrashHelper::instance(), &TrashHelper::onTrashEmptyState);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl, TrashHelper::instance(), &TrashHelper::handleWindowUrlChanged);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction", TrashHelper::instance(), &TrashHelper::checkDragDropAction);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_DragDrop_FileCanMove", TrashHelper::instance(), &TrashHelper::checkCanMove);
     dpfHookSequence->follow("dfmplugin_detailspace", "hook_Icon_Fetch", TrashHelper::instance(), &TrashHelper::detailViewIcon);

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp
@@ -287,10 +287,10 @@ void TrashHelper::onTrashStateChanged()
 {
     // Ensure we know the current state before processing state change
     ensureTrashStateInitialized();
-    
+
     bool actuallyEmpty = FileUtils::trashIsEmpty();
     TrashState newState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
-    
+
     // Only process if state actually changed
     if (newState == trashState)
         return;
@@ -298,7 +298,7 @@ void TrashHelper::onTrashStateChanged()
     trashState = newState;
 
     // Update UI for any state change, but only when trash becomes non-empty
-    // This matches the original logic: if (isTrashEmpty) return; 
+    // This matches the original logic: if (isTrashEmpty) return;
     if (trashState == TrashState::Empty) {
         fmDebug() << "Trash: State changed to empty, no UI update needed";
         return;
@@ -325,7 +325,7 @@ void TrashHelper::onTrashEmptyState()
     // Force refresh the actual state
     bool actuallyEmpty = FileUtils::trashIsEmpty();
     trashState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
-    
+
     if (trashState != TrashState::Empty) {
         fmDebug() << "Trash: Trash is not empty, no action needed";
         return;
@@ -337,7 +337,7 @@ void TrashHelper::onTrashEmptyState()
         if (window) {
             const QUrl &url = window->currentUrl();
             if (url.scheme() == scheme())
-                TrashEventCaller::sendShowEmptyTrash(winId, false); // false means empty
+                TrashEventCaller::sendShowEmptyTrash(winId, false);   // false means empty
         }
     }
     fmDebug() << "Trash: State updated to empty, UI refreshed";
@@ -346,6 +346,13 @@ void TrashHelper::onTrashEmptyState()
 void TrashHelper::trashNotEmpty()
 {
     emit trashNotEmptyState();
+}
+
+void TrashHelper::handleWindowUrlChanged(quint64 winId, const QUrl &url)
+{
+    // url切换时，更新回收站顶部控件显示状态，主要针对标签切换
+    if (url.scheme() == scheme() && trashState != TrashState::Unknown)
+        TrashEventCaller::sendShowEmptyTrash(winId, trashState == TrashState::NotEmpty);
 }
 
 void TrashHelper::onTrashNotEmptyState()
@@ -357,7 +364,7 @@ void TrashHelper::onTrashNotEmptyState()
         if (window) {
             const QUrl &url = window->currentUrl();
             if (url.scheme() == scheme())
-                TrashEventCaller::sendShowEmptyTrash(winId, true); // true means not empty
+                TrashEventCaller::sendShowEmptyTrash(winId, true);   // true means not empty
         }
     }
     fmDebug() << "Trash: State explicitly set to non-empty";
@@ -385,7 +392,7 @@ void TrashHelper::ensureTrashStateInitialized()
         // Lazy initialization: determine actual trash state only when needed
         bool actuallyEmpty = FileUtils::trashIsEmpty();
         trashState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
-        fmDebug() << "Trash: Lazy initialized trash state to" 
-                 << (trashState == TrashState::Empty ? "Empty" : "NotEmpty");
+        fmDebug() << "Trash: Lazy initialized trash state to"
+                  << (trashState == TrashState::Empty ? "Empty" : "NotEmpty");
     }
 }

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.h
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.h
@@ -70,6 +70,7 @@ public:
     bool customRoleDisplayName(const QUrl &url, const DFMGLOBAL_NAMESPACE::ItemRoles role, QString *displayName);
     void onTrashEmptyState();
     void trashNotEmpty();
+    void handleWindowUrlChanged(quint64 winId, const QUrl &url);
 
 private Q_SLOTS:
     void onTrashNotEmptyState();


### PR DESCRIPTION
Fixed an issue where the trash widget display state was not updated when
switching between tabs in the file manager. Added event subscription
to handle window URL changes and refresh the trash widget state
accordingly.

Log: Fixed trash widget state not updating when switching tabs

Influence:
1. Test switching between different tabs while in trash view
2. Verify trash widget correctly shows empty/non-empty state after tab
switches
3. Check that trash state updates properly when files are moved to/
from trash
4. Test both empty and non-empty trash scenarios

fix: 修复标签页切换时回收站控件状态不更新问题

修复了文件管理器在标签页切换时回收站控件显示状态不更新的问题。添加了窗口
URL变化事件订阅，以便在标签切换时刷新回收站控件状态。

Log: 修复标签页切换时回收站控件状态不更新问题

Influence:
1. 测试在回收站视图下切换不同标签页
2. 验证标签页切换后回收站控件正确显示空/非空状态
3. 检查文件移入移出回收站时状态更新是否正常
4. 测试空回收站和非空回收站两种场景

BUG: https://pms.uniontech.com/bug-view-339855.html

## Summary by Sourcery

Ensure the trash widget correctly updates its empty/non-empty state when users switch tabs by listening for URL changes and triggering a UI refresh.

Bug Fixes:
- Fix trash widget state not updating when switching tabs in the file manager

Enhancements:
- Subscribe to window URL change events and add handleWindowUrlChanged handler to refresh the trash widget UI