### PR TITLE
feat: optimize file scanning performance with CountOnly mode

### DIFF
--- a/src/dfm-base/utils/filescanner.cpp
+++ b/src/dfm-base/utils/filescanner.cpp
@@ -81,7 +81,7 @@ private:
     static void scanOtherProtocolsImpl(ScanState &state, const QList<QUrl> &urls);
 
     // 辅助方法
-    static bool readDirectoryEntries(const QString &path, QList<DirEntry> *entries);
+    static bool readDirectoryEntries(const QString &path, QList<DirEntry> *entries, bool countOnly = false);
     static void processRegularFile(ScanState &state, const QString &path, const struct stat &statBuf);
     static void processSymlink(ScanState &state, const QString &path);
     static bool isDirectoryPath(const QString &path, const struct stat &lstatBuf);
@@ -341,7 +341,9 @@ void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &ur
                 collectFileIfEnabled(state, url, true);
             } else {
                 // 非目录：直接收集（普通文件、符号链接等）
-                if (S_ISREG(statBuf.st_mode)) {
+                if (state.options & FileScanner::ScanOption::CountOnly) {
+                    state.result.fileCount++;
+                } else if (S_ISREG(statBuf.st_mode)) {
                     processRegularFile(state, path, statBuf);
                 } else if (S_ISLNK(statBuf.st_mode)) {
                     processSymlink(state, path);
@@ -372,7 +374,8 @@ void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &ur
 
         // 读取目录内容
         QList<DirEntry> entries;
-        bool readSuccess = readDirectoryEntries(dirPath, &entries);
+        bool countOnly = state.options & FileScanner::ScanOption::CountOnly;
+        bool readSuccess = readDirectoryEntries(dirPath, &entries, countOnly);
 
         if (!readSuccess) {
             // 目录读取失败（权限不足），但目录已计数
@@ -388,6 +391,28 @@ void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &ur
 
             const QString entryPath = dirPath + "/" + entry.name;
             const QUrl entryUrl = QUrl::fromLocalFile(entryPath);
+
+            if (countOnly) {
+                // CountOnly 模式：直接用 d_type 计数，无需 stat
+                if (entry.d_type == DT_DIR) {
+                    bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
+                    if (isSingleDepth) {
+                        state.result.directoryCount++;
+                    } else {
+                        ScanContext childCtx;
+                        childCtx.fullPath = entryPath;
+                        childCtx.depth = ctx.depth + 1;
+                        childCtx.isSourcePath = false;
+                        dirStack.push(childCtx);
+                    }
+                } else {
+                    // 普通文件、符号链接、其他类型统一计数
+                    state.result.fileCount++;
+                }
+                collectFileIfEnabled(state, entryUrl, false);
+                emitProgress(state);
+                continue;
+            }
 
             // 跳过特殊系统文件
             if (entry.statOk && S_ISREG(entry.statBuf.st_mode)) {
@@ -534,10 +559,12 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
                             collectFileIfEnabled(state, childUrl, false);
                         } else {
                             // 处理文件
-                            state.result.totalSize += childInfo->size();
                             state.result.fileCount++;
-                            state.result.progressSize += childInfo->size();
-
+                            if (!(state.options & FileScanner::ScanOption::CountOnly)) {
+                                qint64 sz = childInfo->size();
+                                state.result.totalSize += sz;
+                                state.result.progressSize += sz;
+                            }
                             // 收集子文件URL
                             collectFileIfEnabled(state, childUrl, false);
                         }
@@ -546,9 +573,12 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
             }
         } else {
             // 处理文件
-            state.result.totalSize += info->size();
             state.result.fileCount++;
-            state.result.progressSize += info->size();
+            if (!(state.options & FileScanner::ScanOption::CountOnly)) {
+                qint64 sz = info->size();
+                state.result.totalSize += sz;
+                state.result.progressSize += sz;
+            }
 
             // 收集文件URL
             collectFileIfEnabled(state, url, false);
@@ -567,7 +597,7 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
                         << "dirs:" << state.result.directoryCount << "size:" << state.result.totalSize;
 }
 
-bool FileScannerCore::readDirectoryEntries(const QString &path, QList<DirEntry> *entries)
+bool FileScannerCore::readDirectoryEntries(const QString &path, QList<DirEntry> *entries, bool countOnly)
 {
     Q_ASSERT(entries);
     entries->clear();
@@ -595,12 +625,28 @@ bool FileScannerCore::readDirectoryEntries(const QString &path, QList<DirEntry> 
 
         const QByteArray nameBytes(entry->d_name);
         DirEntry dirEntry;
-        dirEntry.name = QString::fromUtf8(nameBytes);   // 统一存储为 QString
+        dirEntry.name = QString::fromUtf8(nameBytes);
         dirEntry.d_type = entry->d_type;
 
-        dirEntry.statOk = (fstatat(dirFd, entry->d_name, &dirEntry.statBuf, AT_SYMLINK_NOFOLLOW) == 0);
-        if (!dirEntry.statOk) {
-            qCWarning(logDFMBase) << "FileScannerCore: fstatat failed for" << dirEntry.name << "in" << path;
+        if (countOnly) {
+            // CountOnly 模式：优先用 d_type，仅在 DT_UNKNOWN 时 fstatat 取类型
+            if (entry->d_type == DT_UNKNOWN) {
+                struct stat sb;
+                if (fstatat(dirFd, entry->d_name, &sb, AT_SYMLINK_NOFOLLOW) == 0) {
+                    if (S_ISDIR(sb.st_mode))
+                        dirEntry.d_type = DT_DIR;
+                    else if (S_ISLNK(sb.st_mode))
+                        dirEntry.d_type = DT_LNK;
+                    else if (S_ISREG(sb.st_mode))
+                        dirEntry.d_type = DT_REG;
+                }
+            }
+            dirEntry.statOk = false;   // CountOnly 不需要 statBuf
+        } else {
+            dirEntry.statOk = (fstatat(dirFd, entry->d_name, &dirEntry.statBuf, AT_SYMLINK_NOFOLLOW) == 0);
+            if (!dirEntry.statOk) {
+                qCWarning(logDFMBase) << "FileScannerCore: fstatat failed for" << dirEntry.name << "in" << path;
+            }
         }
 
         entries->append(dirEntry);

--- a/src/dfm-base/utils/filescanner.h
+++ b/src/dfm-base/utils/filescanner.h
@@ -59,7 +59,8 @@ public:
         NoOption = 0x00,   ///< 无特殊选项
         SingleDepth = 0x01,   ///< 只统计顶层，不递归
         IncludeSource = 0x02,   ///< 包含源目录本身（默认不包含）
-        CollectFiles = 0x04   ///< 收集所有文件URL列表（默认不收集）
+        CollectFiles = 0x04,   ///< 收集所有文件URL列表（默认不收集）
+        CountOnly = 0x08   ///< 只统计数量，跳过大小统计，避免 stat 系统调用以提升性能
     };
     Q_ENUM(ScanOption)
     Q_DECLARE_FLAGS(ScanOptions, ScanOption)

--- a/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
+++ b/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
@@ -69,7 +69,7 @@ void BasicStatusBarPrivate::calcFolderContains(const QList<QUrl> &folderList)
     discardCurrentJob();
 
     fileStatisticsJog = new FileScanner(this);
-    fileStatisticsJog->setOptions(FileScanner::ScanOption::SingleDepth);
+    fileStatisticsJog->setOptions(FileScanner::ScanOption::SingleDepth | FileScanner::ScanOption::CountOnly);
 
     if (isJobDisconnect) {
         isJobDisconnect = false;


### PR DESCRIPTION
Added CountOnly scan option to improve file scanning performance by avoiding unnecessary stat system calls. When CountOnly is enabled, the scanner uses directory entry types (d_type) for basic file counting instead of performing full stat operations. This significantly reduces I/O overhead for operations that only need file/directory counts without size information.

The implementation includes:
1. Added CountOnly flag to ScanOptions enum
2. Modified readDirectoryEntries to accept countOnly parameter
3. Optimized local filesystem scanning to use d_type when possible
4. Enhanced network protocol scanning to skip size calculations in CountOnly mode
5. Updated status bar file counting to use the new optimized mode

Log: Improved file scanning performance in folder statistics

Influence:
1. Test folder statistics in status bar with various directory structures
2. Verify file counts are accurate in CountOnly mode
3. Compare scanning performance between normal and CountOnly modes
4. Test with mixed file types (regular files, directories, symlinks)
5. Verify network protocol scanning works correctly with CountOnly
6. Check that normal scanning mode still provides full file details

feat: 新增 CountOnly 模式优化文件扫描性能

添加 CountOnly 扫描选项，通过避免不必要的 stat 系统调用来提升文件扫描性
能。当启用 CountOnly 模式时，扫描器使用目录条目类型（d_type）进行基本文
件计数，而不是执行完整的 stat 操作。这显著减少了仅需要文件/目录计数而不
需要大小信息的操作的 I/O 开销。

实现包括：
1. 在 ScanOptions 枚举中添加 CountOnly 标志
2. 修改 readDirectoryEntries 函数接受 countOnly 参数
3. 优化本地文件系统扫描，尽可能使用 d_type
4. 增强网络协议扫描，在 CountOnly 模式下跳过大小计算
5. 更新状态栏文件计数以使用新的优化模式

Log: 优化文件夹统计的文件扫描性能

Influence:
1. 测试状态栏中不同目录结构的文件夹统计
2. 验证 CountOnly 模式下的文件计数准确性
3. 比较正常模式和 CountOnly 模式的扫描性能
4. 测试混合文件类型（常规文件、目录、符号链接）
5. 验证网络协议扫描在 CountOnly 模式下正常工作
6. 检查正常扫描模式仍能提供完整的文件详细信息

## Summary by Sourcery

Introduce an optional CountOnly scan mode to speed up file and folder statistics by skipping size and stat-based metadata when only counts are needed.

New Features:
- Add CountOnly scan option to FileScanner to allow counting files and directories without computing sizes.

Enhancements:
- Optimize local filesystem directory scanning to rely on directory entry types in CountOnly mode and avoid per-entry stat calls.
- Adjust other-protocol scanning to skip size accumulation when CountOnly is enabled while still counting files and directories.
- Update status bar folder statistics to use CountOnly mode for faster, shallow directory counts.