### PR TITLE
refactor: replace thread termination with _exit for clean shutdown

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailfactory.cpp
@@ -4,7 +4,6 @@
 
 #include "thumbnailfactory.h"
 #include "thumbnailcreators.h"
-#include "thumbnailhelper.h"
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
@@ -12,6 +11,8 @@
 #include <dfm-base/base/device/deviceproxymanager.h>
 
 #include <QGuiApplication>
+
+#include <unistd.h>
 
 using namespace dfmbase;
 DFMGLOBAL_USE_NAMESPACE
@@ -99,8 +100,7 @@ void ThumbnailFactory::onAboutToQuit()
     bool finished = thread->wait(3000);
     if (!finished) {
         qCWarning(logDFMBase) << "thumbnail: worker thread did not finish within 3 seconds, forcing termination";
-        thread->terminate();
-        thread->wait(1000);
+        _exit(1);
     } else {
         qCInfo(logDFMBase) << "thumbnail: worker thread stopped gracefully";
     }

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.cpp
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/emblemimpl/extensionemblemmanager.cpp
@@ -14,6 +14,8 @@
 #include <QIcon>
 #include <QDir>
 
+#include <unistd.h>
+
 DPUTILS_BEGIN_NAMESPACE
 DFMBASE_USE_NAMESPACE
 
@@ -71,11 +73,11 @@ QIcon ExtensionEmblemManagerPrivate::makeIcon(const QString &path)
         if (QFile::exists(cleanPath)) {
             icon = QIcon(cleanPath);
             if (!icon.isNull()) {
-                iconCaches.insert(cleanPath, icon); // 使用原始 path 作为键，或者 cleanPath
+                iconCaches.insert(cleanPath, icon);   // 使用原始 path 作为键，或者 cleanPath
                 return icon;
             }
         } else {
-             fmWarning() << "Icon file does not exist:" << cleanPath;
+            fmWarning() << "Icon file does not exist:" << cleanPath;
         }
     } else {
         // 如果不是绝对路径，且 fromTheme 失败，可能是相对路径或无效路径
@@ -412,14 +414,13 @@ ExtensionEmblemManager::~ExtensionEmblemManager()
 
     // 停止定时器
     d->readyTimer.stop();
-    
+
     // 确保工作线程正确退出
     if (d->workerThread.isRunning()) {
         d->workerThread.quit();
         if (!d->workerThread.wait(3000)) {
             fmWarning() << "ExtensionEmblemManager: Worker thread did not exit within 3 seconds, forcing termination";
-            d->workerThread.terminate();
-            d->workerThread.wait(1000);
+            _exit(1);
         }
     }
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -77,8 +77,7 @@ FileViewModel::~FileViewModel()
                 thread->quit();
                 if (!thread->wait(1000)) {
                     fmWarning() << "Force terminating discarded thread in destructor";
-                    thread->terminate();
-                    thread->wait(500);
+                    _exit(1);
                 }
             }
         }
@@ -1364,10 +1363,7 @@ void FileViewModel::quitFilterSortWork()
         // 等待线程优雅退出，增加超时处理
         if (!filterSortThread->wait(3000)) {
             fmWarning() << "FilterSortThread did not exit within 3 seconds, forcing termination for URL:" << dirRootUrl.toString();
-            filterSortThread->terminate();
-            if (!filterSortThread->wait(1000)) {
-                fmWarning() << "FilterSortThread termination failed, potential resource leak for URL:" << dirRootUrl.toString();
-            }
+            _exit(1);
         }
     }
 


### PR DESCRIPTION
Changed thread termination method from QThread::terminate() to _exit(1)
in multiple files to ensure clean shutdown when worker threads don't
respond. This avoids potential resource leaks and provides guaranteed
process termination when threads hang beyond timeout.

Influence:
1. Test application shutdown with and without running worker threads
2. Verify resources are properly released on forced termination
3. Check for any unintended side effects in dependent components
4. Monitor system resources after forced shutdown scenarios

refactor: 使用_exit替代线程终止方式以实现干净关闭

在多处文件中将线程终止方式从QThread::terminate()改为_exit(1)，确保工作线
程无响应时的干净关闭。这避免了潜在的资源泄漏并在线程超时挂起时提供强制进
程终止。

Influence:
1. 测试应用在有无工作线程时的关闭情况
2. 验证强制终止时资源是否正确释放
3. 检查对所依赖组件是否有意外副作用
4. 监控强制关闭场景后的系统资源情况

## Summary by Sourcery

Replace unsafe QThread forced termination with process-level _exit for hung worker threads during shutdown.

Bug Fixes:
- Ensure deterministic process shutdown when worker threads fail to exit within the configured timeout.

Enhancements:
- Simplify thread shutdown paths in emblem management, file view model, and thumbnail factory to avoid potential resource leaks on hang.
- Remove unused thumbnail helper include and perform minor logging/formatting cleanups.