### PR TITLE
fix: fix drag drop validation for remote files

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.cpp
@@ -634,7 +634,7 @@ bool DragDropOper::checkSourceValid(const QList<QUrl> &srcUrls)
 
     return std::all_of(srcUrls.cbegin(), srcUrls.cend(),
                        [](const QUrl &url) {
-                           auto info = InfoFactory::create<FileInfo>(url);
+                           auto info = InfoFactory::create<FileInfo>(url, Global::kCreateFileInfoSync);
                            if (!info) {
                                fmDebug() << "Failed to create FileInfo for URL:" << url.toString();
                                return false;


### PR DESCRIPTION
Added protocol check to allow drag and drop operations for remote
files. Previously, the validation only worked with local files
but failed for remote URLs like sftp:// or webdav://. Now it uses
ProtocolUtils::isRemoteFile() to properly handle remote file sources.

Log: Fixed drag and drop validation for remote files

Influence:
1. Test dragging remote files from file manager to other applications
2. Verify drag operations work with sftp://, webdav:// and other remote
protocols
3. Check that local file drag operations still work correctly
4. Test mixed drag operations with both local and remote files

fix: 修复远程文件拖拽验证问题

添加协议检查以允许远程文件的拖拽操作。之前验证仅适用于本地文件，但对于
sftp://或webdav://等远程URL会失败。现在使用ProtocolUtils::isRemoteFile()
来正确处理远程文件源。

Log: 修复远程文件拖拽验证问题

Influence:
1. 测试从文件管理器拖拽远程文件到其他应用
2. 验证sftp://、webdav://等远程协议的拖拽操作
3. 检查本地文件拖拽操作是否仍然正常工作
4. 测试同时包含本地和远程文件的混合拖拽操作

BUG: https://pms.uniontech.com/bug-view-347825.html
