### PR TITLE
fix: resolve MTP file opening blocking main thread

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -343,10 +343,7 @@ bool ThumbnailHelper::checkThumbEnable(const QUrl &url)
     }
 
     bool enable { true };
-    if (ProtocolUtils::isMTPFile(fileUrl)) {   // Check if it's MTP file
-        enable = DConfigManager::instance()->value("org.deepin.dde.file-manager.preview", "mtpThumbnailEnable", true).toBool();
-        qCDebug(logDFMBase) << "thumbnail: MTP file thumbnail enable status:" << enable << "for:" << fileUrl;
-    } else if (DevProxyMng->isFileOfProtocolMounts(fileUrl.path())) {   // Check if it's protocol device
+    if (DevProxyMng->isFileOfProtocolMounts(fileUrl.path())) {   // Check if it's protocol device
         enable = Application::instance()->genericAttribute(Application::kShowThunmbnailInRemote).toBool();
         qCDebug(logDFMBase) << "thumbnail: remote file thumbnail enable status:" << enable << "for:" << fileUrl;
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -102,7 +102,7 @@ void FileOperatorHelper::openFilesByMode(const FileView *view, const QList<QUrl>
                          .toBool();
     QList<QUrl> dirListOpenInNewWindow {};
     for (const QUrl &url : urls) {
-        const FileInfoPointer &fileInfoPtr = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+        const FileInfoPointer &fileInfoPtr = InfoFactory::create<FileInfo>(url);
         if (fileInfoPtr) {
             if (!fileInfoPtr->exists()) {
                 // show alert
@@ -339,7 +339,7 @@ void FileOperatorHelper::pasteClipboardImage(const FileView *view)
     AbstractJobHandler::OperatorCallback callback = [](const AbstractJobHandler::CallbackArgus args) {
         if (args->value(AbstractJobHandler::CallbackKey::kSuccessed).toBool() != false) {
             auto targets = args->value(AbstractJobHandler::CallbackKey::kTargets)
-                              .value<QList<QUrl>>();
+                                   .value<QList<QUrl>>();
             if (!targets.isEmpty()) {
                 fmDebug() << "Requesting selection for created image file:" << targets;
                 WorkspaceHelper::instance()->laterRequestSelectFiles(targets);
@@ -351,13 +351,13 @@ void FileOperatorHelper::pasteClipboardImage(const FileView *view)
 
     // Publish kTouchFile event
     dpfSignalDispatcher->publish(
-        GlobalEventType::kTouchFile,
-        windowId,
-        view->rootUrl(),
-        CreateFileType::kCreateFileTypeDefault,
-        QString("png"),
-        QVariant::fromValue(clipboardData),
-        callback);
+            GlobalEventType::kTouchFile,
+            windowId,
+            view->rootUrl(),
+            CreateFileType::kCreateFileTypeDefault,
+            QString("png"),
+            QVariant::fromValue(clipboardData),
+            callback);
 }
 
 void FileOperatorHelper::undoFiles(const FileView *view)


### PR DESCRIPTION
Changed file info creation from synchronous to asynchronous mode when opening files in MTP directories
Removed explicit kCreateFileInfoSync parameter to use default asynchronous creation
This prevents UI freezing when opening directories with large numbers of files in MTP protocol

Influence:
1. Test opening MTP directories with many files to verify no main thread blocking
2. Verify file operations still work correctly in various protocols
3. Check that file information is properly loaded asynchronously
4. Test performance with different directory sizes and file types

fix: 修复MTP协议下打开大量文件时阻塞主线程的问题

将MTP目录中打开文件时的文件信息创建从同步模式改为异步模式
移除显式的kCreateFileInfoSync参数，使用默认的异步创建方式
这解决了在MTP协议下打开包含大量文件的目录时导致的UI冻结问题

Influence:
1. 测试打开包含大量文件的MTP目录，验证主线程不再被阻塞
2. 验证在各种协议下文件操作仍能正常工作
3. 检查文件信息是否正确异步加载
4. 测试不同目录大小和文件类型下的性能表现

Bug: https://pms.uniontech.com/bug-view-344161.html

## Summary by Sourcery

Avoid blocking the main thread when opening files, particularly in MTP directories, and simplify thumbnail enablement handling for remote/protocol files.

Bug Fixes:
- Prevent UI freezes caused by synchronous file info creation when opening files in MTP directories.

Enhancements:
- Rely on default asynchronous file info creation when opening files instead of forcing synchronous mode.
- Unify thumbnail enablement logic for protocol-based files by handling MTP paths through the generic remote/protocol configuration.