### PR TITLE
fix: prevent auto-mount for loop devices

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -837,25 +837,9 @@ void DeviceManager::doAutoMount(const QString &id, DeviceType type, int timeout)
     }
 
     if (type == DeviceType::kBlockDevice) {
-        auto &&info = getBlockDevInfo(id);
-        if (info.value(DeviceProperty::kIsEncrypted).toBool()
-            || info.value(DeviceProperty::kCryptoBackingDevice).toString() != "/") {
-            qCDebug(logDFMBase) << "Auto mount skipped for encrypted device:" << id;
-            return;
-        }
-        if (info.value(DeviceProperty::kHintIgnore).toBool()) {
-            qCDebug(logDFMBase) << "Auto mount skipped for ignored device:" << id;
-            return;
-        }
-        if (!info.value(DeviceProperty::kHasFileSystem).toBool()) {
-            qCDebug(logDFMBase) << "Auto mount skipped for device without filesystem:" << id;
-            return;
-        }
-        // auto mount is only available for non optical devices and removable device.
-        // the internal devices are mounted when server launched, see @doAutoMountAtStart
-        if (id.startsWith("/org/freedesktop/UDisks2/block_devices/sr"))
-            return;
-        if (!info.value(DeviceProperty::kRemovable).toBool())
+        const auto &info = getBlockDevInfo(id);
+        // auto mount is only available for removable, non optical block device.
+        if (!d->shouldAutoMountBlockDevice(id, info))
             return;
 
         qCInfo(logDFMBase) << "Starting auto mount for block device:" << id;
@@ -885,12 +869,47 @@ void DeviceManagerPrivate::mountAllBlockDev()
                                                   | DeviceQueryOption::kNotMounted) };
     qCInfo(logDFMBase) << "Starting auto mount for" << devs.size() << "mountable block devices:" << devs;
     for (const auto &dev : devs) {
-        if (dev.startsWith("/org/freedesktop/UDisks2/block_devices/sr")) {
-            qCDebug(logDFMBase) << "Skipping auto mount for optical device:" << dev;
+        const auto &info = q->getBlockDevInfo(dev);
+        if (!shouldAutoMountBlockDevice(dev, info))
             continue;
-        }
         q->mountBlockDevAsync(dev, { { "auth.no_user_interaction", true } });   // avoid the auth dialog raising
     }
+}
+
+bool DeviceManagerPrivate::shouldAutoMountBlockDevice(const QString &id, const QVariantMap &info)
+{
+    if (info.value(DeviceProperty::kIsEncrypted).toBool()
+        || info.value(DeviceProperty::kCryptoBackingDevice).toString() != "/") {
+        qCDebug(logDFMBase) << "Auto mount skipped for encrypted device:" << id;
+        return false;
+    }
+
+    if (info.value(DeviceProperty::kHintIgnore).toBool()) {
+        qCDebug(logDFMBase) << "Auto mount skipped for ignored device:" << id;
+        return false;
+    }
+
+    if (info.value(DeviceProperty::kIsLoopDevice).toBool()) {
+        qCDebug(logDFMBase) << "Auto mount skipped for loop device:" << id;
+        return false;
+    }
+
+    if (!info.value(DeviceProperty::kHasFileSystem).toBool()) {
+        qCDebug(logDFMBase) << "Auto mount skipped for device without filesystem:" << id;
+        return false;
+    }
+
+    if (id.startsWith("/org/freedesktop/UDisks2/block_devices/sr")) {
+        qCDebug(logDFMBase) << "Auto mount skipped for optical device:" << id;
+        return false;
+    }
+
+    if (!info.value(DeviceProperty::kRemovable).toBool()) {
+        qCDebug(logDFMBase) << "Auto mount skipped for non-removable block device:" << id;
+        return false;
+    }
+
+    return true;
 }
 
 bool DeviceManagerPrivate::isDaemonMountRunning()

--- a/src/dfm-base/base/device/private/devicemanager_p.h
+++ b/src/dfm-base/base/device/private/devicemanager_p.h
@@ -29,6 +29,7 @@ public:
 private:
     // private operations
     void mountAllBlockDev();
+    bool shouldAutoMountBlockDevice(const QString &id, const QVariantMap &info);
 
     static bool isDaemonMountRunning();
 

--- a/src/plugins/filemanager/dfmplugin-computer/menu/computermenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/menu/computermenuscene.cpp
@@ -194,8 +194,10 @@ void ComputerMenuScene::updateState(QMenu *parent)
         disabled.append(kOpenInNewTab);
 
     // do not show 'rename' entry for loop devices.
-    if (d->info->extraProperties().value(DeviceProperty::kIsLoopDevice, false).toBool())
+    if (d->info->extraProperties().value(DeviceProperty::kIsLoopDevice, false).toBool()) {
         keeped.removeAll(kRename);
+        keeped << (d->info->targetUrl().isValid() ? kUnmount : kMount);
+    }
 
     if (!keeped.isEmpty())
         d->updateMenu(parent, disabled, keeped);


### PR DESCRIPTION
Extracted the auto-mount condition checking logic into a dedicated method `shouldAutoMountBlockDevice` to centralize the validation rules. Added explicit check to skip auto-mount for loop devices by verifying the `kIsLoopDevice` property. This prevents loop devices from being automatically mounted when they are detected, addressing the issue where loop devices were incorrectly being auto-mounted.

Additionally, updated the computer menu scene to ensure loop devices display appropriate mount/unmount options instead of rename functionality, providing consistent UI behavior for loop devices.

Log: Fixed loop device auto-mount issue and improved menu options

Influence:
1. Test that loop devices are no longer auto-mounted when connected
2. Verify that encrypted devices continue to be excluded from auto-mount
3. Check that optical drives and non-removable devices are properly skipped
4. Confirm that removable devices with filesystems are still auto- mounted correctly
5. Test computer menu shows mount/unmount options for loop devices instead of rename
6. Verify menu behavior for different device types remains consistent

fix: 修复 loop 设备自动挂载问题

将自动挂载的条件检查逻辑提取到独立的 `shouldAutoMountBlockDevice` 方
法中，以集中管理验证规则。新增了对 loop 设备的显式检查，通过验证
`kIsLoopDevice` 属性来跳过自动挂载。这解决了 loop 设备在检测到时被错误自
动挂载的问题。

同时更新了计算机菜单场景，确保 loop 设备显示适当的挂载/卸载选项而不是重
命名功能，为 loop 设备提供一致的 UI 行为。

Log: 修复 loop 设备自动挂载问题并改进菜单选项

Influence:
1. 测试 loop 设备在连接时不再自动挂载
2. 验证加密设备继续被排除在自动挂载之外
3. 检查光驱和非可移动设备被正确跳过
4. 确认带有文件系统的可移动设备仍能正确自动挂载
5. 测试计算机菜单对 loop 设备显示挂载/卸载选项而非重命名
6. 验证不同设备类型的菜单行为保持一致性

## Summary by Sourcery

Prevent loop block devices from being auto-mounted and align their context menu options with other mountable devices.

Bug Fixes:
- Skip auto-mount for loop block devices while preserving existing exclusions for encrypted, ignored, optical, and non-removable devices.

Enhancements:
- Centralize block-device auto-mount eligibility checks into a shared helper used by both single-device and bulk auto-mount paths.
- Adjust the computer view context menu so loop devices expose mount/unmount actions instead of rename.