### PR TITLE
fix: fix preview visibility signal emission timing

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.cpp
@@ -64,17 +64,6 @@ void ViewOptionsButton::switchMode(ViewMode mode, const QUrl &url)
     d->fileUrl = url;
 }
 
-void ViewOptionsButton::setVisible(bool visible)
-{
-    DToolButton::setVisible(visible);
-    if (!DConfigManager::instance()->value(kViewDConfName, kDisplayPreviewVisibleKey).toBool()) {
-        fmDebug() << "Display preview is disabled in config, skipping preview visibility change";
-        return;
-    }
-
-    Q_EMIT displayPreviewVisibleChanged(visible);
-}
-
 ViewOptionsButton::~ViewOptionsButton() = default;
 
 void ViewOptionsButton::paintEvent(QPaintEvent *event)
@@ -133,6 +122,21 @@ void ViewOptionsButton::mouseReleaseEvent(QMouseEvent *event)
 {
     DToolButton::mouseReleaseEvent(event);
     update();
+}
+
+bool ViewOptionsButton::event(QEvent *event)
+{
+    const auto type = event->type();
+    if (type == QEvent::Show || type == QEvent::Hide) {
+        if (!DConfigManager::instance()->value(kViewDConfName, kDisplayPreviewVisibleKey).toBool()) {
+            fmDebug() << "Display preview is disabled in config, skipping preview visibility change";
+            return DToolButton::event(event);
+        }
+
+        Q_EMIT displayPreviewVisibleChanged(type == QEvent::Show);
+    }
+
+    return DToolButton::event(event);
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionsbutton.h
@@ -23,8 +23,6 @@ public:
     ~ViewOptionsButton() override;
     void switchMode(DFMBASE_NAMESPACE::Global::ViewMode mode, const QUrl &url);
 
-    void setVisible(bool visible) override;
-
 Q_SIGNALS:
     void displayPreviewVisibleChanged(bool visible);
 
@@ -39,6 +37,7 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    bool event(QEvent *event) override;
 };
 
 }   // namespace dfmplugin_titlebar


### PR DESCRIPTION
The setVisible() override was replaced with an event() handler to
properly handle visibility changes. The previous implementation
emitted displayPreviewVisibleChanged signal directly in setVisible(),
which could cause issues when the preview feature is disabled in
configuration. Now the signal is only emitted for Show/Hide events and
only when preview is enabled, ensuring proper timing and configuration
checks.

This change ensures that visibility changes are handled through the
event system rather than direct method calls, providing more reliable
signal emission that aligns with Qt's event handling mechanism. The
configuration check remains to prevent unnecessary signal emissions when
preview functionality is disabled.

Influence:
1. Test view options button visibility changes in different scenarios
2. Verify that display preview signal is only emitted when preview is
enabled in config
3. Check that button shows/hides correctly in various file manager views
4. Test configuration changes for preview feature and observe button
behavior

fix: 修复预览可见性信号发射时机问题

将 setVisible() 重写替换为 event() 事件处理器，以正确处理可见性变化。之
前的实现在 setVisible() 中直接发射 displayPreviewVisibleChanged 信号，当
预览功能在配置中禁用时可能导致问题。现在信号仅在 Show/Hide 事件且预览功
能启用时发射，确保正确的时机和配置检查。

此更改确保通过事件系统处理可见性变化，而非直接方法调用，提供更可靠的信号
发射机制，与 Qt 的事件处理机制保持一致。配置检查保持不变，以防止在预览功
能禁用时不必要的信号发射。

Influence:
1. 在不同场景下测试视图选项按钮的可见性变化
2. 验证显示预览信号仅在配置中启用预览功能时发射
3. 检查按钮在各种文件管理器视图中的正确显示/隐藏
4. 测试预览功能的配置更改并观察按钮行为

BUG: https://pms.uniontech.com/bug-view-340503.html

## Summary by Sourcery

Replace direct visibility signal emission with event-based handling to fix timing issues and respect the preview-enabled configuration

Bug Fixes:
- Ensure displayPreviewVisibleChanged signal is only emitted on Show/Hide events when preview is enabled in config, preventing spurious emissions when disabled

Enhancements:
- Remove setVisible override and implement event() override to handle visibility changes via the Qt event system