### PR TITLE
fix: ensure status bar visibility in image preview

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
@@ -363,12 +363,11 @@ void FilePreviewDialog::switchToPage(int index)
             qCDebug(logLibFilePreview) << "FilePreviewDialog: reusing existing preview for key:" << key;
             if (preview->setFileUrl(fileList.at(index))) {
                 preview->contentWidget()->updateGeometry();
-                updateTitle();
-                // statusBar->openButton()->setFocus();
                 preview->contentWidget()->adjustSize();
-                int newPerviewWidth = preview->contentWidget()->size().width();
-                int newPerviewHeight = preview->contentWidget()->size().height();
-                setFixedSize(newPerviewWidth, newPerviewHeight + statusBar->height());
+                int newPreviewWidth = preview->contentWidget()->size().width();
+                int newPreviewHeight = preview->contentWidget()->size().height();
+                setFixedSize(newPreviewWidth, newPreviewHeight + statusBar->height());
+                updateTitle();
                 playCurrentPreviewFile();
                 restoreCenterPos();
                 qCInfo(logLibFilePreview) << "FilePreviewDialog: successfully reused preview for file:" << fileList.at(index).toString();
@@ -438,9 +437,9 @@ void FilePreviewDialog::switchToPage(int index)
     // statusBar->openButton()->setFocus();
     this->adjustSize();
     preview->contentWidget()->adjustSize();
-    int newPerviewWidth = preview->contentWidget()->size().width();
-    int newPerviewHeight = preview->contentWidget()->size().height();
-    setFixedSize(newPerviewWidth, newPerviewHeight + statusBar->height());
+    int newPreviewWidth = preview->contentWidget()->size().width();
+    int newPreviewHeight = preview->contentWidget()->size().height();
+    setFixedSize(newPreviewWidth, newPreviewHeight + statusBar->height());
     updateTitle();
 
     // 切换并调整大小后，尝试将窗口移动回之前的中心位置

--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
@@ -83,6 +83,8 @@ void ImagePreview::initialize(QWidget *window, QWidget *statusBar)
                                    font-size: 12px;\
                                    font-weight: 300;}");
 
+    messageStatusBar->show();
+
     DAnchorsBase(messageStatusBar).setCenterIn(statusBar);
     
     fmDebug() << "Image preview: status bar initialized";


### PR DESCRIPTION
1. Explicitly call show() on messageStatusBar to ensure it's visible
after initialization
2. Previously the status bar might remain hidden even after anchors
were set
3. This fixes potential cases where the status bar information would not
display to users

Log: Fixed image preview status bar visibility issue

Influence:
1. Test image preview with various file types
2. Verify status bar appears consistently
3. Check status bar positioning and styling remains correct
4. Test with different window sizes and DPI settings

fix: 确保图片预览中状态栏的可见性

1. 在messageStatusBar上显式调用show()以确保初始化后可见
2. 之前设置锚点后状态栏可能仍保持隐藏状态
3. 修复了状态栏信息可能不会显示给用户的问题

Log: 修复了图片预览状态栏可见性问题

Influence:
1. 测试不同文件类型的图片预览
2. 验证状态栏始终显示
3. 检查状态栏定位和样式保持正确
4. 在不同窗口大小和DPI设置下进行测试

Bug: https://pms.uniontech.com/bug-view-360901.html
