### PR TITLE
fix: prevent duplicate index creation tasks

### DIFF
--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -565,7 +565,7 @@ void FSMonitorPrivate::handleFileMoved(const QString &fromPath, const QString &f
     }
 
     // Skip hidden files if needed
-    if (!showHidden() && (fromName.startsWith('.') || toName.startsWith('.'))) {
+    if (!showHidden() && toName.startsWith('.')) {
         return;
     }
 

--- a/src/services/textindex/task/taskmanager.cpp
+++ b/src/services/textindex/task/taskmanager.cpp
@@ -136,6 +136,8 @@ bool TaskManager::startTask(IndexTask::Type type, const QStringList &pathList, b
     if (type == IndexTask::Type::Create) {
         fmInfo() << "[TaskManager::startTask] Create task detected, clearing existing index status";
         IndexUtility::removeIndexStatusFile();
+        // 创建索引的任务开销巨大，避免任务未完成时进程退出后，重复进入创建任务
+        IndexUtility::saveIndexStatus(QDateTime::currentDateTime());
     }
 
     // 获取对应的任务处理器
@@ -433,7 +435,7 @@ void TaskManager::onTaskFinished(IndexTask::Type type, HandlerResult result)
     if (result.success) {
         if (!result.interrupted || type == IndexTask::Type::Create) {
             fmDebug() << "[TaskManager::onTaskFinished] Task completed successfully, updating index status";
-            IndexUtility::saveIndexStatus(QDateTime::currentDateTime(), Defines::kIndexVersion);
+            IndexUtility::saveIndexStatus(QDateTime::currentDateTime());
         }
     }
     emit taskFinished(typeToString(type), taskPath, result.success);

--- a/src/services/textindex/utils/docutils.cpp
+++ b/src/services/textindex/utils/docutils.cpp
@@ -116,7 +116,7 @@ std::optional<QString> extractHtmlContent(const QString &filePath, size_t maxByt
 
 std::optional<QString> extractFileContent(const QString &filePath, size_t maxBytes)
 {
-    fmInfo() << "About to extract file: " << filePath;
+    fmDebug() << "About to extract file: " << filePath;
     // First try HTML extraction for HTML-style documents
     if (isHtmlStyleDocument(filePath)) {
         auto htmlContent = extractHtmlContent(filePath, maxBytes);


### PR DESCRIPTION
Add index status file update before starting create task to avoid duplicate creation
When starting an index creation task, immediately save the current timestamp and version to index status file
This prevents the system from repeatedly entering creation tasks if the process exits before task completion
Previously, the status file was only cleared but not updated, causing potential duplicate tasks

Log: Fixed issue where index creation tasks could be duplicated after process interruption

Influence:
1. Test index creation task startup and verify status file is properly updated
2. Simulate process interruption during index creation and verify no duplicate tasks
3. Check that existing index status is properly cleared before new creation
4. Verify index version and timestamp are correctly recorded in status file

fix: 防止重复创建索引任务

在启动创建索引任务前立即更新索引状态文件，避免重复创建
当开始索引创建任务时，立即将当前时间戳和版本保存到索引状态文件
这可以防止在任务完成前进程退出时系统重复进入创建任务
之前仅清除了状态文件但未更新，可能导致重复任务问题

Log: 修复进程中断后索引创建任务可能重复的问题

Influence:
1. 测试索引创建任务启动，验证状态文件是否正确更新
2. 模拟索引创建过程中的进程中断，验证无重复任务
3. 检查现有索引状态是否在新创建前正确清除
4. 验证索引版本和时间戳是否正确记录在状态文件中

## Summary by Sourcery

Prevent duplicate index creation tasks and adjust file monitoring and logging behavior.

Bug Fixes:
- Prevent duplicate index creation tasks by updating the index status file when a create task is started instead of only on completion.
- Correct hidden-file move handling so that file moves are skipped based solely on the destination name when hidden files are not shown.

Enhancements:
- Downgrade verbose file content extraction logging from info to debug to reduce log noise.