### PR TITLE
fix: remove GIF from wallpaper supported types in file context menu

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -126,7 +126,7 @@ bool FileOperatorMenuScene::create(QMenu *parent)
         }
 
         const auto mimeType = focusFileInfo->nameOf(NameInfoType::kMimeTypeName);
-        QList<QVariant> supportedTypes = { "image/jpeg", "image/png", "image/bmp", "image/tiff", "image/gif" };
+        QList<QVariant> supportedTypes = { "image/jpeg", "image/png", "image/bmp", "image/tiff" };
         if (supportedTypes.contains(mimeType) && focusFileInfo->isAttributes(OptInfoType::kIsReadable)) {
             tempAction = parent->addAction(d->predicateName.value(ActionID::kSetAsWallpaper));
             d->predicateAction[ActionID::kSetAsWallpaper] = tempAction;


### PR DESCRIPTION
## 根因分析

`src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp:129` 的 `supportedTypes` 列表显式包含了 `"image/gif"`，当右键 GIF 文件时 MIME `image/gif` 命中该列表，"设置壁纸"菜单项被创建并显示。而壁纸系统（treeland/appearance DBus 服务）不支持将 GIF 动图设为静态壁纸，因此设置不生效。

该行自 2022-12-26（commit `f65662b57d`）引入即包含 `"image/gif"`，6.6.1 之后无后续修复。

## 修复方案

从 `supportedTypes` 列表中移除 `"image/gif"`，使右键 GIF 文件时不再显示"设置壁纸"菜单项。仅影响 GIF 格式，jpeg/png/bmp/tiff 不受影响。

## 改动安全评估

**低风险**。仅从局部变量 `supportedTypes` 移除一个字符串字面量，无外部调用者，无函数签名变更，无回归风险。

## Summary by Sourcery

Bug Fixes:
- Hide the "Set as wallpaper" menu item for GIF files, which are not supported by the wallpaper system.