### PR TITLE
Revert "fix: keep desktop canvas origin for top and left dock"

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
@@ -40,10 +40,6 @@ public:
     inline QRect relativeRect(const QRect &avRect, const QRect &geometry)
     {
         QPoint relativePos = avRect.topLeft() - geometry.topLeft();
-        // The desktop root already starts at the screen origin; keep top/left
-        // dock offsets out of the child view origin.
-        relativePos.setX(qMin(relativePos.x(), 0));
-        relativePos.setY(qMin(relativePos.y(), 0));
         return QRect(relativePos, avRect.size());
     }
 


### PR DESCRIPTION
This reverts commit dc6af30dc84f537d52aa07cfa591ad97c9878321.

## Summary by Sourcery

Bug Fixes:
- Restore previous desktop canvas origin handling by removing constraints that forced top/left offsets to be non-positive.