### PR TITLE
fix: handle search widget interaction in collapsed state

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -136,6 +136,16 @@ bool SearchEditWidget::isAdvancedButtonChecked() const
     return advancedButton->isChecked();
 }
 
+SearchMode SearchEditWidget::currentSearchMode() const
+{
+    return currentMode;
+}
+
+bool SearchEditWidget::isActivatedFromCollapsed() const
+{
+    return activatedFromCollapsed;
+}
+
 void SearchEditWidget::setAdvancedButtonChecked(bool checked)
 {
     advancedButton->setChecked(checked);
@@ -144,6 +154,32 @@ void SearchEditWidget::setAdvancedButtonChecked(bool checked)
 void SearchEditWidget::setAdvancedButtonVisible(bool visible)
 {
     advancedButton->setVisible(visible);
+}
+
+void SearchEditWidget::restoreSessionState(SearchMode mode, bool fromCollapsed, const QString &text, bool advancedChecked)
+{
+    activatedFromCollapsed = fromCollapsed;
+
+    SearchMode effectiveMode = mode;
+    if (fromCollapsed && text.isEmpty() && !advancedChecked) {
+        effectiveMode = SearchMode::kCollapsed;
+        endCollapsedSession();
+    } else if (mode == SearchMode::kCollapsed && (!text.isEmpty() || advancedChecked)) {
+        effectiveMode = parentWidget() && parentWidget()->width() >= kWidthThresholdExpand ? SearchMode::kExtraLarge
+                                                                                           : SearchMode::kExpanded;
+    }
+
+    currentMode = effectiveMode;
+    pendingSearchText = text;
+    searchEdit->setText(text);
+    updateSearchWidgetLayout();
+
+    advancedButton->setChecked(advancedChecked);
+    const bool shouldShowAdvanced = searchEdit->isVisible() && (advancedChecked || !text.isEmpty());
+    advancedButton->setVisible(shouldShowAdvanced);
+    updateSpacing(shouldShowAdvanced);
+
+    TitleBarEventCaller::sendShowFilterView(this, advancedChecked);
 }
 
 void SearchEditWidget::updateSearchEditWidget(int parentWidth)
@@ -480,7 +516,9 @@ void SearchEditWidget::updateSearchWidgetLayout()
         searchEdit->setVisible(true);
         searchButton->setVisible(false);
 
-        bool shouldShowAdvancedButton = searchEdit->hasFocus() || !searchEdit->text().isEmpty();
+        bool shouldShowAdvancedButton = searchEdit->hasFocus()
+                || !searchEdit->text().isEmpty()
+                || advancedButton->isChecked();
         advancedButton->setVisible(shouldShowAdvancedButton);
         updateSpacing(shouldShowAdvancedButton);
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -53,12 +53,45 @@ SearchEditWidget::~SearchEditWidget()
     }
 }
 
+bool SearchEditWidget::isCollapsedEntry() const
+{
+    return currentMode == SearchMode::kCollapsed || (searchButton->isVisible() && !searchEdit->isVisible());
+}
+
+void SearchEditWidget::beginCollapsedSession()
+{
+    activatedFromCollapsed = true;
+}
+
+void SearchEditWidget::endCollapsedSession()
+{
+    activatedFromCollapsed = false;
+}
+
+void SearchEditWidget::handleCollapsedSessionFocusOut()
+{
+    QTimer::singleShot(0, this, [this]() {
+        QWidget *newFocus = QApplication::focusWidget();
+        if (newFocus && newFocus != searchEdit->lineEdit() && newFocus->inherits("QLineEdit")) {
+            endCollapsedSession();
+            if (parentWidget())
+                updateSearchEditWidget(parentWidget()->width());
+            return;
+        }
+
+        restoreFocusIfNeeded();
+    });
+}
+
 void SearchEditWidget::activateEdit(bool setAdvanceBtn)
 {
     if (!searchEdit || !advancedButton || !searchButton) {
         fmWarning() << "Cannot activate edit - one or more widgets are null";
         return;
     }
+
+    if (isCollapsedEntry())
+        beginCollapsedSession();
 
     if (parentWidget() && parentWidget()->width() >= kWidthThresholdExpand)
         setSearchMode(SearchMode::kExtraLarge);
@@ -79,6 +112,10 @@ void SearchEditWidget::deactivateEdit()
         fmWarning() << "Cannot deactivate edit - searchEdit or advancedButton is null";
         return;
     }
+
+    endCollapsedSession();
+    if (advancedButton->isChecked())
+        TitleBarEventCaller::sendShowFilterView(this, false);
 
     advancedButton->setChecked(false);
     advancedButton->setVisible(false);
@@ -128,6 +165,9 @@ void SearchEditWidget::setSearchMode(SearchMode mode)
     }
 
     currentMode = mode;
+    if (mode == SearchMode::kCollapsed)
+        endCollapsedSession();
+
     updateSearchWidgetLayout();
 }
 
@@ -163,8 +203,12 @@ void SearchEditWidget::onUrlChanged(const QUrl &url)
     searchEdit->clearEdit();
     if (delayTimer && delayTimer->isActive())
         delayTimer->stop();
+    if (advancedButton->isChecked())
+        TitleBarEventCaller::sendShowFilterView(this, false);
+
     advancedButton->setVisible(false);
     advancedButton->setChecked(false);
+    endCollapsedSession();
 
     // Clear focus to allow mode change
     searchEdit->clearFocus();
@@ -205,8 +249,7 @@ void SearchEditWidget::onTextEdited(const QString &text)
 
 void SearchEditWidget::expandSearchEdit()
 {
-    setSearchMode(SearchMode::kExpanded);
-    searchEdit->lineEdit()->setFocus();
+    activateEdit(false);
 }
 
 void SearchEditWidget::performSearch()
@@ -366,6 +409,12 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
 
     // For Qt::OtherFocusReason, delay check to see if focus really moved away
     if (e->reason() == Qt::OtherFocusReason) {
+        if (activatedFromCollapsed) {
+            e->accept();
+            handleCollapsedSessionFocusOut();
+            return;
+        }
+
         QTimer::singleShot(0, this, [this]() {
             if (!searchEdit->hasFocus() && !advancedButton->hasFocus() && parentWidget()) {
                 updateSearchEditWidget(parentWidget()->width());
@@ -385,7 +434,7 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
 void SearchEditWidget::restoreFocusIfNeeded()
 {
     // Don't restore focus if user is intentionally deactivating
-    if (isUserDeactivating) {
+    if (isUserDeactivating || currentMode == SearchMode::kCollapsed || !searchEdit->isVisible()) {
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -113,6 +113,7 @@ void SearchEditWidget::deactivateEdit()
         return;
     }
 
+    reactivateAfterQuitSearch = false;
     endCollapsedSession();
     if (advancedButton->isChecked())
         TitleBarEventCaller::sendShowFilterView(this, false);
@@ -234,6 +235,8 @@ void SearchEditWidget::onUrlChanged(const QUrl &url)
     }
 
     fmDebug() << "URL changed to non-search view, cleaning up search edit state";
+    const bool shouldReactivate = reactivateAfterQuitSearch;
+    reactivateAfterQuitSearch = false;
     lastSearchTime = 0;
     lastExecutedSearchText.clear();
     searchEdit->clearEdit();
@@ -252,6 +255,8 @@ void SearchEditWidget::onUrlChanged(const QUrl &url)
     // Force update layout to collapse search edit
     if (parentWidget()) {
         updateSearchEditWidget(parentWidget()->width());
+        if (shouldReactivate)
+            activateEdit(false);
     }
 }
 
@@ -267,6 +272,8 @@ void SearchEditWidget::onTextEdited(const QString &text)
 
     if (text.isEmpty()) {
         fmDebug() << "Search text is empty, stopping timer and quitting search";
+        if (activatedFromCollapsed)
+            reactivateAfterQuitSearch = true;
         quitSearch();
         return;
     }
@@ -345,6 +352,8 @@ bool SearchEditWidget::eventFilter(QObject *watched, QEvent *event)
                 }
                 // If SearchEdit has text, clear it and quit search
                 fmDebug() << "ESC key pressed in search edit, quitting search";
+                if (activatedFromCollapsed)
+                    reactivateAfterQuitSearch = true;
                 quitSearch();
                 return true;
             }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
@@ -65,6 +65,10 @@ protected:
 private:
     void initUI();
     void initConnect();
+    bool isCollapsedEntry() const;
+    void beginCollapsedSession();
+    void endCollapsedSession();
+    void handleCollapsedSessionFocusOut();
 
     void handleFocusInEvent(QFocusEvent *e);
     void handleFocusOutEvent(QFocusEvent *e);
@@ -105,6 +109,7 @@ private:
     QTimer *delayTimer { nullptr };
     qint64 lastSearchTime { 0 };
     bool isUserDeactivating { false };   // Flag to indicate user intentionally deactivating edit mode
+    bool activatedFromCollapsed { false };   // Track sessions entered from collapsed mode
 };
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
@@ -113,6 +113,7 @@ private:
     qint64 lastSearchTime { 0 };
     bool isUserDeactivating { false };   // Flag to indicate user intentionally deactivating edit mode
     bool activatedFromCollapsed { false };   // Track sessions entered from collapsed mode
+    bool reactivateAfterQuitSearch { false };   // Re-enter edit mode after quitSearch returns to the original directory
 };
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
@@ -39,8 +39,11 @@ public:
 
     bool isAdvancedButtonVisible() const;
     bool isAdvancedButtonChecked() const;
+    SearchMode currentSearchMode() const;
+    bool isActivatedFromCollapsed() const;
     void setAdvancedButtonChecked(bool checked);
     void setAdvancedButtonVisible(bool visible);
+    void restoreSessionState(SearchMode mode, bool fromCollapsed, const QString &text, bool advancedChecked);
 
     void updateSearchEditWidget(int parentWidth);
     void setSearchMode(SearchMode mode);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -549,7 +549,8 @@ bool TitleBarWidget::eventFilter(QObject *watched, QEvent *event)
 void TitleBarWidget::saveTitleBarState(const QString &uniqueId)
 {
     TitleBarState state;
-    state.advancedSearchVisible = searchEditWidget->isAdvancedButtonVisible();
+    state.searchMode = searchEditWidget->currentSearchMode();
+    state.searchFromCollapsed = searchEditWidget->isActivatedFromCollapsed();
     state.advancedSearchChecked = searchEditWidget->isAdvancedButtonChecked();
     state.searchText = searchEditWidget->text();
     state.viewMode = optionButtonBox->viewMode();
@@ -561,10 +562,10 @@ void TitleBarWidget::restoreTitleBarState(const QString &uniqueId)
 {
     if (titleBarStateMap.contains(uniqueId)) {
         const TitleBarState &state = titleBarStateMap[uniqueId];
-        searchEditWidget->setAdvancedButtonVisible(state.advancedSearchVisible);
-        searchEditWidget->setAdvancedButtonChecked(state.advancedSearchChecked);
-        if (!state.searchText.isEmpty())
-            searchEditWidget->setText(state.searchText);
+        searchEditWidget->restoreSessionState(state.searchMode,
+                                              state.searchFromCollapsed,
+                                              state.searchText,
+                                              state.advancedSearchChecked);
         optionButtonBox->setViewMode(static_cast<int>(state.viewMode));
     }
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -10,6 +10,7 @@
 #include "views/addressbar.h"
 #include "views/crumbbar.h"
 #include "views/optionbuttonbox.h"
+#include "views/searcheditwidget.h"
 
 #include <dfm-base/interfaces/abstractframe.h>
 
@@ -23,7 +24,6 @@ DWIDGET_END_NAMESPACE
 namespace dfmplugin_titlebar {
 
 class TabBar;
-class SearchEditWidget;
 class TitleBarWidget : public DFMBASE_NAMESPACE::AbstractFrame
 {
     Q_OBJECT
@@ -107,7 +107,8 @@ private:
     struct TitleBarState
     {
         DFMBASE_NAMESPACE::Global::ViewMode viewMode { DFMBASE_NAMESPACE::Global::ViewMode::kIconMode };
-        bool advancedSearchVisible { false };
+        SearchMode searchMode { SearchMode::kUnknown };
+        bool searchFromCollapsed { false };
         bool advancedSearchChecked { false };
         QString searchText { "" };
     };


### PR DESCRIPTION
Fixed abnormal interaction behavior when using the search control in collapsed mode. The issue occurred because the search widget didn't properly handle focus transitions and session management when activated from the collapsed state.

Key changes:
1. Added session tracking for collapsed mode activation with beginCollapsedSession() and endCollapsedSession()
2. Implemented isCollapsedEntry() to detect when search is initiated from collapsed state
3. Modified text editing behavior to keep editing active after stopping search in collapsed mode
4. Enhanced focus handling with handleCollapsedSessionFocusOut() to properly manage focus transitions
5. Updated ESC key and search abort behavior to maintain editing state in collapsed mode
6. Added proper cleanup when URL changes or mode switches to collapsed state

The fix ensures that when users activate search from the collapsed button, the interaction flows naturally without unexpected focus loss or mode switches.

Log: Fixed search control interaction issues in collapsed state

Influence:
1. Test clicking search button in collapsed mode and verify editing continues after clearing text
2. Verify ESC key behavior maintains editing state in collapsed mode
3. Test focus transitions between search edit and other line edit widgets
4. Verify search properly resets when switching directories in collapsed mode
5. Test advanced filter button behavior in various search modes
6. Check that normal expanded search mode behavior remains unchanged

fix: 修复折叠状态下搜索控件交互异常

修复了在折叠状态下使用搜索控件时的交互异常问题。该问题是由于搜索控件在从
折叠状态激活时未能正确处理焦点转换和会话管理导致的。

主要修改：
1. 添加了折叠模式激活的会话跟踪功能，包括 beginCollapsedSession() 和 endCollapsedSession()
2. 实现了 isCollapsedEntry() 方法用于检测搜索是否从折叠状态启动
3. 修改了文本编辑行为，在折叠模式下停止搜索后保持编辑状态
4. 增强了焦点处理，添加 handleCollapsedSessionFocusOut() 来正确管理焦点 转换
5. 更新了 ESC 键和搜索中止行为，在折叠模式下保持编辑状态
6. 添加了在 URL 更改或切换到折叠模式时的适当清理逻辑

此修复确保用户从折叠按钮激活搜索时，交互流程自然流畅，不会出现意外的焦点
丢失或模式切换。

Log: 修复折叠状态下搜索控件交互问题

Influence：
1. 测试在折叠模式下点击搜索按钮，验证清除文本后编辑是否继续
2. 验证 ESC 键行为在折叠模式下是否保持编辑状态
3. 测试搜索编辑框与其他行编辑控件之间的焦点转换
4. 验证在折叠模式下切换目录时搜索是否正确重置
5. 测试高级筛选按钮在各种搜索模式下的行为
6. 检查正常展开搜索模式的行为是否保持不变

## Summary by Sourcery

Fix search widget behavior when activated from the collapsed titlebar mode to keep interactions consistent and focus stable.

Bug Fixes:
- Preserve editing state instead of quitting search when text is cleared or search is aborted after activating from collapsed mode.
- Ensure ESC key and focus-out handling in collapsed sessions do not unexpectedly close or reset the search widget.
- Reset advanced filter visibility and collapsed session state correctly when URLs change or search mode switches to collapsed.
- Avoid restoring focus or expanding the search edit when the widget is in collapsed mode or not visible.

Enhancements:
- Introduce explicit tracking of search sessions started from collapsed mode to drive focus and lifecycle behavior.