### PR TITLE
fix: [vault] hide reset password option for transparent encryption

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
@@ -264,7 +264,12 @@ DMenu *VaultHelper::createMenu()
         menu->addAction(QObject::tr("Unlock"), VaultHelper::instance(), &VaultHelper::unlockVaultDialog);
         menu->addSeparator();
         if (OperatorCenter::getInstance()->isNewVaultVersion()) {
-            menu->addAction(QObject::tr("Reset Password"), VaultHelper::instance(), &VaultHelper::showResetPasswordDialog);
+            VaultConfig config;
+            QString encryptionMethod = config.get(kConfigNodeName, kConfigKeyEncryptionMethod, QVariant(kConfigKeyNotExist)).toString();
+            // 重置密码功能仅在新版本且非透明加密时提供
+            if (encryptionMethod != QString(kConfigValueMethodTransparent)) {
+                menu->addAction(QObject::tr("Reset Password"), VaultHelper::instance(), &VaultHelper::showResetPasswordDialog);
+            }
         }
         break;
     case VaultState::kUnlocked: {
@@ -328,7 +333,9 @@ DMenu *VaultHelper::createMenu()
             fmDebug() << "Vault: Auto-lock menu items added";
         }
 
-        if (OperatorCenter::getInstance()->isNewVaultVersion()) {
+        // 重置密码功能仅在新版本且非透明加密时提供
+        if (OperatorCenter::getInstance()->isNewVaultVersion()
+            && encryptionMethod != QString(kConfigValueMethodTransparent)) {
             menu->addAction(QObject::tr("Reset Password"), VaultHelper::instance(), &VaultHelper::showResetPasswordDialog);
         }
         menu->addAction(QObject::tr("Delete File Vault"), VaultHelper::instance(), &VaultHelper::showRemoveVaultDialog);


### PR DESCRIPTION
Add check to disable reset password functionality when vault uses transparent encryption mode, similar to the existing check for old vault versions.

Log: as title

Bug: https://pms.uniontech.com/bug-view-346591.html

## Summary by Sourcery

Bug Fixes:
- Prevent offering the reset password action for vaults configured with transparent encryption, aligning the UI with supported functionality.