### PR TITLE
refactor: reorganize PolicyKitHelper usage across services

### DIFF
--- a/autotests/services/accesscontrol/test_accesscontrol.cpp
+++ b/autotests/services/accesscontrol/test_accesscontrol.cpp
@@ -20,12 +20,14 @@
 #include "accesscontroldbus.h"
 #include "polkit/policykithelper.h"
 #include "utils.h"
+
 #include <dfm-base/base/device/deviceutils.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-mount/dblockmonitor.h>
 #include <dfm-mount/dblockdevice.h>
 
 SERVICEACCESSCONTROL_USE_NAMESPACE
+using ServiceCommon::PolicyKitHelper;
 
 class UT_AccessControlDBus : public testing::Test
 {
@@ -380,8 +382,8 @@ TEST_F(UT_AccessControlDBus, OnBlockDevMounted_SystemDevice_NoAction)
 // PolicyKitHelper Tests
 TEST_F(UT_AccessControlPolicyKitHelper, Instance_Singleton_ReturnsSameInstance)
 {
-    SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper *instance1 = SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper::instance();
-    SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper *instance2 = SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper::instance();
+    PolicyKitHelper *instance1 = PolicyKitHelper::instance();
+    PolicyKitHelper *instance2 = PolicyKitHelper::instance();
 
     EXPECT_EQ(instance1, instance2);
     EXPECT_NE(instance1, nullptr);
@@ -389,14 +391,14 @@ TEST_F(UT_AccessControlPolicyKitHelper, Instance_Singleton_ReturnsSameInstance)
 
 TEST_F(UT_AccessControlPolicyKitHelper, CheckAuthorization_EmptyBusName_ReturnsFalse)
 {
-    SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper *helper = SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper::instance();
+    PolicyKitHelper *helper = PolicyKitHelper::instance();
     bool result = helper->checkAuthorization("test.action", "");
     EXPECT_FALSE(result);
 }
 
 TEST_F(UT_AccessControlPolicyKitHelper, CheckAuthorization_ValidParameters_CallsPolkitQt)
 {
-    SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper *helper = SERVICEACCESSCONTROL_NAMESPACE::PolicyKitHelper::instance();
+    PolicyKitHelper *helper = PolicyKitHelper::instance();
     // This test would require more complex mocking of PolkitQt1 classes
     // For now, we test the basic parameter validation
     bool result = helper->checkAuthorization("test.action", "org.test.service");

--- a/autotests/services/sharecontrol/test_sharecontrol.cpp
+++ b/autotests/services/sharecontrol/test_sharecontrol.cpp
@@ -21,11 +21,13 @@
 #include <algorithm>
 
 // Include the classes under test
+#include "service_sharecontrol_global.h"
 #include "sharecontroldbus.h"
 #include "polkit/policykithelper.h"
 #include <dfm-base/utils/fileutils.h>
 
 SERVICESHARECONTROL_USE_NAMESPACE
+using ServiceCommon::PolicyKitHelper;
 
 class UT_ShareControlDBus : public testing::Test
 {

--- a/src/services/DFMServiceCommon.cmake
+++ b/src/services/DFMServiceCommon.cmake
@@ -2,21 +2,24 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Setup service common resources (e.g. shared PolicyKitHelper)
-# Usage:
-#   FILE(GLOB YOUR_FILES ...)
-#   dfm_setup_service_polkit(YOUR_FILES)
-#   add_library(${PROJECT_NAME} SHARED ${YOUR_FILES})
-function(dfm_setup_service_polkit FILES_VAR)
-    # Exclude old polkit files from individual services
-    list(FILTER ${FILES_VAR} EXCLUDE REGEX "polkit/policykithelper\\.(h|cpp)$")
+# Setup service polkit helper for existing target (after add_library)
+# Usage for target mode (in dependencies.cmake):
+#   function(dfm_setup_xxx_dependencies target_name)
+#       dfm_apply_service_polkit_to_target(${target_name})
+#       ...
+#   endfunction()
+function(dfm_apply_service_polkit_to_target target_name)
+    message(STATUS "DFM: Applying shared polkit helper to target: ${target_name}")
 
     # Add common polkit helper implementation
-    list(APPEND ${FILES_VAR} "${CMAKE_CURRENT_SOURCE_DIR}/../common/polkit/policykithelper.cpp")
-
-    # Return modified list to caller
-    set(${FILES_VAR} ${${FILES_VAR}} PARENT_SCOPE)
+    target_sources(${target_name} PRIVATE
+        ${DFM_SOURCE_DIR}/services/common/polkit/policykithelper.cpp
+    )
 
     # Include common directory for shared headers
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
+    target_include_directories(${target_name} PRIVATE
+        ${DFM_SOURCE_DIR}/services/common
+    )
+
+    message(STATUS "DFM: Shared polkit helper applied successfully")
 endfunction()

--- a/src/services/accesscontrol/CMakeLists.txt
+++ b/src/services/accesscontrol/CMakeLists.txt
@@ -18,9 +18,6 @@ FILE(GLOB FILEOPERATIONS_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/*/*.policy"
     )
 
-# Setup common service resources (polkit helper, etc.)
-dfm_setup_service_polkit(FILEOPERATIONS_FILES)
-
 add_library(${PROJECT_NAME}
     SHARED
     ${FILEOPERATIONS_FILES}

--- a/src/services/accesscontrol/dependencies.cmake
+++ b/src/services/accesscontrol/dependencies.cmake
@@ -6,19 +6,23 @@ cmake_minimum_required(VERSION 3.10)
 # Function to setup accesscontrol service dependencies
 function(dfm_setup_accesscontrol_dependencies target_name)
     message(STATUS "DFM: Setting up accesscontrol service dependencies for: ${target_name}")
-    
+
     # Find required packages
     find_package(PkgConfig REQUIRED)
     find_package(Qt6 REQUIRED COMPONENTS DBus)
-    
+
     # Find system dependencies using pkg-config
     pkg_search_module(crypt REQUIRED libcryptsetup IMPORTED_TARGET)
     pkg_check_modules(PolkitAgent REQUIRED polkit-agent-1 IMPORTED_TARGET)
     pkg_check_modules(PolkitQt6 REQUIRED polkit-qt6-1 IMPORTED_TARGET)
-    
+
     # Apply default service configuration first
     dfm_apply_default_service_config(${target_name})
-    
+
+    # Include service common utilities and apply shared polkit helper
+    include(${DFM_SOURCE_DIR}/services/DFMServiceCommon.cmake)
+    dfm_apply_service_polkit_to_target(${target_name})
+
     # Add accesscontrol-specific dependencies
     target_link_libraries(${target_name} PRIVATE
         Qt6::DBus
@@ -26,10 +30,10 @@ function(dfm_setup_accesscontrol_dependencies target_name)
         PkgConfig::PolkitAgent
         PkgConfig::PolkitQt6
     )
-    
+
     # Setup DBus adaptor for accesscontrol
     dfm_setup_accesscontrol_dbus_interfaces(${target_name})
-    
+
     message(STATUS "DFM: Access control service dependencies configured successfully")
 endfunction()
 

--- a/src/services/mountcontrol/CMakeLists.txt
+++ b/src/services/mountcontrol/CMakeLists.txt
@@ -18,9 +18,6 @@ FILE(GLOB FILEOPERATIONS_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.policy"
     )
 
-# Setup common service resources (polkit helper, etc.)
-dfm_setup_service_polkit(FILEOPERATIONS_FILES)
-
 add_library(${PROJECT_NAME}
     SHARED
     ${FILEOPERATIONS_FILES}

--- a/src/services/mountcontrol/dependencies.cmake
+++ b/src/services/mountcontrol/dependencies.cmake
@@ -6,19 +6,23 @@ cmake_minimum_required(VERSION 3.10)
 # Function to setup mountcontrol service dependencies
 function(dfm_setup_mountcontrol_dependencies target_name)
     message(STATUS "DFM: Setting up mountcontrol service dependencies for: ${target_name}")
-    
+
     # Find required packages
     find_package(PkgConfig REQUIRED)
     find_package(Qt6 REQUIRED COMPONENTS DBus)
-    
+
     # Find system dependencies using pkg-config
     pkg_check_modules(PolkitAgent REQUIRED polkit-agent-1)
     pkg_check_modules(PolkitQt6 REQUIRED polkit-qt6-1)
     pkg_check_modules(mount REQUIRED mount IMPORTED_TARGET)
-    
+
     # Apply default service configuration first
     dfm_apply_default_service_config(${target_name})
-    
+
+    # Include service common utilities and apply shared polkit helper
+    include(${DFM_SOURCE_DIR}/services/DFMServiceCommon.cmake)
+    dfm_apply_service_polkit_to_target(${target_name})
+
     # Add mountcontrol-specific dependencies
     target_link_libraries(${target_name} PRIVATE
         Qt6::DBus
@@ -26,10 +30,10 @@ function(dfm_setup_mountcontrol_dependencies target_name)
         ${PolkitQt6_LIBRARIES}
         PkgConfig::mount
     )
-    
+
     # Setup DBus adaptor for mountcontrol
     dfm_setup_mountcontrol_dbus_interfaces(${target_name})
-    
+
     message(STATUS "DFM: Mount control service dependencies configured successfully")
 endfunction()
 

--- a/src/services/sharecontrol/CMakeLists.txt
+++ b/src/services/sharecontrol/CMakeLists.txt
@@ -18,9 +18,6 @@ FILE(GLOB FILEOPERATIONS_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/*/*.policy"
     )
 
-# Setup common service resources (polkit helper, etc.)
-dfm_setup_service_polkit(FILEOPERATIONS_FILES)
-
 add_library(${PROJECT_NAME}
     SHARED
     ${FILEOPERATIONS_FILES}

--- a/src/services/sharecontrol/dependencies.cmake
+++ b/src/services/sharecontrol/dependencies.cmake
@@ -6,27 +6,31 @@ cmake_minimum_required(VERSION 3.10)
 # Function to setup sharecontrol service dependencies
 function(dfm_setup_sharecontrol_dependencies target_name)
     message(STATUS "DFM: Setting up sharecontrol service dependencies for: ${target_name}")
-    
+
     # Find required packages
     find_package(PkgConfig REQUIRED)
     find_package(Qt6 REQUIRED COMPONENTS DBus)
-    
+
     # Find system dependencies using pkg-config
     pkg_check_modules(PolkitAgent REQUIRED polkit-agent-1)
     pkg_check_modules(PolkitQt6 REQUIRED polkit-qt6-1)
-    
+
     # Apply default service configuration first
     dfm_apply_default_service_config(${target_name})
-    
+
+    # Include service common utilities and apply shared polkit helper
+    include(${DFM_SOURCE_DIR}/services/DFMServiceCommon.cmake)
+    dfm_apply_service_polkit_to_target(${target_name})
+
     # Add sharecontrol-specific dependencies
     target_link_libraries(${target_name} PRIVATE
         ${PolkitAgent_LIBRARIES}
         ${PolkitQt6_LIBRARIES}
     )
-    
+
     # Setup DBus adaptor for sharecontrol
     dfm_setup_sharecontrol_dbus_interfaces(${target_name})
-    
+
     message(STATUS "DFM: Share control service dependencies configured successfully")
 endfunction()
 

--- a/src/services/tpmcontrol/CMakeLists.txt
+++ b/src/services/tpmcontrol/CMakeLists.txt
@@ -18,9 +18,6 @@ FILE(GLOB TPMCONTROL_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/*/*.policy"
     )
 
-# Setup common service resources (polkit helper, etc.)
-dfm_setup_service_polkit(TPMCONTROL_FILES)
-
 add_library(${PROJECT_NAME}
     SHARED
     ${TPMCONTROL_FILES}

--- a/src/services/tpmcontrol/dependencies.cmake
+++ b/src/services/tpmcontrol/dependencies.cmake
@@ -18,6 +18,10 @@ function(dfm_setup_tpmcontrol_dependencies target_name)
     # Apply default service configuration first
     dfm_apply_default_service_config(${target_name})
 
+    # Include service common utilities and apply shared polkit helper
+    include(${DFM_SOURCE_DIR}/services/DFMServiceCommon.cmake)
+    dfm_apply_service_polkit_to_target(${target_name})
+
     # Add tpmcontrol-specific dependencies
     target_link_libraries(${target_name} PRIVATE
         Qt6::DBus


### PR DESCRIPTION
The changes reorganize how PolicyKitHelper is used across multiple services by:
1. Moving PolicyKitHelper implementation to common folder for shared usage
2. Adding target-based CMake function dfm_apply_service_polkit_to_target()
3. Removing redundant PolicyKitHelper setups from individual CMakeLists.txt
4. Updating test cases to use the common namespace alias
5. Ensuring consistent include paths for PolicyKitHelper headers

This refactoring reduces code duplication and improves maintainability by centralizing the PolicyKit helper implementation while maintaining identical functionality.

Influence:
1. Verify all service modules still build correctly
2. Test existing PolicyKit authorization functionality
3. Validate inter-service dependencies haven't been broken
4. Confirm DBus interfaces remain unchanged

refactor: 重构 PolicyKitHelper 在各服务的统一使用方式

本次变更通过以下方式重构了 PolicyKitHelper 在多个服务中的使用：
1. 将 PolicyKitHelper 实现移至公共文件夹供共享使用
2. 新增基于目标的 CMake 函数 dfm_apply_service_polkit_to_target()
3. 从各服务的 CMakeLists.txt 中移除冗余的 PolicyKitHelper 设置
4. 更新测试用例以使用共用命名空间别名
5. 确保 PolicyKitHelper 头文件的包含路径一致

这项重构通过集中 PolicyKit 辅助功能的实现减少了代码重复，提高了可维护
性，同时保持了原有功能不变。

Influence:
1. 验证所有服务模块仍能正确构建
2. 测试现有的 PolicyKit 授权功能
3. 确保服务间依赖关系未被破坏
4. 确认 DBus 接口保持不变

## Summary by Sourcery

Centralize PolicyKitHelper integration for services and switch to a target-based CMake helper.

Enhancements:
- Introduce dfm_apply_service_polkit_to_target() to attach the shared PolicyKitHelper implementation and include paths to existing service targets.
- Refactor accesscontrol, mountcontrol, sharecontrol, and tpmcontrol services to consume the shared PolicyKitHelper via their dependencies.cmake instead of per-target file list manipulation.
- Adjust unit tests to use the common ServiceCommon::PolicyKitHelper alias, reflecting the shared helper location and namespace.