### PR TITLE
fix: ensure FileInfo consistency with InfoCacheController

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/model/fileinfomodel.cpp
@@ -80,10 +80,23 @@ void FileInfoModelPrivate::insertData(const QUrl &url)
     int row = -1;
     {
         QReadLocker lk(&lock);
-        if (auto cur = fileMap.value(url)) {
+        if (fileMap.contains(url)) {
             lk.unlock();
             fmInfo() << "File already exists in model, refreshing:" << url;
-            cur->refresh();   // refresh fileinfo.
+            // Re-fetch to ensure consistency with InfoCacheController
+            auto newInfo = FileCreator->createFileInfo(url);
+            if (newInfo) {
+                newInfo->refresh();
+                QWriteLocker wlk(&lock);
+                fileMap.insert(url, newInfo);
+            } else {
+                QReadLocker lk(&lock);
+                // Fall back to refreshing the existing pointer
+                if (auto cur = fileMap.value(url)) {
+                    lk.unlock();
+                    cur->refresh();
+                }
+            }
             const QModelIndex &index = q->index(url);
             emit q->dataChanged(index, index);
             return;
@@ -178,11 +191,14 @@ void FileInfoModelPrivate::replaceData(const QUrl &oldUrl, const QUrl &newUrl)
                 removeData(oldUrl);
                 lk.relock();
                 position = fileList.indexOf(newUrl);
-                auto cur = fileMap.value(newUrl);
                 lk.unlock();
 
-                // refresh file
-                cur->refresh();
+                // Re-fetch to ensure consistency with InfoCacheController
+                if (auto refreshedInfo = FileCreator->createFileInfo(newUrl)) {
+                    refreshedInfo->refresh();
+                    QWriteLocker wlk(&lock);
+                    fileMap.insert(newUrl, refreshedInfo);
+                }
                 fmInfo() << "File moved to overwrite existing file:" << oldUrl << "->" << newUrl;
             } else {
                 fileList.replace(position, newUrl);
@@ -211,12 +227,23 @@ void FileInfoModelPrivate::updateData(const QUrl &url)
             fmDebug() << "File not in model for update:" << url;
             return;
         }
+    }
 
-        // Although the files cached in InfoCache will be refreshed automatically,
-        // a redundant refresh is still required here, because the current variant of FileInfo
-        // (like DesktopFileInfo created from DesktopFileCreator) is not in InfoCache and will not be refreshed automatically.
-        if (auto info = fileMap.value(url))
-            info->updateAttributes();
+    // Re-fetch from FileCreator to ensure the model holds the same
+    // FileInfoPointer as InfoCacheController, preventing inconsistency
+    // caused by InfoCache eviction and recreation.
+    auto newInfo = FileCreator->createFileInfo(url);
+    if (newInfo) {
+        newInfo->updateAttributes();
+        QWriteLocker lk(&lock);
+        fileMap.insert(url, newInfo);
+    } else {
+        // Fall back to updating the existing pointer
+        QReadLocker lk(&lock);
+        if (auto cur = fileMap.value(url)) {
+            lk.unlock();
+            cur->updateAttributes();
+        }
     }
 
     const QModelIndex &index = q->index(url);
@@ -459,8 +486,15 @@ int FileInfoModel::modelState() const
 
 void FileInfoModel::update()
 {
-    for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor)
-        itor.value()->updateAttributes();
+    for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor) {
+        // Re-fetch to ensure consistency with InfoCacheController
+        if (auto newInfo = FileCreator->createFileInfo(itor.key())) {
+            newInfo->updateAttributes();
+            itor.value() = newInfo;
+        } else {
+            itor.value()->updateAttributes();
+        }
+    }
 
     emit dataChanged(createIndex(0, 0), createIndex(rowCount(rootIndex()) - 1, 0));
 }
@@ -472,8 +506,13 @@ void FileInfoModel::updateFile(const QUrl &url)
 
 void FileInfoModel::refreshAllFile()
 {
-    for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor)
-        itor.value()->refresh();
+    for (auto itor = d->fileMap.begin(); itor != d->fileMap.end(); ++itor) {
+        // Re-fetch to ensure consistency with InfoCacheController
+        if (auto newInfo = FileCreator->createFileInfo(itor.key())) {
+            newInfo->refresh();
+            itor.value() = newInfo;
+        }
+    }
 
     emit dataChanged(createIndex(0, 0), createIndex(rowCount(rootIndex()) - 1, 0));
 }


### PR DESCRIPTION
1. Re-fetch FileInfo from FileCreator in insertData, replaceData,
updateData, update, and refreshAllFile methods
2. Replace direct refresh/updateAttributes calls on existing FileInfo
objects with creation of new FileInfo instances
3. Update fileMap entries with newly created FileInfo pointers to
maintain synchronization
4. Add proper write locking when modifying fileMap after re-fetching
5. Remove redundant refresh calls that could operate on stale FileInfo
objects

The previous implementation directly refreshed existing FileInfo
objects, which caused inconsistency when InfoCacheController evicted and
recreated FileInfo instances. DesktopFileInfo and other custom FileInfo
variants created by DesktopFileCreator are not stored in InfoCache
and would not receive automatic updates. This change ensures the model
always holds the same FileInfoPointer as InfoCacheController by re-
fetching through FileCreator, preventing stale data and synchronization
issues between the model and the global file info cache.

Influence:
1. Test file insertion scenarios where files already exist in the model
2. Verify file replacement operations (move to overwrite existing files)
3. Test file attribute updates through updateData method
4. Verify bulk update operations via update() method
5. Test full refresh functionality with refreshAllFile()
6. Check behavior when InfoCache evicts and recreates FileInfo entries
7. Verify DesktopFileInfo updates are properly reflected in the model
8. Test concurrent access scenarios with read/write locking
9. Verify model dataChanged signals are emitted correctly after updates

fix: 确保 FileInfo 与 InfoCacheController 保持一致

1. 在 insertData、replaceData、updateData、update 和 refreshAllFile 方法
中从 FileCreator 重新获取 FileInfo
2. 将直接对现有 FileInfo 对象的 refresh/updateAttributes 调用替换为创建
新的 FileInfo 实例
3. 使用新创建的 FileInfo 指针更新 fileMap 条目以保持一致性
4. 在重新获取后修改 fileMap 时添加适当的写锁保护
5. 移除可能对陈旧 FileInfo 对象进行操作的冗余刷新调用

之前的实现直接刷新现有的 FileInfo 对象，当 InfoCacheController 驱逐
并重新创建 FileInfo 实例时会导致不一致。由 DesktopFileCreator 创建
的 DesktopFileInfo 和其他自定义 FileInfo 变体未存储在 InfoCache 中，
无法接收自动更新。此更改确保模型始终通过与 InfoCacheController 相同的
FileCreator 重新获取来持有相同的 FileInfoPointer，防止模型与全局文件信息
缓存之间的数据陈旧和同步问题。

Influence:
1. 测试文件已存在于模型中的文件插入场景
2. 验证文件替换操作（移动覆盖现有文件）
3. 测试通过 updateData 方法的文件属性更新
4. 验证通过 update() 方法的批量更新操作
5. 测试 refreshAllFile() 的完整刷新功能
6. 检查 InfoCache 驱逐并重新创建 FileInfo 条目时的行为
7. 验证 DesktopFileInfo 更新是否正确反映在模型中
8. 测试读写锁的并发访问场景
9. 验证更新后模型 dataChanged 信号是否正确发出

BUG: https://pms.uniontech.com/bug-view-354231.html

## Summary by Sourcery

Ensure FileInfoModel stays synchronized with InfoCacheController by re-fetching FileInfo instances via FileCreator instead of mutating existing ones in-place.

Bug Fixes:
- Resolve inconsistencies caused by refreshing stale FileInfo objects when InfoCacheController evicts and recreates entries.

Enhancements:
- Update insert, replace, update, and bulk refresh paths to recreate FileInfo instances and update the internal file map accordingly.
- Add appropriate write locking when updating the file map after re-fetching FileInfo objects to improve thread safety.