### PR TITLE
fix: refine signal emission logic for block device filesystem changes

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -939,6 +939,10 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
             }
             onUpdateBlockItem(id);
         }
+
+        if (propertyName == DeviceProperty::kFileSystem && !var.variant().toString().isEmpty()) {   // idType changed
+            addDevice(diskGroup(), url);
+        }
     }
 }
 


### PR DESCRIPTION
- Emit blockDevMounted signal when filesystem is added with existing mount point
- Trigger auto-mount when filesystem is added without mount point
- Emit blockDevUnmounted signal before removing filesystem interface
- Add device to disk group when filesystem property becomes available
- Remove unnecessary 'using namespace' statements
- Fix potential dangling reference by using value copy for oldData

Log: Improved block device signal handling and computer item watcher logic

## Summary by Sourcery

Refine block device filesystem change handling and update computer item watcher to correctly reflect new filesystem availability.

New Features:
- Automatically trigger block device auto-mount when a filesystem interface is added without an existing mount point.
- Add devices to the disk group when their filesystem property becomes available via D-Bus.

Bug Fixes:
- Emit blockDevMounted when a filesystem interface is added with an existing mount point so mount state stays in sync.
- Emit blockDevUnmounted before removing the filesystem interface using the previously stored mount point to keep unmount events accurate.
- Avoid a potential dangling reference when reading previous block device data by copying the old data value instead of referencing a temporary.

Enhancements:
- Simplify device watcher logic by removing unnecessary namespace usage around device property change emissions.