### PR TITLE
ci(cppcheck): bump actions/checkout to v7 and enable unsafe pr checkout

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Upgrade checkout action from v4 to v7 and enable allow-unsafe-pr-checkout.

升级 checkout action 至 v7 并启用 allow-unsafe-pr-checkout 配置。

Log: 升级cppcheck workflow的checkout版本
Influence: CI cppcheck 工作流升级 checkout action 版本。

## Summary by Sourcery

CI:
- Bump actions/checkout from v4 to v7 in the cppcheck workflow and enable allow-unsafe-pr-checkout.