### PR TITLE
fix: handle re-encryption failure properly and prevent premature dialog deletion

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -305,7 +305,8 @@ void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
             encryptInputs.take(devPath)->deleteLater();   // also will be deleted when encryption started.
         } else {
             fmInfo() << "User provided auth input for device:" << devPath << "proceeding with re-encryption";
-            DiskEncryptMenuScene::doReencryptDevice(dlg->getInputs());
+            if (!DiskEncryptMenuScene::doReencryptDevice(dlg->getInputs()) && encryptInputs.contains(devPath))
+                encryptInputs.take(devPath)->deleteLater();
         }
     });
     dlg->show();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -27,6 +27,7 @@ public:
     QString holderDevice(const QString &device);
     bool onAcquireDevicePwd(const QString &dev, QString *pwd, bool *giveup);
     void setAutoStartDFM(bool enable);
+    void ignoreParamRequest();
 
 private Q_SLOTS:
     void onEncryptProgress(const QString &, const QString &, double);
@@ -37,8 +38,6 @@ private Q_SLOTS:
     void onChgPwdFinished(const QVariantMap &);
     void onRequestAuthArgs(const QVariantMap &);
     void onOverlayDMModeChanged(bool enabled, int result);
-
-    void ignoreParamRequest();
 
     QString acquirePassphrase(const QString &dev, bool &cancelled);
     QString acquirePassphraseByPIN(const QString &dev, bool &cancelled);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -414,7 +414,7 @@ void DiskEncryptMenuScene::doEncryptDevice(const DeviceEncryptParam &param)
     }
 }
 
-void DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
+bool DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
 {
     // if tpm selected, use tpm to generate the key
     QString tpmToken;
@@ -423,15 +423,22 @@ void DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
         QString configPath = tpm_passphrase_utils::getGlobalTPMConfigPath();
         if (configPath.isEmpty()) {
             qCritical() << "Failed to create tpm config path";
-            return;
+            EventsHandler::instance()->ignoreParamRequest();
+            return false;
         }
         tpmToken = generateTPMToken(param.devDesc, param.secType == kPin, configPath);
+        if (tpmToken.isEmpty()) {
+            fmCritical() << "Failed to generate TPM token for re-encryption, device:" << param.devDesc;
+            EventsHandler::instance()->ignoreParamRequest();
+            return false;
+        }
     }
 
     CREATE_DAEMON_INTERFACE(iface);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for SetupAuthArgs, service may be unavailable";
-        return;
+        EventsHandler::instance()->ignoreParamRequest();
+        return false;
     }
 
     // Prepare credentials data
@@ -447,7 +454,11 @@ void DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
     fmDebug() << "Starting device re-encryption via fd";
     if (sendCredentialsViaFd(iface, "SetupAuthArgs", params, true)) {
         QApplication::setOverrideCursor(Qt::WaitCursor);
+        return true;
     }
+
+    EventsHandler::instance()->ignoreParamRequest();
+    return false;
 }
 
 void DiskEncryptMenuScene::doDecryptDevice(const DeviceEncryptParam &param)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
@@ -45,7 +45,7 @@ public:
     virtual bool triggered(QAction *action) override;
     virtual void updateState(QMenu *parent) override;
 
-    static void doReencryptDevice(const disk_encrypt::DeviceEncryptParam &param);
+    static bool doReencryptDevice(const disk_encrypt::DeviceEncryptParam &param);
 
 protected:
     static void encryptDevice(const disk_encrypt::DeviceEncryptParam &param);


### PR DESCRIPTION
1. Change doReencryptDevice to return bool indicating success/failure
2. In eventshandler, only delete the auth input dialog on failure (when
doReencryptDevice returns false)
3. On failure paths (TPM config missing, token generation failure, DBus
invalid, credential send failure), call ignoreParamRequest to clean up
and return false
4. Previously, the dialog was always deleted immediately after calling
doReencryptDevice, even on success, causing potential double deletion or
missing state

Log: Fix re-encryption dialog being destroyed before operation completes

Influence:
1. Test re-encryption with TPM: verify dialog remains open on success,
closes on failure
2. Test re-encryption with passphrase: verify same behavior
3. Test aborting re-encryption mid-way: verify dialog cleanup
4. Verify error handling for invalid TPM config
5. Verify no crash or double deletion in all failure scenarios

fix: 正确处理重新加密失败的情况，防止对话框过早删除

1. 将 doReencryptDevice 返回值改为 bool 类型表示成功/失败
2. 在 eventshandler 中，仅在重新加密失败时删除认证输入对话框
3. 在失败路径（TPM 配置缺失、令牌生成失败、DBus 无效、凭据发送失败）中，
调用 ignoreParamRequest 进行清理并返回 false
4. 此前，对话框总是在调用 doReencryptDevice 后立即删除，即使操作成功，可
能导致重复删除或状态丢失

Log: 修复重新加密对话框在操作完成前被销毁的问题

Influence:
1. 测试使用 TPM 重新加密：验证操作成功时对话框保持打开，失败时关闭
2. 测试使用密码重新加密：验证同样行为
3. 测试中途取消重新加密：验证对话框清理
4. 验证无效 TPM 配置时的错误处理
5. 验证所有失败场景下无崩溃或重复删除
