### PR TITLE
chore: bump verison to 6.5.106

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.106) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 20 Nov 2025 22:37:15 +0800
+
 dde-file-manager (6.5.105) unstable; urgency=medium
 
   * fix bugs


### PR DESCRIPTION
6.5.106

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 6.5.106