### PR TITLE
feat: add markdown file preview plugin

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/pluginInterface/filepreviewfactory.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/pluginInterface/filepreviewfactory.cpp
@@ -68,7 +68,7 @@ bool FilePreviewFactory::isSuitedWithKey(const AbstractBasePreview *view, const 
         qCWarning(logLibFilePreview) << "FilePreviewFactory: null preview instance provided for key compatibility check:" << key;
         return false;
     }
-    
+
     int index = FilePreviewFactory::previewToLoaderIndex.value(view, -1);
 
     if (index == -1) {
@@ -79,4 +79,16 @@ bool FilePreviewFactory::isSuitedWithKey(const AbstractBasePreview *view, const 
     bool suited = index == loader()->indexOf(key);
     qCDebug(logLibFilePreview) << "FilePreviewFactory: preview compatibility check for key:" << key << "result:" << suited;
     return suited;
+}
+
+bool FilePreviewFactory::hasPluginForKey(const QString &key)
+{
+#ifndef QT_NO_LIBRARY
+    int index = loader()->indexOf(key);
+    bool exists = (index != -1);
+    qCDebug(logLibFilePreview) << "FilePreviewFactory: plugin existence check for key:" << key << "result:" << exists;
+    return exists;
+#else
+    return false;
+#endif
 }

--- a/src/apps/dde-file-manager-preview/libdfm-preview/pluginInterface/filepreviewfactory.h
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/pluginInterface/filepreviewfactory.h
@@ -17,6 +17,7 @@ public:
     static QStringList keys();
     static DFMBASE_NAMESPACE::AbstractBasePreview *create(const QString &key);
     static bool isSuitedWithKey(const DFMBASE_NAMESPACE::AbstractBasePreview *view, const QString &key);
+    static bool hasPluginForKey(const QString &key);
 
     static QMap<const DFMBASE_NAMESPACE::AbstractBasePreview *, int> previewToLoaderIndex;
 };

--- a/src/apps/dde-file-manager-preview/pluginpreviews/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(image-preview)
 add_subdirectory(music-preview)
 add_subdirectory(text-preview)
+add_subdirectory(markdown-preview)
 add_subdirectory(dciicon-preview)
 add_subdirectory(pdf-preview)
 

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.10)
+project(dde-markdown-preview-plugin)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+FILE(GLOB_RECURSE MARKDOWNPREVIEW_FILES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.json"
+    "${GlobalFiles}"
+    )
+
+set(BIN_NAME ${PROJECT_NAME})
+
+find_package(Qt6 COMPONENTS Core REQUIRED)
+
+add_library(${BIN_NAME}
+    SHARED
+    ${MARKDOWNPREVIEW_FILES}
+)
+
+set_target_properties(${BIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
+
+target_link_libraries(${BIN_NAME}
+    DFM6::base
+    DFM6::framework
+)
+
+#install library file
+install(TARGETS
+    ${BIN_NAME}
+    LIBRARY
+    DESTINATION
+    ${DFM_PLUGIN_PREVIEW_DIR}
+)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/dde-markdown-preview-plugin.json DESTINATION ${DFM_BUILD_PLUGIN_PREVIEW_DIR}/previews)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/dde-markdown-preview-plugin.json DESTINATION ${DFM_PLUGIN_PREVIEW_DIR})

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/dde-markdown-preview-plugin.json
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/dde-markdown-preview-plugin.json
@@ -1,0 +1,3 @@
+{
+    "Keys" : ["text/markdown"]
+}

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownbrowser.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownbrowser.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "markdownbrowser.h"
+
+#include <QTextDocument>
+#include <QDebug>
+#include <QDir>
+
+using namespace plugin_filepreview;
+
+MarkdownBrowser::MarkdownBrowser(QWidget *parent)
+    : QTextBrowser(parent)
+{
+    setReadOnly(true);
+    setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard | Qt::LinksAccessibleByMouse);
+    setOpenExternalLinks(true);
+    setLineWrapMode(QTextBrowser::WidgetWidth);
+    setFixedSize(800, 500);
+    setFrameStyle(QFrame::NoFrame);
+}
+
+MarkdownBrowser::~MarkdownBrowser()
+{
+}
+
+void MarkdownBrowser::setMarkdownContent(const QString &markdown, const QString &basePath)
+{
+    fmDebug() << "Markdown preview: setting markdown content, base path:" << basePath;
+
+    // Set base path for resolving relative image paths
+    if (!basePath.isEmpty()) {
+        QDir baseDir(basePath);
+        if (baseDir.exists()) {
+            document()->setMetaInformation(QTextDocument::DocumentUrl, QUrl::fromLocalFile(basePath).toString());
+            setSearchPaths(QStringList() << basePath);
+            fmDebug() << "Markdown preview: search paths set to:" << basePath;
+        } else {
+            fmWarning() << "Markdown preview: base path does not exist:" << basePath;
+        }
+    }
+
+    // Set markdown content using QTextDocument
+    document()->setMarkdown(markdown);
+
+    // Move cursor to the start of the document to ensure top of content is visible
+    moveCursor(QTextCursor::Start, QTextCursor::MoveAnchor);
+
+    fmInfo() << "Markdown preview: content set successfully";
+}

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownbrowser.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownbrowser.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MARKDOWNBROWSER_H
+#define MARKDOWNBROWSER_H
+#include "preview_plugin_global.h"
+
+#include <QTextBrowser>
+
+namespace plugin_filepreview {
+class MarkdownBrowser : public QTextBrowser
+{
+    Q_OBJECT
+public:
+    explicit MarkdownBrowser(QWidget *parent = nullptr);
+
+    virtual ~MarkdownBrowser() override;
+
+    void setMarkdownContent(const QString &markdown, const QString &basePath);
+};
+}
+#endif   // MARKDOWNBROWSER_H

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdowncontextwidget.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdowncontextwidget.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "markdowncontextwidget.h"
+#include "markdownbrowser.h"
+
+#include <DPlainTextEdit>
+
+#include <QVBoxLayout>
+
+using namespace plugin_filepreview;
+DWIDGET_USE_NAMESPACE
+
+MarkdownContextWidget::MarkdownContextWidget(QWidget *parent)
+    : QWidget(parent)
+    , m_browserWidget(new MarkdownBrowser(this))
+{
+    DPlainTextEdit *titleWidget = new DPlainTextEdit(this);
+    titleWidget->setFixedHeight(30);
+    titleWidget->setFrameStyle(QFrame::NoFrame);
+    titleWidget->setReadOnly(true);
+    titleWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    QVBoxLayout *mainLay = new QVBoxLayout(this);
+    mainLay->addWidget(titleWidget);
+    mainLay->addWidget(m_browserWidget);
+    mainLay->setContentsMargins(0, 0, 0, 0);
+    mainLay->setSpacing(0);
+}
+
+MarkdownBrowser *MarkdownContextWidget::markdownBrowser() const
+{
+    return m_browserWidget;
+}

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdowncontextwidget.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdowncontextwidget.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MARKDOWNCONTEXTWIDGET_H
+#define MARKDOWNCONTEXTWIDGET_H
+
+#include <QWidget>
+
+namespace plugin_filepreview {
+class MarkdownBrowser;
+class MarkdownContextWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit MarkdownContextWidget(QWidget *parent = nullptr);
+    plugin_filepreview::MarkdownBrowser *markdownBrowser() const;
+
+private:
+    plugin_filepreview::MarkdownBrowser *m_browserWidget { nullptr };
+};
+}
+#endif // MARKDOWNCONTEXTWIDGET_H

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreview.cpp
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "markdownpreview.h"
+#include "markdownbrowser.h"
+#include "markdowncontextwidget.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <QFile>
+#include <QFileInfo>
+#include <QTextStream>
+#include <QDebug>
+
+using namespace plugin_filepreview;
+DFMBASE_USE_NAMESPACE
+
+// 5MB maximum file size
+static constexpr qint64 kMaxReadSize { 1024 * 1024 * 5 };
+
+MarkdownPreview::MarkdownPreview(QObject *parent)
+    : AbstractBasePreview(parent)
+{
+    fmInfo() << "Markdown preview: MarkdownPreview instance created";
+}
+
+MarkdownPreview::~MarkdownPreview()
+{
+    fmInfo() << "Markdown preview: MarkdownPreview instance destroyed";
+    if (m_markdownBrowser) {
+        // Set parent to nullptr first to prevent recursive destruction issues
+        m_markdownBrowser->setParent(nullptr);
+        m_markdownBrowser->deleteLater();
+        m_markdownBrowser = nullptr;
+    }
+}
+
+bool MarkdownPreview::setFileUrl(const QUrl &url)
+{
+    fmInfo() << "Markdown preview: setting file URL:" << url;
+
+    if (m_selectUrl == url) {
+        fmDebug() << "Markdown preview: URL unchanged, skipping:" << url;
+        return true;
+    }
+
+    if (!url.isLocalFile()) {
+        fmWarning() << "Markdown preview: URL is not a local file:" << url;
+        return false;
+    }
+
+    const QString filePath = url.toLocalFile();
+    if (!QFileInfo::exists(filePath)) {
+        fmWarning() << "Markdown preview: file does not exist:" << filePath;
+        return false;
+    }
+
+    QFileInfo fileInfo(filePath);
+    qint64 fileSize = fileInfo.size();
+
+    if (fileSize <= 0) {
+        fmWarning() << "Markdown preview: file is empty or cannot determine size:" << filePath;
+        return false;
+    }
+
+    fmDebug() << "Markdown preview: file size:" << fileSize << "bytes, will read up to:" << kMaxReadSize << "bytes";
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        fmWarning() << "Markdown preview: failed to open file:" << filePath << "error:" << file.errorString();
+        return false;
+    }
+
+    // Limit read size to 5MB
+    qint64 readSize = qMin(fileSize, kMaxReadSize);
+    if (fileSize > kMaxReadSize) {
+        fmDebug() << "Markdown preview: file size exceeds limit, truncating to:" << kMaxReadSize << "bytes";
+    }
+
+    // Read file content
+    QByteArray data = file.read(readSize);
+    file.close();
+
+    if (data.isEmpty()) {
+        fmWarning() << "Markdown preview: failed to read file content:" << filePath;
+        return false;
+    }
+
+    // Convert to QString
+    const QString markdownContent = QString::fromUtf8(data);
+
+    // Create browser widget if not exists
+    if (!m_markdownBrowser) {
+        fmDebug() << "Markdown preview: creating new MarkdownContextWidget";
+        m_markdownBrowser = new MarkdownContextWidget;
+    }
+
+    // Set markdown content with base path for relative images
+    QString basePath = fileInfo.absolutePath();
+    m_markdownBrowser->markdownBrowser()->setMarkdownContent(markdownContent, basePath);
+
+    m_selectUrl = url;
+    m_titleStr = fileInfo.fileName();
+
+    fmInfo() << "Markdown preview: file loaded successfully:" << filePath << "title:" << m_titleStr;
+    Q_EMIT titleChanged();
+
+    return true;
+}
+
+QUrl MarkdownPreview::fileUrl() const
+{
+    return m_selectUrl;
+}
+
+QWidget *MarkdownPreview::contentWidget() const
+{
+    return m_markdownBrowser;
+}
+
+QString MarkdownPreview::title() const
+{
+    return m_titleStr;
+}
+
+bool MarkdownPreview::showStatusBarSeparator() const
+{
+    return false;
+}

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreview.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreview.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MARKDOWNPREVIEW_H
+#define MARKDOWNPREVIEW_H
+
+#include "preview_plugin_global.h"
+
+#include <dfm-base/interfaces/abstractbasepreview.h>
+
+#include <QWidget>
+#include <QPointer>
+#include <QString>
+#include <QUrl>
+
+namespace plugin_filepreview {
+class MarkdownContextWidget;
+class MarkdownPreview : public DFMBASE_NAMESPACE::AbstractBasePreview
+{
+    Q_OBJECT
+
+public:
+    explicit MarkdownPreview(QObject *parent = nullptr);
+    ~MarkdownPreview() override;
+
+    bool setFileUrl(const QUrl &url) override;
+    QUrl fileUrl() const override;
+
+    QWidget *contentWidget() const override;
+
+    QString title() const override;
+    bool showStatusBarSeparator() const override;
+
+private:
+    QUrl m_selectUrl;
+    QString m_titleStr;
+
+    MarkdownContextWidget *m_markdownBrowser { nullptr };
+};
+}
+#endif   // MARKDOWNPREVIEW_H

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreviewplugin.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreviewplugin.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "markdownpreviewplugin.h"
+
+#include <dfm-base/interfaces/abstractbasepreview.h>
+
+DFMBASE_USE_NAMESPACE
+namespace plugin_filepreview {
+
+DFM_LOG_REGISTER_CATEGORY(PREVIEW_NAMESPACE)
+
+AbstractBasePreview *MarkdownPreviewPlugin::create(const QString &key)
+{
+    Q_UNUSED(key)
+
+    return new MarkdownPreview();
+}
+}   //  namespace plugin_filepreview

--- a/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreviewplugin.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/markdown-preview/markdownpreviewplugin.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MARKDOWNPREVIEWPLUGIN_H
+#define MARKDOWNPREVIEWPLUGIN_H
+
+#include "preview_plugin_global.h"
+#include <dfm-base/interfaces/abstractfilepreviewplugin.h>
+
+#include "markdownpreview.h"
+
+namespace plugin_filepreview {
+class MarkdownPreviewPlugin : public DFMBASE_NAMESPACE::AbstractFilePreviewPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID FilePreviewFactoryInterface_iid FILE "dde-markdown-preview-plugin.json")
+
+public:
+    DFMBASE_NAMESPACE::AbstractBasePreview *create(const QString &key) Q_DECL_OVERRIDE;
+};
+}
+#endif   // MARKDOWNPREVIEWPLUGIN_H


### PR DESCRIPTION
1. Implement new markdown preview plugin with text/markdown MIME type support
2. Add MarkdownBrowser widget using QTextBrowser with markdown rendering capabilities
3. Create preview context widget with proper layout and styling
4. Implement file reading with 5MB size limit and UTF-8 encoding support
5. Add plugin detection mechanism to prevent text/* from intercepting text/markdown files
6. Support relative image paths resolution using base directory

Log: Added markdown file preview functionality

Influence:
1. Test preview of various markdown files with different sizes and encodings
2. Verify markdown rendering including headers, lists, links, and code blocks
3. Test relative image paths resolution in markdown files
4. Verify plugin priority when both text/markdown and text/* plugins exist
5. Test file size limits with files larger than 5MB
6. Check preview switching between different file types
7. Verify external link handling in markdown content

feat: 添加 Markdown 文件预览插件

1. 实现新的 Markdown 预览插件，支持 text/markdown MIME 类型
2. 添加使用 QTextBrowser 的 MarkdownBrowser 控件，支持 Markdown 渲染
3. 创建预览上下文控件，包含适当的布局和样式
4. 实现文件读取功能，支持 5MB 大小限制和 UTF-8 编码
5. 添加插件检测机制，防止 text/* 插件拦截 text/markdown 文件
6. 支持使用基础目录解析相对图片路径

Log: 新增 Markdown 文件预览功能

Influence:
1. 测试不同大小和编码的 Markdown 文件预览
2. 验证 Markdown 渲染效果，包括标题、列表、链接和代码块
3. 测试 Markdown 文件中相对图片路径的解析
4. 验证当 text/markdown 和 text/* 插件同时存在时的优先级
5. 测试超过 5MB 文件的尺寸限制处理
6. 检查不同文件类型之间的预览切换
7. 验证 Markdown 内容中外部链接的处理