### PR TITLE
master

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.130) unstable; urgency=medium
+
+  * fix: add delayed loading for burn plugin to improve startup performance
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 31 Mar 2026 20:50:42 +0800
+
 dde-file-manager (6.5.129) unstable; urgency=medium
 
   * fix: improve empty area detection in file manager view

--- a/src/plugins/common/dfmplugin-burn/burn.cpp
+++ b/src/plugins/common/dfmplugin-burn/burn.cpp
@@ -38,6 +38,8 @@ void Burn::initialize()
 
 bool Burn::start()
 {
+    fmDebug() << "[Burn::start] Begin";
+
     dfmplugin_menu_util::menuSceneRegisterScene(SendToDiscMenuCreator::name(), new SendToDiscMenuCreator);
     bindScene("ShareMenu");
 
@@ -45,7 +47,10 @@ bool Burn::start()
 
     connect(Application::dataPersistence(), &Settings::valueChanged, this, &Burn::onPersistenceDataChanged, Qt::DirectConnection);
     Application::dataPersistence()->removeGroup(Persistence::kBurnStateGroup);
+
+    fmDebug() << "[Burn::start] Calling startOpticalDiscScan...";
     DevMngIns->startOpticalDiscScan();
+    fmInfo() << "[Burn::start] startOpticalDiscScan returned";
 
     QString err;
     auto ret = DConfigManager::instance()->addConfig("org.deepin.dde.file-manager.burn", &err);

--- a/src/plugins/desktop/ddplugin-core/core.cpp
+++ b/src/plugins/desktop/ddplugin-core/core.cpp
@@ -27,6 +27,7 @@
 #include <QDBusInterface>
 #include <QDBusPendingCall>
 #include <QKeyEvent>
+#include <QTimer>
 
 Q_DECLARE_METATYPE(QStringList *)
 
@@ -127,8 +128,7 @@ void Core::onFrameReady()
 
 void Core::handleLoadPlugins(const QStringList &names)
 {
-    std::for_each(names.begin(), names.end(), [](const QString &name) {
-        Q_ASSERT(qApp->thread() == QThread::currentThread());
+    auto loadPlugin = [](const QString &name) {
         fmDebug() << "Loading plugin:" << name;
         auto plugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj(name) };
         if (plugin) {
@@ -141,6 +141,21 @@ void Core::handleLoadPlugins(const QStringList &names)
         } else {
             fmWarning() << "Plugin meta object not found for:" << name;
         }
+    };
+
+    std::for_each(names.begin(), names.end(), [&loadPlugin](const QString &name) {
+        Q_ASSERT(qApp->thread() == QThread::currentThread());
+
+        // WORKAROUND(zhangs): delay loading dfmplugin-burn by 10s because it may slow down desktop startup
+        // TODO(zhangs): refactor the plugin logic to avoid performance impact on desktop initialization
+        if (name == "dfmplugin-burn") {
+            QTimer::singleShot(10000, [loadPlugin, name]() {
+                loadPlugin(name);
+            });
+            return;
+        }
+
+        loadPlugin(name);
     });
 }
 


### PR DESCRIPTION
- **fix: add delayed loading for burn plugin to improve startup performance**
- **chore: bump version to 6.5.130**

## Summary by Sourcery

Delay loading of the burn plugin to avoid impacting desktop startup performance and add diagnostics around its initialization.

Bug Fixes:
- Defer loading of the dfmplugin-burn plugin by 10 seconds to mitigate its negative impact on desktop startup performance.

Enhancements:
- Add debug and info logging around the burn plugin start sequence to aid troubleshooting.