### PR TITLE
fix: remove hardcoded time label color

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
@@ -20,11 +20,6 @@ VideoStatusBar::VideoStatusBar(VideoPreview *preview)
 
     control_button->setIcon(QIcon::fromTheme("dfm_pause"));
 
-    QPalette pa_label;
-
-    pa_label.setColor(QPalette::WindowText, QColor("#303030"));
-    timeLabel->setPalette(pa_label);
-
     slider->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     slider->setMinimum(0);
     slider->setOrientation(Qt::Horizontal);


### PR DESCRIPTION
Removed hardcoded color setting for time label in video status bar. The
color was previously set to #303030 using QPalette, but this approach
is unnecessary as the label should inherit the theme colors from the
system. This change ensures proper theme compatibility and maintains
visual consistency with the overall application theme.

Influence:
1. Verify time label text color matches system theme
2. Test video preview functionality in both light and dark themes
3. Check that all UI elements maintain proper color contrast
4. Ensure video playback controls work correctly after the change

fix: 移除时间标签的硬编码颜色设置

删除了视频状态栏中时间标签的硬编码颜色设置。之前使用 QPalette 将颜色设置
为 #303030，但这种方法是不必要的，因为标签应该从系统继承主题颜色。此更改
确保更好的主题兼容性，并与整体应用程序主题保持视觉一致性。

Influence:
1. 验证时间标签文本颜色是否与系统主题匹配
2. 在浅色和深色主题下测试视频预览功能
3. 检查所有UI元素是否保持适当的颜色对比度
4. 确保更改后视频播放控制功能正常工作

BUG: https://pms.uniontech.com/bug-view-337021.html

## Summary by Sourcery

Bug Fixes:
- Fix time label text color in the video status bar so it correctly follows the system theme instead of using a hardcoded color.