### PR TITLE
fix: fix compilation error with C++15 in AbstractJobHandler

### DIFF
--- a/include/dfm-base/interfaces/abstractjobhandler.h
+++ b/include/dfm-base/interfaces/abstractjobhandler.h
@@ -16,7 +16,7 @@
 class QWidget;
 
 typedef QSharedPointer<QMap<quint8, QVariant>> JobInfoPointer;
-Q_DECLARE_METATYPE(JobInfoPointer);
+// Q_DECLARE_METATYPE(JobInfoPointer);
 
 namespace dfmbase {
 class AbstractJobHandler : public QObject
@@ -290,8 +290,8 @@ Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::SupportActions)
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::JobFlag)
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags)
 Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType)
-Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback);
-Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback);
+// Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::OperatorCallback);
+// Q_DECLARE_METATYPE(DFMBASE_NAMESPACE::AbstractJobHandler::OperatorHandleCallback);
 using JobHandlePointer = QSharedPointer<DFMBASE_NAMESPACE::AbstractJobHandler>;
 Q_DECLARE_METATYPE(JobHandlePointer)
 

--- a/src/dfm-base/interfaces/abstractjobhandler.cpp
+++ b/src/dfm-base/interfaces/abstractjobhandler.cpp
@@ -13,6 +13,25 @@ using namespace dfmbase;
 AbstractJobHandler::AbstractJobHandler(QObject *parent)
     : QObject(parent)
 {
+    /* 
+    === Fix for C++15 Compilation Error: Manual Meta-Type Registration ===
+    Reason: C++15 implements stricter template  deduction in <type_traits>. This
+    causes a failure when Q_DECLARE_METATYPE probes complex nested types like
+    QSharedPointer<QMap<quint8, QVariant>>. The 'std::conjunction' fails to
+    resolve 'value' during equality trait probing. By performing runtime
+    registration here, we bypass the static analysis deadlock during header
+    compilation.
+    */
+
+    // Register the job info pointer type (QSharedPointer<QMap<quint8, QVariant>>)
+    qRegisterMetaType<JobInfoPointer>("JobInfoPointer");
+    
+    // Register callback types to prevent "undefined type" errors during 
+    // cross-thread signal-slot delivery or QVariant conversions.
+    qRegisterMetaType<AbstractJobHandler::OperatorCallback>("AbstractJobHandler::OperatorCallback");
+    qRegisterMetaType<AbstractJobHandler::OperatorHandleCallback>("AbstractJobHandler::OperatorHandleCallback");
+    // ============================
+
     connect(this, &AbstractJobHandler::requestShowTipsDialog, this, [=](DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType type, const QList<QUrl> urls) {
         switch (type) {
         case DFMBASE_NAMESPACE::AbstractJobHandler::ShowDialogType::kRestoreFailed:


### PR DESCRIPTION
Specifically, GCC 15's stricter template deduction and equality trait probing (via std::conjunction) caused a build failure when expanding Q_DECLARE_METATYPE for complex types like QSharedPointer<QMap<...>> and std::function in the header file.

This patch resolves the issue by:
1. Commenting out static Q_DECLARE_METATYPE declarations in the header to prevent premature template expansion and deduction deadlocks.
2. Moving the meta-type registration to runtime using qRegisterMetaType within the AbstractJobHandler constructor.

This approach bypasses the static analysis constraints of GCC 15 while preserving the availability of these types in Qt's meta-object system.

Log: Fix build failure on GCC 15/Qt6 environment.

## Summary by Sourcery

Move Qt meta-type registration for complex job handler types from compile-time macros to runtime registration to restore compatibility with newer GCC.

Bug Fixes:
- Resolve GCC 15 compilation errors caused by static Q_DECLARE_METATYPE usage on complex pointer and callback types in AbstractJobHandler.

Enhancements:
- Register JobInfoPointer and job handler callback types at runtime in the AbstractJobHandler constructor to ensure they remain available to Qt's meta-object system without triggering compiler trait probing issues.