### PR TITLE
fix: resolve geometry update issues in background manager

### DIFF
--- a/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
@@ -197,7 +197,8 @@ void BackgroundManager::onGeometryChanged()
         }
 
         if (bw.get() != nullptr) {
-            QRect geometry = d->relativeGeometry(win->geometry());   // scaled area
+            QRect screenGeometry = win->property(DesktopFrameProperty::kPropScreenGeometry).toRect();
+            QRect geometry = d->relativeGeometry(screenGeometry);   // scaled area
             if (bw->geometry() == geometry) {
                 fmWarning() << "Background geometry equals root widget geometry, discarding changes - geometry:" << bw->geometry()
                             << "window geometry:" << win->geometry() << "screen name:" << win->property(DesktopFrameProperty::kPropScreenName).toString()
@@ -206,8 +207,10 @@ void BackgroundManager::onGeometryChanged()
                             << "available geometry:" << win->property(DesktopFrameProperty::kPropScreenAvailableGeometry);
                 continue;
             }
+
             fmInfo() << "Background geometry changed from" << bw->geometry() << "to" << geometry
-                     << "for screen:" << getScreenName(win) << "window geometry:" << win->geometry();
+                     << "for screen:" << getScreenName(win) << "window geometry:" << win->geometry()
+                     << "screen geometry from property:" << screenGeometry;
             bw->setGeometry(geometry);
             changed = true;
         }
@@ -259,7 +262,8 @@ void BackgroundManager::updateBackgroundWidgets()
         BackgroundWidgetPointer bwp = d->backgroundWidgets.value(screeName);
         d->backgroundWidgets.clear();
         if (!bwp.isNull()) {
-            QRect geometry = d->relativeGeometry(primary->geometry());   // scaled area
+            QRect screenGeometry = primary->property(DesktopFrameProperty::kPropScreenGeometry).toRect();
+            QRect geometry = d->relativeGeometry(screenGeometry);   // scaled area
             if (bwp->geometry() != geometry) {
                 fmInfo() << "Updating background widget geometry from" << bwp->geometry() << "to" << geometry;
                 bwp->setGeometry(geometry);
@@ -287,7 +291,8 @@ void BackgroundManager::updateBackgroundWidgets()
             BackgroundWidgetPointer bwp = d->backgroundWidgets.value(screenName);
             if (!bwp.isNull()) {
                 // update widget
-                QRect geometry = d->relativeGeometry(win->geometry());   // scaled area
+                QRect screenGeometry = win->property(DesktopFrameProperty::kPropScreenGeometry).toRect();
+                QRect geometry = d->relativeGeometry(screenGeometry);   // scaled area
                 if (bwp->geometry() != geometry) {
                     fmInfo() << "Updating background widget geometry for screen" << screenName << "from" << bwp->geometry() << "to" << geometry;
                     bwp->setGeometry(geometry);

--- a/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileselectionmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileselectionmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,24 @@ FileSelectionModel::FileSelectionModel(QAbstractItemModel *model, QObject *paren
 
 FileSelectionModel::~FileSelectionModel()
 {
+    // 先停止定时器，防止在析构过程中定时器触发
+    if (d && d->timer.isActive()) {
+        d->timer.stop();
+    }
+
+    // 先解绑模型，清理基类QItemSelectionModel中的QPersistentModelIndex
+    setModel(nullptr);
+
+    // 清理其他成员变量
+    if (d) {
+        // 断开所有信号连接
+        d->timer.disconnect();
+
+        d->selection.clear();
+        d->firstSelectedIndex = QPersistentModelIndex();
+        d->lastSelectedIndex = QPersistentModelIndex();
+        d->selectedList.clear();
+    }
 }
 
 bool FileSelectionModel::isSelected(const QModelIndex &index) const

--- a/src/plugins/filemanager/dfmplugin-workspace/models/private/fileselectionmodel_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/private/fileselectionmodel_p.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,4 +14,21 @@ FileSelectionModelPrivate::FileSelectionModelPrivate(FileSelectionModel *qq)
 {
     timer.setSingleShot(true);
     QObject::connect(&timer, &QTimer::timeout, q, &FileSelectionModel::updateSelecteds);
+}
+
+FileSelectionModelPrivate::~FileSelectionModelPrivate()
+{
+    // 停止定时器，防止在析构过程中定时器触发
+    if (timer.isActive()) {
+        timer.stop();
+    }
+
+    // 断开定时器的所有信号连接
+    timer.disconnect();
+
+    // 清理其他资源
+    selection.clear();
+    firstSelectedIndex = QPersistentModelIndex();
+    lastSelectedIndex = QPersistentModelIndex();
+    selectedList.clear();
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/private/fileselectionmodel_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/private/fileselectionmodel_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2021 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,6 +19,8 @@ class FileSelectionModelPrivate : public QObject
 
 public:
     explicit FileSelectionModelPrivate(FileSelectionModel *qq);
+    ~FileSelectionModelPrivate() override;
+
     mutable QModelIndexList selectedList;
     QItemSelection selection;
     QModelIndex firstSelectedIndex;


### PR DESCRIPTION
Changed the way screen geometry is obtained in background manager to use property-based approach instead of direct window geometry.

Log: Fixed background positioning issues on multi-screen setups

Influence:
1. Test background display on multi-monitor setups with different resolutions
2. Verify background correctly adapts to screen geometry changes
3. Test moving windows between screens and check background updates
4. Verify no flickering or misaligned backgrounds during screen configuration changes
5. Test with various screen scaling factors

fix: 修复背景管理器中的几何更新问题

修改了背景管理器中获取屏幕几何信息的方式，使用基于属性的方法替代直接获取
窗口几何信息。

Log: 修复了多屏幕设置下的背景定位问题

Influence:
1. 测试多显示器设置下不同分辨率的背景显示
2. 验证背景正确适应屏幕几何变化
3. 测试窗口在屏幕间移动时的背景更新情况
4. 验证屏幕配置更改时无闪烁或错位背景
5. 测试各种屏幕缩放比例下的表现

Bug: https://pms.uniontech.com/bug-view-307021.html

## Summary by Sourcery

Use property-based screen geometry to update desktop background widgets more accurately across screens.

Bug Fixes:
- Fix incorrect or stale background positioning when screen geometry changes, especially on multi-monitor setups.

Enhancements:
- Improve background geometry logging by including the screen geometry obtained from window properties for easier debugging.