### PR TITLE
fix: handle default tag color changes properly

### DIFF
--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -48,7 +48,7 @@ using namespace GlobalDConfDefines::BaseConfig;
 
 #define BUILD_VERSION ((QString(VERSION) == "") ? "6.0.0.0" : QString(VERSION))
 
-// defualt plugin IID
+// default plugin IID
 static constexpr char kFmPluginInterface[] { "org.deepin.plugin.filemanager" };
 static constexpr char kCommonPluginInterface[] { "org.deepin.plugin.common" };
 static constexpr char kPluginCore[] { "dfmplugin-core" };

--- a/src/dfm-base/base/application/application.h
+++ b/src/dfm-base/base/application/application.h
@@ -68,7 +68,7 @@ public:
     Q_ENUM(GenericAttribute)
 
     enum TriggerAttribute {
-        kRestoreViewMode,   // restore defualt view mode to all dir
+        kRestoreViewMode,   // restore default view mode to all dir
         kClearSearchHistory   // clear search history
     };
 

--- a/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
+++ b/src/plugins/common/dfmplugin-tag/menu/tagmenuscene.cpp
@@ -282,7 +282,7 @@ QAction *TagMenuScene::createColorListAction(QMenu *parent) const
 
     for (const QString &tag : tags) {
         // The tag name of the database is the display name of the tag
-        if (!TagHelper::instance()->isDefualtTag(tag))
+        if (!TagHelper::instance()->isDefaultTag(tag))
             continue;
 
         const QColor &color = tagColors.value(tag, QColor());

--- a/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
@@ -60,7 +60,7 @@ QList<QUrl> TagHelper::commonUrls(const QList<QUrl> &urls)
     return commonUrls;
 }
 
-QList<QColor> TagHelper::defualtColors() const
+QList<QColor> TagHelper::defaultColors() const
 {
     QList<QColor> colors;
 
@@ -190,7 +190,7 @@ QString TagHelper::getColorNameByTag(const QString &tagName) const
     return randomTagDefine().colorName;
 }
 
-bool TagHelper::isDefualtTag(const QString &tagName) const
+bool TagHelper::isDefaultTag(const QString &tagName) const
 {
     auto ret = std::find_if(colorDefines.cbegin(), colorDefines.cend(), [tagName](const TagColorDefine &define) {
         return define.displayName == tagName;

--- a/src/plugins/common/dfmplugin-tag/utils/taghelper.h
+++ b/src/plugins/common/dfmplugin-tag/utils/taghelper.h
@@ -44,7 +44,7 @@ public:
 
     static QList<QUrl> commonUrls(const QList<QUrl> &urls);
 
-    QList<QColor> defualtColors() const;
+    QList<QColor> defaultColors() const;
 
     QColor queryColorByColorName(const QString &name) const;
     QColor queryColorByDisplayName(const QString &name) const;
@@ -58,7 +58,7 @@ public:
     QUrl makeTagUrlByTagName(const QString &tag) const;
 
     QString getColorNameByTag(const QString &tagName) const;
-    bool isDefualtTag(const QString &tagName) const;
+    bool isDefaultTag(const QString &tagName) const;
 
     void paintTags(QPainter *painter, QRectF &rect, const QList<QColor> &colors) const;
 

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -452,8 +452,27 @@ bool TagManager::changeTagColor(const QString &tagName, const QString &newTagCol
 {
     if (tagName.isEmpty() || newTagColor.isEmpty())
         return false;
+
+    QColor newColor = TagHelper::instance()->queryColorByColorName(newTagColor);
+    QString newDisplayName = TagHelper::instance()->queryDisplayNameByColor(newColor);
+
+    // If changing a default tag to another default color, sync tagName to match
+    if (!newDisplayName.isEmpty() && newDisplayName != tagName
+        && TagHelper::instance()->isDefualtTag(tagName)) {
+        if (getAllTags().contains(newDisplayName)) {
+            DialogManagerInstance->showRenameNameSameErrorDialog(newDisplayName);
+            return false;
+        }
+        // Change color first, then rename to keep consistency
+        QVariantMap colorChangeMap { { tagName, QVariant { newColor.name() } } };
+        TagProxyHandleIns->changeTagsColor(colorChangeMap);
+        QVariantMap oldAndNewName = { { tagName, QVariant { newDisplayName } } };
+        emit tagDeleted(tagName);
+        return TagProxyHandleIns->changeTagNamesWithFiles(oldAndNewName);
+    }
+
     emit tagDeleted(tagName);
-    QVariantMap changeMap { { tagName, QVariant { TagHelper::instance()->queryColorByColorName(newTagColor).name() } } };
+    QVariantMap changeMap { { tagName, QVariant { newColor.name() } } };
     return TagProxyHandleIns->changeTagsColor(changeMap);
 }
 

--- a/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/tagmanager.cpp
@@ -458,7 +458,7 @@ bool TagManager::changeTagColor(const QString &tagName, const QString &newTagCol
 
     // If changing a default tag to another default color, sync tagName to match
     if (!newDisplayName.isEmpty() && newDisplayName != tagName
-        && TagHelper::instance()->isDefualtTag(tagName)) {
+        && TagHelper::instance()->isDefaultTag(tagName)) {
         if (getAllTags().contains(newDisplayName)) {
             DialogManagerInstance->showRenameNameSameErrorDialog(newDisplayName);
             return false;

--- a/src/plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.cpp
@@ -74,7 +74,7 @@ void TagColorListWidget::clearToolTipText()
 
 void TagColorListWidget::initUiElement()
 {
-    QList<QColor> colors = TagHelper::instance()->defualtColors();
+    QList<QColor> colors = TagHelper::instance()->defaultColors();
 
     for (const QColor &color : colors) {
         tagButtons << new TagButton(color, this);

--- a/src/plugins/common/dfmplugin-tag/widgets/tagwidget.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tagwidget.cpp
@@ -76,8 +76,8 @@ void TagWidget::loadTags(const QUrl &url)
     d->crumbEdit->clear();
 
     for (auto it = tagsMap.begin(); it != tagsMap.end(); ++it) {
-        // defualt tag need show checked
-        if (TagHelper::instance()->isDefualtTag(it.key()))
+        // default tag need show checked
+        if (TagHelper::instance()->isDefaultTag(it.key()))
             selectColors << it.value();
 
         DCrumbTextFormat format = d->crumbEdit->makeTextFormat();
@@ -144,7 +144,7 @@ void TagWidget::onCheckedColorChanged(const QColor &color)
     }
 
     for (const QString &tagName : tagNameList) {
-        if (!TagHelper::instance()->isDefualtTag(tagName))
+        if (!TagHelper::instance()->isDefaultTag(tagName))
             newTagNames << tagName;
     }
 

--- a/src/plugins/filemanager/dfmplugin-computer/fileentity/commonentryfileentity.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/fileentity/commonentryfileentity.cpp
@@ -22,7 +22,7 @@ CommonEntryFileEntity::CommonEntryFileEntity(const QUrl &url)
         const auto &map { infos.value(url) };
         reflectionObjName = map.value("ReflectionObject").toString();
         defaultName = QObject::tr(qPrintable(map.value("ItemName").toString()));
-        defualtIcon = QIcon::fromTheme(map.value("ItemIcon").toString());
+        defaultIcon = QIcon::fromTheme(map.value("ItemIcon").toString());
     }
 }
 
@@ -50,8 +50,8 @@ QString CommonEntryFileEntity::displayName() const
 
 QIcon CommonEntryFileEntity::icon() const
 {
-    if (!defualtIcon.isNull())
-        return defualtIcon;
+    if (!defaultIcon.isNull())
+        return defaultIcon;
     if (reflection() && hasMethod("icon")) {
         QIcon theIcon;
         bool ret { QMetaObject::invokeMethod(reflectionObj, "icon",

--- a/src/plugins/filemanager/dfmplugin-computer/fileentity/commonentryfileentity.h
+++ b/src/plugins/filemanager/dfmplugin-computer/fileentity/commonentryfileentity.h
@@ -46,7 +46,7 @@ public:
     QString reflectionObjName;
     mutable QObject *reflectionObj { nullptr };
     QString defaultName;
-    QIcon defualtIcon;
+    QIcon defaultIcon;
 };
 
 }   // end namespace dfmplugin_computer

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -418,7 +418,7 @@ void SideBarWidget::initDefaultModel()
     groupDisplayName.insert(DefaultGroup::kOther, tr("Other"));
     groupDisplayName.insert(DefaultGroup::kNotExistedGroup, tr("Unknown Group"));
 
-    // create defualt separator item.
+    // create default separator item.
     for (const QString &group : currentGroups) {
         auto item = SideBarHelper::createSeparatorItem(group);
         item->setData(groupDisplayName.value(group), Qt::DisplayRole);

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
@@ -139,7 +139,7 @@ QList<ItemRoles> TitleBarEventCaller::sendColumnRoles(QWidget *sender)
     return roleList;
 }
 
-ViewMode TitleBarEventCaller::sendGetDefualtViewMode(const QString &scheme)
+ViewMode TitleBarEventCaller::sendGetDefaultViewMode(const QString &scheme)
 {
     int defaultViewMode = dpfSlotChannel->push("dfmplugin_workspace", "slot_View_GetDefaultViewMode", scheme).toInt();
     return static_cast<ViewMode>(defaultViewMode);

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
@@ -32,7 +32,7 @@ public:
     static void sendTabChanged(QWidget *sender, const QString &uniqueId);
     static void sendTabCreated(QWidget *sender, const QString &uniqueId);
     static void sendTabRemoved(QWidget *sender, const QString &removedId, const QString &nextId);
-    static DFMGLOBAL_NAMESPACE::ViewMode sendGetDefualtViewMode(const QString &scheme);
+    static DFMGLOBAL_NAMESPACE::ViewMode sendGetDefaultViewMode(const QString &scheme);
     static DFMGLOBAL_NAMESPACE::ItemRoles sendCurrentSortRole(QWidget *sender);
     static QList<DFMGLOBAL_NAMESPACE::ItemRoles> sendColumnRoles(QWidget *sender);
     static QString sendColumnDisplyName(QWidget *sender, DFMBASE_NAMESPACE::Global::ItemRoles role);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/optionbuttonbox.cpp
@@ -65,7 +65,7 @@ void OptionButtonBoxPrivate::setViewMode(ViewMode mode)
 
 void OptionButtonBoxPrivate::loadViewMode(const QUrl &url)
 {
-    auto defaultViewMode = static_cast<int>(TitleBarEventCaller::sendGetDefualtViewMode(url.scheme()));
+    auto defaultViewMode = static_cast<int>(TitleBarEventCaller::sendGetDefaultViewMode(url.scheme()));
     auto viewMode = static_cast<ViewMode>(TitleBarHelper::getFileViewStateValue(url, "viewMode", defaultViewMode).toInt());
     if (viewMode == ViewMode::kTreeMode && !DConfigManager::instance()->value(kViewDConfName, kTreeViewEnable, true).toBool()) {
         fmInfo() << "Tree view is disabled in config, switching to list mode";

--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -59,7 +59,7 @@ inline constexpr int kCompactIconModeColumnPadding { 5 };
 inline constexpr int kIconViewSpacing { 10 };   // icon模式下的间距的一半
 inline constexpr int kListViewSpacing { 0 };
 inline constexpr int kIconModeColumnPadding { 10 };
-inline constexpr int kDefualtHeaderSectionWidth { 140 };
+inline constexpr int kDefaultHeaderSectionWidth { 140 };
 inline constexpr int kDefaultItemFileTimeWidth { 145 };
 inline constexpr int kMinimumHeaderSectionWidth { 120 };
 inline constexpr int kListViewHeaderHeight { 36 };

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -745,14 +745,14 @@ QList<ItemRoles> FileViewModel::getColumnRoles() const
             roles.append(static_cast<ItemRoles>(var.toInt()));
         }
     } else if (!customOnly) {
-        static QList<ItemRoles> defualtColumnRoleList = QList<ItemRoles>() << kItemFileDisplayNameRole
+        static QList<ItemRoles> defaultColumnRoleList = QList<ItemRoles>() << kItemFileDisplayNameRole
                                                                            << kItemFileLastModifiedRole
                                                                            << kItemFileCreatedRole
                                                                            << kItemFileSizeRole
                                                                            << kItemFileMimeTypeRole;
 
         int customCount = roles.count();
-        for (auto role : defualtColumnRoleList) {
+        for (auto role : defaultColumnRoleList) {
             if (!roles.contains(role)) {
                 int index = roles.length() - customCount;
 
@@ -779,14 +779,14 @@ ItemRoles FileViewModel::columnToRole(int column) const
             return ItemRoles(headerList.at(column).toInt());
 
     } else if (!customOnly) {
-        static QList<ItemRoles> defualtColumnRoleList = QList<ItemRoles>() << kItemFileDisplayNameRole
+        static QList<ItemRoles> defaultColumnRoleList = QList<ItemRoles>() << kItemFileDisplayNameRole
                                                                            << kItemFileLastModifiedRole
                                                                            << kItemFileCreatedRole
                                                                            << kItemFileSizeRole
                                                                            << kItemFileMimeTypeRole;
 
-        if (defualtColumnRoleList.length() > column) {
-            return defualtColumnRoleList.at(column);
+        if (defaultColumnRoleList.length() > column) {
+            return defaultColumnRoleList.at(column);
         }
     }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2690,13 +2690,13 @@ void FileView::updateListHeaderView()
     d->headerView->setModel(model());
     d->headerView->setRootIndex(rootIndex());
 
-    d->headerView->setDefaultSectionSize(kDefualtHeaderSectionWidth);
+    d->headerView->setDefaultSectionSize(kDefaultHeaderSectionWidth);
     if (d->allowedAdjustColumnSize) {
         d->headerView->setSectionResizeMode(QHeaderView::Interactive);
         d->headerView->setMinimumSectionSize(kMinimumHeaderSectionWidth);
     } else {
         d->headerView->setSectionResizeMode(QHeaderView::Fixed);
-        d->headerView->setMinimumSectionSize(kDefualtHeaderSectionWidth);
+        d->headerView->setMinimumSectionSize(kDefaultHeaderSectionWidth);
     }
 
     d->headerView->setSortIndicator(model()->getColumnByRole(model()->sortRole()), model()->sortOrder());


### PR DESCRIPTION
1. Modified tag color change logic to handle default tags specially
2. When changing a default tag to another default color, automatically
rename tag to match new color's display name
3. Added validation to prevent duplicate tag names during rename
4. Improved flow to maintain tag name-color consistency across the
system
5. Split the operation into color change and name change phases when
needed

Log: Fixed issue where default tags wouldn't properly rename when
changing to another default color

Influence:
1. Test changing default tags to different default colors - should auto-
rename
2. Verify preventing duplicate tag names when renaming
3. Check consistency of tag names and colors in all views
4. Test regular (non-default) tag color changes remain unaffected
5. Verify tag delete and rename signals are properly emitted

fix: 修复默认标签颜色变更的问题

1. 修改了标签颜色变更逻辑以特殊处理默认标签
2. 当把默认标签改为另一个默认颜色时，会自动将标签重命名为新颜色对应的显
示名称
3. 添加了重命名时的重复名称校验
4. 改进了流程以保持系统中标签名称和颜色的一致性
5. 在需要时将操作分为颜色变更和名称变更两个阶段

Log: 修复了默认标签在更改为另一个默认颜色时无法正确重命名的问题

Influence:
1. 测试将默认标签改为不同默认颜色的情况 - 应自动重命名
2. 验证防止重命名时出现重复标签名的情况
3. 检查所有视图中的标签名称和颜色一致性
4. 测试普通(非默认)标签颜色变更不受影响
5. 验证标签删除和重命名信号是否正确发出

Fixes: #361539
