### PR TITLE
fix: fix file scanner signal loss in non-main threads

### DIFF
--- a/src/dfm-base/utils/filescanner.cpp
+++ b/src/dfm-base/utils/filescanner.cpp
@@ -82,8 +82,22 @@ void FileScannerPrivate::startWorker(const QList<QUrl> &urls)
     worker->setOptions(options);
 
     // 连接信号
-    connect(worker, &ScannerWorker::resultReady, this, &FileScannerPrivate::onWorkerResultReady);
-    connect(worker, &ScannerWorker::finished, this, &FileScannerPrivate::onWorkerFinished);
+    // 关键：判断接收者(this)归属线程是否具备事件循环能力
+    QThread *receiverThread = this->thread();
+    bool hasEventLoop = (receiverThread == qApp->thread());
+
+    // 根据是否有事件循环选择连接类型
+    Qt::ConnectionType connectionType = hasEventLoop
+            ? Qt::AutoConnection   // 有事件循环：使用默认行为（队列连接）
+            : Qt::DirectConnection;   // 无事件循环：使用直接连接
+
+    qCDebug(logDFMBase) << "FileScanner: Receiver thread" << receiverThread
+                        << "has event loop:" << hasEventLoop
+                        << "using connection type:"
+                        << (connectionType == Qt::DirectConnection ? "Direct" : "Auto");
+
+    connect(worker, &ScannerWorker::resultReady, this, &FileScannerPrivate::onWorkerResultReady, connectionType);
+    connect(worker, &ScannerWorker::finished, this, &FileScannerPrivate::onWorkerFinished, connectionType);
 
     // 启动工作线程
     if (!workerThread.isRunning()) {

--- a/src/dfm-base/utils/filescanner.cpp
+++ b/src/dfm-base/utils/filescanner.cpp
@@ -23,6 +23,73 @@ DFMBASE_USE_NAMESPACE
 namespace dfmbase {
 
 //===================================================================
+// FileScannerCore - 核心扫描逻辑（纯算法，无 QObject 依赖）
+//===================================================================
+class FileScannerCore
+{
+public:
+    // 进度回调函数类型：返回 true 继续扫描，返回 false 停止扫描
+    using ProgressCallback = std::function<bool(const FileScanner::ScanResult &)>;
+
+    // 目录条目结构
+    struct DirEntry
+    {
+        QByteArray name;
+        unsigned char d_type;
+        struct stat statBuf;
+        bool statOk { false };
+    };
+
+    // 扫描上下文结构
+    struct ScanContext
+    {
+        QString fullPath;
+        int depth { 0 };
+        bool isSourcePath { false };
+    };
+
+    // 核心扫描方法
+    static FileScanner::ScanResult scanImpl(
+            const QList<QUrl> &urls,
+            FileScanner::ScanOptions options,
+            ProgressCallback progressCallback = nullptr);
+
+private:
+    // 扫描状态（在扫描过程中维护）
+    struct ScanState
+    {
+        FileScanner::ScanResult result;
+        FileScanner::ScanOptions options;
+        ProgressCallback progressCallback;
+
+        // 进度节流
+        QElapsedTimer progressTimer;
+        qint64 lastEmittedSize { 0 };
+        qint64 memoryPageSize { 4096 };
+
+        // inode 去重
+        QHash<quint64, QSet<quint64>> processedInodes;
+
+        // 停止标志（用于回调返回 false 时停止）
+        bool shouldStop { false };
+    };
+
+    // 核心扫描逻辑
+    static void scanLocalPathsImpl(ScanState &state, const QList<QUrl> &urls);
+    static void scanOtherProtocolsImpl(ScanState &state, const QList<QUrl> &urls);
+
+    // 辅助方法
+    static bool readDirectoryEntries(const QString &path, QList<DirEntry> *entries);
+    static void processRegularFile(ScanState &state, const QString &path, const struct stat &statBuf);
+    static void processSymlink(ScanState &state, const QString &path);
+    static bool isDirectoryPath(const QString &path, const struct stat &lstatBuf);
+    static void collectFileIfEnabled(ScanState &state, const QUrl &url, bool isSourcePath);
+    static void emitProgress(ScanState &state, bool force = false);
+    static bool isInodeProcessed(const ScanState &state, quint64 device, quint64 inode);
+    static void markInodeProcessed(ScanState &state, quint64 device, quint64 inode);
+};
+
+//===================================================================
 // FileScannerPrivate - 私有实现
 //===================================================================
 class FileScannerPrivate : public QObject
@@ -82,22 +149,8 @@ void FileScannerPrivate::startWorker(const QList<QUrl> &urls)
     worker->setOptions(options);
 
     // 连接信号
-    // 关键：判断接收者(this)归属线程是否具备事件循环能力
-    QThread *receiverThread = this->thread();
-    bool hasEventLoop = (receiverThread == qApp->thread());
-
-    // 根据是否有事件循环选择连接类型
-    Qt::ConnectionType connectionType = hasEventLoop
-            ? Qt::AutoConnection   // 有事件循环：使用默认行为（队列连接）
-            : Qt::DirectConnection;   // 无事件循环：使用直接连接
-
-    qCDebug(logDFMBase) << "FileScanner: Receiver thread" << receiverThread
-                        << "has event loop:" << hasEventLoop
-                        << "using connection type:"
-                        << (connectionType == Qt::DirectConnection ? "Direct" : "Auto");
-
-    connect(worker, &ScannerWorker::resultReady, this, &FileScannerPrivate::onWorkerResultReady, connectionType);
-    connect(worker, &ScannerWorker::finished, this, &FileScannerPrivate::onWorkerFinished, connectionType);
+    connect(worker, &ScannerWorker::resultReady, this, &FileScannerPrivate::onWorkerResultReady);
+    connect(worker, &ScannerWorker::finished, this, &FileScannerPrivate::onWorkerFinished);
 
     // 启动工作线程
     if (!workerThread.isRunning()) {
@@ -115,7 +168,9 @@ void FileScannerPrivate::stopWorker()
 
 void FileScannerPrivate::onWorkerResultReady(const FileScanner::ScanResult &result, bool isFinal)
 {
+    Q_UNUSED(isFinal)
     lastResult = result;
+
     emit q->progressChanged(result);
 }
 
@@ -197,64 +252,74 @@ void FileScanner::stop()
     d->stopWorker();
 }
 
+FileScanner::ScanResult FileScanner::scanSync(const QList<QUrl> &urls, ScanOptions options)
+{
+    if (urls.isEmpty()) {
+        qCWarning(logDFMBase) << "FileScanner::scanSync: Empty URL list";
+        return ScanResult();
+    }
+
+    qCDebug(logDFMBase) << "FileScanner::scanSync: Starting sync scan for" << urls.count() << "URLs";
+
+    // 直接调用核心逻辑（无进度回调）
+    ScanResult result = FileScannerCore::scanImpl(urls, options, nullptr);
+
+    qCDebug(logDFMBase) << "FileScanner::scanSync: Completed - files:" << result.fileCount
+                        << "dirs:" << result.directoryCount << "size:" << result.totalSize;
+
+    return result;
+}
+
+FileScanner::ScanResult FileScanner::scanSyncWithCallback(const QList<QUrl> &urls,
+                                                          ScanOptions options,
+                                                          ProgressCallback progressCallback)
+{
+    if (urls.isEmpty()) {
+        qCWarning(logDFMBase) << "FileScanner::scanSyncWithCallback: Empty URL list";
+        return ScanResult();
+    }
+
+    qCDebug(logDFMBase) << "FileScanner::scanSyncWithCallback: Starting interruptible sync scan for" << urls.count() << "URLs";
+
+    // 调用核心逻辑（带进度回调，支持中断）
+    ScanResult result = FileScannerCore::scanImpl(urls, options, progressCallback);
+
+    qCDebug(logDFMBase) << "FileScanner::scanSyncWithCallback: Completed - files:" << result.fileCount
+                        << "dirs:" << result.directoryCount << "size:" << result.totalSize;
+
+    return result;
+}
+
 //===================================================================
-// ScannerWorker - 工作对象
+// FileScannerCore - 核心扫描逻辑实现
 //===================================================================
-ScannerWorker::ScannerWorker(QObject *parent)
-    : QObject(parent)
+FileScanner::ScanResult FileScannerCore::scanImpl(
+        const QList<QUrl> &urls,
+        FileScanner::ScanOptions options,
+        ProgressCallback progressCallback)
 {
-    memoryPageSize = FileUtils::getMemoryPageSize();
-}
-
-ScannerWorker::~ScannerWorker()
-{
-}
-
-void ScannerWorker::setUrls(const QList<QUrl> &urls)
-{
-    this->urls = urls;
-}
-
-void ScannerWorker::setOptions(FileScanner::ScanOptions options)
-{
-    this->options = options;
-}
-
-void ScannerWorker::start()
-{
-    qCDebug(logDFMBase) << "ScannerWorker: Starting work";
-
-    // 重置状态
-    stopped = false;
-    currentResult.clear();
-    processedInodes.clear();
-    progressTimer.start();
-    lastEmittedSize = 0;
+    ScanState state;
+    state.options = options;
+    state.progressCallback = progressCallback;
+    state.memoryPageSize = FileUtils::getMemoryPageSize();
+    state.progressTimer.start();
 
     // 判断是否为本地文件路径
     if (!urls.isEmpty() && urls.first().scheme() == Global::Scheme::kFile) {
-        scanLocalPaths();
+        scanLocalPathsImpl(state, urls);
     } else {
-        scanOtherProtocols();
+        scanOtherProtocolsImpl(state, urls);
     }
 
-    // 发送最终结果
-    emitProgress(true);
-    emit finished();
+    return state.result;
 }
 
-void ScannerWorker::stop()
+void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &urls)
 {
-    qCDebug(logDFMBase) << "ScannerWorker: Stop requested";
-    stopped = true;
-}
-
-void ScannerWorker::scanLocalPaths()
-{
-    qCDebug(logDFMBase) << "ScannerWorker: Scanning local paths using opendir/readdir";
+    qCDebug(logDFMBase) << "FileScannerCore: Scanning local paths using opendir/readdir";
 
     // ========== 初始化阶段 ==========
-    int processedSourceDirs = 0;   // 实际成功处理的源目录数
+    int processedSourceDirs = 0;
     QStack<ScanContext> dirStack;
 
     // 准备源路径
@@ -271,32 +336,32 @@ void ScannerWorker::scanLocalPaths()
                 ctx.isSourcePath = true;
                 dirStack.push(ctx);
                 // 收集源目录URL（如果启用 CollectFiles 选项）
-                collectFileIfEnabled(url, true);
+                collectFileIfEnabled(state, url, true);
             } else {
                 // 非目录：直接收集（普通文件、符号链接等）
                 if (S_ISREG(statBuf.st_mode)) {
-                    processRegularFile(path, statBuf);
+                    processRegularFile(state, path, statBuf);
                 } else if (S_ISLNK(statBuf.st_mode)) {
-                    processSymlink(path);
+                    processSymlink(state, path);
                 } else {
-                    currentResult.fileCount++;
+                    state.result.fileCount++;
                 }
                 // 收集源文件URL
-                collectFileIfEnabled(url, true);
+                collectFileIfEnabled(state, url, true);
             }
         } else {
-            qCWarning(logDFMBase) << "ScannerWorker: lstat failed for source:" << path;
+            qCWarning(logDFMBase) << "FileScannerCore: lstat failed for source:" << path;
         }
     }
 
     // ========== 遍历阶段 ==========
-    while (!dirStack.isEmpty() && !shouldStop()) {
+    while (!dirStack.isEmpty() && !state.shouldStop) {
         ScanContext ctx = dirStack.pop();
         const QString &dirPath = ctx.fullPath;
 
         // 先计数目录本身（无论是否能读取内容）
-        currentResult.directoryCount++;
-        currentResult.progressSize += memoryPageSize;
+        state.result.directoryCount++;
+        state.result.progressSize += state.memoryPageSize;
 
         // 记录成功处理的源目录（用于最终扣除）
         if (ctx.isSourcePath) {
@@ -309,13 +374,13 @@ void ScannerWorker::scanLocalPaths()
 
         if (!readSuccess) {
             // 目录读取失败（权限不足），但目录已计数
-            qCWarning(logDFMBase) << "ScannerWorker: Failed to read directory contents:" << dirPath;
-            continue;   // 无法读取内容，跳过条目处理
+            qCWarning(logDFMBase) << "FileScannerCore: Failed to read directory contents:" << dirPath;
+            continue;
         }
 
         // 处理每个条目
         for (const DirEntry &entry : entries) {
-            if (shouldStop()) {
+            if (state.shouldStop) {
                 break;
             }
 
@@ -329,25 +394,25 @@ void ScannerWorker::scanLocalPaths()
                     "/dev/core"
                 };
                 if (kSpecialSystemFiles.contains(entryPath)) {
-                    qCDebug(logDFMBase) << "ScannerWorker: Skipping special file:" << entryPath;
+                    qCDebug(logDFMBase) << "FileScannerCore: Skipping special file:" << entryPath;
                     continue;
                 }
             }
 
-            // lstat 失败处理：部分条目可能无法访问，但继续处理其他条目
+            // lstat 失败处理
             if (!entry.statOk) {
-                qCDebug(logDFMBase) << "ScannerWorker: lstat failed for:" << entryPath;
+                qCDebug(logDFMBase) << "FileScannerCore: lstat failed for:" << entryPath;
                 continue;
             }
 
             // 根据类型处理条目
             if (S_ISDIR(entry.statBuf.st_mode)) {
                 // 子目录
-                bool isSingleDepth = options & FileScanner::ScanOption::SingleDepth;
+                bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
                 if (isSingleDepth) {
                     // SingleDepth 模式：计数但不递归
-                    currentResult.directoryCount++;
-                    currentResult.progressSize += memoryPageSize;
+                    state.result.directoryCount++;
+                    state.result.progressSize += state.memoryPageSize;
                 } else {
                     // 递归模式：压栈
                     ScanContext childCtx;
@@ -358,42 +423,40 @@ void ScannerWorker::scanLocalPaths()
                 }
             } else if (S_ISREG(entry.statBuf.st_mode)) {
                 // 常规文件
-                processRegularFile(entryPath, entry.statBuf);
+                processRegularFile(state, entryPath, entry.statBuf);
             } else if (S_ISLNK(entry.statBuf.st_mode)) {
                 // 符号链接
-                processSymlink(entryPath);
+                processSymlink(state, entryPath);
             } else {
-                // 其他特殊文件类型（socket、FIFO、字符设备、块设备等）
-                // 只计数，不计大小
-                currentResult.fileCount++;
+                // 其他特殊文件类型
+                state.result.fileCount++;
             }
 
-            // 收集文件URL（统一处理，支持所有文件类型）
-            collectFileIfEnabled(entryUrl, false);
+            // 收集文件URL
+            collectFileIfEnabled(state, entryUrl, false);
 
             // 定期发送进度
-            emitProgress();
+            emitProgress(state);
         }
     }
 
     // ========== 最终处理 ==========
-    // 默认排除源目录本身（只扣除成功处理的源目录）
-    if (!(options & FileScanner::ScanOption::IncludeSource)) {
-        currentResult.directoryCount -= processedSourceDirs;
+    // 默认排除源目录本身
+    if (!(state.options & FileScanner::ScanOption::IncludeSource)) {
+        state.result.directoryCount -= processedSourceDirs;
     }
 
-    qCDebug(logDFMBase) << "ScannerWorker: Local scan completed - files:" << currentResult.fileCount
-                        << "dirs:" << currentResult.directoryCount
-                        << "size:" << currentResult.totalSize;
+    qCDebug(logDFMBase) << "FileScannerCore: Local scan completed - files:" << state.result.fileCount
+                        << "dirs:" << state.result.directoryCount << "size:" << state.result.totalSize;
 }
 
-void ScannerWorker::scanOtherProtocols()
+void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl> &urls)
 {
-    qCDebug(logDFMBase) << "ScannerWorker: Scanning other protocols using InfoFactory";
+    qCDebug(logDFMBase) << "FileScannerCore: Scanning other protocols using InfoFactory";
 
     QQueue<QUrl> directoryQueue;
     QSet<QUrl> processedUrls;
-    int sourceDirCount = 0;   // 记录源目录数量
+    int sourceDirCount = 0;
 
     // 初始化队列
     for (const QUrl &url : urls) {
@@ -401,7 +464,7 @@ void ScannerWorker::scanOtherProtocols()
         processedUrls.insert(url);
     }
 
-    while (!directoryQueue.isEmpty() && !shouldStop()) {
+    while (!directoryQueue.isEmpty() && !state.shouldStop) {
         QUrl url = directoryQueue.dequeue();
 
         // 判断是否为源路径
@@ -413,7 +476,7 @@ void ScannerWorker::scanOtherProtocols()
                 Global::CreateFileInfoType::kCreateFileInfoSync);
 
         if (!info) {
-            qCWarning(logDFMBase) << "ScannerWorker: Failed to create info for:" << url;
+            qCWarning(logDFMBase) << "FileScannerCore: Failed to create info for:" << url;
             continue;
         }
 
@@ -424,11 +487,11 @@ void ScannerWorker::scanOtherProtocols()
                 sourceDirCount++;
             }
 
-            currentResult.directoryCount++;
-            currentResult.progressSize += memoryPageSize;
+            state.result.directoryCount++;
+            state.result.progressSize += state.memoryPageSize;
 
-            // 收集目录URL（如果启用 CollectFiles 选项）
-            collectFileIfEnabled(url, isSourcePath);
+            // 收集目录URL
+            collectFileIfEnabled(state, url, isSourcePath);
 
             // 创建目录迭代器
             AbstractDirIteratorPointer iterator = DirIteratorFactory::create<AbstractDirIterator>(
@@ -437,14 +500,14 @@ void ScannerWorker::scanOtherProtocols()
                     QDir::AllEntries | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot);
 
             if (!iterator) {
-                qCWarning(logDFMBase) << "ScannerWorker: Failed to create iterator for:" << url;
+                qCWarning(logDFMBase) << "FileScannerCore: Failed to create iterator for:" << url;
                 continue;
             }
 
-            bool isSingleDepth = options & FileScanner::ScanOption::SingleDepth;
+            bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
 
             // 遍历目录
-            while (iterator->hasNext() && !shouldStop()) {
+            while (iterator->hasNext() && !state.shouldStop) {
                 QUrl childUrl = iterator->next();
 
                 if (!processedUrls.contains(childUrl)) {
@@ -459,84 +522,50 @@ void ScannerWorker::scanOtherProtocols()
                         if (childInfo->isAttributes(OptInfoType::kIsDir)) {
                             if (isSingleDepth) {
                                 // SingleDepth 模式：计数但不递归
-                                currentResult.directoryCount++;
-                                currentResult.progressSize += memoryPageSize;
+                                state.result.directoryCount++;
+                                state.result.progressSize += state.memoryPageSize;
                             } else {
                                 // 递归模式：入队
                                 directoryQueue.enqueue(childUrl);
                             }
-                            // 收集子目录URL（始终是 false，因为不是源路径）
-                            collectFileIfEnabled(childUrl, false);
+                            // 收集子目录URL
+                            collectFileIfEnabled(state, childUrl, false);
                         } else {
                             // 处理文件
-                            currentResult.totalSize += childInfo->size();
-                            currentResult.fileCount++;
-                            currentResult.progressSize += childInfo->size();
+                            state.result.totalSize += childInfo->size();
+                            state.result.fileCount++;
+                            state.result.progressSize += childInfo->size();
 
-                            // 收集子文件URL（始终是 false）
-                            collectFileIfEnabled(childUrl, false);
+                            // 收集子文件URL
+                            collectFileIfEnabled(state, childUrl, false);
                         }
                     }
                 }
             }
         } else {
             // 处理文件
-            currentResult.totalSize += info->size();
-            currentResult.fileCount++;
-            currentResult.progressSize += info->size();
+            state.result.totalSize += info->size();
+            state.result.fileCount++;
+            state.result.progressSize += info->size();
 
-            // 收集文件URL（始终是 false）
-            collectFileIfEnabled(url, false);
+            // 收集文件URL
+            collectFileIfEnabled(state, url, false);
         }
 
         // 定期发送进度
-        emitProgress();
+        emitProgress(state);
     }
 
-    // 默认排除源目录本身（除非设置了 IncludeSource 选项）
-    if (!(options & FileScanner::ScanOption::IncludeSource)) {
-        currentResult.directoryCount -= sourceDirCount;
+    // 默认排除源目录本身
+    if (!(state.options & FileScanner::ScanOption::IncludeSource)) {
+        state.result.directoryCount -= sourceDirCount;
     }
 
-    qCDebug(logDFMBase) << "ScannerWorker: Other protocol scan completed - files:" << currentResult.fileCount
-                        << "dirs:" << currentResult.directoryCount
-                        << "size:" << currentResult.totalSize;
+    qCDebug(logDFMBase) << "FileScannerCore: Other protocol scan completed - files:" << state.result.fileCount
+                        << "dirs:" << state.result.directoryCount << "size:" << state.result.totalSize;
 }
 
-bool ScannerWorker::shouldStop() const
-{
-    return stopped.load();
-}
-
-bool ScannerWorker::isInodeProcessed(quint64 device, quint64 inode)
-{
-    return processedInodes.value(device).contains(inode);
-}
-
-void ScannerWorker::markInodeProcessed(quint64 device, quint64 inode)
-{
-    if (!processedInodes.contains(device)) {
-        processedInodes.insert(device, QSet<quint64>());
-    }
-    processedInodes[device].insert(inode);
-}
-
-void ScannerWorker::emitProgress(bool force)
-{
-    qint64 currentSize = currentResult.totalSize;
-
-    // 节流条件：
-    // 1. 距离上次发送超过500ms
-    // 2. 或者大小变化超过10MB
-    // 3. 或者强制发送（完成时）
-    if (force || progressTimer.elapsed() > 500 || qAbs(currentSize - lastEmittedSize) > 10 * 1024 * 1024) {
-        emit resultReady(currentResult, force);
-        lastEmittedSize = currentSize;
-        progressTimer.restart();
-    }
-}
-
-bool ScannerWorker::readDirectoryEntries(const QString &path, QList<DirEntry> *entries)
+bool FileScannerCore::readDirectoryEntries(const QString &path, QList<DirEntry> *entries)
 {
     Q_ASSERT(entries);
     entries->clear();
@@ -544,7 +573,7 @@ bool ScannerWorker::readDirectoryEntries(const QString &path, QList<DirEntry> *e
     QByteArray pathUtf8 = path.toUtf8();
     DIR *dir = opendir(pathUtf8.constData());
     if (!dir) {
-        qCWarning(logDFMBase) << "ScannerWorker: opendir failed for" << path << ":" << strerror(errno);
+        qCWarning(logDFMBase) << "FileScannerCore: opendir failed for" << path << ":" << strerror(errno);
         return false;
     }
 
@@ -569,61 +598,147 @@ bool ScannerWorker::readDirectoryEntries(const QString &path, QList<DirEntry> *e
     return true;
 }
 
-void ScannerWorker::processRegularFile(const QString &path, const struct stat &statBuf)
+void FileScannerCore::processRegularFile(ScanState &state, const QString &path, const struct stat &statBuf)
 {
     // 硬链接去重
     if (statBuf.st_nlink > 1) {
-        if (!isInodeProcessed(statBuf.st_dev, statBuf.st_ino)) {
-            markInodeProcessed(statBuf.st_dev, statBuf.st_ino);
-            currentResult.totalSize += statBuf.st_size;
-            currentResult.fileCount++;
+        if (!isInodeProcessed(state, statBuf.st_dev, statBuf.st_ino)) {
+            markInodeProcessed(state, statBuf.st_dev, statBuf.st_ino);
+            state.result.totalSize += statBuf.st_size;
+            state.result.fileCount++;
         } else {
             // 硬链接已统计，只计数
-            currentResult.fileCount++;
+            state.result.fileCount++;
         }
     } else {
         // st_nlink == 1，直接处理
-        currentResult.totalSize += statBuf.st_size;
-        currentResult.fileCount++;
+        state.result.totalSize += statBuf.st_size;
+        state.result.fileCount++;
     }
-    currentResult.progressSize += statBuf.st_size;
+    state.result.progressSize += statBuf.st_size;
 }
 
-void ScannerWorker::processSymlink(const QString &path)
+void FileScannerCore::processSymlink(ScanState &state, const QString &path)
 {
     // 符号链接只计数，不跟随（不计入大小）
-    currentResult.fileCount++;
-    currentResult.progressSize += memoryPageSize;   // 估算符号链接大小
+    state.result.fileCount++;
+    state.result.progressSize += state.memoryPageSize;
 }
 
-bool ScannerWorker::isDirectoryPath(const QString &path, const struct stat &lstatBuf)
+bool FileScannerCore::isDirectoryPath(const QString &path, const struct stat &lstatBuf)
 {
     if (S_ISDIR(lstatBuf.st_mode)) {
-        return true;   // 直接是目录
+        return true;
     }
     if (S_ISLNK(lstatBuf.st_mode)) {
         struct stat statBuf;
         if (stat(path.toUtf8().constData(), &statBuf) == 0) {
-            return S_ISDIR(statBuf.st_mode);   // 符号链接指向目录
+            return S_ISDIR(statBuf.st_mode);
         }
     }
     return false;
 }
 
-void ScannerWorker::collectFileIfEnabled(const QUrl &url, bool isSourcePath)
+void FileScannerCore::collectFileIfEnabled(ScanState &state, const QUrl &url, bool isSourcePath)
 {
     // 只有启用 CollectFiles 选项才收集
-    if (!(options & FileScanner::ScanOption::CollectFiles)) {
+    if (!(state.options & FileScanner::ScanOption::CollectFiles)) {
         return;
     }
 
     // 如果是源路径且未设置 IncludeSource 选项，则不收集
-    // IncludeSource 语义：true=包含源路径，false=排除源路径
-    if (isSourcePath && !(options & FileScanner::ScanOption::IncludeSource)) {
+    if (isSourcePath && !(state.options & FileScanner::ScanOption::IncludeSource)) {
         return;
     }
 
-    currentResult.allFiles.append(url);
+    state.result.allFiles.append(url);
+}
+
+void FileScannerCore::emitProgress(ScanState &state, bool force)
+{
+    qint64 currentSize = state.result.totalSize;
+
+    // 节流条件
+    if (force || state.progressTimer.elapsed() > 500 || qAbs(currentSize - state.lastEmittedSize) > 10 * 1024 * 1024) {
+        if (state.progressCallback) {
+            bool shouldContinue = state.progressCallback(state.result);
+            if (!shouldContinue) {
+                state.shouldStop = true;
+            }
+        }
+        state.lastEmittedSize = currentSize;
+        state.progressTimer.restart();
+    }
+}
+
+bool FileScannerCore::isInodeProcessed(const ScanState &state, quint64 device, quint64 inode)
+{
+    return state.processedInodes.value(device).contains(inode);
+}
+
+void FileScannerCore::markInodeProcessed(ScanState &state, quint64 device, quint64 inode)
+{
+    if (!state.processedInodes.contains(device)) {
+        state.processedInodes.insert(device, QSet<quint64>());
+    }
+    state.processedInodes[device].insert(inode);
+}
+
+//===================================================================
+// ScannerWorker - 工作对象
+//===================================================================
+ScannerWorker::ScannerWorker(QObject *parent)
+    : QObject(parent)
+{
+}
+
+ScannerWorker::~ScannerWorker()
+{
+}
+
+void ScannerWorker::setUrls(const QList<QUrl> &urls)
+{
+    this->urls = urls;
+}
+
+void ScannerWorker::setOptions(FileScanner::ScanOptions options)
+{
+    this->options = options;
+}
+
+void ScannerWorker::start()
+{
+    qCDebug(logDFMBase) << "ScannerWorker: Starting work";
+
+    // 重置状态
+    stopped = false;
+
+    // 使用核心逻辑，通过回调发送进度
+    auto progressCallback = [this](const FileScanner::ScanResult &result) -> bool {
+        if (shouldStop()) {
+            return false;   // 返回 false 表示停止扫描
+        }
+        emit resultReady(result, false);
+        return true;   // 继续扫描
+    };
+
+    // 调用核心扫描逻辑
+    FileScanner::ScanResult finalResult = FileScannerCore::scanImpl(urls, options, progressCallback);
+
+    // 发送最终结果
+    emit resultReady(finalResult, true);
+    emit finished();
+}
+
+void ScannerWorker::stop()
+{
+    qCDebug(logDFMBase) << "ScannerWorker: Stop requested";
+    stopped = true;
+}
+
+bool ScannerWorker::shouldStop() const
+{
+    return stopped.load();
 }
 
 }   // namespace dfmbase

--- a/src/dfm-base/utils/filescanner.cpp
+++ b/src/dfm-base/utils/filescanner.cpp
@@ -270,16 +270,19 @@ void ScannerWorker::scanLocalPaths()
                 ctx.depth = 0;
                 ctx.isSourcePath = true;
                 dirStack.push(ctx);
-            } else if (S_ISREG(statBuf.st_mode)) {
-                // 普通文件
-                processRegularFile(path, statBuf);
-            } else if (S_ISLNK(statBuf.st_mode)) {
-                // 符号链接
-                processSymlink(path);
+                // 收集源目录URL（如果启用 CollectFiles 选项）
+                collectFileIfEnabled(url, true);
             } else {
-                // 其他特殊文件类型（socket、FIFO、字符设备、块设备等）
-                // 只计数，不计大小
-                currentResult.fileCount++;
+                // 非目录：直接收集（普通文件、符号链接等）
+                if (S_ISREG(statBuf.st_mode)) {
+                    processRegularFile(path, statBuf);
+                } else if (S_ISLNK(statBuf.st_mode)) {
+                    processSymlink(path);
+                } else {
+                    currentResult.fileCount++;
+                }
+                // 收集源文件URL
+                collectFileIfEnabled(url, true);
             }
         } else {
             qCWarning(logDFMBase) << "ScannerWorker: lstat failed for source:" << path;
@@ -317,6 +320,7 @@ void ScannerWorker::scanLocalPaths()
             }
 
             QString entryPath = dirPath + "/" + QString::fromUtf8(entry.name);
+            QUrl entryUrl = QUrl::fromLocalFile(entryPath);
 
             // 跳过特殊系统文件
             if (entry.statOk && S_ISREG(entry.statBuf.st_mode)) {
@@ -364,6 +368,9 @@ void ScannerWorker::scanLocalPaths()
                 currentResult.fileCount++;
             }
 
+            // 收集文件URL（统一处理，支持所有文件类型）
+            collectFileIfEnabled(entryUrl, false);
+
             // 定期发送进度
             emitProgress();
         }
@@ -397,6 +404,9 @@ void ScannerWorker::scanOtherProtocols()
     while (!directoryQueue.isEmpty() && !shouldStop()) {
         QUrl url = directoryQueue.dequeue();
 
+        // 判断是否为源路径
+        bool isSourcePath = urls.contains(url);
+
         // 使用 InfoFactory 创建文件信息
         FileInfoPointer info = InfoFactory::create<FileInfo>(
                 url,
@@ -409,13 +419,16 @@ void ScannerWorker::scanOtherProtocols()
 
         // 检查是否为目录
         if (info->isAttributes(OptInfoType::kIsDir)) {
-            // 检查是否是源 URL
-            if (urls.contains(url)) {
+            // 记录源目录数量
+            if (isSourcePath) {
                 sourceDirCount++;
             }
 
             currentResult.directoryCount++;
             currentResult.progressSize += memoryPageSize;
+
+            // 收集目录URL（如果启用 CollectFiles 选项）
+            collectFileIfEnabled(url, isSourcePath);
 
             // 创建目录迭代器
             AbstractDirIteratorPointer iterator = DirIteratorFactory::create<AbstractDirIterator>(
@@ -452,11 +465,16 @@ void ScannerWorker::scanOtherProtocols()
                                 // 递归模式：入队
                                 directoryQueue.enqueue(childUrl);
                             }
+                            // 收集子目录URL（始终是 false，因为不是源路径）
+                            collectFileIfEnabled(childUrl, false);
                         } else {
                             // 处理文件
                             currentResult.totalSize += childInfo->size();
                             currentResult.fileCount++;
                             currentResult.progressSize += childInfo->size();
+
+                            // 收集子文件URL（始终是 false）
+                            collectFileIfEnabled(childUrl, false);
                         }
                     }
                 }
@@ -466,6 +484,9 @@ void ScannerWorker::scanOtherProtocols()
             currentResult.totalSize += info->size();
             currentResult.fileCount++;
             currentResult.progressSize += info->size();
+
+            // 收集文件URL（始终是 false）
+            collectFileIfEnabled(url, false);
         }
 
         // 定期发送进度
@@ -587,6 +608,22 @@ bool ScannerWorker::isDirectoryPath(const QString &path, const struct stat &lsta
         }
     }
     return false;
+}
+
+void ScannerWorker::collectFileIfEnabled(const QUrl &url, bool isSourcePath)
+{
+    // 只有启用 CollectFiles 选项才收集
+    if (!(options & FileScanner::ScanOption::CollectFiles)) {
+        return;
+    }
+
+    // 如果是源路径且未设置 IncludeSource 选项，则不收集
+    // IncludeSource 语义：true=包含源路径，false=排除源路径
+    if (isSourcePath && !(options & FileScanner::ScanOption::IncludeSource)) {
+        return;
+    }
+
+    currentResult.allFiles.append(url);
 }
 
 }   // namespace dfmbase

--- a/src/dfm-base/utils/filescanner.h
+++ b/src/dfm-base/utils/filescanner.h
@@ -57,7 +57,8 @@ public:
     enum class ScanOption {
         NoOption = 0x00,   ///< 无特殊选项
         SingleDepth = 0x01,   ///< 只统计顶层，不递归
-        IncludeSource = 0x02   ///< 包含源目录本身（默认不包含）
+        IncludeSource = 0x02,   ///< 包含源目录本身（默认不包含）
+        CollectFiles = 0x04   ///< 收集所有文件URL列表（默认不收集）
     };
     Q_ENUM(ScanOption)
     Q_DECLARE_FLAGS(ScanOptions, ScanOption)
@@ -71,9 +72,10 @@ public:
         qint64 progressSize { 0 };   ///< 进度大小（用于显示）
         int fileCount { 0 };   ///< 文件数量
         int directoryCount { 0 };   ///< 目录数量
+        QList<QUrl> allFiles;   ///< 所有文件的URL列表（仅当 CollectFiles 选项启用时填充）
 
         bool isValid() const { return fileCount >= 0 && directoryCount >= 0; }
-        void clear() { totalSize = progressSize = fileCount = directoryCount = 0; }
+        void clear() { totalSize = progressSize = fileCount = directoryCount = 0; allFiles.clear(); }
     };
 
     /**
@@ -255,6 +257,16 @@ private:
      * 使用 InfoFactory 创建文件信息
      */
     void scanOtherProtocols();
+
+    /**
+     * @brief 收集文件URL（如果启用 CollectFiles 选项）
+     * @param url 要收集的URL
+     * @param isSourcePath 是否为源路径
+     *
+     * 根据 CollectFiles 选项决定是否收集文件URL到结果列表。
+     * 如果是源路径且未设置 IncludeSource 选项，则不收集该URL（仅针对目录）。
+     */
+    void collectFileIfEnabled(const QUrl &url, bool isSourcePath = false);
 
     /**
      * @brief 检查是否应该停止

--- a/src/dfm-base/utils/filescanner.h
+++ b/src/dfm-base/utils/filescanner.h
@@ -16,6 +16,7 @@
 #include <QSet>
 #include <QStack>
 
+#include <functional>
 #include <sys/stat.h>
 #include <dirent.h>
 
@@ -115,6 +116,52 @@ public:
      */
     bool isRunning() const;
 
+    /**
+     * @brief 同步扫描文件和目录
+     *
+     * 在当前线程中同步执行扫描，直到完成。
+     * 注意：此方法会阻塞调用线程，不适合在主线程中扫描大量文件。
+     *
+     * @param urls 要扫描的 URL 列表
+     * @param options 扫描选项
+     * @return 扫描结果
+     *
+     * @code
+     * // 示例：同步扫描目录
+     * auto result = FileScanner::scanSync({QUrl::fromLocalFile("/home/user")});
+     * qDebug() << "Total size:" << result.totalSize;
+     * qDebug() << "File count:" << result.fileCount;
+     * @endcode
+     */
+    static ScanResult scanSync(const QList<QUrl> &urls,
+                               ScanOptions options = ScanOption::NoOption);
+
+    /**
+     * @brief 同步扫描文件和目录（支持进度回调）
+     *
+     * 在当前线程中同步执行扫描，支持通过回调函数中断扫描。
+     *
+     * @param urls 要扫描的 URL 列表
+     * @param options 扫描选项
+     * @param progressCallback 进度回调函数，返回 false 可中断扫描
+     * @return 扫描结果
+     *
+     * @code
+     * // 示例：可中断的同步扫描
+     * QAtomicInt stopFlag(0);
+     * auto result = FileScanner::scanSyncWithCallback(
+     *     {QUrl::fromLocalFile("/home/user")},
+     *     FileScanner::ScanOption::NoOption,
+     *     [&stopFlag](const ScanResult &result) -> bool {
+     *         return stopFlag.loadRelaxed() == 0;  // 返回 false 停止扫描
+     *     });
+     * @endcode
+     */
+    using ProgressCallback = std::function<bool(const ScanResult &)>;
+    static ScanResult scanSyncWithCallback(const QList<QUrl> &urls,
+                                           ScanOptions options,
+                                           ProgressCallback progressCallback);
+
 public Q_SLOTS:
     /**
      * @brief 开始扫描
@@ -195,123 +242,16 @@ Q_SIGNALS:
 
 private:
     /**
-     * @brief 扫描本地文件路径
-     *
-     * 使用 opendir/readdir 进行遍历
-     */
-    void scanLocalPaths();
-
-    /**
-     * @brief 目录项结构（用于批量读取）
-     */
-    struct DirEntry
-    {
-        QByteArray name;   // 文件名（UTF-8）
-        struct stat statBuf;   // lstat 结果
-        bool statOk;   // lstat 是否成功
-        unsigned char d_type;   // dirent.d_type (DT_DIR, DT_LNK 等)
-    };
-
-    /**
-     * @brief 遍历上下文
-     */
-    struct ScanContext
-    {
-        QString fullPath;   // 当前完整路径
-        int depth;   // 当前深度（0 = 源目录）
-        bool isSourcePath;   // 是否为源路径
-    };
-
-    /**
-     * @brief 读取目录条目
-     * @param path 目录路径
-     * @param entries 输出参数，目录条目列表
-     * @return 是否成功
-     */
-    bool readDirectoryEntries(const QString &path, QList<DirEntry> *entries);
-
-    /**
-     * @brief 处理常规文件
-     * @param path 文件路径
-     * @param statBuf lstat 结果
-     */
-    void processRegularFile(const QString &path, const struct stat &statBuf);
-
-    /**
-     * @brief 处理符号链接
-     * @param path 链接路径
-     */
-    void processSymlink(const QString &path);
-
-    /**
-     * @brief 判断路径是否为目录（跟随符号链接）
-     * @param path 路径
-     * @param lstatBuf lstat 结果
-     * @return 是否为目录
-     */
-    bool isDirectoryPath(const QString &path, const struct stat &lstatBuf);
-
-    /**
-     * @brief 扫描其他协议（如 SMB, SFTP）
-     *
-     * 使用 InfoFactory 创建文件信息
-     */
-    void scanOtherProtocols();
-
-    /**
-     * @brief 收集文件URL（如果启用 CollectFiles 选项）
-     * @param url 要收集的URL
-     * @param isSourcePath 是否为源路径
-     *
-     * 根据 CollectFiles 选项决定是否收集文件URL到结果列表。
-     * 如果是源路径且未设置 IncludeSource 选项，则不收集该URL（仅针对目录）。
-     */
-    void collectFileIfEnabled(const QUrl &url, bool isSourcePath = false);
-
-    /**
      * @brief 检查是否应该停止
      */
     bool shouldStop() const;
-
-    /**
-     * @brief 检查 inode 是否已处理
-     *
-     * 使用 device + inode 组合避免硬链接重复统计
-     * 只对 st_nlink > 1 的文件调用此方法
-     */
-    bool isInodeProcessed(quint64 device, quint64 inode);
-
-    /**
-     * @brief 标记 inode 为已处理
-     */
-    void markInodeProcessed(quint64 device, quint64 inode);
-
-    /**
-     * @brief 发送进度通知
-     * @param force 是否强制发送
-     */
-    void emitProgress(bool force = false);
 
 private:
     QList<QUrl> urls;
     FileScanner::ScanOptions options { FileScanner::ScanOption::NoOption };
 
-    // 当前结果（工作线程独占，无需锁）
-    FileScanner::ScanResult currentResult;
-
     // 控制标志
     std::atomic<bool> stopped { false };
-
-    // 进度节流
-    QElapsedTimer progressTimer;
-    qint64 lastEmittedSize { 0 };
-
-    // 内存页大小
-    qint64 memoryPageSize { 4096 };
-
-    // inode 去重 - 只对 st_nlink > 1 的文件存储
-    // QHash<device, QSet<inode>>
-    QHash<quint64, QSet<quint64>> processedInodes;
 };
 
 }   // namespace dfmbase

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -276,6 +276,8 @@ bool AbstractWorker::statisticsFilesSize()
     } else {
         fmDebug() << "Using asynchronous file size calculation for remote files";
         statisticsFilesSizeJob.reset(new DFMBASE_NAMESPACE::FileScanner());
+        // 启用文件列表收集，以便获取 allFilesList
+        statisticsFilesSizeJob->setOptions(FileScanner::ScanOption::CollectFiles | FileScanner::ScanOption::IncludeSource);
         connect(statisticsFilesSizeJob.data(), &DFMBASE_NAMESPACE::FileScanner::finished,
                 this, &AbstractWorker::onStatisticsFilesSizeFinish, Qt::DirectConnection);
         connect(statisticsFilesSizeJob.data(), &DFMBASE_NAMESPACE::FileScanner::progressChanged, this, &AbstractWorker::onStatisticsFilesSizeUpdate, Qt::DirectConnection);
@@ -581,10 +583,10 @@ void AbstractWorker::onStatisticsFilesSizeFinish(const FileScanner::ScanResult &
     sourceFilesTotalSize = result.progressSize;
     workData->dirSize = FileUtils::getMemoryPageSize();
     sourceFilesCount = result.fileCount;
-    // 对于异步统计（非本地文件），allFilesList 不是必需的，因为这些操作主要用于本地文件的删除/回收站操作
-    allFilesList.clear();
+    // 获取文件列表（通过 CollectFiles 选项启用）
+    allFilesList = result.allFiles;
 
-    fmInfo() << "Asynchronous file statistics completed - total size:" << sourceFilesTotalSize << "file count:" << sourceFilesCount;
+    fmInfo() << "Asynchronous file statistics completed - total size:" << sourceFilesTotalSize << "file count:" << sourceFilesCount << "allFiles count:" << allFilesList.count();
 }
 
 void AbstractWorker::onStatisticsFilesSizeUpdate(const FileScanner::ScanResult &result)

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -103,8 +103,12 @@ void AbstractWorker::doOperateWork(AbstractJobHandler::SupportActions actions, A
 void AbstractWorker::stop()
 {
     setStat(AbstractJobHandler::JobState::kStopState);
-    if (statisticsFilesSizeJob)
-        statisticsFilesSizeJob->stop();
+
+    // Signal statistics thread to stop
+    if (statisticsThread) {
+        statisticsStopFlag.storeRelaxed(1);   // Set stop flag
+        statisticsThread->wait();   // Now this will return quickly
+    }
 
     if (updateProgressTimer) {
         // Stop timer in main thread using cross-thread method invocation
@@ -275,13 +279,8 @@ bool AbstractWorker::statisticsFilesSize()
         fmInfo() << "File statistics completed - total size:" << sourceFilesTotalSize << "file count:" << sourceFilesCount;
     } else {
         fmDebug() << "Using asynchronous file size calculation for remote files";
-        statisticsFilesSizeJob.reset(new DFMBASE_NAMESPACE::FileScanner());
-        // 启用文件列表收集，以便获取 allFilesList
-        statisticsFilesSizeJob->setOptions(FileScanner::ScanOption::CollectFiles | FileScanner::ScanOption::IncludeSource);
-        connect(statisticsFilesSizeJob.data(), &DFMBASE_NAMESPACE::FileScanner::finished,
-                this, &AbstractWorker::onStatisticsFilesSizeFinish, Qt::DirectConnection);
-        connect(statisticsFilesSizeJob.data(), &DFMBASE_NAMESPACE::FileScanner::progressChanged, this, &AbstractWorker::onStatisticsFilesSizeUpdate, Qt::DirectConnection);
-        statisticsFilesSizeJob->start(sourceUrls);
+        workData->dirSize = FileUtils::getMemoryPageSize();
+        startAsyncStatistics(sourceUrls);
     }
     return true;
 }
@@ -355,8 +354,9 @@ void AbstractWorker::endWork()
              << "completed files:" << completeSourceFiles.count()
              << "time elapsed:" << timeElapsed.elapsed() << "ms";
 
-    if (statisticsFilesSizeJob) {
-        statisticsFilesSizeJob->stop();
+    if (statisticsThread) {
+        statisticsThread->quit();
+        statisticsThread->wait();
     }
 
     emit workerFinish();
@@ -399,11 +399,12 @@ void AbstractWorker::emitProgressChangedNotify(const qint64 &writSize)
                || AbstractJobHandler::JobType::kCleanTrashType == jobType) {
         info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(sourceUrls.count())));
     } else {
-        info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(allFilesList.count())));
+        qint64 count = allFilesList.isEmpty() ? (sourceFilesCount + sourceDirsCount) : allFilesList.count();
+        info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(count));
     }
     AbstractJobHandler::StatisticState state = AbstractJobHandler::StatisticState::kNoState;
-    if (statisticsFilesSizeJob) {
-        if (statisticsFilesSizeJob->isRunning())
+    if (statisticsThread) {
+        if (statisticsThread->isRunning())
             state = AbstractJobHandler::StatisticState::kRunningState;
         else
             state = AbstractJobHandler::StatisticState::kStopState;
@@ -571,27 +572,47 @@ bool AbstractWorker::stateCheck()
     return true;
 }
 /*!
- * \brief AbstractWorker::onStatisticsFilesSizeFinish  Count the size of all files
- * and the slot at the end of the thread
- * \param sizeInfo All file size information
+ * \brief AbstractWorker::startAsyncStatistics Start asynchronous file statistics
+ * \param urls Source URLs to scan
  */
-void AbstractWorker::onStatisticsFilesSizeFinish(const FileScanner::ScanResult &result)
+void AbstractWorker::startAsyncStatistics(const QList<QUrl> &urls)
 {
-    if (!statisticsFilesSizeJob)
-        return;
-    statisticsFilesSizeJob->stop();
-    sourceFilesTotalSize = result.progressSize;
-    workData->dirSize = FileUtils::getMemoryPageSize();
-    sourceFilesCount = result.fileCount;
-    // 获取文件列表（通过 CollectFiles 选项启用）
-    allFilesList = result.allFiles;
+    // Reset stop flag
+    statisticsStopFlag.storeRelaxed(0);
 
-    fmInfo() << "Asynchronous file statistics completed - total size:" << sourceFilesTotalSize << "file count:" << sourceFilesCount << "allFiles count:" << allFilesList.count();
-}
+    // Create thread that executes interruptible scan
+    statisticsThread = QThread::create([this, urls]() {
+        // Create progress callback that checks stop flag
+        auto progressCallback = [this](const DFMBASE_NAMESPACE::FileScanner::ScanResult &result) -> bool {
+            // Check if should stop
+            if (statisticsStopFlag.loadRelaxed() != 0) {
+                fmInfo() << "Statistics scan interrupted by user";
+                return false;   // Stop scanning
+            }
+            return true;   // Continue scanning
+        };
 
-void AbstractWorker::onStatisticsFilesSizeUpdate(const FileScanner::ScanResult &result)
-{
-    sourceFilesTotalSize = result.progressSize;
+        // Call scanSyncWithCallback with progress callback
+        auto result = DFMBASE_NAMESPACE::FileScanner::scanSyncWithCallback(
+                urls,
+                DFMBASE_NAMESPACE::FileScanner::ScanOption::IncludeSource,
+                progressCallback);
+
+        // Only update data if not stopped
+        if (statisticsStopFlag.loadRelaxed() == 0) {
+            // Update atomic variables (thread-safe)
+            sourceFilesTotalSize = result.progressSize;
+            sourceFilesCount = result.fileCount;
+            sourceDirsCount = result.directoryCount;
+
+            fmInfo() << "Asynchronous file statistics completed - total size:" << sourceFilesTotalSize
+                     << "all files count:" << (sourceFilesCount + sourceDirsCount);
+        } else {
+            fmInfo() << "Statistics scan was stopped before completion";
+        }
+    });
+
+    statisticsThread->start();
 }
 
 AbstractWorker::AbstractWorker(QObject *parent)
@@ -711,8 +732,12 @@ AbstractWorker::~AbstractWorker()
     // Ensure all waiting threads are woken up before destruction
     waitCondition.wakeAll();
 
-    if (statisticsFilesSizeJob) {
-        statisticsFilesSizeJob->stop();
+    // Clean up statistics thread
+    if (statisticsThread) {
+        statisticsStopFlag.storeRelaxed(1);   // Signal to stop
+        statisticsThread->quit();
+        statisticsThread->wait();
+        statisticsThread->deleteLater();
     }
 
     // UpdateProgressTimer will be automatically cleaned up when destroyed

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -133,8 +133,6 @@ protected:
 protected slots:
     virtual bool doWork();
     virtual void onUpdateProgress() { }
-    virtual void onStatisticsFilesSizeFinish(const DFMBASE_NAMESPACE::FileScanner::ScanResult &result);
-    virtual void onStatisticsFilesSizeUpdate(const DFMBASE_NAMESPACE::FileScanner::ScanResult &result);
 
 protected:
     void initHandleConnects(const JobHandlePointer handle);
@@ -158,11 +156,15 @@ protected:
 
     static dfmbase::FileInfo::FileType fileType(const DFileInfoPointer &info);
 
+    // 启动异步统计
+    void startAsyncStatistics(const QList<QUrl> &urls);
+
 public:
     virtual ~AbstractWorker();
 
 public:
-    QSharedPointer<DFMBASE_NAMESPACE::FileScanner> statisticsFilesSizeJob { nullptr };   // statistics file info async
+    QThread *statisticsThread { nullptr };   // file statistics thread (for async scanSync call)
+    QAtomicInt statisticsStopFlag { 0 };     // stop flag for statistics thread (0=running, 1=should stop)
     QSharedPointer<UpdateProgressTimer> updateProgressTimer { nullptr };   // update progress timer
 
     JobHandlePointer handle { nullptr };   // handle
@@ -176,6 +178,7 @@ public:
 
     QAtomicInteger<qint64> sourceFilesTotalSize { 0 };   // total size of all source files
     QAtomicInteger<qint64> sourceFilesCount { 0 };   // source files count
+    QAtomicInteger<qint64> sourceDirsCount { 0 };
 
     QList<QUrl> sourceUrls;   // source urls
     QUrl targetUrl;   // target dir url


### PR DESCRIPTION
The original code used default Qt::AutoConnection for signal-slot connections between ScannerWorker and FileScannerPrivate. When the scanner runs in non-main threads without an event loop, signals were being lost because Qt::AutoConnection defaults to Qt::QueuedConnection which requires an event loop.

Changes:
1. Added detection for current thread's event loop presence
2. Use Qt::DirectConnection for threads without event loops
3. Use Qt::AutoConnection for threads with event loops (main thread)
4. Added debug logging to track connection type selection

This ensures signals are properly delivered regardless of which thread the file scanner runs in.

Log: Fixed file scanner signal loss issue in non-main threads

Influence:
1. Test file scanning in main thread - signals should work normally
2. Test file scanning in worker threads without event loops - signals should now be received
3. Verify scan results are properly reported in both scenarios
4. Check debug logs for correct connection type selection

fix: 修复非主线程下文件扫描器信号丢失问题

原始代码在 ScannerWorker 和 FileScannerPrivate 之间使用默认的
Qt::AutoConnection 进行信号槽连接。当扫描器在没有事件循环的非主线程中
运行时，信号会丢失，因为 Qt::AutoConnection 在没有事件循环时会默认为
Qt::QueuedConnection。

修改内容：
1. 添加当前线程事件循环检测
2. 对没有事件循环的线程使用 Qt::DirectConnection
3. 对有事件循环的线程（主线程）使用 Qt::AutoConnection
4. 添加调试日志记录连接类型选择

这确保了无论文件扫描器在哪个线程运行，信号都能正确传递。

Log: 修复非主线程下文件扫描器信号丢失问题

Influence:
1. 在主线程中测试文件扫描 - 信号应正常工作
2. 在没有事件循环的工作线程中测试文件扫描 - 信号现在应能被接收
3. 验证两种场景下的扫描结果是否正确报告
4. 检查调试日志中连接类型选择是否正确

Bug: https://pms.uniontech.com/bug-view-351785.html

## Summary by Sourcery

Ensure file scanner signals are correctly delivered when running in threads without an event loop by adjusting Qt signal connection types based on the current thread context.

Bug Fixes:
- Prevent loss of file scanner signals when running in non-main threads without an event loop by choosing an appropriate Qt connection type dynamically.

Enhancements:
- Add debug logging to record the selected Qt connection type and thread context for file scanner worker signal connections.