### PR TITLE
refactor: improve advanced search state handling

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -81,8 +81,14 @@ void SearchEditWidget::deactivateEdit()
     }
 
     quitSearchActive = false;
+    bool wasChecked = advancedButton->isChecked();
     advancedButton->setChecked(false);
     advancedButton->setVisible(false);
+
+    // programmatic setChecked() does not emit clicked(), so explicitly notify
+    // workspace to hide the advance filter widget
+    if (wasChecked)
+        TitleBarEventCaller::sendShowFilterView(this, false);
 
     searchEdit->clearEdit();
     searchEdit->clearFocus();
@@ -406,7 +412,7 @@ void SearchEditWidget::updateSearchWidgetLayout()
         searchEdit->setVisible(true);
         searchButton->setVisible(false);
 
-        bool shouldShowAdvancedButton = searchEdit->hasFocus() || !searchEdit->text().isEmpty();
+        bool shouldShowAdvancedButton = searchEdit->hasFocus() || !searchEdit->text().isEmpty() || advancedButton->isChecked();
         advancedButton->setVisible(shouldShowAdvancedButton);
         updateSpacing(shouldShowAdvancedButton);
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -547,14 +547,33 @@ void TitleBarWidget::saveTitleBarState(const QString &uniqueId)
 
 void TitleBarWidget::restoreTitleBarState(const QString &uniqueId)
 {
+    bool showFilterView = false;
+
     if (titleBarStateMap.contains(uniqueId)) {
         const TitleBarState &state = titleBarStateMap[uniqueId];
-        searchEditWidget->setAdvancedButtonVisible(state.advancedSearchVisible);
-        searchEditWidget->setAdvancedButtonChecked(state.advancedSearchChecked);
+        showFilterView = state.advancedSearchChecked;
+
+        if (state.advancedSearchChecked) {
+            // Advance widget was active: restore expanded state with button visible
+            searchEditWidget->activateEdit(false);
+            searchEditWidget->setAdvancedButtonChecked(true);
+        } else {
+            // Only restore advanced button when there is search text;
+            // keyboard tab switch may save advancedSearchVisible=true with empty text
+            // (focus was still on search edit when saveTitleBarState ran)
+            searchEditWidget->setAdvancedButtonVisible(state.advancedSearchVisible && !state.searchText.isEmpty());
+            searchEditWidget->setAdvancedButtonChecked(false);
+        }
+
         if (!state.searchText.isEmpty())
             searchEditWidget->setText(state.searchText);
         optionButtonBox->setViewMode(static_cast<int>(state.viewMode));
     }
+
+    // Sync filter view visibility to prevent stale state from previous tab;
+    // programmatic setChecked() does not emit clicked(), so sendShowFilterView
+    // is never called during tab switch — explicitly synchronize here
+    TitleBarEventCaller::sendShowFilterView(searchEditWidget, showFilterView);
 }
 
 bool TitleBarWidget::checkCustomFixedTab(int index)


### PR DESCRIPTION
1. Added explicit filter view visibility notification when deactivating
search
2. Modified advanced button visibility logic to consider checked state
3. Enhanced title bar state restoration to properly handle advanced
search states

Log: Fixed issues with advanced search filter visibility during tab
switches and deactivation

Influence:
1. Test tab switching while advanced search filter is active
2. Verify search edit deactivation properly hides filter view when
needed
3. Check advanced button visibility in different search states
4. Validate search state persistence across different scenarios

refactor: 改进高级搜索状态处理

1. 在搜索停用时添加显式过滤器视图可见性通知
2. 修改高级按钮显示逻辑以考虑选中状态
3. 增强标题栏状态恢复功能以正确处理高级搜索状态

Log: 修复了标签页切换和停用时高级搜索过滤器可见性问题

Influence:
1. 测试在高级搜索过滤器激活状态下切换标签页
2. 验证搜索编辑框停用时正确隐藏过滤器视图
3. 检查不同搜索状态下高级按钮的可见性
4. 验证搜索状态在不同场景下的持久性
