### PR TITLE
fix: improve error handling for SMB mount operations

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
@@ -92,12 +92,12 @@ void travers_prehandler::networkAccessPrehandler(quint64 winId, const QUrl &url,
     static QString kRecordGroup = "defaultSmbPath";
     static QRegularExpression kRegx { "/|\\.|:" };
     DevMngIns->mountNetworkDeviceAsync(mountSource, [=](bool ok, const DFMMOUNT::OperationErrorInfo &err, const QString &mpt) {
-        fmInfo() << "mount done: " << netUrl << ok << err.code << err.message << mpt;
         if (!mpt.isEmpty()) {
             doChangeCurrentUrl(winId, mpt, subPath, netUrl);
         } else if (ok || err.code == DFMMOUNT::DeviceError::kGIOErrorAlreadyMounted) {
             if (isSmb) onSmbRootMounted(mountSource, after);
         } else {
+            fmWarning() << "mount done: " << netUrl << ok << err.code << err.message << mpt;
             QApplication::restoreOverrideCursor();
             onMountFailed(err);
         }


### PR DESCRIPTION
1. Move debug log output to error case only to reduce noise
2. Keep error logging for failed mount attempts
3. Maintain existing functionality for successful mounts

Log: Improved error logging for SMB mount failures

Influence:
1. Test SMB connection with invalid credentials
2. Verify error messages are displayed correctly
3. Check that successful mounts don't produce unnecessary logs
4. Test network drive mounting with various scenarios

fix: 改进SMB挂载操作的错误处理

1. 将调试日志输出移至错误情况，减少日志噪音
2. 保留失败挂载尝试的错误日志记录
3. 保持成功挂载的现有功能

Log: 改进SMB挂载失败的错误日志记录

Influence:
1. 使用无效凭据测试SMB连接
2. 验证错误消息是否正确显示
3. 检查成功挂载不会产生不必要的日志
4. 测试各种场景下的网络驱动器挂载

BUG: https://pms.uniontech.com/bug-view-332291.html

## Summary by Sourcery

Adjust SMB network mount handling to reduce log noise while preserving error reporting for failed mount operations.

Bug Fixes:
- Log SMB mount completion details only on failure instead of all outcomes, and elevate them to warning level for easier diagnosis.

Enhancements:
- Avoid emitting debug/info logs for successful SMB mounts to keep logs concise and focused on issues.