### PR TITLE
fix: reposition window near cursor on last tab tear-off

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -33,6 +33,7 @@
 #include <QIcon>
 #include <QUuid>
 #include <QUrlQuery>
+#include <QScreen>
 #include <QToolTip>
 
 #include <unistd.h>
@@ -103,6 +104,7 @@ public:
     void closeRightTabs(int index);
     void closeOtherTabs(int index);
     bool hasDragPreviewTab() const;
+    void showWindow() const;
 
 public:
     TabBar *q;
@@ -252,7 +254,7 @@ void TabBarPrivate::handleTabReleased(int index)
     }
 
     if (q->count() == 1) {
-        q->window()->show();
+        showWindow();
     } else {
         currentTabIndex = -1;
 
@@ -796,6 +798,31 @@ bool TabBarPrivate::hasDragPreviewTab() const
     return false;
 }
 
+void TabBarPrivate::showWindow() const
+{
+    // Position window near cursor for good visual interaction when tearing off the last tab
+    if (!(q->window()->windowState() & Qt::WindowMaximized)) {
+        QScreen *screen = WindowUtils::cursorScreen();
+        if (screen) {
+            const QRect availGeo = screen->availableGeometry();
+            const QPoint cursorPos = QCursor::pos();
+            const int winW = q->window()->width();
+            const int winH = q->window()->height();
+
+            // Place cursor near the top-center of the window (tab bar area)
+            int x = cursorPos.x() - winW / 2;
+            int y = cursorPos.y() - 20;   // slightly above cursor to align with tab bar
+
+            // Clamp to keep the window fully visible on screen
+            x = qMax(availGeo.left(), qMin(x, availGeo.right() - winW));
+            y = qMax(availGeo.top(), qMin(y, availGeo.bottom() - winH));
+
+            q->window()->move(x, y);
+        }
+    }
+    q->window()->show();
+}
+
 bool TabBarPrivate::canPinned(int index)
 {
     if (qAppName() != "dde-file-manager")
@@ -1235,7 +1262,7 @@ QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option
     painter.setRenderHint(QPainter::Antialiasing, true);
 
     // Hide window during drag: single tab in non-Wayland environment
-    if (!WindowUtils::isWayLand() && 1 == count()) {
+    if (!WindowUtils::isWayLand() && 1 == count() && !isPinned(index)) {
         this->window()->hide();
         fmDebug() << "Hide window during drag: single tab in non-Wayland environment";
     }


### PR DESCRIPTION
When tearing off the last tab (non-pinned) in non-Wayland environments,
the window is now repositioned near the cursor instead of staying at its
previous location. This provides better visual interaction and prevents
the window from appearing far from the user's focus.

Additionally, pinned tabs are now excluded from the window-hide behavior
during drag, ensuring that pinned tabs do not cause unintended window
hiding.

Log: Improved window positioning when tearing off the last tab

Influence:
1. Test tearing off the last non-pinned tab in non-Wayland environment
and verify window appears near cursor
2. Test tearing off the last pinned tab and verify window does not hide
3. Test in maximized window mode to ensure no repositioning occurs
4. Test on multi-monitor setups to verify cursor screen detection works
correctly
5. Test with multiple tabs and verify normal drag behavior is unchanged
6. Test on Wayland to confirm no regressions (window remains visible)

fix: 拖拽最后一个标签页时窗口重新定位到鼠标光标附近

在非 Wayland 环境下拖拽最后一个非固定标签页时，窗口现在会重新定位到鼠标
光标附近，而不是停留在之前的位置。这提供了更好的视觉交互，避免窗口远离用
户视线。

此外，固定标签页现在被排除在拖拽时隐藏窗口的行为之外，确保固定标签页不会
导致意外的窗口隐藏。

Log: 改进拖拽最后一个标签页时的窗口定位

Influence:
1. 在非 Wayland 环境下测试拖拽最后一个非固定标签页，验证窗口出现在光标
附近
2. 测试拖拽最后一个固定标签页，验证窗口不会隐藏
3. 在窗口最大化模式下测试，确保不会发生重新定位
4. 在多显示器设置中测试，验证光标屏幕检测正确
5. 测试多个标签页，验证正常拖拽行为不变
6. 在 Wayland 上测试，确认无回归（窗口保持可见）

BUG: https://pms.uniontech.com/bug-view-370561.html
