### PR TITLE
feat: add kimageformat6-plugins dependency

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -113,6 +113,7 @@ Architecture: any
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},
+ kimageformat6-plugins,
  libpoppler-cpp0v5 (>= 0.48.0),
  gvfs-backends (>=1.27.3),
  cryptsetup,


### PR DESCRIPTION
Added kimageformat6-plugins as a new runtime dependency in the Debian
package control file. This dependency is necessary for proper image
format support within the application. The package likely provides
essential plugins for image processing functionality that the
application requires.

Log:
Influence:
1. Verify application can still build properly with the new dependency
2. Test image handling functionality to ensure all formats are supported
3. Check system package resolution to confirm dependency chain is
correct

feat: 添加 kimageformat6-plugins 依赖

在 Debian 包控制文件中新增 kimageformat6-plugins 运行时依赖。该依赖对于
应用程序内正确的图像格式支持是必需的。该软件包可能提供了应用程序所需的图
像处理功能的基本插件。

Log:
Influence:
1. 验证应用程序能否正确构建并包含新的依赖项
2. 测试图像处理功能以确保所有格式都被支持
3. 检查系统包解析以确认依赖链正确

## Summary by Sourcery

Build:
- Declare kimageformat6-plugins as a runtime dependency in the Debian package control file.