### PR TITLE
fix: handle desktop file renaming with batch append

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -344,7 +344,13 @@ bool FileOperationsEventReceiver::doRenameFiles(const quint64 windowId, const QL
         break;
     }
     case RenameTypes::kBatchAppend: {
-        QMap<QUrl, QUrl> needDealUrls = FileUtils::fileBatchAddText(urls, pair2);
+        auto tmpurls = urls;
+        QMap<QUrl, QUrl> needDealUrls;
+        bool renameDesktop = doRenameDesktopFilesWithAppend(tmpurls, pair2, needDealUrls, successUrls);
+        QMap<QUrl, QUrl> needDealUrls1 = FileUtils::fileBatchAddText(tmpurls, pair2);
+        for (auto it = needDealUrls1.begin(); it != needDealUrls1.end(); ++it) {
+            needDealUrls.insert(it.key(), it.value());
+        }
         if (callback) {
             AbstractJobHandler::CallbackArgus args(new QMap<AbstractJobHandler::CallbackKey, QVariant>);
             args->insert(AbstractJobHandler::CallbackKey::kWindowId, QVariant::fromValue(windowId));
@@ -353,7 +359,10 @@ bool FileOperationsEventReceiver::doRenameFiles(const quint64 windowId, const QL
             args->insert(AbstractJobHandler::CallbackKey::kCustom, custom);
             callback(args);
         }
-        ok = fileHandler.renameFilesBatch(needDealUrls, successUrls);
+
+        if (needDealUrls1.isEmpty() || !renameDesktop)
+            return false;
+        ok = fileHandler.renameFilesBatch(needDealUrls1, successUrls);
         break;
     }
     }
@@ -452,6 +461,68 @@ bool FileOperationsEventReceiver::doRenameDesktopFiles(QList<QUrl> &urls, const 
         auto newName = oldName;
         newName = newName.replace(pair.first, pair.second);
         newUrl.setPath(UrlRoute::urlParent(oldUrl).path() + QDir::separator() + newName);
+        needDealUrls.insert(oldUrl, newUrl);
+        if (newName == oldName) {
+            it = urls.erase(it);
+            continue;
+        }
+
+        desktop.set(key, newName);
+        desktop.set("X-Deepin-Vendor", QStringLiteral("user-custom"));
+        if (!desktop.save(desktopPath, "Desktop Entry")) {
+            return false;
+        }
+        successUrls.insert(oldUrl, newUrl);
+        it = urls.erase(it);
+    }
+
+    return true;
+}
+
+bool FileOperationsEventReceiver::doRenameDesktopFilesWithAppend(QList<QUrl> &urls,
+                                                                 const QPair<QString, AbstractJobHandler::FileNameAddFlag> &pair,
+                                                                 QMap<QUrl, QUrl> &needDealUrls,
+                                                                 QMap<QUrl, QUrl> &successUrls)
+{
+    for (auto it = urls.begin(); it != urls.end();) {
+        auto oldUrl = *it;
+        if (!FileUtils::isDesktopFile(oldUrl)
+            || DFMIO::DFileInfo(oldUrl).attribute(DFMIO::DFileInfo::AttributeID::kStandardIsSymlink).toBool()) {
+            it++;
+            continue;
+        }
+
+        const QString &desktopPath = oldUrl.toLocalFile();
+        Properties desktop(desktopPath, "Desktop Entry");
+        static const QString kLocale = QLocale::system().name();
+        static const QString kLocaleNameTemplate = QString("Name[%1]");
+
+        auto localeName = kLocaleNameTemplate.arg(kLocale);
+
+        QString key;   // to find the present displaying Name
+        if (desktop.contains(localeName)) {
+            key = localeName;
+        } else {
+            auto splittedLocale = kLocale.trimmed().split("_");
+            if (splittedLocale.isEmpty()) {
+                key = "Name";
+            } else {
+                localeName = kLocaleNameTemplate.arg(splittedLocale.first());
+                key = desktop.contains(localeName) ? localeName : "Name";
+            }
+        }
+
+        FileInfoPointer oldFileInfo = InfoFactory::create<FileInfo>(oldUrl);
+        const QString &oldName = oldFileInfo->displayOf(DisPlayInfoType::kFileDisplayName);
+        QString newName = oldName;
+        if (pair.second == AbstractJobHandler::FileNameAddFlag::kPrefix) {
+            newName.insert(0, pair.first);
+        } else {
+            newName.append(pair.first);
+        }
+
+        auto newUrl = oldUrl;
+        newUrl.setPath(oldUrl.adjusted(QUrl::RemoveFilename | QUrl::StripTrailingSlash).path() + QDir::separator() + newName);
         needDealUrls.insert(oldUrl, newUrl);
         if (newName == oldName) {
             it = urls.erase(it);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.h
@@ -246,6 +246,10 @@ private:
                               const QPair<QString, QString> pair,
                               QMap<QUrl, QUrl> &needDealUrls,
                               QMap<QUrl, QUrl> &successUrls);
+bool doRenameDesktopFilesWithAppend(QList<QUrl> &urls,
+                                        const QPair<QString, DFMBASE_NAMESPACE::AbstractJobHandler::FileNameAddFlag> &pair,
+                                        QMap<QUrl, QUrl> &needDealUrls,
+                                        QMap<QUrl, QUrl> &successUrls);
 
     JobHandlePointer doCopyFile(const quint64 windowId, const QList<QUrl> &sources, const QUrl &target,
                                 const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags flags,


### PR DESCRIPTION
1. Modified doRenameFiles function to handle desktop files separately
when using batch append renaming
2. Added new doRenameDesktopFilesWithAppend function to process desktop
files with locale-specific name fields
3. Changed logic to combine desktop file renaming results with regular
file batch renaming
4. Updated success condition to require either desktop files were
renamed or there are regular files to rename

The previous implementation didn't properly handle desktop files
during batch append operations. Desktop files have special display name
handling with locale-specific fields (e.g., Name[zh_CN]) that need to
be updated in the .desktop file content, not just the filename. The
new function extracts the current display name from the desktop file,
applies the append/prepend operation, and updates the appropriate locale
field while preserving the .desktop extension.

Log: Fixed batch renaming of desktop files to properly update display
names in locale-specific fields

Influence:
1. Test batch renaming of desktop files with append/prepend operations
2. Verify desktop files maintain their .desktop extension after renaming
3. Test with mixed selections containing both desktop files and regular
files
4. Verify locale-specific name fields are properly updated in desktop
files
5. Test with different locale settings to ensure correct field selection
6. Verify symlinks to desktop files are not processed as desktop files

fix: 修复桌面文件批量追加重命名问题

1. 修改 doRenameFiles 函数，在使用批量追加重命名时单独处理桌面文件
2. 新增 doRenameDesktopFilesWithAppend 函数，处理带区域设置特定名称字段
的桌面文件
3. 更改逻辑以将桌面文件重命名结果与常规文件批量重命名结合
4. 更新成功条件，要求要么桌面文件被重命名，要么有待重命名的常规文件

之前的实现在批量追加操作中没有正确处理桌面文件。桌面文件具有特殊的
显示名称处理，需要更新 .desktop 文件内容中的区域设置特定字段（例如
Name[zh_CN]），而不仅仅是文件名。新函数从桌面文件提取当前显示名称，应用
追加/前置操作，并更新适当的区域设置字段，同时保留 .desktop 扩展名。

Log: 修复桌面文件批量重命名功能，正确更新区域设置特定字段中的显示名称

Influence:
1. 测试桌面文件的批量追加/前置重命名操作
2. 验证桌面文件重命名后是否保持 .desktop 扩展名
3. 测试同时包含桌面文件和常规文件的混合选择
4. 验证桌面文件中的区域设置特定名称字段是否正确更新
5. 使用不同的区域设置进行测试，确保正确选择字段
6. 验证指向桌面文件的符号链接不会被当作桌面文件处理

BUG: https://pms.uniontech.com/bug-view-353167.html

## Summary by Sourcery

Handle batch append renaming for desktop files alongside regular files, including locale-aware display name updates and integration into the existing batch rename flow.

Bug Fixes:
- Fix batch append renaming so that .desktop files update their locale-specific display name fields instead of only changing filenames.
- Ensure symlinked desktop files are not treated as desktop files during batch append operations.
- Prevent batch append rename from proceeding when there are no regular files to rename or when desktop file processing fails.

Enhancements:
- Introduce a dedicated code path for processing desktop files during batch append operations and merging their results with regular file renames.