### PR TITLE
fix: fix notification issues according to XDG specification

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -213,11 +213,12 @@ bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer &dir)
     if (!stateCheck())
         return false;
 
-    fmDebug() << "Deleting directory recursively:" << dir->urlOf(UrlInfoType::kUrl);
+    const QUrl dirUrl = dir->urlOf(UrlInfoType::kUrl);
+    fmDebug() << "Deleting directory recursively:" << dirUrl;
 
     if (dir->countChildFile() < 0) {
-        fmDebug() << "Directory has no children, treating as file:" << dir->urlOf(UrlInfoType::kUrl);
-        return deleteFileOnOtherDevice(dir->urlOf(UrlInfoType::kUrl));
+        fmDebug() << "Directory has no children, treating as file:" << dirUrl;
+        return deleteFileOnOtherDevice(dirUrl);
     }
 
     AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
@@ -225,26 +226,54 @@ bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer &dir)
     do {
         action = AbstractJobHandler::SupportAction::kNoAction;
         QString errorMsg;
-        iterator = DirIteratorFactory::create<AbstractDirIterator>(dir->urlOf(UrlInfoType::kUrl), &errorMsg);
+        iterator = DirIteratorFactory::create<AbstractDirIterator>(dirUrl, &errorMsg);
         if (!iterator) {
-            fmWarning() << "Create directory iterator failed - dir:" << dir->urlOf(UrlInfoType::kUrl) << "error:" << errorMsg;
-            action = doHandleErrorAndWait(dir->urlOf(UrlInfoType::kUrl), AbstractJobHandler::JobErrorType::kDeleteFileError, errorMsg);
+            fmWarning() << "Create directory iterator failed - dir:" << dirUrl << "error:" << errorMsg;
+            action = doHandleErrorAndWait(dirUrl, AbstractJobHandler::JobErrorType::kDeleteFileError, errorMsg);
         }
     } while (!isStopped() && action == AbstractJobHandler::SupportAction::kRetryAction);
 
     if (action == AbstractJobHandler::SupportAction::kSkipAction) {
-        fmInfo() << "Skipped deleting directory:" << dir->urlOf(UrlInfoType::kUrl);
+        fmInfo() << "Skipped deleting directory:" << dirUrl;
         return true;
     }
     if (action != AbstractJobHandler::SupportAction::kNoAction)
         return false;
 
+    QList<QUrl> childUrls;
+    const qint64 expectedChildren = dir->countChildFile();
+    if (expectedChildren > 0)
+        childUrls.reserve(static_cast<int>(expectedChildren));
+
+    fmDebug() << "Taking child snapshot before delete:" << dirUrl << "expected child count:" << expectedChildren;
+    while (iterator->hasNext()) {
+        if (!stateCheck())
+            return false;
+
+        const QUrl url = iterator->next();
+        if (!url.isValid()) {
+            const QString errorMsg = QStringLiteral("Directory iterator returned an invalid child while deleting directory");
+            fmWarning() << "Invalid child returned by directory iterator - dir:" << dirUrl << "collected children:" << childUrls.count();
+            action = doHandleErrorAndWait(dirUrl, AbstractJobHandler::JobErrorType::kDeleteFileError, errorMsg);
+            if (action == AbstractJobHandler::SupportAction::kRetryAction)
+                return deleteDirOnOtherDevice(dir);
+            if (action == AbstractJobHandler::SupportAction::kSkipAction)
+                return true;
+            return false;
+        }
+
+        childUrls.append(url);
+    }
+
+    fmDebug() << "Directory child snapshot completed:" << dirUrl << "snapshot count:" << childUrls.count();
+
     bool ok { true };
     int childCount = 0;
-    while (iterator->hasNext()) {
-        const QUrl &url = iterator->next();
-        childCount++;
+    for (const QUrl &url : childUrls) {
+        if (!stateCheck())
+            return false;
 
+        childCount++;
         const auto &info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
         if (!info) {
             fmCritical() << "Failed to create file info for directory child - URL:" << url;
@@ -270,10 +299,10 @@ bool DoDeleteFilesWorker::deleteDirOnOtherDevice(const FileInfoPointer &dir)
         }
     }
 
-    fmDebug() << "Deleted" << childCount << "children from directory:" << dir->urlOf(UrlInfoType::kUrl);
+    fmDebug() << "Deleted" << childCount << "children from directory:" << dirUrl;
 
     // delete self dir
-    return deleteFileOnOtherDevice(dir->urlOf(UrlInfoType::kUrl));
+    return deleteFileOnOtherDevice(dirUrl);
 }
 /*!
  * \brief DoCopyFilesWorker::doHandleErrorAndWait Blocking handles errors and returns

--- a/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
@@ -17,6 +17,8 @@
 
 #include <QAbstractItemView>
 #include <QDBusInterface>
+#include <QDBusPendingReply>
+#include <QDBusPendingCallWatcher>
 
 DFMBASE_USE_NAMESPACE
 using namespace ddplugin_organizer;
@@ -158,20 +160,20 @@ void FrameManagerPrivate::onHideAllKeyPressed()
     });
 
     if (!CfgPresenter->isRepeatNoMore() && aboutToHide) {
-        uint notifyId = QDate::currentDate().daysInYear();
+        const quint32 replacesId = hideAllNotifyId;
         QString keySequence = CfgPresenter->hideAllKeySequence().toString();
         QString tips = tr("To disable the One-Click Hide feature, invoke the \"Desktop Settings\" window "
                           "in the desktop context menu and turn off the \"One-Click Hide Collection\".");
         QString cmdNoRepeation = "dde-dconfig,--set,-a,org.deepin.dde.file-manager,-r,org.deepin.dde.file-manager.desktop.organizer,-k,hideAllDialogRepeatNoMore,-v,true";
         QString cmdCloseNotify = QString("dbus-send,--type=method_call,--dest=org.freedesktop.Notifications,/org/freedesktop/Notifications,com.deepin.dde.Notification.CloseNotification,uint32:%1")
-                                         .arg(notifyId);
-        DDBusSender()
+                                         .arg(replacesId);
+        QDBusPendingCall pendingReply = DDBusSender()
                 .service("org.freedesktop.Notifications")
                 .path("/org/freedesktop/Notifications")
                 .interface("org.freedesktop.Notifications")
                 .method(QString("Notify"))
                 .arg(tr("Desktop organizer"))
-                .arg(notifyId)
+                .arg(replacesId)
                 .arg(QString("deepin-toggle-desktop"))
                 .arg(tr("Shortcut \"%1\" to show collections").arg(keySequence))
                 .arg(tips)
@@ -180,6 +182,17 @@ void FrameManagerPrivate::onHideAllKeyPressed()
                                    { "x-deepin-action-close-notify", cmdCloseNotify } })
                 .arg(3000)
                 .call();
+        auto *watcher = new QDBusPendingCallWatcher(pendingReply, this);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher *watcher) {
+            QDBusPendingReply<uint> reply = *watcher;
+            if (reply.isError()) {
+                fmWarning() << "send organizer notification failed:" << reply.error().name() << reply.error().message();
+                hideAllNotifyId = 0;
+            } else {
+                hideAllNotifyId = reply.value();
+            }
+            watcher->deleteLater();
+        });
     }
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
@@ -16,12 +16,20 @@
 #include <DDBusSender>
 
 #include <QAbstractItemView>
+#include <QDBusConnection>
 #include <QDBusInterface>
 #include <QDBusPendingReply>
 #include <QDBusPendingCallWatcher>
+#include <functional>
+#include <memory>
 
 DFMBASE_USE_NAMESPACE
 using namespace ddplugin_organizer;
+
+namespace {
+constexpr int kHideAllNotificationTimeoutMs = 3000;
+constexpr int kHideAllNotificationExpireGraceMs = 100;
+}
 
 #define CanvasCoreSubscribe(topic, func) \
     dpfSignalDispatcher->subscribe("ddplugin_core", QT_STRINGIFY2(topic), this, func);
@@ -40,6 +48,19 @@ FrameManagerPrivate::FrameManagerPrivate(FrameManager *qq)
             organizer->layout();
         }
     });
+
+    hideAllNotifyExpireTimer = new QTimer(this);
+    hideAllNotifyExpireTimer->setSingleShot(true);
+    connect(hideAllNotifyExpireTimer, &QTimer::timeout, this, [this] {
+        hideAllNotifyId = 0;
+    });
+
+    QDBusConnection::sessionBus().connect(QString("org.freedesktop.Notifications"),
+                                          QString("/org/freedesktop/Notifications"),
+                                          QString("org.freedesktop.Notifications"),
+                                          QString("NotificationClosed"),
+                                          this,
+                                          SLOT(onNotificationClosed(uint, uint)));
 }
 
 FrameManagerPrivate::~FrameManagerPrivate()
@@ -160,40 +181,62 @@ void FrameManagerPrivate::onHideAllKeyPressed()
     });
 
     if (!CfgPresenter->isRepeatNoMore() && aboutToHide) {
-        const quint32 replacesId = hideAllNotifyId;
         QString keySequence = CfgPresenter->hideAllKeySequence().toString();
         QString tips = tr("To disable the One-Click Hide feature, invoke the \"Desktop Settings\" window "
                           "in the desktop context menu and turn off the \"One-Click Hide Collection\".");
         QString cmdNoRepeation = "dde-dconfig,--set,-a,org.deepin.dde.file-manager,-r,org.deepin.dde.file-manager.desktop.organizer,-k,hideAllDialogRepeatNoMore,-v,true";
-        QString cmdCloseNotify = QString("dbus-send,--type=method_call,--dest=org.freedesktop.Notifications,/org/freedesktop/Notifications,com.deepin.dde.Notification.CloseNotification,uint32:%1")
-                                         .arg(replacesId);
-        QDBusPendingCall pendingReply = DDBusSender()
-                .service("org.freedesktop.Notifications")
-                .path("/org/freedesktop/Notifications")
-                .interface("org.freedesktop.Notifications")
-                .method(QString("Notify"))
-                .arg(tr("Desktop organizer"))
-                .arg(replacesId)
-                .arg(QString("deepin-toggle-desktop"))
-                .arg(tr("Shortcut \"%1\" to show collections").arg(keySequence))
-                .arg(tips)
-                .arg(QStringList { "close-notify", tr("Close"), "no-repeat", tr("No more prompts") })
-                .arg(QVariantMap { { "x-deepin-action-no-repeat", cmdNoRepeation },
-                                   { "x-deepin-action-close-notify", cmdCloseNotify } })
-                .arg(3000)
-                .call();
-        auto *watcher = new QDBusPendingCallWatcher(pendingReply, this);
-        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher *watcher) {
-            QDBusPendingReply<uint> reply = *watcher;
-            if (reply.isError()) {
-                fmWarning() << "send organizer notification failed:" << reply.error().name() << reply.error().message();
-                hideAllNotifyId = 0;
-            } else {
+        auto sendHideAllNotification = std::make_shared<std::function<void(quint32, bool)>>();
+        *sendHideAllNotification = [this, keySequence, tips, cmdNoRepeation, sendHideAllNotification](quint32 replacesId, bool allowRetry) {
+            QString cmdCloseNotify = QString("dbus-send,--type=method_call,--dest=org.freedesktop.Notifications,/org/freedesktop/Notifications,com.deepin.dde.Notification.CloseNotification,uint32:%1")
+                                             .arg(replacesId);
+            QDBusPendingCall pendingReply = DDBusSender()
+                    .service("org.freedesktop.Notifications")
+                    .path("/org/freedesktop/Notifications")
+                    .interface("org.freedesktop.Notifications")
+                    .method(QString("Notify"))
+                    .arg(tr("Desktop organizer"))
+                    .arg(replacesId)
+                    .arg(QString("deepin-toggle-desktop"))
+                    .arg(tr("Shortcut \"%1\" to show collections").arg(keySequence))
+                    .arg(tips)
+                    .arg(QStringList { "close-notify", tr("Close"), "no-repeat", tr("No more prompts") })
+                    .arg(QVariantMap { { "x-deepin-action-no-repeat", cmdNoRepeation },
+                                       { "x-deepin-action-close-notify", cmdCloseNotify } })
+                    .arg(kHideAllNotificationTimeoutMs)
+                    .call();
+            auto *watcher = new QDBusPendingCallWatcher(pendingReply, this);
+            connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, replacesId, allowRetry, sendHideAllNotification](QDBusPendingCallWatcher *watcher) {
+                QDBusPendingReply<uint> reply = *watcher;
+                if (reply.isError()) {
+                    fmWarning() << "send organizer notification failed:" << reply.error().name() << reply.error().message();
+                    hideAllNotifyId = 0;
+                    hideAllNotifyExpireTimer->stop();
+                    watcher->deleteLater();
+                    if (allowRetry && replacesId != 0) {
+                        (*sendHideAllNotification)(0, false);
+                    }
+                    return;
+                }
+
                 hideAllNotifyId = reply.value();
-            }
-            watcher->deleteLater();
-        });
+                hideAllNotifyExpireTimer->start(kHideAllNotificationTimeoutMs + kHideAllNotificationExpireGraceMs);
+                watcher->deleteLater();
+            });
+        };
+
+        (*sendHideAllNotification)(hideAllNotifyId, true);
     }
+}
+
+void FrameManagerPrivate::onNotificationClosed(uint id, uint reason)
+{
+    Q_UNUSED(reason)
+
+    if (id != hideAllNotifyId)
+        return;
+
+    hideAllNotifyId = 0;
+    hideAllNotifyExpireTimer->stop();
 }
 
 void FrameManagerPrivate::enableChanged(bool e)

--- a/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
@@ -31,9 +31,12 @@ public:
     void layoutSurface(QWidget *root, SurfacePointer surface, bool hidden = false);
     void buildOrganizer();
     QList<SurfacePointer> surfaces() const;
+
 public slots:
     void refeshCanvas();
     void onHideAllKeyPressed();
+    void onNotificationClosed(uint id, uint reason);
+
 public slots:
     void enableChanged(bool e);
     void enableVisibility(bool e);
@@ -54,6 +57,7 @@ public:
     quint32 hideAllNotifyId { 0 };
 
     QTimer *layoutTimer { nullptr };
+    QTimer *hideAllNotifyExpireTimer { nullptr };
 
 private:
     FrameManager *q = nullptr;

--- a/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
@@ -51,6 +51,7 @@ public:
     CollectionModel *model { nullptr };
     CanvasInterface *canvas { nullptr };
     OptionsWindow *options { nullptr };
+    quint32 hideAllNotifyId { 0 };
 
     QTimer *layoutTimer { nullptr };
 


### PR DESCRIPTION
The original code used a fixed notification ID based on days in year, which doesn't comply with XDG specification for notification management. This change implements proper notification handling by:
1. Adding QDBusPendingReply include for async DBus calls
2. Using a member variable hideAllNotifyId to track notification IDs
3. Implementing proper error handling for DBus notification calls
4. Storing the actual notification ID returned by the system
5. Using the stored ID for notification replacement and closing

This ensures that notifications are properly managed according to XDG standards, allowing for notification replacement and proper lifecycle management.

Log: Fixed desktop organizer notification functionality to comply with XDG specification

Influence:
1. Test one-click hide feature with notification enabled
2. Verify notification appears and can be closed properly
3. Test notification replacement when multiple hide operations occur
4. Verify error handling when notification service is unavailable
5. Check that notification actions work correctly

fix: 根据XDG规范修复通知问题

原代码使用基于年份天数的固定通知ID，不符合XDG规范对通知管理的要求。本次
修改实现了正确的通知处理：
1. 添加QDBusPendingReply头文件以支持异步DBus调用
2. 使用成员变量hideAllNotifyId跟踪通知ID
3. 实现DBus通知调用的正确错误处理
4. 存储系统返回的实际通知ID
5. 使用存储的ID进行通知替换和关闭操作

这确保了通知按照XDG标准进行正确管理，支持通知替换和正确的生命周期管理。

Log: 修复桌面整理器通知功能以符合XDG规范

Influence:
1. 测试启用通知时的一键隐藏功能
2. 验证通知正确显示并可正常关闭
3. 测试多次隐藏操作时的通知替换功能
4. 验证通知服务不可用时的错误处理
5. 检查通知操作按钮是否正常工作

Bug: https://pms.uniontech.com/bug-view-352709.html

## Summary by Sourcery

Align desktop organizer notifications with XDG-compliant lifecycle management by tracking and reusing the actual notification ID returned by the system.

Bug Fixes:
- Fix incorrect use of a fixed notification ID by storing and reusing the ID returned from org.freedesktop.Notifications for replacement and closing.
- Handle DBus notification errors when sending organizer notifications and reset the stored notification ID on failure.

Enhancements:
- Introduce a member field to persist the last hide-all notification ID and use it as the replacement ID for subsequent notifications.