### PR TITLE
fix: adjust filesystem option logic for professional edition

### DIFF
--- a/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
@@ -181,7 +181,7 @@ void BurnOptDialog::initializeUi()
     fsComb->setFont(f14);
 
     static const QString &udItem = BurnOptDialog::tr("%1 (Compatible with Windows CD/DVD mode)").arg(QString("U/D/F").remove("/"));
-    if (fsComb->count() == fsTypes.count() && DSysInfo::deepinType() == DSysInfo::DeepinProfessional)
+    if (fsComb->count() == fsTypes.count() && !DSysInfo::isCommunityEdition())
         fsComb->addItem(udItem);
 
     // 控制间距
@@ -307,7 +307,7 @@ void BurnOptDialog::onIndexChanged(int index)
         checkdiscCheckbox->setEnabled(false);
         checksumCheckbox->setChecked(false);
         checksumCheckbox->setEnabled(false);
-        finalizeDiscCheckbox->setChecked(true);
+        finalizeDiscCheckbox->setChecked(false);
         writespeedComb->setCurrentIndex(0);
         writespeedComb->setEnabled(false);
     } else {


### PR DESCRIPTION
1. Changed the condition for showing UDF option from checking
DeepinProfessional to checking non-community edition
2. This provides more accurate filesystem option availability based on
the actual system type
3. The change ensures professional/enterprise users get the right
filesystem options while maintaining compatibility

Log: Fixed UDF filesystem option only visible in professional/enterprise
editions

Influence:
1. Test burn dialog on professional edition to verify UDF option appears
2. Test burn dialog on community edition to ensure UDF option doesn't
appear
3. Verify all other filesystem options remain available in both editions

fix: 调整专业版文件系统选项逻辑

1. 将显示UDF选项的条件从检查DeepinProfessional改为检查非社区版
2. 根据实际系统类型更准确地提供文件系统选项
3. 确保专业/企业用户获取正确的文件系统选项同时保持兼容性

Log: 修复UDF文件系统选项仅在专业/企业版中显示的问题

Influence:
1. 在专业版中测试刻录对话框，验证UDF选项出现
2. 在社区版中测试刻录对话框，确保UDF选项不出现
3. 验证所有其他文件系统选项在两个版本中均保持可用

Fixes: #365897
