### PR TITLE
fix: filter out non-existent files in shred file model

### DIFF
--- a/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.cpp
@@ -68,6 +68,14 @@ QVariant ShredFileModel::data(const QModelIndex &index, int role) const
 void ShredFileModel::setFileList(const QList<QUrl> &fileList)
 {
     beginResetModel();
-    urlList = fileList;
+    urlList.clear();
+    for (const auto &url : fileList) {
+        auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto);
+        if (!info || !info->exists()) {
+            fmWarning() << "The file is invalid and will be excluded: " << url;
+            continue;
+        }
+        urlList.append(url);
+    }
     endResetModel();
 }


### PR DESCRIPTION
## 根因分析

`ShredFileModel::data()` 在文件被外部删除后返回空 `QVariant`，但没有移除对应的模型行，导致 Qt Model/View 框架保留空白行位。

## 修复方案

在 `ShredFileModel::setFileList()` 入口过滤 `info->exists()` 为 false 的无效文件，不添加到模型。

## 改动安全评估

低风险：仅添加入口过滤逻辑，无外部调用者，签名不变。

## Summary by Sourcery

Bug Fixes:
- Exclude non-existent or invalid files from ShredFileModel to avoid blank entries after external file deletion.