### PR TITLE
6.5.127

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+dde-file-manager (6.5.127) unstable; urgency=medium
+
+  * fix: improve image preview reliability for remote files
+  * chore: reorder cmake includes for correct path calculation
+  * fix: handle long filenames and UTF-8 validation in file scanner
+  * feat: optimize file scanning performance with CountOnly mode
+  * fix: enhance network detection for various URI schemes
+  * fix: prevent auto-mount for loop devices
+  * fix: implement non-blocking directory statistics with job management
+  * fix: fix icon display issue in image preview
+  * feat: optimize file scanner performance for count-only mode
+  * fix: improve accessibility cleanup and destruction sequence
+  * fix: improve empty file progress calculation
+  * fix: handle desktop file renaming with batch append
+  * fix: fix icon view text clipping issue
+  * fix: improve icon shadow rendering with aspect ratio
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 20 Mar 2026 12:29:30 +0800
+
 dde-file-manager (6.5.126) unstable; urgency=medium
 
   * fix: handle symlink desktop files in rename operations

--- a/src/dfm-base/utils/filescanner.cpp
+++ b/src/dfm-base/utils/filescanner.cpp
@@ -82,6 +82,7 @@ private:
     static void scanOtherProtocolsImpl(ScanState &state, const QList<QUrl> &urls);
 
     // 辅助方法
+    static qint64 progressDeltaForFileSize(const ScanState &state, qint64 fileSize);
     static bool tryScanOtherProtocolCountOnlyByLocalPath(
             ScanState &state,
             const FileInfoPointer &info,
@@ -323,6 +324,11 @@ FileScanner::ScanResult FileScannerCore::scanImpl(
     return state.result;
 }
 
+qint64 FileScannerCore::progressDeltaForFileSize(const ScanState &state, qint64 fileSize)
+{
+    return fileSize <= 0 ? state.memoryPageSize : fileSize;
+}
+
 void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &urls)
 {
     qCDebug(logDFMBase) << "FileScannerCore: Scanning local paths using opendir/readdir";
@@ -529,8 +535,7 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
 
             bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
             bool countOnly = state.options & FileScanner::ScanOption::CountOnly;
-            if (countOnly && tryScanOtherProtocolCountOnlyByLocalPath(
-                                     state, info, isSingleDepth, &directoryQueue, &processedUrls)) {
+            if (countOnly && tryScanOtherProtocolCountOnlyByLocalPath(state, info, isSingleDepth, &directoryQueue, &processedUrls)) {
                 continue;
             }
 
@@ -575,7 +580,7 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
                             if (!(state.options & FileScanner::ScanOption::CountOnly)) {
                                 qint64 sz = childInfo->size();
                                 state.result.totalSize += sz;
-                                state.result.progressSize += sz;
+                                state.result.progressSize += progressDeltaForFileSize(state, sz);
                             }
                             // 收集子文件URL
                             collectFileIfEnabled(state, childUrl, false);
@@ -589,7 +594,7 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
             if (!(state.options & FileScanner::ScanOption::CountOnly)) {
                 qint64 sz = info->size();
                 state.result.totalSize += sz;
-                state.result.progressSize += sz;
+                state.result.progressSize += progressDeltaForFileSize(state, sz);
             }
 
             // 收集文件URL
@@ -744,7 +749,7 @@ void FileScannerCore::processRegularFile(ScanState &state, const QString &path, 
         state.result.totalSize += statBuf.st_size;
         state.result.fileCount++;
     }
-    state.result.progressSize += statBuf.st_size;
+    state.result.progressSize += progressDeltaForFileSize(state, statBuf.st_size);
 }
 
 void FileScannerCore::processSymlink(ScanState &state, const QString &path)


### PR DESCRIPTION
## Summary by Sourcery

Adjust file scanning progress accounting to handle zero or unknown-sized files more robustly.

Enhancements:
- Add a helper to normalize progress increments based on file size, defaulting to a memory-page-sized chunk for non-positive sizes.
- Use the new helper in local and other-protocol scanning paths to compute progress updates consistently.