### PR TITLE
docs: add SPDX license headers to polkit rules file

### DIFF
--- a/src/services/diskencrypt/polkit/rules/99-dde-file-manager-encrypt.rules
+++ b/src/services/diskencrypt/polkit/rules/99-dde-file-manager-encrypt.rules
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // Polkit rules for DDE File Manager disk encryption
 // This file replaces the deprecated .pkla configuration
 //


### PR DESCRIPTION
Added SPDX license headers to the disk encryption polkit rules file
to comply with open source licensing requirements. The headers include
copyright information for UnionTech Software Technology Co., Ltd.
and specify the GPL-3.0-or-later license. This change ensures proper
licensing documentation for the file that manages disk encryption
permissions for DDE File Manager.

Influence:
1. Verify that the polkit rules file still functions correctly after
header addition
2. Test disk encryption operations to ensure permission rules are
applied properly
3. Check that the file loads without syntax errors in the polkit system
4. Confirm that license headers do not interfere with rule parsing

docs: 为 polkit 规则文件添加 SPDX 许可证头

为磁盘加密 polkit 规则文件添加了 SPDX 许可证头，以符合开源许可证要求。头
部包含 UnionTech Software Technology Co., Ltd. 的版权信息，并指定了 GPL-
3.0-or-later 许可证。此更改确保为管理 DDE 文件管理器磁盘加密权限的文件提
供正确的许可证文档。

Influence:
1. 验证添加头部后 polkit 规则文件是否仍能正常工作
2. 测试磁盘加密操作以确保权限规则正确应用
3. 检查文件在 polkit 系统中加载时无语法错误
4. 确认许可证头不会干扰规则解析

## Summary by Sourcery

Documentation:
- Include SPDX identifier and UnionTech Software Technology Co., Ltd. copyright notice at the top of the 99-dde-file-manager-encrypt.rules file