### PR TITLE
refactor: replace custom ElidedLable with DLabel

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -31,29 +31,6 @@ static constexpr int kFileSizeWidth { 100 };
 static constexpr char kBtnPropertyActionName[] { "btnType" };
 static constexpr AbstractJobHandler::JobState kPausedState = AbstractJobHandler::JobState::kPauseState;
 
-ElidedLable::ElidedLable(QWidget *parent)
-    : QLabel(parent)
-{
-}
-
-ElidedLable::~ElidedLable() { }
-/*!
- * \brief ElidedLable::setText 设置当前文字的内容
- * \param text
- */
-void ElidedLable::setText(const QString &text)
-{
-    QFontMetrics metrics(font());
-    Qt::TextElideMode em = Qt::TextElideMode::ElideMiddle;
-
-    if (!property("TextElideMode").isNull()) {
-        int iem = property("TextElideMode").toInt();
-        em = static_cast<Qt::TextElideMode>(iem);
-    }
-
-    QLabel::setText(metrics.elidedText(text, em, width()));
-}
-
 TaskWidget::TaskWidget(QWidget *parent)
     : QWidget(parent)
 {
@@ -498,11 +475,14 @@ QWidget *TaskWidget::createConflictWidget()
     lbSrcIcon->setFixedSize(48, 48);
     lbSrcIcon->setScaledContents(true);
 
-    lbSrcTitle = new ElidedLable();
-    lbSrcModTime = new ElidedLable();
+    lbSrcTitle = new DLabel();
+    lbSrcTitle->setElideMode(Qt::ElideMiddle);
+    lbSrcModTime = new DLabel();
+    lbSrcModTime->setElideMode(Qt::ElideMiddle);
     lbSrcModTime->setPalette(labelPalette);
 
-    lbSrcFileSize = new ElidedLable();
+    lbSrcFileSize = new DLabel();
+    lbSrcFileSize->setElideMode(Qt::ElideMiddle);
     lbSrcFileSize->setFixedWidth(kFileSizeWidth);
     lbSrcFileSize->setPalette(labelPalette);
 
@@ -510,11 +490,14 @@ QWidget *TaskWidget::createConflictWidget()
     lbDstIcon->setFixedSize(48, 48);
     lbDstIcon->setScaledContents(true);
 
-    lbDstTitle = new ElidedLable();
-    lbDstModTime = new ElidedLable();
+    lbDstTitle = new DLabel();
+    lbDstTitle->setElideMode(Qt::ElideMiddle);
+    lbDstModTime = new DLabel();
+    lbDstModTime->setElideMode(Qt::ElideMiddle);
     lbDstModTime->setPalette(labelPalette);
 
-    lbDstFileSize = new ElidedLable();
+    lbDstFileSize = new DLabel();
+    lbDstFileSize->setElideMode(Qt::ElideMiddle);
     lbDstFileSize->setFixedWidth(kFileSizeWidth);
     lbDstFileSize->setPalette(labelPalette);
 
@@ -633,9 +616,11 @@ QWidget *TaskWidget::createBaseWidget()
     normalLayout->addWidget(progress, Qt::AlignLeft);
     normalLayout->addSpacing(2);
 
-    lbSrcPath = new ElidedLable;
+    lbSrcPath = new DLabel;
+    lbSrcPath->setElideMode(Qt::ElideMiddle);
     lbSpeed = new QLabel;
-    lbDstPath = new ElidedLable;
+    lbDstPath = new DLabel;
+    lbDstPath->setElideMode(Qt::ElideMiddle);
     lbRmTime = new QLabel;
     lbSrcPath->setFixedWidth(kMsgLabelWidth);
     lbSrcPath->setText(tr("In data statistics ..."));
@@ -661,9 +646,9 @@ QWidget *TaskWidget::createBaseWidget()
     vLayout1->addLayout(hLayout1, Qt::AlignTop);
     vLayout1->addLayout(hLayout2, Qt::AlignBottom);
 
-    lbErrorMsg = new ElidedLable;
+    lbErrorMsg = new DLabel;
+    lbErrorMsg->setElideMode(Qt::ElideMiddle);
     lbErrorMsg->setStyleSheet("color:red;");
-    lbErrorMsg->setFixedWidth(kMsgLabelWidth + kSpeedLabelWidth + 20);
     QHBoxLayout *hLayout3 = new QHBoxLayout;
     hLayout3->addSpacing(12);
     hLayout3->addWidget(lbErrorMsg, Qt::AlignLeft);

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.h
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.h
@@ -13,6 +13,7 @@
 #include <DIconButton>
 #include <DPushButton>
 #include <DWarningButton>
+#include <DLabel>
 
 #include <QWidget>
 #include <QLabel>
@@ -23,15 +24,6 @@ class QCheckBox;
 class QVBoxLayout;
 
 namespace dfmbase {
-
-class ElidedLable : public QLabel
-{
-    friend class TaskWidget;
-    Q_OBJECT
-    explicit ElidedLable(QWidget *parent = nullptr);
-    virtual ~ElidedLable();
-    void setText(const QString &text);
-};
 
 class TaskWidget : public QWidget
 {
@@ -82,11 +74,11 @@ protected:
 
 private:
     DTK_WIDGET_NAMESPACE::DWaterProgress *progress { nullptr };   // 左侧水球动画
-    ElidedLable *lbSrcPath { nullptr };   // 左第一个label
-    ElidedLable *lbDstPath { nullptr };   // 左第二个label
+    DTK_WIDGET_NAMESPACE::DLabel *lbSrcPath { nullptr };   // 左第一个label
+    DTK_WIDGET_NAMESPACE::DLabel *lbDstPath { nullptr };   // 左第二个label
     QLabel *lbSpeed { nullptr };   // 右第一个label
     QLabel *lbRmTime { nullptr };   // 右第二个label
-    ElidedLable *lbErrorMsg { nullptr };   // 错误信息label
+    DTK_WIDGET_NAMESPACE::DLabel *lbErrorMsg { nullptr };   // 错误信息label
     DTK_WIDGET_NAMESPACE::DIconButton *btnStop { nullptr };   // 停止按钮
     DTK_WIDGET_NAMESPACE::DIconButton *btnPause { nullptr };   // 暂停按钮
     QHBoxLayout *hLayout4 { nullptr };
@@ -97,12 +89,12 @@ private:
     QLabel *lbSrcIcon { nullptr };   // 冲突widget上的源文件图标
     QLabel *lbDstIcon { nullptr };   // 冲突widget上的目标文件图标
     bool createDestLabels { true };   // 冲突widget上创建目标文件的labels
-    ElidedLable *lbSrcTitle { nullptr };   // 冲突widget上的源文件文件显示名称
-    ElidedLable *lbDstTitle { nullptr };   // 冲突widget上的目标文件显示名称
-    ElidedLable *lbSrcModTime { nullptr };   // 冲突widget上的源文件文件修改时间
-    ElidedLable *lbDstModTime { nullptr };   // 冲突widget上的目标文件修改时间
-    ElidedLable *lbSrcFileSize { nullptr };   // 冲突widget上的源文件文件文件大小
-    ElidedLable *lbDstFileSize { nullptr };   // 冲突widget上的目标文件文件文件大小
+    DTK_WIDGET_NAMESPACE::DLabel *lbSrcTitle { nullptr };   // 冲突widget上的源文件文件显示名称
+    DTK_WIDGET_NAMESPACE::DLabel *lbDstTitle { nullptr };   // 冲突widget上的目标文件显示名称
+    DTK_WIDGET_NAMESPACE::DLabel *lbSrcModTime { nullptr };   // 冲突widget上的源文件文件修改时间
+    DTK_WIDGET_NAMESPACE::DLabel *lbDstModTime { nullptr };   // 冲突widget上的目标文件修改时间
+    DTK_WIDGET_NAMESPACE::DLabel *lbSrcFileSize { nullptr };   // 冲突widget上的源文件文件文件大小
+    DTK_WIDGET_NAMESPACE::DLabel *lbDstFileSize { nullptr };   // 冲突widget上的目标文件文件文件大小
     QWidget *widConfict { nullptr };   // 冲突widget
 
     QCheckBox *chkboxNotAskAgain { nullptr };   // 不在询问按钮


### PR DESCRIPTION
1. Removed the custom ElidedLable class implementation and its header
declaration
2. Replaced all instances of ElidedLable with DTK's DLabel in the UI
components
3. Applied setElideMode(Qt::ElideMiddle) to all DLabel instances for
consistent text elision behavior
4. Removed the fixed width constraint from the error message label
(lbErrorMsg) to allow proper text display

Log: Replaced custom text elision widget with DTK DLabel for better
integration

Influence:
1. Verify that file paths, titles, and other text labels in the task
dialog correctly elide with "..." in the middle when they are too long
2. Check the conflict resolution widget displays file information (name,
size, mod time) correctly with elided text
3. Ensure the main task progress widget shows source and destination
paths with proper text elision
4. Confirm that error messages display fully without being truncated by
fixed width constraints
5. Test UI layout stability with various text lengths in all language
environments

refactor: 用 DLabel 替换自定义的 ElidedLable 控件

1. 移除了自定义 ElidedLable 类的实现及其头文件声明
2. 将所有 UI 组件中的 ElidedLable 实例替换为 DTK 的 DLabel
3. 为所有 DLabel 实例应用 setElideMode(Qt::ElideMiddle) 以保持一致的文本
省略行为
4. 移除了错误信息标签 (lbErrorMsg) 的固定宽度限制，以允许正确显示文本

Log: 使用 DTK DLabel 替换自定义文本省略控件以实现更好的集成

Influence:
1. 验证任务对话框中文件路径、标题等文本标签在过长时能正确使用 "..." 在中
间进行省略
2. 检查冲突解决部件是否正确显示带有省略文本的文件信息（名称、大小、修改
时间）
3. 确保主任务进度部件正确显示带有文本省略的源路径和目标路径
4. 确认错误信息能完全显示而不受固定宽度限制的截断
5. 测试在各种语言环境下不同文本长度时的 UI 布局稳定性

BUG: https://pms.uniontech.com/bug-view-355717.html

## Summary by Sourcery

Replace the custom ElidedLable widget with DTK's DLabel in task-related dialogs to standardize text elision and improve label layout.

Bug Fixes:
- Prevent error messages from being truncated by removing the fixed-width constraint on the error message label and using DLabel with middle elision.

Enhancements:
- Remove the custom ElidedLable implementation in favor of DTK's DLabel for better integration and maintenance.
- Apply middle text elision to all relevant file/path labels in the task and conflict widgets to improve display of long strings.