### PR TITLE
fix: set window title for desktop base window

### DIFF
--- a/src/plugins/desktop/ddplugin-core/frame/basewindow.cpp
+++ b/src/plugins/desktop/ddplugin-core/frame/basewindow.cpp
@@ -8,13 +8,14 @@
 
 DDPCORE_USE_NAMESPACE
 
-BaseWindow::BaseWindow(QWidget *parent) : QWidget(parent)
+BaseWindow::BaseWindow(QWidget *parent)
+    : QWidget(parent)
 {
-
 }
 
 void BaseWindow::init()
 {
+    setWindowTitle("Desktop");
     setAutoFillBackground(false);
     setAttribute(Qt::WA_TranslucentBackground);
     setWindowIcon(QIcon::fromTheme("deepin-toggle-desktop"));


### PR DESCRIPTION
The BaseWindow constructor was missing window title initialization which caused the window to have no title when displayed. Added setWindowTitle("Desktop") call in the init() method to properly set the window title. This ensures the desktop window has a proper title when shown to users.

Log: Fixed missing window title for desktop base window

Influence:
1. Verify desktop window displays with "Desktop" title
2. Test window appearance and transparency attributes
3. Check window icon is correctly set from theme
4. Ensure auto-fill background remains disabled

fix: 为桌面基础窗口设置窗口标题

BaseWindow 构造函数缺少窗口标题初始化，导致窗口显示时没有标题。在 init()
方法中添加了 setWindowTitle("Desktop") 调用以正确设置窗口标题。这确保桌
面窗口在显示给用户时具有适当的标题。

Log: 修复桌面基础窗口缺少标题的问题

Influence:
1. 验证桌面窗口显示时带有"Desktop"标题
2. 测试窗口外观和透明属性
3. 检查窗口图标是否正确从主题设置
4. 确保自动填充背景保持禁用状态