### PR TITLE
test: add comprehensive unit tests for property dialog plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,10 +89,11 @@ dde-file-manager-lib/test_shutil/property/oneProperty.pro
 # clangd cache files
 .cache
 
-# cursor
+# cursor & AI config
 .cursorindexingignore
 .cursor
 .specstory
+.spec-workflow/
 
 # autotests
 Testing

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertydialog.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertydialog.cpp
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include "stubext.h"
+#include <QFileDevice>
+
+#include "dfmplugin_propertydialog_global.h"
+#include "propertydialog.h"
+#include "events/propertyeventreceiver.h"
+#include "events/propertyeventcall.h"
+#include "utils/propertydialogmanager.h"
+#include "utils/propertydialogutil.h"
+#include "utils/computerpropertyhelper.h"
+#include "utils/mediainfofetchworker.h"
+#include "menu/propertymenuscene.h"
+#include "views/filepropertydialog.h"
+#include "views/computerpropertydialog.h"
+
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
+using namespace dfmplugin_propertydialog;
+using namespace dfmplugin_menu_util;
+
+class TestPropertyDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        // Ensure plugin is stopped at beginning of each test
+        propertyDialog.stop();
+    }
+
+    void TearDown() override
+    {
+        // Ensure plugin is stopped at end of each test
+        propertyDialog.stop();
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    static PropertyDialog propertyDialog;   // Use static instance like other plugins
+};
+
+PropertyDialog TestPropertyDialog::propertyDialog;
+
+// Test PropertyDialog class - minimal stubbing to avoid memory alignment issues
+TEST_F(TestPropertyDialog, InitializeTest)
+{
+    EXPECT_NO_THROW(propertyDialog.initialize());
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestPropertyDialog, StartTest)
+{
+    bool result = propertyDialog.start();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, StopTest)
+{
+    // First start the plugin then stop it
+    propertyDialog.start();
+    EXPECT_NO_THROW(propertyDialog.stop());
+    // Stopping again should be safe
+    EXPECT_NO_THROW(propertyDialog.stop());
+}
+
+// Test PropertyEventReceiver class
+TEST_F(TestPropertyDialog, InstanceTest)
+{
+    PropertyEventReceiver *instance1 = PropertyEventReceiver::instance();
+    PropertyEventReceiver *instance2 = PropertyEventReceiver::instance();
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(TestPropertyDialog, BindEventsTest)
+{
+    PropertyEventReceiver receiver;
+    EXPECT_NO_THROW(receiver.bindEvents());
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestPropertyDialog, HandleShowPropertyDialogTest)
+{
+    PropertyEventReceiver receiver;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    EXPECT_NO_THROW(receiver.handleShowPropertyDialog(urls, option));
+}
+
+TEST_F(TestPropertyDialog, HandleViewExtensionRegisterTest)
+{
+    PropertyEventReceiver receiver;
+    auto viewFunc = [](const QUrl &url) -> QWidget* { return nullptr; };
+    bool result = receiver.handleViewExtensionRegister(viewFunc, "test_name", 0);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, HandleCustomViewRegisterTest)
+{
+    PropertyEventReceiver receiver;
+    auto viewFunc = [](const QUrl &url) -> QWidget* { return nullptr; };
+    bool result = receiver.handleCustomViewRegister(viewFunc, "test_scheme");
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, HandleBasicViewExtensionRegisterTest)
+{
+    PropertyEventReceiver receiver;
+    auto func = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> { 
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>(); 
+    };
+    bool result = receiver.handleBasicViewExtensionRegister(func, "test_scheme");
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, HandleBasicFiledFilterAddTest)
+{
+    PropertyEventReceiver receiver;
+    QStringList enums;
+    enums << "kBasisInfo";
+    bool result1 = receiver.handleBasicFiledFilterAdd("test_scheme_unique4", enums);
+    EXPECT_TRUE(result1);
+    
+    enums.clear();
+    enums << "kBasisInfo" << "kPermission";
+    bool result2 = receiver.handleBasicFiledFilterAdd("test_scheme_unique5", enums);
+    EXPECT_TRUE(result2);
+}
+
+// Test PropertyDialogManager class
+TEST_F(TestPropertyDialog, ManagerInstanceTest)
+{
+    PropertyDialogManager &manager1 = PropertyDialogManager::instance();
+    PropertyDialogManager &manager2 = PropertyDialogManager::instance();
+    EXPECT_EQ(&manager1, &manager2);
+}
+
+TEST_F(TestPropertyDialog, RegisterExtensionViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto viewFunc = [](const QUrl &url) -> QWidget* { return nullptr; };
+    bool result = manager.registerExtensionView(viewFunc, "test_name", 0);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, CreateExtensionViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, RegisterCustomViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto viewFunc = [](const QUrl &url) -> QWidget* { return nullptr; };
+    bool result = manager.registerCustomView(viewFunc, "test_scheme_unique1");
+    EXPECT_TRUE(result);
+
+    bool result2 = manager.registerCustomView(viewFunc, "test_scheme_unique1");
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialog, CreateCustomViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *result = manager.createCustomView(url);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(TestPropertyDialog, RegisterBasicViewExtensionTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto func = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> { 
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>(); 
+    };
+    bool result = manager.registerBasicViewExtension(func, "test_scheme_unique2");
+    EXPECT_TRUE(result);
+
+    bool result2 = manager.registerBasicViewExtension(func, "test_scheme_unique2");
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialog, CreateBasicViewExtensionFieldTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createBasicViewExtensionField(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, AddBasicFiledFiltesTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    bool result = manager.addBasicFiledFiltes("test_scheme_unique3", kPermission);
+    EXPECT_TRUE(result);
+
+    bool result2 = manager.addBasicFiledFiltes("test_scheme_unique3", kFileSizeFiled);
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialog, BasicFiledFiltesTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.basicFiledFiltes(url);
+    EXPECT_EQ(result, kNotFilter);
+}
+
+TEST_F(TestPropertyDialog, GetCreatorOptionByNameTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto result = manager.getCreatorOptionByName("nonexistent");
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, AddComputerPropertyDialogTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    EXPECT_NO_THROW(manager.addComputerPropertyDialog());
+}
+
+// Test PropertyDialogUtil class
+TEST_F(TestPropertyDialog, UtilInstanceTest)
+{
+    PropertyDialogUtil *util1 = PropertyDialogUtil::instance();
+    PropertyDialogUtil *util2 = PropertyDialogUtil::instance();
+    EXPECT_EQ(util1, util2);
+}
+
+TEST_F(TestPropertyDialog, ShowPropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+
+    EXPECT_NO_THROW(util.showPropertyDialog(urls, option));
+}
+
+TEST_F(TestPropertyDialog, ShowFilePropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+
+    EXPECT_NO_THROW(util.showFilePropertyDialog(urls, option));
+}
+
+TEST_F(TestPropertyDialog, ShowCustomDialogTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+
+    EXPECT_NO_THROW(util.showCustomDialog(url));
+}
+
+TEST_F(TestPropertyDialog, CloseFilePropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+
+    EXPECT_NO_THROW(util.closeFilePropertyDialog(url));
+}
+
+TEST_F(TestPropertyDialog, CloseCustomPropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    
+    EXPECT_NO_THROW(util.closeCustomPropertyDialog(url));
+}
+
+TEST_F(TestPropertyDialog, CloseAllFilePropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    
+    EXPECT_NO_THROW(util.closeAllFilePropertyDialog());
+}
+
+TEST_F(TestPropertyDialog, CloseAllPropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    
+    EXPECT_NO_THROW(util.closeAllPropertyDialog());
+}
+
+TEST_F(TestPropertyDialog, CreateControlViewTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    EXPECT_NO_THROW(util.createControlView(url, option));
+}
+
+TEST_F(TestPropertyDialog, UpdateCloseIndicatorTest)
+{
+    PropertyDialogUtil util;
+    
+    EXPECT_NO_THROW(util.updateCloseIndicator());
+}
+
+// Test ComputerPropertyHelper class
+TEST_F(TestPropertyDialog, ComputerPropertyHelperSchemeTest)
+{
+    QString scheme = ComputerPropertyHelper::scheme();
+    EXPECT_FALSE(scheme.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, ComputerPropertyHelperCreateComputerPropertyTest)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *widget = ComputerPropertyHelper::createComputerProperty(url);
+    EXPECT_TRUE(widget == nullptr);
+}
+
+// Test MediaInfoFetchWorker class
+TEST_F(TestPropertyDialog, MediaInfoFetchWorkerTest)
+{
+    MediaInfoFetchWorker worker;
+    EXPECT_NO_THROW(worker.getDuration("/tmp/test.mp4"));
+}
+
+// Test PropertyEventCall class
+TEST_F(TestPropertyDialog, PropertyEventCallSendSetPermissionManagerTest)
+{
+    EXPECT_NO_THROW(PropertyEventCall::sendSetPermissionManager(12345, QUrl::fromLocalFile("/tmp/test"), QFileDevice::ReadOwner));
+}
+
+TEST_F(TestPropertyDialog, PropertyEventCallSendFileHideTest)
+{
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    EXPECT_NO_THROW(PropertyEventCall::sendFileHide(12345, urls));
+}
+
+// Test PropertyMenuScene class
+TEST_F(TestPropertyDialog, PropertyMenuCreatorNameTest)
+{
+    QString name = PropertyMenuCreator::name();
+    EXPECT_EQ(name, "PropertyMenu");
+}
+
+TEST_F(TestPropertyDialog, PropertyMenuSceneNameTest)
+{
+    PropertyMenuScene scene;
+    QString name = scene.name();
+    EXPECT_EQ(name, "PropertyMenu");
+}
+
+// Test ComputerPropertyDialog class
+TEST_F(TestPropertyDialog, ComputerPropertyDialogTest)
+{
+    EXPECT_NO_THROW({
+        ComputerPropertyDialog dialog;
+    });
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertydialogmanager.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertydialogmanager.cpp
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QMetaEnum>
+#include <QUrl>
+#include <QVariantHash>
+#include <QMap>
+#include <QMultiMap>
+#include <QPair>
+
+#include "stubext.h"
+#include "utils/propertydialogmanager.h"
+#include "utils/computerpropertyhelper.h"
+#include "dfmplugin_propertydialog_global.h"
+
+using namespace dfmplugin_propertydialog;
+
+class TestPropertyDialogManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TestPropertyDialogManager, instance)
+{
+    PropertyDialogManager &manager1 = PropertyDialogManager::instance();
+    PropertyDialogManager &manager2 = PropertyDialogManager::instance();
+
+    EXPECT_EQ(&manager1, &manager2);
+}
+
+TEST_F(TestPropertyDialogManager, registerExtensionView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return nullptr;
+    };
+
+    bool result = manager.registerExtensionView(mockView, "test_name_unique1", 0);
+    EXPECT_TRUE(result);
+
+    // Test with different index
+    bool result2 = manager.registerExtensionView(mockView, "test_name_unique2", 1);
+    EXPECT_TRUE(result2);
+}
+
+TEST_F(TestPropertyDialogManager, registerExtensionView_WithIndexIncrement)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return nullptr;
+    };
+
+    // Register with index 0
+    bool result = manager.registerExtensionView(mockView, "test_name1_unique", 0);
+    EXPECT_TRUE(result);
+
+    // Register with same index 0, should increment to next available index (1)
+    bool result2 = manager.registerExtensionView(mockView, "test_name2_unique", 0);
+    EXPECT_TRUE(result2);
+
+    // Get the registered options to verify the indexes
+    QVariantHash option1 = manager.getCreatorOptionByName("test_name1_unique");
+    QVariantHash option2 = manager.getCreatorOptionByName("test_name2_unique");
+
+    // The first should have index 0
+    EXPECT_EQ(option1.value(kOption_Key_ViewIndex).toInt(), 0);
+    // The second one should have index 1, as the manager increments on conflict
+    int secondIndex = option2.value(kOption_Key_ViewIndex).toInt();
+    EXPECT_EQ(secondIndex, 1);  // After conflict resolution, should be 1
+}
+
+TEST_F(TestPropertyDialogManager, createExtensionView_Empty)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialogManager, createExtensionView_WithRegisteredView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // First register a view
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return new QWidget();
+    };
+    manager.registerExtensionView(mockView, "test_name_unique", 0);
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url);
+
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_EQ(result.size(), 1);
+
+    // Clean up created widgets
+    for (QWidget *widget : result) {
+        delete widget;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, createExtensionView_WithOptions)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // First register a view to get the original creator callback
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        QWidget *w = new QWidget();
+        w->setObjectName("test_widget");
+        return w;
+    };
+    manager.registerExtensionView(mockView, "test_name_unique", 0);
+
+    // Get the original registered option that contains the creator callback
+    QVariantHash originalOption = manager.getCreatorOptionByName("test_name_unique");
+    ASSERT_FALSE(originalOption.isEmpty());
+    
+    // Create new option with additional parameters but preserving the original creator callback
+    QVariantHash option = originalOption; // Copy all original data including creator callback
+    option.insert(kOption_Key_BasicInfoExpand, false); // Override or add new options
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url, option);
+
+    EXPECT_FALSE(result.isEmpty());
+
+    // Clean up created widgets
+    for (QWidget *widget : result) {
+        delete widget;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, registerCustomView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return new QWidget();
+    };
+
+    bool result = manager.registerCustomView(mockView, "test_scheme_unique1");
+    EXPECT_TRUE(result);
+
+    // Register same scheme again, should fail
+    bool result2 = manager.registerCustomView(mockView, "test_scheme_unique1");
+    EXPECT_FALSE(result2);
+
+    // Register different scheme, should succeed
+    bool result3 = manager.registerCustomView(mockView, "test_scheme_unique2");
+    EXPECT_TRUE(result3);
+
+    // Clean up
+    QWidget *testWidget = mockView(QUrl::fromLocalFile("/tmp"));
+    if (testWidget) {
+        delete testWidget;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, createCustomView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+
+    // Test with no registered views initially
+    QWidget *result = manager.createCustomView(testUrl);
+    
+    // The behavior of createCustomView is to iterate over ALL registered functions
+    // If other tests have registered functions, this may return a widget even for "no registered views"
+
+    // Register a view - it will be used for all URLs as the implementation
+    // iterates over all registered functions and returns the first non-null result
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        // For testing, create a widget for any URL
+        return new QWidget();
+    };
+    bool registerResult = manager.registerCustomView(mockView, "file_unique");
+    EXPECT_TRUE(registerResult);
+
+    // Now calling createCustomView with any URL will return a widget
+    // because the registered function returns a widget for any URL
+    QWidget *result2 = manager.createCustomView(QUrl("ftp://example.com/test"));
+    EXPECT_NE(result2, nullptr);
+
+    QWidget *result3 = manager.createCustomView(testUrl);  // file:///tmp/test 
+    EXPECT_NE(result3, nullptr);
+
+    if (result2) {
+        delete result2;
+    }
+    if (result3) {
+        delete result3;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, registerBasicViewExtension)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockFunc = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        QMap<QString, QMultiMap<QString, QPair<QString, QString>>> result;
+        QMultiMap<QString, QPair<QString, QString>> subMap;
+        subMap.insert("kFileSize", qMakePair(QString("Size"), QString("100KB")));
+        result.insert("kFieldInsert", subMap);
+        return result;
+    };
+
+    bool result = manager.registerBasicViewExtension(mockFunc, "test_scheme_unique1");
+    EXPECT_TRUE(result);
+
+    // Register same scheme again, should fail
+    bool result2 = manager.registerBasicViewExtension(mockFunc, "test_scheme_unique1");
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialogManager, createBasicViewExtensionField)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+
+    // Test with no registered functions
+    auto result = manager.createBasicViewExtensionField(testUrl);
+    EXPECT_TRUE(result.isEmpty());
+
+    // Register a function
+    auto mockFunc = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        QMap<QString, QMultiMap<QString, QPair<QString, QString>>> result;
+        QMultiMap<QString, QPair<QString, QString>> subMap;
+        subMap.insert("kFileSize", qMakePair(QString("Size"), QString("100KB")));
+        result.insert("kFieldInsert", subMap);
+        return result;
+    };
+    manager.registerBasicViewExtension(mockFunc, "file");
+
+    // Test with registered function
+    auto result2 = manager.createBasicViewExtensionField(testUrl);
+    EXPECT_FALSE(result2.isEmpty());
+}
+
+TEST_F(TestPropertyDialogManager, addBasicFiledFiltes)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    bool result = manager.addBasicFiledFiltes("test_scheme_unique1", kPermission);
+    EXPECT_TRUE(result);
+
+    // Add same scheme again, should fail
+    bool result2 = manager.addBasicFiledFiltes("test_scheme_unique1", kFileSizeFiled);
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialogManager, basicFiledFiltes)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+
+    // Test with empty filter hash
+    PropertyFilterType result = manager.basicFiledFiltes(testUrl);
+    EXPECT_EQ(result, kNotFilter);
+
+    // Add a filter
+    manager.addBasicFiledFiltes("file", kPermission);
+
+    // Test with matching scheme
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test");
+    PropertyFilterType result2 = manager.basicFiledFiltes(fileUrl);
+    EXPECT_EQ(result2, kPermission);
+
+    // Test with non-matching scheme
+    QUrl ftpUrl("ftp://example.com/test");
+    PropertyFilterType result3 = manager.basicFiledFiltes(ftpUrl);
+    EXPECT_EQ(result3, kNotFilter);
+}
+
+TEST_F(TestPropertyDialogManager, getCreatorOptionByName)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // Test with non-existent name
+    QVariantHash result = manager.getCreatorOptionByName("nonexistent_unique1");
+    EXPECT_TRUE(result.isEmpty());
+
+    // Register a view
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return nullptr;
+    };
+    manager.registerExtensionView(mockView, "test_name_unique1", 0);
+
+    // Test with existing name
+    QVariantHash result2 = manager.getCreatorOptionByName("test_name_unique1");
+    EXPECT_FALSE(result2.isEmpty());
+    EXPECT_EQ(result2.value(kOption_Key_Name).toString(), "test_name_unique1");
+    EXPECT_EQ(result2.value(kOption_Key_ViewIndex).toInt(), 0);
+}
+
+TEST_F(TestPropertyDialogManager, addComputerPropertyDialog)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // Mock ComputerPropertyHelper::scheme() and createComputerProperty
+    stub.set_lamda(&ComputerPropertyHelper::scheme,
+                   []() -> QString {
+                       return "computer_unique";
+                   });
+
+    bool createComputerPropertyCalled = false;
+    stub.set_lamda(&ComputerPropertyHelper::createComputerProperty,
+                   [&createComputerPropertyCalled](const QUrl &url) -> QWidget* {
+                       createComputerPropertyCalled = true;
+                       return new QWidget();
+                   });
+
+    manager.addComputerPropertyDialog();
+
+    // Verify that ComputerPropertyHelper::createComputerProperty would be called
+    // when creating a custom view for computer scheme
+    QUrl computerUrl("computer_unique:///");
+    QWidget *result = manager.createCustomView(computerUrl);
+
+    EXPECT_TRUE(createComputerPropertyCalled);
+    if (result) {
+        delete result;
+    }
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertydialogutil.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertydialogutil.cpp
@@ -1,0 +1,374 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QTimer>
+#include <QApplication>
+#include <QScreen>
+
+#include "stubext.h"
+#include "utils/propertydialogutil.h"
+#include "utils/propertydialogmanager.h"
+#include "views/filepropertydialog.h"
+#include "views/closealldialog.h"
+#include "dfmplugin_propertydialog_global.h"
+
+// Include DPF framework headers
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/eventsequence.h>
+#include <dfm-base/utils/windowutils.h>
+
+using namespace dfmplugin_propertydialog;
+using namespace dfmbase;
+
+class TestPropertyDialogUtil : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TestPropertyDialogUtil, instance)
+{
+    PropertyDialogUtil *util1 = PropertyDialogUtil::instance();
+    PropertyDialogUtil *util2 = PropertyDialogUtil::instance();
+    
+    EXPECT_NE(util1, nullptr);
+    EXPECT_EQ(util1, util2);
+}
+
+TEST_F(TestPropertyDialogUtil, constructor)
+{
+    PropertyDialogUtil util;
+    
+    EXPECT_NE(util.closeIndicatorTimer, nullptr);
+    EXPECT_NE(util.closeAllDialog, nullptr);
+    EXPECT_EQ(util.closeIndicatorTimer->interval(), 1000);
+}
+
+TEST_F(TestPropertyDialogUtil, showPropertyDialog_SingleFile)
+{
+    PropertyDialogUtil util;
+    
+    // Use correct signature for hook sequence run
+    typedef bool (DPF_NAMESPACE::EventSequenceManager::*RunFunc)(const QString &, const QString &, const QUrl &);
+    auto run = static_cast<RunFunc>(&DPF_NAMESPACE::EventSequenceManager::run);
+    
+    bool hookSequenceRunCalled = false;
+    stub.set_lamda(run,
+                   [&hookSequenceRunCalled](DPF_NAMESPACE::EventSequenceManager *self, const QString &ns, const QString &hook, const QUrl &url) -> bool {
+                        hookSequenceRunCalled = true;
+                        return false; // Don't disable property dialog
+                   });
+    
+    bool showCustomDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showCustomDialog,
+                   [&showCustomDialogCalled](PropertyDialogUtil *self, const QUrl &url) -> bool {
+                        showCustomDialogCalled = true;
+                        return false; // Don't show custom dialog
+                   });
+    
+    bool showFilePropertyDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showFilePropertyDialog,
+                   [&showFilePropertyDialogCalled](PropertyDialogUtil *self, const QList<QUrl> &urls, const QVariantHash &option) {
+                        showFilePropertyDialogCalled = true;
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    util.showPropertyDialog(urls, option);
+    
+    EXPECT_TRUE(hookSequenceRunCalled);
+    EXPECT_TRUE(showCustomDialogCalled);
+    EXPECT_TRUE(showFilePropertyDialogCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, showFilePropertyDialog_SingleFile)
+{
+    PropertyDialogUtil util;
+    
+    bool filterControlViewCalled = false;
+    bool setBasicInfoExpandCalled = false;
+    bool moveCalled = false;
+    bool showCalled = false;
+    
+    // Stub FilePropertyDialog methods with QWidget* as base type
+    stub.set_lamda(&FilePropertyDialog::selectFileUrl,
+                   [](QWidget *self, const QUrl &url) {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        // Mock implementation
+                   });
+    stub.set_lamda(&FilePropertyDialog::filterControlView,
+                   [&filterControlViewCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        filterControlViewCalled = true;
+                   });
+    stub.set_lamda(&FilePropertyDialog::setBasicInfoExpand,
+                   [&setBasicInfoExpandCalled](QWidget *self, bool expand) {
+                        Q_UNUSED(self)
+                        setBasicInfoExpandCalled = true;
+                   });
+    stub.set_lamda(&FilePropertyDialog::size,
+                   [](QWidget *self) -> QSize {
+                        Q_UNUSED(self)
+                        return QSize(400, 300);
+                   });
+    stub.set_lamda(&FilePropertyDialog::initalHeightOfView,
+                   [](QWidget *self) -> int {
+                        Q_UNUSED(self)
+                        return 250;
+                   });
+    
+    // Fix overloaded function issue by using static_cast
+    typedef void (QWidget::*MoveFunc)(const QPoint &);
+    stub.set_lamda(static_cast<MoveFunc>(&FilePropertyDialog::move),
+                   [&moveCalled](QWidget *self, const QPoint &pos) {
+                        Q_UNUSED(self)
+                        Q_UNUSED(pos)
+                        moveCalled = true;
+                   });
+    
+    stub.set_lamda(&FilePropertyDialog::show,
+                   [&showCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        showCalled = true;
+                   });
+    stub.set_lamda(&FilePropertyDialog::activateWindow,
+                   [](QWidget *self) {
+                        Q_UNUSED(self)
+                        // Mock implementation
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    util.showFilePropertyDialog(urls, option);
+    
+    EXPECT_TRUE(filterControlViewCalled);
+    EXPECT_TRUE(setBasicInfoExpandCalled);
+    EXPECT_TRUE(moveCalled);
+    EXPECT_TRUE(showCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, showCustomDialog_NotInCache)
+{
+    PropertyDialogUtil util;
+    
+    // Initially no custom dialog for this URL
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    bool createCustomizeViewCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::createCustomizeView,
+                   [&createCustomizeViewCalled, &testUrl](PropertyDialogUtil *self, const QUrl &url) -> QWidget* {
+                        Q_UNUSED(self)
+                        createCustomizeViewCalled = (url == testUrl);
+                        if (createCustomizeViewCalled) {
+                            QWidget *mockWidget = new QWidget();
+                            return mockWidget;
+                        }
+                        return nullptr;
+                   });
+    
+    bool showCalled = false;
+    bool activateWindowCalled = false;
+    stub.set_lamda(&QWidget::show,
+                   [&showCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        showCalled = true;
+                   });
+    stub.set_lamda(&QWidget::activateWindow,
+                   [&activateWindowCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        activateWindowCalled = true;
+                   });
+    
+    bool result = util.showCustomDialog(testUrl);
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(createCustomizeViewCalled);
+    EXPECT_TRUE(showCalled);
+    EXPECT_TRUE(activateWindowCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, closeFilePropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.closeFilePropertyDialog(testUrl));
+}
+
+TEST_F(TestPropertyDialogUtil, closeCustomPropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.closeCustomPropertyDialog(testUrl));
+}
+
+TEST_F(TestPropertyDialogUtil, closeAllFilePropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    bool closeAllDialogCloseCalled = false;
+    bool closeIndicatorTimerStopCalled = false;
+    
+    // Fix the return type issue - QWidget::close returns bool
+    stub.set_lamda(&QWidget::close,
+                   [&closeAllDialogCloseCalled](QWidget *self) -> bool {
+                        Q_UNUSED(self)
+                        closeAllDialogCloseCalled = true;
+                        return true;
+                   });
+    
+    // Fix overloaded function issue by using static_cast
+    typedef void (QTimer::*StopFunc)();
+    stub.set_lamda(static_cast<StopFunc>(&QTimer::stop),
+                   [&closeIndicatorTimerStopCalled](QTimer *self) {
+                        Q_UNUSED(self)
+                        closeIndicatorTimerStopCalled = true;
+                   });
+    
+    util.closeAllFilePropertyDialog();
+    
+    EXPECT_TRUE(closeIndicatorTimerStopCalled);
+    EXPECT_TRUE(closeAllDialogCloseCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, createControlView)
+{
+    PropertyDialogUtil util;
+    
+    bool createViewCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::createView,
+                   [&createViewCalled](PropertyDialogUtil *self, const QUrl &url, const QVariantHash &option) -> QMap<int, QWidget*> {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        Q_UNUSED(option)
+                        createViewCalled = true;
+                        QMap<int, QWidget*> result;
+                        result.insert(-1, new QWidget());
+                        return result;
+                   });
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    util.createControlView(testUrl, option);
+    
+    EXPECT_TRUE(createViewCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, createView)
+{
+    PropertyDialogUtil util;
+    
+    bool createExtensionViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::createExtensionView,
+                   [&createExtensionViewCalled](PropertyDialogManager *self, const QUrl &url, const QVariantHash &option) -> QMap<int, QWidget*> {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        Q_UNUSED(option)
+                        createExtensionViewCalled = true;
+                        return QMap<int, QWidget*>();
+                   });
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    auto result = util.createView(testUrl, option);
+    
+    EXPECT_TRUE(createExtensionViewCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, createCustomizeView)
+{
+    PropertyDialogUtil util;
+    
+    bool createCustomViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::createCustomView,
+                   [&createCustomViewCalled](PropertyDialogManager *self, const QUrl &url) -> QWidget* {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        createCustomViewCalled = true;
+                        return nullptr;
+                   });
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    QWidget *result = util.createCustomizeView(testUrl);
+    
+    EXPECT_TRUE(createCustomViewCalled);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(TestPropertyDialogUtil, insertExtendedControlFileProperty)
+{
+    PropertyDialogUtil util;
+    
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *widget = new QWidget();
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.insertExtendedControlFileProperty(url, 0, widget));
+    
+    delete widget;
+}
+
+TEST_F(TestPropertyDialogUtil, addExtendedControlFileProperty)
+{
+    PropertyDialogUtil util;
+    
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *widget = new QWidget();
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.addExtendedControlFileProperty(url, widget));
+    
+    delete widget;
+}
+
+TEST_F(TestPropertyDialogUtil, closeAllPropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.closeAllPropertyDialog());
+}
+
+TEST_F(TestPropertyDialogUtil, updateCloseIndicator)
+{
+    PropertyDialogUtil util;
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.updateCloseIndicator());
+}
+
+TEST_F(TestPropertyDialogUtil, createViewWithUrl)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    auto result = util.createView(url, option);
+    EXPECT_TRUE(result.isEmpty()); // Should be empty since no extensions registered
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertyeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertyeventreceiver.cpp
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include "stubext.h"
+#include <QUrl>
+#include <QVariantHash>
+#include <QList>
+#include <QMetaEnum>
+
+#include "events/propertyeventreceiver.h"
+#include "utils/propertydialogutil.h"
+#include "utils/propertydialogmanager.h"
+#include "dfmplugin_propertydialog_global.h"
+#include <dfm-framework/dpf.h>
+
+using namespace dfmplugin_propertydialog;
+using namespace DPF_NAMESPACE;
+
+class TestPropertyEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TestPropertyEventReceiver, instance)
+{
+    PropertyEventReceiver *instance1 = PropertyEventReceiver::instance();
+    PropertyEventReceiver *instance2 = PropertyEventReceiver::instance();
+    
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(TestPropertyEventReceiver, bindEvents)
+{
+    PropertyEventReceiver receiver;
+    
+    // We can't easily stub DPF framework's connect function due to its template nature.
+    // Instead, we just call the function to ensure it doesn't crash.
+    // The actual event binding functionality would be tested in integration tests.
+    EXPECT_NO_THROW(receiver.bindEvents());
+}
+
+TEST_F(TestPropertyEventReceiver, handleShowPropertyDialog)
+{
+    PropertyEventReceiver receiver;
+    
+    // Mock PropertyDialogUtil::instance() to return a mock instance
+    PropertyDialogUtil *mockUtil = new PropertyDialogUtil();
+    stub.set_lamda(&PropertyDialogUtil::instance,
+                   [mockUtil]() -> PropertyDialogUtil* {
+                       return mockUtil;
+                   });
+    
+    // Track if showPropertyDialog is called on the mock
+    bool showPropertyDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showPropertyDialog,
+                   [&showPropertyDialogCalled](PropertyDialogUtil *self, const QList<QUrl> &urls, const QVariantHash &option) {
+                       showPropertyDialogCalled = true;
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    receiver.handleShowPropertyDialog(urls, option);
+    
+    EXPECT_TRUE(showPropertyDialogCalled);
+    
+    delete mockUtil;
+}
+
+TEST_F(TestPropertyEventReceiver, handleShowPropertyDialogWithOptions)
+{
+    PropertyEventReceiver receiver;
+    
+    PropertyDialogUtil *mockUtil = new PropertyDialogUtil();
+    stub.set_lamda(&PropertyDialogUtil::instance,
+                   [mockUtil]() -> PropertyDialogUtil* {
+                       return mockUtil;
+                   });
+    
+    // Mock PropertyDialogManager::instance().getCreatorOptionByName
+    QVariantHash mockOption;
+    mockOption.insert(kOption_Key_Name, "test_name");
+    stub.set_lamda(&PropertyDialogManager::getCreatorOptionByName,
+                   [mockOption](PropertyDialogManager *self, const QString &name) -> QVariantHash {
+                       return mockOption;
+                   });
+    
+    bool showPropertyDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showPropertyDialog,
+                   [&showPropertyDialogCalled](PropertyDialogUtil *self, const QList<QUrl> &urls, const QVariantHash &option) {
+                       showPropertyDialogCalled = true;
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    option.insert(kOption_Key_Name, "test_name");
+    option.insert("test_key", "override_value");
+    
+    receiver.handleShowPropertyDialog(urls, option);
+    
+    EXPECT_TRUE(showPropertyDialogCalled);
+    
+    delete mockUtil;
+}
+
+TEST_F(TestPropertyEventReceiver, handleViewExtensionRegister)
+{
+    PropertyEventReceiver receiver;
+    
+    bool registerExtensionViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::registerExtensionView,
+                   [&registerExtensionViewCalled](PropertyDialogManager *self, CustomViewExtensionView viewCreator, const QString &name, int index) {
+                       registerExtensionViewCalled = true;
+                       return true;
+                   });
+    
+    auto mockView = [](const QUrl &url) -> QWidget* { return nullptr; };
+    
+    bool result = receiver.handleViewExtensionRegister(mockView, "test_name", 0);
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerExtensionViewCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleCustomViewRegister)
+{
+    PropertyEventReceiver receiver;
+    
+    bool registerCustomViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::registerCustomView,
+                   [&registerCustomViewCalled](PropertyDialogManager *self, CustomViewExtensionView view, const QString &scheme) {
+                       registerCustomViewCalled = true;
+                       return true;
+                   });
+    
+    auto mockView = [](const QUrl &url) -> QWidget* { return nullptr; };
+    
+    bool result = receiver.handleCustomViewRegister(mockView, "test_scheme");
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerCustomViewCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleBasicViewExtensionRegister)
+{
+    PropertyEventReceiver receiver;
+    
+    bool registerBasicViewExtensionCalled = false;
+    stub.set_lamda(&PropertyDialogManager::registerBasicViewExtension,
+                   [&registerBasicViewExtensionCalled](PropertyDialogManager *self, BasicViewFieldFunc func, const QString &scheme) {
+                       registerBasicViewExtensionCalled = true;
+                       return true;
+                   });
+    
+    auto mockFunc = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+    
+    bool result = receiver.handleBasicViewExtensionRegister(mockFunc, "test_scheme");
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerBasicViewExtensionCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleBasicFiledFilterAdd_Success)
+{
+    PropertyEventReceiver receiver;
+    
+    bool addBasicFiledFiltesCalled = false;
+    stub.set_lamda(&PropertyDialogManager::addBasicFiledFiltes,
+                   [&addBasicFiledFiltesCalled](PropertyDialogManager *self, const QString &scheme, PropertyFilterType filters) {
+                       addBasicFiledFiltesCalled = true;
+                       return true;
+                   });
+    
+    QStringList enums;
+    enums << "kBasisInfo" << "kPermission";
+    
+    bool result = receiver.handleBasicFiledFilterAdd("test_scheme", enums);
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addBasicFiledFiltesCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleBasicFiledFilterAdd_Failure)
+{
+    PropertyEventReceiver receiver;
+    
+    // Simulate when keysToValue fails
+    bool addBasicFiledFiltesCalled = false;
+    stub.set_lamda(&PropertyDialogManager::addBasicFiledFiltes,
+                   [&addBasicFiledFiltesCalled](PropertyDialogManager *self, const QString &scheme, PropertyFilterType filters) {
+                       addBasicFiledFiltesCalled = true;
+                       return false; // Simulate failure
+                   });
+    
+    QStringList enums;
+    enums << "InvalidEnumValue"; // This will cause keysToValue to fail
+    
+    bool result = receiver.handleBasicFiledFilterAdd("test_scheme", enums);
+    
+    // Result should be false because enum parsing fails
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(addBasicFiledFiltesCalled);
+}


### PR DESCRIPTION
Added complete test coverage for the dfmplugin-propertydialog module including:
- PropertyDialog plugin lifecycle tests
- PropertyEventReceiver event handling tests
- PropertyDialogManager view registration and creation tests
- PropertyDialogUtil dialog management tests
- ComputerPropertyHelper and MediaInfoFetchWorker utility tests
- PropertyMenuScene menu integration tests

Tests cover core functionality like dialog creation, view extensions, custom views, basic field filters, and event handling with proper stubbing and mocking.

Updated .gitignore to include .spec-workflow/ directory for AI workflow configurations.