### PR TITLE
test: add stress tests for VFS monitor file system watcher

### DIFF
--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -7,6 +7,9 @@
 #include <QDir>
 #include <QFile>
 #include <QSignalSpy>
+#include <QTest>
+#include <QSet>
+#include <QElapsedTimer>
 
 #include "services/textindex/service_textindex_global.h"
 #include "services/textindex/fsmonitor/vfsmonitorwatcher.h"
@@ -278,6 +281,120 @@ TEST_F(TestVfsMonitorFileSystemWatcher, FileClosedSignal)
     QList<QVariant> args = spy.takeFirst();
     EXPECT_EQ(args.at(0).toString(), testDir->path());
     EXPECT_EQ(args.at(1).toString(), "closewrite.txt");
+}
+
+// ========== 批量文件写入关闭（压力测试） ==========
+
+TEST_F(TestVfsMonitorFileSystemWatcher, BatchFileClosedStress)
+{
+    ASSERT_NE(watcher, nullptr);
+
+    QSignalSpy spy(watcher, &VfsMonitorFileSystemWatcher::fileClosed);
+    ASSERT_TRUE(spy.isValid());
+
+    constexpr int kFileCount = 20;
+    QStringList fileNames;
+
+    for (int i = 0; i < kFileCount; ++i) {
+        QString name = QString("stress_%1.txt").arg(i);
+        fileNames << name;
+        QString path = testDir->path() + "/" + name;
+        QFile f(path);
+        f.open(QIODevice::WriteOnly);
+        f.write(QString("content %1").arg(i).toUtf8());
+        f.close();
+    }
+
+    // deepin-anything 内核模块事件合并器每 100ms 最多发送 DUMP_SIZE(10) 个事件。
+    // 20 个文件产生 40 个事件(20 NEW_FILE + 20 CLOSE_WRITE_FILE)，需分多批发送。
+    // QSignalSpy::wait() 收到第一个信号就返回，需循环等待直到收齐或超时。
+    QElapsedTimer timer;
+    timer.start();
+    while (spy.count() < kFileCount && !timer.hasExpired(15000)) {
+        QTest::qWait(200);
+    }
+
+    EXPECT_GE(spy.count(), kFileCount)
+        << "Expected at least " << kFileCount << " fileClosed signals, got " << spy.count();
+
+    // 验证每个文件名都出现在信号参数中
+    QSet<QString> seenNames;
+    for (const auto &args : spy) {
+        if (args.count() >= 2)
+            seenNames << args.at(1).toString();
+    }
+    for (const QString &name : fileNames) {
+        EXPECT_TRUE(seenNames.contains(name))
+            << "Missing fileClosed for: " << name.toStdString();
+    }
+}
+
+// ========== 同一文件反复写入关闭（压力测试） ==========
+
+TEST_F(TestVfsMonitorFileSystemWatcher, RepeatedWriteCloseStress)
+{
+    ASSERT_NE(watcher, nullptr);
+
+    QSignalSpy spy(watcher, &VfsMonitorFileSystemWatcher::fileClosed);
+    ASSERT_TRUE(spy.isValid());
+
+    QString filePath = testDir->path() + "/repeated_stress.txt";
+    QString fileName = "repeated_stress.txt";
+
+    constexpr int kIterations = 15;
+    for (int i = 0; i < kIterations; ++i) {
+        QFile f(filePath);
+        f.open(QIODevice::WriteOnly | QIODevice::Truncate);
+        f.write(QString("iteration %1").arg(i).toUtf8());
+        f.close();
+        // 小间隔让事件合并器有机会刷新
+        QTest::qWait(50);
+    }
+
+    // 循环等待收齐所有信号
+    QElapsedTimer timer;
+    timer.start();
+    while (spy.count() < kIterations && !timer.hasExpired(10000)) {
+        QTest::qWait(200);
+    }
+
+    EXPECT_GE(spy.count(), kIterations)
+        << "Expected at least " << kIterations << " fileClosed signals, got " << spy.count();
+
+    // 所有信号的文件名应该一致
+    for (const auto &args : spy) {
+        if (args.count() >= 2) {
+            EXPECT_EQ(args.at(1).toString(), fileName)
+                << "Unexpected file name in fileClosed signal";
+        }
+    }
+}
+
+// ========== 大文件写入关闭 ==========
+
+TEST_F(TestVfsMonitorFileSystemWatcher, LargeFileWriteClose)
+{
+    ASSERT_NE(watcher, nullptr);
+
+    QSignalSpy spy(watcher, &VfsMonitorFileSystemWatcher::fileClosed);
+    ASSERT_TRUE(spy.isValid());
+
+    QString filePath = testDir->path() + "/large_stress.txt";
+    QString fileName = "large_stress.txt";
+
+    QFile f(filePath);
+    f.open(QIODevice::WriteOnly);
+    // 写入 1MB 数据
+    QByteArray chunk(1024 * 1024, 'X');
+    f.write(chunk);
+    f.close();
+
+    int count = waitForSignal(spy, 5000);
+    ASSERT_GT(count, 0) << "fileClosed signal not received for large file";
+
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), testDir->path());
+    EXPECT_EQ(args.at(1).toString(), fileName);
 }
 
 // ========== 路径排除 ==========


### PR DESCRIPTION
Added comprehensive stress tests for the VFS monitor file system watcher
to validate its behavior under heavy load:
1. BatchFileClosedStress test creates 20 files simultaneously to test
event batching
2. RepeatedWriteCloseStress test performs 15 write-close cycles on the
same file
3. LargeFileWriteClose test handles 1MB file operations
These tests address the deepin-anything kernel module's event combiner
behavior that batches up to 10 events every 100ms, requiring proper
waiting strategies in tests to collect all signals.

Log: Added stress tests for file monitoring system

Influence:
1. Test batch file creation and closing with multiple files
2. Test repeated write-close operations on a single file
3. Test monitoring of large files (1MB+)
4. Verify signal delivery timing with kernel event batching
5. Validate fileClosed signal parameters under stress conditions

test: 为 VFS 监控文件系统观察器添加压力测试

添加了针对 VFS 监控文件系统观察器的全面压力测试，以验证其在重负载下的
行为：
1. BatchFileClosedStress 测试同时创建 20 个文件以测试事件批处理
2. RepeatedWriteCloseStress 测试在同一文件上执行 15 次写入-关闭循环
3. LargeFileWriteClose 测试处理 1MB 文件操作
这些测试解决了 deepin-anything 内核模块事件合并器的行为，该合并器每 100
毫秒最多批处理 10 个事件，需要在测试中使用适当的等待策略来收集所有信号。

Log: 为文件监控系统添加压力测试

Influence:
1. 测试批量文件创建和关闭操作
2. 测试同一文件的重复写入-关闭操作
3. 测试大型文件（1MB+）的监控
4. 在存在内核事件批处理的情况下验证信号传递时序
5. 在压力条件下验证 fileClosed 信号参数

## Summary by Sourcery

Add stress test coverage for VfsMonitorFileSystemWatcher to validate fileClosed behavior under heavy load and kernel event batching.

Tests:
- Add a batch file creation/closure stress test that verifies fileClosed is emitted for 20 concurrently written files despite event batching.
- Add a repeated write-close stress test on a single file to ensure consistent fileClosed signaling across many rapid cycles.
- Add a large-file write-close test to confirm correct fileClosed signaling for 1MB file writes.