### PR TITLE
feat: add copy path support for trash items

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+dde-file-manager (6.5.141) unstable; urgency=medium
+
+  * perf: remove redundant index optimization in UpdateIndexHandler
+  * fix: ensure index status persistence after migration
+  * fix: improve emblem scaling logic in HiDPI environments
+  * fix: handle graceful shutdown in device proxy manager
+  * fix: improve MIME type categorization handling
+  * feat: add new mimetypes for office documents
+  * fix: improve text line height calculation accuracy
+  * fix: add HiDPI support for icons across UI
+  * fix: correct file count handling during restoration
+  * fix: prevent highlight cache pollution between search types
+  * fix: optimize tag color and name handling
+  * fix: correct typos in query method names
+  * fix: remove deprecated dde-filemanager-daemon service file
+  * fix: handle default tag color changes properly
+  * chore: correct spelling of 'default' across codebase
+  * refactor: refactor optical share service to session bus
+  * fix: add copy path support for trash items
+  * fix(sidebar): use monotonic timer for click interval guard
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 04 Jun 2026 21:51:38 +0800
+
 dde-file-manager (6.5.140) unstable; urgency=medium
 
   * feat: SMB feature optimization

--- a/src/plugins/filemanager/dfmplugin-trash/trash.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/trash.cpp
@@ -162,6 +162,7 @@ void Trash::followEvents()
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles", TrashHelper::instance(), &TrashHelper::customColumnRole);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_Model_FetchCustomRoleDisplayName", TrashHelper::instance(), &TrashHelper::customRoleDisplayName);
     dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_PasteFiles", TrashFileHelper::instance(), &TrashFileHelper::blockPaste);
+    dpfHookSequence->follow("dfmplugin_workspace", "hook_ShortCut_CopyFilePath", TrashFileHelper::instance(), &TrashFileHelper::hookCopyFilePath);
     dpfHookSequence->follow("dfmplugin_titlebar", "hook_Tab_FileDeleteNotCdComputer", TrashFileHelper::instance(), &TrashFileHelper::handleNotCdComputer);
 
     // hook events, file operation

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.cpp
@@ -177,6 +177,28 @@ bool TrashFileHelper::handleIsSubFile(const QUrl &parent, const QUrl &sub)
     return sub.path().contains(parent.path());
 }
 
+bool TrashFileHelper::hookCopyFilePath(quint64 windowId, const QList<QUrl> &urlList, const QUrl &rootUrl)
+{
+    Q_UNUSED(windowId)
+
+    if (rootUrl.scheme() != scheme())
+        return false;
+
+    if (urlList.isEmpty())
+        return false;
+
+    QStringList pathList;
+    for (const auto &url : std::as_const(urlList)) {
+        pathList << scheme() + "://" + url.path();
+    }
+
+    QMimeData *data = new QMimeData;
+    data->setText(pathList.join('\n'));
+    ClipBoard::instance()->setDataToClipboard(data);
+
+    return true;
+}
+
 bool TrashFileHelper::handleNotCdComputer(const QUrl &url, QUrl *cdUrl)
 {
     if (url.scheme() != scheme())

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.h
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashfilehelper.h
@@ -41,6 +41,7 @@ public:
     bool handleCanTag(const QUrl &url, bool *canTag);
     bool handleIsSubFile(const QUrl &parent, const QUrl &sub);
     bool handleNotCdComputer(const QUrl &url, QUrl *cdUrl);
+    bool hookCopyFilePath(quint64 windowId, const QList<QUrl> &urlList, const QUrl &rootUrl);
 
 private:
     explicit TrashFileHelper(QObject *parent = nullptr);


### PR DESCRIPTION
1. Implemented hookCopyFilePath function in TrashFileHelper to handle
copy path operation for trash items
2. Added hook registration in Trash class initialization to connect the
copy path shortcut
3. The function converts trash URLs to proper format and copies them to
clipboard as text
4. Only processes when items are in trash and URL list is not empty

Log: Added copy path functionality for items in trash

Influence:
1. Test copying path of single trash item
2. Test copying path of multiple trash items simultaneously
3. Verify clipboard contains proper format of trash URLs
4. Verify copy path doesn't work for non-trash items
5. Test behavior with empty selection in trash

feat: 为回收站项目添加复制路径支持

1. 在TrashFileHelper中实现hookCopyFilePath函数，处理回收站项目的复制路径
操作
2. 在Trash类初始化时添加钩子注册，连接复制路径快捷键
3. 该函数将回收站URL转换为适当格式，并以文本形式复制到剪贴板
4. 仅当项目在回收站中且URL列表不为空时才会处理

Log: 新增回收站项目的复制路径功能

Influence:
1. 测试复制单个回收站项目的路径
2. 测试同时复制多个回收站项目的路径
3. 验证剪贴板包含格式正确的回收站URL
4. 验证复制路径对非回收站项目无效
5. 测试回收站中空选时的行为

Fixes: #362191
