### PR TITLE
fix: add real-time disk space query for copy operations

### DIFF
--- a/src/dfm-base/base/device/private/devicehelper.h
+++ b/src/dfm-base/base/device/private/devicehelper.h
@@ -44,6 +44,13 @@ public:
     static QVariantMap loadProtocolInfo(const QString &id);
     static QVariantMap loadProtocolInfo(const ProtocolDevAutoPtr &dev);
 
+    static bool queryUsageOfBlockRealTime(const QVariantMap &itemData,
+                                          quint64 *total, quint64 *avai, quint64 *used);
+    static bool queryUsageOfProtocolRealTime(const QVariantMap &itemData,
+                                             quint64 *total, quint64 *avai, quint64 *used);
+    static bool queryDeviceUsageRealTime(const QVariantMap &itemData,
+                                         quint64 *total, quint64 *avai, quint64 *used);
+
     static bool isMountableBlockDev(const QString &id, QString &why);
     static bool isMountableBlockDev(const BlockDevAutoPtr &dev, QString &why);
     static bool isMountableBlockDev(const QVariantMap &infos, QString &why);

--- a/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
@@ -162,6 +162,7 @@ void ComputerView::showEvent(QShowEvent *event)
     // 订阅容量监控（引用计数 +1）
     QTimer::singleShot(0, []() {
         fmDebug() << "Computer view shown, subscribing to device usage monitoring";
+        DevProxyMng->refreshUsage();
         DevProxyMng->subscribeUsageMonitoring();
     });
 


### PR DESCRIPTION
1. Implement real-time disk space query interface in DeviceHelper to provide accurate capacity information during file operations
2. Add support for both block devices and protocol devices with separate query methods
3. Integrate real-time query into deviceBytesFree function with fallback to cached data
4. Refactor device usage query logic in DeviceWatcher to use the new unified interface
5. Refresh device usage when computer view is shown to ensure data accuracy

Log: Added real-time disk space monitoring for copy operations

Influence:
1. Test file copy operations to devices with limited space to verify real-time capacity updates
2. Verify both block devices (hard drives) and protocol devices (network shares) show accurate available space
3. Check that the system falls back to cached data when real-time query fails
4. Test with optical drives to ensure special handling works correctly
5. Verify capacity display respects configuration settings (disk-based vs filesystem-based)

fix: 为拷贝操作添加实时磁盘空间查询功能

1. 在DeviceHelper中实现实时磁盘空间查询接口，为文件操作提供准确的容量 信息
2. 添加对块设备和协议设备的支持，分别提供查询方法
3. 将实时查询集成到deviceBytesFree函数中，并保留缓存数据回退机制
4. 重构DeviceWatcher中的设备使用量查询逻辑，使用新的统一接口
5. 在计算机视图显示时刷新设备使用量以确保数据准确性

Log: 新增拷贝操作的实时磁盘空间监控功能

Influence:
1. 测试向空间有限的设备拷贝文件，验证实时容量更新功能
2. 验证块设备（硬盘）和协议设备（网络共享）都能显示准确的可用空间
3. 检查实时查询失败时系统是否能正确回退到缓存数据
4. 测试光驱设备的特殊处理逻辑是否正确工作
5. 验证容量显示是否遵循配置设置（基于磁盘或基于文件系统）

Bug: https://pms.uniontech.com/bug-view-350121.html