### PR TITLE
fix: reset file index when restoring defaults

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.search.json
+++ b/assets/configs/org.deepin.dde.file-manager.search.json
@@ -2,6 +2,17 @@
     "magic":"dsg.config.meta",
     "version":"1.0",
     "contents":{
+        "enableFileIndexSearch": {
+            "value":true,
+            "serial":0,
+            "flags":[],
+            "name":"Enable File Index Search",
+            "name[zh_CN]":"开启文件索引搜索",
+            "description[zh_CN]":"用于恢复默认设置时判断是否启用文件索引",
+            "description":"Used for restore defaults to determine whether to enable file index",
+            "permissions":"readwrite",
+            "visibility":"private"
+        },
         "enableFullTextSearch": {
             "value":true,
             "serial":0,

--- a/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
+++ b/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
@@ -48,6 +48,7 @@ inline constexpr char kOcrTextSearch[] { SEARCH_SETTING_GROUP ".02_ocr_text_sear
 
 namespace DConfig {
 inline constexpr char kSearchCfgPath[] { "org.deepin.dde.file-manager.search" };
+inline constexpr char kEnableFileIndexSearch[] { "enableFileIndexSearch" };
 inline constexpr char kEnableFullTextSearch[] { "enableFullTextSearch" };
 inline constexpr char kEnableOcrTextSearch[] { "enableOcrTextSearch" };
 }

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -155,6 +155,19 @@ void Search::regSearchSettingConfig()
                                                   { "type", "checkBoxWidthFileIndex" },
                                                   { "default", true } });
 
+    SettingBackend::instance()->addSettingAccessor(
+            SearchSettings::kFileIndexSearch,
+            []() {
+                return DConfigManager::instance()->value(DConfig::kSearchCfgPath,
+                                                         DConfig::kEnableFileIndexSearch,
+                                                         true);
+            },
+            [](const QVariant &val) {
+                DConfigManager::instance()->setValue(DConfig::kSearchCfgPath,
+                                                     DConfig::kEnableFileIndexSearch,
+                                                     val);
+            });
+
     QString textIndexKey { SearchSettings::kFulltextSearch };
     DialogManager::instance()->registerSettingWidget("checkBoxWidthTextIndex", &SearchHelper::createCheckBoxWidthTextIndex);
     SettingJsonGenerator::instance()->addConfig(SearchSettings::kFulltextSearch,

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -393,6 +393,14 @@ QWidget *SearchHelper::createCheckBoxWidthFileIndex(QObject *opt)
     cb->setDisplayText(qApp->translate("QObject", text.toStdString().c_str()));
     cb->initStatusBar();
 
+    QObject::connect(cb, &IndexStatusCheckBox::checkStateChanged, option, [=](Qt::CheckState state) {
+        option->setValue(state == Qt::CheckState::Checked);
+    });
+    QObject::connect(option, &Dtk::Core::DSettingsOption::valueChanged, cb, [cb](const QVariant &value) {
+        if (value.toBool() && !cb->isChecked())
+            cb->setChecked(true);
+    });
+
     return cb;
 }
 


### PR DESCRIPTION
Added enableFileIndexSearch configuration to track and reset file index
state during default settings restoration. The change includes:
1. New DConfig key kEnableFileIndexSearch to manage file index state
2. Setting accessor to handle file index search configuration
3. Synchronization between UI checkbox and configuration value
4. Chinese and English descriptions explaining the purpose of this
setting

Log: Fixed issue where file index wasn't reset when restoring default
settings

Influence:
1. Test restoring default settings - verify file index search gets reset
properly
2. Verify file index toggle in settings works correctly
3. Check synchronization between UI and configuration values
4. Test search functionality with different file index states

fix: 修复重置默认设置时文件索引未重置的问题

新增enableFileIndexSearch配置用于在恢复默认设置时追踪和重置文件索引状
态。具体修改包括:
1. 新增DConfig键kEnableFileIndexSearch管理文件索引状态
2. 设置访问器处理文件索引搜索配置
3. 同步UI复选框和配置值
4. 添加中英文说明解释该设置的目的

Log: 修复了恢复默认设置时文件索引无法重置的问题

Influence:
1. 测试恢复默认设置 - 验证文件索引搜索是否正确重置
2. 验证设置中的文件索引开关工作正常
3. 检查UI与配置值之间的同步情况
4. 测试不同文件索引状态下的搜索功能

Bug: https://pms.uniontech.com/bug-view-361847.html
