### PR TITLE
fix(search): sync smart search checkbox on restore default

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/utils/checkboxwithsemanticindex.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/checkboxwithsemanticindex.cpp
@@ -23,6 +23,10 @@ CheckBoxWithSemanticIndex::CheckBoxWithSemanticIndex(QWidget *parent)
 
     connect(SearchManager::instance(), &SearchManager::enableFileIndexSearchChanged,
             this, &CheckBoxWithSemanticIndex::setDisabledByFileIndex);
+
+    connect(SearchManager::instance(), &SearchManager::enableSemanticSearchChanged, this, [this](bool enable) {
+        setChecked(enable);
+    });
 }
 
 void CheckBoxWithSemanticIndex::initStatusBar()


### PR DESCRIPTION
## 问题

BUG-370967：【智能语义搜索】恢复默认后，智能搜索不是开启状态

恢复默认后，智能搜索 checkbox UI 未勾选，但重新打开设置界面后能勾选上。其他搜索配置无此问题。

## 根因

`CheckBoxWithSemanticIndex` 构造函数遗漏了对 `SearchManager::enableSemanticSearchChanged` 信号的连接，导致恢复默认时 DConfig 值虽正确恢复为 true，但 UI checkbox 未同步勾选。

对比同目录三个同类 widget（TextIndex/OcrIndex/FileIndex）均正确连接了各自信号同步 `setChecked`，唯独 SemanticIndex 遗漏。

## 修复

在 `checkboxwithsemanticindex.cpp` 构造函数追加 `enableSemanticSearchChanged` → `setChecked` 的连接，与 OcrIndex/TextIndex 模式一致。`setChecked` 内已有防循环保护，改动极小。

## 触发路径

1. 取消勾选智能搜索 → DConfig = false
2. 点击恢复默认 → DConfig = true → emit `enableSemanticSearchChanged(true)`
3. 修复前：checkbox 未监听该信号 → UI 仍显示未勾选 ✗
4. 修复后：checkbox 监听信号 → setChecked(true) → UI 正确勾选 ✓

## 验证

- 恢复默认后智能搜索 checkbox 立即显示勾选
- 取消/重新勾选交互不受影响
- 文件索引关闭时 widget 仍正确灰化（`setDisabledByFileIndex` 逻辑保留）

## 关联

- PMS: https://pms.uniontech.com/bug-view-370967.html
- 详细根因分析: `.pms/bugs/370967/analysis-report.md`

## Summary by Sourcery

Bug Fixes:
- Sync the semantic search checkbox with the SearchManager semantic search enable signal so the UI reflects the restored default state immediately.