### PR TITLE
adjust group header spacing

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -81,6 +81,7 @@ inline constexpr int kTreeExpandArrowHeight { 20 };
 inline constexpr int kTreeArrowAndIconDistance { 8 };
 inline constexpr int kViewAnimationDuration { 366 };
 inline constexpr int kViewAnimationFrameDuration { 16 };
+inline constexpr int kGroupHeaderInterval { 16 };
 
 // tab defines
 inline constexpr int kMaxTabCount { 8 };

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.cpp
@@ -274,6 +274,12 @@ int GroupedModelData::getFileItemCount() const
     return count;
 }
 
+int GroupedModelData::getGroupItemCount() const
+{
+    QMutexLocker locker(&m_mutex);
+    return groups.size();
+}
+
 ModelItemWrapper GroupedModelData::getItemAt(int index) const
 {
     QMutexLocker locker(&m_mutex);

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupedmodeldata.h
@@ -82,7 +82,7 @@ public:
 
     /**
      * @brief Update a specific group header in flattened items
-     * 
+     *
      * This method updates the group header information in flattened items
      * without rebuilding the entire list.
      * @param groupKey The group identifier
@@ -161,6 +161,12 @@ public:
      * @return Total file item count in the flattened list
      */
     int getFileItemCount() const;
+
+    /**
+     * @brief Thread-safe access to group item count
+     * @return Total group item count in the flattened list
+     */
+    int getGroupItemCount() const;
 
     /**
      * @brief Thread-safe access to item at index

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -911,6 +911,15 @@ int FileViewModel::getFileOnlyCount() const
     return filterSortWorker->getFileItemCount();
 }
 
+int FileViewModel::getGroupOnlyCount() const
+{
+    if (!filterSortWorker) {
+        return 0;
+    }
+
+    return filterSortWorker->getGroupItemCount();
+}
+
 void FileViewModel::setDirectoryLoadStrategy(DirectoryLoadStrategy strategy)
 {
     fmDebug() << "Setting directory load strategy:" << static_cast<int>(strategy) << "for URL:" << dirRootUrl.toString();

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -100,6 +100,7 @@ public:
 
     // Get file-only count for status bar (excludes group headers)
     int getFileOnlyCount() const;
+    int getGroupOnlyCount() const;
 
     // 设置目录加载策略
     void setDirectoryLoadStrategy(DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -177,10 +177,19 @@ int FileSortWorker::getFileItemCount()
     if (!isCurrentGroupingEnabled) {
         // Traditional mode: use original logic (same as childrenCount)
         return childrenCountInternal();
-    } else {
-        // Grouping mode: return only file items count (excludes group headers)
-        return groupedModelData.getFileItemCount();
     }
+
+    // Grouping mode: return only file items count (excludes group headers)
+    return groupedModelData.getFileItemCount();
+}
+
+int FileSortWorker::getGroupItemCount()
+{
+    if (!isCurrentGroupingEnabled) {
+        return 0;
+    }
+
+    return groupedModelData.getGroupItemCount();
 }
 
 QVariant FileSortWorker::groupHeaderData(const int index, const int role)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
@@ -83,6 +83,7 @@ public:
 
     int childrenCount();
     int getFileItemCount();
+    int getGroupItemCount();
     QVariant groupHeaderData(const int index, const int role);
     FileItemDataPointer childData(const int index);
     FileItemDataPointer childData(const QUrl &url);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewanimationhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewanimationhelper.cpp
@@ -108,7 +108,7 @@ void ViewAnimationHelper::playViewAnimation()
         return;
     }
 
-    fmInfo() << "Starting view animation playback";
+    fmDebug() << "Starting view animation playback";
 
     if (!delayTimer) {
         delayTimer = new QTimer(this);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -132,6 +132,7 @@ public:
     virtual void paintGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
     QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
+    QRect getExpandButtonRect(const QRectF &rect) const;
 
 protected:
     explicit BaseItemDelegate(BaseItemDelegatePrivate &dd, FileViewHelper *parent);
@@ -152,6 +153,7 @@ protected:
     // Group layout calculation methods
 
     QRect getGroupTextRect(const QStyleOptionViewItem &option) const;
+    QRect getGroupTextRect(const QRectF &rect) const;
 
     QList<QRectF> getCornerGeometryList(const QRectF &baseRect, const QSizeF &cornerSize) const;
     void paintEmblems(QPainter *painter, const QRectF &iconRect, const QModelIndex &index) const;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -257,6 +257,8 @@ private:
     void focusOnView();
 
     bool isGroupHeader(const QModelIndex &index) const;
+    bool isClickInGroupHeaderSpacing(const QPoint &pos, const QModelIndex &index) const;
+    QModelIndex indexAtForSelection(const QPoint &pos) const;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
@@ -102,7 +102,7 @@ void HeaderView::updateColumnWidth()
 
 void HeaderView::doFileNameColumnResize(const int totalWidth)
 {
-    fmInfo() << "Resizing file name column, total width:" << totalWidth;
+    fmDebug() << "Resizing file name column, total width:" << totalWidth;
 
     int fileNameColumn = viewModel()->getColumnByRole(kItemFileDisplayNameRole);
     int columnCount = count();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -761,7 +761,13 @@ QSize IconItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
 {
     // Check if this is a group header item
     if (isGroupHeaderItem(index)) {
-        return getGroupHeaderSizeHint(option, index);
+        auto size = getGroupHeaderSizeHint(option, index);
+        // 为非第一个分组头添加 16px 顶部间隔
+        int displayIndex = index.data(Global::kItemGroupDisplayIndex).toInt();
+        if (displayIndex > 0) {
+            size.setHeight(size.height() + kGroupHeaderInterval);
+        }
+        return size;
     }
 
     Q_D(const IconItemDelegate);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -102,7 +102,12 @@ QSize ListItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
 {
     // Check if this is a group header item
     if (isGroupHeaderItem(index)) {
-        return getGroupHeaderSizeHint(option, index);
+        auto size = getGroupHeaderSizeHint(option, index);
+        // 为非第一个分组头添加 16px 顶部间隔
+        if (index.row() > 0) {
+            size.setHeight(size.height() + kGroupHeaderInterval);
+        }
+        return size;
     }
 
     Q_UNUSED(index)
@@ -772,6 +777,77 @@ QRectF ListItemDelegate::getGroupHeaderBackgroundRect(const QStyleOptionViewItem
     rect.setWidth(totalWidth);
 
     return rect;
+}
+
+void ListItemDelegate::paintGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    if (!painter || !index.isValid()) {
+        return;
+    }
+
+    painter->save();
+
+    // Calculate actual drawing rect (skip top spacing for non-first group headers)
+    QRectF drawRect = option.rect;
+    int displayIndex = index.data(Global::kItemGroupDisplayIndex).toInt();
+
+    if (displayIndex > 0) {
+        // For non-first group headers, skip the top spacing area
+        // The spacing area remains transparent (view background shows through)
+        drawRect.setTop(drawRect.top() + kGroupHeaderInterval);
+    }
+
+    // Now paint the actual group header content using drawRect
+    // Paint background first
+    FileView *view = parent()->parent();
+    if (view) {
+        int totalWidth = view->getHeaderViewWidth() - (kListModeLeftMargin + kListModeRightMargin);
+        QRectF bgRect = drawRect;
+        bgRect.setLeft(bgRect.left() + kListModeLeftMargin);
+        bgRect.setWidth(totalWidth);
+
+        // Paint background with proper color
+        DPalette pl(DPaletteHelper::instance()->palette(option.widget));
+        QColor baseColor = pl.color(DPalette::ColorGroup::Active, DPalette::ColorType::ItemBackground);
+        QColor adjustColor = baseColor;
+
+        if (option.state & QStyle::State_MouseOver) {
+            adjustColor = DGuiApplicationHelper::adjustColor(baseColor, 0, 0, 0, 0, 0, 0, +10);
+        } else {
+            painter->setOpacity(0);
+        }
+
+        QPainterPath path;
+        path.addRoundedRect(bgRect, kListModeRectRadius, kListModeRectRadius);
+        painter->setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
+        painter->fillPath(path, adjustColor);
+    }
+
+    painter->restore();
+
+    // Get group information
+    QString groupText = index.data(Qt::DisplayRole).toString();
+    int fileCount = index.data(Global::kItemGroupFileCount).toInt();
+    if (groupText.isEmpty()) {
+        groupText = "Group";
+    }
+
+    bool isExpanded = index.data(Global::ItemRoles::kItemGroupExpandedRole).toBool();
+
+    // Calculate layout rectangles based on drawRect (not option.rect!)
+    QRect expandButtonRect(drawRect.left() + kListModeLeftMargin + 8,
+                           drawRect.top() + (drawRect.height() - kGroupHeaderInterval) / 2,
+                           kGroupHeaderInterval, kGroupHeaderInterval);
+    QRect textRect(expandButtonRect.right() + 8,
+                   drawRect.top(),
+                   drawRect.width() - (expandButtonRect.right() - drawRect.left()) - kGroupHeaderInterval,
+                   drawRect.height());
+
+    // Paint expand button
+    paintExpandButton(painter, expandButtonRect, isExpanded);
+
+    // Paint group text
+    paintGroupText(painter, textRect, groupText, fileCount, option);
 }
 
 bool ListItemDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index)

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
@@ -65,7 +65,6 @@ private:
 
     // Group functionality implementation
     int getGroupHeaderHeight(const QStyleOptionViewItem &option) const override;
-    void paintGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     QRectF getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const override;
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
@@ -65,6 +65,7 @@ private:
 
     // Group functionality implementation
     int getGroupHeaderHeight(const QStyleOptionViewItem &option) const override;
+    void paintGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
     QRectF getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const override;
     bool editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust grouped list and icon views to support consistent 16px spacing above non-first group headers and update selection, hit-testing, and geometry calculations accordingly.

New Features:
- Add support for counting group header items separately from file items in grouped views.

Bug Fixes:
- Fix selection and index hit-testing in grouped list views with variable-height items and header spacing so that clicks in spacing areas are treated as empty and range selection respects group gaps.

Enhancements:
- Refine group header painting and layout to account for top spacing while keeping backgrounds and hover effects visually correct in list and icon modes.
- Update list view geometry calculations to include additional height from group header spacing, and disable uniform item sizes in list mode to support variable heights.
- Reduce logging verbosity by downgrading some informational messages to debug level.