### PR TITLE
fix: improve text layout handling for fractional scaling

### DIFF
--- a/src/dfm-base/utils/elidetextlayout.cpp
+++ b/src/dfm-base/utils/elidetextlayout.cpp
@@ -12,6 +12,8 @@
 #include <QTextBlock>
 #include <QDebug>
 
+#include <cmath>
+
 #include <dfm-base/dfm_base_global.h>
 
 using namespace dfmbase;
@@ -354,7 +356,9 @@ QList<QRectF> ElideTextLayout::layout(const QRectF &rect, Qt::TextElideMode elid
     auto processLine = [this, &ret, painter, &lastLineRect, background, textLineHeight, &curText, textLines,
                         paintLineWithHighlight, &currentMatches](QTextLine &line) {
         QRectF lRect = line.naturalTextRect();
-        lRect.setHeight(textLineHeight);
+        // Fix clipping on fractional scaling: keep the line rect large enough for
+        // Qt's actual text layout metrics instead of truncating to the logical line height.
+        lRect.setHeight(qMax<qreal>(textLineHeight, std::ceil(line.height())));
 
         ret.append(lRect);
         if (textLines) {

--- a/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/expandedItem.cpp
@@ -78,12 +78,12 @@ void ExpandedItem::paintEvent(QPaintEvent *)
     WorkspaceEventSequence::instance()->doIconItemLayoutText(info, layout.data());
     const QList<QRectF> lines = layout->layout(labelRect, option.textElideMode, &pa, option.palette.brush(QPalette::Normal, QPalette::Highlight), &textList);
 
-    textBounding = GlobalPrivate::boundingRect(lines).toRect();
+    textBounding = GlobalPrivate::boundingRect(lines);
 }
 
 QSize ExpandedItem::sizeHint() const
 {
-    return QSize(width(), static_cast<int>(std::floor(textGeometry().bottom() + contentsMargins().bottom())));
+    return QSize(width(), static_cast<int>(std::ceil(textGeometry().bottom() + contentsMargins().bottom())));
 }
 
 int ExpandedItem::heightForWidth(int width) const
@@ -91,7 +91,7 @@ int ExpandedItem::heightForWidth(int width) const
     if (width != this->width())
         textBounding = QRect();
 
-    return static_cast<int>(std::floor(textGeometry(width).bottom() + contentsMargins().bottom()));
+    return static_cast<int>(std::ceil(textGeometry(width).bottom() + contentsMargins().bottom()));
 }
 
 qreal ExpandedItem::getOpacity() const

--- a/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/iconitemdelegate.cpp
@@ -6,7 +6,6 @@
 #include "iconitemdelegate.h"
 #include "private/iconitemdelegate_p.h"
 
-#include <QMouseEvent>
 #include "utils/itemdelegatehelper.h"
 #include "utils/fileviewhelper.h"
 #include "fileview.h"
@@ -44,6 +43,7 @@
 #include <QPainterPath>
 #include <QToolTip>
 #include <QtMath>
+#include <QMouseEvent>
 
 #include <linux/limits.h>
 


### PR DESCRIPTION
1. Added math header inclusion for std::ceil usage
2. Modified line height calculation to prevent clipping under fractional
scaling by using maximum of logical height or actual text metrics
3. Changed floor to ceil in size calculations to avoid clipping of text
4. Cleaned up header includes in iconitemdelegate.cpp

The changes address rendering issues that occur with fractional scaling
displays, particularly preventing text clipping by:
1. Ensuring text layout boxes are large enough for the actual text
2. Rounding up instead of down for height calculations
3. Making bounding rect calculations consistent with the new approach

Log: Fixed text clipping issues on high DPI displays with fractional
scaling

Influence:
1. Test text rendering on displays with fractional scaling (e.g. 125%,
150%)
2. Verify no text clipping occurs with various font sizes
3. Check layout consistency between different scaling factors
4. Test with long filenames and wrapped text

fix: 改进分数缩放的文本布局处理

1. 添加数学头文件以使用 std::ceil
2. 修改行高计算以防分数缩放下的文本裁剪，使用逻辑高度或实际文本高度的最
大值
3. 将尺寸计算中的 floor 改为 ceil 避免文本裁剪
4. 清理 iconitemdelegate.cpp 的头文件包含

这些更改解决了分数缩放显示器上的渲染问题，特别是通过以下方式防止文本
裁剪：
1. 确保文本布局框足够大以容纳实际文本
2. 在高度计算中向上取整而非向下取整
3. 使边界框计算与新方法保持一致

Log: 修复了高DPI显示器上分数缩放的文本裁剪问题

Influence:
1. 在分数缩放的显示器上测试文本渲染(如125%, 150%)
2. 验证不同字号下没有文本裁剪
3. 检查不同缩放因子下的布局一致性
4. 测试长文件名和换行文本

Fixes: #363253

## Summary by Sourcery

Improve text layout sizing to prevent text clipping on fractional scaling and high-DPI displays.

Bug Fixes:
- Avoid clipping of text lines under fractional display scaling by ensuring line rect heights respect actual text metrics.
- Prevent vertical text truncation in expanded item sizing by rounding height calculations up instead of down.

Enhancements:
- Simplify and correct header includes in icon item delegate to match actual usage.