### PR TITLE
fix: prevent sidebar item painting overflow

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -96,6 +96,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     const bool isActive = opt.widget && opt.widget->isActiveWindow();
 
     painter->setRenderHint(QPainter::Antialiasing);
+    painter->setClipRect(opt.rect);
 
     if (!option.widget)
         return;
@@ -110,8 +111,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     if (!item)
         return DStyledItemDelegate::paint(painter, option, index);
     SideBarItemSeparator *separatorItem = dynamic_cast<SideBarItemSeparator *>(item);
-    // bug-205621
-    QRect itemRect = qApp->devicePixelRatio() > 1.0 ? opt.rect.adjusted(0, 1, 0, -1) : opt.rect;
+    QRect itemRect = opt.rect;
     QPoint dx = QPoint(kItemMargin, 0);
     QPoint dw = QPoint(-12, 0);
     bool selected = opt.state.testFlag(QStyle::State_Selected);


### PR DESCRIPTION
Added painter clipping rect to prevent sidebar item painting overflow
issues. Removed the previous workaround for bug-205621 that adjusted
the item rectangle based on device pixel ratio, as the clipping rect
approach provides a more robust solution.

The issue was that sidebar items could paint outside their designated
rectangle area, causing visual artifacts. By setting the clip rect
to the option's rectangle before painting, we ensure all painting
operations are confined to the correct area. This replaces the previous
conditional adjustment that was device pixel ratio dependent.

Log: Fixed sidebar item display overflow issue

Influence:
1. Test sidebar item rendering at different device pixel ratios
2. Verify no painting artifacts appear when scrolling or resizing
3. Check that selected items display correctly with proper highlighting
4. Test with various sidebar item types (regular items, separators)
5. Verify performance is not impacted by the clipping change

fix: 修复侧边栏项目绘制溢出问题

添加了绘制器裁剪矩形以防止侧边栏项目绘制溢出问题。移除了之前针对bug-
205621的基于设备像素比调整项目矩形的临时解决方案，因为裁剪矩形方法提供了
更稳健的解决方案。

问题在于侧边栏项目可能会在其指定矩形区域外进行绘制，导致视觉伪影。通过在
绘制前将裁剪矩形设置为选项的矩形，我们确保所有绘制操作都限制在正确的区域
内。这取代了之前依赖于设备像素比的条件调整。

Log: 修复侧边栏项目显示溢出问题

Influence:
1. 在不同设备像素比下测试侧边栏项目渲染
2. 验证滚动或调整大小时不会出现绘制伪影
3. 检查选中项目是否正确显示并具有适当高亮
4. 测试各种侧边栏项目类型（常规项目、分隔符）
5. 验证性能不受裁剪更改的影响

BUG: https://pms.uniontech.com/bug-view-312643.html
