### PR TITLE
chore: bump version to 6.5.148

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-file-manager (6.5.148) unstable; urgency=medium
+
+  * refactor: enhance device mount point management
+  * fix: improve vault password reset reliability
+  * Fix: [vault] Unlock vault crash.
+  * Fix: [Vault] Add translate
+  * fix(workspace): use removeWidget instead of takeAt to prevent QWidgetItem leak
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Mon, 29 Jun 2026 17:29:32 +0800
+
 dde-file-manager (6.5.147) unstable; urgency=medium
 
   * refactor: optimize file scanner path handling


### PR DESCRIPTION
6.5.148

Log:

## Summary by Sourcery

Build:
- Update Debian changelog to reflect version 6.5.148 release.