### PR TITLE
fix(sidebar): use monotonic timer for click interval guard

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -16,6 +16,7 @@
 #include <QDropEvent>
 #include <QPalette>
 #include <QStyle>
+#include <QElapsedTimer>
 
 DPSIDEBAR_BEGIN_NAMESPACE
 
@@ -33,7 +34,7 @@ class SideBarViewPrivate : public QObject
     QModelIndex currentHoverIndex;
     bool isItemDragged = false;
     QList<QUrl> urlsForDragEvent;
-    qint64 lastOpTime;   // 上次操作的时间（ms）
+    QElapsedTimer lastOpTimer;
     QUrl draggedUrl;
     QString draggedGroup;
     QVariantMap groupExpandState;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -264,7 +264,7 @@ SideBarView::SideBarView(QWidget *parent)
     connect(this, &DTreeView::doubleClicked, d, &SideBarViewPrivate::onItemDoubleClicked);
 
     d->originPalette = palette();
-    d->lastOpTime = 0;
+    d->lastOpTimer.start();
 
     setStyle(new SidebarViewStyle(style()));
 }
@@ -906,8 +906,8 @@ void SideBarView::onChangeExpandState(const QModelIndex &index, bool expand)
 bool SideBarViewPrivate::checkOpTime()
 {
     // If the interval between twice checking, then return true.
-    if (QDateTime::currentDateTime().toMSecsSinceEpoch() - lastOpTime > 200) {
-        lastOpTime = QDateTime::currentDateTime().toMSecsSinceEpoch();
+    if (lastOpTimer.elapsed() > 200) {
+        lastOpTimer.restart();
         return true;
     }
 


### PR DESCRIPTION
Use QElapsedTimer instead of QDateTime::currentDateTime() in SideBarViewPrivate::checkOpTime() so sidebar click throttling is based on monotonic elapsed time and is not broken by system clock changes after sleep/wake.

Log: 修复侧边栏操作时间间隔检查在系统时间回拨时失效的问题
PMS: https://pms.uniontech.com/bug-view-361695.html
Influence: 修复后，即使系统时间发生回拨（如NTP校时），侧边栏的节流机制仍能正常工作，避免出现意外的重复操作。

## Summary by Sourcery

Bug Fixes:
- Fix sidebar throttling failing when system time moves backwards (e.g., after NTP adjustments or sleep/wake).