### PR TITLE
fix: support pinning computer virtual directory

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -781,7 +781,8 @@ bool TabBarPrivate::canPinned(int index)
     if (UrlRoute::isVirtual(url)) {
         static QStringList supportedSchemes {
             Global::Scheme::kRecent,
-            Global::Scheme::kTrash
+            Global::Scheme::kTrash,
+            Global::Scheme::kComputer
         };
         return supportedSchemes.contains(url.scheme());
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -132,10 +132,12 @@ void TitleBarWidget::openPinnedTabs()
             continue;
         }
 
-        auto info = InfoFactory::create<FileInfo>(url);
-        if (!info || !info->exists()) {
-            fmWarning() << "The file is not exists, skipping:" << tabData;
-            continue;
+        if (!(UrlRoute::isVirtual(url) && UrlRoute::isRootUrl(url))) {
+            auto info = InfoFactory::create<FileInfo>(url);
+            if (!info || !info->exists()) {
+                fmWarning() << "The file is not exists, skipping:" << tabData;
+                continue;
+            }
         }
 
         validPinnedTabs << pinnedTabs[i];


### PR DESCRIPTION
Added support for pinning the computer virtual directory by including
it in the list of supported schemes for tab pinning. Also fixed an
issue where virtual root URLs were incorrectly checked for existence
during pinned tab restoration, which caused the computer directory to be
skipped when opening pinned tabs.

The computer scheme was missing from the supported virtual schemes list,
preventing users from pinning the computer directory. Additionally, the
existence check for virtual root URLs was unnecessary since these are
system-level virtual directories that always exist.

Log: Fixed computer directory pinning functionality

Influence:
1. Test pinning the computer directory from the tab bar
2. Verify that pinned computer tabs open correctly on application
startup
3. Check that other virtual directories (recent, trash) still work as
expected
4. Ensure regular file paths still undergo proper existence validation

fix: 支持固定计算机虚拟目录

将计算机虚拟目录添加到支持固定标签页的方案列表中，从而支持固定计算机目
录。同时修复了在恢复固定标签页时对虚拟根URL进行不必要存在性检查的问题，
该问题导致计算机目录在打开固定标签页时被跳过。

计算机方案之前不在支持的虚拟方案列表中，导致用户无法固定计算机目录。此
外，对虚拟根URL的存在性检查是不必要的，因为这些是系统级虚拟目录，始终
存在。

Log: 修复计算机目录固定功能

Influence:
1. 测试从标签栏固定计算机目录的功能
2. 验证应用程序启动时固定的计算机标签页能否正确打开
3. 检查其他虚拟目录（最近使用、回收站）是否仍正常工作
4. 确保常规文件路径仍进行正确的存在性验证

BUG: https://pms.uniontech.com/bug-view-346539.html

## Summary by Sourcery

Support pinning the computer virtual directory and avoid unnecessary existence checks for virtual root URLs when restoring pinned tabs.

New Features:
- Allow the computer virtual directory to be pinned as a tab alongside other supported virtual locations.

Bug Fixes:
- Prevent virtual root URLs such as the computer directory from being incorrectly skipped during pinned tab restoration by bypassing file existence checks for them.