### PR TITLE
feat: add read-only mode for settings configuration

### DIFF
--- a/src/dfm-base/base/application/application.cpp
+++ b/src/dfm-base/base/application/application.cpp
@@ -25,6 +25,9 @@ Q_GLOBAL_STATIC_WITH_ARGS(Settings, aosGlobal, ("deepin/dde-file-manager/dde-fil
 static constexpr char DP_GLOBAL_FILE[] { "/tmp/.config/deepin/dde-file-manager/dde-file-manager.dp" };
 Q_GLOBAL_STATIC_WITH_ARGS(Settings, dpGlobal, ("", "", DP_GLOBAL_FILE))
 
+// global read-only mode flag for all settings
+static bool sSettingsReadOnly = false;
+
 // blumia: since dde-desktop now also do show file selection dialog job, thus dde-desktop should share the same config file
 //         with dde-file-manager, so we use GenericConfig with specify path to simulate AppConfig.
 
@@ -233,6 +236,7 @@ Settings *Application::genericSetting()
         }
 
         gsGlobal->setAutoSync(true);
+        gsGlobal->setReadOnly(sSettingsReadOnly);
 #ifndef DFM_NO_FILE_WATCHER
         gsGlobal->setWatchChanges(true);
 #endif
@@ -256,6 +260,7 @@ Settings *Application::appSetting()
         }
 
         asGlobal->setAutoSync(true);
+        asGlobal->setReadOnly(sSettingsReadOnly);
 #ifndef DFM_NO_FILE_WATCHER
         asGlobal->setWatchChanges(true);
 #endif
@@ -271,6 +276,7 @@ Settings *Application::genericObtuselySetting()
 {
     if (!gosGlobal.exists()) {
         gosGlobal->setAutoSync(false);
+        gosGlobal->setReadOnly(sSettingsReadOnly);
 #ifndef DFM_NO_FILE_WATCHER
         gosGlobal->setWatchChanges(false);
 #endif
@@ -283,6 +289,7 @@ Settings *Application::appObtuselySetting()
 {
     if (!aosGlobal.exists()) {
         aosGlobal->setAutoSync(false);
+        aosGlobal->setReadOnly(sSettingsReadOnly);
 #ifndef DFM_NO_FILE_WATCHER
         aosGlobal->setWatchChanges(true);
 #endif
@@ -295,6 +302,7 @@ Settings *Application::dataPersistence()
 {
     if (!dpGlobal.exists()) {
         dpGlobal->setAutoSync(true);
+        dpGlobal->setReadOnly(sSettingsReadOnly);
 #ifndef DFM_NO_FILE_WATCHER
         dpGlobal->setWatchChanges(true);
 #endif
@@ -349,6 +357,28 @@ void Application::appAttributeTrigger(TriggerAttribute ta, quint64 winId)
         Q_EMIT instance()->clearSearchHistory(winId);
         break;
     }
+}
+
+void Application::setSettingsReadOnly(bool readOnly)
+{
+    sSettingsReadOnly = readOnly;
+
+    // update already created Settings instances
+    if (gsGlobal.exists())
+        gsGlobal->setReadOnly(readOnly);
+    if (asGlobal.exists())
+        asGlobal->setReadOnly(readOnly);
+    if (gosGlobal.exists())
+        gosGlobal->setReadOnly(readOnly);
+    if (aosGlobal.exists())
+        aosGlobal->setReadOnly(readOnly);
+    if (dpGlobal.exists())
+        dpGlobal->setReadOnly(readOnly);
+}
+
+bool Application::settingsReadOnly()
+{
+    return sSettingsReadOnly;
 }
 
 Application::Application(ApplicationPrivate *dd, QObject *parent)

--- a/src/dfm-base/base/application/application.h
+++ b/src/dfm-base/base/application/application.h
@@ -98,6 +98,9 @@ public:
 
     static void appAttributeTrigger(TriggerAttribute ta, quint64 winId);
 
+    static void setSettingsReadOnly(bool readOnly);
+    static bool settingsReadOnly();
+
 Q_SIGNALS:
     void appAttributeChanged(ApplicationAttribute aa, const QVariant &value);
     void genericAttributeChanged(GenericAttribute ga, const QVariant &value);

--- a/src/dfm-base/base/application/settings.cpp
+++ b/src/dfm-base/base/application/settings.cpp
@@ -31,6 +31,7 @@ public:
     bool autoSync = false;   // automatically synchronize
     bool watchChanges = false;   // monitor for configuration changes
     bool settingFileIsDirty = false;   // set whether the file has cached data (dirty data)
+    bool readOnly = false;   // read-only mode, sync() will not write to file
     QSet<QString> autoSyncGroupExclude;   // when auto sync, exclude some group
     QTimer *syncTimer = nullptr;   // synchronization Timer
     QString fallbackFile;   // backup settings file path
@@ -853,6 +854,12 @@ bool Settings::sync()
         return true;
     }
 
+    // read-only mode: clear dirty flag without writing
+    if (d->readOnly) {
+        d->makeSettingFileToDirty(false);
+        return true;
+    }
+
     const QByteArray &json = d->toJson(d->writableData);
 
     QFile file(d->settingFile);
@@ -887,6 +894,15 @@ bool Settings::autoSync() const
 bool Settings::watchChanges() const
 {
     return d->watchChanges;
+}
+/*!
+ * \brief Settings::isReadOnly 获取是否为只读模式
+ *
+ * \return bool 是否为只读模式
+ */
+bool Settings::isReadOnly() const
+{
+    return d->readOnly;
 }
 
 void Settings::autoSyncExclude(const QString &group, bool sync /*= false*/)
@@ -969,6 +985,25 @@ void Settings::setWatchChanges(bool watchChanges)
         d->settingWatcher->startWatcher();
     } else if (d->settingWatcher) {
         d->settingWatcher.reset();
+    }
+}
+/*!
+ * \brief Settings::setReadOnly 设置是否为只读模式
+ *
+ * 只读模式下，sync() 方法不会将配置写入文件
+ *
+ * \param readOnly 是否为只读模式
+ */
+void Settings::setReadOnly(bool readOnly)
+{
+    if (d->readOnly == readOnly)
+        return;
+
+    d->readOnly = readOnly;
+
+    // clear dirty flag when entering read-only mode
+    if (readOnly && d->settingFileIsDirty) {
+        d->makeSettingFileToDirty(false);
     }
 }
 

--- a/src/dfm-base/base/application/settings.h
+++ b/src/dfm-base/base/application/settings.h
@@ -20,6 +20,7 @@ class Settings : public QObject
     friend class SettingsPrivate;
     Q_PROPERTY(bool autoSync READ autoSync WRITE setAutoSync)
     Q_PROPERTY(bool watchChanges READ watchChanges WRITE setWatchChanges)
+    Q_PROPERTY(bool readOnly READ isReadOnly WRITE setReadOnly)
 public:
     enum ConfigType {
         kAppConfig,
@@ -56,10 +57,12 @@ public:
     bool sync();
     bool autoSync() const;
     bool watchChanges() const;
+    bool isReadOnly() const;
     void autoSyncExclude(const QString &group, bool sync = false);
 public Q_SLOTS:
     void setAutoSync(bool autoSync);
     void setWatchChanges(bool watchChanges);
+    void setReadOnly(bool readOnly);
 
 Q_SIGNALS:
     void valueChanged(const QString &group, const QString &key, const QVariant &value);

--- a/src/plugins/filedialog/core/core.cpp
+++ b/src/plugins/filedialog/core/core.cpp
@@ -10,6 +10,7 @@
 
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
 
+#include <dfm-base/base/application/application.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 
 #include <QDBusError>
@@ -21,6 +22,9 @@ DFM_LOG_REGISTER_CATEGORY(DIALOGCORE_NAMESPACE)
 
 bool Core::start()
 {
+    // filedialog process should not modify shared configuration files
+    DFMBASE_NAMESPACE::Application::setSettingsReadOnly(true);
+
     enterHighPerformanceMode();
     FMWindowsIns.setCustomWindowCreator([](const QUrl &url) {
         return new FileDialog(url);


### PR DESCRIPTION
Added global read-only mode support for all settings instances to prevent file dialogs from modifying shared configuration files. The changes include:
1. Added static flag to track read-only mode state
2. Modified Settings class to support read-only mode where sync() won't write to disk
3. Added public methods to get/set read-only mode in Application class
4. Applied read-only mode to all existing settings instances (generic, app, obtusely, data persistence)
5. Set filedialog process to read-only mode by default to avoid conflicts

Log: Added read-only mode support for configuration settings

Influence:
1. Test that settings modifications are not persisted when in read- only mode
2. Verify that read-only mode can be dynamically toggled
3. Test that file dialog operations don't affect shared configuration files
4. Verify that normal file manager operations still work correctly with writable settings
5. Check that dirty flags are properly cleared when entering read-only mode
6. Test auto-sync behavior in both read-only and writable modes

feat: 为配置设置添加只读模式支持

为所有设置实例添加全局只读模式支持，防止文件对话框修改共享配置文件。更改
包括：
1. 添加静态标志来跟踪只读模式状态
2. 修改 Settings 类以支持只读模式，在此模式下 sync() 不会写入磁盘
3. 在 Application 类中添加获取/设置只读模式的公共方法
4. 对所有现有设置实例应用只读模式（通用、应用、模糊、数据持久化）
5. 默认将文件对话框进程设置为只读模式以避免冲突

Log: 为配置设置添加只读模式支持

Influence:
1. 测试在只读模式下设置修改不会被持久化
2. 验证只读模式可以动态切换
3. 测试文件对话框操作不会影响共享配置文件
4. 验证正常文件管理器操作在可写设置模式下仍能正常工作
5. 检查进入只读模式时脏标志是否正确清除
6. 测试只读和可写模式下的自动同步行为

## Summary by Sourcery

Add a global read-only mode for configuration settings to prevent certain processes from writing to shared config files.

New Features:
- Introduce a read-only mode flag in the Settings class that prevents sync() from writing configuration data to disk while still clearing dirty state.
- Expose application-wide APIs to enable or query read-only mode for all Settings instances and apply it across generic, app, obtuse, and data persistence settings.
- Default the file dialog process to operate with read-only settings so it cannot modify shared configuration files.

Enhancements:
- Extend Settings with a readOnly Qt property and corresponding accessors to support centralized control of settings mutability.