### PR TITLE
fix(sidebar): add collapse animation for resize-triggered sidebar hide

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -216,6 +216,53 @@ void FileManagerWindowPrivate::animateSplitter(bool expanded)
     curSplitterAnimation->start();
 }
 
+void FileManagerWindowPrivate::animateSideBarForResize(bool expanded)
+{
+    if (!sideBar || !sidebarSep || !splitter)
+        return;
+
+    if (!isAnimationEnabled()) {
+        if (expanded)
+            showSideBar();
+        else
+            hideSideBar();
+        return;
+    }
+
+    // Skip if an animation is already running toward the same target.
+    // This prevents the sidebar from restarting its animation on every
+    // high-frequency resize event while the user is still dragging.
+    if (curSplitterAnimation && curSplitterAnimation->state() == QAbstractAnimation::Running) {
+        bool currentTarget = curSplitterAnimation->endValue().toInt() > 1;
+        if (currentTarget == expanded)
+            return;
+    }
+
+    // Set sideBarAutoVisible BEFORE the animation starts so that:
+    //  - During a collapse, if the user reverses direction and widens the
+    //    window, updateSideBarVisibility immediately fires the expand path.
+    //  - During an expand, a subsequent narrowing fires the collapse path.
+    // Both reversals rely on the flag being flipped at animation start, not
+    // at animation end.
+    sideBarAutoVisible = expanded;
+
+    bool lastAnimationStopped = setupAnimation(expanded);
+
+    // Start from the current splitter position so that mid-animation reversal
+    // does not cause a visual jump back to width 1 or lastSidebarExpandedPostion.
+    int start = splitter->sizes().at(0);
+    int end = expanded ? lastSidebarExpandedPostion : 1;
+
+    if (!expanded && !lastAnimationStopped)
+        lastSidebarExpandedPostion = splitter->sizes().at(0);
+
+    configureAnimation(start, end);
+    connectAnimationSignals();
+
+    Q_EMIT q->aboutToPlaySplitterAnimation(start, end);
+    curSplitterAnimation->start();
+}
+
 bool FileManagerWindowPrivate::isAnimationEnabled() const
 {
     return DConfigManager::instance()->value(kAnimationDConfName, kAnimationSidebarEnable, true).toBool();
@@ -651,13 +698,13 @@ void FileManagerWindowPrivate::updateSideBarVisibility()
     bool haveSpaceShowSidebar = totalWidth >= (actualMinRightWidth + kMinimumLeftWidth + splitter->handleWidth());
 
     if (haveSpaceShowSidebar && !sideBarAutoVisible) {
-        showSideBar();
+        animateSideBarForResize(true);
     } else if (!haveSpaceShowSidebar && sideBarAutoVisible) {
-        hideSideBar();
+        animateSideBarForResize(false);
     } else if (sideBarShrinking && sideBarAutoVisible) {
         int newSideBarWidth = totalWidth - actualMinRightWidth - splitter->handleWidth();
         if (newSideBarWidth <= kMinimumLeftWidth) {
-            hideSideBar();
+            animateSideBarForResize(false);
         }
     }
 

--- a/src/dfm-base/widgets/dfmwindow/private/filemanagerwindow_p.h
+++ b/src/dfm-base/widgets/dfmwindow/private/filemanagerwindow_p.h
@@ -51,6 +51,11 @@ public:
     void resetTitleBarSize();
     void resetSideBarSize();
     void animateSplitter(bool expanded);
+    // Animate sidebar show/hide triggered by window resize (not button click).
+    // Differs from animateSplitter: no window-geometry auto-resize, guards against
+    // high-frequency restart, and sets sideBarAutoVisible before animation so the
+    // sidebar can auto re-show after a resize-triggered collapse.
+    void animateSideBarForResize(bool expanded);
 
     void loadWindowState();
     void saveWindowState();


### PR DESCRIPTION
# fix(sidebar): add collapse animation for resize-triggered sidebar hide

## 问题

PMS BUG-353081: 手动调整窗口宽度，侧边栏收起无动效。

窗口 resize 触发的侧边栏显隐走 `resizeEvent → updateSideBarVisibility() → showSideBar()/hideSideBar()`，直接 `setVisible` 切换，无动画；而点击展开按钮走 `animateSplitter`，通过 `QPropertyAnimation` 平滑过渡。两条路径不一致导致收起时"很生硬"。

## 根因

`animateSplitter`（动画显隐）仅在展开按钮点击槽 `filemanagerwindow.cpp:1205` 被调用，resize 路径未接入动画，直接 `showSideBar/hideSideBar`。

## 修复

新增 `animateSideBarForResize(bool expanded)`，将 `updateSideBarVisibility()` 中对 `showSideBar()/hideSideBar()` 的直接调用替换为动画调用，复用 `animateSplitter` 的核心动画机制（`QPropertyAnimation` 驱动 `Splitter::splitPosition`）。针对 resize 场景定制三点：

1. **同方向动画防重启**：检测到已有同方向动画在运行时跳过，避免高频 resize 事件反复 stop+restart 动画导致抖动。
2. **从当前分隔条位置开始**：`start = splitter->sizes().at(0)`，收起动画中途用户反向拖宽窗口时，展开动画从当前实际位置平滑开始，不跳回宽度 1。
3. **动画开始前翻转 `sideBarAutoVisible`**：使方向反转能被 `updateSideBarVisibility` 立即检测并触发反向动画；同时保持用户主动点击展开按钮隐藏后不受窗口尺寸控制展开的原有语义。

## 边界处理验证

- ✅ 收起动画中途反向拖宽：`sideBarAutoVisible` 已为 false，立即触发展开动画，从当前位置平滑开始，无视觉跳动
- ✅ 用户主动按钮隐藏后窗口变宽：不经过 `animateSideBarForResize`（`sideBarAutoVisible` 保持 true），不自动展开
- ✅ sidebarSep / expandButton 一致性：复用 `connectAnimationSignals` 的 `finished` 回调统一设置可见性，`valueChanged` 逐帧更新 separator 位置
- ✅ 动画开关关闭：`isAnimationEnabled()` 检查，fallback 到直接 `showSideBar/hideSideBar`，行为兼容

## 改动

- `src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp` — 新增 `animateSideBarForResize()`，`updateSideBarVisibility()` 三处调用替换
- `src/dfm-base/widgets/dfmwindow/private/filemanagerwindow_p.h` — 新增方法声明

## 关联

- PMS: https://pms.uniontech.com/bug-view-353081.html

## Summary by Sourcery

Animate sidebar visibility changes when triggered by window resizing to align with button-triggered behavior and improve visual smoothness.

Bug Fixes:
- Apply animated show/hide transitions to the sidebar when it is automatically collapsed or expanded due to window resize events instead of toggling visibility instantly.

Enhancements:
- Introduce a dedicated resize-specific sidebar animation helper that reuses existing splitter animation, avoids redundant restarts during continuous resize, and preserves the current splitter position for smoother reversals.