### PR TITLE
fix: refine auto mount logic for non removable devices

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -838,8 +838,8 @@ void DeviceManager::doAutoMount(const QString &id, DeviceType type, int timeout)
 
     if (type == DeviceType::kBlockDevice) {
         const auto &info = getBlockDevInfo(id);
-        // auto mount is only available for removable, non optical block device.
-        if (!d->shouldAutoMountBlockDevice(id, info))
+        // Runtime auto-mount only applies to removable, non-optical block devices.
+        if (!d->shouldAutoMountBlockDeviceAtRuntime(id, info))
             return;
 
         qCInfo(logDFMBase) << "Starting auto mount for block device:" << id;
@@ -903,6 +903,14 @@ bool DeviceManagerPrivate::shouldAutoMountBlockDevice(const QString &id, const Q
         qCDebug(logDFMBase) << "Auto mount skipped for optical device:" << id;
         return false;
     }
+
+    return true;
+}
+
+bool DeviceManagerPrivate::shouldAutoMountBlockDeviceAtRuntime(const QString &id, const QVariantMap &info)
+{
+    if (!shouldAutoMountBlockDevice(id, info))
+        return false;
 
     if (!info.value(DeviceProperty::kRemovable).toBool()) {
         qCDebug(logDFMBase) << "Auto mount skipped for non-removable block device:" << id;

--- a/src/dfm-base/base/device/private/devicemanager_p.h
+++ b/src/dfm-base/base/device/private/devicemanager_p.h
@@ -30,6 +30,7 @@ private:
     // private operations
     void mountAllBlockDev();
     bool shouldAutoMountBlockDevice(const QString &id, const QVariantMap &info);
+    bool shouldAutoMountBlockDeviceAtRuntime(const QString &id, const QVariantMap &info);
 
     static bool isDaemonMountRunning();
 


### PR DESCRIPTION
Refactored the auto-mount logic to separate runtime auto-
mount checks from general auto-mount eligibility. The original
shouldAutoMountBlockDevice function now only handles basic eligibility
checks, while a new shouldAutoMountBlockDeviceAtRuntime function
specifically handles runtime conditions for removable devices. This
prevents non-removable devices from being auto-mounted during runtime
operations while maintaining their general auto-mount capability.

The change ensures that non-removable block devices (like internal hard
drives) are not automatically mounted during runtime operations, which
could cause unnecessary mount operations or conflicts. The general auto-
mount eligibility remains intact for proper device management.

Log: Fixed auto-mount behavior for non-removable devices

Influence:
1. Test auto-mount behavior with removable devices (USB drives)
2. Verify non-removable devices are not auto-mounted during runtime
3. Check that device mounting still works correctly when manually
triggered
4. Test system startup to ensure all eligible devices are properly
mounted
5. Verify optical drives are excluded from auto-mount as before

fix: 优化非可移动设备的自动挂载逻辑

重构了自动挂载逻辑，将运行时自动挂载检查与通用自动挂载资格检查分离。
原来的 shouldAutoMountBlockDevice 函数现在只处理基本资格检查，而新的
shouldAutoMountBlockDeviceAtRuntime 函数专门处理可移动设备的运行时条件。
这可以防止非可移动设备在运行时操作期间被自动挂载，同时保持其通用自动挂载
能力。

此更改确保非可移动块设备（如内部硬盘）在运行时操作期间不会被自动挂载，这
可能会引起不必要的挂载操作或冲突。通用自动挂载资格保持不变，以确保正确的
设备管理。

Log: 修复非可移动设备的自动挂载行为

Influence:
1. 测试可移动设备（U盘）的自动挂载行为
2. 验证非可移动设备在运行时不会被自动挂载
3. 检查手动触发时设备挂载是否仍然正常工作
4. 测试系统启动以确保所有符合条件的设备正确挂载
5. 验证光驱仍然被排除在自动挂载之外

Bug: https://pms.uniontech.com/bug-view-354301.html

## Summary by Sourcery

Refine block device auto-mount logic by separating general eligibility checks from runtime auto-mount behavior for block devices.

Bug Fixes:
- Prevent non-removable block devices from being auto-mounted during runtime operations while preserving their general auto-mount eligibility.

Enhancements:
- Introduce a dedicated runtime auto-mount check for removable, non-optical block devices and reuse the general eligibility logic.