### PR TITLE
fix: unify selection handling for icon and list views

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
@@ -110,12 +110,10 @@ void SelectHelper::selection(const QRect &rect, QItemSelectionModel::SelectionFl
     QItemSelection newSelection;
     caculateSelection(rect, &newSelection);
 
-    if (view->isIconViewMode()) {
-        caculateAndSelectIndex(lastSelection, newSelection, flags);
-        lastSelection = newSelection;
-    } else {
-        view->selectionModel()->select(newSelection, flags);
-    }
+    // Use incremental update for both icon and list modes to avoid flickering
+    // during deselection (shrinking selection range)
+    caculateAndSelectIndex(lastSelection, newSelection, flags);
+    lastSelection = newSelection;
 }
 
 bool SelectHelper::select(const QList<QUrl> &urls)


### PR DESCRIPTION
Previously, icon view mode used incremental selection updates while list view mode used direct selection replacement. This caused visual flickering when shrinking selection ranges in list view mode. Now both modes use the same incremental update approach to ensure consistent behavior and eliminate flickering issues.

The change modifies the selection logic to always use caculateAndSelectIndex method which handles incremental updates properly, replacing the conditional logic that treated icon and list views differently.

Influence:
1. Test selection behavior in both icon and list view modes
2. Verify selection expansion and contraction works smoothly
3. Check for any visual flickering during selection changes
4. Test multiple selection scenarios including drag selection
5. Verify selection persistence when switching between view modes

fix: 统一图标和列表视图的选择处理

之前图标视图模式使用增量选择更新，而列表视图模式使用直接选择替换。这导致
在列表视图模式下缩小选择范围时出现视觉闪烁。现在两种模式都使用相同的增量
更新方法，以确保一致的行为并消除闪烁问题。

此更改修改了选择逻辑，始终使用 caculateAndSelectIndex 方法，该方法能正确
处理增量更新，取代了之前对图标和列表视图区别对待的条件逻辑。

Influence:
1. 测试图标和列表视图模式下的选择行为
2. 验证选择扩展和收缩是否平滑工作
3. 检查选择变化过程中是否有视觉闪烁
4. 测试多种选择场景，包括拖拽选择
5. 验证在视图模式切换时选择的持久性

## Summary by Sourcery

Unify selection handling across icon and list view modes to use incremental updates and eliminate flickering when changing selections.

Bug Fixes:
- Fix visual flickering when shrinking selection ranges in list view mode by using incremental selection updates instead of direct replacement.

Enhancements:
- Apply the same incremental selection update logic to both icon and list views for consistent multi-selection behavior.