### PR TITLE
refactor: reorganize disk encrypt plugin and improve DBus reliability

### DIFF
--- a/debian/dde-file-manager.install
+++ b/debian/dde-file-manager.install
@@ -26,6 +26,7 @@ usr/share/deepin-debug-config/deepin-debug-config.d/*.json
 usr/share/mime/packages/dtk-dci.xml
 usr/lib/systemd/user/
 usr/lib/systemd/system/
+usr/lib/tmpfiles.d/
 usr/share/polkit-1/rules.d/*.rules
 etc/X11/Xsession.d/99dfm-dlnfs-automount
 etc/deepin/dde-file-manager/dfm-dlnfs-automount

--- a/include/dfm-base/dfm_plugin_defines.h
+++ b/include/dfm-base/dfm_plugin_defines.h
@@ -27,7 +27,7 @@ inline constexpr std::initializer_list<const char *> kCommonVirtual {
 inline constexpr std::initializer_list<const char *> kFileManager {
     "dfmplugin-core", "dfmplugin-optical", "dfmplugin-computer",
     "dfmplugin-detailspace", "dfmplugin-sidebar", "dfmplugin-titlebar",
-    "dfmplugin-workspace", "dfmplugin-smbbrowser", "dfmplugin-disk-encrypt"
+    "dfmplugin-workspace", "dfmplugin-smbbrowser"
 };
 
 inline constexpr std::initializer_list<const char *> kDesktop {
@@ -42,7 +42,8 @@ inline constexpr std::initializer_list<const char *> kCommon {
 };
 inline constexpr std::initializer_list<const char *> kFileManager {
     "dfmplugin-trash", "dfmplugin-recent", "dfmplugin-avfsbrowser",
-    "dfmplugin-search", "dfmplugin-myshares", "dfmplugin-vault"
+    "dfmplugin-search", "dfmplugin-myshares", "dfmplugin-vault",
+    "dfmplugin-disk-encrypt"
 };
 
 inline constexpr std::initializer_list<const char *> kDesktop {

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -88,10 +88,11 @@ void EventsHandler::hookEvents()
  */
 bool EventsHandler::isTaskWorking()
 {
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    if (!iface.isValid()) {
+        fmWarning() << "Failed to create DBus interface for IsTaskRunning, service may be unavailable";
+        return false;
+    }
     QDBusReply<bool> reply = iface.call("IsTaskRunning");
     return reply.isValid() && reply.value();
 }
@@ -102,20 +103,22 @@ bool EventsHandler::isTaskWorking()
  */
 bool EventsHandler::hasPendingTask()
 {
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    if (!iface.isValid()) {
+        fmWarning() << "Failed to create DBus interface for IsTaskEmpty, service may be unavailable";
+        return false;
+    }
     QDBusReply<bool> reply = iface.call("IsTaskEmpty");
     return reply.isValid() && !reply.value();
 }
 
 QString EventsHandler::unfinishedDecryptJob()
 {
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    if (!iface.isValid()) {
+        fmWarning() << "Failed to create DBus interface for PendingDecryptionDevice, service may be unavailable";
+        return QString();
+    }
     QDBusReply<QString> reply = iface.call("PendingDecryptionDevice");
     return reply.value();
 }
@@ -134,10 +137,11 @@ bool EventsHandler::isUnderOperating(const QString &device)
 
 int EventsHandler::deviceEncryptStatus(const QString &device)
 {
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    if (!iface.isValid()) {
+        fmWarning() << "Failed to create DBus interface for DeviceStatus, service may be unavailable";
+        return -1;
+    }
     QDBusReply<int> reply = iface.call("DeviceStatus", device);
     if (reply.isValid())
         return reply.value();
@@ -156,10 +160,11 @@ void EventsHandler::resumeEncrypt(const QString &device)
 
 QString EventsHandler::holderDevice(const QString &device)
 {
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    if (!iface.isValid()) {
+        fmWarning() << "Failed to create DBus interface for HolderDevice, service may be unavailable, using original device";
+        return device;
+    }
     QDBusReply<QString> reply = iface.call("HolderDevice", device);
     if (reply.isValid())
         return reply.value();
@@ -315,10 +320,11 @@ void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
 void EventsHandler::ignoreParamRequest()
 {
     fmDebug() << "Ignoring parameter request";
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    if (!iface.isValid()) {
+        fmWarning() << "Failed to create DBus interface for IgnoreAuthSetup, service may be unavailable";
+        return;
+    }
     iface.asyncCall("IgnoreAuthSetup");
     fmInfo() << "Parameter request ignored";
 }

--- a/src/services/diskencrypt/CMakeLists.txt
+++ b/src/services/diskencrypt/CMakeLists.txt
@@ -24,6 +24,7 @@ install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_NAME}.json DESTINATION share/deepin-service-manager/other/)
 install(FILES org.deepin.filemanager.diskencrypt.conf DESTINATION share/dbus-1/system.d/)
 install(FILES deepin-filemanager-diskencrypt.service DESTINATION lib/systemd/system/)
+install(FILES deepin-diskencrypt-tmpfiles.conf DESTINATION lib/tmpfiles.d/)
 install(FILES org.deepin.Filemanager.DiskEncrypt.service DESTINATION share/dbus-1/system-services)
 install(FILES ${CMAKE_SOURCE_DIR}/assets/rules/99-dfm-encrypt.rules DESTINATION /etc/udev/rules.d)
 

--- a/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
+++ b/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# tmpfiles.d configuration for deepin-diskencrypt-service
+# This ensures required directories exist before service starts
+
+# Type Path                            Mode UID  GID  Age Argument
+d     /etc/usec-crypt                   0755 root root -   -
+d     /boot/usec-crypt                  0755 root root -   -
+d     /usr/local/share/applications     0755 root root -   -


### PR DESCRIPTION
Moved disk-encrypt plugin from kFileManager to kCommon category in plugin definitions to better organize plugin dependencies. Enhanced DBus interface reliability by adding timeout settings (2 seconds) and validity checks for all DBus calls. Improved error handling with detailed warning messages when DBus services are unavailable. Restructured code for better readability by removing redundant if-else blocks and standardizing error handling patterns.

Log: Improved disk encryption plugin stability and error reporting

Influence:
1. Test disk encryption operations with available and unavailable DBus services
2. Verify timeout handling for DBus calls under high system load
3. Check error messages when encryption services are not running
4. Test plugin loading and functionality after category reorganization
5. Validate all encryption operations (encrypt, decrypt, change passphrase) work correctly
6. Verify TPM-related functions with available and unavailable TPM services

refactor: 重新组织磁盘加密插件并提升 DBus 可靠性

将磁盘加密插件从 kFileManager 类别移至 kCommon 类别，以更好地组织插件依
赖关系。通过为所有 DBus 调用添加超时设置（2秒）和有效性检查，提升了 DBus
接口的可靠性。改进了错误处理机制，当 DBus 服务不可用时提供详细的警告信
息。通过移除冗余的 if-else 块和标准化错误处理模式，重构了代码以提高可
读性。

Log: 提升磁盘加密插件稳定性和错误报告能力

Influence:
1. 测试 DBus 服务可用和不可用时的磁盘加密操作
2. 验证高系统负载下 DBus 调用的超时处理
3. 检查加密服务未运行时的错误消息显示
4. 测试类别重组后的插件加载和功能
5. 验证所有加密操作（加密、解密、修改密码）正常工作
6. 测试 TPM 服务可用和不可用时的 TPM 相关功能

## Summary by Sourcery

Improve disk encryption plugin robustness and reorganize its plugin category definitions.

Enhancements:
- Add DBus interface validity checks and 2-second timeouts across disk encryption, TPM utilities, and event handling to avoid blocking when services are unavailable.
- Improve logging and error messages for DBus and TPM-related operations to provide clearer diagnostics when services or tasks are unavailable or fail.
- Refine disk encryption passphrase-change flow and related code paths for clearer, more consistent control flow and resource handling.
- Reorganize dfmplugin-disk-encrypt into the common plugin category definitions to better align plugin dependencies.