### PR TITLE
fix: prevent recursive vault unlock during URL changes

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
@@ -31,6 +31,8 @@ DPF_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 using namespace dfmplugin_vault;
 
+bool VaultEventReceiver::s_urlChangeInUnlock = false;
+
 VaultEventReceiver::VaultEventReceiver(QObject *parent)
     : QObject(parent)
 {
@@ -205,8 +207,19 @@ bool VaultEventReceiver::changeUrlEventFilter(quint64 windowId, const QUrl &url)
             VaultHelper::instance()->createVaultDialog();
             return true;
         } else if (VaultState::kEncrypted == state) {
+            // Re-entry guard: unlockVaultDialog → unlockVault → waitForFinished spins a
+            // nested Qt event loop. If a kChangeCurrentUrl event is dispatched inside that
+            // loop, we arrive here again. The filesystem check still sees the vault as
+            // encrypted (cryfs hasn't finished mounting), which would trigger another
+            // unlockVaultDialog → infinite recursion. Consume the event and return.
+            if (s_urlChangeInUnlock) {
+                fmDebug() << "Vault: Unlock already in progress, ignoring redundant URL change";
+                return true;
+            }
             fmDebug() << "Vault: Showing vault unlock dialog";
+            s_urlChangeInUnlock = true;
             VaultHelper::instance()->unlockVaultDialog();
+            s_urlChangeInUnlock = false;
             return true;
         } else if (VaultState::kUnlocked == state) {
             fmDebug() << "Vault: Vault is unlocked, allowing URL change";

--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.h
@@ -16,6 +16,14 @@ class VaultEventReceiver : public QObject
     Q_OBJECT
 private:
     VaultEventReceiver(QObject *parent = nullptr);
+    //! Re-entry guard: prevents recursive calls to changeUrlEventFilter during vault unlock.
+    //! When the vault is encrypted and unlockVaultDialog is called, the synchronous unlock flow
+    //! (waitForFinished on cryfs process) spins a nested Qt event loop. If a kChangeCurrentUrl
+    //! event is dispatched inside that loop, changeUrlEventFilter is called again before the
+    //! first invocation finishes. The filesystem check (state(useCache=false)) still sees the
+    //! vault as encrypted because cryfs hasn't completed mounting, causing another unlockVaultDialog
+    //! call and infinite recursion until the stack is exhausted.
+    static bool s_urlChangeInUnlock;
 
 public:
     static VaultEventReceiver *instance();


### PR DESCRIPTION
1. Added static bool s_urlChangeInUnlock to track vault unlock state
2. Implement reentry guard in changeUrlEventFilter to prevent infinite
recursion
3. The fix addresses an issue where unlocking a vault could trigger
recursive URL change events during the unlock process
4. Added detailed comments explaining the race condition and solution

Log: Fixed vault unlock recursion issue that could crash file manager

Influence:
1. Test vault unlock functionality under normal conditions
2. Verify no crashes occur when quickly changing URLs during unlock
3. Check debug logs for proper reentry guard behavior
4. Test vault access after successful unlock

fix: 修复保险库解锁过程中的递归调用问题

1. 添加静态变量s_urlChangeInUnlock跟踪解锁状态
2. 在changeUrlEventFilter中实现重入防护，防止无限递归
3. 该修复解决了在解锁过程中可能触发递归URL变更事件的问题
4. 添加详细注释解释竞态条件和解决方案

Log: 修复了可能导致文件管理器崩溃的保险库解锁递归问题

Influence:
1. 测试正常情况下的保险库解锁功能
2. 验证在快速变更URL时不会导致崩溃
3. 检查调试日志确保重入防护正常工作
4. 测试成功解锁后的保险库访问

Fixes: #366869
