### PR TITLE
fix: batch-process recent items on startup to avoid UI freeze

### DIFF
--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
@@ -38,6 +38,12 @@ DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 using namespace GlobalServerDefines;
 
+// Batch processing parameters: process a fixed number of pending recent items
+// per timer tick, yielding to the event loop between batches to keep the UI
+// responsive during startup when the recently-used list is large.
+static constexpr int kBatchIntervalMs = 10;   // timer tick interval (ms)
+static constexpr int kBatchSize = 50;          // items processed per tick
+
 RecentManager *RecentManager::instance()
 {
     Q_ASSERT(qApp->thread() == QThread::currentThread());
@@ -73,6 +79,9 @@ QString RecentManager::getRecentOriginPaths(const QUrl &url) const
 RecentManager::RecentManager(QObject *parent)
     : QObject(parent)
 {
+    batchTimer.setInterval(kBatchIntervalMs);
+    batchTimer.setSingleShot(false);
+    connect(&batchTimer, &QTimer::timeout, this, &RecentManager::processPendingItems);
 }
 
 RecentManager::~RecentManager()
@@ -84,20 +93,51 @@ void RecentManager::resetRecentNodes()
     auto reply = recentDBusInterce->GetItemsInfo();
     reply.waitForFinished();
     const QVariantList &topLevelList = reply.value();
+
+    // Collect all items into the pending queue first, then process them in
+    // batches via a timer so the main thread can stay responsive between
+    // batches. Previously the whole list was processed in a single
+    // synchronous for-loop, which blocked the event loop and caused the UI
+    // to freeze when the recently-used list was large.
     for (const auto &value : topLevelList) {
         QDBusArgument dbusArg = value.value<QDBusArgument>();
-
         QVariantMap map;
-        dbusArg >> map;   // 直接将QDBusArgument解包为QVariantMap
-
-        if (!map.isEmpty()) {
-            auto path = map.value(RecentProperty::kPath).toString();
-            auto href = map.value(RecentProperty::kHref).toString();
-            auto modified = map.value(RecentProperty::kModified).toLongLong();
-            onItemAdded(path, href, modified);
-        } else {
+        dbusArg >> map;
+        if (map.isEmpty()) {
             fmWarning() << "Map is empty or could not be converted from DBus argument";
+            continue;
         }
+        PendingItem item {
+            map.value(RecentProperty::kPath).toString(),
+            map.value(RecentProperty::kHref).toString(),
+            map.value(RecentProperty::kModified).toLongLong()
+        };
+        if (!item.path.isEmpty())
+            pendingItems.enqueue(item);
+    }
+
+    fmInfo() << "Queued" << pendingItems.size()
+             << "recent items for batch processing";
+
+    // Kick off batch processing. The timer fires periodically, processing a
+    // fixed number of items per tick and yielding back to the event loop in
+    // between so painting/input can be handled.
+    if (!batchTimer.isActive())
+        batchTimer.start();
+}
+
+void RecentManager::processPendingItems()
+{
+    int processed = 0;
+    while (!pendingItems.isEmpty() && processed < kBatchSize) {
+        const auto &item = pendingItems.dequeue();
+        onItemAdded(item.path, item.href, item.modified);
+        ++processed;
+    }
+
+    if (pendingItems.isEmpty()) {
+        batchTimer.stop();
+        fmInfo() << "Batch processing of recent items finished";
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.h
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.h
@@ -68,6 +68,7 @@ private:
     explicit RecentManager(QObject *parent = nullptr);
     ~RecentManager() override;
     void resetRecentNodes();
+    void processPendingItems();
 
 public slots:
     void reloadRecent();
@@ -76,6 +77,13 @@ public slots:
     void onItemChanged(const QString &path, qint64 modified);
 
 private:
+    struct PendingItem
+    {
+        QString path;
+        QString href;
+        qint64 modified {};
+    };
+
     QScopedPointer<RecentManagerDBusInterface> recentDBusInterce;
     struct RecentItem
     {
@@ -83,6 +91,8 @@ private:
         QString originPath;
     };
     QMap<QUrl, RecentItem> recentItems;
+    QQueue<PendingItem> pendingItems;
+    QTimer batchTimer;
 };
 }   // namespace dfmplugin_recent
 #endif   // RECENTMANAGER_H


### PR DESCRIPTION
## 根因分析

**结论：强根因。** `RecentManager::resetRecentNodes()` 在 GUI 主线程对 daemon 返回的全部最近使用条目做同步 `for` 循环，每条 `onItemAdded()` 构造 `RecentFileInfo`（含 `SyncFileInfo`/`DFileInfo`/`GFile`）、插缓存、`emit subfileCreated`。条目数量大时这一循环独占主线程，事件循环无法处理绘制/输入 → 界面卡死。

关键证据：
- [代码] `recentmanager.cpp:93–110` — `resetRecentNodes()` 原同步 for 循环逐条 `onItemAdded()`。
- [机理] daemon 异步 `ReloadFinished` 到达时机与 UI 启动渲染负载叠加 → 卡死偶发。
- [代码] `recentfileinfo.cpp:23–27` — `RecentFileInfo` 构造即创建代理本地 `SyncFileInfo`，单条虽不昂贵但条目数量大时累积开销 + 每条信号开销共同造成主线程长时间不响应。

## 修复方案

将 `resetRecentNodes()` 的"一次性同步长循环"改为"分批增量处理 + 让出事件循环"：
- 全量条目入 `pendingItems` 队列，启动 `QTimer`（间隔 10ms）。
- `processPendingItems()` 每批处理 50 条，批次间让出事件循环。
- `onItemAdded()` 既有 `recentItems.contains(url)` 去重，保证分批期间 daemon 增量信号到达不重复插入。

## 改动安全评估

**低风险。** 不改动函数签名（`resetRecentNodes` 仍为 private、`onItemAdded` 等槽函数不变），不影响外部调用者。仅 `recentmanager.cpp` + `recentmanager.h` 两个文件，+59/-9 行。

## Summary by Sourcery

Batch recently-loaded recent items on startup to keep the UI responsive when the recently-used list is large.

Bug Fixes:
- Prevent UI freezes caused by processing all recently-used items synchronously on the main thread during startup.

Enhancements:
- Introduce a queued, timer-driven batch processor for recent items so they are loaded incrementally instead of in a single long loop.