### PR TITLE
test: add unit tests for dfmplugin-utils components

### DIFF
--- a/autotests/plugins/dfmplugin-utils/test_globaleventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_globaleventreceiver.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/global/globaleventreceiver.h"
+
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-framework/dpf.h>
+
+#include <QProcess>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_GlobalEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new GlobalEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    GlobalEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+// ========== initEventConnect 测试 ==========
+
+TEST_F(UT_GlobalEventReceiver, initEventConnect_SubscribesEvent)
+{
+    bool subscribed = false;
+
+    typedef bool (EventDispatcherManager::*Subscribe)(EventType, GlobalEventReceiver *, decltype(&GlobalEventReceiver::handleOpenAsAdmin));
+    auto subscribe = static_cast<Subscribe>(&dpf::EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe,
+                   [&subscribed] {
+                       __DBG_STUB_INVOKE__
+                       subscribed = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(subscribed);
+}
+
+// ========== handleOpenAsAdmin 测试 ==========
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_InvalidUrl_ReturnsEarly)
+{
+    bool processStarted = false;
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted] {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(QUrl());
+    EXPECT_FALSE(processStarted);
+
+    receiver->handleOpenAsAdmin(QUrl(""));
+    EXPECT_FALSE(processStarted);
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_ValidLocalFile_StartsProcess)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test_file.txt");
+    QString capturedPath;
+    bool processStarted = false;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted, &capturedPath](const QString &program, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return program == "dde-file-manager-pkexec";
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_TRUE(processStarted);
+    EXPECT_EQ(capturedPath, url.toLocalFile());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_DirSymlink_UsesRedirectedPath)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/symlink_dir");
+    QUrl redirectedUrl = QUrl::fromLocalFile("/tmp/real_dir");
+    QString capturedPath;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsDir || type == OptInfoType::kIsSymLink;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, urlOf),
+                   [&redirectedUrl](FileInfo *, const UrlInfoType) -> QUrl {
+                       __DBG_STUB_INVOKE__
+                       return redirectedUrl;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&capturedPath](const QString &, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_EQ(capturedPath, redirectedUrl.toLocalFile());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_NonLocalUrl_UsesUrlString)
+{
+    QUrl url("smb://server/share");
+    QString capturedPath;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&capturedPath](const QString &, const QStringList &args, const QString &, qint64 *) -> bool {
+                       __DBG_STUB_INVOKE__
+                       if (!args.isEmpty())
+                           capturedPath = args[0];
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_EQ(capturedPath, url.toString());
+}
+
+TEST_F(UT_GlobalEventReceiver, handleOpenAsAdmin_NullFileInfo_ContinuesExecution)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test_file.txt");
+    bool processStarted = false;
+
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    using StartDetachedFunc = bool (*)(const QString &, const QStringList &, const QString &, qint64 *);
+    stub.set_lamda(static_cast<StartDetachedFunc>(QProcess::startDetached),
+                   [&processStarted] {
+                       __DBG_STUB_INVOKE__
+                       processStarted = true;
+                       return true;
+                   });
+
+    receiver->handleOpenAsAdmin(url);
+
+    EXPECT_TRUE(processStarted);
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwithdialog.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithdialog.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithdialog.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/mimetype/mimesappsmanager.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-framework/dpf.h>
+
+#include <QCheckBox>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(MimesAppsManager, initMimeTypeApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        stub.set_lamda(qOverload<const QMimeType &>(&MimesAppsManager::getDefaultAppByMimeType),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QString();
+                       });
+
+        stub.set_lamda(ADDR(MimesAppsManager, getRecommendedApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QStringList();
+                       });
+
+        stub.set_lamda(ADDR(MimesAppsManager, getRecommendedAppsByQio),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                           return QStringList();
+                       });
+
+        stub.set_lamda(&InfoFactory::create<FileInfo>,
+                       [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                           __DBG_STUB_INVOKE__
+                           return nullptr;
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithDialog, Constructor_WithUrlList_CreatesDialog)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, Constructor_WithSingleUrl_CreatesDialog)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    OpenWithDialog *dialog = new OpenWithDialog(url);
+
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(UT_OpenWithDialog, openFileByApp_NoCheckedItem_Returns)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    OpenWithDialog *dialog = new OpenWithDialog(urls);
+
+    dialog->openFileByApp();
+
+    delete dialog;
+}
+
+// ========== OpenWithDialogListItem 测试 ==========
+
+class UT_OpenWithDialogListItem : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithDialogListItem, Constructor_CreatesItem)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("application-x-desktop", "Test App");
+
+    EXPECT_NE(item, nullptr);
+    EXPECT_EQ(item->text(), "Test App");
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, setChecked_UpdatesCheckState)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("application-x-desktop", "Test App");
+
+    item->setChecked(true);
+    item->setChecked(false);
+
+    delete item;
+}
+
+TEST_F(UT_OpenWithDialogListItem, text_ReturnsLabelText)
+{
+    OpenWithDialogListItem *item = new OpenWithDialogListItem("icon", "My Application");
+
+    EXPECT_EQ(item->text(), "My Application");
+
+    delete item;
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwitheventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwitheventreceiver.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithdialog.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-framework/dpf.h>
+
+#include <QApplication>
+#include <QWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        receiver = new OpenWithEventReceiver();
+    }
+
+    void TearDown() override
+    {
+        delete receiver;
+        receiver = nullptr;
+        stub.clear();
+    }
+
+    OpenWithEventReceiver *receiver { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithEventReceiver, initEventConnect_ConnectsSlot)
+{
+    bool connected = false;
+
+    typedef bool (EventChannelManager::*Connect)(const QString &, const QString &, OpenWithEventReceiver *, decltype(&OpenWithEventReceiver::showOpenWithDialog));
+    stub.set_lamda(static_cast<Connect>(&EventChannelManager::connect),
+                   [&connected] {
+                       __DBG_STUB_INVOKE__
+                       connected = true;
+                       return true;
+                   });
+
+    receiver->initEventConnect();
+
+    EXPECT_TRUE(connected);
+}
+
+TEST_F(UT_OpenWithEventReceiver, showOpenWithDialog_WithValidWinId_FindsWindow)
+{
+    quint64 winId = 12345;
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    FileManagerWindow mockWindow(QUrl::fromLocalFile("/home"));
+    stub.set_lamda(ADDR(FileManagerWindowsManager, findWindowById),
+                   [&mockWindow] {
+                       __DBG_STUB_INVOKE__
+                       return &mockWindow;
+                   });
+
+    stub.set_lamda(VADDR(OpenWithDialog, exec),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    receiver->showOpenWithDialog(winId, urls);
+}
+
+TEST_F(UT_OpenWithEventReceiver, showOpenWithDialog_WithZeroWinId_NoParent)
+{
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
+
+    stub.set_lamda(VADDR(OpenWithDialog, exec),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return 0;
+                   });
+
+    receiver->showOpenWithDialog(0, urls);
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwithhelper.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithhelper.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithhelper.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithwidget.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_OpenWithHelper : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_InvalidUrl_ReturnsNull)
+{
+    QUrl invalidUrl;
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(invalidUrl);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_NullFileInfo_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_IsDirectory_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/testdir");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType type) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return type == OptInfoType::kIsDir;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_HookDisabled_ReturnsNull)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, bool *&&);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [](EventSequenceManager *, const QString &, const QString &,
+                      const QUrl &, bool *result) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *result = true;
+                       return true;
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OpenWithHelper, createOpenWithWidget_ValidFile_ReturnsWidget)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, isAttributes),
+                   [](FileInfo *, const OptInfoType) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl, bool *&&);
+    stub.set_lamda(static_cast<RunFunc>(&EventSequenceManager::run),
+                   [](EventSequenceManager *, const QString &, const QString &,
+                      const QUrl &, bool *result) -> bool {
+                       __DBG_STUB_INVOKE__
+                       *result = false;
+                       return false;
+                   });
+
+    stub.set_lamda(ADDR(OpenWithWidget, selectFileUrl),
+                   [](OpenWithWidget *, const QUrl &) {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    QWidget *result = OpenWithHelper::createOpenWithWidget(url);
+
+    EXPECT_NE(result, nullptr);
+    if (result)
+        delete result;
+}

--- a/autotests/plugins/dfmplugin-utils/test_openwithwidget.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_openwithwidget.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwithwidget.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/mimetype/mimesappsmanager.h>
+
+#include <DRadioButton>
+#include <QListWidget>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DFMBASE_USE_NAMESPACE
+
+class UT_OpenWithWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(MimesAppsManager, initMimeTypeApps),
+                       [] {
+                           __DBG_STUB_INVOKE__
+                       });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_OpenWithWidget, Constructor_CreatesWidget)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    EXPECT_NE(widget, nullptr);
+    EXPECT_NE(widget->openWithListWidget, nullptr);
+    EXPECT_NE(widget->openWithBtnGroup, nullptr);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, selectFileUrl_SetsCurrentUrl)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+
+    widget->selectFileUrl(url);
+
+    EXPECT_EQ(widget->currentFileUrl, url);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_FalseState_DoesNothing)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    widget->slotExpandChange(false);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_InvalidUrl_Returns)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_NullFileInfo_Returns)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    widget->currentFileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, slotExpandChange_ValidUrl_LoadsApps)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    widget->currentFileUrl = url;
+
+    auto mockFileInfo = QSharedPointer<FileInfo>(new FileInfo(url));
+    stub.set_lamda(&InfoFactory::create<FileInfo>,
+                   [&mockFileInfo](const QUrl &, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+                       __DBG_STUB_INVOKE__
+                       return mockFileInfo;
+                   });
+
+    stub.set_lamda(VADDR(FileInfo, fileMimeType),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QMimeType();
+                   });
+
+    stub.set_lamda(qOverload<const QMimeType &>(&MimesAppsManager::getDefaultAppByMimeType),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QString();
+                   });
+
+    stub.set_lamda(ADDR(MimesAppsManager, getRecommendedAppsByQio),
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return QStringList();
+                   });
+
+    widget->slotExpandChange(true);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, openWithBtnChecked_WithButton_SetsDefault)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    bool setDefaultCalled = false;
+
+    stub.set_lamda(ADDR(MimesAppsManager, setDefautlAppForTypeByGio),
+                   [&setDefaultCalled] {
+                       __DBG_STUB_INVOKE__
+                       setDefaultCalled = true;
+                       return true;
+                   });
+
+    Dtk::Widget::DRadioButton btn;
+    btn.setProperty("mimeTypeName", "text/plain");
+    btn.setProperty("appPath", "/usr/share/applications/test.desktop");
+
+    widget->openWithBtnChecked(&btn);
+
+    EXPECT_TRUE(setDefaultCalled);
+
+    delete widget;
+}
+
+TEST_F(UT_OpenWithWidget, openWithBtnChecked_NullButton_DoesNothing)
+{
+    OpenWithWidget *widget = new OpenWithWidget();
+    bool setDefaultCalled = false;
+
+    stub.set_lamda(ADDR(MimesAppsManager, setDefautlAppForTypeByGio),
+                   [&setDefaultCalled] {
+                       __DBG_STUB_INVOKE__
+                       setDefaultCalled = true;
+                       return true;
+                   });
+
+    widget->openWithBtnChecked(nullptr);
+
+    EXPECT_FALSE(setDefaultCalled);
+
+    delete widget;
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualglobalplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualglobalplugin.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-utils/global/virtualglobalplugin.h"
+#include "plugins/common/dfmplugin-utils/global/globaleventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualGlobalPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                       [](GlobalEventReceiver *) {
+                           __DBG_STUB_INVOKE__
+                       });
+
+        plugin = new VirtualGlobalPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualGlobalPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualGlobalPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualGlobalPlugin, initialize_CallsInitEventConnect)
+{
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](GlobalEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initEventConnectCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+TEST_F(UT_VirtualGlobalPlugin, start_ReturnsTrue)
+{
+    EXPECT_TRUE(plugin->start());
+}
+
+TEST_F(UT_VirtualGlobalPlugin, PluginLifecycle_InitializeThenStart)
+{
+    bool initCalled = false;
+
+    stub.set_lamda(ADDR(GlobalEventReceiver, initEventConnect),
+                   [&initCalled](GlobalEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initCalled = true;
+                   });
+
+    plugin->initialize();
+    EXPECT_TRUE(initCalled);
+
+    EXPECT_TRUE(plugin->start());
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}

--- a/autotests/plugins/dfmplugin-utils/test_virtualopenwithplugin.cpp
+++ b/autotests/plugins/dfmplugin-utils/test_virtualopenwithplugin.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "openwith/openwithhelper.h"
+#include "plugins/common/dfmplugin-utils/openwith/virtualopenwithplugin.h"
+#include "plugins/common/dfmplugin-utils/openwith/openwitheventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/lifecycle/pluginmetaobject.h>
+
+#include <gtest/gtest.h>
+
+using namespace dfmplugin_utils;
+DPF_USE_NAMESPACE
+
+class UT_VirtualOpenWithPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        plugin = new VirtualOpenWithPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    VirtualOpenWithPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_VirtualOpenWithPlugin, Constructor_EventReceiverInitialized)
+{
+    EXPECT_NE(plugin->eventReceiver.data(), nullptr);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, initialize_CallsInitEventConnect)
+{
+    bool initEventConnectCalled = false;
+
+    stub.set_lamda(ADDR(OpenWithEventReceiver, initEventConnect),
+                   [&initEventConnectCalled](OpenWithEventReceiver *) {
+                       __DBG_STUB_INVOKE__
+                       initEventConnectCalled = true;
+                   });
+
+    plugin->initialize();
+
+    EXPECT_TRUE(initEventConnectCalled);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, start_PropertyDialogInitialized_RegsView)
+{
+    bool regViewCalled = false;
+
+    auto mockMetaObj = QSharedPointer<PluginMetaObject>(new PluginMetaObject);
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [&mockMetaObj] {
+                       __DBG_STUB_INVOKE__
+                       return mockMetaObj;
+                   });
+
+    stub.set_lamda(&PluginMetaObject::pluginState,
+                   [](PluginMetaObject *) -> PluginMetaObject::State {
+                       __DBG_STUB_INVOKE__
+                       return PluginMetaObject::kStarted;
+                   });
+
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, decltype(OpenWithHelper::createOpenWithWidget), const char(&)[8], int &&);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&regViewCalled] {
+                       __DBG_STUB_INVOKE__
+                       regViewCalled = true;
+                       return QVariant();
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(regViewCalled);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, start_PropertyDialogNotInitialized_ConnectsListener)
+{
+    bool listenerConnected = false;
+
+    stub.set_lamda(&LifeCycle::pluginMetaObj,
+                   [] {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    stub.set_lamda(ADDR(Listener, instance),
+                   [&listenerConnected]() -> Listener * {
+                       __DBG_STUB_INVOKE__
+                       listenerConnected = true;
+                       static Listener listener;
+                       return &listener;
+                   });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(listenerConnected);
+}
+
+TEST_F(UT_VirtualOpenWithPlugin, regViewToPropertyDialog_PushesSlot)
+{
+    bool pushCalled = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, decltype(OpenWithHelper::createOpenWithWidget), const char(&)[8], int &&);
+    stub.set_lamda(static_cast<Push>(&EventChannelManager::push),
+                   [&pushCalled] {
+                       __DBG_STUB_INVOKE__
+                       pushCalled = true;
+                       return QVariant();
+                   });
+
+    plugin->regViewToPropertyDialog();
+    EXPECT_TRUE(pushCalled);
+}


### PR DESCRIPTION
Added comprehensive unit test coverage for dfmplugin-utils plugin
components including:
1. GlobalEventReceiver - tests event subscription and handleOpenAsAdmin
functionality with various scenarios
2. OpenWithDialog - tests dialog creation and interaction with file URLs
3. OpenWithEventReceiver - tests event connection and dialog display
logic
4. OpenWithHelper - tests widget creation with different file types
and conditions
5. OpenWithWidget - tests UI components and application selection
behavior
6. VirtualGlobalPlugin - tests plugin lifecycle and event receiver
initialization
7. VirtualOpenWithPlugin - tests plugin startup and property dialog
integration

The tests use stubext for mocking dependencies and cover edge cases
like invalid URLs, null file info, directory handling, and symlink
resolution. Each test class includes proper setup/teardown with stub
management.

测试: 为 dfmplugin-utils 组件添加单元测试

为 dfmplugin-utils 插件组件添加了全面的单元测试覆盖，包括:
1. GlobalEventReceiver - 测试事件订阅和 handleOpenAsAdmin 功能的各种场景
2. OpenWithDialog - 测试对话框创建和与文件 URL 的交互
3. OpenWithEventReceiver - 测试事件连接和对话框显示逻辑
4. OpenWithHelper - 测试不同文件类型和条件下的窗口小部件创建
5. OpenWithWidget - 测试 UI 组件和应用程序选择行为
6. VirtualGlobalPlugin - 测试插件生命周期和事件接收器初始化
7. VirtualOpenWithPlugin - 测试插件启动和属性对话框集成

测试使用 stubext 模拟依赖项，涵盖边缘情况如无效 URL、空文件信息、目录处
理和符号链接解析。每个测试类都包含适当的设置/清理和存根管理。

Influence:
1. Verify all unit tests pass with different build configurations
2. Test with various file types and URL schemes
3. Validate event handling and dialog behavior
4. Check plugin initialization and lifecycle management
5. Test error handling and edge cases
6. Verify mock dependencies work correctly

影响:
1. 验证所有单元测试在不同构建配置下都能通过
2. 使用各种文件类型和 URL 方案进行测试
3. 验证事件处理和对话框行为
4. 检查插件初始化和生命周期管理
5. 测试错误处理和边界情况
6. 验证模拟依赖项正常工作
