### PR TITLE
fix: persist list view column hidden state per URL

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -564,6 +564,20 @@ void FileView::onHeaderHiddenChanged(const QString &roleName, const bool isHidde
 
     d->columnForRoleHiddenMap[roleName] = isHidden;
 
+    const QUrl &url = rootUrl();
+    if (d->shouldPersistState(url)) {
+        for (int i = 0; i < model()->columnCount(); ++i) {
+            if (model()->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString() == roleName) {
+                ItemRoles role = model()->getRoleByColumn(i);
+                QVariantMap hiddenState = d->fileViewStateValue(url, "columnHiddenState", {}).toMap();
+                hiddenState[QString::number(role)] = isHidden;
+                setFileViewStateValue(url, "columnHiddenState", hiddenState);
+                Application::appObtuselySetting()->sync();
+                break;
+            }
+        }
+    }
+
     if (d->allowedAdjustColumnSize) {
         updateListHeaderView();
     } else {
@@ -2425,10 +2439,12 @@ void FileView::initializeConnect()
     connect(d->statusBar->scalingSlider(), &DSlider::valueChanged, this, &FileView::onScalingValueChanged);
 
     connect(model(), &FileViewModel::stateChanged, this, &FileView::onModelStateChanged);
-    connect(model(), &FileViewModel::groupingStateChanged, this, [this](GroupingState) {
-        if (isIconViewMode())
-            d->adjustIconModeSpacing(model()->groupingStrategy());
-    }, Qt::QueuedConnection);
+    connect(
+            model(), &FileViewModel::groupingStateChanged, this, [this](GroupingState) {
+                if (isIconViewMode())
+                    d->adjustIconModeSpacing(model()->groupingStrategy());
+            },
+            Qt::QueuedConnection);
     connect(model(), &FileViewModel::highlightKeywordsChanged, this, [this](const QStringList &keywords) {
         updateDelegateHighlightKeywords(keywords);
         update();
@@ -2664,13 +2680,14 @@ void FileView::updateListHeaderView()
     d->columnRoles.clear();
 
     const QVariantMap &state = Application::appObtuselySetting()->value("WindowManager", "ViewColumnState").toMap();
+    const QVariantMap &hiddenState = d->fileViewStateValue(rootUrl(), "columnHiddenState", {}).toMap();
 
     for (int i = 0; i < d->headerView->count(); ++i) {
         int logicalIndex = d->headerView->logicalIndex(i);
         d->columnRoles << model()->getRoleByColumn(i);
+        ItemRoles curRole = d->columnRoles.last();
 
         if (d->allowedAdjustColumnSize) {
-            ItemRoles curRole = d->columnRoles.last();
             int colWidth = state.value(QString::number(curRole), -1).toInt();
             if (colWidth > 0) {
                 d->headerView->resizeSection(model()->getColumnByRole(curRole), colWidth);
@@ -2689,12 +2706,9 @@ void FileView::updateListHeaderView()
         }
 
         const QString &columnName = model()->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
-
-        if (!d->columnForRoleHiddenMap.contains(columnName)) {
-            d->headerView->setSectionHidden(logicalIndex, false);
-        } else {
-            d->headerView->setSectionHidden(logicalIndex, d->columnForRoleHiddenMap.value(columnName));
-        }
+        bool hidden = hiddenState.value(QString::number(curRole), curRole == kItemFileCreatedRole).toBool();
+        d->columnForRoleHiddenMap[columnName] = hidden;
+        d->headerView->setSectionHidden(logicalIndex, hidden);
     }
 
     if (d->adjustFileNameColumn) {


### PR DESCRIPTION
The column visibility (e.g. "Time created") in list/tree mode was only stored in the in-memory columnForRoleHiddenMap and never written to disk. initDefaultHeaderView() also hard-coded "Time created" as hidden on every new HeaderView, so any FileView reconstruction (process restart, new window/tab, or scheme switch) reset the user choice.

Persist the hidden state per-URL via setFileViewStateValue under the "columnHiddenState" key (QVariantMap keyed by role number), and load it in updateListHeaderView(). Columns without a persisted entry default to visible, except "Time created" which stays hidden by default.

列表模式各列的显隐状态（如"创建时间"）此前仅保存在内存中，从未写入
配置；initDefaultHeaderView() 每次新建表头时还硬编码"创建时间"为隐
藏，导致进程重启、新开窗口/标签页或切换 scheme 视图后用户设置丢失。

现按 URL 持久化列显隐状态（key 为 columnHiddenState，以 role 编号为 键），并在 updateListHeaderView() 中读取。未持久化的列默认显示，仅
"创建时间"默认隐藏。

Log: 持久化列表模式列显隐状态
Influence: 列表/树形模式列显隐设置可按目录记住

## Summary by Sourcery

Persist list view column visibility per directory URL and restore it when updating the list header view so user column visibility choices survive view reconstruction.

Bug Fixes:
- Fix loss of user-configured column visibility in list/tree view after process restarts, new windows/tabs, or scheme switches.

Enhancements:
- Store column hidden state per-item role under a new view state key and default unspecified columns to visible while keeping the created-time column hidden by default.