### PR TITLE
fix: improve HiDPI support for image preview

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -33,6 +33,7 @@ ImageView::ImageView(const QString &fileName, const QByteArray &format, QWidget 
 void ImageView::setFile(const QString &fileName, const QByteArray &format)
 {
     const QSize &dsize = DFMBASE_NAMESPACE::WindowUtils::cursorScreen()->size();
+    const qreal targetDpr = qMax<qreal>(1.0, qApp->devicePixelRatio());
 
     if (format == QByteArrayLiteral("gif")) {
         if (movie) {
@@ -78,8 +79,10 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
                       qMin(static_cast<int>(dsize.height() * 0.7), sourceImageSize.height()));
     QSize showSize = sourceImageSize.scaled(maxShowSize, Qt::KeepAspectRatio);
 
-    // 设置缩放尺寸，让 QImageReader 只加载需要的大小，避免加载完整大图
-    reader.setScaledSize(showSize);
+    // Keep the widget size in logical pixels, but decode extra backing pixels for HiDPI.
+    QSize decodeSize(qMax(1, qRound(showSize.width() * targetDpr)),
+                     qMax(1, qRound(showSize.height() * targetDpr)));
+    reader.setScaledSize(decodeSize);
 
     QImage image = reader.read();
     if (image.isNull()) {
@@ -92,7 +95,10 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     image = DFMBASE_NAMESPACE::FileUtils::convertToSRgbColorSpace(image);
 #endif
     QPixmap pixmap = QPixmap::fromImage(image);
-    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
+    const qreal widthDpr = showSize.width() > 0 ? static_cast<qreal>(image.width()) / showSize.width() : 1.0;
+    const qreal heightDpr = showSize.height() > 0 ? static_cast<qreal>(image.height()) / showSize.height() : 1.0;
+    const qreal effectiveDpr = qMax<qreal>(1.0, qMin(targetDpr, qMin(widthDpr, heightDpr)));
+    pixmap.setDevicePixelRatio(effectiveDpr);
     setPixmap(pixmap);
 }
 


### PR DESCRIPTION
1. Added proper HiDPI support by introducing targetDpr calculation
2. Modified image decoding to account for device pixel ratio when
loading scaled images
3. Implemented more accurate device pixel ratio setting for the final
pixmap
4. Fixed potential division by zero issues in DPR calculations

These changes ensure proper image display quality on HiDPI screens
while maintaining performance by not loading unnecessarily large image
files. The new calculations also prevent artifacts that could occur from
improper scaling between logical and physical pixels.

Log: Improved image preview display quality on HiDPI screens

Influence:
1. Test image preview on various HiDPI screens
2. Verify different image formats display correctly
3. Check memory usage when previewing large images
4. Verify smooth zoom/scale operations
5. Test with different screen scaling factors

fix: 改进图像预览的 HiDPI 支持

1. 通过引入 targetDpr 计算添加适当的 HiDPI 支持
2. 修改图像解码逻辑以在加载缩放图像时考虑设备像素比
3. 为最终 pixmap 实现了更精确的设备像素比设置
4. 修复了 DPR 计算中潜在的除零问题

这些更改确保了在 HiDPI 屏幕上正确显示图像质量，同时通过不加载不必要的大
图像文件来保持性能。新的计算还可以防止由于逻辑像素和物理像素之间不当缩放
而产生的伪影。

Log: 提升 HiDPI 屏幕上的图像预览显示质量

Influence:
1. 在不同 HiDPI 屏幕上测试图像预览
2. 验证不同图像格式是否正确显示
3. 检查预览大图像时的内存使用情况
4. 验证平滑的缩放操作
5. 测试不同的屏幕缩放比例
