### PR TITLE
feat: implement pinned tabs functionality

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -199,17 +199,6 @@
             "description[zh_CN]": "日志规则",
             "permissions": "readwrite",
             "visibility": "public"
-        },
-        "dfm.custom.fixedtab": {
-            "value": [],
-            "serial": 0,
-            "flags": [],
-            "name": "Custom fixed tabs",
-            "name[zh_CN]": "自定义固定标签页",
-            "description": "It's used to configure custom fixed tabs in the file manager.",
-            "description[zh_CN]": "用于配置文件管理器中的自定义固定标签页。",
-            "permissions": "readwrite",
-            "visibility": "private"
         }
     }
 }

--- a/assets/configs/org.deepin.dde.file-manager.view.json
+++ b/assets/configs/org.deepin.dde.file-manager.view.json
@@ -67,6 +67,28 @@
             "description":"Control list height level",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "dfm.custom.fixedtab": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "Custom tabs",
+            "name[zh_CN]": "自定义标签页",
+            "description": "It's used to configure custom tabs in the file manager.",
+            "description[zh_CN]": "用于配置文件管理器中的自定义标签页。",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "dfm.pinned.tabs": {
+            "value": [],
+            "serial": 0,
+            "flags": [],
+            "name": "Pinned tabs",
+            "name[zh_CN]": "固定标签页",
+            "description": "It's used to configure pinned tabs in the file manager.",
+            "description[zh_CN]": "用于配置文件管理器中的固定标签页。",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/autotests/plugins/dfmplugin-titlebar/test_titlebarwidget.cpp
+++ b/autotests/plugins/dfmplugin-titlebar/test_titlebarwidget.cpp
@@ -147,7 +147,7 @@ TEST_F(TitleBarWidgetTest, OpenNewTab_EmptyUrl_CreatesTabWithHomeUrl)
     bool createTabCalled = false;
     bool sendCdCalled = false;
 
-    stub.set_lamda(&TabBar::createTab, [&createTabCalled](TabBar *) {
+    stub.set_lamda(&TabBar::appendTab, [&createTabCalled](TabBar *) {
         __DBG_STUB_INVOKE__
         createTabCalled = true;
         return 0;
@@ -177,7 +177,7 @@ TEST_F(TitleBarWidgetTest, OpenNewTab_ValidUrl_CreatesTabAndNavigates)
     bool createTabCalled = false;
     bool sendCdCalled = false;
 
-    stub.set_lamda(&TabBar::createTab, [&createTabCalled](TabBar *) {
+    stub.set_lamda(&TabBar::appendTab, [&createTabCalled](TabBar *) {
         __DBG_STUB_INVOKE__
         createTabCalled = true;
         return 0;
@@ -217,7 +217,7 @@ TEST_F(TitleBarWidgetTest, OpenCustomFixedTabs_ValidUrls_CreatesInactiveTabs)
         return QVariant();
     });
 
-    stub.set_lamda(&TabBar::createInactiveTab, [&createCount] {
+    stub.set_lamda(&TabBar::appendInactiveTab, [&createCount] {
         __DBG_STUB_INVOKE__
         return createCount++;
     });
@@ -241,7 +241,7 @@ TEST_F(TitleBarWidgetTest, OpenCustomFixedTabs_EmptyList_NoTabsCreated)
         return QVariant(QStringList());
     });
 
-    stub.set_lamda(&TabBar::createInactiveTab, [&createCalled] {
+    stub.set_lamda(&TabBar::appendInactiveTab, [&createCalled] {
         __DBG_STUB_INVOKE__
         createCalled = true;
         return 0;
@@ -495,7 +495,7 @@ TEST_F(TitleBarWidgetTest, HandleHotketCreateNewTab_NoSelection_CreatesTabWithCu
 
     bool createTabCalled = false;
 
-    stub.set_lamda(&TabBar::createTab, [&createTabCalled](TabBar *) {
+    stub.set_lamda(&TabBar::appendTab, [&createTabCalled](TabBar *) {
         __DBG_STUB_INVOKE__
         createTabCalled = true;
         return 0;
@@ -541,7 +541,7 @@ TEST_F(TitleBarWidgetTest, HandleCreateTabList_ValidUrls_CreatesTabsForDirectori
         return true;
     });
 
-    stub.set_lamda(&TabBar::createTab, [&createTabCount](TabBar *) {
+    stub.set_lamda(&TabBar::appendTab, [&createTabCount](TabBar *) {
         __DBG_STUB_INVOKE__
         createTabCount++;
         return createTabCount;
@@ -573,7 +573,7 @@ TEST_F(TitleBarWidgetTest, HandleCreateTabList_EmptyList_NoTabsCreated)
     QList<QUrl> emptyList;
     bool createTabCalled = false;
 
-    stub.set_lamda(&TabBar::createTab, [&createTabCalled](TabBar *) {
+    stub.set_lamda(&TabBar::appendTab, [&createTabCalled](TabBar *) {
         __DBG_STUB_INVOKE__
         createTabCalled = true;
         return 0;

--- a/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
+++ b/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
@@ -23,6 +23,7 @@ inline constexpr char kTreeViewEnable[] { "dfm.treeview.enable" };
 inline constexpr char kDisplayPreviewVisibleKey[] { "dfm.displaypreview.visible" };
 inline constexpr char kOpenFolderWindowsInASeparateProcess[] { "dfm.open.in.single.process" };
 inline constexpr char kCunstomFixedTabs[] { "dfm.custom.fixedtab" };
+inline constexpr char kPinnedTabs[] { "dfm.pinned.tabs" };
 }   // namespace BaseConfig
 
 /*!

--- a/src/plugins/filemanager/dfmplugin-titlebar/dfmplugin_titlebar_global.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dfmplugin_titlebar_global.h
@@ -37,6 +37,14 @@ inline constexpr int kFolderItemHeight { 26 };
 inline constexpr int kFolderIconSize { 16 };
 inline constexpr int kFolderMinWidth { 200 };
 
+namespace TabDef {
+inline constexpr char kTabScheme[] { "pinned-tab" };   // Pinned tab scheme
+inline constexpr char kPinnedId[] { "pinnedId" };
+inline constexpr char kTabUrl[] { "tabUrl" };
+inline constexpr char kTabAlias[] { "tabAlias" };
+inline constexpr char kProcessId[] { "processId" };
+}   // namespace TabDef
+
 namespace CustomKey {
 inline constexpr char kUrl[] { "CrumbData_Key_Url" };
 inline constexpr char kDisplayText[] { "CrumbData_Key_DisplayText" };

--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
@@ -41,6 +41,8 @@ void TitleBar::initialize()
 bool TitleBar::start()
 {
     DFMBASE_USE_NAMESPACE
+    // register pinned tab scheme
+    UrlRoute::regScheme(TabDef::kTabScheme, "/", {}, true);
     // file scheme for crumbar
     dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", QString(Global::Scheme::kFile), QVariantMap {});
 
@@ -99,8 +101,8 @@ void TitleBar::onWindowOpened(quint64 windId)
     connect(window, &FileManagerWindow::windowSplitterWidthChanged, titleBarWidget, &TitleBarWidget::handleSplitterAnimation);
 
     if (qAppName() == "dde-file-manager") {
-        connect(window, &FileManagerWindow::workspaceInstallFinished, titleBarWidget,
-                &TitleBarWidget::openCustomFixedTabs);
+        connect(window, &FileManagerWindow::workspaceInstallFinished, titleBarWidget, &TitleBarWidget::openCustomFixedTabs);
+        connect(window, &FileManagerWindow::workspaceInstallFinished, titleBarWidget, &TitleBarWidget::openPinnedTabs);
     }
 }
 
@@ -165,12 +167,12 @@ void TitleBar::registerTabSettingConfig()
     SettingBackend::instance()->addSettingAccessor(
             "00_base.01_new_windows.02_custom_tab",
             []() {
-                return DConfigManager::instance()->value(kDefaultCfgPath,
+                return DConfigManager::instance()->value(kViewDConfName,
                                                          kCunstomFixedTabs,
                                                          {});
             },
             [](const QVariant &val) {
-                DConfigManager::instance()->setValue(kDefaultCfgPath,
+                DConfigManager::instance()->setValue(kViewDConfName,
                                                      kCunstomFixedTabs,
                                                      val);
             });

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.h
@@ -21,9 +21,11 @@ public:
     explicit TabBar(QWidget *parent = nullptr);
     ~TabBar() override;
 
-    int createTab();
-    int createInactiveTab(const QUrl &url, const QVariantMap &userData = {});
+    int appendTab();
+    int appendInactiveTab(const QUrl &url, bool pinned = false);
+    int insertInactiveTab(int index, const QUrl &url, bool pinned = false);
     void removeTab(int index, int selectIndex = -1);
+    void forceRemoveTab(int index);
     void setCurrentUrl(const QUrl &url);
     void closeTab(const QUrl &url);
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -37,6 +37,8 @@ public:
     CrumbBar *titleCrumbBar() const;
     void openNewTab(const QUrl &url);
     void openCustomFixedTabs();
+    void openPinnedTabs();
+    void activatePinnedTab(const QString &pinnedId);
 
     void showSearchFilterButton(bool visible);
     void setViewModeState(int mode);
@@ -86,6 +88,7 @@ private slots:
 
 private:
     QUrl titlebarUrl;
+    QString pendingPinnedTabId;  // Store pinnedId from pinned:// URL
     DTitlebar *topBar { nullptr };
     TabBar *bottomBar { nullptr };
     QHBoxLayout *topBarCustomLayout { nullptr };


### PR DESCRIPTION
1. Split custom tabs configuration into separate pinned tabs and custom
tabs settings
2. Add pinned tabs support with persistent storage using DConfig
3. Implement tab pinning/unpinning with unique identifiers
4. Support dragging and reordering of pinned tabs across windows
5. Add pinned tab URL scheme for window management
6. Enhance tab bar with improved visual feedback and tooltips

Log: Added pinned tabs feature with drag-and-drop support

Influence:
1. Test pinning and unpinning tabs for various locations (home, trash,
recent)
2. Verify pinned tabs persist after application restart
3. Test dragging pinned tabs between different file manager windows
4. Check tab reordering functionality for pinned tabs
5. Verify proper handling of pinned tabs when closing windows
6. Test opening new windows with pinned tab URLs

feat: 实现固定标签页功能

1. 将自定义标签页配置拆分为独立的固定标签页和自定义标签页设置
2. 使用 DConfig 添加固定标签页支持并实现持久化存储
3. 实现带有唯一标识符的标签页固定/取消固定功能
4. 支持跨窗口拖拽和重新排序固定标签页
5. 添加固定标签页 URL 方案用于窗口管理
6. 增强标签栏的视觉反馈和工具提示功能

Log: 新增固定标签页功能，支持拖拽操作

Influence:
1. 测试为不同位置（首页、回收站、最近使用）固定和取消固定标签页
2. 验证固定标签页在应用重启后是否持久保存
3. 测试在不同文件管理器窗口间拖拽固定标签页
4. 检查固定标签页的重新排序功能
5. 验证关闭窗口时固定标签页的正确处理
6. 测试使用固定标签页 URL 打开新窗口
