### PR TITLE
fix: fix offline SMB host display logic in aggregated mode

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
@@ -282,15 +282,36 @@ void ui_ventry_calls::addAggregatedItems()
     QStringList smbs = getMountedSmb();
     // 1.1 convert to std smb
     smbs = getStandardSmbPaths(smbs);
-    // 2. get all offlined smb
-    smbs.append(VirtualEntryDbHandler::instance()->allSmbIDs());
+
+    // 2. get all offlined smb from DB, but only when show-offline is enabled.
+    //    When showOffline is false, only mounted (online) shares should be aggregated;
+    //    stale DB entries must NOT be surfaced – this mirrors the aggregated-mode branch
+    //    of onShowOfflineChanged() which removes pure-virtual (no mounted share) host
+    //    entries and calls clearData() when the feature is turned off at runtime.
+    if (ProtocolDeviceDisplayManager::instance()->isShowOfflineItem()) {
+        const QStringList &allMountedStdSmb = smbs;
+        QStringList allAggregated;
+        VirtualEntryDbHandler::instance()->allSmbIDs(&allAggregated, nullptr);
+
+        // only append offline host entries that have NO currently-mounted share,
+        // i.e. pure offline hosts – same criterion as the "find orphan host" block
+        // in onShowOfflineChanged().
+        auto hasMountedShareOf = [&allMountedStdSmb](const QString &host) {
+            return std::any_of(allMountedStdSmb.cbegin(), allMountedStdSmb.cend(),
+                               [&](const QString &mounted) { return mounted.startsWith(host); });
+        };
+        std::for_each(allAggregated.cbegin(), allAggregated.cend(), [&](const QString &host) {
+            if (!hasMountedShareOf(host))
+                smbs.append(host);
+        });
+    }
 
     // 3. deduplicated, only keep smb root.
     QSet<QString> hostPaths;
     for (const auto &id : smbs)
         hostPaths.insert(getSmbHostPath(id));
 
-    // 3. add aggregated item
+    // 4. add aggregated item
     std::for_each(hostPaths.cbegin(), hostPaths.cend(), [=](const QString &host) {
         const QUrl &vEntryUrl = makeVEntryUrl(host);
         callItemAdd(vEntryUrl);


### PR DESCRIPTION
The change modifies the addAggregatedItems() function to properly handle
the display of offline SMB hosts when the "show offline items" feature
is disabled. Previously, offline SMB hosts from the database were always
being aggregated regardless of the show-offline setting, which caused
inconsistent behavior with the runtime toggle functionality.

Key changes:
1. Added conditional check for
ProtocolDeviceDisplayManager::instance()->isShowOfflineItem() before
processing offline SMB entries
2. When show-offline is disabled, only mounted (online) SMB shares are
aggregated
3. Implemented logic to filter out pure offline hosts (those without any
mounted shares) when the feature is disabled
4. This ensures consistency with the aggregated-mode branch of
onShowOfflineChanged() which removes pure-virtual host entries

The fix addresses the issue where stale database entries were being
displayed even when the show-offline feature was turned off, providing
proper synchronization between the display setting and the actual
aggregated items.

Log: Fixed offline SMB host display to respect show-offline setting in
aggregated mode

Influence:
1. Test toggling show-offline setting in SMB browser settings
2. Verify that when show-offline is disabled, only mounted SMB shares
appear in aggregated view
3. Confirm that pure offline hosts (with no mounted shares) disappear
when feature is disabled
4. Test that offline hosts reappear when show-offline is re-enabled
5. Verify consistency between aggregated view and individual host
entries

fix: 修复聚合模式下离线 SMB 主机显示逻辑

本次修改改进了 addAggregatedItems() 函数，使其在"显示离线项目"功能禁用时
能正确处理离线 SMB 主机的显示。之前无论显示离线设置如何，数据库中的离线
SMB 主机都会被聚合，这与运行时切换功能的行为不一致。

主要变更：
1. 在处理离线 SMB 条目前添加了对
ProtocolDeviceDisplayManager::instance()->isShowOfflineItem() 的条件检查
2. 当显示离线功能禁用时，仅聚合已挂载（在线）的 SMB 共享
3. 实现了在功能禁用时过滤纯离线主机（没有任何挂载共享的主机）的逻辑
4. 这确保了与 onShowOfflineChanged() 中聚合模式分支的一致性，该分支会移
除纯虚拟主机条目

此修复解决了即使显示离线功能关闭时仍显示陈旧数据库条目的问题，提供了显示
设置与实际聚合项目之间的正确同步。

Log: 修复离线 SMB 主机显示以在聚合模式下遵循显示离线设置

Influence:
1. 测试 SMB 浏览器设置中显示离线设置的切换
2. 验证当显示离线禁用时，聚合视图中仅显示已挂载的 SMB 共享
3. 确认纯离线主机（无挂载共享的主机）在功能禁用时消失
4. 测试当重新启用显示离线时离线主机重新出现
5. 验证聚合视图与单个主机条目之间的一致性

BUG: https://pms.uniontech.com/bug-view-351485.html
