### PR TITLE
fix: resolve device info query for nested mounts and remote files

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -194,7 +194,7 @@ bool DeviceProxyManager::isMptOfDevice(const QString &filePath, QString &id)
 QVariantMap DeviceProxyManager::queryDeviceInfoByPath(const QString &path, bool reload)
 {
     d->initMounts();
-    QString devId, rootDevId;
+    QString devId, rootDevId, blkMtp;
     QReadLocker lk(&d->lock);
     for (auto it = d->allMounts.begin(); it != d->allMounts.end(); it++) {
         if (it.value() == "/") {
@@ -203,8 +203,12 @@ QVariantMap DeviceProxyManager::queryDeviceInfoByPath(const QString &path, bool 
         }
         if (path.startsWith(it.value())
             || (path + "/").startsWith(it.value())) {
-            devId = it.key();
-            break;
+            if (devId.isEmpty() || (!blkMtp.isEmpty() && it.value().startsWith(blkMtp))) {
+                devId = it.key();
+                blkMtp = it.value();
+            }
+            qCDebug(logDFMBase()) << "DeviceProxyManager::queryDeviceInfoByPath path = " << path
+                                  << ", devId = " << devId << ", it.key() = " << it.key() << blkMtp;
         }
     }
     if (devId.isEmpty())

--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -610,6 +610,9 @@ qint64 DeviceUtils::deviceBytesFree(const QUrl &url)
     if (url.scheme() != Global::Scheme::kFile)
         return DFMIO::DFMUtils::deviceBytesFree(url);
 
+    if (ProtocolUtils::isRemoteFile(url))
+        return DFMIO::DFMUtils::deviceBytesFree(url);
+
     auto devicePath = bindPathTransform(url.path(), true);
     auto map = DevProxyMng->queryDeviceInfoByPath(devicePath, true);
 


### PR DESCRIPTION
Improved mount point matching in queryDeviceInfoByPath to select the longest matching mount path instead of the first match. This ensures correct device identification when sub-mounts exist on block device MTP paths. Also added remote file check in deviceBytesFree to delegate remote protocol queries directly to DFMIO, avoiding invalid local device path lookups.

Log: Fixed device info and disk space query for nested mounts

Influence:
1. Test device info query with nested mount points
2. Verify free space display for remote files (SMB/NFS/FTP)
3. Check block device MTP sub-mount device ID resolution
4. Confirm local mount behavior is unaffected

fix: 修复嵌套挂载和远程文件的设备信息查询问题

改进了queryDeviceInfoByPath中的挂载点匹配逻辑，选择最长路径匹配的挂载点
而非首次匹配。这确保了在块设备MTP路径上存在子挂载时能正确识别设备。同时
在deviceBytesFree中新增远程文件检查，将远程协议查询直接委托给DFMIO处理，
避免对远程路径执行无效的本地设备路径查询。

Log: 修复嵌套挂载和远程路径下设备信息及磁盘空间显示错误

Influence:
1. 测试嵌套挂载点的设备信息查询
2. 验证远程文件的可用空间显示（SMB/NFS/FTP）
3. 检查块设备MTP子挂载的设备ID解析
4. 确认本地挂载行为不受影响

Bug: https://pms.uniontech.com/bug-view-357747.html