### PR TITLE
6.5.125

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,36 @@
+dde-file-manager (6.5.125) unstable; urgency=medium
+
+  * fix: fix TIFF image preview crash on DAVS remote filesystem
+  * fix: prevent sidebar disappearing when resizing window with expanded sidebar
+  * fix: improve URL editing logic in crumb bar
+  * fix: prevent unnecessary search operations on new tab
+  * feat: add context menu support to crumb bar blank area
+  * fix: prevent use-after-free in file view model prehandlers
+  * fix: improve root info management with user tracking
+  * refactor: optimize keyword highlighting performance
+  * fix: fix notification issues according to XDG specification
+  * fix: optimize directory deletion with child snapshot
+  * fix: improve hide all notification management
+  * docs: update file manager manual for new features
+  * fix: correct desktop window title for alt+tab switcher
+  * chore: add file manager manual images for multiple locales
+  * refactor: implement lazy loading for search plugin
+  * refactor: simplify search edit widget state management
+  * docs: improve disk encryption UI text clarity
+  * fix: update DBus service names for shutdown interface
+  * fix: fix selection artifact issue in file list view
+  * fix: improve disk encryption UI text clarity
+  * fix: simplify URL handling in createWindow method
+  * fix: improve error handling for device unlock failure
+  * fix: improve filename validation and editing behavior
+  * fix: prevent sidebar item painting overflow
+  * feat: resolve local SFTP mount URLs to prevent deadlock
+  * fix: suppress tab change notification during drag preview
+  * feat: add dock drag-and-drop metadata for desktop files
+  * feat: add dock drag-and-drop metadata for desktop files
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 13 Mar 2026 16:40:02 +0800
+
 dde-file-manager (6.5.124) unstable; urgency=medium
 
   * fix: adjust tab item button icon size and painting logic
@@ -20,7 +53,7 @@ dde-file-manager (6.5.124) unstable; urgency=medium
   * fix: ensure reliable blank disc data loading
   * feat: optimize URL selection logic in detail space
 
-   -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 05 Mar 2026 20:22:14 +0800
+  -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 05 Mar 2026 20:22:14 +0800
 
 dde-file-manager (6.5.123) unstable; urgency=medium
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -53,45 +53,12 @@ SearchEditWidget::~SearchEditWidget()
     }
 }
 
-bool SearchEditWidget::isCollapsedEntry() const
-{
-    return currentMode == SearchMode::kCollapsed || (searchButton->isVisible() && !searchEdit->isVisible());
-}
-
-void SearchEditWidget::beginCollapsedSession()
-{
-    activatedFromCollapsed = true;
-}
-
-void SearchEditWidget::endCollapsedSession()
-{
-    activatedFromCollapsed = false;
-}
-
-void SearchEditWidget::handleCollapsedSessionFocusOut()
-{
-    QTimer::singleShot(0, this, [this]() {
-        QWidget *newFocus = QApplication::focusWidget();
-        if (newFocus && newFocus != searchEdit->lineEdit() && newFocus->inherits("QLineEdit")) {
-            endCollapsedSession();
-            if (parentWidget())
-                updateSearchEditWidget(parentWidget()->width());
-            return;
-        }
-
-        restoreFocusIfNeeded();
-    });
-}
-
 void SearchEditWidget::activateEdit(bool setAdvanceBtn)
 {
     if (!searchEdit || !advancedButton || !searchButton) {
         fmWarning() << "Cannot activate edit - one or more widgets are null";
         return;
     }
-
-    if (isCollapsedEntry())
-        beginCollapsedSession();
 
     if (parentWidget() && parentWidget()->width() >= kWidthThresholdExpand)
         setSearchMode(SearchMode::kExtraLarge);
@@ -113,11 +80,6 @@ void SearchEditWidget::deactivateEdit()
         return;
     }
 
-    reactivateAfterQuitSearch = false;
-    endCollapsedSession();
-    if (advancedButton->isChecked())
-        TitleBarEventCaller::sendShowFilterView(this, false);
-
     advancedButton->setChecked(false);
     advancedButton->setVisible(false);
 
@@ -137,16 +99,6 @@ bool SearchEditWidget::isAdvancedButtonChecked() const
     return advancedButton->isChecked();
 }
 
-SearchMode SearchEditWidget::currentSearchMode() const
-{
-    return currentMode;
-}
-
-bool SearchEditWidget::isActivatedFromCollapsed() const
-{
-    return activatedFromCollapsed;
-}
-
 void SearchEditWidget::setAdvancedButtonChecked(bool checked)
 {
     advancedButton->setChecked(checked);
@@ -155,32 +107,6 @@ void SearchEditWidget::setAdvancedButtonChecked(bool checked)
 void SearchEditWidget::setAdvancedButtonVisible(bool visible)
 {
     advancedButton->setVisible(visible);
-}
-
-void SearchEditWidget::restoreSessionState(SearchMode mode, bool fromCollapsed, const QString &text, bool advancedChecked)
-{
-    activatedFromCollapsed = fromCollapsed;
-
-    SearchMode effectiveMode = mode;
-    if (fromCollapsed && text.isEmpty() && !advancedChecked) {
-        effectiveMode = SearchMode::kCollapsed;
-        endCollapsedSession();
-    } else if (mode == SearchMode::kCollapsed && (!text.isEmpty() || advancedChecked)) {
-        effectiveMode = parentWidget() && parentWidget()->width() >= kWidthThresholdExpand ? SearchMode::kExtraLarge
-                                                                                           : SearchMode::kExpanded;
-    }
-
-    currentMode = effectiveMode;
-    pendingSearchText = text;
-    searchEdit->setText(text);
-    updateSearchWidgetLayout();
-
-    advancedButton->setChecked(advancedChecked);
-    const bool shouldShowAdvanced = searchEdit->isVisible() && (advancedChecked || !text.isEmpty());
-    advancedButton->setVisible(shouldShowAdvanced);
-    updateSpacing(shouldShowAdvanced);
-
-    TitleBarEventCaller::sendShowFilterView(this, advancedChecked);
 }
 
 void SearchEditWidget::updateSearchEditWidget(int parentWidth)
@@ -202,9 +128,6 @@ void SearchEditWidget::setSearchMode(SearchMode mode)
     }
 
     currentMode = mode;
-    if (mode == SearchMode::kCollapsed)
-        endCollapsedSession();
-
     updateSearchWidgetLayout();
 }
 
@@ -235,19 +158,13 @@ void SearchEditWidget::onUrlChanged(const QUrl &url)
     }
 
     fmDebug() << "URL changed to non-search view, cleaning up search edit state";
-    const bool shouldReactivate = reactivateAfterQuitSearch;
-    reactivateAfterQuitSearch = false;
     lastSearchTime = 0;
     lastExecutedSearchText.clear();
     searchEdit->clearEdit();
     if (delayTimer && delayTimer->isActive())
         delayTimer->stop();
-    if (advancedButton->isChecked())
-        TitleBarEventCaller::sendShowFilterView(this, false);
-
     advancedButton->setVisible(false);
     advancedButton->setChecked(false);
-    endCollapsedSession();
 
     // Clear focus to allow mode change
     searchEdit->clearFocus();
@@ -255,8 +172,6 @@ void SearchEditWidget::onUrlChanged(const QUrl &url)
     // Force update layout to collapse search edit
     if (parentWidget()) {
         updateSearchEditWidget(parentWidget()->width());
-        if (shouldReactivate)
-            activateEdit(false);
     }
 }
 
@@ -271,10 +186,8 @@ void SearchEditWidget::onTextEdited(const QString &text)
     pendingSearchText = text;
 
     if (text.isEmpty()) {
-        fmDebug() << "Search text is empty, stopping timer and quitting search";
-        if (activatedFromCollapsed)
-            reactivateAfterQuitSearch = true;
-        quitSearch();
+        fmDebug() << "Search text is empty, stopping timer and stopping search";
+        stopSearch();
         return;
     }
 
@@ -292,7 +205,8 @@ void SearchEditWidget::onTextEdited(const QString &text)
 
 void SearchEditWidget::expandSearchEdit()
 {
-    activateEdit(false);
+    setSearchMode(SearchMode::kExpanded);
+    searchEdit->lineEdit()->setFocus();
 }
 
 void SearchEditWidget::performSearch()
@@ -335,20 +249,7 @@ bool SearchEditWidget::eventFilter(QObject *watched, QEvent *event)
         } else if (event->type() == QEvent::KeyPress) {
             QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
             if (keyEvent->key() == Qt::Key_Escape) {
-                // If SearchEdit is empty, deactivate and exit edit mode
-                if (searchEdit->text().isEmpty()) {
-                    fmDebug() << "ESC key pressed with empty search edit, deactivating and quitting search";
-                    isUserDeactivating = true;
-                    deactivateEdit();
-                    isUserDeactivating = false;
-                    // Emit searchQuit to exit search view
-                    Q_EMIT searchQuit();
-                    return true;
-                }
-                // If SearchEdit has text, clear it and quit search
                 fmDebug() << "ESC key pressed in search edit, quitting search";
-                if (activatedFromCollapsed)
-                    reactivateAfterQuitSearch = true;
                 quitSearch();
                 return true;
             }
@@ -449,12 +350,6 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
 
     // For Qt::OtherFocusReason, delay check to see if focus really moved away
     if (e->reason() == Qt::OtherFocusReason) {
-        if (activatedFromCollapsed) {
-            e->accept();
-            handleCollapsedSessionFocusOut();
-            return;
-        }
-
         QTimer::singleShot(0, this, [this]() {
             if (!searchEdit->hasFocus() && !advancedButton->hasFocus() && parentWidget()) {
                 updateSearchEditWidget(parentWidget()->width());
@@ -469,28 +364,6 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
     if (parentWidget()) {
         updateSearchEditWidget(parentWidget()->width());
     }
-}
-
-void SearchEditWidget::restoreFocusIfNeeded()
-{
-    // Don't restore focus if user is intentionally deactivating
-    if (isUserDeactivating || currentMode == SearchMode::kCollapsed || !searchEdit->isVisible()) {
-        return;
-    }
-
-    QTimer::singleShot(0, this, [this]() {
-        QWidget *newFocus = QApplication::focusWidget();
-        // Allow focus transfer to other edit controls (e.g., AddressBar)
-        if (newFocus && newFocus != searchEdit->lineEdit()
-            && newFocus->inherits("QLineEdit")) {
-            return;
-        }
-        // If no widget has focus or focus went to non-edit widget, restore focus
-        // This handles the case where layout changes (AddressBar hiding) steal focus
-        if (!newFocus || (!newFocus->inherits("QLineEdit") && !newFocus->inherits("QPushButton"))) {
-            searchEdit->lineEdit()->setFocus(Qt::OtherFocusReason);
-        }
-    });
 }
 
 void SearchEditWidget::handleInputMethodEvent(QInputMethodEvent *e)
@@ -520,9 +393,7 @@ void SearchEditWidget::updateSearchWidgetLayout()
         searchEdit->setVisible(true);
         searchButton->setVisible(false);
 
-        bool shouldShowAdvancedButton = searchEdit->hasFocus()
-                || !searchEdit->text().isEmpty()
-                || advancedButton->isChecked();
+        bool shouldShowAdvancedButton = searchEdit->hasFocus() || !searchEdit->text().isEmpty();
         advancedButton->setVisible(shouldShowAdvancedButton);
         updateSpacing(shouldShowAdvancedButton);
     }
@@ -532,6 +403,7 @@ void SearchEditWidget::quitSearch()
 {
     lastSearchTime = 0;
     delayTimer->stop();
+    // deactivateEdit();
     Q_EMIT searchQuit();
 }
 
@@ -587,4 +459,16 @@ bool SearchEditWidget::shouldDelaySearch(const QString &inputText)
 {
     // 对于过短或者通配符搜索，应该延迟
     return inputText.length() < 2 || inputText == "." || inputText == "*";
+}
+
+void SearchEditWidget::restoreFocusIfNeeded()
+{
+    QTimer::singleShot(0, this, [this]() {
+        if (!searchEdit->text().isEmpty()) {
+            // Use QTimer to defer the focus restoration to ensure proper cursor blink
+            QTimer::singleShot(0, this, [this]() {
+                searchEdit->lineEdit()->setFocus(Qt::OtherFocusReason);
+            });
+        }
+    });
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.h
@@ -39,11 +39,8 @@ public:
 
     bool isAdvancedButtonVisible() const;
     bool isAdvancedButtonChecked() const;
-    SearchMode currentSearchMode() const;
-    bool isActivatedFromCollapsed() const;
     void setAdvancedButtonChecked(bool checked);
     void setAdvancedButtonVisible(bool visible);
-    void restoreSessionState(SearchMode mode, bool fromCollapsed, const QString &text, bool advancedChecked);
 
     void updateSearchEditWidget(int parentWidth);
     void setSearchMode(SearchMode mode);
@@ -68,16 +65,10 @@ protected:
 private:
     void initUI();
     void initConnect();
-    bool isCollapsedEntry() const;
-    void beginCollapsedSession();
-    void endCollapsedSession();
-    void handleCollapsedSessionFocusOut();
 
     void handleFocusInEvent(QFocusEvent *e);
     void handleFocusOutEvent(QFocusEvent *e);
     void handleInputMethodEvent(QInputMethodEvent *e);
-
-    void restoreFocusIfNeeded();
 
     void updateSearchWidgetLayout();
     void quitSearch();
@@ -86,8 +77,7 @@ private:
     /**
      * @brief Update spacing between searchEdit and advancedButton
      * @param showAdvancedButton Whether the advanced button should be visible
-     *
-     * This method ensures consistent 10px right margin by adjusting the internal
+     *          * This method ensures consistent 10px right margin by adjusting the internal
      * spacing based on advanced button visibility. When the button is visible,
      * 10px spacing is applied; when hidden, spacing is removed.
      */
@@ -95,6 +85,7 @@ private:
 
     int determineSearchDelay(const QString &inputText);
     bool shouldDelaySearch(const QString &inputText);
+    void restoreFocusIfNeeded();
 
     DTK_WIDGET_NAMESPACE::DIconButton *searchButton { nullptr };   // 搜索栏按钮
     DTK_WIDGET_NAMESPACE::DToolButton *advancedButton { nullptr };   // 高级搜索按钮
@@ -111,9 +102,6 @@ private:
     SearchMode currentMode { SearchMode::kUnknown };
     QTimer *delayTimer { nullptr };
     qint64 lastSearchTime { 0 };
-    bool isUserDeactivating { false };   // Flag to indicate user intentionally deactivating edit mode
-    bool activatedFromCollapsed { false };   // Track sessions entered from collapsed mode
-    bool reactivateAfterQuitSearch { false };   // Re-enter edit mode after quitSearch returns to the original directory
 };
 
 }   // namespace dfmplugin_titlebar

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -549,8 +549,7 @@ bool TitleBarWidget::eventFilter(QObject *watched, QEvent *event)
 void TitleBarWidget::saveTitleBarState(const QString &uniqueId)
 {
     TitleBarState state;
-    state.searchMode = searchEditWidget->currentSearchMode();
-    state.searchFromCollapsed = searchEditWidget->isActivatedFromCollapsed();
+    state.advancedSearchVisible = searchEditWidget->isAdvancedButtonVisible();
     state.advancedSearchChecked = searchEditWidget->isAdvancedButtonChecked();
     state.searchText = searchEditWidget->text();
     state.viewMode = optionButtonBox->viewMode();
@@ -562,10 +561,10 @@ void TitleBarWidget::restoreTitleBarState(const QString &uniqueId)
 {
     if (titleBarStateMap.contains(uniqueId)) {
         const TitleBarState &state = titleBarStateMap[uniqueId];
-        searchEditWidget->restoreSessionState(state.searchMode,
-                                              state.searchFromCollapsed,
-                                              state.searchText,
-                                              state.advancedSearchChecked);
+        searchEditWidget->setAdvancedButtonVisible(state.advancedSearchVisible);
+        searchEditWidget->setAdvancedButtonChecked(state.advancedSearchChecked);
+        if (!state.searchText.isEmpty())
+            searchEditWidget->setText(state.searchText);
         optionButtonBox->setViewMode(static_cast<int>(state.viewMode));
     }
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.h
@@ -10,7 +10,6 @@
 #include "views/addressbar.h"
 #include "views/crumbbar.h"
 #include "views/optionbuttonbox.h"
-#include "views/searcheditwidget.h"
 
 #include <dfm-base/interfaces/abstractframe.h>
 
@@ -24,6 +23,7 @@ DWIDGET_END_NAMESPACE
 namespace dfmplugin_titlebar {
 
 class TabBar;
+class SearchEditWidget;
 class TitleBarWidget : public DFMBASE_NAMESPACE::AbstractFrame
 {
     Q_OBJECT
@@ -89,7 +89,7 @@ private slots:
 
 private:
     QUrl titlebarUrl;
-    QString pendingPinnedTabId;  // Store pinnedId from pinned:// URL
+    QString pendingPinnedTabId;   // Store pinnedId from pinned:// URL
     DTitlebar *topBar { nullptr };
     TabBar *bottomBar { nullptr };
     QHBoxLayout *topBarCustomLayout { nullptr };
@@ -107,8 +107,7 @@ private:
     struct TitleBarState
     {
         DFMBASE_NAMESPACE::Global::ViewMode viewMode { DFMBASE_NAMESPACE::Global::ViewMode::kIconMode };
-        SearchMode searchMode { SearchMode::kUnknown };
-        bool searchFromCollapsed { false };
+        bool advancedSearchVisible { false };
         bool advancedSearchChecked { false };
         QString searchText { "" };
     };


### PR DESCRIPTION
## Summary by Sourcery

Simplify the file manager title bar search widget behavior and stored state around search sessions and advanced search visibility.

Bug Fixes:
- Ensure search focus is reliably restored when there is existing search text, improving cursor visibility after layout changes.

Enhancements:
- Remove collapsed-mode-specific session handling and reactivation logic from the search edit widget to streamline search behavior.
- Simplify title bar state persistence to only store advanced search visibility, checked state, and search text instead of detailed search mode/session metadata.
- Adjust ESC and empty-text handling to consistently stop or quit search without special collapsed-mode reactivation paths.
- Limit the advanced search button visibility criteria to search focus or non-empty text, decoupling it from the button's checked state.