### PR TITLE
fix: eliminate TOCTOU race condition in RootInfo::updateChild

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -710,14 +710,6 @@ SortInfoPointer RootInfo::updateChild(const QUrl &url)
 
     auto realUrl = info->urlOf(UrlInfoType::kUrl);
 
-    {
-        QReadLocker lk(&childrenLock);
-        if (!childrenUrlList.contains(realUrl)) {
-            fmDebug() << "Child not found in list for update:" << realUrl.toString();
-            return nullptr;
-        }
-    }
-
     sort = sortFileInfo(info);
     if (sort.isNull()) {
         fmWarning() << "Failed to create sort info for update:" << url.toString();
@@ -726,7 +718,12 @@ SortInfoPointer RootInfo::updateChild(const QUrl &url)
 
     {
         QWriteLocker lk(&childrenLock);
-        sourceDataList.replace(childrenUrlList.indexOf(realUrl), sort);
+        int index = childrenUrlList.indexOf(realUrl);
+        if (index < 0) {
+            fmDebug() << "Child no longer in list for update:" << realUrl.toString();
+            return nullptr;
+        }
+        sourceDataList.replace(index, sort);
     }
     // NOTE: GlobalEventType::kHideFiles event is watched in fileview, but this can be used to notify update view
     // when the file is modified in other way.


### PR DESCRIPTION
Removed the initial QReadLocker check that could lead to race condition
between checking URL presence and actual update operation. The check
is now performed within a single QWriteLocker to ensure atomicity. This
prevents the case where another thread could remove the URL between the
read check and write operation.

The change combines the existence check and update operation under a
single write lock, eliminating the potential TOCTOU vulnerability while
maintaining thread safety. The debug output was modified to better
reflect the new error condition.

Influence:
1. Test concurrent file operations in workspace to verify no race
conditions occur during updates
2. Verify file updates work normally under heavy load
3. Test edge cases where files might be removed during update operations

fix: 修复RootInfo::updateChild中的TOCTOU竞态条件

移除了可能导致竞态条件的初始QReadLocker检查，该检查存在于检查URL存在状态
与实际的更新操作之间。现在检查操作在单个QWriteLocker内完成以确保原子性。
这样可以防止另一个线程在读取检查和写入操作之间删除URL的情况发生。

此变更将存在性检查和更新操作合并到单个写锁下，消除了潜在的TOCTOU漏洞同时
保持线程安全。调试输出也被修改以更好地反映新的错误条件。

Influence:
1. 测试工作区中的并发文件操作，验证更新过程中不会出现竞态条件
2. 验证在高负载下文件更新功能正常工作
3. 测试文件在更新过程中可能被删除的边缘情况
