### PR TITLE
fix: swap video thumbnail creation priority

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -158,12 +158,12 @@ QImage ThumbnailCreators::videoThumbnailCreator(const QString &filePath, Thumbna
 {
     qCDebug(logDFMBase) << "thumbnail: creating video thumbnail for:" << filePath;
 
-    QImage img = videoThumbnailCreatorLib(filePath, size);
+    QImage img = videoThumbnailCreatorFfmpeg(filePath, size);
     if (img.isNull()) {
-        qCDebug(logDFMBase) << "thumbnail: video library creator failed, trying ffmpeg for:" << filePath;
-        img = videoThumbnailCreatorFfmpeg(filePath, size);
+        qCDebug(logDFMBase) << "thumbnail: video ffmpeg creator failed, trying library for:" << filePath;
+        img = videoThumbnailCreatorLib(filePath, size);
     } else {
-        qCDebug(logDFMBase) << "thumbnail: video library creator succeeded for:" << filePath;
+        qCDebug(logDFMBase) << "thumbnail: video ffmpeg creator succeeded for:" << filePath;
     }
 
     return img;


### PR DESCRIPTION
Changed the order of video thumbnail creation methods to try ffmpeg first before falling back to the library method. This improves thumbnail generation success rate and performance since ffmpeg is generally more reliable and efficient for video thumbnail extraction.

Log: Improved video thumbnail generation reliability

Influence:
1. Test video file thumbnail generation with various formats
2. Verify thumbnail quality and generation speed
3. Test with corrupted or unsupported video files
4. Check fallback mechanism when ffmpeg fails
5. Monitor debug logs for creation method used

fix: 交换视频缩略图生成优先级

将视频缩略图生成方法的顺序改为先尝试ffmpeg，再回退到库方法。这提高了缩略
图生成的成功率和性能，因为ffmpeg通常对视频缩略图提取更可靠和高效。

Log: 提升视频缩略图生成可靠性

Influence:
1. 测试各种格式的视频文件缩略图生成
2. 验证缩略图质量和生成速度
3. 使用损坏或不支持的视频文件进行测试
4. 检查ffmpeg失败时的回退机制
5. 监控调试日志以了解使用的创建方法

## Summary by Sourcery

Prioritize ffmpeg-based video thumbnail generation and fall back to the existing library-based method when ffmpeg fails, improving reliability and performance of video thumbnails.

Bug Fixes:
- Correct video thumbnail creation order so that ffmpeg is attempted first and the library method is used as a fallback.

Enhancements:
- Improve diagnostic logging to indicate which video thumbnail creation method succeeded or failed.