### PR TITLE
6.5.121

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+dde-file-manager (6.5.121) unstable; urgency=medium
+
+  * fix: resolve compilation failure with C++15 in AbstractJobHandler
+  * fix: improve URL handling in file dialog DBus interface
+  * fix: adjust filename length calculation logic
+  * refactor: extract background widget update logic
+  * fix: optimize selection handling during file removal
+  * fix: prevent accessibility cache holding invalid model references
+  * refactor: improve device type detection logic
+  * chore: reorganize documentation structure
+  * docs: add DDE file manager extension mechanism documentation
+  * docs: add dfm-extension plugin specification
+  * fix: fix thread safety issues in file statistics job
+  * fix: fix file rename failure in multi-threaded scenarios
+  * fix: add UI error handling for direct IO copy operations
+  * fix: add real-time disk space query for copy operations
+  * fix: prevent open with dialog when canceling broken symlink access
+  * fix: restore directory permissions after removing anonymous share
+  * fix: add clean trash type to progress notification logic
+  * fix(bluetooth): display accurate error message for long filename transfer failure
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 06 Feb 2026 11:50:16 +0800
+
 dde-file-manager (6.5.120) unstable; urgency=medium
 
   * refactor: replace serial data key with delayed save timer

--- a/src/plugins/common/dfmplugin-dirshare/utils/anonymouspermissionmanager.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/anonymouspermissionmanager.cpp
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "anonymouspermissionmanager.h"
+
+#include <QStandardPaths>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QDir>
+#include <QFileInfo>
+#include <QFile>
+#include <QSaveFile>
+
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/dfm_global_defines.h>
+
+DFMBASE_USE_NAMESPACE
+
+DPDIRSHARE_BEGIN_NAMESPACE
+
+AnonymousPermissionManager *AnonymousPermissionManager::instance()
+{
+    static AnonymousPermissionManager manager;
+    return &manager;
+}
+
+AnonymousPermissionManager::AnonymousPermissionManager(QObject *parent)
+    : QObject(parent)
+{
+    // Use XDG Config specification path
+    configFilePath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
+            + "/deepin/dde-file-manager/anonymous-share-permissions.json";
+    loadFromFile();
+}
+
+bool AnonymousPermissionManager::setAnonymousPermissions(const QString &filePath, DirectoryType type, bool writable)
+{
+    QFileInfo fileInfo(filePath);
+    if (!fileInfo.exists()) {
+        fmWarning() << "File does not exist:" << filePath;
+        return false;
+    }
+
+    QFile::Permissions current = fileInfo.permissions();
+
+    if (type == DirectoryType::kHomeDirectory) {
+        // Record home directory permissions (only on first anonymous share)
+        if (homeRecord.path.isEmpty()) {
+            homeRecord.path = filePath;
+            homeRecord.original = current;
+            homeRecord.expected = getHomeExpectedPermissions(current);
+            fmInfo() << "Recorded home directory:" << filePath
+                     << "original:" << QString::number(homeRecord.original, 8);
+        }
+
+        // Set home directory permissions (add read and execute for others)
+        QFile file(filePath);
+        if (!file.setPermissions(homeRecord.expected)) {
+            fmWarning() << "Failed to set home directory permissions:" << filePath;
+            return false;
+        }
+
+        fmInfo() << "Set home directory permissions for anonymous share:" << filePath
+                 << "from" << QString::number(current, 8)
+                 << "to" << QString::number(homeRecord.expected, 8);
+    } else {
+        // Record shared directory permissions
+        PermissionRecord record;
+        record.original = current;
+
+        // Calculate expected permissions based on writable flag
+        if (writable) {
+            record.expected = getExpectedPermissions(current);
+        } else {
+            // For read-only anonymous share, only add execute permissions
+            using P = QFile::Permission;
+            record.expected = current | P::ExeGroup | P::ExeOther;
+        }
+
+        shareRecords[filePath] = record;
+        fmInfo() << "Recorded shared directory:" << filePath
+                 << "original:" << QString::number(record.original, 8)
+                 << "expected:" << QString::number(record.expected, 8);
+
+        // Set shared directory permissions
+        QFile file(filePath);
+        if (!file.setPermissions(record.expected)) {
+            fmWarning() << "Failed to set shared directory permissions:" << filePath;
+            shareRecords.remove(filePath);
+            return false;
+        }
+
+        fmInfo() << "Set shared directory permissions for anonymous share:" << filePath
+                 << "from" << QString::number(current, 8)
+                 << "to" << QString::number(record.expected, 8);
+    }
+
+    return saveToFile();
+}
+
+bool AnonymousPermissionManager::restoreDirectoryPermissions(const QString &filePath)
+{
+    // Only proceed if has record (record exists means it was anonymous share)
+    if (!shareRecords.contains(filePath))
+        return false;
+
+    const auto &record = shareRecords[filePath];
+    QFile::Permissions current = QFileInfo(filePath).permissions();
+
+    // Check if current permissions match expected permissions
+    // If not equal, user has manually modified permissions
+    if (current != record.expected) {
+        fmInfo() << "Directory permissions modified by user, skip restore:" << filePath
+                 << "expected:" << QString::number(record.expected, 8)
+                 << "current:" << QString::number(current, 8);
+        // Clean record to prevent incorrect restore
+        cleanRecord(filePath);
+        return false;
+    }
+
+    // Restore to original permissions
+    QFile file(filePath);
+    if (file.setPermissions(record.original)) {
+        fmInfo() << "Successfully restored directory permissions:" << filePath
+                 << "from" << QString::number(current, 8)
+                 << "to" << QString::number(record.original, 8);
+        cleanRecord(filePath);
+        return true;
+    }
+
+    fmWarning() << "Failed to restore directory permissions:" << filePath;
+    return false;
+}
+
+bool AnonymousPermissionManager::restoreHomeDirectoryIfNoAnonymousShares()
+{
+    // No home directory record, nothing to do
+    if (homeRecord.path.isEmpty())
+        return false;
+
+    int currentCount = getCurrentAnonymousShareCount();
+
+    // Do not restore if anonymous shares still exist
+    if (currentCount > 0) {
+        fmDebug() << "Still has" << currentCount << "anonymous shares, skip restore home directory";
+        return false;
+    }
+
+    QFile::Permissions current = QFileInfo(homeRecord.path).permissions();
+
+    // Check if user modified home directory permissions
+    if (current != homeRecord.expected) {
+        fmInfo() << "Home directory permissions modified by user, skip restore:"
+                 << "expected:" << QString::number(homeRecord.expected, 8)
+                 << "current:" << QString::number(current, 8);
+        // Clear home record
+        homeRecord = HomeDirectoryRecord();
+        saveToFile();
+        return false;
+    }
+
+    // Restore home directory permissions
+    QFile file(homeRecord.path);
+    if (file.setPermissions(homeRecord.original)) {
+        fmInfo() << "Successfully restored home directory permissions"
+                 << "from" << QString::number(current, 8)
+                 << "to" << QString::number(homeRecord.original, 8);
+        // Clear home record
+        homeRecord = HomeDirectoryRecord();
+        saveToFile();
+        return true;
+    }
+
+    fmWarning() << "Failed to restore home directory permissions:" << homeRecord.path;
+    return false;
+}
+
+void AnonymousPermissionManager::cleanRecord(const QString &filePath)
+{
+    shareRecords.remove(filePath);
+    saveToFile();
+}
+
+QFile::Permissions AnonymousPermissionManager::getExpectedPermissions(QFile::Permissions original) const
+{
+    using P = QFile::Permission;
+    // Anonymous share requires: group write/execute, others write/execute
+    return original | P::WriteGroup | P::ExeGroup | P::WriteOther | P::ExeOther;
+}
+
+QFile::Permissions AnonymousPermissionManager::getHomeExpectedPermissions(QFile::Permissions original) const
+{
+    using P = QFile::Permission;
+    // Home directory requires: others read/execute
+    return original | P::ReadOther | P::ExeOther;
+}
+
+int AnonymousPermissionManager::getCurrentAnonymousShareCount() const
+{
+    // Get anonymous share count from recorded shares in JSON file
+    return shareRecords.size();
+}
+
+bool AnonymousPermissionManager::loadFromFile()
+{
+    QFile file(configFilePath);
+    if (!file.exists()) {
+        // First run, ensure config directory exists
+        QDir().mkpath(QFileInfo(configFilePath).path());
+        fmInfo() << "Config file does not exist, will be created on first save";
+        return true;
+    }
+
+    if (!file.open(QIODevice::ReadOnly)) {
+        fmWarning() << "Failed to open config file for reading:" << configFilePath;
+        return false;
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    if (doc.isNull() || !doc.isObject()) {
+        fmWarning() << "Invalid JSON config file:" << configFilePath;
+        file.close();
+        return false;
+    }
+
+    QJsonObject root = doc.object();
+
+    // Load shared directory records
+    QJsonObject sharesObj = root[kJsonShares].toObject();
+    for (const QString &path : sharesObj.keys()) {
+        QJsonObject shareObj = sharesObj[path].toObject();
+        PermissionRecord record;
+        record.original = static_cast<QFile::Permissions>(shareObj[kJsonOriginal].toInt());
+        record.expected = static_cast<QFile::Permissions>(shareObj[kJsonExpected].toInt());
+        shareRecords[path] = record;
+    }
+
+    // Load home directory record
+    QJsonObject homeObj = root[kJsonHomeDirectory].toObject();
+    if (!homeObj.isEmpty()) {
+        homeRecord.path = homeObj[kJsonPath].toString();
+        homeRecord.original = static_cast<QFile::Permissions>(homeObj[kJsonOriginal].toInt());
+        homeRecord.expected = static_cast<QFile::Permissions>(homeObj[kJsonExpected].toInt());
+    }
+
+    file.close();
+    fmInfo() << "Loaded permission records from config file, shares:" << shareRecords.size();
+    return true;
+}
+
+bool AnonymousPermissionManager::saveToFile()
+{
+    // Ensure directory exists
+    QDir().mkpath(QFileInfo(configFilePath).path());
+
+    QSaveFile file(configFilePath);
+    if (!file.open(QIODevice::WriteOnly)) {
+        fmWarning() << "Failed to open config file for writing:" << configFilePath;
+        return false;
+    }
+
+    QJsonObject root;
+    root[kJsonVersion] = 1;
+
+    // Save shared directory records
+    QJsonObject sharesObj;
+    for (const QString &path : shareRecords.keys()) {
+        const auto &record = shareRecords[path];
+        QJsonObject shareObj;
+        shareObj[kJsonOriginal] = static_cast<int>(record.original);
+        shareObj[kJsonExpected] = static_cast<int>(record.expected);
+        sharesObj[path] = shareObj;
+    }
+    root[kJsonShares] = sharesObj;
+
+    // Save home directory record (only if exists)
+    if (!homeRecord.path.isEmpty()) {
+        QJsonObject homeObj;
+        homeObj[kJsonPath] = homeRecord.path;
+        homeObj[kJsonOriginal] = static_cast<int>(homeRecord.original);
+        homeObj[kJsonExpected] = static_cast<int>(homeRecord.expected);
+        root[kJsonHomeDirectory] = homeObj;
+    }
+
+    file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+
+    // Commit changes atomically
+    if (!file.commit()) {
+        fmWarning() << "Failed to save config file:" << configFilePath;
+        return false;
+    }
+
+    return true;
+}
+
+DPDIRSHARE_END_NAMESPACE

--- a/src/plugins/common/dfmplugin-dirshare/utils/anonymouspermissionmanager.h
+++ b/src/plugins/common/dfmplugin-dirshare/utils/anonymouspermissionmanager.h
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ANONYMOUSPERMISSIONMANAGER_H
+#define ANONYMOUSPERMISSIONMANAGER_H
+
+#include <QObject>
+#include <QFile>
+#include <QMap>
+#include <QFileInfo>
+
+#include "dfmplugin_dirshare_global.h"
+
+DPDIRSHARE_BEGIN_NAMESPACE
+
+class AnonymousPermissionManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    // JSON configuration file keys
+    static constexpr char kJsonVersion[] = "version";
+    static constexpr char kJsonShares[] = "shares";
+    static constexpr char kJsonHomeDirectory[] = "homeDirectory";
+    static constexpr char kJsonPath[] = "path";
+    static constexpr char kJsonOriginal[] = "original";
+    static constexpr char kJsonExpected[] = "expected";
+
+    /**
+     * @brief Directory type enum for clear interface
+     */
+    enum class DirectoryType
+    {
+        kSharedDirectory,
+        kHomeDirectory
+    };
+
+    /**
+     * @brief Permission record structure
+     */
+    struct PermissionRecord
+    {
+        QFile::Permissions original;
+        QFile::Permissions expected;
+    };
+
+    /**
+     * @brief Home directory record structure
+     */
+    struct HomeDirectoryRecord
+    {
+        QString path;
+        QFile::Permissions original;
+        QFile::Permissions expected;
+    };
+
+    static AnonymousPermissionManager *instance();
+
+    /**
+     * @brief Set directory permissions for anonymous share
+     * This method records original permissions and sets new permissions
+     * @param filePath File path
+     * @param type Directory type (shared directory or home directory)
+     * @param writable Whether share is writable (only for shared directories)
+     * @return Success
+     */
+    bool setAnonymousPermissions(const QString &filePath, DirectoryType type, bool writable = true);
+
+    /**
+     * @brief Restore directory permissions (from anonymous share back to original)
+     * @param filePath File path
+     * @return Success
+     */
+    bool restoreDirectoryPermissions(const QString &filePath);
+
+    /**
+     * @brief Restore home directory permissions when no anonymous shares exist
+     * @return Success
+     */
+    bool restoreHomeDirectoryIfNoAnonymousShares();
+
+    /**
+     * @brief Clean permission record for specified path
+     * @param filePath File path
+     */
+    void cleanRecord(const QString &filePath);
+
+private:
+    explicit AnonymousPermissionManager(QObject *parent = nullptr);
+
+    bool loadFromFile();
+    bool saveToFile();
+
+    /**
+     * @brief Calculate expected permissions for anonymous shared directory
+     * (add write and execute permissions for group and others)
+     */
+    QFile::Permissions getExpectedPermissions(QFile::Permissions original) const;
+
+    /**
+     * @brief Calculate expected permissions for home directory
+     * (add read and execute permissions for others)
+     */
+    QFile::Permissions getHomeExpectedPermissions(QFile::Permissions original) const;
+
+    /**
+     * @brief Get current anonymous share count from UserShareHelper
+     */
+    int getCurrentAnonymousShareCount() const;
+
+private:
+    QString configFilePath;
+    QMap<QString, PermissionRecord> shareRecords;
+    HomeDirectoryRecord homeRecord;
+};
+
+DPDIRSHARE_END_NAMESPACE
+
+#endif   // ANONYMOUSPERMISSIONMANAGER_H

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -395,7 +395,8 @@ void AbstractWorker::emitProgressChangedNotify(const qint64 &writSize)
         || AbstractJobHandler::JobType::kCutType == jobType) {
         info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(sourceFilesTotalSize)));
     } else if (AbstractJobHandler::JobType::kMoveToTrashType == jobType
-               || AbstractJobHandler::JobType::kRestoreType == jobType) {
+               || AbstractJobHandler::JobType::kRestoreType == jobType
+               || AbstractJobHandler::JobType::kCleanTrashType == jobType) {
         info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(sourceUrls.count())));
     } else {
         info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(allFilesList.count())));


### PR DESCRIPTION
## Summary by Sourcery

Introduce centralized management of filesystem permissions for anonymous directory shares and ensure permissions are restored when anonymous sharing is disabled or removed.

New Features:
- Add AnonymousPermissionManager utility to record, adjust, and persist filesystem permissions used for anonymous directory and home shares.

Bug Fixes:
- Ensure directory and home directory permissions are correctly restored when an anonymous share is removed or converted to a non-anonymous share from both the widget and context menu flows.
- Include total item count reporting for trash cleaning jobs in file operation progress notifications.

Enhancements:
- Refine dirshare permission handling to rely on AnonymousPermissionManager instead of in-place chmod logic, improving robustness and user-modification safety.