### PR TITLE
refactor: improve initramfs update process reliability

### DIFF
--- a/src/services/diskencrypt/helpers/crypttabhelper.cpp
+++ b/src/services/diskencrypt/helpers/crypttabhelper.cpp
@@ -8,6 +8,7 @@
 #include "inhibithelper.h"
 
 #include <QFile>
+#include <QProcess>
 #include <QRegularExpression>
 #include <QtConcurrent>
 
@@ -238,19 +239,52 @@ void crypttab_helper::saveCryptItems(const QList<CryptItem> &items, bool doUpdat
 
 void crypttab_helper::updateInitramfs()
 {
-    qInfo() << "[crypttab_helper::updateInitramfs] Starting initramfs update process";
-    
-    // QtConcurrent::run([]{
-    auto fd = inhibit_helper::inhibit("Updating initramfs...");
-    qInfo() << "[crypttab_helper::updateInitramfs] System shutdown/sleep inhibited for initramfs update";
-    
-    int ret = std::system("sudo -E /sbin/update-initramfs -u");
-    if (ret != 0) {
-        qCritical() << "[crypttab_helper::updateInitramfs] Failed to update initramfs, error code:" << ret;
+    static constexpr char kSudoCmd[] { "/usr/bin/sudo" };
+    static constexpr char kUpdateInitramfsCmd[] { "/sbin/update-initramfs" };
+
+    qInfo() << "[crypttab_helper::updateInitramfs] Executing update-initramfs via QProcess";
+
+    auto inhibitReply = inhibit_helper::inhibit("Updating initramfs...");
+
+    QDBusUnixFileDescriptor inhibitFd;
+
+    if (inhibitReply.isValid()) {
+        inhibitFd = inhibitReply.value();
+        qInfo() << "[crypttab_helper::updateInitramfs] Inhibit lock acquired, fd:" << inhibitFd.fileDescriptor();
+    } else {
+        qWarning() << "[crypttab_helper::updateInitramfs] Failed to acquire inhibit lock:" << inhibitReply.error().message();
+    }
+
+    QProcess process;
+    process.start(kSudoCmd, QStringList() << "-E" << kUpdateInitramfsCmd << "-u");
+
+    if (!process.waitForStarted()) {
+        qCritical() << "[crypttab_helper::updateInitramfs] Failed to start process:"
+                    << process.errorString() << "Error code:" << process.error();
+        return;
+    }
+
+    if (!process.waitForFinished(300000)) {
+        qCritical() << "[crypttab_helper::updateInitramfs] Process timed out or failed to finish";
+        process.kill();
+        return;
+    }
+
+    int exitCode = process.exitCode();
+    QString stdOut = QString::fromLocal8Bit(process.readAllStandardOutput());
+    QString stdErr = QString::fromLocal8Bit(process.readAllStandardError());
+
+    qInfo() << "[crypttab_helper::updateInitramfs] exit code:" << exitCode;
+    if (!stdOut.isEmpty())
+        qInfo() << "[crypttab_helper::updateInitramfs] stdout:" << stdOut;
+    if (!stdErr.isEmpty())
+        qWarning() << "[crypttab_helper::updateInitramfs] stderr:" << stdErr;
+
+    if (exitCode != 0) {
+        qCritical() << "[crypttab_helper::updateInitramfs] Failed with exit code:" << exitCode;
     } else {
         qInfo() << "[crypttab_helper::updateInitramfs] Initramfs updated successfully";
     }
-    // });
 }
 
 bool crypttab_helper::removeCryptItem(const QString &activeName)


### PR DESCRIPTION
1. Replaced std::system call with QProcess for better error handling
and control
2. Added detailed output logging (stdout/stderr) for debugging
3. Properly handled inhibit lock file descriptor
4. Added process timeout and error checking
5. Used static constants for command paths
6. Improved log messages for better troubleshooting

Log: Improved error reporting for initramfs updates

Influence:
1. Verify initramfs updates work correctly on different systems
2. Test with incorrect sudo permissions to verify error handling
3. Check log output during updates for proper stdout/stderr capture
4. Verify process timeout handling works as expected
5. Test inhibit lock acquisition and proper release

refactor: 改进 initramfs 更新流程的可靠性

1. 使用 QProcess 替代 std::system 调用以获得更好的错误处理和流程控制
2. 添加详细的输出日志(stdout/stderr)用于调试
3. 正确处理抑制锁文件描述符
4. 添加程序超时和错误检查机制
5. 使用静态常量存储命令路径
6. 改进日志信息以便于问题排查

Log: 改进 initramfs 更新功能的错误报告

Influence:
1. 验证在不同系统上 initramfs 更新是否正常工作
2. 使用错误的 sudo 权限测试错误处理功能
3. 检查更新过程中的日志输出是否正确捕获 stdout/stderr
4. 验证程序超时处理是否按预期工作
5. 测试抑制锁获取和释放功能

Fixes: #366619
