### PR TITLE
fix: improve vfs_monitor filesystem event handling

### DIFF
--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -98,12 +98,6 @@ TEST_F(TestVfsMonitorFileSystemWatcher, DirectoryCreatedSignal)
     QDir().mkpath(subDirPath);
 
     int count = waitForSignal(spy);
-    // 已知 bug: 当前内核 vfs_monitor 模块无法检测目录创建
-    // 如果信号未到达，给出明确提示而非崩溃
-    if (count == 0) {
-        GTEST_SKIP() << "Known kernel bug: vfs_monitor does not detect directory creation";
-        return;
-    }
 
     EXPECT_EQ(count, 1);
     QList<QVariant> args = spy.takeFirst();
@@ -159,11 +153,7 @@ TEST_F(TestVfsMonitorFileSystemWatcher, DirectoryDeletedSignal)
 
     QDir().rmdir(subDirPath);
 
-    int count = waitForSignal(deleteSpy);
-    if (count == 0) {
-        GTEST_SKIP() << "Known kernel bug: vfs_monitor may not detect directory deletion";
-        return;
-    }
+    waitForSignal(deleteSpy);
 
     QList<QVariant> args = deleteSpy.takeFirst();
     EXPECT_EQ(args.at(0).toString(), testDir->path());
@@ -224,11 +214,7 @@ TEST_F(TestVfsMonitorFileSystemWatcher, DirectoryRenameMovedSignal)
     QString newDirPath = testDir->path() + "/newdir";
     QDir().rename(oldDirPath, newDirPath);
 
-    int count = waitForSignal(moveSpy);
-    if (count == 0) {
-        GTEST_SKIP() << "Known kernel bug: vfs_monitor may not detect directory rename";
-        return;
-    }
+    waitForSignal(moveSpy);
 
     QList<QVariant> args = moveSpy.takeFirst();
     EXPECT_EQ(args.at(0).toString(), testDir->path());
@@ -356,8 +342,7 @@ TEST_F(TestVfsMonitorFileSystemWatcher, EventsOutsideRootPathsNotEmitted)
     ASSERT_TRUE(spy.isValid());
 
     // 在测试目录之外创建文件（使用 /tmp）
-    QString outsidePath = QDir::tempPath() + "/vfsmonitor_outside_" +
-                          QString::number(QCoreApplication::applicationPid()) + ".txt";
+    QString outsidePath = QDir::tempPath() + "/vfsmonitor_outside_" + QString::number(QCoreApplication::applicationPid()) + ".txt";
     QFile file(outsidePath);
     file.open(QIODevice::WriteOnly);
     file.write("outside");

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -428,32 +428,32 @@ QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(dev_t devic
     // Return the first one that falls under a monitored root path
     // and passes the exclude predicate.
     for (const QString &mp : points) {
-        QString fullPath;
-        if (mp == "/") {
-            fullPath = relPath;
-        } else {
-            fullPath = mp + relPath;
-        }
+        QString fullPath = (mp == "/") ? relPath : (mp + relPath);
 
         if (isLowerFsEvent(deviceId, fullPath))
             continue;
 
-        // Check if under a monitored root path.
-        bool inRoot = false;
-        for (const QString &root : rootPaths) {
-            if (isDescendantOfRoot(fullPath, root)) {
-                inRoot = true;
-                break;
-            }
-        }
-        if (!inRoot)
+        if (std::none_of(rootPaths.cbegin(), rootPaths.cend(),
+                         [&fullPath](const QString &root) { return isDescendantOfRoot(fullPath, root); }))
             continue;
 
-        // Check exclude predicate (symlinks, hidden files, blacklists).
         if (excludePredicate && excludePredicate(fullPath))
             continue;
 
         return fullPath;
+    }
+
+    // In overlay root environments, the root "/" filesystem has no separate mount
+    // entry in mountPoints. When all mount points fail and relPath is already
+    // an absolute path, treat it as the true absolute path and re-check.
+    if (relPath.startsWith('/')) {
+        auto found = std::find_if(rootPaths.cbegin(), rootPaths.cend(),
+                                  [&relPath, this](const QString &root) {
+                                      return isDescendantOfRoot(relPath, root)
+                                              && (!excludePredicate || !excludePredicate(relPath));
+                                  });
+        if (found != rootPaths.cend())
+            return relPath;
     }
 
     return {};


### PR DESCRIPTION
1. Removed workarounds for known kernel bugs in directory monitoring
tests as the underlying issues have been fixed in kernel vfs_monitor
module
2. Simplified path concatenation in tests by removing unnecessary line
breaks
3. Refactored
VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath to:
   - Use ternary operator for cleaner mount point handling
   - Replace manual root path checking with std::none_of algorithm
   - Add special handling for overlay root environments where "/"
filesystem may not have separate mount entry
4. Improved code readability and maintainability with modern C+
+ constructs

Influence:
1. Test directory creation/deletion/rename operations verify the kernel
fixes
2. Verify filesystem events are properly detected in overlay root
environments
3. Ensure excluded paths and blacklists still work as expected
4. Monitor performance changes for path resolution in complex mount
setups

fix: 改进vfs_monitor文件系统事件处理

1. 删除目录监控测试中对已知内核bug的临时解决方案，因为底层问题已在内核
vfs_monitor模块修复
2. 通过移除不必要的换行简化测试中的路径拼接
3. 重构VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath
方法：
   - 使用三元运算符简化挂载点处理
   - 用std::none_of算法替代手动检查根路径
   - 为overlay root环境添加特殊处理，这种情况下"/"文件系统可能没有单独挂
载项
4. 使用现代C++特性提高代码可读性和可维护性

Influence:
1. 测试目录创建/删除/重命名操作，验证内核修复
2. 验证overlay root环境下文件系统事件能正确检测
3. 确保排除路径和黑名单功能仍正常工作
4. 监控复杂挂载设置下路径解析的性能变化

Fixes: #365133
