### PR TITLE
refactor: optimize file path sorting in file view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewsorter.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewsorter.cpp
@@ -534,16 +534,23 @@ QVariant FileViewSorter::getSortData(const QUrl &url)
     }
 
     case SortRole::FilePath:
-    case SortRole::OriginalPath:
-        // FilePath 和 OriginalPath 只能从 FileInfo 获取
+        // FilePath：本地文件直接返回路径，避免创建 FileInfo
+        if (url.isLocalFile()) {
+            return url.toLocalFile();
+        }
+        // 非本地文件需要从 FileInfo 获取显示路径
         if (!fileInfo)
             fileInfo = dfmbase::InfoFactory::create<dfmbase::FileInfo>(url);
-        if (fileInfo) {
-            if (m_context.role == SortRole::FilePath)
-                return fileInfo->displayOf(dfmbase::DisPlayInfoType::kFileDisplayPath);
-            else   // OriginalPath
-                return fileInfo->urlOf(dfmbase::UrlInfoType::kOriginalUrl).path();
-        }
+        if (fileInfo)
+            return fileInfo->displayOf(dfmbase::DisPlayInfoType::kFileDisplayPath);
+        return url.path();
+
+    case SortRole::OriginalPath:
+        // OriginalPath 只能从 FileInfo 获取（垃圾桶场景）
+        if (!fileInfo)
+            fileInfo = dfmbase::InfoFactory::create<dfmbase::FileInfo>(url);
+        if (fileInfo)
+            return fileInfo->urlOf(dfmbase::UrlInfoType::kOriginalUrl).path();
         return url.path();
 
     case SortRole::DeletionDate:


### PR DESCRIPTION
1. Improved performance by directly returning local file paths without
creating FileInfo objects
2. Separated the handling of FilePath and OriginalPath cases for better
code clarity
3. Maintained OriginalPath functionality for recycle bin scenarios

Influence:
1. Verify file sorting works correctly for both local and remote files
2. Test recycling bin file sorting
3. Check performance improvement on large directory listings

refactor: 优化文件视图中的路径排序逻辑

1. 通过直接返回本地文件路径而不创建 FileInfo 对象来提升性能
2. 将 FilePath 和 OriginalPath 的处理分离，提高代码清晰度
3. 保持 OriginalPath 功能在回收站场景中的正常使用

Influence:
1. 验证本地和远程文件的排序功能是否正常
2. 测试回收站文件的排序功能
3. 检查大目录列表的性能提升情况

## Summary by Sourcery

Refine file view sorting to handle file and original paths more efficiently and clearly, while preserving recycle bin behavior.

Enhancements:
- Optimize file path sorting by returning local file paths directly without constructing FileInfo objects.
- Separate FilePath and OriginalPath handling to improve code clarity and maintain correct behavior for recycle bin items.