### PR TITLE
fix(textindex): add OcrIndex path to service manager idle policy

### DIFF
--- a/src/services/textindex/dde-filemanager-textindex.json
+++ b/src/services/textindex/dde-filemanager-textindex.json
@@ -7,6 +7,9 @@
     "policy": [
         {
             "path": "/org/deepin/Filemanager/TextIndex"
+        },
+        {
+            "path": "/org/deepin/Filemanager/OcrIndex"
         }
     ]
 } 


### PR DESCRIPTION
## 修复内容

PMS: BUG-369365

### 问题现象

仅勾选「图片文本内容搜索」(OCR 索引)，取消文件索引和全文搜索时，OCR 索引更新超过 10 分钟后进程被 deepin-service-manager 退出，索引更新中断。

### 根因

`dde-filemanager-textindex.json` 的 `policy` 仅配置了 `/org/deepin/Filemanager/TextIndex` 路径。deepin-service-manager 通过 Qt DBus 内部 hook 拦截进程连接上的消息，**只按 `msg.path()` 匹配**（不看 bus name，见上游 `qtdbushook.cpp:165` 的 `Q_UNUSED(name)`）。

OcrIndexController 的保活机制每 5 分钟向 `/org/deepin/Filemanager/OcrIndex` 路径发 `IsEnabled` 调用，但该路径不在 policy 中，无法重置 10 分钟空闲计时器，进程被杀。

### 修复

在 `policy` 数组中增加 `{"path": "/org/deepin/Filemanager/OcrIndex"}`，使 OCR 保活调用能重置 idle 计时器。

### 验证依据

- 上游源码验证：deepin-service-manager `qtdbushook.cpp` 的 `getServiceObject()` 只用 `msg.path()` 查找 service object，`name` 参数被 `Q_UNUSED` 忽略
- 两个 bus name（`org.deepin.Filemanager.TextIndex` + `org.deepin.Filemanager.OcrIndex`）注册在同一 DBus 连接（同一进程），OCR 调用经任一 bus name 投递都会被 hook 到
- 只需补全 path 即可，无需修改 OcrIndexController 的 bus name

### 影响范围

- 不影响全文搜索（TextIndexController 路径不变）
- 不影响 OCR 搜索客户端（仍使用 `org.deepin.Filemanager.OcrIndex` bus name）

详细根因分析见 \`.pms/bugs/369365/analysis-report.md\`。

## Summary by Sourcery

Extend text index service idle policy to keep the OCR index service alive during ongoing indexing.

Bug Fixes:
- Prevent OCR-only text indexing from being terminated by deepin-service-manager due to missing DBus path in the idle policy.

Enhancements:
- Include the /org/deepin/Filemanager/OcrIndex DBus path in the textindex service policy configuration to align with the OCR index keep-alive mechanism.