### PR TITLE
fix: improve emblem scaling logic in HiDPI environments

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemmanager.cpp
@@ -74,11 +74,31 @@ bool EmblemManager::paintEmblems(int role, const FileInfoPointer &info, QPainter
             continue;
 
         const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : 1.0;
-        const QSize deviceSize(qMax(1, qRound(emblemRect.width()  * dpr)),
+        const QSize deviceSize(qMax(1, qRound(emblemRect.width() * dpr)),
                                qMax(1, qRound(emblemRect.height() * dpr)));
 
         QPixmap emblemPix = emblems.at(i).pixmap(deviceSize);
+        if (emblemPix.isNull())
+            continue;
+
         emblemPix.setDevicePixelRatio(dpr);
+
+        const QSizeF logicalSize = emblemPix.deviceIndependentSize();
+        const QSizeF targetLogicalSize = emblemRect.size();
+        const bool logicalSizeMismatched
+                = qAbs(logicalSize.width() - targetLogicalSize.width()) > 0.5
+                || qAbs(logicalSize.height() - targetLogicalSize.height()) > 0.5;
+
+        // Keep the original crisp HiDPI path for icons that already honor the
+        // requested device-pixel size. Some fixed-size theme PNG emblems used
+        // by extensions may instead return a larger bucketed pixmap (for
+        // example 64x64), which becomes oversized after assigning fractional
+        // DPR. Normalize only those mismatched pixmaps back to the requested
+        // device size.
+        if (logicalSizeMismatched) {
+            emblemPix = emblemPix.scaled(deviceSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+            emblemPix.setDevicePixelRatio(dpr);
+        }
 
         const qreal ax = qRound(emblemRect.x() * dpr) / dpr;
         const qreal ay = qRound(emblemRect.y() * dpr) / dpr;


### PR DESCRIPTION
1. Added null check for emblem pixmap to prevent crashes with invalid
emblems
2. Improved handling of emblem scaling for HiDPI displays by:
   - Comparing logical sizes of emblem and target
   - Only scaling when significant size mismatch detected (0.5px
threshold)
   - Keeping original pixmap for correctly sized emblems to maintain
crispness
3. Preserved device pixel ratio handling throughout scaling operations

Log: Fixed emblems appearing oversized in some HiDPI scenarios and added
null checks

Influence:
1. Test emblem display on HiDPI displays with various scaling factors
2. Verify emblems maintain crisp appearance when properly sized
3. Test with invalid/empty emblem icons to ensure stability
4. Check scaling behavior with different types of emblem sources (theme
PNGs, extension icons)

fix: 改进高分辨率环境下徽标缩放逻辑

1. 添加徽标位图空检查，防止无效徽标导致崩溃
2. 改进高分辨率显示器徽标缩放处理：
   - 比较徽标与目标的逻辑尺寸
   - 仅当检测到显著尺寸不匹配（0.5像素阈值）时才进行缩放
   - 保留正确尺寸徽标的原始位图以保持清晰度
3. 在整个缩放操作过程中保留设备像素比处理

Log: 修复部分高分辨率场景下徽标显示过大的问题并添加空检查

Influence:
1. 在不同缩放因子的高分辨率显示器上测试徽标显示
2. 验证正确尺寸的徽标保持清晰显示
3. 使用无效/空徽标图标测试稳定性
4. 检查不同类型徽标源（主题PNG、扩展图标）的缩放行为

## Summary by Sourcery

Improve emblem rendering robustness and visual correctness, particularly on HiDPI displays.

Bug Fixes:
- Prevent crashes when emblem pixmaps are invalid or fail to load.
- Fix oversized emblem rendering on HiDPI displays caused by mismatched pixmap scaling.

Enhancements:
- Adjust emblem scaling logic to only rescale pixmaps when their logical size significantly differs from the target, preserving crisp rendering for correctly sized emblems.