### PR TITLE
fix: prevent potential crash on application quit

### DIFF
--- a/src/apps/dde-file-manager-preview/filepreview/previewsingleapplication.cpp
+++ b/src/apps/dde-file-manager-preview/filepreview/previewsingleapplication.cpp
@@ -114,6 +114,7 @@ void PreviewSingleApplication::processArgs(const QStringList &list)
 void PreviewSingleApplication::initConnect()
 {
     connect(localServer, &QLocalServer::newConnection, this, &PreviewSingleApplication::handleConnection);
+    connect(this, &QCoreApplication::aboutToQuit, this, &PreviewSingleApplication::closeServer);
 }
 
 QLocalSocket *PreviewSingleApplication::getNewClientConnect(const QString &key, const QByteArray &message)


### PR DESCRIPTION
Added connection to close local server when application is about to quit This change ensures the QLocalServer is properly closed before application termination,
preventing potential crashes that could occur if the server was still active during shutdown

Influence:
1. Test application normal shutdown process
2. Verify server resources are properly released
3. Test multiple quick open/close cycles
4. Check memory usage after application termination

fix: 修复应用退出时潜在的崩溃问题

添加了在应用即将退出时关闭本地服务器的连接
此更改确保在应用程序终止前正确关闭QLocalServer，
防止在关闭过程中服务器仍处于活动状态时可能发生的崩溃

Influence:
1. 测试应用程序正常关闭过程
2. 验证服务器资源是否正确释放
3. 测试多次快速打开/关闭循环
4. 检查应用程序终止后的内存使用情况

## Summary by Sourcery

Bug Fixes:
- Ensure the preview application's QLocalServer is closed when the application is about to quit to avoid potential shutdown crashes.