### PR TITLE
fix: adjust tab border rendering and splitter animation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -182,7 +182,7 @@ void TitleBarWidget::activatePinnedTab(const QString &pinnedId)
 
 void TitleBarWidget::handleSplitterAnimation(const QVariant &position)
 {
-    int newWidth = qMax(0, 95 - position.toInt());
+    int newWidth = qMax(0, 100 - position.toInt());
     if (newWidth == placeholder->width())
         return;
 


### PR DESCRIPTION
Modified the paintTabBackground method to accept an index parameter and
adjust border drawing logic for the first tab. The first tab now omits
the left vertical border line to prevent visual overlap with window
edges. Also increased the splitter animation maximum width from 95 to
100 for better alignment.

The changes include:
1. Added index parameter to paintTabBackground method signature
2. Implemented conditional border drawing for first tab (index 0)
3. For selected first tab: draws path without left vertical line
4. For unselected first tab: draws three sides (top, right, bottom)
instead of full rectangle
5. Adjusted splitter animation maximum width for improved visual
consistency

Log: Fixed tab border rendering issue with window edges

Influence:
1. Verify first tab border rendering matches adjacent UI elements
2. Test tab selection/deselection visual feedback
3. Check splitter animation smoothness and final position
4. Validate tab bar appearance with multiple tabs open
5. Test window resize behavior with tab bar

fix: 调整标签页边框渲染和分割动画

修改了paintTabBackground方法以接受索引参数，并调整了第一个标签页的边框绘
制逻辑。第一个标签页现在省略左侧垂直边框线，防止与窗口边缘产生视觉重叠。
同时将分割动画的最大宽度从95增加到100以实现更好的对齐。

更改包括：
1. 为paintTabBackground方法签名添加索引参数
2. 为第一个标签页（索引0）实现条件边框绘制
3. 选中的第一个标签页：绘制不包含左侧垂直线的路径
4. 未选中的第一个标签页：绘制三个边（上、右、下）而不是完整矩形
5. 调整分割动画最大宽度以改善视觉一致性

Log: 修复了标签页边框与窗口边缘的渲染问题

Influence:
1. 验证第一个标签页边框渲染是否与相邻UI元素匹配
2. 测试标签页选中/取消选中的视觉反馈
3. 检查分割动画流畅度和最终位置
4. 验证多标签页打开时的标签栏外观
5. 测试带标签栏的窗口调整大小行为

BUG: https://pms.uniontech.com/bug-view-351353.html
