### PR TITLE
fix: add HiDPI support for icons across UI

### DIFF
--- a/examples/folder-preview-example/foldercontentwidget.cpp
+++ b/examples/folder-preview-example/foldercontentwidget.cpp
@@ -151,7 +151,7 @@ void FolderContentWidget::loadFolder(const QUrl &url)
     // Set big folder icon
     QFileIconProvider iconProvider;
     QIcon dirIcon = iconProvider.icon(QFileIconProvider::Folder);
-    m_folderIconLabel->setPixmap(dirIcon.pixmap(64, 64));
+    m_folderIconLabel->setPixmap(dirIcon.pixmap(QSize(64, 64) * m_folderIconLabel->devicePixelRatioF()));
 
     // Reset stat badges
     m_fileBadge->setValue("…");

--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -17,6 +17,7 @@
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <DBackgroundGroup>
 #include <DTreeView>
@@ -215,7 +216,7 @@ void DialogManager::showNoPermissionDialog(const QList<QUrl> &urls)
         QFrame *contentFrame = new QFrame;
 
         QLabel *iconLabel = new QLabel;
-        iconLabel->setPixmap(QIcon::fromTheme("dde-file-manager").pixmap(64, 64));
+        iconLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dde-file-manager"), QSize(64, 64), qApp->activeWindow()));
 
         QLabel *titleLabel = new QLabel;
         titleLabel->setText(tr("Sorry, you don't have permission to operate the following %1 file/folder(s)!").arg(QString::number(urls.count())));

--- a/src/dfm-base/utils/iconutils.cpp
+++ b/src/dfm-base/utils/iconutils.cpp
@@ -9,6 +9,8 @@
 #include <QGraphicsDropShadowEffect>
 #include <QGraphicsScene>
 #include <QGraphicsPixmapItem>
+#include <QWidget>
+#include <QApplication>
 
 DFMBASE_USE_NAMESPACE
 
@@ -94,4 +96,12 @@ bool IconUtils::shouldSkipThumbnailFrame(const QString &mimeType)
         Global::Mime::kTypeAppUab
     };
     return kExcludedMimes.contains(mimeType);
+}
+
+QPixmap IconUtils::hiDpiPixmap(const QIcon &icon, const QSize &size, const QWidget *widget)
+{
+    qreal dpr = widget ? widget->devicePixelRatioF() : qApp->devicePixelRatio();
+    QPixmap pix = icon.pixmap(size * dpr);
+    pix.setDevicePixelRatio(dpr);
+    return pix;
 }

--- a/src/dfm-base/utils/iconutils.h
+++ b/src/dfm-base/utils/iconutils.h
@@ -7,6 +7,7 @@
 
 #include <dfm-base/dfm_base_global.h>
 
+#include <QIcon>
 #include <QPixmap>
 
 DFMBASE_BEGIN_NAMESPACE
@@ -24,6 +25,16 @@ QPixmap renderIconBackground(const QSizeF &size, const IconStyle &style = IconSt
 QPixmap addShadowToPixmap(const QPixmap &originalPixmap, int shadowOffsetY, qreal blurRadius, qreal shadowOpacity);
 IconStyle getIconStyle(int size);
 bool shouldSkipThumbnailFrame(const QString &mimeType);
+
+/*!
+ * \brief Generate a HiDPI-aware pixmap from QIcon.
+ * Returns a pixmap scaled by the given widget's devicePixelRatio,
+ * so it renders crisply on high-DPI screens.
+ * \param icon Source QIcon
+ * \param size Logical pixel size (e.g. 128x128)
+ * \param widget Target widget to read devicePixelRatio from
+ */
+QPixmap hiDpiPixmap(const QIcon &icon, const QSize &size, const QWidget *widget);
 }   // end namespace IconUtils
 
 DFMBASE_END_NAMESPACE

--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -10,6 +10,7 @@
 #include <dfm-base/file/local/localfilehandler.h>
 #include <dfm-base/utils/dialogmanager.h>
 #include <dfm-base/utils/windowutils.h>
+#include <dfm-base/utils/iconutils.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/device/devicemanager.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
@@ -333,7 +334,7 @@ void BurnJobManager::showOpticalDumpISOSuccessDialog(const QUrl &imageUrl)
 
     // add icon label
     QLabel *iconLabel { new QLabel };
-    iconLabel->setPixmap(QIcon::fromTheme("dialog-ok").pixmap(96, 96));
+    iconLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dialog-ok"), QSize(96, 96), qApp->activeWindow()));
     mainLayout->addWidget(iconLabel, 0, Qt::AlignTop | Qt::AlignCenter);
 
     d.move(WindowUtils::cursorScreen()->geometry().center()
@@ -368,7 +369,7 @@ void BurnJobManager::showOpticalDumpISOFailedDialog()
 
     // add icon label
     QLabel *iconLabel { new QLabel };
-    iconLabel->setPixmap(QIcon::fromTheme("dialog-error").pixmap(96, 96));
+    iconLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dialog-error"), QSize(96, 96), qApp->activeWindow()));
     mainLayout->addWidget(iconLabel, 0, Qt::AlignTop | Qt::AlignCenter);
 
     d.move(WindowUtils::cursorScreen()->geometry().center()

--- a/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/filepropertydialog.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/utils/fileinfohelper.h>
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/utils/thumbnail/thumbnailhelper.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <DFontSizeManager>
 #include <denhancedwidget.h>
@@ -182,11 +183,15 @@ void FilePropertyDialog::setFileIcon(QLabel *fileIcon, FileInfoPointer fileInfo)
                 icon = QPixmap::fromImage(img);
             }
             if (!icon.isNull()) {
-                fileIcon->setPixmap(icon.pixmap(128, 128).scaled(128, 128, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+                qreal dpr = this->devicePixelRatioF();
+                QPixmap pix = icon.pixmap(QSize(128, 128) * dpr);
+                pix = pix.scaled(QSize(128, 128) * dpr, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                pix.setDevicePixelRatio(dpr);
+                fileIcon->setPixmap(pix);
                 return;
             }
         }
-        fileIcon->setPixmap(fileInfo->fileIcon().pixmap(128, 128));
+        fileIcon->setPixmap(IconUtils::hiDpiPixmap(fileInfo->fileIcon(), QSize(128, 128), this));
     }
 }
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
@@ -6,6 +6,7 @@
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <DFontSizeManager>
 
@@ -43,7 +44,7 @@ void MultiFilePropertyDialog::initHeadUi()
     QIcon icon;
     icon.addFile(QString { ":/images/images/multiple_files.png" });
     icon.addFile(QString { ":/images/images/multiple_files@2x.png" });
-    iconLabel->setPixmap(icon.pixmap(128, 128));
+    iconLabel->setPixmap(IconUtils::hiDpiPixmap(icon, QSize(128, 128), this));
 
     multiFileLable = new QLabel(this);
     DFontSizeManager::instance()->bind(multiFileLable, DFontSizeManager::T9, QFont::Medium);

--- a/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/progressdialog.cpp
@@ -10,6 +10,9 @@
 #include <QVBoxLayout>
 #include <QKeyEvent>
 
+#include <dfm-base/utils/iconutils.h>
+
+DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_utils;
 DWIDGET_USE_NAMESPACE
 
@@ -51,7 +54,7 @@ ShredFailedWidget::ShredFailedWidget(QWidget *parent)
     : QWidget(parent)
 {
     DLabel *failedImage = new DLabel(this);
-    failedImage->setPixmap(QIcon::fromTheme("dialog-error").pixmap(100, 100));
+    failedImage->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dialog-error"), QSize(100, 100), this));
 
     infoLabel = new DLabel(this);
     infoLabel->setMaximumWidth(340);

--- a/src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
@@ -5,6 +5,7 @@
 #include "devicepropertydialog.h"
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/utils/elidetextlayout.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <DDrawer>
 #include <denhancedwidget.h>
@@ -124,7 +125,7 @@ int DevicePropertyDialog::contentHeight() const
 void DevicePropertyDialog::setSelectDeviceInfo(const DeviceInfo &info)
 {
     currentFileUrl = info.deviceUrl;
-    deviceIcon->setPixmap(info.icon.pixmap(128, 128));
+    deviceIcon->setPixmap(IconUtils::hiDpiPixmap(info.icon, QSize(128, 128), this));
     setFileName(info.deviceName);
     deviceBasicWidget->selectFileInfo(info);
     QString deviceShowName = info.deviceDesc.isEmpty() ? info.deviceName : QString("%1(%2)").arg(info.deviceName).arg(info.deviceDesc);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -18,6 +18,9 @@
 
 #include <dfm-mount/dmount.h>
 
+#include <dfm-base/utils/iconutils.h>
+
+DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_diskenc;
 
 EncryptProgressDialog::EncryptProgressDialog(QWidget *parent)
@@ -51,7 +54,7 @@ void EncryptProgressDialog::showResultPage(bool success, const QString &title, c
     setTitle(title);
     resultMsg->setText(message);
     QIcon icon = success ? QIcon::fromTheme("dialog-ok") : QIcon::fromTheme("dialog-error");
-    iconLabel->setPixmap(icon.pixmap(64, 64));
+    iconLabel->setPixmap(IconUtils::hiDpiPixmap(icon, QSize(64, 64), this));
 
     addButton(tr("Confirm"));
     setAttribute(Qt::WA_DeleteOnClose);

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcresultwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcresultwidget.cpp
@@ -10,7 +10,10 @@
 
 #include <QVBoxLayout>
 
+#include <dfm-base/utils/iconutils.h>
+
 DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_titlebar;
 
 DPCResultWidget::DPCResultWidget(QWidget *parent)
@@ -27,10 +30,10 @@ void DPCResultWidget::setResult(bool success, const QString &msg)
 
     if (success) {
         titleLabel->setText(tr("Disk password changed"));
-        resultIcon->setPixmap(QIcon::fromTheme("dfm_success").pixmap(128, 128));
+        resultIcon->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dfm_success"), QSize(128, 128), this));
     } else {
         titleLabel->setText(tr("Failed to change the disk password"));
-        resultIcon->setPixmap(QIcon::fromTheme("dfm_fail").pixmap(128, 128));
+        resultIcon->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dfm_fail"), QSize(128, 128), this));
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
@@ -22,6 +22,7 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/iconutils.h>
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
@@ -472,7 +473,7 @@ void VaultHelper::unlockVaultDialog()
 
             QLabel *iconLabel = new QLabel(contentFrame);
             iconLabel->setAlignment(Qt::AlignCenter);
-            iconLabel->setPixmap(QIcon::fromTheme("dfm_vault_upgrade").pixmap(64, 64));
+            iconLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dfm_vault_upgrade"), QSize(64, 64), contentFrame));
 
             QLabel *textLabel = new QLabel(contentFrame);
             textLabel->setAlignment(Qt::AlignCenter);

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
@@ -14,6 +14,7 @@
 
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/application/settings.h>
+#include <dfm-base/utils/iconutils.h>
 #include <dfm-base/utils/dialogmanager.h>
 
 #include <dfm-framework/dpf.h>
@@ -58,7 +59,7 @@ void VaultActiveFinishedView::initUi()
 
     // 加密保险箱图片
     encryVaultImageLabel = new DLabel(this);
-    encryVaultImageLabel->setPixmap(QIcon::fromTheme("dfm_vault_active_encrypt").pixmap(98, 88));
+    encryVaultImageLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dfm_vault_active_encrypt"), QSize(98, 88), this));
     encryVaultImageLabel->setAlignment(Qt::AlignHCenter);
 
     // 进度条
@@ -179,7 +180,7 @@ void VaultActiveFinishedView::encryptFinished(bool success, const QString &msg)
     if (success) {   // 创建保险箱成功
         fmDebug() << "Vault: Vault creation completed successfully";
         waterProgress->setValue(100);
-        encryptFinishedImageLabel->setPixmap(QIcon::fromTheme("dialog-ok").pixmap(100, 100));
+        encryptFinishedImageLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dialog-ok"), QSize(100, 100), this));
         tipsThree->setText(tr("The setup is complete"));
         finishedBtn->setText(tr("OK"));
         VaultHelper::recordTime(kjsonGroupName, kjsonKeyCreateTime);
@@ -191,7 +192,7 @@ void VaultActiveFinishedView::encryptFinished(bool success, const QString &msg)
         dpfSignalDispatcher->publish("dfmplugin_vault", "signal_ReportLog_Commit", QString("Vault"), data);
     } else {
         fmWarning() << "Vault: Vault creation failed:" << msg;
-        encryptFinishedImageLabel->setPixmap(QIcon::fromTheme("dialog-error").pixmap(100, 100));
+        encryptFinishedImageLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dialog-error"), QSize(100, 100), this));
         tipsThree->setText(msg);
         finishedBtn->setText(tr("Close"));
     }

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
@@ -13,6 +13,7 @@
 #include "utils/pathmanager.h"
 
 #include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -292,7 +293,7 @@ void VaultActiveSaveKeyFileView::onOldPasswordSchemeMigrationFinished()
 
     QLabel *iconLabel = new QLabel(contentFrame);
     iconLabel->setAlignment(Qt::AlignCenter);
-    iconLabel->setPixmap(QIcon::fromTheme("dialog-ok").pixmap(64, 64));
+    iconLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dialog-ok"), QSize(64, 64), this));
 
     QLabel *textLabel = new QLabel(contentFrame);
     textLabel->setAlignment(Qt::AlignCenter);

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
@@ -5,6 +5,7 @@
 #include "vaultactivestartview.h"
 
 #include <dfm-framework/event/event.h>
+#include <dfm-base/utils/iconutils.h>
 
 #ifdef DTKWIDGET_CLASS_DSizeMode
 #    include <DSizeMode>
@@ -17,6 +18,7 @@
 #include <QSpacerItem>
 
 DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_vault;
 
 VaultActiveStartView::VaultActiveStartView(QWidget *parent)
@@ -35,7 +37,7 @@ void VaultActiveStartView::initUi()
     pLabel2->setAlignment(Qt::AlignHCenter);
 
     DLabel *pLabel3 = new DLabel();
-    pLabel3->setPixmap(QIcon::fromTheme("dfm_vault_active_start").pixmap(88, 100));
+    pLabel3->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dfm_vault_active_start"), QSize(88, 100), this));
     pLabel3->setAlignment(Qt::AlignHCenter);
 
     startBtn = new DSuggestButton(tr("Create"), this);

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremoveprogressview.cpp
@@ -11,6 +11,7 @@
 #include "plugins/common/dfmplugin-utils/reportlog/datas/vaultreportdata.h"
 
 #include <dfm-base/base/application/settings.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -44,7 +45,7 @@ VaultRemoveProgressView::VaultRemoveProgressView(QWidget *parent)
     deletedWidget = new QWidget(this);
     QVBoxLayout *deletedLay = new QVBoxLayout;
     deleteFinishedImageLabel = new DLabel(deletedWidget);
-    deleteFinishedImageLabel->setPixmap(QIcon::fromTheme("dialog-ok").pixmap(100, 100));
+    deleteFinishedImageLabel->setPixmap(IconUtils::hiDpiPixmap(QIcon::fromTheme("dialog-ok"), QSize(100, 100), this));
     deleteFinishedImageLabel->setAlignment(Qt::AlignHCenter);
     finishedLabel = new DLabel(tr("Deleted successfully"), deletedWidget);
     deletedLay->addWidget(deleteFinishedImageLabel, 0, Qt::AlignHCenter);

--- a/src/plugins/filemanager/dfmplugin-vault/views/vaultpropertyview/vaultpropertydialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/vaultpropertyview/vaultpropertydialog.cpp
@@ -5,6 +5,7 @@
 #include "vaultpropertydialog.h"
 
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <QPalette>
 #include <denhancedwidget.h>
@@ -68,7 +69,7 @@ void VaultPropertyDialog::createHeadUI(const QUrl &url)
     fileIconLabel->setFixedHeight(128);
     FileInfoPointer info = InfoFactory::create<FileInfo>(url);
     if (!info.isNull())
-        fileIconLabel->setPixmap(info->fileIcon().pixmap(128, 128));
+        fileIconLabel->setPixmap(IconUtils::hiDpiPixmap(info->fileIcon(), QSize(128, 128), this));
 
     fileNameLabel = new QLabel(tr("File Vault"), this);
 


### PR DESCRIPTION
1. Added IconUtils::hiDpiPixmap helper function to properly handle icons
on HiDPI displays
2. Replaced all direct QIcon::pixmap calls with the new helper function
3. The helper function automatically scales icons based on device pixel
ratio
4. Added proper handling of devicePixelRatio when scaling pixmaps
5. This change affects multiple plugins and components across the
codebase

Log: Added proper HiDPI support for all application icons

Influence:
1. Test all dialogs with icons on HiDPI displays
2. Verify icon appearance on both standard and high resolution screens
3. Check icon crispness when window is moved between screens with
different DPI
4. Verify dialog layouts with larger scaled icons
5. Test all error/success/info dialogs with icons

fix: 为全UI的图标添加HiDPI支持

1. 新增IconUtils::hiDpiPixmap辅助函数来处理HiDPI显示器上的图标
2. 将所有QIcon::pixmap直接调用替换为新的辅助函数
3. 该辅助函数会根据设备像素比自动缩放图标
4. 在缩放位图时添加了正确的设备像素比处理
5. 此改动影响了代码库中多个插件和组件

Log: 为所有应用图标添加正确的HiDPI支持

Influence:
1. 在HiDPI显示器上测试所有带图标的对话框
2. 在标准和高分辨率屏幕上验证图标显示
3. 检查窗口在不同DPI屏幕间移动时图标的清晰度
4. 测试含有放大图标后的对话框布局
5. 测试所有带有图标的错误/成功/信息对话框

Bug: https://pms.uniontech.com/bug-view-364069.html
