### PR TITLE
fix(openwith): adjust dialog button gap

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -308,7 +308,7 @@ void OpenWithDialog::initUI()
     buttonLayout->addWidget(setToDefaultCheckBox);
     buttonLayout->addSpacing(20);
     buttonLayout->addWidget(cancelButton);
-    buttonLayout->addSpacing(5);
+    buttonLayout->addSpacing(10);
     buttonLayout->addWidget(chooseButton);
     buttonLayout->setContentsMargins(10, 0, 10, 0);
 


### PR DESCRIPTION
## Summary
- Adjust the gap between the Cancel and Confirm buttons in the open-with dialog from 5px to 10px.
- Keep the surrounding footer margins unchanged.

## Testing
- Not run (UI spacing change only).

## PMS
- https://pms.uniontech.com/bug-view-372569.html

## Summary by Sourcery

Enhancements:
- Adjust the gap between Cancel and Confirm buttons in the open-with dialog from 5px to 10px while keeping existing footer margins.