### PR TITLE
fix: emit dataChanged instead of view->update() for item geometry recalc

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -1083,12 +1083,13 @@ void FileViewModel::onHighlightReady(const QString &taskId, const QString &path,
 
 void FileViewModel::onFileUpdated(int show)
 {
-    auto view = qobject_cast<FileView *>(QObject::parent());
-    if (view) {
-        view->update(index(show, 0, rootIndex()));
-    } else {
-        Q_EMIT dataChanged(index(show, 0, rootIndex()), index(show, 0, rootIndex()));
-    }
+    // NOTE: Use dataChanged instead of view->update() here.
+    // - view->update() only schedules a repaint; it does NOT re-query sizeHint(),
+    //   so opt.rect passed to the delegate's paint() stays unchanged.
+    // - dataChanged() causes the view to both repaint AND recalculate item geometry,
+    //   so that sizeHint() is re-evaluated (e.g. when a file tag is added/removed
+    //   and the item height needs to change to accommodate the extra label).
+    Q_EMIT dataChanged(index(show, 0, rootIndex()), index(show, 0, rootIndex()));
 }
 
 void FileViewModel::onInsert(int firstIndex, int count)


### PR DESCRIPTION
Replace `view->update()` with `dataChanged` signal in `onFileUpdated()`
because `view->update()` only triggers a repaint and does not re-
query `sizeHint()`. Consequently, the optional rectangle passed to
the delegate's `paint()` remains unchanged, breaking layout when an
item's height should change (e.g., after adding/removing file tags).
`dataChanged()` forces the view to both repaint and recalculate item
geometry, ensuring `sizeHint()` is re-evaluated.

Influence:
1. Verify that items correctly re-render and adjust dimensions when file
tags are added or removed.
2. Test item selection and hover effects after an update – the visual
state should remain consistent.
3. Verify no performance regression: rapid updates should still be
smooth and not cause excessive repaints.
4. Test in different view modes (icon, list, etc.) to confirm geometry
recalc works correctly.

fix: 将 view->update() 替换为 dataChanged 信号以重新计算项目几何

在 onFileUpdated() 中将 view->update() 替换为 dataChanged 信号，因为
view->update() 仅触发重绘而不重新查询 sizeHint()，导致传递给 delegate
的 paint() 的可选矩形保持不变，当项目高度需要改变时（例如添加/删除文件
标签后）会破坏布局。dataChanged() 会强制视图重绘并重新计算项目几何，确保
sizeHint() 被重新评估。

Influence:
1. 验证添加或移除文件标签后，项目是否正确重新渲染并调整尺寸。
2. 在更新后测试项目选择和悬停效果，视觉状态应保持一致。
3. 验证无性能回归：快速更新时应保持流畅，不导致过度重绘。
4. 在不同视图模式（图标、列表等）下测试，确认几何重计算正常工作。

BUG: https://pms.uniontech.com/bug-view-365525.html
