### PR TITLE
fix: correct notification parameter order

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
@@ -206,7 +206,7 @@ void DockItemDataManager::playSoundOnDevPlugInOut(bool in)
     DDesktopServices::playSystemSoundEffect(in ? DDesktopServices::SSE_DeviceAdded
                                                : DDesktopServices::SSE_DeviceRemoved);
     if (!in)
-        notify(tr("The device has been safely removed"), "");
+        notify("", tr("The device has been safely removed"));
 }
 
 void DockItemDataManager::sendNotification(const QString &id, const QString &operation)


### PR DESCRIPTION
Fix incorrect parameter order in the notify() function call when displaying device removal notification. The first parameter is the notification title (summary) and the second is the body (content). The message "The device has been safely removed" should be passed as the notification body, not the title, with an empty title.

Log: Safe device removal notification now displays correctly with proper title and body text positioning.

Influence:

Black-box testing: Safely remove a USB device and verify the notification displays correctly with empty title and the message "The device has been safely removed" in the notification body Test both device plug-in and plug-out scenarios to confirm sound and notification behavior works as expected fix: 修正设备移除通知参数顺序

1.修复 notify 函数调用时参数传递顺序错误的问题
2.第一个参数为通知标题，第二个参数为通知内容
3.将"设备已安全移除"提示语从标题位置调整到内容位置
4.确保通知显示时标题为空，内容正确显示提示信息
Log: 修正设备安全移除通知的显示格式

Influence:

1.测试设备安全移除功能，验证通知显示格式正确
2.插入 USB 设备后执行安全移除操作，检查通知内容显示在正确位置
3.测试设备插拔音效和通知功能是否正常工作
4.验证通知标题为空，内容显示"设备已安全移除"
bug: https://pms.uniontech.com/bug-view-353657.html

## Summary by Sourcery

Bug Fixes:
- Ensure the safe device removal notification uses an empty title and shows "The device has been safely removed" as the notification body so it displays in the correct fields.