### PR TITLE
fix(bluetooth): display accurate error message for long filename

### DIFF
--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.h
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.h
@@ -32,6 +32,7 @@ public:
     QMap<QString, const BluetoothAdapter *> getAdapters() const;
     bool hasAdapter();
     bool bluetoothSendEnable();
+    bool isLongFilenameFailure(const QString &sessionPath) const;
 
 public Q_SLOTS:
     void refresh();

--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager_p.h
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager_p.h
@@ -10,6 +10,7 @@
 
 #include <QDBusConnection>
 #include <QDBusReply>
+#include <QMap>
 
 template<class T>
 class QFutureWatcher;
@@ -57,6 +58,7 @@ public:
     BluetoothModel *model { nullptr };
     QDBusInterface *bluetoothInter { nullptr };
     QFutureWatcher<QPair<QString, QString>> *watcher { nullptr };
+    QMap<QString, bool> longFilenameFailures;
 
     Q_DECLARE_PUBLIC(BluetoothManager)
 };

--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
@@ -53,6 +53,7 @@
 #define TXT_FILE_ZEROSIZ dfmplugin_utils::BluetoothTransDialog::tr("Unable to send 0 KB files")
 #define TXT_FILE_NOEXIST dfmplugin_utils::BluetoothTransDialog::tr("File doesn't exist")
 #define TXT_DIR_SELECTED dfmplugin_utils::BluetoothTransDialog::tr("Transferring folders is not supported")
+#define TXT_LONG_FILENAME dfmplugin_utils::BluetoothTransDialog::tr("Error: The filename is too long")
 
 #define TXT_NEXT dfmplugin_utils::BluetoothTransDialog::tr("Next", "button")
 #define TXT_CANC dfmplugin_utils::BluetoothTransDialog::tr("Cancel", "button")
@@ -320,6 +321,17 @@ void BluetoothTransDialog::initConn()
     connect(BluetoothManagerInstance, &BluetoothManager::transferCancledByRemote, this, [this](const QString &sessionPath) {
         if (sessionPath != currSessionPath)
             return;
+
+        if (BluetoothManagerInstance->isLongFilenameFailure(sessionPath)) {
+            if (failedErrorMsgLabel) {
+                failedErrorMsgLabel->setText(TXT_LONG_FILENAME);
+            }
+        } else {
+            if (failedErrorMsgLabel) {
+                failedErrorMsgLabel->setText(TXT_ERROR_REASON);
+            }
+        }
+
         stackedWidget->setCurrentIndex(kFailedPage);
         BluetoothManagerInstance->cancelTransfer(sessionPath);
     });
@@ -534,12 +546,12 @@ QWidget *BluetoothTransDialog::createFailedPage()
     changeLabelTheme(subTitleOfFailedPage);
     pLay->addWidget(subTitleOfFailedPage);
 
-    DLabel *txt2 = new DLabel(TXT_ERROR_REASON, this);
-    txt2->setMargin(0);
-    txt2->setAlignment(Qt::AlignCenter);
-    setObjTextStyle(txt2, 12, false);
-    changeLabelTheme(txt2);
-    pLay->addWidget(txt2);
+    failedErrorMsgLabel = new DLabel(TXT_ERROR_REASON, this);
+    failedErrorMsgLabel->setMargin(0);
+    failedErrorMsgLabel->setAlignment(Qt::AlignCenter);
+    setObjTextStyle(failedErrorMsgLabel, 12, false);
+    changeLabelTheme(failedErrorMsgLabel);
+    pLay->addWidget(failedErrorMsgLabel);
     pLay->addStretch(1);
 
     return w;

--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.h
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.h
@@ -96,6 +96,7 @@ private:
     DLabel *subTitleOfFailedPage { nullptr };
     DLabel *subTitleOfSuccessPage { nullptr };
     DLabel *sendingStatusLabel { nullptr };
+    DLabel *failedErrorMsgLabel { nullptr };   // 失败页面的错误消息标签
     DProgressBar *progressBar { nullptr };
     DSpinner *spinner { nullptr };
 

--- a/translations/dde-file-manager.ts
+++ b/translations/dde-file-manager.ts
@@ -7209,6 +7209,11 @@ You need to upgrade this vault to continue using it.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="56"/>
+        <source>Error: The filename is too long</source>
+        <translation></translation>
+    </message>
+    <message>
         <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="57"/>
         <source>Next</source>
         <comment>button</comment>

--- a/translations/dde-file-manager_zh_CN.ts
+++ b/translations/dde-file-manager_zh_CN.ts
@@ -1734,7 +1734,7 @@ You need to upgrade this vault to continue using it.</source>
     <message>
         <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="17"/>
         <source>Filename has too many characters</source>
-        <translation>文件名过长</translation>
+        <translation>原因：文件名过长</translation>
     </message>
     <message>
         <location filename="../src/dfm-base/qrc/configure/global-setting-template-dfmio-trans.cpp" line="18"/>
@@ -7209,6 +7209,11 @@ You need to upgrade this vault to continue using it.</source>
         <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="55"/>
         <source>Transferring folders is not supported</source>
         <translation>不支持传输文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="56"/>
+        <source>Error: The filename is too long</source>
+        <translation>原因：文件名过长</translation>
     </message>
     <message>
         <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="57"/>

--- a/translations/dde-file-manager_zh_HK.ts
+++ b/translations/dde-file-manager_zh_HK.ts
@@ -7211,6 +7211,11 @@ You need to upgrade this vault to continue using it.</source>
         <translation>不支持傳輸文件夾</translation>
     </message>
     <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="56"/>
+        <source>Error: The filename is too long</source>
+        <translation>原因：檔名過長</translation>
+    </message>
+    <message>
         <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="57"/>
         <source>Next</source>
         <comment>button</comment>

--- a/translations/dde-file-manager_zh_TW.ts
+++ b/translations/dde-file-manager_zh_TW.ts
@@ -7211,6 +7211,11 @@ You need to upgrade this vault to continue using it.</source>
         <translation>不支援傳輸資料夾</translation>
     </message>
     <message>
+        <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="56"/>
+        <source>Error: The filename is too long</source>
+        <translation>原因：檔名過長</translation>
+    </message>
+    <message>
         <location filename="../src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp" line="57"/>
         <source>Next</source>
         <comment>button</comment>


### PR DESCRIPTION
When bluetooth file transfer fails due to filename exceeding 255 characters, show "The filename is too long" instead of generic error message.

Detect filename length in onTransferRemoved when done=false, mark as long filename failure if exceeding 255 characters.

蓝牙传输长文件名文件失败时，准确显示"文件名过长"错误提示。

在onTransferRemoved中检测文件名长度，超过255字符时标记为长文件名失败。

Log: 优化蓝牙传输长文件名失败错误提示
PMS: BUG-338403
Influence: 蓝牙传输文件名超过255字符失败时，用户能看到准确的"文件名过长"错误提示，而不是通用的"蓝牙设备已断开连接"消息，提升用户体验。

## Summary by Sourcery

Improve Bluetooth file transfer failure handling for files whose names exceed the maximum supported length.

Bug Fixes:
- Show a specific 'The filename is too long' error when Bluetooth transfer fails due to filenames over 255 bytes instead of a generic disconnection message.

Enhancements:
- Track long-filename Bluetooth transfer failures in BluetoothManager and surface the status to the transfer dialog for accurate error display.

Documentation:
- Add translations for the new 'The filename is too long' Bluetooth transfer error message in Simplified and Traditional Chinese locales.