### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/src/apps/dde-file-manager/dde-file-manager.desktop
+++ b/src/apps/dde-file-manager/dde-file-manager.desktop
@@ -254,9 +254,9 @@ Name[ur]=ڈیپن فائل منیجر
 Name[uz]=Deepin Fayl Menedjeri
 Name[vi]=Trình quản lý tệp tin
 Name[lo]=ຜູ້ຈັດການໄຟລ໌
-Name[zh_CN]=深度文件管理器
-Name[zh_HK]=Deepin 文件管理器
-Name[zh_TW]=Deepin 檔案管理器
+Name[zh_CN]=文件管理器
+Name[zh_HK]=文件管理器
+Name[zh_TW]=檔案管理器
 
 [Desktop Action new-window]
 Exec=dde-file-manager --new-window


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese desktop entry translations by removing unintended "深度"/"deepin"/"Deepin" prefixes from Name and Comment fields for zh_CN, zh_HK, and zh_TW locales.