### PR TITLE
master

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-file-manager (6.5.145) unstable; urgency=medium
+
+  * feat: add Wayland window activation support
+  * fix: remove redundant stdinNotifier cleanup in WorkerPipe
+  * docs: update file manager search documentation
+  * fix: remove thread termination to prevent SIGABRT crashes
+  * fix: handle vault tag hooks and extension widget sync
+  * fix: improve icon scaling in multi-file property dialog
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 24 Jun 2026 15:00:53 +0800
+
 dde-file-manager (6.5.144) unstable; urgency=medium
 
   * perf: optimize fstab bind info loading

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertydialog.cpp
@@ -41,7 +41,12 @@ MultiFilePropertyDialog::~MultiFilePropertyDialog()
 void MultiFilePropertyDialog::initHeadUi()
 {
     iconLabel = new QLabel(this);
-    iconLabel->setFixedSize(128, 128);
+    // 用 maximumSize + scaledContents 替代 fixedSize：当布局空间充足时 iconLabel
+    // 按 pixmap sizeHint(128x128) 显示，空间不足(scale>1 字体放大撑高布局)时
+    // iconLabel 可被压缩，pixmap 随之平滑缩放，避免与 multiFileLable 因 0 间距重叠。
+    iconLabel->setMaximumSize(128, 128);
+    iconLabel->setScaledContents(true);
+    iconLabel->setAlignment(Qt::AlignCenter);
     QIcon icon;
     icon.addFile(QString { ":/images/images/multiple_files.png" });
     icon.addFile(QString { ":/images/images/multiple_files@2x.png" });


### PR DESCRIPTION
- **fix: improve icon scaling in multi-file property dialog**
- **chore: bump version to 6.5.145**

## Summary by Sourcery

Improve icon scaling behavior in the multi-file property dialog header and update package version metadata.

Bug Fixes:
- Allow the multi-file property dialog icon to scale smoothly and avoid overlapping neighboring labels when layout space is constrained.

Enhancements:
- Adjust the multi-file property dialog icon label configuration to support centered, scalable icon rendering instead of a fixed-size label.

Build:
- Bump Debian package changelog version to 6.5.145.