### PR TITLE
master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ dde-file-manager-lib/test_shutil/property/oneProperty.pro
 # cursor & AI config
 .cursorindexingignore
 .cursor
+.worktrees/
 .specstory
 .spec-workflow/
 .serena/

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogmanager.cpp
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogmanager.cpp
@@ -34,17 +34,14 @@ ReportLogManager::~ReportLogManager()
 
 void ReportLogManager::init()
 {
-    reportWorker = new ReportLogWorker();
-    if (!reportWorker->init()) {
-        reportWorker->deleteLater();
+    if (reportWorkThread || reportWorker)
         return;
-    }
 
-    reportWorkThread = new QThread();
-    connect(reportWorkThread, &QThread::finished, [&]() {
-        reportWorker->deleteLater();
-    });
+    reportWorker = new ReportLogWorker();
+    reportWorkThread = new QThread(this);
     reportWorker->moveToThread(reportWorkThread);
+    connect(reportWorkThread, &QThread::finished, reportWorker, &QObject::deleteLater);
+    connect(reportWorkThread, &QThread::started, reportWorker, &ReportLogWorker::init, Qt::QueuedConnection);
 
     initConnection();
 

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.cpp
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.cpp
@@ -46,29 +46,37 @@ ReportLogWorker::~ReportLogWorker()
         logLibrary.unload();
 }
 
-bool ReportLogWorker::init()
+void ReportLogWorker::init()
 {
-    QList<ReportDataInterface *> datas {
-        new BlockMountReportData,
-        new SmbReportData,
-        new SidebarReportData,
-        new SearchReportData,
-        new VaultReportData,
-        new FileMenuReportData,
-        new AppStartupReportData,
-        new EnterDirReportData,
-        new DesktopStartUpReportData
-    };
+    if (logDataObj.isEmpty()) {
+        QList<ReportDataInterface *> datas {
+            new BlockMountReportData,
+            new SmbReportData,
+            new SidebarReportData,
+            new SearchReportData,
+            new VaultReportData,
+            new FileMenuReportData,
+            new AppStartupReportData,
+            new EnterDirReportData,
+            new DesktopStartUpReportData
+        };
 
-    commonData.insert("app_version", VERSION);
+        std::for_each(datas.cbegin(), datas.cend(), [this](ReportDataInterface *dat) { registerLogData(dat->type(), dat); });
+    }
 
-    std::for_each(datas.cbegin(), datas.cend(), [this](ReportDataInterface *dat) { registerLogData(dat->type(), dat); });
+    if (!commonData.contains("app_version"))
+        commonData.insert("app_version", VERSION);
+
+    if (writeEventLogFunc)
+        return;
 
     logLibrary.setFileName("deepin-event-log");
-    if (!logLibrary.load()) {
-        fmWarning() << "Report log plugin load log library failed!";
-        return false;
-    } else {
+    if (!logLibrary.isLoaded()) {
+        if (!logLibrary.load()) {
+            fmWarning() << "Report log plugin load log library failed!";
+            return;
+        }
+
         fmInfo() << "Report log plugin load log library success.";
     }
 
@@ -77,15 +85,15 @@ bool ReportLogWorker::init()
 
     if (!initEventLogFunc || !writeEventLogFunc) {
         fmWarning() << "Log library init failed!";
-        return false;
+        writeEventLogFunc = nullptr;
+        return;
     }
 
     if (!initEventLogFunc(QApplication::applicationName().toStdString(), false)) {
         fmWarning() << "Log library init function call failed!";
-        return false;
+        writeEventLogFunc = nullptr;
+        return;
     }
-
-    return true;
 }
 
 void ReportLogWorker::commitLog(const QString &type, const QVariantMap &args)
@@ -237,7 +245,7 @@ bool ReportLogWorker::registerLogData(const QString &type, ReportDataInterface *
 
 void ReportLogWorker::commit(const QVariant &args)
 {
-    if (args.isNull() || !args.isValid())
+    if (!writeEventLogFunc || args.isNull() || !args.isValid())
         return;
     const QJsonObject &dataObj = QJsonObject::fromVariantHash(args.toHash());
     QJsonDocument doc(dataObj);

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.h
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.h
@@ -25,9 +25,8 @@ public:
     explicit ReportLogWorker(QObject *parent = nullptr);
     ~ReportLogWorker();
 
-    bool init();
-
 public Q_SLOTS:
+    void init();
     void commitLog(const QString &type, const QVariantMap &args);
     void handleMenuData(const QString &name, const QList<QUrl> &urlList);
     void handleBlockMountData(const QString &id, bool result);


### PR DESCRIPTION
- **chore: ignore local worktrees**
- **refactor: improve report log initialization and thread safety**

## Summary by Sourcery

Make report logging initialization idempotent and thread-safe while avoiding redundant worker/thread creation.

Bug Fixes:
- Prevent committing logs when the event log function is not initialized to avoid potential crashes.
- Avoid reloading the log library and reinitializing common data when already initialized, reducing race conditions.

Enhancements:
- Refactor ReportLogWorker initialization into a void, idempotent slot suitable for running on the worker thread.
- Simplify ReportLogManager initialization to only create the worker and thread once and to initialize the worker when the thread starts.
- Ensure proper ownership and cleanup of the report worker by parenting the worker thread and using direct deleteLater connection.

Chores:
- Update .gitignore to ignore local worktrees.