### PR TITLE
fix: improve filename validation and editing behavior

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -76,61 +76,58 @@ void NameTextEdit::slotTextChanged()
     QSignalBlocker blocker(this);
     Q_UNUSED(blocker)
 
-    QString text = this->toPlainText();
-    const QString old_text = text;
-
-    int text_length = text.length();
-
-    text.remove('/');
+    // Step 1: Strip characters that are always illegal in filenames
+    QString text = toPlainText();
+    const int origLen = text.length();
     text.remove(QChar(0));
 
-    int cursor_pos = this->textCursor().position() - text_length + text.length();
+    // Adjust cursor for the characters just removed
+    int endPos = textCursor().position() - (origLen - text.length());
 
-    while (textLength(text) > NAME_MAX) {
-        text.chop(1);
+    // Step 2: Strip config-defined illegal characters (e.g. \:*"?<>|)
+    const QString dstText = FileUtils::preprocessingFileName(text);
+    const bool hasInvalidChar = (text != dstText);
+    endPos += dstText.length() - text.length();
+    text = dstText;
+
+    // Step 3: Enforce NAME_MAX, protecting the suffix from being truncated.
+    //   Split text into base + dotSuffix, apply processLength only to base,
+    //   then reattach dotSuffix.
+    const QString dotSuffix = (!fileSuffix.isEmpty() && text.endsWith("." + fileSuffix))
+            ? ("." + fileSuffix)
+            : QString();
+    if (!dotSuffix.isEmpty()) {
+        QString base = text.left(text.length() - dotSuffix.length());
+        int basePos = qMin(endPos, static_cast<int>(base.length()));
+        FileUtils::processLength(base, basePos, NAME_MAX - textLength(dotSuffix),
+                                 useCharCount, base, basePos);
+        text = base + dotSuffix;
+        endPos = basePos;
+    } else {
+        FileUtils::processLength(text, endPos, NAME_MAX, useCharCount, text, endPos);
     }
 
-    if (text.size() != old_text.size()) {
-        this->setPlainText(text);
+    // Step 4: Apply changes to the editor
+    if (text != toPlainText()) {
+        setPlainText(text);
     }
 
-    QTextCursor cursor = this->textCursor();
-
+    QTextCursor cursor = textCursor();
     cursor.movePosition(QTextCursor::Start);
-
     do {
-        QTextBlockFormat format = cursor.blockFormat();
-
-        format.setLineHeight(kTextLineHeight, QTextBlockFormat::FixedHeight);
-        cursor.setBlockFormat(format);
+        QTextBlockFormat fmt = cursor.blockFormat();
+        fmt.setLineHeight(kTextLineHeight, QTextBlockFormat::FixedHeight);
+        cursor.setBlockFormat(fmt);
     } while (cursor.movePosition(QTextCursor::NextBlock));
+    cursor.setPosition(endPos);
+    setTextCursor(cursor);
+    setAlignment(Qt::AlignHCenter);
 
-    cursor.setPosition(cursor_pos);
+    if (isReadOnly())
+        setFixedHeight(static_cast<int>(document()->size().height()));
 
-    this->setTextCursor(cursor);
-    this->setAlignment(Qt::AlignHCenter);
-
-    if (this->isReadOnly())
-        this->setFixedHeight(static_cast<int>(this->document()->size().height()));
-
-    QString dstText = FileUtils::preprocessingFileName(text);
-
-    bool hasInvalidChar = text != dstText;
-
-    int endPos = this->textCursor().position() + (dstText.length() - text.length());
-
-    FileUtils::processLength(dstText, endPos, NAME_MAX, true, dstText, endPos);
-    if (text != dstText) {
-        this->setPlainText(dstText);
-        QTextCursor cursor = this->textCursor();
-        cursor.setPosition(endPos);
-        this->setTextCursor(cursor);
-        this->setAlignment(Qt::AlignHCenter);
-    }
-
-    if (hasInvalidChar) {
+    if (hasInvalidChar)
         showAlertMessage(tr("%1 are not allowed").arg("|/\\*:\"'?<>"));
-    }
 }
 
 void NameTextEdit::showAlertMessage(const QString &text, int duration)
@@ -152,7 +149,11 @@ void NameTextEdit::showAlertMessage(const QString &text, int duration)
         label->adjustSize();
     }
 
-    QPoint pos = this->mapToGlobal(QPoint(this->width() / 2, this->height()));
+    if (!this->window())
+        return;
+
+    tooltip->setParent(this->window());
+    QPoint pos = this->mapTo(this->window(), QPoint(this->width() / 2, this->height()));
     tooltip->show(pos.x(), pos.y());
 }
 
@@ -298,17 +299,19 @@ void EditStackedWidget::renameFile()
     if (FileUtils::supportLongName(fileUrl))
         fileNameEdit->setCharCountLimit();
 
+    // Store the suffix so that slotTextChanged() can protect it from truncation
+    fileNameEdit->setSuffix(info.suffix());
     fileNameEdit->setPlainText(info.fileName());
     this->setCurrentIndex(0);
     fileNameEdit->setFixedHeight(textShowFrame->height());
     fileNameEdit->setFocus();
 
-    fileNameEdit->selectAll();
-    int endPos = fileNameEdit->toPlainText().length();
-
+    // Select only the base name (everything before the last extension),
+    // leaving the suffix unselected so the user doesn't accidentally overwrite it.
+    const QString baseName = info.completeBaseName();
     QTextCursor cursor = fileNameEdit->textCursor();
     cursor.setPosition(0);
-    cursor.setPosition(endPos, QTextCursor::KeepAnchor);
+    cursor.setPosition(baseName.length(), QTextCursor::KeepAnchor);
     fileNameEdit->setTextCursor(cursor);
 }
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.h
@@ -28,6 +28,12 @@ public:
     bool isCanceled() const;
     void setIsCanceled(bool isCancele);
     inline void setCharCountLimit() { useCharCount = true; }
+    /**
+     * @brief setSuffix Sets the known file suffix so that length enforcement
+     *        will never truncate into the extension.
+     * @param suffix The suffix string WITHOUT the leading dot (e.g. "txt").
+     */
+    inline void setSuffix(const QString &suffix) { fileSuffix = suffix; }
 
 signals:
     void editFinished();
@@ -50,6 +56,9 @@ private:
 
     bool isCancel = false;
     bool useCharCount = false;
+
+    // Stores the original file suffix to prevent truncation from eating the extension
+    QString fileSuffix {};
 
     DTK_WIDGET_NAMESPACE::DArrowRectangle *tooltip { nullptr };
 };


### PR DESCRIPTION
Refactored the filename validation logic in EditStackedWidget to handle
file extensions more intelligently. The changes include:
1. Reorganized the validation sequence to first remove illegal
characters, then handle length constraints
2. Added protection for file extensions during length truncation to
prevent corrupting file types
3. Improved cursor positioning logic to maintain proper text selection
4. Enhanced tooltip positioning to work correctly with parent windows
5. Modified text selection behavior to only select the base filename
during rename operations

The previous implementation had issues with filename truncation that
could corrupt file extensions and inconsistent validation ordering.
The new approach ensures file extensions are preserved while enforcing
filename length limits and character restrictions.

Log: Improved filename editing with better extension protection and
validation

Influence:
1. Test renaming files with various extensions to ensure they are
preserved
2. Verify that illegal characters are properly filtered out
3. Test filename length limits with files that have long names and
extensions
4. Check cursor positioning and text selection behavior during editing
5. Validate tooltip display for invalid filename characters
6. Test with files that have multiple dots in the filename

fix: 改进文件名验证和编辑行为

重构了 EditStackedWidget 中的文件名验证逻辑，以更智能地处理文件扩展名。
更改包括：
1. 重新组织验证顺序，先移除非法字符，再处理长度约束
2. 在长度截断期间添加对文件扩展名的保护，防止损坏文件类型
3. 改进光标定位逻辑以保持正确的文本选择
4. 增强工具提示定位，使其能正确与父窗口配合工作
5. 修改文本选择行为，在重命名操作中仅选择基本文件名

之前的实现在文件名截断方面存在问题，可能损坏文件扩展名且验证顺序不一致。
新方法确保在强制执行文件名长度限制和字符限制的同时保护文件扩展名。

Log: 改进文件名编辑，提供更好的扩展名保护和验证

Influence:
1. 测试重命名具有各种扩展名的文件，确保扩展名被保留
2. 验证非法字符是否被正确过滤
3. 测试具有长名称和扩展名的文件的文件名长度限制
4. 检查编辑期间的光标定位和文本选择行为
5. 验证无效文件名字符的工具提示显示
6. 测试文件名中包含多个点号的文件

BUG: https://pms.uniontech.com/bug-view-321657.html
