### PR TITLE
feat: enable semantic search by default

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.search.json
+++ b/assets/configs/org.deepin.dde.file-manager.search.json
@@ -36,7 +36,7 @@
             "visibility":"private"
         },
         "enableSemanticSearch": {
-            "value":false,
+            "value":true,
             "serial":0,
             "flags":[],
             "name":"Enable Semantic Search",

--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -276,7 +276,7 @@ void Search::regSearchSettingConfig()
             []() {
                 return DConfigManager::instance()->value(DConfig::kSearchCfgPath,
                                                          DConfig::kEnableOcrTextSearch,
-                                                         true);
+                                                         false);
             },
             [](const QVariant &val) {
                 DConfigManager::instance()->setValue(DConfig::kSearchCfgPath,
@@ -291,14 +291,14 @@ void Search::regSearchSettingConfig()
                                                 { { "key", semanticIndexKey.mid(semanticIndexKey.lastIndexOf(".") + 1) },
                                                   { "text", tr("Smart search") },
                                                   { "type", "checkBoxWithSemanticIndex" },
-                                                  { "default", false } });
+                                                  { "default", true } });
 
     SettingBackend::instance()->addSettingAccessor(
             SearchSettings::kSemanticSearch,
             []() {
                 return DConfigManager::instance()->value(DConfig::kSearchCfgPath,
                                                          DConfig::kEnableSemanticSearch,
-                                                         false);
+                                                         true);
             },
             [](const QVariant &val) {
                 DConfigManager::instance()->setValue(DConfig::kSearchCfgPath,


### PR DESCRIPTION
Changed default value of semantic search to enabled in both config file
and code implementation. This includes:
1. Updated org.deepin.dde.file-manager.search.json config file to set
enableSemanticSearch.value to true
2. Modified search.cpp to reflect this default enabled state for
semantic search
3. Changed default setting for smart search checkbox to true
4. Adjusted OCR text search default value to false to prioritize
semantic search

Log: Enabled semantic search by default in file manager settings

Influence:
1. Verify semantic search works when enabled by default
2. Test file search functionality with semantic search turned on
3. Check if OCR text search behaves correctly when disabled
4. Validate settings persistence through application restarts
5. Test search results with various file types and contents

feat: 默认启用语义搜索

更改了语义搜索的默认值为启用状态，包括配置文件和代码实现层面的修改：
1. 更新org.deepin.dde.file-manager.search.json配置文件，将
enableSemanticSearch.value设为true
2. 修改search.cpp代码以反映语义搜索默认启用的状态
3. 将智能搜索复选框的默认设置改为true
4. 调整OCR文本搜索默认值为false以优先使用语义搜索

Log: 在文件管理器设置中默认启用语义搜索功能

Influence:
1. 验证语义搜索在默认启用时的功能表现
2. 测试语义搜索开启状态下的文件搜索功能
3. 检查OCR文本搜索在禁用状态下的行为是否正确
4. 验证设置在不同应用重启后的持久性
5. 使用各种文件类型和内容测试搜索结果

## Summary by Sourcery

Enable semantic search by default in the file manager search settings and configuration.

New Features:
- Default-enable semantic (smart) search in the file manager search module.

Enhancements:
- Set the smart search UI checkbox to be checked by default to reflect the new semantic search default.
- Disable OCR text search by default to prioritize semantic search in search behavior.