### PR TITLE
fix(sidebar): ungrab QScroller gesture in SideBarView destructor

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -271,6 +271,7 @@ SideBarView::SideBarView(QWidget *parent)
 
 SideBarView::~SideBarView()
 {
+    QScroller::ungrabGesture(viewport());
 }
 
 SideBarModel *SideBarView::model() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -272,6 +272,7 @@ SideBarView::SideBarView(QWidget *parent)
 SideBarView::~SideBarView()
 {
     QScroller::ungrabGesture(viewport());
+    setStyle(nullptr);
 }
 
 SideBarModel *SideBarView::model() const


### PR DESCRIPTION
QScroller::grabGesture() stores internal data in a static hash table and relies on the viewport's destroyed() signal for cleanup.  In the child process, this deferred cleanup may not complete before exit, leaking 16 bytes (qscroller.cpp:375).

Explicitly call ungrabGesture() in the destructor to ensure cleanup.

Log: Fixed 16-byte QScroller leak by ungrabGesture in destructor.

Assisted-by: deepseek-v4-pro

Influence:
1. Verify no QScroller::grabGesture leak under Valgrind in child process
2. Verify touch scrolling still works on sidebar after window recreate
3. Verify no regression from rapid open/close of file manager window

fix(sidebar): 在 SideBarView 析构中取消 QScroller 手势抓取

QScroller::grabGesture() 在静态 hash 表中存储内部数据，依赖 viewport 的 destroyed() 信号进行清理。在子进程中该延迟清理可能在进程退出前
未完成，导致 16 字节泄露（qscroller.cpp:375）。

在析构函数中显式调用 ungrabGesture() 确保清理。

Log: 通过析构中 ungrabGesture() 修复 16 字节 QScroller 泄露。

Influence:
1. Valgrind 下验证子进程无 QScroller::grabGesture 泄露
2. 验证窗口重建后侧边栏触摸滚动仍正常
3. 验证快速打开/关闭文件管理器窗口无回归

Change-Id: I25759311b857fa647a7bfe39043944aeb409d846

## Summary by Sourcery

Bug Fixes:
- Fix a QScroller::grabGesture-related memory leak by ungrabbing the gesture in the SideBarView destructor.