### PR TITLE
fix: optimize disc device scanning logic

### DIFF
--- a/src/dfm-base/base/device/private/discdevicescanner.cpp
+++ b/src/dfm-base/base/device/private/discdevicescanner.cpp
@@ -8,6 +8,7 @@
 #include <dfm-base/base/device/devicemanager.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
 
+#include <DSysInfo>
 #include <QDebug>
 #include <QCoreApplication>
 #include <QRunnable>
@@ -25,6 +26,7 @@ static constexpr char kBlockDeviceIdPrefix[] { "/org/freedesktop/UDisks2/block_d
 
 using namespace dfmbase;
 using namespace DiscDevice;
+DCORE_USE_NAMESPACE
 
 Scanner::Scanner(const QString &dev)
     : device(dev)
@@ -70,7 +72,7 @@ bool DiscDeviceScanner::startScan()
     }
 
     // Usually the Community Edition does not require an optical drive to be inserted
-    if (SysInfoUtils::isDesktopSys() && !SysInfoUtils::isProfessional()) {
+    if (DSysInfo::isCommunityEdition()) {
         qCWarning(logDFMBase) << "Running on desktop community edition, disc scanning not required";
         return false;
     }

--- a/src/dfm-base/utils/sysinfoutils.cpp
+++ b/src/dfm-base/utils/sysinfoutils.cpp
@@ -105,11 +105,6 @@ bool SysInfoUtils::isDeveloperModeEnabled()
     return developerModel;
 }
 
-bool SysInfoUtils::isProfessional()
-{
-    return DSysInfo::deepinType() == DSysInfo::DeepinProfessional;
-}
-
 bool SysInfoUtils::isDeepin23()
 {
     return DSysInfo::isCommunityEdition() && DSysInfo::productVersion() == "23";

--- a/src/dfm-base/utils/sysinfoutils.h
+++ b/src/dfm-base/utils/sysinfoutils.h
@@ -24,7 +24,6 @@ bool isServerSys();
 bool isDesktopSys();
 bool isOpenAsAdmin();
 bool isDeveloperModeEnabled();
-bool isProfessional();
 bool isDeepin23();
 bool isSameUser(const QMimeData *data);
 


### PR DESCRIPTION
1. Simplified disc scanning condition check by directly using
DSysInfo::isCommunityEdition() instead of combining isDesktopSys() and
isProfessional()
2. Removed redundant isProfessional() function from SysInfoUtils since
it's no longer needed
3. Added missing DSysInfo header include in discdevicescanner.cpp
4. Declared DCORE_USE_NAMESPACE for cleaner DSysInfo usage

The change makes the code more maintainable by:
1. Removing duplicate system type checking logic
2. Using more direct system information APIs
3. Cleaning up unused methods
4. Making dependencies more explicit with proper includes

Influence:
1. Verify disc scanning works correctly on different Deepin editions
2. Test installation on different system types to confirm correct
behavior
3. Check log messages when running on community edition

fix: 优化光盘设备扫描逻辑

1. 简化光盘扫描条件检查，直接使用 DSysInfo::isCommunityEdition() 替代
isDesktopSys() 和 isProfessional() 的组合
2. 从 SysInfoUtils 中移除冗余的 isProfessional() 函数
3. 在 discdevicescanner.cpp 中添加缺少的 DSysInfo 头文件引用
4. 声明 DCORE_USE_NAMESPACE 使 DSysInfo 使用更简洁

这些改动使代码更易维护：
1. 移除重复的系统类型检查逻辑
2. 使用更直接的系统信息API
3. 清理未使用的方法
4. 通过正确的头文件引用使依赖关系更明确

Influence:
1. 验证在不同Deepin发行版上光盘扫描功能正常工作
2. 在不同系统类型上测试安装以确认正确行为
3. 检查在社区版上运行时的日志消息

## Summary by Sourcery

Simplify disc device scanning behavior based on Deepin edition and clean up related system info utilities.

Bug Fixes:
- Ensure disc scanning is correctly skipped on community desktop editions by using DSysInfo::isCommunityEdition() directly.

Enhancements:
- Remove the redundant SysInfoUtils::isProfessional() helper in favor of direct DSysInfo APIs.
- Include the DSysInfo header and namespace macro in disc device scanner for clearer and more explicit dependencies.