### PR TITLE
feat: enhance file indexing exclusion with pattern matcher

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.textindex.json
+++ b/assets/configs/org.deepin.dde.file-manager.textindex.json
@@ -143,7 +143,9 @@
 				"CMakeFiles",
 				"CMakeTmp",
 				"CMakeTmpQmake",
-				"lost+found"
+				"lost+found",
+				"UnixBench",
+				"tmp"
 			],
 			"serial": 0,
 			"flags": [],

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
@@ -259,6 +259,15 @@ void ImagePreviewController::onNeedIconFallback(const QUrl &url, const QSize &ta
         }
     }
 
+    // Strategy 3: Final fallback - use "unknown" icon to ensure preview always shows something
+    result = QIcon::fromTheme("unknown").pixmap(iconSizeSquare, dpr);
+    if (!result.isNull()) {
+        Q_EMIT previewReady(url, result);
+        return;
+    }
+
+    // Should never reach here, but emit loadFailed as ultimate safety net
+    fmWarning() << "detailview: failed to load any icon for" << url;
     Q_EMIT loadFailed(url);
 }
 

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/fileinfo/smbsharefileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/fileinfo/smbsharefileinfo.cpp
@@ -62,15 +62,21 @@ QIcon SmbShareFileInfo::fileIcon()
     bool isNetworkRoot = url.scheme() == Global::Scheme::kNetwork
             && url.path() == "/";
     bool isSmbRoot = url.scheme() == Global::Scheme::kSmb
-            && url.path().isEmpty();
+            && (url.path().isEmpty() || url.path() == "/");
 
     if (isNetworkRoot)
         return QIcon::fromTheme("network-workgroup");
     if (isSmbRoot)
         return QIcon::fromTheme("network-server");
 
+    QIcon icon;
     d->checkAndUpdateNode();
-    return QIcon::fromTheme(d->node.iconType);
+    icon = QIcon::fromTheme(d->node.iconType);
+
+    if (!icon.isNull())
+        return icon;
+
+    return QIcon::fromTheme("unknown");
 }
 
 bool SmbShareFileInfo::exists() const

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -7,6 +7,7 @@
 
 #include "fsmonitor.h"
 #include "fsmonitorworker.h"
+#include "utils/pathexcludematcher.h"
 
 #include <QFileInfo>
 #include <QSet>
@@ -108,7 +109,7 @@ public:
 
     QStringList rootPaths;
     QSet<QString> watchedDirectories;
-    QSet<QString> blacklistedPaths;
+    PathExcludeMatcher excludeMatcher;
     bool active { false };
 
     // Resource limits

--- a/src/services/textindex/utils/pathexcludematcher.cpp
+++ b/src/services/textindex/utils/pathexcludematcher.cpp
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "pathexcludematcher.h"
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+PathExcludeMatcher::PathExcludeMatcher() = default;
+
+PathExcludeMatcher::PathExcludeMatcher(const QStringList &patterns)
+{
+    addPatterns(patterns);
+}
+
+void PathExcludeMatcher::addPattern(const QString &pattern)
+{
+    if (pattern.isEmpty()) {
+        return;
+    }
+
+    // Check if pattern already exists
+    for (const auto &existing : m_patterns) {
+        if (existing.original == pattern) {
+            return;
+        }
+    }
+
+    m_patterns.append(parsePattern(pattern));
+}
+
+void PathExcludeMatcher::addPatterns(const QStringList &patterns)
+{
+    for (const QString &pattern : patterns) {
+        addPattern(pattern);
+    }
+}
+
+void PathExcludeMatcher::removePattern(const QString &pattern)
+{
+    m_patterns.removeIf([&pattern](const ExcludePattern &p) {
+        return p.original == pattern;
+    });
+}
+
+void PathExcludeMatcher::clear()
+{
+    m_patterns.clear();
+}
+
+bool PathExcludeMatcher::shouldExclude(const QString &absolutePath) const
+{
+    if (absolutePath.isEmpty() || m_patterns.isEmpty()) {
+        return false;
+    }
+
+    for (const auto &pattern : m_patterns) {
+        if (matchPattern(absolutePath, pattern)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+QStringList PathExcludeMatcher::patterns() const
+{
+    QStringList result;
+    result.reserve(m_patterns.size());
+    for (const auto &pattern : m_patterns) {
+        result.append(pattern.original);
+    }
+    return result;
+}
+
+bool PathExcludeMatcher::hasPatterns() const
+{
+    return !m_patterns.isEmpty();
+}
+
+int PathExcludeMatcher::patternCount() const
+{
+    return m_patterns.size();
+}
+
+PathExcludeMatcher::ExcludePattern PathExcludeMatcher::parsePattern(const QString &pattern)
+{
+    ExcludePattern result;
+    result.original = pattern;
+
+    // Determine pattern type based on syntax
+    if (pattern.startsWith('/')) {
+        // Absolute path prefix: starts with "/"
+        result.type = ExcludePatternType::AbsolutePrefix;
+    } else if (pattern.contains('*') || pattern.contains('?')) {
+        // Glob pattern: contains wildcards
+        result.type = ExcludePatternType::GlobPattern;
+        result.regex = globToRegex(pattern);
+    } else if (pattern.contains('/')) {
+        // Path segment: contains "/" but doesn't start with "/"
+        result.type = ExcludePatternType::PathSegment;
+    } else {
+        // Exact name: plain directory name
+        result.type = ExcludePatternType::ExactName;
+    }
+
+    return result;
+}
+
+bool PathExcludeMatcher::matchPattern(const QString &absolutePath, const ExcludePattern &pattern)
+{
+    switch (pattern.type) {
+    case ExcludePatternType::ExactName: {
+        // Split path into components and check if any matches exactly
+        // This ensures "tmp" matches "/home/user/tmp" and "/home/user/tmp/subdir"
+        // but NOT "/home/user/template"
+        const QStringList parts = absolutePath.split('/', Qt::SkipEmptyParts);
+        return parts.contains(pattern.original);
+    }
+
+    case ExcludePatternType::PathSegment: {
+        // Match path segment with proper boundaries
+        // Ensure we match complete path segments, not substrings
+        // ".local/share/Trash" should match "/.local/share/Trash/" or "/.local/share/Trash"
+        // but NOT "/.local/share/Trashcan"
+        const QString pathWithTrailingSlash = absolutePath.endsWith('/')
+                ? absolutePath
+                : absolutePath + '/';
+        const QString segmentPattern = '/' + pattern.original + '/';
+        return pathWithTrailingSlash.contains(segmentPattern);
+    }
+
+    case ExcludePatternType::AbsolutePrefix: {
+        // Match absolute path prefix
+        // "/home/user/exclude" matches "/home/user/exclude" and "/home/user/exclude/subdir"
+        if (absolutePath == pattern.original) {
+            return true;
+        }
+        // Ensure we match complete path components
+        const QString prefixWithSlash = pattern.original.endsWith('/')
+                ? pattern.original
+                : pattern.original + '/';
+        return absolutePath.startsWith(prefixWithSlash);
+    }
+
+    case ExcludePatternType::GlobPattern: {
+        // Split path into components and check if any matches the glob pattern
+        const QStringList parts = absolutePath.split('/', Qt::SkipEmptyParts);
+        for (const QString &part : parts) {
+            if (pattern.regex.match(part).hasMatch()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    }
+
+    return false;
+}
+
+QRegularExpression PathExcludeMatcher::globToRegex(const QString &glob)
+{
+    QString regexPattern;
+    regexPattern.reserve(glob.size() * 2);
+
+    // Anchor at start
+    regexPattern += '^';
+
+    for (const QChar &ch : glob) {
+        if (ch == '*') {
+            // * matches any characters (including none)
+            regexPattern += ".*";
+        } else if (ch == '?') {
+            // ? matches exactly one character
+            regexPattern += '.';
+        } else if (ch == '.' || ch == '+' || ch == '^' || ch == '$'
+                   || ch == '(' || ch == ')' || ch == '[' || ch == ']'
+                   || ch == '{' || ch == '}' || ch == '|' || ch == '\\') {
+            // Escape regex special characters
+            regexPattern += '\\';
+            regexPattern += ch;
+        } else {
+            regexPattern += ch;
+        }
+    }
+
+    // Anchor at end
+    regexPattern += '$';
+
+    return QRegularExpression(regexPattern);
+}
+
+SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/utils/pathexcludematcher.h
+++ b/src/services/textindex/utils/pathexcludematcher.h
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PATHEXCLUDEMATCHER_H
+#define PATHEXCLUDEMATCHER_H
+
+#include "service_textindex_global.h"
+
+#include <QList>
+#include <QRegularExpression>
+#include <QString>
+#include <QStringList>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+/**
+ * @brief Exclude pattern types for path matching
+ *
+ * Pattern syntax rules:
+ * - ExactName: Plain directory name like "tmp", ".git"
+ *   Matches any directory with this exact name in the path
+ *
+ * - PathSegment: Contains "/" but doesn't start with "/"
+ *   Like ".local/share/Trash", matches this exact path segment
+ *
+ * - AbsolutePrefix: Starts with "/" like "/home/user/exclude"
+ *   Matches paths that start with this absolute path
+ *
+ * - GlobPattern: Contains "*" or "?" wildcards
+ *   Like "build-*", "*.cache", matches directory names using glob
+ */
+enum class ExcludePatternType {
+    ExactName,   ///< Exact directory name match (e.g., "tmp", ".git")
+    PathSegment,   ///< Path segment match (e.g., ".local/share/Trash")
+    AbsolutePrefix,   ///< Absolute path prefix match (e.g., "/home/user/exclude")
+    GlobPattern   ///< Glob wildcard pattern (e.g., "build-*", "*.cache")
+};
+
+/**
+ * @brief Path exclusion pattern matcher
+ *
+ * A utility class for matching file system paths against exclusion patterns.
+ * Supports four types of matching syntax:
+ *
+ * 1. Exact Name Match (ExactName)
+ *    Syntax: "tmp", ".git", "node_modules"
+ *    Rule: If any directory component in the path exactly equals this value,
+ *          the path and all its children are excluded.
+ *    Example: "tmp" matches /home/user/tmp and /home/user/tmp/subdir,
+ *             but NOT /home/user/template
+ *
+ * 2. Path Segment Match (PathSegment)
+ *    Syntax: ".local/share/Trash" (contains "/" but doesn't start with "/")
+ *    Rule: The path contains this exact contiguous sub-path
+ *    Example: ".local/share/Trash" matches /home/user/.local/share/Trash/files
+ *
+ * 3. Absolute Prefix Match (AbsolutePrefix)
+ *    Syntax: "/home/user/exclude" (starts with "/")
+ *    Rule: The path starts with this absolute path
+ *    Example: "/home/user/exclude" matches /home/user/exclude/any/subpath
+ *
+ * 4. Glob Pattern Match (GlobPattern)
+ *    Syntax: "build-*", "*.cache", "test?" (contains * or ?)
+ *    Rule: Any directory component in the path matches the glob pattern
+ *    Example: "build-*" matches /project/build-debug/file
+ *
+ * @note This class is thread-safe for read operations after construction.
+ *       Write operations (add/remove/clear) are not thread-safe.
+ */
+class PathExcludeMatcher
+{
+public:
+    /**
+     * @brief Construct an empty matcher
+     */
+    PathExcludeMatcher();
+
+    /**
+     * @brief Construct a matcher with initial patterns
+     * @param patterns List of pattern strings to parse and add
+     */
+    explicit PathExcludeMatcher(const QStringList &patterns);
+
+    /**
+     * @brief Add a single exclusion pattern
+     * @param pattern Pattern string to parse and add
+     */
+    void addPattern(const QString &pattern);
+
+    /**
+     * @brief Add multiple exclusion patterns
+     * @param patterns List of pattern strings to parse and add
+     */
+    void addPatterns(const QStringList &patterns);
+
+    /**
+     * @brief Remove a pattern by its original string
+     * @param pattern Original pattern string to remove
+     */
+    void removePattern(const QString &pattern);
+
+    /**
+     * @brief Clear all patterns
+     */
+    void clear();
+
+    /**
+     * @brief Check if a path should be excluded
+     * @param absolutePath Absolute path to check
+     * @return true if path matches any exclusion pattern, false otherwise
+     */
+    bool shouldExclude(const QString &absolutePath) const;
+
+    /**
+     * @brief Get the list of original pattern strings
+     * @return List of pattern strings that were added
+     */
+    QStringList patterns() const;
+
+    /**
+     * @brief Check if the matcher has any patterns
+     * @return true if at least one pattern exists
+     */
+    bool hasPatterns() const;
+
+    /**
+     * @brief Get the number of patterns
+     * @return Number of patterns in the matcher
+     */
+    int patternCount() const;
+
+private:
+    /**
+     * @brief Internal representation of a parsed exclude pattern
+     */
+    struct ExcludePattern
+    {
+        QString original;   ///< Original pattern string
+        ExcludePatternType type;   ///< Parsed pattern type
+        QRegularExpression regex;   ///< Compiled regex (only for GlobPattern)
+    };
+
+    /**
+     * @brief Parse a pattern string into ExcludePattern
+     * @param pattern Raw pattern string
+     * @return Parsed ExcludePattern structure
+     */
+    static ExcludePattern parsePattern(const QString &pattern);
+
+    /**
+     * @brief Check if a path matches a specific pattern
+     * @param absolutePath Path to check
+     * @param pattern Parsed pattern to match against
+     * @return true if path matches the pattern
+     */
+    static bool matchPattern(const QString &absolutePath, const ExcludePattern &pattern);
+
+    /**
+     * @brief Convert a glob pattern to QRegularExpression
+     * @param glob Glob pattern string (e.g., "build-*", "*.cache")
+     * @return Compiled regular expression
+     */
+    static QRegularExpression globToRegex(const QString &glob);
+
+    QList<ExcludePattern> m_patterns;
+};
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // PATHEXCLUDEMATCHER_H


### PR DESCRIPTION
Added new PathExcludeMatcher utility class to improve file indexing exclusion logic. The matcher supports four pattern types: exact name matching, path segment matching, absolute prefix matching, and glob pattern matching. This replaces the previous simple substring matching with more precise path component-based exclusion.

Key changes:
1. Added PathExcludeMatcher class with comprehensive pattern matching capabilities
2. Updated FSMonitor to use the new matcher instead of QSet-based substring matching
3. Added support for glob patterns like "build-*" in exclusion lists
4. Improved exclusion accuracy by matching complete path components rather than substrings
5. Added new exclusion patterns: UnixBench, testdir, tmp, and build-*

The previous implementation used simple substring matching which could cause false positives (e.g., "tmp" would match "template"). The new matcher ensures proper boundary checking and supports more expressive exclusion patterns.

Log: Improved file indexing exclusion with advanced pattern matching

Influence:
1. Test file indexing with new exclusion patterns (UnixBench, testdir, tmp, build-*)
2. Verify that glob patterns like "build-*" correctly exclude matching directories
3. Test that exact name matching only excludes complete directory names
4. Verify path segment matching works correctly with multi-level paths
5. Test absolute path prefix exclusion functionality
6. Ensure previously excluded paths still work correctly
7. Check that performance is not negatively impacted

feat: 增强文件索引排除功能，支持模式匹配器

新增 PathExcludeMatcher 工具类来改进文件索引排除逻辑。该匹配器支持四种模
式类型：精确名称匹配、路径段匹配、绝对路径前缀匹配和通配符模式匹配。这取
代了之前简单的子字符串匹配，提供了更精确的基于路径组件的排除功能。

主要变更：
1. 添加 PathExcludeMatcher 类，具备全面的模式匹配能力
2. 更新 FSMonitor 使用新的匹配器替代基于 QSet 的子字符串匹配
3. 在排除列表中新增对通配符模式（如 "build-*"）的支持
4. 通过匹配完整路径组件而非子字符串提高排除准确性
5. 新增排除模式：UnixBench、testdir、tmp 和 build-*

之前的实现使用简单的子字符串匹配，可能导致误排除（例如 "tmp" 会匹配到
"template"）。新的匹配器确保正确的边界检查，并支持更具表达力的排除模式。

Log: 改进文件索引排除功能，支持高级模式匹配

Influence:
1. 测试使用新排除模式（UnixBench、testdir、tmp、build-*）的文件索引功能
2. 验证通配符模式如 "build-*" 是否正确排除匹配的目录
3. 测试精确名称匹配是否仅排除完整的目录名称
4. 验证路径段匹配在多级路径中的正确性
5. 测试绝对路径前缀排除功能
6. 确保之前排除的路径仍然正常工作
7. 检查性能是否受到负面影响

## Summary by Sourcery

Introduce a dedicated path exclusion matcher and integrate it into the file indexing monitor to improve accuracy and flexibility of excluded paths.

New Features:
- Add a PathExcludeMatcher utility that supports exact name, path segment, absolute prefix, and glob-based path exclusion patterns.
- Extend filesystem monitoring to use the new matcher for blacklist checks, enabling more expressive and precise exclusion rules.

Enhancements:
- Replace QSet-based substring blacklist handling in FSMonitor with the centralized PathExcludeMatcher while preserving the existing blacklist API surface.