### PR TITLE
refactor: implement lazy loading for search plugin

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.cpp
@@ -46,18 +46,6 @@ bool TitleBar::start()
     // file scheme for crumbar
     dpfSlotChannel->push("dfmplugin_titlebar", "slot_Custom_Register", QString(Global::Scheme::kFile), QVariantMap {});
 
-    auto searchPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-search") };
-    if (searchPlugin && searchPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
-        TitleBarHelper::searchEnabled = true;
-    } else {
-        connect(
-                DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this,
-                [](const QString &, const QString &name) {
-                    if (name == "dfmplugin-search") TitleBarHelper::searchEnabled = true;
-                },
-                Qt::DirectConnection);
-    }
-
     registerTabSettingConfig();
     return true;
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -40,7 +40,6 @@ QList<QString> TitleBarHelper::kKeepTitleStatusSchemeList {};
 QMap<QString, ViewModeUrlCallback> TitleBarHelper::kViewModeUrlCallbackMap {};
 
 bool TitleBarHelper::newWindowAndTabEnabled { true };
-bool TitleBarHelper::searchEnabled { false };
 
 QList<TitleBarWidget *> TitleBarHelper::titlebars()
 {
@@ -266,6 +265,11 @@ void TitleBarHelper::handleSearch(QWidget *sender, const QString &text)
         }
     }
 
+    if (!tryLoadSearchPlugin()) {
+        fmWarning() << "Failed to load search plugin";
+        return;
+    }
+
     fmInfo() << "Starting search with keyword:" << text;
     TitleBarEventCaller::sendSearch(sender, text);
 }
@@ -283,6 +287,7 @@ void TitleBarHelper::openCurrentUrlInNewTab(quint64 windowId)
 
 void TitleBarHelper::showSettingsDialog(quint64 windowId)
 {
+    tryLoadSearchPlugin();
     dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kShowSettingDialog, windowId);
 }
 
@@ -444,4 +449,22 @@ bool TitleBarHelper::isViewModeVisibleForScheme(int mode, const QString &scheme)
     default:
         return false;
     }
+}
+
+bool TitleBarHelper::tryLoadSearchPlugin()
+{
+    // 搜索插件被懒加载，部分业务依赖它时可能尚未加载
+    static std::once_flag flag;
+    static bool loaded = false;
+    std::call_once(flag, []() {
+        auto searchPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-search") };
+        if (searchPlugin && searchPlugin->pluginState() < DPF_NAMESPACE::PluginMetaObject::kLoaded) {
+            loaded = DPF_NAMESPACE::LifeCycle::loadPlugin(searchPlugin);
+            fmInfo() << "Load result: " << loaded
+                     << "State: " << searchPlugin->pluginState() << "for search plugin";
+        } else if (searchPlugin && searchPlugin->pluginState() >= DPF_NAMESPACE::PluginMetaObject::kLoaded) {
+            loaded = true;
+        }
+    });
+    return loaded;
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.h
@@ -50,10 +50,10 @@ public:
     // View mode switching helper methods
     static bool isTreeViewGloballyEnabled();
     static bool isViewModeVisibleForScheme(int mode, const QString &scheme);
+    static bool tryLoadSearchPlugin();
 
 public:
     static bool newWindowAndTabEnabled;
-    static bool searchEnabled;
 
 private:
     static QMutex &mutex();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -303,11 +303,6 @@ void SearchEditWidget::performSearch()
         return;
     }
 
-    if (!TitleBarHelper::searchEnabled) {
-        fmWarning() << "Search is disabled, cannot perform search";
-        return;
-    }
-
     // Trim whitespace from the search string
     QString trimmedSearchText = pendingSearchText.trimmed();
     if (trimmedSearchText.isEmpty()) {


### PR DESCRIPTION
Remove static searchEnabled flag and replace with on-demand lazy loading mechanism. Previously, the titlebar plugin would check if search plugin was started during initialization and set a flag. Now, when search functionality is actually needed (during search operations or settings dialog), the search plugin is loaded dynamically if not already loaded.

This change improves startup performance by deferring search plugin loading until it's actually required, and eliminates potential race conditions where search might be disabled even after the plugin is loaded.

Log: Improved search plugin loading mechanism for better performance

Influence:
1. Test search functionality in title bar to ensure it still works
2. Verify settings dialog opens correctly
3. Check that search plugin is only loaded when needed
4. Test application startup performance
5. Verify no regression in search-related features

refactor: 实现搜索插件的懒加载机制

移除静态的 searchEnabled 标志，改为按需懒加载机制。之前标题栏插件在初始
化时会检查搜索插件是否已启动并设置标志。现在，当真正需要搜索功能时（搜索
操作或设置对话框），如果搜索插件尚未加载，会动态加载它。

此更改通过延迟搜索插件的加载直到实际需要时，提高了启动性能，并消除了搜索
插件加载后搜索功能仍可能被禁用的潜在竞争条件。

Log: 优化搜索插件加载机制以提升性能

Influence:
1. 测试标题栏中的搜索功能是否正常工作
2. 验证设置对话框能否正确打开
3. 检查搜索插件是否仅在需要时加载
4. 测试应用程序启动性能
5. 验证搜索相关功能无回归

## Summary by Sourcery

Refactor the title bar search integration to lazily load the search plugin on demand instead of relying on a precomputed enabled flag.

Enhancements:
- Introduce a one-time lazy-loading helper that loads the search plugin when search or settings are invoked, improving startup performance and avoiding race conditions.
- Remove the static searchEnabled state and its initialization logic from the title bar plugin, simplifying plugin dependency management.