### PR TITLE
test: add comprehensive unit tests for emblem plugin

### DIFF
--- a/autotests/plugins/dfmplugin-emblem/test_emblem.cpp
+++ b/autotests/plugins/dfmplugin-emblem/test_emblem.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#define private public
+#define protected public
+#include "emblem.h"
+#include "events/emblemeventrecevier.h"
+#undef private
+#undef protected
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <QApplication>
+
+using namespace dfmplugin_emblem;
+DFMBASE_USE_NAMESPACE;
+
+class UT_Emblem : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        if (!qApp) {
+            int argc = 1;
+            char *argv[] = { const_cast<char *>("test") };
+            new QApplication(argc, argv);
+        }
+
+        emblem = new Emblem();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete emblem;
+        emblem = nullptr;
+    }
+
+    Emblem *emblem { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_Emblem, Initialize_InitializesConnections)
+{
+    bool initCalled = false;
+    stub.set_lamda(&EmblemEventRecevier::initializeConnections, [&initCalled] {
+        __DBG_STUB_INVOKE__
+        initCalled = true;
+    });
+
+    emblem->initialize();
+
+    EXPECT_TRUE(initCalled);
+}
+
+TEST_F(UT_Emblem, Start_AddsDConfigSuccessfully)
+{
+    bool addConfigCalled = false;
+    bool addConfigSuccess = true;
+
+    stub.set_lamda(&DConfigManager::addConfig, [&](DConfigManager *, const QString &name, QString *err) {
+        __DBG_STUB_INVOKE__
+        addConfigCalled = true;
+        return addConfigSuccess;
+    });
+
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &defaultValue) {
+        __DBG_STUB_INVOKE__
+        return defaultValue;
+    });
+
+    bool result = emblem->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addConfigCalled);
+}
+
+TEST_F(UT_Emblem, Start_HandlesDConfigFailure)
+{
+    bool addConfigSuccess = false;
+    QString errorMsg = "test error";
+
+    stub.set_lamda(&DConfigManager::addConfig, [&](DConfigManager *, const QString &name, QString *err) {
+        __DBG_STUB_INVOKE__
+        if (err)
+            *err = errorMsg;
+        return addConfigSuccess;
+    });
+
+    bool result = emblem->start();
+
+    EXPECT_TRUE(result);  // start() still returns true even if config fails
+}
+
+TEST_F(UT_Emblem, Start_ReadsHideSystemEmblemsConfig)
+{
+    bool hideEmblems = true;
+    bool valueCalled = false;
+
+    stub.set_lamda(&DConfigManager::addConfig, [](DConfigManager *, const QString &, QString *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DConfigManager::value, [&](DConfigManager *, const QString &path, const QString &key, const QVariant &defaultValue) {
+        __DBG_STUB_INVOKE__
+        valueCalled = true;
+        if (key == kHideSystemEmblems)
+            return QVariant(hideEmblems);
+        return defaultValue;
+    });
+
+    bool result = emblem->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(valueCalled);
+}

--- a/autotests/plugins/dfmplugin-emblem/test_emblemeventrecevier.cpp
+++ b/autotests/plugins/dfmplugin-emblem/test_emblemeventrecevier.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+#include <QPainter>
+#include <QImage>
+
+#define private public
+#define protected public
+#include "events/emblemeventrecevier.h"
+#include "utils/emblemmanager.h"
+#undef private
+#undef protected
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-framework/event/event.h>
+#include <QApplication>
+
+using namespace dfmplugin_emblem;
+DFMBASE_USE_NAMESPACE;
+DPF_USE_NAMESPACE;
+
+class UT_EmblemEventRecevier : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        if (!qApp) {
+            int argc = 1;
+            char *argv[] = { const_cast<char *>("test") };
+            new QApplication(argc, argv);
+        }
+
+        receiver = EmblemEventRecevier::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    EmblemEventRecevier *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_EmblemEventRecevier, Instance_ReturnsSingleton)
+{
+    auto instance1 = EmblemEventRecevier::instance();
+    auto instance2 = EmblemEventRecevier::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_EmblemEventRecevier, HandlePaintEmblems_CallsEmblemManager)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    bool paintCalled = false;
+    stub.set_lamda(&EmblemManager::paintEmblems, [&](EmblemManager *, int role, const FileInfoPointer &info, QPainter *p, QRectF *area) {
+        __DBG_STUB_INVOKE__
+        paintCalled = true;
+        return true;
+    });
+
+    bool result = receiver->handlePaintEmblems(&painter, paintArea, mockInfo);
+
+    EXPECT_TRUE(paintCalled);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_EmblemEventRecevier, InitializeConnections_ConnectsSlot)
+{
+    // This test mainly ensures the function doesn't crash
+    // The actual connection is handled by DPF framework
+    EXPECT_NO_FATAL_FAILURE(receiver->initializeConnections());
+}

--- a/autotests/plugins/dfmplugin-emblem/test_emblemeventsequence.cpp
+++ b/autotests/plugins/dfmplugin-emblem/test_emblemeventsequence.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+#include <QIcon>
+
+#define private public
+#define protected public
+#include "events/emblemeventsequence.h"
+#undef private
+#undef protected
+
+#include <dfm-framework/event/event.h>
+#include <QApplication>
+
+using namespace dfmplugin_emblem;
+DPF_USE_NAMESPACE;
+
+class UT_EmblemEventSequence : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        if (!qApp) {
+            int argc = 1;
+            char *argv[] = { const_cast<char *>("test") };
+            new QApplication(argc, argv);
+        }
+
+        sequence = EmblemEventSequence::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    EmblemEventSequence *sequence { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_EmblemEventSequence, Instance_ReturnsSingleton)
+{
+    auto instance1 = EmblemEventSequence::instance();
+    auto instance2 = EmblemEventSequence::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_EmblemEventSequence, DoFetchExtendEmblems_CallsHookSequence)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QList<QIcon> emblems;
+
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, QList<QIcon> *&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [&] {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return false;
+    });
+
+    bool result = sequence->doFetchExtendEmblems(url, &emblems);
+
+    EXPECT_TRUE(hookCalled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemEventSequence, DoFetchCustomEmblems_CallsHookSequence)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QList<QIcon> emblems;
+
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, QList<QIcon> *&);
+    auto runFunc = static_cast<RunFunc>(&EventSequenceManager::run);
+    stub.set_lamda(runFunc, [&] {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return false;
+    });
+
+    bool result = sequence->doFetchCustomEmblems(url, &emblems);
+
+    EXPECT_TRUE(hookCalled);
+    EXPECT_FALSE(result);
+}

--- a/autotests/plugins/dfmplugin-emblem/test_emblemhelper.cpp
+++ b/autotests/plugins/dfmplugin-emblem/test_emblemhelper.cpp
@@ -1,0 +1,765 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+#include <QSignalSpy>
+#include <QThread>
+#include <QTest>
+
+#define private public
+#define protected public
+#include "utils/emblemhelper.h"
+#undef private
+#undef protected
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-framework/event/event.h>
+#include <dfm-io/dfileinfo.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <QApplication>
+#include <QIcon>
+
+using namespace dfmplugin_emblem;
+DFMBASE_USE_NAMESPACE;
+DPF_USE_NAMESPACE;
+
+// =============================================================================
+// GioEmblemWorker Tests
+// =============================================================================
+class UT_GioEmblemWorker : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+        worker = new GioEmblemWorker();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete worker;
+        worker = nullptr;
+    }
+
+    GioEmblemWorker *worker { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_GioEmblemWorker, OnClear_ClearsCache)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    worker->cache[url] = QList<QIcon>();
+
+    worker->onClear();
+
+    EXPECT_TRUE(worker->cache.isEmpty());
+}
+
+TEST_F(UT_GioEmblemWorker, FetchEmblems_ReturnsEmptyForNullInfo)
+{
+    FileInfoPointer nullInfo;
+    auto emblems = worker->fetchEmblems(nullInfo);
+    EXPECT_TRUE(emblems.isEmpty());
+}
+
+TEST_F(UT_GioEmblemWorker, FetchEmblems_CallsGetGioEmblems)
+{
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    bool getCalled = false;
+    stub.set_lamda(&GioEmblemWorker::getGioEmblems, [&](GioEmblemWorker *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        getCalled = true;
+        return QMap<int, QIcon>();
+    });
+
+    worker->fetchEmblems(mockInfo);
+
+    EXPECT_TRUE(getCalled);
+}
+
+TEST_F(UT_GioEmblemWorker, FetchEmblems_BuildsCorrectList)
+{
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    QMap<int, QIcon> iconMap;
+    iconMap[0] = QIcon::fromTheme("icon0");
+    iconMap[2] = QIcon::fromTheme("icon2");
+
+    stub.set_lamda(&GioEmblemWorker::getGioEmblems, [&](GioEmblemWorker *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return iconMap;
+    });
+
+    auto emblems = worker->fetchEmblems(mockInfo);
+
+    EXPECT_GE(emblems.size(), 3);   // Should have at least 3 elements (0, 1-null, 2)
+}
+
+TEST_F(UT_GioEmblemWorker, GetGioEmblems_ReturnsEmptyForNullInfo)
+{
+    FileInfoPointer nullInfo;
+    auto map = worker->getGioEmblems(nullInfo);
+    EXPECT_TRUE(map.isEmpty());
+}
+
+TEST_F(UT_GioEmblemWorker, GetGioEmblems_ReturnsEmptyForNoEmblemData)
+{
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    stub.set_lamda(VADDR(FileInfo, customAttribute), [] {
+        __DBG_STUB_INVOKE__
+        return QVariant(QStringList());   // Empty list
+    });
+
+    auto map = worker->getGioEmblems(mockInfo);
+
+    EXPECT_TRUE(map.isEmpty());
+}
+
+TEST_F(UT_GioEmblemWorker, GetGioEmblems_ParsesEmblemString)
+{
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    stub.set_lamda(VADDR(FileInfo, customAttribute), [] {
+        __DBG_STUB_INVOKE__
+        QStringList list;
+        list << "/tmp/icon1.png|/tmp/icon2.png";
+        return QVariant(list);
+    });
+
+    bool parseCalled = false;
+    stub.set_lamda(&GioEmblemWorker::parseEmblemString, [&](GioEmblemWorker *, QIcon *, QString &, const QString &) {
+        __DBG_STUB_INVOKE__
+        parseCalled = true;
+        return false;
+    });
+
+    worker->getGioEmblems(mockInfo);
+
+    EXPECT_TRUE(parseCalled);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_ReturnsFalseForEmptyString)
+{
+    QIcon emblem;
+    QString pos;
+    bool result = worker->parseEmblemString(&emblem, pos, "");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_SetsDefaultPosition)
+{
+    QIcon emblem;
+    QString pos;
+
+    stub.set_lamda(static_cast<bool (DFMIO::DFile::*)() const>(&DFMIO::DFile::exists), [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    worker->parseEmblemString(&emblem, pos, "/tmp/test.png");
+
+    EXPECT_EQ("rd", pos);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_ParsesPathWithPosition)
+{
+    QIcon emblem;
+    QString pos;
+    QString emblemStr = "/tmp/test.png;lu";
+
+    stub.set_lamda(static_cast<bool (DFMIO::DFile::*)() const>(&DFMIO::DFile::exists), [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DFMIO::DFile::size, [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return 1024;
+    });
+
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
+                       __DBG_STUB_INVOKE__
+                       return QSharedPointer<FileInfo>(new FileInfo(url));
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf), [](FileInfo *, NameInfoType) {
+        __DBG_STUB_INVOKE__
+        return QString("png");
+    });
+
+    worker->parseEmblemString(&emblem, pos, emblemStr);
+
+    EXPECT_EQ("lu", pos);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_ExpandsTildePath)
+{
+    QIcon emblem;
+    QString pos;
+    QString emblemStr = "~/test.png";
+
+    bool existsCalled = false;
+    stub.set_lamda(static_cast<bool (DFMIO::DFile::*)() const>(&DFMIO::DFile::exists), [&](const DFMIO::DFile *file) {
+        __DBG_STUB_INVOKE__
+        existsCalled = true;
+        return false;
+    });
+
+    worker->parseEmblemString(&emblem, pos, emblemStr);
+
+    EXPECT_TRUE(existsCalled);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_RejectsNonExistentFile)
+{
+    QIcon emblem;
+    QString pos;
+
+    stub.set_lamda(static_cast<bool (DFMIO::DFile::*)() const>(&DFMIO::DFile::exists), [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    bool result = worker->parseEmblemString(&emblem, pos, "/tmp/nonexistent.png");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_RejectsTooLargeFile)
+{
+    QIcon emblem;
+    QString pos;
+
+    stub.set_lamda(static_cast<bool (DFMIO::DFile::*)() const>(&DFMIO::DFile::exists), [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DFMIO::DFile::size, [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return 200000;   // > 102400
+    });
+
+    bool result = worker->parseEmblemString(&emblem, pos, "/tmp/large.png");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_RejectsUnsupportedFormat)
+{
+    QIcon emblem;
+    QString pos;
+
+    stub.set_lamda(static_cast<bool (DFMIO::DFile::*)() const>(&DFMIO::DFile::exists), [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DFMIO::DFile::size, [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return 1024;
+    });
+
+    stub.set_lamda(VADDR(FileInfo, nameOf), [](FileInfo *, NameInfoType) {
+        __DBG_STUB_INVOKE__
+        return QString("txt");   // Unsupported format
+    });
+
+    bool result = worker->parseEmblemString(&emblem, pos, "/tmp/test.txt");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_GioEmblemWorker, ParseEmblemString_AcceptsSupportedFormats)
+{
+    QIcon emblem;
+    QString pos;
+
+    stub.set_lamda(static_cast<bool (DFMIO::DFile::*)() const>(&DFMIO::DFile::exists), [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DFMIO::DFile::size, [](const DFMIO::DFile *) {
+        __DBG_STUB_INVOKE__
+        return 1024;
+    });
+
+    QStringList supportedFormats = { "svg", "png", "gif", "bmp", "jpg" };
+    for (const QString &format : supportedFormats) {
+        stub.set_lamda(VADDR(FileInfo, nameOf), [&](FileInfo *, NameInfoType) {
+            __DBG_STUB_INVOKE__
+            return format;
+        });
+
+        // Just check it doesn't reject based on format
+        worker->parseEmblemString(&emblem, pos, QString("/tmp/test.%1").arg(format));
+        // Result may still be false if icon loading fails, but format check should pass
+    }
+}
+
+TEST_F(UT_GioEmblemWorker, IconNamesEqual_ReturnsTrueForEmptyLists)
+{
+    QList<QIcon> list1, list2;
+    EXPECT_TRUE(worker->iconNamesEqual(list1, list2));
+}
+
+TEST_F(UT_GioEmblemWorker, IconNamesEqual_ReturnsFalseForDifferentSizes)
+{
+    QList<QIcon> list1, list2;
+    list1 << QIcon();
+    list2 << QIcon() << QIcon();
+
+    EXPECT_FALSE(worker->iconNamesEqual(list1, list2));
+}
+
+TEST_F(UT_GioEmblemWorker, IconNamesEqual_ComparesIconNames)
+{
+    QList<QIcon> list1, list2;
+    list1 << QIcon::fromTheme("icon1") << QIcon::fromTheme("icon2");
+    list2 << QIcon::fromTheme("icon1") << QIcon::fromTheme("icon2");
+
+    bool result = worker->iconNamesEqual(list1, list2);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_GioEmblemWorker, SetEmblemIntoIcons_SetsRightDownPosition)
+{
+    QMap<int, QIcon> iconMap;
+    QIcon emblem = QIcon::fromTheme("test");
+
+    worker->setEmblemIntoIcons("rd", emblem, &iconMap);
+
+    EXPECT_TRUE(iconMap.contains(0));
+    EXPECT_EQ(emblem.name(), iconMap[0].name());
+}
+
+TEST_F(UT_GioEmblemWorker, SetEmblemIntoIcons_SetsLeftDownPosition)
+{
+    QMap<int, QIcon> iconMap;
+    QIcon emblem = QIcon::fromTheme("test");
+
+    worker->setEmblemIntoIcons("ld", emblem, &iconMap);
+
+    EXPECT_TRUE(iconMap.contains(1));
+}
+
+TEST_F(UT_GioEmblemWorker, SetEmblemIntoIcons_SetsLeftUpPosition)
+{
+    QMap<int, QIcon> iconMap;
+    QIcon emblem = QIcon::fromTheme("test");
+
+    worker->setEmblemIntoIcons("lu", emblem, &iconMap);
+
+    EXPECT_TRUE(iconMap.contains(2));
+}
+
+TEST_F(UT_GioEmblemWorker, SetEmblemIntoIcons_SetsRightUpPosition)
+{
+    QMap<int, QIcon> iconMap;
+    QIcon emblem = QIcon::fromTheme("test");
+
+    worker->setEmblemIntoIcons("ru", emblem, &iconMap);
+
+    EXPECT_TRUE(iconMap.contains(3));
+}
+
+TEST_F(UT_GioEmblemWorker, SetEmblemIntoIcons_DefaultsToRightDown)
+{
+    QMap<int, QIcon> iconMap;
+    QIcon emblem = QIcon::fromTheme("test");
+
+    worker->setEmblemIntoIcons("unknown", emblem, &iconMap);
+
+    EXPECT_TRUE(iconMap.contains(0));
+}
+
+// =============================================================================
+// EmblemHelper Tests
+// =============================================================================
+class UT_EmblemHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        if (!qApp) {
+            int argc = 1;
+            char *argv[] = { const_cast<char *>("test") };
+            new QApplication(argc, argv);
+        }
+
+        // Stub initialize to prevent thread creation in tests
+        stub.set_lamda(&EmblemHelper::initialize, [](EmblemHelper *) {
+            __DBG_STUB_INVOKE__
+            // Do nothing
+        });
+
+        helper = new EmblemHelper(nullptr);
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete helper;
+        helper = nullptr;
+    }
+
+    EmblemHelper *helper { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_EmblemHelper, HasEmblem_ReturnsFalseForUnknownUrl)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/unknown");
+    EXPECT_FALSE(helper->hasEmblem(url));
+}
+
+TEST_F(UT_EmblemHelper, HasEmblem_ReturnsTrueForKnownUrl)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    helper->productQueue[url] = QList<QIcon>();
+
+    EXPECT_TRUE(helper->hasEmblem(url));
+}
+
+TEST_F(UT_EmblemHelper, ClearEmblem_ClearsProductQueue)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    helper->productQueue[url] = QList<QIcon>();
+
+    helper->clearEmblem();
+
+    EXPECT_FALSE(helper->hasEmblem(url));
+    EXPECT_TRUE(helper->productQueue.isEmpty());
+}
+
+TEST_F(UT_EmblemHelper, SystemEmblems_ReturnsEmptyForNullInfo)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    FileInfoPointer nullInfo;
+    auto emblems = helper->systemEmblems(nullInfo);
+
+    EXPECT_TRUE(emblems.isEmpty());
+}
+
+TEST_F(UT_EmblemHelper, SystemEmblems_ReturnsEmptyForDesktopFiles)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    stub.set_lamda(&FileUtils::isDesktopFileInfo, [](const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test.desktop")));
+    auto emblems = helper->systemEmblems(mockInfo);
+
+    EXPECT_TRUE(emblems.isEmpty());
+}
+
+TEST_F(UT_EmblemHelper, SystemEmblems_ReturnsSymlinkEmblem)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    stub.set_lamda(&FileUtils::isDesktopFileInfo, [](const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](FileInfo *, OptInfoType type) {
+        __DBG_STUB_INVOKE__
+        if (type == OptInfoType::kIsSymLink)
+            return true;
+        return false;
+    });
+
+    auto emblems = helper->systemEmblems(mockInfo);
+
+    EXPECT_FALSE(emblems.isEmpty());
+}
+
+TEST_F(UT_EmblemHelper, SystemEmblems_ReturnsReadonlyEmblem)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    stub.set_lamda(&FileUtils::isDesktopFileInfo, [](const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](FileInfo *, OptInfoType type) {
+        __DBG_STUB_INVOKE__
+        if (type == OptInfoType::kIsWritable)
+            return false;   // Not writable
+        return false;
+    });
+
+    auto emblems = helper->systemEmblems(mockInfo);
+
+    EXPECT_FALSE(emblems.isEmpty());
+}
+
+TEST_F(UT_EmblemHelper, SystemEmblems_ReturnsUnreadableEmblem)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    stub.set_lamda(&FileUtils::isDesktopFileInfo, [](const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes), [](FileInfo *, OptInfoType type) {
+        __DBG_STUB_INVOKE__
+        if (type == OptInfoType::kIsReadable)
+            return false;   // Not readable
+        return false;
+    });
+
+    auto emblems = helper->systemEmblems(mockInfo);
+
+    EXPECT_FALSE(emblems.isEmpty());
+}
+
+TEST_F(UT_EmblemHelper, EmblemRects_ReturnsFourRects)
+{
+    QRectF paintArea(0, 0, 100, 100);
+    auto rects = helper->emblemRects(paintArea);
+
+    EXPECT_EQ(4, rects.size());
+}
+
+TEST_F(UT_EmblemHelper, EmblemRects_CalculatesCorrectPositions)
+{
+    QRectF paintArea(0, 0, 120, 120);
+    auto rects = helper->emblemRects(paintArea);
+
+    // First rect should be at right-down
+    EXPECT_GT(rects[0].x(), paintArea.width() / 2);
+    EXPECT_GT(rects[0].y(), paintArea.height() / 2);
+
+    // Second rect should be at left-down
+    EXPECT_LT(rects[1].x(), paintArea.width() / 2);
+    EXPECT_GT(rects[1].y(), paintArea.height() / 2);
+
+    // Third rect should be at left-up
+    EXPECT_LT(rects[2].x(), paintArea.width() / 2);
+    EXPECT_LT(rects[2].y(), paintArea.height() / 2);
+
+    // Fourth rect should be at right-up
+    EXPECT_GT(rects[3].x(), paintArea.width() / 2);
+    EXPECT_LT(rects[3].y(), paintArea.height() / 2);
+}
+
+TEST_F(UT_EmblemHelper, EmblemRects_BoundsSizeCorrectly)
+{
+    QRectF paintArea(0, 0, 300, 300);
+    auto rects = helper->emblemRects(paintArea);
+
+    for (const auto &rect : rects) {
+        EXPECT_GE(rect.width(), kMinEmblemSize);
+        EXPECT_LE(rect.width(), kMaxEmblemSize);
+        EXPECT_GE(rect.height(), kMinEmblemSize);
+        EXPECT_LE(rect.height(), kMaxEmblemSize);
+    }
+}
+
+TEST_F(UT_EmblemHelper, GioEmblemIcons_ReturnsEmptyForUnknownUrl)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/unknown");
+    auto icons = helper->gioEmblemIcons(url);
+
+    EXPECT_TRUE(icons.isEmpty());
+}
+
+TEST_F(UT_EmblemHelper, GioEmblemIcons_ReturnsStoredIcons)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QList<QIcon> expectedIcons;
+    expectedIcons << QIcon::fromTheme("test-icon");
+
+    helper->productQueue[url] = expectedIcons;
+
+    auto icons = helper->gioEmblemIcons(url);
+
+    EXPECT_EQ(expectedIcons.size(), icons.size());
+}
+
+TEST_F(UT_EmblemHelper, Pending_HandlesNullInfo)
+{
+    EXPECT_NO_THROW(helper->pending(nullptr));
+}
+
+TEST_F(UT_EmblemHelper, Pending_EmitsSignalForValidInfo)
+{
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+    EXPECT_NO_THROW(helper->pending(mockInfo));
+}
+
+TEST_F(UT_EmblemHelper, IsExtEmblemProhibited_ReturnsTrueForRemoteFiles)
+{
+    stub.set_lamda(&ProtocolUtils::isRemoteFile, [](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QUrl url = QUrl("smb://server/share/file");
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+
+    bool result = helper->isExtEmblemProhibited(mockInfo, url);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_EmblemHelper, IsExtEmblemProhibited_ReturnsFalseForLocalDeviceWithEnable)
+{
+    stub.set_lamda(&ProtocolUtils::isRemoteFile, [](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);   // blockExtEnable = true
+    });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+
+    stub.set_lamda(VADDR(FileInfo, extendAttributes), [](FileInfo *, ExtInfoType) {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);   // isLocalDevice = true
+    });
+
+    bool result = helper->isExtEmblemProhibited(mockInfo, url);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemHelper, IsExtEmblemProhibited_ReturnsTrueForNonLocalDeviceWithDisable)
+{
+    stub.set_lamda(&ProtocolUtils::isRemoteFile, [](const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);   // blockExtEnable = false
+    });
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+
+    stub.set_lamda(VADDR(FileInfo, extendAttributes), [](FileInfo *, ExtInfoType) {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);   // isLocalDevice = false
+    });
+
+    bool result = helper->isExtEmblemProhibited(mockInfo, url);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_EmblemHelper, OnEmblemChanged_UpdatesProductQueue)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QList<QIcon> emblems;
+    emblems << QIcon::fromTheme("test-icon");
+
+    stub.set_lamda(&Event::eventType, [](Event *, const QString &, const QString &) {
+        __DBG_STUB_INVOKE__
+        return EventTypeScope::kInValid;
+    });
+
+    helper->onEmblemChanged(url, emblems);
+
+    EXPECT_TRUE(helper->hasEmblem(url));
+    EXPECT_EQ(emblems.size(), helper->productQueue[url].size());
+}
+
+TEST_F(UT_EmblemHelper, OnEmblemChanged_DoesNotPushForEmptyProduct)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QList<QIcon> emptyEmblems;
+
+    helper->onEmblemChanged(url, emptyEmblems);
+
+    // Should update queue but not push events
+    EXPECT_TRUE(helper->hasEmblem(url));
+}
+
+TEST_F(UT_EmblemHelper, OnUrlChanged_ClearsEmblems)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    helper->productQueue[url] = QList<QIcon>();
+
+    helper->onUrlChanged(0, QUrl::fromLocalFile("/tmp/other"));
+
+    EXPECT_FALSE(helper->hasEmblem(url));
+}
+
+TEST_F(UT_EmblemHelper, OnUrlChanged_ReturnsFalse)
+{
+    bool result = helper->onUrlChanged(0, QUrl::fromLocalFile("/tmp/test"));
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemHelper, StandardEmblem_ReturnsLinkEmblem)
+{
+    auto emblem = helper->standardEmblem(SystemEmblemType::kLink);
+    EXPECT_FALSE(emblem.isNull());
+}
+
+TEST_F(UT_EmblemHelper, StandardEmblem_ReturnsLockEmblem)
+{
+    auto emblem = helper->standardEmblem(SystemEmblemType::kLock);
+    EXPECT_FALSE(emblem.isNull());
+}
+
+TEST_F(UT_EmblemHelper, StandardEmblem_ReturnsUnreadableEmblem)
+{
+    auto emblem = helper->standardEmblem(SystemEmblemType::kUnreadable);
+    EXPECT_FALSE(emblem.isNull());
+}
+
+TEST_F(UT_EmblemHelper, StandardEmblem_ReturnsShareEmblem)
+{
+    auto emblem = helper->standardEmblem(SystemEmblemType::kShare);
+    EXPECT_FALSE(emblem.isNull());
+}

--- a/autotests/plugins/dfmplugin-emblem/test_emblemmanager.cpp
+++ b/autotests/plugins/dfmplugin-emblem/test_emblemmanager.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+#include <QPainter>
+#include <QImage>
+
+#define private public
+#define protected public
+#include "utils/emblemmanager.h"
+#include "utils/emblemhelper.h"
+#include "events/emblemeventsequence.h"
+#undef private
+#undef protected
+
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <QApplication>
+
+using namespace dfmplugin_emblem;
+DFMBASE_USE_NAMESPACE;
+DFMGLOBAL_USE_NAMESPACE
+
+class UT_EmblemManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        if (!qApp) {
+            int argc = 1;
+            char *argv[] = { const_cast<char *>("test") };
+            new QApplication(argc, argv);
+        }
+
+        manager = EmblemManager::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+    EmblemManager *manager { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_EmblemManager, Instance_ReturnsSingleton)
+{
+    auto instance1 = EmblemManager::instance();
+    auto instance2 = EmblemManager::instance();
+
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_NE(instance1, nullptr);
+}
+
+TEST_F(UT_EmblemManager, PaintEmblems_ReturnsFalseForInvalidRole)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+    FileInfoPointer info;
+
+    int invalidRole = 999;  // Not kItemIconRole
+    bool result = manager->paintEmblems(invalidRole, info, &painter, &paintArea);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemManager, PaintEmblems_ReturnsFalseForNullInfo)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+    FileInfoPointer info;  // null pointer
+
+    bool result = manager->paintEmblems(kItemIconRole, info, &painter, &paintArea);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemManager, PaintEmblems_SetsRenderHints)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    stub.set_lamda(&EmblemHelper::systemEmblems, [](EmblemHelper *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return QList<QIcon>();
+    });
+
+    stub.set_lamda(&EmblemHelper::isExtEmblemProhibited, [](EmblemHelper *, const FileInfoPointer &, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return true;  // Prohibit to simplify test
+    });
+
+    manager->paintEmblems(kItemIconRole, mockInfo, &painter, &paintArea);
+
+    EXPECT_TRUE(painter.renderHints() & QPainter::SmoothPixmapTransform);
+}
+
+TEST_F(UT_EmblemManager, PaintEmblems_ReturnsFalseWhenNoEmblems)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    stub.set_lamda(&EmblemHelper::systemEmblems, [](EmblemHelper *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return QList<QIcon>();
+    });
+
+    stub.set_lamda(&EmblemHelper::isExtEmblemProhibited, [](EmblemHelper *, const FileInfoPointer &, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    bool result = manager->paintEmblems(kItemIconRole, mockInfo, &painter, &paintArea);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_EmblemManager, PaintEmblems_PaintsSystemEmblems)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    QList<QIcon> systemEmblems;
+    systemEmblems << QIcon::fromTheme("emblem-symbolic-link");
+
+    stub.set_lamda(&EmblemHelper::systemEmblems, [&](EmblemHelper *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return systemEmblems;
+    });
+
+    stub.set_lamda(&EmblemHelper::isExtEmblemProhibited, [](EmblemHelper *, const FileInfoPointer &, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&EmblemHelper::emblemRects, [](EmblemHelper *, const QRectF &) {
+        __DBG_STUB_INVOKE__
+        QList<QRectF> rects;
+        rects << QRectF(10, 10, 20, 20);
+        return rects;
+    });
+
+    bool result = manager->paintEmblems(kItemIconRole, mockInfo, &painter, &paintArea);
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_EmblemManager, PaintEmblems_CallsPendingForGioEmblems)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    bool pendingCalled = false;
+
+    stub.set_lamda(&EmblemHelper::systemEmblems, [](EmblemHelper *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return QList<QIcon>();
+    });
+
+    stub.set_lamda(&EmblemHelper::isExtEmblemProhibited, [](EmblemHelper *, const FileInfoPointer &, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&EmblemHelper::pending, [&](EmblemHelper *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        pendingCalled = true;
+    });
+
+    stub.set_lamda(&EmblemHelper::gioEmblemIcons, [](EmblemHelper *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return QList<QIcon>();
+    });
+
+    stub.set_lamda(&EmblemEventSequence::doFetchCustomEmblems, [](EmblemEventSequence *, const QUrl &, QList<QIcon> *) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&EmblemEventSequence::doFetchExtendEmblems, [](EmblemEventSequence *, const QUrl &, QList<QIcon> *) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    manager->paintEmblems(kItemIconRole, mockInfo, &painter, &paintArea);
+
+    EXPECT_TRUE(pendingCalled);
+}
+
+TEST_F(UT_EmblemManager, PaintEmblems_SkipsNullIcons)
+{
+    QImage image(100, 100, QImage::Format_ARGB32);
+    QPainter painter(&image);
+    QRectF paintArea(0, 0, 100, 100);
+
+    auto mockInfo = QSharedPointer<FileInfo>(new FileInfo(QUrl::fromLocalFile("/tmp/test")));
+
+    QList<QIcon> emblems;
+    emblems << QIcon();  // Null icon
+    emblems << QIcon::fromTheme("emblem-symbolic-link");
+
+    stub.set_lamda(&EmblemHelper::systemEmblems, [&](EmblemHelper *, const FileInfoPointer &) {
+        __DBG_STUB_INVOKE__
+        return emblems;
+    });
+
+    stub.set_lamda(&EmblemHelper::isExtEmblemProhibited, [](EmblemHelper *, const FileInfoPointer &, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&EmblemHelper::emblemRects, [](EmblemHelper *, const QRectF &) {
+        __DBG_STUB_INVOKE__
+        QList<QRectF> rects;
+        rects << QRectF(10, 10, 20, 20) << QRectF(30, 30, 20, 20);
+        return rects;
+    });
+
+    bool result = manager->paintEmblems(kItemIconRole, mockInfo, &painter, &paintArea);
+
+    EXPECT_TRUE(result);
+}


### PR DESCRIPTION
Added complete unit test suite for the dfmplugin-emblem plugin covering
all major components:
1. Emblem class tests for initialization and DConfig management
2. EmblemEventRecevier tests for singleton pattern and paint event
handling
3. EmblemEventSequence tests for hook sequence integration
4. EmblemHelper tests for system emblem logic and emblem positioning
5. GioEmblemWorker tests for GIO emblem parsing and caching
6. EmblemManager tests for emblem painting and role validation

The tests verify proper functionality including:
- Singleton pattern implementations
- DConfig integration and error handling
- File emblem parsing with path expansion and format validation
- System emblem generation for symlinks, read-only files, and unreadable
files
- Emblem positioning calculations for four quadrants
- Integration with event sequences and hook systems
- Proper handling of edge cases and error conditions

Influence:
1. Run all unit tests to verify emblem functionality
2. Test emblem display on files with different attributes
3. Verify GIO emblem parsing from file metadata
4. Check emblem positioning in different icon sizes
5. Test system emblem generation for special file types
6. Validate DConfig settings for emblem visibility

test: 为 emblem 插件添加全面的单元测试

为 dfmplugin-emblem 插件添加了完整的单元测试套件，涵盖所有主要组件：
1. Emblem 类的初始化和 DConfig 管理测试
2. EmblemEventRecevier 的单例模式和绘制事件处理测试
3. EmblemEventSequence 的钩子序列集成测试
4. EmblemHelper 的系统徽标逻辑和徽标定位测试
5. GioEmblemWorker 的 GIO 徽标解析和缓存测试
6. EmblemManager 的徽标绘制和角色验证测试

测试验证了以下功能的正确性：
- 单例模式的实现
- DConfig 集成和错误处理
- 文件徽标解析，包括路径扩展和格式验证
- 符号链接、只读文件和不可读文件的系统徽标生成
- 四个象限的徽标定位计算
- 与事件序列和钩子系统的集成
- 边界情况和错误条件的正确处理

Influence:
1. 运行所有单元测试以验证徽标功能
2. 测试具有不同属性的文件上的徽标显示
3. 验证从文件元数据解析 GIO 徽标
4. 检查不同图标大小下的徽标定位
5. 测试特殊文件类型的系统徽标生成
6. 验证徽标可见性的 DConfig 设置
