### PR TITLE
fix: remove GIF from wallpaper supported types in file context menu

### DIFF
--- a/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -126,7 +126,7 @@ bool FileOperatorMenuScene::create(QMenu *parent)
         }
 
         const auto mimeType = focusFileInfo->nameOf(NameInfoType::kMimeTypeName);
-        QList<QVariant> supportedTypes = { "image/jpeg", "image/png", "image/bmp", "image/tiff", "image/gif" };
+        QList<QVariant> supportedTypes = { "image/jpeg", "image/png", "image/bmp", "image/tiff" };
         if (supportedTypes.contains(mimeType) && focusFileInfo->isAttributes(OptInfoType::kIsReadable)) {
             tempAction = parent->addAction(d->predicateName.value(ActionID::kSetAsWallpaper));
             d->predicateAction[ActionID::kSetAsWallpaper] = tempAction;


### PR DESCRIPTION
## Cherry-pick to release/snipe

将 BUG #372161 的修复提交 cherry-pick 到 `release/snipe` 分支。

### 根因
`src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp` 的 `supportedTypes` 列表包含 `"image/gif"`，导致右键 GIF 图片时显示无效的"设置壁纸"菜单项。壁纸系统不支持 GIF 设为静态壁纸。

### 修复
从 `supportedTypes` 列表移除 `"image/gif"`，仅影响 GIF 格式，jpeg/png/bmp/tiff 不受影响。

### 改动安全
低风险，1 行改动，无外部调用者，无回归风险。已在 master 分支完成 review（Grade A）。

关联 PR (master): https://github.com/linuxdeepin/dde-file-manager/pull/4022

## Summary by Sourcery

Bug Fixes:
- Remove GIF from the supported wallpaper MIME types to prevent an invalid 'Set as wallpaper' option on GIF files.