### PR TITLE
fix: fix icon display issue in image preview

### DIFF
--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
@@ -297,7 +297,7 @@ ImagePreviewController::~ImagePreviewController()
 {
     m_worker->stop();
     m_workerThread.quit();
-    m_workerThread.wait(5000);
+    m_workerThread.wait(25000);
 }
 
 void ImagePreviewController::requestPreview(const QUrl &url, const QSize &targetSize)
@@ -335,7 +335,7 @@ void ImagePreviewController::onNeedIconFallback(const QUrl &url, const QSize &ta
     }
 
     // Strategy 2: Fall back to file icon
-    FileInfoPointer info = InfoFactory::create<FileInfo>(url);
+    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
     if (info) {
         QIcon icon = info->fileIcon();
         // Request square icon with devicePixelRatio, QIcon will maintain its aspect ratio


### PR DESCRIPTION
Fix potential icon display abnormality caused by asynchronous file info creation
Use synchronous file info creation to ensure icon availability during fallback

Log: Fixed icon display issue in image preview

Influence:
1. Test image preview with various file types
2. Verify icon display in file manager detail view
3. Check fallback icon behavior when original icon fails to load
4. Test performance impact of synchronous file info creation

fix: 修复图片预览中图标显示问题

修复由于异步文件信息创建导致的图标显示异常问题
使用同步文件信息创建确保回退时图标可用性

Log: 修复图片预览图标显示异常问题

Influence:
1. 测试各种文件类型的图片预览功能
2. 验证文件管理器详情视图中的图标显示
3. 检查原始图标加载失败时的回退图标行为
4. 测试同步文件信息创建对性能的影响

Bug: https://pms.uniontech.com/bug-view-347247.html

## Summary by Sourcery

Ensure reliable icon availability in image preview fallback handling and improve worker thread shutdown robustness.

Bug Fixes:
- Prevent missing or abnormal icons in image previews by using synchronous file info creation when falling back to file icons.

Enhancements:
- Increase the image preview worker thread shutdown wait time to reduce the risk of premature termination during teardown.