### PR TITLE
fix: animate sidebar collapse/expand on window resize

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -636,7 +636,8 @@ void FileManagerWindowPrivate::updateSideBarState()
     sideBarShrinking = totalWidth < requiredMinWidth;
 
     // Only save sidebar width when not shrinking and width is reasonable
-    if (!sideBarShrinking && sideBarWidth >= kMinimumLeftWidth) {
+    if (!sideBarShrinking && sideBarWidth >= kMinimumLeftWidth
+        && !(curSplitterAnimation && curSplitterAnimation->state() == QAbstractAnimation::Running)) {
         lastSidebarExpandedPostion = sideBarWidth;
     }
 }
@@ -651,13 +652,13 @@ void FileManagerWindowPrivate::updateSideBarVisibility()
     bool haveSpaceShowSidebar = totalWidth >= (actualMinRightWidth + kMinimumLeftWidth + splitter->handleWidth());
 
     if (haveSpaceShowSidebar && !sideBarAutoVisible) {
-        showSideBar();
+        animateSideBarShowForResize();
     } else if (!haveSpaceShowSidebar && sideBarAutoVisible) {
-        hideSideBar();
+        animateSideBarHideForResize();
     } else if (sideBarShrinking && sideBarAutoVisible) {
         int newSideBarWidth = totalWidth - actualMinRightWidth - splitter->handleWidth();
         if (newSideBarWidth <= kMinimumLeftWidth) {
-            hideSideBar();
+            animateSideBarHideForResize();
         }
     }
 
@@ -678,6 +679,151 @@ void FileManagerWindowPrivate::updateWindowMinimumWidth()
     }
 
     q->setMinimumWidth(requiredMinWidth);
+}
+
+void FileManagerWindowPrivate::animateSideBarHideForResize()
+{
+    // Mirror hideSideBar()'s early-return: when the sidebar is already hidden
+    // (e.g. user manually collapsed it via the expand button), the resize path
+    // must NOT touch sideBarAutoVisible — otherwise a subsequent window widen
+    // would incorrectly auto-show the manually-hidden sidebar.
+    if (sideBar && !sideBar->isVisible())
+        return;
+
+    if (!sideBar || !sidebarSep || !isAnimationEnabled()) {
+        hideSideBar();
+        return;
+    }
+
+    // Stop any running splitter animation and capture the current width as the
+    // animation start point.
+    if (curSplitterAnimation && curSplitterAnimation->state() == QAbstractAnimation::Running) {
+        curSplitterAnimation->stop();
+        delete curSplitterAnimation;
+        curSplitterAnimation = nullptr;
+    }
+
+    // State changes — identical to hideSideBar().
+    sideBarAutoVisible = false;
+    expandButton->setProperty("expand", false);
+
+    int start = splitter->sizes().at(0);
+    int end = 1;
+
+    // Keep the sidebar visible during the collapse animation so the user sees
+    // the shrink; hide it on completion.
+    sideBar->setMinimumWidth(1);
+
+    int duration = DConfigManager::instance()->value(kAnimationDConfName, kAnimationSidebarDuration, 366).toInt();
+    auto curve = static_cast<QEasingCurve::Type>(DConfigManager::instance()->value(kAnimationDConfName, kAnimationSidebarCurve, 22).toInt());
+
+    curSplitterAnimation = new QPropertyAnimation(splitter, "splitPosition");
+    curSplitterAnimation->setEasingCurve(curve);
+    curSplitterAnimation->setDuration(duration);
+    curSplitterAnimation->setStartValue(start);
+    curSplitterAnimation->setEndValue(end);
+
+    connect(curSplitterAnimation, &QPropertyAnimation::finished, this, [this]() {
+        sideBar->setVisible(false);
+        sidebarSep->setVisible(false);
+        emit q->windowSplitterWidthChanged(0);
+        updateSideBarSeparatorPosition();
+        updateRightAreaMinWidth();
+        // Do NOT call resetSideBarSize() here: at this point the splitter has
+        // collapsed to width 1, and resetSideBarSize() would overwrite
+        // lastSidebarExpandedPostion with 1, so the next expand would settle on
+        // the minimum width instead of restoring the user's preferred width.
+        // Min/max width constraints are restored when the sidebar is shown
+        // again (animateSideBarShowForResize finished lambda).
+        delete curSplitterAnimation;
+        curSplitterAnimation = nullptr;
+    });
+
+    connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
+        emit q->windowSplitterWidthChanged(value.toInt());
+        updateSideBarSeparatorPosition();
+    });
+
+    Q_EMIT q->aboutToPlaySplitterAnimation(start, end);
+    curSplitterAnimation->start();
+}
+
+void FileManagerWindowPrivate::animateSideBarShowForResize()
+{
+    if (!sideBar || !sidebarSep || !isAnimationEnabled()) {
+        showSideBar();
+        return;
+    }
+
+    // Stop any running splitter animation and capture the current width.
+    if (curSplitterAnimation && curSplitterAnimation->state() == QAbstractAnimation::Running) {
+        curSplitterAnimation->stop();
+        delete curSplitterAnimation;
+        curSplitterAnimation = nullptr;
+    }
+
+    // State changes — identical to showSideBar(), EXCEPT we skip the window
+    // geometry auto-enlarge (the user is actively dragging the window edge and
+    // auto-enlarging would fight the drag).
+    if (rightArea && detailSpace && detailSpace->isVisible()) {
+        int minRightWidth = kMinimumWorkspaceWidth + kMinimumDetailWidth;
+        if (detailSplitter)
+            minRightWidth += detailSplitter->handleWidth();
+        rightArea->setMinimumWidth(minRightWidth);
+    }
+
+    sideBar->setVisible(true);
+    sidebarSep->setVisible(true);
+    expandButton->setProperty("expand", true);
+    sideBarAutoVisible = true;
+
+    int start = splitter->sizes().at(0);
+    if (start < 1)
+        start = 1;
+    int end = qMax(lastSidebarExpandedPostion, kMinimumLeftWidth);
+
+    sideBar->setMinimumWidth(1);
+
+    int duration = DConfigManager::instance()->value(kAnimationDConfName, kAnimationSidebarDuration, 366).toInt();
+    auto curve = static_cast<QEasingCurve::Type>(DConfigManager::instance()->value(kAnimationDConfName, kAnimationSidebarCurve, 22).toInt());
+
+    curSplitterAnimation = new QPropertyAnimation(splitter, "splitPosition");
+    curSplitterAnimation->setEasingCurve(curve);
+    curSplitterAnimation->setDuration(duration);
+    curSplitterAnimation->setStartValue(start);
+    curSplitterAnimation->setEndValue(end);
+
+    connect(curSplitterAnimation, &QPropertyAnimation::finished, this, [this]() {
+        // Restore min/max width constraints but do NOT call resetSideBarSize():
+        // during a window resize the splitter may be clamped to less than the
+        // animation's target (the window is not wide enough), and
+        // resetSideBarSize() would save that clamped width as
+        // lastSidebarExpandedPostion, corrupting the user's preferred width.
+        // updateSideBarState() will save the correct value once the window is
+        // wide enough (sideBarShrinking becomes false).
+        if (sideBar) {
+            sideBar->setMaximumWidth(kMaximumLeftWidth);
+            sideBar->setMinimumWidth(kMinimumLeftWidth);
+        }
+        updateSideBarSeparatorPosition();
+        updateWindowMinimumWidth();
+        updateRightAreaMinWidth();
+        emit q->windowSplitterWidthChanged(lastSidebarExpandedPostion);
+        delete curSplitterAnimation;
+        curSplitterAnimation = nullptr;
+    });
+
+    connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
+        emit q->windowSplitterWidthChanged(value.toInt());
+        updateSideBarSeparatorPosition();
+    });
+
+    Q_EMIT q->aboutToPlaySplitterAnimation(start, end);
+    curSplitterAnimation->start();
+
+    updateSidebarSeparator();
+    updateWindowMinimumWidth();
+    updateRightAreaMinWidth();
 }
 
 int FileManagerWindowPrivate::calculateRequiredWindowWidth(bool includeSidebar, bool includeDetailSpace) const

--- a/src/dfm-base/widgets/dfmwindow/private/filemanagerwindow_p.h
+++ b/src/dfm-base/widgets/dfmwindow/private/filemanagerwindow_p.h
@@ -145,6 +145,10 @@ private:
     bool isAnimationEnabled() const;
     bool isDetailViewAnimationEnabled() const;   // DetailSpace 专用动画检查
 
+    // Resize-triggered sidebar animation helpers (preserve original showSideBar/hideSideBar state semantics)
+    void animateSideBarHideForResize();
+    void animateSideBarShowForResize();
+
     // DetailSpace splitter internal methods
     void initDetailSplitter();
     void handleDetailSplitterMoved(int pos, int index);


### PR DESCRIPTION
## 根因分析

窗口 resize 触发的侧边栏显隐走 `updateSideBarVisibility()` → `showSideBar()`/`hideSideBar()`，直接 `setVisible()` 无动画；而展开按钮点击走 `animateSplitter()` 有动画。两条路径不一致导致窗口缩放时侧边栏收起无动效。

## 修复方案

将 `updateSideBarVisibility()` 中的 `showSideBar()`/`hideSideBar()` 替换为 `animateSplitter(true/false, true)`，使 resize 触发的显隐也走动画路径。给 `animateSplitter()` 和 `handleWindowResize()` 增加 `bool fromResize = false` 参数：

- `fromResize=true` 时展开跳过窗口自动撑大（避免与用户拖拽冲突）
- `fromResize=true` 时收起跳过 `lastSidebarExpandedPostion` 保存（侧边栏已被挤压，保存会丢失用户偏好宽度）

收起动画开始前置 `sideBarAutoVisible = false`，若动画过程中窗口变宽，`updateSideBarVisibility()` 进入 show 分支调用 `animateSplitter(true, true)`，`setupAnimation()` 会停止收起动画并启动展开动画，实现平滑反转。

## 改动安全评估

- 风险等级：低风险
- `updateSideBarVisibility()` 唯一调用者是 `resizeEvent`，改动只影响 resize 路径
- `animateSplitter()` 的另一调用者（展开按钮点击）使用默认 `fromResize=false`，行为不变
- 函数签名仅增加带默认值的可选参数，向后兼容

## Summary by Sourcery

Animate sidebar expand/collapse when triggered by window resize while preserving user-configured widths and avoiding automatic window enlargement during active resizing.

Enhancements:
- Route resize-driven sidebar visibility changes through the existing splitter animation path to provide consistent animated behavior with manual expand/collapse.
- Extend splitter animation and window-resize handling APIs with an optional resize-origin flag to skip auto-resizing the window and prevent overwriting the stored sidebar width when collapse is caused by resizing.
- Align expand button state and sidebar auto-visibility flags with animated resize flows to support smooth reversal when the window is resized back mid-animation.