### PR TITLE
fix: adjust sticky header hover rect to prevent negative y-coordinate

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2167,7 +2167,11 @@ bool FileView::eventFilter(QObject *obj, QEvent *event)
         }
 
         if (d->stickyHelper->currentStickyIndex().isValid() && !d->stickyHelper->currentStickyRect().isNull()) {
-            bool nowHovered = d->stickyHelper->currentStickyRect().contains(hoverPos);
+            QRect stickyRect = d->stickyHelper->currentStickyRect();
+            if (stickyRect.y() < 0)
+                stickyRect.setY(0);
+
+            bool nowHovered = stickyRect.contains(hoverPos);
             if (nowHovered != d->stickyHelper->isStickyHeaderHovered()) {
                 d->stickyHelper->setStickyHeaderHovered(nowHovered);
                 viewport()->update(d->stickyHelper->currentStickyRect());


### PR DESCRIPTION
The sticky header rect may have a negative y-coordinate when the view is
scrolled, causing hover detection to fail. By clamping the y-coordinate
to 0, we ensure the hover area remains valid within the viewport.

Log: Fixed sticky header hover detection when header is partially
scrolled above the view

Influence:
1. Test sticky header hover behavior when scrolled partially above view
2. Verify header remains hoverable when scrolled to top
3. Check no regression in normal scrolling scenarios
4. Verify hover highlight appears correctly for sticky header

fix: 修复粘性表头悬停区域 y 坐标为负的问题

当视图滚动时，粘性表头矩形区域的 y 坐标可能为负，导致悬停检测失败。通过
将 y 坐标限制为 0，确保悬停区域在视口内有效。

Log: 修复粘性表头部分滚出视图顶部时的悬停检测

Influence:
1. 测试粘性表头部分滚出视图顶部时的悬停行为
2. 验证表头滚动到顶部时仍可触发悬停
3. 检查正常滚动场景无回归问题
4. 验证粘性表头悬停高亮显示正确
