### PR TITLE
fix(openwith): adapt hover color for dark mode

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -157,7 +157,10 @@ void OpenWithDialogListItem::paintEvent(QPaintEvent *e)
 
     path.addRoundedRect(rect(), 6, 6);
     pa.setRenderHint(QPainter::Antialiasing);
-    pa.fillPath(path, QColor(0, 0, 0, static_cast<int>(0.05 * 255)));
+    bool isLightTheme = (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType);
+    int alpha = static_cast<int>(0.05 * 255);
+    QColor hoverColor = isLightTheme ? QColor(0, 0, 0, alpha) : QColor(255, 255, 255, alpha);
+    pa.fillPath(path, hoverColor);
 }
 
 class OpenWithDialogListSparerItem : public QWidget


### PR DESCRIPTION
## Summary
- detect theme type before painting hover feedback for open-with list items
- keep the current light theme hover opacity unchanged
- use a semi-transparent white hover fill in dark mode to improve contrast

## 摘要
- 在绘制打开方式列表项悬浮反馈前判断主题类型
- 保持浅色模式现有悬浮透明度不变
- 深色模式改为半透明白色填充，提升悬浮对比度

## Verification
- build the utils plugin locally
- replace `libdfm-utils-plugin.so` in the installed plugin path
- verify the hover effect in the open-with dialog under dark mode

## 验证
- 本地编译 utils 插件
- 替换已安装目录中的 `libdfm-utils-plugin.so`
- 在深色模式下验证打开方式界面的悬浮效果

PMS: https://pms.uniontech.com/bug-view-372577.html

## Summary by Sourcery

Bug Fixes:
- Improve hover contrast for open-with list items in dark mode while preserving existing behavior in light mode.