### PR TITLE
fix: ensure sidebar drag-drop consistency between visual and actual position

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -111,7 +111,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     if (dragOffset != 0)
         opt.rect.translate(0, dragOffset);
 
-    if (sidebarView && !isDragPreview)
+    if (sidebarView && !isDragPreview && dragOffset != 0)
         painter->setClipRect(sidebarView->viewport()->rect());
     else
         painter->setClipRect(opt.rect);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -602,10 +602,28 @@ void SideBarView::dropEvent(QDropEvent *event)
     if (d->draggedUrl.isValid()) {   // select the dragged item when dropped.
         d->notifyOrderChanged();   // notify to update the persistence data
     }
-    if (isInternalDrag)
-        d->clearInternalDragState();
-
     d->dropPos = eventPos;
+
+    if (isInternalDrag) {
+        // Use calculatePlaceholderRow to ensure the actual drop row matches
+        // the visual placeholder shown during dragMoveEvent. The base class
+        // dropEvent relies on dropIndicatorPosition which is never updated
+        // because dragMoveEvent does not call the base class.
+        const int targetRow = d->calculatePlaceholderRow(eventPos, event->mimeData());
+        if (targetRow >= 0 && d->dragSourceIndex.isValid()) {
+            const QModelIndex parent = d->dragSourceIndex.parent();
+            if (auto *sidebarModel = model()) {
+                if (sidebarModel->dropMimeData(event->mimeData(), Qt::MoveAction,
+                                               targetRow, 0, parent)) {
+                    event->setDropAction(Qt::MoveAction);
+                    event->accept();
+                }
+            }
+        }
+        d->clearInternalDragState();
+        return;
+    }
+
     SideBarItem *item = itemAt(eventPos);
     if (!item)
         return DTreeView::dropEvent(event);


### PR DESCRIPTION
Fixed issue where sidebar internal drag-and-drop operations showed the
item in one position visually during drag but dropped it to a different
actual position. The problem occurred because the base class dropEvent
relied on dropIndicatorPosition which wasn't properly updated when
overriding dragMoveEvent.

1. Modified SideBarItemDelegate::paint() to apply clipRect when
sidebarView exists, not in drag preview, AND dragOffset is non-zero
2. Modified SideBarView::dropEvent() to calculate the actual drop row
using calculatePlaceholderRow() for internal drags
3. For internal drags, manually trigger model's dropMimeData with the
correct target row
4. Only apply DTreeView::dropEvent for external drops or when no valid
sidebar item is found

Log: Fixed sidebar drag-and-drop visual feedback inconsistency

Influence:
1. Test internal drag-and-drop between sidebar items - visual
placeholder should match final position
2. Test external drag into sidebar - should work normally
3. Verify drag feedback during movement (clip region application)
4. Test various drop positions (above, below, between items)
5. Verify model persistence after drag operations

fix: 修复侧边栏拖放操作视觉与实际位置不一致问题

修复侧边栏内部拖放操作中，拖拽时显示的位置与最终实际放置位置不一致的问
题。问题原因在于基类的dropEvent依赖于dropIndicatorPosition，而该值在重写
dragMoveEvent时未正确更新。

1. 修改 SideBarItemDelegate::paint()，仅在sidebarView存在、不是拖拽预
览、且dragOffset非零时应用clipRect
2. 修改 SideBarView::dropEvent()，对于内部拖拽使用
calculatePlaceholderRow()计算实际放置行
3. 对于内部拖拽，手动触发模型的dropMimeData并传入正确的目标行
4. 仅对外部拖放或找不到有效侧边栏项的情况应用DTreeView::dropEvent

Log: 修复侧边栏拖放视觉反馈与实际位置不一致的问题

Influence:
1. 测试侧边栏项目间的内部拖放 - 视觉占位符应与最终位置匹配
2. 测试从外部拖入侧边栏 - 应正常工作
3. 验证拖拽移动期间的视觉反馈（裁剪区域应用）
4. 测试各种放置位置（上方、下方、项目之间）
5. 验证拖拽操作后模型持久化是否正常

## Summary by Sourcery

Align sidebar internal drag-and-drop behavior so that the final dropped position matches the visual placeholder, while preserving external drop handling.

Bug Fixes:
- Ensure internal sidebar drag-and-drop uses the calculated placeholder row so the visual indicator and final drop position stay consistent.
- Correct sidebar item painting so the viewport clip is only applied when there is an actual drag offset, avoiding incorrect drag preview clipping.