### PR TITLE
fix: [filedialog] The file name changed when cd dir.

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -241,8 +241,12 @@ void FileDialog::cd(const QUrl &url)
     if (window->workSpace())
         handleUrlChanged(url);
     else
-        connect(
-                window, &FileManagerWindow::workspaceInstallFinished, this, [this, url] { handleUrlChanged(url); }, Qt::DirectConnection);
+        connect(window, &FileManagerWindow::workspaceInstallFinished,
+                this, [this, url] {
+                    handleUrlChanged(url);
+                    d->workspaceInstallFinished = true;
+                },
+                Qt::DirectConnection);
 }
 
 bool FileDialog::saveClosedSate() const
@@ -345,7 +349,8 @@ void FileDialog::selectUrl(const QUrl &url)
         return;
 
     CoreEventsCaller::sendSelectFiles(this->internalWinId(), { url });
-    setCurrentInputName(QFileInfo(url.path()).fileName());
+    if (!d->workspaceInstallFinished)
+        setCurrentInputName(QFileInfo(url.path()).fileName());
 }
 
 QList<QUrl> FileDialog::selectedUrls() const
@@ -1110,6 +1115,8 @@ void FileDialog::closeEvent(QCloseEvent *event)
         event->accept();
     }
     FileManagerWindow::closeEvent(event);
+
+    d->workspaceInstallFinished = false;
 }
 
 bool FileDialog::eventFilter(QObject *watched, QEvent *event)

--- a/src/plugins/filedialog/core/views/filedialog_p.h
+++ b/src/plugins/filedialog/core/views/filedialog_p.h
@@ -55,6 +55,7 @@ private:
     bool allowMixedSelection { false };
     QFileDialog::Options options;
     QUrl currentUrl;
+    bool workspaceInstallFinished { false };
 
     static QStringList cleanFilterList(const QString &filter)
     {


### PR DESCRIPTION
In save mode, when change the dir, the file name changed. logic error and not set the name edit.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-355877.html

## Summary by Sourcery

Prevent the file dialog from overwriting the current file name when changing directories in save mode.

Bug Fixes:
- Guard updating the file name input so it is not reset when navigating to a different directory after workspace installation completes.
- Track workspace installation completion state in the file dialog and reset it on close to avoid incorrect filename updates across dialog uses.