### PR TITLE
fix: improve empty area detection in file manager view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewhelper.cpp
@@ -29,6 +29,8 @@
 #include <QAbstractItemView>
 #include <QTimer>
 
+#include <climits>
+
 Q_DECLARE_METATYPE(QList<QUrl> *)
 
 namespace dfmplugin_workspace {
@@ -248,9 +250,7 @@ bool FileViewHelper::isEmptyArea(const QPoint &pos)
     if (!index.isValid())
         return true;
 
-    if (isSelected(index)) {
-        return false;
-    } else {
+    if (!isSelected(index)) {
         const QRect &rect = parent()->visualRect(index);
 
         if (!rect.contains(pos)) {
@@ -264,21 +264,43 @@ bool FileViewHelper::isEmptyArea(const QPoint &pos)
             return true;
         }
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-        QStyleOptionViewItem option = parent()->viewOptions();
-#else
         QStyleOptionViewItem option;
         parent()->initViewItemOption(&option);
-#endif
         option.rect = rect;
 
         const QList<QRect> &geometryList = itemDelegate()->paintGeomertys(option, index);
-        auto ret = std::any_of(geometryList.begin(), geometryList.end(), [pos](const QRect &geometry) {
+        bool hitPaintGeometry = std::any_of(geometryList.begin(), geometryList.end(), [pos](const QRect &geometry) {
             return geometry.contains(pos);
         });
 
-        return !ret;
+        // In list/tree mode, treat the gap between icon and first text column as item area as well.
+        bool hitIconNameGap = false;
+        if ((parent()->isListViewMode() || parent()->isTreeViewMode()) && !geometryList.isEmpty()) {
+            const QRect iconRect = itemDelegate()->getRectOfItem(RectOfItemType::kItemIconRect, index);
+            QRect firstTextRect;
+            int nearestLeft = INT_MAX;
+
+            // Find the nearest paint rect on the right of icon. This avoids hardcoded indexes
+            // and works for both list ([icon, name, ...]) and tree ([icon, arrow, name, ...]).
+            for (const QRect &geometry : geometryList) {
+                if (geometry.left() > iconRect.right() && geometry.left() < nearestLeft) {
+                    nearestLeft = geometry.left();
+                    firstTextRect = geometry;
+                }
+            }
+
+            if (firstTextRect.isValid() && iconRect.right() < firstTextRect.left()) {
+                QRect gapRect(rect.left(), rect.top(), 0, rect.height());
+                gapRect.setLeft(iconRect.right() + 1);
+                gapRect.setRight(firstTextRect.left() - 1);
+                hitIconNameGap = gapRect.isValid() && gapRect.contains(pos);
+            }
+        }
+
+        return !(hitPaintGeometry || hitIconNameGap);
     }
+
+    return false;
 }
 
 QSize FileViewHelper::viewContentSize() const


### PR DESCRIPTION
The isEmptyArea function was incorrectly treating the gap between icon
and text as empty area in list/tree view modes. This caused issues with
selection behavior where clicking in the gap would not select the item.

The fix adds logic to detect clicks in the icon-text gap area and treat
them as valid item clicks. It dynamically calculates the gap rectangle
by finding the nearest text element to the right of the icon, making it
work for both list view (icon, name) and tree view (icon, arrow, name)
layouts without hardcoded indexes.

Log: Fixed file selection issue when clicking between icon and text in
list/tree view

Influence:
1. Test clicking in the gap between icon and text in list view - should
select item
2. Test clicking in the gap between icon and arrow/text in tree view -
should select item
3. Verify normal selection behavior still works when clicking on icons
and text
4. Test empty area detection still works correctly in non-list/tree
view modes
5. Verify selection behavior with multiple items and drag selection

fix: 修复文件管理器视图中空白区域检测问题

isEmptyArea 函数在列表/树形视图模式下错误地将图标和文本之间的间隙视为空
白区域，导致点击间隙时无法选中项目。

修复添加了检测图标-文本间隙点击的逻辑，将其视为有效的项目点击。通过动态
计算图标右侧最近的文本元素来确定间隙矩形，使其适用于列表视图（图标、名
称）和树形视图（图标、箭头、名称）布局，无需硬编码索引。

Log: 修复列表/树形视图中点击图标和文本之间间隙无法选中文件的问题

Influence:
1. 测试在列表视图中点击图标和文本之间的间隙 - 应能选中项目
2. 测试在树形视图中点击图标和箭头/文本之间的间隙 - 应能选中项目
3. 验证正常选择行为在点击图标和文本时仍正常工作
4. 测试非列表/树形视图模式下的空白区域检测仍正确工作
5. 验证多项目选择和拖拽选择的行为
