### PR TITLE
fix: implement batch file rename with text add functionality

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.cpp
@@ -5,6 +5,7 @@
 #include "filenameutils.h"
 
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
 #include <dfm-io/dfile.h>
 
 #include <QObject>
@@ -12,6 +13,8 @@
 #include <QDebug>
 #include <QMimeDatabase>
 #include <QDir>
+
+#include <linux/limits.h>
 
 DFMBASE_USE_NAMESPACE
 
@@ -320,6 +323,135 @@ QString generateNonConflictingSymlinkName(FileInfoPointer fromInfo, FileInfoPoin
         fmInfo() << "FileNamingUtils: Using display name for symlink:" << displayName << "vs fileName:" << fileName;
         return SymlinkNameGenerator::generateUniqueSymlinkName(components, targetDir);
     }
+}
+
+/*!
+ * \brief Generate file urls for file rename by batch add text
+ *
+ * Special handling for desktop app files to prevent rename failures (case 25414)
+ */
+QMap<QUrl, QUrl> generateFileRenameUrlsByBatchAddText(const QList<QUrl> &originUrls,
+                                                      const QPair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> &pair)
+{
+    const QString addText = pair.first;
+    const auto addFlag = pair.second;
+
+    fmInfo() << "[BATCH_RENAME] Entry: Processing" << originUrls.size() << "files"
+             << ", AddText:" << addText
+             << ", AddFlag:" << (addFlag == AbstractJobHandler::FileNameAddFlag::kPrefix ? "kPrefix" : "kSuffix");
+
+    if (originUrls.isEmpty()) {
+        fmWarning() << "[BATCH_RENAME] Empty URL list";
+        return QMap<QUrl, QUrl> {};
+    }
+
+    if (addText.isEmpty()) {
+        fmWarning() << "[BATCH_RENAME] Empty addText, skipping rename operation";
+        return QMap<QUrl, QUrl> {};
+    }
+
+    if (addFlag != AbstractJobHandler::FileNameAddFlag::kPrefix &&
+        addFlag != AbstractJobHandler::FileNameAddFlag::kSuffix) {
+        fmWarning() << "[BATCH_RENAME] Invalid FileNameAddFlag:" << static_cast<int>(addFlag);
+        return QMap<QUrl, QUrl> {};
+    }
+
+    QMap<QUrl, QUrl> result;
+    int successCount = 0;
+    int skipCount = 0;
+    int errorCount = 0;
+
+    for (const auto &url : originUrls) {
+        fmDebug() << "[BATCH_RENAME] Processing URL:" << url.toString();
+
+        FileInfoPointer info = InfoFactory::create<FileInfo>(url);
+        if (!info) {
+            fmWarning() << "[BATCH_RENAME] Failed to create FileInfo for URL:" << url.toString();
+            errorCount++;
+            continue;
+        }
+
+        const QString originalFileName = info->nameOf(NameInfoType::kFileName);
+        fmDebug() << "[BATCH_RENAME] Original file name:" << originalFileName;
+
+        const QString mimeType = info->nameOf(NameInfoType::kMimeTypeName);
+        const bool isDesktopApp = mimeType.contains(Global::Mime::kTypeAppDesktop);
+        fmDebug() << "[BATCH_RENAME] File type - MIME:" << mimeType << ", isDesktopApp:" << isDesktopApp;
+
+        QString fileBaseName;
+        QString suffix;
+
+        if (isDesktopApp) {
+            fileBaseName = info->displayOf(DisPlayInfoType::kFileDisplayName);
+            suffix = QString();
+            fmInfo() << "[BATCH_RENAME] Desktop app detected, using display name:" << fileBaseName;
+        } else {
+            const auto nameInfo = FileNameParser::parseFileName(info);
+            fileBaseName = nameInfo.baseName.isEmpty() ? info->displayOf(DisPlayInfoType::kFileDisplayName) : nameInfo.baseName;
+            suffix = nameInfo.completeSuffix.isEmpty() ? info->nameOf(NameInfoType::kSuffix) : nameInfo.completeSuffix;
+            fmDebug() << "[BATCH_RENAME] Parsed - baseName:" << fileBaseName << ", suffix:" << suffix;
+        }
+
+        suffix = suffix.isEmpty() ? QString() : QString(".") + suffix;
+
+        const QString oldFileName = fileBaseName;
+        fmDebug() << "[BATCH_RENAME] Before modification:" << oldFileName;
+
+        const int maxLength = NAME_MAX - dfmbase::FileUtils::getFileNameLength(url, originalFileName);
+        const bool supportsLongNames = FileUtils::supportLongName(url);
+        QString trimmedAddText = dfmbase::FileUtils::cutFileName(addText, maxLength, supportsLongNames);
+
+        if (trimmedAddText != addText) {
+            fmInfo() << "[BATCH_RENAME] AddText trimmed - orig:" << addText.length()
+                     << ", new:" << trimmedAddText.length()
+                     << ", max:" << maxLength
+                     << ", longName:" << supportsLongNames;
+        }
+
+        if (trimmedAddText.isEmpty()) {
+            fmWarning() << "[BATCH_RENAME] AddText empty after trim, skipping:" << url.toString();
+            skipCount++;
+            continue;
+        }
+
+        if (addFlag == AbstractJobHandler::FileNameAddFlag::kPrefix) {
+            fileBaseName.insert(0, trimmedAddText);
+            fmDebug() << "[BATCH_RENAME] Added as prefix:" << fileBaseName;
+        } else {
+            fileBaseName.append(trimmedAddText);
+            fmDebug() << "[BATCH_RENAME] Added as suffix:" << fileBaseName;
+        }
+
+        if (!isDesktopApp) {
+            fileBaseName += suffix;
+        }
+
+        QUrl changedUrl = info->getUrlByType(UrlInfoType::kGetUrlByNewFileName, fileBaseName);
+        fmDebug() << "[BATCH_RENAME] New URL:" << changedUrl.toString();
+
+        if (isDesktopApp) {
+            fmInfo() << "[BATCH_RENAME] Desktop app rename - old:" << oldFileName
+                     << " -> new:" << fileBaseName
+                     << ", path:" << info->urlOf(UrlInfoType::kUrl).toString();
+        }
+
+        if (changedUrl != url) {
+            result.insert(url, changedUrl);
+            successCount++;
+            fmDebug() << "[BATCH_RENAME] URL changed";
+        } else {
+            skipCount++;
+            fmDebug() << "[BATCH_RENAME] URL unchanged";
+        }
+    }
+
+    fmInfo() << "[BATCH_RENAME] Exit: Total:" << originUrls.size()
+             << ", Success:" << successCount
+             << ", Skip:" << skipCount
+             << ", Error:" << errorCount
+             << ", Result:" << result.size();
+
+    return result;
 }
 
 }   // namespace FileNamingUtils

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.h
@@ -8,6 +8,7 @@
 #include "dfmplugin_fileoperations_global.h"
 
 #include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
 
 #include <QString>
 #include <QUrl>
@@ -157,6 +158,24 @@ QString generateNonConflictingName(FileInfoPointer fromInfo,
  */
 QString generateNonConflictingSymlinkName(FileInfoPointer fromInfo,
                                           FileInfoPointer targetDir);
+
+/*!
+ * \brief Generate file urls for file rename by batch add text
+ *
+ * This function generates renamed URLs by adding text to file names either as prefix or suffix.
+ * It handles edge cases including desktop app files, directory limits, and file name length constraints.
+ *
+ * Usage examples:
+ * - Prefix mode: "file.txt" + addText("new_") -> "new_file.txt"
+ * - Suffix mode: "file.txt" + addText("_backup") -> "file_backup.txt"
+ * - Desktop app: Special handling to preserve app name integrity
+ *
+ * \param originUrls List of URLs to be renamed
+ * \param pair QPair containing [text to add, add position (prefix/suffix)]
+ * \return QMap mapping original URLs to new URLs (only includes entries that actually changed)
+ */
+QMap<QUrl, QUrl> generateFileRenameUrlsByBatchAddText(const QList<QUrl> &originUrls,
+                                                      const QPair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> &pair);
 }
 
 DPFILEOPERATIONS_END_NAMESPACE

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -347,7 +347,7 @@ bool FileOperationsEventReceiver::doRenameFiles(const quint64 windowId, const QL
         auto tmpurls = urls;
         QMap<QUrl, QUrl> needDealUrls;
         bool renameDesktop = doRenameDesktopFilesWithAppend(tmpurls, pair2, needDealUrls, successUrls);
-        QMap<QUrl, QUrl> needDealUrls1 = FileUtils::fileBatchAddText(tmpurls, pair2);
+        QMap<QUrl, QUrl> needDealUrls1 = FileNamingUtils::generateFileRenameUrlsByBatchAddText(tmpurls, pair2);
         for (auto it = needDealUrls1.begin(); it != needDealUrls1.end(); ++it) {
             needDealUrls.insert(it.key(), it.value());
         }


### PR DESCRIPTION
Implemented generateFileRenameUrlsByBatchAddText in filenameutils to support batch renaming by adding text as prefix or suffix. Added special handling for desktop app files to prevent rename failures (case 25414). The function validates file name lengths, performs truncation based on filesystem limits via FileUtils::getFileNameLength and FileUtils::cutFileName, and properly preserves file extensions. Updated fileoperationseventreceiver.cpp to use the new utility function. Added include for dfm-base/utils/fileutils.h and linux/limits.h to support filename length validation.

fix: 实现批量添加文本重命名功能

在 filenameutils 中实现了 generateFileRenameUrlsByBatchAddText，支持通过前缀或后缀添加文本进行批量重命名。对 .desktop 应用文件进行了特殊处理，防止重命名失败（case 25414）。该函数会校验文件名长度，通过 FileUtils::getFileNameLength 和 FileUtils::cutFileName 根据文件系统限制执行截断，并正确保留文件扩展名。已更新 fileoperationseventreceiver.cpp 以使用该工具函数。添加了 dfm-base/utils/fileutils.h 和 linux/limits.h 的头文件包含以支持文件名长度验证。

Influence:
1. Verify batch rename functionality works correctly for both prefix and suffix modes
2. Test file name length validation and truncation with very long addText
3. Confirm desktop app files are handled without rename errors
4. Validate file extensions are preserved for non-desktop files
5. Test with various file systems (ext4, fat32, exfat) to ensure length limits are respected
6. Verify logging messages are helpful for debugging batch rename operations

影响力：
验证批量重命名功能在前缀和后缀模式下均能正常工作
2. 测试文件名长度验证与截断功能，使用极长文本添加
3. 确认桌面应用程序文件处理过程中无重命名错误
4. 验证非桌面文件的扩展名是否保留
5. 使用多种文件系统（ext4、fat32、exfat）进行测试，以确保长度限制得到遵守
6. 验证日志消息是否有助于调试批量重命名操作

Log: implement batch file rename with text add functionality
Bug: https://pms.uniontech.com/bug-view-354673.html

## Summary by Sourcery

Add a batch file rename helper that appends text as a prefix or suffix and wire it into the file rename flow.

New Features:
- Support batch renaming files by adding configurable prefix or suffix text via a shared filename utility.

Bug Fixes:
- Resolve batch rename failures for desktop app files when adding text to their names.

Enhancements:
- Handle desktop application files specially during batch add-text renames to avoid failures while preserving display names and extensions.
- Enforce filesystem-dependent filename length limits and truncation when adding text during batch renames, with improved logging for debugging.