### PR TITLE
fix(recent): cannot open recent:// url in cmd if plugin is lazy loaded

### DIFF
--- a/src/plugins/filemanager/dfmplugin-recent/recent.json
+++ b/src/plugins/filemanager/dfmplugin-recent/recent.json
@@ -23,6 +23,7 @@
                 "VisiableControl" : "recent",
                 "ReportName" : "Recent"
             }
-        }]
+        }],
+        "PluginSchemes": ["recent"]
     }
 }


### PR DESCRIPTION
## 问题

登入桌面后未打开过文管时，执行 `dde-file-manager recent://` 打开的是计算机页面而非最近使用页面。第二次执行正常（headless 模式下 recent 插件已加载）。

PMS: https://pms.uniontech.com/bug-view-369717.html

## 根因

`dfmplugin-recent` 是 Edge 插件（懒加载），冷启动时不随 Core 插件加载。`CommandParser::openWindowWithUrl` 通过插件元数据的 `Custom.PluginSchemes` 字段构建 scheme→plugin 映射，用于在打开窗口前提前加载对应的懒加载插件。

`recent.json` 的 `Custom` 节缺少 `PluginSchemes` 声明，导致 "recent" scheme 不在映射表中，插件不会被提前加载。`createWindow` 因 `InfoFactory::create<FileInfo>(recent://)` 返回 null（RecentFileInfo 未注册）而 fallback 到默认的 `computer:///`。

同类问题在 commit 83d3c8fd9 中已为 trash、smb 插件修复，但遗漏了 recent。

## 修复

在 `recent.json` 的 `Custom` 节添加 `"PluginSchemes": ["recent"]`，与 trash 插件保持一致。

## 改动

- `src/plugins/filemanager/dfmplugin-recent/recent.json` — Custom 节新增 PluginSchemes 声明（+2/-1）

## 测试

冷启动场景（登入桌面后未打开文管）执行 `dde-file-manager recent://`，验证打开的是最近使用页面而非计算机页面。