### PR TITLE
fix(sidebar): include foreground color in icon cache key

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -74,14 +74,15 @@ void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option)
 }
 }   // namespace GlobalPrivate
 
-QString SideBarItemDelegate::makeIconCacheKey(const DTK_GUI_NAMESPACE::DDciIcon &icon,
-                                             const QSize &size,
+QString SideBarItemDelegate::makeIconCacheKey(const QSize &size,
                                              DTK_GUI_NAMESPACE::DDciIcon::Theme theme,
                                              DTK_GUI_NAMESPACE::DDciIcon::Mode mode,
-                                             const QString &iconId) const
+                                             const QString &iconId,
+                                             const QColor &foreground) const
 {
-    return QString::asprintf("%s|%dx%d|%d|%d", iconId.toUtf8().constData(),
-                             size.width(), size.height(), static_cast<int>(theme), static_cast<int>(mode));
+    return QString::asprintf("%s|%dx%d|%d|%d|%08x", iconId.toUtf8().constData(),
+                             size.width(), size.height(), static_cast<int>(theme),
+                             static_cast<int>(mode), foreground.rgba());
 }
 
 void SideBarItemDelegate::clearIconCache()
@@ -553,7 +554,7 @@ void SideBarItemDelegate::drawDciIcon(const QStyleOptionViewItem &option, QPaint
         palette.setForeground(fg);
     }
 
-    QString key = makeIconCacheKey(dciIcon, iconRect.size(), theme, mode, iconId);
+    QString key = makeIconCacheKey(iconRect.size(), theme, mode, iconId, palette.foreground());
     if (m_iconCache.contains(key)) {
         painter->drawPixmap(iconRect, m_iconCache.value(key));
         return;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -57,10 +57,11 @@ private:
     void drawExpandIndicator(QPainter *painter, QRect &r, bool expandable, const QModelIndex &index, bool isHighlight) const;
 
     mutable QHash<QString, QPixmap> m_iconCache;
-    QString makeIconCacheKey(const DTK_GUI_NAMESPACE::DDciIcon &icon, const QSize &size,
+    QString makeIconCacheKey(const QSize &size,
                              DTK_GUI_NAMESPACE::DDciIcon::Theme theme,
                              DTK_GUI_NAMESPACE::DDciIcon::Mode mode,
-                             const QString &iconId = QString()) const;
+                             const QString &iconId,
+                             const QColor &foreground) const;
     void clearIconCache();
 
 Q_SIGNALS:


### PR DESCRIPTION
fix(sidebar): include foreground color in icon cache key

The icon cache key omits the DDciIconPalette foreground, so normal and
highlighted (keepDrawingHighlighted) sidebar icons share the same cache
entry. Add the foreground rgba to the cache key to prevent collisions.

修复侧边栏图标缓存键缺少前景色维度的问题，避免正常与选中/高亮状态图标缓存碰撞。

Log: 修复侧边栏图标缓存键缺少前景色导致的图标绘制问题
Influence: 侧边栏图标在正常与选中/高亮状态下将正确显示对应前景色。
Change-Id: Iaf87523adc4279d85f77655b079375d354230982

## Summary by Sourcery

Bug Fixes:
- Fix sidebar icon cache collisions by incorporating the foreground color into the icon cache key so different visual states use distinct cache entries.