### PR TITLE
fix: change button text from Verify Key to Verify Password

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
@@ -55,7 +55,7 @@ UnlockView::~UnlockView()
 QStringList UnlockView::btnText()
 {
     if (isOldPasswordSchemeMigrationModeFlag) {
-        return { tr("Cancel", "button"), tr("Verify Key", "button") };
+        return { tr("Cancel", "button"), tr("Verify Password", "button") };
     }
     return { tr("Cancel", "button"), tr("Unlock", "button") };
 }


### PR DESCRIPTION
Changed the button text from "Verify Key" to "Verify Password" in the
unlock view when the system is in old password scheme migration mode.
This change improves user interface clarity and consistency by using
more appropriate terminology that better matches user expectations and
the actual authentication method being used.

The modification ensures that users understand they need to verify
their password rather than a cryptographic key, which reduces potential
confusion during the vault unlocking process in migration scenarios.

Log: Updated button text from "Verify Key" to "Verify Password" for
better clarity

Influence:
1. Verify that the button text displays correctly as "Verify Password"
in old password scheme migration mode
2. Test that the regular unlock mode still shows "Unlock" button text
3. Confirm that cancel button text remains unchanged in both modes
4. Validate that the button functionality works correctly with the new
text

fix: 将按钮文本从"验证密钥"改为"验证密码"

在旧密码方案迁移模式下，将解锁视图中的按钮文本从"验证密钥"改为"验证密
码"。这一更改通过使用更合适的术语来提高用户界面清晰度和一致性，更好地符
合用户期望和实际使用的认证方法。

此修改确保用户理解他们需要验证的是密码而非加密密钥，从而减少在迁移场景下
解锁保险库过程中的潜在混淆。

Log: 将按钮文本从"验证密钥"更新为"验证密码"以提高清晰度

Influence:
1. 验证在旧密码方案迁移模式下按钮文本正确显示为"验证密码"
2. 测试常规解锁模式下的按钮文本仍显示为"解锁"
3. 确认取消按钮文本在两种模式下保持不变
4. 验证按钮功能在新文本下正常工作

BUG: https://pms.uniontech.com/bug-view-346805.html

## Summary by Sourcery

Bug Fixes:
- Update the unlock view migration-mode button label from 'Verify Key' to 'Verify Password' to better reflect the actual authentication action and reduce user confusion.