### PR TITLE
fix: improve search input handling robustness

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -31,8 +31,17 @@ dfmplugin_search::SearchEventReceiver *dfmplugin_search::SearchEventReceiver::in
 
 void SearchEventReceiver::handleSearch(quint64 winId, const QString &keyword)
 {
-    auto window = FMWindowsIns.findWindowById(winId);
-    Q_ASSERT(window);
+    if (winId < 1) {
+        fmWarning() << "Ignore search request with invalid window id";
+        return;
+    }
+
+    auto *window = FMWindowsIns.findWindowById(winId);
+    if (!window) {
+        // Fix: shutdown can outlive a delayed search callback from the titlebar.
+        fmWarning() << "Ignore search request because window no longer exists:" << winId;
+        return;
+    }
 
     const auto &curUrl = window->currentUrl();
     if (ProtocolUtils::isRemoteFile(curUrl)

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
@@ -79,7 +79,10 @@ void TitleBarEventCaller::sendOpenTab(quint64 windowId, const QUrl &url)
 void TitleBarEventCaller::sendSearch(QWidget *sender, const QString &keyword)
 {
     quint64 id = TitleBarHelper::windowId(sender);
-    Q_ASSERT(id > 0);
+    if (id < 1) {
+        fmWarning() << "Cannot send search start signal: invalid window id";
+        return;
+    }
 
     fmInfo() << "Sending search start signal, window id:" << id << "keyword:" << keyword;
     dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Search_Start", id, keyword);

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -262,10 +262,20 @@ void TitleBarHelper::handleJumpToPressed(QWidget *sender, const QString &text)
 void TitleBarHelper::handleSearch(QWidget *sender, const QString &text)
 {
     const auto &currentDir = QDir::currentPath();
+    const auto winId = windowId(sender);
+    if (winId < 1) {
+        fmWarning() << "Cannot start search: invalid window id";
+        return;
+    }
+
     QUrl currentUrl;
-    auto curTitleBar = findTileBarByWindowId(windowId(sender));
-    if (curTitleBar)
-        currentUrl = curTitleBar->currentUrl();
+    auto curTitleBar = findTileBarByWindowId(winId);
+    if (!curTitleBar) {
+        // Fix: the titlebar can already be gone while a delayed search callback is still pending.
+        fmWarning() << "Cannot start search: titlebar already removed for window id" << winId;
+        return;
+    }
+    currentUrl = curTitleBar->currentUrl();
 
     if (currentUrl.isValid()) {
         bool isDisableSearch = dpfSlotChannel->push("dfmplugin_search", "slot_Custom_IsDisableSearch", currentUrl).toBool();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -23,6 +23,7 @@
 #include <DPalette>
 
 #include <QHBoxLayout>
+#include <QCoreApplication>
 #include <QResizeEvent>
 #include <QKeyEvent>
 
@@ -41,6 +42,13 @@ SearchEditWidget::SearchEditWidget(QWidget *parent)
 {
     initUI();
     initConnect();
+    if (qApp) {
+        connect(qApp, &QCoreApplication::aboutToQuit, this, [this]() {
+            // Fix: stop delayed search before shutdown tears down the owning window.
+            delayTimer->stop();
+            pendingSearchText.clear();
+        });
+    }
     searchEdit->lineEdit()->installEventFilter(this);
     searchEdit->installEventFilter(this);
     advancedButton->installEventFilter(this);
@@ -249,6 +257,13 @@ void SearchEditWidget::performSearch()
     QString trimmedSearchText = pendingSearchText.trimmed();
     if (trimmedSearchText.isEmpty()) {
         fmDebug() << "Trimmed search text is empty, skipping search";
+        return;
+    }
+
+    if (TitleBarHelper::windowId(this) < 1) {
+        // Fix: ignore delayed search callbacks once the owner window is already invalid.
+        fmInfo() << "Skip delayed search because owner window is no longer valid";
+        pendingSearchText.clear();
         return;
     }
 


### PR DESCRIPTION
1. Added window ID validation checks before processing search requests
2. Implemented safety checks for delayed search callbacks during
shutdown
3. Added null checks for window and titlebar objects before operations
4. Cleaned up pending searches when application is about to quit
5. Fixed potential crashes when search is requested after window closure

Log: Improved search functionality robustness by handling edge cases

Influence:
1. Test search functionality with rapid open/close of windows
2. Verify search works correctly during application shutdown
3. Test with invalid window IDs to ensure proper error handling
4. Confirm no crashes occur from delayed search callbacks
5. Verify search cancellation works when window closes

fix: 增强搜索输入处理的健壮性

1. 在处理搜索请求前添加窗口 ID 有效性检查
2. 实现关机时延迟搜索回调的安全检查
3. 在操作前添加窗口和标题栏对象的空指针检查
4. 应用程序退出时清理待处理的搜索请求
5. 修复窗口关闭后请求搜索可能导致的崩溃问题

Log: 通过处理边界情况提升搜索功能的健壮性

Influence:
1. 测试窗口快速打开/关闭时的搜索功能
2. 验证应用程序退出时搜索功能正常工作
3. 使用无效窗口ID测试错误处理情况
4. 确认延迟搜索回调不会导致崩溃
5. 验证窗口关闭时搜索取消功能工作正常
