### PR TITLE
test: add unit tests for FileScanner exclude paths feat: implement path exclusion feature in FileScanner

### DIFF
--- a/autotests/libs/dfm-base/test_filescanner.cpp
+++ b/autotests/libs/dfm-base/test_filescanner.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
+#include <QDir>
+#include <QFile>
+#include <QSignalSpy>
+#include <QEventLoop>
+#include <QTimer>
+
+#include <dfm-base/utils/filescanner.h>
+
+using namespace dfmbase;
+
+class TestFileScanner : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tempDir.isValid());
+        rootPath = tempDir.path();
+
+        subdir1 = rootPath + "/subdir1";
+        subdir2 = rootPath + "/subdir2";
+        ASSERT_TRUE(QDir().mkpath(subdir1));
+        ASSERT_TRUE(QDir().mkpath(subdir2));
+
+        fileA = subdir1 + "/file_a.txt";
+        fileB = subdir2 + "/file_b.txt";
+        fileC = rootPath + "/file_c.txt";
+        ASSERT_TRUE(writeFile(fileA, "aaaa"));
+        ASSERT_TRUE(writeFile(fileB, "bbbb"));
+        ASSERT_TRUE(writeFile(fileC, "cccc"));
+    }
+
+    void TearDown() override
+    {
+    }
+
+    static bool writeFile(const QString &path, const QByteArray &content)
+    {
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly))
+            return false;
+        f.write(content);
+        f.close();
+        return true;
+    }
+
+    QTemporaryDir tempDir;
+    QString rootPath;
+    QString subdir1;
+    QString subdir2;
+    QString fileA;
+    QString fileB;
+    QString fileC;
+};
+
+TEST_F(TestFileScanner, ScanSync_Baseline_NoExclude)
+{
+    auto result = FileScanner::scanSync({QUrl::fromLocalFile(rootPath)});
+    EXPECT_TRUE(result.isValid());
+    EXPECT_EQ(result.fileCount, 3);
+    EXPECT_EQ(result.directoryCount, 2);
+    EXPECT_EQ(result.totalSize, 12);
+}
+
+TEST_F(TestFileScanner, ScanSync_Baseline_CountOnly)
+{
+    auto result = FileScanner::scanSync(
+            {QUrl::fromLocalFile(rootPath)},
+            FileScanner::ScanOption::CountOnly);
+    EXPECT_TRUE(result.isValid());
+    EXPECT_EQ(result.fileCount, 3);
+    EXPECT_EQ(result.directoryCount, 2);
+    EXPECT_EQ(result.totalSize, 0);
+}
+
+TEST_F(TestFileScanner, ManualExclude_SinglePath)
+{
+    auto scanner = new FileScanner();
+    scanner->setExcludePaths({subdir1});
+
+    QSignalSpy finishedSpy(scanner, &FileScanner::finished);
+    QEventLoop loop;
+    QObject::connect(scanner, &FileScanner::finished, &loop, &QEventLoop::quit);
+
+    scanner->start({QUrl::fromLocalFile(rootPath)});
+    loop.exec();
+
+    ASSERT_EQ(finishedSpy.count(), 1);
+    auto result = finishedSpy.takeFirst().at(0).value<FileScanner::ScanResult>();
+    EXPECT_EQ(result.fileCount, 2);
+    EXPECT_EQ(result.directoryCount, 1);
+    EXPECT_EQ(result.totalSize, 8);
+
+    delete scanner;
+}
+
+TEST_F(TestFileScanner, ManualExclude_MultiplePaths)
+{
+    auto scanner = new FileScanner();
+    scanner->setExcludePaths({subdir1, subdir2});
+
+    QSignalSpy finishedSpy(scanner, &FileScanner::finished);
+    QEventLoop loop;
+    QObject::connect(scanner, &FileScanner::finished, &loop, &QEventLoop::quit);
+
+    scanner->start({QUrl::fromLocalFile(rootPath)});
+    loop.exec();
+
+    ASSERT_EQ(finishedSpy.count(), 1);
+    auto result = finishedSpy.takeFirst().at(0).value<FileScanner::ScanResult>();
+    EXPECT_EQ(result.fileCount, 1);
+    EXPECT_EQ(result.directoryCount, 0);
+    EXPECT_EQ(result.totalSize, 4);
+
+    delete scanner;
+}
+
+TEST_F(TestFileScanner, ManualExclude_TrailingSlash)
+{
+    auto scanner = new FileScanner();
+    scanner->setExcludePaths({subdir1 + "/"});
+
+    QSignalSpy finishedSpy(scanner, &FileScanner::finished);
+    QEventLoop loop;
+    QObject::connect(scanner, &FileScanner::finished, &loop, &QEventLoop::quit);
+
+    scanner->start({QUrl::fromLocalFile(rootPath)});
+    loop.exec();
+
+    ASSERT_EQ(finishedSpy.count(), 1);
+    auto result = finishedSpy.takeFirst().at(0).value<FileScanner::ScanResult>();
+    EXPECT_EQ(result.fileCount, 2);
+    EXPECT_EQ(result.directoryCount, 1);
+
+    delete scanner;
+}
+
+TEST_F(TestFileScanner, ManualExclude_NoMatch)
+{
+    auto scanner = new FileScanner();
+    scanner->setExcludePaths({rootPath + "/nonexistent"});
+
+    QSignalSpy finishedSpy(scanner, &FileScanner::finished);
+    QEventLoop loop;
+    QObject::connect(scanner, &FileScanner::finished, &loop, &QEventLoop::quit);
+
+    scanner->start({QUrl::fromLocalFile(rootPath)});
+    loop.exec();
+
+    ASSERT_EQ(finishedSpy.count(), 1);
+    auto result = finishedSpy.takeFirst().at(0).value<FileScanner::ScanResult>();
+    EXPECT_EQ(result.fileCount, 3);
+    EXPECT_EQ(result.directoryCount, 2);
+
+    delete scanner;
+}
+
+TEST_F(TestFileScanner, ExcludePaths_GetterSetter)
+{
+    FileScanner scanner;
+    QStringList paths = {"/tmp/foo", "/var/bar"};
+    scanner.setExcludePaths(paths);
+    EXPECT_EQ(scanner.excludePaths(), paths);
+
+    scanner.setExcludePaths({});
+    EXPECT_TRUE(scanner.excludePaths().isEmpty());
+}
+
+TEST_F(TestFileScanner, ScanSyncWithCallback_BasicScan)
+{
+    auto result = FileScanner::scanSyncWithCallback(
+            {QUrl::fromLocalFile(rootPath)},
+            FileScanner::ScanOption::NoOption,
+            [](const FileScanner::ScanResult &) -> bool {
+                return true;
+            });
+
+    EXPECT_TRUE(result.isValid());
+    EXPECT_EQ(result.fileCount, 3);
+    EXPECT_EQ(result.directoryCount, 2);
+    EXPECT_EQ(result.totalSize, 12);
+}

--- a/src/dfm-base/utils/filescanner.cpp
+++ b/src/dfm-base/utils/filescanner.cpp
@@ -43,6 +43,23 @@ public:
         return dir + '/' + name;
     }
 
+    // 路径规范化：去除尾部 '/'（根目录 "/" 保留），转为 UTF-8 QByteArray。
+    static inline QByteArray normalizePath(const QString &p)
+    {
+        QString normalized = p;
+        while (normalized.size() > 1 && normalized.endsWith('/'))
+            normalized.chop(1);
+        return normalized.toUtf8();
+    }
+
+    static inline QByteArray normalizePath(const QByteArray &p)
+    {
+        QByteArray normalized = p;
+        while (normalized.size() > 1 && normalized.endsWith('/'))
+            normalized.chop(1);
+        return normalized;
+    }
+
     // 目录条目结构
     struct DirEntry
     {
@@ -64,7 +81,8 @@ public:
     static FileScanner::ScanResult scanImpl(
             const QList<QUrl> &urls,
             FileScanner::ScanOptions options,
-            ProgressCallback progressCallback = nullptr);
+            ProgressCallback progressCallback = nullptr,
+            const QStringList &manualExcludePaths = {});
 
 private:
     // 扫描状态（在扫描过程中维护）
@@ -81,6 +99,9 @@ private:
 
         // inode 去重
         QHash<quint64, QSet<quint64>> processedInodes;
+
+        // 排除路径集合（规范化后的 UTF-8 QByteArray，精确匹配）
+        QSet<QByteArray> excludePathSet;
 
         // 停止标志（用于回调返回 false 时停止）
         bool shouldStop { false };
@@ -135,6 +156,9 @@ public:
 
     // 选项
     FileScanner::ScanOptions options { FileScanner::ScanOption::NoOption };
+
+    // 排除路径
+    QStringList excludePaths;
 };
 
 FileScannerPrivate::FileScannerPrivate(FileScanner *qq)
@@ -166,6 +190,7 @@ void FileScannerPrivate::startWorker(const QList<QUrl> &urls)
     // 设置参数
     worker->setUrls(urls);
     worker->setOptions(options);
+    worker->setExcludePaths(excludePaths);
 
     // 连接信号
     connect(worker, &ScannerWorker::resultReady, this, &FileScannerPrivate::onWorkerResultReady);
@@ -246,6 +271,16 @@ FileScanner::ScanOptions FileScanner::options() const
     return d->options;
 }
 
+void FileScanner::setExcludePaths(const QStringList &paths)
+{
+    d->excludePaths = paths;
+}
+
+QStringList FileScanner::excludePaths() const
+{
+    return d->excludePaths;
+}
+
 FileScanner::ScanResult FileScanner::result() const
 {
     return d->lastResult;
@@ -318,13 +353,18 @@ FileScanner::ScanResult FileScanner::scanSyncWithCallback(const QList<QUrl> &url
 FileScanner::ScanResult FileScannerCore::scanImpl(
         const QList<QUrl> &urls,
         FileScanner::ScanOptions options,
-        ProgressCallback progressCallback)
+        ProgressCallback progressCallback,
+        const QStringList &manualExcludePaths)
 {
     ScanState state;
     state.options = options;
     state.progressCallback = progressCallback;
     state.memoryPageSize = FileUtils::getMemoryPageSize();
     state.progressTimer.start();
+
+    for (const QString &path : manualExcludePaths) {
+        state.excludePathSet.insert(normalizePath(path));
+    }
 
     // 判断是否为本地文件路径
     if (!urls.isEmpty() && urls.first().scheme() == Global::Scheme::kFile) {
@@ -357,6 +397,10 @@ void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &ur
         if (lstat(path.constData(), &statBuf) == 0) {
             // 判断是否为目录（包括指向目录的符号链接）
             if (isDirectoryPath(path, statBuf)) {
+                if (state.excludePathSet.contains(normalizePath(path))) {
+                    qCDebug(logDFMBase) << "FileScannerCore: Skipping excluded source path:" << path;
+                    continue;
+                }
                 ScanContext ctx;
                 ctx.fullPath = path;
                 ctx.depth = 0;
@@ -420,6 +464,10 @@ void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &ur
             if (countOnly) {
                 // CountOnly 模式：直接用 d_type 计数，无需 stat
                 if (entry.d_type == DT_DIR) {
+                    if (state.excludePathSet.contains(normalizePath(entryPath))) {
+                        qCDebug(logDFMBase) << "FileScannerCore: Skipping excluded path:" << entryPath;
+                        continue;
+                    }
                     bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
                     if (isSingleDepth) {
                         state.result.directoryCount++;
@@ -460,6 +508,10 @@ void FileScannerCore::scanLocalPathsImpl(ScanState &state, const QList<QUrl> &ur
             // 根据类型处理条目
             if (S_ISDIR(entry.statBuf.st_mode)) {
                 // 子目录
+                if (state.excludePathSet.contains(normalizePath(entryPath))) {
+                    qCDebug(logDFMBase) << "FileScannerCore: Skipping excluded path:" << entryPath;
+                    continue;
+                }
                 bool isSingleDepth = state.options & FileScanner::ScanOption::SingleDepth;
                 if (isSingleDepth) {
                     // SingleDepth 模式：计数但不递归
@@ -512,6 +564,10 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
 
     // 初始化队列
     for (const QUrl &url : urls) {
+        if (state.excludePathSet.contains(normalizePath(url.path()))) {
+            qCDebug(logDFMBase) << "FileScannerCore: Skipping excluded source path:" << url.path();
+            continue;
+        }
         directoryQueue.enqueue(url);
         processedUrls.insert(url);
     }
@@ -576,6 +632,10 @@ void FileScannerCore::scanOtherProtocolsImpl(ScanState &state, const QList<QUrl>
 
                     if (childInfo) {
                         if (childInfo->isAttributes(OptInfoType::kIsDir)) {
+                            if (state.excludePathSet.contains(normalizePath(childUrl.path()))) {
+                                qCDebug(logDFMBase) << "FileScannerCore: Skipping excluded path:" << childUrl.path();
+                                continue;
+                            }
                             if (isSingleDepth) {
                                 // SingleDepth 模式：计数但不递归
                                 state.result.directoryCount++;
@@ -665,6 +725,11 @@ bool FileScannerCore::tryScanOtherProtocolCountOnlyByLocalPath(
         processedUrls->insert(childUrl);
 
         if (entry.d_type == DT_DIR) {
+            const QByteArray childLocalPath = joinPath(dirPath, entry.name);
+            if (state.excludePathSet.contains(normalizePath(childLocalPath))) {
+                qCDebug(logDFMBase) << "FileScannerCore: Skipping excluded path:" << childLocalPath;
+                continue;
+            }
             if (isSingleDepth) {
                 // SingleDepth 模式：计数但不递归
                 state.result.directoryCount++;
@@ -851,6 +916,11 @@ void ScannerWorker::setOptions(FileScanner::ScanOptions options)
     this->options = options;
 }
 
+void ScannerWorker::setExcludePaths(const QStringList &paths)
+{
+    excludePaths = paths;
+}
+
 void ScannerWorker::start()
 {
     qCDebug(logDFMBase) << "ScannerWorker: Starting work";
@@ -868,7 +938,7 @@ void ScannerWorker::start()
     };
 
     // 调用核心扫描逻辑
-    FileScanner::ScanResult finalResult = FileScannerCore::scanImpl(urls, options, progressCallback);
+    FileScanner::ScanResult finalResult = FileScannerCore::scanImpl(urls, options, progressCallback, excludePaths);
 
     // 发送最终结果
     emit resultReady(finalResult, true);

--- a/src/dfm-base/utils/filescanner.h
+++ b/src/dfm-base/utils/filescanner.h
@@ -8,6 +8,7 @@
 #include <dfm-base/dfm_base_global.h>
 
 #include <QObject>
+#include <QStringList>
 #include <QUrl>
 #include <QThread>
 #include <QScopedPointer>
@@ -104,6 +105,19 @@ public:
      * @brief 获取当前选项
      */
     ScanOptions options() const;
+
+    /**
+     * @brief 设置排除路径列表
+     * @param paths 要排除的路径列表（精确匹配）
+     *
+     * 必须在 start() 之前调用。排除路径及其所有子内容将不被统计。
+     */
+    void setExcludePaths(const QStringList &paths);
+
+    /**
+     * @brief 获取当前排除路径列表
+     */
+    QStringList excludePaths() const;
 
     /**
      * @brief 获取最新结果
@@ -216,6 +230,7 @@ public:
 
     void setUrls(const QList<QUrl> &urls);
     void setOptions(FileScanner::ScanOptions options);
+    void setExcludePaths(const QStringList &paths);
 
 public Q_SLOTS:
     /**
@@ -250,6 +265,7 @@ private:
 private:
     QList<QUrl> urls;
     FileScanner::ScanOptions options { FileScanner::ScanOption::NoOption };
+    QStringList excludePaths;
 
     // 控制标志
     std::atomic<bool> stopped { false };

--- a/src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicebasicwidget.cpp
@@ -5,6 +5,7 @@
 #include "devicebasicwidget.h"
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/base/device/deviceutils.h>
 
 static constexpr int kMaximumHeight { 31 };
 
@@ -94,6 +95,12 @@ void DeviceBasicWidget::selectFileInfo(const DeviceInfo &info)
     freeSize->setRightValue(sizeFreeStr);
     freeSize->setRightFontSizeWeight(DFontSizeManager::SizeType::T7);
 
+    if (info.mountPoint.path() == QDir::rootPath()) {
+        const auto bindTable = DeviceUtils::fstabBindInfo();
+        fileCalculationUtils->setExcludePaths(bindTable.keys());
+    } else {
+        fileCalculationUtils->setExcludePaths({});
+    }
     fileCalculationUtils->start(QList<QUrl>() << info.mountPoint);
 }
 


### PR DESCRIPTION
Added comprehensive unit tests for the FileScanner's new exclude paths
functionality. The tests cover:
1. Basic sync scanning without excludes
2. Count-only mode scanning
3. Single path exclusion
4. Multiple path exclusion
5. Path normalization with trailing slashes
6. Non-matching exclusions
7. Getter/setter methods for exclude paths

Modified FileScanner implementation to:
1. Add path normalization utilities to handle trailing slashes
2. Support manual path exclusion lists in scan operations
3. Include exclude path support in both sync and async scanning
4. Add exclude path processing in local and other protocol scanning
5. Add debug logging for excluded paths
6. Support exclude paths in both count-only and normal modes
7. Properly handle root directory case ("/" remains unchanged)

The DeviceBasicWidget now uses exclude paths for root mount points to
skip mounted paths.

Path normalization ensures consistent matching by:
1. Removing trailing slashes (except root "/")
2. Converting all paths to UTF-8 QByteArray for consistent comparison

Log: Added support for excluding specific paths during file scanning

Influence:
1. Verify file scanning results match expected counts with excluded
paths
2. Test exclude paths with various path formats (trailing slashes,
relative)
3. Verify root path ("/") handling in excludes
4. Test scanning performance with large excluded paths
5. Verify behavior with nested excluded paths
6. Test with both local and non-local (protocol) paths
7. Verify proper handling of non-existent excluded paths

test: 为文件扫描器添加排除路径单元测试
feat: 实现文件扫描器的路径排除功能

添加了针对文件扫描器新排除路径功能的全面单元测试，测试包括：
1. 无排除路径的基础同步扫描
2. 仅计数模式扫描
3. 单个路径排除
4. 多个路径排除
5. 带尾部斜杠的路径标准化
6. 无匹配的排除路径
7. 排除路径的getter/setter方法

修改文件扫描器实现：
1. 添加处理尾部斜杠的路径标准化工具
2. 支持扫描操作中的手动路径排除列表
3. 在同步和异步扫描中均支持路径排除
4. 在本地和其他协议扫描中添加排除路径处理
5. 添加排除路径的调试日志
6. 在仅计数和普通模式中均支持排除路径
7. 正确处理根目录("/")情况

设备基本信息部件现在对根挂载点使用排除路径来跳过已挂载路径。

路径标准化通过以下方式确保匹配一致性：
1. 去除尾部斜杠(根目录"/"除外)
2. 将所有路径转为UTF-8 QByteArray进行一致性比较

Log: 新增了文件扫描时排除指定路径的功能支持

Influence:
1. 验证带排除路径的文件扫描结果是否符合预期计数
2. 测试不同路径格式(带尾部斜杠、相对路径)的排除
3. 验证根路径("/")在排除中的处理
4. 测试大型排除路径的扫描性能
5. 测试嵌套排除路径的行为
6. 测试本地和非本地(协议)路径
7. 验证对不存在的排除路径的正确处理
