### PR TITLE
fix: optimize sidebar group label text display

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -214,8 +214,18 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     qreal min = baseValue - 2 * ejectIconSize.width() - 10;
     qreal max = baseValue - ejectIconSize.width() - 10;
 
-    if (metricsLabel.horizontalAdvance(text) > (isEjectable ? min : max))
-        text = QFontMetrics(option.widget->font()).elidedText(text, Qt::ElideRight, (isEjectable ? int(min) : int(max)));
+    // For separator (group label) items, the expand/collapse button is only visible on hover.
+    // When not hovering, do not reserve button area so the text can use the full available width.
+    qreal textWidthMax;
+    bool isHovering = opt.state.testFlag(QStyle::State_MouseOver) || isDropTarget;
+    if (separatorItem) {
+        textWidthMax = isHovering ? (baseValue - kExpandIconSize - 10) : baseValue;
+    } else {
+        textWidthMax = isEjectable ? min : max;
+    }
+
+    if (metricsLabel.horizontalAdvance(text) > textWidthMax)
+        text = QFontMetrics(option.widget->font()).elidedText(text, Qt::ElideRight, static_cast<int>(textWidthMax));
     int rowHeight = itemRect.height();
     qreal txtDx = (separatorItem ? 21 : 46);
     qreal txtDy = (itemRect.height() - metricsLabel.lineSpacing()) / 2 - 1;
@@ -458,7 +468,7 @@ void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option,
     } else {
         drawDciIcon(optForIcon, painter, dciIcon, iconRect, cg, keepHighlighted);
     }
-    
+
     painter->restore();
 
     // draw ejectable device icon


### PR DESCRIPTION
Fixed text truncation logic for sidebar group labels (separator items)
to properly utilize available width. Previously, group labels were
unnecessarily truncated even when there was sufficient space, especially
when the expand/collapse button was not visible (during non-hover
states). The fix calculates the maximum text width based on whether the
item is a separator and if the mouse is hovering, ensuring text uses
full available width when the expand button is hidden.

Log: Improved sidebar group label text display to prevent unnecessary
truncation

Influence:
1. Verify group labels in sidebar display full text when not hovering
2. Check that text properly truncates with ellipsis when hovering and
button is visible
3. Test hover states on group labels to ensure expand button appears
correctly
4. Verify text alignment and positioning remains consistent
5. Test with long group names to ensure proper elision behavior

fix: 优化侧边栏分组标签文本显示

修复了侧边栏分组标签（分隔符项目）的文本截断逻辑，以正确利用可用宽度。之
前，分组标签即使在有足够空间时也会被不必要地截断，特别是在展开/折叠按钮
不可见时（非悬停状态）。此修复根据项目是否为分隔符以及鼠标是否悬停来计算
最大文本宽度，确保在展开按钮隐藏时文本使用完整的可用宽度。

Log: 改进侧边栏分组标签文本显示，避免不必要的截断

Influence:
1. 验证侧边栏中的分组标签在非悬停状态下显示完整文本
2. 检查文本在悬停且按钮可见时是否正确截断并显示省略号
3. 测试分组标签的悬停状态，确保展开按钮正确显示
4. 验证文本对齐和位置保持一致性
5. 使用长分组名称测试，确保正确的文本省略行为

BUG: https://pms.uniontech.com/bug-view-351367.html
