### PR TITLE
fix(thumbnail): support thumbnails for image formats with invalid siz…

### DIFF
--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -359,29 +359,42 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
         return {};
     }
 
-    const QSize &imageSize = reader.size();
-
-    // fix 读取损坏icns文件（可能任意损坏的image类文件也有此情况）在arm平台上会导致递归循环的问题
-    // 这里先对损坏文件（imagesize无效）做处理，不再尝试读取其image数据
-    if (!imageSize.isValid()) {
-        qCWarning(logDFMBase) << "thumbnail: image file has invalid size attributes:" << filePath;
-        return {};
-    }
-
-    qCDebug(logDFMBase) << "thumbnail: image file size:" << imageSize << "for:" << filePath;
-
-    const QString &defaultMime = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath)).name();
-    if (imageSize.width() > size || imageSize.height() > size || defaultMime == DFMGLOBAL_NAMESPACE::Mime::kTypeImageSvgXml) {
-        qCDebug(logDFMBase) << "thumbnail: scaling image from" << imageSize << "to fit size:" << size;
-        reader.setScaledSize(reader.size().scaled(size, size, Qt::KeepAspectRatio));
-    }
-
+    const QSize imageSize = reader.size();
     reader.setAutoTransform(true);
     QImage image;
-    if (!reader.read(&image)) {
-        qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
-                              << "error:" << reader.errorString();
-        return image;
+
+    if (imageSize.isValid()) {
+        // size 有效：优先让 QImageReader 在解码阶段按比例缩放，效率更高
+        qCDebug(logDFMBase) << "thumbnail: image file size:" << imageSize << "for:" << filePath;
+
+        const QString &defaultMime = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath)).name();
+        if (imageSize.width() > size || imageSize.height() > size || defaultMime == DFMGLOBAL_NAMESPACE::Mime::kTypeImageSvgXml) {
+            qCDebug(logDFMBase) << "thumbnail: scaling image from" << imageSize << "to fit size:" << size;
+            reader.setScaledSize(imageSize.scaled(size, size, Qt::KeepAspectRatio));
+        }
+
+        if (!reader.read(&image)) {
+            qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
+                                  << "error:" << reader.errorString();
+            return image;
+        }
+    } else {
+        // 注意：icns 等格式的 QImageReader::size() 会返回 (-1,-1) 无效值，但文件本身是正常的、
+        // 可被 read() 解码。这里不再仅凭 size 无效就直接判定文件损坏，而是直接尝试 read()：
+        //  - 若 read() 失败，则认为文件确实损坏（保留对损坏文件的处理，不再读取其图像数据，
+        //    避免 arm 平台上损坏 icns 文件可能导致的递归循环问题）；
+        //  - 若 read() 成功，则对解码结果按需缩放，修复 icns 缩略图不显示的问题。
+        qCDebug(logDFMBase) << "thumbnail: image file reports invalid size, attempting direct read for:" << filePath;
+        if (!reader.read(&image)) {
+            qCWarning(logDFMBase) << "thumbnail: image file has invalid size and cannot be decoded:" << filePath
+                                  << "error:" << reader.errorString();
+            return image;
+        }
+
+        if (image.width() > size || image.height() > size) {
+            qCDebug(logDFMBase) << "thumbnail: scaling decoded image from" << image.size() << "to fit size:" << size;
+            image = image.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        }
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)


### PR DESCRIPTION
…e() like icns

In imageThumbnailCreator, QImageReader::size() returns an invalid value (-1,-1) for icns files. The original code treated any invalid size as a corrupted file and returned an empty image immediately, so valid icns files that could be decoded by QImageReader::read() got no thumbnail.

Refactor the logic into two branches:
- Valid size: keep the efficient path, letting QImageReader scale via setScaledSize() during decoding.
- Invalid size (e.g. icns): attempt reader.read() instead of failing outright. Only treat the file as corrupted if read() fails; otherwise scale the decoded image to the requested thumbnail size. This preserves the existing protection against corrupted files that could cause recursive loops on the arm platform, while restoring thumbnails for icns and similar formats.

Also change `const QSize &imageSize` to a value type to avoid binding a reference to the temporary returned by reader.size(), and move setAutoTransform(true) earlier so both branches apply it.

修复 icns 等格式的图片因 QImageReader::size() 返回无效值而被误判为损坏文件， 导致缩略图不显示的问题。改为当 size 无效时直接尝试 read() 解码：解码成功则按需
缩放返回，解码失败才判定为损坏文件（保留对损坏文件的处理，避免 arm 平台递归循环）。
同时将 imageSize 改为值类型、提前设置 setAutoTransform 以覆盖两个分支。

Log: fix icns and other formats reporting invalid size() not showing thumbnails
Bug: https://pms.uniontech.com/bug-view-370531.html