### PR TITLE
refactor: adjust icon mode background radius calculation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.h
@@ -20,7 +20,7 @@ inline constexpr int kIconModeTextPadding = { 4 };   // 选中背景和文字之
 inline constexpr int kIconModeIconSpacing = { 3 };   // icon与背景的边距
 
 inline constexpr int kIconModeRectRadius = kIconModeTextPadding;
-inline constexpr int kIconModeBackRadius = { 6 };
+inline constexpr int kIconModeBackRadiusCoefficient = { 16 };
 inline constexpr int kIconModeColumuPadding { 10 };
 // end
 

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewdrawhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewdrawhelper.cpp
@@ -60,10 +60,12 @@ QPixmap ViewDrawHelper::renderDragPixmap(dfmbase::Global::ViewMode mode, QModelI
         QPainter painter(&pixmap);
 
         drawDragIcons(&painter, option, pixRect, indexes, topIndex);
-        if (dragCount != 1)
+        if (dragCount != 1) {
             drawDragCount(&painter, topIndex, option, dragCount);
-        else
-            drawDragText(&painter, topIndex, rect.width() - 2 * kIconModeTextPadding - 2 * kIconModeColumuPadding - kIconModeBackRadius);
+        } else {
+            int radius = view->iconSize().width() / kIconModeBackRadiusCoefficient;
+            drawDragText(&painter, topIndex, rect.width() - 2 * kIconModeTextPadding - 2 * kIconModeColumuPadding - radius);
+        }
 
         return pixmap;
     } else if (mode == ViewMode::kListMode || mode == ViewMode::kTreeMode) {
@@ -116,7 +118,7 @@ void ViewDrawHelper::drawDragIcons(QPainter *painter, const QStyleOptionViewItem
         painter->translate(-offsetX, -offsetY);
     }
 
-    //draw top icon
+    // draw top icon
     painter->setOpacity(0.8);
     view->itemDelegate()->paintDragIcon(painter, option, topIndex, defaultIconSize);
 }
@@ -124,7 +126,7 @@ void ViewDrawHelper::drawDragIcons(QPainter *painter, const QStyleOptionViewItem
 void ViewDrawHelper::drawDragCount(QPainter *painter, const QModelIndex &topIndex, const QStyleOptionViewItem &option, int count) const
 {
     QSize defaultIconSize = QSize(dragIconSize, dragIconSize);
-    int length = count > kDragIconMaxCount ? 28 : 24;   //diffrent size for diffrent number of chars
+    int length = count > kDragIconMaxCount ? 28 : 24;   // diffrent size for diffrent number of chars
     QSize iconRealSize = view->itemDelegate()->getIndexIconSize(option, topIndex, defaultIconSize);
     if (iconRealSize.width() > defaultIconSize.width() || iconRealSize.height() > defaultIconSize.height())
         iconRealSize.scale(defaultIconSize, Qt::KeepAspectRatio);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -586,7 +586,8 @@ QPainterPath IconItemDelegate::paintItemBackgroundAndGeomerty(QPainter *painter,
     QRectF outLineRect = backgroundRect;
     outLineRect.setSize(outLineRect.size() - QSizeF(2, 2));
     outLineRect.moveCenter(backgroundRect.center());
-    path.addRoundedRect(outLineRect, kIconModeBackRadius, kIconModeBackRadius);
+    int radius = iconSize.width() / kIconModeBackRadiusCoefficient;
+    path.addRoundedRect(outLineRect, radius, radius);
 
     if (isDropTarget || isSelected || isHover) {   // 只有选中和mouseover才绘制背景
         painter->setRenderHint(QPainter::Antialiasing, true);


### PR DESCRIPTION
Changed the background radius calculation for icon mode from fixed
value to dynamic calculation based on icon size. Replaced constant
kIconModeBackRadius with kIconModeBackRadiusCoefficient (16) to make
the radius proportional to icon size. This ensures consistent visual
appearance across different icon sizes and improves scalability.

The changes affect both drag operation rendering and item background
drawing. For single item drag operations, the text area calculation
now uses dynamic radius. The background rounded rectangles now scale
properly with icon dimensions.

Influence:
1. Test drag operations with different icon sizes
2. Verify visual consistency in icon mode with various icon scale
settings
3. Check background rendering for selected/hovered items
4. Validate text positioning in drag previews
5. Test with both single and multiple item drag operations

refactor: 调整图标模式背景圆角计算方式

将图标模式的背景圆角计算从固定值改为基于图标大小的动态计算。用
kIconModeBackRadiusCoefficient (16) 替换了常量 kIconModeBackRadius，使
圆角半径与图标大小成比例。这确保了不同图标大小下的视觉一致性并提高了可扩
展性。

这些更改影响了拖拽操作渲染和项目背景绘制。对于单项目拖拽操作，文本区域计
算现在使用动态半径。背景圆角矩形现在能够根据图标尺寸正确缩放。

Influence:
1. 测试不同图标大小下的拖拽操作
2. 验证各种图标缩放设置下图标模式的视觉一致性
3. 检查选中/悬停项目的背景渲染
4. 验证拖拽预览中的文本定位
5. 测试单项目和多个项目的拖拽操作

BUG: https://pms.uniontech.com/bug-view-340513.html

## Summary by Sourcery

Refactor icon mode to calculate background corner radius dynamically based on icon size, ensuring consistent rounded visuals across different icon scales and updating drag preview rendering accordingly.

Enhancements:
- Replace fixed background radius with a size‐based coefficient for icon mode
- Use dynamic radius when positioning drag preview text and count
- Scale rounded rectangle backgrounds for selected/hovered items proportionally to icon dimensions