### PR TITLE
feat: [udf-finalize] support UDF disc finalization option

### DIFF
--- a/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
@@ -297,7 +297,7 @@ void BurnOptDialog::onIndexChanged(int index)
         checkdiscCheckbox->setChecked(false);
         checkdiscCheckbox->setEnabled(false);
         donotcloseComb->setChecked(true);
-        donotcloseComb->setEnabled(false);
+        // donotcloseComb->setEnabled(false);
         writespeedComb->setCurrentIndex(0);
         writespeedComb->setEnabled(false);
     } else {


### PR DESCRIPTION
- Enable the "Keep disc appendable" checkbox for UDF burning mode
- Allow users to choose whether to finalize the UDF disc
- Previously the checkbox was force-disabled for UDF format

Log: Enable UDF disc finalization control by removing the forced disable of donotcloseComb checkbox in UDF burning mode
Change-Id: I7e16cf64bdd85ae36048ae5136399895be530a2c

## Summary by Sourcery

New Features:
- Expose UDF disc finalization option in the burn options dialog so users can keep the disc appendable or finalize it.