### PR TITLE
feat: dynamic icon background radius calculation

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -48,6 +48,8 @@ const int CanvasItemDelegate::kIconBackRadius = 18;
 const int CanvasItemDelegate::kIconRectRadius = 4;
 const int CanvasItemDelegate::kIconBackgroundMargin = 4;
 
+inline constexpr int kIconModeBackRadiusCoefficient = 16;
+
 CanvasItemDelegatePrivate::CanvasItemDelegatePrivate(CanvasItemDelegate *qq)
     : q(qq)
 {
@@ -858,7 +860,8 @@ void CanvasItemDelegate::paintBackground(QPainter *painter, const QStyleOptionVi
     painter->setRenderHint(QPainter::Antialiasing);
 
     QPainterPath path;
-    path.addRoundedRect(backgroundRect, kIconRectRadius, kIconRectRadius);
+    int radius = parent()->iconSize().width() / kIconModeBackRadiusCoefficient;
+    path.addRoundedRect(backgroundRect, radius, radius);
     painter->fillPath(path, backgroundColor);
 
     painter->setPen(borderColor);

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -52,6 +52,8 @@ const int CollectionItemDelegate::kIconBackRadius = 18;
 const int CollectionItemDelegate::kIconRectRadius = 4;
 const int CollectionItemDelegate::kIconBackgroundMargin = 4;
 
+inline constexpr int kIconModeBackRadiusCoefficient = 16;
+
 CollectionItemDelegatePrivate::CollectionItemDelegatePrivate(CollectionItemDelegate *qq)
     : q(qq)
 {
@@ -883,7 +885,8 @@ void CollectionItemDelegate::paintBackground(QPainter *painter, const QStyleOpti
     painter->setRenderHint(QPainter::Antialiasing);
 
     QPainterPath path;
-    path.addRoundedRect(backgroundRect, kIconRectRadius, kIconRectRadius);
+    int radius = parent()->iconSize().width() / kIconModeBackRadiusCoefficient;
+    path.addRoundedRect(backgroundRect, radius, radius);
     painter->fillPath(path, backgroundColor);
 
     painter->setPen(borderColor);


### PR DESCRIPTION
Changed the icon background radius calculation from a fixed value to
a dynamic one based on icon size. Added kIconModeBackRadiusCoefficient
constant and modified paintBackground method to calculate radius as icon
width divided by coefficient. This ensures the background radius scales
proportionally with icon size, maintaining visual consistency across
different display settings and icon sizes.

Log: Improved icon background radius scaling for better visual
consistency

Influence:
1. Test icon display with various icon size settings
2. Verify background radius scales correctly with different icon sizes
3. Check visual consistency across different display resolutions
4. Test both canvas and collection views to ensure uniform behavior
5. Verify no rendering artifacts or performance issues

feat: 动态计算图标背景圆角半径

将图标背景圆角半径的计算从固定值改为基于图标大小的动态计算。添加了
kIconModeBackRadiusCoefficient常量，并修改paintBackground方法，将半径计
算为图标宽度除以系数。这确保了背景圆角半径随图标大小按比例缩放，在不同显
示设置和图标大小下保持视觉一致性。

Log: 改进图标背景圆角缩放，提升视觉一致性

Influence:
1. 测试不同图标大小设置下的图标显示效果
2. 验证背景圆角是否随不同图标大小正确缩放
3. 检查不同显示分辨率下的视觉一致性
4. 测试画布和集合视图以确保统一行为
5. 验证无渲染瑕疵或性能问题

BUG: https://pms.uniontech.com/bug-view-342593.html

## Summary by Sourcery

Adjust icon background corner radius to scale dynamically with icon size for consistent appearance across views.

Bug Fixes:
- Fix incorrect or inconsistent icon background rounding across different icon sizes and display settings.

Enhancements:
- Unify icon background radius calculation in canvas and collection item delegates using a shared size-based coefficient.