### PR TITLE
fix: pass option parameter to createView in property dialog

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/utils/propertydialogutil.cpp
@@ -241,8 +241,7 @@ void PropertyDialogUtil::closeAllPropertyDialog()
 
 void PropertyDialogUtil::createControlView(const QUrl &url, const QVariantHash &option)
 {
-    Q_UNUSED(option)
-    QMap<int, QWidget *> controlView = createView(url, {});
+    QMap<int, QWidget *> controlView = createView(url, option);
     int count = controlView.keys().count();
     for (int i = 0; i < count; ++i) {
         int index = controlView.keys()[i];


### PR DESCRIPTION
The `createView` function now receives the `option` parameter instead of
an empty QVariantHash, which was previously ignored via `Q_UNUSED`. This
ensures that any customization options passed to `createControlView` are
actually applied when creating the property dialog views.

Log: Fixed property dialog not applying custom options

Influence:
1. Test property dialog creation with custom options (e.g., custom tab
order, hidden fields)
2. Verify that the dialog behavior matches the provided option values
3. Ensure backward compatibility when no options are passed (should
behave as before)

fix: 属性对话框中将选项参数传递给 createView

现在 `createView` 函数接收 `option` 参数，而不是空的 QVariantHash。之前
通过 `Q_UNUSED` 忽略了该参数。这确保传递给 `createControlView` 的任何自
定义选项在创建属性对话框视图时实际生效。

Log: 修复属性对话框未应用自定义选项的问题

Influence:
1. 测试使用自定义选项（如自定义标签顺序、隐藏字段）创建属性对话框
2. 验证对话框行为与提供的选项值一致
3. 确保未传递选项时的向后兼容性（行为应与之前相同）

BUG: https://pms.uniontech.com/bug-view-365581.html

## Summary by Sourcery

Bug Fixes:
- Apply customization options passed to property dialog creation by forwarding the option hash to createView