### PR TITLE
fix: trim whitespace in tag editor input

### DIFF
--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
@@ -50,8 +50,9 @@ void TagEditor::setDefaultCrumbs(const QStringList &list)
 void TagEditor::onFocusOut()
 {
     if (flagForShown.load(std::memory_order_acquire)) {
-        if (!crumbEdit->toPlainText().remove(QChar::ObjectReplacementCharacter).isEmpty())
-            crumbEdit->appendCrumb(crumbEdit->toPlainText().remove(QChar::ObjectReplacementCharacter));
+        QString text = crumbEdit->toPlainText().remove(QChar::ObjectReplacementCharacter).trimmed();
+        if (!text.isEmpty())
+            crumbEdit->appendCrumb(text);
         processTags();
         close();
     }
@@ -167,7 +168,13 @@ void TagEditor::setupEditHeight()
 
 void TagEditor::processTags()
 {
-    QList<QString> tags = crumbEdit->crumbList();
+    QList<QString> tags;
+    for (const QString &tag : crumbEdit->crumbList()) {
+        QString trimmed = tag.trimmed();
+        if (!trimmed.isEmpty())
+            tags << trimmed;
+    }
+
     QList<QUrl> tempFiles = files;
 
     updateCrumbsColor(TagManager::instance()->assignColorToTags(tags));


### PR DESCRIPTION
1. Added trimming to both crumbEdit text and individual tags before
processing
2. Prevents creation of tags with leading/trailing whitespace
3. Ensures empty strings are properly filtered out
4. Improves consistency in tag handling and storage

Log: Fixed tag editor to properly handle whitespace in input

Influence:
1. Test tag input with leading/trailing spaces
2. Verify empty strings are not saved as tags
3. Check tag color assignment works with trimmed tags
4. Validate tag display in the UI after edit

fix: 修复标签编辑器中对输入空白字符的处理

1. 在处理前对crumbEdit文本和单个标签添加修剪空白字符功能
2. 防止创建包含首尾空白字符的标签
3. 确保空字符串被正确过滤
4. 提升标签处理的统一性和存储一致性

Log: 修复标签编辑器正确处理输入中的空白字符问题

Influence:
1. 测试包含首尾空格的标签输入
2. 验证空字符串不会被保存为标签
3. 检查修剪后的标签颜色分配功能
4. 验证编辑后在UI中的标签显示

PMS: BUG-361413

## Summary by Sourcery

Normalize and validate tag editor input to avoid saving tags with leading/trailing whitespace or empty values.

Bug Fixes:
- Ensure tag editor does not create tags from whitespace-only or untrimmed input values.

Enhancements:
- Trim and filter tag editor crumb text and tag list entries before processing and color assignment.