### PR TITLE
refactor: improve report log initialization and thread safety

### DIFF
--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogmanager.cpp
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogmanager.cpp
@@ -34,17 +34,14 @@ ReportLogManager::~ReportLogManager()
 
 void ReportLogManager::init()
 {
-    reportWorker = new ReportLogWorker();
-    if (!reportWorker->init()) {
-        reportWorker->deleteLater();
+    if (reportWorkThread || reportWorker)
         return;
-    }
 
-    reportWorkThread = new QThread();
-    connect(reportWorkThread, &QThread::finished, [&]() {
-        reportWorker->deleteLater();
-    });
+    reportWorker = new ReportLogWorker();
+    reportWorkThread = new QThread(this);
     reportWorker->moveToThread(reportWorkThread);
+    connect(reportWorkThread, &QThread::finished, reportWorker, &QObject::deleteLater);
+    connect(reportWorkThread, &QThread::started, reportWorker, &ReportLogWorker::init, Qt::QueuedConnection);
 
     initConnection();
 

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.cpp
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.cpp
@@ -46,29 +46,37 @@ ReportLogWorker::~ReportLogWorker()
         logLibrary.unload();
 }
 
-bool ReportLogWorker::init()
+void ReportLogWorker::init()
 {
-    QList<ReportDataInterface *> datas {
-        new BlockMountReportData,
-        new SmbReportData,
-        new SidebarReportData,
-        new SearchReportData,
-        new VaultReportData,
-        new FileMenuReportData,
-        new AppStartupReportData,
-        new EnterDirReportData,
-        new DesktopStartUpReportData
-    };
+    if (logDataObj.isEmpty()) {
+        QList<ReportDataInterface *> datas {
+            new BlockMountReportData,
+            new SmbReportData,
+            new SidebarReportData,
+            new SearchReportData,
+            new VaultReportData,
+            new FileMenuReportData,
+            new AppStartupReportData,
+            new EnterDirReportData,
+            new DesktopStartUpReportData
+        };
 
-    commonData.insert("app_version", VERSION);
+        std::for_each(datas.cbegin(), datas.cend(), [this](ReportDataInterface *dat) { registerLogData(dat->type(), dat); });
+    }
 
-    std::for_each(datas.cbegin(), datas.cend(), [this](ReportDataInterface *dat) { registerLogData(dat->type(), dat); });
+    if (!commonData.contains("app_version"))
+        commonData.insert("app_version", VERSION);
+
+    if (writeEventLogFunc)
+        return;
 
     logLibrary.setFileName("deepin-event-log");
-    if (!logLibrary.load()) {
-        fmWarning() << "Report log plugin load log library failed!";
-        return false;
-    } else {
+    if (!logLibrary.isLoaded()) {
+        if (!logLibrary.load()) {
+            fmWarning() << "Report log plugin load log library failed!";
+            return;
+        }
+
         fmInfo() << "Report log plugin load log library success.";
     }
 
@@ -77,15 +85,15 @@ bool ReportLogWorker::init()
 
     if (!initEventLogFunc || !writeEventLogFunc) {
         fmWarning() << "Log library init failed!";
-        return false;
+        writeEventLogFunc = nullptr;
+        return;
     }
 
     if (!initEventLogFunc(QApplication::applicationName().toStdString(), false)) {
         fmWarning() << "Log library init function call failed!";
-        return false;
+        writeEventLogFunc = nullptr;
+        return;
     }
-
-    return true;
 }
 
 void ReportLogWorker::commitLog(const QString &type, const QVariantMap &args)
@@ -237,7 +245,7 @@ bool ReportLogWorker::registerLogData(const QString &type, ReportDataInterface *
 
 void ReportLogWorker::commit(const QVariant &args)
 {
-    if (args.isNull() || !args.isValid())
+    if (!writeEventLogFunc || args.isNull() || !args.isValid())
         return;
     const QJsonObject &dataObj = QJsonObject::fromVariantHash(args.toHash());
     QJsonDocument doc(dataObj);

--- a/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.h
+++ b/src/plugins/common/dfmplugin-utils/reportlog/reportlogworker.h
@@ -25,9 +25,8 @@ public:
     explicit ReportLogWorker(QObject *parent = nullptr);
     ~ReportLogWorker();
 
-    bool init();
-
 public Q_SLOTS:
+    void init();
     void commitLog(const QString &type, const QVariantMap &args);
     void handleMenuData(const QString &name, const QList<QUrl> &urlList);
     void handleBlockMountData(const QString &id, bool result);


### PR DESCRIPTION
1. Added thread safety check to prevent multiple initialization in
ReportLogManager
2. Modified ReportLogWorker::init() to be idempotent and return void
instead of bool
3. Changed thread ownership by passing parent to QThread constructor
4. Moved worker initialization to thread start signal with queued
connection
5. Improved error handling by setting writeEventLogFunc to nullptr on
failures
6. Added null check for writeEventLogFunc in commit method to prevent
crashes

Log: Improved report log system stability and initialization process

Influence:
1. Test report log initialization multiple times to verify idempotency
2. Verify thread safety when initializing from multiple threads
3. Test log commitment functionality after successful initialization
4. Check error handling when log library fails to load
5. Verify proper cleanup when threads are destroyed
6. Test all report data types are properly registered

refactor: 改进报告日志初始化和线程安全性

1. 添加线程安全检查防止 ReportLogManager 多次初始化
2. 修改 ReportLogWorker::init() 为幂等操作并返回 void 而非 bool
3. 通过向 QThread 构造函数传递父对象改变线程所有权
4. 将工作器初始化移至线程启动信号并使用队列连接
5. 改进错误处理，在失败时将 writeEventLogFunc 设为 nullptr
6. 在提交方法中添加 writeEventLogFunc 空检查防止崩溃

Log: 改进报告日志系统稳定性和初始化流程

Influence:
1. 多次测试报告日志初始化以验证幂等性
2. 验证多线程初始化时的线程安全性
3. 测试成功初始化后的日志提交功能
4. 检查日志库加载失败时的错误处理
5. 验证线程销毁时的正确清理
6. 测试所有报告数据类型是否正确注册

Bug: https://pms.uniontech.com/bug-view-355011.html

## Summary by Sourcery

Refine report logging initialization and threading to make the logging worker idempotent, safer to use from multiple threads, and more robust against logging backend failures.

Bug Fixes:
- Prevent crashes during log commit by skipping commits when the logging function is unavailable or initialization fails.

Enhancements:
- Make ReportLogWorker initialization idempotent, avoiding duplicate log data registration and app version insertion.
- Change ReportLogWorker::init to a void slot and invoke it via a queued connection when the worker thread starts.
- Guard ReportLogManager initialization against multiple invocations and create the worker thread with parent-based ownership.
- Improve handling of the external log library by reusing loaded state and clearing writeEventLogFunc on initialization failures.