### PR TITLE
refactor: replace serial data key with delayed save timer

### DIFF
--- a/src/dfm-base/base/configs/private/settingbackend_p.h
+++ b/src/dfm-base/base/configs/private/settingbackend_p.h
@@ -11,6 +11,7 @@
 #include <QMap>
 #include <QVariant>
 #include <QSet>
+#include <QTimer>
 
 DFMBASE_BEGIN_NAMESPACE
 
@@ -84,7 +85,8 @@ private:
 private:
     QMap<QString, GetOptFunc> getters;
     QMap<QString, SaveOptFunc> setters;
-    QSet<QString> serialDataKey;
+    QTimer* delayedSaveTimer { nullptr };
+    QVariantMap pendingSaveData;
 
     static BidirectionHash<QString, Application::ApplicationAttribute> keyToAA;
     static BidirectionHash<QString, Application::GenericAttribute> keyToGA;

--- a/src/dfm-base/base/configs/settingbackend.h
+++ b/src/dfm-base/base/configs/settingbackend.h
@@ -35,14 +35,9 @@ public:
     void removeSettingAccessor(const QString &key);
     void addSettingAccessor(Application::ApplicationAttribute attr, SaveOptFunc set);
     void addSettingAccessor(Application::GenericAttribute attr, SaveOptFunc set);
-    void addToSerialDataKey(const QString &key);
-    void removeSerialDataKey(const QString &key);
 
-Q_SIGNALS:
-    void optionSetted(const QString &key, const QVariant &value);
-
-public Q_SLOTS:
-    void onOptionSetted(const QString &key, const QVariant &value);
+private Q_SLOTS:
+    void onDelayedSave();
 
 protected:
     void doSetOption(const QString &key, const QVariant &value);

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -226,17 +226,11 @@ void SideBarHelper::bindSetting(const QString &itemVisiableSettingKey, const QSt
                                                        std::bind(saver, itemVisiableControlKey, std::placeholders::_1));
     };
 
-    // FIXME(xust): i don't know what this function do, but seems works to solve this issue.
-    // commit: e634381afdb03f1f835e2e9f35d369ef782b0312
-    // Bug: 156469
-    // figure it out later.
-    SettingBackend::instance()->addToSerialDataKey(itemVisiableSettingKey);
     bindConf(itemVisiableSettingKey, itemVisiableControlKey);
 }
 
 void SideBarHelper::removebindingSetting(const QString &itemVisiableSettingKey)
 {
-    SettingBackend::instance()->removeSerialDataKey(itemVisiableSettingKey);
     SettingBackend::instance()->removeSettingAccessor(itemVisiableSettingKey);
 }
 


### PR DESCRIPTION
The serial data key mechanism has been replaced with a delayed save
timer approach to prevent signal loss due to blocking. Previously,
certain settings were handled serially while others were processed
immediately, which could cause issues when signals were blocked. Now all
settings are batched and saved after a 100ms delay using a QTimer.

The changes include:
1. Remove serialDataKey and related methods (addToSerialDataKey,
removeSerialDataKey)
2. Add delayedSaveTimer and pendingSaveData for batch processing
3. Replace optionSetted signal with onDelayedSave slot
4. Remove obsolete signal-slot connection and cleanup sidebar binding
code
5. Implement batched saving with QSignalBlocker to prevent recursive
signals

This refactor simplifies the setting persistence logic and ensures
consistent behavior across all setting types while preventing potential
signal loss issues.

Influence:
1. Test setting changes are properly persisted after short delays
2. Verify multiple rapid setting changes are batched correctly
3. Check that settings are saved even when UI is busy
4. Confirm sidebar visibility settings work as expected
5. Test application restart to verify settings persistence

refactor: 使用延迟保存计时器替换串行数据键机制

原先的串行数据键机制已被延迟保存计时器方法取代，以防止因信号阻塞导致的设
置丢失。之前某些设置是串行处理的，而其他设置则是立即处理，这可能在信号被
阻塞时导致问题。现在所有设置都会在100毫秒延迟后使用QTimer进行批量保存。

变更包括：
1. 移除serialDataKey及相关方法（addToSerialDataKey、
removeSerialDataKey）
2. 添加delayedSaveTimer和pendingSaveData用于批处理
3. 将optionSetted信号替换为onDelayedSave槽
4. 移除过时的信号槽连接并清理侧边栏绑定代码
5. 使用QSignalBlocker实现批量保存，防止递归信号

此次重构简化了设置持久化逻辑，确保所有设置类型行为一致，同时防止潜在的信
号丢失问题。

Influence:
1. 测试设置变更在短暂延迟后是否正确持久化
2. 验证多个快速设置变更是否正确批量处理
3. 检查在UI繁忙时设置是否仍能保存
4. 确认侧边栏可见性设置按预期工作
5. 测试应用重启以验证设置持久性

BUG: https://pms.uniontech.com/bug-view-347481.html

## Summary by Sourcery

Refactor settings persistence to batch and delay saves, removing the serial data key mechanism in favor of a timer-based approach that avoids signal loss and simplifies sidebar setting bindings.

New Features:
- Introduce a delayed save timer and pending data buffer to batch setting updates before persisting them.

Bug Fixes:
- Ensure settings changes are reliably saved even when signals are blocked or the UI is busy, preventing loss of option updates.

Enhancements:
- Remove the serial data key concept and associated API, replacing it with an internal delayed-save slot that writes all pending settings in one operation.
- Simplify sidebar setting binding by dropping now-unnecessary serial data key registration and cleanup.