### PR TITLE
refactor: unify dialog icons to use dde-file-manager theme

### DIFF
--- a/src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
+++ b/src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
@@ -61,7 +61,7 @@ void MountSecretDiskAskPasswordDialog::initUI()
         unlockBtn->setEnabled(false);
     setSpacing(10);
     setDefaultButton(1);
-    setIcon(QIcon::fromTheme("dialog-warning"));
+    setIcon(QIcon::fromTheme("dde-file-manager"));
 }
 
 void MountSecretDiskAskPasswordDialog::initConnect()

--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -39,7 +39,7 @@ DDialog *DialogManager::showQueryScanningDialog(const QString &title)
     d->setAttribute(Qt::WA_DeleteOnClose);
     Qt::WindowFlags flags = d->windowFlags();
     d->setWindowFlags(flags | Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint);
-    d->setIcon(warningIcon);
+    d->setIcon(QIcon::fromTheme("dde-file-manager"));
     d->addButton(QObject::tr("Cancel", "button"));
     d->addButton(QObject::tr("Stop", "button"), true, DDialog::ButtonWarning);   // 终止
     d->setMaximumWidth(640);
@@ -53,13 +53,13 @@ void DialogManager::showErrorDialog(const QString &title, const QString &message
     Qt::WindowFlags flags = d.windowFlags();
     // dialog show top
     d.setWindowFlags(flags | Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint);
-    d.setIcon(errorIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     d.addButton(tr("Confirm", "button"), true, DDialog::ButtonNormal);
     d.setMaximumWidth(640);
     d.exec();
 }
 
-int DialogManager::showMessageDialog(DialogManager::MessageType messageLevel, const QString &title, const QString &message, QString btnTxt)
+int DialogManager::showMessageDialog(const QString &title, const QString &message, QString btnTxt)
 {
     DDialog d(title, message, qApp->activeWindow());
     d.moveToCenter();
@@ -67,30 +67,18 @@ int DialogManager::showMessageDialog(DialogManager::MessageType messageLevel, co
     buttonTexts.append(btnTxt);
     d.addButtons(buttonTexts);
     d.setDefaultButton(0);
-    if (messageLevel == kMsgWarn) {
-        d.setIcon(warningIcon);
-    } else if (messageLevel == kMsgErr) {
-        d.setIcon(errorIcon);
-    } else {
-        d.setIcon(infoIcon);
-    }
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     int code = d.exec();
     return code;
 }
 
-int DialogManager::showMessageDialog(MessageType messageLevel, const QString &title, const QString &message, const QStringList &btnTxtList)
+int DialogManager::showMessageDialog(const QString &title, const QString &message, const QStringList &btnTxtList)
 {
     DDialog d(title, message, qApp->activeWindow());
     d.moveToCenter();
     d.addButtons(btnTxtList);
     d.setDefaultButton(btnTxtList.size() - 1);
-    if (messageLevel == kMsgWarn) {
-        d.setIcon(warningIcon);
-    } else if (messageLevel == kMsgErr) {
-        d.setIcon(errorIcon);
-    } else {
-        d.setIcon(infoIcon);
-    }
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     int code = d.exec();
     return code;
 }
@@ -211,13 +199,13 @@ void DialogManager::showNoPermissionDialog(const QList<QUrl> &urls)
         }
 
         d.setMessage(message);
-        d.setIcon(warningIcon);
+        d.setIcon(QIcon::fromTheme("dde-file-manager"));
     } else {
 
         QFrame *contentFrame = new QFrame;
 
         QLabel *iconLabel = new QLabel;
-        iconLabel->setPixmap(warningIcon.pixmap(64, 64));
+        iconLabel->setPixmap(QIcon::fromTheme("dde-file-manager").pixmap(64, 64));
 
         QLabel *titleLabel = new QLabel;
         titleLabel->setText(tr("Sorry, you don't have permission to operate the following %1 file/folder(s)!").arg(QString::number(urls.count())));
@@ -262,7 +250,7 @@ void DialogManager::showCopyMoveToSelfDialog()
     buttonTexts.append(tr("OK", "button"));
     d.addButton(buttonTexts[0], true, DDialog::ButtonNormal);
     d.setDefaultButton(0);
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     d.exec();
 }
 
@@ -326,7 +314,7 @@ QString DialogManager::askPasswordForLockedDevice(const QString &devName)
 bool DialogManager::askForFormat()
 {
     DDialog dlg(qApp->activeWindow());
-    dlg.setIcon(warningIcon);
+    dlg.setIcon(QIcon::fromTheme("dde-file-manager"));
     dlg.addButton(tr("Cancel", "button"));
     dlg.addButton(tr("Format", "button"), true, DDialog::ButtonRecommend);
     dlg.setTitle(tr("To access the device, you must format the disk first. Are you sure you want to format it now?"));
@@ -527,7 +515,7 @@ void DialogManager::showRestoreFailedDialog(const int count)
     } else if (count > 1) {
         d.setMessage(tr("Failed to restore %1 files, the target folder is read-only").arg(QString::number(count)));
     }
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     d.addButton(tr("OK", "button"), true, DDialog::ButtonNormal);
     d.exec();
 }
@@ -587,7 +575,7 @@ int DialogManager::showRenameNameSameErrorDialog(const QString &name)
     buttonTexts.append(tr("Confirm", "button"));
     d.addButton(buttonTexts[0], true, DDialog::ButtonNormal);
     d.setDefaultButton(0);
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     int code = d.exec();
     return code;
 }
@@ -601,7 +589,7 @@ void DialogManager::showRenameBusyErrDialog()
     buttonTexts.append(tr("Confirm", "button"));
     d.addButton(buttonTexts[0], true, DDialog::ButtonNormal);
     d.setDefaultButton(0);
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     d.exec();
 }
 
@@ -614,7 +602,7 @@ int DialogManager::showRenameNameDotBeginDialog()
     d.addButton(tr("Cancel"));
 
     d.setDefaultButton(0);
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
 
     int ret = -1;
     connect(&d, &DDialog::buttonClicked, this, [=, &ret](int index, const QString &text) {
@@ -662,7 +650,7 @@ DFMBASE_NAMESPACE::GlobalEventType DialogManager::showBreakSymlinkDialog(const Q
     d.addButton(buttonTexts[0], true);
     d.addButton(buttonTexts[1], false, DDialog::ButtonRecommend);
     d.setDefaultButton(1);
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     int code = d.exec();
     if (code == 1) {
         QList<QUrl> urls;
@@ -684,7 +672,7 @@ int DialogManager::showAskIfAddExcutableFlagAndRunDialog()
     d.addButton(tr("Cancel", "button"));
     d.addButton(tr("Run", "button"), true, DDialog::ButtonRecommend);
     d.setTitle(message);
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     int code = d.exec();
     return code;
 }
@@ -693,7 +681,7 @@ void DialogManager::showDeleteSystemPathWarnDialog(quint64 winId)
 {
     DDialog d(FMWindowsIns.findWindowById(winId));
     d.setTitle(tr("The selected files contain system file/directory, and it cannot be deleted"));
-    d.setIcon(warningIcon);
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     d.addButton(tr("OK", "button"), true, DDialog::ButtonNormal);
     d.exec();
 }
@@ -701,9 +689,6 @@ void DialogManager::showDeleteSystemPathWarnDialog(quint64 winId)
 DialogManager::DialogManager(QObject *parent)
     : QObject(parent)
 {
-    infoIcon = QIcon::fromTheme("dialog-information");
-    warningIcon = QIcon::fromTheme("dialog-warning");
-    errorIcon = QIcon::fromTheme("dialog-error");
 }
 
 DialogManager::~DialogManager()

--- a/src/dfm-base/utils/dialogmanager.h
+++ b/src/dfm-base/utils/dialogmanager.h
@@ -34,11 +34,6 @@ public:
     static DialogManager *instance();
 
 public:
-    enum MessageType {
-        kMsgInfo = 1,
-        kMsgWarn = 2,
-        kMsgErr = 3
-    };
     enum OperateType {
         kMount,
         kUnmount,
@@ -53,8 +48,8 @@ public:
     void showNoPermissionDialog(const QList<QUrl> &urls);
     void showCopyMoveToSelfDialog();
 
-    int showMessageDialog(MessageType messageLevel, const QString &title, const QString &message = "", QString btnTxt = tr("Confirm", "button"));
-    int showMessageDialog(MessageType messageLevel, const QString &title, const QString &message, const QStringList &btnTxtList);
+    int showMessageDialog(const QString &title, const QString &message = "", QString btnTxt = tr("Confirm", "button"));
+    int showMessageDialog(const QString &title, const QString &message, const QStringList &btnTxtList);
 
     void addTask(const JobHandlePointer task);
 
@@ -93,9 +88,6 @@ private:
     ~DialogManager();
 
     TaskDialog *taskdialog = nullptr;   // 文件任务进度和错误处理弹窗
-    QIcon infoIcon;
-    QIcon warningIcon;
-    QIcon errorIcon;
 
     // 存储自定义控件创建器的映射
     QMap<QString, std::function<DSettingsWidgetFactory::WidgetCreateHandler>> settingWidgetCreators;

--- a/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
@@ -94,8 +94,7 @@ void BurnEventReceiver::handlePasteTo(const QList<QUrl> &urls, const QUrl &dest,
                 qint64 srcSize { fi->size() };
                 qint64 avil { qvariant_cast<qint64>(map[DeviceProperty::kSizeFree]) };
                 if (avil == 0 || srcSize > avil) {
-                    DialogManagerInstance->showMessageDialog(DialogManager::kMsgWarn,
-                                                             tr("Unable to burn. Not enough free space on the target disk."));
+                    DialogManagerInstance->showMessageDialog(tr("Unable to burn. Not enough free space on the target disk."));
                 } else {
                     QScopedPointer<BurnOptDialog> dlg { new BurnOptDialog(dev, qApp->activeWindow()) };
                     dlg->setISOImage(urls.front());

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
@@ -162,15 +162,15 @@ void AbstractBurnJob::finishFunc(bool verify, bool verifyRet)
     if (lastStatus == JobStatus::kFailed) {
         jobSuccess = false;
         if (verify && verifyRet)
-            emit requestCompletionDialog(tr("Data verification successful."), "dialog-ok");
+            emit requestCompletionDialog(tr("Data verification successful."), "dde-file-manager");
         else
             emit requestFailureDialog(static_cast<int>(curJobType), lastError, lastSrcMessages);
     } else {
         jobSuccess = true;
         if (verify)
-            emit requestCompletionDialog(tr("Data verification successful."), "dialog-ok");
+            emit requestCompletionDialog(tr("Data verification successful."), "dde-file-manager");
         else
-            emit requestCompletionDialog(tr("Burn process completed"), "dialog-ok");
+            emit requestCompletionDialog(tr("Burn process completed"), "dde-file-manager");
     }
 
     emit burnFinished(firstJobType, jobSuccess);

--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -239,7 +239,7 @@ void BurnJobManager::showOpticalJobCompletionDialog(const QString &msg, const QS
 void BurnJobManager::showOpticalJobFailureDialog(int type, const QString &err, const QStringList &details)
 {
     DDialog d(qApp->activeWindow());
-    d.setIcon(QIcon::fromTheme("dialog-error"));
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     QString failureType;
     switch (type) {
     case AbstractBurnJob::kOpticalBlank:

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -421,7 +421,7 @@ bool ShareControlWidget::validateShareName()
     for (const auto &shareFile : shareFileLst) {
         if (name.toLower() == shareFile.fileName()) {
             DDialog dlg(this);
-            dlg.setIcon(QIcon::fromTheme("dialog-warning"));
+            dlg.setIcon(QIcon::fromTheme("dde-file-manager"));
 
             if (!shareFile.isWritable()) {
                 dlg.setTitle(tr("The share name is used by another user."));

--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
@@ -715,17 +715,17 @@ void BluetoothTransDialog::sendFiles()
 
         if (!info->exists()) {
             close();   // 与产品经理沟通后，为避免文件不存在时的retry可能引起的一系列问题，当用户点击retry的确认时，直接终止流程
-            DialogManagerInstance->showMessageDialog(DFMBASE_NAMESPACE::DialogManager::kMsgErr, TXT_FILE_NOEXIST, "", TXT_OKAY);
+            DialogManagerInstance->showMessageDialog(TXT_FILE_NOEXIST, "", TXT_OKAY);
             return;
         } else if (info->size() > kFileTransferSizeLimits) {
-            DialogManagerInstance->showMessageDialog(DFMBASE_NAMESPACE::DialogManager::kMsgInfo, TXT_FILE_OVERSIZ, "", TXT_OKAY);
+            DialogManagerInstance->showMessageDialog(TXT_FILE_OVERSIZ, "", TXT_OKAY);
             return;
         } else if (info->size() == 0) {
-            DialogManagerInstance->showMessageDialog(DFMBASE_NAMESPACE::DialogManager::kMsgInfo, TXT_FILE_ZEROSIZ, "", TXT_OKAY);
+            DialogManagerInstance->showMessageDialog(TXT_FILE_ZEROSIZ, "", TXT_OKAY);
             return;
         } else if (info->isAttributes(dfmbase::OptInfoType::kIsDir)) {
             close();   // 与产品经理沟通后，为避免文件不存在时的retry可能引起的一系列问题，当用户点击retry的确认时，直接终止流程
-            DialogManagerInstance->showMessageDialog(DFMBASE_NAMESPACE::DialogManager::kMsgErr, TXT_DIR_SELECTED, "", TXT_OKAY);
+            DialogManagerInstance->showMessageDialog(TXT_DIR_SELECTED, "", TXT_OKAY);
             return;
         }
     }

--- a/src/plugins/common/dfmplugin-utils/bluetooth/virtualbluetoothplugin.cpp
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/virtualbluetoothplugin.cpp
@@ -43,7 +43,7 @@ bool VirtualBluetoothPlugin::bluetoothAvailable()
 void VirtualBluetoothPlugin::sendFiles(const QStringList &paths, const QString &deviceId)
 {
     if (!BluetoothTransDialog::isBluetoothIdle()) {
-        DialogManagerInstance->showMessageDialog(DFMBASE_NAMESPACE::DialogManager::kMsgInfo, tr("Sending files now, please try later."));
+        DialogManagerInstance->showMessageDialog(tr("Sending files now, please try later."));
         return;
     }
 

--- a/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
@@ -131,7 +131,7 @@ void ProgressDialog::handleButtonClicked(int index, const QString &text)
 
 void ProgressDialog::initUi()
 {
-    setIcon(QIcon::fromTheme("dialog-warning"));
+    setIcon(QIcon::fromTheme("dde-file-manager"));
     setTitle(tr("Shredding file"));
 
     proWidget = new ProgressWidget(this);

--- a/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredutils.cpp
@@ -197,7 +197,7 @@ QWidget *ShredUtils::createShredSettingItem(QObject *opt)
 bool ShredUtils::confirmAndDisplayFiles(const QList<QUrl> &fileList)
 {
     DDialog dialog(qApp->activeWindow());
-    dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+    dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
 
     QString title = tr("Are you sure to shred these %1 items?").arg(fileList.count());
     QString message = tr("The file will be completely deleted and cannot be recovered.");

--- a/src/plugins/filedialog/core/utils/corehelper.cpp
+++ b/src/plugins/filedialog/core/utils/corehelper.cpp
@@ -69,7 +69,7 @@ bool CoreHelper::askHiddenFile(QWidget *parent)
 {
     DDialog dialog(parent);
 
-    dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+    dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
     dialog.setTitle(QObject::tr("This file will be hidden if the file name starts with '.'. Do you want to hide it?"));
     dialog.addButton(QObject::tr("Hide", "button"), false, DDialog::ButtonWarning);
     dialog.addButton(QObject::tr("Cancel", "button"), true);
@@ -95,7 +95,7 @@ bool CoreHelper::askReplaceFile(QString fileName, QWidget *parent)
         dialog.setWindowModality(Qt::WindowModal);
     }
 
-    dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+    dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
 
     QLabel *titleLabel = dialog.findChild<QLabel *>("TitleLabel");
     if (titleLabel)

--- a/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp
@@ -291,7 +291,7 @@ bool ComputerEventReceiver::askForConfirmChmod(const QString &devName)
     using namespace Dtk::Widget;
     DDialog dlg(tr("%1 is read-only. Do you want to enable read and write permissions for it?").arg(devName),
                 tr("Once enabled, read/write permission will be granted permanently"), qApp->activeWindow());
-    dlg.setIcon(QIcon::fromTheme("dialog-warning"));
+    dlg.setIcon(QIcon::fromTheme("dde-file-manager"));
     dlg.addButton(tr("Cancel"));
     int confirmIdx = dlg.addButton(tr("Enable Now"), true, DDialog::ButtonRecommend);
 

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -227,7 +227,7 @@ void EventsHandler::onEncryptFinished(const QVariantMap &result)
 
     auto dialog = encryptDialogs.take(dev);
     if (!dialog)
-        dialog_utils::showDialog(title, msg, code != 0 ? dialog_utils::kError : dialog_utils::kInfo);
+        dialog_utils::showDialog(title, msg);
     else {
         dialog->showResultPage(success, title, msg);
         if (code == -KErrorRequestExportRecKey) {
@@ -376,8 +376,7 @@ bool EventsHandler::onAcquireDevicePwd(const QString &dev, QString *pwd, bool *c
     bool testTPM = (type == kPin || type == kTpm);
     if (testTPM && tpm_utils::checkTPM() != 0) {
         fmWarning() << "TPM service is not available for device:" << dev;
-        int ret = dialog_utils::showDialog(tr("Error"), tr("TPM status is abnormal, please use the recovery key to unlock it"),
-                                           dialog_utils::DialogType::kError);
+        int ret = dialog_utils::showDialog(tr("Error"), tr("TPM status is abnormal, please use the recovery key to unlock it"));
         // unlock by recovery key.
         if (ret == 0)
             *pwd = acquirePassphraseByRec(dev, *cancelled);
@@ -413,8 +412,7 @@ bool EventsHandler::onAcquireDevicePwd(const QString &dev, QString *pwd, bool *c
         else
             title = tr("TPM error");
 
-        dialog_utils::showDialog(title, tr("Please use recovery key to unlock device."),
-                                 dialog_utils::kInfo);
+        dialog_utils::showDialog(title, tr("Please use recovery key to unlock device."));
 
         *pwd = acquirePassphraseByRec(dev, *cancelled);
     }
@@ -477,7 +475,6 @@ void EventsHandler::showPreEncryptError(const QString &dev, const QString &devNa
     QString msg;
     QString device = QString("%1(%2)").arg(devName).arg(dev.mid(5));
 
-    bool showError = false;
     switch (-code) {
     case (kSuccess):
         title = tr("Preencrypt done");
@@ -493,13 +490,11 @@ void EventsHandler::showPreEncryptError(const QString &dev, const QString &devNa
         msg = tr("Partition %1 preencrypt failed, please see log for more information.(%2)")
                       .arg(device)
                       .arg(code);
-        showError = true;
         fmWarning() << "Pre-encryption failed for device:" << device << "code:" << code;
         break;
     }
 
-    dialog_utils::showDialog(title, msg,
-                             showError ? dialog_utils::kError : dialog_utils::kInfo);
+    dialog_utils::showDialog(title, msg);
 }
 
 void EventsHandler::showDecryptError(const QString &dev, const QString &devName, int code)
@@ -508,12 +503,10 @@ void EventsHandler::showDecryptError(const QString &dev, const QString &devName,
     QString msg;
     QString device = QString("%1(%2)").arg(devName).arg(dev.mid(5));
 
-    bool showFailed = true;
     switch (-code) {
     case (kSuccess):
         title = tr("Decrypt done");
         msg = tr("Partition %1 has been decrypted").arg(device);
-        showFailed = false;
         fmInfo() << "Decryption successful for device:" << device;
         break;
     case kUserCancelled:
@@ -544,8 +537,7 @@ void EventsHandler::showDecryptError(const QString &dev, const QString &devName,
         dialog->showResultPage(code == 0, title, msg);
         dialog->raise();
     } else {
-        dialog_utils::showDialog(title, msg,
-                                 showFailed ? dialog_utils::kError : dialog_utils::kInfo);
+        dialog_utils::showDialog(title, msg);
     }
 }
 
@@ -566,7 +558,6 @@ void EventsHandler::showChgPwdError(const QString &dev, const QString &devName, 
         break;
     }
 
-    bool showError = false;
     switch (-code) {
     case (kSuccess):
         title = tr("Change %1 done").arg(codeType);
@@ -579,7 +570,6 @@ void EventsHandler::showChgPwdError(const QString &dev, const QString &devName, 
     case kErrorChangePassphraseFailed:
         title = tr("Change %1 failed").arg(codeType);
         msg = tr("Wrong %1").arg(codeType);
-        showError = true;
         fmWarning() << "Wrong" << codeType << "for device:" << device;
         break;
     default:
@@ -588,13 +578,11 @@ void EventsHandler::showChgPwdError(const QString &dev, const QString &devName, 
                       .arg(device)
                       .arg(codeType)
                       .arg(code);
-        showError = true;
         fmWarning() << "Password change failed for device:" << device << "type:" << codeType << "code:" << code;
         break;
     }
 
-    dialog_utils::showDialog(title, msg,
-                             showError ? dialog_utils::kError : dialog_utils::kInfo);
+    dialog_utils::showDialog(title, msg);
 }
 
 void EventsHandler::requestReboot()
@@ -616,8 +604,7 @@ bool EventsHandler::canUnlock(const QString &device)
     if (device == unfinishedDecryptJob()) {
         fmWarning() << "Device has unfinished decryption job:" << device;
         dialog_utils::showDialog(tr("Error"),
-                                 tr("Partition is not fully decrypted, please finish decryption before access."),
-                                 dialog_utils::DialogType::kInfo);
+                                 tr("Partition is not fully decrypted, please finish decryption before access."));
         return false;
     }
 
@@ -625,8 +612,7 @@ bool EventsHandler::canUnlock(const QString &device)
     if ((states & kStatusOnline) && (states & kStatusEncrypt)) {
         fmWarning() << "Device is online and encrypting, cannot unlock:" << device << "status:" << states;
         dialog_utils::showDialog(tr("Unlocking partition failed"),
-                                 tr("Please click \"Continue Partition Encryption\" in the right-click menu to complete the partition encryption."),
-                                 dialog_utils::DialogType::kError);
+                                 tr("Please click \"Continue Partition Encryption\" in the right-click menu to complete the partition encryption."));
         return false;
     }
 

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -461,12 +461,12 @@ void EncryptParamsInputDialog::confirmEncrypt()
             fmWarning() << "TPM is locked, showing lockout error";
             QString msg = tr("TPM is locked and cannot be used for partition encryption. "
                              "Please cancel the TPM password or choose another unlocking method.");
-            dialog_utils::showDialog(tr("TPM error"), msg, dialog_utils::DialogType::kError);
+            dialog_utils::showDialog(tr("TPM error"), msg);
             return;
         }
 
         fmCritical() << "TPM status error occurred";
-        dialog_utils::showDialog(tr("TPM error"), tr("TPM status error!"), dialog_utils::DialogType::kError);
+        dialog_utils::showDialog(tr("TPM error"), tr("TPM status error!"));
         return;
     }
     accept();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -84,7 +84,7 @@ void EncryptProgressDialog::onCicked(int idx, const QString &btnTxt)
     QString msg;
     if (!validateExportPath(url.toLocalFile(), &msg)) {
         fmWarning() << "Export path validation failed:" << msg;
-        dialog_utils::showDialog(tr("Error"), msg, dialog_utils::DialogType::kError);
+        dialog_utils::showDialog(tr("Error"), msg);
     } else {
         saveRecKey(url.toLocalFile());
     }
@@ -199,7 +199,7 @@ void EncryptProgressDialog::saveRecKey(const QString &path)
     QFile f(recFileName);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         fmCritical() << "Failed to create recovery key file:" << recFileName << "error:" << f.errorString();
-        dialog_utils::showDialog(tr("Error"), tr("Cannot create recovery key file!"), dialog_utils::DialogType::kError);
+        dialog_utils::showDialog(tr("Error"), tr("Cannot create recovery key file!"));
         return;
     }
     f.write(recKey.toLocal8Bit());

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -294,8 +294,7 @@ void DiskEncryptMenuScene::decryptDevice(const DeviceEncryptParam &param)
         if (passphrase.isEmpty()) {
             fmCritical() << "Failed to retrieve passphrase from TPM for device:" << inputs.devDesc;
             dialog_utils::showDialog(tr("Error"),
-                                     tr("Cannot resolve passphrase from TPM"),
-                                     dialog_utils::DialogType::kError);
+                                     tr("Cannot resolve passphrase from TPM"));
             UnlockPartitionDialog dlg(UnlockPartitionDialog::kRec);
             int ret = dlg.exec();
             if (ret != QDialog::Accepted)
@@ -326,7 +325,7 @@ void DiskEncryptMenuScene::decryptDevice(const DeviceEncryptParam &param)
         inputs.key = tpm_passphrase_utils::getPassphraseFromTPM_NonBlock(inputs.devDesc, inputs.key);
         if (inputs.key.isEmpty()) {
             fmCritical() << "PIN error: failed to retrieve TPM passphrase";
-            dialog_utils::showDialog(tr("Error"), tr("PIN error"), dialog_utils::DialogType::kError);
+            dialog_utils::showDialog(tr("Error"), tr("PIN error"));
             return;
         }
         doDecryptDevice(inputs);
@@ -351,7 +350,7 @@ void DiskEncryptMenuScene::changePassphrase(DeviceEncryptParam param)
             oldKey = tpm_passphrase_utils::getPassphraseFromTPM_NonBlock(dev, oldKey);
             if (oldKey.isEmpty()) {
                 fmCritical() << "PIN error during passphrase change";
-                dialog_utils::showDialog(tr("Error"), tr("PIN error"), dialog_utils::DialogType::kError);
+                dialog_utils::showDialog(tr("Error"), tr("PIN error"));
                 return;
             }
         }
@@ -686,8 +685,7 @@ void DiskEncryptMenuScene::onUnlocked(bool ok, dfmmount::OperationErrorInfo info
     if (!ok && info.code != dfmmount::DeviceError::kUDisksErrorNotAuthorizedDismissed) {
         fmWarning() << "Unlock device failed:" << info.message;
         dialog_utils::showDialog(tr("Unlock partition failed"),
-                                 tr("Wrong passphrase"),
-                                 dialog_utils::kError);
+                                 tr("Wrong passphrase"));
         return;
     }
 
@@ -706,7 +704,7 @@ void DiskEncryptMenuScene::onMounted(bool ok, dfmmount::OperationErrorInfo info,
     QApplication::restoreOverrideCursor();
     if (!ok && info.code != dfmmount::DeviceError::kUDisksErrorNotAuthorizedDismissed) {
         fmWarning() << "Mount device failed:" << info.message;
-        dialog_utils::showDialog(tr("Mount device failed"), "", dialog_utils::kError);
+        dialog_utils::showDialog(tr("Mount device failed"), "");
         return;
     }
 }
@@ -757,8 +755,7 @@ void DiskEncryptMenuScene::onUnmountError(OpType t, const QString &dev, const df
 
     QString operation = (t == kUnmount) ? tr("unmount") : tr("lock");
     dialog_utils::showDialog(tr("Encrypt failed"),
-                             tr("Cannot %1 device %2").arg(operation, dev),
-                             dialog_utils::kError);
+                             tr("Cannot %1 device %2").arg(operation, dev));
 }
 
 void DiskEncryptMenuScene::sortActions(QMenu *parent)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -571,26 +571,15 @@ BlockDev device_utils::createBlockDevice(const QString &devObjPath)
     return monitor->createDeviceById(devObjPath).objectCast<DBlockDevice>();
 }
 
-int dialog_utils::showDialog(const QString &title, const QString &msg, DialogType type)
+int dialog_utils::showDialog(const QString &title, const QString &msg)
 {
     QString icon;
-    switch (type) {
-    case kInfo:
-        icon = "dialog-information";
-        break;
-    case kWarning:
-        icon = "dialog-warning";
-        break;
-    case kError:
-        icon = "dialog-error";
-        break;
-    }
     Dtk::Widget::DDialog d;
     if (isWayland())
         d.setWindowFlag(Qt::WindowStaysOnTopHint);
     d.setTitle(title);
     d.setMessage(msg);
-    d.setIcon(QIcon::fromTheme(icon));
+    d.setIcon(QIcon::fromTheme("dde-file-manager"));
     d.addButton(qApp->translate("dfmplugin_diskenc::ChgPassphraseDialog", "Confirm"));
     return d.exec();
 }
@@ -667,7 +656,7 @@ void dialog_utils::showTPMError(const QString &title, tpm_passphrase_utils::TPME
         break;
     }
     if (!msg.isEmpty())
-        showDialog(title, msg, kError);
+        showDialog(title, msg);
 }
 
 bool dialog_utils::isWayland()

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -71,12 +71,7 @@ BlockDev createBlockDevice(const QString &devObjPath);
 }   // namespace device_utils
 
 namespace dialog_utils {
-enum DialogType {
-    kInfo,
-    kWarning,
-    kError,
-};
-int showDialog(const QString &title, const QString &msg, DialogType type);
+int showDialog(const QString &title, const QString &msg);
 int showConfirmEncryptionDialog(const QString &device, bool needReboot);
 int showConfirmDecryptionDialog(const QString &device, bool needReboot);
 void showTPMError(const QString &title, tpm_passphrase_utils::TPMError err);

--- a/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
@@ -266,7 +266,7 @@ void OpticalMediaWidget::onBurnButtonClicked()
     QFileInfoList listFilesInStage = dirStage.entryInfoList(filter);
     if (listFilesInStage.count() == 0) {
         fmInfo() << "No files found in staging folder, showing warning dialog";
-        DialogManagerInstance->showMessageDialog(DialogManager::kMsgWarn, errTitle);
+        DialogManagerInstance->showMessageDialog(errTitle);
         return;
     }
 
@@ -298,7 +298,7 @@ void OpticalMediaWidget::onStagingFileStatisticsFinished()
     qint64 total { statisticWorker->totalSize() };
     if (avil == 0 || total > avil) {
         fmWarning() << "Insufficient space for burn operation - Available:" << avil << "Required:" << total;
-        DialogManagerInstance->showMessageDialog(DialogManager::kMsgWarn, tr("Unable to burn. Not enough free space on the target disk."));
+        DialogManagerInstance->showMessageDialog(tr("Unable to burn. Not enough free space on the target disk."));
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
@@ -234,7 +234,7 @@ void RecentHelper::removeRecent(const QList<QUrl> &urls)
 {
     // In wayland , dialog needs to set a parent , otherwise it will enter the window modal incorrectly
     DDialog dlg(qApp->activeWindow());
-    dlg.setIcon(QIcon::fromTheme("dialog-warning"));
+    dlg.setIcon(QIcon::fromTheme("dde-file-manager"));
     dlg.addButton(QObject::tr("Cancel", "button"));
     dlg.addButton(QObject::tr("Remove", "button"), true, DDialog::ButtonRecommend);
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/diskpasswordchangingdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/diskpasswordchangingdialog.cpp
@@ -26,7 +26,7 @@ DiskPasswordChangingDialog::DiskPasswordChangingDialog(QWidget *parent)
 void DiskPasswordChangingDialog::initUI()
 {
     setFixedSize(382, 286);
-    setIcon(QIcon::fromTheme("dialog-warning"));
+    setIcon(QIcon::fromTheme("dde-file-manager"));
 
     switchPageWidget = new QStackedWidget(this);
     confirmWidget = new DPCConfirmWidget(this);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -482,7 +482,7 @@ bool TitleBarWidget::checkCustomFixedTab(int index)
     if (UrlRoute::isVirtual(url) && UrlRoute::isRootUrl(url))
         return true;
 
-    int ret = DialogManagerInstance->showMessageDialog(DialogManager::kMsgErr, tr("Directory not found"),
+    int ret = DialogManagerInstance->showMessageDialog(tr("Directory not found"),
                                                        tr("Directory not found. Remove it?"),
                                                        { tr("Cancel", "button"), tr("Remove", "button") });
     if (ret == 1) {

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -125,7 +125,7 @@ bool TrashFileHelper::openFileInPlugin(quint64 windowId, const QList<QUrl> urls)
     if (isOpenFile) {
         fmWarning() << "Trash: Attempting to open files in trash, showing warning dialog";
         const QString &strMsg = QObject::tr("Unable to open items in the trash, please restore it first");
-        DialogManagerInstance->showMessageDialog(DFMBASE_NAMESPACE::DialogManager::kMsgWarn, strMsg);
+        DialogManagerInstance->showMessageDialog(strMsg);
     }
     return isOpenFile;
 }

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebynonewidget.cpp
@@ -66,7 +66,7 @@ void VaultRemoveByNoneWidget::slotCheckAuthorizationFinished(bool result)
         fmCritical() << "Vault: Failed to lock vault for removal";
         QString errMsg = tr("Failed to delete file vault");
         DDialog dialog(this);
-        dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+        dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
         dialog.setTitle(errMsg);
         dialog.addButton(tr("OK"), true, DDialog::ButtonRecommend);
         fmDebug() << "Vault: Showing error dialog for lock failure";

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
@@ -205,7 +205,7 @@ void VaultRemoveByPasswordView::slotCheckAuthorizationFinished(bool result)
         fmCritical() << "Vault: Failed to lock vault for removal";
         QString errMsg = tr("Failed to delete file vault");
         DDialog dialog(this);
-        dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+        dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
         dialog.setTitle(errMsg);
         dialog.addButton(tr("OK"), true, DDialog::ButtonRecommend);
         fmDebug() << "Vault: Showing error dialog for lock failure";

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
@@ -190,7 +190,7 @@ void VaultRemoveByRecoverykeyView::slotCheckAuthorizationFinished(bool result)
         fmCritical() << "Vault: Failed to lock vault for removal";
         QString errMsg = tr("Failed to delete file vault");
         DDialog dialog(this);
-        dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+        dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
         dialog.setTitle(errMsg);
         dialog.addButton(tr("OK"), true, DDialog::ButtonRecommend);
         fmDebug() << "Vault: Showing error dialog for lock failure";

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
@@ -240,7 +240,7 @@ void RecoveryKeyView::handleUnlockVault(bool result)
             //! others
             QString errMsg = tr("Failed to unlock file vault");
             DDialog dialog(this);
-            dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+            dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
             dialog.setTitle(errMsg);
             dialog.addButton(tr("OK"), true, DDialog::ButtonRecommend);
             dialog.exec();

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
@@ -227,7 +227,7 @@ void UnlockView::onVaultUlocked(int state)
         } else if (state == static_cast<int>(ErrorCode::kWrongPassword)) {
             fmWarning() << "Vault: Wrong password error during unlock";
             DDialog dialog(tr("Wrong password"), "", this);
-            dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+            dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
             dialog.addButton(tr("OK", "button"), true, DDialog::ButtonRecommend);
             dialog.exec();
         } else {
@@ -235,7 +235,7 @@ void UnlockView::onVaultUlocked(int state)
             //! error tips
             QString errMsg = tr("Failed to unlock file vault, error code is %1").arg(state);
             DDialog dialog(this);
-            dialog.setIcon(QIcon::fromTheme("dialog-warning"));
+            dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
             dialog.setTitle(errMsg);
             dialog.addButton(tr("OK", "button"), true, DDialog::ButtonRecommend);
             dialog.exec();


### PR DESCRIPTION
Changed all dialog icons from specific warning/error/information icons
to use the unified "dde-file-manager" theme icon. This includes removing
the MessageType enum and simplifying showMessageDialog method signatures
since icon differentiation is no longer needed. The change affects
multiple components including file operations, encryption dialogs, burn
operations, and vault management.

This refactor simplifies icon management and ensures visual consistency
across the application by using a single branded icon for all dialogs
instead of system-specific icons that may vary across platforms.

Log: Unified dialog icons to use dde-file-manager theme for consistency

Influence:
1. Test various dialog appearances including error, warning, and
information scenarios
2. Verify dialog functionality remains unchanged despite icon updates
3. Check consistency across different dialog types and components
4. Test dialog responsiveness and user interaction
5. Verify icon display in different desktop environments and themes

重构：统一对话框图标使用 dde-file-manager 主题

将所有对话框图标从特定的警告/错误/信息图标改为使用统一的 "dde-file-
manager" 主题图标。这包括移除 MessageType 枚举并简化 showMessageDialog
方法签名，因为不再需要图标区分。此更改影响多个组件，包括文件操作、加密对
话框、刻录操作和保险库管理。

此次重构简化了图标管理，通过为所有对话框使用单一品牌图标而非可能因平台而
异的系统特定图标，确保应用程序的视觉一致性。

Log: 统一对话框图标使用 dde-file-manager 主题以保持一致性

Influence:
1. 测试各种对话框外观，包括错误、警告和信息场景
2. 验证对话框功能在图标更新后保持不变
3. 检查不同类型对话框和组件间的一致性
4. 测试对话框响应性和用户交互
5. 验证不同桌面环境和主题下的图标显示

BUG: https://pms.uniontech.com/bug-view-342467.html
