### PR TITLE
fix: handle vault tag hooks and extension widget sync

### DIFF
--- a/src/plugins/common/dfmplugin-tag/tag.cpp
+++ b/src/plugins/common/dfmplugin-tag/tag.cpp
@@ -127,14 +127,17 @@ void Tag::onAllPluginsStarted()
 QWidget *Tag::createTagWidgetForPropertyDialog(const QUrl &url)
 {
     fmDebug() << "Creating tag widget for property dialog, URL:" << url.toString();
-    QUrl realUrl;
-    UniversalUtils::urlTransformToLocal(url, &realUrl);
 
-    if (!TagManager::instance()->canTagFile(realUrl)) {
+    // Pass the ORIGINAL url so scheme-based hooks (e.g. vault's hook_CanTaged
+    // on "dfmvault://") can take effect. Pre-transforming to a local file://
+    // url would strip the scheme and bypass those business-rule hooks.
+    if (!TagManager::instance()->canTagFile(url)) {
         fmDebug() << "Cannot tag file:" << url.toString();
         return nullptr;
     }
 
+    QUrl realUrl;
+    UniversalUtils::urlTransformToLocal(url, &realUrl);
     auto tagWidget = new TagWidget(realUrl);
     tagWidget->initialize();
     return tagWidget;
@@ -165,9 +168,10 @@ void Tag::updateTagWidgetForDetailView(QWidget *widget, const QUrl &url)
 
 bool Tag::shouldShowTagWidget(const QUrl &url)
 {
-    QUrl realUrl;
-    UniversalUtils::urlTransformToLocal(url, &realUrl);
-    return TagManager::instance()->canTagFile(realUrl);
+    // Pass the ORIGINAL url so scheme-based hooks (e.g. vault's hook_CanTaged
+    // on "dfmvault://") can take effect. canTagFile() handles the local
+    // transformation internally; pre-transforming here bypasses those hooks.
+    return TagManager::instance()->canTagFile(url);
 }
 
 void Tag::installToSideBar()

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
@@ -166,21 +166,40 @@ void DetailView::initSpinnerOverlay()
 
 void DetailView::createExtensionWidgets()
 {
-    // Get all registered extensions and create widgets once
-    const auto extensions = DetailManager::instance().extensionInfos();
+    // Initial creation delegates to sync; on first call m_extensionWidgets is
+    // empty so all currently-registered extensions get created.
+    syncExtensionWidgets();
+}
 
-    for (const auto &extInfo : extensions) {
-        // Create widget using create function (pass empty URL, will be updated later)
-        QWidget *widget = extInfo.create(QUrl());
-        if (!widget)
+void DetailView::syncExtensionWidgets()
+{
+    // Extensions are appended in registration order and never removed, so any
+    // with index >= m_extensionWidgets.size() are new (registered after this
+    // view was constructed — e.g. tag plugin when detailspace was default-opened
+    // at startup before plugins finished starting).
+    const auto extensions = DetailManager::instance().extensionInfos();
+    while (m_extensionWidgets.size() < extensions.size()) {
+        int idx = m_extensionWidgets.size();
+        const auto &extInfo = extensions.at(idx);
+
+        QWidget *widget = extInfo.create(m_currentUrl);
+        if (!widget) {
+            // Track the slot so size accounting progresses and we don't loop
+            // forever, even though no widget could be created.
+            ExtensionWidgetHolder holder;
+            holder.widget = nullptr;
+            holder.frame = nullptr;
+            holder.update = extInfo.update;
+            holder.shouldShow = extInfo.shouldShow;
+            m_extensionWidgets.append(holder);
             continue;
+        }
 
         widget->setParent(this);
         widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         if (auto layout = widget->layout())
             layout->setContentsMargins(0, 0, 0, 0);
 
-        // Wrap with separator frame
         QFrame *frame = new QFrame(this);
         auto *separator = new DHorizontalLine(frame);
         separator->setFixedHeight(1);
@@ -190,10 +209,8 @@ void DetailView::createExtensionWidgets()
         frameLayout->addWidget(widget);
         frame->setLayout(frameLayout);
 
-        // Add to layout (after core widgets, before stretch)
         vLayout->insertWidget(vLayout->count() - 1, frame, 0, Qt::AlignTop);
 
-        // Store holder for later updates
         ExtensionWidgetHolder holder;
         holder.widget = widget;
         holder.frame = frame;
@@ -201,7 +218,7 @@ void DetailView::createExtensionWidgets()
         holder.shouldShow = extInfo.shouldShow;
         m_extensionWidgets.append(holder);
 
-        // Initially hidden until setUrl is called
+        // Initially hidden until setUrl / updateExtensionWidgets decides visibility
         frame->setVisible(false);
     }
 }
@@ -231,8 +248,13 @@ void DetailView::updateBasicWidget(const QUrl &url)
 
 void DetailView::updateExtensionWidgets(const QUrl &url)
 {
-    // Update all extension widgets - no deletion/recreation!
+    // Pick up any extensions registered after this view was constructed
+    // (e.g. tag plugin registering after detailspace was default-opened at startup)
+    syncExtensionWidgets();
+
     for (auto &holder : m_extensionWidgets) {
+        if (!holder.widget || !holder.frame)
+            continue;
         // Check if widget should be visible for this URL
         bool visible = holder.shouldShow(url);
         holder.frame->setVisible(visible);

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.h
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.h
@@ -48,6 +48,7 @@ private:
     void initInfoUI();
     void initSpinnerOverlay();
     void createExtensionWidgets();
+    void syncExtensionWidgets();
     void updateHeadUI(const QUrl &url);
     void updateBasicWidget(const QUrl &url);
     void updateExtensionWidgets(const QUrl &url);

--- a/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/events/vaulteventreceiver.cpp
@@ -74,7 +74,18 @@ void VaultEventReceiver::connectEvent()
     dpfHookSequence->follow("dfmplugin_fileoperations", "hook_Operation_RenameFilesAddText", VaultFileHelper::instance(), &VaultFileHelper::renameFilesAddText);
     dpfHookSequence->follow("dfmplugin_fileoperations", "hook_Operation_SetPermission", VaultFileHelper::instance(), &VaultFileHelper::setPermision);
     dpfHookSequence->follow("dfmplugin_propertydialog", "hook_PermissionView_Ash", this, &VaultEventReceiver::handlePermissionViewAsh);
-    dpfHookSequence->follow("dfmplugin_tag", "hook_CanTaged", this, &VaultEventReceiver::handleFileCanTaged);
+
+    auto tagPlugin { DPF_NAMESPACE::LifeCycle::pluginMetaObj("dfmplugin-tag") };
+    if (tagPlugin && tagPlugin->pluginState() == DPF_NAMESPACE::PluginMetaObject::kStarted) {
+        dpfHookSequence->follow("dfmplugin_tag", "hook_CanTaged", this, &VaultEventReceiver::handleFileCanTaged);
+    } else {
+        connect(
+                DPF_NAMESPACE::Listener::instance(), &DPF_NAMESPACE::Listener::pluginStarted, this, [](const QString &iid, const QString &name) {
+                    Q_UNUSED(iid)
+                    if (name == "dfmplugin-tag")
+                        dpfHookSequence->follow("dfmplugin_tag", "hook_CanTaged", VaultEventReceiver::instance(), &VaultEventReceiver::handleFileCanTaged);
+                });
+    }
 
     fmDebug() << "Vault: All vault event receiver connections established";
 }
@@ -300,7 +311,6 @@ bool VaultEventReceiver::handleFileCanTaged(const QUrl &url, bool *canTag)
 {
     if (url.scheme() == VaultHelper::instance()->scheme()) {
         *canTag = false;
-        fmDebug() << "Vault: Vault files cannot be tagged";
         return true;
     }
 


### PR DESCRIPTION
1. Modified tag plugin to pass original URLs instead of transformed URLs
to preserve scheme-based hooks for vault files
2. Improved detail view extension widget synchronization to handle
delayed plugin initialization
3. Added proper hook registration for vault's tag handling based on
plugin startup state

The changes ensure that:
1. Vault file tagging properly respects security hooks by maintaining
original URL schemes
2. Extension widgets in detail view remain functional even when plugins
register after the view is created
3. Vault tagging hooks are properly registered whether tag plugin loads
before or after vault plugin

Log: Fixed issues with vault file tagging and extension widget
synchronization

Influence:
1. Test tagging functionality with vault files (dfmvault:// scheme)
2. Verify tag widgets appear/disappear correctly in property dialogs
3. Check detail view extension widgets with delayed plugin loading
4. Test with various file schemes including local, vault, and network
paths

fix: 处理保险库标签钩子和扩展部件同步问题

1. 修改标签插件以传递原始URL而非转换后的URL，保留针对保险库文件的基于协
议的钩子
2. 改进详情视图扩展部件同步机制，处理插件延迟初始化情况
3. 根据插件启动状态添加保险库标签处理的正确钩子注册

这些更改确保:
1. 保险库文件标记正确遵守安全钩子，保持原始URL协议
2. 即使插件在视图创建后注册，详情视图中的扩展部件仍能正常工作
3. 无论标签插件在保险库插件之前或之后加载，都能正确注册保险库标记钩子

Log: 修复保险库文件标记和扩展部件同步问题
Bug: https://pms.uniontech.com/bug-view-367229.html

## Summary by Sourcery

Ensure vault-tag integration respects scheme-based tagging hooks and that detail view extension widgets stay in sync with late-loading plugins.

Bug Fixes:
- Preserve original URL schemes when evaluating tag eligibility so vault-specific tagging hooks are honored.
- Fix detail view extension widgets not appearing or updating when their plugins register after the view is created.
- Ensure vault tag hooks for CanTaged are registered correctly regardless of plugin startup order.

Enhancements:
- Refactor detail view extension widget handling to lazily sync with the global extension registry instead of creating widgets only once at construction.