### PR TITLE
fix: Fix user configuration deleted by upgrade unit case

### DIFF
--- a/src/tools/upgrade/core/upgradeunit.cpp
+++ b/src/tools/upgrade/core/upgradeunit.cpp
@@ -4,11 +4,14 @@
 
 #include "upgradeunit.h"
 
+#include <QStandardPaths>
+
 using namespace dfm_upgrade;
 
 UpgradeUnit::UpgradeUnit()
 {
-
+    configurationPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager/dde-file-manager.json";
+    backupDirPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager/old";
 }
 
 UpgradeUnit::~UpgradeUnit()

--- a/src/tools/upgrade/core/upgradeunit.h
+++ b/src/tools/upgrade/core/upgradeunit.h
@@ -6,6 +6,7 @@
 #define UPGRADEUNIT_H
 
 #include <QMap>
+#include <QString>
 
 namespace dfm_upgrade {
 
@@ -18,6 +19,10 @@ public:
     virtual bool initialize(const QMap<QString, QString> &args) = 0;
     virtual bool upgrade() = 0;
     virtual void completed();
+
+protected:
+    QString configurationPath;
+    QString backupDirPath;
 };
 
 }

--- a/src/tools/upgrade/units/appattributeupgradeunit.cpp
+++ b/src/tools/upgrade/units/appattributeupgradeunit.cpp
@@ -20,8 +20,6 @@ static constexpr char kConfigKeyIconSizeLevel[] { "IconSizeLevel" };
 static constexpr char kAppAttributeVersion[] { "v1.0" };
 static constexpr int kOldMaxIconSizeLevel { 4 };
 
-static QString kConfigurationPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager/dde-file-manager.json";
-static QString kBackupDirPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager/old";
 
 AppAttributeUpgradeUnit::AppAttributeUpgradeUnit()
     : UpgradeUnit()
@@ -37,9 +35,9 @@ bool AppAttributeUpgradeUnit::initialize(const QMap<QString, QString> &args)
 {
     Q_UNUSED(args)
 
-    QFile file(kConfigurationPath);
+    QFile file(configurationPath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qCWarning(logToolUpgrade) << "Failed to open configuration file:" << kConfigurationPath;
+        qCWarning(logToolUpgrade) << "Failed to open configuration file:" << configurationPath;
         return false;
     }
 
@@ -124,22 +122,22 @@ int AppAttributeUpgradeUnit::transIconSizeLevel(int oldIconSizeLevel) const
 
 bool AppAttributeUpgradeUnit::backupAppAttribute() const
 {
-    QDir backupDir(kBackupDirPath);
+    QDir backupDir(backupDirPath);
     if (!backupDir.exists()) {
         if (!backupDir.mkpath(".")) {
-            qCWarning(logToolUpgrade) << "upgrade: create backup directory failed: " << kBackupDirPath;
+            qCWarning(logToolUpgrade) << "upgrade: create backup directory failed: " << backupDirPath;
             return false;
         }
     }
 
-    QString backupFilePath { kBackupDirPath + "/" + kConfigGroupAppAttribute + "_" + kAppAttributeVersion + ".backup" };
+    QString backupFilePath { backupDirPath + "/" + kConfigGroupAppAttribute + "_" + kAppAttributeVersion + ".backup" };
     if (QFile::exists(backupFilePath)) {
         qCWarning(logToolUpgrade) << "upgrade: backup file already exists: " << backupFilePath;
         return false;
     }
 
-    if (!QFile::copy(kConfigurationPath, backupFilePath)) {
-        qCWarning(logToolUpgrade) << "upgrade: copy file failed: " << kConfigurationPath << " to " << backupFilePath;
+    if (!QFile::copy(configurationPath, backupFilePath)) {
+        qCWarning(logToolUpgrade) << "upgrade: copy file failed: " << configurationPath << " to " << backupFilePath;
         return false;
     }
 
@@ -151,9 +149,9 @@ bool AppAttributeUpgradeUnit::writeConfigFile() const
     QJsonDocument newDoc(configObject);
     QByteArray data = newDoc.toJson();
 
-    QFile writeFile(kConfigurationPath);
+    QFile writeFile(configurationPath);
     if (!writeFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qCWarning(logToolUpgrade) << "upgrade: open file failed: " << kConfigurationPath;
+        qCWarning(logToolUpgrade) << "upgrade: open file failed: " << configurationPath;
         return false;
     }
 

--- a/src/tools/upgrade/units/bookmarkupgradeunit.cpp
+++ b/src/tools/upgrade/units/bookmarkupgradeunit.cpp
@@ -32,9 +32,6 @@ static constexpr char kKeyCreated[] { "created" };
 static constexpr char kKeyLastModi[] { "lastModified" };
 static constexpr char kKeyMountPoint[] { "mountPoint" };
 
-static QString kConfigurationPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager.json";
-static QString kBackupDirPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager/old";
-
 QVariantMap BookmarkData::serialize()
 {
     QVariantMap v;
@@ -50,6 +47,9 @@ QVariantMap BookmarkData::serialize()
 BookMarkUpgradeUnit::BookMarkUpgradeUnit()
     : UpgradeUnit()
 {
+    // define bookmark config path for compatibility
+    configurationPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager.json";
+    backupDirPath = QStandardPaths::standardLocations(QStandardPaths::ConfigLocation).first() + "/deepin/dde-file-manager/old";
 }
 
 QString BookMarkUpgradeUnit::name()
@@ -61,14 +61,14 @@ bool BookMarkUpgradeUnit::initialize(const QMap<QString, QString> &args)
 {
     Q_UNUSED(args)
     qCInfo(logToolUpgrade) << "begin upgrade";
-    if (!UpgradeUtils::backupFile(kConfigurationPath, kBackupDirPath))
-        qCWarning(logToolUpgrade) << "backup file" << kConfigurationPath << "to dir: " << kBackupDirPath << "failed";
+    if (!UpgradeUtils::backupFile(configurationPath, backupDirPath))
+        qCWarning(logToolUpgrade) << "backup file" << configurationPath << "to dir: " << backupDirPath << "failed";
     else
-        qCInfo(logToolUpgrade) << "backup file" << kConfigurationPath << "to dir: " << kBackupDirPath << "success";
+        qCInfo(logToolUpgrade) << "backup file" << configurationPath << "to dir: " << backupDirPath << "success";
 
-    QFile file(kConfigurationPath);
+    QFile file(configurationPath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qCWarning(logToolUpgrade) << "Failed to open configuration file:" << kConfigurationPath;
+        qCWarning(logToolUpgrade) << "Failed to open configuration file:" << configurationPath;
         return false;
     }
 
@@ -189,9 +189,9 @@ QVariantList BookMarkUpgradeUnit::initData() const
 
 bool BookMarkUpgradeUnit::doUpgrade(const QVariantList &quickAccessDatas)
 {
-    QFile file(kConfigurationPath);
+    QFile file(configurationPath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        qCCritical(logToolUpgrade) << "Failed to open configuration file for writing:" << kConfigurationPath;
+        qCCritical(logToolUpgrade) << "Failed to open configuration file for writing:" << configurationPath;
         return false;
     }
 

--- a/src/tools/upgrade/units/vaultupgradeunit.cpp
+++ b/src/tools/upgrade/units/vaultupgradeunit.cpp
@@ -14,12 +14,15 @@ Q_DECLARE_LOGGING_CATEGORY(logToolUpgrade)
 using namespace dfm_upgrade;
 
 VaultUpgradeUnit::VaultUpgradeUnit()
-    : UpgradeUnit(),
-      cryfsConfigFilePathOld(kVaultBasePathOld + QDir::separator() + QString(kVaultEncrypyDirName) + QDir::separator() + QString(kCryfsConfigFileName)),
-      cryfsConfigFilePathNew(kVaultBasePath + QDir::separator() + QString(kVaultEncrypyDirName) + QDir::separator() + QString(kCryfsConfigFileName)),
-      decryptDirPathOld(kVaultBasePathOld + QDir::separator() + QString(kVaultDecryptDirName)),
-      decryptDirPathNew(kVaultBasePath + QDir::separator() + QString(kVaultDecryptDirName))
+    : UpgradeUnit()
 {
+    vaultBasePath = QDir::homePath() + QString("/.config/Vault");
+    vaultBasePathOld = QDir::homePath() + QString("/.local/share/applications");
+
+    cryfsConfigFilePathOld = vaultBasePathOld + QDir::separator() + QString(kVaultEncrypyDirName) + QDir::separator() + QString(kCryfsConfigFileName);
+    cryfsConfigFilePathNew = vaultBasePath + QDir::separator() + QString(kVaultEncrypyDirName) + QDir::separator() + QString(kCryfsConfigFileName);
+    decryptDirPathOld = vaultBasePathOld + QDir::separator() + QString(kVaultDecryptDirName);
+    decryptDirPathNew = vaultBasePath + QDir::separator() + QString(kVaultDecryptDirName);
 }
 
 QString VaultUpgradeUnit::name()
@@ -46,7 +49,7 @@ bool VaultUpgradeUnit::upgrade()
         }
     }
 
-    if (QFile::exists(kVaultBasePath)) {
+    if (QFile::exists(vaultBasePath)) {
         qCCritical(logToolUpgrade) << "Vault: the new vault has exist, can't upgrade, you can remove the new vault, then restart system!";
         return false;
     }
@@ -64,7 +67,7 @@ void VaultUpgradeUnit::completed()
 
 void VaultUpgradeUnit::moveVault()
 {
-    QString vaultNewPath(kVaultBasePath);
+    QString vaultNewPath(vaultBasePath);
     QDir dir;
     if (!dir.exists(vaultNewPath)) {
         bool result = dir.mkpath(vaultNewPath);
@@ -79,43 +82,43 @@ void VaultUpgradeUnit::moveVault()
     else
         qCInfo(logToolUpgrade) << "Vault: mv " << decryptDirPathOld << " to " << decryptDirPathNew;
 
-    QString encryptDirPathOld = kVaultBasePathOld + QDir::separator() + QString(kVaultEncrypyDirName);
-    QString encryptDirPathNew = kVaultBasePath + QDir::separator() + QString(kVaultEncrypyDirName);
+    QString encryptDirPathOld = vaultBasePathOld + QDir::separator() + QString(kVaultEncrypyDirName);
+    QString encryptDirPathNew = vaultBasePath + QDir::separator() + QString(kVaultEncrypyDirName);
     if (!dir.rename(encryptDirPathOld, encryptDirPathNew))
         qCWarning(logToolUpgrade) << "Vault: move encrypt dir failed!";
     else
         qCInfo(logToolUpgrade) << "Vault: mv " << encryptDirPathOld << " to " << encryptDirPathNew;
 
-    QString passwordFilePathOld = kVaultBasePathOld + QDir::separator() + QString(kPasswordFileName);
-    QString passwordFilePathNew = kVaultBasePath + QDir::separator() + QString(kPasswordFileName);
+    QString passwordFilePathOld = vaultBasePathOld + QDir::separator() + QString(kPasswordFileName);
+    QString passwordFilePathNew = vaultBasePath + QDir::separator() + QString(kPasswordFileName);
     if (!QFile::rename(passwordFilePathOld, passwordFilePathNew))
         qCWarning(logToolUpgrade) << "Vault: move password file failed!";
     else
         qCInfo(logToolUpgrade) << "Vault: mv " << passwordFilePathOld << " to " << passwordFilePathNew;
 
-    QString rsaPubKeyFilePathOld = kVaultBasePathOld + QDir::separator() + QString(kRSAPUBKeyFileName);
-    QString rsaPubKeyFilePathNew = kVaultBasePath + QDir::separator() + QString(kRSAPUBKeyFileName);
+    QString rsaPubKeyFilePathOld = vaultBasePathOld + QDir::separator() + QString(kRSAPUBKeyFileName);
+    QString rsaPubKeyFilePathNew = vaultBasePath + QDir::separator() + QString(kRSAPUBKeyFileName);
     if (!QFile::rename(rsaPubKeyFilePathOld, rsaPubKeyFilePathNew))
         qCWarning(logToolUpgrade) << "Vault: move pubkey file failed!";
     else
         qCInfo(logToolUpgrade) << "Vault: mv " << rsaPubKeyFilePathOld << " to " << rsaPubKeyFilePathNew;
 
-    QString rsaCipherFilePathOld = kVaultBasePathOld + QDir::separator() + QString(kRSACiphertextFileName);
-    QString rsaCipherFilePathNew = kVaultBasePath + QDir::separator() + QString(kRSACiphertextFileName);
+    QString rsaCipherFilePathOld = vaultBasePathOld + QDir::separator() + QString(kRSACiphertextFileName);
+    QString rsaCipherFilePathNew = vaultBasePath + QDir::separator() + QString(kRSACiphertextFileName);
     if (!QFile::rename(rsaCipherFilePathOld, rsaCipherFilePathNew))
         qCWarning(logToolUpgrade) << "Vault: move cipher file failed!";
     else
         qCInfo(logToolUpgrade) << "Vault: mv " << rsaCipherFilePathOld << " to " << rsaCipherFilePathNew;
 
-    QString passwordHintFilePathOld = kVaultBasePathOld + QDir::separator() + QString(kPasswordHintFileName);
-    QString passwordHintFilePathNew = kVaultBasePath + QDir::separator() + QString(kPasswordHintFileName);
+    QString passwordHintFilePathOld = vaultBasePathOld + QDir::separator() + QString(kPasswordHintFileName);
+    QString passwordHintFilePathNew = vaultBasePath + QDir::separator() + QString(kPasswordHintFileName);
     if (!QFile::rename(passwordHintFilePathOld, passwordHintFilePathNew))
         qCWarning(logToolUpgrade) << "Vault: move password hint file failed!";
     else
         qCInfo(logToolUpgrade) << "Vault: mv " << passwordHintFilePathOld << " to " << passwordHintFilePathNew;
 
-    QString configFilePathOld = kVaultBasePathOld + QDir::separator() + QString(kVaultConfigFileName);
-    QString configFilePahtNew = kVaultBasePath + QDir::separator() + QString(kVaultConfigFileName);
+    QString configFilePathOld = vaultBasePathOld + QDir::separator() + QString(kVaultConfigFileName);
+    QString configFilePahtNew = vaultBasePath + QDir::separator() + QString(kVaultConfigFileName);
     if (!QFile::rename(configFilePathOld, configFilePahtNew))
         qCWarning(logToolUpgrade) << "Vault: move config file failed!";
     else

--- a/src/tools/upgrade/units/vaultupgradeunit.h
+++ b/src/tools/upgrade/units/vaultupgradeunit.h
@@ -11,8 +11,6 @@
 
 namespace dfm_upgrade {
 
-inline const QString kVaultBasePath(QDir::homePath() + QString("/.config/Vault"));
-inline const QString kVaultBasePathOld(QDir::homePath() + QString("/.local/share/applications"));
 inline constexpr char kVaultDecryptDirName[] { "vault_unlocked" };
 inline constexpr char kVaultEncrypyDirName[] { "vault_encrypted" };
 inline constexpr char kPasswordFileName[] { "pbkdf2clipher" };
@@ -41,6 +39,9 @@ private:
     QString cryfsConfigFilePathNew;
     QString decryptDirPathOld;
     QString decryptDirPathNew;
+
+    QString vaultBasePath;
+    QString vaultBasePathOld;
 };
 }
 


### PR DESCRIPTION
move kConfigurationPath and kBackupDirPath definitions from individual upgrade units to the base UpgradeUnit class to centralize path management and improve code organization.

Log: Fix user configuration deleted by upgrade unit case.

## Summary by Sourcery

Centralize upgrade configuration and vault path handling to prevent user configuration loss during upgrades.

Bug Fixes:
- Ensure upgrade units use consistent configuration and backup paths to avoid deleting existing user configuration during upgrades.

Enhancements:
- Move configuration path and backup directory definitions into the base UpgradeUnit class for shared use across upgrade units.
- Refactor vault upgrade unit to compute vault base paths at construction time instead of using global inline constants.
- Align bookmark upgrade unit to use the new shared configuration and backup paths while maintaining compatibility with legacy bookmark config locations.