### PR TITLE
fix(changelog): fix malformed date timestamp in debian/changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1636,7 +1636,7 @@ dde-file-manager (6.0.46) unstable; urgency=medium
 
   * update file manager baseline version to V6.0.46
 
- -- liujinchang <liujinchang@uniontech.com>  Fri,12 Apr 2024 17:01:53 +0800
+ -- liujinchang <liujinchang@uniontech.com>  Fri, 12 Apr 2024 17:01:53 +0800
 
 dde-file-manager (6.0.45) unstable; urgency=medium
 


### PR DESCRIPTION
Add missing space after comma in date field to comply with Debian changelog date format (RFC 2822), which is required by dh_installchangelogs for proper changelog trimming.

修复debian/changelog中日期时间戳格式错误，在逗号后添加缺失的空格，
符合RFC 2822格式要求，使dh_installchangelogs能正确裁剪changelog。

Log: 修复debian/changelog日期格式错误
Influence: 修复后dh_installchangelogs不再报警告，changelog能被正确裁剪。

打包警告如下：

> dh_installchangelogs: warning: Could not parse timestamp 'Fri,12 Apr 2024 17:01:53 +0800'. debian/changelog will not be trimmed.
> dh_installchangelogs: warning: debian/changelog could not be trimmed. The full changelog will be installed.
> dh_installchangelogs: warning: Could not parse timestamp 'Fri,12 Apr 2024 17:01:53 +0800'. debian/changelog will not be trimmed.
> dh_installchangelogs: warning: debian/changelog could not be trimmed. The full changelog will be installed.

## Summary by Sourcery

Bug Fixes:
- Correct malformed date timestamps in debian/changelog by adding the required space after the weekday comma to satisfy Debian/RFC 2822 format expectations.