### PR TITLE
fix: handle special characters in file dialog URL selection

### DIFF
--- a/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
+++ b/src/plugins/filedialog/core/dbus/filedialoghandledbus.cpp
@@ -56,20 +56,31 @@ QString FileDialogHandleDBus::directoryUrl() const
 
 void FileDialogHandleDBus::selectUrl(const QString &url)
 {
+    if (url.isEmpty()) {
+        FileDialogHandle::selectUrl(QUrl());
+        return;
+    }
+
     QUrl fileUrl(url);
-    const auto &scheme = fileUrl.scheme();
+    QString scheme = fileUrl.scheme();
+
+    // Case 2: No scheme, treat as local file path
     if (scheme.isEmpty()) {
         fileUrl = QUrl::fromLocalFile(url);
     } else {
-        // Extract path portion after "scheme://"
-        int pathStart = url.indexOf("://");
-        if (pathStart != -1) {
-            // For URLs with scheme (e.g., file://), extract path to preserve special characters like '#'
-            fileUrl.clear();
-            fileUrl.setScheme(scheme);
-            QString path = url.mid(pathStart + 3);
-            fileUrl.setPath(path);
+        // Case 1 & 3: Has scheme, check if path was truncated by '#' or '?'
+        // When URL contains '#' or '?', QUrl parses them as fragment/query
+        // e.g., "file:///home/test#file.txt" -> path="/home/test", fragment="file.txt"
+        if (fileUrl.hasFragment() || fileUrl.hasQuery()) {
+            int schemeEnd = url.indexOf("://");
+            if (schemeEnd != -1) {
+                QString originalPath = url.mid(schemeEnd + 3);
+                fileUrl.clear();
+                fileUrl.setScheme(scheme);
+                fileUrl.setPath(originalPath);
+            }
         }
+        // Case 1: For encoded URLs, QUrl's automatic decoding is the expected behavior
     }
 
     FileDialogHandle::selectUrl(fileUrl);


### PR DESCRIPTION
1. Fix empty URL handling by adding early return to prevent invalid
QUrl processing
2. Resolve issue where '#' and '?' characters in file paths were
incorrectly parsed as URL fragment/query
3. Refactor URL parsing logic with clearer case separation:
   - Case 1: URLs with scheme and proper encoding (standard QUrl
behavior)
   - Case 2: Local file paths without scheme (convert using
fromLocalFile)
   - Case 3: URLs with scheme where '#'/'?' should be part of path, not
fragment/query
4. Preserve original path containing special characters by extracting
raw path after "://"
5. Remove redundant manual path extraction logic for standard URLs

Influence:
1. Test file selection with paths containing '#' character (e.g., "/
home/user/file#1.txt")
2. Test file selection with paths containing '?' character (e.g., "/
home/user/file?name.txt")
3. Test empty URL input to verify graceful handling
4. Test standard file:// URLs without special characters to ensure no
regression
5. Test local file paths without scheme (e.g., "/home/user/
document.txt")
6. Test URLs with query parameters that should be preserved as path
7. Verify file dialog correctly selects files with special characters
in names

fix: 修复文件对话框 URL 选择中的特殊字符处理问题

1. 修复空 URL 处理问题，添加早期返回以防止无效的 QUrl 处理
2. 解决文件路径中的 '#' 和 '?' 字符被错误解析为 URL 片段/查询的问题
3. 重构 URL 解析逻辑，明确区分不同情况：
   - 情况 1：带 scheme 且正确编码的 URL（标准 QUrl 行为）
   - 情况 2：无 scheme 的本地文件路径（使用 fromLocalFile 转换）
   - 情况 3：带 scheme 但 '#'/'?' 应作为路径一部分的 URL
4. 通过提取 "://" 后的原始路径，保留包含特殊字符的原始路径
5. 移除标准 URL 的冗余手动路径提取逻辑

Influence:
1. 测试包含 '#' 字符的路径文件选择（如 "/home/user/file#1.txt"）
2. 测试包含 '?' 字符的路径文件选择（如 "/home/user/file?name.txt"）
3. 测试空 URL 输入以验证优雅处理
4. 测试无特殊字符的标准 file:// URL 确保无回归
5. 测试无 scheme 的本地文件路径（如 "/home/user/document.txt"）
6. 测试应保留为路径的带查询参数的 URL
7. 验证文件对话框正确选择名称含特殊字符的文件

BUG: https://pms.uniontech.com/bug-view-357239.html

## Summary by Sourcery

Handle file dialog URL selection more robustly, especially for empty inputs and paths containing special characters.

Bug Fixes:
- Avoid processing empty URL strings by short-circuiting to an empty QUrl selection.
- Preserve '#' and '?' characters in file paths by reconstructing the URL path when QUrl would otherwise parse them as fragment or query components.

Enhancements:
- Refine URL handling logic to clearly distinguish between local file paths without a scheme and schemed URLs while relying on default QUrl behavior for standard encoded URLs.