### PR TITLE
fix: optimize icon display handling in property dialogs

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -61,11 +61,11 @@ void ComputerPropertyDialog::iniUI()
     } else {
         logoIcon = QIcon::fromTheme("dfm_deepin_logo");
     }
-    QSize iconSize(kIconWidth, kIconHeight);
-    qreal dpr = devicePixelRatioF(); // 或 qApp->devicePixelRatio()
-    QPixmap pixmap = logoIcon.pixmap(iconSize * dpr);
-    pixmap.setDevicePixelRatio(dpr);
-    computerIcon->setPixmap(pixmap);
+    const QSize iconSize(kIconWidth, kIconHeight);
+    const qreal dpr = devicePixelRatioF();
+    computerIcon->setFixedSize(iconSize);
+    computerIcon->setAlignment(Qt::AlignCenter);
+    computerIcon->setPixmap(logoIcon.pixmap(iconSize, dpr));
 
     basicInfo = new DLabel(tr("Basic Info"), this);
     DFontSizeManager::instance()->bind(basicInfo, DFontSizeManager::T5, QFont::DemiBold);

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
@@ -41,6 +41,7 @@ MultiFilePropertyDialog::~MultiFilePropertyDialog()
 void MultiFilePropertyDialog::initHeadUi()
 {
     iconLabel = new QLabel(this);
+    iconLabel->setFixedSize(128, 128);
     QIcon icon;
     icon.addFile(QString { ":/images/images/multiple_files.png" });
     icon.addFile(QString { ":/images/images/multiple_files@2x.png" });


### PR DESCRIPTION
1. Simplified icon display logic in ComputerPropertyDialog by removing
unnecessary pixmap scaling steps and using direct pixmap setting
2. Added fixed size of 128x128 for icon label in MultiFilePropertyDialog
for consistent sizing
3. Set proper alignment for computer icon in ComputerPropertyDialog
4. Removed redundant device pixel ratio handling code

Log: Improved icon display quality and consistency in property dialogs

Influence:
1. Verify computer property dialog icons display correctly at different
DPIs
2. Check multi-file property dialog icons maintain proper sizing
3. Ensure alignment of icons in computer property dialog is centered
4. Test dialog appearance at different screen scales and resolutions

fix: 优化属性对话框中图标显示处理

1. 简化ComputerPropertyDialog中的图标显示逻辑，移除不必要的pixmap缩放
步骤
2. 为MultiFilePropertyDialog中的图标标签添加固定尺寸128x128保证一致性
3. 为计算机属性对话框中的图标设置正确的对齐方式
4. 移除冗余的设备像素比处理代码

Log: 改进了属性对话框中的图标显示质量和一致性

Influence:
1. 验证计算机属性对话框图标在不同DPI下显示正确
2. 检查多文件属性对话框图标保持适当尺寸
3. 确保计算机属性对话框中的图标居中对齐
4. 在不同屏幕缩放比例和分辨率下测试对话框外观

Fixes: 366279

## Summary by Sourcery

Simplify and standardize icon rendering in property dialogs for better visual consistency across resolutions and DPIs.

Bug Fixes:
- Correct computer property dialog icon handling to avoid unnecessary scaling artifacts at different device pixel ratios.

Enhancements:
- Center-align and size the computer icon label to provide a consistent appearance in the computer property dialog.
- Apply a fixed 128x128 size to the multi-file property dialog icon label to ensure uniform icon presentation.