### PR TITLE
feat: supports CIFS authentication-free mounting

### DIFF
--- a/autotests/services/mountcontrol/test_cifsmounthelper.cpp
+++ b/autotests/services/mountcontrol/test_cifsmounthelper.cpp
@@ -437,16 +437,6 @@ TEST_F(UT_CifsMountHelper, GenerateMountPath_ValidAddress_ReturnsPath)
     EXPECT_TRUE(result.contains("smb-share:server=192.168.1.100,share=share"));
 }
 
-TEST_F(UT_CifsMountHelper, DecryptPasswd_Base64Encoded_ReturnsDecrypted)
-{
-    // Test password decryption
-    QString encodedPasswd = "dGVzdHBhc3M=";   // base64 encoded "testpass"
-
-    QString result = getHelper()->decryptPasswd(encodedPasswd);
-
-    EXPECT_EQ(result, QString("testpass"));
-}
-
 TEST_F(UT_CifsMountHelper, InvokerUid_ValidDBusContext_ReturnsUid)
 {
     // Test getting invoker UID from DBus context

--- a/autotests/services/mountcontrol/test_mountcontroldbus.cpp
+++ b/autotests/services/mountcontrol/test_mountcontroldbus.cpp
@@ -150,7 +150,7 @@ TEST_F(UT_MountControlDBus, Mount_NoFsTypeSpecified_ReturnsError)
     EXPECT_FALSE(result.value(MountReturnField::kResult).toBool());
     EXPECT_EQ(result.value(MountReturnField::kErrorCode).toInt(), -kNoFsTypeSpecified);
     EXPECT_EQ(result.value(MountReturnField::kErrorMessage).toString(),
-              QString("fsType filed must be specified."));
+              QString("fsType field must be specified."));
 }
 
 TEST_F(UT_MountControlDBus, Mount_UnsupportedFsType_ReturnsError)
@@ -219,7 +219,7 @@ TEST_F(UT_MountControlDBus, Unmount_NoFsTypeSpecified_ReturnsError)
     EXPECT_FALSE(result.value(MountReturnField::kResult).toBool());
     EXPECT_EQ(result.value(MountReturnField::kErrorCode).toInt(), -kNoFsTypeSpecified);
     EXPECT_EQ(result.value(MountReturnField::kErrorMessage).toString(),
-              QString("fsType filed must be specified."));
+              QString("fsType field must be specified."));
 }
 
 TEST_F(UT_MountControlDBus, Unmount_UnsupportedFsType_ReturnsError)

--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -992,8 +992,7 @@ MountPassInfo DeviceManagerPrivate::askForPasswdWhenMountNetworkDevice(const QSt
         info.userName = data.value(kUser).toString();
         info.domain = data.value(kDomain).toString();
         info.savePasswd = static_cast<DFMMOUNT::NetworkMountPasswdSaveMode>(data.value(kPasswdSaveMode).toInt());
-        QString pwd = data.value(kPasswd).toString();
-        info.passwd = DProtocolDevice::isMountByDaemon(uri) ? encryptPasswd(pwd) : pwd;
+        info.passwd = data.value(kPasswd).toString();
 
         // save password in session if samba is integrated.
         if (uri.startsWith(Global::Scheme::kSmb)) {
@@ -1006,14 +1005,6 @@ MountPassInfo DeviceManagerPrivate::askForPasswdWhenMountNetworkDevice(const QSt
 
     QApplication::setOverrideCursor(Qt::WaitCursor);
     return info;
-}
-
-QString DeviceManagerPrivate::encryptPasswd(const QString &passwd)
-{
-    // todo use encrypt-plugin
-    QByteArray byteArray = passwd.toUtf8();
-    QByteArray encodedByteArray = byteArray.toBase64();
-    return QString::fromUtf8(encodedByteArray);
 }
 
 int DeviceManagerPrivate::askForUserChoice(const QString &message, const QStringList &choices)

--- a/src/dfm-base/base/device/private/devicemanager_p.h
+++ b/src/dfm-base/base/device/private/devicemanager_p.h
@@ -38,8 +38,6 @@ private:
     static DFMMOUNT::MountPassInfo askForPasswdWhenMountNetworkDevice(const QString &message, const QString &userDefault, const QString &domainDefault, const QString &uri);
     static int askForUserChoice(const QString &message, const QStringList &choices);
 
-    static QString encryptPasswd(const QString &passwd);
-
 private:
     DeviceWatcher *watcher { nullptr };
     DiscDeviceScanner *discScanner { nullptr };

--- a/src/services/mountcontrol/mountcontroldbus.h
+++ b/src/services/mountcontrol/mountcontroldbus.h
@@ -29,7 +29,6 @@ public slots:
     Q_SCRIPTABLE QStringList SupportedFileSystems();
 
 private:
-    bool checkAuthentication();
     QScopedPointer<SERVICEMOUNTCONTROL_NAMESPACE::MountControlDBusPrivate> d;
 };
 

--- a/src/services/mountcontrol/mounthelpers/abstractmounthelper.h
+++ b/src/services/mountcontrol/mounthelpers/abstractmounthelper.h
@@ -6,12 +6,14 @@
 #define ABSTRACTMOUNTHELPER_H
 
 #include "service_mountcontrol_global.h"
+#include "polkit/policykithelper.h"
 
 #include <QVariantMap>
 
 class QDBusContext;
 
 SERVICEMOUNTCONTROL_BEGIN_NAMESPACE
+inline constexpr char kPolicyKitActionIdDefault[] { "org.deepin.Filemanager.MountController" };
 class AbstractMountHelper
 {
 public:
@@ -20,6 +22,11 @@ public:
     virtual ~AbstractMountHelper() { }
     virtual QVariantMap mount(const QString &path, const QVariantMap &opts) = 0;
     virtual QVariantMap unmount(const QString &path, const QVariantMap &opts) = 0;
+    virtual bool checkAuthentication(const QString &appName)
+    {
+        return ServiceCommon::PolicyKitHelper::instance()->checkAuthorization(kPolicyKitActionIdDefault, appName);
+    }
+
 
 protected:
     QDBusContext *context { nullptr };

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.h
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.h
@@ -32,7 +32,7 @@ private:
     MountStatus checkMount(const QString &path, QString &mpt);
     QString generateMountPath(const QString &address);
     QString mountRoot();
-    QString decryptPasswd(const QString &passwd);
+    QString preparePasswd(const QVariant &passwdVar);
     uint invokerUid();
     std::string convertArgs(const QVariantMap &opts);
     QVariantMap overrideOptions();

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.h
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.h
@@ -25,6 +25,7 @@ public:
 
     virtual QVariantMap mount(const QString &path, const QVariantMap &opts) override;
     virtual QVariantMap unmount(const QString &path, const QVariantMap &opts) override;
+    virtual bool checkAuthentication(const QString &appName) override;
 
     void cleanMountPoint();
 

--- a/src/services/mountcontrol/org.deepin.filemanager.mountcontrol.policy
+++ b/src/services/mountcontrol/org.deepin.filemanager.mountcontrol.policy
@@ -94,4 +94,14 @@
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
+  <action id="org.deepin.Filemanager.MountController.CIFS">
+    <description>Mount and unmount CIFS file systems</description>
+    <message>Authentication is required to mount or unmount CIFS file systems</message>
+    <icon_name>folder</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
 </policyconfig>


### PR DESCRIPTION
## Summary by Sourcery

Support CIFS authentication-free mounting while tightening security and refactoring authentication handling to be per-filesystem.

New Features:
- Allow CIFS mounts to receive passwords via a D-Bus file descriptor instead of base64 strings, enabling more secure and flexible credential handling.
- Introduce per-filesystem authentication checks so CIFS can define its own PolicyKit action separate from the default mount controller action.

Bug Fixes:
- Fix typo in error messages for missing filesystem type in mount and unmount operations.

Enhancements:
- Mount CIFS shares with additional security flags (MS_NOSUID and MS_NODEV) to reduce privilege and device exposure.
- Centralize default PolicyKit authorization in AbstractMountHelper and remove duplicated authentication logic from MountControlDBus.
- Remove unused password base64 encryption/decryption utilities in favor of direct password handling and FD-based transfer for CIFS.

Tests:
- Remove obsolete unit test for CIFS password decryption and update tests to expect the corrected error message text.