### PR TITLE
fix: fix potential crash in FileView destructor

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -132,8 +132,11 @@ FileView::~FileView()
     }
 
     // 3. 断开信号连接
-    if (model()) {
-        disconnect(model(), nullptr, this, nullptr);
+    //    保存 model 指针: setModel(nullptr) 后 model() 返回 nullptr,
+    //    需在解绑前获取以便后续显式删除。
+    FileViewModel *savedModel = model();
+    if (savedModel) {
+        disconnect(savedModel, nullptr, this, nullptr);
     }
     if (selectionModel()) {
         disconnect(selectionModel(), nullptr, this, nullptr);
@@ -144,13 +147,22 @@ FileView::~FileView()
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 
-    // 5. 清理其他订阅
+    // 5. 显式删除 model: ~QAbstractItemModel() 会调用 invalidatePersistentIndexes(),
+    //    将所有残留 QPersistentModelIndex 的 model 指针置 null。
+    //    必须在 ~QObject() 子对象清理前执行,否则 headerView / selectionModel 等
+    //    子控件在 ~QObject() 中销毁时,其内部 QPersistentModelIndex 会访问已销毁
+    //    的 model 私有数据哈希表(removePersistentIndexData)而崩溃。
+    if (savedModel && savedModel->QObject::parent() == this) {
+        delete savedModel;
+    }
+
+    // 6. 清理其他订阅
     dpfSignalDispatcher->unsubscribe("dfmplugin_workspace", "signal_View_HeaderViewSectionChanged", this, &FileView::onHeaderViewSectionChanged);
     dpfSignalDispatcher->unsubscribe("dfmplugin_filepreview", "signal_ThumbnailDisplay_Changed", this, &FileView::onWidgetUpdate);
 
     fmDebug() << "FileView destruction completed";
 
-    // 注意: model 作为 FileView 的子对象,会在基类析构后由 Qt 自动释放
+    // model 已在步骤 5 显式删除,不会进入 ~QObject() 子对象清理流程
 }
 
 QWidget *FileView::widget() const


### PR DESCRIPTION
The change addresses a potential crash scenario in FileView's destructor
by ensuring proper model cleanup. The original code had issues where:
1. The model pointer could be lost when setModel(nullptr) was called
before cleanup
2. HeaderView and selectionModel could access already-destroyed model
data during Qt's internal cleanup process

Key modifications:
1. Save the model pointer before disconnection to ensure access after
setModel(nullptr)
2. Explicitly delete the model before Qt's object cleanup phase
3. Added detailed comments explaining the destruction sequence and crash
mechanism
4. Ensured model cleanup happens before Qt's parent-child destruction
sequence

This fix prevents crashes that could occur during application shutdown
when dealing with persistent model indexes and view components.

Log: Fixed potential crash in file view when closing windows

Influence:
1. Test application shutdown with multiple file views open
2. Verify no crashes occur when rapidly opening/closing file views
3. Check memory usage doesn't increase after view destruction
4. Verify all view-related connections are properly cleaned up

fix: 修复FileView析构函数中潜在的崩溃问题

本次变更通过确保正确的模型清理，解决了FileView析构函数中的潜在崩溃场景。
原代码存在以下问题：
1. 调用setModel(nullptr)后可能丢失模型指针
2. HeaderView和selectionModel可能在Qt内部清理过程中访问已销毁的模型数据

主要修改内容：
1. 在断开连接前保存模型指针，确保之后仍可访问
2. 在Qt对象清理阶段之前显式删除模型
3. 添加详细注释解释销毁顺序和崩溃机制
4. 确保模型清理发生在Qt父子对象销毁序列之前

这个修复可以防止在应用程序关闭时处理持久化模型索引和视图组件时可能发生的
崩溃。

Log: 修复关闭窗口时文件视图的潜在崩溃问题

Influence:
1. 测试打开多个文件视图时的应用程序关闭
2. 验证快速打开/关闭文件视图时不会崩溃
3. 检查视图销毁后内存使用不会增加
4. 验证所有视图相关连接都已正确清理

## Summary by Sourcery

Prevent crashes during FileView destruction by explicitly managing and deleting the view model before Qt's child object cleanup.

Bug Fixes:
- Ensure the FileView model is disconnected and explicitly deleted using a saved pointer to avoid accessing a destroyed model during Qt's cleanup sequence.

Enhancements:
- Clarify the FileView destruction sequence with comments explaining model and persistent index cleanup order.