### PR TITLE
fix: fix clipboard menu state update logic

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
@@ -128,7 +128,7 @@ void ClipBoardMenuScene::updateState(QMenu *parent)
             // 检查是否有传统的剪贴板action或者是否有图像数据
             const QMimeData *mimeData = QApplication::clipboard()->mimeData();
             bool hasValidClipboardData = (ClipBoard::instance()->clipboardAction() != ClipBoard::kUnknownAction)
-                                        || (mimeData && mimeData->hasImage());
+                    || (mimeData && mimeData->hasImage());
 
             bool disabled = !hasValidClipboardData
                     || !curDirInfo->isAttributes(OptInfoType::kIsWritable);
@@ -138,6 +138,12 @@ void ClipBoardMenuScene::updateState(QMenu *parent)
         if (auto copy = d->predicateAction.value(ActionID::kCopy)) {
             if (!d->focusFileInfo->isAttributes(OptInfoType::kIsReadable) && !d->focusFileInfo->isAttributes(OptInfoType::kIsSymLink))
                 copy->setDisabled(true);
+        }
+
+        if (auto cut = d->predicateAction.value(ActionID::kCut)) {
+            const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(d->currentDir);
+            if (!fileInfo || !fileInfo->isAttributes(OptInfoType::kIsWritable))
+                cut->setDisabled(true);
         }
     }
 


### PR DESCRIPTION
Fixed the clipboard menu state update logic to properly handle cut
action disabling when current directory is not writable. The code
formatting was also adjusted for better readability.

1. Fixed inconsistent indentation in clipboard data validation condition
2. Added proper validation for cut action disabling when current
directory lacks write permissions
3. Improved code structure by moving cut action validation to separate
block

Log: Fixed clipboard menu state not updating correctly when current
directory is read-only

Influence:
1. Test clipboard menu in writable directories - cut action should be
enabled
2. Test clipboard menu in read-only directories - cut action should
be disabled
3. Verify paste action state with various clipboard contents
4. Test menu behavior with different file selection states
5. Validate menu updates when directory permissions change

fix: 修复剪贴板菜单状态更新逻辑

修复了剪贴板菜单状态更新逻辑，正确处理当前目录不可写时剪切操作的禁用状
态。同时调整了代码格式以提高可读性。

1. 修复剪贴板数据验证条件中的缩进不一致问题
2. 添加当前目录无写权限时剪切操作禁用的正确验证
3. 通过将剪切操作验证移至单独代码块改善代码结构

Log: 修复当前目录为只读时剪贴板菜单状态更新不正确的问题

Influence:
1. 在可写目录中测试剪贴板菜单 - 剪切操作应启用
2. 在只读目录中测试剪贴板菜单 - 剪切操作应禁用
3. 使用不同剪贴板内容验证粘贴操作状态
4. 测试不同文件选择状态下的菜单行为
5. 验证目录权限变更时的菜单更新

BUG: https://pms.uniontech.com/bug-view-344703.html

## Summary by Sourcery

Bug Fixes:
- Ensure clipboard-driven menu state disables cut when the current directory is not writable while preserving behavior in writable directories.