### PR TITLE
feat: implement tab drag and drop between windows

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
@@ -56,6 +56,8 @@ protected:
     QMimeData *createMimeDataFromTab(int index, const QStyleOptionTab &option) const override;
     QPixmap createDragPixmapFromTab(int index, const QStyleOptionTab &option, QPoint *hotspot) const override;
     bool canInsertFromMimeData(int index, const QMimeData *source) const override;
+    void insertFromMimeData(int index, const QMimeData *source) override;
+    void insertFromMimeDataOnDragEnter(int index, const QMimeData *source) override;
 
     bool eventFilter(QObject *obj, QEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
@@ -63,7 +65,6 @@ protected:
 
 private:
     TabBarPrivate *const d;
-    static QPixmap *sm_pDragPixmap;
 };
 }
 


### PR DESCRIPTION
1. Added tab drag and drop functionality to move tabs between file
manager windows
2. Implemented MIME data serialization for tab metadata including URL,
alias, and user data
3. Enhanced tab release behavior to properly handle single tab scenarios
4. Added window hiding during drag operations in non-Wayland
environments
5. Improved tab insertion logic with proper index management and signal
handling
6. Fixed tab painting by separating close button rendering into
dedicated method

Log: Added tab drag and drop feature to move tabs between windows

Influence:
1. Test dragging tabs between different file manager windows
2. Verify tab metadata is preserved during drag and drop operations
3. Test single tab behavior when dragging to create new windows
4. Verify window hiding/showing during drag operations
5. Test tab close functionality after successful drag and drop
6. Validate tab indexing and ordering after insertions
7. Test right-click context menu on tabs during drag operations

feat: 实现窗口间标签页拖拽功能

1. 添加标签页拖拽功能，支持在文件管理器窗口间移动标签页
2. 实现标签页元数据的MIME数据序列化，包含URL、别名和用户数据
3. 增强标签页释放行为，正确处理单标签页场景
4. 在非Wayland环境下添加拖拽过程中的窗口隐藏功能
5. 改进标签页插入逻辑，包含正确的索引管理和信号处理
6. 通过分离关闭按钮渲染到专用方法修复标签页绘制问题

Log: 新增标签页拖拽功能，支持在窗口间移动标签页

Influence:
1. 测试在不同文件管理器窗口间拖拽标签页
2. 验证拖拽过程中标签页元数据是否保留
3. 测试拖拽创建新窗口时的单标签页行为
4. 验证拖拽过程中的窗口隐藏/显示功能
5. 测试成功拖拽后的标签页关闭功能
6. 验证插入后的标签页索引和排序
7. 测试拖拽过程中标签页的右键上下文菜单
