### PR TITLE
fix: restore desktop context menu on non-primary screens in treeland …

### DIFF
--- a/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.cpp
+++ b/src/plugins/desktop/ddplugin-core/screen/screenproxyqt.cpp
@@ -142,11 +142,8 @@ qreal ScreenProxyQt::devicePixelRatio() const
 
 DisplayMode ScreenProxyQt::displayMode() const
 {
-    if (DFMBASE_NAMESPACE::WindowUtils::isWayLand()) {
-        fmDebug() << "Wayland environment detected, using show-only mode";
-        return DisplayMode::kShowonly;
-    }
-
+    // 历史上为规避 treeland 多屏桌面问题，曾在此对 Wayland 强制返回 kShowonly（仅主屏显示桌面），
+    // 导致多屏扩展模式下非主屏无桌面窗口、右键菜单无法弹出。该限制已不再需要，现放开以恢复多屏扩展。
     QList<ScreenPointer> allScreen = screens();
     if (allScreen.isEmpty()) {
         fmWarning() << "No screens available, using custom mode";


### PR DESCRIPTION
log: Remove the Wayland-only kShowonly early return in ScreenProxyQt::displayMode(), which was a workaround from early treeland support (commit 334387ef7) and later generalized to isWayLand(). It forced every Wayland session into show-only mode, so WindowFrame::buildBaseWindow() only created a desktop window on the primary screen. Non-primary screens had no CanvasView and thus no context menu.

Let the normal screen-count/geometry logic decide the display mode, identical to the X11 path. Single-screen still returns kShowonly; multi-screen with different positions returns kExtend so all screens get desktop windows.

remove Wayland-only kShowonly workaround so non-primary screens get desktop context menu in treeland extend mode

PMS: BUG-367055

## Summary by Sourcery

Bug Fixes:
- Restore desktop windows and context menu on non-primary screens in Wayland/treeland multi-screen extend mode by removing the forced show-only display mode.