### PR TITLE
fix: fix parent path judgment and excluded path filtering

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander.cpp
@@ -79,7 +79,9 @@ void SimplifiedSearchWorker::createSearchers()
         QStringList relevantIndexedPaths;
 
         for (const QString &indexedPath : indexedPaths) {
-            if (isParentPath(searchPath, indexedPath)) {
+            const QString searchPathForMatch = DFMSearcher::matchPath(searchPath);
+            const QString indexedPathForMatch = DFMSearcher::matchPath(indexedPath);
+            if (isParentPath(searchPathForMatch, indexedPathForMatch)) {
                 isParentOfAnyIndexedPath = true;
                 relevantIndexedPaths.append(indexedPath);
             }

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.h
@@ -28,6 +28,7 @@ public:
 
     static bool supportUrl(const QUrl &url);
     static QString realSearchPath(const QUrl &url);
+    static QString matchPath(const QString &path);
 
     bool search() override;
     void stop() override;
@@ -60,7 +61,7 @@ private:
     DFMSEARCH::SearchEngine *engine = nullptr;
     mutable QMutex mutex;
     DFMSearchResultMap allResults;
-    
+
     // 查询类型选择器，负责根据关键词和搜索类型选择合适的策略
     QueryTypeSelector querySelector;
 


### PR DESCRIPTION
Fixed incorrect parent path judgment logic by using normalized paths for comparison
Improved excluded path filtering to only include subpaths of the search directory
Added matchPath method to normalize paths for consistent comparison Enhanced realtime search exclusion to filter paths that are actual subdirectories

Log: Fixed search path matching and exclusion logic

Influence:
1. Test search functionality in nested directory structures
2. Verify excluded paths are properly filtered during realtime search
3. Check path matching consistency across different search scenarios
4. Test search performance with large directory trees

fix: 修复父子路径判断错误和排除路径过滤问题

修复了父子路径判断逻辑错误，使用标准化路径进行比较
改进排除路径过滤，仅包含搜索目录的子路径
新增matchPath方法用于路径标准化以确保一致比较
增强实时搜索排除功能，过滤实际子目录路径

Log: 修复搜索路径匹配和排除逻辑

Influence:
1. 在嵌套目录结构中测试搜索功能
2. 验证实时搜索时排除路径是否正确过滤
3. 检查不同搜索场景下的路径匹配一致性
4. 测试大型目录树下的搜索性能