### PR TITLE
6.5.119

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-file-manager (6.5.119) unstable; urgency=medium
+
+  * fix: optimize parent mime type recursion handling
+  * fix: fix rename failure when switching view modes
+  * fix: use stable focusFile for rename operation
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 30 Jan 2026 11:34:23 +0800
+
 dde-file-manager (6.5.118) unstable; urgency=medium
 
   * fix: check local file before creating file info in property dialog

--- a/src/plugins/filemanager/dfmplugin-workspace/menus/workspacemenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/menus/workspacemenuscene.cpp
@@ -380,15 +380,21 @@ bool WorkspaceMenuScene::normalMenuTriggered(QAction *action)
         if (actionId == dfmplugin_menu::ActionID::kRename) {
             if (1 == d->selectFiles.count()) {
                 fmDebug() << "Starting rename operation for single file";
-                const QModelIndex &index = d->view->selectionModel()->currentIndex();
+
+                // 使用 d->focusFile 而不是 selectionModel()->currentIndex()
+                // 原因：selectionModel()->currentIndex() 在菜单显示期间可能会改变
+                // d->focusFile 是稳定的，表示右键选中的文件
+                const QModelIndex &index = d->view->model()->getIndexByUrl(d->focusFile);
+
                 if (Q_UNLIKELY(!index.isValid())) {
-                    fmWarning() << "Cannot rename: invalid selection index";
+                    fmWarning() << "Cannot rename: invalid selection index for focusFile:" << d->focusFile.toString();
                     return false;
                 }
+
                 QPointer<dfmplugin_workspace::FileView> view = d->view;
                 QTimer::singleShot(80, [view, index]() {
                     if (!view.isNull()) {
-                        fmDebug() << "Executing delayed rename operation";
+                        fmDebug() << "Executing delayed rename operation" << index;
                         view->edit(index, QAbstractItemView::EditKeyPressed, nullptr);
                     }
                 });

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -150,8 +150,14 @@ void FileView::setViewMode(Global::ViewMode mode)
         return;
     }
 
-    if (itemDelegate())
+    if (itemDelegate()) {
         itemDelegate()->hideAllIIndexWidget();
+    }
+
+    // 未正确重置编辑状态导致编辑失败（重命名失效）
+    if (state() == QAbstractItemView::EditingState) {
+        setState(QAbstractItemView::NoState);
+    }
 
     int delegateModeIndex = mode == Global::ViewMode::kTreeMode ? static_cast<int>(Global::ViewMode::kListMode) : static_cast<int>(mode);
     if (d->delegates.keys().contains(delegateModeIndex)) {


### PR DESCRIPTION
## Summary by Sourcery

Improve file rename behavior in the workspace file manager when invoking rename from the context menu and across view mode changes.

Bug Fixes:
- Use the focused file index instead of the current selection index when triggering a rename from the workspace context menu to avoid renaming the wrong item or failing when selection changes while the menu is open.
- Reset the file view editing state when changing view modes to prevent rename/edit operations from failing after a mode switch.