### PR TITLE
refactor: replace DCommandLinkButton with DToolButton for custom tab add directory

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
@@ -10,6 +10,7 @@
 #include <DLabel>
 #include <DToolButton>
 #include <DSettingsOption>
+#include <DStyle>
 
 #include <QPushButton>
 #include <QGridLayout>
@@ -40,7 +41,7 @@ void CustomTabSettingWidget::setOption(QObject *opt)
     }
 
     using namespace std::placeholders;
-    connect(addItemBtn, &DCommandLinkButton::clicked, this, std::bind(&CustomTabSettingWidget::handleAddCustomItem, this, option));
+    connect(addItemBtn, &DToolButton::clicked, this, std::bind(&CustomTabSettingWidget::handleAddCustomItem, this, option));
     connect(option, &DSettingsOption::valueChanged, this, &CustomTabSettingWidget::handleOptionChanged);
 }
 
@@ -50,7 +51,10 @@ void CustomTabSettingWidget::initUI()
     mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setVerticalSpacing(10);
 
-    addItemBtn = new DCommandLinkButton(tr("Add Directory"), this);
+    addItemBtn = new DToolButton(this);
+    addItemBtn->setToolTip(tr("Add Directory"));
+    addItemBtn->setIconSize({ 16, 16 });
+    addItemBtn->setIcon(DStyle::standardIcon(style(), DStyle::SP_IncreaseElement));
     addItemBtn->setEnabled(true);
 
     mainLayout->addWidget(new QLabel(tr("Custom Directory"), this), 0, 0);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.h
@@ -7,7 +7,7 @@
 
 #include "dfmplugin_titlebar_global.h"
 
-#include <DCommandLinkButton>
+#include <DToolButton>
 
 #include <QWidget>
 
@@ -40,7 +40,7 @@ private:
     bool removeRow(QWidget *w);
 
 private:
-    DTK_WIDGET_NAMESPACE::DCommandLinkButton *addItemBtn { nullptr };
+    DTK_WIDGET_NAMESPACE::DToolButton *addItemBtn { nullptr };
     QGridLayout *mainLayout { nullptr };
 };
 }


### PR DESCRIPTION
Changed the "Add Directory" button from DCommandLinkButton to
DToolButton with icon
Added tooltip and standard increase icon for better visual consistency
Updated signal connection from DCommandLinkButton::clicked to
DToolButton::clicked
Modified header file to include DToolButton instead of
DCommandLinkButton

Log: Changed "Add Directory" button style from text link to icon button

Influence:
1. Verify the "Add Directory" button now displays an icon instead of
text link
2. Test button functionality remains the same - still opens directory
selection
3. Check tooltip appears when hovering over the button
4. Verify button is properly enabled/disabled as before
5. Test the button click still triggers the add custom item
functionality
6. Ensure visual consistency with other icon buttons in the interface

refactor: 将自定义标签页添加目录按钮从 DCommandLinkButton 替换为
DToolButton

将"添加目录"按钮从文本链接样式改为带图标的工具按钮
添加工具提示和标准增加图标以提高视觉一致性
更新信号连接从 DCommandLinkButton::clicked 到 DToolButton::clicked
修改头文件引入 DToolButton 替代 DCommandLinkButton

Log: 将"添加目录"按钮样式从文本链接改为图标按钮

Influence:
1. 验证"添加目录"按钮现在显示图标而非文本链接
2. 测试按钮功能保持不变 - 仍能打开目录选择
3. 检查鼠标悬停时工具提示是否正常显示
4. 验证按钮的启用/禁用状态与之前一致
5. 测试按钮点击仍能触发添加自定义项功能
6. 确保与界面中其他图标按钮的视觉一致性

BUG: https://pms.uniontech.com/bug-view-343327.html

## Summary by Sourcery

Refine the custom tab "Add Directory" control to use a consistent icon-based tool button with tooltip while preserving existing behavior.

New Features:
- Add a tooltip to the custom tab "Add Directory" control for clearer affordance.
- Display a standard increase icon on the "Add Directory" control to align with other icon buttons.

Enhancements:
- Replace the text-style DCommandLinkButton with a DToolButton for the custom tab "Add Directory" control to match the interface style.