### PR TITLE
feat: implement clipboard image paste functionality

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -275,6 +275,9 @@ private:
                                  const QVariant &custom,
                                  DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callbackImmediately);
     bool doTouchFilePractically(const quint64 windowId, const QUrl &url, const QUrl &tempUrl = QUrl());
+    QString doTouchFileFromClipboard(const quint64 windowId, const QUrl &url,
+                                     const QString &suffix, const QVariant &custom,
+                                     DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callbackImmediately);
     void saveFileOperation(const QList<QUrl> &sourcesUrls, const QList<QUrl> &targetUrls,
                            DFMBASE_NAMESPACE::GlobalEventType type,
                            const QList<QUrl> &redoSourcesUrls, const QList<QUrl> &redoTargetUrls,

--- a/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
@@ -17,6 +17,9 @@
 
 #include <QMenu>
 #include <QVariant>
+#include <QClipboard>
+#include <QMimeData>
+#include <QApplication>
 
 Q_DECLARE_METATYPE(QList<QUrl> *)
 
@@ -121,7 +124,13 @@ void ClipBoardMenuScene::updateState(QMenu *parent)
                 return;
 
             curDirInfo->refresh();
-            bool disabled = (ClipBoard::instance()->clipboardAction() == ClipBoard::kUnknownAction)
+
+            // 检查是否有传统的剪贴板action或者是否有图像数据
+            const QMimeData *mimeData = QApplication::clipboard()->mimeData();
+            bool hasValidClipboardData = (ClipBoard::instance()->clipboardAction() != ClipBoard::kUnknownAction)
+                                        || (mimeData && mimeData->hasImage());
+
+            bool disabled = !hasValidClipboardData
                     || !curDirInfo->isAttributes(OptInfoType::kIsWritable);
             paste->setDisabled(disabled);
         }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.h
@@ -48,6 +48,8 @@ public:
 private:
     explicit FileOperatorHelper(QObject *parent = nullptr);
     void callBackFunction(const DFMBASE_NAMESPACE::AbstractJobHandler::CallbackArgus args);
+    bool pasteTraditionalFiles(const FileView *view);
+    void pasteClipboardImage(const FileView *view);
     void undoCallBackFunction(QSharedPointer<DFMBASE_NAMESPACE::AbstractJobHandler> handler);
 
     DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback callBack;


### PR DESCRIPTION
Added support for pasting images from clipboard as files through the kTouchFile event system. The implementation centralizes image handling logic in FileOperationsEventReceiver with new doTouchFileFromClipboard method, replacing scattered implementations across different plugins. All clipboard image operations now flow through the standard file operations pipeline for consistency.

Key changes:
1. Added clipboard image detection in doTouchFilePremature
2. Created new doTouchFileFromClipboard method for centralized image handling
3. Modified FileOperatorProxy and FileOperatorHelper to use new kTouchFile mechanism
4. Added proper callbacks for post-operation file selection
5. Included undo/redo support for image operations
6. Added proper error handling and logging

Log: Added support for pasting clipboard images as files

Influence:
1. Test clipboard image paste in various directories
2. Verify filename generation with different formats
3. Test undo/redo functionality for image operations
4. Verify error handling when clipboard has no image data
5. Check performance with large clipboard images
6. Test paste operations with different image formats
7. Verify file selection after paste operation

feat: 实现剪贴板图片粘贴功能

新增通过kTouchFile事件系统将剪贴板中的图像作为文件粘贴的支持。
该实现将图像处理逻辑集中在FileOperationsEventReceiver新增的
doTouchFileFromClipboard方法中，取代了原先分散在不同插件中的实现。现在所
有剪贴板图像操作都通过标准的文件操作流程执行以提高一致性。

主要变更：
1. 在doTouchFilePremature中添加剪贴板图像检测
2. 创建新的doTouchFileFromClipboard方法进行集中式图像处理
3. 修改FileOperatorProxy和FileOperatorHelper使用新的kTouchFile机制
4. 添加适当的回调函数实现操作后的文件选择
5. 包含图像操作的撤销/重做支持
6. 添加完善的错误处理和日志记录

Log: 新增剪贴板图片粘贴文件的支持

Influence:
1. 测试在不同目录中粘贴剪贴板图片
2. 验证不同格式的文件名生成
3. 测试图像操作的撤销/重做功能
4. 验证剪贴板无图像数据时的错误处理
5. 检查处理大型剪贴板图像的性能表现
6. 测试不同图像格式的粘贴操作
7. 验证粘贴操作后的文件选择功能