### PR TITLE
 修复 EmblemHelper 退出时 GioEmblemWorker 内存泄漏

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -204,6 +204,8 @@ EmblemHelper::~EmblemHelper()
 {
     workerThread.quit();
     workerThread.wait();
+    delete worker;
+    worker = nullptr;
 }
 
 QList<QIcon> EmblemHelper::systemEmblems(const FileInfoPointer &info) const
@@ -322,7 +324,6 @@ void EmblemHelper::initialize()
     dpfSignalDispatcher->installEventFilter(GlobalEventType::kChangeCurrentUrl, this, &EmblemHelper::onUrlChanged);
 
     worker->moveToThread(&workerThread);
-    connect(&workerThread, &QThread::finished, worker, &QObject::deleteLater);
     connect(this, &EmblemHelper::requestProduce, worker, &GioEmblemWorker::onProduce, Qt::QueuedConnection);
     connect(this, &EmblemHelper::requestClear, worker, &GioEmblemWorker::onClear, Qt::QueuedConnection);
     connect(worker, &GioEmblemWorker::emblemChanged, this, &EmblemHelper::onEmblemChanged, Qt::QueuedConnection);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
@@ -55,7 +55,7 @@ void RenameBarPrivate::initUI()
     customOPeratorItems = std::make_tuple(new QLabel, new QLineEdit, new QLabel, new QLineEdit, new QLabel);
     frameForLayoutCustomArea = QPair<QHBoxLayout *, QFrame *> { new QHBoxLayout, new QFrame };
 
-    buttonsArea = std::make_tuple(new QPushButton, new QPushButton, new QHBoxLayout, new QFrame);
+    buttonsArea = std::make_tuple(new QPushButton, new QHBoxLayout, new QFrame);
 
     fmDebug() << "UI components created - replace, add, custom areas and buttons";
 }
@@ -198,10 +198,10 @@ void RenameBarPrivate::layoutItems() noexcept
 
     fmDebug() << "Custom area layout configured";
 
-    hBoxLayout = std::get<2>(buttonsArea);
+    hBoxLayout = std::get<1>(buttonsArea);
     hBoxLayout->setSpacing(0);
     hBoxLayout->setContentsMargins(0, 0, 0, 0);
-    frame = std::get<3>(buttonsArea);
+    frame = std::get<2>(buttonsArea);
     hBoxLayout->addSpacing(50);
     hBoxLayout->addWidget(std::get<0>(buttonsArea));
     hBoxLayout->addSpacing(10);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.h
@@ -82,7 +82,7 @@ public:
     QPair<QHBoxLayout *, QFrame *> frameForLayoutCustomArea {};
     QRegularExpressionValidator *validator { nullptr };
 
-    DTuple<QPushButton *, QPushButton *, QHBoxLayout *, QFrame *> buttonsArea {};
+    DTuple<QPushButton *, QHBoxLayout *, QFrame *> buttonsArea {};
 
     DSuggestButton *renameBtn { nullptr };
     bool connectInitOnce { false };

--- a/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/renamebar.cpp
@@ -135,9 +135,7 @@ void RenameBar::onRenamePatternChanged(const int &index) noexcept
     d->currentPattern = static_cast<RenameBarPrivate::RenamePattern>(index);
     fmDebug() << "RenameBar pattern changed to index:" << index;
 
-    bool state { d->renameButtonStates[static_cast<std::size_t>(index)] };   //###: we get the value of state of button in current mode.
     d->stackWidget->setCurrentIndex(index);
-    std::get<1>(d->buttonsArea)->setEnabled(state);
 
     ///###: here, call a slot, this function will set focus of QLineEdit in current mode.
     this->onVisibleChanged(true);


### PR DESCRIPTION
1.  修复 EmblemHelper 退出时 GioEmblemWorker 内存泄漏；
2. 删除 renamebar buttonsArea 中未使用的 QPushButton

## Summary by Sourcery

Fix memory leak in emblem helper and clean up unused UI elements in the rename bar.

Bug Fixes:
- Ensure GioEmblemWorker is explicitly deleted when EmblemHelper is destroyed to prevent a memory leak.
- Correct buttonsArea tuple usage indices after removing an unused QPushButton in the rename bar UI configuration.

Enhancements:
- Remove an unused QPushButton from the rename bar buttons area to simplify the UI structure.