### PR TITLE
chore: bump version to 6.5.162

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.162) unstable; urgency=medium
+
+  * Revert "fix: keep desktop canvas origin for top and left dock"
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 04 Aug 2026 09:17:05 +0800
+
 dde-file-manager (6.5.161) unstable; urgency=medium
 
   * fix: correct icon layout after maximizing window following touch long-press


### PR DESCRIPTION
6.5.162

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog entry for release 6.5.162.