### PR TITLE
feat: add environment detection for strategic indexing

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.textindex.json
+++ b/assets/configs/org.deepin.dde.file-manager.textindex.json
@@ -131,16 +131,16 @@
 			"visibility": "public"
 		},
 		"ocrImageScaleWidth": {
-				"value": 960,
-				"serial": 0,
-				"flags": [],
-				"name": "OCR image scale width",
-				"name[zh_CN]": "OCR 图片缩放宽度",
-				"description[zh_CN]": "OCR 处理前图片等比缩放的最大宽度（像素）。超过此宽度的图片将按比例缩小。设置为 0 表示不限制宽度。",
-				"description": "Maximum width in pixels for OCR image scaling. Images wider than this will be scaled down proportionally. Set to 0 to disable width scaling.",
-				"permissions": "readwrite",
-				"visibility": "public"
-			},
+			"value": 960,
+			"serial": 0,
+			"flags": [],
+			"name": "OCR image scale width",
+			"name[zh_CN]": "OCR 图片缩放宽度",
+			"description[zh_CN]": "OCR 处理前图片等比缩放的最大宽度（像素）。超过此宽度的图片将按比例缩小。设置为 0 表示不限制宽度。",
+			"description": "Maximum width in pixels for OCR image scaling. Images wider than this will be scaled down proportionally. Set to 0 to disable width scaling.",
+			"permissions": "readwrite",
+			"visibility": "public"
+		},
 		"ocrImageScaleHeight": {
 			"value": 540,
 			"serial": 0,
@@ -243,6 +243,50 @@
 			"description": "Number of files to process before committing during indexing, ranging from 100 to 10000. Smaller values commit more frequently, allowing users to see search results sooner, but may impact indexing performance.",
 			"permissions": "readwrite",
 			"visibility": "public"
+		},
+		"idleThresholdSeconds": {
+			"value": 30,
+			"serial": 0,
+			"flags": [],
+			"name": "Idle Threshold (seconds)",
+			"name[zh_CN]": "空闲阈值（秒）",
+			"description[zh_CN]": "系统连续无键盘/鼠标/触控输入的持续时间达到此阈值后判定为空闲，范围为 5 到 600 秒。",
+			"description": "Duration of continuous inactivity (no keyboard/mouse/touch input) before the system is considered idle, ranging from 5 to 600 seconds.",
+			"permissions": "readwrite",
+			"visibility": "private"
+		},
+		"loadSampleIntervalSeconds": {
+			"value": 5,
+			"serial": 0,
+			"flags": [],
+			"name": "Load Sample Interval (seconds)",
+			"name[zh_CN]": "负载采样间隔（秒）",
+			"description[zh_CN]": "CPU 和磁盘忙碌度的采样间隔，范围为 1 到 60 秒。滚动窗口保持最近 60 秒的采样数据。",
+			"description": "Sampling interval for CPU and disk busyness, ranging from 1 to 60 seconds. The rolling window keeps the last 60 seconds of samples.",
+			"permissions": "readwrite",
+			"visibility": "private"
+		},
+		"cpuLoadThresholdPercent": {
+			"value": 30,
+			"serial": 0,
+			"flags": [],
+			"name": "CPU Load Threshold (percent)",
+			"name[zh_CN]": "CPU 负载阈值（百分比）",
+			"description[zh_CN]": "最近 60 秒 CPU 平均占用率上限，超过此值时不判定为空闲，范围为 1 到 100。",
+			"description": "Maximum 60-second average CPU usage percentage for the system to be considered idle, ranging from 1 to 100.",
+			"permissions": "readwrite",
+			"visibility": "private"
+		},
+		"diskBusyThresholdPercent": {
+			"value": 50,
+			"serial": 0,
+			"flags": [],
+			"name": "Disk Busy Threshold (percent)",
+			"name[zh_CN]": "磁盘忙碌度阈值（百分比）",
+			"description[zh_CN]": "数据盘最近 60 秒平均忙碌度上限，超过此值时不判定为空闲，范围为 1 到 100。",
+			"description": "Maximum 60-second average busyness percentage of the data disk for the system to be considered idle, ranging from 1 to 100.",
+			"permissions": "readwrite",
+			"visibility": "private"
 		}
 	}
 }

--- a/autotests/services/textindex/test_loadmonitor.cpp
+++ b/autotests/services/textindex/test_loadmonitor.cpp
@@ -1,0 +1,582 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QTextStream>
+#include <QDir>
+#include <QTest>
+
+#include "stubext.h"
+
+#include "services/textindex/env/loadmonitor.h"
+#include "services/textindex/env/powermonitor.h"
+#include "services/textindex/env/idlemonitor.h"
+#include "services/textindex/env/envdetector.h"
+
+using namespace service_textindex;
+
+// ============================================================================
+// LoadMonitor Tests
+// ============================================================================
+
+class TestLoadMonitor : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        if (!qApp)
+            app = std::make_unique<QCoreApplication>(argc, argv);
+        monitor = std::make_unique<LoadMonitor>();
+    }
+
+    void TearDown() override
+    {
+        monitor.reset();
+    }
+
+    std::unique_ptr<QCoreApplication> app;
+    std::unique_ptr<LoadMonitor> monitor;
+
+    static int argc;
+    static char *argv[];
+};
+
+int TestLoadMonitor::argc = 1;
+char *TestLoadMonitor::argv[] = { const_cast<char *>("test_loadmonitor") };
+
+// --- Construction ---
+
+TEST_F(TestLoadMonitor, Construction_DefaultValues)
+{
+    EXPECT_NE(monitor->m_timer, nullptr);
+    EXPECT_GT(monitor->m_sampleIntervalSecs, 0);
+    EXPECT_GT(monitor->m_cpuThresholdPercent, 0);
+    EXPECT_GT(monitor->m_diskThresholdPercent, 0);
+    EXPECT_DOUBLE_EQ(monitor->cpuAvgPercent(), 0.0);
+    EXPECT_DOUBLE_EQ(monitor->diskBusyPercent(), 0.0);
+    EXPECT_DOUBLE_EQ(monitor->cpuInstantPercent(), 0.0);
+    EXPECT_DOUBLE_EQ(monitor->diskInstantPercent(), 0.0);
+}
+
+// --- readProcStat with real /proc/stat ---
+
+TEST_F(TestLoadMonitor, ReadProcStat_RealFile_ReturnsTrue)
+{
+    qint64 user = -1, guest = -1, total = -1;
+    EXPECT_TRUE(monitor->readProcStat(user, guest, total));
+    EXPECT_GE(user, 0);
+    EXPECT_GE(guest, 0);
+    EXPECT_GE(total, 0);
+    // total should be sum of user + nice + system + idle + iowait + irq + softirq + steal
+    // so it should be at least as large as user alone
+    EXPECT_GE(total, user);
+}
+
+// --- readProcDiskstats with real /proc/diskstats ---
+
+TEST_F(TestLoadMonitor, ReadProcDiskstats_EmptyDeviceName_ReturnsFalse)
+{
+    monitor->m_diskDeviceName.clear();
+    qint64 ioTicks = -1;
+    EXPECT_FALSE(monitor->readProcDiskstats(ioTicks));
+}
+
+TEST_F(TestLoadMonitor, ReadProcDiskstats_RealDiskstats_MatchesPrefix)
+{
+    // Read /proc/diskstats ourselves to find a whole-disk entry
+    QFile file(QStringLiteral("/proc/diskstats"));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text));
+    QString content = QString::fromUtf8(file.readAll());
+    file.close();
+
+    // Find first line with >= 13 fields — that's a whole-disk row
+    qint64 expectedTicks = 0;
+    QString diskName;
+    for (const QString &line : content.split(QLatin1Char('\n'))) {
+        const auto parts = line.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+        if (parts.size() >= 13) {
+            diskName = parts[2];
+            expectedTicks = parts[12].toLongLong();
+            break;
+        }
+    }
+    ASSERT_FALSE(diskName.isEmpty());
+
+    // Set the device name to a fake partition name that starts with the disk name
+    monitor->m_diskDeviceName = diskName + "1";
+    qint64 ioTicks = -1;
+    EXPECT_TRUE(monitor->readProcDiskstats(ioTicks));
+    EXPECT_EQ(ioTicks, expectedTicks);
+}
+
+// --- CPU %usr calculation (mocked readProcStat) ---
+
+TEST_F(TestLoadMonitor, Sample_CpuUsrCalculation_Mocked)
+{
+    stub_ext::StubExt stub;
+
+    // Simulate two samples: first with user=1000 guest=0 total=10000,
+    // second with user=1100 guest=0 total=11000
+    // %usr = (1100-1000 - (0-0)) / (11000-10000) * 100 = 10%
+    int callCount = 0;
+    stub.set_lamda(ADDR(LoadMonitor, readProcStat), [&callCount](LoadMonitor *, qint64 &user, qint64 &guest, qint64 &total) {
+        if (callCount == 0) {
+            user = 1000;
+            guest = 0;
+            total = 10000;
+        } else {
+            user = 1100;
+            guest = 0;
+            total = 11000;
+        }
+        callCount++;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(LoadMonitor, readProcDiskstats), [](LoadMonitor *, qint64 &ioTicks) {
+        ioTicks = 0;
+        return true;
+    });
+
+    QSignalSpy spy(monitor.get(), &LoadMonitor::loadChanged);
+
+    monitor->sample();
+    // First sample only — no percentage computed yet
+    EXPECT_EQ(spy.count(), 0);
+
+    monitor->sample();
+    // Second sample — percentage computed
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_NEAR(args[0].toDouble(), 10.0, 0.01);
+}
+
+// --- CPU %usr with guest correction ---
+
+TEST_F(TestLoadMonitor, Sample_CpuUsrWithGuest_Mocked)
+{
+    stub_ext::StubExt stub;
+
+    // user includes guest, so %usr = (user - guest) / total
+    // Sample 1: user=1500, guest=500, total=10000
+    // Sample 2: user=2500, guest=500, total=11000
+    // delta_user=1000, delta_guest=0, delta_total=1000
+    // %usr = (1000 - 0) / 1000 * 100 = 100%
+    int callCount = 0;
+    stub.set_lamda(ADDR(LoadMonitor, readProcStat), [&callCount](LoadMonitor *, qint64 &user, qint64 &guest, qint64 &total) {
+        if (callCount == 0) {
+            user = 1500;
+            guest = 500;
+            total = 10000;
+        } else {
+            user = 2500;
+            guest = 500;
+            total = 11000;
+        }
+        callCount++;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(LoadMonitor, readProcDiskstats), [](LoadMonitor *, qint64 &ioTicks) {
+        ioTicks = 0;
+        return true;
+    });
+
+    monitor->sample();
+    monitor->sample();
+
+    // %usr = 100% since all delta went to user (minus guest)
+    EXPECT_NEAR(monitor->cpuAvgPercent(), 100.0, 0.01);
+    EXPECT_NEAR(monitor->cpuInstantPercent(), 100.0, 0.01);
+}
+
+// --- Disk %util calculation (mocked readProcDiskstats) ---
+
+TEST_F(TestLoadMonitor, Sample_DiskUtilCalculation_Mocked)
+{
+    stub_ext::StubExt stub;
+
+    // Sample 1: ioTicks=0, Sample 2: ioTicks=500
+    // elapsedMs = 5 * 1000 = 5000
+    // %util = (500 - 0) / 5000 * 100 = 10%
+    int callCount = 0;
+    stub.set_lamda(ADDR(LoadMonitor, readProcDiskstats), [&callCount](LoadMonitor *, qint64 &ioTicks) {
+        ioTicks = (callCount == 0) ? 0 : 500;
+        callCount++;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(LoadMonitor, readProcStat), [](LoadMonitor *, qint64 &user, qint64 &guest, qint64 &total) {
+        user = 1000;
+        guest = 0;
+        total = 10000;
+        return true;
+    });
+
+    monitor->sample();
+    monitor->sample();
+
+    EXPECT_NEAR(monitor->diskBusyPercent(), 10.0, 0.01);
+    EXPECT_NEAR(monitor->diskInstantPercent(), 10.0, 0.01);
+}
+
+// --- Disk %util capped at 100% ---
+
+TEST_F(TestLoadMonitor, Sample_DiskUtilCappedAt100_Mocked)
+{
+    stub_ext::StubExt stub;
+
+    // ioTicks delta exceeds elapsed time → should cap at 100%
+    int callCount = 0;
+    stub.set_lamda(ADDR(LoadMonitor, readProcDiskstats), [&callCount](LoadMonitor *, qint64 &ioTicks) {
+        ioTicks = (callCount == 0) ? 0 : 999999;
+        callCount++;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(LoadMonitor, readProcStat), [](LoadMonitor *, qint64 &user, qint64 &guest, qint64 &total) {
+        user = 1000;
+        guest = 0;
+        total = 10000;
+        return true;
+    });
+
+    monitor->sample();
+    monitor->sample();
+
+    EXPECT_NEAR(monitor->diskBusyPercent(), 100.0, 0.01);
+}
+
+// --- Threshold checks ---
+
+TEST_F(TestLoadMonitor, IsCpuBelowThreshold_DefaultZero_ReturnsTrue)
+{
+    EXPECT_TRUE(monitor->isCpuBelowThreshold());
+}
+
+TEST_F(TestLoadMonitor, IsDiskBelowThreshold_DefaultZero_ReturnsTrue)
+{
+    EXPECT_TRUE(monitor->isDiskBelowThreshold());
+}
+
+// --- setDataPath ---
+
+TEST_F(TestLoadMonitor, SetDataPath_UpdatesDataPath)
+{
+    monitor->setDataPath(QStringLiteral("/tmp"));
+    EXPECT_EQ(monitor->m_dataPath, QStringLiteral("/tmp"));
+}
+
+// --- resolveDataDisk ---
+
+TEST_F(TestLoadMonitor, ResolveDataDisk_EmptyPath_NoDeviceName)
+{
+    monitor->m_dataPath.clear();
+    monitor->resolveDataDisk();
+    EXPECT_TRUE(monitor->m_diskDeviceName.isEmpty());
+}
+
+TEST_F(TestLoadMonitor, ResolveDataDisk_HomePath_ResolvesDevice)
+{
+    monitor->m_dataPath = QDir::homePath();
+    monitor->resolveDataDisk();
+    // On Linux, home should resolve to a block device
+    EXPECT_FALSE(monitor->m_diskDeviceName.isEmpty());
+}
+
+// --- Window management ---
+
+TEST_F(TestLoadMonitor, Window_Size_CappedAtMaxSamples)
+{
+    stub_ext::StubExt stub;
+
+    stub.set_lamda(ADDR(LoadMonitor, readProcStat), [](LoadMonitor *, qint64 &user, qint64 &guest, qint64 &total) {
+        user = 1000;
+        guest = 0;
+        total = 10000;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(LoadMonitor, readProcDiskstats), [](LoadMonitor *, qint64 &ioTicks) {
+        ioTicks = 0;
+        return true;
+    });
+
+    const int maxSamples = qMax(1, 60 / monitor->m_sampleIntervalSecs);
+    for (int i = 0; i < maxSamples + 5; ++i)
+        monitor->sample();
+
+    EXPECT_LE(monitor->m_window.size(), maxSamples);
+}
+
+// --- loadChanged signal ---
+
+TEST_F(TestLoadMonitor, LoadChangedSignal_EmittedOnSecondSample_Mocked)
+{
+    stub_ext::StubExt stub;
+
+    int callCount = 0;
+    stub.set_lamda(ADDR(LoadMonitor, readProcStat), [&callCount](LoadMonitor *, qint64 &user, qint64 &guest, qint64 &total) {
+        user = 1000 * (callCount + 1);
+        guest = 0;
+        total = 10000 * (callCount + 1);
+        callCount++;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(LoadMonitor, readProcDiskstats), [](LoadMonitor *, qint64 &ioTicks) {
+        ioTicks = 0;
+        return true;
+    });
+
+    QSignalSpy spy(monitor.get(), &LoadMonitor::loadChanged);
+    monitor->sample();
+    EXPECT_EQ(spy.count(), 0);
+    monitor->sample();
+    ASSERT_EQ(spy.count(), 1);
+}
+
+// --- start/stop lifecycle ---
+
+TEST_F(TestLoadMonitor, StartStop_TimerRunningState)
+{
+    monitor->setDataPath(QDir::homePath());
+    monitor->start();
+    EXPECT_TRUE(monitor->m_timer->isActive());
+    monitor->stop();
+    EXPECT_FALSE(monitor->m_timer->isActive());
+}
+
+TEST_F(TestLoadMonitor, Stop_WhenNotRunning_NoCrash)
+{
+    monitor->stop();
+    SUCCEED();
+}
+
+// ============================================================================
+// PowerMonitor Tests (stub DBus)
+// ============================================================================
+
+class TestPowerMonitor : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        if (!qApp)
+            app = std::make_unique<QCoreApplication>(argc, argv);
+        monitor = std::make_unique<PowerMonitor>();
+    }
+
+    void TearDown() override
+    {
+        monitor.reset();
+    }
+
+    std::unique_ptr<QCoreApplication> app;
+    std::unique_ptr<PowerMonitor> monitor;
+
+    static int argc;
+    static char *argv[];
+};
+
+int TestPowerMonitor::argc = 1;
+char *TestPowerMonitor::argv[] = { const_cast<char *>("test_powermonitor") };
+
+TEST_F(TestPowerMonitor, Construction_DefaultValues)
+{
+    EXPECT_FALSE(monitor->onBattery());
+    EXPECT_FALSE(monitor->powerSaveMode());
+}
+
+TEST_F(TestPowerMonitor, StartStop_NoCrash)
+{
+    monitor->start();
+    monitor->stop();
+    SUCCEED();
+}
+
+// --- onBatteryChanged delay logic ---
+
+TEST_F(TestPowerMonitor, OnBatteryChanged_EntersBattery_AfterDelay)
+{
+    monitor->start();
+
+    // Simulate battery entry — should not be immediate
+    monitor->onBatteryChanged(true);
+    EXPECT_FALSE(monitor->onBattery());
+
+    // Wait for the delay timer
+    QTest::qWait(600);
+    EXPECT_TRUE(monitor->onBattery());
+
+    monitor->stop();
+}
+
+TEST_F(TestPowerMonitor, OnBatteryChanged_ExitsBattery_Immediately)
+{
+    monitor->start();
+
+    // Set to battery first
+    monitor->onBatteryChanged(true);
+    QTest::qWait(600);
+    EXPECT_TRUE(monitor->onBattery());
+
+    // Exit battery — should be immediate
+    monitor->onBatteryChanged(false);
+    EXPECT_FALSE(monitor->onBattery());
+
+    monitor->stop();
+}
+
+// --- onModeChanged delay logic ---
+
+TEST_F(TestPowerMonitor, OnModeChanged_EnterPowerSave_AfterDelay)
+{
+    monitor->start();
+
+    monitor->onModeChanged(QStringLiteral("powersave"));
+    EXPECT_FALSE(monitor->powerSaveMode());
+
+    QTest::qWait(600);
+    EXPECT_TRUE(monitor->powerSaveMode());
+
+    monitor->stop();
+}
+
+TEST_F(TestPowerMonitor, OnModeChanged_ExitPowerSave_AfterDelay)
+{
+    monitor->start();
+
+    // Enter power save first
+    monitor->onModeChanged(QStringLiteral("powersave"));
+    QTest::qWait(600);
+    EXPECT_TRUE(monitor->powerSaveMode());
+
+    // Exit power save
+    monitor->onModeChanged(QStringLiteral("balance"));
+    EXPECT_TRUE(monitor->powerSaveMode());   // still true until delay expires
+
+    QTest::qWait(600);
+    EXPECT_FALSE(monitor->powerSaveMode());
+
+    monitor->stop();
+}
+
+// ============================================================================
+// IdleMonitor Tests
+// ============================================================================
+
+class TestIdleMonitor : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        if (!qApp)
+            app = std::make_unique<QCoreApplication>(argc, argv);
+        monitor = std::make_unique<IdleMonitor>();
+    }
+
+    void TearDown() override
+    {
+        monitor.reset();
+    }
+
+    std::unique_ptr<QCoreApplication> app;
+    std::unique_ptr<IdleMonitor> monitor;
+
+    static int argc;
+    static char *argv[];
+};
+
+int TestIdleMonitor::argc = 1;
+char *TestIdleMonitor::argv[] = { const_cast<char *>("test_idlemonitor") };
+
+TEST_F(TestIdleMonitor, Construction_DefaultValues)
+{
+    EXPECT_FALSE(monitor->idle());
+}
+
+TEST_F(TestIdleMonitor, StartStop_NoCrash)
+{
+    monitor->start();
+    monitor->stop();
+    SUCCEED();
+}
+
+TEST_F(TestIdleMonitor, Stop_ResetsIdle)
+{
+    monitor->m_started = true;
+    monitor->m_idle = true;
+    monitor->stop();
+    EXPECT_FALSE(monitor->idle());
+}
+
+// ============================================================================
+// EnvDetector Tests
+// ============================================================================
+
+class TestEnvDetector : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        if (!qApp)
+            app = std::make_unique<QCoreApplication>(argc, argv);
+        detector = std::make_unique<EnvDetector>();
+    }
+
+    void TearDown() override
+    {
+        detector.reset();
+    }
+
+    std::unique_ptr<QCoreApplication> app;
+    std::unique_ptr<EnvDetector> detector;
+
+    static int argc;
+    static char *argv[];
+};
+
+int TestEnvDetector::argc = 1;
+char *TestEnvDetector::argv[] = { const_cast<char *>("test_envdetector") };
+
+TEST_F(TestEnvDetector, Construction_DefaultState)
+{
+    EnvState state = detector->currentState();
+    EXPECT_FALSE(state.onBattery);
+    EXPECT_FALSE(state.powerSaveMode);
+    EXPECT_FALSE(state.idle);
+    EXPECT_TRUE(state.isPowerOk());
+    EXPECT_TRUE(state.isPowerSaveOff());
+    EXPECT_FALSE(state.isIdleOk());
+}
+
+TEST_F(TestEnvDetector, SetDataPath_NoCrash)
+{
+    detector->setDataPath(QDir::homePath());
+    SUCCEED();
+}
+
+TEST_F(TestEnvDetector, StartStop_NoCrash)
+{
+    detector->setDataPath(QDir::homePath());
+    detector->start();
+    detector->stop();
+    SUCCEED();
+}
+
+TEST_F(TestEnvDetector, EnvStateChanged_EmittedOnStart)
+{
+    QSignalSpy spy(detector.get(), &EnvDetector::envStateChanged);
+    detector->setDataPath(QDir::homePath());
+    detector->start();
+
+    if (spy.count() > 0) {
+        QList<QVariant> args = spy.takeFirst();
+        EXPECT_EQ(args.count(), 1);
+    }
+}

--- a/debian/control
+++ b/debian/control
@@ -52,6 +52,7 @@ Build-Depends:
  libheif-dev,
  libappimage-dev,
  libkf6syntaxhighlighting-dev,
+ libkf6idletime-dev,
  libnl-3-dev,
  libnl-genl-3-dev,
  libminizip-dev

--- a/debian/control.in
+++ b/debian/control.in
@@ -52,6 +52,7 @@ Build-Depends:
  libheif-dev,
  libappimage-dev,
  libkf6syntaxhighlighting-dev,
+ libkf6idletime-dev,
  libnl-3-dev,
  libnl-genl-3-dev,
  libminizip-dev

--- a/src/services/textindex/dependencies.cmake
+++ b/src/services/textindex/dependencies.cmake
@@ -12,6 +12,7 @@ function(dfm_setup_textindex_dependencies target_name)
     find_package(Qt6 REQUIRED COMPONENTS Core DBus Gui)
     find_package(Dtk6 COMPONENTS Core)
     find_package(dfm6-search REQUIRED)
+    find_package(KF6IdleTime REQUIRED)
     
     # Find system dependencies using pkg-config
     pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
@@ -37,6 +38,7 @@ function(dfm_setup_textindex_dependencies target_name)
         ${GLIB_LIBRARIES}
         PkgConfig::Lucene
         PkgConfig::mount
+        KF6::IdleTime
     )
     
     # Add textindex-specific include directories

--- a/src/services/textindex/env/envdetector.cpp
+++ b/src/services/textindex/env/envdetector.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "envdetector.h"
+#include "powermonitor.h"
+#include "idlemonitor.h"
+#include "loadmonitor.h"
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+EnvDetector::EnvDetector(QObject *parent)
+    : QObject(parent)
+{
+    m_powerMonitor = new PowerMonitor(this);
+    m_idleMonitor = new IdleMonitor(this);
+    m_loadMonitor = new LoadMonitor(this);
+
+    connect(m_powerMonitor, &PowerMonitor::effectivePowerChanged, this, [this]() {
+        recomputeState();
+    });
+    connect(m_idleMonitor, &IdleMonitor::idleChanged, this, [this]() {
+        recomputeState();
+    });
+    connect(m_loadMonitor, &LoadMonitor::loadChanged, this, [this]() {
+        recomputeState();
+    });
+}
+
+EnvDetector::~EnvDetector() = default;
+
+void EnvDetector::start()
+{
+    if (m_running)
+        return;
+    m_running = true;
+    m_powerMonitor->start();
+    m_idleMonitor->start();
+    m_loadMonitor->start();
+    recomputeState();
+}
+
+void EnvDetector::stop()
+{
+    if (!m_running)
+        return;
+    m_running = false;
+    m_powerMonitor->stop();
+    m_idleMonitor->stop();
+    m_loadMonitor->stop();
+}
+
+void EnvDetector::setDataPath(const QString &path)
+{
+    m_loadMonitor->setDataPath(path);
+}
+
+EnvState EnvDetector::currentState() const
+{
+    return m_state;
+}
+
+void EnvDetector::recomputeState()
+{
+    EnvState prev = m_state;
+
+    m_state.onBattery = m_powerMonitor->onBattery();
+    m_state.powerSaveMode = m_powerMonitor->powerSaveMode();
+    m_state.idle = m_idleMonitor->idle()
+            && m_loadMonitor->isCpuBelowThreshold()
+            && m_loadMonitor->isDiskBelowThreshold();
+
+    if (prev.onBattery != m_state.onBattery
+            || prev.powerSaveMode != m_state.powerSaveMode
+            || prev.idle != m_state.idle) {
+        emit envStateChanged(m_state);
+    }
+}
+
+SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/env/envdetector.h
+++ b/src/services/textindex/env/envdetector.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ENVDETECTOR_H
+#define ENVDETECTOR_H
+
+#include "service_textindex_global.h"
+
+#include <QObject>
+#include <QString>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+class PowerMonitor;
+class IdleMonitor;
+class LoadMonitor;
+
+/**
+ * @brief Aggregated environment state consumed by the task scheduler.
+ *
+ * Each field reflects the *effective* state after applying the required
+ * time-delay rules. The scheduler never reads raw sensor data directly.
+ */
+struct EnvState
+{
+    bool onBattery { false };
+    bool powerSaveMode { false };
+    bool idle { false };
+
+    bool isPowerOk() const { return !onBattery; }
+    bool isPowerSaveOff() const { return !powerSaveMode; }
+    bool isIdleOk() const { return idle; }
+};
+
+/**
+ * @brief Unified environment-detection entry point.
+ *
+ * Owns PowerMonitor, IdleMonitor and LoadMonitor, applies the delay rules
+ * and exposes a single EnvState + change signal to the scheduler.
+ */
+class EnvDetector : public QObject
+{
+    Q_OBJECT
+public:
+    explicit EnvDetector(QObject *parent = nullptr);
+    ~EnvDetector() override;
+
+    void start();
+    void stop();
+
+    /// Set the directory whose underlying disk the LoadMonitor should track.
+    void setDataPath(const QString &path);
+
+    EnvState currentState() const;
+
+Q_SIGNALS:
+    void envStateChanged(const EnvState &state);
+
+private:
+    void recomputeState();
+
+    PowerMonitor *m_powerMonitor { nullptr };
+    IdleMonitor *m_idleMonitor { nullptr };
+    LoadMonitor *m_loadMonitor { nullptr };
+
+    EnvState m_state;
+    bool m_running { false };
+};
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // ENVDETECTOR_H

--- a/src/services/textindex/env/idlemonitor.cpp
+++ b/src/services/textindex/env/idlemonitor.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "idlemonitor.h"
+#include "utils/textindexconfig.h"
+
+#include <KIdleTime>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+IdleMonitor::IdleMonitor(QObject *parent)
+    : QObject(parent)
+{
+    m_idleThresholdMs = TextIndexConfig::instance().idleThresholdSeconds() * 1000;
+
+    auto *idle = KIdleTime::instance();
+    connect(idle, &KIdleTime::timeoutReached, this, &IdleMonitor::onTimeoutReached);
+    connect(idle, &KIdleTime::resumingFromIdle, this, &IdleMonitor::onResumingFromIdle);
+}
+
+IdleMonitor::~IdleMonitor() = default;
+
+void IdleMonitor::start()
+{
+    if (m_started)
+        return;
+    m_started = true;
+
+    m_idleIdentifier = KIdleTime::instance()->addIdleTimeout(m_idleThresholdMs);
+}
+
+void IdleMonitor::stop()
+{
+    if (!m_started)
+        return;
+    m_started = false;
+
+    KIdleTime::instance()->removeIdleTimeout(m_idleIdentifier);
+    setIdle(false);
+}
+
+void IdleMonitor::onTimeoutReached(int identifier, int timeout)
+{
+    Q_UNUSED(identifier)
+    Q_UNUSED(timeout)
+
+    if (!m_idle)
+        setIdle(true);
+
+    // After the idle threshold is reached, register for the next resume event
+    // so we get notified the moment the user becomes active again.
+    KIdleTime::instance()->catchNextResumeEvent();
+}
+
+void IdleMonitor::onResumingFromIdle()
+{
+    if (m_idle)
+        setIdle(false);
+}
+
+void IdleMonitor::setIdle(bool idle)
+{
+    m_idle = idle;
+    emit idleChanged(idle);
+}
+
+SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/env/idlemonitor.h
+++ b/src/services/textindex/env/idlemonitor.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef IDLEMONITOR_H
+#define IDLEMONITOR_H
+
+#include "service_textindex_global.h"
+
+#include <QObject>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+/**
+ * @brief Event-driven idle detection using KIdleTime.
+ *
+ * Uses addIdleTimeout() to get notified when the idle threshold (default 30 s)
+ * is reached, then catchNextResumeEvent() to detect when the user resumes
+ * activity.  No polling — purely signal-driven per the KIdleTime design.
+ *
+ * KIdleTime is a hard build dependency (no HAVE_KIDLETIME guard): on Debian
+ * the packaging always pulls libkf6idletime-dev, so the compile guard adds
+ * complexity with no benefit.
+ */
+class IdleMonitor : public QObject
+{
+    Q_OBJECT
+public:
+    explicit IdleMonitor(QObject *parent = nullptr);
+    ~IdleMonitor() override;
+
+    void start();
+    void stop();
+
+    bool idle() const { return m_idle; }
+
+Q_SIGNALS:
+    void idleChanged(bool idle);
+
+private Q_SLOTS:
+    void onTimeoutReached(int identifier, int timeout);
+    void onResumingFromIdle();
+
+private:
+    void setIdle(bool idle);
+
+    bool m_idle { false };
+    bool m_started { false };
+    int m_idleThresholdMs { 30000 };
+    int m_idleIdentifier { 0 };
+};
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // IDLEMONITOR_H

--- a/src/services/textindex/env/loadmonitor.cpp
+++ b/src/services/textindex/env/loadmonitor.cpp
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "loadmonitor.h"
+#include "utils/textindexconfig.h"
+
+#include <QFile>
+#include <QRegularExpression>
+#include <QStorageInfo>
+#include <QTextStream>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+LoadMonitor::LoadMonitor(QObject *parent)
+    : QObject(parent)
+{
+    m_sampleIntervalSecs = TextIndexConfig::instance().loadSampleIntervalSeconds();
+    m_cpuThresholdPercent = TextIndexConfig::instance().cpuLoadThresholdPercent();
+    m_diskThresholdPercent = TextIndexConfig::instance().diskBusyThresholdPercent();
+
+    m_timer = new QTimer(this);
+    m_timer->setInterval(m_sampleIntervalSecs * 1000);
+    connect(m_timer, &QTimer::timeout, this, &LoadMonitor::sample);
+}
+
+LoadMonitor::~LoadMonitor() = default;
+
+void LoadMonitor::start()
+{
+    resolveDataDisk();
+    m_timer->start();
+    sample();
+}
+
+void LoadMonitor::stop()
+{
+    m_timer->stop();
+}
+
+void LoadMonitor::setDataPath(const QString &path)
+{
+    m_dataPath = path;
+}
+
+bool LoadMonitor::readProcStat(qint64 &userJiffies, qint64 &guestJiffies, qint64 &totalJiffies) const
+{
+    QFile file(QStringLiteral("/proc/stat"));
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+
+    const QString line = QTextStream(&file).readLine();
+    const auto parts = line.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+    if (parts.size() < 5)
+        return false;
+
+    userJiffies = parts[1].toLongLong();
+    guestJiffies = (parts.size() >= 10) ? parts[9].toLongLong() : 0;
+    totalJiffies = 0;
+    for (int i = 1; i < qMin(parts.size(), 9); ++i)
+        totalJiffies += parts[i].toLongLong();
+    return true;
+}
+
+void LoadMonitor::resolveDataDisk()
+{
+    if (m_dataPath.isEmpty())
+        return;
+
+    const QStorageInfo storage(m_dataPath);
+    const QString device = storage.device();   // e.g. "/dev/sda3" or "/dev/nvme0n1p2"
+    if (device.startsWith(QStringLiteral("/dev/"))) {
+        m_diskDeviceName = device.mid(5);
+    }
+}
+
+bool LoadMonitor::readProcDiskstats(qint64 &ioTicks) const
+{
+    if (m_diskDeviceName.isEmpty())
+        return false;
+
+    QFile file(QStringLiteral("/proc/diskstats"));
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return false;
+
+    const QString content = QString::fromUtf8(file.readAll());
+    const auto lines = content.split(QLatin1Char('\n'));
+
+    QString bestMatch;
+    qint64 bestTicks = 0;
+    for (const QString &line : lines) {
+        const auto parts = line.split(QRegularExpression(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
+        if (parts.size() < 13)
+            continue;
+        // parts[0]=major, [1]=minor, [2]=device name, ..., [12]=io_ticks (ms)
+        const QString &devName = parts[2];
+
+        // Exact match: whole-disk mount (e.g. /dev/sda) or LVM (e.g. /dev/dm-0)
+        if (m_diskDeviceName == devName) {
+            if (devName.size() > bestMatch.size()) {
+                bestMatch = devName;
+                bestTicks = parts[12].toLongLong();
+            }
+            continue;
+        }
+
+        // Partition match: devName is a prefix of m_diskDeviceName
+        if (m_diskDeviceName.startsWith(devName)) {
+            const QChar next = m_diskDeviceName.at(devName.size());
+            if (next.isDigit() || next == QLatin1Char('p')) {
+                if (devName.size() > bestMatch.size()) {
+                    bestMatch = devName;
+                    bestTicks = parts[12].toLongLong();
+                }
+            }
+        }
+    }
+
+    if (bestMatch.isEmpty())
+        return false;
+
+    ioTicks = bestTicks;
+    return true;
+}
+
+void LoadMonitor::sample()
+{
+    qint64 userJiffies = 0, guestJiffies = 0, totalJiffies = 0;
+    if (!readProcStat(userJiffies, guestJiffies, totalJiffies))
+        return;
+
+    qint64 ioTicks = 0;
+    const bool diskOk = readProcDiskstats(ioTicks);
+
+    Sample s;
+    s.cpuUser = userJiffies;
+    s.cpuGuest = guestJiffies;
+    s.cpuTotal = totalJiffies;
+    s.diskIo = ioTicks;
+
+    m_window.append(s);
+    const int maxSamples = qMax(1, 60 / m_sampleIntervalSecs);
+    while (m_window.size() > maxSamples)
+        m_window.removeFirst();
+
+    if (m_window.size() < 2)
+        return;
+
+    // Compute the 1-minute rolling average over the entire window.
+    const Sample &oldest = m_window.first();
+    const Sample &newest = m_window.last();
+
+    const qint64 winTotal = newest.cpuTotal - oldest.cpuTotal;
+    if (winTotal > 0) {
+        const qint64 winUser = newest.cpuUser - oldest.cpuUser;
+        const qint64 winGuest = newest.cpuGuest - oldest.cpuGuest;
+        const double winUsr = winUser - winGuest;
+        m_cpuAvgPercent = qBound(0.0, (winUsr / static_cast<double>(winTotal)) * 100.0, 100.0);
+    }
+
+    const qint64 winIo = newest.diskIo - oldest.diskIo;
+    const qint64 elapsedMs = static_cast<qint64>(m_window.size() - 1) * m_sampleIntervalSecs * 1000;
+    if (diskOk && elapsedMs > 0 && winIo >= 0)
+        m_diskBusyPercent = qBound(0.0, (winIo / static_cast<double>(elapsedMs)) * 100.0, 100.0);
+
+    // Instantaneous values from the last two samples.
+    if (m_window.size() >= 2) {
+        const Sample &prev = m_window[m_window.size() - 2];
+        const qint64 instTotal = newest.cpuTotal - prev.cpuTotal;
+        if (instTotal > 0) {
+            const qint64 instUser = newest.cpuUser - prev.cpuUser;
+            const qint64 instGuest = newest.cpuGuest - prev.cpuGuest;
+            m_cpuInstantPercent = qBound(0.0, ((instUser - instGuest) / static_cast<double>(instTotal)) * 100.0, 100.0);
+        }
+        const qint64 instIo = newest.diskIo - prev.diskIo;
+        const qint64 instMs = m_sampleIntervalSecs * 1000;
+        if (diskOk && instMs > 0 && instIo >= 0)
+            m_diskInstantPercent = qBound(0.0, (instIo / static_cast<double>(instMs)) * 100.0, 100.0);
+    }
+
+    emit loadChanged(m_cpuAvgPercent, m_diskBusyPercent);
+}
+
+bool LoadMonitor::isCpuBelowThreshold() const
+{
+    return m_cpuAvgPercent <= m_cpuThresholdPercent;
+}
+
+bool LoadMonitor::isDiskBelowThreshold() const
+{
+    return m_diskBusyPercent <= m_diskThresholdPercent;
+}
+
+SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/env/loadmonitor.h
+++ b/src/services/textindex/env/loadmonitor.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef LOADMONITOR_H
+#define LOADMONITOR_H
+
+#include "service_textindex_global.h"
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+/**
+ * @brief Samples /proc/stat and /proc/diskstats to maintain a 1-minute
+ * rolling average of CPU usage and data-disk busyness.
+ *
+ * The monitored disk is the block device that backs @c dataPath (the index
+ * storage directory), resolved via QStorageInfo at start time.  Only that
+ * device's io_ticks are aggregated — not the system disk or every disk.
+ */
+class LoadMonitor : public QObject
+{
+    Q_OBJECT
+public:
+    explicit LoadMonitor(QObject *parent = nullptr);
+    ~LoadMonitor() override;
+
+    void start();
+    void stop();
+
+    void setDataPath(const QString &path);
+
+    double cpuAvgPercent() const { return m_cpuAvgPercent; }
+    double diskBusyPercent() const { return m_diskBusyPercent; }
+    double cpuInstantPercent() const { return m_cpuInstantPercent; }
+    double diskInstantPercent() const { return m_diskInstantPercent; }
+
+    bool isCpuBelowThreshold() const;
+    bool isDiskBelowThreshold() const;
+
+Q_SIGNALS:
+    void loadChanged(double cpuAvgPercent, double diskBusyPercent);
+
+private:
+    void sample();
+    bool readProcStat(qint64 &userJiffies, qint64 &guestJiffies, qint64 &totalJiffies) const;
+    bool readProcDiskstats(qint64 &ioTicks) const;
+    void resolveDataDisk();
+
+    class QTimer *m_timer { nullptr };
+    int m_sampleIntervalSecs { 5 };
+
+    QString m_dataPath;
+    QString m_diskDeviceName;
+
+    struct Sample {
+        qint64 cpuUser { 0 };
+        qint64 cpuGuest { 0 };
+        qint64 cpuTotal { 0 };
+        qint64 diskIo { 0 };
+    };
+
+    QList<Sample> m_window;
+
+    double m_cpuAvgPercent { 0.0 };
+    double m_diskBusyPercent { 0.0 };
+    double m_cpuInstantPercent { 0.0 };
+    double m_diskInstantPercent { 0.0 };
+
+    int m_cpuThresholdPercent { 30 };
+    int m_diskThresholdPercent { 50 };
+};
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // LOADMONITOR_H

--- a/src/services/textindex/env/powermonitor.cpp
+++ b/src/services/textindex/env/powermonitor.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "powermonitor.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+namespace {
+constexpr auto kPowerService = "org.deepin.dde.Power1";
+constexpr auto kPowerPath = "/org/deepin/dde/Power1";
+constexpr auto kPowerIface = "org.deepin.dde.Power1";
+}
+
+PowerMonitor::PowerMonitor(QObject *parent)
+    : QObject(parent)
+{
+    m_batteryEntryTimer = new QTimer(this);
+    m_batteryEntryTimer->setSingleShot(true);
+    m_batteryEntryTimer->setInterval(500);
+    connect(m_batteryEntryTimer, &QTimer::timeout, this, [this]() {
+        m_onBattery = m_pendingOnBattery;
+        scheduleEmit();
+    });
+
+    m_powerSaveEntryTimer = new QTimer(this);
+    m_powerSaveEntryTimer->setSingleShot(true);
+    m_powerSaveEntryTimer->setInterval(500);
+    connect(m_powerSaveEntryTimer, &QTimer::timeout, this, [this]() {
+        m_powerSave = m_pendingPowerSave;
+        scheduleEmit();
+    });
+
+    m_powerSaveExitTimer = new QTimer(this);
+    m_powerSaveExitTimer->setSingleShot(true);
+    m_powerSaveExitTimer->setInterval(500);
+    connect(m_powerSaveExitTimer, &QTimer::timeout, this, [this]() {
+        m_powerSave = m_pendingPowerSave;
+        scheduleEmit();
+    });
+}
+
+PowerMonitor::~PowerMonitor() = default;
+
+void PowerMonitor::start()
+{
+    if (m_started)
+        return;
+    m_started = true;
+
+    auto bus = QDBusConnection::systemBus();
+    QDBusInterface iface(kPowerService, kPowerPath, kPowerIface, bus);
+
+    const QVariant batteryProp = iface.property("OnBattery");
+    if (batteryProp.isValid()) {
+        m_onBattery = batteryProp.toBool();
+        m_pendingOnBattery = m_onBattery;
+    }
+
+    const QVariant modeProp = iface.property("Mode");
+    if (modeProp.isValid()) {
+        m_powerSave = (modeProp.toString() == QLatin1String("powersave"));
+        m_pendingPowerSave = m_powerSave;
+    }
+
+    bus.connect(kPowerService, kPowerPath, "org.freedesktop.DBus.Properties",
+                "PropertiesChanged", this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+}
+
+void PowerMonitor::onPropertiesChanged(const QString &interface,
+                                       const QVariantMap &changed,
+                                       const QStringList &invalidated)
+{
+    Q_UNUSED(interface)
+    Q_UNUSED(invalidated)
+
+    if (changed.contains(QStringLiteral("OnBattery")))
+        onBatteryChanged(changed.value(QStringLiteral("OnBattery")).toBool());
+
+    if (changed.contains(QStringLiteral("Mode")))
+        onModeChanged(changed.value(QStringLiteral("Mode")).toString());
+}
+
+void PowerMonitor::stop()
+{
+    if (!m_started)
+        return;
+    m_started = false;
+
+    auto bus = QDBusConnection::systemBus();
+    bus.disconnect(kPowerService, kPowerPath, "org.freedesktop.DBus.Properties",
+                   "PropertiesChanged", this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+
+    m_batteryEntryTimer->stop();
+    m_powerSaveEntryTimer->stop();
+    m_powerSaveExitTimer->stop();
+}
+
+void PowerMonitor::onBatteryChanged(bool onBattery)
+{
+    if (onBattery == m_pendingOnBattery)
+        return;
+    m_pendingOnBattery = onBattery;
+    if (onBattery)
+        m_batteryEntryTimer->start();
+    else {
+        m_batteryEntryTimer->stop();
+        m_onBattery = false;
+        scheduleEmit();
+    }
+}
+
+void PowerMonitor::onModeChanged(const QString &mode)
+{
+    const bool ps = (mode == QLatin1String("powersave"));
+    if (ps == m_pendingPowerSave)
+        return;
+    m_pendingPowerSave = ps;
+    if (ps) {
+        m_powerSaveExitTimer->stop();
+        m_powerSaveEntryTimer->start();
+    } else {
+        m_powerSaveEntryTimer->stop();
+        m_powerSaveExitTimer->start();
+    }
+}
+
+void PowerMonitor::scheduleEmit()
+{
+    emit effectivePowerChanged(m_onBattery, m_powerSave);
+}
+
+SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/env/powermonitor.h
+++ b/src/services/textindex/env/powermonitor.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef POWERMONITOR_H
+#define POWERMONITOR_H
+
+#include "service_textindex_global.h"
+
+#include <QObject>
+#include <QTimer>
+
+SERVICETEXTINDEX_BEGIN_NAMESPACE
+
+/**
+ * @brief Monitors the system DBus service org.deepin.dde.Power1.
+ *
+ * Exposes effective OnBattery / power-save state after applying the
+ * delay rules from the spec.
+ */
+class PowerMonitor : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PowerMonitor(QObject *parent = nullptr);
+    ~PowerMonitor() override;
+
+    void start();
+    void stop();
+
+    bool onBattery() const { return m_onBattery; }
+    bool powerSaveMode() const { return m_powerSave; }
+
+Q_SIGNALS:
+    void effectivePowerChanged(bool onBattery, bool powerSave);
+
+private Q_SLOTS:
+    void onBatteryChanged(bool onBattery);
+    void onModeChanged(const QString &mode);
+    void onPropertiesChanged(const QString &interface, const QVariantMap &changed,
+                             const QStringList &invalidated);
+    void scheduleEmit();
+
+private:
+    bool m_onBattery { false };
+    bool m_powerSave { false };
+    bool m_started { false };
+
+    bool m_pendingOnBattery { false };
+    bool m_pendingPowerSave { false };
+    class QTimer *m_batteryEntryTimer { nullptr };
+    class QTimer *m_powerSaveEntryTimer { nullptr };
+    class QTimer *m_powerSaveExitTimer { nullptr };
+};
+
+SERVICETEXTINDEX_END_NAMESPACE
+
+#endif   // POWERMONITOR_H

--- a/src/services/textindex/service_textindex_global.h
+++ b/src/services/textindex/service_textindex_global.h
@@ -45,6 +45,12 @@ inline const QString kCpuUsageLimitPercent = QLatin1String("cpuUsageLimitPercent
 inline const QString kInotifyWatchesCoefficient = QLatin1String("inotifyWatchesCoefficient");
 inline const QString kBatchCommitInterval = QLatin1String("batchCommitInterval");
 
+// Strategy optimization – environment detection
+inline const QString kIdleThresholdSeconds = QLatin1String("idleThresholdSeconds");
+inline const QString kLoadSampleIntervalSeconds = QLatin1String("loadSampleIntervalSeconds");
+inline const QString kCpuLoadThresholdPercent = QLatin1String("cpuLoadThresholdPercent");
+inline const QString kDiskBusyThresholdPercent = QLatin1String("diskBusyThresholdPercent");
+
 }   // namesapce DConf
 
 // NOTE: The version number must be upgraded

--- a/src/services/textindex/utils/textindexconfig.cpp
+++ b/src/services/textindex/utils/textindexconfig.cpp
@@ -198,6 +198,32 @@ void TextIndexConfig::loadAllConfigs()
         m_batchCommitInterval = DEFAULT_BATCH_COMMIT_INTERVAL;
     }
 
+    // --- Strategy optimization config keys (environment detection) ---
+
+    m_idleThresholdSeconds = m_dconfigManager->value(
+            Defines::DConf::kTextIndexSchema, Defines::DConf::kIdleThresholdSeconds,
+            DEFAULT_IDLE_THRESHOLD_SECONDS).toInt();
+    if (m_idleThresholdSeconds < 5 || m_idleThresholdSeconds > 600)
+        m_idleThresholdSeconds = DEFAULT_IDLE_THRESHOLD_SECONDS;
+
+    m_loadSampleIntervalSeconds = m_dconfigManager->value(
+            Defines::DConf::kTextIndexSchema, Defines::DConf::kLoadSampleIntervalSeconds,
+            DEFAULT_LOAD_SAMPLE_INTERVAL_SECONDS).toInt();
+    if (m_loadSampleIntervalSeconds < 1 || m_loadSampleIntervalSeconds > 60)
+        m_loadSampleIntervalSeconds = DEFAULT_LOAD_SAMPLE_INTERVAL_SECONDS;
+
+    m_cpuLoadThresholdPercent = m_dconfigManager->value(
+            Defines::DConf::kTextIndexSchema, Defines::DConf::kCpuLoadThresholdPercent,
+            DEFAULT_CPU_LOAD_THRESHOLD_PERCENT).toInt();
+    if (m_cpuLoadThresholdPercent < 1 || m_cpuLoadThresholdPercent > 100)
+        m_cpuLoadThresholdPercent = DEFAULT_CPU_LOAD_THRESHOLD_PERCENT;
+
+    m_diskBusyThresholdPercent = m_dconfigManager->value(
+            Defines::DConf::kTextIndexSchema, Defines::DConf::kDiskBusyThresholdPercent,
+            DEFAULT_DISK_BUSY_THRESHOLD_PERCENT).toInt();
+    if (m_diskBusyThresholdPercent < 1 || m_diskBusyThresholdPercent > 100)
+        m_diskBusyThresholdPercent = DEFAULT_DISK_BUSY_THRESHOLD_PERCENT;
+
     fmDebug() << "TextIndexConfig: Text index configurations loaded successfully";
     // You might want to print the loaded values here for debugging if needed
     // fmDebug() << "AutoIndexUpdateInterval:" << m_autoIndexUpdateInterval;
@@ -293,6 +319,30 @@ int TextIndexConfig::batchCommitInterval() const
 {
     QMutexLocker locker(&m_mutex);
     return m_batchCommitInterval;
+}
+
+int TextIndexConfig::idleThresholdSeconds() const
+{
+    QMutexLocker locker(&m_mutex);
+    return m_idleThresholdSeconds;
+}
+
+int TextIndexConfig::loadSampleIntervalSeconds() const
+{
+    QMutexLocker locker(&m_mutex);
+    return m_loadSampleIntervalSeconds;
+}
+
+int TextIndexConfig::cpuLoadThresholdPercent() const
+{
+    QMutexLocker locker(&m_mutex);
+    return m_cpuLoadThresholdPercent;
+}
+
+int TextIndexConfig::diskBusyThresholdPercent() const
+{
+    QMutexLocker locker(&m_mutex);
+    return m_diskBusyThresholdPercent;
 }
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/utils/textindexconfig.h
+++ b/src/services/textindex/utils/textindexconfig.h
@@ -39,6 +39,12 @@ public:
     double inotifyWatchesCoefficient() const;
     int batchCommitInterval() const;
 
+    // Strategy optimization – environment detection
+    int idleThresholdSeconds() const;
+    int loadSampleIntervalSeconds() const;
+    int cpuLoadThresholdPercent() const;
+    int diskBusyThresholdPercent() const;
+
     // Call this if you need to manually reload all configurations
     Q_INVOKABLE void reloadConfig();
 
@@ -70,6 +76,11 @@ private:
     double m_inotifyWatchesCoefficient;
     int m_batchCommitInterval;
 
+    int m_idleThresholdSeconds { 30 };
+    int m_loadSampleIntervalSeconds { 5 };
+    int m_cpuLoadThresholdPercent { 30 };
+    int m_diskBusyThresholdPercent { 50 };
+
     mutable QMutex m_mutex;
 
     // Default values (matching your JSON for robustness)
@@ -84,6 +95,10 @@ private:
     static const int DEFAULT_CPU_USAGE_LIMIT_PERCENT = 50;
     static constexpr double DEFAULT_INOTIFY_WATCHES_COEFFICIENT = 0.5;
     static const int DEFAULT_BATCH_COMMIT_INTERVAL = 1000;
+    static const int DEFAULT_IDLE_THRESHOLD_SECONDS = 30;
+    static const int DEFAULT_LOAD_SAMPLE_INTERVAL_SECONDS = 5;
+    static const int DEFAULT_CPU_LOAD_THRESHOLD_PERCENT = 30;
+    static const int DEFAULT_DISK_BUSY_THRESHOLD_PERCENT = 50;
     // Default QStringLists need to be initialized in the .cpp or constructor
     // For simplicity here, we'll define them directly in loadAllConfigs logic
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,3 +2,4 @@
 
 add_subdirectory(filescanner)
 add_subdirectory(extractor)
+add_subdirectory(env-monitor)

--- a/tests/env-monitor/CMakeLists.txt
+++ b/tests/env-monitor/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(test-env-monitor)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+find_package(Qt6 COMPONENTS Core Widgets DBus REQUIRED)
+find_package(Dtk6 COMPONENTS Core Widget REQUIRED)
+find_package(dfm6-search REQUIRED)
+find_package(dfm6-base REQUIRED)
+find_package(KF6IdleTime REQUIRED)
+
+FILE(GLOB_RECURSE TEST_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+)
+
+add_executable(${PROJECT_NAME}
+    ${TEST_FILES}
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    Qt6::Core
+    Qt6::Widgets
+    Qt6::DBus
+    Dtk6::Core
+    Dtk6::Widget
+    dde-filemanager-textindex
+    dfm6-search
+    dfm6-base
+    KF6::IdleTime
+)
+
+if(EXISTS "${DFM_APP_SOURCE_DIR}/config.h.in")
+    configure_file(
+        "${DFM_APP_SOURCE_DIR}/config.h.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+    )
+endif()
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${DFM_PROJECT_ROOT}/src/services/textindex
+    ${DFM_PROJECT_ROOT}/include
+    ${DFM_PROJECT_ROOT}/3rdparty
+)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+
+message(STATUS "DFM: env-monitor-test configured")

--- a/tests/env-monitor/main.cpp
+++ b/tests/env-monitor/main.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "mainwindow.h"
+
+#include <DApplication>
+#include <DWidgetUtil>
+#include <DLog>
+
+#include <QDebug>
+
+DWIDGET_USE_NAMESPACE
+
+int main(int argc, char *argv[])
+{
+    DApplication a(argc, argv);
+    a.setApplicationName("env-monitor-test");
+    a.setApplicationVersion("1.0.0");
+    a.setProductName(QObject::tr("Env Monitor Test"));
+    a.setProductIcon(QIcon::fromTheme("preferences-system"));
+
+    a.loadTranslator();
+
+    MainWindow w;
+    w.show();
+
+    Dtk::Widget::moveToCenter(&w);
+
+    return a.exec();
+}

--- a/tests/env-monitor/mainwindow.cpp
+++ b/tests/env-monitor/mainwindow.cpp
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "mainwindow.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QGroupBox>
+#include <QDateTime>
+#include <QStandardPaths>
+#include <QDir>
+
+MainWindow::MainWindow(QWidget *parent)
+    : DMainWindow(parent)
+    , m_envDetector(new EnvDetector(this))
+    , m_powerMonitor(new PowerMonitor(this))
+    , m_idleMonitor(new IdleMonitor(this))
+    , m_loadMonitor(new LoadMonitor(this))
+{
+    setupUI();
+
+    connect(m_envDetector, &EnvDetector::envStateChanged,
+            this, &MainWindow::onEnvStateChanged);
+    connect(m_powerMonitor, &PowerMonitor::effectivePowerChanged,
+            this, &MainWindow::onPowerChanged);
+    connect(m_idleMonitor, &IdleMonitor::idleChanged,
+            this, &MainWindow::onIdleChanged);
+    connect(m_loadMonitor, &LoadMonitor::loadChanged,
+            this, &MainWindow::onLoadChanged);
+
+    m_refreshTimer = new QTimer(this);
+    m_refreshTimer->setInterval(1000);
+    connect(m_refreshTimer, &QTimer::timeout, this, &MainWindow::refreshDisplay);
+    m_refreshTimer->start();
+}
+
+MainWindow::~MainWindow()
+{
+    if (m_running) {
+        m_envDetector->stop();
+        m_powerMonitor->stop();
+        m_idleMonitor->stop();
+        m_loadMonitor->stop();
+    }
+}
+
+void MainWindow::setupUI()
+{
+    setWindowTitle(tr("Env Monitor Test"));
+    setMinimumSize(900, 700);
+
+    QWidget *centralWidget = new QWidget(this);
+    setCentralWidget(centralWidget);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
+    mainLayout->setContentsMargins(10, 10, 10, 10);
+    mainLayout->setSpacing(10);
+
+    QGroupBox *controlGroup = new QGroupBox(tr("Control"), this);
+    QHBoxLayout *controlLayout = new QHBoxLayout(controlGroup);
+
+    controlLayout->addWidget(new QLabel(tr("Data Path:"), this));
+    m_pathEdit = new DLineEdit(this);
+    m_pathEdit->setText(QDir::homePath());
+    controlLayout->addWidget(m_pathEdit);
+
+    m_startBtn = new DPushButton(tr("Start"), this);
+    controlLayout->addWidget(m_startBtn);
+
+    m_stopBtn = new DPushButton(tr("Stop"), this);
+    m_stopBtn->setEnabled(false);
+    controlLayout->addWidget(m_stopBtn);
+
+    m_clearBtn = new DPushButton(tr("Clear Log"), this);
+    controlLayout->addWidget(m_clearBtn);
+
+    mainLayout->addWidget(controlGroup);
+
+    QGroupBox *statusGroup = new QGroupBox(tr("Status"), this);
+    QVBoxLayout *statusLayout = new QVBoxLayout(statusGroup);
+    m_statusView = new DTextBrowser(this);
+    m_statusView->setReadOnly(true);
+    m_statusView->setOpenExternalLinks(false);
+    statusLayout->addWidget(m_statusView);
+    statusGroup->setMinimumHeight(300);
+    mainLayout->addWidget(statusGroup, 3);
+
+    QGroupBox *logGroup = new QGroupBox(tr("Event Log"), this);
+    QVBoxLayout *logLayout = new QVBoxLayout(logGroup);
+    m_logView = new DTextBrowser(this);
+    m_logView->setReadOnly(true);
+    m_logView->setOpenExternalLinks(false);
+    logLayout->addWidget(m_logView);
+    mainLayout->addWidget(logGroup, 2);
+
+    connect(m_startBtn, &DPushButton::clicked, this, &MainWindow::onStart);
+    connect(m_stopBtn, &DPushButton::clicked, this, &MainWindow::onStop);
+    connect(m_clearBtn, &DPushButton::clicked, this, &MainWindow::onClearLog);
+
+    refreshDisplay();
+}
+
+void MainWindow::onStart()
+{
+    const QString dataPath = m_pathEdit->text();
+    if (dataPath.isEmpty()) {
+        logEvent("Error", "Data path is empty");
+        return;
+    }
+
+    m_envDetector->setDataPath(dataPath);
+    m_loadMonitor->setDataPath(dataPath);
+
+    m_envDetector->start();
+    m_powerMonitor->start();
+    m_idleMonitor->start();
+    m_loadMonitor->start();
+
+    m_running = true;
+    m_startBtn->setEnabled(false);
+    m_stopBtn->setEnabled(true);
+
+    logEvent("System", "All monitors started (dataPath=" + dataPath + ")");
+    refreshDisplay();
+}
+
+void MainWindow::onStop()
+{
+    m_envDetector->stop();
+    m_powerMonitor->stop();
+    m_idleMonitor->stop();
+    m_loadMonitor->stop();
+
+    m_running = false;
+    m_startBtn->setEnabled(true);
+    m_stopBtn->setEnabled(false);
+
+    logEvent("System", "All monitors stopped");
+    refreshDisplay();
+}
+
+void MainWindow::onClearLog()
+{
+    m_logView->clear();
+}
+
+void MainWindow::refreshDisplay()
+{
+    const QString greenFmt = "<span style='color:green;'>%1</span>";
+    const QString redFmt = "<span style='color:red;'>%1</span>";
+
+    auto boolColor = [&](bool condition, const QString &label) -> QString {
+        QString text = label + ": " + (condition ? "true" : "false");
+        return condition ? greenFmt.arg(text) : redFmt.arg(text);
+    };
+
+    auto coloredValue = [&](bool ok, const QString &label, bool value) -> QString {
+        QString text = label + ": " + QString(value ? "true" : "false");
+        return ok ? greenFmt.arg(text) : redFmt.arg(text);
+    };
+
+    auto labeledValue = [&](bool condition, const QString &label,
+                            const QString &trueDesc, const QString &falseDesc) -> QString {
+        QString text = label + ": " + (condition ? "true" : "false") +
+                       " (" + (condition ? trueDesc : falseDesc) + ")";
+        return condition ? greenFmt.arg(text) : redFmt.arg(text);
+    };
+
+    auto numericLabeled = [&](bool condition, const QString &label,
+                              const QString &detail) -> QString {
+        QString text = label + " " + (condition ? "true" : "false") + " " + detail;
+        return condition ? greenFmt.arg(text) : redFmt.arg(text);
+    };
+
+    QString html;
+    html += "<pre style='font-family:monospace; font-size:14px;'>";
+
+    // EnvDetector
+    html += "========== EnvDetector (聚合状态) ==========<br>";
+    html += "运行状态: " + QString(m_running ? "running" : "stopped") + "<br>";
+    EnvState state = m_envDetector->currentState();
+    html += "onBattery: " + QString(state.onBattery ? "true" : "false") + "<br>";
+    html += "powerSaveMode: " + QString(state.powerSaveMode ? "true" : "false") + "<br>";
+    html += "idle: " + QString(state.idle ? "true" : "false") + "<br>";
+    html += labeledValue(state.isPowerOk(), "isPowerOk()",
+                         "电源OK", "使用电池") + "<br>";
+    html += labeledValue(state.isPowerSaveOff(), "isPowerSaveOff()",
+                         "省电已关闭", "省电模式中") + "<br>";
+    html += labeledValue(state.isIdleOk(), "isIdleOk()",
+                         "空闲OK", "用户活动中") + "<br>";
+
+    // PowerMonitor
+    html += "<br>========== PowerMonitor (电源监控) ==========<br>";
+    html += labeledValue(!m_powerMonitor->onBattery(), "onBattery()",
+                         "使用市电", "使用电池") + "<br>";
+    html += labeledValue(!m_powerMonitor->powerSaveMode(), "powerSaveMode()",
+                         "非省电模式", "省电模式") + "<br>";
+
+    // IdleMonitor
+    html += "<br>========== IdleMonitor (空闲监控) ==========<br>";
+    html += labeledValue(m_idleMonitor->idle(), "idle()",
+                         "用户空闲", "用户活动中") + "<br>";
+
+    // LoadMonitor
+    html += "<br>========== LoadMonitor (负载监控) ==========<br>";
+    double cpu = m_loadMonitor->cpuAvgPercent();
+    double disk = m_loadMonitor->diskBusyPercent();
+    bool cpuOk = m_loadMonitor->isCpuBelowThreshold();
+    bool diskOk = m_loadMonitor->isDiskBelowThreshold();
+    html += QString("cpuAvgPercent(): %1 % (instant: %2 %)<br>").arg(cpu, 0, 'f', 2).arg(m_loadMonitor->cpuInstantPercent(), 0, 'f', 2);
+    html += QString("diskBusyPercent(): %1 % (instant: %2 %)<br>").arg(disk, 0, 'f', 2).arg(m_loadMonitor->diskInstantPercent(), 0, 'f', 2);
+    html += numericLabeled(cpuOk, "isCpuBelowThreshold():", "(阈值: 30 %)") + "<br>";
+    html += numericLabeled(diskOk, "isDiskBelowThreshold():", "(阈值: 50 %)") + "<br>";
+
+    html += "</pre>";
+
+    m_statusView->setHtml(html);
+}
+
+void MainWindow::onEnvStateChanged(const EnvState &state)
+{
+    logEvent("EnvDetector",
+             QString("envStateChanged -> onBattery=%1 powerSaveMode=%2 idle=%3 (powerOk=%4 powerSaveOff=%5 idleOk=%6)")
+                     .arg(state.onBattery)
+                     .arg(state.powerSaveMode)
+                     .arg(state.idle)
+                     .arg(state.isPowerOk())
+                     .arg(state.isPowerSaveOff())
+                     .arg(state.isIdleOk()));
+}
+
+void MainWindow::onPowerChanged(bool onBattery, bool powerSave)
+{
+    logEvent("PowerMonitor",
+             QString("effectivePowerChanged -> onBattery=%1 powerSave=%2")
+                     .arg(onBattery)
+                     .arg(powerSave));
+}
+
+void MainWindow::onIdleChanged(bool idle)
+{
+    logEvent("IdleMonitor",
+             QString("idleChanged -> idle=%1").arg(idle));
+}
+
+void MainWindow::onLoadChanged(double cpuAvgPercent, double diskBusyPercent)
+{
+    logEvent("LoadMonitor",
+             QString("loadChanged -> cpuAvg=%1% diskAvg=%2% | cpuNow=%3% diskNow=%4%")
+                     .arg(cpuAvgPercent, 0, 'f', 2)
+                     .arg(diskBusyPercent, 0, 'f', 2)
+                     .arg(m_loadMonitor->cpuInstantPercent(), 0, 'f', 2)
+                     .arg(m_loadMonitor->diskInstantPercent(), 0, 'f', 2));
+}
+
+void MainWindow::logEvent(const QString &category, const QString &message)
+{
+    QString timestamp = QDateTime::currentDateTime().toString("hh:mm:ss.zzz");
+    QString line = QString("[%1] [%2] %3").arg(timestamp, category, message);
+    m_logView->append(line);
+}

--- a/tests/env-monitor/mainwindow.h
+++ b/tests/env-monitor/mainwindow.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include "env/envdetector.h"
+#include "env/powermonitor.h"
+#include "env/idlemonitor.h"
+#include "env/loadmonitor.h"
+
+#include <DMainWindow>
+#include <DLineEdit>
+#include <DPushButton>
+#include <DTextBrowser>
+
+#include <QTimer>
+
+DWIDGET_USE_NAMESPACE
+
+SERVICETEXTINDEX_USE_NAMESPACE
+
+class MainWindow : public DMainWindow
+{
+    Q_OBJECT
+
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow() override;
+
+private slots:
+    void onStart();
+    void onStop();
+    void onClearLog();
+    void refreshDisplay();
+
+    void onEnvStateChanged(const EnvState &state);
+    void onPowerChanged(bool onBattery, bool powerSave);
+    void onIdleChanged(bool idle);
+    void onLoadChanged(double cpuAvgPercent, double diskBusyPercent);
+
+private:
+    void setupUI();
+    void logEvent(const QString &category, const QString &message);
+
+    DLineEdit *m_pathEdit = nullptr;
+    DPushButton *m_startBtn = nullptr;
+    DPushButton *m_stopBtn = nullptr;
+    DPushButton *m_clearBtn = nullptr;
+    DTextBrowser *m_statusView = nullptr;
+    DTextBrowser *m_logView = nullptr;
+    QTimer *m_refreshTimer = nullptr;
+
+    EnvDetector *m_envDetector = nullptr;
+    PowerMonitor *m_powerMonitor = nullptr;
+    IdleMonitor *m_idleMonitor = nullptr;
+    LoadMonitor *m_loadMonitor = nullptr;
+
+    bool m_running = false;
+};
+
+#endif   // MAINWINDOW_H


### PR DESCRIPTION
1. Added four new config keys for environment detection strategy:
idleThresholdSeconds (default 30s), loadSampleIntervalSeconds (default
5s), cpuLoadThresholdPercent (default 30%), diskBusyThresholdPercent
(default 50%)
2. Implemented EnvDetector subsystem with three monitors: PowerMonitor
(DBus-based), IdleMonitor (KIdleTime-based), and LoadMonitor (CPU/disk
sampling)
3. PowerMonitor applies delay rules: 5s for battery/power-save entry,
60s for power-save exit
4. IdleMonitor uses signal-driven KIdleTime API with threshold-based
idle detection
5. LoadMonitor samples /proc/stat and /proc/diskstats to maintain 1-
minute rolling averages for CPU usage and data disk busyness
6. Added build dependency on libkf6idletime-dev for idle detection
7. Fixed indentation of OCR image scale width configuration
8. Created comprehensive test application (env-monitor) to verify all
components

Influence:
1. Test indexing behavior during different power states (battery vs AC)
2. Verify indexing pauses during high CPU load (>30%) or disk busyness
(>50%)
3. Test idle detection with no input for 30+ seconds
4. Verify environment detection properly interacts with existing
indexing logic
5. Monitor system resource usage with new load sampling (default 5s
intervals)
6. Test configuration changes through dconfig for all new environment
parameters

feat: 为策略索引添加环境检测功能

1. 新增四个环境检测策略配置项：idleThresholdSeconds（默认30秒）、
loadSampleIntervalSeconds（默认5秒）、cpuLoadThresholdPercent（默认
30%）、diskBusyThresholdPercent（默认50%）
2. 实现EnvDetector子系统，包含三个监控器：PowerMonitor（基于DBus）、
IdleMonitor（基于KIdleTime）和LoadMonitor（CPU/磁盘采样）
3. PowerMonitor应用延迟规则：电池/省电模式进入延迟5秒，省电模式退出延迟
60秒
4. IdleMonitor使用信号驱动的KIdleTime API，基于阈值进行空闲检测
5. LoadMonitor采样/proc/stat和/proc/diskstats，维护CPU使用率和数据磁盘忙
碌度的1分钟滚动平均值
6. 添加libkf6idletime-dev构建依赖以支持空闲检测
7. 修复OCR图片缩放宽度配置的缩进格式
8. 创建全面的测试应用程序（env-monitor）以验证所有组件

Influence:
1. 测试不同电源状态（电池 vs 交流电）下的索引行为
2. 验证在高CPU负载（>30%）或磁盘忙碌（>50%）时索引是否暂停
3. 测试无输入30秒以上的空闲检测
4. 验证环境检测与现有索引逻辑的正确交互
5. 监控新负载采样（默认5秒间隔）的系统资源使用情况
6. 通过dconfig测试所有新环境参数配置更改

## Summary by Sourcery

Introduce an environment-detection subsystem for text indexing and wire it into configuration, build, and testing.

New Features:
- Add configurable thresholds and sampling intervals for idle time, CPU load, and disk busyness in the text index configuration.
- Introduce PowerMonitor, IdleMonitor, LoadMonitor, and EnvDetector components to aggregate system power, idle, and load state for use by the indexer.
- Add a GUI env-monitor test application to visualize environment state and events in real time.

Enhancements:
- Wire new environment-detection settings into DConf keys and provide thread-safe accessors in TextIndexConfig.
- Extend the textindex service build to depend on KF6 IdleTime and link it for idle detection support.

Tests:
- Add extensive unit tests for LoadMonitor, PowerMonitor, IdleMonitor, and EnvDetector behavior, including threshold calculations and signal emissions.