### PR TITLE
fix(computer): show detail text with progress

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -446,6 +446,7 @@ void ComputerItemDelegate::drawDeviceDetail(QPainter *painter, const QStyleOptio
     bool totalSizeVisiable = index.data(ComputerModel::kTotalSizeVisiableRole).toBool();
     bool usedSizeVisiable = index.data(ComputerModel::kUsedSizeVisiableRole).toBool();
     bool showSize = totalSizeVisiable || usedSizeVisiable;
+    QString detailText;
     if (showSize) {
         sizeUsage = index.data(ComputerModel::kSizeUsageRole).toLongLong();
         sizeTotal = index.data(ComputerModel::kSizeTotalRole).toLongLong();
@@ -455,13 +456,17 @@ void ComputerItemDelegate::drawDeviceDetail(QPainter *painter, const QStyleOptio
         }
         auto usage = DFMBASE_NAMESPACE::FileUtils::formatSize(sizeUsage);
         auto total = DFMBASE_NAMESPACE::FileUtils::formatSize(sizeTotal);
-        QString sizeText;
         if (totalSizeVisiable && usedSizeVisiable)
-            sizeText = QString("%1/%2").arg(usage).arg(total);
+            detailText = QString("%1/%2").arg(usage).arg(total);
         else
-            sizeText = total;
-        painter->drawText(detailRect, Qt::AlignLeft, sizeText);
+            detailText = total;
+    } else {
+        detailText = index.data(ComputerModel::kDeviceDescriptionRole).toString();
     }
+
+    // Detail text shares one line: capacity when logged in, description when not logged in.
+    if (!detailText.isEmpty())
+        painter->drawText(detailRect, Qt::AlignLeft, detailText);
 
     // paint progress bar
     bool progressVisiable = index.data(ComputerModel::kProgressVisiableRole).toBool();
@@ -513,11 +518,6 @@ void ComputerItemDelegate::drawDeviceDetail(QPainter *painter, const QStyleOptio
             painter->setBrush(grad);
             painter->drawRoundedRect(usedRect, 3, 3);
         }
-    }
-
-    QString deviceDescription = index.data(ComputerModel::kDeviceDescriptionRole).toString();
-    if (!showSize && !progressVisiable && !deviceDescription.isEmpty()) {
-        painter->drawText(detailRect, Qt::AlignLeft, deviceDescription);
     }
 }
 


### PR DESCRIPTION
fix(computer): show detail text with progress

1. Keep the detail text visible when the device item also shows a progress bar.
2. Unify size text and device description into a shared detail line for login and non-login states.
3. Preserve the progress bar layout while clarifying that the detail text is drawn on the row above it.

Log: Show device detail text and progress bar together in computer items

fix(computer): 在显示进度条时保留详情文案

1. 在设备项显示进度条时仍然显示详情文案。
2. 将容量文本和设备描述统一到同一条详情行，覆盖登录和未登录两种状态。
3. 保持进度条布局不变，并明确详情文案绘制在其上方的独立文本行中。

Log: 修复 computer 设备项无法同时显示详情文案和进度条的问题
PMS: BUG-368763
