### PR TITLE
feat: add silent mode for index tasks

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.OcrIndex.xml
+++ b/assets/dbus/org.deepin.Filemanager.OcrIndex.xml
@@ -23,10 +23,14 @@
     <method name="CreateIndexTask">
       <arg type="b" direction="out"/>
       <arg name="paths" type="as" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
     <method name="UpdateIndexTask">
       <arg type="b" direction="out"/>
       <arg name="paths" type="as" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
     <method name="StopCurrentTask">
       <arg type="b" direction="out"/>

--- a/assets/dbus/org.deepin.Filemanager.TextIndex.xml
+++ b/assets/dbus/org.deepin.Filemanager.TextIndex.xml
@@ -23,10 +23,14 @@
     <method name="CreateIndexTask">
       <arg type="b" direction="out"/>
       <arg name="paths" type="as" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
     <method name="UpdateIndexTask">
       <arg type="b" direction="out"/>
       <arg name="paths" type="as" direction="in"/>
+      <arg name="options" type="a{sv}" direction="in"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="QVariantMap"/>
     </method>
     <method name="StopCurrentTask">
       <arg type="b" direction="out"/>

--- a/src/plugins/daemon/core/abstractindexcontroller.cpp
+++ b/src/plugins/daemon/core/abstractindexcontroller.cpp
@@ -142,7 +142,7 @@ void AbstractIndexController::setupStateHandlers()
                 fmWarning() << "[" << m_descriptor.controllerName << "] Failed to check index database existence:"
                             << reply.error().message();
             } else {
-                startIndexTask(!reply.value());
+                startIndexTask(!reply.value(), true);
             }
             watcher->deleteLater();
         });
@@ -200,7 +200,7 @@ void AbstractIndexController::setupDBusConnections()
     fmInfo() << "[" << m_descriptor.controllerName << "] DBus connections established successfully";
 }
 
-void AbstractIndexController::startIndexTask(bool isCreate)
+void AbstractIndexController::startIndexTask(bool isCreate, bool silent)
 {
     if (!interface) {
         fmWarning() << "[" << m_descriptor.controllerName << "] Cannot start index task, DBus interface not available";
@@ -211,9 +211,11 @@ void AbstractIndexController::startIndexTask(bool isCreate)
     const QString method = isCreate ? QStringLiteral("CreateIndexTask") : QStringLiteral("UpdateIndexTask");
 
     fmInfo() << "[" << m_descriptor.controllerName << "] Starting" << (isCreate ? "CREATE" : "UPDATE")
-             << "index task for directory:" << paths;
+             << "index task for directory:" << paths << "silent:" << silent;
 
-    QDBusPendingCall pendingCall = interface->asyncCall(method, QVariant::fromValue(paths));
+    QVariantMap options;
+    options["silent"] = silent;
+    QDBusPendingCall pendingCall = interface->asyncCall(method, QVariant::fromValue(paths), options);
     auto *watcher = new QDBusPendingCallWatcher(pendingCall, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher](QDBusPendingCallWatcher *) {
         QDBusPendingReply<bool> reply = *watcher;

--- a/src/plugins/daemon/core/abstractindexcontroller.h
+++ b/src/plugins/daemon/core/abstractindexcontroller.h
@@ -10,6 +10,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QScopedPointer>
+#include <QVariantMap>
 
 class QDBusAbstractInterface;
 
@@ -45,7 +46,7 @@ private:
 
     void setupStateHandlers();
     void setupDBusConnections();
-    void startIndexTask(bool isCreate);
+    void startIndexTask(bool isCreate, bool silent = false);
     void updateState(State newState);
     void handleConfigChanged(const QString &config, const QString &key);
     void activeBackend(bool isInit = false);

--- a/src/plugins/filemanager/dfmplugin-search/utils/abstractindexclient.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/abstractindexclient.cpp
@@ -137,7 +137,7 @@ void AbstractIndexClient::handleIndexExistsReply(QDBusPendingCallWatcher *watche
     }
 }
 
-void AbstractIndexClient::startTask(TaskType type, const QStringList &paths)
+void AbstractIndexClient::startTask(TaskType type, const QStringList &paths, const QVariantMap &options)
 {
     if (!ensureInterface()) {
         fmCritical() << "[" << m_descriptor.clientName << "] cannot start task: interface unavailable";
@@ -158,8 +158,8 @@ void AbstractIndexClient::startTask(TaskType type, const QStringList &paths)
         return;
     }
 
-    fmDebug() << "[" << m_descriptor.clientName << "] sending" << method << "request for paths:" << paths;
-    auto watcher = new QDBusPendingCallWatcher(interface->asyncCall(method, QVariant::fromValue(paths)), this);
+    fmDebug() << "[" << m_descriptor.clientName << "] sending" << method << "request for paths:" << paths << "options:" << options;
+    auto watcher = new QDBusPendingCallWatcher(interface->asyncCall(method, QVariant::fromValue(paths), options), this);
     connect(watcher, &QDBusPendingCallWatcher::finished,
             this, [this, type, paths](QDBusPendingCallWatcher *watcher) {
                 FinallyUtil finaly([watcher]() {

--- a/src/plugins/filemanager/dfmplugin-search/utils/abstractindexclient.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/abstractindexclient.h
@@ -9,6 +9,7 @@
 
 #include <QObject>
 #include <QDBusPendingCallWatcher>
+#include <QVariantMap>
 #include <memory>
 
 class QDBusAbstractInterface;
@@ -40,7 +41,7 @@ public:
     explicit AbstractIndexClient(IndexClientDescriptor descriptor, QObject *parent = nullptr);
     ~AbstractIndexClient() override;
 
-    void startTask(TaskType type, const QStringList &paths);
+    void startTask(TaskType type, const QStringList &paths, const QVariantMap &options = QVariantMap());
     void checkIndexExists();
     void checkServiceStatus();
     void checkHasRunningRootTask();

--- a/src/services/textindex/ocrindexdbus.cpp
+++ b/src/services/textindex/ocrindexdbus.cpp
@@ -194,14 +194,16 @@ void OcrIndexDBus::SetEnabled(bool enabled)
     d->runtime->fsEventController()->setEnabled(enabled);
 }
 
-bool OcrIndexDBus::CreateIndexTask(const QStringList &paths)
+bool OcrIndexDBus::CreateIndexTask(const QStringList &paths, const QVariantMap &options)
 {
-    return d->runtime->taskManager()->startTask(IndexTask::Type::Create, paths);
+    bool silent = options.value("silent", false).toBool();
+    return d->runtime->taskManager()->startTask(IndexTask::Type::Create, paths, silent);
 }
 
-bool OcrIndexDBus::UpdateIndexTask(const QStringList &paths)
+bool OcrIndexDBus::UpdateIndexTask(const QStringList &paths, const QVariantMap &options)
 {
-    return d->runtime->taskManager()->startTask(IndexTask::Type::Update, paths);
+    bool silent = options.value("silent", false).toBool();
+    return d->runtime->taskManager()->startTask(IndexTask::Type::Update, paths, silent);
 }
 
 bool OcrIndexDBus::StopCurrentTask()

--- a/src/services/textindex/ocrindexdbus.h
+++ b/src/services/textindex/ocrindexdbus.h
@@ -11,6 +11,7 @@
 #include <QDBusContext>
 #include <QStringList>
 #include <QHash>
+#include <QVariantMap>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 class OcrIndexDBusPrivate;
@@ -31,8 +32,8 @@ public Q_SLOTS:
     void Init();
     bool IsEnabled();
     void SetEnabled(bool enabled);
-    bool CreateIndexTask(const QStringList &paths);
-    bool UpdateIndexTask(const QStringList &paths);
+    bool CreateIndexTask(const QStringList &paths, const QVariantMap &options = QVariantMap());
+    bool UpdateIndexTask(const QStringList &paths, const QVariantMap &options = QVariantMap());
     bool StopCurrentTask();
     bool HasRunningTask();
     bool IndexDatabaseExists();

--- a/src/services/textindex/textindexdbus.cpp
+++ b/src/services/textindex/textindexdbus.cpp
@@ -200,14 +200,16 @@ void TextIndexDBus::SetEnabled(bool enabled)
     d->runtime->fsEventController()->setEnabled(enabled);
 }
 
-bool TextIndexDBus::CreateIndexTask(const QStringList &paths)
+bool TextIndexDBus::CreateIndexTask(const QStringList &paths, const QVariantMap &options)
 {
-    return d->runtime->taskManager()->startTask(IndexTask::Type::Create, paths);
+    bool silent = options.value("silent", false).toBool();
+    return d->runtime->taskManager()->startTask(IndexTask::Type::Create, paths, silent);
 }
 
-bool TextIndexDBus::UpdateIndexTask(const QStringList &paths)
+bool TextIndexDBus::UpdateIndexTask(const QStringList &paths, const QVariantMap &options)
 {
-    return d->runtime->taskManager()->startTask(IndexTask::Type::Update, paths);
+    bool silent = options.value("silent", false).toBool();
+    return d->runtime->taskManager()->startTask(IndexTask::Type::Update, paths, silent);
 }
 
 bool TextIndexDBus::StopCurrentTask()

--- a/src/services/textindex/textindexdbus.h
+++ b/src/services/textindex/textindexdbus.h
@@ -11,6 +11,7 @@
 #include <QDBusContext>
 #include <QStringList>
 #include <QHash>
+#include <QVariantMap>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 class TextIndexDBusPrivate;
@@ -31,8 +32,8 @@ public Q_SLOTS:
     void Init();
     bool IsEnabled();
     void SetEnabled(bool enabled);
-    bool CreateIndexTask(const QStringList &paths);
-    bool UpdateIndexTask(const QStringList &paths);
+    bool CreateIndexTask(const QStringList &paths, const QVariantMap &options = QVariantMap());
+    bool UpdateIndexTask(const QStringList &paths, const QVariantMap &options = QVariantMap());
     bool StopCurrentTask();
     bool HasRunningTask();
     bool IndexDatabaseExists();


### PR DESCRIPTION
Added a silent mode option to index creation and update tasks that
allows suppressing certain notifications or logs when running in
background or automated operations. The changes include:
1. Added options parameter to Create/UpdateIndexTask DBus methods with
QVariantMap
2. Enhanced AbstractIndexController to support silent mode
3. Modified AbstractIndexClient to pass through options
4. Updated OcrIndexDBus and TextIndexDBus implementations
5. Added DBus interface annotations for QVariantMap type

Log: Added silent mode option for index tasks to reduce noise during
automated operations

Influence:
1. Test Create/UpdateIndexTask with and without silent mode
2. Verify logs show appropriate verbosity changes
3. Test DBus interface compatibility with old/new clients
4. Verify task execution isn't affected by silent mode
5. Test with complex QVariantMap options

feat: 为索引任务添加静默模式

为索引创建和更新任务添加了静默模式选项，可在后台或自动化操作中抑制某些通
知或日志。具体变更包括:
1. 为Create/UpdateIndexTask DBus方法添加了QVariantMap类型的options参数
2. 增强AbstractIndexController支持静默模式
3. 修改AbstractIndexClient以传递options参数
4. 更新OcrIndexDBus和TextIndexDBus实现
5. 添加DBus接口的QVariantMap类型注解

Log: 为索引任务添加静默模式选项以减少自动化操作时的日志输出

Influence:
1. 测试带和不带静默模式的Create/UpdateIndexTask
2. 验证日志显示适当的详细程度变化
3. 测试新旧客户端的DBus接口兼容性
4. 验证任务执行不受静默模式影响
5. 测试包含复杂QVariantMap选项的情况
