### PR TITLE
feat: implement atomic file replacement for cut operations

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperatebaseworker.cpp
@@ -69,6 +69,11 @@ ReplacementTarget prepareReplacementTarget(
         const DFileInfoPointer &fromInfo,
         FileCleanupManager &cleanupManager)
 {
+    if (!finalInfo || !fromInfo) {
+        fmWarning() << "Invalid file info pointers in prepareReplacementTarget";
+        return ReplacementTarget();
+    }
+
     ReplacementTarget rt;
     rt.actualInfo = finalInfo;
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filereplacer.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filereplacer.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "filereplacer.h"
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-io/dfileinfo.h>
+
+#include <QFileInfo>
+#include <QRandomGenerator>
+
+#include <unistd.h>
+#include <errno.h>
+
+DFMBASE_USE_NAMESPACE
+USING_IO_NAMESPACE
+
+DPFILEOPERATIONS_BEGIN_NAMESPACE
+
+namespace FileReplacer {
+
+bool shouldUseTemporaryFile(const QString &targetPath)
+{
+    QUrl targetUrl = QUrl::fromLocalFile(targetPath);
+
+    // Only local filesystems
+    if (ProtocolUtils::isRemoteFile(targetUrl)) {
+        return false;
+    }
+
+    DFMIO::DFileInfo fileInfo(targetUrl);
+    fileInfo.initQuerier();
+    // Only if target exists
+    if (!fileInfo.exists()) {
+        return false;
+    }
+
+    // Symlinks are deleted directly, not replaced
+    if (fileInfo.attribute(DFMIO::DFileInfo::AttributeID::kStandardIsSymlink).toBool()) {
+        return false;
+    }
+
+    return true;
+}
+
+FileReplacementContext createReplacementContext(const QString &targetPath)
+{
+    FileReplacementContext ctx;
+
+    if (!shouldUseTemporaryFile(targetPath)) {
+        return ctx;   // Empty context
+    }
+
+    ctx.originalTargetPath = targetPath;
+    ctx.temporaryFilePath = generateTemporaryPath(targetPath);
+    return ctx;
+}
+
+QString generateTemporaryPath(const QString &targetPath)
+{
+    QFileInfo fileInfo(targetPath);
+    QString dirPath = fileInfo.absolutePath();
+
+    // 使用随机字符串作为临时文件名，避免与原始文件名长度相关的问题
+    // 格式: .ddefileop-xxxxxxxx
+    quint32 random = QRandomGenerator::global()->generate();
+    QString suffix = QString::number(random, 16).mid(0, 8).rightJustified(8, '0');
+
+    return QString("%1/.ddefileop-%2").arg(dirPath, suffix);
+}
+
+bool applyReplacement(const FileReplacementContext &context)
+{
+    if (!context.isReplacement()) {
+        return true;   // No replacement needed
+    }
+
+    // Step 1: Remove original target file
+    if (::unlink(context.originalTargetPath.toLocal8Bit().constData()) != 0 && errno != ENOENT) {
+        fmWarning() << "Failed to unlink:" << context.originalTargetPath << "error:" << strerror(errno);
+        ::unlink(context.temporaryFilePath.toLocal8Bit().constData());
+        return false;
+    }
+
+    // Step 2: Atomic rename
+    if (::rename(context.temporaryFilePath.toLocal8Bit().constData(),
+                 context.originalTargetPath.toLocal8Bit().constData())
+        != 0) {
+        fmWarning() << "Failed to rename" << context.temporaryFilePath << "to"
+                    << context.originalTargetPath << "error:" << strerror(errno);
+        ::unlink(context.temporaryFilePath.toLocal8Bit().constData());
+        return false;
+    }
+
+    fmDebug() << "Successfully replaced" << context.originalTargetPath;
+    return true;
+}
+
+}   // namespace FileReplacer
+
+DPFILEOPERATIONS_END_NAMESPACE

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filereplacer.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filereplacer.h
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FILEREPLACER_H
+#define FILEREPLACER_H
+
+#include "dfmplugin_fileoperations_global.h"
+#include <QString>
+#include <QUrl>
+
+DPFILEOPERATIONS_BEGIN_NAMESPACE
+
+/*!
+ * \brief FileReplacementContext - Context for safe file replacement
+ *
+ * Stores information needed to perform atomic file replacement.
+ * This is created at execution time when we know the actual target path
+ * and whether the target already exists and needs to be replaced.
+ */
+class FileReplacementContext
+{
+public:
+    /*!
+     * \brief Original target path (what user expects as final destination)
+     */
+    QString originalTargetPath;
+
+    /*!
+     * \brief Temporary file path (where we actually write to)
+     * Empty if not using temporary file strategy
+     */
+    QString temporaryFilePath;
+
+    /*!
+     * \brief Check if this context represents a replacement operation
+     */
+    bool isReplacement() const
+    {
+        return !originalTargetPath.isEmpty() && !temporaryFilePath.isEmpty();
+    }
+
+    /*!
+     * \brief Reset context to empty state
+     */
+    void reset()
+    {
+        originalTargetPath.clear();
+        temporaryFilePath.clear();
+    }
+};
+
+/*!
+ * \brief Namespace FileReplacer - Safe file replacement utilities
+ *
+ * Responsible for:
+ * - Determining if temporary file strategy should be used for a given target
+ * - Creating replacement context with temporary paths
+ * - Performing atomic rename to finalize replacement
+ */
+namespace FileReplacer {
+
+/*!
+ * \brief Determine if temporary file strategy should be used
+ *
+ * Used when:
+ * - Target is on local filesystem
+ * - Target file already exists
+ * - Target is not a symlink (symlinks are deleted directly)
+ *
+ * \param targetPath Path of target file that would be overwritten
+ * \return true if temporary file should be used
+ */
+bool shouldUseTemporaryFile(const QString &targetPath);
+
+/*!
+ * \brief Create replacement context for safe file replacement
+ *
+ * Analyzes target and decides whether to use temporary file strategy.
+ * If yes, generates temporary path and returns context.
+ * If no, returns empty context (direct overwrite).
+ *
+ * \param targetPath Original target path (destination file)
+ * \return Context with replacement info, or empty if direct overwrite
+ */
+FileReplacementContext createReplacementContext(const QString &targetPath);
+
+/*!
+ * \brief Generate temporary file path for safe replacement
+ *
+ * Format: /path/.ddefileop-xxxxxxxx
+ * Uses hidden file + random suffix to ensure uniqueness and avoid filename length issues
+ *
+ * \param targetPath Original target path
+ * \return Temporary file path
+ */
+QString generateTemporaryPath(const QString &targetPath);
+
+/*!
+ * \brief Perform atomic replacement of target with temporary file
+ *
+ * Operations (atomic at filesystem level):
+ * 1. Unlink original target file
+ * 2. Rename temporary file to target location
+ *
+ * On any failure, temporary file is cleaned up.
+ *
+ * \param context Replacement context (must be valid, i.e., isReplacement() == true)
+ * \return true on success, false on failure
+ */
+bool applyReplacement(const FileReplacementContext &context);
+
+}   // namespace FileReplacer
+
+DPFILEOPERATIONS_END_NAMESPACE
+#endif   // FILEREPLACER_H

--- a/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/clipboardmenuscene.cpp
@@ -135,11 +135,6 @@ void ClipBoardMenuScene::updateState(QMenu *parent)
             paste->setDisabled(disabled);
         }
     } else {   // update menu by focus fileinfo
-        if (auto copy = d->predicateAction.value(ActionID::kCopy)) {
-            if (!d->focusFileInfo->isAttributes(OptInfoType::kIsReadable) && !d->focusFileInfo->isAttributes(OptInfoType::kIsSymLink))
-                copy->setDisabled(true);
-        }
-
         if (auto cut = d->predicateAction.value(ActionID::kCut)) {
             const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(d->currentDir);
             if (!fileInfo || !fileInfo->isAttributes(OptInfoType::kIsWritable))

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileoperatorhelper.cpp
@@ -192,14 +192,6 @@ void FileOperatorHelper::copyFiles(const FileView *view)
         selectedUrls = urls;
     }
 
-    if (selectedUrls.size() == 1) {
-        const FileInfoPointer &fileInfo = InfoFactory::create<FileInfo>(selectedUrls.first());
-        if (!fileInfo || !fileInfo->isAttributes(OptInfoType::kIsReadable)) {
-            fmWarning() << "Cannot copy file - not readable:" << selectedUrls.first().toString();
-            return;
-        }
-    }
-
     if (selectedUrls.isEmpty()) {
         fmDebug() << "Copy operation aborted - no files selected";
         return;


### PR DESCRIPTION
1. Added FileReplacer utility for safe atomic file replacement using temporary files
2. Modified cut file operations to use three-step replacement strategy: rename source to temp, unlink target, atomic rename temp to target
3. Enhanced renameFileByHandler to handle existing target files safely with proper error recovery
4. Simplified trySameDeviceRename by delegating target existence handling to the improved rename method
5. Added cleanup tracking for incomplete temporary files during operations

Log: Improved file cut operations with atomic replacement for better data safety

Influence:
1. Test cutting files to locations with existing files (should replace atomically)
2. Verify cutting large files works correctly with the new replacement strategy
3. Test cutting files across different filesystems and devices
4. Verify error recovery when replacement fails (should restore source file)
5. Test cutting symbolic links and directories (should use original behavior)
6. Check temporary file cleanup after successful and failed operations

feat: 为剪切操作实现原子文件替换功能

1. 新增 FileReplacer 工具类，使用临时文件实现安全的原子文件替换
2. 修改剪切文件操作，采用三步替换策略：重命名源文件到临时位置、删除目标 文件、原子重命名临时文件到目标位置
3. 增强 renameFileByHandler 方法，安全处理目标文件存在的情况并包含正确的 错误恢复机制
4. 简化 trySameDeviceRename 方法，将目标文件存在处理委托给改进的重命名 方法
5. 在操作过程中添加对不完整临时文件的清理跟踪

Log: 改进文件剪切操作，使用原子替换提高数据安全性

Influence:
1. 测试剪切文件到已存在文件的位置（应原子替换）
2. 验证大文件剪切在新替换策略下的正确性
3. 测试跨不同文件系统和设备的文件剪切
4. 验证替换失败时的错误恢复（应恢复源文件）
5. 测试符号链接和目录的剪切（应使用原始行为）
6. 检查成功和失败操作后的临时文件清理情况

## Summary by Sourcery

Introduce an atomic, temporary-file-based replacement strategy for cut and copy operations to safely overwrite existing local files while preserving original behavior for directories and symlinks.

New Features:
- Add FileReplacer utility and FileReplacementContext to support safe, atomic replacement of existing local files using temporary paths.

Enhancements:
- Update cut and copy workflows to route overwrites through FileReplacer when appropriate, including large-file and same-device rename scenarios, and track/clean up temporary files via the existing cleanup manager.
- Simplify same-device rename logic to delegate target-existence handling and error recovery to the enhanced renameFileByHandler implementation.