### PR TITLE
fix: prevent open with dialog when canceling broken symlink access

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1355,10 +1355,17 @@ std::optional<QUrl> LocalFileHandlerPrivate::resolveSymlink(const QUrl &url)
         fileInfo.setFile(canonicalPath);
         if (!fileInfo.exists() && !ProtocolUtils::isSMBFile(QUrl::fromLocalFile(canonicalPath))) {
             // Link is broken
-            lastEvent = DialogManagerInstance->showBreakSymlinkDialog(
+            GlobalEventType dialogResult = DialogManagerInstance->showBreakSymlinkDialog(
                     QFileInfo(currentPath).fileName(),
                     url);
-            invalidPath << url;
+            lastEvent = dialogResult;
+
+            // 只有当用户选择删除或移动到回收站时，才将该路径添加到 invalidPath
+            // 用户点击取消(kUnknowType)时，不添加到 invalidPath，避免触发"打开方式"对话框
+            if (dialogResult != GlobalEventType::kUnknowType) {
+                invalidPath << url;
+            }
+
             return std::nullopt;
         }
 

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -117,7 +117,7 @@ bool TrashFileHelper::openFileInPlugin(quint64 windowId, const QList<QUrl> urls)
     bool isOpenFile = false;
     for (const QUrl &url : urls) {
         auto fileinfo = DFMBASE_NAMESPACE::InfoFactory::create<DFMBASE_NAMESPACE::FileInfo>(url);
-        if (fileinfo && fileinfo->isAttributes(OptInfoType::kIsFile)) {
+        if (fileinfo && fileinfo->fileType() == FileInfo::FileType::kRegularFile) {
             isOpenFile = true;
             break;
         }
@@ -171,7 +171,7 @@ bool TrashFileHelper::handleIsSubFile(const QUrl &parent, const QUrl &sub)
         return false;
     if (!FileUtils::isTrashFile(sub))
         return false;
-    if (UniversalUtils::urlEquals( FileUtils::trashRootUrl(), parent))
+    if (UniversalUtils::urlEquals(FileUtils::trashRootUrl(), parent))
         return true;
 
     return sub.path().contains(parent.path());


### PR DESCRIPTION
Fixed an issue where clicking cancel when accessing a broken symlink would incorrectly trigger the "Open With" dialog. The problem occurred because the system was treating canceled operations the same as broken symlink resolutions, leading to unwanted dialog popups.

The fix modifies the symlink resolution logic to only add URLs to the invalid path list when users choose to delete or move to trash, not when they cancel the operation. This prevents the subsequent "Open With" dialog from appearing unnecessarily.

Additionally, minor code cleanup was performed in the trash plugin to improve file type checking consistency and fix spacing issues.

Log: Fixed issue where canceling broken symlink access would trigger open with dialog

Influence:
1. Test accessing broken symlinks and verify cancel behavior
2. Check that delete/move to trash options still work correctly
3. Verify normal file operations in trash are unaffected
4. Test various file types in trash to ensure proper opening behavior

fix: 修复访问损坏快捷方式时取消操作会弹出打开方式对话框的问题

修复了在访问损坏的快捷方式时点击取消会错误触发"打开方式"对话框的问题。
问题原因是系统将取消操作与损坏快捷方式解析同等对待，导致不必要的对话框
弹出。

修改了快捷方式解析逻辑，仅当用户选择删除或移动到回收站时才将URL添加到无
效路径列表，取消操作时不添加，从而避免后续出现"打开方式"对话框。

同时进行了垃圾箱插件的代码清理，改进了文件类型检查的一致性并修复了空格
问题。

Log: 修复访问损坏快捷方式时取消操作会弹出打开方式对话框的问题

Influence:
1. 测试访问损坏的快捷方式并验证取消操作行为
2. 检查删除/移动到回收站功能是否正常工作
3. 验证垃圾箱中的正常文件操作不受影响
4. 测试垃圾箱中各种文件类型的打开行为

## Summary by Sourcery

Handle broken symlink cancelation without treating it as an invalid path and align trash plugin file handling behavior.

Bug Fixes:
- Prevent canceled broken symlink access from being added to the invalid path list, avoiding unintended "Open With" dialogs.

Enhancements:
- Use explicit regular-file type checking in the trash plugin and clean up minor formatting in URL comparison.