### PR TITLE
fix: improve task manager cleanup safety

### DIFF
--- a/src/services/textindex/task/taskmanager.cpp
+++ b/src/services/textindex/task/taskmanager.cpp
@@ -57,6 +57,7 @@ TaskManager::~TaskManager()
     if (currentTask) {
         fmInfo() << "[TaskManager] Stopping current task before destruction";
         stopCurrentTask();
+        currentTask->disconnect();
     }
 
     if (workerThread.isRunning()) {
@@ -73,6 +74,7 @@ TaskManager::~TaskManager()
         if (!workerThread.wait(5000)) {
             fmWarning() << "[TaskManager] Worker thread still running after 5s, "
                            "will be cleaned up on process exit (terminate() removed to avoid SIGABRT)";
+            _exit(1);
         }
     }
     fmInfo() << "[TaskManager] TaskManager destroyed successfully";


### PR DESCRIPTION
1. Added disconnect() call for currentTask in destructor to prevent
potential signal/slot leaks during destruction
2. Added _exit(1) when worker thread fails to terminate after timeout to
avoid undefined behavior and force process termination
3. These changes ensure more reliable cleanup and prevent resource leaks
during application shutdown

Log: Improved task manager cleanup behavior during application exit

Influence:
1. Test application shutdown scenarios with active tasks
2. Verify proper cleanup of resources during forced termination
3. Check for any lingering threads or resource leaks after exit
4. Test both normal and timeout shutdown paths

fix: 改进任务管理器清理安全性

1. 在析构函数中添加了对currentTask的disconnect()调用，防止在析构过程中出
现信号/槽泄漏
2. 当工作线程超时未终止时添加_exit(1)调用，避免未定义行为并强制进程终止
3. 这些更改确保了更可靠的清理过程，防止应用程序关闭期间的资源泄漏

Log: 改进了应用程序退出时任务管理器的清理行为

Influence:
1. 测试带有活动任务的应用程序关闭场景
2. 验证强制终止期间资源是否正确清理
3. 检查退出后是否有残留线程或资源泄漏
4. 测试正常和超时关闭两种路径

## Summary by Sourcery

Improve TaskManager shutdown reliability and safety during application destruction and process exit.

Bug Fixes:
- Ensure the current task is fully disconnected during TaskManager destruction to prevent signal/slot related leaks or callbacks after destruction.
- Force process termination when the worker thread fails to stop within the timeout to avoid undefined behavior and lingering threads during shutdown.