### PR TITLE
fix: centralize password preprocessing in CIFS mount

### DIFF
--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -104,6 +104,11 @@ QVariantMap CifsMountHelper::mount(const QString &path, const QVariantMap &opts)
     const QString &version = d->probeVersion(host, port == -1 ? 0 : port);
     params.insert(MountOptionsField::kVersion, version);
 
+    // prepare password and cache
+    if (params.contains(MountOptionsField::kPasswd)) {
+        params[MountOptionsField::kPasswd] = preparePasswd(params[MountOptionsField::kPasswd]);
+    }
+
     int errNum = 0;
     QString errMsg;
     while (true) {
@@ -418,11 +423,11 @@ std::string CifsMountHelper::convertArgs(const QVariantMap &opts)
     QStringList params;
     using namespace MountOptionsField;
 
-    QString passwd;
     if (opts.contains(kUser) && opts.contains(kPasswd)
         && !opts.value(kUser).toString().isEmpty()
-        && !(passwd = preparePasswd(opts.value(kPasswd))).isEmpty()) {
+        && !opts.value(kPasswd).toString().isEmpty()) {
         const QString &user = opts.value(kUser).toString();
+        const QString &passwd = opts.value(kPasswd).toString();
         params.append(QString("user=%1").arg(user));
         params.append(QString("pass=%1").arg(passwd));
     } else {


### PR DESCRIPTION
1. Add password preparation step in mount function before calling convertArgs
2. Call preparePasswd to read and escape password from file descriptor
3. Remove redundant preparePasswd call in convertArgs
4. Ensure password is properly escaped before being used in mount arguments

Log: Centralize password preprocessing in CIFS mount

Influence:
1. Password handling is now centralized in mount function
2. Avoid duplicate password processing
3. Ensure password escaping is applied correctly
4. No functional change to mount behavior

fix: 集中 CIFS 挂载中的密码预处理

1. 在 mount 函数中调用 convertArgs 之前添加密码准备步骤
2. 调用 preparePasswd 从文件描述符读取并转义密码
3. 移除 convertArgs 中冗余的 preparePasswd 调用
4. 确保密码在用于挂载参数之前已正确转义

Log: 集中 CIFS 挂载中的密码预处理

Influence:
1. 密码处理现在集中在 mount 函数中
2. 避免重复的密码处理
3. 确保密码转义被正确应用
4. 挂载行为无功能变化

## Summary by Sourcery

Centralize CIFS mount password preprocessing in the mount flow to avoid duplicate handling and ensure consistently escaped credentials before argument conversion.

Enhancements:
- Move password preparation into the main mount function so credentials are processed once before convertArgs.
- Simplify convertArgs by assuming the password is already prepared and only constructing user/pass mount parameters.