### PR TITLE
fix: improve dock area calculation accuracy

### DIFF
--- a/src/plugins/desktop/ddplugin-core/screen/screenqt.cpp
+++ b/src/plugins/desktop/ddplugin-core/screen/screenqt.cpp
@@ -62,76 +62,59 @@ QRect ScreenQt::availableGeometry() const
         return ret;
     }
 
-    DockRect dockrectI = DockInfoIns->frontendWindowRect();   // 原始dock大小
-    const QRect dockrect = GlobalPrivate::dealRectRatio(dockrectI.operator QRect());   // 缩放处理
+    DockRect dockrectI = DockInfoIns->frontendWindowRect();
 
     const qreal ratio = qApp->primaryScreen()->devicePixelRatio();
     const QRect hRect = handleGeometry();
-    const QRect hRectScaled = GlobalPrivate::dealRectRatio(hRect);   // 将物理坐标转换为逻辑坐标
 
-    if (!hRect.contains(dockrectI) && !ret.contains(dockrect)) {
-        QRect orgDockRect(dockrectI);
+    if (!hRect.contains(dockrectI)) {
         fmDebug() << "Dock not contained in screen geometry, using full screen - screen:" << name()
-                  << "handleGeometry:" << hRect << "originalDockRect:" << orgDockRect
-                  << "scaledDockRect:" << dockrect << "ratio:" << ratio;
+                  << "handleGeometry:" << hRect << "dockRect:" << QRect(dockrectI)
+                  << "ratio:" << ratio;
         return ret;
     }
 
     const int dockPos = DockInfoIns->position();
     fmDebug() << "Adjusting available geometry for dock position:" << dockPos << "on screen:" << name();
 
+    // 使用dock物理尺寸直接计算，避免dock坐标(屏幕本地坐标系)与屏幕geometry(虚拟桌面坐标系)
+    // 在不同坐标系下的位置错位问题。ret=geometry()已经是正确的屏幕区域，只需减去dock尺寸。
     switch (dockPos) {
-    case 0:   // 上
-    {
-        // 计算dock底部相对于屏幕顶部的偏移（逻辑坐标）
-        int yOffset = dockrect.bottom() - hRectScaled.top();
-        ret.setY(ret.y() + yOffset);
+    case 0: {   // 上
+        int dockH = static_cast<int>(dockrectI.height / ratio);
+        ret.adjust(0, dockH, 0, 0);
         fmDebug() << "Dock on top, adjusted available geometry:" << ret;
         break;
     }
-    case 1:   // 右
-    {
-        // 计算dock左侧相对于屏幕左侧的距离（逻辑坐标）
-        int w = dockrect.left() - hRectScaled.left();
-        if (w >= 0) {
-            ret.setWidth(w);
-        } else {
-            fmCritical() << "Invalid width calculation for right dock:" << w
-                         << "dockLeft:" << dockrect.left() << "screenLeft:" << hRectScaled.left();
-        }
+    case 1: {   // 右
+        int dockW = static_cast<int>(dockrectI.width / ratio);
+        ret.adjust(0, 0, -dockW, 0);
         fmDebug() << "Dock on right, adjusted available geometry:" << ret;
-    } break;
-    case 2:   // 下
-    {
-        // 计算dock顶部相对于屏幕顶部的距离（逻辑坐标）
-        int h = dockrect.top() - hRectScaled.top();
-        if (h >= 0) {
-            ret.setHeight(h);
-        } else {
-            fmCritical() << "Invalid height calculation for bottom dock:" << h
-                         << "dockTop:" << dockrect.top() << "screenTop:" << hRectScaled.top();
-        }
+        break;
+    }
+    case 2: {   // 下
+        int dockH = static_cast<int>(dockrectI.height / ratio);
+        ret.adjust(0, 0, 0, -dockH);
         fmDebug() << "Dock on bottom, adjusted available geometry:" << ret;
         break;
     }
-    case 3:   // 左
-    {
-        // 计算dock右侧相对于屏幕左侧的偏移（逻辑坐标）
-        int xOffset = dockrect.right() - hRectScaled.left();
-        ret.setX(ret.x() + xOffset);
+    case 3: {   // 左
+        int dockW = static_cast<int>(dockrectI.width / ratio);
+        ret.adjust(dockW, 0, 0, 0);
         fmDebug() << "Dock on left, adjusted available geometry:" << ret;
         break;
     }
     default:
         fmCritical() << "Invalid dock position:" << dockPos
-                     << "handleGeometry:" << hRect << "dockRect:" << dockrectI;
+                     << "handleGeometry:" << hRect << "dockRect:" << QRect(dockrectI);
         break;
     }
 
     if (!checkAvailableGeometry(ret, geometry())) {
         fmCritical() << "Available geometry validation failed - calculated:" << ret
-                     << "dockPosition:" << dockPos << "dockRect:" << dockrect
+                     << "dockPosition:" << dockPos << "dockRect:" << QRect(dockrectI)
                      << "screenGeometry:" << geometry() << "handleGeometry:" << hRect;
+        ret = geometry();   // 校验失败时回退到全屏几何，不减dock
     } else {
         fmDebug() << "Available geometry calculated successfully:" << ret << "for screen:" << name();
     }


### PR DESCRIPTION
Optimized the available geometry calculation when system dock is present
by:
1. Simplified the calculation logic to directly use dock physical
dimensions (adjusted for device pixel ratio)
2. Removed complex coordinate conversions that could cause misalignment
between screen local coordinates and virtual desktop coordinates
3. Changed the adjustment method to use QRect::adjust() for cleaner code
4. Added safety fallback to full screen geometry when validation fails

The previous implementation used multiple coordinate conversions which
could accumulate rounding errors and resulted in inaccurate available
area calculations, especially on high-DPI displays. The new approach is
more stable and reliable.

Log: Improved accuracy of available screen area calculation when system
dock is present

Influence:
1. Verify available screen area calculation with dock at different
positions (top/bottom/left/right)
2. Test on high-DPI displays to ensure correct scaling
3. Verify behavior when dock is not contained in screen geometry
4. Check proper fallback to full screen when calculations fail
validation
5. Test multi-monitor configurations with docks on different screens

fix: 提高Dock区域计算精确度

优化了系统Dock存在时的可用区域计算逻辑：
1. 简化计算逻辑，直接使用Dock物理尺寸（根据设备像素比调整）
2. 移除了可能导致屏幕本地坐标与虚拟桌面坐标错位的复杂坐标转换
3. 使用QRect::adjust()方法进行更清晰的区域调整
4. 在校验失败时添加安全回退到全屏几何的功能

之前的实现使用了多次坐标转换，可能导致舍入误差特别是在高DPI显示器上。新
方法更加稳定可靠。

Log: 提升系统Dock存在时的可用屏幕区域计算精确度

Influence:
1. 验证Dock在不同位置（上/下/左/右）时的可用区域计算
2. 在高DPI显示器上测试确保正确的缩放计算
3. 验证Dock不包含在屏幕几何中时的行为
4. 检查计算失败后正确的全屏回退机制
5. 测试多显示器配置下不同屏幕上的Dock效果

Bug: https://pms.uniontech.com/bug-view-358167.html
