### PR TITLE
fix: resolve mutex deadlock in async file info query

### DIFF
--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -620,7 +620,7 @@ int AsyncFileInfo::cacheAsyncAttributes(const QString &attributes)
 
 bool AsyncFileInfo::asyncQueryDfmFileInfo(int ioPriority, FileInfo::initQuerierAsyncCallback func, void *userData)
 {
-    if (d->queringAttribute)
+    if (d->queringAttribute || !func)
         return false;
     bool dfmNull = false;
     d->queringAttribute = true;

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -87,9 +87,17 @@ bool SyncFileInfo::initQuerier()
 
 void SyncFileInfo::initQuerierAsync(int ioPriority, FileInfo::initQuerierAsyncCallback func, void *userData)
 {
-    QMutexLocker locker(&d->lock);
-    if (d->dfmFileInfo)
-        d->dfmFileInfo->initQuerierAsync(ioPriority, func, userData);
+    if (!func)
+        return;
+
+    auto lockGuard = std::make_shared<std::unique_lock<QMutex>>(d->lock);
+    if (d->dfmFileInfo) {
+        auto wrapper = [lockGuard, func](bool success, void *data) {
+            lockGuard->unlock();
+            func(success, data);
+        };
+        d->dfmFileInfo->initQuerierAsync(ioPriority, wrapper, userData);
+    }
 }
 /*!
  * \brief exists 文件是否存在


### PR DESCRIPTION
The async initQuerierAsync methods in SyncFileInfo and AsyncFileInfo used QMutexLocker (RAII lock guard) which keeps the mutex locked until the function returns. However, the async callback may be invoked while the mutex is still held, and if the callback or its callers attempt to acquire the same lock, a deadlock occurs. Changed to manual lock management and unlock the mutex in the wrapper callback before invoking the user callback to prevent the deadlock.

Log: Fixed deadlock in async file info initialization

Influence:
1. Test async file info query during file operations
2. Verify no deadlock occurs under concurrent access
3. Check file info query works correctly with sync and async paths
4. Test with files on various filesystem types
5. Verify lock is properly released in all callback paths

fix: 修复异步文件信息查询中的互斥锁死锁问题

SyncFileInfo 和 AsyncFileInfo 中的异步 initQuerierAsync 方法使用了 QMutexLocker（RAII锁守卫），该守卫在函数返回前一直持有互斥锁。然而，
异步回调可能在互斥锁仍被持有时就被调用，如果回调或其调用者尝试获取同一
把锁，就会发生死锁。改为手动管理锁的生命周期，并在调用用户回调函数之前
先在包装回调中释放互斥锁，以防止死锁发生。

Log: 修复异步文件信息初始化时的死锁问题

Influence:
1. 测试文件操作期间的异步文件信息查询
2. 验证并发访问下不会发生死锁
3. 检查文件信息查询在同步和异步路径下均正常工作
4. 测试各种文件系统类型
5. 验证锁在所有回调路径中被正确释放

## Summary by Sourcery

Bug Fixes:
- Fix potential mutex deadlock when invoking async file info querier callbacks under concurrent access.