### PR TITLE
fix: fix pinned tabs display and validation issues

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -519,7 +519,7 @@ void TabBarPrivate::paintTabLabel(QPainter *painter, int index, const QStyleOpti
     painter->save();
     const QRect rect = option.rect;
     const bool isSelected = option.state & QStyle::State_Selected;
-    const bool isHovered = option.state & QStyle::State_MouseOver;
+    const bool isItemBtnShowed = (option.state & QStyle::State_MouseOver) || q->isPinned(index);
 
     // 获取主题颜色
     DPalette pal = DPaletteHelper::instance()->palette(q);
@@ -528,13 +528,13 @@ void TabBarPrivate::paintTabLabel(QPainter *painter, int index, const QStyleOpti
     const int tabMargin = 10;
     const int blueMarkerWidth = isSelected ? 6 : 0;
     const int blueMarkerMargin = isSelected ? 4 : 0;
-    const int closeButtonSize = isHovered ? kItemButtonSize : 0;
-    const int closeButtonMargin = isHovered ? kItemButtonMargin : 0;
+    const int closeButtonSize = isItemBtnShowed ? kItemButtonSize : 0;
+    const int closeButtonMargin = isItemBtnShowed ? kItemButtonMargin : 0;
 
     // 计算文本可用宽度（考虑蓝色标记和关闭按钮）
     const int textMargin = blueMarkerWidth + blueMarkerMargin;
     const int leftSpace = tabMargin / 2 + textMargin;
-    const int rightSpace = isHovered ? (closeButtonSize + closeButtonMargin) : 0;
+    const int rightSpace = isItemBtnShowed ? (closeButtonSize + closeButtonMargin) : 0;
     const int availableTextWidth = rect.width() - leftSpace;
 
     // 截断文本以适应可用宽度
@@ -545,7 +545,7 @@ void TabBarPrivate::paintTabLabel(QPainter *painter, int index, const QStyleOpti
     const int textX = rect.x() + (rect.width() - option.fontMetrics.horizontalAdvance(elidedText) - textMargin) / 2 + textMargin;
     const int textY = rect.y() + (rect.height() - option.fontMetrics.height()) / 2 + option.fontMetrics.ascent();
 
-    if (isHovered) {
+    if (isItemBtnShowed) {
         int textEndX = textX + textWidth;
         int buttonStartX = rect.right() - rightSpace;
         if (textEndX > buttonStartX) {


### PR DESCRIPTION
1. Fixed tab close button display logic to show for both hovered and
pinned tabs
2. Added file existence validation when restoring pinned tabs
3. Implemented automatic cleanup of invalid pinned tabs from
configuration

Log: Fixed pinned tabs display and validation issues

Influence:
1. Test pinned tabs show close buttons correctly
2. Verify pinned tabs with invalid URLs are automatically removed
3. Check tab restoration handles missing files gracefully
4. Test tab bar layout with pinned and regular tabs
5. Verify configuration updates correctly when invalid tabs are found

fix: 修复固定标签页显示和验证问题

1. 修复标签页关闭按钮显示逻辑，现在悬停和固定标签页都会显示
2. 在恢复固定标签页时添加文件存在性验证
3. 实现自动清理配置中无效的固定标签页

Log: 修复固定标签页显示和验证问题

Influence:
1. 测试固定标签页是否正确显示关闭按钮
2. 验证包含无效URL的固定标签页是否被自动移除
3. 检查标签页恢复功能是否能优雅处理缺失文件
4. 测试固定和普通标签页共存时的标签栏布局
5. 验证发现无效标签页时配置是否正确更新

## Summary by Sourcery

Ensure pinned file manager tabs display correctly and skip invalid entries when restoring from configuration.

Bug Fixes:
- Show the tab close button for both hovered and pinned tabs to correct pinned tab UI behavior.
- Validate file existence when restoring pinned tabs so missing or invalid URLs are not reopened.

Enhancements:
- Automatically clean up and persist only valid pinned tabs back to configuration after restoration.