### PR TITLE
refactor: simplify setting backend serialization logic

### DIFF
--- a/src/dfm-base/base/configs/private/settingbackend_p.h
+++ b/src/dfm-base/base/configs/private/settingbackend_p.h
@@ -84,7 +84,6 @@ private:
 private:
     QMap<QString, GetOptFunc> getters;
     QMap<QString, SaveOptFunc> setters;
-    QSet<QString> serialDataKey;
 
     static BidirectionHash<QString, Application::ApplicationAttribute> keyToAA;
     static BidirectionHash<QString, Application::GenericAttribute> keyToGA;

--- a/src/dfm-base/base/configs/settingbackend.cpp
+++ b/src/dfm-base/base/configs/settingbackend.cpp
@@ -80,7 +80,6 @@ SettingBackend::SettingBackend(QObject *parent)
 
     connect(Application::instance(), &Application::appAttributeEdited, this, &SettingBackend::onValueChanged);
     connect(Application::instance(), &Application::genericAttributeEdited, this, &SettingBackend::onValueChanged);
-    connect(this, &SettingBackend::optionSetted, this, &SettingBackend::onOptionSetted, Qt::QueuedConnection);
 
     initPresetSettingConfig();
 
@@ -184,33 +183,11 @@ void SettingBackend::addSettingAccessor(Application::GenericAttribute attr, Save
     qCDebug(logDFMBase) << "Setting accessor added for GenericAttribute:" << static_cast<int>(attr) << "key:" << uiKey;
 }
 
-void SettingBackend::addToSerialDataKey(const QString &key)
-{
-    d->serialDataKey.insert(key);
-}
-
-void SettingBackend::removeSerialDataKey(const QString &key)
-{
-    d->serialDataKey.remove(key);
-}
-
-void SettingBackend::onOptionSetted(const QString &key, const QVariant &value)
-{
-    if (d->serialDataKey.contains(key)) {
-        d->saveAsAppAttr(key, value);
-        d->saveAsGenAttr(key, value);
-        d->saveByFunc(key, value);
-    } else {
-        QSignalBlocker blocker(this);
-        d->saveAsAppAttr(key, value);
-        d->saveAsGenAttr(key, value);
-        d->saveByFunc(key, value);
-    }
-}
-
 void SettingBackend::doSetOption(const QString &key, const QVariant &value)
 {
-    Q_EMIT optionSetted(key, value);
+    d->saveAsAppAttr(key, value);
+    d->saveAsGenAttr(key, value);
+    d->saveByFunc(key, value);
 }
 
 void SettingBackend::onValueChanged(int attribute, const QVariant &value)

--- a/src/dfm-base/base/configs/settingbackend.h
+++ b/src/dfm-base/base/configs/settingbackend.h
@@ -35,14 +35,6 @@ public:
     void removeSettingAccessor(const QString &key);
     void addSettingAccessor(Application::ApplicationAttribute attr, SaveOptFunc set);
     void addSettingAccessor(Application::GenericAttribute attr, SaveOptFunc set);
-    void addToSerialDataKey(const QString &key);
-    void removeSerialDataKey(const QString &key);
-
-Q_SIGNALS:
-    void optionSetted(const QString &key, const QVariant &value);
-
-public Q_SLOTS:
-    void onOptionSetted(const QString &key, const QVariant &value);
 
 protected:
     void doSetOption(const QString &key, const QVariant &value);

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -226,17 +226,11 @@ void SideBarHelper::bindSetting(const QString &itemVisiableSettingKey, const QSt
                                                        std::bind(saver, itemVisiableControlKey, std::placeholders::_1));
     };
 
-    // FIXME(xust): i don't know what this function do, but seems works to solve this issue.
-    // commit: e634381afdb03f1f835e2e9f35d369ef782b0312
-    // Bug: 156469
-    // figure it out later.
-    SettingBackend::instance()->addToSerialDataKey(itemVisiableSettingKey);
     bindConf(itemVisiableSettingKey, itemVisiableControlKey);
 }
 
 void SideBarHelper::removebindingSetting(const QString &itemVisiableSettingKey)
 {
-    SettingBackend::instance()->removeSerialDataKey(itemVisiableSettingKey);
     SettingBackend::instance()->removeSettingAccessor(itemVisiableSettingKey);
 }
 


### PR DESCRIPTION
Removed the complex serial data key management system that was
previously used to handle special serialization cases. The code
now directly calls save methods in doSetOption instead of emitting
signals and using queued connections. This simplifies the architecture
and eliminates unnecessary complexity since the serial data key
functionality was not fully understood and appeared to be a workaround
for an unknown issue.

The changes include:
1. Remove serialDataKey member variable and related management methods
2. Remove optionSetted signal and onOptionSetted slot
3. Directly call save methods in doSetOption instead of using queued
connection
4. Remove serial data key registration from sidebar plugin

Influence:
1. Verify that setting changes still propagate correctly to all storage
backends
2. Test sidebar item visibility settings functionality
3. Check that application and generic attributes are properly saved
4. Validate that setting accessors work as expected after refactoring

refactor: 简化设置后端序列化逻辑

移除了之前用于处理特殊序列化情况的复杂串行数据键管理系统。代码现在直接在
doSetOption 中调用保存方法，而不是发射信号和使用队列连接。这简化了架构并
消除了不必要的复杂性，因为串行数据键功能未被完全理解且似乎是针对未知问题
的临时解决方案。

更改包括：
1. 移除 serialDataKey 成员变量及相关管理方法
2. 移除 optionSetted 信号和 onOptionSetted 槽
3. 直接在 doSetOption 中调用保存方法而非使用队列连接
4. 从侧边栏插件中移除串行数据键注册

Influence:
1. 验证设置更改是否正确传播到所有存储后端
2. 测试侧边栏项目可见性设置功能
3. 检查应用程序和通用属性是否正确保存
4. 验证重构后设置访问器是否按预期工作

BUG: https://pms.uniontech.com/bug-view-347481.html

## Summary by Sourcery

Simplify settings backend serialization by inlining save calls and removing the special serial-data key path and related signal/slot indirection.

Bug Fixes:
- Align sidebar visibility settings and other option writes with the unified direct-saving path to resolve issues previously worked around by serial data key handling.

Enhancements:
- Replace the queued signal-based option setting path with direct saving to application attributes, generic attributes, and custom accessors in doSetOption.
- Remove the unused serial data key tracking, including its storage, accessors, and sidebar registration hooks, to streamline settings handling.