### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file

### DIFF
--- a/src/apps/dde-file-manager/dde-file-manager.desktop
+++ b/src/apps/dde-file-manager/dde-file-manager.desktop
@@ -13,6 +13,7 @@ Type=Application
 Version=1.0
 X-Deepin-DEComponent=true
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app.

为单例应用的desktop文件添加X-Deepin-Singleton=true标识。

Log: 添加单例应用标识
PMS: TASK-392841
Influence: AM能识别单例应用，Treeland不再为单例应用显示快速启动画面

## Summary by Sourcery

Mark the file manager desktop entry as a singleton application so desktop environments can treat it appropriately.

New Features:
- Add X-Deepin-Singleton=true flag to the dde-file-manager desktop file to declare it as a singleton app.

Enhancements:
- Improve integration with the application manager and Treeland by ensuring singleton apps are correctly recognized and no longer show quick launch screens.