### PR TITLE
fix: fix fast directory scan condition check

### DIFF
--- a/src/services/textindex/fsmonitor/fsmonitorworker.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitorworker.cpp
@@ -104,7 +104,7 @@ void FSMonitorWorker::tryFastDirectoryScan()
         }
 
         const QString currentStatus = status.value();
-        if (currentStatus != "monitoring") {
+        if (currentStatus != "closed") {
             fmWarning() << "FSMonitorWorker: Cannot use fast directory scan, index status is:" << currentStatus;
             return {};
         }


### PR DESCRIPTION
Changed the condition check for fast directory scan from "monitoring" to "closed" status
The previous condition was incorrect as it was checking for "monitoring" status when it should have been checking for "closed" status This ensures that fast directory scan is only attempted when the file system monitor is in the appropriate state
Fixes a logic error that could cause improper behavior when using fast directory scanning

Influence:
1. Test fast directory scanning functionality when file system monitor is closed
2. Verify that fast scan is not attempted when monitor is in monitoring state
3. Check error logging when fast scan is attempted in incorrect states
4. Validate overall file system monitoring behavior after this fix

fix: 修复快速目录扫描条件检查

将快速目录扫描的条件检查从"monitoring"状态改为"closed"状态
之前的条件检查不正确，应该检查"closed"状态而不是"monitoring"状态
这确保只有在文件系统监视器处于适当状态时才尝试快速目录扫描
修复了可能导致快速目录扫描功能异常的逻辑错误

Influence:
1. 测试当文件系统监视器关闭时的快速目录扫描功能
2. 验证当监视器处于监控状态时不会尝试快速扫描
3. 检查在错误状态下尝试快速扫描时的错误日志记录
4. 验证修复后的整体文件系统监控行为

## Summary by Sourcery

Bug Fixes:
- Fix an incorrect status check that previously allowed fast directory scanning when the index was in the monitoring state instead of the required closed state.