### PR TITLE
fix(thumbnail): scale from transformed image to fix EXIF-oriented thu…

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -359,7 +359,18 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
         return {};
     }
 
-    const QSize &imageSize = reader.size();
+    reader.setAutoTransform(true);
+    QImage image;
+    if (!reader.read(&image)) {
+        qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
+                              << "error:" << reader.errorString();
+        return image;
+    }
+    if (image.isNull()) {
+        qCWarning(logDFMBase) << "thumbnail: the image is null:" << filePath;
+        return image;
+    }
+    const QSize &imageSize = image.size();
 
     // fix 读取损坏icns文件（可能任意损坏的image类文件也有此情况）在arm平台上会导致递归循环的问题
     // 这里先对损坏文件（imagesize无效）做处理，不再尝试读取其image数据
@@ -373,15 +384,7 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
     const QString &defaultMime = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath)).name();
     if (imageSize.width() > size || imageSize.height() > size || defaultMime == DFMGLOBAL_NAMESPACE::Mime::kTypeImageSvgXml) {
         qCDebug(logDFMBase) << "thumbnail: scaling image from" << imageSize << "to fit size:" << size;
-        reader.setScaledSize(reader.size().scaled(size, size, Qt::KeepAspectRatio));
-    }
-
-    reader.setAutoTransform(true);
-    QImage image;
-    if (!reader.read(&image)) {
-        qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
-                              << "error:" << reader.errorString();
-        return image;
+        image = image.scaled({ size, size }, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
…mbnail dimensions

The image thumbnail creator computed the scaled size from reader.size() — the pre-transform metadata — and applied it via reader.setScaledSize() before enabling setAutoTransform(true). For images carrying EXIF rotation tags, the scale target was based on the un-rotated size while the output was rotated, producing thumbnails with swapped width/height and/or distorted aspect ratio.

Reorder the logic so the image is read with setAutoTransform(true) first, then the actual (post-transform) size from the decoded QImage drives the scaling decision, and image.scaled() with Qt::SmoothTransformation generates the thumbnail. This guarantees correct orientation and dimensions.

Additionally, the read() call and null-image guard are now performed before any size query, so corrupt or empty image files are rejected early instead of entering the scaling path.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-370531.html

## Summary by Sourcery

Ensure image thumbnails are generated from the auto-transformed image size to fix orientation-related dimension issues and improve invalid image handling.

Bug Fixes:
- Correct thumbnail scaling for images with EXIF-based rotation so width, height, and aspect ratio match the displayed orientation.
- Reject corrupt or null images earlier in the thumbnail creation flow to avoid entering the scaling path with invalid data.