### PR TITLE
fix: keep desktop canvas origin for top and left dock

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
@@ -40,6 +40,10 @@ public:
     inline QRect relativeRect(const QRect &avRect, const QRect &geometry)
     {
         QPoint relativePos = avRect.topLeft() - geometry.topLeft();
+        // The desktop root already starts at the screen origin; keep top/left
+        // dock offsets out of the child view origin.
+        relativePos.setX(qMin(relativePos.x(), 0));
+        relativePos.setY(qMin(relativePos.y(), 0));
         return QRect(relativePos, avRect.size());
     }
 


### PR DESCRIPTION
log: Prevent available geometry offsets from being applied twice when converting screen geometry to canvas view geometry.

pms:bug-366547

## Summary by Sourcery

Bug Fixes:
- Clamp relative canvas positions so the desktop root continues to start at the screen origin even when top or left docks introduce negative offsets.