### PR TITLE
fix: prevent incorrect tab closure when path is subdirectory

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -209,6 +209,9 @@ bool TabBarPrivate::tabCloseable(const Tab &tab, const QUrl &targetUrl) const
         if (!realCurrentPath.isEmpty() && !realTargetPath.isEmpty()) {
             if (realCurrentPath == realTargetPath)
                 return true;
+
+            if (!realTargetPath.endsWith('/'))
+                realTargetPath.append('/');
             if (realCurrentPath.startsWith(realTargetPath))
                 return true;
         }


### PR DESCRIPTION
Fixed an issue where tabs could not be closed properly when the current
directory was a subdirectory of the target directory. The problem
occurred because the path comparison logic didn't account for cases
where the target path might not end with a trailing slash. Added a check
to ensure the target path always ends with '/' before performing the
startsWith comparison, which ensures proper subdirectory detection.

Influence:
1. Test tab closure when current directory is a subdirectory of target
directory
2. Verify tab closure behavior with paths that don't end with '/'
3. Test normal tab closure scenarios to ensure no regression
4. Check path comparison logic with various directory structures

fix: 修复路径为子目录时标签页无法正确关闭的问题

修复了当当前目录是目标目录的子目录时标签页无法正确关闭的问题。问题的原
因是路径比较逻辑没有处理目标路径可能不以斜杠结尾的情况。添加了检查以确保
在执行 startsWith 比较之前目标路径始终以 '/' 结尾，从而确保正确的子目录
检测。

Influence:
1. 测试当当前目录是目标目录子目录时的标签页关闭功能
2. 验证路径不以 '/' 结尾时的标签页关闭行为
3. 测试正常标签页关闭场景以确保没有回归问题
4. 检查各种目录结构下的路径比较逻辑

BUG: https://pms.uniontech.com/bug-view-346655.html

## Summary by Sourcery

Bug Fixes:
- Ensure path comparison for tab closability normalizes target directory paths so subdirectory tabs can be closed correctly.