### PR TITLE
fix: set fixed width for location combobox in rename bar

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
@@ -97,6 +97,7 @@ void RenameBarPrivate::setUIParameters()
     label = std::get<2>(addOperatorItems);
     label->setObjectName(QString { "RenameBarLabel" });
     comboBox = std::get<3>(addOperatorItems);
+    comboBox->setFixedWidth(180);
     label->setText(QObject::tr("Location"));
     comboBox->addItems(QList<QString> { QObject::tr("Before file name"), QObject::tr("After file name") });
     label->setBuddy(comboBox);


### PR DESCRIPTION
Set fixed width of 180 pixels for the location combobox in the rename
bar to prevent UI layout issues when the combobox content changes. This
ensures consistent appearance and prevents the combobox from resizing
dynamically based on content length.

Influence:
1. Test rename bar UI layout with different text lengths
2. Verify combobox width remains fixed at 180 pixels
3. Check that all combobox items are fully visible
4. Test UI responsiveness when switching between location options

fix: 重命名栏位置组合框设置固定宽度

将重命名栏中的位置组合框设置为固定宽度180像素，防止组合框内容变化时出
现UI布局问题。这确保了界面外观的一致性，避免组合框根据内容长度动态调整
大小。

Influence:
1. 测试重命名栏在不同文本长度下的UI布局
2. 验证组合框宽度保持固定在180像素
3. 检查所有组合框项是否完全可见
4. 测试切换位置选项时的UI响应性

BUG: https://pms.uniontech.com/bug-view-342523.html

## Summary by Sourcery

Bug Fixes:
- Prevent the rename bar location combobox from resizing based on content length, avoiding layout issues and preserving consistent appearance.