### PR TITLE
docs: improve disk encryption UI text clarity

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -716,7 +716,7 @@ int dialog_utils::showConfirmDecryptionDialog(const QString &device, bool needRe
     if (isWayland())
         dlg.setWindowFlag(Qt::WindowStaysOnTopHint);
     dlg.setIcon(QIcon::fromTheme("drive-harddisk-root"));
-    dlg.setTitle(QObject::tr("Decrypt %1?").arg(device));
+    dlg.setTitle(QObject::tr("Decrypt \"%1\" partition?").arg(device));
     dlg.setMessage(QObject::tr("Decryption can take a long time, "
                                "so make sure power is connected until the decryption is complete."));
     dlg.addButton(QObject::tr("Cancel"));

--- a/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
+++ b/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
@@ -33,10 +33,10 @@
   </action>
   <action id="org.deepin.Filemanager.DiskEncrypt.ChangePassphrase">
     <description>Disk encryption</description>
-    <message>Authentication is required to change the passphrase of partition</message>
-    <message xml:lang="zh_CN">修改分区密码需要认证</message>
-    <message xml:lang="zh_HK">修改分區密碼需要認證</message>
-    <message xml:lang="zh_TW">修改分割區密碼需要認證</message>
+    <message>Authentication is required to change the PIN code of the partition</message>
+    <message xml:lang="zh_CN">修改分区PIN码需要认证</message>
+    <message xml:lang="zh_HK">修改分區PIN碼需要認證</message>
+    <message xml:lang="zh_TW">修改分割區PIN碼需要認證</message>
     <icon_name>folder</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/src/services/tpmcontrol/polkit/org.deepin.filemanager.tpmcontrol.policy
+++ b/src/services/tpmcontrol/polkit/org.deepin.filemanager.tpmcontrol.policy
@@ -23,9 +23,9 @@
   <action id="org.deepin.Filemanager.TPMControl.Encrypt">
     <description>Encrypt data with TPM</description>
     <message>Authentication is required to encrypt data with TPM</message>
-    <message xml:lang="zh_CN">使用 TPM 加密数据需要管理员认证</message>
-    <message xml:lang="zh_HK">使用 TPM 加密數據需要管理員認證</message>
-    <message xml:lang="zh_TW">使用 TPM 加密資料需要管理員認證</message>
+    <message xml:lang="zh_CN">TPM 加密需要管理员认证</message>
+    <message xml:lang="zh_HK">TPM 加密需要管理員認證</message>
+    <message xml:lang="zh_TW">TPM 加密需要管理員認證</message>
     <icon_name>folder</icon_name>
     <defaults>
       <allow_any>no</allow_any>
@@ -37,9 +37,9 @@
   <action id="org.deepin.Filemanager.TPMControl.Decrypt">
     <description>Decrypt data with TPM</description>
     <message>Authentication is required to decrypt data with TPM</message>
-    <message xml:lang="zh_CN">使用 TPM 解密数据需要管理员认证</message>
-    <message xml:lang="zh_HK">使用 TPM 解密數據需要管理員認證</message>
-    <message xml:lang="zh_TW">使用 TPM 解密資料需要管理員認證</message>
+    <message xml:lang="zh_CN">TPM 解密需要管理员认证</message>
+    <message xml:lang="zh_HK">TPM 解密需要管理員認證</message>
+    <message xml:lang="zh_TW">TPM 解密需要管理員認證</message>
     <icon_name>folder</icon_name>
     <defaults>
       <allow_any>no</allow_any>


### PR DESCRIPTION
Updated user interface text for disk encryption features to improve
clarity and consistency. Changed the decryption dialog title to
explicitly mention "partition" for better user understanding. Modified
authentication messages to use "PIN code" instead of "passphrase"
for consistency with other system terminology. Simplified TPM-related
authentication messages by removing redundant "data" references.

Log: Improved disk encryption UI text clarity and consistency

Influence:
1. Verify decryption dialog displays correct title with partition
reference
2. Test authentication prompts show updated PIN code terminology
3. Confirm TPM encryption/decryption authentication messages are
simplified
4. Check all language variants display correctly (zh_CN, zh_HK, zh_TW)

docs: 改进磁盘加密界面文本清晰度

更新磁盘加密功能的用户界面文本以提高清晰度和一致性。修改解密对话框标题明
确提及"分区"以便用户更好理解。更改认证消息使用"PIN码"而非"密码短语"以保
持与其他系统术语的一致性。简化TPM相关认证消息，移除冗余的"数据"引用。

Log: 改进磁盘加密界面文本清晰度和一致性

Influence:
1. 验证解密对话框显示正确的包含分区引用的标题
2. 测试认证提示显示更新的PIN码术语
3. 确认TPM加密/解密认证消息已简化
4. 检查所有语言变体显示正确（zh_CN、zh_HK、zh_TW）

BUG: https://pms.uniontech.com/bug-view-344119.html BUG: https://pms.uniontech.com/bug-view-340325.html

## Summary by Sourcery

Clarify disk encryption and TPM-related UI and authentication messaging for better user understanding and terminology consistency.

Bug Fixes:
- Ensure decryption confirmation dialog explicitly identifies the target as a specific partition to reduce ambiguity for users.

Enhancements:
- Align disk encryption authentication prompts with system terminology by using consistent PIN code wording and simplifying TPM encryption/decryption messages across supported locales.