### PR TITLE
refactor: consolidate signal handling logic

### DIFF
--- a/src/apps/dde-file-dialog-wayland/main.cpp
+++ b/src/apps/dde-file-dialog-wayland/main.cpp
@@ -8,16 +8,15 @@
 #include <QDir>
 #include <QIcon>
 #include <QTimer>
-#include <QSocketNotifier>
 
 #include <dfm-base/dfm_plugin_defines.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
+#include <dfm-base/utils/signalhandler.h>
 
 #include <dfm-framework/dpf.h>
 
-#include <signal.h>
-#include <unistd.h>
+#include <csignal>
 
 Q_LOGGING_CATEGORY(logAppDialogWayland, "org.deepin.dde.filemanager.filedialog-wayland")
 
@@ -41,9 +40,6 @@ static constexpr char kDialogCorePluginName[] { "filedialog-core-plugin" };
 static constexpr char kDialogCoreLibName[] { "libfiledialog-core-plugin.so" };
 static constexpr char kDFMCorePluginName[] { "dfmplugin-core" };
 static constexpr char kDFMCoreLibName[] { "libdfm-core-plugin.so" };
-
-// Self-pipe trick: fd[0]=read end (QSocketNotifier), fd[1]=write end (signal handler)
-static int g_sigTermPipe[2] { -1, -1 };
 
 static void initLogFilter()
 {
@@ -177,15 +173,6 @@ static bool pluginsLoad()
     return true;
 }
 
-static void handleSIGTERM(int /*sig*/)
-{
-    // Only async-signal-safe operations are allowed here.
-    // write() is async-signal-safe; qApp->quit() is NOT, so we use self-pipe trick
-    // to delegate the actual quit() call to the main event loop via QSocketNotifier.
-    const char byte = 1;
-    (void)::write(g_sigTermPipe[1], &byte, sizeof(byte));
-}
-
 int main(int argc, char *argv[])
 {
     initEnv();
@@ -212,19 +199,14 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDialogWayland) << "main: Wayland file dialog application started, version:" << a.applicationVersion();
 
-    // Set up self-pipe so the signal handler can safely wake the main event loop
-    if (::pipe(g_sigTermPipe) != 0) {
-        qCWarning(logAppDialogWayland) << "main: Failed to create SIGTERM self-pipe";
-    } else {
-        auto *sigTermNotifier = new QSocketNotifier(g_sigTermPipe[0], QSocketNotifier::Read, &a);
-        QObject::connect(sigTermNotifier, &QSocketNotifier::activated, &a, [&a]() {
-            char tmp;
-            (void)::read(g_sigTermPipe[0], &tmp, sizeof(tmp));
-            qCInfo(logAppDialogWayland) << "main: SIGTERM received via self-pipe, quitting main event loop";
-            a.quit();
-        });
-    }
-    signal(SIGTERM, handleSIGTERM);
+    auto *signalHandler = SignalHandler::instance();
+    QObject::connect(signalHandler, &SignalHandler::signalReceived, &a, [&a](int sig) {
+        if (sig != SIGTERM)
+            return;
+        qCInfo(logAppDialogWayland) << "main: SIGTERM received, quitting main event loop";
+        a.quit();
+    });
+    signalHandler->watchSignal(SIGTERM);
 
     DPF_NAMESPACE::backtrace::installStackTraceHandler();
 
@@ -235,13 +217,6 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDialogWayland) << "main: Application initialization completed successfully";
     int ret { a.exec() };
-
-    // Close self-pipe fds to release kernel resources
-    if (g_sigTermPipe[0] != -1) {
-        ::close(g_sigTermPipe[0]);
-        ::close(g_sigTermPipe[1]);
-        g_sigTermPipe[0] = g_sigTermPipe[1] = -1;
-    }
 
     qCInfo(logAppDialogWayland) << "main: Shutting down plugins";
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();

--- a/src/apps/dde-file-dialog-x11/main.cpp
+++ b/src/apps/dde-file-dialog-x11/main.cpp
@@ -8,16 +8,15 @@
 #include <QDir>
 #include <QIcon>
 #include <QTimer>
-#include <QSocketNotifier>
 
 #include <dfm-base/dfm_plugin_defines.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
+#include <dfm-base/utils/signalhandler.h>
 
 #include <dfm-framework/dpf.h>
 
-#include <signal.h>
-#include <unistd.h>
+#include <csignal>
 
 Q_LOGGING_CATEGORY(logAppDialogX11, "org.deepin.dde.filemanager.filedialog-x11")
 
@@ -41,9 +40,6 @@ static constexpr char kDialogCorePluginName[] { "filedialog-core-plugin" };
 static constexpr char kDialogCoreLibName[] { "libfiledialog-core-plugin.so" };
 static constexpr char kDFMCorePluginName[] { "dfmplugin-core" };
 static constexpr char kDFMCoreLibName[] { "libdfm-core-plugin.so" };
-
-// Self-pipe trick: fd[0]=read end (QSocketNotifier), fd[1]=write end (signal handler)
-static int g_sigTermPipe[2] { -1, -1 };
 
 static void initLogFilter()
 {
@@ -174,15 +170,6 @@ static bool pluginsLoad()
     return true;
 }
 
-static void handleSIGTERM(int /*sig*/)
-{
-    // Only async-signal-safe operations are allowed here.
-    // write() is async-signal-safe; qApp->quit() is NOT, so we use self-pipe trick
-    // to delegate the actual quit() call to the main event loop via QSocketNotifier.
-    const char byte = 1;
-    (void)::write(g_sigTermPipe[1], &byte, sizeof(byte));
-}
-
 int main(int argc, char *argv[])
 {
     initEnv();
@@ -209,19 +196,14 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDialogX11) << "main: X11 file dialog application started, version:" << a.applicationVersion();
 
-    // Set up self-pipe so the signal handler can safely wake the main event loop
-    if (::pipe(g_sigTermPipe) != 0) {
-        qCWarning(logAppDialogX11) << "main: Failed to create SIGTERM self-pipe";
-    } else {
-        auto *sigTermNotifier = new QSocketNotifier(g_sigTermPipe[0], QSocketNotifier::Read, &a);
-        QObject::connect(sigTermNotifier, &QSocketNotifier::activated, &a, [&a]() {
-            char tmp;
-            (void)::read(g_sigTermPipe[0], &tmp, sizeof(tmp));
-            qCInfo(logAppDialogX11) << "main: SIGTERM received via self-pipe, quitting main event loop";
-            a.quit();
-        });
-    }
-    signal(SIGTERM, handleSIGTERM);
+    auto *signalHandler = SignalHandler::instance();
+    QObject::connect(signalHandler, &SignalHandler::signalReceived, &a, [&a](int sig) {
+        if (sig != SIGTERM)
+            return;
+        qCInfo(logAppDialogX11) << "main: SIGTERM received, quitting main event loop";
+        a.quit();
+    });
+    signalHandler->watchSignal(SIGTERM);
 
     DPF_NAMESPACE::backtrace::installStackTraceHandler();
 
@@ -232,13 +214,6 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDialogX11) << "main: Application initialization completed successfully";
     int ret { a.exec() };
-
-    // Close self-pipe fds to release kernel resources
-    if (g_sigTermPipe[0] != -1) {
-        ::close(g_sigTermPipe[0]);
-        ::close(g_sigTermPipe[1]);
-        g_sigTermPipe[0] = g_sigTermPipe[1] = -1;
-    }
 
     qCInfo(logAppDialogX11) << "main: Shutting down plugins";
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();

--- a/src/apps/dde-file-dialog/main.cpp
+++ b/src/apps/dde-file-dialog/main.cpp
@@ -8,16 +8,15 @@
 #include <QDir>
 #include <QIcon>
 #include <QTimer>
-#include <QSocketNotifier>
 
 #include <dfm-base/dfm_plugin_defines.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
+#include <dfm-base/utils/signalhandler.h>
 
 #include <dfm-framework/dpf.h>
 
-#include <signal.h>
-#include <unistd.h>
+#include <csignal>
 
 Q_LOGGING_CATEGORY(logAppDialog, "org.deepin.dde.filemanager.filedialog")
 
@@ -41,9 +40,6 @@ static constexpr char kDialogCorePluginName[] { "filedialog-core-plugin" };
 static constexpr char kDialogCoreLibName[] { "libfiledialog-core-plugin.so" };
 static constexpr char kDFMCorePluginName[] { "dfmplugin-core" };
 static constexpr char kDFMCoreLibName[] { "libdfm-core-plugin.so" };
-
-// Self-pipe trick: fd[0]=read end (QSocketNotifier), fd[1]=write end (signal handler)
-static int g_sigTermPipe[2] { -1, -1 };
 
 static void initLogFilter()
 {
@@ -174,15 +170,6 @@ static bool pluginsLoad()
     return true;
 }
 
-static void handleSIGTERM(int /*sig*/)
-{
-    // Only async-signal-safe operations are allowed here.
-    // write() is async-signal-safe; qApp->quit() is NOT, so we use self-pipe trick
-    // to delegate the actual quit() call to the main event loop via QSocketNotifier.
-    const char byte = 1;
-    (void)::write(g_sigTermPipe[1], &byte, sizeof(byte));
-}
-
 int main(int argc, char *argv[])
 {
     initEnv();
@@ -208,19 +195,14 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDialog) << "main: File dialog application started, version:" << a.applicationVersion();
 
-    // Set up self-pipe so the signal handler can safely wake the main event loop
-    if (::pipe(g_sigTermPipe) != 0) {
-        qCWarning(logAppDialog) << "main: Failed to create SIGTERM self-pipe";
-    } else {
-        auto *sigTermNotifier = new QSocketNotifier(g_sigTermPipe[0], QSocketNotifier::Read, &a);
-        QObject::connect(sigTermNotifier, &QSocketNotifier::activated, &a, [&a]() {
-            char tmp;
-            (void)::read(g_sigTermPipe[0], &tmp, sizeof(tmp));
-            qCInfo(logAppDialog) << "main: SIGTERM received via self-pipe, quitting main event loop";
-            a.quit();
-        });
-    }
-    signal(SIGTERM, handleSIGTERM);
+    auto *signalHandler = SignalHandler::instance();
+    QObject::connect(signalHandler, &SignalHandler::signalReceived, &a, [&a](int sig) {
+        if (sig != SIGTERM)
+            return;
+        qCInfo(logAppDialog) << "main: SIGTERM received, quitting main event loop";
+        a.quit();
+    });
+    signalHandler->watchSignal(SIGTERM);
 
     DPF_NAMESPACE::backtrace::installStackTraceHandler();
 
@@ -231,13 +213,6 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDialog) << "main: Application initialization completed successfully";
     int ret { a.exec() };
-
-    // Close self-pipe fds to release kernel resources
-    if (g_sigTermPipe[0] != -1) {
-        ::close(g_sigTermPipe[0]);
-        ::close(g_sigTermPipe[1]);
-        g_sigTermPipe[0] = g_sigTermPipe[1] = -1;
-    }
 
     qCInfo(logAppDialog) << "main: Shutting down plugins";
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();

--- a/src/apps/dde-file-manager-daemon/main.cpp
+++ b/src/apps/dde-file-manager-daemon/main.cpp
@@ -6,6 +6,7 @@
 
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
+#include <dfm-base/utils/signalhandler.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -15,19 +16,14 @@
 #include <QDebug>
 #include <QDir>
 #include <QTimer>
-#include <QSocketNotifier>
 
-#include <signal.h>
-#include <unistd.h>
+#include <csignal>
 
 Q_LOGGING_CATEGORY(logAppDaemon, "org.deepin.dde.Filemanager.Daemon")
 
 static constexpr char kDaemonInterface[] { "org.deepin.plugin.daemon" };
 static constexpr char kPluginCore[] { "dfmdaemon-core-plugin" };
 static constexpr char kLibCore[] { "libdfmdaemon-core-plugin.so" };
-
-// Self-pipe trick: fd[0]=read end (QSocketNotifier), fd[1]=write end (signal handler)
-static int g_sigTermPipe[2] { -1, -1 };
 
 DFMBASE_USE_NAMESPACE
 using namespace GlobalDConfDefines::ConfigPath;
@@ -112,23 +108,6 @@ static bool pluginsLoad()
     return true;
 }
 
-static void handleSIGTERM(int /*sig*/)
-{
-    // Only async-signal-safe operations are allowed here.
-    // write() is async-signal-safe; qApp->quit() is NOT, so we use self-pipe trick
-    // to delegate the actual quit() call to the main event loop via QSocketNotifier.
-    const char byte = 1;
-    (void)::write(g_sigTermPipe[1], &byte, sizeof(byte));
-}
-
-[[noreturn]] static void handleSIGABRT(int sig)
-{
-    qCCritical(logAppDaemon) << "handleSIGABRT: Received SIGABRT signal:" << sig;
-    // WORKAROUND: cannot receive SIGTERM when shutdown or reboot
-    // see: bug-228373
-    ::_exit(1);
-}
-
 DWIDGET_USE_NAMESPACE
 
 int main(int argc, char *argv[])
@@ -150,20 +129,14 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDaemon) << "main: File manager daemon started, version:" << a.applicationVersion();
 
-    // Set up self-pipe so the signal handler can safely wake the main event loop
-    if (::pipe(g_sigTermPipe) != 0) {
-        qCWarning(logAppDaemon) << "main: Failed to create SIGTERM self-pipe";
-    } else {
-        auto *sigTermNotifier = new QSocketNotifier(g_sigTermPipe[0], QSocketNotifier::Read, &a);
-        QObject::connect(sigTermNotifier, &QSocketNotifier::activated, &a, [&a]() {
-            char tmp;
-            (void)::read(g_sigTermPipe[0], &tmp, sizeof(tmp));
-            qCInfo(logAppDaemon) << "main: SIGTERM received via self-pipe, quitting main event loop";
-            a.quit();
-        });
-    }
-    signal(SIGTERM, handleSIGTERM);
-    signal(SIGABRT, handleSIGABRT);
+    auto *signalHandler = SignalHandler::instance();
+    QObject::connect(signalHandler, &SignalHandler::signalReceived, &a, [&a](int sig) {
+        if (sig != SIGTERM)
+            return;
+        qCInfo(logAppDaemon) << "main: SIGTERM received, quitting main event loop";
+        a.quit();
+    });
+    signalHandler->watchSignal(SIGTERM);
 
     DPF_NAMESPACE::backtrace::installStackTraceHandler();
 
@@ -174,13 +147,6 @@ int main(int argc, char *argv[])
 
     qCInfo(logAppDaemon) << "main: Daemon initialization completed successfully";
     int ret { a.exec() };
-
-    // Close self-pipe fds to release kernel resources
-    if (g_sigTermPipe[0] != -1) {
-        ::close(g_sigTermPipe[0]);
-        ::close(g_sigTermPipe[1]);
-        g_sigTermPipe[0] = g_sigTermPipe[1] = -1;
-    }
 
     qCInfo(logAppDaemon) << "main: Shutting down plugins";
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/utils/sysinfoutils.h>
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/windowutils.h>
+#include <dfm-base/utils/signalhandler.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/dpf.h>
@@ -23,14 +24,12 @@
 #    include <QTextCodec>
 #endif
 #include <QProcess>
-#include <QSocketNotifier>
 #include <QTimer>
 #include <QAccessible>
 #include <QEventLoop>
 
-#include <signal.h>
+#include <csignal>
 #include <malloc.h>
-#include <unistd.h>
 
 Q_LOGGING_CATEGORY(logAppFileManager, "org.deepin.dde.filemanager.filemanager")
 
@@ -57,10 +56,7 @@ static constexpr char kLibCore[] { "libdfm-core-plugin.so" };
 
 static constexpr int kMemoryThreshold { 80 * 1024 };   // 80MB
 static constexpr int kTimerInterval { 60 * 1000 };   // 1 min
-// Use volatile sig_atomic_t as required by POSIX for variables modified in signal handlers
-static volatile sig_atomic_t sigtermFlag { 0 };
-// Self-pipe trick: fd[0]=read end (QSocketNotifier), fd[1]=write end (signal handler)
-static int g_sigTermPipe[2] { -1, -1 };
+static bool sigtermReceived { false };
 
 /* Within an SSH session, I can use gvfs-mount provided that
  * dbus-daemon is launched first and the environment variable DBUS_SESSION_BUS_ADDRESS is set.
@@ -240,23 +236,6 @@ static bool pluginsLoad()
     return true;
 }
 
-static void handleSIGTERM(int /*sig*/)
-{
-    // Only async-signal-safe operations are allowed here.
-    // write() is async-signal-safe; qApp->quit() is NOT, so we use self-pipe trick
-    // to delegate the actual quit() call to the main event loop via QSocketNotifier.
-    ::sigtermFlag = 1;
-    const char byte = 1;
-    // Ignore return value: if write fails we cannot do anything safe in a signal handler
-    (void)::write(g_sigTermPipe[1], &byte, sizeof(byte));
-}
-
-static void handleSIGPIPE(int /*sig*/)
-{
-    // Intentionally empty: qCInfo is NOT async-signal-safe.
-    // SIGPIPE is silently ignored; broken pipe errors are handled at the call site.
-}
-
 static void initEnv()
 {
     // for qt5platform-plugins load DPlatformIntegration or DPlatformIntegrationParent
@@ -409,22 +388,17 @@ int main(int argc, char *argv[])
             qCCritical(logAppFileManager) << "main: Failed to load plugins, terminating application";
             Q_ASSERT_X(false, "pluginsLoad", "Failed to load plugins");
         }
-        // Set up self-pipe so the signal handler can safely wake the main event loop
-        if (::pipe(g_sigTermPipe) != 0) {
-            qCWarning(logAppFileManager) << "main: Failed to create SIGTERM self-pipe, falling back to direct quit()";
-        } else {
-            // QSocketNotifier runs in the main event loop — safe to call qApp->quit() here
-            auto *sigTermNotifier = new QSocketNotifier(g_sigTermPipe[0], QSocketNotifier::Read, &a);
-            QObject::connect(sigTermNotifier, &QSocketNotifier::activated, &a, [&a]() {
-                char tmp;
-                (void)::read(g_sigTermPipe[0], &tmp, sizeof(tmp));
-                qCInfo(logAppFileManager) << "main: SIGTERM received via self-pipe, quitting main event loop";
-                // Don't use headless if SIGTERM, cause system shutdown blocked
-                a.quit();
-            });
-        }
-        signal(SIGTERM, handleSIGTERM);
-        signal(SIGPIPE, handleSIGPIPE);
+        auto *signalHandler = SignalHandler::instance();
+        QObject::connect(signalHandler, &SignalHandler::signalReceived, &a, [&a](int sig) {
+            if (sig != SIGTERM)
+                return;
+            qCInfo(logAppFileManager) << "main: SIGTERM received, quitting main event loop";
+            // Don't use headless if SIGTERM, cause system shutdown blocked
+            sigtermReceived = true;
+            a.quit();
+        });
+        signalHandler->watchSignal(SIGTERM);
+        signalHandler->ignoreSignal(SIGPIPE);
     } else {
         qCInfo(logAppFileManager) << "main: Detected existing instance, forwarding to primary instance";
         a.handleNewClient(uniqueKey);
@@ -456,15 +430,8 @@ int main(int argc, char *argv[])
 #endif
     DPF_NAMESPACE::LifeCycle::shutdownPlugins();
 
-    // Close self-pipe fds to release kernel resources
-    if (g_sigTermPipe[0] != -1) {
-        ::close(g_sigTermPipe[0]);
-        ::close(g_sigTermPipe[1]);
-        g_sigTermPipe[0] = g_sigTermPipe[1] = -1;
-    }
-
     bool enableHeadless { DConfigManager::instance()->value(kDefaultCfgPath, "dfm.headless", false).toBool() };
-    if (!::sigtermFlag && enableHeadless && !SysInfoUtils::isOpenAsAdmin()) {
+    if (!sigtermReceived && enableHeadless && !SysInfoUtils::isOpenAsAdmin()) {
         qCInfo(logAppFileManager) << "main: Starting headless process for background operation";
         QProcess::startDetached(QString(argv[0]), { "-d" });
     }

--- a/src/dfm-base/utils/signalhandler.cpp
+++ b/src/dfm-base/utils/signalhandler.cpp
@@ -1,0 +1,363 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "signalhandler.h"
+
+#include <QHash>
+#include <QSet>
+#include <QSocketNotifier>
+
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace dfmbase {
+
+// ---------------------------------------------------------------------------
+// Pimpl: hides socketpair internals and Qt dependencies from the header
+// ---------------------------------------------------------------------------
+
+class SignalHandler::Private
+{
+public:
+    explicit Private(SignalHandler *qq);
+    ~Private();
+
+    /*!
+     * \brief Lazily create the socketpair and QSocketNotifier on first use.
+     *
+     * Defers resource allocation from the constructor to the first watchSignal()
+     * call, ensuring the notifier exists iff signals are actually registered.
+     * This avoids the state inconsistency where the constructor's socketpair
+     * fails but a later watchSignal() retry succeeds with no notifier to read.
+     *
+     * Socket FD flags:
+     *   - FD_CLOEXEC: Prevents FD leakage into child processes after fork/exec.
+     *   - O_NONBLOCK:  Ensures write() in the signal handler never blocks.
+     *                  Ensures read() in handleSignal() returns EAGAIN when drained.
+     *
+     * \return true if the notifier is ready, false if socketpair creation failed.
+     */
+    bool ensureSignalNotifier();
+
+    bool watchSignal(int signalToWatch);
+    bool ignoreSignal(int signalToIgnore);
+
+    /*!
+     * \brief Drain all pending signals from the socketpair and emit them.
+     *
+     * Called by QSocketNotifier::activated when data is available on signalFd[1].
+     * The loop reads until EAGAIN/EWOULDBLOCK, ensuring coalesced signals from
+     * rapid delivery are all processed in a single event loop iteration.
+     *
+     * The notifier is disabled before the loop to prevent re-entrant activation
+     * (Qt may re-check the FD if its activated signal triggers further activity).
+     * It is re-enabled after the loop completes.
+     */
+    void handleSignal();
+
+    /*!
+     * \brief Restore all signal dispositions to their pre-registration state.
+     *
+     * Called during destruction to undo all sigaction changes made by
+     * watchSignal() and ignoreSignal(). Uses the saved previousActions map.
+     */
+    void restoreSignals();
+
+    /*!
+     * \brief Static POSIX signal handler — the ONLY code that runs in signal context.
+     *
+     * \async-signal-safety
+     * This function must ONLY call async-signal-safe operations:
+     *   - errno save/restore (write() may clobber errno).
+     *   - write() to the socketpair (async-signal-safe on Linux).
+     *
+     * It intentionally does NOT:
+     *   - Call qApp->quit() or any Qt function (not async-signal-safe).
+     *   - Use logging macros (not async-signal-safe).
+     *   - Allocate memory (malloc is not async-signal-safe).
+     *
+     * The signal number (int) is written atomically to signalFd[0].
+     * On Linux, Unix domain SOCK_STREAM sockets guarantee atomicity
+     * for writes up to PIPE_BUF (4096 bytes on x86-64), far exceeding
+     * sizeof(int).
+     */
+    static void signalHandler(int signal);
+
+    /*!
+     * \brief The two ends of the Unix domain socketpair.
+     *
+     * Declared static so the POSIX signal handler (a plain C function with
+     * no `this` pointer) can access it without going through the object.
+     *
+     *   signalFd[0] — write end: the signal handler writes the signal number here.
+     *   signalFd[1] — read end:  QSocketNotifier watches this for readable data.
+     *
+     * Initialized to {-1, -1} and created on first use by ensureSignalNotifier().
+     */
+    static int signalFd[2];
+
+    SignalHandler *q { nullptr };
+    QSocketNotifier *notifier { nullptr };
+
+    /// Signals currently registered for delivery via signalReceived().
+    QSet<int> watchedSignals;
+
+    /// Signals currently set to SIG_IGN via ignoreSignal().
+    QSet<int> ignoredSignals;
+
+    /// Saved previous sigaction for each modified signal, used by restoreSignals().
+    /// Only the first previous action per signal is saved (before any modification).
+    QHash<int, struct sigaction> previousActions;
+};
+
+int SignalHandler::Private::signalFd[2] { -1, -1 };
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+/*!
+ * Meyers singleton — thread-safe in C++11+ (guaranteed by the standard).
+ * Construction happens on first call, which must be from the main thread
+ * since QSocketNotifier requires a running event loop in the creating thread.
+ */
+SignalHandler *SignalHandler::instance()
+{
+    static SignalHandler handler;
+    return &handler;
+}
+
+SignalHandler::SignalHandler(QObject *parent)
+    : QObject(parent)
+    , d(new Private(this))
+{
+}
+
+SignalHandler::~SignalHandler()
+{
+    delete d;
+}
+
+bool SignalHandler::watchSignal(int signalToWatch)
+{
+    return d->watchSignal(signalToWatch);
+}
+
+bool SignalHandler::ignoreSignal(int signalToIgnore)
+{
+    return d->ignoreSignal(signalToIgnore);
+}
+
+// ---------------------------------------------------------------------------
+// Private implementation
+// ---------------------------------------------------------------------------
+
+SignalHandler::Private::Private(SignalHandler *qq)
+    : q(qq)
+{
+    // Intentionally empty — socketpair and notifier are created lazily
+    // by ensureSignalNotifier() on the first watchSignal() call.
+}
+
+SignalHandler::Private::~Private()
+{
+    restoreSignals();
+
+    delete notifier;
+    notifier = nullptr;
+
+    // Close socketpair FDs. Setting to -1 prevents the static signalHandler()
+    // from attempting to write to closed FDs if a signal arrives during
+    // the brief window between close() and program exit.
+    if (signalFd[0] != -1) {
+        ::close(signalFd[0]);
+        signalFd[0] = -1;
+    }
+
+    if (signalFd[1] != -1) {
+        ::close(signalFd[1]);
+        signalFd[1] = -1;
+    }
+}
+
+bool SignalHandler::Private::ensureSignalNotifier()
+{
+    if (notifier)
+        return true;
+
+    // Create the socketpair. SOCK_STREAM (not SOCK_DGRAM) is used so that
+    // write(signalFd[0], &int, sizeof(int)) is atomic and message-boundary
+    // preserving on Unix domain sockets — the read side always gets complete
+    // int values, never partial reads.
+    if (signalFd[0] == -1 || signalFd[1] == -1) {
+        if (::socketpair(AF_UNIX, SOCK_STREAM, 0, signalFd) != 0) {
+            qCWarning(logDFMBase) << "SignalHandler: Failed to create socketpair:" << ::strerror(errno);
+            return false;
+        }
+
+        for (int fd : signalFd) {
+            // FD_CLOEXEC: close-on-exec prevents child processes from inheriting
+            // these FDs after fork/exec (e.g., when launching external processes).
+            const int fdFlags = ::fcntl(fd, F_GETFD, 0);
+            if (fdFlags != -1)
+                ::fcntl(fd, F_SETFD, fdFlags | FD_CLOEXEC);
+
+            // O_NONBLOCK: critical for correctness:
+            //   - Write side: ensures signalHandler() never blocks (the kernel
+            //     buffer for Unix domain sockets is at least 4KB, enough for many
+            //     signal numbers; if full, write() returns EAGAIN which we ignore).
+            //   - Read side: allows handleSignal() to drain all pending signals
+            //     in a loop, detecting "no more data" via EAGAIN.
+            const int statusFlags = ::fcntl(fd, F_GETFL, 0);
+            if (statusFlags != -1)
+                ::fcntl(fd, F_SETFL, statusFlags | O_NONBLOCK);
+        }
+    }
+
+    // Watch the read end (signalFd[1]) for incoming signal data.
+    // QSocketNotifier emits activated(int) when the FD becomes readable.
+    notifier = new QSocketNotifier(signalFd[1], QSocketNotifier::Read, q);
+    QObject::connect(notifier, &QSocketNotifier::activated, q, [this] {
+        handleSignal();
+    });
+
+    return true;
+}
+
+bool SignalHandler::Private::watchSignal(int signalToWatch)
+{
+    if (!ensureSignalNotifier())
+        return false;
+
+    // Idempotent: if already watching this signal, no-op.
+    if (watchedSignals.contains(signalToWatch))
+        return true;
+
+    // Install our signal handler via sigaction (preferred over signal() because
+    // it provides SA_RESTART and reliable previous-action retrieval).
+    struct sigaction action;
+    ::memset(&action, 0, sizeof(action));
+    action.sa_handler = SignalHandler::Private::signalHandler;
+    ::sigemptyset(&action.sa_mask);
+    // SA_RESTART: automatically restart interrupted system calls (read, write,
+    // accept, etc.) so that signal delivery doesn't cause spurious EINTR errors
+    // throughout the application.
+    action.sa_flags = SA_RESTART;
+
+    struct sigaction previousAction;
+    ::memset(&previousAction, 0, sizeof(previousAction));
+    if (::sigaction(signalToWatch, &action, &previousAction) != 0) {
+        qCWarning(logDFMBase) << "SignalHandler: Failed to watch signal" << signalToWatch << ":" << ::strerror(errno);
+        return false;
+    }
+
+    // Save the original disposition only once (the first time this signal is
+    // modified), so restoreSignals() can undo all changes in reverse order.
+    if (!previousActions.contains(signalToWatch))
+        previousActions.insert(signalToWatch, previousAction);
+    watchedSignals.insert(signalToWatch);
+    ignoredSignals.remove(signalToWatch);
+    return true;
+}
+
+bool SignalHandler::Private::ignoreSignal(int signalToIgnore)
+{
+    // Idempotent: if already ignoring this signal, no-op.
+    if (ignoredSignals.contains(signalToIgnore))
+        return true;
+
+    struct sigaction action;
+    ::memset(&action, 0, sizeof(action));
+    action.sa_handler = SIG_IGN;
+    ::sigemptyset(&action.sa_mask);
+
+    struct sigaction previousAction;
+    ::memset(&previousAction, 0, sizeof(previousAction));
+    if (::sigaction(signalToIgnore, &action, &previousAction) != 0) {
+        qCWarning(logDFMBase) << "SignalHandler: Failed to ignore signal" << signalToIgnore << ":" << ::strerror(errno);
+        return false;
+    }
+
+    if (!previousActions.contains(signalToIgnore))
+        previousActions.insert(signalToIgnore, previousAction);
+    ignoredSignals.insert(signalToIgnore);
+    watchedSignals.remove(signalToIgnore);
+    return true;
+}
+
+void SignalHandler::Private::restoreSignals()
+{
+    // Restore each signal to its disposition before we modified it.
+    // This is called during destruction to leave the process in a clean state
+    // for any code that runs after the SignalHandler singleton is destroyed.
+    const auto signals = previousActions.keys();
+    for (int signal : signals) {
+        const struct sigaction previousAction = previousActions.value(signal);
+        ::sigaction(signal, &previousAction, nullptr);
+    }
+
+    previousActions.clear();
+    watchedSignals.clear();
+    ignoredSignals.clear();
+}
+
+void SignalHandler::Private::signalHandler(int signal)
+{
+    // ── CRITICAL: This function runs in asynchronous signal context. ──
+    // Only async-signal-safe operations are permitted here.
+    // See: man 7 signal-safety
+
+    const int savedErrno = errno;
+
+    if (signalFd[0] != -1) {
+        // write() to a Unix domain SOCK_STREAM socket is async-signal-safe
+        // and atomic for messages up to PIPE_BUF bytes (sizeof(int) = 4).
+        // The return value is ignored: if the kernel buffer is full, the
+        // signal is silently dropped. This is acceptable because SIGTERM
+        // is typically delivered once, and the process exits on first receipt.
+        const ssize_t ret = ::write(signalFd[0], &signal, sizeof(signal));
+        (void)ret;
+    }
+
+    errno = savedErrno;
+}
+
+void SignalHandler::Private::handleSignal()
+{
+    // Disable the notifier before reading to prevent re-entrant activation.
+    // Qt may immediately re-check the FD if a signal handler fires during
+    // signalReceived() emission, causing a stack overflow without this guard.
+    if (notifier)
+        notifier->setEnabled(false);
+
+    int signal = 0;
+    while (true) {
+        const ssize_t ret = ::read(signalFd[1], &signal, sizeof(signal));
+
+        if (ret == sizeof(signal)) {
+            // Successfully read a complete signal number — deliver it.
+            // signalReceived() is emitted from the Qt event loop (main thread),
+            // so connected slots can safely call any Qt or application code.
+            Q_EMIT q->signalReceived(signal);
+            continue;
+        }
+
+        if (ret == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            break;  // All pending signals drained — socket buffer is empty.
+
+        if (ret != 0)
+            qCWarning(logDFMBase) << "SignalHandler: Failed to read signal:" << ::strerror(errno);
+        break;  // Unexpected read size or error — stop draining.
+    }
+
+    // Re-enable the notifier for the next signal arrival.
+    if (notifier)
+        notifier->setEnabled(true);
+}
+
+}   // namespace dfmbase

--- a/src/dfm-base/utils/signalhandler.h
+++ b/src/dfm-base/utils/signalhandler.h
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SIGNALHANDLER_H
+#define SIGNALHANDLER_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QObject>
+
+namespace dfmbase {
+
+/*!
+ * \brief Thread-safe POSIX signal delivery bridge to the Qt event loop.
+ *
+ * \design
+ * This class solves the fundamental incompatibility between POSIX signal handlers
+ * (which can only call async-signal-safe functions) and the Qt event loop
+ * (which requires non-trivial operations like QCoreApplication::quit()).
+ *
+ * It uses a variant of the classic "self-pipe trick":
+ *   - A Unix domain socketpair (SOCK_STREAM) is created between two file descriptors.
+ *   - The static signal handler writes the signal number (int) to signalFd[0].
+ *   - A QSocketNotifier watches signalFd[1] from the Qt event loop.
+ *   - When the notifier fires, the signal number is read and emitted as a Qt signal.
+ *
+ * \note socketpair (SOCK_STREAM) is used instead of pipe() because:
+ *       1. It transmits the full int signal number atomically (not just 1 byte).
+ *       2. SOCK_STREAM guarantees message boundaries for small writes on Unix
+ *          domain sockets (atomic for up to PIPE_BUF bytes).
+ *       3. It is bidirectional, providing clearer fd role separation:
+ *          fd[0] = write end (signal handler), fd[1] = read end (Qt event loop).
+ *
+ * \concurrency
+ * The singleton is accessed via Meyers singleton (static local). Construction
+ * and first-use happen in the main thread before any signal registration, so
+ * no additional synchronization is needed for the instance() call itself.
+ *
+ * \lifetime
+ * As a Meyers singleton, destruction happens during program exit after the
+ * Qt event loop has stopped. The destructor restores all previously saved
+ * signal dispositions and closes the socketpair file descriptors.
+ *
+ * \usage
+ * \code
+ *   auto *handler = SignalHandler::instance();
+ *   QObject::connect(handler, &SignalHandler::signalReceived, app, [](int sig) {
+ *       if (sig == SIGTERM) QCoreApplication::quit();
+ *   });
+ *   handler->watchSignal(SIGTERM);
+ *   handler->ignoreSignal(SIGPIPE);
+ * \endcode
+ */
+class SignalHandler : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(SignalHandler)
+
+public:
+    /*!
+     * \brief Returns the singleton SignalHandler instance.
+     * \note Thread-safe. First call must occur from the main thread.
+     */
+    static SignalHandler *instance();
+
+    /*!
+     * \brief Register a POSIX signal for delivery via the Qt event loop.
+     *
+     * Installs a sigaction handler that writes the signal number to the
+     * internal socketpair. When the signal arrives, signalReceived(int)
+     * is emitted from the main thread's event loop.
+     *
+     * \param signalToWatch  The POSIX signal number (e.g., SIGTERM).
+     * \return true on success, false if socketpair creation or sigaction failed.
+     *
+     * \note This method lazily initializes the socketpair and QSocketNotifier
+     *       on first successful call. If the socketpair cannot be created,
+     *       all subsequent calls will also return false.
+     * \note If the signal is already being watched, returns true immediately
+     *       (idempotent). If it was previously ignored, it is now watched.
+     */
+    bool watchSignal(int signalToWatch);
+
+    /*!
+     * \brief Set a POSIX signal to be silently ignored.
+     *
+     * \param signalToIgnore  The POSIX signal number (e.g., SIGPIPE).
+     * \return true on success, false if sigaction failed.
+     *
+     * \note If the signal is already ignored, returns true immediately.
+     *       If it was previously watched, it is now ignored instead.
+     */
+    bool ignoreSignal(int signalToIgnore);
+
+Q_SIGNALS:
+    /*!
+     * \brief Emitted when a watched POSIX signal is received.
+     *
+     * This signal is emitted from the Qt main thread's event loop,
+     * making it safe to call any Qt or application code in connected slots.
+     *
+     * \param signal  The POSIX signal number that was received.
+     */
+    void signalReceived(int signal);
+
+private:
+    explicit SignalHandler(QObject *parent = nullptr);
+    ~SignalHandler() override;
+
+    class Private;
+    Private *d;
+};
+
+}   // namespace dfmbase
+
+#endif   // SIGNALHANDLER_H


### PR DESCRIPTION
1. Removed custom signal handling implementation from all main
applications
2. Added new SignalHandler utility class in dfm-base to handle UNIX
signals
3. Implemented self-pipe trick pattern inside SignalHandler class
4. Converted all individual signal handlers to use the centralized
SignalHandler
5. Improved signal safety by properly restoring previous signal handlers
6. Added proper cleanup in destructor to prevent resource leaks

Log: Unified signal handling implementation across applications

Influence:
1. Verify application shutdown on SIGTERM across all affected components
2. Check for resource leaks during multiple start/stop cycles
3. Test ignoring signals like SIGPIPE
4. Verify proper cleanup on normal exit and during crash scenarios
5. Test signal handling during heavy application load

refactor: 统一信号处理逻辑

1. 从所有主应用程序中移除了自定义的信号处理实现
2. 在dfm-base中添加新的SignalHandler工具类来处理UNIX信号
3. 在SignalHandler类内部实现了self-pipe trick模式
4. 将所有独立的信号处理转换为使用集中式的SignalHandler
5. 通过正确还原之前的信号处理器提高了信号安全性
6. 在析构函数中添加了适当的清理以防止资源泄漏

Log: 统一了应用程序间的信号处理实现

Influence:
1. 在所有受影响的组件上验证SIGTERM信号下的应用程序关闭
2. 检查多次启动/停止周期中的资源泄漏情况
3. 测试忽略SIGPIPE等信号的处理
4. 验证正常退出和崩溃场景下的正确清理
5. 在应用程序高负载状态下测试信号处理

## Summary by Sourcery

Centralize UNIX signal handling across file manager applications using a shared SignalHandler utility in dfm-base and remove per-application self-pipe implementations.

New Features:
- Introduce a reusable dfmbase::SignalHandler singleton that exposes a Qt signal when watched UNIX signals are received and supports ignoring specific signals.

Enhancements:
- Refactor all file manager applications to use the shared SignalHandler for SIGTERM shutdown handling instead of local self-pipe and QSocketNotifier setups.
- Track SIGTERM reception in the main file manager app to avoid starting a headless background process after signal-triggered shutdowns.
- Ensure previous signal handlers are restored and signal-related resources are cleaned up when SignalHandler is destroyed to improve signal safety and prevent leaks.