### PR TITLE
fix: [vault] intermittent vault encryption failure

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp
@@ -905,6 +905,12 @@ void OperatorCenter::removeVault(const QString &basePath)
 
 bool OperatorCenter::isNewVaultVersion() const
 {
+    // 判断是否是透明加密
+    VaultConfig config;
+    QString encryptionMethod = config.get(kConfigNodeName, kConfigKeyEncryptionMethod, QVariant(kConfigKeyNotExist)).toString();
+    if (encryptionMethod == QString(kConfigValueMethodTransparent)) {
+        return false;
+    }
     // 构建LUKS容器文件路径
     QString containerPath = kVaultBasePath + QString("/password_container.bin");
 


### PR DESCRIPTION
Log: as title

Bug: https://pms.uniontech.com/bug-view-347021.html

## Summary by Sourcery

Fix vault creation to use appropriate password source and handle encryption method variants, and adjust vault version detection and recovery container sizing to improve reliability.

Bug Fixes:
- Resolve intermittent failures when creating encrypted vaults by correctly selecting the password or master key based on the configured encryption method.
- Ensure transparent-encryption vaults are not misclassified as new-version vaults during version checks.
- Prevent recovery key storage failures by increasing the size of the password container file used for LUKS.

Enhancements:
- Improve logging severity for critical vault creation failures to aid diagnostics.