### PR TITLE
fix(diskencrypt): validate device encryption status before resuming operations

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -843,7 +843,14 @@ void DiskEncryptMenuScene::updateActions()
         }
     } else if (EventsHandler::instance()->unfinishedDecryptJob() == param.devDesc
                || EventsHandler::instance()->unfinishedDecryptJob() == param.devPhy) {
-        actions[kActIDResumeDecrypt]->setVisible(true);
+        // Defensive check: only show "Continue decrypt" if device is actually LUKS encrypted.
+        // This handles the case where the partition was reformatted after a decrypt job was interrupted.
+        const QString &idType = selectedItemInfo.value("IdType").toString();
+        if (idType == "crypto_LUKS") {
+            actions[kActIDResumeDecrypt]->setVisible(true);
+        } else {
+            fmInfo() << "Device has pending decrypt job but is not LUKS (may have been reformatted), hiding resume decrypt option:" << param.devDesc << "idType:" << idType;
+        }
     } else {
         actions[kActIDEncrypt]->setVisible(true);
     }

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -281,6 +281,15 @@ QString DiskEncryptSetup::PendingDecryptionDevice()
     for (auto f : files) {
         auto name = m_dptr->resolveDeviceByDetachHeaderName(f);
         if (!name.isEmpty()) {
+            // Validate that the device is still encrypted; if it has been reformatted
+            // (e.g. via mke2fs), the LUKS header is gone and this backup file is stale.
+            auto status = crypt_setup_helper::encryptStatus(name);
+            if (status == disk_encrypt::kStatusNotEncrypted || status < 0) {
+                qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Device is no longer encrypted, removing stale backup:"
+                         << name << "file:" << f;
+                QFile::remove(d.absoluteFilePath(f));
+                continue;
+            }
             qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Found pending decryption device:" << name << "from header file:" << f;
             return name;
         }

--- a/src/services/diskencrypt/helpers/jobfilehelper.cpp
+++ b/src/services/diskencrypt/helpers/jobfilehelper.cpp
@@ -244,25 +244,60 @@ QStringList job_file_helper::validJobTypes()
 void job_file_helper::checkJobs()
 {
     qInfo() << "[job_file_helper::checkJobs] Checking and validating existing job files";
-    
+
+    // Check encrypt job files
     JobDescArgs job;
     loadEncryptJobFile(&job);
-    if (job.jobFile.isEmpty()) {
-        qInfo() << "[job_file_helper::checkJobs] No job files to check";
-        return;
+    if (!job.jobFile.isEmpty()) {
+        if (!QFile(job.devPath).exists()) {
+            qInfo() << "[job_file_helper::checkJobs] Encrypt job device no longer exists, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
+            removeJobFile(job.jobFile);
+        } else if (crypt_setup_helper::encryptStatus(job.devPath) == disk_encrypt::kStatusNotEncrypted) {
+            qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing encrypt job file - device:" << job.devPath << "job file:" << job.jobFile;
+            removeJobFile(job.jobFile);
+        } else {
+            qInfo() << "[job_file_helper::checkJobs] Encrypt job file validation completed - device:" << job.devPath << "job file:" << job.jobFile;
+        }
     }
 
-    if (!QFile(job.devPath).exists()) {
-        qInfo() << "[job_file_helper::checkJobs] Job device no longer exists, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
-        removeJobFile(job.jobFile);
-        return;
+    // Check decrypt job file
+    QString decryptJobPath = QString(disk_encrypt::kUSecConfigDir) + "/decrypt.json";
+    QFile decryptJobFile(decryptJobPath);
+    if (decryptJobFile.exists()) {
+        qInfo() << "[job_file_helper::checkJobs] Found decrypt job file:" << decryptJobPath;
+        if (decryptJobFile.open(QIODevice::ReadOnly)) {
+            QByteArray data = decryptJobFile.readAll();
+            decryptJobFile.close();
+
+            QJsonParseError err;
+            QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+            if (err.error == QJsonParseError::NoError && doc.isObject()) {
+                QJsonObject obj = doc.object();
+                QString devPath = obj.value(key_name::KeyDevPath).toString();
+
+                bool shouldRemove = false;
+                if (devPath.isEmpty()) {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job file has no device-path, removing";
+                    shouldRemove = true;
+                } else if (!QFile(devPath).exists()) {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job device no longer exists, removing job file - device:" << devPath;
+                    shouldRemove = true;
+                } else if (crypt_setup_helper::encryptStatus(devPath) == disk_encrypt::kStatusNotEncrypted) {
+                    qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing decrypt job file - device:" << devPath;
+                    shouldRemove = true;
+                }
+
+                if (shouldRemove) {
+                    removeJobFile(decryptJobPath);
+                } else {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job file validation completed - device:" << devPath;
+                }
+            } else {
+                qWarning() << "[job_file_helper::checkJobs] Failed to parse decrypt job file, removing";
+                removeJobFile(decryptJobPath);
+            }
+        }
     }
 
-    if (crypt_setup_helper::encryptStatus(job.devPath) == disk_encrypt::kStatusNotEncrypted) {
-        qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
-        removeJobFile(job.jobFile);
-        return;
-    }
-    
-    qInfo() << "[job_file_helper::checkJobs] Job file validation completed - device:" << job.devPath << "job file:" << job.jobFile;
+    qInfo() << "[job_file_helper::checkJobs] Job file validation completed";
 }


### PR DESCRIPTION
Prevents errors when attempting to resume encryption/decryption on devices that have been reformatted after job interruption.

防止在作业中断后设备被重新格式化时，错误地尝试恢复加密/解密操作。

Log: 验证设备加密状态以处理重新格式化场景
PMS: BUG-368037
Influence: 修复了磁盘加密作业文件验证逻辑，防止在分区被重新格式化后误显示恢复加密/解密选项，提升用户体验和系统稳定性。