### PR TITLE
perf: optimize fstab bind info loading

### DIFF
--- a/src/dfm-base/base/device/deviceutils.cpp
+++ b/src/dfm-base/base/device/deviceutils.cpp
@@ -328,33 +328,29 @@ bool DeviceUtils::parseSmbInfo(const QString &smbPath, QString &host, QString &s
 
 QMap<QString, QString> DeviceUtils::fstabBindInfo()
 {
-    // TODO(perf) this costs times when first painting. most of the time is spent on function 'stat'
-    static QMutex mutex;
-    static QMap<QString, QString> table;
-    struct stat statInfo;
-    int result = stat("/etc/fstab", &statInfo);
+    static QMap<QString, QString> *table = new QMap<QString, QString>;
+    static std::once_flag flag;
 
-    QMutexLocker locker(&mutex);
-    if (0 == result) {
-        static quint32 lastModify = 0;
-        if (lastModify != statInfo.st_mtime) {
-            lastModify = static_cast<quint32>(statInfo.st_mtime);
-            table.clear();
-            struct fstab *fs;
+    std::call_once(flag, []() {
+        qCDebug(logDFMBase) << "fstabBindInfo: initializing...";
 
-            setfsent();
-            while ((fs = getfsent()) != nullptr) {
-                QString mntops(fs->fs_mntops);
-                if (mntops.contains("bind"))
-                    table.insert(fs->fs_spec, fs->fs_file);
+        struct fstab *fs;
+        setfsent();
+        while ((fs = getfsent()) != nullptr) {
+            QString mntops(fs->fs_mntops);
+            // 检查 options 是否包含 "bind"
+            if (mntops.contains("bind")) {
+                QString spec(fs->fs_spec);   // 源路径（如 /home）
+                QString file(fs->fs_file);   // 挂载点（如 /mnt/bind_home）
+                table->insert(spec, file);   // 正向映射：源 → 挂载点
             }
-            endfsent();
         }
-    }
+        endfsent();
+        qCDebug(logDFMBase) << "fstabBindInfo: initialized with" << table->size() << "bind mount entries";
+    });
 
-    return table;
+    return *table;
 }
-
 QString DeviceUtils::nameOfBuiltInDisk(const QVariantMap &datas)
 {
     QVariantMap clearInfo = datas.value(BlockAdditionalProperty::kClearBlockProperty).toMap();


### PR DESCRIPTION
Changed fstabBindInfo() to use std::call_once for thread-safe
initialization instead of manual mutex and stat checking
1. Removed stat-based file modification checking for /etc/fstab
2. Used C++11 std::call_once to ensure single initialization
3. Changed table storage from static QMap to heap-allocated QMap
4. Added debug logging for initialization
5. Simplified the overall logic while maintaining thread safety

Log: Optimized fstab bind mount info loading performance

Influence:
1. Test that bind mount information is correctly parsed from /etc/fstab
2. Verify thread safety during concurrent access
3. Check memory usage to ensure no leaks from heap allocation
4. Validate that returned bind mappings remain correct
5. Test with different fstab configurations including bind mounts
6. Verify initialization occurs exactly once during application lifetime

perf: 优化fstab绑定信息加载性能

将fstabBindInfo()改为使用std::call_once实现线程安全的初始化
1. 移除了基于stat的/etc/fstab修改检查
2. 使用C++11的std::call_once确保单次初始化
3. 将table存储改为堆分配的QMap
4. 添加了初始化调试日志
5. 简化了整体逻辑同时保持线程安全

Log: 优化了fstab绑定挂载信息的加载性能

Influence:
1. 测试是否从/etc/fstab正确解析了绑定挂载信息
2. 验证并发访问时的线程安全性
3. 检查内存使用，确保堆分配没有泄漏
4. 验证返回的绑定映射仍然正确
5. 使用包含绑定挂载的不同fstab配置进行测试
6. 验证在应用生命周期内初始化仅发生一次
