### PR TITLE
fix: adjust crumb bar layout and button width calculation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
@@ -136,7 +136,7 @@ void CrumbBarPrivate::initUI()
     // Crumb Bar Layout
     crumbBarLayout = new QHBoxLayout(q);
     crumbBarLayout->addStretch(1);
-    crumbBarLayout->setContentsMargins(kItemMargin / 2, 3, kItemMargin / 2, 3);
+    crumbBarLayout->setContentsMargins(kItemMargin / 2, 3, kItemMargin * 2, 3);
     crumbBarLayout->setSpacing(0);
     q->setLayout(crumbBarLayout);
 
@@ -177,7 +177,8 @@ void CrumbBarPrivate::updateButtonVisibility()
         return;
     }
 
-    int availableWidth = q->width();
+    const auto &margins = crumbBarLayout->contentsMargins();
+    int availableWidth = q->width() - margins.left() - margins.right();
     QList<UrlPushButton *> buttonsToShow;
     availableWidth -= navButtons[0]->minimumWidth();
     buttonsToShow.append(navButtons[0]);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
@@ -32,6 +32,7 @@ static constexpr int kBorderWidth = 4;
 static constexpr int kFolderborderRectRadius { 6 };
 static constexpr int kFolderButtonRectRadius { 4 };
 static constexpr int kFolderButtonMinWidth { 40 };
+static constexpr int kFolderButtonMaxWidth { 200 };
 
 static QString getIconName(const CrumbData &c)
 {
@@ -588,6 +589,11 @@ void UrlPushButton::updateWidth()
         if (minWidth < kFolderButtonMinWidth)
             minWidth = kFolderButtonMinWidth;
         maxWidth = buttonSize;
+        if (maxWidth > kFolderButtonMaxWidth)
+            maxWidth = kFolderButtonMaxWidth;
+        // Ensure minWidth does not exceed maxWidth
+        if (minWidth > maxWidth)
+            minWidth = maxWidth;
     }
     if (oldMinWidth != minWidth) {
         setMinimumWidth(minWidth);


### PR DESCRIPTION
Fixed layout margin and button width calculation issues in the crumb
bar. Changed the right margin from kItemMargin/2 to kItemMargin*2 to
provide more space. Updated available width calculation to account for
layout margins when determining button visibility. Added maximum width
constraint (200px) to folder buttons and ensured minimum width doesn't
exceed maximum width to prevent layout issues.

Log: Fixed crumb bar layout spacing and button sizing issues

Influence:
1. Test crumb bar layout with various path lengths
2. Verify button visibility in different window sizes
3. Check button sizing with long folder names
4. Test navigation functionality remains intact
5. Verify layout margins appear correctly

fix: 调整面包屑栏布局和按钮宽度计算

修复了面包屑栏中的布局边距和按钮宽度计算问题。将右边距从 kItemMargin/2
改为 kItemMargin*2 以提供更多空间。更新了可用宽度计算，在确定按钮可见性
时考虑布局边距。为文件夹按钮添加了最大宽度限制（200px），并确保最小宽度
不超过最大宽度以防止布局问题。

Log: 修复面包屑栏布局间距和按钮大小问题

Influence:
1. 测试不同路径长度下的面包屑栏布局
2. 验证不同窗口大小下的按钮可见性
3. 检查长文件夹名时的按钮大小
4. 测试导航功能是否保持正常
5. 验证布局边距是否正确显示

BUG: https://pms.uniontech.com/bug-view-346337.html

## Summary by Sourcery

Adjust crumb bar layout margins and folder button sizing constraints to improve spacing and prevent layout issues.

Bug Fixes:
- Correct crumb bar available width calculation by accounting for layout margins when determining button visibility.
- Prevent folder buttons from exceeding a reasonable maximum width and ensure minimum width never surpasses the maximum to avoid visual glitches.

Enhancements:
- Increase right margin in the crumb bar layout to provide additional spacing around navigation elements.