### PR TITLE
fix: 修复恢复加密认证提交失败问题

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.DiskEncrypt.xml
+++ b/assets/dbus/org.deepin.Filemanager.DiskEncrypt.xml
@@ -54,6 +54,7 @@
       <arg name="credentialsFd" type="h" direction="in"/>
     </method>
     <method name="SetupAuthArgs">
+      <arg type="b" direction="out"/>
       <arg name="credentialsFd" type="h" direction="in"/>
     </method>
     <method name="IgnoreAuthSetup">

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -305,7 +305,11 @@ void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
             encryptInputs.take(devPath)->deleteLater();   // also will be deleted when encryption started.
         } else {
             fmInfo() << "User provided auth input for device:" << devPath << "proceeding with re-encryption";
-            DiskEncryptMenuScene::doReencryptDevice(dlg->getInputs());
+            if (!DiskEncryptMenuScene::doReencryptDevice(dlg->getInputs())) {
+                ignoreParamRequest();
+                if (encryptInputs.contains(devPath))
+                    encryptInputs.take(devPath)->deleteLater();
+            }
         }
     });
     dlg->show();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -414,7 +414,7 @@ void DiskEncryptMenuScene::doEncryptDevice(const DeviceEncryptParam &param)
     }
 }
 
-void DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
+bool DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
 {
     // if tpm selected, use tpm to generate the key
     QString tpmToken;
@@ -423,15 +423,23 @@ void DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
         QString configPath = tpm_passphrase_utils::getGlobalTPMConfigPath();
         if (configPath.isEmpty()) {
             qCritical() << "Failed to create tpm config path";
-            return;
+            dialog_utils::showDialog(tr("Re-encryption failed"),
+                                     tr("Failed to get TPM information. Please check whether TPM is available."));
+            return false;
         }
         tpmToken = generateTPMToken(param.devDesc, param.secType == kPin, configPath);
+        if (tpmToken.isEmpty()) {
+            fmCritical() << "Failed to generate TPM token for re-encryption, device:" << param.devDesc;
+            dialog_utils::showDialog(tr("Re-encryption failed"),
+                                     tr("Failed to get TPM information. Please check whether TPM is available."));
+            return false;
+        }
     }
 
     CREATE_DAEMON_INTERFACE(iface);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for SetupAuthArgs, service may be unavailable";
-        return;
+        return false;
     }
 
     // Prepare credentials data
@@ -445,9 +453,14 @@ void DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
 
     // Send credentials via fd
     fmDebug() << "Starting device re-encryption via fd";
-    if (sendCredentialsViaFd(iface, "SetupAuthArgs", params, true)) {
+    // SetupAuthArgs waits for Polkit authentication; keep the call alive while the user authorizes.
+    iface.setTimeout(120000);
+    if (sendCredentialsViaFd(iface, "SetupAuthArgs", params, false)) {
         QApplication::setOverrideCursor(Qt::WaitCursor);
+        return true;
     }
+
+    return false;
 }
 
 void DiskEncryptMenuScene::doDecryptDevice(const DeviceEncryptParam &param)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.h
@@ -45,7 +45,7 @@ public:
     virtual bool triggered(QAction *action) override;
     virtual void updateState(QMenu *parent) override;
 
-    static void doReencryptDevice(const disk_encrypt::DeviceEncryptParam &param);
+    static bool doReencryptDevice(const disk_encrypt::DeviceEncryptParam &param);
 
 protected:
     static void encryptDevice(const disk_encrypt::DeviceEncryptParam &param);

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -187,24 +187,25 @@ bool DiskEncryptSetup::ChangePassphrase(const QDBusUnixFileDescriptor &credentia
     return true;
 }
 
-void DiskEncryptSetup::SetupAuthArgs(const QDBusUnixFileDescriptor &credentialsFd)
+bool DiskEncryptSetup::SetupAuthArgs(const QDBusUnixFileDescriptor &credentialsFd)
 {
     qInfo() << "[DiskEncryptSetup::SetupAuthArgs] Setting up authentication arguments via fd";
 
     if (!m_dptr->checkAuth(kActionEncrypt)) {
         qWarning() << "[DiskEncryptSetup::SetupAuthArgs] Authentication failed for auth args setup";
-        return;
+        return false;
     }
 
     // Parse credentials from fd using common method
     QVariantMap args;
     if (!m_dptr->parseCredentialsFromFd(credentialsFd, &args)) {
         qCritical() << "[DiskEncryptSetup::SetupAuthArgs] Failed to parse credentials from fd";
-        return;
+        return false;
     }
 
     qInfo() << "[DiskEncryptSetup::SetupAuthArgs] Successfully parsed authentication arguments from fd";
     Q_EMIT NotificationHelper::instance()->replyAuthArgs(args);
+    return true;
 }
 
 void DiskEncryptSetup::IgnoreAuthSetup()

--- a/src/services/diskencrypt/dbus/diskencryptsetup.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.h
@@ -33,7 +33,7 @@ public Q_SLOTS:
     bool ResumeEncryption(const QVariantMap &args);
     bool Decryption(const QDBusUnixFileDescriptor &credentialsFd);
     bool ChangePassphrase(const QDBusUnixFileDescriptor &credentialsFd);
-    void SetupAuthArgs(const QDBusUnixFileDescriptor &credentialsFd);
+    bool SetupAuthArgs(const QDBusUnixFileDescriptor &credentialsFd);
     void IgnoreAuthSetup();
 
     QString TpmToken(const QString &dev);


### PR DESCRIPTION
## 变更说明
1. 将 SetupAuthArgs 接口改为返回布尔结果，明确认证参数是否提交成功。
2. 将恢复加密认证参数提交改为同步调用，避免 headless 进程在 Polkit 鉴权前退出。
3. 为 SetupAuthArgs 调用设置较长 DBus 超时时间，覆盖用户完成授权的等待过程。
4. 在认证参数提交失败时通知服务端忽略请求并清理输入对话框。
5. 同步更新 DiskEncrypt DBus XML 接口描述。

## 问题原因
安全加固后 SetupAuthArgs 增加 Polkit 鉴权。headless 模式下密钥输入框关闭后文管进程可能退出，导致 Polkit 最终鉴权时 caller 不合法并返回 NO，认证参数无法提交给恢复加密 worker。

## 验证
- 已完成本地 rebase 到 deepin/master 最新代码。
- 未执行构建验证。

Bug: https://pms.uniontech.com/bug-view-368167.html

## Summary by Sourcery

Ensure re-encryption authentication parameters are submitted synchronously and report their success or failure over DBus.

Bug Fixes:
- Prevent headless re-encryption from failing when Polkit authorization outlives the file manager process by making SetupAuthArgs synchronous and result-bearing.
- Handle TPM configuration and token generation failures during re-encryption by surfacing user-facing error dialogs instead of silently aborting.

Enhancements:
- Return a boolean result from SetupAuthArgs and its caller to clearly indicate whether authentication arguments were successfully submitted.
- Extend the DBus timeout for SetupAuthArgs so the caller can wait while the user completes Polkit authorization.
- Notify the service to ignore and clean up pending auth setups when authentication argument submission fails.

Documentation:
- Update the DiskEncrypt DBus XML definition to document the boolean return value of SetupAuthArgs.