### PR TITLE
fix: handle network disconnection during search and remote file operations

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -8,6 +8,8 @@
 #include "searchmanager/searchmanager.h"
 
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/utils/networkutils.h>
+#include <dfm-base/utils/protocolutils.h>
 
 DFMBASE_USE_NAMESPACE
 namespace dfmplugin_search {
@@ -24,6 +26,12 @@ void SearchEventReceiver::handleSearch(quint64 winId, const QString &keyword)
     Q_ASSERT(window);
 
     const auto &curUrl = window->currentUrl();
+    if (ProtocolUtils::isRemoteFile(curUrl)
+        && NetworkUtils::instance()->checkFtpOrSmbBusy(curUrl)) {
+        fmWarning() << "Network disconnected during search";
+        return;
+    }
+
     QUrl searchUrl;
     if (SearchHelper::isSearchFile(curUrl)) {
         const QUrl &targetUrl = SearchHelper::searchTargetUrl(curUrl);

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -18,6 +18,8 @@
 #include <dfm-base/utils/systempathutil.h>
 #include <dfm-base/utils/finallyutil.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/networkutils.h>
+#include <dfm-base/utils/protocolutils.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
@@ -187,10 +189,12 @@ QList<CrumbData> TitleBarHelper::crumbSeprateUrl(const QUrl &url)
         const QUrl &oneUrl = *iter;
         if (!prefixPath.startsWith(oneUrl.toLocalFile())) {
             QString displayText = oneUrl.fileName();
+            const bool networkBusy = ProtocolUtils::isRemoteFile(oneUrl)
+                && NetworkUtils::instance()->checkFtpOrSmbBusy(oneUrl);
             // Check for possible display text.
             auto infoPointer = InfoFactory::create<DFMBASE_NAMESPACE::FileInfo>(oneUrl,
                                                                                 Global::CreateFileInfoType::kCreateFileInfoSync);
-            if (infoPointer) {
+            if (!networkBusy && infoPointer) {
                 const QString &displayName = infoPointer->displayOf(DisPlayInfoType::kFileDisplayName);
                 if (!displayName.isEmpty())
                     displayText = displayName;


### PR DESCRIPTION
Added network connection checks before performing search operations on
remote files
Implemented network availability verification for title bar display info
of remote files
Added checks for FTP/SMB network busy status using NetworkUtils

These changes prevent:
1. Search operations when network is disconnected
2. Failed attempts to get file info from remote locations during network
issues
3. Improve error handling for network filesystem operations

Log: Fixed network disconnection handling during search and remote file
operations

Influence:
1. Test search functionality with remote files when network is
disconnected
2. Verify breadcrumb display for remote files during network issues
3. Check behavior when switching between networks during operations
4. Test with various remote protocol types (FTP/SMB)
5. Verify error messages when network operations fail

fix: 修复网络断开时搜索和远程文件操作的异常处理

增加在远程文件搜索前检查网络连接的功能
实现对远程文件的标题栏显示信息读取时的网络状态检查
通过NetworkUtils检查FTP/SMB网络是否繁忙

这些修改能够防止:
1. 在网络断开时进行搜索操作
2. 在网络异常时尝试获取远程文件信息
3. 改进网络文件系统操作的错误处理

Log: 修复网络断开时搜索和远程文件操作的处理问题

Influence:
1. 测试在网络断开时对远程文件的搜索功能
2. 验证网络异常时的面包屑导航显示
3. 检查在网络切换过程中的操作行为
4. 测试不同类型的远程协议(FTP/SMB)
5. 验证网络操作失败时的错误消息提示

Bug: https://pms.uniontech.com/bug-view-297965.html
