### PR TITLE
fix: show broken-link dialog for deleted SMB share target

### DIFF
--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1361,8 +1361,12 @@ std::optional<QUrl> LocalFileHandlerPrivate::resolveSymlink(const QUrl &url)
         }
 
         // Check if link target exists
+        // For SMB targets, only skip the broken-link dialog when the share is
+        // unmounted (so the downstream mount/remount flow can take over).
+        // If the share is still mounted but the target is gone, the link is
+        // genuinely broken and the user should be notified.
         fileInfo.setFile(canonicalPath);
-        if (!fileInfo.exists() && !ProtocolUtils::isSMBFile(QUrl::fromLocalFile(canonicalPath))) {
+        if (!fileInfo.exists() && !DeviceUtils::isUnmountSamba(QUrl::fromLocalFile(canonicalPath))) {
             // Link is broken
             GlobalEventType dialogResult = DialogManagerInstance->showBreakSymlinkDialog(
                     QFileInfo(currentPath).fileName(),


### PR DESCRIPTION
1. 修复 resolveSymlink 中对 SMB 目标一律豁免失效判定的问题;
2. 改用 DeviceUtils::isUnmountSamba 区分"未挂载(交下游挂载流程)"与"仍挂载但目标已消失(判失效)";
3. 使"自挂自、未卸载、共享被删"场景下弹出"快捷方式已被更改或移动"对话框而非"打开方式";

=====================================

1. fixed resolveSymlink blanket-exempting all SMB targets from broken-link check;
2. replaced with DeviceUtils::isUnmountSamba to distinguish "unmounted (defer to mount flow)" from "mounted but target gone (broken)";
3. self-mount not-unmounted deleted-share now shows "shortcut changed or moved" dialog instead of "open with";

Log: 修复创建链接后删除共享文件夹再访问链接时无错误提示的问题，区分SMB未挂载与已挂载但目标消失两种情况

PMS: BUG-372593
Bug: https://pms.uniontech.com/bug-view-372593.html

## Summary by Sourcery

Bug Fixes:
- Show the broken-link dialog instead of the open-with dialog when a self-mounted, still-mounted SMB share target has been deleted by distinguishing unmounted shares from mounted-but-missing targets in symlink resolution.