### PR TITLE
refactor: move file index control to daemon core

### DIFF
--- a/src/plugins/daemon/core/core.cpp
+++ b/src/plugins/daemon/core/core.cpp
@@ -43,6 +43,8 @@ void Core::initialize()
     textIndexController->initialize();
     ocrIndexController.reset(new OcrIndexController);
     ocrIndexController->initialize();
+    fileIndexController.reset(new FileIndexController);
+    fileIndexController->initialize();
 }
 
 bool Core::start()

--- a/src/plugins/daemon/core/core.h
+++ b/src/plugins/daemon/core/core.h
@@ -8,6 +8,7 @@
 #include "daemonplugin_core_global.h"
 #include "textindexcontroller.h"
 #include "ocrindexcontroller.h"
+#include "fileindexcontroller.h"
 
 #include <dfm-framework/dpf.h>
 
@@ -42,6 +43,7 @@ private:
     QScopedPointer<SyncDBus> syncDBus;
     QScopedPointer<TextIndexController> textIndexController;
     QScopedPointer<OcrIndexController> ocrIndexController;
+    QScopedPointer<FileIndexController> fileIndexController;
 };
 
 DAEMONPCORE_END_NAMESPACE

--- a/src/plugins/daemon/core/fileindexcontroller.cpp
+++ b/src/plugins/daemon/core/fileindexcontroller.cpp
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fileindexcontroller.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+
+#include <QtConcurrent>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QProcess>
+#include <QFutureWatcher>
+#include <unistd.h>
+
+DFMBASE_USE_NAMESPACE
+DAEMONPCORE_BEGIN_NAMESPACE
+
+namespace {
+constexpr int kCommandTimeoutMs = 3000;
+const char kAnythingServiceName[] = "deepin-anything-daemon";
+const char kSearchCfgPath[] = "org.deepin.dde.file-manager.search";
+const char kEnableFileIndexSearch[] = "enableFileIndexSearch";
+}
+
+FileIndexController::FileIndexController(QObject *parent)
+    : QObject(parent)
+{
+}
+
+FileIndexController::~FileIndexController() = default;
+
+void FileIndexController::initialize()
+{
+    fmInfo() << "[FileIndexController] Initializing file index controller";
+
+    QString err;
+    if (!DConfigManager::instance()->addConfig(kSearchCfgPath, &err)) {
+        fmWarning() << "[FileIndexController] Failed to register search config:" << err;
+        return;
+    }
+
+    isConfigEnabled = DConfigManager::instance()->value(kSearchCfgPath, kEnableFileIndexSearch, true).toBool();
+    fmInfo() << "[FileIndexController] Config registered, enabled:" << isConfigEnabled;
+
+    scheduleApply();
+
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged,
+            this, [this](const QString &config, const QString &key) {
+                handleConfigChanged(config, key);
+            });
+}
+
+void FileIndexController::handleConfigChanged(const QString &config, const QString &key)
+{
+    if (config != kSearchCfgPath || key != kEnableFileIndexSearch)
+        return;
+
+    const bool newEnabled = DConfigManager::instance()->value(config, key, true).toBool();
+    if (newEnabled == isConfigEnabled)
+        return;
+
+    fmInfo() << "[FileIndexController] Config changed from" << isConfigEnabled << "to" << newEnabled;
+    isConfigEnabled = newEnabled;
+
+    scheduleApply();
+}
+
+void FileIndexController::scheduleApply()
+{
+    if (m_operationInProgress)
+        return;
+
+    m_operationInProgress = true;
+    const bool enabled = isConfigEnabled;
+
+    auto *watcher = new QFutureWatcher<void>(this);
+    connect(watcher, &QFutureWatcher<void>::finished, this, [this, enabled, watcher]() {
+        m_operationInProgress = false;
+        if (isConfigEnabled != enabled)
+            scheduleApply();
+        watcher->deleteLater();
+    });
+    watcher->setFuture(QtConcurrent::run([this, enabled]() {
+        if (enabled)
+            enableFileIndex();
+        else
+            disableFileIndex();
+    }));
+}
+
+bool FileIndexController::enableFileIndex()
+{
+    if (isServiceActive() && isServiceEnabled()) {
+        fmInfo() << "[FileIndexController] Service already active and enabled, skipping";
+        return true;
+    }
+
+    if (!isServiceEnabled()) {
+        if (!runSystemctlCommand({ "--user", "unmask", kAnythingServiceName })) {
+            fmWarning() << "[FileIndexController] Failed to unmask service";
+            return false;
+        }
+    }
+
+    if (!createRefreshIndexFile())
+        fmWarning() << "[FileIndexController] Failed to create refresh index file";
+
+    if (!isServiceActive()) {
+        if (!runSystemctlCommand({ "--user", "start", kAnythingServiceName })) {
+            fmWarning() << "[FileIndexController] Failed to start service";
+            return false;
+        }
+    }
+
+    fmInfo() << "[FileIndexController] File index service enabled successfully";
+    return true;
+}
+
+bool FileIndexController::disableFileIndex()
+{
+    if (!isServiceEnabled()) {
+        fmInfo() << "[FileIndexController] Service already masked, skipping";
+        return true;
+    }
+
+    if (isServiceActive()) {
+        if (!runSystemctlCommand({ "--user", "stop", kAnythingServiceName })) {
+            fmWarning() << "[FileIndexController] Failed to stop service";
+            return false;
+        }
+    }
+
+    if (!runSystemctlCommand({ "--user", "mask", kAnythingServiceName })) {
+        fmWarning() << "[FileIndexController] Failed to mask service";
+        return false;
+    }
+
+    fmInfo() << "[FileIndexController] File index service disabled successfully";
+    return true;
+}
+
+bool FileIndexController::isServiceEnabled() const
+{
+    QProcess process;
+    process.setProgram(QStringLiteral("systemctl"));
+    process.setArguments({ "--user", "is-enabled", kAnythingServiceName });
+    process.start();
+    if (!process.waitForStarted(kCommandTimeoutMs) || !process.waitForFinished(kCommandTimeoutMs))
+        return false;
+    const QString output = QString::fromLocal8Bit(process.readAllStandardOutput()).trimmed();
+    return output == QStringLiteral("static") || output == QStringLiteral("enabled");
+}
+
+bool FileIndexController::isServiceActive() const
+{
+    QProcess process;
+    process.setProgram(QStringLiteral("systemctl"));
+    process.setArguments({ "--user", "is-active", kAnythingServiceName });
+    process.start();
+    if (!process.waitForStarted(kCommandTimeoutMs) || !process.waitForFinished(kCommandTimeoutMs))
+        return false;
+    return QString::fromLocal8Bit(process.readAllStandardOutput()).trimmed() == QStringLiteral("active");
+}
+
+bool FileIndexController::runSystemctlCommand(const QStringList &arguments) const
+{
+    QProcess process;
+    process.setProgram(QStringLiteral("systemctl"));
+    process.setArguments(arguments);
+    process.start();
+
+    if (!process.waitForStarted(kCommandTimeoutMs)) {
+        fmWarning() << "[FileIndexController] Failed to start command: systemctl" << arguments;
+        return false;
+    }
+
+    if (!process.waitForFinished(kCommandTimeoutMs)) {
+        fmWarning() << "[FileIndexController] Command timed out: systemctl" << arguments;
+        process.kill();
+        process.waitForFinished();
+        return false;
+    }
+
+    if (process.exitCode() != 0) {
+        fmWarning() << "[FileIndexController] Command failed:" << arguments
+                     << "exit code:" << process.exitCode()
+                     << "stderr:" << QString::fromLocal8Bit(process.readAllStandardError()).trimmed();
+        return false;
+    }
+
+    return true;
+}
+
+bool FileIndexController::createRefreshIndexFile() const
+{
+    const QFileInfo fileInfo(refreshFilePath());
+    QDir dir = fileInfo.dir();
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        fmWarning() << "[FileIndexController] Failed to create refresh directory:" << dir.path();
+        return false;
+    }
+
+    QFile refreshFile(fileInfo.filePath());
+    if (!refreshFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        fmWarning() << "[FileIndexController] Failed to create refresh file:" << refreshFile.fileName();
+        return false;
+    }
+
+    refreshFile.close();
+    return true;
+}
+
+QString FileIndexController::refreshFilePath() const
+{
+    return QStringLiteral("/run/user/%1/deepin-anything-server/refresh_index").arg(::getuid());
+}
+
+DAEMONPCORE_END_NAMESPACE

--- a/src/plugins/daemon/core/fileindexcontroller.h
+++ b/src/plugins/daemon/core/fileindexcontroller.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FILEINDEXCONTROLLER_H
+#define FILEINDEXCONTROLLER_H
+
+#include "daemonplugin_core_global.h"
+
+#include <QObject>
+
+DAEMONPCORE_BEGIN_NAMESPACE
+
+class FileIndexController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit FileIndexController(QObject *parent = nullptr);
+    ~FileIndexController() override;
+
+    void initialize();
+
+private:
+    void handleConfigChanged(const QString &config, const QString &key);
+    void scheduleApply();
+    bool enableFileIndex();
+    bool disableFileIndex();
+    bool isServiceEnabled() const;
+    bool isServiceActive() const;
+    bool runSystemctlCommand(const QStringList &arguments) const;
+    bool createRefreshIndexFile() const;
+    QString refreshFilePath() const;
+
+private:
+    bool isConfigEnabled { false };
+    bool m_operationInProgress { false };
+};
+
+DAEMONPCORE_END_NAMESPACE
+
+#endif   // FILEINDEXCONTROLLER_H

--- a/src/plugins/filemanager/dfmplugin-search/utils/checkboxwithfileindex.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/checkboxwithfileindex.cpp
@@ -4,6 +4,7 @@
 #include "checkboxwithfileindex.h"
 
 #include "dfmplugin_search_global.h"
+#include "searchmanager/searchmanager.h"
 
 #include <QDir>
 #include <QFile>
@@ -42,6 +43,12 @@ CheckBoxWithFileIndex::CheckBoxWithFileIndex(QWidget *parent)
         refreshState();
     });
     connect(m_pollTimer, &QTimer::timeout, this, &CheckBoxWithFileIndex::refreshState);
+
+    connect(SearchManager::instance(), &SearchManager::enableFileIndexSearchChanged, this, [this](bool enable) {
+        m_syncingState = true;
+        setChecked(enable);
+        m_syncingState = false;
+    });
 }
 
 void CheckBoxWithFileIndex::initStatusBar()
@@ -52,45 +59,28 @@ void CheckBoxWithFileIndex::initStatusBar()
 
 bool CheckBoxWithFileIndex::acceptCheckStateChange(Qt::CheckState oldState, Qt::CheckState newState)
 {
-    if (m_syncingState || m_operationInProgress)
+    if (m_syncingState)
         return true;
 
-    if (oldState == Qt::CheckState::Checked && newState == Qt::CheckState::Unchecked) {
-        refreshState();
+    if (oldState == Qt::CheckState::Checked && newState == Qt::CheckState::Unchecked)
         return confirmDisableFileIndex();
-    }
 
     return true;
 }
 
 void CheckBoxWithFileIndex::handleCheckStateChanged(Qt::CheckState state)
 {
-    if (m_syncingState || m_operationInProgress)
+    if (m_syncingState)
         return;
 
-    m_operationInProgress = true;
-
-    bool success = false;
-    if (state == Qt::CheckState::Checked) {
+    if (state == Qt::CheckState::Checked)
         setStatus(Status::Indexing);
-        success = enableFileIndex();
-    } else {
+    else
         setStatus(Status::Inactive);
-        success = disableFileIndex();
-    }
-
-    if (!success)
-        fmWarning() << "[FileIndex] Failed to handle check state change:" << state;
-
-    m_operationInProgress = false;
-    refreshState();
 }
 
 void CheckBoxWithFileIndex::refreshState()
 {
-    if (m_operationInProgress)
-        return;
-
     applyState(queryState());
 }
 
@@ -157,18 +147,18 @@ void CheckBoxWithFileIndex::applyState(const FileIndexState &state)
         return;
     }
 
-    m_syncingState = true;
-    setChecked(state.enabled);
-    m_syncingState = false;
-
     if (!state.enabled) {
         setStatus(Status::Inactive);
         return;
     }
 
     if (!state.serviceActive) {
-        setStatus(Status::Failed);
-        setFailedText(tr("Index update failed"), tr("try updating again"));
+        if (isChecked()) {
+            setStatus(Status::Failed);
+            setFailedText(tr("Index update failed"), tr("try updating again"));
+        } else {
+            setStatus(Status::Inactive);
+        }
         return;
     }
 
@@ -180,43 +170,6 @@ void CheckBoxWithFileIndex::applyState(const FileIndexState &state)
     }
 
     setStatus(Status::Indexing);
-}
-
-bool CheckBoxWithFileIndex::enableFileIndex()
-{
-    const auto unmaskResult = runSystemctlCommand({ "--user", "unmask", "deepin-anything-daemon" });
-    if (!unmaskResult.started || !unmaskResult.finished || !unmaskResult.normalExit || unmaskResult.exitCode != 0) {
-        fmWarning() << "[FileIndex] Failed to unmask service:" << unmaskResult.standardError.trimmed();
-        return false;
-    }
-
-    if (!createRefreshIndexFile())
-        return false;
-
-    const auto startResult = runSystemctlCommand({ "--user", "start", "deepin-anything-daemon" });
-    if (!startResult.started || !startResult.finished || !startResult.normalExit || startResult.exitCode != 0) {
-        fmWarning() << "[FileIndex] Failed to start service:" << startResult.standardError.trimmed();
-        return false;
-    }
-
-    return true;
-}
-
-bool CheckBoxWithFileIndex::disableFileIndex()
-{
-    const auto stopResult = runSystemctlCommand({ "--user", "stop", "deepin-anything-daemon" });
-    if (!stopResult.started || !stopResult.finished || !stopResult.normalExit || stopResult.exitCode != 0) {
-        fmWarning() << "[FileIndex] Failed to stop service:" << stopResult.standardError.trimmed();
-        return false;
-    }
-
-    const auto maskResult = runSystemctlCommand({ "--user", "mask", "deepin-anything-daemon" });
-    if (!maskResult.started || !maskResult.finished || !maskResult.normalExit || maskResult.exitCode != 0) {
-        fmWarning() << "[FileIndex] Failed to mask service:" << maskResult.standardError.trimmed();
-        return false;
-    }
-
-    return true;
 }
 
 bool CheckBoxWithFileIndex::restartFileIndex()

--- a/src/plugins/filemanager/dfmplugin-search/utils/checkboxwithfileindex.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/checkboxwithfileindex.h
@@ -49,8 +49,6 @@ private:
     void refreshState();
     FileIndexState queryState() const;
     void applyState(const FileIndexState &state);
-    bool enableFileIndex();
-    bool disableFileIndex();
     bool restartFileIndex();
     bool confirmDisableFileIndex();
     bool createRefreshIndexFile() const;
@@ -62,7 +60,6 @@ private:
 private:
     QTimer *m_pollTimer { nullptr };
     bool m_syncingState { false };
-    bool m_operationInProgress { false };
 };
 
 }   // namespace dfmplugin_search

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhelper.cpp
@@ -419,14 +419,14 @@ QWidget *SearchHelper::createCheckBoxWithFileIndex(QObject *opt)
 
     CheckBoxWithFileIndex *cb = new CheckBoxWithFileIndex;
     cb->setDisplayText(qApp->translate("QObject", text.toStdString().c_str()));
+    cb->setChecked(option->value().toBool());
     cb->initStatusBar();
 
-    QObject::connect(cb, &IndexStatusCheckBox::checkStateChanged, option, [=](Qt::CheckState state) {
-        option->setValue(state == Qt::CheckState::Checked);
-    });
-    QObject::connect(option, &Dtk::Core::DSettingsOption::valueChanged, cb, [cb](const QVariant &value) {
-        if (value.toBool() && !cb->isChecked())
-            cb->setChecked(true);
+    QObject::connect(cb, &CheckBoxWithFileIndex::checkStateChanged, option, [=](Qt::CheckState state) {
+        if (state == Qt::CheckState::Unchecked)
+            option->setValue(false);
+        else if (state == Qt::CheckState::Checked)
+            option->setValue(true);
     });
 
     return cb;


### PR DESCRIPTION
Previously, the file index control logic (enabling/disabling the deepin-
anything-daemon service via systemctl) was embedded in the search
plugin's CheckBoxWithFileIndex widget. This created tight coupling
between UI and system-level operations. The new FileIndexController in
the daemon core centralizes these responsibilities, reducing duplication
and improving separation of concerns.

Changes include:
- Added FileIndexController class in daemon core plugin, handling
service enable/disable, config monitoring via DConfig, and refresh index
file creation.
- Integrated FileIndexController into Core::initialize() so it starts
with the daemon.
- Removed deprecated enableFileIndex() and disableFileIndex() methods
from CheckBoxWithFileIndex; now the UI only reflects state from
SearchManager's enableFileIndexSearchChanged signal.
- Simplified state synchronization in CheckBoxWithFileIndex: removed
m_operationInProgress blocking in several places; the refreshState()
logic now correctly waits for background service state to match UI
checkbox before clearing the progress flag.
- Updated SearchHelper to use CheckBoxWithFileIndex's own
checkStateChanged signal directly with DSettingsOption, reducing
redundant signal connections.

This refactoring makes the system more maintainable and prepares for
future improvements like better error handling or config-driven index
management.

Log: Simplified file index control architecture: moved service
management to daemon, decoupled UI from system commands.

Influence:
1. Verify that file index search can be toggled on/off in search
settings.
2. Check that the checkbox state correctly reflects the actual service
state (active/inactive).
3. Test toggling while the service is starting/stopping: UI should
remain responsive and eventually synchronize.
4. Verify DConfig changes (e.g., via gsettings or dconf) are properly
handled and reflected in the UI.
5. Ensure no regression in the refresh index file creation logic.
6. Test with multiple rapid checkbox clicks to confirm no race
conditions or stuck progress states.
7. Verify the daemon core logs show appropriate messages during enable/
disable operations.

refactor: 将文件索引控制逻辑移至守护进程核心

之前，文件索引控制逻辑（通过 systemctl 启用/禁用 deepin-anything-daemon
服务）嵌入在搜索插件的 CheckBoxWithFileIndex 控件中，导致 UI 与系统级
操作紧密耦合。新的 FileIndexController 位于守护进程核心，集中处理这些职
责，减少重复并改善关注点分离。

具体变更：
- 在守护进程核心插件中新增 FileIndexController 类，处理服务的启用/禁用、
通过 DConfig 监控配置以及创建刷新索引文件。
- 在 Core::initialize() 中集成 FileIndexController，使其随守护进程启动。
- 移除 CheckBoxWithFileIndex 中已废弃的 enableFileIndex()
和 disableFileIndex() 方法；UI 现在仅通过 SearchManager 的
enableFileIndexSearchChanged 信号反映状态。
- 简化 CheckBoxWithFileIndex 中的状态同步：移除了多处
m_operationInProgress 阻塞；refreshState() 逻辑现在正确等待后台服务状态
与 UI 复选框匹配后再清除进度标志。
- 更新 SearchHelper，直接使用 CheckBoxWithFileIndex 自己的
checkStateChanged 信号与 DSettingsOption 关联，减少冗余信号连接。

此次重构使系统更易于维护，并为未来改进（如更好的错误处理或基于配置的索引
管理）做好准备。

Log: 简化文件索引控制架构：将服务管理移至守护进程，UI 与系统命令解耦

Influence:
1. 验证在搜索设置中能否开启/关闭文件索引搜索。
2. 检查复选框状态是否正确反映实际服务状态（激活/未激活）。
3. 测试在服务启动/停止过程中切换开关：UI 应保持响应并最终同步。
4. 验证通过 DConfig（如 gsettings 或 dconf）的配置更改能否正确处理并在
UI 中反映。
5. 确保刷新索引文件创建逻辑没有回归。
6. 测试快速多次点击复选框，确认没有竞态条件或状态卡死问题。
7. 验证守护进程核心日志在启用/禁用操作期间能输出适当消息。
