### PR TITLE
fix: avoid parenting delete dialog to WA_DeleteOnClose popup

### DIFF
--- a/src/dfm-base/utils/dialogmanager.cpp
+++ b/src/dfm-base/utils/dialogmanager.cpp
@@ -430,7 +430,18 @@ int DialogManager::showDeleteFilesDialog(const QList<QUrl> &urlList, bool isTras
         title = DeleteFileItems.arg(urlList.size());
     }
 
-    DDialog d(qApp->activeWindow());
+    // Don't parent the stack-allocated dialog to a window that may be destroyed
+    // during this dialog's own nested event loop. A WA_DeleteOnClose transient
+    // popup (e.g. TagEditor) closes and deleteLater()-destroys itself once it
+    // loses focus to this dialog; the deferred delete is processed inside
+    // d.exec(), and ~TagEditor -> deleteChildren would then `delete` this
+    // stack object, causing a double-free / corruption crash. Fall back to the
+    // parentless WindowStaysOnTopHint branch below for such windows.
+    QWidget *parent = qApp->activeWindow();
+    if (parent && parent->testAttribute(Qt::WA_DeleteOnClose))
+        parent = nullptr;
+
+    DDialog d(parent);
     if (!d.parentWidget()) {
         d.setWindowFlags(d.windowFlags() | Qt::WindowStaysOnTopHint);
     }


### PR DESCRIPTION
## 根因分析

**结论：强根因**。`DialogManager::showDeleteFilesDialog` 将栈上构造的 `DDialog d` 以 `qApp->activeWindow()` 为父；当活动窗口是 `WA_DeleteOnClose` 的 `TagEditor` 浮窗时，`DDialog d` 成为 `TagEditor` 的 Qt 子对象。`d.exec()` 的嵌套事件循环处理 `TagEditor` 的延迟析构，`~TagEditor -> deleteChildren` 对栈上 `DDialog d` 执行 `delete`，`free()` 收到栈地址（coredump 中 `p=0x7fff9c2b79c0`）→ "double free or corruption (out)" → 崩溃。

关键证据：
- `src/dfm-base/utils/dialogmanager.cpp:433` — `DDialog d(qApp->activeWindow());`（栈对话框，父=活动窗口）。
- `tageditor.cpp` — `WA_DeleteOnClose` + `windowDeactivate→onFocusOut→close()`；dtkwidget `DArrowRectanglePrivate::show` 调 `activateWindow()` 使 `TagEditor` 成为活动窗口。
- `git diff 6.5.152..HEAD` 三处相关文件均无差异，确认 6.5.152→6.6.2 间未修复。

## 修复方案

在 `showDeleteFilesDialog` 中，当 `qApp->activeWindow()` 带 `WA_DeleteOnClose` 时不作为父对象，回退到既有的「无父 + `WindowStaysOnTopHint`」分支。仅新增一处父对象合法性判断，直接打断崩溃链第 4 步（栈对话框不再成为 `TagEditor` 子对象），保留 commit `0016e3eccd` 引入的 Wayland 置顶/模态行为。

## 改动安全评估

**低风险**：仅新增一处父对象合法性判断，函数签名不变；删除文件、清空回收站等其余调用方的活动窗口均为普通主窗口，行为与 Wayland 置顶/模态行为均保持不变；仅 `WA_DeleteOnClose` 瞬时父窗口场景回退为无父置顶（即崩溃路径）。

> 注：`dialogmanager.cpp` 中另有约 20 处相同 `DDialog d(qApp->activeWindow())` anti-pattern，本次仅修 PMS 指向的 `showDeleteFilesDialog`，其余建议后续统一加固。

## Summary by Sourcery

Bug Fixes:
- Fix crash when the delete files dialog is shown while a WA_DeleteOnClose popup (e.g. TagEditor) is the active window by falling back to a parentless, always-on-top dialog in that case.