### PR TITLE
Revert "refactor: simplify setting backend serialization logic"

### DIFF
--- a/src/dfm-base/base/configs/private/settingbackend_p.h
+++ b/src/dfm-base/base/configs/private/settingbackend_p.h
@@ -84,6 +84,7 @@ private:
 private:
     QMap<QString, GetOptFunc> getters;
     QMap<QString, SaveOptFunc> setters;
+    QSet<QString> serialDataKey;
 
     static BidirectionHash<QString, Application::ApplicationAttribute> keyToAA;
     static BidirectionHash<QString, Application::GenericAttribute> keyToGA;

--- a/src/dfm-base/base/configs/settingbackend.h
+++ b/src/dfm-base/base/configs/settingbackend.h
@@ -35,6 +35,14 @@ public:
     void removeSettingAccessor(const QString &key);
     void addSettingAccessor(Application::ApplicationAttribute attr, SaveOptFunc set);
     void addSettingAccessor(Application::GenericAttribute attr, SaveOptFunc set);
+    void addToSerialDataKey(const QString &key);
+    void removeSerialDataKey(const QString &key);
+
+Q_SIGNALS:
+    void optionSetted(const QString &key, const QVariant &value);
+
+public Q_SLOTS:
+    void onOptionSetted(const QString &key, const QVariant &value);
 
 protected:
     void doSetOption(const QString &key, const QVariant &value);

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -226,11 +226,17 @@ void SideBarHelper::bindSetting(const QString &itemVisiableSettingKey, const QSt
                                                        std::bind(saver, itemVisiableControlKey, std::placeholders::_1));
     };
 
+    // FIXME(xust): i don't know what this function do, but seems works to solve this issue.
+    // commit: e634381afdb03f1f835e2e9f35d369ef782b0312
+    // Bug: 156469
+    // figure it out later.
+    SettingBackend::instance()->addToSerialDataKey(itemVisiableSettingKey);
     bindConf(itemVisiableSettingKey, itemVisiableControlKey);
 }
 
 void SideBarHelper::removebindingSetting(const QString &itemVisiableSettingKey)
 {
+    SettingBackend::instance()->removeSerialDataKey(itemVisiableSettingKey);
     SettingBackend::instance()->removeSettingAccessor(itemVisiableSettingKey);
 }
 


### PR DESCRIPTION
Reverts linuxdeepin/dde-file-manager#3510

## Summary by Sourcery

Restore serialized handling of certain setting updates via a dedicated signal/slot in SettingBackend and adjust sidebar bindings to use it for visibility settings.

Bug Fixes:
- Prevent incorrect or re-entrant handling of sidebar visibility settings by reintroducing special serialized processing for selected setting keys.

Enhancements:
- Reintroduce tracking of setting keys requiring serialized updates in SettingBackend and wire it through a signal/slot mechanism used by sidebar configuration.