### PR TITLE
fix: remove thread termination to prevent SIGABRT crashes

### DIFF
--- a/src/services/textindex/task/taskmanager.cpp
+++ b/src/services/textindex/task/taskmanager.cpp
@@ -62,10 +62,17 @@ TaskManager::~TaskManager()
     if (workerThread.isRunning()) {
         fmInfo() << "[TaskManager] Stopping worker thread";
         workerThread.quit();
-        if (!workerThread.wait(5000)) {   // 等待5秒
-            fmWarning() << "[TaskManager] Worker thread did not stop within timeout, forcing termination";
-            workerThread.terminate();
-            workerThread.wait(1000);
+        // worker 为事件循环模型(QThread::exec)，quit() 属协作式退出：当前正在处理的槽
+        // (IndexWriter::commit/optimize 或文件内容提取)执行完后事件循环才会返回。Lucene++ 的长
+        // 操作没有中途取消接口，进入后只能等待其执行完成。
+        // 严禁使用 terminate() —— 其底层是 pthread_cancel，会向 worker 线程注入 forced-unwind
+        // 异常；若 worker 此刻正处在带 catch(...) 的调用链中(如 taskhandler 的索引处理、docparser
+        // 的内容提取)，异常会被 catch(...) 截留且未 rethrow，从而触发 "FATAL: exception not
+        // rethrown"，导致整个进程被 SIGABRT 中止(参见历史 dde-file-manager coredump)。
+        // 此处给足等待时间，超时则交由进程退出兜底(进程 _exit 时线程由内核直接终止，不走 unwind)。
+        if (!workerThread.wait(5000)) {
+            fmWarning() << "[TaskManager] Worker thread still running after 5s, "
+                           "will be cleaned up on process exit (terminate() removed to avoid SIGABRT)";
         }
     }
     fmInfo() << "[TaskManager] TaskManager destroyed successfully";


### PR DESCRIPTION
The destructor previously used QThread::terminate() to forcibly
stop the worker thread after a 5-second timeout, which could lead to
process crashes. The worker thread is event-loop based (QThread::exec)
and relies on cooperative shutdown (QThread::quit). Since Lucene++
operations don't support cancellation mid-execution, we must wait for
them to complete naturally.

Terminate() was dangerous because:
1. It uses pthread_cancel internally, injecting forced-unwind exceptions
2. If caught by catch(...) in worker tasks (like index processing or
content extraction)
3. Would trigger "FATAL: exception not rethrown" SIGABRT crashes (seen
in historical coredumps)

Solution:
1. Removed terminate() completely to avoid crashes
2. Extended wait time and rely on process exit for cleanup
3. Updated warning message to be more descriptive

Influence:
1. Test application shutdown during heavy indexing operations
2. Verify no SIGABRT crashes occur during forced shutdown
3. Monitor thread cleanup behavior in logs during process exit
4. Check if long-running operations complete gracefully

fix: 移除线程终止逻辑以防止SIGABRT崩溃

之前析构函数在5秒超时后使用QThread::terminate()强制停止工作线程，可
能导致进程崩溃。工作线程基于事件循环(QThread::exec)并依赖协作式关闭
(QThread::quit)。由于Lucene++操作不支持执行中途取消，我们必须等待它们自
然完成。

terminate()的危险性：
1. 内部使用pthread_cancel触发强制解栈异常
2. 如果被任务中的catch(...)捕获(如索引处理或内容提取)
3. 会触发"FATAL: exception not rethrown"导致SIGABRT崩溃(历史coredump
可见)

更改方案：
1. 完全移除terminate()调用以避免崩溃
2. 延长等待时间并依赖进程退出进行清理
3. 更新警告信息使其更具描述性

影响范围：
1. 测试在繁重索引操作期间的应用程序关闭
2. 验证强制关闭时不会发生SIGABRT崩溃
3. 在进程退出时监控日志中的线程清理行为
4. 检查长时间运行的操作是否能优雅完成
