### PR TITLE
fix: adjust filename length calculation logic

### DIFF
--- a/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+++ b/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
@@ -211,7 +211,7 @@ void FileDialogStatusBar::onFileNameTextEdited(const QString &text)
     QString dstText = DFMBASE_NAMESPACE::FileUtils::preprocessingFileName(text);
     QString suffix { "" };
     mainWindow->checkFileSuffix(dstText, suffix);
-    int maxLength = NAME_MAX - suffix.length() - 1;
+    int maxLength = suffix.isEmpty() ? NAME_MAX : NAME_MAX - suffix.length() - 1;
     while (DFMBASE_NAMESPACE::FileUtils::getFileNameLength(mainWindow->getcurrenturl(), dstText) > maxLength) {
         dstText.chop(1);
     }
@@ -295,7 +295,7 @@ void FileDialogStatusBar::initializeUi()
 void FileDialogStatusBar::initializeConnect()
 {
     connect(fileNameEdit, &DLineEdit::textEdited, this, &FileDialogStatusBar::onFileNameTextEdited);
-    
+
 #ifdef DTKWIDGET_CLASS_DSizeMode
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this]() {
         updateLayout();


### PR DESCRIPTION
Fixed the filename length calculation in file dialog status bar to
properly handle cases where file suffix is empty. Previously, the
calculation always subtracted suffix length even when no suffix was
present, leading to incorrect maximum length constraints.

The issue occurred in the filename validation logic where the maximum
length was calculated by subtracting suffix length from NAME_MAX
constant. However, when no suffix was present (empty string), the
calculation incorrectly reduced the available length. The fix ensures
suffix length is only subtracted when a suffix actually exists.

Log: Fixed filename length validation in file dialog when no file
extension is specified

Influence:
1. Test file renaming in file dialog with files that have no extension
2. Verify filename length limits are correctly enforced for files with
and without extensions
3. Test filename editing with various suffix scenarios
4. Ensure filename truncation works properly when exceeding maximum
length

fix: 调整文件名长度计算逻辑

修复了文件对话框状态栏中的文件名长度计算问题，正确处理文件后缀为空的情
况。之前即使没有后缀存在，计算也总是从 NAME_MAX 常量中减去后缀长度，导致
最大长度限制不正确。

问题出现在文件名验证逻辑中，最大长度是通过从 NAME_MAX 常量减去后缀长度来
计算的。然而当没有后缀存在（空字符串）时，计算错误地减少了可用长度。修复
确保仅在实际存在后缀时才减去后缀长度。

Log: 修复文件对话框中无文件扩展名时的文件名长度验证问题

Influence:
1. 测试文件对话框中无扩展名文件的文件重命名
2. 验证对有扩展名和无扩展名文件的文件名长度限制是否正确执行
3. 测试各种后缀情况下的文件名编辑
4. 确保超出最大长度时的文件名截断功能正常工作

BUG: https://pms.uniontech.com/bug-view-345815.html

## Summary by Sourcery

Adjust filename length validation in the file dialog status bar to correctly account for optional file suffixes.

Bug Fixes:
- Fix filename maximum length calculation when no file suffix is present so that available length is not reduced unnecessarily.

Enhancements:
- Simplify and clarify filename maximum length computation based on whether a suffix exists.