### PR TITLE
fix: use decode-validation-first strategy for text preview encoding

### DIFF
--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
@@ -14,6 +14,8 @@
 #include <QUrl>
 #include <QFileInfo>
 #include <QDebug>
+#include <QByteArray>
+#include <climits>
 
 using namespace std;
 DFMBASE_USE_NAMESPACE
@@ -91,20 +93,51 @@ bool TextPreview::setFileUrl(const QUrl &url)
     device.seekg(0, ios::beg).read(buf, static_cast<streamsize>(len));
     device.close();
 
-    bool ok { false };
-    QString fileEncoding = DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::detectFileEncoding(filePath, &ok);
-    fmDebug() << "Text preview: detected file encoding:" << fileEncoding << "detection success:" << ok;
+    // len is already capped at kReadTextSize (5 MB) above, but guard the
+    // static_cast<int> explicitly to satisfy static analysis and prevent
+    // potential integer truncation on platforms where long > int.
+    if (len > INT_MAX) {
+        fmWarning() << "Text preview: file too large for preview:" << len;
+        delete[] buf;
+        return false;
+    }
 
-    std::string strBuf(buf, static_cast<unsigned long>(len));
-    if (ok && fileEncoding.toLower() != "utf-8") {
-        fmDebug() << "Text preview: converting from" << fileEncoding << "to UTF-8";
+    QByteArray rawData(buf, static_cast<int>(len));
+
+    // Step 1: if the raw bytes are already valid UTF-8, use them as-is.
+    // This covers ASCII and real UTF-8 files without any conversion overhead.
+    std::string strBuf;
+    if (rawData.isValidUtf8()) {
+        fmDebug() << "Text preview: raw data is valid UTF-8, using directly";
+        strBuf = rawData.toStdString();
+    } else {
+        // Step 2: try GB18030 → UTF-8 first.
+        // GB18030 is the national standard and GBK superset;
+        // in UOS it covers the overwhelming majority of non-UTF-8 CJK text.
+        // This avoids unreliable statistical encoding detection.
         QByteArray out;
-        QByteArray in(buf, static_cast<int>(len));
-        if (DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::convertTextEncoding(in, out, "utf-8")) {
+        if (DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::convertTextEncoding(
+                rawData, out, "utf-8", "gb18030")) {
             strBuf = out.toStdString();
-            fmDebug() << "Text preview: encoding conversion successful";
+            fmDebug() << "Text preview: GB18030 → UTF-8 conversion successful";
         } else {
-            fmWarning() << "Text preview: encoding conversion failed, using original data";
+            // Step 3: fall back to auto-detection for rare
+            // non-GB18030 encodings (Big5, EUC-JP, KOI8-R, …).
+            fmDebug() << "Text preview: GB18030 conversion failed, falling back to auto-detection";
+            bool ok { false };
+            QString fileEncoding = DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::detectFileEncoding(filePath, &ok);
+            fmDebug() << "Text preview: detected file encoding:" << fileEncoding << "detection success:" << ok;
+
+            strBuf = rawData.toStdString();
+            if (ok && fileEncoding.toLower() != "utf-8") {
+                fmDebug() << "Text preview: converting from" << fileEncoding << "to UTF-8";
+                if (DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::convertTextEncoding(rawData, out, "utf-8")) {
+                    strBuf = out.toStdString();
+                    fmDebug() << "Text preview: encoding conversion successful";
+                } else {
+                    fmWarning() << "Text preview: encoding conversion failed, using original data";
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## 根因分析

文本预览插件 `textpreview.cpp` 完全依赖 `DTextEncoding::detectFileEncoding` 检测文件编码，但该检测在实际环境中不可靠：

1. **ICU 字符集检测失效**：DTK 通过 `QLibrary("libicuuc")` 解析 `ucsdet_open` 等符号，但 ICU 74 将这些符号放在 `libicui18n` 且带 `_74` 版本后缀，导致 `LibICU::isValid()` 为 false。
2. **uchardet 大量误判**：仅靠 uchardet 时，对短文本/含 PUA 字符的 GB18030 样本文件频繁误判为 UTF-8/EUC-JP/Big5/ISO-8859-3/WINDOWS-1252。

实测 24 个 GB18030 样本文件，当前检测准确率仅 62%（15/24），即使修复 ICU 也仅 75%（18/24）。

## 修复方案

采用"解码校验优先"三步策略替代纯统计检测：

1. **UTF-8 优先校验**：`QByteArray::isValidUtf8()` 判断原始字节是否为合法 UTF-8，合法则直接使用。
2. **GB18030 兜底转换**：非 UTF-8 内容优先尝试 GB18030→UTF-8 转换（国标、GBK 超集）。
3. **自动检测最后手段**：GB18030 也转换失败时，回退 `DTextEncoding` 自动检测+转换，覆盖极少数真实非 GB18030 的 CJK 文件。

该策略对全部 24 个样本文件预览准确率 100%，且不破坏合法 UTF-8 文件预览。

## 改动安全评估

- 风险等级：低风险
- 仅修改 `TextPreview::setFileUrl` 内部编码处理逻辑，不改变函数签名
- 无外部调用者依赖被改逻辑（`setFileUrl` 是 `AbstractBasePreview` 虚函数实现，由预览框架通过虚函数表调用）

## 测试数据

对 bug 附件中全部 24 个 `.txt` 文件的三种策略对比检测数据见附件。

## Summary by Sourcery

Adopt a decode-validation-first strategy in the text preview plugin to improve file encoding handling and reliability for non-UTF-8 text files.

Bug Fixes:
- Fix incorrect encoding detection for GB18030 and other non-UTF-8 text files in the text preview feature by prioritizing UTF-8 validation and GB18030 conversion before automatic detection.

Enhancements:
- Guard against potential integer truncation when handling large files in text preview to avoid unsafe casting.