### PR TITLE
bug-fix-372103

### DIFF
--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.cpp
@@ -26,6 +26,11 @@ RecentFileInfo::~RecentFileInfo()
 {
 }
 
+void RecentFileInfo::setLastReadTime(const QDateTime &time)
+{
+    lastReadTime = time;
+}
+
 bool RecentFileInfo::exists() const
 {
     return ProxyFileInfo::exists() || url == RecentHelper::rootUrl();
@@ -120,6 +125,8 @@ QString RecentFileInfo::displayOf(const FileInfo::DisplayInfoType type) const
 QVariant RecentFileInfo::timeOf(const FileTimeType type) const
 {
     switch (type) {
+    case TimeInfoType::kLastRead:
+        return lastReadTime;
     case TimeInfoType::kCustomerSupport:
         return timeOf(TimeInfoType::kLastRead);
     default:

--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.h
@@ -9,12 +9,16 @@
 
 #include <dfm-base/interfaces/proxyfileinfo.h>
 
+#include <QDateTime>
+
 namespace dfmplugin_recent {
 class RecentFileInfo : public DFMBASE_NAMESPACE::ProxyFileInfo
 {
 public:
     explicit RecentFileInfo(const QUrl &url);
     ~RecentFileInfo() override;
+
+    void setLastReadTime(const QDateTime &time);
 
     virtual bool exists() const override;
     virtual QFile::Permissions permissions() const override;
@@ -28,6 +32,9 @@ public:
 
     virtual QString displayOf(const DisplayInfoType type) const override;
     virtual QVariant timeOf(const FileTimeType type) const override;
+
+private:
+    QDateTime lastReadTime;
 };
 
 using RecentFileInfoPointer = QSharedPointer<RecentFileInfo>;

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
@@ -38,6 +38,12 @@ DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 using namespace GlobalServerDefines;
 
+// Batch processing parameters: process a fixed number of pending recent items
+// per timer tick, yielding to the event loop between batches to keep the UI
+// responsive during startup when the recently-used list is large.
+static constexpr int kBatchIntervalMs = 10;   // timer tick interval (ms)
+static constexpr int kBatchSize = 50;          // items processed per tick
+
 RecentManager *RecentManager::instance()
 {
     Q_ASSERT(qApp->thread() == QThread::currentThread());
@@ -73,6 +79,9 @@ QString RecentManager::getRecentOriginPaths(const QUrl &url) const
 RecentManager::RecentManager(QObject *parent)
     : QObject(parent)
 {
+    batchTimer.setInterval(kBatchIntervalMs);
+    batchTimer.setSingleShot(false);
+    connect(&batchTimer, &QTimer::timeout, this, &RecentManager::processPendingItems);
 }
 
 RecentManager::~RecentManager()
@@ -84,20 +93,51 @@ void RecentManager::resetRecentNodes()
     auto reply = recentDBusInterce->GetItemsInfo();
     reply.waitForFinished();
     const QVariantList &topLevelList = reply.value();
+
+    // Collect all items into the pending queue first, then process them in
+    // batches via a timer so the main thread can stay responsive between
+    // batches. Previously the whole list was processed in a single
+    // synchronous for-loop, which blocked the event loop and caused the UI
+    // to freeze when the recently-used list was large.
     for (const auto &value : topLevelList) {
         QDBusArgument dbusArg = value.value<QDBusArgument>();
-
         QVariantMap map;
-        dbusArg >> map;   // 直接将QDBusArgument解包为QVariantMap
-
-        if (!map.isEmpty()) {
-            auto path = map.value(RecentProperty::kPath).toString();
-            auto href = map.value(RecentProperty::kHref).toString();
-            auto modified = map.value(RecentProperty::kModified).toLongLong();
-            onItemAdded(path, href, modified);
-        } else {
+        dbusArg >> map;
+        if (map.isEmpty()) {
             fmWarning() << "Map is empty or could not be converted from DBus argument";
+            continue;
         }
+        PendingItem item {
+            map.value(RecentProperty::kPath).toString(),
+            map.value(RecentProperty::kHref).toString(),
+            map.value(RecentProperty::kModified).toLongLong()
+        };
+        if (!item.path.isEmpty())
+            pendingItems.enqueue(item);
+    }
+
+    fmInfo() << "Queued" << pendingItems.size()
+             << "recent items for batch processing";
+
+    // Kick off batch processing. The timer fires periodically, processing a
+    // fixed number of items per tick and yielding back to the event loop in
+    // between so painting/input can be handled.
+    if (!batchTimer.isActive())
+        batchTimer.start();
+}
+
+void RecentManager::processPendingItems()
+{
+    int processed = 0;
+    while (!pendingItems.isEmpty() && processed < kBatchSize) {
+        const auto &item = pendingItems.dequeue();
+        onItemAdded(item.path, item.href, item.modified);
+        ++processed;
+    }
+
+    if (pendingItems.isEmpty()) {
+        batchTimer.stop();
+        fmInfo() << "Batch processing of recent items finished";
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
@@ -4,6 +4,7 @@
 
 #include "recentmanager.h"
 #include "events/recenteventcaller.h"
+#include "files/recentfileinfo.h"
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
@@ -42,7 +43,7 @@ using namespace GlobalServerDefines;
 // per timer tick, yielding to the event loop between batches to keep the UI
 // responsive during startup when the recently-used list is large.
 static constexpr int kBatchIntervalMs = 10;   // timer tick interval (ms)
-static constexpr int kBatchSize = 50;          // items processed per tick
+static constexpr int kBatchSize = 50;   // items processed per tick
 
 RecentManager *RecentManager::instance()
 {
@@ -207,12 +208,14 @@ void RecentManager::onItemAdded(const QString &path, const QString &href, qint64
         return;
     }
 
-    fmDebug() << "Adding recent item to cache:" << url;
+    fmDebug() << "Adding recent item to cache:" << url << modified;
     RecentItem item;
     item.fileInfo = info;
     item.originPath = href;
     recentItems.insert(url, item);
-    item.fileInfo->cacheAttribute(DFMIO::DFileInfo::AttributeID::kTimeAccess, modified);
+    auto recentInfo = item.fileInfo.dynamicCast<RecentFileInfo>();
+    if (recentInfo)
+        recentInfo->setLastReadTime(QDateTime::fromSecsSinceEpoch(modified));
 
     QSharedPointer<AbstractFileWatcher> watcher = WatcherCache::instance().getCacheWatcher(RecentHelper::rootUrl());
     if (watcher)
@@ -250,8 +253,9 @@ void RecentManager::onItemChanged(const QString &path, qint64 modified)
     }
 
     fmDebug() << "Updating recent item access time - path:" << path << "timestamp:" << modified;
-    QDateTime dateTime { QDateTime::fromSecsSinceEpoch(modified) };
-    recentItems[url].fileInfo->cacheAttribute(DFMIO::DFileInfo::AttributeID::kTimeAccess, modified);
+    auto recentInfo = recentItems[url].fileInfo.dynamicCast<RecentFileInfo>();
+    if (recentInfo)
+        recentInfo->setLastReadTime(QDateTime::fromSecsSinceEpoch(modified));
 
     QSharedPointer<AbstractFileWatcher> watcher = WatcherCache::instance().getCacheWatcher(RecentHelper::rootUrl());
     if (watcher)

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.h
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.h
@@ -68,6 +68,7 @@ private:
     explicit RecentManager(QObject *parent = nullptr);
     ~RecentManager() override;
     void resetRecentNodes();
+    void processPendingItems();
 
 public slots:
     void reloadRecent();
@@ -76,6 +77,13 @@ public slots:
     void onItemChanged(const QString &path, qint64 modified);
 
 private:
+    struct PendingItem
+    {
+        QString path;
+        QString href;
+        qint64 modified {};
+    };
+
     QScopedPointer<RecentManagerDBusInterface> recentDBusInterce;
     struct RecentItem
     {
@@ -83,6 +91,8 @@ private:
         QString originPath;
     };
     QMap<QUrl, RecentItem> recentItems;
+    QQueue<PendingItem> pendingItems;
+    QTimer batchTimer;
 };
 }   // namespace dfmplugin_recent
 #endif   // RECENTMANAGER_H


### PR DESCRIPTION
- **fix: batch-process recent items on startup to avoid UI freeze**
- **fix: add last read time support for recent items**

## Summary by Sourcery

Batch recent-item initialization to keep the UI responsive on startup and add explicit last-read time handling for recent items.

New Features:
- Introduce batch processing of recent items via a pending queue and timer to avoid blocking the main thread when loading a large recent list.
- Add dedicated last-read time support to RecentFileInfo and wire it into recent item add/change handling.

Bug Fixes:
- Prevent UI freezes during startup by avoiding synchronous processing of all recent items in a single loop.