### PR TITLE
Feat detailspace

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.view.json
+++ b/assets/configs/org.deepin.dde.file-manager.view.json
@@ -35,6 +35,17 @@
             "permissions":"readwrite",
             "visibility":"private"
         },
+        "dfm.sidebar.visible": {
+            "value":true,
+            "serial":0,
+            "flags":[],
+            "name":"Sidebar visible",
+            "name[zh_CN]":"显示侧边栏",
+            "description[zh_CN]":"控制侧边栏显示",
+            "description":"Control sidebar visibility",
+            "permissions":"readwrite",
+            "visibility":"private"
+        },
         "dfm.icon.size.level": {
             "value":5,
             "serial":0,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-file-manager (6.5.112) unstable; urgency=medium
+
+  * fix: improve detail view content update timing
+  * fix: simplify detail panel drag handling logic
+  * chore: update translation files for component rename
+  * feat: add sidebar visibility persistence
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 26 Dec 2025 10:54:42 +0800
+
 dde-file-manager (6.5.111) unstable; urgency=medium
 
   * fix: improve file copy error handling and method naming

--- a/include/dfm-base/widgets/filemanagerwindow.h
+++ b/include/dfm-base/widgets/filemanagerwindow.h
@@ -54,7 +54,6 @@ public:
 protected:
     void closeEvent(QCloseEvent *event) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
-    void mouseReleaseEvent(QMouseEvent *event) override;
     void moveEvent(QMoveEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     bool eventFilter(QObject *watched, QEvent *event) override;

--- a/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
+++ b/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
@@ -21,6 +21,7 @@ inline constexpr char kAnimationDConfName[] { "org.deepin.dde.file-manager.anima
 namespace BaseConfig {
 inline constexpr char kTreeViewEnable[] { "dfm.treeview.enable" };
 inline constexpr char kDisplayPreviewVisibleKey[] { "dfm.displaypreview.visible" };
+inline constexpr char kSidebarVisibleKey[] { "dfm.sidebar.visible" };
 inline constexpr char kOpenFolderWindowsInASeparateProcess[] { "dfm.open.in.single.process" };
 inline constexpr char kCunstomFixedTabs[] { "dfm.custom.fixedtab" };
 inline constexpr char kPinnedTabs[] { "dfm.pinned.tabs" };

--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -147,6 +147,11 @@ int FileManagerWindowPrivate::loadSidebarState() const
     return kDefaultLeftWidth;
 }
 
+bool FileManagerWindowPrivate::loadSidebarVisibleState() const
+{
+    return DConfigManager::instance()->value(kViewDConfName, kSidebarVisibleKey, true).toBool();
+}
+
 int FileManagerWindowPrivate::splitterPosition() const
 {
     if (!splitter || splitter->sizes().isEmpty())
@@ -287,6 +292,9 @@ void FileManagerWindowPrivate::connectAnimationSignals()
 
         // 动画完成后更新位置
         updateSideBarSeparatorPosition();
+
+        // Persist sidebar visibility state when animation completes
+        DConfigManager::instance()->setValue(kViewDConfName, kSidebarVisibleKey, expanded);
 
         delete curSplitterAnimation;
         curSplitterAnimation = nullptr;
@@ -618,30 +626,44 @@ void FileManagerWindowPrivate::updateSidebarSeparator()
     updateSideBarSeparatorPosition();
 }
 
+void FileManagerWindowPrivate::setSideBarVisible(bool visible, bool persistState)
+{
+    if (visible) {
+        if (sideBar && sideBar->isVisible())
+            return;
+
+        sideBar->setVisible(true);
+        sidebarSep->setVisible(true);
+        expandButton->setProperty("expand", true);
+        sideBarAutoVisible = true;
+        emit q->windowSplitterWidthChanged(lastSidebarExpandedPostion);
+
+        updateSidebarSeparator();
+    } else {
+        if (sideBar && !sideBar->isVisible())
+            return;
+
+        sideBar->setVisible(false);
+        sidebarSep->setVisible(false);
+        expandButton->setProperty("expand", false);
+        sideBarAutoVisible = false;
+        emit q->windowSplitterWidthChanged(0);
+    }
+
+    // Persist sidebar visibility state if requested
+    if (persistState) {
+        DConfigManager::instance()->setValue(kViewDConfName, kSidebarVisibleKey, visible);
+    }
+}
+
 void FileManagerWindowPrivate::showSideBar()
 {
-    if (sideBar && sideBar->isVisible())
-        return;
-
-    sideBar->setVisible(true);
-    sidebarSep->setVisible(true);
-    expandButton->setProperty("expand", true);
-    sideBarAutoVisible = true;
-    emit q->windowSplitterWidthChanged(lastSidebarExpandedPostion);
-
-    updateSidebarSeparator();
+    setSideBarVisible(true, true);
 }
 
 void FileManagerWindowPrivate::hideSideBar()
 {
-    if (sideBar && !sideBar->isVisible())
-        return;
-
-    sideBar->setVisible(false);
-    sidebarSep->setVisible(false);
-    expandButton->setProperty("expand", false);
-    sideBarAutoVisible = false;
-    emit q->windowSplitterWidthChanged(0);
+    setSideBarVisible(false, true);
 }
 
 void FileManagerWindowPrivate::setupSidebarSepTracking()
@@ -1200,9 +1222,17 @@ void FileManagerWindow::initializeUi()
 
 void FileManagerWindow::updateUi()
 {
+    // Only apply UI state after all components are initialized
+    if (!d->sideBar || !d->titleBar || !d->workspace || !d->splitter)
+        return;
+
     int splitterPos = d->loadSidebarState();
     d->lastSidebarExpandedPostion = splitterPos;
     d->setSplitterPosition(splitterPos);
+
+    // Load and apply sidebar visibility state from DConfig (without persisting back)
+    bool sidebarVisible = d->loadSidebarVisibleState();
+    d->setSideBarVisible(sidebarVisible, false);
 
     // Load and set detailSplitter initial size
     d->lastDetailSpaceWidth = d->loadDetailSpaceState();

--- a/src/dfm-base/widgets/dfmwindow/private/filemanagerwindow_p.h
+++ b/src/dfm-base/widgets/dfmwindow/private/filemanagerwindow_p.h
@@ -48,8 +48,10 @@ public:
 
     void showSideBar();
     void hideSideBar();
+    void setSideBarVisible(bool visible, bool persistState);
     void setupSidebarSepTracking();
     int loadSidebarState() const;
+    bool loadSidebarVisibleState() const;
     void saveSidebarState();
     void updateSideBarState();
     void updateSideBarVisibility();

--- a/src/plugins/filemanager/dfmplugin-detailspace/utils/detailspacehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/utils/detailspacehelper.cpp
@@ -84,8 +84,14 @@ void DetailSpaceHelper::showDetailView(quint64 windowId, bool checked)
 
         // IMPORTANT: Update content AFTER detailspace becomes visible
         // Use QTimer to ensure the widget is fully visible before loading content
-        QTimer::singleShot(0, widget, [widget, window]() {
-            setDetailViewByUrl(widget, window->currentUrl());
+        QTimer::singleShot(0, widget, [widget, window, windowId]() {
+            // Refresh with current selection (same logic as handleViewSelectionChanged)
+            const QList<QUrl> &urls = dpfSlotChannel->push("dfmplugin_workspace", "slot_View_GetSelectedUrls", windowId).value<QList<QUrl>>();
+            if (urls.isEmpty()) {
+                setDetailViewByUrl(widget, window->currentUrl());
+            } else {
+                setDetailViewByUrl(widget, urls.first());
+            }
         });
 
     } else if (widget) {

--- a/translations/dde-file-manager.ts
+++ b/translations/dde-file-manager.ts
@@ -4434,41 +4434,41 @@ Enter user and password for %1</source>
     </message>
 </context>
 <context>
-    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <name>dfmplugin_detailspace::FileInfoWidget</name>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="45"/>
         <source>Name</source>
-        <translation>Name</translation>
+        <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="46"/>
         <source>Size</source>
-        <translation>Size</translation>
+        <translation type="unfinished">Size</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="47"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="49"/>
         <source>Duration</source>
-        <translation>Duration</translation>
+        <translation type="unfinished">Duration</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="50"/>
         <source>Type</source>
-        <translation>Type</translation>
+        <translation type="unfinished">Type</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="51"/>
         <source>Accessed</source>
-        <translation>Accessed</translation>
+        <translation type="unfinished">Accessed</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="52"/>
         <source>Modified</source>
-        <translation>Modified</translation>
+        <translation type="unfinished">Modified</translation>
     </message>
 </context>
 <context>
@@ -6574,7 +6574,7 @@ Enter user and password for %1</source>
 <context>
     <name>dfmplugin_tag::Tag</name>
     <message>
-        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="54"/>
         <source>Tag</source>
         <translation>Tag</translation>
     </message>

--- a/translations/dde-file-manager_bo.ts
+++ b/translations/dde-file-manager_bo.ts
@@ -4434,41 +4434,41 @@ Enter user and password for %1</source>
     </message>
 </context>
 <context>
-    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <name>dfmplugin_detailspace::FileInfoWidget</name>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="45"/>
         <source>Name</source>
-        <translation>མིང་།</translation>
+        <translation type="unfinished">མིང་།</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="46"/>
         <source>Size</source>
-        <translation>ཆེ་ཆུང་།</translation>
+        <translation type="unfinished">ཆེ་ཆུང་།</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="47"/>
         <source>Resolution</source>
-        <translation>གཞི་གཏན་ཆེ་ཆུང་</translation>
+        <translation type="unfinished">གཞི་གཏན་ཆེ་ཆུང་</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="49"/>
         <source>Duration</source>
-        <translation>དུས་ཚོད་རིང་ཐུང་།</translation>
+        <translation type="unfinished">དུས་ཚོད་རིང་ཐུང་།</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="50"/>
         <source>Type</source>
-        <translation>རིགས་གྲས།</translation>
+        <translation type="unfinished">རིགས་གྲས།</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="51"/>
         <source>Accessed</source>
-        <translation>ལྟ་སྤྱོད་དུས་ཚོད།</translation>
+        <translation type="unfinished">ལྟ་སྤྱོད་དུས་ཚོད།</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="52"/>
         <source>Modified</source>
-        <translation>བཟོ་བའི་དུས་ཚོད།</translation>
+        <translation type="unfinished">བཟོ་བའི་དུས་ཚོད།</translation>
     </message>
 </context>
 <context>
@@ -6574,7 +6574,7 @@ Enter user and password for %1</source>
 <context>
     <name>dfmplugin_tag::Tag</name>
     <message>
-        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="54"/>
         <source>Tag</source>
         <translation>མཚོན་རྟགས།</translation>
     </message>

--- a/translations/dde-file-manager_lo.ts
+++ b/translations/dde-file-manager_lo.ts
@@ -4435,39 +4435,39 @@ Enter user and password for %1</source>
     </message>
 </context>
 <context>
-    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <name>dfmplugin_detailspace::FileInfoWidget</name>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="45"/>
         <source>Name</source>
         <translation>ឈ្មោះ</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="46"/>
         <source>Size</source>
         <translation>ទំហំ</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="47"/>
         <source>Resolution</source>
         <translation>ຄວາມລະອຽດ</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="49"/>
         <source>Duration</source>
         <translation>ລະດັບເວລາ</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="50"/>
         <source>Type</source>
         <translation>ប្រភេទ</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="51"/>
         <source>Accessed</source>
         <translation>ເຂົ້າໃຊ້</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="52"/>
         <source>Modified</source>
         <translation>ແກນແປງ</translation>
     </message>
@@ -6575,7 +6575,7 @@ Enter user and password for %1</source>
 <context>
     <name>dfmplugin_tag::Tag</name>
     <message>
-        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="54"/>
         <source>Tag</source>
         <translation>តែងតាំង</translation>
     </message>

--- a/translations/dde-file-manager_ug.ts
+++ b/translations/dde-file-manager_ug.ts
@@ -4434,41 +4434,41 @@ Enter user and password for %1</source>
     </message>
 </context>
 <context>
-    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <name>dfmplugin_detailspace::FileInfoWidget</name>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="45"/>
         <source>Name</source>
-        <translation>نامى</translation>
+        <translation type="unfinished">نامى</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="46"/>
         <source>Size</source>
-        <translation>چوڭلۇقى</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="47"/>
         <source>Resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="49"/>
         <source>Duration</source>
-        <translation>ۋاقتى</translation>
+        <translation type="unfinished">ۋاقتى</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="50"/>
         <source>Type</source>
-        <translation>تىپى</translation>
+        <translation type="unfinished">تىپى</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="51"/>
         <source>Accessed</source>
-        <translation>زىيارەت قىلغان ۋاقىت</translation>
+        <translation type="unfinished">زىيارەت قىلغان ۋاقىت</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="52"/>
         <source>Modified</source>
-        <translation>ئۆزگەرتكەن ۋاقىت</translation>
+        <translation type="unfinished">ئۆزگەرتكەن ۋاقىت</translation>
     </message>
 </context>
 <context>
@@ -6574,7 +6574,7 @@ Enter user and password for %1</source>
 <context>
     <name>dfmplugin_tag::Tag</name>
     <message>
-        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="54"/>
         <source>Tag</source>
         <translation>خەتكۈچ</translation>
     </message>

--- a/translations/dde-file-manager_zh_CN.ts
+++ b/translations/dde-file-manager_zh_CN.ts
@@ -4435,39 +4435,39 @@ Enter user and password for %1</source>
     </message>
 </context>
 <context>
-    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <name>dfmplugin_detailspace::FileInfoWidget</name>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="45"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="46"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="47"/>
         <source>Resolution</source>
         <translation>分辨率</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="49"/>
         <source>Duration</source>
         <translation>时长</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="50"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="51"/>
         <source>Accessed</source>
         <translation>访问时间</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="52"/>
         <source>Modified</source>
         <translation>修改时间</translation>
     </message>
@@ -6575,7 +6575,7 @@ Enter user and password for %1</source>
 <context>
     <name>dfmplugin_tag::Tag</name>
     <message>
-        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="54"/>
         <source>Tag</source>
         <translation>标记</translation>
     </message>

--- a/translations/dde-file-manager_zh_HK.ts
+++ b/translations/dde-file-manager_zh_HK.ts
@@ -4435,39 +4435,39 @@ Enter user and password for %1</source>
     </message>
 </context>
 <context>
-    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <name>dfmplugin_detailspace::FileInfoWidget</name>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="45"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="46"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="47"/>
         <source>Resolution</source>
         <translation>解像度</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="49"/>
         <source>Duration</source>
         <translation>時長</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="50"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="51"/>
         <source>Accessed</source>
         <translation>訪問時間</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="52"/>
         <source>Modified</source>
         <translation>修改時間</translation>
     </message>
@@ -6575,7 +6575,7 @@ Enter user and password for %1</source>
 <context>
     <name>dfmplugin_tag::Tag</name>
     <message>
-        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="54"/>
         <source>Tag</source>
         <translation>標記</translation>
     </message>

--- a/translations/dde-file-manager_zh_TW.ts
+++ b/translations/dde-file-manager_zh_TW.ts
@@ -4435,39 +4435,39 @@ Enter user and password for %1</source>
     </message>
 </context>
 <context>
-    <name>dfmplugin_detailspace::FileBaseInfoView</name>
+    <name>dfmplugin_detailspace::FileInfoWidget</name>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="35"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="45"/>
         <source>Name</source>
-        <translation>名稱</translation>
+        <translation></translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="39"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="46"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="44"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="47"/>
         <source>Resolution</source>
         <translation>解析度</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="48"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="49"/>
         <source>Duration</source>
         <translation>時長</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="52"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="50"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="56"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="51"/>
         <source>Accessed</source>
         <translation>訪問時間</translation>
     </message>
     <message>
-        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/filebaseinfoview.cpp" line="60"/>
+        <location filename="../src/plugins/filemanager/dfmplugin-detailspace/views/fileinfowidget.cpp" line="52"/>
         <source>Modified</source>
         <translation>修改時間</translation>
     </message>
@@ -6575,7 +6575,7 @@ Enter user and password for %1</source>
 <context>
     <name>dfmplugin_tag::Tag</name>
     <message>
-        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="49"/>
+        <location filename="../src/plugins/common/dfmplugin-tag/tag.cpp" line="54"/>
         <source>Tag</source>
         <translation>標記</translation>
     </message>


### PR DESCRIPTION
## Summary by Sourcery

Persist and restore sidebar visibility and detailspace behavior, and update related translations and configuration keys.

Enhancements:
- Add persistent sidebar visibility state using a new DConfig key and apply it during UI initialization.
- Refine sidebar show/hide handling via a unified visibility helper and adjust detailspace event filtering and drag state cleanup.
- Improve detailspace content refresh to prioritize the current selection when opening the detail view.
- Update translation contexts from FileBaseInfoView to FileInfoWidget across multiple locales and adjust source locations accordingly.
- Introduce a new global configuration key for sidebar visibility.