### PR TITLE
fix bugs

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -120,7 +120,6 @@ void DeviceProxyManager::reloadOpticalInfo(const QString &id)
 bool DeviceProxyManager::initService()
 {
     d->initConnection();
-    QTimer::singleShot(1000, this, [this] { d->initMounts(); });
     return isDBusRuning();
 }
 

--- a/src/dfm-base/base/device/deviceutils.h
+++ b/src/dfm-base/base/device/deviceutils.h
@@ -8,6 +8,7 @@
 #include <dfm-base/dfm_base_global.h>
 
 #include <QString>
+#include <QSet>
 
 #include <dfm-mount/base/dmountutils.h>
 
@@ -89,6 +90,12 @@ private:
     using Compare = std::function<bool(const QString &, const QString &)>;
     static bool findDlnfsPath(const QString &target, Compare func);
     static QVariantHash toHash(const QVariantMap &map);
+
+    // fstab mount points cache with automatic invalidation
+    static QSet<QString> fstabMountPoints();
+
+    // extract common removable device detection logic (DRY principle)
+    static bool isRemovableDevice(const QVariantHash &devInfo);
 };
 
 }

--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.h
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.h
@@ -51,6 +51,7 @@ private:
     bool blockDeviceFilter(const QVariantMap &data);
     bool protoDeviceFilter(const QVariantMap &data);
     bool isRootDrive(const QString &drivePath);
+    bool isMountPointInFstab(const QString &mountPoint);
     void playSoundOnDevPlugInOut(bool in);
     void updateDockVisible();
     void notify(const QString &title, const QString &msg);


### PR DESCRIPTION
## Summary by Sourcery

Refine device classification and fstab-based filtering, improve selection and accessibility handling in FileView, and adjust device proxy initialization timing.

Bug Fixes:
- Correctly distinguish removable vs built-in/data disks, treating fstab-mounted and root-sibling devices as built-in rather than removable.
- Prevent dock disk-mount plugin from showing devices whose mount points are defined in /etc/fstab.
- Avoid QAccessible cache holding references to destroyed FileView models by explicitly deleting the accessible interface on destruction when accessibility is enabled.
- Preserve non-deleted selections and avoid unintended current item jumps when rows are removed in FileView.
- Avoid delayed mount initialization by removing the deferred initMounts call from DeviceProxyManager.

Enhancements:
- Introduce shared, cached fstab mount point lookups and reusable removable-device detection logic in DeviceUtils and DockItemDataManager for consistent behavior and reduced duplication.