### PR TITLE
fix bugs

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -852,7 +852,7 @@ void DeviceManager::doAutoMount(const QString &id, DeviceType type, int timeout)
             return;
         }
         // auto mount is only available for non optical devices and removable device.
-        // the internal devices are mounted when server launced, see @doAutoMountAtStart
+        // the internal devices are mounted when server launched, see @doAutoMountAtStart
         if (id.startsWith("/org/freedesktop/UDisks2/block_devices/sr"))
             return;
         if (!info.value(DeviceProperty::kRemovable).toBool())

--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -851,6 +851,12 @@ void DeviceManager::doAutoMount(const QString &id, DeviceType type, int timeout)
             qCDebug(logDFMBase) << "Auto mount skipped for device without filesystem:" << id;
             return;
         }
+        // auto mount is only available for non optical devices and removable device.
+        // the internal devices are mounted when server launced, see @doAutoMountAtStart
+        if (id.startsWith("/org/freedesktop/UDisks2/block_devices/sr"))
+            return;
+        if (!info.value(DeviceProperty::kRemovable).toBool())
+            return;
 
         qCInfo(logDFMBase) << "Starting auto mount for block device:" << id;
         mountBlockDevAsync(id, {}, cb, timeout);

--- a/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-burn/events/burneventreceiver.cpp
@@ -42,7 +42,7 @@ BurnEventReceiver *BurnEventReceiver::instance()
 void BurnEventReceiver::handleShowBurnDlg(const QString &dev, bool isSupportedUDF, QWidget *parent)
 {
     QString devId { DeviceUtils::getBlockDeviceId(dev) };
-    auto &&map = DevProxyMng->queryBlockInfo(devId);
+    const auto &map = DevProxyMng->queryBlockInfo(devId, true);
 
     QString defaultDiscName { qvariant_cast<QString>(map[DeviceProperty::kIdLabel]) };
     QStringList speed { qvariant_cast<QStringList>(map[DeviceProperty::kOpticalWriteSpeed]) };

--- a/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
@@ -365,13 +365,13 @@ void ComputerController::mountDevice(quint64 winId, const QString &id, const QSt
         return;
     }
 
-    const auto &&data = DevProxyMng->queryBlockInfo(id);
+    const auto &data = DevProxyMng->queryBlockInfo(id, true);
     if (data.value(DeviceProperty::kOpticalDrive).toBool() && data.value(DeviceProperty::kOpticalBlank).toBool()) {
-        if (!data.value(DeviceProperty::kOpticalWriteSpeed).toStringList().isEmpty()) {   // already load data from xorriso.
-            fmDebug() << "Optical drive with blank disc and write speed data available";
-            cdTo(id, ComputerUtils::makeBurnUrl(id), winId, act);
-            return;
+        if (data.value(DeviceProperty::kOpticalWriteSpeed).toStringList().isEmpty()) {   // already load data from xorriso.
+            fmWarning() << "Optical drive write speed data is empty!";
         }
+        cdTo(id, ComputerUtils::makeBurnUrl(id), winId, act);
+        return;
     }
 
     ComputerUtils::setCursorState(true);

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -926,15 +926,14 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
             Q_EMIT itemPropertyChanged(devUrl, propertyName, var.variant());
         }
 
-        // by default if loop device do not have filesystem interface in udisks, it will not be shown in computer,
-        // and for loop devices, no blockAdded signal will be emited cause it's already existed there, so
-        // watch the filesystemAdded/Removed signal to decide whether to show or hide it.
+        // if any block device's filesystem is added then it should be added into computer view.
+        // and if filesystem is removed, remove from computer view except the optical drive.
         if (propertyName == DeviceProperty::kHasFileSystem) {
-            auto blkInfo = DevProxyMng->queryBlockInfo(id);
-            if (blkInfo.value(DeviceProperty::kIsLoopDevice).toBool()) {
-                if (var.variant().toBool())
-                    addDevice(diskGroup(), url);
-                else
+            auto blkInfo = DevProxyMng->queryBlockInfo(id, true);
+            if (var.variant().toBool()) {
+                addDevice(diskGroup(), url);
+            } else {
+                if (!blkInfo.value(DeviceProperty::kOpticalDrive).toBool())   // 避免光驱被误删
                     removeDevice(url);
             }
             onUpdateBlockItem(id);
@@ -993,9 +992,11 @@ void ComputerItemWatcher::onUpdateBlockItem(const QString &id)
         if (item.info) {
             item.info->refresh();
             // 使用 QMetaObject::invokeMethod 确保在主线程调用 updateSidebarItem
-            QMetaObject::invokeMethod(this, [this, devUrl, item]() {
-                updateSidebarItem(devUrl, item.info->displayName(), item.info->renamable());
-            }, Qt::QueuedConnection);
+            QMetaObject::invokeMethod(
+                    this, [this, devUrl, item]() {
+                        updateSidebarItem(devUrl, item.info->displayName(), item.info->renamable());
+                    },
+                    Qt::QueuedConnection);
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Restrict automatic mounting and visibility updates for block devices based on filesystem presence, removability, and optical-drive status.

Bug Fixes:
- Ensure block devices are added to or removed from the computer view when their filesystem interface appears or disappears, while preventing optical drives from being incorrectly removed.
- Limit auto-mounting to removable, non-optical block devices to avoid mounting internal or optical drives unintentionally.