### PR TITLE
fix: add process shutdown detection for safe plugin teardown

### DIFF
--- a/include/dfm-framework/lifecycle/lifecycle.h
+++ b/include/dfm-framework/lifecycle/lifecycle.h
@@ -13,11 +13,26 @@
 #include <QString>
 #include <QObject>
 
+#include <atomic>
 #include <functional>
 
 DPF_BEGIN_NAMESPACE
 
 namespace LifeCycle {
+// Cross-TU shutdown flag set by shutdownPlugins() before any plugin stop().
+// Used by framework hot paths (e.g. EventChannel) and plugin destructors to
+// short-circuit cross-plugin calls during atexit, where Q_GLOBAL_STATIC
+// destruction order is undefined and may produce use-after-free.
+//
+// NOTE: do NOT rely on QCoreApplication::closingDown() — when the host exits
+// via exit() (e.g. X11 IO error path), the stack-allocated QApplication does
+// not unwind and closingDown() remains false.
+extern std::atomic<bool> g_shuttingDown;
+inline bool isShuttingDown() noexcept
+{
+    return g_shuttingDown.load(std::memory_order_acquire);
+}
+
 void initialize(const QStringList &IIDs, const QStringList &paths);
 void initialize(const QStringList &IIDs, const QStringList &paths, const QStringList &blackNames);
 void initialize(const QStringList &IIDs, const QStringList &paths, const QStringList &blackNames,

--- a/src/dfm-framework/event/eventchannel.cpp
+++ b/src/dfm-framework/event/eventchannel.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <dfm-framework/event/eventchannel.h>
+#include <dfm-framework/lifecycle/lifecycle.h>
 
 #include <QtConcurrent>
 
@@ -60,6 +61,16 @@ QVariant EventChannel::send()
 
 QVariant EventChannel::send(const QVariantList &params)
 {
+    // Short-circuit during process shutdown: when plugins are being stopped,
+    // Q_GLOBAL_STATIC singletons (e.g. Settings) may already be destroyed in
+    // an unspecified order, and invoking cross-plugin handlers risks
+    // use-after-free. Push calls originated from plugin dtors / stop() paths
+    // are semantically meaningless at this point (no one consumes results).
+    if (Q_UNLIKELY(LifeCycle::isShuttingDown())) {
+        qCDebug(logDPF) << "EventChannel: dropping send during shutdown";
+        return QVariant();
+    }
+
     if (!conn) {
         qCWarning(logDPF) << "EventChannel: no connection available for send operation";
         return QVariant();

--- a/src/dfm-framework/event/eventdispatcher.cpp
+++ b/src/dfm-framework/event/eventdispatcher.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <dfm-framework/event/eventdispatcher.h>
+#include <dfm-framework/lifecycle/lifecycle.h>
 
 #include <QtConcurrent>
 
@@ -17,6 +18,15 @@ bool EventDispatcher::dispatch()
 
 bool EventDispatcher::dispatch(const QVariantList &params)
 {
+    // Short-circuit during process shutdown: signal handlers/filters may touch
+    // Q_GLOBAL_STATIC singletons (Settings, Application) that are already
+    // destroyed in unspecified atexit order. Also covers asyncDispatch(),
+    // which forwards here via QtConcurrent::run.
+    if (Q_UNLIKELY(LifeCycle::isShuttingDown())) {
+        qCDebug(logDPF) << "EventDispatcher: dropping dispatch during shutdown";
+        return true;
+    }
+
     auto filtersCopy = filterList;
     auto handlersCopy = handlerList;
 

--- a/src/dfm-framework/event/eventsequence.cpp
+++ b/src/dfm-framework/event/eventsequence.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <dfm-framework/event/eventsequence.h>
+#include <dfm-framework/lifecycle/lifecycle.h>
 
 DPF_USE_NAMESPACE
 
@@ -13,6 +14,15 @@ bool EventSequence::traversal()
 
 bool EventSequence::traversal(const QVariantList &params)
 {
+    // Short-circuit during process shutdown: hook handlers may touch
+    // Q_GLOBAL_STATIC singletons (Settings, Application) that are already
+    // destroyed in unspecified atexit order. Hook chains originated from
+    // plugin dtor / stop() paths are semantically meaningless at this point.
+    if (Q_UNLIKELY(LifeCycle::isShuttingDown())) {
+        qCDebug(logDPF) << "EventSequence: dropping traversal during shutdown";
+        return false;
+    }
+
     for (auto seq : list) {
         if (seq.handler(params))
             return true;

--- a/src/dfm-framework/lifecycle/lifecycle.cpp
+++ b/src/dfm-framework/lifecycle/lifecycle.cpp
@@ -10,6 +10,12 @@
 DPF_BEGIN_NAMESPACE
 namespace LifeCycle {
 
+// Definition of the cross-TU shutdown flag declared in the header.
+// Initialised to false; set to true inside shutdownPlugins() before any
+// plugin stop() runs. Reads are acquire-ordered for visibility of prior
+// writes performed by other threads before shutdown began.
+std::atomic<bool> g_shuttingDown { false };
+
 /*!
  * \brief getPluginManager Get the global plugin manager instance
  * \details Uses Leaky Singleton pattern to avoid static destruction order issues.
@@ -199,8 +205,15 @@ bool loadPlugins()
 void shutdownPlugins()
 {
     static std::once_flag shutdownOnce;
-    
+
     std::call_once(shutdownOnce, []() {
+        // Mark shutdown BEFORE stopPlugins() so any cross-plugin call invoked
+        // from a plugin's stop()/dtor path (e.g. EventChannel::push) is
+        // short-circuited. This is the only reliable signal during atexit,
+        // because QCoreApplication::closingDown() stays false when the host
+        // exits via exit() with a stack-allocated QApplication.
+        g_shuttingDown.store(true, std::memory_order_release);
+
         qCInfo(logDPF) << "LifeCycle: starting plugin shutdown";
         // Now this call is always safe because the instance is never destroyed
         getPluginManager()->stopPlugins();

--- a/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
@@ -11,7 +11,9 @@
 #include "menus/extendcanvasscene.h"
 
 #include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
 #include <dfm-base/dfm_desktop_defines.h>
+#include <dfm-framework/lifecycle/lifecycle.h>
 
 #include <DDBusSender>
 
@@ -43,7 +45,7 @@ FrameManagerPrivate::FrameManagerPrivate(FrameManager *qq)
     layoutTimer = new QTimer(this);
     layoutTimer->setInterval(1000);
     layoutTimer->setSingleShot(true);
-    connect(layoutTimer, &QTimer::timeout, this, [this]{
+    connect(layoutTimer, &QTimer::timeout, this, [this] {
         if (organizer) {
             organizer->layout();
         }
@@ -190,20 +192,20 @@ void FrameManagerPrivate::onHideAllKeyPressed()
             QString cmdCloseNotify = QString("dbus-send,--type=method_call,--dest=org.freedesktop.Notifications,/org/freedesktop/Notifications,com.deepin.dde.Notification.CloseNotification,uint32:%1")
                                              .arg(replacesId);
             QDBusPendingCall pendingReply = DDBusSender()
-                    .service("org.freedesktop.Notifications")
-                    .path("/org/freedesktop/Notifications")
-                    .interface("org.freedesktop.Notifications")
-                    .method(QString("Notify"))
-                    .arg(tr("Desktop organizer"))
-                    .arg(replacesId)
-                    .arg(QString("deepin-toggle-desktop"))
-                    .arg(tr("Shortcut \"%1\" to show collections").arg(keySequence))
-                    .arg(tips)
-                    .arg(QStringList { "close-notify", tr("Close"), "no-repeat", tr("No more prompts") })
-                    .arg(QVariantMap { { "x-deepin-action-no-repeat", cmdNoRepeation },
-                                       { "x-deepin-action-close-notify", cmdCloseNotify } })
-                    .arg(kHideAllNotificationTimeoutMs)
-                    .call();
+                                                    .service("org.freedesktop.Notifications")
+                                                    .path("/org/freedesktop/Notifications")
+                                                    .interface("org.freedesktop.Notifications")
+                                                    .method(QString("Notify"))
+                                                    .arg(tr("Desktop organizer"))
+                                                    .arg(replacesId)
+                                                    .arg(QString("deepin-toggle-desktop"))
+                                                    .arg(tr("Shortcut \"%1\" to show collections").arg(keySequence))
+                                                    .arg(tips)
+                                                    .arg(QStringList { "close-notify", tr("Close"), "no-repeat", tr("No more prompts") })
+                                                    .arg(QVariantMap { { "x-deepin-action-no-repeat", cmdNoRepeation },
+                                                                       { "x-deepin-action-close-notify", cmdCloseNotify } })
+                                                    .arg(kHideAllNotificationTimeoutMs)
+                                                    .call();
             auto *watcher = new QDBusPendingCallWatcher(pendingReply, this);
             connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, replacesId, allowRetry, sendHideAllNotification](QDBusPendingCallWatcher *watcher) {
                 QDBusPendingReply<uint> reply = *watcher;
@@ -341,13 +343,24 @@ FrameManager::FrameManager(QObject *parent)
 
 FrameManager::~FrameManager()
 {
-    turnOff();
+    // During process shutdown (atexit / exit() path), plugin stop order is
+    // unspecified and cross-plugin singletons (Settings, menu scene registry)
+    // may already be destroyed. Skip turnOff() and menu unregister — both
+    // touch cross-plugin state via EventChannel / dfmplugin-menu. Only
+    // perform direct resource cleanup (smart pointers / Qt children).
+    // Active teardown (user disabling organizer) still runs turnOff() via
+    // the explicit stop() path in OrganizerPlugin, not via dtor.
+    if (Q_LIKELY(!DPF_NAMESPACE::LifeCycle::isShuttingDown())) {
+        turnOff();
 
-    // unregister menu
-    dfmplugin_menu_util::menuSceneUnbind(ExtendCanvasCreator::name());
-    auto creator = dfmplugin_menu_util::menuSceneUnregisterScene(ExtendCanvasCreator::name());
-    if (creator)
-        delete creator;
+        // unregister menu
+        dfmplugin_menu_util::menuSceneUnbind(ExtendCanvasCreator::name());
+        auto creator = dfmplugin_menu_util::menuSceneUnregisterScene(ExtendCanvasCreator::name());
+        if (creator)
+            delete creator;
+    } else {
+        fmInfo() << "FrameManager: shutdown detected, skipping turnOff/menu unregister";
+    }
 }
 
 bool FrameManager::initialize()


### PR DESCRIPTION
Added a global shutdown flag in LifeCycle module to handle safe plugin
teardown during application exit. The EventChannel and FrameManager
now check this flag to avoid cross-plugin calls during shutdown when
Q_GLOBAL_STATIC destructors may have already run in arbitrary order.

1. Added atomic g_shuttingDown flag in LifeCycle for shutdown detection
2. Modified EventChannel to short-circuit sends during shutdown
3. Updated FrameManager destructor to skip cleanup during shutdown
4. Improved shutdownPlugins() to set shutdown flag before stopping
plugins

Technical details:
- Uses std::atomic with memory_order_acq_rel for thread safety
- Works around limitations of QCoreApplication::closingDown()
- Prevents use-after-free in cross-plugin calls during atexit
- Only affects shutdown paths - normal operation unchanged

Influence:
1. Test normal application shutdown process
2. Verify plugins can be disabled during runtime
3. Check for any regression in event channel functionality
4. Test exit() path with stack-allocated QApplication
5. Verify no cross-plugin calls happen during shutdown

fix: 添加进程关闭检测以实现安全插件拆卸

在 LifeCycle 模块中添加全局关闭标志以处理应用程序退出时的安全插件拆卸。
EventChannel 和 FrameManager 现在会检查此标志以避免在关闭期间进行跨插件
调用，此时 Q_GLOBAL_STATIC 析构函数可能已经以任意顺序运行。

1. 在 LifeCycle 中添加原子性 g_shuttingDown 标志用于关闭检测
2. 修改 EventChannel 在关闭期间跳过发送操作
3. 更新 FrameManager 析构函数使其在关闭期间跳过清理
4. 改进 shutdownPlugins() 使其在停止插件前设置关闭标志

技术细节:
- 使用 std::atomic 配合 memory_order_acq_rel 保证线程安全
- 解决 QCoreApplication::closingDown() 的限制问题
- 防止 atexit 期间跨插件调用时的 use-after-free 问题
- 仅影响关闭路径 - 正常运行不受影响

影响范围:
1. 测试正常应用程序关闭流程
2. 验证运行时插件禁用功能
3. 检查事件通道功能是否有回归
4. 测试使用栈分配 QApplication 的 exit() 路径
5. 确认关闭期间没有跨插件调用发生

Fixes: #367409
