### PR TITLE
fix: fix special chars in tag editor clearing existing tags

### DIFF
--- a/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
+++ b/src/plugins/common/dfmplugin-tag/utils/taghelper.cpp
@@ -15,6 +15,9 @@
 #include <QPainter>
 #include <QUrl>
 #include <QIcon>
+#include <QTextBlock>
+#include <QTextCursor>
+#include <QTextFragment>
 
 #include <random>
 #include <mutex>
@@ -275,22 +278,45 @@ void TagHelper::crumbEditInputFilter(DCrumbEdit *edit)
     if (!edit)
         return;
 
-    QString srcTcxt = edit->toPlainText().remove(QChar::ObjectReplacementCharacter);
     QRegularExpression rx("[\\\\/\':\\*\\?\"<>|%&]");
-    if (!srcTcxt.isEmpty() && srcTcxt.contains(rx)) {
-        edit->textCursor().document()->setPlainText(srcTcxt.remove(rx));
-        const auto &tagsColors = TagManager::instance()->getTagsColor(edit->crumbList());
-        edit->setProperty("updateCrumbsColor", true);
 
-        for (auto it = tagsColors.begin(); it != tagsColors.end(); ++it) {
-            DCrumbTextFormat format = edit->makeTextFormat();
-            format.setText(it.key());
-            format.setBackground(QBrush(it.value()));
-            format.setBackgroundRadius(5);
-            edit->insertCrumb(format, 0);
+    // Pass 1: collect ranges to sanitize without mutating the document.
+    //         QTextBlock::iterator holds internal pointers into the
+    //         fragment table; mutating during iteration can invalidate them.
+    struct Range
+    {
+        int pos;
+        int len;
+        QString newText;
+    };
+    QList<Range> ranges;
+    for (QTextBlock block = edit->textCursor().document()->begin(); block.isValid(); block = block.next()) {
+        for (auto it = block.begin(); it != block.end(); ++it) {
+            QTextFragment frag = it.fragment();
+            if (!frag.isValid())
+                continue;
+            QString text = frag.text();
+            // skip crumb objects (ObjectReplacementCharacter)
+            if (text.contains(QChar::ObjectReplacementCharacter))
+                continue;
+            if (text.contains(rx))
+                ranges.append({ frag.position(), frag.length(), text.remove(rx) });
         }
-        edit->setProperty("updateCrumbsColor", false);
     }
+
+    if (ranges.isEmpty())
+        return;
+
+    // Pass 2: apply changes from end to start so earlier positions stay valid.
+    QTextCursor cursor(edit->textCursor());
+    cursor.beginEditBlock();
+    for (int i = ranges.size() - 1; i >= 0; --i) {
+        const auto &r = ranges[i];
+        cursor.setPosition(r.pos);
+        cursor.setPosition(r.pos + r.len, QTextCursor::KeepAnchor);
+        cursor.insertText(r.newText);
+    }
+    cursor.endEditBlock();
 }
 
 void TagHelper::initTagColorDefines()


### PR DESCRIPTION
1. 替换 setPlainText() 破坏性操作为逐 fragment 过滤，仅修改纯文本部分;
2. 跳过 crumb 对象（ObjectReplacementCharacter），避免已有标记被销毁;
3. 使用 beginEditBlock/endEditBlock 确保文本操作原子性;

=====================================
1. replaced destructive setPlainText() with per-fragment filtering on plain text only;
2. skipped crumb objects (ObjectReplacementCharacter) to preserve existing tags;
3. wrapped changes in beginEditBlock/endEditBlock for atomic text operation;

Log: 修复标记编辑器输入特殊字符会清空已有标记的问题，改为非破坏性逐字符过滤

PMS: BUG-372877
Bug: https://pms.uniontech.com/bug-view-372877.html

## Summary by Sourcery

Bug Fixes:
- Fix tag editor behavior where entering special characters could clear existing tags by limiting sanitization to plain-text fragments and preserving crumb objects.