### PR TITLE
feat(usbrepair): add USB device repair dialog with error code, simula…

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/CMakeLists.txt
+++ b/src/external/dde-dock-plugins/disk-mount/CMakeLists.txt
@@ -32,6 +32,11 @@ qt6_add_dbus_interface(MOUNT_PLUGIN_FILES
     devicemanager_interface
 )
 
+qt6_add_dbus_interface(MOUNT_PLUGIN_FILES
+    "${CMAKE_SOURCE_DIR}/assets/dbus/org.deepin.Filemanager.UsbRepair.xml"
+    usbrepair_interface
+)
+
 add_library(${PROJECT_NAME} SHARED
     ${MOUNT_PLUGIN_FILES}
     ${QRC_RESOURCES}
@@ -55,7 +60,30 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     PkgConfig::LibMount
 )
 
+# Standalone repair dialog executable (runs in its own process because
+# tray-loader cannot create top-level QWidget windows under dde-shell's
+# custom Wayland protocol)
+add_executable(dde-usb-repair-dialog
+    repair_dialog_main.cpp
+    widgets/repairdialog.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/usbrepair_interface.cpp
+    ${QRC_RESOURCES}
+)
+
+set_target_properties(dde-usb-repair-dialog PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ./
+)
+
+target_link_libraries(dde-usb-repair-dialog PRIVATE
+    Qt6::Widgets
+    Qt6::Core
+    Qt6::DBus
+    Dtk6::Widget
+    Dtk6::Gui
+)
+
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib/dde-dock/plugins/system-trays)
+install(TARGETS dde-usb-repair-dialog RUNTIME DESTINATION bin)
 
 dtk_add_config_meta_files(
     APPID "org.deepin.dde.dock"

--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.cpp
@@ -4,12 +4,16 @@
 
 #include "global_server_defines.h"
 #include "dockitemdatamanager.h"
+#include "usbrepairproxy.h"
 #include "utils/dockutils.h"
+#include "widgets/repairdialog.h"
 
 #include <dtkgui_global.h>
 #include <dtkwidget_global.h>
 #include <DDesktopServices>
 #include <QTimer>
+#include <QDBusPendingCallWatcher>
+#include <QProcess>
 #include <QMutex>
 #include <QSet>
 #include <fstab.h>
@@ -40,6 +44,7 @@ DockItemDataManager::DockItemDataManager(QObject *parent)
                                    this));
     connectDeviceManger();
     watchService();
+    connectRepairService();
 }
 
 void DockItemDataManager::onBlockMounted(const QString &id)
@@ -267,7 +272,7 @@ void DockItemDataManager::updateDockVisible()
     qCInfo(logAppDock) << "dock entry visible:" << visible;
 }
 
-void DockItemDataManager::notify(const QString &title, const QString &msg)
+void DockItemDataManager::notify(const QString &title, const QString &msg, int timeout)
 {
     QDBusInterface iface("org.freedesktop.Notifications",
                          "/org/freedesktop/Notifications",
@@ -281,7 +286,7 @@ void DockItemDataManager::notify(const QString &title, const QString &msg)
          << msg
          << QStringList()
          << QVariantMap()
-         << 3000;
+         << timeout;
     iface.asyncCallWithArgumentList("Notify", args);
 }
 
@@ -451,4 +456,289 @@ void DockItemDataManager::refreshUsage()
         qInfo(logAppDock) << "Dock plugin requesting immediate device usage refresh";
         devMng->RefreshDeviceUsage();
     });
+}
+
+void DockItemDataManager::connectRepairService()
+{
+    m_repairProxy = new UsbRepairProxy(this);
+
+    connect(m_repairProxy, &UsbRepairProxy::fsErrorDetected,
+            this, &DockItemDataManager::onFsErrorDetected);
+    connect(m_repairProxy, &UsbRepairProxy::fsErrorCleared,
+            this, &DockItemDataManager::onFsErrorCleared);
+    connect(m_repairProxy, &UsbRepairProxy::repairProgress,
+            this, &DockItemDataManager::onRepairProgress);
+    connect(m_repairProxy, &UsbRepairProxy::repairFinished,
+            this, &DockItemDataManager::onRepairFinished);
+
+    // Monitor notification actions (on session bus)
+    QDBusConnection::sessionBus().connect(
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+        "ActionInvoked",
+        this,
+        SLOT(onNotifyActionInvoked(uint, QString)));
+
+    QDBusConnection::sessionBus().connect(
+        "org.freedesktop.Notifications",
+        "/org/freedesktop/Notifications",
+        "org.freedesktop.Notifications",
+        "NotificationClosed",
+        this,
+        SLOT(onNotifyClosed(uint, uint)));
+}
+
+void DockItemDataManager::onFsErrorDetected(
+    const QString &devicePath,
+    const QString &deviceName,
+    const QString &fsType,
+    const QString &errorType,
+    bool canRepair,
+    const QString &message)
+{
+    qCInfo(logAppDock) << "USB filesystem error detected:" << devicePath
+                       << "fs:" << fsType << "type:" << errorType
+                       << "canRepair:" << canRepair;
+
+    // Store error info for later use (dialog needs it)
+    m_pendingErrors[devicePath] = { deviceName, fsType, errorType, message };
+
+    if (canRepair) {
+        QString title = tr("Detect Device Abnormality, Repair Recommended");
+        QString msg = tr("Your %1 has data errors, possibly caused by unsafe removal!")
+                          .arg(deviceName);
+        QStringList actions;
+        actions << "repair" << tr("Repair Immediately")
+                << "ignore" << tr("Ignore for Now");
+        notifyWithActions(title, msg, actions, devicePath);
+    } else if (errorType == "read_only") {
+        // Hardware read-only: info-only notification, no repair button
+        QString title = tr("Hardware Failure Warning");
+        QString msg = tr("%1 is in hardware write-protected mode.\n"
+                         "Flash memory may be failing. Please back up data immediately.")
+                          .arg(deviceName);
+        notify(title, msg, 15000);  // 15 seconds
+    } else {
+        // Other non-repairable errors (e.g., unknown filesystem)
+        QString title = tr("Device Damaged, Cannot Auto Repair");
+        QString msg = tr("The data structure of %1 is severely damaged and cannot be recognized or repaired by the system. If there are important files inside, please stop using it. It is recommended to use professional data recovery software or seek professional assistance.")
+                          .arg(deviceName);
+        notify(title, msg, 15000);  // 15 seconds
+    }
+}
+
+void DockItemDataManager::onFsErrorCleared(const QString &devicePath)
+{
+    qCInfo(logAppDock) << "USB filesystem error cleared:" << devicePath;
+    m_pendingErrors.remove(devicePath);
+
+    // Find and close the associated notification
+    uint nid = 0;
+    for (auto it = m_notificationToDevice.begin(); it != m_notificationToDevice.end(); ++it) {
+        if (it.value() == devicePath) {
+            nid = it.key();
+            break;
+        }
+    }
+    if (nid > 0) {
+        QDBusInterface iface("org.freedesktop.Notifications",
+                             "/org/freedesktop/Notifications",
+                             "org.freedesktop.Notifications",
+                             QDBusConnection::sessionBus());
+        iface.asyncCall("CloseNotification", nid);
+        m_notificationToDevice.remove(nid);
+    }
+}
+
+void DockItemDataManager::onNotifyActionInvoked(uint notificationId, const QString &action)
+{
+    qCInfo(logAppDock) << "Notification action invoked:" << notificationId << action;
+
+    if (!m_notificationToDevice.contains(notificationId))
+        return;
+
+    QString devicePath = m_notificationToDevice.value(notificationId);
+
+    if (action == "repair") {
+        closeNotification(notificationId);
+
+        auto it = m_pendingErrors.find(devicePath);
+        if (it != m_pendingErrors.end()) {
+            const PendingErrorInfo &info = it.value();
+            QString deviceSize = blocks.contains(devicePath) ?
+                size_format::formatDiskSize(blocks.value(devicePath).totalSize) : "";
+
+            // Launch standalone repair dialog process. The tray-loader process
+            // cannot create top-level QWidget windows under dde-shell's
+            // custom Wayland protocol, so the dialog must run in its own
+            // process as a regular Wayland client.
+            QProcess::startDetached(QStringLiteral("dde-usb-repair-dialog"), {
+                QStringLiteral("-d"), devicePath,
+                QStringLiteral("-n"), info.deviceName,
+                QStringLiteral("-f"), info.fsType,
+                QStringLiteral("-s"), deviceSize
+            });
+        }
+    } else if (action == "ignore") {
+        // User chose to ignore - just clean up
+        closeNotification(notificationId);
+        m_pendingErrors.remove(devicePath);
+    }
+
+    m_notificationToDevice.remove(notificationId);
+}
+
+void DockItemDataManager::onNotifyClosed(uint notificationId, uint reason)
+{
+    Q_UNUSED(reason)
+    // Do NOT remove from m_notificationToDevice here.
+    // The notification daemon may emit NotificationClosed before ActionInvoked
+    // (or in response to the action click), which would clear the map entry
+    // before onNotifyActionInvoked can look it up. Let onNotifyActionInvoked
+    // handle the removal instead.
+}
+
+void DockItemDataManager::notifyWithActions(const QString &title, const QString &msg,
+                                              const QStringList &actions, const QString &devicePath, int timeout)
+{
+    QDBusInterface iface("org.freedesktop.Notifications",
+                         "/org/freedesktop/Notifications",
+                         "org.freedesktop.Notifications",
+                         QDBusConnection::sessionBus());
+    QVariantList args;
+    args << QString("dde-file-manager")
+         << static_cast<uint>(0)
+         << QString("dde-file-manager")
+         << title
+         << msg
+         << actions
+         << QVariantMap()
+         << timeout;
+    QDBusPendingCall async = iface.asyncCallWithArgumentList("Notify", args);
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(async, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, devicePath](QDBusPendingCallWatcher *w) {
+                QDBusPendingReply<uint> reply = *w;
+                if (!reply.isError()) {
+                    uint notificationId = reply.value();
+                    m_notificationToDevice[notificationId] = devicePath;
+                    qCDebug(logAppDock) << "USB repair notification sent, id:"
+                                        << notificationId << "device:" << devicePath;
+                } else {
+                    qCWarning(logAppDock) << "Failed to send notification:"
+                                          << reply.error().message();
+                }
+                w->deleteLater();
+            });
+}
+
+void DockItemDataManager::closeNotification(uint notificationId)
+{
+    QDBusInterface iface("org.freedesktop.Notifications",
+                         "/org/freedesktop/Notifications",
+                         "org.freedesktop.Notifications",
+                         QDBusConnection::sessionBus());
+    iface.asyncCall("CloseNotification", notificationId);
+}
+
+void DockItemDataManager::onRepairProgress(const QString &devicePath, int percent, const QString &logLine)
+{
+    qCInfo(logAppDock) << "Repair progress:" << devicePath << percent << "%" << logLine;
+
+    // The dialog was already created and is running exec() in its kRepairing state.
+    // Just update the progress.
+    RepairDialog *dialog = m_repairDialogs.value(devicePath);
+    if (dialog) {
+        dialog->setProgress(percent);
+    }
+}
+
+void DockItemDataManager::onRepairFinished(const QString &devicePath, bool success, const QString &summary)
+{
+    qCInfo(logAppDock) << "Repair finished:" << devicePath << "success:" << success << "summary:" << summary;
+
+    // Get device info from pending errors
+    auto it = m_pendingErrors.find(devicePath);
+    QString deviceName = it != m_pendingErrors.end() ? it.value().deviceName : devicePath;
+    QString fsType = it != m_pendingErrors.end() ? it.value().fsType : "";
+
+    // When using the standalone process (dde-usb-repair-dialog), it handles
+    // mounting and dialog UI itself. We only need to clean up pending errors.
+    RepairDialog *dialog = m_repairDialogs.value(devicePath);
+    if (!dialog) {
+        m_pendingErrors.remove(devicePath);
+        return;
+    }
+
+    // In-process dialog path: mount and update dialog state.
+    QString mountPoint;
+    if (success) {
+        qCInfo(logAppDock) << "Attempting to mount device after repair:" << devicePath;
+
+        // Use udisksctl to mount the device
+        QProcess mountProc;
+        mountProc.start("udisksctl", { "mount", "-b", devicePath });
+        mountProc.waitForFinished(10000);
+
+        if (mountProc.exitCode() != 0) {
+            QString err = QString::fromUtf8(mountProc.readAllStandardError());
+            qCWarning(logAppDock) << "Mount failed:" << err;
+            success = false;  // Mount failed, treat as overall failure
+        }
+
+        // Read /proc/mounts to get accurate mount point
+        QFile mounts("/proc/mounts");
+        if (mounts.open(QIODevice::ReadOnly)) {
+            QByteArray data = mounts.readAll();
+            mounts.close();
+            for (const QByteArray &line : data.split('\n')) {
+                QList<QByteArray> parts = line.split(' ');
+                if (parts.size() >= 2 && parts[0] == devicePath.toUtf8()) {
+                    mountPoint = QString::fromUtf8(parts[1]);
+                    qCInfo(logAppDock) << "Mount point from /proc/mounts:" << mountPoint;
+                    break;
+                }
+            }
+        }
+
+        // If mount point is empty, mount failed
+        if (mountPoint.isEmpty()) {
+            qCWarning(logAppDock) << "Mount point is empty after mount attempt";
+            success = false;
+        }
+    }
+
+    if (dialog) {
+        QString deviceSize = blocks.contains(devicePath) ?
+            size_format::formatDiskSize(blocks.value(devicePath).totalSize) : "";
+        dialog->setDeviceInfo(deviceName, deviceSize, fsType.toUpper());
+        dialog->setDevicePath(devicePath, mountPoint);
+
+        if (success) {
+            dialog->setState(RepairDialog::kSuccess);
+
+            // Handle "Open Device" button
+            connect(dialog, &RepairDialog::buttonClicked, this, [dialog](int index, const QString &) {
+                if (index == 1) {  // "Open Device" button (second button)
+                    QString mountPoint = dialog->mountPoint();
+                    if (!mountPoint.isEmpty()) {
+                        qCInfo(logAppDock) << "Opening device:" << mountPoint;
+                        QProcess::startDetached(QStringLiteral("dde-file-manager"), { mountPoint });
+                    }
+                }
+            });
+        } else {
+            // 设置错误码（包含修复失败的原因或挂载失败的错误）
+            QString errorCode = summary;
+            if (errorCode.isEmpty()) {
+                errorCode = tr("Repair operation failed");
+            }
+            dialog->setErrorCode(errorCode);
+            dialog->setState(RepairDialog::kFailed);
+        }
+    }
+
+    // Clean up pending errors; dialog will be deleted after exec() returns
+    m_pendingErrors.remove(devicePath);
 }

--- a/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.h
+++ b/src/external/dde-dock-plugins/disk-mount/device/dockitemdatamanager.h
@@ -14,6 +14,15 @@
 typedef QMap<QString, DockItemData> ItemContainer;
 
 using DeviceManager = OrgDeepinFilemanagerDaemonDeviceManagerInterface;
+class UsbRepairProxy;
+class RepairDialog;
+
+struct PendingErrorInfo {
+    QString deviceName;
+    QString fsType;
+    QString errorType;
+    QString message;
+};
 class DockItemDataManager : public QObject
 {
     Q_OBJECT
@@ -45,6 +54,19 @@ private Q_SLOTS:
     void onServiceRegistered();
     void onServiceUnregistered();
 
+    // USB Repair slots
+    void onFsErrorDetected(const QString &devicePath,
+                           const QString &deviceName,
+                           const QString &fsType,
+                           const QString &errorType,
+                           bool canRepair,
+                           const QString &message);
+    void onFsErrorCleared(const QString &devicePath);
+    void onNotifyActionInvoked(uint notificationId, const QString &action);
+    void onNotifyClosed(uint notificationId, uint reason);
+    void onRepairProgress(const QString &devicePath, int percent, const QString &logLine);
+    void onRepairFinished(const QString &devicePath, bool success, const QString &summary);
+
 private:
     explicit DockItemDataManager(QObject *parent = nullptr);
 
@@ -54,19 +76,29 @@ private:
     bool isMountPointInFstab(const QString &mountPoint);
     void playSoundOnDevPlugInOut(bool in);
     void updateDockVisible();
-    void notify(const QString &title, const QString &msg);
+    void notify(const QString &title, const QString &msg, int timeout = 3000);
+    void notifyWithActions(const QString &title, const QString &msg,
+                           const QStringList &actions, const QString &devicePath, int timeout = 10000);
+    void closeNotification(uint notificationId);
 
     DockItemData buildBlockItem(const QVariantMap &data);
     DockItemData buildProtocolItem(const QVariantMap &data);
 
     void connectDeviceManger();
     void watchService();
+    void connectRepairService();
 
 private:
     ItemContainer blocks;
     ItemContainer protocols;
 
     QScopedPointer<DeviceManager> devMng;
+
+    // USB Repair
+    UsbRepairProxy *m_repairProxy { nullptr };
+    QMap<uint, QString> m_notificationToDevice;   // notification ID → devicePath
+    QMap<QString, PendingErrorInfo> m_pendingErrors;   // devicePath → error info
+    QMap<QString, RepairDialog *> m_repairDialogs;   // devicePath → repair dialog
 };
 
 #endif   // DOCKITEMDATAMANAGER_H

--- a/src/external/dde-dock-plugins/disk-mount/device/usbrepairproxy.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/device/usbrepairproxy.cpp
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "usbrepairproxy.h"
+
+#include <QDBusConnection>
+#include <QDBusPendingCallWatcher>
+
+Q_DECLARE_LOGGING_CATEGORY(logAppDock)
+
+UsbRepairProxy::UsbRepairProxy(QObject *parent)
+    : QObject(parent)
+{
+    // NOTE: UsbRepair service is on system bus (not session bus!)
+    m_watcher = new QDBusServiceWatcher(
+        kServiceName,
+        QDBusConnection::systemBus(),
+        QDBusServiceWatcher::WatchForOwnerChange,
+        this);
+
+    connect(m_watcher, &QDBusServiceWatcher::serviceRegistered,
+            this, &UsbRepairProxy::onServiceRegistered);
+    connect(m_watcher, &QDBusServiceWatcher::serviceUnregistered,
+            this, &UsbRepairProxy::onServiceUnregistered);
+
+    // Try to connect immediately if service is already running
+    onServiceRegistered(kServiceName);
+}
+
+UsbRepairProxy::~UsbRepairProxy()
+{
+}
+
+void UsbRepairProxy::startRepair(const QString &devicePath)
+{
+    if (!m_interface || !m_interface->isValid())
+        return;
+
+    // Async call — the actual result comes via RepairFinished D-Bus signal
+    m_interface->asyncCall("Repair", devicePath);
+}
+
+void UsbRepairProxy::cancelRepair(const QString &devicePath)
+{
+    if (!m_interface || !m_interface->isValid())
+        return;
+
+    m_interface->asyncCall("CancelRepair", devicePath);
+}
+
+void UsbRepairProxy::onServiceRegistered(const QString &serviceName)
+{
+    Q_UNUSED(serviceName)
+    if (m_interface)
+        return;
+
+    m_interface.reset(new Interface(
+        kServiceName,
+        kServicePath,
+        QDBusConnection::systemBus(),
+        this));
+
+    if (m_interface->isValid()) {
+        connectSignals();
+        qCInfo(logAppDock) << "UsbRepairProxy: connected to UsbRepair service on system bus";
+    } else {
+        qCWarning(logAppDock) << "UsbRepairProxy: failed to connect to UsbRepair service:"
+                              << m_interface->lastError().message();
+        m_interface.reset();
+    }
+}
+
+void UsbRepairProxy::onServiceUnregistered(const QString &serviceName)
+{
+    Q_UNUSED(serviceName)
+    qCInfo(logAppDock) << "UsbRepairProxy: UsbRepair service unregistered";
+    m_interface.reset();
+}
+
+void UsbRepairProxy::connectSignals()
+{
+    if (!m_interface)
+        return;
+
+    connect(m_interface.data(), &Interface::FsErrorDetected,
+            this, &UsbRepairProxy::fsErrorDetected);
+    connect(m_interface.data(), &Interface::FsErrorCleared,
+            this, &UsbRepairProxy::fsErrorCleared);
+    connect(m_interface.data(), &Interface::RepairProgress,
+            this, &UsbRepairProxy::repairProgress);
+    connect(m_interface.data(), &Interface::RepairFinished,
+            this, &UsbRepairProxy::repairFinished);
+}

--- a/src/external/dde-dock-plugins/disk-mount/device/usbrepairproxy.h
+++ b/src/external/dde-dock-plugins/disk-mount/device/usbrepairproxy.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef USBREPAIRPROXY_H
+#define USBREPAIRPROXY_H
+
+#include "usbrepair_interface.h"
+
+#include <QObject>
+#include <QDBusServiceWatcher>
+#include <QScopedPointer>
+
+class UsbRepairProxy : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit UsbRepairProxy(QObject *parent = nullptr);
+    ~UsbRepairProxy();
+
+    void startRepair(const QString &devicePath);
+    void cancelRepair(const QString &devicePath);
+
+Q_SIGNALS:
+    void fsErrorDetected(const QString &devicePath,
+                         const QString &deviceName,
+                         const QString &fsType,
+                         const QString &errorType,
+                         bool canRepair,
+                         const QString &message);
+    void fsErrorCleared(const QString &devicePath);
+    void repairProgress(const QString &devicePath,
+                        int percent,
+                        const QString &logLine);
+    void repairFinished(const QString &devicePath,
+                        bool success,
+                        const QString &summary);
+
+private Q_SLOTS:
+    void onServiceRegistered(const QString &serviceName);
+    void onServiceUnregistered(const QString &serviceName);
+
+private:
+    void connectSignals();
+
+    using Interface = OrgDeepinFilemanagerUsbRepairInterface;
+    QScopedPointer<Interface> m_interface;
+    QDBusServiceWatcher *m_watcher { nullptr };
+
+    static constexpr char kServiceName[] { "org.deepin.Filemanager.UsbRepair" };
+    static constexpr char kServicePath[] { "/org/deepin/Filemanager/UsbRepair" };
+};
+
+#endif   // USBREPAIRPROXY_H

--- a/src/external/dde-dock-plugins/disk-mount/repair_dialog_main.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/repair_dialog_main.cpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "widgets/repairdialog.h"
+#include "usbrepair_interface.h"
+
+#include <DApplication>
+#include <QDBusConnection>
+#include <QProcess>
+#include <QFile>
+#include <QCommandLineParser>
+#include <QTimer>
+
+DWIDGET_USE_NAMESPACE
+
+using UsbRepairIface = OrgDeepinFilemanagerUsbRepairInterface;
+
+static constexpr char kServiceName[] = "org.deepin.Filemanager.UsbRepair";
+static constexpr char kServicePath[] = "/org/deepin/Filemanager/UsbRepair";
+
+int main(int argc, char *argv[])
+{
+    DApplication app(argc, argv);
+    app.setApplicationName("dde-usb-repair-dialog");
+    app.setQuitOnLastWindowClosed(true);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("USB Repair Dialog");
+    parser.addHelpOption();
+    QCommandLineOption devicePathOpt({ "d", "device-path" },
+        "Block device path (e.g. /dev/sda1)", "path");
+    QCommandLineOption deviceNameOpt({ "n", "device-name" },
+        "Display name of the device", "name");
+    QCommandLineOption fsTypeOpt({ "f", "fs-type" },
+        "Filesystem type (e.g. vfat)", "type");
+    QCommandLineOption deviceSizeOpt({ "s", "device-size" },
+        "Formatted device size string", "size");
+    parser.addOptions({ devicePathOpt, deviceNameOpt, fsTypeOpt, deviceSizeOpt });
+    parser.process(app);
+
+    QString devicePath = parser.value(devicePathOpt);
+    QString deviceName = parser.value(deviceNameOpt);
+    QString fsType = parser.value(fsTypeOpt);
+    QString deviceSize = parser.value(deviceSizeOpt);
+
+    if (devicePath.isEmpty()) {
+        qWarning("No device path provided");
+        return 1;
+    }
+
+    // Connect to USB repair service on system bus
+    UsbRepairIface repairIface(kServiceName, kServicePath, QDBusConnection::systemBus());
+    const QString ifaceError = repairIface.lastError().message();
+
+    RepairDialog dialog;
+    dialog.setDeviceInfo(deviceName, deviceSize, fsType.toUpper());
+    dialog.setDevicePath(devicePath, QString());
+
+    if (!repairIface.isValid()) {
+        // Service unavailable: surface the error instead of leaving the dialog
+        // stuck in a repairing state after the user clicks "Start Repair".
+        qWarning() << "Cannot connect to UsbRepair service:" << ifaceError;
+        dialog.setErrorCode(QObject::tr("Cannot connect to repair service"));
+        dialog.setState(RepairDialog::kFailed);
+    } else {
+        dialog.setState(RepairDialog::kConfirm);
+    }
+
+    // Track whether repair has been started to avoid double-start
+    bool repairStarted = false;
+
+    // Handle confirmation dialog buttons
+    QObject::connect(&dialog, &RepairDialog::buttonClicked, &app,
+        [&](int index, const QString &) {
+
+            switch (dialog.getState()) {
+            case RepairDialog::kConfirm:
+                if (index == 1 && !repairStarted) {
+                    repairStarted = true;
+                    QTimer::singleShot(0, &app, [&]() {
+                        dialog.setState(RepairDialog::kRepairing);
+
+                        QDBusPendingCall call = repairIface.asyncCall("Repair", devicePath);
+                        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, &app);
+                        QObject::connect(watcher, &QDBusPendingCallWatcher::finished, &app,
+                            [](QDBusPendingCallWatcher *w) {
+                                QDBusPendingReply<bool, QString> reply = *w;
+                                if (reply.isError()) {
+                                    qWarning() << "Repair async call failed:" << reply.error().message();
+                                }
+                                w->deleteLater();
+                            });
+                    });
+                } else {
+                    app.quit();
+                }
+                break;
+            case RepairDialog::kSuccess:
+                if (index == 1) {
+                    // "Open Device" button
+                    QString mp = dialog.mountPoint();
+                    if (!mp.isEmpty())
+                        QProcess::startDetached("dde-file-manager", { mp });
+                }
+                app.quit();
+                break;
+            case RepairDialog::kFailed:
+                app.quit();
+                break;
+            default:
+                break;
+            }
+        });
+
+    // Listen for repair progress signals
+    QObject::connect(&repairIface, &UsbRepairIface::RepairProgress,
+        &dialog, [&dialog, devicePath](const QString &path, int percent, const QString &) {
+            if (path == devicePath)
+                dialog.setProgress(percent);
+        });
+
+    // Listen for repair finished signals
+    QObject::connect(&repairIface, &UsbRepairIface::RepairFinished,
+        &dialog, [&dialog, &app, devicePath](const QString &path, bool success, const QString &summary) {
+            if (path != devicePath)
+                return;
+
+            QTimer::singleShot(0, &app, [&dialog, &app, devicePath, success, summary]() {
+                if (success) {
+                    // Mount asynchronously to avoid blocking the event loop,
+                    // which causes the window to appear greyed out under Wayland.
+                    QProcess *mountProc = new QProcess(&app);
+                    QObject::connect(mountProc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                        &app, [&dialog, devicePath, mountProc](int, QProcess::ExitStatus) {
+                            QString mountPoint;
+                            QFile mounts("/proc/mounts");
+                            if (mounts.open(QIODevice::ReadOnly)) {
+                                QByteArray data = mounts.readAll();
+                                mounts.close();
+                                for (const QByteArray &line : data.split('\n')) {
+                                    QList<QByteArray> parts = line.split(' ');
+                                    if (parts.size() >= 2 && parts[0] == devicePath.toUtf8()) {
+                                        mountPoint = QString::fromUtf8(parts[1]);
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (mountPoint.isEmpty()) {
+                                dialog.setErrorCode(QObject::tr("Mount failed after repair"));
+                                dialog.setState(RepairDialog::kFailed);
+                            } else {
+                                dialog.setDevicePath(devicePath, mountPoint);
+                                dialog.setState(RepairDialog::kSuccess);
+                            }
+                            mountProc->deleteLater();
+                        });
+                    mountProc->start("udisksctl", { "mount", "-b", devicePath });
+                } else {
+                    dialog.setErrorCode(summary);
+                    dialog.setState(RepairDialog::kFailed);
+                }
+            });
+        });
+
+    // Use show() + app.exec() instead of dialog.exec().
+    // DDialog::exec() uses its own QEventLoop that returns on hideEvent,
+    // and clearButtons()/clearContents() during state transitions can
+    // trigger a hide, causing exec() to exit prematurely.
+    dialog.show();
+    return app.exec();
+}

--- a/src/external/dde-dock-plugins/disk-mount/widgets/repairdialog.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/repairdialog.cpp
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "repairdialog.h"
+
+#include <QFrame>
+#include <QVBoxLayout>
+#include <QTimer>
+#include <QDateTime>
+#include <QFont>
+#include <cmath>
+#include <DLabel>
+#include <DWaterProgress>
+
+DWIDGET_USE_NAMESPACE
+
+RepairDialog::RepairDialog(QWidget *parent)
+    : DDialog(parent)
+{
+    setFixedSize(360, 250);
+}
+
+void RepairDialog::setDeviceInfo(const QString &deviceName, const QString &deviceSize, const QString &fsType)
+{
+    m_deviceName = deviceName;
+    m_deviceSize = deviceSize;
+    m_fsType = fsType;
+}
+
+void RepairDialog::setDevicePath(const QString &devicePath, const QString &mountPoint)
+{
+    m_devicePath = devicePath;
+    m_mountPoint = mountPoint;
+}
+
+void RepairDialog::setErrorCode(const QString &errorCode)
+{
+    m_errorCode = errorCode;
+}
+
+void RepairDialog::setState(RepairState state)
+{
+    m_state = state;
+
+    // Stop simulated progress timer and reset widget pointer before
+    // clearing contents, otherwise the timer fires on a deleted widget.
+    if (m_progressTimer)
+        m_progressTimer->stop();
+    m_progressWidget = nullptr;
+
+    // 清除现有内容和按钮
+    clearContents();
+    clearButtons();
+
+    switch (state) {
+    case kConfirm:
+        initConfirmUI();
+        break;
+    case kRepairing:
+        initRepairingUI();
+        break;
+    case kSuccess:
+        initSuccessUI();
+        break;
+    case kFailed:
+        initFailedUI();
+        break;
+    }
+
+    // Re-activate the window after content rebuild so buttons are
+    // properly rendered and receive focus (not greyed out).
+    if (isVisible()) {
+        raise();
+        activateWindow();
+    }
+}
+
+void RepairDialog::setProgress(int percent)
+{
+    if (!m_progressWidget)
+        return;
+
+    if (percent >= 0 && percent <= 100) {
+        m_progressWidget->setVisible(true);
+
+        // Start DWaterProgress if not already started
+        if (!m_progressWidget->property("running").toBool()) {
+            m_progressWidget->start();
+            m_progressWidget->setProperty("running", true);
+        }
+        m_progressWidget->setValue(percent);
+    }
+}
+
+void RepairDialog::reject()
+{
+    // 修复进行中不允许关闭
+    if (m_state == kRepairing) {
+        return;
+    }
+    DDialog::reject();
+}
+
+void RepairDialog::initConfirmUI()
+{
+    setIcon(QIcon::fromTheme("dde-file-manager"));
+    setTitle(tr("Repair Storage Device"));
+
+    QFrame *mainFrame = new QFrame(this);
+    QVBoxLayout *mainLay = new QVBoxLayout(mainFrame);
+
+    QString subtitle = tr("Preparing to repair device: %1 (%2 %3)")
+                          .arg(m_deviceName, m_deviceSize, m_fsType);
+    DLabel *subtitleLabel = new DLabel(subtitle, mainFrame);
+    subtitleLabel->setAlignment(Qt::AlignLeft);
+
+    QString message = tr("The device will be unmounted during repair. "
+                        "It will be automatically remounted after repair is complete. "
+                        "Please do not remove the device during the repair process.");
+    DLabel *msgLabel = new DLabel(message, mainFrame);
+    msgLabel->setWordWrap(true);
+    msgLabel->setAlignment(Qt::AlignLeft);
+
+    mainLay->addWidget(subtitleLabel);
+    mainLay->addSpacing(10);
+    mainLay->addWidget(msgLabel);
+    mainFrame->setLayout(mainLay);
+
+    addContent(mainFrame);
+
+    addButton(tr("Cancel"));
+    addButton(tr("Start Repair"), true, ButtonType::ButtonRecommend);
+
+    setCloseButtonVisible(true);
+    setOnButtonClickedClose(false);
+}
+
+void RepairDialog::initRepairingUI()
+{
+    setIcon(QIcon::fromTheme("dde-file-manager"));
+    setTitle(tr("Repairing Storage Device"));
+
+    QFrame *mainFrame = new QFrame(this);
+    QVBoxLayout *mainLay = new QVBoxLayout(mainFrame);
+
+    QString subtitle = tr("Repairing device: %1 (%2 %3)")
+                          .arg(m_deviceName, m_deviceSize, m_fsType);
+    DLabel *subtitleLabel = new DLabel(subtitle, mainFrame);
+    subtitleLabel->setAlignment(Qt::AlignCenter);
+
+    // Create progress widget
+    m_progressWidget = new DTK_WIDGET_NAMESPACE::DWaterProgress(mainFrame);
+    m_progressWidget->setValue(0);
+    m_progressWidget->setFixedSize(60, 60);
+
+    mainLay->addWidget(subtitleLabel);
+    mainLay->addSpacing(20);
+    mainLay->addWidget(m_progressWidget, 0, Qt::AlignCenter);
+    mainFrame->setLayout(mainLay);
+
+    addContent(mainFrame);
+
+    setCloseButtonVisible(false);
+    setOnButtonClickedClose(false);
+
+    // 自动启动模拟进度
+    startSimulatedProgress();
+}
+
+void RepairDialog::initSuccessUI()
+{
+    setIcon(QIcon::fromTheme("dde-file-manager"));
+    setTitle(tr("Repair Complete"));
+
+    QFrame *mainFrame = new QFrame(this);
+    QVBoxLayout *mainLay = new QVBoxLayout(mainFrame);
+
+    QString message = tr("The device has been successfully repaired. "
+                        "The device has been remounted and is now ready to use.");
+    DLabel *msgLabel = new DLabel(message, mainFrame);
+    msgLabel->setWordWrap(true);
+    msgLabel->setAlignment(Qt::AlignCenter);
+
+    mainLay->addSpacing(20);
+    mainLay->addWidget(msgLabel);
+    mainFrame->setLayout(mainLay);
+
+    addContent(mainFrame);
+
+    addButton(tr("Close"));
+    addButton(tr("Open Device"), true, ButtonType::ButtonRecommend);
+
+    setCloseButtonVisible(true);
+    setOnButtonClickedClose(true);
+}
+
+void RepairDialog::initFailedUI()
+{
+    setIcon(QIcon::fromTheme("dde-file-manager"));
+    setTitle(tr("Repair Failed"));
+
+    QFrame *mainFrame = new QFrame(this);
+    QVBoxLayout *mainLay = new QVBoxLayout(mainFrame);
+
+    QString message = tr("Failed to repair the device. This may be due to serious format errors "
+                        "or physical damage. To protect your data, it is recommended to stop "
+                        "writing new files and try using professional data recovery software "
+                        "or seek manual assistance.");
+    DLabel *msgLabel = new DLabel(message, mainFrame);
+    msgLabel->setWordWrap(true);
+    msgLabel->setAlignment(Qt::AlignCenter);
+
+    mainLay->addSpacing(20);
+    mainLay->addWidget(msgLabel);
+
+    // 错误码显示
+    if (!m_errorCode.isEmpty()) {
+        DLabel *errorCodeLabel = new DLabel(mainFrame);
+        QString errorCodeText = tr("Error Code: %1").arg(m_errorCode);
+        errorCodeLabel->setText(errorCodeText);
+        errorCodeLabel->setAlignment(Qt::AlignCenter);
+
+        // 设置字体样式，让它看起来像代码
+        QFont errorCodeFont = errorCodeLabel->font();
+        errorCodeFont.setFamily("Monospace");
+        errorCodeLabel->setFont(errorCodeFont);
+
+        // 设置文本省略和tooltip
+        errorCodeLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        errorCodeLabel->setToolTip(m_errorCode);  // 鼠标悬停显示完整错误码
+
+        // 设置固定宽度来强制省略
+        errorCodeLabel->setMaximumWidth(280);
+        errorCodeLabel->setWordWrap(false);
+
+        mainLay->addSpacing(10);
+        mainLay->addWidget(errorCodeLabel);
+    }
+    mainFrame->setLayout(mainLay);
+
+    addContent(mainFrame);
+
+    addButton(tr("Close"), true);
+
+    setCloseButtonVisible(true);
+    setOnButtonClickedClose(true);
+}
+
+void RepairDialog::startSimulatedProgress()
+{
+    // 创建定时器用于更新进度
+    if (!m_progressTimer) {
+        m_progressTimer = new QTimer(this);
+        connect(m_progressTimer, &QTimer::timeout, this, &RepairDialog::updateSimulatedProgress);
+    }
+
+    // 记录开始时间
+    m_progressStartTime = QDateTime::currentMSecsSinceEpoch();
+
+    // 启动进度条动画
+    if (m_progressWidget && !m_progressWidget->property("running").toBool()) {
+        m_progressWidget->start();
+        m_progressWidget->setProperty("running", true);
+    }
+
+    // 每100毫秒更新一次进度
+    m_progressTimer->start(100);
+}
+
+void RepairDialog::updateSimulatedProgress()
+{
+    qint64 elapsedMs = QDateTime::currentMSecsSinceEpoch() - m_progressStartTime;
+    double elapsedSec = elapsedMs / 1000.0;  // 转换为秒
+    int progress = 0;
+
+    if (elapsedSec <= 120) {
+        // 前2分钟：使用easeOutQuad从0%涨到90%
+        double t = elapsedSec / 120.0;  // 0.0 到 1.0
+        double easedT = easeOutQuad(t);  // 应用缓动函数
+        progress = static_cast<int>(easedT * 90);
+    } else {
+        // 2分钟后：使用对数增长，越到后面越慢
+        // 2分钟: 90%
+        // 10分钟: 95%
+        // 30分钟: 98%
+        // 最终趋近99%
+
+        double timeBeyond2Min = elapsedSec - 120.0;
+        double logFactor = log(1.0 + timeBeyond2Min / 60.0) / log(29.0);  // 归一化到0-1
+        double additionalProgress = logFactor * 9.0;  // 从90%再增长9%
+        progress = 90 + static_cast<int>(additionalProgress);
+
+        // 如果超过60分钟，停止在99%
+        if (elapsedSec >= 3600) {
+            progress = kMaxProgress;
+            m_progressTimer->stop();
+        }
+    }
+
+    // 确保不超过最大进度
+    if (progress > kMaxProgress) {
+        progress = kMaxProgress;
+    }
+
+    setProgress(progress);
+}

--- a/src/external/dde-dock-plugins/disk-mount/widgets/repairdialog.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/repairdialog.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef REPAIRDIALOG_H
+#define REPAIRDIALOG_H
+
+#include <DDialog>
+#include <DWaterProgress>
+
+#include <QMap>
+#include <QTimer>
+
+class RepairDialog : public DTK_WIDGET_NAMESPACE::DDialog
+{
+    Q_OBJECT
+
+public:
+    enum RepairState {
+        kConfirm,       // 确认是否修复
+        kRepairing,     // 修复进行中
+        kSuccess,       // 修复成功
+        kFailed         // 修复失败
+    };
+
+    explicit RepairDialog(QWidget *parent = nullptr);
+
+    void setDeviceInfo(const QString &deviceName, const QString &deviceSize, const QString &fsType);
+    void setDevicePath(const QString &devicePath, const QString &mountPoint);
+    void setProgress(int percent);
+    void setErrorCode(const QString &errorCode);  // 设置错误码
+    void setState(RepairState state);  // 切换对话框状态
+    void startSimulatedProgress();  // 启动模拟进度
+    RepairState getState() const { return m_state; }
+
+    QString devicePath() const { return m_devicePath; }
+    QString mountPoint() const { return m_mountPoint; }
+
+    void reject() override;
+
+private:
+    void initConfirmUI();
+    void initRepairingUI();
+    void initSuccessUI();
+    void initFailedUI();
+    void updateSimulatedProgress();  // 更新模拟进度
+
+    // 缓动函数：easeOutQuad，增长越来越慢
+    double easeOutQuad(double t) { return t * (2 - t); }
+
+    QString m_deviceName;
+    QString m_deviceSize;
+    QString m_fsType;
+    QString m_devicePath;        // Device DBus path
+    QString m_mountPoint;        // Device mount point
+    QString m_errorCode;         // 错误码
+    RepairState m_state { kConfirm };
+
+    DTK_WIDGET_NAMESPACE::DWaterProgress *m_progressWidget { nullptr };
+    QTimer *m_progressTimer { nullptr };
+    qint64 m_progressStartTime { 0 };  // 进度开始时间
+    static constexpr int kMaxProgress = 99;  // 最大进度99%
+};
+
+#endif   // REPAIRDIALOG_H

--- a/src/services/usbrepair/usbrepairmonitor.cpp
+++ b/src/services/usbrepair/usbrepairmonitor.cpp
@@ -122,8 +122,15 @@ void UsbRepairMonitor::onInterfacesRemoved(
 
 void UsbRepairMonitor::checkDeviceHealth(const QString &blockObjPath)
 {
+    // Check if device should be ignored (e.g., UDISKS_IGNORE=1)
+    if (shouldIgnoreDevice(blockObjPath)) {
+        fmDebug() << "UsbRepairMonitor: device marked as ignored, skipping health check:" << blockObjPath;
+        return;
+    }
+
     QString deviceName;
     if (!isUsbDevice(blockObjPath, &deviceName)) {
+        fmDebug() << "UsbRepairMonitor: not a USB device, skipping health check:" << blockObjPath;
         return;
     }
 
@@ -198,8 +205,10 @@ bool UsbRepairMonitor::isUsbDevice(const QString &blockObjPath, QString *deviceN
 
     // Get drive object path
     QDBusObjectPath drivePath = blockIface.property("Drive").value<QDBusObjectPath>();
-    if (drivePath.path().isEmpty() || drivePath.path() == "/")
+    if (drivePath.path().isEmpty() || drivePath.path() == "/") {
+        fmDebug() << "UsbRepairMonitor: no drive associated with block device:" << blockObjPath;
         return false;
+    }
 
     // Check drive ConnectionBus == "usb"
     QDBusInterface driveIface(
@@ -208,12 +217,16 @@ bool UsbRepairMonitor::isUsbDevice(const QString &blockObjPath, QString *deviceN
         Defines::kUdisks2DriveIface,
         QDBusConnection::systemBus());
 
-    if (!driveIface.isValid())
+    if (!driveIface.isValid()) {
+        fmDebug() << "UsbRepairMonitor: drive interface invalid for:" << blockObjPath << "drive:" << drivePath.path();
         return false;
+    }
 
     QString connectionBus = driveIface.property("ConnectionBus").toString();
-    if (connectionBus != "usb")
+    if (connectionBus != "usb") {
+        fmDebug() << "UsbRepairMonitor: not USB (ConnectionBus =" << connectionBus << ") skipping:" << blockObjPath;
         return false;
+    }
 
     if (deviceName) {
         *deviceName = driveIface.property("Id").toString();
@@ -227,6 +240,9 @@ bool UsbRepairMonitor::isUsbDevice(const QString &blockObjPath, QString *deviceN
 
     // Check removable
     bool removable = driveIface.property("Removable").toBool();
+    if (!removable)
+        fmDebug() << "UsbRepairMonitor: drive not removable, skipping:" << blockObjPath;
+
     return removable;
 }
 
@@ -241,10 +257,13 @@ QString UsbRepairMonitor::getDeviceFile(const QString &blockObjPath)
     if (!blockIface.isValid())
         return {};
 
-    // Device 属性是 D-Bus 字节数组(ay)，常以 '\0' 结尾；直接 toString() 会保留尾部空字节，
-    // 导致后续路径匹配、进程参数出错。用 constData() 截断尾部空字节。
-    QByteArray dev = blockIface.property("Device").toByteArray();
-    return QString::fromUtf8(dev.constData());
+    // udisks2 "Device" property is type "ay" (byte array). Qt converts it to
+    // a QString that may contain a trailing NUL byte (e.g. "/dev/sda1\0"),
+    // which breaks string comparisons and regex matching. Strip trailing NULs.
+    QString deviceFile = blockIface.property("Device").toString();
+    while (deviceFile.endsWith(QChar::Null))
+        deviceFile.chop(1);
+    return deviceFile;
 }
 
 QString UsbRepairMonitor::getFsType(const QString &deviceFile)
@@ -343,8 +362,15 @@ bool UsbRepairMonitor::checkDirtyBit(const QString &deviceFile, const QString &f
 
 void UsbRepairMonitor::checkMissingFilesystem(const QString &blockObjPath)
 {
+    // Check if device should be ignored (e.g., UDISKS_IGNORE=1)
+    if (shouldIgnoreDevice(blockObjPath)) {
+        fmDebug() << "UsbRepairMonitor: device marked as ignored, skipping missing filesystem check:" << blockObjPath;
+        return;
+    }
+
     QString deviceName;
     if (!isUsbDevice(blockObjPath, &deviceName)) {
+        fmDebug() << "UsbRepairMonitor: not a USB device, skipping missing filesystem check:" << blockObjPath;
         return;
     }
 
@@ -437,3 +463,23 @@ void UsbRepairMonitor::checkMissingFilesystem(const QString &blockObjPath)
                           "Data may be recoverable through repair."));
 }
 
+bool UsbRepairMonitor::shouldIgnoreDevice(const QString &blockObjPath)
+{
+    QDBusInterface blockIface(
+        Defines::kUdisks2Service,
+        blockObjPath,
+        Defines::kUdisks2BlockIface,
+        QDBusConnection::systemBus());
+
+    if (!blockIface.isValid())
+        return false;
+
+    // Check HintIgnore property - this is set when UDISKS_IGNORE=1
+    bool hintIgnore = blockIface.property("HintIgnore").toBool();
+
+    if (hintIgnore) {
+        fmDebug() << "UsbRepairMonitor: device has HintIgnore=true (UDISKS_IGNORE):" << blockObjPath;
+    }
+
+    return hintIgnore;
+}

--- a/src/services/usbrepair/usbrepairmonitor.h
+++ b/src/services/usbrepair/usbrepairmonitor.h
@@ -51,6 +51,7 @@ private:
     bool isDeviceMounted(const QString &deviceFile);
     bool isHardwareReadOnly(const QString &deviceFile);
     bool checkDirtyBit(const QString &deviceFile, const QString &fsType);
+    bool shouldIgnoreDevice(const QString &blockObjPath);
     QString getParentDriveObjPath(const QString &blockObjPath);
 
     QDBusInterface *m_udisks2ObjMgr { nullptr };

--- a/src/services/usbrepair/usbrepairworker.cpp
+++ b/src/services/usbrepair/usbrepairworker.cpp
@@ -262,7 +262,6 @@ bool UsbRepairWorker::checkAuthorization(const QString &callerBusName)
 
     return result == Authority::Yes;
 }
-
 bool UsbRepairWorker::umountDevice(const QString &devicePath)
 {
     QProcess proc;


### PR DESCRIPTION
…ted progress and device ignore support

- Add UsbRepairProxy class to handle repair service communication via system bus
- Implement repair dialog UI with confirm, repairing, success and failed states
- Integrate repair notifications with action buttons in DockItemDataManager
- Support automatic mounting after successful repair process
- Add standalone repair dialog entry (dde-usb-repair-dialog)
- Display error codes and simulate repair progress with easeOutQuad easing
- Support ignoring devices marked with UDISKS_IGNORE (HintIgnore) in UsbRepairMonitor
- Add repair dialog translations across 6 locales (zh_CN/zh_HK/zh_TW/bo/ug and template)

Log: 完善USB存储设备修复功能，新增修复对话框、错误码显示、模拟进度及设备忽略
Task: https://pms.uniontech.com/task-view-392215.html

Change-Id: Icb1e817bb98b79154e5d0bd2c300f5513484b51d

## Summary by Sourcery

Integrate a USB storage repair workflow into the dock disk-mount plugin, including a dedicated repair dialog process, monitoring, and notification-driven user interactions.

New Features:
- Add a USB repair proxy and monitoring pipeline that detects filesystem issues on removable USB devices and exposes repair progress and completion via D-Bus.
- Introduce a standalone USB repair dialog application with multi-state UI (confirm, repairing, success, failed) that displays error codes and optional device opening after repair.
- Support interactive desktop notifications for USB errors with repair and ignore actions that launch the dedicated repair dialog for the affected device.

Enhancements:
- Refine USB repair service logging and robustness by improving device detection, handling ignored devices, and cleaning up filesystem type and drive checks.
- Automatically remount devices after a successful repair and derive the mount point to enable opening the repaired device in the file manager.
- Improve user feedback for non-repairable or hardware write-protected devices via clearer notification messages and failure summaries.

Build:
- Extend the disk-mount plugin CMake configuration to generate the UsbRepair D-Bus interface stubs and build/install the dde-usb-repair-dialog executable.

Documentation:
- Add and update translation strings for the USB repair notifications, dialog states, and worker messages across multiple locales, including Chinese variants, Tibetan, Uyghur, and the template.