### PR TITLE
fix: correct polkit prompt for partition passphrase change (snipe)

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -14,9 +14,9 @@
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
 
-// VfsMonitorFileSystemWatcher 依赖 deepin-anything 内核模块
-// 如果模块不可用，create() 返回 nullptr，相关测试应被跳过
-// 注意: 当前内核 vfs_monitor 模块存在已知 bug（无法检测目录创建），
+// VfsMonitorFileSystemWatcher 依赖 deepin-anything 事件分发 socket
+// 如果事件分发不可用，create() 返回 nullptr，相关测试应被跳过
+// 注意: 当前 deepin-anything 事件链路若不可用，
 // 目录相关测试使用 ASSERT 严格模式，失败时直接终止当前测试而非崩溃
 class TestVfsMonitorFileSystemWatcher : public ::testing::Test
 {
@@ -33,7 +33,7 @@ protected:
         QStringList rootPaths = { testDir->path() };
         watcher = VfsMonitorFileSystemWatcher::create(rootPaths, {}, nullptr);
         if (!watcher) {
-            GTEST_SKIP() << "deepin-anything kernel module not available, skipping tests";
+            GTEST_SKIP() << "deepin-anything event dispatcher not available, skipping tests";
         }
     }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+dde-file-manager (6.5.160) unstable; urgency=medium
+
+  * fix(preview): resolve filename/resolution overlap in image preview status bar
+  * fix: fix potential crash in FileView destructor
+  * fix(textindex): add OcrIndex path to service manager idle policy
+  * fix(recent): cannot open recent:// url in cmd if plugin is lazy loaded
+  * fix(filedialog): keep recent hidden in save dialog on config change
+  * fix(recent): register watcher for recent scheme to enable view refresh
+  * fix: optimize share removal and permission management
+  * fix: improve path display for file conflict messages
+  * fix: improve search input handling robustness
+  * fix: properly handle selection state during model teardown
+  * fix(sidebar): avoid stale drop targets during external drags
+  * fix(burn): show error details in erase failure dialog
+  * refactor: switch from netlink to socket for deepin-anything events
+  * fix: improve mount point resolution in filesystem watcher
+  * fix: correct desktop available geometry on treeland fractional scaling
+  * fix: keep desktop canvas origin for top and left dock
+  * fix(diskencrypt): validate device encryption status before resuming operations
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * fix: reposition window near cursor on last tab tear-off
+  * fix(image-preview): support preview for formats with invalid size() like icns
+  * fix(thumbnail): support thumbnails for image formats with invalid size() like icns
+  * ci(cppcheck): bump actions/checkout to v7 and enable unsafe pr checkout
+  * fix(titlebar): stabilize virtual keyboard display
+  * fix(propertydialog): use D-Bus SystemInfo for installed memory size
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 24 Jul 2026 13:04:08 +0800
+
 dde-file-manager (6.5.151) unstable; urgency=medium
 
   * refactor: replace thread termination with _exit for clean shutdown

--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -68,9 +68,23 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     reader.setAutoTransform(true);
     sourceImageSize = reader.size();
 
+    QImage image;
+    bool needScaleAfterRead = false;   // 对于 size() 无法预知的格式（如 icns），读取后再缩放
     if (!sourceImageSize.isValid()) {
-        setPixmap(QPixmap());
-        return;
+        // 部分格式（如 icns）无法通过 size() 提前获取尺寸，这里先做一次解码，
+        // 失败则按原逻辑置空；成功则用实际图像尺寸进行后续处理。
+        image = reader.read();
+        if (image.isNull()) {
+            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+            setPixmap(QPixmap());
+            return;
+        }
+        sourceImageSize = image.size();
+        if (!sourceImageSize.isValid()) {
+            setPixmap(QPixmap());
+            return;
+        }
+        needScaleAfterRead = true;
     }
 
     // 计算保持宽高比的显示尺寸
@@ -78,15 +92,20 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
                       qMin(static_cast<int>(dsize.height() * 0.7), sourceImageSize.height()));
     QSize showSize = sourceImageSize.scaled(maxShowSize, Qt::KeepAspectRatio);
 
-    // 设置缩放尺寸，让 QImageReader 只加载需要的大小，避免加载完整大图
-    reader.setScaledSize(showSize);
-
-    QImage image = reader.read();
-    if (image.isNull()) {
-        fmWarning() << "Image preview: failed to load image:" << reader.errorString();
-        setPixmap(QPixmap());
-        return;
+    if (needScaleAfterRead) {
+        // 该格式无法依赖 setScaledSize，直接对已解码图像做平滑缩放
+        image = image.scaled(showSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    } else {
+        // 设置缩放尺寸，让 QImageReader 只加载需要的大小，避免加载完整大图
+        reader.setScaledSize(showSize);
+        image = reader.read();
+        if (image.isNull()) {
+            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+            setPixmap(QPixmap());
+            return;
+        }
     }
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // 应用颜色空间转换，解决CMYK等格式的颜色显示问题 (仅Qt6)
     image = DFMBASE_NAMESPACE::FileUtils::convertToSRgbColorSpace(image);

--- a/src/apps/dde-file-manager/dde-file-manager.desktop
+++ b/src/apps/dde-file-manager/dde-file-manager.desktop
@@ -13,6 +13,7 @@ Type=Application
 Version=1.0
 X-Deepin-DEComponent=true
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -360,28 +360,41 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
     }
 
     const QSize &imageSize = reader.size();
-
-    // fix 读取损坏icns文件（可能任意损坏的image类文件也有此情况）在arm平台上会导致递归循环的问题
-    // 这里先对损坏文件（imagesize无效）做处理，不再尝试读取其image数据
-    if (!imageSize.isValid()) {
-        qCWarning(logDFMBase) << "thumbnail: image file has invalid size attributes:" << filePath;
-        return {};
-    }
-
-    qCDebug(logDFMBase) << "thumbnail: image file size:" << imageSize << "for:" << filePath;
-
-    const QString &defaultMime = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath)).name();
-    if (imageSize.width() > size || imageSize.height() > size || defaultMime == DFMGLOBAL_NAMESPACE::Mime::kTypeImageSvgXml) {
-        qCDebug(logDFMBase) << "thumbnail: scaling image from" << imageSize << "to fit size:" << size;
-        reader.setScaledSize(reader.size().scaled(size, size, Qt::KeepAspectRatio));
-    }
-
     reader.setAutoTransform(true);
     QImage image;
-    if (!reader.read(&image)) {
-        qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
-                              << "error:" << reader.errorString();
-        return image;
+
+    if (imageSize.isValid()) {
+        // size 有效：优先让 QImageReader 在解码阶段按比例缩放，效率更高
+        qCDebug(logDFMBase) << "thumbnail: image file size:" << imageSize << "for:" << filePath;
+
+        const QString &defaultMime = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath)).name();
+        if (imageSize.width() > size || imageSize.height() > size || defaultMime == DFMGLOBAL_NAMESPACE::Mime::kTypeImageSvgXml) {
+            qCDebug(logDFMBase) << "thumbnail: scaling image from" << imageSize << "to fit size:" << size;
+            reader.setScaledSize(imageSize.scaled(size, size, Qt::KeepAspectRatio));
+        }
+
+        if (!reader.read(&image)) {
+            qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
+                                  << "error:" << reader.errorString();
+            return image;
+        }
+    } else {
+        // 注意：icns 等格式的 QImageReader::size() 会返回 (-1,-1) 无效值，但文件本身是正常的、
+        // 可被 read() 解码。这里不再仅凭 size 无效就直接判定文件损坏，而是直接尝试 read()：
+        //  - 若 read() 失败，则认为文件确实损坏（保留对损坏文件的处理，不再读取其图像数据，
+        //    避免 arm 平台上损坏 icns 文件可能导致的递归循环问题）；
+        //  - 若 read() 成功，则对解码结果按需缩放，修复 icns 缩略图不显示的问题。
+        qCDebug(logDFMBase) << "thumbnail: image file reports invalid size, attempting direct read for:" << filePath;
+        if (!reader.read(&image)) {
+            qCWarning(logDFMBase) << "thumbnail: image file has invalid size and cannot be decoded:" << filePath
+                                  << "error:" << reader.errorString();
+            return image;
+        }
+
+        if (image.width() > size || image.height() > size) {
+            qCDebug(logDFMBase) << "thumbnail: scaling decoded image from" << image.size() << "to fit size:" << size;
+            image = image.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        }
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
@@ -415,7 +415,13 @@ void EraseJob::work()
     if (!mediaChangDected()) {
         ret = false;
         fmWarning() << "Device disconnected:" << curDevId;
-        emit requestFailureDialog(static_cast<int>(curJobType), QObject::tr("Device disconnected"), {});
+    }
+
+    if (!ret) {
+        failureDialogShown = true;
+        emit requestFailureDialog(static_cast<int>(curJobType),
+                                 lastError.isEmpty() ? QObject::tr("Device disconnected") : lastError,
+                                 lastSrcMessages);
     }
 
     comfort();

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.h
@@ -63,6 +63,8 @@ public:
     void setProperty(PropertyType type, const QVariant &val);
     void addTask();
 
+    bool failureDialogShown {};
+
 protected:
     virtual bool fileSystemLimitsValid();
     virtual void updateMessage(JobInfoPointer ptr);

--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -44,7 +44,7 @@ void BurnJobManager::startEraseDisc(const QString &dev)
     initBurnJobConnect(job);
     connect(qobject_cast<EraseJob *>(job), &EraseJob::eraseFinished, this, [job, this](bool result) {
         startAuditLogForEraseDisc(job->currentDeviceInfo(), result);
-        if (!result) {
+        if (!result && !job->failureDialogShown) {
             DialogManagerInstance->showErrorDialog(tr("Erase failed"),
                                                    tr("Unable to complete disc erasure. "
                                                       "This may be due to read/write limitations or the disc media status. "
@@ -263,7 +263,10 @@ void BurnJobManager::showOpticalJobFailureDialog(int type, const QString &err, c
     QWidget *detailsw = new QWidget(&d);
     detailsw->setLayout(new QVBoxLayout());
     QTextEdit *te = new QTextEdit();
-    te->setPlainText(details.join('\n'));
+    QStringList detailContent = details;
+    if (detailContent.isEmpty() && !err.isEmpty())
+        detailContent << err;
+    te->setPlainText(detailContent.join('\n'));
     te->setReadOnly(true);
     te->hide();
     detailsw->layout()->addWidget(te);

--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -395,8 +395,12 @@ QString ComputerInfoThread::cpuInfo() const
 
 QString ComputerInfoThread::memoryInfo() const
 {
+    qint64 installedMemory = UniversalUtils::computerMemory();
+    if (installedMemory <= 0)
+        installedMemory = DSysInfo::memoryInstalledSize();
+
     return QString("%1 (%2 %3)")
-            .arg(formatCap(DSysInfo::memoryInstalledSize(), 1024, 0))
+            .arg(formatCap(installedMemory, 1024, 0))
             .arg(formatCap(DSysInfo::memoryTotalSize()))
             .arg(tr("Available"));
 }

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -31,8 +31,17 @@ dfmplugin_search::SearchEventReceiver *dfmplugin_search::SearchEventReceiver::in
 
 void SearchEventReceiver::handleSearch(quint64 winId, const QString &keyword)
 {
-    auto window = FMWindowsIns.findWindowById(winId);
-    Q_ASSERT(window);
+    if (winId < 1) {
+        fmWarning() << "Ignore search request with invalid window id";
+        return;
+    }
+
+    auto *window = FMWindowsIns.findWindowById(winId);
+    if (!window) {
+        // Fix: shutdown can outlive a delayed search callback from the titlebar.
+        fmWarning() << "Ignore search request because window no longer exists:" << winId;
+        return;
+    }
 
     const auto &curUrl = window->currentUrl();
     if (ProtocolUtils::isRemoteFile(curUrl)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -49,6 +49,9 @@ class SideBarViewPrivate : public QObject
     bool checkTargetEnable(const QUrl &targetUrl);
     bool canEnter(QDragEnterEvent *event);
     bool canMove(QDragMoveEvent *event);
+    void updateHoverIndex(const QModelIndex &index);
+    void clearHoverIndex();
+    bool isCursorInsideIndex(const QModelIndex &index, const QPoint &fallbackPos) const;
 
 private Q_SLOTS:
     void currentChanged(const QModelIndex &curIndex);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -21,6 +21,7 @@
 
 #include <QtConcurrent>
 #include <QDebug>
+#include <QCursor>
 #include <QMimeData>
 #include <QApplication>
 #include <QMouseEvent>
@@ -87,6 +88,48 @@ void SideBarViewPrivate::setTransparentPalette()
 void SideBarViewPrivate::restorePalette()
 {
     q->setPalette(originPalette);
+}
+
+void SideBarViewPrivate::updateHoverIndex(const QModelIndex &index)
+{
+    if (currentHoverIndex == index)
+        return;
+
+    const QModelIndex previousHoverIndex = currentHoverIndex;
+    currentHoverIndex = index;
+
+    if (previousHoverIndex.isValid())
+        q->update(previousHoverIndex);
+    if (currentHoverIndex.isValid())
+        q->update(currentHoverIndex);
+}
+
+void SideBarViewPrivate::clearHoverIndex()
+{
+    updateHoverIndex(QModelIndex());
+}
+
+bool SideBarViewPrivate::isCursorInsideIndex(const QModelIndex &index, const QPoint &fallbackPos) const
+{
+    if (!index.isValid())
+        return false;
+
+    const QRect itemRect = q->visualRect(index);
+    const QPoint globalPos = QCursor::pos();
+    if (QWidget *windowWidget = q->window()) {
+        const QPoint windowPos = windowWidget->mapFromGlobal(globalPos);
+        if (QWidget *targetWidget = windowWidget->childAt(windowPos)) {
+            if (!(targetWidget == q || q->isAncestorOf(targetWidget)))
+                return false;
+
+            const QPoint cursorPos = q->viewport()->mapFromGlobal(globalPos);
+            return itemRect.contains(cursorPos);
+        }
+    }
+
+    // Fallback for compositor paths where childAt/global lookup is unavailable
+    // but the sidebar viewport still owns the active pointer hover state.
+    return q->viewport()->underMouse() && itemRect.contains(fallbackPos);
 }
 
 void SideBarViewPrivate::notifyOrderChanged()
@@ -324,7 +367,7 @@ void SideBarView::mouseReleaseEvent(QMouseEvent *event)
 
 void SideBarView::dragEnterEvent(QDragEnterEvent *event)
 {
-    d->currentHoverIndex = QModelIndex();
+    d->clearHoverIndex();
     d->updateDFMMimeData(event);
     if (event->source() != this) {
         d->urlsForDragEvent = d->dfmMimeData.isValid() ? d->dfmMimeData.urls() : event->mimeData()->urls();
@@ -366,12 +409,20 @@ void SideBarView::dragEnterEvent(QDragEnterEvent *event)
 
 void SideBarView::dragMoveEvent(QDragMoveEvent *event)
 {
-    if (event->source() != this)
-        d->currentHoverIndex = indexAt(event->position().toPoint());
+    const QPoint eventPos = event->position().toPoint();
+    const QModelIndex hoverIndex = indexAt(eventPos);
 
-    SideBarItem *item = itemAt(event->position().toPoint());
+    if (event->source() != this)
+        d->updateHoverIndex(hoverIndex);
+
+    if (event->source() != this && !d->isCursorInsideIndex(hoverIndex, eventPos)) {
+        d->clearHoverIndex();
+        event->ignore();
+        return;
+    }
+
+    SideBarItem *item = itemAt(eventPos);
     if (item) {
-        viewport()->update();
         if (!d->canMove(event)) {
             event->setDropAction(Qt::IgnoreAction);
             event->ignore();
@@ -394,23 +445,21 @@ void SideBarView::dragLeaveEvent(QDragLeaveEvent *event)
     d->draggedUrl = QUrl("");
     d->isItemDragged = false;
     setState(State::NoState);
-
-    if (d->currentHoverIndex.isValid()) {
-        update(d->currentHoverIndex);
-        d->currentHoverIndex = QModelIndex();
-    }
+    d->clearHoverIndex();
 }
 
 void SideBarView::dropEvent(QDropEvent *event)
 {
-    d->currentHoverIndex = QModelIndex();
+    const QPoint eventPos = event->position().toPoint();
+    const QModelIndex hoverIndex = indexAt(eventPos);
+    d->clearHoverIndex();
     d->isItemDragged = false;
     if (d->draggedUrl.isValid()) {   // select the dragged item when dropped.
         d->notifyOrderChanged();   // notify to update the persistence data
     }
 
-    d->dropPos = event->position().toPoint();
-    SideBarItem *item = itemAt(event->position().toPoint());
+    d->dropPos = eventPos;
+    SideBarItem *item = itemAt(eventPos);
     if (!item)
         return DTreeView::dropEvent(event);
 
@@ -420,12 +469,7 @@ void SideBarView::dropEvent(QDropEvent *event)
     fmDebug() << "target item: " << item->group() << "|" << item->text() << "|" << item->url();
     fmDebug() << "item->itemInfo().finalUrl: " << item->itemInfo().finalUrl;
     fmDebug() << "item flags:" << item->flags();
-    // wayland环境下QCursor::pos()在此场景中不能获取正确的光标当前位置，代替方案为直接使用QDropEvent::pos()
-    // QDropEvent::pos() 实际上就是drop发生时光标在该widget坐标系中的position (mapFromGlobal(QCursor::pos()))
-    // 但rc本来就是由event->pos()计算item得出的Rect，这样判断似乎就没有意义了（虽然原来的逻辑感觉也没什么意义）
-    QPoint pt = event->position().toPoint();   // mapFromGlobal(QCursor::pos());
-    QRect rc = visualRect(indexAt(event->position().toPoint()));
-    if (!rc.contains(pt)) {
+    if (!d->isCursorInsideIndex(hoverIndex, eventPos)) {
         fmDebug() << "mouse not in my area";
         return DTreeView::dropEvent(event);
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
@@ -78,7 +78,10 @@ void TitleBarEventCaller::sendOpenTab(quint64 windowId, const QUrl &url)
 void TitleBarEventCaller::sendSearch(QWidget *sender, const QString &keyword)
 {
     quint64 id = TitleBarHelper::windowId(sender);
-    Q_ASSERT(id > 0);
+    if (id < 1) {
+        fmWarning() << "Cannot send search start signal: invalid window id";
+        return;
+    }
 
     fmInfo() << "Sending search start signal, window id:" << id << "keyword:" << keyword;
     dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Search_Start", id, keyword);

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -257,10 +257,20 @@ void TitleBarHelper::handleJumpToPressed(QWidget *sender, const QString &text)
 void TitleBarHelper::handleSearch(QWidget *sender, const QString &text)
 {
     const auto &currentDir = QDir::currentPath();
+    const auto winId = windowId(sender);
+    if (winId < 1) {
+        fmWarning() << "Cannot start search: invalid window id";
+        return;
+    }
+
     QUrl currentUrl;
-    auto curTitleBar = findTileBarByWindowId(windowId(sender));
-    if (curTitleBar)
-        currentUrl = curTitleBar->currentUrl();
+    auto curTitleBar = findTileBarByWindowId(winId);
+    if (!curTitleBar) {
+        // Fix: the titlebar can already be gone while a delayed search callback is still pending.
+        fmWarning() << "Cannot start search: titlebar already removed for window id" << winId;
+        return;
+    }
+    currentUrl = curTitleBar->currentUrl();
 
     if (currentUrl.isValid()) {
         bool isDisableSearch = dpfSlotChannel->push("dfmplugin_search", "slot_Custom_IsDisableSearch", currentUrl).toBool();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -24,6 +24,9 @@
 
 #include <QHBoxLayout>
 #include <QCoreApplication>
+#include <QGuiApplication>
+#include <QInputMethod>
+#include <QMetaObject>
 #include <QResizeEvent>
 #include <QKeyEvent>
 
@@ -380,6 +383,11 @@ void SearchEditWidget::handleFocusInEvent(QFocusEvent *e)
 {
     advancedButton->setVisible(true);
     updateSpacing(true);   // Advanced button is now visible
+
+    QMetaObject::invokeMethod(this, [this] {
+        if (searchEdit->lineEdit()->hasFocus())
+            QGuiApplication::inputMethod()->show();
+    }, Qt::QueuedConnection);
 }
 
 void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -23,6 +23,7 @@
 #include <DPalette>
 
 #include <QHBoxLayout>
+#include <QCoreApplication>
 #include <QResizeEvent>
 #include <QKeyEvent>
 
@@ -41,6 +42,13 @@ SearchEditWidget::SearchEditWidget(QWidget *parent)
 {
     initUI();
     initConnect();
+    if (qApp) {
+        connect(qApp, &QCoreApplication::aboutToQuit, this, [this]() {
+            // Fix: stop delayed search before shutdown tears down the owning window.
+            delayTimer->stop();
+            pendingSearchText.clear();
+        });
+    }
     searchEdit->lineEdit()->installEventFilter(this);
     searchEdit->installEventFilter(this);
     advancedButton->installEventFilter(this);
@@ -249,6 +257,13 @@ void SearchEditWidget::performSearch()
     QString trimmedSearchText = pendingSearchText.trimmed();
     if (trimmedSearchText.isEmpty()) {
         fmDebug() << "Trimmed search text is empty, skipping search";
+        return;
+    }
+
+    if (TitleBarHelper::windowId(this) < 1) {
+        // Fix: ignore delayed search callbacks once the owner window is already invalid.
+        fmInfo() << "Skip delayed search because owner window is no longer valid";
+        pendingSearchText.clear();
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -33,6 +33,7 @@
 #include <QIcon>
 #include <QUuid>
 #include <QUrlQuery>
+#include <QScreen>
 #include <QToolTip>
 
 #include <unistd.h>
@@ -103,6 +104,7 @@ public:
     void closeRightTabs(int index);
     void closeOtherTabs(int index);
     bool hasDragPreviewTab() const;
+    void showWindow() const;
 
 public:
     TabBar *q;
@@ -252,7 +254,7 @@ void TabBarPrivate::handleTabReleased(int index)
     }
 
     if (q->count() == 1) {
-        q->window()->show();
+        showWindow();
     } else {
         currentTabIndex = -1;
 
@@ -796,6 +798,31 @@ bool TabBarPrivate::hasDragPreviewTab() const
     return false;
 }
 
+void TabBarPrivate::showWindow() const
+{
+    // Position window near cursor for good visual interaction when tearing off the last tab
+    if (!(q->window()->windowState() & Qt::WindowMaximized)) {
+        QScreen *screen = WindowUtils::cursorScreen();
+        if (screen) {
+            const QRect availGeo = screen->availableGeometry();
+            const QPoint cursorPos = QCursor::pos();
+            const int winW = q->window()->width();
+            const int winH = q->window()->height();
+
+            // Place cursor near the top-center of the window (tab bar area)
+            int x = cursorPos.x() - winW / 2;
+            int y = cursorPos.y() - 20;   // slightly above cursor to align with tab bar
+
+            // Clamp to keep the window fully visible on screen
+            x = qMax(availGeo.left(), qMin(x, availGeo.right() - winW));
+            y = qMax(availGeo.top(), qMin(y, availGeo.bottom() - winH));
+
+            q->window()->move(x, y);
+        }
+    }
+    q->window()->show();
+}
+
 bool TabBarPrivate::canPinned(int index)
 {
     if (qAppName() != "dde-file-manager")
@@ -1235,7 +1262,7 @@ QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option
     painter.setRenderHint(QPainter::Antialiasing, true);
 
     // Hide window during drag: single tab in non-Wayland environment
-    if (!WindowUtils::isWayLand() && 1 == count()) {
+    if (!WindowUtils::isWayLand() && 1 == count() && !isPinned(index)) {
         this->window()->hide();
         fmDebug() << "Hide window during drag: single tab in non-Wayland environment";
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -34,8 +34,13 @@
 #endif
 
 #include <QHBoxLayout>
+#include <QApplication>
 #include <QEvent>
+#include <QGuiApplication>
+#include <QInputMethod>
+#include <QMetaObject>
 #include <QResizeEvent>
+#include <QTimer>
 
 using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
@@ -488,6 +493,7 @@ void TitleBarWidget::showAddrsssBar(const QUrl &url)
     crumbBar->hide();
     addressBar->show();
     addressBar->setFocus();
+    QGuiApplication::inputMethod()->show();
     addressBar->setCurrentUrl(url);
 }
 
@@ -500,7 +506,13 @@ void TitleBarWidget::showCrumbBar()
         addressBar->clear();
         addressBar->hide();
     }
-    setFocus();
+    QMetaObject::invokeMethod(this, [this] {
+        QWidget *focusWidget = QApplication::focusWidget();
+        if (!focusWidget || focusWidget == addressBar
+            || addressBar->isAncestorOf(focusWidget)) {
+            setFocus();
+        }
+    }, Qt::QueuedConnection);
 }
 
 void TitleBarWidget::showSearchFilterButton(bool visible)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
@@ -35,9 +35,19 @@ void SelectHelper::click(const QModelIndex &index)
 
 void SelectHelper::release()
 {
-    fmDebug() << "SelectHelper release event - clearing current selection and pressed index";
+    fmDebug() << "SelectHelper release event - clearing drag selection state";
     currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
     currentPressedIndex = QModelIndex();
+}
+
+void SelectHelper::prepareForModelTeardown()
+{
+    fmDebug() << "SelectHelper preparing for model teardown - clearing model-bound selection state";
+    lastPressedIndex = QModelIndex();
+    currentPressedIndex = QModelIndex();
+    currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
 }
 
 void SelectHelper::setSelection(const QItemSelection &selection)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
@@ -26,6 +26,7 @@ public:
     QModelIndex getCurrentPressedIndex() const;
     void click(const QModelIndex &index);
     void release();
+    void prepareForModelTeardown();
     void setSelection(const QItemSelection &selection);
     void selection(const QRect &rect, QItemSelectionModel::SelectionFlags flags);
     bool select(const QList<QUrl> &urls);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -144,6 +144,15 @@ FileView::~FileView()
     }
     setCurrentIndex(QModelIndex());
 
+    // SelectHelper caches QItemSelection, which owns QPersistentModelIndex in Qt6.
+    // Destroy it before detaching/deleting the model to avoid helper teardown
+    // walking stale persistent indexes after the model has gone away.
+    if (d && d->selectHelper) {
+        d->selectHelper->prepareForModelTeardown();
+        delete d->selectHelper;
+        d->selectHelper = nullptr;
+    }
+
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -25,6 +25,8 @@
 #include <QDir>
 #include <QFile>
 #include <QProcess>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include <polkit-qt6-1/PolkitQt1/Authority>
 
@@ -33,6 +35,7 @@
 static constexpr char kActionEncrypt[] { "org.deepin.Filemanager.DiskEncrypt.Encrypt" };
 static constexpr char kActionDecrypt[] { "org.deepin.Filemanager.DiskEncrypt.Decrypt" };
 static constexpr char kActionChgPwd[] { "org.deepin.Filemanager.DiskEncrypt.ChangePassphrase" };
+static constexpr char kActionChgPIN[] { "org.deepin.Filemanager.DiskEncrypt.ChangePIN" };
 
 FILE_ENCRYPT_USE_NS
 
@@ -161,15 +164,35 @@ bool DiskEncryptSetup::ChangePassphrase(const QDBusUnixFileDescriptor &credentia
 {
     qInfo() << "[DiskEncryptSetup::ChangePassphrase] Passphrase change request received via fd";
 
-    if (!m_dptr->checkAuth(kActionChgPwd)) {
-        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
-        return false;
-    }
-
-    // Parse credentials from fd using common method
+    // Parse credentials first to determine the encryption type for the correct polkit action
     QVariantMap args;
     if (!m_dptr->parseCredentialsFromFd(credentialsFd, &args)) {
         qCritical() << "[DiskEncryptSetup::ChangePassphrase] Failed to parse credentials from fd";
+        return false;
+    }
+
+    // Determine the security key type to select the appropriate polkit action.
+    // The server independently infers secType from the device's TPM token
+    // (via TpmToken, which includes holder-device fallback) rather than
+    // trusting client-supplied input for the authorization decision.
+    auto dev = args.value(disk_encrypt::encrypt_param_keys::kKeyDevice).toString();
+    QString token = TpmToken(dev);
+    QString usePin;
+    if (!token.isEmpty()) {
+        QJsonParseError parseError;
+        QJsonDocument doc = QJsonDocument::fromJson(token.toLocal8Bit(), &parseError);
+        if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+            qWarning() << "[DiskEncryptSetup::ChangePassphrase] Failed to parse TPM token JSON for device:" << dev << "Error:" << parseError.errorString();
+            return false;
+        }
+        QJsonObject obj = doc.object();
+        usePin = obj.value("pin").toString("");
+    }
+    auto secType = (usePin == "1") ? disk_encrypt::kPin : disk_encrypt::kPwd;
+    const QString &action = (secType == disk_encrypt::kPin) ? kActionChgPIN : kActionChgPwd;
+
+    if (!m_dptr->checkAuth(action)) {
+        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
         return false;
     }
 

--- a/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
+++ b/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
@@ -33,6 +33,19 @@
   </action>
   <action id="org.deepin.Filemanager.DiskEncrypt.ChangePassphrase">
     <description>Disk encryption</description>
+    <message>Authentication is required to change the passphrase of the partition</message>
+    <message xml:lang="zh_CN">修改加密口令需要认证</message>
+    <message xml:lang="zh_HK">修改加密口令需要認證</message>
+    <message xml:lang="zh_TW">修改加密口令需要認證</message>
+    <icon_name>folder</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+  <action id="org.deepin.Filemanager.DiskEncrypt.ChangePIN">
+    <description>Disk encryption</description>
     <message>Authentication is required to change the PIN code of the partition</message>
     <message xml:lang="zh_CN">修改分区PIN码需要认证</message>
     <message xml:lang="zh_HK">修改分區PIN碼需要認證</message>

--- a/src/services/textindex/dependencies.cmake
+++ b/src/services/textindex/dependencies.cmake
@@ -16,7 +16,7 @@ function(dfm_setup_textindex_dependencies target_name)
     # Find system dependencies using pkg-config
     pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
     pkg_check_modules(GLIB REQUIRED glib-2.0)
-    pkg_check_modules(NL REQUIRED IMPORTED_TARGET libnl-3.0 libnl-genl-3.0)
+    pkg_check_modules(mount REQUIRED mount IMPORTED_TARGET)
     
     # Apply default service configuration first (this provides DFM6::base, Qt6::Core, Qt6::DBus)
     dfm_apply_default_service_config(${target_name})
@@ -36,7 +36,7 @@ function(dfm_setup_textindex_dependencies target_name)
         dde-file-manager-extractor-lib
         ${GLIB_LIBRARIES}
         PkgConfig::Lucene
-        PkgConfig::NL
+        PkgConfig::mount
     )
     
     # Add textindex-specific include directories

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -114,7 +114,7 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
 
     // Try to create VfsMonitorFileSystemWatcher for global file system events.
     // Pass shouldExcludePath as the exclude predicate so filtering happens
-    // at the netlink callback level (before any signals are emitted).
+    // before any socket-delivered events are emitted.
     vfsWatcher.reset(VfsMonitorFileSystemWatcher::create(
         this->rootPaths,
         [this](const QString &path) { return shouldExcludePath(path); },
@@ -122,15 +122,15 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
     vfsMonitorAvailable = (vfsWatcher != nullptr);
 
     if (vfsMonitorAvailable) {
-        // vfs_monitor mode: create/delete/move from vfs, fileClosed from inotify.
+        // deepin-anything dispatcher mode: create/delete/move from vfs, fileClosed from inotify.
         // Restrict inotify to IN_CLOSE_WRITE only, reducing kernel event delivery.
         watcher->setWatchFlags(InotifyFileSystemWatcher::WatchFlag::FileClose);
         setupVfsMonitorConnections();
-        fmInfo() << "FSMonitor: Using dual watcher mode (vfs_monitor + inotify fallback)";
+        fmInfo() << "FSMonitor: Using dual watcher mode (deepin-anything dispatcher + inotify fallback)";
     } else {
         // inotify-only mode: all signals from InotifyFileSystemWatcher (existing behavior).
         setupWatcherConnections();
-        fmInfo() << "FSMonitor: Using inotify-only mode (vfs_monitor not available)";
+        fmInfo() << "FSMonitor: Using inotify-only mode (deepin-anything dispatcher not available)";
     }
 
     fmDebug() << "FSMonitor: Initialized with" << excludeMatcher.patternCount()

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -64,7 +64,7 @@ public:
     // Parse and connect watcher signals (inotify-only fallback mode)
     void setupWatcherConnections();
 
-    // Connect vfs_monitor watcher signals (create/delete/move from vfs, fileClosed from inotify)
+    // Connect deepin-anything watcher signals (create/delete/move from vfs, fileClosed from inotify)
     void setupVfsMonitorConnections();
 
     // Set up the worker thread and connections

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -4,33 +4,26 @@
 
 #include "vfsmonitorwatcher_p.h"
 
-#include <QFileInfo>
 #include <QDir>
-#include <QFile>
-#include <QTextStream>
-
-#include <netlink/genl/ctrl.h>
-#include <netlink/genl/genl.h>
-#include <netlink/netlink.h>
-#include <netlink/socket.h>
-#include <netlink/attr.h>
-#include <netlink/msg.h>
+#include <QFileInfo>
 
 #include <libmount.h>
-#include <sys/sysmacros.h>
 
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <algorithm>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
-// Netlink family and multicast group names (matching vfs_genl.h)
-static constexpr char kVfsMonitorFamilyName[] = "vfsmonitor";
-static constexpr char kVfsMonitorMcgDentry[] = "vfsmonitor_de";
-
-// --- Per-instance C callback for libnl ---
-
 namespace {
+
+constexpr char kDispatcherSocketPath[] = "/run/deepin-anything/event-dispatcher.sock";
+constexpr size_t kDispatchMaxPathLen = 4096;
 
 struct MountEntry
 {
@@ -38,31 +31,14 @@ struct MountEntry
     int parentMountId { 0 };
     QString mountPoint;
     bool isBindMount { false };
-    bool isLowerFs { false };
 };
 
-// Netlink attribute policy for parsing vfs_monitor messages.
-struct nla_policy vfsPolicy[VFSMONITOR_A_MAX + 1];
-
-void initVfsPolicy()
+struct DispatchEvent
 {
-    std::memset(vfsPolicy, 0, sizeof(vfsPolicy));
-    vfsPolicy[VFSMONITOR_A_ACT].type = NLA_U8;
-    vfsPolicy[VFSMONITOR_A_COOKIE].type = NLA_U32;
-    vfsPolicy[VFSMONITOR_A_MAJOR].type = NLA_U16;
-    vfsPolicy[VFSMONITOR_A_MINOR].type = NLA_U8;
-    vfsPolicy[VFSMONITOR_A_PATH].type = NLA_NUL_STRING;
-    vfsPolicy[VFSMONITOR_A_PATH].maxlen = 4096;
-}
-
-bool mountPointStartsWith(const QString &path, const QString &mountPoint)
-{
-    if (!path.startsWith(mountPoint))
-        return false;
-
-    return mountPoint.endsWith('/') || path.length() == mountPoint.length()
-            || path.at(mountPoint.length()) == '/';
-}
+    int32_t action;
+    uint32_t cookie;
+    char eventPath[kDispatchMaxPathLen];
+};
 
 bool isDescendantOfRoot(const QString &path, const QString &root)
 {
@@ -78,15 +54,18 @@ bool isDescendantOfRoot(const QString &path, const QString &root)
     return root.endsWith('/') || path.at(root.length()) == '/';
 }
 
+bool mountPointStartsWith(const QString &path, const QString &mountPoint)
+{
+    if (!path.startsWith(mountPoint))
+        return false;
+
+    return mountPoint.endsWith('/') || path.length() == mountPoint.length()
+            || path.at(mountPoint.length()) == '/';
+}
+
 bool cStringEquals(const char *left, const char *right)
 {
     return left && right && qstrcmp(left, right) == 0;
-}
-
-bool isLowerFsType(const char *fsType)
-{
-    return cStringEquals(fsType, "overlay") || cStringEquals(fsType, "fuse.dlnfs")
-            || cStringEquals(fsType, "ulnfs");
 }
 
 bool isParentChainUnderRoot(const QHash<int, MountEntry> &byMountId, const MountEntry &entry)
@@ -112,25 +91,21 @@ bool isParentChainUnderRoot(const QHash<int, MountEntry> &byMountId, const Mount
 QHash<int, MountEntry> collectMountEntries(libmnt_table *mtab)
 {
     QHash<int, MountEntry> byMountId;
-    struct libmnt_iter *iter = mnt_new_iter(MNT_ITER_FORWARD);
+    libmnt_iter *iter = mnt_new_iter(MNT_ITER_FORWARD);
     if (!iter)
         return byMountId;
 
-    struct libmnt_fs *fs;
+    libmnt_fs *fs = nullptr;
     while (mnt_table_next_fs(mtab, iter, &fs) == 0) {
         const char *target = mnt_fs_get_target(fs);
         if (!target)
             continue;
 
-        const char *root = mnt_fs_get_root(fs);
-        const char *fsType = mnt_fs_get_fstype(fs);
-
         MountEntry entry;
         entry.deviceId = mnt_fs_get_devno(fs);
         entry.parentMountId = mnt_fs_get_parent_id(fs);
         entry.mountPoint = QString::fromUtf8(target);
-        entry.isBindMount = !cStringEquals(root, "/");
-        entry.isLowerFs = isLowerFsType(fsType);
+        entry.isBindMount = !cStringEquals(mnt_fs_get_root(fs), "/");
 
         byMountId.insert(mnt_fs_get_id(fs), entry);
     }
@@ -139,163 +114,33 @@ QHash<int, MountEntry> collectMountEntries(libmnt_table *mtab)
     return byMountId;
 }
 
-// Per-instance callback: arg is the VfsMonitorFileSystemWatcherPrivate pointer,
-// registered per-socket via nl_socket_modify_cb. No global state needed.
-int vfsMonitorMsgCallback(struct nl_msg *msg, void *arg)
+QString filterDirectPath(const QStringList &rootPaths,
+                         const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
+                         const QString &fullPath)
 {
-    auto *d = static_cast<VfsMonitorFileSystemWatcherPrivate *>(arg);
-
-    if (!d) {
-        return NL_SKIP;
+    if (std::none_of(rootPaths.cbegin(), rootPaths.cend(),
+                     [&fullPath](const QString &root) { return isDescendantOfRoot(fullPath, root); })) {
+        return {};
     }
 
-    struct nlattr *tb[VFSMONITOR_A_MAX + 1];
-    std::memset(tb, 0, sizeof(tb));
+    if (excludePredicate && excludePredicate(fullPath))
+        return {};
 
-    struct nlmsghdr *nh = nlmsg_hdr(msg);
-    int err = genlmsg_parse(nh, 0, tb, VFSMONITOR_A_MAX, vfsPolicy);
-    if (err < 0) {
-        return NL_SKIP;
-    }
-
-    if (!tb[VFSMONITOR_A_PATH]) {
-        return NL_SKIP;
-    }
-
-    // Extract attributes.
-    uint8_t act = tb[VFSMONITOR_A_ACT] ? nla_get_u8(tb[VFSMONITOR_A_ACT]) : 0;
-    uint32_t cookie = tb[VFSMONITOR_A_COOKIE] ? nla_get_u32(tb[VFSMONITOR_A_COOKIE]) : 0;
-    uint16_t major = tb[VFSMONITOR_A_MAJOR] ? nla_get_u16(tb[VFSMONITOR_A_MAJOR]) : 0;
-    uint8_t minor = tb[VFSMONITOR_A_MINOR] ? nla_get_u8(tb[VFSMONITOR_A_MINOR]) : 0;
-    const char *pathCStr = reinterpret_cast<const char *>(nla_data(tb[VFSMONITOR_A_PATH]));
-
-    // Skip non-filesystem events.
-    if (act > ACT_UNMOUNT) {
-        return NL_OK;
-    }
-
-    // Mount/unmount events don't carry meaningful path data for indexing,
-    // but they invalidate our mount point cache. Flag the dirty bit so
-    // handleNetlinkMessage() can refresh the cache after this batch.
-    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
-        d->mountPointsDirty = true;
-        return NL_OK;
-    }
-
-    dev_t deviceId = makedev(major, minor);
-
-    // RENAME_FROM events must be stored before filtering, because the paired
-    // RENAME_TO may land in an excluded path (e.g., trash). We need the
-    // RENAME_FROM info to emit a delete when that happens.
-    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
-        QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-        if (fullPath.isNull())
-            return NL_OK;   // Source itself is excluded, no point tracking.
-
-        auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-
-        RenameFromInfo info;
-        info.path = parentPath;
-        info.name = name;
-        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
-        d->pendingRenames.insert(cookie, info);
-        return NL_OK;
-    }
-
-    // RENAME_TO events need independent path resolution because the target may
-    // be filtered (e.g., moved to trash). In that case we emit a delete for the
-    // source instead of a move — the generic fullPath.isNull() gate below would
-    // swallow this event before we could check pendingRenames.
-    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
-        auto *q = d->q_ptr;
-        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
-
-        auto it = d->pendingRenames.find(cookie);
-        if (it != d->pendingRenames.end()) {
-            QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
-                else
-                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
-            } else {
-                // Target is filtered (e.g., moved to trash) → source is gone.
-                if (isDir)
-                    Q_EMIT q->directoryDeleted(it->path, it->name);
-                else
-                    Q_EMIT q->fileDeleted(it->path, it->name);
-            }
-            d->pendingRenames.erase(it);
-        } else {
-            // Unpaired RENAME_TO: treat as creation if in monitored area.
-            QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryCreated(parentPath, name);
-                else
-                    Q_EMIT q->fileCreated(parentPath, name);
-            }
-        }
-        return NL_OK;
-    }
-
-    // For all other events, reconstruct and filter the full path.
-    QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-    if (fullPath.isNull()) {
-        return NL_OK;
-    }
-
-    auto *q = d->q_ptr;
-    auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-
-    switch (act) {
-    case ACT_NEW_FILE:
-    case ACT_NEW_LINK:
-    case ACT_NEW_SYMLINK:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-
-    case ACT_NEW_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-
-    case ACT_DEL_FILE:
-        Q_EMIT q->fileDeleted(parentPath, name);
-        break;
-
-    case ACT_DEL_FOLDER:
-        Q_EMIT q->directoryDeleted(parentPath, name);
-        break;
-
-        // Synthetic events (kernel-paired rename).
-    case ACT_RENAME_FILE:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-
-    case ACT_RENAME_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-
-    default:
-        break;
-    }
-
-    return NL_OK;
+    return fullPath;
 }
 
-static bool registerMessageCallback(nl_sock *sock, VfsMonitorFileSystemWatcherPrivate *d)
+QString filterEventPath(const QStringList &rootPaths,
+                        const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
+                        const char *eventPath)
 {
-    // Pass d directly as per-socket callback data. Each nl_sock gets its own
-    // callback arg, so multiple instances are naturally supported.
-    int ret = nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM,
-                                  vfsMonitorMsgCallback, d);
-    if (ret != 0) {
-        return false;
-    }
+    if (!eventPath || eventPath[0] == '\0')
+        return {};
 
-    return true;
+    const QString fullPath = QDir::cleanPath(QString::fromUtf8(eventPath));
+    if (!fullPath.startsWith('/'))
+        return {};
+
+    return filterDirectPath(rootPaths, excludePredicate, fullPath);
 }
 
 }   // anonymous namespace
@@ -306,8 +151,13 @@ VfsMonitorFileSystemWatcherPrivate::VfsMonitorFileSystemWatcherPrivate(
         const QStringList &rootPaths,
         VfsMonitorFileSystemWatcher::PathExcludePredicate excludePredicate,
         VfsMonitorFileSystemWatcher *qq)
-    : q_ptr(qq), rootPaths(rootPaths), excludePredicate(std::move(excludePredicate))
+    : q_ptr(qq), excludePredicate(std::move(excludePredicate))
 {
+    this->rootPaths.reserve(rootPaths.size());
+    for (const QString &path : rootPaths) {
+        this->rootPaths.append(QDir(path).absolutePath());
+    }
+    this->rootPaths.removeDuplicates();
 }
 
 VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
@@ -316,26 +166,19 @@ VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
         notifier->setEnabled(false);
     }
 
-    // No global callback state to clear — the per-socket callback data (this
-    // pointer) becomes invalid when nlSock is freed below, and the callback
-    // checks for null before dereferencing.
-
-    if (nlSock) {
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
+    if (socketFd >= 0) {
+        ::close(socketFd);
+        socketFd = -1;
     }
 }
 
 bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
 {
     mountPoints.clear();
-    childMountPoints.clear();
-    lowerFsExists = false;
 
-    struct libmnt_table *mtab = mnt_new_table();
-    if (!mtab) {
+    libmnt_table *mtab = mnt_new_table();
+    if (!mtab)
         return false;
-    }
 
     if (mnt_table_parse_mtab(mtab, nullptr) < 0) {
         mnt_free_table(mtab);
@@ -345,115 +188,59 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
     const QHash<int, MountEntry> byMountId = collectMountEntries(mtab);
     mnt_free_table(mtab);
 
-    QHash<int, MountEntry> rootMountTree;
     for (auto it = byMountId.cbegin(); it != byMountId.cend(); ++it) {
-        const auto &entry = it.value();
-
+        const MountEntry &entry = it.value();
         if (!isParentChainUnderRoot(byMountId, entry))
             continue;
 
         mountPoints[entry.deviceId].append(entry.mountPoint);
-        rootMountTree.insert(it.key(), entry);
-        lowerFsExists = lowerFsExists || entry.isLowerFs;
     }
 
     for (auto &points : mountPoints) {
-        std::sort(points.begin(), points.end(),
-                  [](const QString &a, const QString &b) {
-                      return a.length() > b.length();
-                  });
-    }
-
-    for (auto it = rootMountTree.cbegin(); it != rootMountTree.cend(); ++it) {
-        const auto &parent = it.value();
-        QStringList children;
-        for (const auto &entry : std::as_const(rootMountTree)) {
-            if (entry.parentMountId == it.key()) {
-                children.append(entry.mountPoint);
-            }
-        }
-
-        if (!children.isEmpty())
-            childMountPoints[parent.deviceId].append(children);
-    }
-
-    for (auto &points : childMountPoints) {
         points.removeDuplicates();
         std::sort(points.begin(), points.end(),
-                  [](const QString &a, const QString &b) {
-                      return a.length() > b.length();
+                  [](const QString &left, const QString &right) {
+                      return left.length() > right.length();
                   });
     }
 
-    int totalPoints = 0;
-    for (const auto &pts : std::as_const(mountPoints)) {
-        totalPoints += pts.size();
-    }
-    fmInfo() << "VfsMonitor: loaded" << mountPoints.size()
-             << "devices," << totalPoints << "mount points,"
-             << childMountPoints.size() << "devices with child mount points,"
-             << "lowerfs exists:" << lowerFsExists;
     return !mountPoints.isEmpty();
 }
 
-bool VfsMonitorFileSystemWatcherPrivate::isLowerFsEvent(dev_t deviceId, const QString &fullPath) const
+QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char *absolutePath) const
 {
-    if (!lowerFsExists)
-        return false;
+    const QString directPath = filterEventPath(rootPaths, excludePredicate, absolutePath);
+    if (!directPath.isNull())
+        return directPath;
 
-    auto it = childMountPoints.find(deviceId);
-    if (it == childMountPoints.end())
-        return false;
-
-    for (const QString &childMountPoint : it.value()) {
-        if (mountPointStartsWith(fullPath, childMountPoint)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(dev_t deviceId,
-                                                                     const char *relativePath) const
-{
-    auto it = mountPoints.find(deviceId);
-    if (it == mountPoints.end())
+    if (!absolutePath || absolutePath[0] == '\0')
         return {};
 
-    const QStringList &points = it.value();
-    const QString relPath = QString::fromUtf8(relativePath);
+    const QString fullPath = QDir::cleanPath(QString::fromUtf8(absolutePath));
+    if (!fullPath.startsWith('/'))
+        return {};
 
-    // Try each mount point (sorted longest first).
-    // Return the first one that falls under a monitored root path
-    // and passes the exclude predicate.
-    for (const QString &mp : points) {
-        QString fullPath = (mp == "/") ? relPath : (mp + relPath);
+    for (auto deviceIt = mountPoints.cbegin(); deviceIt != mountPoints.cend(); ++deviceIt) {
+        const QStringList &points = deviceIt.value();
+        for (const QString &sourceMountPoint : points) {
+            if (!mountPointStartsWith(fullPath, sourceMountPoint))
+                continue;
 
-        if (isLowerFsEvent(deviceId, fullPath))
-            continue;
+            const QString suffix = (sourceMountPoint == "/")
+                    ? fullPath
+                    : fullPath.mid(sourceMountPoint.length());
 
-        if (std::none_of(rootPaths.cbegin(), rootPaths.cend(),
-                         [&fullPath](const QString &root) { return isDescendantOfRoot(fullPath, root); }))
-            continue;
+            for (const QString &candidateMountPoint : points) {
+                const QString candidateFullPath = (candidateMountPoint == "/")
+                        ? suffix
+                        : candidateMountPoint + suffix;
+                const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
+                if (!filteredCandidate.isNull())
+                    return filteredCandidate;
+            }
 
-        if (excludePredicate && excludePredicate(fullPath))
-            continue;
-
-        return fullPath;
-    }
-
-    // In overlay root environments, the root "/" filesystem has no separate mount
-    // entry in mountPoints. When all mount points fail and relPath is already
-    // an absolute path, treat it as the true absolute path and re-check.
-    if (relPath.startsWith('/')) {
-        auto found = std::find_if(rootPaths.cbegin(), rootPaths.cend(),
-                                  [&relPath, this](const QString &root) {
-                                      return isDescendantOfRoot(relPath, root)
-                                              && (!excludePredicate || !excludePredicate(relPath));
-                                  });
-        if (found != rootPaths.cend())
-            return relPath;
+            break;
+        }
     }
 
     return {};
@@ -465,95 +252,168 @@ QPair<QString, QString> VfsMonitorFileSystemWatcherPrivate::splitPath(const QStr
     return qMakePair(fi.absolutePath(), fi.fileName());
 }
 
-bool VfsMonitorFileSystemWatcherPrivate::initNetlink()
+bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
 {
     Q_Q(VfsMonitorFileSystemWatcher);
 
-    // Build mount point cache first (no netlink dependency).
     if (!initMountPoints()) {
-        fmWarning() << "VfsMonitor: failed to initialize mount points";
+        fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
     }
 
-    nlSock = nl_socket_alloc();
-    if (!nlSock) {
-        fmWarning() << "VfsMonitor: failed to allocate netlink socket";
+    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (socketFd < 0) {
+        fmWarning() << "VfsMonitor: failed to create dispatcher socket:" << std::strerror(errno);
         return false;
     }
 
-    if (genl_connect(nlSock) != 0) {
-        fmWarning() << "VfsMonitor: genl_connect failed";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
+    sockaddr_un address {};
+    address.sun_family = AF_UNIX;
+    std::strncpy(address.sun_path, kDispatcherSocketPath, sizeof(address.sun_path) - 1);
+
+    if (::connect(socketFd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0) {
+        fmWarning() << "VfsMonitor: deepin-anything event dispatcher not available:" << std::strerror(errno);
+        ::close(socketFd);
+        socketFd = -1;
         return false;
     }
 
-    // Set receive buffer to system maximum to prevent event loss.
-    QFile rmemFile("/proc/sys/net/core/rmem_max");
-    if (rmemFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        QTextStream in(&rmemFile);
-        bool ok = false;
-        int maxRcvbuf = in.readLine().trimmed().toInt(&ok);
-        if (ok && maxRcvbuf > 0) {
-            if (nl_socket_set_buffer_size(nlSock, maxRcvbuf, 0) != 0) {
-                fmWarning() << "VfsMonitor: failed to set socket buffer size";
-            }
-        }
-        rmemFile.close();
-    }
-
-    nl_socket_disable_seq_check(nlSock);
-    nl_socket_disable_auto_ack(nlSock);
-
-    int mcgrpId = genl_ctrl_resolve_grp(nlSock, kVfsMonitorFamilyName, kVfsMonitorMcgDentry);
-    if (mcgrpId < 0) {
-        fmWarning() << "VfsMonitor: vfs_monitor kernel module not available";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    if (nl_socket_add_membership(nlSock, mcgrpId) != 0) {
-        fmWarning() << "VfsMonitor: failed to join multicast group";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    initVfsPolicy();
-
-    if (!registerMessageCallback(nlSock, this)) {
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    int fd = nl_socket_get_fd(nlSock);
-    notifier = new QSocketNotifier(fd, QSocketNotifier::Read, q);
+    notifier = new QSocketNotifier(socketFd, QSocketNotifier::Read, q);
     QObject::connect(notifier, &QSocketNotifier::activated, q, [this]() {
-        handleNetlinkMessage();
+        handleSocketMessage();
     });
 
-    fmInfo() << "VfsMonitor: connected to vfs_monitor kernel module";
+    fmInfo() << "VfsMonitor: connected to deepin-anything event dispatcher";
     return true;
 }
 
-void VfsMonitorFileSystemWatcherPrivate::handleNetlinkMessage()
+void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
 {
-    int ret = nl_recvmsgs_default(nlSock);
-    if (ret < 0 && ret != -NLE_AGAIN) {
-        fmWarning() << "VfsMonitor: nl_recvmsgs_default failed, error:" << ret;
+    if (socketFd < 0) {
+        return;
     }
 
-    // Refresh mount point cache if mount/unmount events were received.
-    // Done after nl_recvmsgs_default() so the cache is up-to-date for the
-    // next batch of file events.
-    if (mountPointsDirty) {
-        mountPointsDirty = false;
-        if (initMountPoints()) {
-            fmInfo() << "VfsMonitor: mount point cache refreshed";
-        } else {
-            fmWarning() << "VfsMonitor: failed to refresh mount point cache";
+    DispatchEvent event {};
+    ssize_t received = -1;
+    do {
+        received = ::recv(socketFd, &event, sizeof(event), 0);
+    } while (received < 0 && errno == EINTR);
+
+    if (received == 0) {
+        fmWarning() << "VfsMonitor: event dispatcher connection closed";
+        if (notifier) {
+            notifier->setEnabled(false);
         }
+        ::close(socketFd);
+        socketFd = -1;
+        return;
+    }
+
+    if (received < 0) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
+        }
+        return;
+    }
+
+    constexpr size_t kMinMessageSize = offsetof(DispatchEvent, eventPath) + 1;
+    if (static_cast<size_t>(received) < kMinMessageSize) {
+        fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
+        return;
+    }
+
+    event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+
+    const int act = event.action;
+    const uint32_t cookie = event.cookie;
+    const char *pathCStr = event.eventPath;
+
+    if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+        return;
+    }
+
+    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
+        if (!initMountPoints()) {
+            fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
+        }
+        return;
+    }
+
+    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
+        QString fullPath = resolveAndFilterFullPath(pathCStr);
+        if (fullPath.isNull())
+            return;
+
+        auto [parentPath, name] = splitPath(fullPath);
+        RenameFromInfo info;
+        info.path = parentPath;
+        info.name = name;
+        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
+        pendingRenames.insert(cookie, info);
+        return;
+    }
+
+    auto *q = q_ptr;
+    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
+        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
+        auto it = pendingRenames.find(cookie);
+        if (it != pendingRenames.end()) {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (!fullPath.isNull()) {
+                auto [parentPath, name] = splitPath(fullPath);
+                if (isDir)
+                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
+                else
+                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
+            } else {
+                if (isDir)
+                    Q_EMIT q->directoryDeleted(it->path, it->name);
+                else
+                    Q_EMIT q->fileDeleted(it->path, it->name);
+            }
+            pendingRenames.erase(it);
+        } else {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (!fullPath.isNull()) {
+                auto [parentPath, name] = splitPath(fullPath);
+                if (isDir)
+                    Q_EMIT q->directoryCreated(parentPath, name);
+                else
+                    Q_EMIT q->fileCreated(parentPath, name);
+            }
+        }
+        return;
+    }
+
+    const QString fullPath = resolveAndFilterFullPath(pathCStr);
+    if (fullPath.isNull()) {
+        return;
+    }
+
+    auto [parentPath, name] = splitPath(fullPath);
+
+    switch (act) {
+    case ACT_NEW_FILE:
+    case ACT_NEW_LINK:
+    case ACT_NEW_SYMLINK:
+        Q_EMIT q->fileCreated(parentPath, name);
+        break;
+    case ACT_NEW_FOLDER:
+        Q_EMIT q->directoryCreated(parentPath, name);
+        break;
+    case ACT_DEL_FILE:
+        Q_EMIT q->fileDeleted(parentPath, name);
+        break;
+    case ACT_DEL_FOLDER:
+        Q_EMIT q->directoryDeleted(parentPath, name);
+        break;
+    case ACT_RENAME_FILE:
+        Q_EMIT q->fileCreated(parentPath, name);
+        break;
+    case ACT_RENAME_FOLDER:
+        Q_EMIT q->directoryCreated(parentPath, name);
+        break;
+    default:
+        break;
     }
 
     // Clean up orphaned RENAME_FROM entries.
@@ -584,7 +444,7 @@ VfsMonitorFileSystemWatcher *VfsMonitorFileSystemWatcher::create(const QStringLi
 {
     auto *watcher = new VfsMonitorFileSystemWatcher(rootPaths, std::move(excludePredicate), parent);
 
-    if (!watcher->d_func()->initNetlink()) {
+    if (!watcher->d_func()->initDispatcher()) {
         delete watcher;
         return nullptr;
     }

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -129,20 +129,6 @@ QString filterDirectPath(const QStringList &rootPaths,
     return fullPath;
 }
 
-QString filterEventPath(const QStringList &rootPaths,
-                        const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
-                        const char *eventPath)
-{
-    if (!eventPath || eventPath[0] == '\0')
-        return {};
-
-    const QString fullPath = QDir::cleanPath(QString::fromUtf8(eventPath));
-    if (!fullPath.startsWith('/'))
-        return {};
-
-    return filterDirectPath(rootPaths, excludePredicate, fullPath);
-}
-
 }   // anonymous namespace
 
 // ========== VfsMonitorFileSystemWatcherPrivate ==========
@@ -175,6 +161,7 @@ VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
 bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
 {
     mountPoints.clear();
+    orderedMountPoints.clear();
 
     libmnt_table *mtab = mnt_new_table();
     if (!mtab)
@@ -194,6 +181,7 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
             continue;
 
         mountPoints[entry.deviceId].append(entry.mountPoint);
+        orderedMountPoints.append({ entry.deviceId, entry.mountPoint });
     }
 
     for (auto &points : mountPoints) {
@@ -204,15 +192,16 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
                   });
     }
 
+    std::sort(orderedMountPoints.begin(), orderedMountPoints.end(),
+              [](const MountPointAlias &left, const MountPointAlias &right) {
+                  return left.mountPoint.length() > right.mountPoint.length();
+              });
+
     return !mountPoints.isEmpty();
 }
 
 QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char *absolutePath) const
 {
-    const QString directPath = filterEventPath(rootPaths, excludePredicate, absolutePath);
-    if (!directPath.isNull())
-        return directPath;
-
     if (!absolutePath || absolutePath[0] == '\0')
         return {};
 
@@ -220,27 +209,34 @@ QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char 
     if (!fullPath.startsWith('/'))
         return {};
 
-    for (auto deviceIt = mountPoints.cbegin(); deviceIt != mountPoints.cend(); ++deviceIt) {
-        const QStringList &points = deviceIt.value();
-        for (const QString &sourceMountPoint : points) {
-            if (!mountPointStartsWith(fullPath, sourceMountPoint))
-                continue;
+    const QString directPath = filterDirectPath(rootPaths, excludePredicate, fullPath);
+    if (!directPath.isNull())
+        return directPath;
 
-            const QString suffix = (sourceMountPoint == "/")
-                    ? fullPath
-                    : fullPath.mid(sourceMountPoint.length());
+    for (const MountPointAlias &sourceAlias : orderedMountPoints) {
+        if (!mountPointStartsWith(fullPath, sourceAlias.mountPoint))
+            continue;
 
-            for (const QString &candidateMountPoint : points) {
-                const QString candidateFullPath = (candidateMountPoint == "/")
-                        ? suffix
-                        : candidateMountPoint + suffix;
-                const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
-                if (!filteredCandidate.isNull())
-                    return filteredCandidate;
-            }
+        const auto pointsIt = mountPoints.constFind(sourceAlias.deviceId);
+        if (pointsIt == mountPoints.cend())
+            return {};
 
-            break;
+        const QString suffix = (sourceAlias.mountPoint == "/")
+                ? fullPath
+                : fullPath.mid(sourceAlias.mountPoint.length());
+
+        for (const QString &candidateMountPoint : pointsIt.value()) {
+            const QString candidateFullPath = (candidateMountPoint == "/")
+                    ? suffix
+                    : candidateMountPoint + suffix;
+            const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
+            if (!filteredCandidate.isNull())
+                return filteredCandidate;
         }
+
+        // The longest matching source mount point wins. If its aliases do not
+        // land inside a monitored root, do not fall back to shorter prefixes.
+        return {};
     }
 
     return {};
@@ -260,7 +256,8 @@ bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
         fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
     }
 
-    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    // The notifier runs on the GUI thread, so keep dispatcher reads nonblocking.
+    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
     if (socketFd < 0) {
         fmWarning() << "VfsMonitor: failed to create dispatcher socket:" << std::strerror(errno);
         return false;
@@ -292,136 +289,142 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
         return;
     }
 
-    DispatchEvent event {};
-    ssize_t received = -1;
-    do {
-        received = ::recv(socketFd, &event, sizeof(event), 0);
-    } while (received < 0 && errno == EINTR);
-
-    if (received == 0) {
-        fmWarning() << "VfsMonitor: event dispatcher connection closed";
-        if (notifier) {
-            notifier->setEnabled(false);
-        }
-        ::close(socketFd);
-        socketFd = -1;
-        return;
-    }
-
-    if (received < 0) {
-        if (errno != EAGAIN && errno != EWOULDBLOCK) {
-            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
-        }
-        return;
-    }
-
+    auto *q = q_ptr;
     constexpr size_t kMinMessageSize = offsetof(DispatchEvent, eventPath) + 1;
-    if (static_cast<size_t>(received) < kMinMessageSize) {
-        fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
-        return;
-    }
 
-    event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+    // Drain all queued packets for this wakeup so the notifier stays level-safe.
+    while (true) {
+        DispatchEvent event {};
+        ssize_t received = -1;
+        do {
+            received = ::recv(socketFd, &event, sizeof(event), 0);
+        } while (received < 0 && errno == EINTR);
 
-    const int act = event.action;
-    const uint32_t cookie = event.cookie;
-    const char *pathCStr = event.eventPath;
-
-    if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
-        return;
-    }
-
-    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
-        if (!initMountPoints()) {
-            fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
-        }
-        return;
-    }
-
-    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
-        QString fullPath = resolveAndFilterFullPath(pathCStr);
-        if (fullPath.isNull())
+        if (received == 0) {
+            fmWarning() << "VfsMonitor: event dispatcher connection closed";
+            if (notifier) {
+                notifier->setEnabled(false);
+            }
+            ::close(socketFd);
+            socketFd = -1;
             return;
+        }
+
+        if (received < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return;
+            }
+
+            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
+            return;
+        }
+
+        if (static_cast<size_t>(received) < kMinMessageSize) {
+            fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
+            continue;
+        }
+
+        event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+
+        const int act = event.action;
+        const uint32_t cookie = event.cookie;
+        const char *pathCStr = event.eventPath;
+
+        if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+            continue;
+        }
+
+        if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
+            if (!initMountPoints()) {
+                fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
+            }
+            continue;
+        }
+
+        if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (fullPath.isNull())
+                continue;
+
+            auto [parentPath, name] = splitPath(fullPath);
+            RenameFromInfo info;
+            info.path = parentPath;
+            info.name = name;
+            info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
+            pendingRenames.insert(cookie, info);
+            continue;
+        }
+
+        if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
+            const bool isDir = (act == ACT_RENAME_TO_FOLDER);
+            auto it = pendingRenames.find(cookie);
+            if (it != pendingRenames.end()) {
+                QString fullPath = resolveAndFilterFullPath(pathCStr);
+                if (!fullPath.isNull()) {
+                    auto [parentPath, name] = splitPath(fullPath);
+                    if (isDir)
+                        Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
+                    else
+                        Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
+                } else {
+                    if (isDir)
+                        Q_EMIT q->directoryDeleted(it->path, it->name);
+                    else
+                        Q_EMIT q->fileDeleted(it->path, it->name);
+                }
+                pendingRenames.erase(it);
+            } else {
+                QString fullPath = resolveAndFilterFullPath(pathCStr);
+                if (!fullPath.isNull()) {
+                    auto [parentPath, name] = splitPath(fullPath);
+                    if (isDir)
+                        Q_EMIT q->directoryCreated(parentPath, name);
+                    else
+                        Q_EMIT q->fileCreated(parentPath, name);
+                }
+            }
+            continue;
+        }
+
+        const QString fullPath = resolveAndFilterFullPath(pathCStr);
+        if (fullPath.isNull()) {
+            continue;
+        }
 
         auto [parentPath, name] = splitPath(fullPath);
-        RenameFromInfo info;
-        info.path = parentPath;
-        info.name = name;
-        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
-        pendingRenames.insert(cookie, info);
-        return;
-    }
 
-    auto *q = q_ptr;
-    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
-        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
-        auto it = pendingRenames.find(cookie);
-        if (it != pendingRenames.end()) {
-            QString fullPath = resolveAndFilterFullPath(pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
-                else
-                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
-            } else {
-                if (isDir)
-                    Q_EMIT q->directoryDeleted(it->path, it->name);
-                else
-                    Q_EMIT q->fileDeleted(it->path, it->name);
-            }
-            pendingRenames.erase(it);
-        } else {
-            QString fullPath = resolveAndFilterFullPath(pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryCreated(parentPath, name);
-                else
-                    Q_EMIT q->fileCreated(parentPath, name);
-            }
+        switch (act) {
+        case ACT_NEW_FILE:
+        case ACT_NEW_LINK:
+        case ACT_NEW_SYMLINK:
+            Q_EMIT q->fileCreated(parentPath, name);
+            break;
+        case ACT_NEW_FOLDER:
+            Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        case ACT_DEL_FILE:
+            Q_EMIT q->fileDeleted(parentPath, name);
+            break;
+        case ACT_DEL_FOLDER:
+            Q_EMIT q->directoryDeleted(parentPath, name);
+            break;
+        case ACT_RENAME_FILE:
+            Q_EMIT q->fileCreated(parentPath, name);
+            break;
+        case ACT_RENAME_FOLDER:
+            Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        default:
+            break;
         }
-        return;
-    }
 
-    const QString fullPath = resolveAndFilterFullPath(pathCStr);
-    if (fullPath.isNull()) {
-        return;
-    }
-
-    auto [parentPath, name] = splitPath(fullPath);
-
-    switch (act) {
-    case ACT_NEW_FILE:
-    case ACT_NEW_LINK:
-    case ACT_NEW_SYMLINK:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-    case ACT_NEW_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-    case ACT_DEL_FILE:
-        Q_EMIT q->fileDeleted(parentPath, name);
-        break;
-    case ACT_DEL_FOLDER:
-        Q_EMIT q->directoryDeleted(parentPath, name);
-        break;
-    case ACT_RENAME_FILE:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-    case ACT_RENAME_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-    default:
-        break;
-    }
-
-    // Clean up orphaned RENAME_FROM entries.
-    static constexpr int kPendingRenameCleanupThreshold = 1000;
-    if (pendingRenames.size() > kPendingRenameCleanupThreshold) {
-        fmWarning() << "VfsMonitor: pending rename table too large ("
-                    << pendingRenames.size() << "), clearing";
-        pendingRenames.clear();
+        // Clean up orphaned RENAME_FROM entries.
+        static constexpr int kPendingRenameCleanupThreshold = 1000;
+        if (pendingRenames.size() > kPendingRenameCleanupThreshold) {
+            fmWarning() << "VfsMonitor: pending rename table too large ("
+                        << pendingRenames.size() << "), clearing";
+            pendingRenames.clear();
+        }
     }
 }
 

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
@@ -16,16 +16,16 @@ SERVICETEXTINDEX_BEGIN_NAMESPACE
 class VfsMonitorFileSystemWatcherPrivate;
 
 // VfsMonitorFileSystemWatcher: File system watcher using deepin-anything
-// vfs_monitor kernel module via Linux Generic Netlink multicast.
+// event dispatcher socket exposed by deepin-anything-server.
 //
-// Receives global file system events (create, delete, move) from the kernel,
-// covering all mounted filesystems without the need for recursive inotify watches.
-// File close events (IN_CLOSE_WRITE) are NOT provided -- use InotifyFileSystemWatcher
-// for those.
+// Receives global file system events (create, delete, move) forwarded by
+// deepin-anything-server from /run/deepin-anything/event-dispatcher.sock.
+// File close events (IN_CLOSE_WRITE) are NOT provided -- use
+// InotifyFileSystemWatcher for those.
 //
 // Usage:
 //   auto *watcher = VfsMonitorFileSystemWatcher::create(rootPaths, excludePredicate, parent);
-//   if (watcher) { ... }  // kernel module available
+//   if (watcher) { ... }  // event dispatcher available
 //   // else: fallback to inotify-only mode
 class VfsMonitorFileSystemWatcher : public QObject
 {
@@ -35,13 +35,14 @@ class VfsMonitorFileSystemWatcher : public QObject
 
 public:
     // Predicate for path exclusion. Return true to suppress the event.
-    // Called from the netlink callback thread context (main thread via Qt event loop).
+    // Called from the main thread via Qt event loop.
     using PathExcludePredicate = std::function<bool(const QString &fullPath)>;
 
     ~VfsMonitorFileSystemWatcher() override;
 
-    // Factory method: attempts to connect to the vfsmonitor Generic Netlink family.
-    // Returns nullptr if the kernel module is not available (graceful degradation).
+    // Factory method: attempts to connect to the deepin-anything event
+    // dispatcher socket. Returns nullptr if the dispatcher is not available
+    // (graceful degradation).
     static VfsMonitorFileSystemWatcher *create(const QStringList &rootPaths,
                                                PathExcludePredicate excludePredicate,
                                                QObject *parent = nullptr);

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -11,9 +11,8 @@
 #include <QHash>
 #include <QStringList>
 
+#include <cstdint>
 #include <sys/types.h>
-
-struct nl_sock;
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
@@ -24,20 +23,6 @@ struct RenameFromInfo
     QString name;
     bool isDirectory { false };
 };
-
-// Netlink attribute indices (matching vfs_genl.h)
-enum VfsMonitorAttr : int {
-    VFSMONITOR_A_UNSPEC = 0,
-    VFSMONITOR_A_ACT,
-    VFSMONITOR_A_COOKIE,
-    VFSMONITOR_A_MAJOR,
-    VFSMONITOR_A_MINOR,
-    VFSMONITOR_A_PATH,
-    VFSMONITOR_A_UID,
-    VFSMONITOR_A_TGID,
-    __VFSMONITOR_A_MAX
-};
-#define VFSMONITOR_A_MAX (__VFSMONITOR_A_MAX - 1)
 
 // Event action constants (matching vfs_change_consts.h)
 enum VfsMonitorAct : uint8_t {
@@ -67,12 +52,13 @@ public:
                                        VfsMonitorFileSystemWatcher *qq);
     ~VfsMonitorFileSystemWatcherPrivate();
 
-    bool initNetlink();
-    void handleNetlinkMessage();
+    bool initDispatcher();
+    void handleSocketMessage();
 
-    // Reconstruct full path from relative path + device, then check against
-    // rootPaths and excludePredicate. Returns null if filtered out.
-    QString resolveAndFilterFullPath(dev_t deviceId, const char *relativePath) const;
+    // The event dispatcher sends absolute paths, but they may use a different
+    // mount alias than the monitored root path. This helper normalizes across
+    // same-device mount aliases before applying rootPaths and excludePredicate.
+    QString resolveAndFilterFullPath(const char *absolutePath) const;
 
     static QPair<QString, QString> splitPath(const QString &fullPath);
 
@@ -81,22 +67,13 @@ public:
     QStringList rootPaths;
     VfsMonitorFileSystemWatcher::PathExcludePredicate excludePredicate;
 
-    nl_sock *nlSock { nullptr };
+    int socketFd { -1 };
     QSocketNotifier *notifier { nullptr };
 
     QHash<uint32_t, RenameFromInfo> pendingRenames;
-
-    // dev_t -> sorted mount point list (longest first).
     QHash<dev_t, QStringList> mountPoints;
-    QHash<dev_t, QStringList> childMountPoints;
-    bool lowerFsExists { false };
-
-    // Set to true when an ACT_MOUNT/ACT_UNMOUNT event is received, cleared
-    // after initMountPoints() rebuilds the cache in handleNetlinkMessage().
-    bool mountPointsDirty { false };
 
     bool initMountPoints();
-    bool isLowerFsEvent(dev_t deviceId, const QString &fullPath) const;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -10,6 +10,7 @@
 #include <QSocketNotifier>
 #include <QHash>
 #include <QStringList>
+#include <QVector>
 
 #include <cstdint>
 #include <sys/types.h>
@@ -22,6 +23,12 @@ struct RenameFromInfo
     QString path;
     QString name;
     bool isDirectory { false };
+};
+
+struct MountPointAlias
+{
+    dev_t deviceId { 0 };
+    QString mountPoint;
 };
 
 // Event action constants (matching vfs_change_consts.h)
@@ -72,6 +79,7 @@ public:
 
     QHash<uint32_t, RenameFromInfo> pendingRenames;
     QHash<dev_t, QStringList> mountPoints;
+    QVector<MountPointAlias> orderedMountPoints;
 
     bool initMountPoints();
 };


### PR DESCRIPTION
Cherry-pick of fix from master branch.

## 修复内容

- 在 policy 文件中新增 ChangePIN action 用于 PIN 码修改场景
- 将原 ChangePassphrase action 提示改为「修改加密口令需要认证」
- 服务端通过 TpmToken(dev) 独立推断加密类型，选择对应 polkit action
- JSON 解析增加 QJsonParseError 校验

Original PR: #4052

## Summary by Sourcery

Update filesystem monitoring to use the deepin-anything event dispatcher socket instead of the vfs_monitor netlink kernel module, refine image and preview handling for formats with unknown sizes, improve drag-and-drop and focus behaviors in the UI, harden delayed search and selection lifecycle handling, and adjust disk encryption authorization and burn job error reporting.

New Features:
- Add support for deepin-anything event dispatcher socket to deliver global filesystem events with mount-alias normalization.
- Introduce a distinct polkit ChangePIN action for TPM PIN-based disk encryption and select it automatically based on TPM token metadata.

Bug Fixes:
- Fix missing thumbnails and previews for image formats (such as icns) that report invalid sizes but can still be decoded.
- Prevent crashes and invalid behavior from delayed search callbacks and selection helpers when windows, titlebars, or models have already been destroyed.
- Correct drag-and-drop hover and drop hit-testing in the sidebar, especially under Wayland or compositor limitations.
- Ensure the last browser window is restored near the cursor after tearing off the final tab and avoid hiding the window when dragging pinned single tabs.
- Avoid duplicate or empty burn failure dialogs and ensure device disconnection errors are surfaced consistently.
- Derive the correct disk encryption polkit action from TPM token JSON with robust JSON parse error handling.
- Improve memory info reporting by falling back to an alternative installed-memory source when the primary query fails.

Enhancements:
- Normalize and deduplicate monitored root paths and mount point aliases for more accurate filesystem event filtering and path resolution.
- Document and rename VfsMonitor components to reflect the new deepin-anything dispatcher-based design.
- Improve on-screen keyboard visibility and focus behavior for search, address bars, and text inputs in the titlebar.
- Tighten validation of window IDs and existence checks before starting or dispatching searches to avoid acting on invalid windows.

Build:
- Replace libnl dependencies with libmount in the textindex service build configuration.

CI:
- Update cppcheck workflow to use a newer checkout action version with safer PR checkout settings.

Tests:
- Adjust VfsMonitorFileSystemWatcher tests to expect the deepin-anything event dispatcher socket instead of the kernel module.