### PR TITLE
fix: prevent file selection when text eliding is active

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1624,6 +1624,9 @@ void FileView::mouseMoveEvent(QMouseEvent *event)
     if (d->pressedStartWithExpand)
         return;
 
+    if (itemDelegate() && !itemDelegate()->pressedTruncateGroupKey().isEmpty())
+        return;
+
     if (event->buttons() & Qt::LeftButton)
         d->mouseMoveRect = QRect(event->globalPos(), d->mouseLastPos);
 


### PR DESCRIPTION
Added a check in FileView mouseMoveEvent to prevent accidental file
selection when text eliding (truncate) is active. When the user is
interacting with truncated text (e.g., clicking/holding on text that has
been elided), we should not trigger file selection behavior.

This fixes an issue where users could accidentally select files while
trying to interact with elided text in the file manager. The item
delegate's pressedTruncateGroupKey status now properly blocks selection
actions.

Influence:
1. Test file selection behavior - try selecting files normally
2. Try interacting with elided file names (click/hold/drag)
3. Verify truncation menu still works while file selection is blocked
4. Verify normal file operations aren't affected when not interacting
with truncated text

fix: 防止文本截断激活时错误选择文件

在FileView的mouseMoveEvent中添加检查，当文本截断（缩略）处于活动状态时阻
止文件选择。当用户与截断的文本交互时（例如点击/按住已被缩略的文本），不
应触发文件选择行为。

这修复了用户在尝试与文件管理器中缩略文本交互时可能意外选择文件的问题。项
目代理的pressedTruncateGroupKey状态现在能正确阻止选择操作。

Influence:
1. 测试文件选择行为 - 正常尝试选择文件
2. 尝试与缩略的文件名交互（点击/按住/拖动）
3. 验证在文件选择被阻止时，截断菜单仍能正常工作
4. 验证在非截断文本交互情况下，正常文件操作不受影响

## Summary by Sourcery

Bug Fixes:
- Avoid accidental file selection when interacting with elided (truncated) file names in the workspace file view.