### PR TITLE
fix: improve search auto-grouping behavior

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/search.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/search.cpp
@@ -341,6 +341,8 @@ void Search::bindEvents()
     // URL 切换时根据列宽更新 highlight 定位窗口大小
     dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl,
                                    SearchEventReceiverIns, &SearchEventReceiver::handleUrlChanged);
+    dpfSignalDispatcher->subscribe(GlobalEventType::kChangeCurrentUrl,
+                                   SearchManager::instance(), &SearchManager::onWindowUrlChanged);
 
     // connect self slot events
     static constexpr auto selfSpace { DPF_MACRO_TO_STR(DPSEARCH_NAMESPACE) };
@@ -359,6 +361,8 @@ void Search::bindWindows()
         onWindowOpened(id);
     });
     connect(&FMWindowsIns, &FileManagerWindowsManager::windowOpened, this, &Search::onWindowOpened, Qt::DirectConnection);
+    connect(&FMWindowsIns, &FileManagerWindowsManager::windowClosed,
+            SearchManager::instance(), &SearchManager::onWindowClosed, Qt::DirectConnection);
 }
 
 }   // namespace Search

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.cpp
@@ -57,12 +57,16 @@ bool SearchManager::search(quint64 winId, const QString &taskId, const QUrl &url
         // desired here. Re-pushing on every keyword change would otherwise
         // flip the group order (Exact/Smart) on the second search.
         if (ok && SearchHelper::shouldEnableSemanticSearch(keyword)) {
-            QMetaObject::invokeMethod(this, [winId]() {
+            const SearchSignature signature { url, keyword };
+            QMetaObject::invokeMethod(this, [this, winId, signature]() {
                 const QString current = dpfSlotChannel->push(
                     "dfmplugin_workspace", "slot_Model_CurrentGroupStrategy", winId).toString();
-                if (current != MatchMethod::kStrategyName) {
+
+                const bool alreadyAutoGrouped = autoGroupedSearches.value(winId) == signature;
+                if (current != MatchMethod::kStrategyName && !alreadyAutoGrouped) {
                     dpfSlotChannel->push("dfmplugin_workspace", "slot_Model_SetGroup",
                                          winId, QString(MatchMethod::kStrategyName));
+                    autoGroupedSearches.insert(winId, signature);
                 }
             }, Qt::QueuedConnection);
         }
@@ -152,6 +156,19 @@ void SearchManager::onDConfigValueChanged(const QString &config, const QString &
         fmInfo() << "Semantic search configuration changed - enabled:" << enabled;
         emit enableSemanticSearchChanged(enabled);
     }
+}
+
+void SearchManager::onWindowUrlChanged(quint64 winId, const QUrl &url)
+{
+    if (url.scheme() != SearchHelper::scheme())
+        autoGroupedSearches.remove(winId);
+}
+
+void SearchManager::onWindowClosed(quint64 winId)
+{
+    autoGroupedSearches.remove(winId);
+    winTasksMap.remove(winId);
+    taskIdMap.remove(winId);
 }
 
 SearchManager::SearchManager(QObject *parent)

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
@@ -40,6 +40,8 @@ public:
 
 public Q_SLOTS:
     void onDConfigValueChanged(const QString &config, const QString &key);
+    void onWindowUrlChanged(quint64 winId, const QUrl &url);
+    void onWindowClosed(quint64 winId);
 
 signals:
     void matched(const QString &taskId);
@@ -55,6 +57,8 @@ signals:
     void fileRename(const QUrl &oldUrl, const QUrl &newUrl);
 
 private:
+    using SearchSignature = QPair<QUrl, QString>;
+
     explicit SearchManager(QObject *parent = nullptr);
     ~SearchManager();
 
@@ -62,6 +66,7 @@ private:
     QMap<quint64, QString> taskIdMap;  // 当前窗口最近一次的搜索taskId
     QMultiMap<quint64, QString> winTasksMap;  // 窗口ID对应的所有搜索任务ID
     QMap<QString, QPair<QUrl, QString>> taskInfoMap; // 保存任务ID对应的url和keyword
+    QMap<quint64, SearchSignature> autoGroupedSearches; // 每个窗口最近一次自动应用匹配方式分组的搜索签名
 };
 
 }


### PR DESCRIPTION
1. Added tracking of automatic grouping state to prevent duplicate
grouping operations
2. Added window URL change handling to clear grouping state when leaving
search mode
3. Introduced SearchSignature type to uniquely identify search sessions
4. Added autoGroupedSearches map to track which windows have been auto-
grouped

The changes ensure that:
1. The same search session doesn't repeatedly trigger auto-grouping
2. Search grouping state is properly cleared when switching out of
search results
3. Auto-grouping only happens once per valid search condition

Log: Improved search results grouping behavior

Influence:
1. Test search operations with different keywords to verify auto-
grouping triggers only once
2. Verify grouping state clears when navigating away from search results
3. Test simultaneous searches in multiple windows to ensure independent
grouping states

fix: 改进搜索自动分组行为

1. 添加了自动分组状态跟踪，防止重复分组操作
2. 添加了窗口URL变更处理，离开搜索模式时清除分组状态
3. 引入SearchSignature类型用于唯一标识搜索会话
4. 添加autoGroupedSearches映射记录哪些窗口已被自动分组

修改确保：
1. 相同的搜索会话不会重复触发自动分组
2. 切换出搜索结果时能正确清除分组状态
3. 每个有效的搜索条件只会执行一次自动分组

Log: 改进了搜索结果的分组显示行为

Influence:
1. 测试不同关键词搜索，验证自动分组只触发一次
2. 验证导航离开搜索结果时会清除分组状态
3. 测试多窗口同时搜索，确保各窗口分组状态独立

## Summary by Sourcery

Improve automatic grouping behavior for semantic search results and ensure grouping state resets when leaving search mode.

New Features:
- Track per-window search signatures to prevent repeated auto-grouping for the same semantic search session.

Bug Fixes:
- Avoid reapplying search result grouping multiple times for the same search conditions.
- Clear auto-grouping state when a window navigates away from search results, preventing stale grouping behavior.

Enhancements:
- Subscribe SearchManager to window URL change events so search grouping reacts correctly to navigation.