### PR TITLE
feature/fix BUG370193

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
@@ -9,8 +9,6 @@
 #include <dfm-base/utils/fileutils.h>
 #include "imageview.h"
 
-#include <DAnchors>
-
 #include <QImageReader>
 #include <QProcess>
 #include <QMimeType>
@@ -19,7 +17,6 @@
 #include <QFileInfo>
 #include <QMimeData>
 
-DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 using namespace plugin_filepreview;
 
@@ -32,7 +29,7 @@ ImagePreview::ImagePreview(QObject *parent)
 ImagePreview::~ImagePreview()
 {
     fmInfo() << "Image preview: ImagePreview instance destroyed";
-    
+
     if (imageView)
         imageView->deleteLater();
 
@@ -43,7 +40,7 @@ ImagePreview::~ImagePreview()
 bool ImagePreview::canPreview(const QUrl &url, QByteArray *format) const
 {
     fmDebug() << "Image preview: checking if can preview:" << url;
-    
+
     QByteArray f = QImageReader::imageFormat(url.toLocalFile());
 
     if (f.isEmpty()) {
@@ -77,23 +74,29 @@ void ImagePreview::initialize(QWidget *window, QWidget *statusBar)
     Q_UNUSED(window)
 
     fmDebug() << "Image preview: initializing with status bar";
-    
+
     messageStatusBar = new QLabel(statusBar);
     messageStatusBar->setStyleSheet("QLabel{font-family: Helvetica;\
                                    font-size: 12px;\
                                    font-weight: 300;}");
+    // Expanding 水平策略：让 messageStatusBar 在 QHBoxLayout 中抢占 previewTitle 与 openBtn
+    // 之间的多余空间，配合 AlignCenter 使分辨率文本在该空间内居中——previewTitle 短时
+    // 接近 statusBar 几何中心，previewTitle 长时多余空间被压缩，标签自然回缩避让。
+    messageStatusBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    messageStatusBar->setAlignment(Qt::AlignCenter);
 
     messageStatusBar->show();
 
-    DAnchorsBase(messageStatusBar).setCenterIn(statusBar);
-    
+    // 分辨率标签通过 statusBarWidget() 交给 FilePreviewDialog 的 QHBoxLayout 统一管理，
+    // 不再用 DAnchors 绝对居中——避免与 previewTitle 在 statusBar 中心区域重叠。
+
     fmDebug() << "Image preview: status bar initialized";
 }
 
 bool ImagePreview::setFileUrl(const QUrl &url)
 {
     fmInfo() << "Image preview: setting file URL:" << url;
-    
+
     if (currentFileUrl == url) {
         fmDebug() << "Image preview: URL unchanged, skipping:" << url;
         return true;
@@ -159,4 +162,17 @@ QWidget *ImagePreview::contentWidget() const
 QString ImagePreview::title() const
 {
     return imageTitle;
+}
+
+QWidget *ImagePreview::statusBarWidget() const
+{
+    return messageStatusBar;
+}
+
+Qt::Alignment ImagePreview::statusBarWidgetAlignment() const
+{
+    // 返回 0（默认）让 widget 按 sizePolicy 参与 QHBoxLayout 的空间分配——
+    // 配合 messageStatusBar 的 Expanding 策略使其占满 previewTitle 与 openBtn 之间的多余空间。
+    // 文本居中由 QLabel::setAlignment(AlignCenter) 负责，不在此处设 alignment 以免抑制 Expanding。
+    return Qt::Alignment();
 }

--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.h
@@ -34,6 +34,9 @@ public:
 
     QString title() const override;
 
+    QWidget *statusBarWidget() const override;
+    Qt::Alignment statusBarWidgetAlignment() const override;
+
 private:
     QUrl currentFileUrl;
     QPointer<QLabel> messageStatusBar;

--- a/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
@@ -40,6 +40,10 @@ public:
     inline QRect relativeRect(const QRect &avRect, const QRect &geometry)
     {
         QPoint relativePos = avRect.topLeft() - geometry.topLeft();
+        // The desktop root already starts at the screen origin; keep top/left
+        // dock offsets out of the child view origin.
+        relativePos.setX(qMin(relativePos.x(), 0));
+        relativePos.setY(qMin(relativePos.y(), 0));
         return QRect(relativePos, avRect.size());
     }
 

--- a/src/plugins/desktop/ddplugin-core/screen/screenqt.cpp
+++ b/src/plugins/desktop/ddplugin-core/screen/screenqt.cpp
@@ -8,6 +8,7 @@
 #include <qpa/qplatformscreen.h>
 #include <QDebug>
 #include <QApplication>
+#include <QWindow>
 
 namespace GlobalPrivate {
 static QRect dealRectRatio(QRect orgRect)
@@ -64,13 +65,29 @@ QRect ScreenQt::availableGeometry() const
 
     DockRect dockrectI = DockInfoIns->frontendWindowRect();
 
-    const qreal ratio = qApp->primaryScreen()->devicePixelRatio();
+    // wayland 分数缩放下不能用 QScreen::devicePixelRatio()：它是 wl_output 的整数 scale(真实 1.25
+    // 会被报成 2)，与逻辑几何不自洽，用它换算物理 dock 会少减、导致最底行被遮。真实分数缩放由合成器
+    // 经 wp_fractional_scale 按 surface 下发，只体现在“窗口”的 devicePixelRatio 上，故取本屏对应顶层
+    // 窗口的 devicePixelRatio；无窗口(早期/异常)时回退到本屏 devicePixelRatio 并钳到 >=1。
+    qreal ratio = qscreen->devicePixelRatio();
+    for (QWindow *w : qApp->topLevelWindows()) {
+        if (w->screen() == qscreen && w->devicePixelRatio() > 0) {
+            ratio = w->devicePixelRatio();
+            break;
+        }
+    }
+    if (ratio < 1.0)
+        ratio = 1.0;
     const QRect hRect = handleGeometry();
 
-    if (!hRect.contains(dockrectI)) {
+    // treeland 下 handleGeometry() 返回逻辑坐标，与物理 dock 错位会误判“不在本屏”，故补一次逻辑判断：
+    // 仅当物理判断与逻辑判断都认为 dock 不在本屏时，才退回全屏几何。
+    const QRect dockrectLogical(static_cast<int>(dockrectI.x / ratio), static_cast<int>(dockrectI.y / ratio),
+                                static_cast<int>(dockrectI.width / ratio), static_cast<int>(dockrectI.height / ratio));
+    if (!hRect.contains(dockrectI) && !ret.contains(dockrectLogical)) {
         fmDebug() << "Dock not contained in screen geometry, using full screen - screen:" << name()
                   << "handleGeometry:" << hRect << "dockRect:" << QRect(dockrectI)
-                  << "ratio:" << ratio;
+                  << "dockRectLogical:" << dockrectLogical << "ratio:" << ratio;
         return ret;
     }
 

--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -1161,6 +1161,13 @@ void FileDialog::initConnect()
 {
     connect(statusBar()->acceptButton(), &QPushButton::clicked, this, &FileDialog::onAcceptButtonClicked);
     connect(statusBar()->rejectButton(), &QPushButton::clicked, this, &FileDialog::onRejectButtonClicked);
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this,
+            [this](const QString &cfg, const QString &key) {
+                if (cfg != QString("org.deepin.dde.file-manager.sidebar") || key != QString("itemVisiable"))
+                    return;
+                if (d->acceptMode == QFileDialog::AcceptSave)
+                    urlSchemeEnable("recent", false);
+            });
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     connect(statusBar()->comboBox(),
             static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated),

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -843,7 +843,14 @@ void DiskEncryptMenuScene::updateActions()
         }
     } else if (EventsHandler::instance()->unfinishedDecryptJob() == param.devDesc
                || EventsHandler::instance()->unfinishedDecryptJob() == param.devPhy) {
-        actions[kActIDResumeDecrypt]->setVisible(true);
+        // Defensive check: only show "Continue decrypt" if device is actually LUKS encrypted.
+        // This handles the case where the partition was reformatted after a decrypt job was interrupted.
+        const QString &idType = selectedItemInfo.value("IdType").toString();
+        if (idType == "crypto_LUKS") {
+            actions[kActIDResumeDecrypt]->setVisible(true);
+        } else {
+            fmInfo() << "Device has pending decrypt job but is not LUKS (may have been reformatted), hiding resume decrypt option:" << param.devDesc << "idType:" << idType;
+        }
     } else {
         actions[kActIDEncrypt]->setVisible(true);
     }

--- a/src/plugins/filemanager/dfmplugin-recent/recent.json
+++ b/src/plugins/filemanager/dfmplugin-recent/recent.json
@@ -23,6 +23,7 @@
                 "VisiableControl" : "recent",
                 "ReportName" : "Recent"
             }
-        }]
+        }],
+        "PluginSchemes": ["recent"]
     }
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -132,8 +132,11 @@ FileView::~FileView()
     }
 
     // 3. 断开信号连接
-    if (model()) {
-        disconnect(model(), nullptr, this, nullptr);
+    //    保存 model 指针: setModel(nullptr) 后 model() 返回 nullptr,
+    //    需在解绑前获取以便后续显式删除。
+    FileViewModel *savedModel = model();
+    if (savedModel) {
+        disconnect(savedModel, nullptr, this, nullptr);
     }
     if (selectionModel()) {
         disconnect(selectionModel(), nullptr, this, nullptr);
@@ -144,13 +147,22 @@ FileView::~FileView()
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 
-    // 5. 清理其他订阅
+    // 5. 显式删除 model: ~QAbstractItemModel() 会调用 invalidatePersistentIndexes(),
+    //    将所有残留 QPersistentModelIndex 的 model 指针置 null。
+    //    必须在 ~QObject() 子对象清理前执行,否则 headerView / selectionModel 等
+    //    子控件在 ~QObject() 中销毁时,其内部 QPersistentModelIndex 会访问已销毁
+    //    的 model 私有数据哈希表(removePersistentIndexData)而崩溃。
+    if (savedModel && savedModel->QObject::parent() == this) {
+        delete savedModel;
+    }
+
+    // 6. 清理其他订阅
     dpfSignalDispatcher->unsubscribe("dfmplugin_workspace", "signal_View_HeaderViewSectionChanged", this, &FileView::onHeaderViewSectionChanged);
     dpfSignalDispatcher->unsubscribe("dfmplugin_filepreview", "signal_ThumbnailDisplay_Changed", this, &FileView::onWidgetUpdate);
 
     fmDebug() << "FileView destruction completed";
 
-    // 注意: model 作为 FileView 的子对象,会在基类析构后由 Qt 自动释放
+    // model 已在步骤 5 显式删除,不会进入 ~QObject() 子对象清理流程
 }
 
 QWidget *FileView::widget() const

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -281,6 +281,15 @@ QString DiskEncryptSetup::PendingDecryptionDevice()
     for (auto f : files) {
         auto name = m_dptr->resolveDeviceByDetachHeaderName(f);
         if (!name.isEmpty()) {
+            // Validate that the device is still encrypted; if it has been reformatted
+            // (e.g. via mke2fs), the LUKS header is gone and this backup file is stale.
+            auto status = crypt_setup_helper::encryptStatus(name);
+            if (status == disk_encrypt::kStatusNotEncrypted || status < 0) {
+                qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Device is no longer encrypted, removing stale backup:"
+                         << name << "file:" << f;
+                QFile::remove(d.absoluteFilePath(f));
+                continue;
+            }
             qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Found pending decryption device:" << name << "from header file:" << f;
             return name;
         }

--- a/src/services/diskencrypt/helpers/jobfilehelper.cpp
+++ b/src/services/diskencrypt/helpers/jobfilehelper.cpp
@@ -244,25 +244,60 @@ QStringList job_file_helper::validJobTypes()
 void job_file_helper::checkJobs()
 {
     qInfo() << "[job_file_helper::checkJobs] Checking and validating existing job files";
-    
+
+    // Check encrypt job files
     JobDescArgs job;
     loadEncryptJobFile(&job);
-    if (job.jobFile.isEmpty()) {
-        qInfo() << "[job_file_helper::checkJobs] No job files to check";
-        return;
+    if (!job.jobFile.isEmpty()) {
+        if (!QFile(job.devPath).exists()) {
+            qInfo() << "[job_file_helper::checkJobs] Encrypt job device no longer exists, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
+            removeJobFile(job.jobFile);
+        } else if (crypt_setup_helper::encryptStatus(job.devPath) == disk_encrypt::kStatusNotEncrypted) {
+            qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing encrypt job file - device:" << job.devPath << "job file:" << job.jobFile;
+            removeJobFile(job.jobFile);
+        } else {
+            qInfo() << "[job_file_helper::checkJobs] Encrypt job file validation completed - device:" << job.devPath << "job file:" << job.jobFile;
+        }
     }
 
-    if (!QFile(job.devPath).exists()) {
-        qInfo() << "[job_file_helper::checkJobs] Job device no longer exists, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
-        removeJobFile(job.jobFile);
-        return;
+    // Check decrypt job file
+    QString decryptJobPath = QString(disk_encrypt::kUSecConfigDir) + "/decrypt.json";
+    QFile decryptJobFile(decryptJobPath);
+    if (decryptJobFile.exists()) {
+        qInfo() << "[job_file_helper::checkJobs] Found decrypt job file:" << decryptJobPath;
+        if (decryptJobFile.open(QIODevice::ReadOnly)) {
+            QByteArray data = decryptJobFile.readAll();
+            decryptJobFile.close();
+
+            QJsonParseError err;
+            QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+            if (err.error == QJsonParseError::NoError && doc.isObject()) {
+                QJsonObject obj = doc.object();
+                QString devPath = obj.value(key_name::KeyDevPath).toString();
+
+                bool shouldRemove = false;
+                if (devPath.isEmpty()) {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job file has no device-path, removing";
+                    shouldRemove = true;
+                } else if (!QFile(devPath).exists()) {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job device no longer exists, removing job file - device:" << devPath;
+                    shouldRemove = true;
+                } else if (crypt_setup_helper::encryptStatus(devPath) == disk_encrypt::kStatusNotEncrypted) {
+                    qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing decrypt job file - device:" << devPath;
+                    shouldRemove = true;
+                }
+
+                if (shouldRemove) {
+                    removeJobFile(decryptJobPath);
+                } else {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job file validation completed - device:" << devPath;
+                }
+            } else {
+                qWarning() << "[job_file_helper::checkJobs] Failed to parse decrypt job file, removing";
+                removeJobFile(decryptJobPath);
+            }
+        }
     }
 
-    if (crypt_setup_helper::encryptStatus(job.devPath) == disk_encrypt::kStatusNotEncrypted) {
-        qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
-        removeJobFile(job.jobFile);
-        return;
-    }
-    
-    qInfo() << "[job_file_helper::checkJobs] Job file validation completed - device:" << job.devPath << "job file:" << job.jobFile;
+    qInfo() << "[job_file_helper::checkJobs] Job file validation completed";
 }

--- a/src/services/textindex/dde-filemanager-textindex.json
+++ b/src/services/textindex/dde-filemanager-textindex.json
@@ -7,6 +7,9 @@
     "policy": [
         {
             "path": "/org/deepin/Filemanager/TextIndex"
+        },
+        {
+            "path": "/org/deepin/Filemanager/OcrIndex"
         }
     ]
 } 


### PR DESCRIPTION
- **fix(preview): resolve filename/resolution overlap in image preview status bar**
- **fix: fix potential crash in FileView destructor**
- **fix: correct desktop available geometry on treeland fractional scaling**
- **fix(textindex): add OcrIndex path to service manager idle policy**
- **fix(recent): cannot open recent:// url in cmd if plugin is lazy loaded**
- **fix: keep desktop canvas origin for top and left dock**
- **fix(diskencrypt): validate device encryption status before resuming operations**
- **fix(filedialog): keep recent hidden in save dialog on config change**
