### PR TITLE
340959

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -113,7 +113,10 @@ void EncryptProgressDialog::initUI()
     progressLay->addWidget(progress, 0, Qt::AlignCenter);
     progress->start();
 
+    const int kMessageLabelLen = 380;
+
     message = new QLabel(this);
+    message->setMinimumWidth(kMessageLabelLen);
     message->setWordWrap(true);
     message->setAlignment(Qt::AlignCenter);
     progressLay->addWidget(message, 0, Qt::AlignCenter);
@@ -128,11 +131,13 @@ void EncryptProgressDialog::initUI()
     resultLay->addWidget(iconLabel, 0, Qt::AlignCenter);
 
     resultMsg = new QLabel(this);
+    resultMsg->setMinimumWidth(kMessageLabelLen);
     resultMsg->setWordWrap(true);
     resultMsg->setAlignment(Qt::AlignCenter);
     resultLay->addWidget(resultMsg, 0, Qt::AlignCenter);
 
     warningLabel = new QLabel(this);
+    warningLabel->setMinimumWidth(kMessageLabelLen);
     resultLay->addWidget(warningLabel);
     QPalette pal = warningLabel->palette();
     pal.setColor(QPalette::WindowText, QColor("red"));

--- a/translations/dde-file-manager_zh_CN.ts
+++ b/translations/dde-file-manager_zh_CN.ts
@@ -4849,7 +4849,7 @@ Enter user and password for %1</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="204"/>
         <source>Enable partition encryption</source>
-        <translation>启用分区加密</translation>
+        <translation>开启分区加密</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp" line="296"/>


### PR DESCRIPTION
- **fix: adjust dialog size when message text wraps**
- **fix: update Chinese translation for partition encryption**

## Summary by Sourcery

Adjust disk encryption progress dialog layout and update Chinese translation for partition encryption text.

Bug Fixes:
- Prevent overly narrow message labels in the disk encryption progress dialog by enforcing a minimum width so wrapped text displays properly.
- Refine the Simplified Chinese translation for the "Enable partition encryption" menu entry to use more appropriate wording.