### PR TITLE
feat: add Wayland window activation support

### DIFF
--- a/src/apps/dde-file-manager/commandparser.cpp
+++ b/src/apps/dde-file-manager/commandparser.cpp
@@ -93,6 +93,17 @@ QString CommandParser::value(const QString &name) const
 
 void CommandParser::processCommand()
 {
+    // Apply XDG activation token for Wayland/Treeland before any window operation.
+    // The compositor provides this token via D-Bus StartupId to allow the window
+    // to be properly activated on Wayland where applications cannot raise themselves.
+    if (isSet("activation-token")) {
+        const QString &token = value("activation-token");
+        if (!token.isEmpty()) {
+            qputenv("XDG_ACTIVATION_TOKEN", token.toUtf8());
+            qCInfo(logAppFileManager) << "Set XDG_ACTIVATION_TOKEN for Wayland activation:" << token;
+        }
+    }
+
     if (isSet("d")) {
         qCInfo(logAppFileManager) << "Starting file manager in headless mode";
         dpfSignalDispatcher->publish(GlobalEventType::kHeadlessStarted);
@@ -190,6 +201,9 @@ void CommandParser::initOptions()
     QCommandLineOption sessionOption(QStringList() << "s"
                                                    << "sessionfile",
                                      "support session loader");
+    QCommandLineOption activationTokenOption(QStringList() << "activation-token",
+                                             "XDG activation token for Wayland/Treeland window activation",
+                                             "token");
 
     addOption(newWindowOption);
     addOption(backendOption);
@@ -203,6 +217,7 @@ void CommandParser::initOptions()
     addOption(openWithDialog);
     addOption(openHomeOption);
     addOption(sessionOption);
+    addOption(activationTokenOption);
 }
 
 void CommandParser::addOption(const QCommandLineOption &option)

--- a/src/plugins/daemon/filemanager1/filemanager1dbus.cpp
+++ b/src/plugins/daemon/filemanager1/filemanager1dbus.cpp
@@ -33,15 +33,19 @@ FileManager1DBus::FileManager1DBus(QObject *parent)
  */
 void FileManager1DBus::ShowFolders(const QStringList &URIs, const QString &StartupId)
 {
-    Q_UNUSED(StartupId)
-    fmInfo() << "[FileManager1DBus] ShowFolders request - URIs:" << URIs;
+    fmInfo() << "[FileManager1DBus] ShowFolders request - URIs:" << URIs << "StartupId:" << StartupId;
 
-    if (QProcess::startDetached("file-manager.sh", QStringList() << "--raw" << URIs)) {
+    QStringList args { "--raw" };
+    args << URIs;
+    if (!StartupId.isEmpty())
+        args << "--activation-token" << StartupId;
+
+    if (QProcess::startDetached("file-manager.sh", args)) {
         fmDebug() << "[FileManager1DBus] ShowFolders launched via file-manager.sh";
         return;
     }
 
-    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, QStringList() << "--raw" << URIs)) {
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, args)) {
         fmDebug() << "[FileManager1DBus] ShowFolders launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for ShowFolders request";
@@ -54,17 +58,19 @@ void FileManager1DBus::ShowFolders(const QStringList &URIs, const QString &Start
  */
 void FileManager1DBus::ShowItemProperties(const QStringList &URIs, const QString &StartupId)
 {
-    Q_UNUSED(StartupId)
-    fmInfo() << "[FileManager1DBus] ShowItemProperties request - URIs:" << URIs;
+    fmInfo() << "[FileManager1DBus] ShowItemProperties request - URIs:" << URIs << "StartupId:" << StartupId;
 
-    if (QProcess::startDetached("file-manager.sh", QStringList() << "--raw"
-                                                                 << "-p" << URIs)) {
+    QStringList args { "--raw", "-p" };
+    args << URIs;
+    if (!StartupId.isEmpty())
+        args << "--activation-token" << StartupId;
+
+    if (QProcess::startDetached("file-manager.sh", args)) {
         fmDebug() << "[FileManager1DBus] ShowItemProperties launched via file-manager.sh";
         return;
     }
 
-    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, QStringList() << "--raw"
-                                                                       << "-p" << URIs)) {
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, args)) {
         fmDebug() << "[FileManager1DBus] ShowItemProperties launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for ShowItemProperties request";
@@ -80,15 +86,19 @@ void FileManager1DBus::ShowItemProperties(const QStringList &URIs, const QString
  */
 void FileManager1DBus::ShowItems(const QStringList &URIs, const QString &StartupId)
 {
-    Q_UNUSED(StartupId)
-    fmInfo() << "[FileManager1DBus] ShowItems request - URIs:" << URIs;
+    fmInfo() << "[FileManager1DBus] ShowItems request - URIs:" << URIs << "StartupId:" << StartupId;
 
-    if (QProcess::startDetached("file-manager.sh", QStringList() << "--show-item" << URIs << "--raw")) {
+    QStringList args { "--show-item" };
+    args << URIs << "--raw";
+    if (!StartupId.isEmpty())
+        args << "--activation-token" << StartupId;
+
+    if (QProcess::startDetached("file-manager.sh", args)) {
         fmDebug() << "[FileManager1DBus] ShowItems launched via file-manager.sh";
         return;
     }
 
-    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, QStringList() << "--show-item" << URIs << "--raw")) {
+    if (QProcess::startDetached(DFM_FILE_MANAGER_BINARY, args)) {
         fmDebug() << "[FileManager1DBus] ShowItems launched via dde-file-manager binary";
     } else {
         fmWarning() << "[FileManager1DBus] Failed to launch file manager for ShowItems request";


### PR DESCRIPTION
1. Added XDG activation token handling for proper window activation on
Wayland/Treeland
2. Implemented --activation-token command line option
3. Modified D-Bus methods (ShowFolders/ShowItems/ShowItemProperties) to
pass StartupId as activation token
4. Added environment variable XDG_ACTIVATION_TOKEN when activation token
is provided
5. Enhanced logging for activation token handling

Log: Added support for proper window activation on Wayland/Treeland
using XDG activation tokens

Influence:
1. Test file manager launch with --activation-token parameter on Wayland
2. Verify window activation when launched from other applications
3. Check D-Bus method calls with StartupId parameter
4. Test with both file-manager.sh and direct binary launch
5. Verify logging contains activation token information when provided

feat: 添加 Wayland 窗口激活支持

1. 添加 XDG 激活令牌处理用于在 Wayland/Treeland 上正确激活窗口
2. 实现--activation-token命令行选项
3. 修改D-Bus方法(ShowFolders/ShowItems/ShowItemProperties)传递StartupId
作为激活令牌
4. 当提供激活令牌时设置XDG_ACTIVATION_TOKEN环境变量
5. 增强激活令牌处理的日志记录

Log: 新增支持使用XDG激活令牌在Wayland/Treeland上正确激活窗口

Influence:
1. 在Wayland环境下使用--activation-token参数测试文件管理器启动
2. 验证从其他应用程序启动时的窗口激活效果
3. 测试带有StartupId参数的D-Bus方法调用
4. 分别测试通过file-manager.sh和直接二进制文件启动
5. 验证日志是否包含提供的激活令牌信息
