### PR TITLE
Fix(filedialog): change last visited URL saving logic for V25

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -54,18 +54,6 @@ FileDialogPrivate::FileDialogPrivate(FileDialog *qq)
     //! fix: FileDialog no needs to restore window state on creating.
     //! see FileManagerWindowsManager::createWindow
     q->setProperty("_dfm_Disable_RestoreWindowState_", true);
-
-    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
-    lastVisitedDir = qtSets.value("FileDialog/lastVisited").toUrl();
-
-    delaySaveTimer = new QTimer(this);
-    delaySaveTimer->setInterval(3000);
-    connect(delaySaveTimer, &QTimer::timeout, this, &FileDialogPrivate::saveLastVisited);
-}
-
-FileDialogPrivate::~FileDialogPrivate()
-{
-    saveLastVisited();
 }
 
 void FileDialogPrivate::handleSaveAcceptBtnClicked()
@@ -216,18 +204,6 @@ bool FileDialogPrivate::checkFileSuffix(const QString &filename, QString &suffix
     return false;
 }
 
-void FileDialogPrivate::setLastVisited(const QUrl &dir)
-{
-    lastVisitedDir = dir;
-    delaySaveTimer->start();
-}
-
-void FileDialogPrivate::saveLastVisited()
-{
-    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
-    qtSets.setValue("FileDialog/lastVisited", lastVisitedDir.toString());
-}
-
 /*!
  * \class FileDialog
  */
@@ -257,8 +233,6 @@ FileDialog::~FileDialog()
 void FileDialog::cd(const QUrl &url)
 {
     FileManagerWindow::cd(url);
-
-    d->lastVisitedDir = url;
 
     auto window = FMWindowsIns.findWindowById(this->internalWinId());
     if (!window)
@@ -293,7 +267,14 @@ QFileDialog::ViewMode FileDialog::currentViewMode() const
 
 QUrl FileDialog::lastVisitedUrl() const
 {
-    return d->lastVisitedDir;
+    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
+    return qtSets.value("FileDialog/lastVisited").toUrl();
+}
+
+void FileDialog::saveLastVisitedUrl(const QUrl &currentUrl)
+{
+    QSettings qtSets(QSettings::UserScope, QLatin1String("QtProject"));
+    qtSets.setValue("FileDialog/lastVisited", currentUrl.toString());
 }
 
 void FileDialog::setDirectory(const QString &directory)
@@ -708,6 +689,9 @@ bool FileDialog::checkFileSuffix(const QString &filename, QString &suffix)
 
 void FileDialog::accept()
 {
+    // 记录当前的访问目录
+    saveLastVisitedUrl(currentUrl());
+
     done(QDialog::Accepted);
 }
 
@@ -1184,9 +1168,6 @@ void FileDialog::initConnect()
             this, &FileDialog::selectedNameFilterChanged);
 #endif
     connect(this, &FileDialog::selectionFilesChanged, &FileDialog::updateAcceptButtonState);
-    connect(this, &FileDialog::currentUrlChanged, this, [this](auto url) {
-        d->lastVisitedDir = url;
-    });
 }
 
 void FileDialog::initEventsConnect()

--- a/src/plugins/filedialog/core/views/filedialog.h
+++ b/src/plugins/filedialog/core/views/filedialog.h
@@ -34,6 +34,7 @@ public:
     bool saveClosedSate() const override;
     void updateAsDefaultSize();
     QUrl lastVisitedUrl() const;
+    void saveLastVisitedUrl(const QUrl &currentUrl);
 
 public:
     QFileDialog::ViewMode currentViewMode() const;

--- a/src/plugins/filedialog/core/views/filedialog_p.h
+++ b/src/plugins/filedialog/core/views/filedialog_p.h
@@ -30,16 +30,11 @@ class FileDialogPrivate : public QObject
 
 public:
     explicit FileDialogPrivate(FileDialog *qq);
-    ~FileDialogPrivate();
 
     void handleSaveAcceptBtnClicked();
     void handleOpenAcceptBtnClicked();
     void handleOpenNewWindow(const QUrl &url);
     bool checkFileSuffix(const QString &filename, QString &suffix);
-    void setLastVisited(const QUrl &dir);
-
-public Q_SLOTS:
-    void saveLastVisited();
 
 private:
     static constexpr int kDefaultWindowWidth { 960 };
@@ -60,8 +55,6 @@ private:
     bool allowMixedSelection { false };
     QFileDialog::Options options;
     QUrl currentUrl;
-    QUrl lastVisitedDir;
-    QTimer *delaySaveTimer { nullptr };
 
     static QStringList cleanFilterList(const QString &filter)
     {


### PR DESCRIPTION
- Remove delayed timer-based saving of last visited directory
- Save last visited URL directly when dialog is accepted instead of on every directory change
- Remove FileDialogPrivate destructor and related members (lastVisitedDir, delaySaveTimer, setLastVisited, saveLastVisited)
- Add saveLastVisitedUrl() public method to FileDialog class
- Update copyright year from 2023 to 2026

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-356027.html

## Summary by Sourcery

Adjust file dialog last visited directory persistence to save directly on acceptance and simplify related state handling.

Enhancements:
- Store and retrieve the file dialog's last visited URL directly via QSettings instead of maintaining it in the private dialog state.
- Expose a new saveLastVisitedUrl() API on FileDialog and invoke it when the dialog is accepted to record the final directory.
- Remove the FileDialogPrivate destructor and associated delayed-timer mechanism for persisting the last visited directory.