### PR TITLE
refactor: replace system calls with QProcess for security

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+dde-file-manager (6.5.135) unstable; urgency=medium
+
+  * fix: handle network disconnection during search and remote file operations
+  * refactor: consolidate signal handling logic
+  * feat: add checksum verification for disc burning
+  * chore: update translations
+  * feat: add touch gesture support for sidebar scrolling
+  * fix: improve dock area calculation accuracy
+  * refactor: replace system calls with QProcess for security
+  * feat: add property dialog update mechanism for file rename
+  * fix: prevent auth dialog when auto-mounting hot-plugged devices
+  * refactor: improve headless process startup implementation
+  * feat: pass launch_type when launching apps via DBus
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 08 May 2026 13:46:49 +0800
+
 dde-file-manager (6.5.134) unstable; urgency=medium
 
   * fix: handle file paths correctly in terminal open operation

--- a/src/services/diskencrypt/helpers/abrecoveryhelper.cpp
+++ b/src/services/diskencrypt/helpers/abrecoveryhelper.cpp
@@ -7,6 +7,7 @@
 
 #include <QFile>
 #include <QElapsedTimer>
+#include <QProcess>
 
 FILE_ENCRYPT_USE_NS
 
@@ -65,9 +66,9 @@ void abrecovery_helper::disableRecovery()
     auto fd = inhibit_helper::inhibit(QObject::tr("Updating grub..."));
     qInfo() << "[abrecovery_helper::disableRecovery] System shutdown/sleep inhibited for GRUB update, fd:" << fd.value().fileDescriptor();
     
-    int ret = system("update-grub");
+    int ret = QProcess::execute("update-grub");
     auto elapsed = t.elapsed();
-    
+
     if (ret == 0) {
         qInfo() << "[abrecovery_helper::disableRecovery] GRUB update completed successfully in" << elapsed << "ms";
     } else {

--- a/src/services/diskencrypt/workers/normalinitencryptworker.cpp
+++ b/src/services/diskencrypt/workers/normalinitencryptworker.cpp
@@ -8,6 +8,8 @@
 #include "helpers/blockdevhelper.h"
 #include "helpers/jobfilehelper.h"
 
+#include <QProcess>
+
 FILE_ENCRYPT_USE_NS
 
 NormalInitEncryptWorker::NormalInitEncryptWorker(const QVariantMap &args, QObject *parent)
@@ -49,7 +51,7 @@ void NormalInitEncryptWorker::run()
     qInfo() << "[NormalInitEncryptWorker::run] Normal device encryption initialized successfully, device:" << devPath;
 
     sleep(1);
-    system("udevadm trigger");
+    QProcess::startDetached("udevadm", { "trigger" });
 }
 
 job_file_helper::JobDescArgs NormalInitEncryptWorker::initJobArgs(DevPtr ptr)

--- a/src/services/tpmcontrol/core/tpmwork.cpp
+++ b/src/services/tpmcontrol/core/tpmwork.cpp
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QDir>
+#include <QProcess>
 #include <unistd.h>
 
 // C structures for libutpm2.so
@@ -94,36 +95,35 @@ int TPMWork::isTPMAvailable()
 
 int TPMWork::checkTPMLockout()
 {
-    const char* tempFile = "dde_tpmcontrol_lockout_output.txt";
-    std::string command = "tpm2_getcap properties-variable > ";
-    command += tempFile;
-    int ret = system(command.c_str());
-    if (ret != 0) {
-        remove(tempFile);
-        fmCritical() << "Exec" << command << "failed with return code:" << ret;
+    QProcess proc;
+    proc.start("tpm2_getcap", { "properties-variable" });
+    if (!proc.waitForStarted()) {
+        fmCritical() << "Failed to start tpm2_getcap";
+        return -1;
+    }
+    if (!proc.waitForFinished(30000)) {
+        fmCritical() << "tpm2_getcap timed out after 30s";
+        proc.kill();
+        proc.waitForFinished();
+        return -1;
+    }
+    if (proc.exitCode() != 0) {
+        fmCritical() << "Exec tpm2_getcap properties-variable failed with return code:" << proc.exitCode();
         return -1;
     }
 
-    FILE* fp = fopen(tempFile, "r");
-    if (!fp) {
-        remove(tempFile);
-        fmCritical() << "Open" << tempFile << "failed!";
-        return -1;
-    }
-
-    char line[256];
+    QByteArray output = proc.readAllStandardOutput();
+    QList<QByteArray> lines = output.split('\n');
     int lockoutStatus = -2; // not find "inLockout:"
-    fmDebug() << "Parsing TPM properties from file:" << tempFile;
-    while (fgets(line, sizeof(line), fp)) {
-        if (strstr(line, "inLockout:")) {
-            char* colon = strchr(line, ':');
-            if (colon) {
-                char* value = colon + 1;
-                while (*value && (*value == ' ' || *value == '\t')) {
-                    value++;
-                }
-                int num;
-                if (sscanf(value, "%d", &num) == 1) {
+    fmDebug() << "Parsing TPM properties from tpm2_getcap output";
+    for (const QByteArray &line : lines) {
+        if (line.contains("inLockout:")) {
+            int colonPos = line.indexOf(':');
+            if (colonPos >= 0) {
+                QByteArray value = line.mid(colonPos + 1).trimmed();
+                bool ok = false;
+                int num = value.toInt(&ok);
+                if (ok) {
                     lockoutStatus = num;
                 }
             }
@@ -134,8 +134,6 @@ int TPMWork::checkTPMLockout()
     if (lockoutStatus == -2)
         fmCritical() << "Not find inLockout in TPM properties";
 
-    fclose(fp);
-    remove(tempFile);
     return lockoutStatus;
 }
 

--- a/src/services/tpmcontrol/core/tpmwork.cpp
+++ b/src/services/tpmcontrol/core/tpmwork.cpp
@@ -101,7 +101,7 @@ int TPMWork::checkTPMLockout()
         fmCritical() << "Failed to start tpm2_getcap";
         return -1;
     }
-    if (!proc.waitForFinished(30000)) {
+    if (!proc.waitForFinished()) {
         fmCritical() << "tpm2_getcap timed out after 30s";
         proc.kill();
         proc.waitForFinished();
@@ -114,7 +114,7 @@ int TPMWork::checkTPMLockout()
 
     QByteArray output = proc.readAllStandardOutput();
     QList<QByteArray> lines = output.split('\n');
-    int lockoutStatus = -2; // not find "inLockout:"
+    int lockoutStatus = -2;   // not find "inLockout:"
     fmDebug() << "Parsing TPM properties from tpm2_getcap output";
     for (const QByteArray &line : lines) {
         if (line.contains("inLockout:")) {
@@ -158,7 +158,7 @@ int TPMWork::getRandom(int size, QString *output)
     }
 
     // Dynamically allocate buffer matching the requested size
-    QByteArray buffer(size + 1, 0);  // +1 for null terminator
+    QByteArray buffer(size + 1, 0);   // +1 for null terminator
     int ret = func(size, buffer.data());
     if (ret == 0) {
         *output = QString::fromLatin1(buffer.constData());


### PR DESCRIPTION
1. Replaced all direct system() calls with QProcess for improved
security and better process control
2. In abrecovery_helper.cpp, changed update-grub execution to use
QProcess::execute()
3. In normalinitencryptworker.cpp, replaced udevadm trigger call with
QProcess::startDetached()
4. In tpmwork.cpp, completely refactored TPM lockout check to use
QProcess with proper timeout handling and output parsing
5. Added proper error handling and cleanup for process execution

Security: Removing system() calls prevents potential shell injection
vulnerabilities and provides better process isolation

Influence:
1. Verify GRUB updates still work correctly via QProcess
2. Test udevadm trigger functionality after encryption
3. Validate TPM lockout status detection with new QProcess
implementation
4. Check for proper timeout handling in TPM operations
5. Ensure all error cases are properly reported

refactor: 使用 QProcess 替换 system 调用提高安全性

1. 将所有直接 system() 调用替换为 QProcess 以提高安全性和进程控制
2. 在 abrecovery_helper.cpp 中，改用 QProcess::execute() 执行 update-
grub
3. 在 normalinitencryptworker.cpp 中，使用 QProcess::startDetached() 触
发 udevadm
4. 在 tpmwork.cpp 中彻底重构 TPM 锁定检查，使用带超时处理的 QProcess 和
输出解析
5. 添加了进程执行的正确错误处理和清理

安全: 移除 system() 调用可防止潜在的 shell 注入漏洞并提供更好的进程隔离

Influence:
1. 验证通过 QProcess 的 GRUB 更新仍然正常工作
2. 测试加密后 udevadm 触发功能
3. 使用新的 QProcess 实现验证 TPM 锁定状态检测
4. 检查 TPM 操作中是否正确处理超时
5. 确保所有错误情况都被正确报告
