### PR TITLE
refactor: remove redundant UI configurations

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
@@ -279,11 +279,6 @@ void FilePreviewDialog::initUI()
     layout->addLayout(separatorLayout, 1);
     layout->addWidget(statusBar, 0, Qt::AlignBottom);
 
-    QAction *shortcutAction = new QAction(this);
-
-    shortcutAction->setShortcut(QKeySequence::Copy);
-    addAction(shortcutAction);
-
     connect(statusBar->preButton(), &QPushButton::clicked, this, &FilePreviewDialog::previousPage);
     connect(statusBar->nextButton(), &QPushButton::clicked, this, &FilePreviewDialog::nextPage);
     connect(statusBar->openButton(), &QPushButton::clicked, this, &FilePreviewDialog::openFile);

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textbrowseredit.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textbrowseredit.cpp
@@ -18,8 +18,6 @@ TextBrowserEdit::TextBrowserEdit(QWidget *parent)
     setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
     setLineWrapMode(QPlainTextEdit::WidgetWidth);
     setFixedSize(800, 500);
-    setFocusPolicy(Qt::NoFocus);
-    setContextMenuPolicy(Qt::NoContextMenu);
     setFrameStyle(QFrame::NoFrame);
 
     connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &TextBrowserEdit::scrollbarValueChange);


### PR DESCRIPTION
1. Removed unused copy shortcut action initialization in FilePreviewDialog
2. Removed unnecessary focus and context menu restrictions from TextBrowserEdit

The copy shortcut action was added but never used or connected to any handler, making it redundant. For TextBrowserEdit, the focus and context menu restrictions were overly restrictive since the component already inherits appropriate behaviors from QPlainTextEdit. These cleanups simplify the code without affecting functionality.

Influence:
1. Verify text selection still works correctly in preview dialog
2. Check keyboard navigation works properly in text preview
3. Ensure context menu appears when expected in text preview
4. Verify clipboard operations work as intended without the shortcut action

refactor: 移除冗余的UI配置

1. 移除了FilePreviewDialog中未使用的复制快捷键动作初始化
2. 移除了TextBrowserEdit中不必要的焦点和上下文菜单限制

复制快捷键动作被添加但从未使用或连接到任何处理器，使其变得冗余。对于
TextBrowserEdit来说，焦点和上下文菜单的限制过于严格，因为该组件已经从
QPlainTextEdit继承了适当的行为。这些清理工作在不影响功能的情况下简化了
代码。

Influence:
1. 验证预览对话框中文本选择仍能正常工作
2. 检查文本预览中键盘导航是否正确
3. 确保文本预览中上下文菜单在需要时能正常显示
4. 验证移除快捷键动作后剪贴板操作仍能正常运行

## Summary by Sourcery

Simplify text preview UI configuration by removing redundant actions and restrictions that are no longer needed.

Enhancements:
- Remove an unused copy keyboard shortcut action from the file preview dialog.
- Relax unnecessary focus and context menu restrictions on the text preview editor to rely on default QPlainTextEdit behavior.