### PR TITLE
fix: fix icon view text clipping issue

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -682,6 +682,8 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
                                                        kIconViewSpacing, kIconViewSpacing));
     }
 
+    painter->save();
+    painter->setClipRect(opt.rect);
     // init file name geometry
     QRectF labelRect = drawingRect;
     labelRect.setTop(static_cast<int>(iconRect.bottom()) + kIconModeTextPadding + kIconModeIconSpacing);
@@ -718,7 +720,7 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
         d->expandedItem->setDifferenceOfLastRow(parent()->parent()->rowCount() - parent()->parent()->indexOfRow(index) - 1);
 
         updateEditorGeometry(d->expandedItem, opt, index);
-
+        painter->restore();
         return;
     } else {
         if (!singleSelected) {
@@ -757,6 +759,7 @@ void IconItemDelegate::paintItemFileName(QPainter *painter, QRectF iconRect, QPa
 
     QStringList textList {};
     layout->layout(labelRect, opt.textElideMode, painter, background, &textList);
+    painter->restore();
 }
 
 QSize IconItemDelegate::iconSizeByIconSizeLevel() const


### PR DESCRIPTION
Fixed text clipping issue in icon view mode by adding proper painter
clipping.
Added painter->save() and painter->restore() calls with
setClipRect(opt.rect) to ensure text rendering stays within item
boundaries.
Previously, file names could overflow outside their designated area
causing visual artifacts.

Log: Fixed file name text clipping in icon view

Influence:
1. Test icon view display with various file names (short, long, special
characters)
2. Verify text rendering stays within icon item boundaries
3. Check that expanded items still display correctly
4. Test with different icon sizes and text elide modes

fix: 修复图标视图文本裁剪问题

修复了图标视图模式下文本裁剪问题，通过添加正确的绘制器裁剪。
添加了 painter->save() 和 painter->restore() 调用，配合
setClipRect(opt.rect) 确保文本渲染保持在项目边界内。
之前，文件名可能会溢出到其指定区域之外，导致视觉伪影。

Log: 修复图标视图中文件名文本裁剪问题

Influence:
1. 测试图标视图显示各种文件名（短、长、特殊字符）
2. 验证文本渲染是否保持在图标项目边界内
3. 检查展开的项目是否仍能正确显示
4. 测试不同图标大小和文本省略模式

BUG: https://pms.uniontech.com/bug-view-320575.html

## Summary by Sourcery

Bug Fixes:
- Clamp icon view file name rendering to the item rectangle so long labels no longer draw outside their allocated area.