### PR TITLE
feat: optimize wallpaper loading with caching and scaling

### DIFF
--- a/src/plugins/desktop/ddplugin-background/backgroundmanager_p.h
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager_p.h
@@ -45,9 +45,11 @@ public:
     void forceRequest();
     void terminate(bool wait);
     Q_INVOKABLE void onFinished(void *pData);
-    static QPixmap getPixmap(const QString &path, const QPixmap &defalutPixmap = QPixmap());
+    static QPixmap getPixmap(const QString &path, const QSize &targetSize, const QPixmap &defaultPixmap = QPixmap());
 
 private:
+    void queryCacheAndClassify(Requestion &req, QList<Requestion> &cachedRequests, QList<Requestion> &uncachedRequests);
+    void processRequests(const QList<Requestion> &cachedRequests, const QList<Requestion> &uncachedRequests, bool forceMode = false);
     static void runUpdate(BackgroundBridge *self, QList<Requestion> reqs);
 
 private:


### PR DESCRIPTION
Added LRU cache for wallpapers to improve performance and memory usage
Implemented smart image scaling during decoding to reduce memory
footprint
Enhanced error handling with better logging and file existence checks
Modified getPixmap to accept target size parameter for proper scaling
Cache uses file modification time in key to handle wallpaper updates
Optimized large image handling by scaling during decode phase

Log: Improved wallpaper loading performance with caching system

Influence:
1. Test wallpaper loading with different image formats and sizes
2. Verify cache behavior by switching between multiple wallpapers
3. Check memory usage when loading large wallpapers
4. Test wallpaper updates by modifying image files
5. Verify proper scaling on different screen resolutions
6. Test error handling with missing or corrupted image files

feat: 优化壁纸加载性能，添加缓存和缩放功能

添加壁纸LRU缓存以提高性能和内存使用效率
实现解码过程中的智能图像缩放以减少内存占用
增强错误处理，改进日志记录和文件存在性检查
修改getPixmap方法接受目标尺寸参数以实现正确缩放
缓存使用文件修改时间作为键值以处理壁纸更新
通过解码阶段缩放优化大图像处理

Log: 使用缓存系统提升壁纸加载性能

Influence:
1. 测试不同图像格式和尺寸的壁纸加载
2. 通过切换多个壁纸验证缓存行为
3. 检查加载大壁纸时的内存使用情况
4. 通过修改图像文件测试壁纸更新
5. 验证不同屏幕分辨率下的正确缩放
6. 测试缺失或损坏图像文件的错误处理

BUG: https://pms.uniontech.com/bug-view-312067.html

## Summary by Sourcery

Optimize wallpaper loading by adding a cached, size-aware image loading path and integrating it into the background update flow.

New Features:
- Introduce a global LRU cache for wallpapers keyed by path, target size, and modification time to reuse decoded pixmaps across requests.

Bug Fixes:
- Ensure wallpapers are refreshed when files change by incorporating file modification time into the cache key.

Enhancements:
- Decode and scale wallpapers to the target size during image reading to reduce memory usage and avoid redundant scaling work.
- Update the wallpaper loading API to accept a target size and return already scaled pixmaps for use in background updates.
- Improve robustness of wallpaper loading with existence checks and detailed logging for image size and decode failures.