### PR TITLE
perf: remove redundant index optimization in UpdateIndexHandler

### DIFF
--- a/src/services/textindex/task/taskhandler.cpp
+++ b/src/services/textindex/task/taskhandler.cpp
@@ -855,18 +855,13 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
                 result.interrupted = true;
             }
 
-            // ProgressReporter的析构函数会处理最后的commit，但为了确保在optimize前所有更改都已提交
-            // 我们显式调用一次commit
-            fmDebug() << "[UpdateIndexHandler] Ensuring all changes are committed before optimization";
+            // ProgressReporter的析构函数会处理最后的commit，确保所有更改都已提交
+            fmDebug() << "[UpdateIndexHandler] Ensuring all changes are committed";
             writer->commit();
 
-            if (!running.isSilent()) {
-                fmDebug() << "[UpdateIndexHandler] Starting index optimization";
-                writer->optimize();
-                fmDebug() << "[UpdateIndexHandler] Index optimization completed";
-            } else {
-                fmInfo() << "[UpdateIndexHandler] Skipping index optimization in silent mode";
-            }
+            // 不再调用 optimize()：增量更新场景下 lucene++ 的自动合并策略已足够保证查询性能
+            // optimize() 会强制合并所有 segment 为单个 segment，产生巨大的 IO 开销
+            fmDebug() << "[UpdateIndexHandler] Relying on lucene++ automatic merge policy instead of optimize";
 
             // 仅在完整完成时清理旧索引；中断时保留 .old 供下次恢复使用
             if (!result.interrupted) {


### PR DESCRIPTION
The change removes explicit index optimization (writer->optimize())
in the UpdateIndexHandler, relying instead on lucene++'s automatic
merge policy. The optimization was causing unnecessary IO overhead by
forcing all segments to merge into one, which is particularly costly in
incremental update scenarios.

Additionally, simplified debug messages to better reflect the current
behavior and rationale. The ProgressReporter's destructor already
handles the final commit, so the explicit commit remains as an
additional safeguard.

Log: Removed unnecessary full index optimization during updates to
improve performance

Influence:
1. Test index update operations to verify automatic merge policy works
correctly
2. Monitor system IO usage during index updates for reduced overhead
3. Verify search performance remains acceptable after multiple updates
4. Ensure interrupt scenarios still correctly preserve the .old index
copies

perf: 在 UpdateIndexHandler 中移除冗余的索引优化

本次修改移除了 UpdateIndexHandler 中显式的索引优化调用
(writer->optimize())，转而依赖 lucene++ 的自动合并策略。原优化操作会强制
将所有段合并为单个段，在增量更新场景下会产生不必要的IO开销。

同时简化了调试信息以更好地反映当前行为和原理。由于 ProgressReporter 的析
构函数已经处理了最终提交，显式的 commit 调用保留作为额外保障。

Log: 移除了更新过程中的不必要全索引优化以提高性能

Influence:
1. 测试索引更新操作以验证自动合并策略正常工作
2. 监控索引更新期间系统IO使用情况的减少
3. 验证多次更新后搜索性能仍可接受
4. 确保中断场景仍能正确保留.old索引副本

## Summary by Sourcery

Remove explicit index optimization from the update index task handler to rely on Lucene++’s automatic merge policy and adjust related logging.

Enhancements:
- Remove redundant optimize() call during index updates to avoid unnecessary IO overhead while relying on Lucene++’s automatic segment merge policy.
- Simplify and clarify debug messages around index commit behavior and merge handling in the update flow.