### PR TITLE
fix(burn): show error details in erase failure dialog

### DIFF
--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
@@ -415,7 +415,13 @@ void EraseJob::work()
     if (!mediaChangDected()) {
         ret = false;
         fmWarning() << "Device disconnected:" << curDevId;
-        emit requestFailureDialog(static_cast<int>(curJobType), QObject::tr("Device disconnected"), {});
+    }
+
+    if (!ret) {
+        failureDialogShown = true;
+        emit requestFailureDialog(static_cast<int>(curJobType),
+                                 lastError.isEmpty() ? QObject::tr("Device disconnected") : lastError,
+                                 lastSrcMessages);
     }
 
     comfort();

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.h
@@ -14,13 +14,14 @@
 
 namespace dfmplugin_burn {
 
-struct VerifyResult {
+struct VerifyResult
+{
     bool dataVerifyEnabled { false };   // kVerifyDatas was enabled
-    bool dataVerifyOk { true };         // checkmedia passed (bad <= 2%)
-    bool checksumEnabled { false };     // kChecksum was enabled
-    bool checksumOk { true };           // verifyChecksum passed
-    bool checksumSkipped { false };     // true if skipped (e.g. data verify failed)
-    char checksumError[256] { 0 };      // error detail from verifyChecksum
+    bool dataVerifyOk { true };   // checkmedia passed (bad <= 2%)
+    bool checksumEnabled { false };   // kChecksum was enabled
+    bool checksumOk { true };   // verifyChecksum passed
+    bool checksumSkipped { false };   // true if skipped (e.g. data verify failed)
+    char checksumError[256] { 0 };   // error detail from verifyChecksum
 };
 
 class AbstractBurnJob : public QThread
@@ -56,12 +57,14 @@ public:
 
 public:
     explicit AbstractBurnJob(const QString &dev, const JobHandlePointer handler);
-    virtual ~AbstractBurnJob() override {}
+    virtual ~AbstractBurnJob() override { }
 
     QVariantMap currentDeviceInfo() const;
     QVariant property(PropertyType type) const;
     void setProperty(PropertyType type, const QVariant &val);
     void addTask();
+
+    std::atomic<bool> failureDialogShown {};
 
 protected:
     virtual bool fileSystemLimitsValid();
@@ -113,7 +116,7 @@ class EraseJob : public AbstractBurnJob
 
 public:
     explicit EraseJob(const QString &dev, const JobHandlePointer handler);
-    virtual ~EraseJob() override {}
+    virtual ~EraseJob() override { }
 
 signals:
     void eraseFinished(bool result);
@@ -129,7 +132,7 @@ class BurnISOFilesJob : public AbstractBurnJob
 
 public:
     explicit BurnISOFilesJob(const QString &dev, const JobHandlePointer handler);
-    virtual ~BurnISOFilesJob() override {}
+    virtual ~BurnISOFilesJob() override { }
 
 protected:
     virtual bool fileSystemLimitsValid() override;
@@ -143,7 +146,7 @@ class BurnISOImageJob : public AbstractBurnJob
 
 public:
     explicit BurnISOImageJob(const QString &dev, const JobHandlePointer handler);
-    virtual ~BurnISOImageJob() override {}
+    virtual ~BurnISOImageJob() override { }
 
 protected:
     virtual void writeFunc(int progressFd, int checkFd) override;
@@ -156,7 +159,7 @@ class BurnUDFFilesJob : public AbstractBurnJob
 
 public:
     explicit BurnUDFFilesJob(const QString &dev, const JobHandlePointer handler);
-    virtual ~BurnUDFFilesJob() override {}
+    virtual ~BurnUDFFilesJob() override { }
 
 protected:
     virtual bool fileSystemLimitsValid() override;
@@ -171,7 +174,7 @@ class DumpISOImageJob : public AbstractBurnJob
 
 public:
     explicit DumpISOImageJob(const QString &dev, const JobHandlePointer handler);
-    virtual ~DumpISOImageJob() override {}
+    virtual ~DumpISOImageJob() override { }
 
 signals:
     void requestOpticalDumpISOSuccessDialog(const QUrl &imageUrl);

--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -44,7 +44,7 @@ void BurnJobManager::startEraseDisc(const QString &dev)
     initBurnJobConnect(job);
     connect(qobject_cast<EraseJob *>(job), &EraseJob::eraseFinished, this, [job, this](bool result) {
         startAuditLogForEraseDisc(job->currentDeviceInfo(), result);
-        if (!result) {
+        if (!result && !job->failureDialogShown) {
             DialogManagerInstance->showErrorDialog(tr("Erase failed"),
                                                    tr("Unable to complete disc erasure. "
                                                       "This may be due to read/write limitations or the disc media status. "
@@ -263,7 +263,10 @@ void BurnJobManager::showOpticalJobFailureDialog(int type, const QString &err, c
     QWidget *detailsw = new QWidget(&d);
     detailsw->setLayout(new QVBoxLayout());
     QTextEdit *te = new QTextEdit();
-    te->setPlainText(details.join('\n'));
+    QStringList detailContent = details;
+    if (detailContent.isEmpty() && !err.isEmpty())
+        detailContent << err;
+    te->setPlainText(detailContent.join('\n'));
     te->setReadOnly(true);
     te->hide();
     detailsw->layout()->addWidget(te);


### PR DESCRIPTION
Pass lastSrcMessages to requestFailureDialog instead of empty list so
that xorriso/libburn error details are displayed when erase fails.

Add failureDialogShown flag to avoid showing duplicate error dialog
when showOpticalJobFailureDialog was already shown.

Fix showOpticalJobFailureDialog to use err as detail content fallback
when details list is empty.

修复擦除光盘失败时详情对话框内容为空的问题，传递xorriso错误消息到界面。
添加标志位避免失败时弹出重复的对话框，details为空时用err兜底显示。

Log: 修复擦除光盘失败详情为空的问题
PMS: BUG-370931
Influence: 擦除光盘失败时失败详情对话框能正确显示错误信息，避免重复弹窗。

## Summary by Sourcery

Improve error handling and user feedback when optical disc erase operations fail.

Bug Fixes:
- Ensure erase failure dialogs include xorriso/libburn error details by passing recorded source messages.
- Prevent duplicate erase failure dialogs by tracking whether a failure dialog has already been shown for a job.
- Fallback to the main error string in optical failure dialogs when no detailed messages are available.