### PR TITLE
test: expand unit test coverage for search plugin components

### DIFF
--- a/autotests/plugins/dfmplugin-search/test_dfmsearcher.cpp
+++ b/autotests/plugins/dfmplugin-search/test_dfmsearcher.cpp
@@ -6,20 +6,84 @@
 #include <QUrl>
 #include <QSignalSpy>
 #include <QMutex>
+#include <QVariant>
 
 #include "searchmanager/searcher/dfmsearch/dfmsearcher.h"
 #include "searchmanager/searcher/dfmsearch/querystrategies.h"
 #include "searchmanager/searcher/searchresult_define.h"
 
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/application/application.h>
+
+#include <dfm-search/searchfactory.h>
 #include <dfm-search/searchengine.h>
 #include <dfm-search/searchquery.h>
 #include <dfm-search/searchoptions.h>
 #include <dfm-search/contentsearchapi.h>
+#include <dfm-search/dsearch_global.h>
 
 #include "stubext.h"
 
+DFMBASE_USE_NAMESPACE
 DPSEARCH_USE_NAMESPACE
 DFM_SEARCH_USE_NS
+
+// Mock SearchEngine for testing
+class MockSearchEngine : public DFMSEARCH::SearchEngine
+{
+public:
+    explicit MockSearchEngine(DFMSEARCH::SearchType type, QObject *parent = nullptr)
+        : SearchEngine(parent), m_type(type), m_status(DFMSEARCH::SearchStatus::Ready)
+    {
+    }
+
+    DFMSEARCH::SearchType searchType() const { return m_type; }
+    DFMSEARCH::SearchStatus status() const { return m_status; }
+    DFMSEARCH::SearchOptions searchOptions() const { return m_options; }
+
+    void search(const DFMSEARCH::SearchQuery &query)
+    {
+        m_query = query;
+        m_status = DFMSEARCH::SearchStatus::Searching;
+        emit searchStarted();
+    }
+
+    void cancel()
+    {
+        m_status = DFMSEARCH::SearchStatus::Cancelled;
+        emit searchCancelled();
+    }
+
+    void setSearchOptions(const DFMSEARCH::SearchOptions &options)
+    {
+        m_options = options;
+    }
+
+    void setStatus(DFMSEARCH::SearchStatus status) { m_status = status; }
+
+    void emitFinished(const QList<DFMSEARCH::SearchResult> &results = {})
+    {
+        m_status = DFMSEARCH::SearchStatus::Finished;
+        emit searchFinished(results);
+    }
+
+    void emitResultsFound(const QList<DFMSEARCH::SearchResult> &results)
+    {
+        emit resultsFound(results);
+    }
+
+    void emitError(const DFMSEARCH::SearchError &error)
+    {
+        emit errorOccurred(error);
+    }
+
+private:
+    DFMSEARCH::SearchType m_type;
+    DFMSEARCH::SearchStatus m_status;
+    DFMSEARCH::SearchOptions m_options;
+    DFMSEARCH::SearchQuery m_query;
+};
 
 class TestDFMSearcher : public testing::Test
 {
@@ -28,15 +92,74 @@ public:
     {
         searchUrl = QUrl::fromLocalFile("/home/test");
         keyword = "test_keyword";
-        searchType = DFMSEARCH::SearchType::Content;
-        searcher = new DFMSearcher(searchUrl, keyword, nullptr, searchType);
+        searchType = DFMSEARCH::SearchType::FileName;
     }
 
     void TearDown() override
     {
-        delete searcher;
-        searcher = nullptr;
+        if (searcher) {
+            delete searcher;
+            searcher = nullptr;
+        }
         stub.clear();
+    }
+
+    void setupBasicStubs()
+    {
+        // Stub UrlRoute::urlToPath
+        stub.set_lamda(&UrlRoute::urlToPath, [](const QUrl &url) -> QString {
+            __DBG_STUB_INVOKE__
+            return url.toLocalFile();
+        });
+
+        // Stub FileUtils::bindPathTransform
+        stub.set_lamda(static_cast<QString (*)(const QString &, bool)>(&FileUtils::bindPathTransform),
+                       [](const QString &path, bool) -> QString {
+                           __DBG_STUB_INVOKE__
+                           return path;
+                       });
+
+        // Stub Application::genericAttribute
+        stub.set_lamda(&Application::genericAttribute, [] {
+            __DBG_STUB_INVOKE__
+            return QVariant(false);
+        });
+
+        // Stub DFMSEARCH::Global functions
+        stub.set_lamda(DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        stub.set_lamda(&DFMSEARCH::Global::isPathInFileNameIndexDirectory, [](const QString &) -> bool {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        stub.set_lamda(&DFMSEARCH::Global::isHiddenPathOrInHiddenDir, [](const QString &) -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        stub.set_lamda(&DFMSEARCH::Global::defaultIndexedDirectory, []() -> QStringList {
+            __DBG_STUB_INVOKE__
+            return QStringList() << "/home/test/indexed";
+        });
+    }
+
+    DFMSearcher *createSearcherWithMockEngine(DFMSEARCH::SearchType type = DFMSEARCH::SearchType::FileName)
+    {
+        setupBasicStubs();
+
+        MockSearchEngine *mockEngine = new MockSearchEngine(type);
+
+        stub.set_lamda(&DFMSEARCH::SearchFactory::createEngine,
+                       [mockEngine](DFMSEARCH::SearchType, QObject *) -> DFMSEARCH::SearchEngine * {
+                           __DBG_STUB_INVOKE__
+                           return mockEngine;
+                       });
+
+        return new DFMSearcher(searchUrl, keyword, nullptr, type);
     }
 
 protected:
@@ -47,8 +170,11 @@ protected:
     DFMSEARCH::SearchType searchType;
 };
 
+// ========== Constructor Tests ==========
 TEST_F(TestDFMSearcher, Constructor_WithValidParameters_CreatesInstance)
 {
+    searcher = createSearcherWithMockEngine();
+
     EXPECT_NE(searcher, nullptr);
     EXPECT_EQ(searcher->searchUrl, searchUrl);
     EXPECT_EQ(searcher->keyword, keyword);
@@ -57,262 +183,728 @@ TEST_F(TestDFMSearcher, Constructor_WithValidParameters_CreatesInstance)
 TEST_F(TestDFMSearcher, Constructor_WithParent_SetsParentCorrectly)
 {
     QObject parent;
+    setupBasicStubs();
 
-    DFMSearcher searcherWithParent(searchUrl, keyword, &parent, searchType);
+    MockSearchEngine *mockEngine = new MockSearchEngine(DFMSEARCH::SearchType::FileName);
+    stub.set_lamda(&DFMSEARCH::SearchFactory::createEngine,
+                   [mockEngine](DFMSEARCH::SearchType, QObject *) -> DFMSEARCH::SearchEngine * {
+                       __DBG_STUB_INVOKE__
+                       return mockEngine;
+                   });
+
+    DFMSearcher searcherWithParent(searchUrl, keyword, &parent, DFMSEARCH::SearchType::FileName);
 
     EXPECT_EQ(searcherWithParent.parent(), &parent);
 }
 
-TEST_F(TestDFMSearcher, Constructor_WithDifferentSearchTypes_HandlesCorrectly)
+TEST_F(TestDFMSearcher, Constructor_EngineCreationFails_HandlesGracefully)
 {
-    QList<DFMSEARCH::SearchType> searchTypes = {
-        DFMSEARCH::SearchType::Content,
-        DFMSEARCH::SearchType::FileName,
-    };
+    setupBasicStubs();
 
-    for (auto type : searchTypes) {
-        DFMSearcher testSearcher(searchUrl, keyword, nullptr, type);
-        EXPECT_TRUE(true); // Test that construction succeeds
-    }
+    bool engineCreationFailed = false;
+    stub.set_lamda(&DFMSEARCH::SearchFactory::createEngine,
+                   [&engineCreationFailed](DFMSEARCH::SearchType, QObject *) -> DFMSEARCH::SearchEngine * {
+                       __DBG_STUB_INVOKE__
+                       engineCreationFailed = true;
+                       return nullptr;
+                   });
+
+    searcher = new DFMSearcher(searchUrl, keyword, nullptr, DFMSEARCH::SearchType::FileName);
+
+    EXPECT_TRUE(engineCreationFailed);
+    EXPECT_NE(searcher, nullptr);
 }
 
-TEST_F(TestDFMSearcher, SupportUrl_WithValidLocalFile_ReturnsTrue)
+// ========== Static Methods Tests ==========
+TEST_F(TestDFMSearcher, SupportUrl_WithFileScheme_ReturnsTrue)
 {
     QUrl localFileUrl = QUrl::fromLocalFile("/home/user/documents");
 
-    // Mock url support check
-    stub.set_lamda(&DFMSearcher::supportUrl, [](const QUrl &) -> bool {
-        __DBG_STUB_INVOKE__
-        return true;
-    });
-
     bool result = DFMSearcher::supportUrl(localFileUrl);
+
     EXPECT_TRUE(result);
 }
 
-TEST_F(TestDFMSearcher, SupportUrl_WithInvalidUrl_ReturnsFalse)
+TEST_F(TestDFMSearcher, SupportUrl_WithNonFileScheme_ReturnsFalse)
 {
-    QUrl invalidUrl("http://example.com");
+    QUrl httpUrl("http://example.com");
 
-    // Mock url support check
-    stub.set_lamda(&DFMSearcher::supportUrl, [](const QUrl &) -> bool {
-        __DBG_STUB_INVOKE__
-        return false;
-    });
+    bool result = DFMSearcher::supportUrl(httpUrl);
 
-    bool result = DFMSearcher::supportUrl(invalidUrl);
     EXPECT_FALSE(result);
 }
 
-TEST_F(TestDFMSearcher, RealSearchPath_WithValidUrl_ReturnsPath)
+TEST_F(TestDFMSearcher, SupportUrl_WithEmptyUrl_ReturnsFalse)
+{
+    QUrl emptyUrl;
+
+    bool result = DFMSearcher::supportUrl(emptyUrl);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestDFMSearcher, RealSearchPath_WithValidUrl_ReturnsTransformedPath)
 {
     QUrl testUrl = QUrl::fromLocalFile("/home/user/documents");
     QString expectedPath = "/home/user/documents";
 
-    // Mock real search path extraction
-    stub.set_lamda(&DFMSearcher::realSearchPath, [&expectedPath](const QUrl &) -> QString {
+    stub.set_lamda(&UrlRoute::urlToPath, [&expectedPath](const QUrl &) -> QString {
         __DBG_STUB_INVOKE__
         return expectedPath;
     });
 
+    stub.set_lamda(static_cast<QString (*)(const QString &, bool)>(&FileUtils::bindPathTransform),
+                   [&expectedPath](const QString &path, bool) -> QString {
+                       __DBG_STUB_INVOKE__
+                       EXPECT_EQ(path, expectedPath);
+                       return expectedPath;
+                   });
+
     QString result = DFMSearcher::realSearchPath(testUrl);
+
     EXPECT_EQ(result, expectedPath);
 }
 
+// ========== Search Method Tests ==========
 TEST_F(TestDFMSearcher, Search_WithValidConfiguration_ReturnsTrue)
 {
-    // Mock search engine operations
-    stub.set_lamda(&DFMSEARCH::SearchEngine::search, [] {
-        __DBG_STUB_INVOKE__
-    });
+    searcher = createSearcherWithMockEngine();
 
     bool result = searcher->search();
-    EXPECT_TRUE(result || !result); // Either result is valid depending on implementation
+
+    EXPECT_TRUE(result);
 }
 
-TEST_F(TestDFMSearcher, Search_WithEngineNotReady_ReturnsFalse)
+TEST_F(TestDFMSearcher, Search_EmptyKeyword_ReturnsFalse)
 {
-    // Mock engine not ready
-    stub.set_lamda(&DFMSEARCH::SearchEngine::status, []() {
-        __DBG_STUB_INVOKE__
-        return SearchStatus::Ready;
-    });
+    setupBasicStubs();
+
+    MockSearchEngine *mockEngine = new MockSearchEngine(DFMSEARCH::SearchType::FileName);
+    stub.set_lamda(&DFMSEARCH::SearchFactory::createEngine,
+                   [mockEngine](DFMSEARCH::SearchType, QObject *) -> DFMSEARCH::SearchEngine * {
+                       __DBG_STUB_INVOKE__
+                       return mockEngine;
+                   });
+
+    searcher = new DFMSearcher(searchUrl, "", nullptr, DFMSEARCH::SearchType::FileName);
 
     bool result = searcher->search();
-    EXPECT_TRUE(result || !result); // Handle both possibilities
+
+    EXPECT_FALSE(result);
 }
 
-TEST_F(TestDFMSearcher, Stop_CallsEngineStop)
+TEST_F(TestDFMSearcher, Search_WithContentType_UnsupportedPath_EmitsFinishedAndReturnsTrue)
 {
-    // Mock search engine stop
-    stub.set_lamda(&DFMSEARCH::SearchEngine::cancel, []() {
+    setupBasicStubs();
+
+    // Content search but path not in indexed directory
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
         __DBG_STUB_INVOKE__
+        return true;
     });
+
+    stub.set_lamda(&DFMSEARCH::Global::isPathInFileNameIndexDirectory, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::Content);
+
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+
+    bool result = searcher->search();
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(finishedSpy.count(), 1);
+}
+
+TEST_F(TestDFMSearcher, Search_WithContentType_SupportedPath_StartsSearch)
+{
+    setupBasicStubs();
+
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isPathInFileNameIndexDirectory, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::Content);
+
+    bool result = searcher->search();
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestDFMSearcher, Stop_WhenNotSearching_DoesNothing)
+{
+    searcher = createSearcherWithMockEngine();
+
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+    engine->setStatus(DFMSEARCH::SearchStatus::Ready);
+
+    QSignalSpy cancelledSpy(engine, &DFMSEARCH::SearchEngine::searchCancelled);
+
+    searcher->stop();
+
+    EXPECT_EQ(cancelledSpy.count(), 0);
+}
+
+TEST_F(TestDFMSearcher, Stop_WithNullEngine_DoesNotCrash)
+{
+    setupBasicStubs();
+
+    stub.set_lamda(&DFMSEARCH::SearchFactory::createEngine,
+                   [](DFMSEARCH::SearchType, QObject *) -> DFMSEARCH::SearchEngine * {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    searcher = new DFMSearcher(searchUrl, keyword, nullptr, DFMSEARCH::SearchType::FileName);
 
     EXPECT_NO_FATAL_FAILURE(searcher->stop());
 }
 
+// ========== HasItem and TakeAll Tests ==========
 TEST_F(TestDFMSearcher, HasItem_WithNoResults_ReturnsFalse)
 {
+    searcher = createSearcherWithMockEngine();
+
     bool hasItems = searcher->hasItem();
-    EXPECT_TRUE(hasItems || !hasItems); // Either result is valid
+
+    EXPECT_FALSE(hasItems);
 }
 
 TEST_F(TestDFMSearcher, HasItem_WithResults_ReturnsTrue)
 {
-    // This would typically be set by search results
+    searcher = createSearcherWithMockEngine();
+
+    // Manually add results
+    QUrl resultUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult searchResult(resultUrl);
+    searcher->allResults.insert(resultUrl, searchResult);
+
     bool hasItems = searcher->hasItem();
-    EXPECT_TRUE(hasItems || !hasItems);
+
+    EXPECT_TRUE(hasItems);
 }
 
 TEST_F(TestDFMSearcher, TakeAll_WithNoResults_ReturnsEmptyMap)
 {
+    searcher = createSearcherWithMockEngine();
+
     DFMSearchResultMap results = searcher->takeAll();
-    EXPECT_TRUE(true); // Test that method can be called
+
+    EXPECT_TRUE(results.isEmpty());
 }
 
-TEST_F(TestDFMSearcher, TakeAll_WithResults_ReturnsResults)
+TEST_F(TestDFMSearcher, TakeAll_WithResults_ReturnsAndClearsResults)
 {
+    searcher = createSearcherWithMockEngine();
+
+    // Manually add results
+    QUrl resultUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult searchResult(resultUrl);
+    searcher->allResults.insert(resultUrl, searchResult);
+
     DFMSearchResultMap results = searcher->takeAll();
-    EXPECT_TRUE(true);
+
+    EXPECT_EQ(results.size(), 1);
+    EXPECT_TRUE(results.contains(resultUrl));
+    EXPECT_FALSE(searcher->hasItem());
 }
 
-TEST_F(TestDFMSearcher, OnSearchStarted_CallsCorrectly)
+// ========== GetSearchType Tests ==========
+TEST_F(TestDFMSearcher, GetSearchType_WithFileNameType_ReturnsFileName)
 {
-    // Mock signal emission
-    stub.set_lamda(&AbstractSearcher::unearthed, [](AbstractSearcher *, AbstractSearcher *) {
-        __DBG_STUB_INVOKE__
-    });
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
 
-    // Invoke slot manually
-    QMetaObject::invokeMethod(searcher, "onSearchStarted", Qt::DirectConnection);
+    DFMSEARCH::SearchType type = searcher->getSearchType();
 
-    EXPECT_TRUE(true);
+    EXPECT_EQ(type, DFMSEARCH::SearchType::FileName);
 }
 
-TEST_F(TestDFMSearcher, OnSearchFinished_WithResults_ProcessesResults)
+TEST_F(TestDFMSearcher, GetSearchType_WithNullEngine_ReturnsFileName)
 {
-    QList<DFMSEARCH::SearchResult> mockResults;
+    setupBasicStubs();
 
-    // Invoke slot manually
-    QMetaObject::invokeMethod(searcher, "onSearchFinished", Qt::DirectConnection,
-                              Q_ARG(QList<DFMSEARCH::SearchResult>, mockResults));
+    stub.set_lamda(&DFMSEARCH::SearchFactory::createEngine,
+                   [](DFMSEARCH::SearchType, QObject *) -> DFMSEARCH::SearchEngine * {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
 
-    EXPECT_TRUE(true);
+    searcher = new DFMSearcher(searchUrl, keyword, nullptr, DFMSEARCH::SearchType::Content);
+
+    DFMSEARCH::SearchType type = searcher->getSearchType();
+
+    EXPECT_EQ(type, DFMSEARCH::SearchType::FileName);
 }
 
-TEST_F(TestDFMSearcher, OnSearchCancelled_CallsCorrectly)
+// ========== ProcessSearchResult Tests ==========
+TEST_F(TestDFMSearcher, ProcessSearchResult_WithFileNameSearch_CreatesFileNameResult)
 {
-    // Invoke slot manually
-    QMetaObject::invokeMethod(searcher, "onSearchCancelled", Qt::DirectConnection);
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
 
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, OnSearchError_HandlesError)
-{
-    DFMSEARCH::SearchError mockError;
-
-    // Invoke slot manually
-    QMetaObject::invokeMethod(searcher, "onSearchError", Qt::DirectConnection,
-                              Q_ARG(DFMSEARCH::SearchError, mockError));
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, CreateSearchQuery_ReturnsValidQuery)
-{
-    // Call private method via metaObject
-    DFMSEARCH::SearchQuery query;
-    QMetaObject::invokeMethod(searcher, "createSearchQuery", Qt::DirectConnection,
-                              Q_RETURN_ARG(DFMSEARCH::SearchQuery, query));
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, ProcessSearchResult_WithValidResult_ProcessesCorrectly)
-{
+    // Create a mock search result
     DFMSEARCH::SearchResult mockResult;
-
-    // Call private method via metaObject
-    QMetaObject::invokeMethod(searcher, "processSearchResult", Qt::DirectConnection,
-                              Q_ARG(DFMSEARCH::SearchResult, mockResult));
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, GetSearchType_ReturnsCorrectType)
-{
-    // Call private method via metaObject
-    DFMSEARCH::SearchType type;
-    QMetaObject::invokeMethod(searcher, "getSearchType", Qt::DirectConnection,
-                              Q_RETURN_ARG(DFMSEARCH::SearchType, type));
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, GetSearchMethod_WithValidPath_ReturnsMethod)
-{
-    QString testPath = "/home/test";
-
-    // Call private method via metaObject
-    DFMSEARCH::SearchMethod method;
-    QMetaObject::invokeMethod(searcher, "getSearchMethod", Qt::DirectConnection,
-                              Q_RETURN_ARG(DFMSEARCH::SearchMethod, method),
-                              Q_ARG(QString, testPath));
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, HandleRemainingResults_WithResults_HandlesCorrectly)
-{
-    QList<DFMSEARCH::SearchResult> mockResults;
-
-    // Call private method via metaObject
-    QMetaObject::invokeMethod(searcher, "handleRemainingResults", Qt::DirectConnection,
-                              Q_ARG(QList<DFMSEARCH::SearchResult>, mockResults));
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, IsValidSearchParameters_ValidatesParameters)
-{
-    // Call private method via metaObject
-    bool isValid = false;
-    QMetaObject::invokeMethod(searcher, "isValidSearchParameters", Qt::DirectConnection,
-                              Q_RETURN_ARG(bool, isValid));
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestDFMSearcher, CompleteWorkflow_SearchTakeAllStop)
-{
-    // Mock all operations for complete workflow
-    stub.set_lamda(&SearchEngine::search, [] {
+    stub.set_lamda(&DFMSEARCH::SearchResult::path, [&mockResult]() -> QString {
         __DBG_STUB_INVOKE__
+        return "/home/test/file1.txt";
     });
 
-    stub.set_lamda(&DFMSEARCH::SearchEngine::cancel, []() {
-        __DBG_STUB_INVOKE__
-    });
+    searcher->processSearchResult(mockResult);
 
-    // Execute complete workflow
-    bool searchResult = searcher->search();
-    bool hasItems = searcher->hasItem();
+    EXPECT_TRUE(searcher->hasItem());
     DFMSearchResultMap results = searcher->takeAll();
-    searcher->stop();
+    EXPECT_EQ(results.size(), 1);
 
-    EXPECT_TRUE(true);
+    QUrl expectedUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    EXPECT_TRUE(results.contains(expectedUrl));
+    EXPECT_FALSE(results[expectedUrl].isContentMatch());
 }
 
-TEST_F(TestDFMSearcher, ThreadSafety_WithMutexProtection)
+TEST_F(TestDFMSearcher, ProcessSearchResult_WithContentSearch_CreatesContentResult)
 {
-    // Test thread safety with mutex protection
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::Content);
+
+    // Create a mock search result
+    DFMSEARCH::SearchResult mockResult;
+    stub.set_lamda(&DFMSEARCH::SearchResult::path, [&mockResult]() -> QString {
+        __DBG_STUB_INVOKE__
+        return "/home/test/file1.txt";
+    });
+
+    QString expectedContent = "highlighted content";
+    stub.set_lamda(&DFMSEARCH::ContentResultAPI::highlightedContent,
+                   [&expectedContent](DFMSEARCH::ContentResultAPI *) -> QString {
+                       __DBG_STUB_INVOKE__
+                       return expectedContent;
+                   });
+
+    searcher->processSearchResult(mockResult);
+
+    EXPECT_TRUE(searcher->hasItem());
+    DFMSearchResultMap results = searcher->takeAll();
+    EXPECT_EQ(results.size(), 1);
+
+    QUrl expectedUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    EXPECT_TRUE(results.contains(expectedUrl));
+}
+
+// ========== Signal Tests ==========
+TEST_F(TestDFMSearcher, OnSearchStarted_EmitsNoSignals)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+    QSignalSpy unearthedSpy(searcher, &DFMSearcher::unearthed);
+
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+
+    emit engine->searchStarted();
+
+    EXPECT_EQ(finishedSpy.count(), 0);
+    EXPECT_EQ(unearthedSpy.count(), 0);
+}
+
+TEST_F(TestDFMSearcher, OnSearchFinished_WithResults_ProcessesAndEmitsFinished)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+
+    // Create mock results
+    QList<DFMSEARCH::SearchResult> mockResults;
+    DFMSEARCH::SearchResult result1;
+    stub.set_lamda(&DFMSEARCH::SearchResult::path, [&result1]() -> QString {
+        __DBG_STUB_INVOKE__
+        return "/home/test/file1.txt";
+    });
+    mockResults.append(result1);
+
+    // Set resultFoundEnabled to false so results are processed in onSearchFinished
+    DFMSEARCH::SearchOptions options;
+    options.setResultFoundEnabled(false);
+    engine->setSearchOptions(options);
+
+    engine->emitFinished(mockResults);
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+}
+
+TEST_F(TestDFMSearcher, OnSearchFinished_WithRealtimeResults_OnlyEmitsFinished)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+
+    // Set resultFoundEnabled to true (realtime)
+    DFMSEARCH::SearchOptions options;
+    options.setResultFoundEnabled(true);
+    engine->setSearchOptions(options);
+
+    QList<DFMSEARCH::SearchResult> emptyResults;
+    engine->emitFinished(emptyResults);
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+}
+
+TEST_F(TestDFMSearcher, OnSearchCancelled_EmitsFinished)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+
+    engine->cancel();
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+}
+
+TEST_F(TestDFMSearcher, OnSearchError_EmitsFinished)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+
+    DFMSEARCH::SearchError error;
+    engine->emitError(error);
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+}
+
+TEST_F(TestDFMSearcher, ResultsFound_ProcessesResultsAndEmitsUnearthed)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy unearthedSpy(searcher, &DFMSearcher::unearthed);
+
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+
+    // Create mock results
+    QList<DFMSEARCH::SearchResult> mockResults;
+    DFMSEARCH::SearchResult result1;
+    stub.set_lamda(&DFMSEARCH::SearchResult::path, [&result1]() -> QString {
+        __DBG_STUB_INVOKE__
+        return "/home/test/file1.txt";
+    });
+    mockResults.append(result1);
+
+    engine->emitResultsFound(mockResults);
+
+    EXPECT_EQ(unearthedSpy.count(), 1);
+    EXPECT_TRUE(searcher->hasItem());
+}
+
+// ========== GetSearchMethod Tests ==========
+TEST_F(TestDFMSearcher, GetSearchMethod_ContentSearch_ReturnsIndexed)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::Content);
+
+    DFMSEARCH::SearchMethod method = searcher->getSearchMethod("/home/test");
+
+    EXPECT_EQ(method, DFMSEARCH::SearchMethod::Indexed);
+}
+
+TEST_F(TestDFMSearcher, GetSearchMethod_FileNameSearch_IndexReady_PathInIndex_ReturnsIndexed)
+{
+    setupBasicStubs();
+
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isPathInFileNameIndexDirectory, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isHiddenPathOrInHiddenDir, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
+
+    DFMSEARCH::SearchMethod method = searcher->getSearchMethod("/home/test");
+
+    EXPECT_EQ(method, DFMSEARCH::SearchMethod::Indexed);
+}
+
+TEST_F(TestDFMSearcher, GetSearchMethod_FileNameSearch_IndexNotReady_ReturnsRealtime)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
+    stub.set_lamda(DFMSEARCH::Global::isFileNameIndexReadyForSearch, [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    DFMSEARCH::SearchMethod method = searcher->getSearchMethod("/home/test");
+
+    EXPECT_EQ(method, DFMSEARCH::SearchMethod::Realtime);
+}
+
+TEST_F(TestDFMSearcher, GetSearchMethod_FileNameSearch_PathNotInIndex_ReturnsRealtime)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+        __DBG_STUB_INVOKE__
+                return true;
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isPathInFileNameIndexDirectory, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+                return false;
+    });
+
+    DFMSEARCH::SearchMethod method = searcher->getSearchMethod("/home/test");
+
+    EXPECT_EQ(method, DFMSEARCH::SearchMethod::Realtime);
+}
+
+TEST_F(TestDFMSearcher, GetSearchMethod_FileNameSearch_InHiddenDir_ReturnsRealtime)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+        __DBG_STUB_INVOKE__
+                return true;
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isHiddenPathOrInHiddenDir, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+                return true;
+    });
+
+    DFMSEARCH::SearchMethod method = searcher->getSearchMethod("/home/test/.hidden");
+
+    EXPECT_EQ(method, DFMSEARCH::SearchMethod::Realtime);
+}
+
+// ========== ConfigureSearchOptions Tests ==========
+TEST_F(TestDFMSearcher, ConfigureSearchOptions_SetsBasicOptions)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine();
+
+    DFMSEARCH::SearchOptions options = searcher->configureSearchOptions("/home/test");
+
+    EXPECT_EQ(options.searchPath(), "/home/test");
+    EXPECT_FALSE(options.caseSensitive());
+}
+
+TEST_F(TestDFMSearcher, ConfigureSearchOptions_HiddenFilesEnabled_IncludesHidden)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine();
+    stub.set_lamda(&Application::genericAttribute, [](Application::GenericAttribute attr) -> QVariant {
+        __DBG_STUB_INVOKE__
+                if (attr == Application::kShowedHiddenFiles)
+                return QVariant(true);
+        return QVariant(false);
+    });
+
+    DFMSEARCH::SearchOptions options = searcher->configureSearchOptions("/home/test");
+
+    EXPECT_TRUE(options.includeHidden());
+}
+
+TEST_F(TestDFMSearcher, ConfigureSearchOptions_InHiddenDirectory_AlwaysIncludesHidden)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine();
+    stub.set_lamda(&Application::genericAttribute, [] {
+        __DBG_STUB_INVOKE__
+                return QVariant(false);   // Hidden files disabled
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isHiddenPathOrInHiddenDir, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+                return true;   // But in hidden directory
+    });
+
+    DFMSEARCH::SearchOptions options = searcher->configureSearchOptions("/home/test/.hidden");
+
+    EXPECT_TRUE(options.includeHidden());
+}
+
+TEST_F(TestDFMSearcher, ConfigureSearchOptions_RealtimeMethod_EnablesResultFound)
+{
+    setupBasicStubs();
+
+    searcher = createSearcherWithMockEngine();
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+        __DBG_STUB_INVOKE__
+                return false;   // Force realtime method
+    });
+
+    DFMSEARCH::SearchOptions options = searcher->configureSearchOptions("/home/test");
+
+    EXPECT_EQ(options.method(), DFMSEARCH::SearchMethod::Realtime);
+    EXPECT_TRUE(options.resultFoundEnabled());
+}
+
+// ========== ShouldExcludeIndexedPaths Tests ==========
+TEST_F(TestDFMSearcher, ShouldExcludeIndexedPaths_InHiddenDir_ReturnsFalse)
+{
+    setupBasicStubs();
+    searcher = createSearcherWithMockEngine();
+    stub.set_lamda(&DFMSEARCH::Global::isHiddenPathOrInHiddenDir, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+                return true;
+    });
+
+    bool result = searcher->shouldExcludeIndexedPaths("/home/test/.hidden");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestDFMSearcher, ShouldExcludeIndexedPaths_FileNameSearch_IndexNotReady_ReturnsFalse)
+{
+    setupBasicStubs();
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+        __DBG_STUB_INVOKE__
+                return false;
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isHiddenPathOrInHiddenDir, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+                return false;
+    });
+
+    bool result = searcher->shouldExcludeIndexedPaths("/home/test");
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(TestDFMSearcher, ShouldExcludeIndexedPaths_NormalCase_ReturnsTrue)
+{
+    setupBasicStubs();
+    searcher = createSearcherWithMockEngine(DFMSEARCH::SearchType::FileName);
+    stub.set_lamda(&DFMSEARCH::Global::isFileNameIndexReadyForSearch, []() -> bool {
+        __DBG_STUB_INVOKE__
+                return true;
+    });
+
+    stub.set_lamda(&DFMSEARCH::Global::isHiddenPathOrInHiddenDir, [](const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+                return false;
+    });
+
+    bool result = searcher->shouldExcludeIndexedPaths("/home/test");
+
+    EXPECT_TRUE(result);
+}
+
+// ========== Thread Safety Tests ==========
+TEST_F(TestDFMSearcher, ThreadSafety_ConcurrentHasItemAndTakeAll_NoDataRace)
+{
+    searcher = createSearcherWithMockEngine();
+
+    // Add some results
+    QUrl resultUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult searchResult(resultUrl);
+    searcher->allResults.insert(resultUrl, searchResult);
+
     // Simulate concurrent access
     bool hasItems1 = searcher->hasItem();
     DFMSearchResultMap results1 = searcher->takeAll();
     bool hasItems2 = searcher->hasItem();
     DFMSearchResultMap results2 = searcher->takeAll();
 
-    EXPECT_TRUE(true);
+    EXPECT_TRUE(hasItems1);
+    EXPECT_FALSE(results1.isEmpty());
+    EXPECT_FALSE(hasItems2);
+    EXPECT_TRUE(results2.isEmpty());
+}
+
+// ========== Integration Tests ==========
+TEST_F(TestDFMSearcher, CompleteWorkflow_Search_ReceiveResults_TakeAll)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy unearthedSpy(searcher, &DFMSearcher::unearthed);
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+
+    // Start search
+    bool searchResult = searcher->search();
+    EXPECT_TRUE(searchResult);
+
+    // Simulate results being found
+    MockSearchEngine *engine = dynamic_cast<MockSearchEngine *>(searcher->engine);
+    ASSERT_NE(engine, nullptr);
+
+    QList<DFMSEARCH::SearchResult> mockResults;
+    DFMSEARCH::SearchResult result1;
+    stub.set_lamda(&DFMSEARCH::SearchResult::path, [&result1]() -> QString {
+        __DBG_STUB_INVOKE__
+        return "/home/test/file1.txt";
+    });
+    mockResults.append(result1);
+
+    engine->emitResultsFound(mockResults);
+
+    EXPECT_EQ(unearthedSpy.count(), 1);
+    EXPECT_TRUE(searcher->hasItem());
+
+    // Take all results
+    DFMSearchResultMap results = searcher->takeAll();
+    EXPECT_EQ(results.size(), 1);
+    EXPECT_FALSE(searcher->hasItem());
+}
+
+TEST_F(TestDFMSearcher, CompleteWorkflow_Search_Cancel)
+{
+    searcher = createSearcherWithMockEngine();
+
+    QSignalSpy finishedSpy(searcher, &DFMSearcher::finished);
+
+    // Start search
+    bool searchResult = searcher->search();
+    EXPECT_TRUE(searchResult);
+
+    // Cancel search
+    searcher->stop();
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+}
+
+TEST_F(TestDFMSearcher, CreateSearchQuery_CallsQuerySelector)
+{
+    searcher = createSearcherWithMockEngine();
+
+    DFMSEARCH::SearchQuery query = searcher->createSearchQuery();
+
+    // Query should be created by querySelector
+    EXPECT_TRUE(true);   // Basic validation that method completes
 }

--- a/autotests/plugins/dfmplugin-search/test_iteratorsearcher.cpp
+++ b/autotests/plugins/dfmplugin-search/test_iteratorsearcher.cpp
@@ -9,11 +9,16 @@
 #include <QRegularExpression>
 #include <QSharedPointer>
 #include <QTimer>
+#include <QApplication>
+#include <QThread>
 
 #include "searchmanager/searcher/iterator/iteratorsearcher.h"
 #include "searchmanager/searcher/searchresult_define.h"
+#include "utils/searchhelper.h"
+#include "iterator/searchdiriterator.h"
 
 #include <dfm-base/interfaces/abstractdiriterator.h>
+#include <dfm-base/interfaces/abstractfileinfo.h>
 #include <dfm-base/base/schemefactory.h>
 
 #include "stubext.h"
@@ -21,11 +26,127 @@
 DPSEARCH_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 
+// Mock FileInfo for testing
+class MockFileInfo : public FileInfo
+{
+public:
+    explicit MockFileInfo(const QUrl &url, bool isDir = false, bool isSymlink = false,
+                          const QString &displayName = QString(), bool fileExists = true)
+        : FileInfo(url), m_isDir(isDir), m_isSymlink(isSymlink), m_displayName(displayName), m_exists(fileExists)
+    {
+        if (m_displayName.isEmpty())
+            m_displayName = url.fileName();
+    }
+
+    bool exists() const override { return m_exists; }
+
+    bool isAttributes(const OptInfoType type) const override
+    {
+        if (type == OptInfoType::kIsDir)
+            return m_isDir;
+        if (type == OptInfoType::kIsSymLink)
+            return m_isSymlink;
+        return FileInfo::isAttributes(type);
+    }
+
+    QString displayOf(const DisPlayInfoType type) const override
+    {
+        if (type == DisPlayInfoType::kFileDisplayName)
+            return m_displayName;
+        return FileInfo::displayOf(type);
+    }
+
+    QUrl urlOf(const UrlInfoType type) const override
+    {
+        if (type == UrlInfoType::kUrl)
+            return url;
+        return FileInfo::urlOf(type);
+    }
+
+private:
+    bool m_isDir;
+    bool m_isSymlink;
+    QString m_displayName;
+    bool m_exists;
+};
+
+// Mock AbstractDirIterator for testing
+class MockDirIterator : public AbstractDirIterator
+{
+public:
+    explicit MockDirIterator(const QUrl &url,
+                             const QStringList &nameFilters = QStringList(),
+                             QDir::Filters filters = QDir::NoFilter,
+                             QDirIterator::IteratorFlags flags = QDirIterator::NoIteratorFlags)
+        : AbstractDirIterator(url, nameFilters, filters, flags), m_url(url), m_currentIndex(0)
+    {
+        // Add some mock files with fileInfo
+        addMockEntry(QUrl::fromLocalFile("/home/test/file1.txt"), false, false, "file1.txt");
+        addMockEntry(QUrl::fromLocalFile("/home/test/file2.doc"), false, false, "file2.doc");
+        addMockEntry(QUrl::fromLocalFile("/home/test/subdir"), true, false, "subdir");
+    }
+
+    void addMockEntry(const QUrl &url, bool isDir, bool isSymlink, const QString &displayName)
+    {
+        m_mockUrls << url;
+        m_mockInfos << FileInfoPointer(new MockFileInfo(url, isDir, isSymlink, displayName, true));
+    }
+
+    QUrl next() override
+    {
+        if (m_currentIndex < m_mockUrls.size()) {
+            return m_mockUrls[m_currentIndex++];
+        }
+        return QUrl();
+    }
+
+    bool hasNext() const override
+    {
+        return m_currentIndex < m_mockUrls.size();
+    }
+
+    QString fileName() const override
+    {
+        if (m_currentIndex > 0 && m_currentIndex <= m_mockUrls.size()) {
+            return m_mockUrls[m_currentIndex - 1].fileName();
+        }
+        return QString();
+    }
+
+    QUrl fileUrl() const override
+    {
+        if (m_currentIndex > 0 && m_currentIndex <= m_mockUrls.size()) {
+            return m_mockUrls[m_currentIndex - 1];
+        }
+        return QUrl();
+    }
+
+    const FileInfoPointer fileInfo() const override
+    {
+        if (m_currentIndex > 0 && m_currentIndex <= m_mockInfos.size()) {
+            return m_mockInfos[m_currentIndex - 1];
+        }
+        return nullptr;
+    }
+
+    QUrl url() const override
+    {
+        return m_url;
+    }
+
+    // Public members for testing access
+    QUrl m_url;
+    QList<QUrl> m_mockUrls;
+    QList<FileInfoPointer> m_mockInfos;
+    mutable int m_currentIndex;
+};
+
 class TestIteratorSearcherBridge : public testing::Test
 {
 public:
     void SetUp() override
     {
+        DirIteratorFactory::regClass<SearchDirIterator>(SearchHelper::scheme());
         bridge = new IteratorSearcherBridge();
     }
 
@@ -46,16 +167,62 @@ class TestIteratorSearcher : public testing::Test
 public:
     void SetUp() override
     {
+        DirIteratorFactory::regClass<SearchDirIterator>(SearchHelper::scheme());
         searchUrl = QUrl::fromLocalFile("/home/test");
-        keyword = "test_keyword";
-        searcher = new IteratorSearcher(searchUrl, keyword);
+        keyword = "test";
     }
 
     void TearDown() override
     {
-        delete searcher;
-        searcher = nullptr;
+        if (searcher) {
+            delete searcher;
+            searcher = nullptr;
+        }
         stub.clear();
+    }
+
+    void setupBasicStubs()
+    {
+        stub.set_lamda(&SearchHelper::checkWildcardAndToRegularExpression,
+                       [](SearchHelper *, const QString &keyword) -> QString {
+                           __DBG_STUB_INVOKE__
+                           return keyword;   // Return as-is for simplicity
+                       });
+
+        // Stub QTimer operations
+        stub.set_lamda(static_cast<void (QTimer::*)(int)>(&QTimer::start), [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&QTimer::stop, [](QTimer *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&QTimer::isActive, [](const QTimer *) -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        // Stub QApplication thread
+        stub.set_lamda(&QApplication::thread, [] {
+            __DBG_STUB_INVOKE__
+            return QThread::currentThread();
+        });
+
+        stub.set_lamda(&QObject::thread, [](const QObject *) -> QThread * {
+            __DBG_STUB_INVOKE__
+            return QThread::currentThread();
+        });
+
+        // Stub QMetaObject::invokeMethodImpl - correct signature for Qt 6
+        stub.set_lamda(static_cast<bool (*)(QObject *, QtPrivate::QSlotObjectBase *,
+                                            Qt::ConnectionType, qsizetype,
+                                            const void *const *, const char *const *,
+                                            const QtPrivate::QMetaTypeInterface *const *)>(&QMetaObject::invokeMethodImpl),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
     }
 
 protected:
@@ -65,7 +232,7 @@ protected:
     QString keyword;
 };
 
-// IteratorSearcherBridge Tests
+// ========== IteratorSearcherBridge Tests ==========
 TEST_F(TestIteratorSearcherBridge, Constructor_CreatesValidInstance)
 {
     EXPECT_NE(bridge, nullptr);
@@ -79,143 +246,862 @@ TEST_F(TestIteratorSearcherBridge, Constructor_WithParent_SetsParentCorrectly)
     EXPECT_EQ(bridgeWithParent.parent(), &parent);
 }
 
-TEST_F(TestIteratorSearcherBridge, SetSearcher_WithValidSearcher_SetsCorrectly)
+TEST_F(TestIteratorSearcherBridge, SetSearcher_WithValidSearcher_ConnectsSignals)
 {
     IteratorSearcher testSearcher(QUrl::fromLocalFile("/home/test"), "test");
 
-    bridge->setSearcher(&testSearcher);
-
-    EXPECT_TRUE(true);   // Test that method can be called without crash
+    EXPECT_NO_FATAL_FAILURE(bridge->setSearcher(&testSearcher));
 }
 
 TEST_F(TestIteratorSearcherBridge, SetSearcher_WithNullSearcher_HandlesCorrectly)
 {
-    bridge->setSearcher(nullptr);
-
-    EXPECT_TRUE(true);
+    EXPECT_NO_FATAL_FAILURE(bridge->setSearcher(nullptr));
 }
 
-TEST_F(TestIteratorSearcherBridge, CreateIterator_WithValidUrl_CallsCorrectly)
+TEST_F(TestIteratorSearcherBridge, CreateIterator_WithValidUrl_EmitsSignal)
 {
-    QUrl testUrl = QUrl::fromLocalFile("/home/test");
-
+    QUrl testUrl = QUrl("search:///home/test");
     EXPECT_NO_FATAL_FAILURE(bridge->createIterator(testUrl));
 }
 
-TEST_F(TestIteratorSearcherBridge, CreateIterator_WithInvalidUrl_HandlesCorrectly)
+TEST_F(TestIteratorSearcherBridge, CreateIterator_WithInvalidUrl_EmitsNullIterator)
 {
     QUrl invalidUrl;
-
     EXPECT_NO_FATAL_FAILURE(bridge->createIterator(invalidUrl));
 }
 
-TEST_F(TestIteratorSearcherBridge, IteratorCreatedSignal_CanBeEmitted)
-{
-    QSignalSpy spy(bridge, &IteratorSearcherBridge::iteratorCreated);
-
-    QSharedPointer<AbstractDirIterator> mockIterator;
-
-    // Emit signal manually for testing
-    emit bridge->iteratorCreated(mockIterator);
-
-    EXPECT_EQ(spy.count(), 1);
-}
-
-// IteratorSearcher Tests
+// ========== IteratorSearcher Constructor Tests ==========
 TEST_F(TestIteratorSearcher, Constructor_WithValidParameters_CreatesInstance)
 {
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
     EXPECT_NE(searcher, nullptr);
     EXPECT_EQ(searcher->searchUrl, searchUrl);
-    EXPECT_NE(searcher->keyword, keyword);
 }
 
+TEST_F(TestIteratorSearcher, Constructor_WithWildcardKeyword_ProcessesCorrectly)
+{
+    setupBasicStubs();
+
+    QString wildcardKeyword = "*.txt";
+
+    searcher = new IteratorSearcher(searchUrl, wildcardKeyword);
+
+    EXPECT_NE(searcher, nullptr);
+}
+
+TEST_F(TestIteratorSearcher, Constructor_InitializesBatchTimer)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    EXPECT_NE(searcher->batchTimer, nullptr);
+}
+
+TEST_F(TestIteratorSearcher, Constructor_SetsDefaultBatchLimits)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    EXPECT_EQ(searcher->batchResultLimit, 200);
+    EXPECT_EQ(searcher->batchTimeLimit, 500);
+}
+
+TEST_F(TestIteratorSearcher, Constructor_CreatesRegexPattern)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    EXPECT_TRUE(searcher->regex.isValid());
+}
+
+// ========== Static Methods Tests ==========
 TEST_F(TestIteratorSearcher, IsSupportSearch_WithAnyUrl_ReturnsTrue)
 {
-    QList<QUrl> testUrls = {
-        QUrl::fromLocalFile("/home/test"),
-        QUrl("file:///home/test"),
-        QUrl("ftp://example.com/test"),
-        QUrl()   // Empty URL
-    };
+    QUrl testUrl = QUrl::fromLocalFile("/home/test");
 
-    for (const QUrl &url : testUrls) {
-        bool result = IteratorSearcher::isSupportSearch(url);
-        EXPECT_TRUE(result);
-    }
+    EXPECT_TRUE(IteratorSearcher::isSupportSearch(testUrl));
 }
 
-// TEST_F(TestIteratorSearcher, Search_WithValidConfiguration_ReturnsTrue)
-// {
-//     // Mock timer operations
-//     stub.set_lamda(static_cast<void (QTimer::*)(int)>(&QTimer::start), []() {
-//         __DBG_STUB_INVOKE__
-//     });
-
-//     bool result = searcher->search();
-//     EXPECT_TRUE(result || !result);   // Either result is valid depending on implementation
-// }
-
-TEST_F(TestIteratorSearcher, Stop_StopsRunningSearch)
+// ========== Search Method Tests ==========
+TEST_F(TestIteratorSearcher, Search_FromReadyState_ReturnsTrue)
 {
-    // Mock timer operations
-    stub.set_lamda(&QTimer::stop, [](QTimer *) {
-        __DBG_STUB_INVOKE__
-    });
+    setupBasicStubs();
+    searcher = new IteratorSearcher(searchUrl, keyword);
 
-    stub.set_lamda(&QTimer::deleteLater, [](QObject *) {
-        __DBG_STUB_INVOKE__
-    });
+    bool result = searcher->search();
 
-    EXPECT_NO_FATAL_FAILURE(searcher->stop());
+    EXPECT_TRUE(result);
 }
 
-TEST_F(TestIteratorSearcher, Stop_WhenNotRunning_HandlesCorrectly)
+TEST_F(TestIteratorSearcher, Search_FromNonReadyState_ReturnsFalse)
 {
-    // Stop without starting
-    EXPECT_NO_FATAL_FAILURE(searcher->stop());
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    // Set status to non-ready
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    bool result = searcher->search();
+
+    EXPECT_FALSE(result);
 }
 
+TEST_F(TestIteratorSearcher, Search_EnqueuesSearchUrl)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    searcher->search();
+
+    EXPECT_FALSE(searcher->pendingDirs.isEmpty());
+}
+
+TEST_F(TestIteratorSearcher, Search_MultipleCallsWithoutStop_ReturnsFalse)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    bool firstCall = searcher->search();
+    EXPECT_TRUE(firstCall);
+
+    // Second call should fail because status is already kRuning
+    bool secondCall = searcher->search();
+    EXPECT_FALSE(secondCall);
+}
+
+// ========== Stop Method Tests ==========
+TEST_F(TestIteratorSearcher, Stop_FromRunningState_ClearsQueue)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    searcher->stop();
+    EXPECT_EQ(searcher->status.loadAcquire(), AbstractSearcher::kTerminated);
+}
+
+TEST_F(TestIteratorSearcher, Stop_FromReadyState_DoesNotEmitSignals)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    QSignalSpy finishedSpy(searcher, &IteratorSearcher::finished);
+
+    searcher->stop();
+
+    EXPECT_EQ(finishedSpy.count(), 0);
+}
+
+TEST_F(TestIteratorSearcher, Stop_WithResults_EmitsUnearthed)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Add results
+    QUrl resultUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult result;
+    result.setUrl(resultUrl);
+    searcher->resultMap.insert(resultUrl, result);
+
+    QSignalSpy unearthedSpy(searcher, &IteratorSearcher::unearthed);
+
+    searcher->stop();
+
+    EXPECT_EQ(unearthedSpy.count(), 1);
+}
+
+TEST_F(TestIteratorSearcher, Stop_MultipleCalls_OnlyFirstCallEmitsSignals)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    QSignalSpy finishedSpy(searcher, &IteratorSearcher::finished);
+
+    searcher->stop();
+    EXPECT_EQ(finishedSpy.count(), 1);
+
+    // Second stop call should not emit signals
+    searcher->stop();
+    EXPECT_EQ(finishedSpy.count(), 1);
+}
+
+// ========== HasItem and TakeAll Tests ==========
 TEST_F(TestIteratorSearcher, HasItem_WithNoResults_ReturnsFalse)
 {
-    bool hasItems = searcher->hasItem();
-    EXPECT_TRUE(hasItems || !hasItems);   // Either result is valid
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    EXPECT_FALSE(searcher->hasItem());
 }
 
 TEST_F(TestIteratorSearcher, HasItem_WithResults_ReturnsTrue)
 {
-    bool hasItems = searcher->hasItem();
-    EXPECT_TRUE(hasItems || !hasItems);
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    // Add result
+    QUrl resultUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult result;
+    result.setUrl(resultUrl);
+    searcher->resultMap.insert(resultUrl, result);
+
+    EXPECT_TRUE(searcher->hasItem());
 }
 
 TEST_F(TestIteratorSearcher, TakeAll_WithNoResults_ReturnsEmptyMap)
 {
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
     DFMSearchResultMap results = searcher->takeAll();
-    EXPECT_TRUE(true);   // Test that method can be called
+
+    EXPECT_TRUE(results.isEmpty());
 }
 
-TEST_F(TestIteratorSearcher, TakeAll_WithResults_ReturnsResults)
+TEST_F(TestIteratorSearcher, TakeAll_WithResults_ReturnsAndClearsResults)
 {
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    // Add results
+    QUrl url1 = QUrl::fromLocalFile("/home/test/file1.txt");
+    QUrl url2 = QUrl::fromLocalFile("/home/test/file2.txt");
+    DFMSearchResult result1, result2;
+    result1.setUrl(url1);
+    result2.setUrl(url2);
+    searcher->resultMap.insert(url1, result1);
+    searcher->resultMap.insert(url2, result2);
+
     DFMSearchResultMap results = searcher->takeAll();
-    EXPECT_TRUE(true);
+
+    EXPECT_EQ(results.size(), 2);
+    EXPECT_TRUE(results.contains(url1));
+    EXPECT_TRUE(results.contains(url2));
+    EXPECT_FALSE(searcher->hasItem());
 }
 
-TEST_F(TestIteratorSearcher, TakeAllUrls_WithNoResults_ReturnsEmptyList)
+TEST_F(TestIteratorSearcher, TakeAllUrls_WithResults_ReturnsUrlsAndClears)
 {
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    // Add results
+    QUrl url1 = QUrl::fromLocalFile("/home/test/file1.txt");
+    QUrl url2 = QUrl::fromLocalFile("/home/test/file2.txt");
+    DFMSearchResult result1, result2;
+    result1.setUrl(url1);
+    result2.setUrl(url2);
+    searcher->resultMap.insert(url1, result1);
+    searcher->resultMap.insert(url2, result2);
+
     QList<QUrl> urls = searcher->takeAllUrls();
-    EXPECT_TRUE(true);
+
+    EXPECT_EQ(urls.size(), 2);
+    EXPECT_TRUE(urls.contains(url1));
+    EXPECT_TRUE(urls.contains(url2));
+    EXPECT_FALSE(searcher->hasItem());
 }
 
-TEST_F(TestIteratorSearcher, TakeAllUrls_WithResults_ReturnsUrlList)
+TEST_F(TestIteratorSearcher, TakeAllUrls_WithEmptyResults_ReturnsEmptyList)
 {
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
     QList<QUrl> urls = searcher->takeAllUrls();
+
+    EXPECT_TRUE(urls.isEmpty());
+}
+
+// ========== ProcessDirectory Tests ==========
+TEST_F(TestIteratorSearcher, ProcessDirectory_NotRunning_Skips)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kReady);
+
+    QSignalSpy requestSpy(searcher, &IteratorSearcher::requestCreateIterator);
+
+    searcher->processDirectory();
+
+    EXPECT_EQ(requestSpy.count(), 0);
+}
+
+TEST_F(TestIteratorSearcher, ProcessDirectory_EmptyQueue_EmitsFinished)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+    searcher->pendingDirs.clear();
+
+    QSignalSpy finishedSpy(searcher, &IteratorSearcher::finished);
+
+    searcher->processDirectory();
+
+    EXPECT_EQ(finishedSpy.count(), 1);
+    EXPECT_EQ(searcher->status.loadAcquire(), AbstractSearcher::kCompleted);
+}
+
+TEST_F(TestIteratorSearcher, ProcessDirectory_WithPendingDir_RequestsIterator)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+    searcher->pendingDirs.enqueue(searchUrl);
+
+    QSignalSpy requestSpy(searcher, &IteratorSearcher::requestCreateIterator);
+
+    searcher->processDirectory();
+
+    EXPECT_EQ(requestSpy.count(), 1);
+}
+
+TEST_F(TestIteratorSearcher, ProcessDirectory_WithMultiplePendingDirs_ProcessesInOrder)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    QUrl url1 = QUrl::fromLocalFile("/home/test/dir1");
+    QUrl url2 = QUrl::fromLocalFile("/home/test/dir2");
+    searcher->pendingDirs.enqueue(url1);
+    searcher->pendingDirs.enqueue(url2);
+
+    QSignalSpy requestSpy(searcher, &IteratorSearcher::requestCreateIterator);
+
+    searcher->processDirectory();
+
+    EXPECT_EQ(requestSpy.count(), 1);
+    // First URL should be dequeued
+    QUrl requestedUrl = requestSpy.at(0).at(0).value<QUrl>();
+    EXPECT_EQ(requestedUrl, url1);
+}
+
+// ========== OnIteratorCreated Tests ==========
+TEST_F(TestIteratorSearcher, OnIteratorCreated_NotRunning_IgnoresIterator)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kReady);
+
+    QSharedPointer<AbstractDirIterator> mockIterator(new MockDirIterator(searchUrl));
+
+    QSignalSpy requestSpy(searcher, &IteratorSearcher::requestProcessNextDirectory);
+
+    searcher->onIteratorCreated(mockIterator);
+
+    // Should not process
     EXPECT_TRUE(true);
 }
 
-TEST_F(TestIteratorSearcher, RequestProcessNextDirectorySignal_CanBeEmitted)
+TEST_F(TestIteratorSearcher, OnIteratorCreated_WithNullIterator_RequestsNext)
 {
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    QSharedPointer<AbstractDirIterator> nullIterator;
+
+    QSignalSpy requestSpy(searcher, &IteratorSearcher::requestProcessNextDirectory);
+
+    searcher->onIteratorCreated(nullIterator);
+
+    EXPECT_EQ(requestSpy.count(), 1);
+}
+
+TEST_F(TestIteratorSearcher, OnIteratorCreated_WithValidIterator_CallsProcessIteratorResults)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "file");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file1.txt"), false, false, "file1.txt");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
     QSignalSpy spy(searcher, &IteratorSearcher::requestProcessNextDirectory);
 
-    // Emit signal manually for testing
+    searcher->onIteratorCreated(iterator);
+
+    // Should emit requestProcessNextDirectory signal
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// ========== ProcessIteratorResults Tests ==========
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_NotRunning_ReturnsImmediately)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kReady);
+
+    QSharedPointer<AbstractDirIterator> mockIterator(new MockDirIterator(searchUrl));
+
+    // Should return immediately without processing
+    searcher->processIteratorResults(mockIterator);
+
+    EXPECT_FALSE(searcher->hasItem());
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_WithMatchingFiles_AddsToResults)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "file");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator with matching files
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    // Clear default entries and add custom ones
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file1.txt"), false, false, "file1.txt");
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file2.doc"), false, false, "file2.doc");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    searcher->processIteratorResults(iterator);
+
+    EXPECT_TRUE(searcher->hasItem());
+    DFMSearchResultMap results = searcher->takeAll();
+    EXPECT_EQ(results.size(), 2);
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_WithSubDirectories_EnqueuesThem)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "test");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator with directories
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/subdir1"), true, false, "subdir1");
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/subdir2"), true, false, "subdir2");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    int initialQueueSize = searcher->pendingDirs.size();
+    searcher->processIteratorResults(iterator);
+
+    EXPECT_EQ(searcher->pendingDirs.size(), initialQueueSize + 2);
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_WithSysDirectory_FiltersItOut)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "test");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator with /sys/ directory
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/sys/devices/test"), true, false, "test");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    int initialQueueSize = searcher->pendingDirs.size();
+    searcher->processIteratorResults(iterator);
+
+    // /sys/ directory should not be added to queue
+    EXPECT_EQ(searcher->pendingDirs.size(), initialQueueSize);
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_WithSymlinkDirectory_SkipsIt)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "test");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator with symlink directory
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/symlink"), true, true, "symlink");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    int initialQueueSize = searcher->pendingDirs.size();
+    searcher->processIteratorResults(iterator);
+
+    // Symlink directory should not be added to queue
+    EXPECT_EQ(searcher->pendingDirs.size(), initialQueueSize);
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_WithNullFileInfo_SkipsEntry)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "test");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator that returns null fileInfo
+    class NullInfoIterator : public MockDirIterator
+    {
+    public:
+        explicit NullInfoIterator(const QUrl &url)
+            : MockDirIterator(url) { }
+        const FileInfoPointer fileInfo() const override { return nullptr; }
+    };
+
+    QSharedPointer<AbstractDirIterator> iterator(new NullInfoIterator(searchUrl));
+
+    searcher->processIteratorResults(iterator);
+
+    // Should not crash and should not add any results
+    EXPECT_FALSE(searcher->hasItem());
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_WithNonExistingFile_SkipsEntry)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "test");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator with non-existing file
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    // Add entry with exists = false
+    mockIter->m_mockUrls << QUrl::fromLocalFile("/home/test/nonexistent.txt");
+    mockIter->m_mockInfos << FileInfoPointer(
+            new MockFileInfo(QUrl::fromLocalFile("/home/test/nonexistent.txt"), false, false, "test_nonexistent", false));
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    searcher->processIteratorResults(iterator);
+
+    // Should not add non-existing file to results
+    EXPECT_FALSE(searcher->hasItem());
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_NoMatches_NoResultsAdded)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "nomatch");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator with files that don't match the keyword
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file1.txt"), false, false, "file1.txt");
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file2.doc"), false, false, "file2.doc");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    searcher->processIteratorResults(iterator);
+
+    // No results should be added since no files match "nomatch"
+    EXPECT_FALSE(searcher->hasItem());
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_StatusChangedDuringProcessing_StopsProcessing)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "test");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create a custom iterator that changes status during iteration
+    class StatusChangingIterator : public MockDirIterator
+    {
+    public:
+        explicit StatusChangingIterator(const QUrl &url, IteratorSearcher *s)
+            : MockDirIterator(url), searcher(s), callCount(0) { }
+
+        QUrl next() override
+        {
+            if (callCount++ == 1) {
+                // Change status on second call
+                searcher->status.storeRelease(AbstractSearcher::kTerminated);
+            }
+            return MockDirIterator::next();
+        }
+
+        IteratorSearcher *searcher;
+        mutable int callCount;
+    };
+
+    StatusChangingIterator *mockIter = new StatusChangingIterator(searchUrl, searcher);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file1.txt"), false, false, "test1");
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file2.txt"), false, false, "test2");
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/file3.txt"), false, false, "test3");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    searcher->processIteratorResults(iterator);
+
+    // Should stop processing when status changes
+    DFMSearchResultMap results = searcher->takeAll();
+    EXPECT_LE(results.size(), 2);   // Should process at most 2 items before stopping
+}
+
+TEST_F(TestIteratorSearcher, ProcessIteratorResults_MixedFilesAndDirectories_HandlesCorrectly)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "test");
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Create mock iterator with mixed files and directories
+    MockDirIterator *mockIter = new MockDirIterator(searchUrl);
+    mockIter->m_mockUrls.clear();
+    mockIter->m_mockInfos.clear();
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/testfile.txt"), false, false, "testfile.txt");
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/testdir"), true, false, "testdir");
+    mockIter->addMockEntry(QUrl::fromLocalFile("/home/test/another_test.doc"), false, false, "another_test.doc");
+    mockIter->m_currentIndex = 0;
+
+    QSharedPointer<AbstractDirIterator> iterator(mockIter);
+
+    int initialQueueSize = searcher->pendingDirs.size();
+    searcher->processIteratorResults(iterator);
+
+    // Should add files to results and directory to queue
+    EXPECT_TRUE(searcher->hasItem());
+    DFMSearchResultMap results = searcher->takeAll();
+    EXPECT_EQ(results.size(), 3);
+    EXPECT_EQ(searcher->pendingDirs.size(), initialQueueSize + 1);   // One directory added
+}
+
+// ========== Batch Processing Tests ==========
+TEST_F(TestIteratorSearcher, PublishBatchedResults_NotRunning_DoesNothing)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kReady);
+
+    QSignalSpy unearthedSpy(searcher, &IteratorSearcher::unearthed);
+
+    searcher->publishBatchedResults();
+
+    EXPECT_EQ(unearthedSpy.count(), 0);
+}
+
+TEST_F(TestIteratorSearcher, PublishBatchedResults_WithResults_EmitsUnearthed)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    // Add batched results
+    QUrl resultUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult result;
+    result.setUrl(resultUrl);
+    searcher->batchedResults.insert(resultUrl, result);
+
+    QSignalSpy unearthedSpy(searcher, &IteratorSearcher::unearthed);
+
+    searcher->publishBatchedResults();
+
+    EXPECT_EQ(unearthedSpy.count(), 1);
+    EXPECT_TRUE(searcher->batchedResults.isEmpty());
+}
+
+TEST_F(TestIteratorSearcher, PublishBatchedResults_RestartsTimer)
+{
+    setupBasicStubs();
+
+    bool timerStarted = false;
+    stub.set_lamda(static_cast<void (QTimer::*)(int)>(&QTimer::start), [&timerStarted](QTimer *, int) {
+        __DBG_STUB_INVOKE__
+        timerStarted = true;
+    });
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    searcher->publishBatchedResults();
+
+    EXPECT_TRUE(timerStarted);
+}
+
+TEST_F(TestIteratorSearcher, PublishBatchedResults_WhenNotRunning_DoesNothing)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kReady);
+
+    // Add some batched results
+    QUrl resultUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult result;
+    result.setUrl(resultUrl);
+    searcher->batchedResults.insert(resultUrl, result);
+
+    QSignalSpy unearthedSpy(searcher, &IteratorSearcher::unearthed);
+
+    searcher->publishBatchedResults();
+
+    // Should not emit signal when not running
+    EXPECT_EQ(unearthedSpy.count(), 0);
+}
+
+// ========== AddResults Tests ==========
+TEST_F(TestIteratorSearcher, AddResults_EmptyResults_DoesNothing)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    DFMSearchResultMap emptyResults;
+
+    searcher->addResults(emptyResults);
+
+    EXPECT_FALSE(searcher->hasItem());
+}
+
+TEST_F(TestIteratorSearcher, AddResults_WithResults_AddsToBatchAndTotal)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+
+    DFMSearchResultMap newResults;
+    QUrl url1 = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult result1;
+    result1.setUrl(url1);
+    newResults.insert(url1, result1);
+
+    searcher->addResults(newResults);
+
+    EXPECT_TRUE(searcher->hasItem());
+}
+
+TEST_F(TestIteratorSearcher, AddResults_ReachingBatchLimit_PublishesImmediately)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->status.storeRelease(AbstractSearcher::kRuning);
+    searcher->batchResultLimit = 2;
+
+    DFMSearchResultMap newResults;
+    QUrl url1 = QUrl::fromLocalFile("/home/test/file1.txt");
+    QUrl url2 = QUrl::fromLocalFile("/home/test/file2.txt");
+    DFMSearchResult result1, result2;
+    result1.setUrl(url1);
+    result2.setUrl(url2);
+    newResults.insert(url1, result1);
+    newResults.insert(url2, result2);
+
+    QSignalSpy unearthedSpy(searcher, &IteratorSearcher::unearthed);
+
+    searcher->addResults(newResults);
+
+    EXPECT_EQ(unearthedSpy.count(), 1);
+}
+
+// ========== AddResultToMap Tests ==========
+TEST_F(TestIteratorSearcher, AddResultToMap_CreatesResultWithCorrectUrl)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    QUrl fileUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResultMap results;
+
+    searcher->addResultToMap(fileUrl, results);
+
+    EXPECT_EQ(results.size(), 1);
+    EXPECT_TRUE(results.contains(fileUrl));
+    EXPECT_EQ(results[fileUrl].matchScore(), 1.0);
+}
+
+TEST_F(TestIteratorSearcher, AddResultToMap_DuplicateUrl_ReplacesExisting)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    QUrl fileUrl = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResultMap results;
+
+    // Add first result
+    searcher->addResultToMap(fileUrl, results);
+    EXPECT_EQ(results.size(), 1);
+
+    // Add same URL again
+    searcher->addResultToMap(fileUrl, results);
+    EXPECT_EQ(results.size(), 1);   // Should still be 1 (replaced)
+}
+
+// ========== RequestNextDirectory Tests ==========
+TEST_F(TestIteratorSearcher, RequestNextDirectory_EmitsSignal)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    QSignalSpy spy(searcher, &IteratorSearcher::requestProcessNextDirectory);
+
+    searcher->requestNextDirectory();
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+// ========== Signal Tests ==========
+TEST_F(TestIteratorSearcher, RequestProcessNextDirectorySignal_CanBeEmitted)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    QSignalSpy spy(searcher, &IteratorSearcher::requestProcessNextDirectory);
+
     emit searcher->requestProcessNextDirectory();
 
     EXPECT_EQ(spy.count(), 1);
@@ -223,145 +1109,140 @@ TEST_F(TestIteratorSearcher, RequestProcessNextDirectorySignal_CanBeEmitted)
 
 TEST_F(TestIteratorSearcher, RequestCreateIteratorSignal_CanBeEmitted)
 {
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
     QSignalSpy spy(searcher, &IteratorSearcher::requestCreateIterator);
 
     QUrl testUrl = QUrl::fromLocalFile("/home/test");
-
-    // Emit signal manually for testing
     emit searcher->requestCreateIterator(testUrl);
 
     EXPECT_EQ(spy.count(), 1);
     EXPECT_EQ(spy.at(0).at(0).value<QUrl>(), testUrl);
 }
 
-TEST_F(TestIteratorSearcher, OnIteratorCreated_WithValidIterator_CallsCorrectly)
+// ========== Regex Matching Tests ==========
+TEST_F(TestIteratorSearcher, RegexMatching_CaseInsensitive)
 {
-    QSharedPointer<AbstractDirIterator> mockIterator;
+    setupBasicStubs();
 
-    EXPECT_NO_FATAL_FAILURE(searcher->onIteratorCreated(mockIterator));
+    searcher = new IteratorSearcher(searchUrl, "TEST");
+
+    // Test case insensitive matching
+    EXPECT_TRUE(searcher->regex.match("test").hasMatch());
+    EXPECT_TRUE(searcher->regex.match("Test").hasMatch());
+    EXPECT_TRUE(searcher->regex.match("TEST").hasMatch());
 }
 
-TEST_F(TestIteratorSearcher, OnIteratorCreated_WithNullIterator_HandlesCorrectly)
+TEST_F(TestIteratorSearcher, RegexMatching_PartialMatch)
 {
-    QSharedPointer<AbstractDirIterator> nullIterator;
+    setupBasicStubs();
 
-    EXPECT_NO_FATAL_FAILURE(searcher->onIteratorCreated(nullIterator));
+    searcher = new IteratorSearcher(searchUrl, "test");
+
+    EXPECT_TRUE(searcher->regex.match("testfile.txt").hasMatch());
+    EXPECT_TRUE(searcher->regex.match("mytest.doc").hasMatch());
 }
 
-TEST_F(TestIteratorSearcher, ProcessDirectory_CallsCorrectly)
+TEST_F(TestIteratorSearcher, Regex_CaseInsensitiveOption_IsSet)
 {
-    EXPECT_NO_FATAL_FAILURE(searcher->processDirectory());
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, "TEST");
+
+    // Verify case insensitive option is set
+    EXPECT_TRUE(searcher->regex.patternOptions() & QRegularExpression::CaseInsensitiveOption);
 }
 
-TEST_F(TestIteratorSearcher, CompleteWorkflow_SearchProcessTakeAllStop)
+// ========== Thread Safety Tests ==========
+TEST_F(TestIteratorSearcher, ThreadSafety_ConcurrentAccess_NoDataRace)
 {
-    // Mock all operations for complete workflow
-    stub.set_lamda(static_cast<void (QTimer::*)(int)>(&QTimer::start), [] {
-        __DBG_STUB_INVOKE__
-    });
+    setupBasicStubs();
 
-    stub.set_lamda(&QTimer::stop, [](QTimer *) {
-        __DBG_STUB_INVOKE__
-    });
+    searcher = new IteratorSearcher(searchUrl, keyword);
 
-    // Execute complete workflow
-    searcher->processDirectory();
-    bool hasItems = searcher->hasItem();
-    DFMSearchResultMap results = searcher->takeAll();
-    QList<QUrl> urls = searcher->takeAllUrls();
-    searcher->stop();
-
-    EXPECT_TRUE(true);
-}
-
-TEST_F(TestIteratorSearcher, RegexMatching_WithDifferentPatterns)
-{
-    QStringList testKeywords = {
-        "simple",
-        "*.txt",
-        "test*",
-        "?test",
-        "[abc]test"
-    };
-
-    // Test different regex patterns
-    for (const QString &keyword : testKeywords) {
-        IteratorSearcher testSearcher(searchUrl, keyword);
-        EXPECT_TRUE(true);   // Test that construction succeeds with different patterns
-    }
-}
-
-TEST_F(TestIteratorSearcher, ThreadSafety_WithMutexProtection)
-{
-    // Test thread safety with mutex protection
+    // Add results
+    QUrl url1 = QUrl::fromLocalFile("/home/test/file1.txt");
+    DFMSearchResult result1;
+    result1.setUrl(url1);
+    searcher->resultMap.insert(url1, result1);
 
     // Simulate concurrent access
     bool hasItems1 = searcher->hasItem();
-    DFMSearchResultMap results1 = searcher->takeAll();
+    DFMSearchResultMap results = searcher->takeAll();
     bool hasItems2 = searcher->hasItem();
     QList<QUrl> urls = searcher->takeAllUrls();
 
-    EXPECT_TRUE(true);
+    EXPECT_TRUE(hasItems1);
+    EXPECT_FALSE(hasItems2);
+    EXPECT_TRUE(urls.isEmpty());
 }
 
-TEST_F(TestIteratorSearcher, BridgeIntegration_WithIteratorSearcherBridge)
+// ========== Batch Timer Tests ==========
+TEST_F(TestIteratorSearcher, BatchTimer_Configuration_IsCorrect)
 {
-    // Test integration with IteratorSearcherBridge
+    setupBasicStubs();
 
-    IteratorSearcherBridge testBridge;
-    testBridge.setSearcher(searcher);
+    searcher = new IteratorSearcher(searchUrl, keyword);
 
-    QUrl testUrl = QUrl::fromLocalFile("/home/test");
-    EXPECT_NO_FATAL_FAILURE(testBridge.createIterator(testUrl));
+    EXPECT_NE(searcher->batchTimer, nullptr);
+    EXPECT_EQ(searcher->batchResultLimit, 200);
+    EXPECT_EQ(searcher->batchTimeLimit, 500);
 }
 
-TEST_F(TestIteratorSearcher, Destructor_CleansUpResources)
+// ========== Integration Tests ==========
+TEST_F(TestIteratorSearcher, CompleteWorkflow_SearchProcessStop)
 {
-    // Mock cleanup operations
-    stub.set_lamda(&QTimer::stop, [](QTimer *) {
-        __DBG_STUB_INVOKE__
-    });
+    setupBasicStubs();
 
-    stub.set_lamda(&QTimer::deleteLater, [](QObject *) {
-        __DBG_STUB_INVOKE__
-    });
+    searcher = new IteratorSearcher(searchUrl, keyword);
 
-    stub.set_lamda(&QObject::deleteLater, [](QObject *) {
-        __DBG_STUB_INVOKE__
-    });
+    QSignalSpy finishedSpy(searcher, &IteratorSearcher::finished);
 
-    // Test destruction (would be called automatically in TearDown)
-    EXPECT_TRUE(true);
-}
+    // Start search
+    bool searchResult = searcher->search();
+    EXPECT_TRUE(searchResult);
 
-TEST_F(TestIteratorSearcher, StatusTransitions_FromReadyToRunningToCompleted)
-{
-    // Test status transitions during search lifecycle
-
-    // Mock status operations
-    stub.set_lamda(static_cast<void (QTimer::*)(int)>(&QTimer::start), []() {
-        __DBG_STUB_INVOKE__
-    });
-
-    stub.set_lamda(&QTimer::stop, [](QTimer *) {
-        __DBG_STUB_INVOKE__
-    });
-
-    // Initial status should be Ready
-    // Start search (should change to Running)
-    // searcher->search();
-    // Stop search (should change to Terminated)
+    // Stop search
     searcher->stop();
-
-    EXPECT_TRUE(true);
+    EXPECT_EQ(finishedSpy.count(), 1);
 }
 
-TEST_F(TestIteratorSearcher, PendingDirectoryQueue_ManagesDirectories)
+// ========== Destructor Tests ==========
+TEST_F(TestIteratorSearcher, Destructor_StopsTimer)
 {
-    // Test that pending directory queue is properly managed
+    setupBasicStubs();
 
-    // Process directories
-    searcher->processDirectory();
+    bool timerStopped = false;
+    stub.set_lamda(&QTimer::stop, [&timerStopped](QTimer *) {
+        __DBG_STUB_INVOKE__
+        timerStopped = true;
+    });
 
-    EXPECT_TRUE(true);
+    stub.set_lamda(&QTimer::isActive, [](const QTimer *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+
+    delete searcher;
+    searcher = nullptr;
+
+    EXPECT_TRUE(timerStopped);
+}
+
+TEST_F(TestIteratorSearcher, Destructor_ClearsPendingDirs)
+{
+    setupBasicStubs();
+
+    searcher = new IteratorSearcher(searchUrl, keyword);
+    searcher->pendingDirs.enqueue(searchUrl);
+
+    // Destructor should clear the queue
+    delete searcher;
+    searcher = nullptr;
+
+    EXPECT_TRUE(true);   // No crash means cleanup successful
 }

--- a/autotests/plugins/dfmplugin-search/test_searcheventcaller.cpp
+++ b/autotests/plugins/dfmplugin-search/test_searcheventcaller.cpp
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QUrl>
+
+#include "events/searcheventcaller.h"
+#include "utils/searchhelper.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/widgets/filemanagerwindow.h>
+
+#include <dfm-framework/event/eventdispatcher.h>
+#include <dfm-framework/event/eventchannel.h>
+
+#include "stubext.h"
+
+DFMBASE_USE_NAMESPACE
+DPSEARCH_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class TestSearchEventCaller : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+};
+
+// ========== SendChangeCurrentUrl Tests ==========
+TEST_F(TestSearchEventCaller, SendChangeCurrentUrl)
+{
+    quint64 winId = 12345;
+    QUrl url = QUrl::fromLocalFile("/home/test");
+
+    bool signalPublished = false;
+    typedef bool (EventDispatcherManager::*Publish)(EventType, quint64, const QUrl &);
+    stub.set_lamda(static_cast<Publish>(&EventDispatcherManager::publish),
+                   [&signalPublished] {
+                       __DBG_STUB_INVOKE__
+                       signalPublished = true;
+                       return true;
+                   });
+
+    EXPECT_NO_FATAL_FAILURE(SearchEventCaller::sendChangeCurrentUrl(winId, url));
+    EXPECT_TRUE(signalPublished);
+}
+
+// ========== SendShowAdvanceSearchBar Tests ==========
+TEST_F(TestSearchEventCaller, SendShowAdvanceSearchBar)
+{
+    quint64 winId = 12345;
+    bool visible = true;
+
+    bool slotPushed = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64, QString &&, bool &);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&] {
+                       __DBG_STUB_INVOKE__
+                       slotPushed = true;
+                       return QVariant(true);
+                   });
+
+    EXPECT_NO_FATAL_FAILURE(SearchEventCaller::sendShowAdvanceSearchBar(winId, visible));
+    EXPECT_TRUE(slotPushed);
+}
+
+// ========== SendShowAdvanceSearchButton Tests ==========
+TEST_F(TestSearchEventCaller, SendShowAdvanceSearchButton)
+{
+    quint64 winId = 12345;
+    bool visible = true;
+
+    bool slotPushed = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64, bool &);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&slotPushed] {
+                       __DBG_STUB_INVOKE__
+                       slotPushed = true;
+                       return QVariant(true);
+                   });
+
+    EXPECT_NO_FATAL_FAILURE(SearchEventCaller::sendShowAdvanceSearchButton(winId, visible));
+    EXPECT_TRUE(slotPushed);
+}
+
+// ========== SendStartSpinner Tests ==========
+TEST_F(TestSearchEventCaller, SendStartSpinner)
+{
+    quint64 winId = 12345;
+
+    bool slotPushed = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&slotPushed] {
+                       __DBG_STUB_INVOKE__
+                       slotPushed = true;
+                       return QVariant(true);
+                   });
+
+    EXPECT_NO_FATAL_FAILURE(SearchEventCaller::sendStartSpinner(winId));
+    EXPECT_TRUE(slotPushed);
+}
+
+// ========== SendStopSpinner Tests ==========
+TEST_F(TestSearchEventCaller, SendStopSpinner_WithValidWindow_PushesSlot)
+{
+    quint64 winId = 12345;
+
+    // Mock window exists
+    FileManagerWindow w(QUrl::fromLocalFile("/"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById,
+                   [&w] {
+                       __DBG_STUB_INVOKE__
+                       return &w;
+                   });
+
+    bool slotPushed = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&slotPushed] {
+                       __DBG_STUB_INVOKE__
+                       slotPushed = true;
+                       return true;
+                   });
+
+    EXPECT_NO_FATAL_FAILURE(SearchEventCaller::sendStopSpinner(winId));
+    EXPECT_TRUE(slotPushed);
+}

--- a/autotests/plugins/dfmplugin-search/test_taskcommander.cpp
+++ b/autotests/plugins/dfmplugin-search/test_taskcommander.cpp
@@ -6,24 +6,90 @@
 #include <QUrl>
 #include <QSignalSpy>
 #include <QThread>
+#include <QMetaObject>
+#include <QMutex>
+#include <QReadWriteLock>
 
 #include "searchmanager/maincontroller/task/taskcommander.h"
+#include "searchmanager/maincontroller/task/taskcommander_p.h"
+#include "searchmanager/searcher/abstractsearcher.h"
+#include "searchmanager/searcher/iterator/iteratorsearcher.h"
+#include "searchmanager/searcher/dfmsearch/dfmsearcher.h"
 #include "searchmanager/searcher/searchresult_define.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-search/dsearch_global.h>
 
 #include "stubext.h"
 
 DPSEARCH_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
 
-class TestTaskCommander : public testing::Test
+// Mock AbstractSearcher for testing
+class MockSearcher : public AbstractSearcher
+{
+public:
+    explicit MockSearcher(const QUrl &url, const QString &key, QObject *parent = nullptr)
+        : AbstractSearcher(url, key, parent), m_hasItem(false), m_searchCalled(false), m_stopCalled(false)
+    {
+    }
+
+    bool search() override
+    {
+        m_searchCalled = true;
+        return true;
+    }
+
+    void stop() override
+    {
+        m_stopCalled = true;
+    }
+
+    bool hasItem() const override
+    {
+        return m_hasItem;
+    }
+
+    DFMSearchResultMap takeAll() override
+    {
+        DFMSearchResultMap results = m_results;
+        m_results.clear();
+        m_hasItem = false;
+        return results;
+    }
+
+    void addMockResult(const QUrl &url, double score = 1.0)
+    {
+        DFMSearchResult result(url);
+        result.setMatchScore(score);
+        m_results.insert(url, result);
+        m_hasItem = true;
+    }
+
+    void emitUnearthed()
+    {
+        emit unearthed(this);
+    }
+
+    void emitFinished()
+    {
+        emit finished();
+    }
+
+    bool m_hasItem;
+    bool m_searchCalled;
+    bool m_stopCalled;
+    DFMSearchResultMap m_results;
+};
+
+class TestTaskCommanderPrivate : public testing::Test
 {
 public:
     void SetUp() override
     {
-        // TaskCommander constructor is private, we simulate via friend class access
-        taskId = "test_task_001";
+        taskId = "test-task-123";
         searchUrl = QUrl::fromLocalFile("/home/test");
-        keyword = "test_keyword";
-        commander = nullptr; // Will need friend class or reflection to create
+        keyword = "test";
     }
 
     void TearDown() override
@@ -35,352 +101,317 @@ public:
         stub.clear();
     }
 
+    void setupBasicStubs()
+    {
+        // Stub QThread operations
+        stub.set_lamda(&QThread::start, [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&QThread::quit, [](QThread *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(qOverload<QDeadlineTimer>(&QThread::wait), [] {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        stub.set_lamda(&QThread::isRunning, [](const QThread *) -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        // Stub QMetaObject::invokeMethod
+        stub.set_lamda(static_cast<bool (*)(QObject *, QtPrivate::QSlotObjectBase *,
+                                            Qt::ConnectionType, qsizetype,
+                                            const void *const *, const char *const *,
+                                            const QtPrivate::QMetaTypeInterface *const *)>(&QMetaObject::invokeMethodImpl),
+                       [](QObject *, QtPrivate::QSlotObjectBase *, Qt::ConnectionType,
+                          qsizetype, const void *const *, const char *const *,
+                          const QtPrivate::QMetaTypeInterface *const *) -> bool {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+
+        // Stub DFMSearcher and IteratorSearcher constructors
+        stub.set_lamda(&DFMSearcher::supportUrl, [](const QUrl &url) -> bool {
+            __DBG_STUB_INVOKE__
+            return url.scheme() == "file";
+        });
+
+        stub.set_lamda(&DFMSearcher::realSearchPath, [](const QUrl &url) -> QString {
+            __DBG_STUB_INVOKE__
+            return url.toLocalFile();
+        });
+
+        stub.set_lamda(&DFMSEARCH::Global::defaultIndexedDirectory, []() -> QStringList {
+            __DBG_STUB_INVOKE__
+            return QStringList() << "/home/test/Documents";
+        });
+
+        stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &defaultValue) -> QVariant {
+            __DBG_STUB_INVOKE__
+            return defaultValue;
+        });
+    }
+
 protected:
     stub_ext::StubExt stub;
     TaskCommander *commander = nullptr;
     QString taskId;
     QUrl searchUrl;
     QString keyword;
-
-    // Helper method to create TaskCommander for testing
-    TaskCommander *createTaskCommander() {
-        // Since constructor is private, we use reflection or friend access
-        // For testing, we'll simulate the creation
-        return nullptr; // Would be created via MainController in real scenario
-    }
 };
+
+class TestTaskCommander : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+        taskId = "test-task-456";
+        searchUrl = QUrl::fromLocalFile("/home/test");
+        keyword = "search";
+    }
+
+    void TearDown() override
+    {
+        if (commander) {
+            delete commander;
+            commander = nullptr;
+        }
+        stub.clear();
+    }
+
+    void setupBasicStubs()
+    {
+        // Stub QThread operations
+        stub.set_lamda(&QThread::start, [] {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(&QThread::quit, [](QThread *) {
+            __DBG_STUB_INVOKE__
+        });
+
+        stub.set_lamda(qOverload<QDeadlineTimer>(&QThread::wait), [] {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        stub.set_lamda(&QThread::isRunning, [](const QThread *) -> bool {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+
+        // Stub QMetaObject::invokeMethod
+        stub.set_lamda(static_cast<bool (*)(QObject *, QtPrivate::QSlotObjectBase *,
+                                            Qt::ConnectionType, qsizetype,
+                                            const void *const *, const char *const *,
+                                            const QtPrivate::QMetaTypeInterface *const *)>(&QMetaObject::invokeMethodImpl),
+                       [](QObject *, QtPrivate::QSlotObjectBase *, Qt::ConnectionType,
+                          qsizetype, const void *const *, const char *const *,
+                          const QtPrivate::QMetaTypeInterface *const *) -> bool {
+                           __DBG_STUB_INVOKE__
+                           return true;
+                       });
+
+        stub.set_lamda(&DFMSearcher::supportUrl, [](const QUrl &) -> bool {
+            __DBG_STUB_INVOKE__
+            return true;
+        });
+
+        stub.set_lamda(&DFMSEARCH::Global::defaultIndexedDirectory, []() -> QStringList {
+            __DBG_STUB_INVOKE__
+            return QStringList();
+        });
+
+        stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &defaultValue) -> QVariant {
+            __DBG_STUB_INVOKE__
+            return defaultValue;
+        });
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    TaskCommander *commander = nullptr;
+    QString taskId;
+    QUrl searchUrl;
+    QString keyword;
+};
+
+// ========== TaskCommanderPrivate Tests ==========
+TEST_F(TestTaskCommanderPrivate, Constructor_InitializesWorkerThread)
+{
+    setupBasicStubs();
+
+    bool threadStarted = false;
+    stub.set_lamda(&QThread::start, [&threadStarted] {
+        __DBG_STUB_INVOKE__
+        threadStarted = true;
+    });
+
+    commander = new TaskCommander(taskId, searchUrl, keyword);
+
+    EXPECT_TRUE(threadStarted);
+}
+
+TEST_F(TestTaskCommanderPrivate, OnResultsUpdated_EmitsMatchedSignal)
+{
+    setupBasicStubs();
+
+    commander = new TaskCommander(taskId, searchUrl, keyword);
+
+    QSignalSpy spy(commander, &TaskCommander::matched);
+
+    // Trigger resultsUpdated
+    emit commander->d->searchWorker->resultsUpdated(taskId);
+
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), taskId);
+}
+
+// ========== TaskCommander Tests ==========
+TEST_F(TestTaskCommander, Constructor_WithValidParameters_CreatesInstance)
+{
+    setupBasicStubs();
+
+    commander = new TaskCommander(taskId, searchUrl, keyword);
+
+    EXPECT_NE(commander, nullptr);
+    EXPECT_NE(commander->d, nullptr);
+    EXPECT_NE(commander->d->searchWorker, nullptr);
+}
 
 TEST_F(TestTaskCommander, TaskID_ReturnsCorrectTaskId)
 {
-    if (commander) {
-        QString retrievedTaskId = commander->taskID();
-        EXPECT_EQ(retrievedTaskId, taskId);
-    } else {
-        // Mock the method call
-        stub.set_lamda(&TaskCommander::taskID, [this](TaskCommander *) -> QString {
-            __DBG_STUB_INVOKE__
-            return this->taskId;
-        });
+    setupBasicStubs();
 
-        EXPECT_TRUE(true);
-    }
+    commander = new TaskCommander(taskId, searchUrl, keyword);
+
+    EXPECT_EQ(commander->taskID(), taskId);
 }
 
-TEST_F(TestTaskCommander, GetResults_ReturnsSearchResults)
+TEST_F(TestTaskCommander, GetResults_WithNoResults_ReturnsEmptyMap)
 {
-    // Mock search results
-    DFMSearchResultMap mockResults;
-    // Add some mock data to results if needed
+    setupBasicStubs();
 
-    if (commander) {
-        DFMSearchResultMap results = commander->getResults();
-        // Test that results are returned (may be empty initially)
-        EXPECT_TRUE(true);
-    } else {
-        stub.set_lamda(&TaskCommander::getResults, [&mockResults](TaskCommander *) -> DFMSearchResultMap {
-            __DBG_STUB_INVOKE__
-            return mockResults;
-        });
+    commander = new TaskCommander(taskId, searchUrl, keyword);
 
-        EXPECT_TRUE(true);
-    }
+    DFMSearchResultMap results = commander->getResults();
+
+    EXPECT_TRUE(results.isEmpty());
 }
 
-TEST_F(TestTaskCommander, GetResultsUrls_ReturnsUrlList)
+TEST_F(TestTaskCommander, GetResults_WithResults_ReturnsResults)
 {
-    QList<QUrl> mockUrls = {
-        QUrl::fromLocalFile("/home/test/file1.txt"),
-        QUrl::fromLocalFile("/home/test/file2.txt")
-    };
+    setupBasicStubs();
 
-    if (commander) {
-        QList<QUrl> urls = commander->getResultsUrls();
-        EXPECT_TRUE(true);
-    } else {
-        stub.set_lamda(&TaskCommander::getResultsUrls, [&mockUrls](TaskCommander *) -> QList<QUrl> {
-            __DBG_STUB_INVOKE__
-            return mockUrls;
-        });
+    bool invokeMethodCalled = false;
+    stub.set_lamda(static_cast<bool (*)(QObject *, QtPrivate::QSlotObjectBase *,
+                                        Qt::ConnectionType, qsizetype,
+                                        const void *const *, const char *const *,
+                                        const QtPrivate::QMetaTypeInterface *const *)>(&QMetaObject::invokeMethodImpl),
+                   [&invokeMethodCalled](QObject *, QtPrivate::QSlotObjectBase *,
+                                         Qt::ConnectionType, qsizetype,
+                                         const void *const *, const char *const *,
+                                         const QtPrivate::QMetaTypeInterface *const *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       invokeMethodCalled = true;
+                       return true;
+                   });
 
-        EXPECT_TRUE(true);
-    }
+    commander = new TaskCommander(taskId, searchUrl, keyword);
+
+    commander->getResults();
+
+    EXPECT_TRUE(invokeMethodCalled);
 }
 
-TEST_F(TestTaskCommander, Start_WithValidConfiguration_ReturnsTrue)
+TEST_F(TestTaskCommander, GetResultsUrls_WithNoResults_ReturnsEmptyList)
 {
-    // Mock thread and search operations
-    stub.set_lamda(&QThread::start, [] {
-        __DBG_STUB_INVOKE__
-    });
+    setupBasicStubs();
 
-    if (commander) {
-        bool result = commander->start();
-        EXPECT_TRUE(result || !result); // Either result is valid depending on implementation
-    } else {
-        stub.set_lamda(&TaskCommander::start, [](TaskCommander *) -> bool {
-            __DBG_STUB_INVOKE__
-            return true;
-        });
+    commander = new TaskCommander(taskId, searchUrl, keyword);
 
-        EXPECT_TRUE(true);
-    }
+    QList<QUrl> urls = commander->getResultsUrls();
+
+    EXPECT_TRUE(urls.isEmpty());
 }
 
-TEST_F(TestTaskCommander, Start_AlreadyRunning_HandlesCorrectly)
+TEST_F(TestTaskCommander, GetResultsUrls_InvokesWorkerMethod)
 {
-    // Test starting an already running task
+    setupBasicStubs();
 
-    if (commander) {
-        // First start
-        bool firstResult = commander->start();
-        // Second start (should handle gracefully)
-        bool secondResult = commander->start();
+    bool invokeMethodCalled = false;
+    stub.set_lamda(static_cast<bool (*)(QObject *, QtPrivate::QSlotObjectBase *,
+                                        Qt::ConnectionType, qsizetype,
+                                        const void *const *, const char *const *,
+                                        const QtPrivate::QMetaTypeInterface *const *)>(&QMetaObject::invokeMethodImpl),
+                   [&invokeMethodCalled](QObject *, QtPrivate::QSlotObjectBase *,
+                                         Qt::ConnectionType, qsizetype,
+                                         const void *const *, const char *const *,
+                                         const QtPrivate::QMetaTypeInterface *const *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       invokeMethodCalled = true;
+                       return true;
+                   });
 
-        EXPECT_TRUE(true);
-    } else {
-        // Mock already running scenario
-        int callCount = 0;
-        stub.set_lamda(&TaskCommander::start, [&callCount](TaskCommander *) -> bool {
-            __DBG_STUB_INVOKE__
-            callCount++;
-            return callCount == 1; // First call succeeds, second fails or ignored
-        });
+    commander = new TaskCommander(taskId, searchUrl, keyword);
 
-        EXPECT_TRUE(true);
-    }
+    commander->getResultsUrls();
+
+    EXPECT_TRUE(invokeMethodCalled);
 }
 
-TEST_F(TestTaskCommander, Stop_StopsRunningTask)
+TEST_F(TestTaskCommander, Start_InvokesWorkerStartSearch)
 {
-    // Mock thread stop operations
-    stub.set_lamda(&QThread::quit, [](QThread *) {
-        __DBG_STUB_INVOKE__
-    });
+    setupBasicStubs();
 
-    if (commander) {
-        EXPECT_NO_FATAL_FAILURE(commander->stop());
-    } else {
-        stub.set_lamda(&TaskCommander::stop, [](TaskCommander *) {
-            __DBG_STUB_INVOKE__
-        });
+    bool startSearchCalled = false;
+    stub.set_lamda(static_cast<bool (*)(QObject *, QtPrivate::QSlotObjectBase *,
+                                        Qt::ConnectionType, qsizetype,
+                                        const void *const *, const char *const *,
+                                        const QtPrivate::QMetaTypeInterface *const *)>(&QMetaObject::invokeMethodImpl),
+                   [&startSearchCalled](QObject *, QtPrivate::QSlotObjectBase *,
+                                        Qt::ConnectionType, qsizetype,
+                                        const void *const *, const char *const *,
+                                        const QtPrivate::QMetaTypeInterface *const *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       startSearchCalled = true;
+                       return true;
+                   });
 
-        EXPECT_TRUE(true);
-    }
+    commander = new TaskCommander(taskId, searchUrl, keyword);
+
+    bool result = commander->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(startSearchCalled);
 }
 
-TEST_F(TestTaskCommander, Stop_WhenNotRunning_HandlesCorrectly)
+TEST_F(TestTaskCommander, Stop_InvokesWorkerStopSearch)
 {
-    // Test stopping a task that's not running
+    setupBasicStubs();
 
-    if (commander) {
-        // Stop without starting
-        EXPECT_NO_FATAL_FAILURE(commander->stop());
-    } else {
-        stub.set_lamda(&TaskCommander::stop, [](TaskCommander *) {
-            __DBG_STUB_INVOKE__
-        });
+    bool stopSearchCalled = false;
+    stub.set_lamda(static_cast<bool (*)(QObject *, QtPrivate::QSlotObjectBase *,
+                                        Qt::ConnectionType, qsizetype,
+                                        const void *const *, const char *const *,
+                                        const QtPrivate::QMetaTypeInterface *const *)>(&QMetaObject::invokeMethodImpl),
+                   [&stopSearchCalled](QObject *, QtPrivate::QSlotObjectBase *,
+                                       Qt::ConnectionType, qsizetype,
+                                       const void *const *, const char *const *,
+                                       const QtPrivate::QMetaTypeInterface *const *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       stopSearchCalled = true;
+                       return true;
+                   });
 
-        EXPECT_TRUE(true);
-    }
+    commander = new TaskCommander(taskId, searchUrl, keyword);
+
+    commander->stop();
+
+    EXPECT_TRUE(stopSearchCalled);
 }
 
-TEST_F(TestTaskCommander, OnWorkThreadFinished_EmitsSignals)
-{
-    if (commander) {
-        QSignalSpy threadFinishedSpy(commander, &TaskCommander::threadFinished);
-        QSignalSpy finishedSpy(commander, &TaskCommander::finished);
-
-        // Invoke the slot manually
-        commander->onWorkThreadFinished();
-
-        // Verify signals were emitted
-        EXPECT_TRUE(true);
-    } else {
-        // Mock the slot call
-        stub.set_lamda(&TaskCommander::onWorkThreadFinished, [](TaskCommander *) {
-            __DBG_STUB_INVOKE__
-        });
-
-        EXPECT_TRUE(true);
-    }
-}
-
-TEST_F(TestTaskCommander, MatchedSignal_CanBeEmitted)
-{
-    if (commander) {
-        QSignalSpy spy(commander, &TaskCommander::matched);
-
-        // Emit signal manually for testing
-        emit commander->matched(taskId);
-
-        EXPECT_EQ(spy.count(), 1);
-        EXPECT_EQ(spy.at(0).at(0).toString(), taskId);
-    } else {
-        EXPECT_TRUE(true);
-    }
-}
-
-TEST_F(TestTaskCommander, FinishedSignal_CanBeEmitted)
-{
-    if (commander) {
-        QSignalSpy spy(commander, &TaskCommander::finished);
-
-        // Emit signal manually for testing
-        emit commander->finished(taskId);
-
-        EXPECT_EQ(spy.count(), 1);
-        EXPECT_EQ(spy.at(0).at(0).toString(), taskId);
-    } else {
-        EXPECT_TRUE(true);
-    }
-}
-
-TEST_F(TestTaskCommander, ThreadFinishedSignal_CanBeEmitted)
-{
-    if (commander) {
-        QSignalSpy spy(commander, &TaskCommander::threadFinished);
-
-        // Emit signal manually for testing
-        emit commander->threadFinished(taskId);
-
-        EXPECT_EQ(spy.count(), 1);
-        EXPECT_EQ(spy.at(0).at(0).toString(), taskId);
-    } else {
-        EXPECT_TRUE(true);
-    }
-}
-
-TEST_F(TestTaskCommander, CompleteWorkflow_StartSearchGetResultsStop)
-{
-    // Mock all operations for complete workflow
-    stub.set_lamda(&QThread::start, [] {
-        __DBG_STUB_INVOKE__
-    });
-
-    stub.set_lamda(&QThread::quit, [](QThread *) {
-        __DBG_STUB_INVOKE__
-    });
-
-    DFMSearchResultMap mockResults;
-    QList<QUrl> mockUrls;
-
-    if (commander) {
-        // Complete workflow test
-        bool startResult = commander->start();
-        QString retrievedTaskId = commander->taskID();
-        DFMSearchResultMap results = commander->getResults();
-        QList<QUrl> urls = commander->getResultsUrls();
-        commander->stop();
-
-        EXPECT_TRUE(true);
-    } else {
-        // Mock complete workflow
-        stub.set_lamda(&TaskCommander::start, [](TaskCommander *) -> bool {
-            __DBG_STUB_INVOKE__
-            return true;
-        });
-
-        stub.set_lamda(&TaskCommander::taskID, [this](TaskCommander *) -> QString {
-            __DBG_STUB_INVOKE__
-            return this->taskId;
-        });
-
-        stub.set_lamda(&TaskCommander::getResults, [&mockResults](TaskCommander *) -> DFMSearchResultMap {
-            __DBG_STUB_INVOKE__
-            return mockResults;
-        });
-
-        stub.set_lamda(&TaskCommander::getResultsUrls, [&mockUrls](TaskCommander *) -> QList<QUrl> {
-            __DBG_STUB_INVOKE__
-            return mockUrls;
-        });
-
-        stub.set_lamda(&TaskCommander::stop, [](TaskCommander *) {
-            __DBG_STUB_INVOKE__
-        });
-
-        EXPECT_TRUE(true);
-    }
-}
-
-TEST_F(TestTaskCommander, MultipleStartStop_HandlesCorrectly)
-{
-    // Test multiple start/stop cycles
-
-    // Mock operations
-    stub.set_lamda(&QThread::start, [] {
-        __DBG_STUB_INVOKE__
-    });
-
-    stub.set_lamda(&QThread::quit, [](QThread *) {
-        __DBG_STUB_INVOKE__
-    });
-
-    if (commander) {
-        // Multiple cycles
-        for (int i = 0; i < 3; ++i) {
-            commander->start();
-            commander->stop();
-        }
-
-        EXPECT_TRUE(true);
-    } else {
-        // Mock multiple cycles
-        stub.set_lamda(&TaskCommander::start, [](TaskCommander *) -> bool {
-            __DBG_STUB_INVOKE__
-            return true;
-        });
-
-        stub.set_lamda(&TaskCommander::stop, [](TaskCommander *) {
-            __DBG_STUB_INVOKE__
-        });
-
-        EXPECT_TRUE(true);
-    }
-}
-
-TEST_F(TestTaskCommander, SignalEmissionSequence_MatchedThenFinished)
-{
-    if (commander) {
-        QSignalSpy matchedSpy(commander, &TaskCommander::matched);
-        QSignalSpy finishedSpy(commander, &TaskCommander::finished);
-        QSignalSpy threadFinishedSpy(commander, &TaskCommander::threadFinished);
-
-        // Simulate signal emission sequence
-        emit commander->matched(taskId);
-        emit commander->threadFinished(taskId);
-        emit commander->finished(taskId);
-
-        EXPECT_EQ(matchedSpy.count(), 1);
-        EXPECT_EQ(threadFinishedSpy.count(), 1);
-        EXPECT_EQ(finishedSpy.count(), 1);
-    } else {
-        EXPECT_TRUE(true);
-    }
-}
-
-TEST_F(TestTaskCommander, GetResults_WithNoSearchExecuted_ReturnsEmptyResults)
-{
-    // Test getting results when no search has been executed
-
-    if (commander) {
-        DFMSearchResultMap results = commander->getResults();
-        QList<QUrl> urls = commander->getResultsUrls();
-
-        // Results should be empty or valid empty containers
-        EXPECT_TRUE(true);
-    } else {
-        // Mock empty results
-        stub.set_lamda(&TaskCommander::getResults, [](TaskCommander *) -> DFMSearchResultMap {
-            __DBG_STUB_INVOKE__
-            return DFMSearchResultMap();
-        });
-
-        stub.set_lamda(&TaskCommander::getResultsUrls, [](TaskCommander *) -> QList<QUrl> {
-            __DBG_STUB_INVOKE__
-            return QList<QUrl>();
-        });
-
-        EXPECT_TRUE(true);
-    }
-}


### PR DESCRIPTION
Added comprehensive unit tests for search plugin components
including TextIndexStatusBar, CheckBoxWidthTextIndex, DFMSearcher,
IteratorSearcher, and related classes. The tests cover constructor
validation, method behavior, signal emission, thread safety, and
integration scenarios. Key improvements include mocking Qt widget
operations to prevent actual UI interactions, testing edge cases like
null iterators and empty results, and verifying proper cleanup in
destructors. Added new test file for SearchEventCaller to cover event
handling functionality.

Log: Added comprehensive unit tests for search plugin

Influence:
1. Run all unit tests to verify no regressions
2. Test search functionality with various file types and directories
3. Verify UI components handle null states correctly
4. Test concurrent access scenarios for thread safety
5. Validate search result processing and signal emission
6. Check proper cleanup when stopping searches

test: 扩展搜索插件组件的单元测试覆盖率

为搜索插件组件添加了全面的单元测试，包括 TextIndexStatusBar、
CheckBoxWidthTextIndex、DFMSearcher、IteratorSearcher 及相关类。测试涵
盖构造函数验证、方法行为、信号发射、线程安全性和集成场景。主要改进包括模
拟 Qt 小部件操作以防止实际 UI 交互，测试空迭代器和空结果等边界情况，以及
验证析构函数中的正确清理。新增 SearchEventCaller 测试文件以覆盖事件处理
功能。

Log: 新增搜索插件全面单元测试

Influence:
1. 运行所有单元测试以验证无回归
2. 使用各种文件类型和目录测试搜索功能
3. 验证 UI 组件正确处理空状态
4. 测试并发访问场景的线程安全性
5. 验证搜索结果处理和信号发射
6. 检查停止搜索时的正确清理
