### PR TITLE
feat: add separate ChangePIN action for disk encryption

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -519,7 +519,8 @@ void DiskEncryptMenuScene::doChangePassphrase(const DeviceEncryptParam &param)
         { encrypt_param_keys::kKeyOldPassphrase, toBase64(param.key) },
         { encrypt_param_keys::kKeyValidateWithRecKey, param.validateByRecKey },
         { encrypt_param_keys::kKeyTPMToken, token },
-        { encrypt_param_keys::kKeyDeviceName, param.deviceDisplayName }
+        { encrypt_param_keys::kKeyDeviceName, param.deviceDisplayName },
+        { encrypt_param_keys::kKeySecType, param.secType }
     };
     stream << params;
 

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -33,6 +33,7 @@
 static constexpr char kActionEncrypt[] { "org.deepin.Filemanager.DiskEncrypt.Encrypt" };
 static constexpr char kActionDecrypt[] { "org.deepin.Filemanager.DiskEncrypt.Decrypt" };
 static constexpr char kActionChgPwd[] { "org.deepin.Filemanager.DiskEncrypt.ChangePassphrase" };
+static constexpr char kActionChgPIN[] { "org.deepin.Filemanager.DiskEncrypt.ChangePIN" };
 
 FILE_ENCRYPT_USE_NS
 
@@ -161,15 +162,16 @@ bool DiskEncryptSetup::ChangePassphrase(const QDBusUnixFileDescriptor &credentia
 {
     qInfo() << "[DiskEncryptSetup::ChangePassphrase] Passphrase change request received via fd";
 
-    if (!m_dptr->checkAuth(kActionChgPwd)) {
-        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
-        return false;
-    }
-
     // Parse credentials from fd using common method
     QVariantMap args;
     if (!m_dptr->parseCredentialsFromFd(credentialsFd, &args)) {
         qCritical() << "[DiskEncryptSetup::ChangePassphrase] Failed to parse credentials from fd";
+        return false;
+    }
+
+    auto secType = static_cast<disk_encrypt::SecKeyType>(args.value(disk_encrypt::encrypt_param_keys::kKeySecType).toInt());
+    if (!m_dptr->checkAuth(secType == disk_encrypt::kPin ? kActionChgPIN : kActionChgPwd)) {
+        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
         return false;
     }
 

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -47,6 +47,7 @@ inline constexpr char kKeyOperationResult[] { "operation-result" };
 inline constexpr char kKeyRecoveryKey[] { "recovery-key" };
 inline constexpr char kKeyJobType[] { "job-type" };
 inline constexpr char kKeyValidateWithRecKey[] { "validate-with-reckey" };
+inline constexpr char kKeySecType[] { "sec-type" };
 }   // namespace encrypt_param_keys
 
 inline const QStringList kDisabledEncryptPath {

--- a/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
+++ b/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
@@ -33,6 +33,19 @@
   </action>
   <action id="org.deepin.Filemanager.DiskEncrypt.ChangePassphrase">
     <description>Disk encryption</description>
+    <message>Authentication is required to change the passphrase of the partition</message>
+    <message xml:lang="zh_CN">修改分区口令需要认证</message>
+    <message xml:lang="zh_HK">修改分區口令需要認證</message>
+    <message xml:lang="zh_TW">修改分割區口令需要認證</message>
+    <icon_name>folder</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+  <action id="org.deepin.Filemanager.DiskEncrypt.ChangePIN">
+    <description>Disk encryption</description>
     <message>Authentication is required to change the PIN code of the partition</message>
     <message xml:lang="zh_CN">修改分区PIN码需要认证</message>
     <message xml:lang="zh_HK">修改分區PIN碼需要認證</message>


### PR DESCRIPTION
1. Add new DBus action constant `kActionChgPIN` for PIN change
operations
2. Modify `ChangePassphrase` method to parse security type from
arguments before authentication
3. Use security type (`kPin` vs others) to select appropriate PolKit
action (`ChangePIN` or `ChangePassphrase`)
4. Add `kKeySecType` parameter to pass security type through the
encryption parameter stream
5. Update PolKit policy file to define separate action for PIN changes
with appropriate messages

This change ensures that changing a PIN requires a different privilege
elevation than changing a passphrase, providing finer-grained security
control.

Log: Added distinct authentication action for changing disk encryption
PIN

Influence:
1. Test changing passphrase on a LUKS-encrypted partition
2. Test changing PIN on a TPM-bound encrypted partition
3. Verify that each operation triggers the correct PolKit authentication
prompt
4. Verify that the "ChangePIN" action shows the correct message in the
auth dialog
5. Check that unauthorized users cannot change PIN without proper
authentication
6. Test backward compatibility with existing passphrase change requests

feat: 为磁盘加密操作添加独立的 ChangePIN 认证动作

1. 新增用于更改 PIN 码的 DBus 动作常量 `kActionChgPIN`
2. 修改 `ChangePassphrase` 方法，在解析凭据后检查安全类型
3. 根据安全类型（PIN 或其他）选择不同的 PolKit 动作（`ChangePIN` 或
`ChangePassphrase`）
4. 添加 `kKeySecType` 参数，将安全类型传递至加密参数流
5. 更新 PolKit 策略文件，为 PIN 更改定义独立的动作及提示信息

此项修改使得更改 PIN 码与更改口令需要不同的权限提升，提供更细粒度的安全
控制。

Log: 新增磁盘加密 PIN 更改的独立认证动作

Influence:
1. 测试在 LUKS 加密分区上更改口令
2. 测试在 TPM 绑定加密分区上更改 PIN 码
3. 验证每个操作触发正确的 PolKit 认证弹窗
4. 验证更改 PIN 时弹窗显示正确的提示信息
5. 检查未授权用户无法通过认证更改 PIN
6. 测试现有口令更改请求的向后兼容性

BUG: https://pms.uniontech.com/bug-view-366717.html

## Summary by Sourcery

Introduce distinct authorization handling for changing disk encryption PINs versus passphrases and propagate the security type through the encryption parameter flow.

New Features:
- Add a separate DBus/PolKit action for changing disk encryption PINs.
- Include the security type in disk encryption parameters to distinguish PIN-based operations from passphrase changes.

Enhancements:
- Adjust passphrase change handling to select the appropriate PolKit action based on the provided security type.