### PR TITLE
Fix: [Vault] The file dialog not stay on top.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
@@ -183,6 +183,9 @@ void VaultActiveSaveKeyFileView::initUiForSizeMode()
 
 void VaultActiveSaveKeyFileView::initConnect()
 {
+    connect(selectfileSavePathEdit, &DFileChooserEdit::dialogOpened, this, [this](){
+        filedialog->setWindowFlag(Qt::WindowStaysOnTopHint);
+    });
     connect(selectfileSavePathEdit, &DFileChooserEdit::fileChoosed, this, &VaultActiveSaveKeyFileView::slotChangeEdit);
     connect(filedialog, &DFileDialog::fileSelected, this, &VaultActiveSaveKeyFileView::slotSelectCurrentFile);
     connect(nextBtn, &DPushButton::clicked,

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -55,9 +55,13 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
 
     filePathEdit = new DFileChooserEdit(this);
     filePathEdit->lineEdit()->setPlaceholderText(tr("Select Key File"));
+    fileDialog = new DFileDialog(this, QDir::homePath());
+    fileDialog->setNameFilters({ QString("KEY file(*.key)") });
+    filePathEdit->setFileDialog(fileDialog);
     filePathEdit->setDirectoryUrl(QDir::homePath());
     filePathEdit->setFileMode(DFileDialog::ExistingFiles);
     filePathEdit->setNameFilters({ QString("KEY file(*.key)") });
+    filePathEdit->lineEdit()->setReadOnly(true);
 
     verificationPrompt = new DLabel(this);
     verificationPrompt->setForegroundRole(DPalette::TextWarning);
@@ -77,6 +81,10 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
     mainLayout->addWidget(verificationPrompt);
 
     this->setLayout(mainLayout);
+
+    connect(filePathEdit, &DFileChooserEdit::dialogOpened, this, [this](){
+        fileDialog->setWindowFlag(Qt::WindowStaysOnTopHint);
+    });
     connect(filePathEdit, &DFileChooserEdit::fileChoosed, this, &RetrievePasswordView::onBtnSelectFilePath);
     connect(filePathEdit->lineEdit(), &QLineEdit::textChanged, this, &RetrievePasswordView::onTextChanged);
 


### PR DESCRIPTION
-- Set the file dialog stay on top.

Log：fix issue
Bug: https://pms.uniontech.com/bug-view-367637.html