### PR TITLE
fix: adjust focus handling in search edit widget

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -342,7 +342,7 @@ void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)
     }
 
     // Handle special focus reasons that should not trigger collapse
-    if (e->reason() == Qt::PopupFocusReason || e->reason() == Qt::ActiveWindowFocusReason) {
+    if (e->reason() == Qt::PopupFocusReason) {
         e->accept();
         restoreFocusIfNeeded();
         return;


### PR DESCRIPTION
Removed Qt::ActiveWindowFocusReason from the focus out event condition
to prevent unnecessary widget collapse when switching windows. This
improves user experience by maintaining search widget visibility during
window switching operations.

Log: Fixed issue where search widget would collapse unexpectedly when
switching between windows

Influence:
1. Test search widget behavior when clicking on popup menus
2. Verify search box remains visible when switching between application
windows
3. Check that proper collapse behavior remains for other focus out
reasons
4. Test with different window managers and desktop environments

fix: 调整搜索编辑小部件的焦点处理

从焦点移出事件条件中移除了 Qt::ActiveWindowFocusReason，以防止在切换窗口
时不必要的控件折叠。这改善了用户通过窗口切换操作时保持搜索小部件可见性的
体验。

Log: 修复了在窗口间切换时搜索小工具意外折叠的问题

Influence:
1. 测试点击弹出菜单时的搜索小部件行为
2. 验证在切换应用程序窗口时搜索框是否保持可见
3. 检查其他焦点移出原因是否仍保持正确的折叠行为
4. 在不同窗口管理器和桌面环境中进行测试

## Summary by Sourcery

Bug Fixes:
- Prevent search widget from collapsing when switching between application windows while preserving non-popup focus-out collapse behavior.