### PR TITLE
fix: [xps] the type of xps cannot display correctly in dde-file-manager

### DIFF
--- a/assets/mimetypes/text.mimetype
+++ b/assets/mimetypes/text.mimetype
@@ -44,3 +44,4 @@ application/javascript
 application/sql
 application/x-yaml
 application/x-php
+application/vnd.ms-xpsdocument


### PR DESCRIPTION
- add application/vnd.ms-xpsdocument to text.mimetype

Log: [xps] the type of xps cannot display correctly in dde-file-manager
Bug: https://pms.uniontech.com/bug-view-345673.html

## Summary by Sourcery

Bug Fixes:
- Ensure XPS (.xps) files are associated with the correct MIME type so their file type is shown correctly in dde-file-manager.