### PR TITLE
chore: bump version to 6.5.160

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+dde-file-manager (6.5.160) unstable; urgency=medium
+
+  * fix(preview): resolve filename/resolution overlap in image preview status bar
+  * fix: fix potential crash in FileView destructor
+  * fix(textindex): add OcrIndex path to service manager idle policy
+  * fix(recent): cannot open recent:// url in cmd if plugin is lazy loaded
+  * fix(filedialog): keep recent hidden in save dialog on config change
+  * fix(recent): register watcher for recent scheme to enable view refresh
+  * fix: optimize share removal and permission management
+  * fix: improve path display for file conflict messages
+  * fix: improve search input handling robustness
+  * fix: properly handle selection state during model teardown
+  * fix(sidebar): avoid stale drop targets during external drags
+  * fix(burn): show error details in erase failure dialog
+  * refactor: switch from netlink to socket for deepin-anything events
+  * fix: improve mount point resolution in filesystem watcher
+  * fix: correct desktop available geometry on treeland fractional scaling
+  * fix: keep desktop canvas origin for top and left dock
+  * fix(diskencrypt): validate device encryption status before resuming operations
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * fix: reposition window near cursor on last tab tear-off
+  * fix(image-preview): support preview for formats with invalid size() like icns
+  * fix(thumbnail): support thumbnails for image formats with invalid size() like icns
+  * ci(cppcheck): bump actions/checkout to v7 and enable unsafe pr checkout
+  * fix(titlebar): stabilize virtual keyboard display
+  * fix(propertydialog): use D-Bus SystemInfo for installed memory size
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 24 Jul 2026 13:04:08 +0800
+
 dde-file-manager (6.5.151) unstable; urgency=medium
 
   * refactor: replace thread termination with _exit for clean shutdown


### PR DESCRIPTION
6.5.160

Log:

## Summary by Sourcery

Chores:
- Align Debian packaging metadata with version 6.5.160.