### PR TITLE
fix: ensure address bar shows on context menu

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
@@ -25,6 +25,7 @@
 
 #include <QCompleter>
 #include <QFontMetrics>
+#include "addressbar.h"
 
 using namespace dfmplugin_titlebar;
 
@@ -641,4 +642,10 @@ void AddressBar::inputMethodEvent(QInputMethodEvent *e)
         setCursorPosition(pos);
     }
     QLineEdit::inputMethodEvent(e);
+}
+
+void dfmplugin_titlebar::AddressBar::contextMenuEvent(QContextMenuEvent *e)
+{
+    showOnFocusLostOnce();
+    QLineEdit::contextMenuEvent(e);
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.h
@@ -33,6 +33,7 @@ protected:
     void paintEvent(QPaintEvent *e) override;
     void showEvent(QShowEvent *event) override;
     void inputMethodEvent(QInputMethodEvent *e) override;
+    void contextMenuEvent(QContextMenuEvent *e) override;
 
 Q_SIGNALS:
     void lostFocus();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -236,15 +236,6 @@ void TitleBarWidget::handleHotketSwitchViewMode(int mode)
 
 void TitleBarWidget::handleHotketCloseCurrentTab()
 {
-    if (tabBar()->count() == 1) {
-        auto winId = TitleBarHelper::windowId(this);
-        auto window = FMWindowsIns.findWindowById(winId);
-        if (window)
-            window->close();
-
-        return;
-    }
-
     tabBar()->removeTab(tabBar()->currentIndex());
 }
 


### PR DESCRIPTION
Fixed an issue where the address bar might not show properly when
opening the context menu. The problem occurred because the address bar's
visibility logic conflicted with context menu events. Added override of
contextMenuEvent to call showOnFocusLostOnce() before delegating to the
base class, ensuring the address bar remains visible when users right-
click to access the context menu.

Log: Fixed address bar disappearing when opening context menu

Influence:
1. Right-click on the address bar to open context menu - should remain
visible
2. Test various interactions with address bar while context menu is open
3. Verify focus behavior when switching between address bar and other
UI elements
4. Check that all context menu options work correctly when address bar
is visible

fix: 修复地址栏在打开上下文菜单时不显示的问题

修复了打开上下文菜单时地址栏可能无法正确显示的问题。该问题是由于地址栏的
可见性逻辑与上下文菜单事件冲突导致的。添加了contextMenuEvent的重写，在委
托给基类之前调用showOnFocusLostOnce()，确保用户右键点击打开上下文菜单时
地址栏保持可见。

Log: 修复打开上下文菜单时地址栏消失的问题

Influence:
1. 右键点击地址栏打开上下文菜单 - 应保持可见
2. 测试在上下文菜单打开时与地址栏的各种交互
3. 验证在地址栏和其他UI元素之间切换时的焦点行为
4. 检查地址栏可见时所有上下文菜单选项是否正常工作

BUG: https://pms.uniontech.com/bug-view-355771.html

## Summary by Sourcery

Bug Fixes:
- Prevent the address bar from disappearing when users open its context menu via right-click.