### PR TITLE
6.5.109

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+dde-file-manager (6.5.109) unstable; urgency=medium
+
+  * feat: optimize search input delay for Chinese characters
+  * fix: adjust header margin logic for grouped view
+  * test: add unit tests for dfmdaemon-core and dfmplugin-computer
+  * test: [tools]add comprehensive unit tests for upgrade units and utils
+  * fix: use synchronous file info creation in property dialog
+  * fix: add permission tracking logs and fix empty file list issue
+  * fix: Fix user configuration deleted by upgrade unit case
+  * test: prevent unit tests from modifying user configuration files
+  * test: add unit tests for avfsbrowser plugin components
+  * fix: unify selection handling for icon and list views
+  * feat: adjust group header spacing in icon view
+  * feat: adjust group header spacing to 16px in list view
+  * fix: adapt desktop collection layout on resolution change
+  * test: Add unit tests for tools and canvas plugin.
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 11 Dec 2025 20:34:12 +0800
+
 dde-file-manager (6.5.108) unstable; urgency=medium
 
   * Add some unit tests

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -463,8 +463,8 @@ int SearchEditWidget::determineSearchDelay(const QString &inputText)
 
         if (inputText == ".")
             delay += 1000;
-    } else if (byteCount > 3) {
-        delay = 0;
+    } else if (byteCount >= 6) {   // 通常中文2字为6字节
+        delay = 100;
     }
 
     return delay;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent immediate search execution for short multi-byte (e.g., Chinese) input by introducing a small delay once the input reaches six bytes or more.