### PR TITLE
refactor: switch from netlink to socket for deepin-anything events

### DIFF
--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -14,9 +14,9 @@
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
 
-// VfsMonitorFileSystemWatcher 依赖 deepin-anything 内核模块
-// 如果模块不可用，create() 返回 nullptr，相关测试应被跳过
-// 注意: 当前内核 vfs_monitor 模块存在已知 bug（无法检测目录创建），
+// VfsMonitorFileSystemWatcher 依赖 deepin-anything 事件分发 socket
+// 如果事件分发不可用，create() 返回 nullptr，相关测试应被跳过
+// 注意: 当前 deepin-anything 事件链路若不可用，
 // 目录相关测试使用 ASSERT 严格模式，失败时直接终止当前测试而非崩溃
 class TestVfsMonitorFileSystemWatcher : public ::testing::Test
 {
@@ -33,7 +33,7 @@ protected:
         QStringList rootPaths = { testDir->path() };
         watcher = VfsMonitorFileSystemWatcher::create(rootPaths, {}, nullptr);
         if (!watcher) {
-            GTEST_SKIP() << "deepin-anything kernel module not available, skipping tests";
+            GTEST_SKIP() << "deepin-anything event dispatcher not available, skipping tests";
         }
     }
 

--- a/src/services/textindex/dependencies.cmake
+++ b/src/services/textindex/dependencies.cmake
@@ -16,7 +16,7 @@ function(dfm_setup_textindex_dependencies target_name)
     # Find system dependencies using pkg-config
     pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
     pkg_check_modules(GLIB REQUIRED glib-2.0)
-    pkg_check_modules(NL REQUIRED IMPORTED_TARGET libnl-3.0 libnl-genl-3.0)
+    pkg_check_modules(mount REQUIRED mount IMPORTED_TARGET)
     
     # Apply default service configuration first (this provides DFM6::base, Qt6::Core, Qt6::DBus)
     dfm_apply_default_service_config(${target_name})
@@ -36,7 +36,7 @@ function(dfm_setup_textindex_dependencies target_name)
         dde-file-manager-extractor-lib
         ${GLIB_LIBRARIES}
         PkgConfig::Lucene
-        PkgConfig::NL
+        PkgConfig::mount
     )
     
     # Add textindex-specific include directories

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -114,7 +114,7 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
 
     // Try to create VfsMonitorFileSystemWatcher for global file system events.
     // Pass shouldExcludePath as the exclude predicate so filtering happens
-    // at the netlink callback level (before any signals are emitted).
+    // before any socket-delivered events are emitted.
     vfsWatcher.reset(VfsMonitorFileSystemWatcher::create(
         this->rootPaths,
         [this](const QString &path) { return shouldExcludePath(path); },
@@ -122,15 +122,15 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
     vfsMonitorAvailable = (vfsWatcher != nullptr);
 
     if (vfsMonitorAvailable) {
-        // vfs_monitor mode: create/delete/move from vfs, fileClosed from inotify.
+        // deepin-anything dispatcher mode: create/delete/move from vfs, fileClosed from inotify.
         // Restrict inotify to IN_CLOSE_WRITE only, reducing kernel event delivery.
         watcher->setWatchFlags(InotifyFileSystemWatcher::WatchFlag::FileClose);
         setupVfsMonitorConnections();
-        fmInfo() << "FSMonitor: Using dual watcher mode (vfs_monitor + inotify fallback)";
+        fmInfo() << "FSMonitor: Using dual watcher mode (deepin-anything dispatcher + inotify fallback)";
     } else {
         // inotify-only mode: all signals from InotifyFileSystemWatcher (existing behavior).
         setupWatcherConnections();
-        fmInfo() << "FSMonitor: Using inotify-only mode (vfs_monitor not available)";
+        fmInfo() << "FSMonitor: Using inotify-only mode (deepin-anything dispatcher not available)";
     }
 
     fmDebug() << "FSMonitor: Initialized with" << excludeMatcher.patternCount()

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -64,7 +64,7 @@ public:
     // Parse and connect watcher signals (inotify-only fallback mode)
     void setupWatcherConnections();
 
-    // Connect vfs_monitor watcher signals (create/delete/move from vfs, fileClosed from inotify)
+    // Connect deepin-anything watcher signals (create/delete/move from vfs, fileClosed from inotify)
     void setupVfsMonitorConnections();
 
     // Set up the worker thread and connections

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -4,33 +4,26 @@
 
 #include "vfsmonitorwatcher_p.h"
 
-#include <QFileInfo>
 #include <QDir>
-#include <QFile>
-#include <QTextStream>
-
-#include <netlink/genl/ctrl.h>
-#include <netlink/genl/genl.h>
-#include <netlink/netlink.h>
-#include <netlink/socket.h>
-#include <netlink/attr.h>
-#include <netlink/msg.h>
+#include <QFileInfo>
 
 #include <libmount.h>
-#include <sys/sysmacros.h>
 
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <algorithm>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
-// Netlink family and multicast group names (matching vfs_genl.h)
-static constexpr char kVfsMonitorFamilyName[] = "vfsmonitor";
-static constexpr char kVfsMonitorMcgDentry[] = "vfsmonitor_de";
-
-// --- Per-instance C callback for libnl ---
-
 namespace {
+
+constexpr char kDispatcherSocketPath[] = "/run/deepin-anything/event-dispatcher.sock";
+constexpr size_t kDispatchMaxPathLen = 4096;
 
 struct MountEntry
 {
@@ -38,31 +31,14 @@ struct MountEntry
     int parentMountId { 0 };
     QString mountPoint;
     bool isBindMount { false };
-    bool isLowerFs { false };
 };
 
-// Netlink attribute policy for parsing vfs_monitor messages.
-struct nla_policy vfsPolicy[VFSMONITOR_A_MAX + 1];
-
-void initVfsPolicy()
+struct DispatchEvent
 {
-    std::memset(vfsPolicy, 0, sizeof(vfsPolicy));
-    vfsPolicy[VFSMONITOR_A_ACT].type = NLA_U8;
-    vfsPolicy[VFSMONITOR_A_COOKIE].type = NLA_U32;
-    vfsPolicy[VFSMONITOR_A_MAJOR].type = NLA_U16;
-    vfsPolicy[VFSMONITOR_A_MINOR].type = NLA_U8;
-    vfsPolicy[VFSMONITOR_A_PATH].type = NLA_NUL_STRING;
-    vfsPolicy[VFSMONITOR_A_PATH].maxlen = 4096;
-}
-
-bool mountPointStartsWith(const QString &path, const QString &mountPoint)
-{
-    if (!path.startsWith(mountPoint))
-        return false;
-
-    return mountPoint.endsWith('/') || path.length() == mountPoint.length()
-            || path.at(mountPoint.length()) == '/';
-}
+    int32_t action;
+    uint32_t cookie;
+    char eventPath[kDispatchMaxPathLen];
+};
 
 bool isDescendantOfRoot(const QString &path, const QString &root)
 {
@@ -78,15 +54,18 @@ bool isDescendantOfRoot(const QString &path, const QString &root)
     return root.endsWith('/') || path.at(root.length()) == '/';
 }
 
+bool mountPointStartsWith(const QString &path, const QString &mountPoint)
+{
+    if (!path.startsWith(mountPoint))
+        return false;
+
+    return mountPoint.endsWith('/') || path.length() == mountPoint.length()
+            || path.at(mountPoint.length()) == '/';
+}
+
 bool cStringEquals(const char *left, const char *right)
 {
     return left && right && qstrcmp(left, right) == 0;
-}
-
-bool isLowerFsType(const char *fsType)
-{
-    return cStringEquals(fsType, "overlay") || cStringEquals(fsType, "fuse.dlnfs")
-            || cStringEquals(fsType, "ulnfs");
 }
 
 bool isParentChainUnderRoot(const QHash<int, MountEntry> &byMountId, const MountEntry &entry)
@@ -112,25 +91,21 @@ bool isParentChainUnderRoot(const QHash<int, MountEntry> &byMountId, const Mount
 QHash<int, MountEntry> collectMountEntries(libmnt_table *mtab)
 {
     QHash<int, MountEntry> byMountId;
-    struct libmnt_iter *iter = mnt_new_iter(MNT_ITER_FORWARD);
+    libmnt_iter *iter = mnt_new_iter(MNT_ITER_FORWARD);
     if (!iter)
         return byMountId;
 
-    struct libmnt_fs *fs;
+    libmnt_fs *fs = nullptr;
     while (mnt_table_next_fs(mtab, iter, &fs) == 0) {
         const char *target = mnt_fs_get_target(fs);
         if (!target)
             continue;
 
-        const char *root = mnt_fs_get_root(fs);
-        const char *fsType = mnt_fs_get_fstype(fs);
-
         MountEntry entry;
         entry.deviceId = mnt_fs_get_devno(fs);
         entry.parentMountId = mnt_fs_get_parent_id(fs);
         entry.mountPoint = QString::fromUtf8(target);
-        entry.isBindMount = !cStringEquals(root, "/");
-        entry.isLowerFs = isLowerFsType(fsType);
+        entry.isBindMount = !cStringEquals(mnt_fs_get_root(fs), "/");
 
         byMountId.insert(mnt_fs_get_id(fs), entry);
     }
@@ -139,163 +114,33 @@ QHash<int, MountEntry> collectMountEntries(libmnt_table *mtab)
     return byMountId;
 }
 
-// Per-instance callback: arg is the VfsMonitorFileSystemWatcherPrivate pointer,
-// registered per-socket via nl_socket_modify_cb. No global state needed.
-int vfsMonitorMsgCallback(struct nl_msg *msg, void *arg)
+QString filterDirectPath(const QStringList &rootPaths,
+                         const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
+                         const QString &fullPath)
 {
-    auto *d = static_cast<VfsMonitorFileSystemWatcherPrivate *>(arg);
-
-    if (!d) {
-        return NL_SKIP;
+    if (std::none_of(rootPaths.cbegin(), rootPaths.cend(),
+                     [&fullPath](const QString &root) { return isDescendantOfRoot(fullPath, root); })) {
+        return {};
     }
 
-    struct nlattr *tb[VFSMONITOR_A_MAX + 1];
-    std::memset(tb, 0, sizeof(tb));
+    if (excludePredicate && excludePredicate(fullPath))
+        return {};
 
-    struct nlmsghdr *nh = nlmsg_hdr(msg);
-    int err = genlmsg_parse(nh, 0, tb, VFSMONITOR_A_MAX, vfsPolicy);
-    if (err < 0) {
-        return NL_SKIP;
-    }
-
-    if (!tb[VFSMONITOR_A_PATH]) {
-        return NL_SKIP;
-    }
-
-    // Extract attributes.
-    uint8_t act = tb[VFSMONITOR_A_ACT] ? nla_get_u8(tb[VFSMONITOR_A_ACT]) : 0;
-    uint32_t cookie = tb[VFSMONITOR_A_COOKIE] ? nla_get_u32(tb[VFSMONITOR_A_COOKIE]) : 0;
-    uint16_t major = tb[VFSMONITOR_A_MAJOR] ? nla_get_u16(tb[VFSMONITOR_A_MAJOR]) : 0;
-    uint8_t minor = tb[VFSMONITOR_A_MINOR] ? nla_get_u8(tb[VFSMONITOR_A_MINOR]) : 0;
-    const char *pathCStr = reinterpret_cast<const char *>(nla_data(tb[VFSMONITOR_A_PATH]));
-
-    // Skip non-filesystem events.
-    if (act > ACT_UNMOUNT) {
-        return NL_OK;
-    }
-
-    // Mount/unmount events don't carry meaningful path data for indexing,
-    // but they invalidate our mount point cache. Flag the dirty bit so
-    // handleNetlinkMessage() can refresh the cache after this batch.
-    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
-        d->mountPointsDirty = true;
-        return NL_OK;
-    }
-
-    dev_t deviceId = makedev(major, minor);
-
-    // RENAME_FROM events must be stored before filtering, because the paired
-    // RENAME_TO may land in an excluded path (e.g., trash). We need the
-    // RENAME_FROM info to emit a delete when that happens.
-    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
-        QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-        if (fullPath.isNull())
-            return NL_OK;   // Source itself is excluded, no point tracking.
-
-        auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-
-        RenameFromInfo info;
-        info.path = parentPath;
-        info.name = name;
-        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
-        d->pendingRenames.insert(cookie, info);
-        return NL_OK;
-    }
-
-    // RENAME_TO events need independent path resolution because the target may
-    // be filtered (e.g., moved to trash). In that case we emit a delete for the
-    // source instead of a move — the generic fullPath.isNull() gate below would
-    // swallow this event before we could check pendingRenames.
-    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
-        auto *q = d->q_ptr;
-        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
-
-        auto it = d->pendingRenames.find(cookie);
-        if (it != d->pendingRenames.end()) {
-            QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
-                else
-                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
-            } else {
-                // Target is filtered (e.g., moved to trash) → source is gone.
-                if (isDir)
-                    Q_EMIT q->directoryDeleted(it->path, it->name);
-                else
-                    Q_EMIT q->fileDeleted(it->path, it->name);
-            }
-            d->pendingRenames.erase(it);
-        } else {
-            // Unpaired RENAME_TO: treat as creation if in monitored area.
-            QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryCreated(parentPath, name);
-                else
-                    Q_EMIT q->fileCreated(parentPath, name);
-            }
-        }
-        return NL_OK;
-    }
-
-    // For all other events, reconstruct and filter the full path.
-    QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-    if (fullPath.isNull()) {
-        return NL_OK;
-    }
-
-    auto *q = d->q_ptr;
-    auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-
-    switch (act) {
-    case ACT_NEW_FILE:
-    case ACT_NEW_LINK:
-    case ACT_NEW_SYMLINK:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-
-    case ACT_NEW_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-
-    case ACT_DEL_FILE:
-        Q_EMIT q->fileDeleted(parentPath, name);
-        break;
-
-    case ACT_DEL_FOLDER:
-        Q_EMIT q->directoryDeleted(parentPath, name);
-        break;
-
-        // Synthetic events (kernel-paired rename).
-    case ACT_RENAME_FILE:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-
-    case ACT_RENAME_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-
-    default:
-        break;
-    }
-
-    return NL_OK;
+    return fullPath;
 }
 
-static bool registerMessageCallback(nl_sock *sock, VfsMonitorFileSystemWatcherPrivate *d)
+QString filterEventPath(const QStringList &rootPaths,
+                        const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
+                        const char *eventPath)
 {
-    // Pass d directly as per-socket callback data. Each nl_sock gets its own
-    // callback arg, so multiple instances are naturally supported.
-    int ret = nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM,
-                                  vfsMonitorMsgCallback, d);
-    if (ret != 0) {
-        return false;
-    }
+    if (!eventPath || eventPath[0] == '\0')
+        return {};
 
-    return true;
+    const QString fullPath = QDir::cleanPath(QString::fromUtf8(eventPath));
+    if (!fullPath.startsWith('/'))
+        return {};
+
+    return filterDirectPath(rootPaths, excludePredicate, fullPath);
 }
 
 }   // anonymous namespace
@@ -306,8 +151,13 @@ VfsMonitorFileSystemWatcherPrivate::VfsMonitorFileSystemWatcherPrivate(
         const QStringList &rootPaths,
         VfsMonitorFileSystemWatcher::PathExcludePredicate excludePredicate,
         VfsMonitorFileSystemWatcher *qq)
-    : q_ptr(qq), rootPaths(rootPaths), excludePredicate(std::move(excludePredicate))
+    : q_ptr(qq), excludePredicate(std::move(excludePredicate))
 {
+    this->rootPaths.reserve(rootPaths.size());
+    for (const QString &path : rootPaths) {
+        this->rootPaths.append(QDir(path).absolutePath());
+    }
+    this->rootPaths.removeDuplicates();
 }
 
 VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
@@ -316,26 +166,19 @@ VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
         notifier->setEnabled(false);
     }
 
-    // No global callback state to clear — the per-socket callback data (this
-    // pointer) becomes invalid when nlSock is freed below, and the callback
-    // checks for null before dereferencing.
-
-    if (nlSock) {
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
+    if (socketFd >= 0) {
+        ::close(socketFd);
+        socketFd = -1;
     }
 }
 
 bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
 {
     mountPoints.clear();
-    childMountPoints.clear();
-    lowerFsExists = false;
 
-    struct libmnt_table *mtab = mnt_new_table();
-    if (!mtab) {
+    libmnt_table *mtab = mnt_new_table();
+    if (!mtab)
         return false;
-    }
 
     if (mnt_table_parse_mtab(mtab, nullptr) < 0) {
         mnt_free_table(mtab);
@@ -345,115 +188,59 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
     const QHash<int, MountEntry> byMountId = collectMountEntries(mtab);
     mnt_free_table(mtab);
 
-    QHash<int, MountEntry> rootMountTree;
     for (auto it = byMountId.cbegin(); it != byMountId.cend(); ++it) {
-        const auto &entry = it.value();
-
+        const MountEntry &entry = it.value();
         if (!isParentChainUnderRoot(byMountId, entry))
             continue;
 
         mountPoints[entry.deviceId].append(entry.mountPoint);
-        rootMountTree.insert(it.key(), entry);
-        lowerFsExists = lowerFsExists || entry.isLowerFs;
     }
 
     for (auto &points : mountPoints) {
-        std::sort(points.begin(), points.end(),
-                  [](const QString &a, const QString &b) {
-                      return a.length() > b.length();
-                  });
-    }
-
-    for (auto it = rootMountTree.cbegin(); it != rootMountTree.cend(); ++it) {
-        const auto &parent = it.value();
-        QStringList children;
-        for (const auto &entry : std::as_const(rootMountTree)) {
-            if (entry.parentMountId == it.key()) {
-                children.append(entry.mountPoint);
-            }
-        }
-
-        if (!children.isEmpty())
-            childMountPoints[parent.deviceId].append(children);
-    }
-
-    for (auto &points : childMountPoints) {
         points.removeDuplicates();
         std::sort(points.begin(), points.end(),
-                  [](const QString &a, const QString &b) {
-                      return a.length() > b.length();
+                  [](const QString &left, const QString &right) {
+                      return left.length() > right.length();
                   });
     }
 
-    int totalPoints = 0;
-    for (const auto &pts : std::as_const(mountPoints)) {
-        totalPoints += pts.size();
-    }
-    fmInfo() << "VfsMonitor: loaded" << mountPoints.size()
-             << "devices," << totalPoints << "mount points,"
-             << childMountPoints.size() << "devices with child mount points,"
-             << "lowerfs exists:" << lowerFsExists;
     return !mountPoints.isEmpty();
 }
 
-bool VfsMonitorFileSystemWatcherPrivate::isLowerFsEvent(dev_t deviceId, const QString &fullPath) const
+QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char *absolutePath) const
 {
-    if (!lowerFsExists)
-        return false;
+    const QString directPath = filterEventPath(rootPaths, excludePredicate, absolutePath);
+    if (!directPath.isNull())
+        return directPath;
 
-    auto it = childMountPoints.find(deviceId);
-    if (it == childMountPoints.end())
-        return false;
-
-    for (const QString &childMountPoint : it.value()) {
-        if (mountPointStartsWith(fullPath, childMountPoint)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(dev_t deviceId,
-                                                                     const char *relativePath) const
-{
-    auto it = mountPoints.find(deviceId);
-    if (it == mountPoints.end())
+    if (!absolutePath || absolutePath[0] == '\0')
         return {};
 
-    const QStringList &points = it.value();
-    const QString relPath = QString::fromUtf8(relativePath);
+    const QString fullPath = QDir::cleanPath(QString::fromUtf8(absolutePath));
+    if (!fullPath.startsWith('/'))
+        return {};
 
-    // Try each mount point (sorted longest first).
-    // Return the first one that falls under a monitored root path
-    // and passes the exclude predicate.
-    for (const QString &mp : points) {
-        QString fullPath = (mp == "/") ? relPath : (mp + relPath);
+    for (auto deviceIt = mountPoints.cbegin(); deviceIt != mountPoints.cend(); ++deviceIt) {
+        const QStringList &points = deviceIt.value();
+        for (const QString &sourceMountPoint : points) {
+            if (!mountPointStartsWith(fullPath, sourceMountPoint))
+                continue;
 
-        if (isLowerFsEvent(deviceId, fullPath))
-            continue;
+            const QString suffix = (sourceMountPoint == "/")
+                    ? fullPath
+                    : fullPath.mid(sourceMountPoint.length());
 
-        if (std::none_of(rootPaths.cbegin(), rootPaths.cend(),
-                         [&fullPath](const QString &root) { return isDescendantOfRoot(fullPath, root); }))
-            continue;
+            for (const QString &candidateMountPoint : points) {
+                const QString candidateFullPath = (candidateMountPoint == "/")
+                        ? suffix
+                        : candidateMountPoint + suffix;
+                const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
+                if (!filteredCandidate.isNull())
+                    return filteredCandidate;
+            }
 
-        if (excludePredicate && excludePredicate(fullPath))
-            continue;
-
-        return fullPath;
-    }
-
-    // In overlay root environments, the root "/" filesystem has no separate mount
-    // entry in mountPoints. When all mount points fail and relPath is already
-    // an absolute path, treat it as the true absolute path and re-check.
-    if (relPath.startsWith('/')) {
-        auto found = std::find_if(rootPaths.cbegin(), rootPaths.cend(),
-                                  [&relPath, this](const QString &root) {
-                                      return isDescendantOfRoot(relPath, root)
-                                              && (!excludePredicate || !excludePredicate(relPath));
-                                  });
-        if (found != rootPaths.cend())
-            return relPath;
+            break;
+        }
     }
 
     return {};
@@ -465,95 +252,168 @@ QPair<QString, QString> VfsMonitorFileSystemWatcherPrivate::splitPath(const QStr
     return qMakePair(fi.absolutePath(), fi.fileName());
 }
 
-bool VfsMonitorFileSystemWatcherPrivate::initNetlink()
+bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
 {
     Q_Q(VfsMonitorFileSystemWatcher);
 
-    // Build mount point cache first (no netlink dependency).
     if (!initMountPoints()) {
-        fmWarning() << "VfsMonitor: failed to initialize mount points";
+        fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
     }
 
-    nlSock = nl_socket_alloc();
-    if (!nlSock) {
-        fmWarning() << "VfsMonitor: failed to allocate netlink socket";
+    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (socketFd < 0) {
+        fmWarning() << "VfsMonitor: failed to create dispatcher socket:" << std::strerror(errno);
         return false;
     }
 
-    if (genl_connect(nlSock) != 0) {
-        fmWarning() << "VfsMonitor: genl_connect failed";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
+    sockaddr_un address {};
+    address.sun_family = AF_UNIX;
+    std::strncpy(address.sun_path, kDispatcherSocketPath, sizeof(address.sun_path) - 1);
+
+    if (::connect(socketFd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0) {
+        fmWarning() << "VfsMonitor: deepin-anything event dispatcher not available:" << std::strerror(errno);
+        ::close(socketFd);
+        socketFd = -1;
         return false;
     }
 
-    // Set receive buffer to system maximum to prevent event loss.
-    QFile rmemFile("/proc/sys/net/core/rmem_max");
-    if (rmemFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        QTextStream in(&rmemFile);
-        bool ok = false;
-        int maxRcvbuf = in.readLine().trimmed().toInt(&ok);
-        if (ok && maxRcvbuf > 0) {
-            if (nl_socket_set_buffer_size(nlSock, maxRcvbuf, 0) != 0) {
-                fmWarning() << "VfsMonitor: failed to set socket buffer size";
-            }
-        }
-        rmemFile.close();
-    }
-
-    nl_socket_disable_seq_check(nlSock);
-    nl_socket_disable_auto_ack(nlSock);
-
-    int mcgrpId = genl_ctrl_resolve_grp(nlSock, kVfsMonitorFamilyName, kVfsMonitorMcgDentry);
-    if (mcgrpId < 0) {
-        fmWarning() << "VfsMonitor: vfs_monitor kernel module not available";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    if (nl_socket_add_membership(nlSock, mcgrpId) != 0) {
-        fmWarning() << "VfsMonitor: failed to join multicast group";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    initVfsPolicy();
-
-    if (!registerMessageCallback(nlSock, this)) {
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    int fd = nl_socket_get_fd(nlSock);
-    notifier = new QSocketNotifier(fd, QSocketNotifier::Read, q);
+    notifier = new QSocketNotifier(socketFd, QSocketNotifier::Read, q);
     QObject::connect(notifier, &QSocketNotifier::activated, q, [this]() {
-        handleNetlinkMessage();
+        handleSocketMessage();
     });
 
-    fmInfo() << "VfsMonitor: connected to vfs_monitor kernel module";
+    fmInfo() << "VfsMonitor: connected to deepin-anything event dispatcher";
     return true;
 }
 
-void VfsMonitorFileSystemWatcherPrivate::handleNetlinkMessage()
+void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
 {
-    int ret = nl_recvmsgs_default(nlSock);
-    if (ret < 0 && ret != -NLE_AGAIN) {
-        fmWarning() << "VfsMonitor: nl_recvmsgs_default failed, error:" << ret;
+    if (socketFd < 0) {
+        return;
     }
 
-    // Refresh mount point cache if mount/unmount events were received.
-    // Done after nl_recvmsgs_default() so the cache is up-to-date for the
-    // next batch of file events.
-    if (mountPointsDirty) {
-        mountPointsDirty = false;
-        if (initMountPoints()) {
-            fmInfo() << "VfsMonitor: mount point cache refreshed";
-        } else {
-            fmWarning() << "VfsMonitor: failed to refresh mount point cache";
+    DispatchEvent event {};
+    ssize_t received = -1;
+    do {
+        received = ::recv(socketFd, &event, sizeof(event), 0);
+    } while (received < 0 && errno == EINTR);
+
+    if (received == 0) {
+        fmWarning() << "VfsMonitor: event dispatcher connection closed";
+        if (notifier) {
+            notifier->setEnabled(false);
         }
+        ::close(socketFd);
+        socketFd = -1;
+        return;
+    }
+
+    if (received < 0) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
+        }
+        return;
+    }
+
+    constexpr size_t kMinMessageSize = offsetof(DispatchEvent, eventPath) + 1;
+    if (static_cast<size_t>(received) < kMinMessageSize) {
+        fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
+        return;
+    }
+
+    event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+
+    const int act = event.action;
+    const uint32_t cookie = event.cookie;
+    const char *pathCStr = event.eventPath;
+
+    if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+        return;
+    }
+
+    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
+        if (!initMountPoints()) {
+            fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
+        }
+        return;
+    }
+
+    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
+        QString fullPath = resolveAndFilterFullPath(pathCStr);
+        if (fullPath.isNull())
+            return;
+
+        auto [parentPath, name] = splitPath(fullPath);
+        RenameFromInfo info;
+        info.path = parentPath;
+        info.name = name;
+        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
+        pendingRenames.insert(cookie, info);
+        return;
+    }
+
+    auto *q = q_ptr;
+    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
+        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
+        auto it = pendingRenames.find(cookie);
+        if (it != pendingRenames.end()) {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (!fullPath.isNull()) {
+                auto [parentPath, name] = splitPath(fullPath);
+                if (isDir)
+                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
+                else
+                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
+            } else {
+                if (isDir)
+                    Q_EMIT q->directoryDeleted(it->path, it->name);
+                else
+                    Q_EMIT q->fileDeleted(it->path, it->name);
+            }
+            pendingRenames.erase(it);
+        } else {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (!fullPath.isNull()) {
+                auto [parentPath, name] = splitPath(fullPath);
+                if (isDir)
+                    Q_EMIT q->directoryCreated(parentPath, name);
+                else
+                    Q_EMIT q->fileCreated(parentPath, name);
+            }
+        }
+        return;
+    }
+
+    const QString fullPath = resolveAndFilterFullPath(pathCStr);
+    if (fullPath.isNull()) {
+        return;
+    }
+
+    auto [parentPath, name] = splitPath(fullPath);
+
+    switch (act) {
+    case ACT_NEW_FILE:
+    case ACT_NEW_LINK:
+    case ACT_NEW_SYMLINK:
+        Q_EMIT q->fileCreated(parentPath, name);
+        break;
+    case ACT_NEW_FOLDER:
+        Q_EMIT q->directoryCreated(parentPath, name);
+        break;
+    case ACT_DEL_FILE:
+        Q_EMIT q->fileDeleted(parentPath, name);
+        break;
+    case ACT_DEL_FOLDER:
+        Q_EMIT q->directoryDeleted(parentPath, name);
+        break;
+    case ACT_RENAME_FILE:
+        Q_EMIT q->fileCreated(parentPath, name);
+        break;
+    case ACT_RENAME_FOLDER:
+        Q_EMIT q->directoryCreated(parentPath, name);
+        break;
+    default:
+        break;
     }
 
     // Clean up orphaned RENAME_FROM entries.
@@ -584,7 +444,7 @@ VfsMonitorFileSystemWatcher *VfsMonitorFileSystemWatcher::create(const QStringLi
 {
     auto *watcher = new VfsMonitorFileSystemWatcher(rootPaths, std::move(excludePredicate), parent);
 
-    if (!watcher->d_func()->initNetlink()) {
+    if (!watcher->d_func()->initDispatcher()) {
         delete watcher;
         return nullptr;
     }

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -129,20 +129,6 @@ QString filterDirectPath(const QStringList &rootPaths,
     return fullPath;
 }
 
-QString filterEventPath(const QStringList &rootPaths,
-                        const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
-                        const char *eventPath)
-{
-    if (!eventPath || eventPath[0] == '\0')
-        return {};
-
-    const QString fullPath = QDir::cleanPath(QString::fromUtf8(eventPath));
-    if (!fullPath.startsWith('/'))
-        return {};
-
-    return filterDirectPath(rootPaths, excludePredicate, fullPath);
-}
-
 }   // anonymous namespace
 
 // ========== VfsMonitorFileSystemWatcherPrivate ==========
@@ -175,6 +161,7 @@ VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
 bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
 {
     mountPoints.clear();
+    orderedMountPoints.clear();
 
     libmnt_table *mtab = mnt_new_table();
     if (!mtab)
@@ -194,6 +181,7 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
             continue;
 
         mountPoints[entry.deviceId].append(entry.mountPoint);
+        orderedMountPoints.append({ entry.deviceId, entry.mountPoint });
     }
 
     for (auto &points : mountPoints) {
@@ -204,15 +192,16 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
                   });
     }
 
+    std::sort(orderedMountPoints.begin(), orderedMountPoints.end(),
+              [](const MountPointAlias &left, const MountPointAlias &right) {
+                  return left.mountPoint.length() > right.mountPoint.length();
+              });
+
     return !mountPoints.isEmpty();
 }
 
 QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char *absolutePath) const
 {
-    const QString directPath = filterEventPath(rootPaths, excludePredicate, absolutePath);
-    if (!directPath.isNull())
-        return directPath;
-
     if (!absolutePath || absolutePath[0] == '\0')
         return {};
 
@@ -220,27 +209,34 @@ QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char 
     if (!fullPath.startsWith('/'))
         return {};
 
-    for (auto deviceIt = mountPoints.cbegin(); deviceIt != mountPoints.cend(); ++deviceIt) {
-        const QStringList &points = deviceIt.value();
-        for (const QString &sourceMountPoint : points) {
-            if (!mountPointStartsWith(fullPath, sourceMountPoint))
-                continue;
+    const QString directPath = filterDirectPath(rootPaths, excludePredicate, fullPath);
+    if (!directPath.isNull())
+        return directPath;
 
-            const QString suffix = (sourceMountPoint == "/")
-                    ? fullPath
-                    : fullPath.mid(sourceMountPoint.length());
+    for (const MountPointAlias &sourceAlias : orderedMountPoints) {
+        if (!mountPointStartsWith(fullPath, sourceAlias.mountPoint))
+            continue;
 
-            for (const QString &candidateMountPoint : points) {
-                const QString candidateFullPath = (candidateMountPoint == "/")
-                        ? suffix
-                        : candidateMountPoint + suffix;
-                const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
-                if (!filteredCandidate.isNull())
-                    return filteredCandidate;
-            }
+        const auto pointsIt = mountPoints.constFind(sourceAlias.deviceId);
+        if (pointsIt == mountPoints.cend())
+            return {};
 
-            break;
+        const QString suffix = (sourceAlias.mountPoint == "/")
+                ? fullPath
+                : fullPath.mid(sourceAlias.mountPoint.length());
+
+        for (const QString &candidateMountPoint : pointsIt.value()) {
+            const QString candidateFullPath = (candidateMountPoint == "/")
+                    ? suffix
+                    : candidateMountPoint + suffix;
+            const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
+            if (!filteredCandidate.isNull())
+                return filteredCandidate;
         }
+
+        // The longest matching source mount point wins. If its aliases do not
+        // land inside a monitored root, do not fall back to shorter prefixes.
+        return {};
     }
 
     return {};
@@ -260,7 +256,8 @@ bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
         fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
     }
 
-    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    // The notifier runs on the GUI thread, so keep dispatcher reads nonblocking.
+    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
     if (socketFd < 0) {
         fmWarning() << "VfsMonitor: failed to create dispatcher socket:" << std::strerror(errno);
         return false;
@@ -292,136 +289,142 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
         return;
     }
 
-    DispatchEvent event {};
-    ssize_t received = -1;
-    do {
-        received = ::recv(socketFd, &event, sizeof(event), 0);
-    } while (received < 0 && errno == EINTR);
-
-    if (received == 0) {
-        fmWarning() << "VfsMonitor: event dispatcher connection closed";
-        if (notifier) {
-            notifier->setEnabled(false);
-        }
-        ::close(socketFd);
-        socketFd = -1;
-        return;
-    }
-
-    if (received < 0) {
-        if (errno != EAGAIN && errno != EWOULDBLOCK) {
-            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
-        }
-        return;
-    }
-
+    auto *q = q_ptr;
     constexpr size_t kMinMessageSize = offsetof(DispatchEvent, eventPath) + 1;
-    if (static_cast<size_t>(received) < kMinMessageSize) {
-        fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
-        return;
-    }
 
-    event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+    // Drain all queued packets for this wakeup so the notifier stays level-safe.
+    while (true) {
+        DispatchEvent event {};
+        ssize_t received = -1;
+        do {
+            received = ::recv(socketFd, &event, sizeof(event), 0);
+        } while (received < 0 && errno == EINTR);
 
-    const int act = event.action;
-    const uint32_t cookie = event.cookie;
-    const char *pathCStr = event.eventPath;
-
-    if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
-        return;
-    }
-
-    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
-        if (!initMountPoints()) {
-            fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
-        }
-        return;
-    }
-
-    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
-        QString fullPath = resolveAndFilterFullPath(pathCStr);
-        if (fullPath.isNull())
+        if (received == 0) {
+            fmWarning() << "VfsMonitor: event dispatcher connection closed";
+            if (notifier) {
+                notifier->setEnabled(false);
+            }
+            ::close(socketFd);
+            socketFd = -1;
             return;
+        }
+
+        if (received < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return;
+            }
+
+            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
+            return;
+        }
+
+        if (static_cast<size_t>(received) < kMinMessageSize) {
+            fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
+            continue;
+        }
+
+        event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+
+        const int act = event.action;
+        const uint32_t cookie = event.cookie;
+        const char *pathCStr = event.eventPath;
+
+        if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+            continue;
+        }
+
+        if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
+            if (!initMountPoints()) {
+                fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
+            }
+            continue;
+        }
+
+        if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (fullPath.isNull())
+                continue;
+
+            auto [parentPath, name] = splitPath(fullPath);
+            RenameFromInfo info;
+            info.path = parentPath;
+            info.name = name;
+            info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
+            pendingRenames.insert(cookie, info);
+            continue;
+        }
+
+        if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
+            const bool isDir = (act == ACT_RENAME_TO_FOLDER);
+            auto it = pendingRenames.find(cookie);
+            if (it != pendingRenames.end()) {
+                QString fullPath = resolveAndFilterFullPath(pathCStr);
+                if (!fullPath.isNull()) {
+                    auto [parentPath, name] = splitPath(fullPath);
+                    if (isDir)
+                        Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
+                    else
+                        Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
+                } else {
+                    if (isDir)
+                        Q_EMIT q->directoryDeleted(it->path, it->name);
+                    else
+                        Q_EMIT q->fileDeleted(it->path, it->name);
+                }
+                pendingRenames.erase(it);
+            } else {
+                QString fullPath = resolveAndFilterFullPath(pathCStr);
+                if (!fullPath.isNull()) {
+                    auto [parentPath, name] = splitPath(fullPath);
+                    if (isDir)
+                        Q_EMIT q->directoryCreated(parentPath, name);
+                    else
+                        Q_EMIT q->fileCreated(parentPath, name);
+                }
+            }
+            continue;
+        }
+
+        const QString fullPath = resolveAndFilterFullPath(pathCStr);
+        if (fullPath.isNull()) {
+            continue;
+        }
 
         auto [parentPath, name] = splitPath(fullPath);
-        RenameFromInfo info;
-        info.path = parentPath;
-        info.name = name;
-        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
-        pendingRenames.insert(cookie, info);
-        return;
-    }
 
-    auto *q = q_ptr;
-    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
-        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
-        auto it = pendingRenames.find(cookie);
-        if (it != pendingRenames.end()) {
-            QString fullPath = resolveAndFilterFullPath(pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
-                else
-                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
-            } else {
-                if (isDir)
-                    Q_EMIT q->directoryDeleted(it->path, it->name);
-                else
-                    Q_EMIT q->fileDeleted(it->path, it->name);
-            }
-            pendingRenames.erase(it);
-        } else {
-            QString fullPath = resolveAndFilterFullPath(pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryCreated(parentPath, name);
-                else
-                    Q_EMIT q->fileCreated(parentPath, name);
-            }
+        switch (act) {
+        case ACT_NEW_FILE:
+        case ACT_NEW_LINK:
+        case ACT_NEW_SYMLINK:
+            Q_EMIT q->fileCreated(parentPath, name);
+            break;
+        case ACT_NEW_FOLDER:
+            Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        case ACT_DEL_FILE:
+            Q_EMIT q->fileDeleted(parentPath, name);
+            break;
+        case ACT_DEL_FOLDER:
+            Q_EMIT q->directoryDeleted(parentPath, name);
+            break;
+        case ACT_RENAME_FILE:
+            Q_EMIT q->fileCreated(parentPath, name);
+            break;
+        case ACT_RENAME_FOLDER:
+            Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        default:
+            break;
         }
-        return;
-    }
 
-    const QString fullPath = resolveAndFilterFullPath(pathCStr);
-    if (fullPath.isNull()) {
-        return;
-    }
-
-    auto [parentPath, name] = splitPath(fullPath);
-
-    switch (act) {
-    case ACT_NEW_FILE:
-    case ACT_NEW_LINK:
-    case ACT_NEW_SYMLINK:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-    case ACT_NEW_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-    case ACT_DEL_FILE:
-        Q_EMIT q->fileDeleted(parentPath, name);
-        break;
-    case ACT_DEL_FOLDER:
-        Q_EMIT q->directoryDeleted(parentPath, name);
-        break;
-    case ACT_RENAME_FILE:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-    case ACT_RENAME_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-    default:
-        break;
-    }
-
-    // Clean up orphaned RENAME_FROM entries.
-    static constexpr int kPendingRenameCleanupThreshold = 1000;
-    if (pendingRenames.size() > kPendingRenameCleanupThreshold) {
-        fmWarning() << "VfsMonitor: pending rename table too large ("
-                    << pendingRenames.size() << "), clearing";
-        pendingRenames.clear();
+        // Clean up orphaned RENAME_FROM entries.
+        static constexpr int kPendingRenameCleanupThreshold = 1000;
+        if (pendingRenames.size() > kPendingRenameCleanupThreshold) {
+            fmWarning() << "VfsMonitor: pending rename table too large ("
+                        << pendingRenames.size() << "), clearing";
+            pendingRenames.clear();
+        }
     }
 }
 

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
@@ -16,16 +16,16 @@ SERVICETEXTINDEX_BEGIN_NAMESPACE
 class VfsMonitorFileSystemWatcherPrivate;
 
 // VfsMonitorFileSystemWatcher: File system watcher using deepin-anything
-// vfs_monitor kernel module via Linux Generic Netlink multicast.
+// event dispatcher socket exposed by deepin-anything-server.
 //
-// Receives global file system events (create, delete, move) from the kernel,
-// covering all mounted filesystems without the need for recursive inotify watches.
-// File close events (IN_CLOSE_WRITE) are NOT provided -- use InotifyFileSystemWatcher
-// for those.
+// Receives global file system events (create, delete, move) forwarded by
+// deepin-anything-server from /run/deepin-anything/event-dispatcher.sock.
+// File close events (IN_CLOSE_WRITE) are NOT provided -- use
+// InotifyFileSystemWatcher for those.
 //
 // Usage:
 //   auto *watcher = VfsMonitorFileSystemWatcher::create(rootPaths, excludePredicate, parent);
-//   if (watcher) { ... }  // kernel module available
+//   if (watcher) { ... }  // event dispatcher available
 //   // else: fallback to inotify-only mode
 class VfsMonitorFileSystemWatcher : public QObject
 {
@@ -35,13 +35,14 @@ class VfsMonitorFileSystemWatcher : public QObject
 
 public:
     // Predicate for path exclusion. Return true to suppress the event.
-    // Called from the netlink callback thread context (main thread via Qt event loop).
+    // Called from the main thread via Qt event loop.
     using PathExcludePredicate = std::function<bool(const QString &fullPath)>;
 
     ~VfsMonitorFileSystemWatcher() override;
 
-    // Factory method: attempts to connect to the vfsmonitor Generic Netlink family.
-    // Returns nullptr if the kernel module is not available (graceful degradation).
+    // Factory method: attempts to connect to the deepin-anything event
+    // dispatcher socket. Returns nullptr if the dispatcher is not available
+    // (graceful degradation).
     static VfsMonitorFileSystemWatcher *create(const QStringList &rootPaths,
                                                PathExcludePredicate excludePredicate,
                                                QObject *parent = nullptr);

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -11,9 +11,8 @@
 #include <QHash>
 #include <QStringList>
 
+#include <cstdint>
 #include <sys/types.h>
-
-struct nl_sock;
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
@@ -24,20 +23,6 @@ struct RenameFromInfo
     QString name;
     bool isDirectory { false };
 };
-
-// Netlink attribute indices (matching vfs_genl.h)
-enum VfsMonitorAttr : int {
-    VFSMONITOR_A_UNSPEC = 0,
-    VFSMONITOR_A_ACT,
-    VFSMONITOR_A_COOKIE,
-    VFSMONITOR_A_MAJOR,
-    VFSMONITOR_A_MINOR,
-    VFSMONITOR_A_PATH,
-    VFSMONITOR_A_UID,
-    VFSMONITOR_A_TGID,
-    __VFSMONITOR_A_MAX
-};
-#define VFSMONITOR_A_MAX (__VFSMONITOR_A_MAX - 1)
 
 // Event action constants (matching vfs_change_consts.h)
 enum VfsMonitorAct : uint8_t {
@@ -67,12 +52,13 @@ public:
                                        VfsMonitorFileSystemWatcher *qq);
     ~VfsMonitorFileSystemWatcherPrivate();
 
-    bool initNetlink();
-    void handleNetlinkMessage();
+    bool initDispatcher();
+    void handleSocketMessage();
 
-    // Reconstruct full path from relative path + device, then check against
-    // rootPaths and excludePredicate. Returns null if filtered out.
-    QString resolveAndFilterFullPath(dev_t deviceId, const char *relativePath) const;
+    // The event dispatcher sends absolute paths, but they may use a different
+    // mount alias than the monitored root path. This helper normalizes across
+    // same-device mount aliases before applying rootPaths and excludePredicate.
+    QString resolveAndFilterFullPath(const char *absolutePath) const;
 
     static QPair<QString, QString> splitPath(const QString &fullPath);
 
@@ -81,22 +67,13 @@ public:
     QStringList rootPaths;
     VfsMonitorFileSystemWatcher::PathExcludePredicate excludePredicate;
 
-    nl_sock *nlSock { nullptr };
+    int socketFd { -1 };
     QSocketNotifier *notifier { nullptr };
 
     QHash<uint32_t, RenameFromInfo> pendingRenames;
-
-    // dev_t -> sorted mount point list (longest first).
     QHash<dev_t, QStringList> mountPoints;
-    QHash<dev_t, QStringList> childMountPoints;
-    bool lowerFsExists { false };
-
-    // Set to true when an ACT_MOUNT/ACT_UNMOUNT event is received, cleared
-    // after initMountPoints() rebuilds the cache in handleNetlinkMessage().
-    bool mountPointsDirty { false };
 
     bool initMountPoints();
-    bool isLowerFsEvent(dev_t deviceId, const QString &fullPath) const;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -10,6 +10,7 @@
 #include <QSocketNotifier>
 #include <QHash>
 #include <QStringList>
+#include <QVector>
 
 #include <cstdint>
 #include <sys/types.h>
@@ -22,6 +23,12 @@ struct RenameFromInfo
     QString path;
     QString name;
     bool isDirectory { false };
+};
+
+struct MountPointAlias
+{
+    dev_t deviceId { 0 };
+    QString mountPoint;
 };
 
 // Event action constants (matching vfs_change_consts.h)
@@ -72,6 +79,7 @@ public:
 
     QHash<uint32_t, RenameFromInfo> pendingRenames;
     QHash<dev_t, QStringList> mountPoints;
+    QVector<MountPointAlias> orderedMountPoints;
 
     bool initMountPoints();
 };


### PR DESCRIPTION
Changed vfsmonitor implementation from using netlink kernel interface to
UNIX domain socket with deepin-anything event dispatcher. This removes
dependency on libnl and makes the implementation more straightforward
by:
1. Replacing netlink protocol parsing with simple socket messages
2. Simplifying mount point tracking code
3. Removing device ID and child mount tracking (handled by dispatcher)
4. Using fixed path socket for event delivery
5. Making error handling more robust with standard UNIX socket APIs

The change was made because:
1. Netlink implementation was complex and prone to error
2. New approach provides more consistent event delivery
3. Removes kernel module dependency
4. Reduces code complexity and maintenance overhead
5. Better aligns with deepin-anything architecture evolution

Log: Changed vfsmonitor implementation to use deepin-anything socket
instead of netlink interface

Influence:
1. Verify file system events are still properly detected
2. Test with various file operations (create, delete, rename)
3. Verify mount/unmount handling works correctly
4. Check performance with high event volumes
5. Test fallback to inotify when dispatcher unavailable
6. Verify no regression in excluded path handling

refactor: 从 netlink 切换为 socket 接收 deepin-anything 事件

将 vfsmonitor 实现从使用 netlink 内核接口改为使用 UNIX domain socket 接
收 deepin-anything 事件分发器的数据。主要变更包括:
1. 用简单的 socket 消息取代 netlink 协议解析
2. 简化挂载点跟踪代码
3. 移除设备 ID 和子挂载点跟踪(由分发器处理)
4. 使用固定路径的 socket 接收事件
5. 使用标准 UNIX socket API 实现更健壮的错误处理

修改原因:
1. 原 netlink 实现复杂且容易出错
2. 新方法提供更稳定的事件传递
3. 去除内核模块依赖
4. 降低代码复杂度和维护成本
5. 更好地适应 deepin-anything 架构演进

Log: 将 vfsmonitor 实现改为使用 deepin-anything 的 socket 接口替代
netlink

影响范围:
1. 验证文件系统事件仍能被正确检测
2. 测试各种文件操作(创建、删除、重命名)
3. 验证挂载/卸载处理正常工作
4. 检查高事件量情况下的性能
5. 测试分发器不可用时的 inotify 回退
6. 确保路径排除功能没有退化
