### PR TITLE
fix: trim whitespace from address bar input

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/addressbar.cpp
@@ -346,7 +346,7 @@ void AddressBarPrivate::onTextEdited(const QString &text)
 
 void AddressBarPrivate::onReturnPressed()
 {
-    QString text { q->text() };
+    QString text { q->text().trimmed() };
     if (text.isEmpty())
         return;
 


### PR DESCRIPTION
This change adds `.trimmed()` to the address bar input text when the
return key is pressed. The modification prevents navigation failures
caused by accidental leading or trailing whitespace in user input.
Previously, strings containing only spaces would not trigger early
return checks, potentially causing unexpected behavior when attempting
to navigate to such paths.

Log: Fixed address bar navigation issue where whitespace-only input
could cause errors

Influence:
1. Test address bar with inputs containing leading spaces (e.g., " /
home/user")
2. Test address bar with inputs containing trailing spaces (e.g., "/
home/user ")
3. Test address bar with inputs containing both leading and trailing
spaces
4. Verify navigation still works correctly for normal inputs without
extra whitespace
5. Test edge case of input containing only spaces
6. Verify the change does not affect legitimate file/folder names with
intentional spaces in the middle

fix: 修整地址栏输入框的空白字符

此修改在按下回车键时对地址栏输入文本添加了 `.trimmed()` 处理。该修改可以
防止用户意外输入的前后空格导致导航失败。此前，包含空格的字符串不会触发早
期返回检查，可能在尝试导航到此类路径时造成意外行为。

Log: 修复了地址栏导航问题，纯空格输入可能导致错误

Influence:
1. 测试地址栏输入包含前导空格的情况（如" /home/user"）
2. 测试地址栏输入包含尾部空格的情况（如"/home/user "）
3. 测试地址栏输入同时包含前后空格的情况
4. 验证正常输入（无额外空格）的导航功能仍然正常
5. 测试仅包含空格的输入这一边界情况
6. 验证此修改不影响名称中间包含空格的文件/文件夹的正确导航

## Summary by Sourcery

Bug Fixes:
- Prevent navigation failures when the address bar input contains leading or trailing spaces or consists only of whitespace.