### PR TITLE
fix: validate screen available geometry

### DIFF
--- a/include/dfm-base/interfaces/screen/abstractscreen.h
+++ b/include/dfm-base/interfaces/screen/abstractscreen.h
@@ -21,6 +21,7 @@ public:
     virtual QRect geometry() const = 0;
     virtual QRect availableGeometry() const = 0;
     virtual QRect handleGeometry() const = 0;
+    virtual bool checkAvailableGeometry(const QRect &available, const QRect &screen) const = 0;
 Q_SIGNALS:
     void geometryChanged(const QRect &);
     void availableGeometryChanged(const QRect &);

--- a/include/dfm-base/interfaces/screen/abstractscreenproxy.h
+++ b/include/dfm-base/interfaces/screen/abstractscreenproxy.h
@@ -39,6 +39,7 @@ public:
 
 protected:
     virtual void processEvent() = 0;
+    virtual bool validateEvent(Event event) const;
 
 protected:
     void appendEvent(Event);

--- a/src/dfm-base/interfaces/screen/abstractscreen.cpp
+++ b/src/dfm-base/interfaces/screen/abstractscreen.cpp
@@ -8,11 +8,6 @@ namespace dfmbase {
 
 AbstractScreen::AbstractScreen(QObject *parent) : QObject(parent)
 {
-
 }
 
 }
-
-
-
-

--- a/src/dfm-base/interfaces/screen/abstractscreenproxy.cpp
+++ b/src/dfm-base/interfaces/screen/abstractscreenproxy.cpp
@@ -44,4 +44,9 @@ void AbstractScreenProxy::appendEvent(AbstractScreenProxy::Event e)
     eventShot->start(100);
 }
 
+bool AbstractScreenProxy::validateEvent(AbstractScreenProxy::Event) const
+{
+    return true;
+}
+
 }

--- a/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.cpp
+++ b/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.cpp
@@ -286,6 +286,14 @@ void ScreenProxyQt::processEvent()
         }
     }
 
+    // 移除未通过校验的事件
+    for (auto it = events.begin(); it != events.end();) {
+        if (!validateEvent(it.key()))
+            it = events.erase(it);
+        else
+            ++it;
+    }
+
     // 事件优先级。由上往下，背景和画布模块在处理上层的事件已经处理过下层事件的涉及的改变，因此直接忽略
     if (events.contains(AbstractScreenProxy::kMode)) {
         emit displayModeChanged();
@@ -296,6 +304,22 @@ void ScreenProxyQt::processEvent()
     } else if (events.contains(AbstractScreenProxy::kAvailableGeometry)) {
         emit screenAvailableGeometryChanged();
     }
+}
+
+bool ScreenProxyQt::validateEvent(Event event) const
+{
+    if (event != AbstractScreenProxy::kAvailableGeometry)
+        return true;
+
+    for (ScreenPointer sp : logicScreens()) {
+        if (!sp->checkAvailableGeometry(sp->availableGeometry(), sp->geometry())) {
+            fmWarning() << "Invalid available geometry on screen:" << sp->name()
+                        << "available:" << sp->availableGeometry()
+                        << "screen:" << sp->geometry() << ", discarding event";
+            return false;
+        }
+    }
+    return true;
 }
 
 bool ScreenProxyQt::checkUsedScreens()

--- a/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.h
+++ b/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.h
@@ -36,6 +36,7 @@ private slots:
 
 protected:
     void processEvent() override;
+    bool validateEvent(Event event) const override;
     bool checkUsedScreens();
 
 private:

--- a/src/plugins/desktop/ddplugin-core/screen/screenqt.h
+++ b/src/plugins/desktop/ddplugin-core/screen/screenqt.h
@@ -23,9 +23,9 @@ public:
     virtual QRect availableGeometry() const override;
     virtual QRect handleGeometry() const override;
     QScreen *screen() const;
+    bool checkAvailableGeometry(const QRect &ava, const QRect &scr) const override;
 
 private:
-    bool checkAvailableGeometry(const QRect &ava, const QRect &scr) const;
     QScreen *qscreen = nullptr;
 };
 


### PR DESCRIPTION
1. Added checkAvailableGeometry virtual method to AbstractScreen
interface
2. Implemented validateEvent in ScreenProxyQt to filter invalid geometry
events
3. Modified event processing to include validation before handling
4. Added logging for invalid geometry cases

The changes address issues where incorrect availableGeometry values
could cause coordinate errors. By validating event data before
processing and filtering out invalid geometry changes, we prevent the
propagation of bad screen layout data.

Log: Fix screen coordinate errors caused by invalid available geometry

Influence:
1. Test multi-screen setups with different geometry configurations
2. Verify proper handling when available geometry exceeds screen bounds
3. Check behavior during screen configuration changes
4. Monitor logs for invalid geometry warnings

fix: 验证屏幕可用区域几何属性

1. 在 AbstractScreen 接口中添加 checkAvailableGeometry 虚方法
2. 在 ScreenProxyQt 中实现 validateEvent 方法来过滤无效的几何事件
3. 修改事件处理流程以包含处理前的验证步骤
4. 为无效几何情况添加日志记录

这些修改解决了因错误的 availableGeometry 值导致坐标错误的问题。通过在处
理前验证事件数据并过滤无效的几何变化，我们防止了不良屏幕布局数据的传播。

Log: 修复无效可用区域导致的屏幕坐标错误

Bug: https://pms.uniontech.com/bug-view-359395.html

Influence:
1. 测试不同几何配置的多显示器设置
2. 验证当可用区域超出屏幕边界时的正确处理
3. 检查屏幕配置变更时的行为
4. 监控日志中的无效几何警告

## Summary by Sourcery

Validate and filter screen geometry change events to prevent propagating invalid available geometry data in multi-screen setups.

Bug Fixes:
- Prevent screen coordinate errors by discarding availableGeometry events whose values are inconsistent with the underlying screen geometry.

Enhancements:
- Introduce a virtual checkAvailableGeometry method on AbstractScreen and a validateEvent hook on AbstractScreenProxy to allow platform-specific validation of screen geometry events.