### PR TITLE
feat: add configurable device polling and network check

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.mount.json
+++ b/assets/configs/org.deepin.dde.file-manager.mount.json
@@ -45,6 +45,28 @@
             "description":"Configures network protocols that support alias settings",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "checkNetworkAccessable": {
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Check that the target host is accessible before accessing the web directory.",
+            "name[zh_CN]": "访问网络目录前检查目标主机是否可访问。",
+            "description[zh_CN]": "可以有效保证访问目录不会因为网络不通而长时间阻塞。如果远程主机禁用了这些端口的连接，可以关闭此项。",
+            "description": "It can effectively ensure that access to the directory will not be blocked for a long time due to network failure. This can be turned off if the remote host has disabled connections to these ports.",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "deviceUsagePollingInterval": {
+            "value": 10,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Device usage polling interval",
+            "name[zh_CN]": "设备容量轮询间隔",
+            "description[zh_CN]": "轮询设备使用量的时间间隔，单位为秒。较小的值更新更及时，但会消耗更多系统资源。最小值为10秒。",
+            "description": "The interval for polling device usage in seconds. Smaller values provide more timely updates but consume more system resources. Minimum value is 10 seconds.",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
+++ b/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
@@ -16,6 +16,7 @@ inline constexpr char kAnimationDConfName[] { "org.deepin.dde.file-manager.anima
 inline constexpr char kDesktopDConfName[] { "org.deepin.dde.file-manager.desktop" };
 inline constexpr char kSearchDConfName[] { "org.deepin.dde.file-manager.search" };
 inline constexpr char kOperationsDConfName[] { "org.deepin.dde.file-manager.operations" };
+inline constexpr char kMountDConfName[] { "org.deepin.dde.file-manager.mount" };
 }   // namespace ConfigPath
 
 /*!

--- a/src/dfm-base/base/device/private/devicewatcher.cpp
+++ b/src/dfm-base/base/device/private/devicewatcher.cpp
@@ -9,6 +9,7 @@
 #include <dfm-base/base/device/deviceutils.h>
 #include <dfm-base/base/device/deviceproxymanager.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/configs/dconfig/global_dconf_defines.h>
 #include <dfm-base/dbusservice/global_server_defines.h>
 #include <dfm-base/utils/finallyutil.h>
 
@@ -26,6 +27,11 @@
 using namespace dfmbase;
 DFM_MOUNT_USE_NS
 using namespace GlobalServerDefines;
+using namespace GlobalDConfDefines::ConfigPath;
+
+namespace {
+inline constexpr char kKeyDeviceUsagePollingInterval[] { "deviceUsagePollingInterval" };
+}
 
 DeviceWatcher::DeviceWatcher(QObject *parent)
     : QObject(parent), d(new DeviceWatcherPrivate(this))
@@ -44,7 +50,7 @@ void DeviceWatcher::startPollingUsage()
         return;
 
     qCInfo(logDFMBase) << "Starting device usage polling";
-    d->pollingTimer.start(d->kPollingInterval);   // 然后启动定时器
+    d->pollingTimer.start(d->pollingInterval);   // 然后启动定时器
 }
 
 void DeviceWatcher::stopPollingUsage()
@@ -532,5 +538,34 @@ DeviceWatcherPrivate::DeviceWatcherPrivate(DeviceWatcher *qq)
     : QObject(qq), q(qq)
 {
     connect(DevProxyMng, &DeviceProxyManager::devSizeChanged, this, &DeviceWatcherPrivate::updateStorage, Qt::QueuedConnection);
-    DConfigManager::instance()->addConfig("org.deepin.dde.file-manager.mount");
+    DConfigManager::instance()->addConfig(kMountDConfName);
+
+    // 读取 DConfig 配置的轮询间隔
+    int cfgInterval = DConfigManager::instance()->value(kMountDConfName, kKeyDeviceUsagePollingInterval, 10).toInt();
+    // 配置单位为秒，转换为毫秒，并确保不小于最小值
+    pollingInterval = qMax(cfgInterval * 1000, kMinPollingInterval);
+    qCInfo(logDFMBase) << "Device usage polling interval set to" << pollingInterval << "ms";
+
+    // 监听配置变化
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, [this](const QString &config, const QString &key) {
+        if (config == kMountDConfName && key == kKeyDeviceUsagePollingInterval) {
+            onPollingIntervalChanged();
+        }
+    });
+}
+
+void DeviceWatcherPrivate::onPollingIntervalChanged()
+{
+    int cfgInterval = DConfigManager::instance()->value(kMountDConfName, kKeyDeviceUsagePollingInterval, 10).toInt();
+    int newInterval = qMax(cfgInterval * 1000, kMinPollingInterval);
+
+    if (newInterval != pollingInterval) {
+        pollingInterval = newInterval;
+        qCInfo(logDFMBase) << "Device usage polling interval changed to" << pollingInterval << "ms";
+
+        // 如果定时器正在运行，则更新间隔
+        if (pollingTimer.isActive()) {
+            pollingTimer.setInterval(pollingInterval);
+        }
+    }
 }

--- a/src/dfm-base/base/device/private/devicewatcher_p.h
+++ b/src/dfm-base/base/device/private/devicewatcher_p.h
@@ -47,6 +47,7 @@ public:
 private Q_SLOTS:
     void queryUsageAsync();
     void updateStorage(const QString &id, quint64 total, quint64 avai);
+    void onPollingIntervalChanged();
 
 private:
     void queryUsageOfItem(const QVariantMap &itemData, DFMMOUNT::DeviceType type);
@@ -57,7 +58,8 @@ private:
     DeviceWatcher *q { nullptr };
 
     QTimer pollingTimer;
-    const int kPollingInterval = 10000;
+    int pollingInterval { 10000 };
+    static constexpr int kMinPollingInterval { 10000 };
 
     QHash<QString, QVariantMap> allBlockInfos;
     QHash<QString, QVariantMap> allProtocolInfos;

--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -4,6 +4,9 @@
 
 #include "networkutils.h"
 
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/configs/dconfig/global_dconf_defines.h>
+
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <QTcpSocket>
@@ -19,11 +22,13 @@
 #include <libmount.h>
 
 using namespace dfmbase;
+using namespace GlobalDConfDefines::ConfigPath;
 
 static constexpr char kSmbPort[] { "445" };
 static constexpr char kSmbPortOther[] { "139" };
 static constexpr char kFtpPort[] { "21" };
 static constexpr char kSftpPort[] { "22" };
+static constexpr char kCheckNetworkAccessable[] { "checkNetworkAccessable" };
 
 NetworkUtils *NetworkUtils::instance()
 {
@@ -35,6 +40,15 @@ bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, 
 {
     if (host.isEmpty())
         return true;
+
+    auto checkNet = DConfigManager::instance()->value(kMountDConfName, kCheckNetworkAccessable, false).toBool();
+
+    if (!checkNet) {
+        qCInfo(logDFMBase) << "NetworkUtils::checkNetConnection Skip network check." << host << port;
+        return true;
+    }
+
+    qCInfo(logDFMBase) << "NetworkUtils::checkNetConnection net work check host = " << host << ", port = " << port << " !!!";
 
     QTcpSocket conn;
     conn.connectToHost(host, port.toUShort());


### PR DESCRIPTION
1. Add two new DConfig settings to mount config: checkNetworkAccessable
(default true) and deviceUsagePollingInterval (default 10s)
2. Implement runtime configurable device usage polling interval via
DConfig, supporting dynamic changes
3. Add network accessibility check toggle to avoid blocking when host is
unreachable (e.g., firewalled ports)
4. Refactor polling interval from hardcoded constant to configurable
value with minimum 10s protection
5. Update DeviceWatcher to listen for DConfig changes and adjust polling
timer on-the-fly

Log: Added mount-related DConfig options for network accessibility check
and device polling interval

Influence:
1. Verify that setting checkNetworkAccessable to false skips network
checks for SMB/FTP/SFTP hosts
2. Test device usage polling interval changes via DConfig (e.g., set to
20s) and verify timer updates
3. Confirm that changing polling interval while polling is active takes
effect immediately
4. Ensure minimum interval of 10s is enforced even if config sets lower
value
5. Check that existing mounts and network access behavior is unaffected
when config uses defaults
6. Test DConfig persistence across file manager restarts

feat: 添加可配置的设备轮询和网络检查功能

1. 在 mount 配置中添加两个 DConfig 设置：checkNetworkAccessable（默认
true）和 deviceUsagePollingInterval（默认 10 秒）
2. 实现通过 DConfig 动态配置设备容量轮询间隔，并支持运行时变更
3. 添加网络可达性检查开关，当主机不可达（如端口被防火墙阻止）时避免阻塞
访问
4. 将轮询间隔从硬编码常量改为可配置值，并设置最小 10 秒保护
5. 更新 DeviceWatcher 以监听 DConfig 变化，并实时调整轮询定时器

Log: 新增挂载相关的 DConfig 配置项：网络可达性检查与设备轮询间隔

Influence:
1. 验证将 checkNetworkAccessable 设置为 false 后，跳过 SMB/FTP/SFTP 主机
的网络检查
2. 通过 DConfig 修改设备轮询间隔（例如设置为 20 秒），验证定时器更新
3. 确认在轮询活动期间修改间隔后立即生效
4. 确保即使配置了更小的值，轮询间隔仍不小于 10 秒
5. 检查保持默认配置时，现有挂载和网络访问行为不受影响
6. 测试 DConfig 配置在文件管理器重启后保持持久化

TASK: https://pms.uniontech.com/task-view-393123.html

## Summary by Sourcery

Add mount-related DConfig options to control device usage polling interval and toggle network accessibility checks for remote mounts.

New Features:
- Make device usage polling interval configurable via the org.deepin.dde.file-manager.mount DConfig profile with runtime updates and a minimum enforced interval.
- Introduce a DConfig-controlled switch to enable or disable network reachability checks for SMB/FTP/SFTP hosts before connecting.

Enhancements:
- Refine DeviceWatcher to use a dynamic polling interval sourced from DConfig instead of a hardcoded constant and to react to configuration changes on-the-fly.
- Extend global DConfig definitions and mount configuration assets to include the new mount configuration namespace and options.