### PR TITLE
fix: fix direct io copy progress issue with empty files

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/docopyfileworker.cpp
@@ -246,6 +246,9 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFileWithDirectIO(const DFileInf
     }
 
     auto fromSize = fromInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
+    if (fromSize <= 0) {
+        workData->zeroOrlinkOrDirWriteSize += FileUtils::getMemoryPageSize();
+    }
 
     // Open destination file with O_DIRECT
     WriteMode preferredMode = WriteMode::Direct;
@@ -318,7 +321,7 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFileWithDirectIO(const DFileInf
             // Handle read error with UI dialog
             auto jobError = mapSystemErrorToJobError(savedErrno, false);
             AbstractJobHandler::SupportAction action = doHandleErrorAndWait(
-                fromInfo->uri(), toInfo->uri(), jobError, false);
+                    fromInfo->uri(), toInfo->uri(), jobError, false);
 
             if (action == AbstractJobHandler::SupportAction::kRetryAction) {
                 // Seek back to retry reading this chunk
@@ -373,7 +376,7 @@ DoCopyFileWorker::NextDo DoCopyFileWorker::doCopyFileWithDirectIO(const DFileInf
                 // Handle write error with UI dialog
                 auto jobError = mapSystemErrorToJobError(savedErrno, true);
                 AbstractJobHandler::SupportAction action = doHandleErrorAndWait(
-                    fromInfo->uri(), toInfo->uri(), jobError, true);
+                        fromInfo->uri(), toInfo->uri(), jobError, true);
 
                 if (action == AbstractJobHandler::SupportAction::kRetryAction) {
                     // Seek to retry writing this chunk


### PR DESCRIPTION
When copying empty files using direct IO, the progress calculation was incorrect because no data was being read or written. This caused the progress bar to not advance properly for empty files during copy operations.

The fix adds a check for files with size <= 0 and increments the write size by the system's memory page size. This ensures that empty files are properly accounted for in progress calculations while maintaining compatibility with direct IO requirements.

Log: Fixed progress display issue when copying empty files with direct IO

Influence:
1. Test copying empty files with direct IO enabled
2. Verify progress bar advances correctly for empty files
3. Test copying mixed files (empty and non-empty) in batch operations
4. Confirm normal file copying still works as expected
5. Validate progress calculation accuracy for various file sizes

fix: 修复direct io拷贝空文件进度异常问题

当使用direct IO拷贝空文件时，由于没有数据被读取或写入，进度计算不正确。
这导致在拷贝操作期间空文件的进度条无法正常推进。

修复方案是添加对大小<=0的文件的检查，并将写入大小增加系统内存页大小。这
确保了空文件在进度计算中得到正确统计，同时保持与direct IO要求的兼容性。

Log: 修复使用direct IO拷贝空文件时的进度显示问题

Influence:
1. 测试启用direct IO时空文件的拷贝
2. 验证空文件的进度条正确推进
3. 测试批量操作中混合文件（空文件和非空文件）的拷贝
4. 确认正常文件拷贝仍按预期工作
5. 验证各种文件大小的进度计算准确性

## Summary by Sourcery

Bug Fixes:
- Ensure empty files copied with direct I/O contribute to progress by incrementing write size based on system memory page size.