### PR TITLE
fix: improve trash state handling and initialization

### DIFF
--- a/src/dfm-base/file/local/desktopfileinfo.cpp
+++ b/src/dfm-base/file/local/desktopfileinfo.cpp
@@ -102,8 +102,13 @@ QString DesktopFileInfo::desktopIconName() const
 {
     // special handling for trash desktop file which has tash datas
     if (d->iconName == "user-trash") {
-        if (!FileUtils::trashIsEmpty())
-            return "user-trash-full";
+        const auto trashState = FileUtils::trashEmptyState();
+        if (trashState == FileUtils::TrashEmptyState::kEmpty)
+            return d->iconName;
+
+        // Fix: desktop startup must not synchronously touch trash:///.
+        // Default to the non-empty icon until trashcore finishes probing.
+        return "user-trash-full";
     }
 
     return d->iconName;

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -58,6 +58,12 @@
 
 #include <DDBusSender>
 
+#include <atomic>
+
+namespace {
+std::atomic<int> kTrashEmptyState { static_cast<int>(dfmbase::FileUtils::TrashEmptyState::kUnknown) };
+}
+
 #include <unistd.h>
 #include <sys/stat.h>
 #include <linux/limits.h>
@@ -377,6 +383,16 @@ bool FileUtils::trashIsEmpty()
         return info->countChildFile() == 0;
     }
     return true;
+}
+
+FileUtils::TrashEmptyState FileUtils::trashEmptyState()
+{
+    return static_cast<TrashEmptyState>(kTrashEmptyState.load());
+}
+
+void FileUtils::setTrashEmptyState(TrashEmptyState state)
+{
+    kTrashEmptyState.store(static_cast<int>(state));
 }
 
 QUrl FileUtils::trashRootUrl()

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -18,6 +18,12 @@ namespace dfmbase {
 class FileUtils
 {
 public:
+    enum class TrashEmptyState {
+        kUnknown,
+        kEmpty,
+        kNotEmpty
+    };
+
     struct FilesSizeInfo
     {
         qint64 totalSize { 0 };
@@ -50,6 +56,8 @@ public:
     static bool isSameFile(const QString &path1, const QString &path2);
     static bool isCdRomDevice(const QUrl &url);
     static bool trashIsEmpty();
+    static TrashEmptyState trashEmptyState();
+    static void setTrashEmptyState(TrashEmptyState state);
     static QUrl trashRootUrl();
     static bool isTrashFile(const QUrl &url);
     static bool isTrashRootFile(const QUrl &url);

--- a/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.cpp
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "trashcoreeventsender.h"
-#include "utils/trashcorehelper.h"
+#include "trashcorestartupprobe.h"
 
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/base/standardpaths.h>
@@ -18,32 +18,33 @@
 #include <QDebug>
 #include <QUrl>
 
-#include <functional>
-
 using namespace dfmplugin_trashcore;
 DFMBASE_USE_NAMESPACE
 
 TrashCoreEventSender::TrashCoreEventSender(QObject *parent)
     : QObject(parent)
 {
-    // Remove blocking FileUtils::trashIsEmpty() call from constructor
-    // State will be lazily initialized on first watcher event
-    initTrashWatcher();
+    FileUtils::setTrashEmptyState(FileUtils::TrashEmptyState::kUnknown);
+
+    timer.setSingleShot(true);
+    timer.setInterval(5000);
+    connect(&timer, &QTimer::timeout, this, &TrashCoreEventSender::tryInitialize);
+
+    startupProbe = new TrashCoreStartupProbe(this);
+    connect(startupProbe, &TrashCoreStartupProbe::ready,
+            this, &TrashCoreEventSender::tryInitialize);
+    startupProbe->start();
 }
 
 void TrashCoreEventSender::initTrashWatcher()
 {
+    if (trashFileWatcher)
+        return;
+
     trashFileWatcher.reset(new LocalFileWatcher(FileUtils::trashRootUrl(), this));
 
     connect(trashFileWatcher.data(), &AbstractFileWatcher::subfileCreated, this, &TrashCoreEventSender::sendTrashStateChangedAdd);
     connect(trashFileWatcher.data(), &AbstractFileWatcher::fileDeleted, this, &TrashCoreEventSender::sendTrashStateChangedDel);
-
-    if (!checkAndStartWatcher()) {
-        connect(&timer, &QTimer::timeout, this, &TrashCoreEventSender::checkAndStartWatcher);
-        timer.setSingleShot(true);
-        timer.setInterval(5000);
-        timer.start();
-    }
 }
 
 bool TrashCoreEventSender::checkAndStartWatcher()
@@ -52,7 +53,13 @@ bool TrashCoreEventSender::checkAndStartWatcher()
         timer.start();
         return false;
     }
-    return trashFileWatcher->startWatcher();
+
+    if (!trashFileWatcher->startWatcher()) {
+        timer.start();
+        return false;
+    }
+
+    return true;
 }
 
 TrashCoreEventSender *TrashCoreEventSender::instance()
@@ -61,10 +68,38 @@ TrashCoreEventSender *TrashCoreEventSender::instance()
     return &sender;
 }
 
+void TrashCoreEventSender::tryInitialize()
+{
+    if (watcherInitialized || !startupProbe || !startupProbe->isReady())
+        return;
+
+    initTrashWatcher();
+    if (!checkAndStartWatcher())
+        return;
+
+    watcherInitialized = true;
+    initTrashState();
+}
+
+void TrashCoreEventSender::initTrashState()
+{
+    const bool actuallyEmpty = FileUtils::trashIsEmpty();
+    trashState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
+    FileUtils::setTrashEmptyState(actuallyEmpty ? FileUtils::TrashEmptyState::kEmpty
+                                                : FileUtils::TrashEmptyState::kNotEmpty);
+
+    // Startup defaults to the non-empty icon, so only an empty result needs
+    // an immediate correction signal.
+    if (trashState == TrashState::Empty)
+        dpfSignalDispatcher->publish("dfmplugin_trashcore", "signal_TrashCore_TrashStateChanged");
+}
+
 void TrashCoreEventSender::sendTrashStateChangedDel()
 {
     bool actuallyEmpty = FileUtils::trashIsEmpty();
     TrashState newState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
+    FileUtils::setTrashEmptyState(actuallyEmpty ? FileUtils::TrashEmptyState::kEmpty
+                                                : FileUtils::TrashEmptyState::kNotEmpty);
 
     // Only send signal if state actually changed
     if (trashState == TrashState::Unknown || newState != trashState) {
@@ -81,6 +116,7 @@ void TrashCoreEventSender::sendTrashStateChangedDel()
 void TrashCoreEventSender::sendTrashStateChangedAdd()
 {
     // If trash was empty and files are being added, it's now not empty
+    FileUtils::setTrashEmptyState(FileUtils::TrashEmptyState::kNotEmpty);
     if (trashState == TrashState::Unknown || trashState == TrashState::Empty) {
         trashState = TrashState::NotEmpty;
         qInfo() << "TrashCore: Trash became non-empty, sending state changed signal";

--- a/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
@@ -19,6 +19,8 @@ class AbstractFileWatcher;
 
 namespace dfmplugin_trashcore {
 
+class TrashCoreStartupProbe;
+
 class TrashCoreEventSender final : public QObject
 {
     Q_OBJECT
@@ -28,6 +30,7 @@ public:
     static TrashCoreEventSender *instance();
 
 private slots:
+    void tryInitialize();
     void sendTrashStateChangedDel();
     void sendTrashStateChangedAdd();
 
@@ -40,12 +43,15 @@ private:
 
     explicit TrashCoreEventSender(QObject *parent = nullptr);
     void initTrashWatcher();
+    void initTrashState();
     bool checkAndStartWatcher();
 
 private:
+    TrashCoreStartupProbe *startupProbe { nullptr };
     QSharedPointer<DFMBASE_NAMESPACE::AbstractFileWatcher> trashFileWatcher = nullptr;
     TrashState trashState { TrashState::Unknown };
     QTimer timer;
+    bool watcherInitialized { false };
 };
 
 }

--- a/src/plugins/common/dfmplugin-trashcore/events/trashcorestartupprobe.cpp
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcorestartupprobe.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "trashcorestartupprobe.h"
+
+namespace dfmplugin_trashcore {
+
+namespace {
+constexpr int kProbeTimeoutMs = 120 * 1000;
+constexpr int kProbeRetryIntervalMs = 60 * 1000;
+}
+
+TrashCoreStartupProbe::TrashCoreStartupProbe(QObject *parent)
+    : QObject(parent)
+{
+    probeTimeoutTimer.setSingleShot(true);
+    retryTimer.setSingleShot(true);
+
+    connect(&probeTimeoutTimer, &QTimer::timeout,
+            this, &TrashCoreStartupProbe::handleProbeTimeout);
+    connect(&retryTimer, &QTimer::timeout,
+            this, &TrashCoreStartupProbe::startProbe);
+}
+
+void TrashCoreStartupProbe::start()
+{
+    if (readyState || probeProcess)
+        return;
+
+    startProbe();
+}
+
+bool TrashCoreStartupProbe::isReady() const
+{
+    return readyState;
+}
+
+void TrashCoreStartupProbe::startProbe()
+{
+    if (readyState || probeProcess)
+        return;
+
+    probeProcess = new QProcess(this);
+    probeProcess->setProgram("gio");
+    probeProcess->setArguments({ "info", "trash:///" });
+
+    connect(probeProcess, static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished),
+            this, &TrashCoreStartupProbe::handleProbeFinished);
+    connect(probeProcess, &QProcess::errorOccurred,
+            this, &TrashCoreStartupProbe::handleProbeError);
+
+    probeProcess->start();
+    probeTimeoutTimer.start(kProbeTimeoutMs);
+}
+
+void TrashCoreStartupProbe::handleProbeFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    probeTimeoutTimer.stop();
+
+    const bool success = (exitStatus == QProcess::NormalExit && exitCode == 0);
+    cleanupProcess();
+    if (!success) {
+        scheduleRetry();
+        return;
+    }
+
+    readyState = true;
+    emit ready();
+}
+
+void TrashCoreStartupProbe::handleProbeError(QProcess::ProcessError error)
+{
+    if (error != QProcess::FailedToStart)
+        return;
+
+    probeTimeoutTimer.stop();
+    cleanupProcess();
+    scheduleRetry();
+}
+
+void TrashCoreStartupProbe::handleProbeTimeout()
+{
+    if (!probeProcess)
+        return;
+
+    probeProcess->kill();
+}
+
+void TrashCoreStartupProbe::cleanupProcess()
+{
+    if (!probeProcess)
+        return;
+
+    probeProcess->deleteLater();
+    probeProcess = nullptr;
+}
+
+void TrashCoreStartupProbe::scheduleRetry()
+{
+    if (readyState || retryTimer.isActive())
+        return;
+
+    retryTimer.start(kProbeRetryIntervalMs);
+}
+
+}   // namespace dfmplugin_trashcore

--- a/src/plugins/common/dfmplugin-trashcore/events/trashcorestartupprobe.h
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcorestartupprobe.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TRASHCORESTARTUPPROBE_H
+#define TRASHCORESTARTUPPROBE_H
+
+#include "dfmplugin_trashcore_global.h"
+
+#include <QObject>
+#include <QProcess>
+#include <QTimer>
+
+namespace dfmplugin_trashcore {
+
+class TrashCoreStartupProbe final : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(TrashCoreStartupProbe)
+
+public:
+    explicit TrashCoreStartupProbe(QObject *parent = nullptr);
+
+    void start();
+    bool isReady() const;
+
+Q_SIGNALS:
+    void ready();
+
+private Q_SLOTS:
+    void startProbe();
+    void handleProbeFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void handleProbeError(QProcess::ProcessError error);
+    void handleProbeTimeout();
+
+private:
+    void cleanupProcess();
+    void scheduleRetry();
+
+private:
+    QProcess *probeProcess { nullptr };
+    QTimer probeTimeoutTimer;
+    QTimer retryTimer;
+    bool readyState { false };
+};
+
+}   // namespace dfmplugin_trashcore
+
+#endif   // TRASHCORESTARTUPPROBE_H

--- a/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-trash/utils/trashhelper.cpp
@@ -285,8 +285,15 @@ bool TrashHelper::customRoleDisplayName(const QUrl &url, const Global::ItemRoles
 
 void TrashHelper::onTrashStateChanged()
 {
-    bool actuallyEmpty = FileUtils::trashIsEmpty();
-    trashState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
+    const auto cachedState = FileUtils::trashEmptyState();
+    if (cachedState == FileUtils::TrashEmptyState::kUnknown) {
+        bool actuallyEmpty = FileUtils::trashIsEmpty();
+        trashState = actuallyEmpty ? TrashState::Empty : TrashState::NotEmpty;
+    } else {
+        trashState = (cachedState == FileUtils::TrashEmptyState::kEmpty)
+                ? TrashState::Empty
+                : TrashState::NotEmpty;
+    }
 
     // When trash becomes non-empty, update UI
     const QList<quint64> &windowIds = FMWindowsIns.windowIdList();


### PR DESCRIPTION
1. Add TrashEmptyState enum and atomic state tracking in FileUtils
2. Create TrashCoreStartupProbe to asynchronously check trash
availability at startup
3. Modify DesktopFileInfo to avoid synchronous trash checks
4. Refactor TrashCoreEventSender with lazy initialization and state
management
5. Cache trash state to avoid redundant synchronous checks
6. Default to "trash full" icon until actual state is confirmed

Log: Improved trash state handling with asynchronous initialization and
state caching

Influence:
1. Verify trash icon shows correctly during startup
2. Test emptying trash updates icon immediately
3. Check adding files to trash updates icon correctly
4. Verify system behavior when trash service is unavailable
5. Test application startup when trash is not mounted

fix: 改进回收站状态处理和初始化

1. 在FileUtils中添加TrashEmptyState枚举和原子状态跟踪
2. 创建TrashCoreStartupProbe异步检查启动时的回收站可用性
3. 修改DesktopFileInfo以避免同步的回收站检查
4. 重构TrashCoreEventSender使用延迟初始化和状态管理
5. 缓存回收站状态以避免冗余的同步检查
6. 默认显示"回收站满"图标直到实际状态确认

Log: 改进回收站状态处理，实现异步初始化和状态缓存

Influence:
1. 验证启动时回收站图标显示正确
2. 测试清空回收站是否能立即更新图标
3. 检查添加文件到回收站能否正确更新图标
4. 验证回收站服务不可用时系统行为
5. 测试回收站未挂载时的应用启动情况

## Summary by Sourcery

Improve trash state initialization and icon behavior by introducing asynchronous startup probing and cached trash state tracking.

New Features:
- Add TrashEmptyState enum and atomic cached trash state in FileUtils.
- Introduce TrashCoreStartupProbe to asynchronously verify trash availability at startup.

Enhancements:
- Refine TrashCoreEventSender to lazily initialize the trash watcher once startup probing confirms readiness and to initialize global trash state accordingly.
- Update TrashHelper and DesktopFileInfo to rely on cached trash state to avoid synchronous trash access during UI startup and icon updates.