### PR TITLE
Fix(titlebar): resolve highlight artifact in completer under high DPI…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/completerviewdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/completerviewdelegate.cpp
@@ -34,9 +34,12 @@ void CompleterViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
         cg = QPalette::Inactive;
     }
 
+    // Fix: Adjust rect for high DPI scaling to avoid edge artifacts (similar to bug-205621 in sidebar)
+    QRect paintRect = qApp->devicePixelRatio() > 1.0 ? opt.rect.adjusted(0, 1, 0, -1) : opt.rect;
+
     // draw background
     if (option.showDecorationSelected && (option.state & (QStyle::State_Selected | QStyle::State_MouseOver))) {
-        painter->fillRect(option.rect, option.palette.brush(cg, QPalette::Highlight));
+        painter->fillRect(paintRect, option.palette.brush(cg, QPalette::Highlight));
     }
 
     // draw icon


### PR DESCRIPTION
… scaling

Adjust the paint rect by 1 pixel inward when devicePixelRatio > 1.0 to avoid edge artifacts during keyboard navigation.

修复高DPI缩放下completer列表项高亮背景边缘残留问题，参考sidebar的bug-205621修复方案。

Log: 修复高DPI缩放下completer高亮残留问题
Bug: https://pms.uniontech.com/bug-view-355159.html
Influence: 解决屏幕缩放≥1.25x时键盘切换completer列表项出现蓝色直线残留的UI显示问题。

## Summary by Sourcery

Bug Fixes:
- Prevent highlight background edge artifacts in the completer list under high DPI scaling by slightly shrinking the painted rectangle.