### PR TITLE
fix: simplify option button box width management

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -174,12 +174,10 @@ void OptionButtonBox::updateOptionButtonBox(int parentWidth)
     if (parentWidth <= kCompactModeThreshold) {
         if (!d->isCompactMode) {
             switchToCompactMode();
-            updateFixedWidth();
         }
     } else {
         if (d->isCompactMode) {
             switchToNormalMode();
-            updateFixedWidth();
         }
     }
 }
@@ -245,7 +243,7 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
     if (parent() && qobject_cast<QWidget *>(parent())) {
         if (OptionButtonManager::instance()->hasVsibleState(d->currentUrl.scheme())
             && OptionButtonManager::instance()->optBtnVisibleState(d->currentUrl.scheme()) == OptionButtonManager::kHideAllBtn) {
-            setFixedWidth(0);
+            setVisible(false);
             return;
         }
         if (qobject_cast<QWidget *>(parent())->width() <= kCompactModeThreshold) {
@@ -253,7 +251,7 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
         } else {
             switchToNormalMode();
         }
-        updateFixedWidth();
+        setVisible(true);
     }
 }
 
@@ -420,41 +418,6 @@ void OptionButtonBox::initUiForSizeMode()
     d->hBoxLayout->addWidget(d->sortByButton);
 
     setLayout(d->hBoxLayout);
-}
-
-void OptionButtonBox::updateFixedWidth()
-{
-    int fixedWidth = 10;   // Initial spacing
-
-    // View mode buttons section (left side)
-    if (d->isCompactMode) {
-        fixedWidth += 48;   // Compact button width
-        fixedWidth += 10;   // Spacing after compact button
-        fixedWidth -= 20;
-    } else {
-        fixedWidth += 10;   // Spacing after compact button, using their actual width
-        // Only count visible view mode buttons (each is kToolButtonSize = 30)
-        if (d->iconViewEnabled && d->iconViewButton && !d->iconViewButton->isHidden())
-            fixedWidth += d->iconViewButton->width();
-        if (d->listViewEnabled && d->listViewButton && !d->listViewButton->isHidden())
-            fixedWidth += d->listViewButton->width();
-        if (d->treeViewEnabled && d->treeViewButton && !d->treeViewButton->isHidden())
-            fixedWidth += d->treeViewButton->width();
-    }
-
-    // ViewOptions button (part of left side, also kToolButtonSize = 30)
-    if (d->viewOptionsEnabled && d->viewOptionsButton && !d->viewOptionsButton->isHidden())
-        fixedWidth += kToolButtonSize;
-
-    // Small fixed spacing + controlled stretch space to achieve ~15px total
-    fixedWidth += 5;   // Fixed spacing before stretch
-    // fixedWidth += 10;   // Controlled stretch space (5px + 10px = 15px total)
-
-    // SortByButton (right side - width is 46 when visible)
-    if (d->sortByEnabled && d->sortByButton && !d->sortByButton->isHidden())
-        fixedWidth += 46;   // kSortToolButtonWidth
-
-    setFixedWidth(fixedWidth);
 }
 
 DToolButton *OptionButtonBox::listViewButton() const

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.h
@@ -41,7 +41,6 @@ private:
     void initializeUi();
     void initConnect();
     void initUiForSizeMode();
-    void updateFixedWidth();
 
     void switchToCompactMode();
     void switchToNormalMode();


### PR DESCRIPTION
Removed the manual fixed width calculation and update logic in
OptionButtonBox. Instead of calculating precise widths and calling
updateFixedWidth() when switching modes or URL changes, the component
now relies on layout management and visibility control. When all buttons
should be hidden, setVisible(false) is used instead of setting width
to 0. The updateFixedWidth() method was completely removed as it was
complex, error-prone, and unnecessary with proper layout management.

Log: Fixed potential layout issues when switching view modes or changing
directories in the file manager title bar.

Influence:
1. Test switching between compact and normal mode by resizing the file
manager window.
2. Verify button visibility when navigating to locations where option
buttons should be hidden (e.g., specific schemes configured to hide
all buttons).
3. Check that the layout remains stable and buttons are correctly spaced
in both view modes.
4. Ensure no visual glitches or overlapping buttons occur during mode
transitions.

fix: 简化选项按钮框的宽度管理

移除了 OptionButtonBox 中手动计算和更新固定宽度的逻辑。组件现在依赖
布局管理和可见性控制，而不是在切换模式或 URL 变化时计算精确宽度并调用
updateFixedWidth()。当所有按钮都应隐藏时，使用 setVisible(false) 而不是
将宽度设置为 0。完全移除了 updateFixedWidth() 方法，因为该方法复杂、容易
出错，并且在正确的布局管理下是不必要的。

Log: 修复了文件管理器标题栏在切换视图模式或更改目录时可能出现的布局
问题。

Influence:
1. 通过调整文件管理器窗口大小，测试在紧凑模式和正常模式之间切换。
2. 导航到应隐藏选项按钮的位置（例如，配置为隐藏所有按钮的特定方案）时，
验证按钮的可见性。
3. 检查两种视图模式下布局是否保持稳定，按钮间距是否正确。
4. 确保模式切换过程中没有视觉故障或按钮重叠。

BUG: https://pms.uniontech.com/bug-view-352997.html

## Summary by Sourcery

Simplify OptionButtonBox width and visibility handling to rely on layout management instead of manual fixed-width calculations.

Enhancements:
- Remove manual fixed-width computation and the updateFixedWidth helper from OptionButtonBox, relying on layout and visibility instead.
- Control OptionButtonBox visibility directly when all option buttons are hidden instead of shrinking the widget to zero width.