### PR TITLE
fix(disk-encrypt): restore auto-resume decrypt dialog after interruption

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -775,19 +775,24 @@ void DiskEncryptMenuScene::sortActions(QMenu *parent)
 {
     Q_ASSERT(parent);
     QList<QAction *> acts = parent->actions();
-    if (acts.isEmpty()) {
-        fmDebug() << "No actions to sort";
-        return;
-    }
 
-    QAction *before { acts.last() };
-    for (int i = 0; i < acts.count(); ++i) {
-        auto act = acts.at(i);
-        QString actID = act->property(ActionPropertyKey::kActionID).toString();
-        if (actID == "computer-rename"   // the encrypt actions should be under computer-rename
-            && (i + 1) < acts.count()) {
-            before = acts.at(i + 1);
-            break;
+    // When the menu is empty (e.g. programmatic trigger from
+    // processUnfinshedDecrypt), insertAction(nullptr, act) appends actions to
+    // the end. Do NOT early-return for empty menus — that prevents actions
+    // from being added and breaks the auto-resume-decrypt dialog (PMS BUG-372719,
+    // regression from BUG-307533). Only call acts.last() when non-empty to
+    // preserve the BUG-307533 null-safety fix.
+    QAction *before { nullptr };
+    if (!acts.isEmpty()) {
+        before = acts.last();
+        for (int i = 0; i < acts.count(); ++i) {
+            auto act = acts.at(i);
+            QString actID = act->property(ActionPropertyKey::kActionID).toString();
+            if (actID == "computer-rename"   // the encrypt actions should be under computer-rename
+                && (i + 1) < acts.count()) {
+                before = acts.at(i + 1);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
## 根因分析

`processUnfinshedDecrypt`（自动续做解密入口）新建一个空 `QMenu`，依赖 `DiskEncryptMenuScene::sortActions` 把加密菜单动作挂到这个空菜单上。但提交 `d5cce0b47`（修复 PMS BUG-307533）给 `sortActions` 增加了"菜单为空直接 return"的早退保护，导致动作不再被插入空菜单 → `menu->actions()` 为空 → `find_if` 找不到 `de_1_decrypt` → 打印 "Decrypt action not found in menu" 后直接返回，`triggered` 与确认弹窗均不执行。

这是一个回归 bug：BUG-307533 的防御性修复意外破坏了 `processUnfinshedDecrypt` 对"空菜单也会被追加动作"的隐含契约。

## 修复方案

修改 `DiskEncryptMenuScene::sortActions`：菜单为空时不再早退，而是以 `before=nullptr` 把动作追加到菜单（`insertAction(nullptr, act)` 等价于 append），同时保留 BUG-307533 的空指针安全（仅非空时才调 `acts.last()`）。非空菜单行为与现状完全一致，不影响正常右键菜单。

## 改动安全评估

- 风险等级：**低风险**
- 不改函数签名，仅改内部逻辑
- 仅 1 处实际调用（`updateState` → `sortActions`），非空菜单行为不变
- 空菜单分支恢复为 BUG-307533 之前的行为，同时保留空指针安全

## Summary by Sourcery

Bug Fixes:
- Fix regression where the auto-resume decrypt dialog failed to appear because sortActions early-returned on empty menus, preventing decrypt actions from being inserted.