### PR TITLE
fix: set initial progress value to 0

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -471,9 +471,9 @@ QWidget *TaskWidget::createConflictWidget()
     QColor text_color = labelPalette.text().color();
     labelPalette.setColor(QPalette::Text, text_color);
 
-    lbSrcIcon = new QLabel();
+    lbSrcIcon = new IconUtils::IconLabel();
     lbSrcIcon->setFixedSize(48, 48);
-    lbSrcIcon->setScaledContents(true);
+    lbSrcIcon->setIconSize({ 48, 48 });
 
     lbSrcTitle = new DLabel();
     lbSrcTitle->setElideMode(Qt::ElideMiddle);
@@ -486,9 +486,9 @@ QWidget *TaskWidget::createConflictWidget()
     lbSrcFileSize->setFixedWidth(kFileSizeWidth);
     lbSrcFileSize->setPalette(labelPalette);
 
-    lbDstIcon = new QLabel();
+    lbDstIcon = new IconUtils::IconLabel();
     lbDstIcon->setFixedSize(48, 48);
-    lbDstIcon->setScaledContents(true);
+    lbDstIcon->setIconSize({ 48, 48 });
 
     lbDstTitle = new DLabel();
     lbDstTitle->setElideMode(Qt::ElideMiddle);
@@ -842,7 +842,7 @@ bool TaskWidget::showFileInfo(const FileInfoPointer info, const bool isOrg)
 
     if (!needRetry)
         info->customData(Global::ItemRoles::kItemFileRefreshIcon);
-    auto icon = thumImage.isNull() ? info->fileIcon().pixmap(48, 48) : QPixmap::fromImage(thumImage);
+    QIcon icon = thumImage.isNull() ? info->fileIcon() : QPixmap::fromImage(thumImage);
 
     auto modifyTimeStr = QString(tr("Time modified: %1"))
                                  .arg(info->timeOf(TimeInfoType::kLastModified).value<QDateTime>().isValid()
@@ -863,13 +863,13 @@ bool TaskWidget::showFileInfo(const FileInfoPointer info, const bool isOrg)
         sizeStr = QString(tr("Size: %1")).arg(info->extendAttributes(ExtInfoType::kSizeFormat).toString());
     }
     if (isOrg) {
-        lbSrcIcon->setPixmap(icon);
+        lbSrcIcon->setIcon(icon);
         lbSrcModTime->setText(modifyTimeStr);
         lbSrcTitle->setText(titleStr);
         lbSrcFileSize->setText(sizeStr);
         originInfo = needRetry ? info : nullptr;
     } else {
-        lbDstIcon->setPixmap(icon);
+        lbDstIcon->setIcon(icon);
         lbDstModTime->setText(modifyTimeStr);
         lbDstTitle->setText(titleStr);
         lbDstFileSize->setText(sizeStr);

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -344,7 +344,7 @@ void TaskWidget::onShowTaskProccess(const JobInfoPointer JobInfo)
     qint64 current = JobInfo->value(AbstractJobHandler::NotifyInfoKey::kCurrentProgressKey).value<qint64>();
     qint64 total = JobInfo->value(AbstractJobHandler::NotifyInfoKey::kTotalSizeKey).value<qint64>();
 
-    qint64 value = 1;
+    qint64 value = 0;
 
     if (total > 0 && current > 0) {
         value = static_cast<qint64>((static_cast<qreal>(current) / total) * 100);

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.h
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.h
@@ -8,6 +8,7 @@
 #include <dfm-base/dfm_base_global.h>
 #include <dfm-base/interfaces/abstractjobhandler.h>
 #include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/iconutils.h>
 
 #include <DWaterProgress>
 #include <DIconButton>
@@ -86,8 +87,8 @@ private:
 
     QWidget *baseWid { nullptr };   // 基本信息widget
 
-    QLabel *lbSrcIcon { nullptr };   // 冲突widget上的源文件图标
-    QLabel *lbDstIcon { nullptr };   // 冲突widget上的目标文件图标
+    IconUtils::IconLabel *lbSrcIcon { nullptr };   // 冲突widget上的源文件图标
+    IconUtils::IconLabel *lbDstIcon { nullptr };   // 冲突widget上的目标文件图标
     bool createDestLabels { true };   // 冲突widget上创建目标文件的labels
     DTK_WIDGET_NAMESPACE::DLabel *lbSrcTitle { nullptr };   // 冲突widget上的源文件文件显示名称
     DTK_WIDGET_NAMESPACE::DLabel *lbDstTitle { nullptr };   // 冲突widget上的目标文件显示名称

--- a/src/dfm-base/utils/iconutils.h
+++ b/src/dfm-base/utils/iconutils.h
@@ -7,12 +7,63 @@
 
 #include <dfm-base/dfm_base_global.h>
 
+#include <DIconButton>
+#include <DStyleOption>
+
 #include <QIcon>
 #include <QPixmap>
 
 DFMBASE_BEGIN_NAMESPACE
 
 namespace IconUtils {
+
+/*!
+ * \class IconLabel
+ * \brief 非交互式的图标显示控件，继承自 DIconButton 但屏蔽所有交互效果
+ *
+ * 该控件用于需要显示主题感知图标但不需要交互的场景。
+ * 通过重写事件处理方法为空实现，完全屏蔽鼠标和键盘交互，
+ * 同时保留 DIconButton 的主题切换自动更新图标能力。
+ */
+class IconLabel : public DTK_WIDGET_NAMESPACE::DIconButton
+{
+    Q_OBJECT
+
+public:
+    explicit IconLabel(QWidget *parent = nullptr)
+        : DIconButton(parent)
+    {
+        // 设置为扁平样式，移除按钮装饰
+        setFlat(true);
+        // 禁止键盘焦点
+        setFocusPolicy(Qt::NoFocus);
+        // 使用箭头光标
+        setCursor(Qt::ArrowCursor);
+    }
+
+protected:
+    // 重写 initStyleOption，移除悬停和按下状态标志，阻止样式渲染交互效果
+    void initStyleOption(DTK_WIDGET_NAMESPACE::DStyleOptionButton *option) const override
+    {
+        DIconButton::initStyleOption(option);
+        // 清除悬停和按下状态标志
+        option->state &= ~(QStyle::State_MouseOver | QStyle::State_Sunken);
+    }
+
+    // 屏蔽所有鼠标交互事件
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEnterEvent *) override { }
+#else
+    void enterEvent(QEvent *) override { }
+#endif
+    void leaveEvent(QEvent *) override { }
+    void mousePressEvent(QMouseEvent *) override { }
+    void mouseReleaseEvent(QMouseEvent *) override { }
+    void mouseMoveEvent(QMouseEvent *) override { }
+    void mouseDoubleClickEvent(QMouseEvent *) override { }
+    void keyPressEvent(QKeyEvent *) override { }
+};
+
 struct IconStyle
 {
     int stroke { 2 };

--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
@@ -8,8 +8,11 @@
 
 #include <dfm-base/utils/windowutils.h>
 
+#include <DGuiApplicationHelper>
+
 #include <QAbstractTextDocumentLayout>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace dfmplugin_tag;
 
@@ -117,10 +120,9 @@ void TagEditor::initializeParameters()
     setMargin(0);
     setFixedWidth(140);
     setFocusPolicy(Qt::StrongFocus);
-    setBorderColor(palette().color(QPalette::Base));
-    setBackgroundColor(palette().color(QPalette::Base));
     setWindowFlags(Qt::FramelessWindowHint);
     setAttribute(Qt::WA_DeleteOnClose);
+    updateBackgroundColor();
 }
 
 void TagEditor::initializeLayout()
@@ -139,6 +141,7 @@ void TagEditor::initializeConnect()
 {
     QObject::connect(this, &TagEditor::windowDeactivate, this, &TagEditor::onFocusOut);
     QObject::connect(crumbEdit, &QTextEdit::textChanged, this, &TagEditor::filterInput);
+    QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &TagEditor::updateBackgroundColor);
 
     if (!isShowInTagDir) {
         QObject::connect(crumbEdit, &DCrumbEdit::crumbListChanged, this, [=] {
@@ -200,4 +203,10 @@ void TagEditor::updateCrumbsColor(const QMap<QString, QColor> &tagsColor)
     }
 
     crumbEdit->setProperty("updateCrumbsColor", false);
+}
+
+void TagEditor::updateBackgroundColor()
+{
+    setBorderColor(palette().color(QPalette::Base));
+    setBackgroundColor(palette().color(QPalette::Base));
 }

--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.h
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.h
@@ -50,6 +50,7 @@ private:
 
     void processTags();
     void updateCrumbsColor(const QMap<QString, QColor> &tagsColor);
+    void updateBackgroundColor();
 
     void onPressESC() noexcept;
 


### PR DESCRIPTION
The initial progress value was set to 1, causing the progress bar to
show
a non-zero value before any work begins. Changed it to 0 to accurately
reflect that the task has not started yet.

Influence:
1. Verify that the progress bar starts at 0 when a task begins
2. Test that progress updates correctly as the task proceeds
3. Check edge cases where current or total is zero

fix: 将初始进度值设为0

初始进度值被设置为1，导致任务开始前进度条就显示非零值。将其改为0以准确反
映任务尚未开始的状态。

Influence:
1. 验证任务开始时进度条从0开始
2. 测试任务进行中进度更新是否正确
3. 检查当前值或总值为0时的边界情况

BUG: https://pms.uniontech.com/bug-view-365081.html

## Summary by Sourcery

Bug Fixes:
- Initialize task progress to 0 instead of a non-zero value so the progress bar starts from 0 before any work begins.