### PR TITLE
feat: add batch rename support for undo/redo

### DIFF
--- a/include/dfm-base/interfaces/abstractjobhandler.h
+++ b/include/dfm-base/interfaces/abstractjobhandler.h
@@ -34,10 +34,11 @@ public:
         kCopyIntegrityChecking = 0x40,   // 复制文件时进行完整性校验
         kDeleteForceDeleteFile = 0x80,   // 强制删除文件夹(去除文件夹的只读权限)
         kDontFormatFileName = 0x100,   // 拷贝时不处理文件名称
-        kRevocation = 0x200,   // 拷贝时不处理文件名称
+        kRevocation = 0x200,   // 撤销操作
         kCopyRemote = 0x400,   // 深信服远程拷贝
         kRedo = 0x800,   // 重新执行（ctrl + Y）
         kCountProgressCustomize = 0x1000,   // 强制使用自己统计进度
+        kRevocationFiles = 0x2000   // 撤销多文件操作
     };
     Q_ENUM(JobFlag)
     Q_DECLARE_FLAGS(JobFlags, JobFlag)

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -189,14 +189,26 @@ bool FileOperationsEventReceiver::revocation(const quint64 windowId, const QVari
                                   targets.first(),
                                   AbstractJobHandler::JobFlag::kRevocation);
         break;
-    case kRenameFiles:
+    case kRenameFiles: {
         if (targets.isEmpty())
             return true;
 
+        QMap<QUrl, QUrl> renamedFiles;
+        QList<QUrl> successSources, successTargets;
         for (int i = 0; i < sources.size(); ++i) {
-            handleOperationRenameFile(windowId, sources[i], targets[i], AbstractJobHandler::JobFlag::kRevocation);
+            if (handleOperationRenameFile(windowId, sources[i], targets[i], AbstractJobHandler::JobFlag::kRevocationFiles)) {
+                successSources.append(sources[i]);
+                successTargets.append(targets[i]);
+                renamedFiles.insert(sources[i], targets[i]);
+            }
         }
-        break;
+        if (!successSources.isEmpty()) {
+            dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kRenameFileResult,
+                                         windowId, renamedFiles, true, QString());
+            saveFileOperation(successTargets, successSources, GlobalEventType::kRenameFiles,
+                              successSources, successTargets, GlobalEventType::kRenameFiles, true);
+        }
+    } break;
     default:
         return false;
     }
@@ -267,17 +279,22 @@ bool FileOperationsEventReceiver::redo(const quint64 windowId, const QVariantMap
     case kRenameFiles: {
         if (targets.isEmpty())
             return true;
+
+        QMap<QUrl, QUrl> renamedFiles;
         QList<QUrl> successSources, successTargets;
         for (int i = 0; i < sources.size(); ++i) {
             if (handleOperationRenameFile(windowId, sources[i], targets[i],
                                           AbstractJobHandler::JobFlag::kRedo)) {
                 successSources.append(sources[i]);
                 successTargets.append(targets[i]);
+                renamedFiles.insert(sources[i], targets[i]);
             }
         }
         if (!successSources.isEmpty()) {
-            saveFileOperation(successTargets, successSources, GlobalEventType::kRenameFile,
-                              successSources, successTargets, GlobalEventType::kRenameFile);
+            dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kRenameFileResult,
+                                         windowId, renamedFiles, true, QString());
+            saveFileOperation(successTargets, successSources, GlobalEventType::kRenameFiles,
+                              successSources, successTargets, GlobalEventType::kRenameFiles);
         }
 
         break;
@@ -1294,16 +1311,20 @@ bool FileOperationsEventReceiver::handleOperationRenameFile(const quint64 window
     }
     // TODO:: file renameFile finished need to send file renameFile finished event
     QMap<QUrl, QUrl> renamedFiles { { oldUrl, newUrl } };
-    dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kRenameFileResult,
-                                 windowId, renamedFiles, ok, error);
+    AbstractJobHandler::JobFlags tmFlags = flags;
+    // Don't publish result for batch operations (revocation/redo), will be published together later
+    if (!tmFlags.testFlag(AbstractJobHandler::JobFlag::kRevocationFiles) && !tmFlags.testFlag(AbstractJobHandler::JobFlag::kRedo)) {
+        dpfSignalDispatcher->publish(DFMBASE_NAMESPACE::GlobalEventType::kRenameFileResult,
+                                     windowId, renamedFiles, ok, error);
+    }
+
     if (ok) {
         ClipBoard::instance()->replaceClipboardUrl(oldUrl, newUrl);
         dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Rename",
                                      oldUrl, newUrl);
     }
 
-    AbstractJobHandler::JobFlags tmFlags = flags;
-    if (!tmFlags.testFlag(AbstractJobHandler::JobFlag::kRedo))
+    if (!tmFlags.testFlag(AbstractJobHandler::JobFlag::kRedo) && !tmFlags.testFlag(AbstractJobHandler::JobFlag::kRevocationFiles))
         saveFileOperation({ newUrl }, { oldUrl }, GlobalEventType::kRenameFile,
                           { oldUrl }, { newUrl }, GlobalEventType::kRenameFile,
                           tmFlags.testFlag(AbstractJobHandler::JobFlag::kRevocation));


### PR DESCRIPTION
1. Added new JobFlag kRevocationFiles to support batch undo/redo
operations for multiple file renames
2. Modified revocation and redo handlers for kRenameFiles case to
process multiple files in batch
3. Updated handleOperationRenameFile to avoid publishing individual
results during batch operations
4. Changed flag values to accommodate new kRevocationFiles flag while
maintaining existing flag order

Log: Added batch undo/redo support for multiple file rename operations

Influence:
1. Test single file rename undo/redo functionality
2. Test multiple file rename batch undo/redo operations
3. Verify that rename results are properly published for batch
operations
4. Check clipboard URL replacement still works correctly
5. Validate file operation history is saved appropriately for batch
undo/redo

feat: 为撤销/重做添加批量重命名支持

1. 新增 JobFlag kRevocationFiles 以支持多个文件重命名操作的批量撤销/重做
2. 修改 kRenameFiles 情况的撤销和重做处理器，以批量处理多个文件
3. 更新 handleOperationRenameFile 函数，避免在批量操作期间发布单个结果
4. 调整标志位值以容纳新的 kRevocationFiles 标志，同时保持现有标志顺序

Log: 新增多个文件重命名操作的批量撤销/重做功能

Influence:
1. 测试单个文件重命名撤销/重做功能
2. 测试多个文件重命名批量撤销/重做操作
3. 验证批量操作的重命名结果是否正确发布
4. 检查剪贴板URL替换功能是否仍正常工作
5. 验证文件操作历史是否适当保存批量撤销/重做记录

BUG: https://pms.uniontech.com/bug-view-355133.html

## Summary by Sourcery

Add batch undo/redo support for multi-file rename operations and adjust job flags and event handling accordingly.

New Features:
- Support batch undo/redo of multiple file rename operations using aggregated rename results.

Bug Fixes:
- Ensure multi-file rename undo/redo correctly records file operation history and publishes consistent rename results.

Enhancements:
- Adjust rename event publishing to aggregate results for batch operations instead of emitting per-file events.
- Introduce a dedicated job flag for multi-file revocation and update existing job flag values to preserve ordering semantics.