### PR TITLE
fix: (menu)add action grouping functionality to maintain menu item order

### DIFF
--- a/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
@@ -26,6 +26,8 @@
 using namespace dfmplugin_tag;
 DFMBASE_USE_NAMESPACE
 
+static constexpr char kActionGroupId[] { "act_group_id" };
+
 TagMenuScene::TagMenuScene(QObject *parent)
     : AbstractMenuScene(parent), d(new TagMenuScenePrivate(this))
 {
@@ -101,6 +103,10 @@ bool TagMenuScene::create(QMenu *parent)
     tagAction->setProperty(ActionPropertyKey::kActionID, QString(TagActionId::kActTagAddKey));
     parent->addAction(tagAction);
     d->predicateAction.insert(TagActionId::kActTagAddKey, tagAction);
+
+    // Set same group ID to prevent other menu items from being inserted between them
+    colorListAction->setProperty(kActionGroupId, "dfm_tag_group");
+    tagAction->setProperty(kActionGroupId, "dfm_tag_group");
     return AbstractMenuScene::create(parent);
 }
 


### PR DESCRIPTION
- Add kActionGroupId property constant to identify menu item groups
- Implement logic to ensure grouped menu items stay adjacent and are not separated by other menu items
- Apply grouping to tag menu scene to keep color list and tag actions together Log: fix: (menu)add action grouping functionality to maintain menu item order Bug: https://pms.uniontech.com/bug-view-345525.html

Change-Id: Idfec074665e8011d5d7470d8cbe9788c44d4991f

## Summary by Sourcery

Ensure menu actions that belong to the same logical group remain adjacent in menus and apply this grouping to tag-related menu actions.

New Features:
- Introduce an action group identifier property for menu items to support grouping in menus.

Bug Fixes:
- Prevent other menu items from being inserted between grouped tag color list and tag actions in the tag menu scene.

Enhancements:
- Add post-processing of menu actions to re-order grouped items so they remain contiguous within a menu.