### PR TITLE
feat: add syntax highlighting support for text preview

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -49,7 +49,8 @@ Build-Depends:
  liblcms2-dev,
  libdeepin-service-framework-dev,
  libheif-dev,
- libappimage-dev
+ libappimage-dev,
+ libkf6syntaxhighlighting-dev
 Standards-Version: 4.5.0
 Homepage: http://www.deepin.org
 

--- a/debian/control.in
+++ b/debian/control.in
@@ -49,7 +49,8 @@ Build-Depends:
  liblcms2-dev,
  libdeepin-service-framework-dev,
  libheif-dev,
- libappimage-dev
+ libappimage-dev,
+ libkf6syntaxhighlighting-dev
 Standards-Version: 4.5.0
 Homepage: http://www.deepin.org
 

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/CMakeLists.txt
@@ -13,6 +13,7 @@ FILE(GLOB_RECURSE TEXTPREVIEW_FILES CONFIGURE_DEPENDS
 set(BIN_NAME ${PROJECT_NAME})
 
 find_package(Qt6 COMPONENTS Core REQUIRED)
+find_package(KF6SyntaxHighlighting REQUIRED)
 
 add_library(${BIN_NAME}
     SHARED
@@ -24,6 +25,7 @@ set_target_properties(${BIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${DFM_BUIL
 target_link_libraries(${BIN_NAME}
     DFM6::base
     DFM6::framework
+    KF6::SyntaxHighlighting
 )
 
 #install library file

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textbrowseredit.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textbrowseredit.cpp
@@ -4,11 +4,15 @@
 
 #include "textbrowseredit.h"
 
+#include <DGuiApplicationHelper>
+#include <KSyntaxHighlighting/Theme>
+
 #include <QScrollBar>
 #include <QDebug>
 
 #include <algorithm>
 
+DGUI_USE_NAMESPACE
 using namespace plugin_filepreview;
 constexpr int kReadTextSize { 1024 * 1024 * 5 };
 TextBrowserEdit::TextBrowserEdit(QWidget *parent)
@@ -20,23 +24,42 @@ TextBrowserEdit::TextBrowserEdit(QWidget *parent)
     setFixedSize(800, 500);
     setFrameStyle(QFrame::NoFrame);
 
+    // Set fixed-pitch (monospace) font, reference: deepin-editor dtextedit.cpp:1909
+    QFont font = document()->defaultFont();
+    font.setFamily("Noto Mono");
+    font.setFixedPitch(true);
+    font.setPointSizeF(10);
+    setFont(font);
+
     connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &TextBrowserEdit::scrollbarValueChange);
     connect(verticalScrollBar(), &QScrollBar::sliderMoved, this, &TextBrowserEdit::sliderPositionValueChange);
+
+    // Connect to system theme change signal for dynamic theme switching
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, &TextBrowserEdit::onThemeTypeChanged);
 }
 
 TextBrowserEdit::~TextBrowserEdit()
 {
     filestr.clear();
+    // Explicitly delete highlighter to ensure clean destruction
+    if (m_highlighter) {
+        delete m_highlighter;
+        m_highlighter = nullptr;
+    }
 }
 
 void TextBrowserEdit::setFileData(std::string &data)
 {
+    // Clear old content first
     clear();
     filestr = data;
     std::string::iterator temp = filestr.begin();
     appendText(temp);
     this->moveCursor(QTextCursor::Start, QTextCursor::MoveAnchor);
     lastPosition = verticalScrollBar()->sliderPosition();
+
+    fmDebug() << "Text preview: file data loaded";
 }
 
 void TextBrowserEdit::wheelEvent(QWheelEvent *e)
@@ -126,4 +149,71 @@ void TextBrowserEdit::appendText(std::string::iterator &data)
         insertPlainText(textData);
         filestr.clear();
     }
+}
+
+void TextBrowserEdit::setSyntaxDefinition(const QString &filePath)
+{
+    // IMPORTANT: Delete old highlighter to ensure clean state
+    // This prevents crashes from pending highlight events on old content
+    if (m_highlighter) {
+        delete m_highlighter;
+        m_highlighter = nullptr;
+        fmDebug() << "Text preview: deleted old syntax highlighter";
+    }
+
+    // Detect syntax definition based on file name
+    auto definition = m_repository.definitionForFileName(filePath);
+
+    if (definition.isValid()) {
+        // Code file detected: create NEW highlighter for this file
+        m_highlighter = new KSyntaxHighlighting::SyntaxHighlighter(document());
+
+        // Set theme based on current system theme
+        bool isDarkTheme = DGuiApplicationHelper::instance()->themeType()
+                == DGuiApplicationHelper::DarkType;
+        auto theme = m_repository.defaultTheme(isDarkTheme
+                                                       ? KSyntaxHighlighting::Repository::DarkTheme
+                                                       : KSyntaxHighlighting::Repository::LightTheme);
+        m_highlighter->setTheme(theme);
+
+        // Set syntax definition
+        m_highlighter->setDefinition(definition);
+
+        fmInfo() << "Text preview: created new syntax highlighter for" << definition.name()
+                 << "with theme" << theme.name();
+    } else {
+        // Plain text file: no highlighter needed
+        fmDebug() << "Text preview: no syntax definition found for" << filePath
+                  << ", using plain text mode";
+    }
+}
+
+void TextBrowserEdit::onThemeTypeChanged()
+{
+    updateHighlighterTheme();
+}
+
+void TextBrowserEdit::updateHighlighterTheme()
+{
+    if (!m_highlighter) {
+        fmDebug() << "Text preview: no highlighter to update theme";
+        return;
+    }
+
+    // Determine current system theme type
+    bool isDarkTheme = DGuiApplicationHelper::instance()->themeType()
+            == DGuiApplicationHelper::DarkType;
+
+    // Get corresponding syntax highlighting theme
+    auto theme = m_repository.defaultTheme(isDarkTheme
+                                                   ? KSyntaxHighlighting::Repository::DarkTheme
+                                                   : KSyntaxHighlighting::Repository::LightTheme);
+
+    // Apply theme to highlighter
+    m_highlighter->setTheme(theme);
+
+    // Re-apply highlighting with new theme
+    m_highlighter->rehighlight();
+
+    fmInfo() << "Text preview: syntax highlighter theme updated to" << theme.name();
 }

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textbrowseredit.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textbrowseredit.h
@@ -7,6 +7,10 @@
 #include "preview_plugin_global.h"
 
 #include <QPlainTextEdit>
+#include <QPointer>
+
+#include <KSyntaxHighlighting/Repository>
+#include <KSyntaxHighlighting/SyntaxHighlighter>
 
 #include <vector>
 
@@ -21,6 +25,16 @@ public:
 
     void setFileData(std::string &data);
 
+    /**
+     * @brief Set syntax highlighting based on file path
+     * @param filePath File path used to detect syntax definition
+     *
+     * This method will automatically detect if the file is a code file
+     * and enable syntax highlighting if applicable. Falls back to plain
+     * text if no syntax definition is found.
+     */
+    void setSyntaxDefinition(const QString &filePath);
+
 protected:
     void wheelEvent(QWheelEvent *e) override;
 
@@ -29,14 +43,28 @@ private slots:
 
     void sliderPositionValueChange(int position);
 
+    void onThemeTypeChanged();
+
 private:
     int verifyEndOfStrIntegrity(const char *s, int l);
 
     void appendText(std::string::iterator &data);
 
+    /**
+     * @brief Update syntax highlighter theme based on current system theme
+     *
+     * This method is called when system theme changes (light/dark mode).
+     * It's also reused by setSyntaxDefinition() for initial theme setup.
+     */
+    void updateHighlighterTheme();
+
     std::string filestr;
 
     int lastPosition { 0 };
+
+    // Syntax highlighting support
+    KSyntaxHighlighting::Repository m_repository;
+    QPointer<KSyntaxHighlighting::SyntaxHighlighter> m_highlighter;
 };
 }
 #endif   // TEXTBROWSER_H

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
@@ -107,7 +107,9 @@ bool TextPreview::setFileUrl(const QUrl &url)
             fmWarning() << "Text preview: encoding conversion failed, using original data";
         }
     }
-    
+
+    // Set syntax highlighting before setting file data
+    textBrowser->textBrowserEdit()->setSyntaxDefinition(filePath);
     textBrowser->textBrowserEdit()->setFileData(strBuf);
     delete[] buf;
     buf = nullptr;


### PR DESCRIPTION
Added KSyntaxHighlighting integration to text preview plugin for better code file visualization. Key changes include:
1. Added libkf6syntaxhighlighting-dev build dependency
2. Implemented syntax highlighting with KDE syntax highlighting library
3. Added automatic theme switching between light/dark modes
4. Used monospace font (Noto Mono) for better code readability
5. Added proper highlighter lifecycle management with QPointer
6. Fixed highlighter-document binding issue after text clear()

Log: Added syntax highlighting support for code files in text preview

Influence:
1. Test previewing various code files (.cpp, .py, .js, etc.) to verify syntax highlighting
2. Verify theme switching between light and dark modes
3. Test files without syntax definitions fall back to plain text
4. Check monospace font rendering for different file types
5. Verify scroll behavior remains unchanged with highlighting
6. Test large file handling performance with highlighting enabled

feat: 为文本预览添加语法高亮支持

为文本预览插件添加 KSyntaxHighlighting 集成，提升代码文件可视化效果。主
要变更包括：
1. 添加 libkf6syntaxhighlighting-dev 构建依赖
2. 使用 KDE 语法高亮库实现语法高亮功能
3. 添加浅色/深色主题自动切换支持
4. 使用等宽字体（Noto Mono）提升代码可读性
5. 使用 QPointer 实现高亮器生命周期管理
6. 修复文本清除后高亮器与文档绑定问题

Log: 在文本预览中为代码文件添加语法高亮支持

Influence:
1. 测试预览各种代码文件（.cpp、.py、.js 等）验证语法高亮效果
2. 验证浅色和深色主题切换功能
3. 测试无语法定义的文件回退到纯文本模式
4. 检查不同文件类型的等宽字体渲染效果
5. 验证启用高亮后滚动行为保持不变
6. 测试大文件处理性能是否受高亮影响

## Summary by Sourcery

Integrate syntax highlighting into the text preview plugin and align its appearance with system theme and code-oriented styling.

New Features:
- Add syntax highlighting for code files in the text preview using KSyntaxHighlighting with automatic fallback to plain text when no definition is available.
- Enable dynamic switching of the syntax highlighting theme based on the system light/dark theme.
- Apply a monospace font to the text preview for improved code readability.

Enhancements:
- Improve lifecycle management of the syntax highlighter instance to avoid stale bindings and ensure clean destruction.

Build:
- Add KF6SyntaxHighlighting as a required dependency and link it into the text preview plugin.