### PR TITLE
fix(titlebar): stabilize virtual keyboard display

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -24,6 +24,9 @@
 
 #include <QHBoxLayout>
 #include <QCoreApplication>
+#include <QGuiApplication>
+#include <QInputMethod>
+#include <QMetaObject>
 #include <QResizeEvent>
 #include <QKeyEvent>
 
@@ -380,6 +383,11 @@ void SearchEditWidget::handleFocusInEvent(QFocusEvent *e)
 {
     advancedButton->setVisible(true);
     updateSpacing(true);   // Advanced button is now visible
+
+    QMetaObject::invokeMethod(this, [this] {
+        if (searchEdit->lineEdit()->hasFocus())
+            QGuiApplication::inputMethod()->show();
+    }, Qt::QueuedConnection);
 }
 
 void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -34,8 +34,13 @@
 #endif
 
 #include <QHBoxLayout>
+#include <QApplication>
 #include <QEvent>
+#include <QGuiApplication>
+#include <QInputMethod>
+#include <QMetaObject>
 #include <QResizeEvent>
+#include <QTimer>
 
 using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
@@ -488,6 +493,7 @@ void TitleBarWidget::showAddrsssBar(const QUrl &url)
     crumbBar->hide();
     addressBar->show();
     addressBar->setFocus();
+    QGuiApplication::inputMethod()->show();
     addressBar->setCurrentUrl(url);
 }
 
@@ -500,7 +506,13 @@ void TitleBarWidget::showCrumbBar()
         addressBar->clear();
         addressBar->hide();
     }
-    setFocus();
+    QMetaObject::invokeMethod(this, [this] {
+        QWidget *focusWidget = QApplication::focusWidget();
+        if (!focusWidget || focusWidget == addressBar
+            || addressBar->isAncestorOf(focusWidget)) {
+            setFocus();
+        }
+    }, Qt::QueuedConnection);
 }
 
 void TitleBarWidget::showSearchFilterButton(bool visible)


### PR DESCRIPTION
Ensure virtual keyboard requests occur after the search input gains focus.

确保搜索输入框获得焦点后再请求显示虚拟键盘。

Log: 稳定标题栏虚拟键盘显示
Influence: 修复地址栏和搜索框首次或切换焦点时键盘未弹出的问题。

## Summary by Sourcery

Stabilize virtual keyboard display behavior when interacting with the title bar address and search inputs.

Bug Fixes:
- Ensure the virtual keyboard is shown when the address bar gains focus, including on first focus and when switching from the crumb bar.
- Ensure the virtual keyboard is shown when the search input line edit gains focus, avoiding missed keyboard pop-ups on focus changes.

Enhancements:
- Adjust title bar focus handling so switching between crumb bar and address bar preserves appropriate focus without interfering with other focused widgets.