### PR TITLE
fix(propertydialog): use D-Bus SystemInfo for installed memory size

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -395,8 +395,12 @@ QString ComputerInfoThread::cpuInfo() const
 
 QString ComputerInfoThread::memoryInfo() const
 {
+    qint64 installedMemory = UniversalUtils::computerMemory();
+    if (installedMemory <= 0)
+        installedMemory = DSysInfo::memoryInstalledSize();
+
     return QString("%1 (%2 %3)")
-            .arg(formatCap(DSysInfo::memoryInstalledSize(), 1024, 0))
+            .arg(formatCap(installedMemory, 1024, 0))
             .arg(formatCap(DSysInfo::memoryTotalSize()))
             .arg(tr("Available"));
 }


### PR DESCRIPTION
## 根因分析

`ComputerInfoThread::memoryInfo()` 使用 dtkcore 的 `DSysInfo::memoryInstalledSize()`（lshw `id=="memory"`）作为内存总量数据源。在兆芯 KX-7000 双 DDR5（16+16=32GB）平台上返回值偏低（约 30GB），导致计算机属性对话框显示的总内存少 2GB。

dde-control-center 优先使用 D-Bus `org.deepin.dde.SystemInfo1.MemorySize`（dde-daemon 提供，匹配 `Description=="system memory"`），获取正确的 32GB。dde-file-manager 已有 `UniversalUtils::computerMemory()` 封装了相同的 D-Bus 读取逻辑，但 `memoryInfo()` 未使用。

## 修复方案

修改 `memoryInfo()` 优先使用 `UniversalUtils::computerMemory()` 获取安装内存值，与 dde-control-center 数据源一致。该值无效时回退到 `DSysInfo::memoryInstalledSize()`（防御 history bug 181735 中 D-Bus 返回 0 的场景）。

## 改动安全评估

低风险 — 仅修改 `memoryInfo()` 内部逻辑，函数签名不变，无外部调用者影响。`UniversalUtils::computerMemory()` 已在项目中稳定使用。

## Summary by Sourcery

Bug Fixes:
- Correct the reported installed memory size in the computer property dialog by using the same D-Bus-based source as dde-control-center.