### PR TITLE
refactor: remove COMPILE_ON_V2X macro system

### DIFF
--- a/cmake/DFMCommon.cmake
+++ b/cmake/DFMCommon.cmake
@@ -20,10 +20,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-z,relro -Wl,-z,now")
 
 # Common definitions
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(COMPILE_ON_V2X TRUE)
 add_definitions(-DQT_MESSAGELOGCONTEXT)
 add_definitions(-DENABLE_TESTING)
-add_definitions(-DCOMPILE_ON_V2X)
 
 # Architecture-specific settings
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips")

--- a/src/apps/dde-file-manager-daemon/CMakeLists.txt
+++ b/src/apps/dde-file-manager-daemon/CMakeLists.txt
@@ -29,19 +29,17 @@ target_link_libraries(
 # Enable position-independent executables for improved security
 target_link_options(${PROJECT_NAME} PRIVATE -pie)
 
-if (COMPILE_ON_V2X)
-    if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
-        pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)
-    endif()
-
-    macro(install_symlink filepath wantsdir)
-        file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/link/${wantsdir}/)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${SYSTEMD_USER_UNIT_DIR}/${filepath} ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath})
-        install(FILES ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath} DESTINATION ${SYSTEMD_USER_UNIT_DIR}/${wantsdir}/)
-    endmacro(install_symlink)
-
-    install_symlink(dde-file-manager.service dde-session-initialized.target.wants)
+if (NOT DEFINED SYSTEMD_USER_UNIT_DIR)
+    pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)
 endif()
+
+macro(install_symlink filepath wantsdir)
+    file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/link/${wantsdir}/)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${SYSTEMD_USER_UNIT_DIR}/${filepath} ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath})
+    install(FILES ${PROJECT_BINARY_DIR}/link/${wantsdir}/${filepath} DESTINATION ${SYSTEMD_USER_UNIT_DIR}/${wantsdir}/)
+endmacro(install_symlink)
+
+install_symlink(dde-file-manager.service dde-session-initialized.target.wants)
 
 # binary
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -62,13 +62,9 @@
 #include <sys/stat.h>
 #include <linux/limits.h>
 
-#ifdef COMPILE_ON_V2X
-#    define APPEARANCE_SERVICE "org.deepin.dde.Appearance1"
-#    define APPEARANCE_PATH "/org/deepin/dde/Appearance1"
-#else
-#    define APPEARANCE_SERVICE "com.deepin.daemon.Appearance"
-#    define APPEARANCE_PATH "/com/deepin/daemon/Appearance"
-#endif
+#define APPEARANCE_SERVICE "org.deepin.dde.Appearance1"
+#define APPEARANCE_PATH "/org/deepin/dde/Appearance1"
+
 using namespace GlobalDConfDefines::ConfigPath;
 
 namespace dfmbase {

--- a/src/dfm-base/utils/universalutils.cpp
+++ b/src/dfm-base/utils/universalutils.cpp
@@ -25,55 +25,25 @@
 #include <QRegularExpression>
 #include <DUtil>
 
-#ifdef COMPILE_ON_V2X
-#    define SYSTEM_SYSTEMINFO_SERVICE "org.deepin.dde.SystemInfo1"
-#    define SYSTEM_SYSTEMINFO_PATH "/org/deepin/dde/SystemInfo1"
-#    define SYSTEM_SYSTEMINFO_INTERFACE "org.deepin.dde.SystemInfo1"
+#define SYSTEM_SYSTEMINFO_SERVICE "org.deepin.dde.SystemInfo1"
+#define SYSTEM_SYSTEMINFO_PATH "/org/deepin/dde/SystemInfo1"
+#define SYSTEM_SYSTEMINFO_INTERFACE "org.deepin.dde.SystemInfo1"
 
-#    define DEAMON_DOCK_SERVICE "org.deepin.dde.daemon.Dock1"
-#    define DEAMON_DOCK_PATH "/org/deepin/dde/daemon/Dock1"
-#    define DEAMON_DOCK_INTERFACE "org.deepin.dde.daemon.Dock1"
+#define DEAMON_DOCK_SERVICE "org.deepin.dde.daemon.Dock1"
+#define DEAMON_DOCK_PATH "/org/deepin/dde/daemon/Dock1"
+#define DEAMON_DOCK_INTERFACE "org.deepin.dde.daemon.Dock1"
 
-#    define DDE_LOCKSERVICE_SERVICE "org.deepin.dde.LockService1"
-#    define DDE_LOCKSERVICE_PATH "/org/deepin/dde/LockService1"
-#    define DDE_LOCKSERVICE_INTERFACE "org.deepin.dde.LockService1"
+#define DDE_LOCKSERVICE_SERVICE "org.deepin.dde.LockService1"
+#define DDE_LOCKSERVICE_PATH "/org/deepin/dde/LockService1"
+#define DDE_LOCKSERVICE_INTERFACE "org.deepin.dde.LockService1"
 
-#    define DESKTOP_FILEMONITOR_SERVICE "org.deepin.dde.desktop.filemonitor"
-#    define DESKTOP_FILEMONITOR_PATH "/org/deepin/dde/desktop/filemonitor"
-#    define DESKTOP_FILEMONITOR_INTERFACE "org.deepin.dde.desktop.filemonitor"
+#define DESKTOP_FILEMONITOR_SERVICE "org.deepin.dde.desktop.filemonitor"
+#define DESKTOP_FILEMONITOR_PATH "/org/deepin/dde/desktop/filemonitor"
+#define DESKTOP_FILEMONITOR_INTERFACE "org.deepin.dde.desktop.filemonitor"
 
-#    define IDLE_SCREEN_SAVER_SERVICE "org.freedesktop.ScreenSaver"
-#    define IDLE_SCREEN_SAVER_PATH "/org/freedesktop/ScreenSaver"
-#    define IDLE_SCREEN_SAVER_INTERFACE "org.freedesktop.ScreenSaver"
-#else
-#    define APP_MANAGER_SERVICE "com.deepin.SessionManager"
-#    define APP_MANAGER_PATH "/com/deepin/StartManager"
-#    define APP_MANAGER_INTERFACE "com.deepin.StartManager"
-
-#    define SYSTEM_SYSTEMINFO_SERVICE "com.deepin.system.SystemInfo"
-#    define SYSTEM_SYSTEMINFO_PATH "/com/deepin/system/SystemInfo"
-#    define SYSTEM_SYSTEMINFO_INTERFACE "com.deepin.system.SystemInfo"
-
-#    define DEAMON_SYSTEMINFO_SERVICE "com.deepin.daemon.SystemInfo"
-#    define DEAMON_SYSTEMINFO_PATH "/com/deepin/daemon/SystemInfo"
-#    define DEAMON_SYSTEMINFO_INTERFACE "com.deepin.daemon.SystemInfo"
-
-#    define DEAMON_DOCK_SERVICE "com.deepin.dde.daemon.Dock"
-#    define DEAMON_DOCK_PATH "/com/deepin/dde/daemon/Dock"
-#    define DEAMON_DOCK_INTERFACE "com.deepin.dde.daemon.Dock"
-
-#    define DDE_LOCKSERVICE_SERVICE "com.deepin.dde.LockService"
-#    define DDE_LOCKSERVICE_PATH "/com/deepin/dde/LockService"
-#    define DDE_LOCKSERVICE_INTERFACE "com.deepin.dde.LockService"
-
-#    define DESKTOP_FILEMONITOR_SERVICE "com.deepin.dde.desktop.filemonitor"
-#    define DESKTOP_FILEMONITOR_PATH "/com/deepin/dde/desktop/filemonitor"
-#    define DESKTOP_FILEMONITOR_INTERFACE "com.deepin.dde.desktop.filemonitor"
-
-#    define IDLE_SCREEN_SAVER_SERVICE "org.freedesktop.ScreenSaver"
-#    define IDLE_SCREEN_SAVER_PATH "/org/freedesktop/ScreenSaver"
-#    define IDLE_SCREEN_SAVER_INTERFACE "org.freedesktop.ScreenSaver"
-#endif
+#define IDLE_SCREEN_SAVER_SERVICE "org.freedesktop.ScreenSaver"
+#define IDLE_SCREEN_SAVER_PATH "/org/freedesktop/ScreenSaver"
+#define IDLE_SCREEN_SAVER_INTERFACE "org.freedesktop.ScreenSaver"
 
 namespace dfmbase {
 
@@ -264,36 +234,8 @@ QString UniversalUtils::sizeFormat(qint64 size, int percision)
 
 bool UniversalUtils::runCommand(const QString &cmd, const QStringList &args, const QString &wd)
 {
-#ifdef COMPILE_ON_V2X
     qCDebug(logDFMBase) << "Running command via Qt process (V2X mode):" << cmd << args;
     return QProcess::startDetached(cmd, args, wd);
-#else
-    if (checkLaunchAppInterface()) {
-        qCDebug(logDFMBase) << "Running command via DBus application manager:" << cmd << args;
-        QDBusInterface appManager(APP_MANAGER_SERVICE,
-                                  APP_MANAGER_PATH,
-                                  APP_MANAGER_INTERFACE,
-                                  QDBusConnection::sessionBus());
-
-        QList<QVariant> argumentList;
-        argumentList << QVariant::fromValue(cmd) << QVariant::fromValue(args);
-
-        if (!wd.isEmpty()) {
-            QVariantMap opt = { { "dir", wd } };
-            argumentList << QVariant::fromValue(opt);
-            appManager.asyncCallWithArgumentList(QStringLiteral("RunCommandWithOptions"), argumentList);
-        } else {
-            appManager.asyncCallWithArgumentList(QStringLiteral("RunCommand"), argumentList);
-        }
-
-        return true;
-    } else {
-        qCDebug(logDFMBase) << "Running command via Qt process (fallback):" << cmd << args;
-        return QProcess::startDetached(cmd, args, wd);
-    }
-
-    return false;
-#endif
 }
 
 int UniversalUtils::dockHeight()

--- a/src/external/dde-shell-plugins/panel-desktop/main.cpp
+++ b/src/external/dde-shell-plugins/panel-desktop/main.cpp
@@ -100,14 +100,13 @@ static bool pluginsLoad()
     qCInfo(logAppDesktop) << "Using plugins dir:" << pluginsDirs;
 
     QStringList blackNames { DConfigManager::instance()->value(kPluginsDConfName, "desktop.blackList").toStringList() };
-#ifdef COMPILE_ON_V2X
     if (DFMBASE_NAMESPACE::WindowUtils::isWayLand()) {
         qCInfo(logAppDesktop) << "disable background by TreeLand";
         if (!blackNames.contains("ddplugin-background")) {
             blackNames.append("ddplugin-background");
         }
     }
-#endif
+
     DPF_NAMESPACE::LifeCycle::initialize({ kDesktopPluginInterface, kCommonPluginInterface }, pluginsDirs, blackNames);
     DPF_NAMESPACE::LifeCycle::setLazyloadFilter(lazyLoadFilter);
     DPF_NAMESPACE::LifeCycle::registerQtVersionInsensitivePlugins(Plugins::Utils::desktopAllPlugins());

--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -16,13 +16,8 @@
 
 #include <cmath>
 
-#ifdef COMPILE_ON_V20
-#    define SYSTEM_INFO_SERVICE "com.deepin.daemon.SystemInfo"
-#    define SYSTEM_INFO_PATH "/com/deepin/daemon/SystemInfo"
-#else
-#    define SYSTEM_INFO_SERVICE "org.deepin.dde.SystemInfo1"
-#    define SYSTEM_INFO_PATH "/org/deepin/dde/SystemInfo1"
-#endif
+#define SYSTEM_INFO_SERVICE "org.deepin.dde.SystemInfo1"
+#define SYSTEM_INFO_PATH "/org/deepin/dde/SystemInfo1"
 
 static constexpr int kMaximumHeightOfTwoRow { 52 };
 static constexpr int kMaximumHeightOfOneRow { 31 };

--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.cpp
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothmanager.cpp
@@ -12,23 +12,12 @@
 #include <QDBusServiceWatcher>
 #include <QFileInfo>
 
-#include <limits.h>
-
-#ifdef COMPILE_ON_V20
-#    define BluetoothService "com.deepin.daemon.Bluetooth"
-#    define BluetoothPath "/com/deepin/daemon/Bluetooth"
-#    define BluetoothInterface "com.deepin.daemon.Bluetooth"
-#    define ControlcenterService "com.deepin.dde.ControlCenter"
-#    define ControlcenterPath "/com/deepin/dde/ControlCenter"
-#    define ControlcenterInterface "com.deepin.dde.ControlCenter"
-#else
-#    define BluetoothService "org.deepin.dde.Bluetooth1"
-#    define BluetoothPath "/org/deepin/dde/Bluetooth1"
-#    define BluetoothInterface "org.deepin.dde.Bluetooth1"
-#    define ControlcenterService "org.deepin.dde.ControlCenter1"
-#    define ControlcenterPath "/org/deepin/dde/ControlCenter1"
-#    define ControlcenterInterface "org.deepin.dde.ControlCenter1"
-#endif
+#define BluetoothService "org.deepin.dde.Bluetooth1"
+#define BluetoothPath "/org/deepin/dde/Bluetooth1"
+#define BluetoothInterface "org.deepin.dde.Bluetooth1"
+#define ControlcenterService "org.deepin.dde.ControlCenter1"
+#define ControlcenterPath "/org/deepin/dde/ControlCenter1"
+#define ControlcenterInterface "org.deepin.dde.ControlCenter1"
 
 #define BluetoothPage "bluetooth"
 
@@ -357,7 +346,7 @@ void BluetoothManagerPrivate::onTransferRemoved(const QString &file, const QDBus
         bool isTooLong = utf8Name.size() > NAME_MAX;
 
         longFilenameFailures[sessionPathStr] = isTooLong;
-        fmWarning() << "bluetooth TransferRemoved: failed by long filename:" << isTooLong 
+        fmWarning() << "bluetooth TransferRemoved: failed by long filename:" << isTooLong
                     << " namelen=" << utf8Name.size() << " session=" << sessionPathStr;
         Q_EMIT q->transferCancledByRemote(sessionPathStr);
     } else {

--- a/src/plugins/daemon/vault/daemonplugin_vaultdaemon_global.h
+++ b/src/plugins/daemon/vault/daemonplugin_vaultdaemon_global.h
@@ -19,14 +19,8 @@
 DAEMONPVAULT_BEGIN_NAMESPACE
 DFM_LOG_USE_CATEGORY(DAEMONPVAULT_NAMESPCE)
 
-#ifdef COMPILE_ON_V2X
 inline constexpr char kAppSessionService[] { "org.deepin.dde.SessionManager1" };
 inline constexpr char kAppSessionPath[] { "/org/deepin/dde/SessionManager1" };
-#else
-inline constexpr char kAppSessionService[] { "com.deepin.SessionManager" };
-inline constexpr char kAppSessionPath[] { "/com/deepin/SessionManager" };
-#endif
-
 inline const QString kVaultConfigPath(QDir::homePath() + QString("/.config/Vault"));
 inline constexpr char kVaultMountDirName[] { "vault_unlocked" };
 inline constexpr char kVaultBaseDirName[] { "vault_encrypted" };
@@ -45,7 +39,7 @@ enum class Connectivity {
     Noconnectivity,
     Portal,
     Limited,
-    Full        // 主机已连接到网络，并且似乎能够访问完整的Internet
+    Full   // 主机已连接到网络，并且似乎能够访问完整的Internet
 };
 
 enum VaultState {

--- a/src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/menu/canvasmenuscene.cpp
@@ -128,15 +128,11 @@ CanvasMenuScene::CanvasMenuScene(QObject *parent)
     d->predicateName[ActionID::kAutoArrange] = tr("Auto arrange");
 
     if (ddplugin_desktop_util::enableScreensaver()) {
-#ifdef COMPILE_ON_V2X
         if (SysInfoUtils::isDeepin23()) {
             d->predicateName[ActionID::kWallpaperSettings] = tr("Wallpaper and Screensaver");
         } else {
             d->predicateName[ActionID::kWallpaperSettings] = tr("Set Wallpaper");
         }
-#else
-        d->predicateName[ActionID::kWallpaperSettings] = tr("Personalization");
-#endif
     } else {
         d->predicateName[ActionID::kWallpaperSettings] = tr("Set Wallpaper");
     }
@@ -354,14 +350,9 @@ bool CanvasMenuScene::triggered(QAction *action)
         // Display Settings
         if (actionId == ActionID::kDisplaySettings) {
             fmDebug() << "Opening display settings via ControlCenter";
-#ifdef COMPILE_ON_V2X
             QDBusMessage msg = QDBusMessage::createMethodCall("org.deepin.dde.ControlCenter1", "/org/deepin/dde/ControlCenter1",
                                                               "org.deepin.dde.ControlCenter1", "ShowPage");
-#else
-            QDBusMessage msg = QDBusMessage::createMethodCall("com.deepin.dde.ControlCenter", "/com/deepin/dde/ControlCenter",
-                                                              "com.deepin.dde.ControlCenter", "ShowModule");
 
-#endif
             msg.setArguments({ QVariant::fromValue(QString("display")) });
             QDBusConnection::sessionBus().asyncCall(msg, 5);
             fmInfo() << "ControlCenter service called - service:" << msg.service() << "arguments:" << msg.arguments();

--- a/src/plugins/desktop/ddplugin-core/screen/dbus-private/dbushelper.h
+++ b/src/plugins/desktop/ddplugin-core/screen/dbus-private/dbushelper.h
@@ -6,16 +6,8 @@
 #define DOCKHELPER_H
 
 #include "ddplugin_core_global.h"
-
-#ifdef COMPILE_ON_V2X
 #include "dbusdock1.h"
 #include "dbusdisplay1.h"
-//#include "dbusmonitor1.h"
-#else
-#include "dbusdock.h"
-//#include "dbusmonitor.h"
-#include "dbusdisplay.h"
-#endif
 
 #include <QObject>
 
@@ -44,4 +36,4 @@ DDPCORE_END_NAMESPACE
 #define DockInfoIns ddplugin_core::DBusHelper::ins()->dock()
 #define DisplayInfoIns ddplugin_core::DBusHelper::ins()->display()
 
-#endif // DOCKHELPER_H
+#endif   // DOCKHELPER_H

--- a/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.cpp
+++ b/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.cpp
@@ -142,12 +142,10 @@ qreal ScreenProxyQt::devicePixelRatio() const
 
 DisplayMode ScreenProxyQt::displayMode() const
 {
-#ifdef COMPILE_ON_V2X
     if (DFMBASE_NAMESPACE::WindowUtils::isWayLand()) {
         fmDebug() << "Wayland environment detected, using show-only mode";
         return DisplayMode::kShowonly;
     }
-#endif
 
     QList<ScreenPointer> allScreen = screens();
     if (allScreen.isEmpty()) {

--- a/src/plugins/desktop/ddplugin-wallpapersetting/dbus/dbussessionmanager.h
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/dbus/dbussessionmanager.h
@@ -23,24 +23,22 @@
 /*
  * Proxy class for interface org.deepin.dde.SessionManager1
  */
-class DBusSessionManager: public QDBusAbstractInterface
+class DBusSessionManager : public QDBusAbstractInterface
 {
 public:
-#ifdef COMPILE_ON_V2X
     static inline const char *staticInterfaceName()
-    { return "org.deepin.dde.SessionManager1"; }
+    {
+        return "org.deepin.dde.SessionManager1";
+    }
     static inline const char *staticServiceName()
-    { return "org.deepin.dde.SessionManager1"; }
+    {
+        return "org.deepin.dde.SessionManager1";
+    }
     static inline const char *staticObjectPath()
-    { return "/org/deepin/dde/SessionManager1"; }
-#else
-    static inline const char *staticInterfaceName()
-    { return "com.deepin.SessionManager"; }
-    static inline const char *staticServiceName()
-    { return "com.deepin.SessionManager"; }
-    static inline const char *staticObjectPath()
-    { return "/com/deepin/SessionManager"; }
-#endif
+    {
+        return "/org/deepin/dde/SessionManager1";
+    }
+
 private:
     Q_OBJECT
     Q_SLOT void __propertyChanged__(const QDBusMessage &msg)
@@ -63,6 +61,7 @@ private:
             }
         }
     }
+
 public:
     explicit DBusSessionManager(QObject *parent = nullptr);
 
@@ -70,17 +69,23 @@ public:
 
     Q_PROPERTY(QString CurrentUid READ currentUid)
     inline QString currentUid() const
-    { return qvariant_cast< QString >(property("CurrentUid")); }
+    {
+        return qvariant_cast<QString>(property("CurrentUid"));
+    }
 
     Q_PROPERTY(bool Locked READ locked NOTIFY LockedChanged)
     inline bool locked() const
-    { return qvariant_cast< bool >(property("Locked")); }
+    {
+        return qvariant_cast<bool>(property("Locked"));
+    }
 
     Q_PROPERTY(int Stage READ stage)
     inline int stage() const
-    { return qvariant_cast< int >(property("Stage")); }
+    {
+        return qvariant_cast<int>(property("Stage"));
+    }
 
-Q_SIGNALS: // SIGNALS
+Q_SIGNALS:   // SIGNALS
     void LockedChanged() const;
 };
 

--- a/src/plugins/desktop/ddplugin-wallpapersetting/private/wallpapersettings_p.h
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/private/wallpapersettings_p.h
@@ -11,17 +11,9 @@
 #include "wallaperpreview.h"
 #include "dbus/screensaver_interface.h"
 #include "dbus/dbussessionmanager.h"
+#include "dbus/appearance_interface.h"
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-#    include <com_deepin_wm.h>
-#endif
-#ifdef COMPILE_ON_V2X
-#    include "dbus/appearance_interface.h"
-#    define APPEARANCE_NAME org::deepin::dde::Appearance1
-#else
-#    include <com_deepin_daemon_appearance.h>
-#    define APPEARANCE_NAME com::deepin::daemon::Appearance
-#endif
+#define APPEARANCE_NAME org::deepin::dde::Appearance1
 
 #include <DIconButton>
 #include <DRegionMonitor>

--- a/src/plugins/desktop/ddplugin-wallpapersetting/wallaperpreview.h
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/wallaperpreview.h
@@ -7,16 +7,11 @@
 
 #include "ddplugin_wallpapersetting_global.h"
 #include "backgroundpreview.h"
+#include "dbus/appearance_interface.h"
 
 #include <dfm-base/interfaces/screen/abstractscreen.h>
 
-#ifdef COMPILE_ON_V2X
-#    include "dbus/appearance_interface.h"
 using BackgroudInter = org::deepin::dde::Appearance1;
-#else
-#    include <com_deepin_wm.h>
-using BackgroudInter = com::deepin::wm;
-#endif
 
 #include <QObject>
 #include <QMap>

--- a/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.h
+++ b/src/plugins/desktop/ddplugin-wallpapersetting/wlsetplugin.h
@@ -23,7 +23,6 @@ public slots:
     bool wallpaperSetting(const QString &name);
     bool screenSaverSetting(const QString &name);
     bool hookCanvasRequest(const QString &screen);
-#ifndef COMPILE_ON_V20
     void onQuit();
 
 protected:
@@ -32,7 +31,6 @@ protected:
 
 private:
     WallpaperSettings *wallpaperSettings = nullptr;
-#endif
 };
 
 class WlSetPlugin : public dpf::Plugin

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -24,15 +24,9 @@
 #include <DDBusSender>
 #include <DUtil>
 
-#ifdef COMPILE_ON_V2X
-#    define DDE_SHUTDOWN_SERVICE "org.deepin.dde.ShutdownFront1"
-#    define DDE_SHUTDOWN_PATH "/org/deepin/dde/ShutdownFront1"
-#    define DDE_SHUTDOWN_INTERFACE "org.deepin.dde.ShutdownFront1"
-#else
-#    define DDE_SHUTDOWN_SERVICE "com.deepin.ShutdownFront"
-#    define DDE_SHUTDOWN_PATH "/com/deepin/ShutdownFront"
-#    define DDE_SHUTDOWN_INTERFACE "com.deepin.ShutdownFront"
-#endif
+#define DDE_SHUTDOWN_SERVICE "org.deepin.dde.ShutdownFront1"
+#define DDE_SHUTDOWN_PATH "/org/deepin/dde/ShutdownFront1"
+#define DDE_SHUTDOWN_INTERFACE "org.deepin.dde.ShutdownFront1"
 
 Q_DECLARE_METATYPE(QString *)
 Q_DECLARE_METATYPE(bool *)
@@ -155,7 +149,7 @@ void EventsHandler::resumeEncrypt(const QString &device)
                          kDaemonBusPath,
                          kDaemonBusIface,
                          QDBusConnection::systemBus());
-    iface.asyncCall("ResumeEncryption", QVariantMap{{encrypt_param_keys::kKeyDevice, device}});
+    iface.asyncCall("ResumeEncryption", QVariantMap { { encrypt_param_keys::kKeyDevice, device } });
 }
 
 QString EventsHandler::holderDevice(const QString &device)
@@ -701,8 +695,7 @@ void EventsHandler::setAutoStartDFM(bool enable)
 
             if (QFile::copy(kReencryptDesktopFile, autostartFile)) {
                 fmInfo() << "Successfully copied desktop file to autostart directory";
-                QFile::setPermissions(autostartFile, QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner |
-                                                     QFile::ReadGroup | QFile::ReadOther);
+                QFile::setPermissions(autostartFile, QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner | QFile::ReadGroup | QFile::ReadOther);
             } else {
                 fmWarning() << "Failed to copy desktop file to autostart directory";
             }
@@ -771,11 +764,9 @@ void EventsHandler::onOverlayDMModeChanged(bool enabled, int result)
             .arg(message)
             .arg(QStringList())
             .arg(QVariantMap())
-            .arg(10000)  // 10 seconds timeout
+            .arg(10000)   // 10 seconds timeout
             .call();
 }
-
-
 
 EventsHandler::EventsHandler(QObject *parent)
     : QObject { parent }

--- a/src/plugins/filemanager/dfmplugin-vault/dfmplugin_vault_global.h
+++ b/src/plugins/filemanager/dfmplugin-vault/dfmplugin_vault_global.h
@@ -199,13 +199,9 @@ inline constexpr char kAcBtnVaultRemovePasswordHint[] { "btn_vault_remove_passwo
 }
 
 inline constexpr char kDeamonServiceName[] { "org.deepin.Filemanager.AccessControlManager" };
-#ifdef COMPILE_ON_V2X
 inline constexpr char kAppSessionService[] { "org.deepin.dde.SessionManager1" };
 inline constexpr char kAppSessionPath[] { "/org/deepin/dde/SessionManager1" };
-#else
-inline constexpr char kAppSessionService[] { "com.deepin.SessionManager" };
-inline constexpr char kAppSessionPath[] { "/com/deepin/SessionManager" };
-#endif
+
 inline constexpr char kNetWorkDBusServiceName[] { "org.deepin.service.SystemNetwork" };
 inline constexpr char kNetWorkDBusPath[] { "/org/deepin/service/SystemNetwork" };
 inline constexpr char kNetWorkDBusInterfaces[] { "org.deepin.service.SystemNetwork" };


### PR DESCRIPTION
1. Removed all COMPILE_ON_V2X macro checks and related conditional compilation
2. Unified service names and paths to use new org.deepin.dde.* format consistently
3. Simplified build system by removing V2X-specific definitions and logic
4. Removed legacy code paths that were maintained for V20 compatibility
5. Updated DBus service references to point to new service names

The change removes the dual-version maintenance burden and standardizes on the newer dde service naming scheme. All functionality is now handled through the new service interfaces without version-specific code paths.

Influence:
1. Verify all DBus-related functionality works with new service names
2. Test application startup and basic operations
3. Check system integration points like settings dialogs
4. Validate feature compatibility across different system configurations
5. Confirm all removed legacy code paths have proper replacements

重构: 移除系统版本判定的宏

1. 移除了所有COMPILE_ON_V2X宏判断和相关条件编译代码
2. 统一使用org.deepin.dde.*格式的服务名称和路径
3. 简化构建系统，移除了V2X特定的定义和逻辑
4. 移除了为V20兼容性维护的遗留代码路径
5. 更新DBus服务引用指向新的服务名称

此变更消除了维护双版本的负担，并统一采用新的dde服务命名方案。所有功能现
在都通过新的服务接口处理，不再有版本特定的代码路径。

影响范围：
1. 验证所有DBus相关功能与新服务名称的兼容性
2. 测试应用程序启动和基本操作
3. 检查系统集成点如设置对话框
4. 在不同系统配置下验证功能兼容性
5. 确认所有移除的遗留代码路径都有适当的替代实现

## Summary by Sourcery

Standardize on the newer org.deepin.dde.* DBus services and remove legacy dual-version compatibility paths and macros.

Enhancements:
- Replace all version-specific DBus service/interface/path definitions with the unified org.deepin.dde.*1 naming scheme across utilities, plugins, and vault components.
- Remove COMPILE_ON_V2X/COMPILE_ON_V20 conditional branches, simplifying runtime behavior such as command execution, display handling, and wallpapers/appearance integration to a single modern code path.
- Clean up desktop and shell plugin logic to rely on the new session/control center/dbus helpers and modern environment checks without legacy variants.

Build:
- Simplify CMake configuration by dropping the COMPILE_ON_V2X definition and always configuring systemd user unit directory and symlink installation logic.