### PR TITLE
Fix: [dirshare] improve file watcher with parent directory monitoring

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/dfmplugin_dirshare_global.h
+++ b/src/plugins/common/dfmplugin-dirshare/dfmplugin_dirshare_global.h
@@ -38,6 +38,15 @@ inline constexpr char kAnonymous[] { "anonymous" };
 
 inline constexpr char kEventSpace[] { "dfmplugin_dirshare" };
 
+namespace ShareConfig {
+static constexpr char kShareConfigPath[] { "/var/lib/samba/usershares" };
+static constexpr char kShareName[] { "sharename" };
+static constexpr char kShareAcl[] { "usershare_acl" };
+static constexpr char kSharePath[] { "path" };
+static constexpr char kShareComment[] { "comment" };
+static constexpr char kGuestOk[] { "guest_ok" };
+}   // namespace ShareConfig
+
 DPDIRSHARE_END_NAMESPACE
 
 #endif   // DFMPLUGIN_DIRSHARE_GLOBAL_H

--- a/src/plugins/common/dfmplugin-dirshare/utils/sharewatchermanager.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/sharewatchermanager.cpp
@@ -5,6 +5,9 @@
 #include "sharewatchermanager.h"
 
 #include <dfm-base/file/local/localfilewatcher.h>
+#include <dfm-base/utils/finallyutil.h>
+
+#include <dfm-io/dfmio_utils.h>
 
 using namespace dfmplugin_dirshare;
 DFMBASE_USE_NAMESPACE
@@ -16,29 +19,154 @@ ShareWatcherManager::ShareWatcherManager(QObject *parent)
 
 ShareWatcherManager::~ShareWatcherManager()
 {
+    for (auto &watcher : watchers) {
+        if (watcher) {
+            watcher->stopWatcher();
+        }
+    }
+    for (auto &list : parentWatchers) {
+        for (auto &watcher : list) {
+            if (watcher) {
+                watcher->stopWatcher();
+            }
+        }
+    }
 }
 
-LocalFileWatcher *ShareWatcherManager::add(const QString &path)
+QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher> ShareWatcherManager::add(const QString &path)
 {
     auto watcher = watchers.value(path);
     if (watcher)
         return watcher;
 
-    watcher = new LocalFileWatcher(QUrl::fromLocalFile(path), this);
+    watcher = QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher>(new LocalFileWatcher(QUrl::fromLocalFile(path)));
+
+    if (!watcher) {
+        qWarning() << "Failed to create watcher for:" << path;
+        return nullptr;
+    }
+
+    connect(watcher.data(), &LocalFileWatcher::fileAttributeChanged, this, [this](const QUrl &url) {
+        if (shouldEmitSignal(url))
+            Q_EMIT this->fileAttributeChanged(url.toLocalFile());
+    });
+    connect(watcher.data(), &LocalFileWatcher::fileDeleted, this, [this](const QUrl &url) {
+        if (shouldEmitSignal(url))
+            Q_EMIT this->fileDeleted(url.toLocalFile());
+    });
+    connect(watcher.data(), &LocalFileWatcher::subfileCreated, this, [this](const QUrl &url) {
+        if (shouldEmitSignal(url))
+            Q_EMIT this->subfileCreated(url.toLocalFile());
+    });
+    connect(watcher.data(), &LocalFileWatcher::fileRename, this, [this](const QUrl &oldUrl, const QUrl &newUrl) {
+        if (shouldEmitSignal(oldUrl))
+            Q_EMIT this->fileMoved(oldUrl.toLocalFile(), newUrl.toLocalFile());
+    });
+
+    if (!watcher->startWatcher()) {
+        qWarning() << "Failed to start watcher for:" << path;
+        return nullptr;
+    }
+
     watchers.insert(path, watcher);
 
-    connect(watcher, &LocalFileWatcher::fileAttributeChanged, this, [this](const QUrl &url) { Q_EMIT this->fileAttributeChanged(url.toLocalFile()); });
-    connect(watcher, &LocalFileWatcher::fileDeleted, this, [this](const QUrl &url) { Q_EMIT this->fileDeleted(url.toLocalFile()); });
-    connect(watcher, &LocalFileWatcher::subfileCreated, this, [this](const QUrl &url) { Q_EMIT this->subfileCreated(url.toLocalFile()); });
-    connect(watcher, &LocalFileWatcher::fileRename, this, [this](const QUrl &oldUrl, const QUrl &newUrl) { Q_EMIT this->fileMoved(oldUrl.toLocalFile(), newUrl.toLocalFile()); });
-
-    watcher->startWatcher();
+    // 处理父目录监视器问题
+    if (path != ShareConfig::kShareConfigPath)
+        addParentPathsWatcher(path);
     return watcher;
 }
 
 void ShareWatcherManager::remove(const QString &path)
 {
     auto watcher = watchers.take(path);
-    if (watcher)
-        watcher->deleteLater();
+    // 处理父目录监视器问题
+    removeParentPathsWatcher(path);
+}
+
+void ShareWatcherManager::addParentPathsWatcher(const QString &path)
+{
+    auto rootPath = dfmio::DFMUtils::mountPathFromUrl(QUrl::fromLocalFile(path));
+    if (rootPath.isEmpty()) {
+        qWarning() << "Failed to get mount path for:" << path;
+        return;
+    }
+    if (path == rootPath || path == (rootPath + QDir::separator()))
+        return;
+
+    // 使用 QDir 处理路径，提高可读性和效率
+    QDir rootDir(rootPath);
+    QDir targetDir(path);
+
+    QString relativePath = rootDir.relativeFilePath(path);
+    QStringList parts = relativePath.split(QDir::separator(), Qt::SkipEmptyParts);
+
+    QString currentPath = rootPath;
+    for (const auto &part : parts) {
+        currentPath = QDir::cleanPath(currentPath + QDir::separator() + part);
+        addParentWatcher(path, currentPath);
+    }
+}
+
+void ShareWatcherManager::removeParentPathsWatcher(const QString &path)
+{
+    parentWatchers.remove(path);
+}
+
+void ShareWatcherManager::addParentWatcher(const QString &path, const QString &parentPath)
+{
+    auto add = [=](const QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher> &watcher){
+        if (watcher.isNull())
+            return;
+        auto ps = parentWatchers.value(path);
+        if (ps.contains(watcher))
+            return;
+        ps.append(watcher);
+        parentWatchers.insert(path, ps);
+    };
+
+    // 找当前监视的父目录
+    for (const auto &ps : parentWatchers.values()) {
+        for (const auto &p : ps) {
+            if (p && p->url().toLocalFile() == parentPath) {
+                add(p);
+                return;
+            }
+        }
+    }
+
+    // 找当前监视的共享目录
+    auto watcher = watchers.value(parentPath);
+
+    if (watcher.isNull())
+        watcher = QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher>(new LocalFileWatcher(QUrl::fromLocalFile(parentPath)));
+
+    connect(watcher.data(), &LocalFileWatcher::fileDeleted, this, [this](const QUrl &url) {
+        // 删除的目录是任意一个当前共享目录的父目录，发送当前共享目录被删除信号
+        const QString localPath = url.toLocalFile();
+        for (const auto &path : watchers.keys()) {
+            if (path == localPath || path.startsWith(localPath + QDir::separator()))
+                Q_EMIT this->fileDeleted(path);
+        }
+    });
+
+    connect(watcher.data(), &LocalFileWatcher::fileRename, this, [this](const QUrl &oldUrl, const QUrl &newUrl) {
+        Q_UNUSED(newUrl);
+        // 删除的目录是任意一个当前共享目录的父目录，发送当前共享目录被删除信号
+        for (const auto &path : watchers.keys()) {
+            const QString localPath = oldUrl.toLocalFile();
+            if (path == localPath || path.startsWith(localPath + QDir::separator()))
+                Q_EMIT this->fileDeleted(path);
+        }
+    });
+
+    add(watcher);
+    if (!watcher->startWatcher()) {
+        qWarning() << "Failed to start watcher for:" << path;
+        return;
+    }
+}
+
+bool ShareWatcherManager::shouldEmitSignal(const QUrl &url) const
+{
+    return url.toLocalFile().startsWith(ShareConfig::kShareConfigPath) || watchers.contains(url.toLocalFile());
 }

--- a/src/plugins/common/dfmplugin-dirshare/utils/sharewatchermanager.h
+++ b/src/plugins/common/dfmplugin-dirshare/utils/sharewatchermanager.h
@@ -26,8 +26,14 @@ public:
     explicit ShareWatcherManager(QObject *parent = nullptr);
     ~ShareWatcherManager();
 
-    DFMBASE_NAMESPACE::LocalFileWatcher *add(const QString &path);
+    QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher> add(const QString &path);
     void remove(const QString &path);
+
+private:
+    void addParentPathsWatcher(const QString &path);
+    void removeParentPathsWatcher(const QString &path);
+    void addParentWatcher(const QString &path, const QString &parentPath);
+    bool shouldEmitSignal(const QUrl &url) const;
 
 Q_SIGNALS:
     void fileDeleted(const QString &filePath);
@@ -36,7 +42,8 @@ Q_SIGNALS:
     void subfileCreated(const QString &filePath);
 
 private:
-    QMap<QString, DFMBASE_NAMESPACE::LocalFileWatcher *> watchers;
+    QHash<QString, QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher>> watchers;
+    QHash<QString, QList<QSharedPointer<DFMBASE_NAMESPACE::LocalFileWatcher>>> parentWatchers;
 };
 
 }

--- a/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
@@ -49,15 +49,6 @@ static constexpr char kFuncSetPasswd[] { "SetUserSharePassword" };
 static constexpr char kFuncCloseShare[] { "CloseSmbShareByShareName" };
 }   // namespace DaemonServiceIFace
 
-namespace ShareConfig {
-static constexpr char kShareConfigPath[] { "/var/lib/samba/usershares" };
-static constexpr char kShareName[] { "sharename" };
-static constexpr char kShareAcl[] { "usershare_acl" };
-static constexpr char kSharePath[] { "path" };
-static constexpr char kShareComment[] { "comment" };
-static constexpr char kGuestOk[] { "guest_ok" };
-}   // namespace ShareConfig
-
 UserShareHelper *UserShareHelper::instance()
 {
     static UserShareHelper helper;


### PR DESCRIPTION
- Convert watchers from raw pointers to QSharedPointer for better memory management
- Add parent directory watcher support to handle parent deletion/rename scenarios
- Monitor share config path changes in addition to shared directories
- Move ShareConfig namespace constants to global header for better code organization
- Use QHash instead of QMap for watcher storage

When a parent directory of a shared directory is deleted or renamed, the system now correctly detects and notifies about the shared directory changes.

Log: improve file watcher with parent directory monitoring
Bug: https://pms.uniontech.com/bug-view-346203.html

## Summary by Sourcery

Improve directory sharing watcher robustness by monitoring parent directories and share configuration paths while updating watcher storage and configuration constants.

New Features:
- Add monitoring for parent directories of shared paths to detect deletions and renames affecting shared directories.
- Emit share change events only when they relate to known shared paths or the share configuration directory.
- Expose share configuration constants in a global header for reuse across the plugin.

Bug Fixes:
- Ensure shared directory deletions are detected when a parent directory is removed or renamed.

Enhancements:
- Replace raw LocalFileWatcher pointers with QSharedPointer and store watchers in QHash for safer and faster lookup.
- Track and manage parent directory watcher instances associated with each shared path.