### PR TITLE
fix(image-preview): support preview for formats with invalid size() l…

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -69,9 +69,24 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     reader.setAutoTransform(true);
     sourceImageSize = reader.size();
 
+    QImage image;
+    bool needScaleAfterRead = false;   // 对于 size() 无法预知的格式（如 icns），读取后再缩放
+
     if (!sourceImageSize.isValid()) {
-        setPixmap(QPixmap());
-        return;
+        // 部分格式（如 icns）无法通过 size() 提前获取尺寸，这里先做一次解码，
+        // 失败则按原逻辑置空；成功则用实际图像尺寸进行后续处理。
+        image = reader.read();
+        if (image.isNull()) {
+            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+            setPixmap(QPixmap());
+            return;
+        }
+        sourceImageSize = image.size();
+        if (!sourceImageSize.isValid()) {
+            setPixmap(QPixmap());
+            return;
+        }
+        needScaleAfterRead = true;
     }
 
     // 计算保持宽高比的显示尺寸
@@ -82,13 +97,18 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     // Keep the widget size in logical pixels, but decode extra backing pixels for HiDPI.
     QSize decodeSize(qMax(1, qRound(showSize.width() * targetDpr)),
                      qMax(1, qRound(showSize.height() * targetDpr)));
-    reader.setScaledSize(decodeSize);
 
-    QImage image = reader.read();
-    if (image.isNull()) {
-        fmWarning() << "Image preview: failed to load image:" << reader.errorString();
-        setPixmap(QPixmap());
-        return;
+    if (needScaleAfterRead) {
+        // 该格式无法依赖 setScaledSize，直接对已解码图像做平滑缩放
+        image = image.scaled(decodeSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    } else {
+        reader.setScaledSize(decodeSize);
+        image = reader.read();
+        if (image.isNull()) {
+            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+            setPixmap(QPixmap());
+            return;
+        }
     }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // 应用颜色空间转换，解决CMYK等格式的颜色显示问题 (仅Qt6)


### PR DESCRIPTION
…ike icns

For some image formats (e.g. icns), QImageReader::size() returns an invalid value (-1, -1) while reader.read() can still decode the image successfully. The previous code returned early and set an empty pixmap when size() was invalid, which made these files impossible to preview.

- When size() is invalid, perform a probe read() first to obtain the real image size; fall back to the original empty-pixmap behavior only if the read fails or the size remains invalid.
- For such formats, scale the already-decoded QImage directly instead of relying on QImageReader::setScaledSize, avoiding a redundant decode and formats that don't support setScaledSize.
- Keep the original single-read fast path for formats where size() is valid, so there is no performance impact on common images.

修复 icns 等格式无法预览的问题：当 QImageReader::size() 返回无效
值（-1, -1）但 read() 仍可解码时，不再直接返回空 pixmap，而是先
解码获取真实尺寸再做缩放；常规格式仍走原有的单次读取高效路径，
不受影响。

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-370529.html