### PR TITLE
fix: implement non-blocking directory statistics with job management

### DIFF
--- a/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
+++ b/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp
@@ -20,6 +20,11 @@ BasicStatusBarPrivate::BasicStatusBarPrivate(BasicStatusBar *qq)
     initFormatStrings();
 }
 
+BasicStatusBarPrivate::~BasicStatusBarPrivate()
+{
+    discardCurrentJob();
+}
+
 void BasicStatusBarPrivate::initFormatStrings()
 {
     onlyOneItemCounted = tr("%1 item");
@@ -68,24 +73,52 @@ void BasicStatusBarPrivate::calcFolderContains(const QList<QUrl> &folderList)
 {
     discardCurrentJob();
 
-    fileStatisticsJog = new FileScanner(this);
-    fileStatisticsJog->setOptions(FileScanner::ScanOption::SingleDepth | FileScanner::ScanOption::CountOnly);
-
-    if (isJobDisconnect) {
-        isJobDisconnect = false;
-        initJobConnection();
+    // If too many retired jobs are still stuck (typically due to network I/O),
+    // stop scheduling new contains-scans to avoid unbounded resource growth.
+    if (retiredJobs.size() >= kMaxRetiredJobs) {
+        qCWarning(logDFMBase) << "BasicStatusBar: skip folder contains scan, retired jobs reached limit"
+                              << retiredJobs.size() << ", limit:" << kMaxRetiredJobs
+                              << ", request urls:" << folderList.size();
+        showContains = false;
+        q->updateStatusMessage();
+        return;
     }
+
+    auto *job = new FileScanner(this);
+    job->setOptions(FileScanner::ScanOption::SingleDepth | FileScanner::ScanOption::CountOnly);
+    finishedJobs.remove(job);
+
+    connect(job, &FileScanner::finished, this, [this, job](const FileScanner::ScanResult &) {
+        // `finished` can be emitted before worker thread fully stops. Track it
+        // so retireJob() can release completed jobs without waiting for re-finished.
+        finishedJobs.insert(job);
+        if (retiredJobs.remove(job) > 0) {
+            job->deleteLater();
+        }
+    });
+
+    connect(job, &QObject::destroyed, this, [this, job]() {
+        finishedJobs.remove(job);
+        retiredJobs.remove(job);
+    });
+
+    fileStatisticsJog = job;
+    ++scanGeneration;
+    initJobConnection(job, scanGeneration);
 
     fileStatisticsJog->start(folderList);
 }
 
-void BasicStatusBarPrivate::initJobConnection()
+void BasicStatusBarPrivate::initJobConnection(FileScanner *job, quint64 generation)
 {
-    if (!fileStatisticsJog)
+    if (!job)
         return;
 
-    auto onFoundFile = [this](const FileScanner::ScanResult &result) {
-        if (!sender())
+    auto onFoundFile = [this, job, generation](const FileScanner::ScanResult &result) {
+        if (generation != scanGeneration)
+            return;
+
+        if (job != fileStatisticsJog)
             return;
 
         int newCount = result.fileCount + result.directoryCount;
@@ -95,7 +128,25 @@ void BasicStatusBarPrivate::initJobConnection()
         }
     };
 
-    connect(fileStatisticsJog, &FileScanner::progressChanged, this, onFoundFile);
+    connect(job, &FileScanner::progressChanged, this, onFoundFile);
+}
+
+void BasicStatusBarPrivate::retireJob(FileScanner *job)
+{
+    if (!job)
+        return;
+
+    // Detach from BasicStatusBar lifetime so blocked scanners won't be
+    // synchronously destroyed on UI-thread during parent teardown.
+    job->setParent(nullptr);
+
+    if (job->isRunning() && !finishedJobs.contains(job)) {
+        retiredJobs.insert(job);
+        job->stop();
+        return;
+    }
+
+    job->deleteLater();
 }
 
 void BasicStatusBarPrivate::discardCurrentJob()
@@ -103,13 +154,7 @@ void BasicStatusBarPrivate::discardCurrentJob()
     if (!fileStatisticsJog)
         return;
 
-    fileStatisticsJog->disconnect();
-    isJobDisconnect = true;
-
-    if (fileStatisticsJog->isRunning()) {
-        fileStatisticsJog->stop();
-    }
-
-    fileStatisticsJog->deleteLater();
+    auto *oldJob = fileStatisticsJog.data();
     fileStatisticsJog = nullptr;
+    retireJob(oldJob);
 }

--- a/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.h
+++ b/src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.h
@@ -14,6 +14,7 @@
 #include <QObject>
 #include <QString>
 #include <QPointer>
+#include <QSet>
 
 class QLabel;
 class QHBoxLayout;
@@ -29,6 +30,7 @@ class BasicStatusBarPrivate : public QObject
 
 public:
     explicit BasicStatusBarPrivate(BasicStatusBar *qq);
+    ~BasicStatusBarPrivate() override;
 
     void initFormatStrings();
 
@@ -36,8 +38,9 @@ public:
     void initLayout();
 
     void calcFolderContains(const QList<QUrl> &folderList);
-    void initJobConnection();
     void discardCurrentJob();
+    void initJobConnection(FileScanner *job, quint64 generation);
+    void retireJob(FileScanner *job);
 
     QString onlyOneItemCounted;
     QString counted;
@@ -62,7 +65,10 @@ public:
 
 
     QPointer<FileScanner> fileStatisticsJog;
-    bool isJobDisconnect = true;
+    QSet<FileScanner *> retiredJobs;
+    QSet<FileScanner *> finishedJobs;
+    quint64 scanGeneration = 0;
+    static constexpr int kMaxRetiredJobs = 2;
 };
 
 }


### PR DESCRIPTION
1. Add destructor to properly clean up jobs and prevent memory leaks
2. Implement job retirement mechanism to handle slow network I/ O operations
3. Add generation tracking to ignore outdated scan results
4. Introduce job tracking sets (retiredJobs and finishedJobs) for proper cleanup
5. Add maximum retired jobs limit to prevent unbounded resource growth
6. Improve job connection handling with generation-based filtering

Log: Improved status bar directory scanning to be non-blocking and more reliable

Influence:
1. Test status bar display with local directories containing many files
2. Test with network drives or slow storage devices
3. Verify that status updates correctly show file counts
4. Test rapid directory switching to ensure old scans are properly discarded
5. Monitor memory usage during prolonged file operations
6. Verify that UI remains responsive during large directory scans

fix: 实现非阻塞目录统计与任务管理

1. 添加析构函数以正确清理任务，防止内存泄漏
2. 实现任务退休机制处理慢速网络I/O操作
3. 添加生成跟踪以忽略过时的扫描结果
4. 引入任务跟踪集合（retiredJobs和finishedJobs）进行适当清理
5. 添加最大退休任务限制防止资源无限增长
6. 改进基于生成过滤的任务连接处理

Log: 改进状态栏目录扫描为非阻塞模式，提高可靠性

Influence:
1. 测试包含大量文件的本地目录状态栏显示
2. 测试网络驱动器或慢速存储设备
3. 验证状态更新正确显示文件数量
4. 测试快速切换目录确保旧扫描被正确丢弃
5. 监控长时间文件操作时的内存使用情况
6. 验证在大目录扫描期间UI保持响应

## Summary by Sourcery

Make status bar directory scanning jobs non-blocking and safely managed to avoid leaks and stale updates.

Bug Fixes:
- Ensure file scanning jobs are properly discarded on destruction to prevent memory leaks and dangling operations.
- Ignore outdated scan results when switching directories rapidly by tracking scan generations.
- Avoid blocking UI teardown on slow or stuck file scanners by retiring running jobs instead of synchronously destroying them.
- Prevent unbounded growth of background scan jobs by enforcing a maximum number of retired jobs and skipping new scans when the limit is reached.

Enhancements:
- Track active, retired, and finished file scanning jobs to improve cleanup and lifecycle management.
- Improve status bar updates by only applying progress from the current active scan job.