### PR TITLE
fix: add error handling for D-Bus connection and registration

### DIFF
--- a/src/services/accesscontrol/accesscontroldbus.cpp
+++ b/src/services/accesscontrol/accesscontroldbus.cpp
@@ -59,7 +59,14 @@ AccessControlDBus::AccessControlDBus(const char *name, QObject *parent)
     QDBusConnection::RegisterOptions opts =
             QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
 
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name)).registerObject(kAccessControlManagerObjPath, this, opts);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[AccessControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(kAccessControlManagerObjPath, this, opts)) {
+        fmWarning() << "[AccessControlDBus] failed to register object on path:" << kAccessControlManagerObjPath;
+    }
 }
 
 AccessControlDBus::~AccessControlDBus()

--- a/src/services/mountcontrol/mountcontroldbus.cpp
+++ b/src/services/mountcontrol/mountcontroldbus.cpp
@@ -33,7 +33,14 @@ MountControlDBus::MountControlDBus(const char *name, QObject *parent)
     QDBusConnection::RegisterOptions opts =
             QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
 
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name)).registerObject(kMountControlObjPath, this, opts);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[MountControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(kMountControlObjPath, this, opts)) {
+        fmWarning() << "[MountControlDBus] failed to register object on path:" << kMountControlObjPath;
+    }
 }
 
 MountControlDBus::~MountControlDBus() { }

--- a/src/services/opticalshare/opticalsharedbus.cpp
+++ b/src/services/opticalshare/opticalsharedbus.cpp
@@ -24,8 +24,14 @@ OpticalShareDBus::OpticalShareDBus(const char *name, QObject *parent)
 {
     fmInfo() << "OpticalShareDBus: initializing service with name:" << name;
     adapter = new OpticalShareAdaptor(this);
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name))
-            .registerObject(GlobalServerDefines::OpticalShareDBusInfo::kPath, this, QDBusConnection::ExportAdaptors);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "OpticalShareDBus: failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(GlobalServerDefines::OpticalShareDBusInfo::kPath, this, QDBusConnection::ExportAdaptors)) {
+        fmWarning() << "OpticalShareDBus: failed to register object on path:" << GlobalServerDefines::OpticalShareDBusInfo::kPath;
+    }
 }
 
 OpticalShareDBus::~OpticalShareDBus()

--- a/src/services/sharecontrol/sharecontroldbus.cpp
+++ b/src/services/sharecontrol/sharecontroldbus.cpp
@@ -36,7 +36,14 @@ ShareControlDBus::ShareControlDBus(const char *name, QObject *parent)
 {
     fmInfo() << "[ShareControlDBus] Initializing share control service with name:" << name;
     adapter = new UserShareManagerAdaptor(this);
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name)).registerObject(kUserShareObjPath, this, QDBusConnection::ExportAdaptors);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[ShareControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject(kUserShareObjPath, this, QDBusConnection::ExportAdaptors)) {
+        fmWarning() << "[ShareControlDBus] failed to register object on path:" << kUserShareObjPath;
+    }
     fmInfo() << "[ShareControlDBus] Share control service registered successfully";
 }
 

--- a/src/services/tpmcontrol/tpmcontroldbus.cpp
+++ b/src/services/tpmcontrol/tpmcontroldbus.cpp
@@ -30,8 +30,14 @@ TPMControlDBus::TPMControlDBus(const char *name, QObject *parent)
             QDBusConnection::ExportAllSignals |
             QDBusConnection::ExportAllProperties;
 
-    QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name))
-            .registerObject("/org/deepin/Filemanager/TPMControl", this, opts);
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    if (!conn.isConnected()) {
+        fmWarning() << "[TPMControlDBus] failed to connect to system bus";
+        return;
+    }
+    if (!conn.registerObject("/org/deepin/Filemanager/TPMControl", this, opts)) {
+        fmWarning() << "[TPMControlDBus] failed to register object on path: /org/deepin/Filemanager/TPMControl";
+    }
 
     fmInfo() << "TPMControlDBus registered on SystemBus";
 }


### PR DESCRIPTION
1. Added explicit error checking for D-Bus connection status
2. Added failure handling when registering D-Bus objects fails
3. Added warning logs for all failure cases
4. Applied consistent error handling pattern across multiple service classes (AccessControl, MountControl, OpticalShare, ShareControl, TPMControl)

Influence:
1. Test with disabled/blocked system D-Bus to verify error logs
2. Verify service behavior when D-Bus registration fails
3. Check warning messages appear in logs for all failure scenarios
4. Test service availability after connection/registration failures

fix: 为D-Bus连接和注册添加错误处理

1. 添加了对D-Bus连接状态的显式错误检查
2. 添加了D-Bus对象注册失败时的处理逻辑
3. 为所有失败情况添加了警告日志
4. 在多个服务类(AccessControl, MountControl, OpticalShare, ShareControl, TPMControl)中应用了统一的错误处理模式

Influence:
1. 测试禁用/阻塞系统D-Bus时的错误日志
2. 验证D-Bus注册失败时的服务行为
3. 检查所有失败场景下警告信息是否正确记录
4. 测试连接/注册失败后的服务可用性

Fixes: #361265

## Summary by Sourcery

Add robust D-Bus connection and object registration error handling across multiple service DBus classes.

Bug Fixes:
- Handle failures to connect to the system D-Bus bus before registering service objects.
- Log and safely handle failures when registering D-Bus objects for affected services.

Enhancements:
- Apply a consistent D-Bus error handling and warning-logging pattern to AccessControl, MountControl, OpticalShare, ShareControl, and TPMControl DBus services.