### PR TITLE
refactor: separate monitoring and silent scan delays

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.textindex.json
+++ b/assets/configs/org.deepin.dde.file-manager.textindex.json
@@ -13,6 +13,17 @@
 			"permissions": "readwrite",
 			"visibility": "public"
 		},
+		"monitoringStartDelaySeconds": {
+			"value": 3,
+			"serial": 0,
+			"flags": [],
+			"name": "Monitoring Start Delay (seconds)",
+			"name[zh_CN]": "监控启动延迟（秒）",
+			"description[zh_CN]": "文件系统监控启动的延迟时间，单位为秒。此延迟避免在启用监控后立即启动文件系统监控。",
+			"description": "Delay before starting file system monitoring after enabling in seconds. This delay avoids immediate monitoring startup when monitoring is enabled.",
+			"permissions": "readwrite",
+			"visibility": "public"
+		},
 		"silentIndexUpdateDelay": {
 			"value": 180,
 			"serial": 0,

--- a/src/services/textindex/fsmonitor/fseventcontroller.h
+++ b/src/services/textindex/fsmonitor/fseventcontroller.h
@@ -54,9 +54,11 @@ private:
     bool m_silentlyFlag { false };
     bool m_lastSilentlyFlag { m_silentlyFlag };
     int m_collectorIntervalSecs { 3 };         // FSEventCollector event collection interval (seconds)
+    int m_monitoringStartDelaySecs { 3 };      // FSEventController monitoring start delay (seconds)
     int m_silentStartDelaySecs { 180 };        // FSEventController silent start delay (seconds)
     std::unique_ptr<FSEventCollector> m_fsEventCollector;
-    QTimer *m_startTimer { nullptr };
+    QTimer *m_monitoringStartTimer { nullptr };
+    QTimer *m_silentStartTimer { nullptr };
     QTimer *m_stopTimer { nullptr };
 
     // Collected file events

--- a/src/services/textindex/fsmonitor/fsmonitorworker.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitorworker.cpp
@@ -104,7 +104,7 @@ void FSMonitorWorker::tryFastDirectoryScan()
         }
 
         const QString currentStatus = status.value();
-        if (currentStatus != "monitoring") {
+        if (currentStatus == "closed") {
             fmWarning() << "FSMonitorWorker: Cannot use fast directory scan, index status is:" << currentStatus;
             return {};
         }
@@ -125,6 +125,7 @@ void FSMonitorWorker::tryFastDirectoryScan()
             directories = std::move(result.value());
         }
 
+        fmInfo() << "FSMonitorWorker: Fast directory scan found" << directories.size() << "directories";
         // Filter excluded directories
         QStringList filteredDirs;
         for (const auto &dir : std::as_const(directories)) {

--- a/src/services/textindex/service_textindex_global.h
+++ b/src/services/textindex/service_textindex_global.h
@@ -26,6 +26,7 @@ inline const QString kAnythingDirType = QLatin1String("dir");
 namespace DConf {
 inline const QString kTextIndexSchema = QLatin1String("org.deepin.dde.file-manager.textindex");
 inline const QString kAutoIndexUpdateInterval = QLatin1String("autoIndexUpdateInterval");
+inline const QString kMonitoringStartDelaySeconds = QLatin1String("monitoringStartDelaySeconds");
 inline const QString kSilentIndexUpdateDelay = QLatin1String("silentIndexUpdateDelay");
 inline const QString kInotifyResourceCleanupDelay = QLatin1String("inotifyResourceCleanupDelay");
 inline const QString kMaxIndexFileSizeMB = QLatin1String("maxIndexFileSizeMB");

--- a/src/services/textindex/textindexdbus.cpp
+++ b/src/services/textindex/textindexdbus.cpp
@@ -96,6 +96,7 @@ void TextIndexDBusPrivate::handleSlientStart()
         fmInfo() << "TextIndexDBus: Starting silent index task for:" << pathsToProcess;
 
         if (q->IndexDatabaseExists()) {   // update
+            // TODO: update if ...
             taskManager->startTask(IndexTask::Type::Update, pathsToProcess, true);
         } else {   // create
             taskManager->startTask(IndexTask::Type::Create, pathsToProcess, true);

--- a/src/services/textindex/utils/indexutility.cpp
+++ b/src/services/textindex/utils/indexutility.cpp
@@ -20,8 +20,17 @@ namespace IndexUtility {
 
 bool isIndexWithAnything(const QString &path)
 {
-    if (!DFMSEARCH::Global::isFileNameIndexReadyForSearch())
-        return false;
+    auto status = DFMSEARCH::Global::fileNameIndexStatus();
+    if (!status.has_value()) {
+        fmWarning() << "Anything indexing is disabled";
+        return {};
+    }
+
+    const QString currentStatus = status.value();
+    if (currentStatus == "closed") {
+        fmWarning() << "Anything indexing is closed";
+        return {};
+    }
 
     return isDefaultIndexedDirectory(path);
 }
@@ -343,12 +352,12 @@ QStringList extractAncestorPaths(const QString &filePath)
         return ancestorPaths;
 
     QFileInfo fileInfo(filePath);
-    QString currentPath = fileInfo.path(); // 初始为文件所在的目录路径
+    QString currentPath = fileInfo.path();   // 初始为文件所在的目录路径
 
     // 循环向上获取所有父目录，直到根目录
     while (currentPath != "/" && !currentPath.isEmpty()) {
         ancestorPaths.append(currentPath);
-        currentPath = QFileInfo(currentPath).path(); // 获取父目录
+        currentPath = QFileInfo(currentPath).path();   // 获取父目录
     }
 
     // 如果文件路径是根目录下的文件，确保包括根目录

--- a/src/services/textindex/utils/textindexconfig.cpp
+++ b/src/services/textindex/utils/textindexconfig.cpp
@@ -60,6 +60,19 @@ void TextIndexConfig::loadAllConfigs()
         m_autoIndexUpdateInterval = DEFAULT_AUTO_INDEX_UPDATE_INTERVAL;
     }
 
+    // Monitoring Start Delay (FSEventController monitoring start delay)
+    m_monitoringStartDelaySeconds = m_dconfigManager->value(
+                                                            Defines::DConf::kTextIndexSchema,
+                                                            Defines::DConf::kMonitoringStartDelaySeconds,
+                                                            DEFAULT_MONITORING_START_DELAY_SECONDS)
+                                            .toInt();
+    // Validate monitoringStartDelaySeconds
+    if (m_monitoringStartDelaySeconds < 0 || m_monitoringStartDelaySeconds > 3600) {
+        fmWarning() << "TextIndexConfig: Invalid monitoringStartDelaySeconds value:" << m_monitoringStartDelaySeconds
+                    << ", using default:" << DEFAULT_MONITORING_START_DELAY_SECONDS;
+        m_monitoringStartDelaySeconds = DEFAULT_MONITORING_START_DELAY_SECONDS;
+    }
+
     // Silent Index Update Delay (FSEventController first start delay)
     m_silentIndexUpdateDelay = m_dconfigManager->value(
                                                        Defines::DConf::kTextIndexSchema,
@@ -181,6 +194,12 @@ int TextIndexConfig::autoIndexUpdateInterval() const
 {
     QMutexLocker locker(&m_mutex);
     return m_autoIndexUpdateInterval;
+}
+
+int TextIndexConfig::monitoringStartDelaySeconds() const
+{
+    QMutexLocker locker(&m_mutex);
+    return m_monitoringStartDelaySeconds;
 }
 
 int TextIndexConfig::silentIndexUpdateDelay() const

--- a/src/services/textindex/utils/textindexconfig.h
+++ b/src/services/textindex/utils/textindexconfig.h
@@ -25,6 +25,7 @@ public:
 
     // Getter methods for each configuration
     int autoIndexUpdateInterval() const;
+    int monitoringStartDelaySeconds() const;
     int silentIndexUpdateDelay() const;
     qint64 inotifyResourceCleanupDelayMs() const;
     int maxIndexFileSizeMB() const;
@@ -53,6 +54,7 @@ private:
 
     // Member variables to store the loaded configuration values
     int m_autoIndexUpdateInterval;
+    int m_monitoringStartDelaySeconds;
     int m_silentIndexUpdateDelay;
     qint64 m_inotifyResourceCleanupDelayMs;
     int m_maxIndexFileSizeMB;
@@ -68,6 +70,7 @@ private:
 
     // Default values (matching your JSON for robustness)
     static const int DEFAULT_AUTO_INDEX_UPDATE_INTERVAL = 3;
+    static const int DEFAULT_MONITORING_START_DELAY_SECONDS = 3;
     static const int DEFAULT_SILENT_INDEX_UPDATE_DELAY = 180;
     static const qint64 DEFAULT_INOTIFY_RESOURCE_CLEANUP_DELAY = 1800000LL;   // 30 * 60 * 1000
     static const int DEFAULT_MAX_INDEX_FILE_SIZE_MB = 50;


### PR DESCRIPTION
Added separate delay configuration for file system monitoring startup and silent index scanning. Previously both operations used the same delay timer, which caused monitoring to be delayed unnecessarily during silent scans. Now monitoring starts quickly (3 seconds by default) while silent scanning maintains its longer delay (180 seconds by default) to avoid performance impact during system startup.

Key changes:
1. Added new configuration option "monitoringStartDelaySeconds" with default value of 3 seconds
2. Split single start timer into two separate timers: monitoringStartTimer and silentStartTimer
3. Monitoring now starts immediately or after short delay, while silent scanning uses longer delay
4. Updated configuration handling to support both delay parameters independently
5. Improved status checking logic for fast directory scanning

Log: Added separate delay controls for file monitoring and silent indexing

Influence:
1. Test file system monitoring startup behavior with different delay settings
2. Verify that monitoring starts quickly after enabling while silent scanning remains delayed
3. Test configuration changes for both delay parameters
4. Verify that fast directory scanning works correctly with new status checks
5. Test system performance during startup with separate delay controls

refactor: 分离监控和静默扫描的延迟设置

为文件系统监控启动和静默索引扫描添加了独立的延迟配置。之前两个操作使用相
同的延迟计时器，导致在静默扫描期间监控被不必要地延迟。现在监控可以快速启
动（默认3秒），而静默扫描保持较长的延迟（默认180秒），以避免在系统启动期
间影响性能。

主要变更：
1. 新增配置选项"monitoringStartDelaySeconds"，默认值为3秒
2. 将单个启动计时器拆分为两个独立计时器：monitoringStartTimer和 silentStartTimer
3. 监控现在立即启动或经过短暂延迟后启动，而静默扫描使用较长的延迟
4. 更新配置处理以独立支持两个延迟参数
5. 改进了快速目录扫描的状态检查逻辑

Log: 新增文件监控和静默索引的独立延迟控制

Influence:
1. 测试不同延迟设置下的文件系统监控启动行为
2. 验证启用后监控快速启动而静默扫描保持延迟
3. 测试两个延迟参数的配置变更
4. 验证快速目录扫描与新状态检查的兼容性
5. 测试分离延迟控制下的系统启动性能