### PR TITLE
fix: expand support for long filenames on ulnfs

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -1234,7 +1234,7 @@ QString FileUtils::normalPathToTrash(const QString &normal)
 bool FileUtils::supportLongName(const QUrl &url)
 {
     const static QList<QString> datas {
-        "vfat", "exfat", "ntfs", "ntfs3", "fuseblk", "fuse.dlnfs", "udf"
+        "vfat", "exfat", "ntfs", "ntfs3", "fuseblk", "fuse.dlnfs", "udf", "ulnfs"
     };
 
     const QString &fileSystem = dfmio::DFMUtils::fsTypeFromUrl(url);


### PR DESCRIPTION
Added "ulnfs" to the list of filesystems supporting long filenames in FileUtils::supportLongName().

Task: https://pms.uniontech.com/task-view-381255.html

## Summary by Sourcery

Bug Fixes:
- Treat ulnfs filesystems as supporting long filenames in FileUtils::supportLongName().