### PR TITLE
fix: ensure index status persistence after migration

### DIFF
--- a/src/services/textindex/task/taskhandler.cpp
+++ b/src/services/textindex/task/taskhandler.cpp
@@ -685,6 +685,13 @@ TaskHandler TaskHandlers::CreateIndexHandler(const IndexContext &context)
                 fmInfo() << "[CreateIndexHandler] Created index directory:" << indexDir;
             }
 
+            // prepare() 可能将旧索引目录重命名为 .old，导致 status 文件随旧目录被移走
+            // 在新目录确认存在后重新保存 status，防止进程中途退出后重复进入 Create
+            if (migrator.isActive() && context.stateStore()) {
+                context.stateStore()->saveIndexStatus(QDateTime::currentDateTime());
+                fmInfo() << "[CreateIndexHandler] Re-saved index status after migration rename";
+            }
+
             IndexWriterPtr writer = newLucene<IndexWriter>(
                     FSDirectory::open(indexDir.toStdWString()),
                     boost::static_pointer_cast<Lucene::Analyzer>(context.profile().createAnalyzer()),


### PR DESCRIPTION
Fix an issue where the index status file could be lost during migration
when old index directory is renamed. Added status file saving after
confirming new directory exists to maintain consistency during
interrupted operations.

Log: Fixed potential loss of index status during migration operations

Influence:
1. Test index migration with clean shutdown
2. Test index migration with forced termination during process
3. Verify index status persistence after migration completes
4. Check recovery behavior when process crashes mid-migration

fix: 修复迁移过程中索引状态可能丢失的问题

解决在迁移过程中旧索引目录重命名导致索引状态文件丢失的问题。在确认新目录
存在后重新保存状态文件，确保操作中断时仍能保持状态一致性。

Log: 修复迁移操作期间索引状态可能丢失的问题

Influence:
1. 测试正常关闭时的索引迁移
2. 测试迁移过程中强制终止的情况
3. 验证迁移完成后索引状态的持久性
4. 检查迁移过程崩溃后的恢复行为

## Summary by Sourcery

Bug Fixes:
- Prevent loss of index status files when the old index directory is renamed during migration by persisting status after the new directory is created.