### PR TITLE
fix: correct file count handling during restoration

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -395,9 +395,12 @@ void AbstractWorker::emitProgressChangedNotify(const qint64 &writSize)
         || AbstractJobHandler::JobType::kCutType == jobType) {
         info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(sourceFilesTotalSize)));
     } else if (AbstractJobHandler::JobType::kMoveToTrashType == jobType
-               || AbstractJobHandler::JobType::kRestoreType == jobType
                || AbstractJobHandler::JobType::kCleanTrashType == jobType) {
         info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(sourceUrls.count())));
+    } else if (AbstractJobHandler::JobType::kRestoreType == jobType) {
+        // Restore may expand sourceUrls.size()==1 (trash root) into allFilesList (N files),
+        // so total must use sourceFilesCount which is set in statisticsFilesSize().
+        info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(qint64(sourceFilesCount)));
     } else {
         qint64 count = allFilesList.isEmpty() ? (sourceFilesCount + sourceDirsCount) : allFilesList.count();
         info->insert(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey, QVariant::fromValue(count));


### PR DESCRIPTION
Fixed an issue where file count reporting was incorrect during trash
restoration operations. The restoration operation was being treated like
other trash operations (move to trash, clean trash) which simply count
source URLs, but restoration needs special handling because a single
trash root URL can expand to multiple files during restoration.

The fix separates restoration logic into its own condition, using
the pre-calculated sourceFilesCount value which is properly set
during statistic collection rather than relying on the simple
sourceUrls.count(). This ensures accurate progress reporting when
restoring files from trash.

Log: Fixed incorrect file count display during trash restoration

Influence:
1. Test restoring single files from trash
2. Test restoring multiple files from trash
3. Test restoring trash root (whole trash contents)
4. Verify progress bar accuracy in all cases

fix: 修复回收站恢复操作中的文件计数处理

修复了回收站恢复操作中文件计数报告不正确的问题。恢复操作原本被当作与其
他回收站操作(移动到回收站、清空回收站)相同的处理方式，仅简单计算源URL数
量，但恢复操作需要特殊处理，因为单个回收站根URL在恢复过程中可能扩展成多
个文件。

该修复将恢复逻辑分离到单独条件中，使用在统计收集过程中正确设置的
sourceFilesCount值，而不是依赖简单的sourceUrls.count()。这确保了从回收站
恢复文件时进度报告的准确性。

Log: 修复回收站恢复时的文件计数显示问题

Influence:
1. 测试从回收站恢复单个文件
2. 测试从回收站恢复多个文件
3. 测试恢复回收站根目录(全部内容)
4. 验证所有情况下进度条的准确性

Fixes: #364091
