### PR TITLE
fix: set device pixel ratio for image preview

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -74,6 +74,7 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     QSize showSize = QSize(qMin(static_cast<int>(dsize.width() * 0.7), sourceImageSize.width()),
                            qMin(static_cast<int>(dsize.height() * 0.7), sourceImageSize.height()));
     QPixmap pixmap = QPixmap::fromImage(image).scaled(showSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
     setPixmap(pixmap);
 }
 


### PR DESCRIPTION
Set device pixel ratio for the scaled pixmap to ensure proper display
on high DPI screens. Without this setting, images might appear blurry
or incorrectly scaled on high resolution displays.

Log: Fixed image preview display issue on high DPI screens

Influence:
1. Test image preview on high DPI displays
2. Verify image sharpness and scaling on different screen resolutions
3. Check image preview in file manager with various image formats
4. Test with multiple display scaling factors

fix: 为图片预览设置设备像素比例

为缩放后的像素图设置设备像素比例，确保在高 DPI 屏幕上正确显示。
没有此设置时，图像在高分辨率显示器上可能出现模糊或缩放不正确的问题。

Log: 修复高 DPI 屏幕下图片预览显示问题

Influence:
1. 在高 DPI 显示器上测试图片预览功能
2. 验证不同屏幕分辨率下的图像清晰度和缩放效果
3. 使用各种图片格式测试文件管理器中的图片预览
4. 测试多种显示缩放比例下的显示效果

BUG: https://pms.uniontech.com/bug-view-342611.html

## Summary by Sourcery

Bug Fixes:
- Ensure scaled image previews use the application device pixel ratio to avoid blurriness and incorrect scaling on high resolution displays.