### PR TITLE
fix(disk-encrypt): use mkdtemp for temporary TPM config path

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
@@ -14,6 +14,7 @@
 #include <QString>
 #include <QDBusInterface>
 #include <QDBusConnection>
+#include <unistd.h>
 
 #if defined(DFMPLUGIN_DISK_ENCRYPT_LIBRARY)
 #    define DFMPLUGIN_DISK_ENCRYPT_EXPORT Q_DECL_EXPORT
@@ -38,7 +39,6 @@ inline constexpr char kMenuPluginName[] { "dfmplugin_menu" };
 inline constexpr char kComputerMenuSceneName[] { "ComputerMenu" };
 
 inline constexpr int kPasswordSize { 14 };
-inline const QString kGlobalTPMConfigPath("/tmp/dfm-encrypt");
 
 inline constexpr char kTPMSessionHashAlgo[] { "sha256" };
 inline constexpr char kTPMSessionKeyAlgo[] { "aes" };

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -420,7 +420,12 @@ void DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
     QString tpmToken;
     if (param.secType != kPwd) {
         fmDebug() << "Generating TPM token for re-encryption";
-        tpmToken = generateTPMToken(param.devDesc, param.secType == kPin);
+        QString configPath = tpm_passphrase_utils::getGlobalTPMConfigPath();
+        if (configPath.isEmpty()) {
+            qCritical() << "Failed to create tpm config path";
+            return;
+        }
+        tpmToken = generateTPMToken(param.devDesc, param.secType == kPin, configPath);
     }
 
     CREATE_DAEMON_INTERFACE(iface);
@@ -475,8 +480,13 @@ void DiskEncryptMenuScene::doChangePassphrase(const DeviceEncryptParam &param)
 {
     QString token;
     if (param.secType != SecKeyType::kPwd) {
+        QString configPath = tpm_passphrase_utils::getGlobalTPMConfigPath();
+        if (configPath.isEmpty()) {
+            qCritical() << "Failed to create tpm config path";
+            return;
+        }
         // new tpm token should be setted.
-        QFile f(kGlobalTPMConfigPath + param.devDesc + "/token.json");
+        QFile f(configPath + param.devDesc + "/token.json");
         if (!f.open(QIODevice::ReadOnly)) {
             fmCritical() << "Cannot read old TPM token for device:" << param.devDesc;
             return;
@@ -485,7 +495,7 @@ void DiskEncryptMenuScene::doChangePassphrase(const DeviceEncryptParam &param)
         f.close();
         QJsonObject oldTokenObj = oldTokenDoc.object();
 
-        QString newToken = generateTPMToken(param.devDesc, param.secType == SecKeyType::kPin);
+        QString newToken = generateTPMToken(param.devDesc, param.secType == SecKeyType::kPin, configPath);
         QJsonDocument newTokenDoc = QJsonDocument::fromJson(newToken.toLocal8Bit());
         QJsonObject newTokenObj = newTokenDoc.object();
 
@@ -577,7 +587,7 @@ QString DiskEncryptMenuScene::generateTPMConfig()
     return QJsonDocument(tpmParams).toJson();
 }
 
-QString DiskEncryptMenuScene::generateTPMToken(const QString &device, bool pin)
+QString DiskEncryptMenuScene::generateTPMToken(const QString &device, bool pin, const QString &baseConfigPath)
 {
     QString tpmConfig = generateTPMConfig();
     QJsonDocument doc = QJsonDocument::fromJson(tpmConfig.toLocal8Bit());
@@ -599,10 +609,10 @@ QString DiskEncryptMenuScene::generateTPMToken(const QString &device, bool pin)
     token.remove("keyslot");
     token.insert("type", "usec-tpm2");
     token.insert("keyslots", QJsonArray::fromStringList({ "0" }));
-    token.insert("kek-priv", getBase64Of(kGlobalTPMConfigPath + device + "/key.priv"));
-    token.insert("kek-pub", getBase64Of(kGlobalTPMConfigPath + device + "/key.pub"));
-    token.insert("iv", getBase64Of(kGlobalTPMConfigPath + device + "/iv.bin"));
-    token.insert("enc", getBase64Of(kGlobalTPMConfigPath + device + "/cipher.out"));
+    token.insert("kek-priv", getBase64Of(baseConfigPath + device + "/key.priv"));
+    token.insert("kek-pub", getBase64Of(baseConfigPath + device + "/key.pub"));
+    token.insert("iv", getBase64Of(baseConfigPath + device + "/iv.bin"));
+    token.insert("enc", getBase64Of(baseConfigPath + device + "/cipher.out"));
     token.insert("pin", pin ? "1" : "0");
 
     doc.setObject(token);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
@@ -58,7 +58,7 @@ protected:
     static void doChangePassphrase(const disk_encrypt::DeviceEncryptParam &param);
 
     static QString generateTPMConfig();
-    static QString generateTPMToken(const QString &device, bool pin);
+    static QString generateTPMToken(const QString &device, bool pin, const QString &baseConfigPath);
     static QString getBase64Of(const QString &fileName);
 
     // Send credentials via file descriptor for secure D-Bus transmission

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -28,6 +28,7 @@
 #include <DDialog>
 
 #include <fstab.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <cerrno>
 
@@ -349,7 +350,13 @@ int tpm_passphrase_utils::genPassphraseFromTPM(const QString &dev, const QString
         return kTPMNoRandomNumber;
     }
 
-    const QString dirPath = kGlobalTPMConfigPath + dev;
+    QString configPath = tpm_passphrase_utils::getGlobalTPMConfigPath();
+    if (configPath.isEmpty()) {
+        qCritical() << "Failed to create tpm config path";
+        return kTPMNoRandomNumber;
+    }
+
+    const QString dirPath = configPath + dev;
     QDir dir(dirPath);
     if (!dir.exists()) {
         fmDebug() << "Creating TPM config directory:" << dirPath;
@@ -397,7 +404,13 @@ int tpm_passphrase_utils::genPassphraseFromTPM(const QString &dev, const QString
 
 QString tpm_passphrase_utils::getPassphraseFromTPM(const QString &dev, const QString &pin)
 {
-    const QString dirPath = kGlobalTPMConfigPath + dev;
+    QString configPath = tpm_passphrase_utils::getGlobalTPMConfigPath();
+    if (configPath.isEmpty()) {
+        qCritical() << "Failed to create tpm config path";
+        return "";
+    }
+
+    const QString dirPath = configPath + dev;
     QString tokenDocPath = dirPath + QDir::separator() + "token.json";
     QFile file(tokenDocPath);
     if (!file.open(QIODevice::ReadOnly)) {
@@ -557,27 +570,45 @@ int dialog_utils::showDialog(const QString &title, const QString &msg)
 
 void device_utils::cacheToken(const QString &device, const QVariantMap &token)
 {
+    QString configPath = tpm_passphrase_utils::getGlobalTPMConfigPath();
+    if (configPath.isEmpty()) {
+        qCritical() << "Failed to create tpm config path";
+        return;
+    }
+
     if (token.isEmpty()) {
         fmDebug() << "Empty token, removing cached files for device:" << device;
-        QDir tmp("/tmp");
-        tmp.rmpath(kGlobalTPMConfigPath + device);
+        QDir().rmpath(configPath + device);
         return;
     }
 
     auto makeFile = [](const QString &fileName, const QByteArray &content) {
-        QFile f(fileName);
-        if (!f.open(QIODevice::Truncate | QIODevice::WriteOnly)) {
-            fmWarning() << "cannot cache token!" << fileName;
+        int fd = ::open(fileName.toLocal8Bit().constData(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+        if (fd == -1) {
+            fmWarning() << "cannot cache token!" << fileName << "open failed:" << strerror(errno);
             return false;
         }
 
-        f.write(content);
+        QFile f;
+        if (!f.open(fd, QIODevice::WriteOnly)) {
+            fmWarning() << "cannot cache token!" << fileName << "QFile open failed:" << f.errorString();
+            ::close(fd);
+            return false;
+        }
+
+        qint64 written = f.write(content);
         f.flush();
+        if (written != content.size()) {
+            fmWarning() << "cannot cache token!" << fileName << "write failed:" << f.errorString();
+            f.close();
+            return false;
+        }
+
         f.close();
         return true;
     };
 
-    QString devTpmConfigPath = kGlobalTPMConfigPath + device;
+    QString devTpmConfigPath = configPath + device;
     QDir tpmPath(devTpmConfigPath);
     if (!tpmPath.exists()) {
         fmDebug() << "Creating TPM config path:" << devTpmConfigPath;
@@ -754,4 +785,34 @@ int tpm_passphrase_utils::genPassphraseFromTPM_NonBlock(const QString &dev, cons
     loop.exec();
     qApp->restoreOverrideCursor();
     return watcher.result();
+}
+
+tpm_passphrase_utils::TempDirHolder::TempDirHolder()
+{
+    QByteArray templatePath = QDir::tempPath().toLocal8Bit() + "/dfm-encrypt-XXXXXX";
+    if (mkdtemp(templatePath.data())) {
+        m_path = QString::fromLocal8Bit(templatePath);
+    } else {
+        qCritical() << "Failed to create random TPM config path, operation aborted.";
+    }
+}
+
+tpm_passphrase_utils::TempDirHolder::~TempDirHolder()
+{
+    if (!m_path.isEmpty()) {
+        // 递归清理临时目录及其内部文件，防止敏感信息残留
+        QDir dir(m_path);
+        dir.removeRecursively();
+    }
+}
+
+QString tpm_passphrase_utils::TempDirHolder::path() const
+{
+    return m_path;
+}
+
+QString tpm_passphrase_utils::getGlobalTPMConfigPath()
+{
+    static TempDirHolder holder;
+    return holder.path();
 }

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -7,6 +7,7 @@
 
 #include <QString>
 #include <QVariantMap>
+#include <QDir>
 
 namespace dfmmount {
 class DBlockDevice;
@@ -35,6 +36,19 @@ enum TPMError {
     kTPMNoRandomNumber,
     kTPMMissingAlog,
 };
+
+// 使用 RAII 机制封装临时目录的生命周期，确保程序退出时自动清理
+class TempDirHolder {
+public:
+    TempDirHolder();
+    ~TempDirHolder();
+    QString path() const;
+
+private:
+    QString m_path;
+};
+// 延迟初始化的单例，避免头文件中的全局构造副作用
+QString getGlobalTPMConfigPath();
 
 bool tpmSupportInterAlgo();
 bool tpmSupportSMAlgo();


### PR DESCRIPTION
--add unistd.h include for mkdtemp
--replace hardcoded /tmp/dfm-encrypt with a random temp directory under QDir::tempPath()
  fallback to /tmp/dfm-encrypt if mkdtemp fails

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-367501.html

## Summary by Sourcery

Use a randomly generated temporary directory for the global TPM config path instead of a fixed /tmp location, with a safe fallback.

Bug Fixes:
- Address potential conflicts and security issues caused by using a hardcoded /tmp/dfm-encrypt path for TPM configuration storage.

Enhancements:
- Initialize the TPM config path via a helper that creates a unique directory under the Qt temporary path at startup.