### PR TITLE
fix: check local file before creating file info in property dialog

### DIFF
--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -226,10 +226,12 @@ void CommandParser::showPropertyDialog()
     QList<QUrl> urlList;
     for (const QString &path : paths) {
         QUrl url = QUrl::fromUserInput(path);
-        const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
-        if (!fileInfo || !fileInfo->exists()) {
-            qCWarning(logAppFileManager) << "Failed to show property dialog: invalid path or file not exists -" << path;
-            continue;
+        if (url.isLocalFile()) {
+            const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(url);
+            if (!fileInfo || !fileInfo->exists()) {
+                qCWarning(logAppFileManager) << "Failed to show property dialog: invalid path or file not exists -" << path;
+                continue;
+            }
         }
 
         QString uPath = url.path();


### PR DESCRIPTION
Added local file validation before attempting to create FileInfo objects for property dialog. Previously, the code would try to create FileInfo for any URL path without checking if it's a local file, which could cause issues with non-local file paths. Now only local files are processed for property dialog display, preventing potential crashes or errors when handling remote or special URLs.

Log: Fixed property dialog opening failure with non-local file paths

Influence:
1. Test opening property dialog with local files - should work normally
2. Test with remote URLs (ftp, http) - should skip gracefully without errors
3. Test with invalid local paths - should show warning and skip
4. Verify that valid local files still display property dialog correctly
5. Check console logs for proper warning messages when skipping non- local files

fix: 在属性对话框创建文件信息前检查是否为本地文件

添加了本地文件验证，在尝试为属性对话框创建FileInfo对象之前进行检查。之
前代码会为任何URL路径尝试创建FileInfo，而不检查是否为本地文件，这可能导
致处理远程或特殊URL时出现问题。现在只有本地文件会被处理用于属性对话框显
示，防止处理远程URL时出现潜在崩溃或错误。

Log: 修复了使用非本地文件路径时属性对话框打开失败的问题

Influence:
1. 测试使用本地文件打开属性对话框 - 应正常工作
2. 测试使用远程URL（ftp、http） - 应优雅跳过且不报错
3. 测试使用无效本地路径 - 应显示警告并跳过
4. 验证有效的本地文件仍能正确显示属性对话框
5. 检查控制台日志，确保跳过非本地文件时有正确的警告信息

Bug: https://pms.uniontech.com/bug-view-348227.html

## Summary by Sourcery

Bug Fixes:
- Prevent property dialog failures when invoked with non-local or invalid file paths by skipping non-local URLs and logging warnings.