### PR TITLE
feat: [joliet-longname] increase Joliet filename and path length limits

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/burncheckstrategy.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burncheckstrategy.cpp
@@ -15,8 +15,8 @@ static constexpr int kMaxCommontFilePathBytes { 1024 };
 
 static constexpr int kMaxISO9660FileNameSize { 32 };
 
-static constexpr int kMaxJolietFileNameSize { 64 };
-static constexpr int kMaxJolietFilePathSize { 120 };
+static constexpr int kMaxJolietFileNameSize { 103 };
+static constexpr int kMaxJolietFilePathSize { 800 };
 
 BurnCheckStrategy::BurnCheckStrategy(const QString &path, QObject *parent)
     : QObject(parent), currentStagePath(path)


### PR DESCRIPTION
- Increased Joliet filename size limit from 64 to 103 characters
- Increased Joliet file path size limit from 120 to 800 characters

Log: Enhanced Joliet filesystem support with larger filename and path limits for disc burning
Change-Id: I75bbc6a9035010e37f0fb4a3f95b1afcdb1660cc

## Summary by Sourcery

Increase allowable Joliet filename and path lengths for disc burning validation.

New Features:
- Support longer Joliet filenames up to the new size limit during burn checks.
- Support longer Joliet file paths up to the new size limit during burn checks.