### PR TITLE
fix: fix app entry command execution on computer page

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
@@ -79,7 +79,13 @@ void ComputerController::onOpenItem(quint64 winId, const QUrl &url)
         } else if (suffix == SuffixInfo::kAppEntry) {
             QString cmd = info->extraProperty(ExtraPropertyName::kExecuteCommand).toString();
             fmDebug() << "App entry, executing command:" << cmd;
-            QProcess::startDetached(cmd);
+
+            // Split command string into program and arguments
+            QStringList parts = QProcess::splitCommand(cmd);
+            if (!parts.isEmpty()) {
+                QString program = parts.takeFirst();
+                QProcess::startDetached(program, parts);
+            }
         } else {
             fmDebug() << "Other type, sending open item event";
             ComputerEventCaller::sendOpenItem(winId, info->urlOf(UrlInfoType::kUrl));


### PR DESCRIPTION
The previous implementation used QProcess::startDetached(cmd) with
a full command string, which could fail when the command contains
arguments with spaces or special characters. This change splits the
command string into program and arguments using QProcess::splitCommand()
before executing, ensuring proper handling of complex commands.

Log: Fixed an issue where some application entries on the computer page
might fail to launch

Influence:
1. Test clicking various app entries on the computer page to ensure they
launch correctly
2. Test app entries with commands containing spaces in arguments
3. Test app entries with commands containing special characters in
arguments
4. Verify that both simple commands (single word) and complex commands
(with arguments) work properly

fix: 修复计算机页面应用入口命令执行问题

之前的实现使用 QProcess::startDetached(cmd) 直接执行完整命令
字符串，当命令包含空格或特殊字符的参数时可能会失败。此更改使用
QProcess::splitCommand() 将命令字符串拆分为程序和参数后再执行，确保正确
处理复杂命令。

Log: 修复了计算机页面某些应用入口可能无法启动的问题

Influence:
1. 测试点击计算机页面的各种应用入口，确保它们能正确启动
2. 测试包含空格参数的应用入口命令
3. 测试包含特殊字符参数的应用入口命令
4. 验证简单命令（单个单词）和复杂命令（带参数）都能正常工作

BUG: https://pms.uniontech.com/bug-view-356073.html

## Summary by Sourcery

Bug Fixes:
- Fix failure to launch some application entries whose execute commands contain spaces or special characters in their arguments.