### PR TITLE
fix: adjust file size label display in conflict dialog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-file-manager (6.5.150) unstable; urgency=medium
+
+  * fix(workspace): parent CustomTopWidgetInterface to prevent leak
+  * fix: adjust file size label display in conflict dialog
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 30 Jun 2026 10:57:43 +0800
+
 dde-file-manager (6.5.149) unstable; urgency=medium
 
   * Fix(computer): Rollback code

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -482,8 +482,8 @@ QWidget *TaskWidget::createConflictWidget()
     lbSrcModTime->setPalette(labelPalette);
 
     lbSrcFileSize = new DLabel();
-    lbSrcFileSize->setElideMode(Qt::ElideMiddle);
-    lbSrcFileSize->setFixedWidth(kFileSizeWidth);
+    lbSrcFileSize->setElideMode(Qt::ElideNone);
+    lbSrcFileSize->setMinimumWidth(kFileSizeWidth);
     lbSrcFileSize->setPalette(labelPalette);
 
     lbDstIcon = new IconUtils::IconLabel();
@@ -497,8 +497,8 @@ QWidget *TaskWidget::createConflictWidget()
     lbDstModTime->setPalette(labelPalette);
 
     lbDstFileSize = new DLabel();
-    lbDstFileSize->setElideMode(Qt::ElideMiddle);
-    lbDstFileSize->setFixedWidth(kFileSizeWidth);
+    lbDstFileSize->setElideMode(Qt::ElideNone);
+    lbDstFileSize->setMinimumWidth(kFileSizeWidth);
     lbDstFileSize->setPalette(labelPalette);
 
     QGridLayout *conflictMainLayout = new QGridLayout();


### PR DESCRIPTION
1. Changed file size labels in conflict dialog from EllipseMiddle to
None for elide mode
2. Replaced fixed width with minimum width to allow dynamic sizing
3. These changes improve readability of full file size information in
conflict dialogs

Log: File sizes are now displayed in full without truncation in conflict
dialogs

Influence:
1. Verify file sizes display fully in conflict dialogs
2. Test with various file size lengths to ensure proper dynamic sizing
3. Check UI layout stability with different file sizes

fix: 调整冲突对话框中文件大小标签的显示

1. 将冲突对话框中文件大小标签的省略模式从EllipseMiddle改为None
2. 将固定宽度改为最小宽度以支持动态调整大小
3. 这些改动提高了冲突对话框中完整文件大小信息的可读性

Log: 冲突对话框中的文件大小现在会完整显示而不会被截断

Influence:
1. 验证冲突对话框中文件大小能否完整显示
2. 测试不同长度的文件大小以确保动态调整正常
3. 检查不同文件大小情况下UI布局的稳定性

Fixes: #368023

## Summary by Sourcery

Bug Fixes:
- Prevent file size labels in conflict dialogs from being truncated by disabling text elision and using minimum width instead of fixed width.