### PR TITLE
fix(dfm-base): skip unnecessary initEnumerator(false) to prevent FTS …

### DIFF
--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -387,8 +387,15 @@ bool LocalDirIterator::oneByOne()
 
 bool LocalDirIterator::initIterator()
 {
-    if (d->dfmioDirIterator)
-        return d->dfmioDirIterator->initEnumerator(oneByOne());
+    if (d->dfmioDirIterator) {
+        // When oneByOne() is false, sortFileInfoList() uses opendir/readdir
+        // directly and does not need the FTS tree.  Skipping initEnumerator(false)
+        // avoids an unnecessary fts_open() allocation that would otherwise leak
+        // because LocalDirIterator::sortFileInfoList() never calls fts_close().
+        if (!oneByOne())
+            return true;
+        return d->dfmioDirIterator->initEnumerator(true);
+    }
     return false;
 }
 


### PR DESCRIPTION
…leak

LocalDirIterator::initIterator() called initEnumerator(false) which internally invokes openDirByfts() to allocate an FTS tree.  However, LocalDirIterator::sortFileInfoList() uses its own opendir()/readdir() /closedir() implementation and never calls fts_close(), leaving the FTS tree (5,279 bytes) leaked.

When oneByOne() is false (batch mode), skip initEnumerator(false) entirely since the FTS tree is not needed.

Log: Fixed FTS tree leak by skipping unnecessary initEnumerator(false).

Assisted-by: deepseek-v4-pro

Influence:
1. Open local directory in batch mode under Valgrind — verify zero fts_open leak
2. Test oneByOne()=true path (async mode) still initializes correctly
3. Test vault and SMB directory traversal
4. Verify batch mode sorting still works

fix(dfm-base): 跳过不必要的 initEnumerator(false) 防止 FTS 泄露

LocalDirIterator::initIterator() 调用 initEnumerator(false) 内部 通过 openDirByfts() 分配 FTS 树，但 LocalDirIterator 的
sortFileInfoList() 使用自己的 opendir/readdir/closedir 实现， 从不调用 fts_close()，导致 FTS 树（5,279 字节）泄露。

当 oneByOne() 返回 false（批量模式）时，直接跳过 initEnumerator(false)， 因为该模式下不需要 FTS 树。

Log: 通过跳过不必要的 initEnumerator(false) 修复 FTS 树泄露。

Influence:
1. Valgrind 下批量模式打开本地目录 — 验证 fts_open 零泄露
2. 测试 oneByOne()=true（异步模式）仍正确初始化
3. 测试保险箱和 SMB 目录遍历
4. 验证批量模式排序功能正常

Change-Id: I2777df0d4a09bed294dd1c5dd8d37ee2cd6c58fd

## Summary by Sourcery

Bug Fixes:
- Avoid leaking the FTS tree when iterating local directories in batch mode by not initializing the enumerator when oneByOne() is false.