### PR TITLE
fix: prevent use-after-free in file view model prehandlers

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -161,9 +161,17 @@ QModelIndex FileViewModel::setRootUrl(const QUrl &url)
             if (prehandler) {
                 fmDebug() << "Executing prehandler for scheme:" << url.scheme();
                 quint64 winId = FileManagerWindowsManager::instance().findWindowId(qobject_cast<FileView *>(QObject::parent()));
-                prehandler(winId, url, [this]() {
+
+                // Use QPointer to safely capture this pointer for async callback
+                QPointer<FileViewModel> self(this);
+                prehandler(winId, url, [self]() {
+                    // Check if object is still valid before accessing members
+                    if (!self) {
+                        fmWarning() << "FileViewModel destroyed before prehandler callback, ignoring";
+                        return;
+                    }
                     // 预处理完成后执行加载
-                    this->executeLoad();
+                    self->executeLoad();
                 });
                 return rootIndex();   // 返回当前索引，保持UI状态
             }
@@ -195,10 +203,18 @@ QModelIndex FileViewModel::setRootUrl(const QUrl &url)
         if (prehandler) {
             fmDebug() << "Executing prehandler for scheme:" << url.scheme();
             quint64 winId = FileManagerWindowsManager::instance().findWindowId(qobject_cast<FileView *>(QObject::parent()));
-            prehandler(winId, url, [this, index, url]() {
-                this->canFetchFiles = true;
-                this->fetchingUrl = url;
-                this->fetchMore(index);
+
+            // Use QPointer to safely capture this pointer for async callback
+            QPointer<FileViewModel> self(this);
+            prehandler(winId, url, [self, index, url]() {
+                // Check if object is still valid before accessing members
+                if (!self) {
+                    fmWarning() << "FileViewModel destroyed before prehandler callback, ignoring";
+                    return;
+                }
+                self->canFetchFiles = true;
+                self->fetchingUrl = url;
+                self->fetchMore(index);
             });
         }
     } else {


### PR DESCRIPTION
Fixed potential use-after-free crashes in FileViewModel by using QPointer to safely capture the 'this' pointer in asynchronous prehandler callbacks. When the prehandler completes asynchronously, the FileViewModel instance might have been destroyed, leading to crashes when accessing member variables.

The changes add QPointer wrapping around 'this' and check for object validity before accessing any members in the callback. This ensures safe destruction handling and prevents crashes when the model is destroyed while prehandlers are still pending.

Log: Fixed potential crashes when switching file views quickly

Influence:
1. Test rapid file view switching between different locations
2. Verify no crashes occur when navigating away during prehandler execution
3. Test file operations with slow network locations or delayed prehandlers
4. Verify model destruction during async operations doesn't cause crashes
5. Test with various file schemes that use prehandlers

fix: 修复文件视图模型预处理器中的潜在悬空指针问题

通过使用 QPointer 安全地捕获异步预处理器回调中的 'this' 指针，修复了
FileViewModel 中潜在的悬空指针使用导致的崩溃问题。当预处理器异步完成时，
FileViewModel 实例可能已被销毁，导致访问成员变量时发生崩溃。

此次更改添加了 QPointer 包装 'this' 指针，并在回调中访问任何成员之前检查
对象有效性。这确保了安全的析构处理，防止在预处理器仍处于挂起状态时模型被
销毁导致的崩溃。

Log: 修复快速切换文件视图时可能出现的崩溃问题

Influence:
1. 测试在不同位置之间快速切换文件视图
2. 验证在预处理器执行期间导航离开不会导致崩溃
3. 测试使用慢速网络位置或延迟预处理器的文件操作
4. 验证在异步操作期间模型销毁不会导致崩溃
5. 测试使用各种需要预处理器的文件方案

## Summary by Sourcery

Bug Fixes:
- Prevent crashes caused by accessing FileViewModel after destruction in asynchronous prehandler callbacks for setting the root URL.