### PR TITLE
fix(workspace): improve group header expand button hit area

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -618,6 +618,23 @@ QRect BaseItemDelegate::getExpandButtonRect(const QRectF &rect) const
     return buttonRect;
 }
 
+QRect BaseItemDelegate::getExpandButtonHitRect(const QStyleOptionViewItem &option) const
+{
+    return getExpandButtonHitRect(option.rect);
+}
+
+QRect BaseItemDelegate::getExpandButtonHitRect(const QRectF &rect) const
+{
+    const QRect visualRect = getExpandButtonRect(rect);
+
+    // Keep the arrow visuals unchanged while making the click target easier to hit.
+    QRect hitRect;
+    hitRect.setSize(QSize(qMax(visualRect.width(), 24), qMax(visualRect.height(), 24)));
+    hitRect.moveCenter(visualRect.center());
+
+    return hitRect;
+}
+
 QRect BaseItemDelegate::getTruncateButtonRect(const QStyleOptionViewItem &option) const
 {
     QRectF buttonBaseRect = getGroupHeaderBackgroundRect(option);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -141,6 +141,8 @@ public:
 
     QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
     QRect getExpandButtonRect(const QRectF &rect) const;
+    QRect getExpandButtonHitRect(const QStyleOptionViewItem &option) const;
+    QRect getExpandButtonHitRect(const QRectF &rect) const;
     QRect getTruncateButtonRect(const QStyleOptionViewItem &option) const;
     QRect getTruncateButtonRect(const QRectF &rect) const;
     bool shouldShowTruncateButton(const QModelIndex &index) const;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1279,9 +1279,17 @@ bool FileView::groupExpandOrCollapseItem(const QModelIndex &index, const QPoint 
         return true;
     }
     QStyleOptionViewItem op;
-    QRect rect = (index == d->stickyHelper->currentStickyIndex()) ? d->stickyHelper->currentStickyRect() : visualRect(index);
+    const bool isStickyHeader = (index == d->stickyHelper->currentStickyIndex());
+    QRect rect = isStickyHeader ? d->stickyHelper->currentStickyRect() : visualRect(index);
     op.rect = rect;
-    QRect arrowRect = itemDelegate()->getExpandButtonRect(op);
+
+    if (!isStickyHeader && index.data(Global::kItemGroupDisplayIndex).toInt() > 0) {
+        // Non-first group headers reserve a 16px transparent gap above the content.
+        // Align the hit area with the actual painted arrow inside the content rect.
+        op.rect.setTop(op.rect.top() + kGroupHeaderInterval);
+    }
+
+    QRect arrowRect = itemDelegate()->getExpandButtonHitRect(op);
 
     if (!arrowRect.contains(pos))
         return false;


### PR DESCRIPTION
Align the group header hit area with the painted arrow content rect.
Expand the click target without changing the arrow visuals.

对齐分组头展开按钮热区与实际绘制内容区。
扩大点击区域，但不改变箭头视觉效果。

Log: 修复分组头展开按钮命中区域
PMS: BUG-370273
Influence: 修复后非首个分组头的展开折叠点击更稳定，减少误选整组。

## Summary by Sourcery

Improve the reliability of clicking group header expand/collapse arrows in the workspace file view.

Bug Fixes:
- Fix misaligned and overly small hit area for non-first group header expand/collapse buttons so clicks match the visible arrow.

Enhancements:
- Introduce a dedicated expand-button hit rectangle that aligns with the painted arrow and enforces a minimum clickable size without changing visuals.