### PR TITLE
fix: fix trash file restore URL encoding issue

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -110,7 +110,7 @@ bool DoRestoreTrashFilesWorker::translateUrls()
             info->startTime = deleteInfo.first().toInt();
             info->endTime = deleteInfo.at(1).toInt();
             url.setUserInfo("");
-            targetUrls.insert(url, info);
+            targetUrls.insert(QUrl::fromPercentEncoding(url.toString().toUtf8()), info);
         }
     }
 


### PR DESCRIPTION
Fixed URL encoding issue when restoring files from trash by properly
decoding percent-encoded URLs before inserting into targetUrls map. The
original code was using raw URL strings which could contain percent-
encoding, leading to incorrect file paths during restoration.

Previously, URLs with percent-encoding (like spaces as %20) were being
stored as-is in the targetUrls map, causing file path mismatches during
the restore operation. Now using QUrl::fromPercentEncoding to properly
decode the URLs before storage.

Log: Fixed issue where files with special characters in names could not
be properly restored from trash

Influence:
1. Test restoring files with spaces, special characters, or non-ASCII
characters from trash
2. Verify that files with encoded characters in names are correctly
restored to their original locations
3. Check trash restoration functionality for files with complex naming
patterns
4. Ensure backward compatibility with existing trash items

fix: 修复回收站文件恢复时的 URL 编码问题

修复了从回收站恢复文件时的 URL 编码问题，通过在插入 targetUrls 映射之
前正确解码百分号编码的 URL。原代码使用原始 URL 字符串，可能包含百分号编
码，导致恢复过程中文件路径不正确。

之前，带有百分号编码（如空格为 %20）的 URL 被原样存储在 targetUrls 映射
中，导致恢复操作时文件路径不匹配。现在使用 QUrl::fromPercentEncoding 在
存储前正确解码 URL。

Log: 修复了带有特殊字符的文件无法从回收站正确恢复的问题

Influence:
1. 测试从回收站恢复带有空格、特殊字符或非 ASCII 字符的文件
2. 验证带有编码字符的文件名是否正确恢复到原始位置
3. 检查复杂命名模式文件的回收站恢复功能
4. 确保与现有回收站项目的向后兼容性

BUG: https://pms.uniontech.com/bug-view-344767.html
