### PR TITLE
Fix: [emblem] cache icons and ignore empty icon paths

### DIFF
--- a/src/plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager_p.h
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager_p.h
@@ -70,6 +70,10 @@ public:
     bool readyFlag { false };
     QList<QPair<QString, int>> readyLocalPaths;
     QMap<QString, QList<QPair<QString, int>>> positionEmbelmCaches;   // file path ->  { pairs { emblem icon path, pos }}
+    // 缓存已加载的图标，避免重复加载
+    // 键: 图标路径或主题名称
+    // 值: 对应的QIcon对象
+    QHash<QString, QIcon> iconCaches;
 };
 
 DPUTILS_END_NAMESPACE


### PR DESCRIPTION
- Cache emblem icons by path to avoid redundant QIcon creation.
- Safely handle empty icon paths and icon names when creating emblems.

Log: cache icons and ignore empty icon paths
Bug: https://pms.uniontech.com//bug-view-343229.html

## Summary by Sourcery

Cache emblem icons and ignore empty icon paths or names when generating emblems to avoid redundant icon creation and handle invalid inputs safely.

Bug Fixes:
- Prevent crashes or incorrect behavior by skipping emblem creation for empty icon paths and names.

Enhancements:
- Introduce an in-memory cache of emblem icons keyed by path to reduce redundant QIcon creation and improve performance.