### PR TITLE
test: update function coverage reached 50.1%.

### DIFF
--- a/autotests/libs/dfm-base/test_abstractfilewatcher.cpp
+++ b/autotests/libs/dfm-base/test_abstractfilewatcher.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractfilewatcher.cpp
+ * @brief Unit tests for AbstractFileWatcher default implementations.
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QDir>
+#include <QTemporaryDir>
+
+#include <dfm-base/interfaces/abstractfilewatcher.h>
+#include <dfm-base/interfaces/private/abstractfilewatcher_p.h>
+#include <dfm-base/base/urlroute.h>
+
+using namespace dfmbase;
+
+class TestWatcherPrivate : public AbstractFileWatcherPrivate
+{
+public:
+    explicit TestWatcherPrivate(const QUrl &url, AbstractFileWatcher *q)
+        : AbstractFileWatcherPrivate(url, q) { }
+
+    bool start() override
+    {
+        return true;
+    }
+    bool stop() override
+    {
+        return true;
+    }
+};
+
+class TestFileWatcher : public AbstractFileWatcher
+{
+public:
+    explicit TestFileWatcher(const QUrl &url, QObject *parent = nullptr)
+        : AbstractFileWatcher(new TestWatcherPrivate(url, this), parent) { }
+};
+
+class AbstractFileWatcherTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+};
+
+TEST_F(AbstractFileWatcherTest, UrlReturnsWatchedUrl)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    TestFileWatcher watcher(url);
+    EXPECT_EQ(watcher.url().scheme(), url.scheme());
+}
+
+TEST_F(AbstractFileWatcherTest, StartStopRestart)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    TestFileWatcher watcher(url);
+    EXPECT_TRUE(watcher.startWatcher());
+    EXPECT_TRUE(watcher.stopWatcher());
+    // restartWatcher = stopWatcher() && startWatcher(); both true here
+    EXPECT_TRUE(watcher.restartWatcher());
+}
+
+TEST_F(AbstractFileWatcherTest, StopWhenNotStartedReturnsTrue)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    TestFileWatcher watcher(url);
+    EXPECT_TRUE(watcher.stopWatcher());
+}
+
+TEST_F(AbstractFileWatcherTest, StartIdempotent)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    TestFileWatcher watcher(url);
+    EXPECT_TRUE(watcher.startWatcher());
+    EXPECT_TRUE(watcher.startWatcher());   // already started
+}
+
+TEST_F(AbstractFileWatcherTest, SetEnabledSubfileWatcherNoCrash)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    TestFileWatcher watcher(url);
+    EXPECT_NO_FATAL_FAILURE({ watcher.setEnabledSubfileWatcher(QUrl("file:///tmp/sub"), true); });
+}
+
+TEST_F(AbstractFileWatcherTest, CacheInfoConnectSizeManipulation)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    TestFileWatcher watcher(url);
+    EXPECT_EQ(watcher.getCacheInfoConnectSize(), 0);
+    watcher.addCacheInfoConnectSize();
+    EXPECT_EQ(watcher.getCacheInfoConnectSize(), 1);
+    watcher.reduceCacheInfoConnectSize();
+    EXPECT_EQ(watcher.getCacheInfoConnectSize(), 0);
+}
+
+TEST_F(AbstractFileWatcherTest, NotifyMethodsNoCrash)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    TestFileWatcher watcher(url);
+    EXPECT_NO_FATAL_FAILURE({ watcher.notifyFileAdded(QUrl("file:///tmp/new")); });
+    EXPECT_NO_FATAL_FAILURE({ watcher.notifyFileChanged(QUrl("file:///tmp/changed")); });
+    EXPECT_NO_FATAL_FAILURE({ watcher.notifyFileDeleted(QUrl("file:///tmp/gone")); });
+}
+
+TEST_F(AbstractFileWatcherTest, FormatPathStatic)
+{
+    QString p = AbstractFileWatcherPrivate::formatPath("/tmp/some_path/");
+    EXPECT_FALSE(p.endsWith("/"));
+    EXPECT_EQ(p, QString("/tmp/some_path"));
+}

--- a/autotests/libs/dfm-base/test_abstractjobhandler.cpp
+++ b/autotests/libs/dfm-base/test_abstractjobhandler.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractjobhandler.cpp
+ * @brief Unit tests for AbstractJobHandler default implementations.
+ *
+ * Note: QMap<quint8, QVariant> (JobInfoPointer's value type) triggers a Qt6
+ * static assertion when fully instantiated in some contexts, so we avoid
+ * creating JobInfoPointer objects and only exercise the no-arg / primitive
+ * default methods.
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/interfaces/abstractjobhandler.h>
+
+using namespace dfmbase;
+
+class TestJobHandler : public AbstractJobHandler
+{
+public:
+    explicit TestJobHandler(QObject *parent = nullptr)
+        : AbstractJobHandler(parent) { }
+};
+
+TEST(AbstractJobHandlerTest, DefaultCurrentJobProcessIsZero)
+{
+    TestJobHandler handler;
+    EXPECT_EQ(handler.currentJobProcess(), 0.0);
+}
+
+TEST(AbstractJobHandlerTest, DefaultTotalSizeIsZero)
+{
+    TestJobHandler handler;
+    EXPECT_EQ(handler.totalSize(), 0);
+}
+
+TEST(AbstractJobHandlerTest, DefaultCurrentSizeIsZero)
+{
+    TestJobHandler handler;
+    EXPECT_EQ(handler.currentSize(), 0);
+}
+
+TEST(AbstractJobHandlerTest, DefaultCurrentStateIsUnknown)
+{
+    TestJobHandler handler;
+    EXPECT_EQ(handler.currentState(), AbstractJobHandler::JobState::kUnknowState);
+}
+
+TEST(AbstractJobHandlerTest, SetSignalConnectFinished)
+{
+    TestJobHandler handler;
+    EXPECT_NO_FATAL_FAILURE({ handler.setSignalConnectFinished(); });
+}
+
+TEST(AbstractJobHandlerTest, OperateTaskJobNoCrash)
+{
+    TestJobHandler handler;
+    EXPECT_NO_FATAL_FAILURE({
+        handler.operateTaskJob(AbstractJobHandler::SupportAction::kStartAction);
+    });
+}
+
+TEST(AbstractJobHandlerTest, StartCallsOperateTaskJob)
+{
+    TestJobHandler handler;
+    EXPECT_NO_FATAL_FAILURE({ handler.start(); });
+}

--- a/autotests/libs/dfm-base/test_abstractmenuscene.cpp
+++ b/autotests/libs/dfm-base/test_abstractmenuscene.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractmenuscene.cpp
+ * @brief Unit tests for AbstractMenuScene default implementations.
+ */
+
+#include <gtest/gtest.h>
+#include <QMenu>
+#include <QAction>
+#include <QVariantHash>
+
+#include <dfm-base/interfaces/abstractmenuscene.h>
+
+using namespace dfmbase;
+
+class TestMenuScene : public AbstractMenuScene
+{
+public:
+    explicit TestMenuScene(const QString &n, QObject *parent = nullptr)
+        : AbstractMenuScene(parent), m_name(n) { }
+    QString name() const override { return m_name; }
+    QString m_name;
+};
+
+TEST(AbstractMenuSceneTest, InitializeReturnsTrueWithEmptyParams)
+{
+    TestMenuScene scene("test");
+    QVariantHash params;
+    EXPECT_TRUE(scene.initialize(params));
+}
+
+TEST(AbstractMenuSceneTest, CreateWithNullParent)
+{
+    TestMenuScene scene("test");
+    QMenu menu;
+    EXPECT_NO_FATAL_FAILURE({ (void)scene.create(&menu); });
+}
+
+TEST(AbstractMenuSceneTest, UpdateStateNoCrash)
+{
+    TestMenuScene scene("test");
+    QMenu menu;
+    EXPECT_NO_FATAL_FAILURE({ scene.updateState(&menu); });
+}
+
+TEST(AbstractMenuSceneTest, TriggeredReturnsFalseWithNoChildren)
+{
+    TestMenuScene scene("test");
+    QAction action("act");
+    EXPECT_FALSE(scene.triggered(&action));
+}
+
+TEST(AbstractMenuSceneTest, ActionFilterReturnsFalse)
+{
+    TestMenuScene scene("test");
+    QAction action("act");
+    EXPECT_FALSE(scene.actionFilter(&scene, &action));
+}
+
+TEST(AbstractMenuSceneTest, SceneReturnsNullptrWithNoChildren)
+{
+    TestMenuScene scene("test");
+    QAction action("act");
+    EXPECT_EQ(scene.scene(&action), nullptr);
+}
+
+TEST(AbstractMenuSceneTest, AddSubsceneSucceeds)
+{
+    TestMenuScene scene("parent");
+    auto *child = new TestMenuScene("child");
+    EXPECT_TRUE(scene.addSubscene(child));
+    EXPECT_FALSE(scene.subscene().isEmpty());
+}
+
+TEST(AbstractMenuSceneTest, AddSubsceneNullReturnsFalse)
+{
+    TestMenuScene scene("parent");
+    EXPECT_FALSE(scene.addSubscene(nullptr));
+}
+
+TEST(AbstractMenuSceneTest, RemoveSubscene)
+{
+    TestMenuScene scene("parent");
+    auto *child = new TestMenuScene("child");
+    scene.addSubscene(child);
+    EXPECT_NO_FATAL_FAILURE({ scene.removeSubscene(child); });
+    EXPECT_TRUE(scene.subscene().isEmpty());
+}
+
+TEST(AbstractMenuSceneTest, SetSubscene)
+{
+    TestMenuScene scene("parent");
+    auto *c1 = new TestMenuScene("c1");
+    auto *c2 = new TestMenuScene("c2");
+    QList<AbstractMenuScene *> subs { c1, c2 };
+    EXPECT_NO_FATAL_FAILURE({ scene.setSubscene(subs); });
+    EXPECT_EQ(scene.subscene().size(), 2);
+}
+
+TEST(AbstractMenuSceneTest, FilterActionBySubsceneHelperNull)
+{
+    QAction action("act");
+    EXPECT_FALSE(filterActionBySubscene(nullptr, &action));
+}

--- a/autotests/libs/dfm-base/test_applaunchutils.cpp
+++ b/autotests/libs/dfm-base/test_applaunchutils.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_applaunchutils.cpp
+ * @brief Unit tests for AppLaunchUtils (applaunchutils.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+
+#include <dfm-base/utils/applaunchutils.h>
+
+using namespace dfmbase;
+
+TEST(AppLaunchUtilsTest, InstanceReturnsRef)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)&AppLaunchUtils::instance(); });
+}
+
+TEST(AppLaunchUtilsTest, AddCustomStrategyAndLaunch)
+{
+    auto &utils = AppLaunchUtils::instance();
+    bool called = false;
+    AppLaunchFunc strategy = [&called](const QString &, const QStringList &) -> bool {
+        called = true;
+        return true;
+    };
+    utils.addStrategy(strategy, 0);
+
+    bool ok = utils.launchApp("org.test.app.desktop", { "file:///tmp/x.txt" });
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(called);
+}
+
+TEST(AppLaunchUtilsTest, LaunchAppNoStrategyFails)
+{
+    // A strategy that always fails with a non-existent desktop file
+    auto &utils = AppLaunchUtils::instance();
+    bool ok = utils.launchApp("/no/such/app.desktop", {});
+    // may succeed if an earlier strategy returns true, but generally false here
+    EXPECT_NO_FATAL_FAILURE({ (void)ok; });
+}
+
+TEST(AppLaunchUtilsTest, DefaultLaunchAppNonExistent)
+{
+    auto &utils = AppLaunchUtils::instance();
+    EXPECT_NO_FATAL_FAILURE({ (void)utils.defaultLaunchApp("/no/such/app.desktop", {}); });
+}
+
+TEST(AppLaunchUtilsTest, ExecuteCommandNonExistentProgram)
+{
+    auto &utils = AppLaunchUtils::instance();
+    bool ok = utils.executeCommand("/no/such/program/xyz", { "arg1" }, "shortcut");
+    EXPECT_FALSE(ok);
+}

--- a/autotests/libs/dfm-base/test_application.cpp
+++ b/autotests/libs/dfm-base/test_application.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_application.cpp
+ * @brief Unit tests for Application static config API (application.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QVariant>
+#include <QUrl>
+#include <QString>
+
+#include <dfm-base/base/application/application.h>
+
+using namespace dfmbase;
+
+TEST(ApplicationTest, InstanceReturnsPointer)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::instance(); });
+}
+
+TEST(ApplicationTest, AppObtuselySettingReturnsPointer)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::appObtuselySetting(); });
+}
+
+TEST(ApplicationTest, GenericObtuselySettingReturnsPointer)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::genericObtuselySetting(); });
+}
+
+TEST(ApplicationTest, GenericSettingReturnsPointer)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::genericSetting(); });
+}
+
+TEST(ApplicationTest, AppSettingReturnsPointer)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::appSetting(); });
+}
+
+TEST(ApplicationTest, DataPersistenceReturnsPointer)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::dataPersistence(); });
+}
+
+TEST(ApplicationTest, AppAttributeReturnsValid)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        (void)Application::appAttribute(Application::kIconSizeLevel);
+    });
+}
+
+TEST(ApplicationTest, AppUrlAttributeReturnsValid)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        (void)Application::appUrlAttribute(Application::kUrlOfNewWindow);
+    });
+}
+
+TEST(ApplicationTest, SetAppAttributeNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        Application::setAppAttribute(Application::kIconSizeLevel, QVariant(2));
+    });
+}
+
+TEST(ApplicationTest, SyncAppAttributeNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::syncAppAttribute(); });
+}
+
+TEST(ApplicationTest, GenericAttributeReturnsValid)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        (void)Application::genericAttribute(Application::kPreviewTextFile);
+    });
+}
+
+TEST(ApplicationTest, SetGenericAttributeNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        Application::setGenericAttribute(Application::kShowedHiddenFiles, QVariant(true));
+    });
+}
+
+TEST(ApplicationTest, SyncGenericAttributeNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)Application::syncGenericAttribute(); });
+}

--- a/autotests/libs/dfm-base/test_asyncfileinfo.cpp
+++ b/autotests/libs/dfm-base/test_asyncfileinfo.cpp
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_asyncfileinfo.cpp
+ * @brief Unit tests for AsyncFileInfo (asyncfileinfo.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QIcon>
+#include <QMutexLocker>
+#include <mutex>
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+using namespace dfmbase;
+
+class AsyncFileInfoTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+        filePath = rootPath + "/async.txt";
+        QFile f(filePath);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("async content");
+        f.close();
+        url = QUrl::fromLocalFile(filePath);
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    QString filePath;
+    QUrl url;
+    static std::once_flag flag;
+};
+
+std::once_flag AsyncFileInfoTest::flag;
+
+TEST_F(AsyncFileInfoTest, ConstructAndQueryBasics)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.exists(); });
+    EXPECT_NO_FATAL_FAILURE({ info.refresh(); });
+    EXPECT_NO_FATAL_FAILURE({ info.cacheAttribute(DFMIO::DFileInfo::AttributeID::kStandardName, QVariant()); });
+}
+
+TEST_F(AsyncFileInfoTest, NameOfAllTypes)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({
+        (void)info.nameOf(FileInfo::FileNameInfoType::kFileName);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kBaseName);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kCompleteBaseName);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kCompleteSuffix);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kFileCopyName);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kIconName);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kGenericIconName);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kMimeTypeName);
+        (void)info.nameOf(FileInfo::FileNameInfoType::kFileNameOfRename);
+    });
+}
+
+TEST_F(AsyncFileInfoTest, PathOfAllTypes)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({
+        (void)info.pathOf(FileInfo::FilePathInfoType::kFilePath);
+        (void)info.pathOf(FileInfo::FilePathInfoType::kAbsoluteFilePath);
+        (void)info.pathOf(FileInfo::FilePathInfoType::kPath);
+        (void)info.pathOf(FileInfo::FilePathInfoType::kAbsolutePath);
+        (void)info.pathOf(FileInfo::FilePathInfoType::kSymLinkTarget);
+        (void)info.pathOf(FileInfo::FilePathInfoType::kCanonicalPath);
+    });
+}
+
+TEST_F(AsyncFileInfoTest, UrlOfAllTypes)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({
+        (void)info.urlOf(FileInfo::FileUrlInfoType::kUrl);
+        (void)info.urlOf(FileInfo::FileUrlInfoType::kRedirectedFileUrl);
+        (void)info.urlOf(FileInfo::FileUrlInfoType::kOriginalUrl);
+        (void)info.urlOf(FileInfo::FileUrlInfoType::kParentUrl);
+    });
+}
+
+TEST_F(AsyncFileInfoTest, IsAttributesAllTypes)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({
+        (void)info.isAttributes(FileInfo::FileIsType::kIsFile);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsDir);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsReadable);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsWritable);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsHidden);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsSymLink);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsExecutable);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsRoot);
+        (void)info.isAttributes(FileInfo::FileIsType::kIsBundle);
+    });
+}
+
+TEST_F(AsyncFileInfoTest, CanAttributesAllTypes)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({
+        (void)info.canAttributes(FileInfo::FileCanType::kCanDelete);
+        (void)info.canAttributes(FileInfo::FileCanType::kCanTrash);
+        (void)info.canAttributes(FileInfo::FileCanType::kCanRename);
+        (void)info.canAttributes(FileInfo::FileCanType::kCanHidden);
+        (void)info.canAttributes(FileInfo::FileCanType::kCanMoveOrCopy);
+        (void)info.canAttributes(FileInfo::FileCanType::kCanDrop);
+    });
+}
+
+TEST_F(AsyncFileInfoTest, ExtendAttributesAllTypes)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kFileLocalDevice);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kFileCdRomDevice);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kSizeFormat);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kInode);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kOwner);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kGroup);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kFileIsHid);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kOwnerId);
+        (void)info.extendAttributes(FileInfo::FileExtendedInfoType::kGroupId);
+    });
+}
+
+TEST_F(AsyncFileInfoTest, PermissionAndSizeAndTime)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.permission(QFileDevice::ReadOwner); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.permissions(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.size(); });
+    EXPECT_NO_FATAL_FAILURE({
+        (void)info.timeOf(FileInfo::FileTimeType::kCreateTime);
+        (void)info.timeOf(FileInfo::FileTimeType::kBirthTime);
+        (void)info.timeOf(FileInfo::FileTimeType::kMetadataChangeTime);
+        (void)info.timeOf(FileInfo::FileTimeType::kLastModified);
+        (void)info.timeOf(FileInfo::FileTimeType::kLastRead);
+        (void)info.timeOf(FileInfo::FileTimeType::kDeletionTime);
+        (void)info.timeOf(FileInfo::FileTimeType::kLastModifiedSecond);
+    });
+}
+
+TEST_F(AsyncFileInfoTest, CountChildFileAndDisplayAndExtra)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.countChildFile(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.countChildFileAsync(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.displayOf(FileInfo::DisplayInfoType::kFileDisplayName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.displayOf(FileInfo::DisplayInfoType::kSizeDisplayName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.extraProperties(); });
+}
+
+TEST_F(AsyncFileInfoTest, ViewOfTip)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.viewOfTip(FileInfo::ViewType::kEmptyDir); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.viewOfTip(FileInfo::ViewType::kLoading); });
+}
+
+TEST_F(AsyncFileInfoTest, ExtendedAttributesAndCache)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ info.setExtendedAttributes(FileInfo::FileExtendedInfoType::kOwner, QVariant("root")); });
+    EXPECT_NO_FATAL_FAILURE({ info.updateAttributes({}); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.asyncQueryDfmFileInfo(0, nullptr, nullptr); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.errorCodeFromDfmio(); });
+}
+
+TEST_F(AsyncFileInfoTest, NotifyUrls)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.notifyUrls(); });
+    EXPECT_NO_FATAL_FAILURE({ info.setNotifyUrl(QUrl("file:///tmp/x"), "ptr"); });
+    EXPECT_NO_FATAL_FAILURE({ info.removeNotifyUrl(QUrl("file:///tmp/x"), "ptr"); });
+}
+
+TEST_F(AsyncFileInfoTest, GetUrlByType)
+{
+    AsyncFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.getUrlByType(FileInfo::FileUrlInfoType::kGetUrlByChildFileName, "child"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.fileType(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info.supportedOfAttributes(FileInfo::SupportType::kDrag); });
+}

--- a/autotests/libs/dfm-base/test_chinese2pinyin.cpp
+++ b/autotests/libs/dfm-base/test_chinese2pinyin.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_chinese2pinyin.cpp
+ * @brief Unit tests for Pinyin::Chinese2Pinyin (chinese2pinyin.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+
+#include <dfm-base/utils/chinese2pinyin.h>
+
+using namespace Pinyin;
+
+TEST(Chinese2PinyinTest, AsciiPassThrough)
+{
+    QString result = Chinese2Pinyin("hello");
+    EXPECT_EQ(result, QString("hello"));
+}
+
+TEST(Chinese2PinyinTest, EmptyString)
+{
+    QString result = Chinese2Pinyin("");
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(Chinese2PinyinTest, ChineseCharacterConverted)
+{
+    QString result = Chinese2Pinyin(QString::fromUtf8("中"));
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_NE(result, QString::fromUtf8("中"));
+}
+
+TEST(Chinese2PinyinTest, MixedContent)
+{
+    QString result = Chinese2Pinyin(QString::fromUtf8("a中b"));
+    EXPECT_TRUE(result.startsWith('a'));
+    EXPECT_TRUE(result.endsWith('b'));
+    EXPECT_GT(result.size(), 2);
+}
+
+TEST(Chinese2PinyinTest, NonDictCharPassesThrough)
+{
+    // Emoji / rare chars not in the pinyin dict should pass through unchanged.
+    QString emoji = QString::fromUtf8("\xF0\x9F\x98\x80");
+    QString result = Chinese2Pinyin(emoji);
+    EXPECT_EQ(result, emoji);
+}

--- a/autotests/libs/dfm-base/test_clipboard.cpp
+++ b/autotests/libs/dfm-base/test_clipboard.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_clipboard.cpp
+ * @brief Unit tests for ClipBoard (clipboard.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QGuiApplication>
+#include <QClipboard>
+#include <QMimeData>
+#include <QUrl>
+#include <QList>
+
+#include <dfm-base/utils/clipboard.h>
+
+using namespace dfmbase;
+
+TEST(ClipBoardTest, InstanceReturnsNonNull)
+{
+    EXPECT_NE(ClipBoard::instance(), nullptr);
+}
+
+TEST(ClipBoardTest, SetUrlsToClipboardCopy)
+{
+    QList<QUrl> urls { QUrl("file:///tmp/a"), QUrl("file:///tmp/b") };
+    EXPECT_NO_FATAL_FAILURE({
+        ClipBoard::setUrlsToClipboard(urls, ClipBoard::ClipboardAction::kCopyAction);
+    });
+}
+
+TEST(ClipBoardTest, SetUrlsToClipboardCut)
+{
+    QList<QUrl> urls { QUrl("file:///tmp/c") };
+    EXPECT_NO_FATAL_FAILURE({
+        ClipBoard::setUrlsToClipboard(urls, ClipBoard::ClipboardAction::kCutAction);
+    });
+}
+
+TEST(ClipBoardTest, ClipboardFileUrlList)
+{
+    QList<QUrl> urls { QUrl("file:///tmp/clip_test") };
+    ClipBoard::setUrlsToClipboard(urls, ClipBoard::ClipboardAction::kCopyAction);
+    EXPECT_NO_FATAL_FAILURE({ (void)ClipBoard::instance()->clipboardFileUrlList(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)ClipBoard::instance()->clipboardAction(); });
+}
+
+TEST(ClipBoardTest, RemoveUrls)
+{
+    QList<QUrl> urls { QUrl("file:///tmp/r1"), QUrl("file:///tmp/r2") };
+    ClipBoard::setUrlsToClipboard(urls, ClipBoard::ClipboardAction::kCopyAction);
+    EXPECT_NO_FATAL_FAILURE({
+        ClipBoard::instance()->removeUrls(QList<QUrl> { QUrl("file:///tmp/r1") });
+    });
+}
+
+TEST(ClipBoardTest, ReplaceClipboardUrl)
+{
+    QList<QUrl> urls { QUrl("file:///tmp/old") };
+    ClipBoard::setUrlsToClipboard(urls, ClipBoard::ClipboardAction::kCopyAction);
+    EXPECT_NO_FATAL_FAILURE({
+        ClipBoard::instance()->replaceClipboardUrl(QUrl("file:///tmp/old"), QUrl("file:///tmp/new"));
+    });
+}
+
+TEST(ClipBoardTest, SetCurUrlToClipboardForRemote)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        ClipBoard::setCurUrlToClipboardForRemote(QUrl("file:///tmp/remote"));
+    });
+}
+
+TEST(ClipBoardTest, ClearClipboard)
+{
+    EXPECT_NO_FATAL_FAILURE({ ClipBoard::clearClipboard(); });
+}
+
+TEST(ClipBoardTest, SupportCut)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)ClipBoard::supportCut(); });
+}

--- a/autotests/libs/dfm-base/test_configsynchronizer.cpp
+++ b/autotests/libs/dfm-base/test_configsynchronizer.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_configsynchronizer.cpp
+ * @brief Unit tests for ConfigSynchronizer (configsynchronizer.cpp)
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/base/configs/configsynchronizer.h>
+
+using namespace dfmbase;
+
+TEST(ConfigSynchronizerTest, InstanceReturnsPointer)
+{
+    EXPECT_NE(ConfigSynchronizer::instance(), nullptr);
+}
+
+TEST(ConfigSynchronizerTest, WatchChangeInvalidPairReturnsFalse)
+{
+    SyncPair pair;   // default-constructed: type == kNone -> isValid() false
+    EXPECT_FALSE(ConfigSynchronizer::instance()->watchChange(pair));
+}

--- a/autotests/libs/dfm-base/test_desktopfile.cpp
+++ b/autotests/libs/dfm-base/test_desktopfile.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_desktopfile.cpp
+ * @brief Unit tests for DesktopFile (desktopfile.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryFile>
+#include <QFile>
+#include <QTextStream>
+#include <QDir>
+
+#include <dfm-base/utils/desktopfile.h>
+
+using namespace dfmbase;
+
+namespace {
+QString writeDesktop(const QString &path, const QString &content)
+{
+    QFile f(path);
+    f.open(QIODevice::WriteOnly | QIODevice::Text);
+    QTextStream out(&f);
+    out << content;
+    f.close();
+    return path;
+}
+}   // namespace
+
+TEST(DesktopFileTest, EmptyFileNameYieldsDefaults)
+{
+    DesktopFile df("");
+    EXPECT_EQ(df.desktopFileName(), QString(""));
+    EXPECT_EQ(df.desktopPureFileName(), QString(""));
+    // type is left default-constructed (empty) when file is not loaded
+    EXPECT_EQ(df.desktopType(), QString(""));
+    EXPECT_TRUE(df.desktopCategories().isEmpty());
+    EXPECT_TRUE(df.desktopMimeType().isEmpty());
+    EXPECT_FALSE(df.isNoShow());
+}
+
+TEST(DesktopFileTest, NonExistentFileYieldsDefaults)
+{
+    DesktopFile df("/no/such/desktop/file.desktop");
+    EXPECT_EQ(df.desktopType(), QString(""));
+}
+
+TEST(DesktopFileTest, ParsesFullDesktopEntry)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+
+    writeDesktop(path,
+                 "[Desktop Entry]\n"
+                 "Name=MyApp\n"
+                 "Exec=myapp %f\n"
+                 "Icon=myapp-icon\n"
+                 "Type=Application\n"
+                 "Categories=Utility;System;\n"
+                 "MimeType=text/plain;image/png;\n"
+                 "X-Deepin-AppID=myapp\n"
+                 "X-Deepin-Vendor=deepin\n"
+                 "NoDisplay=true\n");
+
+    DesktopFile df(path);
+    EXPECT_EQ(df.desktopExec(), QString("myapp %f"));
+    EXPECT_EQ(df.desktopIcon(), QString("myapp-icon"));
+    EXPECT_EQ(df.desktopType(), QString("Application"));
+    EXPECT_EQ(df.desktopDeepinId(), QString("myapp"));
+    EXPECT_EQ(df.desktopDeepinVendor(), QString("deepin"));
+    EXPECT_TRUE(df.desktopCategories().contains("Utility"));
+    EXPECT_TRUE(df.desktopCategories().contains("System"));
+    EXPECT_TRUE(df.desktopMimeType().contains("text/plain"));
+    EXPECT_TRUE(df.desktopMimeType().contains("image/png"));
+}
+
+TEST(DesktopFileTest, IsNoShowWhenHidden)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writeDesktop(path, "[Desktop Entry]\nName=H\nHidden=true\n");
+
+    DesktopFile df(path);
+    EXPECT_TRUE(df.isNoShow());
+}
+
+TEST(DesktopFileTest, IsNoShowWhenNoDisplayWithoutMime)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writeDesktop(path, "[Desktop Entry]\nName=N\nNoDisplay=true\n");
+
+    DesktopFile df(path);
+    EXPECT_TRUE(df.isNoShow());
+}
+
+TEST(DesktopFileTest, NotNoShowWhenNoDisplayWithMime)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writeDesktop(path,
+                 "[Desktop Entry]\nName=N\nNoDisplay=true\nMimeType=text/plain;\n");
+
+    DesktopFile df(path);
+    EXPECT_FALSE(df.isNoShow());
+}
+
+TEST(DesktopFileTest, DesktopPureFileNameStripsPathAndExtension)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writeDesktop(path, "[Desktop Entry]\nName=X\n");
+
+    DesktopFile df(path);
+    QString pure = df.desktopPureFileName();
+    EXPECT_FALSE(pure.endsWith(".desktop"));
+    EXPECT_FALSE(pure.contains("/"));
+}
+
+TEST(DesktopFileTest, DesktopDisplayNamePrefersGenericNameForDeepin)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writeDesktop(path,
+                 "[Desktop Entry]\nName=MyApp\nGenericName=Generic App\n"
+                 "X-Deepin-Vendor=deepin\n");
+
+    DesktopFile df(path);
+    EXPECT_EQ(df.desktopDisplayName(), QString("Generic App"));
+}
+
+TEST(DesktopFileTest, DesktopDisplayNameFallsBackToLocalName)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writeDesktop(path, "[Desktop Entry]\nName=MyApp\n");
+
+    DesktopFile df(path);
+    EXPECT_EQ(df.desktopDisplayName(), df.desktopLocalName());
+}
+
+TEST(DesktopFileTest, CategoriesEmptyWhenAbsent)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writeDesktop(path, "[Desktop Entry]\nName=N\n");
+
+    DesktopFile df(path);
+    EXPECT_TRUE(df.desktopCategories().isEmpty());
+}

--- a/autotests/libs/dfm-base/test_desktopfileinfo.cpp
+++ b/autotests/libs/dfm-base/test_desktopfileinfo.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_desktopfileinfo.cpp
+ * @brief Unit tests for DesktopFileInfo (desktopfileinfo.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QTextStream>
+#include <QDir>
+#include <QUrl>
+#include <QIcon>
+#include <mutex>
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/desktopfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+using namespace dfmbase;
+
+class DesktopFileInfoTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QString makeDesktopFile(const QString &name, const QString &exec,
+                            const QString &icon, const QString &type = "Application",
+                            const QString &deepinId = "", const QString &deepinVendor = "")
+    {
+        QString path = rootPath + "/" + name;
+        QFile f(path);
+        if (!f.open(QIODevice::WriteOnly))
+            return {};
+        QTextStream ts(&f);
+        ts << "[Desktop Entry]\n";
+        ts << "Name=" << name.section('.', 0, 0) << "\n";
+        ts << "GenericName=" << name.section('.', 0, 0) << " Generic\n";
+        ts << "Exec=" << exec << "\n";
+        ts << "Icon=" << icon << "\n";
+        ts << "Type=" << type << "\n";
+        ts << "Categories=Utility;\n";
+        if (!deepinId.isEmpty())
+            ts << "X-Deepin-AppID=" << deepinId << "\n";
+        if (!deepinVendor.isEmpty())
+            ts << "X-Deepin-Vendor=" << deepinVendor << "\n";
+        f.close();
+        return path;
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    static std::once_flag flag;
+};
+
+std::once_flag DesktopFileInfoTest::flag;
+
+TEST_F(DesktopFileInfoTest, ParseStandardDesktopFile)
+{
+    QString path = makeDesktopFile("myapp.desktop", "myapp", "myapp-icon", "Application",
+                                   "dde-test", "deepin");
+    QUrl url = QUrl::fromLocalFile(path);
+
+    auto real = InfoFactory::create<FileInfo>(url);
+    ASSERT_NE(real, nullptr);
+    real->initQuerier();
+
+    DesktopFileInfo desktop(url, real);
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.desktopName(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.desktopExec(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.desktopIconName(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.desktopType(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.desktopCategories(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.canTag(); });
+}
+
+TEST_F(DesktopFileInfoTest, NameOfAndDisplayOf)
+{
+    QString path = makeDesktopFile("calc.desktop", "calc", "calc", "Application");
+    QUrl url = QUrl::fromLocalFile(path);
+    auto real = InfoFactory::create<FileInfo>(url);
+    real->initQuerier();
+
+    DesktopFileInfo desktop(url, real);
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.nameOf(FileInfo::FileNameInfoType::kFileNameOfRename); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.nameOf(FileInfo::FileNameInfoType::kBaseNameOfRename); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.nameOf(FileInfo::FileNameInfoType::kSuffixOfRename); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.nameOf(FileInfo::FileNameInfoType::kFileCopyName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.nameOf(FileInfo::FileNameInfoType::kIconName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.nameOf(FileInfo::FileNameInfoType::kGenericIconName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.nameOf(FileInfo::FileNameInfoType::kFileName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.displayOf(FileInfo::DisplayInfoType::kFileDisplayName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.displayOf(FileInfo::DisplayInfoType::kSizeDisplayName); });
+}
+
+TEST_F(DesktopFileInfoTest, CanAttributesForComputerEntry)
+{
+    QString path = makeDesktopFile("computer.desktop", "dde-computer", "computer",
+                                   "Application", "dde-computer", "deepin");
+    QUrl url = QUrl::fromLocalFile(path);
+    auto real = InfoFactory::create<FileInfo>(url);
+    real->initQuerier();
+
+    DesktopFileInfo desktop(url, real);
+    EXPECT_FALSE(desktop.canAttributes(FileInfo::FileCanType::kCanMoveOrCopy));
+    EXPECT_FALSE(desktop.canAttributes(FileInfo::FileCanType::kCanDrop));
+    EXPECT_FALSE(desktop.canTag());
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.supportedOfAttributes(FileInfo::SupportType::kDrag); });
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.supportedOfAttributes(FileInfo::SupportType::kDrop); });
+}
+
+TEST_F(DesktopFileInfoTest, CanAttributesForTrashEntry)
+{
+    QString path = makeDesktopFile("trash.desktop", "dde-trash", "user-trash",
+                                   "Application", "dde-trash", "deepin");
+    QUrl url = QUrl::fromLocalFile(path);
+    auto real = InfoFactory::create<FileInfo>(url);
+    real->initQuerier();
+
+    DesktopFileInfo desktop(url, real);
+    EXPECT_FALSE(desktop.canAttributes(FileInfo::FileCanType::kCanMoveOrCopy));
+    EXPECT_FALSE(desktop.canTag());
+    EXPECT_EQ(desktop.supportedOfAttributes(FileInfo::SupportType::kDrag), Qt::IgnoreAction);
+}
+
+TEST_F(DesktopFileInfoTest, FileIconAndRefresh)
+{
+    QString path = makeDesktopFile("icon.desktop", "iconapp", "iconapp", "Application");
+    QUrl url = QUrl::fromLocalFile(path);
+    auto real = InfoFactory::create<FileInfo>(url);
+    real->initQuerier();
+
+    DesktopFileInfo desktop(url, real);
+    EXPECT_NO_FATAL_FAILURE({ (void)desktop.fileIcon(); });
+    EXPECT_NO_FATAL_FAILURE({ desktop.refresh(); });
+    EXPECT_NO_FATAL_FAILURE({ desktop.updateAttributes({}); });
+}
+
+TEST_F(DesktopFileInfoTest, DesktopFileInfoStatic)
+{
+    QString path = makeDesktopFile("static.desktop", "staticapp", "static", "Application");
+    QUrl url = QUrl::fromLocalFile(path);
+    EXPECT_NO_FATAL_FAILURE({ (void)DesktopFileInfo::desktopFileInfo(url); });
+
+    auto info = InfoFactory::create<FileInfo>(url);
+    ASSERT_NE(info, nullptr);
+    EXPECT_NO_FATAL_FAILURE({ (void)DesktopFileInfo::convert(info); });
+}

--- a/autotests/libs/dfm-base/test_deviceutils.cpp
+++ b/autotests/libs/dfm-base/test_deviceutils.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_deviceutils.cpp
+ * @brief Unit tests for DeviceUtils (deviceutils.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QVariantMap>
+#include <QVariantHash>
+#include <QUrl>
+#include <QDir>
+
+#include <dfm-base/base/device/deviceutils.h>
+
+using namespace dfmbase;
+
+TEST(DeviceUtilsTest, FormatOpticalMediaTypeKnown)
+{
+    EXPECT_EQ(DeviceUtils::formatOpticalMediaType("optical_cd"), QString("CD-ROM"));
+    EXPECT_EQ(DeviceUtils::formatOpticalMediaType("optical_dvd"), QString("DVD-ROM"));
+    EXPECT_EQ(DeviceUtils::formatOpticalMediaType("optical_bd"), QString("BD-ROM"));
+}
+
+TEST(DeviceUtilsTest, FormatOpticalMediaTypeUnknown)
+{
+    EXPECT_EQ(DeviceUtils::formatOpticalMediaType("not_a_media"), QString());
+}
+
+TEST(DeviceUtilsTest, NameOfSizeBytes)
+{
+    QString name = DeviceUtils::nameOfSize(512);
+    EXPECT_FALSE(name.isEmpty());
+    EXPECT_TRUE(name.contains("B"));
+}
+
+TEST(DeviceUtilsTest, NameOfSizeGigabytes)
+{
+    QString name = DeviceUtils::nameOfSize(5LL * 1024 * 1024 * 1024);
+    EXPECT_FALSE(name.isEmpty());
+    EXPECT_TRUE(name.contains("GB"));
+}
+
+TEST(DeviceUtilsTest, NameOfDefaultWithLabel)
+{
+    QString name = DeviceUtils::nameOfDefault("MyDisk", 1024);
+    EXPECT_EQ(name, QString("MyDisk"));
+}
+
+TEST(DeviceUtilsTest, NameOfDefaultWithoutLabel)
+{
+    QString name = DeviceUtils::nameOfDefault("", 1024);
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(DeviceUtilsTest, IsSystemDiskByMountPoint)
+{
+    QVariantHash info;
+    info["MountPoint"] = QDir::rootPath();
+    EXPECT_TRUE(DeviceUtils::isSystemDisk(info));
+}
+
+TEST(DeviceUtilsTest, IsSystemDiskNotRoot)
+{
+    QVariantHash info;
+    info["mountPoint"] = "/mnt/data";
+    EXPECT_FALSE(DeviceUtils::isSystemDisk(info));
+}
+
+TEST(DeviceUtilsTest, IsDataDiskRemovable)
+{
+    QVariantHash info;
+    info["Removable"] = true;
+    EXPECT_FALSE(DeviceUtils::isDataDisk(info));
+}
+
+TEST(DeviceUtilsTest, IsDataDiskByLabel)
+{
+    QVariantHash info;
+    info["IdLabel"] = "_dde_data";
+    EXPECT_TRUE(DeviceUtils::isDataDisk(info));
+}
+
+TEST(DeviceUtilsTest, BindPathTransformIdentity)
+{
+    QString path = "/some/random/path";
+    EXPECT_EQ(DeviceUtils::bindPathTransform(path, false), path);
+}

--- a/autotests/libs/dfm-base/test_deviceutils_ext.cpp
+++ b/autotests/libs/dfm-base/test_deviceutils_ext.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_deviceutils_ext.cpp
+ * @brief Extended unit tests for DeviceUtils pure-logic functions.
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QVariantMap>
+#include <QVariantHash>
+#include <QMap>
+
+#include <dfm-base/base/device/deviceutils.h>
+
+using namespace dfmbase;
+
+TEST(DeviceUtilsExtTest, FormatOpticalMediaTypeKnown)
+{
+    EXPECT_EQ(DeviceUtils::formatOpticalMediaType("optical_cd"), QString("CD-ROM"));
+    EXPECT_EQ(DeviceUtils::formatOpticalMediaType("optical_dvd"), QString("DVD-ROM"));
+    EXPECT_EQ(DeviceUtils::formatOpticalMediaType("optical_bd"), QString("BD-ROM"));
+}
+
+TEST(DeviceUtilsExtTest, FormatOpticalMediaTypeUnknown)
+{
+    EXPECT_TRUE(DeviceUtils::formatOpticalMediaType("no_such_media").isEmpty());
+}
+
+TEST(DeviceUtilsExtTest, ParseSmbInfoBasic)
+{
+    QString host, share;
+    QString port;
+    bool ok = DeviceUtils::parseSmbInfo(",server=myhost,share=share1", host, share, &port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(host, QString("myhost"));
+    EXPECT_EQ(share, QString("share1"));
+}
+
+TEST(DeviceUtilsExtTest, ParseSmbInfoWithPort)
+{
+    QString host, share;
+    QString port;
+    bool ok = DeviceUtils::parseSmbInfo(":port=445,server=h,share=s", host, share, &port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(host, QString("h"));
+    EXPECT_EQ(share, QString("s"));
+    EXPECT_EQ(port, QString("445"));
+}
+
+TEST(DeviceUtilsExtTest, ParseSmbInfoNoMatch)
+{
+    QString host, share;
+    bool ok = DeviceUtils::parseSmbInfo("not-a-valid-smb-path", host, share);
+    EXPECT_FALSE(ok);
+}
+
+TEST(DeviceUtilsExtTest, NameOfDefaultWithLabel)
+{
+    EXPECT_EQ(DeviceUtils::nameOfDefault("mydisk", 1024), QString("mydisk"));
+}
+
+TEST(DeviceUtilsExtTest, NameOfDefaultNoLabel)
+{
+    QString name = DeviceUtils::nameOfDefault("", 1024);
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(DeviceUtilsExtTest, NameOfSizeZero)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::nameOfSize(0); });
+}
+
+TEST(DeviceUtilsExtTest, NameOfSizeLarge)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::nameOfSize(1024ULL * 1024 * 1024 * 500); });
+}
+
+TEST(DeviceUtilsExtTest, IsSystemDiskRootMount)
+{
+    QVariantHash info;
+    info.insert("MountPoint", "/");
+    EXPECT_TRUE(DeviceUtils::isSystemDisk(info));
+}
+
+TEST(DeviceUtilsExtTest, IsSystemDiskNonRoot)
+{
+    QVariantHash info;
+    info.insert("MountPoint", "/data");
+    EXPECT_FALSE(DeviceUtils::isSystemDisk(info));
+}
+
+TEST(DeviceUtilsExtTest, IsSystemDiskRootRecover)
+{
+    QVariantHash info;
+    info.insert("MountPoint", "/sysroot");
+    info.insert("IdLabel", "RootA");
+    EXPECT_TRUE(DeviceUtils::isSystemDisk(info));
+}
+
+TEST(DeviceUtilsExtTest, IsDataDiskNonRemovable)
+{
+    QVariantHash info;
+    info.insert("MountPoint", "/data");
+    info.insert("IdLabel", "_dde_data");
+    EXPECT_TRUE(DeviceUtils::isDataDisk(info));
+}
+
+TEST(DeviceUtilsExtTest, IsDataDiskRootIsNotData)
+{
+    QVariantHash info;
+    info.insert("MountPoint", "/");
+    EXPECT_FALSE(DeviceUtils::isDataDisk(info));
+}
+
+TEST(DeviceUtilsExtTest, IsRemovableDeviceOptical)
+{
+    QVariantHash info;
+    info.insert("CanPowerOff", true);
+    info.insert("Drive", "some-drive-xyz");   // differs from (likely empty) root drive
+    EXPECT_TRUE(DeviceUtils::isRemovableDevice(info));
+}
+
+TEST(DeviceUtilsExtTest, IsRemovableDeviceNotPowerOff)
+{
+    QVariantHash info;
+    // CanPowerOff defaults to false -> not removable
+    EXPECT_FALSE(DeviceUtils::isRemovableDevice(info));
+}
+
+TEST(DeviceUtilsExtTest, BindPathTransformRootUnchanged)
+{
+    EXPECT_EQ(DeviceUtils::bindPathTransform("/", true), QString("/"));
+    EXPECT_EQ(DeviceUtils::bindPathTransform("relative", true), QString("relative"));
+}
+
+TEST(DeviceUtilsExtTest, IsSubpathOfDlnfs)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::isSubpathOfDlnfs("/some/path"); });
+}
+
+TEST(DeviceUtilsExtTest, IsMountPointOfDlnfs)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::isMountPointOfDlnfs("/some/path"); });
+}
+
+TEST(DeviceUtilsExtTest, GetLongestMountRootPath)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::getLongestMountRootPath("/some/path"); });
+}
+
+TEST(DeviceUtilsExtTest, ConvertSuitableDisplayNameVariantHash)
+{
+    QVariantHash info;
+    info.insert("IdLabel", "usb");
+    info.insert("SizeTotal", 0);
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::convertSuitableDisplayName(info); });
+}
+
+TEST(DeviceUtilsExtTest, NameOfAliasEmpty)
+{
+    EXPECT_TRUE(DeviceUtils::nameOfAlias("no-such-uuid").isEmpty());
+}
+
+TEST(DeviceUtilsExtTest, NameOfBuiltInDiskOpticalIsNot)
+{
+    QVariantMap info;
+    info.insert("OpticalDrive", true);
+    EXPECT_FALSE(DeviceUtils::isBuiltInDisk(info));
+}

--- a/autotests/libs/dfm-base/test_deviceutils_ext2.cpp
+++ b/autotests/libs/dfm-base/test_deviceutils_ext2.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_deviceutils_ext2.cpp
+ * @brief Second batch of DeviceUtils tests targeting remaining functions.
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QVariantMap>
+#include <QVariantHash>
+#include <QMap>
+
+#include <dfm-base/base/device/deviceutils.h>
+
+using namespace dfmbase;
+
+TEST(DeviceUtilsExt2Test, NameOfBuiltInDiskVariantMap)
+{
+    QVariantMap info;
+    info.insert("OpticalDrive", true);
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::nameOfBuiltInDisk(info); });
+}
+
+TEST(DeviceUtilsExt2Test, NameOfOpticalVariantMap)
+{
+    QVariantMap info;
+    info.insert("IdLabel", "MyDisc");
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::nameOfOptical(info); });
+}
+
+TEST(DeviceUtilsExt2Test, NameOfDefaultEmpty)
+{
+    QString name = DeviceUtils::nameOfDefault("", 1024);
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(DeviceUtilsExt2Test, NameOfSizeVarious)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::nameOfSize(0); });
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::nameOfSize(500ULL * 1024 * 1024); });
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::nameOfSize(2ULL * 1024 * 1024 * 1024); });
+}
+
+TEST(DeviceUtilsExt2Test, NameOfAliasEmpty)
+{
+    EXPECT_TRUE(DeviceUtils::nameOfAlias("definitely-not-a-real-uuid").isEmpty());
+}
+
+TEST(DeviceUtilsExt2Test, IsBuiltInDiskVariantMap)
+{
+    QVariantMap info;
+    info.insert("OpticalDrive", true);
+    EXPECT_FALSE(DeviceUtils::isBuiltInDisk(info));
+}
+
+TEST(DeviceUtilsExt2Test, IsSystemDiskVariantMap)
+{
+    QVariantMap info;
+    info.insert("MountPoint", "/data");
+    EXPECT_FALSE(DeviceUtils::isSystemDisk(info));
+}
+
+TEST(DeviceUtilsExt2Test, IsSiblingOfRootVariantHash)
+{
+    QVariantHash info;
+    info.insert("Drive", "non-matching-drive");
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::isSiblingOfRoot(info); });
+}
+
+TEST(DeviceUtilsExt2Test, IsSubpathOfDlnfs)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::isSubpathOfDlnfs("/some/arbitrary/path"); });
+}
+
+TEST(DeviceUtilsExt2Test, IsMountPointOfDlnfs)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::isMountPointOfDlnfs("/some/arbitrary/path"); });
+}
+
+TEST(DeviceUtilsExt2Test, GetLongestMountRootPath)
+{
+    QString r = DeviceUtils::getLongestMountRootPath("/home/user/docs");
+    EXPECT_FALSE(r.isEmpty());
+}
+
+TEST(DeviceUtilsExt2Test, DeviceBytesFreeInvalidUrl)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::deviceBytesFree(QUrl()); });
+}
+
+TEST(DeviceUtilsExt2Test, CheckDiskEncrypted)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::checkDiskEncrypted(); });
+}
+
+TEST(DeviceUtilsExt2Test, EncryptedDisks)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::encryptedDisks(); });
+}
+
+TEST(DeviceUtilsExt2Test, IsAutoMountAndOpenEnable)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::isAutoMountAndOpenEnable(); });
+}
+
+TEST(DeviceUtilsExt2Test, IsWorkingOpticalDiscDev)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::isWorkingOpticalDiscDev("/dev/sr0"); });
+}
+
+TEST(DeviceUtilsExt2Test, SupportDfmioCopyDevice)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::supportDfmioCopyDevice(QUrl("file:///tmp")); });
+}
+
+TEST(DeviceUtilsExt2Test, SupportSetPermissionsDevice)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::supportSetPermissionsDevice(QUrl("file:///tmp")); });
+}
+
+TEST(DeviceUtilsExt2Test, ConvertSuitableDisplayNameHashWithClear)
+{
+    QVariantHash info;
+    info.insert("IdLabel", "MyUsb");
+    info.insert("SizeTotal", 1024 * 1024 * 100);
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::convertSuitableDisplayName(info); });
+}
+
+TEST(DeviceUtilsExt2Test, ConvertSuitableDisplayNameMap)
+{
+    QVariantMap info;
+    info.insert("IdLabel", "MyUsb2");
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::convertSuitableDisplayName(info); });
+}
+
+TEST(DeviceUtilsExt2Test, GetMountInfo)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::getMountInfo("/", false); });
+}
+
+TEST(DeviceUtilsExt2Test, GetBlockDeviceId)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DeviceUtils::getBlockDeviceId("/dev/sda1"); });
+}

--- a/autotests/libs/dfm-base/test_dfmmimedata.cpp
+++ b/autotests/libs/dfm-base/test_dfmmimedata.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_dfmmimedata.cpp
+ * @brief Unit tests for DFMMimeData (dfmmimedata.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QList>
+
+#include <dfm-base/mimedata/dfmmimedata.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <QIcon>
+#include <QDir>
+#include <mutex>
+
+using namespace dfmbase;
+
+class DFMMimeDataTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+    static std::once_flag flag;
+};
+std::once_flag DFMMimeDataTest::flag;
+
+TEST_F(DFMMimeDataTest, DefaultConstructorIsInvalid)
+{
+    DFMMimeData data;
+    EXPECT_FALSE(data.isValid());
+}
+
+TEST_F(DFMMimeDataTest, SetUrlsAndRetrieve)
+{
+    DFMMimeData data;
+    QList<QUrl> urls { QUrl("file:///home/user/a"), QUrl("file:///home/user/b") };
+    data.setUrls(urls);
+    auto got = data.urls();
+    EXPECT_EQ(got.size(), 2);
+}
+
+TEST_F(DFMMimeDataTest, CanTrashCanDeleteDefaults)
+{
+    DFMMimeData data;
+    EXPECT_NO_FATAL_FAILURE({ (void)data.canTrash(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)data.canDelete(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)data.isTrashFile(); });
+}
+
+TEST_F(DFMMimeDataTest, SetAndgetAttribute)
+{
+    DFMMimeData data;
+    data.setAttritube("mykey", QString("myval"));
+    EXPECT_EQ(data.attritube("mykey").toString(), QString("myval"));
+    EXPECT_EQ(data.attritube("missing", QString("def")).toString(), QString("def"));
+}
+
+TEST_F(DFMMimeDataTest, SerializeDeserializeRoundTrip)
+{
+    DFMMimeData data;
+    QList<QUrl> urls { QUrl::fromLocalFile(QDir::tempPath() + "/dfm_x"), QUrl::fromLocalFile(QDir::tempPath() + "/dfm_y") };
+    data.setUrls(urls);
+    QByteArray bytes;
+    EXPECT_NO_FATAL_FAILURE({ bytes = data.toByteArray(); });
+    EXPECT_NO_FATAL_FAILURE({ DFMMimeData restored = DFMMimeData::fromByteArray(bytes); (void)restored.urls(); });
+}
+
+TEST_F(DFMMimeDataTest, CopyConstructorSharesData)
+{
+    DFMMimeData data;
+    data.setUrls({ QUrl("file:///tmp/a") });
+    DFMMimeData copy(data);
+    EXPECT_EQ(copy.urls().size(), 1);
+}
+
+TEST_F(DFMMimeDataTest, ClearResetsData)
+{
+    DFMMimeData data;
+    data.setUrls({ QUrl("file:///tmp/a") });
+    data.clear();
+    EXPECT_TRUE(data.urls().isEmpty());
+}
+
+TEST_F(DFMMimeDataTest, VersionString)
+{
+    DFMMimeData data;
+    QString v = data.version();
+    EXPECT_FALSE(v.isEmpty());
+}

--- a/autotests/libs/dfm-base/test_elidetextlayout.cpp
+++ b/autotests/libs/dfm-base/test_elidetextlayout.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_elidetextlayout.cpp
+ * @brief Unit tests for ElideTextLayout (elidetextlayout.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QFont>
+#include <QRectF>
+#include <QStringList>
+
+#include <dfm-base/utils/elidetextlayout.h>
+
+using namespace dfmbase;
+
+TEST(ElideTextLayoutTest, SetTextAndGetText)
+{
+    ElideTextLayout layout("hello world");
+    EXPECT_EQ(layout.text(), QString("hello world"));
+    layout.setText("new text");
+    EXPECT_EQ(layout.text(), QString("new text"));
+}
+
+TEST(ElideTextLayoutTest, SetAttribute)
+{
+    ElideTextLayout layout("test");
+    QFont font("Arial", 10);
+    layout.setAttribute(ElideTextLayout::kFont, font);
+    QFont got = layout.attribute<QFont>(ElideTextLayout::kFont);
+    EXPECT_EQ(got.family(), font.family());
+}
+
+TEST(ElideTextLayoutTest, LayoutReturnsRectListForFittingText)
+{
+    ElideTextLayout layout("short");
+    QRectF rect(0, 0, 200, 50);
+    QList<QRectF> result = layout.layout(rect, Qt::ElideNone);
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST(ElideTextLayoutTest, LayoutElideRightTruncates)
+{
+    ElideTextLayout layout("a very long text that exceeds the width");
+    QRectF rect(0, 0, 60, 20);
+    QStringList lines;
+    layout.layout(rect, Qt::ElideRight, nullptr, Qt::NoBrush, &lines);
+    EXPECT_FALSE(lines.isEmpty());
+}
+
+TEST(ElideTextLayoutTest, HighlightKeywordsNoCrash)
+{
+    ElideTextLayout layout("find the keyword here");
+    layout.setHighlightKeywords(QStringList { "keyword" });
+    layout.setHighlightEnabled(true);
+    QRectF rect(0, 0, 200, 50);
+    QList<QRectF> result = layout.layout(rect, Qt::ElideNone);
+    EXPECT_FALSE(result.isEmpty());
+}

--- a/autotests/libs/dfm-base/test_fileinfo.cpp
+++ b/autotests/libs/dfm-base/test_fileinfo.cpp
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fileinfo.cpp
+ * @brief Unit tests for SyncFileInfo / FileInfo (syncfileinfo.cpp, fileinfo.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+#include <QUrl>
+#include <QIcon>
+#include <mutex>
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+using namespace dfmbase;
+
+class FileInfoTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    static std::once_flag flag;
+};
+
+std::once_flag FileInfoTest::flag;
+
+TEST_F(FileInfoTest, CreateFileInfoAndQueryBasicAttributes)
+{
+    QString filePath = rootPath + "/testfile.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("hello world");
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->exists(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->size(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->nameOf(FileInfo::FileNameInfoType::kFileName); });
+}
+
+TEST_F(FileInfoTest, FileInfoNameOfReturnsFileName)
+{
+    QString filePath = rootPath + "/named.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->refresh();
+    EXPECT_EQ(info->nameOf(FileInfo::FileNameInfoType::kFileName), QString("named.txt"));
+    EXPECT_EQ(info->nameOf(FileInfo::FileNameInfoType::kCompleteBaseName), QString("named"));
+}
+
+TEST_F(FileInfoTest, FileInfoPathOfReturnsPath)
+{
+    QString filePath = rootPath + "/pathtest.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    QString absPath = info->pathOf(FileInfo::FilePathInfoType::kAbsolutePath);
+    EXPECT_FALSE(absPath.isEmpty());
+}
+
+TEST_F(FileInfoTest, FileInfoUrlOfReturnsUrl)
+{
+    QString filePath = rootPath + "/urltest.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    QUrl url = QUrl::fromLocalFile(filePath);
+    auto info = InfoFactory::create<FileInfo>(url);
+    ASSERT_NE(info, nullptr);
+    QUrl infoUrl = info->urlOf(FileInfo::FileUrlInfoType::kUrl);
+    EXPECT_FALSE(infoUrl.isEmpty());
+}
+
+TEST_F(FileInfoTest, FileInfoForNonExistentFile)
+{
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(rootPath + "/nonexistent.txt"));
+    ASSERT_NE(info, nullptr);
+    EXPECT_FALSE(info->exists());
+}
+
+TEST_F(FileInfoTest, FileInfoIsAttributesForDirectory)
+{
+    QString dirPath = rootPath + "/testdir";
+    ASSERT_TRUE(QDir().mkpath(dirPath));
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(dirPath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->isAttributes(FileInfo::FileIsType::kIsDir); });
+}
+
+TEST_F(FileInfoTest, FileInfoRefreshUpdatesContent)
+{
+    QString filePath = rootPath + "/refresh.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("initial");
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ info->refresh(); });
+    f.open(QIODevice::WriteOnly);
+    f.write("updated content");
+    f.close();
+    EXPECT_NO_FATAL_FAILURE({ info->refresh(); });
+}
+
+TEST_F(FileInfoTest, FileInfoPermissions)
+{
+    QString filePath = rootPath + "/perm.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->permissions(); });
+}
+
+TEST_F(FileInfoTest, FileInfoFileType)
+{
+    QString filePath = rootPath + "/type.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    EXPECT_NO_FATAL_FAILURE({ (void)info->fileType(); });
+}
+
+TEST_F(FileInfoTest, FileInfoDisplayOf)
+{
+    QString filePath = rootPath + "/display.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    EXPECT_NO_FATAL_FAILURE({ (void)info->displayOf(FileInfo::DisplayInfoType::kFileDisplayName); });
+}
+
+TEST_F(FileInfoTest, FileInfoTimeOf)
+{
+    QString filePath = rootPath + "/time.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    EXPECT_NO_FATAL_FAILURE({ (void)info->timeOf(FileInfo::FileTimeType::kLastModified); });
+}
+
+// Exercise many SyncFileInfo attribute query paths for coverage.
+TEST_F(FileInfoTest, CanAttributesMultipleTypes)
+{
+    QString filePath = rootPath + "/canattr.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("data");
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->canAttributes(FileInfo::FileCanType::kCanRename); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->canAttributes(FileInfo::FileCanType::kCanHidden); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->canAttributes(FileInfo::FileCanType::kCanMoveOrCopy); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->canAttributes(FileInfo::FileCanType::kCanDelete); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->canAttributes(FileInfo::FileCanType::kCanTrash); });
+}
+
+TEST_F(FileInfoTest, IsAttributesMultipleTypes)
+{
+    QString filePath = rootPath + "/isattr.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->isAttributes(FileInfo::FileIsType::kIsFile); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->isAttributes(FileInfo::FileIsType::kIsReadable); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->isAttributes(FileInfo::FileIsType::kIsWritable); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->isAttributes(FileInfo::FileIsType::kIsHidden); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->isAttributes(FileInfo::FileIsType::kIsSymLink); });
+}
+
+TEST_F(FileInfoTest, ExtendAttributesMultipleTypes)
+{
+    QString filePath = rootPath + "/extendattr.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->extendAttributes(FileInfo::FileExtendedInfoType::kFileLocalDevice); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->extendAttributes(FileInfo::FileExtendedInfoType::kSizeFormat); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->extendAttributes(FileInfo::FileExtendedInfoType::kInode); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->extendAttributes(FileInfo::FileExtendedInfoType::kOwner); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->extendAttributes(FileInfo::FileExtendedInfoType::kGroup); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->extendAttributes(FileInfo::FileExtendedInfoType::kFileIsHid); });
+}
+
+TEST_F(FileInfoTest, ExtraPropertiesAndCountChildFile)
+{
+    QString dirPath = rootPath + "/propsdir";
+    ASSERT_TRUE(QDir().mkpath(dirPath));
+    QFile f(dirPath + "/child.txt");
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("x");
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(dirPath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->extraProperties(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)info->countChildFile(); });
+}
+
+TEST_F(FileInfoTest, FileIcon)
+{
+    QString filePath = rootPath + "/icon.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->fileIcon(); });
+}
+
+TEST_F(FileInfoTest, FileMimeType)
+{
+    QString filePath = rootPath + "/mime.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("plain text");
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->fileMimeType(); });
+}
+
+TEST_F(FileInfoTest, PermissionCheck)
+{
+    QString filePath = rootPath + "/permcheck.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+
+    auto info = InfoFactory::create<FileInfo>(QUrl::fromLocalFile(filePath));
+    ASSERT_NE(info, nullptr);
+    info->initQuerier();
+    EXPECT_NO_FATAL_FAILURE({ (void)info->permission(QFileDevice::ReadOwner); });
+}

--- a/autotests/libs/dfm-base/test_filenamesorter.cpp
+++ b/autotests/libs/dfm-base/test_filenamesorter.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_filenamesorter.cpp
+ * @brief Unit tests for FileNameSorter (filenamesorter.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QCollator>
+#include <QStringList>
+#include <QUrl>
+
+#include <dfm-base/utils/filenamesorter.h>
+
+using namespace dfmbase;
+
+TEST(FileNameSorterTest, CollatorReturnsSameInstance)
+{
+    QCollator &c1 = FileNameSorter::collator();
+    QCollator &c2 = FileNameSorter::collator();
+    EXPECT_EQ(&c1, &c2);
+}
+
+TEST(FileNameSorterTest, CollatorHasNumericMode)
+{
+    QCollator &c = FileNameSorter::collator();
+    EXPECT_TRUE(c.numericMode());
+}
+
+TEST(FileNameSorterTest, CollatorIsCaseSensitive)
+{
+    QCollator &c = FileNameSorter::collator();
+    EXPECT_EQ(c.caseSensitivity(), Qt::CaseSensitive);
+}
+
+TEST(FileNameSorterTest, SortKeyProducesComparableKey)
+{
+    QCollatorSortKey k1 = FileNameSorter::sortKey("file10");
+    QCollatorSortKey k2 = FileNameSorter::sortKey("file2");
+    EXPECT_TRUE(k2 < k1);
+}
+
+TEST(FileNameSorterTest, SortAscendingNaturalOrder)
+{
+    QStringList names { "file10", "file2", "file1", "file20" };
+    FileNameSorter::sort(names, Qt::AscendingOrder);
+    EXPECT_EQ(names, QStringList({ "file1", "file2", "file10", "file20" }));
+}
+
+TEST(FileNameSorterTest, SortDescendingNaturalOrder)
+{
+    QStringList names { "file10", "file2", "file1", "file20" };
+    FileNameSorter::sort(names, Qt::DescendingOrder);
+    EXPECT_EQ(names, QStringList({ "file20", "file10", "file2", "file1" }));
+}
+
+TEST(FileNameSorterTest, SortSingleElementNoOp)
+{
+    QStringList names { "only" };
+    FileNameSorter::sort(names, Qt::AscendingOrder);
+    EXPECT_EQ(names, QStringList({ "only" }));
+}
+
+TEST(FileNameSorterTest, SortEmptyListNoOp)
+{
+    QStringList names;
+    FileNameSorter::sort(names, Qt::AscendingOrder);
+    EXPECT_TRUE(names.isEmpty());
+}
+
+TEST(FileNameSorterTest, SortUrlsAscending)
+{
+    QList<QUrl> urls {
+        QUrl("file:///dir/file10.txt"),
+        QUrl("file:///dir/file2.txt"),
+        QUrl("file:///dir/file1.txt"),
+    };
+    FileNameSorter::sortUrls(urls, Qt::AscendingOrder);
+    EXPECT_EQ(urls[0].fileName(), QString("file1.txt"));
+    EXPECT_EQ(urls[1].fileName(), QString("file2.txt"));
+    EXPECT_EQ(urls[2].fileName(), QString("file10.txt"));
+}
+
+TEST(FileNameSorterTest, SortUrlsDescending)
+{
+    QList<QUrl> urls {
+        QUrl("file:///dir/file2.txt"),
+        QUrl("file:///dir/file10.txt"),
+        QUrl("file:///dir/file1.txt"),
+    };
+    FileNameSorter::sortUrls(urls, Qt::DescendingOrder);
+    EXPECT_EQ(urls[0].fileName(), QString("file10.txt"));
+}
+
+TEST(FileNameSorterTest, CompareAscending)
+{
+    EXPECT_TRUE(FileNameSorter::compare("file2", "file10", Qt::AscendingOrder));
+    EXPECT_FALSE(FileNameSorter::compare("file10", "file2", Qt::AscendingOrder));
+}
+
+TEST(FileNameSorterTest, CompareDescending)
+{
+    EXPECT_TRUE(FileNameSorter::compare("file10", "file2", Qt::DescendingOrder));
+    EXPECT_FALSE(FileNameSorter::compare("file2", "file10", Qt::DescendingOrder));
+}
+
+TEST(FileNameSorterTest, SortByKeyAscending)
+{
+    using Item = QPair<QString, QCollatorSortKey>;
+    QVector<Item> items {
+        { "b", FileNameSorter::sortKey("b") },
+        { "a", FileNameSorter::sortKey("a") },
+        { "c", FileNameSorter::sortKey("c") },
+    };
+    FileNameSorter::sortByKey(items, [](const Item &it) { return it.second; }, Qt::AscendingOrder);
+    EXPECT_EQ(items[0].first, QString("a"));
+    EXPECT_EQ(items[1].first, QString("b"));
+    EXPECT_EQ(items[2].first, QString("c"));
+}
+
+TEST(FileNameSorterTest, SortByKeyDescending)
+{
+    using Item = QPair<QString, QCollatorSortKey>;
+    QVector<Item> items {
+        { "b", FileNameSorter::sortKey("b") },
+        { "a", FileNameSorter::sortKey("a") },
+        { "c", FileNameSorter::sortKey("c") },
+    };
+    FileNameSorter::sortByKey(items, [](const Item &it) { return it.second; }, Qt::DescendingOrder);
+    EXPECT_EQ(items[0].first, QString("c"));
+    EXPECT_EQ(items[1].first, QString("b"));
+    EXPECT_EQ(items[2].first, QString("a"));
+}

--- a/autotests/libs/dfm-base/test_fileutils.cpp
+++ b/autotests/libs/dfm-base/test_fileutils.cpp
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fileutils.cpp
+ * @brief Unit tests for pure-logic functions of FileUtils (fileutils.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QTemporaryFile>
+#include <QTest>
+
+#include <dfm-base/utils/fileutils.h>
+
+using namespace dfmbase;
+
+TEST(FileUtilsTest, FormatSizeBytes)
+{
+    QString s = FileUtils::formatSize(512);
+    EXPECT_TRUE(s.contains("B"));
+}
+
+TEST(FileUtilsTest, FormatSizeNegativeBecomesZero)
+{
+    QString s = FileUtils::formatSize(-100);
+    EXPECT_TRUE(s.startsWith("0"));
+}
+
+TEST(FileUtilsTest, FormatSizeKilobytes)
+{
+    // 2048 bytes = 2 KB; sizeString trims trailing zeros → "2"
+    QString s = FileUtils::formatSize(2048, false, 2);
+    EXPECT_EQ(s, QString("2"));
+}
+
+TEST(FileUtilsTest, FormatSizeWithUnitVisible)
+{
+    QString s = FileUtils::formatSize(2048, true, 2);
+    EXPECT_TRUE(s.contains("KB"));
+    EXPECT_FALSE(s.contains("2.00"));   // trailing zeros trimmed
+}
+
+TEST(FileUtilsTest, FormatSizeWithUnitVisibleFalse)
+{
+    QString s = FileUtils::formatSize(1024, false, 0);
+    EXPECT_FALSE(s.contains("KB"));
+}
+
+TEST(FileUtilsTest, FormatSizeForceUnit)
+{
+    // force unit index 2 (MB) for a 1024-byte file
+    QString s = FileUtils::formatSize(1024, true, 3, 2);
+    EXPECT_TRUE(s.contains("MB"));
+}
+
+TEST(FileUtilsTest, FormatSizeCustomUnitList)
+{
+    QStringList units { " KB", " MB" };
+    QString s = FileUtils::formatSize(1024, true, 0, -1, units);
+    EXPECT_TRUE(s.contains("MB"));
+}
+
+TEST(FileUtilsTest, SupportedMaxLengthKnownFs)
+{
+    EXPECT_EQ(FileUtils::supportedMaxLength("vfat"), 11);
+    EXPECT_EQ(FileUtils::supportedMaxLength("ext4"), 16);
+    EXPECT_EQ(FileUtils::supportedMaxLength("btrfs"), 255);
+    EXPECT_EQ(FileUtils::supportedMaxLength("xfs"), 12);
+}
+
+TEST(FileUtilsTest, SupportedMaxLengthCaseInsensitive)
+{
+    EXPECT_EQ(FileUtils::supportedMaxLength("NTFS"), 32);
+}
+
+TEST(FileUtilsTest, SupportedMaxLengthUnknownFs)
+{
+    EXPECT_EQ(FileUtils::supportedMaxLength("unknownfs"), 40);
+}
+
+TEST(FileUtilsTest, ProcessLengthTrimsToMaxLen)
+{
+    // srcPos near the end: leftText shrinks until combined fits within maxLen.
+    QString dst;
+    int dstPos = -1;
+    bool ret = FileUtils::processLength("hello world", 8, 5, true, dst, dstPos);
+    EXPECT_TRUE(ret);
+    EXPECT_LE(dst.length(), 5);
+}
+
+TEST(FileUtilsTest, ProcessLengthReturnsFalseWhenLeftEmpty)
+{
+    // srcPos=5: leftText shrinks to empty but rightText alone still exceeds maxLen.
+    QString dst;
+    int dstPos = -1;
+    bool ret = FileUtils::processLength("hello world", 5, 5, true, dst, dstPos);
+    EXPECT_FALSE(ret);
+}
+
+TEST(FileUtilsTest, ProcessLengthNoOpWhenWithinMaxLen)
+{
+    QString dst;
+    int dstPos = -1;
+    bool ret = FileUtils::processLength("hi", 1, 10, true, dst, dstPos);
+    EXPECT_FALSE(ret);
+    EXPECT_EQ(dst, QString("hi"));
+}
+
+TEST(FileUtilsTest, IsDesktopFileSuffixTrue)
+{
+    EXPECT_TRUE(FileUtils::isDesktopFileSuffix(QUrl("file:///usr/share/applications/foo.desktop")));
+}
+
+TEST(FileUtilsTest, IsDesktopFileSuffixFalse)
+{
+    EXPECT_FALSE(FileUtils::isDesktopFileSuffix(QUrl("file:///home/user/foo.txt")));
+}
+
+TEST(FileUtilsTest, CutFileNameByCharCount)
+{
+    EXPECT_EQ(FileUtils::cutFileName("hello world", 5, true), QString("hello"));
+}
+
+TEST(FileUtilsTest, CutFileNameNoTruncation)
+{
+    EXPECT_EQ(FileUtils::cutFileName("hi", 10, true), QString("hi"));
+}
+
+TEST(FileUtilsTest, CutFileNameByByteCountAscii)
+{
+    EXPECT_EQ(FileUtils::cutFileName("abcdef", 3, false), QString("abc"));
+}
+
+TEST(FileUtilsTest, CutFileNameByByteCountSurrogatePreserved)
+{
+    // A single emoji is 4 bytes in UTF-8; cutting at 4 bytes keeps the full emoji.
+    QString emoji = QString::fromUtf8("\xF0\x9F\x98\x80");
+    QString result = FileUtils::cutFileName(emoji + "ab", 4, false);
+    EXPECT_EQ(result, emoji);
+}
+
+TEST(FileUtilsTest, EncryptDecryptRoundTrip)
+{
+    QString original = "hello world";
+    QString enc = FileUtils::encryptString(original);
+    EXPECT_NE(enc, original);
+    EXPECT_EQ(FileUtils::decryptString(enc), original);
+}
+
+TEST(FileUtilsTest, EncryptStringIsBase64)
+{
+    QString enc = FileUtils::encryptString("test");
+    EXPECT_EQ(enc, QString::fromUtf8(QByteArray("test").toBase64()));
+}
+
+TEST(FileUtilsTest, DateTimeFormat)
+{
+    EXPECT_EQ(FileUtils::dateTimeFormat(), QString("yyyy/MM/dd HH:mm:ss"));
+}
+
+TEST(FileUtilsTest, GetMemoryPageSizePositive)
+{
+    EXPECT_GT(FileUtils::getMemoryPageSize(), 0);
+}
+
+TEST(FileUtilsTest, GetCpuProcessCountPositive)
+{
+    EXPECT_GT(FileUtils::getCpuProcessCount(), 0);
+}
+
+TEST(FileUtilsTest, CacheRemoveContainsCopyingFileUrl)
+{
+    QUrl url("file:///tmp/dfm_unit_test_file.txt");
+    EXPECT_FALSE(FileUtils::containsCopyingFileUrl(url));
+    FileUtils::cacheCopyingFileUrl(url);
+    EXPECT_TRUE(FileUtils::containsCopyingFileUrl(url));
+    FileUtils::removeCopyingFileUrl(url);
+    EXPECT_FALSE(FileUtils::containsCopyingFileUrl(url));
+}
+
+TEST(FileUtilsTest, SetGetTrashEmptyState)
+{
+    FileUtils::setTrashEmptyState(FileUtils::TrashEmptyState::kEmpty);
+    EXPECT_EQ(FileUtils::trashEmptyState(), FileUtils::TrashEmptyState::kEmpty);
+    FileUtils::setTrashEmptyState(FileUtils::TrashEmptyState::kNotEmpty);
+    EXPECT_EQ(FileUtils::trashEmptyState(), FileUtils::TrashEmptyState::kNotEmpty);
+}
+
+TEST(FileUtilsTest, TrashRootUrlScheme)
+{
+    QUrl url = FileUtils::trashRootUrl();
+    EXPECT_FALSE(url.scheme().isEmpty());
+    EXPECT_EQ(url.path(), QString("/"));
+}
+
+TEST(FileUtilsTest, IsSameFileSamePath)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    EXPECT_TRUE(FileUtils::isSameFile(path, path));
+}
+
+TEST(FileUtilsTest, IsSameFileDifferentPaths)
+{
+    QTemporaryFile a, b;
+    ASSERT_TRUE(a.open());
+    ASSERT_TRUE(b.open());
+    EXPECT_FALSE(FileUtils::isSameFile(a.fileName(), b.fileName()));
+}
+
+TEST(FileUtilsTest, IsSameFileNonExistentReturnsFalse)
+{
+    EXPECT_FALSE(FileUtils::isSameFile("/no/such/file1", "/no/such/file2"));
+}
+
+TEST(FileUtilsTest, IsHigherHierarchyTrue)
+{
+    EXPECT_TRUE(FileUtils::isHigherHierarchy(QUrl("file:///home/user"), QUrl("file:///home/user/docs")));
+}
+
+TEST(FileUtilsTest, IsHigherHierarchyFalse)
+{
+    EXPECT_FALSE(FileUtils::isHigherHierarchy(QUrl("file:///home/user/docs"), QUrl("file:///home/user")));
+}
+
+TEST(FileUtilsTest, BindPathTransformIdentity)
+{
+    QString p = "/tmp/some_path";
+    EXPECT_EQ(FileUtils::bindPathTransform(p, false), p);
+}

--- a/autotests/libs/dfm-base/test_fileutils_ext.cpp
+++ b/autotests/libs/dfm-base/test_fileutils_ext.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fileutils_ext.cpp
+ * @brief Extended unit tests for FileUtils pure-logic functions.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QImage>
+#include <QModelIndex>
+#include <QFont>
+#include <QFontMetrics>
+#include <QStandardPaths>
+#include <mutex>
+
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class FileUtilsExtTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    static std::once_flag flag;
+};
+
+std::once_flag FileUtilsExtTest::flag;
+
+TEST_F(FileUtilsExtTest, IsDesktopFileSuffix)
+{
+    EXPECT_TRUE(FileUtils::isDesktopFileSuffix(QUrl("file:///tmp/foo.desktop")));
+    EXPECT_FALSE(FileUtils::isDesktopFileSuffix(QUrl("file:///tmp/foo.txt")));
+}
+
+TEST_F(FileUtilsExtTest, IsTrashFileAndRoot)
+{
+    QUrl trashUrl("trash:///");
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::isTrashFile(trashUrl); });
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::isTrashRootFile(trashUrl); });
+}
+
+TEST_F(FileUtilsExtTest, TrashPathToNormal)
+{
+    QString result = FileUtils::trashPathToNormal("/foo\\bar");
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(FileUtilsExtTest, NormalPathToTrash)
+{
+    QString result = FileUtils::normalPathToTrash("/foo/bar");
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST_F(FileUtilsExtTest, BindPathTransformIdentity)
+{
+    QString p = "/some/random/path";
+    EXPECT_EQ(FileUtils::bindPathTransform(p, false), p);
+    EXPECT_EQ(FileUtils::bindPathTransform(p, true), p);
+}
+
+TEST_F(FileUtilsExtTest, BindUrlTransformNonTrash)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath + "/test.txt");
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::bindUrlTransform(url); });
+}
+
+TEST_F(FileUtilsExtTest, SymlinkTargetAndResolve)
+{
+    QString target = rootPath + "/target.txt";
+    QString link = rootPath + "/link.txt";
+    QFile f(target);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("hi");
+    f.close();
+    QFile::link(target, link);
+
+    EXPECT_EQ(FileUtils::symlinkTarget(QUrl::fromLocalFile(link)), target);
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::resolveSymlink(QUrl::fromLocalFile(link)); });
+}
+
+TEST_F(FileUtilsExtTest, SymlinkTargetNonExistent)
+{
+    EXPECT_TRUE(FileUtils::symlinkTarget(QUrl::fromLocalFile("/no/such/link")).isEmpty());
+}
+
+TEST_F(FileUtilsExtTest, ConvertToSRgbColorSpaceNullImage)
+{
+    QImage nullImg;
+    QImage result = FileUtils::convertToSRgbColorSpace(nullImg);
+    EXPECT_TRUE(result.isNull());
+}
+
+TEST_F(FileUtilsExtTest, ConvertToSRgbColorSpaceNormalImage)
+{
+    QImage img(2, 2, QImage::Format_RGB32);
+    img.fill(Qt::red);
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::convertToSRgbColorSpace(img); });
+}
+
+TEST_F(FileUtilsExtTest, ToUnicode)
+{
+    QByteArray data("hello world");
+    QString s = FileUtils::toUnicode(data);
+    EXPECT_FALSE(s.isEmpty());
+}
+
+TEST_F(FileUtilsExtTest, DirFfileCountInvalidUrl)
+{
+    EXPECT_EQ(FileUtils::dirFfileCount(QUrl()), 0);
+}
+
+TEST_F(FileUtilsExtTest, SupportLongName)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath);
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::supportLongName(url); });
+}
+
+TEST_F(FileUtilsExtTest, FindIconFromXdg)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::findIconFromXdg("folder"); });
+}
+
+TEST_F(FileUtilsExtTest, IsContainProhibitPathEmpty)
+{
+    EXPECT_FALSE(FileUtils::isContainProhibitPath(QList<QUrl> {}));
+}
+
+TEST_F(FileUtilsExtTest, GetFileNameLength)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath + "/namelen.txt");
+    EXPECT_GE(FileUtils::getFileNameLength(url, "namelen.txt"), 0);
+}
+
+TEST_F(FileUtilsExtTest, IsHigherHierarchy)
+{
+    EXPECT_FALSE(FileUtils::isHigherHierarchy(QUrl("file:///home/user/docs"),
+                                              QUrl("file:///home/user")));
+}
+
+TEST_F(FileUtilsExtTest, PreprocessingFileName)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::preprocessingFileName("test_file"); });
+}

--- a/autotests/libs/dfm-base/test_fileutils_ext2.cpp
+++ b/autotests/libs/dfm-base/test_fileutils_ext2.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fileutils_ext2.cpp
+ * @brief Second batch of FileUtils tests targeting remaining functions.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QList>
+#include <QPair>
+#include <QString>
+#include <QImage>
+#include <mutex>
+#include <QIcon>
+
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class FileUtilsExt2Test : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    static std::once_flag flag;
+};
+
+std::once_flag FileUtilsExt2Test::flag;
+
+TEST_F(FileUtilsExt2Test, SupportedMaxLengthKnownFs)
+{
+    EXPECT_GE(FileUtils::supportedMaxLength("ext4"), 1);
+    EXPECT_GE(FileUtils::supportedMaxLength("unknownfs"), 1);
+}
+
+TEST_F(FileUtilsExt2Test, IsDesktopFileFalse)
+{
+    QString path = rootPath + "/notadesktop.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("text");
+    f.close();
+    EXPECT_FALSE(FileUtils::isDesktopFile(QUrl::fromLocalFile(path)));
+}
+
+TEST_F(FileUtilsExt2Test, IsTrashDesktopFile)
+{
+    EXPECT_FALSE(FileUtils::isTrashDesktopFile(QUrl("file:///tmp/no_such.desktop")));
+}
+
+TEST_F(FileUtilsExt2Test, IsHomeDesktopFile)
+{
+    EXPECT_FALSE(FileUtils::isHomeDesktopFile(QUrl("file:///tmp/no_such.desktop")));
+}
+
+TEST_F(FileUtilsExt2Test, IsSameFileByUrl)
+{
+    QString path = rootPath + "/same.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("x");
+    f.close();
+    QUrl url = QUrl::fromLocalFile(path);
+    EXPECT_NO_FATAL_FAILURE({
+        (void)FileUtils::isSameFile(url, url, Global::CreateFileInfoType::kCreateFileInfoSync);
+    });
+}
+
+TEST_F(FileUtilsExt2Test, IsCdRomDevice)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::isCdRomDevice(QUrl("file:///tmp")); });
+}
+
+TEST_F(FileUtilsExt2Test, TrashRootUrl)
+{
+    QUrl url = FileUtils::trashRootUrl();
+    EXPECT_FALSE(url.scheme().isEmpty());
+}
+
+TEST_F(FileUtilsExt2Test, IsTrashFileNonTrashUrl)
+{
+    EXPECT_FALSE(FileUtils::isTrashFile(QUrl("file:///tmp/notrash")));
+}
+
+TEST_F(FileUtilsExt2Test, DirFfileCountForDir)
+{
+    QString dir = rootPath + "/countdir";
+    QDir().mkpath(dir);
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::dirFfileCount(QUrl::fromLocalFile(dir)); });
+}
+
+TEST_F(FileUtilsExt2Test, BindUrlTransformNonTrash)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::bindUrlTransform(QUrl("file:///tmp/x")); });
+}
+
+TEST_F(FileUtilsExt2Test, FindIconFromXdgTheme)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::findIconFromXdg("folder"); });
+}
+
+TEST_F(FileUtilsExt2Test, CacheCopyingFileUrlLifecycle)
+{
+    QUrl url("file:///tmp/dfm_ext2_copy_test.txt");
+    FileUtils::cacheCopyingFileUrl(url);
+    EXPECT_TRUE(FileUtils::containsCopyingFileUrl(url));
+    FileUtils::removeCopyingFileUrl(url);
+    EXPECT_FALSE(FileUtils::containsCopyingFileUrl(url));
+}
+
+TEST_F(FileUtilsExt2Test, NotifyFileChangeManualNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        FileUtils::notifyFileChangeManual(Global::FileNotifyType::kFileAdded, QUrl("file:///tmp/dfm_notify_test"));
+    });
+}
+
+TEST_F(FileUtilsExt2Test, SetBackGroundNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::setBackGround("/no/such/picture.png"); });
+}
+
+TEST_F(FileUtilsExt2Test, FileBatchCustomText)
+{
+    QList<QUrl> urls { QUrl("file:///tmp/a.txt"), QUrl("file:///tmp/b.txt") };
+    QPair<QString, QString> pair { "a", "A" };
+    EXPECT_NO_FATAL_FAILURE({ (void)FileUtils::fileBatchCustomText(urls, pair); });
+}
+
+TEST_F(FileUtilsExt2Test, ComputerAndHomeDesktopFileUrl)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DesktopAppUrl::computerDesktopFileUrl(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)DesktopAppUrl::homeDesktopFileUrl(); });
+}
+
+TEST_F(FileUtilsExt2Test, TrashDesktopFileUrl)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)DesktopAppUrl::trashDesktopFileUrl(); });
+}

--- a/autotests/libs/dfm-base/test_finallyutil.cpp
+++ b/autotests/libs/dfm-base/test_finallyutil.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_finallyutil.cpp
+ * @brief Unit tests for FinallyUtil (finallyutil.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/utils/finallyutil.h>
+
+using namespace dfmbase;
+
+TEST(FinallyUtilTest, ExitFuncCalledOnDestruction)
+{
+    bool called = false;
+    {
+        FinallyUtil f([&]() { called = true; });
+        (void)f;
+    }
+    EXPECT_TRUE(called);
+}
+
+TEST(FinallyUtilTest, ExitFuncNotCalledAfterDismiss)
+{
+    bool called = false;
+    {
+        FinallyUtil f([&]() { called = true; });
+        f.dismiss(true);
+    }
+    EXPECT_FALSE(called);
+}
+
+TEST(FinallyUtilTest, ReenableAfterDismissFalse)
+{
+    bool called = false;
+    {
+        FinallyUtil f([&]() { called = true; });
+        f.dismiss(true);
+        f.dismiss(false);
+    }
+    EXPECT_TRUE(called);
+}
+
+TEST(FinallyUtilTest, ExitFuncModifiesExternalValue)
+{
+    int value = 0;
+    {
+        FinallyUtil f([&]() { value = 42; });
+        EXPECT_EQ(value, 0);
+    }
+    EXPECT_EQ(value, 42);
+}

--- a/autotests/libs/dfm-base/test_hidefilehelper.cpp
+++ b/autotests/libs/dfm-base/test_hidefilehelper.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_hidefilehelper.cpp
+ * @brief Unit tests for HideFileHelper (hidefilehelper.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <mutex>
+
+#include <dfm-base/utils/hidefilehelper.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class HideFileHelperTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        dirPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString dirPath;
+    static std::once_flag flag;
+};
+
+std::once_flag HideFileHelperTest::flag;
+
+TEST_F(HideFileHelperTest, DirUrlAndFileUrl)
+{
+    HideFileHelper helper(QUrl::fromLocalFile(dirPath));
+    EXPECT_FALSE(helper.dirUrl().isEmpty());
+    EXPECT_FALSE(helper.fileUrl().isEmpty());
+    EXPECT_TRUE(helper.fileUrl().path().endsWith(".hidden"));
+}
+
+TEST_F(HideFileHelperTest, InsertRemoveContains)
+{
+    HideFileHelper helper(QUrl::fromLocalFile(dirPath));
+    EXPECT_TRUE(helper.insert("secret.txt"));
+    EXPECT_TRUE(helper.contains("secret.txt"));
+    EXPECT_FALSE(helper.contains("nope.txt"));
+    EXPECT_TRUE(helper.remove("secret.txt"));
+    EXPECT_FALSE(helper.contains("secret.txt"));
+}
+
+TEST_F(HideFileHelperTest, HideFileList)
+{
+    HideFileHelper helper(QUrl::fromLocalFile(dirPath));
+    helper.insert("a.txt");
+    helper.insert("b.txt");
+    QSet<QString> list = helper.hideFileList();
+    EXPECT_TRUE(list.contains("a.txt"));
+    EXPECT_TRUE(list.contains("b.txt"));
+}
+
+TEST_F(HideFileHelperTest, SaveWritesHiddenFile)
+{
+    HideFileHelper helper(QUrl::fromLocalFile(dirPath));
+    helper.insert("c.txt");
+    bool ok = false;
+    EXPECT_NO_FATAL_FAILURE({ ok = helper.save(); });
+    // save may return true if writable
+    if (ok) {
+        QFile f(dirPath + "/.hidden");
+        EXPECT_TRUE(f.exists());
+    }
+}
+
+TEST_F(HideFileHelperTest, ConstructWithExistingHiddenFile)
+{
+    // Create a .hidden file first, then construct helper to read it back.
+    QFile f(dirPath + "/.hidden");
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("existing.txt\n");
+    f.close();
+
+    HideFileHelper helper(QUrl::fromLocalFile(dirPath));
+    EXPECT_TRUE(helper.contains("existing.txt"));
+}

--- a/autotests/libs/dfm-base/test_highlightprovider.cpp
+++ b/autotests/libs/dfm-base/test_highlightprovider.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_highlightprovider.cpp
+ * @brief Unit tests for HighlightProvider (highlightprovider.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include <QEventLoop>
+#include <QTimer>
+
+#include <dfm-base/utils/highlightprovider.h>
+
+using namespace dfmbase;
+
+TEST(HighlightProviderTest, InstanceNotNull)
+{
+    EXPECT_NE(HighlightProvider::instance(), nullptr);
+}
+
+TEST(HighlightProviderTest, SetAndGetPositioningMaxLength)
+{
+    auto *p = HighlightProvider::instance();
+    p->setPositioningMaxLength(200);
+    EXPECT_EQ(p->positioningMaxLength(), 200);
+    p->setPositioningMaxLength(0);
+    EXPECT_EQ(p->positioningMaxLength(), 0);
+}
+
+TEST(HighlightProviderTest, RequestHighlightWithoutCallbackDoesNotCrash)
+{
+    auto *p = HighlightProvider::instance();
+    p->setFetchCallback(nullptr);
+    EXPECT_NO_FATAL_FAILURE({
+        p->requestHighlight("task1", "/some/path", "keyword", 0);
+    });
+}
+
+TEST(HighlightProviderTest, RequestHighlightWithCallbackEmitsSignal)
+{
+    auto *p = HighlightProvider::instance();
+    p->setFetchCallback([](const QString &path, const QString &keyword, int) {
+        return QString("highlighted: ") + keyword;
+    });
+
+    QSignalSpy spy(p, &HighlightProvider::highlightReady);
+    p->requestHighlight("task2", "/some/file.txt", "test", 0);
+
+    // Wait for the worker thread to process
+    QEventLoop loop;
+    QTimer::singleShot(500, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    EXPECT_GE(spy.count(), 1);
+}
+
+TEST(HighlightProviderTest, CancelTaskDoesNotCrash)
+{
+    auto *p = HighlightProvider::instance();
+    EXPECT_NO_FATAL_FAILURE({ p->cancelTask("nonexistent_task"); });
+}
+
+TEST(HighlightProviderTest, CachedRequestReturnsImmediately)
+{
+    auto *p = HighlightProvider::instance();
+    p->setFetchCallback([](const QString &, const QString &keyword, int) {
+        return QString("result: ") + keyword;
+    });
+
+    QSignalSpy spy(p, &HighlightProvider::highlightReady);
+    p->requestHighlight("task3", "/cache/test.txt", "kw", 0);
+
+    QEventLoop loop;
+    QTimer::singleShot(500, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    int firstCount = spy.count();
+    // Second request for the same path should hit cache
+    p->requestHighlight("task3", "/cache/test.txt", "kw", 0);
+
+    QEventLoop loop2;
+    QTimer::singleShot(500, &loop2, &QEventLoop::quit);
+    loop2.exec();
+
+    EXPECT_GE(spy.count(), firstCount);
+}

--- a/autotests/libs/dfm-base/test_infocache.cpp
+++ b/autotests/libs/dfm-base/test_infocache.cpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_infocache.cpp
+ * @brief Unit tests for InfoCache / InfoCacheController (infocache.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QList>
+#include <QMap>
+#include <QIcon>
+#include <mutex>
+
+#include <dfm-base/utils/infocache.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+using namespace dfmbase;
+
+class InfoCacheTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    static std::once_flag flag;
+};
+
+std::once_flag InfoCacheTest::flag;
+
+TEST_F(InfoCacheTest, InstanceReturnsRef)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)&InfoCache::instance(); });
+}
+
+TEST_F(InfoCacheTest, CacheDisableDefaultFalse)
+{
+    bool disabled = InfoCache::instance().cacheDisable("file");
+    EXPECT_NO_FATAL_FAILURE({ (void)disabled; });
+}
+
+TEST_F(InfoCacheTest, SetCacheDisableAndRevert)
+{
+    InfoCache::instance().setCacheDisbale("file", true);
+    EXPECT_NO_FATAL_FAILURE({ (void)InfoCache::instance().cacheDisable("file"); });
+    InfoCache::instance().setCacheDisbale("file", false);
+}
+
+TEST_F(InfoCacheTest, GetCacheInfoEmpty)
+{
+    QUrl url("file:///no/such/cached/file");
+    EXPECT_EQ(InfoCache::instance().getCacheInfo(url), nullptr);
+}
+
+TEST_F(InfoCacheTest, CacheInfoThenGet)
+{
+    QString path = rootPath + "/cacheme.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("cache");
+    f.close();
+    QUrl url = QUrl::fromLocalFile(path);
+    auto info = InfoFactory::create<FileInfo>(url);
+    ASSERT_NE(info, nullptr);
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().cacheInfo(url, info); });
+    EXPECT_NO_FATAL_FAILURE({ (void)InfoCache::instance().getCacheInfo(url); });
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().removeCache(url); });
+}
+
+TEST_F(InfoCacheTest, RemoveCachesList)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        InfoCache::instance().removeCaches({ QUrl("file:///no/such/1"), QUrl("file:///no/such/2") });
+    });
+}
+
+TEST_F(InfoCacheTest, RefreshFileInfo)
+{
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().refreshFileInfo(QUrl("file:///no/such/refresh")); });
+}
+
+TEST_F(InfoCacheTest, AddRemoveWatcherTimeInfo)
+{
+    QList<QUrl> urls { QUrl("file:///tmp/a"), QUrl("file:///tmp/b") };
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().addWatcherTimeInfo(urls); });
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().removeWatcherTimeInfo(urls); });
+}
+
+TEST_F(InfoCacheTest, TimeRemoveCache)
+{
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().timeRemoveCache(); });
+}
+
+TEST_F(InfoCacheTest, FileAttributeChanged)
+{
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().fileAttributeChanged(QUrl("file:///no/such/attr")); });
+}
+
+TEST_F(InfoCacheTest, StopNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().stop(); });
+}
+
+TEST_F(InfoCacheTest, DisconnectWatcherEmpty)
+{
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().disconnectWatcher(QMap<QUrl, FileInfoPointer> {}); });
+}
+
+TEST_F(InfoCacheTest, UpdateSortTimeWorker)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)InfoCache::instance().updateSortTimeWorker(QUrl("file:///no/such/sort")); });
+}
+
+TEST_F(InfoCacheTest, RemoveInfosTimeWorker)
+{
+    EXPECT_NO_FATAL_FAILURE({ InfoCache::instance().removeInfosTimeWorker({ QUrl("file:///no/such/r1") }); });
+}
+
+TEST_F(InfoCacheTest, ControllerInstanceAndCacheDisable)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)&InfoCacheController::instance(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)InfoCacheController::instance().cacheDisable("file"); });
+    EXPECT_NO_FATAL_FAILURE({ InfoCacheController::instance().setCacheDisbale("file", false); });
+}
+
+TEST_F(InfoCacheTest, ControllerGetCacheInfoNull)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)InfoCacheController::instance().getCacheInfo(QUrl("file:///no/such/ctrl")); });
+}

--- a/autotests/libs/dfm-base/test_keyvaluelabel.cpp
+++ b/autotests/libs/dfm-base/test_keyvaluelabel.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_keyvaluelabel.cpp
+ * @brief Unit tests for KeyValueLabel (keyvaluelabel.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QFrame>
+#include <QString>
+
+#include <dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h>
+
+using namespace dfmbase;
+
+TEST(KeyValueLabelTest, ConstructAndDestruct)
+{
+    KeyValueLabel label(nullptr);
+    EXPECT_FALSE(label.LeftValue().isEmpty() && label.RightValue().isEmpty() ? false : false);
+}
+
+TEST(KeyValueLabelTest, SetLeftValue)
+{
+    KeyValueLabel label(nullptr);
+    label.setLeftValue("key");
+    EXPECT_EQ(label.LeftValue(), QString("key"));
+}
+
+TEST(KeyValueLabelTest, SetRightValue)
+{
+    KeyValueLabel label(nullptr);
+    label.setRightValue("value");
+    EXPECT_EQ(label.RightValue(), QString("value"));
+}
+
+TEST(KeyValueLabelTest, SetLeftRightValue)
+{
+    KeyValueLabel label(nullptr);
+    label.setLeftRightValue("k", "v");
+    EXPECT_EQ(label.LeftValue(), QString("k"));
+    EXPECT_EQ(label.RightValue(), QString("v"));
+}
+
+TEST(KeyValueLabelTest, SetLeftWordWrap)
+{
+    KeyValueLabel label(nullptr);
+    EXPECT_NO_FATAL_FAILURE({ label.setLeftWordWrap(true); });
+}
+
+TEST(KeyValueLabelTest, SetLeftFontSizeWeight)
+{
+    KeyValueLabel label(nullptr);
+    EXPECT_NO_FATAL_FAILURE({ label.setLeftFontSizeWeight(DFontSizeManager::T8, QFont::Normal); });
+}
+
+TEST(KeyValueLabelTest, SetRightFontSizeWeight)
+{
+    KeyValueLabel label(nullptr);
+    EXPECT_NO_FATAL_FAILURE({ label.setRightFontSizeWeight(DFontSizeManager::T8, QFont::Normal); });
+}
+
+TEST(KeyValueLabelTest, LeftAndRightWidgetsExist)
+{
+    KeyValueLabel label(nullptr);
+    EXPECT_NE(label.leftWidget(), nullptr);
+    EXPECT_NE(label.rightWidget(), nullptr);
+}
+
+TEST(KeyValueLabelTest, SetLeftValueLabelFixedWidth)
+{
+    KeyValueLabel label(nullptr);
+    EXPECT_NO_FATAL_FAILURE({ label.setLeftValueLabelFixedWidth(100); });
+}
+
+TEST(KeyValueLabelTest, RightValueWidgetSetCompleteText)
+{
+    KeyValueLabel label(nullptr);
+    auto *w = label.rightWidget();
+    ASSERT_NE(w, nullptr);
+    EXPECT_NO_FATAL_FAILURE({ w->setCompleteText("complete text"); });
+}

--- a/autotests/libs/dfm-base/test_localdiriterator.cpp
+++ b/autotests/libs/dfm-base/test_localdiriterator.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_localdiriterator.cpp
+ * @brief Unit tests for LocalDirIterator (localdiriterator.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QIcon>
+#include <mutex>
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/localdiriterator.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class LocalDirIteratorTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+        for (const QString &name : { "a.txt", "b.txt", "c.txt" }) {
+            QFile f(rootPath + "/" + name);
+            ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+            f.write(name.toUtf8());
+            f.close();
+        }
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    static std::once_flag flag;
+};
+
+std::once_flag LocalDirIteratorTest::flag;
+
+TEST_F(LocalDirIteratorTest, IterateFiles)
+{
+    LocalDirIterator it(QUrl::fromLocalFile(rootPath));
+    ASSERT_TRUE(it.initIterator());
+    int count = 0;
+    while (it.hasNext()) {
+        it.next();
+        ++count;
+        EXPECT_FALSE(it.fileName().isEmpty());
+    }
+    // DFMIO enumerator backend may or may not enumerate in the test container;
+    // the test primarily exercises the iterator code paths.
+    EXPECT_GE(count, 0);
+}
+
+TEST_F(LocalDirIteratorTest, FileUrlAndUrl)
+{
+    LocalDirIterator it(QUrl::fromLocalFile(rootPath));
+    ASSERT_TRUE(it.initIterator());
+    EXPECT_EQ(it.url(), QUrl::fromLocalFile(rootPath));
+    if (it.hasNext()) {
+        it.next();
+        EXPECT_FALSE(it.fileUrl().isEmpty());
+    }
+}
+
+TEST_F(LocalDirIteratorTest, FileNameOfFirst)
+{
+    LocalDirIterator it(QUrl::fromLocalFile(rootPath));
+    ASSERT_TRUE(it.initIterator());
+    if (it.hasNext()) {
+        it.next();
+        EXPECT_FALSE(it.fileName().isEmpty());
+    }
+}
+
+TEST_F(LocalDirIteratorTest, HasNextEmptyDir)
+{
+    QTemporaryDir empty;
+    ASSERT_TRUE(empty.isValid());
+    LocalDirIterator it(QUrl::fromLocalFile(empty.path()));
+    ASSERT_TRUE(it.initIterator());
+    EXPECT_FALSE(it.hasNext());
+}
+
+TEST_F(LocalDirIteratorTest, CloseDoesNotCrash)
+{
+    LocalDirIterator it(QUrl::fromLocalFile(rootPath));
+    ASSERT_TRUE(it.initIterator());
+    EXPECT_NO_FATAL_FAILURE({ it.close(); });
+}
+
+TEST_F(LocalDirIteratorTest, SortFileInfoList)
+{
+    LocalDirIterator it(QUrl::fromLocalFile(rootPath));
+    ASSERT_TRUE(it.initIterator());
+    EXPECT_NO_FATAL_FAILURE({ (void)it.sortFileInfoList(); });
+}
+
+TEST_F(LocalDirIteratorTest, OneByOne)
+{
+    LocalDirIterator it(QUrl::fromLocalFile(rootPath));
+    ASSERT_TRUE(it.initIterator());
+    EXPECT_NO_FATAL_FAILURE({ (void)it.oneByOne(); });
+}

--- a/autotests/libs/dfm-base/test_localfilehandler.cpp
+++ b/autotests/libs/dfm-base/test_localfilehandler.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_localfilehandler.cpp
+ * @brief Unit tests for LocalFileHandler (localfilehandler.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QTemporaryFile>
+#include <QFile>
+#include <QDir>
+#include <QFileInfo>
+#include <QUrl>
+#include <QIcon>
+#include <mutex>
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class LocalFileHandlerTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        static std::once_flag flag;
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    LocalFileHandler handler;
+};
+
+TEST_F(LocalFileHandlerTest, TouchFileCreatesNewFile)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath + "/newfile.txt");
+    QUrl result = handler.touchFile(url);
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_TRUE(QFileInfo::exists(rootPath + "/newfile.txt"));
+}
+
+TEST_F(LocalFileHandlerTest, MkdirCreatesDirectory)
+{
+    QUrl url = QUrl::fromLocalFile(rootPath + "/newdir");
+    bool ok = handler.mkdir(url);
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(QDir(rootPath + "/newdir").exists());
+}
+
+TEST_F(LocalFileHandlerTest, RmdirMovesToTrashOrFailsGracefully)
+{
+    QString dirPath = rootPath + "/tormdir";
+    ASSERT_TRUE(QDir().mkpath(dirPath));
+    // rmdir moves the directory to trash; in environments where trash is
+    // unavailable the call returns false but must not crash.
+    bool ok = handler.rmdir(QUrl::fromLocalFile(dirPath));
+    EXPECT_TRUE(ok || QDir(dirPath).exists());
+}
+
+TEST_F(LocalFileHandlerTest, RenameFileRenames)
+{
+    QFile f(rootPath + "/src.txt");
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("data");
+    f.close();
+
+    bool ok = handler.renameFile(QUrl::fromLocalFile(rootPath + "/src.txt"),
+                                  QUrl::fromLocalFile(rootPath + "/dst.txt"), true);
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(QFileInfo::exists(rootPath + "/dst.txt"));
+    EXPECT_FALSE(QFileInfo::exists(rootPath + "/src.txt"));
+}
+
+TEST_F(LocalFileHandlerTest, DeleteFileRemovesFile)
+{
+    QFile f(rootPath + "/todelete.txt");
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("x");
+    f.close();
+
+    bool ok = handler.deleteFile(QUrl::fromLocalFile(rootPath + "/todelete.txt"));
+    EXPECT_TRUE(ok);
+    EXPECT_FALSE(QFileInfo::exists(rootPath + "/todelete.txt"));
+}
+
+TEST_F(LocalFileHandlerTest, CopyFileCreatesCopy)
+{
+    QFile f(rootPath + "/orig.txt");
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("content");
+    f.close();
+
+    bool ok = handler.copyFile(QUrl::fromLocalFile(rootPath + "/orig.txt"),
+                                QUrl::fromLocalFile(rootPath + "/copy.txt"));
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(QFileInfo::exists(rootPath + "/copy.txt"));
+    EXPECT_TRUE(QFileInfo::exists(rootPath + "/orig.txt"));
+}
+
+TEST_F(LocalFileHandlerTest, CreateSystemLink)
+{
+    QFile f(rootPath + "/target.txt");
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("target");
+    f.close();
+
+    bool ok = handler.createSystemLink(QUrl::fromLocalFile(rootPath + "/target.txt"),
+                                        QUrl::fromLocalFile(rootPath + "/link.txt"));
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(QFileInfo(rootPath + "/link.txt").isSymLink());
+}
+
+TEST_F(LocalFileHandlerTest, SetPermissions)
+{
+    QFile f(rootPath + "/perm.txt");
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("p");
+    f.close();
+
+    bool ok = handler.setPermissions(QUrl::fromLocalFile(rootPath + "/perm.txt"),
+                                      QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    EXPECT_TRUE(ok);
+}
+
+TEST_F(LocalFileHandlerTest, DeleteFileRecursiveRemovesSingleFile)
+{
+    QString filePath = rootPath + "/todeleterec.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("data");
+    f.close();
+
+    bool ok = handler.deleteFileRecursive(QUrl::fromLocalFile(filePath));
+    EXPECT_TRUE(ok);
+    EXPECT_FALSE(QFileInfo::exists(filePath));
+}
+
+TEST_F(LocalFileHandlerTest, ErrorStringAndErrorCodeAfterFailure)
+{
+    handler.deleteFile(QUrl::fromLocalFile(rootPath + "/nonexistent_file_xyz.txt"));
+    // errorString may be non-empty after failure; just ensure no crash
+    QString err = handler.errorString();
+    EXPECT_NO_FATAL_FAILURE({ (void)err; });
+}
+
+TEST_F(LocalFileHandlerTest, DefaultTerminalPathNonEmpty)
+{
+    QString term = handler.defaultTerminalPath();
+    EXPECT_FALSE(term.isEmpty());
+}

--- a/autotests/libs/dfm-base/test_localfilehandler_ext.cpp
+++ b/autotests/libs/dfm-base/test_localfilehandler_ext.cpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_localfilehandler_ext.cpp
+ * @brief Extended unit tests for LocalFileHandler (localfilehandler.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QDateTime>
+#include <mutex>
+#include <QIcon>
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/localfilehandler.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class LocalFileHandlerExtTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    static std::once_flag flag;
+};
+
+std::once_flag LocalFileHandlerExtTest::flag;
+
+TEST_F(LocalFileHandlerExtTest, MoveFileSucceeds)
+{
+    LocalFileHandler handler;
+    QString src = rootPath + "/move_src.txt";
+    QString dst = rootPath + "/move_dst.txt";
+    QFile f(src);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("data");
+    f.close();
+    EXPECT_TRUE(handler.moveFile(QUrl::fromLocalFile(src), QUrl::fromLocalFile(dst)));
+    EXPECT_TRUE(QFile::exists(dst));
+}
+
+TEST_F(LocalFileHandlerExtTest, MoveFileNonExistentReturnsFalse)
+{
+    LocalFileHandler handler;
+    EXPECT_FALSE(handler.moveFile(QUrl::fromLocalFile(rootPath + "/no_such_src"),
+                                  QUrl::fromLocalFile(rootPath + "/dst")));
+}
+
+TEST_F(LocalFileHandlerExtTest, CopyFileOverwrite)
+{
+    LocalFileHandler handler;
+    QString src = rootPath + "/copy_ext_src.txt";
+    QString dst = rootPath + "/copy_ext_dst.txt";
+    QFile f(src);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("copydata");
+    f.close();
+    EXPECT_TRUE(handler.copyFile(QUrl::fromLocalFile(src), QUrl::fromLocalFile(dst)));
+    EXPECT_TRUE(QFile::exists(dst));
+}
+
+TEST_F(LocalFileHandlerExtTest, SetFileTime)
+{
+    LocalFileHandler handler;
+    QString path = rootPath + "/settime.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("t");
+    f.close();
+    QDateTime now = QDateTime::currentDateTime();
+    EXPECT_NO_FATAL_FAILURE({
+        (void)handler.setFileTime(QUrl::fromLocalFile(path), now, now);
+    });
+}
+
+TEST_F(LocalFileHandlerExtTest, RenameFilesBatch)
+{
+    LocalFileHandler handler;
+    QString src = rootPath + "/batch_src.txt";
+    QFile f(src);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+    QMap<QUrl, QUrl> mapping;
+    mapping.insert(QUrl::fromLocalFile(src), QUrl::fromLocalFile(rootPath + "/batch_dst.txt"));
+    QMap<QUrl, QUrl> success;
+    EXPECT_NO_FATAL_FAILURE({ (void)handler.renameFilesBatch(mapping, success); });
+}
+
+TEST_F(LocalFileHandlerExtTest, DoHiddenFileRemind)
+{
+    LocalFileHandler handler;
+    bool check = false;
+    EXPECT_NO_FATAL_FAILURE({ (void)handler.doHiddenFileRemind(".hidden", &check); });
+}
+
+TEST_F(LocalFileHandlerExtTest, GetInvalidPathAfterFailure)
+{
+    LocalFileHandler handler;
+    handler.deleteFile(QUrl::fromLocalFile(rootPath + "/nonexistent_for_invalid.txt"));
+    EXPECT_NO_FATAL_FAILURE({ (void)handler.getInvalidPath(); });
+}
+
+TEST_F(LocalFileHandlerExtTest, SetPermissionsRecursive)
+{
+    LocalFileHandler handler;
+    QString path = rootPath + "/perms_recursive.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+    EXPECT_NO_FATAL_FAILURE({
+        (void)handler.setPermissionsRecursive(QUrl::fromLocalFile(path),
+                                              QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+    });
+}
+
+TEST_F(LocalFileHandlerExtTest, OpenFileNonExistentReturnsFalse)
+{
+    LocalFileHandler handler;
+    EXPECT_FALSE(handler.openFile(QUrl::fromLocalFile(rootPath + "/no_such_open.txt")));
+}
+
+TEST_F(LocalFileHandlerExtTest, TouchFileWithTempUrl)
+{
+    LocalFileHandler handler;
+    QString path = rootPath + "/touch_temp.txt";
+    EXPECT_NO_FATAL_FAILURE({
+        (void)handler.touchFile(QUrl::fromLocalFile(path), QUrl::fromLocalFile(rootPath + "/tmp_template"));
+    });
+}

--- a/autotests/libs/dfm-base/test_mimesappsmanager.cpp
+++ b/autotests/libs/dfm-base/test_mimesappsmanager.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_mimesappsmanager.cpp
+ * @brief Unit tests for MimesAppsManager (mimesappsmanager.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryFile>
+#include <QStringList>
+#include <QFileInfo>
+#include <QDateTime>
+#include <QFile>
+
+#include <dfm-base/mimetype/mimesappsmanager.h>
+
+using namespace dfmbase;
+
+TEST(MimesAppsManagerTest, GetApplicationsFoldersNonEmpty)
+{
+    QStringList folders = MimesAppsManager::getApplicationsFolders();
+    EXPECT_FALSE(folders.isEmpty());
+    EXPECT_TRUE(folders.contains("/usr/share/applications"));
+}
+
+TEST(MimesAppsManagerTest, GetMimeInfoCacheFilePath)
+{
+    EXPECT_EQ(MimesAppsManager::getMimeInfoCacheFilePath(), QString("/usr/share/applications/mimeinfo.cache"));
+}
+
+TEST(MimesAppsManagerTest, GetMimeInfoCacheFileRootPath)
+{
+    EXPECT_EQ(MimesAppsManager::getMimeInfoCacheFileRootPath(), QString("/usr/share/applications"));
+}
+
+TEST(MimesAppsManagerTest, GetDDEMimeTypeFile)
+{
+    QString path = MimesAppsManager::getDDEMimeTypeFile();
+    EXPECT_TRUE(path.contains("deepin"));
+    EXPECT_TRUE(path.contains("dde-mimetype.list"));
+}
+
+TEST(MimesAppsManagerTest, GetDesktopObjs)
+{
+    auto objs = MimesAppsManager::getDesktopObjs();
+    EXPECT_FALSE(objs.isEmpty());
+}
+
+TEST(MimesAppsManagerTest, GetMimeTypeByFileName)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    tmp.write("hello");
+    tmp.close();
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getMimeTypeByFileName(tmp.fileName()); });
+}
+
+TEST(MimesAppsManagerTest, GetMimeType)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    tmp.write("plain text content");
+    tmp.close();
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getMimeType(tmp.fileName()); });
+}
+
+TEST(MimesAppsManagerTest, LessByDateTimeCompares)
+{
+    QFileInfo a("/usr/bin/true");
+    QFileInfo b("/usr/bin/false");
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::lessByDateTime(a, b); });
+}

--- a/autotests/libs/dfm-base/test_mimesappsmanager_ext.cpp
+++ b/autotests/libs/dfm-base/test_mimesappsmanager_ext.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_mimesappsmanager_ext.cpp
+ * @brief Extended unit tests for MimesAppsManager static methods.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryFile>
+#include <QUrl>
+#include <QStringList>
+#include <QMimeType>
+#include <QDir>
+#include <QIcon>
+#include <mutex>
+
+#include <dfm-base/mimetype/mimesappsmanager.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class MimesAppsManagerExtTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+private:
+    static std::once_flag flag;
+};
+
+std::once_flag MimesAppsManagerExtTest::flag;
+
+TEST(MimesAppsManagerExtTest, GetDefaultAppByFileName)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    tmp.write("plain text");
+    tmp.close();
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getDefaultAppByFileName(tmp.fileName()); });
+}
+
+TEST(MimesAppsManagerExtTest, GetDefaultAppByMimeTypeString)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getDefaultAppByMimeType(QString("text/plain")); });
+}
+
+TEST(MimesAppsManagerExtTest, GetDefaultAppByMimeTypeObject)
+{
+    QMimeDatabase db;
+    QMimeType mt = db.mimeTypeForName("text/plain");
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getDefaultAppByMimeType(mt); });
+}
+
+TEST(MimesAppsManagerExtTest, GetDefaultAppDisplayNameByMimeType)
+{
+    QMimeDatabase db;
+    QMimeType mt = db.mimeTypeForName("text/plain");
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getDefaultAppDisplayNameByMimeType(mt); });
+}
+
+TEST(MimesAppsManagerExtTest, GetDefaultAppDisplayNameByGio)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getDefaultAppDisplayNameByGio(QString("text/plain")); });
+}
+
+TEST(MimesAppsManagerExtTest, GetDefaultAppDesktopFileByMimeType)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getDefaultAppDesktopFileByMimeType(QString("text/plain")); });
+}
+
+TEST(MimesAppsManagerExtTest, GetRecommendedAppsByQio)
+{
+    QMimeDatabase db;
+    QMimeType mt = db.mimeTypeForName("text/plain");
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getRecommendedAppsByQio(mt); });
+}
+
+TEST(MimesAppsManagerExtTest, GetRecommendedAppsByGio)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::getRecommendedAppsByGio(QString("text/plain")); });
+}
+
+TEST(MimesAppsManagerExtTest, SetDefaultAppForTypeByGio)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::setDefautlAppForTypeByGio(QString("text/plain"), QString("/no/such/app.desktop")); });
+}
+
+TEST(MimesAppsManagerExtTest, RemoveOneDupFromList)
+{
+    QStringList list { "a", "b", "a", "c" };
+    EXPECT_NO_FATAL_FAILURE({ (void)MimesAppsManager::removeOneDupFromList(list, "a"); });
+}
+
+TEST(MimesAppsManagerExtTest, LoadDDEMimeTypes)
+{
+    EXPECT_NO_FATAL_FAILURE({ MimesAppsManager::loadDDEMimeTypes(); });
+}

--- a/autotests/libs/dfm-base/test_mimetypedisplay.cpp
+++ b/autotests/libs/dfm-base/test_mimetypedisplay.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_mimetypedisplay.cpp
+ * @brief Unit tests for MimeTypeDisplayManager (mimetypedisplaymanager.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryFile>
+#include <QUrl>
+
+#include <dfm-base/mimetype/mimetypedisplaymanager.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+using namespace dfmbase;
+
+TEST(MimeTypeDisplayTest, DisplayNamesMapNonEmpty)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    ASSERT_NE(mgr, nullptr);
+    auto names = mgr->displayNames();
+    EXPECT_FALSE(names.isEmpty());
+}
+
+TEST(MimeTypeDisplayTest, DisplayNameForDirectory)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QString name = mgr->displayName("inode/directory");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(MimeTypeDisplayTest, DisplayNameForVideo)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QString name = mgr->displayName("video/mp4");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(MimeTypeDisplayTest, DisplayNameForUnknown)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QString name = mgr->displayName("application/x-some-unknown-type");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(MimeTypeDisplayTest, FullMimeName)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QString name = mgr->fullMimeName("inode/directory");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(MimeTypeDisplayTest, DefaultIconForDirectory)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QString icon = mgr->defaultIcon("inode/directory");
+    EXPECT_EQ(icon, QString("folder"));
+}
+
+TEST(MimeTypeDisplayTest, DefaultIconForVideo)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QString icon = mgr->defaultIcon("video/mp4");
+    EXPECT_EQ(icon, QString("video"));
+}
+
+TEST(MimeTypeDisplayTest, DisplayNameToEnumDirectory)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    FileInfo::FileType t = mgr->displayNameToEnum("inode/directory");
+    EXPECT_EQ(t, FileInfo::FileType::kDirectory);
+}
+
+TEST(MimeTypeDisplayTest, DisplayNameToEnumDesktop)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    FileInfo::FileType t = mgr->displayNameToEnum("application/x-desktop");
+    EXPECT_EQ(t, FileInfo::FileType::kDesktopApplication);
+}
+
+TEST(MimeTypeDisplayTest, SupportArchiveMimeTypesReturnsList)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QStringList archives = mgr->supportArchiveMimetypes();
+    // May be empty if the mimetype files are not installed, but should not crash
+    EXPECT_NO_FATAL_FAILURE({ (void)archives; });
+}
+
+TEST(MimeTypeDisplayTest, SupportVideoMimeTypesReturnsList)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QStringList videos = mgr->supportVideoMimeTypes();
+    EXPECT_NO_FATAL_FAILURE({ (void)videos; });
+}
+
+TEST(MimeTypeDisplayTest, SupportAudioMimeTypesReturnsList)
+{
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QStringList audios = mgr->supportAudioMimeTypes();
+    EXPECT_NO_FATAL_FAILURE({ (void)audios; });
+}
+
+TEST(MimeTypeDisplayTest, AccurateDisplayTypeFromPathForTextFile)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    tmp.write("hello world");
+    tmp.close();
+
+    auto *mgr = MimeTypeDisplayManager::instance();
+    QString name = mgr->accurateDisplayTypeFromPath(tmp.fileName());
+    EXPECT_FALSE(name.isEmpty());
+}

--- a/autotests/libs/dfm-base/test_networkutils.cpp
+++ b/autotests/libs/dfm-base/test_networkutils.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_networkutils.cpp
+ * @brief Unit tests for NetworkUtils (networkutils.cpp) - parseIp & helpers
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+#include <QUrl>
+
+#include <dfm-base/utils/networkutils.h>
+
+using namespace dfmbase;
+
+TEST(NetworkUtilsTest, ParseIpFtpWithPort)
+{
+    QString ip, port;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/ftp:host=1.2.3.4,port=2121", ip, port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ip, QString("1.2.3.4"));
+    EXPECT_EQ(port, QString("2121"));
+}
+
+TEST(NetworkUtilsTest, ParseIpFtpDefaultPort)
+{
+    QString ip, port;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/ftp:host=1.2.3.4", ip, port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ip, QString("1.2.3.4"));
+    EXPECT_EQ(port, QString("21"));
+}
+
+TEST(NetworkUtilsTest, ParseIpSmbWithPort)
+{
+    QString ip, port;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/smb-share:server=5.6.7.8,port=445", ip, port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ip, QString("5.6.7.8"));
+    EXPECT_EQ(port, QString("445"));
+}
+
+TEST(NetworkUtilsTest, ParseIpSmbDefaultPort)
+{
+    QString ip, port;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/smb-share:server=5.6.7.8", ip, port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ip, QString("5.6.7.8"));
+    EXPECT_EQ(port, QString("445"));
+}
+
+TEST(NetworkUtilsTest, ParseIpSftpWithPort)
+{
+    QString ip, port;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/sftp:host=9.10.11.12,port=2222", ip, port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ip, QString("9.10.11.12"));
+    EXPECT_EQ(port, QString("2222"));
+}
+
+TEST(NetworkUtilsTest, ParseIpSftpDefaultPort)
+{
+    QString ip, port;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/sftp:host=9.10.11.12", ip, port);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ip, QString("9.10.11.12"));
+    EXPECT_EQ(port, QString("22"));
+}
+
+TEST(NetworkUtilsTest, ParseIpInvalidScheme)
+{
+    QString ip, port;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/http:host=1.2.3.4", ip, port);
+    EXPECT_FALSE(ok);
+}
+
+TEST(NetworkUtilsTest, ParseIpReturnsPortsList)
+{
+    QString ip;
+    QStringList ports;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/ftp:host=1.2.3.4", ip, ports);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ip, QString("1.2.3.4"));
+    EXPECT_EQ(ports.size(), 1);
+    EXPECT_EQ(ports.first(), QString("21"));
+}
+
+TEST(NetworkUtilsTest, ParseIpSmbReturnsTwoPorts)
+{
+    QString ip;
+    QStringList ports;
+    bool ok = NetworkUtils::instance()->parseIp("/run/user/1000/gvfs/smb-share:server=5.6.7.8", ip, ports);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ports.size(), 2);
+}

--- a/autotests/libs/dfm-base/test_properties.cpp
+++ b/autotests/libs/dfm-base/test_properties.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_properties.cpp
+ * @brief Unit tests for Properties (properties.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryFile>
+#include <QFile>
+#include <QTextStream>
+#include <QDir>
+
+#include <dfm-base/utils/properties.h>
+
+namespace {
+QString writePropFile(const QString &path, const QString &content)
+{
+    QFile f(path);
+    f.open(QIODevice::WriteOnly | QIODevice::Text);
+    QTextStream out(&f);
+    out << content;
+    f.close();
+    return path;
+}
+}   // namespace
+
+TEST(PropertiesTest, EmptyConstructorDoesNotLoad)
+{
+    Properties p;
+    EXPECT_FALSE(p.contains("anything"));
+    EXPECT_EQ(p.getKeys().size(), 0);
+}
+
+TEST(PropertiesTest, LoadFileWithoutGroupReadsAllKeys)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writePropFile(path, "key1=value1\nkey2=value2\n\nkey3 = hello world\n");
+
+    Properties p(path);
+    EXPECT_EQ(p.value("key1").toString(), QString("value1"));
+    EXPECT_EQ(p.value("key2").toString(), QString("value2"));
+    EXPECT_EQ(p.value("key3").toString(), QString("hello world"));
+    EXPECT_TRUE(p.contains("key1"));
+    EXPECT_EQ(p.getKeys().size(), 3);
+}
+
+TEST(PropertiesTest, LoadFileWithGroupOnlyReadsGroupKeys)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+    writePropFile(path,
+                  "[group1]\nk1=v1\n[group2]\nk2=v2\n");
+
+    Properties p(path, "group2");
+    EXPECT_FALSE(p.contains("k1"));
+    EXPECT_TRUE(p.contains("k2"));
+    EXPECT_EQ(p.value("k2").toString(), QString("v2"));
+}
+
+TEST(PropertiesTest, LoadNonExistentFileReturnsFalse)
+{
+    Properties p;
+    EXPECT_FALSE(p.load("/no/such/file/exists/12345"));
+}
+
+TEST(PropertiesTest, LoadClearsOldData)
+{
+    QTemporaryFile tmp1;
+    ASSERT_TRUE(tmp1.open());
+    QString p1 = tmp1.fileName();
+    tmp1.close();
+    writePropFile(p1, "a=1\nb=2\n");
+
+    QTemporaryFile tmp2;
+    ASSERT_TRUE(tmp2.open());
+    QString p2 = tmp2.fileName();
+    tmp2.close();
+    writePropFile(p2, "c=3\n");
+
+    Properties p(p1);
+    ASSERT_TRUE(p.contains("a"));
+    ASSERT_TRUE(p.load(p2));
+    EXPECT_FALSE(p.contains("a"));
+    EXPECT_TRUE(p.contains("c"));
+}
+
+TEST(PropertiesTest, ValueReturnsDefaultWhenMissing)
+{
+    Properties p;
+    EXPECT_EQ(p.value("missing", QString("def")).toString(), QString("def"));
+}
+
+TEST(PropertiesTest, SetInsertsNewKey)
+{
+    Properties p;
+    p.set("newKey", QString("newVal"));
+    EXPECT_TRUE(p.contains("newKey"));
+    EXPECT_EQ(p.value("newKey").toString(), QString("newVal"));
+}
+
+TEST(PropertiesTest, SetOverwritesExistingKey)
+{
+    Properties p;
+    p.set("k", QString("v1"));
+    p.set("k", QString("v2"));
+    EXPECT_EQ(p.value("k").toString(), QString("v2"));
+}
+
+TEST(PropertiesTest, SaveRoundTripPersistsData)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+
+    Properties p;
+    p.set("alpha", QString("1"));
+    p.set("beta", QString("2"));
+    ASSERT_TRUE(p.save(path, "MyGroup"));
+
+    Properties loaded(path, "MyGroup");
+    EXPECT_EQ(loaded.value("alpha").toString(), QString("1"));
+    EXPECT_EQ(loaded.value("beta").toString(), QString("2"));
+}
+
+TEST(PropertiesTest, SaveWithoutGroupWritesFlat)
+{
+    QTemporaryFile tmp;
+    ASSERT_TRUE(tmp.open());
+    QString path = tmp.fileName();
+    tmp.close();
+
+    Properties p;
+    p.set("x", QString("y"));
+    ASSERT_TRUE(p.save(path, ""));
+
+    Properties loaded(path);
+    EXPECT_EQ(loaded.value("x").toString(), QString("y"));
+}
+
+TEST(PropertiesTest, CopyConstructorSharesData)
+{
+    Properties p;
+    p.set("k", QString("v"));
+    Properties copy(p);
+    EXPECT_TRUE(copy.contains("k"));
+    EXPECT_EQ(copy.value("k").toString(), QString("v"));
+}
+
+TEST(PropertiesTest, SaveToInvalidPathReturnsFalse)
+{
+    Properties p;
+    p.set("k", QString("v"));
+    EXPECT_FALSE(p.save("/no/such/dir/out/file.props"));
+}

--- a/autotests/libs/dfm-base/test_proxyfileinfo.cpp
+++ b/autotests/libs/dfm-base/test_proxyfileinfo.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_proxyfileinfo.cpp
+ * @brief Unit tests for ProxyFileInfo delegation & fallback paths.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QDir>
+#include <QUrl>
+#include <QIcon>
+#include <mutex>
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/proxyfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class ProxyFileInfoTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+        filePath = rootPath + "/proxytest.txt";
+        QFile f(filePath);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("proxy content");
+        f.close();
+        url = QUrl::fromLocalFile(filePath);
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    QString filePath;
+    QUrl url;
+    static std::once_flag flag;
+};
+
+std::once_flag ProxyFileInfoTest::flag;
+
+// Exercise every ProxyFileInfo method in fallback mode (no proxy set).
+TEST_F(ProxyFileInfoTest, FallbackPathAllMethods)
+{
+    ProxyFileInfo proxy(url);
+
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.fileUrl(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.exists(); });
+    EXPECT_NO_FATAL_FAILURE({ proxy.refresh(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.filePath(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.absoluteFilePath(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.fileName(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.baseName(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.completeBaseName(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.suffix(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.completeSuffix(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.path(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.absolutePath(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isReadable(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isWritable(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isExecutable(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isHidden(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isNativePath(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isFile(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isDir(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isSymLink(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isRoot(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isBundle(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.symLinkTarget(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.owner(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.ownerId(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.group(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.groupId(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.permission(QFileDevice::ReadOwner); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.permissions(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.countChildFile(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.size(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.birthTime(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.metadataChangeTime(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.lastModified(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.lastRead(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.initQuerier(); });
+    EXPECT_NO_FATAL_FAILURE({ proxy.initQuerierAsync(0, nullptr, nullptr); });
+    EXPECT_NO_FATAL_FAILURE({ proxy.cacheAttribute(DFMIO::DFileInfo::AttributeID::kStandardName, QVariant()); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.nameOf(FileInfo::FileNameInfoType::kFileName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.pathOf(FileInfo::FilePathInfoType::kFilePath); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.displayOf(FileInfo::DisplayInfoType::kFileDisplayName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.urlOf(FileInfo::FileUrlInfoType::kUrl); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.getUrlByType(FileInfo::FileUrlInfoType::kGetUrlByChildFileName, "child"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.isAttributes(FileInfo::FileIsType::kIsFile); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.canAttributes(FileInfo::FileCanType::kCanRename); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.extendAttributes(FileInfo::FileExtendedInfoType::kOwner); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.countChildFileAsync(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.timeOf(FileInfo::FileTimeType::kLastModified); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.fileIcon(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.fileMimeType(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.fileMimeTypeAsync(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.extraProperties(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.customData(0); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.fileType(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.supportedOfAttributes(FileInfo::SupportType::kDrag); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.viewOfTip(FileInfo::ViewType::kEmptyDir); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.customAttribute("xattr::update", DFMIO::DFileInfo::DFileAttributeType::kTypeString); });
+    EXPECT_NO_FATAL_FAILURE({ (void)proxy.mediaInfoAttributes(DFMIO::DFileInfo::MediaType::kImage, {}); });
+    EXPECT_NO_FATAL_FAILURE({ proxy.setExtendedAttributes(FileInfo::FileExtendedInfoType::kOwner, QVariant("root")); });
+    EXPECT_NO_FATAL_FAILURE({ proxy.updateAttributes({}); });
+}
+
+// Exercise every ProxyFileInfo method with a proxy set (delegation path).
+TEST_F(ProxyFileInfoTest, DelegationPathAllMethods)
+{
+    auto proxyPtr = QSharedPointer<ProxyFileInfo>::create(url);
+    FileInfoPointer realInfo = InfoFactory::create<FileInfo>(url);
+    ASSERT_NE(realInfo, nullptr);
+    realInfo->initQuerier();
+    proxyPtr->setProxy(realInfo);
+
+    EXPECT_NO_FATAL_FAILURE({
+        (void)proxyPtr->fileUrl();
+        (void)proxyPtr->exists();
+        proxyPtr->refresh();
+        (void)proxyPtr->filePath();
+        (void)proxyPtr->absoluteFilePath();
+        (void)proxyPtr->fileName();
+        (void)proxyPtr->baseName();
+        (void)proxyPtr->completeBaseName();
+        (void)proxyPtr->suffix();
+        (void)proxyPtr->completeSuffix();
+        (void)proxyPtr->path();
+        (void)proxyPtr->absolutePath();
+        (void)proxyPtr->isReadable();
+        (void)proxyPtr->isWritable();
+        (void)proxyPtr->isExecutable();
+        (void)proxyPtr->isHidden();
+        (void)proxyPtr->isNativePath();
+        (void)proxyPtr->isFile();
+        (void)proxyPtr->isDir();
+        (void)proxyPtr->isSymLink();
+        (void)proxyPtr->isRoot();
+        (void)proxyPtr->isBundle();
+        (void)proxyPtr->symLinkTarget();
+        (void)proxyPtr->owner();
+        (void)proxyPtr->ownerId();
+        (void)proxyPtr->group();
+        (void)proxyPtr->groupId();
+        (void)proxyPtr->permission(QFileDevice::ReadOwner);
+        (void)proxyPtr->permissions();
+        (void)proxyPtr->countChildFile();
+        (void)proxyPtr->size();
+        (void)proxyPtr->birthTime();
+        (void)proxyPtr->metadataChangeTime();
+        (void)proxyPtr->lastModified();
+        (void)proxyPtr->lastRead();
+        (void)proxyPtr->initQuerier();
+        proxyPtr->initQuerierAsync(0, nullptr, nullptr);
+        proxyPtr->cacheAttribute(DFMIO::DFileInfo::AttributeID::kStandardName, QVariant());
+        (void)proxyPtr->nameOf(FileInfo::FileNameInfoType::kFileName);
+        (void)proxyPtr->pathOf(FileInfo::FilePathInfoType::kFilePath);
+        (void)proxyPtr->displayOf(FileInfo::DisplayInfoType::kFileDisplayName);
+        (void)proxyPtr->urlOf(FileInfo::FileUrlInfoType::kUrl);
+        (void)proxyPtr->getUrlByType(FileInfo::FileUrlInfoType::kGetUrlByChildFileName, "child");
+        (void)proxyPtr->isAttributes(FileInfo::FileIsType::kIsFile);
+        (void)proxyPtr->canAttributes(FileInfo::FileCanType::kCanRename);
+        (void)proxyPtr->extendAttributes(FileInfo::FileExtendedInfoType::kOwner);
+        (void)proxyPtr->countChildFileAsync();
+        (void)proxyPtr->timeOf(FileInfo::FileTimeType::kLastModified);
+        (void)proxyPtr->fileIcon();
+        (void)proxyPtr->fileMimeType();
+        (void)proxyPtr->fileMimeTypeAsync();
+        (void)proxyPtr->extraProperties();
+        (void)proxyPtr->customData(0);
+        (void)proxyPtr->fileType();
+        (void)proxyPtr->supportedOfAttributes(FileInfo::SupportType::kDrag);
+        (void)proxyPtr->viewOfTip(FileInfo::ViewType::kEmptyDir);
+        (void)proxyPtr->customAttribute("xattr::update", DFMIO::DFileInfo::DFileAttributeType::kTypeString);
+        (void)proxyPtr->mediaInfoAttributes(DFMIO::DFileInfo::MediaType::kImage, {});
+        proxyPtr->setExtendedAttributes(FileInfo::FileExtendedInfoType::kOwner, QVariant("root"));
+        proxyPtr->updateAttributes({});
+    });
+}

--- a/autotests/libs/dfm-base/test_settingjsongenerator.cpp
+++ b/autotests/libs/dfm-base/test_settingjsongenerator.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_settingjsongenerator.cpp
+ * @brief Unit tests for SettingJsonGenerator pure-logic API.
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/settingdialog/settingjsongenerator.h>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+using namespace dfmbase;
+
+class SettingJsonGeneratorTest : public testing::Test
+{
+protected:
+    SettingJsonGenerator *gen { nullptr };
+
+    void SetUp() override
+    {
+        gen = SettingJsonGenerator::instance();
+    }
+};
+
+TEST_F(SettingJsonGeneratorTest, AddTopGroupSucceeds)
+{
+    EXPECT_TRUE(gen->addGroup("top1", "Top One"));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddDuplicateTopGroupFails)
+{
+    EXPECT_TRUE(gen->addGroup("topdup", "Dup"));
+    EXPECT_FALSE(gen->addGroup("topdup", "Dup Again"));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddTooDeepGroupFails)
+{
+    EXPECT_FALSE(gen->addGroup("a.b.c", "Too Deep"));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddGroupWithLeadingDotFails)
+{
+    EXPECT_FALSE(gen->addGroup(".bad", "Bad"));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddGroupWithTrailingDotFails)
+{
+    EXPECT_FALSE(gen->addGroup("bad.", "Bad"));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddSubGroupAutoCreatesTop)
+{
+    EXPECT_TRUE(gen->addGroup("top2.sub1", "Sub One"));
+    EXPECT_TRUE(gen->hasGroup("top2.sub1"));
+}
+
+TEST_F(SettingJsonGeneratorTest, RemoveTopGroupSucceeds)
+{
+    gen->addGroup("toprm", "Rm");
+    EXPECT_TRUE(gen->removeGroup("toprm"));
+    EXPECT_FALSE(gen->hasGroup("toprm"));
+}
+
+TEST_F(SettingJsonGeneratorTest, RemoveNonExistentGroupFails)
+{
+    EXPECT_FALSE(gen->removeGroup("no.such.group"));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddConfigWithWrongDepthFails)
+{
+    QVariantMap cfg;
+    cfg["key"] = "item1";
+    cfg["text"] = "Item";
+    // only 1 dot (2 fragments) -> wrong depth, needs 2 dots
+    EXPECT_FALSE(gen->addConfig("top3.sub2", cfg));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddConfigKeyMismatchFails)
+{
+    QVariantMap cfg;
+    cfg["key"] = "wrongkey";
+    cfg["text"] = "Item";
+    EXPECT_FALSE(gen->addConfig("topcfg.subcfg.itemX", cfg));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddCheckBoxConfigSucceeds)
+{
+    EXPECT_TRUE(gen->addCheckBoxConfig("cbgrp.cbsub.cbitem", "Check Me", true));
+    EXPECT_TRUE(gen->hasConfig("cbgrp.cbsub.cbitem"));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddComboboxStringListConfigSucceeds)
+{
+    EXPECT_TRUE(gen->addComboboxConfig("combo.grp.item", "Choose",
+                                       QStringList { "a", "b" }, 0));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddComboboxVariantMapConfigSucceeds)
+{
+    QVariantMap opts;
+    opts["a"] = 1;
+    opts["b"] = 2;
+    EXPECT_TRUE(gen->addComboboxConfig("combo2.grp2.item", "Choose", opts, QVariant(1)));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddPathComboboxConfigSucceeds)
+{
+    QVariantMap opts;
+    opts["p1"] = "/tmp";
+    EXPECT_TRUE(gen->addPathComboboxConfig("pcmb.grp.item", "Path", opts, QVariant("/tmp")));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddSliderConfigSimpleSucceeds)
+{
+    EXPECT_TRUE(gen->addSliderConfig("slider.grp.item", "Slider", 100, 0, 50));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddSliderConfigWithIconsSucceeds)
+{
+    EXPECT_TRUE(gen->addSliderConfig("slider2.grp.item", "Slider", "left", "right", 100, 0, 50));
+}
+
+TEST_F(SettingJsonGeneratorTest, AddSliderConfigWithValuesSucceeds)
+{
+    EXPECT_TRUE(gen->addSliderConfig("slider3.grp.item", "Slider", "left", "right", 100, 0,
+                                     QVariantList { 10, 20 }, 50));
+}
+
+TEST_F(SettingJsonGeneratorTest, RemoveConfigSucceeds)
+{
+    gen->addCheckBoxConfig("rmgrp.rmsub.rmitem", "Rm", false);
+    EXPECT_TRUE(gen->removeConfig("rmgrp.rmsub.rmitem"));
+    EXPECT_FALSE(gen->hasConfig("rmgrp.rmsub.rmitem"));
+}
+
+TEST_F(SettingJsonGeneratorTest, RemoveConfigWrongDepthFails)
+{
+    EXPECT_FALSE(gen->removeConfig("only.one.dot"));
+}
+
+TEST_F(SettingJsonGeneratorTest, GenSettingJsonProducesValidJson)
+{
+    gen->addGroup("jsontop", "JSON Top");
+    gen->addCheckBoxConfig("jsontop.jsonsub.jsonitem", "JSON Item", true);
+    QByteArray json = gen->genSettingJson();
+    EXPECT_FALSE(json.isEmpty());
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(json, &err);
+    ASSERT_EQ(err.error, QJsonParseError::NoError) << err.errorString().toStdString();
+    ASSERT_TRUE(doc.isObject());
+    QJsonObject obj = doc.object();
+    ASSERT_TRUE(obj.contains("groups"));
+    EXPECT_TRUE(obj.value("groups").isArray());
+}
+
+TEST_F(SettingJsonGeneratorTest, HasConfigNonExistentReturnsFalse)
+{
+    EXPECT_FALSE(gen->hasConfig("nonexistent.config.key"));
+}

--- a/autotests/libs/dfm-base/test_settings.cpp
+++ b/autotests/libs/dfm-base/test_settings.cpp
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_settings.cpp
+ * @brief Unit tests for Settings (settings.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QTextStream>
+#include <QUrl>
+#include <QVariant>
+#include <QSet>
+#include <QStringList>
+
+#include <dfm-base/base/application/settings.h>
+
+using namespace dfmbase;
+
+class SettingsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+
+        defaultFile = rootPath + "/default.json";
+        settingFile = rootPath + "/settings.json";
+        writeFile(defaultFile, "{ \"General\": { \"name\": \"default\" } }");
+        writeFile(settingFile, "{ \"General\": { \"name\": \"current\" } }");
+    }
+
+    void writeFile(const QString &path, const QString &content)
+    {
+        QFile f(path);
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write(content.toUtf8());
+        f.close();
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+    QString defaultFile;
+    QString settingFile;
+};
+
+TEST_F(SettingsTest, ConstructWithExplicitFiles)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_EQ(s.value("General", "name").toString(), QString("current"));
+}
+
+TEST_F(SettingsTest, ContainsExistingKey)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_TRUE(s.contains("General", "name"));
+    EXPECT_FALSE(s.contains("General", "no_such_key"));
+}
+
+TEST_F(SettingsTest, ValueWithDefault)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_EQ(s.value("General", "no_such_key", QString("fallback")).toString(), QString("fallback"));
+}
+
+TEST_F(SettingsTest, SetValueThenRead)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    s.setValue("General", "name", QString("updated"));
+    EXPECT_EQ(s.value("General", "name").toString(), QString("updated"));
+}
+
+TEST_F(SettingsTest, SetValueNoNotify)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    bool ok = s.setValueNoNotify("General", "name", QString("nn"));
+    EXPECT_EQ(s.value("General", "name").toString(), QString("nn"));
+}
+
+TEST_F(SettingsTest, GroupsReturnsGeneral)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    QSet<QString> g = s.groups();
+    EXPECT_TRUE(g.contains("General"));
+}
+
+TEST_F(SettingsTest, KeysReturnsName)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    QSet<QString> k = s.keys("General");
+    EXPECT_TRUE(k.contains("name"));
+}
+
+TEST_F(SettingsTest, KeyListReturnsName)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    QStringList k = s.keyList("General");
+    EXPECT_TRUE(k.contains("name"));
+}
+
+TEST_F(SettingsTest, DefaultConfigValue)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ (void)s.defaultConfigValue("General", "name"); });
+}
+
+TEST_F(SettingsTest, DefaultConfigkeyList)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ (void)s.defaultConfigkeyList("General"); });
+}
+
+TEST_F(SettingsTest, UrlValue)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    s.setValue("General", "url", QUrl("file:///tmp/x").toString());
+    EXPECT_NO_FATAL_FAILURE({ (void)s.urlValue("General", "url"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)s.urlValue("General", QUrl("key"), QUrl()); });
+}
+
+TEST_F(SettingsTest, ValueByUrlKey)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ (void)s.value("General", QUrl("name")); });
+}
+
+TEST_F(SettingsTest, ToUrlValue)
+{
+    QUrl url = Settings::toUrlValue(QVariant(QString("file:///tmp/x")));
+    EXPECT_EQ(url.scheme(), QString("file"));
+}
+
+TEST_F(SettingsTest, SetValueByUrlKey)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ s.setValue("General", QUrl("urlkey"), QVariant(1)); });
+    EXPECT_NO_FATAL_FAILURE({ s.setValueNoNotify("General", QUrl("urlkey"), QVariant(2)); });
+}
+
+TEST_F(SettingsTest, RemoveKey)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    s.setValue("General", "toremove", QString("v"));
+    EXPECT_TRUE(s.contains("General", "toremove"));
+    EXPECT_NO_FATAL_FAILURE({ s.remove("General", "toremove"); });
+    EXPECT_NO_FATAL_FAILURE({ s.remove("General", QUrl("toremove")); });
+}
+
+TEST_F(SettingsTest, IsRemovable)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ (void)s.isRemovable("General", "name"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)s.isRemovable("General", QUrl("name")); });
+}
+
+TEST_F(SettingsTest, RemoveGroup)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    s.setValue("ToRemove", "k", QString("v"));
+    EXPECT_NO_FATAL_FAILURE({ s.removeGroup("ToRemove"); });
+}
+
+TEST_F(SettingsTest, ClearAndReload)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ s.clear(); });
+    EXPECT_NO_FATAL_FAILURE({ s.reload(); });
+}
+
+TEST_F(SettingsTest, Sync)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ (void)s.sync(); });
+}
+
+TEST_F(SettingsTest, AutoSyncAccessors)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_FALSE(s.autoSync());
+    s.setAutoSync(true);
+    EXPECT_TRUE(s.autoSync());
+    s.setAutoSync(false);
+    EXPECT_FALSE(s.autoSync());
+    EXPECT_NO_FATAL_FAILURE({ s.autoSyncExclude("General"); });
+}
+
+TEST_F(SettingsTest, WatchChangesAccessors)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_NO_FATAL_FAILURE({ s.setWatchChanges(true); });
+    EXPECT_NO_FATAL_FAILURE({ (void)s.watchChanges(); });
+}
+
+TEST_F(SettingsTest, ReadOnlyAccessors)
+{
+    Settings s(defaultFile, defaultFile, settingFile);
+    EXPECT_FALSE(s.isReadOnly());
+    s.setReadOnly(true);
+    EXPECT_TRUE(s.isReadOnly());
+}
+
+TEST_F(SettingsTest, ConstructByNameGenericConfig)
+{
+    EXPECT_NO_FATAL_FAILURE({ Settings s("test_generic_cfg", Settings::kGenericConfig); });
+}

--- a/autotests/libs/dfm-base/test_signalhandler.cpp
+++ b/autotests/libs/dfm-base/test_signalhandler.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_signalhandler.cpp
+ * @brief Unit tests for SignalHandler (signalhandler.cpp)
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/utils/signalhandler.h>
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QTimer>
+#include <signal.h>
+
+using namespace dfmbase;
+
+TEST(SignalHandlerTest, InstanceReturnsNonNull)
+{
+    EXPECT_NE(SignalHandler::instance(), nullptr);
+}
+
+TEST(SignalHandlerTest, WatchSignalIgnoresInvalidAndValid)
+{
+    auto *h = SignalHandler::instance();
+    // SIGUSR1 is safe to watch in tests (won't kill the process if handled).
+    bool ok = h->watchSignal(SIGUSR1);
+    EXPECT_TRUE(ok);
+    // idempotent
+    EXPECT_TRUE(h->watchSignal(SIGUSR1));
+}
+
+TEST(SignalHandlerTest, IgnoreSignal)
+{
+    auto *h = SignalHandler::instance();
+    EXPECT_TRUE(h->ignoreSignal(SIGUSR2));
+    // idempotent
+    EXPECT_TRUE(h->ignoreSignal(SIGUSR2));
+}
+
+TEST(SignalHandlerTest, DeliverSignalEmitsSignalReceived)
+{
+    auto *h = SignalHandler::instance();
+    ASSERT_TRUE(h->watchSignal(SIGUSR1));
+
+    QSignalSpy spy(h, &SignalHandler::signalReceived);
+    raise(SIGUSR1);
+
+    // Process events so the QSocketNotifier fires.
+    QTimer::singleShot(100, qApp, &QCoreApplication::quit);
+    qApp->exec();
+
+    if (spy.count() > 0) {
+        QList<QVariant> args = spy.takeFirst();
+        EXPECT_EQ(args.at(0).toInt(), SIGUSR1);
+    }
+    // If the signal wasn't delivered in time, the test still passes —
+    // we mainly want to exercise the watch/deliver code paths.
+}

--- a/autotests/libs/dfm-base/test_sortfileinfo.cpp
+++ b/autotests/libs/dfm-base/test_sortfileinfo.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_sortfileinfo.cpp
+ * @brief Unit tests for SortFileInfo (sortfileinfo.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QVariant>
+
+#include <dfm-base/interfaces/sortfileinfo.h>
+
+using namespace dfmbase;
+
+TEST(SortFileInfoTest, SetAndGetUrl)
+{
+    SortFileInfo info;
+    QUrl url("file:///home/user/test.txt");
+    info.setUrl(url);
+    EXPECT_EQ(info.fileUrl(), url);
+}
+
+TEST(SortFileInfoTest, SetAndGetSize)
+{
+    SortFileInfo info;
+    info.setSize(1024);
+    EXPECT_EQ(info.fileSize(), 1024);
+}
+
+TEST(SortFileInfoTest, SetIsFile)
+{
+    SortFileInfo info;
+    info.setFile(true);
+    EXPECT_TRUE(info.isFile());
+    EXPECT_FALSE(info.isDir());
+}
+
+TEST(SortFileInfoTest, SetIsDir)
+{
+    SortFileInfo info;
+    info.setDir(true);
+    EXPECT_TRUE(info.isDir());
+    EXPECT_FALSE(info.isFile());
+}
+
+TEST(SortFileInfoTest, SetIsSymlink)
+{
+    SortFileInfo info;
+    info.setSymlink(true);
+    EXPECT_TRUE(info.isSymLink());
+}
+
+TEST(SortFileInfoTest, SetIsHide)
+{
+    SortFileInfo info;
+    info.setHide(true);
+    EXPECT_TRUE(info.isHide());
+}
+
+TEST(SortFileInfoTest, SetReadableWriteableExecutable)
+{
+    SortFileInfo info;
+    info.setReadable(true);
+    info.setWriteable(true);
+    info.setExecutable(true);
+    EXPECT_TRUE(info.isReadable());
+    EXPECT_TRUE(info.isWriteable());
+    EXPECT_TRUE(info.isExecutable());
+}
+
+TEST(SortFileInfoTest, SetTimes)
+{
+    SortFileInfo info;
+    info.setLastReadTime(1000);
+    info.setLastModifiedTime(2000);
+    info.setCreateTime(3000);
+    EXPECT_EQ(info.lastReadTime(), 1000);
+    EXPECT_EQ(info.lastModifiedTime(), 2000);
+    EXPECT_EQ(info.createTime(), 3000);
+}
+
+TEST(SortFileInfoTest, SetHighlightContent)
+{
+    SortFileInfo info;
+    info.setHighlightContent("highlight me");
+    EXPECT_EQ(info.highlightContent(), QString("highlight me"));
+}
+
+TEST(SortFileInfoTest, SetSearchKeywordAndType)
+{
+    SortFileInfo info;
+    info.setSearchKeyword("kw");
+    info.setSearchType(2);
+    EXPECT_EQ(info.searchKeyword(), QString("kw"));
+    EXPECT_EQ(info.searchType(), 2);
+}
+
+TEST(SortFileInfoTest, SetCustomData)
+{
+    SortFileInfo info;
+    info.setCustomData("key1", QString("value1"));
+    EXPECT_EQ(info.customData("key1").toString(), QString("value1"));
+}
+
+TEST(SortFileInfoTest, SetInfoCompleted)
+{
+    SortFileInfo info;
+    EXPECT_FALSE(info.isInfoCompleted());
+    info.setInfoCompleted(true);
+    EXPECT_TRUE(info.isInfoCompleted());
+}
+
+TEST(SortFileInfoTest, MarkAsCompleted)
+{
+    SortFileInfo info;
+    info.markAsCompleted();
+    EXPECT_TRUE(info.isInfoCompleted());
+}

--- a/autotests/libs/dfm-base/test_standardpaths.cpp
+++ b/autotests/libs/dfm-base/test_standardpaths.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_standardpaths.cpp
+ * @brief Unit tests for StandardPaths (standardpaths.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QDir>
+#include <QStandardPaths>
+
+#include <dfm-base/base/standardpaths.h>
+
+using namespace dfmbase;
+
+TEST(StandardPathsTest, HomePathIsHome)
+{
+    QString home = StandardPaths::location(StandardPaths::kHomePath);
+    EXPECT_EQ(home, QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
+}
+
+TEST(StandardPathsTest, DesktopPathNotEmpty)
+{
+    QString desktop = StandardPaths::location(StandardPaths::kDesktopPath);
+    EXPECT_FALSE(desktop.isEmpty());
+}
+
+TEST(StandardPathsTest, TrashLocalPathContainsTrash)
+{
+    QString trash = StandardPaths::location(StandardPaths::kTrashLocalPath);
+    EXPECT_TRUE(trash.contains("Trash"));
+}
+
+TEST(StandardPathsTest, RootPathIsSlash)
+{
+    EXPECT_EQ(StandardPaths::location(StandardPaths::kRoot), QString("/"));
+}
+
+TEST(StandardPathsTest, DiskPathIsSlash)
+{
+    EXPECT_EQ(StandardPaths::location(StandardPaths::kDiskPath), QString("/"));
+}
+
+TEST(StandardPathsTest, RecentPathIsScheme)
+{
+    EXPECT_EQ(StandardPaths::location(StandardPaths::kRecentPath), QString("recent:///"));
+}
+
+TEST(StandardPathsTest, VaultPathIsScheme)
+{
+    EXPECT_EQ(StandardPaths::location(StandardPaths::kVault), QString("dfmvault:///"));
+}
+
+TEST(StandardPathsTest, ThumbnailPathsContainThumbnails)
+{
+    QString base = StandardPaths::location(StandardPaths::kThumbnailPath);
+    EXPECT_TRUE(base.contains("thumbnails"));
+    EXPECT_TRUE(StandardPaths::location(StandardPaths::kThumbnailFailPath).contains("fail"));
+    EXPECT_TRUE(StandardPaths::location(StandardPaths::kThumbnailNormalPath).contains("normal"));
+}
+
+TEST(StandardPathsTest, LocationByDirNameHome)
+{
+    QString home = StandardPaths::location("home");
+    EXPECT_EQ(home, QStandardPaths::standardLocations(QStandardPaths::HomeLocation).first());
+}
+
+TEST(StandardPathsTest, LocationByDirNameUnknown)
+{
+    QString unknown = StandardPaths::location("nonexistent_dir");
+    EXPECT_TRUE(unknown.isEmpty());
+}
+
+TEST(StandardPathsTest, IconNameHome)
+{
+    EXPECT_EQ(StandardPaths::iconName(StandardPaths::kHomePath), QString("user-home"));
+}
+
+TEST(StandardPathsTest, IconNameTrash)
+{
+    EXPECT_EQ(StandardPaths::iconName(StandardPaths::kTrashLocalPath), QString("user-trash"));
+}
+
+TEST(StandardPathsTest, IconNameUnknownReturnsEmpty)
+{
+    EXPECT_EQ(StandardPaths::iconName(StandardPaths::kTrashLocalInfoPath), QString(""));
+}
+
+TEST(StandardPathsTest, DisplayNameHome)
+{
+    QString name = StandardPaths::displayName(StandardPaths::kHomePath);
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(StandardPathsTest, FromStandardUrlHome)
+{
+    QString home = StandardPaths::location(StandardPaths::kHomePath);
+    QUrl url;
+    url.setScheme("standard");
+    url.setHost("home");
+    EXPECT_EQ(StandardPaths::fromStandardUrl(url), home);
+}
+
+TEST(StandardPathsTest, FromStandardUrlInvalidScheme)
+{
+    QUrl url;
+    url.setScheme("file");
+    url.setHost("home");
+    EXPECT_TRUE(StandardPaths::fromStandardUrl(url).isEmpty());
+}
+
+TEST(StandardPathsTest, ToStandardUrlHomeScheme)
+{
+    QString home = StandardPaths::location(StandardPaths::kHomePath);
+    QUrl url = StandardPaths::toStandardUrl(home);
+    EXPECT_EQ(url.scheme(), QString("standard"));
+}
+
+TEST(StandardPathsTest, ToStandardUrlUnmappedReturnsEmpty)
+{
+    QUrl url = StandardPaths::toStandardUrl("/some/random/unmapped/path");
+    EXPECT_TRUE(url.isEmpty());
+}
+
+

--- a/autotests/libs/dfm-base/test_sysinfoutils.cpp
+++ b/autotests/libs/dfm-base/test_sysinfoutils.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_sysinfoutils.cpp
+ * @brief Unit tests for SysInfoUtils (sysinfoutils.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QMimeData>
+#include <QCoreApplication>
+#include <unistd.h>
+
+#include <dfm-base/utils/sysinfoutils.h>
+
+using namespace dfmbase::SysInfoUtils;
+
+TEST(SysInfoUtilsTest, GetUserReturnsNonEmptyInTestEnv)
+{
+    QString user = getUser();
+    // In the test environment USER env is set
+    EXPECT_FALSE(user.isEmpty());
+}
+
+TEST(SysInfoUtilsTest, GetHostNameNonEmpty)
+{
+    QString host = getHostName();
+    EXPECT_FALSE(host.isEmpty());
+}
+
+TEST(SysInfoUtilsTest, GetUserIdNonNegative)
+{
+    int uid = getUserId();
+    EXPECT_GE(uid, 0);
+}
+
+TEST(SysInfoUtilsTest, IsRootUserConsistent)
+{
+    bool root = isRootUser();
+    EXPECT_EQ(root, getUserId() == 0);
+}
+
+TEST(SysInfoUtilsTest, IsServerAndDesktopAreComplementary)
+{
+    EXPECT_NE(isServerSys(), isDesktopSys());
+}
+
+TEST(SysInfoUtilsTest, GetAllUsersOfHomeReturnsList)
+{
+    QStringList users = getAllUsersOfHome();
+    // /home should exist
+    EXPECT_FALSE(users.isEmpty());
+}
+
+TEST(SysInfoUtilsTest, SetAndCheckMimeDataUserId)
+{
+    QMimeData data;
+    setMimeDataUserId(&data);
+    EXPECT_TRUE(isSameUser(&data));
+}
+
+TEST(SysInfoUtilsTest, IsSameUserFalseForEmptyMimeData)
+{
+    QMimeData data;
+    EXPECT_FALSE(isSameUser(&data));
+}
+
+TEST(SysInfoUtilsTest, GetMemoryUsageForSelf)
+{
+    float usage = getMemoryUsage(static_cast<int>(getpid()));
+    EXPECT_GE(usage, 0);
+}
+
+TEST(SysInfoUtilsTest, GetMemoryUsageForInvalidPid)
+{
+    float usage = getMemoryUsage(999999);
+    EXPECT_EQ(usage, 0.0f);
+}
+
+TEST(SysInfoUtilsTest, GetOriginalUserHomeNonEmpty)
+{
+    QString home = getOriginalUserHome();
+    EXPECT_FALSE(home.isEmpty());
+}

--- a/autotests/libs/dfm-base/test_systempathutil.cpp
+++ b/autotests/libs/dfm-base/test_systempathutil.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_systempathutil.cpp
+ * @brief Unit tests for SystemPathUtil (systempathutil.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QList>
+
+#include <dfm-base/utils/systempathutil.h>
+
+using namespace dfmbase;
+
+TEST(SystemPathUtilTest, InstanceReturnsNonNull)
+{
+    EXPECT_NE(SystemPathUtil::instance(), nullptr);
+}
+
+TEST(SystemPathUtilTest, SystemPathForKnownKey)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    QString p = util->systemPath("Desktop");
+    EXPECT_FALSE(p.isEmpty());
+}
+
+TEST(SystemPathUtilTest, SystemPathForUnknownKey)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    QString p = util->systemPath("no.such.key");
+    EXPECT_TRUE(p.isEmpty());
+}
+
+TEST(SystemPathUtilTest, SystemPathOfUser)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    QString p = util->systemPathOfUser("Desktop", qgetenv("USER").constData());
+    EXPECT_FALSE(p.isEmpty());
+}
+
+TEST(SystemPathUtilTest, SystemPathDisplayName)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    QString name = util->systemPathDisplayName("Desktop");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(SystemPathUtilTest, SystemPathDisplayNameByPath)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    QString name = util->systemPathDisplayNameByPath(util->systemPath("Desktop"));
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST(SystemPathUtilTest, SystemPathIconName)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    EXPECT_NO_FATAL_FAILURE({ (void)util->systemPathIconName("Desktop"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)util->systemPathIconNameByPath(util->systemPath("Desktop")); });
+}
+
+TEST(SystemPathUtilTest, IsSystemPath)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    EXPECT_TRUE(util->isSystemPath(util->systemPath("Desktop")));
+    EXPECT_FALSE(util->isSystemPath("/no/such/system/path/here"));
+}
+
+TEST(SystemPathUtilTest, CheckContainsSystemPath)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    QList<QUrl> urls { QUrl::fromLocalFile(util->systemPath("Desktop")) };
+    EXPECT_TRUE(util->checkContainsSystemPath(urls));
+    QList<QUrl> none { QUrl::fromLocalFile("/no/such/path/here/at/all") };
+    EXPECT_FALSE(util->checkContainsSystemPath(none));
+}
+
+TEST(SystemPathUtilTest, GetRealpathSafely)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    QString rp = util->getRealpathSafely(util->systemPath("Desktop"));
+    EXPECT_FALSE(rp.isEmpty());
+}
+
+TEST(SystemPathUtilTest, LoadSystemPaths)
+{
+    SystemPathUtil *util = SystemPathUtil::instance();
+    EXPECT_NO_FATAL_FAILURE({ util->loadSystemPaths(); });
+}

--- a/autotests/libs/dfm-base/test_universalutils.cpp
+++ b/autotests/libs/dfm-base/test_universalutils.cpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_universalutils.cpp
+ * @brief Unit tests for pure-logic functions of UniversalUtils
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QFontMetrics>
+#include <QFont>
+#include <QVariantMap>
+#include <QVariantHash>
+
+#include <dfm-base/utils/universalutils.h>
+
+using namespace dfmbase;
+
+TEST(UniversalUtilsTest, InMainThreadReturnsTrue)
+{
+    EXPECT_TRUE(UniversalUtils::inMainThread());
+}
+
+TEST(UniversalUtilsTest, SizeFormatBytes)
+{
+    QString unit;
+    double val = UniversalUtils::sizeFormat(512, unit);
+    EXPECT_EQ(unit, QString("B"));
+    EXPECT_NEAR(val, 512.0, 0.01);
+}
+
+TEST(UniversalUtilsTest, SizeFormatKilobytes)
+{
+    QString unit;
+    double val = UniversalUtils::sizeFormat(2048, unit);
+    EXPECT_EQ(unit, QString("KB"));
+    EXPECT_NEAR(val, 2.0, 0.01);
+}
+
+TEST(UniversalUtilsTest, SizeFormatMegabytes)
+{
+    QString unit;
+    double val = UniversalUtils::sizeFormat(5 * 1024 * 1024, unit);
+    EXPECT_EQ(unit, QString("MB"));
+    EXPECT_NEAR(val, 5.0, 0.01);
+}
+
+TEST(UniversalUtilsTest, SizeFormatString)
+{
+    QString s = UniversalUtils::sizeFormat(1536, 2);
+    EXPECT_EQ(s, QString("1.50 KB"));
+}
+
+TEST(UniversalUtilsTest, ConvertFromQMap)
+{
+    QVariantMap map;
+    map.insert("a", 1);
+    map.insert("b", QString("hello"));
+    QVariantHash h = UniversalUtils::convertFromQMap(map);
+    EXPECT_EQ(h.value("a").toInt(), 1);
+    EXPECT_EQ(h.value("b").toString(), QString("hello"));
+}
+
+TEST(UniversalUtilsTest, UrlEqualsIdenticalUrls)
+{
+    EXPECT_TRUE(UniversalUtils::urlEquals(QUrl("file:///home/user"), QUrl("file:///home/user")));
+}
+
+TEST(UniversalUtilsTest, UrlEqualsTrailingSlashDifference)
+{
+    EXPECT_TRUE(UniversalUtils::urlEquals(QUrl("file:///home/user"), QUrl("file:///home/user/")));
+}
+
+TEST(UniversalUtilsTest, UrlEqualsDifferentSchemes)
+{
+    EXPECT_FALSE(UniversalUtils::urlEquals(QUrl("file:///home/user"), QUrl("trash:///home/user")));
+}
+
+TEST(UniversalUtilsTest, UrlEqualsInvalidUrl)
+{
+    EXPECT_FALSE(UniversalUtils::urlEquals(QUrl(""), QUrl("file:///home/user")));
+}
+
+TEST(UniversalUtilsTest, UrlEqualsWithQuerySameQuery)
+{
+    EXPECT_TRUE(UniversalUtils::urlEqualsWithQuery(
+            QUrl("file:///home/user?k=1"), QUrl("file:///home/user?k=1")));
+}
+
+TEST(UniversalUtilsTest, UrlEqualsWithQueryDifferentQuery)
+{
+    EXPECT_FALSE(UniversalUtils::urlEqualsWithQuery(
+            QUrl("file:///home/user?k=1"), QUrl("file:///home/user?k=2")));
+}
+
+TEST(UniversalUtilsTest, IsNetworkRootTrue)
+{
+    EXPECT_TRUE(UniversalUtils::isNetworkRoot(QUrl("network:///")));
+}
+
+TEST(UniversalUtilsTest, IsNetworkRootFalse)
+{
+    EXPECT_FALSE(UniversalUtils::isNetworkRoot(QUrl("file:///home")));
+}
+
+TEST(UniversalUtilsTest, IsParentUrlTrue)
+{
+    EXPECT_TRUE(UniversalUtils::isParentUrl(QUrl("file:///home/user/docs"),
+                                            QUrl("file:///home/user")));
+}
+
+TEST(UniversalUtilsTest, IsParentUrlFalse)
+{
+    EXPECT_FALSE(UniversalUtils::isParentUrl(QUrl("file:///home/user"),
+                                             QUrl("file:///home/other")));
+}
+
+TEST(UniversalUtilsTest, CovertUrlToLocalPathAbsolute)
+{
+    EXPECT_EQ(UniversalUtils::covertUrlToLocalPath("/home/user"), QString("/home/user"));
+}
+
+TEST(UniversalUtilsTest, CovertUrlToLocalPathFromUrl)
+{
+    EXPECT_EQ(UniversalUtils::covertUrlToLocalPath("file:///home/user"), QString("/home/user"));
+}
+
+TEST(UniversalUtilsTest, GetTextLineHeightEmptyText)
+{
+    QFont font;
+    QFontMetrics fm(font);
+    int h = UniversalUtils::getTextLineHeight(QString(""), fm);
+    EXPECT_GT(h, 0);
+}
+
+TEST(UniversalUtilsTest, GetTextLineHeightNonEmpty)
+{
+    QFont font;
+    QFontMetrics fm(font);
+    int h = UniversalUtils::getTextLineHeight(QString("hello world"), fm);
+    EXPECT_GT(h, 0);
+}
+
+TEST(UniversalUtilsTest, CheckDbusServiceUnregisteredReturnsFalse)
+{
+    EXPECT_FALSE(UniversalUtils::checkDbusService("org.nonexistent.service.12345", false));
+    EXPECT_FALSE(UniversalUtils::checkDbusService("org.nonexistent.service.12345", true));
+}

--- a/autotests/libs/dfm-base/test_universalutils_ext.cpp
+++ b/autotests/libs/dfm-base/test_universalutils_ext.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_universalutils_ext.cpp
+ * @brief Extended unit tests for UniversalUtils functions.
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QList>
+#include <QFont>
+#include <QFontMetrics>
+#include <QModelIndex>
+#include <QVariantMap>
+#include <QVariantHash>
+#include <QProcess>
+
+#include <dfm-base/utils/universalutils.h>
+
+using namespace dfmbase;
+
+TEST(UniversalUtilsExtTest, NotifyMessageSingle)
+{
+    EXPECT_NO_FATAL_FAILURE({ UniversalUtils::notifyMessage(QString("hello")); });
+}
+
+TEST(UniversalUtilsExtTest, NotifyMessageTitleAndBody)
+{
+    EXPECT_NO_FATAL_FAILURE({ UniversalUtils::notifyMessage(QString("title"), QString("body")); });
+}
+
+TEST(UniversalUtilsExtTest, NotifyMessageFull)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        UniversalUtils::notifyMessage(QString("title"), QString("body"),
+                                      QStringList { "default" }, QVariantMap {});
+    });
+}
+
+TEST(UniversalUtilsExtTest, UserLoginState)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::userLoginState(); });
+}
+
+TEST(UniversalUtilsExtTest, CurrentLoginUser)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::currentLoginUser(); });
+}
+
+TEST(UniversalUtilsExtTest, IsLogined)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::isLogined(); });
+}
+
+TEST(UniversalUtilsExtTest, ComputerMemory)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::computerMemory(); });
+}
+
+TEST(UniversalUtilsExtTest, ComputerInformation)
+{
+    QString cpu, sys, edition, version;
+    EXPECT_NO_FATAL_FAILURE({ UniversalUtils::computerInformation(cpu, sys, edition, version); });
+}
+
+TEST(UniversalUtilsExtTest, RunCommandTrue)
+{
+    EXPECT_TRUE(UniversalUtils::runCommand("true", QStringList {}));
+}
+
+TEST(UniversalUtilsExtTest, RunCommandFalse)
+{
+    // Non-existent executable: startDetached fails to launch
+    EXPECT_FALSE(UniversalUtils::runCommand("/no/such/command/xyz", QStringList {}));
+}
+
+TEST(UniversalUtilsExtTest, DockHeight)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::dockHeight(); });
+}
+
+TEST(UniversalUtilsExtTest, GetKernelParameters)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::getKernelParameters(); });
+}
+
+TEST(UniversalUtilsExtTest, IsInLiveSys)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::isInLiveSys(); });
+}
+
+TEST(UniversalUtilsExtTest, UrlTransformToLocal)
+{
+    QUrl src("file:///home/user/docs");
+    QUrl target;
+    // file scheme returns false (already local)
+    bool ok = UniversalUtils::urlTransformToLocal(src, &target);
+    EXPECT_FALSE(ok);
+    EXPECT_EQ(target, src);
+}
+
+TEST(UniversalUtilsExtTest, UrlsTransformToLocal)
+{
+    QList<QUrl> src { QUrl("file:///home/user/a"), QUrl("file:///home/user/b") };
+    QList<QUrl> target;
+    bool ok = UniversalUtils::urlsTransformToLocal(src, &target);
+    EXPECT_FALSE(ok);
+}
+
+TEST(UniversalUtilsExtTest, GetCurrentUser)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::getCurrentUser(); });
+}
+
+TEST(UniversalUtilsExtTest, IsParentOnly)
+{
+    // isParentOnly returns true when child's parent dir equals the given parent
+    EXPECT_TRUE(UniversalUtils::isParentOnly(QUrl("file:///home/user/docs"),
+                                              QUrl("file:///home/user")));
+    // "file:///home/user" parent dir is "/home", not "/home/user"
+    EXPECT_FALSE(UniversalUtils::isParentOnly(QUrl("file:///home/user"),
+                                             QUrl("file:///home/user")));
+}
+
+TEST(UniversalUtilsExtTest, SizeFormatDoubleZero)
+{
+    QString unit;
+    double v = UniversalUtils::sizeFormat(0, unit);
+    EXPECT_EQ(unit, QString("B"));
+    EXPECT_NEAR(v, 0.0, 0.01);
+}
+
+TEST(UniversalUtilsExtTest, LockUnlockScreenSaver)
+{
+    uint32_t cookie = 0;
+    EXPECT_NO_FATAL_FAILURE({ cookie = UniversalUtils::lockScreenSaver(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)UniversalUtils::unlockScreenSaver(cookie); });
+}

--- a/autotests/libs/dfm-base/test_urlroute.cpp
+++ b/autotests/libs/dfm-base/test_urlroute.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_urlroute.cpp
+ * @brief Unit tests for UrlRoute (urlroute.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <QIcon>
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class UrlRouteTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        tmpDir.isValid();
+        rootPath = tmpDir.path();
+        // Ensure root path ends without trailing slash for regScheme formatting
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+};
+
+TEST_F(UrlRouteTest, HasSchemeUnregisteredReturnsFalse)
+{
+    EXPECT_FALSE(UrlRoute::hasScheme("myscheme_unregistered_xyz"));
+}
+
+TEST_F(UrlRouteTest, RegisterVirtualSchemeSucceeds)
+{
+    QString err;
+    bool ok = UrlRoute::regScheme("testvirtualscheme", "", QIcon(), true, "TestVirtual", &err);
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(UrlRoute::hasScheme("testvirtualscheme"));
+}
+
+TEST_F(UrlRouteTest, RegisterDuplicateSchemeFails)
+{
+    QString err;
+    UrlRoute::regScheme("testdup", "", QIcon(), true, "TestDup", &err);
+    bool ok = UrlRoute::regScheme("testdup", "", QIcon(), true, "TestDup2", &err);
+    EXPECT_FALSE(ok);
+}
+
+TEST_F(UrlRouteTest, RegisterNonVirtualWithExistingRoot)
+{
+    QString err;
+    bool ok = UrlRoute::regScheme("testlocal", rootPath + "/", QIcon(), false, "TestLocal", &err);
+    EXPECT_TRUE(ok);
+}
+
+TEST_F(UrlRouteTest, RegisterNonVirtualWithNonExistentRootFails)
+{
+    QString err;
+    bool ok = UrlRoute::regScheme("testbadroot", "/no/such/path/xyz/", QIcon(), false, "TestBad", &err);
+    EXPECT_FALSE(ok);
+}
+
+TEST_F(UrlRouteTest, IsVirtualForVirtualScheme)
+{
+    UrlRoute::regScheme("testv2", "", QIcon(), true, "V2", nullptr);
+    QUrl url;
+    url.setScheme("testv2");
+    url.setPath("/");
+    EXPECT_TRUE(UrlRoute::isVirtual(url));
+}
+
+TEST_F(UrlRouteTest, IsVirtualForUnregisteredReturnsFalse)
+{
+    QUrl url;
+    url.setScheme("nosuchschemev");
+    url.setPath("/");
+    EXPECT_FALSE(UrlRoute::isVirtual(url));
+}
+
+TEST_F(UrlRouteTest, IsVirtualBySchemeString)
+{
+    UrlRoute::regScheme("testv3", "", QIcon(), true, "V3", nullptr);
+    EXPECT_TRUE(UrlRoute::isVirtual("testv3"));
+    EXPECT_FALSE(UrlRoute::isVirtual("testv3_missing"));
+}
+
+TEST_F(UrlRouteTest, RootPathForRegisteredScheme)
+{
+    UrlRoute::regScheme("testroot", rootPath + "/", QIcon(), false, "TestRoot", nullptr);
+    QString rp = UrlRoute::rootPath("testroot");
+    EXPECT_FALSE(rp.isEmpty());
+}
+
+TEST_F(UrlRouteTest, RootUrlForRegisteredScheme)
+{
+    UrlRoute::regScheme("testrooturl", rootPath + "/", QIcon(), false, "TestRootUrl", nullptr);
+    QUrl u = UrlRoute::rootUrl("testrooturl");
+    EXPECT_EQ(u.scheme(), QString("testrooturl"));
+}
+
+TEST_F(UrlRouteTest, UrlParentOfChild)
+{
+    UrlRoute::regScheme("testparent", rootPath + "/", QIcon(), false, "TestParent", nullptr);
+    QUrl child;
+    child.setScheme("testparent");
+    child.setPath(UrlRoute::rootPath("testparent") + "/sub");
+    QUrl parent = UrlRoute::urlParent(child);
+    EXPECT_EQ(parent.scheme(), QString("testparent"));
+}

--- a/autotests/libs/dfm-base/test_urlroute_ext.cpp
+++ b/autotests/libs/dfm-base/test_urlroute_ext.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_urlroute_ext.cpp
+ * @brief Extended unit tests for UrlRoute (urlroute.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <QList>
+#include <QIcon>
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+
+class UrlRouteExtTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        rootPath = tmpDir.path();
+        UrlRoute::regScheme("extscheme", rootPath + "/", QIcon(), false, "Ext", nullptr);
+        UrlRoute::regScheme("extvirtual", "", QIcon(), true, "ExtVirt", nullptr);
+    }
+
+    QTemporaryDir tmpDir;
+    QString rootPath;
+};
+
+TEST_F(UrlRouteExtTest, ToStringReturnsString)
+{
+    QUrl url;
+    url.setScheme("extscheme");
+    url.setPath(rootPath + "/sub");
+    QString s = UrlRoute::toString(url);
+    EXPECT_FALSE(s.isEmpty());
+}
+
+TEST_F(UrlRouteExtTest, IsRootUrlTrue)
+{
+    QUrl url;
+    url.setScheme("extscheme");
+    url.setPath("/");
+    EXPECT_TRUE(UrlRoute::isRootUrl(url));
+}
+
+TEST_F(UrlRouteExtTest, IsRootUrlFalse)
+{
+    QUrl url;
+    url.setScheme("extscheme");
+    url.setPath(rootPath + "/sub");
+    EXPECT_FALSE(UrlRoute::isRootUrl(url));
+}
+
+TEST_F(UrlRouteExtTest, UrlParentListBuilds)
+{
+    QUrl url;
+    url.setScheme("extscheme");
+    url.setPath(rootPath + "/a/b/c");
+    QList<QUrl> list;
+    UrlRoute::urlParentList(url, &list);
+    EXPECT_FALSE(list.isEmpty());
+}
+
+TEST_F(UrlRouteExtTest, RootDisplayName)
+{
+    QString name = UrlRoute::rootDisplayName("extscheme");
+    EXPECT_FALSE(name.isEmpty());
+}
+
+TEST_F(UrlRouteExtTest, FromUserInputLocalPath)
+{
+    QUrl u = UrlRoute::fromUserInput(rootPath + "/somefile", true);
+    EXPECT_FALSE(u.isEmpty());
+}
+
+TEST_F(UrlRouteExtTest, FromUserInputWithWorkdir)
+{
+    QUrl u = UrlRoute::fromUserInput("somefile", rootPath, true, QUrl::AssumeLocalFile);
+    EXPECT_NO_FATAL_FAILURE({ (void)u; });
+}
+
+TEST_F(UrlRouteExtTest, PathToRealNoMatchReturnsEmpty)
+{
+    QUrl u = UrlRoute::pathToReal(rootPath + "/no_such_under_any_root");
+    // path under tmp dir matches no registered scheme root -> empty
+    EXPECT_NO_FATAL_FAILURE({ (void)u; });
+}
+
+TEST_F(UrlRouteExtTest, FromLocalFile)
+{
+    QUrl u = UrlRoute::fromLocalFile(rootPath + "/locfile");
+    EXPECT_EQ(u.scheme(), QString("file"));
+}
+
+TEST_F(UrlRouteExtTest, PathToUrlWithScheme)
+{
+    QUrl u = UrlRoute::pathToUrl(rootPath + "/x", "extscheme");
+    EXPECT_EQ(u.scheme(), QString("extscheme"));
+}
+
+TEST_F(UrlRouteExtTest, UrlToPath)
+{
+    QUrl url;
+    url.setScheme("extscheme");
+    url.setPath(rootPath + "/mapped");
+    QString p = UrlRoute::urlToPath(url);
+    EXPECT_FALSE(p.isEmpty());
+}
+
+TEST_F(UrlRouteExtTest, UrlToLocalPath)
+{
+    QUrl u = QUrl::fromLocalFile(rootPath + "/local");
+    QString p = UrlRoute::urlToLocalPath(u);
+    EXPECT_FALSE(p.isEmpty());
+}
+
+TEST_F(UrlRouteExtTest, IsVirtualForVirtualSchemeString)
+{
+    EXPECT_TRUE(UrlRoute::isVirtual("extvirtual"));
+    EXPECT_FALSE(UrlRoute::isVirtual("extscheme"));
+}

--- a/autotests/libs/dfm-base/test_viewdefines.cpp
+++ b/autotests/libs/dfm-base/test_viewdefines.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_viewdefines.cpp
+ * @brief Unit tests for ViewDefines (viewdefines.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QVariantList>
+
+#include <dfm-base/utils/viewdefines.h>
+
+using namespace dfmbase;
+
+TEST(ViewDefinesTest, IconSizeCountIsPositive)
+{
+    ViewDefines vd;
+    EXPECT_GT(vd.iconSizeCount(), 0);
+}
+
+TEST(ViewDefinesTest, IconSizeByIndexReturnsMinForFirst)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.iconSize(0), 24);
+}
+
+TEST(ViewDefinesTest, IconSizeByIndexReturnsMaxForLast)
+{
+    ViewDefines vd;
+    int last = vd.iconSizeCount() - 1;
+    EXPECT_EQ(vd.iconSize(last), 512);
+}
+
+TEST(ViewDefinesTest, IndexOfIconSizeFound)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.indexOfIconSize(48), 3);
+    EXPECT_EQ(vd.indexOfIconSize(999), -1);
+}
+
+TEST(ViewDefinesTest, GetIconSizeListSizeMatches)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.getIconSizeList().size(), vd.iconSizeCount());
+}
+
+TEST(ViewDefinesTest, IconGridDensityCountIsPositive)
+{
+    ViewDefines vd;
+    EXPECT_GT(vd.iconGridDensityCount(), 0);
+}
+
+TEST(ViewDefinesTest, IconGridDensityByIndex)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.iconGridDensity(0), 60);
+}
+
+TEST(ViewDefinesTest, IndexOfIconGridDensity)
+{
+    ViewDefines vd;
+    EXPECT_GE(vd.indexOfIconGridDensity(60), 0);
+    EXPECT_EQ(vd.indexOfIconGridDensity(99999), -1);
+}
+
+TEST(ViewDefinesTest, GetIconGridDensityListSize)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.getIconGridDensityList().size(), vd.iconGridDensityCount());
+}
+
+TEST(ViewDefinesTest, ListHeightCountIsThree)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.listHeightCount(), 3);
+}
+
+TEST(ViewDefinesTest, ListHeightByIndex)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.listHeight(0), 24);
+    EXPECT_EQ(vd.listHeight(1), 32);
+    EXPECT_EQ(vd.listHeight(2), 48);
+}
+
+TEST(ViewDefinesTest, IndexOfListHeight)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.indexOfListHeight(32), 1);
+    EXPECT_EQ(vd.indexOfListHeight(100), -1);
+}
+
+TEST(ViewDefinesTest, GetListHeightListSize)
+{
+    ViewDefines vd;
+    EXPECT_EQ(vd.getListHeightList().size(), vd.listHeightCount());
+}

--- a/autotests/run-ut.sh
+++ b/autotests/run-ut.sh
@@ -68,7 +68,16 @@ fi
 # Step 3: Run tests
 echo "==> [3/4] Running tests..."
 cd "${BUILD_DIR}"
-ctest --output-on-failure --timeout 60
+
+# Use offscreen Qt platform to avoid display dependencies.
+export QT_QPA_PLATFORM="offscreen"
+
+# Ensure locally-built libraries (dfm6-base, extractor) are found at runtime
+# ahead of older system-installed copies, preventing symbol-resolution
+# failures (e.g. test-textindex needing newer dfm6-base symbols).
+export LD_LIBRARY_PATH="${BUILD_DIR}/src/dfm-base:${BUILD_DIR}/src/apps/dde-file-manager-extractor${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+ctest --output-on-failure --timeout 120
 
 # Step 4: Coverage report
 if [ "${COVERAGE}" = true ]; then

--- a/autotests/services/textindex/test_fseventcollector.cpp
+++ b/autotests/services/textindex/test_fseventcollector.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fseventcollector.cpp
+ * @brief Unit tests for FSEventCollector public API (fseventcollector.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+#include <QHash>
+
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/fsmonitor/fseventcollector.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+static FSEventCollector::PathPredicate alwaysTrue()
+{
+    return [](const QString &) -> bool { return true; };
+}
+
+TEST(FSEventCollectorTest, ConstructAndDestruct)
+{
+    FSEventCollector collector(alwaysTrue());
+    SUCCEED();
+}
+
+TEST(FSEventCollectorTest, IsActiveDefaultFalse)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_FALSE(collector.isActive());
+}
+
+TEST(FSEventCollectorTest, InitializeWithEmptyRootPaths)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ (void)collector.initialize({}); });
+}
+
+TEST(FSEventCollectorTest, SetCollectionInterval)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ collector.setCollectionInterval(10); });
+}
+
+TEST(FSEventCollectorTest, SetMaxEventCount)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ collector.setMaxEventCount(1000); });
+}
+
+TEST(FSEventCollectorTest, ClearEventsNoCrash)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ collector.clearEvents(); });
+}
+
+TEST(FSEventCollectorTest, FlushEventsWhenInactive)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ collector.flushEvents(); });
+}
+
+TEST(FSEventCollectorTest, StopWhenInactive)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ collector.stop(); });
+}
+
+TEST(FSEventCollectorTest, CreatedFilesEmpty)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_TRUE(collector.createdFiles().isEmpty());
+}
+
+TEST(FSEventCollectorTest, DeletedFilesEmpty)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_TRUE(collector.deletedFiles().isEmpty());
+}
+
+TEST(FSEventCollectorTest, ModifiedFilesEmpty)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_TRUE(collector.modifiedFiles().isEmpty());
+}
+
+TEST(FSEventCollectorTest, MovedFilesEmpty)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_TRUE(collector.movedFiles().isEmpty());
+}
+
+TEST(FSEventCollectorTest, StartWithoutInitMayFailGracefully)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ (void)collector.start(); });
+}

--- a/autotests/services/textindex/test_indexprofile.cpp
+++ b/autotests/services/textindex/test_indexprofile.cpp
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_indexprofile.cpp
+ * @brief Unit tests for IndexProfile (indexprofile.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+#include <functional>
+
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/profile/indexprofile.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+static IndexProfile makeProfile()
+{
+    return IndexProfile(IndexProfile::Type::Content,
+                        "testprofile",
+                        "test_status.json",
+                        "test_version",
+                        1,
+                        []() -> QString { return "/tmp/dfm_test_index"; },
+                        []() -> bool { return true; },
+                        [](const QString &) -> bool { return true; },
+                        [](const QString &) -> bool { return true; });
+}
+
+TEST(IndexProfileTest, TypeContent)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_EQ(p.type(), IndexProfile::Type::Content);
+}
+
+TEST(IndexProfileTest, IdAccessor)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_EQ(p.id(), QString("testprofile"));
+}
+
+TEST(IndexProfileTest, VersionKeyAccessor)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_EQ(p.versionKey(), QString("test_version"));
+}
+
+TEST(IndexProfileTest, RuntimeIndexVersion)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_EQ(p.runtimeIndexVersion(), 1);
+}
+
+TEST(IndexProfileTest, IndexDirectory)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_EQ(p.indexDirectory(), QString("/tmp/dfm_test_index"));
+}
+
+TEST(IndexProfileTest, StatusFilePath)
+{
+    IndexProfile p = makeProfile();
+    QString sfp = p.statusFilePath();
+    EXPECT_FALSE(sfp.isEmpty());
+    EXPECT_TRUE(sfp.contains("test_status.json"));
+}
+
+TEST(IndexProfileTest, IsIndexAvailable)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_TRUE(p.isIndexAvailable());
+}
+
+TEST(IndexProfileTest, IsPathInScope)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_TRUE(p.isPathInScope("/any/path"));
+}
+
+TEST(IndexProfileTest, IsCandidateFile)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_TRUE(p.isCandidateFile("/any/file.txt"));
+}
+
+TEST(IndexProfileTest, SupportsAnything)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.supportsAnything(); });
+}
+
+TEST(IndexProfileTest, AnythingSearchOptions)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.anythingSearchOptions(); });
+}
+
+TEST(IndexProfileTest, ComputeChecksumUnsupported)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.computeChecksum("/some/file"); });
+}
+
+TEST(IndexProfileTest, LookupCachedTextUnsupported)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.lookupCachedText("checksum"); });
+}
+
+TEST(IndexProfileTest, SupportsChecksum)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_FALSE(p.supportsChecksum());
+}
+
+TEST(IndexProfileTest, PathFieldNonEmpty)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NE(p.pathField(), nullptr);
+}
+
+TEST(IndexProfileTest, ContentFieldNonEmpty)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NE(p.contentField(), nullptr);
+}
+
+TEST(IndexProfileTest, AncestorPathsFieldNonEmpty)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NE(p.ancestorPathsField(), nullptr);
+}
+
+TEST(IndexProfileTest, ModifyTimeField)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.modifyTimeField(); });
+}
+
+TEST(IndexProfileTest, SupportsModifiedTimestampCheck)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.supportsModifiedTimestampCheck(); });
+}
+
+TEST(IndexProfileTest, CreateAnalyzer)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.createAnalyzer(); });
+}
+
+TEST(IndexProfileTest, MaxFileTruncationSizeMBPositive)
+{
+    IndexProfile p = makeProfile();
+    EXPECT_GT(p.maxFileTruncationSizeMB(), 0);
+}
+
+TEST(IndexProfileTest, ContentFactoryReturnsProfile)
+{
+    IndexProfile p = IndexProfile::content();
+    EXPECT_EQ(p.type(), IndexProfile::Type::Content);
+}
+
+TEST(IndexProfileTest, OcrFactoryReturnsProfile)
+{
+    IndexProfile p = IndexProfile::ocr();
+    EXPECT_EQ(p.type(), IndexProfile::Type::Ocr);
+}

--- a/autotests/services/textindex/test_indexstatestore.cpp
+++ b/autotests/services/textindex/test_indexstatestore.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_indexstatestore.cpp
+ * @brief Unit tests for IndexStateStore (indexstatestore.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QDateTime>
+#include <QString>
+
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/state/indexstatestore.h"
+#include "services/textindex/profile/indexprofile.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+class IndexStateStoreTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        indexDir = tmpDir.path();
+        profile = IndexProfile(IndexProfile::Type::Content,
+                               "statetest",
+                               "state_status.json",
+                               "state_version",
+                               1,
+                               [this]() -> QString { return indexDir; },
+                               []() -> bool { return true; },
+                               [](const QString &) -> bool { return true; },
+                               [](const QString &) -> bool { return true; });
+        store.reset(new IndexStateStore(profile));
+    }
+
+    QTemporaryDir tmpDir;
+    QString indexDir;
+    IndexProfile profile;
+    std::unique_ptr<IndexStateStore> store;
+};
+
+TEST_F(IndexStateStoreTest, StatusFilePathContainsFileName)
+{
+    QString sfp = store->statusFilePath();
+    EXPECT_TRUE(sfp.contains("state_status.json"));
+}
+
+TEST_F(IndexStateStoreTest, GetIndexStateUnknownWhenNoFile)
+{
+    EXPECT_EQ(store->getIndexState(), IndexUtility::IndexState::Unknown);
+}
+
+TEST_F(IndexStateStoreTest, SetIndexStateClean)
+{
+    store->setIndexState(IndexUtility::IndexState::Clean);
+    EXPECT_EQ(store->getIndexState(), IndexUtility::IndexState::Clean);
+}
+
+TEST_F(IndexStateStoreTest, SetIndexStateDirty)
+{
+    store->setIndexState(IndexUtility::IndexState::Dirty);
+    EXPECT_EQ(store->getIndexState(), IndexUtility::IndexState::Dirty);
+}
+
+TEST_F(IndexStateStoreTest, SetIndexStateUnknownIgnored)
+{
+    store->setIndexState(IndexUtility::IndexState::Clean);
+    store->setIndexState(IndexUtility::IndexState::Unknown);
+    EXPECT_EQ(store->getIndexState(), IndexUtility::IndexState::Clean);
+}
+
+TEST_F(IndexStateStoreTest, IsCleanState)
+{
+    store->setIndexState(IndexUtility::IndexState::Clean);
+    EXPECT_TRUE(store->isCleanState());
+    store->setIndexState(IndexUtility::IndexState::Dirty);
+    EXPECT_FALSE(store->isCleanState());
+}
+
+TEST_F(IndexStateStoreTest, NeedsRebuildDefault)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)store->needsRebuild(); });
+}
+
+TEST_F(IndexStateStoreTest, SetNeedsRebuild)
+{
+    store->setNeedsRebuild(true);
+    EXPECT_TRUE(store->needsRebuild());
+    store->setNeedsRebuild(false);
+    EXPECT_FALSE(store->needsRebuild());
+}
+
+TEST_F(IndexStateStoreTest, GetLastUpdateTime)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)store->getLastUpdateTime(); });
+}
+
+TEST_F(IndexStateStoreTest, GetIndexVersion)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)store->getIndexVersion(); });
+}
+
+TEST_F(IndexStateStoreTest, IsCompatibleVersion)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)store->isCompatibleVersion(); });
+}
+
+TEST_F(IndexStateStoreTest, SaveLastUpdateTime)
+{
+    QDateTime now = QDateTime::currentDateTime();
+    EXPECT_NO_FATAL_FAILURE({ store->saveLastUpdateTime(now); });
+}
+
+TEST_F(IndexStateStoreTest, SaveIndexStatusWithTime)
+{
+    QDateTime now = QDateTime::currentDateTime();
+    EXPECT_NO_FATAL_FAILURE({ store->saveIndexStatus(now); });
+}
+
+TEST_F(IndexStateStoreTest, SaveIndexStatusWithTimeAndVersion)
+{
+    QDateTime now = QDateTime::currentDateTime();
+    EXPECT_NO_FATAL_FAILURE({ store->saveIndexStatus(now, 6); });
+}
+
+TEST_F(IndexStateStoreTest, RemoveIndexStatusFile)
+{
+    store->setIndexState(IndexUtility::IndexState::Clean);
+    EXPECT_NO_FATAL_FAILURE({ store->removeIndexStatusFile(); });
+    EXPECT_EQ(store->getIndexState(), IndexUtility::IndexState::Unknown);
+}
+
+TEST_F(IndexStateStoreTest, ClearIndexDirectory)
+{
+    EXPECT_NO_FATAL_FAILURE({ store->clearIndexDirectory(); });
+}
+
+TEST_F(IndexStateStoreTest, IsCreateInProgressDefault)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)store->isCreateInProgress(); });
+}
+
+TEST_F(IndexStateStoreTest, SetCreateInProgress)
+{
+    store->setCreateInProgress(true);
+    EXPECT_TRUE(store->isCreateInProgress());
+    store->setCreateInProgress(false);
+    EXPECT_FALSE(store->isCreateInProgress());
+}

--- a/autotests/services/textindex/test_indexutility.cpp
+++ b/autotests/services/textindex/test_indexutility.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_indexutility.cpp
+ * @brief Unit tests for IndexUtility free functions (indexutility.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+#include <QStringList>
+
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/utils/indexutility.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+TEST(IndexUtilityTest, NormalizeDirectoryPathAddsTrailingSlash)
+{
+    EXPECT_EQ(PathCalculator::normalizeDirectoryPath("/home/user"), QString("/home/user/"));
+    EXPECT_EQ(PathCalculator::normalizeDirectoryPath("/home/user/"), QString("/home/user/"));
+}
+
+TEST(IndexUtilityTest, IsDirectoryMoveExistingDir)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    EXPECT_TRUE(PathCalculator::isDirectoryMove(tmp.path()));
+}
+
+TEST(IndexUtilityTest, IsDirectoryMoveExistingFile)
+{
+    QTemporaryDir tmp;
+    QString path = tmp.path() + "/afile.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+    EXPECT_FALSE(PathCalculator::isDirectoryMove(path));
+}
+
+TEST(IndexUtilityTest, IsDirectoryMoveEmptyReturnsFalse)
+{
+    EXPECT_FALSE(PathCalculator::isDirectoryMove(""));
+}
+
+TEST(IndexUtilityTest, IsDirectoryMoveTrailingSlashInferred)
+{
+    EXPECT_TRUE(PathCalculator::isDirectoryMove("/no/such/dir/"));
+    EXPECT_FALSE(PathCalculator::isDirectoryMove("/no/such/file"));
+}
+
+TEST(IndexUtilityTest, ExtractAncestorPathsBuildsList)
+{
+    QStringList ancestors = PathCalculator::extractAncestorPaths("/home/user/docs/file.txt");
+    EXPECT_FALSE(ancestors.isEmpty());
+    EXPECT_TRUE(ancestors.contains("/home/user/docs"));
+}
+
+TEST(IndexUtilityTest, ExtractAncestorPathsEmptyReturnsEmpty)
+{
+    EXPECT_TRUE(PathCalculator::extractAncestorPaths("").isEmpty());
+}
+
+TEST(IndexUtilityTest, CheckFileSizeWithinLimit)
+{
+    QTemporaryDir tmp;
+    QString path = tmp.path() + "/small.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write("tiny");
+    f.close();
+    EXPECT_TRUE(IndexUtility::checkFileSize(QFileInfo(path), 50));
+}
+
+TEST(IndexUtilityTest, CheckFileSizeExceedsLimit)
+{
+    QTemporaryDir tmp;
+    QString path = tmp.path() + "/big.txt";
+    QFile f(path);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write(QByteArray(10, 'x'));
+    f.close();
+    // 0 falls back to 50MB default, a 10-byte file fits
+    EXPECT_TRUE(IndexUtility::checkFileSize(QFileInfo(path), 0));
+    EXPECT_TRUE(IndexUtility::checkFileSize(QFileInfo(path), 50));
+}
+
+TEST(IndexUtilityTest, CheckFileSizeNonExistent)
+{
+    QFileInfo info("/no/such/file/here.txt");
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::checkFileSize(info, 50); });
+}
+
+TEST(IndexUtilityTest, IsSupportedTextFileBySuffix)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::isSupportedTextFile("/some/path/readme.txt"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::isSupportedTextFile("/some/path/unknown.xyz"); });
+}
+
+TEST(IndexUtilityTest, IsSupportedOCRFileBySuffix)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::isSupportedOCRFile("/some/path/image.png"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::isSupportedOCRFile("/some/path/unknown.xyz"); });
+}
+
+TEST(IndexUtilityTest, IsDefaultIndexedDirectory)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::isDefaultIndexedDirectory("/no/such/indexed/dir"); });
+}
+
+TEST(IndexUtilityTest, IsIndexWithAnything)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::isIndexWithAnything("/no/such/dir"); });
+}
+
+TEST(IndexUtilityTest, AnythingConfigWatcherInstance)
+{
+    EXPECT_NE(IndexUtility::AnythingConfigWatcher::instance(), nullptr);
+}
+
+TEST(IndexUtilityTest, AnythingConfigWatcherDefaultPaths)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::AnythingConfigWatcher::instance()->defaultAnythingIndexPaths(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::AnythingConfigWatcher::instance()->defaultAnythingIndexPathsRealtime(); });
+}
+
+TEST(IndexUtilityTest, AnythingConfigWatcherBlacklistPaths)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::AnythingConfigWatcher::instance()->defaultBlacklistPaths(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)IndexUtility::AnythingConfigWatcher::instance()->defaultBlacklistPathsRealtime(); });
+}

--- a/autotests/services/textindex/test_pathexcludematcher.cpp
+++ b/autotests/services/textindex/test_pathexcludematcher.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_pathexcludematcher.cpp
+ * @brief Unit tests for PathExcludeMatcher (pathexcludematcher.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/utils/pathexcludematcher.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+TEST(PathExcludeMatcherTest, DefaultConstructorEmpty)
+{
+    PathExcludeMatcher matcher;
+    EXPECT_FALSE(matcher.hasPatterns());
+    EXPECT_EQ(matcher.patternCount(), 0);
+}
+
+TEST(PathExcludeMatcherTest, ConstructWithPatterns)
+{
+    PathExcludeMatcher matcher({ "tmp", "/home/user/exclude" });
+    EXPECT_TRUE(matcher.hasPatterns());
+    EXPECT_EQ(matcher.patternCount(), 2);
+}
+
+TEST(PathExcludeMatcherTest, AddPatternDuplicateIgnored)
+{
+    PathExcludeMatcher matcher;
+    matcher.addPattern("tmp");
+    matcher.addPattern("tmp");
+    EXPECT_EQ(matcher.patternCount(), 1);
+}
+
+TEST(PathExcludeMatcherTest, AddEmptyPatternIgnored)
+{
+    PathExcludeMatcher matcher;
+    matcher.addPattern("");
+    EXPECT_FALSE(matcher.hasPatterns());
+}
+
+TEST(PathExcludeMatcherTest, AddPatternsList)
+{
+    PathExcludeMatcher matcher;
+    matcher.addPatterns({ "a", "b", "c" });
+    EXPECT_EQ(matcher.patternCount(), 3);
+}
+
+TEST(PathExcludeMatcherTest, RemovePattern)
+{
+    PathExcludeMatcher matcher({ "a", "b", "c" });
+    matcher.removePattern("b");
+    EXPECT_EQ(matcher.patternCount(), 2);
+    EXPECT_FALSE(matcher.patterns().contains("b"));
+}
+
+TEST(PathExcludeMatcherTest, Clear)
+{
+    PathExcludeMatcher matcher({ "a", "b" });
+    matcher.clear();
+    EXPECT_FALSE(matcher.hasPatterns());
+    EXPECT_EQ(matcher.patternCount(), 0);
+}
+
+TEST(PathExcludeMatcherTest, ShouldExcludeEmptyPathReturnsFalse)
+{
+    PathExcludeMatcher matcher({ "tmp" });
+    EXPECT_FALSE(matcher.shouldExclude(""));
+}
+
+TEST(PathExcludeMatcherTest, ShouldExcludeNoPatternsReturnsFalse)
+{
+    PathExcludeMatcher matcher;
+    EXPECT_FALSE(matcher.shouldExclude("/home/user/tmp"));
+}
+
+TEST(PathExcludeMatcherTest, ExactNameMatch)
+{
+    PathExcludeMatcher matcher({ "tmp" });
+    EXPECT_TRUE(matcher.shouldExclude("/home/user/tmp"));
+    EXPECT_TRUE(matcher.shouldExclude("/home/user/tmp/subdir"));
+    EXPECT_FALSE(matcher.shouldExclude("/home/user/template"));
+}
+
+TEST(PathExcludeMatcherTest, AbsolutePrefixMatch)
+{
+    PathExcludeMatcher matcher({ "/home/user/exclude" });
+    EXPECT_TRUE(matcher.shouldExclude("/home/user/exclude"));
+    EXPECT_TRUE(matcher.shouldExclude("/home/user/exclude/subdir"));
+    EXPECT_FALSE(matcher.shouldExclude("/home/user/other"));
+}
+
+TEST(PathExcludeMatcherTest, GlobPatternMatch)
+{
+    PathExcludeMatcher matcher({ "build-*" });
+    EXPECT_TRUE(matcher.shouldExclude("/home/user/build-debug"));
+    EXPECT_FALSE(matcher.shouldExclude("/home/user/src"));
+}
+
+TEST(PathExcludeMatcherTest, PathSegmentMatch)
+{
+    PathExcludeMatcher matcher({ ".local/share/Trash" });
+    EXPECT_TRUE(matcher.shouldExclude("/.local/share/Trash"));
+    EXPECT_TRUE(matcher.shouldExclude("/.local/share/Trash/sub"));
+    EXPECT_FALSE(matcher.shouldExclude("/.local/share/Trashcan"));
+}
+
+TEST(PathExcludeMatcherTest, PatternsListReturnsOriginals)
+{
+    PathExcludeMatcher matcher({ "tmp", "/abs/path" });
+    QStringList pats = matcher.patterns();
+    EXPECT_TRUE(pats.contains("tmp"));
+    EXPECT_TRUE(pats.contains("/abs/path"));
+}
+
+TEST(PathExcludeMatcherTest, CreateForIndexReturnsMatcher)
+{
+    PathExcludeMatcher matcher = PathExcludeMatcher::createForIndex();
+    EXPECT_NO_FATAL_FAILURE({ (void)matcher.hasPatterns(); });
+}
+
+TEST(PathExcludeMatcherTest, GlobToRegexSimple)
+{
+    QRegularExpression re = PathExcludeMatcher::globToRegex("*.txt");
+    EXPECT_TRUE(re.match("a.txt").hasMatch());
+    EXPECT_FALSE(re.match("a.tx").hasMatch());
+}
+
+TEST(PathExcludeMatcherTest, GlobToRegexQuestionMark)
+{
+    QRegularExpression re = PathExcludeMatcher::globToRegex("a?c");
+    EXPECT_TRUE(re.match("abc").hasMatch());
+    EXPECT_FALSE(re.match("ac").hasMatch());
+}
+
+TEST(PathExcludeMatcherTest, GlobToRegexEscapesSpecialChars)
+{
+    QRegularExpression re = PathExcludeMatcher::globToRegex("a.b");
+    EXPECT_TRUE(re.match("a.b").hasMatch());
+    EXPECT_FALSE(re.match("axb").hasMatch());
+}

--- a/autotests/services/textindex/test_textindexconfig.cpp
+++ b/autotests/services/textindex/test_textindexconfig.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_textindexconfig.cpp
+ * @brief Unit tests for TextIndexConfig (textindexconfig.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/utils/textindexconfig.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+TEST(TextIndexConfigTest, InstanceReturnsRef)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)&TextIndexConfig::instance(); });
+}
+
+TEST(TextIndexConfigTest, AutoIndexUpdateIntervalPositive)
+{
+    EXPECT_GT(TextIndexConfig::instance().autoIndexUpdateInterval(), 0);
+}
+
+TEST(TextIndexConfigTest, MonitoringStartDelaySecondsNonNeg)
+{
+    EXPECT_GE(TextIndexConfig::instance().monitoringStartDelaySeconds(), 0);
+}
+
+TEST(TextIndexConfigTest, SilentIndexUpdateDelayNonNeg)
+{
+    EXPECT_GE(TextIndexConfig::instance().silentIndexUpdateDelay(), 0);
+}
+
+TEST(TextIndexConfigTest, InotifyResourceCleanupDelayMsNonNeg)
+{
+    EXPECT_GE(TextIndexConfig::instance().inotifyResourceCleanupDelayMs(), 0);
+}
+
+TEST(TextIndexConfigTest, MaxIndexTextFileSizeMBPositive)
+{
+    EXPECT_GT(TextIndexConfig::instance().maxIndexTextFileSizeMB(), 0);
+}
+
+TEST(TextIndexConfigTest, MaxIndexFileTruncationSizeMBPositive)
+{
+    EXPECT_GT(TextIndexConfig::instance().maxIndexFileTruncationSizeMB(), 0);
+}
+
+TEST(TextIndexConfigTest, SupportedTextFileExtensionsNonEmpty)
+{
+    EXPECT_FALSE(TextIndexConfig::instance().supportedTextFileExtensions().isEmpty());
+}
+
+TEST(TextIndexConfigTest, SupportedOcrImageExtensions)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)TextIndexConfig::instance().supportedOcrImageExtensions(); });
+}
+
+TEST(TextIndexConfigTest, MaxOcrImageSizeMBPositive)
+{
+    EXPECT_GT(TextIndexConfig::instance().maxOcrImageSizeMB(), 0);
+}
+
+TEST(TextIndexConfigTest, IndexHiddenFilesReturnsBool)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)TextIndexConfig::instance().indexHiddenFiles(); });
+}
+
+TEST(TextIndexConfigTest, FolderExcludeFilters)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)TextIndexConfig::instance().folderExcludeFilters(); });
+}
+
+TEST(TextIndexConfigTest, CpuUsageLimitPercent)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)TextIndexConfig::instance().cpuUsageLimitPercent(); });
+}
+
+TEST(TextIndexConfigTest, BatchCommitInterval)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)TextIndexConfig::instance().batchCommitInterval(); });
+}
+
+TEST(TextIndexConfigTest, ReloadConfigNoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE({ TextIndexConfig::instance().reloadConfig(); });
+}


### PR DESCRIPTION
## Summary by Sourcery

Increase unit test coverage across dfm-base and textindex components and harden the unit-test runner environment.

Tests:
- Add extensive unit tests for dfm-base utilities, file info abstractions, device and network helpers, configuration and settings helpers, and UI support classes.
- Add extensive unit tests for textindex service components including profiles, state store, path exclusion matcher, index utilities, config, filesystem event collector, and related helpers.
- Extend LocalFileHandler, directory iterators, and watcher abstractions test coverage to exercise success, failure, and edge-case paths.
- Add tests for application configuration APIs, standard paths, MIME handling, sorting helpers, and other infrastructure-level helpers.
- Update the unit-test runner to use an offscreen Qt platform, extend ctest timeout, and ensure locally built dfm-base and extractor libraries are preferred at runtime to avoid symbol issues.