### PR TITLE
semantic search

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
@@ -50,10 +50,20 @@ bool SearchManager::search(quint64 winId, const QString &taskId, const QUrl &url
         // dpfSlotChannel->push is synchronous and does NOT hop threads, so a
         // direct push here would mutate the model from the wrong thread and
         // silently no-op. Dispatch to SearchManager's thread (main) instead.
+        //
+        // Guard: only push when the current strategy differs. Pushing the same
+        // strategy again triggers setGroupingStrategy's toggle behavior
+        // (Ascending↔Descending) — that's a UI affordance for menu clicks, not
+        // desired here. Re-pushing on every keyword change would otherwise
+        // flip the group order (Exact/Smart) on the second search.
         if (ok && SearchHelper::shouldEnableSemanticSearch(keyword)) {
             QMetaObject::invokeMethod(this, [winId]() {
-                dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetGroup",
-                                     winId, QString(MatchMethod::kStrategyName));
+                const QString current = dpfSlotChannel->push(
+                    "dfmplugin_workspace", "slot_Model_CurrentGroupStrategy", winId).toString();
+                if (current != MatchMethod::kStrategyName) {
+                    dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetGroup",
+                                         winId, QString(MatchMethod::kStrategyName));
+                }
             }, Qt::QueuedConnection);
         }
         return ok;

--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
@@ -718,6 +718,20 @@ bool GroupingEngine::isGroupVisibleWithConversion(const QString &groupKey,
         }
     }
 
+    // Fallback: when FileInfo is not yet materialized (e.g. search results in
+    // kPreserve mode where grouping runs before the view lazily creates FileInfo
+    // via data(kItemCreateFileInfoRole)), the conversion above yields an empty
+    // list. Most custom strategies' isGroupVisible simply checks !infos.isEmpty(),
+    // so falling back to !groupFiles.isEmpty() preserves correct visibility and
+    // avoids an empty-view deadlock where 0 groups → 0 items → FileInfo never
+    // created → 0 groups on regroup. Once FileInfo is materialized, subsequent
+    // regrouping calls go through the full conversion path as intended.
+    if (groupFileInfos.isEmpty() && !groupFiles.isEmpty()) {
+        fmDebug() << "GroupingEngine: FileInfo not yet materialized for custom strategy"
+                  << strategyName << "- falling back to non-empty check";
+        return true;
+    }
+
     return strategy->isGroupVisible(groupKey, groupFileInfos);
 }
 

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -142,6 +142,11 @@ QModelIndex FileViewModel::setRootUrl(const QUrl &url)
         return QModelIndex();
     }
 
+    // New URL => any deferred grouping was for the previous directory; drop it
+    // so a stale strategy can't be applied after the new traversal finishes.
+    hasPendingGrouping = false;
+    pendingGroupStrategy.clear();
+
     fmInfo() << "Setting root URL:" << url.toString() << "with strategy:" << static_cast<int>(dirLoadStrategy);
 
     QVariantMap data;
@@ -692,7 +697,17 @@ void FileViewModel::sort(int column, Qt::SortOrder order)
 void FileViewModel::grouping(const QString &strategyName, Qt::SortOrder order)
 {
     if (state == ModelState::kBusy) {
-        fmWarning() << "Cannot group while model is busy for URL:" << dirRootUrl.toString();
+        // Defer, don't drop: callers such as SearchManager::search push the
+        // grouping request via a queued slot invocation that routinely lands
+        // while traversal is still streaming results in. Stash the latest
+        // request and replay it from onWorkFinish() once the model goes idle.
+        // Last-write-wins: a newer call overrides any previously pending one.
+        hasPendingGrouping = true;
+        pendingGroupStrategy = strategyName;
+        pendingGroupOrder = order;
+        fmDebug() << "Model is busy, deferring grouping request:" << strategyName
+                  << "order:" << (order == Qt::AscendingOrder ? "Ascending" : "Descending")
+                  << "URL:" << dirRootUrl.toString();
         return;
     }
     fmInfo() << "Grouping by :" << strategyName << "order:" << (order == Qt::AscendingOrder ? "Ascending" : "Descending") << "URL:" << dirRootUrl.toString();
@@ -708,6 +723,12 @@ void FileViewModel::grouping(const QString &strategyName, Qt::SortOrder order)
 void FileViewModel::stopTraversWork(const QUrl &newUrl)
 {
     fmInfo() << "Stopping traversal work, current URL:" << dirRootUrl.toString() << "new URL:" << newUrl.toString();
+
+    // URL is changing — any deferred grouping request was for the old URL and
+    // must not be replayed against the new one. Clear before changing state so
+    // the kIdle transition below can't trigger a stray replay.
+    hasPendingGrouping = false;
+    pendingGroupStrategy.clear();
 
     changeState(ModelState::kIdle);
     closeCursorTimer();
@@ -1239,6 +1260,23 @@ void FileViewModel::onWorkFinish(int visiableCount, int totalCount)
 
     this->changeState(ModelState::kIdle);
     closeCursorTimer();
+
+    // Replay a grouping request that was deferred while the model was busy
+    // (e.g. a semantic-search MatchMethod grouping request that arrived mid
+    // traversal). Dispatch via a queued connection so the apply runs outside
+    // of the stateChanged() signal emission stack — re-entering grouping()
+    // synchronously here would make the signal chain hard to reason about.
+    if (hasPendingGrouping) {
+        const QString strategy = pendingGroupStrategy;
+        const Qt::SortOrder order = pendingGroupOrder;
+        hasPendingGrouping = false;
+        pendingGroupStrategy.clear();
+        QMetaObject::invokeMethod(this, [this, strategy, order]() {
+            fmInfo() << "Replaying deferred grouping after work finish:" << strategy
+                     << "URL:" << dirRootUrl.toString();
+            grouping(strategy, order);
+        }, Qt::QueuedConnection);
+    }
 
     // 如果是保留策略，在加载完成后清理旧的RootInfo对象
     if (dirLoadStrategy == DirectoryLoadStrategy::kPreserve) {

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -206,6 +206,15 @@ private:
 
     DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy dirLoadStrategy { DFMGLOBAL_NAMESPACE::DirectoryLoadStrategy::kCreateNew };
     QUrl preparedUrl;
+
+    // Deferred grouping: when grouping() is called while the model is kBusy
+    // (e.g. during search result streaming), the request is stashed here and
+    // replayed once traversal finishes in onWorkFinish(). A URL change clears
+    // it so a stale strategy never leaks across directories. Last-write-wins
+    // semantics: a newer grouping() call overrides any pending one.
+    bool hasPendingGrouping { false };
+    QString pendingGroupStrategy;
+    Qt::SortOrder pendingGroupOrder { Qt::AscendingOrder };
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -914,8 +914,12 @@ void FileView::setSort(const ItemRoles role, const Qt::SortOrder order)
 
 void FileView::setGroup(const QString &strategyName, const Qt::SortOrder order)
 {
-    if (model()->currentState() == ModelState::kBusy)
-        return;
+    // NOTE: do NOT short-circuit on ModelState::kBusy here. When a grouping
+    // request arrives mid-traversal (e.g. SearchManager::search pushes a
+    // queued slot_Model_SetGroup that lands while search results are still
+    // streaming in), the model's grouping() will stash it as a pending
+    // request and replay it from onWorkFinish() once traversal completes.
+    // Dropping the request here would silently defeat that deferral.
     if (strategyName == model()->groupingStrategy() && order == model()->groupingOrder())
         return;
 


### PR DESCRIPTION
- **fix: improve grouping request handling during busy state**
- **fix: prevent search grouping strategy toggle on repeated searches**

## Summary by Sourcery

Improve semantic search grouping behavior by deferring grouping requests while the model is busy and avoiding unintended toggling of grouping strategy on repeated searches.

Bug Fixes:
- Defer grouping requests issued during busy model state and replay them once traversal completes to ensure search-triggered grouping is applied reliably.
- Clear any pending grouping requests when the root URL changes or traversal is stopped to prevent stale strategies from leaking across directories.
- Prevent repeated semantic searches from re-pushing the same grouping strategy and unintentionally toggling group order.
- Ensure custom grouping strategies correctly show groups when FileInfo is not yet materialized by falling back to checking non-empty underlying file lists instead of derived FileInfo lists.

Enhancements:
- Add pending grouping state to FileViewModel and rely on it from FileView to support deferred grouping across search result streaming.