### PR TITLE
fix: correct cursor wait handling in file sorting

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -1441,7 +1441,7 @@ void FileViewModel::connectFilterSortWorkSignals()
             },
             Qt::QueuedConnection);
     connect(
-            filterSortWorker.data(), &FileSortWorker::reqUestCloseCursor, this, [this] {
+            filterSortWorker.data(), &FileSortWorker::requestCloseCursor, this, [this] {
                 closeCursorTimer();
             },
             Qt::QueuedConnection);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1232,6 +1232,11 @@ void FileSortWorker::checkNameFilters(const FileItemDataPointer itemData)
 
 void FileSortWorker::filterAllFilesOrdered()
 {
+    emit requestCursorWait();
+    FinallyUtil release([this] {
+        emit requestCloseCursor();
+    });
+
     visibleTreeChildren.clear();
     filterAndSortFiles(current, true, false);
 }
@@ -1293,7 +1298,7 @@ void FileSortWorker::resortCurrent(const bool reverse)
     if (isCurrentGroupingEnabled) {
         applyGrouping(getAllFiles());
     }
-    emit reqUestCloseCursor();
+    emit requestCloseCursor();
 }
 
 QList<QUrl> FileSortWorker::filterFilesByParent(const QUrl &dir, const bool byInfo)
@@ -1986,7 +1991,7 @@ bool FileSortWorker::checkAndUpdateFileInfoUpdate()
         if (!mimeSorting) {
             waitUpdatedFiles.clear();
             if (isCanceled)
-                emit reqUestCloseCursor();
+                emit requestCloseCursor();
             return !isCanceled;
         }
         auto info = item->fileInfo();
@@ -2095,7 +2100,7 @@ void FileSortWorker::applyGrouping(const QList<FileItemDataPointer> &files)
 
     emit requestCursorWait();
     FinallyUtil release([this] {
-        emit reqUestCloseCursor();
+        emit requestCloseCursor();
     });
 
     // Perform grouping using GroupingEngine

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.h
@@ -123,7 +123,7 @@ signals:
 
     void requestUpdateView();
     void requestCursorWait();
-    void reqUestCloseCursor();
+    void requestCloseCursor();
 
     // Grouping-related signals
     void groupDataChanged();


### PR DESCRIPTION
1. Added cursor wait request before file sorting operation begins
2. Implemented FinallyUtil to ensure cursor is properly released after
sorting
3. Fixed typo in cursor release emit (changed reqUestCloseCursor to
requestCloseCursor)
4. Maintains proper cursor state during resource-intensive file
operations

Log: Fixed cursor state handling during file sorting operations

Influence:
1. Test file sorting in workspace with large number of files
2. Verify cursor displays wait state during sorting
3. Confirm cursor returns to normal state after completion
4. Check performance impact with various file quantities

fix: 修复文件排序时的光标等待处理

1. 在文件排序操作开始前添加了光标等待请求
2. 使用FinallyUtil确保排序后正确释放光标
3. 修正了光标释放的emit拼写错误(从reqUestCloseCursor改为
requestCloseCursor)
4. 在资源密集型文件操作期间保持正确的光标状态

Log: 修复了文件排序时光标状态处理问题

Influence:
1. 测试处理大量文件时的排序功能
2. 验证排序期间光标显示等待状态
3. 确认完成后光标恢复正常状态
4. 检查不同文件数量下的性能影响
