### PR TITLE
add UAB file thumbnail support

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -152,6 +152,7 @@ inline constexpr char kTypeAppVMAsf[] { "application/vnd.ms-asf" };
 inline constexpr char kTypeAppCRRMedia[] { "application/cnd.rn-realmedia" };
 inline constexpr char kTypeAppVRRMedia[] { "application/vnd.rn-realmedia" };
 inline constexpr char kTypeAppAppimage[] { "application/vnd.appimage" };
+inline constexpr char kTypeAppUab[] { "application/vnd.linyaps.uab" };
 inline constexpr char kTypeTextHtml[] { "text/html" };
 inline constexpr char kTypeAppXhtmlXml[] { "application/xhtml+xml" };
 inline constexpr char kTypeTextXPython[] { "text/x-python" };

--- a/src/apps/dde-file-manager-daemon/dbusservice/dde-file-manager.service
+++ b/src/apps/dde-file-manager-daemon/dbusservice/dde-file-manager.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=DDE File Manager Daemon
 
-Wants=dde-session-pre.target
-After=dde-session-pre.target
+Wants=dde-session-core.target
+After=dde-session-core.target
 
-Wants=dde-session-initialized.target
 PartOf=dde-session-initialized.target
 Before=dde-session-initialized.target
 

--- a/src/dfm-base/utils/iconutils.cpp
+++ b/src/dfm-base/utils/iconutils.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "iconutils.h"
 
+#include <dfm-base/dfm_global_defines.h>
+
 #include <QPainter>
 #include <QGraphicsDropShadowEffect>
 #include <QGraphicsScene>
@@ -107,4 +109,14 @@ QPixmap IconUtils::renderIconBackground(const QSizeF &size, const IconStyle &sty
     p.drawRoundedRect(rect, style.radius, style.radius);
     p.end();
     return pm;
+}
+
+bool IconUtils::shouldSkipThumbnailFrame(const QString &mimeType)
+{
+    // appimage, uab 不显示缩略图底板
+    static const QStringList kExcludedMimes = {
+        Global::Mime::kTypeAppAppimage,
+        Global::Mime::kTypeAppUab
+    };
+    return kExcludedMimes.contains(mimeType);
 }

--- a/src/dfm-base/utils/iconutils.h
+++ b/src/dfm-base/utils/iconutils.h
@@ -23,6 +23,7 @@ QPixmap renderIconBackground(const QSize &size, const IconStyle &style = IconSty
 QPixmap renderIconBackground(const QSizeF &size, const IconStyle &style = IconStyle {});
 QPixmap addShadowToPixmap(const QPixmap &originalPixmap, int shadowOffsetY, qreal blurRadius, qreal shadowOpacity);
 IconStyle getIconStyle(int size);
+bool shouldSkipThumbnailFrame(const QString &mimeType);
 }   // end namespace IconUtils
 
 DFMBASE_END_NAMESPACE

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.h
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.h
@@ -21,6 +21,7 @@ QImage imageThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::Thumb
 QImage djvuThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage pdfThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage appimageThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
+QImage uabThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage pptxThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 }   // namespace ThumbnailCreators
 }   // namespace dfmbase

--- a/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
@@ -35,6 +35,7 @@ ThumbnailFactory::ThumbnailFactory(QObject *parent)
     registerThumbnailCreator("audio/*", ThumbnailCreators::audioThumbnailCreator);
     registerThumbnailCreator("video/*", ThumbnailCreators::videoThumbnailCreator);
     registerThumbnailCreator(Mime::kTypeAppAppimage, ThumbnailCreators::appimageThumbnailCreator);
+    registerThumbnailCreator(Mime::kTypeAppUab, ThumbnailCreators::uabThumbnailCreator);
     registerThumbnailCreator(Mime::kTypeAppPptx, ThumbnailCreators::pptxThumbnailCreator);
 
     init();

--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.h
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.h
@@ -35,12 +35,24 @@ public:
     static QByteArray dataToMd5Hex(const QByteArray &data);
 
 private:
+    enum class SupportCheckStrategy {
+        kUnconditional,   // Unconditional support (e.g., AppImage, UAB)
+        kCheckImage,   // Check kPreviewImage attribute
+        kCheckAudio,   // Check kPreviewAudio attribute
+        kCheckVideo,   // Check kPreviewVideo attribute
+        kCheckText,   // Check kPreviewTextFile attribute
+        kCheckDocument   // Check kPreviewDocumentFile attribute
+    };
+
+    void initMimeTypeSupport();
     bool checkMimeTypeSupport(const QMimeType &mime);
     void makePath(const QString &path);
+    bool evaluateStrategy(SupportCheckStrategy strategy);
 
 private:
     DMimeDatabase mimeDatabase;
     QHash<QMimeType, qint64> sizeLimitHash;
+    QHash<QString, SupportCheckStrategy> mimeTypeSupportStrategy;
 };
 }   // namespace dfmbase
 

--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -433,8 +433,7 @@ bool CanvasItemDelegate::isThumnailIconIndex(const QModelIndex &index) const
 
     FileInfoPointer info { parent()->model()->fileInfo(index) };
     if (info) {
-        // appimage 不显示缩略图底板
-        if (info->nameOf(NameInfoType::kMimeTypeName) == Global::Mime::kTypeAppAppimage)
+        if (IconUtils::shouldSkipThumbnailFrame(info->nameOf(NameInfoType::kMimeTypeName)))
             return false;
 
         const auto &attribute { info->extendAttributes(ExtInfoType::kFileThumbnail) };

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -426,8 +426,7 @@ bool CollectionItemDelegate::isThumnailIconIndex(const QModelIndex &index) const
 
     FileInfoPointer info { parent()->model()->fileInfo(index) };
     if (info) {
-        // appimage 不显示缩略图底板
-        if (info->nameOf(NameInfoType::kMimeTypeName) == Global::Mime::kTypeAppAppimage)
+        if (IconUtils::shouldSkipThumbnailFrame(info->nameOf(NameInfoType::kMimeTypeName)))
             return false;
 
         const auto &attribute { info->extendAttributes(ExtInfoType::kFileThumbnail) };

--- a/src/plugins/filemanager/dfmplugin-detailspace/utils/detailspacehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/utils/detailspacehelper.cpp
@@ -108,7 +108,7 @@ void DetailSpaceHelper::showDetailView(quint64 windowId, bool checked)
 void DetailSpaceHelper::setDetailViewSelectFileUrl(quint64 windowId, const QUrl &url)
 {
     DetailSpaceWidget *w = findDetailSpaceByWindowId(windowId);
-    if (w)
+    if (w && url.isValid())
         setDetailViewByUrl(w, url);
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -12,6 +12,7 @@
 #include "models/fileviewmodel.h"
 
 #include <dfm-base/dfm_base_global.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <DPalette>
 #include <DPaletteHelper>
@@ -76,8 +77,7 @@ bool BaseItemDelegate::isThumnailIconIndex(const QModelIndex &index) const
 
     FileInfoPointer info { parent()->fileInfo(index) };
     if (info) {
-        // appimage 不显示缩略图底板
-        if (info->nameOf(NameInfoType::kMimeTypeName) == Global::Mime::kTypeAppAppimage)
+        if (IconUtils::shouldSkipThumbnailFrame(info->nameOf(NameInfoType::kMimeTypeName)))
             return false;
 
         const auto &attribute { info->extendAttributes(ExtInfoType::kFileThumbnail) };
@@ -409,7 +409,7 @@ void BaseItemDelegate::paintGroupText(QPainter *painter, const QRect &textRect, 
 
     // Get fonts from DFontSizeManager
     QFont groupTitleFont = DFontSizeManager::instance()->t6();   // T6 for group title
-    QFont fileCountFont = DFontSizeManager::instance()->t8();    // T8 for file count
+    QFont fileCountFont = DFontSizeManager::instance()->t8();   // T8 for file count
 
     // Determine base text color based on theme
     bool isLightTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::ColorType::LightType;


### PR DESCRIPTION
## Summary by Sourcery

Add thumbnail generation and UI handling for UAB application packages and refactor MIME-based thumbnail support.

New Features:
- Support generating thumbnails for UAB (application/vnd.linyaps.uab) packages by extracting embedded icon data from a dedicated ELF section.
- Register UAB MIME type and wire it into the thumbnail factory so UAB files use the new thumbnail creator.

Enhancements:
- Refine MIME-type-based thumbnail support into a configurable strategy map, enabling unified handling of image, audio, video, text, document, and executable package types.
- Adjust PPTX thumbnail handling to consider parent MIME types and introduce a size limit for PPTX thumbnails.
- Unify AppImage and PPTX existence and MIME checks to rely on FileInfo objects instead of direct QFile checks.
- Exclude AppImage and UAB thumbnails from having a decorative thumbnail frame via a shared IconUtils helper.
- Ensure detail view URL updates only occur when the provided URL is valid.