### PR TITLE
fix: add error handling for D-Bus connection and registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ Makefile.*
 
 debug
 release
-build*
+build
 
 *.pro.user
 *.pro.user*

--- a/src/services/accesscontrol/accesscontroldbus.cpp
+++ b/src/services/accesscontrol/accesscontroldbus.cpp
@@ -59,7 +59,14 @@ AccessControlDBus::AccessControlDBus(const char *name, QObject *parent)
     QDBusConnection::RegisterOptions opts =
             QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
 
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name)).registerObject(kAccessControlManagerObjPath, this, opts);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[AccessControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(kAccessControlManagerObjPath, this, opts)) {
+        fmWarning() << "[AccessControlDBus] failed to register object on path:" << kAccessControlManagerObjPath;
+    }
 }
 
 AccessControlDBus::~AccessControlDBus()

--- a/src/services/mountcontrol/mountcontroldbus.cpp
+++ b/src/services/mountcontrol/mountcontroldbus.cpp
@@ -33,7 +33,14 @@ MountControlDBus::MountControlDBus(const char *name, QObject *parent)
     QDBusConnection::RegisterOptions opts =
             QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
 
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name)).registerObject(kMountControlObjPath, this, opts);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[MountControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(kMountControlObjPath, this, opts)) {
+        fmWarning() << "[MountControlDBus] failed to register object on path:" << kMountControlObjPath;
+    }
 }
 
 MountControlDBus::~MountControlDBus() { }

--- a/src/services/opticalshare/opticalsharedbus.cpp
+++ b/src/services/opticalshare/opticalsharedbus.cpp
@@ -24,8 +24,14 @@ OpticalShareDBus::OpticalShareDBus(const char *name, QObject *parent)
 {
     fmInfo() << "OpticalShareDBus: initializing service with name:" << name;
     adapter = new OpticalShareAdaptor(this);
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name))
-            .registerObject(GlobalServerDefines::OpticalShareDBusInfo::kPath, this, QDBusConnection::ExportAdaptors);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "OpticalShareDBus: failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(GlobalServerDefines::OpticalShareDBusInfo::kPath, this, QDBusConnection::ExportAdaptors)) {
+        fmWarning() << "OpticalShareDBus: failed to register object on path:" << GlobalServerDefines::OpticalShareDBusInfo::kPath;
+    }
 }
 
 OpticalShareDBus::~OpticalShareDBus()

--- a/src/services/sharecontrol/sharecontroldbus.cpp
+++ b/src/services/sharecontrol/sharecontroldbus.cpp
@@ -36,7 +36,14 @@ ShareControlDBus::ShareControlDBus(const char *name, QObject *parent)
 {
     fmInfo() << "[ShareControlDBus] Initializing share control service with name:" << name;
     adapter = new UserShareManagerAdaptor(this);
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name)).registerObject(kUserShareObjPath, this, QDBusConnection::ExportAdaptors);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[ShareControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(kUserShareObjPath, this, QDBusConnection::ExportAdaptors)) {
+        fmWarning() << "[ShareControlDBus] failed to register object on path:" << kUserShareObjPath;
+    }
     fmInfo() << "[ShareControlDBus] Share control service registered successfully";
 }
 

--- a/src/services/textindex/document/builderoptions.h
+++ b/src/services/textindex/document/builderoptions.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef BUILDEROPTIONS_H
+#define BUILDEROPTIONS_H
+
+#include "service_textindex_global.h"
+
+#include <QString>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+/**
+ * @brief Optional metadata passed to document builders
+ *
+ * Carries supplementary information that extends the basic
+ * (filePath, text) contract without polluting the virtual interface.
+ * Individual builders pick only the fields they need.
+ */
+struct BuilderOptions
+{
+    QString checksum;   ///< MD5 hex digest (optional, used by OCR builder)
+};
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // BUILDEROPTIONS_H

--- a/src/services/textindex/document/contentdocumentbuilder.cpp
+++ b/src/services/textindex/document/contentdocumentbuilder.cpp
@@ -18,8 +18,11 @@ using namespace Lucene;
 DFM_SEARCH_USE_NS
 using namespace DFMSEARCH::LuceneFieldNames;
 
-DocumentPtr ContentDocumentBuilder::build(const QString &filePath, const QString &text) const
+DocumentPtr ContentDocumentBuilder::build(const QString &filePath, const QString &text,
+                                          const BuilderOptions &options) const
 {
+    Q_UNUSED(options)
+
     DocumentPtr doc = newLucene<Document>();
 
     doc->add(newLucene<Field>(Content::kPath, filePath.toStdWString(),
@@ -42,6 +45,12 @@ DocumentPtr ContentDocumentBuilder::build(const QString &filePath, const QString
     NumericFieldPtr birthTimeField = newLucene<NumericField>(Content::kBirthTime, Field::STORE_YES, true);
     birthTimeField->setLongValue(birthTimeSecs);
     doc->add(birthTimeField);
+
+    // Add file size as NumericField for efficient range queries
+    const qint64 fileSize = fileInfo.size();
+    NumericFieldPtr fileSizeField = newLucene<NumericField>(Content::kFileSize, Field::STORE_YES, true);
+    fileSizeField->setLongValue(fileSize);
+    doc->add(fileSizeField);
 
     doc->add(newLucene<Field>(Content::kFilename, fileInfo.fileName().toStdWString(),
                               Field::STORE_YES, Field::INDEX_ANALYZED));

--- a/src/services/textindex/document/contentdocumentbuilder.h
+++ b/src/services/textindex/document/contentdocumentbuilder.h
@@ -12,7 +12,9 @@ SERVICETEXTINDEX_BEGIN_NAMESPACE
 class ContentDocumentBuilder : public IndexDocumentBuilder
 {
 public:
-    Lucene::DocumentPtr build(const QString &filePath, const QString &text) const override;
+    Lucene::DocumentPtr build(const QString &filePath,
+                              const QString &text,
+                              const BuilderOptions &options = {}) const override;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/document/indexdocumentbuilder.h
+++ b/src/services/textindex/document/indexdocumentbuilder.h
@@ -5,6 +5,7 @@
 #ifndef INDEXDOCUMENTBUILDER_H
 #define INDEXDOCUMENTBUILDER_H
 
+#include "document/builderoptions.h"
 #include "service_textindex_global.h"
 
 #include <QString>
@@ -18,7 +19,9 @@ class IndexDocumentBuilder
 public:
     virtual ~IndexDocumentBuilder() = default;
 
-    virtual Lucene::DocumentPtr build(const QString &filePath, const QString &text) const = 0;
+    virtual Lucene::DocumentPtr build(const QString &filePath,
+                                      const QString &text,
+                                      const BuilderOptions &options = {}) const = 0;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/document/ocrdocumentbuilder.cpp
+++ b/src/services/textindex/document/ocrdocumentbuilder.cpp
@@ -17,7 +17,8 @@ using namespace Lucene;
 DFM_SEARCH_USE_NS
 using namespace DFMSEARCH::LuceneFieldNames;
 
-DocumentPtr OcrDocumentBuilder::build(const QString &filePath, const QString &text) const
+DocumentPtr OcrDocumentBuilder::build(const QString &filePath, const QString &text,
+                                       const BuilderOptions &options) const
 {
     DocumentPtr doc = newLucene<Document>();
 
@@ -44,6 +45,12 @@ DocumentPtr OcrDocumentBuilder::build(const QString &filePath, const QString &te
     birthTimeField->setLongValue(birthTimeSecs);
     doc->add(birthTimeField);
 
+    // Add file size as NumericField for efficient range queries
+    const qint64 fileSize = fileInfo.size();
+    NumericFieldPtr fileSizeField = newLucene<NumericField>(OcrText::kFileSize, Field::STORE_YES, true);
+    fileSizeField->setLongValue(fileSize);
+    doc->add(fileSizeField);
+
     doc->add(newLucene<Field>(OcrText::kFilename, fileInfo.fileName().toStdWString(),
                               Field::STORE_YES, Field::INDEX_ANALYZED));
 
@@ -52,6 +59,12 @@ DocumentPtr OcrDocumentBuilder::build(const QString &filePath, const QString &te
             : QStringLiteral("N");
     doc->add(newLucene<Field>(OcrText::kIsHidden, hiddenTag.toStdWString(),
                               Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
+
+    // Add MD5 checksum for deduplication (exact match, not tokenized)
+    if (!options.checksum.isEmpty()) {
+        doc->add(newLucene<Field>(OcrText::kCheckSum, options.checksum.toStdWString(),
+                                  Field::STORE_YES, Field::INDEX_NOT_ANALYZED));
+    }
 
     if (!text.trimmed().isEmpty()) {
         doc->add(newLucene<Field>(OcrText::kOcrContents, text.trimmed().toStdWString(),

--- a/src/services/textindex/document/ocrdocumentbuilder.h
+++ b/src/services/textindex/document/ocrdocumentbuilder.h
@@ -12,7 +12,9 @@ SERVICETEXTINDEX_BEGIN_NAMESPACE
 class OcrDocumentBuilder : public IndexDocumentBuilder
 {
 public:
-    Lucene::DocumentPtr build(const QString &filePath, const QString &text) const override;
+    Lucene::DocumentPtr build(const QString &filePath,
+                              const QString &text,
+                              const BuilderOptions &options = {}) const override;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/extractor/indexextractor.h
+++ b/src/services/textindex/extractor/indexextractor.h
@@ -16,6 +16,8 @@ struct IndexExtractionResult
     bool success { false };
     QString text;
     QString error;
+    QString checksum;       ///< MD5 hex digest of the source file (if computed)
+    bool deduplicated { false };  ///< true if text was obtained via checksum deduplication
 };
 
 class IndexExtractor

--- a/src/services/textindex/extractor/ocrdeduplication.cpp
+++ b/src/services/textindex/extractor/ocrdeduplication.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "ocrdeduplication.h"
+#include "utils/scopeguard.h"
+
+#include <dfm-search/field_names.h>
+
+#include <lucene++/LuceneHeaders.h>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+using namespace Lucene;
+DFM_SEARCH_USE_NS
+using namespace DFMSEARCH::LuceneFieldNames;
+
+namespace OcrDeduplication {
+
+QString lookupByTextChecksum(const QString &checksum, const QString &ocrIndexDir)
+{
+    if (checksum.isEmpty() || ocrIndexDir.isEmpty()) {
+        return {};
+    }
+
+    try {
+        IndexReaderPtr reader = IndexReader::open(
+                FSDirectory::open(ocrIndexDir.toStdWString()), true);
+
+        ScopeGuard readerCloser([&reader]() {
+            try {
+                if (reader) {
+                    reader->close();
+                }
+            } catch (...) {
+            }
+        });
+
+        SearcherPtr searcher = newLucene<IndexSearcher>(reader);
+        TermQueryPtr query = newLucene<TermQuery>(
+                newLucene<Term>(OcrText::kCheckSum, checksum.toStdWString()));
+
+        TopDocsPtr topDocs = searcher->search(query, 1);
+
+        if (topDocs->totalHits == 0) {
+            return {};
+        }
+
+        DocumentPtr doc = searcher->doc(topDocs->scoreDocs[0]->doc);
+        const String ocrContents = doc->get(OcrText::kOcrContents);
+
+        return ocrContents.empty() ? QString()
+                                   : QString::fromStdWString(ocrContents);
+    } catch (...) {
+        // Deduplication is a best-effort optimization.
+        // On any failure, fall through to normal OCR extraction.
+        return {};
+    }
+}
+
+}   // namespace OcrDeduplication
+
+SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/extractor/ocrdeduplication.h
+++ b/src/services/textindex/extractor/ocrdeduplication.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef OCRDEDUPLICATION_H
+#define OCRDEDUPLICATION_H
+
+#include "service_textindex_global.h"
+
+#include <QString>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+namespace OcrDeduplication {
+
+/**
+ * @brief Attempt to find existing OCR text by file checksum
+ *
+ * Opens the OCR index read-only, searches for a document with matching
+ * checksum, and returns the ocr_contents text if found.
+ *
+ * This is a best-effort optimization: on any failure (index unavailable,
+ * corrupt, etc.) it returns an empty string so normal OCR extraction proceeds.
+ *
+ * @param checksum  MD5 hex digest of the file
+ * @param ocrIndexDir  Path to the OCR Lucene index directory
+ * @return The OCR text if a matching document was found, empty string otherwise
+ */
+QString lookupByTextChecksum(const QString &checksum, const QString &ocrIndexDir);
+
+}   // namespace OcrDeduplication
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // OCRDEDUPLICATION_H

--- a/src/services/textindex/profile/indexprofile.cpp
+++ b/src/services/textindex/profile/indexprofile.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "indexprofile.h"
+#include "extractor/ocrdeduplication.h"
+#include "utils/filehash.h"
 #include "utils/indexutility.h"
 #include "utils/textindexconfig.h"
 
@@ -19,7 +21,9 @@ IndexProfile::IndexProfile(Type type,
                            AvailabilityChecker availabilityChecker,
                            ScopeChecker scopeChecker,
                            CandidateChecker candidateChecker,
-                           AnythingSearchOptionsProvider anythingSearchOptionsProvider)
+                           AnythingSearchOptionsProvider anythingSearchOptionsProvider,
+                           ChecksumProvider checksumProvider,
+                           TextCacheLookup textCacheLookup)
     : m_type(type),
       m_id(std::move(id)),
       m_statusFileName(std::move(statusFileName)),
@@ -29,7 +33,9 @@ IndexProfile::IndexProfile(Type type,
       m_availabilityChecker(std::move(availabilityChecker)),
       m_scopeChecker(std::move(scopeChecker)),
       m_candidateChecker(std::move(candidateChecker)),
-      m_anythingSearchOptionsProvider(std::move(anythingSearchOptionsProvider))
+      m_anythingSearchOptionsProvider(std::move(anythingSearchOptionsProvider)),
+      m_checksumProvider(std::move(checksumProvider)),
+      m_textCacheLookup(std::move(textCacheLookup))
 {
 }
 
@@ -93,6 +99,21 @@ bool IndexProfile::supportsAnything() const
     return !anythingSearchOptions().isEmpty();
 }
 
+QString IndexProfile::computeChecksum(const QString &filePath) const
+{
+    return m_checksumProvider ? m_checksumProvider(filePath) : QString();
+}
+
+QString IndexProfile::lookupCachedText(const QString &checksum) const
+{
+    return m_textCacheLookup ? m_textCacheLookup(checksum) : QString();
+}
+
+bool IndexProfile::supportsChecksum() const
+{
+    return static_cast<bool>(m_checksumProvider);
+}
+
 IndexProfile IndexProfile::content()
 {
     return IndexProfile {
@@ -116,6 +137,10 @@ IndexProfile IndexProfile::content()
 
 IndexProfile IndexProfile::ocr()
 {
+    // Capture OCR index directory for use in the text cache lookup lambda.
+    // This avoids repeatedly querying the global function on every lookup call.
+    const QString ocrIndexDir = DFMSEARCH::Global::ocrTextIndexDirectory();
+
     return IndexProfile {
         Type::Ocr,
         QStringLiteral("ocr"),
@@ -131,6 +156,12 @@ IndexProfile IndexProfile::ocr()
                 { Defines::kAnythingPicType },
                 TextIndexConfig::instance().supportedOcrImageExtensions()
             };
+        },
+        // ChecksumProvider: compute file MD5
+        [](const QString &filePath) { return FileHash::computeMd5(filePath); },
+        // TextCacheLookup: find existing OCR text by checksum
+        [ocrIndexDir](const QString &checksum) {
+            return OcrDeduplication::lookupByTextChecksum(checksum, ocrIndexDir);
         }
     };
 }

--- a/src/services/textindex/profile/indexprofile.h
+++ b/src/services/textindex/profile/indexprofile.h
@@ -34,6 +34,8 @@ public:
     using ScopeChecker = std::function<bool(const QString &)>;
     using CandidateChecker = std::function<bool(const QString &)>;
     using AnythingSearchOptionsProvider = std::function<AnythingSearchOptions()>;
+    using ChecksumProvider = std::function<QString(const QString &filePath)>;
+    using TextCacheLookup = std::function<QString(const QString &checksum)>;
 
     IndexProfile() = default;
     IndexProfile(Type type,
@@ -45,7 +47,9 @@ public:
                  AvailabilityChecker availabilityChecker,
                  ScopeChecker scopeChecker,
                  CandidateChecker candidateChecker,
-                 AnythingSearchOptionsProvider anythingSearchOptionsProvider = {});
+                 AnythingSearchOptionsProvider anythingSearchOptionsProvider = {},
+                 ChecksumProvider checksumProvider = {},
+                 TextCacheLookup textCacheLookup = {});
 
     Type type() const;
     const QString &id() const;
@@ -58,6 +62,20 @@ public:
     bool isCandidateFile(const QString &path) const;
     AnythingSearchOptions anythingSearchOptions() const;
     bool supportsAnything() const;
+
+    /**
+     * @brief Compute a checksum for the given file, if the profile supports it
+     * @return Checksum string, or empty if the profile does not support checksumming
+     */
+    QString computeChecksum(const QString &filePath) const;
+
+    /**
+     * @brief Look up cached extraction text by checksum, if the profile supports it
+     * @return Cached text, or empty if no cache hit or not supported
+     */
+    QString lookupCachedText(const QString &checksum) const;
+
+    bool supportsChecksum() const;
 
     static IndexProfile content();
     static IndexProfile ocr();
@@ -73,6 +91,8 @@ private:
     ScopeChecker m_scopeChecker;
     CandidateChecker m_candidateChecker;
     AnythingSearchOptionsProvider m_anythingSearchOptionsProvider;
+    ChecksumProvider m_checksumProvider;
+    TextCacheLookup m_textCacheLookup;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/task/taskhandler.cpp
+++ b/src/services/textindex/task/taskhandler.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "taskhandler.h"
+#include "document/builderoptions.h"
 #include "fileprovider.h"
 #include "progressnotifier.h"
 #include "moveprocessor.h"
@@ -229,14 +230,33 @@ DocumentPtr createFileDocument(const IndexContext &context, const QString &file)
                 : config.maxIndexFileTruncationSizeMB();
         const size_t maxBytes = static_cast<size_t>(truncationSizeMB) * 1024 * 1024;
 
-        const IndexExtractionResult extraction = context.extractor()->extract(file, maxBytes);
-        if (!extraction.success) {
-            fmInfo() << "[createFileDocument] Failed to extract content from file:" << file
-                     << "profile:" << context.profile().id()
-                     << "error:" << extraction.error;
+        BuilderOptions options;
+        IndexExtractionResult extraction;
+
+        // Checksum-based deduplication (profile decides whether to support it)
+        options.checksum = context.profile().computeChecksum(file);
+        if (!options.checksum.isEmpty()) {
+            const QString cachedText = context.profile().lookupCachedText(options.checksum);
+            if (!cachedText.isEmpty()) {
+                fmInfo() << "[createFileDocument] Text cache hit for:" << file
+                         << "profile:" << context.profile().id()
+                         << "checksum:" << options.checksum;
+                extraction = { true, cachedText, QString(), options.checksum, true };
+            }
         }
 
-        return context.documentBuilder()->build(file, extraction.text);
+        // If cache did not provide text, perform normal extraction
+        if (extraction.text.isEmpty() && !extraction.deduplicated) {
+            extraction = context.extractor()->extract(file, maxBytes);
+            if (!extraction.success) {
+                fmInfo() << "[createFileDocument] Failed to extract content from file:" << file
+                         << "profile:" << context.profile().id()
+                         << "error:" << extraction.error;
+            }
+            extraction.checksum = options.checksum;
+        }
+
+        return context.documentBuilder()->build(file, extraction.text, options);
     } catch (const LuceneException &e) {
         fmWarning() << "[createFileDocument] Create document failed with Lucene exception:" << file
                     << "error:" << QString::fromStdWString(e.getError());

--- a/src/services/textindex/utils/filehash.cpp
+++ b/src/services/textindex/utils/filehash.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "filehash.h"
+
+#include <QCryptographicHash>
+#include <QFile>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+namespace FileHash {
+
+QString computeMd5(const QString &filePath)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+
+    QCryptographicHash hash(QCryptographicHash::Md5);
+    if (!hash.addData(&file)) {
+        return {};
+    }
+
+    return QString::fromLatin1(hash.result().toHex());
+}
+
+}   // namespace FileHash
+
+SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/utils/filehash.h
+++ b/src/services/textindex/utils/filehash.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FILEHASH_H
+#define FILEHASH_H
+
+#include "service_textindex_global.h"
+
+#include <QString>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+namespace FileHash {
+
+/**
+ * @brief Compute MD5 checksum of a file
+ * @param filePath Absolute path to the file
+ * @return MD5 hex digest string (32 lowercase chars), or empty string on failure
+ */
+QString computeMd5(const QString &filePath);
+
+}   // namespace FileHash
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // FILEHASH_H

--- a/src/services/tpmcontrol/tpmcontroldbus.cpp
+++ b/src/services/tpmcontrol/tpmcontroldbus.cpp
@@ -30,8 +30,14 @@ TPMControlDBus::TPMControlDBus(const char *name, QObject *parent)
             QDBusConnection::ExportAllSignals |
             QDBusConnection::ExportAllProperties;
 
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name))
-            .registerObject("/org/deepin/Filemanager/TPMControl", this, opts);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[TPMControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject("/org/deepin/Filemanager/TPMControl", this, opts)) {
+        fmWarning() << "[TPMControlDBus] failed to register object on path: /org/deepin/Filemanager/TPMControl";
+    }
 
     fmInfo() << "TPMControlDBus registered on SystemBus";
 }


### PR DESCRIPTION
1. Added explicit error checking for D-Bus connection status
2. Added failure handling when registering D-Bus objects fails
3. Added warning logs for all failure cases
4. Applied consistent error handling pattern across multiple service
classes (AccessControl, MountControl, OpticalShare, ShareControl,
TPMControl)

Influence:
1. Test with disabled/blocked system D-Bus to verify error logs
2. Verify service behavior when D-Bus registration fails
3. Check warning messages appear in logs for all failure scenarios
4. Test service availability after connection/registration failures

fix: 为D-Bus连接和注册添加错误处理

1. 添加了对D-Bus连接状态的显式错误检查
2. 添加了D-Bus对象注册失败时的处理逻辑
3. 为所有失败情况添加了警告日志
4. 在多个服务类(AccessControl, MountControl, OpticalShare, ShareControl,
TPMControl)中应用了统一的错误处理模式

Influence:
1. 测试禁用/阻塞系统D-Bus时的错误日志
2. 验证D-Bus注册失败时的服务行为
3. 检查所有失败场景下警告信息是否正确记录
4. 测试连接/注册失败后的服务可用性

Fixes: #361265

## Summary by Sourcery

Harden D-Bus service initialization by handling connection and registration failures across service DBus classes.

Bug Fixes:
- Prevent silent failures when connecting to the system D-Bus or registering service objects by checking connection status and registration results.

Enhancements:
- Add consistent warning logging for D-Bus connection and object registration failures in AccessControl, MountControl, OpticalShare, ShareControl, and TPMControl services.