### PR TITLE
feat: pass launch_type when launching apps via DBus

### DIFF
--- a/src/dfm-base/utils/applaunchutils.cpp
+++ b/src/dfm-base/utils/applaunchutils.cpp
@@ -94,7 +94,7 @@ bool AppLaunchUtilsPrivate::launchByDBus(const QString &desktopFile, const QStri
         return false;
     }
 
-    QVariantMap options;
+    QVariantMap options{{QStringLiteral("_launch_type"), QVariant::fromValue(3)}};
 
     QDBusMessage reply = interface->callWithArgumentList(QDBus::Block,
                                                          "Launch",


### PR DESCRIPTION
通过 DBus 启动应用时传入 launch_type 参数，用于应用启动埋点统计。
launch_type=3 表示从桌面图标双击启动。

Pass launch_type parameter when launching applications via DBus for application launch event reporting. launch_type=3 indicates the app was launched by double-clicking a desktop icon.

PMS: TASK-388657

## Summary by Sourcery

New Features:
- Pass a fixed launch_type value when launching applications over DBus to distinguish desktop icon double-click launches.