### PR TITLE
feat: add dynamic highlight positioning adjustment

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+dde-file-manager (6.5.143) unstable; urgency=medium
+
+  * fix: optimize icon display handling in property dialogs
+  * refactor: optimize plugin service initialization and DBus handling
+  * feat: add silent mode for index tasks
+  * fix: adjust filesystem option logic for professional edition
+  * refactor: improve initramfs update process reliability
+  * refactor: replace appAttribute with appUrlAttribute
+  * feat: add dynamic highlight positioning adjustment
+  * fix: initialize uninitialized bool variables in CommonEntryFileEntity and UpdateResult
+  * fix: set initial progress value to 0
+  * fix: update tag editor background on theme change
+  * feat: add theme-aware icon labels in task conflict widget
+  * chore: update translations
+  * feat: truncate base name for symlinks to respect NAME_MAX limit on dlnfs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 17 Jun 2026 17:26:47 +0800
+
 dde-file-manager (6.5.142) unstable; urgency=medium
 
   * fix: replace system calls with QProcess for filesystem operations

--- a/src/dfm-base/utils/highlightprovider.cpp
+++ b/src/dfm-base/utils/highlightprovider.cpp
@@ -49,6 +49,16 @@ void HighlightProvider::setFetchCallback(FetchHighlightCallback cb)
     fetchCallback = std::move(cb);
 }
 
+void HighlightProvider::setPositioningMaxLength(int chars)
+{
+    m_positioningMaxLength.store(chars, std::memory_order_release);
+}
+
+int HighlightProvider::positioningMaxLength() const
+{
+    return m_positioningMaxLength.load(std::memory_order_acquire);
+}
+
 void HighlightProvider::requestHighlight(const QString &taskId, const QString &path,
                                           const QString &keyword, int searchType,
                                           bool highPriority)

--- a/src/dfm-base/utils/highlightprovider.h
+++ b/src/dfm-base/utils/highlightprovider.h
@@ -32,6 +32,12 @@ public:
     // 注入实际的 fetchHighlight 实现（由 search 插件调用）
     void setFetchCallback(FetchHighlightCallback cb);
 
+    // 设置 highlight 的定位窗口大小（字符数），由视图层根据列宽动态设置
+    // 0 表示使用 ContentRetriever 内置默认值
+    // 线程安全：使用 atomic 保证 worker thread 无锁读取
+    void setPositioningMaxLength(int chars);
+    int positioningMaxLength() const;
+
     // 请求单个文件的 highlightContent
     // highPriority: true 表示可见区域请求，插入队列头部优先处理
     void requestHighlight(const QString &taskId, const QString &path,
@@ -61,6 +67,7 @@ private:
     ~HighlightProvider() override;
 
     FetchHighlightCallback fetchCallback;
+    std::atomic<int> m_positioningMaxLength{0};
     QThread *workerThread = nullptr;
     QObject *worker = nullptr;   // 工作线程上的占位 QObject（用于槽函数调度）
 

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -100,7 +100,8 @@ void SearchEventReceiver::handleUrlChanged(quint64 winId, const QUrl &url)
         if (nameColWidth <= 0)
             return;
 
-        int avgCharWidth = qMax(11, QApplication::font().pointSize());
+        int width = QFontMetrics(QApplication::font()).averageCharWidth();
+        int avgCharWidth = qMax(11, width);
         int posLen = qMax(30, nameColWidth / avgCharWidth);
         HighlightProvider::instance()->setPositioningMaxLength(posLen);
     });

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -10,8 +10,17 @@
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/utils/networkutils.h>
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/utils/highlightprovider.h>
+#include <dfm-base/dfm_global_defines.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QFont>
+#include <QFontMetrics>
+#include <QTimer>
 
 DFMBASE_USE_NAMESPACE
+
 namespace dfmplugin_search {
 
 dfmplugin_search::SearchEventReceiver *dfmplugin_search::SearchEventReceiver::instance()
@@ -74,6 +83,27 @@ void SearchEventReceiver::handleFileDelete(const QUrl &url)
 void SearchEventReceiver::handleFileRename(const QUrl &oldUrl, const QUrl &newUrl)
 {
     emit SearchManager::instance()->fileRename(oldUrl, newUrl);
+}
+
+void SearchEventReceiver::handleUrlChanged(quint64 winId, const QUrl &url)
+{
+    if (url.scheme() != SearchHelper::scheme())
+        return;
+
+    // 延迟到下一事件循环：此时视图已创建完成，列宽已调整
+    QTimer::singleShot(0, this, [winId] {
+        int nameColWidth = dpfSlotChannel->push("dfmplugin_workspace",
+                                                "slot_View_GetColumnWidth",
+                                                winId,
+                                                DFMGLOBAL_NAMESPACE::kItemFileDisplayNameRole)
+                                   .value<int>();
+        if (nameColWidth <= 0)
+            return;
+
+        int avgCharWidth = qMax(11, QApplication::font().pointSize());
+        int posLen = qMax(30, nameColWidth / avgCharWidth);
+        HighlightProvider::instance()->setPositioningMaxLength(posLen);
+    });
 }
 
 SearchEventReceiver::SearchEventReceiver(QObject *parent)

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.h
@@ -28,6 +28,7 @@ public slots:
     void handleFileAdd(const QUrl &url);
     void handleFileDelete(const QUrl &url);
     void handleFileRename(const QUrl &oldUrl, const QUrl &newUrl);
+    void handleUrlChanged(quint64 winId, const QUrl &url);
 
 private:
     explicit SearchEventReceiver(QObject *parent = nullptr);

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -68,8 +68,15 @@ void Search::initialize()
             // Reuse the retriever in the worker thread to avoid rebuilding it
             // for every highlight request.
             thread_local DFMSEARCH::ContentRetriever retriever;
+
+            DFMSEARCH::HighlightOptions opts;
+            int posLen = HighlightProvider::instance()->positioningMaxLength();
+            if (posLen > 0)
+                opts.positioningMaxLength = posLen;
+
             return retriever.fetchHighlight(path, keyword,
-                                            static_cast<DFMSEARCH::SearchType>(searchType));
+                                            static_cast<DFMSEARCH::SearchType>(searchType),
+                                            opts);
         });
 
     bindEvents();
@@ -256,6 +263,10 @@ void Search::bindEvents()
                                    SearchEventReceiverIns, &SearchEventReceiver::handleFileDelete);
     dpfSignalDispatcher->subscribe("dfmplugin_fileoperations", "signal_File_Rename",
                                    SearchEventReceiverIns, &SearchEventReceiver::handleFileRename);
+
+    // URL 切换时根据列宽更新 highlight 定位窗口大小
+    dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl,
+                                   SearchEventReceiverIns, &SearchEventReceiver::handleUrlChanged);
 
     // connect self slot events
     static constexpr auto selfSpace { DPF_MACRO_TO_STR(DPSEARCH_NAMESPACE) };

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -563,5 +563,7 @@ int WorkspaceEventReceiver::handleGetColumnWidth(quint64 windowId, DFMBASE_NAMES
         return 0;
 
     int column = view->model()->getColumnByRole(role);
+    if (column < 0)
+        return 0;
     return view->getColumnWidth(column);
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -141,6 +141,8 @@ void WorkspaceEventReceiver::initConnection()
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleRegisterDataCache);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_AboutToChangeViewWidth",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleAboutToChangeViewWidth);
+    dpfSlotChannel->connect(kCurrentEventSpace, "slot_View_GetColumnWidth",
+                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleGetColumnWidth);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Model_RegisterLoadStrategy",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleRegisterLoadStrategy);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_Model_GetCurrentBusy",
@@ -548,4 +550,18 @@ bool WorkspaceEventReceiver::handleGetCurrentModelBusy(quint64 windowId)
     bool isBusy = view->model()->currentState() == ModelState::kBusy;
     fmDebug() << "WorkspaceEventReceiver: Current view busy state:" << isBusy << "for window ID:" << windowId;
     return isBusy;
+}
+
+int WorkspaceEventReceiver::handleGetColumnWidth(quint64 windowId, DFMBASE_NAMESPACE::Global::ItemRoles role)
+{
+    WorkspaceWidget *workspaceWidget = WorkspaceHelper::instance()->findWorkspaceByWindowId(windowId);
+    if (!workspaceWidget)
+        return 0;
+
+    auto *view = dynamic_cast<FileView *>(workspaceWidget->currentView());
+    if (!view || !view->model())
+        return 0;
+
+    int column = view->model()->getColumnByRole(role);
+    return view->getColumnWidth(column);
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -78,6 +78,7 @@ public slots:
     void handleRegisterDataCache(const QString &scheme);
     void handleSetAlwaysOpenInCurrentWindow(const quint64 windowID);
     void handleAboutToChangeViewWidth(const quint64 windowID, int deltaWidth);
+    int handleGetColumnWidth(quint64 windowId, DFMBASE_NAMESPACE::Global::ItemRoles role);
 
     void handleTabCreated(const quint64 windowId, const QString &uniqueId);
     void handleTabRemoved(const quint64 windowId, const QString &removedId, const QString &nextId);

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.h
@@ -59,6 +59,7 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_View_GetFilter)
     DPF_EVENT_REG_SLOT(slot_View_SetAlwaysOpenInCurrentWindow)
     DPF_EVENT_REG_SLOT(slot_View_AboutToChangeViewWidth)
+    DPF_EVENT_REG_SLOT(slot_View_GetColumnWidth)
 
     DPF_EVENT_REG_SLOT(slot_Model_SetCustomFilterData)
     DPF_EVENT_REG_SLOT(slot_Model_SetCustomFilterCallback)


### PR DESCRIPTION
1. Added HighlightProvider API to set and get positioning window size
2. Implemented automatic calculation of positioning window based on filename column width
3. Added workspace slot to query column width for other plugins
4. Integrated dynamic positioning with content retrieval for search highlights

The changes allow the highlight positioning window to adapt dynamically to the filename column width in the view, improving highlight visibility and context. The positioning is calculated using font metrics and column width, ensuring appropriate context around matches is shown. Thread-safe atomic operations are used for cross-thread communication.

Log: Added dynamic text highlight positioning that adjusts to column width

Influence:
1. Test search highlighting with different column widths
2. Verify highlight positioning in narrow and wide views
3. Check performance impact of dynamic positioning calculation
4. Verify thread safety of atomic operations
5. Test mixed cases of default and custom positioning sizes

feat: 添加动态高亮定位调整功能

1. 添加 HighlightProvider API 用于设置和获取定位窗口大小
2. 实现基于文件名列宽自动计算定位窗口
3. 添加工作区插槽供其他插件查询列宽
4. 将动态定位功能集成到搜索高亮内容检索

这些修改使得高亮定位窗口能够根据视图中的文件名列宽动态调整，改善了高亮文
本的可见性和上下文显示。定位计算使用字体度量和列宽，确保在匹配项周围显示
适当的上下文。跨线程通信使用线程安全的原子操作保证数据一致性。

Log: 添加了根据列宽自动调整的文本高亮定位功能

Influence:
1. 测试不同列宽下的搜索高亮效果
2. 验证在窄视图和宽视图中高亮定位
3. 检查动态定位计算的性能影响
4. 验证原子操作的线程安全性
5. 测试默认和自定义定位大小的混合情况

Fixes: #365083