### PR TITLE
fix: [vault] crash when restoring `leftErrorTimes`

### DIFF
--- a/src/plugins/daemon/vault/dbus/vaultmanagerdbus.cpp
+++ b/src/plugins/daemon/vault/dbus/vaultmanagerdbus.cpp
@@ -140,8 +140,13 @@ void VaultManagerDBus::RestoreLeftoverErrorInputTimes(int userID)
         fmWarning() << "[VaultManagerDBus::RestoreLeftoverErrorInputTimes] Invalid invoker for user ID:" << userID;
         return;
     }
+    restoreLeftoverErrorInputTimes(userID);
+}
+
+void VaultManagerDBus::restoreLeftoverErrorInputTimes(int userID)
+{
     mapLeftoverInputTimes[userID] = kErrorInputTime;
-    fmInfo() << "[VaultManagerDBus::RestoreLeftoverErrorInputTimes] Restored error input times for user:" << userID;
+    fmInfo() << "[VaultManagerDBus::restoreLeftoverErrorInputTimes] Restored error input times for user:" << userID;
 }
 
 void VaultManagerDBus::StartTimerOfRestorePasswordInput(int userID)
@@ -174,8 +179,13 @@ void VaultManagerDBus::RestoreNeedWaitMinutes(int userID)
         fmWarning() << "[VaultManagerDBus::RestoreNeedWaitMinutes] Invalid invoker for user ID:" << userID;
         return;
     }
+    restoreNeedWaitMinutes(userID);
+}
+
+void VaultManagerDBus::restoreNeedWaitMinutes(int userID)
+{
     mapNeedMinutes[userID] = kTotalWaitTime;
-    fmInfo() << "[VaultManagerDBus::RestoreNeedWaitMinutes] Restored wait time for user:" << userID;
+    fmInfo() << "[VaultManagerDBus::restoreNeedWaitMinutes] Restored wait time for user:" << userID;
 }
 
 void VaultManagerDBus::timerEvent(QTimerEvent *event)
@@ -192,9 +202,9 @@ void VaultManagerDBus::timerEvent(QTimerEvent *event)
         if (mapNeedMinutes[userID] < 1) {
             killTimer(timerID);
             mapTimer.remove(timerID);
-            // 密码剩余输入次数还原，需要等待的分钟数还原
-            RestoreLeftoverErrorInputTimes(userID);
-            RestoreNeedWaitMinutes(userID);
+            // 密码剩余输入次数还原,需要等待的分钟数还原,在计时器启动时已经检查权限，这里不再检查
+            restoreLeftoverErrorInputTimes(userID);
+            restoreNeedWaitMinutes(userID);
             fmInfo() << "[VaultManagerDBus::timerEvent] Timer expired for user" << userID << ", restored input attempts";
         }
     }

--- a/src/plugins/daemon/vault/dbus/vaultmanagerdbus.h
+++ b/src/plugins/daemon/vault/dbus/vaultmanagerdbus.h
@@ -123,6 +123,18 @@ private:
      */
     QString GetCurrentUser() const;
 
+    /*!
+     * \brief  内部还原保险箱剩余错误密码输入次数（不检查权限）
+     * \param userID
+     */
+    void restoreLeftoverErrorInputTimes(int userID);
+
+    /*!
+     * \brief  内部还原保险箱需要等待的分钟数（不检查权限）
+     * \param userID
+     */
+    void restoreNeedWaitMinutes(int userID);
+
     QMap<QString, VaultClock *> mapUserClock {};   // map user and timer.
     VaultClock *curVaultClock { nullptr };   // current user clock.
     QString currentUser {};   // current system user.


### PR DESCRIPTION
Log: as title

Bug: https://pms.uniontech.com/bug-view-350459.html https://pms.uniontech.com/bug-view-350519.html

## Summary by Sourcery

Handle vault password retry restoration both via permission-checked DBus slots and internal helpers to avoid crashes when restoring state from the timer callback.

Bug Fixes:
- Prevent crashes when restoring leftover error input attempts and wait minutes by using internal restore helpers that bypass permission checks from timer events.

Enhancements:
- Refine logging and comments around vault error input attempt and wait-time restoration for clearer diagnostics.