### PR TITLE
fix: improve image preview reliability for remote files

### DIFF
--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
@@ -14,6 +14,8 @@
 #include <dfm-base/utils/protocolutils.h>
 
 #include <dfm-framework/dpf.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-io/dfile.h>
 
 #include <QImageReader>
 #include <QMovie>
@@ -76,13 +78,10 @@ void ImagePreviewWorker::loadPreview(const QUrl &url, const QSize &targetSize)
     if (isImageMimeType(mimeType)) {
         // Check if we should skip original image loading for remote/optical files
         if (!shouldSkipOriginalImageLoad(url, fileSize)) {
-            // Special handling for TIFF files on DAV/DAVS remote filesystem
-            // DAV/DAVS (WebDAV with or without SSL) may have incomplete data reads due to
-            // network instability, causing libtiff to crash when accessing incomplete strip
-            // data via memcpy. Load entire file into memory first to ensure data integrity.
-            if (mimeType == "image/tiff"
-                && (ProtocolUtils::isDavFile(url) || ProtocolUtils::isDavsFile(url))) {
-                result = loadImageFromMemory(filePath, targetSize);
+            // For DAV/DAVS mounted files, prefer full-memory loading to avoid
+            // partial/streaming read issues on remote filesystem.
+            if (ProtocolUtils::isDavFile(url) || ProtocolUtils::isDavsFile(url)) {
+                result = loadImageFromMemory(url, filePath, fileSize, targetSize);
             } else {
                 result = loadOriginalImage(filePath, targetSize);
             }
@@ -170,7 +169,7 @@ QPixmap ImagePreviewWorker::loadOriginalImage(const QString &filePath, const QSi
     return pixmap;
 }
 
-QPixmap ImagePreviewWorker::loadImageFromMemory(const QString &filePath, const QSize &targetSize)
+QPixmap ImagePreviewWorker::loadImageFromMemory(const QUrl &url, const QString &filePath, qint64 expectedSize, const QSize &targetSize)
 {
     // This method loads an image file entirely into memory before decoding.
     // It's designed to work around issues with remote filesystem (especially DAVS)
@@ -188,21 +187,38 @@ QPixmap ImagePreviewWorker::loadImageFromMemory(const QString &filePath, const Q
     // By reading the entire file into memory first, we ensure data integrity before
     // passing it to QImageReader, eliminating the streaming read issue.
 
-    QFile file(filePath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        fmWarning() << "detailview: failed to open file for memory loading:" << filePath;
-        return QPixmap();
+    // Prefer reading from original remote URI (via GIO backend) instead of
+    // gvfs-fuse mount path, to avoid truncated reads on /run/user/.../gvfs.
+    QUrl readUrl = url;
+    if (!readUrl.isValid()) {
+        readUrl = QUrl::fromLocalFile(filePath);
+    }
+    if (readUrl.isLocalFile()) {
+        const SyncFileInfo info(readUrl);
+        const QUrl originalUrl = info.urlOf(UrlInfoType::kOriginalUrl);
+        if (originalUrl.isValid()) {
+            readUrl = originalUrl;
+        }
     }
 
-    QByteArray fileData = file.readAll();
-    file.close();
+    qreal dpr = qApp->devicePixelRatio();
+    QSize maxSize = targetSize * dpr;
 
+    QByteArray fileData = DFMIO::DFile(readUrl).readAll();
     if (fileData.isEmpty()) {
-        fmWarning() << "detailview: empty data from file:" << filePath;
+        fmWarning() << "detailview: empty data from file:" << filePath << "readUrl:" << readUrl;
         return QPixmap();
     }
 
-    // Load image from memory buffer instead of file path
+    // Reject truncated data to avoid rendering incomplete image.
+    if (expectedSize > 0 && fileData.size() < expectedSize) {
+        fmWarning() << "detailview: incomplete data:" << filePath
+                    << "actual:" << fileData.size() << "expected:" << expectedSize
+                    << "readUrl:" << readUrl;
+        return QPixmap();
+    }
+
+    // Load image from memory buffer instead of file path.
     QBuffer buffer(&fileData);
     buffer.open(QIODevice::ReadOnly);
 
@@ -214,9 +230,6 @@ QPixmap ImagePreviewWorker::loadImageFromMemory(const QString &filePath, const Q
         return QPixmap();
     }
 
-    qreal dpr = qApp->devicePixelRatio();
-    QSize maxSize = targetSize * dpr;
-
     if (originalSize.width() > maxSize.width()
         || originalSize.height() > maxSize.height()) {
         QSize scaledSize = originalSize.scaled(maxSize, Qt::KeepAspectRatio);
@@ -225,7 +238,8 @@ QPixmap ImagePreviewWorker::loadImageFromMemory(const QString &filePath, const Q
 
     QImage image = reader.read();
     if (image.isNull()) {
-        fmWarning() << "detailview: failed to decode image from memory:" << filePath;
+        fmWarning() << "detailview: failed to decode image from memory:"
+                    << filePath << "readUrl:" << readUrl << reader.errorString();
         return QPixmap();
     }
 

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.h
@@ -36,7 +36,7 @@ private:
     bool isImageMimeType(const QString &mimeType) const;
     bool shouldSkipOriginalImageLoad(const QUrl &url, qint64 fileSize) const;
     QPixmap loadOriginalImage(const QString &filePath, const QSize &targetSize);
-    QPixmap loadImageFromMemory(const QString &filePath, const QSize &targetSize);
+    QPixmap loadImageFromMemory(const QUrl &url, const QString &filePath, qint64 expectedSize, const QSize &targetSize);
     QPixmap loadThumbnail(const QUrl &url, const QSize &targetSize);
 
 private:


### PR DESCRIPTION
Enhanced image preview loading for remote filesystems to prevent crashes and incomplete previews. The main changes include:
1. Extended memory-based loading to all DAV/DAVS files instead of just TIFF files
2. Added support for reading from original remote URLs to avoid gvfs- fuse mount issues
3. Implemented file size validation to detect truncated reads
4. Improved error logging with detailed context information

The previous implementation only applied memory loading to TIFF files on DAV/DAVS protocols, but other image formats could also suffer from similar streaming read issues. By using the original remote URL directly via GIO backend instead of the gvfs mount path, we avoid truncated reads that commonly occur with network filesystems. The file size validation ensures we don't attempt to render incomplete images.

Influence:
1. Test image preview for various formats (JPEG, PNG, TIFF) on WebDAV mounts
2. Verify preview works correctly for large remote images
3. Check that incomplete file reads are properly handled without crashes
4. Test preview loading speed and memory usage for remote files
5. Verify error cases display appropriate fallback behavior

fix: 改进远程文件图像预览的可靠性

增强远程文件系统的图像预览加载功能，防止崩溃和不完整预览。主要改进包括：
1. 将基于内存的加载扩展到所有 DAV/DAVS 文件，而不仅是 TIFF 文件
2. 添加对从原始远程 URL 读取的支持，避免 gvfs-fuse 挂载问题
3. 实现文件大小验证以检测截断读取
4. 改进错误日志记录，包含详细上下文信息

之前的实现仅对 DAV/DAVS 协议上的 TIFF 文件应用内存加载，但其他图像格式也
可能遭受类似的流式读取问题。通过直接使用原始远程 URL（通过 GIO 后端）而
不是 gvfs 挂载路径，我们避免了网络文件系统常见的截断读取问题。文件大小验
证确保我们不会尝试渲染不完整的图像。

Influence:
1. 测试 WebDAV 挂载上各种格式（JPEG、PNG、TIFF）的图像预览
2. 验证大型远程图像的预览功能正常
3. 检查不完整文件读取是否得到正确处理且不会崩溃
4. 测试远程文件的预览加载速度和内存使用情况
5. 验证错误情况显示适当的回退行为

Bug: https://pms.uniontech.com/bug-view-353209.html

## Summary by Sourcery

Improve reliability of image previews for remote WebDAV files by loading them fully into memory via their original URLs and validating the data before rendering.

Bug Fixes:
- Prevent crashes and incomplete previews when loading images from DAV/DAVS remote filesystems by using memory-based loading for all image formats.
- Detect and reject truncated remote image data based on expected file size to avoid rendering corrupted previews.

Enhancements:
- Read remote image data via the original GIO-backed URL instead of the gvfs mount path, with a local-path fallback for robustness.
- Enrich image loading error logs with original URL and decoder error details to aid diagnosis of remote preview failures.