### PR TITLE
fix: adjust header margin logic for grouped view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -82,6 +82,7 @@ inline constexpr int kTreeArrowAndIconDistance { 8 };
 inline constexpr int kViewAnimationDuration { 366 };
 inline constexpr int kViewAnimationFrameDuration { 16 };
 inline constexpr int kGroupHeaderInterval { 16 };
+inline constexpr int kDefaultHeaderBottomMargin { 10 };
 
 // tab defines
 inline constexpr int kMaxTabCount { 8 };

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2495,7 +2495,9 @@ void FileView::initializeScrollBarWatcher()
                     d->headerView->syncOffset(hVal);
                 });
             } else if (value == 0 && margins.bottom() == 0) {
-                headerLayout->setContentsMargins(0, 0, 0, 10);
+                // Only restore bottom margin in non-grouped mode
+                int bottomMargin = isGroupedView() ? 0 : kDefaultHeaderBottomMargin;
+                headerLayout->setContentsMargins(0, 0, 0, bottomMargin);
                 QTimer::singleShot(0, this, [this]() {
                     if (!d->headerView)
                         return;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -369,7 +369,7 @@ void FileViewPrivate::adjustHeaderLayoutMargin(const QString &strategyName)
 
     // Determine margin based on grouping state
     bool isGrouped = strategyName != GroupStrategy::kNoGroup;
-    int bottomMargin = isGrouped ? 0 : 10;
+    int bottomMargin = isGrouped ? 0 : kDefaultHeaderBottomMargin;
 
     headerLayout->setContentsMargins(0, 0, 0, bottomMargin);
     fmDebug() << "Header layout bottom margin adjusted to:" << bottomMargin


### PR DESCRIPTION
Fixed an issue where the header layout's bottom margin was incorrectly set in grouped view mode. Previously, the margin was always set to 10 when scrollbar value was 0, which caused visual issues in grouped display. Now only applies the 10px bottom margin in non-grouped mode, while keeping 0 margin in grouped view to maintain proper spacing.

The change ensures that grouped view displays correctly without unnecessary padding at the bottom of the header section. This improves visual consistency between different view modes.

Influence:
1. Test file view in both grouped and non-grouped modes
2. Verify header spacing when scrollbar is at position 0
3. Check that grouped view has no extra bottom margin
4. Confirm non-grouped view maintains proper 10px bottom margin
5. Test scrolling behavior and header synchronization

fix: 修复分组视图下头部边距逻辑问题

修复了在分组视图模式下头部布局底部边距设置不正确的问题。之前当滚动条值为
0时，边距总是设置为10，这导致分组显示出现视觉问题。现在仅在非分组模式下
应用10px底部边距，而在分组视图中保持0边距以维持适当的间距。

该更改确保分组视图正确显示，不会在头部区域底部产生不必要的填充。这提高了
不同视图模式之间的视觉一致性。

Influence:
1. 测试分组和非分组模式下的文件视图
2. 验证滚动条在位置0时的头部间距
3. 检查分组视图没有额外的底部边距
4. 确认非分组视图保持适当的10px底部边距
5. 测试滚动行为和头部同步功能

## Summary by Sourcery

Bug Fixes:
- Prevent extra bottom margin from being applied to the header in grouped file view when the scrollbar value is 0, while preserving the 10px margin in non-grouped view.