### PR TITLE
feat: add wallpaper fill style configuration

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.desktop.json
+++ b/assets/configs/org.deepin.dde.file-manager.desktop.json
@@ -79,6 +79,17 @@
 			"permissions": "readwrite",
 			"visibility": "public"
 		},
+		"wallpaperFillStyle": {
+			"value": "",
+			"serial": 2,
+			"flags": [],
+			"name": "Wallpaper Fill Style",
+			"name[zh_CN]": "桌面壁纸填充方式",
+			"description": "The style used to fill the desktop wallpaper. Numeric values are used: 0 for Fill, 1 for Fit, 2 for Stretch, 3 for Flatten, and 4 for Center.",
+			"description[zh_CN]": "用于填充桌面壁纸的样式。使用数字表示：0 表示填充，1 表示适应，2 表示拉伸，3 表示平铺，4 表示居中。",
+			"permissions": "readwrite",
+			"visibility": "public"
+		},
 		"enableCanvasInputMethod": {
 			"value": true,
 			"serial": 0,

--- a/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager.cpp
@@ -8,10 +8,14 @@
 #include "backgrounddefault.h"
 #include "desktoputils/ddplugin_eventinterface_helper.h"
 
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/dfm_desktop_defines.h>
 #include <dfm-base/utils/universalutils.h>
 
 #include <QImageReader>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QPainter>
 #include <QtConcurrent>
 #include <QPixmapCache>
 #include <QCryptographicHash>
@@ -24,6 +28,9 @@ DDP_BACKGROUND_USE_NAMESPACE
 
 #define CanvasCoreUnsubscribe(topic, func) \
     dpfSignalDispatcher->unsubscribe("ddplugin_core", QT_STRINGIFY2(topic), this, func);
+
+static constexpr char kConfName[] { "org.deepin.dde.file-manager.desktop" };
+static constexpr char KwallpaperFillStyle[] { "wallpaperFillStyle" };
 
 // Generate cache key for wallpaper: wallpaper:path@widthxheight
 static QString generateCacheKey(const QString &path, const QSize &size)
@@ -62,8 +69,8 @@ static QString getScaledPathFromCache(const QString &wallpaperPath, const QSize 
     sizeArray << QVariant::fromValue(screenSize);
 
     QDBusReply<QStringList> reply = iface.call("GetProcessedImagePathByFd",
-                                                QVariant::fromValue(dbusFd),
-                                                pathMd5, sizeArray);
+                                               QVariant::fromValue(dbusFd),
+                                               pathMd5, sizeArray);
     file.close();
 
     if (!reply.isValid() || reply.value().isEmpty())
@@ -125,6 +132,7 @@ BackgroundManager::BackgroundManager(QObject *parent)
     d->service = new BackgroundDDE(this);
 
     d->bridge = new BackgroundBridge(d);
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, &BackgroundManager::onConfigChanged, Qt::DirectConnection);
 }
 
 BackgroundManager::~BackgroundManager()
@@ -166,6 +174,16 @@ QMap<QString, QString> BackgroundManager::allBackgroundPath()
 QString BackgroundManager::backgroundPath(const QString &screen)
 {
     return d->backgroundPaths.value(screen);
+}
+
+void BackgroundManager::onConfigChanged(const QString &cfg, const QString &key)
+{
+    if (cfg != QString(kConfName) || key != QString(KwallpaperFillStyle))
+        return;
+
+    QPixmapCache::clear();
+    onBackgroundChanged();
+    return;
 }
 
 void BackgroundManager::onBackgroundBuild()
@@ -542,6 +560,24 @@ QPixmap BackgroundBridge::getPixmap(const QString &path, const QSize &targetSize
     return backgroundPixmap;
 }
 
+QPixmap BackgroundBridge::getPixmap(const QString &path, const QPixmap &defaultPixmap)
+{
+    if (path.isEmpty())
+        return defaultPixmap;
+
+    QString currentWallpaper = path.startsWith("file:") ? QUrl(path).toLocalFile() : path;
+    QPixmap backgroundPixmap(currentWallpaper);
+    // fix whiteboard shows when a jpeg file with filename xxx.png
+    // content formart not epual to extension
+    if (backgroundPixmap.isNull()) {
+        QImageReader reader(currentWallpaper);
+        reader.setDecideFormatFromContent(true);
+        backgroundPixmap = QPixmap::fromImage(reader.read());
+    }
+
+    return backgroundPixmap.isNull() ? defaultPixmap : backgroundPixmap;
+}
+
 void BackgroundBridge::onFinished(void *pData)
 {
     fmInfo() << "Background update finished - data pointer:" << pData << "force mode:" << force;
@@ -604,35 +640,52 @@ void BackgroundBridge::runUpdate(BackgroundBridge *self, QList<Requestion> reqs)
         QSize trueSize = req.size;
         QString wallpaperPath = req.path.startsWith("file:") ? QUrl(req.path).toLocalFile() : req.path;
 
-        // Try WallpaperCache service first for pre-scaled image
-        QString cachedPath = getScaledPathFromCache(wallpaperPath, trueSize);
-        QPixmap pix;
-        if (!cachedPath.isEmpty()) {
-            QImageReader cachedReader(cachedPath);
-            cachedReader.setDecideFormatFromContent(true);
-            QImage cachedImage = cachedReader.read();
-            if (!cachedImage.isNull()) {
-                pix = QPixmap::fromImage(std::move(cachedImage));
-                fmInfo() << "Using WallpaperCache scaled image:" << cachedPath
-                         << "for screen:" << req.screen;
-            }
-        }
+        // Read wallpaper fill style from dconfig
+        QString styleConfig = DConfigManager::instance()->value(kConfName, KwallpaperFillStyle, QString()).toString();
+        int style = getValueFromJson(styleConfig, req.screen);
+        auto wallpaperStyle = static_cast<WallpaperStyle>(style);
 
-        // Fallback: load and scale original image
-        if (pix.isNull()) {
-            QPixmap backgroundPixmap = BackgroundBridge::getPixmap(req.path, trueSize);
+        QPixmap pix;
+
+        if (wallpaperStyle == WallpaperStyle::Fill) {
+            // Fill style: use WallpaperCache service for pre-scaled image
+            QString cachedPath = getScaledPathFromCache(wallpaperPath, trueSize);
+            if (!cachedPath.isEmpty()) {
+                QImageReader cachedReader(cachedPath);
+                cachedReader.setDecideFormatFromContent(true);
+                QImage cachedImage = cachedReader.read();
+                if (!cachedImage.isNull()) {
+                    pix = QPixmap::fromImage(std::move(cachedImage));
+                    fmInfo() << "Using WallpaperCache scaled image:" << cachedPath
+                             << "for screen:" << req.screen;
+                }
+            }
+
+            // Fallback: load and scale original image
+            if (pix.isNull()) {
+                QPixmap backgroundPixmap = BackgroundBridge::getPixmap(req.path, trueSize);
+                if (backgroundPixmap.isNull()) {
+                    fmCritical() << "Failed to read background for screen:" << req.screen << "path:" << req.path;
+                    continue;
+                }
+
+                pix = backgroundPixmap;
+                if (pix.width() > trueSize.width() || pix.height() > trueSize.height()) {
+                    pix = pix.copy(QRect(static_cast<int>((pix.width() - trueSize.width()) / 2.0),
+                                         static_cast<int>((pix.height() - trueSize.height()) / 2.0),
+                                         trueSize.width(),
+                                         trueSize.height()));
+                }
+            }
+        } else {
+            // Non-Fill styles: load original image and apply processPixmap
+            QPixmap backgroundPixmap = BackgroundBridge::getPixmap(req.path);
             if (backgroundPixmap.isNull()) {
                 fmCritical() << "Failed to read background for screen:" << req.screen << "path:" << req.path;
                 continue;
             }
 
-            pix = backgroundPixmap;
-            if (pix.width() > trueSize.width() || pix.height() > trueSize.height()) {
-                pix = pix.copy(QRect(static_cast<int>((pix.width() - trueSize.width()) / 2.0),
-                                     static_cast<int>((pix.height() - trueSize.height()) / 2.0),
-                                     trueSize.width(),
-                                     trueSize.height()));
-            }
+            pix = processPixmap(backgroundPixmap, wallpaperStyle, trueSize);
         }
 
         // check stop
@@ -641,7 +694,7 @@ void BackgroundBridge::runUpdate(BackgroundBridge *self, QList<Requestion> reqs)
             return;
         }
 
-        fmInfo() << "Successfully processed background for screen:" << req.screen << "path:" << req.path << "size:" << trueSize;
+        fmInfo() << "Successfully processed background for screen:" << req.screen << "path:" << req.path << "size:" << trueSize << "style:" << style;
         req.pixmap = pix;
         recorder.append(req);
     }
@@ -656,4 +709,91 @@ void BackgroundBridge::runUpdate(BackgroundBridge *self, QList<Requestion> reqs)
     *pRecorder = std::move(recorder);
     QMetaObject::invokeMethod(self, "onFinished", Qt::QueuedConnection, Q_ARG(void *, pRecorder));
     self->getting = false;
+}
+
+QPixmap BackgroundBridge::processPixmap(const QPixmap &originalPixmap, WallpaperStyle style, const QSize &targetSize)
+{
+    switch (style) {
+    case WallpaperStyle::Fit: {
+        QPixmap flattenPixmap(targetSize);
+        flattenPixmap.fill(Qt::transparent);   // 填充透明
+        QPainter painter(&flattenPixmap);
+        QSize scaledSize = originalPixmap.size().scaled(targetSize, Qt::KeepAspectRatio);
+        int xOffset = (targetSize.width() - scaledSize.width()) / 2;
+        int yOffset = (targetSize.height() - scaledSize.height()) / 2;
+        painter.drawPixmap(xOffset, yOffset, originalPixmap.scaled(scaledSize, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        painter.end();
+        return flattenPixmap;
+    }
+    case WallpaperStyle::Stretch: {
+        return originalPixmap.scaled(targetSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    }
+    case WallpaperStyle::Flatten: {
+        QPixmap flattenPixmap(targetSize);
+        QPainter painter(&flattenPixmap);
+        int tileWidth = originalPixmap.width();
+        int tileHeight = originalPixmap.height();
+
+        for (int y = 0; y < targetSize.height(); y += tileHeight) {
+            for (int x = 0; x < targetSize.width(); x += tileWidth) {
+                painter.drawPixmap(x, y, originalPixmap);
+            }
+        }
+        painter.end();
+        return flattenPixmap;
+    }
+    case WallpaperStyle::Center: {
+        QPixmap centeredPixmap(targetSize);
+        centeredPixmap.fill(Qt::transparent);   // 填充透明
+        QPainter painter(&centeredPixmap);
+
+        // 获取原始图片的尺寸
+        QSize originalSize = originalPixmap.size();
+
+        // 计算居中偏移
+        int xOffset = (targetSize.width() - originalSize.width()) / 2;
+        int yOffset = (targetSize.height() - originalSize.height()) / 2;
+
+        // 直接居中绘制原始图片
+        painter.drawPixmap(xOffset, yOffset, originalPixmap);
+        painter.end();
+        return centeredPixmap;
+    }
+    case WallpaperStyle::Fill:
+    default: {
+        auto pix = originalPixmap.scaled(targetSize,
+                                         Qt::KeepAspectRatioByExpanding,
+                                         Qt::SmoothTransformation);
+
+        if (pix.width() > targetSize.width() || pix.height() > targetSize.height()) {
+            pix = pix.copy(QRect(static_cast<int>((pix.width() - targetSize.width()) / 2.0),
+                                 static_cast<int>((pix.height() - targetSize.height()) / 2.0),
+                                 targetSize.width(),
+                                 targetSize.height()));
+        }
+        return pix;   // 默认返回原始图像
+    }
+    }
+}
+
+int BackgroundBridge::getValueFromJson(QString json, const QString &screenName)
+{
+    // The string in dconfig contains extra characters
+    if (json.startsWith('"')) {
+        json.remove(0, 1);
+    }
+    if (json.endsWith('"')) {
+        json.chop(1);
+    }
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(json.toUtf8());
+
+    if (!jsonDoc.isObject())
+        return 0;
+
+    QJsonObject jsonObj = jsonDoc.object();
+
+    if (jsonObj.contains(screenName))
+        return jsonObj[screenName].toInt();
+
+    return 0;
 }

--- a/src/plugins/desktop/ddplugin-background/backgroundmanager.h
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager.h
@@ -37,6 +37,7 @@ private slots:
     void onDetachWindows();
     void onGeometryChanged();
     void onBackgroundChanged();
+    void onConfigChanged(const QString &cfg, const QString &key);
 
 private:
     BackgroundWidgetPointer createBackgroundWidget(QWidget *root);

--- a/src/plugins/desktop/ddplugin-background/backgroundmanager_p.h
+++ b/src/plugins/desktop/ddplugin-background/backgroundmanager_p.h
@@ -23,6 +23,13 @@ public:
         QSize size;
         QPixmap pixmap;
     };
+    enum class WallpaperStyle {
+        Fill = 0,        // 填充
+        Fit,             // 适应
+        Stretch,         // 拉伸
+        Flatten,         // 平铺
+        Center           // 居中
+    };
 
 public:
     explicit BackgroundBridge(class BackgroundManagerPrivate *ptr);
@@ -46,11 +53,14 @@ public:
     void terminate(bool wait);
     Q_INVOKABLE void onFinished(void *pData);
     static QPixmap getPixmap(const QString &path, const QSize &targetSize, const QPixmap &defaultPixmap = QPixmap());
+    static QPixmap getPixmap(const QString &path, const QPixmap &defaultPixmap = QPixmap());
 
 private:
     void queryCacheAndClassify(Requestion &req, QList<Requestion> &cachedRequests, QList<Requestion> &uncachedRequests);
     void processRequests(const QList<Requestion> &cachedRequests, const QList<Requestion> &uncachedRequests, bool forceMode = false);
     static void runUpdate(BackgroundBridge *self, QList<Requestion> reqs);
+    static QPixmap processPixmap(const QPixmap &originalPixmap, WallpaperStyle style, const QSize &targetSize);
+    static int getValueFromJson(QString json, const QString &screenName);
 
 private:
     class BackgroundManagerPrivate *d = nullptr;


### PR DESCRIPTION
Add support for configuring desktop wallpaper fill styles (Fill, Fit,
Stretch, Flatten, Center). This allows users to choose how the wallpaper
is displayed on the screen. A new DConfig key `wallpaperFillStyle` has
been added to `org.deepin.dde.file-manager.desktop.json`. The background
manager now listens for changes to this config, clears the pixmap cache,
and re-renders the wallpaper accordingly. The background bridge selects
the appropriate rendering strategy: for Fill style it uses the existing
WallpaperCache service or scaled cropping; for other styles it calls a
new `processPixmap` function that handles scaling, tiling, centering,
etc. A JSON parsing utility `getValueFromJson` extracts per-screen style
values from the config (expected format: `{"screenName": styleNumber}
`). Added a new overload of `getPixmap` to load original images without
scaling for non-Fill styles.

Log: Added wallpaper fill style configuration feature

Influence:
1. Test setting each fill style (Fill, Fit, Stretch, Flatten, Center)
via dconfig and verify wallpaper display
2. Test changing style dynamically and ensure wallpaper updates
immediately without restart
3. Test with multi-monitor setups, verify per-screen style if config
supports it
4. Test with different image sizes and aspect ratios
5. Test with corrupted or unsupported image formats (e.g., .png
with .jpg content)
6. Verify that the wallpaper cache is cleared when style changes
7. Test default behavior when config value is empty or invalid
8. Test performance with large images and screen resolutions

feat: 添加桌面壁纸填充方式配置

支持配置桌面壁纸的填充方式（填充、适应、拉伸、平铺、居中）。新增 DConfig
键 `wallpaperFillStyle` 到 `org.deepin.dde.file-manager.desktop.json`。
背景管理器监听该配置变化，清除缓存并重新渲染壁纸。背景桥根据配置选
择渲染策略：填充模式使用原有的 WallpaperCache 服务或裁剪缩放；其他
模式调用新的 `processPixmap` 函数处理缩放、平铺、居中等操作。新增
`getValueFromJson` 工具函数从 JSON 格式的配置值解析每个屏幕的样式值（预
期格式：`{"screenName": styleNumber}`）。新增 `getPixmap` 重载函数以加载
原始图片（不缩放）用于非填充模式。

Log: 新增桌面壁纸填充方式配置功能

Influence:
1. 测试通过 dconfig 设置每种填充方式（填充/适应/拉伸/平铺/居中），验证壁
纸显示效果
2. 测试动态修改样式，确保壁纸立即更新，无需重启
3. 测试多屏环境，如果配置支持按屏幕设置则验证每个屏幕的样式
4. 测试不同尺寸和宽高比的图片
5. 测试损坏或不支持的图片格式（如 .png 后缀但内容为 .jpg）
6. 验证修改样式时壁纸缓存被清除
7. 测试配置值为空或无效时的默认行为
8. 测试大尺寸图片和高分辨率屏幕下的性能

TASK: https://pms.uniontech.com/task-view-393123.html 
TASK: https://pms.uniontech.com/task-view-371829.html

## Summary by Sourcery

Add configurable wallpaper fill styles and hook them into the desktop background rendering pipeline.

New Features:
- Introduce a wallpaper fill style enum supporting Fill, Fit, Stretch, Flatten, and Center modes.
- Add DConfig key wallpaperFillStyle in org.deepin.dde.file-manager.desktop to control wallpaper rendering per screen.

Enhancements:
- Update background manager to listen for wallpaperFillStyle changes, clear pixmap cache, and re-render wallpapers immediately.
- Extend background bridge image loading and processing logic to support style-specific scaling, tiling, centering, and aspect handling.
