### PR TITLE
Fix(disk-encrypt): Enhance security.

### DIFF
--- a/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
+++ b/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
@@ -15,7 +15,7 @@
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
   <action id="org.deepin.Filemanager.DiskEncrypt.Decrypt">
@@ -28,7 +28,7 @@
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
   <action id="org.deepin.Filemanager.DiskEncrypt.ChangePassphrase">
@@ -54,7 +54,7 @@
     <defaults>
       <allow_any>no</allow_any>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 </policyconfig>

--- a/src/services/tpmcontrol/polkit/org.deepin.filemanager.tpmcontrol.policy
+++ b/src/services/tpmcontrol/polkit/org.deepin.filemanager.tpmcontrol.policy
@@ -6,45 +6,17 @@
   <vendor>Deepin</vendor>
   <vendor_url>https://www.deepin.org</vendor_url>
 
-  <action id="org.deepin.Filemanager.TPMControl.Query">
-    <description>Query TPM status</description>
-    <message>Authentication is required to query TPM status</message>
-    <message xml:lang="zh_CN">查询 TPM 状态需要认证</message>
-    <message xml:lang="zh_HK">查詢 TPM 狀態需要認證</message>
-    <message xml:lang="zh_TW">查詢 TPM 狀態需要認證</message>
+  <action id="org.deepin.Filemanager.TPMControl.Access">
+    <description>Access the TPM chip</description>
+    <message>Authorization is required to access the TPM chip</message>
+    <message xml:lang="zh_CN">访问 TPM 芯片需要授权</message>
+    <message xml:lang="zh_HK">存取 TPM 晶片需要授權</message>
+    <message xml:lang="zh_TW">存取 TPM 晶片需要授權</message>
     <icon_name>folder</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>yes</allow_active>
-    </defaults>
-  </action>
-
-  <action id="org.deepin.Filemanager.TPMControl.Encrypt">
-    <description>Encrypt data with TPM</description>
-    <message>Authentication is required to encrypt data with TPM</message>
-    <message xml:lang="zh_CN">TPM 加密需要管理员认证</message>
-    <message xml:lang="zh_HK">TPM 加密需要管理員認證</message>
-    <message xml:lang="zh_TW">TPM 加密需要管理員認證</message>
-    <icon_name>folder</icon_name>
-    <defaults>
-      <allow_any>no</allow_any>
-      <allow_inactive>no</allow_inactive>
       <allow_active>auth_admin_keep</allow_active>
-    </defaults>
-  </action>
-
-  <action id="org.deepin.Filemanager.TPMControl.Decrypt">
-    <description>Decrypt data with TPM</description>
-    <message>Authentication is required to decrypt data with TPM</message>
-    <message xml:lang="zh_CN">TPM 解密需要管理员认证</message>
-    <message xml:lang="zh_HK">TPM 解密需要管理員認證</message>
-    <message xml:lang="zh_TW">TPM 解密需要管理員認證</message>
-    <icon_name>folder</icon_name>
-    <defaults>
-      <allow_any>no</allow_any>
-      <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
     </defaults>
   </action>
 

--- a/src/services/tpmcontrol/service_tpmcontrol_global.h
+++ b/src/services/tpmcontrol/service_tpmcontrol_global.h
@@ -57,9 +57,7 @@ inline constexpr char kPcrBank[] { "PropertyKey_PcrBank" };
 
 // PolicyKit action IDs
 namespace PolicyKitActionId {
-inline constexpr char kQuery[] { "org.deepin.Filemanager.TPMControl.Query" };
-inline constexpr char kEncrypt[] { "org.deepin.Filemanager.TPMControl.Encrypt" };
-inline constexpr char kDecrypt[] { "org.deepin.Filemanager.TPMControl.Decrypt" };
+inline constexpr char kAccess[] { "org.deepin.Filemanager.TPMControl.Access" };
 }
 
 SERVICETPMCONTROL_END_NAMESPACE

--- a/src/services/tpmcontrol/tpmcontroldbus.cpp
+++ b/src/services/tpmcontrol/tpmcontroldbus.cpp
@@ -152,7 +152,7 @@ int TPMControlDBus::IsTPMAvailable()
 {
     fmInfo() << "IsTPMAvailable called";
 
-    if (!checkAuthentication(PolicyKitActionId::kQuery)) {
+    if (!checkAuthentication(PolicyKitActionId::kAccess)) {
         return kAuthFailed;
     }
 
@@ -163,7 +163,7 @@ int TPMControlDBus::CheckTPMLockout()
 {
     fmInfo() << "CheckTPMLockout called";
 
-    if (!checkAuthentication(PolicyKitActionId::kQuery)) {
+    if (!checkAuthentication(PolicyKitActionId::kAccess)) {
         return kAuthFailed;
     }
 
@@ -174,7 +174,7 @@ int TPMControlDBus::IsSupportAlgo(const QString &algoName, bool &support)
 {
     fmInfo() << "IsSupportAlgo called for:" << algoName;
 
-    if (!checkAuthentication(PolicyKitActionId::kQuery)) {
+    if (!checkAuthentication(PolicyKitActionId::kAccess)) {
         return kAuthFailed;
     }
 
@@ -185,7 +185,7 @@ int TPMControlDBus::OwnerAuthStatus()
 {
     fmInfo() << "OwnerAuthStatus called";
 
-    if (!checkAuthentication(PolicyKitActionId::kQuery)) {
+    if (!checkAuthentication(PolicyKitActionId::kAccess)) {
         return kAuthFailed;
     }
 
@@ -196,7 +196,7 @@ int TPMControlDBus::GetRandom(int size, QDBusUnixFileDescriptor &randomData)
 {
     fmInfo() << "GetRandom called with size:" << size;
 
-    if (!checkAuthentication(PolicyKitActionId::kEncrypt)) {
+    if (!checkAuthentication(PolicyKitActionId::kAccess)) {
         return kAuthFailed;
     }
 
@@ -221,7 +221,7 @@ int TPMControlDBus::Encrypt(const QDBusUnixFileDescriptor &params)
 {
     fmInfo() << "Encrypt called";
 
-    if (!checkAuthentication(PolicyKitActionId::kEncrypt)) {
+    if (!checkAuthentication(PolicyKitActionId::kAccess)) {
         return kAuthFailed;
     }
 
@@ -239,7 +239,7 @@ int TPMControlDBus::Decrypt(const QDBusUnixFileDescriptor &params, QDBusUnixFile
 {
     fmInfo() << "Decrypt called";
 
-    if (!checkAuthentication(PolicyKitActionId::kDecrypt)) {
+    if (!checkAuthentication(PolicyKitActionId::kAccess)) {
         return kAuthFailed;
     }
 


### PR DESCRIPTION
-- Fix the issue where the currently logged-in user can access the TPM
   chip without requiring authentication.
-- Modify encryption/decryption authorization to have a certain time validity,
   preventing repeated authentication requests.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-372451.html

## Summary by Sourcery

Enhancements:
- Replace separate query/encrypt/decrypt PolicyKit action IDs with a single access action for TPM control operations to simplify and tighten authorization semantics.