### PR TITLE
chore: update debian changelog for version 6.5.105

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.105) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 13 Nov 2025 19:46:11 +0800
+
 dde-file-manager (6.5.104) unstable; urgency=medium
 
   * Upgrade compatibility issues


### PR DESCRIPTION
Updated Debian changelog to add new entry for version 6.5.105. The
changelog now includes the new version number, release urgency level,
brief bug fix description, and maintainer information with timestamp.
This is a standard maintenance update to track package changes for the
Debian packaging system.

Influence:
1. Verify package version information is correctly displayed
2. Check changelog formatting complies with Debian standards
3. Confirm timestamp and maintainer information accuracy
4. Ensure package management tools can parse the changelog correctly

chore: 更新 Debian 变更日志至版本 6.5.105

更新了 Debian 变更日志，为版本 6.5.105 添加了新条目。变更日志现在包含新
的版本号、发布紧急级别、简短的错误修复描述以及带有时间戳的维护者信息。这
是标准的维护更新，用于跟踪 Debian 打包系统的软件包变更。

Influence:
1. 验证软件包版本信息是否正确显示
2. 检查变更日志格式是否符合 Debian 标准
3. 确认时间戳和维护者信息的准确性
4. 确保包管理工具能够正确解析变更日志

## Summary by Sourcery

Chores:
- Add new changelog entry for Debian package version 6.5.105 including urgency level, brief fix description, and maintainer information