### PR TITLE
fix(textindex): add auto-reconnect and enlarge SO_RCVBUF for vfsmonitor

### DIFF
--- a/autotests/services/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/services/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -10,6 +10,14 @@
 #include <QTest>
 #include <QSet>
 #include <QElapsedTimer>
+#include <QSocketNotifier>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
 
 #include "services/textindex/service_textindex_global.h"
 #include "services/textindex/fsmonitor/vfsmonitorwatcher.h"
@@ -497,4 +505,171 @@ TEST_F(TestVfsMonitorFileSystemWatcher, EventsOutsideRootPathsNotEmitted)
 
     // 清理
     QFile::remove(outsidePath);
+}
+
+// ======================================================================
+// 重连机制单元测试
+// 通过 DFM_VFSMONITOR_SOCKET_PATH 环境变量将 watcher 指向测试自建的 mock
+// dispatcher socket，模拟服务端断开，验证 watcher 能自动重连。
+// ======================================================================
+
+// 创建并监听一个 AF_UNIX SOCK_SEQPACKET socket，返回 listen fd。
+static int createMockDispatcher(const QString &path)
+{
+    int fd = ::socket(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
+    if (fd < 0)
+        return -1;
+
+    ::unlink(path.toUtf8().constData());   // remove stale socket file
+
+    sockaddr_un addr {};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, path.toUtf8().constData(), sizeof(addr.sun_path) - 1);
+
+    if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+        ::close(fd);
+        return -1;
+    }
+    if (::listen(fd, 5) < 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+// 接受一个客户端连接（非阻塞 listen fd），返回 client fd 或 -1（无待连接）。
+static int acceptOneClient(int listenFd)
+{
+    int fd = ::accept4(listenFd, nullptr, nullptr, SOCK_NONBLOCK);
+    return fd;
+}
+
+class TestVfsMonitorReconnect : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // 在临时目录下创建 mock dispatcher socket
+        QString templatePath = QDir::homePath() + "/Documents/.test_vfsreconnect_XXXXXX";
+        testDir = std::make_unique<QTemporaryDir>(templatePath);
+        ASSERT_TRUE(testDir->isValid());
+        mockSocketPath = testDir->path() + "/mock-dispatcher.sock";
+
+        // 启动 mock dispatcher
+        listenFd = createMockDispatcher(mockSocketPath);
+        ASSERT_GE(listenFd, 0) << "Failed to create mock dispatcher";
+
+        // 设置环境变量，使 watcher 连接到 mock dispatcher
+        qputenv("DFM_VFSMONITOR_SOCKET_PATH", mockSocketPath.toUtf8());
+
+        // 创建 watcher
+        watcher = VfsMonitorFileSystemWatcher::create({ testDir->path() }, {}, nullptr);
+        ASSERT_NE(watcher, nullptr) << "Watcher creation failed";
+
+        // 接受初始连接
+        clientFd = waitForAccept(listenFd, 3000);
+        ASSERT_GE(clientFd, 0) << "Mock dispatcher did not accept initial connection";
+    }
+
+    void TearDown() override
+    {
+        if (clientFd >= 0)
+            ::close(clientFd);
+        if (listenFd >= 0) {
+            ::close(listenFd);
+        }
+        ::unlink(mockSocketPath.toUtf8().constData());
+        qunsetenv("DFM_VFSMONITOR_SOCKET_PATH");
+        delete watcher;
+        watcher = nullptr;
+        testDir.reset();
+    }
+
+    // 轮询等待 accept 返回 fd，超时返回 -1
+    int waitForAccept(int fd, int timeoutMs)
+    {
+        QElapsedTimer timer;
+        timer.start();
+        while (!timer.hasExpired(timeoutMs)) {
+            int cfd = acceptOneClient(fd);
+            if (cfd >= 0)
+                return cfd;
+            QTest::qWait(50);
+        }
+        return -1;
+    }
+
+    std::unique_ptr<QTemporaryDir> testDir;
+    QString mockSocketPath;
+    int listenFd { -1 };
+    int clientFd { -1 };
+    VfsMonitorFileSystemWatcher *watcher { nullptr };
+};
+
+// 断开后 watcher 应在退避时间后自动重连
+TEST_F(TestVfsMonitorReconnect, ReconnectsAfterServerClosesConnection)
+{
+    ASSERT_NE(watcher, nullptr);
+    ASSERT_GE(clientFd, 0);
+
+    // 模拟服务端踢掉客户端：关闭 server 端的 client fd。
+    // 客户端下次 recv() 将返回 0，触发 handleDisconnect()。
+    ::close(clientFd);
+    clientFd = -1;
+
+    // 给 watcher 的事件循环一点时间，让 QSocketNotifier 触发 handleSocketMessage()。
+    // handleSocketMessage 在收到 recv()==0 后调用 handleDisconnect，后者以 1s
+    // 退避启动 reconnectTimer。我们等待 ~2.5s 容纳事件循环 + 1s 退避。
+    int newClientFd = waitForAccept(listenFd, 5000);
+    ASSERT_GE(newClientFd, 0)
+        << "Watcher did not reconnect within 5s after server-side close";
+
+    ::close(newClientFd);
+}
+
+// 重连后 backoff 应复位：断开后先关闭 mock listen socket 使重连失败数次
+// （backoff 增至 2s/4s），恢复 listen 后重连成功，再次断开验证快速重连。
+TEST_F(TestVfsMonitorReconnect, BackoffResetsAfterSuccessfulReconnect)
+{
+    ASSERT_NE(watcher, nullptr);
+    ASSERT_GE(clientFd, 0);
+
+    // --- Phase 1: force backoff growth ---
+    // Close the server-side client fd to trigger a disconnect.
+    ::close(clientFd);
+    clientFd = -1;
+
+    // Close the listen socket so the watcher's first reconnect attempt fails.
+    // We need a fresh path because bind() to the same path would fail if the
+    // old socket file lingers; instead we close+reopen on the same path.
+    ::close(listenFd);
+    listenFd = -1;
+
+    // Wait long enough for the watcher to attempt at least one failed
+    // reconnect (1s initial backoff fires, attemptReconnect fails, backoff
+    // grows to 2s). Give it ~3s to be safe.
+    QTest::qWait(3000);
+
+    // Reopen the mock dispatcher on the same path so reconnect can succeed.
+    listenFd = createMockDispatcher(mockSocketPath);
+    ASSERT_GE(listenFd, 0) << "Failed to reopen mock dispatcher";
+
+    // Wait for the watcher to reconnect (backoff may be 2s or 4s at this
+    // point; give generous timeout).
+    int reconnectFd = waitForAccept(listenFd, 10000);
+    ASSERT_GE(reconnectFd, 0) << "Watcher did not reconnect after restoring listen socket";
+
+    // --- Phase 2: verify backoff was reset ---
+    // Disconnect again. If backoff was reset, the next reconnect fires in ~1s;
+    // if it was NOT reset, it could be 4s+. We use a 2500ms window: a 1s
+    // reconnect completes well within it, while a 4s+ reconnect does not.
+    ::close(reconnectFd);
+
+    QElapsedTimer timer;
+    timer.start();
+    int finalReconnectFd = waitForAccept(listenFd, 2500);
+    ASSERT_GE(finalReconnectFd, 0)
+        << "Reconnect took too long; backoff was not reset after success";
+
+    ::close(finalReconnectFd);
 }

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -148,6 +148,10 @@ VfsMonitorFileSystemWatcherPrivate::VfsMonitorFileSystemWatcherPrivate(
 
 VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
 {
+    if (reconnectTimer) {
+        reconnectTimer->stop();
+    }
+
     if (notifier) {
         notifier->setEnabled(false);
     }
@@ -248,13 +252,9 @@ QPair<QString, QString> VfsMonitorFileSystemWatcherPrivate::splitPath(const QStr
     return qMakePair(fi.absolutePath(), fi.fileName());
 }
 
-bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
+bool VfsMonitorFileSystemWatcherPrivate::establishConnection()
 {
     Q_Q(VfsMonitorFileSystemWatcher);
-
-    if (!initMountPoints()) {
-        fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
-    }
 
     // The notifier runs on the GUI thread, so keep dispatcher reads nonblocking.
     socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
@@ -265,7 +265,8 @@ bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
 
     sockaddr_un address {};
     address.sun_family = AF_UNIX;
-    std::strncpy(address.sun_path, kDispatcherSocketPath, sizeof(address.sun_path) - 1);
+    const QByteArray path = socketPath.toUtf8();
+    std::strncpy(address.sun_path, path.constData(), sizeof(address.sun_path) - 1);
 
     if (::connect(socketFd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0) {
         fmWarning() << "VfsMonitor: deepin-anything event dispatcher not available:" << std::strerror(errno);
@@ -274,10 +275,57 @@ bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
         return false;
     }
 
+    // Enlarge the receive buffer so bursts of 4 KB dispatch events don't fill
+    // the kernel buffer and cause the server to see EAGAIN on send() — which
+    // currently results in the server kicking this client ("slow client").
+    // Mirrors deepin-anything commit 5807fc0 (SO_RCVBUF = 1 MiB).
+    constexpr int kReceiveBufSize = 1 << 20;   // 1 MiB
+    if (::setsockopt(socketFd, SOL_SOCKET, SO_RCVBUF, &kReceiveBufSize,
+                     sizeof(kReceiveBufSize)) < 0) {
+        fmDebug() << "VfsMonitor: setsockopt(SO_RCVBUF) failed:" << std::strerror(errno);
+    }
+
     notifier = new QSocketNotifier(socketFd, QSocketNotifier::Read, q);
     QObject::connect(notifier, &QSocketNotifier::activated, q, [this]() {
         handleSocketMessage();
     });
+
+    return true;
+}
+
+bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
+{
+    Q_Q(VfsMonitorFileSystemWatcher);
+
+    if (!initMountPoints()) {
+        fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
+    }
+
+    // Resolve the dispatcher socket path. Production uses the well-known
+    // path; the DFM_VFSMONITOR_SOCKET_PATH env var lets unit tests point the
+    // watcher at a mock dispatcher they control.
+    socketPath = QString::fromUtf8(qgetenv("DFM_VFSMONITOR_SOCKET_PATH"));
+    if (socketPath.isEmpty())
+        socketPath = QString::fromUtf8(kDispatcherSocketPath);
+
+    // Reconnect timer lives on the same thread as the notifier (the thread
+    // that called create()). It is single-shot and rearmed by attemptReconnect().
+    reconnectTimer = new QTimer(q);
+    reconnectTimer->setSingleShot(true);
+    QObject::connect(reconnectTimer, &QTimer::timeout, q, [this]() {
+        attemptReconnect();
+    });
+    reconnectBackoffMs = 0;
+
+    if (!establishConnection()) {
+        // Initial connection failed: the dispatcher is not running yet.
+        // Return false so create() reports the watcher as unavailable and
+        // FSMonitorPrivate degrades to inotify-only mode. The auto-reconnect
+        // timer created above only self-heals connections that were
+        // established at runtime and then dropped; it cannot help here
+        // because create() deletes this watcher on a failed first connect.
+        return false;
+    }
 
     fmInfo() << "VfsMonitor: connected to deepin-anything event dispatcher";
     return true;
@@ -302,11 +350,7 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
 
         if (received == 0) {
             fmWarning() << "VfsMonitor: event dispatcher connection closed";
-            if (notifier) {
-                notifier->setEnabled(false);
-            }
-            ::close(socketFd);
-            socketFd = -1;
+            handleDisconnect();
             return;
         }
 
@@ -316,6 +360,9 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
             }
 
             fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
+            // A persistent recv error would spin the notifier. Treat it like a
+            // disconnect so the socket is rebuilt instead of looping forever.
+            handleDisconnect();
             return;
         }
 
@@ -429,6 +476,45 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
             pendingRenames.clear();
         }
     }
+}
+
+void VfsMonitorFileSystemWatcherPrivate::handleDisconnect()
+{
+    if (notifier) {
+        notifier->setEnabled(false);
+        notifier->deleteLater();
+        notifier = nullptr;
+    }
+
+    if (socketFd >= 0) {
+        ::close(socketFd);
+        socketFd = -1;
+    }
+
+    // Backoff: start at 1 s, double up to 30 s. Reset to 0 on a successful
+    // reconnect (attemptReconnect) so the next outage starts fresh.
+    if (reconnectBackoffMs <= 0)
+        reconnectBackoffMs = 1000;
+
+    if (!reconnectTimer)
+        return;   // shutting down
+
+    fmInfo() << "VfsMonitor: scheduling dispatcher reconnect in" << reconnectBackoffMs << "ms";
+    reconnectTimer->start(reconnectBackoffMs);
+}
+
+void VfsMonitorFileSystemWatcherPrivate::attemptReconnect()
+{
+    if (establishConnection()) {
+        reconnectBackoffMs = 0;   // success: next outage restarts at 1 s
+        fmInfo() << "VfsMonitor: reconnected to deepin-anything event dispatcher";
+        return;
+    }
+
+    // Grow the backoff (cap at 30 s) and retry.
+    reconnectBackoffMs = std::min(reconnectBackoffMs * 2, 30000);
+    if (reconnectTimer)
+        reconnectTimer->start(reconnectBackoffMs);
 }
 
 // ========== VfsMonitorFileSystemWatcher ==========

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -8,6 +8,7 @@
 #include "vfsmonitorwatcher.h"
 
 #include <QSocketNotifier>
+#include <QTimer>
 #include <QHash>
 #include <QStringList>
 #include <QVector>
@@ -63,6 +64,16 @@ public:
     bool initDispatcher();
     void handleSocketMessage();
 
+    // Tear down the current connection (socket + notifier) and arm the
+    // reconnect timer. Safe to call whether or not a connection exists.
+    void handleDisconnect();
+    // Timer callback: attempt a fresh socket()+connect(); on success rebuild
+    // the notifier and stop the timer; on failure grow the backoff.
+    void attemptReconnect();
+    // Create the socket, connect, enlarge the receive buffer and build the
+    // notifier. Returns true on success. Does not touch the reconnect timer.
+    bool establishConnection();
+
     // The event dispatcher sends absolute paths, but they may use a different
     // mount alias than the monitored root path. This helper normalizes across
     // same-device mount aliases before applying rootPaths and excludePredicate.
@@ -77,6 +88,15 @@ public:
 
     int socketFd { -1 };
     QSocketNotifier *notifier { nullptr };
+
+    // Reconnection state. After a disconnect the watcher keeps trying to
+    // reconnect with exponential backoff so monitoring always recovers.
+    QTimer *reconnectTimer { nullptr };
+    int reconnectBackoffMs { 0 };
+
+    // Overridable socket path (env: DFM_VFSMONITOR_SOCKET_PATH). Defaults to
+    // kDispatcherSocketPath; used by unit tests to point at a mock dispatcher.
+    QString socketPath;
 
     QHash<uint32_t, RenameFromInfo> pendingRenames;
     QHash<dev_t, QStringList> mountPoints;


### PR DESCRIPTION
## 问题

textindex 服务的 vfsmonitor 偶尔打出日志 `VfsMonitor: event dispatcher connection closed`，之后整个文件监控机制永久失效，索引无法根据文件变动增量更新。

## 根因

`VfsMonitorFileSystemWatcher` 通过 `SOCK_SEQPACKET` 连接 deepin-anything 的事件分发 socket。服务端 `event_dispatcher_send()` 在 `send()` 返回 `EAGAIN`（客户端内核接收缓冲满）时直接踢掉客户端（`"slow client ... kicking"` → `close(fd)`）。客户端 `recv()` 随后返回 0，打出上述日志后**只关闭 socket、不重连**，监控永久失效。

缓冲不足只是诱因；**缺少断连自动重连**才是"不可恢复"的根因（参考提交 `wangrong1069/deepin-anything@5807fc0` 给 deepin-anything 自家的 `event_listener` 配了 `start_restart_check` 重连，本仓库此前没有对应物）。

## 修复

1. **扩大接收缓冲**：`establishConnection()` 在 `connect()` 成功后 `setsockopt(SO_RCVBUF, 1 MiB)`，降低突发时被服务端踢掉的概率（借鉴参考提交对 `event_receiver` 的 `SO_RCVBUF` 扩容）。
2. **断连自动重连（核心）**：`received == 0` 及非 EAGAIN 的 recv 错误统一走 `handleDisconnect()` → 以指数退避（1s 起、翻倍、上限 30s）的 `QTimer` 周期性 `attemptReconnect()`，重连成功后重建 `QSocketNotifier`、复位退避。重连期间不清空 `rootPaths/mountPoints`，连上即恢复事件流。
3. **修正刷屏缺陷**：原非 EAGAIN recv 错误只打日志不关 socket，导致 `QSocketNotifier` 反复触发刷屏；现并入重连路径。
4. **测试可注入**：新增 `DFM_VFSMONITOR_SOCKET_PATH` 环境变量，允许单元测试将 watcher 指向自建 mock dispatcher（生产默认仍是 `/run/deepin-anything/event-dispatcher.sock`）。

## 单元测试

新增 `TestVfsMonitorReconnect` 测试夹具，通过 `DFM_VFSMONITOR_SOCKET_PATH` 指向自建 mock SOCK_SEQPACKET dispatcher：

- `ReconnectsAfterServerClosesConnection`：服务端关闭 client fd 模拟踢人，验证 watcher 在退避后自动重连（mock 端再次 accept 到新连接）。
- `BackoffResetsAfterSuccessfulReconnect`：连续两次断开，验证重连成功后退避复位（第二次仍能快速重连）。

## 改动文件

- `src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h`
- `src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp`
- `autotests/services/textindex/test_vfsmonitorfilesystemwatcher.cpp`

## Summary by Sourcery

Add automatic reconnection with exponential backoff for the vfsmonitor watcher’s dispatcher socket and increase its receive buffer to avoid being dropped by the server.

Bug Fixes:
- Ensure vfsmonitor monitoring recovers automatically after the dispatcher connection is closed or encounters persistent receive errors, preventing permanent loss of file change events.

Enhancements:
- Increase the dispatcher socket receive buffer size to reduce the likelihood of the server disconnecting the watcher under burst load.
- Introduce an environment-configurable dispatcher socket path to support redirecting the watcher to alternative or test-specific endpoints.

Tests:
- Add unit tests with a mock SOCK_SEQPACKET dispatcher to verify automatic reconnection behavior and backoff reset after successful reconnects.