### PR TITLE
fix: change _launch_type value to dde-file-manager

### DIFF
--- a/src/dfm-base/utils/applaunchutils.cpp
+++ b/src/dfm-base/utils/applaunchutils.cpp
@@ -94,7 +94,7 @@ bool AppLaunchUtilsPrivate::launchByDBus(const QString &desktopFile, const QStri
         return false;
     }
 
-    QVariantMap options{{QStringLiteral("_launch_type"), QVariant::fromValue(3)}};
+    QVariantMap options{{QStringLiteral("_launch_type"), QStringLiteral("dde-file-manager")}};
 
     QDBusMessage reply = interface->callWithArgumentList(QDBus::Block,
                                                          "Launch",


### PR DESCRIPTION
Change the _launch_type parameter value passed to ApplicationManager1 from integer 3 to the string "dde-file-manager". This aligns with the expected protocol of dde-application-manager, where _launch_type is used to identify the application that initiated the launch for app launch event reporting.

将通过 DBus 传递给 ApplicationManager1 的 _launch_type 参数值从整数 3 修改为字符串 "dde-file-manager"。此变更与 dde-application-manager 所 期望的协议保持一致，_launch_type 用于在应用启动埋点统计中标识发起启动
操作的应用程序。

PMS: TASK-388657