### PR TITLE
fix: suppress tab change notification during drag preview

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -40,6 +40,7 @@
 #include <QFileInfo>
 #include <QTimer>
 #include <QDir>
+#include <QMimeData>
 #include <QProcess>
 #include <QDebug>
 #include <QApplication>
@@ -307,6 +308,36 @@ bool FileUtils::isHomeDesktopFile(const QUrl &url)
         return df.desktopDeepinId() == kDDEHomeId;
     }
     return false;
+}
+
+/**
+ * @brief FileUtils::setDockDnDMimeData
+ * Writes dock drag-and-drop metadata into \a mimeData for a single .desktop file.
+ *
+ * Sets "text/x-dde-dock-dnd-appid" to the application ID derived from \a url,
+ * and "text/x-dde-dock-dnd-source" to \a source.
+ * Does nothing if \a url does not refer to a .desktop file or the app ID cannot
+ * be determined.
+ *
+ * @param mimeData  The QMimeData object to populate. Must not be null.
+ * @param url       A local file URL pointing to a .desktop file.
+ * @param source    The drag source identifier (e.g. "dde-desktop").
+ */
+void FileUtils::setDockDnDMimeData(QMimeData *mimeData, const QUrl &url, const QString &source)
+{
+    Q_ASSERT(mimeData);
+
+    if (!isDesktopFile(url))
+        return;
+
+    if (auto info = InfoFactory::create<FileInfo>(url)) {
+        const auto &appId = info->nameOf(NameInfoType::kCompleteBaseName);
+        if (appId.isEmpty())
+            return;
+
+        mimeData->setData(QStringLiteral("text/x-dde-dock-dnd-appid"), appId.toUtf8());
+        mimeData->setData(QStringLiteral("text/x-dde-dock-dnd-source"), source.toUtf8());
+    }
 }
 
 bool FileUtils::isSameMountPoint(const QUrl &url1, const QUrl &url2)

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -11,6 +11,8 @@
 #include <dfm-base/interfaces/abstractjobhandler.h>
 #include <dfm-base/utils/desktopfile.h>
 
+class QMimeData;
+
 namespace dfmbase {
 
 class FileUtils
@@ -41,6 +43,7 @@ public:
     static bool isTrashDesktopFile(const QUrl &url);
     static bool isComputerDesktopFile(const QUrl &url);
     static bool isHomeDesktopFile(const QUrl &url);
+    static void setDockDnDMimeData(QMimeData *mimeData, const QUrl &url, const QString &source);
     static bool isSameMountPoint(const QUrl &url1, const QUrl &url2);
     static bool isSameDevice(const QUrl &url1, const QUrl &url2);
     static bool isSameFile(const QUrl &url1, const QUrl &url2,

--- a/src/plugins/desktop/ddplugin-canvas/model/canvasproxymodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/canvasproxymodel.cpp
@@ -736,6 +736,10 @@ QMimeData *CanvasProxyModel::mimeData(const QModelIndexList &indexes) const
     // set user id
     SysInfoUtils::setMimeDataUserId(mimedt);
 
+    // For single .desktop file drag, add dock DnD metadata
+    if (urls.size() == 1)
+        FileUtils::setDockDnDMimeData(mimedt, urls.first(), kDdeDestop);
+
     return mimedt;
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
@@ -498,6 +498,10 @@ QMimeData *CollectionModel::mimeData(const QModelIndexList &indexes) const
     // set user id
     SysInfoUtils::setMimeDataUserId(mm);
 
+    // For single .desktop file drag, add dock DnD metadata
+    if (urls.size() == 1)
+        FileUtils::setDockDnDMimeData(mm, urls.first(), "dde-desktop");
+
     return mm;
 }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -59,6 +59,7 @@ struct Tab
     QVariantMap userData;
     bool isInactive { false };
     bool isPinned { false };
+    bool isDragPreview { false };
 };
 
 namespace dfmplugin_titlebar {
@@ -101,6 +102,7 @@ public:
     void closeLeftTabs(int index);
     void closeRightTabs(int index);
     void closeOtherTabs(int index);
+    bool hasDragPreviewTab() const;
 
 public:
     TabBar *q;
@@ -110,7 +112,6 @@ public:
 
     int nextTabUniqueId { 0 };
     int currentTabIndex { -1 };
-    bool isDragging { false };
     QTimer *updateConfigTimer { nullptr };
     int lastTooltipTabIndex { -1 };
     bool lastTooltipOnButton { false };
@@ -340,7 +341,8 @@ void TabBarPrivate::handleIndexChanged(int index)
         });
     }
 
-    if (!isDragging)
+    // Suppress notification while any drag-preview tab exists in this TabBar.
+    if (!hasDragPreviewTab())
         Q_EMIT q->currentTabChanged(currentTabIndex, index);
     currentTabIndex = index;
 }
@@ -783,6 +785,15 @@ bool TabBarPrivate::updateTabInfo(int index, std::function<void(Tab &)> modifier
     modifier(tab);
     q->setTabData(index, QVariant::fromValue(tab));
     return true;
+}
+
+bool TabBarPrivate::hasDragPreviewTab() const
+{
+    for (int i = 0; i < q->count(); ++i) {
+        if (tabInfo(i).isDragPreview)
+            return true;
+    }
+    return false;
 }
 
 bool TabBarPrivate::canPinned(int index)
@@ -1276,16 +1287,6 @@ bool TabBar::eventFilter(QObject *obj, QEvent *e)
         return DTabBar::eventFilter(obj, e);
     }
 
-    // Handle drag events on TabBar itself
-    if (obj == this) {
-        if (eventType == QEvent::DragEnter) {
-            d->isDragging = true;
-        } else if (eventType == QEvent::DragLeave || eventType == QEvent::Drop) {
-            d->isDragging = false;
-        }
-        return DTabBar::eventFilter(obj, e);
-    }
-
     // Handle events on internal tabBar widget
     if (obj == d->tabBar) {
         if (eventType == QEvent::MouseMove) {
@@ -1405,12 +1406,19 @@ void TabBar::insertFromMimeDataOnDragEnter(int index, const QMimeData *source)
     QUrl url = QUrl(tabDataObj[TabDef::kTabUrl].toString());
     QString alias = tabDataObj[TabDef::kTabAlias].toString();
 
-    fmInfo() << "Inserting tab from MIME data at index" << index << "url:" << url;
+    fmInfo() << "Inserting drag-preview tab at index" << index << "url:" << url;
 
     // Create inactive tab at specified index
     // Insert at specific position
     QSignalBlocker blk(this);
-    insertTab(index, alias.isEmpty() ? d->tabDisplayName(url) : alias);
+    int previewIndex = insertTab(index, alias.isEmpty() ? d->tabDisplayName(url) : alias);
+    blk.unblock();
+
+    Tab previewTab;
+    previewTab.tabUrl = url;
+    previewTab.tabAlias = alias;
+    previewTab.isDragPreview = true;
+    setTabData(previewIndex, QVariant::fromValue(previewTab));
 }
 
 void TabBar::resizeEvent(QResizeEvent *e)

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -589,6 +589,10 @@ QMimeData *FileViewModel::mimeData(const QModelIndexList &indexes) const
     SysInfoUtils::setMimeDataUserId(data);
     data->setData(DFMGLOBAL_NAMESPACE::Mime::kDFMAppTypeKey, QByteArray(kDdeFileManager));
 
+    // For single .desktop file drag, add dock DnD metadata
+    if (urls.size() == 1)
+        FileUtils::setDockDnDMimeData(data, urls.first(), kDdeFileManager);
+
     return data;
 }
 


### PR DESCRIPTION
Added a new flag 'isDragPreview' to Tab structure to identify tabs that
are being previewed during drag operations.
Replaced the global 'isDragging' flag with a method
'hasDragPreviewTab()' that checks for any existing drag preview tabs.
This prevents unwanted currentTabChanged signals from being emitted
while drag preview tabs are present, which could cause incorrect tab
switching behavior.
Modified 'insertFromMimeDataOnDragEnter()' to mark newly created preview
tabs with the 'isDragPreview' flag.
Removed event filtering for drag events on the TabBar itself since drag
preview tracking is now handled through the tab-specific flag.

Influence:
1. Test drag-and-drop operations between tab bars to ensure preview tabs
work correctly
2. Verify that current tab doesn't change unexpectedly during drag
operations
3. Check that tab switching still works normally when no drag preview
is active
4. Test tab insertion at various positions during drag operations
5. Verify tab data is properly preserved for preview tabs

fix: 在拖拽预览期间抑制标签页变更通知

在Tab结构体中新增'isDragPreview'标志，用于标识拖拽操作期间正在预览的标
签页。
将全局的'isDragging'标志替换为'hasDragPreviewTab()'方法，该方法检查是否
存在任何拖拽预览标签页。
这可以防止在存在拖拽预览标签页时发出不需要的currentTabChanged信号，避免
导致错误的标签页切换行为。
修改'insertFromMimeDataOnDragEnter()'方法，为新创建的预览标签页标
记'isDragPreview'标志。
移除了TabBar本身的拖拽事件过滤，因为现在通过特定标签页的标志来处理拖拽预
览跟踪。

Influence:
1. 测试标签栏之间的拖放操作，确保预览标签页正常工作
2. 验证在拖拽操作期间当前标签页不会意外切换
3. 检查在没有拖拽预览活动时，标签页切换仍能正常工作
4. 测试拖拽操作期间在不同位置插入标签页
5. 验证预览标签页的标签数据是否正确保留

BUG: https://pms.uniontech.com/bug-view-352823.html

## Summary by Sourcery

Suppress tab change notifications while drag-preview tabs are active to prevent unintended tab switching during drag-and-drop.

Bug Fixes:
- Prevent unintended currentTabChanged emissions caused by drag-preview tabs during drag-and-drop operations between tab bars.

Enhancements:
- Track drag-preview state per tab via an isDragPreview flag and a hasDragPreviewTab() helper instead of using a global dragging flag.
- Improve drag-and-drop tab insertion by explicitly creating and marking preview tabs with their associated URL and alias.