### PR TITLE
fix: optimize tag color and name handling

### DIFF
--- a/src/plugins/common/dfmplugin-tag/menu/private/tagmenuscene_p.h
+++ b/src/plugins/common/dfmplugin-tag/menu/private/tagmenuscene_p.h
@@ -22,6 +22,7 @@ public:
     QRect getSurfaceRect(QWidget *);
     QStringList tagNames {};
     bool onCollection { false };
+    QMap<QString, QString> colorToTag {};
 };
 
 }

--- a/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
@@ -203,7 +203,7 @@ void TagMenuScene::onHoverChanged(const QColor &color)
             QString tagName = d->colorToTag.value(color.name(), QString());
             // Fallback to hardcoded table for brand-new tags not yet in DB
             if (tagName.isEmpty())
-                tagName = TagHelper::instance()->qureyDisplayNameByColor(color);
+                tagName = TagHelper::instance()->queryDisplayNameByColor(color);
             if (sameColors.contains(color))
                 tagWidget->setToolTipText(tr("Remove tag \"%1\"").arg(tagName));
             else
@@ -223,7 +223,7 @@ void TagMenuScene::onColorClicked(const QColor &color)
         QString tagName = d->colorToTag.value(color.name(), QString());
         // Fallback to hardcoded table for brand-new tags not yet in DB
         if (tagName.isEmpty())
-            tagName = TagHelper::instance()->qureyDisplayNameByColor(color);
+            tagName = TagHelper::instance()->queryDisplayNameByColor(color);
 
         if (tagName.isEmpty())
             return;

--- a/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
@@ -199,7 +199,11 @@ void TagMenuScene::onHoverChanged(const QColor &color)
             return;
 
         if (Q_LIKELY(color.isValid())) {
-            const QString &tagName = TagHelper::instance()->qureyDisplayNameByColor(color);
+            // DB-first lookup: use cached mapping from createColorListAction
+            QString tagName = d->colorToTag.value(color.name(), QString());
+            // Fallback to hardcoded table for brand-new tags not yet in DB
+            if (tagName.isEmpty())
+                tagName = TagHelper::instance()->qureyDisplayNameByColor(color);
             if (sameColors.contains(color))
                 tagWidget->setToolTipText(tr("Remove tag \"%1\"").arg(tagName));
             else
@@ -215,13 +219,22 @@ void TagMenuScene::onColorClicked(const QColor &color)
 {
     TagColorListWidget *tagWidget = getMenuListWidget();
     if (tagWidget) {
+        // DB-first lookup: use cached mapping from createColorListAction
+        QString tagName = d->colorToTag.value(color.name(), QString());
+        // Fallback to hardcoded table for brand-new tags not yet in DB
+        if (tagName.isEmpty())
+            tagName = TagHelper::instance()->qureyDisplayNameByColor(color);
+
+        if (tagName.isEmpty())
+            return;
+
         QList<QColor> colors = tagWidget->checkedColorList();
         if (colors.contains(color)) {
             //add checked tag
-            TagManager::instance()->addTagsForFiles({ TagHelper::instance()->qureyDisplayNameByColor(color) }, d->selectFiles);
+            TagManager::instance()->addTagsForFiles({ tagName }, d->selectFiles);
         } else {
             // delete checked tag
-            TagManager::instance()->removeTagsOfFiles({ TagHelper::instance()->qureyDisplayNameByColor(color) }, d->selectFiles);
+            TagManager::instance()->removeTagsOfFiles({ tagName }, d->selectFiles);
         }
     }
 }
@@ -257,14 +270,22 @@ QAction *TagMenuScene::createColorListAction(QMenu *parent) const
     action->setDefaultWidget(colorListWidget);
     // get tags by focus fileinfo
     QStringList tags = TagManager::instance()->getTagsByUrls({ FileUtils::bindUrlTransform(d->focusFile) });
+    // Query actual colors from DB to handle renamed tags correctly
+    QMap<QString, QColor> tagColors = TagManager::instance()->getTagsColor(tags);
     QList<QColor> colors;
+
+    // Build color->tagName mapping from DB once for onHoverChanged/onColorClicked reuse
+    const auto allTags = TagManager::instance()->getAllTags();
+    d->colorToTag.clear();
+    for (auto it = allTags.cbegin(); it != allTags.cend(); ++it)
+        d->colorToTag[it.value().name()] = it.key();
 
     for (const QString &tag : tags) {
         // The tag name of the database is the display name of the tag
         if (!TagHelper::instance()->isDefualtTag(tag))
             continue;
 
-        const QColor &color = TagHelper::instance()->qureyColorByDisplayName(tag);
+        const QColor &color = tagColors.value(tag, QColor());
 
         if (Q_LIKELY(color.isValid()))
             colors << color;

--- a/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
@@ -77,7 +77,7 @@ TagHelper::TagHelper(QObject *parent)
     initTagColorDefines();
 }
 
-QColor TagHelper::qureyColorByColorName(const QString &name) const
+QColor TagHelper::queryColorByColorName(const QString &name) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [name](const TagColorDefine &define) {
         return define.colorName == name;
@@ -89,7 +89,7 @@ QColor TagHelper::qureyColorByColorName(const QString &name) const
     return QColor();
 }
 
-QColor TagHelper::qureyColorByDisplayName(const QString &name) const
+QColor TagHelper::queryColorByDisplayName(const QString &name) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [name](const TagColorDefine &define) {
         return define.displayName == name;
@@ -101,7 +101,7 @@ QColor TagHelper::qureyColorByDisplayName(const QString &name) const
     return QColor();
 }
 
-QString TagHelper::qureyColorNameByColor(const QColor &color) const
+QString TagHelper::queryColorNameByColor(const QColor &color) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [color](const TagColorDefine &define) {
         return define.color.name() == color.name();
@@ -113,7 +113,7 @@ QString TagHelper::qureyColorNameByColor(const QColor &color) const
     return QString();
 }
 
-QString TagHelper::qureyIconNameByColorName(const QString &colorName) const
+QString TagHelper::queryIconNameByColorName(const QString &colorName) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [colorName](const TagColorDefine &define) {
         return define.colorName == colorName;
@@ -125,7 +125,7 @@ QString TagHelper::qureyIconNameByColorName(const QString &colorName) const
     return QString();
 }
 
-QString TagHelper::qureyIconNameByColor(const QColor &color) const
+QString TagHelper::queryIconNameByColor(const QColor &color) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [color](const TagColorDefine &define) {
         return define.color.name() == color.name();
@@ -137,7 +137,7 @@ QString TagHelper::qureyIconNameByColor(const QColor &color) const
     return QString();
 }
 
-QString TagHelper::qureyDisplayNameByColor(const QColor &color) const
+QString TagHelper::queryDisplayNameByColor(const QColor &color) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [color](const TagColorDefine &define) {
         return define.color.name() == color.name();
@@ -149,7 +149,7 @@ QString TagHelper::qureyDisplayNameByColor(const QColor &color) const
     return QString();
 }
 
-QString TagHelper::qureyColorNameByDisplayName(const QString &name) const
+QString TagHelper::queryColorNameByDisplayName(const QString &name) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [name](const TagColorDefine &define) {
         return define.displayName == name;

--- a/src/plugins/common/dfmplugin-tag/utils/taghelper.h
+++ b/src/plugins/common/dfmplugin-tag/utils/taghelper.h
@@ -46,13 +46,13 @@ public:
 
     QList<QColor> defualtColors() const;
 
-    QColor qureyColorByColorName(const QString &name) const;
-    QColor qureyColorByDisplayName(const QString &name) const;
-    QString qureyColorNameByColor(const QColor &color) const;
-    QString qureyIconNameByColorName(const QString &colorName) const;
-    QString qureyIconNameByColor(const QColor &color) const;
-    QString qureyDisplayNameByColor(const QColor &color) const;
-    QString qureyColorNameByDisplayName(const QString &name) const;
+    QColor queryColorByColorName(const QString &name) const;
+    QColor queryColorByDisplayName(const QString &name) const;
+    QString queryColorNameByColor(const QColor &color) const;
+    QString queryIconNameByColorName(const QString &colorName) const;
+    QString queryIconNameByColor(const QColor &color) const;
+    QString queryDisplayNameByColor(const QColor &color) const;
+    QString queryColorNameByDisplayName(const QString &name) const;
 
     QString getTagNameFromUrl(const QUrl &url) const;
     QUrl makeTagUrlByTagName(const QString &tag) const;

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -467,6 +467,14 @@ bool TagManager::changeTagName(const QString &tagName, const QString &newName)
         return false;
     }
 
+    // If new name matches a default color, sync the tag color to match.
+    // This prevents inconsistency where tagName="Gray" but tagColor remains #9023fc.
+    QColor defaultColor = TagHelper::instance()->qureyColorByDisplayName(newName);
+    if (defaultColor.isValid()) {
+        QVariantMap colorChangeMap { { tagName, QVariant { defaultColor.name() } } };
+        TagProxyHandleIns->changeTagsColor(colorChangeMap);
+    }
+
     QVariantMap oldAndNewName = { { tagName, QVariant { newName } } };
     emit tagDeleted(tagName);
     return TagProxyHandleIns->changeTagNamesWithFiles(oldAndNewName);
@@ -731,6 +739,7 @@ void TagManager::onTagColorChanged(const QVariantMap &tagAndColorName)
         dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", url, map);
         ++it;
     }
+    emit tagColorChanged(tagAndColorName);
 }
 
 void TagManager::onTagNameChanged(const QVariantMap &oldAndNew)

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -239,7 +239,7 @@ QString TagManager::getTagIconName(const QString &tag) const
 
     const auto &dataMap = getTagsColorName({ tag });
     if (dataMap.contains(tag))
-        return TagHelper::instance()->qureyIconNameByColor(QColor(dataMap.value(tag)));
+        return TagHelper::instance()->queryIconNameByColor(QColor(dataMap.value(tag)));
 
     return QString();
 }
@@ -357,7 +357,7 @@ bool TagManager::addTagsForFiles(const QList<QString> &tags, const QList<QUrl> &
     // tag --- color
     QMap<QString, QVariant> tagWithColor {};
     for (const QString &tagName : tags) {
-        QString colorName = tagColorMap.contains(tagName) ? tagColorMap[tagName] : TagHelper::instance()->qureyColorByDisplayName(tagName).name();
+        QString colorName = tagColorMap.contains(tagName) ? tagColorMap[tagName] : TagHelper::instance()->queryColorByDisplayName(tagName).name();
         tagWithColor[tagName] = QVariant { QList<QString> { colorName } };
     }
 
@@ -453,7 +453,7 @@ bool TagManager::changeTagColor(const QString &tagName, const QString &newTagCol
     if (tagName.isEmpty() || newTagColor.isEmpty())
         return false;
     emit tagDeleted(tagName);
-    QVariantMap changeMap { { tagName, QVariant { TagHelper::instance()->qureyColorByColorName(newTagColor).name() } } };
+    QVariantMap changeMap { { tagName, QVariant { TagHelper::instance()->queryColorByColorName(newTagColor).name() } } };
     return TagProxyHandleIns->changeTagsColor(changeMap);
 }
 
@@ -469,7 +469,7 @@ bool TagManager::changeTagName(const QString &tagName, const QString &newName)
 
     // If new name matches a default color, sync the tag color to match.
     // This prevents inconsistency where tagName="Gray" but tagColor remains #9023fc.
-    QColor defaultColor = TagHelper::instance()->qureyColorByDisplayName(newName);
+    QColor defaultColor = TagHelper::instance()->queryColorByDisplayName(newName);
     if (defaultColor.isValid()) {
         QVariantMap colorChangeMap { { tagName, QVariant { defaultColor.name() } } };
         TagProxyHandleIns->changeTagsColor(colorChangeMap);
@@ -656,7 +656,7 @@ void TagManager::contenxtMenuHandle(quint64 windowId, const QUrl &url, const QPo
     connect(tagAction, &QWidgetAction::triggered, TagManager::instance(), [url, tagWidget]() {
         if (tagWidget->checkedColorList().size() > 0) {
             QString tagName = TagHelper::instance()->getTagNameFromUrl(url);
-            QString colorName = TagHelper::instance()->qureyColorNameByColor(tagWidget->checkedColorList().first());
+            QString colorName = TagHelper::instance()->queryColorNameByColor(tagWidget->checkedColorList().first());
 
             TagManager::instance()->changeTagColor(tagName, colorName);
         }
@@ -689,7 +689,7 @@ QMap<QString, QColor> TagManager::assignColorToTags(const QStringList &tagList) 
                 tagColor = allTags[tag];
             } else {
                 const auto &colorName = TagHelper::instance()->getColorNameByTag(tag);
-                tagColor = TagHelper::instance()->qureyColorByColorName(colorName);
+                tagColor = TagHelper::instance()->queryColorByColorName(colorName);
                 TagManager::instance()->registerTagColor(tag, tagColor.name());
             }
 
@@ -730,7 +730,7 @@ void TagManager::onTagColorChanged(const QVariantMap &tagAndColorName)
     auto it = tagAndColorName.begin();
     while (it != tagAndColorName.end()) {
         QUrl url = TagHelper::instance()->makeTagUrlByTagName(it.key());
-        QString iconName = TagHelper::instance()->qureyIconNameByColor(QColor(it.value().toString()));
+        QString iconName = TagHelper::instance()->queryIconNameByColor(QColor(it.value().toString()));
         QIcon icon = QIcon::fromTheme(iconName);
         QVariantMap map {
             { "Property_Key_Icon", icon },

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
@@ -76,6 +76,7 @@ public:
 
 Q_SIGNALS:
     void tagDeleted(const QString &tagName);
+    void tagColorChanged(const QVariantMap &tagAndColorName);
     void filesTagged(const QVariantMap &fileAndTags);
     void filesUntagged(const QVariantMap &fileAndTags);
     void filesHidden(const QVariantMap &fileAndTags);

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.h
@@ -47,7 +47,7 @@ public:
     QString getTagIconName(const QString &tag) const;
     void hideFiles(const QList<QString> &tags, const QList<QUrl> &files);
 
-    // qurey
+    // query
     TagColorMap getAllTags();
     TagColorMap getTagsColor(const QStringList &tags) const;
     QStringList getTagsByUrls(const QList<QUrl> &urls) const;

--- a/src/plugins/common/dfmplugin-tag/widgets/tagwidget.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagwidget.cpp
@@ -124,13 +124,23 @@ void TagWidget::onCheckedColorChanged(const QColor &color)
     QList<QUrl> urlList { d->url };
     QList<QColor> checkedColors = d->colorListWidget->checkedColorList();
 
+    // Build color->tagName mapping from DB, so renamed tags resolve correctly
+    const auto allTags = TagManager::instance()->getAllTags();
+    QMap<QString, QString> colorToTag;
+    for (auto it = allTags.cbegin(); it != allTags.cend(); ++it)
+        colorToTag[it.value().name()] = it.key();
+
     QStringList newTagNames;
     for (const QColor &color : checkedColors) {
-        QString colorName = TagHelper::instance()->qureyDisplayNameByColor(color);
-        if (colorName.isEmpty())
+        // DB-first lookup: use actual tagName from DB
+        QString tagName = colorToTag.value(color.name(), QString());
+        // Fallback to hardcoded table for brand-new tags not yet in DB
+        if (tagName.isEmpty())
+            tagName = TagHelper::instance()->qureyDisplayNameByColor(color);
+        if (tagName.isEmpty())
             continue;
 
-        newTagNames << colorName;
+        newTagNames << tagName;
     }
 
     for (const QString &tagName : tagNameList) {
@@ -145,6 +155,13 @@ void TagWidget::onCheckedColorChanged(const QColor &color)
 void TagWidget::onTagChanged(const QVariantMap &fileAndTags)
 {
     if (fileAndTags.contains(d->url.path()))
+        loadTags(d->url);
+}
+
+void TagWidget::onTagColorChanged(const QVariantMap &tagAndColorName)
+{
+    Q_UNUSED(tagAndColorName)
+    if (!d->url.isEmpty())
         loadTags(d->url);
 }
 
@@ -164,6 +181,11 @@ void TagWidget::initConnection()
 
     connect(TagManager::instance(), &TagManager::filesTagged, this, &TagWidget::onTagChanged);
     connect(TagManager::instance(), &TagManager::filesUntagged, this, &TagWidget::onTagChanged);
+    connect(TagManager::instance(), &TagManager::tagColorChanged, this, &TagWidget::onTagColorChanged);
+    connect(TagManager::instance(), &TagManager::tagDeleted, this, [this](const QString &) {
+        if (!d->url.isEmpty())
+            loadTags(d->url);
+    });
 }
 
 void TagWidget::updateCrumbsColor(const QMap<QString, QColor> &tagsColor)

--- a/src/plugins/common/dfmplugin-tag/widgets/tagwidget.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagwidget.cpp
@@ -136,7 +136,7 @@ void TagWidget::onCheckedColorChanged(const QColor &color)
         QString tagName = colorToTag.value(color.name(), QString());
         // Fallback to hardcoded table for brand-new tags not yet in DB
         if (tagName.isEmpty())
-            tagName = TagHelper::instance()->qureyDisplayNameByColor(color);
+            tagName = TagHelper::instance()->queryDisplayNameByColor(color);
         if (tagName.isEmpty())
             continue;
 

--- a/src/plugins/common/dfmplugin-tag/widgets/tagwidget.h
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagwidget.h
@@ -45,6 +45,7 @@ public slots:
     void onCrumbListChanged();
     void onCheckedColorChanged(const QColor &color);
     void onTagChanged(const QVariantMap &fileAndTags);
+    void onTagColorChanged(const QVariantMap &tagAndColorName);
     void filterInput();
 
 protected:


### PR DESCRIPTION
1. Added colorToTag mapping in TagMenuScenePrivate to cache tag name
lookups
2. Implemented two-level lookup for tag names (DB cache fallback to
hardcoded)
3. Added tagColorChanged signal in TagManager for UI updates
4. Modified TagWidget to handle tag color changes and deletions
5. Improved tag name consistency when changing to default color names
6. Enhanced performance by reducing DB queries through caching

The changes improve:
- Correct handling of renamed tags through DB-first lookups
- Performance by caching color-name mappings
- Consistency between tag names and colors
- Responsiveness to backend changes through new signals

Log: Improved tag management reliability and performance with better
caching

Influence:
1. Test tag creation and renaming with custom colors
2. Verify tag color consistency after renaming
3. Check performance with large number of tags
4. Test tag widget updates when backend changes occur
5. Verify fallback to hardcoded color names works
6. Test menu hover and click behavior with renamed tags

fix: 优化标签颜色和名称处理

1. 在TagMenuScenePrivate中添加colorToTag映射缓存标签名称查询
2. 实现两级标签名称查询(DB缓存回退到硬编码)
3. 在TagManager中添加tagColorChanged信号用于UI更新
4. 修改TagWidget以处理标签颜色变化和删除
5. 改进将标签改为默认颜色名称时的名称一致性
6. 通过缓存减少数据库查询提高性能

变更改进:
- 通过DB优先查询正确处理重命名标签
- 通过缓存提高性能
- 保证标签名称与颜色一致性
- 通过新信号增强对后端变化的响应

Log: 通过更好的缓存机制提升标签管理可靠性和性能

Influence:
1. 测试使用自定义颜色的标签创建和重命名
2. 验证重命名后标签颜色的一致性
3. 检查大量标签时的性能表现
4. 测试后端变化时标签小部件的更新
5. 验证回退到硬编码颜色名称功能
6. 测试重命名标签时的菜单悬停和点击行为

Fixes: #363651

## Summary by Sourcery

Improve tag name and color handling by using database-backed mappings, emitting color change signals, and updating widgets in response to tag updates and deletions.

New Features:
- Add a cached color-to-tag mapping in the tag menu scene for resolving tag names from colors using database data.
- Introduce a tagColorChanged signal in TagManager and handle it in TagWidget to refresh displayed tags when colors change.

Bug Fixes:
- Ensure renamed tags are correctly resolved when selecting, hovering, or applying tags by preferring database lookups over hardcoded color-name mappings.
- Keep tag names and colors consistent when renaming tags to a default color name by synchronizing the tag color with the default color.

Enhancements:
- Reduce redundant database queries and improve tag menu performance by caching color-to-tag mappings and reusing them across interactions.
- Ensure TagWidget reloads tags when tag colors change or tags are deleted to keep the UI in sync with backend state.