### PR TITLE
feat: add property dialog update mechanism for file rename

### DIFF
--- a/src/plugins/common/dfmplugin-dirshare/dirshare.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/dirshare.cpp
@@ -16,7 +16,9 @@
 #include <QDebug>
 
 using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+using ViewExtensionUpdateFunc = std::function<void(QWidget *widget, const QUrl &url)>;
 Q_DECLARE_METATYPE(CustomViewExtensionView)
+Q_DECLARE_METATYPE(ViewExtensionUpdateFunc)
 
 namespace dfmplugin_dirshare {
 DFM_LOG_REGISTER_CATEGORY(DPDIRSHARE_NAMESPACE)
@@ -125,8 +127,18 @@ void DirShare::bindEvents()
 
 void DirShare::regToPropertyDialog()
 {
-    CustomViewExtensionView func { DirShare::createShareControlWidget };
-    dpfSlotChannel->push("dfmplugin_propertydialog", "slot_ViewExtension_Register", func, "DirShare", 2);
+    CustomViewExtensionView create { DirShare::createShareControlWidget };
+    ViewExtensionUpdateFunc update { [](QWidget *widget, const QUrl &url) {
+        auto *shareWidget = qobject_cast<ShareControlWidget *>(widget);
+        if (!shareWidget)
+            return;
+        // updateFile(oldUrl, newUrl) checks if oldUrl matches internal url before updating.
+        // Pass url as both old and new to unconditionally update to the new URL.
+        QMetaObject::invokeMethod(shareWidget, "updateFile",
+                                  Qt::DirectConnection,
+                                  Q_ARG(QUrl, url), Q_ARG(QUrl, url));
+    } };
+    dpfSlotChannel->push("dfmplugin_propertydialog", "slot_ViewExtensionWithUpdate_Register", create, update, QString("DirShare"), 2);
 }
 
 void DirShare::onShareStateChanged(const QString &path)

--- a/src/plugins/common/dfmplugin-propertydialog/dfmplugin_propertydialog_global.h
+++ b/src/plugins/common/dfmplugin-propertydialog/dfmplugin_propertydialog_global.h
@@ -75,6 +75,7 @@ enum class ComputerInfoItem : uint8_t {
 
 using BasicExpandMap = QMultiMap<BasicFieldExpandEnum, QPair<QString, QString>>;
 using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+using ViewExtensionUpdateFunc = std::function<void(QWidget *widget, const QUrl &url)>;
 using BasicViewFieldFunc = std::function<QMap<QString, QMultiMap<QString, QPair<QString, QString>>>(const QUrl &url)>;
 using ViewIntiCallback = std::function<void(QWidget *w, const QVariantHash &opt)>;
 
@@ -85,10 +86,12 @@ static constexpr char kOption_Key_DisableCustomDialog[] { "Option_Key_DisableCus
 static constexpr char kOption_Key_ViewIndex[] { "Option_Key_ViewIndex" };
 static constexpr char kOption_Key_ViewInitCalback[] { "Option_Key_ViewInitCalback" };
 static constexpr char kOption_Key_CreatorCalback[] { "Option_Key_CreatorCalback" };
+static constexpr char kOption_Key_UpdaterCallback[] { "Option_Key_UpdaterCallback" };
 
 DPPROPERTYDIALOG_END_NAMESPACE
 
 Q_DECLARE_METATYPE(DPPROPERTYDIALOG_NAMESPACE::CustomViewExtensionView);
+Q_DECLARE_METATYPE(DPPROPERTYDIALOG_NAMESPACE::ViewExtensionUpdateFunc);
 Q_DECLARE_METATYPE(DPPROPERTYDIALOG_NAMESPACE::BasicViewFieldFunc);
 Q_DECLARE_METATYPE(DPPROPERTYDIALOG_NAMESPACE::ViewIntiCallback);
 

--- a/src/plugins/common/dfmplugin-propertydialog/events/propertyeventreceiver.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/events/propertyeventreceiver.cpp
@@ -29,6 +29,9 @@ void PropertyEventReceiver::bindEvents()
     dpfSlotChannel->connect(DPF_MACRO_TO_STR(DPPROPERTYDIALOG_NAMESPACE), "slot_ViewExtension_Register",
                             this, &PropertyEventReceiver::handleViewExtensionRegister);
 
+    dpfSlotChannel->connect(DPF_MACRO_TO_STR(DPPROPERTYDIALOG_NAMESPACE), "slot_ViewExtensionWithUpdate_Register",
+                            this, &PropertyEventReceiver::handleViewExtensionRegisterWithUpdate);
+
     dpfSlotChannel->connect(DPF_MACRO_TO_STR(DPPROPERTYDIALOG_NAMESPACE), "slot_CustomView_Register",
                             this, &PropertyEventReceiver::handleCustomViewRegister);
 
@@ -61,6 +64,13 @@ void PropertyEventReceiver::handleShowPropertyDialog(const QList<QUrl> &urls, co
 bool PropertyEventReceiver::handleViewExtensionRegister(CustomViewExtensionView view, const QString &name, int index)
 {
     return PropertyDialogManager::instance().registerExtensionView(view, name, index);
+}
+
+bool PropertyEventReceiver::handleViewExtensionRegisterWithUpdate(CustomViewExtensionView creator,
+                                                                  ViewExtensionUpdateFunc updater,
+                                                                  const QString &name, int index)
+{
+    return PropertyDialogManager::instance().registerExtensionViewWithUpdate(creator, updater, name, index);
 }
 
 bool PropertyEventReceiver::handleCustomViewRegister(CustomViewExtensionView view, const QString &scheme)

--- a/src/plugins/common/dfmplugin-propertydialog/events/propertyeventreceiver.h
+++ b/src/plugins/common/dfmplugin-propertydialog/events/propertyeventreceiver.h
@@ -23,6 +23,9 @@ public:
 
     void handleShowPropertyDialog(const QList<QUrl> &urls, const QVariantHash &option);
     bool handleViewExtensionRegister(CustomViewExtensionView view, const QString &name, int index);
+    bool handleViewExtensionRegisterWithUpdate(CustomViewExtensionView creator,
+                                               ViewExtensionUpdateFunc updater,
+                                               const QString &name, int index);
     bool handleCustomViewRegister(CustomViewExtensionView view, const QString &scheme);
     bool handleBasicViewExtensionRegister(BasicViewFieldFunc func, const QString &scheme);
     bool handleBasicFiledFilterAdd(const QString &scheme, const QStringList &enums);

--- a/src/plugins/common/dfmplugin-propertydialog/propertydialog.h
+++ b/src/plugins/common/dfmplugin-propertydialog/propertydialog.h
@@ -21,6 +21,7 @@ class PropertyDialog : public dpf::Plugin
     // slot events
     DPF_EVENT_REG_SLOT(slot_PropertyDialog_Show)
     DPF_EVENT_REG_SLOT(slot_ViewExtension_Register)
+    DPF_EVENT_REG_SLOT(slot_ViewExtensionWithUpdate_Register)
     DPF_EVENT_REG_SLOT(slot_CustomView_Register)
     DPF_EVENT_REG_SLOT(slot_BasicViewExtension_Register)
     DPF_EVENT_REG_SLOT(slot_BasicFiledFilter_Add)

--- a/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogmanager.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogmanager.cpp
@@ -33,11 +33,6 @@ bool PropertyDialogManager::registerExtensionView(CustomViewExtensionView viewCr
         //        return false;
     }
 
-    // 1. Different models have different `viewCreator`, `name` and `index`;
-    // 2. Here give basic widget a initial expand state : true;
-    // 3. The initial expand state of added view is false;
-    // 4. When the external model(plugin) call the `slot_PropertyDialog_Show`, it can transfers a option value to
-    // adjust the field value of initOption, for example, to set a function pointer ViewIntiCallback to update the UI.
     ViewIntiCallback viewInitiCb { nullptr };
     QVariantHash initOption = {
         { kOption_Key_Name, name },
@@ -48,9 +43,28 @@ bool PropertyDialogManager::registerExtensionView(CustomViewExtensionView viewCr
         { kOption_Key_DisableCustomDialog, false },
         { kOption_Key_ViewInitCalback, QVariant::fromValue(viewInitiCb) }
     };
-    // Store a initial option, it would be updated in `kOption_Key_ViewInitCalback` if needed.
     creatorOptions.insert(index, initOption);
     return true;
+}
+
+bool PropertyDialogManager::registerExtensionViewWithUpdate(CustomViewExtensionView creator,
+                                                             ViewExtensionUpdateFunc updater,
+                                                             const QString &name, int index)
+{
+    if (!registerExtensionView(creator, name, index))
+        return false;
+
+    // Store the updater callback in the registered option hash
+    auto keys = creatorOptions.keys();
+    for (int idx : keys) {
+        for (auto it = creatorOptions.find(idx); it != creatorOptions.end() && it.key() == idx; ++it) {
+            if (it.value().value(kOption_Key_Name).toString() == name) {
+                it.value().insert(kOption_Key_UpdaterCallback, QVariant::fromValue(updater));
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 QMap<int, QWidget *> PropertyDialogManager::createExtensionView(const QUrl &url, const QVariantHash &option)
@@ -82,6 +96,11 @@ QMap<int, QWidget *> PropertyDialogManager::createExtensionView(const QUrl &url,
             if (g != nullptr) {
                 if (viewInitCallback)
                     viewInitCallback(g, showViewOption);
+
+                // Propagate updater callback as a dynamic property on the widget
+                auto updater = DPF_NAMESPACE::paramGenerator<ViewExtensionUpdateFunc>(showViewOption.value(kOption_Key_UpdaterCallback));
+                if (updater)
+                    g->setProperty(kOption_Key_UpdaterCallback, QVariant::fromValue(updater));
 
                 temp.insert(index, g);
             }
@@ -199,4 +218,13 @@ QVariantHash PropertyDialogManager::getCreatorOptionByName(const QString &name) 
     }
 
     return QVariantHash();
+}
+
+ViewExtensionUpdateFunc PropertyDialogManager::getUpdaterByName(const QString &name) const
+{
+    auto opt = getCreatorOptionByName(name);
+    if (opt.isEmpty())
+        return {};
+
+    return DPF_NAMESPACE::paramGenerator<ViewExtensionUpdateFunc>(opt.value(kOption_Key_UpdaterCallback));
 }

--- a/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogmanager.h
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogmanager.h
@@ -20,7 +20,11 @@ public:
     static PropertyDialogManager &instance();
 
     bool registerExtensionView(CustomViewExtensionView viewCreator, const QString &name, int index = -1);
+    bool registerExtensionViewWithUpdate(CustomViewExtensionView creator,
+                                         ViewExtensionUpdateFunc updater,
+                                         const QString &name, int index = -1);
     QMap<int, QWidget *> createExtensionView(const QUrl &url, const QVariantHash &option = QVariantHash());
+    ViewExtensionUpdateFunc getUpdaterByName(const QString &name) const;
     bool registerCustomView(CustomViewExtensionView view, const QString &scheme);
     QWidget *createCustomView(const QUrl &url);
 

--- a/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.cpp
@@ -158,10 +158,19 @@ void PropertyDialogUtil::insertExtendedControlFileProperty(const QUrl &url, int 
     }
 }
 
-/*!
- * \brief           Normal view control extension
- * \param widget    The view to be inserted
- */
+void PropertyDialogUtil::insertExtendedControlFileProperty(const QUrl &url, int index, QWidget *widget, ViewExtensionUpdateFunc updater)
+{
+    if (widget) {
+        FilePropertyDialog *dialog = nullptr;
+        if (filePropertyDialogs.contains(url)) {
+            dialog = filePropertyDialogs.value(url);
+        } else {
+            dialog = new FilePropertyDialog();
+        }
+        dialog->insertExtendedControl(index, widget, updater);
+    }
+}
+
 void PropertyDialogUtil::addExtendedControlFileProperty(const QUrl &url, QWidget *widget)
 {
     if (widget) {
@@ -175,6 +184,19 @@ void PropertyDialogUtil::addExtendedControlFileProperty(const QUrl &url, QWidget
     }
 }
 
+void PropertyDialogUtil::addExtendedControlFileProperty(const QUrl &url, QWidget *widget, ViewExtensionUpdateFunc updater)
+{
+    if (widget) {
+        FilePropertyDialog *dialog = nullptr;
+        if (filePropertyDialogs.contains(url)) {
+            dialog = filePropertyDialogs.value(url);
+        } else {
+            dialog = new FilePropertyDialog();
+        }
+        dialog->addExtendedControl(widget, updater);
+    }
+}
+
 void PropertyDialogUtil::closeFilePropertyDialog(const QUrl &url)
 {
     if (filePropertyDialogs.contains(url)) {
@@ -183,6 +205,14 @@ void PropertyDialogUtil::closeFilePropertyDialog(const QUrl &url)
 
     if (filePropertyDialogs.isEmpty())
         closeAllDialog->close();
+}
+
+void PropertyDialogUtil::renameFilePropertyDialog(const QUrl &oldUrl, const QUrl &newUrl)
+{
+    if (filePropertyDialogs.contains(oldUrl)) {
+        FilePropertyDialog *dialog = filePropertyDialogs.take(oldUrl);
+        filePropertyDialogs.insert(newUrl, dialog);
+    }
 }
 
 void PropertyDialogUtil::closeCustomPropertyDialog(const QUrl &url)
@@ -211,14 +241,26 @@ void PropertyDialogUtil::closeAllPropertyDialog()
 
 void PropertyDialogUtil::createControlView(const QUrl &url, const QVariantHash &option)
 {
-    QMap<int, QWidget *> controlView = createView(url, option);
+    Q_UNUSED(option)
+    QMap<int, QWidget *> controlView = createView(url, {});
     int count = controlView.keys().count();
     for (int i = 0; i < count; ++i) {
-        QWidget *view = controlView.value(controlView.keys()[i]);
-        if (controlView.keys()[i] == -1) {
-            addExtendedControlFileProperty(url, view);
+        int index = controlView.keys()[i];
+        QWidget *view = controlView.value(index);
+        if (!view)
+            continue;
+
+        auto updater = view->property(kOption_Key_UpdaterCallback).value<ViewExtensionUpdateFunc>();
+        if (updater) {
+            if (index == -1)
+                addExtendedControlFileProperty(url, view, updater);
+            else
+                insertExtendedControlFileProperty(url, index, view, updater);
         } else {
-            insertExtendedControlFileProperty(url, controlView.keys()[i], view);
+            if (index == -1)
+                addExtendedControlFileProperty(url, view);
+            else
+                insertExtendedControlFileProperty(url, index, view);
         }
     }
 }

--- a/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.h
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.h
@@ -27,8 +27,11 @@ public slots:
     void showFilePropertyDialog(const QList<QUrl> &urls, const QVariantHash &option = QVariantHash());
     bool showCustomDialog(const QUrl &url);
     void insertExtendedControlFileProperty(const QUrl &url, int index, QWidget *widget);
+    void insertExtendedControlFileProperty(const QUrl &url, int index, QWidget *widget, ViewExtensionUpdateFunc updater);
     void addExtendedControlFileProperty(const QUrl &url, QWidget *widget);
+    void addExtendedControlFileProperty(const QUrl &url, QWidget *widget, ViewExtensionUpdateFunc updater);
     void closeFilePropertyDialog(const QUrl &url);
+    void renameFilePropertyDialog(const QUrl &oldUrl, const QUrl &newUrl);
     void closeCustomPropertyDialog(const QUrl &url);
     void closeAllFilePropertyDialog();
     void closeAllPropertyDialog();

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -387,6 +387,16 @@ int BasicWidget::getFileCount()
 void BasicWidget::updateFileUrl(const QUrl &url)
 {
     currentUrl = url;
+
+    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+    if (info.isNull())
+        return;
+
+    if (fileLocation) {
+        fileLocation->setRightValue(info->isAttributes(OptInfoType::kIsSymLink) ? info->pathOf(PathInfoType::kSymLinkTarget)
+                                                                                 : info->pathOf(PathInfoType::kAbsoluteFilePath),
+                                    Qt::ElideMiddle, Qt::AlignVCenter, true);
+    }
 }
 
 void BasicWidget::slotFileCountAndSizeChange(const FileScanner::ScanResult &result)

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -176,6 +176,7 @@ void NameTextEdit::keyPressEvent(QKeyEvent *event)
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
         setIsCanceled(false);
         emit editFinished();
+        return;
     }
     QTextEdit::keyPressEvent(event);
 }

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -289,10 +289,23 @@ void FilePropertyDialog::insertExtendedControl(int index, QWidget *widget)
     connect(hanceedWidget, &DEnhancedWidget::heightChanged, this, &FilePropertyDialog::processHeight);
 }
 
+void FilePropertyDialog::insertExtendedControl(int index, QWidget *widget, ViewExtensionUpdateFunc updater)
+{
+    insertExtendedControl(index, widget);
+    if (updater)
+        extensionUpdaters.insert(widget, updater);
+}
+
 void FilePropertyDialog::addExtendedControl(QWidget *widget)
 {
     QVBoxLayout *vlayout = qobject_cast<QVBoxLayout *>(scrollArea->widget()->layout());
     insertExtendedControl(vlayout->count() - 1, widget);
+}
+
+void FilePropertyDialog::addExtendedControl(QWidget *widget, ViewExtensionUpdateFunc updater)
+{
+    QVBoxLayout *vlayout = qobject_cast<QVBoxLayout *>(scrollArea->widget()->layout());
+    insertExtendedControl(vlayout->count() - 1, widget, updater);
 }
 
 void FilePropertyDialog::closeDialog()
@@ -300,10 +313,29 @@ void FilePropertyDialog::closeDialog()
     emit closed(currentFileUrl);
 }
 
-void FilePropertyDialog::onSelectUrlRenamed(const QUrl &url)
+void FilePropertyDialog::onSelectUrlRenamed(const QUrl &newUrl)
 {
-    close();
-    PropertyDialogUtil::instance()->showPropertyDialog({ url }, QVariantHash());
+    QUrl oldUrl = currentFileUrl;
+    currentFileUrl = newUrl;
+    currentInfo = InfoFactory::create<FileInfo>(newUrl, Global::CreateFileInfoType::kCreateFileInfoSync);
+
+    if (fileIcon && !currentInfo.isNull())
+        setFileIcon(fileIcon, currentInfo);
+
+    if (basicWidget)
+        basicWidget->updateFileUrl(newUrl);
+
+    if (permissionManagerWidget)
+        permissionManagerWidget->updateFileUrl(newUrl);
+
+    for (auto it = extensionUpdaters.begin(); it != extensionUpdaters.end(); ++it) {
+        if (it.value())
+            it.value()(it.key(), newUrl);
+    }
+
+    PropertyDialogUtil::instance()->renameFilePropertyDialog(oldUrl, newUrl);
+
+    processHeight(contentHeight());
 }
 
 void FilePropertyDialog::onFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg)

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.h
@@ -44,7 +44,9 @@ public:
 public slots:
     void processHeight(int height);
     void insertExtendedControl(int index, QWidget *widget);
+    void insertExtendedControl(int index, QWidget *widget, ViewExtensionUpdateFunc updater);
     void addExtendedControl(QWidget *widget);
+    void addExtendedControl(QWidget *widget, ViewExtensionUpdateFunc updater);
     void closeDialog();
     void onSelectUrlRenamed(const QUrl &url);
     void onFileInfoUpdated(const QUrl &url, const QString &infoPtr, const bool isLinkOrg);
@@ -78,6 +80,7 @@ private:
     QFrame *textShowFrame { nullptr };
     DTK_WIDGET_NAMESPACE::DIconButton *editButton { nullptr };
     QList<QWidget *> extendedControl {};
+    QMap<QWidget *, ViewExtensionUpdateFunc> extensionUpdaters {};
     QUrl currentFileUrl {};
     int extendedHeight { 0 };
     DTK_WIDGET_NAMESPACE::DPlatformWindowHandle *platformWindowHandle { nullptr };

--- a/src/plugins/common/dfmplugin-tag/tag.cpp
+++ b/src/plugins/common/dfmplugin-tag/tag.cpp
@@ -271,11 +271,20 @@ void Tag::bindWindows()
 void Tag::regToPropertyDialog()
 {
     fmDebug() << "Registering tag widget to property dialog";
-    CustomViewExtensionView func { Tag::createTagWidgetForPropertyDialog };
+    CustomViewExtensionView create { Tag::createTagWidgetForPropertyDialog };
+    ViewExtensionUpdateFunc update { [](QWidget *widget, const QUrl &url) {
+        auto *tagWidget = qobject_cast<TagWidget *>(widget);
+        if (!tagWidget)
+            return;
+        QUrl realUrl;
+        UniversalUtils::urlTransformToLocal(url, &realUrl);
+        tagWidget->setUrl(realUrl);
+    } };
     dpfSlotChannel->push("dfmplugin_propertydialog",
-                         "slot_ViewExtension_Register",
-                         func,
-                         "Tag",
+                         "slot_ViewExtensionWithUpdate_Register",
+                         create,
+                         update,
+                         QString("Tag"),
                          0);
 }
 

--- a/src/plugins/common/dfmplugin-utils/openwith/virtualopenwithplugin.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/virtualopenwithplugin.cpp
@@ -4,11 +4,14 @@
 
 #include "virtualopenwithplugin.h"
 #include "openwith/openwithhelper.h"
+#include "openwith/openwithwidget.h"
 
 using namespace dfmplugin_utils;
 
 using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+using ViewExtensionUpdateFunc = std::function<void(QWidget *widget, const QUrl &url)>;
 Q_DECLARE_METATYPE(CustomViewExtensionView)
+Q_DECLARE_METATYPE(ViewExtensionUpdateFunc)
 
 void VirtualOpenWithPlugin::initialize()
 {
@@ -37,6 +40,12 @@ bool VirtualOpenWithPlugin::start()
 
 void VirtualOpenWithPlugin::regViewToPropertyDialog()
 {
-    CustomViewExtensionView func { OpenWithHelper::createOpenWithWidget };
-    dpfSlotChannel->push("dfmplugin_propertydialog", "slot_ViewExtension_Register", func, "Virtual", 2);
+    CustomViewExtensionView create { OpenWithHelper::createOpenWithWidget };
+    ViewExtensionUpdateFunc update { [](QWidget *widget, const QUrl &url) {
+        auto *openWidget = qobject_cast<OpenWithWidget *>(widget);
+        if (!openWidget)
+            return;
+        openWidget->selectFileUrl(url);
+    } };
+    dpfSlotChannel->push("dfmplugin_propertydialog", "slot_ViewExtensionWithUpdate_Register", create, update, QString("Virtual"), 2);
 }


### PR DESCRIPTION
1. Introduce ViewExtensionUpdateFunc callback type to enable dynamic

updates of property dialog widgets when files are renamed

2. Add new slot_ViewExtensionWithUpdate_Register API alongside existing

slot_ViewExtension_Register for backward compatibility

3. Implement registerExtensionViewWithUpdate in PropertyDialogManager to

store updater callbacks with creator options

4. Modify FilePropertyDialog to track extension widgets and their

updaters, calling them on file rename instead of closing dialog

5. Update BasicWidget::updateFileUrl to refresh file location display

when URL changes

6. Fix NameTextEdit::keyPressEvent to prevent duplicate editFinished

signals on Enter key

7. Migrate DirShare, Tag, and VirtualOpenWithPlugin to use new

registration API with proper update handlers

8. Add renameFilePropertyDialog helper to update dialog URL tracking

without destroying UI

This change improves user experience by keeping property dialogs open

during file rename operations and dynamically updating all widget

content, avoiding the disruptive close-and-reopen behavior.

Log: Property dialog now stays open and updates content when file is

renamed

Influence:

1. Test file rename operation with property dialog open - verify dialog

stays open and updates

2. Verify share widget updates correctly when shared folder is renamed

3. Verify tag widget updates and shows correct tags for renamed file

4. Verify open with widget updates to show correct application

associations

5. Test basic info widget (file location path) updates correctly

6. Verify permission widget updates for renamed file

7. Test multiple rapid renames while property dialog is open

8. Verify no memory leaks or crashes during rename operations with

extended controls

9. Test canceling rename operation - verify dialog remains consistent

10. Verify backward compatibility with plugins using old registration

API

feat: 添加属性对话框文件重命名更新机制

1. 引入 ViewExtensionUpdateFunc 回调类型，支持文件重命名时动态更新属性对

话框控件

2. 新增 slot_ViewExtensionWithUpdate_Register API，与现有

slot_ViewExtension_Register 保持向后兼容

3. 在 PropertyDialogManager 中实现 registerExtensionViewWithUpdate，存储

更新器回调与创建选项

4. 修改 FilePropertyDialog 以跟踪扩展控件及其更新器，在文件重命名时调用

而非关闭对话框

5. 更新 BasicWidget::updateFileUrl 以在 URL 变化时刷新文件位置显示

6. 修复 NameTextEdit::keyPressEvent 防止 Enter 键触发重复的 editFinished

信号

7. 迁移 DirShare、Tag 和 VirtualOpenWithPlugin 使用新注册 API 并添加适当

的更新处理程序

8. 添加 renameFilePropertyDialog 辅助函数以更新对话框 URL 跟踪而不销

毁 UI

此改进提升了用户体验，文件重命名时保持属性对话框打开并动态更新所有控件内

容，避免了破坏性的关闭再打开行为。

Log: 属性对话框在文件重命名时保持打开并更新内容

Influence:

1. 测试文件重命名操作时属性对话框保持打开并更新

2. 验证共享文件夹重命名时共享控件正确更新

3. 验证标签控件更新并显示重命名文件的正确标签

4. 验证打开方式控件更新以显示正确的应用程序关联

5. 测试基本信息控件（文件位置路径）正确更新

6. 验证权限控件为重命名文件更新

7. 测试属性对话框打开时多次快速重命名

8. 验证重命名操作期间扩展控件无内存泄漏或崩溃

9. 测试取消重命名操作 - 验证对话框保持一致

10. 验证使用旧注册 API 的插件向后兼容

BUG: https://pms.uniontech.com/bug-view-343233.html
