### PR TITLE
refactor: simplify CREATE_DBUS_INTERFACE macro

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
@@ -86,9 +86,8 @@ inline void setupDbusInterface(QDBusInterface &iface)
  *   CREATE_DBUS_INTERFACE(iface, service, path, interface)
  *   CREATE_TPM_INTERFACE(iface)
  */
-#define CREATE_DBUS_INTERFACE(name, service, path, interface)                    \
-    QDBusInterface name(service, path, interface, QDBusConnection::systemBus()); \
-    setupDbusInterface(name)
+#define CREATE_DBUS_INTERFACE(name, service, path, interface) \
+    QDBusInterface name(service, path, interface, QDBusConnection::systemBus());
 
 #define CREATE_TPM_INTERFACE(name) \
     CREATE_DBUS_INTERFACE(name, kTPMControlService, kTPMControlPath, kTPMControlInterface)


### PR DESCRIPTION
Removed the setupDbusInterface function call from CREATE_DBUS_INTERFACE macro to simplify the interface creation process. The setupDbusInterface function was previously used to configure D-Bus interface settings but is no longer needed as the interface can be used directly after creation. This change makes the macro cleaner and more straightforward.

Influence:
1. Verify that D-Bus interface creation still works correctly
2. Test TPM interface creation using CREATE_TPM_INTERFACE macro
3. Ensure all existing D-Bus calls function properly after the change
4. Check that no additional configuration is required for D-Bus interfaces

refactor: 简化 CREATE_DBUS_INTERFACE 宏定义

从 CREATE_DBUS_INTERFACE 宏中移除了 setupDbusInterface 函数调用，以简化 接口创建过程。setupDbusInterface 函数之前用于配置 D-Bus 接口设置，但现在
不再需要，因为接口创建后可以直接使用。此更改使宏更加简洁和直接。

Influence:
1. 验证 D-Bus 接口创建是否仍然正常工作
2. 测试使用 CREATE_TPM_INTERFACE 宏创建 TPM 接口
3. 确保所有现有的 D-Bus 调用在更改后功能正常
4. 检查 D-Bus 接口是否不需要额外的配置

Bug: https://pms.uniontech.com/bug-view-347205.html

## Summary by Sourcery

Simplify D-Bus interface creation macros by removing unnecessary post-construction setup.

Enhancements:
- Refactor CREATE_DBUS_INTERFACE macro to construct QDBusInterface instances without calling the now-unneeded setupDbusInterface helper.
- Keep CREATE_TPM_INTERFACE macro behavior aligned with the streamlined D-Bus interface creation.