### PR TITLE
refactor: extract view switch button and refine sort button UI

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -8,6 +8,7 @@
 #include "utils/optionbuttonmanager.h"
 #include "utils/titlebarhelper.h"
 #include "views/sortbybutton.h"
+#include "views/viewswitchbutton.h"
 #include "views/viewoptionsbutton.h"
 
 #include <dfm-base/base/application/application.h>
@@ -17,7 +18,6 @@
 
 #include <dfm-framework/event/event.h>
 
-#include <DMenu>
 #include <DGuiApplicationHelper>
 #include <dtkwidget_global.h>
 #ifdef DTKWIDGET_CLASS_DSizeMode
@@ -47,20 +47,7 @@ void OptionButtonBoxPrivate::updateCompactButton()
     }
 
     // Update icon based on current view mode
-    switch (currentMode) {
-    case ViewMode::kIconMode:
-        compactButton->setIcon(QIcon::fromTheme("dfm_viewlist_icons"));
-        break;
-    case ViewMode::kListMode:
-        compactButton->setIcon(QIcon::fromTheme("dfm_viewlist_details"));
-        break;
-    case ViewMode::kTreeMode:
-        compactButton->setIcon(QIcon::fromTheme("dfm_viewlist_tree"));
-        break;
-    default:
-        fmWarning() << "Unknown view mode for compact button:" << int(currentMode);
-        break;
-    }
+    compactButton->setViewModeIcon(currentMode);
 }
 
 void OptionButtonBoxPrivate::setViewMode(ViewMode mode)
@@ -213,6 +200,10 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
         }
         d->sortByButton->setHidden(!d->sortByEnabled);
         d->viewOptionsButton->setVisible(d->viewOptionsEnabled);
+        // 同步紧凑模式菜单项的启用状态，与非紧凑模式下的视图按钮保持一致
+        d->compactButton->setViewModeActionEnabled(ViewMode::kIconMode, d->iconViewEnabled);
+        d->compactButton->setViewModeActionEnabled(ViewMode::kListMode, d->listViewEnabled);
+        d->compactButton->setViewModeActionEnabled(ViewMode::kTreeMode, !needDisableTreeBtn);
 
         if (state == OptionButtonManager::kHideAllBtn) {
             setContentsMargins(0, 0, 0, 0);
@@ -239,6 +230,10 @@ void OptionButtonBox::onUrlChanged(const QUrl &url)
         d->sortByButton->setHidden(false);
         d->viewOptionsButton->setHidden(false);
         setContentsMargins(5, 0, 0, 0);
+        // 正常状态下，确保紧凑模式菜单中所有视图选项均可用
+        d->compactButton->setViewModeActionEnabled(ViewMode::kIconMode, true);
+        d->compactButton->setViewModeActionEnabled(ViewMode::kListMode, true);
+        d->compactButton->setViewModeActionEnabled(ViewMode::kTreeMode, true);
     }
 
     // Update button box size according to the parent widget width
@@ -323,10 +318,7 @@ void OptionButtonBox::initializeUi()
     d->viewOptionsButton->setIconSize(buttonIconSize);
     d->viewOptionsButton->setCheckable(false);
 
-    d->compactButton = new CustomDToolButton(this);
-    d->compactButton->setPopupMode(DToolButton::InstantPopup);
-    d->compactButton->setFixedSize(48, kToolButtonSize);
-    d->compactButton->setIconSize(QSize(kToolButtonIconSize, kToolButtonIconSize));
+    d->compactButton = new ViewSwitchButton(this);
     d->compactButton->setVisible(false);
 
     initUiForSizeMode();
@@ -352,37 +344,10 @@ void OptionButtonBox::initConnect()
 
     connect(Application::instance(), &Application::viewModeChanged, d, &OptionButtonBoxPrivate::onViewModeChanged);
 
-    auto menu = new DMenu(d->compactButton);
-    auto iconAction = menu->addAction(tr("Icon view"));
-    iconAction->setIcon(QIcon::fromTheme("dfm_viewlist_icons"));
-    iconAction->setCheckable(true);
-
-    auto listAction = menu->addAction(tr("List view"));
-    listAction->setIcon(QIcon::fromTheme("dfm_viewlist_details"));
-    listAction->setCheckable(true);
-
-    auto treeAction = menu->addAction(tr("Tree view"));
-    treeAction->setIcon(QIcon::fromTheme("dfm_viewlist_tree"));
-    treeAction->setCheckable(true);
-
-    auto updateCheckedState = [=]() {
-        iconAction->setChecked(d->currentMode == ViewMode::kIconMode);
-        listAction->setChecked(d->currentMode == ViewMode::kListMode);
-        treeAction->setChecked(d->currentMode == ViewMode::kTreeMode);
-    };
-
-    connect(iconAction, &QAction::triggered, this, [this]() {
-        d->setViewMode(ViewMode::kIconMode);
+    // CompactButton 内部自行管理菜单，这里只需连接其信号即可
+    connect(d->compactButton, &ViewSwitchButton::viewModeChangeRequested, this, [this](ViewMode mode) {
+        d->setViewMode(mode);
     });
-    connect(listAction, &QAction::triggered, this, [this]() {
-        d->setViewMode(ViewMode::kListMode);
-    });
-    connect(treeAction, &QAction::triggered, this, [this]() {
-        d->setViewMode(ViewMode::kTreeMode);
-    });
-
-    connect(menu, &DMenu::aboutToShow, this, updateCheckedState);
-    d->compactButton->setMenu(menu);
 
 #ifdef DTKWIDGET_CLASS_DSizeMode
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, [this]() {
@@ -401,9 +366,9 @@ void OptionButtonBox::initUiForSizeMode()
     d->hBoxLayout->setSpacing(0);
     d->hBoxLayout->setContentsMargins(0, 0, 0, 0);
 
+    d->hBoxLayout->addSpacing(10);
     // Add compact button (for compact mode)
     d->hBoxLayout->addWidget(d->compactButton);
-    d->hBoxLayout->addSpacing(10);
 
     // Add view mode buttons (left side)
     d->hBoxLayout->addWidget(d->iconViewButton);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/optionbuttonbox_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/optionbuttonbox_p.h
@@ -23,6 +23,7 @@ using DFMBASE_NAMESPACE::Global::ViewMode;
 class SortByButton;
 class ViewOptionsButton;
 class OptionButtonBox;
+class ViewSwitchButton;
 class OptionButtonBoxPrivate : public QObject
 {
     Q_OBJECT
@@ -50,7 +51,7 @@ private:
     SortByButton *sortByButton { nullptr };
     ViewOptionsButton *viewOptionsButton { nullptr };
     QHBoxLayout *hBoxLayout { nullptr };
-    DTK_WIDGET_NAMESPACE::DToolButton *compactButton { nullptr };
+    ViewSwitchButton *compactButton { nullptr };
     bool isCompactMode { false };
 
     ViewMode currentMode { ViewMode::kIconMode };

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/private/viewswitchbutton_p.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/private/viewswitchbutton_p.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef VIEWSWITCHBUTTON_P_H
+#define VIEWSWITCHBUTTON_P_H
+
+#include "dfmplugin_titlebar_global.h"
+
+#include <dfm-base/dfm_global_defines.h>
+
+#include <DToolButton>
+#include <DMenu>
+
+namespace dfmplugin_titlebar {
+
+class ViewSwitchButton;
+
+class ViewSwitchButtonPrivate : public QObject
+{
+    Q_OBJECT
+    friend class ViewSwitchButton;
+    ViewSwitchButton *const q;
+
+public:
+    explicit ViewSwitchButtonPrivate(ViewSwitchButton *parent);
+    ~ViewSwitchButtonPrivate() override;
+
+public slots:
+    void updateCheckedState();
+
+private:
+    void initializeUi();
+    void setupMenu();
+
+    bool hoverFlag { false };
+    QString currentIconName;           // 当前显示的视图模式图标名
+    DTK_WIDGET_NAMESPACE::DMenu *menu { nullptr };   // 内部拥有的弹出菜单
+    DFMBASE_NAMESPACE::Global::ViewMode currentMode { DFMBASE_NAMESPACE::Global::ViewMode::kIconMode };   // 当前视图模式，用于菜单勾选状态同步
+    QAction *iconAction { nullptr };
+    QAction *listAction { nullptr };
+    QAction *treeAction { nullptr };
+};
+
+}   // namespace dfmplugin_titlebar
+
+#endif   // VIEWSWITCHBUTTON_P_H

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
@@ -25,12 +25,16 @@ DFMGLOBAL_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
-static constexpr int kSortToolButtonWidth { 46 };
-static constexpr int kSortToolLeftButtonSize { 16 };
-static constexpr int kSortToolArrowButtonSize { 12 };
-static constexpr int kSortToolHMargin { 6 };
-static constexpr int kSortToolVMargin { 9 };
+static constexpr int kSortToolPadding { 6 };   // 按钮整体边距
+static constexpr int kSortToolSpacing { 6 };   // 内部元素间距
+static constexpr int kSortToolLeftButtonSize { 16 };   // 左侧排序图标尺寸
+static constexpr int kSortToolArrowCircleSize { 18 };   // 右侧箭头圆形背景尺寸
+static constexpr int kSortToolArrowButtonSize { 12 };   // 右侧箭头图标尺寸
 static constexpr char kItemRole[] = "item-role";
+// 按钮总宽 = padding + iconSize + spacing + circleSize + padding
+static constexpr int kSortToolButtonWidth { kSortToolPadding + kSortToolLeftButtonSize
+                                            + kSortToolSpacing + kSortToolArrowCircleSize
+                                            + kSortToolPadding };
 
 namespace GroupStrategy {
 inline constexpr char kNoGroup[] { "NoGroupStrategy" };
@@ -130,7 +134,7 @@ void SortByButtonPrivate::setupMenu()
 
 void SortByButtonPrivate::initializeUi()
 {
-    q->setFixedSize(kSortToolButtonWidth, kToolButtonSize);   // 设置固定大小
+    q->setFixedSize(kSortToolButtonWidth, kToolButtonSize);   // 按钮宽度由常量自动计算
     menu = new QMenu(q);
     groupMenu = new QMenu(q);
 }
@@ -190,40 +194,59 @@ void SortByButton::paintEvent(QPaintEvent *event)
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
 
-    QStyleOptionButton opt;
-    opt.initFrom(this);
+    bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+    bool menuVisible = d->menu->isVisible();
 
-    if (d->hoverFlag || d->menu->isVisible()) {
-        QStylePainter painter(this);
-        painter.setRenderHint(QPainter::Antialiasing);
-        QStyleOptionToolButton option;
-        QToolButton::initStyleOption(&option);
-        option.state |= QStyle::State_MouseOver;
-
-        bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
-
-        QColor hoverColor;
+    // 绘制整体按钮背景（hover/press 状态）
+    if (d->hoverFlag || menuVisible) {
+        QColor bgColor;
         if (isDown()) {
-            // 按下状态 - 20%不透明度
-            hoverColor = isDarkTheme ? QColor(255, 255, 255, 51)
-                                     : QColor(0, 0, 0, 51);
+            // 按下状态 - 20% 不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 51)
+                                  : QColor(0, 0, 0, 51);
         } else {
-            // 悬浮状态 - 10%不透明度
-            hoverColor = isDarkTheme ? QColor(255, 255, 255, 26)
-                                     : QColor(0, 0, 0, 26);
+            // 悬浮状态 - 10% 不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 26)
+                                  : QColor(0, 0, 0, 26);
         }
-
-        option.palette.setBrush(QPalette::Button, hoverColor);
-
-        option.rect.adjust(1, -1, -1, 1);
-        painter.drawComplexControl(QStyle::CC_ToolButton, option);
+        painter.save();
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(bgColor);
+        painter.drawRoundedRect(rect().adjusted(1, 1, -1, -1), 6, 6);
+        painter.restore();
     }
 
-    // Draw left icon
-    int leftIconY = kSortToolVMargin + (height() - 2 * kSortToolVMargin - kSortToolLeftButtonSize) / 2;
-    QRect leftRect(kSortToolHMargin, leftIconY, kSortToolLeftButtonSize, kSortToolLeftButtonSize);
-    auto leftIcon = QIcon::fromTheme("dfm_sortby_arrange");
+    // 计算内容区垂直居中位置
+    int iconY = (height() - kSortToolLeftButtonSize) / 2;
+    int circleY = (height() - kSortToolArrowCircleSize) / 2;
 
+    // 左侧排序图标矩形
+    QRect leftRect(kSortToolPadding, iconY, kSortToolLeftButtonSize, kSortToolLeftButtonSize);
+
+    // 右侧圆形背景矩形
+    int circleX = kSortToolPadding + kSortToolLeftButtonSize + kSortToolSpacing;
+    QRect circleRect(circleX, circleY, kSortToolArrowCircleSize, kSortToolArrowCircleSize);
+
+    // 绘制右侧圆形背景
+    if (d->hoverFlag || menuVisible) {
+        QColor circleColor;
+        if (menuVisible) {
+            // active 状态：高亮色半透明圆形背景
+            circleColor = isDarkTheme ? QColor(255, 255, 255, 40)
+                                      : QColor(0, 0, 0, 30);
+        } else {
+            circleColor = isDarkTheme ? QColor(255, 255, 255, 30)
+                                      : QColor(0, 0, 0, 20);
+        }
+        painter.save();
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(circleColor);
+        painter.drawEllipse(circleRect);
+        painter.restore();
+    }
+
+    // 绘制左侧排序图标
+    auto leftIcon = QIcon::fromTheme("dfm_sortby_arrange");
     painter.save();
     if (d->iconClicked) {
         painter.setPen(palette().highlight().color());   // Use highlight color for icon when clicked
@@ -231,15 +254,23 @@ void SortByButton::paintEvent(QPaintEvent *event)
     leftIcon.paint(&painter, leftRect);
     painter.restore();
 
-    // Draw right arrow
-    int arrowY = kSortToolVMargin + (height() - 2 * kSortToolVMargin - kSortToolArrowButtonSize) / 2;
-    QRect rightRect(width() - kSortToolHMargin - kSortToolArrowButtonSize, arrowY, kSortToolArrowButtonSize, kSortToolArrowButtonSize);
-    opt.rect = rightRect;
+    // 绘制右侧下拉箭头
+    int arrowSize = kSortToolArrowButtonSize;
+    int arrowX = circleX + (kSortToolArrowCircleSize - arrowSize) / 2;
+    int arrowY = (height() - arrowSize) / 2;
+    QRect arrowRect(arrowX, arrowY, arrowSize, arrowSize);
 
-    if (d->menu->isVisible()) {
-        painter.setPen(palette().highlight().color());   // Use highlight color for arrow when menu visible
+    QStyleOptionButton arrowOpt;
+    arrowOpt.initFrom(this);
+    arrowOpt.rect = arrowRect;
+
+    painter.save();
+    if (menuVisible) {
+        // active 状态：箭头显示高亮色
+        painter.setPen(palette().highlight().color());
     }
-    style()->drawPrimitive(QStyle::PE_IndicatorArrowDown, &opt, &painter, this);
+    style()->drawPrimitive(QStyle::PE_IndicatorArrowDown, &arrowOpt, &painter, this);
+    painter.restore();
 }
 
 void SortByButton::mousePressEvent(QMouseEvent *event)
@@ -250,7 +281,7 @@ void SortByButton::mousePressEvent(QMouseEvent *event)
         update();
     }
     if (event->button() == Qt::LeftButton) {
-        int leftWidth = 2 * kSortToolHMargin + kSortToolLeftButtonSize;
+        int leftWidth = 2 * kSortToolPadding + kSortToolLeftButtonSize;
         d->iconClicked = event->position().x() <= leftWidth;   // Check if icon area is clicked
 
         if (event->position().x() > leftWidth && d->menu) {
@@ -270,6 +301,11 @@ void SortByButton::mousePressEvent(QMouseEvent *event)
             }
 
             d->menu->exec(mapToGlobal(rect().bottomLeft()));
+            // 菜单关闭后（exec 返回），重置按下状态
+            if (isDown()) {
+                setDown(false);
+                update();
+            }
         } else if (d->iconClicked) {
             // Check busy state before sorting
             bool isBusy = TitleBarEventCaller::sendGetCurrentModelBusy(this);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewswitchbutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewswitchbutton.cpp
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "private/viewswitchbutton_p.h"
+#include "views/viewswitchbutton.h"
+
+#include <DGuiApplicationHelper>
+#include <DMenu>
+#include <dtkwidget_global.h>
+
+#include <QPainter>
+#include <QStyleOptionButton>
+#include <QMouseEvent>
+
+using namespace dfmplugin_titlebar;
+using namespace dfmbase::Global;
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
+
+static constexpr int kCompactToolPadding { 6 };   // 按钮整体边距
+static constexpr int kCompactToolSpacing { 6 };   // 内部元素间距
+static constexpr int kCompactToolLeftIconSize { 16 };   // 左侧视图模式图标尺寸
+static constexpr int kCompactToolArrowCircleSize { 18 };   // 右侧箭头圆形背景尺寸
+static constexpr int kCompactToolArrowSize { 12 };   // 右侧箭头图标尺寸
+// 按钮总宽 = padding + iconSize + spacing + circleSize + padding
+static constexpr int kCompactToolButtonWidth { kCompactToolPadding + kCompactToolLeftIconSize
+                                               + kCompactToolSpacing + kCompactToolArrowCircleSize
+                                               + kCompactToolPadding };
+
+ViewSwitchButtonPrivate::ViewSwitchButtonPrivate(ViewSwitchButton *parent)
+    : QObject(parent),
+      q(parent)
+{
+    initializeUi();
+    setupMenu();
+}
+
+ViewSwitchButtonPrivate::~ViewSwitchButtonPrivate() = default;
+
+void ViewSwitchButtonPrivate::initializeUi()
+{
+    q->setFixedSize(kCompactToolButtonWidth, kToolButtonSize);
+}
+
+void ViewSwitchButtonPrivate::setupMenu()
+{
+    menu = new DTK_WIDGET_NAMESPACE::DMenu(q);
+
+    iconAction = menu->addAction(QObject::tr("Icon view"));
+    iconAction->setIcon(QIcon::fromTheme("dfm_viewlist_icons"));
+    iconAction->setCheckable(true);
+
+    listAction = menu->addAction(QObject::tr("List view"));
+    listAction->setIcon(QIcon::fromTheme("dfm_viewlist_details"));
+    listAction->setCheckable(true);
+
+    treeAction = menu->addAction(QObject::tr("Tree view"));
+    treeAction->setIcon(QIcon::fromTheme("dfm_viewlist_tree"));
+    treeAction->setCheckable(true);
+
+    // 菜单显示前同步勾选状态
+    connect(menu, &DTK_WIDGET_NAMESPACE::DMenu::aboutToShow,
+            this, &ViewSwitchButtonPrivate::updateCheckedState);
+
+    connect(iconAction, &QAction::triggered, q, [this]() {
+        emit q->viewModeChangeRequested(ViewMode::kIconMode);
+    });
+    connect(listAction, &QAction::triggered, q, [this]() {
+        emit q->viewModeChangeRequested(ViewMode::kListMode);
+    });
+    connect(treeAction, &QAction::triggered, q, [this]() {
+        emit q->viewModeChangeRequested(ViewMode::kTreeMode);
+    });
+}
+
+void ViewSwitchButtonPrivate::updateCheckedState()
+{
+    if (iconAction)
+        iconAction->setChecked(currentMode == ViewMode::kIconMode);
+    if (listAction)
+        listAction->setChecked(currentMode == ViewMode::kListMode);
+    if (treeAction)
+        treeAction->setChecked(currentMode == ViewMode::kTreeMode);
+}
+
+ViewSwitchButton::ViewSwitchButton(QWidget *parent)
+    : DToolButton(parent), d(new ViewSwitchButtonPrivate(this))
+{
+}
+
+ViewSwitchButton::~ViewSwitchButton() = default;
+
+void ViewSwitchButton::setViewModeIcon(DFMBASE_NAMESPACE::Global::ViewMode mode)
+{
+    // 同时更新图标和内部记录的当前模式（供菜单勾选状态同步用）
+    d->currentMode = mode;
+    switch (mode) {
+    case DFMBASE_NAMESPACE::Global::ViewMode::kIconMode:
+        d->currentIconName = "dfm_viewlist_icons";
+        break;
+    case DFMBASE_NAMESPACE::Global::ViewMode::kListMode:
+        d->currentIconName = "dfm_viewlist_details";
+        break;
+    case DFMBASE_NAMESPACE::Global::ViewMode::kTreeMode:
+        d->currentIconName = "dfm_viewlist_tree";
+        break;
+    default:
+        fmWarning() << "CompactButton: unknown view mode" << static_cast<int>(mode);
+        return;
+    }
+    update();
+}
+
+void ViewSwitchButton::setViewModeActionEnabled(DFMBASE_NAMESPACE::Global::ViewMode mode, bool enabled)
+{
+    QAction *action = nullptr;
+    switch (mode) {
+    case DFMBASE_NAMESPACE::Global::ViewMode::kIconMode:
+        action = d->iconAction;
+        break;
+    case DFMBASE_NAMESPACE::Global::ViewMode::kListMode:
+        action = d->listAction;
+        break;
+    case DFMBASE_NAMESPACE::Global::ViewMode::kTreeMode:
+        action = d->treeAction;
+        break;
+    default:
+        fmWarning() << "CompactButton::setViewModeActionEnabled: unknown view mode" << static_cast<int>(mode);
+        return;
+    }
+    if (action)
+        action->setEnabled(enabled);
+}
+
+void ViewSwitchButton::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    const bool isDarkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+    const bool menuVisible = d->menu && d->menu->isVisible();
+
+    // ---- 绘制整体按钮背景（hover/press 状态）----
+    if (d->hoverFlag || menuVisible) {
+        QColor bgColor;
+        if (isDown()) {
+            // 按下状态 - 20% 不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 51)
+                                  : QColor(0, 0, 0, 51);
+        } else {
+            // 悬浮状态 - 10% 不透明度
+            bgColor = isDarkTheme ? QColor(255, 255, 255, 26)
+                                  : QColor(0, 0, 0, 26);
+        }
+        painter.save();
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(bgColor);
+        painter.drawRoundedRect(rect().adjusted(1, 1, -1, -1), 6, 6);
+        painter.restore();
+    }
+
+    // ---- 计算各元素垂直居中位置 ----
+    const int iconY = (height() - kCompactToolLeftIconSize) / 2;
+    const int circleY = (height() - kCompactToolArrowCircleSize) / 2;
+    const int circleX = kCompactToolPadding + kCompactToolLeftIconSize + kCompactToolSpacing;
+
+    // ---- 左侧视图模式图标矩形 ----
+    const QRect leftRect(kCompactToolPadding, iconY, kCompactToolLeftIconSize, kCompactToolLeftIconSize);
+
+    // ---- 右侧圆形背景矩形 ----
+    const QRect circleRect(circleX, circleY, kCompactToolArrowCircleSize, kCompactToolArrowCircleSize);
+
+    // ---- 绘制右侧圆形背景 ----
+    if (d->hoverFlag || menuVisible) {
+        QColor circleColor;
+        if (menuVisible) {
+            // active 状态：较深的半透明圆形背景
+            circleColor = isDarkTheme ? QColor(255, 255, 255, 40)
+                                      : QColor(0, 0, 0, 30);
+        } else {
+            circleColor = isDarkTheme ? QColor(255, 255, 255, 30)
+                                      : QColor(0, 0, 0, 20);
+        }
+        painter.save();
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(circleColor);
+        painter.drawEllipse(circleRect);
+        painter.restore();
+    }
+
+    // ---- 绘制左侧视图模式图标 ----
+    if (!d->currentIconName.isEmpty()) {
+        const auto leftIcon = QIcon::fromTheme(d->currentIconName);
+        painter.save();
+        if (menuVisible) {
+            painter.setPen(palette().highlight().color());
+        }
+        leftIcon.paint(&painter, leftRect);
+        painter.restore();
+    }
+
+    // ---- 绘制右侧下拉箭头 ----
+    const int arrowX = circleX + (kCompactToolArrowCircleSize - kCompactToolArrowSize) / 2;
+    const int arrowY = (height() - kCompactToolArrowSize) / 2;
+    const QRect arrowRect(arrowX, arrowY, kCompactToolArrowSize, kCompactToolArrowSize);
+
+    QStyleOptionButton arrowOpt;
+    arrowOpt.initFrom(this);
+    arrowOpt.rect = arrowRect;
+
+    painter.save();
+    if (menuVisible) {
+        // active 状态：箭头显示高亮色
+        painter.setPen(palette().highlight().color());
+    }
+    style()->drawPrimitive(QStyle::PE_IndicatorArrowDown, &arrowOpt, &painter, this);
+    painter.restore();
+}
+
+void ViewSwitchButton::mousePressEvent(QMouseEvent *event)
+{
+    DToolButton::mousePressEvent(event);
+    if (!d->hoverFlag) {
+        d->hoverFlag = true;
+    }
+
+    if (event->button() == Qt::LeftButton && d->menu) {
+        update();
+        d->menu->exec(mapToGlobal(rect().bottomLeft()));
+        // 菜单关闭后（exec 返回），重置按下状态
+        // 因为菜单弹出期间 mouseReleaseEvent 被拦截，isDown() 仍为 true
+        if (isDown()) {
+            setDown(false);
+        }
+    }
+    update();
+}
+
+void ViewSwitchButton::enterEvent(QEnterEvent *event)
+{
+    DToolButton::enterEvent(event);
+    if (!d->hoverFlag) {
+        d->hoverFlag = true;
+        update();
+    }
+}
+
+void ViewSwitchButton::leaveEvent(QEvent *event)
+{
+    DToolButton::leaveEvent(event);
+    if (d->hoverFlag) {
+        d->hoverFlag = false;
+        update();
+    }
+}
+
+void ViewSwitchButton::mouseMoveEvent(QMouseEvent *event)
+{
+    DToolButton::mouseMoveEvent(event);
+    if (!d->hoverFlag) {
+        d->hoverFlag = true;
+        update();
+    }
+}
+
+void ViewSwitchButton::mouseReleaseEvent(QMouseEvent *event)
+{
+    DToolButton::mouseReleaseEvent(event);
+    update();
+}

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewswitchbutton.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewswitchbutton.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef VIEWSWITCHBUTTON_H
+#define VIEWSWITCHBUTTON_H
+
+#include "dfmplugin_titlebar_global.h"
+
+#include <dfm-base/dfm_global_defines.h>
+
+#include <DToolButton>
+
+#include <QWidget>
+
+namespace dfmplugin_titlebar {
+
+class ViewSwitchButtonPrivate;
+
+class ViewSwitchButton : public DTK_WIDGET_NAMESPACE::DToolButton
+{
+    Q_OBJECT
+    friend class ViewSwitchButtonPrivate;
+    ViewSwitchButtonPrivate *const d;
+
+public:
+    explicit ViewSwitchButton(QWidget *parent = nullptr);
+    ~ViewSwitchButton() override;
+
+    void setViewModeIcon(DFMBASE_NAMESPACE::Global::ViewMode mode);
+    void setViewModeActionEnabled(DFMBASE_NAMESPACE::Global::ViewMode mode, bool enabled);
+
+signals:
+    void viewModeChangeRequested(DFMBASE_NAMESPACE::Global::ViewMode mode);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+};
+
+}   // namespace dfmplugin_titlebar
+
+#endif   // VIEWSWITCHBUTTON_H


### PR DESCRIPTION
Extracted the compact view mode button into a dedicated ViewSwitchButton
class to improve code modularity and maintainability. The new class
encapsulates all view mode switching logic including menu management,
icon updates, and action enablement. Also refactored SortByButton to use
consistent visual design patterns with circular background for dropdown
arrow and improved hover/press states. The changes include:
1. Created ViewSwitchButton class with private implementation
2. Moved view mode menu logic from OptionButtonBox to ViewSwitchButton
3. Added setViewModeActionEnabled() method to control menu item states
4. Updated OptionButtonBox to use ViewSwitchButton instead of
CustomDToolButton
5. Refactored SortByButton paintEvent to match new visual style with
circular arrow background
6. Fixed button state reset after menu closes in both buttons
7. Improved layout spacing and button positioning in compact mode

Log: Improved UI consistency and code structure for view mode and sort
buttons

Influence:
1. Test view mode switching in both normal and compact modes
2. Verify menu items are properly enabled/disabled based on URL context
3. Check visual consistency between SortByButton and ViewSwitchButton
4. Test hover and press states for both buttons
5. Verify menu closes properly and button states reset correctly
6. Test dark/light theme compatibility
7. Verify layout in different size modes

refactor: 提取视图切换按钮并优化排序按钮UI

将紧凑模式下的视图模式按钮提取为独立的 ViewSwitchButton 类，以提高代码模
块化和可维护性。新类封装了所有视图模式切换逻辑，包括菜单管理、图标更新和
操作启用控制。同时重构了 SortByButton，使其使用一致的视觉设计模式，包括
下拉箭头的圆形背景和改进的悬停/按下状态。具体变更包括：
1. 创建了 ViewSwitchButton 类及其私有实现
2. 将视图模式菜单逻辑从 OptionButtonBox 移动到 ViewSwitchButton
3. 添加 setViewModeActionEnabled() 方法控制菜单项状态
4. 更新 OptionButtonBox 使用 ViewSwitchButton 替代 CustomDToolButton
5. 重构 SortByButton 的绘制事件以匹配新的视觉风格，包括圆形箭头背景
6. 修复了两个按钮在菜单关闭后的状态重置问题
7. 改进了紧凑模式下的布局间距和按钮定位

Log: 优化视图模式和排序按钮的UI一致性和代码结构

Influence:
1. 测试正常模式和紧凑模式下的视图模式切换
2. 验证菜单项根据URL上下文正确启用/禁用
3. 检查 SortByButton 和 ViewSwitchButton 的视觉一致性
4. 测试两个按钮的悬停和按下状态
5. 验证菜单正确关闭且按钮状态正确重置
6. 测试深色/浅色主题兼容性
7. 验证不同尺寸模式下的布局效果

BUG: https://pms.uniontech.com/bug-view-352991.html

## Summary by Sourcery

Extract view mode switching into a dedicated compact view switch button and align sort and view controls with a unified titlebar button style.

Bug Fixes:
- Ensure button pressed state is correctly reset after menus close for both the sort button and the compact view switch button.

Enhancements:
- Introduce a ViewSwitchButton component that encapsulates compact-mode view switching, including its internal menu and icon management.
- Refine SortByButton layout and painting to use padding-based sizing and a circular background for the dropdown arrow, matching the new compact button style.
- Update OptionButtonBox to use ViewSwitchButton in compact mode and to synchronize view option availability with the main view mode controls.
- Improve hover, pressed, and active visual states for both sort and compact view switch buttons, including dark/light theme support.
- Adjust compact mode layout spacing so the new view switch button integrates cleanly with existing titlebar controls.