### PR TITLE
feat: add remote image size limit for detail view

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.view.json
+++ b/assets/configs/org.deepin.dde.file-manager.view.json
@@ -89,6 +89,17 @@
             "description[zh_CN]": "用于配置文件管理器中的固定标签页。",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "dfm.detailview.remote.image.maxsize": {
+            "value": 31457280,
+            "serial": 0,
+            "flags": [],
+            "name": "Maximum image size for detail view on remote/optical devices",
+            "name[zh_CN]": "网络和光盘设备详细视图中图片原图加载的最大文件大小",
+            "description": "Maximum file size in bytes for loading original images in detail view when files are on remote mounts or optical devices. Files larger than this will skip to thumbnail loading. Default is 30MB (31457280 bytes).",
+            "description[zh_CN]": "当文件位于网络挂载或光盘设备时，详细视图中加载图片原图的最大文件大小（字节）。超过此大小的文件将跳过原图加载直接使用缩略图。默认为30MB（31457280字节）。",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
+++ b/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
@@ -24,6 +24,7 @@ inline constexpr char kDisplayPreviewVisibleKey[] { "dfm.displaypreview.visible"
 inline constexpr char kOpenFolderWindowsInASeparateProcess[] { "dfm.open.in.single.process" };
 inline constexpr char kCunstomFixedTabs[] { "dfm.custom.fixedtab" };
 inline constexpr char kPinnedTabs[] { "dfm.pinned.tabs" };
+inline constexpr char kDetailViewRemoteImageMaxSize[] { "dfm.detailview.remote.image.maxsize" };
 }   // namespace BaseConfig
 
 /*!

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.h
@@ -34,6 +34,7 @@ Q_SIGNALS:
 
 private:
     bool isImageMimeType(const QString &mimeType) const;
+    bool shouldSkipOriginalImageLoad(const QUrl &url, qint64 fileSize) const;
     QPixmap loadOriginalImage(const QString &filePath, const QSize &targetSize);
     QPixmap loadThumbnail(const QUrl &url, const QSize &targetSize);
 


### PR DESCRIPTION
Added a configurable file size limit for loading original images in detail view when files are on remote mounts or optical devices. This prevents performance issues when loading large images over network connections. The default limit is set to 30MB, and files exceeding this size will automatically use thumbnails instead of loading the full original image.

The implementation includes:
1. New DConfig setting for maximum file size
2. Detection of remote and optical device files
3. Size comparison logic to skip original image loading when appropriate
4. Logging for skipped files to aid debugging

Log: Added configurable file size limit for original image loading on remote/optical devices in detail view

Influence:
1. Test image preview in detail view for local files (should work as before)
2. Test image preview for remote files under 30MB (should load original)
3. Test image preview for remote files over 30MB (should use thumbnail)
4. Test image preview for optical device files with various sizes
5. Verify the DConfig setting can be modified and takes effect
6. Check logs to confirm skipped file loading when appropriate

feat: 为详细视图添加远程图片大小限制

添加了可配置的文件大小限制，用于在网络挂载或光盘设备上的文件在详细视图中
加载图片原图。这可以防止通过网络连接加载大图片时的性能问题。默认限制设置
为30MB，超过此大小的文件将自动使用缩略图而不是加载完整的原图。

实现包括：
1. 新的DConfig设置用于最大文件大小
2. 远程和光盘设备文件的检测
3. 适当情况下跳过原图加载的大小比较逻辑
4. 跳过文件加载的日志记录以帮助调试

Log: 在详细视图中为远程/光盘设备上的图片原图加载添加了可配置的文件大小
限制

Influence:
1. 测试本地文件的详细视图图片预览（应保持原有行为）
2. 测试小于30MB的远程文件图片预览（应加载原图）
3. 测试大于30MB的远程文件图片预览（应使用缩略图）
4. 测试不同大小的光盘设备文件图片预览
5. 验证DConfig设置可以修改并生效
6. 检查日志确认适当情况下跳过文件加载

## Summary by Sourcery

Add a configurable size-based limit for loading original images from remote or optical devices in the detail view to improve performance and fall back to thumbnails when appropriate.

New Features:
- Introduce a DConfig option to define the maximum allowed file size for original image loading in detail view for remote and optical device files.

Enhancements:
- Update image preview logic to skip loading original images for oversized remote or optical files and fall back to thumbnails, with logging for skipped loads.