### PR TITLE
fix: fix incorrect grouping of large files during copy operations

### DIFF
--- a/include/dfm-base/interfaces/fileinfo.h
+++ b/include/dfm-base/interfaces/fileinfo.h
@@ -118,6 +118,7 @@ public:
         kFileNeedUpdate = 51,   // 文件信息需要在显示更新
         kFileNeedTransInfo = 52,   // 文件信息需要转换为desktopfileinfo
         kFileHighlightContent = 53,   // 文件需要高亮内容
+        kExpectedSize = 54,   // 文件预期大小（用于正在拷贝/移动的文件）
         kUnknowExtendedInfo = 255,
     };
     /*!

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.h
@@ -102,6 +102,7 @@ private:
     bool doCopyLocalFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo);
     bool doCopyOtherFile(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
     bool doCopyLocalByRange(const DFileInfoPointer fromInfo, const DFileInfoPointer toInfo, bool *skip);
+    void setExpectedSizeForTarget(const QUrl &targetUrl, qint64 size);
 
 protected Q_SLOTS:
     void emitErrorNotify(const QUrl &from, const QUrl &to, const AbstractJobHandler::JobErrorType &error,

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
@@ -859,8 +859,7 @@ FileInfoPointer GroupingEngine::getFileInfoFromFileItem(const FileItemDataPointe
     auto fileInfo = file->fileInfo();
     const auto url = file->data(ItemRoles::kItemUrlRole).toUrl();
 
-    // 非本地fileinfo是异步的，文件属性可能无法得到
-    if (!fileInfo || !ProtocolUtils::isLocalFile(url)) {
+    if (!fileInfo) {
         fileInfo = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         Q_ASSERT(fileInfo);
         if (!fileInfo) {

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/sizegroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/sizegroupstrategy.cpp
@@ -65,8 +65,21 @@ QString SizeGroupStrategy::getGroupKey(const FileInfoPointer &info) const
         return "unknown";
     }
 
-    // Get file size and classify
-    qint64 size = info->size();
+    // Get file size for classification
+    // Priority: Use expected size (for files being copied/moved), fallback to actual size
+    qint64 size = 0;
+    QVariant expectedSize = info->extendAttributes(ExtInfoType::kExpectedSize);
+
+    if (expectedSize.isValid() && expectedSize.toLongLong() > 0) {
+        // Use expected size for files being operated on (copying/moving)
+        size = expectedSize.toLongLong();
+        fmDebug() << "SizeGroupStrategy: Using expected size for file:" << info->urlOf(UrlInfoType::kUrl).toString()
+                  << "expected:" << size << "bytes";
+    } else {
+        // Use actual size
+        size = info->size();
+    }
+
     QString groupKey = classifyBySize(size);
 
     fmDebug() << "SizeGroupStrategy: File" << info->urlOf(UrlInfoType::kUrl).toString()

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/typegroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/typegroupstrategy.cpp
@@ -9,6 +9,8 @@
 #include <dfm-base/interfaces/fileinfo.h>
 
 #include <QDebug>
+#include <QMimeDatabase>
+#include <QMimeType>
 
 DPWORKSPACE_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
@@ -66,17 +68,15 @@ QString TypeGroupStrategy::getGroupKey(const FileInfoPointer &info) const
         return "directory";
     }
 
-    // Get MIME type and map to group
-    QString mimeType = info->nameOf(NameInfoType::kMimeTypeName);
-    if (mimeType.isEmpty()) {
-        // Fallback: try to get MIME type from file extension
-        mimeType = info->fileMimeType().name();
-    }
+    // asyncfile 无法准确获取 mimetype
+    static QMimeDatabase mimeDb;
+    QMimeType mimeType = mimeDb.mimeTypeForFile(info->pathOf(PathInfoType::kFilePath));
+    QString mimeTypeName = mimeType.name();
 
-    QString groupKey = mapMimeTypeToGroup(mimeType);
+    QString groupKey = mapMimeTypeToGroup(mimeTypeName);
 
     fmDebug() << "TypeGroupStrategy: File" << info->urlOf(UrlInfoType::kUrl).toString()
-              << "MIME type:" << mimeType << "-> group:" << groupKey;
+              << "MIME type:" << mimeTypeName << "-> group:" << groupKey;
 
     return groupKey;
 }


### PR DESCRIPTION
1. Added kExpectedSize extended attribute to track file sizes during copy/move operations
2. Modified file copy operations to set expected size for target files before copying
3. Updated SizeGroupStrategy to prioritize expected size over actual size for files being copied
4. Fixed TypeGroupStrategy to use QMimeDatabase for more reliable MIME type detection
5. Improved file info creation in GroupingEngine to handle non-local files properly

Log: Fixed incorrect file grouping when copying large files

Influence:
1. Test copying large files (>4GB) and verify they are correctly grouped by expected size
2. Test file grouping during copy operations to ensure proper categorization
3. Verify MIME type detection works correctly for various file types
4. Test file operations with both local and non-local files
5. Check that file grouping updates correctly when copy operations complete

fix: 修复拷贝大文件时错误分组的问题

1. 新增 kExpectedSize 扩展属性用于跟踪拷贝/移动操作中的文件大小
2. 修改文件拷贝操作，在拷贝前为目标文件设置预期大小
3. 更新 SizeGroupStrategy 优先使用预期大小而非实际大小进行分组
4. 修复 TypeGroupStrategy 使用 QMimeDatabase 实现更可靠的 MIME 类型检测
5. 改进 GroupingEngine 中的文件信息创建，正确处理非本地文件

Log: 修复拷贝大文件时分组错误的问题

Influence:
1. 测试拷贝大文件（>4GB）并验证其按预期大小正确分组
2. 测试拷贝操作期间的文件分组，确保正确分类
3. 验证各种文件类型的 MIME 类型检测是否正确工作
4. 测试本地和非本地文件的文件操作
5. 检查拷贝操作完成后文件分组是否正确更新

Bug: https://pms.uniontech.com/bug-view-336293.html

## Summary by Sourcery

Fix file grouping behavior during copy and move operations, especially for large files, by using expected file size metadata and more reliable MIME type detection.

Bug Fixes:
- Ensure large files being copied or moved are grouped by their expected final size rather than their temporary on-disk size.
- Fix MIME type–based grouping by using QMimeDatabase for more accurate type detection.
- Correct file info retrieval in the grouping engine so non-local and missing file info cases are handled reliably.

Enhancements:
- Introduce an expected size extended attribute on file info objects to support size-aware operations during copy and move workflows.