### PR TITLE
fix(preview): 缩小预览箭头图标尺寸与播放图标一致

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
@@ -14,7 +14,7 @@ FilePreviewDialogStatusBar::FilePreviewDialogStatusBar(QWidget *parent)
 {
     qCDebug(logLibFilePreview) << "FilePreviewDialogStatusBar: initializing status bar";
     
-    QSize iconSize(16, 16);
+    QSize iconSize(12, 12);
     preBtn = new QPushButton(this);
     preBtn->setObjectName("PreButton");
     preBtn->setIcon(QIcon::fromTheme("go-previous").pixmap(iconSize));


### PR DESCRIPTION
## 修改内容

将预览状态栏中上一页/下一页箭头图标尺寸从 16px 缩小为 12px，与播放/暂停图标大小保持一致。

## 修改文件

- `src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp`：将 `iconSize` 从 `QSize(16, 16)` 改为 `QSize(12, 12)`

## 关联

PMS: https://pms.uniontech.com/bug-view-372325.html

## Summary by Sourcery

Align preview status bar icon and text presentation with the rest of the player UI for consistent appearance.

Bug Fixes:
- Adjust preview navigation button icon size from 16px to 12px to match play/pause controls.

Enhancements:
- Change image preview status bar label styling to use QFont instead of a stylesheet so text color follows theme palettes and avoids font fallback issues.