### PR TITLE
fix(image-preview): fix italic font and color issue in status bar

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
@@ -16,6 +16,8 @@
 #include <QLabel>
 #include <QFileInfo>
 #include <QMimeData>
+ 
+#include <DGuiApplicationHelper>
 
 DFMBASE_USE_NAMESPACE
 using namespace plugin_filepreview;
@@ -76,9 +78,12 @@ void ImagePreview::initialize(QWidget *window, QWidget *statusBar)
     fmDebug() << "Image preview: initializing with status bar";
 
     messageStatusBar = new QLabel(statusBar);
-    messageStatusBar->setStyleSheet("QLabel{font-family: Helvetica;\
-                                   font-size: 12px;\
-                                   font-weight: 300;}");
+    // 不使用 setStyleSheet 设置字号——stylesheet 会阻断 DTK 调色板随主题更新，
+    // 导致深色模式下文字颜色不随主题变化（卡在白色）。改用 QFont 保留调色板传播，
+    // 同时避免显式指定 Helvetica + font-weight 300 触发 fontconfig 斜体回退。
+    QFont statusBarFont = messageStatusBar->font();
+    statusBarFont.setPixelSize(12);
+    messageStatusBar->setFont(statusBarFont);
     // Expanding 水平策略：让 messageStatusBar 在 QHBoxLayout 中抢占 previewTitle 与 openBtn
     // 之间的多余空间，配合 AlignCenter 使分辨率文本在该空间内居中——previewTitle 短时
     // 接近 statusBar 几何中心，previewTitle 长时多余空间被压缩，标签自然回缩避让。


### PR DESCRIPTION
## 修复内容

1. 移除 setStyleSheet 中指定的 Helvetica + font-weight 300，避免 fontconfig 斜体回退导致分辨率文本显示倾斜
2. 改用 QFont::setPixelSize 设置字号，保留 DTK 调色板随主题更新的传播机制
3. 修复深色模式下分辨率文字颜色不随主题变化的问题（setStyleSheet 会阻断 DTK 调色板传播）

## 问题原因

图片预览状态栏的 QLabel 使用了 `setStyleSheet("QLabel{font-family: Helvetica; font-size: 12px; font-weight: 300;}")` 设置字体样式，导致两个问题：

- **文字倾斜**：`font-weight: 300`（Light 字重）配合 `font-family: Helvetica`，当系统没有 Helvetica Light 字体时，fontconfig 会回退到斜体样式
- **深色模式颜色异常**：setStyleSheet 会阻断 DTK 调色板随主题更新的传播机制，导致深色模式下文字颜色卡在白色

## 修复方案

将 `setStyleSheet` 替换为 `QFont::setPixelSize`，与同文件状态栏中 `openBtn` 的做法一致。去掉 stylesheet 后，QLabel 的文字颜色重新由 DTK 调色板统一管理。

## PMS

[PMS: BUG-371945](https://pms.uniontech.com/bug-view-371945.html)

## Summary by Sourcery

Adjust image preview status bar label styling to rely on DTK palette and prevent unintended italic rendering.

Bug Fixes:
- Fix image preview status bar resolution text appearing italic due to Helvetica light-weight font fallback.
- Fix image preview status bar text color not updating correctly in dark mode because stylesheet usage blocked DTK palette propagation.

Enhancements:
- Use QFont pixel size configuration for the status bar label to align with existing button styling and maintain theme-driven appearance.