### PR TITLE
feat: add configurable default burn filesystem type

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.burn.json
+++ b/assets/configs/org.deepin.dde.file-manager.burn.json
@@ -12,6 +12,17 @@
             "description":"It's used to control whether to enable the built-in burn.",
             "permissions":"readwrite",
             "visibility":"public"
+        },
+        "defaultBurnFilesystemType":{
+            "value": 1,
+            "serial":0,
+            "flags":[],
+            "name":"Default burn file system type",
+            "name[zh_CN]":"默认刻录文件系统类型",
+            "description[zh_CN]":"刻录光盘时文件系统的默认选项。0（仅 ISO9660），1（ISO9660 + Joliet 支持），2（ISO9660 + RockRidge 支持），3（UDF 支持）",
+            "description":"Default options for file system when burning discs. 0 (ISO9660 only), 1 (ISO9660 + Joliet support), 2 (ISO9660 + RockRidge support), 3 (UDF support)",
+            "permissions":"readwrite",
+            "visibility":"public"
         }
     }
 }

--- a/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
@@ -40,8 +40,11 @@ void BurnOptDialog::setUDFSupported(bool supported, bool disableISOOpts)
     if (!model || model->rowCount() < 4)
         return;
 
-    if (!supported)
+    if (!supported) {
         model->setData(model->index(3, 0), 0, Qt::UserRole - 1);
+        if (BurnHelper::defaultBurnFs() == 3)
+            fsComb->setCurrentIndex(1);
+    }
     if (disableISOOpts) {
         model->setData(model->index(0, 0), 0, Qt::UserRole - 1);
         model->setData(model->index(1, 0), 0, Qt::UserRole - 1);
@@ -175,7 +178,7 @@ void BurnOptDialog::initializeUi()
 
     fsComb = new QComboBox;
     fsComb->addItems(fsTypes);
-    fsComb->setCurrentIndex(1);   // 默认使用 i + j 的方式刻录
+    fsComb->setCurrentIndex(BurnHelper::defaultBurnFs());
     vLay->addWidget(fsComb);
     fsLabel->setFont(f13);
     fsComb->setFont(f14);

--- a/src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnhelper.cpp
@@ -235,6 +235,15 @@ bool BurnHelper::isBurnEnabled()
     return ret.isValid() ? ret.toBool() : true;
 }
 
+int BurnHelper::defaultBurnFs()
+{
+    const auto &&ret = DConfigManager::instance()->value("org.deepin.dde.file-manager.burn", "defaultBurnFilesystemType", 1);
+    int r = ret.toInt();
+    if (r > 3 || r < 0)
+        r = 1;
+    return r;
+}
+
 bool BurnHelper::burnIsOnLocalStaging(const QUrl &url)
 {
     if (!url.path().contains("/.cache/deepin/discburn/_dev_"))

--- a/src/plugins/common/dfmplugin-burn/utils/burnhelper.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnhelper.h
@@ -29,6 +29,7 @@ public:
     static void updateBurningStateToPersistence(const QString &id, const QString &dev, bool working);
     static void mapStagingFilesPath(const QList<QUrl> &srcList, const QList<QUrl> &targetList);
     static bool isBurnEnabled();
+    static int defaultBurnFs();
     static bool burnIsOnLocalStaging(const QUrl &url);
     static QFileInfoList localFileInfoList(const QString &path);
     static QFileInfoList localFileInfoListRecursive(const QString &path, QDir::Filters filters = (QDir::Files | QDir::NoSymLinks));


### PR DESCRIPTION
1. Added a new DConfig key "defaulBurnFilesystemType" to the burn
configuration JSON, allowing system administrators or users to
set the default filesystem type (0=ISO9660, 1=ISO9660+Joliet,
2=ISO9660+RockRidge, 3=UDF).
2. Modified BurnOptDialog to read this config value via
BurnHelper::defaultBurnFs() instead of hardcoding index 1 for the combo
box initial selection.
3. When UDF is not supported and the configured default is 3 (UDF),
automatically fall back to index 1 (ISO9660+Joliet) to avoid an invalid
selection.
4. Added range validation in BurnHelper::defaultBurnFs() to ensure the
returned value is between 0 and 3.

Log: Added a configurable default filesystem type for disc burning

Influence:
1. Test that the default burn filesystem combo box selects index
according to the config value when the dialog opens.
2. Verify that when UDF support is unavailable and the config is set to
3, the combo box automatically switches to index 1.
3. Test all four valid config values (0, 1, 2, 3) and confirm the combo
box behaves correctly.
4. Test invalid config values (e.g., -1, 4) and ensure the fallback to
1 occurs.
5. Verify that the config can be changed dynamically and takes effect on
next dialog open.

feat: 添加可配置的默认刻录文件系统类型

1. 在刻录配置 JSON 中新增 DConfig 配置键 "defaulBurnFilesystemType"，
允许系统管理员或用户设置默认文件系统类型（0=ISO9660、1=ISO9660+Joliet、
2=ISO9660+RockRidge、3=UDF）。
2. 修改 BurnOptDialog，通过 BurnHelper::defaultBurnFs() 读取该配置值替换
原来的硬编码索引 1。
3. 当 UDF 不支持且配置默认值为 3 (UDF) 时，自动回退到索引 1
(ISO9660+Joliet) 以避免无效选择。
4. 在 BurnHelper::defaultBurnFs() 中添加范围校验，确保返回值在 0~3 之
间。

Log: 新增可配置的默认刻录文件系统类型

Influence:
1. 测试打开刻录对话框时默认文件系统组合框是否按配置值选择索引。
2. 验证当 UDF 不支持且配置为 3 时，组合框自动切换到索引 1。
3. 测试四个有效配置值（0、1、2、3），确认组合框行为正确。
4. 测试无效配置值（如 -1、4），确保回退到 1。
5. 验证配置可动态修改，并在下次打开对话框时生效。

TASK: https://pms.uniontech.com/task-view-393123.html 
TASK: https://pms.uniontech.com/task-view-349979.html

## Summary by Sourcery

Make the disc burn filesystem selection default configurable via DConfig and ensure safe fallbacks when UDF is unavailable or misconfigured.

New Features:
- Introduce a configurable default filesystem type for disc burning via the defaulBurnFilesystemType DConfig key.

Enhancements:
- Add a BurnHelper::defaultBurnFs() helper that reads and validates the configured default filesystem type.
- Initialize the burn options dialog filesystem combo box using the configured default instead of a hardcoded index.
- Automatically fall back to ISO9660+Joliet when UDF is disabled but configured as the default filesystem type.
