### PR TITLE
feat: add right-click outside menu handling for X11

### DIFF
--- a/src/dfm-base/base/configs/private/settingbackend_p.h
+++ b/src/dfm-base/base/configs/private/settingbackend_p.h
@@ -11,7 +11,6 @@
 #include <QMap>
 #include <QVariant>
 #include <QSet>
-#include <QTimer>
 
 DFMBASE_BEGIN_NAMESPACE
 
@@ -86,7 +85,6 @@ private:
     QMap<QString, GetOptFunc> getters;
     QMap<QString, SaveOptFunc> setters;
     QSet<QString> serialDataKey;
-    QTimer serialSyncTimer;
 
     static BidirectionHash<QString, Application::ApplicationAttribute> keyToAA;
     static BidirectionHash<QString, Application::GenericAttribute> keyToGA;

--- a/src/dfm-base/utils/eventfilterutils.cpp
+++ b/src/dfm-base/utils/eventfilterutils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/dfm-base/utils/eventfilterutils.cpp
+++ b/src/dfm-base/utils/eventfilterutils.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "eventfilterutils.h"
+#include "windowutils.h"
+
+#include <QMouseEvent>
+#include <QMenu>
+#include <QApplication>
+#include <QTimer>
+#include <QContextMenuEvent>
+
+namespace dfmbase {
+namespace EventFilter {
+
+bool handleRightClickOutsideMenu(QEvent *event, QObject *context)
+{
+    // Only effective in X11 environment
+    if (!WindowUtils::isX11()) {
+        return false;
+    }
+
+    if (event->type() != QEvent::MouseButtonPress) {
+        return false;
+    }
+
+    QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+    if (mouseEvent->button() != Qt::RightButton) {
+        return false;
+    }
+
+    QWidget *activePopup = QApplication::activePopupWidget();
+    QMenu *activeMenu = qobject_cast<QMenu *>(activePopup);
+    if (!activeMenu) {
+        return false;
+    }
+
+    QPoint globalPos = mouseEvent->globalPosition().toPoint();
+
+    // Check if click is inside menu or its visible submenus
+    bool insideMenu = activeMenu->geometry().contains(globalPos);
+    if (!insideMenu) {
+        QAction *active = activeMenu->activeAction();
+        if (active && active->menu() && active->menu()->isVisible()) {
+            insideMenu = active->menu()->geometry().contains(globalPos);
+        }
+    }
+
+    if (insideMenu) {
+        return false;
+    }
+
+    // Click outside menu: close the menu first
+    activeMenu->close();
+
+    // Delay triggering new context menu
+    QTimer::singleShot(0, context ? context : qApp, [globalPos]() {
+        QWidget *targetWidget = QApplication::widgetAt(globalPos);
+        if (targetWidget) {
+            QPoint localPos = targetWidget->mapFromGlobal(globalPos);
+            QContextMenuEvent *contextEvent = new QContextMenuEvent(
+                    QContextMenuEvent::Mouse,
+                    localPos,
+                    globalPos);
+            QApplication::postEvent(targetWidget, contextEvent);
+        }
+    });
+
+    return true;   // Block event
+}
+
+}   // namespace EventFilter
+}   // namespace dfmbase

--- a/src/dfm-base/utils/eventfilterutils.h
+++ b/src/dfm-base/utils/eventfilterutils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/dfm-base/utils/eventfilterutils.h
+++ b/src/dfm-base/utils/eventfilterutils.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef EVENTFILTERUTILS_H
+#define EVENTFILTERUTILS_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QEvent>
+
+namespace dfmbase {
+namespace EventFilter {
+
+/**
+ * @brief Handle right-click outside menu (only effective in X11 environment)
+ * @param event The event to process
+ * @param context Context object (optional, for QObject context)
+ * @return true Event has been processed and blocked, false continue propagation
+ */
+bool handleRightClickOutsideMenu(QEvent *event, QObject *context = nullptr);
+
+}   // namespace EventFilter
+}   // namespace dfmbase
+
+#endif   // EVENTFILTERUTILS_H

--- a/src/plugins/desktop/ddplugin-core/core.cpp
+++ b/src/plugins/desktop/ddplugin-core/core.cpp
@@ -8,6 +8,7 @@
 
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/eventfilterutils.h>
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/base/standardpaths.h>
 #include <dfm-base/base/schemefactory.h>
@@ -96,6 +97,8 @@ bool Core::start()
 
 void Core::stop()
 {
+    qApp->removeEventFilter(this);
+
     delete handle;
     handle = nullptr;
 
@@ -143,6 +146,11 @@ void Core::handleLoadPlugins(const QStringList &names)
 
 bool Core::eventFilter(QObject *watched, QEvent *event)
 {
+    // Handle right-click outside menu
+    if (EventFilter::handleRightClickOutsideMenu(event, this)) {
+        return true;
+    }
+
     static bool paintHandled = false;
     // windows paint
     if (!paintHandled && event->type() == QEvent::Paint) {

--- a/src/plugins/filemanager/dfmplugin-core/core.h
+++ b/src/plugins/filemanager/dfmplugin-core/core.h
@@ -24,6 +24,9 @@ public:
     virtual void stop() override;
     void connectToServer();
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 private slots:
     void onAllPluginsInitialized();
     void onAllPluginsStarted();


### PR DESCRIPTION
## Summary by Sourcery

Improve X11 context menu behavior by globally handling right-clicks outside open menus.

New Features:
- Add a shared event filter utility to detect and handle right-clicks outside active menus on X11, closing the current menu and opening a new context menu at the click position.

Enhancements:
- Install and remove a global event filter in desktop and file manager cores to leverage the new right-click outside menu handling.
- Clean up an unused timer member from the settings backend implementation.