### PR TITLE
refactor: optimize file operations worker class structure

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cutfiles/docutfilesworker.cpp
@@ -384,12 +384,12 @@ DFileInfoPointer DoCutFilesWorker::trySameDeviceRename(const DFileInfoPointer &s
         result = doMergDir(sourceInfo, newTargetInfo, skip);
     } else {
         if (newTargetInfo->exists()) {
-            result = deleteFile(newTargetInfo->uri(), newTargetInfo->uri(), skip);
+            result = localFileHandler->deleteFile(newTargetInfo->uri());
             if (result) {
                 *skip = false;   // deleteFile拷贝成功会设置skip为true，正确的删除后设置skip为false
                 result = renameFileByHandler(sourceInfo, newTargetInfo, skip);
             } else {
-                fmDebug() << "Failed to delete existing target file during rename - file:" << newTargetInfo->uri();
+                fmWarning() << "Failed to delete existing target file during rename - file:" << newTargetInfo->uri();
             }
         } else {
             result = renameFileByHandler(sourceInfo, newTargetInfo, skip);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/domovetotrashfilesworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/domovetotrashfilesworker.h
@@ -38,6 +38,7 @@ protected:
     bool isCanMoveToTrash(const QUrl &url, bool *result);
     QUrl trashTargetUrl(const QUrl &url);
     AbstractJobHandler::SupportAction doHandleErrorNoSpace(const QUrl &url);
+    bool canWriteFile(const QUrl &url) const;
 
 private:
     FileInfoPointer targetFileInfo { nullptr };   // target file information


### PR DESCRIPTION
Refactored FileOperateBaseWorker by removing unused methods and moving specific functionality to relevant subclasses. Deleted unused methods including readAheadSourceFile, deleteFile, deleteDir, actionOperating, and canWriteFile. Moved canWriteFile method to DoMoveToTrashFilesWorker where it's actually used. Changed debug message to warning message in cut files operation for better error visibility. Also fixed disk space check logic by removing redundant action reset.

This cleanup improves code maintainability by removing dead code and properly organizing functionality where it belongs. The changes ensure each worker class only contains methods relevant to its specific operations.

Influence:
1. Test file cutting operations with existing target files
2. Verify trash file operations still work correctly
3. Check disk space validation during file operations
4. Test file permission checks in trash operations
5. Verify no regression in file copy/move operations

refactor: 优化文件操作工作类结构

重构 FileOperateBaseWorker，移除未使用的方法并将特定功能移至相关子
类。删除了 readAheadSourceFile、deleteFile、deleteDir、actionOperating 和 canWriteFile 等未使用方法。将 canWriteFile 方法移至实际使用它的
DoMoveToTrashFilesWorker 中。在文件剪切操作中将调试消息改为警告消息以提
高错误可见性。同时通过移除冗余的 action 重置来修复磁盘空间检查逻辑。

此次清理通过移除死代码和合理组织功能到所属位置，提高了代码可维护性。更改
确保每个工作类仅包含与其特定操作相关的方法。

Influence:
1. 测试存在目标文件时的文件剪切操作
2. 验证回收站文件操作仍正常工作
3. 检查文件操作期间的磁盘空间验证
4. 测试回收站操作中的文件权限检查
5. 验证文件复制/移动操作无回归