### PR TITLE
fix: prevent crash when editor is destroyed during abnormal conditions

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -808,6 +808,8 @@ QWidget *IconItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
     Q_D(const IconItemDelegate);
 
+    ++d->editingSessionId;
+    const quint64 sessionId = d->editingSessionId;
     d->editingIndex = index;
 
     IconItemEditor *editor = new IconItemEditor(parent);
@@ -818,9 +820,10 @@ QWidget *IconItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
     connect(editor, &IconItemEditor::inputFocusOut, this, &IconItemDelegate::editorFinished);
 
-    connect(editor, &IconItemEditor::destroyed, this, [this, d] {
-        QWidget *editor = this->parent()->indexWidget(d->editingIndex);
-        if (!editor || editor == sender()) {
+    connect(editor, &IconItemEditor::destroyed, this, [d, sessionId] {
+        // Only clear state if this is still the current editing session
+        // This handles abnormal cases (view destruction, model reset, etc.) that bypass destroyEditor
+        if (d->editingSessionId == sessionId) {
             d->editingIndex = QModelIndex();
         }
     });

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -123,6 +123,8 @@ QWidget *ListItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     D_DC(ListItemDelegate);
     Q_UNUSED(option);
 
+    ++d->editingSessionId;
+    const quint64 sessionId = d->editingSessionId;
     d->editingIndex = index;
     d->editor = new ListItemEditor(parent);
     auto size = sizeHint(option, index);
@@ -130,9 +132,12 @@ QWidget *ListItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
     connect(static_cast<ListItemEditor *>(d->editor), &ListItemEditor::inputFocusOut, this, &ListItemDelegate::editorFinished);
 
-    connect(d->editor, &QLineEdit::destroyed, this, [=] {
-        d->editingIndex = QModelIndex();
-        d->editor = nullptr;
+    connect(d->editor, &QLineEdit::destroyed, this, [d, sessionId] {
+        // Only clear state if this is still the current editing session
+        if (d->editingSessionId == sessionId) {
+            d->editingIndex = QModelIndex();
+            d->editor = nullptr;
+        }
     });
 
     auto windowId = WorkspaceHelper::instance()->windowId(parent);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/baseitemdelegate_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/baseitemdelegate_p.h
@@ -36,6 +36,7 @@ public:
     QSize itemSizeHint;
     mutable QModelIndex editingIndex;
     mutable QLineEdit *editor = nullptr;
+    mutable quint64 editingSessionId { 0 };
 
     AbstractItemPaintProxy *paintProxy { nullptr };
     QWidget *commitDataCurentWidget { nullptr };


### PR DESCRIPTION
Added session-based tracking for editor state to handle cases where editor destruction occurs outside normal workflow. Previously, the code would crash when accessing parent()->indexWidget() if the view was already destroyed. Now uses a session ID to track the current editing session and only clears state if the destroyed editor belongs to the current session.

This fixes crashes that occurred in Icon view when the editor was destroyed due to view destruction, model reset, or other abnormal conditions that bypass the normal destroyEditor() flow. The session ID approach ensures that stale editor destruction events don't interfere with current editing state.

Log: Fixed crash when renaming files in Icon view during view changes

Influence:
1. Test file renaming in Icon view under normal conditions
2. Test renaming while switching views or closing windows
3. Test renaming during model refresh or file system changes
4. Verify no crashes occur when destroying views with active editors
5. Test consecutive renaming operations to ensure session tracking works correctly

fix: 修复编辑器在异常条件下销毁时导致的崩溃问题

添加基于会话的编辑器状态跟踪机制，用于处理编辑器在正常工作流之外被销毁的
情况。之前当视图已被销毁时，访问parent()->indexWidget()会导致崩溃。现在
使用会话ID跟踪当前编辑会话，仅当被销毁的编辑器属于当前会话时才清除状态。

这修复了在图标视图下，当编辑器因视图销毁、模型重置或其他绕过正常
destroyEditor()流程的异常条件而被销毁时发生的崩溃问题。会话ID方法确保过
时的编辑器销毁事件不会干扰当前编辑状态。

Log: 修复了在图标视图下更改视图时重命名文件导致的崩溃问题

Influence:
1. 测试在正常条件下图标视图中的文件重命名功能
2. 测试在切换视图或关闭窗口时的重命名操作
3. 测试在模型刷新或文件系统更改期间的重命名操作
4. 验证在销毁带有活动编辑器的视图时不会发生崩溃
5. 测试连续重命名操作以确保会话跟踪正常工作

Bug: https://pms.uniontech.com/bug-view-351423.html