### PR TITLE
feat: add match method grouping for search results

### DIFF
--- a/include/dfm-base/interfaces/abstractgroupstrategy.h
+++ b/include/dfm-base/interfaces/abstractgroupstrategy.h
@@ -7,6 +7,7 @@
 
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/interfaces/sortfileinfo.h>
 
 #include <QObject>
 #include <QString>
@@ -38,6 +39,26 @@ public:
      * @return The group key string that identifies which group this file belongs to
      */
     virtual QString getGroupKey(const FileInfoPointer &info) const = 0;
+
+    /**
+     * @brief Get the group key for a file item, with its SortFileInfo available
+     *
+     * Some grouping dimensions depend on data that lives on the SortFileInfo
+     * (e.g. search match type) rather than the FileInfo. The SortFileInfo is
+     * only carried through the data pipeline for the search scheme, so this
+     * overload is invoked when it is available; otherwise the basic overload
+     * is used. The default just delegates to the basic overload — existing
+     * strategies need not override this.
+     *
+     * @param info The file info to classify (always non-null)
+     * @param sortInfo The sort info to classify (may be null when not carried)
+     * @return The group key string that identifies which group this file belongs to
+     */
+    virtual QString getGroupKey(const FileInfoPointer &info, const SortInfoPointer &sortInfo) const
+    {
+        Q_UNUSED(sortInfo)
+        return getGroupKey(info);
+    }
 
     /**
      * @brief Get the display name for a group key

--- a/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
+++ b/src/plugins/filemanager/dfmplugin-search/dfmplugin_search_global.h
@@ -30,6 +30,16 @@ inline constexpr char kSortByPath[] { "sort-by-path" };
 inline constexpr char kGroupByPath[] { "group-by-path" };
 }
 
+// Match Method grouping dimension. Lives in the search plugin — the workspace
+// only holds the strategy via the dfm-base abstract pointer and never knows
+// these constants. Registered with supportedSchemes = ["search"] so the
+// dimension only appears in search-view menus and the title-bar group button.
+namespace MatchMethod {
+inline constexpr char kStrategyName[] { "MatchMethod" };
+inline constexpr char kGroupExact[] { "exact" };   // keyword hits: FileName/Content/OCR
+inline constexpr char kGroupSmart[] { "smart" };   // semantic hits
+}   // namespace MatchMethod
+
 namespace CustomKey {
 inline constexpr char kDisableSearch[] { "Property_Key_DisableSearch" };
 inline constexpr char kRedirectedPath[] { "Property_Key_RedirectedPath" };

--- a/src/plugins/filemanager/dfmplugin-search/groups/matchmethodgroupstrategy.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/groups/matchmethodgroupstrategy.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "matchmethodgroupstrategy.h"
+
+#include <dfm-base/dfm_log_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/interfaces/sortfileinfo.h>
+
+#include <dfm-search/dsearch_global.h>
+
+DPSEARCH_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+MatchMethodGroupStrategy::MatchMethodGroupStrategy(QObject *parent)
+    : AbstractGroupStrategy(parent)
+{
+    fmDebug() << "MatchMethodGroupStrategy: initialized";
+}
+
+MatchMethodGroupStrategy::~MatchMethodGroupStrategy()
+{
+}
+
+QString MatchMethodGroupStrategy::getGroupKey(const FileInfoPointer &info) const
+{
+    Q_UNUSED(info)
+    // No SortInfo carried (non-search context, or sortInfo null) → degrade to
+    // Exact. The strategy only appears in the search-scheme menu, so this path
+    // is a defensive fallback rather than a normal case.
+    return MatchMethod::kGroupExact;
+}
+
+QString MatchMethodGroupStrategy::getGroupKey(const FileInfoPointer &info, const SortInfoPointer &sortInfo) const
+{
+    Q_UNUSED(info)
+    // sortInfo is emitted once by SearchDirIterator and never mutated
+    // afterwards — reading searchType() is a plain int load, lock-free and
+    // race-free. Semantic = 40 → Smart; everything else (FileName/Content/Ocr)
+    // → Exact. Priority (Exact > Smart) is already applied upstream by
+    // mergeResults' score-based dedup, so a URL that matched both ways shows
+    // up here only with the surviving (higher-priority) type.
+    if (sortInfo) {
+        const int type = sortInfo->searchType();
+        if (type == static_cast<int>(DFMSEARCH::SearchType::Semantic))
+            return MatchMethod::kGroupSmart;
+    }
+    return MatchMethod::kGroupExact;
+}
+
+QString MatchMethodGroupStrategy::getGroupDisplayName(const QString &groupKey) const
+{
+    if (groupKey == MatchMethod::kGroupExact)
+        return tr("Exact Match");
+    if (groupKey == MatchMethod::kGroupSmart)
+        return tr("Smart Match");
+    return groupKey;
+}
+
+QStringList MatchMethodGroupStrategy::getGroupOrder() const
+{
+    return { MatchMethod::kGroupExact, MatchMethod::kGroupSmart };
+}
+
+int MatchMethodGroupStrategy::getGroupDisplayOrder(const QString &groupKey) const
+{
+    if (groupKey == MatchMethod::kGroupExact)
+        return 0;
+    if (groupKey == MatchMethod::kGroupSmart)
+        return 1;
+    return 2;   // unknown → end
+}
+
+bool MatchMethodGroupStrategy::isGroupVisible(const QString &groupKey, const QList<FileInfoPointer> &infos) const
+{
+    Q_UNUSED(groupKey)
+    // Same pattern as TypeGroupStrategy — hide empty groups so a search with
+    // no semantic results shows no "Smart" header.
+    return !infos.isEmpty();
+}
+
+QString MatchMethodGroupStrategy::getStrategyName() const
+{
+    return MatchMethod::kStrategyName;
+}

--- a/src/plugins/filemanager/dfmplugin-search/groups/matchmethodgroupstrategy.h
+++ b/src/plugins/filemanager/dfmplugin-search/groups/matchmethodgroupstrategy.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MATCHMETHODGROUPSTRATEGY_H
+#define MATCHMETHODGROUPSTRATEGY_H
+
+#include "dfmplugin_search_global.h"
+
+#include <dfm-base/interfaces/abstractgroupstrategy.h>
+#include <dfm-base/dfm_global_defines.h>
+
+DPSEARCH_BEGIN_NAMESPACE
+
+// Groups search results by how each URL was matched (Exact vs Smart). Pure
+// search business: lives in dfmplugin_search, crosses the plugin boundary to
+// the workspace only through the dfm-base AbstractGroupStrategy abstract
+// pointer. The match method is read directly from each item's SortFileInfo
+// (searchType()), which the SearchDirIterator stamps once before emitting —
+// so the strategy is stateless and needs no shared registry / winId / locking.
+// Priority (Exact > Smart) is already resolved upstream by
+// SimplifiedSearchWorker::mergeResults' score-based dedup.
+class MatchMethodGroupStrategy : public DFMBASE_NAMESPACE::AbstractGroupStrategy
+{
+    Q_OBJECT
+
+public:
+    explicit MatchMethodGroupStrategy(QObject *parent);
+    ~MatchMethodGroupStrategy() override;
+
+    // Basic overload (non-search / no SortInfo): default to Exact.
+    QString getGroupKey(const FileInfoPointer &info) const override;
+    // SortInfo overload (search view): reads searchType() to classify.
+    QString getGroupKey(const FileInfoPointer &info, const SortInfoPointer &sortInfo) const override;
+    QString getGroupDisplayName(const QString &groupKey) const override;
+    QStringList getGroupOrder() const override;
+    int getGroupDisplayOrder(const QString &groupKey) const override;
+    bool isGroupVisible(const QString &groupKey, const QList<FileInfoPointer> &infos) const override;
+    QString getStrategyName() const override;
+};
+
+DPSEARCH_END_NAMESPACE
+
+#endif   // MATCHMETHODGROUPSTRATEGY_H

--- a/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/iterator/searchdiriterator.cpp
@@ -197,6 +197,12 @@ QList<QSharedPointer<SortFileInfo>> SearchDirIterator::sortFileInfoList()
     QList<QSharedPointer<SortFileInfo>> files;
     // 预分配空间以提高性能
     files.reserve(results.size());
+
+    // Stamp each SortFileInfo with its searchType — the workspace's
+    // MatchMethod strategy reads this later (via GroupingEngine passing the
+    // SortInfoPointer into getGroupKey) to classify Exact vs Smart. No shared
+    // registry: the match method travels with the data, so there is nothing
+    // to race against or to outlive.
     for (auto it = results.begin(); it != results.end(); ++it) {
         auto sortInfo = QSharedPointer<SortFileInfo>(new SortFileInfo());
         sortInfo->setUrl(it.key());

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -14,8 +14,10 @@
 #include "topwidget/advancesearchbar.h"
 #include "menus/searchmenuscene.h"
 #include "searchmanager/searchmanager.h"
+#include "groups/matchmethodgroupstrategy.h"
 
 #include <dfm-base/utils/highlightprovider.h>
+#include <dfm-base/interfaces/abstractgroupstrategy.h>
 
 #include <dfm-search/contentretriever.h>
 
@@ -40,6 +42,10 @@ using ShowTopWidgetCallback = std::function<bool(QWidget *, const QUrl &)>;
 using ViewModeUrlCallback = std::function<QUrl(const QUrl)>;
 using ViewHintShouldShowCallback = std::function<bool(const QUrl &, QString *)>;
 using ViewHintActionCallback = std::function<void(const QString &)>;
+// Identical signature to the workspace's StrategyFactory typedef — registered
+// the same way so DPF_NAMESPACE::paramGenerator resolves to the same metatype
+// across plugin boundaries.
+using StrategyFactory = std::function<DFMBASE_NAMESPACE::AbstractGroupStrategy *(QObject *)>;
 Q_DECLARE_METATYPE(CreateTopWidgetCallback);
 Q_DECLARE_METATYPE(ShowTopWidgetCallback);
 Q_DECLARE_METATYPE(QList<QVariantMap> *);
@@ -48,6 +54,7 @@ Q_DECLARE_METATYPE(QVariant *)
 Q_DECLARE_METATYPE(ViewModeUrlCallback)
 Q_DECLARE_METATYPE(ViewHintShouldShowCallback);
 Q_DECLARE_METATYPE(ViewHintActionCallback);
+Q_DECLARE_METATYPE(StrategyFactory);
 
 DFMBASE_USE_NAMESPACE
 DFMGLOBAL_USE_NAMESPACE
@@ -182,6 +189,23 @@ void Search::regSearchToWorkspace()
         { "Property_Key_ViewHintOnAction", QVariant::fromValue(onAction) }
     };
     dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterViewHint", hintMap);
+
+    // Register the "Match Method" group strategy with the workspace's
+    // registered-strategy extension point. The strategy object crosses the
+    // plugin boundary through the dfm-base AbstractGroupStrategy abstract
+    // pointer; only control signaling crosses via dpf. supportedSchemes =
+    // ["search"] so the dimension only appears in search-view menus and the
+    // title-bar group button.
+    StrategyFactory factory { [](QObject *parent) -> AbstractGroupStrategy * {
+        return new MatchMethodGroupStrategy(parent);
+    } };
+    QVariantMap groupMap {
+        { "Property_Key_GroupStrategyName", QString(MatchMethod::kStrategyName) },
+        { "Property_Key_GroupStrategyDisplayName", tr("Match Method") },
+        { "Property_Key_GroupStrategySchemes", QStringList { SearchHelper::scheme() } },
+        { "Property_Key_GroupStrategyFactory", QVariant::fromValue(factory) }
+    };
+    dpfSlotChannel->push("dfmplugin_workspace", "slot_RegisterGroupStrategy", groupMap);
 }
 
 void Search::regSearchSettingConfig()

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander.cpp
@@ -14,7 +14,6 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-search/dsearch_global.h>
-#include <dfm-search/semanticsearcher.h>
 
 #include <QDebug>
 
@@ -136,8 +135,9 @@ void SimplifiedSearchWorker::createSearchersForUrl(const QUrl &url)
     for (auto type : searchTypes)
         appendSearcher(new DFMSearcher(url, searchKeyword, this, type));
 
-    // 语义搜索：在索引就绪、dconfig 开启且 keyword 含语义意图时才创建
-    if (shouldEnableSemanticSearch())
+    // Reuse the shared gating predicate so the pre-search grouping setup and
+    // runtime adapter creation stay consistent.
+    if (SearchHelper::shouldEnableSemanticSearch(searchKeyword))
         appendSearcher(new SemanticAdapter(url, searchKeyword, this));
 }
 
@@ -156,22 +156,6 @@ QList<SearchType> SimplifiedSearchWorker::resolveEnabledSearchTypes() const
     }
 
     return types;
-}
-
-bool SimplifiedSearchWorker::shouldEnableSemanticSearch() const
-{
-    // 语义搜索依赖文件名索引（内部会编排 FileName/Content/OCR 子引擎）
-    if (!DFMSEARCH::Global::isFileNameIndexReadyForSearch())
-        return false;
-
-    if (!DConfigManager::instance()->value(
-                DConfig::kSearchCfgPath, DConfig::kEnableSemanticSearch, false).toBool()) {
-        return false;
-    }
-
-    // 仅当 keyword 真正包含语义意图时才创建 adapter，避免纯关键词触发无谓的语义搜索开销
-    DFMSEARCH::SemanticSearcher checker;
-    return checker.isSemanticQuery(searchKeyword);
 }
 
 void SimplifiedSearchWorker::appendSearcher(AbstractSearcher *searcher)

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander_p.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/maincontroller/task/taskcommander_p.h
@@ -62,9 +62,8 @@ private:
     void cleanupSearchers();
     void mergeResults(AbstractSearcher *searcher);
 
-    // 职责拆分：解析启用的搜索类型 / 判定是否需要语义搜索 / 注册 searcher
+    // 职责拆分：解析启用的搜索类型 / 注册 searcher
     QList<DFMSEARCH::SearchType> resolveEnabledSearchTypes() const;
-    bool shouldEnableSemanticSearch() const;
     void appendSearcher(AbstractSearcher *searcher);
 
     QString taskId;

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
@@ -37,7 +37,26 @@ bool SearchManager::search(quint64 winId, const QString &taskId, const QUrl &url
     // Perform search
     if (mainController) {
         taskIdMap[winId] = taskId;
-        return mainController->doSearchTask(taskId, url, keyword);
+        const bool ok = mainController->doSearchTask(taskId, url, keyword);
+
+        // T1: auto-apply the MatchMethod grouping for this search when a
+        // SemanticAdapter will actually be created (C2). Stateless per-search
+        // — re-applied on every search start. The user can still switch to any
+        // other grouping manually; leaving search view restores the target
+        // URL's persisted strategy via the existing per-URL persistence.
+        //
+        // doSearch() runs on the iterator's worker thread, but the workspace
+        // model (slot_Model_SetGroup's target) lives on the main thread.
+        // dpfSlotChannel->push is synchronous and does NOT hop threads, so a
+        // direct push here would mutate the model from the wrong thread and
+        // silently no-op. Dispatch to SearchManager's thread (main) instead.
+        if (ok && SearchHelper::shouldEnableSemanticSearch(keyword)) {
+            QMetaObject::invokeMethod(this, [winId]() {
+                dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetGroup",
+                                     winId, QString(MatchMethod::kStrategyName));
+            }, Qt::QueuedConnection);
+        }
+        return ok;
     }
 
     fmWarning() << "MainController not available, cannot start search task:" << taskId;

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
@@ -11,6 +11,9 @@
 #include <QObject>
 #include <QMap>
 #include <QMultiMap>
+#include <QHash>
+#include <QPair>
+#include <QUrl>
 
 namespace dfmplugin_search {
 
@@ -25,13 +28,13 @@ public:
 
     void init();
     bool search(quint64 winId, const QString &taskId, const QUrl &url, const QString &keyword);
-    
+
     // 获取统一的搜索结果数据
     DFMSearchResultMap matchedResults(const QString &taskId);
-    
+
     // 为向后兼容保留的接口，只获取URL列表
     QList<QUrl> matchedResultUrls(const QString &taskId);
-    
+
     void stop(const QString &taskId);
     void stop(quint64 winId);
 

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -10,6 +10,9 @@
 #include "checkboxwithsemanticindex.h"
 #include "topwidget/advancesearchbar.h"
 
+#include <dfm-search/dsearch_global.h>
+#include <dfm-search/semanticsearcher.h>
+
 #include <dfm-base/interfaces/fileinfo.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/urlroute.h>
@@ -110,6 +113,23 @@ QUrl SearchHelper::setSearchWinId(const QUrl &searchUrl, const QString &winId)
     url.setQuery(query);
 
     return url;
+}
+
+bool SearchHelper::shouldEnableSemanticSearch(const QString &keyword)
+{
+    // Shared predicate for both the search-start path and the runtime worker:
+    // only enable semantic search when index readiness, config, and query
+    // intent all match.
+    if (!DFMSEARCH::Global::isFileNameIndexReadyForSearch())
+        return false;
+
+    if (!DConfigManager::instance()->value(DConfig::kSearchCfgPath,
+                                           DConfig::kEnableSemanticSearch, false).toBool()) {
+        return false;
+    }
+
+    DFMSEARCH::SemanticSearcher checker;
+    return checker.isSemanticQuery(keyword);
 }
 
 QUrl SearchHelper::viewModelUrl(const QUrl &url)

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.h
@@ -39,6 +39,12 @@ public:
     static QUrl setSearchWinId(const QUrl &searchUrl, const QString &winId);
     static QUrl viewModelUrl(const QUrl &url);
 
+    // Whether a SemanticAdapter would actually be created for this keyword
+    // (C2: index ready + dconfig on + keyword carries semantic intent). Shared
+    // by the search-start path and the runtime worker so grouping setup and
+    // adapter creation use the same predicate.
+    static bool shouldEnableSemanticSearch(const QString &keyword);
+
     static QUrl fromSearchFile(const QString &filePath);
     static QUrl fromSearchFile(const QUrl &targetUrl, const QString &keyword, const QString &winId);
     static bool showTopWidget(QWidget *w, const QUrl &url);

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
@@ -4,6 +4,7 @@
 
 #include "titlebareventcaller.h"
 #include "utils/titlebarhelper.h"
+#include "views/titlebarwidget.h"
 
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/base/schemefactory.h>
@@ -182,4 +183,27 @@ bool TitleBarEventCaller::sendGetCurrentModelBusy(QWidget *sender)
         return false;
     }
     return dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_GetCurrentBusy", id).toBool();
+}
+
+QList<QPair<QString, QString>> TitleBarEventCaller::sendRegisteredGroupStrategies(QWidget *sender)
+{
+    // Resolve the current view's scheme so the workspace can filter registered
+    // strategies by supportedSchemes (e.g. search's MatchMethod only appears
+    // under the "search" scheme). Falls back to empty (no filter) on failure.
+    quint64 id = TitleBarHelper::windowId(sender);
+    QString scheme;
+    if (id > 0) {
+        if (auto *bar = TitleBarHelper::findTileBarByWindowId(id))
+            scheme = bar->currentUrl().scheme();
+    }
+
+    QList<QPair<QString, QString>> result;
+    const QVariantList entries = dpfSlotChannel->push("dfmplugin_workspace",
+                                                      "slot_RegisteredGroupStrategies",
+                                                      scheme).toList();
+    for (const QVariant &v : entries) {
+        const QVariantMap m = v.toMap();
+        result.append({ m.value("name").toString(), m.value("displayName").toString() });
+    }
+    return result;
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.h
@@ -10,6 +10,9 @@
 #include <dfm-base/dfm_global_defines.h>
 
 #include <QObject>
+#include <QList>
+#include <QPair>
+#include <QString>
 
 namespace dfmplugin_titlebar {
 
@@ -40,6 +43,10 @@ public:
     static QString sendCurrentGroupRoleStrategy(QWidget *sender);
     static void sendSetGroupStrategy(QWidget *sender, const QString &strategy);
     static bool sendGetCurrentModelBusy(QWidget *sender);
+
+    // Registered external group strategies (e.g. search's "Match Method"),
+    // filtered by the current view's scheme. Each entry is {strategyName, displayName}.
+    static QList<QPair<QString, QString>> sendRegisteredGroupStrategies(QWidget *sender);
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/sortbybutton.cpp
@@ -31,6 +31,7 @@ static constexpr int kSortToolLeftButtonSize { 16 };   // 左侧排序图标尺�
 static constexpr int kSortToolArrowCircleSize { 18 };   // 右侧箭头圆形背景尺寸
 static constexpr int kSortToolArrowButtonSize { 12 };   // 右侧箭头图标尺寸
 static constexpr char kItemRole[] = "item-role";
+static constexpr char kItemStrategy[] = "item-strategy";   // registered strategy name
 // 按钮总宽 = padding + iconSize + spacing + circleSize + padding
 static constexpr int kSortToolButtonWidth { kSortToolPadding + kSortToolLeftButtonSize
                                             + kSortToolSpacing + kSortToolArrowCircleSize
@@ -91,6 +92,15 @@ void SortByButtonPrivate::setItemGroupRoles()
     const QString groupStrategy = TitleBarEventCaller::sendCurrentGroupRoleStrategy(q);
     auto actList = groupMenu->actions();
     for (auto act : actList) {
+        // Registered external strategies carry their strategy name directly.
+        const QVariant stratProp = act->property(kItemStrategy);
+        if (stratProp.isValid() && stratProp.typeId() == QMetaType::QString) {
+            if (stratProp.toString() == groupStrategy) {
+                act->setChecked(true);
+                return;
+            }
+            continue;
+        }
         auto role = act->property(kItemRole).value<DFMGLOBAL_NAMESPACE::ItemRoles>();
         const auto &strategy = roleToGroupingStrategy(role);
         if (strategy == groupStrategy) {
@@ -125,6 +135,19 @@ void SortByButtonPrivate::setupMenu()
         act = groupMenu->addAction(name);
         act->setCheckable(true);
         act->setProperty(kItemRole, role);
+    }
+
+    // Append registered external strategies (e.g. search's "Match Method"),
+    // filtered by the current view's scheme. Their strategy name is carried as
+    // a dedicated property so groupMenuTriggered can route them through the
+    // same sendSetGroupStrategy path as built-ins.
+    const auto registered = TitleBarEventCaller::sendRegisteredGroupStrategies(q);
+    for (const auto &e : registered) {
+        const QString &strategyName = e.first;
+        const QString &display = e.second;
+        auto regAct = groupMenu->addAction(display);
+        regAct->setCheckable(true);
+        regAct->setProperty(kItemStrategy, strategyName);
     }
 
     // Add Group by submenu
@@ -164,6 +187,16 @@ void SortByButtonPrivate::groupMenuTriggered(QAction *action)
 {
     if (!action)
         return;
+
+    // Registered external strategies carry their strategy name directly.
+    const QVariant stratProp = action->property(kItemStrategy);
+    if (stratProp.isValid() && stratProp.typeId() == QMetaType::QString) {
+        const QString &strategy = stratProp.toString();
+        if (!strategy.isEmpty()) {
+            TitleBarEventCaller::sendSetGroupStrategy(q, strategy);
+            return;
+        }
+    }
 
     auto property = action->property(kItemRole);
     if (!property.isValid()) {

--- a/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/dfmplugin_workspace_global.h
@@ -27,6 +27,7 @@
 namespace dfmbase {
 class FileInfo;
 class SortFileInfo;
+class AbstractGroupStrategy;
 }
 
 DPWORKSPACE_BEGIN_NAMESPACE
@@ -113,6 +114,11 @@ inline constexpr char kViewHintIcon[] { "Property_Key_ViewHintIcon" };
 inline constexpr char kViewHintActions[] { "Property_Key_ViewHintActions" };
 inline constexpr char kViewHintShouldShow[] { "Property_Key_ViewHintShouldShow" };
 inline constexpr char kViewHintOnAction[] { "Property_Key_ViewHintOnAction" };
+// Registered group strategy payload keys (for slot_RegisterGroupStrategy)
+inline constexpr char kGroupStrategyName[] { "Property_Key_GroupStrategyName" };
+inline constexpr char kGroupStrategyDisplayName[] { "Property_Key_GroupStrategyDisplayName" };
+inline constexpr char kGroupStrategySchemes[] { "Property_Key_GroupStrategySchemes" };
+inline constexpr char kGroupStrategyFactory[] { "Property_Key_GroupStrategyFactory" };
 }
 
 using CreateTopWidgetCallback = std::function<QWidget *()>;
@@ -129,6 +135,14 @@ using ViewModeUrlCallback = std::function<QUrl(const QUrl)>;
 // the built-in close button which arrives with id "close".
 using ViewHintShouldShowCallback = std::function<bool(const QUrl &, QString *text)>;
 using ViewHintActionCallback = std::function<void(const QString &id)>;
+
+// Registered group strategy factory: produces an AbstractGroupStrategy* for the
+// given parent. Strategies that need per-window context carry their own state
+// (the data they need — e.g. each item's SortFileInfo — already travels with
+// the item, so the factory need not thread winId). Cross-plugin transport uses
+// Q_DECLARE_METATYPE + DPF_NAMESPACE::paramGenerator — same pattern as the
+// ViewHint callbacks above.
+using StrategyFactory = std::function<DFMBASE_NAMESPACE::AbstractGroupStrategy *(QObject *)>;
 
 // Specification for a per-scheme floating view hint. Registered via
 // slot_RegisterViewHint; consumed by WorkspacePage on url/scheme switch.
@@ -221,6 +235,7 @@ Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::FileViewRoutePrehaldler);
 Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::ViewModeUrlCallback);
 Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::ViewHintShouldShowCallback);
 Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::ViewHintActionCallback);
+Q_DECLARE_METATYPE(DPWORKSPACE_NAMESPACE::StrategyFactory);
 Q_DECLARE_METATYPE(QString *)
 Q_DECLARE_METATYPE(QVariant *)
 Q_DECLARE_METATYPE(QDir::Filters)

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.cpp
@@ -9,6 +9,7 @@
 #include "views/workspacewidget.h"
 #include "views/fileview.h"
 #include "models/fileviewmodel.h"
+#include "groups/groupingfactory.h"
 
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/dfm_event_defines.h>
@@ -68,6 +69,10 @@ void WorkspaceEventReceiver::initConnection()
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleRegisterCustomTopWidget);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_RegisterViewHint",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleRegisterViewHint);
+    dpfSlotChannel->connect(kCurrentEventSpace, "slot_RegisterGroupStrategy",
+                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleRegisterGroupStrategy);
+    dpfSlotChannel->connect(kCurrentEventSpace, "slot_RegisteredGroupStrategies",
+                            WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleRegisteredGroupStrategies);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_GetCustomTopWidgetVisible",
                             WorkspaceEventReceiver::instance(), &WorkspaceEventReceiver::handleGetCustomTopWidgetVisible);
     dpfSlotChannel->connect(kCurrentEventSpace, "slot_ShowCustomTopWidget",
@@ -430,6 +435,37 @@ void WorkspaceEventReceiver::handleRegisterViewHint(const QVariantMap &dataMap)
     }
     fmDebug() << "WorkspaceEventReceiver: Registering view hint for scheme:" << spec.scheme;
     WorkspaceHelper::instance()->registerViewHint(spec.scheme, spec);
+}
+
+void WorkspaceEventReceiver::handleRegisterGroupStrategy(const QVariantMap &dataMap)
+{
+    const QString name = dataMap.value(PropertyKey::kGroupStrategyName).toString();
+    if (name.isEmpty()) {
+        fmWarning() << "WorkspaceEventReceiver: group strategy registration has empty name, ignored";
+        return;
+    }
+    RegisteredGroupStrategy entry(dataMap);
+    if (!entry.factory) {
+        fmWarning() << "WorkspaceEventReceiver: group strategy registration has null factory for" << name;
+        return;
+    }
+    fmInfo() << "WorkspaceEventReceiver: Registering group strategy" << name
+             << "schemes:" << entry.supportedSchemes;
+    GroupingFactory::registerStrategy(name, entry);
+}
+
+QVariantList WorkspaceEventReceiver::handleRegisteredGroupStrategies(const QString &schemeFilter)
+{
+    const auto entries = GroupingFactory::registeredStrategies(schemeFilter);
+    QVariantList result;
+    result.reserve(entries.size());
+    for (const auto &e : entries) {
+        QVariantMap m;
+        m["name"] = e.first;
+        m["displayName"] = e.second;
+        result.append(m);
+    }
+    return result;
 }
 
 bool WorkspaceEventReceiver::handleGetCustomTopWidgetVisible(const quint64 windowID, const QString &scheme)

--- a/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/events/workspaceeventreceiver.h
@@ -69,6 +69,8 @@ public slots:
     QString handleFindMenuScene(const QString &scheme);
     void handleRegisterCustomTopWidget(const QVariantMap &dataMap);
     void handleRegisterViewHint(const QVariantMap &dataMap);
+    void handleRegisterGroupStrategy(const QVariantMap &dataMap);
+    QVariantList handleRegisteredGroupStrategies(const QString &schemeFilter = QString());
     bool handleGetCustomTopWidgetVisible(const quint64 windowID, const QString &scheme);
     bool handleCheckSchemeViewIsFileView(const QString &scheme);
     QList<QUrl> handleGetSelectedUrls(const quint64 windowID);

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
@@ -156,7 +156,7 @@ QString GroupingEngine::getGroupKeyForFiles(const QList<FileItemDataPointer> &fi
 
     if (!groupKeyItem.isNull()) {
         auto groupKeyInfo = getFileInfoFromFileItem(groupKeyItem);
-        groupKey = strategy->getGroupKey(groupKeyInfo);
+        groupKey = strategy->getGroupKey(groupKeyInfo, groupKeyItem->fileSortInfo());
     }
 
     return groupKey;
@@ -589,7 +589,9 @@ GroupingEngine::GroupingResult GroupingEngine::performGrouping(const QList<FileI
                 }
             }
 
-            QString groupKey = strategy->getGroupKey(fileInfo);
+            // Pass the SortFileInfo too when available — search-strategy dimensions
+            // (Match Method) read match metadata from it rather than from FileInfo.
+            QString groupKey = strategy->getGroupKey(fileInfo, file->fileSortInfo());
             if (groupKey.isEmpty()) {
                 fmWarning() << "GroupingEngine: Empty group key for file" << file->data(DFMBASE_NAMESPACE::Global::kItemUrlRole).toUrl();
                 continue;

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingfactory.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingfactory.cpp
@@ -14,10 +14,61 @@
 
 DPWORKSPACE_USE_NAMESPACE
 
-AbstractGroupStrategy *GroupingFactory::createStrategy(const QString &strategyName, QObject *parent)
+QHash<QString, RegisteredGroupStrategy> &GroupingFactory::registry()
+{
+    static QHash<QString, RegisteredGroupStrategy> s_registry;
+    return s_registry;
+}
+
+void GroupingFactory::registerStrategy(const QString &name, const RegisteredGroupStrategy &entry)
+{
+    if (name.isEmpty() || !entry.factory) {
+        fmWarning() << "GroupingFactory: refusing to register invalid strategy:" << name;
+        return;
+    }
+    registry().insert(name, entry);
+    fmInfo() << "GroupingFactory: registered external strategy:" << name
+             << "schemes:" << entry.supportedSchemes;
+}
+
+QList<QPair<QString, QString>> GroupingFactory::registeredStrategies(const QString &schemeFilter)
+{
+    QList<QPair<QString, QString>> result;
+    for (auto it = registry().constBegin(); it != registry().constEnd(); ++it) {
+        if (!schemeFilter.isEmpty()
+            && !it.value().supportedSchemes.isEmpty()
+            && !it.value().supportedSchemes.contains(schemeFilter)) {
+            continue;
+        }
+        result.append({ it.key(), it.value().displayName });
+    }
+    return result;
+}
+
+bool GroupingFactory::isRegistered(const QString &name)
+{
+    return registry().contains(name);
+}
+
+AbstractGroupStrategy *GroupingFactory::createStrategy(const QString &strategyName,
+                                                       QObject *parent)
 {
     fmDebug() << "GroupingFactory: Creating strategy for name:" << strategyName;
 
+    // External extension point first — registered strategies win over built-ins
+    // of the same name (allows overrides; harmless because we register at start
+    // time and never collide with built-in names in practice).
+    auto it = registry().constFind(strategyName);
+    if (it != registry().constEnd() && it.value().factory) {
+        AbstractGroupStrategy *s = it.value().factory(parent);
+        if (s) {
+            s->setParent(parent);
+            return s;
+        }
+        fmWarning() << "GroupingFactory: external factory returned null for:" << strategyName;
+    }
+
+    // Built-in fallback (hardcoded if/else — YAGNI on refactoring to registration)
     if (strategyName == GroupStrategy::kNoGroup) {
         return new NoGroupStrategy(parent);
     } else if (strategyName == GroupStrategy::kName) {

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingfactory.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingfactory.h
@@ -11,10 +11,31 @@
 #include <dfm-base/dfm_global_defines.h>
 
 #include <QObject>
+#include <QHash>
+#include <QString>
+#include <QStringList>
 
 DPWORKSPACE_BEGIN_NAMESPACE
 
 using namespace DFMBASE_NAMESPACE;
+
+// A registered external group strategy entry. External plugins (e.g.
+// dfmplugin_search) register strategies through the workspace DPF slots; the
+// workspace holds them by abstract pointer and never touches business logic.
+struct RegisteredGroupStrategy
+{
+    QString displayName;
+    QStringList supportedSchemes;   // empty list = available everywhere
+    StrategyFactory factory { nullptr };
+
+    RegisteredGroupStrategy() = default;
+    inline explicit RegisteredGroupStrategy(const QVariantMap &map)
+        : displayName { map.value(PropertyKey::kGroupStrategyDisplayName).toString() },
+          supportedSchemes { map.value(PropertyKey::kGroupStrategySchemes).toStringList() },
+          factory { DPF_NAMESPACE::paramGenerator<StrategyFactory>(map.value(PropertyKey::kGroupStrategyFactory)) }
+    {
+    }
+};
 
 class GroupingFactory : public QObject
 {
@@ -25,12 +46,23 @@ public:
      * @brief Create a grouping strategy instance by name
      * @param strategyName The name of the strategy to create
      * @param parent The parent object for the created strategy
-     * @return A pointer to the created strategy, or nullptr if the strategy name is invalid
+     * @return A pointer to the created strategy, or nullptr if the name is invalid
      */
-    static AbstractGroupStrategy *createStrategy(const QString &strategyName, QObject *parent = nullptr);
+    static AbstractGroupStrategy *createStrategy(const QString &strategyName,
+                                                 QObject *parent = nullptr);
+
+    // --- External extension point ---
+    // The registry is consulted first by createStrategy; built-in strategies
+    // are the fallback. Registered at plugin start time, queried at menu/setup
+    // time. Main-thread only — no locking.
+    static void registerStrategy(const QString &name, const RegisteredGroupStrategy &entry);
+    static QList<QPair<QString, QString>> registeredStrategies(const QString &schemeFilter = QString());
+    static bool isRegistered(const QString &name);
 
 private:
     GroupingFactory() = delete;  // Prevent instantiation
+
+    static QHash<QString, RegisteredGroupStrategy> &registry();
 };
 
 DPWORKSPACE_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/menus/sortanddisplaymenuscene.cpp
@@ -8,6 +8,7 @@
 #include "views/fileview.h"
 #include "models/fileviewmodel.h"
 #include "utils/workspacehelper.h"
+#include "groups/groupingfactory.h"
 #include "events/workspaceeventcaller.h"
 
 #include <dfm-base/dfm_log_defines.h>
@@ -245,6 +246,13 @@ bool SortAndDisplayMenuScene::triggered(QAction *action)
                 d->groupByStrategy(GroupStrategy::kType);
                 return true;
             }
+
+            // registered external strategies — action id is the strategy name
+            if (GroupingFactory::isRegistered(actionId)) {
+                fmInfo() << "Grouping by registered strategy:" << actionId;
+                d->groupByStrategy(actionId);
+                return true;
+            }
         }
     }
 
@@ -353,6 +361,22 @@ QMenu *SortAndDisplayMenuScenePrivate::addGroupByActions(QMenu *menu)
     predicateAction[ActionID::kGroupByType] = tempAction;
     tempAction->setProperty(ActionPropertyKey::kActionID, QString(ActionID::kGroupByType));
 
+    // Registered external strategies (e.g. search plugin's "Match Method").
+    // Filtered by the current view's scheme so a strategy only appears where it
+    // declared support. The strategy name doubles as the action id — triggered
+    // routes through the same groupByStrategy(name) path as built-ins.
+    const QString scheme = view ? view->rootUrl().scheme() : QString();
+    for (const auto &entry : GroupingFactory::registeredStrategies(scheme)) {
+        const QString &name = entry.first;
+        const QString &display = entry.second;
+        if (predicateAction.contains(name))
+            continue;   // avoid clobbering a built-in slot of the same name
+        tempAction = subMenu->addAction(display);
+        tempAction->setCheckable(true);
+        predicateAction[name] = tempAction;
+        tempAction->setProperty(ActionPropertyKey::kActionID, name);
+    }
+
     return subMenu;
 }
 
@@ -450,6 +474,10 @@ void SortAndDisplayMenuScenePrivate::updateEmptyAreaActionState()
     } else if (currentStrategy == GroupStrategy::kType) {
         predicateAction[ActionID::kGroupByType]->setChecked(true);
         fmDebug() << "Set group by type action as checked";
+    } else if (predicateAction.contains(currentStrategy)) {
+        // Registered external strategy — its action id is the strategy name.
+        predicateAction[currentStrategy]->setChecked(true);
+        fmDebug() << "Set registered group action as checked:" << currentStrategy;
     } else {
         fmDebug() << "Unknown grouping strategy:" << currentStrategy;
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -39,7 +39,8 @@ void insertToList(QList<T> &list, int index, const T &t)
 }
 }   // namespace
 
-FileSortWorker::FileSortWorker(const QUrl &url, const QString &key, FileViewFilterCallback callfun,
+FileSortWorker::FileSortWorker(const QUrl &url, const QString &key,
+                               FileViewFilterCallback callfun,
                                const QStringList &nameFilters, const QDir::Filters filters, QObject *parent)
     : QObject(parent),
       current(url),

--- a/src/plugins/filemanager/dfmplugin-workspace/workspace.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/workspace.h
@@ -36,6 +36,8 @@ class Workspace : public dpf::Plugin
     DPF_EVENT_REG_SLOT(slot_FindMenuScene)
     DPF_EVENT_REG_SLOT(slot_RegisterCustomTopWidget)
     DPF_EVENT_REG_SLOT(slot_RegisterViewHint)
+    DPF_EVENT_REG_SLOT(slot_RegisterGroupStrategy)
+    DPF_EVENT_REG_SLOT(slot_RegisteredGroupStrategies)
     DPF_EVENT_REG_SLOT(slot_ShowCustomTopWidget)
     DPF_EVENT_REG_SLOT(slot_GetCustomTopWidgetVisible)
     DPF_EVENT_REG_SLOT(slot_CheckSchemeViewIsFileView)


### PR DESCRIPTION
Implement match method grouping strategy to categorize search results
into Exact and Smart matches
Extend AbstractGroupStrategy interface to support SortFileInfo context
Register new strategy with workspace for search scheme only
Auto-apply grouping when semantic search is enabled
Move shared semantic search predicate to SearchHelper for consistency
between pre-search and runtime

Log: Added grouping by search match method (Exact vs Smart)

Influence:
1. Test search with semantic-enabled keywords to see auto-grouping
2. Manually switch to Match Method grouping via titlebar/menu
3. Verify display of both Exact and Smart groups when both exist
4. Test with non-search views to ensure strategy doesn't appear
5. Verify menu visibility only in search scheme

feat: 添加搜索结果的匹配方式分组功能

实现匹配方式分组策略，将搜索结果分为精确匹配和智能匹配
扩展AbstractGroupStrategy接口以支持SortFileInfo上下文
为搜索方案注册新的分组策略
当启用语义搜索时自动应用此分组方式
将共享的语义搜索判断逻辑移至SearchHelper保持前后一致

Log: 新增按搜索匹配方式(精确/智能)分组功能

Influence:
1. 测试使用含语义意图关键词的搜索，观察自动分组效果
2. 通过标题栏/菜单手动切换到匹配方式分组
3. 验证当同时存在两种匹配结果时的分组显示
4. 在非搜索视图中测试确保不出现此分组策略
5. 验证仅在搜索方案中显示该分组菜单项
