### PR TITLE
fix: call search plugin load before showing filter view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -67,6 +67,7 @@ void SearchEditWidget::activateEdit(bool setAdvanceBtn)
 
     if (searchEdit->hasFocus() && setAdvanceBtn) {
         advancedButton->setChecked(!advancedButton->isChecked());
+        TitleBarHelper::tryLoadSearchPlugin();
         TitleBarEventCaller::sendShowFilterView(this, advancedButton->isChecked());
     } else {
         searchEdit->lineEdit()->setFocus();


### PR DESCRIPTION
Added TitleBarHelper::tryLoadSearchPlugin() call before showing the
filter view in SearchEditWidget::activateEdit to ensure the search
plugin is properly initialized before the advanced search interface
is displayed.

This fixes an issue where the advanced search might not work correctly
if displayed immediately after activating the search edit, as the
required plugin might not be loaded yet.

Log: Fixed advanced search potentially not working when first activated

Influence:
1. Test opening advanced search immediately after focusing the search
bar
2. Verify all advanced search functionality is available when first
opened
3. Check for any delays or performance impacts during first-time search
activation

fix: 显示过滤器视图前添加搜索插件加载调用

在SearchEditWidget::activateEdit中添加了
TitleBarHelper::tryLoadSearchPlugin()调用，确保在显示高级搜索界面前正确
初始化搜索插件。修复了立即激活搜索编辑后高级搜索可能无法正常工作的问题，
因为依赖的插件可能尚未加载。

Log: 修复首次激活时高级搜索可能无法使用的问题

Influence:
1. 测试在聚焦搜索栏后立即打开高级搜索
2. 验证首次打开时高级搜索功能是否全部可用
3. 检查首次搜索激活时是否存在延迟或性能影响

## Summary by Sourcery

Bug Fixes:
- Fix advanced search sometimes not working when the filter view is opened immediately after focusing the search bar.