### PR TITLE
fix: correct burn path length validation boundary conditions

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/burncheckstrategy.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burncheckstrategy.cpp
@@ -67,7 +67,7 @@ bool BurnCheckStrategy::validFile(const QFileInfo &info)
 
     QString absoluteFilePathWithStagePath { info.absoluteFilePath() };
     const QString &fileName { info.fileName() };
-    const QString &absoluteFilePath { QDir::separator() + absoluteFilePathWithStagePath.remove(currentStagePath) };
+    const QString &absoluteFilePath { absoluteFilePathWithStagePath.remove(currentStagePath) };
     invalidName = fileName;
 
     if (!validFileNameCharacters(fileName)) {
@@ -203,7 +203,7 @@ bool JolietCheckStrategy::validFileNameCharacters(const QString &fileName)
 
 bool JolietCheckStrategy::validFilePathCharacters(const QString &filePath)
 {
-    return filePath.size() < kMaxJolietFilePathSize;
+    return filePath.size() <= kMaxJolietFilePathSize;
 }
 
 /*!


### PR DESCRIPTION
- Remove redundant separator prefix when building absolute file path
- Change path length check from < to <= for accurate boundary validation

Log: Fix boundary issues in burn file path length detection
Change-Id: I5582203f33a20c377965dae3ec74107b507eb50c

## Summary by Sourcery

Adjust burn path handling and path length validation to correctly respect maximum Joliet file path size limits.

Bug Fixes:
- Remove an extra path separator when constructing absolute burn file paths from staged paths.
- Treat the maximum Joliet file path size as inclusive in length validation to fix off-by-one boundary errors.