### PR TITLE
fix: handle symlink desktop files in rename operations

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -421,10 +421,12 @@ bool FileOperationsEventReceiver::doRenameDesktopFiles(QList<QUrl> &urls, const 
 {
     for (auto it = urls.begin(); it != urls.end();) {
         auto oldUrl = *it;
-        if (!FileUtils::isDesktopFile(oldUrl)) {
+        if (!FileUtils::isDesktopFile(oldUrl)
+            || DFMIO::DFileInfo(oldUrl).attribute(DFMIO::DFileInfo::AttributeID::kStandardIsSymlink).toBool()) {
             it++;
             continue;
         }
+
         const QString &desktopPath = oldUrl.toLocalFile();
         Properties desktop(desktopPath, "Desktop Entry");
         static const QString kLocale = QLocale::system().name();


### PR DESCRIPTION
Fixed an issue where renaming operations could fail or cause incorrect
behavior when encountering symlinks to desktop files. The code now
properly checks for symlinks before processing desktop file entries
during rename operations.

Previously, the rename logic for desktop files only checked if a file
had a .desktop extension but did not verify whether it was a symbolic
link. This could lead to attempts to modify the target file's properties
instead of the symlink itself, or other unexpected behavior. The fix
adds a check using DFMIO::DFileInfo to detect if the file is a symlink
(kStandardIsSymlink attribute) and skips processing for such files,
ensuring that only regular desktop files are processed.

Influence:
1. Test renaming regular desktop files to ensure they still work
correctly
2. Test renaming symlinks to desktop files to verify they are skipped
3. Verify that other file types (non-desktop) continue to work as before
4. Test with mixed lists containing both regular desktop files and
symlinks
5. Verify the behavior when symlinks point to non-existent desktop files

fix: 在重命名操作中正确处理桌面文件符号链接

修复了在重命名操作中遇到指向桌面文件的符号链接时可能导致失败或错误行为
的问题。代码现在在重命名操作期间处理桌面文件条目之前会正确检查是否为符号
链接。

之前，桌面文件的重命名逻辑仅检查文件是否具有 .desktop 扩展名，但未验证
其是否为符号链接。这可能导致尝试修改目标文件的属性而非符号链接本身，或
其他意外行为。此修复添加了使用 DFMIO::DFileInfo 来检测文件是否为符号链接
（kStandardIsSymlink 属性）的检查，并跳过对此类文件的处理，确保仅处理常
规桌面文件。

Influence:
1. 测试重命名常规桌面文件以确保它们仍然正常工作
2. 测试重命名指向桌面文件的符号链接以验证它们被跳过
3. 验证其他文件类型（非桌面文件）继续像以前一样工作
4. 测试包含常规桌面文件和符号链接的混合列表
5. 验证当符号链接指向不存在的桌面文件时的行为

BUG: https://pms.uniontech.com/bug-view-353171.html

## Summary by Sourcery

Bug Fixes:
- Prevent rename operations from incorrectly processing or failing on symlinks that point to desktop files.