### PR TITLE
feat(desktop): add config to toggle input method on desktop canvas

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.desktop.json
+++ b/assets/configs/org.deepin.dde.file-manager.desktop.json
@@ -78,6 +78,17 @@
 			"description": "It's used to control whether to enable the WaterMask.",
 			"permissions": "readwrite",
 			"visibility": "public"
+		},
+		"enableCanvasInputMethod": {
+			"value": true,
+			"serial": 0,
+			"flags": [],
+			"name": "Enable Input Method on Desktop Canvas",
+			"name[zh_CN]": "桌面画布启用输入法",
+			"description": "Whether the desktop canvas activates the input method (for hotkey switching). Turn off on touch-screen large-display machines to prevent the soft keyboard from popping up on the desktop.",
+			"description[zh_CN]": "桌面画布是否激活输入法（用于快捷键切换）。触屏大屏机型应关闭，避免桌面弹出软键盘。",
+			"permissions": "readwrite",
+			"visibility": "public"
 		}
 	}
 }

--- a/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
+++ b/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
@@ -13,6 +13,7 @@ inline constexpr char kDefaultCfgPath[] { "org.deepin.dde.file-manager" };
 inline constexpr char kPluginsDConfName[] { "org.deepin.dde.file-manager.plugins" };
 inline constexpr char kViewDConfName[] { "org.deepin.dde.file-manager.view" };
 inline constexpr char kAnimationDConfName[] { "org.deepin.dde.file-manager.animation" };
+inline constexpr char kDesktopDConfName[] { "org.deepin.dde.file-manager.desktop" };
 }   // namespace ConfigPath
 
 /*!
@@ -25,6 +26,7 @@ inline constexpr char kOpenFolderWindowsInASeparateProcess[] { "dfm.open.in.sing
 inline constexpr char kCunstomFixedTabs[] { "dfm.custom.fixedtab" };
 inline constexpr char kPinnedTabs[] { "dfm.pinned.tabs" };
 inline constexpr char kDetailViewRemoteImageMaxSize[] { "dfm.detailview.remote.image.maxsize" };
+inline constexpr char kKeyCanvasInputMethod[] { "enableCanvasInputMethod" };
 }   // namespace BaseConfig
 
 /*!

--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
@@ -16,6 +16,7 @@
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-framework/dpf.h>
 #include <dfm-base/base/application/application.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <QPainter>
 #include <QDebug>
@@ -28,6 +29,8 @@
 
 DFMBASE_USE_NAMESPACE
 using namespace ddplugin_canvas;
+using namespace GlobalDConfDefines::ConfigPath;
+using namespace GlobalDConfDefines::BaseConfig;
 
 CanvasView::CanvasView(QWidget *parent)
     : QAbstractItemView(parent), d(new CanvasViewPrivate(this))
@@ -283,7 +286,7 @@ QRect CanvasView::expendedVisualRect(const QModelIndex &index) const
 QVariant CanvasView::inputMethodQuery(Qt::InputMethodQuery query) const
 {
     // When no item is selected, return input method area where the current mouse is located
-    if (query == Qt::ImCursorRectangle && !currentIndex().isValid())
+    if (d->imEnabled && query == Qt::ImCursorRectangle && !currentIndex().isValid())
         return QRect(mapFromGlobal(QCursor::pos()), iconSize());
 
     return QAbstractItemView::inputMethodQuery(query);
@@ -387,7 +390,7 @@ void CanvasView::contextMenuEvent(QContextMenuEvent *event)
         flags = model()->flags(index);
         d->menuProxy->showNormalMenu(index, flags, gridPos);
     }
-    if (WindowUtils::isWayLand())
+    if (WindowUtils::isWayLand() && d->imEnabled)
         setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
@@ -472,7 +475,7 @@ void CanvasView::focusInEvent(QFocusEvent *event)
 
     // WA_InputMethodEnabled will be set to false if current index is invalid in QAbstractItemView::focusInEvent
     // To enable WA_InputMethodEnabled no matter whether the current index is valid or not.
-    if (!testAttribute(Qt::WA_InputMethodEnabled))
+    if (d->imEnabled && !testAttribute(Qt::WA_InputMethodEnabled))
         setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
@@ -674,7 +677,7 @@ void CanvasView::currentChanged(const QModelIndex &current, const QModelIndex &p
 
     // WA_InputMethodEnabled will be set to false if current index is invalid in QAbstractItemView::currentChanged
     // To enable WA_InputMethodEnabled no matter whether the current index is valid or not.
-    if (!testAttribute(Qt::WA_InputMethodEnabled))
+    if (d->imEnabled && !testAttribute(Qt::WA_InputMethodEnabled))
         setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
@@ -770,7 +773,9 @@ void CanvasView::wheelEvent(QWheelEvent *event)
 void CanvasView::initUI()
 {
     setAttribute(Qt::WA_TranslucentBackground);
-    setAttribute(Qt::WA_InputMethodEnabled);
+    d->imEnabled = DConfigManager::instance()->value(kDesktopDConfName, kKeyCanvasInputMethod, true).toBool();
+    if (d->imEnabled)
+        setAttribute(Qt::WA_InputMethodEnabled);
     viewport()->setAttribute(Qt::WA_TranslucentBackground);
     viewport()->setAutoFillBackground(false);
     setFrameShape(QFrame::NoFrame);

--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview_p.h
@@ -132,6 +132,7 @@ public:
     ViewSettingUtil *viewSetting;
     OperState state;
     bool flicker = false;
+    bool imEnabled { true };   // 是否在桌面画布激活输入法（触屏大屏机型关闭以避免误弹软键盘）
 
     CanvasViewMenuProxy *menuProxy = nullptr;
     WatermaskContainer *waterMask = nullptr;

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -24,6 +24,7 @@
 #include <dfm-base/utils/clipboard.h>
 #include <dfm-base/utils/filenamesorter.h>
 #include <dfm-base/base/application/application.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <DApplication>
 #include <DFileDragClient>
@@ -40,6 +41,8 @@ using namespace ddplugin_organizer;
 DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 DFMGLOBAL_USE_NAMESPACE
+using namespace GlobalDConfDefines::ConfigPath;
+using namespace GlobalDConfDefines::BaseConfig;
 
 // no need view margin, this 2px used to draw inner and out order.
 static constexpr int kCollectionViewMargin = 0;   // 2
@@ -62,7 +65,9 @@ CollectionViewPrivate::~CollectionViewPrivate()
 void CollectionViewPrivate::initUI()
 {
     q->setAttribute(Qt::WA_TranslucentBackground);
-    q->setAttribute(Qt::WA_InputMethodEnabled);
+    imEnabled = DConfigManager::instance()->value(kDesktopDConfName, kKeyCanvasInputMethod, true).toBool();
+    if (imEnabled)
+        q->setAttribute(Qt::WA_InputMethodEnabled);
 
 #ifdef QT_SCROLL_WHEEL_ANI
     QScrollBar *bar = q->verticalScrollBar();
@@ -2270,7 +2275,7 @@ void CollectionView::focusInEvent(QFocusEvent *event)
 
     // WA_InputMethodEnabled will be set to false if current index is invalid in QAbstractItemView::focusInEvent
     // To enable WA_InputMethodEnabled no matter whether the current index is valid or not.
-    if (!testAttribute(Qt::WA_InputMethodEnabled))
+    if (d->imEnabled && !testAttribute(Qt::WA_InputMethodEnabled))
         setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 
@@ -2328,7 +2333,7 @@ void CollectionView::keyboardSearch(const QString &search)
 QVariant CollectionView::inputMethodQuery(Qt::InputMethodQuery query) const
 {
     // When no item is selected, return input method area where the current mouse is located
-    if (query == Qt::ImCursorRectangle && !currentIndex().isValid())
+    if (d->imEnabled && query == Qt::ImCursorRectangle && !currentIndex().isValid())
         return QRect(mapFromGlobal(QCursor::pos()), iconSize());
 
     return QAbstractItemView::inputMethodQuery(query);
@@ -2368,7 +2373,7 @@ void CollectionView::currentChanged(const QModelIndex &current, const QModelInde
 
     // WA_InputMethodEnabled will be set to false if current index is invalid in QAbstractItemView::currentChanged
     // To enable WA_InputMethodEnabled no matter whether the current index is valid or not.
-    if (!testAttribute(Qt::WA_InputMethodEnabled))
+    if (d->imEnabled && !testAttribute(Qt::WA_InputMethodEnabled))
         setAttribute(Qt::WA_InputMethodEnabled, true);
 }
 

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview_p.h
@@ -166,6 +166,7 @@ public:
 
     bool flicker = false;
     bool freeze { false };
+    bool imEnabled { true };   // 是否在桌面画布激活输入法（触屏大屏机型关闭以避免误弹软键盘）
 
     DFMBASE_NAMESPACE::DFMMimeData dfmmimeData;
 };


### PR DESCRIPTION
- Add `enableCanvasInputMethod` dconfig item in desktop config to control whether input method is activated on desktop canvas
- Define `kDesktopDConfName` and `kKeyCanvasInputMethod` constants in global dconfig defines
- Gate input method activation behind `imEnabled` flag in CanvasView (initUI, focusInEvent, currentChanged, contextMenuEvent, inputMethodQuery) to avoid soft keyboard popping up on touch-screen devices
- Apply the same input method toggle to CollectionView in organizer

新增(desktop): 新增桌面画布输入法开关配置

- 在桌面配置中新增 `enableCanvasInputMethod` dconfig 配置项，控制是否在桌面画布激活输入法
- 在全局 dconfig 定义中新增 `kDesktopDConfName` 和 `kKeyCanvasInputMethod` 常量
- 在 CanvasView 中以 `imEnabled` 标志控制输入法激活（initUI、focusInEvent、currentChanged、contextMenuEvent、inputMethodQuery），避免触屏设备误弹软键盘
- 在 organizer 的 CollectionView 中应用相同的输入法开关控制

Log: 为桌面画布新增输入法开关配置，触屏大屏机型可关闭输入法以避免误弹软键盘
Task: https://pms.uniontech.com/task-view-391985.html