### PR TITLE
fix: improve file watcher handling for settings files

### DIFF
--- a/src/dfm-base/base/configs/private/settingbackend_p.h
+++ b/src/dfm-base/base/configs/private/settingbackend_p.h
@@ -11,6 +11,7 @@
 #include <QMap>
 #include <QVariant>
 #include <QSet>
+#include <QTimer>
 
 DFMBASE_BEGIN_NAMESPACE
 
@@ -85,6 +86,7 @@ private:
     QMap<QString, GetOptFunc> getters;
     QMap<QString, SaveOptFunc> setters;
     QSet<QString> serialDataKey;
+    QTimer serialSyncTimer;
 
     static BidirectionHash<QString, Application::ApplicationAttribute> keyToAA;
     static BidirectionHash<QString, Application::GenericAttribute> keyToGA;

--- a/src/plugins/filedialog/core/core.cpp
+++ b/src/plugins/filedialog/core/core.cpp
@@ -23,9 +23,6 @@ DFM_LOG_REGISTER_CATEGORY(DIALOGCORE_NAMESPACE)
 
 bool Core::start()
 {
-    DFMBASE_NAMESPACE::Application::instance()->appSetting()->setReadOnly(true);
-    DFMBASE_NAMESPACE::Application::instance()->appObtuselySetting()->setReadOnly(true);
-
     enterHighPerformanceMode();
     FMWindowsIns.setCustomWindowCreator([](const QUrl &url) {
         return new FileDialog(url);
@@ -86,6 +83,9 @@ void Core::onAllPluginsStarted()
 {
     if (!registerDialogDBus())
         abort();
+
+    DFMBASE_NAMESPACE::Application::instance()->appSetting()->setReadOnly(true);
+    DFMBASE_NAMESPACE::Application::instance()->appObtuselySetting()->setReadOnly(true);
 
     dfmplugin_menu_util::menuSceneRegisterScene(FileDialogMenuCreator::name(), new FileDialogMenuCreator);
     bindScene("WorkspaceMenu");


### PR DESCRIPTION
Added file rename event handling to properly monitor settings files
when they are rewritten (e.g., by QSaveFile). Previously, when QSaveFile
commits changes by renaming a temporary file to the target file, the
file watcher would stop working because the inode changes. This fix adds
a rename event handler that reloads configuration data and restarts the
watcher when such events occur.

Also fixed the initialization order in the file dialog plugin to set
settings as read-only after all plugins have started, ensuring proper
initialization sequence.

Log: Fixed settings file monitoring to handle file rewrite operations
correctly

Influence:
1. Test settings persistence when multiple processes modify the same
settings file
2. Verify that file watcher continues working after settings file is
rewritten
3. Test file dialog functionality to ensure settings are properly read-
only after initialization
4. Check that configuration changes are properly detected and reloaded

fix: 改进设置文件的文件监视器处理

添加了文件重命名事件处理，以在设置文件被重写时（例如通过QSaveFile）正确
监视设置文件。之前，当QSaveFile通过将临时文件重命名为目标文件来提交更改
时，文件监视器会停止工作，因为inode发生了变化。此修复添加了一个重命名事
件处理程序，在发生此类事件时重新加载配置数据并重新启动监视器。

同时修复了文件对话框插件中的初始化顺序，在所有插件启动后将设置设为只读，
确保正确的初始化顺序。

Log: 修复设置文件监视功能，正确处理文件重写操作

Influence:
1. 测试多个进程修改同一设置文件时的设置持久性
2. 验证设置文件被重写后文件监视器是否继续工作
3. 测试文件对话框功能，确保初始化后设置正确设为只读
4. 检查配置更改是否被正确检测和重新加载

BUG: https://pms.uniontech.com/bug-view-348471.html