### PR TITLE
fix(polkit): require auth for CIFS mount and TPM query actions

### DIFF
--- a/src/services/mountcontrol/org.deepin.filemanager.mountcontrol.policy
+++ b/src/services/mountcontrol/org.deepin.filemanager.mountcontrol.policy
@@ -101,7 +101,7 @@
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 </policyconfig>

--- a/src/services/tpmcontrol/polkit/org.deepin.filemanager.tpmcontrol.policy
+++ b/src/services/tpmcontrol/polkit/org.deepin.filemanager.tpmcontrol.policy
@@ -16,7 +16,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 


### PR DESCRIPTION
## 根因分析

镜像 polkit 安全扫描报告文件管理器两个 action 配置“不安全”：`MountController.CIFS` 与 `TPMControl.Query` 的 `allow_active=yes`。

经核查源码与 PMS 历史记录（关联 bug #363289），这两处 `yes` 是**经安全评审通过的有意免鉴权设计**（CIFS 免鉴权有评审邮件佐证；TPM Query 仅守护 4 个只读状态查询方法，敏感的 Encrypt/Decrypt 仍需管理员鉴权）。扫描工具“凡 `allow_active=yes` 即标记”的一刀切规则命中了这两项豁免。根因为强根因：by-design 豁免被静态规则重新标记。

关键证据：
- `dde-file-manager/src/services/mountcontrol/org.deepin.filemanager.mountcontrol.policy:94,104`：通用挂载 `auth_admin_keep`，仅 CIFS 拆出设 `yes`；`cifsmounthelper.cpp:37,194` 证实仅用于 CIFS 挂载分支。
- `dde-file-manager/src/services/tpmcontrol/tpmcontroldbus.cpp:155/166/177/188` 证实 `kQuery` 只守护 4 个只读查询方法，`GetRandom/Encrypt`(`:199/:224`)、`Decrypt`(`:242`) 走独立 action 且需管理员鉴权。
- bug #363289 备注 #3/#4（刘郑）+ 本 bug #372451 备注 #4（王荣）确认“已通过评审 / 仅只读接口无安全风险”。

## 修复方案

经用户决策采用**方案 B**：将两个 action 的 `<allow_active>yes</allow_active>` 改为 `<allow_active>auth_admin_keep</allow_active>`，使镜像 polkit 安全扫描通过。改动极小（2 行 XML 值替换），不触碰 C++ 代码与 action 拆分结构，调用方 `checkAuthorization`/`checkAuthentication` 无需改动。

## 改动安全评估

中风险（建议性继续）：无函数签名变更、无公开函数删除、各 1 处引用（非 >5），不构成高风险阻断。改动为运行时行为回退——CIFS 挂载/卸载与 TPM 只读状态查询将要求管理员鉴权，回退 bug #363289 此前评审通过的免鉴权特性，系当前安全专项要求，用户已明确接受。详见附件 `change-safety.md`。

## 改动文件

- `src/services/mountcontrol/org.deepin.filemanager.mountcontrol.policy`：第 104 行 `MountController.CIFS` 的 `allow_active` `yes` → `auth_admin_keep`
- `src/services/tpmcontrol/polkit/org.deepin.filemanager.tpmcontrol.policy`：第 19 行 `TPMControl.Query` 的 `allow_active` `yes` → `auth_admin_keep`

PMS: https://pms.uniontech.com/bug-view-372451.html

## Summary by Sourcery

Enhancements:
- Align polkit policies for CIFS mounting and TPM status queries with stricter auth_admin_keep requirements instead of unconditional active allowance.