### PR TITLE
fix: set proper image view size constraints

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -51,6 +51,8 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
         return;
     } else {
         setMovie(nullptr);
+        setMinimumSize(MIN_SIZE);
+        setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
     }
 
     if (movie) {


### PR DESCRIPTION
Added minimum and maximum size constraints in ImageView when displaying
static images to prevent UI layout issues. The minimum size is set to a
defined constant MIN_SIZE (likely ensuring a reasonable viewing area),
while the maximum size is removed (QWIDGETSIZE_MAX) to allow proper
scaling of large images.

This change fixes potential UI problems where images might be displayed
too small or not scaling properly in the preview window.

fix: 设置正确的图像视图大小限制

在显示静态图像时为 ImageView 添加了最小和最大尺寸限制，以防止 UI 布局问
题。最小尺寸设置为定义的常量 MIN_SIZE（可能确保合理的可视区域），同时取
消最大尺寸限制（QWIDGETSIZE_MAX）以允许大图像正确缩放。

该更改修复了预览窗口中图像可能显示过小或缩放不当的潜在 UI 问题。

Bug: https://pms.uniontech.com/bug-view-360905.html
