### PR TITLE
fix: correct icon layout after maximizing window following touch long-press

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1963,6 +1963,15 @@ void FileView::contextMenuEvent(QContextMenuEvent *event)
         return;
     }
 
+    // Reset any stale drag-select state left by touch long-press before showing the menu.
+    // On touch screens a long-press synthesizes a left-button press/move that sets
+    // DragSelectingState; the subsequent release is consumed by the modal menu exec()
+    // and never reaches mouseReleaseEvent, so the state is never reset. A stale
+    // DragSelectingState later makes QListView::resizeEvent skip doDelayedItemsLayout,
+    // leaving visualRect() with stale item positions and breaking icon layout on
+    // maximize. Resetting here mirrors what mouseReleaseEvent would do.
+    setState(QAbstractItemView::NoState);
+
     if (NetworkUtils::instance()->checkFtpOrSmbBusy(rootUrl())) {
         fmWarning() << "Cannot show context menu: FTP or SMB is busy for URL:" << rootUrl().toString();
         DialogManager::instance()->showUnableToVistDir(rootUrl().path());

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -338,12 +338,25 @@ void FileViewPrivate::updateHorizontalOffset()
         }
 
         // itemColumn每行绘制的个数，contentWidth绘制区域宽度，itemWidth每一个item + 2倍间距的绘制宽度
-        if (contentWidth - itemWidth * itemColumn <= 0
-            || (contentWidth - itemWidth * itemColumn) / 2 >= itemWidth) {
-            columnCountByCalc = 1;
-            initHorizontalOffset = false;
-            fmDebug() << "Resetting to single column layout";
-            return;
+        // 当 visualRect() 返回瞬态过程中上一轮（更窄）布局的坐标时，扫描得到的 itemColumn 会偏小，
+        // 代入新的 contentWidth 后会被误判为“过疏”而错误回退单列。在回退前先用 contentWidth/itemWidth
+        // 重推每行列数：若重推后不再过疏，说明是脏坐标导致的误判，采用重推值；仍过疏才真正回退单列。
+        auto wouldReset = [&]() {
+            return contentWidth - itemWidth * itemColumn <= 0
+                    || (contentWidth - itemWidth * itemColumn) / 2 >= itemWidth;
+        };
+        if (wouldReset()) {
+            int calcColumn = contentWidth / itemWidth;
+            if (calcColumn > 0 && calcColumn < rowCount) {
+                itemColumn = calcColumn;
+                columnCountByCalc = itemColumn;
+            }
+            if (wouldReset()) {
+                columnCountByCalc = 1;
+                initHorizontalOffset = false;
+                fmDebug() << "Resetting to single column layout";
+                return;
+            }
         }
         horizontalOffset = -(contentWidth - itemWidth * itemColumn) / 2;
     }


### PR DESCRIPTION
## 根因分析

BUG-370855：触屏长按弹出空白处右键菜单、关闭菜单后最大化窗口，图标模式图标全部挤到左侧。根因是触屏长按合成左键 `mouseMoveEvent` 设 `DragSelectingState`，菜单 `exec()` grab 鼠标导致 `mouseReleaseEvent` 不送达、state 不复位；最大化时 `QListView::resizeEvent` 因 state≠NoState 跳过 `doDelayedItemsLayout`，`visualRect` 读旧布局坐标，`updateHorizontalOffset` 误判过疏回退单列，`paintEvent` 粘连。

## 修复方案

1. `FileView::contextMenuEvent` 显示菜单前 `setState(NoState)`，清除触屏长按遗留的 `DragSelectingState`（根因修复）。
2. `FileViewPrivate::updateHorizontalOffset` 对脏 `visualRect` 扫描得到的 `itemColumn` 增加 `contentWidth/itemWidth` 重推保护，避免误判过疏回退单列（症状加固）。正常路径行为不变。

## 改动安全评估

低风险。两处改动签名不变，仅影响 `FileView`/`FileViewPrivate` 内部实现。`updateHorizontalOffset` 的重推路径仅在扫描结果即将误判时触发，干净布局下 `wouldReset()` 为 false，行为字节级不变。

## 代码审查

自动 review 结论：**通过（A）**，无严重/一般问题，1 个可选建议项。详见附件 review 报告。

## Summary by Sourcery

Fix incorrect icon layout after maximizing the window following a touch long-press by resetting stale view state before opening the context menu and hardening column calculation against transient stale item geometry.

Bug Fixes:
- Reset stale drag-select state before showing the file view context menu to ensure resize events relayout icons correctly after touch long-press interactions.
- Adjust horizontal offset column calculation in the file view to avoid erroneously collapsing to a single-column layout when visual item geometry is temporarily stale.