### PR TITLE
Fix: [vault] Unlock vault crash.

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/fileencrypthandle.cpp
@@ -195,11 +195,6 @@ void FileEncryptHandle::createVault(const QString &lockBaseDir, const QString &u
 bool FileEncryptHandle::unlockVault(const QString &lockBaseDir, const QString &unlockFileDir, const QString &DSecureString)
 {
     fmInfo() << "Vault: Starting vault unlock";
-    if (!createDirIfNotExist(unlockFileDir)) {
-        fmCritical() << "Vault: Failed to create unlock directory:" << unlockFileDir;
-        DialogManager::instance()->showErrorDialog(tr("Unlock failed"), tr("The %1 directory is occupied,\n please clear the files in this directory and try to unlock the safe again.").arg(unlockFileDir));
-        return false;
-    }
 
     bool result { false };
     d->mutex->lock();

--- a/src/plugins/filemanager/dfmplugin-vault/utils/pathmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/pathmanager.cpp
@@ -5,9 +5,12 @@
 #include "pathmanager.h"
 #include "vaultdefine.h"
 
+#include <dfm-base/utils/dialogmanager.h>
+
 #include <dfm-io/dfmio_utils.h>
 
 using namespace dfmplugin_vault;
+DFMBASE_USE_NAMESPACE
 
 PathManager::PathManager(QObject *parent)
     : QObject(parent)
@@ -24,6 +27,21 @@ QString PathManager::vaultUnlockPath()
     return makeVaultLocalPath("", kVaultDecryptDirName);
 }
 
+QString PathManager::vaultPswContainerPath(const QString &baseDirPath)
+{
+    return baseDirPath + QDir::separator() + kVaultPswContainerFileName;
+}
+
+QString PathManager::vaultEncryptPath(const QString &baseDirPath)
+{
+    return baseDirPath + QDir::separator() + kVaultEncrypyDirName;
+}
+
+QString PathManager::vaultMountPath(const QString &baseDirPath)
+{
+    return baseDirPath + QDir::separator() + kVaultDecryptDirName;
+}
+
 QString PathManager::makeVaultLocalPath(const QString &path, const QString &base)
 {
     if (base.isEmpty()) {
@@ -38,4 +56,31 @@ QString PathManager::addPathSlash(const QString &path)
 {
     return DFMIO::DFMUtils::buildFilePath(path.toStdString().c_str(),
                                           QString("/").toStdString().c_str(), nullptr);
+}
+
+bool PathManager::createDirIfNotExist(const QString &path)
+{
+    if (!QFile::exists(path)) {
+        QDir().mkpath(path);
+    } else {
+        QDir dir(path);
+        if (!dir.isEmpty()) {
+            fmCritical() << "Vault: Create vault dir failed, dir is not empty!";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool PathManager::createVaultMountDir(const QString &vaultBasePath)
+{
+    QString mountDir = PathManager::vaultMountPath(vaultBasePath);
+    if (!createDirIfNotExist(mountDir)) {
+        DialogManager::instance()->showErrorDialog(tr("Unlock failed"),
+                                                   tr("The %1 directory is occupied,\n "
+                                                      "please clear the files in this directory and try to unlock the safe again.")
+                                                           .arg(mountDir));
+        return false;
+    }
+    return true;
 }

--- a/src/plugins/filemanager/dfmplugin-vault/utils/pathmanager.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/pathmanager.h
@@ -16,12 +16,15 @@ public:
 
 public:
     static QString vaultLockPath();
-
     static QString vaultUnlockPath();
-
+    static QString vaultPswContainerPath(const QString &baseDirPath);
+    static QString vaultEncryptPath(const QString &baseDirPath);
+    static QString vaultMountPath(const QString &baseDirPath);
     static QString makeVaultLocalPath(const QString &path = "", const QString &base = "");
-
     static QString addPathSlash(const QString &path);
+
+    static bool createDirIfNotExist(const QString &path);
+    static bool createVaultMountDir(const QString &vaultBasePath);
 signals:
 
 public slots:

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaultdefine.h
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaultdefine.h
@@ -22,6 +22,7 @@ inline constexpr char kRSAPUBKeyFileName[] { "rsapubkey" };
 inline constexpr char kRSACiphertextFileName[] { "rsaclipher" };
 inline constexpr char kPasswordHintFileName[] { "passwordHint" };
 inline constexpr char kVaultConfigFileName[] { "vaultConfig.ini" };
+inline constexpr char kVaultPswContainerFileName[] { "password_container.bin" };
 
 //propertydailog and detaillview property change
 inline constexpr char kFieldReplace[] { "kFieldReplace" };

--- a/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/utils/vaulthelper.cpp
@@ -446,6 +446,9 @@ void VaultHelper::unlockVaultDialog()
         if (!password.isEmpty()) {
             fmDebug() << "Vault: Password retrieved from keyring, attempting unlock";
 
+            if (!PathManager::createVaultMountDir(kVaultBasePath))
+                return;
+
             if (unlockVault(password)) {
                 fmInfo() << "Vault: Automatic unlock successful";
                 VaultHelper::instance()->defaultCdAction(VaultHelper::instance()->currentWindowId(),

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
@@ -239,6 +239,9 @@ void VaultActiveSaveKeyFileView::slotNextBtnClicked()
             return;
         }
 
+        if (!PathManager::createVaultMountDir(kVaultBasePath))
+            return;
+
         spinner->move((width() - spinner->width()) / 2, (height() - spinner->height()) / 2);
         spinner->show();
         spinner->raise();

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
@@ -137,11 +137,9 @@ void RecoveryKeyView::buttonClicked(int index, const QString &text)
         
         if (isValid) {
             unlockByKey = true;
-            QString encryptBaseDir = PathManager::vaultLockPath();
-            QString decryptFileDir = PathManager::vaultUnlockPath();
-            fmDebug() << "Vault: Vault paths - encrypted:" << encryptBaseDir << "decrypted:" << decryptFileDir;
-
-            bool result = FileEncryptHandle::instance()->unlockVault(encryptBaseDir, decryptFileDir, strCipher);
+            if (!PathManager::createVaultMountDir(kVaultBasePath))
+                return;
+            bool result = VaultHelper::instance()->unlockVault(strCipher);
             fmDebug() << "Vault: Unlock operation result:" << result;
             handleUnlockVault(result);
         } else {

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -7,6 +7,7 @@
 #include "views/createvaultview/vaultactivesavekeyfileview.h"
 #include "views/vaultpagebase.h"
 #include "utils/vaultutils.h"
+#include "utils/pathmanager.h"
 #include "utils/vaulthelper.h"
 #include "utils/vaultautolock.h"
 #include "utils/encryption/operatorcenter.h"
@@ -122,6 +123,9 @@ void RetrievePasswordView::verificationKey()
         emit sigBtnEnabled(1, false);
         return;
     }
+
+    if (!PathManager::createVaultMountDir(kVaultBasePath))
+        return;
 
     emit sigBtnEnabled(1, false);
     emit sigBtnEnabled(0, false);

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
@@ -10,6 +10,7 @@
 #include "utils/vaultautolock.h"
 #include "utils/servicemanager.h"
 #include "utils/fileencrypthandle.h"
+#include "utils/pathmanager.h"
 #include "dbus/vaultdbusutils.h"
 #include "views/createvaultview/vaultactivesavekeyfileview.h"
 #include "views/vaultpagebase.h"
@@ -140,6 +141,8 @@ void UnlockView::buttonClicked(int index, const QString &text)
 {
     fmDebug() << "Vault: Unlock view button clicked - index:" << index << "text:" << text;
     if (index == 1) {
+        if (!PathManager::createVaultMountDir(kVaultBasePath))
+            return;
         emit sigBtnEnabled(1, false);
         emit sigBtnEnabled(0, false);
 


### PR DESCRIPTION
-- When the mount dir has file, unlock vault crash. -- The root cause is that dialog was created and displayed in a child thread.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-345499.html

## Summary by Sourcery

Ensure vault unlock operations validate and prepare the vault mount directory before proceeding, preventing crashes when the mount directory is occupied.

Bug Fixes:
- Prevent vault unlock from crashing when the mount directory already contains files by validating the directory and showing an error dialog instead of continuing.

Enhancements:
- Centralize vault-related path construction and mount-directory creation logic in PathManager, including new helpers for password container, encrypt, and mount paths.