### PR TITLE
fix(workspace): improve group header expand button hit area

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -518,6 +518,23 @@ QRect BaseItemDelegate::getExpandButtonRect(const QRectF &rect) const
     return buttonRect;
 }
 
+QRect BaseItemDelegate::getExpandButtonHitRect(const QStyleOptionViewItem &option) const
+{
+    return getExpandButtonHitRect(option.rect);
+}
+
+QRect BaseItemDelegate::getExpandButtonHitRect(const QRectF &rect) const
+{
+    const QRect visualRect = getExpandButtonRect(rect);
+
+    // Keep the arrow visuals unchanged while making the click target easier to hit.
+    QRect hitRect;
+    hitRect.setSize(QSize(qMax(visualRect.width(), 24), qMax(visualRect.height(), 24)));
+    hitRect.moveCenter(visualRect.center());
+
+    return hitRect;
+}
+
 QRect BaseItemDelegate::getGroupTextRect(const QStyleOptionViewItem &option) const
 {
     return getGroupTextRect(option.rect);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -136,6 +136,8 @@ public:
 
     QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
     QRect getExpandButtonRect(const QRectF &rect) const;
+    QRect getExpandButtonHitRect(const QStyleOptionViewItem &option) const;
+    QRect getExpandButtonHitRect(const QRectF &rect) const;
 
 protected:
     explicit BaseItemDelegate(BaseItemDelegatePrivate &dd, FileViewHelper *parent);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1550,7 +1550,14 @@ bool FileView::groupExpandOrCollapseItem(const QModelIndex &index, const QPoint 
     QStyleOptionViewItem op;
     QRect rect = visualRect(index);   // 绘制区域
     op.rect = rect;
-    QRect arrowRect = itemDelegate()->getExpandButtonRect(op);
+
+    if (index.data(Global::kItemGroupDisplayIndex).toInt() > 0) {
+        // 非首个分组头在顶部预留 16px 透明间隔，实际内容区从间隔下方开始。
+        // 命中区与绘制区对齐，避免命中位置相对箭头上移。
+        op.rect.setTop(op.rect.top() + kGroupHeaderInterval);
+    }
+
+    QRect arrowRect = itemDelegate()->getExpandButtonHitRect(op);
 
     if (!arrowRect.contains(pos))
         return false;


### PR DESCRIPTION
## 根因分析

文管智能搜索结果中"非首个分组头"的展开/折叠箭头点击不灵敏，与智能搜索功能无关，是 dfmplugin-workspace 分组头 delegate 的命中区问题。

非首个分组头（displayIndex > 0）总高 48px，绘制侧 `paintGroupHeader` 跳过顶部 16px 透明间隔后在 32px 内容区居中绘制箭头（位于 `原top+24`）；而命中侧 `groupExpandOrCollapseItem` 用整组头 48px visualRect 经 `getExpandButtonRect` 计算箭头（位于 `原top+16`）。两者差 8px，叠加命中区仅 16x16 → 点击可见箭头极易落空 → 退化为"选中整组"。

## 修复方案

参照主线 master commit `23a713b4a16`，在 release/snipe 分支重新实现（剔除该分支不存在的 StickyHeader 逻辑）：

1. `BaseItemDelegate` 新增 `getExpandButtonHitRect`：以箭头视觉中心居中、命中区尺寸 `max(视觉,24)×max(视觉,24)`，箭头视觉不变、点击区扩大。
2. `FileView::groupExpandOrCollapseItem`：对非首个分组头将 `op.rect` 顶部下移 `kGroupHeaderInterval`(16px) 与绘制内容区对齐，消除 8px 上移；命中矩形改用 `getExpandButtonHitRect`。

## 改动安全评估

- 仅新增 public 方法，不修改既有签名，无外部调用者受影响。
- 首个分组头（displayIndex==0）不进入新增分支，行为不变，无回归。
- 无 root/DBus/外部接口变更，无安全/合规风险。

PMS: BUG-370273

## Summary by Sourcery

Improve group header expand button hit detection in the workspace file view so clicks reliably toggle group expansion rather than selecting the group.

Bug Fixes:
- Align the hit test region of non-first group headers with their visual content area to fix missed clicks on the expand/collapse arrow.

Enhancements:
- Introduce a dedicated expand button hit rectangle that enlarges the clickable area around the arrow without changing its visual appearance.