### PR TITLE
fix(burn): show error details in erase failure dialog

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
@@ -415,7 +415,13 @@ void EraseJob::work()
     if (!mediaChangDected()) {
         ret = false;
         fmWarning() << "Device disconnected:" << curDevId;
-        emit requestFailureDialog(static_cast<int>(curJobType), QObject::tr("Device disconnected"), {});
+    }
+
+    if (!ret) {
+        failureDialogShown = true;
+        emit requestFailureDialog(static_cast<int>(curJobType),
+                                 lastError.isEmpty() ? QObject::tr("Device disconnected") : lastError,
+                                 lastSrcMessages);
     }
 
     comfort();

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.h
@@ -63,6 +63,8 @@ public:
     void setProperty(PropertyType type, const QVariant &val);
     void addTask();
 
+    bool failureDialogShown {};
+
 protected:
     virtual bool fileSystemLimitsValid();
     virtual void updateMessage(JobInfoPointer ptr);

--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -44,7 +44,7 @@ void BurnJobManager::startEraseDisc(const QString &dev)
     initBurnJobConnect(job);
     connect(qobject_cast<EraseJob *>(job), &EraseJob::eraseFinished, this, [job, this](bool result) {
         startAuditLogForEraseDisc(job->currentDeviceInfo(), result);
-        if (!result) {
+        if (!result && !job->failureDialogShown) {
             DialogManagerInstance->showErrorDialog(tr("Erase failed"),
                                                    tr("Unable to complete disc erasure. "
                                                       "This may be due to read/write limitations or the disc media status. "
@@ -263,7 +263,10 @@ void BurnJobManager::showOpticalJobFailureDialog(int type, const QString &err, c
     QWidget *detailsw = new QWidget(&d);
     detailsw->setLayout(new QVBoxLayout());
     QTextEdit *te = new QTextEdit();
-    te->setPlainText(details.join('\n'));
+    QStringList detailContent = details;
+    if (detailContent.isEmpty() && !err.isEmpty())
+        detailContent << err;
+    te->setPlainText(detailContent.join('\n'));
     te->setReadOnly(true);
     te->hide();
     detailsw->layout()->addWidget(te);


### PR DESCRIPTION
Pass lastSrcMessages to requestFailureDialog instead of empty list so
that xorriso/libburn error details are displayed when erase fails.

Add failureDialogShown flag to avoid showing duplicate error dialog
when showOpticalJobFailureDialog was already shown.

Fix showOpticalJobFailureDialog to use err as detail content fallback
when details list is empty.

修复擦除光盘失败时详情对话框内容为空的问题，传递xorriso错误消息到界面。
添加标志位避免失败时弹出重复的对话框，details为空时用err兜底显示。

Log: 修复擦除光盘失败详情为空的问题
PMS: BUG-370931
Influence: 擦除光盘失败时失败详情对话框能正确显示错误信息，避免重复弹窗。
