### PR TITLE
Optimization of searchedit and address bar interaction

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
@@ -493,20 +493,6 @@ void AddressBar::focusInEvent(QFocusEvent *e)
 
 void AddressBar::focusOutEvent(QFocusEvent *e)
 {
-    // blumia: Sometimes completion will trigger weird Qt::ActiveWindowFocusReason event,
-    //         right click context menu will trigger Qt::PopupFocusReason event. It will
-    //         cause focusOutEvent. So we simply ignore it here.
-    // blumia: 2019/12/01: seems now based on current 5.11.3.2+c1-1+deepin version of Qt,
-    //         completion will no longer trigger Qt::ActiveWindowFocusReason reason focus
-    //         out event, so we comment out this case for now and see if it still happens.
-    // fix bug#38455 文管启动后第一次点击搜索，再点击筛选按钮，会导致搜索框隐藏
-    // 第一次点击筛选按钮，会发出Qt::OtherFocusReason信号导致搜索框隐藏，所以将其屏蔽
-    // zhangs: 2024/04/09：On wayland `Qt::ActiveWindowFocusReason` is triggered again! （bug-249081）
-    if (e->reason() == Qt::ActiveWindowFocusReason || e->reason() == Qt::PopupFocusReason) {
-        e->accept();
-        setFocus();
-        return;
-    }
     d->completionPrefix.clear();
     d->completerView->hide();
     if (d->isKeepVisible) {

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
@@ -31,6 +31,7 @@
 #include <QClipboard>
 #include <QPushButton>
 #include <QMouseEvent>
+#include <QContextMenuEvent>
 #include <QUrlQuery>
 
 using namespace dfmplugin_titlebar;
@@ -347,11 +348,6 @@ void CrumbBar::mousePressEvent(QMouseEvent *event)
 {
     d->clickedPos = event->globalPosition().toPoint();
 
-    if (event->button() == Qt::RightButton && d->clickableAreaEnabled) {
-        event->accept();
-        return;
-    }
-
     auto button = d->buttonAt(event->pos());
     if (event->button() != Qt::RightButton || !button) {
         QFrame::mousePressEvent(event);
@@ -369,6 +365,38 @@ void CrumbBar::mouseReleaseEvent(QMouseEvent *event)
             emit editUrl(urlToEdit);
         });
     }
+}
+
+void CrumbBar::contextMenuEvent(QContextMenuEvent *event)
+{
+    // 检查点击位置是否在按钮上
+    auto button = d->buttonAt(event->pos());
+    if (button) {
+        // 如果点击在按钮上，让按钮自己处理右键菜单
+        QFrame::contextMenuEvent(event);
+        return;
+    }
+
+    // 点击在空白区域，显示完整路径的右键菜单
+    event->accept();
+
+    // 使用原始完整 URL，提供回退逻辑
+    QUrl urlToShow = d->editableUrl.isEmpty() ? d->lastUrl : d->editableUrl;
+
+    if (!urlToShow.isValid()) {
+        return;
+    }
+
+    // 设置弹出菜单可见状态
+    setPopupVisible(true);
+
+    // 创建并显示菜单
+    QMenu menu(this);
+    customMenu(urlToShow, &menu);
+    menu.exec(event->globalPos());
+
+    // 恢复状态
+    setPopupVisible(false);
 }
 
 void CrumbBar::resizeEvent(QResizeEvent *event)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.cpp
@@ -328,7 +328,8 @@ void CrumbBar::customMenu(const QUrl &url, QMenu *menu)
 
     menu->addSeparator();
 
-    QUrl fullUrl = d->lastUrl;
+    // 使用原始完整 URL 进行编辑，提供回退逻辑
+    QUrl fullUrl = d->editableUrl.isEmpty() ? d->lastUrl : d->editableUrl;
     menu->addAction(editIcon, QObject::tr("Edit address"), this, [this, fullUrl]() {
         emit this->editUrl(fullUrl);
     });
@@ -363,7 +364,9 @@ void CrumbBar::mouseReleaseEvent(QMouseEvent *event)
 
     if (event->button() == Qt::LeftButton) {
         QTimer::singleShot(0, this, [this]() {
-            editUrl(d->lastUrl);
+            // 使用原始完整 URL 进行编辑，提供回退逻辑
+            QUrl urlToEdit = d->editableUrl.isEmpty() ? d->lastUrl : d->editableUrl;
+            emit editUrl(urlToEdit);
         });
     }
 }
@@ -417,6 +420,9 @@ void CrumbBar::leaveEvent(QEvent *event)
 
 void CrumbBar::onUrlChanged(const QUrl &url)
 {
+    // 保存原始完整 URL 用于编辑
+    d->editableUrl = url;
+
     auto sourceUrl = url;
     if (TitleBarHelper::checkKeepTitleStatus(url)) {
         QUrlQuery query { url.query() };

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/crumbbar.h
@@ -46,6 +46,7 @@ protected:
     void paintEvent(QPaintEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void contextMenuEvent(QContextMenuEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void showEvent(QShowEvent *event) override;
     bool eventFilter(QObject *watched, QEvent *event) override;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/crumbbar_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/crumbbar_p.h
@@ -29,7 +29,8 @@ class CrumbBarPrivate
     QHBoxLayout *crumbBarLayout;
     QPoint clickedPos;
     bool clickableAreaEnabled { false };
-    QUrl lastUrl;
+    QUrl lastUrl;        // 用于面包屑显示的 URL
+    QUrl editableUrl;    // 用于地址栏编辑的原始完整 URL
     bool hoverFlag { false };   // 鼠标是否悬停在按钮上
     bool popupVisible { false };
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -186,8 +186,8 @@ void SearchEditWidget::onTextEdited(const QString &text)
     pendingSearchText = text;
 
     if (text.isEmpty()) {
-        fmDebug() << "Search text is empty, stopping timer and stopping search";
-        stopSearch();
+        fmDebug() << "Search text is empty, stopping timer and quitting search";
+        quitSearch();
         return;
     }
 
@@ -254,6 +254,17 @@ bool SearchEditWidget::eventFilter(QObject *watched, QEvent *event)
         } else if (event->type() == QEvent::KeyPress) {
             QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
             if (keyEvent->key() == Qt::Key_Escape) {
+                // If SearchEdit is empty, deactivate and exit edit mode
+                if (searchEdit->text().isEmpty()) {
+                    fmDebug() << "ESC key pressed with empty search edit, deactivating and quitting search";
+                    isUserDeactivating = true;
+                    deactivateEdit();
+                    isUserDeactivating = false;
+                    // Emit searchQuit to exit search view
+                    Q_EMIT searchQuit();
+                    return true;
+                }
+                // If SearchEdit has text, clear it and quit search
                 fmDebug() << "ESC key pressed in search edit, quitting search";
                 quitSearch();
                 return true;
@@ -346,23 +357,6 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
         updateSpacing(false);   // Advanced button is now hidden
     }
 
-    // Helper lambda to restore focus if needed
-    auto restoreFocusIfNeeded = [this]() {
-        QTimer::singleShot(0, this, [this]() {
-            QWidget *newFocus = QApplication::focusWidget();
-            // Allow focus transfer to other edit controls (e.g., AddressBar)
-            if (newFocus && newFocus != searchEdit->lineEdit()
-                && newFocus->inherits("QLineEdit")) {
-                return;
-            }
-            // If no widget has focus or focus went to non-edit widget, restore focus
-            // This handles the case where layout changes (AddressBar hiding) steal focus
-            if (!newFocus || (!newFocus->inherits("QLineEdit") && !newFocus->inherits("QPushButton"))) {
-                searchEdit->lineEdit()->setFocus(Qt::OtherFocusReason);
-            }
-        });
-    };
-
     // Handle special focus reasons that should not trigger collapse
     if (e->reason() == Qt::PopupFocusReason || e->reason() == Qt::ActiveWindowFocusReason) {
         e->accept();
@@ -386,6 +380,28 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
     if (parentWidget()) {
         updateSearchEditWidget(parentWidget()->width());
     }
+}
+
+void SearchEditWidget::restoreFocusIfNeeded()
+{
+    // Don't restore focus if user is intentionally deactivating
+    if (isUserDeactivating) {
+        return;
+    }
+
+    QTimer::singleShot(0, this, [this]() {
+        QWidget *newFocus = QApplication::focusWidget();
+        // Allow focus transfer to other edit controls (e.g., AddressBar)
+        if (newFocus && newFocus != searchEdit->lineEdit()
+            && newFocus->inherits("QLineEdit")) {
+            return;
+        }
+        // If no widget has focus or focus went to non-edit widget, restore focus
+        // This handles the case where layout changes (AddressBar hiding) steal focus
+        if (!newFocus || (!newFocus->inherits("QLineEdit") && !newFocus->inherits("QPushButton"))) {
+            searchEdit->lineEdit()->setFocus(Qt::OtherFocusReason);
+        }
+    });
 }
 
 void SearchEditWidget::handleInputMethodEvent(QInputMethodEvent *e)
@@ -425,7 +441,6 @@ void SearchEditWidget::quitSearch()
 {
     lastSearchTime = 0;
     delayTimer->stop();
-    // deactivateEdit();
     Q_EMIT searchQuit();
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -348,12 +348,19 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
 
     // Helper lambda to restore focus if needed
     auto restoreFocusIfNeeded = [this]() {
-        if (!searchEdit->text().isEmpty()) {
-            // Use QTimer to defer the focus restoration to ensure proper cursor blink
-            QTimer::singleShot(0, this, [this]() {
+        QTimer::singleShot(0, this, [this]() {
+            QWidget *newFocus = QApplication::focusWidget();
+            // Allow focus transfer to other edit controls (e.g., AddressBar)
+            if (newFocus && newFocus != searchEdit->lineEdit()
+                && newFocus->inherits("QLineEdit")) {
+                return;
+            }
+            // If no widget has focus or focus went to non-edit widget, restore focus
+            // This handles the case where layout changes (AddressBar hiding) steal focus
+            if (!newFocus || (!newFocus->inherits("QLineEdit") && !newFocus->inherits("QPushButton"))) {
                 searchEdit->lineEdit()->setFocus(Qt::OtherFocusReason);
-            });
-        }
+            }
+        });
     };
 
     // Handle special focus reasons that should not trigger collapse

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
@@ -70,6 +70,8 @@ private:
     void handleFocusOutEvent(QFocusEvent *e);
     void handleInputMethodEvent(QInputMethodEvent *e);
 
+    void restoreFocusIfNeeded();
+
     void updateSearchWidgetLayout();
     void quitSearch();
     void stopSearch();
@@ -102,6 +104,7 @@ private:
     SearchMode currentMode { SearchMode::kUnknown };
     QTimer *delayTimer { nullptr };
     qint64 lastSearchTime { 0 };
+    bool isUserDeactivating { false };   // Flag to indicate user intentionally deactivating edit mode
 };
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -271,7 +271,9 @@ void TitleBarWidget::handleHotketCreateNewTab()
         }
     }
 
-    openNewTab(currentUrl());
+    // Use crumbBar's lastUrl() to avoid reopening search:// URLs
+    // which would trigger unnecessary search operations
+    openNewTab(crumbBar ? crumbBar->lastUrl() : currentUrl());
 }
 
 void TitleBarWidget::handleCreateTabList(const QList<QUrl> &urlList)
@@ -680,6 +682,9 @@ void TitleBarWidget::onTabCloseRequested(int index)
 void TitleBarWidget::onTabAddButtonClicked()
 {
     QUrl url = Application::instance()->appUrlAttribute(Application::kUrlOfNewTab);
+    if (!url.isValid() && crumbBar)
+        url = crumbBar->lastUrl();
+
     auto tabUrl = tabBar()->tabUrl(tabBar()->currentIndex());
     if (!url.isValid() && tabUrl.isValid())
         url = tabUrl;


### PR DESCRIPTION
## Summary by Sourcery

Optimize interaction between the search box, address bar, and title bar navigation to avoid unintended search exits and improve URL editing behavior.

Bug Fixes:
- Prevent search from being prematurely stopped when the search text is cleared or focus changes unintentionally.
- Allow ESC in the search box to either clear search or exit edit mode depending on whether there is text, avoiding inconsistent deactivation.
- Fix focus handling so that switching between the search box and address bar does not steal or lose focus unexpectedly.
- Ensure editing the address bar uses the original full URL instead of a processed breadcrumb URL, preserving a correct fallback when editing.
- Avoid opening new tabs with search URLs, preventing unnecessary re-triggering of search operations.
- Provide a fallback URL for the new tab button when the configured new-tab URL is invalid, using the crumb bar’s last visited URL.