### PR TITLE
Fix: [filedialog] The dir graying in smb.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1798,7 +1798,7 @@ bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool by
         return true;
 
     auto item = childData(sortInfo->fileUrl());
-    if (item && !nameFilters.isEmpty() && !item->data(Global::ItemRoles::kItemFileIsDirRole).toBool()) {
+    if (item && !nameFilters.isEmpty() && !sortInfo->isDir()) {
         QRegularExpression re("", QRegularExpression::CaseInsensitiveOption);
         bool hasMatched { false };
         for (int i = 0; i < nameFilters.size(); ++i) {


### PR DESCRIPTION
-- Can not get dir info by item.
-- Use sortInfo to get dir info.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-359197.html

## Summary by Sourcery

Bug Fixes:
- Fix incorrect handling of SMB directories being treated as non-directories when applying name filters, which caused directories to appear greyed out.