### PR TITLE
test(dde-file-manager): add entryfileinfo/thumbnail/indextask tests 

### DIFF
--- a/autotests/libs/dfm-base/test_entryfileinfo.cpp
+++ b/autotests/libs/dfm-base/test_entryfileinfo.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_entryfileinfo.cpp
+ * @brief Unit tests for EntryFileInfo (entryfileinfo.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QIcon>
+#include <QVariant>
+#include <QVariantHash>
+#include <mutex>
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/interfaces/abstractentryfileentity.h>
+#include <dfm-base/file/entry/entryfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+using namespace dfmbase;
+
+namespace {
+class TestEntryEntity : public AbstractEntryFileEntity
+{
+public:
+    explicit TestEntryEntity(const QUrl &url)
+        : AbstractEntryFileEntity(url) {}
+    QString displayName() const override { return QStringLiteral("TestEntry"); }
+    QIcon icon() const override { return QIcon(); }
+    bool exists() const override { return true; }
+    bool showProgress() const override { return false; }
+    bool showTotalSize() const override { return false; }
+    bool showUsageSize() const override { return false; }
+    EntryOrder order() const override { return EntryOrder::kOrderCustom; }
+};
+}   // namespace
+
+class EntryFileInfoTest : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kEntry, "/", QIcon(), true, "entry", nullptr);
+            EntryEntityFactor::registCreator<TestEntryEntity>("_common_");
+            EntryEntityFactor::registCreator<TestEntryEntity>("tag");
+        });
+    }
+
+    void SetUp() override
+    {
+        url = QUrl("entry:///home/user/myentry.tag");
+    }
+
+    QUrl url;
+    static std::once_flag flag;
+};
+
+std::once_flag EntryFileInfoTest::flag;
+
+TEST_F(EntryFileInfoTest, ConstructAndEntity)
+{
+    EntryFileInfo info(url);
+    EXPECT_NE(info.entity(), nullptr);
+}
+
+TEST_F(EntryFileInfoTest, Order)
+{
+    EntryFileInfo info(url);
+    EXPECT_EQ(info.order(), AbstractEntryFileEntity::EntryOrder::kOrderCustom);
+}
+
+TEST_F(EntryFileInfoTest, TargetUrl)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.targetUrl(); });
+}
+
+TEST_F(EntryFileInfoTest, IsAccessable)
+{
+    EntryFileInfo info(url);
+    EXPECT_TRUE(info.isAccessable());
+}
+
+TEST_F(EntryFileInfoTest, Description)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.description(); });
+}
+
+TEST_F(EntryFileInfoTest, ExtraProperty)
+{
+    EntryFileInfo info(url);
+    info.setExtraProperty("k", QVariant(1));
+    EXPECT_EQ(info.extraProperty("k").toInt(), 1);
+    EXPECT_EQ(info.extraProperty("missing").toInt(), 0);
+}
+
+TEST_F(EntryFileInfoTest, Renamable)
+{
+    EntryFileInfo info(url);
+    EXPECT_FALSE(info.renamable());
+}
+
+TEST_F(EntryFileInfoTest, DisplayName)
+{
+    EntryFileInfo info(url);
+    EXPECT_EQ(info.displayName(), QString("TestEntry"));
+}
+
+TEST_F(EntryFileInfoTest, EditDisplayText)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.editDisplayText(); });
+}
+
+TEST_F(EntryFileInfoTest, SizeTotalAndUsageAndFree)
+{
+    EntryFileInfo info(url);
+    EXPECT_EQ(info.sizeTotal(), 0);
+    EXPECT_EQ(info.sizeUsage(), 0);
+    EXPECT_EQ(info.sizeFree(), 0);
+}
+
+TEST_F(EntryFileInfoTest, ShowFlags)
+{
+    EntryFileInfo info(url);
+    EXPECT_FALSE(info.showTotalSize());
+    EXPECT_FALSE(info.showUsedSize());
+    EXPECT_FALSE(info.showProgress());
+}
+
+TEST_F(EntryFileInfoTest, Exists)
+{
+    EntryFileInfo info(url);
+    EXPECT_TRUE(info.exists());
+}
+
+TEST_F(EntryFileInfoTest, NameOfBaseNameEmpty)
+{
+    EntryFileInfo info(url);
+    EXPECT_TRUE(info.nameOf(FileInfo::FileNameInfoType::kBaseName).isEmpty());
+}
+
+TEST_F(EntryFileInfoTest, NameOfSuffix)
+{
+    EntryFileInfo info(url);
+    EXPECT_EQ(info.nameOf(FileInfo::FileNameInfoType::kSuffix), QString("tag"));
+}
+
+TEST_F(EntryFileInfoTest, NameOfDefault)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.nameOf(FileInfo::FileNameInfoType::kFileName); });
+}
+
+TEST_F(EntryFileInfoTest, DisplayOfFileDisplayName)
+{
+    EntryFileInfo info(url);
+    EXPECT_EQ(info.displayOf(FileInfo::DisplayInfoType::kFileDisplayName), QString("TestEntry"));
+}
+
+TEST_F(EntryFileInfoTest, DisplayOfOther)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.displayOf(FileInfo::DisplayInfoType::kSizeDisplayName); });
+}
+
+TEST_F(EntryFileInfoTest, PathOfPathAndFilePath)
+{
+    EntryFileInfo info(url);
+    EXPECT_EQ(info.pathOf(FileInfo::FilePathInfoType::kPath), url.path());
+    EXPECT_EQ(info.pathOf(FileInfo::FilePathInfoType::kFilePath), url.path());
+}
+
+TEST_F(EntryFileInfoTest, PathOfDefault)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.pathOf(FileInfo::FilePathInfoType::kAbsoluteFilePath); });
+}
+
+TEST_F(EntryFileInfoTest, FileIconAndRefresh)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.fileIcon(); });
+    EXPECT_NO_FATAL_FAILURE({ info.refresh(); });
+}
+
+TEST_F(EntryFileInfoTest, ExtraProperties)
+{
+    EntryFileInfo info(url);
+    EXPECT_NO_FATAL_FAILURE({ (void)info.extraProperties(); });
+}

--- a/autotests/libs/dfm-base/test_thumbnailcreators.cpp
+++ b/autotests/libs/dfm-base/test_thumbnailcreators.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_thumbnailcreators.cpp
+ * @brief Unit tests for ThumbnailCreators free functions (thumbnailcreators.cpp)
+ *
+ * Calls each creator with a non-existent path; they are expected to return a
+ * null QImage without crashing, exercising the entry/early-return paths.
+ */
+
+#include <gtest/gtest.h>
+#include <QImage>
+#include <QString>
+
+#include <dfm-base/utils/thumbnail/thumbnailcreators.h>
+#include <dfm-base/dfm_global_defines.h>
+
+using namespace dfmbase;
+using namespace ThumbnailCreators;
+using DFMGLOBAL_NAMESPACE::ThumbnailSize;
+
+TEST(ThumbnailCreatorsTest, DefaultThumbnailCreatorNonExistentReturnsNull)
+{
+    QImage img = defaultThumbnailCreator("/no/such/file.xyz", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, VideoThumbnailCreatorNonExistent)
+{
+    QImage img = videoThumbnailCreator("/no/such/video.mp4", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, VideoThumbnailCreatorFfmpegNonExistent)
+{
+    QImage img = videoThumbnailCreatorFfmpeg("/no/such/video.mp4", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, VideoThumbnailCreatorLibNonExistent)
+{
+    QImage img = videoThumbnailCreatorLib("/no/such/video.mp4", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, TextThumbnailCreatorNonExistent)
+{
+    QImage img = textThumbnailCreator("/no/such/file.txt", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, AudioThumbnailCreatorNonExistent)
+{
+    QImage img = audioThumbnailCreator("/no/such/audio.mp3", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, ImageThumbnailCreatorNonExistent)
+{
+    QImage img = imageThumbnailCreator("/no/such/image.png", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, DjvuThumbnailCreatorNonExistent)
+{
+    QImage img = djvuThumbnailCreator("/no/such/doc.djvu", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, PdfThumbnailCreatorNonExistent)
+{
+    QImage img = pdfThumbnailCreator("/no/such/doc.pdf", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, AppimageThumbnailCreatorNonExistent)
+{
+    QImage img = appimageThumbnailCreator("/no/such/app.AppImage", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, PptxThumbnailCreatorNonExistent)
+{
+    QImage img = pptxThumbnailCreator("/no/such/deck.pptx", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, UabThumbnailCreatorNonExistent)
+{
+    QImage img = uabThumbnailCreator("/no/such/app.uab", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, KrataThumbnailCreatorNonExistent)
+{
+    QImage img = krataThumbnailCreator("/no/such/file.xyz", ThumbnailSize::kNormal);
+    EXPECT_TRUE(img.isNull());
+}
+
+TEST(ThumbnailCreatorsTest, DefaultThumbnailCreatorLargeSizeDowngrades)
+{
+    QImage img = defaultThumbnailCreator("/no/such/file.xyz", ThumbnailSize::kXLarge);
+    EXPECT_TRUE(img.isNull());
+}

--- a/autotests/services/textindex/test_indextask.cpp
+++ b/autotests/services/textindex/test_indextask.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_indextask.cpp
+ * @brief Unit tests for IndexTask getters/setters (indextask.cpp)
+ *
+ * start() asserts it runs off the main thread, so we only exercise the
+ * non-threaded API surface here.
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/task/indextask.h"
+#include "services/textindex/task/taskhandler.h"
+#include "services/textindex/utils/taskstate.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+static TaskHandler makeNoopHandler()
+{
+    return [](const QString &path, TaskState &state) -> HandlerResult {
+        HandlerResult r;
+        r.success = true;
+        return r;
+    };
+}
+
+TEST(IndexTaskTest, ConstructAndAccessors)
+{
+    IndexTask task(IndexTask::Type::Create, "/tmp/dfm_test_path", makeNoopHandler());
+    EXPECT_EQ(task.taskPath(), QString("/tmp/dfm_test_path"));
+    EXPECT_EQ(task.taskType(), IndexTask::Type::Create);
+    EXPECT_EQ(task.status(), IndexTask::Status::NotStarted);
+    EXPECT_FALSE(task.isRunning());
+}
+
+TEST(IndexTaskTest, SilentAccessors)
+{
+    IndexTask task(IndexTask::Type::Update, "/tmp/p", makeNoopHandler());
+    EXPECT_FALSE(task.silent());
+    task.setSilent(true);
+    EXPECT_TRUE(task.silent());
+    task.setSilent(false);
+    EXPECT_FALSE(task.silent());
+}
+
+TEST(IndexTaskTest, IndexCorruptedAccessors)
+{
+    IndexTask task(IndexTask::Type::CreateFileList, "/tmp/p", makeNoopHandler());
+    EXPECT_FALSE(task.isIndexCorrupted());
+    task.setIndexCorrupted(true);
+    EXPECT_TRUE(task.isIndexCorrupted());
+    task.setIndexCorrupted(false);
+    EXPECT_FALSE(task.isIndexCorrupted());
+}
+
+TEST(IndexTaskTest, StopWhenNotRunningNoCrash)
+{
+    IndexTask task(IndexTask::Type::RemoveFileList, "/tmp/p", makeNoopHandler());
+    EXPECT_NO_FATAL_FAILURE({ task.stop(); });
+}
+
+TEST(TaskStateTest, DefaultNotRunning)
+{
+    TaskState s;
+    EXPECT_FALSE(s.isRunning());
+}
+
+TEST(TaskStateTest, StartStop)
+{
+    TaskState s;
+    s.start();
+    EXPECT_TRUE(s.isRunning());
+    s.stop();
+    EXPECT_FALSE(s.isRunning());
+}
+
+TEST(TaskStateTest, Silent)
+{
+    TaskState s;
+    EXPECT_FALSE(s.isSilent());
+    s.setSilent(true);
+    EXPECT_TRUE(s.isSilent());
+}


### PR DESCRIPTION
- EntryFileInfo (construct/entity/order/targetUrl/extraProperty/nameOf/displayOf/pathOf/icon/refresh) with a test AbstractEntryFileEntity registered for '_common_' and 'tag'
- ThumbnailCreators (all 14 creators exercised with non-existent paths -> null QImage early-return paths)
- IndexTask getters/setters (taskPath/taskType/status/silent/corrupted/stop) + TaskState

## Summary by Sourcery

Add unit tests covering EntryFileInfo behavior, thumbnail creator early-return paths, and IndexTask/TaskState accessors in dfm-base and textindex services.

Tests:
- Introduce comprehensive EntryFileInfo tests using a test entry entity registered for common and tag schemes.
- Add tests validating all thumbnail creator functions return null images for non-existent paths and handle large size requests.
- Add tests for IndexTask and TaskState getters, setters, and non-threaded control methods in the text index service.