### PR TITLE
fix: prevent highlight cache pollution between search types

### DIFF
--- a/src/dfm-base/utils/highlightprovider.cpp
+++ b/src/dfm-base/utils/highlightprovider.cpp
@@ -7,6 +7,16 @@
 #include <QMutexLocker>
 #include <QDebug>
 
+namespace {
+
+// 将 path 和 searchType 组合为唯一缓存 key，避免不同搜索类型互相污染
+static QString compositeKey(const QString &path, int searchType)
+{
+    return path + QStringLiteral("|") + QString::number(searchType);
+}
+
+}   // namespace
+
 namespace dfmbase {
 
 static const QString kPendingToken = QStringLiteral("__pending__");
@@ -49,10 +59,11 @@ void HighlightProvider::requestHighlight(const QString &taskId, const QString &p
     }
 
     // Step 1: 检查缓存
+    const QString key = compositeKey(path, searchType);
     {
         QMutexLocker lk(&cacheMutex);
         auto &taskCache = cache[taskId];
-        auto it = taskCache.find(path);
+        auto it = taskCache.find(key);
 
         if (it != taskCache.end()) {
             const QString &cached = it.value();
@@ -72,7 +83,7 @@ void HighlightProvider::requestHighlight(const QString &taskId, const QString &p
         }
 
         // 标记为 pending
-        taskCache[path] = kPendingToken;
+        taskCache[key] = kPendingToken;
     }
 
     // Step 2: 加入请求队列
@@ -158,7 +169,7 @@ void HighlightProvider::processNextRequest()
                 // 会话在 fetch 期间被 cancelTask 取消，跳过存储和通知
                 continue;
             }
-            cache[req.taskId][req.path] = content;
+            cache[req.taskId][compositeKey(req.path, req.searchType)] = content;
         }
 
         if (content.isEmpty())

--- a/src/dfm-base/utils/highlightprovider.h
+++ b/src/dfm-base/utils/highlightprovider.h
@@ -68,7 +68,7 @@ private:
     QList<HighlightRequest> pendingRequests;   // 优先级队列：高优先级插入头部
     std::atomic<int> processing { 0 };         // 工作线程处理状态标记
 
-    // 缓存：QHash<taskId, QHash<path, content>>
+    // 缓存：QHash<taskId, QHash<compositeKey(path|searchType), content>>
     // 未请求 = 不存在于 map 中
     // 特殊 "__pending__" = 请求中
     // 空 QString = 已获取但无高亮内容


### PR DESCRIPTION
1. Added compositeKey function to combine path and searchType as unique
cache key
2. Modified cache storage and lookup to use composite key instead of
raw path
3. Updated header documentation to reflect cache structure change

The issue was that different search types (like name search and content
search) would share the same cache entry when using the same path,
causing incorrect highlight results. The fix ensures each search type
maintains its own cached highlight information for the same path.

Log: Fixed issue where different search types might show incorrect
highlight results

Influence:
1. Test file search highlighting with different search types (name/
content)
2. Verify cache works correctly for same path with different search
types
3. Check that pending and cached states are properly handled
4. Test search cancellation during highlight processing

fix: 修复不同搜索类型间高亮缓存污染问题

1. 添加compositeKey函数组合路径和搜索类型作为唯一缓存键
2. 修改缓存存储和查找逻辑使用组合键而非原始路径
3. 更新头文件文档说明缓存结构变更

原问题在于不同搜索类型(如名称搜索和内容搜索)在使用相同路径时会共享缓存条
目，导致显示错误的高亮结果。此修复确保每种搜索类型都能为相同路径维护自己
的高亮信息缓存。

Log: 修复了不同搜索类型可能显示错误高亮结果的问题

Influence:
1. 测试使用不同搜索类型(名称/内容)时的文件高亮显示
2. 验证相同路径不同搜索类型的缓存正常工作
3. 检查待处理状态和缓存状态是否正确处理
4. 测试高亮处理过程中的搜索取消功能

Bug: https://pms.uniontech.com/bug-view-364229.html
