### PR TITLE
fix: resolve autostart setting failure and job file persistence issues

### DIFF
--- a/src/services/diskencrypt/helpers/commonhelper.cpp
+++ b/src/services/diskencrypt/helpers/commonhelper.cpp
@@ -13,14 +13,15 @@
 #include <QDir>
 
 #include <DConfig>
+#include <unistd.h>
 
 FILE_ENCRYPT_USE_NS
 
 void common_helper::createDFMDesktopEntry()
 {
     qInfo() << "[common_helper::createDFMDesktopEntry] Creating DFM desktop entry for reencryption";
-    
-    const QString &kLocalShareApps  = "/usr/local/share/applications";
+
+    const QString &kLocalShareApps = "/usr/local/share/applications";
     QDir d(kLocalShareApps);
     if (!d.exists()) {
         auto ok = d.mkpath(kLocalShareApps);
@@ -37,7 +38,7 @@ void common_helper::createDFMDesktopEntry()
         "[Desktop Entry]\n"
         "Categories=System;\n"
         "Comment=To auto launch reencryption\n"
-        "Exec=/usr/bin/dde-file-manager -d\n"
+        "Exec=/usr/libexec/dde-file-manager -d\n"
         "GenericName=Disk Reencrypt\n"
         "Icon=dde-file-manager\n"
         "Name=Disk Reencrypt\n"
@@ -54,15 +55,18 @@ void common_helper::createDFMDesktopEntry()
         return;
     }
     f.write(desktop);
+    f.flush();
+    auto ret = ::fsync(f.handle());
     f.close();
 
-    qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file created successfully:" << disk_encrypt::kReencryptDesktopFile;
+    qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file created successfully:" << disk_encrypt::kReencryptDesktopFile
+            << "Sync status: " << ret;
 }
 
 QString common_helper::encryptCipher()
 {
     qInfo() << "[common_helper::encryptCipher] Getting encryption cipher configuration";
-    
+
     auto cfg = Dtk::Core::DConfig::create("org.deepin.dde.file-manager",
                                           "org.deepin.dde.file-manager.diskencrypt");
     cfg->deleteLater();
@@ -73,7 +77,7 @@ QString common_helper::encryptCipher()
         qWarning() << "[common_helper::encryptCipher] Unsupported cipher algorithm, using default:" << cipher << "-> aes";
         return "aes";
     }
-    
+
     qInfo() << "[common_helper::encryptCipher] Using encryption cipher:" << cipher;
     return cipher;
 }
@@ -81,7 +85,7 @@ QString common_helper::encryptCipher()
 void common_helper::createRebootFlagFile(const QString &dev)
 {
     qInfo() << "[common_helper::createRebootFlagFile] Creating reboot flag file for device:" << dev;
-    
+
     QString fileName = disk_encrypt::kRebootFlagFilePrefix + dev.mid(5);
     QFile f(fileName);
     if (!f.open(QIODevice::Truncate | QIODevice::WriteOnly)) {
@@ -95,7 +99,7 @@ void common_helper::createRebootFlagFile(const QString &dev)
 QString common_helper::genRecoveryKey()
 {
     qInfo() << "[common_helper::genRecoveryKey] Generating recovery key";
-    
+
     QString recKey;
     QLibrary lib("usec-recoverykey");
     dfmbase::FinallyUtil finalClear([&] { if (lib.isLoaded()) lib.unload(); });
@@ -134,7 +138,7 @@ QString common_helper::genRecoveryKey()
 QString common_helper::genRandomString(int len)
 {
     qDebug() << "[common_helper::genRandomString] Generating random string with length:" << len;
-    
+
     // 定义字符集
     const QString charset = QString("0123456789"
                                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
- Call ApplicationManager1.ReloadApplications before setting AutoStart property to ensure newly created desktop file is recognized
- Refactor setAutoStartDFM with reusable constants for AM1 service/path/interface
- Add syncToDisk helper using fsync to ensure job files are persisted to disk before system reboot
- Replace flush with fsync for encrypt/decrypt job file creation

Log: Fix autostart may not work for dynamically created desktop files; ensure job files are synced to disk to prevent data loss during initramfs update
Bug: https://pms.uniontech.com/bug-view-343187.html

## Summary by Sourcery

Ensure disk encryption autostart configuration is reliably applied and job files are durably persisted to disk.

Bug Fixes:
- Refresh ApplicationManager1 applications before toggling the file manager autostart setting so dynamically created desktop files are recognized.
- Guarantee encrypt/decrypt job files are fully synced to disk to avoid data loss during system or initramfs updates.

Enhancements:
- Refactor ApplicationManager1 D-Bus usage in the autostart handler to use shared constants and reuse the session bus connection.