### PR TITLE
feat: add configurable search and exec run

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.operations.json
+++ b/assets/configs/org.deepin.dde.file-manager.operations.json
@@ -34,6 +34,17 @@
             "description":"Open this configuration and report the results of the paste event to the specified location.",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "dfm.show.run.exec": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "Show run exec file",
+            "name[zh_CN]": "显示/隐藏双击可执行文件时的\"运行\"和\"在终端中运行\"按钮",
+            "description[zh_CN]": "显示/隐藏双击可执行文件时的\"运行\"和\"在终端中运行\"按钮",
+            "description": "Show/hide the 'Run' and 'Run in Terminal' buttons when double clicking on an executable file",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/assets/configs/org.deepin.dde.file-manager.search.json
+++ b/assets/configs/org.deepin.dde.file-manager.search.json
@@ -67,6 +67,17 @@
             "description":"Used to determine whether the search authorization experience hint has already been handled",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "dfm.enable.search": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "Search enable",
+            "name[zh_CN]": "搜索是否可用",
+            "description[zh_CN]": "搜索是否可用",
+            "description": "Search enable",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
+++ b/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
@@ -14,6 +14,8 @@ inline constexpr char kPluginsDConfName[] { "org.deepin.dde.file-manager.plugins
 inline constexpr char kViewDConfName[] { "org.deepin.dde.file-manager.view" };
 inline constexpr char kAnimationDConfName[] { "org.deepin.dde.file-manager.animation" };
 inline constexpr char kDesktopDConfName[] { "org.deepin.dde.file-manager.desktop" };
+inline constexpr char kSearchDConfName[] { "org.deepin.dde.file-manager.search" };
+inline constexpr char kOperationsDConfName[] { "org.deepin.dde.file-manager.operations" };
 }   // namespace ConfigPath
 
 /*!
@@ -27,6 +29,8 @@ inline constexpr char kCunstomFixedTabs[] { "dfm.custom.fixedtab" };
 inline constexpr char kPinnedTabs[] { "dfm.pinned.tabs" };
 inline constexpr char kDetailViewRemoteImageMaxSize[] { "dfm.detailview.remote.image.maxsize" };
 inline constexpr char kKeyCanvasInputMethod[] { "enableCanvasInputMethod" };
+inline constexpr char kConfigEnableSearch[] { "dfm.enable.search" };
+inline constexpr char kShowRunExec[] { "dfm.show.run.exec" };
 }   // namespace BaseConfig
 
 /*!

--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -21,6 +21,8 @@
 #include <dfm-base/utils/networkutils.h>
 #include <dfm-base/dfm_event_defines.h>
 #include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/configs/dconfig/global_dconf_defines.h>
 #include <dfm-base/utils/protocolutils.h>
 
 #include <dfm-io/doperator.h>
@@ -55,6 +57,8 @@ extern "C" {
 
 using namespace dfmbase;
 using namespace GlobalServerDefines;
+using namespace GlobalDConfDefines::ConfigPath;
+using namespace GlobalDConfDefines::BaseConfig;
 
 LocalFileHandler::LocalFileHandler()
     : d(new LocalFileHandlerPrivate(this))
@@ -1392,6 +1396,9 @@ bool LocalFileHandlerPrivate::handleExecutableFile(const QUrl &fileUrl, bool *re
         qCWarning(logDFMBase) << "Invalid parameters to handleExecutableFile";
         return false;
     }
+
+    if (!DConfigManager::instance()->value(kOperationsDConfName, kShowRunExec, true).toBool())
+        return false;
 
     // Handle executable scripts
     if (isExecutableScript(fileUrl.path())) {

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -196,7 +196,8 @@ void TitleBarWidget::handleSplitterAnimation(const QVariant &position)
 
 void TitleBarWidget::handleHotkeyCtrlF()
 {
-    searchEditWidget->activateEdit();
+    if (searchEditWidget->isVisible())
+        searchEditWidget->activateEdit();
 }
 
 void TitleBarWidget::handleHotkeyCtrlL()
@@ -339,6 +340,8 @@ void TitleBarWidget::initializeUi()
     // search widget
     searchEditWidget = new SearchEditWidget(this);
     searchEditWidget->setFixedHeight(30);
+    if (!DConfigManager::instance()->value(kSearchDConfName, kConfigEnableSearch, true).toBool())
+        searchEditWidget->setVisible(false);
 
     // option button
     optionButtonBox = new OptionButtonBox(this);
@@ -444,6 +447,13 @@ void TitleBarWidget::initConnect()
     });
 
     connect(this, &TitleBarWidget::currentUrlChanged, searchEditWidget, &SearchEditWidget::onUrlChanged);
+
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, [this](const QString &config, const QString &key) {
+        if (config == kSearchDConfName && key == kConfigEnableSearch) {
+            bool enabled = DConfigManager::instance()->value(kSearchDConfName, kConfigEnableSearch, true).toBool();
+            searchEditWidget->setVisible(enabled);
+        }
+    });
 
     connect(bottomBar, &TabBar::newTabCreated, this, &TitleBarWidget::onTabCreated);
     connect(bottomBar, &TabBar::requestCreateView, this, &TitleBarWidget::handleCreateView);


### PR DESCRIPTION
Add two new DConfig options: `dfm.enable.search` to control visibility
of
the search widget, and `dfm.show.run.exec` to enable/disable the "Run"
and "Run in Terminal" dialogs for executable files. The search widget
visibility can be toggled dynamically at runtime via DConfig value
change
signal. The exec run dialog is controlled at the point of handling
executable files.

Log: Added configurable search and executable run buttons

Influence:
1. Test search widget visibility when toggling `dfm.enable.search` in
DConfig
2. Verify Ctrl+F hotkey behavior when search is hidden (should not
activate)
3. Test double-clicking an executable file with `dfm.show.run.exec` set
to false
4. Verify that the dialog does not appear when disabled
5. Test dynamic toggling of search widget via DConfig value change
signal
6. Ensure existing functionality remains unchanged when both options are
enabled (default)

feat: 添加可配置的搜索和可执行文件运行按钮

新增两个 DConfig 选项：`dfm.enable.search` 用于控制搜索框的可见性，
`dfm.show.run.exec` 用于启用/禁用双击可执行文件时弹出的“运行”和“在终端中
运行”对话框。
搜索框的可见性可以通过 DConfig 值变化信号动态切换，运行对话框在处理可执
行文件时控制。

Log: 新增可配置的搜索和可执行文件运行按钮

Influence:
1. 在 DConfig 中切换 `dfm.enable.search` 后测试搜索框的可见性
2. 验证搜索框隐藏时 Ctrl+F 快捷键的行为（不应激活搜索框）
3. 测试将 `dfm.show.run.exec` 设置为 false 后双击可执行文件
4. 验证禁用时不弹出对话框
5. 测试通过 DConfig 值变化信号动态切换搜索框
6. 确保两个选项默认启用时现有功能不变

TASK: https://pms.uniontech.com/task-view-393123.html

## Summary by Sourcery

Introduce configurable search widget visibility and executable run dialog behavior controlled by new DConfig options, including runtime toggling of search visibility and guarding executable handling with the new settings.

New Features:
- Add DConfig-controlled visibility for the title bar search widget via dfm.enable.search.
- Add DConfig option dfm.show.run.exec to enable or disable run dialogs when opening executable files.

Enhancements:
- Make the Ctrl+F hotkey activate search only when the search widget is visible.
- React to DConfig value change signals to dynamically show or hide the search widget at runtime.

Build:
- Register new DConf config paths and keys for search and file operations, with corresponding JSON config files.