### PR TITLE
fix(vaultunlockpages): disable button based on password input

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -50,7 +50,6 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
     filePathEdit->setDirectoryUrl(QDir::homePath());
     filePathEdit->setFileMode(DFileDialog::ExistingFiles);
     filePathEdit->setNameFilters({ QString("KEY file(*.key)") });
-    filePathEdit->lineEdit()->setReadOnly(true);
 
     verificationPrompt = new DLabel(this);
     verificationPrompt->setForegroundRole(DPalette::TextWarning);
@@ -71,7 +70,7 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
 
     this->setLayout(mainLayout);
     connect(filePathEdit, &DFileChooserEdit::fileChoosed, this, &RetrievePasswordView::onBtnSelectFilePath);
-
+    connect(filePathEdit->lineEdit(), &QLineEdit::textChanged, this, &RetrievePasswordView::onTextChanged);
 #ifdef ENABLE_TESTING
     AddATTag(qobject_cast<QWidget *>(filePathEdit), AcName::kAcEditVaultRetrieveOtherPath);
     fmDebug() << "Vault: Testing accessibility tags added";
@@ -157,6 +156,14 @@ void RetrievePasswordView::onBtnSelectFilePath(const QString &path)
     filePathEdit->setText(path);
     if (!path.isEmpty())
         emit sigBtnEnabled(1, true);
+}
+
+void RetrievePasswordView::onTextChanged(const QString &path)
+{
+    if(!path.isEmpty())
+        emit sigBtnEnabled(1, true);
+    else
+        emit sigBtnEnabled(1, false);
 }
 
 void RetrievePasswordView::showEvent(QShowEvent *event)

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.h
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.h
@@ -63,6 +63,8 @@ public slots:
      */
     void onBtnSelectFilePath(const QString &path);
 
+    void onTextChanged(const QString &path);
+
 private:
     /*!
      * /brief setVerificationPage   设置密钥验证页面

--- a/src/plugins/filemanager/dfmplugin-vault/views/vaultunlockpages.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/vaultunlockpages.cpp
@@ -112,6 +112,7 @@ void VaultUnlockPages::pageSelect(PageType page)
         QStringList btnList = retrievePasswordView->btnText();
         addButton(btnList[0], false);
         addButton(btnList[1], true, ButtonType::ButtonRecommend);
+        getButton(1)->setEnabled(false);
         connect(retrievePasswordView, &RetrievePasswordView::signalJump, this, &VaultUnlockPages::pageSelect);
         connect(retrievePasswordView, &RetrievePasswordView::sigBtnEnabled, this, &VaultUnlockPages::onSetBtnEnabled);
         connect(retrievePasswordView, &RetrievePasswordView::sigCloseDialog, this, &VaultUnlockPages::close);


### PR DESCRIPTION
- Added functionality to disable the button in VaultUnlockPages when the password input is empty.
- Introduced a new signal in RetrievePasswordView to emit button state changes based on text input.
- Updated the UI logic to ensure the button reflects the current state of the password input field.

These changes enhance user experience by preventing actions when the password field is empty.

bug: https://pms.uniontech.com/bug-view-342775.html

## Summary by Sourcery

Disable the vault unlock confirmation button until valid password-related input is provided and propagate input-based enablement state from the retrieve password view to the vault unlock pages.

Bug Fixes:
- Ensure the vault unlock action button starts disabled on the retrieve password page and only becomes clickable when non-empty input is provided in the associated text field.

Enhancements:
- Allow editing of the key file path field and emit button enablement state changes whenever its text content changes.