### PR TITLE
fix: fix TIFF image preview crash on DAVS remote filesystem

### DIFF
--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
@@ -11,12 +11,15 @@
 #include <dfm-base/base/device/deviceproxymanager.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/base/configs/dconfig/global_dconf_defines.h>
+#include <dfm-base/utils/protocolutils.h>
 
 #include <dfm-framework/dpf.h>
 
 #include <QImageReader>
 #include <QMovie>
 #include <QApplication>
+#include <QFile>
+#include <QBuffer>
 
 Q_DECLARE_METATYPE(QString *)
 
@@ -73,7 +76,17 @@ void ImagePreviewWorker::loadPreview(const QUrl &url, const QSize &targetSize)
     if (isImageMimeType(mimeType)) {
         // Check if we should skip original image loading for remote/optical files
         if (!shouldSkipOriginalImageLoad(url, fileSize)) {
-            result = loadOriginalImage(filePath, targetSize);
+            // Special handling for TIFF files on DAV/DAVS remote filesystem
+            // DAV/DAVS (WebDAV with or without SSL) may have incomplete data reads due to
+            // network instability, causing libtiff to crash when accessing incomplete strip
+            // data via memcpy. Load entire file into memory first to ensure data integrity.
+            if (mimeType == "image/tiff"
+                && (ProtocolUtils::isDavFile(url) || ProtocolUtils::isDavsFile(url))) {
+                result = loadImageFromMemory(filePath, targetSize);
+            } else {
+                result = loadOriginalImage(filePath, targetSize);
+            }
+
             if (!result.isNull()) {
                 Q_EMIT previewReady(url, result);
                 return;
@@ -149,6 +162,70 @@ QPixmap ImagePreviewWorker::loadOriginalImage(const QString &filePath, const QSi
 
     QImage image = reader.read();
     if (image.isNull()) {
+        return QPixmap();
+    }
+
+    QPixmap pixmap = QPixmap::fromImage(image);
+    pixmap.setDevicePixelRatio(dpr);
+    return pixmap;
+}
+
+QPixmap ImagePreviewWorker::loadImageFromMemory(const QString &filePath, const QSize &targetSize)
+{
+    // This method loads an image file entirely into memory before decoding.
+    // It's designed to work around issues with remote filesystem (especially DAVS)
+    // where streaming reads may return incomplete data due to:
+    // - Network instability or latency
+    // - Filesystem cache not fully synchronized
+    // - Concurrent access causing race conditions
+    //
+    // For TIFF files, libtiff's TIFFReadEncodedStrip may receive incomplete strip data
+    // from TIFFReadFile (which calls QFile::read on remote files), leading to:
+    // 1. tif->tif_rawcc set to expected byte count from TIFF header (e.g., 5760 bytes)
+    // 2. Actual buffer contains only partial data (e.g., 2880 bytes)
+    // 3. DumpModeDecode's memcpy attempts to copy full expected size, causing buffer overflow
+    //
+    // By reading the entire file into memory first, we ensure data integrity before
+    // passing it to QImageReader, eliminating the streaming read issue.
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        fmWarning() << "detailview: failed to open file for memory loading:" << filePath;
+        return QPixmap();
+    }
+
+    QByteArray fileData = file.readAll();
+    file.close();
+
+    if (fileData.isEmpty()) {
+        fmWarning() << "detailview: empty data from file:" << filePath;
+        return QPixmap();
+    }
+
+    // Load image from memory buffer instead of file path
+    QBuffer buffer(&fileData);
+    buffer.open(QIODevice::ReadOnly);
+
+    QImageReader reader(&buffer);
+    reader.setAutoTransform(true);
+
+    QSize originalSize = reader.size();
+    if (!originalSize.isValid()) {
+        return QPixmap();
+    }
+
+    qreal dpr = qApp->devicePixelRatio();
+    QSize maxSize = targetSize * dpr;
+
+    if (originalSize.width() > maxSize.width()
+        || originalSize.height() > maxSize.height()) {
+        QSize scaledSize = originalSize.scaled(maxSize, Qt::KeepAspectRatio);
+        reader.setScaledSize(scaledSize);
+    }
+
+    QImage image = reader.read();
+    if (image.isNull()) {
+        fmWarning() << "detailview: failed to decode image from memory:" << filePath;
         return QPixmap();
     }
 

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.h
@@ -36,6 +36,7 @@ private:
     bool isImageMimeType(const QString &mimeType) const;
     bool shouldSkipOriginalImageLoad(const QUrl &url, qint64 fileSize) const;
     QPixmap loadOriginalImage(const QString &filePath, const QSize &targetSize);
+    QPixmap loadImageFromMemory(const QString &filePath, const QSize &targetSize);
     QPixmap loadThumbnail(const QUrl &url, const QSize &targetSize);
 
 private:


### PR DESCRIPTION
Add special handling for TIFF files on DAVS (WebDAV over SSL) filesystems to prevent crashes during image preview. The issue occurred because remote filesystem streaming reads may return incomplete data due to network instability, causing libtiff to crash when accessing incomplete strip data via memcpy. The solution loads entire TIFF files into memory first for DAVS URLs to ensure data integrity before decoding.

Implemented new loadImageFromMemory method that reads complete file data into memory buffer before passing to QImageReader. This eliminates the streaming read issue that caused buffer overflow in TIFF decoding. The change only affects TIFF files on DAVS remote filesystems, preserving existing behavior for other file types and local files.

Log: Fixed TIFF image preview crash on remote WebDAV filesystems

Influence:
1. Test TIFF file preview on DAVS remote filesystem with various network conditions
2. Verify TIFF preview still works correctly on local filesystem
3. Test other image formats (JPEG, PNG) on DAVS to ensure no regression
4. Verify large TIFF files load properly with memory constraints
5. Test image preview with different network speeds and stability
6. Check that thumbnail generation still works for all image types

fix: 修复 DAVS 远程文件系统上 TIFF 图片预览崩溃问题

为 DAVS（基于 SSL 的 WebDAV）文件系统上的 TIFF 文件添加特殊处理，防止图
片预览时发生崩溃。该问题是由于远程文件系统的流式读取可能因网络不稳定返回
不完整数据，导致 libtiff 在通过 memcpy 访问不完整条带数据时崩溃。解决方
案是针对 DAVS URL 的 TIFF 文件，先完整加载到内存中确保数据完整性后再进行
解码。

实现了新的 loadImageFromMemory 方法，在传递给 QImageReader 之前将完整文 件数据读入内存缓冲区。这消除了导致 TIFF 解码中缓冲区溢出的流式读取问题。
此更改仅影响 DAVS 远程文件系统上的 TIFF 文件，保留对其他文件类型和本地文
件的现有行为。

Log: 修复远程 WebDAV 文件系统上 TIFF 图片预览崩溃问题

Influence:
1. 在各种网络条件下测试 DAVS 远程文件系统上的 TIFF 文件预览
2. 验证本地文件系统上的 TIFF 预览功能仍正常工作
3. 测试 DAVS 上其他图片格式（JPEG、PNG）确保无回归问题
4. 验证大尺寸 TIFF 文件在内存限制下正常加载
5. 使用不同网络速度和稳定性测试图片预览功能
6. 检查所有图片类型的缩略图生成功能是否正常

## Summary by Sourcery

Handle TIFF previews on DAV/DAVS remote filesystems by loading image data into memory before decoding to avoid crashes from incomplete reads.

Bug Fixes:
- Prevent crashes when previewing TIFF images stored on DAV/DAVS (WebDAV) remote filesystems by avoiding streaming reads that can return incomplete data.

Enhancements:
- Introduce a memory-based image loading path that reads entire files into a buffer and decodes from memory when needed for safe preview handling.