### PR TITLE
fix: handle Ctrl+Left/Right key events properly

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -663,6 +663,22 @@ void FileView::keyPressEvent(QKeyEvent *event)
             case Qt::Key_Right:
                 return QWidget::keyPressEvent(event);
             }
+            break;
+        // Ctrl+Left/Right 用于前进/后退（由 FileManagerWindowPrivate::processKeyPressEvent
+        // 发射 reqBack/reqForward 信号处理）。此处必须显式转发给 QWidget::keyPressEvent，
+        // 否则会落入 DListView::keyPressEvent（即 QAbstractItemView）的默认实现：
+        // QAbstractItemView 会用 Ctrl 修饰键移动 currentIndex 并以 NoUpdate 标志调用
+        // setSelection，进而触发 SelectHelper::selection 打印
+        // "Selection with NoUpdate flag - skipping" 并 accept() 事件，导致按键事件被
+        // 父类消费、不再向上冒泡到 FileManagerWindow，前进/后退失效（BUG370967）。
+        // 交给 QWidget::keyPressEvent 后，事件会被 ignore()，从而冒泡到窗口层处理。
+        case Qt::ControlModifier:
+            switch (event->key()) {
+            case Qt::Key_Left:
+            case Qt::Key_Right:
+                return QWidget::keyPressEvent(event);
+            }
+            break;
         }
         return DListView::keyPressEvent(event);
     }


### PR DESCRIPTION
Forward Ctrl+Left/Right key events to QWidget to ensure proper bubbling
to FileManagerWindow for back/forward navigation. Previously these
events were being handled by DListView's default implementation which
would consume them, preventing the FileManagerWindow from receiving the
events and thus breaking back/forward functionality (BUG370967). The fix
explicitly routes these key combinations to QWidget::keyPressEvent which
ignores them, allowing proper event bubbling.

Log: Fixed back and forward navigation with Ctrl+Left/Right key
combinations no longer working

Influence:
1. Test back/forward navigation using Ctrl+Left and Ctrl+Right keys
2. Verify both keyboard navigation and toolbar back/forward buttons
work consistently
3. Test other Ctrl+key combinations to ensure normal behavior is
preserved

fix: 正确处理Ctrl+左右方向键事件

将Ctrl+左右方向键事件转发给QWidget确保能正确冒泡到FileManagerWindow
处理前进后退功能。原先这些事件会被DListView的默认实现处理并消耗，导致
FileManagerWindow无法收到事件从而使前进后退功能失效(BUG370967)。本修复明
确将这些按键组合路由到QWidget::keyPressEvent，后者会忽略这些事件从而实现
正确的事件冒泡。

Log: 修复了Ctrl+左右方向键无法进行前进后退导航的问题

Influence:
1. 测试使用Ctrl+左右方向键的前进后退导航功能
2. 验证键盘导航和工具栏前进后退按钮功能一致
3. 测试其他Ctrl组合键确保正常功能不受影响

## Summary by Sourcery

Bug Fixes:
- Restore back and forward navigation using Ctrl+Left and Ctrl+Right by forwarding these key events to QWidget instead of consuming them in the list view.