### PR TITLE
fix bugs

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/utils/previewdialogmanager.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/utils/previewdialogmanager.cpp
@@ -128,6 +128,13 @@ void PreviewDialogManager::showPreviewDialog(const quint64 winId, const QList<QU
         filePreviewDialog->setEntryUrlList(dirUrl);
     }
 
+    if (!filePreviewDialog->hasValidPreview()) {
+        qCWarning(logLibFilePreview) << "PreviewDialogManager: preview creation failed, not showing dialog";
+        filePreviewDialog->deleteLater();
+        filePreviewDialog = nullptr;
+        return;
+    }
+
     qCInfo(logLibFilePreview) << "PreviewDialogManager: displaying preview dialog";
     if (updatePos) {
         filePreviewDialog->show();

--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
@@ -507,6 +507,11 @@ void FilePreviewDialog::updateTitle()
     qCDebug(logLibFilePreview) << "FilePreviewDialog: updated title to:" << elidedText;
 }
 
+bool FilePreviewDialog::hasValidPreview() const
+{
+    return preview != nullptr;
+}
+
 QString FilePreviewDialog::generalKey(const QString &key)
 {
     const QStringList &tmp = key.split('/');

--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.h
@@ -31,6 +31,8 @@ public:
 
     void setCurrentWinID(quint64 winID);
 
+    bool hasValidPreview() const;
+
 signals:
     void signalCloseEvent();
 

--- a/src/plugins/daemon/core/core.cpp
+++ b/src/plugins/daemon/core/core.cpp
@@ -59,7 +59,7 @@ bool Core::start()
     // DeviceManagerDBus class, so this code seems useless.
     // but now it doesn't bring me any issue, left now and remove it later.
     if (!DevProxyMng->initService()) {
-        fmCritical() << "device manager cannot connect to server!";
+        fmWarning() << "device manager cannot connect to server!";
         DevMngIns->startMonitor();
     }
 

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/dragdropoper.cpp
@@ -641,7 +641,10 @@ bool DragDropOper::checkSourceValid(const QList<QUrl> &srcUrls)
                            }
 
                            // Check for standard move/copy/rename capabilities.
-                           if (info->canAttributes(CanableInfoType::kCanMoveOrCopy) || info->canAttributes(CanableInfoType::kCanRename))
+                           // BUG-346975, BUG-350297
+                           if (!info->exists()
+                               || info->canAttributes(CanableInfoType::kCanMoveOrCopy)
+                               || info->canAttributes(CanableInfoType::kCanRename))
                                return true;
 
                            fmDebug() << "Drag operation not enabled for URL:" << url.toString();

--- a/src/plugins/desktop/ddplugin-core/core.cpp
+++ b/src/plugins/desktop/ddplugin-core/core.cpp
@@ -178,7 +178,7 @@ bool Core::eventFilter(QObject *watched, QEvent *event)
 void Core::connectToServer()
 {
     if (!DevProxyMng->initService()) {
-        fmCritical() << "Device manager cannot connect to server, starting local monitor";
+        fmWarning() << "Device manager cannot connect to server, starting local monitor";
         DevMngIns->startMonitor();
     } else {
         fmInfo() << "Device manager connected to server successfully";

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -159,7 +159,7 @@ bool DragDropHelper::dragMove(QDragMoveEvent *event)
         // copy action must origin file can copy
         const QUrl &targetUrl = hoverFileInfo->urlOf(UrlInfoType::kUrl);
         FileInfoPointer info = InfoFactory::create<FileInfo>(url);
-        if (event->dropAction() == Qt::DropAction::CopyAction && !info->canAttributes(CanableInfoType::kCanMoveOrCopy)) {
+        if (event->dropAction() == Qt::DropAction::CopyAction && info->exists() && !info->canAttributes(CanableInfoType::kCanMoveOrCopy)) {
             fmDebug() << "Copy operation not allowed for URL:" << url.toString();
             view->setViewSelectState(false);
             event->ignore();
@@ -485,7 +485,10 @@ bool DragDropHelper::checkDragEnable(const QUrl &dragUrl, const QUrl &targetUrl)
         return false;
 
     // Check for standard move/copy/rename capabilities.
-    if (info->canAttributes(CanableInfoType::kCanMoveOrCopy) || info->canAttributes(CanableInfoType::kCanRename))
+    // BUG-350297
+    if (!info->exists()
+        || info->canAttributes(CanableInfoType::kCanMoveOrCopy)
+        || info->canAttributes(CanableInfoType::kCanRename))
         return true;
 
     // Some desktop files may allow trash even if not movable/renamable.
@@ -505,5 +508,5 @@ bool DragDropHelper::checkMoveEnable(const QUrl &dragUrl, const QUrl &toUrl) con
     if (FileUtils::isDesktopFile(info->urlOf(UrlInfoType::kUrl))) {
         return info->canAttributes(CanableInfoType::kCanMoveOrCopy) || (FileUtils::isTrashFile(toUrl) || FileUtils::isTrashDesktopFile(toUrl));
     }
-    return info->canAttributes(CanableInfoType::kCanRename);
+    return !info->exists() || info->canAttributes(CanableInfoType::kCanRename);
 }


### PR DESCRIPTION
## Summary by Sourcery

Adjust drag-and-drop and preview handling to better respect file existence and capabilities while softening device manager connection failures.

Bug Fixes:
- Prevent disallowing copy operations for non-existent drag sources by checking file existence before enforcing move/copy capabilities.
- Allow drag-and-drop and move operations to proceed when the source file no longer exists to avoid blocking valid workflows.
- Avoid showing a preview dialog when preview creation fails by checking for a valid preview instance first.

Enhancements:
- Downgrade device manager connection failures from critical errors to warnings while continuing to fall back to local monitoring.