### PR TITLE
Revert "fix: keep desktop canvas origin for top and left dock"

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
@@ -40,10 +40,6 @@ public:
     inline QRect relativeRect(const QRect &avRect, const QRect &geometry)
     {
         QPoint relativePos = avRect.topLeft() - geometry.topLeft();
-        // The desktop root already starts at the screen origin; keep top/left
-        // dock offsets out of the child view origin.
-        relativePos.setX(qMin(relativePos.x(), 0));
-        relativePos.setY(qMin(relativePos.y(), 0));
         return QRect(relativePos, avRect.size());
     }
 


### PR DESCRIPTION
This reverts commit c82359e702cd2a006e7b705743da41e3d7474f22.

## Summary by Sourcery

Revert the previous change that constrained desktop canvas child view origins for top and left docks, restoring the original relative rectangle calculation behavior.