### PR TITLE
fix: handle graceful shutdown in device proxy manager

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -8,6 +8,7 @@
 #include "private/deviceproxymanager_p.h"
 
 #include <QDBusServiceWatcher>
+#include <QCoreApplication>
 
 #include <glib.h>
 
@@ -230,6 +231,14 @@ DeviceProxyManager::~DeviceProxyManager()
 DeviceProxyManagerPrivate::DeviceProxyManagerPrivate(DeviceProxyManager *qq, QObject *parent)
     : QObject(parent), q(qq)
 {
+    if (qApp) {
+        connect(qApp, &QCoreApplication::aboutToQuit, this, [this] {
+            isShuttingDown.storeRelease(true);
+            dbusWatcher.reset();
+            devMngDBus.reset();
+            disconnCurrentConnections();
+        });
+    }
 }
 
 DeviceProxyManagerPrivate::~DeviceProxyManagerPrivate()
@@ -243,13 +252,22 @@ bool DeviceProxyManagerPrivate::isDBusRuning()
 
 void DeviceProxyManagerPrivate::initConnection()
 {
+    if (isShuttingDown.loadAcquire())
+        return;
+
     dbusWatcher.reset(new QDBusServiceWatcher(kDeviceService, QDBusConnection::sessionBus()));
     q->connect(dbusWatcher.data(), &QDBusServiceWatcher::serviceRegistered, q, [this] {
+        if (isShuttingDown.loadAcquire())
+            return;
         connectToDBus();
         emit q->devMngDBusRegistered();
         qCInfo(logDFMBase) << "Device manager DBus service registered, switching to DBus connection";
     });
     q->connect(dbusWatcher.data(), &QDBusServiceWatcher::serviceUnregistered, q, [this] {
+        if (isShuttingDown.loadAcquire()) {
+            devMngDBus.reset();
+            return;
+        }
         devMngDBus.reset();
         connectToAPI();
         emit q->devMngDBusUnregistered();
@@ -346,6 +364,9 @@ bool DeviceProxyManagerPrivate::isExternalBlock(const QVariantMap &info) const
 
 void DeviceProxyManagerPrivate::connectToDBus()
 {
+    if (isShuttingDown.loadAcquire())
+        return;
+
     if (currentConnectionType == kDBusConnecting)
         return;
 
@@ -390,6 +411,9 @@ void DeviceProxyManagerPrivate::connectToDBus()
 
 void DeviceProxyManagerPrivate::connectToAPI()
 {
+    if (isShuttingDown.loadAcquire())
+        return;
+
     if (currentConnectionType == kAPIConnecting)
         return;
     disconnCurrentConnections();

--- a/src/dfm-base/base/device/private/deviceproxymanager_p.h
+++ b/src/dfm-base/base/device/private/deviceproxymanager_p.h
@@ -18,6 +18,7 @@
 #include <QScopedPointer>
 #include <QList>
 #include <QtCore/qobjectdefs.h>
+#include <QAtomicInteger>
 #include <QReadWriteLock>
 
 using DeviceManagerInterface = OrgDeepinFilemanagerDaemonDeviceManagerInterface;
@@ -54,6 +55,7 @@ private:
     QScopedPointer<QDBusServiceWatcher> dbusWatcher;
     QList<QMetaObject::Connection> connections;
     int currentConnectionType = kNoneConnection;   // 0 for API connection and 1 for DBus connection
+    QAtomicInteger<bool> isShuttingDown { false };
     QReadWriteLock lock;
     QMap<QString, QString> externalMounts;
     QMap<QString, QString> allMounts;   // contain system disk


### PR DESCRIPTION
Added proper cleanup handling during application shutdown to prevent
potential crashes and DBus-related issues. This includes:

1. Added QCoreApplication::aboutToQuit signal handler to clean up
resources
2. Introduced QAtomicInteger flag to track shutdown state
3. Added shutdown checks before performing DBus operations
4. Properly release DBus watcher and manager resources during shutdown
5. Skip DBus operations if shutdown is in progress

The changes prevent:
- Potential DBus calls after application shutdown
- Resource leaks during process termination
- Race conditions during shutdown sequence

Log: Fixed potential crashes during application shutdown related to
device manager DBus operations

Influence:
1. Test application shutdown with active device operations
2. Verify no DBus-related errors in logs during shutdown
3. Check that all device manager resources are properly released
4. Test with various device connection states during shutdown
5. Verify no memory leaks during shutdown sequence

fix: 设备代理管理器实现优雅关机处理

增加了应用关闭时的清理处理，防止潜在崩溃和DBus相关问题，包括:

1. 添加QCoreApplication::aboutToQuit信号处理程序进行资源清理
2. 引入QAtomicInteger标志跟踪关机状态
3. 在执行DBus操作前增加关机状态检查
4. 关机期间正确释放DBus观察器和管理器资源
5. 关机进行时跳过DBus操作

这些修改防止了:
- 应用关机后的潜在DBus调用
- 进程终止时的资源泄漏
- 关机序列中的竞态条件

Log: 修复了应用关机时设备管理器DBus操作相关的潜在崩溃问题

Influence:
1. 测试在有设备操作运行时关闭应用
2. 验证关机时日志中没有DBus相关错误
3. 检查所有设备管理器资源是否正确释放
4. 测试关机时不同设备连接状态的场景
5. 验证关机序列中没有内存泄漏

## Summary by Sourcery

Improve device proxy manager shutdown handling to avoid DBus operations and resource usage during application termination.

Bug Fixes:
- Prevent DBus connections and operations from being initiated or switched while the application is shutting down.
- Avoid crashes and race conditions during shutdown by cleaning up DBus watcher, manager instances, and active connections when the app is about to quit.

Enhancements:
- Track application shutdown state in the device proxy manager using an atomic flag to guard DBus and API connection logic.