### PR TITLE
fix: adjust scroll position for sticky header in grouped view

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -391,6 +391,7 @@ void BaseItemDelegate::paintStickyGroupHeader(QPainter *painter, const QStyleOpt
     if (option.widget) {
         painter->save();
 
+        painter->setClipRect(option.rect);
         DPalette pl(DPaletteHelper::instance()->palette(option.widget));
         painter->setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform);
 
@@ -406,6 +407,11 @@ void BaseItemDelegate::paintStickyGroupHeader(QPainter *painter, const QStyleOpt
             path.addRoundedRect(bgRect, kListModeRectRadius, kListModeRectRadius);
             painter->fillPath(path, adjustColor);
         }
+
+        QColor separatorColor = pl.color(QPalette::Active, QPalette::BrightText);
+        separatorColor.setAlphaF(0.07);
+        painter->setPen(QPen(separatorColor, 1));
+        painter->drawLine(drawRect.bottomLeft(), drawRect.bottomRight());
 
         painter->restore();
     }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1765,6 +1765,22 @@ QRect FileView::visualRect(const QModelIndex &index) const
     return rect;
 }
 
+void FileView::scrollTo(const QModelIndex &index, ScrollHint hint)
+{
+    DListView::scrollTo(index, hint);
+
+    if (!isGroupedView() || !index.isValid() || isGroupHeader(index))
+        return;
+
+    int headerHeight = stickyHeaderHeight();
+    if (headerHeight <= 0)
+        return;
+
+    QRect rect = visualRect(index);
+    if (rect.isValid() && rect.top() < headerHeight)
+        verticalScrollBar()->setValue(verticalScrollBar()->value() - (headerHeight - rect.top()));
+}
+
 void FileView::setIconSize(const QSize &size)
 {
     DListView::setIconSize(size);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -78,6 +78,7 @@ public:
                      const QVector<int> &roles = QVector<int>()) override;
     QModelIndex indexAt(const QPoint &pos) const override;
     virtual QRect visualRect(const QModelIndex &index) const override;
+    void scrollTo(const QModelIndex &index, ScrollHint hint = EnsureVisible) override;
     void setIconSize(const QSize &size);
     int horizontalOffset() const override;
     int verticalOffset() const override;


### PR DESCRIPTION
Override `scrollTo` in FileView to ensure items are not hidden behind
the sticky header in grouped view. After calling the base class
`scrollTo`, the method checks if the target item is visually located
under the sticky header. If so, it adjusts the vertical scrollbar to
bring the item fully into view, preventing obstruction.

Log: Fixed item obstruction by sticky header in grouped view

Influence:
1. Test keyboard navigation (Up/Down keys) in grouped view
2. Test programmatic `scrollTo` calls with various indices
3. Verify that items are not hidden behind the sticky header after
scrolling
4. Test with different sticky header heights (e.g., different group
header sizes)
5. Ensure no regression in non-grouped view scrolling behavior
6. Verify that group headers themselves are not affected by the
adjustment

fix: 修复分组视图中粘性表头遮挡项目的问题

重写 FileView 的 `scrollTo` 方法，确保在分组视图中项目不会被粘性表头遮
挡。在调用基类 `scrollTo` 后，检查目标项目是否位于粘性表头下方，如果是，
则调整垂直滚动条，使项目完全可见。

Log: 修复分组视图中粘性表头遮挡项目的问题

Influence:
1. 在分组视图中测试键盘导航（上/下键）
2. 测试通过程序调用 `scrollTo` 方法，传入不同索引
3. 验证滚动后项目不会被粘性表头遮挡
4. 测试不同粘性表头高度（如不同分组表头大小）
5. 确保非分组视图的滚动行为无回归
6. 验证分组表头本身不受此调整影响
