### PR TITLE
fix: eliminate TOCTOU race condition in file mode change

### DIFF
--- a/src/services/accesscontrol/accesscontroldbus.cpp
+++ b/src/services/accesscontrol/accesscontroldbus.cpp
@@ -205,14 +205,11 @@ bool AccessControlDBus::Chmod(const QString &path, uint mode)
         return false;
     }
 
-    QFile f(path);
-    if (!f.exists()) {
-        fmWarning() << "[AccessControlDBus::Chmod] File does not exist:" << path;
-        return false;
-    }
+    // setFileMode 内部使用 open(O_NOFOLLOW) + fchmod，原子性处理路径校验，
+    // 无需在此处进行 QFile::exists() 检查（那会引入 TOCTOU 竞态）
 
     fmInfo() << "[AccessControlDBus::Chmod] Changing access permission for path:" << path << "to mode:" << QString::number(mode, 8);
-    int ret = ::Utils::setFileMode(path.toStdString().c_str(), mode);
+    int ret = ::Utils::setFileMode(path, mode);
     if (ret != 0) {
         fmCritical() << "[AccessControlDBus::Chmod] Failed to change permission for path:" << path << "error:" << strerror(errno);
         return false;
@@ -278,9 +275,9 @@ void AccessControlDBus::onBlockDevMounted(const QString &deviceId, const QString
         QString source = globalDevPolicies.value(kTypeBlock).first;
         int policy = globalDevPolicies.value(kTypeBlock).second;
         QString fs { dev->fileSystem() };
-        
+
         fmInfo() << "[AccessControlDBus::onBlockDevMounted] Current access mode:" << mode << "policy:" << policy << "for device:" << devDesc;
-        
+
         if (mode != policy) {
             if (policy == kPolicyDisable) {
                 fmInfo() << "[AccessControlDBus::onBlockDevMounted] Device should be disabled, unmounting:" << devDesc;

--- a/src/services/accesscontrol/utils.cpp
+++ b/src/services/accesscontrol/utils.cpp
@@ -14,6 +14,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/fcntl.h>
 #include <unistd.h>
 #include <libcryptsetup.h>
 
@@ -48,12 +49,23 @@ int Utils::setFileMode(const QString &mountPoint, uint mode)
 {
     QByteArray bytes { mountPoint.toLocal8Bit() };
     fmInfo() << "[Utils::setFileMode] Changing file mode for path:" << bytes << "to mode:" << QString::number(mode, 8);
-    int result = chmod(bytes.data(), mode);
+
+    // O_NOFOLLOW: 拒绝符号链接，若末级路径是 symlink 则 open 返回 ELOOP
+    // fchmod: 基于 FD 操作，绑定到 inode，消除 TOCTOU 竞态
+    int fd = open(bytes.data(), O_PATH | O_NOFOLLOW);
+    if (fd < 0) {
+        fmCritical() << "[Utils::setFileMode] Failed to open path:" << bytes << "error:" << strerror(errno);
+        return -1;
+    }
+
+    int result = fchmod(fd, mode);
     if (result != 0) {
-        fmCritical() << "[Utils::setFileMode] Failed to change file mode for path:" << bytes << "error:" << strerror(errno);
+        fmCritical() << "[Utils::setFileMode] Failed to change file mode for fd:" << fd << "error:" << strerror(errno);
     } else {
         fmInfo() << "[Utils::setFileMode] Successfully changed file mode for path:" << bytes;
     }
+
+    close(fd);
     return result;
 }
 
@@ -153,9 +165,9 @@ void Utils::loadDevPolicy(DevPolicyType *devPolicies)
         fmWarning() << "[Utils::loadDevPolicy] Cannot open device policy config file:" << devConfigPath();
         return;
     }
-    
+
     fmInfo() << "[Utils::loadDevPolicy] Loading device policies from:" << devConfigPath();
-    
+
     QJsonParseError err;
     QJsonDocument doc = QJsonDocument::fromJson(config.readAll(), &err);
     config.close();
@@ -202,8 +214,8 @@ void Utils::saveVaultPolicy(const QVariantMap &policy)
     }
     config.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
 
-    fmInfo() << "[Utils::saveVaultPolicy] Saving vault policy - type:" << policy.value(kPolicyType).toInt() 
-             << "hide state:" << policy.value(kVaultHideState).toInt() 
+    fmInfo() << "[Utils::saveVaultPolicy] Saving vault policy - type:" << policy.value(kPolicyType).toInt()
+             << "hide state:" << policy.value(kVaultHideState).toInt()
              << "policy state:" << policy.value(kPolicyState).toInt();
 
     QJsonParseError err;
@@ -234,9 +246,9 @@ void Utils::loadVaultPolicy(VaultPolicyType *vaultPolicies)
         fmWarning() << "[Utils::loadVaultPolicy] Cannot open vault policy config file:" << valultConfigPath();
         return;
     }
-    
+
     fmInfo() << "[Utils::loadVaultPolicy] Loading vault policies from:" << valultConfigPath();
-    
+
     QJsonParseError err;
     QJsonDocument doc = QJsonDocument::fromJson(config.readAll(), &err);
     config.close();
@@ -271,7 +283,7 @@ void Utils::loadVaultPolicy(VaultPolicyType *vaultPolicies)
 DPCErrorCode Utils::checkDiskPassword(crypt_device **cd, const char *pwd, const char *device)
 {
     fmInfo() << "[Utils::checkDiskPassword] Checking disk password for device:" << device;
-    
+
     int r = crypt_init(cd, device);
     if (r < 0) {
         fmCritical() << "[Utils::checkDiskPassword] crypt_init failed for device:" << device << "error code:" << r;


### PR DESCRIPTION
1. Removed redundant QFile::exists() check which could lead to TOCTOU
(Time-of-Check to Time-of-Use) race condition
2. Modified setFileMode to use open(O_NOFOLLOW) + fchmod for atomic
operation
3. Added O_NOFOLLOW to prevent symlink following
4. Now uses file descriptor operations to bind to inode, eliminating
race window
5. Added proper file descriptor cleanup with close()

Log: Fixed potential security vulnerability in file permission changes

Influence:
1. Test file permission changes on regular files
2. Verify behavior with symbolic links (should fail with ELOOP)
3. Test concurrent access scenarios to confirm race condition
elimination
4. Verify permission changes on files in different locations/mount
points
5. Check error handling for non-existent paths

fix: 消除文件权限修改中的TOCTOU竞态条件

1. 移除了可能导致TOCTOU竞态条件的冗余QFile::exists()检查
2. 修改setFileMode使用open(O_NOFOLLOW) + fchmod实现原子操作
3. 添加O_NOFOLLOW防止符号链接跟随
4. 使用文件描述符操作绑定到inode,消除了竞态窗口
5. 添加了正确的文件描述符清理(close())

Log: 修复了文件权限修改中的潜在安全漏洞

Influence:
1. 测试普通文件的权限变更
2. 验证对符号链接的行为(应该返回ELOOP错误)
3. 测试并发访问场景,确认竞态条件的消除
4. 验证不同位置/挂载点文件的权限变更
5. 检查对不存在路径的错误处理

Fixes: #364817

## Summary by Sourcery

Eliminate a TOCTOU race in file permission changes by switching to descriptor-based chmod and removing a non-atomic existence check.

Bug Fixes:
- Prevent TOCTOU race conditions in chmod by using open(O_NOFOLLOW) with fchmod on the resulting file descriptor.
- Avoid inadvertent symlink traversal during permission changes by rejecting symbolic link targets.
- Remove a redundant QFile::exists() pre-check that could cause non-atomic path validation and race windows.