### PR TITLE
chore: bump version to 6.5.129

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-file-manager (6.5.129) unstable; urgency=medium
+
+  * fix: improve empty area detection in file manager view
+  * fix: ensure proper cleanup before unloading plugins
+  * feat: add sorting capability to directory traversal
+  * refactor: improve report log initialization and thread safety
+  * fix: implement batch file rename with text add functionality
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Mon, 30 Mar 2026 19:35:06 +0800
+
 dde-file-manager (6.5.128) unstable; urgency=medium
 
   * style: refactor elide text layout code formatting


### PR DESCRIPTION
6.5.129

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog entry for version 6.5.129.