### PR TITLE
feat: truncate base name for symlinks to respect NAME_MAX limit on dlnfs

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.cpp
@@ -80,7 +80,7 @@ FileNameComponents parseFileName(FileInfoPointer fileInfo)
         }
     }
 
-    FileNameComponents components(baseName, completeSuffix, fileName);
+    FileNameComponents components(fileInfo->urlOf(UrlInfoType::kUrl), baseName, completeSuffix, fileName);
 
     return components;
 }
@@ -244,12 +244,43 @@ QString generateUniqueSymlinkName(const FileNameComponents &components,
         return QString();
     }
 
+    // Calculate complete suffix length (including the dot separator)
+    // Total length = baseName + symlinkSuffix + completeSuffix <= NAME_MAX
+    const QString &completeSuffix = components.completeSuffix;
+    const int suffixLength = completeSuffix.isEmpty() ? 0 : completeSuffix.toLocal8Bit().size() + 1;   // +1 for '.'
+
+    // Get original baseName length for comparison (to avoid unnecessary truncation)
+    const int originalBaseNameLen = dfmbase::FileUtils::getFileNameLength(components.srcUrl, components.baseName);
+    const bool useCharCount = dfmbase::FileUtils::supportLongName(components.srcUrl);
+
     int number = 0;
     QString candidateName;
 
     do {
         const QString symlinkSuffix = generateSymlinkSuffix(number);
-        candidateName = constructSymlinkFileName(components, symlinkSuffix);
+        const int symlinkSuffixLen = dfmbase::FileUtils::getFileNameLength(components.srcUrl, symlinkSuffix);
+
+        // Calculate remaining space for baseName: NAME_MAX - symlinkSuffix - completeSuffix
+        const int remainingSpace = NAME_MAX - symlinkSuffixLen - suffixLength;
+
+        // Only truncate if necessary and if it would actually reduce the length
+        QString trimmedBaseName = components.baseName;
+        if (remainingSpace < originalBaseNameLen) {
+            if (remainingSpace > 0) {
+                trimmedBaseName = dfmbase::FileUtils::cutFileName(trimmedBaseName, remainingSpace, useCharCount);
+            } else {
+                // No space left for baseName after suffix — cannot generate a valid name
+                fmWarning() << "SymlinkNameGenerator: NAME_MAX too small for symlink naming"
+                            << ", symlinkSuffixLen:" << symlinkSuffixLen
+                            << ", suffixLength:" << suffixLength;
+                return QString();
+            }
+        }
+
+        FileNameComponents trimmedComponents = components;
+        trimmedComponents.baseName = trimmedBaseName;
+
+        candidateName = constructSymlinkFileName(trimmedComponents, symlinkSuffix);
         ++number;
 
         // Safety check to prevent infinite loops
@@ -316,6 +347,7 @@ QString generateNonConflictingSymlinkName(FileInfoPointer fromInfo, FileInfoPoin
         // Special case: displayName != fileName (e.g., desktop files)
         // Use displayName as baseName directly without extension parsing
         FileNameComponents components;
+        components.srcUrl = fromInfo->urlOf(UrlInfoType::kUrl);
         components.baseName = displayName;
         components.completeSuffix = QString();   // No extension for display names
         components.fileName = displayName;
@@ -350,8 +382,7 @@ QMap<QUrl, QUrl> generateFileRenameUrlsByBatchAddText(const QList<QUrl> &originU
         return QMap<QUrl, QUrl> {};
     }
 
-    if (addFlag != AbstractJobHandler::FileNameAddFlag::kPrefix &&
-        addFlag != AbstractJobHandler::FileNameAddFlag::kSuffix) {
+    if (addFlag != AbstractJobHandler::FileNameAddFlag::kPrefix && addFlag != AbstractJobHandler::FileNameAddFlag::kSuffix) {
         fmWarning() << "[BATCH_RENAME] Invalid FileNameAddFlag:" << static_cast<int>(addFlag);
         return QMap<QUrl, QUrl> {};
     }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/filenameutils.h
@@ -20,13 +20,14 @@ DPFILEOPERATIONS_BEGIN_NAMESPACE
  */
 struct FileNameComponents
 {
+    QUrl srcUrl;   // Source file url
     QString baseName;   // Base name without extension
     QString completeSuffix;   // File extension
     QString fileName;   // Complete file name
 
     FileNameComponents() = default;
-    FileNameComponents(const QString &base, const QString &ext, const QString &full)
-        : baseName(base), completeSuffix(ext), fileName(full) { }
+    FileNameComponents(const QUrl &url, const QString &base, const QString &ext, const QString &full)
+        : srcUrl(url), baseName(base), completeSuffix(ext), fileName(full) { }
 };
 
 /*!


### PR DESCRIPTION
When creating a symlink, the total file name (including symlink suffix
and complete suffix) must not exceed NAME_MAX. Previously, the base name
was not truncated, which could cause symlink creation to fail on file
systems with strict length limits (e.g., dlnfs). The fix calculates the
remaining space after accounting for the symlink suffix and complete
suffix, then truncates the base name only if necessary.

Additionally, the symlink's URL is now passed to
`generateUniqueSymlinkName` so that file-system specific length limits
can be queried via `FileUtils::getFileNameLength` and `supportLongName`.

Log: When creating symlinks, the file name is now automatically
truncated to stay within the file system's maximum name length,
preventing creation failures on dlnfs or other restricted file systems.

Influence:
1. Test symlink creation on ext4 (regular) and dlnfs (long-name) file
systems.
2. Verify that symlink names exceeding NAME_MAX are correctly truncated.
3. Test symlinks with long base names, with and without suffixes.
4. Test symlinks created from desktop files (displayName != fileName).
5. Ensure that backward compatibility is maintained: existing calls to
`generateUniqueSymlinkName` with default URL still work.
6. Check that the truncation respects multi-byte characters (UTF-8)
on dlnfs.

feat: 截断符号链接的基本名以遵守 dlnfs 文件系统的 NAME_MAX 限制

创建符号链接时，完整文件名（包括 symlink 后缀和完整后缀）不能超过
NAME_MAX。之前没有对基本名进行截断，可能导致在严格限制长度的文件系统（如
dlnfs）上创建失败。此修复在计算 symlink 后缀和完整后缀所占空间后，仅在必
要时截断基本名。

同时，将符号链接的 URL 传递给 `generateUniqueSymlinkName`，以便通过
`FileUtils::getFileNameLength` 和 `supportLongName` 查询文件系统特定的长
度限制。

Log: 创建符号链接时，文件名会自动截断以符合文件系统的最大长度限制，防止
在 dlnfs 或其他受限文件系统上创建失败。

Influence:
1. 在 ext4（常规）和 dlnfs（长文件名）文件系统上测试符号链接创建。
2. 验证超过 NAME_MAX 的符号链接名是否正确截断。
3. 测试长基本名、带后缀和不带后缀的符号链接。
4. 测试从桌面文件创建的符号链接（displayName != fileName）。
5. 确保向后兼容性：使用默认 URL 的现有调用仍然正常工作。
6. 检查截断是否在 dlnfs 上正确处理多字节字符（UTF-8）。

BUG: https://pms.uniontech.com/bug-view-366233.html

## Summary by Sourcery

Ensure generated symlink names respect file-system name length limits by truncating the base name when necessary while preserving existing behavior for other callers.

New Features:
- Support file-system-specific name length enforcement when generating unique symlink names, including on dlnfs.

Bug Fixes:
- Prevent symlink creation failures on file systems with strict NAME_MAX limits by truncating overly long base names in generated symlink names.

Enhancements:
- Propagate the symlink URL into the symlink-name generator and use file-utility helpers to compute and apply safe truncation of the base name based on suffix lengths and file-system capabilities.