### PR TITLE
feat: resolve local SFTP mount URLs to prevent deadlock

### DIFF
--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -8,6 +8,9 @@
 #include <QFutureWatcher>
 #include <QTcpSocket>
 #include <QNetworkProxy>
+#include <QHostAddress>
+#include <QNetworkInterface>
+#include <QRegularExpression>
 
 #include <netdb.h>
 #include <arpa/inet.h>
@@ -240,6 +243,66 @@ QMap<QString, QString> NetworkUtils::cifsMountHostInfo()
         mnt_free_iter(iter);
     }
     return table;
+}
+
+/*!
+ * \brief NetworkUtils::resolveLocalSftpMountUrl
+ *
+ * When \a url is a GVFS SFTP path (e.g.
+ * \c /run/user/1000/gvfs/sftp:host=localhost/home/user/file) and the SFTP
+ * server is the local machine, strips the GVFS prefix and returns the
+ * corresponding real local \c file:// URL.  In all other cases \a url is
+ * returned unchanged.
+ *
+ * The host-is-local check follows three steps:
+ *  1. Loopback literals (\c localhost, \c 127.0.0.1, \c ::1).
+ *  2. Numeric IP — compared against every address on all local interfaces via
+ *     \c QNetworkInterface::allAddresses().
+ */
+QUrl NetworkUtils::resolveLocalSftpMountUrl(const QUrl &url)
+{
+    // Extract host from the SFTP GVFS path segment.
+    QString host, port;
+    if (!instance()->parseIp(url.path(), host, port))
+        return url;
+
+    // Determine whether the SFTP server is the local machine.
+    const auto isLocalMachine = [](const QString &h) -> bool {
+        // Step 1: loopback literals
+        if (h.compare(QLatin1String("localhost"), Qt::CaseInsensitive) == 0
+            || h == QLatin1String("127.0.0.1")
+            || h == QLatin1String("::1"))
+            return true;
+
+        // Step 2: numeric IP — match against all local interface addresses
+        const QHostAddress candidate(h);
+        if (candidate.isNull())
+            return false;
+
+        const auto &localAddrs = QNetworkInterface::allAddresses();
+        return std::any_of(localAddrs.cbegin(), localAddrs.cend(),
+                           [&candidate](const QHostAddress &la) {
+                               return la.isEqual(candidate, QHostAddress::TolerantConversion);
+                           });
+    };
+
+    if (!isLocalMachine(host))
+        return url;
+
+    // Strip the GVFS SFTP mount prefix to obtain the real local path.
+    // Supported formats:
+    //   /run/user/<uid>/gvfs/sftp:host=<h>[,params]/<local-path>
+    //   /root/.gvfs/sftp:host=<h>[,params]/<local-path>
+    static const QRegularExpression sftpPrefix(R"(^/run/user/\d+/gvfs/sftp:[^/]*|^/root/\.gvfs/sftp:[^/]*)");
+    QString localPath = url.toLocalFile();
+    localPath.remove(sftpPrefix);
+    if (localPath.isEmpty())
+        localPath = QStringLiteral("/");
+
+    qCInfo(logDFMBase) << "resolveLocalSftpMountUrl: self-mounted SFTP detected,"
+                          " resolved symlink target to local path:"
+                       << localPath << "(original:" << url.toLocalFile() << ")";
+    return QFile::exists(localPath) ? QUrl::fromLocalFile(localPath) : url;
 }
 
 NetworkUtils::NetworkUtils(QObject *parent)

--- a/src/dfm-base/utils/networkutils.h
+++ b/src/dfm-base/utils/networkutils.h
@@ -32,6 +32,20 @@ public:
     // if network mount，get network mount
     static QMap<QString, QString> cifsMountHostInfo();
 
+    /**
+     * @brief resolveLocalSftpMountUrl
+     *   If @p url is a GVFS SFTP path whose server is the local machine,
+     *   strips the GVFS prefix and returns the real local @c file:// URL.
+     *   In all other cases @p url is returned unchanged.
+     *
+     *   This prevents a deadlock that occurs when a symlink created inside a
+     *   self-mounted SFTP share points back into the same GVFS mount hierarchy,
+     *   causing the SFTP FUSE daemon to issue a re-entrant request to itself.
+     * @param url  Source URL (potentially a GVFS SFTP path).
+     * @return     Resolved local URL, or @p url unchanged when not applicable.
+     */
+    static QUrl resolveLocalSftpMountUrl(const QUrl &url);
+
 protected:
     explicit NetworkUtils(QObject *parent = nullptr);
 };

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -25,6 +25,7 @@
 #include <dfm-base/utils/systempathutil.h>
 #include <dfm-base/utils/protocolutils.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/utils/networkutils.h>
 
 #include <dfm-io/dfmio_utils.h>
 
@@ -1442,7 +1443,12 @@ bool FileOperationsEventReceiver::handleOperationLinkFile(const quint64 windowId
 
     // Apply bind path transformation for source
     const QString &bindPath = FileUtils::bindPathTransform(localUrl.path(), false);
-    const QUrl sourceUrl = QUrl::fromLocalFile(bindPath);
+    QUrl sourceUrl = QUrl::fromLocalFile(bindPath);
+    // If the source is a GVFS SFTP path whose server is the local machine,
+    // resolve it to the real local path to prevent the SFTP daemon from
+    // following the symlink back into its own mount hierarchy (deadlock).
+    if (ProtocolUtils::isSFTPFile(sourceUrl))
+        sourceUrl = NetworkUtils::resolveLocalSftpMountUrl(sourceUrl);
 
     // Determine target URL based on different scenarios
     QUrl targetUrl = determineLinkTarget(localUrl, link, silence, windowId);


### PR DESCRIPTION
1. Added NetworkUtils::resolveLocalSftpMountUrl() method to detect and
convert local SFTP GVFS paths to regular file URLs
2. Implemented host detection logic for local SFTP servers (localhost,
loopback IPs, local interface addresses)
3. Modified file link operation to use this resolution for source URLs
4. Added necessary Qt network headers and ProtocolUtils dependency

This change prevents a deadlock scenario where a symlink created
inside a self-mounted SFTP share points back into the same GVFS mount
hierarchy, causing the SFTP FUSE daemon to issue a re-entrant request
to itself. The solution detects when an SFTP path refers to the local
machine and converts it to a regular file:// URL, bypassing the GVFS
layer.

Influence:
1. Test creating symlinks in SFTP mounts that point to local files
2. Verify that remote SFTP mounts still work correctly
3. Test with various local host representations (localhost,
127.0.0.1, ::1, local IP addresses)
4. Verify file operations continue to work for non-SFTP URLs
5. Test edge cases like empty paths or invalid SFTP URLs
6. Verify logging output when local SFTP mounts are detected

feat: 解析本地SFTP挂载URL以防止死锁

1. 添加NetworkUtils::resolveLocalSftpMountUrl()方法，用于检测并将本地
SFTP GVFS路径转换为常规文件URL
2. 实现本地SFTP服务器的主机检测逻辑（localhost、回环IP、本地接口地址）
3. 修改文件链接操作以对源URL使用此解析功能
4. 添加必要的Qt网络头文件和ProtocolUtils依赖

此更改防止了在自挂载的SFTP共享内创建的符号链接指向同一GVFS挂载层次结构
时导致的死锁场景，该场景会导致SFTP FUSE守护程序向自身发出重入请求。解决
方案检测SFTP路径是否指向本地机器，并将其转换为常规file:// URL，从而绕过
GVFS层。

Influence:
1. 测试在指向本地文件的SFTP挂载中创建符号链接
2. 验证远程SFTP挂载是否仍能正常工作
3. 使用各种本地主机表示进行测试（localhost、127.0.0.1、::1、本地IP地址）
4. 验证文件操作对于非SFTP URL是否继续工作
5. 测试边缘情况，如空路径或无效的SFTP URL
6. 验证检测到本地SFTP挂载时的日志输出

BUG: https://pms.uniontech.com/bug-view-352211.html

## Summary by Sourcery

Resolve local self-mounted SFTP GVFS paths to real local file URLs when creating file links to avoid deadlocks in the SFTP daemon.

New Features:
- Introduce NetworkUtils::resolveLocalSftpMountUrl() to translate local GVFS SFTP mount paths into file:// URLs when they refer to the local machine.

Bug Fixes:
- Prevent deadlock when symlinks inside a self-mounted SFTP share point back into the same GVFS SFTP mount hierarchy by resolving local SFTP paths to direct file URLs.

Enhancements:
- Update file link operations to run source paths through the new local SFTP resolution logic and add required Qt network and ProtocolUtils dependencies.