### PR TITLE
chore: update gitignore to exclude .codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ AGENTS.md
 .claude
 .agents
 .worktrees
+.codex
 
 
 # autotests


### PR DESCRIPTION
Remove references to .codex file from repository tracking
Deleted .codex file and added its pattern to .gitignore
These changes ensure the .codex file won't be tracked or committed

Influence:
1. Verify .codex file is properly ignored
2. Test that new .codex files won't appear in git status
3. Confirm existing .codex file is no longer tracked

chore: 更新.gitignore排除.codex文件

从版本控制中移除.codex文件的跟踪
删除.codex文件并将其模式添加到.gitignore
这些更改确保.codex文件不会被跟踪或提交

Influence:
1. 验证.codex文件被正确忽略
2. 测试新的.codex文件不会出现在git状态中
3. 确认现有的.codex文件不再被跟踪

## Summary by Sourcery

Stop tracking .codex files by updating repository ignore rules.

Chores:
- Remove existing .codex file from version control and history of tracked files.
- Add .codex ignore pattern to .gitignore so future .codex files are not committed.