### PR TITLE
feat: add singleton property to desktop applications

### DIFF
--- a/src/apps/dde-file-manager/dde-file-manager.desktop
+++ b/src/apps/dde-file-manager/dde-file-manager.desktop
@@ -13,6 +13,7 @@ Type=Application
 Version=1.0
 X-Deepin-DEComponent=true
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!

--- a/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-computer.desktop
+++ b/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-computer.desktop
@@ -10,6 +10,7 @@ Terminal=false
 Type=Application
 X-AppStream-Ignore=true
 X-Deepin-AppID=dde-computer
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!

--- a/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-home.desktop
+++ b/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-home.desktop
@@ -12,6 +12,7 @@ Type=Application
 X-AppStream-Ignore=true
 X-Deepin-AppID=dde-file-manager
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!

--- a/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-trash.desktop
+++ b/src/external/dde-shell-plugins/panel-desktop/data/applications/dde-trash.desktop
@@ -11,6 +11,7 @@ Terminal=false
 Type=Application
 X-AppStream-Ignore=true
 X-Deepin-AppID=dde-trash
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Added X-Deepin-Singleton=true property to four desktop application files to ensure only one instance of each application runs at a time. This prevents multiple windows of the same application from being launched, improving user experience and system resource management. Affected applications include: dde-file-manager, dde-computer, dde-home, and dde-trash.

Log: Applications now open in single instance mode

Influence:
1. Test clicking on file manager icon multiple times - should not open multiple windows
2. Verify computer, home, and trash applications behave similarly
3. Check that existing instances are brought to front instead of creating new ones
4. Test application launching from different methods (dock, desktop, command line)
5. Verify no impact on application functionality or performance

feat: 为桌面应用程序添加单例属性

在四个桌面应用程序文件中添加了 X-Deepin-Singleton=true 属性，确保每个
应用程序只能运行一个实例。这可以防止启动同一应用程序的多个窗口，从而改
善用户体验和系统资源管理。受影响的应用程序包括：dde-file-manager、dde-
computer、dde-home 和 dde-trash。

Log: 应用程序现在以单例模式打开

Influence:
1. 测试多次点击文件管理器图标 - 不应打开多个窗口
2. 验证计算机、主目录和回收站应用程序具有相同行为
3. 检查是否将现有实例置于前台而不是创建新实例
4. 测试从不同方法（任务栏、桌面、命令行）启动应用程序
5. 验证对应用程序功能或性能没有影响

## Summary by Sourcery

Add singleton behavior to key desktop applications to ensure only one instance runs at a time.

New Features:
- Enable single-instance mode for dde-file-manager via desktop entry configuration.
- Enable single-instance mode for dde-computer via desktop entry configuration.
- Enable single-instance mode for dde-home via desktop entry configuration.
- Enable single-instance mode for dde-trash via desktop entry configuration.