### PR TITLE
fix(workspace): parent CustomTopWidgetInterface to prevent leak

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/workspacepage.cpp
@@ -189,6 +189,10 @@ void WorkspacePage::setCustomTopWidgetVisible(const QString &scheme, bool visibl
             TopWidgetPtr topWidgetPtr = QSharedPointer<QWidget>(interface->create(this));
             if (topWidgetPtr) {
                 bool keepTop = interface->isKeepTop();
+                // Transfer ownership: interface was created without a parent
+                // (workspaceeventreceiver.cpp:411), parent it to the top widget
+                // so it is destroyed automatically when the top widget is removed.
+                interface->setParent(topWidgetPtr.get());
                 int insertIndex = 0;
                 if (keepTop) {
                     ++highPriorityTopWidgetsCount;
@@ -199,6 +203,9 @@ void WorkspacePage::setCustomTopWidgetVisible(const QString &scheme, bool visibl
                 topWidgets.insert(scheme, topWidgetPtr);
                 topWidgetPtr->setVisible(visible);
                 fmDebug() << "setCustomTopWidgetVisible: new topWidget created and set visible";
+            } else {
+                // interface is owned by nobody if create() fails
+                delete interface;
             }
         }
     }


### PR DESCRIPTION
CustomTopWidgetInterface is created via `new` without a parent QObject (workspaceeventreceiver.cpp:411) and never deleted after use in setCustomTopWidgetVisible(), leaking 208 bytes (88 direct + 120 indirect).

Parent the interface to the created top widget so Qt's ownership tree cleans it up automatically.  Handle the create() failure path with an explicit delete.

Log: Fixed 208-byte CustomTopWidgetInterface leak by parenting to top widget.

Influence:
1. Verify no CustomTopWidgetInterface leak under Valgrind
2. Test search bar show/hide does not regress
3. Test custom top widget (e.g. advanced search bar) lifecycle

fix(workspace): 将 CustomTopWidgetInterface 挂父对象防止泄露

CustomTopWidgetInterface 通过 `new` 创建时无父 QObject
(workspaceeventreceiver.cpp:411)，在 setCustomTopWidgetVisible() 中 使用后从未释放，泄露 208 字节（88 直接 + 120 间接）。

将 interface 挂到创建的 top widget 上，利用 Qt 父子树自动释放。
create() 失败时显式 delete 处理。

Log: 通过挂父对象修复 208 字节 CustomTopWidgetInterface 泄露。

Influence:
1. Valgrind 下验证无 CustomTopWidgetInterface 泄露
2. 测试搜索栏显示/隐藏无回归
3. 测试自定义顶部组件（如高级搜索栏）生命周期

Change-Id: I22a9d3e3bf9fd5778127d91db652af33ab190a62

## Summary by Sourcery

Bug Fixes:
- Prevent leaking CustomTopWidgetInterface instances by parenting them to the created top widget and explicitly deleting them when widget creation fails.