### PR TITLE
refactor: unify optical share service naming

### DIFF
--- a/src/dfm-base/dbusservice/global_server_defines.h
+++ b/src/dfm-base/dbusservice/global_server_defines.h
@@ -131,7 +131,7 @@ inline constexpr char kMessage[] { "message" };
 }   // namespace NetworkMountParamKey
 
 namespace OpticalShareDBusInfo {
-inline constexpr char kService[] { "org.deepin.Filemanager.OpticalShare" };
+inline constexpr char kService[] { "org.deepin.Filemanager.Daemon" };
 inline constexpr char kPath[] { "/org/deepin/Filemanager/Daemon/OpticalShare" };
 inline constexpr char kInterface[] { "org.deepin.Filemanager.OpticalShare" };
 }   // namespace OpticalShareDBusInfo

--- a/src/plugins/daemon/opticalshare/CMakeLists.txt
+++ b/src/plugins/daemon/opticalshare/CMakeLists.txt
@@ -32,6 +32,3 @@ install(TARGETS
     ${DFM_PLUGIN_FILEMANAGER_CORE_DIR}
 )
 
-# install dbus service file
-install(FILES org.deepin.Filemanager.Daemon.OpticalShare.service
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/dbus-1/services)

--- a/src/plugins/daemon/opticalshare/opticalshare.cpp
+++ b/src/plugins/daemon/opticalshare/opticalshare.cpp
@@ -16,8 +16,8 @@ void OpticalShareDBusWorker::launchService()
     Q_ASSERT(QThread::currentThread() != qApp->thread());
 
     auto conn = QDBusConnection::sessionBus();
-    if (!conn.registerService("org.deepin.Filemanager.OpticalShare")) {
-        fmCritical() << "[OpticalShareDBusWorker] Failed to register D-Bus service 'org.deepin.Filemanager.OpticalShare'";
+    if (!conn.registerService("org.deepin.Filemanager.Daemon")) {
+        fmCritical() << "[OpticalShareDBusWorker] Failed to register D-Bus service 'org.deepin.Filemanager.Daemon'";
         return;
     }
 

--- a/src/plugins/daemon/opticalshare/org.deepin.Filemanager.Daemon.OpticalShare.service
+++ b/src/plugins/daemon/opticalshare/org.deepin.Filemanager.Daemon.OpticalShare.service
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.deepin.Filemanager.OpticalShare
-Exec=/usr/bin/dde-file-manager-daemon


### PR DESCRIPTION
1. Changed DBus service name from 'org.deepin.Filemanager.OpticalShare'
to 'org.deepin.Filemanager.Daemon' for consistency with other daemon
services
2. Removed redundant DBus service file installation since now sharing
the main daemon's service name
3. Updated error messages to reflect new service name
4. Kept existing path and interface names to maintain compatibility

Influence:
1. Verify optical share functionality still works through DBus
2. Test that services register correctly with new naming
3. Check for any existing scripts or integrations that might rely on old
service name
4. Validate no regression in optical media sharing features

refactor: 统一光驱共享服务命名

1. 将DBus服务名称从'org.deepin.Filemanager.OpticalShare'改
为'org.deepin.Filemanager.Daemon'以与其他守护程序服务保持一致
2. 移除了冗余的DBus服务文件安装
3. 更新错误消息以反映新服务名称
4. 保留现有路径和接口名称以保持兼容性

Influence:
1. 验证通过DBus的光驱共享功能仍然正常
2. 测试服务能否以新名称正确注册
3. 检查是否有现有脚本或集成依赖旧服务名
4. 确认光驱共享功能没有回归

## Summary by Sourcery

Unify the optical share plugin to use the main file manager daemon D-Bus service name and clean up related configuration.

Enhancements:
- Update the optical share D-Bus service identifier to use org.deepin.Filemanager.Daemon while keeping existing path and interface names for compatibility.
- Remove the dedicated optical share D-Bus service file and its installation step, relying on the main daemon service instead.
- Adjust optical share error logging messages to reflect the new D-Bus service name.