### PR TITLE
fix: improve path display for file conflict messages

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
@@ -9,6 +9,29 @@
 #include <QUrl>
 #include <QLabel>
 
+namespace {
+
+// Keep the conflict path text aligned with TaskWidget's actual path label width.
+static constexpr int kConflictPathLabelWidth { 468 };
+
+QString elideTemplatePath(const QFontMetrics &metrics, const QString &pattern, const QString &path, int width)
+{
+    static const QString kPlaceholderToken { QStringLiteral("__DFM_PATH_PLACEHOLDER__") };
+    const QString templatedText = pattern.arg(kPlaceholderToken);
+    const int placeholderPos = templatedText.indexOf(kPlaceholderToken);
+    if (placeholderPos < 0)
+        return metrics.elidedText(pattern.arg(path), Qt::ElideMiddle, width);
+
+    const QString prefix = templatedText.left(placeholderPos);
+    const QString suffix = templatedText.mid(placeholderPos + kPlaceholderToken.size());
+    const int fixedWidth = metrics.horizontalAdvance(prefix) + metrics.horizontalAdvance(suffix);
+    const int pathWidth = qMax(0, width - fixedWidth);
+
+    return prefix + metrics.elidedText(path, Qt::ElideMiddle, pathWidth) + suffix;
+}
+
+}
+
 namespace dfmplugin_fileoperations {
 QString ErrorMessageAndAction::errorMsg(const QUrl &from, const QUrl &to, const AbstractJobHandler::JobErrorType &error, const bool isTo, const QString &errorMsg, const bool allUsErrorMsg)
 {
@@ -244,25 +267,32 @@ void ErrorMessageAndAction::errorSrcAndDestString(const QUrl &from,
         *sorceMsg = QString(tr("%1 already exists in target folder")).arg(from.fileName());
         static QLabel label;
         static QFontMetrics metrics(label.font());
-        static Qt::TextElideMode em = Qt::TextElideMode::ElideMiddle;
-        int pre = metrics.horizontalAdvance(tr("Original path %1").arg(from.path()));
-        int last = metrics.horizontalAdvance(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()));
-        static int total = 350;
-        if (pre > total / 2 && last > total / 2) {
-            *toMsg = metrics.elidedText(tr("Original path %1").arg(from.path()), em, total / 2)
-                    + " " + metrics.elidedText(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()), em, total / 2);
+        const QString sourcePath = from.path();
+        const QString targetPath = FileOperationsUtils::parentUrl(to).path();
+        const QString originalPathPattern = tr("Original path %1");
+        const QString targetPathPattern = tr("Target path %1");
+        const QString separator { QStringLiteral(" ") };
+        const int separatorWidth = metrics.horizontalAdvance(separator);
+        const int availableWidth = kConflictPathLabelWidth - separatorWidth;
+        const int pre = metrics.horizontalAdvance(originalPathPattern.arg(sourcePath));
+        const int last = metrics.horizontalAdvance(targetPathPattern.arg(targetPath));
+
+        if (pre > availableWidth / 2 && last > availableWidth / 2) {
+            *toMsg = elideTemplatePath(metrics, originalPathPattern, sourcePath, availableWidth / 2)
+                    + separator
+                    + elideTemplatePath(metrics, targetPathPattern, targetPath, availableWidth - availableWidth / 2);
             return;
         }
-        if (pre + last > total) {
-            *toMsg = pre > total / 2
-                    ? metrics.elidedText(tr("Original path %1").arg(from.path()), em, total - last)
-                            + " " + tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path())
-                    : tr("Original path %1").arg(from.path())
-                            + " " + metrics.elidedText(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()), em, total - pre);
+        if (pre + last > availableWidth) {
+            *toMsg = pre > availableWidth / 2
+                    ? elideTemplatePath(metrics, originalPathPattern, sourcePath, availableWidth - last)
+                            + separator + targetPathPattern.arg(targetPath)
+                    : originalPathPattern.arg(sourcePath)
+                            + separator + elideTemplatePath(metrics, targetPathPattern, targetPath, availableWidth - pre);
             return;
         }
         *toMsg = QString(tr("Original path %1 Target path %2"))
-                         .arg(from.path(), FileOperationsUtils::parentUrl(to).path());
+                         .arg(sourcePath, targetPath);
     }
     return;
 }


### PR DESCRIPTION
1. Extracted path eliding logic into helper function elideTemplatePath
2. Added constant width definition for consistent path label display
(kConflictPathLabelWidth)
3. Improved readability by breaking down complex path display logic
4. Added proper string constants and localization pattern handling
5. Optimized width calculations with better variable naming
6. Simplified ternary operations in path display logic

The changes improve the display of file conflict paths by:
- Making the path elision more accurate and consistent
- Better handling of path display in limited space
- Improving maintainability through helper functions
- Ensuring proper localization support
- Making the code more readable with better variable names

Log: Improved display of conflict file paths in file operation dialogs

Influence:
1. Test file operations that trigger conflict scenarios
2. Verify path display with various path lengths in conflict dialogs
3. Check localization support with different languages
4. Test UI with different font sizes

fix: 改进文件冲突消息的路径显示

1. 将路径省略逻辑提取到辅助函数 elideTemplatePath
2. 添加固定宽度定义以实现一致的路径标签显示
3. 通过分解复杂的路径显示逻辑提高可读性
4. 添加适当的字符串常量和本地化模式处理
5. 通过更好的变量命名优化宽度计算
6. 简化路径显示逻辑中的三元操作

这些改进通过以下方式提升了文件冲突路径的显示：
- 使路径省略更准确和一致
- 在有限空间内更好地处理路径显示
- 通过辅助函数提高可维护性
- 确保适当的本地化支持
- 通过更好的变量命名使代码更易读

Log: 改进文件操作对话框中冲突文件路径的显示

Influence:
1. 测试触发冲突场景的文件操作
2. 验证冲突对话框中不同长度路径的显示
3. 检查不同语言的本地化支持
4. 测试不同字体大小下的UI显示

Fixes: #370133
