### PR TITLE
feat: track index creation progress to prevent duplicate builds

### DIFF
--- a/src/services/textindex/service_textindex_global.h
+++ b/src/services/textindex/service_textindex_global.h
@@ -72,6 +72,7 @@ inline const QString kOcrVersionKey = QLatin1String("version");
 inline const QString kLastUpdateTimeKey = QLatin1String("lastUpdateTime");
 inline const QString kStateKey = QLatin1String("state");
 inline const QString kNeedsRebuildKey = QLatin1String("needsRebuild");
+inline const QString kCreateInProgressKey = QLatin1String("createInProgress");
 
 // json - value
 inline const QString kStateClean = QLatin1String("clean");   // state

--- a/src/services/textindex/state/indexstatestore.cpp
+++ b/src/services/textindex/state/indexstatestore.cpp
@@ -157,6 +157,19 @@ void IndexStateStore::setNeedsRebuild(bool need) const
     writeStatusJson(statusFilePath(), obj);
 }
 
+bool IndexStateStore::isCreateInProgress() const
+{
+    const QJsonObject obj = readStatusJson(statusFilePath());
+    return obj.contains(Defines::kCreateInProgressKey) ? obj[Defines::kCreateInProgressKey].toBool() : false;
+}
+
+void IndexStateStore::setCreateInProgress(bool inProgress) const
+{
+    QJsonObject obj = readStatusJson(statusFilePath());
+    obj[Defines::kCreateInProgressKey] = inProgress;
+    writeStatusJson(statusFilePath(), obj);
+}
+
 QString IndexStateStore::getLastUpdateTime() const
 {
     const QJsonObject obj = readStatusJson(statusFilePath());

--- a/src/services/textindex/state/indexstatestore.h
+++ b/src/services/textindex/state/indexstatestore.h
@@ -149,6 +149,29 @@ public:
     void setNeedsRebuild(bool need) const;
 
     /**
+     * @brief 读取 createInProgress 标记
+     * @return true 表示 CREATE 任务未完成（重型 UPDATE 的判定依据）；false 表示无 CREATE 进行中
+     *
+     * 状态机：
+     * - CREATE startTask 时置 true
+     * - Create/Update 全量任务成功完成时置 false
+     * - 中断/失败时不操作（保持原值），下次重启仍判定为重型
+     * - 增量任务不操作
+     *
+     * 字段缺失时默认返回 false（旧版遗留文件或文件不存在）。
+     */
+    bool isCreateInProgress() const;
+
+    /**
+     * @brief 设置 createInProgress 标记并持久化
+     * @param inProgress CREATE 任务是否未完成
+     *
+     * 采用 read-modify-write 模式：先读取整个 JSON，更新字段，再写回。
+     * 不破坏文件中的其他字段（如 state、needsRebuild、version 等）。
+     */
+    void setCreateInProgress(bool inProgress) const;
+
+    /**
      * @brief 获取上次更新时间
      * @return 格式化时间字符串 "yyyy-MM-dd hh:mm:ss"，文件不存在时返回空字符串
      */

--- a/src/services/textindex/task/taskmanager.cpp
+++ b/src/services/textindex/task/taskmanager.cpp
@@ -162,6 +162,7 @@ bool TaskManager::startTask(IndexTask::Type type, const QStringList &pathList, b
         // 创建索引的任务开销巨大，避免任务未完成时进程退出后，重复进入创建任务
         if (m_context && m_context->stateStore()) {
             m_context->stateStore()->saveIndexStatus(QDateTime::currentDateTime());
+            m_context->stateStore()->setCreateInProgress(true);
         }
     }
 
@@ -532,8 +533,10 @@ void TaskManager::finalizeIndexState(IndexTask::Type type, const HandlerResult &
 
     if (isFullScanTask(type)) {
         m_recoveryPending = false;
-        if (m_context && m_context->stateStore())
+        if (m_context && m_context->stateStore()) {
             m_context->stateStore()->setIndexState(IndexUtility::IndexState::Clean);
+            m_context->stateStore()->setCreateInProgress(false);
+        }
         fmInfo() << "[TaskManager::onTaskFinished] Full-scan task completed, index state set to clean";
     } else if (!m_recoveryPending) {
         if (m_context && m_context->stateStore())


### PR DESCRIPTION
Added createInProgress state tracking mechanism to prevent duplicate
full index creation tasks after process restarts. This solves the issue
where interrupted index creation tasks could be restarted multiple
times, causing unnecessary resource consumption and potential data
corruption.

The changes introduce a new persistent flag in the index status JSON
that tracks whether a heavyweight CREATE task is currently in progress.
When a CREATE task starts, the flag is set to true, and only reset
to false when the full-scan task completes successfully. This ensures
that if the process crashes or is interrupted during index creation,
subsequent attempts will recognize an incomplete creation and avoid
starting another duplicate heavyweight task.

Technical details:
1. Added kCreateInProgressKey constant definition in
service_textindex_global.h
2. Implemented isCreateInProgress() and setCreateInProgress() methods in
IndexStateStore to read/write the persistent flag
3. Modified TaskManager::startTask() to set the flag to true when
starting a CREATE task
4. Modified TaskManager::finalizeIndexState() to reset the flag to false
when full-scan tasks complete successfully
5. The flag maintains its value during interruptions/failures and is
only cleared upon successful completion

Log: Fixed index creation task duplication issue after process restart

Influence:
1. Test creating a new index and verify the createInProgress flag is set
2. Interrupt index creation (kill process) and verify flag persists
3. Restart and verify that duplicate CREATE tasks are not started
4. Complete a full index creation and verify the flag is cleared
5. Test incremental updates do not affect the flag
6. Verify existing index status files without the flag default to false

feat: 跟踪索引创建进度以防止重复构建

添加了 createInProgress 状态跟踪机制，防止进程重启后重复执行完整的索引创
建任务。这解决了索引创建任务被中断后可能多次重启的问题，从而避免不必要的
资源消耗和潜在的数据损坏。

变更引入了一个新的持久化标志到索引状态 JSON 中，用于跟踪重量级 CREATE 任
务当前是否正在进行中。当 CREATE 任务开始时，标志被设为 true，只有在全量
扫描任务成功完成时才重置为 false。这确保了如果进程在索引创建期间崩溃或
被中断，后续尝试将识别到未完成的创建过程，从而避免启动另一个重复的重量级
任务。

技术细节:
1. 在 service_textindex_global.h 中添加了 kCreateInProgressKey 常量定义
2. 在 IndexStateStore 中实现了 isCreateInProgress() 和
setCreateInProgress() 方法，用于读写持久化标志
3. 修改了 TaskManager::startTask()，在启动 CREATE 任务时将标志设为 true
4. 修改了 TaskManager::finalizeIndexState()，在全量扫描任务成功完成时重
置标志为 false
5. 标志在中断/失败期间保持其值，仅在成功完成后清除

Log: 修复进程重启后索引创建任务重复执行的问题

Influence:
1. 测试创建新索引并验证 createInProgress 标志是否被设置
2. 中断索引创建（终止进程）并验证标志是否持久化
3. 重启后验证是否不会启动重复的 CREATE 任务
4. 完成完整的索引创建并验证标志是否被清除
5. 测试增量更新不影响该标志
6. 验证不带该标志的现有索引状态文件默认返回 false

## Summary by Sourcery

Track index creation progress via a persistent flag to avoid duplicate heavyweight CREATE tasks after interruptions or process restarts.

New Features:
- Introduce a createInProgress flag in the index status JSON to indicate ongoing index creation tasks.

Bug Fixes:
- Prevent repeated full index creation tasks from being started after process restarts when a previous creation did not complete.

Enhancements:
- Extend IndexStateStore with helpers to read and update index creation progress while preserving other status fields.
- Update task lifecycle handling so full-scan completion clears the index creation progress flag.