### PR TITLE
fix: remove xwechat_files from textindex exclusion list

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.textindex.json
+++ b/assets/configs/org.deepin.dde.file-manager.textindex.json
@@ -200,8 +200,7 @@
 				"lost+found",
 				"UnixBench",
 				"tmp",
-				"testdir",
-				"xwechat_files"
+				"testdir"
 			],
 			"serial": 0,
 			"flags": [],


### PR DESCRIPTION
1. Removed xwechat_files from the exclusion list in textindex
configuration
2. This allows file search functionality to index WeChat file
directories
3. Change was made to improve file discovery and search experience for
WeChat users
4. The exclusion list contained various system directories and test
directories, but xwechat_files was considered unnecessary for exclusion

Influence:
1. Test file search functionality with WeChat directories
2. Verify system performance with xwechat_files now being indexed
3. Check if any unexpected behavior occurs when indexing these files
4. Test overall search performance with this change

fix: 从文本索引排除列表中移除xwechat_files

1. 从文本索引配置的排除列表中移除了xwechat_files
2. 这允许文件搜索功能索引微信文件目录
3. 此项更改旨在改善微信用户的文件发现和搜索体验
4. 排除列表中包含各种系统目录和测试目录，但xwechat_files被认为不需要排除

Influence:
1. 测试针对微信目录的文件搜索功能
2. 验证系统在索引xwechat_files时的性能表现
3. 检查索引这些文件时是否会出现意外行为
4. 测试这项变更后的整体搜索性能

## Summary by Sourcery

New Features:
- Enable indexing and search of WeChat file directories by including xwechat_files in the text index scope.