### PR TITLE
feat: add trash file tags change notification

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.Daemon.TagManager.xml
+++ b/assets/dbus/org.deepin.Filemanager.Daemon.TagManager.xml
@@ -26,6 +26,8 @@
       <arg name="fileAndTags" type="a{sv}" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
     </signal>
+    <signal name="TrashFileTagsChanged">
+    </signal>
     <method name="Query">
       <arg type="v" direction="out"/>
       <arg name="opt" type="i" direction="in"/>

--- a/src/plugins/common/dfmplugin-tag/data/tagproxyhandle.cpp
+++ b/src/plugins/common/dfmplugin-tag/data/tagproxyhandle.cpp
@@ -50,6 +50,7 @@ void TagProxyHandlePrivate::connectToDBus()
     connections << q->connect(ptr, &TagManagerDBusInterface::TagsNameChanged, q, &TagProxyHandle::tagsNameChanged);
     connections << q->connect(ptr, &TagManagerDBusInterface::FilesTagged, q, &TagProxyHandle::filesTagged);
     connections << q->connect(ptr, &TagManagerDBusInterface::FilesUntagged, q, &TagProxyHandle::filesUntagged);
+    connections << q->connect(ptr, &TagManagerDBusInterface::TrashFileTagsChanged, q, &TagProxyHandle::trashFileTagsChanged);
 }
 
 void TagProxyHandlePrivate::disconnCurrentConnections()

--- a/src/plugins/common/dfmplugin-tag/data/tagproxyhandle.h
+++ b/src/plugins/common/dfmplugin-tag/data/tagproxyhandle.h
@@ -54,6 +54,7 @@ Q_SIGNALS:
     void tagsColorChanged(const QVariantMap &oldAndNew);
     void tagsDeleted(const QStringList &tags);
     void tagsNameChanged(const QVariantMap &oldAndNew);
+    void trashFileTagsChanged();
     void tagServiceRegistered();
 
 private:

--- a/src/plugins/common/dfmplugin-tag/utils/filetagcache.h
+++ b/src/plugins/common/dfmplugin-tag/utils/filetagcache.h
@@ -30,6 +30,7 @@ public Q_SLOTS:
     void onTagsNameChanged(const QVariantMap &oldAndNew);
     void onFilesTagged(const QVariantMap &fileAndTags);
     void onFilesUntagged(const QVariantMap &fileAndTags);
+    void onTrashFileTagsChanged();
 
 private:
     explicit FileTagCacheWorker(QObject *parent = nullptr);
@@ -65,10 +66,8 @@ private:
     void taggeFiles(const QVariantMap &fileAndTags);
     void untaggeFiles(const QVariantMap &fileAndTags);
 
-    void saveTrashTags(const QString &path, qint64 inode, const QStringList &tags);
     QStringList getTrashTags(const QString &path, qint64 inode) const;
-    void removeTrashTags(const QString &path, qint64 inode);
-    void clearAllTrashTags();
+    void reloadTrashFileTagsCache();
 
 private:
     QScopedPointer<FileTagCachePrivate> d;
@@ -88,10 +87,7 @@ public:
     QMap<QString, QColor> getCacheTagsColor(const QStringList &tags);
     QHash<QString, QStringList> findChildren(const QString &parentPath) const;
 
-    void saveTrashFileTags(const QString &path, qint64 inode, const QStringList &tags);
     QStringList getTrashFileTags(const QString &path, qint64 inode);
-    void removeTrashFileTags(const QString &path, qint64 inode);
-    void clearAllTrashTags();
 
 Q_SIGNALS:
     void initLoadTagInfos();

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -488,9 +488,6 @@ bool TagManager::saveTrashFileTags(const QString &originalPath, qint64 fileInode
     if (originalPath.isEmpty() || fileInode <= 0 || tagNames.isEmpty())
         return false;
 
-    // Save to cache
-    FileTagCacheIns.saveTrashFileTags(originalPath, fileInode, tagNames);
-
     // Save to database via D-Bus
     return TagProxyHandleIns->saveTrashFileTags(originalPath, fileInode, tagNames);
 }
@@ -514,18 +511,12 @@ bool TagManager::removeTrashFileTags(const QString &originalPath, qint64 fileIno
     if (originalPath.isEmpty())
         return false;
 
-    // Remove from cache
-    FileTagCacheIns.removeTrashFileTags(originalPath, fileInode);
-
     // Remove from database via D-Bus
     return TagProxyHandleIns->removeTrashFileTags(originalPath, fileInode);
 }
 
 bool TagManager::clearAllTrashTags()
 {
-    // Clear cache
-    FileTagCacheIns.clearAllTrashTags();
-
     // Clear database via D-Bus
     return TagProxyHandleIns->clearAllTrashTags();
 }

--- a/src/plugins/daemon/tag/tagdbhandler.cpp
+++ b/src/plugins/daemon/tag/tagdbhandler.cpp
@@ -757,7 +757,7 @@ bool TagDbHandler::saveTrashFileTags(const QString &originalPath, qint64 inode, 
         return false;
     }
 
-    emit trashFileTagsSaved(originalPath, inode, tags);
+    emit trashFileTagsChanged();
     fmInfo() << "TagDbHandler::saveTrashFileTags: Successfully saved trash file tags";
     return true;
 }
@@ -832,7 +832,7 @@ bool TagDbHandler::removeTrashFileTags(const QString &originalPath, qint64 inode
         return false;
     }
 
-    emit trashFileTagsRestored(originalPath, inode);
+    emit trashFileTagsChanged();
     fmInfo() << "TagDbHandler::removeTrashFileTags: Successfully removed trash file tags";
     return true;
 }
@@ -850,7 +850,7 @@ bool TagDbHandler::clearAllTrashTags()
         return false;
     }
 
-    emit trashTagsCleared();
+    emit trashFileTagsChanged();
     fmInfo() << "TagDbHandler::clearAllTrashTags: Successfully cleared all trash file tags";
     return true;
 }

--- a/src/plugins/daemon/tag/tagdbhandler.h
+++ b/src/plugins/daemon/tag/tagdbhandler.h
@@ -85,9 +85,7 @@ Q_SIGNALS:
     void tagsNameChanged(const QVariantMap &oldAndNewName);
     void filesWereTagged(const QVariantMap &filesWereTagged);
     void filesUntagged(const QVariantMap &delTagsOfFile);
-    void trashFileTagsSaved(const QString &originalPath, qint64 inode, const QStringList &tags);
-    void trashFileTagsRestored(const QString &originalPath, qint64 inode);
-    void trashTagsCleared();
+    void trashFileTagsChanged();
 
 private:
     QScopedPointer<DFMBASE_NAMESPACE::SqliteHandle> handle;

--- a/src/plugins/daemon/tag/tagmanagerdbus.cpp
+++ b/src/plugins/daemon/tag/tagmanagerdbus.cpp
@@ -22,6 +22,7 @@ void TagManagerDBus::initConnect()
     connect(TagDbHandler::instance(), &TagDbHandler::tagsNameChanged, this, &TagManagerDBus::TagsNameChanged);
     connect(TagDbHandler::instance(), &TagDbHandler::filesWereTagged, this, &TagManagerDBus::FilesTagged);
     connect(TagDbHandler::instance(), &TagDbHandler::filesUntagged, this, &TagManagerDBus::FilesUntagged);
+    connect(TagDbHandler::instance(), &TagDbHandler::trashFileTagsChanged, this, &TagManagerDBus::TrashFileTagsChanged);
 }
 
 QDBusVariant TagManagerDBus::Query(int opt, const QStringList value)

--- a/src/plugins/daemon/tag/tagmanagerdbus.h
+++ b/src/plugins/daemon/tag/tagmanagerdbus.h
@@ -32,6 +32,7 @@ Q_SIGNALS:
     void TagsNameChanged(const QVariantMap &oldAndNew);
     void FilesTagged(const QVariantMap &fileAndTags);
     void FilesUntagged(const QVariantMap &fileAndTags);
+    void TrashFileTagsChanged();
 
 private:
     void initConnect();


### PR DESCRIPTION
Added a unified signal for trash file tags changes to replace multiple
specific signals. The new TrashFileTagsChanged signal is emitted
whenever any trash file tags are modified (saved, removed, or cleared).
Updated the file tag cache to reload all trash file tags data when this
signal is received, ensuring cache consistency with the database.

This change simplifies the signal handling logic and improves cache
synchronization by using a single notification mechanism instead
of separate signals for different operations. The cache now fetches
complete trash file tags data from the database when changes occur,
rather than trying to maintain individual cache entries.

Log: Added unified notification for trash file tags changes

Influence:
1. Test tagging files in trash and verify cache updates correctly
2. Test removing tags from trashed files and check cache synchronization
3. Test clearing all trash tags and confirm cache is properly refreshed
4. Verify tag display in file manager for trashed files remains accurate
5. Test multiple concurrent tag operations on trashed files

feat: 添加回收站文件标签变更通知

添加统一的回收站文件标签变更信号以替代多个特定信号。新的
TrashFileTagsChanged 信号在回收站文件标签被修改（保存、移除或清空）时发
出。更新文件标签缓存以在接收到此信号时重新加载所有回收站文件标签数据，确
保缓存与数据库的一致性。

此变更简化了信号处理逻辑，通过使用单一通知机制替代不同操作的单独信号，提
高了缓存同步效率。缓存现在在变更发生时从数据库获取完整的回收站文件标签数
据，而不是尝试维护单个缓存条目。

Log: 新增回收站文件标签变更统一通知

Influence:
1. 测试回收站中文件标签功能并验证缓存正确更新
2. 测试从回收站文件移除标签并检查缓存同步
3. 测试清空所有回收站标签并确认缓存正确刷新
4. 验证文件管理器中回收站文件的标签显示准确性
5. 测试回收站文件的多个并发标签操作

BUG: https://pms.uniontech.com/bug-view-333051.html

## Summary by Sourcery

Introduce a unified trash file tags change notification and update the cache to reload trash tag data from the database on this signal.

New Features:
- Add a TrashFileTagsChanged D-Bus signal for notifying any modifications to trash file tags.

Bug Fixes:
- Ensure trash file tag cache stays consistent with the database by reloading from the source instead of incrementally updating entries.

Enhancements:
- Simplify trash tag signal handling by replacing multiple specific signals with a single consolidated change signal.
- Streamline tag cache logic by removing direct trash-tag cache mutations from TagManager and delegating consistency to the centralized cache reload mechanism.