### PR TITLE
feat: add index state tracking for crash recovery

### DIFF
--- a/src/services/textindex/service_textindex_global.h
+++ b/src/services/textindex/service_textindex_global.h
@@ -51,6 +51,9 @@ inline constexpr int kIndexVersion { 2 };
 // json
 inline const QString kVersionKey = QLatin1String("version");
 inline const QString kLastUpdateTimeKey = QLatin1String("lastUpdateTime");
+inline const QString kStateKey = QLatin1String("state");
+inline const QString kStateClean = QLatin1String("clean");
+inline const QString kStateDirty = QLatin1String("dirty");
 }   // namespace Defines
 
 DFM_LOG_USE_CATEGORY(SERVICETEXTINDEX_NAMESPACE)

--- a/src/services/textindex/task/taskmanager.h
+++ b/src/services/textindex/task/taskmanager.h
@@ -40,6 +40,7 @@ public:
     bool startFileMoveTask(const QHash<QString, QString> &movedFiles, bool silent = false);
 
     bool hasRunningTask() const;
+    bool hasQueuedTasks() const;
     void stopCurrentTask();
 
     std::optional<IndexTask::Type> currentTaskType() const;

--- a/src/services/textindex/utils/indexutility.h
+++ b/src/services/textindex/utils/indexutility.h
@@ -15,6 +15,33 @@ SERVICETEXTINDEX_BEGIN_NAMESPACE
 
 namespace IndexUtility {
 
+/**
+ * @brief Index state for crash recovery
+ */
+enum class IndexState {
+    Clean,    ///< Index is complete, last shutdown was clean with no pending tasks
+    Dirty,    ///< Index may be incomplete, needs global update on next start
+    Unknown   ///< State field not found (legacy status file or corrupted)
+};
+
+/**
+ * @brief Get current index state from status file
+ * @return IndexState value, returns Unknown if state field doesn't exist
+ */
+IndexState getIndexState();
+
+/**
+ * @brief Set index state in status file
+ * @param state The state to set
+ */
+void setIndexState(IndexState state);
+
+/**
+ * @brief Check if index is in clean state
+ * @return true if state is Clean, false otherwise
+ */
+bool isCleanState();
+
 bool isIndexWithAnything(const QString &path);
 bool isDefaultIndexedDirectory(const QString &path);
 bool isPathInContentIndexDirectory(const QString &path);


### PR DESCRIPTION
Added index state management to track whether indexing operations completed cleanly or were interrupted. This enables intelligent recovery on service restart by avoiding unnecessary global updates when the index was properly shut down.

1. Added IndexState enum with Clean, Dirty, and Unknown states
2. Implemented state persistence in index status file with JSON serialization
3. TaskManager now marks state as Dirty when starting tasks and Clean when all tasks complete successfully
4. TextIndexDBus checks state during silent startup to skip global updates for clean shutdowns
5. Added cleanup logic to mark state as Dirty if tasks are interrupted during service shutdown
6. Refactored status file handling to use shared helper functions

Log: Improved indexing service reliability with crash recovery mechanism

Influence:
1. Test service restart after clean shutdown - should skip global update
2. Test service restart after interrupted indexing - should trigger global update
3. Verify state persistence across service restarts
4. Test index creation when no database exists (should proceed normally)
5. Verify task queue management with multiple indexing operations
6. Test service shutdown during active indexing operations

feat: 添加索引状态跟踪以支持崩溃恢复

新增索引状态管理功能，用于跟踪索引操作是否正常完成或被中断。这使服务重启
时能够智能恢复，避免在索引正常关闭时执行不必要的全局更新。

1. 添加包含 Clean、Dirty 和 Unknown 状态的 IndexState 枚举
2. 在索引状态文件中实现状态持久化，使用 JSON 序列化
3. TaskManager 在启动任务时将状态标记为 Dirty，所有任务成功完成后标记 为 Clean
4. TextIndexDBus 在静默启动时检查状态，对于干净关闭跳过全局更新
5. 添加清理逻辑，在服务关闭时如果任务被中断则将状态标记为 Dirty
6. 重构状态文件处理以使用共享辅助函数

Log: 通过崩溃恢复机制提升索引服务可靠性

Influence:
1. 测试服务在干净关闭后重启 - 应跳过全局更新
2. 测试服务在索引中断后重启 - 应触发全局更新
3. 验证状态在服务重启间的持久性
4. 测试不存在数据库时的索引创建（应正常进行）
5. 验证多索引操作的任务队列管理
6. 测试在活跃索引操作期间的服务关闭

## Summary by Sourcery

Introduce persistent index state tracking to enable crash-aware recovery and avoid unnecessary global reindexing after clean shutdowns.

New Features:
- Add an IndexState enum and helper APIs to persist and query index cleanliness in the index status file.
- Use index state during silent startup to decide whether to run a global update or skip it when the index was cleanly shut down.

Enhancements:
- Refactor index status file handling to use shared JSON read/write helpers and extend the status schema with a state field.
- Update TaskManager to mark the index state as dirty when tasks start and clean when all queued tasks complete successfully.
- Extend service cleanup to detect unfinished indexing work and mark the index state as dirty for the next startup.