### PR TITLE
fix: remove redundant stdinNotifier cleanup in WorkerPipe

### DIFF
--- a/src/apps/dde-file-manager-extractor/libextractor/workerpipe.cpp
+++ b/src/apps/dde-file-manager-extractor/libextractor/workerpipe.cpp
@@ -37,10 +37,6 @@ WorkerPipe::WorkerPipe(QObject *parent)
 
 WorkerPipe::~WorkerPipe()
 {
-    if (d->stdinNotifier) {
-        delete d->stdinNotifier;
-    }
-
     if (d->outputFd >= 0) {
         ::close(d->outputFd);
     }


### PR DESCRIPTION
Remove deletion of stdinNotifier in WorkerPipe destructor since it
is managed by QObject parent-child mechanism. The notifier will be
automatically deleted when its parent is destroyed.

This change prevents potential double deletion issues since QObject
already handles the cleanup of child objects. The outputFd cleanup
remains since it's not a QObject and needs manual resource management.

Influence:
1. Test file extraction functionality to ensure no regression
2. Verify process cleanup and resource release when closing file manager
3. Check memory usage during multiple file operations for leaks

fix: 在WorkerPipe中移除冗余的stdinNotifier清理

移除WorkerPipe析构函数中对stdinNotifier的手动删除操作，因为它已由QObject
的父子对象机制管理。当父对象销毁时会自动删除子对象。

此修改防止了潜在的双重删除问题，因为QObject已经处理了子对象的清理工作。
outputFd的清理保留不变，因为它不是QObject并需要手动资源管理。

Influence:
1. 测试文件提取功能以确保没有回归问题
2. 验证关闭文件管理器时的进程清理和资源释放
3. 在多次文件操作期间检查内存使用情况是否存在泄漏

## Summary by Sourcery

Bug Fixes:
- Prevent potential double deletion of stdinNotifier by relying on QObject’s automatic child cleanup in WorkerPipe’s destructor.