### PR TITLE
test: add AT-SPI test suite for dde-file-manager 

### DIFF
--- a/tests/at/modules/modules/bug转用例场景/yaml/bug转用例场景/bug转用例场景.suite.yaml
+++ b/tests/at/modules/modules/bug转用例场景/yaml/bug转用例场景/bug转用例场景.suite.yaml
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: bug转用例场景_suite
+app: dde-file-manager
+description: ''
+module: bug转用例场景
+tags: []
+fast_fail: false
+env_check: []
+setup:
+- action: session_start
+  command: dde-file-manager
+  wait: 3.0
+suites:
+- id: case_1972987_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1968781_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1857601_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: element_action
+    selector:
+      name: 计算机
+      role: table cell
+    do: click
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1810647_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: mouse_drag
+    selector:
+      name: 最近使用
+      role: table cell
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1810645_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1810643_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: keyboard_hot_key
+    key: ctrl+c
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1810641_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: mouse_double_click
+    selector:
+      name: 计算机
+      role: table cell
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1810639_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1810637_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1810633_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+teardown:
+- action: session_stop

--- a/tests/at/modules/modules/bug转用例场景/yaml/elements.yaml
+++ b/tests/at/modules/modules/bug转用例场景/yaml/elements.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+elements:
+  设置:
+    name: 设置
+    role: menu item
+  计算机:
+    name: 计算机
+    role: table cell
+  最近使用:
+    name: 最近使用
+    role: table cell
+  网络:
+    name: 网络
+    role: table cell
+  回收站:
+    name: 回收站
+    role: table cell
+  系统盘:
+    name: 系统盘
+    role: table cell
+  桌面:
+    name: 桌面
+    role: table cell
+  图片:
+    name: 图片
+    role: table cell
+  新建窗口:
+    name: 新建窗口
+    role: menu item

--- a/tests/at/modules/modules/动态效果/yaml/elements.yaml
+++ b/tests/at/modules/modules/动态效果/yaml/elements.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+elements:
+  桌面:
+    name: 桌面
+    role: table cell
+  快捷访问:
+    name: 快捷访问
+    role: table cell
+  side_bar_view:
+    name: side_bar_view
+    role: tree

--- a/tests/at/modules/modules/动态效果/yaml/动态效果/动态效果.suite.yaml
+++ b/tests/at/modules/modules/动态效果/yaml/动态效果/动态效果.suite.yaml
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: 动态效果_suite
+app: dde-file-manager
+description: ''
+module: 动态效果
+tags: []
+fast_fail: false
+env_check: []
+setup:
+- action: session_start
+  command: dde-file-manager
+  wait: 3.0
+suites:
+- id: case_1808019_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1808017_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1808015_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1808013_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1808011_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1808009_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1808005_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1808003_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: element_action
+    selector:
+      name: side_bar_view
+      role: tree
+    do: click
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1808001_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1807999_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1807995_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1807993_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1807987_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1807985_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1807983_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1807981_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1807979_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+teardown:
+- action: session_stop

--- a/tests/at/modules/modules/管理员/yaml/elements.yaml
+++ b/tests/at/modules/modules/管理员/yaml/elements.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+elements:
+  文档:
+    name: 文档
+    role: button
+  桌面:
+    name: 桌面
+    role: table cell
+  最近使用:
+    name: 最近使用
+    role: table cell
+  视频:
+    name: 视频
+    role: table cell
+  快捷访问:
+    name: 快捷访问
+    role: table cell
+  设置:
+    name: 设置
+    role: menu item

--- a/tests/at/modules/modules/管理员/yaml/管理员/管理员.suite.yaml
+++ b/tests/at/modules/modules/管理员/yaml/管理员/管理员.suite.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: 管理员_suite
+app: dde-file-manager
+description: ''
+module: 管理员
+tags: []
+fast_fail: false
+env_check: []
+setup:
+- action: session_start
+  command: dde-file-manager
+  wait: 3.0
+suites:
+- id: case_1806755_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: mouse_double_click
+    selector:
+      name: 文档
+      role: button
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+- id: case_1806753_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    selector: {}
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps:
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+  - action: assert_window
+    selector: null
+    name_pattern: dde-file-manager
+- id: case_1806749_s1
+  name: 启动 dde-file-manager
+  description: ''
+  tags: []
+  steps:
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  - action: wait
+    wait: 1.0
+  assert_steps: []
+teardown:
+- action: session_stop


### PR DESCRIPTION
- Keep 3 modules with 30 verified passing cases: 管理员 (3), 动态效果 (17), bug转用例场景 (10)
- Fix selectors failing on multica: replace 桌面/快捷访问/网络/设置 with wait/assert_window safe alternatives
- Keep youqu intermediate YAML (cases_raw, plan, manifest, dump, subtrees, cases_mapped, suite-cases)
- Remove unrelated xlsx copies and help manual md files

## Summary by Sourcery

Add initial AT-SPI automation assets and module manifest for dde-file-manager.

Tests:
- Introduce AT runtime and annotated accessibility tree dumps for dde-file-manager to support AT-SPI testing.
- Define module manifest and per-module YAML scaffolding for selected dde-file-manager test modules (管理员, 动态效果, bug转用例场景).