### PR TITLE
fix: fix video content not switching when previewing multiple videos

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videowidget.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videowidget.cpp
@@ -41,7 +41,18 @@ QSize VideoWidget::sizeHint() const
 
 void VideoWidget::playFile(const QUrl &url)
 {
+    fmDebug() << "Video widget: playFile called with URL:" << url;
+
     videoUrl = url;
+
+    // If widget is already visible, play immediately to support file switching
+    // Otherwise, wait for showEvent to trigger playback (first-time display)
+    if (isVisible() && !url.isEmpty()) {
+        fmDebug() << "Video widget: widget is visible, playing video immediately";
+        play(videoUrl);
+    } else {
+        fmDebug() << "Video widget: widget not visible, deferring playback to showEvent";
+    }
 }
 
 void VideoWidget::mouseReleaseEvent(QMouseEvent *event)


### PR DESCRIPTION
The issue occurred when switching between video files in preview mode. The playFile() method was only storing the URL but not immediately playing it when the widget was already visible. This caused the video content to remain unchanged when switching between different video files.

The fix adds immediate playback when the widget is visible and a valid URL is provided. For initial display, playback is still deferred to showEvent() to maintain existing behavior. Added debug logging to help track playback behavior.

Log: Fixed issue where video preview content would not update when switching between different video files

Influence:
1. Test switching between different video files in preview mode
2. Verify video content updates correctly when switching files
3. Test initial video preview loading behavior
4. Check that playback still works correctly for first-time preview
5. Verify no regression in video playback functionality

fix: 修复预览多个视频时视频内容未切换的问题

问题出现在预览模式下切换视频文件时。playFile() 方法仅存储了 URL，但在部
件已可见时没有立即播放视频。这导致切换不同视频文件时视频内容保持不变。

修复方案是在部件可见且提供有效 URL 时立即播放视频。对于初始显示，播放仍
延迟到 showEvent() 以保持现有行为。添加了调试日志以帮助跟踪播放行为。

Log: 修复了在切换不同视频文件时视频预览内容不会更新的问题

Influence:
1. 测试预览模式下切换不同视频文件
2. 验证切换文件时视频内容正确更新
3. 测试初始视频预览加载行为
4. 检查首次预览时播放功能仍正常工作
5. 验证视频播放功能没有回归问题

## Summary by Sourcery

Ensure video preview updates correctly when switching between files in an already visible preview widget.

Bug Fixes:
- Fix video preview content not updating when switching between different video files while the preview widget is visible.

Enhancements:
- Add debug logging around video playback to trace URL handling and playback timing during preview.