### PR TITLE
fix(workspace): use removeWidget instead of takeAt to prevent QWidget…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -96,7 +96,7 @@ void FileViewPrivate::initIconModeView()
         if (headerView) {
             headerView->disconnect();
             auto headerLayout = qobject_cast<QVBoxLayout *>(headerWidget->layout());
-            headerLayout->takeAt(0);
+            headerLayout->removeWidget(headerView);
             headerView->deleteLater();
             headerView = nullptr;
             fmDebug() << "Header view removed for icon mode";


### PR DESCRIPTION
…Item leak

headerLayout->takeAt(0) removes the QLayoutItem from the layout but discards the return value without deleting it, leaking the QWidgetItemV2 (88 bytes per item) allocated during addWidget(headerView) via QLayoutPrivate::createWidgetItem.

Use removeWidget(headerView) which properly removes the widget from the layout and deletes the associated QWidgetItem.

Log: Fixed 88-byte QWidgetItem leak by using removeWidget over takeAt.

Assisted-by: deepseek-v4-pro

Influence:
1. Verify no QLayoutPrivate::createWidgetItem leak under Valgrind
2. Test list mode <-> icon mode switching does not regress header display
3. Test rapid view mode switching does not accumulate leaks

fix(workspace): 使用 removeWidget 替换 takeAt 防止 QWidgetItem 泄露

headerLayout->takeAt(0) 从布局中移除了 QLayoutItem 但丢弃了返回值 未释放，导致 addWidget(headerView) 时通过 QLayoutPrivate::createWidgetItem 分配的 QWidgetItemV2（每个 88 字节）泄露。

改用 removeWidget(headerView)，正确移除 widget 并释放关联的 QWidgetItem。

Log: 通过 removeWidget 替换 takeAt 修复 88 字节 QWidgetItem 泄露。

Influence:
1. Valgrind 下验证无 QLayoutPrivate::createWidgetItem 泄露
2. 测试列表模式 ↔ 图标模式切换不影响表头显示
3. 测试快速视图模式切换不累积泄露

Change-Id: If64a3d6888a996cb151e8e03322c5ad52ac24c10

## Summary by Sourcery

Bug Fixes:
- Fix memory leak caused by discarding QLayoutItem when removing the header view from the workspace layout.