### PR TITLE
feat(sidebar): migrate partition expand/collapse feature from v20

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.sidebar.json
+++ b/assets/configs/org.deepin.dde.file-manager.sidebar.json
@@ -46,6 +46,17 @@
             "description":"It's used to control the folding/unfolding state of groups in the sidebar.",
             "permissions":"readwrite",
             "visibility":"public"
+        },
+        "partitionExpandable":{
+            "value":false,
+            "serial":0,
+            "flags":[],
+            "name":"Partition expandable",
+            "name[zh_CN]":"分区展开功能",
+            "description[zh_CN]":"用于控制是否允许展开分区显示子文件夹",
+            "description":"It's used to control whether partition items can be expanded to show subdirectories.",
+            "permissions":"readwrite",
+            "visibility":"public"
         }
     }
 }

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -637,7 +637,8 @@ void ComputerItemWatcher::updateSidebarItem(const QUrl &url, const QString &newN
     QVariantMap map {
         { "Property_Key_DisplayName", newName },
         { "Property_Key_Editable", editable },
-        { "Property_Key_FinalUrl", findFinalUrl(info) }
+        { "Property_Key_FinalUrl", findFinalUrl(info) },
+        { "Property_Key_ItemExpandable", info->targetUrl().isValid() }
     };
     dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", url, map);
 }
@@ -770,6 +771,7 @@ QVariantMap ComputerItemWatcher::makeSidebarItem(DFMEntryFileInfoPointer info)
         { "Property_Key_EditDisplayText", info->editDisplayText() },
         { "Property_Key_Icon", QIcon::fromTheme(iconName) },
         { "Property_Key_FinalUrl", findFinalUrl(info) },
+        { "Property_Key_ItemExpandable", info->targetUrl().isValid() },
         { "Property_Key_QtItemFlags", QVariant::fromValue(flags) },
         { "Property_Key_Ejectable", ejectableOrders.contains(info->order()) || netShareSchemes.contains(netShareUrl.scheme()) },
         { "Property_Key_CallbackItemClicked", QVariant::fromValue(cdCb) },

--- a/src/plugins/filemanager/dfmplugin-sidebar/dfmplugin_sidebar_global.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/dfmplugin_sidebar_global.h
@@ -77,6 +77,9 @@ inline constexpr char kVisiableDisplayName[] { "Property_Key_VisiableDisplayName
 // a string, used to report log
 inline constexpr char kReportName[] { "Property_Key_ReportName" };
 
+// value is bool, whether the sidebar item can be expanded to show subdirectories
+inline constexpr char kItemExpandable[] { "Property_Key_ItemExpandable" };
+
 // calllbacks
 inline constexpr char kCallbackItemClicked[] { "Property_Key_CallbackItemClicked" };   // value is ItemClickedActionCallback
 inline constexpr char kCallbackContextMenu[] { "Property_Key_CallbackContextMenu" };   // value is ContextMenuCallback
@@ -89,6 +92,7 @@ namespace ConfigInfos {
 inline constexpr char kConfName[] { "org.deepin.dde.file-manager.sidebar" };
 inline constexpr char kVisiableKey[] { "itemVisiable" };
 inline constexpr char kGroupExpandedKey[] { "groupExpanded" };
+inline constexpr char kPartitionExpandableKey[] { "partitionExpandable" };
 }   // namespace ConfigInfos
 
 using ItemClickedActionCallback = std::function<void(quint64 windowId, const QUrl &url)>;
@@ -112,6 +116,7 @@ struct ItemInfo
     QString visiableControlKey;
     QString visiableDisplayName;
     QString reportName;
+    bool isExpandable { false };
 
     ItemClickedActionCallback clickedCb { nullptr };
     ContextMenuCallback contextMenuCb { nullptr };
@@ -132,6 +137,7 @@ struct ItemInfo
           visiableControlKey({ map[PropertyKey::kVisiableControlKey].toString() }),
           visiableDisplayName({ map[PropertyKey::kVisiableDisplayName].toString() }),
           reportName({ map[PropertyKey::kReportName].toString() }),
+          isExpandable { map[PropertyKey::kItemExpandable].toBool() },
           clickedCb { DPF_NAMESPACE::paramGenerator<ItemClickedActionCallback>(map[PropertyKey::kCallbackItemClicked]) },
           contextMenuCb { DPF_NAMESPACE::paramGenerator<ContextMenuCallback>(map[PropertyKey::kCallbackContextMenu]) },
           renameCb { DPF_NAMESPACE::paramGenerator<RenameCallback>(map[PropertyKey::kCallbackRename]) },
@@ -157,6 +163,14 @@ inline constexpr char kAcDmSideBar[] { "left_side_bar" };
 inline constexpr char kAcDmSideBarView[] { "side_bar_view" };
 inline constexpr char kAcSidebarMenuDefault[] { "default_sidebar_menu" };
 }
+
+// Geometry constants for partition expand indicator (shared by view and delegate).
+namespace ExpandIndicatorGeometry {
+inline constexpr int kIndentPerLayer { 10 };   // pixels per nesting level
+inline constexpr int kIconOffset { 8 };        // left offset within the indented rect
+inline constexpr int kIconSize { 10 };         // indicator icon size
+inline constexpr int kHitMargin { 4 };         // extra hit area on each side
+}   // namespace ExpandIndicatorGeometry
 
 DPSIDEBAR_END_NAMESPACE
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -9,6 +9,7 @@
 #include "treemodels/sidebarmodel.h"
 #include "utils/sidebarhelper.h"
 #include "utils/sidebarinfocachemananger.h"
+#include "utils/devicemountsubscriber.h"
 
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/dfm_global_defines.h>
@@ -200,8 +201,15 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
         info.editDisplayText = properties[PropertyKey::kEditDisplayText].toString();
     if (properties.contains(PropertyKey::kIcon))
         info.icon = qvariant_cast<QIcon>(properties[PropertyKey::kIcon]);
-    if (properties.contains(PropertyKey::kFinalUrl))
+    if (properties.contains(PropertyKey::kFinalUrl)) {
         info.finalUrl = properties[PropertyKey::kFinalUrl].toUrl();
+        // Notify device mount subscribers when a device's finalUrl becomes valid.
+        if (info.finalUrl.isValid() && info.group == DefaultGroup::kDevice && info.finalUrl.scheme() == "file") {
+            fmDebug() << "SideBarEventReceiver: Device mounted, notifying subscribers:"
+                      << url << "at" << info.finalUrl;
+            DeviceMountSubscriber::instance()->notifyMountFinished(url, info.finalUrl);
+        }
+    }
     if (properties.contains(PropertyKey::kQtItemFlags))
         info.flags = qvariant_cast<Qt::ItemFlags>(properties[PropertyKey::kQtItemFlags]);
     if (properties.contains(PropertyKey::kIsEjectable))
@@ -214,6 +222,8 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
         info.visiableDisplayName = properties[PropertyKey::kVisiableDisplayName].toString();
     if (properties.contains(PropertyKey::kReportName))
         info.reportName = properties[PropertyKey::kReportName].toString();
+    if (properties.contains(PropertyKey::kItemExpandable))
+        info.isExpandable = properties[PropertyKey::kItemExpandable].toBool();
 
     if (properties.contains(PropertyKey::kCallbackItemClicked))
         info.clickedCb = DPF_NAMESPACE::paramGenerator<ItemClickedActionCallback>(properties[PropertyKey::kCallbackItemClicked]);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -472,6 +472,8 @@ void SideBarModel::onItemExpanded(const QModelIndex &index)
     if (url.isEmpty())
         url = item->url();
 
+    m_urlIndexMap.insert(url, QPersistentModelIndex(index));
+
     if (fileWatcher)
         fileWatcher->watchDirectory(url);
 }
@@ -503,6 +505,9 @@ void SideBarModel::onItemCollapsed(const QModelIndex &index)
     auto idxes = findRowsByUrlRecursive(url, partGrp);
     bool needWatching = std::any_of(idxes.cbegin(), idxes.cend(), isExpandedInAnyView);
 
+    if (!needWatching)
+        m_urlIndexMap.remove(url);
+
     if (fileWatcher && !needWatching) {
         fmDebug() << url << "in sidebar no need to be watched anymore.";
         fileWatcher->unwatchDirectory(url);
@@ -517,39 +522,34 @@ void SideBarModel::addSubItems(const QModelIndex &index, const QList<QUrl> &urls
         return;
     }
 
-    // Collect existing child urls for comparison.
-    QList<QUrl> existingItems;
-    for (int i = 0; i < parentItem->rowCount(); i++) {
-        SideBarItem *childItem = static_cast<SideBarItem *>(parentItem->child(i));
-        if (childItem)
-            existingItems.append(childItem->url());
+    QSet<QUrl> urlSet(urls.begin(), urls.end());
+
+    QSet<QUrl> existingSet;
+    for (int i = 0; i < parentItem->rowCount(); ++i) {
+        SideBarItem *child = static_cast<SideBarItem *>(parentItem->child(i));
+        if (child)
+            existingSet.insert(child->url());
     }
 
-    // Remove children that no longer exist.
-    QList<QUrl> itemsToRemove;
-    for (auto existed : existingItems) {
-        if (!urls.contains(existed))
-            itemsToRemove.append(existed);
-    }
-
-    for (int i = itemsToRemove.size() - 1; i >= 0; --i) {
-        auto url = itemsToRemove.at(i);
-        for (int row = 0; row < parentItem->rowCount(); ++row) {
-            SideBarItem *child = static_cast<SideBarItem *>(parentItem->child(row));
-            if (child && UniversalUtils::urlEquals(child->url(), url)) {
-                SideBarInfoCacheMananger::instance()->removeItemInfoCache(child->url());
-                parentItem->removeRow(row);
-                break;
-            }
+    for (int i = parentItem->rowCount() - 1; i >= 0; --i) {
+        SideBarItem *child = static_cast<SideBarItem *>(parentItem->child(i));
+        if (child && !urlSet.contains(child->url())) {
+            SideBarInfoCacheMananger::instance()->removeItemInfoCache(child->url());
+            parentItem->removeRow(i);
         }
     }
 
-    for (auto url : urls)
+    for (const QUrl &url : urlSet - existingSet)
         addSubItem(index, url);
 }
 
 void SideBarModel::onDirectoryCreated(const QUrl &parentUrl, const QUrl &url)
 {
+    auto it = m_urlIndexMap.find(parentUrl);
+    if (it != m_urlIndexMap.end() && it->isValid()) {
+        addSubItem(*it, url);
+        return;
+    }
     auto partGrp = findGroupIndex(DefaultGroup::kDevice);
     auto idxes = findRowsByUrlRecursive(parentUrl, partGrp);
     for (auto idx : idxes)
@@ -558,6 +558,11 @@ void SideBarModel::onDirectoryCreated(const QUrl &parentUrl, const QUrl &url)
 
 void SideBarModel::onDirectoryRemoved(const QUrl &parentUrl, const QUrl &url)
 {
+    auto it = m_urlIndexMap.find(url);
+    if (it != m_urlIndexMap.end() && it->isValid()) {
+        removeSubItem(*it, url);
+        return;
+    }
     auto partGrp = findGroupIndex(DefaultGroup::kDevice);
     auto idxes = findRowsByUrlRecursive(url, partGrp);
     for (auto idx : idxes)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -4,16 +4,24 @@
 
 #include "sidebarmodel.h"
 #include "treeviews/sidebaritem.h"
+#include "treeviews/sidebarwidget.h"
 #include "utils/sidebarhelper.h"
+#include "utils/sidebarfilewatcher.h"
+#include "utils/sidebarinfocachemananger.h"
 
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/application/application.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-framework/event/event.h>
 
 #include <QMimeData>
 #include <QDebug>
 #include <QtConcurrent>
+#include <QStack>
+#include <QTreeView>
 
 DPSIDEBAR_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
 
 /*!
  * \class SideBarModel
@@ -22,6 +30,10 @@ DPSIDEBAR_USE_NAMESPACE
 SideBarModel::SideBarModel(QObject *parent)
     : QStandardItemModel(parent)
 {
+    fileWatcher = new SidebarFileWatcher(this);
+    connect(fileWatcher, &SidebarFileWatcher::directoryCreated, this, &SideBarModel::onDirectoryCreated);
+    connect(fileWatcher, &SidebarFileWatcher::directoryRemoved, this, &SideBarModel::onDirectoryRemoved);
+    connect(fileWatcher, &SidebarFileWatcher::directoryRenamed, this, &SideBarModel::onDirectoryRenamed);
 }
 
 bool SideBarModel::canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const
@@ -382,6 +394,51 @@ QModelIndex SideBarModel::findRowByUrl(const QUrl &url) const
     return retIndex;
 }
 
+QModelIndex SideBarModel::findGroupIndex(const QString &name) const
+{
+    for (int i = 0; i < rowCount(); ++i) {
+        auto item = itemFromIndex(i);
+        SideBarItemSeparator *groupItem = dynamic_cast<SideBarItemSeparator *>(item);
+        if (groupItem && groupItem->group() == name)
+            return index(i, 0);
+    }
+    fmWarning() << "Group not found in sidebar!" << name;
+    return {};
+}
+
+QModelIndexList SideBarModel::findRowsByUrlRecursive(const QUrl &url, const QModelIndex &parent) const
+{
+    QModelIndexList ret;
+    QStack<QModelIndex> stack;
+    stack.push(parent);
+
+    while (!stack.isEmpty()) {
+        auto current = stack.pop();
+        for (int i = 0; i < rowCount(current); ++i) {
+            auto idx = index(i, 0, current);
+            if (!idx.isValid())
+                continue;
+
+            auto item = itemFromIndex(idx);
+            if (!item)
+                continue;
+
+            if (UniversalUtils::urlEquals(url, item->url())
+                || UniversalUtils::urlEquals(url, item->targetUrl())
+                || (item->itemInfo().findMeCb && item->itemInfo().findMeCb(item->url(), url))) {
+                ret << idx;
+                continue;
+            }
+
+            if (UniversalUtils::isParentUrl(url, item->url())
+                || UniversalUtils::isParentUrl(url, item->targetUrl())) {
+                stack.push(idx);
+            }
+        }
+    }
+    return ret;
+}
+
 void SideBarModel::addEmptyItem()
 {
     // Attention!
@@ -403,4 +460,231 @@ void SideBarModel::addEmptyItem()
 
     QStandardItemModel::appendRow(emptyItem);
     endInsertRows();
+}
+
+void SideBarModel::onItemExpanded(const QModelIndex &index)
+{
+    SideBarItem *item = itemFromIndex(index);
+    if (!item)
+        return;
+
+    QUrl url = item->targetUrl();
+    if (url.isEmpty())
+        url = item->url();
+
+    if (fileWatcher)
+        fileWatcher->watchDirectory(url);
+}
+
+void SideBarModel::onItemCollapsed(const QModelIndex &index)
+{
+    SideBarItem *item = itemFromIndex(index);
+    if (!item)
+        return;
+
+    QUrl url = item->targetUrl();
+    if (url.isEmpty())
+        url = item->url();
+
+    // Before unwatching, make sure no other sidebar view still has this url expanded.
+    auto isExpandedInAnyView = [](const QModelIndex &idx) {
+        if (!idx.isValid())
+            return false;
+
+        auto sbs = SideBarHelper::allSideBar();
+        return std::any_of(sbs.cbegin(), sbs.cend(), [idx](SideBarWidget *w) {
+            auto v = qobject_cast<QTreeView *>(w->view());
+            return v && v->isExpanded(idx);
+        });
+    };
+    auto partGrp = findGroupIndex(DefaultGroup::kDevice);
+    if (!partGrp.isValid())
+        return;
+    auto idxes = findRowsByUrlRecursive(url, partGrp);
+    bool needWatching = std::any_of(idxes.cbegin(), idxes.cend(), isExpandedInAnyView);
+
+    if (fileWatcher && !needWatching) {
+        fmDebug() << url << "in sidebar no need to be watched anymore.";
+        fileWatcher->unwatchDirectory(url);
+    }
+}
+
+void SideBarModel::addSubItems(const QModelIndex &index, const QList<QUrl> &urls)
+{
+    SideBarItem *parentItem = itemFromIndex(index);
+    if (!parentItem) {
+        fmWarning() << "cannot find parent sidebar item!" << index;
+        return;
+    }
+
+    // Collect existing child urls for comparison.
+    QList<QUrl> existingItems;
+    for (int i = 0; i < parentItem->rowCount(); i++) {
+        SideBarItem *childItem = static_cast<SideBarItem *>(parentItem->child(i));
+        if (childItem)
+            existingItems.append(childItem->url());
+    }
+
+    // Remove children that no longer exist.
+    QList<QUrl> itemsToRemove;
+    for (auto existed : existingItems) {
+        if (!urls.contains(existed))
+            itemsToRemove.append(existed);
+    }
+
+    for (int i = itemsToRemove.size() - 1; i >= 0; --i) {
+        auto url = itemsToRemove.at(i);
+        for (int row = 0; row < parentItem->rowCount(); ++row) {
+            SideBarItem *child = static_cast<SideBarItem *>(parentItem->child(row));
+            if (child && UniversalUtils::urlEquals(child->url(), url)) {
+                SideBarInfoCacheMananger::instance()->removeItemInfoCache(child->url());
+                parentItem->removeRow(row);
+                break;
+            }
+        }
+    }
+
+    for (auto url : urls)
+        addSubItem(index, url);
+}
+
+void SideBarModel::onDirectoryCreated(const QUrl &parentUrl, const QUrl &url)
+{
+    auto partGrp = findGroupIndex(DefaultGroup::kDevice);
+    auto idxes = findRowsByUrlRecursive(parentUrl, partGrp);
+    for (auto idx : idxes)
+        addSubItem(idx, url);
+}
+
+void SideBarModel::onDirectoryRemoved(const QUrl &parentUrl, const QUrl &url)
+{
+    auto partGrp = findGroupIndex(DefaultGroup::kDevice);
+    auto idxes = findRowsByUrlRecursive(url, partGrp);
+    for (auto idx : idxes)
+        removeSubItem(idx, url);
+}
+
+void SideBarModel::onDirectoryRenamed(const QUrl &parentUrl, const QUrl &oldUrl, const QUrl &newUrl)
+{
+    onDirectoryRemoved(parentUrl, oldUrl);
+    onDirectoryCreated(parentUrl, newUrl);
+}
+
+void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
+{
+    auto info = InfoFactory::create<FileInfo>(url, dfmbase::Global::kCreateFileInfoSync);
+    if (!info) {
+        fmWarning() << "Failed to create FileInfo instance!" << url;
+        return;
+    }
+
+    if (info->isAttributes(FileInfo::FileIsType::kIsHidden)
+        && !Application::instance()->genericAttribute(dfmbase::Application::kShowedHiddenFiles).toBool()) {
+        fmInfo() << "Hidden file created and not hidden files should not be displayed" << url;
+        return;
+    }
+
+    SideBarItem *parentItem = itemFromIndex(index);
+    if (!parentItem) {
+        fmDebug() << "Failed to get parent item from index";
+        return;
+    }
+
+    // Skip if the child already exists.
+    int childCount = parentItem->rowCount();
+    for (int i = 0; i < childCount; ++i) {
+        SideBarItem *childItem = dynamic_cast<SideBarItem *>(parentItem->child(i));
+        if (childItem && DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, childItem->url()))
+            return;
+    }
+
+    QString group = parentItem->group();
+    QString fileName = info ? info->fileName() : "Unknown";
+    QIcon folderIcon = QIcon::fromTheme("folder");
+
+    SideBarItem *item = new SideBarItem(folderIcon, fileName, group, url);
+    if (!item) {
+        fmDebug() << "Failed to create new sidebar item";
+        return;
+    }
+
+    ItemInfo itemInfo = ItemInfo(url, { { PropertyKey::kItemExpandable, true },
+                                        { PropertyKey::kFinalUrl, url },
+                                        { PropertyKey::kGroup, DefaultGroup::kDevice } });
+    SideBarInfoCacheMananger::instance()->addItemInfoCache(itemInfo);
+
+    // Sub-items are not editable and not draggable.
+    Qt::ItemFlags flags = item->flags();
+    flags &= ~Qt::ItemIsEditable;
+    flags &= ~Qt::ItemIsDragEnabled;
+    item->setFlags(flags);
+
+    // Insert in alphabetical order.
+    QString newName = fileName;
+    int insertRow = childCount;
+    for (int i = 0; i < childCount; ++i) {
+        SideBarItem *childItem = dynamic_cast<SideBarItem *>(parentItem->child(i));
+        if (childItem) {
+            QString childName = childItem->text();
+            if (newName.localeAwareCompare(childName) < 0) {
+                insertRow = i;
+                break;
+            }
+        }
+    }
+
+    parentItem->insertRow(insertRow, item);
+}
+
+void SideBarModel::removeSubItem(const QModelIndex &index, const QUrl &url)
+{
+    if (!index.isValid()) {
+        fmDebug() << "Directory not found in sidebar:" << url;
+        return;
+    }
+
+    QModelIndex parentIndex = index.parent();
+    if (!parentIndex.isValid()) {
+        fmDebug() << "Parent index is invalid";
+        return;
+    }
+
+    QStandardItem *parentItem = itemFromIndex(parentIndex);
+    if (!parentItem) {
+        fmDebug() << "Failed to get parent item from index";
+        return;
+    }
+
+    SideBarItem *itemToRemove = itemFromIndex(index);
+    if (!itemToRemove) {
+        fmDebug() << "Failed to get item from index";
+        return;
+    }
+
+    SideBarItemSeparator *separatorItem = dynamic_cast<SideBarItemSeparator *>(parentItem);
+    if (separatorItem) {
+        // Parent is a separator (group), so only remove children of the current item.
+        fmDebug() << "Parent item is a separator, removing all children of:" << url;
+
+        int childCount = itemToRemove->rowCount();
+        if (childCount > 0) {
+            beginRemoveRows(index, 0, childCount - 1);
+            for (int i = childCount - 1; i >= 0; --i) {
+                if (auto *child = static_cast<SideBarItem *>(itemToRemove->child(i)))
+                    SideBarInfoCacheMananger::instance()->removeItemInfoCache(child->url());
+                itemToRemove->removeRow(i);
+            }
+            endRemoveRows();
+            fmDebug() << "Removed" << childCount << "children from:" << url;
+        }
+
+        emit requestCollapseItem(index);
+        fmDebug() << "Requested to collapse item after removed children:" << url;
+    } else {
+        // Parent is a regular item, remove the item itself.
+        fmDebug() << "Removing item:" << url;
+        SideBarInfoCacheMananger::instance()->removeItemInfoCache(url);
+        parentItem->removeRow(index.row());
+        fmDebug() << "Item removed from sidebar:" << url;
+    }
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
@@ -14,10 +14,12 @@ DPSIDEBAR_BEGIN_NAMESPACE
 
 class SideBarItem;
 class SideBarItemSeparator;
+class SidebarFileWatcher;
 class SideBarModel : public QStandardItemModel
 {
     Q_OBJECT
     friend class SidebarView;
+    friend class SideBarView;
 
 public:
     explicit SideBarModel(QObject *parent = nullptr);
@@ -37,12 +39,32 @@ public:
     bool removeRow(const QUrl &url);
     void updateRow(const QUrl &url, const ItemInfo &newInfo);
     QModelIndex findRowByUrl(const QUrl &url) const;
+    QModelIndex findGroupIndex(const QString &name) const;
+    QModelIndexList findRowsByUrlRecursive(const QUrl &url, const QModelIndex &parent) const;
 
     void addEmptyItem();
+
+    // Partition sub-item management
+    void onItemExpanded(const QModelIndex &index);
+    void onItemCollapsed(const QModelIndex &index);
+    void addSubItems(const QModelIndex &index, const QList<QUrl> &urls);
+
+signals:
+    void requestCollapseItem(const QModelIndex &index);
+
+private slots:
+    void onDirectoryCreated(const QUrl &parentUrl, const QUrl &url);
+    void onDirectoryRemoved(const QUrl &parentUrl, const QUrl &url);
+    void onDirectoryRenamed(const QUrl &parentUrl, const QUrl &oldUrl, const QUrl &newUrl);
+
+    void addSubItem(const QModelIndex &index, const QUrl &url);
+    void removeSubItem(const QModelIndex &index, const QUrl &url);
 
 private:
     QMutex locker;
     mutable SideBarItem *curDragItem { nullptr };
+
+    SidebarFileWatcher *fileWatcher { nullptr };
 };
 
 DPSIDEBAR_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
@@ -9,6 +9,8 @@
 
 #include <QStandardItemModel>
 #include <QMutex>
+#include <QPersistentModelIndex>
+#include <QHash>
 
 DPSIDEBAR_BEGIN_NAMESPACE
 
@@ -65,6 +67,7 @@ private:
     mutable SideBarItem *curDragItem { nullptr };
 
     SidebarFileWatcher *fileWatcher { nullptr };
+    QHash<QUrl, QPersistentModelIndex> m_urlIndexMap;
 };
 
 DPSIDEBAR_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -19,6 +19,7 @@
 #include <QElapsedTimer>
 #include <QPersistentModelIndex>
 #include <QPointer>
+#include <QHash>
 
 class QVariantAnimation;
 
@@ -54,6 +55,10 @@ class SideBarViewPrivate : public QObject
     QUrl sidebarUrl;
     DFMBASE_NAMESPACE::DFMMimeData dfmMimeData;
     QPalette originPalette;
+    bool ignoreNextMouseRelease = false;
+
+    // Track pending device-mount subscriptions so we can cancel stale ones.
+    QHash<QUrl, int> pendingMountSubs;
 
     explicit SideBarViewPrivate(SideBarView *qq);
     bool checkOpTime();   // 检查当前操作与上次操作的时间间隔
@@ -70,10 +75,14 @@ class SideBarViewPrivate : public QObject
     int calculatePlaceholderRow(const QPoint &pos, const QMimeData *data) const;
     void updatePlaceholderRow(int row, const QModelIndex &parent);
     int dragItemOffset(const QModelIndex &index, int rowHeight) const;
+    void expandPartitionItem(const QModelIndex &index, const QUrl &url);
+    void cancelPendingMountSubscription(const QUrl &deviceUrl);
 
 private Q_SLOTS:
     void currentChanged(const QModelIndex &curIndex);
     void onItemDoubleClicked(const QModelIndex &index);
+    void expandItem(const QModelIndex &parentIndex, const QList<QUrl> &subFolders);
+    void onExpandableChanged();
 
 private:
     void setTransparentPalette();

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -74,9 +74,26 @@ void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option)
 }
 }   // namespace GlobalPrivate
 
+QString SideBarItemDelegate::makeIconCacheKey(const DTK_GUI_NAMESPACE::DDciIcon &icon,
+                                             const QSize &size,
+                                             DTK_GUI_NAMESPACE::DDciIcon::Theme theme,
+                                             DTK_GUI_NAMESPACE::DDciIcon::Mode mode,
+                                             const QString &iconId) const
+{
+    return QString::asprintf("%s|%dx%d|%d|%d", iconId.toUtf8().constData(),
+                             size.width(), size.height(), static_cast<int>(theme), static_cast<int>(mode));
+}
+
+void SideBarItemDelegate::clearIconCache()
+{
+    m_iconCache.clear();
+}
+
 SideBarItemDelegate::SideBarItemDelegate(QAbstractItemView *parent)
     : DStyledItemDelegate(parent)
 {
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::paletteTypeChanged,
+            this, [this]() { clearIconCache(); });
 }
 
 void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -204,7 +221,9 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         iconMode = QIcon::Disabled;
     if (!suppressDraggedSelection && !isDraggingItemNotHighlighted && (selected || keepDrawingHighlighted))
         iconMode = QIcon::Selected;
-    drawExpandIndicator(painter, itemRect, sidebarItem ? sidebarItem->itemInfo().isExpandable : false, index, keepDrawingHighlighted);
+    bool isExpandable = sidebarItem && sidebarItem->itemInfo().isExpandable;
+    if (isExpandable)
+        drawExpandIndicator(painter, itemRect, true, index, keepDrawingHighlighted);
     if (opt.features & QStyleOptionViewItem::HasDecoration)
         drawIcon(opt, painter, index, itemRect, isEjectable, iconSize, iconMode, cg, keepDrawingHighlighted);
 
@@ -486,7 +505,8 @@ void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option,
         QIcon::State state = option.state & QStyle::State_Open ? QIcon::On : QIcon::Off;
         option.icon.paint(painter, iconRect, option.decorationAlignment, iconMode, state);
     } else {
-        drawDciIcon(optForIcon, painter, dciIcon, iconRect, cg, keepHighlighted);
+        drawDciIcon(optForIcon, painter, dciIcon, iconRect, cg, keepHighlighted,
+                    index.data(SideBarItem::kItemUrlRole).toUrl().toString());
     }
 
     painter->restore();
@@ -513,14 +533,15 @@ void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option,
             QStyle *style { option.widget ? option.widget->style() : QApplication::style() };
             style->drawItemPixmap(painter, iconRect, Qt::AlignCenter, px);
         } else {
-            drawDciIcon(option, painter, dciIcon, iconRect, cg, keepHighlighted);
+            drawDciIcon(option, painter, dciIcon, iconRect, cg, keepHighlighted, QStringLiteral("media-eject-symbolic"));
         }
     }
 }
 
 void SideBarItemDelegate::drawDciIcon(const QStyleOptionViewItem &option, QPainter *painter,
                                       const DTK_GUI_NAMESPACE::DDciIcon &dciIcon, const QRect &iconRect,
-                                      const QPalette::ColorGroup &cg, bool keepHighlighted) const
+                                      const QPalette::ColorGroup &cg, bool keepHighlighted,
+                                      const QString &iconId) const
 {
     DDciIcon::Mode mode = DStyle::toDciIconMode(&option);
     auto appTheme = DGuiApplicationHelper::toColorType(option.palette);
@@ -531,8 +552,26 @@ void SideBarItemDelegate::drawDciIcon(const QStyleOptionViewItem &option, QPaint
         const QColor fg = painter->pen().color();
         palette.setForeground(fg);
     }
-    dciIcon.paint(painter, iconRect, painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio(),
-                  theme, mode, Qt::AlignCenter, palette);
+
+    QString key = makeIconCacheKey(dciIcon, iconRect.size(), theme, mode, iconId);
+    if (m_iconCache.contains(key)) {
+        painter->drawPixmap(iconRect, m_iconCache.value(key));
+        return;
+    }
+
+    const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+    QPixmap px(iconRect.size() * dpr);
+    px.setDevicePixelRatio(dpr);
+    px.fill(Qt::transparent);
+    {
+        QPainter p(&px);
+        p.setRenderHints(painter->renderHints());
+        dciIcon.paint(&p, QRect(QPoint(0, 0), iconRect.size()), dpr, theme, mode, Qt::AlignCenter, palette);
+    }
+    if (m_iconCache.size() > 50)
+        m_iconCache.clear();
+    m_iconCache.insert(key, px);
+    painter->drawPixmap(iconRect, px);
 }
 
 void SideBarItemDelegate::drawMouseHoverBackground(QPainter *painter, const DPalette &palette, const QRect &r, const QColor &widgetColor) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -204,6 +204,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         iconMode = QIcon::Disabled;
     if (!suppressDraggedSelection && !isDraggingItemNotHighlighted && (selected || keepDrawingHighlighted))
         iconMode = QIcon::Selected;
+    drawExpandIndicator(painter, itemRect, sidebarItem ? sidebarItem->itemInfo().isExpandable : false, index, keepDrawingHighlighted);
     if (opt.features & QStyleOptionViewItem::HasDecoration)
         drawIcon(opt, painter, index, itemRect, isEjectable, iconSize, iconMode, cg, keepDrawingHighlighted);
 
@@ -575,6 +576,42 @@ void SideBarItemDelegate::drawMouseHoverExpandButton(QPainter *painter, const QR
     painter->setOpacity(1);
     painter->setPen(Qt::gray);
     QIcon icon = QIcon::fromTheme(isExpanded ? "go-up" : "go-down");
+    icon.paint(painter, iconRect, Qt::AlignmentFlag::AlignCenter);
+    painter->restore();
+}
+
+void SideBarItemDelegate::drawExpandIndicator(QPainter *painter, QRect &r, bool expandable, const QModelIndex &index, bool isHighlight) const
+{
+    DStandardItem *item = qobject_cast<const SideBarModel *>(index.model())->itemFromIndex(index);
+    SideBarItem *subItem = dynamic_cast<SideBarItem *>(item);
+
+    if (!expandable || !subItem || subItem->group() != DefaultGroup::kDevice)
+        return;
+
+    // Only draw the indicator when partition expansion is enabled.
+    SideBarView *view = dynamic_cast<SideBarView *>(this->parent());
+    if (!view || !view->isPartitionExpandable())
+        return;
+
+    // Apply indentation only for items that will actually draw an indicator.
+    auto layer = 0;
+    auto idx(index);
+    while (idx.parent().isValid()) {
+        idx = idx.parent();
+        layer++;
+    }
+    r.setX(r.x() + ExpandIndicatorGeometry::kIndentPerLayer * layer);
+
+    int iconSize = ExpandIndicatorGeometry::kIconSize;
+    int x = r.left() + ExpandIndicatorGeometry::kIconOffset;
+    int y = r.top() + (r.height() / 2) - (iconSize / 2);
+    QRect iconRect(QPoint(x, y), QSize(iconSize, iconSize));
+
+    painter->save();
+    painter->setOpacity(1);
+    painter->setPen(qApp->palette().color(isHighlight ? QPalette::HighlightedText : QPalette::Text));
+    bool expanded = view ? view->isExpanded(index) : false;
+    QIcon icon = QIcon::fromTheme(expanded ? "go-down" : "go-next");
     icon.paint(painter, iconRect, Qt::AlignmentFlag::AlignCenter);
     painter->restore();
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -10,6 +10,8 @@
 #include <dfm-base/interfaces/fileinfo.h>
 
 #include <DStyledItemDelegate>
+#include <QHash>
+#include <QPixmap>
 
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
@@ -47,11 +49,19 @@ private:
                   QIcon::Mode iconMode, QPalette::ColorGroup cg, bool keepHighlighted) const;
     void drawDciIcon(const QStyleOptionViewItem &option, QPainter *painter,
                      const DTK_GUI_NAMESPACE::DDciIcon &dciIcon, const QRect &iconRect,
-                     const QPalette::ColorGroup &cg, bool keepHighlighted) const;
+                     const QPalette::ColorGroup &cg, bool keepHighlighted,
+                     const QString &iconId = QString()) const;
 
     void drawMouseHoverBackground(QPainter *painter, const DPalette &palette, const QRect &r, const QColor &widgetColor) const;
     void drawMouseHoverExpandButton(QPainter *painter, const QRect &r, bool isExpanded) const;
     void drawExpandIndicator(QPainter *painter, QRect &r, bool expandable, const QModelIndex &index, bool isHighlight) const;
+
+    mutable QHash<QString, QPixmap> m_iconCache;
+    QString makeIconCacheKey(const DTK_GUI_NAMESPACE::DDciIcon &icon, const QSize &size,
+                             DTK_GUI_NAMESPACE::DDciIcon::Theme theme,
+                             DTK_GUI_NAMESPACE::DDciIcon::Mode mode,
+                             const QString &iconId = QString()) const;
+    void clearIconCache();
 
 Q_SIGNALS:
     void rename(const QModelIndex &index, QString newName) const;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -51,6 +51,7 @@ private:
 
     void drawMouseHoverBackground(QPainter *painter, const DPalette &palette, const QRect &r, const QColor &widgetColor) const;
     void drawMouseHoverExpandButton(QPainter *painter, const QRect &r, bool isExpanded) const;
+    void drawExpandIndicator(QPainter *painter, QRect &r, bool expandable, const QModelIndex &index, bool isHighlight) const;
 
 Q_SIGNALS:
     void rename(const QModelIndex &index, QString newName) const;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -113,30 +113,31 @@ void SideBarViewPrivate::onItemDoubleClicked(const QModelIndex &index)
 
             QModelIndex capturedIndex = index;
             QPointer<SideBarView> view = q;
+            QPointer<SideBarViewPrivate> guard(this);
             QUrl deviceUrl = nodeUrl;
 
             int subId = DeviceMountSubscriber::instance()->subscribe(
                     nodeUrl,
-                    [capturedIndex, view, this, deviceUrl](const QUrl &mountedUrl) {
-                        pendingMountSubs.remove(deviceUrl);
-
-                        if (!view) {
+                    [capturedIndex, view, guard, deviceUrl](const QUrl &mountedUrl) {
+                        if (!view || !guard) {
                             fmDebug() << "SideBarViewPrivate: View destroyed before mount completed";
                             return;
                         }
 
+                        guard->pendingMountSubs.remove(deviceUrl);
+
                         fmDebug() << "SideBarViewPrivate: Device mounted at" << mountedUrl
                                   << ", auto-expanding directory";
 
-                        QTimer::singleShot(100, view, [capturedIndex, mountedUrl, view, this]() {
-                            if (!view) {
+                        QTimer::singleShot(100, view, [capturedIndex, mountedUrl, view, guard]() {
+                            if (!view || !guard) {
                                 fmDebug() << "SideBarViewPrivate: View destroyed during delayed expansion";
                                 return;
                             }
 
                             if (mountedUrl.isValid() && mountedUrl.scheme() == "file"
                                 && QDir(mountedUrl.path()).exists()) {
-                                expandPartitionItem(capturedIndex, mountedUrl);
+                                guard->expandPartitionItem(capturedIndex, mountedUrl);
                             } else {
                                 fmDebug() << "SideBarViewPrivate: Unable to expand - invalid mounted URL:"
                                           << mountedUrl;
@@ -587,6 +588,7 @@ SideBarView::SideBarView(QWidget *parent)
     connect(this, &DTreeView::doubleClicked, d, &SideBarViewPrivate::onItemDoubleClicked);
     connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, [=](const QString &cfg, const QString &key) {
         if (cfg == ConfigInfos::kConfName && key == ConfigInfos::kPartitionExpandableKey) {
+            m_partitionExpandableCache.reset();
             d->onExpandableChanged();
         }
     });
@@ -1186,7 +1188,10 @@ int SideBarView::dragItemVerticalOffset(const QModelIndex &index, int rowHeight)
 
 bool SideBarView::isPartitionExpandable() const
 {
-    return SideBarHelper::partitionExpandable();
+    if (m_partitionExpandableCache.has_value())
+        return *m_partitionExpandableCache;
+    m_partitionExpandableCache = SideBarHelper::partitionExpandable();
+    return *m_partitionExpandableCache;
 }
 
 Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *data, Qt::DropActions actions) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -8,14 +8,20 @@
 #include "sidebaritem.h"
 #include "utils/fileoperatorhelper.h"
 #include "utils/sidebarhelper.h"
+#include "utils/sidebarinfocachemananger.h"
+#include "utils/devicemountsubscriber.h"
 #include "private/sidebarview_p.h"
+#include "events/sidebareventcaller.h"
 
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/base/urlroute.h>
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/utils/sysinfoutils.h>
+#include <dfm-base/utils/traversaldirthread.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -36,6 +42,8 @@
 #include <QScrollBar>
 #include <QScroller>
 #include <QVariantAnimation>
+#include <QPointer>
+#include <QDir>
 
 #include <unistd.h>
 
@@ -72,12 +80,76 @@ void SideBarViewPrivate::onItemDoubleClicked(const QModelIndex &index)
         return;
     }
     SideBarItem *item = q->model()->itemFromIndex(index);
-    if (!dynamic_cast<SideBarItemSeparator *>(item)) {
-        fmDebug() << "Double clicked on non-separator item, ignoring";
+
+    // Handle group separator expand/collapse.
+    if (dynamic_cast<SideBarItemSeparator *>(item)) {
+        q->onChangeExpandState(index, !q->isExpanded(index));
         return;
     }
 
-    q->onChangeExpandState(index, !q->isExpanded(index));
+    // Handle partition sub-directory expand/collapse.
+    if (item && item->group() == DefaultGroup::kDevice) {
+        if (!SideBarHelper::partitionExpandable()) {
+            fmDebug() << "Partition expansion is disabled";
+            return;
+        }
+
+        QUrl finalUrl = item->itemInfo().finalUrl;
+        QUrl nodeUrl = item->url();
+        if (nodeUrl.scheme() == "file")
+            finalUrl = nodeUrl;
+
+        bool deviceMounted = !finalUrl.isEmpty() && finalUrl.isValid();
+
+        fmDebug() << "is mounted?" << deviceMounted << finalUrl;
+        if (deviceMounted) {
+            expandPartitionItem(index, finalUrl);
+        } else {
+            // Device not yet mounted; subscribe to mount event and auto-expand later.
+            // Cancel any previous subscription for the same device to avoid duplicate toggling.
+            cancelPendingMountSubscription(nodeUrl);
+
+            fmDebug() << "SideBarViewPrivate: Device not mounted, subscribing to mount events:" << nodeUrl;
+
+            QModelIndex capturedIndex = index;
+            QPointer<SideBarView> view = q;
+            QUrl deviceUrl = nodeUrl;
+
+            int subId = DeviceMountSubscriber::instance()->subscribe(
+                    nodeUrl,
+                    [capturedIndex, view, this, deviceUrl](const QUrl &mountedUrl) {
+                        pendingMountSubs.remove(deviceUrl);
+
+                        if (!view) {
+                            fmDebug() << "SideBarViewPrivate: View destroyed before mount completed";
+                            return;
+                        }
+
+                        fmDebug() << "SideBarViewPrivate: Device mounted at" << mountedUrl
+                                  << ", auto-expanding directory";
+
+                        QTimer::singleShot(100, view, [capturedIndex, mountedUrl, view, this]() {
+                            if (!view) {
+                                fmDebug() << "SideBarViewPrivate: View destroyed during delayed expansion";
+                                return;
+                            }
+
+                            if (mountedUrl.isValid() && mountedUrl.scheme() == "file"
+                                && QDir(mountedUrl.path()).exists()) {
+                                expandPartitionItem(capturedIndex, mountedUrl);
+                            } else {
+                                fmDebug() << "SideBarViewPrivate: Unable to expand - invalid mounted URL:"
+                                          << mountedUrl;
+                            }
+                        });
+                    });
+            if (subId >= 0)
+                pendingMountSubs.insert(nodeUrl, subId);
+        }
+        return;
+    }
+
+    fmDebug() << "Double clicked on non-separator item, ignoring";
 }
 
 void SideBarViewPrivate::setTransparentPalette()
@@ -90,6 +162,90 @@ void SideBarViewPrivate::setTransparentPalette()
 void SideBarViewPrivate::restorePalette()
 {
     q->setPalette(originPalette);
+}
+
+void SideBarViewPrivate::expandItem(const QModelIndex &index, const QList<QUrl> &subFolders)
+{
+    if (!index.isValid())
+        return;
+
+    q->model()->addSubItems(index, subFolders);
+    q->expand(index);
+    q->onChangeExpandState(index, true);
+    q->setCurrentUrl(sidebarUrl);
+}
+
+void SideBarViewPrivate::expandPartitionItem(const QModelIndex &index, const QUrl &url)
+{
+    // If already expanded, collapse it.
+    if (q->isExpanded(index)) {
+        q->collapse(index);
+        q->onChangeExpandState(index, false);
+        return;
+    }
+
+    auto filters = QDir::Dirs | QDir::NoDotAndDotDot;
+    if (Application::instance()->genericAttribute(Application::kShowedHiddenFiles).toBool())
+        filters |= QDir::Hidden;
+    TraversalDirThread *t = new TraversalDirThread(url, {}, filters, QDirIterator::FollowSymlinks);
+    connect(t, &TraversalDirThread::finished, t, &TraversalDirThread::deleteLater);
+    connect(t, &TraversalDirThread::updateChildren, this, [=](const QList<QUrl> &subs) {
+        this->expandItem(index, subs);
+    });
+    t->start();
+}
+
+void SideBarViewPrivate::cancelPendingMountSubscription(const QUrl &deviceUrl)
+{
+    auto it = pendingMountSubs.find(deviceUrl);
+    if (it != pendingMountSubs.end()) {
+        DeviceMountSubscriber::instance()->unsubscribe(it.value());
+        pendingMountSubs.erase(it);
+    }
+}
+
+void SideBarViewPrivate::onExpandableChanged()
+{
+    if (SideBarHelper::partitionExpandable())
+        return;
+
+    fmDebug() << "Partition expansion is disabled";
+    SideBarModel *sidebarModel = q->model();
+    if (!sidebarModel) {
+        fmDebug() << "SideBarViewPrivate: Model is null, cannot collapse partitions";
+        return;
+    }
+
+    auto groupIndex = sidebarModel->findGroupIndex(DefaultGroup::kDevice);
+    if (!groupIndex.isValid()) {
+        fmDebug() << "SideBarViewPrivate: Group index not found";
+        return;
+    }
+
+    // Use rowCount(groupIndex) — not rowCount() — so we iterate device children, not top-level groups.
+    for (int i = 0; i < sidebarModel->rowCount(groupIndex); ++i) {
+        QModelIndex index = sidebarModel->index(i, 0, groupIndex);
+        if (!index.isValid())
+            continue;
+
+        DStandardItem *item = sidebarModel->itemFromIndex(index);
+        SideBarItem *sidebarItem = dynamic_cast<SideBarItem *>(item);
+
+        if (sidebarItem && sidebarItem->group() == DefaultGroup::kDevice) {
+            // Collapse the partition and remove its sub-items so file watchers are released.
+            if (q->isExpanded(index)) {
+                fmDebug() << "SideBarViewPrivate: Collapsing expanded partition:" << sidebarItem->url();
+                q->collapse(index);
+                q->onChangeExpandState(index, false);
+            }
+            // Remove dynamically-added sub-items (keep the partition item itself).
+            while (sidebarItem->rowCount() > 0) {
+                if (auto *child = static_cast<SideBarItem *>(sidebarItem->child(0)))
+                    SideBarInfoCacheMananger::instance()->removeItemInfoCache(child->url());
+                sidebarItem->removeRow(0);
+            }
+        }
+    }
 }
 
 void SideBarViewPrivate::updateHoverIndex(const QModelIndex &index)
@@ -429,6 +585,11 @@ SideBarView::SideBarView(QWidget *parent)
 
     connect(this, &DTreeView::clicked, d, &SideBarViewPrivate::currentChanged);
     connect(this, &DTreeView::doubleClicked, d, &SideBarViewPrivate::onItemDoubleClicked);
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, [=](const QString &cfg, const QString &key) {
+        if (cfg == ConfigInfos::kConfName && key == ConfigInfos::kPartitionExpandableKey) {
+            d->onExpandableChanged();
+        }
+    });
 
     d->originPalette = palette();
     d->lastOpTimer.start();
@@ -441,6 +602,11 @@ SideBarView::SideBarView(QWidget *parent)
 
 SideBarView::~SideBarView()
 {
+    // Cancel any pending device-mount subscriptions to avoid lingering callbacks.
+    for (auto it = d->pendingMountSubs.begin(); it != d->pendingMountSubs.end(); ++it)
+        DeviceMountSubscriber::instance()->unsubscribe(it.value());
+    d->pendingMountSubs.clear();
+
     QScroller::ungrabGesture(viewport());
     setStyle(nullptr);
 }
@@ -462,6 +628,30 @@ void SideBarView::mousePressEvent(QMouseEvent *event)
     d->draggedUrl = urlAt(event->pos());
     auto item = itemAt(event->pos());
     d->draggedGroup = item ? item->group() : "";
+
+    auto index = indexAt(event->pos());
+    if (event->button() == Qt::LeftButton && index.isValid()
+        && item && item->group() == DefaultGroup::kDevice) {
+        if (item->itemInfo().isExpandable && SideBarHelper::partitionExpandable()) {
+            int layer = 0;
+            auto parentIdx = index;
+            while (parentIdx.parent().isValid()) {
+                parentIdx = parentIdx.parent();
+                layer++;
+            }
+            // see @SideBarItemDelegate::drawExpandIndicator
+            // The indicator is painted at (layer * kExpandIndentPerLayer + kExpandIconOffset).
+            // Expand the hit area by kExpandHitMargin on both sides for easier clicking.
+            int iconLeft = layer * ExpandIndicatorGeometry::kIndentPerLayer + ExpandIndicatorGeometry::kIconOffset;
+            int collapseIconLeft = iconLeft - ExpandIndicatorGeometry::kHitMargin;
+            int collapseIconRight = iconLeft + ExpandIndicatorGeometry::kIconSize + ExpandIndicatorGeometry::kHitMargin;
+            if (event->pos().x() >= collapseIconLeft && event->pos().x() <= collapseIconRight) {
+                d->onItemDoubleClicked(index);
+                d->ignoreNextMouseRelease = true;
+                return;   // do not select the item.
+            }
+        }
+    }
 
     if (event->button() == Qt::RightButton) {
         // fix bug#33502 鼠标挪动到侧边栏底部右键，滚动条滑动，不能定位到选中的栏目上
@@ -489,6 +679,13 @@ void SideBarView::mouseReleaseEvent(QMouseEvent *event)
 
             dpfSignalDispatcher->publish("dfmplugin_sidebar", "signal_ReportLog_Commit", QString("Sidebar"), data);
         }
+    }
+
+    // Prevent selecting an item when the mouse press was consumed by the
+    // expand-indicator click handler (see mousePressEvent).
+    if (d->ignoreNextMouseRelease) {
+        d->ignoreNextMouseRelease = false;
+        return;
     }
 
     DTreeView::mouseReleaseEvent(event);
@@ -987,6 +1184,11 @@ int SideBarView::dragItemVerticalOffset(const QModelIndex &index, int rowHeight)
     return d->dragItemOffset(index, rowHeight);
 }
 
+bool SideBarView::isPartitionExpandable() const
+{
+    return SideBarHelper::partitionExpandable();
+}
+
 Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *data, Qt::DropActions actions) const
 {
     // Got a copy of urls so whatever data was changed, it won't affact the following code.
@@ -1196,7 +1398,24 @@ void SideBarView::onChangeExpandState(const QModelIndex &index, bool expand)
         if (expand)
             setCurrentUrl(d->sidebarUrl);   // To make sure, when expand the group item, the current item is highlighted.
     }
+
+    // Notify SideBarModel to start/stop file watching for partition items.
+    if (expand) {
+        sidebarModel->onItemExpanded(index);
+    } else {
+        sidebarModel->onItemCollapsed(index);
+    }
+
     update(index);
+}
+
+void SideBarView::onRequestCollapseItem(const QModelIndex &index)
+{
+    if (index.isValid()) {
+        collapse(index);
+        onChangeExpandState(index, false);
+        fmDebug() << "Collapsed item per model request:" << index.data(Qt::DisplayRole).toString();
+    }
 }
 
 bool SideBarViewPrivate::checkOpTime()

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -8,6 +8,7 @@
 #include "dfmplugin_sidebar_global.h"
 
 #include <DTreeView>
+#include <optional>
 
 DWIDGET_USE_NAMESPACE
 
@@ -58,6 +59,8 @@ protected:
 
 private:
     inline QString dragEventUrls() const;
+
+    mutable std::optional<bool> m_partitionExpandableCache;
 
 public Q_SLOTS:
     void updateSeparatorVisibleState();

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -41,6 +41,7 @@ public:
     bool isDraggedSource(const QModelIndex &index) const;
     bool isRenderingDragPreview() const;
     int dragItemVerticalOffset(const QModelIndex &index, int rowHeight) const;
+    bool isPartitionExpandable() const;
 
 protected:
     void mousePressEvent(QMouseEvent *event) override;
@@ -61,6 +62,7 @@ private:
 public Q_SLOTS:
     void updateSeparatorVisibleState();
     void onChangeExpandState(const QModelIndex &index, bool expand);
+    void onRequestCollapseItem(const QModelIndex &index);
 
 Q_SIGNALS:
     void requestRemoveItem();

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -459,6 +459,7 @@ void SideBarWidget::initConnect()
     connect(kSidebarModelIns.data(), &SideBarModel::rowsInserted, sidebarView, &SideBarView::updateSeparatorVisibleState);
     connect(kSidebarModelIns.data(), &SideBarModel::rowsRemoved, sidebarView, &SideBarView::updateSeparatorVisibleState);
     connect(kSidebarModelIns.data(), &SideBarModel::rowsMoved, sidebarView, &SideBarView::updateSeparatorVisibleState);
+    connect(kSidebarModelIns.data(), &SideBarModel::requestCollapseItem, sidebarView, &SideBarView::onRequestCollapseItem);
 
     // 监听窗口特效模式切换
     connect(compositingConfig, &DConfig::valueChanged, this, [this](const QString &key) {

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/devicemountsubscriber.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/devicemountsubscriber.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "devicemountsubscriber.h"
+
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-base/dfm_log_defines.h>
+
+DPSIDEBAR_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+DeviceMountSubscriber *DeviceMountSubscriber::instance()
+{
+    static DeviceMountSubscriber instance;
+    return &instance;
+}
+
+DeviceMountSubscriber::DeviceMountSubscriber(QObject *parent)
+    : QObject(parent)
+{
+    connect(&cleanupTimer, &QTimer::timeout, this, &DeviceMountSubscriber::cleanupExpiredSubscriptions);
+    cleanupTimer.start(60000);   // check once per minute
+    fmDebug() << "DeviceMountSubscriber initialized";
+}
+
+int DeviceMountSubscriber::subscribe(const QUrl &deviceUrl, std::function<void(const QUrl &)> callback)
+{
+    if (!deviceUrl.isValid()) {
+        fmWarning() << "DeviceMountSubscriber: Cannot subscribe to invalid URL";
+        return -1;
+    }
+
+    int id = nextSubscriptionId++;
+
+    Subscription sub;
+    sub.id = id;
+    sub.deviceUrl = deviceUrl;
+    sub.callback = callback;
+    sub.timestamp = QDateTime::currentDateTime();
+
+    subscriptions.insert(id, sub);
+
+    fmDebug() << "DeviceMountSubscriber: Subscribed to" << deviceUrl << "with ID" << id
+              << "- active subscriptions:" << subscriptions.size();
+
+    return id;
+}
+
+void DeviceMountSubscriber::unsubscribe(int subscriptionId)
+{
+    if (subscriptions.contains(subscriptionId)) {
+        QUrl url = subscriptions[subscriptionId].deviceUrl;
+        fmDebug() << "DeviceMountSubscriber: Unsubscribed ID" << subscriptionId
+                  << "for device" << url
+                  << "- remaining subscriptions:" << (subscriptions.size() - 1);
+        subscriptions.remove(subscriptionId);
+    } else {
+        fmWarning() << "DeviceMountSubscriber: Attempted to unsubscribe non-existent ID" << subscriptionId;
+    }
+}
+
+void DeviceMountSubscriber::notifyMountFinished(const QUrl &deviceUrl, const QUrl &mountedUrl)
+{
+    if (!deviceUrl.isValid() || !mountedUrl.isValid()) {
+        fmWarning() << "DeviceMountSubscriber: Invalid URL in notifyMountFinished"
+                   << "deviceUrl:" << deviceUrl << "mountedUrl:" << mountedUrl;
+        return;
+    }
+
+    fmDebug() << "DeviceMountSubscriber: Device mounted" << deviceUrl << "at" << mountedUrl
+              << "- checking" << subscriptions.size() << "subscriptions";
+
+    QList<int> matchedIds;
+
+    for (auto it = subscriptions.begin(); it != subscriptions.end(); ++it) {
+        if (UniversalUtils::urlEquals(it.value().deviceUrl, deviceUrl)) {
+            fmDebug() << "DeviceMountSubscriber: Found matching subscription ID" << it.key()
+                     << "for device" << deviceUrl;
+
+            try {
+                fmDebug() << "DeviceMountSubscriber: Executing callback for ID" << it.key();
+                it.value().callback(mountedUrl);
+            } catch (const std::exception &e) {
+                fmWarning() << "DeviceMountSubscriber: Exception in callback:" << e.what();
+            } catch (...) {
+                fmWarning() << "DeviceMountSubscriber: Unknown exception in callback";
+            }
+
+            matchedIds.append(it.key());
+        }
+    }
+
+    for (int id : matchedIds) {
+        fmDebug() << "DeviceMountSubscriber: Removing completed subscription ID" << id;
+        subscriptions.remove(id);
+    }
+
+    if (matchedIds.isEmpty()) {
+        fmDebug() << "DeviceMountSubscriber: No matching subscriptions found for device:" << deviceUrl;
+    } else {
+        fmDebug() << "DeviceMountSubscriber: Processed" << matchedIds.size()
+                 << "subscriptions for device:" << deviceUrl
+                 << "- remaining subscriptions:" << subscriptions.size();
+    }
+}
+
+void DeviceMountSubscriber::cleanupExpiredSubscriptions()
+{
+    QDateTime now = QDateTime::currentDateTime();
+    QList<int> expiredIds;
+
+    for (auto it = subscriptions.begin(); it != subscriptions.end(); ++it) {
+        int ageInSeconds = it.value().timestamp.secsTo(now);
+        if (ageInSeconds > 600) {   // 10 minutes
+            expiredIds.append(it.key());
+            fmDebug() << "DeviceMountSubscriber: Subscription ID" << it.key()
+                     << "expired after" << ageInSeconds << "seconds";
+        }
+    }
+
+    for (int id : expiredIds) {
+        fmDebug() << "DeviceMountSubscriber: Removing expired subscription ID" << id
+                 << "for device" << subscriptions[id].deviceUrl;
+        subscriptions.remove(id);
+    }
+
+    if (!expiredIds.isEmpty()) {
+        fmDebug() << "DeviceMountSubscriber: Cleaned up" << expiredIds.size()
+                 << "expired subscriptions - remaining:" << subscriptions.size();
+    }
+}

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/devicemountsubscriber.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/devicemountsubscriber.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DEVICEMOUNTSUBSCRIBER_H
+#define DEVICEMOUNTSUBSCRIBER_H
+
+#include "dfmplugin_sidebar_global.h"
+
+#include <QObject>
+#include <QMap>
+#include <QUrl>
+#include <QTimer>
+#include <QDateTime>
+#include <functional>
+
+DPSIDEBAR_BEGIN_NAMESPACE
+
+/**
+ * @brief Device mount event subscription manager.
+ *
+ * Implements a publish-subscribe pattern to handle callbacks after a device
+ * mount completes. Used by the sidebar to auto-expand a partition once its
+ * underlying device is mounted.
+ */
+class DeviceMountSubscriber : public QObject
+{
+    Q_OBJECT
+public:
+    static DeviceMountSubscriber *instance();
+
+    int subscribe(const QUrl &deviceUrl, std::function<void(const QUrl &)> callback);
+    void unsubscribe(int subscriptionId);
+    void notifyMountFinished(const QUrl &deviceUrl, const QUrl &mountedUrl);
+
+private:
+    explicit DeviceMountSubscriber(QObject *parent = nullptr);
+
+    struct Subscription {
+        int id;
+        QUrl deviceUrl;
+        std::function<void(const QUrl &)> callback;
+        QDateTime timestamp;
+    };
+
+    QMap<int, Subscription> subscriptions;
+    int nextSubscriptionId = 0;
+    QTimer cleanupTimer;
+
+    void cleanupExpiredSubscriptions();
+};
+
+DPSIDEBAR_END_NAMESPACE
+
+#endif   // DEVICEMOUNTSUBSCRIBER_H

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarfilewatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarfilewatcher.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "sidebarfilewatcher.h"
+#include "dfm-base/dfm_log_defines.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/traversaldirthread.h>
+
+#include <QDebug>
+
+DPSIDEBAR_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+SidebarFileWatcher::SidebarFileWatcher(QObject *parent)
+    : QObject(parent)
+{
+    connect(Application::instance(), &Application::showedHiddenFilesChanged, this, &SidebarFileWatcher::onHiddenFileStatusChanged);
+}
+
+SidebarFileWatcher::~SidebarFileWatcher()
+{
+    stopAllWatchers();
+}
+
+void SidebarFileWatcher::watchDirectory(const QUrl &url)
+{
+    if (url.isValid() && !watchers.contains(url)) {
+        auto watcher = WatcherFactory::create<AbstractFileWatcher>(url, false);
+        connect(watcher.data(), &AbstractFileWatcher::subfileCreated, this, &SidebarFileWatcher::onSubfileCreated);
+        connect(watcher.data(), &AbstractFileWatcher::fileDeleted, this, &SidebarFileWatcher::onFileDeleted);
+        connect(watcher.data(), &AbstractFileWatcher::fileRename, this, &SidebarFileWatcher::onFileRename);
+        connect(watcher.data(), &AbstractFileWatcher::fileAttributeChanged, this, &SidebarFileWatcher::onFileAttributeChanged);
+
+        watcher->startWatcher();
+        watchers.insert(url, watcher);
+    }
+}
+
+void SidebarFileWatcher::unwatchDirectory(const QUrl &url)
+{
+    if (watchers.contains(url)) {
+        auto watcher = watchers.take(url);
+        watcher->stopWatcher();
+    }
+}
+
+void SidebarFileWatcher::stopAllWatchers()
+{
+    for (auto watcher : watchers) {
+        watcher->stopWatcher();
+    }
+    watchers.clear();
+}
+
+void SidebarFileWatcher::onSubfileCreated(const QUrl &url)
+{
+    QUrl parentUrl = url.adjusted(QUrl::RemoveFilename);
+    if (parentUrl.scheme() == Global::Scheme::kBurn && parentUrl.path().contains("/staging_files/")) {
+        auto path = parentUrl.path();
+        path.replace("/staging_files/", "/disc_files/");
+        parentUrl.setPath(path);
+    }
+
+    auto info = InfoFactory::create<FileInfo>(url, dfmbase::Global::kCreateFileInfoSync);
+    if (!info)
+        return;
+    if (!info->isAttributes(FileInfo::FileIsType::kIsDir))
+        return;
+
+    emit directoryCreated(parentUrl, url);
+}
+
+void SidebarFileWatcher::onFileDeleted(const QUrl &url)
+{
+    QUrl parentUrl = url.adjusted(QUrl::RemoveFilename);
+    emit directoryRemoved(parentUrl, url);
+    if (watchers.contains(url)) {
+        auto w = watchers.take(url);
+        w->stopWatcher();
+    }
+}
+
+void SidebarFileWatcher::onFileRename(const QUrl &oldUrl, const QUrl &newUrl)
+{
+    QFileInfo newFileInfo(newUrl.toLocalFile());
+
+    if (newFileInfo.isDir()) {
+        QUrl parentUrl = newUrl.adjusted(QUrl::RemoveFilename);
+        emit directoryRenamed(parentUrl, oldUrl, newUrl);
+    }
+}
+
+void SidebarFileWatcher::onFileAttributeChanged(const QUrl &url)
+{
+    bool showHiddenFiles = Application::genericAttribute(Application::kShowedHiddenFiles).toBool();
+
+    auto info = InfoFactory::create<FileInfo>(url, dfmbase::Global::kCreateFileInfoSync);
+    if (!info) {
+        fmWarning() << "Failed to create FileInfo for" << url;
+        return;
+    }
+
+    if (!info->isAttributes(FileInfo::FileIsType::kIsDir)) {
+        return;
+    }
+
+    bool isHidden = info->isAttributes(FileInfo::FileIsType::kIsHidden);
+
+    QUrl parentUrl = url.adjusted(QUrl::RemoveFilename);
+
+    if (!showHiddenFiles) {
+        if (isHidden) {
+            emit directoryRemoved(parentUrl, url);
+        } else {
+            emit directoryCreated(parentUrl, url);
+        }
+    }
+}
+
+void SidebarFileWatcher::onHiddenFileStatusChanged(bool showHidden)
+{
+    auto watchingUrls = watchers.keys();
+    for (auto url : watchingUrls) {
+        TraversalDirThread *t = new TraversalDirThread(url, {}, QDir::Hidden | QDir::Dirs | QDir::NoDotAndDotDot, QDirIterator::FollowSymlinks);
+        connect(t, &TraversalDirThread::updateChildren, this, [=](const QList<QUrl> &dirs) {
+            setDirsVisible(showHidden, dirs);
+        });
+        connect(t, &TraversalDirThread::finished, t, &TraversalDirThread::deleteLater);
+        t->start();
+    }
+}
+
+void SidebarFileWatcher::setDirsVisible(bool showHidden, const QList<QUrl> &dirs)
+{
+    if (dirs.isEmpty())
+        return;
+    auto parentUrl = dirs.first().adjusted(QUrl::RemoveFilename);
+    for (auto dir : dirs) {
+        auto info = InfoFactory::create<FileInfo>(dir, dfmbase::Global::kCreateFileInfoSync);
+        if (!info || !info->isAttributes(FileInfo::FileIsType::kIsHidden))
+            continue;
+        if (showHidden)
+            emit directoryCreated(parentUrl, dir);
+        else
+            emit directoryRemoved(parentUrl, dir);
+    }
+}

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarfilewatcher.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarfilewatcher.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SIDEBARFILEWATCHER_H
+#define SIDEBARFILEWATCHER_H
+
+#include "dfmplugin_sidebar_global.h"
+
+#include <dfm-base/interfaces/abstractfilewatcher.h>
+#include <dfm-base/base/application/application.h>
+
+#include <QObject>
+#include <QMap>
+#include <QUrl>
+
+DPSIDEBAR_BEGIN_NAMESPACE
+
+class SidebarFileWatcher : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SidebarFileWatcher(QObject *parent = nullptr);
+    ~SidebarFileWatcher();
+
+    void watchDirectory(const QUrl &url);
+    void unwatchDirectory(const QUrl &url);
+    void stopAllWatchers();
+
+signals:
+    void directoryCreated(const QUrl &parentUrl, const QUrl &url);
+    void directoryRemoved(const QUrl &parentUrl, const QUrl &url);
+    void directoryRenamed(const QUrl &parentUrl, const QUrl &oldUrl, const QUrl &newUrl);
+
+private slots:
+    void onSubfileCreated(const QUrl &url);
+    void onFileDeleted(const QUrl &url);
+    void onFileRename(const QUrl &oldUrl, const QUrl &newUrl);
+    void onFileAttributeChanged(const QUrl &url);
+
+    void onHiddenFileStatusChanged(bool showHidden);
+    void setDirsVisible(bool showHidden, const QList<QUrl> &dirs);
+
+private:
+    QMap<QUrl, AbstractFileWatcherPointer> watchers;
+};
+
+DPSIDEBAR_END_NAMESPACE
+
+#endif   // SIDEBARFILEWATCHER_H

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -322,6 +322,11 @@ QVariantMap SideBarHelper::groupExpandRules()
     return DConfigManager::instance()->value(ConfigInfos::kConfName, ConfigInfos::kGroupExpandedKey).toMap();
 }
 
+bool SideBarHelper::partitionExpandable()
+{
+    return DConfigManager::instance()->value(ConfigInfos::kConfName, ConfigInfos::kPartitionExpandableKey, false).toBool();
+}
+
 void SideBarHelper::saveGroupsStateToConfig(const QVariant &var)
 {
     const QStringList keys = var.toMap().keys();

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.h
@@ -42,6 +42,7 @@ public:
     static void registCustomSettingItem();
     static QVariantMap hiddenRules();
     static QVariantMap groupExpandRules();
+    static bool partitionExpandable();
 
     static void saveGroupsStateToConfig(const QVariant &var);
     static void openFolderInASeparateProcess(const QUrl &url);


### PR DESCRIPTION
## 功能说明

将 v20 文管（gerrit release/107x 分支）侧边栏分区展开/折叠功能（DConfig `partitionExpandable`）迁移到 v25（github master 分支）。

开启后允许在侧边栏中展开磁盘分区项，直接浏览子目录，支持：
- 展开/折叠指示器显示
- 双击/单击展开分区子目录
- 子目录实时监听（创建/删除/重命名自动更新）
- 未挂载设备挂载后自动展开
- 配置切换时自动折叠已展开分区

## 改动概览

| 类型 | 数量 | 说明 |
|------|------|------|
| 修改 | 14 个 | sidebar.json, global.h, sidebarhelper, sidebareventreceiver, sidebarmodel, sidebarview, sidebaritemdelegate, sidebarwidget, computeritemwatcher |
| 新增 | 4 个 | devicemountsubscriber (.h/.cpp), sidebarfilewatcher (.h/.cpp) |

## 验证

已通过 lz-code-review 代码审查（评分 B），所有必须修复项和改进建议均已处理。

TASK: https://pms.uniontech.com/task-view-393123.html

## Summary by Sourcery

Add configurable partition expand/collapse support to the file manager sidebar, including live subdirectory listing and automatic handling of device mount state.

New Features:
- Allow sidebar device entries to expand into subdirectories via double-click or expand indicator when partition expansion is enabled.
- Introduce a configuration key and UI indicator for controlling and visualizing partition expandability in the sidebar.
- Add automatic subscription to device-mount events so unmounted partitions expand once their devices are mounted.

Enhancements:
- Integrate a sidebar-specific directory watcher to keep expanded partition subfolders in sync with filesystem changes and hidden-file visibility.
- Extend sidebar model, view, and delegate to manage dynamic child items for device entries and coordinate expansion state across views.
- Update computer item watcher and sidebar event handling to propagate partition expandability and mount completion events.