### PR TITLE
feat: integrate file close events into vfs monitor mode

### DIFF
--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -256,6 +256,30 @@ TEST_F(TestVfsMonitorFileSystemWatcher, SymlinkCreationEmitsFileCreated)
     EXPECT_EQ(args.at(1).toString(), "symlink_link.txt");
 }
 
+// ========== 文件写入关闭 ==========
+
+TEST_F(TestVfsMonitorFileSystemWatcher, FileClosedSignal)
+{
+    ASSERT_NE(watcher, nullptr);
+
+    QSignalSpy spy(watcher, &VfsMonitorFileSystemWatcher::fileClosed);
+    ASSERT_TRUE(spy.isValid());
+
+    // 创建文件并写入内容后关闭，触发 ACT_CLOSE_WRITE_FILE
+    QString filePath = testDir->path() + "/closewrite.txt";
+    QFile file(filePath);
+    file.open(QIODevice::WriteOnly);
+    file.write("close write test");
+    file.close();
+
+    int count = waitForSignal(spy);
+    ASSERT_GT(count, 0) << "fileClosed signal not received within timeout";
+
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), testDir->path());
+    EXPECT_EQ(args.at(1).toString(), "closewrite.txt");
+}
+
 // ========== 路径排除 ==========
 
 TEST_F(TestVfsMonitorFileSystemWatcher, ExcludePredicateFiltersEvents)

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -106,8 +106,6 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
         return false;
     }
 
-    watcher.reset(new InotifyFileSystemWatcher());
-
     // Use static factory method to create configured blacklist matcher
     // BEFORE creating VfsMonitor watcher (needs it for excludePredicate).
     excludeMatcher = PathExcludeMatcher::createForIndex();
@@ -122,13 +120,13 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
     vfsMonitorAvailable = (vfsWatcher != nullptr);
 
     if (vfsMonitorAvailable) {
-        // deepin-anything dispatcher mode: create/delete/move from vfs, fileClosed from inotify.
-        // Restrict inotify to IN_CLOSE_WRITE only, reducing kernel event delivery.
-        watcher->setWatchFlags(InotifyFileSystemWatcher::WatchFlag::FileClose);
+        // VfsMonitor handles all events including ACT_CLOSE_WRITE_FILE,
+        // so InotifyFileSystemWatcher is not needed.
         setupVfsMonitorConnections();
-        fmInfo() << "FSMonitor: Using dual watcher mode (deepin-anything dispatcher + inotify fallback)";
+        fmInfo() << "FSMonitor: Using vfs monitor mode (deepin-anything dispatcher)";
     } else {
-        // inotify-only mode: all signals from InotifyFileSystemWatcher (existing behavior).
+        // Inotify-only mode: create InotifyFileSystemWatcher for all events.
+        watcher.reset(new InotifyFileSystemWatcher());
         setupWatcherConnections();
         fmInfo() << "FSMonitor: Using inotify-only mode (deepin-anything dispatcher not available)";
     }
@@ -382,7 +380,7 @@ bool FSMonitorPrivate::addWatchForDirectory(const QString &path)
     }
 
     // Add to watcher
-    if (watcher->addPath(path)) {
+    if (watcher && watcher->addPath(path)) {
         watchedDirectories.insert(path);
         //   fmDebug() << "FSMonitor: Added watch for directory:" << path;
         return true;
@@ -399,7 +397,8 @@ void FSMonitorPrivate::removeWatchForDirectory(const QString &path)
     }
 
     if (watchedDirectories.contains(path)) {
-        watcher->removePath(path);
+        if (watcher)
+            watcher->removePath(path);
         watchedDirectories.remove(path);
         fmDebug() << "FSMonitor: Removed watch for directory:" << path;
     }
@@ -443,7 +442,7 @@ void FSMonitorPrivate::setupWatcherConnections()
 
 void FSMonitorPrivate::setupVfsMonitorConnections()
 {
-    // Create/delete/move events from VfsMonitorFileSystemWatcher.
+    // All events come from VfsMonitorFileSystemWatcher (create/delete/move/close-write).
     // The kernel already distinguishes files from directories, so we can
     // emit the specific directory* signals directly without QFileInfo checks.
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileCreated,
@@ -454,7 +453,7 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileDeleted,
                      q_ptr, [this](const QString &path, const QString &name) {
                           handleFileDeleted(path, name);
-                     });
+                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileMoved,
                      q_ptr, [this](const QString &fromPath, const QString &fromName,
@@ -462,24 +461,19 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
                          handleFileMoved(fromPath, fromName, toPath, toName);
                      });
 
+    QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileClosed,
+                     q_ptr, [this](const QString &path, const QString &name) {
+                         handleFileClosed(path, name);
+                     });
+
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryCreated,
                      q_ptr, [this](const QString &path, const QString &name) {
-                         // VfsMonitor already knows it's a directory -- emit directly.
                          Q_EMIT q_ptr->directoryCreated(path, name);
-
-                         // Add new directory to inotify watch for fileClosed support.
-                         QString fullPath = QDir(path).absoluteFilePath(name);
-                         if (!isSymbolicLink(fullPath) && !shouldExcludePath(fullPath)) {
-                             addDirectoryRecursively(fullPath);
-                         }
                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryDeleted,
                      q_ptr, [this](const QString &path, const QString &name) {
                          Q_EMIT q_ptr->directoryDeleted(path, name);
-
-                         QString fullPath = QDir(path).absoluteFilePath(name);
-                         removeWatchForDirectory(fullPath);
                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryMoved,
@@ -489,20 +483,6 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
                                    << "->" << toPath << "/" << toName;
 
                          Q_EMIT q_ptr->directoryMoved(fromPath, fromName, toPath, toName);
-
-                         QString fromFullPath = QDir(fromPath).absoluteFilePath(fromName);
-                         removeWatchForDirectory(fromFullPath);
-
-                         QString toFullPath = QDir(toPath).absoluteFilePath(toName);
-                         if (!toPath.isEmpty() && !isSymbolicLink(toFullPath) && !shouldExcludePath(toFullPath)) {
-                             addDirectoryRecursively(toFullPath);
-                         }
-                     });
-
-    // fileClosed always comes from InotifyFileSystemWatcher (IN_CLOSE_WRITE).
-    QObject::connect(watcher.data(), &InotifyFileSystemWatcher::fileClosed,
-                     q_ptr, [this](const QString &path, const QString &name) {
-                         handleFileClosed(path, name);
                      });
 }
 
@@ -656,7 +636,7 @@ void FSMonitorPrivate::handleDirectoriesBatch(const QStringList &paths)
         if (!watchedDirectories.contains(path) && !shouldExcludePath(path)) {
             qApp->processEvents();
             // Add each path individually to avoid blocking from addPaths
-            if (watcher->addPath(path)) {
+            if (watcher && watcher->addPath(path)) {
                 watchedDirectories.insert(path);
                 addedCount++;
             } else {

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -64,7 +64,7 @@ public:
     // Parse and connect watcher signals (inotify-only fallback mode)
     void setupWatcherConnections();
 
-    // Connect deepin-anything watcher signals (create/delete/move from vfs, fileClosed from inotify)
+    // Connect vfs monitor signals (all events from deepin-anything dispatcher)
     void setupVfsMonitorConnections();
 
     // Set up the worker thread and connections

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -330,7 +330,7 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
         const uint32_t cookie = event.cookie;
         const char *pathCStr = event.eventPath;
 
-        if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+        if (act < ACT_NEW_FILE || act > ACT_CLOSE_WRITE_FILE) {
             continue;
         }
 
@@ -413,6 +413,9 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
             break;
         case ACT_RENAME_FOLDER:
             Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        case ACT_CLOSE_WRITE_FILE:
+            Q_EMIT q->fileClosed(parentPath, name);
             break;
         default:
             break;

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
@@ -18,10 +18,9 @@ class VfsMonitorFileSystemWatcherPrivate;
 // VfsMonitorFileSystemWatcher: File system watcher using deepin-anything
 // event dispatcher socket exposed by deepin-anything-server.
 //
-// Receives global file system events (create, delete, move) forwarded by
-// deepin-anything-server from /run/deepin-anything/event-dispatcher.sock.
-// File close events (IN_CLOSE_WRITE) are NOT provided -- use
-// InotifyFileSystemWatcher for those.
+// Receives global file system events (create, delete, move, close-write)
+// forwarded by deepin-anything-server from
+// /run/deepin-anything/event-dispatcher.sock.
 //
 // Usage:
 //   auto *watcher = VfsMonitorFileSystemWatcher::create(rootPaths, excludePredicate, parent);
@@ -56,6 +55,7 @@ Q_SIGNALS:
     void directoryDeleted(const QString &path, const QString &name);
     void directoryMoved(const QString &fromPath, const QString &fromName,
                         const QString &toPath, const QString &toName);
+    void fileClosed(const QString &path, const QString &name);
 
 private:
     explicit VfsMonitorFileSystemWatcher(const QStringList &rootPaths,

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -46,7 +46,8 @@ enum VfsMonitorAct : uint8_t {
     ACT_RENAME_FROM_FOLDER = 10,
     ACT_RENAME_TO_FOLDER = 11,
     ACT_MOUNT = 12,
-    ACT_UNMOUNT = 13
+    ACT_UNMOUNT = 13,
+    ACT_CLOSE_WRITE_FILE = 14
 };
 
 class VfsMonitorFileSystemWatcherPrivate


### PR DESCRIPTION
Enhanced FSMonitor to handle file close events natively through
VfsMonitor instead of using a dual-watcher approach. Previously,
when deepin-anything dispatcher was available, the system
used a combined mode where create/delete/move events came from
VfsMonitorFileSystemWatcher, but file close (IN_CLOSE_WRITE)
events required a separate InotifyFileSystemWatcher instance. Now
VfsMonitorFileSystemWatcher processes ACT_CLOSE_WRITE_FILE events from
the socket and emits a fileClosed signal, eliminating the need for
parallel inotify watching when deepin-anything is active.

Key changes:
1. Added ACT_CLOSE_WRITE_FILE enum and handling in
VfsMonitorFileSystemWatcher
2. Updated FSMonitor to use only VfsMonitor when available, removing
InotifyFileSystemWatcher dependency in this mode
3. Removed directory watch management code from VfsMonitor signal
connections since all events including directory creation/deletion are
now handled directly
4. Added unit test for fileClosed signal in
TestVfsMonitorFileSystemWatcher
5. Updated logging messages to reflect single-watcher architecture

Benefits:
- Simplified architecture with single event source
- Reduced system resource usage by eliminating redundant inotify watches
- Consistent event delivery through one channel
- Cleaner code structure and maintenance

Influence:
1. Test file close event detection when VfsMonitor is available
2. Verify all file operations (create, delete, move, close) work in vfs
monitor mode
3. Test fallback to inotify-only mode when deepin-anything is
unavailable
4. Verify proper handling of directory operations without redundant
inotify watch adjustments
5. Test signal emission timing and consistency for file close events
6. Verify path exclusion logic still works correctly with both modes

feat: 将文件关闭事件集成到 vfs 监控模式中

增强了 FSMonitor，使其能够通过 VfsMonitor 本地处理文件关闭事件，无需
使用双观察者方法。之前，当 deepin-anything 调度器可用时，系统使用组合
模式：创建/删除/移动事件来自 VfsMonitorFileSystemWatcher，但文件关闭
（IN_CLOSE_WRITE）事件需要一个单独的 InotifyFileSystemWatcher 实例。现
在，VfsMonitorFileSystemWatcher 处理来自套接字的 ACT_CLOSE_WRITE_FILE
事件并发出 fileClosed 信号，从而在 deepin-anything 激活时消除了并行
inotify 监视的需求。

主要更改：
1. 在 VfsMonitorFileSystemWatcher 中添加了 ACT_CLOSE_WRITE_FILE 枚举和处
理逻辑
2. 更新 FSMonitor，使其在可用时仅使用 VfsMonitor，移除了该模式下对
InotifyFileSystemWatcher 的依赖
3. 从 VfsMonitor 信号连接中移除了目录监视管理代码，因为现在所有事件（包
括目录创建/删除）都由其直接处理
4. 在 TestVfsMonitorFileSystemWatcher 中添加了 fileClosed 信号的单元测试
5. 更新日志消息以反映单观察者架构

好处：
- 使用单一事件源简化了架构
- 通过消除冗余的 inotify 监视减少了系统资源使用
- 通过单一通道实现一致的事件传递
- 更清晰的代码结构和易于维护

影响：
1. VfsMonitor 可用时，测试文件关闭事件检测
2. 验证 vfs 监控模式下所有文件操作（创建、删除、移动、关闭）是否正常工作
3. 测试 deepin-anything 不可用时的 inotify-only 降级模式
4. 验证无需冗余的 inotify 监视调整，目录操作处理是否正确
5. 测试文件关闭事件的信号发射时序和一致性
6. 验证路径排除逻辑在两种模式下是否仍能正确工作

## Summary by Sourcery

Handle all filesystem events, including file-close, via VfsMonitor when available and simplify FSMonitor’s watcher setup accordingly.

New Features:
- Emit a fileClosed signal from VfsMonitorFileSystemWatcher based on the new ACT_CLOSE_WRITE_FILE event from the deepin-anything dispatcher.

Enhancements:
- Simplify FSMonitor to use only VfsMonitorFileSystemWatcher in vfs monitor mode, removing the dependency on InotifyFileSystemWatcher and related directory watch management.
- Clarify and update logging and comments to reflect the single-watcher vfs monitor architecture.

Tests:
- Add a unit test verifying that VfsMonitorFileSystemWatcher emits fileClosed with correct path and name when a file is written and closed.