### PR TITLE
fix: handle file paths correctly in terminal open operation

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperationsevent/fileoperationseventreceiver.cpp
@@ -1692,7 +1692,14 @@ bool FileOperationsEventReceiver::handleOperationOpenInTerminal(const quint64 wi
         if (!url.isLocalFile())
             continue;
 
-        ok = doOpenInTerminal(url);
+        QUrl targetUrl = url;
+        QFileInfo fileInfo(url.toLocalFile());
+        if (!fileInfo.isDir()) {
+            // If the URL points to a file or non-existent path, use its parent directory
+            targetUrl = QUrl::fromLocalFile(fileInfo.absolutePath());
+        }
+
+        ok = doOpenInTerminal(targetUrl);
         if (!result)
             result = ok;
     }


### PR DESCRIPTION
Modified terminal open operation to handle cases when URLs point to
files instead of directories. Now checks if path is a directory and if
not, uses parent directory for the terminal operation.

Previously, attempting to open a file in terminal would fail silently
or with error. This change ensures proper functionality by automatically
switching to parent directory when needed.

Log: Fixed terminal opening behavior for file paths

Influence:
1. Test opening terminal with directory paths (should work as before)
2. Test opening terminal with file paths (should now open parent
directory)
3. Verify behavior with both local and non-local file URLs
4. Check special characters in file/directory names
5. Test with symlinked files/directories

fix: 正确处理终端打开操作中的文件路径

修改终端打开操作以处理URL指向文件而非目录的情况。现在会检查路径是否为目
录，如果不是则使用父目录进行终端操作。

之前尝试在终端中打开文件会静默失败或报错。此更改通过自动切换到父目录确保
功能正常。

Log: 修复了文件路径的终端打开行为

Influence:
1. 测试用目录路径打开终端（应保持原有功能）
2. 测试用文件路径打开终端（现在应该打开父目录）
3. 验证本地和非本地文件URL的行为
4. 检查包含特殊字符的文件/目录名
5. 测试符号链接文件/目录的情况

## Summary by Sourcery

Bug Fixes:
- Fix opening a terminal on file paths by resolving the terminal working directory to the file’s parent directory.