### PR TITLE
fix: ship dfm-reencrypt.desktop via package instead of runtime creation

### DIFF
--- a/debian/dde-file-manager.install
+++ b/debian/dde-file-manager.install
@@ -15,6 +15,7 @@ usr/lib/*/dde-file-manager/plugins/previews/*.so
 usr/lib/*/dde-file-manager/plugins/previews/*.json
 usr/share/applications/dde-file-manager.desktop
 usr/share/applications/dde-open.desktop
+usr/share/applications/dfm-reencrypt.desktop
 usr/share/dde-file-manager/translations/*.qm
 usr/share/dbus-1/interfaces/*.xml
 usr/share/dbus-1/services/*.service

--- a/src/services/diskencrypt/CMakeLists.txt
+++ b/src/services/diskencrypt/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_options(${BIN_NAME} PRIVATE -pie)
 
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_NAME}.json DESTINATION share/deepin-service-manager/other/)
+install(FILES dfm-reencrypt.desktop DESTINATION share/applications)
 install(FILES org.deepin.filemanager.diskencrypt.conf DESTINATION share/dbus-1/system.d/)
 install(FILES deepin-filemanager-diskencrypt.service DESTINATION lib/systemd/system/)
 install(FILES deepin-diskencrypt-tmpfiles.conf DESTINATION lib/tmpfiles.d/)

--- a/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
+++ b/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
@@ -8,4 +8,3 @@
 # Type Path                            Mode UID  GID  Age Argument
 d     /etc/usec-crypt                   0755 root root -   -
 d     /boot/usec-crypt                  0755 root root -   -
-d     /usr/local/share/applications     0755 root root -   -

--- a/src/services/diskencrypt/dfm-reencrypt.desktop
+++ b/src/services/diskencrypt/dfm-reencrypt.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Categories=System;
+Comment=To auto launch reencryption
+Exec=/usr/libexec/dde-file-manager -d
+GenericName=Disk Reencrypt
+Icon=dde-file-manager
+Name=Disk Reencrypt
+Terminal=false
+Type=Application
+NoDisplay=true
+X-AppStream-Ignore=true
+X-Deepin-AppID=dde-file-manager
+X-Deepin-Vendor=deepin

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -24,7 +24,7 @@ static QString toBase64(const QString rawstr)
 }
 
 inline constexpr char kUSecConfigDir[] { "/etc/usec-crypt" };
-inline constexpr char kReencryptDesktopFile[] { "/usr/local/share/applications/dfm-reencrypt.desktop" };
+inline constexpr char kReencryptDesktopFile[] { "/usr/share/applications/dfm-reencrypt.desktop" };
 inline constexpr char kRebootFlagFilePrefix[] { "/tmp/dfm_encrypt_reboot_flag_" };
 
 namespace job_type {

--- a/src/services/diskencrypt/helpers/commonhelper.cpp
+++ b/src/services/diskencrypt/helpers/commonhelper.cpp
@@ -10,57 +10,23 @@
 #include <QFile>
 #include <QLibrary>
 #include <QRandomGenerator>
-#include <QDir>
 
 #include <DConfig>
-#include <unistd.h>
 
 FILE_ENCRYPT_USE_NS
 
 void common_helper::createDFMDesktopEntry()
 {
-    qInfo() << "[common_helper::createDFMDesktopEntry] Creating DFM desktop entry for reencryption";
-
-    const QString &kLocalShareApps = "/usr/local/share/applications";
-    QDir d(kLocalShareApps);
-    if (!d.exists()) {
-        auto ok = d.mkpath(kLocalShareApps);
-        qInfo() << "[common_helper::createDFMDesktopEntry] Applications directory created:" << kLocalShareApps << "success:" << ok;
+    // The desktop file is shipped via the package (installed to
+    // /usr/share/applications/dfm-reencrypt.desktop). There is no need to
+    // create it at runtime anymore -- writing to /usr at runtime fails on
+    // immutable systems (磐石) and triggers security interception.
+    // Keep this function as a no-op compatibility stub so existing callers
+    // (DiskEncryptSetupPrivate::initialize) stay unaffected.
+    if (!QFile::exists(disk_encrypt::kReencryptDesktopFile)) {
+        qWarning() << "[common_helper::createDFMDesktopEntry] Reencrypt desktop file is missing,"
+                   << "it should be shipped by the package:" << disk_encrypt::kReencryptDesktopFile;
     }
-
-    QFile f(disk_encrypt::kReencryptDesktopFile);
-    if (f.exists()) {
-        qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file already exists, skipping creation:" << disk_encrypt::kReencryptDesktopFile;
-        return;
-    }
-
-    QByteArray desktop {
-        "[Desktop Entry]\n"
-        "Categories=System;\n"
-        "Comment=To auto launch reencryption\n"
-        "Exec=/usr/libexec/dde-file-manager -d\n"
-        "GenericName=Disk Reencrypt\n"
-        "Icon=dde-file-manager\n"
-        "Name=Disk Reencrypt\n"
-        "Terminal=false\n"
-        "Type=Application\n"
-        "NoDisplay=true\n"
-        "X-AppStream-Ignore=true\n"
-        "X-Deepin-AppID=dde-file-manager\n"
-        "X-Deepin-Vendor=deepin\n"
-    };
-
-    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        qCritical() << "[common_helper::createDFMDesktopEntry] Failed to open desktop file for writing:" << disk_encrypt::kReencryptDesktopFile;
-        return;
-    }
-    f.write(desktop);
-    f.flush();
-    auto ret = ::fsync(f.handle());
-    f.close();
-
-    qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file created successfully:" << disk_encrypt::kReencryptDesktopFile
-            << "Sync status: " << ret;
 }
 
 QString common_helper::encryptCipher()


### PR DESCRIPTION
## 根因分析

磐石（不可变系统）下 `/usr` 只读，而 diskencrypt 服务初始化时 `common_helper::createDFMDesktopEntry()` 硬编码向 `/usr/local/share/applications/dfm-reencrypt.desktop` 写入 desktop 文件，写入失败触发安全拦截，导致文件管理器首次打开异常、文件索引选项缺失。

关键证据：
- `src/services/diskencrypt/globaltypesdefine.h:27` — `kReencryptDesktopFile` 硬编码为 `/usr/local/share/applications/dfm-reencrypt.desktop`
- `src/services/diskencrypt/helpers/commonhelper.cpp:24,50` — `createDFMDesktopEntry()` 运行时 `mkpath` + `open(WriteOnly)` 写入该只读路径，磐石下失败
- desktop 文件内容完全静态（无运行时变量），无需运行时生成

## 修复方案

改为通过 debian 包安装静态 desktop 文件到 `/usr/share/applications/`，移除运行时写入只读路径的逻辑：
1. 新增静态 `dfm-reencrypt.desktop` 文件
2. CMakeLists 安装到 `/usr/share/applications/`，debian install 同步添加
3. `kReencryptDesktopFile` 路径常量更新为包安装路径
4. `createDFMDesktopEntry()` 简化为仅检查文件存在性（保留函数避免调用者改动）
5. 移除 tmpfiles.d 中 `/usr/local/share/applications` 目录创建条目

## 改动安全评估

低风险。函数签名不变，`createDFMDesktopEntry()` 变为空操作（文件已存在），调用者 `DiskEncryptSetupPrivate::initialize()` 不受影响。`setAutoStartDFM()` 通过 `kReencryptDesktopFile` 读取 desktop 文件，路径常量更新后 AM1 的 appId 提取和 autostart 复制逻辑均不变。

历史考察确认：运行时创建是早期实现便利选择，desktop 文件内容完全静态，无运行时动态变量，改为包安装安全正确。

## Summary by Sourcery

Ship the dfm-reencrypt desktop entry via packaging instead of runtime creation to avoid writes to read-only /usr on immutable systems.

Bug Fixes:
- Prevent diskencrypt initialization from failing on immutable systems due to attempts to create dfm-reencrypt.desktop under /usr/local at runtime.

Enhancements:
- Simplify createDFMDesktopEntry into a no-op compatibility stub that only verifies the presence of the packaged desktop file.

Build:
- Install the static dfm-reencrypt.desktop file to /usr/share/applications via CMake and Debian packaging, and stop creating /usr/local/share/applications via tmpfiles.d.