### PR TITLE
Security hardening

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.cpp
@@ -4,8 +4,6 @@
 
 #include "interfaceactivevault.h"
 #include "operatorcenter.h"
-#include "utils/vaulthelper.h"
-#include "utils/pathmanager.h"
 
 using namespace dfmplugin_vault;
 
@@ -31,29 +29,4 @@ bool InterfaceActiveVault::checkPassword(const QString &password, QString &ciphe
 bool InterfaceActiveVault::checkUserKey(const QString &userKey, QString &cipher)
 {
     return OperatorCenter::getInstance()->checkUserKey(userKey, cipher);
-}
-
-QString InterfaceActiveVault::getEncryptDir()
-{
-    return OperatorCenter::getInstance()->getEncryptDirPath();
-}
-
-QString InterfaceActiveVault::getDecryptDir()
-{
-    return OperatorCenter::getInstance()->getdecryptDirPath();
-}
-
-QStringList InterfaceActiveVault::getConfigFilePath()
-{
-    return OperatorCenter::getInstance()->getConfigFilePath();
-}
-
-VaultState InterfaceActiveVault::vaultState()
-{
-    return VaultHelper::instance()->state(PathManager::makeVaultLocalPath(QString(""), kVaultEncrypyDirName));
-}
-
-bool InterfaceActiveVault::getRootPassword()
-{
-    return OperatorCenter::getInstance()->getRootPassword();
 }

--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.cpp
@@ -57,8 +57,3 @@ bool InterfaceActiveVault::getRootPassword()
 {
     return OperatorCenter::getInstance()->getRootPassword();
 }
-
-int InterfaceActiveVault::executionShellCommand(const QString &strCmd, QStringList &lstShellOutput)
-{
-    return OperatorCenter::getInstance()->executionShellCommand(strCmd, lstShellOutput);
-}

--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.h
@@ -70,20 +70,6 @@ public:
      * @return
      */
     static bool getRootPassword();
-
-    /**
-    * @brief executionShellCommand 执行shell命令并获得shell命令的返回值
-    * @param strCmd 要执行的shell命令
-    * @param lstShellOutput shell命令返回的结果
-    * @return 返回值为0表示成功，其它都不成功
-    */
-    static int executionShellCommand(const QString &strCmd, QStringList &lstShellOutput);
-
-signals:
-
-public slots:
-
-private:
 };
 }
 #endif   // INTERFACEACTIVEVAULT_H

--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/interfaceactivevault.h
@@ -40,36 +40,6 @@ public:
      * @return 是否成功
      */
     static bool checkUserKey(const QString &userKey, QString &cipher);
-
-    /**
-     * @brief getEncryptedDir 获得加密文件夹路径
-     * @return
-     */
-    static QString getEncryptDir();
-
-    /**
-     * @brief getDecryptDir 获得解密文件夹路径
-     * @return
-     */
-    static QString getDecryptDir();
-
-    /**
-     * @brief getConfigFilePath
-     * @return
-     */
-    static QStringList getConfigFilePath();
-
-    /**
-     * @brief vaultState // 获得保险箱状态
-     * @return
-     */
-    static VaultState vaultState();
-
-    /**
-     * @brief getRootPassword 管理员权限认证
-     * @return
-     */
-    static bool getRootPassword();
 };
 }
 #endif   // INTERFACEACTIVEVAULT_H

--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp
@@ -716,11 +716,6 @@ void OperatorCenter::clearSaltAndPasswordCipher()
     strCryfsPassword.clear();
 }
 
-QString OperatorCenter::getEncryptDirPath()
-{
-    return makeVaultLocalPath(kVaultEncrypyDirName);
-}
-
 QString OperatorCenter::getdecryptDirPath()
 {
     return makeVaultLocalPath(kVaultDecryptDirName);
@@ -766,23 +761,6 @@ QString OperatorCenter::autoGeneratePassword(int length)
 
     fmDebug() << "Vault: Generated password success";
     return strPassword;
-}
-
-bool OperatorCenter::getRootPassword()
-{
-    // 判断当前是否是管理员登陆
-    bool res = runCmd("id -un");   // file path is fixed. So write cmd direct
-    if (res && standOutput.trimmed() == "root") {
-        fmDebug() << "Vault: Already running as root";
-        return true;
-    }
-
-    if (false == executeProcess("sudo whoami")) {
-        fmWarning() << "Vault: Failed to get root privileges";
-        return false;
-    }
-
-    return true;
 }
 
 Result OperatorCenter::savePasswordToKeyring(const QString &password)

--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.cpp
@@ -785,45 +785,6 @@ bool OperatorCenter::getRootPassword()
     return true;
 }
 
-int OperatorCenter::executionShellCommand(const QString &strCmd, QStringList &lstShellOutput)
-{
-    FILE *fp;
-
-    std::string sCmd = strCmd.toStdString();
-    const char *cmd = sCmd.c_str();
-
-    // 命令为空
-    if (strCmd.isEmpty()) {
-        fmCritical() << "Vault: the shell cmd is empty!";
-        return -1;
-    }
-
-    if ((fp = popen(cmd, "r")) == nullptr) {
-        perror("popen");
-        fmCritical() << QString("Vault Error: popen error: %s").arg(strerror(errno));
-        return -1;
-    } else {
-        char buf[kBuffterMaxLine] = { '\0' };
-        while (fgets(buf, sizeof(buf), fp)) {   // 获得每行输出
-            QString strLineOutput(buf);
-            if (strLineOutput.endsWith('\n'))
-                strLineOutput.chop(1);
-            lstShellOutput.push_back(strLineOutput);
-        }
-
-        int res;
-        if ((res = pclose(fp)) == -1) {
-            fmCritical() << "Vault: close popen file pointer fp failed!";
-            return res;
-        } else if (res == 0) {
-            return res;
-        } else {
-            fmCritical() << QString("Vault: popen res is : %1").arg(res);
-            return res;
-        }
-    }
-}
-
 Result OperatorCenter::savePasswordToKeyring(const QString &password)
 {
     GError *error = Q_NULLPTR;
@@ -1116,7 +1077,7 @@ bool OperatorCenter::upgradeOldVaultByPassword(const QString &oldPassword, QStri
     int ret = PasswordManager::createLuksContainer(containerPath.toUtf8().constData(),
                                                    masterKey.constData(),
                                                    static_cast<size_t>(masterKey.size()),
-                                                   oldPassword.toUtf8().constData(),  // 使用 oldPassword
+                                                   oldPassword.toUtf8().constData(),   // 使用 oldPassword
                                                    slotID);
     if (ret != 0) {
         fmWarning() << "Vault: upgradeOldVaultByPassword failed to create LUKS container, ret =" << ret;
@@ -1136,7 +1097,7 @@ bool OperatorCenter::upgradeOldVaultByPassword(const QString &oldPassword, QStri
     // 将恢复密钥添加到 LUKS KeySlot 1
     int recoveryKeySlotId = 0;
     ret = PasswordManager::addNewPassword(containerPath.toUtf8().constData(),
-                                          oldPassword.toUtf8().constData(),  // 使用 oldPassword 作为 existingPassword
+                                          oldPassword.toUtf8().constData(),   // 使用 oldPassword 作为 existingPassword
                                           recoveryKey.toUtf8().constData(),
                                           recoveryKeySlotId);
     if (ret != 0) {
@@ -1151,7 +1112,6 @@ bool OperatorCenter::upgradeOldVaultByPassword(const QString &oldPassword, QStri
     outRecoveryKey = recoveryKey;
     return true;
 }
-
 
 bool OperatorCenter::resetPasswordByOldPassword(const QString &oldPassword, const QString &newPassword, const QString &passwordHint)
 {
@@ -1210,7 +1170,7 @@ bool OperatorCenter::resetPasswordByRecoveryKey(const QString &recoveryKey, cons
     size_t masterKeySize = 64;
     int ret = PasswordManager::exportMasterKeyByKeyslot(containerPath.toUtf8().constData(),
                                                         recoveryKeyBytes.constData(),
-                                                        1,  // 恢复密钥在槽1
+                                                        1,   // 恢复密钥在槽1
                                                         masterKeyBuf, &masterKeySize);
     if (ret != 0) {
         fmWarning() << "Vault: Recovery key verification failed";
@@ -1223,11 +1183,11 @@ bool OperatorCenter::resetPasswordByRecoveryKey(const QString &recoveryKey, cons
     // 4. 使用恢复密钥添加新密码到新的KeySlot
     int newKeySlotId = 0;
     ret = PasswordManager::addNewPasswordByKeyslot(
-        containerPath.toUtf8().constData(),
-        recoveryKeyBytes.constData(),
-        1,  // 恢复密钥在槽1
-        newPassword.toUtf8().constData(),
-        newKeySlotId);
+            containerPath.toUtf8().constData(),
+            recoveryKeyBytes.constData(),
+            1,   // 恢复密钥在槽1
+            newPassword.toUtf8().constData(),
+            newKeySlotId);
 
     if (ret != 0) {
         fmWarning() << "Vault: Failed to add new password";

--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.h
@@ -78,8 +78,6 @@ public:
     //! 清除盐值及密码密文的缓存
     void clearSaltAndPasswordCipher();
 
-    //! 获得加密文件夹路径
-    QString getEncryptDirPath();
     //! 获得解密文件夹路径
     QString getdecryptDirPath();
 
@@ -88,9 +86,6 @@ public:
 
     //! 随即生成密码
     QString autoGeneratePassword(int minLength);
-
-    //! 管理员权限认证
-    bool getRootPassword();
 
     Result savePasswordToKeyring(const QString &password);
     QString passwordFromKeyring();

--- a/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/encryption/operatorcenter.h
@@ -92,9 +92,6 @@ public:
     //! 管理员权限认证
     bool getRootPassword();
 
-    //! 执行shell命令并获得shell命令的返回值
-    int executionShellCommand(const QString &strCmd, QStringList &lstShellOutput);
-
     Result savePasswordToKeyring(const QString &password);
     QString passwordFromKeyring();
 

--- a/src/services/diskencrypt/helpers/filesystemhelper.cpp
+++ b/src/services/diskencrypt/helpers/filesystemhelper.cpp
@@ -9,6 +9,7 @@
 
 #include <QFile>
 #include <QDir>
+#include <QProcess>
 
 #include <sys/stat.h>
 #include <fstab.h>
@@ -21,11 +22,8 @@ bool filesystem_helper::shrinkFileSystem_ext(const QString &device)
 {
     qInfo() << "[filesystem_helper::shrinkFileSystem_ext] Starting filesystem shrink operation for device:" << device;
     
-    // TODO(xust): not find the API of resize2fs, use BIN program temp
-    QString cmd = QString("e2fsck -f -y %1").arg(device);
-    qInfo() << "[filesystem_helper::shrinkFileSystem_ext] Running filesystem check command:" << cmd;
-    
-    int ret = ::system(cmd.toStdString().c_str());
+    int ret = QProcess::execute("e2fsck", { "-f", "-y", device });
+    qInfo() << "[filesystem_helper::shrinkFileSystem_ext] e2fsck exit code:" << ret << "device:" << device;
     if (ret != 0) {
         qCritical() << "[filesystem_helper::shrinkFileSystem_ext] Filesystem check failed for device:" << device << "error code:" << ret;
         return false;
@@ -35,11 +33,9 @@ bool filesystem_helper::shrinkFileSystem_ext(const QString &device)
     auto size = blockdev_helper::devDeviceSize(device) / 1024 / 1024;
     auto targetSize = size - 32;
     qInfo() << "[filesystem_helper::shrinkFileSystem_ext] Device will be resized from" << size << "MB to" << targetSize << "MB for device:" << device;
-    
-    cmd = QString("resize2fs %1 %2M").arg(device).arg(targetSize);
-    qInfo() << "[filesystem_helper::shrinkFileSystem_ext] Running resize command:" << cmd;
-    
-    ret = ::system(cmd.toStdString().c_str());
+
+    ret = QProcess::execute("resize2fs", { device, QString("%1M").arg(targetSize) });
+    qInfo() << "[filesystem_helper::shrinkFileSystem_ext] resize2fs exit code:" << ret << "device:" << device;
     if (ret != 0) {
         qCritical() << "[filesystem_helper::shrinkFileSystem_ext] Filesystem resize failed for device:" << device << "error code:" << ret;
         return false;
@@ -53,21 +49,16 @@ bool filesystem_helper::expandFileSystem_ext(const QString &device)
 {
     qInfo() << "[filesystem_helper::expandFileSystem_ext] Starting filesystem expand operation for device:" << device;
     
-    // TODO(xust): not find the API of resize2fs, use BIN program temp
-    QString cmd = QString("e2fsck -f -y %1").arg(device);
-    qInfo() << "[filesystem_helper::expandFileSystem_ext] Running filesystem check command:" << cmd;
-    
-    int ret = ::system(cmd.toStdString().c_str());
+    int ret = QProcess::execute("e2fsck", { "-f", "-y", device });
+    qInfo() << "[filesystem_helper::expandFileSystem_ext] e2fsck exit code:" << ret << "device:" << device;
     if (ret != 0) {
         qCritical() << "[filesystem_helper::expandFileSystem_ext] Filesystem check failed for device:" << device << "error code:" << ret;
         return false;
     }
     qInfo() << "[filesystem_helper::expandFileSystem_ext] Filesystem check completed successfully for device:" << device;
 
-    cmd = QString("resize2fs %1").arg(device);
-    qInfo() << "[filesystem_helper::expandFileSystem_ext] Running resize command:" << cmd;
-    
-    ret = ::system(cmd.toStdString().c_str());
+    ret = QProcess::execute("resize2fs", { device });
+    qInfo() << "[filesystem_helper::expandFileSystem_ext] resize2fs exit code:" << ret << "device:" << device;
     if (ret != 0) {
         qCritical() << "[filesystem_helper::expandFileSystem_ext] Filesystem resize failed for device:" << device << "error code:" << ret;
         return false;


### PR DESCRIPTION
- **fix: replace system calls with QProcess for filesystem operations**
- **fix: remove unused shell command execution code**
- **refactor: simplify vault encryption interface**

## Summary by Sourcery

Harden filesystem and vault components by removing insecure shell execution paths and simplifying the vault encryption interface.

Bug Fixes:
- Replace raw system-based filesystem operations with QProcess-based execution for e2fsck and resize2fs to avoid unsafe shell command usage.

Enhancements:
- Remove unused vault APIs related to encrypt/decrypt directory paths, root privilege acquisition, and generic shell command execution from the encryption operator and public interface.
- Simplify the active vault encryption interface by relying only on necessary key checking and internal helpers.