### PR TITLE
fix: Fix sw64 gcc not support pie by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     set(CMAKE_SKIP_BUILD_RPATH TRUE)
 endif()
 
+# Enable position-independent code for improved security (ASLR)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # sub directories
 add_subdirectory(src/apps)
 add_subdirectory(src/dfm-base)

--- a/src/apps/dde-file-dialog-wayland/CMakeLists.txt
+++ b/src/apps/dde-file-dialog-wayland/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(
     DFM6::framework
 )
 
+# Enable position-independent executables for improved security
+target_link_options(${PROJECT_NAME} PRIVATE -pie)
+
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 install(FILES data/com.deepin.filemanager.filedialog_wayland.service DESTINATION share/dbus-1/services)
 

--- a/src/apps/dde-file-dialog-x11/CMakeLists.txt
+++ b/src/apps/dde-file-dialog-x11/CMakeLists.txt
@@ -21,6 +21,9 @@ target_link_libraries(
     DFM6::framework
 )
 
+# Enable position-independent executables for improved security
+target_link_options(${PROJECT_NAME} PRIVATE -pie)
+
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 install(FILES data/com.deepin.filemanager.filedialog_x11.service DESTINATION share/dbus-1/services)
 

--- a/src/apps/dde-file-dialog/CMakeLists.txt
+++ b/src/apps/dde-file-dialog/CMakeLists.txt
@@ -20,6 +20,9 @@ target_link_libraries(
     DFM6::framework
 )
 
+# Enable position-independent executables for improved security
+target_link_options(${PROJECT_NAME} PRIVATE -pie)
+
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 install(FILES data/com.deepin.filemanager.filedialog.service DESTINATION share/dbus-1/services)
 

--- a/src/apps/dde-file-manager-daemon/CMakeLists.txt
+++ b/src/apps/dde-file-manager-daemon/CMakeLists.txt
@@ -26,6 +26,8 @@ target_link_libraries(
     DFM6::framework
 )
 
+# Enable position-independent executables for improved security
+target_link_options(${PROJECT_NAME} PRIVATE -pie)
 
 if (COMPILE_ON_V2X)
     if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)

--- a/src/apps/dde-file-manager-preview/filepreview/CMakeLists.txt
+++ b/src/apps/dde-file-manager-preview/filepreview/CMakeLists.txt
@@ -27,4 +27,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     DFM6::base
 )
 
+# Enable position-independent executables for improved security
+target_link_options(${BIN_NAME} PRIVATE -pie)
+
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/src/apps/dde-file-manager/CMakeLists.txt
+++ b/src/apps/dde-file-manager/CMakeLists.txt
@@ -47,6 +47,9 @@ target_link_libraries(
     Dtk6::Widget
 )
 
+# Enable position-independent executables for improved security
+target_link_options(${PROJECT_NAME} PRIVATE -pie)
+
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
 
 # sh

--- a/src/services/diskencrypt/CMakeLists.txt
+++ b/src/services/diskencrypt/CMakeLists.txt
@@ -20,6 +20,9 @@ add_executable(${BIN_NAME}
 # Apply service configuration using shared dependencies
 dfm_setup_diskencrypt_dependencies(${PROJECT_NAME})
 
+# Enable position-independent executables for improved security
+target_link_options(${BIN_NAME} PRIVATE -pie)
+
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_NAME}.json DESTINATION share/deepin-service-manager/other/)
 install(FILES org.deepin.filemanager.diskencrypt.conf DESTINATION share/dbus-1/system.d/)


### PR DESCRIPTION
Add the -fPIE parameter via CMAKE_POSITION_INDEPENDENT_CODE.
Add the -pie parameter via target_link_options.

Log: Update compiler flags for security enhancements
Bug: https://pms.uniontech.com/bug-view-339563.html

## Summary by Sourcery

Enable position-independent code and executables across key file manager components to address platform-specific PIE defaults and improve security.

Build:
- Turn on CMAKE_POSITION_INDEPENDENT_CODE globally to compile position-independent code by default.
- Add -pie linker options to main file manager, dialogs, preview, daemon, and diskencrypt executables to produce position-independent executables.