### PR TITLE
fix: handle empty directory refresh and clean sort data

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -1279,6 +1279,10 @@ void FileViewModel::onWorkFinish(int visiableCount, int totalCount)
 
     // 如果是保留策略，在加载完成后清理旧的RootInfo对象
     if (dirLoadStrategy == DirectoryLoadStrategy::kPreserve) {
+        if (visiableCount == 0) {
+            beginResetModel();
+            endResetModel();
+        }
         fmDebug() << "Cleaning unused roots after preserve strategy completion for URL:" << dirRootUrl.toString();
         // 获取当前URL所有子目录的RootInfo
         FileDataManager::instance()->cleanUnusedRoots(dirRootUrl, currentKey);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -389,6 +389,7 @@ void FileSortWorker::handleTraversalFinish(const QString &key, bool noDataProduc
         visibleChildren.clear();
 
         children.clear();
+        groupedModelData.clear();
     }
 
     Q_EMIT requestSetIdel(visibleChildren.count(), childrenDataMap.count());


### PR DESCRIPTION
1. Added model reset when visible count is 0 in preserve strategy to
properly handle empty directory refresh
2. Cleaned groupedModelData in FileSortWorker to prevent potential
memory leaks and ensure proper sorting on next load
3. These changes address issues with UI refresh when directories become
empty and maintain clean state for sorting operations

Log: Fixed empty directory refresh issues in file manager

Influence:
1. Test opening and refreshing empty directories
2. Verify file sorting works correctly after visiting an empty directory
3. Check memory usage when repeatedly opening and closing directories

fix: 处理空目录刷新和清理排序数据

1. 在保留策略中当可视项为0时重置模型，以正确处理空目录刷新
2. 在FileSortWorker中清理groupedModelData以防止内存泄漏并确保下次加载正
确排序
3. 这些修改解决了目录变为空时UI刷新的问题并保持排序操作的干净状态

Log: 修复文件管理器中空目录刷新问题

Influence:
1. 测试打开和刷新空目录
2. 验证访问空目录后文件排序功能正常工作
3. 检查反复打开和关闭目录时的内存使用情况

## Summary by Sourcery

Handle empty directory refresh and ensure sort state is cleaned after traversal to avoid stale data and potential memory issues.

Bug Fixes:
- Reset the file view model when preserve strategy completes with zero visible items to fix UI refresh in empty directories.
- Clear grouped model data in the file sort worker after traversal to prevent stale sorting state and potential memory leaks.