### PR TITLE
feat: add USB repair service with D-Bus interface and PolKit authenti…

### DIFF
--- a/assets/dbus/org.deepin.Filemanager.UsbRepair.xml
+++ b/assets/dbus/org.deepin.Filemanager.UsbRepair.xml
@@ -1,0 +1,35 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.deepin.Filemanager.UsbRepair">
+    <method name="Repair">
+      <arg type="b" direction="out"/>
+      <arg name="devicePath" type="s" direction="in"/>
+      <arg name="errorMessage" type="s" direction="out"/>
+    </method>
+    <method name="CancelRepair">
+      <arg type="b" direction="out"/>
+      <arg name="devicePath" type="s" direction="in"/>
+    </method>
+    <signal name="FsErrorDetected">
+      <arg name="devicePath" type="s" direction="out"/>
+      <arg name="deviceName" type="s" direction="out"/>
+      <arg name="fsType" type="s" direction="out"/>
+      <arg name="errorType" type="s" direction="out"/>
+      <arg name="canRepair" type="b" direction="out"/>
+      <arg name="message" type="s" direction="out"/>
+    </signal>
+    <signal name="RepairProgress">
+      <arg name="devicePath" type="s" direction="out"/>
+      <arg name="percent" type="i" direction="out"/>
+      <arg name="logLine" type="s" direction="out"/>
+    </signal>
+    <signal name="RepairFinished">
+      <arg name="devicePath" type="s" direction="out"/>
+      <arg name="success" type="b" direction="out"/>
+      <arg name="summary" type="s" direction="out"/>
+    </signal>
+    <signal name="FsErrorCleared">
+      <arg name="devicePath" type="s" direction="out"/>
+    </signal>
+  </interface>
+</node>

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(mountcontrol)
 add_subdirectory(textindex)
 add_subdirectory(diskencrypt)
 add_subdirectory(tpmcontrol)
+add_subdirectory(usbrepair)
 
 # 安全加固
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deepin-service-group@.service.d DESTINATION /etc/systemd/system/)

--- a/src/services/usbrepair/CMakeLists.txt
+++ b/src/services/usbrepair/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(dde-filemanager-usbrepair)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Include service configuration
+include(${CMAKE_CURRENT_SOURCE_DIR}/dependencies.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../DFMServiceCommon.cmake)
+
+FILE(GLOB USBREPAIR_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.json"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.xml"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.policy"
+    )
+
+add_library(${PROJECT_NAME}
+    SHARED
+    ${USBREPAIR_FILES}
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ../../)
+
+# Apply service configuration using shared dependencies
+dfm_setup_usbrepair_dependencies(${PROJECT_NAME} "usbrepair")
+
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/deepin-service-manager/)
+install(FILES ${PROJECT_NAME}.json DESTINATION share/deepin-service-manager/system/)
+install(FILES org.deepin.filemanager.usbrepair.conf DESTINATION share/dbus-1/system.d/)
+
+set(PolicyDir "${CMAKE_INSTALL_PREFIX}/share/polkit-1/actions")
+install(FILES org.deepin.filemanager.usbrepair.policy DESTINATION ${PolicyDir})
+
+INSTALL_DBUS_SERVICE(org.deepin.Filemanager.UsbRepair root)
+
+# Install systemd drop-in configuration for security hardening
+# This adds security restrictions without modifying the shared service template
+install(FILES
+    systemd/security-hardening.conf
+    DESTINATION
+    lib/systemd/system/deepin-service-plugin@org.deepin.Filemanager.UsbRepair.service.d/
+)

--- a/src/services/usbrepair/dde-filemanager-usbrepair.json
+++ b/src/services/usbrepair/dde-filemanager-usbrepair.json
@@ -1,0 +1,13 @@
+{
+    "name": "org.deepin.Filemanager.UsbRepair",
+    "libPath": "libdde-filemanager-usbrepair.so",
+    "group": "app",
+    "policyStartType": "Resident",
+    "idleTime": 0,
+    "pluginType": "qt",
+    "policy": [
+        {
+            "path": "/org/deepin/Filemanager/UsbRepair"
+        }
+    ]
+}

--- a/src/services/usbrepair/dependencies.cmake
+++ b/src/services/usbrepair/dependencies.cmake
@@ -1,0 +1,62 @@
+# dependencies.cmake - Dependencies configuration for usbrepair service
+# This file defines the specific dependencies and configuration for the USB repair service
+
+cmake_minimum_required(VERSION 3.10)
+
+# Function to setup usbrepair service dependencies
+function(dfm_setup_usbrepair_dependencies target_name)
+    message(STATUS "DFM: Setting up usbrepair service dependencies for: ${target_name}")
+
+    # Find required packages
+    find_package(PkgConfig REQUIRED)
+    find_package(Qt6 REQUIRED COMPONENTS DBus)
+
+    # Find system dependencies using pkg-config
+    pkg_check_modules(PolkitAgent REQUIRED polkit-agent-1)
+    pkg_check_modules(PolkitQt6 REQUIRED polkit-qt6-1)
+
+    # Apply default service configuration first (DFM6::base + Qt6::Core + Qt6::DBus)
+    dfm_apply_default_service_config(${target_name})
+
+    # Include service common utilities and apply shared polkit helper
+    include(${DFM_SOURCE_DIR}/services/DFMServiceCommon.cmake)
+    dfm_apply_service_polkit_to_target(${target_name})
+
+    # Add usbrepair-specific dependencies
+    target_link_libraries(${target_name} PRIVATE
+        ${PolkitAgent_LIBRARIES}
+        ${PolkitQt6_LIBRARIES}
+    )
+
+    # Setup DBus adaptor for usbrepair
+    dfm_setup_usbrepair_dbus_interfaces(${target_name})
+
+    message(STATUS "DFM: UsbRepair service dependencies configured successfully")
+endfunction()
+
+# Function to setup usbrepair-specific DBus interfaces
+function(dfm_setup_usbrepair_dbus_interfaces target_name)
+    message(STATUS "DFM: Setting up usbrepair DBus interfaces for: ${target_name}")
+
+    # Define the DBus interface file path using DFM_ASSETS_DIR
+    set(DBUS_INTERFACE_FILE "${DFM_ASSETS_DIR}/dbus/org.deepin.Filemanager.UsbRepair.xml")
+
+    # Check if the DBus interface file exists
+    if(EXISTS "${DBUS_INTERFACE_FILE}")
+        message(STATUS "DFM: Found UsbRepair DBus interface file: ${DBUS_INTERFACE_FILE}")
+
+        # Generate DBus adaptor
+        qt6_add_dbus_adaptor(ADAPTOR_SOURCES ${DBUS_INTERFACE_FILE}
+            usbrepairdbus.h UsbRepairDBus)
+
+        # Add generated sources to target
+        if(ADAPTOR_SOURCES)
+            target_sources(${target_name} PRIVATE ${ADAPTOR_SOURCES})
+            message(STATUS "DFM: Added UsbRepair DBus adaptor sources to target")
+        endif()
+    else()
+        message(WARNING "DFM: UsbRepair DBus interface file not found: ${DBUS_INTERFACE_FILE}")
+    endif()
+endfunction()
+
+message(STATUS "DFM: UsbRepair service dependencies configuration loaded")

--- a/src/services/usbrepair/org.deepin.filemanager.usbrepair.conf
+++ b/src/services/usbrepair/org.deepin.filemanager.usbrepair.conf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE busconfig PUBLIC
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="org.deepin.Filemanager.UsbRepair"/>
+    <allow send_destination="org.deepin.Filemanager.UsbRepair"/>
+  </policy>
+  <policy context="default">
+    <allow send_destination="org.deepin.Filemanager.UsbRepair"/>
+  </policy>
+</busconfig>

--- a/src/services/usbrepair/org.deepin.filemanager.usbrepair.policy
+++ b/src/services/usbrepair/org.deepin.filemanager.usbrepair.policy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>deepin</vendor>
+  <vendor_url>https://www.deepin.com/</vendor_url>
+  <action id="org.deepin.filemanager.usbrepair.repair">
+    <description>Repair USB drive filesystem</description>
+    <message>Authentication is required to repair the filesystem on a removable device</message>
+    <message xml:lang="zh_CN">需要授权以修复可移动设备的文件系统</message>
+    <icon_name>drive-removable-media</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/src/services/usbrepair/plugin.cpp
+++ b/src/services/usbrepair/plugin.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "usbrepairdbus.h"
+
+static UsbRepairDBus *usbRepairDBus = nullptr;
+
+// DEBUG:
+// 1. build a debug so file and copy to install path
+// 2. sudo systemctl stop deepin-service-plugin@org.deepin.Filemanager.UsbRepair.service
+// 3. launch app: sudo /usr/bin/deepin-service-manager -g app
+
+extern "C" int DSMRegister(const char *name, void *data)
+{
+    (void)data;
+    usbRepairDBus = new UsbRepairDBus(name);
+    return 0;
+}
+
+extern "C" int DSMUnRegister(const char *name, void *data)
+{
+    (void)name;
+    (void)data;
+    if (usbRepairDBus) {
+        usbRepairDBus->cleanup();
+        usbRepairDBus->deleteLater();
+        usbRepairDBus = nullptr;
+    }
+    return 0;
+}

--- a/src/services/usbrepair/private/usbrepairdbus_p.h
+++ b/src/services/usbrepair/private/usbrepairdbus_p.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef USBREPAIRDBUS_P_H
+#define USBREPAIRDBUS_P_H
+
+#include "service_usbrepair_global.h"
+#include "usbrepairadaptor.h"
+#include "usbrepairmonitor.h"
+#include "usbrepairworker.h"
+
+class UsbRepairDBus;
+
+SERVICEUSBREPAIR_BEGIN_NAMESPACE
+
+class UsbRepairDBusPrivate
+{
+    friend class ::UsbRepairDBus;
+
+public:
+    explicit UsbRepairDBusPrivate(UsbRepairDBus *qq)
+        : q(qq),
+          adapter(new UsbRepairAdaptor(qq)),
+          monitor(new UsbRepairMonitor(qq)),
+          worker(new UsbRepairWorker(qq))
+    {
+        initConnect();
+    }
+    ~UsbRepairDBusPrivate() { }
+
+    void initConnect();
+
+private:
+    UsbRepairDBus *q { nullptr };
+    UsbRepairAdaptor *adapter { nullptr };
+    UsbRepairMonitor *monitor { nullptr };
+    UsbRepairWorker *worker { nullptr };
+};
+
+SERVICEUSBREPAIR_END_NAMESPACE
+
+#endif   // USBREPAIRDBUS_P_H

--- a/src/services/usbrepair/service_usbrepair_global.h
+++ b/src/services/usbrepair/service_usbrepair_global.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SERVICE_USBREPAIR_GLOBAL_H
+#define SERVICE_USBREPAIR_GLOBAL_H
+
+#include <dfm-base/dfm_log_defines.h>
+
+#include <QString>
+#include <QStringList>
+
+#define SERVICEUSBREPAIR_NAMESPACE service_usbrepair
+#define SERVICEUSBREPAIR_BEGIN_NAMESPACE namespace SERVICEUSBREPAIR_NAMESPACE {
+#define SERVICEUSBREPAIR_END_NAMESPACE }
+#define SERVICEUSBREPAIR_USE_NAMESPACE using namespace SERVICEUSBREPAIR_NAMESPACE;
+
+SERVICEUSBREPAIR_BEGIN_NAMESPACE
+
+namespace Defines {
+
+// D-Bus
+inline const QString kServiceName = QLatin1String("org.deepin.Filemanager.UsbRepair");
+inline constexpr char kServiceObjPath[] { "/org/deepin/Filemanager/UsbRepair" };
+
+// PolKit
+inline const QString kPolkitActionId = QLatin1String("org.deepin.filemanager.usbrepair.repair");
+
+// Filesystem whitelist
+inline const QStringList kSupportedFsTypes = { "vfat", "exfat", "ntfs", "ext4" };
+
+// Timeout (ms)
+inline constexpr int kFsckTimeoutMs { 300000 };   // 300s
+
+// Monitor delay (ms)
+inline constexpr int kMountSettleDelayMs { 3000 };   // 3 seconds - wait for auto-mount to complete
+
+// Error types
+inline const QString kErrorTypeDirtyBit = QLatin1String("dirty_bit");
+inline const QString kErrorTypeMountFailed = QLatin1String("mount_failed");
+inline const QString kErrorTypeReadOnly = QLatin1String("read_only");
+
+// udisks2
+inline const QString kUdisks2Service = QLatin1String("org.freedesktop.UDisks2");
+inline const QString kUdisks2Path = QLatin1String("/org/freedesktop/UDisks2");
+inline const QString kUdisks2ObjectMgrIface = QLatin1String("org.freedesktop.DBus.ObjectManager");
+inline const QString kUdisks2BlockIface = QLatin1String("org.freedesktop.UDisks2.Block");
+inline const QString kUdisks2FilesystemIface = QLatin1String("org.freedesktop.UDisks2.Filesystem");
+inline const QString kUdisks2DriveIface = QLatin1String("org.freedesktop.UDisks2.Drive");
+
+}   // namespace Defines
+
+DFM_LOG_USE_CATEGORY(SERVICEUSBREPAIR_NAMESPACE)
+
+SERVICEUSBREPAIR_END_NAMESPACE
+
+#endif   // SERVICE_USBREPAIR_GLOBAL_H

--- a/src/services/usbrepair/systemd/security-hardening.conf
+++ b/src/services/usbrepair/systemd/security-hardening.conf
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Security hardening for UsbRepair service
+# This service runs fsck on USB devices and needs access to /dev and mount
+
+[Service]
+# System protection
+ProtectSystem=full
+ProtectHome=true
+ProtectProc=invisible
+
+# Process isolation
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=false
+
+# Security options
+NoNewPrivileges=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+
+# Forbid access to sensitive paths
+InaccessiblePaths=-/etc/shadow
+InaccessiblePaths=-/etc/sudoers
+InaccessiblePaths=-/etc/sudoers.d
+InaccessiblePaths=-/root
+InaccessiblePaths=-/var/log
+InaccessiblePaths=-/var/cache
+
+# Performance
+OOMScoreAdjust=-200
+Nice=-5

--- a/src/services/usbrepair/usbrepairdbus.cpp
+++ b/src/services/usbrepair/usbrepairdbus.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "usbrepairdbus.h"
+#include "private/usbrepairdbus_p.h"
+
+SERVICEUSBREPAIR_BEGIN_NAMESPACE
+DFM_LOG_REGISTER_CATEGORY(SERVICEUSBREPAIR_NAMESPACE)
+SERVICEUSBREPAIR_END_NAMESPACE
+
+SERVICEUSBREPAIR_USE_NAMESPACE
+
+void UsbRepairDBusPrivate::initConnect()
+{
+    // Monitor signals → forward as D-Bus signals
+    QObject::connect(monitor, &UsbRepairMonitor::errorDetected,
+                     q, &UsbRepairDBus::FsErrorDetected);
+    QObject::connect(monitor, &UsbRepairMonitor::errorCleared,
+                     q, &UsbRepairDBus::FsErrorCleared);
+
+    // Worker signals → forward as D-Bus signals
+    QObject::connect(worker, &UsbRepairWorker::progress,
+                     q, &UsbRepairDBus::RepairProgress);
+    QObject::connect(worker, &UsbRepairWorker::finished,
+                     q, &UsbRepairDBus::RepairFinished);
+}
+
+UsbRepairDBus::UsbRepairDBus(const char *name, QObject *parent)
+    : QObject(parent), QDBusContext(), d(new UsbRepairDBusPrivate(this))
+{
+    QDBusConnection::RegisterOptions opts =
+            QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals;
+
+    // NOTE: Use SystemBus (not SessionBus like textindex) because:
+    // - fsck requires root privileges
+    // - udisks2 events are on system bus
+    QDBusConnection bus = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
+    bus.registerObject(Defines::kServiceObjPath, this, opts);
+
+    // Start monitoring immediately
+    d->monitor->startMonitoring();
+
+    fmInfo() << "UsbRepairDBus: service registered on system bus";
+}
+
+UsbRepairDBus::~UsbRepairDBus() { }
+
+void UsbRepairDBus::cleanup()
+{
+    d->monitor->stopMonitoring();
+}
+
+bool UsbRepairDBus::Repair(const QString &devicePath, QString &errorMessage)
+{
+    QString callerBusName = message().service();
+    return d->worker->startRepair(devicePath, callerBusName, errorMessage);
+}
+
+bool UsbRepairDBus::CancelRepair(const QString &devicePath)
+{
+    QString callerBusName = message().service();
+    return d->worker->cancelRepair(devicePath, callerBusName);
+}

--- a/src/services/usbrepair/usbrepairdbus.h
+++ b/src/services/usbrepair/usbrepairdbus.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef USBREPAIRDBUS_H
+#define USBREPAIRDBUS_H
+
+#include "service_usbrepair_global.h"
+
+#include <QObject>
+#include <QDBusContext>
+
+SERVICEUSBREPAIR_BEGIN_NAMESPACE
+class UsbRepairDBusPrivate;
+SERVICEUSBREPAIR_END_NAMESPACE
+
+class UsbRepairDBus : public QObject, public QDBusContext
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.deepin.Filemanager.UsbRepair")
+
+public:
+    explicit UsbRepairDBus(const char *name, QObject *parent = nullptr);
+    ~UsbRepairDBus();
+
+    void cleanup();
+
+public Q_SLOTS:
+    bool Repair(const QString &devicePath, QString &errorMessage);
+    bool CancelRepair(const QString &devicePath);
+
+Q_SIGNALS:
+    void FsErrorDetected(const QString &devicePath,
+                         const QString &deviceName,
+                         const QString &fsType,
+                         const QString &errorType,
+                         bool canRepair,
+                         const QString &message);
+    void RepairProgress(const QString &devicePath,
+                        int percent,
+                        const QString &logLine);
+    void RepairFinished(const QString &devicePath,
+                        bool success,
+                        const QString &summary);
+    void FsErrorCleared(const QString &devicePath);
+
+private:
+    QScopedPointer<SERVICEUSBREPAIR_NAMESPACE::UsbRepairDBusPrivate> d;
+};
+
+#endif   // USBREPAIRDBUS_H

--- a/src/services/usbrepair/usbrepairmonitor.cpp
+++ b/src/services/usbrepair/usbrepairmonitor.cpp
@@ -1,0 +1,439 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "usbrepairmonitor.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QDBusArgument>
+#include <QDBusMetaType>
+#include <QTimer>
+#include <QProcess>
+#include <QFile>
+#include <QRegularExpression>
+
+SERVICEUSBREPAIR_USE_NAMESPACE
+
+UsbRepairMonitor::UsbRepairMonitor(QObject *parent)
+    : QObject(parent)
+{
+}
+
+UsbRepairMonitor::~UsbRepairMonitor()
+{
+    stopMonitoring();
+}
+
+void UsbRepairMonitor::startMonitoring()
+{
+    if (m_udisks2ObjMgr)
+        return;
+
+    // Register DBUS meta types - required for InterfacesAdded signal
+    qDBusRegisterMetaType<QVariantMap>();
+    qDBusRegisterMetaType<QMap<QString, QVariantMap>>();
+
+    QDBusConnection bus = QDBusConnection::systemBus();
+
+    m_udisks2ObjMgr = new QDBusInterface(
+        Defines::kUdisks2Service,
+        Defines::kUdisks2Path,
+        Defines::kUdisks2ObjectMgrIface,
+        bus, this);
+
+    bool connected1 = bus.connect(Defines::kUdisks2Service,
+                                   Defines::kUdisks2Path,
+                                   Defines::kUdisks2ObjectMgrIface,
+                                   "InterfacesAdded",
+                                   this, SLOT(onInterfacesAdded(QDBusObjectPath, QMap<QString, QVariantMap>)));
+    fmInfo() << "UsbRepairMonitor: InterfacesAdded connected:" << connected1;
+
+    bool connected2 = bus.connect(Defines::kUdisks2Service,
+                                   Defines::kUdisks2Path,
+                                   Defines::kUdisks2ObjectMgrIface,
+                                   "InterfacesRemoved",
+                                   this, SLOT(onInterfacesRemoved(QDBusObjectPath, QStringList)));
+    fmInfo() << "UsbRepairMonitor: InterfacesRemoved connected:" << connected2;
+    fmInfo() << "UsbRepairMonitor: started monitoring udisks2";
+}
+
+void UsbRepairMonitor::stopMonitoring()
+{
+    if (!m_udisks2ObjMgr)
+        return;
+
+    QDBusConnection bus = QDBusConnection::systemBus();
+    bus.disconnect(Defines::kUdisks2Service,
+                   Defines::kUdisks2Path,
+                   Defines::kUdisks2ObjectMgrIface,
+                   "InterfacesAdded",
+                   this, SLOT(onInterfacesAdded(QDBusObjectPath, QMap<QString, QVariantMap>)));
+    bus.disconnect(Defines::kUdisks2Service,
+                   Defines::kUdisks2Path,
+                   Defines::kUdisks2ObjectMgrIface,
+                   "InterfacesRemoved",
+                   this, SLOT(onInterfacesRemoved(QDBusObjectPath, QStringList)));
+
+    delete m_udisks2ObjMgr;
+    m_udisks2ObjMgr = nullptr;
+
+    fmInfo() << "UsbRepairMonitor: stopped monitoring";
+}
+
+void UsbRepairMonitor::onInterfacesAdded(
+    const QDBusObjectPath &objectPath,
+    const QMap<QString, QVariantMap> &interfacesAndProperties)
+{
+    QString objPath = objectPath.path();
+
+    // Case 1: Filesystem interface added - normal detection path
+    if (interfacesAndProperties.contains(Defines::kUdisks2FilesystemIface)) {
+        fmDebug() << "UsbRepairMonitor: filesystem interface added:" << objPath;
+
+        // Delay check to let udisks2 finish auto-mount
+        QTimer::singleShot(Defines::kMountSettleDelayMs, this, [this, objPath]() {
+            checkDeviceHealth(objPath);
+        });
+        return;
+    }
+
+    // Case 2: Block interface added but no Filesystem interface
+    // This usually means filesystem is too corrupted to recognize
+    if (interfacesAndProperties.contains(Defines::kUdisks2BlockIface)) {
+        fmDebug() << "UsbRepairMonitor: block interface added without filesystem:" << objPath;
+
+        // Delay check to see if filesystem appears later
+        QTimer::singleShot(Defines::kMountSettleDelayMs, this, [this, objPath]() {
+            checkMissingFilesystem(objPath);
+        });
+    }
+}
+
+void UsbRepairMonitor::onInterfacesRemoved(
+    const QDBusObjectPath &objectPath,
+    const QStringList &interfaces)
+{
+    Q_UNUSED(interfaces)
+    QString objPath = objectPath.path();
+    emit errorCleared(objPath);
+}
+
+void UsbRepairMonitor::checkDeviceHealth(const QString &blockObjPath)
+{
+    QString deviceName;
+    if (!isUsbDevice(blockObjPath, &deviceName)) {
+        return;
+    }
+
+    QString deviceFile = getDeviceFile(blockObjPath);
+    if (deviceFile.isEmpty()) {
+        fmDebug() << "UsbRepairMonitor: no device file for:" << blockObjPath;
+        return;
+    }
+
+    // Skip whole-disk devices (e.g., /dev/sdb), only process partitions (e.g., /dev/sdb1)
+    // This prevents duplicate notifications for the same USB device
+    QRegularExpression re(R"(.+[0-9]+$)");
+    if (!re.match(deviceFile).hasMatch()) {
+        fmDebug() << "UsbRepairMonitor: skipping whole-disk device:" << deviceFile;
+        return;
+    }
+
+    QString fsType = getFsType(deviceFile);
+    if (fsType.isEmpty()) {
+        fmDebug() << "UsbRepairMonitor: cannot determine fs type for:" << deviceFile;
+
+        // Notify user about unrecognized filesystem (deviceName already obtained above)
+        emit errorDetected(deviceFile, deviceName, "unknown",
+                           Defines::kErrorTypeMountFailed, false,
+                           tr("Filesystem type cannot be detected. The device may be severely damaged "
+                              "or formatted with an unsupported filesystem. Data recovery may require professional tools."));
+        return;
+    }
+
+    // Check whitelist
+    if (!Defines::kSupportedFsTypes.contains(fsType)) {
+        fmDebug() << "UsbRepairMonitor: unsupported fs type:" << fsType;
+        return;
+    }
+
+    // Check hardware read-only
+    if (isHardwareReadOnly(deviceFile)) {
+        emit errorDetected(deviceFile, deviceName, fsType,
+                           Defines::kErrorTypeReadOnly, false,
+                           tr("Device is hardware write-protected, flash memory may be failing. "
+                              "Please back up data immediately."));
+        return;
+    }
+
+    bool mounted = isDeviceMounted(deviceFile);
+
+    // If device is mounted successfully after 3 seconds, it's healthy - skip dirty bit check
+    if (mounted) {
+        fmDebug() << "UsbRepairMonitor: device mounted successfully after delay, skipping dirty bit check:" << deviceFile;
+        return;
+    }
+
+    // If mount failed (not mounted), check if filesystem damage is the cause
+    if (checkDirtyBit(deviceFile, fsType)) {
+        emit errorDetected(deviceFile, deviceName, fsType,
+                           Defines::kErrorTypeMountFailed, true,
+                           tr("Filesystem error detected, device may not have been safely ejected. "
+                              "Mount might have failed due to filesystem corruption."));
+    }
+}
+
+bool UsbRepairMonitor::isUsbDevice(const QString &blockObjPath, QString *deviceName)
+{
+    QDBusInterface blockIface(
+        Defines::kUdisks2Service,
+        blockObjPath,
+        Defines::kUdisks2BlockIface,
+        QDBusConnection::systemBus());
+
+    if (!blockIface.isValid())
+        return false;
+
+    // Get drive object path
+    QDBusObjectPath drivePath = blockIface.property("Drive").value<QDBusObjectPath>();
+    if (drivePath.path().isEmpty() || drivePath.path() == "/")
+        return false;
+
+    // Check drive ConnectionBus == "usb"
+    QDBusInterface driveIface(
+        Defines::kUdisks2Service,
+        drivePath.path(),
+        Defines::kUdisks2DriveIface,
+        QDBusConnection::systemBus());
+
+    if (!driveIface.isValid())
+        return false;
+
+    QString connectionBus = driveIface.property("ConnectionBus").toString();
+    if (connectionBus != "usb")
+        return false;
+
+    if (deviceName) {
+        *deviceName = driveIface.property("Id").toString();
+        QString vendor = driveIface.property("Vendor").toString();
+        QString model = driveIface.property("Model").toString();
+        if (!vendor.isEmpty() || !model.isEmpty()) {
+            *deviceName = (vendor.isEmpty() ? "" : vendor + " ")
+                    + (model.isEmpty() ? "" : model);
+        }
+    }
+
+    // Check removable
+    bool removable = driveIface.property("Removable").toBool();
+    return removable;
+}
+
+QString UsbRepairMonitor::getDeviceFile(const QString &blockObjPath)
+{
+    QDBusInterface blockIface(
+        Defines::kUdisks2Service,
+        blockObjPath,
+        Defines::kUdisks2BlockIface,
+        QDBusConnection::systemBus());
+
+    if (!blockIface.isValid())
+        return {};
+
+    // Device 属性是 D-Bus 字节数组(ay)，常以 '\0' 结尾；直接 toString() 会保留尾部空字节，
+    // 导致后续路径匹配、进程参数出错。用 constData() 截断尾部空字节。
+    QByteArray dev = blockIface.property("Device").toByteArray();
+    return QString::fromUtf8(dev.constData());
+}
+
+QString UsbRepairMonitor::getFsType(const QString &deviceFile)
+{
+    QProcess proc;
+    proc.start("blkid", { "-o", "value", "-s", "TYPE", deviceFile });
+    proc.waitForFinished(5000);
+    QString output = proc.readAllStandardOutput().trimmed();
+    fmInfo() << "UsbRepairMonitor: command: blkid -o value -s TYPE" << deviceFile << "| exitCode:" << proc.exitCode() << "| output:" << output;
+    if (proc.exitCode() == 0) {
+        if (!output.isEmpty()) {
+            // ext2/ext3 use the same e2fsck tool as ext4; normalize so the
+            // whitelist and monitoring logic treat them uniformly.
+            if (output == "ext2" || output == "ext3")
+                output = "ext4";
+            return output;
+        }
+    }
+
+    // Fallback: try udisks2 property
+    // (This is less accurate but serves as backup)
+    return {};
+}
+
+bool UsbRepairMonitor::isDeviceMounted(const QString &deviceFile)
+{
+    // Read /proc/mounts directly — most reliable
+    QFile mounts("/proc/mounts");
+    if (mounts.open(QIODevice::ReadOnly)) {
+        QByteArray data = mounts.readAll();
+        mounts.close();
+        for (const QByteArray &line : data.split('\n')) {
+            if (line.startsWith(deviceFile.toUtf8() + " "))
+                return true;
+        }
+    }
+    return false;
+}
+
+bool UsbRepairMonitor::isHardwareReadOnly(const QString &deviceFile)
+{
+    // Get the whole-disk device (strip partition number)
+    // e.g. /dev/sdb1 → /dev/sdb
+    QString wholeDisk = deviceFile;
+    QRegularExpression re(R"((.+)[0-9]+$)");
+    QRegularExpressionMatch match = re.match(deviceFile);
+    if (match.hasMatch())
+        wholeDisk = match.captured(1);
+
+    QProcess proc;
+    proc.start("blockdev", { "--getro", wholeDisk });
+    proc.waitForFinished(3000);
+    QString output = proc.readAllStandardOutput().trimmed();
+    fmInfo() << "UsbRepairMonitor: command: blockdev --getro" << wholeDisk << "| exitCode:" << proc.exitCode() << "| output:" << output;
+    if (proc.exitCode() == 0) {
+        return output == "1";
+    }
+    return false;
+}
+
+bool UsbRepairMonitor::checkDirtyBit(const QString &deviceFile, const QString &fsType)
+{
+    QProcess proc;
+    QString command;
+
+    if (fsType == "vfat") {
+        command = "fsck.fat -n " + deviceFile;
+        proc.start("fsck.fat", { "-n", deviceFile });
+    } else if (fsType == "exfat") {
+        command = "fsck.exfat -n " + deviceFile;
+        proc.start("fsck.exfat", { "-n", deviceFile });
+    } else if (fsType == "ntfs") {
+        command = "ntfsfix -n " + deviceFile;
+        proc.start("ntfsfix", { "-n", deviceFile });
+    } else if (fsType == "ext4") {
+        command = "e2fsck -n " + deviceFile;
+        proc.start("e2fsck", { "-n", deviceFile });
+    } else {
+        return false;
+    }
+
+    proc.waitForFinished(30000);
+    int exitCode = proc.exitCode();
+    QString output = QString::fromUtf8(proc.readAllStandardOutput())
+            + QString::fromUtf8(proc.readAllStandardError());
+    fmInfo() << "UsbRepairMonitor: command:" << command << "| exitCode:" << exitCode << "| output:" << output;
+
+    // exitCode == 0 means clean
+    // exitCode > 0 means errors detected
+    // Negative / crash means tool not available
+    if (exitCode < 0)
+        return false;
+
+    return exitCode > 0;
+}
+
+void UsbRepairMonitor::checkMissingFilesystem(const QString &blockObjPath)
+{
+    QString deviceName;
+    if (!isUsbDevice(blockObjPath, &deviceName)) {
+        return;
+    }
+
+    QString deviceFile = getDeviceFile(blockObjPath);
+    if (deviceFile.isEmpty()) {
+        fmDebug() << "UsbRepairMonitor: no device file for:" << blockObjPath;
+        return;
+    }
+
+    // Skip whole-disk devices (e.g., /dev/sdb), only process partitions (e.g., /dev/sdb1)
+    // This prevents duplicate notifications for the same USB device
+    QRegularExpression re(R"(.+[0-9]+$)");
+    if (!re.match(deviceFile).hasMatch()) {
+        fmDebug() << "UsbRepairMonitor: skipping whole-disk device:" << deviceFile;
+        return;
+    }
+
+    // Double-check if filesystem has appeared in the meantime.
+    // 直接查询 org.freedesktop.UDisks2.Filesystem 接口的 MountPoints 属性：
+    // Properties.Get 对不存在的接口返回无效 QVariant，符合 D-Bus 规范。
+    QDBusInterface fsIface(
+        Defines::kUdisks2Service,
+        blockObjPath,
+        Defines::kUdisks2FilesystemIface,
+        QDBusConnection::systemBus());
+
+    if (fsIface.isValid() && fsIface.property("MountPoints").isValid()) {
+        fmDebug() << "UsbRepairMonitor: filesystem appeared for:" << deviceFile;
+        checkDeviceHealth(blockObjPath);
+        return;
+    }
+
+    // Still no filesystem interface - try to detect using 'file' command
+    // This can identify filesystem type even when severely corrupted
+    QProcess proc;
+    proc.start("file", { "-s", deviceFile });
+    proc.waitForFinished(5000);
+    QString output = proc.readAllStandardOutput();
+    fmInfo() << "UsbRepairMonitor: command: file -s" << deviceFile << "| exitCode:" << proc.exitCode() << "| output:" << output;
+
+    if (proc.exitCode() != 0) {
+        fmDebug() << "UsbRepairMonitor: file command failed for:" << deviceFile;
+        return;
+    }
+
+    QString fsType;
+
+    // Parse file command output for filesystem signatures
+    if (output.contains("FAT", Qt::CaseInsensitive))
+        fsType = "vfat";
+    else if (output.contains("exFAT", Qt::CaseInsensitive))
+        fsType = "exfat";
+    else if (output.contains("NTFS", Qt::CaseInsensitive))
+        fsType = "ntfs";
+    else if (output.contains("ext2", Qt::CaseInsensitive) ||
+             output.contains("ext3", Qt::CaseInsensitive) ||
+             output.contains("ext4", Qt::CaseInsensitive))
+        fsType = "ext4";
+
+    if (fsType.isEmpty()) {
+        fmDebug() << "UsbRepairMonitor: cannot detect filesystem type for:" << deviceFile;
+
+        // Notify user about unrecognized filesystem
+        emit errorDetected(deviceFile, deviceName, "unknown",
+                           Defines::kErrorTypeMountFailed, false,
+                           tr("Filesystem type cannot be detected. The device may be severely damaged "
+                              "or formatted with an unsupported filesystem. Data recovery may require professional tools."));
+        return;
+    }
+
+    // Check whitelist
+    if (!Defines::kSupportedFsTypes.contains(fsType)) {
+        fmDebug() << "UsbRepairMonitor: unsupported fs type:" << fsType;
+        return;
+    }
+
+    // Check hardware read-only
+    if (isHardwareReadOnly(deviceFile)) {
+        emit errorDetected(deviceFile, deviceName, fsType,
+                           Defines::kErrorTypeReadOnly, false,
+                           tr("Device is hardware write-protected, flash memory may be failing. "
+                              "Please back up data immediately."));
+        return;
+    }
+
+    // Found a supported but corrupted filesystem
+    emit errorDetected(deviceFile, deviceName, fsType,
+                       Defines::kErrorTypeMountFailed, true,
+                       tr("Filesystem is severely corrupted and cannot be recognized. "
+                          "Data may be recoverable through repair."));
+}
+

--- a/src/services/usbrepair/usbrepairmonitor.h
+++ b/src/services/usbrepair/usbrepairmonitor.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef USBREPAIRMONITOR_H
+#define USBREPAIRMONITOR_H
+
+#include "service_usbrepair_global.h"
+
+#include <QObject>
+#include <QDBusObjectPath>
+#include <QMap>
+
+class QDBusInterface;
+class QDBusArgument;
+
+SERVICEUSBREPAIR_BEGIN_NAMESPACE
+
+class UsbRepairMonitor : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit UsbRepairMonitor(QObject *parent = nullptr);
+    ~UsbRepairMonitor();
+
+    void startMonitoring();
+    void stopMonitoring();
+
+Q_SIGNALS:
+    void errorDetected(const QString &devicePath,
+                       const QString &deviceName,
+                       const QString &fsType,
+                       const QString &errorType,
+                       bool canRepair,
+                       const QString &message);
+    void errorCleared(const QString &devicePath);
+
+private Q_SLOTS:
+    void onInterfacesAdded(const QDBusObjectPath &objectPath,
+                           const QMap<QString, QVariantMap> &interfacesAndProperties);
+    void onInterfacesRemoved(const QDBusObjectPath &objectPath,
+                             const QStringList &interfaces);
+
+private:
+    void checkDeviceHealth(const QString &blockObjPath);
+    void checkMissingFilesystem(const QString &blockObjPath);
+    bool isUsbDevice(const QString &blockObjPath, QString *deviceName = nullptr);
+    QString getDeviceFile(const QString &blockObjPath);
+    QString getFsType(const QString &deviceFile);
+    bool isDeviceMounted(const QString &deviceFile);
+    bool isHardwareReadOnly(const QString &deviceFile);
+    bool checkDirtyBit(const QString &deviceFile, const QString &fsType);
+    QString getParentDriveObjPath(const QString &blockObjPath);
+
+    QDBusInterface *m_udisks2ObjMgr { nullptr };
+};
+
+SERVICEUSBREPAIR_END_NAMESPACE
+
+#endif   // USBREPAIRMONITOR_H

--- a/src/services/usbrepair/usbrepairworker.cpp
+++ b/src/services/usbrepair/usbrepairworker.cpp
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "usbrepairworker.h"
+
+#include <QDBusInterface>
+#include <QDBusObjectPath>
+#include <QFile>
+#include <QTimer>
+#include <QProcess>
+#include <QRegularExpression>
+
+#include <polkit-qt6-1/PolkitQt1/Authority>
+#include <errno.h>
+
+SERVICEUSBREPAIR_USE_NAMESPACE
+
+UsbRepairWorker::UsbRepairWorker(QObject *parent)
+    : QObject(parent)
+{
+}
+
+UsbRepairWorker::~UsbRepairWorker()
+{
+
+    if (m_timeoutTimer)
+        m_timeoutTimer->stop();
+    if (m_currentProcess) {
+        m_currentProcess->kill();
+        m_currentProcess->waitForFinished(5000);
+    }
+}
+
+bool UsbRepairWorker::startRepair(const QString &devicePath, const QString &callerBusName,
+                                  QString &errorMessage)
+{
+    // 1. Validate device path
+    if (!validateDevicePath(devicePath)) {
+        errorMessage = tr("Invalid device path: %1").arg(devicePath);
+        return false;
+    }
+
+    // 2. Idempotency check
+    if (isRepairing(devicePath)) {
+        errorMessage = tr("Device is already being repaired: %1").arg(devicePath);
+        return false;
+    }
+
+    // 3. Detect filesystem type
+    QString fsType = detectFsType(devicePath);
+    if (fsType.isEmpty()) {
+        errorMessage = tr("Cannot detect filesystem type for: %1").arg(devicePath);
+        return false;
+    }
+
+    // 4. Whitelist check
+    if (!Defines::kSupportedFsTypes.contains(fsType)) {
+        errorMessage = tr("Unsupported filesystem type: %1").arg(fsType);
+        return false;
+    }
+
+    // 5. Check hardware read-only
+    QProcess blockdevProc;
+    QString wholeDisk = devicePath;
+    QRegularExpression re(R"((.+)[0-9]+$)");
+    QRegularExpressionMatch match = re.match(devicePath);
+    if (match.hasMatch())
+        wholeDisk = match.captured(1);
+
+    blockdevProc.start("blockdev", { "--getro", wholeDisk });
+    blockdevProc.waitForFinished(3000);
+    if (blockdevProc.exitCode() == 0 && blockdevProc.readAllStandardOutput().trimmed() == "1") {
+        errorMessage = tr("Device is hardware write-protected, cannot repair");
+        return false;
+    }
+
+    // 6. PolKit authorization
+    if (!checkAuthorization(callerBusName)) {
+        errorMessage = tr("Authorization failed");
+        return false;
+    }
+
+    // 7. Umount if mounted
+    bool wasMounted = false;
+    QFile mounts("/proc/mounts");
+    if (mounts.open(QIODevice::ReadOnly)) {
+        QByteArray data = mounts.readAll();
+        mounts.close();
+        for (const QByteArray &line : data.split('\n')) {
+            if (line.startsWith(devicePath.toUtf8() + " ")) {
+                wasMounted = true;
+                break;
+            }
+        }
+    }
+
+    if (wasMounted && !umountDevice(devicePath)) {
+        errorMessage = tr("Failed to unmount device: %1").arg(devicePath);
+        return false;
+    }
+
+    // 8. Start repair
+    m_currentDevice = devicePath;
+    m_currentFsType = fsType;
+    m_activeRepairs.insert(devicePath);
+    executeFsck(devicePath, fsType);
+
+    return true;
+}
+
+bool UsbRepairWorker::cancelRepair(const QString &devicePath, const QString &callerBusName)
+{
+    if (!checkAuthorization(callerBusName))
+        return false;
+
+    if (m_currentDevice != devicePath || !m_currentProcess)
+        return false;
+
+    m_currentProcess->kill();
+    return true;
+}
+
+bool UsbRepairWorker::isRepairing(const QString &devicePath) const
+{
+    return m_activeRepairs.contains(devicePath);
+}
+
+void UsbRepairWorker::onFsckReadyRead()
+{
+    if (!m_currentProcess)
+        return;
+
+    // Read both stdout and stderr and accumulate
+    QString stdout = QString::fromUtf8(m_currentProcess->readAllStandardOutput());
+    QString stderr = QString::fromUtf8(m_currentProcess->readAllStandardError());
+    QString output = stdout + stderr;
+
+    // Accumulate for final logging
+    m_fsckOutput += output;
+
+    for (const QString &line : output.split('\n', Qt::SkipEmptyParts)) {
+        // Parse progress percentage from output
+        int percent = -1;   // -1 = indeterminate
+        QRegularExpression percentRe(R"((\d+)%)");
+        QRegularExpressionMatch match = percentRe.match(line);
+        if (match.hasMatch())
+            percent = match.captured(1).toInt();
+
+        emit progress(m_currentDevice, percent, line);
+    }
+}
+
+void UsbRepairWorker::onFsckFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    Q_UNUSED(exitStatus)
+
+    // 防御：异常路径下可能重入或 process 已被销毁
+    if (!m_currentProcess)
+        return;
+
+    // 任务结束，停止超时定时器，避免残留触发误杀后续任务的进程
+    if (m_timeoutTimer)
+        m_timeoutTimer->stop();
+
+    QString device = m_currentDevice;
+    QString fsType = m_currentFsType;
+    QString summary;
+    bool success = false;
+
+    // Read any remaining output that wasn't captured by onFsckReadyRead
+    QString remainingOutput = QString::fromUtf8(m_currentProcess->readAllStandardError())
+            + QString::fromUtf8(m_currentProcess->readAllStandardOutput());
+    m_fsckOutput += remainingOutput;
+
+    fmInfo() << "UsbRepairWorker: fsck finished | device:" << device << "| fstype:" << fsType << "| exitCode:" << exitCode << "| timedOut:" << m_timedOut << "| output:" << m_fsckOutput;
+
+    if (m_timedOut) {
+        // kill() 触发的终止：统一在此收尾，不再由 onFsckTimeout 自行 emit
+        success = false;
+        summary = tr("Repair timed out after %1 seconds")
+                .arg(Defines::kFsckTimeoutMs / 1000);
+    } else if (exitCode == 0) {
+        success = true;
+        summary = tr("Filesystem repair completed successfully");
+    } else if (fsType == "ntfs" && exitCode != 0) {
+        success = false;
+        summary = tr("NTFS repair capability is limited on Linux. "
+                     "Please connect the device to a Windows system for deep repair.");
+    } else {
+        success = (exitCode == 1);   // exit code 1 = errors corrected
+        if (success) {
+            summary = tr("Filesystem errors have been repaired");
+        } else {
+            summary = tr("Filesystem repair failed (exit code: %1)").arg(exitCode);
+            if (!m_fsckOutput.trimmed().isEmpty())
+                summary += "\n" + m_fsckOutput.trimmed();
+        }
+    }
+
+    m_timedOut = false;
+    m_activeRepairs.remove(device);
+    m_currentDevice.clear();
+    m_currentFsType.clear();
+    m_currentProcess->deleteLater();
+    m_currentProcess = nullptr;
+
+    emit finished(device, success, summary);
+}
+
+void UsbRepairWorker::onFsckTimeout()
+{
+    if (!m_currentProcess)
+        return;
+
+    // 仅置标志并 kill，finished 信号统一由 onFsckFinished 发射一次，
+    // 避免 kill() 异步触发 QProcess::finished 造成重复 emit。
+    m_timedOut = true;
+    m_currentProcess->kill();
+}
+
+void UsbRepairWorker::onFsckErrorOccurred(QProcess::ProcessError error)
+{
+    if (error != QProcess::FailedToStart)
+        return;
+
+    // 启动失败时 QProcess 不会发射 finished，需在此统一收尾，避免状态悬挂。
+    if (!m_currentProcess)
+        return;
+
+    if (m_timeoutTimer)
+        m_timeoutTimer->stop();
+
+    const QString device = m_currentDevice;
+    const QString summary = tr("Failed to start repair process: %1")
+            .arg(m_currentProcess->errorString().isEmpty()
+                     ? tr("unknown error")
+                     : m_currentProcess->errorString());
+
+    m_activeRepairs.remove(device);
+    m_currentDevice.clear();
+    m_currentFsType.clear();
+    m_currentProcess->deleteLater();
+    m_currentProcess = nullptr;
+
+    fmWarning() << "UsbRepairWorker: fsck failed to start | device:" << device
+                << "| error:" << static_cast<int>(error);
+    emit finished(device, false, summary);
+}
+
+bool UsbRepairWorker::checkAuthorization(const QString &callerBusName)
+{
+    using namespace PolkitQt1;
+
+    if (callerBusName.isEmpty())
+        return false;
+
+    Authority::Result result = Authority::instance()->checkAuthorizationSync(
+        Defines::kPolkitActionId,
+        SystemBusNameSubject(callerBusName),
+        Authority::AllowUserInteraction);
+
+    return result == Authority::Yes;
+}
+
+bool UsbRepairWorker::umountDevice(const QString &devicePath)
+{
+    QProcess proc;
+    proc.start("umount", { devicePath });
+    proc.waitForFinished(10000);
+    if (proc.exitCode() != 0) {
+        fmWarning() << "UsbRepairWorker: umount failed:" << proc.readAllStandardError();
+        return false;
+    }
+    return true;
+}
+
+QString UsbRepairWorker::detectFsType(const QString &devicePath)
+{
+    QProcess proc;
+
+    // Method 1: blkid (fastest, works for normal cases)
+    proc.start("blkid", { "-o", "value", "-s", "TYPE", devicePath });
+    proc.waitForFinished(5000);
+    if (proc.exitCode() == 0) {
+        QString output = proc.readAllStandardOutput().trimmed();
+        if (!output.isEmpty()) {
+            // ext2/ext3 use the same e2fsck tool as ext4; normalize so the
+            // whitelist and repair logic treat them uniformly.
+            if (output == "ext2" || output == "ext3")
+                output = "ext4";
+            return output;
+        }
+    }
+
+    // Method 2: file command (fallback for corrupted filesystems)
+    // Reads magic numbers and raw structures even when filesystem is severely damaged
+    proc.start("file", { "-s", devicePath });
+    proc.waitForFinished(5000);
+    QString fileOutput = proc.readAllStandardOutput();
+    fmInfo() << "UsbRepairWorker: command: file -s" << devicePath << "| exitCode:" << proc.exitCode() << "| output:" << fileOutput;
+    if (proc.exitCode() == 0) {
+        // Parse file command output for filesystem signatures
+        if (fileOutput.contains("FAT", Qt::CaseInsensitive))
+            return "vfat";
+        else if (fileOutput.contains("exFAT", Qt::CaseInsensitive))
+            return "exfat";
+        else if (fileOutput.contains("NTFS", Qt::CaseInsensitive))
+            return "ntfs";
+        else if (fileOutput.contains("ext2 filesystem", Qt::CaseInsensitive) ||
+                 fileOutput.contains("ext3 filesystem", Qt::CaseInsensitive) ||
+                 fileOutput.contains("ext4 filesystem", Qt::CaseInsensitive))
+            return "ext4";
+    }
+
+    return {};
+}
+
+bool UsbRepairWorker::validateDevicePath(const QString &devicePath)
+{
+    if (devicePath.isEmpty())
+        return false;
+    if (!devicePath.startsWith("/dev/"))
+        return false;
+    // Must not contain path traversal
+    if (devicePath.contains(".."))
+        return false;
+    if (!QFile::exists(devicePath))
+        return false;
+
+    // 安全：仅允许修复 USB 可移动设备，拒绝系统盘等固定磁盘被卸载/修复
+    return isUsbBlockDevice(devicePath);
+}
+
+bool UsbRepairWorker::isUsbBlockDevice(const QString &devicePath)
+{
+    // 通过 udisks2 校验：block.Drive → drive.ConnectionBus=="usb" && drive.Removable
+    QDBusInterface blockIface(
+        Defines::kUdisks2Service,
+        blockObjPathFromDevice(devicePath),
+        Defines::kUdisks2BlockIface,
+        QDBusConnection::systemBus());
+    if (!blockIface.isValid())
+        return false;
+
+    QDBusObjectPath drivePath = blockIface.property("Drive").value<QDBusObjectPath>();
+    if (drivePath.path().isEmpty() || drivePath.path() == "/")
+        return false;
+
+    QDBusInterface driveIface(
+        Defines::kUdisks2Service,
+        drivePath.path(),
+        Defines::kUdisks2DriveIface,
+        QDBusConnection::systemBus());
+    if (!driveIface.isValid())
+        return false;
+
+    if (driveIface.property("ConnectionBus").toString() != "usb")
+        return false;
+
+    return driveIface.property("Removable").toBool();
+}
+
+QString UsbRepairWorker::blockObjPathFromDevice(const QString &devicePath)
+{
+    // Convert /dev/sdb1 to /org/freedesktop/UDisks2/block_devices/sdb1
+    QString basename = devicePath.mid(5);  // Remove "/dev/"
+    return QString("/org/freedesktop/UDisks2/block_devices/%1").arg(basename);
+}
+
+void UsbRepairWorker::executeFsck(const QString &devicePath, const QString &fsType)
+{
+    m_timedOut = false;
+    m_currentProcess = new QProcess(this);
+    connect(m_currentProcess, &QProcess::readyReadStandardOutput,
+            this, &UsbRepairWorker::onFsckReadyRead);
+    connect(m_currentProcess, &QProcess::readyReadStandardError,
+            this, &UsbRepairWorker::onFsckReadyRead);
+    connect(m_currentProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, &UsbRepairWorker::onFsckFinished);
+    connect(m_currentProcess, &QProcess::errorOccurred,
+            this, &UsbRepairWorker::onFsckErrorOccurred);
+
+    // Reset output accumulator
+    m_fsckOutput.clear();
+
+    // 超时保护：成员定时器统一管理，onFsckFinished 收尾时 stop()，
+    // 避免旧任务定时器残留触发 onFsckTimeout 误杀下一个任务的进程。
+    if (!m_timeoutTimer) {
+        m_timeoutTimer = new QTimer(this);
+        m_timeoutTimer->setSingleShot(true);
+        connect(m_timeoutTimer, &QTimer::timeout, this, &UsbRepairWorker::onFsckTimeout);
+    }
+    m_timeoutTimer->start(Defines::kFsckTimeoutMs);
+
+    if (fsType == "vfat") {
+        m_currentProcess->start("fsck.fat", { "-a", "-w", devicePath });
+    } else if (fsType == "exfat") {
+        m_currentProcess->start("fsck.exfat", { "-p", devicePath });
+    } else if (fsType == "ntfs") {
+        m_currentProcess->start("ntfsfix", { devicePath });
+    } else if (fsType == "ext4") {
+        m_currentProcess->start("e2fsck", { "-p", devicePath });
+    } else {
+        // Unsupported type should have been filtered during preparation.
+        m_timeoutTimer->stop();
+        m_currentProcess->deleteLater();
+        m_currentProcess = nullptr;
+        m_activeRepairs.remove(devicePath);
+        m_currentDevice.clear();
+        emit finished(devicePath, false, tr("Unsupported filesystem type: %1").arg(fsType));
+        return;
+    }
+    fmInfo() << "UsbRepairWorker: command:" << m_currentProcess->program()
+             << m_currentProcess->arguments();
+}

--- a/src/services/usbrepair/usbrepairworker.h
+++ b/src/services/usbrepair/usbrepairworker.h
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef USBREPAIRWORKER_H
+#define USBREPAIRWORKER_H
+
+#include "service_usbrepair_global.h"
+
+#include <QObject>
+#include <QProcess>
+#include <QSet>
+
+class QTimer;
+SERVICEUSBREPAIR_BEGIN_NAMESPACE
+
+class UsbRepairWorker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit UsbRepairWorker(QObject *parent = nullptr);
+    ~UsbRepairWorker();
+
+    bool startRepair(const QString &devicePath, const QString &callerBusName, QString &errorMessage);
+    bool cancelRepair(const QString &devicePath, const QString &callerBusName);
+    bool isRepairing(const QString &devicePath) const;
+
+Q_SIGNALS:
+    void progress(const QString &devicePath, int percent, const QString &logLine);
+    void finished(const QString &devicePath, bool success, const QString &summary);
+
+private Q_SLOTS:
+    void onFsckReadyRead();
+    void onFsckFinished(int exitCode, QProcess::ExitStatus exitStatus);
+    void onFsckTimeout();
+    void onFsckErrorOccurred(QProcess::ProcessError error);
+
+private:
+    bool checkAuthorization(const QString &callerBusName);
+    bool umountDevice(const QString &devicePath);
+    QString detectFsType(const QString &devicePath);
+    bool validateDevicePath(const QString &devicePath);
+    void executeFsck(const QString &devicePath, const QString &fsType);
+    QString blockObjPathFromDevice(const QString &devicePath);
+    bool isUsbBlockDevice(const QString &devicePath);
+
+    QProcess *m_currentProcess { nullptr };
+    QString m_currentDevice;
+    QString m_currentFsType;
+    QString m_fsckOutput;
+    QSet<QString> m_activeRepairs;
+    bool m_timedOut { false };   // 标记 fsck 是否超时，供 onFsckFinished 统一收尾判断
+    QTimer *m_timeoutTimer { nullptr };   // 超时定时器句柄，任务结束即 stop，防止旧定时器误杀后续任务进程
+};
+
+SERVICEUSBREPAIR_END_NAMESPACE
+
+#endif   // USBREPAIRWORKER_H


### PR DESCRIPTION
…cation

- Add new usbrepair subdirectory to CMakeLists.txt
- Create comprehensive USB repair service with D-Bus interface for filesystem error detection and repair functionality
- Implement PolKit policy for privileged operations on USB devices
- Add D-Bus configuration and security policies for system-level access
- Include systemd security hardening configuration
- Integrate with udisks2 for monitoring USB device filesystem health
- Support multiple filesystem types (vfat, exfat, ntfs, ext4) with appropriate repair tools
- Adapt to Qt6/DFM6 service framework with dependencies.cmake

Log: feat: add USB repair service with D-Bus interface and PolKit authentication
Task: https://pms.uniontech.com/task-view-388225.html

Change-Id: Id1f953a5e4c22501240a4a7c3d0ad1fa8a55dcaa