### PR TITLE
fix: initialize uninitialized bool variables in CommonEntryFileEntity and UpdateResult

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/fileentity/commonentryfileentity.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/fileentity/commonentryfileentity.cpp
@@ -65,7 +65,7 @@ QIcon CommonEntryFileEntity::icon() const
 bool CommonEntryFileEntity::exists() const
 {
     if (reflection() && hasMethod("exists")) {
-        bool isExists;
+        bool isExists = false;
         bool ret { QMetaObject::invokeMethod(reflectionObj, "exists",
                                              Qt::DirectConnection, Q_RETURN_ARG(bool, isExists)) };
         if (ret)
@@ -77,7 +77,7 @@ bool CommonEntryFileEntity::exists() const
 bool CommonEntryFileEntity::showProgress() const
 {
     if (reflection() && hasMethod("showProgress")) {
-        bool show;
+        bool show = false;
         bool ret { QMetaObject::invokeMethod(reflectionObj, "showProgress",
                                              Qt::DirectConnection, Q_RETURN_ARG(bool, show)) };
         if (ret)
@@ -89,7 +89,7 @@ bool CommonEntryFileEntity::showProgress() const
 bool CommonEntryFileEntity::showTotalSize() const
 {
     if (reflection() && hasMethod("showTotalSize")) {
-        bool show;
+        bool show = false;
         bool ret { QMetaObject::invokeMethod(reflectionObj, "showTotalSize",
                                              Qt::DirectConnection, Q_RETURN_ARG(bool, show)) };
         if (ret)
@@ -101,7 +101,7 @@ bool CommonEntryFileEntity::showTotalSize() const
 bool CommonEntryFileEntity::showUsageSize() const
 {
     if (reflection() && hasMethod("showUsageSize")) {
-        bool show;
+        bool show = false;
         bool ret { QMetaObject::invokeMethod(reflectionObj, "showUsageSize",
                                              Qt::DirectConnection, Q_RETURN_ARG(bool, show)) };
         if (ret)

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.h
@@ -59,8 +59,8 @@ public:
     struct UpdateResult
     {
         GroupedModelData newData;   ///< The new model data
-        int pos;   ///< The position of the updated items
-        int count;   ///< The number of items in the update
+        int pos = 0;   ///< The position of the updated items
+        int count = 0;   ///< The number of items in the update
         bool success = false;   ///< Whether the operation succeeded
         bool alwaysUpdate = false;
     };


### PR DESCRIPTION
Initialize bool variables in commonentryfileentity.cpp (isExists, show)
and int fields in
UpdateResult struct (pos, count) to default values (false and 0
respectively). This prevents
undefined behavior when QMetaObject::invokeMethod fails or the struct is
used without explicit
initialization, ensuring the returned values are predictable and safe.

Log: Fix uninitialized variables in file entity existence checks and
workspace grouping

Influence:
1. Verify file existence checks in Computer plugin (e.g., mounted
devices, network locations)
2. Test progress display, total size, and usage size indicators for
listed entries
3. Check workspace grouping updates after file operations (rename,
delete, move) to ensure correct position/count
4. Run unit tests for CommonEntryFileEntity and grouping engine

fix: 初始化 CommonEntryFileEntity 和 UpdateResult 中的未初始化变量

在 commonentryfileentity.cpp 中将 bool 变量（isExists, show）初始化为
false，在 UpdateResult 结构体中将 int 字段（pos, count）初始化为 0。当
QMetaObject::invokeMethod 调用失败或结构体未显式初始化时，此修改可避免未
定义行为，确保返回值可预测且安全。

Log: 修复计算机插件文件存在性检查和工作区分组中的未初始化变量

Influence:
1. 验证计算机插件中文件存在性检查（如挂载设备、网络位置）
2. 测试列出条目的进度显示、总大小和使用大小指示器
3. 检查文件操作（重命名、删除、移动）后工作区分组更新是否正确，确保位置/
计数正确
4. 运行 CommonEntryFileEntity 和分组引擎的单元测试

BUG: https://pms.uniontech.com/bug-view-366407.html

## Summary by Sourcery

Initialize default values for file entity existence/progress flags and grouping update metadata to avoid undefined behavior when reflection calls or struct initialization fail.

Bug Fixes:
- Default CommonEntryFileEntity reflection-derived boolean flags to false when invokeMethod fails.
- Initialize GroupingEngine::UpdateResult position and count fields to 0 to ensure predictable workspace grouping updates.