### PR TITLE
feat: optimize file scanner performance for count-only mode

### DIFF
--- a/src/dfm-base/utils/filescanner.cpp
+++ b/src/dfm-base/utils/filescanner.cpp
@@ -13,6 +13,7 @@
 #include <QTimer>
 #include <QCoreApplication>
 #include <QDebug>
+#include <QDir>
 #include <QQueue>
 
 #include <dirent.h>
@@ -81,6 +82,12 @@ private:
     static void scanOtherProtocolsImpl(ScanState &state, const QList<QUrl> &urls);
 
     // 辅助方法
+    static bool tryScanOtherProtocolCountOnlyByLocalPath(
+            ScanState &state,
+            const FileInfoPointer &info,
+            bool isSingleDepth,
+            QQueue<QUrl> *directoryQueue,
+            QSet<QUrl> *processedUrls);
     static bool readDirectoryEntries(const QString &path, QList<DirEntry> *entries, bool countOnly = false);
     static void processRegularFile(ScanState &state, const QString &path, const struct stat &statBuf);
     static void processSymlink(ScanState &state, const QString &path);
@@ -520,7 +527,14 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
             // 收集目录URL
             collectFileIfEnabled(state, url, isSourcePath);
 
-            // 创建目录迭代器
+            bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
+            bool countOnly = state.options & FileScanner::ScanOption::CountOnly;
+            if (countOnly && tryScanOtherProtocolCountOnlyByLocalPath(
+                                     state, info, isSingleDepth, &directoryQueue, &processedUrls)) {
+                continue;
+            }
+
+            // 创建目录迭代器（快速路径不可用时回退）
             AbstractDirIteratorPointer iterator = DirIteratorFactory::create<AbstractDirIterator>(
                     url,
                     QStringList(),
@@ -530,8 +544,6 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
                 qCWarning(logDFMBase) << "FileScannerCore: Failed to create iterator for:" << url;
                 continue;
             }
-
-            bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
 
             // 遍历目录
             while (iterator->hasNext() && !state.shouldStop) {
@@ -595,6 +607,65 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
 
     qCDebug(logDFMBase) << "FileScannerCore: Other protocol scan completed - files:" << state.result.fileCount
                         << "dirs:" << state.result.directoryCount << "size:" << state.result.totalSize;
+}
+
+bool FileScannerCore::tryScanOtherProtocolCountOnlyByLocalPath(
+        ScanState &state,
+        const FileInfoPointer &info,
+        bool isSingleDepth,
+        QQueue<QUrl> *directoryQueue,
+        QSet<QUrl> *processedUrls)
+{
+    Q_ASSERT(directoryQueue);
+    Q_ASSERT(processedUrls);
+
+    // CountOnly 模式下，优先复用 readDirectoryEntries，避免 DirIteratorFactory 的高开销
+    const QString dirPath = info->pathOf(PathInfoType::kAbsoluteFilePath);
+    const bool canUseLocalPath = QDir::isAbsolutePath(dirPath) && QDir(dirPath).exists();
+    if (!canUseLocalPath) {
+        return false;
+    }
+
+    QList<DirEntry> entries;
+    if (!readDirectoryEntries(dirPath, &entries, true)) {
+        return false;
+    }
+
+    for (const DirEntry &entry : entries) {
+        if (state.shouldStop) {
+            break;
+        }
+
+        QUrl childUrl = info->getUrlByType(UrlInfoType::kGetUrlByChildFileName, entry.name);
+        if (!childUrl.isValid()) {
+            continue;
+        }
+
+        if (processedUrls->contains(childUrl)) {
+            continue;
+        }
+        processedUrls->insert(childUrl);
+
+        if (entry.d_type == DT_DIR) {
+            if (isSingleDepth) {
+                // SingleDepth 模式：计数但不递归
+                state.result.directoryCount++;
+                state.result.progressSize += state.memoryPageSize;
+            } else {
+                // 递归模式：入队
+                directoryQueue->enqueue(childUrl);
+            }
+        } else {
+            // CountOnly 模式：普通文件、符号链接、其他类型统一计数
+            state.result.fileCount++;
+        }
+
+        // 收集子文件/目录URL
+        collectFileIfEnabled(state, childUrl, false);
+        emitProgress(state);
+    }
+
+    return true;
 }
 
 bool FileScannerCore::readDirectoryEntries(const QString &path, QList<DirEntry> *entries, bool countOnly)


### PR DESCRIPTION
Added a new optimization method tryScanOtherProtocolCountOnlyByLocalPath that uses local file system operations for counting files and directories when scanning other protocols in count-only mode. This avoids the overhead of creating directory iterators through DirIteratorFactory when only counting is needed.

The optimization checks if the directory path can be accessed locally and uses readDirectoryEntries for efficient counting. This significantly improves performance for count-only scans by reducing the cost of iterator creation and protocol abstraction layers.

Log: Improved file scanning performance in count-only mode

Influence:
1. Test file scanning in count-only mode with various protocols
2. Verify that file and directory counts remain accurate with the optimization
3. Test scanning with both single-depth and recursive modes
4. Verify that the optimization correctly falls back to original method when local path access is not available
5. Test scanning performance improvement with large directories
6. Verify that progress reporting and cancellation still work correctly

feat: 优化仅计数模式下的文件扫描性能

新增了 tryScanOtherProtocolCountOnlyByLocalPath 优化方法，在扫描其他协议 且处于仅计数模式时，使用本地文件系统操作来统计文件和目录数量。这避免了在
仅需要计数时通过 DirIteratorFactory 创建目录迭代器的开销。

该优化检查目录路径是否可以通过本地方式访问，并使用 readDirectoryEntries
进行高效计数。通过减少迭代器创建和协议抽象层的成本，显著提高了仅计数扫描
的性能。

Log: 优化了仅计数模式下的文件扫描性能

Influence:
1. 测试各种协议下的仅计数模式文件扫描
2. 验证优化后文件和目录计数仍然准确
3. 测试单层深度和递归扫描模式
4. 验证当本地路径访问不可用时，优化能正确回退到原始方法
5. 测试大目录扫描的性能改进
6. 验证进度报告和取消功能仍然正常工作

## Summary by Sourcery

Optimize other-protocol directory scanning in count-only mode by using a fast local-path based counting path before falling back to the generic iterator-based scanner.

New Features:
- Add a local-filesystem based fast path for counting entries when scanning other protocols in count-only mode.

Enhancements:
- Reduce overhead of other-protocol scans by reusing readDirectoryEntries for counting and avoiding unnecessary directory iterator creation in count-only scenarios.