### PR TITLE
fix: clear selection cache on model structural changes

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/canvasselectionmodel.cpp
@@ -10,10 +10,23 @@
 
 using namespace ddplugin_canvas;
 
-CanvasSelectionModel::CanvasSelectionModel(CanvasProxyModel *model, QObject *parent) : QItemSelectionModel(model, parent)
+CanvasSelectionModel::CanvasSelectionModel(CanvasProxyModel *model, QObject *parent)
+    : QItemSelectionModel(model, parent)
 {
     // clear immediately the cache if selection changed.
     connect(this, &CanvasSelectionModel::selectionChanged, this, &CanvasSelectionModel::clearSelectedCache, Qt::DirectConnection);
+
+    // The cache holds plain QModelIndex (non-persistent), whose row number is a snapshot
+    // and does NOT auto-update when the model structure changes. If rows are inserted or
+    // removed at positions before the cached index, the cached row number becomes stale
+    // and may point to a completely different file — even though selectionChanged is never
+    // emitted (because the selected item itself was not touched). We must therefore
+    // invalidate the cache on any structural model change.
+    connect(model, &QAbstractItemModel::rowsInserted, this, &CanvasSelectionModel::clearSelectedCache, Qt::DirectConnection);
+    connect(model, &QAbstractItemModel::rowsRemoved, this, &CanvasSelectionModel::clearSelectedCache, Qt::DirectConnection);
+    connect(model, &QAbstractItemModel::rowsMoved, this, &CanvasSelectionModel::clearSelectedCache, Qt::DirectConnection);
+    connect(model, &QAbstractItemModel::layoutChanged, this, &CanvasSelectionModel::clearSelectedCache, Qt::DirectConnection);
+    connect(model, &QAbstractItemModel::modelReset, this, &CanvasSelectionModel::clearSelectedCache, Qt::DirectConnection);
 }
 
 CanvasProxyModel *CanvasSelectionModel::model() const
@@ -58,7 +71,7 @@ QList<QUrl> CanvasSelectionModel::selectedUrls() const
     auto indexs = selectedIndexesCache();
     QList<QUrl> urls;
     for (auto index : indexs)
-        urls <<  model()->fileUrl(index);
+        urls << model()->fileUrl(index);
 
     return urls;
 }
@@ -79,5 +92,3 @@ void CanvasSelectionModel::hookClear()
     if (hook)
         hook->clear();
 }
-
-


### PR DESCRIPTION
The selection cache holds plain QModelIndex objects which are non-
persistent and do not auto-update when the model structure changes. When
rows are inserted, removed, moved, or when layout changes occur before
the cached index positions, the cached row numbers become stale and
may point to incorrect files. This happens even though selectionChanged
is not emitted since the selected items themselves are not modified.
To prevent this inconsistency, we now connect to all structural
change signals (rowsInserted, rowsRemoved, rowsMoved, layoutChanged,
modelReset) from the model to clear the selection cache immediately.

Influence:
1. Test file selection after adding new files to the canvas
2. Verify selection consistency after deleting files from the canvas
3. Test selection behavior when moving files around
4. Verify selection cache is properly cleared after model layout changes
5. Test selection accuracy after model reset operations

fix: 在模型结构变化时清除选择缓存

选择缓存保存的是普通的QModelIndex对象，这些对象是非持久化的，在模型结构
变化时不会自动更新。当在缓存索引位置之前插入、删除、移动行，或者布局发
生变化时，缓存的行号会变得过时，可能指向错误的文件。即使selectionChanged
信号没有被触发（因为选中的项目本身没有被修改），这种情况也会发生。为了
防止这种不一致性，我们现在连接到模型的所有结构变化信号（rowsInserted、
rowsRemoved、rowsMoved、layoutChanged、modelReset），以便立即清除选择
缓存。

Influence:
1. 测试在画布上添加新文件后的文件选择功能
2. 验证从画布删除文件后的选择一致性
3. 测试移动文件时的选择行为
4. 验证模型布局变化后选择缓存是否正确清除
5. 测试模型重置操作后的选择准确性

BUG: https://pms.uniontech.com/bug-view-351189.html
