### PR TITLE
feat: add comprehensive unit tests for organizer plugin

### DIFF
--- a/autotests/plugins/ddplugin-organizer/test_collectionholder.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_collectionholder.cpp
@@ -1,0 +1,575 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "collection/collectionholder.h"
+#include "collection/collectionholder_p.h"
+#include "view/collectionframe.h"
+#include "view/collectionwidget.h"
+#include "view/collectionview.h"
+#include "mode/collectiondataprovider.h"
+#include "models/collectionmodel.h"
+#include "private/surface.h"
+#include "config/configpresenter.h"
+
+#include <QPropertyAnimation>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace ddplugin_organizer;
+
+class MockCollectionDataProvider : public CollectionDataProvider
+{
+public:
+    MockCollectionDataProvider() : CollectionDataProvider(nullptr) {}
+    QString replace(const QUrl &, const QUrl &) override { return QString(); }
+    QString append(const QUrl &) override { return QString(); }
+    QString prepend(const QUrl &) override { return QString(); }
+    void insert(const QUrl &, const QString &, const int) override {}
+    QString remove(const QUrl &) override { return QString(); }
+    QString change(const QUrl &) override { return QString(); }
+};
+
+class UT_CollectionHolder : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        mockProvider = new MockCollectionDataProvider();
+        holder = new CollectionHolder("test_id", mockProvider);
+    }
+
+    virtual void TearDown() override
+    {
+        delete holder;
+        holder = nullptr;
+        delete mockProvider;
+        mockProvider = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    CollectionHolder *holder = nullptr;
+    MockCollectionDataProvider *mockProvider = nullptr;
+};
+
+TEST_F(UT_CollectionHolder, Constructor_WithValidParams_InitializesCorrectly)
+{
+    EXPECT_NE(holder, nullptr);
+    EXPECT_EQ(holder->id(), "test_id");
+}
+
+TEST_F(UT_CollectionHolder, id_ReturnsCorrectId)
+{
+    EXPECT_EQ(holder->id(), "test_id");
+}
+
+TEST_F(UT_CollectionHolder, name_WithWidget_ReturnsTitleName)
+{
+    QString expectedName = "Test Collection";
+
+    stub.set_lamda(&CollectionWidget::titleName, [expectedName]() {
+        __DBG_STUB_INVOKE__
+        return expectedName;
+    });
+
+    holder->d->widget = new CollectionWidget("test", mockProvider);
+
+    QString result = holder->name();
+    EXPECT_EQ(result, expectedName);
+
+    delete holder->d->widget;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setName_WithWidget_SetsTitleName)
+{
+    QString testName = "New Name";
+    bool setNameCalled = false;
+
+    stub.set_lamda(&CollectionWidget::setTitleName, [&setNameCalled, testName](CollectionWidget *, const QString &name) {
+        __DBG_STUB_INVOKE__
+        setNameCalled = true;
+        EXPECT_EQ(name, testName);
+    });
+
+    holder->d->widget = new CollectionWidget("test", mockProvider);
+
+    holder->setName(testName);
+    EXPECT_TRUE(setNameCalled);
+
+    delete holder->d->widget;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, frame_ReturnsFrame)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    holder->d->frame = testFrame;
+
+    EXPECT_EQ(holder->frame(), testFrame);
+
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, widget_ReturnsWidget)
+{
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->widget = testWidget;
+
+    EXPECT_EQ(holder->widget(), testWidget);
+
+    delete testWidget;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, itemView_WithWidget_ReturnsView)
+{
+    CollectionView *mockView = nullptr;
+
+    stub.set_lamda(&CollectionWidget::view, [&mockView]() {
+        __DBG_STUB_INVOKE__
+        return mockView;
+    });
+
+    holder->d->widget = new CollectionWidget("test", mockProvider);
+
+    EXPECT_EQ(holder->itemView(), mockView);
+
+    delete holder->d->widget;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, itemView_WithoutWidget_ReturnsNullptr)
+{
+    holder->d->widget = nullptr;
+    EXPECT_EQ(holder->itemView(), nullptr);
+}
+
+TEST_F(UT_CollectionHolder, surface_ReturnsSetSurface)
+{
+    Surface *testSurface = new Surface();
+    holder->d->surface = testSurface;
+
+    EXPECT_EQ(holder->surface(), testSurface);
+
+    delete testSurface;
+    holder->d->surface = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setSurface_WithFrame_SetsParent)
+{
+    Surface *testSurface = new Surface();
+    CollectionFrame *testFrame = new CollectionFrame();
+
+    holder->d->frame = testFrame;
+    holder->setSurface(testSurface);
+
+    EXPECT_EQ(holder->d->surface, testSurface);
+    EXPECT_EQ(testFrame->parent(), testSurface);
+
+    delete testFrame;
+    delete testSurface;
+    holder->d->frame = nullptr;
+    holder->d->surface = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setSurface_WithoutFrame_OnlySetsSurface)
+{
+    Surface *testSurface = new Surface();
+    holder->d->frame = nullptr;
+
+    holder->setSurface(testSurface);
+
+    EXPECT_EQ(holder->d->surface, testSurface);
+
+    delete testSurface;
+    holder->d->surface = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, show_CallsFrameShowAndRaise)
+{
+    bool showCalled = false;
+    bool raiseCalled = false;
+
+    stub.set_lamda(&CollectionFrame::show, [&showCalled]() {
+        __DBG_STUB_INVOKE__
+        showCalled = true;
+    });
+
+    stub.set_lamda(&CollectionFrame::raise, [&raiseCalled]() {
+        __DBG_STUB_INVOKE__
+        raiseCalled = true;
+    });
+
+    CollectionFrame *testFrame = new CollectionFrame();
+    holder->d->frame = testFrame;
+
+    holder->show();
+
+    EXPECT_TRUE(showCalled);
+    EXPECT_TRUE(raiseCalled);
+
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setMovable_True_SetsMovableFeature)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    holder->d->frame = testFrame;
+
+    holder->setMovable(true);
+    EXPECT_TRUE(holder->movable());
+
+    holder->setMovable(false);
+    EXPECT_FALSE(holder->movable());
+
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setClosable_True_SetsClosableFeature)
+{
+    stub.set_lamda(&CollectionWidget::setClosable, [](CollectionWidget *, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    CollectionFrame *testFrame = new CollectionFrame();
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->frame = testFrame;
+    holder->d->widget = testWidget;
+
+    holder->setClosable(true);
+    EXPECT_TRUE(holder->closable());
+
+    holder->setClosable(false);
+    EXPECT_FALSE(holder->closable());
+
+    delete testWidget;
+    delete testFrame;
+    holder->d->frame = nullptr;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setFloatable_True_SetsFloatableFeature)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    holder->d->frame = testFrame;
+
+    holder->setFloatable(true);
+    EXPECT_TRUE(holder->floatable());
+
+    holder->setFloatable(false);
+    EXPECT_FALSE(holder->floatable());
+
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setHiddableCollection_True_SetsHiddableFeature)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    holder->d->frame = testFrame;
+
+    holder->setHiddableCollection(true);
+    EXPECT_TRUE(holder->hiddableCollection());
+
+    holder->setHiddableCollection(false);
+    EXPECT_FALSE(holder->hiddableCollection());
+
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setStretchable_True_SetsStretchableFeature)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    holder->d->frame = testFrame;
+
+    holder->setStretchable(true);
+    EXPECT_TRUE(holder->stretchable());
+
+    holder->setStretchable(false);
+    EXPECT_FALSE(holder->stretchable());
+
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setAdjustable_True_SetsAdjustableFeature)
+{
+    stub.set_lamda(&CollectionWidget::setAdjustable, [](CollectionWidget *, bool) {
+        __DBG_STUB_INVOKE__
+    });
+
+    CollectionFrame *testFrame = new CollectionFrame();
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->frame = testFrame;
+    holder->d->widget = testWidget;
+
+    holder->setAdjustable(true);
+    EXPECT_TRUE(holder->adjustable());
+
+    holder->setAdjustable(false);
+    EXPECT_FALSE(holder->adjustable());
+
+    delete testWidget;
+    delete testFrame;
+    holder->d->frame = nullptr;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, hiddableTitleBar_ReturnsFalse)
+{
+    EXPECT_FALSE(holder->hiddableTitleBar());
+}
+
+TEST_F(UT_CollectionHolder, hiddableView_ReturnsFalse)
+{
+    EXPECT_FALSE(holder->hiddableView());
+}
+
+TEST_F(UT_CollectionHolder, setRenamable_CallsWidgetSetRenamable)
+{
+    bool renamableValue = false;
+
+    stub.set_lamda(&CollectionWidget::setRenamable, [&renamableValue](CollectionWidget *, bool val) {
+        __DBG_STUB_INVOKE__
+        renamableValue = val;
+    });
+
+    stub.set_lamda(&CollectionWidget::renamable, [&renamableValue]() {
+        __DBG_STUB_INVOKE__
+        return renamableValue;
+    });
+
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->widget = testWidget;
+
+    holder->setRenamable(true);
+    EXPECT_TRUE(holder->renamable());
+
+    delete testWidget;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, createAnimation_ReturnsValidAnimation)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    testFrame->setGeometry(100, 100, 200, 200);
+    holder->d->frame = testFrame;
+
+    QPropertyAnimation *animation = holder->createAnimation();
+
+    EXPECT_NE(animation, nullptr);
+    EXPECT_EQ(animation->duration(), 500);
+    EXPECT_EQ(animation->targetObject(), testFrame);
+
+    delete animation;
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setStyle_WithMatchingKey_SetsStyle)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->frame = testFrame;
+    holder->d->widget = testWidget;
+
+    stub.set_lamda(&CollectionWidget::setCollectionSize, [](CollectionWidget *, const CollectionFrameSize &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    CollectionStyle style;
+    style.key = "test_id";
+    style.rect = QRect(50, 50, 300, 400);
+    style.sizeMode = CollectionFrameSize::kLarge;
+    style.screenIndex = 2;
+
+    holder->setStyle(style);
+
+    EXPECT_EQ(holder->d->screenIndex, 2);
+    EXPECT_EQ(holder->d->sizeMode, CollectionFrameSize::kLarge);
+
+    delete testWidget;
+    delete testFrame;
+    holder->d->frame = nullptr;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setStyle_WithMismatchingKey_DoesNothing)
+{
+    holder->d->screenIndex = 1;
+    holder->d->sizeMode = CollectionFrameSize::kMiddle;
+
+    CollectionStyle style;
+    style.key = "wrong_id";
+    style.screenIndex = 3;
+    style.sizeMode = CollectionFrameSize::kSmall;
+
+    holder->setStyle(style);
+
+    EXPECT_EQ(holder->d->screenIndex, 1);
+    EXPECT_EQ(holder->d->sizeMode, CollectionFrameSize::kMiddle);
+}
+
+TEST_F(UT_CollectionHolder, style_ReturnsCurrentStyle)
+{
+    CollectionFrame *testFrame = new CollectionFrame();
+    testFrame->setGeometry(100, 100, 200, 300);
+    holder->d->frame = testFrame;
+    holder->d->screenIndex = 2;
+    holder->d->sizeMode = CollectionFrameSize::kLarge;
+
+    CollectionStyle result = holder->style();
+
+    EXPECT_EQ(result.key, "test_id");
+    EXPECT_EQ(result.screenIndex, 2);
+    EXPECT_EQ(result.sizeMode, CollectionFrameSize::kLarge);
+    EXPECT_EQ(result.rect, testFrame->geometry());
+
+    delete testFrame;
+    holder->d->frame = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, selectFiles_WithItemView_CallsSelectUrls)
+{
+    bool selectUrlsCalled = false;
+    bool scrollCalled = false;
+    QList<QUrl> testUrls = { QUrl("file:///test1.txt"), QUrl("file:///test2.txt") };
+
+    stub.set_lamda(&CollectionView::selectUrls, [&selectUrlsCalled](CollectionView *, const QList<QUrl> &) {
+        __DBG_STUB_INVOKE__
+        selectUrlsCalled = true;
+    });
+
+    stub.set_lamda(&CollectionView::scrollToBottom, [&scrollCalled]() {
+        __DBG_STUB_INVOKE__
+        scrollCalled = true;
+    });
+
+    stub.set_lamda(&CollectionWidget::view, []() {
+        __DBG_STUB_INVOKE__
+        static CollectionView *view = nullptr;
+        return view;
+    });
+
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->widget = testWidget;
+
+    // itemView returns nullptr, so selectFiles should return early
+    holder->selectFiles(testUrls);
+
+    delete testWidget;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setFreeze_WithOptimizationEnabled_CallsWidgetSetFreeze)
+{
+    bool freezeCalled = false;
+
+    stub.set_lamda(&ConfigPresenter::optimizeMovingPerformance, []() {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    stub.set_lamda(&CollectionWidget::setFreeze, [&freezeCalled](CollectionWidget *, bool) {
+        __DBG_STUB_INVOKE__
+        freezeCalled = true;
+    });
+
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->widget = testWidget;
+
+    holder->setFreeze(true);
+    EXPECT_TRUE(freezeCalled);
+
+    delete testWidget;
+    holder->d->widget = nullptr;
+}
+
+TEST_F(UT_CollectionHolder, setFreeze_WithOptimizationDisabled_DoesNotCallSetFreeze)
+{
+    bool freezeCalled = false;
+
+    stub.set_lamda(&ConfigPresenter::optimizeMovingPerformance, []() {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    stub.set_lamda(&CollectionWidget::setFreeze, [&freezeCalled](CollectionWidget *, bool) {
+        __DBG_STUB_INVOKE__
+        freezeCalled = true;
+    });
+
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->widget = testWidget;
+
+    holder->setFreeze(true);
+    EXPECT_FALSE(freezeCalled);
+
+    delete testWidget;
+    holder->d->widget = nullptr;
+}
+
+class UT_CollectionHolderPrivate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        mockProvider = new MockCollectionDataProvider();
+        holder = new CollectionHolder("test_id", mockProvider);
+    }
+
+    virtual void TearDown() override
+    {
+        delete holder;
+        holder = nullptr;
+        delete mockProvider;
+        mockProvider = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    CollectionHolder *holder = nullptr;
+    MockCollectionDataProvider *mockProvider = nullptr;
+};
+
+TEST_F(UT_CollectionHolderPrivate, Constructor_InitializesMembers)
+{
+    EXPECT_NE(holder->d, nullptr);
+    EXPECT_EQ(holder->d->id, "test_id");
+    EXPECT_EQ(holder->d->q, holder);
+    EXPECT_EQ(holder->d->provider, mockProvider);
+}
+
+TEST_F(UT_CollectionHolderPrivate, onAdjustFrameSizeMode_UpdatesSizeMode)
+{
+    bool styleChangedEmitted = false;
+
+    stub.set_lamda(&CollectionWidget::setCollectionSize, [](CollectionWidget *, const CollectionFrameSize &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QObject::connect(holder, &CollectionHolder::styleChanged, [&styleChangedEmitted](const QString &) {
+        styleChangedEmitted = true;
+    });
+
+    CollectionWidget *testWidget = new CollectionWidget("test", mockProvider);
+    holder->d->widget = testWidget;
+
+    holder->d->onAdjustFrameSizeMode(CollectionFrameSize::kLarge);
+
+    EXPECT_EQ(holder->d->sizeMode, CollectionFrameSize::kLarge);
+    EXPECT_TRUE(styleChangedEmitted);
+
+    delete testWidget;
+    holder->d->widget = nullptr;
+}

--- a/autotests/plugins/ddplugin-organizer/test_collectionhookinterface.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_collectionhookinterface.cpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "broker/collectionhookinterface.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QPoint>
+#include <QMimeData>
+#include <QPainter>
+#include <QStyleOptionViewItem>
+
+#include <gtest/gtest.h>
+
+using namespace ddplugin_organizer;
+DPF_USE_NAMESPACE
+
+class UT_CollectionHookInterface : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_CollectionHookInterface, dropData_WithValidParams_CallsHook)
+{
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*Run)(const QString &, const QString &, QString, const QMimeData *&, const QPoint &, void *&);
+    stub.set_lamda(static_cast<Run>(&EventSequenceManager::run), [&hookCalled]() {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return true;
+    });
+
+    QString viewId = "test_view";
+    QMimeData mimeData;
+    QPoint viewPos(100, 200);
+
+    bool result = CollectionHookInterface::dropData(viewId, &mimeData, viewPos);
+    EXPECT_TRUE(hookCalled);
+}
+
+TEST_F(UT_CollectionHookInterface, keyPress_WithValidParams_CallsHook)
+{
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*Run)(const QString &, const QString &, QString , int &, int &, void *&);
+    stub.set_lamda(static_cast<Run>(&EventSequenceManager::run), [&hookCalled]() {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return true;
+    });
+
+    QString viewId = "test_view";
+    int key = Qt::Key_Enter;
+    int modifiers = Qt::NoModifier;
+
+    bool result = CollectionHookInterface::keyPress(viewId, key, modifiers);
+    EXPECT_TRUE(hookCalled);
+}
+
+TEST_F(UT_CollectionHookInterface, startDrag_WithValidParams_CallsHook)
+{
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*Run)(const QString &, const QString &, QString, int &, void *&);
+    stub.set_lamda(static_cast<Run>(&EventSequenceManager::run), [&hookCalled]() {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return true;
+    });
+
+    QString viewId = "test_view";
+    int supportedActions = Qt::CopyAction;
+
+    bool result = CollectionHookInterface::startDrag(viewId, supportedActions);
+    EXPECT_TRUE(hookCalled);
+}
+
+TEST_F(UT_CollectionHookInterface, dragMove_WithValidParams_CallsHook)
+{
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*Run)(const QString &, const QString &, QString ,const QMimeData *&, const QPoint &, void *&);
+    stub.set_lamda(static_cast<Run>(&EventSequenceManager::run), [&hookCalled]() {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return true;
+    });
+
+    QString viewId = "test_view";
+    QMimeData mimeData;
+    QPoint viewPos(150, 250);
+
+    bool result = CollectionHookInterface::dragMove(viewId, &mimeData, viewPos);
+    EXPECT_TRUE(hookCalled);
+}
+
+TEST_F(UT_CollectionHookInterface, keyboardSearch_WithValidParams_CallsHook)
+{
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*Run)(const QString &, const QString &, QString , const QString &, void *&);
+    stub.set_lamda(static_cast<Run>(&EventSequenceManager::run), [&hookCalled]() {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return true;
+    });
+
+    QString viewId = "test_view";
+    QString search = "test_search";
+
+    bool result = CollectionHookInterface::keyboardSearch(viewId, search);
+    EXPECT_TRUE(hookCalled);
+}
+
+TEST_F(UT_CollectionHookInterface, drawFile_WithValidParams_CallsHook)
+{
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*Run)(const QString &, const QString &, QString, const QUrl &,
+                                              QPainter *&, const QStyleOptionViewItem *&, void *&);
+    stub.set_lamda(static_cast<Run>(&EventSequenceManager::run), [&hookCalled]() {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return true;
+    });
+
+    QString viewId = "test_view";
+    QUrl file("file:///tmp/testfile.txt");
+    QPainter *painter = nullptr;
+    QStyleOptionViewItem *option = nullptr;
+
+    bool result = CollectionHookInterface::drawFile(viewId, file, painter, option);
+    EXPECT_TRUE(hookCalled);
+}
+
+TEST_F(UT_CollectionHookInterface, shortcutkeyPress_WithValidParams_CallsHook)
+{
+    bool hookCalled = false;
+    typedef bool (EventSequenceManager::*Run)(const QString &, const QString &, QString, int &, int &, void *&);
+    stub.set_lamda(static_cast<Run>(&EventSequenceManager::run), [&hookCalled]() {
+        __DBG_STUB_INVOKE__
+        hookCalled = true;
+        return true;
+    });
+
+    QString viewId = "test_view";
+    int key = Qt::Key_F5;
+    int modifiers = Qt::NoModifier;
+
+    bool result = CollectionHookInterface::shortcutkeyPress(viewId, key, modifiers);
+    EXPECT_TRUE(hookCalled);
+}

--- a/autotests/plugins/ddplugin-organizer/test_collectionitemdelegate.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_collectionitemdelegate.cpp
@@ -1,0 +1,551 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "delegate/collectionitemdelegate.h"
+#include "delegate/collectionitemdelegate_p.h"
+#include "delegate/itemeditor.h"
+#include "view/collectionview.h"
+#include "models/collectionmodel.h"
+#include "mode/custom/customdatahandler.h"
+
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/elidetextlayout.h>
+
+#include <QPainter>
+#include <QStyleOptionViewItem>
+#include <QApplication>
+#include <QScrollBar>
+#include <QStandardItemModel>
+
+#include <gtest/gtest.h>
+
+DFMBASE_USE_NAMESPACE
+using namespace ddplugin_organizer;
+
+class UT_CollectionItemDelegate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        provider = new CustomDataHandler();
+        view = new CollectionView("test_uuid", provider);
+        delegate = new CollectionItemDelegate(view);
+    }
+
+    void TearDown() override
+    {
+        delete delegate;
+        delegate = nullptr;
+        delete view;
+        view = nullptr;
+        delete provider;
+        provider = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    CollectionItemDelegate *delegate = nullptr;
+    CollectionView *view = nullptr;
+    CollectionDataProvider *provider = nullptr;
+};
+
+TEST_F(UT_CollectionItemDelegate, MinimumIconLevel_ReturnsZero)
+{
+    EXPECT_EQ(CollectionItemDelegate::minimumIconLevel(), 0);
+}
+
+TEST_F(UT_CollectionItemDelegate, MaximumIconLevel_ReturnsMaxIndex)
+{
+    EXPECT_EQ(CollectionItemDelegate::maximumIconLevel(), 4);
+}
+
+TEST_F(UT_CollectionItemDelegate, IconSize_ValidLevel_ReturnsCorrectSize)
+{
+    EXPECT_EQ(delegate->iconSize(0), QSize(32, 32));
+    EXPECT_EQ(delegate->iconSize(1), QSize(48, 48));
+    EXPECT_EQ(delegate->iconSize(2), QSize(64, 64));
+    EXPECT_EQ(delegate->iconSize(3), QSize(96, 96));
+    EXPECT_EQ(delegate->iconSize(4), QSize(128, 128));
+}
+
+TEST_F(UT_CollectionItemDelegate, IconSize_InvalidLevel_ReturnsEmptySize)
+{
+    EXPECT_EQ(delegate->iconSize(-1), QSize());
+    EXPECT_EQ(delegate->iconSize(5), QSize());
+}
+
+TEST_F(UT_CollectionItemDelegate, IconLevel_DefaultLevel_ReturnsOne)
+{
+    EXPECT_EQ(delegate->iconLevel(), 1);
+}
+
+TEST_F(UT_CollectionItemDelegate, SetIconLevel_SameLevel_ReturnsCurrentLevel)
+{
+    int currentLevel = delegate->iconLevel();
+    EXPECT_EQ(delegate->setIconLevel(currentLevel), currentLevel);
+}
+
+TEST_F(UT_CollectionItemDelegate, SetIconLevel_ValidLevel_ReturnsNewLevel)
+{
+    int result = delegate->setIconLevel(2);
+    EXPECT_EQ(result, 2);
+    EXPECT_EQ(delegate->iconLevel(), 2);
+}
+
+TEST_F(UT_CollectionItemDelegate, SetIconLevel_InvalidLevel_ReturnsNegativeOne)
+{
+    EXPECT_EQ(delegate->setIconLevel(-1), -1);
+    EXPECT_EQ(delegate->setIconLevel(10), -1);
+}
+
+TEST_F(UT_CollectionItemDelegate, IconSizeLevelDescription_ValidIndex_ReturnsDescription)
+{
+    EXPECT_FALSE(delegate->iconSizeLevelDescription(0).isEmpty());
+    EXPECT_FALSE(delegate->iconSizeLevelDescription(1).isEmpty());
+    EXPECT_FALSE(delegate->iconSizeLevelDescription(4).isEmpty());
+}
+
+TEST_F(UT_CollectionItemDelegate, IconSizeLevelDescription_InvalidIndex_ReturnsEmpty)
+{
+    EXPECT_TRUE(delegate->iconSizeLevelDescription(-1).isEmpty());
+    EXPECT_TRUE(delegate->iconSizeLevelDescription(5).isEmpty());
+}
+
+TEST_F(UT_CollectionItemDelegate, SizeHint_ReturnsCachedHint)
+{
+    QStyleOptionViewItem option;
+    QModelIndex index;
+    QSize hint = delegate->sizeHint(option, index);
+    EXPECT_TRUE(hint.isValid());
+}
+
+TEST_F(UT_CollectionItemDelegate, BoundingRect_EmptyList_ReturnsEmptyRect)
+{
+    QList<QRectF> rects;
+    QRectF result = CollectionItemDelegate::boundingRect(rects);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_CollectionItemDelegate, BoundingRect_SingleRect_ReturnsSameRect)
+{
+    QList<QRectF> rects;
+    rects << QRectF(10, 20, 100, 50);
+    QRectF result = CollectionItemDelegate::boundingRect(rects);
+    EXPECT_EQ(result, rects.first());
+}
+
+TEST_F(UT_CollectionItemDelegate, BoundingRect_MultipleRects_ReturnsBoundingRect)
+{
+    QList<QRectF> rects;
+    rects << QRectF(10, 20, 50, 50);
+    rects << QRectF(100, 100, 50, 50);
+    rects << QRectF(5, 150, 200, 30);
+
+    QRectF result = CollectionItemDelegate::boundingRect(rects);
+
+    EXPECT_EQ(result.left(), 5);
+    EXPECT_EQ(result.top(), 20);
+    EXPECT_EQ(result.right(), 205);
+    EXPECT_EQ(result.bottom(), 180);
+}
+
+TEST_F(UT_CollectionItemDelegate, IconRect_ReturnsCorrectPosition)
+{
+    QRect paintRect(0, 0, 100, 150);
+    QRect iconR = delegate->iconRect(paintRect);
+
+    EXPECT_EQ(iconR.top(), CollectionItemDelegate::kIconTopSpacing);
+    EXPECT_TRUE(iconR.width() > 0);
+    EXPECT_TRUE(iconR.height() > 0);
+}
+
+TEST_F(UT_CollectionItemDelegate, LabelRect_ReturnsRectBelowIcon)
+{
+    QRect paintRect(0, 0, 100, 150);
+    QRect usedRect(26, 4, 48, 48);
+
+    QRect labelR = CollectionItemDelegate::labelRect(paintRect, usedRect);
+
+    EXPECT_EQ(labelR.top(), usedRect.bottom() + CollectionItemDelegate::kIconBackgroundMargin);
+    EXPECT_EQ(labelR.width(), paintRect.width() - 2 * CollectionItemDelegate::kTextPadding);
+}
+
+TEST_F(UT_CollectionItemDelegate, MayExpand_NoSelection_ReturnsFalse)
+{
+    stub.set_lamda(VADDR(CollectionView, selectedIndexes), [] {
+        __DBG_STUB_INVOKE__
+        return QModelIndexList();
+    });
+
+    EXPECT_FALSE(delegate->mayExpand());
+}
+
+TEST_F(UT_CollectionItemDelegate, MayExpand_MultipleSelection_ReturnsFalse)
+{
+    stub.set_lamda(VADDR(CollectionView, selectedIndexes), [] {
+        __DBG_STUB_INVOKE__
+        QModelIndexList list;
+        list << QModelIndex() << QModelIndex();
+        return list;
+    });
+
+    EXPECT_FALSE(delegate->mayExpand());
+}
+
+TEST_F(UT_CollectionItemDelegate, MayExpand_SingleSelection_ReturnsTrue)
+{
+    stub.set_lamda(VADDR(CollectionView, selectedIndexes), [] {
+        __DBG_STUB_INVOKE__
+        QModelIndexList list;
+        list << QModelIndex();
+        return list;
+    });
+
+    QModelIndex who;
+    EXPECT_TRUE(delegate->mayExpand(&who));
+}
+
+TEST_F(UT_CollectionItemDelegate, VisualAlignment_LeftToRight_KeepsAlignment)
+{
+    Qt::Alignment align = Qt::AlignLeft | Qt::AlignTop;
+    Qt::Alignment result = CollectionItemDelegate::visualAlignment(Qt::LeftToRight, align);
+    EXPECT_TRUE(result & Qt::AlignLeft);
+}
+
+TEST_F(UT_CollectionItemDelegate, VisualAlignment_RightToLeft_SwapsLeftRight)
+{
+    Qt::Alignment align = Qt::AlignLeft | Qt::AlignTop;
+    Qt::Alignment result = CollectionItemDelegate::visualAlignment(Qt::RightToLeft, align);
+    EXPECT_TRUE(result & Qt::AlignRight);
+}
+
+TEST_F(UT_CollectionItemDelegate, VisualAlignment_NoHorizontal_AddsLeft)
+{
+    Qt::Alignment align = Qt::AlignTop;
+    Qt::Alignment result = CollectionItemDelegate::visualAlignment(Qt::LeftToRight, align);
+    EXPECT_TRUE(result & Qt::AlignLeft);
+}
+
+TEST_F(UT_CollectionItemDelegate, GetIconPixmap_NullIcon_ReturnsEmptyPixmap)
+{
+    QIcon nullIcon;
+    QPixmap result = CollectionItemDelegate::getIconPixmap(nullIcon, QSize(48, 48), 1.0);
+    EXPECT_TRUE(result.isNull());
+}
+
+TEST_F(UT_CollectionItemDelegate, GetIconPixmap_ZeroSize_ReturnsEmptyPixmap)
+{
+    QIcon icon = QIcon::fromTheme("folder");
+    QPixmap result = CollectionItemDelegate::getIconPixmap(icon, QSize(0, 0), 1.0);
+    EXPECT_TRUE(result.isNull());
+}
+
+TEST_F(UT_CollectionItemDelegate, GetIconPixmap_NegativeSize_ReturnsEmptyPixmap)
+{
+    QIcon icon = QIcon::fromTheme("folder");
+    QPixmap result = CollectionItemDelegate::getIconPixmap(icon, QSize(-10, 48), 1.0);
+    EXPECT_TRUE(result.isNull());
+}
+
+TEST_F(UT_CollectionItemDelegate, CreateEditor_ReturnsItemEditor)
+{
+    stub.set_lamda(&FileUtils::supportLongName, [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(ADDR(CollectionItemDelegate, isTransparent), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(&CollectionModel::rootUrl, [] {
+        __DBG_STUB_INVOKE__
+        return QUrl::fromLocalFile("/home");
+    });
+
+    QWidget parent;
+    QStyleOptionViewItem option;
+    QModelIndex index;
+
+    QWidget *editor = delegate->createEditor(&parent, option, index);
+
+    EXPECT_NE(editor, nullptr);
+    EXPECT_NE(qobject_cast<ItemEditor *>(editor), nullptr);
+
+    delete editor;
+}
+
+TEST_F(UT_CollectionItemDelegate, IsTransparent_NoCutAction_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ClipBoard, clipboardAction), [] {
+        __DBG_STUB_INVOKE__
+        return ClipBoard::kCopyAction;
+    });
+
+    QModelIndex index;
+    EXPECT_FALSE(delegate->isTransparent(index));
+}
+
+TEST_F(UT_CollectionItemDelegate, IsTransparent_CutActionNoFile_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(ClipBoard, clipboardAction), [] {
+        __DBG_STUB_INVOKE__
+        return ClipBoard::kCutAction;
+    });
+    stub.set_lamda(ADDR(CollectionModel, fileInfo), [] {
+        __DBG_STUB_INVOKE__
+        return FileInfoPointer(nullptr);
+    });
+
+    QModelIndex index;
+    EXPECT_FALSE(delegate->isTransparent(index));
+}
+
+TEST_F(UT_CollectionItemDelegate, IsThumnailIconIndex_InvalidIndex_ReturnsFalse)
+{
+    QModelIndex invalidIndex;
+    EXPECT_FALSE(delegate->isThumnailIconIndex(invalidIndex));
+}
+
+TEST_F(UT_CollectionItemDelegate, UpdateItemSizeHint_UpdatesSizeHint)
+{
+    QSize oldHint = delegate->sizeHint(QStyleOptionViewItem(), QModelIndex());
+
+    delegate->setIconLevel(3);
+    delegate->updateItemSizeHint();
+
+    QSize newHint = delegate->sizeHint(QStyleOptionViewItem(), QModelIndex());
+    EXPECT_NE(oldHint, newHint);
+}
+
+TEST_F(UT_CollectionItemDelegate, CommitDataAndCloseEditor_NoOpenEditor_DoesNotCrash)
+{
+    stub.set_lamda(VADDR(CollectionView, currentIndex), [] {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+    stub.set_lamda(ADDR(QAbstractItemView, isPersistentEditorOpen), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_NO_THROW(delegate->commitDataAndCloseEditor());
+}
+
+TEST_F(UT_CollectionItemDelegate, RevertAndCloseEditor_NoOpenEditor_DoesNotCrash)
+{
+    stub.set_lamda(VADDR(CollectionView, currentIndex), [] {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+    stub.set_lamda(ADDR(QAbstractItemView, isPersistentEditorOpen), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    EXPECT_NO_THROW(delegate->revertAndcloseEditor());
+}
+
+TEST_F(UT_CollectionItemDelegate, RevertAndCloseEditor_HasOpenEditor_ClosesEditor)
+{
+    bool closeCalled = false;
+    stub.set_lamda(VADDR(CollectionView, currentIndex), [] {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+    stub.set_lamda(ADDR(QAbstractItemView, isPersistentEditorOpen), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(ADDR(QAbstractItemView, closePersistentEditor), [&closeCalled] {
+        __DBG_STUB_INVOKE__
+        closeCalled = true;
+    });
+
+    delegate->revertAndcloseEditor();
+    EXPECT_TRUE(closeCalled);
+}
+
+TEST_F(UT_CollectionItemDelegate, ClipboardDataChanged_NoOpenEditor_UpdatesView)
+{
+    bool updateCalled = false;
+    stub.set_lamda(VADDR(CollectionView, currentIndex), [] {
+        __DBG_STUB_INVOKE__
+        return QModelIndex();
+    });
+    stub.set_lamda(ADDR(QAbstractItemView, isPersistentEditorOpen), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(qOverload<>(&QWidget::update), [&updateCalled] {
+        __DBG_STUB_INVOKE__
+        updateCalled = true;
+    });
+
+    delegate->clipboardDataChanged();
+    EXPECT_TRUE(updateCalled);
+    stub.clear();
+}
+
+class UT_CollectionItemDelegatePrivate : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        provider = new CustomDataHandler();
+        view = new CollectionView("test_uuid", provider);
+        delegate = new CollectionItemDelegate(view);
+    }
+
+    void TearDown() override
+    {
+        delete delegate;
+        delegate = nullptr;
+        delete view;
+        view = nullptr;
+        delete provider;
+        provider = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    CollectionItemDelegate *delegate = nullptr;
+    CollectionView *view = nullptr;
+    CollectionDataProvider *provider = nullptr;
+};
+
+TEST_F(UT_CollectionItemDelegatePrivate, AvailableTextRect_ModifiesTop)
+{
+    QRect labelRect(10, 50, 80, 100);
+    QRect result = delegate->d->availableTextRect(labelRect);
+
+    int expectedTop = labelRect.top() + CollectionItemDelegate::kIconSpacing
+            + CollectionItemDelegate::kTextPadding;
+    EXPECT_EQ(result.top(), expectedTop);
+    EXPECT_EQ(result.left(), labelRect.left());
+    EXPECT_EQ(result.width(), labelRect.width());
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, IsHighlight_SelectedWithDecoration_ReturnsTrue)
+{
+    QStyleOptionViewItem option;
+    option.state = QStyle::State_Selected;
+    option.showDecorationSelected = true;
+
+    EXPECT_TRUE(delegate->d->isHighlight(option));
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, IsHighlight_NotSelected_ReturnsFalse)
+{
+    QStyleOptionViewItem option;
+    option.state = QStyle::State_None;
+    option.showDecorationSelected = true;
+
+    EXPECT_FALSE(delegate->d->isHighlight(option));
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, IsHighlight_NoDecorationSelected_ReturnsFalse)
+{
+    QStyleOptionViewItem option;
+    option.state = QStyle::State_Selected;
+    option.showDecorationSelected = false;
+
+    EXPECT_FALSE(delegate->d->isHighlight(option));
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, CreateTextlayout_ReturnsValidLayout)
+{
+    stub.set_lamda(ADDR(Application, instance), [] {
+        __DBG_STUB_INVOKE__
+        static Application app;
+        return &app;
+    });
+    stub.set_lamda(&Application::genericAttribute, [] {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+
+    QStandardItemModel model;
+    model.appendRow(new QStandardItem("test"));
+    QModelIndex index = model.index(0, 0);
+
+    auto layout = delegate->d->createTextlayout(index, nullptr);
+    EXPECT_NE(layout, nullptr);
+    delete layout;
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, NeedExpend_SmallText_ReturnsFalse)
+{
+    stub.set_lamda(ADDR(Application, instance), [] {
+        __DBG_STUB_INVOKE__
+        static Application app;
+        return &app;
+    });
+    stub.set_lamda(&Application::genericAttribute, [] {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+    stub.set_lamda(ADDR(CollectionItemDelegate, textPaintRect), [] {
+        __DBG_STUB_INVOKE__
+        return QRect(0, 0, 80, 20);
+    });
+
+    QStyleOptionViewItem option;
+    QStandardItemModel model;
+    model.appendRow(new QStandardItem("short"));
+    QModelIndex index = model.index(0, 0);
+    QRect textRect(0, 0, 80, 40);
+
+    bool result = delegate->d->needExpend(option, index, textRect);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, NeedExpend_LongText_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(Application, instance), [] {
+        __DBG_STUB_INVOKE__
+        static Application app;
+        return &app;
+    });
+    stub.set_lamda(&Application::genericAttribute, [] {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+    stub.set_lamda(ADDR(CollectionItemDelegate, textPaintRect), [] {
+        __DBG_STUB_INVOKE__
+        return QRect(0, 0, 80, 100);
+    });
+
+    QStyleOptionViewItem option;
+    QStandardItemModel model;
+    model.appendRow(new QStandardItem("very long text that needs expansion"));
+    QModelIndex index = model.index(0, 0);
+    QRect textRect(0, 0, 80, 40);
+
+    bool result = delegate->d->needExpend(option, index, textRect);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, CurrentIconLevel_InitialValue_IsValid)
+{
+    EXPECT_GE(delegate->d->currentIconLevel, 0);
+    EXPECT_LE(delegate->d->currentIconLevel, CollectionItemDelegate::maximumIconLevel());
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, IconLevelDescriptions_HasCorrectCount)
+{
+    EXPECT_EQ(delegate->d->iconLevelDescriptions.size(),
+              CollectionItemDelegatePrivate::kIconSizes.size());
+}
+
+TEST_F(UT_CollectionItemDelegatePrivate, ItemSizeHint_IsValid)
+{
+    EXPECT_TRUE(delegate->d->itemSizeHint.isValid());
+    EXPECT_GT(delegate->d->itemSizeHint.width(), 0);
+    EXPECT_GT(delegate->d->itemSizeHint.height(), 0);
+}

--- a/autotests/plugins/ddplugin-organizer/test_collectionviewbroker.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_collectionviewbroker.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "broker/collectionviewbroker.h"
+#include "view/collectionview.h"
+#include "view/collectionview_p.h"
+#include "mode/collectiondataprovider.h"
+#include "mode/custom/customdatahandler.h"
+
+#include <QUrl>
+#include <QRect>
+#include <QPoint>
+
+#include <gtest/gtest.h>
+
+using namespace ddplugin_organizer;
+
+class UT_CollectionViewBroker : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&CollectionViewPrivate::initUI, []() {
+            __DBG_STUB_INVOKE__
+        });
+        stub.set_lamda(&CollectionViewPrivate::initConnect, []() {
+            __DBG_STUB_INVOKE__
+        });
+
+        provider = new CustomDataHandler();
+        view = new CollectionView("test_uuid", provider);
+        broker = new CollectionViewBroker(view);
+    }
+
+    virtual void TearDown() override
+    {
+        delete broker;
+        broker = nullptr;
+        delete view;
+        view = nullptr;
+        delete provider;
+        provider = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    CollectionViewBroker *broker = nullptr;
+    CollectionView *view = nullptr;
+    CollectionDataProvider *provider = nullptr;
+};
+
+TEST_F(UT_CollectionViewBroker, Constructor_WithParent_InitializesView)
+{
+    EXPECT_NE(broker, nullptr);
+    EXPECT_EQ(broker->getView(), view);
+    EXPECT_EQ(broker->parent(), view);
+}
+
+TEST_F(UT_CollectionViewBroker, Constructor_WithNullParent_ViewIsNull)
+{
+    CollectionViewBroker nullBroker(nullptr);
+    EXPECT_EQ(nullBroker.getView(), nullptr);
+}
+
+TEST_F(UT_CollectionViewBroker, getView_ReturnsCorrectView)
+{
+    EXPECT_EQ(broker->getView(), view);
+}
+
+TEST_F(UT_CollectionViewBroker, setView_UpdatesViewAndParent)
+{
+    CollectionViewBroker testBroker(nullptr);
+    EXPECT_EQ(testBroker.getView(), nullptr);
+
+    testBroker.setView(view);
+    EXPECT_EQ(testBroker.getView(), view);
+    EXPECT_EQ(testBroker.parent(), view);
+}
+
+TEST_F(UT_CollectionViewBroker, setView_WithNull_SetsNull)
+{
+    broker->setView(nullptr);
+    EXPECT_EQ(broker->getView(), nullptr);
+}
+
+TEST_F(UT_CollectionViewBroker, gridPoint_FileInList_ReturnsTrueAndSetsPos)
+{
+    QUrl testFile("file:///tmp/test.txt");
+    QList<QUrl> mockItems;
+    mockItems.append(testFile);
+    QPoint expectedPos(2, 3);
+
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&mockItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockItems;
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::nodeToPos, [&expectedPos](CollectionViewPrivate *, int node) {
+        __DBG_STUB_INVOKE__
+        return expectedPos;
+    });
+
+    QPoint resultPos;
+    bool result = broker->gridPoint(testFile, resultPos);
+
+    EXPECT_TRUE(result);
+    EXPECT_EQ(resultPos, expectedPos);
+}
+
+TEST_F(UT_CollectionViewBroker, gridPoint_FileNotInList_ReturnsFalse)
+{
+    QUrl testFile("file:///tmp/nonexistent.txt");
+    QList<QUrl> mockItems;
+    mockItems.append(QUrl("file:///tmp/other.txt"));
+
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&mockItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockItems;
+    });
+
+    QPoint resultPos(999, 999);
+    bool result = broker->gridPoint(testFile, resultPos);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_CollectionViewBroker, gridPoint_EmptyList_ReturnsFalse)
+{
+    QUrl testFile("file:///tmp/test.txt");
+    QList<QUrl> emptyItems;
+
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&emptyItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return emptyItems;
+    });
+
+    QPoint resultPos;
+    bool result = broker->gridPoint(testFile, resultPos);
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_CollectionViewBroker, gridPoint_MultipleFiles_FindsCorrectIndex)
+{
+    QUrl file1("file:///tmp/file1.txt");
+    QUrl file2("file:///tmp/file2.txt");
+    QUrl file3("file:///tmp/file3.txt");
+    QList<QUrl> mockItems;
+    mockItems << file1 << file2 << file3;
+
+    int calledWithNode = -1;
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&mockItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockItems;
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::nodeToPos, [&calledWithNode](CollectionViewPrivate *, int node) {
+        __DBG_STUB_INVOKE__
+        calledWithNode = node;
+        return QPoint(node, node);
+    });
+
+    QPoint resultPos;
+    broker->gridPoint(file2, resultPos);
+
+    EXPECT_EQ(calledWithNode, 1);
+    EXPECT_EQ(resultPos, QPoint(1, 1));
+}
+
+TEST_F(UT_CollectionViewBroker, visualRect_FileInList_ReturnsRect)
+{
+    QUrl testFile("file:///tmp/test.txt");
+    QList<QUrl> mockItems;
+    mockItems.append(testFile);
+    QPoint nodePos(1, 2);
+    QRect expectedRect(10, 20, 100, 100);
+
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&mockItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockItems;
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::nodeToPos, [&nodePos](CollectionViewPrivate *, int) {
+        __DBG_STUB_INVOKE__
+        return nodePos;
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::visualRect, [&expectedRect](CollectionViewPrivate *, const QPoint &) {
+        __DBG_STUB_INVOKE__
+        return expectedRect;
+    });
+
+    QRect result = broker->visualRect(testFile);
+
+    EXPECT_EQ(result, expectedRect);
+}
+
+TEST_F(UT_CollectionViewBroker, visualRect_FileNotInList_ReturnsEmptyRect)
+{
+    QUrl testFile("file:///tmp/nonexistent.txt");
+    QList<QUrl> mockItems;
+    mockItems.append(QUrl("file:///tmp/other.txt"));
+
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&mockItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockItems;
+    });
+
+    QRect result = broker->visualRect(testFile);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_CollectionViewBroker, visualRect_EmptyList_ReturnsEmptyRect)
+{
+    QUrl testFile("file:///tmp/test.txt");
+    QList<QUrl> emptyItems;
+
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&emptyItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return emptyItems;
+    });
+
+    QRect result = broker->visualRect(testFile);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_CollectionViewBroker, visualRect_CallsNodeToPosWithCorrectNode)
+{
+    QUrl file1("file:///tmp/file1.txt");
+    QUrl file2("file:///tmp/file2.txt");
+    QList<QUrl> mockItems;
+    mockItems << file1 << file2;
+
+    int calledWithNode = -1;
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&mockItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockItems;
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::nodeToPos, [&calledWithNode](CollectionViewPrivate *, int node) {
+        __DBG_STUB_INVOKE__
+        calledWithNode = node;
+        return QPoint(0, 0);
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::visualRect, [](CollectionViewPrivate *, const QPoint &) {
+        __DBG_STUB_INVOKE__
+        return QRect(0, 0, 50, 50);
+    });
+
+    broker->visualRect(file2);
+
+    EXPECT_EQ(calledWithNode, 1);
+}
+
+TEST_F(UT_CollectionViewBroker, visualRect_PassesPosToVisualRect)
+{
+    QUrl testFile("file:///tmp/test.txt");
+    QList<QUrl> mockItems;
+    mockItems.append(testFile);
+    QPoint expectedPos(5, 10);
+    QPoint receivedPos;
+
+    stub.set_lamda(VADDR(CustomDataHandler, items), [&mockItems](CollectionDataProvider *, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockItems;
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::nodeToPos, [&expectedPos](CollectionViewPrivate *, int) {
+        __DBG_STUB_INVOKE__
+        return expectedPos;
+    });
+
+    stub.set_lamda(&CollectionViewPrivate::visualRect, [&receivedPos](CollectionViewPrivate *, const QPoint &pos) {
+        __DBG_STUB_INVOKE__
+        receivedPos = pos;
+        return QRect(0, 0, 50, 50);
+    });
+
+    broker->visualRect(testFile);
+
+    EXPECT_EQ(receivedPos, expectedPos);
+}

--- a/autotests/plugins/ddplugin-organizer/test_configpresenter.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_configpresenter.cpp
@@ -1,0 +1,462 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "config/configpresenter.h"
+#include "config/organizerconfig.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <QKeySequence>
+#include <QWidget>
+#include <QSignalSpy>
+
+#include <gtest/gtest.h>
+
+using namespace ddplugin_organizer;
+DFMBASE_USE_NAMESPACE
+
+class UT_ConfigPresenter : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        presenter = ConfigPresenter::instance();
+        presenter->initialize();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    ConfigPresenter *presenter = nullptr;
+};
+
+TEST_F(UT_ConfigPresenter, instance_ReturnsSingleton)
+{
+    ConfigPresenter *instance1 = ConfigPresenter::instance();
+    ConfigPresenter *instance2 = ConfigPresenter::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_ConfigPresenter, version_ReturnsSetVersion)
+{
+    QString testVersion = "1.0.0";
+
+    stub.set_lamda(&OrganizerConfig::setVersion, [](OrganizerConfig *, const QString &) {
+        __DBG_STUB_INVOKE__
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    presenter->setVersion(testVersion);
+    EXPECT_EQ(presenter->version(), testVersion);
+}
+
+TEST_F(UT_ConfigPresenter, isEnable_ReturnsEnableState)
+{
+    EXPECT_TRUE(presenter->isEnable() == true || presenter->isEnable() == false);
+}
+
+TEST_F(UT_ConfigPresenter, setEnable_UpdatesEnableState)
+{
+    stub.set_lamda(&DConfigManager::setValue, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+    });
+    stub.set_lamda(&OrganizerConfig::setEnable, [](OrganizerConfig *, bool) {
+        __DBG_STUB_INVOKE__
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    presenter->setEnable(true);
+    EXPECT_TRUE(presenter->isEnable());
+
+    presenter->setEnable(false);
+    EXPECT_FALSE(presenter->isEnable());
+}
+
+TEST_F(UT_ConfigPresenter, isEnableVisibility_ReturnsVisibilityState)
+{
+    EXPECT_TRUE(presenter->isEnableVisibility() == true || presenter->isEnableVisibility() == false);
+}
+
+TEST_F(UT_ConfigPresenter, setEnableVisibility_UpdatesVisibilityState)
+{
+    stub.set_lamda(&DConfigManager::setValue, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+    });
+
+    presenter->setEnableVisibility(true);
+    EXPECT_TRUE(presenter->isEnableVisibility());
+
+    presenter->setEnableVisibility(false);
+    EXPECT_FALSE(presenter->isEnableVisibility());
+}
+
+TEST_F(UT_ConfigPresenter, mode_ReturnsCurrentMode)
+{
+    OrganizerMode mode = presenter->mode();
+    EXPECT_TRUE(mode >= OrganizerMode::kNormalized && mode <= OrganizerMode::kCustom);
+}
+
+TEST_F(UT_ConfigPresenter, setMode_UpdatesMode)
+{
+    stub.set_lamda(&OrganizerConfig::setMode, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    presenter->setMode(OrganizerMode::kNormalized);
+    EXPECT_EQ(presenter->mode(), OrganizerMode::kNormalized);
+}
+
+TEST_F(UT_ConfigPresenter, classification_ReturnsCurrentClassifier)
+{
+    Classifier cf = presenter->classification();
+    EXPECT_TRUE(cf >= Classifier::kType && cf <= Classifier::kSize);
+}
+
+TEST_F(UT_ConfigPresenter, setClassification_UpdatesClassifier)
+{
+    stub.set_lamda(&OrganizerConfig::setClassification, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    presenter->setClassification(Classifier::kType);
+    EXPECT_EQ(presenter->classification(), Classifier::kType);
+}
+
+TEST_F(UT_ConfigPresenter, hideAllKeySequence_ReturnsKeySequence)
+{
+    QString mockSeq = "Ctrl+H";
+
+    stub.set_lamda(&DConfigManager::value, [mockSeq](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(mockSeq);
+    });
+
+    QKeySequence seq = presenter->hideAllKeySequence();
+    EXPECT_EQ(seq.toString(), mockSeq);
+}
+
+TEST_F(UT_ConfigPresenter, setHideAllKeySequence_SetsKeySequence)
+{
+    bool setValueCalled = false;
+
+    stub.set_lamda(&DConfigManager::setValue, [&setValueCalled](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        setValueCalled = true;
+    });
+
+    presenter->setHideAllKeySequence(QKeySequence("Ctrl+H"));
+    EXPECT_TRUE(setValueCalled);
+}
+
+TEST_F(UT_ConfigPresenter, isRepeatNoMore_ReturnsValue)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+
+    EXPECT_TRUE(presenter->isRepeatNoMore());
+}
+
+TEST_F(UT_ConfigPresenter, setRepeatNoMore_SetsValue)
+{
+    bool setValueCalled = false;
+
+    stub.set_lamda(&DConfigManager::setValue, [&setValueCalled](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        setValueCalled = true;
+    });
+
+    presenter->setRepeatNoMore(true);
+    EXPECT_TRUE(setValueCalled);
+}
+
+TEST_F(UT_ConfigPresenter, surfaceSizes_ReturnsListOfSizes)
+{
+    QList<QSize> mockSizes = { QSize(1920, 1080), QSize(1280, 720) };
+
+    stub.set_lamda(&OrganizerConfig::surfaceSizes, [mockSizes](OrganizerConfig *) {
+        __DBG_STUB_INVOKE__
+        return mockSizes;
+    });
+
+    QList<QSize> result = presenter->surfaceSizes();
+    EXPECT_EQ(result.size(), 2);
+}
+
+TEST_F(UT_ConfigPresenter, lastStyleConfigId_ReturnsId)
+{
+    QString mockId = "config_123";
+
+    stub.set_lamda(&OrganizerConfig::lastStyleConfigId, [mockId](const OrganizerConfig *) {
+        __DBG_STUB_INVOKE__
+        return mockId;
+    });
+
+    EXPECT_EQ(presenter->lastStyleConfigId(), mockId);
+}
+
+TEST_F(UT_ConfigPresenter, setLastStyleConfigId_SetsId)
+{
+    bool setIdCalled = false;
+
+    stub.set_lamda(&OrganizerConfig::setLastStyleConfigId, [&setIdCalled](OrganizerConfig *, const QString &) {
+        __DBG_STUB_INVOKE__
+        setIdCalled = true;
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    presenter->setLastStyleConfigId("test_id");
+    EXPECT_TRUE(setIdCalled);
+}
+
+TEST_F(UT_ConfigPresenter, hasConfigId_ReturnsTrueIfExists)
+{
+    stub.set_lamda(&OrganizerConfig::hasConfigId, [](const OrganizerConfig *, const QString &id) {
+        __DBG_STUB_INVOKE__
+        return id == "existing_id";
+    });
+
+    EXPECT_TRUE(presenter->hasConfigId("existing_id"));
+    EXPECT_FALSE(presenter->hasConfigId("nonexistent_id"));
+}
+
+TEST_F(UT_ConfigPresenter, customProfile_ReturnsCollectionBaseList)
+{
+    QList<CollectionBaseDataPtr> mockList;
+    CollectionBaseDataPtr data(new CollectionBaseData);
+    data->key = "test_key";
+    data->name = "Test Collection";
+    mockList.append(data);
+
+    stub.set_lamda(qOverload<bool>(&OrganizerConfig::collectionBase), [mockList](const OrganizerConfig *, bool custom) {
+        __DBG_STUB_INVOKE__
+        if (custom)
+            return mockList;
+        return QList<CollectionBaseDataPtr>();
+    });
+
+    QList<CollectionBaseDataPtr> result = presenter->customProfile();
+    EXPECT_EQ(result.size(), 1);
+}
+
+TEST_F(UT_ConfigPresenter, saveCustomProfile_SavesProfile)
+{
+    bool writeCalled = false;
+
+    stub.set_lamda(&OrganizerConfig::writeCollectionBase, [&writeCalled](OrganizerConfig *, bool, const QList<CollectionBaseDataPtr> &) {
+        __DBG_STUB_INVOKE__
+        writeCalled = true;
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QList<CollectionBaseDataPtr> data;
+    presenter->saveCustomProfile(data);
+    EXPECT_TRUE(writeCalled);
+}
+
+TEST_F(UT_ConfigPresenter, normalProfile_ReturnsCollectionBaseList)
+{
+    QList<CollectionBaseDataPtr> mockList;
+    CollectionBaseDataPtr data(new CollectionBaseData);
+    data->key = "normal_key";
+    data->name = "Normal Collection";
+    mockList.append(data);
+
+    stub.set_lamda(qOverload<bool>(&OrganizerConfig::collectionBase), [mockList](const OrganizerConfig *, bool custom) {
+        __DBG_STUB_INVOKE__
+        if (!custom)
+            return mockList;
+        return QList<CollectionBaseDataPtr>();
+    });
+
+    QList<CollectionBaseDataPtr> result = presenter->normalProfile();
+    EXPECT_EQ(result.size(), 1);
+}
+
+TEST_F(UT_ConfigPresenter, saveNormalProfile_SavesProfile)
+{
+    bool writeCalled = false;
+
+    stub.set_lamda(&OrganizerConfig::writeCollectionBase, [&writeCalled](OrganizerConfig *, bool, const QList<CollectionBaseDataPtr> &) {
+        __DBG_STUB_INVOKE__
+        writeCalled = true;
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QList<CollectionBaseDataPtr> data;
+    presenter->saveNormalProfile(data);
+    EXPECT_TRUE(writeCalled);
+}
+
+TEST_F(UT_ConfigPresenter, normalStyle_WithValidKey_ReturnsStyle)
+{
+    CollectionStyle mockStyle;
+    mockStyle.key = "test_key";
+    mockStyle.screenIndex = 1;
+
+    stub.set_lamda(&OrganizerConfig::collectionStyle, [mockStyle](const OrganizerConfig *, const QString &, const QString &) {
+        __DBG_STUB_INVOKE__
+        return mockStyle;
+    });
+
+    CollectionStyle result = presenter->normalStyle("config_id", "test_key");
+    EXPECT_EQ(result.key, "test_key");
+}
+
+TEST_F(UT_ConfigPresenter, normalStyle_WithEmptyKey_ReturnsEmptyStyle)
+{
+    CollectionStyle result = presenter->normalStyle("config_id", "");
+    EXPECT_TRUE(result.key.isEmpty());
+}
+
+TEST_F(UT_ConfigPresenter, updateNormalStyle_WithValidStyle_UpdatesStyle)
+{
+    bool updateCalled = false;
+
+    stub.set_lamda(&OrganizerConfig::updateCollectionStyle, [&updateCalled](OrganizerConfig *, const QString &, const CollectionStyle &) {
+        __DBG_STUB_INVOKE__
+        updateCalled = true;
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    CollectionStyle style;
+    style.key = "test_key";
+    presenter->updateNormalStyle("config_id", style);
+    EXPECT_TRUE(updateCalled);
+}
+
+TEST_F(UT_ConfigPresenter, updateNormalStyle_WithEmptyKey_DoesNotUpdate)
+{
+    bool updateCalled = false;
+
+    stub.set_lamda(&OrganizerConfig::updateCollectionStyle, [&updateCalled](OrganizerConfig *, const QString &, const CollectionStyle &) {
+        __DBG_STUB_INVOKE__
+        updateCalled = true;
+    });
+
+    CollectionStyle style;
+    style.key = "";
+    presenter->updateNormalStyle("config_id", style);
+    EXPECT_FALSE(updateCalled);
+}
+
+TEST_F(UT_ConfigPresenter, customStyle_ReturnsEmptyStyle)
+{
+    CollectionStyle result = presenter->customStyle("any_key");
+    EXPECT_TRUE(result.key.isEmpty());
+}
+
+TEST_F(UT_ConfigPresenter, enabledTypeCategories_ReturnsCategories)
+{
+    QStringList mockCategories = { "kApp", "kDocument", "kPicture" };
+
+    stub.set_lamda(&DConfigManager::value, [mockCategories](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(mockCategories);
+    });
+
+    ItemCategories result = presenter->enabledTypeCategories();
+    EXPECT_TRUE(result & kCatApplication);
+    EXPECT_TRUE(result & kCatDocument);
+    EXPECT_TRUE(result & kCatPicture);
+}
+
+TEST_F(UT_ConfigPresenter, setEnabledTypeCategories_SetsCategories)
+{
+    bool setValueCalled = false;
+
+    stub.set_lamda(&DConfigManager::setValue, [&setValueCalled](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        setValueCalled = true;
+    });
+
+    ItemCategories cats;
+    cats |= kCatApplication;
+    cats |= kCatDocument;
+    presenter->setEnabledTypeCategories(cats);
+    EXPECT_TRUE(setValueCalled);
+}
+
+TEST_F(UT_ConfigPresenter, organizeAction_ReturnsAction)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(0);
+    });
+
+    EXPECT_EQ(presenter->organizeAction(), kOnTrigger);
+}
+
+TEST_F(UT_ConfigPresenter, organizeAction_ReturnsAlways)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(1);
+    });
+
+    EXPECT_EQ(presenter->organizeAction(), kAlways);
+}
+
+TEST_F(UT_ConfigPresenter, organizeOnTriggered_ReturnsTrueForOnTrigger)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(0);
+    });
+
+    EXPECT_TRUE(presenter->organizeOnTriggered());
+}
+
+TEST_F(UT_ConfigPresenter, optimizeMovingPerformance_ReturnsValue)
+{
+    stub.set_lamda(&DConfigManager::value, [](DConfigManager *, const QString &, const QString &, const QVariant &) {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);
+    });
+
+    EXPECT_TRUE(presenter->optimizeMovingPerformance());
+}
+
+TEST_F(UT_ConfigPresenter, writeNormalStyle_WritesStyles)
+{
+    bool writeCalled = false;
+
+    stub.set_lamda(&OrganizerConfig::writeCollectionStyle, [&writeCalled](OrganizerConfig *, const QString &, const QList<CollectionStyle> &) {
+        __DBG_STUB_INVOKE__
+        writeCalled = true;
+    });
+    stub.set_lamda(&OrganizerConfig::sync, [](OrganizerConfig *, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    QList<CollectionStyle> styles;
+    presenter->writeNormalStyle("config_id", styles);
+    EXPECT_TRUE(writeCalled);
+}

--- a/autotests/plugins/ddplugin-organizer/test_itemeditor.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_itemeditor.cpp
@@ -1,0 +1,607 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "delegate/itemeditor.h"
+#include "delegate/collectionitemdelegate.h"
+
+#include <dfm-base/utils/fileutils.h>
+
+#include <DArrowRectangle>
+#include <DStyle>
+
+#include <QApplication>
+#include <QVBoxLayout>
+#include <QGraphicsOpacityEffect>
+#include <QTextCursor>
+#include <QLabel>
+#include <QTimer>
+#include <QKeyEvent>
+#include <QFocusEvent>
+
+#include <gtest/gtest.h>
+
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+using namespace ddplugin_organizer;
+
+class UT_ItemEditor : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        editor = new ItemEditor();
+    }
+
+    void TearDown() override
+    {
+        delete editor;
+        editor = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    ItemEditor *editor = nullptr;
+};
+
+TEST_F(UT_ItemEditor, Constructor_InitializesCorrectly)
+{
+    EXPECT_NE(editor, nullptr);
+    EXPECT_NE(editor->editor(), nullptr);
+    EXPECT_EQ(editor->frameShape(), QFrame::NoFrame);
+}
+
+TEST_F(UT_ItemEditor, Text_EmptyEditor_ReturnsEmpty)
+{
+    EXPECT_TRUE(editor->text().isEmpty());
+}
+
+TEST_F(UT_ItemEditor, SetText_ValidText_SetsText)
+{
+    QString testText = "test_file.txt";
+    editor->setText(testText);
+    EXPECT_EQ(editor->text(), testText);
+}
+
+TEST_F(UT_ItemEditor, SetText_EmptyText_SetsEmpty)
+{
+    editor->setText("");
+    EXPECT_TRUE(editor->text().isEmpty());
+}
+
+TEST_F(UT_ItemEditor, MaximumLength_DefaultValue_ReturnsMax)
+{
+    EXPECT_EQ(editor->maximumLength(), INT_MAX);
+}
+
+TEST_F(UT_ItemEditor, SetMaximumLength_ValidValue_SetsLength)
+{
+    editor->setMaximumLength(255);
+    EXPECT_EQ(editor->maximumLength(), 255);
+}
+
+TEST_F(UT_ItemEditor, SetMaximumLength_ZeroValue_KeepsOld)
+{
+    int oldMax = editor->maximumLength();
+    editor->setMaximumLength(0);
+    EXPECT_EQ(editor->maximumLength(), oldMax);
+}
+
+TEST_F(UT_ItemEditor, SetMaximumLength_NegativeValue_KeepsOld)
+{
+    int oldMax = editor->maximumLength();
+    editor->setMaximumLength(-10);
+    EXPECT_EQ(editor->maximumLength(), oldMax);
+}
+
+TEST_F(UT_ItemEditor, SetMaxHeight_SetsValue)
+{
+    editor->setMaxHeight(500);
+    EXPECT_NO_THROW(editor->updateGeometry());
+}
+
+TEST_F(UT_ItemEditor, SetCharCountLimit_SetsFlag)
+{
+    editor->setCharCountLimit();
+    EXPECT_NO_THROW(editor->updateGeometry());
+}
+
+TEST_F(UT_ItemEditor, SetOpacity_FullOpacity_RemovesEffect)
+{
+    editor->setOpacity(0.5);
+    editor->setOpacity(1.0);
+    EXPECT_EQ(editor->graphicsEffect(), nullptr);
+}
+
+TEST_F(UT_ItemEditor, SetOpacity_LessThanOne_AddsEffect)
+{
+    editor->setOpacity(0.5);
+    QGraphicsOpacityEffect *effect = qobject_cast<QGraphicsOpacityEffect *>(editor->graphicsEffect());
+    EXPECT_NE(effect, nullptr);
+    EXPECT_DOUBLE_EQ(effect->opacity(), 0.5);
+}
+
+TEST_F(UT_ItemEditor, SetOpacity_ZeroOpacity_AddsEffect)
+{
+    editor->setOpacity(0.0);
+    QGraphicsOpacityEffect *effect = qobject_cast<QGraphicsOpacityEffect *>(editor->graphicsEffect());
+    EXPECT_NE(effect, nullptr);
+}
+
+TEST_F(UT_ItemEditor, SetOpacity_MultipleCalls_UpdatesEffect)
+{
+    editor->setOpacity(0.5);
+    editor->setOpacity(0.3);
+    QGraphicsOpacityEffect *effect = qobject_cast<QGraphicsOpacityEffect *>(editor->graphicsEffect());
+    EXPECT_NE(effect, nullptr);
+    EXPECT_DOUBLE_EQ(effect->opacity(), 0.3);
+}
+
+TEST_F(UT_ItemEditor, Select_TextContainsPart_SelectsPart)
+{
+    QString fullText = "test_file.txt";
+    QString part = "test_file";
+    editor->setText(fullText);
+    editor->select(part);
+
+    QTextCursor cursor = editor->editor()->textCursor();
+    EXPECT_TRUE(cursor.hasSelection());
+}
+
+TEST_F(UT_ItemEditor, Select_TextNotContainsPart_NoSelection)
+{
+    QString fullText = "test_file.txt";
+    QString part = "nonexistent";
+    editor->setText(fullText);
+    editor->select(part);
+
+    QTextCursor cursor = editor->editor()->textCursor();
+    EXPECT_FALSE(cursor.hasSelection());
+}
+
+TEST_F(UT_ItemEditor, SetBaseGeometry_SetsGeometry)
+{
+    QRect base(100, 100, 200, 300);
+    QSize itemSize(150, 200);
+    QMargins margin(5, 10, 5, 10);
+
+    editor->setBaseGeometry(base, itemSize, margin);
+
+    EXPECT_EQ(editor->pos(), base.topLeft());
+    EXPECT_EQ(editor->width(), base.width());
+}
+
+TEST_F(UT_ItemEditor, UpdateGeometry_WithText_AdjustsSize)
+{
+    editor->setText("test");
+    editor->updateGeometry();
+    EXPECT_TRUE(editor->height() > 0);
+}
+
+TEST_F(UT_ItemEditor, Editor_ReturnsValidEditor)
+{
+    RenameEdit *renameEdit = editor->editor();
+    EXPECT_NE(renameEdit, nullptr);
+}
+
+TEST_F(UT_ItemEditor, CreateEditor_ReturnsValidEdit)
+{
+    RenameEdit *edit = ItemEditor::createEditor();
+    EXPECT_NE(edit, nullptr);
+    EXPECT_EQ(edit->wordWrapMode(), QTextOption::WrapAnywhere);
+    EXPECT_EQ(edit->alignment(), Qt::AlignHCenter);
+    EXPECT_EQ(edit->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(edit->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(edit->frameShape(), QFrame::NoFrame);
+    delete edit;
+}
+
+TEST_F(UT_ItemEditor, CreateTooltip_ReturnsValidTooltip)
+{
+    DArrowRectangle *tooltip = ItemEditor::createTooltip();
+    EXPECT_NE(tooltip, nullptr);
+    EXPECT_EQ(tooltip->objectName(), "AlertTooltip");
+
+    QLabel *label = qobject_cast<QLabel *>(tooltip->getContent());
+    EXPECT_NE(label, nullptr);
+    EXPECT_TRUE(label->wordWrap());
+
+    delete tooltip;
+}
+
+TEST_F(UT_ItemEditor, ShowAlertMessage_CreatesTooltip)
+{
+    stub.set_lamda(VADDR(DArrowRectangle, show), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    editor->showAlertMessage("Test message", 100);
+    EXPECT_NE(editor->tooltip, nullptr);
+}
+
+TEST_F(UT_ItemEditor, ShowAlertMessage_SetsLabelText)
+{
+    stub.set_lamda(VADDR(DArrowRectangle, show), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    QString testMsg = "Test alert message";
+    editor->showAlertMessage(testMsg, 100);
+
+    QLabel *label = qobject_cast<QLabel *>(editor->tooltip->getContent());
+    EXPECT_NE(label, nullptr);
+    EXPECT_EQ(label->text(), testMsg);
+}
+
+class UT_RenameEdit : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        edit = new RenameEdit();
+    }
+
+    void TearDown() override
+    {
+        delete edit;
+        edit = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    RenameEdit *edit = nullptr;
+};
+
+TEST_F(UT_RenameEdit, Constructor_InitializesCorrectly)
+{
+    EXPECT_NE(edit, nullptr);
+    EXPECT_EQ(edit->document()->documentMargin(), CollectionItemDelegate::kTextPadding);
+}
+
+TEST_F(UT_RenameEdit, StackCurrent_EmptyStack_ReturnsEmpty)
+{
+    EXPECT_TRUE(edit->stackCurrent().isEmpty());
+}
+
+TEST_F(UT_RenameEdit, PushStack_AddsItem)
+{
+    edit->pushStatck("first");
+    EXPECT_EQ(edit->stackCurrent(), "first");
+}
+
+TEST_F(UT_RenameEdit, PushStack_MultipleItems_ReturnsLast)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    edit->pushStatck("third");
+    EXPECT_EQ(edit->stackCurrent(), "third");
+}
+
+TEST_F(UT_RenameEdit, StackBack_SingleItem_ReturnsSame)
+{
+    edit->pushStatck("only");
+    QString result = edit->stackBack();
+    EXPECT_EQ(result, "only");
+}
+
+TEST_F(UT_RenameEdit, StackBack_MultipleItems_ReturnsPrevious)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    QString result = edit->stackBack();
+    EXPECT_EQ(result, "first");
+}
+
+TEST_F(UT_RenameEdit, StackBack_AtBeginning_ReturnsFirst)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    edit->stackBack();
+    QString result = edit->stackBack();
+    EXPECT_EQ(result, "first");
+}
+
+TEST_F(UT_RenameEdit, StackAdvance_AtEnd_ReturnsLast)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    QString result = edit->stackAdvance();
+    EXPECT_EQ(result, "second");
+}
+
+TEST_F(UT_RenameEdit, StackAdvance_AfterBack_ReturnsNext)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    edit->pushStatck("third");
+    edit->stackBack();
+    edit->stackBack();
+    QString result = edit->stackAdvance();
+    EXPECT_EQ(result, "second");
+}
+
+TEST_F(UT_RenameEdit, PushStack_AfterBack_RemovesForwardHistory)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    edit->pushStatck("third");
+    edit->stackBack();
+    edit->stackBack();
+    edit->pushStatck("new");
+
+    EXPECT_EQ(edit->stackCurrent(), "new");
+    QString advanced = edit->stackAdvance();
+    EXPECT_EQ(advanced, "new");
+}
+
+TEST_F(UT_RenameEdit, Undo_RestoresPreviousText)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    edit->undo();
+    EXPECT_EQ(edit->stackCurrent(), "first");
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, Redo_RestoresNextText)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    edit->stackBack();
+
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    edit->redo();
+    EXPECT_EQ(edit->stackCurrent(), "second");
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, AdjustStyle_SetsDocumentMargin)
+{
+    edit->adjustStyle();
+    EXPECT_EQ(edit->document()->documentMargin(), CollectionItemDelegate::kTextPadding);
+}
+
+TEST_F(UT_RenameEdit, KeyPressEvent_EnterKey_AcceptsEvent)
+{
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
+    edit->keyPressEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, KeyPressEvent_TabKey_AcceptsEvent)
+{
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
+    edit->keyPressEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, KeyPressEvent_BacktabKey_AcceptsEvent)
+{
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Backtab, Qt::NoModifier);
+    edit->keyPressEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, KeyPressEvent_UndoSequence_CallsUndo)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Z, Qt::ControlModifier);
+    edit->keyPressEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+    EXPECT_EQ(edit->stackCurrent(), "first");
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, KeyPressEvent_RedoSequence_CallsRedo)
+{
+    edit->pushStatck("first");
+    edit->pushStatck("second");
+    edit->stackBack();
+
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Y, Qt::ControlModifier);
+    edit->keyPressEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+    EXPECT_EQ(edit->stackCurrent(), "second");
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, ShowEvent_NotActiveWindow_ActivatesWindow)
+{
+    bool activateCalled = false;
+    stub.set_lamda(ADDR(QWidget, isActiveWindow), [] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+    stub.set_lamda(ADDR(QWidget, activateWindow), [&activateCalled] {
+        __DBG_STUB_INVOKE__
+        activateCalled = true;
+    });
+
+    QShowEvent event;
+    edit->showEvent(&event);
+
+    EXPECT_TRUE(activateCalled);
+}
+
+TEST_F(UT_RenameEdit, ShowEvent_IsActiveWindow_DoesNotActivate)
+{
+    bool activateCalled = false;
+    stub.set_lamda(ADDR(QWidget, isActiveWindow), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+    stub.set_lamda(ADDR(QWidget, activateWindow), [&activateCalled] {
+        __DBG_STUB_INVOKE__
+        activateCalled = true;
+    });
+
+    QShowEvent event;
+    edit->showEvent(&event);
+
+    EXPECT_FALSE(activateCalled);
+}
+
+TEST_F(UT_RenameEdit, FocusOutEvent_DifferentFocusWidget_InvokesInputFocusOut)
+{
+    ItemEditor *parent = new ItemEditor();
+    edit->setParent(parent);
+
+    stub.set_lamda(&QApplication::focusWidget, [] {
+        __DBG_STUB_INVOKE__
+        return static_cast<QWidget *>(nullptr);
+    });
+
+    QFocusEvent event(QEvent::FocusOut, Qt::OtherFocusReason);
+    edit->focusOutEvent(&event);
+
+    edit->setParent(nullptr);
+    delete parent;
+}
+
+TEST_F(UT_RenameEdit, EventFilter_PaintEvent_ReturnsTrueForSelf)
+{
+    QPaintEvent paintEvent(QRect(0, 0, 100, 100));
+    bool result = edit->eventFilter(edit, &paintEvent);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_RenameEdit, EventFilter_NonPaintEvent_ReturnsFalse)
+{
+    QMouseEvent mouseEvent(QEvent::MouseButtonPress, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    bool result = edit->eventFilter(edit, &mouseEvent);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_RenameEdit, EventFilter_PaintEventOtherObj_CallsBase)
+{
+    QWidget other;
+    QPaintEvent paintEvent(QRect(0, 0, 100, 100));
+    bool result = edit->eventFilter(&other, &paintEvent);
+    EXPECT_FALSE(result);
+}
+
+class UT_ItemEditor_TextChanged : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        editor = new ItemEditor();
+    }
+
+    void TearDown() override
+    {
+        delete editor;
+        editor = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    ItemEditor *editor = nullptr;
+};
+
+TEST_F(UT_ItemEditor_TextChanged, TextChanged_EmptyText_UpdatesGeometry)
+{
+    editor->setText("");
+    EXPECT_NO_THROW(editor->updateGeometry());
+}
+
+TEST_F(UT_ItemEditor_TextChanged, TextChanged_ReadOnly_DoesNotProcess)
+{
+    editor->editor()->setReadOnly(true);
+    editor->setText("test");
+    EXPECT_TRUE(editor->editor()->isReadOnly());
+}
+
+class UT_RenameEdit_ContextMenu : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        edit = new RenameEdit();
+    }
+
+    void TearDown() override
+    {
+        delete edit;
+        edit = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    RenameEdit *edit = nullptr;
+};
+
+TEST_F(UT_RenameEdit_ContextMenu, ContextMenuEvent_ReadOnly_AcceptsEvent)
+{
+    edit->setReadOnly(true);
+
+    QContextMenuEvent event(QContextMenuEvent::Mouse, QPoint(10, 10));
+    edit->contextMenuEvent(&event);
+
+    EXPECT_TRUE(event.isAccepted());
+}
+
+TEST_F(UT_RenameEdit_ContextMenu, ContextMenuEvent_NotReadOnly_CreatesMenu)
+{
+    bool menuCreated = false;
+    stub.set_lamda(qOverload<>(&QTextEdit::createStandardContextMenu), [&menuCreated] {
+        __DBG_STUB_INVOKE__
+        menuCreated = true;
+        return static_cast<QMenu *>(nullptr);
+    });
+
+    QContextMenuEvent event(QContextMenuEvent::Mouse, QPoint(10, 10));
+    edit->contextMenuEvent(&event);
+
+    EXPECT_TRUE(menuCreated);
+}

--- a/autotests/plugins/ddplugin-organizer/test_organizerbroker.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_organizerbroker.cpp
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "broker/organizerbroker.h"
+
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QRect>
+#include <QPoint>
+#include <QAbstractItemView>
+
+#include <gtest/gtest.h>
+
+using namespace ddplugin_organizer;
+
+class MockOrganizerBroker : public OrganizerBroker
+{
+public:
+    explicit MockOrganizerBroker(QObject *parent = nullptr)
+        : OrganizerBroker(parent) {}
+
+    void refreshModel(bool global, int ms, bool file) override
+    {
+        refreshModelCalled = true;
+        lastGlobal = global;
+        lastMs = ms;
+        lastFile = file;
+    }
+
+    QString gridPoint(const QUrl &item, QPoint *point) override
+    {
+        gridPointCalled = true;
+        lastGridPointUrl = item;
+        if (point)
+            *point = mockPoint;
+        return mockGridPointResult;
+    }
+
+    QRect visualRect(const QString &id, const QUrl &item) override
+    {
+        visualRectCalled = true;
+        lastVisualRectId = id;
+        lastVisualRectUrl = item;
+        return mockVisualRect;
+    }
+
+    QAbstractItemView *view(const QString &id) override
+    {
+        viewCalled = true;
+        lastViewId = id;
+        return mockView;
+    }
+
+    QRect iconRect(const QString &id, QRect vrect) override
+    {
+        iconRectCalled = true;
+        lastIconRectId = id;
+        lastIconRectVRect = vrect;
+        return mockIconRect;
+    }
+
+    bool selectAllItems() override
+    {
+        selectAllItemsCalled = true;
+        return mockSelectAllResult;
+    }
+
+    // Test state tracking
+    bool refreshModelCalled = false;
+    bool lastGlobal = false;
+    int lastMs = 0;
+    bool lastFile = false;
+
+    bool gridPointCalled = false;
+    QUrl lastGridPointUrl;
+    QPoint mockPoint;
+    QString mockGridPointResult;
+
+    bool visualRectCalled = false;
+    QString lastVisualRectId;
+    QUrl lastVisualRectUrl;
+    QRect mockVisualRect;
+
+    bool viewCalled = false;
+    QString lastViewId;
+    QAbstractItemView *mockView = nullptr;
+
+    bool iconRectCalled = false;
+    QString lastIconRectId;
+    QRect lastIconRectVRect;
+    QRect mockIconRect;
+
+    bool selectAllItemsCalled = false;
+    bool mockSelectAllResult = true;
+};
+
+class UT_OrganizerBroker : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        broker = new MockOrganizerBroker();
+    }
+
+    virtual void TearDown() override
+    {
+        delete broker;
+        broker = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    MockOrganizerBroker *broker = nullptr;
+};
+
+TEST_F(UT_OrganizerBroker, Constructor_WithParent_InitializesCorrectly)
+{
+    QObject parent;
+    MockOrganizerBroker brokerWithParent(&parent);
+    EXPECT_EQ(brokerWithParent.parent(), &parent);
+}
+
+TEST_F(UT_OrganizerBroker, Constructor_WithNullParent_InitializesCorrectly)
+{
+    EXPECT_NE(broker, nullptr);
+    EXPECT_EQ(broker->parent(), nullptr);
+}
+
+TEST_F(UT_OrganizerBroker, init_CallsSlotConnect_ReturnsTrue)
+{
+    bool result = broker->init();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_OrganizerBroker, refreshModel_WithGlobalTrue_CallsRefreshModel)
+{
+    broker->refreshModel(true, 100, false);
+
+    EXPECT_TRUE(broker->refreshModelCalled);
+    EXPECT_TRUE(broker->lastGlobal);
+    EXPECT_EQ(broker->lastMs, 100);
+    EXPECT_FALSE(broker->lastFile);
+}
+
+TEST_F(UT_OrganizerBroker, refreshModel_WithFileFlagTrue_CallsRefreshModel)
+{
+    broker->refreshModel(false, 200, true);
+
+    EXPECT_TRUE(broker->refreshModelCalled);
+    EXPECT_FALSE(broker->lastGlobal);
+    EXPECT_EQ(broker->lastMs, 200);
+    EXPECT_TRUE(broker->lastFile);
+}
+
+TEST_F(UT_OrganizerBroker, gridPoint_WithValidUrl_ReturnsId)
+{
+    QUrl testUrl("file:///tmp/test.txt");
+    QPoint expectedPoint(5, 10);
+    QString expectedResult = "collection_1";
+
+    broker->mockPoint = expectedPoint;
+    broker->mockGridPointResult = expectedResult;
+
+    QPoint resultPoint;
+    QString result = broker->gridPoint(testUrl, &resultPoint);
+
+    EXPECT_TRUE(broker->gridPointCalled);
+    EXPECT_EQ(broker->lastGridPointUrl, testUrl);
+    EXPECT_EQ(result, expectedResult);
+    EXPECT_EQ(resultPoint, expectedPoint);
+}
+
+TEST_F(UT_OrganizerBroker, gridPoint_WithNullPoint_DoesNotCrash)
+{
+    QUrl testUrl("file:///tmp/test.txt");
+    broker->mockGridPointResult = "collection_2";
+
+    QString result = broker->gridPoint(testUrl, nullptr);
+
+    EXPECT_TRUE(broker->gridPointCalled);
+    EXPECT_EQ(result, "collection_2");
+}
+
+TEST_F(UT_OrganizerBroker, visualRect_WithValidParams_ReturnsRect)
+{
+    QString testId = "view_1";
+    QUrl testUrl("file:///tmp/test.txt");
+    QRect expectedRect(100, 200, 50, 50);
+
+    broker->mockVisualRect = expectedRect;
+
+    QRect result = broker->visualRect(testId, testUrl);
+
+    EXPECT_TRUE(broker->visualRectCalled);
+    EXPECT_EQ(broker->lastVisualRectId, testId);
+    EXPECT_EQ(broker->lastVisualRectUrl, testUrl);
+    EXPECT_EQ(result, expectedRect);
+}
+
+TEST_F(UT_OrganizerBroker, view_WithValidId_ReturnsView)
+{
+    QString testId = "view_1";
+
+    QAbstractItemView *result = broker->view(testId);
+
+    EXPECT_TRUE(broker->viewCalled);
+    EXPECT_EQ(broker->lastViewId, testId);
+    EXPECT_EQ(result, broker->mockView);
+}
+
+TEST_F(UT_OrganizerBroker, iconRect_WithValidParams_ReturnsRect)
+{
+    QString testId = "view_1";
+    QRect inputRect(10, 20, 100, 100);
+    QRect expectedRect(15, 25, 48, 48);
+
+    broker->mockIconRect = expectedRect;
+
+    QRect result = broker->iconRect(testId, inputRect);
+
+    EXPECT_TRUE(broker->iconRectCalled);
+    EXPECT_EQ(broker->lastIconRectId, testId);
+    EXPECT_EQ(broker->lastIconRectVRect, inputRect);
+    EXPECT_EQ(result, expectedRect);
+}
+
+TEST_F(UT_OrganizerBroker, selectAllItems_ReturnsTrueWhenSuccessful)
+{
+    broker->mockSelectAllResult = true;
+
+    bool result = broker->selectAllItems();
+
+    EXPECT_TRUE(broker->selectAllItemsCalled);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_OrganizerBroker, selectAllItems_ReturnsFalseWhenFailed)
+{
+    broker->mockSelectAllResult = false;
+
+    bool result = broker->selectAllItems();
+
+    EXPECT_TRUE(broker->selectAllItemsCalled);
+    EXPECT_FALSE(result);
+}

--- a/autotests/plugins/ddplugin-organizer/test_organizerconfig.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_organizerconfig.cpp
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "config/organizerconfig.h"
+#include "config/organizerconfig_p.h"
+
+#include <QSettings>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QUrl>
+
+#include <gtest/gtest.h>
+
+using namespace ddplugin_organizer;
+
+class UT_OrganizerConfig : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        tempDir = new QTemporaryDir();
+        ASSERT_TRUE(tempDir->isValid());
+
+        stub.set_lamda(&OrganizerConfig::path, [this]() {
+            __DBG_STUB_INVOKE__
+            return tempDir->filePath("test_organizer.conf");
+        });
+
+        config = new OrganizerConfig();
+    }
+
+    virtual void TearDown() override
+    {
+        delete config;
+        config = nullptr;
+        delete tempDir;
+        tempDir = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    OrganizerConfig *config = nullptr;
+    QTemporaryDir *tempDir = nullptr;
+};
+
+TEST_F(UT_OrganizerConfig, Constructor_CreatesConfig)
+{
+    EXPECT_NE(config, nullptr);
+    EXPECT_NE(config->d, nullptr);
+    EXPECT_NE(config->d->settings, nullptr);
+}
+
+TEST_F(UT_OrganizerConfig, isEnable_DefaultReturnsFalse)
+{
+    EXPECT_FALSE(config->isEnable());
+}
+
+TEST_F(UT_OrganizerConfig, setEnable_SetsEnableState)
+{
+    config->setEnable(true);
+    config->sync(0);
+    EXPECT_TRUE(config->isEnable());
+
+    config->setEnable(false);
+    config->sync(0);
+    EXPECT_FALSE(config->isEnable());
+}
+
+TEST_F(UT_OrganizerConfig, mode_DefaultReturnsNormalized)
+{
+    int mode = config->mode();
+    EXPECT_EQ(mode, static_cast<int>(OrganizerMode::kNormalized));
+}
+
+TEST_F(UT_OrganizerConfig, setMode_SetsMode)
+{
+    config->setMode(static_cast<int>(OrganizerMode::kCustom));
+    config->sync(0);
+    EXPECT_EQ(config->mode(), static_cast<int>(OrganizerMode::kCustom));
+
+    config->setMode(static_cast<int>(OrganizerMode::kNormalized));
+    config->sync(0);
+    EXPECT_EQ(config->mode(), static_cast<int>(OrganizerMode::kNormalized));
+}
+
+TEST_F(UT_OrganizerConfig, setVersion_SetsVersion)
+{
+    config->setVersion("2.0.0");
+    config->sync(0);
+    // Version is write-only, no getter to verify directly
+    SUCCEED();
+}
+
+TEST_F(UT_OrganizerConfig, classification_DefaultReturnsType)
+{
+    int cf = config->classification();
+    EXPECT_EQ(cf, static_cast<int>(Classifier::kType));
+}
+
+TEST_F(UT_OrganizerConfig, setClassification_SetsClassification)
+{
+    config->setClassification(static_cast<int>(Classifier::kSize));
+    config->sync(0);
+    EXPECT_EQ(config->classification(), static_cast<int>(Classifier::kSize));
+}
+
+TEST_F(UT_OrganizerConfig, surfaceSizes_EmptyByDefault)
+{
+    QList<QSize> sizes = config->surfaceSizes();
+    EXPECT_TRUE(sizes.isEmpty());
+}
+
+TEST_F(UT_OrganizerConfig, setScreenInfo_SetsScreenResolutions)
+{
+    QMap<QString, QString> info;
+    info.insert("Screen_1", "1920:1080");
+    info.insert("Screen_2", "1280:720");
+
+    config->setScreenInfo(info);
+    config->sync(0);
+
+    QList<QSize> sizes = config->surfaceSizes();
+    EXPECT_EQ(sizes.size(), 2);
+}
+
+TEST_F(UT_OrganizerConfig, lastStyleConfigId_EmptyByDefault)
+{
+    QString id = config->lastStyleConfigId();
+    EXPECT_TRUE(id.isEmpty());
+}
+
+TEST_F(UT_OrganizerConfig, setLastStyleConfigId_SetsId)
+{
+    config->setLastStyleConfigId("test_config_id");
+    config->sync(0);
+    EXPECT_EQ(config->lastStyleConfigId(), "test_config_id");
+}
+
+TEST_F(UT_OrganizerConfig, hasConfigId_ReturnsFalseForNonexistent)
+{
+    EXPECT_FALSE(config->hasConfigId("nonexistent_id"));
+}
+
+TEST_F(UT_OrganizerConfig, sync_WithZeroMs_SyncsImmediately)
+{
+    config->setEnable(true);
+    config->sync(0);
+    EXPECT_TRUE(config->isEnable());
+}
+
+TEST_F(UT_OrganizerConfig, sync_WithPositiveMs_StartsTimer)
+{
+    config->setEnable(true);
+    config->sync(100);
+    EXPECT_TRUE(config->d->syncTimer.isActive());
+}
+
+TEST_F(UT_OrganizerConfig, collectionBase_Custom_EmptyByDefault)
+{
+    QList<CollectionBaseDataPtr> bases = config->collectionBase(true);
+    EXPECT_TRUE(bases.isEmpty());
+}
+
+TEST_F(UT_OrganizerConfig, collectionBase_Normal_EmptyByDefault)
+{
+    QList<CollectionBaseDataPtr> bases = config->collectionBase(false);
+    EXPECT_TRUE(bases.isEmpty());
+}
+
+TEST_F(UT_OrganizerConfig, writeCollectionBase_Custom_WritesData)
+{
+    QList<CollectionBaseDataPtr> bases;
+    CollectionBaseDataPtr data(new CollectionBaseData);
+    data->key = "custom_key";
+    data->name = "Custom Collection";
+    data->items.append(QUrl("file:///test1.txt"));
+    data->items.append(QUrl("file:///test2.txt"));
+    bases.append(data);
+
+    config->writeCollectionBase(true, bases);
+    config->sync(0);
+
+    QList<CollectionBaseDataPtr> result = config->collectionBase(true);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first()->key, "custom_key");
+    EXPECT_EQ(result.first()->name, "Custom Collection");
+    EXPECT_EQ(result.first()->items.size(), 2);
+}
+
+TEST_F(UT_OrganizerConfig, writeCollectionBase_Normal_WritesData)
+{
+    QList<CollectionBaseDataPtr> bases;
+    CollectionBaseDataPtr data(new CollectionBaseData);
+    data->key = "normal_key";
+    data->name = "Normal Collection";
+    bases.append(data);
+
+    config->writeCollectionBase(false, bases);
+    config->sync(0);
+
+    QList<CollectionBaseDataPtr> result = config->collectionBase(false);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first()->key, "normal_key");
+}
+
+TEST_F(UT_OrganizerConfig, updateCollectionBase_UpdatesExistingData)
+{
+    QList<CollectionBaseDataPtr> bases;
+    CollectionBaseDataPtr data(new CollectionBaseData);
+    data->key = "update_key";
+    data->name = "Original Name";
+    bases.append(data);
+
+    config->writeCollectionBase(true, bases);
+    config->sync(0);
+
+    data->name = "Updated Name";
+    data->items.append(QUrl("file:///new_item.txt"));
+    config->updateCollectionBase(true, data);
+    config->sync(0);
+
+    CollectionBaseDataPtr result = config->collectionBase(true, "update_key");
+    EXPECT_NE(result, nullptr);
+    EXPECT_EQ(result->name, "Updated Name");
+    EXPECT_EQ(result->items.size(), 1);
+}
+
+TEST_F(UT_OrganizerConfig, collectionBase_WithInvalidKey_ReturnsNull)
+{
+    CollectionBaseDataPtr result = config->collectionBase(true, "nonexistent_key");
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(UT_OrganizerConfig, collectionStyle_ReturnsEmptyStyleByDefault)
+{
+    CollectionStyle style = config->collectionStyle("", "test_key");
+    EXPECT_TRUE(style.key.isEmpty());
+}
+
+TEST_F(UT_OrganizerConfig, writeCollectionStyle_WritesStyles)
+{
+    QList<CollectionStyle> styles;
+    CollectionStyle style;
+    style.key = "style_key";
+    style.screenIndex = 1;
+    style.rect = QRect(100, 100, 200, 300);
+    style.sizeMode = CollectionFrameSize::kLarge;
+    style.customGeo = true;
+    styles.append(style);
+
+    config->writeCollectionStyle("config_1", styles);
+    config->sync(0);
+
+    CollectionStyle result = config->collectionStyle("config_1", "style_key");
+    EXPECT_EQ(result.key, "style_key");
+    EXPECT_EQ(result.screenIndex, 1);
+    EXPECT_EQ(result.rect, QRect(100, 100, 200, 300));
+    EXPECT_EQ(result.sizeMode, CollectionFrameSize::kLarge);
+    EXPECT_TRUE(result.customGeo);
+}
+
+TEST_F(UT_OrganizerConfig, updateCollectionStyle_UpdatesExistingStyle)
+{
+    QList<CollectionStyle> styles;
+    CollectionStyle style;
+    style.key = "update_style";
+    style.screenIndex = 0;
+    style.rect = QRect(0, 0, 100, 100);
+    styles.append(style);
+
+    config->writeCollectionStyle("", styles);
+    config->sync(0);
+
+    style.screenIndex = 2;
+    style.rect = QRect(50, 50, 150, 150);
+    config->updateCollectionStyle("", style);
+    config->sync(0);
+
+    CollectionStyle result = config->collectionStyle("", "update_style");
+    EXPECT_EQ(result.screenIndex, 2);
+    EXPECT_EQ(result.rect, QRect(50, 50, 150, 150));
+}
+
+TEST_F(UT_OrganizerConfig, writeCollectionStyle_SkipsEmptyKeys)
+{
+    QList<CollectionStyle> styles;
+    CollectionStyle validStyle;
+    validStyle.key = "valid_key";
+    validStyle.screenIndex = 1;
+
+    CollectionStyle invalidStyle;
+    invalidStyle.key = "";
+    invalidStyle.screenIndex = 2;
+
+    styles.append(invalidStyle);
+    styles.append(validStyle);
+
+    config->writeCollectionStyle("test_config", styles);
+    config->sync(0);
+
+    CollectionStyle result = config->collectionStyle("test_config", "valid_key");
+    EXPECT_EQ(result.key, "valid_key");
+}
+
+class UT_OrganizerConfigPrivate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        tempDir = new QTemporaryDir();
+        ASSERT_TRUE(tempDir->isValid());
+
+        stub.set_lamda(&OrganizerConfig::path, [this]() {
+            __DBG_STUB_INVOKE__
+            return tempDir->filePath("test_organizer.conf");
+        });
+
+        config = new OrganizerConfig();
+    }
+
+    virtual void TearDown() override
+    {
+        delete config;
+        config = nullptr;
+        delete tempDir;
+        tempDir = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    OrganizerConfig *config = nullptr;
+    QTemporaryDir *tempDir = nullptr;
+};
+
+TEST_F(UT_OrganizerConfigPrivate, value_WithEmptyKey_ReturnsDefault)
+{
+    QVariant result = config->d->value("group", "", QVariant("default"));
+    EXPECT_EQ(result.toString(), "default");
+}
+
+TEST_F(UT_OrganizerConfigPrivate, value_WithEmptyGroup_ReadsFromRoot)
+{
+    config->d->setValue("", "test_key", "test_value");
+
+    QVariant result = config->d->value("", "test_key", QVariant());
+    EXPECT_EQ(result.toString(), "test_value");
+}
+
+TEST_F(UT_OrganizerConfigPrivate, value_WithGroup_ReadsFromGroup)
+{
+    config->d->setValue("TestGroup", "group_key", "group_value");
+
+    QVariant result = config->d->value("TestGroup", "group_key", QVariant());
+    EXPECT_EQ(result.toString(), "group_value");
+}
+
+TEST_F(UT_OrganizerConfigPrivate, setValue_WritesToSettings)
+{
+    config->d->setValue("TestGroup", "write_key", "write_value");
+    config->sync(0);
+
+    QVariant result = config->d->value("TestGroup", "write_key", QVariant());
+    EXPECT_EQ(result.toString(), "write_value");
+}


### PR DESCRIPTION
1. Added 6 new unit test files covering core organizer plugin components
2. Implemented tests for CollectionHolder class including constructor,
properties, and style management
3. Added tests for CollectionHookInterface covering drag-drop, keyboard
events, and rendering hooks
4. Created tests for CollectionItemDelegate testing icon sizing, text
rendering, and editor functionality
5. Implemented tests for CollectionViewBroker verifying grid positioning
and visual rect calculations
6. Added tests for ConfigPresenter covering configuration management and
settings persistence
7. Created tests for ItemEditor including text editing, geometry
management, and alert system
8. Added tests for OrganizerBroker testing plugin integration and view
management
9. Implemented tests for OrganizerConfig covering configuration storage
and serialization

Log: Added comprehensive unit test suite for desktop organizer plugin

Influence:
1. Run unit tests to verify all functionality works correctly
2. Test collection holder creation and property management
3. Verify drag-drop operations work as expected
4. Test icon sizing and text rendering in different modes
5. Validate configuration persistence across sessions
6. Test file organization and grid positioning
7. Verify editor functionality and text input validation

feat: 为桌面整理插件添加全面单元测试

1. 新增6个单元测试文件，覆盖整理插件核心组件
2. 实现CollectionHolder类测试，包括构造函数、属性和样式管理
3. 添加CollectionHookInterface测试，覆盖拖放、键盘事件和渲染钩子
4. 创建CollectionItemDelegate测试，验证图标大小调整、文本渲染和编辑器
功能
5. 实现CollectionViewBroker测试，验证网格定位和可视矩形计算
6. 添加ConfigPresenter测试，覆盖配置管理和设置持久化
7. 创建ItemEditor测试，包括文本编辑、几何管理和警报系统
8. 添加OrganizerBroker测试，验证插件集成和视图管理
9. 实现OrganizerConfig测试，覆盖配置存储和序列化

Log: 新增桌面整理插件全面单元测试套件

Influence:
1. 运行单元测试验证所有功能正常工作
2. 测试集合持有器创建和属性管理
3. 验证拖放操作按预期工作
4. 测试不同模式下的图标大小调整和文本渲染
5. 验证配置在不同会话间的持久化
6. 测试文件整理和网格定位功能
7. 验证编辑器功能和文本输入验证
