### PR TITLE
fix: improve icon shadow rendering with aspect ratio

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -138,12 +138,12 @@ void CanvasItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         // draw icon and background
         const QRect rIcon = iconRect(option.rect);
         paintBackground(painter, indexOption, rIcon);
-        const std::optional<QRectF> &pIcon = paintIcon( painter, indexOption.icon,
-                                                        { rIcon,
-                                                          Qt::AlignCenter,
-                                                          (option.state & QStyle::State_Enabled) ? QIcon::Normal : QIcon::Disabled,
-                                                          QIcon::Off,
-                                                          isThumnailIconIndex(index) });   // why Enabled?
+        const std::optional<QRectF> &pIcon = paintIcon(painter, indexOption.icon,
+                                                       { rIcon,
+                                                         Qt::AlignCenter,
+                                                         (option.state & QStyle::State_Enabled) ? QIcon::Normal : QIcon::Disabled,
+                                                         QIcon::Off,
+                                                         isThumnailIconIndex(index) });   // why Enabled?
 
         // If the thumbnail drawing is empty, then redraw the file fileicon
         if (!pIcon.has_value()) {
@@ -318,9 +318,9 @@ QSize CanvasItemDelegate::paintDragIcon(QPainter *painter, const QStyleOptionVie
     initStyleOption(&indexOption, index);
 
     painter->setRenderHints(painter->renderHints() | QPainter::Antialiasing | QPainter::SmoothPixmapTransform, true);
-    const std::optional<QRectF> &pIcon = paintIcon( painter, indexOption.icon,
-                                                    { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
-                                                      QIcon::Off, isThumnailIconIndex(index) });
+    const std::optional<QRectF> &pIcon = paintIcon(painter, indexOption.icon,
+                                                   { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
+                                                     QIcon::Off, isThumnailIconIndex(index) });
     // If the thumbnail drawing is empty, then redraw the file fileicon
     if (!pIcon.has_value()) {
         const QIcon &fileIcon = index.data(Global::ItemRoles::kItemFileIconRole).value<QIcon>();
@@ -826,19 +826,43 @@ std::optional<QRectF> CanvasItemDelegate::paintIcon(QPainter *painter, const QIc
             y = opts.rect.y() + (opts.rect.height() - h) / 2.0;
         }
 
-        QRectF backgroundRect { x, y, w, h };
-        QRectF imageRect { backgroundRect };
+        QRectF imageRect { x, y, w, h };
 
-        // 绘制带有阴影的背景
+        // Calculate aspect ratio for proportional adjustments
+        qreal radio = w / h;
+        // Avoid collapsing very narrow/tall thumbnails (e.g. 99x1026) to 0px after inset.
+        // Calculate inset proportionally to maintain aspect ratio
+        int insetX, insetY;
+        if (radio > 1.0) {
+            // Wide image: insetY should be proportionally smaller
+            insetX = qMin<qreal>(iconStyle.shadowRange, qMax<qreal>(0.0, (imageRect.width() - 1.0) / 2.0));
+            insetY = qRound(insetX / radio);
+        } else if (radio < 1.0 && radio > 0) {
+            // Tall image: insetX should be proportionally smaller
+            insetY = qMin<qreal>(iconStyle.shadowRange, qMax<qreal>(0.0, (imageRect.height() - 1.0) / 2.0));
+            insetX = qRound(insetY * radio);
+        } else {
+            // Square or invalid ratio
+            insetX = qMin<qreal>(iconStyle.shadowRange, qMax<qreal>(0.0, (imageRect.width() - 1.0) / 2.0));
+            insetY = insetX;
+        }
+
+        imageRect.adjust(insetX, insetY, -insetX, -insetY);
+
+        // 绘制带有阴影的背景：
+        // backgroundRect = imageRect 外扩 stroke，作为白色底板区域
+        // shadowRect     = backgroundRect 再外扩 shadowRange，用于容纳阴影扩散
         auto stroke { iconStyle.stroke };
+        auto shadowRange { iconStyle.shadowRange };
+        QRectF backgroundRect { imageRect };
         backgroundRect.adjust(-stroke, -stroke, stroke, stroke);
         const auto &originPixmap { IconUtils::renderIconBackground(backgroundRect.size(), iconStyle) };
-        const auto &shadowPixmap { IconUtils::addShadowToPixmap(originPixmap, iconStyle.shadowOffset, iconStyle.shadowRange, 0.2) };
-        painter->drawPixmap(backgroundRect, shadowPixmap, QRectF());
-        // Avoid collapsing very narrow/tall thumbnails to 0px after inset.
-        const qreal insetX = qMin<qreal>(iconStyle.shadowRange, qMax<qreal>(0.0, (imageRect.width() - 1.0) / 2.0));
-        const qreal insetY = qMin<qreal>(iconStyle.shadowRange, qMax<qreal>(0.0, (imageRect.height() - 1.0) / 2.0));
-        imageRect.adjust(insetX, insetY, -insetX, -insetY);
+        // addShadowToPixmap 会在四周各扩展 shadowRange 像素来容纳阴影
+        const auto &shadowPixmap { IconUtils::addShadowToPixmap(originPixmap, iconStyle.shadowOffset, shadowRange, 0.2) };
+        // 绘制目标区域需外扩 shadowRange，使阴影像素完整显示
+        QRectF shadowRect { backgroundRect };
+        shadowRect.adjust(-shadowRange, -shadowRange, shadowRange, shadowRange);
+        painter->drawPixmap(shadowRect, shadowPixmap, QRectF());
 
         QPainterPath clipPath;
         auto radius { iconStyle.radius - iconStyle.stroke };

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -157,12 +157,12 @@ void CollectionItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem
         // draw icon and background
         const QRect rIcon = iconRect(option.rect);
         paintBackground(painter, indexOption, rIcon);
-        const std::optional<QRect> &pIcon = paintIcon( painter, indexOption.icon,
-                                                       { rIcon,
-                                                         Qt::AlignCenter,
-                                                         (option.state & QStyle::State_Enabled) ? QIcon::Normal : QIcon::Disabled,
-                                                         QIcon::Off,
-                                                         isThumnailIconIndex(index) });   // why Enabled?
+        const std::optional<QRect> &pIcon = paintIcon(painter, indexOption.icon,
+                                                      { rIcon,
+                                                        Qt::AlignCenter,
+                                                        (option.state & QStyle::State_Enabled) ? QIcon::Normal : QIcon::Disabled,
+                                                        QIcon::Off,
+                                                        isThumnailIconIndex(index) });   // why Enabled?
         // If the thumbnail drawing is empty, then redraw the file fileicon
         if (!pIcon.has_value()) {
             const QIcon &fileIcon = index.data(Global::ItemRoles::kItemFileIconRole).value<QIcon>();
@@ -341,9 +341,9 @@ QSize CollectionItemDelegate::paintDragIcon(QPainter *painter, const QStyleOptio
     initStyleOption(&indexOption, index);
 
     painter->setRenderHints(painter->renderHints() | QPainter::Antialiasing | QPainter::SmoothPixmapTransform, true);
-    const std::optional<QRect> &pIcon = paintIcon( painter, indexOption.icon,
-                                                   { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
-                                                     QIcon::Off, isThumnailIconIndex(index) });
+    const std::optional<QRect> &pIcon = paintIcon(painter, indexOption.icon,
+                                                  { indexOption.rect, Qt::AlignCenter, QIcon::Normal,
+                                                    QIcon::Off, isThumnailIconIndex(index) });
     // If the thumbnail drawing is empty, then redraw the file fileicon
     if (!pIcon.has_value()) {
         const QIcon &fileIcon = index.data(Global::ItemRoles::kItemFileIconRole).value<QIcon>();
@@ -853,19 +853,43 @@ std::optional<QRect> CollectionItemDelegate::paintIcon(QPainter *painter, const 
             y = opts.rect.y() + (opts.rect.height() - h) / 2.0;
         }
 
-        QRect backgroundRect { qRound(x), qRound(y), qRound(w), qRound(h) };
-        QRect imageRect { backgroundRect };
+        QRect imageRect { qRound(x), qRound(y), qRound(w), qRound(h) };
 
-        // 绘制带有阴影的背景
+        // Calculate aspect ratio for proportional adjustments
+        qreal radio = w / h;
+        // Avoid collapsing very narrow/tall thumbnails (e.g. 99x1026) to 0px after inset.
+        // Calculate inset proportionally to maintain aspect ratio
+        int insetX, insetY;
+        if (radio > 1.0) {
+            // Wide image: insetY should be proportionally smaller
+            insetX = qMin(iconStyle.shadowRange, qMax(0, (imageRect.width() - 1) / 2));
+            insetY = qRound(insetX / radio);
+        } else if (radio < 1.0 && radio > 0) {
+            // Tall image: insetX should be proportionally smaller
+            insetY = qMin(iconStyle.shadowRange, qMax(0, (imageRect.height() - 1) / 2));
+            insetX = qRound(insetY * radio);
+        } else {
+            // Square or invalid ratio
+            insetX = qMin(iconStyle.shadowRange, qMax(0, (imageRect.width() - 1) / 2));
+            insetY = insetX;
+        }
+
+        imageRect.adjust(insetX, insetY, -insetX, -insetY);
+
+        // 绘制带有阴影的背景：
+        // backgroundRect = imageRect 外扩 stroke，作为白色底板区域
+        // shadowRect     = backgroundRect 再外扩 shadowRange，用于容纳阴影扩散
         auto stroke { iconStyle.stroke };
+        auto shadowRange { iconStyle.shadowRange };
+        QRect backgroundRect { imageRect };
         backgroundRect.adjust(-stroke, -stroke, stroke, stroke);
         const auto &originPixmap { IconUtils::renderIconBackground(backgroundRect.size(), iconStyle) };
-        const auto &shadowPixmap { IconUtils::addShadowToPixmap(originPixmap, iconStyle.shadowOffset, iconStyle.shadowRange, 0.2) };
-        painter->drawPixmap(backgroundRect, shadowPixmap);
-        // Avoid collapsing very narrow/tall thumbnails to 0px after inset.
-        const int insetX = qMin(iconStyle.shadowRange, qMax(0, (imageRect.width() - 1) / 2));
-        const int insetY = qMin(iconStyle.shadowRange, qMax(0, (imageRect.height() - 1) / 2));
-        imageRect.adjust(insetX, insetY, -insetX, -insetY);
+        // addShadowToPixmap 会在四周各扩展 shadowRange 像素来容纳阴影
+        const auto &shadowPixmap { IconUtils::addShadowToPixmap(originPixmap, iconStyle.shadowOffset, shadowRange, 0.2) };
+        // 绘制目标区域需外扩 shadowRange，使阴影像素完整显示
+        QRect shadowRect { backgroundRect };
+        shadowRect.adjust(-shadowRange, -shadowRange, shadowRange, shadowRange);
+        painter->drawPixmap(shadowRect, shadowPixmap);
 
         QPainterPath clipPath;
         auto radius { iconStyle.radius - iconStyle.stroke };

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/itemdelegatehelper.cpp
@@ -104,26 +104,50 @@ bool ItemDelegateHelper::paintIcon(QPainter *painter, const QIcon &icon, const P
             y = opts.rect.y() + (opts.rect.height() - h) / 2.0;
         }
 
-        QRect backgroundRect { qRound(x), qRound(y), qRound(w), qRound(h) };
-        QRect imageRect { backgroundRect };
+        QRect imageRect { qRound(x), qRound(y), qRound(w), qRound(h) };
 
-        // 绘制带有阴影的背景
+        // Calculate aspect ratio for proportional adjustments
+        qreal radio = w / h;
+        // Avoid collapsing very narrow/tall thumbnails (e.g. 99x1026) to 0px after inset.
+        // Calculate inset proportionally to maintain aspect ratio
+        int insetX, insetY;
+        if (radio > 1.0) {
+            // Wide image: insetY should be proportionally smaller
+            insetX = qMin(iconStyle.shadowRange, qMax(0, (imageRect.width() - 1) / 2));
+            insetY = qRound(insetX / radio);
+        } else if (radio < 1.0 && radio > 0) {
+            // Tall image: insetX should be proportionally smaller
+            insetY = qMin(iconStyle.shadowRange, qMax(0, (imageRect.height() - 1) / 2));
+            insetX = qRound(insetY * radio);
+        } else {
+            // Square or invalid ratio
+            insetX = qMin(iconStyle.shadowRange, qMax(0, (imageRect.width() - 1) / 2));
+            insetY = insetX;
+        }
+
+        imageRect.adjust(insetX, insetY, -insetX, -insetY);
+
+        // 绘制带有阴影的背景：
+        // backgroundRect = imageRect 外扩 stroke，作为白色底板区域
+        // shadowRect     = backgroundRect 再外扩 shadowRange，用于容纳阴影扩散
         auto stroke { iconStyle.stroke };
+        auto shadowRange { iconStyle.shadowRange };
+        QRect backgroundRect { imageRect };
         backgroundRect.adjust(-stroke, -stroke, stroke, stroke);
         const auto &originPixmap { IconUtils::renderIconBackground(backgroundRect.size(), iconStyle) };
-        const auto &shadowPixmap { IconUtils::addShadowToPixmap(originPixmap, iconStyle.shadowOffset, iconStyle.shadowRange, 0.2) };
-        painter->drawPixmap(backgroundRect, shadowPixmap);
-        // Avoid collapsing very narrow/tall thumbnails (e.g. 99x1026) to 0px after inset.
-        const int insetX = qMin(iconStyle.shadowRange, qMax(0, (imageRect.width() - 1) / 2));
-        const int insetY = qMin(iconStyle.shadowRange, qMax(0, (imageRect.height() - 1) / 2));
-        imageRect.adjust(insetX, insetY, -insetX, -insetY);
+        // addShadowToPixmap 会在四周各扩展 shadowRange 像素来容纳阴影
+        const auto &shadowPixmap { IconUtils::addShadowToPixmap(originPixmap, iconStyle.shadowOffset, shadowRange, 0.2) };
+        // 绘制目标区域需外扩 shadowRange，使阴影像素完整显示
+        QRect shadowRect { backgroundRect };
+        shadowRect.adjust(-shadowRange, -shadowRange, shadowRange, shadowRange);
+        painter->drawPixmap(shadowRect, shadowPixmap);
+
         QPainterPath clipPath;
         auto radius { iconStyle.radius - iconStyle.stroke };
         clipPath.addRoundedRect(imageRect, radius, radius);
         painter->setClipPath(clipPath);
         painter->drawPixmap(imageRect, px);
         painter->restore();
-
     } else {
         // 使用QRectF来避免舍入误差，同时保持比例
         QRectF targetRect(qRound(x), qRound(y), w, h);


### PR DESCRIPTION
Fixed icon shadow rendering to maintain proper aspect ratio when
applying insets for thumbnail images. Previously, fixed inset values
could collapse very narrow or tall thumbnails to zero size. Now
calculates proportional insets based on image aspect ratio to preserve
thumbnail visibility while maintaining shadow effect. Also corrected
shadow rendering area calculation to ensure shadow pixels are fully
displayed.

The changes ensure that thumbnails with extreme aspect ratios (e.g.,
99x1026) remain visible after applying shadow insets. The algorithm now:
1. Calculates aspect ratio to determine proportional inset adjustments
2. For wide images (ratio > 1.0): reduces vertical inset proportionally
3. For tall images (ratio < 1.0): reduces horizontal inset
proportionally
4. For square images: uses equal insets
5. Correctly calculates shadow rectangle to accommodate full shadow
range

Log: Fixed thumbnail display issue where very narrow or tall images
could become invisible due to incorrect shadow inset calculations

Influence:
1. Test file manager with various image aspect ratios (wide, tall,
square)
2. Verify thumbnails remain visible for extreme aspect ratios
3. Check shadow rendering consistency across different image sizes
4. Test icon display in list, icon, and other view modes
5. Verify no visual artifacts or clipping issues with shadow effects

fix: 改进图标阴影渲染以保持宽高比

修复了图标阴影渲染，在应用缩略图内边距时保持正确的宽高比。之前固定的内边
距值可能导致非常窄或高的缩略图缩小到零尺寸。现在根据图像宽高比计算比例内
边距，在保持阴影效果的同时保留缩略图可见性。同时修正了阴影渲染区域计算，
确保阴影像素完全显示。

这些更改确保具有极端宽高比（例如99x1026）的缩略图在应用阴影内边距后保持
可见。算法现在：
1. 计算宽高比以确定比例内边距调整
2. 对于宽图像（比例 > 1.0）：按比例减少垂直内边距
3. 对于高图像（比例 < 1.0）：按比例减少水平内边距
4. 对于方形图像：使用相等内边距
5. 正确计算阴影矩形以容纳完整的阴影范围

Log: 修复了缩略图显示问题，之前非常窄或高的图像可能因错误的阴影内边距计
算而变得不可见

Influence:
1. 测试文件管理器处理各种图像宽高比（宽、高、方形）
2. 验证极端宽高比的缩略图保持可见
3. 检查不同图像尺寸的阴影渲染一致性
4. 测试列表、图标和其他视图模式下的图标显示
5. 验证阴影效果没有视觉伪影或裁剪问题

BUG: https://pms.uniontech.com/bug-view-352999.html

## Summary by Sourcery

Improve icon painting to preserve thumbnail visibility and correctly render shadows for icons with extreme aspect ratios.

Bug Fixes:
- Prevent very narrow or tall thumbnail icons from collapsing to zero size when applying shadow insets.
- Ensure shadow bitmaps are drawn within a correctly expanded rectangle so the full shadow is visible without clipping.

Enhancements:
- Adjust icon insets proportionally based on image aspect ratio to maintain a visually balanced shadowed background across different thumbnail shapes.