### PR TITLE
fix: improve text wrapping in key value label

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -226,7 +226,7 @@ RightValueWidget::RightValueWidget(QWidget *parent)
 {
     setReadOnly(true);
     setFrameShape(QFrame::NoFrame);
-    setWordWrapMode(QTextOption::WrapAnywhere);
+    setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     setContextMenuPolicy(Qt::CustomContextMenu);
 
     connect(this, &RightValueWidget::customContextMenuRequested, this, &RightValueWidget::customContextMenuEvent);


### PR DESCRIPTION
Change word wrapping mode from WrapAnywhere to
WrapAtWordBoundaryOrAnywhere for better readability This prevents text from being broken in the middle of words, making the content more user-friendly
The change ensures that text wraps at word boundaries when possible, improving the overall appearance

Log: Improved text wrapping in property labels to avoid breaking words

Influence:
1. Test displaying long text values in property dialogs
2. Verify text wraps correctly at word boundaries
3. Check that very long words without spaces still wrap appropriately
4. Test with different font sizes and window widths
5. Verify readability improvement in various scenarios

fix: 优化键值标签中的文本换行

将文本换行模式从任意位置换行改为在单词边界或任意位置换行，提高可读性
避免在单词中间断开文本，使内容更加用户友好
此更改确保文本尽可能在单词边界处换行，改善整体显示效果

Log: 优化属性标签中的文本换行，避免单词被截断

Influence:
1. 测试属性对话框中长文本值的显示
2. 验证文本是否在单词边界正确换行
3. 检查没有空格的长单词是否仍能适当换行
4. 测试不同字体大小和窗口宽度下的显示效果
5. 验证在各种场景下的可读性改进

Bug: https://pms.uniontech.com/bug-view-346457.html

## Summary by Sourcery

Bug Fixes:
- Prevent key-value label text from breaking in the middle of words by adjusting the word wrap mode.