### PR TITLE
fix: add index validation before updating sidebar view

### DIFF
--- a/src/plugins/filedialog/core/dbus/filedialoghandle.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandle.cpp
@@ -49,6 +49,8 @@ FileDialogHandle::FileDialogHandle(QWidget *parent)
         abort();
     }
     auto defaultUrl = d_func()->dialog->lastVisitedUrl();
+    if (defaultUrl.isValid() && defaultUrl.scheme().isEmpty())
+        defaultUrl = QUrl::fromLocalFile(defaultUrl.path());
     if (!defaultUrl.isValid())
         defaultUrl = QUrl::fromLocalFile(DFMBASE_NAMESPACE::StandardPaths::location(StandardPaths::kHomePath));
     d_func()->dialog->cd(defaultUrl);
@@ -353,10 +355,10 @@ void FileDialogHandle::setFileMode(QFileDialog::FileMode mode)
 void FileDialogHandle::setAcceptMode(QFileDialog::AcceptMode mode)
 {
     D_D(FileDialogHandle);
-    
+
     if (!d->dialog)
         return;
-    
+
     isSetAcceptMode = true;
     CoreHelper::delayInvokeProxy(
             [dialog = d->dialog, mode]() {

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -297,9 +297,14 @@ void SideBarWidget::onItemActived(const QModelIndex &index)
         fmDebug() << "Reverted to previous item after separate process launch";
         return;
     }
+
     SideBarManager::instance()->runCd(item, SideBarHelper::windowId(this));
-    sidebarView->update(sidebarView->previousIndex());
-    sidebarView->update(sidebarView->currentIndex());
+    auto preIndex = sidebarView->previousIndex();
+    auto curIndex = sidebarView->currentIndex();
+    if (preIndex.isValid())
+        sidebarView->update(preIndex);
+    if (curIndex.isValid())
+        sidebarView->update(curIndex);
 
     fmInfo() << "Item activation completed, URL:" << url;
 }


### PR DESCRIPTION
Added validation checks for previous and current indexes before calling update on the sidebar view. Previously, the code would call update() directly on the indexes without checking if they are valid, which could cause issues if the indexes were invalid.

The fix ensures that update() is only called when the indexes are valid, preventing potential crashes or unexpected behavior when dealing with invalid model indexes. This improves the robustness of the sidebar widget when handling item activation events.

Influence:
1. Test clicking on various sidebar items to ensure proper activation
2. Verify that sidebar view updates correctly after item selection
3. Test edge cases where indexes might be invalid
4. Ensure no crashes occur during sidebar navigation

fix: 添加索引验证后再更新侧边栏视图

在调用侧边栏视图更新之前添加了对前后索引的验证检查。之前代码会直接对索引
调用update()而不检查其是否有效，这可能在索引无效时导致问题。

修复确保仅在索引有效时调用update()，防止在处理无效模型索引时出现潜在崩溃
或意外行为。这提高了侧边栏小部件处理项目激活事件时的鲁棒性。

Influence:
1. 测试点击各种侧边栏项目以确保正确激活
2. 验证项目选择后侧边栏视图是否正确更新
3. 测试索引可能无效的边缘情况
4. 确保侧边栏导航过程中不会出现崩溃