### PR TITLE
fix: correct external device detection for encrypted partitions

### DIFF
--- a/src/dfm-base/base/device/private/deviceproxymanager_p.h
+++ b/src/dfm-base/base/device/private/deviceproxymanager_p.h
@@ -38,6 +38,7 @@ public:
     void initConnection();
     void initMounts();
     QString canonicalMountPoint(const QString &mpt) const;
+    bool isExternalBlock(const QVariantMap &info) const;
 
     void connectToDBus();
     void connectToAPI();

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -126,11 +126,10 @@ protected:
     long copyTid = { -1 };   // 使用 /pric/[pid]/task/[tid]/io 文件中的的 writeBytes 字段的值作为判断已写入数据的依据
     qint64 targetDeviceStartSectorsWritten { 0 };   // 记录任务开始时目标磁盘设备已写入扇区数
     QString targetSysDevPath;   // /sys/dev/block/x:x
-    qint16 targetLogSecionSize { 512 };   // 目标设备逻辑扇区大小
+    qint16 targetLogicSectorSize { 512 };   // 目标设备逻辑扇区大小
     qint8 targetIsRemovable { 1 };   // 目标磁盘设备是不是可移除或者热插拔设备
     DirPermissonList dirPermissonList;   // dir set Permisson list
     QFuture<void> syncResult;
-    QString blocakTargetRootPath;
 
     std::atomic_int threadCopyFileCount { 0 };
     QList<DFileInfoPointer> cutAndDeleteFiles;


### PR DESCRIPTION
The previous implementation had issues detecting external removable devices when they were encrypted partitions (LUKS/dm-crypt). The kRemovable property was being checked directly on the encrypted device instead of the underlying physical device. This caused encrypted external devices to be incorrectly classified as internal devices.

Key changes:
1. Added isExternalBlock() method that properly handles encrypted devices by checking the backing physical device's removable property
2. Replaced direct kRemovable checks with the new method in both initMounts() and addMounts()
3. Enhanced file copy progress tracking to correctly identify external encrypted devices by querying the underlying physical device information
4. Improved sector size detection using sysfs instead of relying on lsblk command
5. Removed unused blocakTargetRootPath variable

The fix ensures that encrypted external devices are properly recognized as removable, allowing for correct progress tracking and device management.

Log: Fixed issue where encrypted external devices were not properly detected as removable

Influence:
1. Test file copy operations to encrypted external USB drives
2. Verify progress tracking works correctly for encrypted devices
3. Check that encrypted devices appear in external devices list
4. Test with both encrypted and unencrypted external devices
5. Verify device properties are correctly reported for LUKS partitions

fix: 修复加密分区外部设备检测问题

之前的实现在处理加密分区（LUKS/dm-crypt）时无法正确检测外部可移动设备。
系统直接检查加密设备的kRemovable属性，而不是底层物理设备的属性，导致加密
的外部设备被错误分类为内部设备。

主要修改：
1. 新增isExternalBlock()方法，通过检查底层物理设备的可移动属性来正确处理 加密设备
2. 在initMounts()和addMounts()中替换直接kRemovable检查为新的方法
3. 增强文件复制进度跟踪功能，通过查询底层物理设备信息正确识别加密的外部 设备
4. 改用sysfs检测扇区大小，不再依赖lsblk命令
5. 移除未使用的blocakTargetRootPath变量

此修复确保加密的外部设备被正确识别为可移动设备，从而实现准确的进度跟踪和
设备管理。

Log: 修复加密外部设备无法正确识别为可移动设备的问题

Influence：
1. 测试向加密外部USB设备复制文件的功能
2. 验证加密设备的进度跟踪是否正常工作
3. 检查加密设备是否正确显示在外部设备列表中
4. 同时测试加密和未加密的外部设备
5. 验证LUKS分区的设备属性是否正确报告

Bug: https://pms.uniontech.com/bug-view-347531.html

## Summary by Sourcery

Ensure encrypted external block devices are correctly recognized as removable and update progress tracking to rely on sysfs-based sector size detection instead of lsblk.

New Features:
- Add centralized external block device detection that correctly handles encrypted devices by checking their backing physical device.

Bug Fixes:
- Fix misclassification of encrypted external removable devices as internal disks, restoring proper external device handling and progress tracking.

Enhancements:
- Refine file copy progress accounting to use DeviceProxyManager for external block detection and to read sector size from sysfs.
- Remove an unused target root path member from the file operation worker.