### PR TITLE
fix: prevent auth dialog when auto-mounting hot-plugged devices

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -843,7 +843,7 @@ void DeviceManager::doAutoMount(const QString &id, DeviceType type, int timeout)
             return;
 
         qCInfo(logDFMBase) << "Starting auto mount for block device:" << id;
-        mountBlockDevAsync(id, {}, cb, timeout);
+        mountBlockDevAsync(id, { { "auth.no_user_interaction", true } }, cb, timeout);
     }
 }
 


### PR DESCRIPTION
- Add 'auth.no_user_interaction' option to doAutoMount for block devices
- Align behavior with mountAllBlockDev which already uses this option
- Fixes spurious authentication prompts during frequent USB plug/unplug

修复(device): 防止热插拔设备自动挂载时弹出鉴权窗口

- 为doAutoMount添加'auth.no_user_interaction'挂载选项
- 与mountAllBlockDev行为保持一致，该函数已使用此选项
- 修复频繁拔插U盘时偶发的身份验证弹窗问题

Log: 修复热插拔设备自动挂载时触发鉴权窗口的问题
Bug: https://pms.uniontech.com/bug-view-359849.html

## Summary by Sourcery

Bug Fixes:
- Suppress spurious authentication dialogs during automatic mounting of frequently plugged/unplugged USB and other block devices by enabling non-interactive auth for auto-mount operations.