### PR TITLE
feat: add thumbnail support for Krita .kra/.krz files

### DIFF
--- a/cmake/DFMLibraryConfig.cmake
+++ b/cmake/DFMLibraryConfig.cmake
@@ -21,6 +21,7 @@ function(dfm_configure_base_library target_name)
     pkg_check_modules(mount REQUIRED mount IMPORTED_TARGET)
     pkg_check_modules(LIBHEIF REQUIRED libheif)
     pkg_search_module(X11 REQUIRED x11 IMPORTED_TARGET)
+    pkg_check_modules(MINIZIP REQUIRED minizip IMPORTED_TARGET)
     
     # Qt version specific dependencies
     if(${QT_VERSION_MAJOR} EQUAL "6")
@@ -81,6 +82,7 @@ function(dfm_configure_base_library target_name)
             poppler-cpp
             ${LIBHEIF_LIBRARIES}
             libappimage
+            PkgConfig::MINIZIP
     )
     
     # Include directories

--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,8 @@ Build-Depends:
  libappimage-dev,
  libkf6syntaxhighlighting-dev,
  libnl-3-dev,
- libnl-genl-3-dev
+ libnl-genl-3-dev,
+ libminizip-dev
 Standards-Version: 4.5.0
 Homepage: http://www.deepin.org
 

--- a/debian/control.in
+++ b/debian/control.in
@@ -53,7 +53,8 @@ Build-Depends:
  libappimage-dev,
  libkf6syntaxhighlighting-dev,
  libnl-3-dev,
- libnl-genl-3-dev
+ libnl-genl-3-dev,
+ libminizip-dev
 Standards-Version: 4.5.0
 Homepage: http://www.deepin.org
 

--- a/include/dfm-base/dfm_global_defines.h
+++ b/include/dfm-base/dfm_global_defines.h
@@ -154,6 +154,7 @@ inline constexpr char kTypeAppVMAsf[] { "application/vnd.ms-asf" };
 inline constexpr char kTypeAppCRRMedia[] { "application/cnd.rn-realmedia" };
 inline constexpr char kTypeAppVRRMedia[] { "application/vnd.rn-realmedia" };
 inline constexpr char kTypeAppAppimage[] { "application/vnd.appimage" };
+inline constexpr char kTypeAppKrita[] { "application/x-krita" };
 inline constexpr char kTypeAppUab[] { "application/vnd.linyaps.uab" };
 inline constexpr char kTypeTextHtml[] { "text/html" };
 inline constexpr char kTypeAppXhtmlXml[] { "application/xhtml+xml" };

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -20,6 +20,8 @@
 #include <QImageReader>
 #include <QDebug>
 #include <QTemporaryDir>
+#include <minizip/unzip.h>
+#include <string>
 
 #include <libheif/heif.h>
 #include <QImage>
@@ -793,4 +795,53 @@ QImage ThumbnailCreators::uabThumbnailCreator(const QString &filePath, Thumbnail
 
     qCDebug(logDFMBase) << "thumbnail: UAB thumbnail created successfully for:" << filePath;
     return icon;
+}
+
+QImage ThumbnailCreators::krataThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size)
+{
+    Q_UNUSED(size)
+
+    const std::string path = filePath.toStdString();
+
+    auto extractEntry = [&](const char *entryName) -> QByteArray {
+        unzFile zf = unzOpen(path.c_str());
+        if (!zf)
+            return {};
+        if (unzLocateFile(zf, entryName, 0) != UNZ_OK) {
+            unzClose(zf);
+            return {};
+        }
+        unz_file_info fi;
+        if (unzGetCurrentFileInfo(zf, &fi, nullptr, 0, nullptr, 0, nullptr, 0) != UNZ_OK) {
+            unzClose(zf);
+            return {};
+        }
+        if (unzOpenCurrentFile(zf) != UNZ_OK) {
+            unzClose(zf);
+            return {};
+        }
+        QByteArray data(static_cast<int>(fi.uncompressed_size), Qt::Uninitialized);
+        int n = unzReadCurrentFile(zf, data.data(), static_cast<unsigned>(data.size()));
+        unzCloseCurrentFile(zf);
+        unzClose(zf);
+        if (n < 0)
+            return {};
+        data.resize(n);
+        return data;
+    };
+
+    QByteArray data = extractEntry("mergedimage.png");
+    if (data.isEmpty())
+        data = extractEntry("preview.png");
+    if (data.isEmpty()) {
+        qCWarning(logDFMBase) << "[krita-thumb]: no preview found in" << filePath;
+        return {};
+    }
+
+    QImage img;
+    if (!img.loadFromData(data, "PNG")) {
+        qCWarning(logDFMBase) << "[krita-thumb]: failed to decode preview PNG from" << filePath;
+        return {};
+    }
+    return img;
 }

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.h
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.h
@@ -23,6 +23,7 @@ QImage pdfThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::Thumbna
 QImage appimageThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage uabThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 QImage pptxThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
+QImage krataThumbnailCreator(const QString &filePath, DFMGLOBAL_NAMESPACE::ThumbnailSize size);
 }   // namespace ThumbnailCreators
 }   // namespace dfmbase
 

--- a/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
@@ -37,6 +37,7 @@ ThumbnailFactory::ThumbnailFactory(QObject *parent)
     registerThumbnailCreator(Mime::kTypeAppAppimage, ThumbnailCreators::appimageThumbnailCreator);
     registerThumbnailCreator(Mime::kTypeAppUab, ThumbnailCreators::uabThumbnailCreator);
     registerThumbnailCreator(Mime::kTypeAppPptx, ThumbnailCreators::pptxThumbnailCreator);
+    registerThumbnailCreator(Mime::kTypeAppKrita, ThumbnailCreators::krataThumbnailCreator);
 
     init();
 }

--- a/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailhelper.cpp
@@ -59,6 +59,7 @@ void ThumbnailHelper::initMimeTypeSupport()
     // === Executable package types (unconditional icon display) ===
     mimeTypeSupportStrategy.insert(Mime::kTypeAppAppimage, Strategy::kUnconditional);
     mimeTypeSupportStrategy.insert(Mime::kTypeAppUab, Strategy::kUnconditional);
+    mimeTypeSupportStrategy.insert(Mime::kTypeAppKrita, Strategy::kUnconditional);
 }
 
 void ThumbnailHelper::initSizeLimit()
@@ -84,6 +85,7 @@ void ThumbnailHelper::initSizeLimit()
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAudioFlac), INT64_MAX);
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAppAppimage), INT64_MAX);
     sizeLimitHash.insert(mimeDatabase.mimeTypeForName(DFMGLOBAL_NAMESPACE::Mime::kTypeAppUab), INT64_MAX);
+    sizeLimitHash.insert(mimeDatabase.mimeTypeForName(Mime::kTypeAppKrita), INT64_MAX);
 
     qCInfo(logDFMBase) << "thumbnail: initialized size limits for" << sizeLimitHash.size() << "mime types";
 }


### PR DESCRIPTION
## What this does
Adds thumbnail support for Krita .kra and .krz files in DDE File Manager.

## How it works
- Extracts the embedded `mergedimage.png` (Krita ≥ 3) or `preview.png` 
  from the .kra zip archive using minizip
- Registers `krataThumbnailCreator` in ThumbnailFactory
- Adds `application/x-krita` to mimeTypeSupportStrategy and size limit map
- Adds `kTypeAppKrita` MIME constant to dfm_global_defines.h

## Dependency
Requires `libminizip-dev` (already available in Deepin/Debian repos)

## Testing
Tested on Deepin 25 with real .kra files — thumbnails generate correctly 
for both mergedimage.png and preview.png variants.