### PR TITLE
chore: bump version to 6.5.149

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.149) unstable; urgency=medium
+
+  * Fix(computer): Rollback code
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Mon, 29 Jun 2026 23:11:18 +0800
+
 dde-file-manager (6.5.148) unstable; urgency=medium
 
   * refactor: enhance device mount point management


### PR DESCRIPTION
6.5.149

Log:

## Summary by Sourcery

Bump project version metadata to 6.5.149.

Build:
- Update Debian packaging changelog to reflect version 6.5.149.

Chores:
- Align release notes/changelog with the 6.5.149 version bump.