### PR TITLE
fix: align text line height calculation in canvas/organizer

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/canvasitemdelegate.cpp
@@ -659,7 +659,13 @@ void CanvasItemDelegate::updateItemSizeHint() const
 {
     d->textLineHeight = parent()->fontMetrics().height();
     int width = parent()->iconSize().width() * 17 / 10;
-    int height = parent()->iconSize().height() + kIconSpacing + kTextPadding + 2 * d->textLineHeight + kTextPadding;
+    // Use UniversalUtils::getTextLineHeight for text area height to stay consistent
+    // with the layout engine (ElideTextLayout), which also uses it for per-line height.
+    // Without this, fractional scaling (e.g. 125%) causes ceil() in getTextLineHeight
+    // to produce a larger line height than fontMetrics().height(), making the available
+    // text space too small for 2 lines and collapsing multi-line names into 1 line.
+    int textLineHeight = UniversalUtils::getTextLineHeight(QString(), parent()->fontMetrics());
+    int height = parent()->iconSize().height() + kIconSpacing + kTextPadding + 2 * textLineHeight + kTextPadding;
     d->itemSizeHint = QSize(width, height);
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/collectionitemdelegate.cpp
@@ -662,8 +662,14 @@ void CollectionItemDelegate::updateItemSizeHint() const
     d->textLineHeight = parent()->fontMetrics().height();
     // old style
     int width = parent()->iconSize().width() * 17 / 10;
+    // Use UniversalUtils::getTextLineHeight for text area height to stay consistent
+    // with the layout engine (ElideTextLayout), which also uses it for per-line height.
+    // Without this, fractional scaling (e.g. 125%) causes ceil() in getTextLineHeight
+    // to produce a larger line height than fontMetrics().height(), making the available
+    // text space too small for 2 lines and collapsing multi-line names into 1 line.
+    int textLineHeight = UniversalUtils::getTextLineHeight(QString(), parent()->fontMetrics());
     int height = kIconTopSpacing + parent()->iconSize().height()
-            + kIconSpacing + kTextPadding + 2 * d->textLineHeight + kTextPadding;
+            + kIconSpacing + kTextPadding + 2 * textLineHeight + kTextPadding;
 
     // new style
     //    int textFontWidth = parent()->fontMetrics().width("中");


### PR DESCRIPTION
1. Changed text line height calculation to use
UniversalUtils::getTextLineHeight instead of fontMetrics().height()
2. Modified both CanvasItemDelegate and CollectionItemDelegate
implementations
3. Ensures consistency with ElideTextLayout's line height calculations

This change fixes an issue where fractional scaling (e.g. 125%) caused
text space miscalculations:
- The different line height calculations between fontMetrics() and
getTextLineHeight
- Ceil() in getTextLineHeight could produce larger values than
fontMetrics()
- This made the available text space too small for 2 lines
- Resulted in multi-line names incorrectly collapsing into single line

Log: Fixed text layout issues with fractional scaling in desktop icons

Influence:
1. Test desktop icon text display at different fractional scaling (125%,
150%)
2. Verify multi-line names display correctly with various scaling
factors
3. Check text alignment and spacing remains consistent across different
displays/DPIs

fix: 修正画布/桌面图标文本行高计算问题

1. 改用 UniversalUtils::getTextLineHeight 计算文本行高，替代原来的
fontMetrics().height()
2. 同时修改了 CanvasItemDelegate 和 CollectionItemDelegate 的实现
3. 确保与 ElideTextLayout 的行高计算保持一致

此修改解决了以下问题：
- 不同缩放比例(如125%)导致文本空间计算错误
- getTextLineHeight 中的 ceil() 计算结果比 fontMetrics() 返回值大
- 导致文本空间不足只能显示单行文本
- 多行文件名被错误地压缩为单行显示

Log: 修复桌面图标在非整数缩放比例下的文本布局问题

Influence:
1. 在不同缩放比例(125%、150%)下测试桌面图标文本显示
2. 验证多行文件名在不同缩放下的正确显示
3. 检查文本对齐和间距在不同显示设备/DPI下的表现一致性

Fixes: #365219
