### PR TITLE
fix: use deleteLater for safer header view cleanup

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -97,7 +97,7 @@ void FileViewPrivate::initIconModeView()
             headerView->disconnect();
             auto headerLayout = qobject_cast<QVBoxLayout *>(headerWidget->layout());
             headerLayout->takeAt(0);
-            delete headerView;
+            headerView->deleteLater();
             headerView = nullptr;
             fmDebug() << "Header view removed for icon mode";
         }


### PR DESCRIPTION
- Change the direct call to `delete` to use Qt's `deleteLater()`

Reason: `deleteLater()` is the recommended object cleanup method in Qt, which defers execution until control returns to the event loop, preventing crashes caused by deleting objects during event processing

Log: use deleteLater for safer header view cleanup
Bug: https://pms.uniontech.com/bug-view-350483.html

## Summary by Sourcery

Bug Fixes:
- Replace direct deletion of the header view with deleteLater() to prevent unsafe object destruction while the event loop is running.