### PR TITLE
fix(preview): use DSlider in video status bar

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
@@ -45,7 +45,7 @@ QColor controlIconColor(bool hovered)
 }
 
 VideoStatusBar::VideoStatusBar(VideoPreview *preview)
-    : QWidget(nullptr), p(preview), slider(new QSlider(this)), timeLabel(new QLabel(this)), sliderIsPressed(false)
+    : QWidget(nullptr), p(preview), slider(new DSlider(Qt::Horizontal, this)), timeLabel(new QLabel(this)), sliderIsPressed(false)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
@@ -56,7 +56,6 @@ VideoStatusBar::VideoStatusBar(VideoPreview *preview)
 
     slider->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     slider->setMinimum(0);
-    slider->setOrientation(Qt::Horizontal);
 
     QHBoxLayout *layout = new QHBoxLayout(this);
 
@@ -84,15 +83,15 @@ VideoStatusBar::VideoStatusBar(VideoPreview *preview)
         updateControlButtonIcon();
     });
 
-    connect(slider, &QSlider::valueChanged, this, [this] {
+    connect(slider, &DSlider::valueChanged, this, [this] {
         p->playerWidget->engine().seekAbsolute(slider->value());
     });
 
-    connect(slider, &QSlider::sliderPressed, this, [this] {
+    connect(slider, &DSlider::sliderPressed, this, [this] {
         sliderIsPressed = true;
     });
 
-    connect(slider, &QSlider::sliderReleased, this, [this] {
+    connect(slider, &DSlider::sliderReleased, this, [this] {
         sliderIsPressed = false;
     });
 

--- a/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.h
@@ -8,10 +8,10 @@
 #include "preview_plugin_global.h"
 
 #include <DIconButton>
+#include <DSlider>
 
-#include <QWidget>
-#include <QSlider>
 #include <QLabel>
+#include <QWidget>
 
 class QObject;
 class QEvent;
@@ -32,7 +32,7 @@ private:
 
 public:
     VideoPreview *p;
-    QSlider *slider;
+    DTK_WIDGET_NAMESPACE::DSlider *slider;
     QLabel *timeLabel;
     bool sliderIsPressed;
 


### PR DESCRIPTION
1. Replace the video preview progress slider with DSlider to match DTK styling.
2. Update the slider signal connections to use DSlider interfaces consistently.
3. Keep the existing seek and playback progress behavior unchanged.

Log: Use DSlider in the video preview status bar for consistent slider styling.

fix(preview): 视频预览状态栏使用 DSlider

1. 将视频预览进度滑块替换为 DSlider，以统一 DTK 风格显示。
2. 同步调整滑块相关信号连接，统一使用 DSlider 接口。
3. 保持原有的拖动定位和播放进度更新行为不变。

Log: 在视频预览状态栏中使用 DSlider 以统一滑块样式。
PMS: BUG-369249
PMS Link: https://pms.uniontech.com/bug-view-369249.html