### PR TITLE
fix: add URL validation for file operations

### DIFF
--- a/src/dfm-base/utils/filestatisticsjob.cpp
+++ b/src/dfm-base/utils/filestatisticsjob.cpp
@@ -110,6 +110,10 @@ bool FileStatisticsJobPrivate::stateCheck()
 void FileStatisticsJobPrivate::processFile(const QUrl &url, const bool followLink, QQueue<QUrl> &directoryQueue)
 {
     FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+    if (!info) {
+        qCWarning(logDFMBase) << "File statistics failed: unsupported URL scheme:" << url;
+        return;
+    }
 
     processFile(info, followLink, directoryQueue);
 }

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.h
@@ -48,6 +48,7 @@ private:
     void stopDelayDodge();
     void updateDFMMimeData(QDropEvent *event);
     bool checkTargetEnable(const QUrl &targetUrl);
+    bool checkSourceValid(const QList<QUrl> &srcUrls);
 
 protected:
     CanvasView *view = nullptr;


### PR DESCRIPTION
Added validation checks for unsupported URL schemes in file statistics
and drag-drop operations to prevent crashes when handling invalid URLs.
The fix includes:
1. In FileStatisticsJob: Check if FileInfo creation succeeds before
processing files
2. In DragDropOper: Validate source URLs before allowing drag operations
3. Added canAttributes check to ensure files support move/copy/rename
operations

Log: Fixed potential crashes when dragging unsupported file types

Influence:
1. Test dragging files with unsupported URL schemes should be ignored
2. Verify file statistics job handles invalid URLs gracefully without
crashing
3. Test drag operations with files that lack move/copy permissions
should be rejected
4. Ensure normal file operations continue to work as expected

fix: 为文件操作添加URL验证

增加了对文件统计和拖拽操作中不支持的URL方案的验证检查，以防止处理无效URL
时发生崩溃。修复内容包括：
1. 在FileStatisticsJob中：在处理文件前检查FileInfo创建是否成功
2. 在DragDropOper中：在允许拖拽操作前验证源URL有效性
3. 添加canAttributes检查以确保文件支持移动/复制/重命名操作

Log: 修复拖拽不支持的文件类型时可能出现的崩溃问题

Influence:
1. 测试拖拽不支持URL方案的文件应被忽略
2. 验证文件统计作业能优雅处理无效URL而不崩溃
3. 测试拖拽缺乏移动/复制权限的文件应被拒绝
4. 确保正常的文件操作继续按预期工作

BUG: https://pms.uniontech.com/bug-view-346975.html

## Summary by Sourcery

Add URL validity checks to file drag-and-drop and file statistics processing to safely ignore unsupported or invalid sources.

Bug Fixes:
- Prevent crashes in drag-and-drop when source URLs are invalid, unsupported, or lack move/copy/rename capabilities by validating all source URLs before processing.
- Avoid crashes in file statistics calculation by skipping URLs that fail FileInfo creation due to unsupported schemes.