### PR TITLE
fix: handle temporary file replacement in organizer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+dde-file-manager (6.5.114) unstable; urgency=medium
+
+  * fix: add dynamic thumbnail update for image preview
+  * chore: update translations
+  * fix: fix video content not switching when previewing multiple videos
+  * fix: improve text wrapping in key value label
+  * feat: add remote image size limit for detail view
+  * fix: handle temporary file replacement in organizer
+  * fix: improve network device mount error handling
+  * feat: add operation failure dialog with detailed error display
+  * fix: optimize tab bar event handling logic
+  * fix: support pinning computer virtual directory
+  * fix: prevent incorrect tab closure when path is subdirectory
+  * chore(diskencrypt): comment out security restrictions in service file
+  * fix: [vault] hide reset password option for transparent encryption
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 06 Jan 2026 17:12:40 +0800
+
 dde-file-manager (6.5.113) unstable; urgency=medium
 
   * fix(delegate): add file icon fallback when thumbnail rendering fails

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalized/type/typeclassifier.cpp
@@ -236,8 +236,15 @@ bool TypeClassifier::acceptRename(const QUrl &oldUrl, const QUrl &newUrl)
     for (auto base : baseData())
         collected.append(base->items);
     if (collected.contains(newUrl)) {
-        // if the newUrl existed in collections, means new file replaced the old file.
-        // remove it from collection
+        if (!collected.contains(oldUrl)) {
+            // oldUrl not in collection (e.g., temporary file .EmvVrz), newUrl in collection
+            // This is a file content replacement (save operation), not file overwrite
+            // Keep the file in collection without removing it
+            return true;
+        }
+        // Both oldUrl and newUrl are in collection
+        // This is a real file overwrite scenario (e.g., mv a.txt b.txt, both exist)
+        // Remove newUrl before processing the rename
         remove(newUrl);
         return true;
     } else if (collected.contains(oldUrl)) {

--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -1056,12 +1056,25 @@ bool NormalizedMode::filterDataRenamed(const QUrl &oldUrl, const QUrl &newUrl)
         return d->classifier->acceptRename(oldUrl, newUrl);
 
     QString oldType = d->classifier->key(oldUrl);
-    if (oldType.isEmpty())   // old item is not in collection.
+    if (oldType.isEmpty()) {
+        // oldUrl is not in any collection
+        // Check if newUrl is in collection (temporary file replacement scenario)
+        QString newType = d->classifier->key(newUrl);
+        if (!newType.isEmpty()) {
+            // newUrl is in collection, this is a temporary file replacement (save operation)
+            // File should remain in collection, canvas should not take over
+            return true;
+        }
+        // Neither oldUrl nor newUrl is in collection
         return false;
+    }
 
+    // oldUrl is in collection
     QString newType = d->classifier->classify(newUrl);
-    if (newType != oldType)   // the renamed result should be placed on desktop not in collection
+    if (newType != oldType) {
+        // Type changed, file should be moved to canvas
         return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
Improved file rename handling to distinguish between actual file overwrites and temporary file replacements during save operations. The previous logic incorrectly removed files from collections when temporary files (like .EmvVrz) were used during save operations, mistaking them for real file overwrites.

Key changes:
1. Added special case handling for temporary file replacements where oldUrl is not in collection but newUrl is
2. Enhanced logic to differentiate between file save operations and actual file moves/renames
3. Improved type checking consistency in rename filtering

Log: Fixed issue where files were incorrectly removed from collections during save operations

Influence:
1. Test file save operations with various applications to ensure files remain in collections
2. Verify file renaming between different types works correctly (files should move to canvas)
3. Test actual file overwrite scenarios where both files exist in collection
4. Check temporary file handling with common applications like text editors
5. Verify collection integrity after multiple save/rename operations

fix: 修复整理器中临时文件替换处理问题

改进了文件重命名处理逻辑，能够区分实际的文件覆盖和在保存操作中的临时文件
替换。之前的逻辑在保存操作中使用临时文件（如 .EmvVrz）时错误地将文件从集
合中移除，误认为它们是真实的文件覆盖。

主要更改：
1. 为临时文件替换添加特殊处理情况，当 oldUrl 不在集合中但 newUrl 在集合 中时
2. 增强逻辑以区分文件保存操作和实际的文件移动/重命名
3. 改进了重命名过滤中的类型检查一致性

Log: 修复了在保存操作期间文件被错误地从集合中移除的问题

Influence:
1. 测试各种应用程序的文件保存操作，确保文件保留在集合中
2. 验证在不同类型之间重命名文件的功能正常（文件应移动到画布）
3. 测试实际的文件覆盖场景，其中两个文件都存在于集合中
4. 检查常见应用程序（如文本编辑器）的临时文件处理
5. 验证多次保存/重命名操作后的集合完整性

Bug: https://pms.uniontech.com/bug-view-345117.html

## Summary by Sourcery

Adjust organizer rename handling to correctly treat temporary save-file replacements without disrupting collection membership.

Bug Fixes:
- Prevent files from being incorrectly removed from collections when applications use temporary files during save operations.
- Ensure collection items are only moved to the canvas when a rename actually changes the file’s classified type.
- Fix misclassification of overwrite scenarios where both old and new URLs are already in collections, keeping genuine overwrites consistent.