### PR TITLE
refactor: simplify application launch logic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+dde-file-manager (6.5.115) unstable; urgency=medium
+
+  * chore: update translations
+  * fix: fix text color display issue in KeyValueLabel
+  * fix: control view mode switching with hotkeys
+  * fix: improve error handling for SMB mount operations
+  * fix: fix text index status bar icon display issues
+  * fix: add URL validation for file operations
+  * fix: adjust tag widget layout spacing
+  * feat: add read-only mode support to settings system
+  * refactor: improve settings file write safety
+  * fix: fix settings value comparison with JSON round-trip
+  * fix: prevent detail space loading when saveClosedState is false
+  * fix: add loading spinner for file preview
+  * fix: simplify checkbox with message widget layout
+  * Fix: [emblem] cache icons and ignore empty icon paths
+  * fix: [xps] the type of xps cannot display correctly in dde-file-manager
+  * refactor: simplify CREATE_DBUS_INTERFACE macro
+  * fix: prevent duplicate index creation tasks
+  * feat: change password handling from base64 to file descriptor
+  * feat: supports CIFS authentication-free mounting
+  * feat: add timeout handling for password file descriptor reading in CIFS mount
+  * fix: (menu)add action grouping functionality to maintain menu item order
+  * fix: [vault] intermittent vault encryption failure
+  * refactor: simplify application launch logic
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Thu, 15 Jan 2026 21:29:12 +0800
+
 dde-file-manager (6.5.114) unstable; urgency=medium
 
   * fix: add dynamic thumbnail update for image preview

--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -373,34 +373,7 @@ bool LocalFileHandler::openFilesByApp(const QList<QUrl> &fileUrls, const QString
 
     qCDebug(logDFMBase) << "LocalFileHandler::openFilesByApp: Opening" << fileUrls.size()
                         << "files with app:" << desktopFile;
-
-    GDesktopAppInfo *appInfo = g_desktop_app_info_new_from_filename(desktopFile.toLocal8Bit().constData());
-    if (!appInfo) {
-        qCWarning(logDFMBase) << "LocalFileHandler::openFilesByApp: Failed to create GDesktopAppInfo from:"
-                              << desktopFile << "Check if file exists and PATH is correct";
-        return false;
-    }
-
-    QStringList filePathsStr;
-    for (const auto &url : fileUrls) {
-        filePathsStr << url.toString();
-    }
-
-    QString terminalFlag = QString(g_desktop_app_info_get_string(appInfo, "Terminal"));
-    if (terminalFlag == "true") {
-        qCDebug(logDFMBase) << "LocalFileHandler::openFilesByApp: Running terminal application:" << desktopFile;
-        QString exec = QString(g_desktop_app_info_get_string(appInfo, "Exec"));
-        QStringList args;
-        args << "-e" << exec.split(" ").at(0) << filePathsStr;
-        QString termPath = defaultTerminalPath();
-        qCDebug(logDFMBase) << "LocalFileHandler::openFilesByApp: Terminal command:" << termPath << args;
-        ok = QProcess::startDetached(termPath, args);
-    } else {
-        qCDebug(logDFMBase) << "LocalFileHandler::openFilesByApp: Launching GUI application:" << desktopFile;
-        ok = d->launchApp(desktopFile, filePathsStr);
-    }
-    g_object_unref(appInfo);
-
+    ok = d->launchApp(desktopFile, QUrl::toStringList(fileUrls));
     if (ok) {
         qCInfo(logDFMBase) << "LocalFileHandler::openFilesByApp: Successfully opened files with app:"
                            << desktopFile << "Files count:" << fileUrls.size();


### PR DESCRIPTION
The openFilesByApp function has been refactored to remove direct
GDesktopAppInfo usage and terminal application handling. Instead, it
now delegates all application launching to the private launchApp method.
This simplifies the codebase and centralizes application launching
logic. The previous implementation had separate handling for terminal
applications which is no longer needed as the launchApp method can
handle both GUI and terminal applications appropriately.

Additionally, the terminal opening logic has been enhanced to handle
long file names more intelligently. When opening terminals, it now
checks if the filename exceeds system limits (NAME_MAX) and uses
different parameter passing methods accordingly to avoid issues with
long filenames while maintaining proper application identity separation.

Log: Improved application launching and terminal opening behavior

Influence:
1. Test opening various file types with different applications
2. Verify terminal applications launch correctly with file parameters
3. Test opening directories with long names in terminal
4. Verify application theme separation is maintained
5. Test edge cases with very long filenames in terminal operations

重构：简化应用程序启动逻辑

openFilesByApp 函数已重构，移除了直接使用 GDesktopAppInfo 和终端应用程序
处理逻辑。现在将所有应用程序启动委托给私有的 launchApp 方法。这简化了代
码库并集中了应用程序启动逻辑。之前的实现中对终端应用程序有单独处理，但现
在不再需要，因为 launchApp 方法可以适当地处理 GUI 和终端应用程序。

此外，终端打开逻辑已增强，能更智能地处理长文件名。在打开终端时，现在会检
查文件名是否超过系统限制（NAME_MAX），并相应使用不同的参数传递方法，以避
免长文件名问题，同时保持适当的应用程序身份分离。

Log: 改进了应用程序启动和终端打开行为

Influence:
1. 测试使用不同应用程序打开各种文件类型
2. 验证终端应用程序能正确使用文件参数启动
3. 测试在终端中打开长名称目录
4. 验证应用程序主题分离是否保持
5. 测试终端操作中长文件名的边界情况

BUG: https://pms.uniontech.com/bug-view-346967.html BUG: https://pms.uniontech.com/bug-view-282217.html

## Summary by Sourcery

Refactor file opening and terminal launch logic to centralize application launching and improve handling of long filenames in terminals.

Bug Fixes:
- Fix failures when opening directories with very long names in a terminal by switching to a safer invocation mode when NAME_MAX is exceeded.

Enhancements:
- Route all application launches in LocalFileHandler::openFilesByApp through the shared launchApp helper instead of duplicating terminal-specific logic.
- Adjust terminal opening behavior to choose between argument-based and working-directory-based invocation depending on filename length to avoid system limits while preserving application identity separation.