### PR TITLE
fix(recent): register watcher for recent scheme to enable view refresh

### DIFF
--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "recentfilewatcher.h"
+#include "private/recentfilewatcher_p.h"
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_recent;
+
+RecentFileWatcherPrivate::RecentFileWatcherPrivate(const QUrl &fileUrl, RecentFileWatcher *qq)
+    : AbstractFileWatcherPrivate(fileUrl, qq)
+{
+}
+
+bool RecentFileWatcherPrivate::start()
+{
+    started = true;
+    return true;
+}
+
+bool RecentFileWatcherPrivate::stop()
+{
+    started = false;
+    return true;
+}
+
+RecentFileWatcher::RecentFileWatcher(const QUrl &url, QObject *parent)
+    : AbstractFileWatcher(new RecentFileWatcherPrivate(url, this), parent)
+{
+    dptr = static_cast<RecentFileWatcherPrivate *>(d.data());
+}
+
+RecentFileWatcher::~RecentFileWatcher()
+{
+}

--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.h
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RECENTFILEWATCHER_H
+#define RECENTFILEWATCHER_H
+
+#include "dfmplugin_recent_global.h"
+
+#include <dfm-base/interfaces/abstractfilewatcher.h>
+
+namespace dfmplugin_recent {
+
+class RecentFileWatcherPrivate;
+class RecentFileWatcher : public DFMBASE_NAMESPACE::AbstractFileWatcher
+{
+    Q_OBJECT
+
+public:
+    explicit RecentFileWatcher() = delete;
+    explicit RecentFileWatcher(const QUrl &url, QObject *parent = nullptr);
+    ~RecentFileWatcher() override;
+
+private:
+    RecentFileWatcherPrivate *dptr;
+};
+
+}
+
+#endif   // RECENTFILEWATCHER_H

--- a/src/plugins/filemanager/dfmplugin-recent/private/recentfilewatcher_p.h
+++ b/src/plugins/filemanager/dfmplugin-recent/private/recentfilewatcher_p.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RECENTFILEWATCHER_P_H
+#define RECENTFILEWATCHER_P_H
+
+#include <dfm-base/interfaces/private/abstractfilewatcher_p.h>
+
+namespace dfmplugin_recent {
+
+class RecentFileWatcher;
+class RecentFileWatcherPrivate : public DFMBASE_NAMESPACE::AbstractFileWatcherPrivate
+{
+    friend RecentFileWatcher;
+
+public:
+    explicit RecentFileWatcherPrivate(const QUrl &fileUrl, RecentFileWatcher *qq);
+
+public:
+    bool start() override;
+    bool stop() override;
+};
+
+}
+
+#endif   // RECENTFILEWATCHER_P_H

--- a/src/plugins/filemanager/dfmplugin-recent/recent.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/recent.cpp
@@ -5,6 +5,7 @@
 #include "recent.h"
 #include "files/recentfileinfo.h"
 #include "files/recentdiriterator.h"
+#include "files/recentfilewatcher.h"
 #include "utils/recentmanager.h"
 #include "utils/recentfilehelper.h"
 #include "menus/recentmenuscene.h"
@@ -45,6 +46,7 @@ void Recent::initialize()
     // 注册Scheme为"recent"的扩展的文件信息 本地默认文件的
     InfoFactory::regClass<RecentFileInfo>(RecentHelper::scheme());
     DirIteratorFactory::regClass<RecentDirIterator>(RecentHelper::scheme());
+    WatcherFactory::regClass<RecentFileWatcher>(RecentHelper::scheme());
 
     followEvents();
     bindEvents();


### PR DESCRIPTION
The recent plugin registered UrlRoute, InfoFactory, and DirIteratorFactory but was missing WatcherFactory registration. Without a watcher, WatcherCache returns null, so RecentManager cannot emit fileDeleted/subfileCreated/ fileAttributeChanged signals to the view, causing the recent list to not refresh after removing items.

recent插件未注册WatcherFactory，导致WatcherCache中无watcher， RecentManager无法通过watcher转发信号到视图层，移除记录后视图不刷新。

Log: 修复最近使用移除记录后窗口不刷新的问题
PMS: BUG-370267
Influence: 修复后移除最近使用记录时视图实时刷新，多窗口同步更新。