### PR TITLE
fix: resolve incomplete string display in encrypt progress dialog

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -114,6 +114,8 @@ void EncryptProgressDialog::initUI()
     progress->start();
 
     message = new QLabel(this);
+    message->setWordWrap(true);
+    message->setAlignment(Qt::AlignCenter);
     progressLay->addWidget(message, 0, Qt::AlignCenter);
 
     QFrame *resultPage = new QFrame(this);
@@ -126,6 +128,8 @@ void EncryptProgressDialog::initUI()
     resultLay->addWidget(iconLabel, 0, Qt::AlignCenter);
 
     resultMsg = new QLabel(this);
+    resultMsg->setWordWrap(true);
+    resultMsg->setAlignment(Qt::AlignCenter);
     resultLay->addWidget(resultMsg, 0, Qt::AlignCenter);
 
     warningLabel = new QLabel(this);


### PR DESCRIPTION
- Enable word wrap for message label to prevent text truncation
- Enable word wrap for result message label to ensure full text visibility
- Add center alignment for both labels to improve visual consistency
- Include qnamespace.h header for Qt::AlignCenter flag

Log: Fixed incomplete string display by enabling word wrap and center alignment for message labels

Bug: https://pms.uniontech.com/bug-view-340499.html

## Summary by Sourcery

Fix incomplete string display in the encryption progress dialog

Bug Fixes:
- Enable word wrap and center alignment for progress and result message labels to prevent text truncation and improve visual consistency

Build:
- Include qnamespace.h header for Qt::AlignCenter flag