### PR TITLE
fix: enhance network detection for various URI schemes

### DIFF
--- a/src/dfm-base/base/device/private/devicehelper.cpp
+++ b/src/dfm-base/base/device/private/devicehelper.cpp
@@ -41,6 +41,28 @@ static constexpr char kBurnMediaType[] { "BurnMediaType" };
 static constexpr char kBurnWriteSpeed[] { "BurnWriteSpeed" };
 
 using namespace dfmbase;
+
+namespace {
+
+const QHash<QString, QString> &defaultPortMap()
+{
+    static const QHash<QString, QString> map = {
+        { Global::Scheme::kFtp, "21" },
+        { Global::Scheme::kSFtp, "22" },
+        { Global::Scheme::kDav, "80" },
+        { Global::Scheme::kDavs, "443" },
+        { Global::Scheme::kNfs, "2049" }
+    };
+    return map;
+}
+
+QString defaultPortForScheme(const QString &scheme)
+{
+    return defaultPortMap().value(scheme, QString());
+}
+
+}   // namespace
+
 DFM_MOUNT_USE_NS
 // see: https://github.com/linuxdeepin/dtk/issues/134
 DWIDGET_USE_NAMESPACE
@@ -471,22 +493,38 @@ void DeviceHelper::readOpticalInfo(QVariantMap &datas)
 bool DeviceHelper::checkNetworkConnection(const QString &id)
 {
     QUrl url(id);
-    if (!(ProtocolUtils::isSMBFile(url) || ProtocolUtils::isSFTPFile(url) || ProtocolUtils::isFTPFile(url)))
+    if (!ProtocolUtils::isRemoteFile(url)
+        || ProtocolUtils::isMTPFile(url)
+        || ProtocolUtils::isGphotoFile(url))
         return true;
 
     QString host, port;
-    if (NetworkUtils::instance()->parseIp(url.path(), host, port)) {
-        if (url.scheme() == "smb" && url.port() == -1) {
-            QStringList defaultSmbPorts = { "445", "139" };
-            return std::any_of(defaultSmbPorts.cbegin(), defaultSmbPorts.cend(),
-                               [host](const QString &port) {
-                                   bool connected = NetworkUtils::instance()->checkNetConnection(host, port);
-                                   qCDebug(logDFMBase) << "Network connection check for host:" << host
-                                                       << "port:" << port
-                                                       << "result:" << connected;
-                                   return connected;
-                               });
-        }
+    // Prefer standard URI parsing first (e.g. sftp://host/, davs://host/path).
+    host = url.host();
+    if (!host.isEmpty()) {
+        if (url.port() > 0)
+            port = QString::number(url.port());
+        else
+            port = defaultPortForScheme(url.scheme());
+    }
+
+    // Fallback to existing mount-path parser for gvfs/cifs style local mount paths.
+    if (host.isEmpty() || port.isEmpty())
+        NetworkUtils::instance()->parseIp(url.path(), host, port);
+
+    if (url.scheme() == "smb" && url.port() == -1) {
+        QStringList defaultSmbPorts = { "445", "139" };
+        return std::any_of(defaultSmbPorts.cbegin(), defaultSmbPorts.cend(),
+                           [host](const QString &port) {
+                               bool connected = NetworkUtils::instance()->checkNetConnection(host, port);
+                               qCDebug(logDFMBase) << "Network connection check for host:" << host
+                                                   << "port:" << port
+                                                   << "result:" << connected;
+                               return connected;
+                           });
+    }
+
+    if (!host.isEmpty() && !port.isEmpty()) {
         return NetworkUtils::instance()->checkNetConnection(host, port);
     }
 
@@ -518,7 +556,12 @@ QVariantMap DeviceHelper::makeFakeProtocolInfo(const QString &id)
             fakeInfo[DeviceProperty::kDisplayName] = QObject::tr("Unknown");
     } else {
         QString host, port;
-        if (NetworkUtils::instance()->parseIp(QUrl(id).path(), host, port))
+        QUrl url(id);
+        host = url.host();
+        if (host.isEmpty())
+            NetworkUtils::instance()->parseIp(url.path(), host, port);
+
+        if (!host.isEmpty())
             fakeInfo[DeviceProperty::kDisplayName] = host;
         else
             fakeInfo[DeviceProperty::kDisplayName] = QObject::tr("Unknown");

--- a/src/dfm-base/utils/protocolutils.cpp
+++ b/src/dfm-base/utils/protocolutils.cpp
@@ -20,6 +20,17 @@ bool isRemoteFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
+    // Fast path: known remote schemes
+    const auto &scheme = url.scheme();
+    static const QSet<QString> kRemoteSchemes {
+        Global::Scheme::kSmb, Global::Scheme::kFtp, Global::Scheme::kSFtp,
+        Global::Scheme::kGPhoto, Global::Scheme::kGPhoto2, Global::Scheme::kMtp,
+        Global::Scheme::kAfc, Global::Scheme::kDav, Global::Scheme::kDavs,
+        Global::Scheme::kNfs
+    };
+    if (kRemoteSchemes.contains(scheme))
+        return true;
+
     // TODO(xust) smbmounts path might be changed in the future.
     static const QRegularExpression gvfsMatch { R"((^/run/user/\d+/gvfs/|^/root/.gvfs/|^/(?:run/)?media/[\s\S]*/smbmounts))" };
     return hasMatch(url.toLocalFile(), gvfsMatch);
@@ -30,6 +41,9 @@ bool isMTPFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
+    if (url.scheme() == Global::Scheme::kMtp)
+        return true;
+
     static const QRegularExpression gvfsMatch { R"(^/run/user/\d+/gvfs/mtp:host|^/root/.gvfs/mtp:host)" };
     return hasMatch(url.toLocalFile(), gvfsMatch);
 }
@@ -39,6 +53,10 @@ bool isGphotoFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
+    const auto &scheme = url.scheme();
+    if (scheme == Global::Scheme::kGPhoto || scheme == Global::Scheme::kGPhoto2)
+        return true;
+
     static const QRegularExpression gvfsMatch { R"(^/run/user/\d+/gvfs/gphoto2:host|^/root/.gvfs/gphoto2:host)" };
     return hasMatch(url.toLocalFile(), gvfsMatch);
 }
@@ -47,6 +65,8 @@ bool isFTPFile(const QUrl &url)
 {
     if (!url.isValid())
         return false;
+    if (url.scheme() == Global::Scheme::kFtp)
+        return true;
 
     static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/s?ftp|^/root/.gvfs/s?ftp))" };
     return hasMatch(url.path(), smbMatch);
@@ -56,6 +76,8 @@ bool isSFTPFile(const QUrl &url)
 {
     if (!url.isValid())
         return false;
+    if (url.scheme() == Global::Scheme::kSFtp)
+        return true;
 
     static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/sftp|^/root/.gvfs/sftp))" };
     return hasMatch(url.path(), smbMatch);
@@ -93,6 +115,9 @@ bool isNFSFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
+    if (url.scheme() == Global::Scheme::kNfs)
+        return true;
+
     static const QRegularExpression nfsMatch { R"((^/run/user/\d+/gvfs/nfs|^/root/.gvfs/nfs))" };
     return hasMatch(url.path(), nfsMatch);
 }
@@ -102,6 +127,9 @@ bool isDavFile(const QUrl &url)
     if (!url.isValid())
         return false;
 
+    if (url.scheme() == Global::Scheme::kDav)
+        return true;
+
     static const QRegularExpression davMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=false|^/root/.gvfs/dav.*ssl=false))" };
     return hasMatch(url.path(), davMatch);
 }
@@ -110,6 +138,9 @@ bool isDavsFile(const QUrl &url)
 {
     if (!url.isValid())
         return false;
+
+    if (url.scheme() == Global::Scheme::kDavs)
+        return true;
 
     static const QRegularExpression davsMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=true|^/root/.gvfs/dav.*ssl=true))" };
     return hasMatch(url.path(), davsMatch);


### PR DESCRIPTION
Improved network connection detection logic to handle multiple URI schemes more reliably and avoid application freezes. The changes include:
1. Added scheme-based default port mapping for common network protocols (FTP, SFTP, DAV, NFS, SMB)
2. Enhanced URI parsing to handle both standard URI formats and legacy mount paths
3. Updated protocol detection functions to check scheme first before falling back to path matching
4. Fixed network connection checking logic to properly exclude MTP and GPhoto devices

The previous implementation had limitations in detecting network connectivity for various URI schemes, which could lead to application hangs when network connections were lost. This enhancement ensures more robust network detection across different protocol types.

Log: Improved network connection detection for remote file protocols

Influence:
1. Test network file operations with different protocols (FTP, SFTP, SMB, DAV, NFS)
2. Verify application behavior when network connection is lost during file operations
3. Test with both standard URI formats and legacy mount paths
4. Check that MTP and GPhoto devices are properly excluded from network detection
5. Verify default port assignments for various protocols
6. Test network recovery scenarios after connection loss

fix: 增强多种URI方案下的网络检测

改进网络连接检测逻辑，更可靠地处理多种URI方案并避免应用卡死。具体变更
包括：
1. 为常见网络协议（FTP、SFTP、DAV、NFS、SMB）添加基于方案的默认端口映射
2. 增强URI解析功能，同时支持标准URI格式和传统挂载路径
3. 更新协议检测函数，优先检查方案类型，再回退到路径匹配
4. 修复网络连接检查逻辑，正确排除MTP和GPhoto设备

之前的实现在检测各种URI方案的网络连接性方面存在限制，可能导致网络连接丢
失时应用程序卡死。此增强确保跨不同协议类型的更可靠网络检测。

Log: 改进远程文件协议的网络连接检测

Influence:
1. 使用不同协议（FTP、SFTP、SMB、DAV、NFS）测试网络文件操作
2. 验证文件操作期间网络连接丢失时的应用程序行为
3. 测试标准URI格式和传统挂载路径
4. 检查MTP和GPhoto设备是否正确从网络检测中排除
5. 验证各种协议的默认端口分配
6. 测试连接丢失后的网络恢复场景

## Summary by Sourcery

Improve remote file network detection and URI handling to make connectivity checks more robust and avoid hangs.

Bug Fixes:
- Correct network connectivity checks for remote URIs so that MTP and GPhoto devices are excluded and no longer trigger unnecessary network probing.

Enhancements:
- Add scheme-based default port mapping and URI parsing for common remote protocols (FTP, SFTP, DAV, DAVS, NFS, SMB) when checking network connectivity.
- Extend protocol detection helpers to recognize remote resources primarily by URI scheme, with path-based matching as a fallback.
- Improve generation of fake protocol info to derive display names from standard remote URIs as well as legacy mount paths.