### PR TITLE
fix: decode URL percent encoding in selectedUrls

### DIFF
--- a/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -80,7 +80,7 @@ QStringList FileDialogHandleDBus::selectedUrls() const
     QStringList list;
 
     for (const QUrl &url : FileDialogHandle::selectedUrls())
-        list << url.toString();
+        list << QUrl::fromPercentEncoding(url.toString().toUtf8());
 
     return list;
 }


### PR DESCRIPTION
The selectedUrls() method was returning URL strings with percent
encoding intact which caused incorrect display of special characters in
file paths. This fix uses QUrl::fromPercentEncoding() to properly decode
the URLs before returning them, ensuring that file names with special
characters are displayed correctly.

Influence:
1. Test file selection with filenames containing spaces, special
characters, or non-ASCII characters
2. Verify that selected file URLs are properly decoded and displayed
3. Check that the file dialog correctly handles various character
encodings
4. Ensure backward compatibility with existing file selection
functionality

fix: 修复 selectedUrls 中的 URL 百分比编码解码问题

selectedUrls() 方法之前返回的 URL 字符串保留了百分比编码，导致文件路径中
的特殊字符显示不正确。此修复使用 QUrl::fromPercentEncoding() 在返回 URL
之前正确解码它们，确保包含特殊字符的文件名能够正确显示。

Influence:
1. 测试包含空格、特殊字符或非 ASCII 字符的文件名选择功能
2. 验证选中的文件 URL 是否正确解码和显示
3. 检查文件对话框是否正确处理各种字符编码
4. 确保与现有文件选择功能的向后兼容性

BUG: https://pms.uniontech.com/bug-view-317361.html

## Summary by Sourcery

Bug Fixes:
- Fix incorrect display of selected file paths by decoding percent-encoded URLs returned from the file dialog.