### PR TITLE
fix: optimize OCR image processing dimensions

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.textindex.json
+++ b/assets/configs/org.deepin.dde.file-manager.textindex.json
@@ -131,7 +131,7 @@
 			"visibility": "public"
 		},
 		"ocrImageScaleWidth": {
-				"value": 1280,
+				"value": 960,
 				"serial": 0,
 				"flags": [],
 				"name": "OCR image scale width",
@@ -142,7 +142,7 @@
 				"visibility": "public"
 			},
 		"ocrImageScaleHeight": {
-			"value": 720,
+			"value": 540,
 			"serial": 0,
 			"flags": [],
 			"name": "OCR image scale height",

--- a/src/apps/dde-file-manager-extractor/plugins/ocr-extractor/ocrextractor.cpp
+++ b/src/apps/dde-file-manager-extractor/plugins/ocr-extractor/ocrextractor.cpp
@@ -25,8 +25,8 @@ constexpr int kDefaultMaxOcrImageSizeMB = 30;
 constexpr int kMaxAllowedOcrImageSizeMB = 1024;
 constexpr char kOcrImageScaleWidth[] = "ocrImageScaleWidth";
 constexpr char kOcrImageScaleHeight[] = "ocrImageScaleHeight";
-constexpr int kDefaultImageMaxWidth = 1280;
-constexpr int kDefaultImageMaxHeight = 720;
+constexpr int kDefaultImageMaxWidth = 960;
+constexpr int kDefaultImageMaxHeight = 540;
 constexpr char kPreferredOcrPlugin[] = "PPOCR_V5";
 
 QStringList defaultSupportedImageExtensions()


### PR DESCRIPTION
Reduced default OCR processing dimensions from 1280x720 to 960x540 for
better performance while maintaining sufficient resolution for accurate
text recognition. This change is reflected in both the configuration
file and the extractor implementation code.

1. Updated json configuration file with new default width (960) and
height (540)
2. Modified corresponding constants in ocrextractor.cpp
3. Lower resolution means faster processing with minimal impact on OCR
accuracy

Log: Optimized OCR image processing dimensions for better performance

Influence:
1. Test OCR functionality with various image sizes
2. Verify processing time improvements with different image resolutions
3. Check OCR accuracy remains acceptable with new dimensions
4. Test with edge cases (very small/large images, different aspect
ratios)

fix: 优化OCR图像处理尺寸

将默认OCR处理尺寸从1280x720调整为960x540，在保持足够分辨率以确保文字识别
准确性的同时提高处理性能。这一改动同时体现在配置文件和提取器实现代码中。

1. 更新json配置文件中的默认宽度(960)和高度(540)设置
2. 修改ocrextractor.cpp中对应的常量定义
3. 降低分辨率意味着更快的处理速度，同时对OCR准确性的影响最小

Log: 优化OCR图像处理尺寸以提高性能

Influence:
1. 测试不同尺寸图像的OCR功能
2. 验证不同分辨率下的处理时间改进效果
3. 检查OCR准确性在新尺寸下是否保持可接受水平
4. 测试边界情况(极小/极大尺寸图像，不同纵横比)

## Summary by Sourcery

Enhancements:
- Lower the default maximum OCR image width and height used by the extractor from 1280x720 to 960x540 in code and configuration.