### PR TITLE
chore: update translations

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
@@ -27,9 +27,9 @@ bool hasComputerMenuRegisted()
 
 void DiskEncryptEntry::initialize()
 {
-    auto i18n = new QTranslator(this);
-    i18n->load(QLocale(), "disk-encrypt", "_", "/usr/share/dde-file-manager/translations");
-    QCoreApplication::installTranslator(i18n);
+    // auto i18n = new QTranslator(this);
+    // i18n->load(QLocale(), "disk-encrypt", "_", "/usr/share/dde-file-manager/translations");
+    // QCoreApplication::installTranslator(i18n);
 
     auto mng = dfmbase::DConfigManager::instance();
     mng->addConfig(kEncryptDConfig);

--- a/translations/dde-file-manager_zh_CN.ts
+++ b/translations/dde-file-manager_zh_CN.ts
@@ -4772,7 +4772,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="60"/>
         <source>Please input %1 to decrypt device</source>
-        <translation>请输入%1以解密设备</translation>
+        <translation>请输入%1以取消加密设备</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp" line="61"/>
@@ -4931,12 +4931,12 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="139"/>
         <source>Use TPM+PIN to unlock on this computer (recommended)</source>
-        <translation>在此计算机上侍弄TPM+PIN码解锁（推荐）</translation>
+        <translation>在此计算机上使用TPM+PIN码解锁（推荐）</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="140"/>
         <source>Automatic unlocking on this computer by TPM</source>
-        <translation>再次计算机上使用TPM自动解锁</translation>
+        <translation>在此计算机上使用TPM自动解锁</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp" line="167"/>
@@ -5309,7 +5309,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="633"/>
         <source>Please click the right disk menu &quot;Continue partition encryption&quot; to complete partition encryption.</source>
-        <translation>请单击右侧磁盘菜单&quot;继续分区加密&quot;以完成分区加密。</translation>
+        <translation>请先点击磁盘右键菜单“继续分区加密”完成分区加密。</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp" line="661"/>


### PR DESCRIPTION
Bug: https://pms.uniontech.com/bug-view-340325.html

## Summary by Sourcery

Update Chinese translations for the disk encryption UI and disable manual translator installation in the DiskEncryptEntry plugin

Bug Fixes:
- Correct Chinese translations for decrypt device prompt, TPM unlock options, and disk menu instructions

Chores:
- Comment out manual QTranslator initialization in DiskEncryptEntry plugin code