### PR TITLE
fix: update DBus service names for shutdown interface

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -25,13 +25,13 @@
 #include <DUtil>
 
 #ifdef COMPILE_ON_V2X
-#    define APP_MANAGER_SERVICE "org.deepin.dde.SessionManager1"
-#    define APP_MANAGER_PATH "/org/deepin/dde/SessionManager1"
-#    define APP_MANAGER_INTERFACE "org.deepin.dde.SessionManager1"
+#    define DDE_SHUTDOWN_SERVICE "org.deepin.dde.ShutdownFront1"
+#    define DDE_SHUTDOWN_PATH "/org/deepin/dde/ShutdownFront1"
+#    define DDE_SHUTDOWN_INTERFACE "org.deepin.dde.ShutdownFront1"
 #else
-#    define APP_MANAGER_SERVICE "com.deepin.SessionManager"
-#    define APP_MANAGER_PATH "/com/deepin/SessionManager"
-#    define APP_MANAGER_INTERFACE "com.deepin.SessionManager"
+#    define DDE_SHUTDOWN_SERVICE "com.deepin.ShutdownFront"
+#    define DDE_SHUTDOWN_PATH "/com/deepin/ShutdownFront"
+#    define DDE_SHUTDOWN_INTERFACE "com.deepin.ShutdownFront"
 #endif
 
 Q_DECLARE_METATYPE(QString *)
@@ -600,10 +600,10 @@ void EventsHandler::showChgPwdError(const QString &dev, const QString &devName, 
 void EventsHandler::requestReboot()
 {
     fmInfo() << "Requesting system reboot";
-    QDBusInterface sessMng(APP_MANAGER_SERVICE,
-                           APP_MANAGER_PATH,
-                           APP_MANAGER_INTERFACE);
-    sessMng.asyncCall("RequestReboot");
+    QDBusInterface sessMng(DDE_SHUTDOWN_SERVICE,
+                           DDE_SHUTDOWN_PATH,
+                           DDE_SHUTDOWN_INTERFACE);
+    sessMng.asyncCall("Restart");
 }
 
 bool EventsHandler::canUnlock(const QString &device)


### PR DESCRIPTION
Changed DBus service names and method calls from SessionManager to
ShutdownFront for better alignment with actual system shutdown services.
The previous service names were incorrect for reboot functionality,
which could cause the reboot request to fail. Updated both V2X and
non-V2X compilation paths to use the appropriate shutdown service
interfaces.

Log: Fixed system reboot functionality by using correct DBus service

Influence:
1. Test reboot functionality after disk encryption operations
2. Verify DBus service availability and method calls
3. Check system response to reboot requests
4. Ensure compatibility with both V2X and standard DDE environments

fix: 更新关机接口的 DBus 服务名称

将 DBus 服务名称和方法调用从 SessionManager 更改为 ShutdownFront，以更好
地与实际系统关机服务对齐。之前的服务名称对于重启功能不正确，可能导致重启
请求失败。更新了 V2X 和非 V2X 编译路径以使用适当的关机服务接口。

Log: 通过使用正确的 DBus 服务修复系统重启功能

Influence:
1. 测试磁盘加密操作后的重启功能
2. 验证 DBus 服务可用性和方法调用
3. 检查系统对重启请求的响应
4. 确保与 V2X 和标准 DDE 环境的兼容性

BUG: https://pms.uniontech.com/bug-view-342239.html

## Summary by Sourcery

Bug Fixes:
- Fix system reboot after disk encryption operations by calling the proper ShutdownFront DBus service and Restart method instead of the deprecated SessionManager RequestReboot call.