### PR TITLE
fix: correct file creation time handling in local dir iterator

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+dde-file-manager (6.5.142) unstable; urgency=medium
+
+  * fix: replace system calls with QProcess for filesystem operations
+  * fix: remove unused shell command execution code
+  * refactor: simplify vault encryption interface
+  * fix: eliminate TOCTOU race condition in file mode change
+  * fix: enhance security in disk encryption recovery key handling
+  * refactor: unify optical share service naming
+  * fix: update file mode setting implementation
+  * refactor: improve protocol file detection and testing
+  * fix: align text line height calculation in canvas/organizer
+  * fix: improve vfs_monitor filesystem event handling
+  * fix: throttle signal emissions in file operations
+  * feat: add krita mime type support
+  * refactor: improve task notification throttling
+  * fix: correct file creation time handling in local dir iterator
+  * feat: add thumbnail support for Krita .kra/.krz files
+  * Add libminizip-dev to dependencies in control file
+  * fix: pass option parameter to createView in property dialog
+  * fix: emit dataChanged instead of view->update() for item geometry recalc
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 11 Jun 2026 18:38:18 +0800
+
 dde-file-manager (6.5.141) unstable; urgency=medium
 
   * perf: remove redundant index optimization in UpdateIndexHandler

--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -81,7 +81,6 @@ SortInfoPointer createSortInfo(const QString &parentPath, const QString &fileNam
     uint64_t effectiveSize = stx.stx_size;
     time_t effectiveAtime = stx.stx_atime.tv_sec;
     time_t effectiveMtime = stx.stx_mtime.tv_sec;
-    time_t effectiveCtime = stx.stx_ctime.tv_sec;
     time_t effectiveBtime = (stx.stx_mask & STATX_BTIME) ? stx.stx_btime.tv_sec : 0;
 
     // 符号链接：获取目标文件属性
@@ -95,7 +94,6 @@ SortInfoPointer createSortInfo(const QString &parentPath, const QString &fileNam
                 effectiveSize = targetStx.stx_size;
                 effectiveAtime = targetStx.stx_atime.tv_sec;
                 effectiveMtime = targetStx.stx_mtime.tv_sec;
-                effectiveCtime = targetStx.stx_ctime.tv_sec;
                 if (targetStx.stx_mask & STATX_BTIME)
                     effectiveBtime = targetStx.stx_btime.tv_sec;
             }
@@ -114,8 +112,7 @@ SortInfoPointer createSortInfo(const QString &parentPath, const QString &fileNam
     info->setExecutable((effectiveMode & S_IXUSR) != 0);
     info->setLastReadTime(effectiveAtime);
     info->setLastModifiedTime(effectiveMtime);
-    // 创建时间：优先使用 birth time，否则回退到 ctime
-    info->setCreateTime(effectiveBtime > 0 ? effectiveBtime : effectiveCtime);
+    info->setCreateTime(effectiveBtime);
     info->setInfoCompleted(true);
     return info;
 }


### PR DESCRIPTION
1. Removed fallback to ctime when birth time is not available
2. Now strictly uses birth time (effectiveBtime) for creation time

The previous implementation had a fallback mechanism using ctime when
birth time was not available. This could lead to incorrect file creation
time reporting since ctime represents metadata change time, not actual
file creation time. The change ensures accurate file creation time
reporting by only using birth time when it's available.

Log: Fixed file creation time reporting in file manager to only use
birth time

Influence:
1. Verify file creation time in file properties dialog
2. Test sorting files by creation time
3. Check behavior with files that have/do not have birth timestamps
4. Verify across different filesystems (ext4, NTFS, etc.)

fix: 修正本地目录迭代器中文件创建时间的处理

1. 移除了当birth time不可用时回退到ctime的逻辑
2. 现在严格使用birth time(effectiveBtime)作为创建时间

之前的实现在birth time不可用时会回退使用ctime，这可能导致错误的文件创建
时间报告，因为ctime表示的是元数据变更时间而非实际的文件创建时间。此修改
确保只使用birth time来报告文件创建时间，从而提高准确性。

Log: 修复了文件管理器中文件创建时间报告，现在仅使用birth time

Influence:
1. 在文件属性对话框中验证文件创建时间
2. 测试按创建时间排序文件功能
3. 检查有无birth timestamp文件的处理行为
4. 在不同文件系统(ext4, NTFS等)上验证功能

Fixes: #365719

## Summary by Sourcery

Bug Fixes:
- Correct file creation time reporting by removing the fallback from birth time to ctime in the local directory iterator.