### PR TITLE
fix: skip file existence check in SMB mount handling

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1064,8 +1064,9 @@ bool LocalFileHandlerPrivate::doOpenFiles(const QList<QUrl> &urls, const QString
             continue;
         }
 
+        // Do not check the file exists, as it may affect the SMB connection mounting
         FileInfoPointer info = InfoFactory::create<FileInfo>(url);
-        if (!info || !info->exists()) {
+        if (!info) {
             qCWarning(logDFMBase) << "Failed to create FileInfo for:" << url;
             transUrls.removeOne(url);
             continue;


### PR DESCRIPTION
Remove the file existence check when opening files to prevent issues
with SMB connection mounting. The previous implementation would
incorrectly filter out valid SMB mount points during the file opening
process because it checked if the file exists before mounting, which
could fail for network locations that require authentication or
connection establishment.

The change modifies the condition to only check if the FileInfo object
was created successfully, without verifying file existence. This ensures
SMB mounts can proceed properly while still maintaining basic error
handling for invalid URLs.

Log: Fixed issue where SMB network drives would fail to mount when
opening files

Influence:
1. Test opening SMB network locations that require authentication
2. Verify local file opening still works correctly
3. Test with various network drive configurations
4. Check error handling for truly invalid URLs
5. Verify file operations on successfully mounted SMB shares

fix: 修复SMB挂载处理中跳过文件存在性检查

移除打开文件时的文件存在性检查，以防止SMB连接挂载出现问题。之前的实现会
在挂载前检查文件是否存在，这会导致需要认证或连接建立的网络位置被错误过
滤掉。

修改后的条件仅检查FileInfo对象是否创建成功，不再验证文件是否存在。这确保
了SMB挂载可以正常进行，同时仍对无效URL保持基本的错误处理。

Log: 修复了打开文件时SMB网络驱动器无法挂载的问题

Influence:
1. 测试需要认证的SMB网络位置的打开
2. 验证本地文件打开功能正常
3. 测试各种网络驱动器配置
4. 检查对真正无效URL的错误处理
5. 验证在成功挂载的SMB共享上的文件操作

BUG: https://pms.uniontech.com/bug-view-340311.html

## Summary by Sourcery

Bug Fixes:
- Remove file existence verification before opening files to prevent valid SMB network shares from being incorrectly filtered out.