### PR TITLE
fix: correct polkit prompt for partition passphrase change (snipe)

### DIFF
--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -25,6 +25,8 @@
 #include <QDir>
 #include <QFile>
 #include <QProcess>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include <polkit-qt6-1/PolkitQt1/Authority>
 
@@ -33,6 +35,7 @@
 static constexpr char kActionEncrypt[] { "org.deepin.Filemanager.DiskEncrypt.Encrypt" };
 static constexpr char kActionDecrypt[] { "org.deepin.Filemanager.DiskEncrypt.Decrypt" };
 static constexpr char kActionChgPwd[] { "org.deepin.Filemanager.DiskEncrypt.ChangePassphrase" };
+static constexpr char kActionChgPIN[] { "org.deepin.Filemanager.DiskEncrypt.ChangePIN" };
 
 FILE_ENCRYPT_USE_NS
 
@@ -161,15 +164,35 @@ bool DiskEncryptSetup::ChangePassphrase(const QDBusUnixFileDescriptor &credentia
 {
     qInfo() << "[DiskEncryptSetup::ChangePassphrase] Passphrase change request received via fd";
 
-    if (!m_dptr->checkAuth(kActionChgPwd)) {
-        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
-        return false;
-    }
-
-    // Parse credentials from fd using common method
+    // Parse credentials first to determine the encryption type for the correct polkit action
     QVariantMap args;
     if (!m_dptr->parseCredentialsFromFd(credentialsFd, &args)) {
         qCritical() << "[DiskEncryptSetup::ChangePassphrase] Failed to parse credentials from fd";
+        return false;
+    }
+
+    // Determine the security key type to select the appropriate polkit action.
+    // The server independently infers secType from the device's TPM token
+    // (via TpmToken, which includes holder-device fallback) rather than
+    // trusting client-supplied input for the authorization decision.
+    auto dev = args.value(disk_encrypt::encrypt_param_keys::kKeyDevice).toString();
+    QString token = TpmToken(dev);
+    QString usePin;
+    if (!token.isEmpty()) {
+        QJsonParseError parseError;
+        QJsonDocument doc = QJsonDocument::fromJson(token.toLocal8Bit(), &parseError);
+        if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+            qWarning() << "[DiskEncryptSetup::ChangePassphrase] Failed to parse TPM token JSON for device:" << dev << "Error:" << parseError.errorString();
+            return false;
+        }
+        QJsonObject obj = doc.object();
+        usePin = obj.value("pin").toString("");
+    }
+    auto secType = (usePin == "1") ? disk_encrypt::kPin : disk_encrypt::kPwd;
+    const QString &action = (secType == disk_encrypt::kPin) ? kActionChgPIN : kActionChgPwd;
+
+    if (!m_dptr->checkAuth(action)) {
+        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
         return false;
     }
 

--- a/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
+++ b/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
@@ -33,6 +33,19 @@
   </action>
   <action id="org.deepin.Filemanager.DiskEncrypt.ChangePassphrase">
     <description>Disk encryption</description>
+    <message>Authentication is required to change the passphrase of the partition</message>
+    <message xml:lang="zh_CN">修改加密口令需要认证</message>
+    <message xml:lang="zh_HK">修改加密口令需要認證</message>
+    <message xml:lang="zh_TW">修改加密口令需要認證</message>
+    <icon_name>folder</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+  <action id="org.deepin.Filemanager.DiskEncrypt.ChangePIN">
+    <description>Disk encryption</description>
     <message>Authentication is required to change the PIN code of the partition</message>
     <message xml:lang="zh_CN">修改分区PIN码需要认证</message>
     <message xml:lang="zh_HK">修改分區PIN碼需要認證</message>


### PR DESCRIPTION
Cherry-pick of fix from master branch.

## 修复内容

- 在 policy 文件中新增 ChangePIN action 用于 PIN 码修改场景
- 将原 ChangePassphrase action 提示改为「修改加密口令需要认证」
- 服务端通过 TpmToken(dev) 独立推断加密类型，选择对应 polkit action

Original PR: #4052

## Summary by Sourcery

Adjust passphrase change handling to select the correct polkit authorization based on TPM token–derived encryption type, and extend policy to support PIN-based changes.

New Features:
- Introduce a dedicated polkit action for PIN change operations in the disk encryption service.

Bug Fixes:
- Ensure partition passphrase change prompts use the correct polkit action depending on whether the device uses a PIN or password.
- Prevent incorrect client-driven encryption type selection by inferring security type from the server-side TPM token.

Enhancements:
- Refine passphrase change messaging in the polkit policy to clearly indicate that modifying the encryption passphrase requires authentication.