### PR TITLE
fix bugs

### DIFF
--- a/src/dfm-base/base/application/settings.h
+++ b/src/dfm-base/base/application/settings.h
@@ -20,6 +20,8 @@ class Settings : public QObject
     friend class SettingsPrivate;
     Q_PROPERTY(bool autoSync READ autoSync WRITE setAutoSync)
     Q_PROPERTY(bool watchChanges READ watchChanges WRITE setWatchChanges)
+    Q_PROPERTY(bool readOnly READ isReadOnly WRITE setReadOnly)
+
 public:
     enum ConfigType {
         kAppConfig,
@@ -57,9 +59,12 @@ public:
     bool autoSync() const;
     bool watchChanges() const;
     void autoSyncExclude(const QString &group, bool sync = false);
+    bool isReadOnly() const;
+
 public Q_SLOTS:
     void setAutoSync(bool autoSync);
     void setWatchChanges(bool watchChanges);
+    void setReadOnly(bool readOnly);
 
 Q_SIGNALS:
     void valueChanged(const QString &group, const QString &key, const QVariant &value);

--- a/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
@@ -12,20 +12,17 @@
 CheckBoxWithMessage::CheckBoxWithMessage(QWidget *parent)
     : QWidget(parent)
 {
-    auto widget = new QWidget(this);
-    widget->setContentsMargins(0, 0, 0, 0);
-    QVBoxLayout *layout = new QVBoxLayout(widget);
+    QVBoxLayout *layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
-    setLayout(layout);
 
-    checkBox = new QCheckBox(widget);
+    checkBox = new QCheckBox(this);
     layout->addWidget(checkBox);
 
     QHBoxLayout *hLayout = new QHBoxLayout();
     hLayout->setContentsMargins(30, 0, 0, 0);
     layout->addLayout(hLayout);
 
-    msgLabel = new Dtk::Widget::DTipLabel("", widget);
+    msgLabel = new Dtk::Widget::DTipLabel("", this);
     msgLabel->setAlignment(Qt::AlignLeft);
     msgLabel->setWordWrap(true);
     hLayout->addWidget(msgLabel);

--- a/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/settingdialog.cpp
@@ -269,7 +269,7 @@ QPair<QWidget *, QWidget *> SettingDialog::createAutoMountOpenCheckBox(QObject *
     return qMakePair(openCheckBox, nullptr);
 }
 
-QPair<QWidget *, QWidget *> SettingDialog::createCheckBoxWithMessage(QObject *opt)
+QWidget *SettingDialog::createCheckBoxWithMessage(QObject *opt)
 {
     auto option = qobject_cast<Dtk::Core::DSettingsOption *>(opt);
     const QString &text = option->data("text").toString();
@@ -290,7 +290,7 @@ QPair<QWidget *, QWidget *> SettingDialog::createCheckBoxWithMessage(QObject *op
 
     QObject::connect(option, &DSettingsOption::valueChanged, cb, [=](QVariant value) { cb->setChecked(value.toBool()); });
 
-    return qMakePair(cb, nullptr);
+    return cb;
 }
 
 QPair<QWidget *, QWidget *> SettingDialog::createPushButton(QObject *opt)

--- a/src/dfm-base/dialogs/settingsdialog/settingdialog.h
+++ b/src/dfm-base/dialogs/settingsdialog/settingdialog.h
@@ -30,7 +30,7 @@ public:
 private:
     [[nodiscard]] static QPair<QWidget *, QWidget *> createAutoMountCheckBox(QObject *opt);
     [[nodiscard]] static QPair<QWidget *, QWidget *> createAutoMountOpenCheckBox(QObject *opt);
-    [[nodiscard]] static QPair<QWidget *, QWidget *> createCheckBoxWithMessage(QObject *opt);
+    [[nodiscard]] static QWidget *createCheckBoxWithMessage(QObject *opt);
     [[nodiscard]] static QPair<QWidget *, QWidget *> createPushButton(QObject *opt);
     [[nodiscard]] static QPair<QWidget *, QWidget *> createSliderWithSideIcon(QObject *opt);
     [[nodiscard]] static QPair<QWidget *, QWidget *> createPathComboboxItem(QObject *opt);

--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -367,6 +367,9 @@ int FileManagerWindowPrivate::loadDetailSpaceState() const
 
 void FileManagerWindowPrivate::loadDetailSpaceVisibility()
 {
+    if (!q->saveClosedSate())
+        return;
+
     // Check if there are other windows already open
     auto windowList = FMWindowsIns.windowIdList();
 

--- a/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
@@ -63,6 +63,7 @@ void TagWidgetPrivate::initializeUI()
         tagColorListLayout->addWidget(tagLable);
         tagColorListLayout->addWidget(tagLeftLable);
         tagColorListLayout->addWidget(colorListWidget);
+        tagColorListLayout->addStretch();
     } else {
         tagColorListLayout = new QVBoxLayout;
         tagColorListLayout->addWidget(tagLable, 0, Qt::AlignLeft);

--- a/src/plugins/filedialog/core/core.cpp
+++ b/src/plugins/filedialog/core/core.cpp
@@ -11,6 +11,8 @@
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
 
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
 
 #include <QDBusError>
 #include <QDBusConnection>
@@ -21,6 +23,9 @@ DFM_LOG_REGISTER_CATEGORY(DIALOGCORE_NAMESPACE)
 
 bool Core::start()
 {
+    DFMBASE_NAMESPACE::Application::instance()->appSetting()->setReadOnly(true);
+    DFMBASE_NAMESPACE::Application::instance()->appObtuselySetting()->setReadOnly(true);
+
     enterHighPerformanceMode();
     FMWindowsIns.setCustomWindowCreator([](const QUrl &url) {
         return new FileDialog(url);

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.h
@@ -8,8 +8,10 @@
 #include "dfmplugin_detailspace_global.h"
 
 #include <DFrame>
+#include <DSpinner>
 #include <QVBoxLayout>
 #include <QUrl>
+#include <QTimer>
 
 class QScrollArea;
 
@@ -44,12 +46,15 @@ private slots:
 
 private:
     void initInfoUI();
+    void initSpinnerOverlay();
     void createExtensionWidgets();
     void updateHeadUI(const QUrl &url);
     void updateBasicWidget(const QUrl &url);
     void updateExtensionWidgets(const QUrl &url);
     void updatePreviewSize();
     void reloadPreviewFile();
+    void startPreviewLoading();
+    void finishPreviewLoading();
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -66,6 +71,12 @@ private:
 
     // Reusable extension widgets
     QList<ExtensionWidgetHolder> m_extensionWidgets;
+
+    // Loading state management
+    QWidget *m_spinnerOverlay { nullptr };
+    DTK_WIDGET_NAMESPACE::DSpinner *m_spinner { nullptr };
+    QTimer *m_loadingTimer { nullptr };
+    static constexpr int kSpinnerDelayMs = 200;
 
     QUrl m_currentUrl;
 };


### PR DESCRIPTION
## Summary by Sourcery

Make settings handling more robust and support read-only mode, improve file dialog and detail view behavior, and adjust several UI components for better layout and state handling.

Bug Fixes:
- Prevent redundant settings writes by normalizing values for comparison after JSON serialization.
- Avoid writing configuration files when in read-only mode and ensure detail space visibility loads only when window state should be saved.
- Ensure detail view preview loading state finishes correctly when previews are ready and avoid stale previews being shown.
- Fix layout and parenting issues in CheckBoxWithMessage and ensure tag color list layout stretches correctly.

Enhancements:
- Write settings files atomically using QSaveFile with error logging on failures.
- Add configurable read-only mode to Settings and apply it to file dialog application settings.
- Add a delayed spinner overlay to the detail view preview area to indicate long-running preview loads without flashing on fast loads.
- Simplify the checkbox-with-message setting dialog factory to return a single widget instead of a pair.