### PR TITLE
Feat(filedialog): improve address bar navigation and Enter key handli…

### DIFF
--- a/src/plugins/filedialog/core/core.cpp
+++ b/src/plugins/filedialog/core/core.cpp
@@ -13,6 +13,10 @@
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/base/schemefactory.h>
+
+#include <QUrlQuery>
 
 #include <QDBusError>
 #include <QDBusConnection>
@@ -89,6 +93,13 @@ void Core::onAllPluginsStarted()
 
     dfmplugin_menu_util::menuSceneRegisterScene(FileDialogMenuCreator::name(), new FileDialogMenuCreator);
     bindScene("WorkspaceMenu");
+
+    // Follow the titlebar "tab-enter-dir" hook. In the file-chooser dialog process
+    // entering a file path means cd-ing into the parent directory and selecting the
+    // file, so we handle it here and return true to stop the hook chain. In the
+    // file-manager process no plugin follows this hook, so it returns false and
+    // the titlebar falls back to opening the file directly.
+    dpfHookSequence->follow("dfmplugin_titlebar", "hook_Tab_EnterDir", this, &Core::handleEnterDir);
 }
 
 void Core::bindScene(const QString &parentScene)
@@ -151,6 +162,25 @@ void Core::exitOnShutdown(bool shutdown)
         // 尝试正常、优雅地退出
         qApp->quit();
     }
+}
+
+bool Core::handleEnterDir(quint64 windowId, const QUrl &url)
+{
+    const FileInfoPointer &info = InfoFactory::create<FileInfo>(url);
+    if (!info || !info->exists()) {
+        fmWarning() << "Enter-dir failed: file not exists, url:" << url;
+        return true;   // consumed: the dialog should never fall back to opening the file
+    }
+
+    QUrl parentUrl = info->urlOf(FileInfo::FileUrlInfoType::kParentUrl);
+    QUrlQuery query;
+    query.addQueryItem("selectUrl", url.toString());
+    parentUrl.setQuery(query);
+
+    fmInfo() << "FileChooser enter-dir: cd to parent and select, window:" << windowId
+             << "parent:" << parentUrl.toString(QUrl::RemoveQuery) << "select:" << url.toString();
+    dpfSignalDispatcher->publish(GlobalEventType::kChangeCurrentUrl, windowId, parentUrl);
+    return true;
 }
 
 }   // namespace filedialog_core

--- a/src/plugins/filedialog/core/core.h
+++ b/src/plugins/filedialog/core/core.h
@@ -24,6 +24,7 @@ private slots:
     void onAllPluginsStarted();
     void bindScene(const QString &parentScene);
     void bindSceneOnAdded(const QString &newScene);
+    bool handleEnterDir(quint64 windowId, const QUrl &url);
     void enterHighPerformanceMode();
     void exitOnShutdown(bool);
 

--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -934,7 +934,15 @@ bool FileDialog::isFileNameEditFocused() const
 void FileDialog::handleEnterInSaveMode()
 {
     // INFO: [FileDialog::handleEnterInSaveMode] Processing Enter key in save mode.
-    
+
+    // 当焦点位于标题栏的地址栏时（如编辑路径），回车由地址栏自身处理跳转，
+    // 不应触发保存操作，直接返回。
+    QWidget *focusWidget = QApplication::focusWidget();
+    if (focusWidget && titleBar() && titleBar()->isAncestorOf(focusWidget)) {
+        // INFO: [FileDialog::handleEnterInSaveMode] Enter pressed in titlebar address bar, let it handle navigation.
+        return;
+    }
+
     // 保存模式下的逻辑：
     // 1. 如果焦点在文件名编辑框，直接触发保存
     // 2. 如果焦点在文件视图且选中目录，让文件视图处理（进入目录）

--- a/src/plugins/filemanager/dfmplugin-titlebar/titlebar.h
+++ b/src/plugins/filemanager/dfmplugin-titlebar/titlebar.h
@@ -52,6 +52,7 @@ class TitleBar : public dpf::Plugin
     DPF_EVENT_REG_HOOK(hook_Tab_SetTabName)
     DPF_EVENT_REG_HOOK(hook_Tab_Closeable)
     DPF_EVENT_REG_HOOK(hook_Tab_FileDeleteNotCdComputer)
+    DPF_EVENT_REG_HOOK(hook_Tab_EnterDir)
 
 public:
     virtual void initialize() override;

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -245,7 +245,8 @@ void TitleBarHelper::handleJumpToPressed(QWidget *sender, const QString &text)
         fmInfo() << "jump :" << inputStr;
         const FileInfoPointer &info = InfoFactory::create<FileInfo>(url);
         if (info && info->exists() && info->isAttributes(OptInfoType::kIsFile)) {
-            TitleBarEventCaller::sendOpenFile(sender, url);
+            if (!dpfHookSequence->run("dfmplugin_titlebar", "hook_Tab_EnterDir", TitleBarHelper::windowId(sender), url))
+                TitleBarEventCaller::sendOpenFile(sender, url);
         } else {
             TitleBarEventCaller::sendCd(sender, url);
         }


### PR DESCRIPTION
…ng in chooser mode

Add a new utility `UniversalUtils::isChooserDialogProcess()` to detect whether the current process is a file chooser / select dialog (dde-file-dialog, dde-select-dialog-x11, dde-select-dialog-wayland).

Two related fixes for the file chooser dialog:

1. In `FileDialog::handleEnterInSaveMode()`, return early when the focused widget is inside the title bar (e.g. the address bar). The Enter key should trigger address bar navigation, not the save action.

2. In `TitleBarHelper::handleJumpToPressed()`, when running as a chooser dialog process, jumping to a file path in the address bar now navigates to the file's parent directory and selects the file (via a `selectUrl` query parameter) instead of opening it directly, which matches the expected chooser dialog behavior.

Log: Add feature for chooser dialog.
Task: https://pms.uniontech.com/task-view-392211.html

## Summary by Sourcery

Improve file chooser dialog behavior for address bar navigation and Enter key handling in save mode.

New Features:
- Add a utility to detect whether the current process is running as a file chooser or select dialog.

Bug Fixes:
- Prevent Enter key presses in the title bar address bar from triggering the save action in save mode.
- Ensure jumping to a file path in the address bar in chooser dialogs navigates to the parent directory and selects the file instead of opening it directly.