### PR TITLE
fix: fix home path comparison in file sorting

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1165,8 +1165,9 @@ void FileSortWorker::handleAddChildren(const QString &key,
 
     // In the home, it is necessary to sort by display name.
     // So, using `sortAllFiles` to reorder
-    auto parentUrl = makeParentUrl(children.first()->fileUrl());
-    bool isHome = parentUrl.path() == StandardPaths::location(StandardPaths::kHomePath);
+    const auto parentUrl = makeParentUrl(children.first()->fileUrl());
+    const auto path = FileUtils::bindPathTransform(parentUrl.path(), false);
+    bool isHome = (path == StandardPaths::location(StandardPaths::kHomePath));
     if (!isHome && sortRole != DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault && this->sortRole == sortRole
         && this->sortOrder == sortOrder && this->isMixDirAndFile == isMixDirAndFile) {
         if (handleSource)
@@ -2019,7 +2020,7 @@ QVariant FileSortWorker::data(const SortInfoPointer &info, Global::ItemRoles rol
         const QUrl &url = info->fileUrl();
         static const QString kHomePath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
         const auto &path = QDir::cleanPath(url.adjusted(QUrl::RemoveFilename | QUrl::StripTrailingSlash).toLocalFile());
-        return path == kHomePath;
+        return FileUtils::bindPathTransform(path, false) == kHomePath;
     };
 
     // 1. 非本地文件的搜索结果不会进行sortinfo的填充，因此直接返回
@@ -2413,13 +2414,11 @@ void FileSortWorker::doModelChanged(const ModelChangeType type, int index, int c
         case ModelChangeType::kRemoveRows:
             handleAboutToRemoveFilesFromGroup(index, count);
             break;
-
         // 插入/删除完成事件，在分组模式下触发通用的变更处理
         case ModelChangeType::kInsertFinished:
         case ModelChangeType::kRemoveFinished:
             handleGroupingChanged();
             break;
-
         // 直接转发专门用于分组视图的事件
         case ModelChangeType::kInsertGroupRows:
             Q_EMIT insertGroupRows(index, count);


### PR DESCRIPTION
The original code compared file paths directly for determining if a file is in the home directory, which could fail when dealing with bind- mounted paths or special file system configurations. This fix uses FileUtils::bindPathTransform to normalize paths before comparison, ensuring accurate identification of home directory files.

The changes include:
1. Using bindPathTransform to normalize parent URL paths in handleAddChildren
2. Applying the same path transformation in the home directory check within data method
3. This ensures consistent path comparison across different file system configurations

Influence:
1. Verify file sorting works correctly in home directory
2. Test with bind-mounted paths and special file system setups
3. Check that home directory files are properly identified and sorted
4. Validate that non-home directory sorting remains unaffected

fix: 修复文件排序中的主目录路径比较问题

原始代码直接比较文件路径来判断文件是否在主目录中，这在处理绑定挂载路径或
特殊文件系统配置时可能会失败。此修复使用FileUtils::bindPathTransform在比 较前规范化路径，确保准确识别主目录文件。

更改包括：
1. 在handleAddChildren中使用bindPathTransform规范化父URL路径
2. 在data方法中的主目录检查应用相同的路径转换
3. 确保在不同文件系统配置下路径比较的一致性

Influence:
1. 验证主目录中的文件排序是否正确工作
2. 测试绑定挂载路径和特殊文件系统设置
3. 检查主目录文件是否被正确识别和排序
4. 验证非主目录排序是否保持不受影响

## Summary by Sourcery

Normalize file paths before home-directory comparison in file sorting logic to ensure correct behavior across bind mounts and special filesystems.

Bug Fixes:
- Fix home-directory detection in file sorting by applying bindPathTransform before comparing paths.
- Ensure the home-directory check in the data method uses normalized paths for consistent sorting behavior.

Enhancements:
- Simplify model change handling switch by removing superfluous case separators.