### PR TITLE
fix: migrate autostart management to ApplicationManager1

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -26,7 +26,7 @@ public:
     void resumeEncrypt(const QString &device);
     QString holderDevice(const QString &device);
     bool onAcquireDevicePwd(const QString &dev, QString *pwd, bool *giveup);
-    void autoStartDFM();
+    void setAutoStartDFM(bool enable);
 
 private Q_SLOTS:
     void onEncryptProgress(const QString &, const QString &, double);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -474,7 +474,7 @@ void DiskEncryptMenuScene::doDecryptDevice(const DeviceEncryptParam &param)
     fmDebug() << "Calling Decryption D-Bus method via fd";
     if (sendCredentialsViaFd(iface, "Decryption", params, false)) {
         QApplication::setOverrideCursor(Qt::WaitCursor);
-        EventsHandler::instance()->autoStartDFM();
+        EventsHandler::instance()->setAutoStartDFM(true);
     } else {
         fmCritical() << "Decryption failed to start";
     }


### PR DESCRIPTION
- Replace deprecated SessionManager AddAutostart method with ApplicationManager1 AutoStart property
- Refactor autoStartDFM() to setAutoStartDFM(bool enable) for bidirectional control
- Enable autostart when encryption/decryption begins, disable when operations complete
- Use DUtil helpers for proper app ID extraction and DBus path escaping
- Remove manual autostart file deletion in favor of property-based management

Log: Migrate from SessionManager AddAutostart to ApplicationManager1 AutoStart property for managing file manager autostart behavior during disk encryption operations

Bug: https://pms.uniontech.com/bug-view-340269.html

## Summary by Sourcery

Manage disk encryption file manager autostart via ApplicationManager1 AutoStart property instead of SessionManager AddAutostart and manual desktop file removal.

New Features:
- Allow enabling and disabling the file manager autostart state bidirectionally through a new setAutoStartDFM(bool) helper.

Bug Fixes:
- Ensure file manager autostart is correctly disabled after encryption or decryption completes instead of relying on manual autostart file deletion.

Enhancements:
- Use DUtil helpers to derive the application ID and escape it for D-Bus object paths when configuring ApplicationManager1.
- Replace direct SessionManager AddAutostart calls with property-based autostart management on ApplicationManager1 applications.