### PR TITLE
feat: add model busy state detection for UI operations

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
@@ -173,3 +173,13 @@ void TitleBarEventCaller::sendSetGroupStrategy(QWidget *sender, const QString &s
     Q_ASSERT(id > 0);
     dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetGroup", id, strategy);
 }
+
+bool TitleBarEventCaller::sendGetCurrentModelBusy(QWidget *sender)
+{
+    quint64 id = TitleBarHelper::windowId(sender);
+    if (id < 1) {
+        fmWarning() << "Cannot get model busy state: invalid window id" << id;
+        return false;
+    }
+    return dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_GetCurrentBusy", id).toBool();
+}

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
@@ -39,6 +39,7 @@ public:
     static void sendSetSort(QWidget *sender, DFMGLOBAL_NAMESPACE::ItemRoles role);
     static QString sendCurrentGroupRoleStrategy(QWidget *sender);
     static void sendSetGroupStrategy(QWidget *sender, const QString &strategy);
+    static bool sendGetCurrentModelBusy(QWidget *sender);
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
@@ -254,11 +254,29 @@ void SortByButton::mousePressEvent(QMouseEvent *event)
         d->iconClicked = event->position().x() <= leftWidth;   // Check if icon area is clicked
 
         if (event->position().x() > leftWidth && d->menu) {
+            // Query current tab's busy state before showing menu
+            bool isBusy = TitleBarEventCaller::sendGetCurrentModelBusy(this);
+
             d->setupMenu();
             d->setItemSortRoles();
             d->setItemGroupRoles();
+
+            // Disable all actions if model is busy
+            if (isBusy) {
+                for (QAction *action : d->menu->actions()) {
+                    action->setEnabled(false);
+                }
+                fmDebug() << "SortByButton: Menu actions disabled - current tab model is busy";
+            }
+
             d->menu->exec(mapToGlobal(rect().bottomLeft()));
         } else if (d->iconClicked) {
+            // Check busy state before sorting
+            bool isBusy = TitleBarEventCaller::sendGetCurrentModelBusy(this);
+            if (isBusy) {
+                fmDebug() << "SortByButton: Sort operation blocked - current tab model is busy";
+                return;
+            }
             d->sort();
         }
         update();   // Trigger repaint

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -86,6 +86,8 @@ public slots:
     void handleRegisterLoadStrategy(const QString &scheme, DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy strategy);
     void handleRegisterFocusFileViewDisabled(const QString &scheme);
 
+    bool handleGetCurrentModelBusy(quint64 windowId);
+
 private:
     explicit WorkspaceEventReceiver(QObject *parent = nullptr);
 };

--- a/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
@@ -476,4 +476,11 @@ void SortAndDisplayMenuScenePrivate::updateEmptyAreaActionState()
         fmDebug() << "Unknown view mode:" << static_cast<int>(mode);
         break;
     }
+
+    // 在视图忙碌状态（迭代和排序时）不能进行排序、分组
+    const bool busy = view->model()->currentState() == ModelState::kBusy;
+    for (const char *id : { ActionID::kSortBy, ActionID::kGroupBy }) {
+        if (auto it = predicateAction.find(id); it != predicateAction.end())
+            it.value()->setEnabled(!busy);
+    }
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.h
@@ -74,6 +74,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_Model_SetGroup)
     DPF_EVENT_REG_SLOT(slot_Model_RegisterDataCache)
     DPF_EVENT_REG_SLOT(slot_Model_RegisterLoadStrategy)
+    DPF_EVENT_REG_SLOT(slot_Model_GetCurrentBusy)
 
     // hook events
     DPF_EVENT_REG_HOOK(hook_SendOpenWindow)


### PR DESCRIPTION
Added model busy state detection to prevent UI operations during file operations. The changes include:
1. Added new event slot to query current model's busy state
2. Modified SortByButton to check busy state before showing menu or performing sort
3. Updated context menu to disable sort/group actions when model is busy
4. Implemented busy state detection in workspace event receiver

Log: Added busy state detection to prevent UI operations during file operations

Influence:
1. Test that sort button menu actions are disabled when file operations are in progress
2. Verify that clicking sort icon is blocked during busy state
3. Check that context menu sort/group actions are disabled during file operations
4. Test that normal functionality returns after file operations complete
5. Verify busy state detection works across different file operations (copy, move, delete, etc.)

feat: 添加模型忙碌状态检测以控制UI操作

添加了模型忙碌状态检测功能，防止在文件操作期间进行UI操作。主要变更包括：
1. 新增查询当前模型忙碌状态的事件槽
2. 修改排序按钮，在显示菜单或执行排序前检查忙碌状态
3. 更新上下文菜单，在模型忙碌时禁用排序/分组操作
4. 在工作空间事件接收器中实现忙碌状态检测

Log: 添加忙碌状态检测，防止在文件操作期间进行UI操作

Influence:
1. 测试在文件操作进行时排序按钮菜单操作是否被禁用
2. 验证在忙碌状态下点击排序图标是否被阻止
3. 检查在文件操作期间上下文菜单的排序/分组操作是否被禁用
4. 测试文件操作完成后正常功能是否恢复
5. 验证忙碌状态检测在不同文件操作（复制、移动、删除等）中正常工作

## Summary by Sourcery

Add busy-state awareness to the file manager UI to block or disable sorting actions while the underlying file model is performing operations.

New Features:
- Expose a new workspace event slot to query the current file model busy state from other components.
- Provide a title bar API for querying the active window's model busy state from UI widgets.

Enhancements:
- Update the sort button to check the model busy state before opening its menu or performing sort operations, disabling menu actions when busy.
- Disable sort and group actions in the workspace context menu when the current view's model is busy.