### PR TITLE
refactor: simplify trash state change handling

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/mode/normalizedmode.cpp
@@ -775,7 +775,7 @@ void NormalizedMode::rebuild(bool reorganize)
         // In "organize on trigger" mode and not manually triggered (reorganize=false),
         // only classify files that were previously organized (from profiles).
         // This prevents newly enabled categories from auto-organizing files on desktop restart.
-        if (CfgPresenter->organizeOnTriggered()) {
+        if (!reorganize && CfgPresenter->organizeOnTriggered()) {
             QList<QUrl> organizedFiles;
             for (const CollectionBaseDataPtr &profile : profiles) {
                 std::copy_if(profile->items.cbegin(), profile->items.cend(),

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp
@@ -285,24 +285,8 @@ bool TrashHelper::customRoleDisplayName(const QUrl &url, const Global::ItemRoles
 
 void TrashHelper::onTrashStateChanged()
 {
-    // Ensure we know the current state before processing state change
-    ensureTrashStateInitialized();
-
     bool actuallyEmpty = FileUtils::trashIsEmpty();
-    TrashState newState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
-
-    // Only process if state actually changed
-    if (newState == trashState)
-        return;
-
-    trashState = newState;
-
-    // Update UI for any state change, but only when trash becomes non-empty
-    // This matches the original logic: if (isTrashEmpty) return;
-    if (trashState == TrashState::Empty) {
-        fmDebug() << "Trash: State changed to empty, no UI update needed";
-        return;
-    }
+    trashState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
 
     // When trash becomes non-empty, update UI
     const QList<quint64> &windowIds = FMWindowsIns.windowIdList();
@@ -384,15 +368,4 @@ void TrashHelper::initEvent()
     if (!resutl)
         fmWarning() << "subscribe signal_TrashCore_TrashStateChanged from dfmplugin_trashcore is failed.";
     connect(this, &TrashHelper::trashNotEmptyState, this, &TrashHelper::onTrashNotEmptyState, Qt::QueuedConnection);
-}
-
-void TrashHelper::ensureTrashStateInitialized()
-{
-    if (trashState == TrashState::Unknown) {
-        // Lazy initialization: determine actual trash state only when needed
-        bool actuallyEmpty = FileUtils::trashIsEmpty();
-        trashState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
-        fmDebug() << "Trash: Lazy initialized trash state to"
-                  << (trashState == TrashState::Empty ? "Empty" : "NotEmpty");
-    }
 }

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.h
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.h
@@ -90,7 +90,6 @@ private:
 
     explicit TrashHelper(QObject *parent = nullptr);
     void initEvent();
-    void ensureTrashStateInitialized();
 
 private:
     DFMBASE_NAMESPACE::LocalFileWatcher *trashFileWatcher { nullptr };


### PR DESCRIPTION
Removed redundant state initialization logic and simplified the trash
state change handling. The ensureTrashStateInitialized() method was
unnecessary since the state can be directly determined when needed. Also
removed the state change filtering logic since UI updates should happen
regardless of whether trash becomes empty or non-empty.

The previous implementation had complex state tracking with lazy
initialization and conditional UI updates. The new approach directly
checks the trash state and updates UI accordingly, making the code more
straightforward and eliminating potential state synchronization issues.

Log: Improved trash state change handling for better reliability

Influence:
1. Test moving files to trash and verify UI updates correctly
2. Test emptying trash and verify UI reflects empty state
3. Verify trash state changes are properly handled during application
startup
4. Test multiple rapid trash operations to ensure state consistency

refactor: 简化回收站状态变更处理

移除了冗余的状态初始化逻辑并简化了回收站状态变更处理。
ensureTrashStateInitialized() 方法不再必要，因为状态可以在需要时直接确
定。同时移除了状态变更过滤逻辑，因为无论回收站变为空还是非空状态，UI 都
应该更新。

之前的实现具有复杂的状态跟踪机制，包含延迟初始化和条件性 UI 更新。新方
法直接检查回收站状态并相应更新 UI，使代码更加直观，消除了潜在的状态同步
问题。

Log: 改进回收站状态变更处理以提高可靠性

Influence:
1. 测试将文件移至回收站并验证 UI 是否正确更新
2. 测试清空回收站并验证 UI 是否反映空状态
3. 验证应用启动期间回收站状态变更是否正确处理
4. 测试多次快速回收站操作以确保状态一致性

BUG: https://pms.uniontech.com/bug-view-347919.html

## Summary by Sourcery

Enhancements:
- Remove lazy trash state initialization helper and redundant state-change filtering to streamline and clarify trash state tracking and UI updates.