### PR TITLE
fix(openwith): increase bottom action gap

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -319,7 +319,7 @@ void OpenWithDialog::initUI()
     QVBoxLayout *bottomLayout = new QVBoxLayout;
 
     bottomLayout->addWidget(new DHorizontalLine(this));
-    bottomLayout->addSpacing(5);
+    bottomLayout->addSpacing(10);
     bottomLayout->addLayout(buttonLayout);
     bottomLayout->setContentsMargins(10, 0, 10, 0);
 


### PR DESCRIPTION
## Summary
- increase the spacing between the bottom separator and the action buttons from 5px to 10px
- keep the rest of the open-with dialog layout and separator style unchanged

PMS: https://pms.uniontech.com/bug-view-372645.html

## Summary by Sourcery

Enhancements:
- Adjust the bottom layout spacing in the open-with dialog to add more gap between the separator line and action buttons.