### PR TITLE
chore: bump version to 6.5.117

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.117) unstable; urgency=medium
+
+  * Revert "refactor: simplify setting backend serialization logic"
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 23 Jan 2026 11:29:37 +0800
+
 dde-file-manager (6.5.116) unstable; urgency=medium
 
   * feat: optimize directory scanning performance


### PR DESCRIPTION
6.5.116

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog metadata for the 6.5.117 release.