### PR TITLE
fix: remove directory marker in handleDirectoryCreated

### DIFF
--- a/src/services/textindex/fsmonitor/fseventcollector.cpp
+++ b/src/services/textindex/fsmonitor/fseventcollector.cpp
@@ -474,6 +474,8 @@ void FSEventCollectorPrivate::handleFileMoved(const QString &fromPath, const QSt
 
 void FSEventCollectorPrivate::handleDirectoryCreated(const QString &path, const QString &name)
 {
+    QString fullPath = normalizePath(path, name);
+    deletedDirectoriesMarker.remove(fullPath);
     handleFileCreated(path, name);
 }
 


### PR DESCRIPTION
Fixed an issue where directories that were recreated were not being
properly removed from the deleted directories marker set. Added explicit
removal when handling directory creation events to prevent stale
entries.

The change ensures the tracking system correctly reflects when a
directory is recreated after being deleted, avoiding potential false
positives in file system monitoring.

Influence:
1. Test directory recreation scenarios where a directory is deleted and
then recreated
2. Verify that monitoring correctly tracks the new directory status
3. Check behavior with nested directory structures
4. Test with rapid delete-create operations

fix: 在handleDirectoryCreated中移除目录标记

修复了重新创建的目录未从已删除目录标记集中正确移除的问题。在处理目录创建
事件时显式移除标记，以避免残留条目。

此更改确保跟踪系统能正确反映目录被删除后又重新创建的情况，防止文件系统监
控出现误报。

Influence:
1. 测试目录被删除后又重新创建的场景
2. 验证监控系统是否正确追踪新目录状态
3. 检查嵌套目录结构下的行为
4. 测试快速删除-创建操作的情况
