### PR TITLE
fix: handle search box cleanup properly in collapse mode

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -339,7 +339,13 @@ void SearchEditWidget::initConnect()
 {
     connect(searchButton, &DIconButton::clicked, this, &SearchEditWidget::expandSearchEdit);
     connect(searchEdit, &DSearchEdit::textEdited, this, &SearchEditWidget::onTextEdited, Qt::QueuedConnection);
-    connect(searchEdit, &DSearchEdit::searchAborted, this, &SearchEditWidget::quitSearch);
+    connect(searchEdit, &DSearchEdit::searchAborted, this, [this]() {
+        quitSearch();
+        // 窗口较窄（kCollapsed 模式）：不保留搜索框，让 onUrlChanged 走 full cleanup
+        // 直接折叠回搜索按钮，等同于按两次 ESC
+        if (parentWidget() && parentWidget()->width() <= kWidthThresholdCollapse)
+            quitSearchActive = false;
+    });
     connect(advancedButton, &DToolButton::clicked, this, &SearchEditWidget::onAdvancedButtonClicked);
     connect(delayTimer, &QTimer::timeout, this, &SearchEditWidget::performSearch);   // 连接计时器超时信号
 


### PR DESCRIPTION
1. Modified search abort handler to check for narrow window condition
2. When in collapse mode (width <= threshold), reset quitSearchActive
flag
3. Enables proper cleanup when window is too narrow for persistent
search box

Log: Fixed search box cleanup behavior in collapsed window mode

Influence:
1. Test search in narrow windows (width <= 300px)
2. Verify search box exits completely when hitting ESC
3. Check behavior transitions between narrow and wide modes
4. Verify search history isn't improperly retained

fix: 正确处理折叠模式下的搜索框清理

1. 修改搜索中止处理程序以检查窄窗口条件
2. 当处于折叠模式(宽度<=阈值)时，重置quitSearchActive标志
3. 确保窗口太窄时能够正确清理搜索框

Log: 修复折叠窗口模式下搜索框清理行为

Influence:
1. 在窄窗口(宽度<=300px)中测试搜索功能
2. 验证按下ESC时搜索框是否完全退出
3. 检查窄窗口和宽窗口模式之间的过渡行为
4. 验证搜索历史不会错误保留

## Summary by Sourcery

Bug Fixes:
- Ensure that aborting a search in collapsed (narrow) window mode collapses the search box and clears its active state for proper cleanup.