### PR TITLE
fix: use IO‑free path canonicalization to avoid blocking main thread

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -9,6 +9,8 @@
 
 #include <QDBusServiceWatcher>
 
+#include <glib.h>
+
 using namespace dfmbase;
 static constexpr char kDeviceService[] { "org.deepin.Filemanager.Daemon" };
 static constexpr char kDevMngPath[] { "/org/deepin/Filemanager/Daemon/DeviceManager" };
@@ -299,9 +301,9 @@ QString DeviceProxyManagerPrivate::canonicalMountPoint(const QString &mpt) const
         return {};
 
     QString mountPoint = mpt;
-    QFileInfo fileInfo(mountPoint);
-    if (fileInfo.exists())
-        mountPoint = fileInfo.canonicalFilePath();
+    g_autofree gchar *canonical_mpt = g_canonicalize_filename(mountPoint.toStdString().c_str(), NULL);
+    if (canonical_mpt)
+        mountPoint = canonical_mpt;
 
     mountPoint = mountPoint.endsWith("/") ? mountPoint : mountPoint + "/";
     return mountPoint;


### PR DESCRIPTION
Replace QFileInfo::canonicalFilePath() with g_canonicalize_filename() in DeviceProxyManagerPrivate::canonicalMountPoint(). The former performs actual filesystem I/O to resolve symlinks and check file existence, which can block the main thread when called frequently or on slow storage. The latter is a purely string‑based path normalization that does not access the filesystem, providing the same canonical form without I/O overhead.

Log: Replace QFileInfo::canonicalFilePath with g_canonicalize_filename to avoid blocking main thread

Influence:
1. Verify that canonicalMountPoint still returns correct canonical paths for typical mount point strings (including paths with ".", "..", extra slashes, and symlinks)
2. Ensure the function does not introduce regressions in device mounting, unmounting, or mount point detection
3. Confirm that external and protocol device mount point caching works correctly with the new implementation
4. Test that the change does not affect performance negatively in other parts of the system

fix: 使用无IO的路径规范化函数避免主线程卡顿

将 DeviceProxyManagerPrivate::canonicalMountPoint() 中的 QFileInfo::canonicalFilePath() 替换为 g_canonicalize_filename()。 前者会执行实际的文件系统 I/O 来解析符号链接并检查文件存在性，当频繁调用或
在慢速存储上时可能阻塞主线程。后者是纯字符串的路径规范化，不访问文件系统，
提供相同的规范形式而无 I/O 开销。

Log: 将 QFileInfo::canonicalFilePath 替换为 g_canonicalize_filename 以避免阻塞主线程

Influence:
1. 验证 canonicalMountPoint 对于典型的挂载点字符串（包括包含 "."、".."、 多余斜杠和符号链接的路径）仍返回正确的规范路径
2. 确保该函数不会在设备挂载、卸载或挂载点检测中引入回归
3. 确认外部设备和协议设备挂载点缓存与新实现正常工作
4. 测试该更改不会对系统其他部分的性能产生负面影响

Bug: https://pms.uniontech.com/bug-view-338063.html

## Summary by Sourcery

Enhancements:
- Replace QFileInfo-based canonicalization with glib's g_canonicalize_filename in DeviceProxyManagerPrivate::canonicalMountPoint to eliminate filesystem I/O during mount point normalization.