### PR TITLE
chore: reorder cmake includes for correct path calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ option(OPT_ENABLE_BUILD_TESTS "Build test/demo programs" OFF)
 include(install_dconfig)
 include(install_treeland_overrides)
 include(install_dbus_service)
-include(GNUInstallDirs)
 include(DFMInstallDirs)
+include(GNUInstallDirs)
 
 # Skip build rpath for reproducible release build
 if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/cmake/DFMInstallDirs.cmake
+++ b/cmake/DFMInstallDirs.cmake
@@ -1,8 +1,10 @@
-include(GNUInstallDirs)
-
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX /usr)
 endif()
+
+# include(GNUInstallDirs) must come after set(CMAKE_INSTALL_PREFIX /usr),
+# because the GNUInstallDirs script calculates CMAKE_IN_<dir> based on PREFIX.
+include(GNUInstallDirs)
 
 # Base directories
 if(NOT DEFINED LIB_INSTALL_DIR)


### PR DESCRIPTION
The order of include statements in CMakeLists.txt has been adjusted to ensure proper path calculation. DFMInstallDirs.cmake now includes GNUInstallDirs after setting CMAKE_INSTALL_PREFIX, which is necessary because GNUInstallDirs calculates installation paths based on the current prefix value. This fix resolves potential issues with incorrect installation directory paths when using custom prefixes.

The main CMakeLists.txt file has also been updated to maintain consistent include ordering, with DFMInstallDirs included before GNUInstallDirs to prevent any dependency conflicts.

Influence:
1. Verify cmake configuration completes without warnings about path variables
2. Test installation with default prefix (/usr) to ensure paths are correct
3. Test installation with custom prefix to verify path calculations work properly
4. Check that all files are installed to expected locations
5. Verify build reproducibility with different prefix settings

chore: 调整 cmake include 顺序以确保正确路径计算

已调整 CMakeLists.txt 中 include 语句的顺序以确保正确的路径计
算。DFMInstallDirs.cmake 现在在设置 CMAKE_INSTALL_PREFIX 后包含 GNUInstallDirs，这是必要的，因为 GNUInstallDirs 基于当前前缀值计算安装路 径。此修复解决了使用自定义前缀时可能出现的安装目录路径不正确的问题。

主 CMakeLists.txt 文件也已更新以保持一致的 include 顺序，将
DFMInstallDirs 包含在 GNUInstallDirs 之前以防止任何依赖冲突。

Influence:
1. 验证 cmake 配置完成时没有关于路径变量的警告
2. 使用默认前缀 (/usr) 测试安装以确保路径正确
3. 使用自定义前缀测试安装以验证路径计算正常工作
4. 检查所有文件是否安装到预期位置
5. 验证不同前缀设置下的构建可重现性

## Summary by Sourcery

Reorder CMake include directives so that DFMInstallDirs sets the install prefix before GNUInstallDirs computes derived installation paths, ensuring correct install directory calculation for both default and custom prefixes.

Build:
- Adjust CMake include order in DFMInstallDirs.cmake to include GNUInstallDirs only after setting CMAKE_INSTALL_PREFIX.
- Align include ordering in the top-level CMakeLists.txt so DFMInstallDirs is processed before GNUInstallDirs for consistent path handling.