### PR TITLE
feat: add device usage monitoring with reference counting

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.Daemon.DeviceManager.xml
+++ b/assets/dbus/org.deepin.Filemanager.Daemon.DeviceManager.xml
@@ -73,6 +73,12 @@
     </method>
     <method name="DetachAllMountedDevices">
     </method>
+    <method name="StartMonitoringUsage">
+    </method>
+    <method name="StopMonitoringUsage">
+    </method>
+    <method name="RefreshDeviceUsage">
+    </method>
     <method name="GetBlockDevicesIdList">
       <arg type="as" direction="out"/>
       <arg name="opts" type="i" direction="in"/>

--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -752,6 +752,16 @@ void DeviceManager::stopPollingDeviceUsage()
     d->watcher->stopPollingUsage();
 }
 
+void DeviceManager::initUsageCache()
+{
+    d->watcher->initUsageCache();
+}
+
+void DeviceManager::refreshUsage()
+{
+    d->watcher->refreshUsage();
+}
+
 void DeviceManager::startMonitor()
 {
     if (isMonitoring())

--- a/src/dfm-base/base/device/devicemanager.h
+++ b/src/dfm-base/base/device/devicemanager.h
@@ -76,6 +76,10 @@ public:
 
     void startPollingDeviceUsage();
     void stopPollingDeviceUsage();
+
+    void initUsageCache();
+    void refreshUsage();
+
     void enableBlockAutoMount();
 
     void startMonitor();

--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -80,6 +80,33 @@ QVariantMap DeviceProxyManager::queryProtocolInfo(const QString &id, bool reload
     }
 }
 
+void DeviceProxyManager::subscribeUsageMonitoring()
+{
+    if (d->isDBusRuning() && d->devMngDBus) {
+        d->devMngDBus->StartMonitoringUsage();
+    } else {
+        DevMngIns->startPollingDeviceUsage();
+    }
+}
+
+void DeviceProxyManager::unsubscribeUsageMonitoring()
+{
+    if (d->isDBusRuning() && d->devMngDBus) {
+        d->devMngDBus->StopMonitoringUsage();
+    } else {
+        DevMngIns->stopPollingDeviceUsage();
+    }
+}
+
+void DeviceProxyManager::refreshUsage()
+{
+    if (d->isDBusRuning() && d->devMngDBus) {
+        d->devMngDBus->RefreshDeviceUsage();
+    } else {
+        DevMngIns->refreshUsage();
+    }
+}
+
 void DeviceProxyManager::reloadOpticalInfo(const QString &id)
 {
     if (d->isDBusRuning() && d->devMngDBus)

--- a/src/dfm-base/base/device/deviceproxymanager.h
+++ b/src/dfm-base/base/device/deviceproxymanager.h
@@ -38,6 +38,9 @@ public:
     QStringList getAllProtocolIds();
     QVariantMap queryBlockInfo(const QString &id, bool reload = false);
     QVariantMap queryProtocolInfo(const QString &id, bool reload = false);
+    void subscribeUsageMonitoring();
+    void unsubscribeUsageMonitoring();
+    void refreshUsage();
 
     // device operation
     void reloadOpticalInfo(const QString &id);

--- a/src/dfm-base/base/device/private/devicewatcher.h
+++ b/src/dfm-base/base/device/private/devicewatcher.h
@@ -37,6 +37,9 @@ public:
     void startPollingUsage();
     void stopPollingUsage();
 
+    void initUsageCache();
+    void refreshUsage();
+
     void startWatch();
     void stopWatch();
     void initDevDatas();

--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
@@ -9,6 +9,7 @@
 #include <dtkgui_global.h>
 #include <dtkwidget_global.h>
 #include <DDesktopServices>
+#include <QTimer>
 
 Q_DECLARE_LOGGING_CATEGORY(logAppDock)
 
@@ -381,4 +382,28 @@ void DockItemDataManager::watchService()
                 qCInfo(logAppDock) << serv << "registered.";
                 onServiceRegistered();
             });
+}
+
+void DockItemDataManager::subscribeUsageMonitoring()
+{
+    QTimer::singleShot(0, this, [this]() {
+        qCDebug(logAppDock) << "Dock plugin subscribing to device usage monitoring";
+        devMng->StartMonitoringUsage();
+    });
+}
+
+void DockItemDataManager::unsubscribeUsageMonitoring()
+{
+    QTimer::singleShot(0, this, [this]() {
+        qCDebug(logAppDock) << "Dock plugin unsubscribing from device usage monitoring";
+        devMng->StopMonitoringUsage();
+    });
+}
+
+void DockItemDataManager::refreshUsage()
+{
+    QTimer::singleShot(0, this, [this]() {
+        qInfo(logAppDock) << "Dock plugin requesting immediate device usage refresh";
+        devMng->RefreshDeviceUsage();
+    });
 }

--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.h
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.h
@@ -24,6 +24,10 @@ public:
     void ejectAll();
     void ejectDevice(const QString &id);
 
+    void subscribeUsageMonitoring();
+    void unsubscribeUsageMonitoring();
+    void refreshUsage();  // 立即刷新设备容量
+
 Q_SIGNALS:
     void requesetSetDockVisible(bool visible);
     void mountAdded(const DockItemData &item);

--- a/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.cpp
@@ -30,7 +30,25 @@ DeviceList::DeviceList(QWidget *parent)
 void DeviceList::showEvent(QShowEvent *e)
 {
     updateHeight();
+
+    // 立即刷新设备容量（显示最新数据）
+    qCDebug(logAppDock) << "DeviceList shown, requesting immediate usage refresh";
+    manager->refreshUsage();
+
+    // 订阅容量监控（引用计数 +1，持续更新）
+    qCDebug(logAppDock) << "DeviceList shown, subscribing to usage monitoring";
+    manager->subscribeUsageMonitoring();
+
     QScrollArea::showEvent(e);
+}
+
+void DeviceList::hideEvent(QHideEvent *e)
+{
+    // 取消订阅容量监控（引用计数 -1）
+    qCDebug(logAppDock) << "DeviceList hidden, unsubscribing from usage monitoring";
+    manager->unsubscribeUsageMonitoring();
+
+    QScrollArea::hideEvent(e);
 }
 
 void DeviceList::addDevice(const DockItemData &item)

--- a/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/devicelist.h
@@ -22,6 +22,7 @@ public:
 
 protected:
     void showEvent(QShowEvent *e) override;
+    void hideEvent(QHideEvent *e) override;
 
 private Q_SLOTS:
     void addDevice(const DockItemData &item);

--- a/src/plugins/daemon/core/dependencies.cmake
+++ b/src/plugins/daemon/core/dependencies.cmake
@@ -26,6 +26,12 @@ function(dfm_setup_daemon_core_dependencies target_name)
     #     OPTIONS -M -S
     # )
     
+    # qt6_generate_dbus_interface(
+    #     ${CMAKE_CURRENT_SOURCE_DIR}/devicemanagerdbus.h
+    #     ${DeviceManager_XML}
+    #     OPTIONS -M -S
+    # )
+
     # Add adaptors (Sync_XML will be available after generation)
     qt6_add_dbus_adaptor(DBUS_SOURCES ${DeviceManager_XML}
         devicemanagerdbus.h DeviceManagerDBus)

--- a/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
@@ -14,6 +14,8 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+
 #include <dfm-framework/dpf.h>
 
 #include <QEvent>
@@ -145,6 +147,13 @@ void ComputerView::showEvent(QShowEvent *event)
     fmInfo() << "start update item visible in computerview.";
     handleComputerItemVisible();
     fmInfo() << "end update item visible in computerview.";
+
+    // 订阅容量监控（引用计数 +1）
+    QTimer::singleShot(0, []() {
+        fmDebug() << "Computer view shown, subscribing to device usage monitoring";
+        DevProxyMng->subscribeUsageMonitoring();
+    });
+
     DListView::showEvent(event);
 }
 
@@ -152,6 +161,13 @@ void ComputerView::hideEvent(QHideEvent *event)
 {
     auto selectionModel = this->selectionModel();
     selectionModel->clearSelection();
+
+    // 取消订阅容量监控（引用计数 -1）
+    QTimer::singleShot(0, []() {
+        fmDebug() << "Computer view hidden, unsubscribing from device usage monitoring";
+        DevProxyMng->unsubscribeUsageMonitoring();
+    });
+
     DListView::hideEvent(event);
 }
 

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -992,7 +992,10 @@ void ComputerItemWatcher::onUpdateBlockItem(const QString &id)
         auto item = initedDatas.at(ret - initedDatas.cbegin());
         if (item.info) {
             item.info->refresh();
-            updateSidebarItem(devUrl, item.info->displayName(), item.info->renamable());
+            // 使用 QMetaObject::invokeMethod 确保在主线程调用 updateSidebarItem
+            QMetaObject::invokeMethod(this, [this, devUrl, item]() {
+                updateSidebarItem(devUrl, item.info->displayName(), item.info->renamable());
+            }, Qt::QueuedConnection);
         }
     }
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
@@ -110,12 +110,7 @@ QVariant FileItemData::data(int role) const
             const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url);
             if (info) {
                 info->customData(kItemFileRefreshIcon);
-
-                if (info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() && !info->extendAttributes(ExtInfoType::kFileNeedUpdate).toBool()) {
-                    updateOnce = true;
-                    info->setExtendedAttributes(ExtInfoType::kFileNeedUpdate, false);
-                    info->updateAttributes();
-                }
+                info->updateAttributes();
             } else {
                 fmWarning() << "Failed to create FileInfo for URL:" << url.toString();
             }
@@ -272,9 +267,9 @@ QVariant FileItemData::data(int role) const
     case kItemGroupDisplayIndex:
         return QVariant(groupDisplayIndex);
     case kItemFileIconRole:
-            if (!info)
-                return QIcon::fromTheme("empty");
-            return info->fileIcon();
+        if (!info)
+            return QIcon::fromTheme("empty");
+        return info->fileIcon();
     default:
         return QVariant();
     }


### PR DESCRIPTION
## Summary by Sourcery

Introduce on-demand device usage monitoring with reference-counted subscriptions over DBus, and hook UI components to start/stop monitoring based on visibility while providing explicit usage refresh APIs.

New Features:
- Add DBus methods and infrastructure to start, stop, and immediately refresh device usage monitoring per client.
- Expose subscription and refresh APIs in DeviceManager, DeviceWatcher, DeviceProxyManager, and dock/filemanager components for device usage monitoring.
- Initialize device usage cache once at startup without starting polling, and allow one-off refresh requests from clients.

Enhancements:
- Make device usage polling run only while there are subscribed clients using a reference-counted client set, including automatic cleanup on DBus client disconnect.
- Refine DeviceWatcher polling to use a persistent timer connection and log state transitions, and use the global thread pool for asynchronous usage queries.
- Simplify file item attribute updates by always refreshing attributes without special-case local device update flags.

Build:
- Comment out automatic DBus interface generation for DeviceManager in the daemon core CMake dependencies.