### PR TITLE
fix: properly handle selection state during model teardown

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
@@ -44,9 +44,19 @@ void SelectHelper::click(const QModelIndex &index)
 
 void SelectHelper::release()
 {
-    fmDebug() << "SelectHelper release event - clearing current selection and pressed index";
+    fmDebug() << "SelectHelper release event - clearing drag selection state";
     currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
     currentPressedIndex = QModelIndex();
+}
+
+void SelectHelper::prepareForModelTeardown()
+{
+    fmDebug() << "SelectHelper preparing for model teardown - clearing model-bound selection state";
+    lastPressedIndex = QModelIndex();
+    currentPressedIndex = QModelIndex();
+    currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
 }
 
 void SelectHelper::setSelection(const QItemSelection &selection)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
@@ -26,6 +26,7 @@ public:
     QModelIndex getCurrentPressedIndex() const;
     void click(const QModelIndex &index);
     void release();
+    void prepareForModelTeardown();
     void setSelection(const QItemSelection &selection);
     void selection(const QRect &rect, QItemSelectionModel::SelectionFlags flags);
     bool select(const QList<QUrl> &urls);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -146,6 +146,15 @@ FileView::~FileView()
     }
     setCurrentIndex(QModelIndex());
 
+    // SelectHelper caches QItemSelection, which owns QPersistentModelIndex in Qt6.
+    // Destroy it before detaching/deleting the model to avoid helper teardown
+    // walking stale persistent indexes after the model has gone away.
+    if (d && d->selectHelper) {
+        d->selectHelper->prepareForModelTeardown();
+        delete d->selectHelper;
+        d->selectHelper = nullptr;
+    }
+
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 


### PR DESCRIPTION
1. Added prepareForModelTeardown() method to clear model-related
selection state
2. Updated release() method to also clear lastSelection
3. Modified FileView destructor to properly clean up SelectHelper before
model destruction
4. Added debug logging for teardown operations

The changes address an issue with stale QPersistentModelIndexes being
accessed after model destruction in Qt6. The selection helper now
properly clears its state before model teardown, preventing potential
crashes or undefined behavior when persistent indexes become invalid.

Influence:
1. Test file manager closing scenarios
2. Verify no crashes occur during model changes/destruction
3. Check selection behavior remains consistent after cleanup
4. Monitor debug output for teardown operations

fix: 在模型销毁时正确处理选择状态

1. 新增prepareForModelTeardown()方法用于清理模型相关的选择状态
2. 更新release()方法同时清理lastSelection
3. 修改FileView析构函数在模型销毁前正确清理SelectHelper
4. 添加了拆卸操作的调试日志

这些修改解决了Qt6中模型销毁后访问到无效QPersistentModelIndex的问题。现在
选择助手会在模型拆卸前正确清理状态，防止持续索引失效时可能发生的崩溃或未
定义行为。

Influence:
1. 测试文件管理器关闭场景
2. 验证模型变更/销毁时不会发生崩溃
3. 检查清理后选择行为保持一致性
4. 监控拆卸操作的调试输出
