### PR TITLE
fix: improve root path comparison in file cleanup

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -97,7 +97,12 @@ void FileDataManager::cleanRoot(const QUrl &rootUrl)
 
     auto rootInfoKeys = rootInfoMap.keys();
     for (const auto &rootInfo : rootInfoKeys) {
-        if (rootInfo.path().startsWith(rootPath) || rootInfo.path() == rootUrl.path()) {
+        QString infoPath = rootInfo.path();
+        if (!infoPath.endsWith("/"))
+            infoPath.append("/");
+
+        // Compare normalized paths (both with trailing slash) for accurate matching
+        if (infoPath.startsWith(rootPath) || infoPath == rootPath) {
             rootInfoMap.value(rootInfo)->disconnect();
             auto root = rootInfoMap.take(rootInfo);
             if (!root) {


### PR DESCRIPTION
Fixed path comparison logic in FileDataManager::cleanRoot to handle
trailing slashes consistently. Previously, the comparison could fail
when one path had a trailing slash and the other didn't. Now both paths
are normalized to have trailing slashes before comparison, ensuring
accurate matching when cleaning up root file data.

The change ensures that path comparisons work correctly regardless of
trailing slash variations, preventing potential memory leaks or improper
cleanup of file data when managing workspace roots.

Influence:
1. Test file manager cleanup with various path formats (with/without
trailing slashes)
2. Verify root path removal works correctly for nested directories
3. Check memory management when multiple roots are cleaned up
4. Test edge cases with similar path prefixes

fix: 修复文件清理中根路径比较问题

修复了 FileDataManager::cleanRoot 中的路径比较逻辑，确保处理尾部斜杠的
一致性。之前当一个路径有尾部斜杠而另一个没有时，比较可能会失败。现在在
比较之前将两个路径都标准化为带有尾部斜杠，确保在清理根文件数据时能够准确
匹配。

此更改确保路径比较在不同尾部斜杠变体下都能正确工作，防止在管理工作区根目
录时出现潜在的内存泄漏或文件数据清理不当。

Influence:
1. 测试使用各种路径格式（带/不带尾部斜杠）的文件管理器清理功能
2. 验证嵌套目录的根路径删除功能正常工作
3. 检查清理多个根目录时的内存管理
4. 测试具有相似路径前缀的边缘情况

BUG: https://pms.uniontech.com/bug-view-314159.html

## Summary by Sourcery

Bug Fixes:
- Fix root path comparison in FileDataManager::cleanRoot to handle trailing slashes consistently and avoid missed cleanup of matching roots.