### PR TITLE
refactor: replace appAttribute with appUrlAttribute

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/menu/virtualentrymenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/menu/virtualentrymenuscene.cpp
@@ -344,7 +344,7 @@ void VirtualEntryMenuScenePrivate::actCptForget()
 
 void VirtualEntryMenuScenePrivate::gotoDefaultPageOnUnmount()
 {
-    const QUrl &defaultUrl = Application::instance()->appAttribute(Application::kUrlOfNewWindow).toUrl();
+    const QUrl &defaultUrl = Application::instance()->appUrlAttribute(Application::kUrlOfNewWindow);
     const auto &&winIds = FileManagerWindowsManager::instance().windowIdList();
     for (const auto &winId : winIds) {
         const auto &window = FileManagerWindowsManager::instance().findWindowById(winId);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -499,7 +499,7 @@ QString TabBarPrivate::tabDisplayName(const QUrl &url) const
 
 QUrl TabBarPrivate::determineRedirectUrl(const QUrl &currentUrl, const QUrl &targetUrl) const
 {
-    const QUrl &defaultUrl = Application::instance()->appAttribute(Application::kUrlOfNewWindow).toUrl();
+    const QUrl &defaultUrl = Application::instance()->appUrlAttribute(Application::kUrlOfNewWindow);
 
     // BUG: 303643
     QString targetPath = targetUrl.toLocalFile();


### PR DESCRIPTION
1. Changed appAttribute(Application::kUrlOfNewWindow).toUrl() to
appUrlAttribute(Application::kUrlOfNewWindow)
2. Modification made in both VirtualEntryMenuScene and TabBar components
3. Improves code clarity and type safety by using dedicated URL accessor
method
4. Removes unnecessary URL conversion step

Influence:
1. Test default URL behavior when unmounting virtual entries
2. Verify tab switching and URL redirection functionality
3. Ensure the same default URL is properly obtained in all scenarios
4. Check for any potential URL handling issues in edge cases

refactor: 将 appAttribute 替换为 appUrlAttribute

1. 将 appAttribute(Application::kUrlOfNewWindow).toUrl() 改为
appUrlAttribute(Application::kUrlOfNewWindow)
2. 在 VirtualEntryMenuScene 和 TabBar 组件中都进行了修改
3. 通过使用专用的URL访问方法提高了代码清晰度和类型安全性
4. 移除了不必要的URL转换步骤

Influence:
1. 测试卸载虚拟入口时的默认URL行为
2. 验证标签页切换和URL重定向功能
3. 确保在所有场景中都能正确获取相同的默认URL
4. 检查边缘情况下可能存在的URL处理问题
