### PR TITLE
feat: add DLNFS config monitoring for text indexing

### DIFF
--- a/src/services/textindex/ocrindexdbus.cpp
+++ b/src/services/textindex/ocrindexdbus.cpp
@@ -80,6 +80,11 @@ void OcrIndexDBusPrivate::initConnect()
                          fmInfo() << "OcrIndexDBus: ANYTHING config changed, marking rebuild required. reason:" << reason;
                          runtime->stateStore().setNeedsRebuild(true);
                      });
+    QObject::connect(IndexUtility::DlnfsConfigWatcher::instance(), &IndexUtility::DlnfsConfigWatcher::rebuildRequired,
+                     q, [this](const QString &reason) {
+                         fmInfo() << "OcrIndexDBus: DLNFS config changed, marking rebuild required. reason:" << reason;
+                         runtime->stateStore().setNeedsRebuild(true);
+                     });
 }
 
 void OcrIndexDBusPrivate::handleMonitoring(bool start)

--- a/src/services/textindex/textindexdbus.cpp
+++ b/src/services/textindex/textindexdbus.cpp
@@ -72,6 +72,11 @@ void TextIndexDBusPrivate::initConnect()
                          fmInfo() << "TextIndexDBus: ANYTHING config changed, marking rebuild required. reason:" << reason;
                          runtime->stateStore().setNeedsRebuild(true);
                      });
+    QObject::connect(IndexUtility::DlnfsConfigWatcher::instance(), &IndexUtility::DlnfsConfigWatcher::rebuildRequired,
+                     q, [this](const QString &reason) {
+                         fmInfo() << "TextIndexDBus: DLNFS config changed, marking rebuild required. reason:" << reason;
+                         runtime->stateStore().setNeedsRebuild(true);
+                     });
 }
 
 void TextIndexDBusPrivate::handleMonitoring(bool start)

--- a/src/services/textindex/utils/indexutility.cpp
+++ b/src/services/textindex/utils/indexutility.cpp
@@ -178,6 +178,76 @@ AnythingConfigWatcher::AnythingConfigWatcher(QObject *parent)
     defaultBlacklistPathsRealtime();
 }
 
+// ─────────────────────────────────────────────
+// ConfigRebuildWatcher
+// ─────────────────────────────────────────────
+
+ConfigRebuildWatcher::ConfigRebuildWatcher(const QList<WatchEntry> &entries, QObject *parent)
+    : QObject(parent)
+{
+    for (const auto &entry : entries) {
+        ConfigHolder holder;
+        holder.appId = entry.appId;
+        holder.configId = entry.configId;
+        holder.watchedKey = entry.key;
+        holder.config = DConfig::create(entry.appId, entry.configId, "", this);
+
+        if (!holder.config) {
+            qWarning() << "ConfigRebuildWatcher: Failed to create DConfig for" << entry.appId << entry.configId;
+            continue;
+        }
+        if (!holder.config->isValid()) {
+            qWarning() << "ConfigRebuildWatcher: DConfig is not valid for" << entry.appId << entry.configId;
+            holder.config->deleteLater();
+            holder.config = nullptr;
+            continue;
+        }
+
+        // Capture by value for the lambda closure,
+        // since DConfig::valueChanged only provides the key, not the config source.
+        const auto configId = entry.configId;
+        const auto watchedKey = entry.key;
+        connect(holder.config, &DConfig::valueChanged, this,
+                [this, configId, watchedKey](const QString &key) {
+                    if (key == watchedKey) {
+                        const QString reason = QStringLiteral("%1:%2Changed").arg(configId, key);
+                        fmInfo() << "ConfigRebuildWatcher:" << reason;
+                        emit rebuildRequired(reason);
+                    }
+                });
+
+        m_configs.append(holder);
+    }
+}
+
+ConfigRebuildWatcher::~ConfigRebuildWatcher() = default;
+
+// ─────────────────────────────────────────────
+// DlnfsConfigWatcher
+// ─────────────────────────────────────────────
+
+DlnfsConfigWatcher *DlnfsConfigWatcher::instance()
+{
+    static DlnfsConfigWatcher *inst = new DlnfsConfigWatcher;
+    return inst;
+}
+
+DlnfsConfigWatcher::~DlnfsConfigWatcher() = default;
+
+DlnfsConfigWatcher::DlnfsConfigWatcher(QObject *parent)
+    : QObject(parent),
+      m_watcher(new ConfigRebuildWatcher({ { QStringLiteral("org.deepin.dde.file-manager"),
+                                             QStringLiteral("org.deepin.dde.file-manager"),
+                                             QStringLiteral("dfm.mount.dlnfs") },
+                                           { QStringLiteral("org.deepin.dlnfs"),
+                                             QStringLiteral("org.deepin.dlnfs"),
+                                             QStringLiteral("ulnfs") } },
+                                         this))
+{
+    connect(m_watcher, &ConfigRebuildWatcher::rebuildRequired,
+            this, &DlnfsConfigWatcher::rebuildRequired);
+}
+
 }   // namespace IndexUtility
 
 namespace PathCalculator {

--- a/src/services/textindex/utils/indexutility.h
+++ b/src/services/textindex/utils/indexutility.h
@@ -78,6 +78,62 @@ private:
     QStringList blacklistPaths;
 };
 
+/**
+ * @brief Generic DConfig watcher that emits rebuildRequired when watched keys change
+ *
+ * Provides a reusable mechanism to monitor multiple DConfig sources
+ * and trigger index rebuilds when configuration changes are detected.
+ */
+class ConfigRebuildWatcher : public QObject
+{
+    Q_OBJECT
+public:
+    struct WatchEntry {
+        QString appId;
+        QString configId;
+        QString key;
+    };
+
+    explicit ConfigRebuildWatcher(const QList<WatchEntry> &entries, QObject *parent = nullptr);
+    ~ConfigRebuildWatcher() override;
+
+Q_SIGNALS:
+    void rebuildRequired(const QString &reason);
+
+private:
+    struct ConfigHolder {
+        DTK_CORE_NAMESPACE::DConfig *config { nullptr };
+        QString appId;
+        QString configId;
+        QString watchedKey;
+    };
+    QList<ConfigHolder> m_configs;
+};
+
+/**
+ * @brief Watches dlnfs/ulnfs configuration changes that affect file indexing
+ *
+ * Monitors two DConfig sources:
+ * - org.deepin.dde.file-manager: dfm.mount.dlnfs
+ * - org.deepin.dlnfs: ulnfs
+ *
+ * When any watched key changes, emits rebuildRequired to trigger index rebuild.
+ */
+class DlnfsConfigWatcher : public QObject
+{
+    Q_OBJECT
+public:
+    static DlnfsConfigWatcher *instance();
+    ~DlnfsConfigWatcher() override;
+
+Q_SIGNALS:
+    void rebuildRequired(const QString &reason);
+
+private:
+    explicit DlnfsConfigWatcher(QObject *parent = nullptr);
+    ConfigRebuildWatcher *m_watcher { nullptr };
+};
+
 }   // namespace IndexUtility
 
 namespace PathCalculator {


### PR DESCRIPTION
1. Implement ConfigRebuildWatcher as a generic DConfig monitoring class
2. Add DlnfsConfigWatcher specifically for watching DLNFS-related
configuration changes
3. Connect configuration changes to index rebuild signals in both
TextIndexDBus and OcrIndexDBus
4. Monitor two key DLNFS configuration items that affect file indexing
behavior

Changes were made to ensure the text index gets properly rebuilt when
DLNFS (Deepin Network File System) configuration changes, as these
changes can affect which files are visible and how they should be
indexed.

Log: Added automatic index rebuilding when DLNFS configuration changes

Influence:
1. Test changing DLNFS/ULNFS configuration settings to verify index
rebuild is triggered
2. Verify logging shows proper configuration change detection
3. Test with invalid configurations to ensure graceful handling
4. Verify index rebuild behavior doesn't impact normal system operations

feat: 为文本索引添加DLNFS配置监控功能

1. 实现通用的ConfigRebuildWatcher类用于监控DConfig变更
2. 新增专门监控DLNFS相关配置变更的DlnfsConfigWatcher
3. 在TextIndexDBus和OcrIndexDBus中连接配置变更信号到索引重建信号
4. 监控两项影响文件索引行为的DLNFS关键配置项

这些变更确保当DLNFS(深度网络文件系统)配置变化时能正确重建文本索引，因为
这些变化会影响文件的可见性和索引方式。

Log: 新增DLNFS配置变更时自动重建索引功能

Influence:
1. 测试修改DLNFS/ULNFS配置设置验证索引重建是否触发
2. 验证日志是否能正确记录配置变更检测
3. 测试无效配置情况下的优雅处理
4. 验证索引重建行为不影响系统正常操作

Bug: https://pms.uniontech.com/bug-view-360147.html
