### PR TITLE
fix(workspace): improve group header expand button hit area

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
@@ -44,9 +44,19 @@ void SelectHelper::click(const QModelIndex &index)
 
 void SelectHelper::release()
 {
-    fmDebug() << "SelectHelper release event - clearing current selection and pressed index";
+    fmDebug() << "SelectHelper release event - clearing drag selection state";
     currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
     currentPressedIndex = QModelIndex();
+}
+
+void SelectHelper::prepareForModelTeardown()
+{
+    fmDebug() << "SelectHelper preparing for model teardown - clearing model-bound selection state";
+    lastPressedIndex = QModelIndex();
+    currentPressedIndex = QModelIndex();
+    currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
 }
 
 void SelectHelper::setSelection(const QItemSelection &selection)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
@@ -26,6 +26,7 @@ public:
     QModelIndex getCurrentPressedIndex() const;
     void click(const QModelIndex &index);
     void release();
+    void prepareForModelTeardown();
     void setSelection(const QItemSelection &selection);
     void selection(const QRect &rect, QItemSelectionModel::SelectionFlags flags);
     bool select(const QList<QUrl> &urls);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -618,6 +618,23 @@ QRect BaseItemDelegate::getExpandButtonRect(const QRectF &rect) const
     return buttonRect;
 }
 
+QRect BaseItemDelegate::getExpandButtonHitRect(const QStyleOptionViewItem &option) const
+{
+    return getExpandButtonHitRect(option.rect);
+}
+
+QRect BaseItemDelegate::getExpandButtonHitRect(const QRectF &rect) const
+{
+    const QRect visualRect = getExpandButtonRect(rect);
+
+    // Keep the arrow visuals unchanged while making the click target easier to hit.
+    QRect hitRect;
+    hitRect.setSize(QSize(qMax(visualRect.width(), 24), qMax(visualRect.height(), 24)));
+    hitRect.moveCenter(visualRect.center());
+
+    return hitRect;
+}
+
 QRect BaseItemDelegate::getTruncateButtonRect(const QStyleOptionViewItem &option) const
 {
     QRectF buttonBaseRect = getGroupHeaderBackgroundRect(option);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -141,6 +141,8 @@ public:
 
     QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
     QRect getExpandButtonRect(const QRectF &rect) const;
+    QRect getExpandButtonHitRect(const QStyleOptionViewItem &option) const;
+    QRect getExpandButtonHitRect(const QRectF &rect) const;
     QRect getTruncateButtonRect(const QStyleOptionViewItem &option) const;
     QRect getTruncateButtonRect(const QRectF &rect) const;
     bool shouldShowTruncateButton(const QModelIndex &index) const;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -146,6 +146,15 @@ FileView::~FileView()
     }
     setCurrentIndex(QModelIndex());
 
+    // SelectHelper caches QItemSelection, which owns QPersistentModelIndex in Qt6.
+    // Destroy it before detaching/deleting the model to avoid helper teardown
+    // walking stale persistent indexes after the model has gone away.
+    if (d && d->selectHelper) {
+        d->selectHelper->prepareForModelTeardown();
+        delete d->selectHelper;
+        d->selectHelper = nullptr;
+    }
+
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1279,9 +1279,17 @@ bool FileView::groupExpandOrCollapseItem(const QModelIndex &index, const QPoint 
         return true;
     }
     QStyleOptionViewItem op;
-    QRect rect = (index == d->stickyHelper->currentStickyIndex()) ? d->stickyHelper->currentStickyRect() : visualRect(index);
+    const bool isStickyHeader = (index == d->stickyHelper->currentStickyIndex());
+    QRect rect = isStickyHeader ? d->stickyHelper->currentStickyRect() : visualRect(index);
     op.rect = rect;
-    QRect arrowRect = itemDelegate()->getExpandButtonRect(op);
+
+    if (!isStickyHeader && index.data(Global::kItemGroupDisplayIndex).toInt() > 0) {
+        // Non-first group headers reserve a 16px transparent gap above the content.
+        // Align the hit area with the actual painted arrow inside the content rect.
+        op.rect.setTop(op.rect.top() + kGroupHeaderInterval);
+    }
+
+    QRect arrowRect = itemDelegate()->getExpandButtonHitRect(op);
 
     if (!arrowRect.contains(pos))
         return false;


### PR DESCRIPTION
## Summary
- align the non-first group header hit area with the painted content rect
- enlarge the expand button hit target to 24x24 without changing visuals
- reduce accidental whole-group selection when clicking expand or collapse

## Root Cause
- see .pms/bugs/370273/analysis-report.md
- PMS: BUG-370273

## Summary by Sourcery

Adjust workspace file view group header expand/collapse hit targets and selection helper lifecycle to make expand clicks more reliable and to avoid model teardown issues.

New Features:
- Improve group header expand/collapse button hit area alignment and size in the workspace file view

Bug Fixes:
- Reduce accidental whole-group selection when clicking group header expand or collapse in the workspace file view
- Prevent stale QPersistentModelIndex access by clearing SelectHelper state before model teardown

Enhancements:
- Refine SelectHelper release behavior to fully reset drag-selection state and related cached selections