### PR TITLE
fix: prevent UAF crash in SyncDBus task handling

### DIFF
--- a/src/plugins/daemon/core/syncdbus.cpp
+++ b/src/plugins/daemon/core/syncdbus.cpp
@@ -23,25 +23,23 @@ DAEMONPCORE_USE_NAMESPACE
 static constexpr int kMaxConcurrentSyncs = 4;
 
 SyncDBus::SyncDBus(QObject *parent)
-    : QObject(parent)
-    , m_threadPool(new QThreadPool(this))
-    , m_nextTaskId(1)
+    : QObject(parent), m_threadPool(new QThreadPool(this)), m_nextTaskId(1)
 {
     // Configure thread pool for sync operations
     m_threadPool->setMaxThreadCount(kMaxConcurrentSyncs);
-    
+
     fmInfo() << "SyncDBus service initialized with max" << kMaxConcurrentSyncs << "concurrent operations";
 }
 
 SyncDBus::~SyncDBus()
 {
     fmInfo() << "SyncDBus service shutting down";
-    
+
     // Clear active tasks map (tasks will be auto-deleted by QThreadPool)
     m_activeTasks.clear();
-    
+
     // Wait for all tasks to complete before destruction
-    if (!m_threadPool->waitForDone(5000)) { // 5 second timeout
+    if (!m_threadPool->waitForDone(5000)) {   // 5 second timeout
         fmWarning() << "Some sync tasks did not complete within timeout, forcing shutdown";
     }
 }
@@ -62,39 +60,41 @@ int SyncDBus::SyncFS(const QString &path, const QVariantMap &options)
 
     // Generate unique task ID
     int taskId = generateTaskId();
-    
-    // Create sync task with automatic cleanup
+
+    // Create sync task; manual lifecycle management required because
+    // taskCompleted uses QueuedConnection — QThreadPool must NOT delete
+    // the task before the queued slot finishes reading its members.
     SyncTask *task = new SyncTask(taskId, path, options);
-    task->setAutoDelete(true); // Let QThreadPool handle deletion
-    
+    task->setAutoDelete(false);
+
     // Connect task completion signal before adding to active tasks
     connect(task, &SyncTask::taskCompleted, this, &SyncDBus::onSyncTaskCompleted, Qt::QueuedConnection);
-    
+
     // Add to active tasks with weak tracking
     m_activeTasks.insert(taskId, task);
-    
+
     // Start the task
     m_threadPool->start(task);
-    
+
     fmInfo() << "Started sync operation for path:" << path << "with task ID:" << taskId;
-    
+
     return taskId;
 }
 
 QVariantMap SyncDBus::GetSyncStatus()
 {
     QVariantMap status;
-    
+
     status["activeTaskCount"] = m_activeTasks.size();
     status["maxConcurrentTasks"] = kMaxConcurrentSyncs;
     status["threadPoolActiveThreads"] = m_threadPool->activeThreadCount();
-    
+
     QStringList activePaths;
     for (auto task : m_activeTasks) {
         activePaths.append(task->path());
     }
     status["activePaths"] = activePaths;
-    
+
     return status;
 }
 
@@ -107,10 +107,10 @@ void SyncDBus::onSyncTaskCompleted(SyncTask *task)
 
     int taskId = task->taskId();
     QString path = task->path();
-    
+
     // Remove from active tasks (task will be auto-deleted by QThreadPool)
     m_activeTasks.remove(taskId);
-    
+
     // Emit appropriate signal based on task result
     if (task->isSuccessful()) {
         fmInfo() << "Sync operation completed successfully for path:" << path << "task ID:" << taskId;
@@ -120,8 +120,9 @@ void SyncDBus::onSyncTaskCompleted(SyncTask *task)
         fmWarning() << "Sync operation failed for path:" << path << "task ID:" << taskId << "error:" << errorMsg;
         emit SyncFailed(taskId, path, errorMsg);
     }
-    
-    // Note: Task will be automatically deleted by QThreadPool
+
+    // Manually delete the task (autoDelete is disabled — see SyncFS)
+    task->deleteLater();
 }
 
 int SyncDBus::generateTaskId()
@@ -132,39 +133,35 @@ int SyncDBus::generateTaskId()
 // SyncTask implementation
 
 SyncTask::SyncTask(int taskId, const QString &path, const QVariantMap &options, QObject *parent)
-    : QObject(parent)
-    , m_taskId(taskId)
-    , m_path(path)
-    , m_options(options)
-    , m_success(false)
+    : QObject(parent), m_taskId(taskId), m_path(path), m_options(options), m_success(false)
 {
 }
 
 void SyncTask::run()
 {
     fmDebug() << "Starting sync task" << m_taskId << "for path:" << m_path;
-    
+
     int fd = -1;
-    
+
     try {
         // Resolve the actual filesystem path
         QString resolvedPath = QFileInfo(m_path).absoluteFilePath();
-        
+
         // Open the path (works for both files and directories)
         fd = open(resolvedPath.toLocal8Bit().constData(), O_RDONLY);
-        
+
         if (fd == -1) {
             m_errorMessage = QString("Failed to open path: %1 (errno: %2)").arg(resolvedPath).arg(strerror(errno));
             fmWarning() << "Sync task" << m_taskId << "failed:" << m_errorMessage;
             emit taskCompleted(this);
             return;
         }
-        
+
         // Perform the sync operation
         int result = syncfs(fd);
         close(fd);
-        fd = -1; // Mark as closed
-        
+        fd = -1;   // Mark as closed
+
         if (result == 0) {
             m_success = true;
             fmDebug() << "Sync task" << m_taskId << "completed successfully for path:" << m_path;
@@ -180,7 +177,7 @@ void SyncTask::run()
         m_errorMessage = "Unexpected exception during sync operation";
         fmWarning() << "Sync task" << m_taskId << "failed with exception";
     }
-    
+
     // Always emit completion signal (ensures cleanup)
     emit taskCompleted(this);
-} 
+}


### PR DESCRIPTION
Changed task deletion strategy from auto-delete to manual deletion
because:
1. AutoDelete=true caused Use-After-Free when QueuedConnection slot
accessed task members
2. QueuedConnection means the taskCompleted signal handler runs later
when the task might already be deleted
3. Manual deletion ensures task exists until signal processing completes

Log: Fixed potential crash during file synchronization operations

Influence:
1. Test file sync operations with various paths and options
2. Stress test with rapid sequential sync requests
3. Verify no crashes occur during concurrent sync operations
4. Check memory usage for leaks after multiple sync cycles

fix: 修复SyncDBus任务处理中的UAF崩溃问题

更改任务删除策略从自动删除改为手动删除原因：
1. AutoDelete=true会导致访问已释放内存（QueuedConnection槽访问任务成
员时）
2. QueuedConnection意味着任务完成信号处理器运行时任务可能已被删除
3. 手动删除确保信号处理完成前任务对象一直存在

Log: 修复文件同步操作中潜在的崩溃问题

Influence:
1. 使用不同路径和选项测试文件同步操作
2. 进行快速连续同步请求的压力测试
3. 验证并发同步操作不会导致崩溃
4. 检查多次同步周期后的内存使用情况是否有泄露

## Summary by Sourcery

Bug Fixes:
- Ensure SyncDBus sync tasks are not deleted by QThreadPool before queued taskCompleted handlers finish accessing task data.