### PR TITLE
fix(preview): show video play button background

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
@@ -15,7 +15,6 @@ VideoStatusBar::VideoStatusBar(VideoPreview *preview)
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
     DIconButton *control_button = new DIconButton(this);
-    control_button->setFlat(true);
     control_button->setIconSize({ 24, 24 });
 
     control_button->setIcon(QIcon::fromTheme("dfm_pause"));


### PR DESCRIPTION
1. Remove the flat style from the video preview play/pause button.
2. Restore the default button background to match the Open button.
3. Keep the existing play/pause behavior and icon switching unchanged.

Log: Fixed the missing background on the video preview play/pause button

fix(preview): 显示视频播放按钮背景

1. 移除视频预览播放/暂停按钮的扁平样式。
2. 恢复默认按钮背景，使其与「打开」按钮样式一致。
3. 保持原有播放/暂停逻辑和图标切换行为不变。

Log: 修复视频预览播放/暂停按钮缺少背景的问题
PMS: https://pms.uniontech.com/bug-view-369243.html