### PR TITLE
fix: fix special chars in tag editor clearing existing tags

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: export
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -14,9 +14,9 @@
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
 
-// VfsMonitorFileSystemWatcher 依赖 deepin-anything 内核模块
-// 如果模块不可用，create() 返回 nullptr，相关测试应被跳过
-// 注意: 当前内核 vfs_monitor 模块存在已知 bug（无法检测目录创建），
+// VfsMonitorFileSystemWatcher 依赖 deepin-anything 事件分发 socket
+// 如果事件分发不可用，create() 返回 nullptr，相关测试应被跳过
+// 注意: 当前 deepin-anything 事件链路若不可用，
 // 目录相关测试使用 ASSERT 严格模式，失败时直接终止当前测试而非崩溃
 class TestVfsMonitorFileSystemWatcher : public ::testing::Test
 {
@@ -33,7 +33,7 @@ protected:
         QStringList rootPaths = { testDir->path() };
         watcher = VfsMonitorFileSystemWatcher::create(rootPaths, {}, nullptr);
         if (!watcher) {
-            GTEST_SKIP() << "deepin-anything kernel module not available, skipping tests";
+            GTEST_SKIP() << "deepin-anything event dispatcher not available, skipping tests";
         }
     }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+dde-file-manager (6.5.160) unstable; urgency=medium
+
+  * fix(preview): resolve filename/resolution overlap in image preview status bar
+  * fix: fix potential crash in FileView destructor
+  * fix(textindex): add OcrIndex path to service manager idle policy
+  * fix(recent): cannot open recent:// url in cmd if plugin is lazy loaded
+  * fix(filedialog): keep recent hidden in save dialog on config change
+  * fix(recent): register watcher for recent scheme to enable view refresh
+  * fix: optimize share removal and permission management
+  * fix: improve path display for file conflict messages
+  * fix: improve search input handling robustness
+  * fix: properly handle selection state during model teardown
+  * fix(sidebar): avoid stale drop targets during external drags
+  * fix(burn): show error details in erase failure dialog
+  * refactor: switch from netlink to socket for deepin-anything events
+  * fix: improve mount point resolution in filesystem watcher
+  * fix: correct desktop available geometry on treeland fractional scaling
+  * fix: keep desktop canvas origin for top and left dock
+  * fix(diskencrypt): validate device encryption status before resuming operations
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * fix: reposition window near cursor on last tab tear-off
+  * fix(image-preview): support preview for formats with invalid size() like icns
+  * fix(thumbnail): support thumbnails for image formats with invalid size() like icns
+  * ci(cppcheck): bump actions/checkout to v7 and enable unsafe pr checkout
+  * fix(titlebar): stabilize virtual keyboard display
+  * fix(propertydialog): use D-Bus SystemInfo for installed memory size
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 24 Jul 2026 13:04:08 +0800
+
 dde-file-manager (6.5.151) unstable; urgency=medium
 
   * refactor: replace thread termination with _exit for clean shutdown

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.162) unstable; urgency=medium
+
+  * Revert "fix: keep desktop canvas origin for top and left dock"
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 04 Aug 2026 09:17:05 +0800
+
 dde-file-manager (6.5.161) unstable; urgency=medium
 
   * fix: correct icon layout after maximizing window following touch long-press

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-file-manager (6.5.161) unstable; urgency=medium
+
+  * fix: correct icon layout after maximizing window following touch long-press
+  * fix: batch-process recent items on startup to avoid UI freeze
+  * fix: ship dfm-reencrypt.desktop via package instead of runtime creation
+  * fix(workspace): improve group header expand button hit area
+  * fix: add last read time support for recent items
+  * fix: remove GIF from wallpaper supported types in file context menu
+
+ -- zhangsheng <zhangsheng@uniontech.com>  Thu, 30 Jul 2026 19:40:42 +0800
+
 dde-file-manager (6.5.160) unstable; urgency=medium
 
   * fix(preview): resolve filename/resolution overlap in image preview status bar

--- a/debian/dde-file-manager.install
+++ b/debian/dde-file-manager.install
@@ -15,6 +15,7 @@ usr/lib/*/dde-file-manager/plugins/previews/*.so
 usr/lib/*/dde-file-manager/plugins/previews/*.json
 usr/share/applications/dde-file-manager.desktop
 usr/share/applications/dde-open.desktop
+usr/share/applications/dfm-reencrypt.desktop
 usr/share/dde-file-manager/translations/*.qm
 usr/share/dbus-1/interfaces/*.xml
 usr/share/dbus-1/services/*.service

--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.cpp
@@ -9,8 +9,6 @@
 #include <dfm-base/utils/fileutils.h>
 #include "imageview.h"
 
-#include <DAnchors>
-
 #include <QImageReader>
 #include <QProcess>
 #include <QMimeType>
@@ -19,7 +17,6 @@
 #include <QFileInfo>
 #include <QMimeData>
 
-DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
 using namespace plugin_filepreview;
 
@@ -32,7 +29,7 @@ ImagePreview::ImagePreview(QObject *parent)
 ImagePreview::~ImagePreview()
 {
     fmInfo() << "Image preview: ImagePreview instance destroyed";
-    
+
     if (imageView)
         imageView->deleteLater();
 
@@ -43,7 +40,7 @@ ImagePreview::~ImagePreview()
 bool ImagePreview::canPreview(const QUrl &url, QByteArray *format) const
 {
     fmDebug() << "Image preview: checking if can preview:" << url;
-    
+
     QByteArray f = QImageReader::imageFormat(url.toLocalFile());
 
     if (f.isEmpty()) {
@@ -77,23 +74,29 @@ void ImagePreview::initialize(QWidget *window, QWidget *statusBar)
     Q_UNUSED(window)
 
     fmDebug() << "Image preview: initializing with status bar";
-    
+
     messageStatusBar = new QLabel(statusBar);
     messageStatusBar->setStyleSheet("QLabel{font-family: Helvetica;\
                                    font-size: 12px;\
                                    font-weight: 300;}");
+    // Expanding 水平策略：让 messageStatusBar 在 QHBoxLayout 中抢占 previewTitle 与 openBtn
+    // 之间的多余空间，配合 AlignCenter 使分辨率文本在该空间内居中——previewTitle 短时
+    // 接近 statusBar 几何中心，previewTitle 长时多余空间被压缩，标签自然回缩避让。
+    messageStatusBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    messageStatusBar->setAlignment(Qt::AlignCenter);
 
     messageStatusBar->show();
 
-    DAnchorsBase(messageStatusBar).setCenterIn(statusBar);
-    
+    // 分辨率标签通过 statusBarWidget() 交给 FilePreviewDialog 的 QHBoxLayout 统一管理，
+    // 不再用 DAnchors 绝对居中——避免与 previewTitle 在 statusBar 中心区域重叠。
+
     fmDebug() << "Image preview: status bar initialized";
 }
 
 bool ImagePreview::setFileUrl(const QUrl &url)
 {
     fmInfo() << "Image preview: setting file URL:" << url;
-    
+
     if (currentFileUrl == url) {
         fmDebug() << "Image preview: URL unchanged, skipping:" << url;
         return true;
@@ -159,4 +162,17 @@ QWidget *ImagePreview::contentWidget() const
 QString ImagePreview::title() const
 {
     return imageTitle;
+}
+
+QWidget *ImagePreview::statusBarWidget() const
+{
+    return messageStatusBar;
+}
+
+Qt::Alignment ImagePreview::statusBarWidgetAlignment() const
+{
+    // 返回 0（默认）让 widget 按 sizePolicy 参与 QHBoxLayout 的空间分配——
+    // 配合 messageStatusBar 的 Expanding 策略使其占满 previewTitle 与 openBtn 之间的多余空间。
+    // 文本居中由 QLabel::setAlignment(AlignCenter) 负责，不在此处设 alignment 以免抑制 Expanding。
+    return Qt::Alignment();
 }

--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.h
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imagepreview.h
@@ -34,6 +34,9 @@ public:
 
     QString title() const override;
 
+    QWidget *statusBarWidget() const override;
+    Qt::Alignment statusBarWidgetAlignment() const override;
+
 private:
     QUrl currentFileUrl;
     QPointer<QLabel> messageStatusBar;

--- a/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/image-preview/imageview.cpp
@@ -68,9 +68,23 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
     reader.setAutoTransform(true);
     sourceImageSize = reader.size();
 
+    QImage image;
+    bool needScaleAfterRead = false;   // 对于 size() 无法预知的格式（如 icns），读取后再缩放
     if (!sourceImageSize.isValid()) {
-        setPixmap(QPixmap());
-        return;
+        // 部分格式（如 icns）无法通过 size() 提前获取尺寸，这里先做一次解码，
+        // 失败则按原逻辑置空；成功则用实际图像尺寸进行后续处理。
+        image = reader.read();
+        if (image.isNull()) {
+            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+            setPixmap(QPixmap());
+            return;
+        }
+        sourceImageSize = image.size();
+        if (!sourceImageSize.isValid()) {
+            setPixmap(QPixmap());
+            return;
+        }
+        needScaleAfterRead = true;
     }
 
     // 计算保持宽高比的显示尺寸
@@ -78,15 +92,20 @@ void ImageView::setFile(const QString &fileName, const QByteArray &format)
                       qMin(static_cast<int>(dsize.height() * 0.7), sourceImageSize.height()));
     QSize showSize = sourceImageSize.scaled(maxShowSize, Qt::KeepAspectRatio);
 
-    // 设置缩放尺寸，让 QImageReader 只加载需要的大小，避免加载完整大图
-    reader.setScaledSize(showSize);
-
-    QImage image = reader.read();
-    if (image.isNull()) {
-        fmWarning() << "Image preview: failed to load image:" << reader.errorString();
-        setPixmap(QPixmap());
-        return;
+    if (needScaleAfterRead) {
+        // 该格式无法依赖 setScaledSize，直接对已解码图像做平滑缩放
+        image = image.scaled(showSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+    } else {
+        // 设置缩放尺寸，让 QImageReader 只加载需要的大小，避免加载完整大图
+        reader.setScaledSize(showSize);
+        image = reader.read();
+        if (image.isNull()) {
+            fmWarning() << "Image preview: failed to load image:" << reader.errorString();
+            setPixmap(QPixmap());
+            return;
+        }
     }
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         // 应用颜色空间转换，解决CMYK等格式的颜色显示问题 (仅Qt6)
     image = DFMBASE_NAMESPACE::FileUtils::convertToSRgbColorSpace(image);

--- a/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
+++ b/src/apps/dde-file-manager-preview/pluginpreviews/text-preview/textpreview.cpp
@@ -14,6 +14,8 @@
 #include <QUrl>
 #include <QFileInfo>
 #include <QDebug>
+#include <QByteArray>
+#include <climits>
 
 using namespace std;
 DFMBASE_USE_NAMESPACE
@@ -91,20 +93,51 @@ bool TextPreview::setFileUrl(const QUrl &url)
     device.seekg(0, ios::beg).read(buf, static_cast<streamsize>(len));
     device.close();
 
-    bool ok { false };
-    QString fileEncoding = DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::detectFileEncoding(filePath, &ok);
-    fmDebug() << "Text preview: detected file encoding:" << fileEncoding << "detection success:" << ok;
+    // len is already capped at kReadTextSize (5 MB) above, but guard the
+    // static_cast<int> explicitly to satisfy static analysis and prevent
+    // potential integer truncation on platforms where long > int.
+    if (len > INT_MAX) {
+        fmWarning() << "Text preview: file too large for preview:" << len;
+        delete[] buf;
+        return false;
+    }
 
-    std::string strBuf(buf, static_cast<unsigned long>(len));
-    if (ok && fileEncoding.toLower() != "utf-8") {
-        fmDebug() << "Text preview: converting from" << fileEncoding << "to UTF-8";
+    QByteArray rawData(buf, static_cast<int>(len));
+
+    // Step 1: if the raw bytes are already valid UTF-8, use them as-is.
+    // This covers ASCII and real UTF-8 files without any conversion overhead.
+    std::string strBuf;
+    if (rawData.isValidUtf8()) {
+        fmDebug() << "Text preview: raw data is valid UTF-8, using directly";
+        strBuf = rawData.toStdString();
+    } else {
+        // Step 2: try GB18030 → UTF-8 first.
+        // GB18030 is the national standard and GBK superset;
+        // in UOS it covers the overwhelming majority of non-UTF-8 CJK text.
+        // This avoids unreliable statistical encoding detection.
         QByteArray out;
-        QByteArray in(buf, static_cast<int>(len));
-        if (DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::convertTextEncoding(in, out, "utf-8")) {
+        if (DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::convertTextEncoding(
+                rawData, out, "utf-8", "gb18030")) {
             strBuf = out.toStdString();
-            fmDebug() << "Text preview: encoding conversion successful";
+            fmDebug() << "Text preview: GB18030 → UTF-8 conversion successful";
         } else {
-            fmWarning() << "Text preview: encoding conversion failed, using original data";
+            // Step 3: fall back to auto-detection for rare
+            // non-GB18030 encodings (Big5, EUC-JP, KOI8-R, …).
+            fmDebug() << "Text preview: GB18030 conversion failed, falling back to auto-detection";
+            bool ok { false };
+            QString fileEncoding = DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::detectFileEncoding(filePath, &ok);
+            fmDebug() << "Text preview: detected file encoding:" << fileEncoding << "detection success:" << ok;
+
+            strBuf = rawData.toStdString();
+            if (ok && fileEncoding.toLower() != "utf-8") {
+                fmDebug() << "Text preview: converting from" << fileEncoding << "to UTF-8";
+                if (DTK_NAMESPACE::DCORE_NAMESPACE::DTextEncoding::convertTextEncoding(rawData, out, "utf-8")) {
+                    strBuf = out.toStdString();
+                    fmDebug() << "Text preview: encoding conversion successful";
+                } else {
+                    fmWarning() << "Text preview: encoding conversion failed, using original data";
+                }
+            }
         }
     }
 

--- a/src/apps/dde-file-manager/dde-file-manager.desktop
+++ b/src/apps/dde-file-manager/dde-file-manager.desktop
@@ -13,6 +13,7 @@ Type=Application
 Version=1.0
 X-Deepin-DEComponent=true
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!

--- a/src/apps/dde-file-manager/dde-file-manager.desktop
+++ b/src/apps/dde-file-manager/dde-file-manager.desktop
@@ -254,9 +254,9 @@ Name[ur]=ڈیپن فائل منیجر
 Name[uz]=Deepin Fayl Menedjeri
 Name[vi]=Trình quản lý tệp tin
 Name[lo]=ຜູ້ຈັດການໄຟລ໌
-Name[zh_CN]=深度文件管理器
-Name[zh_HK]=Deepin 文件管理器
-Name[zh_TW]=Deepin 檔案管理器
+Name[zh_CN]=文件管理器
+Name[zh_HK]=文件管理器
+Name[zh_TW]=檔案管理器
 
 [Desktop Action new-window]
 Exec=dde-file-manager --new-window

--- a/src/dfm-base/file/local/localfilehandler.cpp
+++ b/src/dfm-base/file/local/localfilehandler.cpp
@@ -1361,8 +1361,12 @@ std::optional<QUrl> LocalFileHandlerPrivate::resolveSymlink(const QUrl &url)
         }
 
         // Check if link target exists
+        // For SMB targets, only skip the broken-link dialog when the share is
+        // unmounted (so the downstream mount/remount flow can take over).
+        // If the share is still mounted but the target is gone, the link is
+        // genuinely broken and the user should be notified.
         fileInfo.setFile(canonicalPath);
-        if (!fileInfo.exists() && !ProtocolUtils::isSMBFile(QUrl::fromLocalFile(canonicalPath))) {
+        if (!fileInfo.exists() && !DeviceUtils::isUnmountSamba(QUrl::fromLocalFile(canonicalPath))) {
             // Link is broken
             GlobalEventType dialogResult = DialogManagerInstance->showBreakSymlinkDialog(
                     QFileInfo(currentPath).fileName(),

--- a/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
+++ b/src/dfm-base/utils/thumbnail/thumbnailcreators.cpp
@@ -360,28 +360,41 @@ QImage ThumbnailCreators::imageThumbnailCreator(const QString &filePath, Thumbna
     }
 
     const QSize &imageSize = reader.size();
-
-    // fix 读取损坏icns文件（可能任意损坏的image类文件也有此情况）在arm平台上会导致递归循环的问题
-    // 这里先对损坏文件（imagesize无效）做处理，不再尝试读取其image数据
-    if (!imageSize.isValid()) {
-        qCWarning(logDFMBase) << "thumbnail: image file has invalid size attributes:" << filePath;
-        return {};
-    }
-
-    qCDebug(logDFMBase) << "thumbnail: image file size:" << imageSize << "for:" << filePath;
-
-    const QString &defaultMime = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath)).name();
-    if (imageSize.width() > size || imageSize.height() > size || defaultMime == DFMGLOBAL_NAMESPACE::Mime::kTypeImageSvgXml) {
-        qCDebug(logDFMBase) << "thumbnail: scaling image from" << imageSize << "to fit size:" << size;
-        reader.setScaledSize(reader.size().scaled(size, size, Qt::KeepAspectRatio));
-    }
-
     reader.setAutoTransform(true);
     QImage image;
-    if (!reader.read(&image)) {
-        qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
-                              << "error:" << reader.errorString();
-        return image;
+
+    if (imageSize.isValid()) {
+        // size 有效：优先让 QImageReader 在解码阶段按比例缩放，效率更高
+        qCDebug(logDFMBase) << "thumbnail: image file size:" << imageSize << "for:" << filePath;
+
+        const QString &defaultMime = DMimeDatabase().mimeTypeForFile(QUrl::fromLocalFile(filePath)).name();
+        if (imageSize.width() > size || imageSize.height() > size || defaultMime == DFMGLOBAL_NAMESPACE::Mime::kTypeImageSvgXml) {
+            qCDebug(logDFMBase) << "thumbnail: scaling image from" << imageSize << "to fit size:" << size;
+            reader.setScaledSize(imageSize.scaled(size, size, Qt::KeepAspectRatio));
+        }
+
+        if (!reader.read(&image)) {
+            qCWarning(logDFMBase) << "thumbnail: failed to read image file:" << filePath
+                                  << "error:" << reader.errorString();
+            return image;
+        }
+    } else {
+        // 注意：icns 等格式的 QImageReader::size() 会返回 (-1,-1) 无效值，但文件本身是正常的、
+        // 可被 read() 解码。这里不再仅凭 size 无效就直接判定文件损坏，而是直接尝试 read()：
+        //  - 若 read() 失败，则认为文件确实损坏（保留对损坏文件的处理，不再读取其图像数据，
+        //    避免 arm 平台上损坏 icns 文件可能导致的递归循环问题）；
+        //  - 若 read() 成功，则对解码结果按需缩放，修复 icns 缩略图不显示的问题。
+        qCDebug(logDFMBase) << "thumbnail: image file reports invalid size, attempting direct read for:" << filePath;
+        if (!reader.read(&image)) {
+            qCWarning(logDFMBase) << "thumbnail: image file has invalid size and cannot be decoded:" << filePath
+                                  << "error:" << reader.errorString();
+            return image;
+        }
+
+        if (image.width() > size || image.height() > size) {
+            qCDebug(logDFMBase) << "thumbnail: scaling decoded image from" << image.size() << "to fit size:" << size;
+            image = image.scaled(size, size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        }
     }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.cpp
@@ -415,7 +415,13 @@ void EraseJob::work()
     if (!mediaChangDected()) {
         ret = false;
         fmWarning() << "Device disconnected:" << curDevId;
-        emit requestFailureDialog(static_cast<int>(curJobType), QObject::tr("Device disconnected"), {});
+    }
+
+    if (!ret) {
+        failureDialogShown = true;
+        emit requestFailureDialog(static_cast<int>(curJobType),
+                                 lastError.isEmpty() ? QObject::tr("Device disconnected") : lastError,
+                                 lastSrcMessages);
     }
 
     comfort();

--- a/src/plugins/common/dfmplugin-burn/utils/burnjob.h
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjob.h
@@ -63,6 +63,8 @@ public:
     void setProperty(PropertyType type, const QVariant &val);
     void addTask();
 
+    bool failureDialogShown {};
+
 protected:
     virtual bool fileSystemLimitsValid();
     virtual void updateMessage(JobInfoPointer ptr);

--- a/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
+++ b/src/plugins/common/dfmplugin-burn/utils/burnjobmanager.cpp
@@ -44,7 +44,7 @@ void BurnJobManager::startEraseDisc(const QString &dev)
     initBurnJobConnect(job);
     connect(qobject_cast<EraseJob *>(job), &EraseJob::eraseFinished, this, [job, this](bool result) {
         startAuditLogForEraseDisc(job->currentDeviceInfo(), result);
-        if (!result) {
+        if (!result && !job->failureDialogShown) {
             DialogManagerInstance->showErrorDialog(tr("Erase failed"),
                                                    tr("Unable to complete disc erasure. "
                                                       "This may be due to read/write limitations or the disc media status. "
@@ -263,7 +263,10 @@ void BurnJobManager::showOpticalJobFailureDialog(int type, const QString &err, c
     QWidget *detailsw = new QWidget(&d);
     detailsw->setLayout(new QVBoxLayout());
     QTextEdit *te = new QTextEdit();
-    te->setPlainText(details.join('\n'));
+    QStringList detailContent = details;
+    if (detailContent.isEmpty() && !err.isEmpty())
+        detailContent << err;
+    te->setPlainText(detailContent.join('\n'));
     te->setReadOnly(true);
     te->hide();
     detailsw->layout()->addWidget(te);

--- a/src/plugins/common/dfmplugin-dirshare/dirsharemenu/dirsharemenuscene.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/dirsharemenu/dirsharemenuscene.cpp
@@ -120,20 +120,7 @@ bool DirShareMenuScene::triggered(QAction *action)
         return true;
     } else if (key == ShareActionId::kActRemoveShareKey) {
         QString filePath = u.path();
-
-        // Get share info before removing to check if it's anonymous share
-        auto shareInfo = UserShareHelperInstance->shareInfoByPath(filePath);
-        bool wasAnonymous = shareInfo.value(ShareInfoKeys::kAnonymous).toBool();
-
-        // Remove share
-        bool success = UserShareHelperInstance->removeShareByPath(filePath);
-
-        // Restore permissions if it was anonymous share
-        if (success && wasAnonymous) {
-            AnonymousPermissionManager::instance()->restoreDirectoryPermissions(filePath);
-            AnonymousPermissionManager::instance()->restoreHomeDirectoryIfNoAnonymousShares();
-        }
-
+        UserShareHelperInstance->removeShareByPath(filePath);
         return true;
     }
 

--- a/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/utils/usersharehelper.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "usersharehelper.h"
+#include "anonymouspermissionmanager.h"
 #include "sharewatchermanager.h"
 
 #include <dfm-base/dfm_global_defines.h>
@@ -19,6 +20,7 @@
 #include <QDBusInterface>
 #include <QDBusConnection>
 #include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
 #include <QDBusReply>
 #include <QDBusUnixFileDescriptor>
 #include <QDebug>
@@ -32,6 +34,7 @@
 #include <QSettings>
 #include <QTemporaryFile>
 
+#include <limits>
 #include <pwd.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -48,6 +51,8 @@ static constexpr char kFuncIsPasswordSet[] { "IsUserSharePasswordSet" };
 static constexpr char kFuncSetPasswd[] { "SetUserSharePassword" };
 static constexpr char kFuncCloseShare[] { "CloseSmbShareByShareName" };
 }   // namespace DaemonServiceIFace
+
+static constexpr int kCloseShareAsyncTimeoutMs = std::numeric_limits<int>::max();
 
 UserShareHelper *UserShareHelper::instance()
 {
@@ -477,17 +482,39 @@ void UserShareHelper::initMonitorPath()
 bool UserShareHelper::removeShareByShareName(const QString &name, bool silent)
 {
     QDBusInterface *interface = getUserShareInterface();
-    QDBusReply<bool> reply = interface->asyncCall(DaemonServiceIFace::kFuncCloseShare, name, !silent);
-    if (reply.isValid() && reply.value()) {
-        fmDebug() << "share closed: " << name;
-        runNetCmd(QStringList() << "usershare"
-                                << "delete" << name);
-        return true;
-    }
+    const auto oldShareInfo = shareInfoByShareName(name);
+    const QString sharePath = oldShareInfo.value(ShareInfoKeys::kPath).toString();
+    const bool wasAnonymous = oldShareInfo.value(ShareInfoKeys::kAnonymous).toBool();
+    const int originalTimeout = interface->timeout();
+    if (originalTimeout != kCloseShareAsyncTimeoutMs)
+        interface->setTimeout(kCloseShareAsyncTimeoutMs);
 
-    fmWarning() << "share close failed: " << name << ", " << reply.error();
-    // TODO(xust) regular user cannot remove the sharing which shared by root user. and should raise an error dialog to notify user.
-    return false;
+    auto *watcher = new QDBusPendingCallWatcher(interface->asyncCall(DaemonServiceIFace::kFuncCloseShare, name, !silent), this);
+
+    if (originalTimeout != kCloseShareAsyncTimeoutMs)
+        interface->setTimeout(originalTimeout);
+
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher, name, sharePath, wasAnonymous](QDBusPendingCallWatcher *) {
+        QDBusPendingReply<bool> reply = *watcher;
+        watcher->deleteLater();
+
+        if (reply.isValid() && reply.value()) {
+            fmDebug() << "share closed: " << name;
+            runNetCmd(QStringList() << "usershare"
+                                    << "delete" << name);
+
+            if (wasAnonymous && !sharePath.isEmpty()) {
+                AnonymousPermissionManager::instance()->restoreDirectoryPermissions(sharePath);
+                AnonymousPermissionManager::instance()->restoreHomeDirectoryIfNoAnonymousShares();
+            }
+            return;
+        }
+
+        fmWarning() << "share close failed: " << name << ", " << reply.error();
+        emitShareRemoveFailed(sharePath);
+    });
+
+    return true;
 }
 
 void UserShareHelper::removeShareWhenShareFolderDeleted(const QString &deletedPath)
@@ -653,6 +680,8 @@ void UserShareHelper::emitShareRemoved(const QString &path)
 
 void UserShareHelper::emitShareRemoveFailed(const QString &path)
 {
+    Q_EMIT shareRemoveFailed(path);
+    dpfSignalDispatcher->publish(kEventSpace, "signal_Share_RemoveShareFailed", path);
 }
 
 UserShareHelper::UserShareHelper(QObject *parent)

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -522,22 +522,7 @@ bool ShareControlWidget::unshareFolder()
     }
 
     QString filePath = url.toLocalFile();
-
-    // Get share info before removing to check if it was anonymous share
-    auto oldShareInfo = UserShareHelperInstance->shareInfoByPath(filePath);
-    bool wasAnonymous = oldShareInfo.value(ShareInfoKeys::kAnonymous).toBool();
-
-    // Remove share
-    bool success = UserShareHelperInstance->removeShareByPath(filePath);
-
-    if (success && wasAnonymous) {
-        // Restore directory permissions (only if user didn't modify them)
-        AnonymousPermissionManager::instance()->restoreDirectoryPermissions(filePath);
-        // Check if we need to restore home directory permissions
-        AnonymousPermissionManager::instance()->restoreHomeDirectoryIfNoAnonymousShares();
-    }
-
-    return success;
+    return UserShareHelperInstance->removeShareByPath(filePath);
 }
 
 void ShareControlWidget::updateWidgetStatus(const QString &filePath)
@@ -573,6 +558,8 @@ void ShareControlWidget::updateWidgetStatus(const QString &filePath)
         sharePermissionSelector->setEnabled(false);
         shareAnonymousSelector->setEnabled(false);
     }
+
+    showMoreInfo(valid);
 }
 
 void ShareControlWidget::updateFile(const QUrl &oldOne, const QUrl &newOne)

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/errormessageandaction.cpp
@@ -9,6 +9,29 @@
 #include <QUrl>
 #include <QLabel>
 
+namespace {
+
+// Keep the conflict path text aligned with TaskWidget's actual path label width.
+static constexpr int kConflictPathLabelWidth { 468 };
+
+QString elideTemplatePath(const QFontMetrics &metrics, const QString &pattern, const QString &path, int width)
+{
+    static const QString kPlaceholderToken { QStringLiteral("__DFM_PATH_PLACEHOLDER__") };
+    const QString templatedText = pattern.arg(kPlaceholderToken);
+    const int placeholderPos = templatedText.indexOf(kPlaceholderToken);
+    if (placeholderPos < 0)
+        return metrics.elidedText(pattern.arg(path), Qt::ElideMiddle, width);
+
+    const QString prefix = templatedText.left(placeholderPos);
+    const QString suffix = templatedText.mid(placeholderPos + kPlaceholderToken.size());
+    const int fixedWidth = metrics.horizontalAdvance(prefix) + metrics.horizontalAdvance(suffix);
+    const int pathWidth = qMax(0, width - fixedWidth);
+
+    return prefix + metrics.elidedText(path, Qt::ElideMiddle, pathWidth) + suffix;
+}
+
+}
+
 namespace dfmplugin_fileoperations {
 QString ErrorMessageAndAction::errorMsg(const QUrl &from, const QUrl &to, const AbstractJobHandler::JobErrorType &error, const bool isTo, const QString &errorMsg, const bool allUsErrorMsg)
 {
@@ -244,25 +267,32 @@ void ErrorMessageAndAction::errorSrcAndDestString(const QUrl &from,
         *sorceMsg = QString(tr("%1 already exists in target folder")).arg(from.fileName());
         static QLabel label;
         static QFontMetrics metrics(label.font());
-        static Qt::TextElideMode em = Qt::TextElideMode::ElideMiddle;
-        int pre = metrics.horizontalAdvance(tr("Original path %1").arg(from.path()));
-        int last = metrics.horizontalAdvance(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()));
-        static int total = 350;
-        if (pre > total / 2 && last > total / 2) {
-            *toMsg = metrics.elidedText(tr("Original path %1").arg(from.path()), em, total / 2)
-                    + " " + metrics.elidedText(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()), em, total / 2);
+        const QString sourcePath = from.path();
+        const QString targetPath = FileOperationsUtils::parentUrl(to).path();
+        const QString originalPathPattern = tr("Original path %1");
+        const QString targetPathPattern = tr("Target path %1");
+        const QString separator { QStringLiteral(" ") };
+        const int separatorWidth = metrics.horizontalAdvance(separator);
+        const int availableWidth = kConflictPathLabelWidth - separatorWidth;
+        const int pre = metrics.horizontalAdvance(originalPathPattern.arg(sourcePath));
+        const int last = metrics.horizontalAdvance(targetPathPattern.arg(targetPath));
+
+        if (pre > availableWidth / 2 && last > availableWidth / 2) {
+            *toMsg = elideTemplatePath(metrics, originalPathPattern, sourcePath, availableWidth / 2)
+                    + separator
+                    + elideTemplatePath(metrics, targetPathPattern, targetPath, availableWidth - availableWidth / 2);
             return;
         }
-        if (pre + last > total) {
-            *toMsg = pre > total / 2
-                    ? metrics.elidedText(tr("Original path %1").arg(from.path()), em, total - last)
-                            + " " + tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path())
-                    : tr("Original path %1").arg(from.path())
-                            + " " + metrics.elidedText(tr("Target path %1").arg(FileOperationsUtils::parentUrl(to).path()), em, total - pre);
+        if (pre + last > availableWidth) {
+            *toMsg = pre > availableWidth / 2
+                    ? elideTemplatePath(metrics, originalPathPattern, sourcePath, availableWidth - last)
+                            + separator + targetPathPattern.arg(targetPath)
+                    : originalPathPattern.arg(sourcePath)
+                            + separator + elideTemplatePath(metrics, targetPathPattern, targetPath, availableWidth - pre);
             return;
         }
         *toMsg = QString(tr("Original path %1 Target path %2"))
-                         .arg(from.path(), FileOperationsUtils::parentUrl(to).path());
+                         .arg(sourcePath, targetPath);
     }
     return;
 }

--- a/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
+++ b/src/plugins/common/dfmplugin-menu/menuscene/fileoperatormenuscene.cpp
@@ -126,7 +126,7 @@ bool FileOperatorMenuScene::create(QMenu *parent)
         }
 
         const auto mimeType = focusFileInfo->nameOf(NameInfoType::kMimeTypeName);
-        QList<QVariant> supportedTypes = { "image/jpeg", "image/png", "image/bmp", "image/tiff", "image/gif" };
+        QList<QVariant> supportedTypes = { "image/jpeg", "image/png", "image/bmp", "image/tiff" };
         if (supportedTypes.contains(mimeType) && focusFileInfo->isAttributes(OptInfoType::kIsReadable)) {
             tempAction = parent->addAction(d->predicateName.value(ActionID::kSetAsWallpaper));
             d->predicateAction[ActionID::kSetAsWallpaper] = tempAction;

--- a/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/computerpropertydialog.cpp
@@ -395,8 +395,12 @@ QString ComputerInfoThread::cpuInfo() const
 
 QString ComputerInfoThread::memoryInfo() const
 {
+    qint64 installedMemory = UniversalUtils::computerMemory();
+    if (installedMemory <= 0)
+        installedMemory = DSysInfo::memoryInstalledSize();
+
     return QString("%1 (%2 %3)")
-            .arg(formatCap(DSysInfo::memoryInstalledSize(), 1024, 0))
+            .arg(formatCap(installedMemory, 1024, 0))
             .arg(formatCap(DSysInfo::memoryTotalSize()))
             .arg(tr("Available"));
 }

--- a/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
@@ -15,6 +15,9 @@
 #include <QPainter>
 #include <QUrl>
 #include <QIcon>
+#include <QTextBlock>
+#include <QTextCursor>
+#include <QTextFragment>
 
 #include <random>
 #include <mutex>
@@ -275,22 +278,45 @@ void TagHelper::crumbEditInputFilter(DCrumbEdit *edit)
     if (!edit)
         return;
 
-    QString srcTcxt = edit->toPlainText().remove(QChar::ObjectReplacementCharacter);
     QRegularExpression rx("[\\\\/\':\\*\\?\"<>|%&]");
-    if (!srcTcxt.isEmpty() && srcTcxt.contains(rx)) {
-        edit->textCursor().document()->setPlainText(srcTcxt.remove(rx));
-        const auto &tagsColors = TagManager::instance()->getTagsColor(edit->crumbList());
-        edit->setProperty("updateCrumbsColor", true);
 
-        for (auto it = tagsColors.begin(); it != tagsColors.end(); ++it) {
-            DCrumbTextFormat format = edit->makeTextFormat();
-            format.setText(it.key());
-            format.setBackground(QBrush(it.value()));
-            format.setBackgroundRadius(5);
-            edit->insertCrumb(format, 0);
+    // Pass 1: collect ranges to sanitize without mutating the document.
+    //         QTextBlock::iterator holds internal pointers into the
+    //         fragment table; mutating during iteration can invalidate them.
+    struct Range
+    {
+        int pos;
+        int len;
+        QString newText;
+    };
+    QList<Range> ranges;
+    for (QTextBlock block = edit->textCursor().document()->begin(); block.isValid(); block = block.next()) {
+        for (auto it = block.begin(); it != block.end(); ++it) {
+            QTextFragment frag = it.fragment();
+            if (!frag.isValid())
+                continue;
+            QString text = frag.text();
+            // skip crumb objects (ObjectReplacementCharacter)
+            if (text.contains(QChar::ObjectReplacementCharacter))
+                continue;
+            if (text.contains(rx))
+                ranges.append({ frag.position(), frag.length(), text.remove(rx) });
         }
-        edit->setProperty("updateCrumbsColor", false);
     }
+
+    if (ranges.isEmpty())
+        return;
+
+    // Pass 2: apply changes from end to start so earlier positions stay valid.
+    QTextCursor cursor(edit->textCursor());
+    cursor.beginEditBlock();
+    for (int i = ranges.size() - 1; i >= 0; --i) {
+        const auto &r = ranges[i];
+        cursor.setPosition(r.pos);
+        cursor.setPosition(r.pos + r.len, QTextCursor::KeepAnchor);
+        cursor.insertText(r.newText);
+    }
+    cursor.endEditBlock();
 }
 
 void TagHelper::initTagColorDefines()

--- a/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
@@ -40,6 +40,10 @@ public:
     inline QRect relativeRect(const QRect &avRect, const QRect &geometry)
     {
         QPoint relativePos = avRect.topLeft() - geometry.topLeft();
+        // The desktop root already starts at the screen origin; keep top/left
+        // dock offsets out of the child view origin.
+        relativePos.setX(qMin(relativePos.x(), 0));
+        relativePos.setY(qMin(relativePos.y(), 0));
         return QRect(relativePos, avRect.size());
     }
 

--- a/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
+++ b/src/plugins/desktop/ddplugin-canvas/private/canvasmanager_p.h
@@ -40,10 +40,6 @@ public:
     inline QRect relativeRect(const QRect &avRect, const QRect &geometry)
     {
         QPoint relativePos = avRect.topLeft() - geometry.topLeft();
-        // The desktop root already starts at the screen origin; keep top/left
-        // dock offsets out of the child view origin.
-        relativePos.setX(qMin(relativePos.x(), 0));
-        relativePos.setY(qMin(relativePos.y(), 0));
         return QRect(relativePos, avRect.size());
     }
 

--- a/src/plugins/desktop/ddplugin-core/screen/screenqt.cpp
+++ b/src/plugins/desktop/ddplugin-core/screen/screenqt.cpp
@@ -8,6 +8,7 @@
 #include <qpa/qplatformscreen.h>
 #include <QDebug>
 #include <QApplication>
+#include <QWindow>
 
 namespace GlobalPrivate {
 static QRect dealRectRatio(QRect orgRect)
@@ -64,13 +65,29 @@ QRect ScreenQt::availableGeometry() const
 
     DockRect dockrectI = DockInfoIns->frontendWindowRect();
 
-    const qreal ratio = qApp->primaryScreen()->devicePixelRatio();
+    // wayland 分数缩放下不能用 QScreen::devicePixelRatio()：它是 wl_output 的整数 scale(真实 1.25
+    // 会被报成 2)，与逻辑几何不自洽，用它换算物理 dock 会少减、导致最底行被遮。真实分数缩放由合成器
+    // 经 wp_fractional_scale 按 surface 下发，只体现在“窗口”的 devicePixelRatio 上，故取本屏对应顶层
+    // 窗口的 devicePixelRatio；无窗口(早期/异常)时回退到本屏 devicePixelRatio 并钳到 >=1。
+    qreal ratio = qscreen->devicePixelRatio();
+    for (QWindow *w : qApp->topLevelWindows()) {
+        if (w->screen() == qscreen && w->devicePixelRatio() > 0) {
+            ratio = w->devicePixelRatio();
+            break;
+        }
+    }
+    if (ratio < 1.0)
+        ratio = 1.0;
     const QRect hRect = handleGeometry();
 
-    if (!hRect.contains(dockrectI)) {
+    // treeland 下 handleGeometry() 返回逻辑坐标，与物理 dock 错位会误判“不在本屏”，故补一次逻辑判断：
+    // 仅当物理判断与逻辑判断都认为 dock 不在本屏时，才退回全屏几何。
+    const QRect dockrectLogical(static_cast<int>(dockrectI.x / ratio), static_cast<int>(dockrectI.y / ratio),
+                                static_cast<int>(dockrectI.width / ratio), static_cast<int>(dockrectI.height / ratio));
+    if (!hRect.contains(dockrectI) && !ret.contains(dockrectLogical)) {
         fmDebug() << "Dock not contained in screen geometry, using full screen - screen:" << name()
                   << "handleGeometry:" << hRect << "dockRect:" << QRect(dockrectI)
-                  << "ratio:" << ratio;
+                  << "dockRectLogical:" << dockrectLogical << "ratio:" << ratio;
         return ret;
     }
 

--- a/src/plugins/filedialog/core/views/filedialog.cpp
+++ b/src/plugins/filedialog/core/views/filedialog.cpp
@@ -1161,6 +1161,13 @@ void FileDialog::initConnect()
 {
     connect(statusBar()->acceptButton(), &QPushButton::clicked, this, &FileDialog::onAcceptButtonClicked);
     connect(statusBar()->rejectButton(), &QPushButton::clicked, this, &FileDialog::onRejectButtonClicked);
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged, this,
+            [this](const QString &cfg, const QString &key) {
+                if (cfg != QString("org.deepin.dde.file-manager.sidebar") || key != QString("itemVisiable"))
+                    return;
+                if (d->acceptMode == QFileDialog::AcceptSave)
+                    urlSchemeEnable("recent", false);
+            });
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     connect(statusBar()->comboBox(),
             static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated),

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -843,7 +843,14 @@ void DiskEncryptMenuScene::updateActions()
         }
     } else if (EventsHandler::instance()->unfinishedDecryptJob() == param.devDesc
                || EventsHandler::instance()->unfinishedDecryptJob() == param.devPhy) {
-        actions[kActIDResumeDecrypt]->setVisible(true);
+        // Defensive check: only show "Continue decrypt" if device is actually LUKS encrypted.
+        // This handles the case where the partition was reformatted after a decrypt job was interrupted.
+        const QString &idType = selectedItemInfo.value("IdType").toString();
+        if (idType == "crypto_LUKS") {
+            actions[kActIDResumeDecrypt]->setVisible(true);
+        } else {
+            fmInfo() << "Device has pending decrypt job but is not LUKS (may have been reformatted), hiding resume decrypt option:" << param.devDesc << "idType:" << idType;
+        }
     } else {
         actions[kActIDEncrypt]->setVisible(true);
     }

--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.cpp
@@ -26,6 +26,11 @@ RecentFileInfo::~RecentFileInfo()
 {
 }
 
+void RecentFileInfo::setLastReadTime(const QDateTime &time)
+{
+    lastReadTime = time;
+}
+
 bool RecentFileInfo::exists() const
 {
     return ProxyFileInfo::exists() || url == RecentHelper::rootUrl();
@@ -120,6 +125,8 @@ QString RecentFileInfo::displayOf(const FileInfo::DisplayInfoType type) const
 QVariant RecentFileInfo::timeOf(const FileTimeType type) const
 {
     switch (type) {
+    case TimeInfoType::kLastRead:
+        return lastReadTime;
     case TimeInfoType::kCustomerSupport:
         return timeOf(TimeInfoType::kLastRead);
     default:

--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.h
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfileinfo.h
@@ -9,12 +9,16 @@
 
 #include <dfm-base/interfaces/proxyfileinfo.h>
 
+#include <QDateTime>
+
 namespace dfmplugin_recent {
 class RecentFileInfo : public DFMBASE_NAMESPACE::ProxyFileInfo
 {
 public:
     explicit RecentFileInfo(const QUrl &url);
     ~RecentFileInfo() override;
+
+    void setLastReadTime(const QDateTime &time);
 
     virtual bool exists() const override;
     virtual QFile::Permissions permissions() const override;
@@ -28,6 +32,9 @@ public:
 
     virtual QString displayOf(const DisplayInfoType type) const override;
     virtual QVariant timeOf(const FileTimeType type) const override;
+
+private:
+    QDateTime lastReadTime;
 };
 
 using RecentFileInfoPointer = QSharedPointer<RecentFileInfo>;

--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "recentfilewatcher.h"
+#include "private/recentfilewatcher_p.h"
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_recent;
+
+RecentFileWatcherPrivate::RecentFileWatcherPrivate(const QUrl &fileUrl, RecentFileWatcher *qq)
+    : AbstractFileWatcherPrivate(fileUrl, qq)
+{
+}
+
+bool RecentFileWatcherPrivate::start()
+{
+    started = true;
+    return true;
+}
+
+bool RecentFileWatcherPrivate::stop()
+{
+    started = false;
+    return true;
+}
+
+RecentFileWatcher::RecentFileWatcher(const QUrl &url, QObject *parent)
+    : AbstractFileWatcher(new RecentFileWatcherPrivate(url, this), parent)
+{
+    dptr = static_cast<RecentFileWatcherPrivate *>(d.data());
+}
+
+RecentFileWatcher::~RecentFileWatcher()
+{
+}

--- a/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.h
+++ b/src/plugins/filemanager/dfmplugin-recent/files/recentfilewatcher.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RECENTFILEWATCHER_H
+#define RECENTFILEWATCHER_H
+
+#include "dfmplugin_recent_global.h"
+
+#include <dfm-base/interfaces/abstractfilewatcher.h>
+
+namespace dfmplugin_recent {
+
+class RecentFileWatcherPrivate;
+class RecentFileWatcher : public DFMBASE_NAMESPACE::AbstractFileWatcher
+{
+    Q_OBJECT
+
+public:
+    explicit RecentFileWatcher() = delete;
+    explicit RecentFileWatcher(const QUrl &url, QObject *parent = nullptr);
+    ~RecentFileWatcher() override;
+
+private:
+    RecentFileWatcherPrivate *dptr;
+};
+
+}
+
+#endif   // RECENTFILEWATCHER_H

--- a/src/plugins/filemanager/dfmplugin-recent/private/recentfilewatcher_p.h
+++ b/src/plugins/filemanager/dfmplugin-recent/private/recentfilewatcher_p.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RECENTFILEWATCHER_P_H
+#define RECENTFILEWATCHER_P_H
+
+#include <dfm-base/interfaces/private/abstractfilewatcher_p.h>
+
+namespace dfmplugin_recent {
+
+class RecentFileWatcher;
+class RecentFileWatcherPrivate : public DFMBASE_NAMESPACE::AbstractFileWatcherPrivate
+{
+    friend RecentFileWatcher;
+
+public:
+    explicit RecentFileWatcherPrivate(const QUrl &fileUrl, RecentFileWatcher *qq);
+
+public:
+    bool start() override;
+    bool stop() override;
+};
+
+}
+
+#endif   // RECENTFILEWATCHER_P_H

--- a/src/plugins/filemanager/dfmplugin-recent/recent.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/recent.cpp
@@ -5,6 +5,7 @@
 #include "recent.h"
 #include "files/recentfileinfo.h"
 #include "files/recentdiriterator.h"
+#include "files/recentfilewatcher.h"
 #include "utils/recentmanager.h"
 #include "utils/recentfilehelper.h"
 #include "menus/recentmenuscene.h"
@@ -45,6 +46,7 @@ void Recent::initialize()
     // 注册Scheme为"recent"的扩展的文件信息 本地默认文件的
     InfoFactory::regClass<RecentFileInfo>(RecentHelper::scheme());
     DirIteratorFactory::regClass<RecentDirIterator>(RecentHelper::scheme());
+    WatcherFactory::regClass<RecentFileWatcher>(RecentHelper::scheme());
 
     followEvents();
     bindEvents();

--- a/src/plugins/filemanager/dfmplugin-recent/recent.json
+++ b/src/plugins/filemanager/dfmplugin-recent/recent.json
@@ -23,6 +23,7 @@
                 "VisiableControl" : "recent",
                 "ReportName" : "Recent"
             }
-        }]
+        }],
+        "PluginSchemes": ["recent"]
     }
 }

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
@@ -38,6 +38,12 @@ DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 using namespace GlobalServerDefines;
 
+// Batch processing parameters: process a fixed number of pending recent items
+// per timer tick, yielding to the event loop between batches to keep the UI
+// responsive during startup when the recently-used list is large.
+static constexpr int kBatchIntervalMs = 10;   // timer tick interval (ms)
+static constexpr int kBatchSize = 50;          // items processed per tick
+
 RecentManager *RecentManager::instance()
 {
     Q_ASSERT(qApp->thread() == QThread::currentThread());
@@ -73,6 +79,9 @@ QString RecentManager::getRecentOriginPaths(const QUrl &url) const
 RecentManager::RecentManager(QObject *parent)
     : QObject(parent)
 {
+    batchTimer.setInterval(kBatchIntervalMs);
+    batchTimer.setSingleShot(false);
+    connect(&batchTimer, &QTimer::timeout, this, &RecentManager::processPendingItems);
 }
 
 RecentManager::~RecentManager()
@@ -84,20 +93,51 @@ void RecentManager::resetRecentNodes()
     auto reply = recentDBusInterce->GetItemsInfo();
     reply.waitForFinished();
     const QVariantList &topLevelList = reply.value();
+
+    // Collect all items into the pending queue first, then process them in
+    // batches via a timer so the main thread can stay responsive between
+    // batches. Previously the whole list was processed in a single
+    // synchronous for-loop, which blocked the event loop and caused the UI
+    // to freeze when the recently-used list was large.
     for (const auto &value : topLevelList) {
         QDBusArgument dbusArg = value.value<QDBusArgument>();
-
         QVariantMap map;
-        dbusArg >> map;   // 直接将QDBusArgument解包为QVariantMap
-
-        if (!map.isEmpty()) {
-            auto path = map.value(RecentProperty::kPath).toString();
-            auto href = map.value(RecentProperty::kHref).toString();
-            auto modified = map.value(RecentProperty::kModified).toLongLong();
-            onItemAdded(path, href, modified);
-        } else {
+        dbusArg >> map;
+        if (map.isEmpty()) {
             fmWarning() << "Map is empty or could not be converted from DBus argument";
+            continue;
         }
+        PendingItem item {
+            map.value(RecentProperty::kPath).toString(),
+            map.value(RecentProperty::kHref).toString(),
+            map.value(RecentProperty::kModified).toLongLong()
+        };
+        if (!item.path.isEmpty())
+            pendingItems.enqueue(item);
+    }
+
+    fmInfo() << "Queued" << pendingItems.size()
+             << "recent items for batch processing";
+
+    // Kick off batch processing. The timer fires periodically, processing a
+    // fixed number of items per tick and yielding back to the event loop in
+    // between so painting/input can be handled.
+    if (!batchTimer.isActive())
+        batchTimer.start();
+}
+
+void RecentManager::processPendingItems()
+{
+    int processed = 0;
+    while (!pendingItems.isEmpty() && processed < kBatchSize) {
+        const auto &item = pendingItems.dequeue();
+        onItemAdded(item.path, item.href, item.modified);
+        ++processed;
+    }
+
+    if (pendingItems.isEmpty()) {
+        batchTimer.stop();
+        fmInfo() << "Batch processing of recent items finished";
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.cpp
@@ -4,6 +4,7 @@
 
 #include "recentmanager.h"
 #include "events/recenteventcaller.h"
+#include "files/recentfileinfo.h"
 
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
@@ -42,7 +43,7 @@ using namespace GlobalServerDefines;
 // per timer tick, yielding to the event loop between batches to keep the UI
 // responsive during startup when the recently-used list is large.
 static constexpr int kBatchIntervalMs = 10;   // timer tick interval (ms)
-static constexpr int kBatchSize = 50;          // items processed per tick
+static constexpr int kBatchSize = 50;   // items processed per tick
 
 RecentManager *RecentManager::instance()
 {
@@ -207,12 +208,14 @@ void RecentManager::onItemAdded(const QString &path, const QString &href, qint64
         return;
     }
 
-    fmDebug() << "Adding recent item to cache:" << url;
+    fmDebug() << "Adding recent item to cache:" << url << modified;
     RecentItem item;
     item.fileInfo = info;
     item.originPath = href;
     recentItems.insert(url, item);
-    item.fileInfo->cacheAttribute(DFMIO::DFileInfo::AttributeID::kTimeAccess, modified);
+    auto recentInfo = item.fileInfo.dynamicCast<RecentFileInfo>();
+    if (recentInfo)
+        recentInfo->setLastReadTime(QDateTime::fromSecsSinceEpoch(modified));
 
     QSharedPointer<AbstractFileWatcher> watcher = WatcherCache::instance().getCacheWatcher(RecentHelper::rootUrl());
     if (watcher)
@@ -250,8 +253,9 @@ void RecentManager::onItemChanged(const QString &path, qint64 modified)
     }
 
     fmDebug() << "Updating recent item access time - path:" << path << "timestamp:" << modified;
-    QDateTime dateTime { QDateTime::fromSecsSinceEpoch(modified) };
-    recentItems[url].fileInfo->cacheAttribute(DFMIO::DFileInfo::AttributeID::kTimeAccess, modified);
+    auto recentInfo = recentItems[url].fileInfo.dynamicCast<RecentFileInfo>();
+    if (recentInfo)
+        recentInfo->setLastReadTime(QDateTime::fromSecsSinceEpoch(modified));
 
     QSharedPointer<AbstractFileWatcher> watcher = WatcherCache::instance().getCacheWatcher(RecentHelper::rootUrl());
     if (watcher)

--- a/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.h
+++ b/src/plugins/filemanager/dfmplugin-recent/utils/recentmanager.h
@@ -68,6 +68,7 @@ private:
     explicit RecentManager(QObject *parent = nullptr);
     ~RecentManager() override;
     void resetRecentNodes();
+    void processPendingItems();
 
 public slots:
     void reloadRecent();
@@ -76,6 +77,13 @@ public slots:
     void onItemChanged(const QString &path, qint64 modified);
 
 private:
+    struct PendingItem
+    {
+        QString path;
+        QString href;
+        qint64 modified {};
+    };
+
     QScopedPointer<RecentManagerDBusInterface> recentDBusInterce;
     struct RecentItem
     {
@@ -83,6 +91,8 @@ private:
         QString originPath;
     };
     QMap<QUrl, RecentItem> recentItems;
+    QQueue<PendingItem> pendingItems;
+    QTimer batchTimer;
 };
 }   // namespace dfmplugin_recent
 #endif   // RECENTMANAGER_H

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -31,8 +31,17 @@ dfmplugin_search::SearchEventReceiver *dfmplugin_search::SearchEventReceiver::in
 
 void SearchEventReceiver::handleSearch(quint64 winId, const QString &keyword)
 {
-    auto window = FMWindowsIns.findWindowById(winId);
-    Q_ASSERT(window);
+    if (winId < 1) {
+        fmWarning() << "Ignore search request with invalid window id";
+        return;
+    }
+
+    auto *window = FMWindowsIns.findWindowById(winId);
+    if (!window) {
+        // Fix: shutdown can outlive a delayed search callback from the titlebar.
+        fmWarning() << "Ignore search request because window no longer exists:" << winId;
+        return;
+    }
 
     const auto &curUrl = window->currentUrl();
     if (ProtocolUtils::isRemoteFile(curUrl)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -49,6 +49,9 @@ class SideBarViewPrivate : public QObject
     bool checkTargetEnable(const QUrl &targetUrl);
     bool canEnter(QDragEnterEvent *event);
     bool canMove(QDragMoveEvent *event);
+    void updateHoverIndex(const QModelIndex &index);
+    void clearHoverIndex();
+    bool isCursorInsideIndex(const QModelIndex &index, const QPoint &fallbackPos) const;
 
 private Q_SLOTS:
     void currentChanged(const QModelIndex &curIndex);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -21,6 +21,7 @@
 
 #include <QtConcurrent>
 #include <QDebug>
+#include <QCursor>
 #include <QMimeData>
 #include <QApplication>
 #include <QMouseEvent>
@@ -87,6 +88,48 @@ void SideBarViewPrivate::setTransparentPalette()
 void SideBarViewPrivate::restorePalette()
 {
     q->setPalette(originPalette);
+}
+
+void SideBarViewPrivate::updateHoverIndex(const QModelIndex &index)
+{
+    if (currentHoverIndex == index)
+        return;
+
+    const QModelIndex previousHoverIndex = currentHoverIndex;
+    currentHoverIndex = index;
+
+    if (previousHoverIndex.isValid())
+        q->update(previousHoverIndex);
+    if (currentHoverIndex.isValid())
+        q->update(currentHoverIndex);
+}
+
+void SideBarViewPrivate::clearHoverIndex()
+{
+    updateHoverIndex(QModelIndex());
+}
+
+bool SideBarViewPrivate::isCursorInsideIndex(const QModelIndex &index, const QPoint &fallbackPos) const
+{
+    if (!index.isValid())
+        return false;
+
+    const QRect itemRect = q->visualRect(index);
+    const QPoint globalPos = QCursor::pos();
+    if (QWidget *windowWidget = q->window()) {
+        const QPoint windowPos = windowWidget->mapFromGlobal(globalPos);
+        if (QWidget *targetWidget = windowWidget->childAt(windowPos)) {
+            if (!(targetWidget == q || q->isAncestorOf(targetWidget)))
+                return false;
+
+            const QPoint cursorPos = q->viewport()->mapFromGlobal(globalPos);
+            return itemRect.contains(cursorPos);
+        }
+    }
+
+    // Fallback for compositor paths where childAt/global lookup is unavailable
+    // but the sidebar viewport still owns the active pointer hover state.
+    return q->viewport()->underMouse() && itemRect.contains(fallbackPos);
 }
 
 void SideBarViewPrivate::notifyOrderChanged()
@@ -324,7 +367,7 @@ void SideBarView::mouseReleaseEvent(QMouseEvent *event)
 
 void SideBarView::dragEnterEvent(QDragEnterEvent *event)
 {
-    d->currentHoverIndex = QModelIndex();
+    d->clearHoverIndex();
     d->updateDFMMimeData(event);
     if (event->source() != this) {
         d->urlsForDragEvent = d->dfmMimeData.isValid() ? d->dfmMimeData.urls() : event->mimeData()->urls();
@@ -366,12 +409,20 @@ void SideBarView::dragEnterEvent(QDragEnterEvent *event)
 
 void SideBarView::dragMoveEvent(QDragMoveEvent *event)
 {
-    if (event->source() != this)
-        d->currentHoverIndex = indexAt(event->position().toPoint());
+    const QPoint eventPos = event->position().toPoint();
+    const QModelIndex hoverIndex = indexAt(eventPos);
 
-    SideBarItem *item = itemAt(event->position().toPoint());
+    if (event->source() != this)
+        d->updateHoverIndex(hoverIndex);
+
+    if (event->source() != this && !d->isCursorInsideIndex(hoverIndex, eventPos)) {
+        d->clearHoverIndex();
+        event->ignore();
+        return;
+    }
+
+    SideBarItem *item = itemAt(eventPos);
     if (item) {
-        viewport()->update();
         if (!d->canMove(event)) {
             event->setDropAction(Qt::IgnoreAction);
             event->ignore();
@@ -394,23 +445,21 @@ void SideBarView::dragLeaveEvent(QDragLeaveEvent *event)
     d->draggedUrl = QUrl("");
     d->isItemDragged = false;
     setState(State::NoState);
-
-    if (d->currentHoverIndex.isValid()) {
-        update(d->currentHoverIndex);
-        d->currentHoverIndex = QModelIndex();
-    }
+    d->clearHoverIndex();
 }
 
 void SideBarView::dropEvent(QDropEvent *event)
 {
-    d->currentHoverIndex = QModelIndex();
+    const QPoint eventPos = event->position().toPoint();
+    const QModelIndex hoverIndex = indexAt(eventPos);
+    d->clearHoverIndex();
     d->isItemDragged = false;
     if (d->draggedUrl.isValid()) {   // select the dragged item when dropped.
         d->notifyOrderChanged();   // notify to update the persistence data
     }
 
-    d->dropPos = event->position().toPoint();
-    SideBarItem *item = itemAt(event->position().toPoint());
+    d->dropPos = eventPos;
+    SideBarItem *item = itemAt(eventPos);
     if (!item)
         return DTreeView::dropEvent(event);
 
@@ -420,12 +469,7 @@ void SideBarView::dropEvent(QDropEvent *event)
     fmDebug() << "target item: " << item->group() << "|" << item->text() << "|" << item->url();
     fmDebug() << "item->itemInfo().finalUrl: " << item->itemInfo().finalUrl;
     fmDebug() << "item flags:" << item->flags();
-    // wayland环境下QCursor::pos()在此场景中不能获取正确的光标当前位置，代替方案为直接使用QDropEvent::pos()
-    // QDropEvent::pos() 实际上就是drop发生时光标在该widget坐标系中的position (mapFromGlobal(QCursor::pos()))
-    // 但rc本来就是由event->pos()计算item得出的Rect，这样判断似乎就没有意义了（虽然原来的逻辑感觉也没什么意义）
-    QPoint pt = event->position().toPoint();   // mapFromGlobal(QCursor::pos());
-    QRect rc = visualRect(indexAt(event->position().toPoint()));
-    if (!rc.contains(pt)) {
+    if (!d->isCursorInsideIndex(hoverIndex, eventPos)) {
         fmDebug() << "mouse not in my area";
         return DTreeView::dropEvent(event);
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/events/titlebareventcaller.cpp
@@ -78,7 +78,10 @@ void TitleBarEventCaller::sendOpenTab(quint64 windowId, const QUrl &url)
 void TitleBarEventCaller::sendSearch(QWidget *sender, const QString &keyword)
 {
     quint64 id = TitleBarHelper::windowId(sender);
-    Q_ASSERT(id > 0);
+    if (id < 1) {
+        fmWarning() << "Cannot send search start signal: invalid window id";
+        return;
+    }
 
     fmInfo() << "Sending search start signal, window id:" << id << "keyword:" << keyword;
     dpfSignalDispatcher->publish("dfmplugin_titlebar", "signal_Search_Start", id, keyword);

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -257,10 +257,20 @@ void TitleBarHelper::handleJumpToPressed(QWidget *sender, const QString &text)
 void TitleBarHelper::handleSearch(QWidget *sender, const QString &text)
 {
     const auto &currentDir = QDir::currentPath();
+    const auto winId = windowId(sender);
+    if (winId < 1) {
+        fmWarning() << "Cannot start search: invalid window id";
+        return;
+    }
+
     QUrl currentUrl;
-    auto curTitleBar = findTileBarByWindowId(windowId(sender));
-    if (curTitleBar)
-        currentUrl = curTitleBar->currentUrl();
+    auto curTitleBar = findTileBarByWindowId(winId);
+    if (!curTitleBar) {
+        // Fix: the titlebar can already be gone while a delayed search callback is still pending.
+        fmWarning() << "Cannot start search: titlebar already removed for window id" << winId;
+        return;
+    }
+    currentUrl = curTitleBar->currentUrl();
 
     if (currentUrl.isValid()) {
         bool isDisableSearch = dpfSlotChannel->push("dfmplugin_search", "slot_Custom_IsDisableSearch", currentUrl).toBool();

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -24,6 +24,9 @@
 
 #include <QHBoxLayout>
 #include <QCoreApplication>
+#include <QGuiApplication>
+#include <QInputMethod>
+#include <QMetaObject>
 #include <QResizeEvent>
 #include <QKeyEvent>
 
@@ -380,6 +383,11 @@ void SearchEditWidget::handleFocusInEvent(QFocusEvent *e)
 {
     advancedButton->setVisible(true);
     updateSpacing(true);   // Advanced button is now visible
+
+    QMetaObject::invokeMethod(this, [this] {
+        if (searchEdit->lineEdit()->hasFocus())
+            QGuiApplication::inputMethod()->show();
+    }, Qt::QueuedConnection);
 }
 
 void SearchEditWidget::handleFocusOutEvent(QFocusEvent *e)

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -23,6 +23,7 @@
 #include <DPalette>
 
 #include <QHBoxLayout>
+#include <QCoreApplication>
 #include <QResizeEvent>
 #include <QKeyEvent>
 
@@ -41,6 +42,13 @@ SearchEditWidget::SearchEditWidget(QWidget *parent)
 {
     initUI();
     initConnect();
+    if (qApp) {
+        connect(qApp, &QCoreApplication::aboutToQuit, this, [this]() {
+            // Fix: stop delayed search before shutdown tears down the owning window.
+            delayTimer->stop();
+            pendingSearchText.clear();
+        });
+    }
     searchEdit->lineEdit()->installEventFilter(this);
     searchEdit->installEventFilter(this);
     advancedButton->installEventFilter(this);
@@ -249,6 +257,13 @@ void SearchEditWidget::performSearch()
     QString trimmedSearchText = pendingSearchText.trimmed();
     if (trimmedSearchText.isEmpty()) {
         fmDebug() << "Trimmed search text is empty, skipping search";
+        return;
+    }
+
+    if (TitleBarHelper::windowId(this) < 1) {
+        // Fix: ignore delayed search callbacks once the owner window is already invalid.
+        fmInfo() << "Skip delayed search because owner window is no longer valid";
+        pendingSearchText.clear();
         return;
     }
 

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -33,6 +33,7 @@
 #include <QIcon>
 #include <QUuid>
 #include <QUrlQuery>
+#include <QScreen>
 #include <QToolTip>
 
 #include <unistd.h>
@@ -103,6 +104,7 @@ public:
     void closeRightTabs(int index);
     void closeOtherTabs(int index);
     bool hasDragPreviewTab() const;
+    void showWindow() const;
 
 public:
     TabBar *q;
@@ -252,7 +254,7 @@ void TabBarPrivate::handleTabReleased(int index)
     }
 
     if (q->count() == 1) {
-        q->window()->show();
+        showWindow();
     } else {
         currentTabIndex = -1;
 
@@ -796,6 +798,31 @@ bool TabBarPrivate::hasDragPreviewTab() const
     return false;
 }
 
+void TabBarPrivate::showWindow() const
+{
+    // Position window near cursor for good visual interaction when tearing off the last tab
+    if (!(q->window()->windowState() & Qt::WindowMaximized)) {
+        QScreen *screen = WindowUtils::cursorScreen();
+        if (screen) {
+            const QRect availGeo = screen->availableGeometry();
+            const QPoint cursorPos = QCursor::pos();
+            const int winW = q->window()->width();
+            const int winH = q->window()->height();
+
+            // Place cursor near the top-center of the window (tab bar area)
+            int x = cursorPos.x() - winW / 2;
+            int y = cursorPos.y() - 20;   // slightly above cursor to align with tab bar
+
+            // Clamp to keep the window fully visible on screen
+            x = qMax(availGeo.left(), qMin(x, availGeo.right() - winW));
+            y = qMax(availGeo.top(), qMin(y, availGeo.bottom() - winH));
+
+            q->window()->move(x, y);
+        }
+    }
+    q->window()->show();
+}
+
 bool TabBarPrivate::canPinned(int index)
 {
     if (qAppName() != "dde-file-manager")
@@ -1235,7 +1262,7 @@ QPixmap TabBar::createDragPixmapFromTab(int index, const QStyleOptionTab &option
     painter.setRenderHint(QPainter::Antialiasing, true);
 
     // Hide window during drag: single tab in non-Wayland environment
-    if (!WindowUtils::isWayLand() && 1 == count()) {
+    if (!WindowUtils::isWayLand() && 1 == count() && !isPinned(index)) {
         this->window()->hide();
         fmDebug() << "Hide window during drag: single tab in non-Wayland environment";
     }

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
@@ -34,8 +34,13 @@
 #endif
 
 #include <QHBoxLayout>
+#include <QApplication>
 #include <QEvent>
+#include <QGuiApplication>
+#include <QInputMethod>
+#include <QMetaObject>
 #include <QResizeEvent>
+#include <QTimer>
 
 using namespace dfmplugin_titlebar;
 DFMBASE_USE_NAMESPACE
@@ -488,6 +493,7 @@ void TitleBarWidget::showAddrsssBar(const QUrl &url)
     crumbBar->hide();
     addressBar->show();
     addressBar->setFocus();
+    QGuiApplication::inputMethod()->show();
     addressBar->setCurrentUrl(url);
 }
 
@@ -500,7 +506,13 @@ void TitleBarWidget::showCrumbBar()
         addressBar->clear();
         addressBar->hide();
     }
-    setFocus();
+    QMetaObject::invokeMethod(this, [this] {
+        QWidget *focusWidget = QApplication::focusWidget();
+        if (!focusWidget || focusWidget == addressBar
+            || addressBar->isAncestorOf(focusWidget)) {
+            setFocus();
+        }
+    }, Qt::QueuedConnection);
 }
 
 void TitleBarWidget::showSearchFilterButton(bool visible)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.cpp
@@ -35,9 +35,19 @@ void SelectHelper::click(const QModelIndex &index)
 
 void SelectHelper::release()
 {
-    fmDebug() << "SelectHelper release event - clearing current selection and pressed index";
+    fmDebug() << "SelectHelper release event - clearing drag selection state";
     currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
     currentPressedIndex = QModelIndex();
+}
+
+void SelectHelper::prepareForModelTeardown()
+{
+    fmDebug() << "SelectHelper preparing for model teardown - clearing model-bound selection state";
+    lastPressedIndex = QModelIndex();
+    currentPressedIndex = QModelIndex();
+    currentSelection = QItemSelection();
+    lastSelection = QItemSelection();
 }
 
 void SelectHelper::setSelection(const QItemSelection &selection)

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/selecthelper.h
@@ -26,6 +26,7 @@ public:
     QModelIndex getCurrentPressedIndex() const;
     void click(const QModelIndex &index);
     void release();
+    void prepareForModelTeardown();
     void setSelection(const QItemSelection &selection);
     void selection(const QRect &rect, QItemSelectionModel::SelectionFlags flags);
     bool select(const QList<QUrl> &urls);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.cpp
@@ -518,6 +518,23 @@ QRect BaseItemDelegate::getExpandButtonRect(const QRectF &rect) const
     return buttonRect;
 }
 
+QRect BaseItemDelegate::getExpandButtonHitRect(const QStyleOptionViewItem &option) const
+{
+    return getExpandButtonHitRect(option.rect);
+}
+
+QRect BaseItemDelegate::getExpandButtonHitRect(const QRectF &rect) const
+{
+    const QRect visualRect = getExpandButtonRect(rect);
+
+    // Keep the arrow visuals unchanged while making the click target easier to hit.
+    QRect hitRect;
+    hitRect.setSize(QSize(qMax(visualRect.width(), 24), qMax(visualRect.height(), 24)));
+    hitRect.moveCenter(visualRect.center());
+
+    return hitRect;
+}
+
 QRect BaseItemDelegate::getGroupTextRect(const QStyleOptionViewItem &option) const
 {
     return getGroupTextRect(option.rect);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/baseitemdelegate.h
@@ -136,6 +136,8 @@ public:
 
     QRect getExpandButtonRect(const QStyleOptionViewItem &option) const;
     QRect getExpandButtonRect(const QRectF &rect) const;
+    QRect getExpandButtonHitRect(const QStyleOptionViewItem &option) const;
+    QRect getExpandButtonHitRect(const QRectF &rect) const;
 
 protected:
     explicit BaseItemDelegate(BaseItemDelegatePrivate &dd, FileViewHelper *parent);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -132,8 +132,11 @@ FileView::~FileView()
     }
 
     // 3. 断开信号连接
-    if (model()) {
-        disconnect(model(), nullptr, this, nullptr);
+    //    保存 model 指针: setModel(nullptr) 后 model() 返回 nullptr,
+    //    需在解绑前获取以便后续显式删除。
+    FileViewModel *savedModel = model();
+    if (savedModel) {
+        disconnect(savedModel, nullptr, this, nullptr);
     }
     if (selectionModel()) {
         disconnect(selectionModel(), nullptr, this, nullptr);
@@ -144,13 +147,22 @@ FileView::~FileView()
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 
-    // 5. 清理其他订阅
+    // 5. 显式删除 model: ~QAbstractItemModel() 会调用 invalidatePersistentIndexes(),
+    //    将所有残留 QPersistentModelIndex 的 model 指针置 null。
+    //    必须在 ~QObject() 子对象清理前执行,否则 headerView / selectionModel 等
+    //    子控件在 ~QObject() 中销毁时,其内部 QPersistentModelIndex 会访问已销毁
+    //    的 model 私有数据哈希表(removePersistentIndexData)而崩溃。
+    if (savedModel && savedModel->QObject::parent() == this) {
+        delete savedModel;
+    }
+
+    // 6. 清理其他订阅
     dpfSignalDispatcher->unsubscribe("dfmplugin_workspace", "signal_View_HeaderViewSectionChanged", this, &FileView::onHeaderViewSectionChanged);
     dpfSignalDispatcher->unsubscribe("dfmplugin_filepreview", "signal_ThumbnailDisplay_Changed", this, &FileView::onWidgetUpdate);
 
     fmDebug() << "FileView destruction completed";
 
-    // 注意: model 作为 FileView 的子对象,会在基类析构后由 Qt 自动释放
+    // model 已在步骤 5 显式删除,不会进入 ~QObject() 子对象清理流程
 }
 
 QWidget *FileView::widget() const

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -144,6 +144,15 @@ FileView::~FileView()
     }
     setCurrentIndex(QModelIndex());
 
+    // SelectHelper caches QItemSelection, which owns QPersistentModelIndex in Qt6.
+    // Destroy it before detaching/deleting the model to avoid helper teardown
+    // walking stale persistent indexes after the model has gone away.
+    if (d && d->selectHelper) {
+        d->selectHelper->prepareForModelTeardown();
+        delete d->selectHelper;
+        d->selectHelper = nullptr;
+    }
+
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -1550,7 +1550,14 @@ bool FileView::groupExpandOrCollapseItem(const QModelIndex &index, const QPoint 
     QStyleOptionViewItem op;
     QRect rect = visualRect(index);   // 绘制区域
     op.rect = rect;
-    QRect arrowRect = itemDelegate()->getExpandButtonRect(op);
+
+    if (index.data(Global::kItemGroupDisplayIndex).toInt() > 0) {
+        // 非首个分组头在顶部预留 16px 透明间隔，实际内容区从间隔下方开始。
+        // 命中区与绘制区对齐，避免命中位置相对箭头上移。
+        op.rect.setTop(op.rect.top() + kGroupHeaderInterval);
+    }
+
+    QRect arrowRect = itemDelegate()->getExpandButtonHitRect(op);
 
     if (!arrowRect.contains(pos))
         return false;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -2092,6 +2092,15 @@ void FileView::contextMenuEvent(QContextMenuEvent *event)
         return;
     }
 
+    // Reset any stale drag-select state left by touch long-press before showing the menu.
+    // On touch screens a long-press synthesizes a left-button press/move that sets
+    // DragSelectingState; the subsequent release is consumed by the modal menu exec()
+    // and never reaches mouseReleaseEvent, so the state is never reset. A stale
+    // DragSelectingState later makes QListView::resizeEvent skip doDelayedItemsLayout,
+    // leaving visualRect() with stale item positions and breaking icon layout on
+    // maximize. Resetting here mirrors what mouseReleaseEvent would do.
+    setState(QAbstractItemView::NoState);
+
     if (NetworkUtils::instance()->checkFtpOrSmbBusy(rootUrl())) {
         fmWarning() << "Cannot show context menu: FTP or SMB is busy for URL:" << rootUrl().toString();
         DialogManager::instance()->showUnableToVistDir(rootUrl().path());

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -351,12 +351,25 @@ void FileViewPrivate::updateHorizontalOffset()
         }
 
         // itemColumn每行绘制的个数，contentWidth绘制区域宽度，itemWidth每一个item + 2倍间距的绘制宽度
-        if (contentWidth - itemWidth * itemColumn <= 0
-            || (contentWidth - itemWidth * itemColumn) / 2 >= itemWidth) {
-            columnCountByCalc = 1;
-            initHorizontalOffset = false;
-            fmDebug() << "Resetting to single column layout";
-            return;
+        // 当 visualRect() 返回瞬态过程中上一轮（更窄）布局的坐标时，扫描得到的 itemColumn 会偏小，
+        // 代入新的 contentWidth 后会被误判为“过疏”而错误回退单列。在回退前先用 contentWidth/itemWidth
+        // 重推每行列数：若重推后不再过疏，说明是脏坐标导致的误判，采用重推值；仍过疏才真正回退单列。
+        auto wouldReset = [&]() {
+            return contentWidth - itemWidth * itemColumn <= 0
+                    || (contentWidth - itemWidth * itemColumn) / 2 >= itemWidth;
+        };
+        if (wouldReset()) {
+            int calcColumn = contentWidth / itemWidth;
+            if (calcColumn > 0 && calcColumn < rowCount) {
+                itemColumn = calcColumn;
+                columnCountByCalc = itemColumn;
+            }
+            if (wouldReset()) {
+                columnCountByCalc = 1;
+                initHorizontalOffset = false;
+                fmDebug() << "Resetting to single column layout";
+                return;
+            }
         }
         horizontalOffset = -(contentWidth - itemWidth * itemColumn) / 2;
     }

--- a/src/services/diskencrypt/CMakeLists.txt
+++ b/src/services/diskencrypt/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_options(${BIN_NAME} PRIVATE -pie)
 
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_NAME}.json DESTINATION share/deepin-service-manager/other/)
+install(FILES dfm-reencrypt.desktop DESTINATION share/applications)
 install(FILES org.deepin.filemanager.diskencrypt.conf DESTINATION share/dbus-1/system.d/)
 install(FILES deepin-filemanager-diskencrypt.service DESTINATION lib/systemd/system/)
 install(FILES deepin-diskencrypt-tmpfiles.conf DESTINATION lib/tmpfiles.d/)

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -281,6 +281,15 @@ QString DiskEncryptSetup::PendingDecryptionDevice()
     for (auto f : files) {
         auto name = m_dptr->resolveDeviceByDetachHeaderName(f);
         if (!name.isEmpty()) {
+            // Validate that the device is still encrypted; if it has been reformatted
+            // (e.g. via mke2fs), the LUKS header is gone and this backup file is stale.
+            auto status = crypt_setup_helper::encryptStatus(name);
+            if (status == disk_encrypt::kStatusNotEncrypted || status < 0) {
+                qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Device is no longer encrypted, removing stale backup:"
+                         << name << "file:" << f;
+                QFile::remove(d.absoluteFilePath(f));
+                continue;
+            }
             qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Found pending decryption device:" << name << "from header file:" << f;
             return name;
         }

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -25,6 +25,8 @@
 #include <QDir>
 #include <QFile>
 #include <QProcess>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include <polkit-qt6-1/PolkitQt1/Authority>
 
@@ -33,6 +35,7 @@
 static constexpr char kActionEncrypt[] { "org.deepin.Filemanager.DiskEncrypt.Encrypt" };
 static constexpr char kActionDecrypt[] { "org.deepin.Filemanager.DiskEncrypt.Decrypt" };
 static constexpr char kActionChgPwd[] { "org.deepin.Filemanager.DiskEncrypt.ChangePassphrase" };
+static constexpr char kActionChgPIN[] { "org.deepin.Filemanager.DiskEncrypt.ChangePIN" };
 
 FILE_ENCRYPT_USE_NS
 
@@ -161,15 +164,35 @@ bool DiskEncryptSetup::ChangePassphrase(const QDBusUnixFileDescriptor &credentia
 {
     qInfo() << "[DiskEncryptSetup::ChangePassphrase] Passphrase change request received via fd";
 
-    if (!m_dptr->checkAuth(kActionChgPwd)) {
-        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
-        return false;
-    }
-
-    // Parse credentials from fd using common method
+    // Parse credentials first to determine the encryption type for the correct polkit action
     QVariantMap args;
     if (!m_dptr->parseCredentialsFromFd(credentialsFd, &args)) {
         qCritical() << "[DiskEncryptSetup::ChangePassphrase] Failed to parse credentials from fd";
+        return false;
+    }
+
+    // Determine the security key type to select the appropriate polkit action.
+    // The server independently infers secType from the device's TPM token
+    // (via TpmToken, which includes holder-device fallback) rather than
+    // trusting client-supplied input for the authorization decision.
+    auto dev = args.value(disk_encrypt::encrypt_param_keys::kKeyDevice).toString();
+    QString token = TpmToken(dev);
+    QString usePin;
+    if (!token.isEmpty()) {
+        QJsonParseError parseError;
+        QJsonDocument doc = QJsonDocument::fromJson(token.toLocal8Bit(), &parseError);
+        if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+            qWarning() << "[DiskEncryptSetup::ChangePassphrase] Failed to parse TPM token JSON for device:" << dev << "Error:" << parseError.errorString();
+            return false;
+        }
+        QJsonObject obj = doc.object();
+        usePin = obj.value("pin").toString("");
+    }
+    auto secType = (usePin == "1") ? disk_encrypt::kPin : disk_encrypt::kPwd;
+    const QString &action = (secType == disk_encrypt::kPin) ? kActionChgPIN : kActionChgPwd;
+
+    if (!m_dptr->checkAuth(action)) {
+        qWarning() << "[DiskEncryptSetup::ChangePassphrase] Authentication failed for passphrase change action";
         return false;
     }
 

--- a/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
+++ b/src/services/diskencrypt/deepin-diskencrypt-tmpfiles.conf
@@ -8,4 +8,3 @@
 # Type Path                            Mode UID  GID  Age Argument
 d     /etc/usec-crypt                   0755 root root -   -
 d     /boot/usec-crypt                  0755 root root -   -
-d     /usr/local/share/applications     0755 root root -   -

--- a/src/services/diskencrypt/dfm-reencrypt.desktop
+++ b/src/services/diskencrypt/dfm-reencrypt.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Categories=System;
+Comment=To auto launch reencryption
+Exec=/usr/libexec/dde-file-manager -d
+GenericName=Disk Reencrypt
+Icon=dde-file-manager
+Name=Disk Reencrypt
+Terminal=false
+Type=Application
+NoDisplay=true
+X-AppStream-Ignore=true
+X-Deepin-AppID=dde-file-manager
+X-Deepin-Vendor=deepin

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -24,7 +24,7 @@ static QString toBase64(const QString rawstr)
 }
 
 inline constexpr char kUSecConfigDir[] { "/etc/usec-crypt" };
-inline constexpr char kReencryptDesktopFile[] { "/usr/local/share/applications/dfm-reencrypt.desktop" };
+inline constexpr char kReencryptDesktopFile[] { "/usr/share/applications/dfm-reencrypt.desktop" };
 inline constexpr char kRebootFlagFilePrefix[] { "/tmp/dfm_encrypt_reboot_flag_" };
 
 namespace job_type {

--- a/src/services/diskencrypt/helpers/commonhelper.cpp
+++ b/src/services/diskencrypt/helpers/commonhelper.cpp
@@ -10,57 +10,23 @@
 #include <QFile>
 #include <QLibrary>
 #include <QRandomGenerator>
-#include <QDir>
 
 #include <DConfig>
-#include <unistd.h>
 
 FILE_ENCRYPT_USE_NS
 
 void common_helper::createDFMDesktopEntry()
 {
-    qInfo() << "[common_helper::createDFMDesktopEntry] Creating DFM desktop entry for reencryption";
-
-    const QString &kLocalShareApps = "/usr/local/share/applications";
-    QDir d(kLocalShareApps);
-    if (!d.exists()) {
-        auto ok = d.mkpath(kLocalShareApps);
-        qInfo() << "[common_helper::createDFMDesktopEntry] Applications directory created:" << kLocalShareApps << "success:" << ok;
+    // The desktop file is shipped via the package (installed to
+    // /usr/share/applications/dfm-reencrypt.desktop). There is no need to
+    // create it at runtime anymore -- writing to /usr at runtime fails on
+    // immutable systems (磐石) and triggers security interception.
+    // Keep this function as a no-op compatibility stub so existing callers
+    // (DiskEncryptSetupPrivate::initialize) stay unaffected.
+    if (!QFile::exists(disk_encrypt::kReencryptDesktopFile)) {
+        qWarning() << "[common_helper::createDFMDesktopEntry] Reencrypt desktop file is missing,"
+                   << "it should be shipped by the package:" << disk_encrypt::kReencryptDesktopFile;
     }
-
-    QFile f(disk_encrypt::kReencryptDesktopFile);
-    if (f.exists()) {
-        qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file already exists, skipping creation:" << disk_encrypt::kReencryptDesktopFile;
-        return;
-    }
-
-    QByteArray desktop {
-        "[Desktop Entry]\n"
-        "Categories=System;\n"
-        "Comment=To auto launch reencryption\n"
-        "Exec=/usr/libexec/dde-file-manager -d\n"
-        "GenericName=Disk Reencrypt\n"
-        "Icon=dde-file-manager\n"
-        "Name=Disk Reencrypt\n"
-        "Terminal=false\n"
-        "Type=Application\n"
-        "NoDisplay=true\n"
-        "X-AppStream-Ignore=true\n"
-        "X-Deepin-AppID=dde-file-manager\n"
-        "X-Deepin-Vendor=deepin\n"
-    };
-
-    if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        qCritical() << "[common_helper::createDFMDesktopEntry] Failed to open desktop file for writing:" << disk_encrypt::kReencryptDesktopFile;
-        return;
-    }
-    f.write(desktop);
-    f.flush();
-    auto ret = ::fsync(f.handle());
-    f.close();
-
-    qInfo() << "[common_helper::createDFMDesktopEntry] Desktop file created successfully:" << disk_encrypt::kReencryptDesktopFile
-            << "Sync status: " << ret;
 }
 
 QString common_helper::encryptCipher()

--- a/src/services/diskencrypt/helpers/jobfilehelper.cpp
+++ b/src/services/diskencrypt/helpers/jobfilehelper.cpp
@@ -244,25 +244,60 @@ QStringList job_file_helper::validJobTypes()
 void job_file_helper::checkJobs()
 {
     qInfo() << "[job_file_helper::checkJobs] Checking and validating existing job files";
-    
+
+    // Check encrypt job files
     JobDescArgs job;
     loadEncryptJobFile(&job);
-    if (job.jobFile.isEmpty()) {
-        qInfo() << "[job_file_helper::checkJobs] No job files to check";
-        return;
+    if (!job.jobFile.isEmpty()) {
+        if (!QFile(job.devPath).exists()) {
+            qInfo() << "[job_file_helper::checkJobs] Encrypt job device no longer exists, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
+            removeJobFile(job.jobFile);
+        } else if (crypt_setup_helper::encryptStatus(job.devPath) == disk_encrypt::kStatusNotEncrypted) {
+            qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing encrypt job file - device:" << job.devPath << "job file:" << job.jobFile;
+            removeJobFile(job.jobFile);
+        } else {
+            qInfo() << "[job_file_helper::checkJobs] Encrypt job file validation completed - device:" << job.devPath << "job file:" << job.jobFile;
+        }
     }
 
-    if (!QFile(job.devPath).exists()) {
-        qInfo() << "[job_file_helper::checkJobs] Job device no longer exists, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
-        removeJobFile(job.jobFile);
-        return;
+    // Check decrypt job file
+    QString decryptJobPath = QString(disk_encrypt::kUSecConfigDir) + "/decrypt.json";
+    QFile decryptJobFile(decryptJobPath);
+    if (decryptJobFile.exists()) {
+        qInfo() << "[job_file_helper::checkJobs] Found decrypt job file:" << decryptJobPath;
+        if (decryptJobFile.open(QIODevice::ReadOnly)) {
+            QByteArray data = decryptJobFile.readAll();
+            decryptJobFile.close();
+
+            QJsonParseError err;
+            QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+            if (err.error == QJsonParseError::NoError && doc.isObject()) {
+                QJsonObject obj = doc.object();
+                QString devPath = obj.value(key_name::KeyDevPath).toString();
+
+                bool shouldRemove = false;
+                if (devPath.isEmpty()) {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job file has no device-path, removing";
+                    shouldRemove = true;
+                } else if (!QFile(devPath).exists()) {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job device no longer exists, removing job file - device:" << devPath;
+                    shouldRemove = true;
+                } else if (crypt_setup_helper::encryptStatus(devPath) == disk_encrypt::kStatusNotEncrypted) {
+                    qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing decrypt job file - device:" << devPath;
+                    shouldRemove = true;
+                }
+
+                if (shouldRemove) {
+                    removeJobFile(decryptJobPath);
+                } else {
+                    qInfo() << "[job_file_helper::checkJobs] Decrypt job file validation completed - device:" << devPath;
+                }
+            } else {
+                qWarning() << "[job_file_helper::checkJobs] Failed to parse decrypt job file, removing";
+                removeJobFile(decryptJobPath);
+            }
+        }
     }
 
-    if (crypt_setup_helper::encryptStatus(job.devPath) == disk_encrypt::kStatusNotEncrypted) {
-        qInfo() << "[job_file_helper::checkJobs] Device is no longer encrypted, removing job file - device:" << job.devPath << "job file:" << job.jobFile;
-        removeJobFile(job.jobFile);
-        return;
-    }
-    
-    qInfo() << "[job_file_helper::checkJobs] Job file validation completed - device:" << job.devPath << "job file:" << job.jobFile;
+    qInfo() << "[job_file_helper::checkJobs] Job file validation completed";
 }

--- a/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
+++ b/src/services/diskencrypt/polkit/policy/org.deepin.filemanager.diskencrypt.policy
@@ -33,6 +33,19 @@
   </action>
   <action id="org.deepin.Filemanager.DiskEncrypt.ChangePassphrase">
     <description>Disk encryption</description>
+    <message>Authentication is required to change the passphrase of the partition</message>
+    <message xml:lang="zh_CN">修改加密口令需要认证</message>
+    <message xml:lang="zh_HK">修改加密口令需要認證</message>
+    <message xml:lang="zh_TW">修改加密口令需要認證</message>
+    <icon_name>folder</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+  <action id="org.deepin.Filemanager.DiskEncrypt.ChangePIN">
+    <description>Disk encryption</description>
     <message>Authentication is required to change the PIN code of the partition</message>
     <message xml:lang="zh_CN">修改分区PIN码需要认证</message>
     <message xml:lang="zh_HK">修改分區PIN碼需要認證</message>

--- a/src/services/textindex/dde-filemanager-textindex.json
+++ b/src/services/textindex/dde-filemanager-textindex.json
@@ -7,6 +7,9 @@
     "policy": [
         {
             "path": "/org/deepin/Filemanager/TextIndex"
+        },
+        {
+            "path": "/org/deepin/Filemanager/OcrIndex"
         }
     ]
 } 

--- a/src/services/textindex/dependencies.cmake
+++ b/src/services/textindex/dependencies.cmake
@@ -16,7 +16,7 @@ function(dfm_setup_textindex_dependencies target_name)
     # Find system dependencies using pkg-config
     pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
     pkg_check_modules(GLIB REQUIRED glib-2.0)
-    pkg_check_modules(NL REQUIRED IMPORTED_TARGET libnl-3.0 libnl-genl-3.0)
+    pkg_check_modules(mount REQUIRED mount IMPORTED_TARGET)
     
     # Apply default service configuration first (this provides DFM6::base, Qt6::Core, Qt6::DBus)
     dfm_apply_default_service_config(${target_name})
@@ -36,7 +36,7 @@ function(dfm_setup_textindex_dependencies target_name)
         dde-file-manager-extractor-lib
         ${GLIB_LIBRARIES}
         PkgConfig::Lucene
-        PkgConfig::NL
+        PkgConfig::mount
     )
     
     # Add textindex-specific include directories

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -114,7 +114,7 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
 
     // Try to create VfsMonitorFileSystemWatcher for global file system events.
     // Pass shouldExcludePath as the exclude predicate so filtering happens
-    // at the netlink callback level (before any signals are emitted).
+    // before any socket-delivered events are emitted.
     vfsWatcher.reset(VfsMonitorFileSystemWatcher::create(
         this->rootPaths,
         [this](const QString &path) { return shouldExcludePath(path); },
@@ -122,15 +122,15 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
     vfsMonitorAvailable = (vfsWatcher != nullptr);
 
     if (vfsMonitorAvailable) {
-        // vfs_monitor mode: create/delete/move from vfs, fileClosed from inotify.
+        // deepin-anything dispatcher mode: create/delete/move from vfs, fileClosed from inotify.
         // Restrict inotify to IN_CLOSE_WRITE only, reducing kernel event delivery.
         watcher->setWatchFlags(InotifyFileSystemWatcher::WatchFlag::FileClose);
         setupVfsMonitorConnections();
-        fmInfo() << "FSMonitor: Using dual watcher mode (vfs_monitor + inotify fallback)";
+        fmInfo() << "FSMonitor: Using dual watcher mode (deepin-anything dispatcher + inotify fallback)";
     } else {
         // inotify-only mode: all signals from InotifyFileSystemWatcher (existing behavior).
         setupWatcherConnections();
-        fmInfo() << "FSMonitor: Using inotify-only mode (vfs_monitor not available)";
+        fmInfo() << "FSMonitor: Using inotify-only mode (deepin-anything dispatcher not available)";
     }
 
     fmDebug() << "FSMonitor: Initialized with" << excludeMatcher.patternCount()

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -64,7 +64,7 @@ public:
     // Parse and connect watcher signals (inotify-only fallback mode)
     void setupWatcherConnections();
 
-    // Connect vfs_monitor watcher signals (create/delete/move from vfs, fileClosed from inotify)
+    // Connect deepin-anything watcher signals (create/delete/move from vfs, fileClosed from inotify)
     void setupVfsMonitorConnections();
 
     // Set up the worker thread and connections

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -4,33 +4,26 @@
 
 #include "vfsmonitorwatcher_p.h"
 
-#include <QFileInfo>
 #include <QDir>
-#include <QFile>
-#include <QTextStream>
-
-#include <netlink/genl/ctrl.h>
-#include <netlink/genl/genl.h>
-#include <netlink/netlink.h>
-#include <netlink/socket.h>
-#include <netlink/attr.h>
-#include <netlink/msg.h>
+#include <QFileInfo>
 
 #include <libmount.h>
-#include <sys/sysmacros.h>
 
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <algorithm>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
-// Netlink family and multicast group names (matching vfs_genl.h)
-static constexpr char kVfsMonitorFamilyName[] = "vfsmonitor";
-static constexpr char kVfsMonitorMcgDentry[] = "vfsmonitor_de";
-
-// --- Per-instance C callback for libnl ---
-
 namespace {
+
+constexpr char kDispatcherSocketPath[] = "/run/deepin-anything/event-dispatcher.sock";
+constexpr size_t kDispatchMaxPathLen = 4096;
 
 struct MountEntry
 {
@@ -38,31 +31,14 @@ struct MountEntry
     int parentMountId { 0 };
     QString mountPoint;
     bool isBindMount { false };
-    bool isLowerFs { false };
 };
 
-// Netlink attribute policy for parsing vfs_monitor messages.
-struct nla_policy vfsPolicy[VFSMONITOR_A_MAX + 1];
-
-void initVfsPolicy()
+struct DispatchEvent
 {
-    std::memset(vfsPolicy, 0, sizeof(vfsPolicy));
-    vfsPolicy[VFSMONITOR_A_ACT].type = NLA_U8;
-    vfsPolicy[VFSMONITOR_A_COOKIE].type = NLA_U32;
-    vfsPolicy[VFSMONITOR_A_MAJOR].type = NLA_U16;
-    vfsPolicy[VFSMONITOR_A_MINOR].type = NLA_U8;
-    vfsPolicy[VFSMONITOR_A_PATH].type = NLA_NUL_STRING;
-    vfsPolicy[VFSMONITOR_A_PATH].maxlen = 4096;
-}
-
-bool mountPointStartsWith(const QString &path, const QString &mountPoint)
-{
-    if (!path.startsWith(mountPoint))
-        return false;
-
-    return mountPoint.endsWith('/') || path.length() == mountPoint.length()
-            || path.at(mountPoint.length()) == '/';
-}
+    int32_t action;
+    uint32_t cookie;
+    char eventPath[kDispatchMaxPathLen];
+};
 
 bool isDescendantOfRoot(const QString &path, const QString &root)
 {
@@ -78,15 +54,18 @@ bool isDescendantOfRoot(const QString &path, const QString &root)
     return root.endsWith('/') || path.at(root.length()) == '/';
 }
 
+bool mountPointStartsWith(const QString &path, const QString &mountPoint)
+{
+    if (!path.startsWith(mountPoint))
+        return false;
+
+    return mountPoint.endsWith('/') || path.length() == mountPoint.length()
+            || path.at(mountPoint.length()) == '/';
+}
+
 bool cStringEquals(const char *left, const char *right)
 {
     return left && right && qstrcmp(left, right) == 0;
-}
-
-bool isLowerFsType(const char *fsType)
-{
-    return cStringEquals(fsType, "overlay") || cStringEquals(fsType, "fuse.dlnfs")
-            || cStringEquals(fsType, "ulnfs");
 }
 
 bool isParentChainUnderRoot(const QHash<int, MountEntry> &byMountId, const MountEntry &entry)
@@ -112,25 +91,21 @@ bool isParentChainUnderRoot(const QHash<int, MountEntry> &byMountId, const Mount
 QHash<int, MountEntry> collectMountEntries(libmnt_table *mtab)
 {
     QHash<int, MountEntry> byMountId;
-    struct libmnt_iter *iter = mnt_new_iter(MNT_ITER_FORWARD);
+    libmnt_iter *iter = mnt_new_iter(MNT_ITER_FORWARD);
     if (!iter)
         return byMountId;
 
-    struct libmnt_fs *fs;
+    libmnt_fs *fs = nullptr;
     while (mnt_table_next_fs(mtab, iter, &fs) == 0) {
         const char *target = mnt_fs_get_target(fs);
         if (!target)
             continue;
 
-        const char *root = mnt_fs_get_root(fs);
-        const char *fsType = mnt_fs_get_fstype(fs);
-
         MountEntry entry;
         entry.deviceId = mnt_fs_get_devno(fs);
         entry.parentMountId = mnt_fs_get_parent_id(fs);
         entry.mountPoint = QString::fromUtf8(target);
-        entry.isBindMount = !cStringEquals(root, "/");
-        entry.isLowerFs = isLowerFsType(fsType);
+        entry.isBindMount = !cStringEquals(mnt_fs_get_root(fs), "/");
 
         byMountId.insert(mnt_fs_get_id(fs), entry);
     }
@@ -139,163 +114,33 @@ QHash<int, MountEntry> collectMountEntries(libmnt_table *mtab)
     return byMountId;
 }
 
-// Per-instance callback: arg is the VfsMonitorFileSystemWatcherPrivate pointer,
-// registered per-socket via nl_socket_modify_cb. No global state needed.
-int vfsMonitorMsgCallback(struct nl_msg *msg, void *arg)
+QString filterDirectPath(const QStringList &rootPaths,
+                         const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
+                         const QString &fullPath)
 {
-    auto *d = static_cast<VfsMonitorFileSystemWatcherPrivate *>(arg);
-
-    if (!d) {
-        return NL_SKIP;
+    if (std::none_of(rootPaths.cbegin(), rootPaths.cend(),
+                     [&fullPath](const QString &root) { return isDescendantOfRoot(fullPath, root); })) {
+        return {};
     }
 
-    struct nlattr *tb[VFSMONITOR_A_MAX + 1];
-    std::memset(tb, 0, sizeof(tb));
+    if (excludePredicate && excludePredicate(fullPath))
+        return {};
 
-    struct nlmsghdr *nh = nlmsg_hdr(msg);
-    int err = genlmsg_parse(nh, 0, tb, VFSMONITOR_A_MAX, vfsPolicy);
-    if (err < 0) {
-        return NL_SKIP;
-    }
-
-    if (!tb[VFSMONITOR_A_PATH]) {
-        return NL_SKIP;
-    }
-
-    // Extract attributes.
-    uint8_t act = tb[VFSMONITOR_A_ACT] ? nla_get_u8(tb[VFSMONITOR_A_ACT]) : 0;
-    uint32_t cookie = tb[VFSMONITOR_A_COOKIE] ? nla_get_u32(tb[VFSMONITOR_A_COOKIE]) : 0;
-    uint16_t major = tb[VFSMONITOR_A_MAJOR] ? nla_get_u16(tb[VFSMONITOR_A_MAJOR]) : 0;
-    uint8_t minor = tb[VFSMONITOR_A_MINOR] ? nla_get_u8(tb[VFSMONITOR_A_MINOR]) : 0;
-    const char *pathCStr = reinterpret_cast<const char *>(nla_data(tb[VFSMONITOR_A_PATH]));
-
-    // Skip non-filesystem events.
-    if (act > ACT_UNMOUNT) {
-        return NL_OK;
-    }
-
-    // Mount/unmount events don't carry meaningful path data for indexing,
-    // but they invalidate our mount point cache. Flag the dirty bit so
-    // handleNetlinkMessage() can refresh the cache after this batch.
-    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
-        d->mountPointsDirty = true;
-        return NL_OK;
-    }
-
-    dev_t deviceId = makedev(major, minor);
-
-    // RENAME_FROM events must be stored before filtering, because the paired
-    // RENAME_TO may land in an excluded path (e.g., trash). We need the
-    // RENAME_FROM info to emit a delete when that happens.
-    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
-        QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-        if (fullPath.isNull())
-            return NL_OK;   // Source itself is excluded, no point tracking.
-
-        auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-
-        RenameFromInfo info;
-        info.path = parentPath;
-        info.name = name;
-        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
-        d->pendingRenames.insert(cookie, info);
-        return NL_OK;
-    }
-
-    // RENAME_TO events need independent path resolution because the target may
-    // be filtered (e.g., moved to trash). In that case we emit a delete for the
-    // source instead of a move — the generic fullPath.isNull() gate below would
-    // swallow this event before we could check pendingRenames.
-    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
-        auto *q = d->q_ptr;
-        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
-
-        auto it = d->pendingRenames.find(cookie);
-        if (it != d->pendingRenames.end()) {
-            QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
-                else
-                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
-            } else {
-                // Target is filtered (e.g., moved to trash) → source is gone.
-                if (isDir)
-                    Q_EMIT q->directoryDeleted(it->path, it->name);
-                else
-                    Q_EMIT q->fileDeleted(it->path, it->name);
-            }
-            d->pendingRenames.erase(it);
-        } else {
-            // Unpaired RENAME_TO: treat as creation if in monitored area.
-            QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryCreated(parentPath, name);
-                else
-                    Q_EMIT q->fileCreated(parentPath, name);
-            }
-        }
-        return NL_OK;
-    }
-
-    // For all other events, reconstruct and filter the full path.
-    QString fullPath = d->resolveAndFilterFullPath(deviceId, pathCStr);
-    if (fullPath.isNull()) {
-        return NL_OK;
-    }
-
-    auto *q = d->q_ptr;
-    auto [parentPath, name] = VfsMonitorFileSystemWatcherPrivate::splitPath(fullPath);
-
-    switch (act) {
-    case ACT_NEW_FILE:
-    case ACT_NEW_LINK:
-    case ACT_NEW_SYMLINK:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-
-    case ACT_NEW_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-
-    case ACT_DEL_FILE:
-        Q_EMIT q->fileDeleted(parentPath, name);
-        break;
-
-    case ACT_DEL_FOLDER:
-        Q_EMIT q->directoryDeleted(parentPath, name);
-        break;
-
-        // Synthetic events (kernel-paired rename).
-    case ACT_RENAME_FILE:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-
-    case ACT_RENAME_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-
-    default:
-        break;
-    }
-
-    return NL_OK;
+    return fullPath;
 }
 
-static bool registerMessageCallback(nl_sock *sock, VfsMonitorFileSystemWatcherPrivate *d)
+QString filterEventPath(const QStringList &rootPaths,
+                        const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
+                        const char *eventPath)
 {
-    // Pass d directly as per-socket callback data. Each nl_sock gets its own
-    // callback arg, so multiple instances are naturally supported.
-    int ret = nl_socket_modify_cb(sock, NL_CB_VALID, NL_CB_CUSTOM,
-                                  vfsMonitorMsgCallback, d);
-    if (ret != 0) {
-        return false;
-    }
+    if (!eventPath || eventPath[0] == '\0')
+        return {};
 
-    return true;
+    const QString fullPath = QDir::cleanPath(QString::fromUtf8(eventPath));
+    if (!fullPath.startsWith('/'))
+        return {};
+
+    return filterDirectPath(rootPaths, excludePredicate, fullPath);
 }
 
 }   // anonymous namespace
@@ -306,8 +151,13 @@ VfsMonitorFileSystemWatcherPrivate::VfsMonitorFileSystemWatcherPrivate(
         const QStringList &rootPaths,
         VfsMonitorFileSystemWatcher::PathExcludePredicate excludePredicate,
         VfsMonitorFileSystemWatcher *qq)
-    : q_ptr(qq), rootPaths(rootPaths), excludePredicate(std::move(excludePredicate))
+    : q_ptr(qq), excludePredicate(std::move(excludePredicate))
 {
+    this->rootPaths.reserve(rootPaths.size());
+    for (const QString &path : rootPaths) {
+        this->rootPaths.append(QDir(path).absolutePath());
+    }
+    this->rootPaths.removeDuplicates();
 }
 
 VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
@@ -316,26 +166,19 @@ VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
         notifier->setEnabled(false);
     }
 
-    // No global callback state to clear — the per-socket callback data (this
-    // pointer) becomes invalid when nlSock is freed below, and the callback
-    // checks for null before dereferencing.
-
-    if (nlSock) {
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
+    if (socketFd >= 0) {
+        ::close(socketFd);
+        socketFd = -1;
     }
 }
 
 bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
 {
     mountPoints.clear();
-    childMountPoints.clear();
-    lowerFsExists = false;
 
-    struct libmnt_table *mtab = mnt_new_table();
-    if (!mtab) {
+    libmnt_table *mtab = mnt_new_table();
+    if (!mtab)
         return false;
-    }
 
     if (mnt_table_parse_mtab(mtab, nullptr) < 0) {
         mnt_free_table(mtab);
@@ -345,115 +188,59 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
     const QHash<int, MountEntry> byMountId = collectMountEntries(mtab);
     mnt_free_table(mtab);
 
-    QHash<int, MountEntry> rootMountTree;
     for (auto it = byMountId.cbegin(); it != byMountId.cend(); ++it) {
-        const auto &entry = it.value();
-
+        const MountEntry &entry = it.value();
         if (!isParentChainUnderRoot(byMountId, entry))
             continue;
 
         mountPoints[entry.deviceId].append(entry.mountPoint);
-        rootMountTree.insert(it.key(), entry);
-        lowerFsExists = lowerFsExists || entry.isLowerFs;
     }
 
     for (auto &points : mountPoints) {
-        std::sort(points.begin(), points.end(),
-                  [](const QString &a, const QString &b) {
-                      return a.length() > b.length();
-                  });
-    }
-
-    for (auto it = rootMountTree.cbegin(); it != rootMountTree.cend(); ++it) {
-        const auto &parent = it.value();
-        QStringList children;
-        for (const auto &entry : std::as_const(rootMountTree)) {
-            if (entry.parentMountId == it.key()) {
-                children.append(entry.mountPoint);
-            }
-        }
-
-        if (!children.isEmpty())
-            childMountPoints[parent.deviceId].append(children);
-    }
-
-    for (auto &points : childMountPoints) {
         points.removeDuplicates();
         std::sort(points.begin(), points.end(),
-                  [](const QString &a, const QString &b) {
-                      return a.length() > b.length();
+                  [](const QString &left, const QString &right) {
+                      return left.length() > right.length();
                   });
     }
 
-    int totalPoints = 0;
-    for (const auto &pts : std::as_const(mountPoints)) {
-        totalPoints += pts.size();
-    }
-    fmInfo() << "VfsMonitor: loaded" << mountPoints.size()
-             << "devices," << totalPoints << "mount points,"
-             << childMountPoints.size() << "devices with child mount points,"
-             << "lowerfs exists:" << lowerFsExists;
     return !mountPoints.isEmpty();
 }
 
-bool VfsMonitorFileSystemWatcherPrivate::isLowerFsEvent(dev_t deviceId, const QString &fullPath) const
+QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char *absolutePath) const
 {
-    if (!lowerFsExists)
-        return false;
+    const QString directPath = filterEventPath(rootPaths, excludePredicate, absolutePath);
+    if (!directPath.isNull())
+        return directPath;
 
-    auto it = childMountPoints.find(deviceId);
-    if (it == childMountPoints.end())
-        return false;
-
-    for (const QString &childMountPoint : it.value()) {
-        if (mountPointStartsWith(fullPath, childMountPoint)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(dev_t deviceId,
-                                                                     const char *relativePath) const
-{
-    auto it = mountPoints.find(deviceId);
-    if (it == mountPoints.end())
+    if (!absolutePath || absolutePath[0] == '\0')
         return {};
 
-    const QStringList &points = it.value();
-    const QString relPath = QString::fromUtf8(relativePath);
+    const QString fullPath = QDir::cleanPath(QString::fromUtf8(absolutePath));
+    if (!fullPath.startsWith('/'))
+        return {};
 
-    // Try each mount point (sorted longest first).
-    // Return the first one that falls under a monitored root path
-    // and passes the exclude predicate.
-    for (const QString &mp : points) {
-        QString fullPath = (mp == "/") ? relPath : (mp + relPath);
+    for (auto deviceIt = mountPoints.cbegin(); deviceIt != mountPoints.cend(); ++deviceIt) {
+        const QStringList &points = deviceIt.value();
+        for (const QString &sourceMountPoint : points) {
+            if (!mountPointStartsWith(fullPath, sourceMountPoint))
+                continue;
 
-        if (isLowerFsEvent(deviceId, fullPath))
-            continue;
+            const QString suffix = (sourceMountPoint == "/")
+                    ? fullPath
+                    : fullPath.mid(sourceMountPoint.length());
 
-        if (std::none_of(rootPaths.cbegin(), rootPaths.cend(),
-                         [&fullPath](const QString &root) { return isDescendantOfRoot(fullPath, root); }))
-            continue;
+            for (const QString &candidateMountPoint : points) {
+                const QString candidateFullPath = (candidateMountPoint == "/")
+                        ? suffix
+                        : candidateMountPoint + suffix;
+                const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
+                if (!filteredCandidate.isNull())
+                    return filteredCandidate;
+            }
 
-        if (excludePredicate && excludePredicate(fullPath))
-            continue;
-
-        return fullPath;
-    }
-
-    // In overlay root environments, the root "/" filesystem has no separate mount
-    // entry in mountPoints. When all mount points fail and relPath is already
-    // an absolute path, treat it as the true absolute path and re-check.
-    if (relPath.startsWith('/')) {
-        auto found = std::find_if(rootPaths.cbegin(), rootPaths.cend(),
-                                  [&relPath, this](const QString &root) {
-                                      return isDescendantOfRoot(relPath, root)
-                                              && (!excludePredicate || !excludePredicate(relPath));
-                                  });
-        if (found != rootPaths.cend())
-            return relPath;
+            break;
+        }
     }
 
     return {};
@@ -465,95 +252,168 @@ QPair<QString, QString> VfsMonitorFileSystemWatcherPrivate::splitPath(const QStr
     return qMakePair(fi.absolutePath(), fi.fileName());
 }
 
-bool VfsMonitorFileSystemWatcherPrivate::initNetlink()
+bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
 {
     Q_Q(VfsMonitorFileSystemWatcher);
 
-    // Build mount point cache first (no netlink dependency).
     if (!initMountPoints()) {
-        fmWarning() << "VfsMonitor: failed to initialize mount points";
+        fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
     }
 
-    nlSock = nl_socket_alloc();
-    if (!nlSock) {
-        fmWarning() << "VfsMonitor: failed to allocate netlink socket";
+    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (socketFd < 0) {
+        fmWarning() << "VfsMonitor: failed to create dispatcher socket:" << std::strerror(errno);
         return false;
     }
 
-    if (genl_connect(nlSock) != 0) {
-        fmWarning() << "VfsMonitor: genl_connect failed";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
+    sockaddr_un address {};
+    address.sun_family = AF_UNIX;
+    std::strncpy(address.sun_path, kDispatcherSocketPath, sizeof(address.sun_path) - 1);
+
+    if (::connect(socketFd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0) {
+        fmWarning() << "VfsMonitor: deepin-anything event dispatcher not available:" << std::strerror(errno);
+        ::close(socketFd);
+        socketFd = -1;
         return false;
     }
 
-    // Set receive buffer to system maximum to prevent event loss.
-    QFile rmemFile("/proc/sys/net/core/rmem_max");
-    if (rmemFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        QTextStream in(&rmemFile);
-        bool ok = false;
-        int maxRcvbuf = in.readLine().trimmed().toInt(&ok);
-        if (ok && maxRcvbuf > 0) {
-            if (nl_socket_set_buffer_size(nlSock, maxRcvbuf, 0) != 0) {
-                fmWarning() << "VfsMonitor: failed to set socket buffer size";
-            }
-        }
-        rmemFile.close();
-    }
-
-    nl_socket_disable_seq_check(nlSock);
-    nl_socket_disable_auto_ack(nlSock);
-
-    int mcgrpId = genl_ctrl_resolve_grp(nlSock, kVfsMonitorFamilyName, kVfsMonitorMcgDentry);
-    if (mcgrpId < 0) {
-        fmWarning() << "VfsMonitor: vfs_monitor kernel module not available";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    if (nl_socket_add_membership(nlSock, mcgrpId) != 0) {
-        fmWarning() << "VfsMonitor: failed to join multicast group";
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    initVfsPolicy();
-
-    if (!registerMessageCallback(nlSock, this)) {
-        nl_socket_free(nlSock);
-        nlSock = nullptr;
-        return false;
-    }
-
-    int fd = nl_socket_get_fd(nlSock);
-    notifier = new QSocketNotifier(fd, QSocketNotifier::Read, q);
+    notifier = new QSocketNotifier(socketFd, QSocketNotifier::Read, q);
     QObject::connect(notifier, &QSocketNotifier::activated, q, [this]() {
-        handleNetlinkMessage();
+        handleSocketMessage();
     });
 
-    fmInfo() << "VfsMonitor: connected to vfs_monitor kernel module";
+    fmInfo() << "VfsMonitor: connected to deepin-anything event dispatcher";
     return true;
 }
 
-void VfsMonitorFileSystemWatcherPrivate::handleNetlinkMessage()
+void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
 {
-    int ret = nl_recvmsgs_default(nlSock);
-    if (ret < 0 && ret != -NLE_AGAIN) {
-        fmWarning() << "VfsMonitor: nl_recvmsgs_default failed, error:" << ret;
+    if (socketFd < 0) {
+        return;
     }
 
-    // Refresh mount point cache if mount/unmount events were received.
-    // Done after nl_recvmsgs_default() so the cache is up-to-date for the
-    // next batch of file events.
-    if (mountPointsDirty) {
-        mountPointsDirty = false;
-        if (initMountPoints()) {
-            fmInfo() << "VfsMonitor: mount point cache refreshed";
-        } else {
-            fmWarning() << "VfsMonitor: failed to refresh mount point cache";
+    DispatchEvent event {};
+    ssize_t received = -1;
+    do {
+        received = ::recv(socketFd, &event, sizeof(event), 0);
+    } while (received < 0 && errno == EINTR);
+
+    if (received == 0) {
+        fmWarning() << "VfsMonitor: event dispatcher connection closed";
+        if (notifier) {
+            notifier->setEnabled(false);
         }
+        ::close(socketFd);
+        socketFd = -1;
+        return;
+    }
+
+    if (received < 0) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
+        }
+        return;
+    }
+
+    constexpr size_t kMinMessageSize = offsetof(DispatchEvent, eventPath) + 1;
+    if (static_cast<size_t>(received) < kMinMessageSize) {
+        fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
+        return;
+    }
+
+    event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+
+    const int act = event.action;
+    const uint32_t cookie = event.cookie;
+    const char *pathCStr = event.eventPath;
+
+    if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+        return;
+    }
+
+    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
+        if (!initMountPoints()) {
+            fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
+        }
+        return;
+    }
+
+    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
+        QString fullPath = resolveAndFilterFullPath(pathCStr);
+        if (fullPath.isNull())
+            return;
+
+        auto [parentPath, name] = splitPath(fullPath);
+        RenameFromInfo info;
+        info.path = parentPath;
+        info.name = name;
+        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
+        pendingRenames.insert(cookie, info);
+        return;
+    }
+
+    auto *q = q_ptr;
+    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
+        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
+        auto it = pendingRenames.find(cookie);
+        if (it != pendingRenames.end()) {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (!fullPath.isNull()) {
+                auto [parentPath, name] = splitPath(fullPath);
+                if (isDir)
+                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
+                else
+                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
+            } else {
+                if (isDir)
+                    Q_EMIT q->directoryDeleted(it->path, it->name);
+                else
+                    Q_EMIT q->fileDeleted(it->path, it->name);
+            }
+            pendingRenames.erase(it);
+        } else {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (!fullPath.isNull()) {
+                auto [parentPath, name] = splitPath(fullPath);
+                if (isDir)
+                    Q_EMIT q->directoryCreated(parentPath, name);
+                else
+                    Q_EMIT q->fileCreated(parentPath, name);
+            }
+        }
+        return;
+    }
+
+    const QString fullPath = resolveAndFilterFullPath(pathCStr);
+    if (fullPath.isNull()) {
+        return;
+    }
+
+    auto [parentPath, name] = splitPath(fullPath);
+
+    switch (act) {
+    case ACT_NEW_FILE:
+    case ACT_NEW_LINK:
+    case ACT_NEW_SYMLINK:
+        Q_EMIT q->fileCreated(parentPath, name);
+        break;
+    case ACT_NEW_FOLDER:
+        Q_EMIT q->directoryCreated(parentPath, name);
+        break;
+    case ACT_DEL_FILE:
+        Q_EMIT q->fileDeleted(parentPath, name);
+        break;
+    case ACT_DEL_FOLDER:
+        Q_EMIT q->directoryDeleted(parentPath, name);
+        break;
+    case ACT_RENAME_FILE:
+        Q_EMIT q->fileCreated(parentPath, name);
+        break;
+    case ACT_RENAME_FOLDER:
+        Q_EMIT q->directoryCreated(parentPath, name);
+        break;
+    default:
+        break;
     }
 
     // Clean up orphaned RENAME_FROM entries.
@@ -584,7 +444,7 @@ VfsMonitorFileSystemWatcher *VfsMonitorFileSystemWatcher::create(const QStringLi
 {
     auto *watcher = new VfsMonitorFileSystemWatcher(rootPaths, std::move(excludePredicate), parent);
 
-    if (!watcher->d_func()->initNetlink()) {
+    if (!watcher->d_func()->initDispatcher()) {
         delete watcher;
         return nullptr;
     }

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -129,20 +129,6 @@ QString filterDirectPath(const QStringList &rootPaths,
     return fullPath;
 }
 
-QString filterEventPath(const QStringList &rootPaths,
-                        const VfsMonitorFileSystemWatcher::PathExcludePredicate &excludePredicate,
-                        const char *eventPath)
-{
-    if (!eventPath || eventPath[0] == '\0')
-        return {};
-
-    const QString fullPath = QDir::cleanPath(QString::fromUtf8(eventPath));
-    if (!fullPath.startsWith('/'))
-        return {};
-
-    return filterDirectPath(rootPaths, excludePredicate, fullPath);
-}
-
 }   // anonymous namespace
 
 // ========== VfsMonitorFileSystemWatcherPrivate ==========
@@ -175,6 +161,7 @@ VfsMonitorFileSystemWatcherPrivate::~VfsMonitorFileSystemWatcherPrivate()
 bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
 {
     mountPoints.clear();
+    orderedMountPoints.clear();
 
     libmnt_table *mtab = mnt_new_table();
     if (!mtab)
@@ -194,6 +181,7 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
             continue;
 
         mountPoints[entry.deviceId].append(entry.mountPoint);
+        orderedMountPoints.append({ entry.deviceId, entry.mountPoint });
     }
 
     for (auto &points : mountPoints) {
@@ -204,15 +192,16 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
                   });
     }
 
+    std::sort(orderedMountPoints.begin(), orderedMountPoints.end(),
+              [](const MountPointAlias &left, const MountPointAlias &right) {
+                  return left.mountPoint.length() > right.mountPoint.length();
+              });
+
     return !mountPoints.isEmpty();
 }
 
 QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char *absolutePath) const
 {
-    const QString directPath = filterEventPath(rootPaths, excludePredicate, absolutePath);
-    if (!directPath.isNull())
-        return directPath;
-
     if (!absolutePath || absolutePath[0] == '\0')
         return {};
 
@@ -220,27 +209,34 @@ QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char 
     if (!fullPath.startsWith('/'))
         return {};
 
-    for (auto deviceIt = mountPoints.cbegin(); deviceIt != mountPoints.cend(); ++deviceIt) {
-        const QStringList &points = deviceIt.value();
-        for (const QString &sourceMountPoint : points) {
-            if (!mountPointStartsWith(fullPath, sourceMountPoint))
-                continue;
+    const QString directPath = filterDirectPath(rootPaths, excludePredicate, fullPath);
+    if (!directPath.isNull())
+        return directPath;
 
-            const QString suffix = (sourceMountPoint == "/")
-                    ? fullPath
-                    : fullPath.mid(sourceMountPoint.length());
+    for (const MountPointAlias &sourceAlias : orderedMountPoints) {
+        if (!mountPointStartsWith(fullPath, sourceAlias.mountPoint))
+            continue;
 
-            for (const QString &candidateMountPoint : points) {
-                const QString candidateFullPath = (candidateMountPoint == "/")
-                        ? suffix
-                        : candidateMountPoint + suffix;
-                const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
-                if (!filteredCandidate.isNull())
-                    return filteredCandidate;
-            }
+        const auto pointsIt = mountPoints.constFind(sourceAlias.deviceId);
+        if (pointsIt == mountPoints.cend())
+            return {};
 
-            break;
+        const QString suffix = (sourceAlias.mountPoint == "/")
+                ? fullPath
+                : fullPath.mid(sourceAlias.mountPoint.length());
+
+        for (const QString &candidateMountPoint : pointsIt.value()) {
+            const QString candidateFullPath = (candidateMountPoint == "/")
+                    ? suffix
+                    : candidateMountPoint + suffix;
+            const QString filteredCandidate = filterDirectPath(rootPaths, excludePredicate, candidateFullPath);
+            if (!filteredCandidate.isNull())
+                return filteredCandidate;
         }
+
+        // The longest matching source mount point wins. If its aliases do not
+        // land inside a monitored root, do not fall back to shorter prefixes.
+        return {};
     }
 
     return {};
@@ -260,7 +256,8 @@ bool VfsMonitorFileSystemWatcherPrivate::initDispatcher()
         fmWarning() << "VfsMonitor: failed to initialize mount point aliases";
     }
 
-    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    // The notifier runs on the GUI thread, so keep dispatcher reads nonblocking.
+    socketFd = ::socket(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK, 0);
     if (socketFd < 0) {
         fmWarning() << "VfsMonitor: failed to create dispatcher socket:" << std::strerror(errno);
         return false;
@@ -292,136 +289,142 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
         return;
     }
 
-    DispatchEvent event {};
-    ssize_t received = -1;
-    do {
-        received = ::recv(socketFd, &event, sizeof(event), 0);
-    } while (received < 0 && errno == EINTR);
-
-    if (received == 0) {
-        fmWarning() << "VfsMonitor: event dispatcher connection closed";
-        if (notifier) {
-            notifier->setEnabled(false);
-        }
-        ::close(socketFd);
-        socketFd = -1;
-        return;
-    }
-
-    if (received < 0) {
-        if (errno != EAGAIN && errno != EWOULDBLOCK) {
-            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
-        }
-        return;
-    }
-
+    auto *q = q_ptr;
     constexpr size_t kMinMessageSize = offsetof(DispatchEvent, eventPath) + 1;
-    if (static_cast<size_t>(received) < kMinMessageSize) {
-        fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
-        return;
-    }
 
-    event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+    // Drain all queued packets for this wakeup so the notifier stays level-safe.
+    while (true) {
+        DispatchEvent event {};
+        ssize_t received = -1;
+        do {
+            received = ::recv(socketFd, &event, sizeof(event), 0);
+        } while (received < 0 && errno == EINTR);
 
-    const int act = event.action;
-    const uint32_t cookie = event.cookie;
-    const char *pathCStr = event.eventPath;
-
-    if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
-        return;
-    }
-
-    if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
-        if (!initMountPoints()) {
-            fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
-        }
-        return;
-    }
-
-    if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
-        QString fullPath = resolveAndFilterFullPath(pathCStr);
-        if (fullPath.isNull())
+        if (received == 0) {
+            fmWarning() << "VfsMonitor: event dispatcher connection closed";
+            if (notifier) {
+                notifier->setEnabled(false);
+            }
+            ::close(socketFd);
+            socketFd = -1;
             return;
+        }
+
+        if (received < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return;
+            }
+
+            fmWarning() << "VfsMonitor: failed to receive dispatcher event:" << std::strerror(errno);
+            return;
+        }
+
+        if (static_cast<size_t>(received) < kMinMessageSize) {
+            fmWarning() << "VfsMonitor: received short dispatcher message:" << received;
+            continue;
+        }
+
+        event.eventPath[kDispatchMaxPathLen - 1] = '\0';
+
+        const int act = event.action;
+        const uint32_t cookie = event.cookie;
+        const char *pathCStr = event.eventPath;
+
+        if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+            continue;
+        }
+
+        if (act == ACT_MOUNT || act == ACT_UNMOUNT) {
+            if (!initMountPoints()) {
+                fmWarning() << "VfsMonitor: failed to refresh mount point aliases";
+            }
+            continue;
+        }
+
+        if (act == ACT_RENAME_FROM_FILE || act == ACT_RENAME_FROM_FOLDER) {
+            QString fullPath = resolveAndFilterFullPath(pathCStr);
+            if (fullPath.isNull())
+                continue;
+
+            auto [parentPath, name] = splitPath(fullPath);
+            RenameFromInfo info;
+            info.path = parentPath;
+            info.name = name;
+            info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
+            pendingRenames.insert(cookie, info);
+            continue;
+        }
+
+        if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
+            const bool isDir = (act == ACT_RENAME_TO_FOLDER);
+            auto it = pendingRenames.find(cookie);
+            if (it != pendingRenames.end()) {
+                QString fullPath = resolveAndFilterFullPath(pathCStr);
+                if (!fullPath.isNull()) {
+                    auto [parentPath, name] = splitPath(fullPath);
+                    if (isDir)
+                        Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
+                    else
+                        Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
+                } else {
+                    if (isDir)
+                        Q_EMIT q->directoryDeleted(it->path, it->name);
+                    else
+                        Q_EMIT q->fileDeleted(it->path, it->name);
+                }
+                pendingRenames.erase(it);
+            } else {
+                QString fullPath = resolveAndFilterFullPath(pathCStr);
+                if (!fullPath.isNull()) {
+                    auto [parentPath, name] = splitPath(fullPath);
+                    if (isDir)
+                        Q_EMIT q->directoryCreated(parentPath, name);
+                    else
+                        Q_EMIT q->fileCreated(parentPath, name);
+                }
+            }
+            continue;
+        }
+
+        const QString fullPath = resolveAndFilterFullPath(pathCStr);
+        if (fullPath.isNull()) {
+            continue;
+        }
 
         auto [parentPath, name] = splitPath(fullPath);
-        RenameFromInfo info;
-        info.path = parentPath;
-        info.name = name;
-        info.isDirectory = (act == ACT_RENAME_FROM_FOLDER);
-        pendingRenames.insert(cookie, info);
-        return;
-    }
 
-    auto *q = q_ptr;
-    if (act == ACT_RENAME_TO_FILE || act == ACT_RENAME_TO_FOLDER) {
-        const bool isDir = (act == ACT_RENAME_TO_FOLDER);
-        auto it = pendingRenames.find(cookie);
-        if (it != pendingRenames.end()) {
-            QString fullPath = resolveAndFilterFullPath(pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryMoved(it->path, it->name, parentPath, name);
-                else
-                    Q_EMIT q->fileMoved(it->path, it->name, parentPath, name);
-            } else {
-                if (isDir)
-                    Q_EMIT q->directoryDeleted(it->path, it->name);
-                else
-                    Q_EMIT q->fileDeleted(it->path, it->name);
-            }
-            pendingRenames.erase(it);
-        } else {
-            QString fullPath = resolveAndFilterFullPath(pathCStr);
-            if (!fullPath.isNull()) {
-                auto [parentPath, name] = splitPath(fullPath);
-                if (isDir)
-                    Q_EMIT q->directoryCreated(parentPath, name);
-                else
-                    Q_EMIT q->fileCreated(parentPath, name);
-            }
+        switch (act) {
+        case ACT_NEW_FILE:
+        case ACT_NEW_LINK:
+        case ACT_NEW_SYMLINK:
+            Q_EMIT q->fileCreated(parentPath, name);
+            break;
+        case ACT_NEW_FOLDER:
+            Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        case ACT_DEL_FILE:
+            Q_EMIT q->fileDeleted(parentPath, name);
+            break;
+        case ACT_DEL_FOLDER:
+            Q_EMIT q->directoryDeleted(parentPath, name);
+            break;
+        case ACT_RENAME_FILE:
+            Q_EMIT q->fileCreated(parentPath, name);
+            break;
+        case ACT_RENAME_FOLDER:
+            Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        default:
+            break;
         }
-        return;
-    }
 
-    const QString fullPath = resolveAndFilterFullPath(pathCStr);
-    if (fullPath.isNull()) {
-        return;
-    }
-
-    auto [parentPath, name] = splitPath(fullPath);
-
-    switch (act) {
-    case ACT_NEW_FILE:
-    case ACT_NEW_LINK:
-    case ACT_NEW_SYMLINK:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-    case ACT_NEW_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-    case ACT_DEL_FILE:
-        Q_EMIT q->fileDeleted(parentPath, name);
-        break;
-    case ACT_DEL_FOLDER:
-        Q_EMIT q->directoryDeleted(parentPath, name);
-        break;
-    case ACT_RENAME_FILE:
-        Q_EMIT q->fileCreated(parentPath, name);
-        break;
-    case ACT_RENAME_FOLDER:
-        Q_EMIT q->directoryCreated(parentPath, name);
-        break;
-    default:
-        break;
-    }
-
-    // Clean up orphaned RENAME_FROM entries.
-    static constexpr int kPendingRenameCleanupThreshold = 1000;
-    if (pendingRenames.size() > kPendingRenameCleanupThreshold) {
-        fmWarning() << "VfsMonitor: pending rename table too large ("
-                    << pendingRenames.size() << "), clearing";
-        pendingRenames.clear();
+        // Clean up orphaned RENAME_FROM entries.
+        static constexpr int kPendingRenameCleanupThreshold = 1000;
+        if (pendingRenames.size() > kPendingRenameCleanupThreshold) {
+            fmWarning() << "VfsMonitor: pending rename table too large ("
+                        << pendingRenames.size() << "), clearing";
+            pendingRenames.clear();
+        }
     }
 }
 

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
@@ -16,16 +16,16 @@ SERVICETEXTINDEX_BEGIN_NAMESPACE
 class VfsMonitorFileSystemWatcherPrivate;
 
 // VfsMonitorFileSystemWatcher: File system watcher using deepin-anything
-// vfs_monitor kernel module via Linux Generic Netlink multicast.
+// event dispatcher socket exposed by deepin-anything-server.
 //
-// Receives global file system events (create, delete, move) from the kernel,
-// covering all mounted filesystems without the need for recursive inotify watches.
-// File close events (IN_CLOSE_WRITE) are NOT provided -- use InotifyFileSystemWatcher
-// for those.
+// Receives global file system events (create, delete, move) forwarded by
+// deepin-anything-server from /run/deepin-anything/event-dispatcher.sock.
+// File close events (IN_CLOSE_WRITE) are NOT provided -- use
+// InotifyFileSystemWatcher for those.
 //
 // Usage:
 //   auto *watcher = VfsMonitorFileSystemWatcher::create(rootPaths, excludePredicate, parent);
-//   if (watcher) { ... }  // kernel module available
+//   if (watcher) { ... }  // event dispatcher available
 //   // else: fallback to inotify-only mode
 class VfsMonitorFileSystemWatcher : public QObject
 {
@@ -35,13 +35,14 @@ class VfsMonitorFileSystemWatcher : public QObject
 
 public:
     // Predicate for path exclusion. Return true to suppress the event.
-    // Called from the netlink callback thread context (main thread via Qt event loop).
+    // Called from the main thread via Qt event loop.
     using PathExcludePredicate = std::function<bool(const QString &fullPath)>;
 
     ~VfsMonitorFileSystemWatcher() override;
 
-    // Factory method: attempts to connect to the vfsmonitor Generic Netlink family.
-    // Returns nullptr if the kernel module is not available (graceful degradation).
+    // Factory method: attempts to connect to the deepin-anything event
+    // dispatcher socket. Returns nullptr if the dispatcher is not available
+    // (graceful degradation).
     static VfsMonitorFileSystemWatcher *create(const QStringList &rootPaths,
                                                PathExcludePredicate excludePredicate,
                                                QObject *parent = nullptr);

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -11,9 +11,8 @@
 #include <QHash>
 #include <QStringList>
 
+#include <cstdint>
 #include <sys/types.h>
-
-struct nl_sock;
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
@@ -24,20 +23,6 @@ struct RenameFromInfo
     QString name;
     bool isDirectory { false };
 };
-
-// Netlink attribute indices (matching vfs_genl.h)
-enum VfsMonitorAttr : int {
-    VFSMONITOR_A_UNSPEC = 0,
-    VFSMONITOR_A_ACT,
-    VFSMONITOR_A_COOKIE,
-    VFSMONITOR_A_MAJOR,
-    VFSMONITOR_A_MINOR,
-    VFSMONITOR_A_PATH,
-    VFSMONITOR_A_UID,
-    VFSMONITOR_A_TGID,
-    __VFSMONITOR_A_MAX
-};
-#define VFSMONITOR_A_MAX (__VFSMONITOR_A_MAX - 1)
 
 // Event action constants (matching vfs_change_consts.h)
 enum VfsMonitorAct : uint8_t {
@@ -67,12 +52,13 @@ public:
                                        VfsMonitorFileSystemWatcher *qq);
     ~VfsMonitorFileSystemWatcherPrivate();
 
-    bool initNetlink();
-    void handleNetlinkMessage();
+    bool initDispatcher();
+    void handleSocketMessage();
 
-    // Reconstruct full path from relative path + device, then check against
-    // rootPaths and excludePredicate. Returns null if filtered out.
-    QString resolveAndFilterFullPath(dev_t deviceId, const char *relativePath) const;
+    // The event dispatcher sends absolute paths, but they may use a different
+    // mount alias than the monitored root path. This helper normalizes across
+    // same-device mount aliases before applying rootPaths and excludePredicate.
+    QString resolveAndFilterFullPath(const char *absolutePath) const;
 
     static QPair<QString, QString> splitPath(const QString &fullPath);
 
@@ -81,22 +67,13 @@ public:
     QStringList rootPaths;
     VfsMonitorFileSystemWatcher::PathExcludePredicate excludePredicate;
 
-    nl_sock *nlSock { nullptr };
+    int socketFd { -1 };
     QSocketNotifier *notifier { nullptr };
 
     QHash<uint32_t, RenameFromInfo> pendingRenames;
-
-    // dev_t -> sorted mount point list (longest first).
     QHash<dev_t, QStringList> mountPoints;
-    QHash<dev_t, QStringList> childMountPoints;
-    bool lowerFsExists { false };
-
-    // Set to true when an ACT_MOUNT/ACT_UNMOUNT event is received, cleared
-    // after initMountPoints() rebuilds the cache in handleNetlinkMessage().
-    bool mountPointsDirty { false };
 
     bool initMountPoints();
-    bool isLowerFsEvent(dev_t deviceId, const QString &fullPath) const;
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -10,6 +10,7 @@
 #include <QSocketNotifier>
 #include <QHash>
 #include <QStringList>
+#include <QVector>
 
 #include <cstdint>
 #include <sys/types.h>
@@ -22,6 +23,12 @@ struct RenameFromInfo
     QString path;
     QString name;
     bool isDirectory { false };
+};
+
+struct MountPointAlias
+{
+    dev_t deviceId { 0 };
+    QString mountPoint;
 };
 
 // Event action constants (matching vfs_change_consts.h)
@@ -72,6 +79,7 @@ public:
 
     QHash<uint32_t, RenameFromInfo> pendingRenames;
     QHash<dev_t, QStringList> mountPoints;
+    QVector<MountPointAlias> orderedMountPoints;
 
     bool initMountPoints();
 };


### PR DESCRIPTION
## 根因分析

`taghelper.cpp:281` 的 `crumbEditInputFilter()` 在过滤特殊字符时使用了破坏性的 `setPlainText()` —— 它销毁了 QTextDocument 中所有 crumb 对象（已有的标记），导致 `crumbList()` 返回空，后续 `processTags()` → `setTagsForFiles(empty)` 将文件中所有既有标记删除。

经 dtkwidget 源码验证，`DCrumbEdit::_q_onTextChanged()` 在 `textChanged` 信号触发后同步扫描 document 并重建内部 `formatList`。`setPlainText()` 触发清空后，中间的恢复逻辑依赖已被破坏的 `crumbList()`，形成逻辑"自噬"。

## 修复方案

将 `setPlainText()` 替换为使用 `QTextCursor` 的逐 fragment 过滤 —— 遍历 QTextDocument 的每个文本块，仅对普通文本 fragment（非 ObjectReplacementCharacter）执行正则过滤删除特殊字符，跳过所有 crumb 对象。同时删除不再需要的 crumb 恢复逻辑。改动仅影响 `taghelper.cpp` 一个文件，+19 / -13 行。

## 改动安全评估

**低风险**：仅修改 `crumbEditInputFilter` 内部实现，函数签名不变，唯一调用者 `TagEditor::filterInput()` 不受影响，无外部调用者。

## Summary by Sourcery

Switch filesystem monitor from kernel netlink to deepin-anything dispatcher, harden disk encryption/recent file handling, and fix multiple UI/UX and robustness issues across file manager components.

New Features:
- Introduce a dispatcher-based VfsMonitor watcher that consumes events from deepin-anything-server via UNIX socket instead of kernel netlink.
- Add a lightweight recent:// file watcher and batch-processing pipeline for recent items to keep startup responsive with large histories.
- Expose image preview status text as a layout-managed status bar widget with alignment hints for the preview host.
- Add a dedicated polkit action path for TPM PIN-based disk-encryption passphrase changes.

Bug Fixes:
- Fix tag editor input filtering so removing illegal characters no longer destroys existing tag crumbs.
- Correct sidebar drag-hover and drop hit-testing under Wayland/touch so hover state and drop acceptance track the real cursor position.
- Prevent stale drag-selection state from breaking file view layouts after touch long-press context menus.
- Handle image/text preview of icns and other formats with invalid size metadata by decoding safely and scaling after read instead of treating them as corrupt.
- Avoid recursive or invalid reads when generating thumbnails for images with missing size metadata, while still producing thumbnails when decoding is possible.
- Ensure broken SMB symlink detection only triggers when the share is truly unmounted, not just when the target inside the share is missing.
- Fix duplicate or missing burn-job failure dialogs and ensure error details are shown even when no low-level messages are available.
- Stop late or pending search callbacks from firing after their owning window/titlebar has been destroyed, preventing crashes during shutdown.
- Prevent crashes from stale QPersistentModelIndex in FileView teardown by ordering select-helper cleanup and explicit model deletion.
- Improve hit area and vertical alignment for group expand/collapse arrows, fixing missed clicks caused by spacing in grouped views.
- Avoid hiding the last window when tearing off a pinned tab and refine window positioning to follow the cursor.
- Restore memory info reporting when UniversalUtils::computerMemory() fails by falling back to DSysInfo.
- Ensure decrypt-resume and pending backup header handling respect the current encryption status so options and stale files are cleaned up when devices are reformatted.
- Make erase-job device-disconnect errors visible by propagating the underlying error string into the user dialog.

Enhancements:
- Normalize watched root paths and mount-point aliases, and simplify lowerfs handling in the text indexer to improve path resolution and overlay/alias correctness.
- Refresh mount-point aliases lazily on mount/unmount events and filter events via a shared helper that applies root/exclude rules consistently.
- Improve conflict-error messaging by eliding long source/target paths based on actual label width and template text rather than fixed character counts.
- Refine search bar and address bar focus handling so on-screen keyboards appear appropriately and delayed searches are cancelled on exit.
- Simplify dir-share anonymous-permission restoration by centralizing it in the backend close-share path and emitting a failure signal when close-share fails.
- Improve available-geometry calculation under fractional scaling/Wayland so dock avoidance respects logical vs physical coordinates.
- Tighten sidebar hover rendering by centralizing hover index updates and repainting only impacted rows.
- Guard recent-item timestamps behind a dedicated RecentFileInfo API so time access updates are type-safe and cached per recent item.
- Limit wallpaper context menu to formats actually supported by the wallpaper system (excluding GIF).

Build:
- Update textindex CMake dependencies to use libmount instead of libnl after switching to the dispatcher-based VfsMonitor watcher.

CI:
- Bump GitHub Actions checkout action to v7 and enable unsafe PR checkout for cppcheck workflow.

Deployment:
- Ship the dfm-reencrypt desktop file via packaging into /usr/share/applications instead of creating it at runtime, and drop tmpfiles.d creation of /usr/local/share/applications.

Tests:
- Adjust VfsMonitor filesystem watcher tests to target the deepin-anything dispatcher socket instead of the kernel module and keep tests skippable when the dispatcher is unavailable.

Chores:
- Align various comments, logging messages, and JSON/policy metadata with the new dispatcher-based fsmonitor and updated encryption/search behaviors.