### PR TITLE
fix: fix data disk detection logic

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -721,8 +721,13 @@ bool DeviceUtils::isSystemDisk(const QVariantMap &devInfo)
 
 bool DeviceUtils::isDataDisk(const QVariantHash &devInfo)
 {
-    // 如果是可移除设备，则不是数据盘
-    if (devInfo.value(kCanPowerOff).toBool() && !isSiblingOfRoot(devInfo))
+    // 判断是否为可移除设备（非数据盘）
+    // 注意：部分USB硬盘 kCanPowerOff 为 true 但 kEjectable 为 false，
+    // 此处需同时满足两者才视为可移除设备，避免将USB硬盘误判为非数据盘。
+    bool isRemovable = devInfo.value(kCanPowerOff).toBool()
+            && devInfo.value(kEjectable).toBool();
+
+    if (isRemovable && !isSiblingOfRoot(devInfo))
         return false;
 
     // 如果是根目录，则不是数据盘


### PR DESCRIPTION
Fixed the data disk detection logic to properly exclude USB hard drives from being classified as data disks. The previous condition only checked if the device could be powered off and wasn't a sibling of the root device, but this incorrectly included USB hard drives which have ejectable set to false. Now the condition also requires the device to be ejectable, ensuring USB hard drives are correctly excluded from data disk classification.

Influence:
1. Test with various storage devices including USB hard drives, internal disks, and removable media
2. Verify that USB hard drives are no longer incorrectly classified as data disks
3. Confirm that internal data disks are still properly detected
4. Check that removable media like USB flash drives are correctly excluded from data disk category
5. Validate system disk detection remains unaffected

fix: 修复数据盘检测逻辑

修复了数据盘检测逻辑，正确地将USB硬盘从数据盘分类中排除。之前的条件只检
查设备是否可以断电且不是根设备的同级设备，但这错误地包含了ejectable设置
为false的USB硬盘。现在条件还要求设备必须是可弹出的，确保USB硬盘被正确排
除在数据盘分类之外。

Influence:
1. 使用各种存储设备进行测试，包括USB硬盘、内部磁盘和可移动介质
2. 验证USB硬盘不再被错误地分类为数据盘
3. 确认内部数据盘仍能正确检测
4. 检查可移动介质（如U盘）是否正确排除在数据盘类别之外
5. 验证系统盘检测功能不受影响

Bug: https://pms.uniontech.com/bug-view-349437.html

## Summary by Sourcery

Bug Fixes:
- Prevent USB hard drives with non-ejectable flags from being incorrectly classified as data disks while keeping internal disk and system disk detection behavior unchanged.