### PR TITLE
feat: enhance restore failed dialog with detailed error information

### DIFF
--- a/include/dfm-base/interfaces/abstractjobhandler.h
+++ b/include/dfm-base/interfaces/abstractjobhandler.h
@@ -250,6 +250,7 @@ Q_SIGNALS:   // 发送给任务调用者使用的信号
      */
     void speedUpdatedNotify(const JobInfoPointer jobInfo);
     void requestShowTipsDialog(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType type, const QList<QUrl> list);
+    void requestShowFailedDialog(const QMap<QUrl, QString> &failedInfo);
     void workerFinish();
     void requestRemoveTaskWidget();
     void requestSaveRedoOperation(const QString &token, const qint64 deleteFirstFileSize);

--- a/src/dfm-base/interfaces/abstractjobhandler.cpp
+++ b/src/dfm-base/interfaces/abstractjobhandler.cpp
@@ -23,6 +23,8 @@ AbstractJobHandler::AbstractJobHandler(QObject *parent)
             break;
         }
     });
+
+    connect(this, &AbstractJobHandler::requestShowFailedDialog, DialogManagerInstance, &DialogManager::showOperationFailedDialog);
 }
 
 AbstractJobHandler::~AbstractJobHandler() {}

--- a/src/dfm-base/utils/dialogmanager.h
+++ b/src/dfm-base/utils/dialogmanager.h
@@ -66,6 +66,7 @@ public:
     int showNormalDeleteConfirmDialog(const QList<QUrl> &urls);
 
     void showRestoreFailedDialog(const int count);
+    void showOperationFailedDialog(const QMap<QUrl, QString> &failedInfo);
     int showRestoreDeleteFilesDialog(const QList<QUrl> &urlList);
 
     // rename

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.cpp
@@ -28,6 +28,7 @@ void AbstractJob::setJobArgs(const JobHandlePointer handle, const QList<QUrl> &s
     
     connect(handle.get(), &AbstractJobHandler::userAction, this, &AbstractJob::operateAation);
     connect(this, &AbstractJob::requestShowTipsDialog, handle.get(), &AbstractJobHandler::requestShowTipsDialog);
+    connect(this, &AbstractJob::requestShowFailedDialog, handle.get(), &AbstractJobHandler::requestShowFailedDialog);
 
     // 连接worker中的所有错误信号，转发给jobhandler
     connect(doWorker.data(), &AbstractWorker::errorNotify, this, &AbstractJob::handleError, Qt::QueuedConnection);
@@ -53,6 +54,7 @@ AbstractJob::AbstractJob(AbstractWorker *doWorker, QObject *parent)
         this->doWorker->moveToThread(&thread);
         connect(doWorker, &AbstractWorker::workerFinish, this, &AbstractJob::deleteLater);
         connect(doWorker, &AbstractWorker::requestShowTipsDialog, this, &AbstractJob::requestShowTipsDialog);
+        connect(doWorker, &AbstractWorker::requestShowFailedDialog, this, &AbstractJob::requestShowFailedDialog);
         connect(doWorker, &AbstractWorker::retryErrSuccess, this, &AbstractJob::handleRetryErrorSuccess, Qt::QueuedConnection);
         connect(doWorker, &AbstractWorker::fileAdded, this, &AbstractJob::handleFileAdded, Qt::QueuedConnection);
         connect(doWorker, &AbstractWorker::fileDeleted, this, &AbstractJob::handleFileDeleted, Qt::QueuedConnection);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.h
@@ -44,6 +44,7 @@ signals:   // 对线程协同的worker使用
     void errorNotify(const JobInfoPointer jobInfo);
 
     void requestShowTipsDialog(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType type, const QList<QUrl> list);
+    void requestShowFailedDialog(const QMap<QUrl, QString> &failedInfo);
 
 protected slots:
     void operateAation(AbstractJobHandler::SupportActions actions);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -94,6 +94,7 @@ signals:
     void removeTaskWidget();
 
     void requestShowTipsDialog(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType type, const QList<QUrl> &list);
+    void requestShowFailedDialog(const QMap<QUrl, QString> &failedInfo);
     void workerFinish();
     void requestSaveRedoOperation(const QString &token, const qint64 deleteFirstFileSize);
     void startWork();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -154,7 +154,7 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
     if (!allFilesList.empty())
         urlsSource = allFilesList;
 
-    QList<QUrl> failUrls;
+    QMap<QUrl, QString> failUrls;
     for (const auto &url : urlsSource) {
         if (!stateCheck())
             return false;
@@ -224,14 +224,14 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
                 break;
             }
             if (!trashSucc)
-                failUrls.append(url);
+                failUrls.insert(url, fileHandler.errorString());
         }
         handleSourceFiles.append(fileUrl);
     }
 
     if (failUrls.count() > 0) {
         fmWarning() << "Restore operation completed with failures - failed count:" << failUrls.count();
-        emit requestShowTipsDialog(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType::kRestoreFailed, failUrls);
+        emit requestShowFailedDialog(failUrls);
         return false;
     }
 


### PR DESCRIPTION
Changed the restore failed dialog to display detailed error information
for each file instead of just showing a count. The signal parameter
was changed from QList<QUrl> to QMap<QUrl, QString> to carry both file
URLs and their corresponding error messages. For single file failures,
it shows the specific error message. For multiple file failures, it
provides an expandable details view with a tree widget showing file
names and error reasons.

Log: Improved restore failure dialog to show detailed error information
per file

Influence:
1. Test restoring files to read-only directories to trigger the failure
dialog
2. Verify single file failure shows specific error message
3. Test multiple file failures to see expandable details view
4. Check that file names and error reasons are properly displayed in the
tree view
5. Verify the show/hide details functionality works correctly
6. Test dialog resizing behavior when expanding/collapsing details

feat: 增强恢复失败对话框显示详细错误信息

将恢复失败对话框改为显示每个文件的详细错误信息，而不仅仅是显示数量统计。
信号参数从 QList<QUrl> 改为 QMap<QUrl, QString> 以同时携带文件URL和对应
的错误消息。对于单个文件失败，显示具体的错误信息。对于多个文件失败，提供
可展开的详细信息视图，使用树形控件显示文件名和错误原因。

Log: 改进恢复失败对话框，显示每个文件的详细错误信息

Influence:
1. 测试恢复到只读目录以触发失败对话框
2. 验证单个文件失败显示具体错误信息
3. 测试多个文件失败查看可展开的详细信息视图
4. 检查文件名和错误原因在树形视图中的正确显示
5. 验证显示/隐藏详细信息功能正常工作
6. 测试展开/折叠详细信息时的对话框大小调整行为

BUG: https://pms.uniontech.com/bug-view-343271.html

## Summary by Sourcery

Enhance the restore-failed dialog to show per-file error details instead of a simple failure count.

New Features:
- Display specific error information for a single failed restore, including the file and its error message.
- Provide an expandable details view listing all failed files and their error reasons when multiple restores fail.

Enhancements:
- Propagate detailed restore failure information via a QMap of file URLs to error messages through job and worker APIs instead of a simple URL list.
- Improve the restore failure dialog UI with a tree view, tooltips, and dynamic show/hide details behavior for better readability of errors.