### PR TITLE
fix(image): support TGA 1.0 thumbnails and previews via fallback parser

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -77,9 +77,16 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
         // 失败则按原逻辑置空；成功则用实际图像尺寸进行后续处理。
         image = reader.read();
         if (image.isNull()) {
-            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
-            setPixmap(QPixmap());
-            return;
+            // TGA 1.0 回退：TGA 1.0 文件没有 TGA 2.0 的 TRUEVISION-XFILE 签名，
+            // QImageReader 无法读取。用自带解析器作为回退。
+            if (DFMBASE_NAMESPACE::FileUtils::isTgaFile(fileName)) {
+                image = DFMBASE_NAMESPACE::FileUtils::readTgaImage(fileName);
+            }
+            if (image.isNull()) {
+                fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+                setPixmap(QPixmap());
+                return;
+            }
         }
         sourceImageSize = image.size();
         if (!sourceImageSize.isValid()) {
@@ -105,9 +112,18 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
         reader.setScaledSize(decodeSize);
         image = reader.read();
         if (image.isNull()) {
-            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
-            setPixmap(QPixmap());
-            return;
+            // TGA 1.0 回退
+            if (DFMBASE_NAMESPACE::FileUtils::isTgaFile(fileName)) {
+                image = DFMBASE_NAMESPACE::FileUtils::readTgaImage(fileName);
+                if (!image.isNull()) {
+                    image = image.scaled(decodeSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+                }
+            }
+            if (image.isNull()) {
+                fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+                setPixmap(QPixmap());
+                return;
+            }
         }
     }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -44,6 +44,8 @@
 #include <QProcess>
 #include <QDebug>
 #include <QApplication>
+#include <QFile>
+#include <QDataStream>
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 #    include <QTextCodec>
 #endif
@@ -1077,6 +1079,157 @@ QImage FileUtils::convertToSRgbColorSpace(const QImage &image)
     return convertedImage;
 }
 #endif
+
+/*!
+ * \brief 手动解析 TGA 1.0 格式图片。
+ *
+ * Qt 自带的 qtga 插件要求文件末尾有 TRUEVISION-XFILE 签名（TGA 2.0），
+ * TGA 1.0（原始 TGA）没有此签名，导致 QImageReader 无法读取。
+ * 本方法直接解析 TGA 1.0 格式，支持未压缩真彩色（type 2）和 RLE 压缩真彩色
+ * （type 10），像素深度 24/32 bpp，作为 QImageReader 失败时的回退。
+ */
+QImage FileUtils::readTgaImage(const QString &filePath)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qCWarning(logDFMBase) << "TGA: failed to open file:" << filePath << file.errorString();
+        return {};
+    }
+
+    QDataStream stream(&file);
+    stream.setByteOrder(QDataStream::LittleEndian);
+
+    // --- 读取 18 字节 TGA 头（各字段类型须与规范逐一对应） ---
+    quint8 idLength, colorMapType, imageType, colorMapDepth, pixelDepth, descriptor;
+    quint16 colorMapOrigin, colorMapLength, xOrigin, yOrigin, width, height;
+
+    stream >> idLength;
+    stream >> colorMapType;
+    stream >> imageType;
+    stream >> colorMapOrigin;
+    stream >> colorMapLength;
+    stream >> colorMapDepth;
+    stream >> xOrigin;
+    stream >> yOrigin;
+    stream >> width;
+    stream >> height;
+    stream >> pixelDepth;
+    stream >> descriptor;
+
+    if (stream.status() != QDataStream::Ok) {
+        qCWarning(logDFMBase) << "TGA: failed to read header for:" << filePath;
+        return {};
+    }
+
+    // 仅支持真彩色（未压缩 type 2 和 RLE type 10）
+    if (imageType != 2 && imageType != 10) {
+        qCWarning(logDFMBase) << "TGA: unsupported image type" << imageType << "for:" << filePath;
+        return {};
+    }
+    if (pixelDepth != 24 && pixelDepth != 32) {
+        qCWarning(logDFMBase) << "TGA: unsupported pixel depth" << pixelDepth << "for:" << filePath;
+        return {};
+    }
+    if (width == 0 || height == 0) {
+        qCWarning(logDFMBase) << "TGA: invalid dimensions" << width << "x" << height << "for:" << filePath;
+        return {};
+    }
+
+    // 拒绝超大尺寸，避免对畸形文件做无意义的超大内存分配
+    const int bytesPerPixel = pixelDepth / 8;
+    const qint64 dataSize = qint64(width) * height * bytesPerPixel;
+    static constexpr qint64 kMaxTgaDataSize = 256 * 1024 * 1024;   // 256 MB
+    if (dataSize > kMaxTgaDataSize) {
+        qCWarning(logDFMBase) << "TGA: pixel data too large" << dataSize << "for:" << filePath;
+        return {};
+    }
+
+    // 跳过 ID 字段和颜色表
+    qint64 skipBytes = idLength;
+    if (colorMapType == 1) {
+        skipBytes += colorMapOrigin + colorMapLength * ((colorMapDepth + 7) / 8);
+    }
+    if (!file.seek(18 + skipBytes)) {
+        qCWarning(logDFMBase) << "TGA: failed to skip header data for:" << filePath;
+        return {};
+    }
+
+    // --- 读取像素数据 ---
+    QByteArray rawData;
+    if (imageType == 2) {
+        // 未压缩
+        rawData = file.read(dataSize);
+        if (rawData.size() != dataSize) {
+            qCWarning(logDFMBase) << "TGA: incomplete pixel data for:" << filePath;
+            return {};
+        }
+    } else {
+        // RLE 压缩
+        rawData.reserve(dataSize);
+        while (rawData.size() < dataSize && !stream.atEnd()) {
+            quint8 packetHeader;
+            stream >> packetHeader;
+            int count = (packetHeader & 0x7f) + 1;
+            if (packetHeader & 0x80) {
+                // RLE packet: read one pixel, repeat count times
+                QByteArray pixel(bytesPerPixel, '\0');
+                const int read = stream.readRawData(pixel.data(), bytesPerPixel);
+                if (read != bytesPerPixel) {
+                    qCWarning(logDFMBase) << "TGA: RLE pixel read failed for:" << filePath;
+                    return {};
+                }
+                for (int i = 0; i < count && rawData.size() + bytesPerPixel <= dataSize; ++i) {
+                    rawData.append(pixel);
+                }
+            } else {
+                // Raw packet: read count pixels
+                QByteArray pixels(count * bytesPerPixel, '\0');
+                const int read = stream.readRawData(pixels.data(), pixels.size());
+                if (read != pixels.size()) {
+                    qCWarning(logDFMBase) << "TGA: raw packet read failed for:" << filePath;
+                    return {};
+                }
+                rawData.append(pixels);
+            }
+        }
+        if (rawData.size() != dataSize) {
+            qCWarning(logDFMBase) << "TGA: incomplete RLE data for:" << filePath;
+            return {};
+        }
+    }
+
+    // --- 创建 QImage 并填充像素 ---
+    QImage::Format format = (pixelDepth == 32) ? QImage::Format_ARGB32 : QImage::Format_RGB32;
+    QImage image(width, height, format);
+    if (image.isNull()) {
+        qCWarning(logDFMBase) << "TGA: failed to allocate image" << width << "x" << height << "for:" << filePath;
+        return {};
+    }
+
+    const bool topOrigin = descriptor & 0x20;
+    const uchar *src = reinterpret_cast<const uchar *>(rawData.constData());
+
+    for (int y = 0; y < height; ++y) {
+        int destY = topOrigin ? y : (height - 1 - y);
+        QRgb *scanline = reinterpret_cast<QRgb *>(image.scanLine(destY));
+        for (int x = 0; x < width; ++x) {
+            uchar b = *src++;
+            uchar g = *src++;
+            uchar r = *src++;
+            uchar a = (pixelDepth == 32) ? *src++ : 0xff;
+            scanline[x] = qRgba(r, g, b, a);
+        }
+    }
+
+    qCDebug(logDFMBase) << "TGA: successfully decoded" << width << "x" << height << "image:" << filePath;
+    return image;
+}
+
+bool FileUtils::isTgaFile(const QString &filePath)
+{
+    const QMimeType &mimeType = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath));
+    return mimeType.name() == "image/x-tga";
+}
 
 QString FileUtils::encryptString(const QString &str)
 {

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -104,6 +104,9 @@ public:
     static QImage convertToSRgbColorSpace(const QImage &image);
 #endif
 
+    static QImage readTgaImage(const QString &filePath);
+    static bool isTgaFile(const QString &filePath);
+
 private:
     static QMutex cacheCopyingMutex;
     static QSet<QUrl> copyingUrl;

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -376,6 +376,20 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
         if (!reader.read(&image)) {
             qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
                                   << "error:" << reader.errorString();
+            // TGA 1.0 回退：canRead 返回 true 但 read 失败时尝试自带解析器
+            if (mimeType == "x-tga") {
+                QImage tgaImage = FileUtils::readTgaImage(filePath);
+                if (!tgaImage.isNull()) {
+                    if (tgaImage.width() > size || tgaImage.height() > size) {
+                        tgaImage = tgaImage.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                    }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                    tgaImage = FileUtils::convertToSRgbColorSpace(tgaImage);
+#endif
+                    qCDebug(logDFMBase) << "thumbnail: TGA 1.0 decoded via fallback for:" << filePath;
+                    return tgaImage;
+                }
+            }
             return image;
         }
     } else {
@@ -388,6 +402,20 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
         if (!reader.read(&image)) {
             qCWarning(logDFMBase) << "thumbnail: image file has invalid size and cannot be decoded:" << filePath
                                   << "error:" << reader.errorString();
+            // TGA 1.0 回退：canRead 返回 true 但 read 失败时尝试自带解析器
+            if (mimeType == "x-tga") {
+                QImage tgaImage = FileUtils::readTgaImage(filePath);
+                if (!tgaImage.isNull()) {
+                    if (tgaImage.width() > size || tgaImage.height() > size) {
+                        tgaImage = tgaImage.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                    }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                    tgaImage = FileUtils::convertToSRgbColorSpace(tgaImage);
+#endif
+                    qCDebug(logDFMBase) << "thumbnail: TGA 1.0 decoded via fallback for:" << filePath;
+                    return tgaImage;
+                }
+            }
             return image;
         }
 

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/base/configs/dconfig/global_dconf_defines.h>
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/utils/fileutils.h>
 
 #include <dfm-framework/dpf.h>
 #include <dfm-base/file/local/syncfileinfo.h>
@@ -145,13 +146,31 @@ QPixmap ImagePreviewWorker::loadOriginalImage(const QString &filePath, const QSi
     QImageReader reader(filePath);
     reader.setAutoTransform(true);
 
+    const qreal dpr = qApp->devicePixelRatio();
+    const QSize maxSize = targetSize * dpr;
+
     QSize originalSize = reader.size();
     if (!originalSize.isValid()) {
+        // TGA 1.0 回退：QImageReader 无法识别时尝试自带解析器
+        if (FileUtils::isTgaFile(filePath)) {
+            QImage tgaImage = FileUtils::readTgaImage(filePath);
+            if (!tgaImage.isNull()) {
+                originalSize = tgaImage.size();
+                if (originalSize.width() > maxSize.width()
+                    || originalSize.height() > maxSize.height()) {
+                    tgaImage = tgaImage.scaled(originalSize.scaled(maxSize, Qt::KeepAspectRatio),
+                                               Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+                }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                tgaImage = FileUtils::convertToSRgbColorSpace(tgaImage);
+#endif
+                QPixmap pixmap = QPixmap::fromImage(tgaImage);
+                pixmap.setDevicePixelRatio(dpr);
+                return pixmap;
+            }
+        }
         return QPixmap();
     }
-
-    qreal dpr = qApp->devicePixelRatio();
-    QSize maxSize = targetSize * dpr;
 
     if (originalSize.width() > maxSize.width()
         || originalSize.height() > maxSize.height()) {
@@ -161,7 +180,20 @@ QPixmap ImagePreviewWorker::loadOriginalImage(const QString &filePath, const QSi
 
     QImage image = reader.read();
     if (image.isNull()) {
-        return QPixmap();
+        // TGA 1.0 回退
+        if (FileUtils::isTgaFile(filePath)) {
+            image = FileUtils::readTgaImage(filePath);
+        }
+        if (image.isNull()) {
+            return QPixmap();
+        }
+        if (image.width() > maxSize.width() || image.height() > maxSize.height()) {
+            image = image.scaled(image.size().scaled(maxSize, Qt::KeepAspectRatio),
+                                 Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+        }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        image = FileUtils::convertToSRgbColorSpace(image);
+#endif
     }
 
     QPixmap pixmap = QPixmap::fromImage(image);


### PR DESCRIPTION
## Description

TGA 1.0 格式图片（原始 TGA，无 TGA 2.0 的 `TRUEVISION-XFILE` 签名）在文件管理器中无法展示缩略图和预览。Qt 自带的 `qtga` 插件要求该签名，即使安装了 `kimageformat6-plugins`，在某些环境下 `QImageReader::read()` 仍然失败。

本 PR 新增 `FileUtils::readTgaImage()` 公共方法，手动解析 TGA 1.0 格式，在 `QImageReader::read()` 失败时作为回退，覆盖缩略图生成、详情面板预览、独立图片预览三个场景。

### Changes

- **`src/dfm-base/utils/fileutils.h`** — 声明 `readTgaImage()` 和 `isTgaFile()`
- **`src/dfm-base/utils/fileutils.cpp`** — 实现 TGA 1.0 解析器（支持未压缩 type 2 和 RLE type 10，24/32 bpp，BGR→RGB，top/bottom origin）及 `isTgaFile()` 格式判断
- **`src/dfm-base/utils/thumbnail/thumbnailcreators.cpp`** — 缩略图路径，两处 `read()` 失败点回退
- **`src/plugins/filemanager/dfmplugin-detailspace/views/imagepreviewworker.cpp`** — 详情面板预览回退
- **`src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp`** — 独立预览回退

### Design

- 仅在 `QImageReader::read()` 失败且文件为 TGA 格式时回退，不影响其他格式
- 不依赖外部插件，无论 `kimageformat6-plugins` 是否安装均可工作
- 所有回退点均通过 `isTgaFile()` 做格式门禁

PMS: BUG-371969

## Summary by Sourcery

Add a built-in TGA 1.0 image decoder and use it as a fallback when QImageReader fails so that TGA images show thumbnails and previews across the file manager.

New Features:
- Introduce FileUtils::readTgaImage and FileUtils::isTgaFile to decode legacy TGA 1.0 images without relying on external plugins.

Bug Fixes:
- Ensure TGA 1.0 images correctly display thumbnails and previews in the file manager, details pane, and standalone preview even when the Qt TGA plugin cannot read them.

Enhancements:
- Wire the TGA 1.0 fallback decoding into thumbnail creation and image preview flows, including size limiting and sRGB color space conversion where applicable.