### PR TITLE
fix: correct encrypt progress dialog position issue

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -228,14 +228,13 @@ void EventsHandler::onEncryptFinished(const QVariantMap &result)
     if (!dialog)
         dialog_utils::showDialog(title, msg, code != 0 ? dialog_utils::kError : dialog_utils::kInfo);
     else {
-        auto pos = dialog->geometry().topLeft();
         dialog->showResultPage(success, title, msg);
         if (code == -KErrorRequestExportRecKey) {
             auto recKey = result.value(encrypt_param_keys::kKeyRecoveryKey).toString();
             dialog->setRecoveryKey(recKey, dev);
             dialog->showExportPage();
         }
-        dialog->move(pos);
+        dialog->raise();
     }
 
     // delete auto start file.
@@ -327,7 +326,7 @@ void EventsHandler::onEncryptProgress(const QString &dev, const QString &devName
         QString device = QString("%1(%2)").arg(devName).arg(dev.mid(5));
 
         QApplication::restoreOverrideCursor();
-        auto dlg = new EncryptProgressDialog(qApp->activeWindow());
+        auto dlg = new EncryptProgressDialog();
         dlg->setText(tr("%1 is under encrypting...").arg(device),
                      tr("The encrypting process may have system lag, please minimize the system operation"));
         encryptDialogs.insert(dev, dlg);
@@ -348,7 +347,7 @@ void EventsHandler::onDecryptProgress(const QString &dev, const QString &devName
         QString device = QString("%1(%2)").arg(devName).arg(dev.mid(5));
 
         QApplication::restoreOverrideCursor();
-        auto dlg = new EncryptProgressDialog(qApp->activeWindow());
+        auto dlg = new EncryptProgressDialog();
         dlg->setText(tr("%1 is under decrypting...").arg(device),
                      tr("The decrypting process may have system lag, please minimize the system operation"));
         decryptDialogs.insert(dev, dlg);
@@ -545,9 +544,8 @@ void EventsHandler::showDecryptError(const QString &dev, const QString &devName,
 
     auto dialog = decryptDialogs.take(dev);
     if (dialog) {
-        auto pos = dialog->geometry().topLeft();
         dialog->showResultPage(code == 0, title, msg);
-        dialog->move(pos);
+        dialog->raise();
     } else {
         dialog_utils::showDialog(title, msg,
                                  showFailed ? dialog_utils::kError : dialog_utils::kInfo);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include <QMap>
+#include <QPointer>
 
 namespace dfmplugin_diskenc {
 class EncryptProgressDialog;
@@ -54,9 +55,9 @@ private Q_SLOTS:
 private:
     explicit EventsHandler(QObject *parent = nullptr);
 
-    QMap<QString, EncryptProgressDialog *> encryptDialogs;
-    QMap<QString, EncryptProgressDialog *> decryptDialogs;
-    QMap<QString, EncryptParamsInputDialog *> encryptInputs;
+    QMap<QString, QPointer<EncryptProgressDialog>> encryptDialogs;
+    QMap<QString, QPointer<EncryptProgressDialog>> decryptDialogs;
+    QMap<QString, QPointer<EncryptParamsInputDialog>> encryptInputs;
 signals:
 };
 }

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -54,7 +54,6 @@ void EncryptProgressDialog::showResultPage(bool success, const QString &title, c
     iconLabel->setPixmap(icon.pixmap(64, 64));
 
     addButton(tr("Confirm"));
-    setCloseButtonVisible(true);
     setAttribute(Qt::WA_DeleteOnClose);
     setOnButtonClickedClose(true);
 }


### PR DESCRIPTION
- Remove parent window association to fix dialog position anomaly
- Replace manual position saving with raise() method for proper window focus
- Use QPointer for dialog management to prevent dangling pointer issues
- Comment out close button on result page to improve UX

Log: Fixed encrypt progress dialog position issue after encryption completion

Bug: https://pms.uniontech.com/bug-view-340249.html

## Summary by Sourcery

Fix encrypt/decrypt progress dialog positioning and focus anomalies by removing parent window associations and manual repositioning, replacing them with raise(), improve pointer safety, and hide the result page close button.

Bug Fixes:
- Fix encrypt/decrypt progress dialog positioning and focus after completion

Enhancements:
- Use QPointer for dialog management to prevent dangling pointers
- Remove parent window associations and manual repositioning in favor of raise() for proper dialog focus and position
- Disable close button on result page to improve user experience