### PR TITLE
fix: handle empty mimeData urls by parsing x-special/gnome-copied-files

### DIFF
--- a/src/dfm-base/utils/clipboard.cpp
+++ b/src/dfm-base/utils/clipboard.cpp
@@ -86,6 +86,23 @@ void onClipboardDataChanged()
         if (url.isValid() && !url.scheme().isEmpty())
             clipboardFileUrls << url;
     }
+
+    // user set x-special/gnome-copied-files's value,but do not set mimedata's urls
+    // so use x-special/gnome-copied-files's value to set clipboard urls;
+    if (!clipboardFileUrls.isEmpty())
+        return;
+
+    qCInfo(logDFMBase()) << "onClipboardDataChanged mimedata's urls is empty, use x-special/gnome-copied-files's value : " << data;
+    auto dataList = data.split("\n");
+    for (const auto &file : dataList) {
+      QUrl url(file);
+      if (url.isValid() && !url.scheme().isEmpty())
+        clipboardFileUrls << url;
+    }
+
+    if (clipboardFileUrls.isEmpty()) {
+        qCWarning(logDFMBase) << "onClipboardDataChanged clipboardFileUrls read url is empty!!!! clipboardAction = " << clipboardAction;
+    }
 }
 }   // namespace GlobalData
 


### PR DESCRIPTION
When x-special/gnome-copied-files is set but mimeData urls is empty, parse the x-special/gnome-copied-files value to extract file URLs instead.

Log: handle empty mimeData urls by parsing x-special/gnome-copied-files
Bug: https://pms.uniontech.com//bug-view-353197.html

## Summary by Sourcery

Bug Fixes:
- Ensure file URLs are correctly extracted from x-special/gnome-copied-files when the MIME data URL list is empty, preventing clipboard handling failures.