### PR TITLE
fix: improve breadcrumbs for mounted devices

### DIFF
--- a/src/dfm-base/base/device/devicealiasmanager.cpp
+++ b/src/dfm-base/base/device/devicealiasmanager.cpp
@@ -185,6 +185,7 @@ bool NPDeviceAliasManager::setAlias(const QUrl &protocolUrl, const QString &alia
     if (modified) {
         QWriteLocker lk(&rwLock);
         Application::genericSetting()->setValue(kNPAliasGroupName, kAliasItemName, itemList);
+        Application::genericSetting()->sync();
     }
 
     return true;

--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -172,6 +172,8 @@ bool BookMarkManager::addBookMark(const QList<QUrl> &urls)
             }
 
             Application::genericSetting()->setValue(kConfigGroupQuickAccess, kConfigKeyName, list);
+            Application::genericSetting()->sync();
+
             quickAccessDataMap[url] = bookmarkData;
             sortedUrls.removeOne(url);
             sortedUrls.append(url);
@@ -315,7 +317,9 @@ bool BookMarkManager::bookMarkRename(const QUrl &url, const QString &newName)
             map[kKeyLastModi] = QDateTime::currentDateTime().toString(Qt::ISODate);
             quickAccessDataMap[url].name = newName;
             list.replace(i, map);
+
             Application::genericSetting()->setValue(kConfigGroupQuickAccess, kConfigKeyName, list);
+            Application::genericSetting()->sync();
 
             renameBookmarkToDConfig(oldName, newName);
 
@@ -383,8 +387,10 @@ void BookMarkManager::saveSortedItemsToConfigFile(const QList<QUrl> &order)
         index++;
     }
 
-    if (!sorted.isEmpty())
+    if (!sorted.isEmpty()) {
         Application::genericSetting()->setValue(kConfigGroupQuickAccess, kConfigKeyName, sorted);
+        Application::genericSetting()->sync();
+    }
 }
 
 void BookMarkManager::saveQuickAccessToSortedItems(const QVariantList &list)
@@ -563,6 +569,7 @@ void BookMarkManager::fileRenamed(const QUrl &oldUrl, const QUrl &newUrl)
             dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", oldUrl, map);
 
             Application::genericSetting()->setValue(kConfigGroupQuickAccess, kConfigKeyName, list);
+            Application::genericSetting()->sync();
             updateBookmarkUrlToDconfig(oldUrl, newUrl);
             break;
         }

--- a/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/controller/computercontroller.cpp
@@ -249,6 +249,7 @@ void ComputerController::doSetAlias(DFMEntryFileInfoPointer info, const QString 
     }
 
     Application::genericSetting()->setValue(kAliasGroupName, kAliasItemName, list);
+    Application::genericSetting()->sync();
     Q_EMIT updateItemAlias(info->urlOf(UrlInfoType::kUrl), alias, false);
 }
 

--- a/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/events/computereventreceiver.cpp
@@ -27,6 +27,46 @@
 using namespace dfmplugin_computer;
 DFMBASE_USE_NAMESPACE
 
+namespace {
+
+// Helper: select appropriate symbolic icon name for device
+static QString devIconName(const DFMEntryFileInfoPointer &info)
+{
+    const QString iconName = info->fileIcon().name();
+    if (iconName.startsWith("media"))
+        return "media-optical-symbolic";
+    if (info->order() == AbstractEntryFileEntity::kOrderRemovableDisks)
+        return "drive-removable-media-symbolic";
+    if (iconName == "android-device")
+        return "phone-symbolic";
+    if (iconName == "ios-device")
+        return "phone-apple-iphone-symbolic";
+    return {};
+}
+
+// Helper: build breadcrumb trail (root + sub-directories)
+static void appendCrumbs(QList<QVariantMap> *group,
+                         const QString &devPath,
+                         const QString &fullPath,
+                         const QString &iconName)
+{
+    // root node with icon
+    group->push_back({ { "CrumbData_Key_Url", QUrl::fromLocalFile(devPath) },
+                       { "CrumbData_Key_IconName", iconName },
+                       { "CrumbData_Key_DisplayText", "" } });
+
+    // child directory nodes
+    QString currPrefix = devPath;
+    const auto subPathList = fullPath.mid(devPath.size()).split('/', Qt::SkipEmptyParts);
+    for (const auto &dirName : subPathList) {
+        currPrefix += '/' + dirName;
+        group->push_back({ { "CrumbData_Key_Url", QUrl::fromLocalFile(currPrefix) },
+                           { "CrumbData_Key_DisplayText", dirName } });
+    }
+}
+
+}   // namespace
+
 ComputerEventReceiver *ComputerEventReceiver::instance()
 {
     static ComputerEventReceiver ins;
@@ -235,53 +275,33 @@ bool ComputerEventReceiver::parseCifsMountCrumb(const QUrl &url, QList<QVariantM
 
 bool ComputerEventReceiver::parseDevMountCrumb(const QUrl &url, QList<QVariantMap> *mapGroup)
 {
-    // fix bug-326657
-    QString filePath = url.path();
+    const QString filePath = url.path();
     if (!DevProxyMng->isFileOfExternalMounts(filePath))
         return false;
 
     const auto &deviceInfo = DevProxyMng->queryDeviceInfoByPath(filePath);
-    auto id = deviceInfo.value(GlobalServerDefines::DeviceProperty::kId).toString();
+    const QString id = deviceInfo.value(GlobalServerDefines::DeviceProperty::kId).toString();
     if (id.isEmpty())
         return false;
 
-    QUrl devUrl = id.startsWith(kBlockDeviceIdPrefix)
+    // find device entry info
+    const QUrl devUrl = id.startsWith(kBlockDeviceIdPrefix)
             ? ComputerUtils::makeBlockDevUrl(id)
             : ComputerUtils::makeProtocolDevUrl(id);
-    DFMEntryFileInfoPointer info(new EntryFileInfo(devUrl));
-    if (!info)
+    const DFMEntryFileInfoPointer info(new EntryFileInfo(devUrl));
+    if (!info || !info->targetUrl().isLocalFile())
         return false;
-    const auto &devPath = info->targetUrl().path();
 
+    const QString devPath = info->targetUrl().toLocalFile();
     if (devPath.isEmpty() || devPath == "/")
         return false;
 
-    QString iconName { info->fileIcon().name() };
-    if (info->fileIcon().name().startsWith("media"))
-        iconName = "media-optical-symbolic";
-    else if (info->order() == AbstractEntryFileEntity::kOrderRemovableDisks)   // always display as USB icon for removable disks.
-        iconName = "drive-removable-media-symbolic";
-    else if (iconName == "android-device")
-        iconName = "phone-symbolic";
-    else if (iconName == "ios-device")
-        iconName = "phone-apple-iphone-symbolic";
-    else
-        iconName += "-symbolic";
+    const auto iconName = devIconName(info);
+    if (iconName.isEmpty())
+        return false;
 
-    QVariantMap rootNode { { "CrumbData_Key_Url", QUrl::fromLocalFile(devPath) },
-                           { "CrumbData_Key_IconName", iconName },
-                           { "CrumbData_Key_DisplayText", "" } };
-    mapGroup->push_back(rootNode);
-
-    QString currPrefix = devPath;
-    auto subPathList = filePath.remove(devPath).split("/", Qt::SkipEmptyParts);
-    while (subPathList.count() > 0) {
-        QString dirName = subPathList.takeFirst();
-        currPrefix = currPrefix + "/" + dirName;
-        QVariantMap dirNode { { "CrumbData_Key_Url", QUrl::fromLocalFile(currPrefix) },
-                              { "CrumbData_Key_DisplayText", dirName } };
-        mapGroup->push_back(dirNode);
-    }
+    // build breadcrumb trail with appropriate icon
+    appendCrumbs(mapGroup, devPath, filePath, iconName);
     return true;
 }
 

--- a/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/views/computerview.cpp
@@ -358,6 +358,7 @@ void ComputerView::onUpdateItemAlias(const QUrl &url, const QString &alias, bool
         QString sidebarName = alias.isEmpty() ? item.info->displayName() : alias;
         QVariantMap map {
             { "Property_Key_DisplayName", sidebarName },
+            { "Property_Key_EditDisplayText", sidebarName },
             { "Property_Key_Editable", true }
         };
         dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", item.info->urlOf(UrlInfoType::kUrl), map);

--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -11,12 +11,51 @@
 #include "utils/sidebarinfocachemananger.h"
 
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/file/entry/entryfileinfo.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/settingdialog/settingjsongenerator.h>
 
 #include <dfm-framework/dpf.h>
 
 DPSIDEBAR_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+namespace {
+inline constexpr char kNPAliasGroupName[] { "NetworkProtocolDeviceAlias" };
+inline constexpr char kAliasItemName[] { "Items" };
+inline constexpr char kBlockEntrySuffix[] { "blockdev" };
+inline constexpr char kProtocolEntrySuffix[] { "protodev" };
+inline constexpr char kSmbVirtualScheme[] { "vsmb" };
+inline constexpr char kSmbVirtualEntrySuffix[] { "ventry" };
+
+bool isAliasSetting(const QString &group, const QString &key)
+{
+    return key == kAliasItemName
+            && (group == BlockAdditionalProperty::kAliasGroupName
+                || group == kNPAliasGroupName);
+}
+
+QUrl aliasAwareEntryUrl(const QUrl &url)
+{
+    if (url.scheme() == Global::Scheme::kEntry
+        && (url.path().endsWith(kBlockEntrySuffix) || url.path().endsWith(kProtocolEntrySuffix)))
+        return url;
+
+    if (url.scheme() == kSmbVirtualScheme) {
+        QUrl smbUrl = url;
+        smbUrl.setScheme(Global::Scheme::kSmb);
+
+        QUrl entryUrl;
+        entryUrl.setScheme(Global::Scheme::kEntry);
+        entryUrl.setPath(smbUrl.toString() + "." + QString(kSmbVirtualEntrySuffix));
+        return entryUrl;
+    }
+
+    return {};
+}
+}
 
 SideBarEventReceiver *SideBarEventReceiver::instance()
 {
@@ -99,7 +138,6 @@ bool SideBarEventReceiver::handleItemAdd(const QUrl &url, const QVariantMap &pro
         // for select to computer
         QUrl &&itemUrl = item->url();
         QUrl &&sidebarUrl = sidebar->currentUrl();
-        DFMBASE_USE_NAMESPACE
         if (UniversalUtils::urlEquals(itemUrl, sidebarUrl)
             || (info.finalUrl.isValid() && UniversalUtils::urlEquals(sidebarUrl, info.finalUrl)))
             sidebar->setCurrentUrl(item->url());
@@ -186,20 +224,52 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
     if (properties.contains(PropertyKey::kCallbackFindMe))
         info.findMeCb = DPF_NAMESPACE::paramGenerator<FindMeCallback>(properties[PropertyKey::kCallbackFindMe]);
 
+    bool ret { false };
+    if (urlUpdated)
+        ret = SideBarInfoCacheMananger::instance()->addItemInfoCache(info);
+    else
+        ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(url, info);
+
     QList<SideBarWidget *> allSideBar = SideBarHelper::allSideBar();
     if (!allSideBar.isEmpty()) {
-        bool ret { false };
-        if (urlUpdated)
-            ret = SideBarInfoCacheMananger::instance()->addItemInfoCache(info);
-        else
-            ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(url, info);
         allSideBar.first()->updateItem(url, info);
         return ret;
-    } else {
-        fmWarning() << "No sidebar widgets available for item update, url:" << url;
     }
 
-    return false;
+    if (SideBarWidget::kSidebarModelIns)
+        SideBarWidget::kSidebarModelIns->updateRow(url, info);
+
+    fmDebug() << "Updated sidebar cache without visible widget, url:" << url;
+    return ret;
+}
+
+void SideBarEventReceiver::handleAliasSettingChanged(const QString &group, const QString &key, const QVariant &value)
+{
+    Q_UNUSED(value)
+
+    if (!isAliasSetting(group, key))
+        return;
+
+    auto cacheMgr = SideBarInfoCacheMananger::instance();
+    const auto groups = cacheMgr->groups();
+    for (const auto &cacheGroup : groups) {
+        const auto items = cacheMgr->indexCacheList(cacheGroup);
+        for (const auto &cachedInfo : items) {
+            const QUrl entryUrl = aliasAwareEntryUrl(cachedInfo.url);
+            if (!entryUrl.isValid())
+                continue;
+
+            EntryFileInfo entryInfo(entryUrl);
+            ItemInfo refreshedInfo = cachedInfo;
+            refreshedInfo.displayName = entryInfo.displayName();
+            refreshedInfo.editDisplayText = entryInfo.editDisplayText();
+            refreshedInfo.isEditable = entryInfo.renamable();
+
+            cacheMgr->updateItemInfoCache(cachedInfo.url, refreshedInfo);
+            if (SideBarWidget::kSidebarModelIns)
+                SideBarWidget::kSidebarModelIns->updateRow(cachedInfo.url, refreshedInfo);
+        }
+    }
 }
 
 bool SideBarEventReceiver::handleItemInsert(int index, const QUrl &url, const QVariantMap &properties)

--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.h
@@ -26,6 +26,7 @@ public slots:
     bool handleItemRemove(const QUrl &url);
     bool handleItemUpdate(const QUrl &url, const QVariantMap &properties);
     bool handleItemInsert(int index, const QUrl &url, const QVariantMap &properties);
+    void handleAliasSettingChanged(const QString &group, const QString &key, const QVariant &value);
     void handleItemHidden(const QUrl &url, bool visible);   // TODO(zhangs): remove
     void handleItemTriggerEdit(quint64 winId, const QUrl &url);
     void handleSidebarUpdateSelection(quint64 winId);

--- a/src/plugins/filemanager/dfmplugin-sidebar/sidebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/sidebar.cpp
@@ -13,6 +13,8 @@
 #include <dfm-base/widgets/filemanagerwindow.h>
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/standardpaths.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/dpf.h>
@@ -24,9 +26,11 @@ DFMBASE_USE_NAMESPACE
 
 void SideBar::initialize()
 {
-    connect(&FMWindowsIns, &FileManagerWindowsManager::windowOpened, this, &SideBar::onWindowOpened, Qt::DirectConnection);
-    connect(&FMWindowsIns, &FileManagerWindowsManager::windowClosed, this, &SideBar::onWindowClosed, Qt::DirectConnection);
-    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, &SideBar::onConfigChanged, Qt::DirectConnection);
+    connect(&FMWindowsIns, &FileManagerWindowsManager::windowOpened, this, &SideBar::onWindowOpened);
+    connect(&FMWindowsIns, &FileManagerWindowsManager::windowClosed, this, &SideBar::onWindowClosed);
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, &SideBar::onConfigChanged);
+    connect(Application::genericSetting(), &Settings::valueEdited,
+            SideBarEventReceiver::instance(), &SideBarEventReceiver::handleAliasSettingChanged);
 
     SideBarEventReceiver::instance()->bindEvents();
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -188,7 +188,8 @@ QList<CrumbData> TitleBarHelper::crumbSeprateUrl(const QUrl &url)
         if (!prefixPath.startsWith(oneUrl.toLocalFile())) {
             QString displayText = oneUrl.fileName();
             // Check for possible display text.
-            auto infoPointer = InfoFactory::create<DFMBASE_NAMESPACE::FileInfo>(oneUrl);
+            auto infoPointer = InfoFactory::create<DFMBASE_NAMESPACE::FileInfo>(oneUrl,
+                                                                                Global::CreateFileInfoType::kCreateFileInfoSync);
             if (infoPointer) {
                 const QString &displayName = infoPointer->displayOf(DisPlayInfoType::kFileDisplayName);
                 if (!displayName.isEmpty())


### PR DESCRIPTION
1. Refactor device icon selection logic into helper function
devIconName()
2. Implement dedicated helper appendCrumbs() for building breadcrumb
trails
3. Fix SMB/gvfs mounted devices display in title bar crumbs
4. Ensure consistent icon representation for different device types
5. Improve path handling for mounted device breadcrumbs
6. Optimize synchronous file info creation for better performance

Log: Improved display of mounted devices in title bar breadcrumbs

Influence:
1. Test title bar breadcrumbs for different mounted devices (SMB, USB,
etc.)
2. Verify correct icons appear for various device types
3. Check breadcrumb behavior with nested directories on mounted devices
4. Validate path handling for both block devices and protocol mounts

fix: 优化挂载设备在标题栏面包屑中的显示

1. 将设备图标选择逻辑重构为 helper 函数 devIconName()
2. 实现专用的 appendCrumbs() helper 用于构建面包屑路径
3. 修复 SMB/gvfs 挂载设备在标题栏面包屑中的显示问题
4. 确保不同类型设备图标显示的一致性
5. 改进挂载设备路径处理方式
6. 优化同步文件信息创建以提高性能

Log: 优化标题栏中挂载设备的显示效果

Influence:
1. 测试不同类型挂载设备(SMB, USB等)的标题栏面包屑显示
2. 验证各类设备图标是否正确显示
3. 检查挂载设备上嵌套目录的面包屑行为
4. 验证块设备和协议挂载的路径处理是否正确

Bug: https://pms.uniontech.com/bug-view-357197.html
