### PR TITLE
fix: set read permissions for TPM encrypted files to prevent decryption failure

### DIFF
--- a/src/services/tpmcontrol/core/tpmwork.cpp
+++ b/src/services/tpmcontrol/core/tpmwork.cpp
@@ -243,6 +243,16 @@ int TPMWork::encrypt(const QVariantMap &params)
     int ret = func(&pa);
     if (ret != 0) {
         fmCritical() << "utpm2_encrypt_by_tools failed with error code:" << ret;
+    } else {
+        // 上述函数生成的文件，普通用户无访问权限，所以会导致往写入的 Token 相关信息为空，
+        // 从而导致密码解密失败。所以在此将文件设置为可读。
+        QDir d(arrDirPath);
+        auto entries = d.entryInfoList(QDir::NoDotAndDotDot);
+        for (const auto &entry : entries) {
+            auto ok = QFile::setPermissions(entry.absoluteFilePath(),
+                                            QFile::ReadOwner | QFile::ReadGroup | QFile::ReadOther);
+            fmInfo() << "Read permission has been set to tpm file:" << entry.fileName() << ok;
+        }
     }
 
     return ret;


### PR DESCRIPTION
- Added file permission setting logic after successful TPM encryption
- Set read permissions (Owner | Group | Other) for all generated files in the TPM directory
- Fixed the issue where normal users cannot access TPM files, causing empty Token information

Log: Set read permissions for TPM encrypted files to allow normal user access and prevent decryption failures

Bug: https://pms.uniontech.com/bug-view-343001.html

## Summary by Sourcery

Bug Fixes:
- Set read permissions on TPM-generated files so non-privileged users can read token data and prevent decryption from failing.