### PR TITLE
fix: throttle signal emissions in file operations

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -379,6 +379,14 @@ void AbstractWorker::emitStateChangedNotify()
  */
 void AbstractWorker::emitCurrentTaskNotify(const QUrl &from, const QUrl &to)
 {
+    // Throttle: limit signal emission to ~10fps to prevent main-thread event storm
+    // when processing massive file operations (e.g. deleting 1M+ files).
+    if (!d_taskThrottleTimer.isValid())
+        d_taskThrottleTimer.start();
+    if (d_taskThrottleTimer.elapsed() - d_lastTaskEmitElapsed < kMinTaskEmitIntervalMs)
+        return;
+    d_lastTaskEmitElapsed = d_taskThrottleTimer.elapsed();
+
     JobInfoPointer info = createCopyJobInfo(from, to);
 
     emit currentTaskNotify(info);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -210,7 +210,13 @@ public:
     std::atomic_int64_t elapsed { 0 };
     std::atomic_int64_t deleteFirstFileSize { false };
     bool isCutMerge { false };
+
+    // Throttle: limit emitCurrentTaskNotify to ~10fps to prevent signal storm
+    QElapsedTimer d_taskThrottleTimer;
+    qint64 d_lastTaskEmitElapsed { 0 };
+    static constexpr qint64 kMinTaskEmitIntervalMs = 100;
 };
+
 DPFILEOPERATIONS_END_NAMESPACE
 
 #endif   // ABSTRACTWORKER_H


### PR DESCRIPTION
Added signal throttling mechanism to prevent main thread overload during
massive file operations. The changes include:
1. Introduced QElapsedTimer to track signal emission intervals
2. Added minimum interval (100ms/~10fps) between signal emissions
3. Only emit currentTaskNotify when the timer exceeds interval threshold
4. This prevents UI freezing during bulk operations like deleting
millions of files

Log: Reduced UI freeze during massive file operations by throttling
status updates

Influence:
1. Test bulk file operations (copy/move/delete 1M+ files)
2. Verify UI remains responsive during operations
3. Check task progress updates are still accurate but now throttled
4. Ensure no important status updates are missed due to throttling

fix: 文件操作中添加信号发射节流机制

为防止大量文件操作时主线程过载，添加了信号节流机制。主要变更包括：
1. 引入QElapsedTimer来跟踪信号发射间隔
2. 添加信号发射的最小间隔(100ms/约10fps)
3. 仅在计时器超过间隔阈值时发射currentTaskNotify信号
4. 这可以防止在执行批量操作(如删除数百万文件)时UI冻结

Log: 通过限制状态更新频率减少大量文件操作时的UI冻结现象

Influence:
1. 测试批量文件操作(拷贝/移动/删除1M+文件)
2. 验证操作期间UI保持响应
3. 检查任务进度更新仍准确但频率降低
4. 确保没有重要的状态更新因节流机制而被遗漏

Fixes: #365227
