### PR TITLE
feat: adjust tab hover background opacity

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -376,7 +376,7 @@ void TabBarPrivate::paintTabBackground(QPainter *painter, const QStyleOptionTab 
 
     // 绘制背景
     if (isHovered) {
-        QColor bgColor = isDarkTheme ? QColor(255, 255, 255, 15) : QColor(0, 0, 0, 26);
+        QColor bgColor = isDarkTheme ? QColor(255, 255, 255, qRound(255 * 0.05)) : QColor(0, 0, 0, qRound(255 * 0.05));
         painter->setBrush(bgColor);
     } else {
         painter->setBrush(pal.color(QPalette::Active, QPalette::Base));


### PR DESCRIPTION
Adjust tab hover background opacity for better visual consistency across
themes. Changed the alpha values from hardcoded numbers to percentage-
based calculations using qRound for more precise opacity control. The
opacity is now set to 5% for both dark and light themes instead of the
previous 15/26 values, providing a more subtle hover effect.

Log: Improved tab hover visual effect with consistent opacity

Influence:
1. Test tab hover effect in both dark and light themes
2. Verify hover background opacity is consistent across themes
3. Check visual appearance doesn't affect tab readability
4. Test hover animation smoothness and performance

feat: 调整标签页悬停背景透明度

调整标签页悬停背景透明度以实现更好的主题间视觉一致性。将硬编码的透明度值
改为基于百分比的qRound计算，提供更精确的透明度控制。现在黑暗和明亮主题的
透明度统一设置为5%，而不是之前的15/26值，提供更微妙的悬停效果。

Log: 改进标签页悬停视觉效果，透明度更加一致

Influence:
1. 测试黑暗和明亮主题下的标签页悬停效果
2. 验证悬停背景透明度在不同主题下保持一致
3. 检查视觉效果不影响标签页可读性
4. 测试悬停动画流畅度和性能表现

BUG: https://pms.uniontech.com/bug-view-342577.html

## Summary by Sourcery

Enhancements:
- Unify tab hover background opacity across dark and light themes using a consistent, percentage-based alpha value for improved visual consistency.