### PR TITLE
feat: make vault context menu actions configurable via DConfig

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.vault.json
+++ b/assets/configs/org.deepin.dde.file-manager.vault.json
@@ -12,6 +12,56 @@
             "description[zh_CN]": "联网环境下，是否可以解锁保险箱。默认值(true)，可选值(true, false)",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "emptyMenuActions": {
+            "value": [
+                "new-folder",
+                "new-document",
+                "separator-line",
+                "display-as",
+                "sort-by",
+                "group-by",
+                "refresh",
+                "separator-line",
+                "paste",
+                "select-all",
+                "property"
+            ],
+            "serial": 0,
+            "flags": [],
+            "name": "空白区域菜单项",
+            "name[zh_CN]": "空白区域菜单项",
+            "description": "保险箱空白区域的右键菜单项配置",
+            "description[zh_CN]": "保险箱空白区域的右键菜单项配置",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "normalMenuActions": {
+            "value": [
+                "open",
+                "open-with",
+                "separator-line",
+                "open-in-new-window",
+                "open-in-new-tab",
+                "stage-file-to-burning",
+                "cut",
+                "copy",
+                "rename",
+                "delete",
+                "reverse-select",
+                "separator-line",
+                "file-shred",
+                "send-to",
+                "property"
+            ],
+            "serial": 0,
+            "flags": [],
+            "name": "常规菜单项",
+            "name[zh_CN]": "常规菜单项",
+            "description": "保险箱常规右键菜单项配置",
+            "description[zh_CN]": "保险箱常规右键菜单项配置",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
 }

--- a/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/menus/vaultmenuscene.cpp
@@ -9,6 +9,7 @@
 #include "plugins/common/dfmplugin-menu/menuscene/action_defines.h"
 
 #include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <QMenu>
 #include <QList>
@@ -32,7 +33,7 @@ VaultMenuScenePrivate::VaultMenuScenePrivate(VaultMenuScene *qq)
 
 QStringList VaultMenuScenePrivate::emptyMenuActionRule()
 {
-    static QStringList actionRule {
+    static QStringList defaultActionRule {
         "new-folder",
         "new-document",
         "separator-line",
@@ -46,12 +47,18 @@ QStringList VaultMenuScenePrivate::emptyMenuActionRule()
         "property"
     };
 
-    return actionRule;
+    const QVariant vRe = DConfigManager::instance()->value(kVaultDConfigName, "emptyMenuActions");
+    if (!vRe.isValid()) {
+        DConfigManager::instance()->setValue(kVaultDConfigName, "emptyMenuActions", defaultActionRule);
+        return defaultActionRule;
+    }
+
+    return vRe.toStringList();
 }
 
 QStringList VaultMenuScenePrivate::normalMenuActionRule()
 {
-    static QStringList actionRule {
+    static QStringList defaultActionRule {
         "open",
         "open-with",
         "separator-line",
@@ -69,7 +76,13 @@ QStringList VaultMenuScenePrivate::normalMenuActionRule()
         "property"
     };
 
-    return actionRule;
+    const QVariant vRe = DConfigManager::instance()->value(kVaultDConfigName, "normalMenuActions");
+    if (!vRe.isValid()) {
+        DConfigManager::instance()->setValue(kVaultDConfigName, "normalMenuActions", defaultActionRule);
+        return defaultActionRule;
+    }
+
+    return vRe.toStringList();
 }
 
 void VaultMenuScenePrivate::filterMenuAction(QMenu *menu, const QStringList &actions)


### PR DESCRIPTION
Previously, the vault's right-click context menu actions for empty
areas and normal files were hardcoded into static lists. This
change introduces two new DConfig entries (`emptyMenuActions` and
`normalMenuActions`) in the vault configuration file, allowing system
administrators or users to customize which actions appear in the
vault's context menus. The C++ code now reads these configurations from
DConfigManager, falling back to the original default lists if the config
keys are invalid or missing. This enables dynamic management of vault
menu items without code changes.

Log: Added DConfig support for vault context menu customization

Influence:
1. Test empty area context menu in vault: verify that default actions
(new-folder, new-document, display-as, sort-by, etc.) appear as
expected.
2. Test normal file context menu in vault: verify that default actions
(open, open-with, cut, copy, delete, property, etc.) appear.
3. Modify the DConfig values (e.g., via dconfig-center or manually) to
add/remove actions and verify the menu updates accordingly.
4. Test with invalid or missing config keys: ensure the fallback to
default lists works correctly.
5. Verify that the configuration is readwrite and private, as intended.
6. Test on both Chinese and English locales to ensure the description
and name fields are displayed correctly.

feat: 使保险箱右键菜单项可通过DConfig配置

之前，保险箱空白区域和常规文件的右键菜单动作被硬编码在静态列表中。
此修改在保险箱配置文件中新增了两个DConfig条目（`emptyMenuActions`和
`normalMenuActions`），允许系统管理员或用户自定义保险箱右键菜单中显示的
动作。C++代码现在从DConfigManager读取这些配置，如果配置键无效或缺失，则
回退到原始的默认列表。这使得无需修改代码即可动态管理保险箱菜单项。

Log: 为保险箱右键菜单自定义添加DConfig支持

Influence:
1. 测试保险箱空白区域右键菜单：验证默认动作（新建文件夹、新建文档、显示
方式、排序方式等）正常显示。
2. 测试保险箱常规文件右键菜单：验证默认动作（打开、打开方式、剪切、复
制、删除、属性等）正常显示。
3. 修改DConfig的值（例如通过dconfig-center或手动修改），增删动作，验证菜
单更新正确。
4. 测试无效或缺失的配置键：确保回退到默认列表的逻辑正常。
5. 验证配置项为可读写且私有属性。
6. 在中文和英文环境下测试，确保描述和名称字段正确显示。

TASK: https://pms.uniontech.com/task-view-393123.html

## Summary by Sourcery

Make vault context menu actions configurable via DConfig while preserving existing defaults.

New Features:
- Introduce configurable DConfig entries for empty-area and normal-file vault context menus to allow customization of visible actions.

Enhancements:
- Persist user- or admin-defined context menu action lists in vault DConfig, falling back to the previous static defaults when configuration is missing or invalid.