### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/src/apps/dde-file-manager/dde-file-manager.desktop
+++ b/src/apps/dde-file-manager/dde-file-manager.desktop
@@ -13,6 +13,7 @@ Type=Application
 Version=1.0
 X-Deepin-DEComponent=true
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

New Features:
- Expose singleton metadata for dde-file-manager via the X-Deepin-Singleton flag in its desktop file.