### PR TITLE
fix: use synchronous file info creation in property dialog

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -252,7 +252,7 @@ void BasicWidget::basicFieldFilter(const QUrl &url)
 
 void BasicWidget::basicFill(const QUrl &url)
 {
-    FileInfoPointer info = InfoFactory::create<FileInfo>(url);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (info.isNull())
         return;
     if (!info->canAttributes(CanableInfoType::kCanHidden))
@@ -409,7 +409,7 @@ void BasicWidget::slotFileHide(Qt::CheckState state)
 
 void BasicWidget::slotOpenFileLocation()
 {
-    FileInfoPointer info = InfoFactory::create<FileInfo>(currentUrl);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(currentUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (info.isNull())
         return;
 
@@ -419,7 +419,7 @@ void BasicWidget::slotOpenFileLocation()
             : info->pathOf(PathInfoType::kAbsoluteFilePath);
 
     const QUrl targetUrl = QUrl::fromLocalFile(targetPath);
-    const auto &targetInfo = InfoFactory::create<FileInfo>(targetUrl);
+    const auto &targetInfo = InfoFactory::create<FileInfo>(targetUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (targetInfo.isNull())
         return;
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -346,7 +346,7 @@ void EditStackedWidget::showTextShowFrame()
 void EditStackedWidget::selectFile(const QUrl &url)
 {
     fileUrl = url;
-    FileInfoPointer info = InfoFactory::create<FileInfo>(url);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (!info.isNull()) {
         initTextShowFrame(info->displayOf(DisPlayInfoType::kFileDisplayName));
         if (!info->canAttributes(CanableInfoType::kCanRename)) {

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -99,7 +99,7 @@ void FilePropertyDialog::createHeadUI(const QUrl &url)
 {
     fileIcon = new QLabel(this);
     fileIcon->setFixedHeight(128);
-    currentInfo = InfoFactory::create<FileInfo>(url);
+    currentInfo = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
     setFileIcon(fileIcon, currentInfo);
 
     editStackWidget = new EditStackedWidget(this);

--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -53,7 +53,7 @@ PermissionManagerWidget::~PermissionManagerWidget()
 void PermissionManagerWidget::selectFileUrl(const QUrl &url)
 {
     selectUrl = url;
-    FileInfoPointer info = InfoFactory::create<FileInfo>(url);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
 
     if (info.isNull())
         return;
@@ -267,7 +267,7 @@ void PermissionManagerWidget::setComboBoxByPermission(QComboBox *cb, int permiss
 void PermissionManagerWidget::toggleFileExecutable(bool isChecked)
 {
 
-    FileInfoPointer info = InfoFactory::create<FileInfo>(selectUrl);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(selectUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (info.isNull())
         return;
 
@@ -333,7 +333,7 @@ void PermissionManagerWidget::paintEvent(QPaintEvent *evt)
 
 void PermissionManagerWidget::onComboBoxChanged()
 {
-    FileInfoPointer info = InfoFactory::create<FileInfo>(selectUrl);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(selectUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (info.isNull())
         return;
 


### PR DESCRIPTION
Changed all InfoFactory::create<FileInfo> calls to use synchronous creation type (kCreateFileInfoSync) instead of the default asynchronous mode. This ensures file information is immediately available when property dialog operations are performed, preventing race conditions and UI inconsistencies.

The property dialog requires immediate access to file metadata for display and permission management. Using asynchronous file info creation could lead to delayed or missing data when users quickly interact with dialog controls. Synchronous creation guarantees that file properties are fully loaded before any UI operations occur.

Influence:
1. Test property dialog opening speed for various file types
2. Verify file information displays correctly immediately after dialog opens
3. Test permission changes and file operations in property dialog
4. Check for any performance impact when opening properties for large files
5. Verify "Open File Location" functionality works reliably

fix: 在属性对话框中使用同步文件信息创建

将所有 InfoFactory::create<FileInfo> 调用改为使用同步创建类型
(kCreateFileInfoSync) 替代默认的异步模式。这确保在执行属性对话框操作时文
件信息立即可用，防止竞态条件和UI不一致问题。

属性对话框需要立即访问文件元数据进行显示和权限管理。使用异步文件信息创建
可能导致用户快速与对话框控件交互时出现数据延迟或缺失。同步创建保证在UI操
作发生前文件属性已完全加载。

Influence:
1. 测试各种文件类型的属性对话框打开速度
2. 验证对话框打开后文件信息立即正确显示
3. 测试属性对话框中的权限更改和文件操作
4. 检查打开大文件属性时是否有性能影响
5. 验证"打开文件位置"功能可靠工作

## Summary by Sourcery

Use synchronous file info creation when populating and interacting with the file property dialog to ensure metadata is available immediately and avoid UI race conditions.

Bug Fixes:
- Ensure file metadata is synchronously loaded for basic property fields, preventing delayed or missing information in the dialog.
- Load file info synchronously for "Open File Location" to reliably resolve the correct target path.
- Load file info synchronously when selecting files in the permission manager to avoid stale or incomplete permission data.
- Ensure file info is synchronously available when toggling executability or changing permission-related combobox values.
- Synchronously load file info when selecting a file for the edit stack to guarantee the display name and rename capability are accurate on dialog open.