### PR TITLE
fix: prevent inappropriate validation prompt in export path dialog

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -413,6 +413,7 @@ void EncryptParamsInputDialog::onExpPathChanged(const QString &path, bool silent
 
     QString msg;
     btnNext->setEnabled(validateExportPath(path, &msg));
+    if (!msg.isEmpty() && !silent)
         keyExportInput->showAlertMessage(msg);
 }
 


### PR DESCRIPTION
- Added condition to check silent flag before showing alert message
- Ensures validation message only displays when user interaction is expected

Log: Fix inappropriate validation prompt in key export dialog by checking silent mode

Bug: https://pms.uniontech.com/bug-view-340345.html

## Summary by Sourcery

Bug Fixes:
- Prevent alert message from appearing in export path dialog when silent mode is enabled