### PR TITLE
fix: prevent duplicate filename display during fast scrolling

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -689,12 +689,18 @@ QString ListItemDelegate::getCorrectDisplayName(QPainter *painter, const QModelI
                     break;
             }
 
-            const QString &suffix = "." + index.data(kItemFileSuffixRole).toString();
+            const QString roleDisplayName = index.data(role).toString().remove('\n');
+            const QString rawSuffix = index.data(kItemFileSuffixRole).toString();
+            const QString suffix = "." + rawSuffix;
             if (suffix == ".")
                 break;
 
             // 获取基础名称（不含后缀）
             displayName = index.data(kItemFileBaseNameRole).toString().remove('\n');
+            // During fast scrolling FileInfo may be unavailable and both base/suffix
+            // fallback to the full file name, which would produce "name.name".
+            if (!roleDisplayName.isEmpty() && displayName == roleDisplayName && rawSuffix == roleDisplayName)
+                break;
 
             // 根据设置决定是否显示后缀
             bool showSuffix { Application::instance()->genericAttribute(Application::kShowedFileSuffix).toBool() };


### PR DESCRIPTION
Fixed an issue where during fast scrolling, when FileInfo becomes
unavailable, both base name and suffix would fallback to the full
filename, resulting in duplicate display like "filename.filename". Added
a check to break early when both base name and suffix match the role
display name.

Influence:
1. Test file list display during fast scrolling
2. Verify filename display correctness with various file types
3. Check that duplicate filename issue is resolved
4. Test with both suffix display enabled and disabled

fix: 修复快速滚动时文件名重复显示问题

修复了在快速滚动时，当FileInfo不可用的情况下，基础名称和后缀都会回退到完
整文件名，导致出现"filename.filename"重复显示的问题。添加了检查逻辑，当
基础名称和后缀都与角色显示名称匹配时提前中断处理。

Influence:
1. 测试快速滚动时的文件列表显示
2. 验证各种文件类型的文件名显示正确性
3. 检查重复文件名问题是否已解决
4. 测试启用和禁用后缀显示的情况

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate filename display such as "name.name" when FileInfo is unavailable and both base name and suffix fall back to the full filename during fast scrolling.