### PR TITLE
refactor: improve protocol file detection and testing

### DIFF
--- a/autotests/libs/CMakeLists.txt
+++ b/autotests/libs/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(dfm-extension)
 add_subdirectory(dfm-framework)
 add_subdirectory(textindex)
+add_subdirectory(dfm-base)

--- a/autotests/libs/dfm-base/CMakeLists.txt
+++ b/autotests/libs/dfm-base/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# dfm-base unit tests
+# Stub DeviceProxyManager to avoid DBus/system dependencies.
+
+file(GLOB_RECURSE TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+)
+
+dfm_add_test(test-dfm-base
+    SOURCES ${TEST_SOURCES}
+    LINK_LIBRARIES DFM6::base Qt6::Test
+)

--- a/autotests/libs/dfm-base/main.cpp
+++ b/autotests/libs/dfm-base/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QCoreApplication>
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfm_base)

--- a/autotests/libs/dfm-base/test_protocolutils.cpp
+++ b/autotests/libs/dfm-base/test_protocolutils.cpp
@@ -1,0 +1,610 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_protocolutils.cpp
+ * @brief Unit tests for ProtocolUtils namespace (protocolutils.cpp)
+ *
+ * Coverage:
+ *   - matchPath() [indirect]: via scheme-based and path-based protocols
+ *   - gvfsPathStart() [indirect]: via isGvfsPath / isGvfsProtocolPath
+ *   - isGvfsPath() [indirect]: via isRemoteFile
+ *   - isGvfsProtocolPath() [indirect]: via isMTPFile, isGphotoFile, etc.
+ *   - isMediaSmbMountPath() [indirect]: via isRemoteFile, isSMBFile
+ *   - isRemoteFile()   - all branches
+ *   - isMTPFile()       - scheme + gvfs path
+ *   - isGphotoFile()    - scheme + gvfs path
+ *   - isFTPFile()       - scheme + gvfs path (ftp + sftp)
+ *   - isSFTPFile()      - scheme + gvfs path
+ *   - isSMBFile()       - scheme + gvfs path + media smb
+ *   - isLocalFile()     - local + remote + device mount exclusion
+ *   - isNFSFile()       - scheme + gvfs path
+ *   - isDavFile()       - scheme + gvfs path + ssl=false
+ *   - isDavsFile()      - scheme + gvfs path + ssl=true
+ *   - Invalid URLs      - all functions return false
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <stub.h>
+
+using namespace dfmbase;
+
+// ---------------------------------------------------------------------------
+// Stub DeviceProxyManager to avoid DBus dependency in isLocalFile().
+// ---------------------------------------------------------------------------
+static DeviceProxyManager *stubDevProxyMng = nullptr;
+
+static DeviceProxyManager *stub_instance()
+{
+    if (!stubDevProxyMng)
+        stubDevProxyMng = new DeviceProxyManager(nullptr);   // -fno-access-control
+    return stubDevProxyMng;
+}
+
+static bool stub_isFileOfExternalBlockMounts(const QString &)
+{
+    return false;
+}
+static bool stub_isFileOfProtocolMounts(const QString &)
+{
+    return false;
+}
+
+__attribute__((constructor)) static void register_deviceproxymanager_stub()
+{
+    static Stub st;
+    st.set(ADDR(DeviceProxyManager, instance), stub_instance);
+    st.set(ADDR(DeviceProxyManager, isFileOfExternalBlockMounts), stub_isFileOfExternalBlockMounts);
+    st.set(ADDR(DeviceProxyManager, isFileOfProtocolMounts), stub_isFileOfProtocolMounts);
+}
+
+// =============================================================================
+// Test fixtures
+// =============================================================================
+
+class TestProtocolUtils : public testing::Test
+{
+protected:
+    // Helper: build a gvfs-like path with given UID and protocol prefix.
+    // e.g. gvfsPath(1000, "mtp:host") → "/run/user/1000/gvfs/mtp:host=..."
+    static QString gvfsPath(int uid, const QString &protocol)
+    {
+        return QStringLiteral("/run/user/%1/gvfs/%2").arg(uid).arg(protocol);
+    }
+};
+
+// =============================================================================
+// Invalid URL — all functions must return false
+// =============================================================================
+
+class TestInvalidUrl : public TestProtocolUtils
+{
+};
+
+TEST_F(TestInvalidUrl, RemoteFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestInvalidUrl, MTPFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isMTPFile(url));
+}
+
+TEST_F(TestInvalidUrl, GphotoFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isGphotoFile(url));
+}
+
+TEST_F(TestInvalidUrl, FTPFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isFTPFile(url));
+}
+
+TEST_F(TestInvalidUrl, SFTPFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isSFTPFile(url));
+}
+
+TEST_F(TestInvalidUrl, SMBFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isSMBFile(url));
+}
+
+TEST_F(TestInvalidUrl, NFSFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isNFSFile(url));
+}
+
+TEST_F(TestInvalidUrl, DavFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isDavFile(url));
+}
+
+TEST_F(TestInvalidUrl, DavsFile)
+{
+    QUrl url;
+    EXPECT_FALSE(ProtocolUtils::isDavsFile(url));
+}
+
+// =============================================================================
+// isRemoteFile
+// =============================================================================
+
+class TestIsRemoteFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Smb)
+{
+    QUrl url("smb://192.168.1.1/share");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Ftp)
+{
+    QUrl url("ftp://ftp.example.com/pub");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Sftp)
+{
+    QUrl url("sftp://user@host/path");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Mtp)
+{
+    QUrl url("mtp://host");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Afc)
+{
+    QUrl url("afc://host");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Dav)
+{
+    QUrl url("dav://server/path");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Davs)
+{
+    QUrl url("davs://server/path");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaKnownScheme_Nfs)
+{
+    QUrl url("nfs://server/path");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaGvfsPath_User)
+{
+    QUrl url = QUrl::fromLocalFile("/run/user/1000/gvfs/smb:host=server");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaGvfsPath_Root)
+{
+    QUrl url = QUrl::fromLocalFile("/root/.gvfs/smb:host=server");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaMediaSmbMount)
+{
+    QUrl url = QUrl::fromLocalFile("/media/zhangs/smbmounts/share");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, ViaRunMediaSmbMount)
+{
+    QUrl url = QUrl::fromLocalFile("/run/media/zhangs/smbmounts/share");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, LocalFileIsNotRemote)
+{
+    QUrl url = QUrl::fromLocalFile("/home/zhangs/document.txt");
+    EXPECT_FALSE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, GvfsPathNoDigitUid_ReturnsFalse)
+{
+    // "/run/user/abc/gvfs/..." → not a valid UID (no digits)
+    QUrl url = QUrl::fromLocalFile("/run/user/abc/gvfs/smb:host=server");
+    EXPECT_FALSE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestIsRemoteFile, GvfsPathNoGvfsSuffix_ReturnsFalse)
+{
+    // "/run/user/1000/other/..." → not a gvfs path
+    QUrl url = QUrl::fromLocalFile("/run/user/1000/other/smb:host=server");
+    EXPECT_FALSE(ProtocolUtils::isRemoteFile(url));
+}
+
+// =============================================================================
+// isMTPFile
+// =============================================================================
+
+class TestIsMTPFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsMTPFile, ViaScheme)
+{
+    QUrl url("mtp://host");
+    EXPECT_TRUE(ProtocolUtils::isMTPFile(url));
+}
+
+TEST_F(TestIsMTPFile, ViaGvfsPath)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "mtp:host=usb123"));
+    EXPECT_TRUE(ProtocolUtils::isMTPFile(url));
+}
+
+TEST_F(TestIsMTPFile, ViaRootGvfsPath)
+{
+    QUrl url = QUrl::fromLocalFile("/root/.gvfs/mtp:host=usb123");
+    EXPECT_TRUE(ProtocolUtils::isMTPFile(url));
+}
+
+TEST_F(TestIsMTPFile, NotMTP)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "smb:host=server"));
+    EXPECT_FALSE(ProtocolUtils::isMTPFile(url));
+}
+
+// =============================================================================
+// isGphotoFile
+// =============================================================================
+
+class TestIsGphotoFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsGphotoFile, ViaSchemeGphoto)
+{
+    QUrl url("gphoto://host");
+    EXPECT_TRUE(ProtocolUtils::isGphotoFile(url));
+}
+
+TEST_F(TestIsGphotoFile, ViaSchemeGphoto2)
+{
+    QUrl url("gphoto2://host");
+    EXPECT_TRUE(ProtocolUtils::isGphotoFile(url));
+}
+
+TEST_F(TestIsGphotoFile, ViaGvfsPath)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "gphoto2:host=camera"));
+    EXPECT_TRUE(ProtocolUtils::isGphotoFile(url));
+}
+
+TEST_F(TestIsGphotoFile, NotGphoto)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "mtp:host=device"));
+    EXPECT_FALSE(ProtocolUtils::isGphotoFile(url));
+}
+
+// =============================================================================
+// isFTPFile
+// =============================================================================
+
+class TestIsFTPFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsFTPFile, ViaScheme)
+{
+    QUrl url("ftp://ftp.example.com/pub");
+    EXPECT_TRUE(ProtocolUtils::isFTPFile(url));
+}
+
+TEST_F(TestIsFTPFile, ViaGvfsPathFtp)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "ftp:host=server"));
+    EXPECT_TRUE(ProtocolUtils::isFTPFile(url));
+}
+
+TEST_F(TestIsFTPFile, ViaGvfsPathSftp)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "sftp:host=server"));
+    EXPECT_TRUE(ProtocolUtils::isFTPFile(url));
+}
+
+TEST_F(TestIsFTPFile, NotFtp)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "smb:host=server"));
+    EXPECT_FALSE(ProtocolUtils::isFTPFile(url));
+}
+
+// =============================================================================
+// isSFTPFile
+// =============================================================================
+
+class TestIsSFTPFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsSFTPFile, ViaScheme)
+{
+    QUrl url("sftp://user@host/path");
+    EXPECT_TRUE(ProtocolUtils::isSFTPFile(url));
+}
+
+TEST_F(TestIsSFTPFile, ViaGvfsPath)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "sftp:host=server"));
+    EXPECT_TRUE(ProtocolUtils::isSFTPFile(url));
+}
+
+TEST_F(TestIsSFTPFile, FtpNotSftp)
+{
+    // isSFTPFile should NOT match plain "ftp" gvfs prefix
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "ftp:host=server"));
+    EXPECT_FALSE(ProtocolUtils::isSFTPFile(url));
+}
+
+// =============================================================================
+// isSMBFile
+// =============================================================================
+
+class TestIsSMBFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsSMBFile, ViaScheme)
+{
+    QUrl url("smb://192.168.1.1/share");
+    EXPECT_TRUE(ProtocolUtils::isSMBFile(url));
+}
+
+TEST_F(TestIsSMBFile, ViaGvfsPath)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "smb:host=server,share=data"));
+    EXPECT_TRUE(ProtocolUtils::isSMBFile(url));
+}
+
+TEST_F(TestIsSMBFile, ViaMediaSmbMount)
+{
+    QUrl url = QUrl::fromLocalFile("/media/zhangs/smbmounts/share");
+    EXPECT_TRUE(ProtocolUtils::isSMBFile(url));
+}
+
+TEST_F(TestIsSMBFile, ViaRunMediaSmbMount)
+{
+    QUrl url = QUrl::fromLocalFile("/run/media/zhangs/smbmounts/share");
+    EXPECT_TRUE(ProtocolUtils::isSMBFile(url));
+}
+
+TEST_F(TestIsSMBFile, NotSmb)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "ftp:host=server"));
+    EXPECT_FALSE(ProtocolUtils::isSMBFile(url));
+}
+
+TEST_F(TestIsSMBFile, MediaPathWithoutSmbmounts_NotSmb)
+{
+    // "/media/zhangs/usb" contains "/media/" but no "/smbmounts"
+    QUrl url = QUrl::fromLocalFile("/media/zhangs/usb/data");
+    EXPECT_FALSE(ProtocolUtils::isSMBFile(url));
+}
+
+// =============================================================================
+// isNFSFile
+// =============================================================================
+
+class TestIsNFSFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsNFSFile, ViaScheme)
+{
+    QUrl url("nfs://server/path");
+    EXPECT_TRUE(ProtocolUtils::isNFSFile(url));
+}
+
+TEST_F(TestIsNFSFile, ViaGvfsPath)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "nfs:host=server,path=/export/data"));
+    EXPECT_TRUE(ProtocolUtils::isNFSFile(url));
+}
+
+TEST_F(TestIsNFSFile, NotNfs)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "smb:host=server"));
+    EXPECT_FALSE(ProtocolUtils::isNFSFile(url));
+}
+
+// =============================================================================
+// isDavFile / isDavsFile — SSL flag discrimination
+// =============================================================================
+
+class TestIsDavFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsDavFile, ViaScheme)
+{
+    QUrl url("dav://server/path");
+    EXPECT_TRUE(ProtocolUtils::isDavFile(url));
+}
+
+TEST_F(TestIsDavFile, ViaGvfsPath_WithSslFalse)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "dav:host=server,ssl=false"));
+    EXPECT_TRUE(ProtocolUtils::isDavFile(url));
+}
+
+TEST_F(TestIsDavFile, ViaGvfsPath_WithSslTrue_IsDavNotDavs)
+{
+    // ssl=true → isDavsFile, not isDavFile
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "dav:host=server,ssl=true"));
+    EXPECT_FALSE(ProtocolUtils::isDavFile(url));
+}
+
+TEST_F(TestIsDavFile, NotDav)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "smb:host=server"));
+    EXPECT_FALSE(ProtocolUtils::isDavFile(url));
+}
+
+class TestIsDavsFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsDavsFile, ViaScheme)
+{
+    QUrl url("davs://server/path");
+    EXPECT_TRUE(ProtocolUtils::isDavsFile(url));
+}
+
+TEST_F(TestIsDavsFile, ViaGvfsPath_WithSslTrue)
+{
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "dav:host=server,ssl=true"));
+    EXPECT_TRUE(ProtocolUtils::isDavsFile(url));
+}
+
+TEST_F(TestIsDavsFile, ViaGvfsPath_WithSslFalse_IsDavsNotDav)
+{
+    // ssl=false → isDavFile, not isDavsFile
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "dav:host=server,ssl=false"));
+    EXPECT_FALSE(ProtocolUtils::isDavsFile(url));
+}
+
+// =============================================================================
+// isLocalFile — depends on stubbed DevProxyMng (returns false for mounts)
+// =============================================================================
+
+class TestIsLocalFile : public TestProtocolUtils
+{
+};
+
+TEST_F(TestIsLocalFile, OrdinaryLocalFile)
+{
+    QUrl url = QUrl::fromLocalFile("/home/zhangs/documents/readme.md");
+    EXPECT_TRUE(ProtocolUtils::isLocalFile(url));
+}
+
+TEST_F(TestIsLocalFile, RootPath)
+{
+    QUrl url = QUrl::fromLocalFile("/");
+    EXPECT_TRUE(ProtocolUtils::isLocalFile(url));
+}
+
+TEST_F(TestIsLocalFile, RemoteSchemeIsNotLocal)
+{
+    QUrl url("smb://server/share");
+    EXPECT_FALSE(ProtocolUtils::isLocalFile(url));
+}
+
+TEST_F(TestIsLocalFile, GvfsPathIsNotLocal)
+{
+    // DevProxyMng stub returns false → isRemoteFile takes precedence
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "smb:host=server"));
+    EXPECT_FALSE(ProtocolUtils::isLocalFile(url));
+}
+
+// =============================================================================
+// Edge cases — boundary conditions for gvfsPathStart
+// =============================================================================
+
+class TestGvfsPathEdgeCases : public TestProtocolUtils
+{
+};
+
+TEST_F(TestGvfsPathEdgeCases, MultiDigitUid)
+{
+    // UID like 1000, 10000, etc. should all parse correctly
+    QUrl url = QUrl::fromLocalFile("/run/user/10000/gvfs/smb:host=server");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestGvfsPathEdgeCases, ZeroUid)
+{
+    // UID 0 → root user, but through /run/user path
+    QUrl url = QUrl::fromLocalFile("/run/user/0/gvfs/smb:host=server");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestGvfsPathEdgeCases, RootPrefix_WithoutGvfsSubdir)
+{
+    // "/root/.gvfs" alone without protocol prefix → still a gvfs path
+    QUrl url = QUrl::fromLocalFile("/root/.gvfs/");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestGvfsPathEdgeCases, EmptyScheme_GvfsPath_IsRemote)
+{
+    // Empty scheme but path is a valid gvfs mount path — still detected as remote.
+    // QUrl::isValid() returns true for empty scheme URLs.
+    QUrl url;
+    url.setPath("/run/user/1000/gvfs/smb:host=server");
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestGvfsPathEdgeCases, FileUrl_WithNonLocalPath)
+{
+    // QUrl with file:// scheme but the path contains gvfs
+    QUrl url("file:///run/user/1000/gvfs/smb:host=server");
+    // url.isLocalFile() returns true → toLocalFile() is used
+    EXPECT_TRUE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestGvfsPathEdgeCases, UidOnly_NoGvfsSuffix)
+{
+    // "/run/user/1000/other" → not a gvfs path
+    QUrl url = QUrl::fromLocalFile("/run/user/1000/other/path");
+    EXPECT_FALSE(ProtocolUtils::isRemoteFile(url));
+}
+
+TEST_F(TestGvfsPathEdgeCases, ProtocolPrefixCaseSensitive)
+{
+    // gvfs protocol prefixes are case-sensitive (all lowercase)
+    QUrl url = QUrl::fromLocalFile(gvfsPath(1000, "MTP:host=device"));
+    EXPECT_FALSE(ProtocolUtils::isMTPFile(url));
+}
+
+// =============================================================================
+// Non-file URLs — path() vs toLocalFile() behavior
+// =============================================================================
+
+class TestNonLocalUrl : public TestProtocolUtils
+{
+};
+
+TEST_F(TestNonLocalUrl, SftpUrl_UsesUrlPath)
+{
+    // For non-local URLs, matchPath returns url.path() not url.toLocalFile()
+    // sftp://host/path → url.path() = "/path"
+    QUrl url("sftp://host/gvfs/sftp:host=server");
+    // Not a gvfs-style path (no /run/user/ prefix)
+    EXPECT_TRUE(ProtocolUtils::isSFTPFile(url));   // true via scheme
+}
+
+TEST_F(TestNonLocalUrl, DavUrlWithSslInPath)
+{
+    // dav://host/dav:host=server,ssl=false → url.path() = "/dav:host=server,ssl=false"
+    // Not a gvfs-style path, so only scheme match
+    QUrl url("dav://host/dav:host=server,ssl=false");
+    EXPECT_TRUE(ProtocolUtils::isDavFile(url));   // true via scheme
+}

--- a/autotests/libs/textindex/CMakeLists.txt
+++ b/autotests/libs/textindex/CMakeLists.txt
@@ -18,4 +18,7 @@ dfm_add_test(test-textindex
 
 # textindex source files use relative includes (e.g. "service_textindex_global.h")
 # so the textindex source root must be in the include path.
-target_include_directories(test-textindex PRIVATE ${DFM_SOURCE_DIR}/services/textindex)
+target_include_directories(test-textindex PRIVATE
+    ${DFM_SOURCE_DIR}/services/textindex
+    ${DFM_PROJECT_ROOT}/include
+)

--- a/src/dfm-base/dbusservice/opticalshareproxy.h
+++ b/src/dfm-base/dbusservice/opticalshareproxy.h
@@ -10,8 +10,7 @@
 #include <QObject>
 #include <QScopedPointer>
 #include <QVariantMap>
-
-class QDBusInterface;
+#include <QDBusInterface>
 
 namespace dfmbase {
 

--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -282,7 +282,13 @@ QMap<QString, QVariant> DesktopFileInfo::desktopFileInfo(const QUrl &fileUrl)
 
 QSharedPointer<FileInfo> DesktopFileInfo::convert(QSharedPointer<FileInfo> fileInfo)
 {
+    if (fileInfo.isNull())
+        return fileInfo;
+
     const QUrl &url = fileInfo->urlOf(UrlInfoType::kUrl);
+    if (!url.isValid() || url.scheme().isEmpty())
+        return fileInfo;
+
     // invoking suffix/mimeTypeName might cost huge time
     if (ProtocolUtils::isRemoteFile(url))
         return fileInfo;

--- a/src/dfm-base/utils/protocolutils.cpp
+++ b/src/dfm-base/utils/protocolutils.cpp
@@ -9,10 +9,51 @@ DFMBASE_BEGIN_NAMESPACE
 
 namespace ProtocolUtils {
 
-// Helper function: match with cached compiled regex
-static bool hasMatch(const QString &txt, const QRegularExpression &re)
+static QString matchPath(const QUrl &url)
 {
-    return re.match(txt).hasMatch();
+    return url.isLocalFile() ? url.toLocalFile() : url.path();
+}
+
+static int gvfsPathStart(const QString &path)
+{
+    static const QString kUserPrefix = QStringLiteral("/run/user/");
+    static const QString kUserGvfsPrefix = QStringLiteral("/gvfs/");
+    static const QString kRootGvfsPrefix = QStringLiteral("/root/.gvfs/");
+
+    if (path.startsWith(kRootGvfsPrefix))
+        return kRootGvfsPrefix.size();
+
+    if (!path.startsWith(kUserPrefix))
+        return -1;
+
+    int pos = kUserPrefix.size();
+    const int size = path.size();
+    while (pos < size && path.at(pos).isDigit())
+        ++pos;
+
+    if (pos == kUserPrefix.size() || !path.mid(pos).startsWith(kUserGvfsPrefix))
+        return -1;
+
+    return pos + kUserGvfsPrefix.size();
+}
+
+static bool isGvfsPath(const QString &path)
+{
+    return gvfsPathStart(path) >= 0;
+}
+
+static bool isGvfsProtocolPath(const QString &path, const QString &protocolPrefix)
+{
+    const int start = gvfsPathStart(path);
+    return start >= 0 && path.mid(start).startsWith(protocolPrefix);
+}
+
+static bool isMediaSmbMountPath(const QString &path)
+{
+    if (!path.startsWith(QStringLiteral("/media/")) && !path.startsWith(QStringLiteral("/run/media/")))
+        return false;
+
+    return path.contains(QStringLiteral("/smbmounts"));
 }
 
 bool isRemoteFile(const QUrl &url)
@@ -31,9 +72,8 @@ bool isRemoteFile(const QUrl &url)
     if (kRemoteSchemes.contains(scheme))
         return true;
 
-    // TODO(xust) smbmounts path might be changed in the future.
-    static const QRegularExpression gvfsMatch { R"((^/run/user/\d+/gvfs/|^/root/.gvfs/|^/(?:run/)?media/[\s\S]*/smbmounts))" };
-    return hasMatch(url.toLocalFile(), gvfsMatch);
+    const QString path = matchPath(url);
+    return isGvfsPath(path) || isMediaSmbMountPath(path);
 }
 
 bool isMTPFile(const QUrl &url)
@@ -44,8 +84,7 @@ bool isMTPFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kMtp)
         return true;
 
-    static const QRegularExpression gvfsMatch { R"(^/run/user/\d+/gvfs/mtp:host|^/root/.gvfs/mtp:host)" };
-    return hasMatch(url.toLocalFile(), gvfsMatch);
+    return isGvfsProtocolPath(matchPath(url), QStringLiteral("mtp:host"));
 }
 
 bool isGphotoFile(const QUrl &url)
@@ -57,8 +96,7 @@ bool isGphotoFile(const QUrl &url)
     if (scheme == Global::Scheme::kGPhoto || scheme == Global::Scheme::kGPhoto2)
         return true;
 
-    static const QRegularExpression gvfsMatch { R"(^/run/user/\d+/gvfs/gphoto2:host|^/root/.gvfs/gphoto2:host)" };
-    return hasMatch(url.toLocalFile(), gvfsMatch);
+    return isGvfsProtocolPath(matchPath(url), QStringLiteral("gphoto2:host"));
 }
 
 bool isFTPFile(const QUrl &url)
@@ -68,8 +106,9 @@ bool isFTPFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kFtp)
         return true;
 
-    static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/s?ftp|^/root/.gvfs/s?ftp))" };
-    return hasMatch(url.path(), smbMatch);
+    const QString path = matchPath(url);
+    return isGvfsProtocolPath(path, QStringLiteral("ftp"))
+            || isGvfsProtocolPath(path, QStringLiteral("sftp"));
 }
 
 bool isSFTPFile(const QUrl &url)
@@ -79,8 +118,7 @@ bool isSFTPFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kSFtp)
         return true;
 
-    static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/sftp|^/root/.gvfs/sftp))" };
-    return hasMatch(url.path(), smbMatch);
+    return isGvfsProtocolPath(matchPath(url), QStringLiteral("sftp"));
 }
 
 bool isSMBFile(const QUrl &url)
@@ -90,8 +128,8 @@ bool isSMBFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kSmb)
         return true;
     // TODO(xust) smbmounts path might be changed in the future.
-    static const QRegularExpression smbMatch { R"((^/run/user/\d+/gvfs/smb|^/root/.gvfs/smb|^/(?:run/)?media/[\s\S]*/smbmounts))" };
-    return hasMatch(url.path(), smbMatch);
+    const QString path = matchPath(url);
+    return isGvfsProtocolPath(path, QStringLiteral("smb")) || isMediaSmbMountPath(path);
 }
 
 bool isLocalFile(const QUrl &url)
@@ -118,8 +156,7 @@ bool isNFSFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kNfs)
         return true;
 
-    static const QRegularExpression nfsMatch { R"((^/run/user/\d+/gvfs/nfs|^/root/.gvfs/nfs))" };
-    return hasMatch(url.path(), nfsMatch);
+    return isGvfsProtocolPath(matchPath(url), QStringLiteral("nfs"));
 }
 
 bool isDavFile(const QUrl &url)
@@ -130,8 +167,8 @@ bool isDavFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kDav)
         return true;
 
-    static const QRegularExpression davMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=false|^/root/.gvfs/dav.*ssl=false))" };
-    return hasMatch(url.path(), davMatch);
+    const QString path = matchPath(url);
+    return isGvfsProtocolPath(path, QStringLiteral("dav:")) && path.contains(QStringLiteral("ssl=false"));
 }
 
 bool isDavsFile(const QUrl &url)
@@ -142,8 +179,8 @@ bool isDavsFile(const QUrl &url)
     if (url.scheme() == Global::Scheme::kDavs)
         return true;
 
-    static const QRegularExpression davsMatch { R"((^/run/user/\d+/gvfs/dav.*ssl=true|^/root/.gvfs/dav.*ssl=true))" };
-    return hasMatch(url.path(), davsMatch);
+    const QString path = matchPath(url);
+    return isGvfsProtocolPath(path, QStringLiteral("dav:")) && path.contains(QStringLiteral("ssl=true"));
 }
 
 }   // namespace ProtocolUtils


### PR DESCRIPTION
1. Refactor protocol detection logic in ProtocolUtils:
   - Replace regex matching with more efficient string operations
   - Add helper functions for path pattern matching
   - Support both scheme-based and path-based protocol detection
   - Better handle edge cases for local/remote file determination

2. Add comprehensive unit tests in autotests/libs/dfm-base:
   - Cover all protocol types (MTP, SMB, FTP, SFTP, NFS, DAV/Davs)
   - Test both scheme-based (URLs) and path-based (local paths)
detection
   - Validate edge cases including UID variations and path formats
   - Add stub for DeviceProxyManager to avoid DBus dependencies

3. Fix safety check in desktop file handling:
   - Add null check for fileInfo pointer
   - Add URL validity check before scheme processing

Log: Improved protocol file detection accuracy and performance

Influence:
1. Test with various remote URLs (smb://, ftp://, sftp:// etc)
2. Test with local paths containing /run/user/<uid>/gvfs/ patterns
3. Verify correct detection of media mounts under /media/ and /run/
media/
4. Test boundary conditions with different UID formats
5. Verify local/remote file determination accuracy

refactor: 改进协议文件检测功能并添加测试用例

1. 重构ProtocolUtils中的协议检测逻辑:
   - 使用字符串操作替代正则表达式匹配提高效率
   - 添加路径模式匹配的辅助函数
   - 支持同时处理基于协议和基于路径的检测
   - 更好地处理本地/远程文件判断的边缘情况

2. 在autotests/libs/dfm-base中添加全面的单元测试:
   - 覆盖所有协议类型(MTP, SMB, FTP, SFTP, NFS, DAV/Davs)
   - 测试基于协议(URL)和基于路径(本地路径)的检测
   - 验证包括UID变体和路径格式在内的边缘情况
   - 添加DeviceProxyManager的stub以避免DBus依赖

3. 修复桌面文件处理的安全检查:
   - 添加对fileInfo指针的空检查
   - 在进行协议处理前添加URL有效性检查

Log: 提升协议文件检测的准确性和性能

Influence:
1. 测试各种远程URL(smb://, ftp://, sftp://等)
2. 测试包含/run/user/<uid>/gvfs/模式的本地路径
3. 验证/media/和/run/media/下媒体挂载点的正确检测
4. 测试不同UID格式的边界条件
5. 验证本地/远程文件判断的准确性
