### PR TITLE
fix: ship dfm-reencrypt.desktop via package instead of runtime creation

### DIFF
--- a/debian/dde-file-manager.install
+++ b/debian/dde-file-manager.install
@@ -15,6 +15,7 @@ usr/lib/*/dde-file-manager/plugins/previews/*.so
 usr/lib/*/dde-file-manager/plugins/previews/*.json
 usr/share/applications/dde-file-manager.desktop
 usr/share/applications/dde-open.desktop
+usr/share/applications/dfm-reencrypt.desktop
 usr/share/dde-file-manager/translations/*.qm
 usr/share/dbus-1/interfaces/*.xml
 usr/share/dbus-1/services/*.service

--- a/src/services/diskencrypt/CMakeLists.txt
+++ b/src/services/diskencrypt/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_options(${BIN_NAME} PRIVATE -pie)
 
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_NAME}.json DESTINATION share/deepin-service-manager/other/)
+install(FILES dfm-reencrypt.desktop DESTINATION share/applications)
 install(FILES org.deepin.filemanager.diskencrypt.conf DESTINATION share/dbus-1/system.d/)
 install(FILES deepin-filemanager-diskencrypt.service DESTINATION lib/systemd/system/)
 install(FILES deepin-diskencrypt-tmpfiles.conf DESTINATION lib/tmpfiles.d/)

--- a/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
+++ b/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
@@ -8,4 +8,3 @@
 # Type Path                            Mode UID  GID  Age Argument
 d     /etc/usec-crypt                   0755 root root -   -
 d     /boot/usec-crypt                  0755 root root -   -
-d     /usr/local/share/applications     0755 root root -   -

--- a/src/services/diskencrypt/dfm-reencrypt.desktop
+++ b/src/services/diskencrypt/dfm-reencrypt.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Categories=System;
+Comment=To auto launch reencryption
+Exec=/usr/libexec/dde-file-manager -d
+GenericName=Disk Reencrypt
+Icon=dde-file-manager
+Name=Disk Reencrypt
+Terminal=false
+Type=Application
+NoDisplay=true
+X-AppStream-Ignore=true
+X-Deepin-AppID=dde-file-manager
+X-Deepin-Vendor=deepin

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -24,7 +24,7 @@ static QString toBase64(const QString rawstr)
 }
 
 inline constexpr char kUSecConfigDir[] { "/etc/usec-crypt" };
-inline constexpr char kReencryptDesktopFile[] { "/usr/local/share/applications/dfm-reencrypt.desktop" };
+inline constexpr char kReencryptDesktopFile[] { "/usr/share/applications/dfm-reencrypt.desktop" };
 inline constexpr char kRebootFlagFilePrefix[] { "/tmp/dfm_encrypt_reboot_flag_" };
 
 namespace job_type {

--- a/src/services/diskencrypt/helpers/commonhelper.cpp
+++ b/src/services/diskencrypt/helpers/commonhelper.cpp
@@ -10,57 +10,23 @@
 #include <QFile>
 #include <QLibrary>
 #include <QRandomGenerator>
-#include <QDir>
 
 #include <DConfig>
-#include <unistd.h>
 
 FILE_ENCRYPT_USE_NS
 
 void common_helper::createDFMDesktopEntry()
 {
-    qInfo() << "[common_helper::createDFMDesktopEntry] Creating DFM desktop entry for reencryption";
-
-    const QString &kLocalShareApps = "/usr/local/share/applications";
-    QDir d(kLocalShareApps);
-    if (!d.exists()) {
-        auto ok = d.mkpath(kLocalShareApps);
-        qInfo() << "[common_helper::createDFMDesktopEntry] Applications directory created:" << kLocalShareApps << "success:" << ok;
+    // The desktop file is shipped via the package (installed to
+    // /usr/share/applications/dfm-reencrypt.desktop). There is no need to
+    // create it at runtime anymore -- writing to /usr at runtime fails on
+    // immutable systems (磐石) and triggers security interception.
+    // Keep this function as a no-op compatibility stub so existing callers
+    // (DiskEncryptSetupPrivate::initialize) stay unaffected.
+    if (!QFile::exists(disk_encrypt::kReencryptDesktopFile)) {
+        qWarning() << "[common_helper::createDFMDesktopEntry] Reencrypt desktop file is missing,"
+                   << "it should be shipped by the package:" << disk_encrypt::kReencryptDesktopFile;
     }
-
-    QFile f(disk_encrypt::kReencryptDesktopFile);
-    if (f.exists()) {
-        qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file already exists, skipping creation:" << disk_encrypt::kReencryptDesktopFile;
-        return;
-    }
-
-    QByteArray desktop {
-        "[Desktop Entry]\n"
-        "Categories=System;\n"
-        "Comment=To auto launch reencryption\n"
-        "Exec=/usr/libexec/dde-file-manager -d\n"
-        "GenericName=Disk Reencrypt\n"
-        "Icon=dde-file-manager\n"
-        "Name=Disk Reencrypt\n"
-        "Terminal=false\n"
-        "Type=Application\n"
-        "NoDisplay=true\n"
-        "X-AppStream-Ignore=true\n"
-        "X-Deepin-AppID=dde-file-manager\n"
-        "X-Deepin-Vendor=deepin\n"
-    };
-
-    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        qCritical() << "[common_helper::createDFMDesktopEntry] Failed to open desktop file for writing:" << disk_encrypt::kReencryptDesktopFile;
-        return;
-    }
-    f.write(desktop);
-    f.flush();
-    auto ret = ::fsync(f.handle());
-    f.close();
-
-    qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file created successfully:" << disk_encrypt::kReencryptDesktopFile
-            << "Sync status: " << ret;
 }
 
 QString common_helper::encryptCipher()


### PR DESCRIPTION
1. 新增静态 dfm-reencrypt.desktop 文件，内容与原运行时生成的一致;
2. 通过 CMakeLists 安装到 /usr/share/applications/，debian install 同步添加;
3. 将 kReencryptDesktopFile 路径常量从 /usr/local/share/applications/ 改为 /usr/share/applications/;
4. 简化 createDFMDesktopEntry() 为仅检查文件存在性，移除运行时写入逻辑;
5. 移除 tmpfiles.d 中 /usr/local/share/applications 目录创建条目;

=====================================

1. added static dfm-reencrypt.desktop file, content matches the original runtime-generated version;
2. installed to /usr/share/applications/ via CMakeLists, debian install updated accordingly;
3. changed kReencryptDesktopFile path constant from /usr/local/share/applications/ to /usr/share/applications/;
4. simplified createDFMDesktopEntry() to existence-check only, removed runtime write logic;
5. removed /usr/local/share/applications directory creation entry from tmpfiles.d;

Log: 磐石不可变系统下 /usr 只读，运行时写入 dfm-reencrypt.desktop 失败触发安全拦截，改为包安装静态文件

Bug: https://pms.uniontech.com/bug-view-372023.html

## Summary by Sourcery

Ship dfm-reencrypt.desktop as a static file via packaging instead of creating it at runtime, aligning paths with system directories and removing now-unnecessary tmpfiles setup.

New Features:
- Provide a packaged dfm-reencrypt.desktop desktop entry under /usr/share/applications.

Bug Fixes:
- Avoid runtime writes to /usr on immutable systems by relying on a pre-installed desktop file instead of generating it on startup.

Enhancements:
- Change the reencrypt desktop file path constant to point to /usr/share/applications instead of /usr/local/share/applications.
- Simplify createDFMDesktopEntry() to only verify the presence of the packaged desktop file and warn if missing.
- Remove the tmpfiles.d entry that created /usr/local/share/applications, since the directory and runtime file creation are no longer needed.

Build:
- Install dfm-reencrypt.desktop via CMake into share/applications and update Debian packaging to ship the file.