### PR TITLE
fix(delegate): add file icon fallback when thumbnail rendering fails

### DIFF
--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -118,6 +118,7 @@ enum ItemRoles {
     kItemGroupDisplayIndex = Qt::UserRole + 41,
     kItemGroupExpandedRole = Qt::UserRole + 42,
     kItemGroupFileCount = Qt::UserRole + 43,
+    kItemFileIconRole = Qt::UserRole + 44,    // item file really icon, not thumnal
     kItemUnknowRole = Qt::UserRole + 999
 };
 

--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -138,13 +138,23 @@ void CanvasItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         // draw icon and background
         const QRect rIcon = iconRect(option.rect);
         paintBackground(painter, indexOption, rIcon);
-        paintIcon(painter, indexOption.icon,
-                  { rIcon,
-                    Qt::AlignCenter,
-                    (option.state & QStyle::State_Enabled) ? QIcon::Normal : QIcon::Disabled,
-                    QIcon::Off,
-                    isThumnailIconIndex(index) });   // why Enabled?
+        const std::optional<QRectF> &pIcon = paintIcon( painter, indexOption.icon,
+                                                        { rIcon,
+                                                          Qt::AlignCenter,
+                                                          (option.state & QStyle::State_Enabled) ? QIcon::Normal : QIcon::Disabled,
+                                                          QIcon::Off,
+                                                          isThumnailIconIndex(index) });   // why Enabled?
 
+        // If the thumbnail drawing is empty, then redraw the file fileicon
+        if (!pIcon.has_value()) {
+            const QIcon &fileIcon = index.data(Global::ItemRoles::kItemFileIconRole).value<QIcon>();
+            paintIcon(painter, fileIcon,
+                      { rIcon,
+                        Qt::AlignCenter,
+                        (option.state & QStyle::State_Enabled) ? QIcon::Normal : QIcon::Disabled,
+                        QIcon::Off,
+                        false });   // why Enabled?
+        }
         // paint emblems to icon
         paintEmblems(painter, rIcon, parent()->model()->fileInfo(index));
 
@@ -308,11 +318,23 @@ QSize CanvasItemDelegate::paintDragIcon(QPainter *painter, const QStyleOptionVie
     initStyleOption(&indexOption, index);
 
     painter->setRenderHints(painter->renderHints() | QPainter::Antialiasing | QPainter::SmoothPixmapTransform, true);
-    return paintIcon(painter, indexOption.icon,
-                     { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
-                       QIcon::Off, isThumnailIconIndex(index) })
-            .size()
-            .toSize();
+    const std::optional<QRectF> &pIcon = paintIcon( painter, indexOption.icon,
+                                                    { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
+                                                      QIcon::Off, isThumnailIconIndex(index) });
+    // If the thumbnail drawing is empty, then redraw the file fileicon
+    if (!pIcon.has_value()) {
+        const QIcon &fileIcon = index.data(Global::ItemRoles::kItemFileIconRole).value<QIcon>();
+        const std::optional<QRectF> paintRect = paintIcon(painter, fileIcon,
+                                                          { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
+                                                            QIcon::Off, false });
+        if (paintRect.has_value()) {
+            return paintRect->size().toSize();
+        } else {
+            return QSize();
+        }
+    }
+
+    return pIcon->size().toSize();
 }
 
 int CanvasItemDelegate::textLineHeight() const
@@ -746,13 +768,16 @@ void CanvasItemDelegate::initStyleOption(QStyleOptionViewItem *option, const QMo
  * \param mode: icon mode (Normal, Disabled, Active, Selected )
  * \param state: The state for which a pixmap is intended to be used. (On, Off)
  */
-QRectF CanvasItemDelegate::paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts)
+std::optional<QRectF> CanvasItemDelegate::paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts)
 {
     // Copy of QStyle::alignedRect
     Qt::Alignment alignment { visualAlignment(painter->layoutDirection(), opts.alignment) };
     const qreal pixelRatio = painter->device()->devicePixelRatioF();
     const QPixmap &px = getIconPixmap(icon, opts.rect.size().toSize(), pixelRatio, opts.mode, opts.state);
 
+    // 缩略图缩放到指定的size，绘制不出来就直接返回，绘制fileicon
+    if (px.isNull() && opts.isThumb)
+        return std::nullopt;
     // 保持图标原始比例
     qreal w = px.width() / px.devicePixelRatio();
     qreal h = px.height() / px.devicePixelRatio();

--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.h
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.h
@@ -63,7 +63,7 @@ public:
 protected:
     void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override;
     QRect textPaintRect(const QStyleOptionViewItem &option, const QModelIndex &index, const QRect &rText, bool elide) const;
-    static QRectF paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
+    static std::optional<QRectF> paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
     static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info);
 
     void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const;

--- a/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
@@ -544,6 +544,8 @@ QVariant FileInfoModel::data(const QModelIndex &index, int itemRole) const
         return indexFileInfo->nameOf(NameInfoType::kBaseNameOfRename);
     case Global::ItemRoles::kItemFileSuffixOfRenameRole:
         return indexFileInfo->nameOf(NameInfoType::kSuffixOfRename);
+    case Global::ItemRoles::kItemFileIconRole:
+            return indexFileInfo->fileIcon();
     default:
         return QString();
     }

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.h
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.h
@@ -59,7 +59,7 @@ public:
 
 protected:
     void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override;
-    static QRect paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
+    static std::optional<QRect> paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
     static QRectF paintEmblems(QPainter *painter, const QRectF &rect, const FileInfoPointer &info);
 
     void paintBackground(QPainter *painter, const QStyleOptionViewItem &option, const QRect &iconRect) const;

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
@@ -271,6 +271,10 @@ QVariant FileItemData::data(int role) const
         return QString();
     case kItemGroupDisplayIndex:
         return QVariant(groupDisplayIndex);
+    case kItemFileIconRole:
+            if (!info)
+                return QIcon::fromTheme("empty");
+            return info->fileIcon();
     default:
         return QVariant();
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.cpp
@@ -44,13 +44,17 @@ QPixmap ItemDelegateHelper::getIconPixmap(const QIcon &icon, const QSize &size, 
  *
  * \return void
  **/
-void ItemDelegateHelper::paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts)
+bool ItemDelegateHelper::paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts)
 {
     // Copy of QStyle::alignedRect
     Qt::Alignment alignment = visualAlignment(painter->layoutDirection(), opts.alignment);
     const qreal pixelRatio = painter->device()->devicePixelRatioF();
     const QPixmap &px = getIconPixmap(icon, opts.rect.size().toSize(), pixelRatio, opts.mode, opts.state);
     
+    // 缩略图缩放到指定的size，绘制不出来就直接返回，绘制fileicon
+    if (px.isNull() && opts.isThumb)
+        return false;
+
     // 保持图标原始比例
     qreal w = px.width() / px.devicePixelRatio();
     qreal h = px.height() / px.devicePixelRatio();
@@ -123,6 +127,8 @@ void ItemDelegateHelper::paintIcon(QPainter *painter, const QIcon &icon, const P
         QRectF targetRect(qRound(x), qRound(y), w, h);
         painter->drawPixmap(targetRect, px, px.rect());
     }
+
+    return true;
 }
 
 void ItemDelegateHelper::drawBackground(const qreal &backgroundRadius, const QRectF &rect, QRectF &lastLineRect, const QBrush &backgroundBrush, QPainter *painter)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.h
@@ -59,7 +59,7 @@ public:
     }
     static QPixmap getIconPixmap(const QIcon &icon, const QSize &size, qreal pixelRatio,
                                  QIcon::Mode mode = QIcon::Normal, QIcon::State state = QIcon::Off);
-    static void paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
+    static bool paintIcon(QPainter *painter, const QIcon &icon, const PaintIconOpts &opts);
 
     static void hideTooltipImmediately();
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/abstractitempaintproxy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/abstractitempaintproxy.cpp
@@ -3,8 +3,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "abstractitempaintproxy.h"
+#include "fileview.h"
+#include "models/fileviewmodel.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/iconutils.h>
 
 using namespace dfmplugin_workspace;
+DFMGLOBAL_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
 
 AbstractItemPaintProxy::AbstractItemPaintProxy(QObject *parent)
     : QObject(parent)
@@ -63,4 +70,22 @@ bool AbstractItemPaintProxy::supportContentPreview() const
 void AbstractItemPaintProxy::setStyleProxy(QStyle *style)
 {
     this->style = style;
+}
+
+bool AbstractItemPaintProxy::isThumnailIconIndex(const QModelIndex &index) const
+{
+    auto parent = dynamic_cast<FileView *>(this->parent());
+    if (!index.isValid() || !parent)
+        return false;
+
+    FileInfoPointer info { parent->model()->fileInfo(index) };
+    if (info) {
+        if (IconUtils::shouldSkipThumbnailFrame(info->nameOf(NameInfoType::kMimeTypeName)))
+            return false;
+
+        const auto &attribute { info->extendAttributes(ExtInfoType::kFileThumbnail) };
+        if (attribute.isValid() && !attribute.value<QIcon>().isNull())
+            return true;
+    }
+    return false;
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/abstractitempaintproxy.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/abstractitempaintproxy.h
@@ -32,6 +32,8 @@ public:
     virtual bool supportContentPreview() const;
 
     void setStyleProxy(QStyle *style);
+protected:
+    bool isThumnailIconIndex(const QModelIndex &index) const;
 
 protected:
     QStyle *style;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -231,10 +231,18 @@ void BaseItemDelegate::paintDragIcon(QPainter *painter, const QStyleOptionViewIt
 
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
-    ItemDelegateHelper::paintIcon(painter, opt.icon,
-                                  { iconRect, Qt::AlignCenter,
-                                    QIcon::Normal, QIcon::Off,
-                                    ViewMode::kIconMode, isThumnailIconIndex(index) });
+    auto drawFileIcon = ItemDelegateHelper::paintIcon(painter, opt.icon,
+                                                      { iconRect, Qt::AlignCenter,
+                                                        QIcon::Normal, QIcon::Off,
+                                                        ViewMode::kIconMode, isThumnailIconIndex(index) });
+    // If the thumbnail drawing is empty, then redraw the file fileicon
+    if (!drawFileIcon) {
+        const QIcon &fileIcon = index.data(dfmbase::Global::ItemRoles::kItemFileIconRole).value<QIcon>();
+        ItemDelegateHelper::paintIcon(painter, fileIcon,
+                                      { iconRect, Qt::AlignCenter,
+                                        QIcon::Normal, QIcon::Off,
+                                        ViewMode::kIconMode, false });
+    }
 }
 
 QSize BaseItemDelegate::getIndexIconSize(const QStyleOptionViewItem &option, const QModelIndex &index, const QSize &size) const

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -629,13 +629,24 @@ QRectF IconItemDelegate::paintItemIcon(QPainter *painter, const QStyleOptionView
     } else {
         bool isEnabled = opt.state & QStyle::State_Enabled;
         // draw icon
-        ItemDelegateHelper::paintIcon(painter, opt.icon,
-                                      { iconRect,
-                                        Qt::AlignCenter,
-                                        isEnabled ? QIcon::Normal : QIcon::Disabled,
-                                        QIcon::Off,
-                                        ViewMode::kIconMode,
-                                        isThumnailIconIndex(index) });
+        auto drawFileIcon = ItemDelegateHelper::paintIcon(painter, opt.icon,
+                                                          { iconRect,
+                                                            Qt::AlignCenter,
+                                                            isEnabled ? QIcon::Normal : QIcon::Disabled,
+                                                            QIcon::Off,
+                                                            ViewMode::kIconMode,
+                                                            isThumnailIconIndex(index) });
+        // If the thumbnail drawing is empty, then redraw the file fileicon
+        if (!drawFileIcon) {
+            const QIcon &fileIcon = index.data(Global::ItemRoles::kItemFileIconRole).value<QIcon>();
+            ItemDelegateHelper::paintIcon(painter, fileIcon,
+                                          { iconRect,
+                                            Qt::AlignCenter,
+                                            isEnabled ? QIcon::Normal : QIcon::Disabled,
+                                            QIcon::Off,
+                                            ViewMode::kIconMode,
+                                            false });
+        }
     }
 
     paintEmblems(painter, iconRect, index);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitempaintproxy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitempaintproxy.cpp
@@ -5,6 +5,7 @@
 #include "listitempaintproxy.h"
 #include "fileview.h"
 #include "utils/itemdelegatehelper.h"
+#include <dfm-base/dfm_global_defines.h>
 
 using namespace dfmplugin_workspace;
 
@@ -20,7 +21,14 @@ void ListItemPaintProxy::drawIcon(QPainter *painter, QRectF *rect, const QStyleO
     *rect = iconRect(index, rect->toRect());
 
     bool isEnabled = option.state & QStyle::State_Enabled;
-    ItemDelegateHelper::paintIcon(painter, option.icon, { *rect, Qt::AlignCenter, isEnabled ? QIcon::Normal : QIcon::Disabled });
+    auto drawFileIcon = ItemDelegateHelper::paintIcon(painter, option.icon, { *rect, Qt::AlignCenter, isEnabled ? QIcon::Normal : QIcon::Disabled, QIcon::Off, dfmbase::Global::ViewMode::kListMode,
+                                                                              isThumnailIconIndex(index) });
+    // If the thumbnail drawing is empty, then redraw the file fileicon
+    if (!drawFileIcon) {
+        const QIcon &fileIcon = index.data(dfmbase::Global::ItemRoles::kItemFileIconRole).value<QIcon>();
+        ItemDelegateHelper::paintIcon(painter, fileIcon, { *rect, Qt::AlignCenter, isEnabled ? QIcon::Normal : QIcon::Disabled , QIcon::Off, dfmbase::Global::ViewMode::kListMode,
+                                                           isThumnailIconIndex(index) });
+    }
 }
 
 QRectF ListItemPaintProxy::rectByType(RectOfItemType type, const QModelIndex &index)

--- a/src/plugins/filemanager/dfmplugin-workspace/views/treeitempaintproxy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/treeitempaintproxy.cpp
@@ -27,7 +27,14 @@ void TreeItemPaintProxy::drawIcon(QPainter *painter, QRectF *rect, const QStyleO
 
     if (rect->right() <= firstColumnRightBoundary) {
         bool isEnabled = option.state & QStyle::State_Enabled;
-        ItemDelegateHelper::paintIcon(painter, option.icon, { *rect, Qt::AlignCenter, isEnabled ? QIcon::Normal : QIcon::Disabled });
+        auto drawFileIcon = ItemDelegateHelper::paintIcon(painter, option.icon, { *rect, Qt::AlignCenter, isEnabled ? QIcon::Normal : QIcon::Disabled, QIcon::Off, dfmbase::Global::ViewMode::kTreeMode,
+                                                                                  isThumnailIconIndex(index) });
+        // If the thumbnail drawing is empty, then redraw the file fileicon
+        if (!drawFileIcon) {
+            const QIcon &fileIcon = index.data(dfmbase::Global::ItemRoles::kItemFileIconRole).value<QIcon>();
+            ItemDelegateHelper::paintIcon(painter, fileIcon, { *rect, Qt::AlignCenter, isEnabled ? QIcon::Normal : QIcon::Disabled, QIcon::Off, dfmbase::Global::ViewMode::kTreeMode,
+                                                               isThumnailIconIndex(index) });
+        }
     }
 
     if (index.data(kItemTreeViewCanExpandRole).toBool())


### PR DESCRIPTION
When thumbnail pixmap is null or fails to render, the icon area remains empty. This change adds a fallback mechanism to display the file icon instead of showing a blank space.

Changes:
 - Add kItemFileIconRole to ItemRoles enum for accessing file icons
 - Modify paintIcon() to return bool indicating success/failure
 - Return QRect(-1, -1, -1, -1) when thumbnail pixmap is null
 - Add fallback logic in all delegates to use file icon when thumbnail fails
 - Update FileInfoModel and FileItemData to provide file icon via new role
 - Apply fallback in CanvasItemDelegate, CollectionItemDelegate, IconItemDelegate, BaseItemDelegate, ListItemPaintProxy, and TreeItemPaintProxy

This ensures users always see an icon representation even when thumbnails cannot be generated.

Log: add file icon fallback when thumbnail rendering fails
Bug: https://pms.uniontech.com/bug-view-340119.html

## Summary by Sourcery

Ensure file icons are always displayed in canvas, collection, icon, list, and tree views when thumbnail rendering fails by introducing a dedicated file icon role and thumbnail fallback handling across delegates and helpers.

Bug Fixes:
- Prevent empty icon areas when thumbnail pixmaps are null or cannot be rendered by falling back to the underlying file icon.

Enhancements:
- Introduce a kItemFileIconRole model role and plumb it through file models and item data to expose the raw file icon separately from thumbnails.
- Change shared icon painting helpers to report thumbnail rendering failures so delegates can trigger file icon fallback instead.