### PR TITLE
master

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.139) unstable; urgency=medium
+
+  * fix: launch dde-file-manager-pkexec correctly under Treeland
+  * fix: improve file renaming filename/suffix handling
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 21 May 2026 22:39:06 +0800
+
 dde-file-manager (6.5.138) unstable; urgency=medium
 
   * fix: trim whitespace in tag editor input

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
@@ -10,6 +10,7 @@
 #include <dfm-base/utils/thumbnail/thumbnailfactory.h>
 
 #include <QStandardPaths>
+#include <QFileInfo>
 
 using namespace dfmbase;
 using namespace dfmbase::Global;
@@ -191,11 +192,11 @@ QVariant FileItemData::data(int role) const
     case kItemFileBaseNameOfRenameRole:
         if (info)
             return info->nameOf(NameInfoType::kBaseNameOfRename);
-        return url.fileName();
+        return QFileInfo(url.path()).completeBaseName();
     case kItemFileSuffixOfRenameRole:
         if (info)
             return info->nameOf(NameInfoType::kSuffixOfRename);
-        return url.fileName();
+        return QFileInfo(url.path()).completeSuffix();
     case kItemUrlRole:
         if (info)
             return info->urlOf(UrlInfoType::kUrl);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -179,6 +179,9 @@ void ListItemDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionV
 
 void ListItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
+    // Fix: prewarm fileinfo before reading rename suffix/base name, otherwise
+    // list/tree rename can fall back to the raw file name and duplicate suffixes.
+    index.data(kItemCreateFileInfoRole);
     // 这里设置了光标选中位置后最终还是会被全选，移到eventFilter中处理
     return QAbstractItemDelegate::setEditorData(editor, index);
 }


### PR DESCRIPTION
- **fix: improve file renaming filename/suffix handling**
- **chore: bump version to 6.5.139**

## Summary by Sourcery

Improve filename and suffix handling during file renaming and update the package version.

Bug Fixes:
- Ensure file rename base name and suffix are derived correctly for list and tree views, avoiding duplicated suffixes when editing names.

Enhancements:
- Prewarm file info in the list item delegate before initializing the rename editor to ensure consistent rename behavior.

Chores:
- Bump package version to 6.5.139 in the Debian changelog.