### PR TITLE
fix: prevent file descriptor leak in image preview widget

### DIFF
--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewwidget.cpp
@@ -25,18 +25,11 @@ ImagePreviewWidget::~ImagePreviewWidget()
 
 void ImagePreviewWidget::setPixmap(const QPixmap &pixmap)
 {
-    // Avoid flicker with static pixmap if an animated image is running
-    if (m_hasAnimatedImage && m_movie && m_movie->state() == QMovie::Running) {
-        return;
-    }
+    // Stop and release any animated image resources before switching to static pixmap
+    stopAnimatedImage();
 
     m_pixmap = pixmap;
     update();
-
-    // If there is an animated image and it's not running, start it now
-    if (m_hasAnimatedImage && m_movie && m_movie->state() != QMovie::Running) {
-        m_movie->start();
-    }
 }
 
 QPixmap ImagePreviewWidget::pixmap() const
@@ -68,6 +61,7 @@ void ImagePreviewWidget::stopAnimatedImage()
 {
     if (m_hasAnimatedImage && m_movie) {
         m_movie->stop();
+        m_movie->setFileName("");  // Release file descriptor to allow device unmounting
         m_hasAnimatedImage = false;
     }
 }


### PR DESCRIPTION
1. Modified setPixmap method to always stop animated images before setting static pixmaps
2. Added file descriptor release by setting empty filename in stopAnimatedImage method
3. Removed redundant state checks and simplified the logic flow

The previous implementation had a race condition where animated images could continue running when switching to static images, causing file descriptors to remain open. This prevented proper device unmounting when previewing images from removable media. The fix ensures animated images are properly stopped and their file descriptors released before any pixmap changes.

Log: Fixed issue where removable devices couldn't be safely ejected after previewing animated images

Influence:
1. Test previewing animated GIFs and switching to static images
2. Verify that removable media can be safely ejected after image preview
3. Check that static image display works correctly after animated images
4. Test various image format transitions to ensure no resource leaks
5. Verify animated image playback stops when switching images

fix: 修复图片预览控件中的文件描述符泄漏问题

1. 修改 setPixmap 方法，在设置静态图片前始终停止动画图片播放
2. 在 stopAnimatedImage 方法中添加文件描述符释放，通过设置空文件名
3. 移除冗余的状态检查并简化逻辑流程

之前的实现存在竞态条件，当切换到静态图片时动画图片可能继续运行，导致文件
描述符保持打开状态。这会在预览可移动媒体上的图片时阻止设备正常卸载。修复
确保在图片切换前正确停止动画图片并释放其文件描述符。

Log: 修复预览动画图片后无法安全弹出可移动设备的问题

Influence:
1. 测试预览动画 GIF 并切换到静态图片
2. 验证图片预览后可以安全弹出可移动媒体
3. 检查动画图片后静态图片显示是否正确
4. 测试各种图片格式转换以确保无资源泄漏
5. 验证切换图片时动画图片播放正确停止

## Summary by Sourcery

Ensure the image preview widget always stops animated images and releases their resources before displaying static pixmaps to prevent file descriptor leaks when switching images.

Bug Fixes:
- Fix a file descriptor leak caused by animated images continuing to run when switching to static pixmaps, which previously prevented safe unmounting of removable devices.

Enhancements:
- Simplify image preview widget state handling by centralizing animated image shutdown logic in stopAnimatedImage and removing redundant state checks.