### PR TITLE
fix: correct icon layout after maximizing window following touch long-press

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2092,6 +2092,15 @@ void FileView::contextMenuEvent(QContextMenuEvent *event)
         return;
     }
 
+    // Reset any stale drag-select state left by touch long-press before showing the menu.
+    // On touch screens a long-press synthesizes a left-button press/move that sets
+    // DragSelectingState; the subsequent release is consumed by the modal menu exec()
+    // and never reaches mouseReleaseEvent, so the state is never reset. A stale
+    // DragSelectingState later makes QListView::resizeEvent skip doDelayedItemsLayout,
+    // leaving visualRect() with stale item positions and breaking icon layout on
+    // maximize. Resetting here mirrors what mouseReleaseEvent would do.
+    setState(QAbstractItemView::NoState);
+
     if (NetworkUtils::instance()->checkFtpOrSmbBusy(rootUrl())) {
         fmWarning() << "Cannot show context menu: FTP or SMB is busy for URL:" << rootUrl().toString();
         DialogManager::instance()->showUnableToVistDir(rootUrl().path());

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -351,12 +351,25 @@ void FileViewPrivate::updateHorizontalOffset()
         }
 
         // itemColumn每行绘制的个数，contentWidth绘制区域宽度，itemWidth每一个item + 2倍间距的绘制宽度
-        if (contentWidth - itemWidth * itemColumn <= 0
-            || (contentWidth - itemWidth * itemColumn) / 2 >= itemWidth) {
-            columnCountByCalc = 1;
-            initHorizontalOffset = false;
-            fmDebug() << "Resetting to single column layout";
-            return;
+        // 当 visualRect() 返回瞬态过程中上一轮（更窄）布局的坐标时，扫描得到的 itemColumn 会偏小，
+        // 代入新的 contentWidth 后会被误判为“过疏”而错误回退单列。在回退前先用 contentWidth/itemWidth
+        // 重推每行列数：若重推后不再过疏，说明是脏坐标导致的误判，采用重推值；仍过疏才真正回退单列。
+        auto wouldReset = [&]() {
+            return contentWidth - itemWidth * itemColumn <= 0
+                    || (contentWidth - itemWidth * itemColumn) / 2 >= itemWidth;
+        };
+        if (wouldReset()) {
+            int calcColumn = contentWidth / itemWidth;
+            if (calcColumn > 0 && calcColumn < rowCount) {
+                itemColumn = calcColumn;
+                columnCountByCalc = itemColumn;
+            }
+            if (wouldReset()) {
+                columnCountByCalc = 1;
+                initHorizontalOffset = false;
+                fmDebug() << "Resetting to single column layout";
+                return;
+            }
         }
         horizontalOffset = -(contentWidth - itemWidth * itemColumn) / 2;
     }


### PR DESCRIPTION
1. 修复触屏长按触发右键菜单后最大化窗口导致图标排布异常的问题;
2. 在 contextMenuEvent 中显示菜单前重置视图状态，清除触屏长按遗留的 DragSelectingState;
3. 在 updateHorizontalOffset 中对 visualRect 扫描得到的脏 itemColumn 增加重推保护，避免误判过疏而回退单列;

=====================================

1. fix icon layout corruption after maximizing the window following a touch long-press context menu;
2. reset view state before showing the menu in contextMenuEvent to clear the stale DragSelectingState left by touch long-press;
3. add a recompute guard in updateHorizontalOffset for stale itemColumn scanned from visualRect, preventing false "too sparse" single-column fallback;

Log: 修复触屏长按弹出右键菜单后最大化窗口时图标排布异常的问题，根因是触屏长按遗留的 DragSelectingState 导致最大化时跳过布局重算

Bug: https://pms.uniontech.com/bug-view-370855.html

## Summary by Sourcery

Fix icon layout issues triggered by touch long-press context menus and subsequent window maximization by stabilizing view state and column calculation.

Bug Fixes:
- Prevent icon layout corruption when maximizing the window after invoking a context menu via touch long-press by resetting stale drag-selection state before showing the menu.
- Avoid erroneous fallback to a single-column layout when recalculating horizontal offsets using transient or stale item geometry from visualRect().