### PR TITLE
perf: optimize multi-thread file copying performance 

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/copyfiles/docopyfilesworker.cpp
@@ -76,6 +76,9 @@ bool DoCopyFilesWorker::doWork()
 
 void DoCopyFilesWorker::stop()
 {
+    // clean muilt thread copy file info queue
+    threadCopyFileCount = 0;
+
     FileOperateBaseWorker::stop();
 }
 
@@ -118,6 +121,8 @@ bool DoCopyFilesWorker::initArgs()
 
 void DoCopyFilesWorker::endWork()
 {
+    waitThreadPoolOver();
+
     // deal target files
     for (DFileInfoPointer info : precompleteTargetFileInfo) {
         info->initQuerier();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -196,7 +196,8 @@ public:
 
     QWaitCondition waitCondition;
     QMutex mutex;
-    int threadCount { 8 };
+    QVector<QSharedPointer<DoCopyFileWorker>> threadCopyWorker;
+    int threadCount { 4 };
     std::atomic_bool retry { false };
     QSharedPointer<QThreadPool> threadPool { nullptr };
     static std::atomic_bool bigFileCopy;

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -69,20 +69,16 @@ void DoCopyFileWorker::stop()
     }
 }
 
-void DoCopyFileWorker::skipMemcpyBigFile(const QUrl url)
-{
-    memcpySkipUrl = url;
-}
 // main thread using
 void DoCopyFileWorker::operateAction(const AbstractJobHandler::SupportAction action)
 {
-    retry = !workData->signalThread && AbstractJobHandler::SupportAction::kRetryAction == action;
+    retry = !workData->singleThread && AbstractJobHandler::SupportAction::kRetryAction == action;
     currentAction = action;
     resume();
 }
 void DoCopyFileWorker::doFileCopy(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo)
 {
-    doDfmioFileCopy(fromInfo, toInfo, nullptr);
+    doCopyFileByRange(fromInfo, toInfo, nullptr);
     workData->completeFileCount++;
 }
 
@@ -1014,7 +1010,7 @@ bool DoCopyFileWorker::verifyFileIntegrity(const qint64 &blockSize, const ulong 
 
 void DoCopyFileWorker::checkRetry()
 {
-    if (!workData->signalThread && retry && !isStopped()) {
+    if (!workData->singleThread && retry && !isStopped()) {
         retry = false;
         emit retryErrSuccess(quintptr(this));
     }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -71,7 +71,6 @@ public:
     void pause();
     void resume();
     void stop();
-    void skipMemcpyBigFile(const QUrl url);
     void operateAction(const AbstractJobHandler::SupportAction action);
     // normal copy
     NextDo doCopyFilePractically(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo,
@@ -97,7 +96,6 @@ signals:
                      const bool isTo, const quint64 id, const QString &errorMsg,
                      const bool allUsErrorMsg);
     void retryErrSuccess(const quint64 id);
-    void skipCopyLocalBigFile(const QUrl fromUrl);
 
 private:   // file copy
     bool stateCheck();
@@ -163,7 +161,6 @@ private:
     std::atomic_bool retry { false };
     int blockFileFd { -1 };
     QList<QUrl> skipUrls;
-    QUrl memcpySkipUrl;
     DThreadList<QSharedPointer<dfmio::DOperator>> fileOps;
 };
 DPFILEOPERATIONS_END_NAMESPACE

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -133,7 +133,6 @@ private:   // file copy
                                  const QSharedPointer<DFMIO::DFile> &toDevice, const QSharedPointer<DFMIO::DFile> &fromDevice, const qint64 readSize, bool *skip,
                                  const qint64 currentPos,
                                  const qint64 &surplusSize, qint64 &curWrite);
-    void setTargetPermissions(const FileInfoPointer &fromInfo, const FileInfoPointer &toInfo);
     void setTargetPermissions(const QUrl &fromUrl, const QUrl &toUrl);
     bool verifyFileIntegrity(const qint64 &blockSize, const ulong &sourceCheckSum,
                              const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo,

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -104,26 +104,6 @@ void FileOperateBaseWorker::emitSpeedUpdatedNotify(const qint64 &writSize)
 }
 
 /*!
- * \brief FileOperateBaseWorker::setTargetPermissions Set permissions on the target file
- * \param fromInfo File information of source file
- * \param toInfo File information of target file
- */
-void FileOperateBaseWorker::setTargetPermissions(const QUrl &fromUrl, const QUrl &toUrl)
-{
-    // 修改文件修改时间
-    const auto &fromInfo = InfoFactory::create<FileInfo>(fromUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
-    const auto &toInfo = InfoFactory::create<FileInfo>(toUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
-    localFileHandler->setFileTime(toInfo->urlOf(UrlInfoType::kUrl),
-                                  fromInfo->timeOf(TimeInfoType::kLastRead).value<QDateTime>(),
-                                  fromInfo->timeOf(TimeInfoType::kLastModified).value<QDateTime>());
-    QFileDevice::Permissions permissions = fromInfo->permissions();
-    QString path = fromInfo->urlOf(UrlInfoType::kUrl).path();
-    // 权限为0000时，源文件已经被删除，无需修改新建的文件的权限为0000
-    if (permissions != 0000 && !ProtocolUtils::isMTPFile(toInfo->urlOf(UrlInfoType::kUrl)))
-        localFileHandler->setPermissions(toInfo->urlOf(UrlInfoType::kUrl), permissions);
-}
-
-/*!
  * \brief FileOperateBaseWorker::readAheadSourceFile Pre read source file content
  * \param fileInfo File information of source file
  */

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -51,7 +51,6 @@ public:
                        const QUrl &toUrl, bool *skip);
     bool checkDiskSpaceAvailable(const QUrl &fromUrl, const QUrl &toUrl, bool *skip);
     bool checkTotalDiskSpaceAvailable(const QUrl &fromUrl, const QUrl &toUrl, bool *skip);
-    void setTargetPermissions(const QUrl &fromUrl, const QUrl &toUrl);
     void setAllDirPermisson();
     void determineCountProcessType();
     qint64 getWriteDataSize();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -86,6 +86,7 @@ public:
     bool checkAndCopyDir(const DFileInfoPointer &fromInfo, const DFileInfoPointer &toInfo, bool *skip);
 
 protected:
+    void waitThreadPoolOver();
     void initCopyWay();
     bool shouldUseBlockWriteType() const;
     QUrl trashInfo(const DFileInfoPointer &fromInfo);
@@ -94,9 +95,11 @@ protected:
     void setSkipValue(bool *skip, AbstractJobHandler::SupportAction action);
 
 private:
+    void initThreadCopy();
     void initSignalCopyWorker();
     bool actionOperating(const AbstractJobHandler::SupportAction action, const qint64 size, bool *skip);
     QUrl createNewTargetUrl(const DFileInfoPointer &toInfo, const QString &fileName);
+    bool doCopyLocalFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
     bool doCopyOtherFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
     bool doCopyLocalByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
 
@@ -129,6 +132,7 @@ protected:
     QFuture<void> syncResult;
     QString blocakTargetRootPath;
 
+    std::atomic_int threadCopyFileCount { 0 };
     QList<DFileInfoPointer> cutAndDeleteFiles;
 };
 DPFILEOPERATIONS_END_NAMESPACE

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/workerdata.h
@@ -64,7 +64,7 @@ public:
     QAtomicInteger<qint64> blockRenameWriteSize { 0 };   // The copy size is 0. The write statistics size of the linked file and directory
     QAtomicInteger<qint64> skipWriteSize { 0 };   // 跳过的文件大
     QAtomicInteger<qint64> completeFileCount { 0 };   // copy complete file count
-    std::atomic_bool signalThread { true };
+    std::atomic_bool singleThread { true };
     DThreadMap<QUrl, qint64> everyFileWriteSize;
     DThreadList<QSharedPointer<DPFILEOPERATIONS_NAMESPACE::WorkerData::BlockFileCopyInfo>> blockCopyInfoQueue;
 };

--- a/src/services/textindex/utils/docutils.cpp
+++ b/src/services/textindex/utils/docutils.cpp
@@ -116,6 +116,7 @@ std::optional<QString> extractHtmlContent(const QString &filePath, size_t maxByt
 
 std::optional<QString> extractFileContent(const QString &filePath, size_t maxBytes)
 {
+    fmInfo() << "About to extract file: " << filePath;
     // First try HTML extraction for HTML-style documents
     if (isHtmlStyleDocument(filePath)) {
         auto htmlContent = extractHtmlContent(filePath, maxBytes);


### PR DESCRIPTION
## Summary by Sourcery

Optimize multi-thread file copying performance by introducing configurable multi-threading for local transfers and refactoring the worker classes to support concurrent operations.

New Features:
- Add multi-threaded copy support for local file operations using a QThreadPool and multiple DoCopyFileWorker instances.

Enhancements:
- Dynamically choose between single-threaded and multi-threaded copying based on file size, number of files, and CPU core count.
- Implement a wait mechanism to ensure all thread pool tasks complete before finalizing operations.
- Refactor AbstractWorker to propagate pause, resume, stop, and retry actions across thread-specific workers.
- Add logging in DocUtils to trace file extraction operations.

Chores:
- Remove deprecated single-thread permission setting and skipMemcpyBigFile methods.
- Replace the workData.signalThread flag with workData.singleThread and clean up related logic across FileOperateBaseWorker and DoCopyFileWorker.
- Clean up unused methods and update worker headers to reflect multi-threading changes.