### PR TITLE
fix(propertydialog): include source directories in multi-file size ca…

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp
@@ -28,6 +28,7 @@ MultiFileBasicInfoWidget::MultiFileBasicInfoWidget(const QList<QUrl> &urls,
     : DArrowLineDrawer(parent)
     , fileCalculationUtils(new FileScanner)
 {
+    fileCalculationUtils->setOptions(FileScanner::ScanOption::IncludeSource);
     initUI();
     loadData(urls);
 }


### PR DESCRIPTION
…lculation

Set the IncludeSource scan option on FileScanner in MultiFileBasicInfoWidget so that the selected source directories themselves are counted in the total size and file count, ensuring accurate property values for multi-file selections.

## Summary by Sourcery

Bug Fixes:
- Include source directories themselves in multi-file size and file count calculations to provide accurate property values.