### PR TITLE
fix: show broken-link dialog for deleted SMB share target

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1365,8 +1365,12 @@ std::optional<QUrl> LocalFileHandlerPrivate::resolveSymlink(const QUrl &url)
         }
 
         // Check if link target exists
+        // For SMB targets, only skip the broken-link dialog when the share is
+        // unmounted (so the downstream mount/remount flow can take over).
+        // If the share is still mounted but the target is gone, the link is
+        // genuinely broken and the user should be notified.
         fileInfo.setFile(canonicalPath);
-        if (!fileInfo.exists() && !ProtocolUtils::isSMBFile(QUrl::fromLocalFile(canonicalPath))) {
+        if (!fileInfo.exists() && !DeviceUtils::isUnmountSamba(QUrl::fromLocalFile(canonicalPath))) {
             // Link is broken
             GlobalEventType dialogResult = DialogManagerInstance->showBreakSymlinkDialog(
                     QFileInfo(currentPath).fileName(),


### PR DESCRIPTION
## 根因分析

`LocalFileHandlerPrivate::resolveSymlink`（`src/dfm-base/file/local/localfilehandler.cpp:1369`）对所有 SMB 目标一律豁免链接失效判定（`!isSMBFile`），没有区分"共享未挂载（应触发挂载）"与"共享仍挂载但目标已真实消失（应判失效）"。当用户"自挂自、未卸载、共享被删"时，失效链接被当成普通文件送进 `doOpenFiles`，目标打开失败后上层 `handleOperationOpenFiles` 因 `lastEventType()==kUnknowType` 回退到"打开方式"对话框，而非期望的"此快捷方式已被更改或移动"提示。

## 修复方案

将第 1369 行的条件从 `!ProtocolUtils::isSMBFile(...)` 改为 `!DeviceUtils::isUnmountSamba(...)`。`isUnmountSamba = isSMBFile && !isFileOfProtocolMounts`，即"是 SMB 且不在挂载表中"才跳过失效判定。这样：
- 未挂载 SMB（Bug 298567 场景）：`isUnmountSamba` 真 → 跳过失效判定 → 交下游挂载流程（保持原行为）
- 仍挂载但目标消失（本 Bug）：`isUnmountSamba` 假 → 判失效 → 弹"快捷方式已被更改或移动"对话框（修复目标）
- 本地目标消失：`isUnmountSamba` 假 → 判失效 → 保持原行为
- 目标正常：`exists()` 真 → 不进失效分支 → 正常打开

`isUnmountSamba` 走挂载表内存匹配（`DeviceUtils::isUnmountSamba` → `DevProxyMng->isFileOfProtocolMounts`），不做实时 stat，判定快且稳定。

## 改动安全评估

低风险。改动为函数内部单条件收紧，不改变函数签名、不改变返回值契约。`resolveSymlink` 唯一业务调用者 `openFiles` 只消费返回值（`std::optional<QUrl>`），不依赖被改条件。`DeviceUtils` 头文件已在文件顶部引入。历史 blame 显示第 1369 行由 commit `892ee3104`（Bug 298567）引入，本次修复保留其对"未挂载 SMB"的豁免意图，仅收紧到未挂载子情况。

## Summary by Sourcery

Bug Fixes:
- Ensure deleted targets on still-mounted SMB shares are treated as broken links and trigger the appropriate broken-link dialog instead of falling back to the generic open-with dialog.