### PR TITLE
fix: improve vault password reset reliability

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
@@ -4,7 +4,7 @@
 
 #include "resetpasswordbykeyfileview.h"
 #include "utils/encryption/operatorcenter.h"
-#include "utils/vaulthelper.h"
+#include "dbus/vaultdbusutils.h"
 
 #include <dfm-base/utils/dialogmanager.h>
 
@@ -319,8 +319,8 @@ bool ResetPasswordByKeyFileView::checkRepeatPassword()
 bool ResetPasswordByKeyFileView::checkInputInfo()
 {
     return !keyFileEdit->text().isEmpty()
-           && checkPassword(newPasswordEdit->text())
-           && checkRepeatPassword();
+            && checkPassword(newPasswordEdit->text())
+            && checkRepeatPassword();
 }
 
 void ResetPasswordByKeyFileView::showEvent(QShowEvent *event)
@@ -384,6 +384,9 @@ void ResetPasswordByKeyFileView::onResetPasswordFinished()
         switchMethodLabel->setEnabled(true);
 
     if (result.success) {
+        // 密码重置成功，恢复错误次数限制和等待时间
+        VaultDBusUtils::restoreLeftoverErrorInputTimes();
+        VaultDBusUtils::restoreNeedWaitMinutes();
         DialogManager::instance()->showMessageDialog(tr("Success"), tr("Password reset successfully"));
         emit sigCloseDialog();
     } else {


### PR DESCRIPTION
1. Changed vault helper include to use DBus utils for better
interprocess communication
2. Fixed code indentation in checkInputInfo method for consistency
3. Added critical security feature to reset error count and wait time
after successful password reset
4. Maintained existing error handling for failed password reset attempts

Log:
1. Fixed indentation in password reset view
2. Added proper reset of security counters after successful password
reset
3. Improved vault manager communication via DBus

Influence:
1. Test password reset flow with valid and invalid key files
2. Verify security counters are properly reset after successful
operation
3. Check error messages for failed attempts
4. Test UI responsiveness during vault operations
5. Validate DBus communication between components

fix: 提高保险库密码重置可靠性

1. 将保险库助手引用改为使用 DBus 工具实现更好的进程间通信
2. 修正 checkInputInfo 方法中的代码缩进保持一致性
3. 新增关键安全功能：成功重置密码后重置错误计数和等待时间
4. 保留对密码重置失败情况的现有错误处理

Log:
1. 修复密码重置视图中的缩进问题
2. 成功重置密码后正确重置安全计数器
3. 通过 DBus 改进保险库管理器通信

Influence:
1. 测试有效和无效密钥文件下的密码重置流程
2. 验证成功操作后安全计数器是否正确重置
3. 检查失败尝试的错误提示信息
4. 测试保险库操作期间的UI响应性
5. 验证组件间的DBus通信

Fixes: #347967

## Summary by Sourcery

Improve vault password reset reliability and security counters handling when resetting via key file.

New Features:
- Reset security error count and wait time after a successful vault password reset via key file.

Enhancements:
- Switch vault password reset view to use DBus-based vault utilities for interprocess communication.
- Align input validation logic indentation in the key-file-based reset password view for consistency.