### PR TITLE
feat: add last read time support for recent items

### DIFF
--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.cpp
@@ -26,6 +26,11 @@ RecentFileInfo::~RecentFileInfo()
 {
 }
 
+void RecentFileInfo::setLastReadTime(const QDateTime &time)
+{
+    lastReadTime = time;
+}
+
 bool RecentFileInfo::exists() const
 {
     return ProxyFileInfo::exists() || url == RecentHelper::rootUrl();
@@ -120,6 +125,8 @@ QString RecentFileInfo::displayOf(const FileInfo::DisplayInfoType type) const
 QVariant RecentFileInfo::timeOf(const FileTimeType type) const
 {
     switch (type) {
+    case TimeInfoType::kLastRead:
+        return lastReadTime;
     case TimeInfoType::kCustomerSupport:
         return timeOf(TimeInfoType::kLastRead);
     default:

--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.h
@@ -9,12 +9,16 @@
 
 #include <dfm-base/interfaces/proxyfileinfo.h>
 
+#include <QDateTime>
+
 namespace dfmplugin_recent {
 class RecentFileInfo : public DFMBASE_NAMESPACE::ProxyFileInfo
 {
 public:
     explicit RecentFileInfo(const QUrl &url);
     ~RecentFileInfo() override;
+
+    void setLastReadTime(const QDateTime &time);
 
     virtual bool exists() const override;
     virtual QFile::Permissions permissions() const override;
@@ -28,6 +32,9 @@ public:
 
     virtual QString displayOf(const DisplayInfoType type) const override;
     virtual QVariant timeOf(const FileTimeType type) const override;
+
+private:
+    QDateTime lastReadTime;
 };
 
 using RecentFileInfoPointer = QSharedPointer<RecentFileInfo>;

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
@@ -4,6 +4,7 @@
 
 #include "recentmanager.h"
 #include "events/recenteventcaller.h"
+#include "files/recentfileinfo.h"
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
@@ -42,7 +43,7 @@ using namespace GlobalServerDefines;
 // per timer tick, yielding to the event loop between batches to keep the UI
 // responsive during startup when the recently-used list is large.
 static constexpr int kBatchIntervalMs = 10;   // timer tick interval (ms)
-static constexpr int kBatchSize = 50;          // items processed per tick
+static constexpr int kBatchSize = 50;   // items processed per tick
 
 RecentManager *RecentManager::instance()
 {
@@ -207,12 +208,14 @@ void RecentManager::onItemAdded(const QString &path, const QString &href, qint64
         return;
     }
 
-    fmDebug() << "Adding recent item to cache:" << url;
+    fmDebug() << "Adding recent item to cache:" << url << modified;
     RecentItem item;
     item.fileInfo = info;
     item.originPath = href;
     recentItems.insert(url, item);
-    item.fileInfo->cacheAttribute(DFMIO::DFileInfo::AttributeID::kTimeAccess, modified);
+    auto recentInfo = item.fileInfo.dynamicCast<RecentFileInfo>();
+    if (recentInfo)
+        recentInfo->setLastReadTime(QDateTime::fromSecsSinceEpoch(modified));
 
     QSharedPointer<AbstractFileWatcher> watcher = WatcherCache::instance().getCacheWatcher(RecentHelper::rootUrl());
     if (watcher)
@@ -250,8 +253,9 @@ void RecentManager::onItemChanged(const QString &path, qint64 modified)
     }
 
     fmDebug() << "Updating recent item access time - path:" << path << "timestamp:" << modified;
-    QDateTime dateTime { QDateTime::fromSecsSinceEpoch(modified) };
-    recentItems[url].fileInfo->cacheAttribute(DFMIO::DFileInfo::AttributeID::kTimeAccess, modified);
+    auto recentInfo = recentItems[url].fileInfo.dynamicCast<RecentFileInfo>();
+    if (recentInfo)
+        recentInfo->setLastReadTime(QDateTime::fromSecsSinceEpoch(modified));
 
     QSharedPointer<AbstractFileWatcher> watcher = WatcherCache::instance().getCacheWatcher(RecentHelper::rootUrl());
     if (watcher)


### PR DESCRIPTION
Added last read time tracking for recent files to improve performance
and data consistency
1. Added setLastReadTime() method and lastReadTime member in
RecentFileInfo class
2. Modified timeOf() method to return custom last read time for recent
items
3. Updated RecentManager to set last read time directly on
RecentFileInfo objects instead of using DFileInfo attribute caching
4. This change ensures proper time synchronization between the recent
manager cache and file info objects

Log: Improved recent files management with direct last read time
tracking

Influence:
1. Test recent file access time display in file manager
2. Verify recent items are properly sorted by access time
3. Test adding new recent items and updating existing ones
4. Verify performance with large numbers of recent items
5. Test compatibility with existing recent files functionality

feat: 最近文件添加最后访问时间支持

为最近文件添加了最后访问时间追踪，以提高性能和数据一致性
1. 在 RecentFileInfo 类中添加了 setLastReadTime() 方法和 lastReadTime
成员
2. 修改 timeOf() 方法为最近项目返回自定义的最后读取时间
3. 更新 RecentManager 直接在 RecentFileInfo 对象上设置最后读取时间，而不
是使用 DFileInfo 属性缓存
4. 这一更改确保了最近管理器缓存和文件信息对象之间的正确时间同步

Log: 改进最近文件管理，直接追踪最后访问时间

Influence:
1. 测试文件管理器中最近文件访问时间的显示
2. 验证最近项目按访问时间正确排序
3. 测试添加新的最近项目和更新现有项目
4. 验证处理大量最近项目时的性能
5. 测试与现有最近文件功能的兼容性

## Summary by Sourcery

Add explicit last read time tracking for recent items to improve recent file access time handling and consistency.

New Features:
- Track last read time on recent files via RecentFileInfo and expose it through the timeOf API.

Enhancements:
- Update RecentManager to set and update last read time directly on RecentFileInfo instances instead of using generic file info attribute caching.