### PR TITLE
fix(titlebar): stabilize virtual keyboard display

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -22,9 +22,13 @@
 #include <DGuiApplicationHelper>
 #include <DPalette>
 
+#include <QGuiApplication>
 #include <QHBoxLayout>
+#include <QInputMethod>
 #include <QResizeEvent>
 #include <QKeyEvent>
+#include <QMetaObject>
+#include <QTimer>
 
 DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
@@ -365,6 +369,11 @@ void SearchEditWidget::handleFocusInEvent(QFocusEvent *e)
 {
     advancedButton->setVisible(true);
     updateSpacing(true);   // Advanced button is now visible
+
+    QMetaObject::invokeMethod(this, [this] {
+        if (searchEdit->lineEdit()->hasFocus())
+            QGuiApplication::inputMethod()->show();
+    }, Qt::QueuedConnection);
 }
 
 void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -33,9 +33,14 @@
 #    include <DSizeMode>
 #endif
 
+#include <QApplication>
+#include <QGuiApplication>
 #include <QHBoxLayout>
+#include <QInputMethod>
 #include <QEvent>
 #include <QResizeEvent>
+#include <QMetaObject>
+#include <QTimer>
 
 using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
@@ -488,6 +493,7 @@ void TitleBarWidget::showAddrsssBar(const QUrl &url)
     crumbBar->hide();
     addressBar->show();
     addressBar->setFocus();
+    QGuiApplication::inputMethod()->show();
     addressBar->setCurrentUrl(url);
 }
 
@@ -500,7 +506,12 @@ void TitleBarWidget::showCrumbBar()
         addressBar->clear();
         addressBar->hide();
     }
-    setFocus();
+
+    QMetaObject::invokeMethod(this, [this] {
+        QWidget *focusWidget = QApplication::focusWidget();
+        if (!focusWidget || focusWidget == addressBar || addressBar->isAncestorOf(focusWidget))
+            setFocus();
+    }, Qt::QueuedConnection);
 }
 
 void TitleBarWidget::showSearchFilterButton(bool visible)


### PR DESCRIPTION
Request the input method after search focus settles and preserve new focus.

在搜索框焦点稳定后请求输入法，并避免地址栏隐藏时抢占新焦点。

Log: 修复文件管理器搜索框虚拟键盘偶发不显示

Influence: 搜索框和地址栏首次获得焦点时可稳定显示虚拟键盘。

## Summary by Sourcery

Stabilize virtual keyboard behavior for the file manager title bar by coordinating focus handling for the address bar and search field.

Bug Fixes:
- Ensure the virtual keyboard consistently appears when the search field first gains focus.
- Prevent the address bar from stealing focus and hiding the virtual keyboard when a new widget has already received focus.