### PR TITLE
fix: improve network device mount error handling

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -623,7 +623,7 @@ void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType
             DProtocolDevice::mountNetworkDevice(address, func, DeviceManagerPrivate::askForUserChoice,
                                                 wrappedCb, timeout);
         } else {
-            wrappedCb(false, Utils::genOperateErrorInfo(DeviceError::kUserErrorTimedOut), "");
+            wrappedCb(false, Utils::genOperateErrorInfo(DeviceError::kUserErrorFailed, tr("Unable to connect to %1").arg(host)), "");
             qCWarning(logDFMBase) << "cannot access network " << host << ":" << port;
         }
     });

--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -155,6 +155,10 @@ void DialogManager::showErrorDialogWhenOperateDeviceFailed(OperateType type, DFM
             errMsg = tr("Permission denied");
         else if (static_cast<int>(err.code) == ENOENT)
             errMsg = tr("No such file or directory");
+        else if (err.code == DeviceError::kUserErrorFailed
+                 || (err.code >= DeviceError::kGIOError
+                     && err.code <= DeviceError::kGIOErrorMessageTooLarge))
+            errMsg = err.message;
         else
             errMsg = tr("Authentication failed");
 


### PR DESCRIPTION
1. Enhanced error message when network device mount fails by providing
specific connection failure details instead of generic timeout message
2. Updated error dialog handling to display custom error messages for
DeviceError::kUserErrorFailed and GIO error range
3. Added proper error message propagation for GIO-related errors to show
actual error details to users

Log: Improved error messages for network device connection failures

Influence:
1. Test mounting network devices with invalid addresses to verify error
messages
2. Check error dialog displays when network connection fails
3. Verify GIO error messages are properly shown in error dialogs
4. Test various device operation failure scenarios to ensure appropriate
error messages

fix: 改进网络设备挂载错误处理

1. 当网络设备挂载失败时，提供具体的连接失败详情而非通用的超时错误信息
2. 更新错误对话框处理，为 DeviceError::kUserErrorFailed 和 GIO 错误范围
显示自定义错误消息
3. 为 GIO 相关错误添加正确的错误消息传播，向用户显示实际错误详情

Log: 改进了网络设备连接失败时的错误提示信息

Influence:
1. 测试使用无效地址挂载网络设备时的错误消息显示
2. 检查网络连接失败时错误对话框的显示
3. 验证 GIO 错误消息是否正确显示在错误对话框中
4. 测试各种设备操作失败场景，确保显示适当的错误消息

BUG: https://pms.uniontech.com/bug-view-344147.html

## Summary by Sourcery

Improve user-visible error reporting for network device mount failures and related device operation errors.

Bug Fixes:
- Return a specific connection failure error instead of a generic timeout when a network device cannot be accessed.
- Display backend-provided error messages for user-failed and GIO-related device errors in the error dialog.