### PR TITLE
fix: persist list view column hidden state per URL

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -564,6 +564,20 @@ void FileView::onHeaderHiddenChanged(const QString &roleName, const bool isHidde
 
     d->columnForRoleHiddenMap[roleName] = isHidden;
 
+    const QUrl &url = rootUrl();
+    if (d->shouldPersistState(url)) {
+        for (int i = 0; i < model()->columnCount(); ++i) {
+            if (model()->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString() == roleName) {
+                ItemRoles role = model()->getRoleByColumn(i);
+                QVariantMap hiddenState = d->fileViewStateValue(url, "columnHiddenState").toMap();
+                hiddenState[QString::number(role)] = isHidden;
+                setFileViewStateValue(url, "columnHiddenState", hiddenState);
+                Application::appObtuselySetting()->sync();
+                break;
+            }
+        }
+    }
+
     if (d->allowedAdjustColumnSize) {
         updateListHeaderView();
     } else {
@@ -2664,13 +2678,14 @@ void FileView::updateListHeaderView()
     d->columnRoles.clear();
 
     const QVariantMap &state = Application::appObtuselySetting()->value("WindowManager", "ViewColumnState").toMap();
+    const QVariantMap &hiddenState = d->fileViewStateValue(rootUrl(), "columnHiddenState").toMap();
 
     for (int i = 0; i < d->headerView->count(); ++i) {
         int logicalIndex = d->headerView->logicalIndex(i);
         d->columnRoles << model()->getRoleByColumn(i);
+        ItemRoles curRole = d->columnRoles.last();
 
         if (d->allowedAdjustColumnSize) {
-            ItemRoles curRole = d->columnRoles.last();
             int colWidth = state.value(QString::number(curRole), -1).toInt();
             if (colWidth > 0) {
                 d->headerView->resizeSection(model()->getColumnByRole(curRole), colWidth);
@@ -2689,12 +2704,9 @@ void FileView::updateListHeaderView()
         }
 
         const QString &columnName = model()->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
-
-        if (!d->columnForRoleHiddenMap.contains(columnName)) {
-            d->headerView->setSectionHidden(logicalIndex, false);
-        } else {
-            d->headerView->setSectionHidden(logicalIndex, d->columnForRoleHiddenMap.value(columnName));
-        }
+        bool hidden = hiddenState.value(QString::number(curRole), curRole == kItemFileCreatedRole).toBool();
+        d->columnForRoleHiddenMap[columnName] = hidden;
+        d->headerView->setSectionHidden(logicalIndex, hidden);
     }
 
     if (d->adjustFileNameColumn) {


### PR DESCRIPTION
## 问题描述

fileview 列表模式默认不支持「创建时间」列，但可通过右键菜单手动显示。然而切换目录或文件管理器进程退出后，该显示设置没有持久化保存。

## 根因

`FileView` 中列显隐状态仅保存在内存态 `QMap<QString,bool> columnForRoleHiddenMap` 中，从未写入配置文件。而 `initDefaultHeaderView()` 在每次新建 `HeaderView` 时都硬编码「创建时间」列为隐藏。因此任何导致 `FileView` 重建的情形（进程重启、新窗口/标签页、切换 scheme 视图）都会重置用户设置。

## 修复方案

按 URL 持久化列显隐状态（与列顺序 `headerList` 同一 `FileViewState` 机制）：

1. `onHeaderHiddenChanged`：用户切换列显隐后，将状态以 role 编号为键写入该 URL 的 `columnHiddenState`。
2. `updateListHeaderView`：从 per-URL `columnHiddenState` 读取显隐状态并应用，未持久化的列默认显示，仅 `kItemFileCreatedRole` 默认隐藏（保留原有默认行为）。

## 影响范围

- 列表/树形模式列显隐设置可按目录记住
- 进程重启后各目录恢复之前的列显隐状态
- 不影响列宽度、列顺序等已有持久化逻辑

Log: 持久化列表模式列显隐状态

## Summary by Sourcery

Persist list view column visibility per URL so file columns (including creation time) retain their hidden/shown state across navigation and restarts.

Bug Fixes:
- Fix loss of user-configured column visibility in file list/tree views after navigating, reopening windows, or restarting the file manager.

Enhancements:
- Store column hidden state alongside existing per-URL view state and apply it when initializing headers, keeping the creation time column hidden by default unless explicitly changed.