### PR TITLE
fix: fix selection artifact issue in file list view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -481,6 +481,9 @@ void ListItemDelegate::paintItemBackground(QPainter *painter, const QStyleOption
         painter->setRenderHints(QPainter::Antialiasing
                                 | QPainter::TextAntialiasing
                                 | QPainter::SmoothPixmapTransform);
+        // Clip to the item rect to prevent anti-aliased rounded corner pixels from
+        // bleeding into adjacent rows and leaving selection color artifacts after deselection.
+        painter->setClipRect(option.rect);
 
         painter->fillPath(path, adjustColor);
     }


### PR DESCRIPTION
Fixed a visual artifact issue where anti-aliased rounded corners of
selected items would leave residual selection colors on adjacent rows
after deselection. Added clip rect to painter to confine painting
operations within the item's boundaries while maintaining proper spacing
between items in multi-selection scenarios.

The previous implementation without clipping allowed anti-aliasing
pixels to extend beyond the item's rectangle, causing visual artifacts.
Using clip rect instead of shrinking the painting rectangle preserves
the intended spacing between items in multi-selection mode.

Influence:
1. Test single item selection and deselection to verify no residual
colors remain
2. Test multi-item selection to ensure proper spacing between selected
items
3. Verify rounded corners render correctly without visual artifacts
4. Test selection behavior with various file types and view modes
5. Check that item backgrounds are properly confined to their respective
areas

fix: 修复文件列表视图中的选择残留问题

修复了在选择项取消选择后，抗锯齿圆角像素会渗透到相邻行并留下选择颜色残留
的视觉问题。通过为绘制器设置裁剪矩形，将绘制操作限制在项目边界内，同时在
多选模式下保持项目之间的适当间距。

之前的实现没有使用裁剪，导致抗锯齿像素超出项目矩形范围，产生视觉残留。使
用裁剪矩形而非缩小绘制区域的方法可以保持多选模式下项目之间的预期间距。

Influence:
1. 测试单选项目的选择和取消选择，验证无残留颜色
2. 测试多项目选择，确保选中项目间有适当间距
3. 验证圆角渲染正确无误视问题
4. 使用不同文件类型和视图模式测试选择行为
5. 检查项目背景是否正确地限制在各自区域内

BUG: https://pms.uniontech.com/bug-view-332513.html

## Summary by Sourcery

Bug Fixes:
- Ensure selection backgrounds in the file list view no longer bleed into adjacent rows after deselection due to anti-aliased rounded corners.