### PR TITLE
perf: optimize drag-and-drop performance in FileView

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/dragdrophelper.cpp
@@ -167,6 +167,7 @@ bool DragDropHelper::dragMove(QDragMoveEvent *event)
         }
 
         if (UniversalUtils::urlEquals(targetUrl, url)) {
+            currentHoverIndexUrl = targetUrl;
             view->setViewSelectState(false);
             event->ignore();
             return true;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -963,6 +963,9 @@ GroupingState FileView::groupingState()
 
 void FileView::setViewSelectState(bool isSelect)
 {
+    // 拖拽时一直在设置d->isShowViewSelectBox值，每次都在全屏绘制，绘制效率低下
+    if (d->isShowViewSelectBox == isSelect)
+        return;
     d->isShowViewSelectBox = isSelect;
     viewport()->update();
 }
@@ -1838,6 +1841,9 @@ void FileView::mouseReleaseEvent(QMouseEvent *event)
 
 void FileView::dragEnterEvent(QDragEnterEvent *event)
 {
+    d->dragUpdate = QModelIndex();
+    d->dragAutoScrollTimer.stop();
+    d->dragAutoScrollCount = 0;
     if (d->dragDropHelper->dragEnter(event))
         return;
 
@@ -1846,26 +1852,47 @@ void FileView::dragEnterEvent(QDragEnterEvent *event)
 
 void FileView::dragMoveEvent(QDragMoveEvent *event)
 {
-    // Always call parent implementation first - it includes auto-scroll logic
-
-    // Note: 此处一定要调用QAbstractItemView的dragMoveEvent,而非父类的。
-    // 这是因为QListView::dragMoveEvent中对viewMode的listview进行了特殊处理，导致后续
-    // 无法进入到QAbstractItemView::dragMoveEvent。
-    // 而当前类的viewMode是重定义的，并非QListView定义的ViewMode，这就导致图标模式
-    // 实际上被当作QListView::ListMode处理。最根因的解决方案应该是基于QAbstractItemView重写整个视图，
-    // 当前整个FileView的实现是畸形的，在QListView的实现上进行的魔改隐藏了很多问题
-    QAbstractItemView::dragMoveEvent(event);
-
-    // Handle drag-drop helper logic, but don't let it prevent Qt's auto-scroll logic
+    // 不调用 QAbstractItemView::dragMoveEvent：它在 canDrop 分支里执行
+    // d->viewport->update() 做全 viewport 重绘，仅为绘制 Qt 内置 drop indicator。
+    // 而 FileView 已 setDropIndicatorShown(false)，该重绘纯浪费，是拖拽卡顿根因。
+    // auto-scroll 由本类自管（见 timerEvent），保留滚动能力的同时彻底避免全屏重绘。
     if (d->dragDropHelper->dragMove(event)) {
-        viewport()->update();
-        // Note: We intentionally don't return here, so that both auto-scroll and dragDropHelper work
+        auto index = indexAt(event->position().toPoint());
+        auto last = d->dragUpdate;
+        if (last.isValid() && last != index)
+            update(last);
+
+        if (index.isValid() && last != index)
+            update(index);
+
+        d->dragUpdate = index;
+    }
+
+    // 自管 auto-scroll：复刻 QAbstractItemViewPrivate::shouldAutoScroll 的边界判定，
+    // 滚动经 scrollBar->setValue → scrollContentsBy → viewport->scroll(bitblt) + 窄条 update。
+    d->dragCursorPos = event->position().toPoint();
+    const QRect area = viewport()->rect();
+    const int margin = autoScrollMargin();
+    const bool nearEdge = (d->dragCursorPos.y() - area.top() < margin)
+                          || (area.bottom() - d->dragCursorPos.y() < margin)
+                          || (d->dragCursorPos.x() - area.left() < margin)
+                          || (area.right() - d->dragCursorPos.x() < margin);
+    if (nearEdge) {
+        if (!d->dragAutoScrollTimer.isActive())
+            d->dragAutoScrollCount = 0;
+        d->dragAutoScrollTimer.start(50, this);   // 50ms = ScrollPerPixel 模式间隔
+    } else {
+        d->dragAutoScrollTimer.stop();
+        d->dragAutoScrollCount = 0;
     }
 }
 
 void FileView::dragLeaveEvent(QDragLeaveEvent *event)
 {
     setViewSelectState(false);
+    d->dragUpdate = QModelIndex();
+    d->dragAutoScrollTimer.stop();
+    d->dragAutoScrollCount = 0;
     if (d->dragDropHelper->dragLeave(event))
         return;
 
@@ -1877,6 +1904,44 @@ void FileView::dropEvent(QDropEvent *event)
     setViewSelectState(false);
     d->dragDropHelper->drop(event);
     setState(QAbstractItemView::NoState);
+    d->dragUpdate = QModelIndex();
+    d->dragAutoScrollTimer.stop();
+    d->dragAutoScrollCount = 0;
+}
+
+void FileView::timerEvent(QTimerEvent *event)
+{
+    if (event->timerId() == d->dragAutoScrollTimer.timerId()) {
+        const QRect area = viewport()->rect();
+        const int margin = autoScrollMargin();
+        QScrollBar *vb = verticalScrollBar();
+        QScrollBar *hb = horizontalScrollBar();
+        const int step = qMax(vb->pageStep(), hb->pageStep());
+        if (d->dragAutoScrollCount < step)
+            ++d->dragAutoScrollCount;
+
+        bool scrolled = false;
+        if (d->dragCursorPos.y() - area.top() < margin) {
+            vb->setValue(vb->value() - d->dragAutoScrollCount);
+            scrolled = true;
+        } else if (area.bottom() - d->dragCursorPos.y() < margin) {
+            vb->setValue(vb->value() + d->dragAutoScrollCount);
+            scrolled = true;
+        }
+        if (d->dragCursorPos.x() - area.left() < margin) {
+            hb->setValue(hb->value() - d->dragAutoScrollCount);
+            scrolled = true;
+        } else if (area.right() - d->dragCursorPos.x() < margin) {
+            hb->setValue(hb->value() + d->dragAutoScrollCount);
+            scrolled = true;
+        }
+        if (!scrolled) {
+            d->dragAutoScrollTimer.stop();
+            d->dragAutoScrollCount = 0;
+        }
+        return;
+    }
+    DListView::timerEvent(event);
 }
 
 QModelIndex FileView::indexAt(const QPoint &pos) const

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1841,9 +1841,7 @@ void FileView::mouseReleaseEvent(QMouseEvent *event)
 
 void FileView::dragEnterEvent(QDragEnterEvent *event)
 {
-    d->dragUpdate = QModelIndex();
-    d->dragAutoScrollTimer.stop();
-    d->dragAutoScrollCount = 0;
+    resetDragState();
     if (d->dragDropHelper->dragEnter(event))
         return;
 
@@ -1856,43 +1854,16 @@ void FileView::dragMoveEvent(QDragMoveEvent *event)
     // d->viewport->update() 做全 viewport 重绘，仅为绘制 Qt 内置 drop indicator。
     // 而 FileView 已 setDropIndicatorShown(false)，该重绘纯浪费，是拖拽卡顿根因。
     // auto-scroll 由本类自管（见 timerEvent），保留滚动能力的同时彻底避免全屏重绘。
-    if (d->dragDropHelper->dragMove(event)) {
-        auto index = indexAt(event->position().toPoint());
-        auto last = d->dragUpdate;
-        if (last.isValid() && last != index)
-            update(last);
+    if (d->dragDropHelper->dragMove(event))
+        updateDragHighlight(indexAt(event->position().toPoint()));
 
-        if (index.isValid() && last != index)
-            update(index);
-
-        d->dragUpdate = index;
-    }
-
-    // 自管 auto-scroll：复刻 QAbstractItemViewPrivate::shouldAutoScroll 的边界判定，
-    // 滚动经 scrollBar->setValue → scrollContentsBy → viewport->scroll(bitblt) + 窄条 update。
-    d->dragCursorPos = event->position().toPoint();
-    const QRect area = viewport()->rect();
-    const int margin = autoScrollMargin();
-    const bool nearEdge = (d->dragCursorPos.y() - area.top() < margin)
-                          || (area.bottom() - d->dragCursorPos.y() < margin)
-                          || (d->dragCursorPos.x() - area.left() < margin)
-                          || (area.right() - d->dragCursorPos.x() < margin);
-    if (nearEdge) {
-        if (!d->dragAutoScrollTimer.isActive())
-            d->dragAutoScrollCount = 0;
-        d->dragAutoScrollTimer.start(50, this);   // 50ms = ScrollPerPixel 模式间隔
-    } else {
-        d->dragAutoScrollTimer.stop();
-        d->dragAutoScrollCount = 0;
-    }
+    updateDragAutoScroll(event->position().toPoint());
 }
 
 void FileView::dragLeaveEvent(QDragLeaveEvent *event)
 {
     setViewSelectState(false);
-    d->dragUpdate = QModelIndex();
-    d->dragAutoScrollTimer.stop();
-    d->dragAutoScrollCount = 0;
+    resetDragState();
     if (d->dragDropHelper->dragLeave(event))
         return;
 
@@ -1904,44 +1875,91 @@ void FileView::dropEvent(QDropEvent *event)
     setViewSelectState(false);
     d->dragDropHelper->drop(event);
     setState(QAbstractItemView::NoState);
-    d->dragUpdate = QModelIndex();
-    d->dragAutoScrollTimer.stop();
-    d->dragAutoScrollCount = 0;
+    resetDragState();
 }
 
 void FileView::timerEvent(QTimerEvent *event)
 {
     if (event->timerId() == d->dragAutoScrollTimer.timerId()) {
-        const QRect area = viewport()->rect();
-        const int margin = autoScrollMargin();
-        QScrollBar *vb = verticalScrollBar();
-        QScrollBar *hb = horizontalScrollBar();
-        const int step = qMax(vb->pageStep(), hb->pageStep());
-        if (d->dragAutoScrollCount < step)
-            ++d->dragAutoScrollCount;
-
-        bool scrolled = false;
-        if (d->dragCursorPos.y() - area.top() < margin) {
-            vb->setValue(vb->value() - d->dragAutoScrollCount);
-            scrolled = true;
-        } else if (area.bottom() - d->dragCursorPos.y() < margin) {
-            vb->setValue(vb->value() + d->dragAutoScrollCount);
-            scrolled = true;
-        }
-        if (d->dragCursorPos.x() - area.left() < margin) {
-            hb->setValue(hb->value() - d->dragAutoScrollCount);
-            scrolled = true;
-        } else if (area.right() - d->dragCursorPos.x() < margin) {
-            hb->setValue(hb->value() + d->dragAutoScrollCount);
-            scrolled = true;
-        }
-        if (!scrolled) {
-            d->dragAutoScrollTimer.stop();
-            d->dragAutoScrollCount = 0;
-        }
+        processDragAutoScroll();
         return;
     }
     DListView::timerEvent(event);
+}
+
+void FileView::resetDragState()
+{
+    d->dragUpdate = QModelIndex();
+    d->dragAutoScrollTimer.stop();
+    d->dragAutoScrollCount = 0;
+}
+
+void FileView::updateDragHighlight(const QModelIndex &index)
+{
+    const auto last = d->dragUpdate;
+    if (last.isValid() && last != index)
+        update(last);
+    if (index.isValid() && last != index)
+        update(index);
+    d->dragUpdate = index;
+}
+
+void FileView::updateDragAutoScroll(QPoint pos)
+{
+    d->dragCursorPos = pos;
+
+    const QRect area = viewport()->rect();
+    const int margin = autoScrollMargin();
+    const bool nearEdge = (pos.y() - area.top() < margin)
+                          || (area.bottom() - pos.y() < margin)
+                          || (pos.x() - area.left() < margin)
+                          || (area.right() - pos.x() < margin);
+
+    if (nearEdge) {
+        if (!d->dragAutoScrollTimer.isActive())
+            d->dragAutoScrollCount = 0;
+        d->dragAutoScrollTimer.start(50, this);   // 50ms = ScrollPerPixel 模式间隔
+    } else {
+        d->dragAutoScrollTimer.stop();
+        d->dragAutoScrollCount = 0;
+    }
+}
+
+bool FileView::processDragAutoScroll()
+{
+    const QRect area = viewport()->rect();
+    const int margin = autoScrollMargin();
+    QScrollBar *vb = verticalScrollBar();
+    QScrollBar *hb = horizontalScrollBar();
+    const int step = qMax(vb->pageStep(), hb->pageStep());
+
+    if (d->dragAutoScrollCount < step)
+        ++d->dragAutoScrollCount;
+
+    bool scrolled = false;
+    const QPoint &pos = d->dragCursorPos;
+
+    if (pos.y() - area.top() < margin) {
+        vb->setValue(vb->value() - d->dragAutoScrollCount);
+        scrolled = true;
+    } else if (area.bottom() - pos.y() < margin) {
+        vb->setValue(vb->value() + d->dragAutoScrollCount);
+        scrolled = true;
+    }
+
+    if (pos.x() - area.left() < margin) {
+        hb->setValue(hb->value() - d->dragAutoScrollCount);
+        scrolled = true;
+    } else if (area.right() - pos.x() < margin) {
+        hb->setValue(hb->value() + d->dragAutoScrollCount);
+        scrolled = true;
+    }
+
+    if (!scrolled) {
+        d->dragAutoScrollTimer.stop();
+        d->dragAutoScrollCount = 0;
+    }
+    return scrolled;
 }
 
 QModelIndex FileView::indexAt(const QPoint &pos) const

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -168,6 +168,7 @@ protected:
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dragLeaveEvent(QDragLeaveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+    void timerEvent(QTimerEvent *event) override;
     void updateGeometries() override;
     void startDrag(Qt::DropActions supportedActions) override;
     QModelIndexList selectedIndexes() const override;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -215,6 +215,11 @@ private:
     void initializeGroupHeaderTimer();
     void updateDelegateHighlightKeywords(const QStringList &keywords);
 
+    void resetDragState();
+    void updateDragHighlight(const QModelIndex &index);
+    void updateDragAutoScroll(QPoint pos);
+    bool processDragAutoScroll();
+
     void delayUpdateStatusBar();
     void updateStatusBar();
     void updateLoadingIndicator();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
@@ -15,6 +15,7 @@
 #include <QObject>
 #include <QUrl>
 #include <QLabel>
+#include <QBasicTimer>
 
 namespace GlobalPrivate {
 inline constexpr int kListViewMinimumWidth { 80 };
@@ -91,6 +92,10 @@ class FileViewPrivate
     bool itemsExpandable { false };
     std::atomic_bool isShowSmbMountError { false };
     QString previousGroupStrategy { GroupStrategy::kNoGroup };
+    QModelIndex dragUpdate;
+    QBasicTimer dragAutoScrollTimer;
+    QPoint dragCursorPos;
+    int dragAutoScrollCount { 0 };
 
     explicit FileViewPrivate(FileView *qq);
     int iconModeColumnCount(int itemWidth = 0) const;


### PR DESCRIPTION
1. Added selective viewport updates to only redraw affected items during
drag move operations
2. Implemented custom auto-scroll logic to avoid QAbstractItemView's
full viewport updates
3. Tracked hover index changes to minimize unnecessary re-renders
4. Added state checks to prevent redundant view selection box updates

The changes address performance issues during drag-and-drop operations
by:
- Avoiding full viewport updates when only specific items need redrawing
- Maintaining visual feedback while significantly improving
responsiveness
- Replacing Qt's default auto-scroll behavior with more efficient
implementation
- Adding proper state cleanup during drag leave/drop events

Log: Improved drag-and-drop experience with smoother performance

Influence:
1. Test drag operations across folder views with many items
2. Verify hover highlight shows correctly during drag move
3. Check auto-scroll behavior near viewport edges
4. Test drag operations between different folders
5. Verify no visual artifacts during drag-and-drop

perf: 优化文件视图中的拖拽性能

1. 添加选择性视口更新，仅在拖拽移动时重绘受影响区域
2. 实现自定义自动滚动逻辑以避免QAbstractItemView的全屏重绘
3. 跟踪悬停索引变化以最小化不必要的重新渲染
4. 添加状态检查防止冗余视图选择框更新

这些改进通过以下方式解决了拖拽操作中的性能问题：
- 当仅需重绘特定项目时避免全视口更新
- 保持视觉反馈的同时显著提升响应速度
- 用更高效实现取代Qt默认的自动滚动行为
- 在拖拽离开/放下事件中添加适当的状态清理

Log: 优化了拖拽操作的性能表现，体验更流畅

Influence:
1. 测试包含大量项目的文件夹视图中的拖拽操作
2. 验证拖拽移动时的悬停高亮显示正确
3. 检查接近视口边缘时的自动滚动行为
4. 测试不同文件夹间的拖拽操作
5. 验证拖拽过程中无视觉异常

## Summary by Sourcery

Improve FileView drag-and-drop responsiveness by minimizing unnecessary viewport repaints and managing auto-scroll behavior internally during drag operations.

Enhancements:
- Skip redundant selection box updates when the state does not change to avoid unnecessary full-viewport redraws.
- Replace QAbstractItemView-based dragMove handling with custom logic that only repaints affected items and drives auto-scroll without triggering full viewport updates.
- Introduce internal drag auto-scroll state and timer-based scrolling near viewport edges to maintain smooth drag behavior while limiting repaint scope.
- Reset drag-related state, including hover tracking and auto-scroll, on drag enter, leave, and drop events for consistent visual feedback and cleanup.
- Track the current hover index URL in the drag/drop helper to support accurate hover handling during drag moves.