### PR TITLE
fix: improve crumb bar layout and button visibility

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
@@ -136,7 +136,7 @@ void CrumbBarPrivate::initUI()
     // Crumb Bar Layout
     crumbBarLayout = new QHBoxLayout(q);
     crumbBarLayout->addStretch(1);
-    crumbBarLayout->setContentsMargins(kItemMargin / 2, 3, kItemMargin * 2, 3);
+    crumbBarLayout->setContentsMargins(kItemMargin / 2, 3, kItemMargin * 10, 3);
     crumbBarLayout->setSpacing(0);
     q->setLayout(crumbBarLayout);
 
@@ -215,6 +215,9 @@ void CrumbBarPrivate::updateButtonVisibility()
             if (titleBar)
                 availableWidth = titleBar->calculateRemainingWidth();
         }
+        // Reserve the right-side clickable area (layout right margin) so users
+        // can always click the blank space on the right to enter address editing mode.
+        availableWidth -= margins.right();
         availableWidth -= kItemMargin * 3;
         if (!stackedDatas.isEmpty()) {
             availableWidth -= navButtons[1]->minimumWidth();
@@ -229,8 +232,11 @@ void CrumbBarPrivate::updateButtonVisibility()
                 stackedDatas.append(data);
             }
         } else if (availableWidth < navButtons.last()->minimumWidth()) {
-            // Compress current directory name
+            // Compress current directory name; set both min and max width so the
+            // layout strictly bounds the button, allowing the paint code to
+            // apply middle-ellipsis when the text no longer fits.
             navButtons.last()->setMinimumWidth(availableWidth);
+            navButtons.last()->setMaximumWidth(availableWidth);
         }
     }
 
@@ -373,6 +379,12 @@ void CrumbBar::resizeEvent(QResizeEvent *event)
 
 void CrumbBar::showEvent(QShowEvent *event)
 {
+    // When transitioning back from address-bar edit mode, the layout has not yet
+    // redistributed the freed space at this point.  Defer the recalculation to
+    // the next event-loop iteration so buttons are sized with up-to-date widths.
+    QTimer::singleShot(0, this, [this]() {
+        d->updateButtonVisibility();
+    });
     return QFrame::showEvent(event);
 }
 
@@ -469,7 +481,12 @@ void CrumbBar::onHideAddrAndUpdateCrumbs(const QUrl &url)
             d->navButtons.append(button);
         }
     }
-    d->updateButtonVisibility();
+    // Defer updateButtonVisibility until Qt has performed a layout pass and all
+    // newly-inserted buttons have correct geometry/minimumWidth values.
+    // (Same pattern as resizeEvent — direct call here would read stale sizes.)
+    QTimer::singleShot(0, this, [this]() {
+        d->updateButtonVisibility();
+    });
 }
 
 void CrumbBar::paintEvent(QPaintEvent *event)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/urlpushbutton.cpp
@@ -32,7 +32,6 @@ static constexpr int kBorderWidth = 4;
 static constexpr int kFolderborderRectRadius { 6 };
 static constexpr int kFolderButtonRectRadius { 4 };
 static constexpr int kFolderButtonMinWidth { 40 };
-static constexpr int kFolderButtonMaxWidth { 200 };
 
 static QString getIconName(const CrumbData &c)
 {
@@ -589,11 +588,6 @@ void UrlPushButton::updateWidth()
         if (minWidth < kFolderButtonMinWidth)
             minWidth = kFolderButtonMinWidth;
         maxWidth = buttonSize;
-        if (maxWidth > kFolderButtonMaxWidth)
-            maxWidth = kFolderButtonMaxWidth;
-        // Ensure minWidth does not exceed maxWidth
-        if (minWidth > maxWidth)
-            minWidth = maxWidth;
     }
     if (oldMinWidth != minWidth) {
         setMinimumWidth(minWidth);


### PR DESCRIPTION
1. Increased right margin from 2x to 10x kItemMargin to reserve
clickable area for address editing
2. Added maximum width constraint for compressed directory buttons to
enable proper ellipsis rendering
3. Deferred layout updates using QTimer::singleShot to ensure correct
geometry calculations
4. Removed hard-coded maximum width limit for folder buttons to allow
proper text display
5. Fixed layout calculation by accounting for right margin when
determining available width

Log: Improved breadcrumb navigation layout and address bar accessibility

Influence:
1. Test breadcrumb navigation in deep directory paths with long names
2. Verify right-click area consistently triggers address editing mode
3. Check directory name compression with ellipsis when space is limited
4. Test navigation button visibility during window resizing
5. Verify smooth transitions between address bar and breadcrumb modes
6. Test folder button text display with various path lengths

fix: 优化面包屑导航栏布局和按钮可见性

1. 将右边距从2倍增加到10倍kItemMargin，为地址编辑保留可点击区域
2. 为压缩的目录按钮添加最大宽度约束，确保正确显示省略号
3. 使用QTimer::singleShot延迟布局更新，确保几何计算准确
4. 移除文件夹按钮的硬编码最大宽度限制，允许正确显示文本
5. 在计算可用宽度时考虑右边距，修复布局计算问题

Log: 改进面包屑导航布局和地址栏可访问性

Influence:
1. 测试深层目录路径中长名称的面包屑导航
2. 验证右侧点击区域始终能触发地址编辑模式
3. 检查空间有限时的目录名称压缩和省略号显示
4. 测试窗口调整大小时的导航按钮可见性
5. 验证地址栏和面包屑模式之间的平滑切换
6. 测试不同路径长度下的文件夹按钮文本显示

BUG: https://pms.uniontech.com/bug-view-351471.html
