### PR TITLE
fix: fix terminal opening failure with long paths

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -284,6 +284,7 @@ private:
                            const dfmbase::GlobalEventType redo,
                            const bool isUndo = false, const QUrl &templateUrl = QUrl());
     QUrl determineLinkTarget(const QUrl &sourceUrl, const QUrl &linkUrl, const bool silence, const quint64 windowId);
+    bool doOpenInTerminal(const QUrl &url);
 
 private:
     std::unique_ptr<FileCopyMoveJob> copyMoveJob { std::make_unique<FileCopyMoveJob>() };


### PR DESCRIPTION
Extracted terminal opening logic into a dedicated method to handle
long file paths properly. The previous implementation had issues with
systemd's 255-byte filename limit when changing directories. The new
approach uses command-line arguments to pass the directory path instead
of changing the current working directory, which avoids the filename
length limitation.

Log: Fixed terminal opening failure when path contains long filenames

Influence:
1. Test opening terminal in directories with long path names
2. Verify terminal opens correctly with different terminal emulators
(dde-daemon, x-terminal-emulator, xterm)
3. Check that both local and remote file URLs are handled properly
4. Test multiple directory selection and terminal opening
5. Verify error handling when no terminal emulator is available

fix: 修复长路径下终端打开失败问题

将终端打开逻辑提取到独立方法中，以正确处理长文件路径。之前的实现在切换
目录时存在systemd的255字节文件名限制问题。新方法使用命令行参数传递目录路
径，而不是改变当前工作目录，从而避免了文件名长度限制。

Log: 修复路径包含长文件名时终端打开失败的问题

Influence:
1. 测试在包含长路径名的目录中打开终端
2. 验证使用不同终端模拟器（dde-daemon、x-terminal-emulator、xterm）时终
端正确打开
3. 检查本地和远程文件URL都能正确处理
4. 测试多目录选择和终端打开功能
5. 验证无可用终端模拟器时的错误处理

BUG: https://pms.uniontech.com/bug-view-309495.html
BUG: https://pms.uniontech.com/bug-view-345811.html

## Summary by Sourcery

Fix opening terminals from the file operations plugin, especially for directories with long paths, by centralizing and hardening the terminal-launch logic.

Bug Fixes:
- Resolve terminal launch failures for directories with long or long-filename paths by avoiding reliance on changing the current working directory.
- Ensure terminal opening works consistently across different terminal emulators, including Deepin default-terminal, Debian x-terminal-emulator, and xterm.