### PR TITLE
fix(preview): tune video control icon

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
@@ -5,19 +5,54 @@
 #include "videostatusbar.h"
 #include "videopreview.h"
 
+#include <DGuiApplicationHelper>
 #include <DIconButton>
 
+#include <QApplication>
+#include <QEvent>
+#include <QIcon>
+#include <QPainter>
+
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace plugin_filepreview;
+
+namespace {
+constexpr int kControlButtonIconSize { 16 };
+
+QIcon createColoredIcon(const QString &iconName, const QColor &color, const QSize &size, const QWidget *widget)
+{
+    const qreal dpr = widget ? widget->devicePixelRatioF() : qApp->devicePixelRatio();
+    QPixmap pixmap = QIcon::fromTheme(iconName).pixmap(size, dpr);
+    if (pixmap.isNull())
+        return QIcon();
+
+    QPainter painter(&pixmap);
+    painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+    painter.fillRect(pixmap.rect(), color);
+
+    return QIcon(pixmap);
+}
+
+QColor controlIconColor(bool hovered)
+{
+    const bool darkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+    QColor color = darkTheme ? QColor(Qt::white) : QColor(Qt::black);
+    if (!hovered)
+        color.setAlphaF(0.7);
+    return color;
+}
+}
+
 VideoStatusBar::VideoStatusBar(VideoPreview *preview)
     : QWidget(nullptr), p(preview), slider(new QSlider(this)), timeLabel(new QLabel(this)), sliderIsPressed(false)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
-    DIconButton *control_button = new DIconButton(this);
-    control_button->setIconSize({ 24, 24 });
-
-    control_button->setIcon(QIcon::fromTheme("dfm_pause"));
+    controlButton = new DIconButton(this);
+    controlButton->setIconSize({ kControlButtonIconSize, kControlButtonIconSize });
+    controlButton->installEventFilter(this);
+    updateControlButtonIcon();
 
     slider->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     slider->setMinimum(0);
@@ -26,11 +61,11 @@ VideoStatusBar::VideoStatusBar(VideoPreview *preview)
     QHBoxLayout *layout = new QHBoxLayout(this);
 
     layout->setContentsMargins(0, 0, 20, 0);
-    layout->addWidget(control_button);
+    layout->addWidget(controlButton);
     layout->addWidget(slider);
     layout->addWidget(timeLabel);
 
-    connect(control_button, &DIconButton::clicked, this, [this] {
+    connect(controlButton, &DIconButton::clicked, this, [this] {
         // 由于调用了setBackendProperty("keep-open", "yes")
         // 导致视频播放状态不对（要暂停到最后一帧，所以视频播放完毕后状态还是暂停）
         // 如果是暂停状态，调用pause一定会播放，之后再调用play也没有影响
@@ -39,12 +74,14 @@ VideoStatusBar::VideoStatusBar(VideoPreview *preview)
         p->playerWidget->engine().play();
     });
 
-    connect(p, &VideoPreview::sigPlayState, this, [this, control_button] {
-        if (p->playerWidget->engine().state() == dmr::PlayerEngine::Playing) {
-            control_button->setIcon(QIcon::fromTheme("dfm_pause"));
-        } else {
-            control_button->setIcon(QIcon::fromTheme("dfm_start"));
-        }
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, [this] {
+                updateControlButtonIcon();
+            });
+
+    connect(p, &VideoPreview::sigPlayState, this, [this] {
+        controlButtonShowsPause = p->playerWidget->engine().state() == dmr::PlayerEngine::Playing;
+        updateControlButtonIcon();
     });
 
     connect(slider, &QSlider::valueChanged, this, [this] {
@@ -67,4 +104,43 @@ VideoStatusBar::VideoStatusBar(VideoPreview *preview)
         }
         timeLabel->setText(dmr::utils::Time2str(p->playerWidget->engine().elapsed()));
     });
+}
+
+bool VideoStatusBar::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == controlButton) {
+        switch (event->type()) {
+        case QEvent::Enter:
+            controlButtonHovered = true;
+            updateControlButtonIcon();
+            break;
+        case QEvent::Leave:
+            controlButtonHovered = false;
+            updateControlButtonIcon();
+            break;
+        case QEvent::StyleChange:
+        case QEvent::PaletteChange:
+        case QEvent::ApplicationPaletteChange:
+        case QEvent::ScreenChangeInternal:
+        case QEvent::DevicePixelRatioChange:
+            updateControlButtonIcon();
+            break;
+        default:
+            break;
+        }
+    }
+
+    return QWidget::eventFilter(watched, event);
+}
+
+void VideoStatusBar::updateControlButtonIcon()
+{
+    if (!controlButton)
+        return;
+
+    const QString iconName = controlButtonShowsPause ? QStringLiteral("dfm_pause")
+                                                     : QStringLiteral("dfm_start");
+    const QSize iconSize(kControlButtonIconSize, kControlButtonIconSize);
+    controlButton->setIconSize(iconSize);
+    controlButton->setIcon(createColoredIcon(iconName, controlIconColor(controlButtonHovered), iconSize, controlButton));
 }

--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.h
@@ -7,9 +7,14 @@
 
 #include "preview_plugin_global.h"
 
+#include <DIconButton>
+
 #include <QWidget>
 #include <QSlider>
 #include <QLabel>
+
+class QObject;
+class QEvent;
 
 namespace plugin_filepreview {
 class VideoPreview;
@@ -19,10 +24,22 @@ class VideoStatusBar : public QWidget
 public:
     explicit VideoStatusBar(VideoPreview *preview);
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    void updateControlButtonIcon();
+
+public:
     VideoPreview *p;
     QSlider *slider;
     QLabel *timeLabel;
     bool sliderIsPressed;
+
+private:
+    DTK_WIDGET_NAMESPACE::DIconButton *controlButton { nullptr };
+    bool controlButtonHovered { false };
+    bool controlButtonShowsPause { true };
 };
 }
 #endif   // VIDEOSTATUSBAR_H


### PR DESCRIPTION
1. Update the video play/pause control icon to use a 16x16 logical size.
2. Apply DTK-style icon colors for light and dark themes, and switch to pure black/white on hover.
3. Refresh the control icon on theme and device pixel ratio changes so it stays correct under scaling.

Log: Adjust the video preview control icon style and scaling behavior.

fix(preview): 调整视频控制图标样式

1. 将视频播放/暂停控制图标调整为 16x16 逻辑尺寸。
2. 按照 DTK 规范适配浅色和深色主题图标颜色，悬停时切换为纯黑和纯白。
3. 在主题和设备像素比变化时刷新控制图标，保证缩放场景下显示正确。

Log: 调整视频预览控制图标的样式与缩放显示行为。
PMS: https://pms.uniontech.com/bug-view-369317.html