### PR TITLE
fix: improve URL handling in file dialog DBus interface

### DIFF
--- a/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
@@ -40,8 +40,8 @@ QString FileDialogHandleDBus::directory() const
 void FileDialogHandleDBus::setDirectoryUrl(const QString &directory)
 {
     QString path = QDir::homePath();
-    if(!directory.isEmpty())
-       path = directory;
+    if (!directory.isEmpty())
+        path = directory;
     QUrl dir(path);
     if (dir.scheme().isEmpty()) {
         dir = QUrl::fromLocalFile(path);
@@ -56,7 +56,23 @@ QString FileDialogHandleDBus::directoryUrl() const
 
 void FileDialogHandleDBus::selectUrl(const QString &url)
 {
-    FileDialogHandle::selectUrl(QUrl(url));
+    QUrl fileUrl(url);
+    const auto &scheme = fileUrl.scheme();
+    if (scheme.isEmpty()) {
+        fileUrl = QUrl::fromLocalFile(url);
+    } else {
+        // Extract path portion after "scheme://"
+        int pathStart = url.indexOf("://");
+        if (pathStart != -1) {
+            // For URLs with scheme (e.g., file://), extract path to preserve special characters like '#'
+            fileUrl.clear();
+            fileUrl.setScheme(scheme);
+            QString path = url.mid(pathStart + 3);
+            fileUrl.setPath(path);
+        }
+    }
+
+    FileDialogHandle::selectUrl(fileUrl);
 }
 
 QStringList FileDialogHandleDBus::selectedUrls() const


### PR DESCRIPTION
1. Fixed inconsistent indentation in setDirectoryUrl method
2. Enhanced selectUrl method to properly handle URLs with schemes
3. Added special character preservation for URLs containing '#' and
other reserved characters
4. Improved URL parsing logic to extract path components correctly

Log: Fixed file dialog URL handling for special characters

Influence:
1. Test file selection with URLs containing special characters like '#'
2. Verify file dialog works correctly with both local file paths and
full URLs
3. Test various URL schemes to ensure proper path extraction
4. Validate that selected URLs are correctly parsed and displayed
5. Check backward compatibility with existing file path formats

fix: 修复文件对话框 DBus 接口中的 URL 处理问题

1. 修复 setDirectoryUrl 方法中的缩进不一致问题
2. 增强 selectUrl 方法以正确处理带协议的 URL
3. 添加对包含 '#' 等保留字符的 URL 的特殊字符保留功能
4. 改进 URL 解析逻辑以正确提取路径组件

Log: 修复文件对话框对特殊字符的 URL 处理

Influence:
1. 测试包含特殊字符（如 '#'）的 URL 文件选择功能
2. 验证文件对话框在本地文件路径和完整 URL 下的正常工作
3. 测试各种 URL 协议以确保正确的路径提取
4. 验证选中的 URL 是否正确解析和显示
5. 检查与现有文件路径格式的向后兼容性

BUG: https://pms.uniontech.com/bug-view-317361.html

## Summary by Sourcery

Improve DBus file dialog URL handling to correctly interpret local paths and URLs with schemes while preserving special characters.

Bug Fixes:
- Ensure selectUrl correctly parses and forwards URLs with schemes, including those containing special characters such as '#'.
- Fix setDirectoryUrl directory resolution so both empty and non-empty directory values are handled consistently.

Enhancements:
- Refine URL parsing in the DBus file dialog interface to distinguish between schemeless paths and fully qualified URLs, preserving their path components.