### PR TITLE
fix: add UI error handling for direct IO copy operations

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.h
@@ -147,6 +147,7 @@ private:   // file copy
     bool handlePauseResume(FileWriter &writer, const QString &dest, bool *skip);
     NextDo actionToNextDo(AbstractJobHandler::SupportAction action, qint64 size, bool *skip);
     bool shouldFallbackFromCopyFileRange(int errorCode) const;
+    AbstractJobHandler::JobErrorType mapSystemErrorToJobError(int systemErrno, bool isWriteError);
 
 public:
     static void progressCallback(int64_t current, int64_t total, void *progressData);


### PR DESCRIPTION
1. Removed redundant error message parameters from doHandleErrorAndWait calls
2. Added immediate errno saving to prevent value corruption
3. Implemented system error to job error type mapping function
4. Added UI dialog support for read/write errors during direct IO copy
5. Implemented retry mechanism for failed operations with proper file seeking

Log: Fixed direct IO copy operations to show proper error dialogs instead of silently failing

Influence:
1. Test direct IO copy with insufficient disk space scenarios
2. Verify permission denied errors trigger proper UI dialogs
3. Test retry functionality for transient I/O errors
4. Validate error mapping for various system error codes
5. Check file position handling during retry operations

fix: 为直接IO拷贝操作添加UI错误处理

1. 从doHandleErrorAndWait调用中移除冗余的错误消息参数
2. 添加立即保存errno值以防止值被破坏
3. 实现系统错误到作业错误类型的映射函数
4. 为直接IO拷贝过程中的读写错误添加UI对话框支持
5. 实现失败操作的重试机制，包含正确的文件定位处理

Log: 修复直接IO拷贝操作，现在会显示正确的错误对话框而不是静默失败

Influence:
1. 测试磁盘空间不足场景下的直接IO拷贝
2. 验证权限拒绝错误是否正确触发UI对话框
3. 测试瞬时I/O错误的重试功能
4. 验证各种系统错误代码的错误映射
5. 检查重试操作期间的文件位置处理

## Summary by Sourcery

Handle direct I/O copy read/write failures with proper UI error reporting and retry support.

Bug Fixes:
- Ensure direct I/O copy read and write errors surface as job errors instead of silently failing.
- Preserve errno values during direct I/O operations to avoid incorrect error handling.
- Correctly restore file positions when retrying failed read or write chunks in direct I/O copies.

Enhancements:
- Map system errno values to high-level job error types for consistent UI error dialogs during direct I/O copies.
- Simplify error handling calls by removing redundant error message parameters from direct I/O copy operations.