### PR TITLE
fix: fix dynamic argument replacement in OEM menu commands

### DIFF
--- a/src/plugins/common/dfmplugin-menu/oemmenuscene/oemmenu.h
+++ b/src/plugins/common/dfmplugin-menu/oemmenuscene/oemmenu.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,7 +25,7 @@ public:
     QList<QAction *> emptyActions(const QUrl &currentDir, bool onDesktop = false);
     QList<QAction *> normalActions(const QList<QUrl> &files, bool onDesktop = false);
     QList<QAction *> focusNormalActions(const QUrl &foucs, const QList<QUrl> &files, bool onDesktop = false);
-    QPair<QString, QStringList> makeCommand(const QAction *action, const QUrl &dir, const QUrl &foucs, const QList<QUrl> &files);
+    QPair<QString, QStringList> makeCommand(const QAction *action, const QUrl &dir, const QUrl &focus, const QList<QUrl> &files);
 
 private:
     QScopedPointer<OemMenuPrivate> d;

--- a/src/plugins/common/dfmplugin-menu/oemmenuscene/private/oemmenu_p.h
+++ b/src/plugins/common/dfmplugin-menu/oemmenuscene/private/oemmenu_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -49,13 +49,14 @@ public:
     void clearSubMenus();
     void setActionProperty(QAction *const action, const Dtk::Core::DDesktopEntry &entry, const QString &key, const QString &section = "Desktop Entry") const;
     QStringList splitCommand(const QString &cmd);
-    ArgType execDynamicArg(const QString &cmd) const;
+    QPair<ArgType, int> execDynamicArg(const QStringList &args, int index) const;
     QStringList replace(QStringList &args, const QString &before, const QString &after) const;
     QStringList replaceList(QStringList &args, const QString &before, const QStringList &after) const;
     QStringList urlListToLocalFile(const QList<QUrl> &files) const;
     QString urlToString(const QUrl &file) const;
     QStringList urlListToString(const QList<QUrl> &files) const;
     void appendParentMineType(const QStringList &parentmimeTypes, QStringList &mimeTypes) const;
+    QStringList applyDynamicArg(const QStringList &args, ArgType type, const QUrl &dir, const QUrl &focus, const QList<QUrl> &files) const;
 
 public:
     QSharedPointer<QTimer> delayedLoadFileTimer;


### PR DESCRIPTION
Fixed an issue where dynamic argument replacement in OEM menu
commands was not properly handling multiple placeholders. The original
implementation only processed the first placeholder found in the command
arguments. The new implementation uses a loop to repeatedly process
dynamic arguments until no more placeholders are found, ensuring all
%d, %f, %F, %u, and %U placeholders are correctly replaced with their
corresponding values.

The changes include:
1. Initializing return value with original arguments
2. Using a while loop to process multiple dynamic arguments
3. Rebuilding command string after each replacement to detect next
placeholder
4. Maintaining the same replacement logic for different argument types

Influence:
1. Test OEM menu commands with single dynamic argument placeholder
2. Test OEM menu commands with multiple dynamic argument placeholders
3. Verify all placeholder types (%d, %f, %F, %u, %U) work correctly
4. Test combinations of different placeholder types in same command
5. Verify file path and URL replacements work as expected

fix: 修复 OEM 菜单命令中动态参数替换问题

修复了 OEM 菜单命令中动态参数替换无法正确处理多个占位符的问题。原实现只
能处理命令参数中的第一个占位符。新实现使用循环重复处理动态参数，直到找不
到更多占位符，确保所有 %d、%f、%F、%u 和 %U 占位符都能正确替换为对应值。

更改包括：
1. 使用原始参数初始化返回值
2. 使用 while 循环处理多个动态参数
3. 每次替换后重新构建命令字符串以检测下一个占位符
4. 保持不同参数类型的相同替换逻辑

Influence:
1. 测试包含单个动态参数占位符的 OEM 菜单命令
2. 测试包含多个动态参数占位符的 OEM 菜单命令
3. 验证所有占位符类型（%d、%f、%F、%u、%U）正常工作
4. 测试同一命令中不同占位符类型的组合
5. 验证文件路径和 URL 替换按预期工作

## Summary by Sourcery

Fix OEM menu command generation to correctly handle multiple dynamic argument placeholders and align project license metadata with REUSE specifications.

Bug Fixes:
- Ensure OEM menu commands replace all dynamic argument placeholders across arguments instead of only the first occurrence.

Enhancements:
- Refactor dynamic argument detection and application into reusable helpers that operate over argument lists and track placeholder positions.

Build:
- Adopt REUSE-compliant licensing configuration via REUSE.toml and remove the legacy .reuse/dep5 file.