### PR TITLE
fix: update error message for EACCES error code

### DIFF
--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -164,7 +164,7 @@ void DialogManager::showErrorDialogWhenOperateDeviceFailed(OperateType type, DFM
         else if (err.code == DeviceError::kDaemonErrorCannotMkdirMountPoint)
             errMsg = tr("Cannot create the mountpoint: the file name is too long");
         else if (static_cast<int>(err.code) == EACCES)
-            errMsg = tr("Authentication failed");
+            errMsg = tr("Permission denied");
         else if (static_cast<int>(err.code) == ENOENT)
             errMsg = tr("No such file or directory");
         else


### PR DESCRIPTION
Changed error message from "Authentication failed" to "Permission
denied" for EACCES error code
This change provides more accurate and specific error information to
users when file system operations fail due to permission issues
The EACCES error code specifically indicates permission denial rather
than general authentication failure

Log: Updated error message for permission denied cases

Influence:
1. Test device operations that trigger permission denied errors
2. Verify error dialog shows "Permission denied" instead of
"Authentication failed"
3. Check consistency with other permission-related error messages
4. Test various file operations that may encounter EACCES errors

fix: 更新 EACCES 错误代码的错误消息

将 EACCES 错误代码的错误消息从"认证失败"更改为"权限被拒绝"
此更改在文件系统操作因权限问题失败时为用户提供更准确和具体的错误信息
EACCES 错误代码专门表示权限被拒绝，而非一般的认证失败

Log: 更新权限被拒绝情况下的错误提示信息

Influence:
1. 测试触发权限被拒绝错误的设备操作
2. 验证错误对话框显示"权限被拒绝"而非"认证失败"
3. 检查与其他权限相关错误消息的一致性
4. 测试可能遇到 EACCES 错误的各种文件操作

BUG: https://pms.uniontech.com/bug-view-339135.html

## Summary by Sourcery

Bug Fixes:
- Correct the error message for EACCES to "Permission denied" when file operations fail due to permission denial