### PR TITLE
fix: remove redundant view state saving

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1280,11 +1280,6 @@ void FileView::updateHorizontalOffset()
     updateEditorGeometries();
 }
 
-void FileView::updateView()
-{
-    viewport()->update();
-}
-
 void FileView::updateOneView(const QModelIndex &index)
 {
     update(index);
@@ -2449,18 +2444,6 @@ void FileView::initializeConnect()
 
     dpfSignalDispatcher->subscribe("dfmplugin_workspace", "signal_View_HeaderViewSectionChanged", this, &FileView::onHeaderViewSectionChanged);
 
-    auto pluginName { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin_filepreview") };
-    if (pluginName && pluginName->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
-        dpfSignalDispatcher->subscribe("dfmplugin_filepreview", "signal_ThumbnailDisplay_Changed", this, &FileView::onWidgetUpdate);
-    } else {
-        connect(
-                DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this, [=](const QString &iid, const QString &name) {
-                    Q_UNUSED(iid)
-                    if (name == "dfmplugin_filepreview")
-                        dpfSignalDispatcher->subscribe("dfmplugin_filepreview", "signal_ThumbnailDisplay_Changed", this, &FileView::onWidgetUpdate);
-                },
-                Qt::DirectConnection);
-    }
     connect(&FileInfoHelper::instance(), &FileInfoHelper::smbSeverMayModifyPassword, this, [this](const QUrl &url) {
         if (ProtocolUtils::isSMBFile(rootUrl()) && url.path().startsWith(rootUrl().path())) {
             fmInfo() << rootUrl() << url << "smb server may modify password";

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -577,7 +577,7 @@ void FileView::wheelEvent(QWheelEvent *event)
         } else {
             decreaseIcon();
         }
-        emit viewStateChanged();
+
         event->accept();
         return;
     }
@@ -2434,7 +2434,6 @@ void FileView::initializeConnect()
     connect(this, &DListView::clicked, this, &FileView::onClicked, Qt::UniqueConnection);
     connect(this, &DListView::doubleClicked, this, &FileView::onDoubleClicked);
     connect(this, &DListView::iconSizeChanged, this, &FileView::updateHorizontalOffset, Qt::QueuedConnection);
-    connect(this, &FileView::viewStateChanged, this, &FileView::saveViewModeState);
 
     connect(Application::instance(), &Application::iconSizeLevelChanged, this, &FileView::onIconSizeChanged);
     connect(Application::instance(), &Application::gridDensityLevelChanged, this, &FileView::onItemWidthLevelChanged);
@@ -2852,7 +2851,6 @@ void FileView::saveViewModeState()
 {
     const QUrl &url = rootUrl();
 
-    setFileViewStateValue(url, "iconSizeLevel", d->statusBar->scalingSlider()->value());
     setFileViewStateValue(url, "viewMode", static_cast<int>(d->currentViewMode));
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -183,8 +183,6 @@ protected:
     void showEvent(QShowEvent *event) override;
 
 Q_SIGNALS:
-    void reqOpenNewWindow(const QList<QUrl> &urls);
-    void viewStateChanged();
     void selectUrlChanged(const QList<QUrl> &urls);
 
 private slots:
@@ -194,7 +192,6 @@ private slots:
     void setIconSizeBySizeIndex(const int sizeIndex);
     void onShowFileSuffixChanged(bool isShow);
     void updateHorizontalOffset();
-    void updateView();
     void updateOneView(const QModelIndex &index);
     void onSelectionChanged(const QItemSelection &indexInRect, const QItemSelection &deselected);
     void onDefaultViewModeChanged(int mode);


### PR DESCRIPTION
Removed the emission of viewStateChanged signal during mouse wheel events and disconnected the signal from saveViewModeState function. Also removed the saving of iconSizeLevel in saveViewModeState function. These changes eliminate redundant state saving operations that were causing unnecessary performance overhead during icon size adjustments via mouse wheel.

The view state saving is now handled more efficiently through other mechanisms, and the icon size level is managed separately through the Application::iconSizeLevelChanged signal connection that remains intact.

Influence:
1. Test mouse wheel icon scaling functionality to ensure it still works correctly
2. Verify that view mode state is properly saved when changing view modes
3. Confirm that icon size changes are persisted correctly through application settings
4. Check that no regression occurs in view state persistence

fix: 移除冗余的视图状态保存

移除了鼠标滚轮事件中的viewStateChanged信号发射，并断开了该信号与
saveViewModeState函数的连接。同时移除了saveViewModeState函数中对
iconSizeLevel的保存。这些更改消除了在通过鼠标滚轮调整图标大小时导致的冗
余状态保存操作，减少了不必要的性能开销。

视图状态保存现在通过其他机制更高效地处理，图标大小级别通过保留的
Application::iconSizeLevelChanged信号连接单独管理。

Influence:
1. 测试鼠标滚轮图标缩放功能是否正常工作
2. 验证切换视图模式时视图状态是否正确保存
3. 确认图标大小变更通过应用程序设置正确持久化
4. 检查视图状态持久化功能没有出现回归问题

## Summary by Sourcery

Optimize file view state handling by removing redundant view state updates during mouse wheel icon resizing and simplifying persisted view mode state.

Bug Fixes:
- Eliminate unnecessary view state persistence triggered on every mouse wheel icon size change to avoid redundant work and potential performance overhead.

Enhancements:
- Simplify view mode state persistence by no longer storing icon size level as part of the view mode state, relying instead on the existing application-level icon size management.