### PR TITLE
feat: adjust icon spacing on grouping state change

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2400,6 +2400,10 @@ void FileView::initializeConnect()
     connect(d->statusBar->scalingSlider(), &DSlider::valueChanged, this, &FileView::onScalingValueChanged);
 
     connect(model(), &FileViewModel::stateChanged, this, &FileView::onModelStateChanged);
+    connect(model(), &FileViewModel::groupingStateChanged, this, [this](GroupingState) {
+        if (isIconViewMode())
+            d->adjustIconModeSpacing(model()->groupingStrategy());
+    }, Qt::QueuedConnection);
     connect(model(), &FileViewModel::highlightKeywordsChanged, this, [this](const QStringList &keywords) {
         updateDelegateHighlightKeywords(keywords);
         update();


### PR DESCRIPTION
1. Added a new connection to handle model's groupingStateChanged signal
2. In icon view mode, adjust icon spacing based on the new grouping
strategy
3. Ensures proper visual refresh when grouping state changes (e.g.,
switching between grouping modes)

Log: Adjust icon spacing when grouping state changes

Influence:
1. Test grouping functionality: enable/disable grouping, switch between
different grouping strategies
2. Verify icon view spacing is correctly adjusted after each grouping
change
3. Check that list view mode is unaffected
4. Validate visual consistency when grouping is toggled in different
view modes

feat: 分组状态变化时调整图标间距

1. 新增连接处理模型的 groupingStateChanged 信号
2. 在图标视图模式下，根据新的分组策略调整图标间距
3. 确保分组状态变化时（如切换分组模式）界面能正确刷新

Log: 分组状态变化时调整图标间距

Influence:
1. 测试分组功能：启用/禁用分组，切换不同分组策略
2. 验证图标视图下分组切换后间距是否正确调整
3. 检查列表视图模式不受影响
4. 验证不同视图模式下分组切换的视觉一致性

BUG: https://pms.uniontech.com/bug-view-370291.html

## Summary by Sourcery

Update file view to react to model grouping state changes and keep icon view spacing in sync with the active grouping strategy.

New Features:
- Adjust icon view icon spacing whenever the model's grouping state changes to match the current grouping strategy.

Enhancements:
- Ensure icon view layout is refreshed via a queued connection when grouping state updates, without affecting list view behavior.