### PR TITLE
fix: fix maximize button state not synced when reopening folder

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -59,6 +59,7 @@ public slots:
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 private:
     void initializeUi();


### PR DESCRIPTION
When a file manager window is maximized and then closed, reopening a folder window causes the maximize button state to be incorrect. This happens because DTitlebar's event filter is installed during the show event, but the window state change event is not properly triggered to sync the button state.

The fix adds a showEvent handler that waits for DTitlebar's event filter to be fully installed, then sends a WindowStateChange event to trigger DTitlebar's handleParentWindowStateChange() method. This ensures the maximize button correctly reflects the window's maximized state when the titlebar is first shown.

Log: Fixed maximize button state not updating correctly when reopening maximized folder windows

Influence:
1. Test opening a folder window and maximizing it
2. Close the folder window and reopen another folder
3. Verify the maximize button shows the correct state (restore button for maximized windows)
4. Test with normal, maximized, and fullscreen window states
5. Verify the fix works for both single and multiple window scenarios

fix: 修复重新打开文件夹时最大化按钮状态不同步的问题

当文件管理器窗口最大化后关闭，重新打开文件夹窗口时，最大化按钮状态显示不
正确。这是因为DTitlebar的事件过滤器在显示事件期间安装，但窗口状态变化事
件没有正确触发来同步按钮状态。

该修复添加了showEvent处理程序，等待DTitlebar的事件过滤器完全安装后，发送
WindowStateChange事件来触发DTitlebar的handleParentWindowStateChange()方 法。这确保了标题栏首次显示时，最大化按钮能正确反映窗口的最大化状态。

Log: 修复重新打开最大化文件夹窗口时最大化按钮状态不更新的问题

Influence:
1. 测试打开文件夹窗口并最大化
2. 关闭文件夹窗口后重新打开另一个文件夹
3. 验证最大化按钮显示正确状态（最大化窗口显示恢复按钮）
4. 测试正常、最大化和全屏窗口状态
5. 验证修复在单窗口和多窗口场景下均有效

Bug: https://pms.uniontech.com/bug-view-351341.html

## Summary by Sourcery

Bug Fixes:
- Fix maximize button state not updating when reopening a previously maximized file manager window by syncing titlebar state on first show.