### PR TITLE
fix: ensure proper cleanup before unloading plugins

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -26,6 +26,7 @@
 #include <QSocketNotifier>
 #include <QTimer>
 #include <QAccessible>
+#include <QEventLoop>
 
 #include <signal.h>
 #include <malloc.h>
@@ -442,6 +443,13 @@ int main(int argc, char *argv[])
 
     mo->unRegisterDBus();
     a.closeServer();
+    // Process deferred deletions twice: first for pending deletions, then for
+    // deletions chained by QObject destructors. Restrict event processing to avoid
+    // triggering new interactive/input/socket work during shutdown.
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents
+                                    | QEventLoop::ExcludeSocketNotifiers);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
 #if QT_CONFIG(accessibility)
     // Ensure accessibility cache is cleaned before unloading plugin shared libraries.
     QAccessible::cleanup();


### PR DESCRIPTION
Added QEventLoop include and enhanced cleanup process in main.cpp
to properly handle deferred deletions before unloading plugin shared
libraries. The changes include calling sendPostedEvents twice with
DeferredDelete events and processing all events in between to ensure
accessibility cache is cleaned properly.

This fix addresses potential crashes or memory leaks that could occur
when plugin shared libraries are unloaded while deferred deletions are
still pending. The previous cleanup sequence might not have processed
all pending events, leading to accessibility-related issues during
shutdown.

Influence:
1. Test application shutdown process to ensure no crashes occur
2. Verify that all file manager windows are properly closed
3. Check for any memory leaks during application termination
4. Test accessibility features to ensure they work correctly during
shutdown
5. Verify plugin unloading happens without errors

fix: 确保在卸载插件前正确清理

在 main.cpp 中添加了 QEventLoop 包含并增强了清理过程，以在卸载插件
共享库之前正确处理延迟删除。更改包括两次调用 sendPostedEvents 处理
DeferredDelete 事件，并在中间处理所有事件，确保正确清理辅助功能缓存。

此修复解决了当插件共享库卸载时延迟删除仍处于挂起状态可能导致的崩溃或内存
泄漏问题。之前的清理顺序可能没有处理所有挂起的事件，导致关闭期间出现辅助
功能相关问题。

Influence:
1. 测试应用程序关闭过程，确保不会发生崩溃
2. 验证所有文件管理器窗口是否正确关闭
3. 检查应用程序终止期间是否存在内存泄漏
4. 测试辅助功能在关闭期间是否正常工作
5. 验证插件卸载是否无错误发生

## Summary by Sourcery

Improve application shutdown cleanup to safely process deferred deletions before unloading plugins and cleaning accessibility resources.

Bug Fixes:
- Ensure deferred QObject deletions are fully processed during shutdown to prevent crashes or leaks when unloading plugin shared libraries.

Enhancements:
- Restrict event processing during shutdown to avoid new user input or socket activity while cleaning up application resources.