### PR TITLE
feat: implement trash file tag persistence

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -207,8 +207,8 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
                 completeSourceFiles.append(fileUrl);
                 completeCustomInfos.append(trashInfoCache);
             }
-            if (!completeTargetFiles.contains(restoreInfo->uri()))
-                completeTargetFiles.append(restoreInfo->uri());
+            if (!completeTargetFiles.contains(newTargetInfo->uri()))
+                completeTargetFiles.append(newTargetInfo->uri());
             emit fileRenamed(fileUrl, newTargetInfo->uri());
         } else {
             auto errorCode = fileHandler.errorCode();

--- a/src/plugins/common/dfmplugin-tag/data/tagproxyhandle.h
+++ b/src/plugins/common/dfmplugin-tag/data/tagproxyhandle.h
@@ -38,6 +38,12 @@ public:
     bool deleteFiles(const QVariantMap &value);
     bool deleteFileTags(const QVariantMap &value);
 
+    bool saveTrashFileTags(const QString &originalPath, qint64 inode, const QStringList &tags);
+    QStringList getTrashFileTags(const QString &originalPath, qint64 inode);
+    bool removeTrashFileTags(const QString &originalPath, qint64 inode);
+    bool clearAllTrashTags();
+    QVariantHash getAllTrashFileTags();
+
     bool connectToService();
 
     bool isValid();

--- a/src/plugins/common/dfmplugin-tag/dfmplugin_tag_global.h
+++ b/src/plugins/common/dfmplugin-tag/dfmplugin_tag_global.h
@@ -24,18 +24,23 @@ enum class QueryOpts : int {
     kTagsOfFile,   // get tags of a file
     kFilesOfTag,   // get files of a tag
     kColorOfTags,   // get color-tag map
-    kTagIntersectionOfFiles   // get tag intersection of files
+    kTagIntersectionOfFiles,   // get tag intersection of files
+    kTrashFileTags,   // get trash file tags
+    kAllTrashFileTags   // get all trash file tags
 };
 
 enum class InsertOpts : int {
     kTags,
-    kTagOfFiles
+    kTagOfFiles,
+    kTrashFileTags   // save trash file tags
 };
 
 enum class DeleteOpts : int {
     kTags,
     kFiles,
-    kTagOfFiles
+    kTagOfFiles,
+    kTrashFileTags,   // delete trash file tags
+    kAllTrashTags   // clear all trash file tags
 };
 
 enum class UpdateOpts : int {

--- a/src/plugins/common/dfmplugin-tag/events/tageventreceiver.h
+++ b/src/plugins/common/dfmplugin-tag/events/tageventreceiver.h
@@ -24,6 +24,8 @@ public slots:
     void handleFileCutResult(const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls, bool ok, const QString &errMsg);
     void handleFileCopyResult(const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls, bool ok, const QString &errMsg);
     void handleFileRemoveResult(const QList<QUrl> &srcUrls, bool ok, const QString &errMsg);
+    void handleFileTrashedResult(const QList<QUrl> &srcUrls, bool ok, const QString &errMsg);
+    void handleTrashCleanedResult(const QList<QUrl> &destUrls, bool ok, const QString &errMsg);
     void handleFileRenameResult(quint64 winId, const QMap<QUrl, QUrl> &renamedUrls, bool ok, const QString &errMsg);
     void handleWindowUrlChanged(quint64 winId, const QUrl &url);
     void handleRestoreFromTrashResult(const QList<QUrl> &srcUrls, const QList<QUrl> &destUrls,

--- a/src/plugins/common/dfmplugin-tag/tag.cpp
+++ b/src/plugins/common/dfmplugin-tag/tag.cpp
@@ -248,7 +248,8 @@ void Tag::bindEvents()
     dpfSignalDispatcher->subscribe(GlobalEventType::kHideFilesResult, TagEventReceiver::instance(), &TagEventReceiver::handleHideFilesResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kCutFileResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileCutResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kCopyResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileCopyResult);
-    dpfSignalDispatcher->subscribe(GlobalEventType::kMoveToTrashResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileRemoveResult);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kMoveToTrashResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileTrashedResult);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kCleanTrashResult, TagEventReceiver::instance(), &TagEventReceiver::handleTrashCleanedResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kDeleteFilesResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileRemoveResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kRenameFileResult, TagEventReceiver::instance(), &TagEventReceiver::handleFileRenameResult);
     dpfSignalDispatcher->subscribe(GlobalEventType::kRestoreFromTrashResult, TagEventReceiver::instance(), &TagEventReceiver::handleRestoreFromTrashResult);

--- a/src/plugins/common/dfmplugin-tag/utils/filetagcache.h
+++ b/src/plugins/common/dfmplugin-tag/utils/filetagcache.h
@@ -65,6 +65,11 @@ private:
     void taggeFiles(const QVariantMap &fileAndTags);
     void untaggeFiles(const QVariantMap &fileAndTags);
 
+    void saveTrashTags(const QString &path, qint64 inode, const QStringList &tags);
+    QStringList getTrashTags(const QString &path, qint64 inode) const;
+    void removeTrashTags(const QString &path, qint64 inode);
+    void clearAllTrashTags();
+
 private:
     QScopedPointer<FileTagCachePrivate> d;
 };
@@ -82,6 +87,11 @@ public:
     QStringList getTagsByFile(const QString &path);
     QMap<QString, QColor> getCacheTagsColor(const QStringList &tags);
     QHash<QString, QStringList> findChildren(const QString &parentPath) const;
+
+    void saveTrashFileTags(const QString &path, qint64 inode, const QStringList &tags);
+    QStringList getTrashFileTags(const QString &path, qint64 inode);
+    void removeTrashFileTags(const QString &path, qint64 inode);
+    void clearAllTrashTags();
 
 Q_SIGNALS:
     void initLoadTagInfos();

--- a/src/plugins/common/dfmplugin-tag/utils/private/filetagcache_p.h
+++ b/src/plugins/common/dfmplugin-tag/utils/private/filetagcache_p.h
@@ -19,6 +19,7 @@ class FileTagCachePrivate
 
     QHash<QString, QVariant> fileTagsCache;   // file path ->  tag name list
     QHash<QString, QColor> tagProperty;   // tag name -> QColor
+    QHash<QString, QVariant> trashFileTagsCache;   // "path:inode" -> tag name list
     QReadWriteLock lock;
 
 public:

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -483,6 +483,53 @@ bool TagManager::removeChildren(const QString &parentPath)
     return ret;
 }
 
+bool TagManager::saveTrashFileTags(const QString &originalPath, quint64 fileInode, const QStringList &tagNames)
+{
+    if (originalPath.isEmpty() || tagNames.isEmpty())
+        return false;
+
+    // Save to cache
+    FileTagCacheIns.saveTrashFileTags(originalPath, fileInode, tagNames);
+
+    // Save to database via D-Bus
+    return TagProxyHandleIns->saveTrashFileTags(originalPath, fileInode, tagNames);
+}
+
+QStringList TagManager::getTrashFileTags(const QString &originalPath, quint64 fileInode)
+{
+    if (originalPath.isEmpty())
+        return {};
+
+    // Try cache first
+    const auto &cachedTags = FileTagCacheIns.getTrashFileTags(originalPath, fileInode);
+    if (!cachedTags.isEmpty())
+        return cachedTags;
+
+    // Query from database via D-Bus
+    return TagProxyHandleIns->getTrashFileTags(originalPath, fileInode);
+}
+
+bool TagManager::removeTrashFileTags(const QString &originalPath, quint64 fileInode)
+{
+    if (originalPath.isEmpty())
+        return false;
+
+    // Remove from cache
+    FileTagCacheIns.removeTrashFileTags(originalPath, fileInode);
+
+    // Remove from database via D-Bus
+    return TagProxyHandleIns->removeTrashFileTags(originalPath, fileInode);
+}
+
+bool TagManager::clearAllTrashTags()
+{
+    // Clear cache
+    FileTagCacheIns.clearAllTrashTags();
+
+    // Clear database via D-Bus
+    return TagProxyHandleIns->clearAllTrashTags();
+}
+
 QMap<QString, QString> TagManager::getTagsColorName(const QStringList &tags) const
 {
     if (tags.isEmpty())

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
@@ -63,6 +63,12 @@ public:
     bool changeTagName(const QString &tagName, const QString &newName);
     bool removeChildren(const QString &parentPath);
 
+    // tag trash
+    bool saveTrashFileTags(const QString &originalPath, quint64 fileInode, const QStringList &tagNames);
+    QStringList getTrashFileTags(const QString &originalPath, quint64 fileInode);
+    bool removeTrashFileTags(const QString &originalPath, quint64 fileInode);
+    bool clearAllTrashTags();
+
     static void contenxtMenuHandle(quint64 windowId, const QUrl &url, const QPoint &globalPos);
     static void renameHandle(quint64 windowId, const QUrl &url, const QString &name);
 

--- a/src/plugins/daemon/tag/beans/trashfiletaginfo.cpp
+++ b/src/plugins/daemon/tag/beans/trashfiletaginfo.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "trashfiletaginfo.h"
+
+DAEMONPTAG_BEGIN_NAMESPACE
+
+TrashFileTagInfo::TrashFileTagInfo(QObject *parent)
+    : QObject(parent)
+{
+}
+
+int TrashFileTagInfo::getTrashIndex() const
+{
+    return trashIndex;
+}
+
+void TrashFileTagInfo::setTrashIndex(int value)
+{
+    trashIndex = value;
+}
+
+QString TrashFileTagInfo::getOriginalPath() const
+{
+    return originalPath;
+}
+
+void TrashFileTagInfo::setOriginalPath(const QString &value)
+{
+    originalPath = value;
+}
+
+qint64 TrashFileTagInfo::getFileInode() const
+{
+    return fileInode;
+}
+
+void TrashFileTagInfo::setFileInode(qint64 value)
+{
+    fileInode = value;
+}
+
+QString TrashFileTagInfo::getTagNames() const
+{
+    return tagNames;
+}
+
+void TrashFileTagInfo::setTagNames(const QString &value)
+{
+    tagNames = value;
+}
+
+qint64 TrashFileTagInfo::getDeleteTime() const
+{
+    return deleteTime;
+}
+
+void TrashFileTagInfo::setDeleteTime(qint64 value)
+{
+    deleteTime = value;
+}
+
+QString TrashFileTagInfo::getFuture() const
+{
+    return future;
+}
+
+void TrashFileTagInfo::setFuture(const QString &value)
+{
+    future = value;
+}
+
+DAEMONPTAG_END_NAMESPACE

--- a/src/plugins/daemon/tag/beans/trashfiletaginfo.h
+++ b/src/plugins/daemon/tag/beans/trashfiletaginfo.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TRASHFILETAGINFO_H
+#define TRASHFILETAGINFO_H
+
+#include "daemonplugin_tag_global.h"
+
+#include <QObject>
+
+DAEMONPTAG_BEGIN_NAMESPACE
+
+class TrashFileTagInfo : public QObject
+{
+    Q_OBJECT
+
+    Q_CLASSINFO("TableName", "trash_file_tags")
+    Q_PROPERTY(int trashIndex READ getTrashIndex WRITE setTrashIndex)
+    Q_PROPERTY(QString originalPath READ getOriginalPath WRITE setOriginalPath)
+    Q_PROPERTY(qint64 fileInode READ getFileInode WRITE setFileInode)
+    Q_PROPERTY(QString tagNames READ getTagNames WRITE setTagNames)
+    Q_PROPERTY(qint64 deleteTime READ getDeleteTime WRITE setDeleteTime)
+    Q_PROPERTY(QString future READ getFuture WRITE setFuture)
+
+public:
+    explicit TrashFileTagInfo(QObject *parent = nullptr);
+
+    int getTrashIndex() const;
+    void setTrashIndex(int value);
+
+    QString getOriginalPath() const;
+    void setOriginalPath(const QString &value);
+
+    qint64 getFileInode() const;
+    void setFileInode(qint64 value);
+
+    QString getTagNames() const;
+    void setTagNames(const QString &value);
+
+    qint64 getDeleteTime() const;
+    void setDeleteTime(qint64 value);
+
+    QString getFuture() const;
+    void setFuture(const QString &value);
+
+private:
+    int trashIndex {};
+    QString originalPath {};
+    qint64 fileInode {};
+    QString tagNames {};
+    qint64 deleteTime {};
+    QString future {};
+};
+
+DAEMONPTAG_END_NAMESPACE
+
+#endif   // TRASHFILETAGINFO_H

--- a/src/plugins/daemon/tag/daemonplugin_tag_global.h
+++ b/src/plugins/daemon/tag/daemonplugin_tag_global.h
@@ -24,18 +24,23 @@ enum class QueryOpts : int {
     kTagsOfFile,   // get tags of a file
     kFilesOfTag,   // get files of a tag
     kColorOfTags,   // get color-tag map
-    kTagIntersectionOfFiles   // get tag intersection of files
+    kTagIntersectionOfFiles,   // get tag intersection of files
+    kTrashFileTags,   // get trash file tags
+    kAllTrashFileTags   // get all trash file tags
 };
 
 enum class InsertOpts : int {
     kTags,
-    kTagOfFiles
+    kTagOfFiles,
+    kTrashFileTags   // save trash file tags
 };
 
 enum class DeleteOpts : int {
     kTags,
     kFiles,
-    kTagOfFiles
+    kTagOfFiles,
+    kTrashFileTags,   // remove trash file tags
+    kAllTrashTags   // clear all trash tags
 };
 
 enum class UpdateOpts : int {

--- a/src/plugins/daemon/tag/tagdbhandler.h
+++ b/src/plugins/daemon/tag/tagdbhandler.h
@@ -55,6 +55,15 @@ public:
     bool changeTagNamesWithFiles(const QVariantMap &data);
     bool changeFilePaths(const QVariantMap &data);
 
+    // Trash file tags operations
+    bool saveTrashFileTags(const QString &originalPath, qint64 inode, const QStringList &tags);
+    QStringList getTrashFileTags(const QString &originalPath, qint64 inode);
+    QVariantMap getTrashFileTags(const QStringList &queryParams);
+    bool removeTrashFileTags(const QString &originalPath, qint64 inode);
+    bool clearAllTrashTags();
+    bool hasTrashFileTags(const QString &originalPath, qint64 inode);
+    QVariantHash getAllTrashFileTags();
+
     QString lastError() const;
 
 private:
@@ -76,6 +85,9 @@ Q_SIGNALS:
     void tagsNameChanged(const QVariantMap &oldAndNewName);
     void filesWereTagged(const QVariantMap &filesWereTagged);
     void filesUntagged(const QVariantMap &delTagsOfFile);
+    void trashFileTagsSaved(const QString &originalPath, qint64 inode, const QStringList &tags);
+    void trashFileTagsRestored(const QString &originalPath, qint64 inode);
+    void trashTagsCleared();
 
 private:
     QScopedPointer<DFMBASE_NAMESPACE::SqliteHandle> handle;

--- a/src/plugins/daemon/tag/tagmanagerdbus.cpp
+++ b/src/plugins/daemon/tag/tagmanagerdbus.cpp
@@ -48,6 +48,13 @@ QDBusVariant TagManagerDBus::Query(int opt, const QStringList value)
     case QueryOpts::kTagIntersectionOfFiles:
         dbusVar.setVariant(TagDbHandler::instance()->getSameTagsOfDiffUrls(value));
         break;
+    case QueryOpts::kTrashFileTags:
+        dbusVar.setVariant(TagDbHandler::instance()->getTrashFileTags(value));
+        break;
+    case QueryOpts::kAllTrashFileTags: {
+        dbusVar.setVariant(TagDbHandler::instance()->getAllTrashFileTags());
+        break;
+    }
     }
 
     return dbusVar;
@@ -62,6 +69,12 @@ bool TagManagerDBus::Insert(int opt, const QVariantMap value)
         return TagDbHandler::instance()->addTagProperty(value);
     case InsertOpts::kTagOfFiles:
         return TagDbHandler::instance()->addTagsForFiles(value);
+    case InsertOpts::kTrashFileTags: {
+        QString path = value.value("originalPath").toString();
+        qint64 inode = value.value("inode").toLongLong();
+        QStringList tags = value.value("tags").toStringList();
+        return TagDbHandler::instance()->saveTrashFileTags(path, inode, tags);
+    }
     }
 
     return false;
@@ -72,6 +85,13 @@ bool TagManagerDBus::Delete(int opt, const QVariantMap value)
     DeleteOpts deleteOpt { opt };
 
     switch (deleteOpt) {
+    case DeleteOpts::kTrashFileTags: {
+        QString path = value.value("originalPath").toString();
+        qint64 inode = value.value("inode").toLongLong();
+        return TagDbHandler::instance()->removeTrashFileTags(path, inode);
+    }
+    case DeleteOpts::kAllTrashTags:
+        return TagDbHandler::instance()->clearAllTrashTags();
     case DeleteOpts::kTags:
         return TagDbHandler::instance()->deleteTags(value.first().toStringList());
     case DeleteOpts::kFiles:


### PR DESCRIPTION
Add trash file tag management system to preserve file tags when files
are moved to trash and restore them when files are recovered
1. Add new database table for storing trash file tags with original path
and inode as key
2. Implement D-Bus interface extensions for trash tag operations
3. Add event handlers for trash operations (move to trash, clean trash,
restore from trash)
4. Create cache layer for trash tag data to improve performance
5. Parse trash info files during restore to recover original file path
6. Use inode-based identification to handle file path changes

Log: Added trash file tag persistence feature

Influence:
1. Test moving tagged files to trash and verify tags are preserved
2. Test restoring files from trash and verify tags are recovered
3. Test cleaning trash and verify all trash tags are removed
4. Test multiple files with same name but different paths in trash
5. Verify tag cache consistency after trash operations
6. Test D-Bus interface for trash tag operations
7. Verify database integrity after multiple trash operations

feat: 实现回收站文件标签持久化功能

新增回收站文件标签管理系统，用于在文件移至回收站时保留标签，并在文件恢复
时还原标签
1. 新增数据库表用于存储回收站文件标签，以原始路径和inode作为键
2. 实现回收站标签操作的D-Bus接口扩展
3. 添加回收站操作的事件处理程序（移至回收站、清空回收站、从回收站恢复）
4. 创建回收站标签数据缓存层以提高性能
5. 在恢复时解析回收站信息文件以恢复原始文件路径
6. 使用基于inode的标识来处理文件路径变更

Log: 新增回收站文件标签持久化功能

Influence:
1. 测试将带标签文件移至回收站并验证标签是否保留
2. 测试从回收站恢复文件并验证标签是否还原
3. 测试清空回收站并验证所有回收站标签是否被移除
4. 测试回收站中同名但路径不同的多个文件
5. 验证回收站操作后标签缓存的一致性
6. 测试回收站标签操作的D-Bus接口
7. 验证多次回收站操作后数据库的完整性

BUG: https://pms.uniontech.com/bug-view-333051.html

## Summary by Sourcery

Add persistent management of tags for files moved to and restored from the trash, backed by a new database table, D-Bus APIs, and event handling.

New Features:
- Persist tags for trashed files using a dedicated trash_file_tags database table keyed by original path and inode.
- Expose trash tag operations over existing D-Bus interfaces for saving, querying, and deleting trash tag records.
- Maintain an in-memory cache of trash file tags to speed up lookups during trash and restore operations.
- Handle tag preservation on move-to-trash, restore-from-trash, and clean-trash events so tags are removed from live files, stored with trash metadata, and restored when recovered.

Bug Fixes:
- Ensure restore-from-trash processing uses the actual new target URLs when aggregating restored destinations.