### PR TITLE
fix: handle last tab close redirection properly

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -169,6 +169,7 @@ void TitleBarWidget::activatePinnedTab(const QString &pinnedId)
         if (tabPinnedId == pinnedId) {
             fmInfo() << "Found and activating pinned tab at index" << i << "with pinnedId:" << pinnedId;
             tabBar()->setCurrentIndex(i);
+            Q_EMIT tabBar()->currentChanged(i);
             return;
         }
     }


### PR DESCRIPTION
Added logic to handle URL redirection when closing the last tab to
prevent navigation issues. The changes include:
1. Added handleLastTabClose method to manage URL redirection for the
last tab
2. Implemented determineRedirectUrl method with special handling for
external mounts and gvfs paths
3. Added findValidParentPath method to find valid parent directories
when current path becomes invalid
4. Modified closeTab to call the new redirection logic when closing the
last tab
5. Added workaround for BUG-236625 related to MTP protocol and gvfs
mount paths

This fix addresses navigation problems when closing tabs that point
to removed or unmounted locations, ensuring users are redirected to
appropriate valid paths instead of encountering errors.

Log: Fixed tab closing behavior to properly redirect when last tab is
closed

Influence:
1. Test closing the last tab when current directory is valid
2. Test closing the last tab when current directory is removed/unmounted
3. Verify redirection to computer:/// for external mounts
4. Test MTP device ejection scenario with internal storage paths
5. Verify gvfs mount path handling redirects to default URL
6. Test navigation consistency after tab operations

fix: 修复关闭最后一个标签页时的重定向问题

添加了处理最后一个标签页关闭时URL重定向的逻辑，防止导航问题。变更包括：
1. 添加handleLastTabClose方法管理最后一个标签页的URL重定向
2. 实现determineRedirectUrl方法，包含对外部挂载和gvfs路径的特殊处理
3. 添加findValidParentPath方法在当前路径无效时查找有效的父目录
4. 修改closeTab方法在关闭最后一个标签页时调用新的重定向逻辑
5. 添加针对BUG-236625的解决方案，处理MTP协议和gvfs挂载路径相关问题

此修复解决了关闭指向已删除或卸载位置的标签页时的导航问题，确保用户被重定
向到适当的有效路径而不是遇到错误。

Log: 修复关闭最后一个标签页时的重定向行为

Influence:
1. 测试当前目录有效时关闭最后一个标签页
2. 测试当前目录被删除/卸载时关闭最后一个标签页
3. 验证外部挂载重定向到computer:///
4. 测试MTP设备弹出时内部存储路径的场景
5. 验证gvfs挂载路径处理重定向到默认URL
6. 测试标签页操作后的导航一致性

## Summary by Sourcery

Ensure closing the last file manager tab redirects to a valid location instead of leaving the window on an invalid or unmounted path.

Bug Fixes:
- Fix last-tab closing behavior to navigate to an appropriate fallback URL when the current directory is removed or unmounted, including external mounts and gvfs paths.
- Work around MTP-related issues where internal storage removal could incorrectly redirect to a gvfs mount root instead of the computer root URL.

Enhancements:
- Add URL redirection logic that determines a safe target path when closing the last tab, including falling back to a valid parent directory when needed.