### PR TITLE
fix: adjust extension widget margins

### DIFF
--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
@@ -174,6 +174,8 @@ void DetailView::createExtensionWidgets()
 
         widget->setParent(this);
         widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+        if (auto layout = widget->layout())
+            layout->setContentsMargins(0, 0, 0, 0);
 
         // Wrap with separator frame
         QFrame *frame = new QFrame(this);


### PR DESCRIPTION
Fixed extension widget layout margins to remove unnecessary spacing
around the content. The extension widgets were previously using default
margins which created unwanted visual gaps. By setting the contents
margins to zero, the widgets now align properly with the surrounding
interface elements.

Influence:
1. Verify extension widgets display without extra spacing
2. Check that all extension widgets maintain proper alignment
3. Test with different extension types to ensure consistent appearance
4. Verify no layout issues occur when multiple extensions are present

fix: 调整扩展控件边距

修复扩展控件布局边距，移除内容周围不必要的间距。之前扩展控件使用默认边距
导致视觉上出现不必要的间隙。通过将内容边距设置为零，现在控件能够与周围界
面元素正确对齐。

Influence:
1. 验证扩展控件显示时没有额外间距
2. 检查所有扩展控件是否保持正确对齐
3. 测试不同类型的扩展以确保外观一致
4. 验证多个扩展同时存在时不会出现布局问题

BUG: https://pms.uniontech.com/bug-view-347993.html

## Summary by Sourcery

Bug Fixes:
- Remove unintended content margins from extension widgets in the detail view so they no longer render with extra padding around their contents.