### PR TITLE
fix(filedialog): keep recent hidden in save dialog on config change

### DIFF
--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -1161,6 +1161,13 @@ void FileDialog::initConnect()
 {
     connect(statusBar()->acceptButton(), &QPushButton::clicked, this, &FileDialog::onAcceptButtonClicked);
     connect(statusBar()->rejectButton(), &QPushButton::clicked, this, &FileDialog::onRejectButtonClicked);
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this,
+            [this](const QString &cfg, const QString &key) {
+                if (cfg != QString("org.deepin.dde.file-manager.sidebar") || key != QString("itemVisiable"))
+                    return;
+                if (d->acceptMode == QFileDialog::AcceptSave)
+                    urlSchemeEnable("recent", false);
+            });
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     connect(statusBar()->comboBox(),
             static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated),


### PR DESCRIPTION
Listen to DConfigManager valueChanged and re-hide recent sidebar item when itemVisiable changes if dialog is in AcceptSave mode.

监听DConfig配置变化，当itemVisiable改变时，若对话框处于
AcceptSave模式则重新隐藏最近使用侧边栏项。

Log: 修复文件保存对话框在运行时设置变化后显示最近使用的问题
PMS: BUG-370193
Influence: 文件保存对话框在用户运行时切换"显示最近使用"设置后，侧边栏不再错误显示最近使用项。

## Summary by Sourcery

Bug Fixes:
- Prevent the recent sidebar entry from becoming visible in the save dialog when the "show recent" setting is toggled during runtime.