### PR TITLE
fix(image-preview): fix preview failure for formats without size probe

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -67,9 +67,17 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     // 使用 QImageReader 进行高效加载，避免大图片内存溢出
     QImageReader reader(fileName, format);
     reader.setAutoTransform(true);
-    sourceImageSize = reader.size();
 
+    QImage image = reader.read();
+    if (image.isNull()) {
+        fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+        setPixmap(QPixmap());
+        return;
+    }
+    // tga/icns 等插件未实现尺寸探测接口，QImageReader.size() 返回 (-1,-1)，需实际读取以获取真实尺寸
+    sourceImageSize = image.size();
     if (!sourceImageSize.isValid()) {
+        fmWarning() << "Image preview: the image size is not valid";
         setPixmap(QPixmap());
         return;
     }
@@ -82,14 +90,10 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     // Keep the widget size in logical pixels, but decode extra backing pixels for HiDPI.
     QSize decodeSize(qMax(1, qRound(showSize.width() * targetDpr)),
                      qMax(1, qRound(showSize.height() * targetDpr)));
-    reader.setScaledSize(decodeSize);
+    // reader 已完成读取，setScaledSize 不再生效，直接将已加载的 image 缩放到 decodeSize，
+    // 保留 HiDPI 所需的额外像素，同时避免持有全分辨率图像造成内存浪费。
+    image = image.scaled(decodeSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
-    QImage image = reader.read();
-    if (image.isNull()) {
-        fmWarning() << "Image preview: failed to load image:" << reader.errorString();
-        setPixmap(QPixmap());
-        return;
-    }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // 应用颜色空间转换，解决CMYK等格式的颜色显示问题 (仅Qt6)
     image = DFMBASE_NAMESPACE::FileUtils::convertToSRgbColorSpace(image);


### PR DESCRIPTION
Some image format plugins (e.g. tga, icns) do not implement the size probe interface, so QImageReader::size() returns (-1, -1) without reading the data. The previous code called reader.size() before reader.read(), which yielded an invalid size and caused the preview to be discarded without rendering anything.

Read the image first via reader.read() to obtain the real dimensions, then scale the already-loaded image to the HiDPI decode size with QImage::scaled() instead of QImageReader::setScaledSize() (which has no effect once reading is complete). Add fmWarning() logs for the load-failure and invalid-size paths.

Log: 修复 tga/icns 等未实现尺寸探测接口的图片格式预览失败问题
PMS: BUG-370529
Influence: 修复后 tga/icns 等格式图片在预览中可正常显示