### PR TITLE
fix: remove redundant D-Bus interface validation checks

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
@@ -170,13 +170,6 @@ void UserShareHelper::setSambaPasswd(const QString &userName, const QString &pas
 
     // Call D-Bus interface with pipe file descriptor
     QDBusInterface *interface = getUserShareInterface();
-    if (!interface || !interface->isValid()) {
-        fmWarning() << "UserShare D-Bus interface is not available";
-        close(pipefd[0]);
-        Q_EMIT sambaPasswordSet(false);
-        return;
-    }
-
     QDBusReply<bool> reply = interface->call(DaemonServiceIFace::kFuncSetPasswd, QVariant::fromValue(fd));
     bool success = reply.isValid() && reply.value();
     fmInfo() << "Samba password set result:" << success
@@ -360,11 +353,6 @@ bool UserShareHelper::needDisableShareWidget(FileInfoPointer info)
 bool UserShareHelper::isUserSharePasswordSet(const QString &username)
 {
     QDBusInterface *interface = getUserShareInterface();
-    if (!interface || !interface->isValid()) {
-        fmWarning() << "UserShare D-Bus interface is not available when checking password";
-        return false;
-    }
-
     QDBusReply<bool> reply = interface->call(DaemonServiceIFace::kFuncIsPasswordSet, username);
     bool result = reply.isValid() ? reply.value() : false;
     fmDebug() << "isSharePasswordSet result: " << result << ", error: " << reply.error();
@@ -498,11 +486,6 @@ void UserShareHelper::initMonitorPath()
 bool UserShareHelper::removeShareByShareName(const QString &name, bool silent)
 {
     QDBusInterface *interface = getUserShareInterface();
-    if (!interface || !interface->isValid()) {
-        fmWarning() << "UserShare D-Bus interface is not available when removing share:" << name;
-        return false;
-    }
-
     QDBusReply<bool> reply = interface->asyncCall(DaemonServiceIFace::kFuncCloseShare, name, !silent);
     if (reply.isValid() && reply.value()) {
         fmDebug() << "share closed: " << name;


### PR DESCRIPTION
Remove duplicate D-Bus interface validation checks from multiple
methods in UserShareHelper class. The getUserShareInterface() function
already performs comprehensive validation and returns nullptr if the
interface is unavailable. This eliminates redundant code and simplifies
maintenance.

The validation logic was duplicated across setSambaPasswd(),
isUserSharePasswordSet(), and removeShareByShareName() methods. Since
getUserShareInterface() already handles interface validation and returns
null for invalid interfaces, the additional checks were unnecessary. The
D-Bus calls will naturally fail if the interface is invalid, and error
handling is already implemented in the calling code.

Influence:
1. Test samba password setting functionality with valid and invalid D-
Bus connections
2. Verify share password status checking works correctly
3. Test share removal operations with both available and unavailable D-
Bus services
4. Confirm error handling remains consistent when D-Bus interface is
unavailable
5. Validate that existing share management features continue to work
as expected

fix: 移除冗余的 D-Bus 接口验证检查

从 UserShareHelper 类的多个方法中移除重复的 D-Bus 接口验证检查。
getUserShareInterface() 函数已经执行了全面的验证，并在接口不可用时返回空
指针。这消除了冗余代码并简化了维护。

验证逻辑在 setSambaPasswd()、isUserSharePasswordSet() 和
removeShareByShareName() 方法中重复存在。由于 getUserShareInterface() 已
经处理接口验证并在接口无效时返回空值，额外的检查变得不必要。如果接口无
效，D-Bus 调用自然会失败，并且调用代码中已经实现了错误处理。

Influence:
1. 测试在有效和无效 D-Bus 连接下的 samba 密码设置功能
2. 验证共享密码状态检查功能正常工作
3. 测试在 D-Bus 服务可用和不可用情况下的共享删除操作
4. 确认当 D-Bus 接口不可用时错误处理保持一致
5. 验证现有的共享管理功能继续按预期工作

BUG: https://pms.uniontech.com/bug-view-340315.html

## Summary by Sourcery

Enhancements:
- Remove redundant D-Bus interface validity checks from setSambaPasswd, isUserSharePasswordSet, and removeShareByShareName methods