### PR TITLE
fix: improve vault password reset dialog handling

### DIFF
--- a/src/plugins/filedialog/core/utils/corehelper.cpp
+++ b/src/plugins/filedialog/core/utils/corehelper.cpp
@@ -86,15 +86,6 @@ bool CoreHelper::askReplaceFile(QString fileName, QWidget *parent)
 {
     DDialog dialog(parent);
 
-    // NOTE(zccrs): dxcb bug
-    if ((!WindowUtils::isWayLand() && !DPlatformWindowHandle::isEnabledDXcb(parent))
-#if DTK_VERSION > DTK_VERSION_CHECK(2, 0, 5, 0)
-        || pwPluginVersionGreaterThen("1.1.8.3")
-#endif
-    ) {
-        dialog.setWindowModality(Qt::WindowModal);
-    }
-
     dialog.setIcon(QIcon::fromTheme("dde-file-manager"));
 
     QLabel *titleLabel = dialog.findChild<QLabel *>("TitleLabel");
@@ -139,9 +130,9 @@ QString CoreHelper::findExtensionName(const QString &fileName, const QStringList
 
     const QString fileNameExtension = db->suffixForFileName(fileName);
 
-    for (const QString &filter : newNameFilters) {   //从扩展名列表中轮询，目前发现的应用程序传入扩展名列表均只有一个
-        newNameFilterExtension = db->suffixForFileName(filter);   //在QMimeDataBase里面查询扩展名是否存在（不能查询正则表达式）
-        if (newNameFilterExtension.isEmpty()) {   //未查询到扩展名用正则表达式再查一次，新加部分，解决WPS保存文件去掉扩展名后没有补上扩展名的问题
+    for (const QString &filter : newNameFilters) {   // 从扩展名列表中轮询，目前发现的应用程序传入扩展名列表均只有一个
+        newNameFilterExtension = db->suffixForFileName(filter);   // 在QMimeDataBase里面查询扩展名是否存在（不能查询正则表达式）
+        if (newNameFilterExtension.isEmpty()) {   // 未查询到扩展名用正则表达式再查一次，新加部分，解决WPS保存文件去掉扩展名后没有补上扩展名的问题
             QRegularExpression regExp(QRegularExpression::wildcardToRegularExpression(filter.mid(2)),
                                       QRegularExpression::CaseInsensitiveOption);
             fmInfo() << "File Dialog: Cannot find extesion name by QMimeDataBase::suffixForFileName，try regexp: " << filter;
@@ -150,18 +141,18 @@ QString CoreHelper::findExtensionName(const QString &fileName, const QStringList
                     if (regExp.match("^" + suffixe + "$").hasMatch()) {
                         newNameFilterExtension = suffixe;
                         fmInfo() << "Find extesion name by regexp: " << suffixe;
-                        break;   //查询到后跳出循环
+                        break;   // 查询到后跳出循环
                     }
                 }
                 if (!newNameFilterExtension.isEmpty()) {
-                    break;   //查询到后跳出循环
+                    break;   // 查询到后跳出循环
                 }
             }
         }
 
         QRegularExpression re(QRegularExpression::wildcardToRegularExpression(newNameFilterExtension),
                               QRegularExpression::CaseInsensitiveOption);
-        if (re.match("^" + fileNameExtension + "$").hasMatch()) {   //原扩展名与新扩展名不匹配？
+        if (re.match("^" + fileNameExtension + "$").hasMatch()) {   // 原扩展名与新扩展名不匹配？
             fmInfo() << "Set new filter rules:" << newNameFilters;
             // TODO(liuyangming):
             // getFileView()->setNameFilters(newNameFilters); //这里传递回去的有可能是一个正则表达式，它决定哪些文件不被置灰

--- a/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
@@ -8,6 +8,7 @@
 
 #include <dfm-base/utils/dialogmanager.h>
 
+#include <DDialog>
 #include <DFontSizeManager>
 #include <DSpinner>
 
@@ -387,8 +388,18 @@ void ResetPasswordByKeyFileView::onResetPasswordFinished()
         // 密码重置成功，恢复错误次数限制和等待时间
         VaultDBusUtils::restoreLeftoverErrorInputTimes();
         VaultDBusUtils::restoreNeedWaitMinutes();
-        DialogManager::instance()->showMessageDialog(tr("Success"), tr("Password reset successfully"));
+        // 先关闭重置密码对话框（退出外层模态事件循环），避免嵌套 exec 导致合成器不映射提示窗口
         emit sigCloseDialog();
+        // 再用非阻塞方式弹出成功提示，不依赖 qApp->activeWindow()，避免异步回调中 activeWindow 为空
+        DDialog *msgDlg = new DDialog(tr("Success"), tr("Password reset successfully"));
+        msgDlg->setAttribute(Qt::WA_DeleteOnClose);
+        msgDlg->addButtons(QStringList { QObject::tr("Confirm", "button") });
+        msgDlg->setDefaultButton(0);
+        msgDlg->setIcon(QIcon::fromTheme("dde-file-manager"));
+        msgDlg->moveToCenter();
+        msgDlg->show();
+        msgDlg->raise();
+        msgDlg->activateWindow();
     } else {
         keyFileEdit->setAlert(true);
         keyFileEdit->showAlertMessage(tr("Failed to reset password. Please check your key file."), kToolTipShowDuration);

--- a/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
@@ -10,6 +10,7 @@
 
 #include <dfm-base/utils/dialogmanager.h>
 
+#include <DDialog>
 #include <DFontSizeManager>
 #include <DSpinner>
 
@@ -280,8 +281,8 @@ bool ResetPasswordByOldPasswordView::checkRepeatPassword()
 bool ResetPasswordByOldPasswordView::checkInputInfo()
 {
     return !oldPasswordEdit->text().isEmpty()
-           && checkPassword(newPasswordEdit->text())
-           && checkRepeatPassword();
+            && checkPassword(newPasswordEdit->text())
+            && checkRepeatPassword();
 }
 
 void ResetPasswordByOldPasswordView::showEvent(QShowEvent *event)
@@ -350,8 +351,18 @@ void ResetPasswordByOldPasswordView::onResetPasswordFinished()
         // 密码重置成功，恢复错误次数限制
         VaultDBusUtils::restoreLeftoverErrorInputTimes();
         VaultDBusUtils::restoreNeedWaitMinutes();
-        DialogManager::instance()->showMessageDialog(tr("Success"), tr("Password reset successfully"));
+        // 先关闭重置密码对话框（退出外层模态事件循环），避免嵌套 exec 导致合成器不映射提示窗口
         emit sigCloseDialog();
+        // 再用非阻塞方式弹出成功提示，不依赖 qApp->activeWindow()，避免异步回调中 activeWindow 为空
+        DDialog *msgDlg = new DDialog(tr("Success"), tr("Password reset successfully"));
+        msgDlg->setAttribute(Qt::WA_DeleteOnClose);
+        msgDlg->addButtons(QStringList { QObject::tr("Confirm", "button") });
+        msgDlg->setDefaultButton(0);
+        msgDlg->setIcon(QIcon::fromTheme("dde-file-manager"));
+        msgDlg->moveToCenter();
+        msgDlg->show();
+        msgDlg->raise();
+        msgDlg->activateWindow();
     } else {
         // 重置失败
         oldPasswordEdit->setAlert(true);


### PR DESCRIPTION
1. Removed redundant DXCB and Wayland window modality check code that's
no longer needed in CoreHelper
2. Improved Chinese code comments formatting with proper spacing around
comments
3. Fixed password reset dialog handling in vault module to avoid nested
modal dialogs
4. Modified success dialog to show non-blocking message after closing
the main dialog
5. Adjusted code formatting for better readability in password check
conditions

Log: Improved vault password reset dialog shows success message after
closing the dialog

Influence:
1. Test vault password reset flow with both old password and key file
methods
2. Verify successful password reset shows proper non-blocking success
dialog
3. Check dialog behavior under both X11 and Wayland environments
4. Test with incorrect passwords to ensure error messages display
correctly
5. Validate password input validation logic for new/old passwords

fix: 改进密码重置对话框处理

1. 移除CoreHelper中不再需要的DXCB和Wayland窗口模态检查代码
2. 改进中文代码注释格式，添加适当的注释空格
3. 修复保险柜模块密码重置对话框处理，避免嵌套模态对话框
4. 修改成功对话框在主对话框关闭后显示非阻塞消息
5. 调整密码检查条件代码格式以提高可读性

Log: 改进保险柜密码重置功能，在关闭对话框后显示成功提示

Influence:
1. 测试使用旧密码和密钥文件两种方式的密码重置流程
2. 验证成功密码重置后正确显示非阻塞成功对话框
3. 检查在X11和Wayland环境下的对话框行为
4. 测试错误密码输入确保正确显示错误信息
5. 验证新旧密码输入验证逻辑

Fixes: #367913

## Summary by Sourcery

Improve vault password reset success dialog behavior to avoid nested modal dialogs and ensure reliable display.

Bug Fixes:
- Prevent nested modal dialogs when completing vault password reset by closing the main dialog before showing the success message.

Enhancements:
- Show the vault password reset success message using a non-blocking dialog independent of the active window.
- Remove obsolete DXCB/Wayland window modality handling in CoreHelper.
- Clean up Chinese inline comments spacing in CoreHelper and adjust password validation condition formatting for readability.