### PR TITLE
test: prevent unit tests from modifying user configuration files

### DIFF
--- a/autotests/plugins/dfmplugin-burn/test_auditlogjob.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_auditlogjob.cpp
@@ -8,6 +8,8 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/file/local/syncfileinfo.h>
 #include <dfm-base/file/local/asyncfileinfo.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
 
 #include <QDBusInterface>
 #include <QThread>
@@ -232,6 +234,11 @@ TEST_F(UT_AuditLogJob, BurnFilesAuditLogJob_writeLog)
         __DBG_STUB_INVOKE__
         dbusCallCalled = true;
         return QDBusMessage();
+    });
+
+    stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+        __DBG_STUB_INVOKE__
+        return true;
     });
 
     QDBusInterface interface("test.service", "/test/path", "test.interface");

--- a/autotests/plugins/dfmplugin-burn/test_burnoptdialog.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burnoptdialog.cpp
@@ -9,6 +9,9 @@
 
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+
 #include <dfm-burn/dopticaldiscmanager.h>
 #include <dfm-burn/dopticaldiscinfo.h>
 
@@ -37,6 +40,10 @@ protected:
         stub.set_lamda(ADDR(WindowUtils, isWayLand), [] {
             __DBG_STUB_INVOKE__
             return false;
+        });
+        stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+            __DBG_STUB_INVOKE__
+            return true;
         });
 
         dialog = new BurnOptDialog("/dev/sr0");
@@ -304,6 +311,11 @@ TEST_F(UT_BurnOptDialog, startDataBurn_EmptyVolumeName)
         return QUrl::fromLocalFile("/tmp/staging");
     });
 
+    stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
     dialog->volnameEdit->clear();
     dialog->lastVolName = "DefaultVolume";
 
@@ -424,6 +436,11 @@ TEST_F(UT_BurnOptDialog, onButnBtnClicked_Burn_DeviceNotExists)
 
 TEST_F(UT_BurnOptDialog, volnameEdit_TextChanged_ValidLength)
 {
+    stub.set_lamda(ADDR(Settings, sync), [](Settings *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
     QString validText = "ValidVolumeName";
 
     dialog->volnameEdit->setText(validText);


### PR DESCRIPTION
The unit tests were incorrectly modifying real user configuration files instead of using temporary test files. This change fixes the test infrastructure to isolate test data from user data.

1. In test_recentmanager.cpp: Replaced QTemporaryFile with a proper temporary directory structure that mimics the real ~/.local/share path. Added stubbing of QDir::homePath() to redirect to the temporary directory, preventing modification of the user's actual recently- used.xbel file.
2. In test_auditlogjob.cpp and test_burnoptdialog.cpp: Added stubs for Settings::sync() method to prevent test operations from writing to real application settings files during testing.

These changes ensure that unit tests run in complete isolation and do not interfere with user configuration files or application settings.

Influence:
1. Verify that unit tests no longer create or modify files in the user's home directory
2. Test that the temporary directory structure is properly created and cleaned up
3. Confirm that Settings::sync() calls are properly stubbed and don't persist changes
4. Ensure all file operations are contained within test-specific temporary directories

test: 修复单元测试篡改用户配置文件的问题

单元测试之前错误地修改了真实的用户配置文件而不是使用临时测试文件。本次修
改修复了测试基础设施，将测试数据与用户数据隔离。

1. 在 test_recentmanager.cpp 中：使用适当的临时目录结构替换 QTemporaryFile，模拟真实的 ~/.local/share 路径。添加对 QDir::homePath() 的桩函数重定向到临时目录，防止修改用户实际的 recently-used.xbel 文件。
2. 在 test_auditlogjob.cpp 和 test_burnoptdialog.cpp 中：添加对 Settings::sync() 方法的桩函数，防止测试操作在测试期间写入真实的应用程序
设置文件。

这些更改确保单元测试在完全隔离的环境中运行，不会干扰用户配置文件或应用程
序设置。

Influence:
1. 验证单元测试不再在用户主目录中创建或修改文件
2. 测试临时目录结构是否正确创建和清理
3. 确认 Settings::sync() 调用被正确桩函数替换且不会持久化更改
4. 确保所有文件操作都包含在测试专用的临时目录中

## Summary by Sourcery

Ensure unit tests do not touch real user configuration or settings files by isolating filesystem and settings interactions in tests.

Tests:
- Rework recent-manager tests to use a dedicated temporary directory tree and stubbed home directory instead of writing to the real recently-used.xbel file.
- Stub application Settings::sync() in burn option dialog and audit log job tests to prevent writes to real application settings during test execution.