### PR TITLE
feat: change default disk encryption algorithm to AES

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.diskencrypt.json
+++ b/assets/configs/org.deepin.dde.file-manager.diskencrypt.json
@@ -14,7 +14,7 @@
             "visibility":"public"
         },
         "encryptAlgorithm" : {
-            "value": "sm4",
+            "value": "aes",
             "serial":0,
             "flags":["global"],
             "name":"Encrypt algorithm",

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -49,11 +49,11 @@ QString config_utils::cipherType()
     auto cfg = Dtk::Core::DConfig::create("org.deepin.dde.file-manager",
                                           "org.deepin.dde.file-manager.diskencrypt");
     cfg->deleteLater();
-    auto cipher = cfg->value("encryptAlgorithm", "sm4").toString();
+    auto cipher = cfg->value("encryptAlgorithm", "aes").toString();
     QStringList supportedCipher { "sm4", "aes" };
     if (!supportedCipher.contains(cipher)) {
-        fmWarning() << "Unsupported cipher type:" << cipher << ", falling back to sm4";
-        return "sm4";
+        fmWarning() << "Unsupported cipher type:" << cipher << ", falling back to aes";
+        return "aes";
     }
     return cipher;
 }

--- a/src/services/diskencrypt/helpers/commonhelper.cpp
+++ b/src/services/diskencrypt/helpers/commonhelper.cpp
@@ -66,12 +66,12 @@ QString common_helper::encryptCipher()
     auto cfg = Dtk::Core::DConfig::create("org.deepin.dde.file-manager",
                                           "org.deepin.dde.file-manager.diskencrypt");
     cfg->deleteLater();
-    auto cipher = cfg->value("encryptAlgorithm", "sm4").toString();
-    
+    auto cipher = cfg->value("encryptAlgorithm", "aes").toString();
+
     QStringList supportedCipher { "sm4", "aes" };
     if (!supportedCipher.contains(cipher)) {
-        qWarning() << "[common_helper::encryptCipher] Unsupported cipher algorithm, using default:" << cipher << "-> sm4";
-        return "sm4";
+        qWarning() << "[common_helper::encryptCipher] Unsupported cipher algorithm, using default:" << cipher << "-> aes";
+        return "aes";
     }
     
     qInfo() << "[common_helper::encryptCipher] Using encryption cipher:" << cipher;


### PR DESCRIPTION
- Update default encryption algorithm from sm4 to aes in config file
- Modify fallback cipher from sm4 to aes in encryptutils.cpp
- Modify fallback cipher from sm4 to aes in commonhelper.cpp

Log: Change default disk encryption algorithm from SM4 to AES

Task: https://github.com/linuxdeepin/dde-file-manager/pull/3442

## Summary by Sourcery

Set AES as the default disk encryption algorithm across file manager disk encryption components.

New Features:
- Default disk encryption algorithm now uses AES when no explicit algorithm is configured.

Enhancements:
- Validate configured disk encryption cipher against supported algorithms and fall back to AES when an unsupported value is encountered.
- Align disk encryption helper utilities and configuration to use consistent AES defaults and logging messages.