### PR TITLE
refactor: improve headless process startup implementation

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -433,7 +433,14 @@ int main(int argc, char *argv[])
     bool enableHeadless { DConfigManager::instance()->value(kDefaultCfgPath, "dfm.headless", false).toBool() };
     if (!sigtermReceived && enableHeadless && !SysInfoUtils::isOpenAsAdmin()) {
         qCInfo(logAppFileManager) << "main: Starting headless process for background operation";
-        QProcess::startDetached(QString(argv[0]), { "-d" });
+        QProcess process;
+        process.setProgram("dde-file-manager");
+        process.setArguments({"-d"});
+        process.setUnixProcessParameters(QProcess::UnixProcessFlag::CloseFileDescriptors);
+        process.setStandardOutputFile(QProcess::nullDevice());
+        process.setStandardErrorFile(QProcess::nullDevice());
+        qint64 pid;
+        process.startDetached(&pid);
     }
 
     qCInfo(logAppFileManager) << "main: Application exiting with code:" << ret;


### PR DESCRIPTION
1. Replace simple QProcess::startDetached call with detailed QProcess configuration
2. Explicitly set program name to "dde-file-manager" instead of using argv[0]
3. Add UnixProcessFlag::CloseFileDescriptors to prevent inheriting file descriptors from parent process
4. Redirect standard output and error to null device for cleaner process management
5. Capture process PID for better process tracking and management

Log: Improved background process startup with proper resource isolation
Bug: https://pms.uniontech.com/bug-view-357391.html

Influence:
1. Verify headless process starts correctly on systems with DConfig enabled
2. Check that child process does not inherit parent file descriptors
3. Verify standard output and error are properly redirected
4. Test background process behavior during application lifecycle
5. Verify no resource leaks during multiple start/stop cycles

refactor: 改进后台无头进程启动实现

1. 使用详细的 QProcess 配置替代简单的 startDetached 调用
2. 显式设置程序名为 "dde-file-manager" 而非使用 argv[0]
3. 添加 UnixProcessFlag::CloseFileDescriptors 标志防止继承父进程文件描述符
4. 将标准输出和标准错误重定向到空设备以实现更清洁的进程管理
5. 捕获进程 PID 以便更好地跟踪和管理进程

Log: 改进后台进程启动，实现适当的资源隔离

Influence:
1. 验证在启用 DConfig 的系统上无头进程正确启动
2. 检查子进程未继承父进程的文件描述符
3. 验证标准输出和标准错误正确重定向
4. 测试应用程序生命周期中的后台进程行为
5. 验证多次启动/停止周期中无资源泄漏

## Summary by Sourcery

Refine headless background process startup for dde-file-manager to improve isolation and manageability of the detached process.

Enhancements:
- Replace the simple detached launch of the headless background process with an explicitly configured QProcess, including program name and arguments.
- Ensure the headless child process does not inherit parent file descriptors and has its stdout/stderr redirected to the null device.
- Capture the PID of the detached headless process to support better tracking and lifecycle management.