### PR TITLE
refactor: improve vault removal UI and key validation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.h
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.h
@@ -20,6 +20,7 @@ class DToolTip;
 class DFloatingWidget;
 class DLabel;
 class DSpinner;
+class DCommandLinkButton;
 DWIDGET_END_NAMESPACE
 
 namespace dfmplugin_vault {
@@ -51,15 +52,12 @@ Q_SIGNALS:
     void signalJump(const RemoveWidgetType &type);
     void sigCloseDialog();
 
-protected:
-    bool eventFilter(QObject *obj, QEvent *evt) override;
-
 private:
     DTK_WIDGET_NAMESPACE::DPasswordEdit *pwdEdit { nullptr };
     QPushButton *tipsBtn { nullptr };
     DTK_WIDGET_NAMESPACE::DToolTip *tooltip { nullptr };
     DTK_WIDGET_NAMESPACE::DFloatingWidget *floatWidget { nullptr };
-    DTK_WIDGET_NAMESPACE::DLabel *keyDeleteLabel { Q_NULLPTR };
+    DTK_WIDGET_NAMESPACE::DCommandLinkButton *toggleModeBtn { Q_NULLPTR };
     DTK_WIDGET_NAMESPACE::DSpinner *spinner { nullptr };
 };
 }

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.h
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.h
@@ -17,6 +17,7 @@ DWIDGET_BEGIN_NAMESPACE
 class DToolTip;
 class DFloatingWidget;
 class DSpinner;
+class DFileChooserEdit;
 DWIDGET_END_NAMESPACE
 
 namespace dfmplugin_vault {
@@ -28,8 +29,6 @@ public:
     ~VaultRemoveByRecoverykeyView() override;
 
     QString getRecoverykey();
-    void clear();
-
     void showAlertMessage(const QString &text, int duration = 3000);
 
     QStringList btnText() const;
@@ -45,14 +44,24 @@ Q_SIGNALS:
     void sigCloseDialog();
 
 private:
+    void initUI();
+
     //! 输入凭证后，对凭证添加“-”
     int afterRecoveryKeyChanged(QString &str);
+    void checkRecoveryKeyV1();
+    void checkRecoveryKeyV2();
 
     bool eventFilter(QObject *watched, QEvent *event) override;
 
+    // Helper functions for recovery key validation
+    bool validateRecoveryKeyV1(const QString &key);
+    void handleRecoveryKeyV1ValidationResult(bool isValid);
+    bool validateRecoveryKeyFile(const QString &file);
+    void handleRecoveryKeyFileValidationResult(bool isValid);
+
 private:
     QPlainTextEdit *keyEdit { nullptr };
-
+    DTK_WIDGET_NAMESPACE::DFileChooserEdit *filePathEdit { nullptr };
     DTK_WIDGET_NAMESPACE::DToolTip *tooltip { nullptr };
     DTK_WIDGET_NAMESPACE::DFloatingWidget *floatWidget { nullptr };
     DTK_WIDGET_NAMESPACE::DSpinner *spinner { nullptr };


### PR DESCRIPTION
Refactored vault removal views to enhance user experience and
code maintainability. Replaced DLabel with DCommandLinkButton for
mode switching in password view to provide better visual feedback.
Restructured recovery key view to support both text input and
file selection based on vault version. Improved code organization
by separating validation logic into dedicated methods for better
readability and maintainability.

Key changes:
1. Password view: Replaced clickable label with command link button for
switching to recovery key mode
2. Recovery key view: Added file chooser for new vault versions while
maintaining text input for older versions
3. Extracted validation logic into separate methods for different vault
versions
4. Improved error handling and user feedback mechanisms
5. Enhanced UI consistency with proper widget styling

Log: Improved vault removal interface with better mode switching and
dual recovery key input methods

Influence:
1. Test password-based vault removal with valid and invalid passwords
2. Verify mode switching between password and recovery key views
3. Test recovery key validation with both text input and file selection
4. Validate error messages for incorrect keys and file selections
5. Check UI responsiveness during loading states
6. Verify proper handling of different vault versions

refactor: 优化保险箱删除界面和密钥验证逻辑

重构保险箱删除视图以提升用户体验和代码可维护性。在密码视图中将 DLabel 替
换为 DCommandLinkButton 以实现模式切换，提供更好的视觉反馈。重构恢复密钥
视图以支持基于保险箱版本的文本输入和文件选择两种方式。通过将验证逻辑分离
到专用方法中改善代码组织结构，提高可读性和可维护性。

主要变更：
1. 密码视图：将可点击标签替换为命令链接按钮，用于切换到恢复密钥模式
2. 恢复密钥视图：为新版本保险箱添加文件选择器，同时保持旧版本的文本输入
3. 为不同保险箱版本提取验证逻辑到单独方法中
4. 改进错误处理和用户反馈机制
5. 使用适当的控件样式增强UI一致性

Log: 优化保险箱删除界面，改进模式切换和双重恢复密钥输入方式

Influence:
1. 测试基于密码的保险箱删除功能，使用有效和无效密码
2. 验证密码视图和恢复密钥视图之间的模式切换
3. 测试恢复密钥验证，包括文本输入和文件选择两种方式
4. 验证错误消息显示，包括错误密钥和文件选择
5. 检查加载状态下的UI响应性
6. 验证对不同保险箱版本的正确处理

BUG: https://pms.uniontech.com/bug-view-343037.html
