### PR TITLE
fix: fix music title color issue in dark theme

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
@@ -17,6 +17,8 @@
 #include <QBuffer>
 #include <QImageReader>
 
+#include <DFontSizeManager>
+
 #include <unicode/ucnv.h>
 #include <unicode/ucsdet.h>
 #include <taglib/tag.h>
@@ -34,6 +36,8 @@
 #endif
 
 using namespace plugin_filepreview;
+DWIDGET_USE_NAMESPACE
+
 MusicMessageView::MusicMessageView(const QString &uri, QWidget *parent)
     : QFrame(parent),
       currentUrl(uri)
@@ -49,12 +53,7 @@ void MusicMessageView::initUI()
 
     titleLabel = new QLabel(this);
     titleLabel->setObjectName("Title");
-    QFont titleFont = titleLabel->font();
-    titleFont.setPixelSize(18);
-    titleLabel->setFont(titleFont);
-    QPalette titlePe;
-    titlePe.setColor(QPalette::WindowText, QColor("#101010"));
-    titleLabel->setPalette(titlePe);
+    DFontSizeManager::instance()->bind(titleLabel, DFontSizeManager::SizeType::T4, QFont::Weight::DemiBold);
 
     artistLabel = new QLabel(this);
     artistLabel->setObjectName("Artist");
@@ -308,7 +307,7 @@ void MusicMessageView::characterEncodingTransform(MediaMeta &meta, void *obj)
             meta.album = TStringToQString(tag->album());
             meta.artist = TStringToQString(tag->artist());
             meta.title = TStringToQString(tag->title());
-            meta.codec = "UTF-8";   //info codec
+            meta.codec = "UTF-8";   // info codec
         } else {
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
             QTextCodec *codec = QTextCodec::codecForName(detectCodec);
@@ -336,7 +335,7 @@ void MusicMessageView::characterEncodingTransform(MediaMeta &meta, void *obj)
         meta.codec = "UTF-8";
     }
 
-    //empty str
+    // empty str
     meta.album = meta.album.simplified();
     meta.artist = meta.artist.simplified();
     meta.title = meta.title.simplified();


### PR DESCRIPTION
Fixed music preview plugin title label color rendering issue in dark theme by replacing custom font styling with DFontSizeManager. Previously, the title label used hardcoded color values that didn't adapt to theme changes, causing visibility issues in dark mode. Now it uses the system's font management which automatically handles theme- appropriate coloring.

The change also includes minor code cleanups:
1. Added proper namespace usage for DFontSizeManager
2. Fixed comment formatting consistency
3. Removed redundant color and font settings that were causing the theme compatibility issue

Log: Fixed music title display color issue in dark theme

Influence:
1. Test music file preview in both light and dark themes
2. Verify title text is clearly visible in all theme modes
3. Check that font size and weight remain consistent
4. Confirm other metadata labels (artist, album) display correctly
5. Test with various music file formats to ensure encoding detection still works

fix: 修复黑色主题下音乐标题颜色异常问题

修复音乐预览插件标题标签在黑色主题下的颜色显示问题，通过使用
DFontSizeManager 替换自定义字体样式。之前标题标签使用硬编码的颜色值，无
法适应主题变化，导致在深色模式下显示异常。现在使用系统的字体管理，能够自
动处理适合主题的配色。

同时包含代码清理：
1. 添加了 DFontSizeManager 的命名空间使用
2. 修复了注释格式的一致性
3. 移除了导致主题兼容性问题的冗余颜色和字体设置

Log: 修复黑色主题下音乐标题显示颜色异常问题

Influence:
1. 在亮色和黑色主题下测试音乐文件预览功能
2. 验证标题文本在所有主题模式下都清晰可见
3. 检查字体大小和粗细是否保持一致
4. 确认其他元数据标签（艺术家、专辑）显示正确
5. 测试各种音乐文件格式以确保编码检测功能正常

Bug: https://pms.uniontech.com/bug-view-351375.html