### PR TITLE
feat: add dock drag-and-drop metadata for desktop files

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -310,36 +310,6 @@ bool FileUtils::isHomeDesktopFile(const QUrl &url)
     return false;
 }
 
-/**
- * @brief FileUtils::setDockDnDMimeData
- * Writes dock drag-and-drop metadata into \a mimeData for a single .desktop file.
- *
- * Sets "text/x-dde-dock-dnd-appid" to the application ID derived from \a url,
- * and "text/x-dde-dock-dnd-source" to \a source.
- * Does nothing if \a url does not refer to a .desktop file or the app ID cannot
- * be determined.
- *
- * @param mimeData  The QMimeData object to populate. Must not be null.
- * @param url       A local file URL pointing to a .desktop file.
- * @param source    The drag source identifier (e.g. "dde-desktop").
- */
-void FileUtils::setDockDnDMimeData(QMimeData *mimeData, const QUrl &url, const QString &source)
-{
-    Q_ASSERT(mimeData);
-
-    if (!isDesktopFile(url))
-        return;
-
-    if (auto info = InfoFactory::create<FileInfo>(url)) {
-        const auto &appId = info->nameOf(NameInfoType::kCompleteBaseName);
-        if (appId.isEmpty())
-            return;
-
-        mimeData->setData(QStringLiteral("text/x-dde-dock-dnd-appid"), appId.toUtf8());
-        mimeData->setData(QStringLiteral("text/x-dde-dock-dnd-source"), source.toUtf8());
-    }
-}
-
 bool FileUtils::isSameMountPoint(const QUrl &url1, const QUrl &url2)
 {
     if (!url1.isLocalFile())

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -43,7 +43,6 @@ public:
     static bool isTrashDesktopFile(const QUrl &url);
     static bool isComputerDesktopFile(const QUrl &url);
     static bool isHomeDesktopFile(const QUrl &url);
-    static void setDockDnDMimeData(QMimeData *mimeData, const QUrl &url, const QString &source);
     static bool isSameMountPoint(const QUrl &url1, const QUrl &url2);
     static bool isSameDevice(const QUrl &url1, const QUrl &url2);
     static bool isSameFile(const QUrl &url1, const QUrl &url2,

--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "universalutils.h"
+#include "fileutils.h"
 
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/base/schemefactory.h>
@@ -561,9 +562,9 @@ uint32_t UniversalUtils::lockScreenSaver()
         return 0;
 
     QDBusInterface screenSaverManager(IDLE_SCREEN_SAVER_SERVICE,
-                                IDLE_SCREEN_SAVER_PATH,
-                                IDLE_SCREEN_SAVER_INTERFACE,
-                                QDBusConnection::sessionBus());
+                                      IDLE_SCREEN_SAVER_PATH,
+                                      IDLE_SCREEN_SAVER_INTERFACE,
+                                      QDBusConnection::sessionBus());
 
     QList<QVariant> arg;
     arg << qApp->applicationDisplayName()   // who
@@ -572,7 +573,7 @@ uint32_t UniversalUtils::lockScreenSaver()
     QDBusReply<uint32_t> reply = screenSaverManager.callWithArgumentList(QDBus::AutoDetect, "Inhibit", arg);
     if (reply.isValid()) {
         qCInfo(logDFMBase) << "Inhibition cookie:" << reply.value();
-        return  reply.value();
+        return reply.value();
     }
 
     qCWarning(logDFMBase) << "UniversalUtils::lockScreenSaver Failed to inhibit screensaver:" << reply.error().message();
@@ -588,9 +589,9 @@ bool UniversalUtils::unlockScreenSaver(const uint32_t cookie)
         return false;
 
     QDBusInterface screenSaverManager(IDLE_SCREEN_SAVER_SERVICE,
-                                IDLE_SCREEN_SAVER_PATH,
-                                IDLE_SCREEN_SAVER_INTERFACE,
-                                QDBusConnection::sessionBus());
+                                      IDLE_SCREEN_SAVER_PATH,
+                                      IDLE_SCREEN_SAVER_INTERFACE,
+                                      QDBusConnection::sessionBus());
 
     QList<QVariant> arg;
     arg << cookie;   // cookie
@@ -598,7 +599,7 @@ bool UniversalUtils::unlockScreenSaver(const uint32_t cookie)
     QDBusReply<void> reply = screenSaverManager.callWithArgumentList(QDBus::Block, "UnInhibit", arg);
     if (reply.isValid()) {
         qCInfo(logDFMBase) << "UniversalUtils::unlockScreenSaver call UnInhibit finished! ";
-        return  true;
+        return true;
     }
 
     qCWarning(logDFMBase) << "UniversalUtils::unlockScreenSaver Failed to uninhibit screensaver:" << reply.error().message();
@@ -608,7 +609,7 @@ bool UniversalUtils::unlockScreenSaver(const uint32_t cookie)
 
 bool UniversalUtils::checkDbusService(const QString &service, bool isSystemDbus)
 {
-    QDBusConnectionInterface *interface{ nullptr };
+    QDBusConnectionInterface *interface { nullptr };
     if (isSystemDbus) {
         interface = QDBusConnection::systemBus().interface();
     } else {
@@ -632,6 +633,36 @@ bool UniversalUtils::checkDbusService(const QString &service, bool isSystemDbus)
     }
 
     return true;
+}
+
+/**
+ * @brief FileUtils::setDockDnDMimeData
+ * Writes dock drag-and-drop metadata into \a mimeData for a single .desktop file.
+ *
+ * Sets "text/x-dde-dock-dnd-appid" to the application ID derived from \a url,
+ * and "text/x-dde-dock-dnd-source" to \a source.
+ * Does nothing if \a url does not refer to a .desktop file or the app ID cannot
+ * be determined.
+ *
+ * @param mimeData  The QMimeData object to populate. Must not be null.
+ * @param url       A local file URL pointing to a .desktop file.
+ * @param source    The drag source identifier (e.g. "dde-desktop").
+ */
+void UniversalUtils::setDockDnDMimeData(QMimeData *mimeData, const QUrl &url, const QString &source)
+{
+    Q_ASSERT(mimeData);
+
+    if (!FileUtils::isDesktopFile(url))
+        return;
+
+    if (auto info = InfoFactory::create<FileInfo>(url)) {
+        const auto &appId = info->nameOf(NameInfoType::kCompleteBaseName);
+        if (appId.isEmpty())
+            return;
+
+        mimeData->setData(QStringLiteral("text/x-dde-dock-dnd-appid"), appId.toUtf8());
+        mimeData->setData(QStringLiteral("text/x-dde-dock-dnd-source"), source.toUtf8());
+    }
 }
 
 }

--- a/src/dfm-base/utils/universalutils.h
+++ b/src/dfm-base/utils/universalutils.h
@@ -79,6 +79,7 @@ public:
      * \return 服务存在时返回 true，否则返回 false。
      */
     static bool checkDbusService(const QString &service, bool isSystemDbus);
+    static void setDockDnDMimeData(QMimeData *mimeData, const QUrl &url, const QString &source);
 };
 
 }

--- a/src/plugins/desktop/ddplugin-canvas/model/canvasproxymodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/canvasproxymodel.cpp
@@ -9,6 +9,7 @@
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/sysinfoutils.h>
 #include <dfm-base/utils/sortutils.h>
+#include <dfm-base/utils/universalutils.h>
 #include <dfm-base/base/application/application.h>
 
 #include <dfm-framework/event/event.h>
@@ -738,7 +739,7 @@ QMimeData *CanvasProxyModel::mimeData(const QModelIndexList &indexes) const
 
     // For single .desktop file drag, add dock DnD metadata
     if (urls.size() == 1)
-        FileUtils::setDockDnDMimeData(mimedt, urls.first(), kDdeDestop);
+        UniversalUtils::setDockDnDMimeData(mimedt, urls.first(), kDdeDestop);
 
     return mimedt;
 }

--- a/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/models/collectionmodel.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/sysinfoutils.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
 #include <dfm-base/base/schemefactory.h>
 
 #include <dfm-framework/dpf.h>
@@ -500,7 +501,7 @@ QMimeData *CollectionModel::mimeData(const QModelIndexList &indexes) const
 
     // For single .desktop file drag, add dock DnD metadata
     if (urls.size() == 1)
-        FileUtils::setDockDnDMimeData(mm, urls.first(), "dde-desktop");
+        UniversalUtils::setDockDnDMimeData(mm, urls.first(), "dde-desktop");
 
     return mm;
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -591,7 +591,7 @@ QMimeData *FileViewModel::mimeData(const QModelIndexList &indexes) const
 
     // For single .desktop file drag, add dock DnD metadata
     if (urls.size() == 1)
-        FileUtils::setDockDnDMimeData(data, urls.first(), kDdeFileManager);
+        UniversalUtils::setDockDnDMimeData(data, urls.first(), kDdeFileManager);
 
     return data;
 }


### PR DESCRIPTION
Added a new utility function FileUtils::setDockDnDMimeData to embed
dock-specific drag-and-drop metadata when dragging a single .desktop
file. This function sets two custom MIME types: "text/x-dde-dock-
dnd-appid" with the application ID (derived from the .desktop file's
basename) and "text/x-dde-dock-dnd-source" with the source identifier
(e.g., "dde-desktop", "dde-file-manager"). The function safely handles
invalid inputs and non-desktop files. This functionality is integrated
into three different model classes (CanvasProxyModel, CollectionModel,
FileViewModel) that handle drag operations, ensuring that when a
user drags a single .desktop file from the desktop canvas, collection
organizer, or file manager workspace, the necessary metadata for dock
interaction is included.

Log: Added support for dragging .desktop files to the dock by providing
necessary metadata

Influence:
1. Drag a single .desktop file from the desktop canvas and verify the
dock can accept it
2. Drag a single .desktop file from a collection organizer view and
verify the dock can accept it
3. Drag a single .desktop file from the file manager workspace and
verify the dock can accept it
4. Drag multiple files (including a .desktop file) and verify dock
metadata is not set
5. Drag a non-desktop file and verify no dock metadata is added
6. Verify the source identifier is correctly set for each drag source
(dde-desktop, dde-file-manager)
7. Check that the application ID is correctly extracted from
the .desktop file name

feat: 为桌面文件添加任务栏拖放元数据

新增工具函数 FileUtils::setDockDnDMimeData，用于在拖拽单个 .desktop 文
件时嵌入任务栏特定的拖放元数据。该函数设置两种自定义 MIME 类型："text/
x-dde-dock-dnd-appid" 包含应用程序ID（从 .desktop 文件的基本名派生），以
及 "text/x-dde-dock-dnd-source" 包含源标识符（例如 "dde-desktop"、"dde-
file-manager"）。该函数安全处理无效输入和非桌面文件。此功能已集成到三个
不同的模型类（CanvasProxyModel、CollectionModel、FileViewModel）中，这
些类处理拖拽操作，确保当用户从桌面画布、集合整理器或文件管理工作区拖拽单
个 .desktop 文件时，包含用于任务栏交互的必要元数据。

Log: 新增支持将 .desktop 文件拖拽到任务栏，提供必要的元数据

Influence:
1. 从桌面画布拖拽单个 .desktop 文件，验证任务栏可以接受
2. 从集合整理器视图拖拽单个 .desktop 文件，验证任务栏可以接受
3. 从文件管理工作区拖拽单个 .desktop 文件，验证任务栏可以接受
4. 拖拽多个文件（包含 .desktop 文件），验证任务栏元数据未被设置
5. 拖拽非桌面文件，验证未添加任务栏元数据
6. 验证每个拖拽源的源标识符是否正确设置（dde-desktop, dde-file-manager）
7. 检查应用程序ID是否正确从 .desktop 文件名中提取

BUG: https://pms.uniontech.com/bug-view-271349.html

## Summary by Sourcery

New Features:
- Enable dock-aware drag-and-drop for single .desktop files by embedding application and source metadata into QMimeData from desktop canvas, collection organizer, and file manager views.