### PR TITLE
fix: improve accessibility cleanup and destruction sequence

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -25,6 +25,7 @@
 #include <QProcess>
 #include <QSocketNotifier>
 #include <QTimer>
+#include <QAccessible>
 
 #include <signal.h>
 #include <malloc.h>
@@ -441,6 +442,10 @@ int main(int argc, char *argv[])
 
     mo->unRegisterDBus();
     a.closeServer();
+#if QT_CONFIG(accessibility)
+    // Ensure accessibility cache is cleaned before unloading plugin shared libraries.
+    QAccessible::cleanup();
+#endif
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();
 
     // Close self-pipe fds to release kernel resources

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -106,23 +106,32 @@ FileView::~FileView()
 {
     fmInfo() << "Destroying FileView for URL:" << rootUrl();
 #if QT_CONFIG(accessibility)
-    // 防止 QAccessibleCache 在退出时持有已释放 model 的引用
+    // 通知无障碍系统该对象即将销毁，避免退出阶段继续访问此 view
     if (QAccessible::isActive()) {
-        QAccessibleInterface *iface = QAccessible::queryAccessibleInterface(this);
-        if (iface) {
-            QAccessible::Id id = QAccessible::uniqueId(iface);
-            if (id != QAccessible::Id(0)) {
-                QAccessible::deleteAccessibleInterface(id);
-            }
-        }
+        QAccessibleEvent hideEvent(this, QAccessible::ObjectHide);
+        QAccessible::updateAccessibility(&hideEvent);
     }
 #endif
 
-    // 关键修复: 必须在基类(QAbstractItemView)析构前解绑 model
-    // 原因: QAbstractItemView 持有 QPersistentModelIndex,如果 model 先于基类析构,
-    //      这些 QPersistentModelIndex 析构时会访问已释放的 model 导致崩溃
+    // 必须在基类(QAbstractItemView)析构前解绑 model:
+    // QAbstractItemView / delegate / selection / header 可能持有 QPersistentModelIndex,
+    // 若 model 先释放会在索引析构时访问已销毁模型。
 
-    // 1. 断开信号连接
+    // 1. 先结束编辑器，避免编辑器无障碍对象继续持有 model index
+    if (itemDelegate()) {
+        itemDelegate()->commitDataAndCloseActiveEditor();
+        itemDelegate()->hideAllIIndexWidget();
+    }
+
+    // 2. 避免在析构阶段主动操作 headerView 的 selectionModel。
+    // 某些退出时序下，headerView 内部旧 selectionModel 可能已悬空，
+    // 调用 setSelectionModel(nullptr) 会在 Qt 内部触发崩溃。
+    // 此处仅解除 model 关联，selectionModel 交由 QObject 析构流程处理。
+    if (d && d->headerView) {
+        d->headerView->setModel(nullptr);
+    }
+
+    // 3. 断开信号连接
     if (model()) {
         disconnect(model(), nullptr, this, nullptr);
     }
@@ -130,12 +139,12 @@ FileView::~FileView()
         disconnect(selectionModel(), nullptr, this, nullptr);
         selectionModel()->clear();
     }
+    setCurrentIndex(QModelIndex());
 
-    // 2. 解绑 model (关键步骤!)
-    // 这会触发 QAbstractItemView 清理所有 QPersistentModelIndex
+    // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 
-    // 3. 清理其他订阅
+    // 5. 清理其他订阅
     dpfSignalDispatcher->unsubscribe("dfmplugin_workspace", "signal_View_HeaderViewSectionChanged", this, &FileView::onHeaderViewSectionChanged);
     dpfSignalDispatcher->unsubscribe("dfmplugin_filepreview", "signal_ThumbnailDisplay_Changed", this, &FileView::onWidgetUpdate);
 


### PR DESCRIPTION
1. Added QAccessible::cleanup() call in main.cpp to ensure accessibility cache is cleaned before unloading plugin shared libraries
2. Improved FileView destruction sequence to prevent crashes during shutdown:
   - Replaced manual QAccessible interface deletion with proper ObjectHide event notification
   - Added proper editor cleanup before model destruction
   - Fixed headerView model detachment to avoid accessing dangling selectionModel
   - Enhanced model unbinding sequence with proper signal disconnections and index clearing

Influence:
1. Test application shutdown process to ensure no crashes occur
2. Verify accessibility features still work correctly after the changes
3. Test file view operations including selection, editing, and navigation
4. Verify no memory leaks or dangling pointers during destruction
5. Test with accessibility tools enabled to ensure proper cleanup

fix: 改进无障碍清理和析构顺序

1. 在 main.cpp 中添加 QAccessible::cleanup() 调用，确保在卸载插件共享库 前清理无障碍缓存
2. 改进 FileView 析构顺序以防止关闭时崩溃：
   - 用正确的 ObjectHide 事件通知替换手动 QAccessible 接口删除
   - 在模型销毁前添加适当的编辑器清理
   - 修复 headerView 模型分离以避免访问悬空的选择模型
   - 增强模型解绑顺序，包括正确的信号断开和索引清理

Influence:
1. 测试应用程序关闭过程，确保不会发生崩溃
2. 验证无障碍功能在更改后仍正常工作
3. 测试文件视图操作，包括选择、编辑和导航
4. 验证析构过程中没有内存泄漏或悬空指针
5. 启用无障碍工具测试以确保正确清理

## Summary by Sourcery

Improve accessibility shutdown behavior and the destruction sequence of FileView to prevent crashes and dangling references during application exit.

Bug Fixes:
- Prevent crashes during FileView destruction by ensuring the view unbinds from its model and related components in a safe order.
- Avoid potential crashes caused by header view selection model access during shutdown by detaching only the model and letting QObject handle selection model destruction.
- Eliminate issues with accessibility interfaces holding stale model indexes by ending editors and clearing the current index before model teardown.
- Prevent accessibility cache from referencing unloaded plugin objects by cleaning up QAccessible before shutting down plugins.

Enhancements:
- Notify the accessibility system with an ObjectHide event when FileView is destroyed to ensure assistive technologies are updated correctly.