### PR TITLE
feat: add sticky group header and fix search auth hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ AGENTS.md
 .agents
 .worktrees
 .codex
-
+.opencode
 
 # autotests
 Testing

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -124,7 +124,8 @@ bool SearchHelper::shouldEnableSemanticSearch(const QString &keyword)
         return false;
 
     if (!DConfigManager::instance()->value(DConfig::kSearchCfgPath,
-                                           DConfig::kEnableSemanticSearch, false).toBool()) {
+                                           DConfig::kEnableSemanticSearch, false)
+                 .toBool()) {
         return false;
     }
 
@@ -488,6 +489,10 @@ bool SearchHelper::shouldShowAuthHint(const QUrl &url, QString *text)
     if (DConfigManager::instance()->value(cfg, DConfig::kSearchAuthHintDone, false).toBool())
         return false;
 
+    bool needHint = !DConfigManager::instance()->value(cfg, DConfig::kEnableFileIndexSearch, false).toBool();
+    if (!needHint)
+        return false;
+
     // 收集尚未开启的搜索模式，仅在提示中展示用户实际需要开启的功能项。
     QStringList modes = disabledSearchModes();
     if (modes.isEmpty())
@@ -563,7 +568,8 @@ QStringList SearchHelper::disabledSearchModes()
         modes << tr("\"Full-Text search\"");
     if (!DConfigManager::instance()->value(cfg, DConfig::kEnableOcrTextSearch, false).toBool())
         modes << tr("\"Image-Content search\"");
-    if (!DConfigManager::instance()->value(cfg, DConfig::kEnableSemanticSearch, false).toBool())
+    if (!DConfigManager::instance()->value(cfg, DConfig::kEnableSemanticSearch, false).toBool()
+        || !DConfigManager::instance()->value(cfg, DConfig::kEnableFileIndexSearch, false).toBool())
         modes << tr("\"Smart search\"");
     return modes;
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -369,24 +369,53 @@ void BaseItemDelegate::paintGroupHeader(QPainter *painter, const QStyleOptionVie
 
     painter->restore();
 
-    // Get group information
+    paintGroupHeaderContent(painter, drawRect, option, index);
+}
+
+void BaseItemDelegate::paintStickyGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    if (!painter || !index.isValid()) {
+        return;
+    }
+
+    QRectF drawRect = option.rect;
+
+    if (option.widget) {
+        painter->save();
+
+        DPalette pl(DPaletteHelper::instance()->palette(option.widget));
+        painter->setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
+
+        QColor baseColor = pl.color(QPalette::Active, QPalette::Window);
+        painter->fillRect(drawRect, baseColor);
+
+        if (option.state & QStyle::State_MouseOver) {
+            QRectF bgRect = getGroupHeaderBackgroundRect(option);
+            QColor itemColor = pl.color(DPalette::ColorGroup::Active, DPalette::ColorType::ItemBackground);
+            QColor adjustColor = DGuiApplicationHelper::adjustColor(itemColor, 0, 0, 0, 0, 0, 0, +10);
+
+            QPainterPath path;
+            path.addRoundedRect(bgRect, kListModeRectRadius, kListModeRectRadius);
+            painter->fillPath(path, adjustColor);
+        }
+
+        painter->restore();
+    }
+
+    paintGroupHeaderContent(painter, drawRect, option, index);
+}
+
+void BaseItemDelegate::paintGroupHeaderContent(QPainter *painter, const QRectF &drawRect, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
     QString groupText = index.data(Qt::DisplayRole).toString();
     int fileCount = index.data(Global::kItemGroupFileCount).toInt();
-    if (groupText.isEmpty()) {
+    if (groupText.isEmpty())
         groupText = "Group";
-    }
 
     bool isExpanded = index.data(Global::ItemRoles::kItemGroupExpandedRole).toBool();
 
-    // Use centralized layout methods for consistent positioning
-    QRect expandButtonRect = getExpandButtonRect(drawRect);
-    QRect textRect = getGroupTextRect(drawRect);
-
-    // Paint expand button
-    paintExpandButton(painter, expandButtonRect, isExpanded);
-
-    // Paint group text
-    paintGroupText(painter, textRect, groupText, fileCount, option);
+    paintExpandButton(painter, getExpandButtonRect(drawRect), isExpanded);
+    paintGroupText(painter, getGroupTextRect(drawRect), groupText, fileCount, option);
 }
 
 QRectF BaseItemDelegate::getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -136,6 +136,8 @@ public:
     virtual bool isGroupHeaderItem(const QModelIndex &index) const;
     virtual QSize getGroupHeaderSizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
     virtual void paintGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    virtual void paintStickyGroupHeader(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    virtual int getGroupHeaderHeight(const QStyleOptionViewItem &option) const = 0;
 
     QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
     QRect getExpandButtonRect(const QRectF &rect) const;
@@ -145,14 +147,12 @@ protected:
 
     virtual void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override;
 
-    // Pure virtual method for group header height - must be implemented by subclasses
-    virtual int getGroupHeaderHeight(const QStyleOptionViewItem &option) const = 0;
-
     // Virtual method for group header background rect - can be overridden by subclasses
     virtual QRectF getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const;
 
     // Group rendering helper methods
     void paintGroupBackground(QPainter *painter, const QStyleOptionViewItem &option) const;
+    void paintGroupHeaderContent(QPainter *painter, const QRectF &drawRect, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void paintExpandButton(QPainter *painter, const QRect &buttonRect, bool isExpanded) const;
     void paintGroupText(QPainter *painter, const QRect &textRect, const QString &text, int count, const QStyleOptionViewItem &option) const;
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -940,6 +940,7 @@ void FileView::setGroup(const QString &strategyName, const Qt::SortOrder order)
 
     // 在分组开始前保存当前的分组策略
     d->previousGroupStrategy = model()->groupingStrategy();
+    clearStickyHeaderState();
 
     model()->grouping(strategyName, order);
 
@@ -1546,7 +1547,7 @@ bool FileView::groupExpandOrCollapseItem(const QModelIndex &index, const QPoint 
         return true;
     }
     QStyleOptionViewItem op;
-    QRect rect = visualRect(index);   // 绘制区域
+    QRect rect = (index == d->currentStickyIndex) ? d->currentStickyRect : visualRect(index);
     op.rect = rect;
     QRect arrowRect = itemDelegate()->getExpandButtonRect(op);
 
@@ -1714,6 +1715,22 @@ void FileView::setSelection(const QRect &rect, QItemSelectionModel::SelectionFla
 
 void FileView::mousePressEvent(QMouseEvent *event)
 {
+    if (isPosInStickyHeader(event->pos())) {
+        QModelIndex stickyIdx = d->currentStickyIndex;
+        if (event->button() == Qt::LeftButton) {
+            d->lastClickedIndex = stickyIdx;
+            if (groupExpandOrCollapseItem(stickyIdx, event->pos())) {
+                if (stickyIdx.data(Global::kItemGroupExpandedRole).toBool())
+                    scrollStickyHeaderToTop(stickyIdx);
+                return;
+            }
+            d->groupHeaderTimer->start();
+        } else if (event->button() == Qt::RightButton) {
+            onGroupHeaderClicked(stickyIdx);
+        }
+        return;
+    }
+
     if (event->buttons().testFlag(Qt::LeftButton)) {
         d->mouseLeftPressed = true;
         d->mouseLastPos = event->globalPos();
@@ -1809,6 +1826,10 @@ void FileView::mousePressEvent(QMouseEvent *event)
 
 void FileView::mouseMoveEvent(QMouseEvent *event)
 {
+    if (isPosInStickyHeader(event->pos())) {
+        return;
+    }
+
     if (d->pressedStartWithExpand)
         return;
 
@@ -1964,6 +1985,9 @@ bool FileView::processDragAutoScroll()
 
 QModelIndex FileView::indexAt(const QPoint &pos) const
 {
+    if (d->currentStickyIndex.isValid() && d->currentStickyRect.contains(pos))
+        return QModelIndex();
+
     // For icon mode, use custom calculation
     if (isIconViewMode()) {
         QSize itemSize = itemSizeHint();
@@ -2393,6 +2417,35 @@ bool FileView::eventFilter(QObject *obj, QEvent *event)
             d->headerView->doFileNameColumnResize(width());
         }
         break;
+    case QEvent::HoverMove: {
+        if (d->currentStickyIndex.isValid() && !d->currentStickyRect.isNull()) {
+            auto *he = static_cast<QHoverEvent *>(event);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            QPoint hoverPos = he->pos();
+#else
+            QPoint hoverPos = he->position().toPoint();
+#endif
+            // currentStickyRect is in viewport coordinates; map hover pos
+            // from the event's target widget to the viewport if needed.
+            if (QWidget *w = qobject_cast<QWidget *>(obj)) {
+                if (w != viewport())
+                    hoverPos = viewport()->mapFromGlobal(w->mapToGlobal(hoverPos));
+            }
+            bool nowHovered = d->currentStickyRect.contains(hoverPos);
+            if (nowHovered != d->stickyHeaderHovered) {
+                d->stickyHeaderHovered = nowHovered;
+                viewport()->update(d->currentStickyRect);
+            }
+        }
+        break;
+    }
+    case QEvent::HoverLeave: {
+        if (d->stickyHeaderHovered && d->currentStickyIndex.isValid()) {
+            d->stickyHeaderHovered = false;
+            viewport()->update(d->currentStickyRect);
+        }
+        break;
+    }
     // blumia: 这里通过给横向滚动条加事件过滤器并监听其显示隐藏时间来判断是否应当进入吸附状态。
     //         不过其实可以通过 Resize 事件的 size 和 oldSize 判断是否由于窗口调整大小而进入了吸附状态。
     //         鉴于已经实现完了，如果当前的实现方式实际发现了较多问题，则应当调整为使用 Resize 事件来标记吸附状态的策略。
@@ -2450,6 +2503,19 @@ void FileView::paintEvent(QPaintEvent *event)
         QPen pen(color, kSelectBoxLineWidth);
         painter.setPen(pen);
         painter.drawRect(QRectF(kSelectBoxLineWidth / 2, kSelectBoxLineWidth / 2, viewport()->size().width() - kSelectBoxLineWidth, viewport()->size().height() - kSelectBoxLineWidth));
+    }
+
+    if (isGroupedView() && model()->groupingState() == GroupingState::kIdle) {
+        const int headerHeight = stickyHeaderHeight();
+        QModelIndex stickyIdx = findStickyGroupIndex(headerHeight);
+        if (stickyIdx.isValid()) {
+            int stickyY = computeStickyY(headerHeight);
+            paintStickyHeaderOverlay(stickyIdx, stickyY, headerHeight);
+        } else if (d->currentStickyIndex.isValid()) {
+            clearStickyHeaderState();
+        }
+    } else if (d->currentStickyIndex.isValid()) {
+        clearStickyHeaderState();
     }
 }
 
@@ -2657,6 +2723,10 @@ void FileView::initializeScrollBarWatcher()
                     d->headerView->syncOffset(hVal);
                 });
             }
+        }
+
+        if (isGroupedView()) {
+            viewport()->update();
         }
     });
 }
@@ -2916,6 +2986,7 @@ void FileView::onModelStateChanged()
 {
     fmDebug() << "Model state changed to:" << static_cast<int>(model()->currentState()) << "for URL:" << rootUrl().toString();
 
+    clearStickyHeaderState();
     updateContentLabel();
     updateLoadingIndicator();
     updateSelectedUrl();
@@ -3024,6 +3095,14 @@ bool FileView::isGroupHeader(const QModelIndex &index) const
     return !index.data(kItemGroupHeaderKey).toString().isEmpty();
 }
 
+int FileView::groupHeaderContentTop(const QModelIndex &index) const
+{
+    int top = visualRect(index).top();
+    if (index.data(Global::kItemGroupDisplayIndex).toInt() > 0)
+        top += kGroupHeaderInterval;
+    return top;
+}
+
 bool FileView::isClickInGroupHeaderSpacing(const QPoint &pos, const QModelIndex &index) const
 {
     if (!index.isValid() || !isGroupHeader(index))
@@ -3079,6 +3158,7 @@ void FileView::onGroupExpansionToggled(const QString &groupKey)
     }
 
     // Forward to model for handling
+    clearStickyHeaderState();
     if (model()) {
         model()->toggleGroupExpansion(groupKey);
     }
@@ -3097,4 +3177,179 @@ void FileView::onGroupHeaderClicked(const QModelIndex &index)
     if (d->selectHelper) {
         d->selectHelper->handleGroupHeaderClick(index, QApplication::keyboardModifiers());
     }
+}
+
+int FileView::stickyHeaderHeight() const
+{
+    if (!itemDelegate())
+        return 0;
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QStyleOptionViewItem opt = viewOptions();
+#else
+    QStyleOptionViewItem opt;
+    initViewItemOption(&opt);
+#endif
+    return itemDelegate()->getGroupHeaderHeight(opt);
+}
+
+QModelIndex FileView::findStickyGroupIndex(int headerHeight) const
+{
+    if (!isGroupedView() || !model())
+        return QModelIndex();
+
+    const int rowCount = model()->rowCount(rootIndex());
+    if (rowCount == 0 || model()->groupingState() != GroupingState::kIdle)
+        return QModelIndex();
+
+    if (d->currentStickyIndex.isValid() && isGroupHeader(d->currentStickyIndex)
+        && groupHeaderContentTop(d->currentStickyIndex) < 0) {
+        if (!d->cachedNextStickyHeader.isValid())
+            return d->currentStickyIndex;
+        if (isGroupHeader(d->cachedNextStickyHeader)
+            && groupHeaderContentTop(d->cachedNextStickyHeader) >= 0)
+            return d->currentStickyIndex;
+    }
+
+    QModelIndex firstVisible;
+    if (isIconViewMode()) {
+        firstVisible = iconIndexAt(QPoint(0, 1), itemSizeHint());
+    } else {
+        firstVisible = DListView::indexAt(QPoint(0, 1));
+    }
+
+    if (!firstVisible.isValid()) {
+        for (int i = 0; i < rowCount; ++i) {
+            QModelIndex idx = model()->index(i, 0, rootIndex());
+            QRect rect = visualRect(idx);
+            if (rect.bottom() >= 0) {
+                firstVisible = idx;
+                break;
+            }
+            if (rect.top() > 0)
+                break;
+        }
+    }
+
+    if (!firstVisible.isValid())
+        return QModelIndex();
+
+    QModelIndex sticky;
+    for (int i = firstVisible.row(); i >= 0; --i) {
+        QModelIndex idx = model()->index(i, 0, rootIndex());
+        if (isGroupHeader(idx)) {
+            int contentTop = groupHeaderContentTop(idx);
+            if (contentTop >= headerHeight)
+                return QModelIndex();
+            if (contentTop >= 0) {
+                for (int j = idx.row() - 1; j >= 0; --j) {
+                    QModelIndex prevIdx = model()->index(j, 0, rootIndex());
+                    if (isGroupHeader(prevIdx)) {
+                        sticky = prevIdx;
+                        break;
+                    }
+                }
+            } else {
+                sticky = idx;
+            }
+            break;
+        }
+    }
+
+    // Cache the next group header so computeStickyY is O(1).
+    d->cachedNextStickyHeader = QModelIndex();
+    if (sticky.isValid()) {
+        for (int i = sticky.row() + 1; i < rowCount; ++i) {
+            QModelIndex idx = model()->index(i, 0, rootIndex());
+            if (isGroupHeader(idx)) {
+                d->cachedNextStickyHeader = idx;
+                break;
+            }
+        }
+    }
+    return sticky;
+}
+
+int FileView::computeStickyY(int headerHeight) const
+{
+    if (!d->cachedNextStickyHeader.isValid())
+        return 0;
+
+    int nextTop = visualRect(d->cachedNextStickyHeader).top();
+    return qMax(-headerHeight, qMin(0, nextTop - headerHeight));
+}
+
+void FileView::paintStickyHeaderOverlay(const QModelIndex &index, int y, int headerHeight)
+{
+    if (!index.isValid() || !itemDelegate())
+        return;
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QStyleOptionViewItem opt = viewOptions();
+#else
+    QStyleOptionViewItem opt;
+    initViewItemOption(&opt);
+#endif
+    opt.widget = viewport();
+    opt.rect = QRect(0, y, viewport()->width(), headerHeight);
+    opt.index = index;
+
+    if (d->stickyHeaderHovered)
+        opt.state |= QStyle::State_MouseOver;
+    else
+        opt.state &= ~QStyle::State_MouseOver;
+
+    QPainter painter(viewport());
+    itemDelegate()->paintStickyGroupHeader(&painter, opt, index);
+
+    d->currentStickyIndex = index;
+    d->currentStickyRect = opt.rect;
+}
+
+bool FileView::isPosInStickyHeader(const QPoint &pos) const
+{
+    return d->currentStickyIndex.isValid() && d->currentStickyRect.contains(pos);
+}
+
+void FileView::clearStickyHeaderState()
+{
+    d->currentStickyIndex = QModelIndex();
+    d->currentStickyRect = QRect();
+    d->stickyHeaderHovered = false;
+    d->cachedNextStickyHeader = QModelIndex();
+}
+
+void FileView::scrollStickyHeaderToTop(const QModelIndex &headerIndex)
+{
+    const int row = headerIndex.row();
+    QTimer::singleShot(0, this, [this, row] {
+        QModelIndex idx = model()->index(row, 0, rootIndex());
+        if (idx.isValid())
+            scrollTo(idx, QAbstractItemView::PositionAtTop);
+    });
+}
+
+void FileView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    if (isPosInStickyHeader(event->pos())) {
+        if (event->button() == Qt::LeftButton) {
+            d->groupHeaderTimer->stop();
+            QModelIndex stickyIdx = d->currentStickyIndex;
+            bool wasExpanded = stickyIdx.data(Global::kItemGroupExpandedRole).toBool();
+            groupExpandOrCollapseItem(stickyIdx, QPoint(), false);
+            if (wasExpanded)
+                scrollStickyHeaderToTop(stickyIdx);
+        }
+        return;
+    }
+    DListView::mouseDoubleClickEvent(event);
+}
+
+void FileView::leaveEvent(QEvent *event)
+{
+    if (d->stickyHeaderHovered && d->currentStickyIndex.isValid()) {
+        d->stickyHeaderHovered = false;
+        viewport()->update(d->currentStickyRect);
+    }
+    DListView::leaveEvent(event);
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -164,6 +164,8 @@ protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void leaveEvent(QEvent *event) override;
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dragLeaveEvent(QDragLeaveEvent *event) override;
@@ -264,6 +266,15 @@ private:
     bool isGroupHeader(const QModelIndex &index) const;
     bool isClickInGroupHeaderSpacing(const QPoint &pos, const QModelIndex &index) const;
     QModelIndex indexAtForSelection(const QPoint &pos) const;
+
+    QModelIndex findStickyGroupIndex(int headerHeight) const;
+    int computeStickyY(int headerHeight) const;
+    int stickyHeaderHeight() const;
+    void paintStickyHeaderOverlay(const QModelIndex &index, int y, int headerHeight);
+    bool isPosInStickyHeader(const QPoint &pos) const;
+    void clearStickyHeaderState();
+    void scrollStickyHeaderToTop(const QModelIndex &headerIndex);
+    int groupHeaderContentTop(const QModelIndex &index) const;
 };
 
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
@@ -89,6 +89,11 @@ class FileViewPrivate
     bool initHorizontalOffset { false };
     int columnCountByCalc { 0 };
 
+    QModelIndex currentStickyIndex;
+    QRect currentStickyRect;
+    bool stickyHeaderHovered { false };
+    QModelIndex cachedNextStickyHeader;
+
     bool itemsExpandable { false };
     std::atomic_bool isShowSmbMountError { false };
     QString previousGroupStrategy { GroupStrategy::kNoGroup };


### PR DESCRIPTION
1. Implement sticky group header in file view: when scrolling, the group
header sticks to the top of the viewport until the next group header
pushes it away. Includes hover effect and expand/collapse support.
2. Refactor group header painting to share code between normal and
sticky headers.
3. Fix search authorization hint: skip showing auth hint if file index
search is already enabled.
4. Fix disabled search mode list: include "Smart search" also when file
index search is disabled, not only semantic search.
5. Add `.opencode` to gitignore.

Log: Group headers now stick to the top when scrolling in grouped file
view; search auth hint no longer appears when file indexing is enabled.

Influence:
1. Enable grouping (e.g., by type or date) in a folder and scroll down.
Verify the first visible group header sticks to the top.
2. Verify that clicking the expand/collapse arrow on a sticky header
works and expands/collapses the group.
3. Verify that double-clicking a sticky header collapses the group and
scrolls to make the header at top.
4. Verify right-click on sticky header shows the same context menu as
normal group header.
5. Hover over sticky header and verify visual highlight.
6. Test with icon view mode to ensure sticky header behaves correctly.
7. Test switching group strategy and verify sticky header state resets.
8. Test search auth hint: when file index search is already enabled, the
auth hint should not appear even if other search modes are disabled.
9. Verify "Smart search" is listed in disabled modes when either
semantic search or file index search is disabled.

feat: 添加粘性组头功能，修复搜索认证提示逻辑

1. 在文件视图分组模式下实现粘性组头：滚动时，当前组的组头会吸附在视口顶
部，直到下一组组头将其推离。支持悬停效果和展开/折叠交互。
2. 重构组头绘制代码，将通用绘制逻辑提取到 `paintGroupHeaderContent`，供
普通组头和粘性组头共享。
3. 修复搜索授权提示逻辑：当已启用文件索引搜索时，不再显示授权提示。
4. 修复禁用搜索模式列表：当文件索引搜索或语义搜索任一被禁用时，将"智能搜
索"列入禁用模式列表。
5. 将 `.opencode` 添加到 gitignore。

Log: 分组文件视图中组头随滚动吸附到顶部；开启文件索引后不再弹出搜索授权
提示。
