### PR TITLE
fix: correct URL encoding in file dialog selectedUrls method

### DIFF
--- a/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
@@ -80,7 +80,7 @@ QStringList FileDialogHandleDBus::selectedUrls() const
     QStringList list;
 
     for (const QUrl &url : FileDialogHandle::selectedUrls())
-        list << QUrl::fromPercentEncoding(url.toString().toUtf8());
+        list << url.toString();
 
     return list;
 }


### PR DESCRIPTION
Changed the selectedUrls() method in FileDialogHandleDBus to return URL
strings directly instead of double-encoding them. Previously, the method
was calling QUrl::fromPercentEncoding() on already properly formatted
URL strings, which was causing incorrect URL decoding. This fix ensures
that URLs returned by the file dialog are properly formatted and can be
used directly by applications without additional processing.

Log: Fixed file dialog URL encoding issue that caused incorrect file
paths

Influence:
1. Test file selection in file dialogs to ensure selected URLs are
correctly formatted
2. Verify that file operations work properly with the returned URLs
3. Test with files containing special characters in their names
4. Verify that the URLs are properly decoded when used in other parts of
the application

fix: 修复文件对话框 selectedUrls 方法中的 URL 编码问题

更改了 FileDialogHandleDBus 中的 selectedUrls() 方法，直接返回 URL 字符
串而不是对其进行双重编码。之前，该方法在已经正确格式化的 URL 字符串上调
用 QUrl::fromPercentEncoding()，这导致了不正确的 URL 解码。此修复确保文
件对话框返回的 URL 格式正确，可以被应用程序直接使用而无需额外处理。

Log: 修复了文件对话框 URL 编码问题，该问题导致文件路径不正确

Influence:
1. 测试文件对话框中的文件选择，确保选中的 URL 格式正确
2. 验证使用返回的 URL 时文件操作能正常工作
3. 测试包含特殊字符的文件名
4. 验证 URL 在应用程序其他部分使用时能正确解码

BUG: https://pms.uniontech.com/bug-view-351995.html

## Summary by Sourcery

Bug Fixes:
- Correct selectedUrls() in the DBus file dialog to avoid double-decoding URLs, ensuring returned file URLs are valid and usable by callers.