### PR TITLE
feat: enhance SMB network discovery reliability

### DIFF
--- a/src/dfm-base/utils/systemservicemanager.cpp
+++ b/src/dfm-base/utils/systemservicemanager.cpp
@@ -4,6 +4,8 @@
 
 #include "systemservicemanager.h"
 
+#include <dfm-base/utils/sysinfoutils.h>
+
 #include <QDBusInterface>
 #include <QDBusReply>
 #include <QDBusConnection>
@@ -65,6 +67,11 @@ bool SystemServiceManager::isServiceRunning(const QString &serviceName)
     return state.toString() == "running";
 }
 
+bool SystemServiceManager::serviceExists(const QString &serviceName)
+{
+    return !unitPathFromName(serviceName).isEmpty();
+}
+
 bool SystemServiceManager::startService(const QString &serviceName)
 {
     if (serviceName.isEmpty()) {
@@ -111,14 +118,18 @@ bool SystemServiceManager::enableServiceNow(const QString &serviceName)
         return false;
     }
 
-    // pkexec 会查找 systemctl 的完整路径，但显式指定更安全
-    // 通常 systemctl 位于 /usr/bin/ 或 /bin/
-    // QStandardPaths::findExecutable 可以帮助找到它
-    QString program = "pkexec";
+    QString program;
     QStringList arguments;
-    arguments << "systemctl"
-              << "enable"
-              << "--now" << serviceName;
+    if (SysInfoUtils::isRootUser()) {
+        program = "systemctl";
+        arguments << "enable"
+                  << "--now" << serviceName;
+    } else {
+        program = "pkexec";
+        arguments << "systemctl"
+                  << "enable"
+                  << "--now" << serviceName;
+    }
 
     qCInfo(logDFMBase) << "SystemServiceManager: Executing:" << program << arguments.join(" ");
 
@@ -164,8 +175,9 @@ QString SystemServiceManager::unitPathFromName(const QString &serviceName)
         return QString();
     }
 
-    // 使用 GetUnit 方法获取 unit 路径
-    QDBusReply<QDBusObjectPath> reply = managerIface.call("GetUnit", serviceName);
+    // LoadUnit can resolve installed but currently inactive units; it fails when
+    // the unit file is unavailable.
+    QDBusReply<QDBusObjectPath> reply = managerIface.call("LoadUnit", serviceName);
     if (!reply.isValid()) {
         qCWarning(logDFMBase) << "SystemServiceManager: Failed to get unit path for" << serviceName
                               << "Error:" << reply.error().message();

--- a/src/dfm-base/utils/systemservicemanager.h
+++ b/src/dfm-base/utils/systemservicemanager.h
@@ -59,6 +59,13 @@ public:
     bool isServiceRunning(const QString &serviceName);
 
     /**
+     * @brief 检查服务 unit 是否存在
+     * @param serviceName 服务名（如 "smbd.service"）
+     * @return true 表示 systemd 可以加载该 unit
+     */
+    bool serviceExists(const QString &serviceName);
+
+    /**
      * @brief 启动服务（临时，重启后失效）
      * @param serviceName 服务名
      * @return true 表示操作成功

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/iterator/smbshareiterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/iterator/smbshareiterator.cpp
@@ -6,9 +6,17 @@
 #include "private/smbshareiterator_p.h"
 #include "utils/smbbrowserutils.h"
 
+#include <QElapsedTimer>
+#include <QThread>
+
 using namespace dfmplugin_smbbrowser;
 DFMBASE_USE_NAMESPACE
 USING_IO_NAMESPACE
+
+namespace {
+static constexpr int kNetworkDiscoveryWarmupTimeoutMs { 12000 };
+static constexpr int kNetworkDiscoveryWarmupIntervalMs { 800 };
+}
 
 // TODO(xust) TODO(lanxs): using local enumerator temperarily, using SmbBrowserEnumerator or something later.
 
@@ -19,11 +27,16 @@ SmbShareIteratorPrivate::SmbShareIteratorPrivate(const QUrl &url, dfmplugin_smbb
         QMutexLocker locker(&smb_browser_utils::nodesMutex());
         smb_browser_utils::shareNodes().clear();
     }
-    enumerator.reset(new DEnumerator(url));
+    resetEnumerator();
 }
 
 SmbShareIteratorPrivate::~SmbShareIteratorPrivate()
 {
+}
+
+void SmbShareIteratorPrivate::resetEnumerator()
+{
+    enumerator.reset(new DEnumerator(rootUrl));
 }
 
 SmbShareIterator::SmbShareIterator(const QUrl &url, const QStringList &nameFilters, QDir::Filters filters, QDirIterator::IteratorFlags flags)
@@ -91,7 +104,37 @@ QUrl SmbShareIterator::url() const
 
 bool SmbShareIterator::initIterator()
 {
-    if (d->enumerator)
+    bool waitForDiscoveryWarmup = false;
+    if (d->rootUrl == smb_browser_utils::netNeighborRootUrl()) {
+        if (!smb_browser_utils::ensureNetworkDiscoveryService(&waitForDiscoveryWarmup)) {
+            fmWarning() << "Network discovery service is unavailable, network neighborhood enumeration may be incomplete";
+        }
+    }
+
+    if (!d->enumerator)
+        return false;
+
+    if (!waitForDiscoveryWarmup)
         return d->enumerator->initEnumerator(oneByOne());
-    return false;
+
+    QElapsedTimer timer;
+    timer.start();
+    while (true) {
+        if (!d->enumerator->initEnumerator(oneByOne()))
+            return false;
+
+        if (d->enumerator->hasNext()) {
+            fmInfo() << "Network neighborhood data is ready after service warm-up, elapsed:" << timer.elapsed();
+            return true;
+        }
+
+        if (timer.elapsed() >= kNetworkDiscoveryWarmupTimeoutMs)
+            break;
+
+        QThread::msleep(kNetworkDiscoveryWarmupIntervalMs);
+        d->resetEnumerator();
+    }
+
+    fmWarning() << "Network neighborhood data is still empty after service warm-up, elapsed:" << timer.elapsed();
+    return true;
 }

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/private/smbshareiterator_p.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/private/smbshareiterator_p.h
@@ -26,6 +26,7 @@ class SmbShareIteratorPrivate
 public:
     explicit SmbShareIteratorPrivate(const QUrl &url, SmbShareIterator *qq);
     ~SmbShareIteratorPrivate();
+    void resetEnumerator();
 
 private:
     SmbShareIterator *q { nullptr };

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.cpp
@@ -21,6 +21,7 @@
 #include <QUrl>
 #include <QDBusInterface>
 #include <QDBusPendingCall>
+#include <QMutexLocker>
 #include <QtConcurrent>
 
 Q_DECLARE_METATYPE(const char *)
@@ -28,6 +29,25 @@ using namespace GlobalDConfDefines::ConfigPath;
 
 namespace dfmplugin_smbbrowser {
 namespace smb_browser_utils {
+
+namespace {
+static constexpr char kAvahiDaemonService[] { "avahi-daemon.service" };
+
+QString serviceUnitName(const QString &service)
+{
+    if (service == "smb")
+        return "smbd.service";
+    if (service == "nmb")
+        return "nmbd.service";
+    if (service == "smbd" || service == "nmbd")
+        return service + ".service";
+    if (service == "smbd.service" || service == "nmbd.service")
+        return service;
+    if (service == kAvahiDaemonService)
+        return kAvahiDaemonService;
+    return {};
+}
+}
 
 QString networkScheme()
 {
@@ -83,44 +103,84 @@ QString getDeviceIdByStdSmb(const QString &stdSmb)
  */
 bool isServiceRuning(const QString &service)
 {
-    if (service.isEmpty() || (service != "smb" && service != "nmb")) {
+    const QString &serviceName = serviceUnitName(service);
+    if (serviceName.isEmpty()) {
         fmWarning() << "Invalid service name for status check:" << service;
         return false;
     }
 
-    // 使用 SystemServiceManager 检查服务状态
-    QString serviceName = QString("%1d.service").arg(service);
     return dfmbase::SystemServiceManager::instance().isServiceRunning(serviceName);
 }
 
 bool enableServiceNow(const QString &service)
 {
-    if (service.isEmpty() || (service != "smb" && service != "nmb")) {
+    const QString &serviceName = serviceUnitName(service);
+    if (serviceName.isEmpty()) {
         fmWarning() << "Invalid service name for enable operation:" << service;
         return false;
     }
-    fmDebug() << "Enable service:" << service;
-    QString serviceName = QString("%1d.service").arg(service);
+
+    fmDebug() << "Enable service:" << serviceName;
     bool result = dfmbase::SystemServiceManager::instance().enableServiceNow(serviceName);
-    fmDebug() << "Service enable result for" << service << ":" << result;
+    fmDebug() << "Service enable result for" << serviceName << ":" << result;
     return result;
 }
 
 bool checkAndEnableService(const QString &service)
 {
+    const QString &serviceName = serviceUnitName(service);
+    if (serviceName.isEmpty()) {
+        fmWarning() << "Invalid service name for check operation:" << service;
+        return false;
+    }
+
+    if (!dfmbase::SystemServiceManager::instance().serviceExists(serviceName)) {
+        fmWarning() << "Service unit does not exist:" << serviceName;
+        return false;
+    }
+
     if (isServiceRuning(service)) {
-        fmDebug() << "Service already running:" << service;
+        fmDebug() << "Service already running:" << serviceName;
         return true;
     }
 
-    fmDebug() << "Service not running, attempting to start:" << service;
+    fmDebug() << "Service not running, attempting to start:" << serviceName;
     if (enableServiceNow(service)) {
-        fmDebug() << "Successfully started and enabled service:" << service;
+        fmDebug() << "Successfully started and enabled service:" << serviceName;
         return true;
     }
 
-    fmCritical() << "Failed to start service:" << service;
+    fmCritical() << "Failed to start service:" << serviceName;
     return false;
+}
+
+bool ensureNetworkDiscoveryService(bool *serviceStarted)
+{
+    if (serviceStarted)
+        *serviceStarted = false;
+
+    static QMutex mutex;
+    QMutexLocker locker(&mutex);
+
+    const QString serviceName { kAvahiDaemonService };
+    if (!dfmbase::SystemServiceManager::instance().serviceExists(serviceName)) {
+        fmWarning() << "Network discovery service unit does not exist:" << serviceName;
+        return false;
+    }
+
+    if (isServiceRuning(serviceName)) {
+        fmDebug() << "Network discovery service already running:" << serviceName;
+        return true;
+    }
+
+    if (!enableServiceNow(serviceName)) {
+        fmCritical() << "Failed to start network discovery service:" << serviceName;
+        return false;
+    }
+
+    if (serviceStarted)
+        *serviceStarted = true;
+    return true;
 }
 
 void bindSetting()

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.h
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.h
@@ -27,6 +27,7 @@ QString getDeviceIdByStdSmb(const QString &stdSmb);
 bool isServiceRuning(const QString &service);
 bool enableServiceNow(const QString &service);
 bool checkAndEnableService(const QString &service);
+bool ensureNetworkDiscoveryService(bool *serviceStarted = nullptr);
 
 void initSettingPane();
 // bind dconfig


### PR DESCRIPTION
Added logic to automatically start avahi-daemon.service for network
neighborhood discovery and improved service management robustness.

1. Added serviceExists() method to SystemServiceManager for better
service verification
2. Modified enableServiceNow() to handle root user scenario differently
3. Implemented warm-up wait period before network neighborhood
enumeration
4. Added mutex protection for service state interactions
5. Improved service unit name handling with standardized parsing
6. Added avahi-daemon service as critical dependency for SMB discovery

Log: Improved network neighborhood reliability by ensuring avahi-daemon
is running

Influence:
1. Test network neighborhood listing under different service states
2. Verify service auto-start works for both root and non-root users
3. Test scenarios where services are missing or disabled
4. Verify mutex protection prevents race conditions
5. Check UI response times during initial network discovery
6. Test with mixed SMB/NMB/Avahi service configurations

feat: 增强SMB网络发现的可靠性

添加自动启动avahi-daemon服务以支持网络邻居发现，并提升了服务管理的健壮性

1. 在SystemServiceManager中添加serviceExists()方法用于验证服务存在状态
2. 修改enableServiceNow()方法以区分root用户场景处理
3. 实现网络邻居枚举前的服务预热等待机制
4. 为服务状态交互添加互斥锁保护
5. 改进服务单元名处理方式，采用标准化解析
6. 添加avahi-daemon服务作为SMB发现的关键依赖项

Log: 通过确保avahi-daemon运行提升网络邻居功能的可靠性

Influence:
1. 测试不同服务状态下的网络邻居列表显示
2. 验证服务自动启动在root和非root用户下都能正常工作
3. 测试服务缺失或禁用场景下的处理
4. 确认互斥锁能有效防止竞态条件
5. 检查初始网络发现时的UI响应时间
6. 测试混合SMB/NMB/Avahi服务配置下的表现

Bug: https://pms.uniontech.com/bug-view-337981.html
