### PR TITLE
fix bugs

### DIFF
--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.cpp
@@ -14,6 +14,8 @@
 #ifdef DTKWIDGET_CLASS_DSizeMode
 #    include <DSizeMode>
 #endif
+#include <DGuiApplicationHelper>
+#include <DPalette>
 
 static constexpr int kMaxShowRowNum { 4 };
 static constexpr char kSelectAllName[] { "select-all" };
@@ -194,6 +196,12 @@ void KeyValueLabel::setLeftFontSizeWeight(DFontSizeManager::SizeType sizeType, Q
 void KeyValueLabel::setRightFontSizeWeight(DFontSizeManager::SizeType sizeType, QFont::Weight fontWeight, DPalette::ColorType foregroundRole)
 {
     DFontSizeManager::instance()->bind(rightValueEdit, sizeType, fontWeight);
+
+    // Set text color for QTextEdit (different from DLabel's setForegroundRole)
+    if (foregroundRole != DPalette::NoType) {
+        DPalette palette = DGuiApplicationHelper::instance()->applicationPalette();
+        rightValueEdit->setTextColor(palette.color(foregroundRole));
+    }
 }
 
 QString KeyValueLabel::LeftValue()
@@ -228,6 +236,10 @@ RightValueWidget::RightValueWidget(QWidget *parent)
     setFrameShape(QFrame::NoFrame);
     setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     setContextMenuPolicy(Qt::CustomContextMenu);
+
+    // Force normal text color to prevent grayed-out appearance in read-only state
+    DPalette palette = DGuiApplicationHelper::instance()->applicationPalette();
+    setTextColor(palette.color(DPalette::Text));
 
     connect(this, &RightValueWidget::customContextMenuRequested, this, &RightValueWidget::customContextMenuEvent);
 }

--- a/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h
+++ b/src/dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h
@@ -24,14 +24,19 @@ class RightValueWidget : public QTextEdit
 public:
     explicit RightValueWidget(QWidget *parent = nullptr);
     void setCompleteText(const QString &text);
+    void setForegroundRole(DPalette::ColorType role);
 
 protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
     void showEvent(QShowEvent *event) override;
     void focusOutEvent(QFocusEvent *e) override;
+    void changeEvent(QEvent *event) override;
 
 private Q_SLOTS:
     void customContextMenuEvent(const QPoint &pos);
+
+private:
+    void updateTextPalette();
 
 Q_SIGNALS:
     void clicked();
@@ -39,6 +44,7 @@ Q_SIGNALS:
 private:
     QString completeText;
     bool isContextMenuShow { false };
+    DPalette::ColorType currentforegroundRole = DPalette::NoType;
 };
 
 class KeyValueLabel : public QFrame

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -7,6 +7,7 @@
 #include "dialogs/connecttoserverdialog.h"
 #include "dialogs/diskpasswordchangingdialog.h"
 #include "views/titlebarwidget.h"
+#include "utils/optionbuttonmanager.h"
 
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.h>
@@ -20,6 +21,7 @@
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -30,6 +32,8 @@
 
 using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
+using namespace GlobalDConfDefines::ConfigPath;
+using namespace GlobalDConfDefines::BaseConfig;
 
 QMap<quint64, TitleBarWidget *> TitleBarHelper::kTitleBarMap {};
 QList<QString> TitleBarHelper::kKeepTitleStatusSchemeList {};
@@ -415,4 +419,29 @@ void TitleBarHelper::setFileViewStateValue(const QUrl &url, const QString &key, 
     QVariantMap map = Application::appObtuselySetting()->value("FileViewState", viewModeUrl).toMap();
     map[key] = value;
     Application::appObtuselySetting()->setValue("FileViewState", viewModeUrl, map);
+}
+
+bool TitleBarHelper::isTreeViewGloballyEnabled()
+{
+    return DConfigManager::instance()->value(kViewDConfName, kTreeViewEnable, true).toBool();
+}
+
+bool TitleBarHelper::isViewModeVisibleForScheme(int mode, const QString &scheme)
+{
+    // If no scheme restriction, all modes are visible
+    if (!OptionButtonManager::instance()->hasVsibleState(scheme))
+        return true;
+
+    auto state = OptionButtonManager::instance()->optBtnVisibleState(scheme);
+
+    switch (mode) {
+    case 0:   // Icon mode
+        return !(state & OptionButtonManager::kHideIconViewBtn);
+    case 1:   // List mode
+        return !(state & OptionButtonManager::kHideListViewBtn);
+    case 2:   // Tree mode
+        return !(state & OptionButtonManager::kHideTreeViewBtn);
+    default:
+        return false;
+    }
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
@@ -47,6 +47,10 @@ public:
     static void setFileViewStateValue(const QUrl &url, const QString &key, const QVariant &value);
     static QUrl transformViewModeUrl(const QUrl &url);
 
+    // View mode switching helper methods
+    static bool isTreeViewGloballyEnabled();
+    static bool isViewModeVisibleForScheme(int mode, const QString &scheme);
+
 public:
     static bool newWindowAndTabEnabled;
     static bool searchEnabled;


### PR DESCRIPTION
## Summary by Sourcery

Adjust title bar view mode hotkey handling and fix text color behavior for key-value labels.

Bug Fixes:
- Respect per-scheme visibility restrictions when switching file manager view modes via keyboard shortcuts to avoid invoking unsupported modes.
- Ensure right-side key-value text uses the correct palette-based foreground color, including in read-only state, to prevent grayed-out appearance.

Enhancements:
- Integrate option button visibility management into title bar view mode switching logic for more consistent UI behavior.