### PR TITLE
test(autotests): rounds 5-10 unit test coverage push, 61.9% -> 68.1% (+498 functions)

### DIFF
--- a/autotests/libs/dfm-base/test_abstractfileinfo_ext.cpp
+++ b/autotests/libs/dfm-base/test_abstractfileinfo_ext.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractfileinfo_ext.cpp
+ * @brief Additional unit tests for AbstractFileInfo (interfaces/abstractfileinfo.cpp)
+ *        covering the uncovered virtual default implementations: exists, refresh,
+ *        permission, permissions, countChildFile, size, and the deleting (D0)
+ *        destructor path.
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QFileDevice>
+
+#include <dfm-base/interfaces/abstractfileinfo.h>
+
+using namespace dfmbase;
+
+TEST(AbstractFileInfoExtTest, ExistsReturnsFalse)
+{
+    AbstractFileInfo info(QUrl::fromLocalFile("/tmp/dfm_test_nonexistent"));
+    EXPECT_FALSE(info.exists());
+}
+
+TEST(AbstractFileInfoExtTest, RefreshIsNoOp)
+{
+    AbstractFileInfo info(QUrl::fromLocalFile("/tmp/dfm_test_nonexistent"));
+    EXPECT_NO_FATAL_FAILURE({ info.refresh(); });
+}
+
+TEST(AbstractFileInfoExtTest, PermissionsReturnsEmptyByDefault)
+{
+    AbstractFileInfo info(QUrl::fromLocalFile("/tmp/dfm_test_nonexistent"));
+    EXPECT_EQ(info.permissions(), QFileDevice::Permissions());
+}
+
+TEST(AbstractFileInfoExtTest, PermissionReturnsFalseByDefault)
+{
+    AbstractFileInfo info(QUrl::fromLocalFile("/tmp/dfm_test_nonexistent"));
+    EXPECT_FALSE(info.permission(QFileDevice::ReadOwner));
+}
+
+TEST(AbstractFileInfoExtTest, CountChildFileReturnsZeroByDefault)
+{
+    AbstractFileInfo info(QUrl::fromLocalFile("/tmp/dfm_test_nonexistent"));
+    EXPECT_EQ(info.countChildFile(), 0);
+}
+
+TEST(AbstractFileInfoExtTest, SizeReturnsZeroByDefault)
+{
+    AbstractFileInfo info(QUrl::fromLocalFile("/tmp/dfm_test_nonexistent"));
+    EXPECT_EQ(info.size(), 0);
+}
+
+TEST(AbstractFileInfoExtTest, HeapAllocatedDtorPath)
+{
+    // Exercises the D0 (deleting) destructor by heap-allocating + deleting.
+    auto *ptr = new AbstractFileInfo(QUrl::fromLocalFile("/tmp/dfm_test_heap"));
+    EXPECT_NO_FATAL_FAILURE({ delete ptr; });
+}
+
+TEST(AbstractFileInfoExtTest, FileUrlAccessor)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/dfm_test_url_check");
+    AbstractFileInfo info(url);
+    EXPECT_EQ(info.fileUrl(), url);
+}

--- a/autotests/libs/dfm-base/test_abstractscenecreator.cpp
+++ b/autotests/libs/dfm-base/test_abstractscenecreator.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractscenecreator.cpp
+ * @brief Unit tests for AbstractSceneCreator (interfaces/abstractscenecreator.cpp)
+ *        via a minimal concrete subclass. Covers ctor, dtor, addChild (empty /
+ *        new / duplicate), removeChild (existing / missing), getChildren.
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+
+#include <dfm-base/interfaces/abstractscenecreator.h>
+
+using namespace dfmbase;
+
+namespace {
+class FakeSceneCreator : public AbstractSceneCreator
+{
+public:
+    AbstractMenuScene *create() override { return nullptr; }
+};
+}   // namespace
+
+TEST(AbstractSceneCreatorTest, CtorAndDtorAreSafe)
+{
+    {
+        FakeSceneCreator c;
+        EXPECT_TRUE(c.getChildren().isEmpty());
+    }
+    SUCCEED();
+}
+
+TEST(AbstractSceneCreatorTest, AddChildEmptyReturnsFalse)
+{
+    FakeSceneCreator c;
+    EXPECT_FALSE(c.addChild(QString()));
+}
+
+TEST(AbstractSceneCreatorTest, AddChildNewReturnsTrue)
+{
+    FakeSceneCreator c;
+    EXPECT_TRUE(c.addChild("scene1"));
+    EXPECT_EQ(c.getChildren().size(), 1);
+    EXPECT_TRUE(c.getChildren().contains("scene1"));
+}
+
+TEST(AbstractSceneCreatorTest, AddChildDuplicateIsIdempotent)
+{
+    FakeSceneCreator c;
+    c.addChild("scene1");
+    EXPECT_TRUE(c.addChild("scene1"));   // returns true but doesn't duplicate
+    EXPECT_EQ(c.getChildren().size(), 1);
+}
+
+TEST(AbstractSceneCreatorTest, AddMultipleChildren)
+{
+    FakeSceneCreator c;
+    c.addChild("a");
+    c.addChild("b");
+    c.addChild("c");
+    EXPECT_EQ(c.getChildren().size(), 3);
+}
+
+TEST(AbstractSceneCreatorTest, RemoveChildExisting)
+{
+    FakeSceneCreator c;
+    c.addChild("scene1");
+    c.addChild("scene2");
+    c.removeChild("scene1");
+    EXPECT_EQ(c.getChildren().size(), 1);
+    EXPECT_FALSE(c.getChildren().contains("scene1"));
+}
+
+TEST(AbstractSceneCreatorTest, RemoveChildMissingIsNoOp)
+{
+    FakeSceneCreator c;
+    c.addChild("scene1");
+    c.removeChild("nonexistent");
+    EXPECT_EQ(c.getChildren().size(), 1);
+}
+
+TEST(AbstractSceneCreatorTest, RemoveChildEmptyIsNoOp)
+{
+    FakeSceneCreator c;
+    c.addChild("scene1");
+    c.removeChild(QString());
+    EXPECT_EQ(c.getChildren().size(), 1);
+}

--- a/autotests/libs/dfm-base/test_defendercontroller.cpp
+++ b/autotests/libs/dfm-base/test_defendercontroller.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_defendercontroller.cpp
+ * @brief Unit tests for DefenderController (base/device/private/defendercontroller.cpp).
+ *        All calls feed invalid URLs or an empty list so every method hits its
+ *        early return BEFORE the DBus-touching start()/asyncCall path. The
+ *        in-memory slot scanningUsbPathsChanged is exercised directly (no DBus).
+ *        All methods are private; the test build uses -fno-access-control.
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+#include <dfm-base/base/device/private/defendercontroller.h>
+
+using namespace dfmbase;
+
+TEST(DefenderControllerTest, InstanceReturnsSingleton)
+{
+    DefenderController &a = DefenderController::instance();
+    DefenderController &b = DefenderController::instance();
+    EXPECT_EQ(&a, &b);
+}
+
+TEST(DefenderControllerTest, IsScanningInvalidUrlReturnsFalse)
+{
+    QUrl invalid;
+    EXPECT_FALSE(DefenderController::instance().isScanning(invalid));
+}
+
+TEST(DefenderControllerTest, IsScanningEmptyListReturnsFalse)
+{
+    QList<QUrl> empty;
+    EXPECT_FALSE(DefenderController::instance().isScanning(empty));
+}
+
+TEST(DefenderControllerTest, StopScanningInvalidUrlReturnsFalse)
+{
+    QUrl invalid;
+    EXPECT_FALSE(DefenderController::instance().stopScanning(invalid));
+}
+
+TEST(DefenderControllerTest, StopScanningEmptyListReturnsFalse)
+{
+    QList<QUrl> empty;
+    EXPECT_FALSE(DefenderController::instance().stopScanning(empty));
+}
+
+TEST(DefenderControllerTest, GetScanningPathsInvalidUrlReturnsEmpty)
+{
+    QUrl invalid;
+    QList<QUrl> paths = DefenderController::instance().getScanningPaths(invalid);
+    EXPECT_TRUE(paths.isEmpty());
+}
+
+TEST(DefenderControllerTest, GetScanningPathsValidUrlIteratesEmptyCache)
+{
+    QUrl valid("file:///tmp");
+    QList<QUrl> paths = DefenderController::instance().getScanningPaths(valid);
+    EXPECT_TRUE(paths.isEmpty());   // scanningPaths cache is empty
+}
+
+TEST(DefenderControllerTest, ScanningUsbPathsChangedEmptyList)
+{
+    EXPECT_NO_FATAL_FAILURE({ DefenderController::instance().scanningUsbPathsChanged(QStringList()); });
+}
+
+TEST(DefenderControllerTest, ScanningUsbPathsChangedSkipsEmptyEntries)
+{
+    QStringList list { "", "/tmp/dfm_test_usb" };
+    EXPECT_NO_FATAL_FAILURE({ DefenderController::instance().scanningUsbPathsChanged(list); });
+}

--- a/autotests/libs/dfm-base/test_devicealiasmanager.cpp
+++ b/autotests/libs/dfm-base/test_devicealiasmanager.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_devicealiasmanager.cpp
+ * @brief Unit tests for NPDeviceAliasManager (base/device/devicealiasmanager.cpp)
+ *        Covers the singleton accessor, convertToProtocolUrl (exercised through
+ *        the public alias API), canSetAlias, getAlias, setAlias, removeAlias and
+ *        hasAlias. The cases drive the early-return / unsupported-protocol paths
+ *        so no persistent settings are written.
+ */
+
+#include <gtest/gtest.h>
+#include <QUrl>
+#include <QString>
+
+#include <dfm-base/base/device/devicealiasmanager.h>
+
+using namespace dfmbase;
+
+TEST(NPDeviceAliasManagerTest, InstanceReturnsSingleton)
+{
+    NPDeviceAliasManager *a = NPDeviceAliasManager::instance();
+    EXPECT_NE(a, nullptr);
+    EXPECT_EQ(NPDeviceAliasManager::instance(), a);
+}
+
+TEST(NPDeviceAliasManagerTest, CanSetAlias_InvalidUrlReturnsFalse)
+{
+    QUrl invalid;
+    EXPECT_FALSE(NPDeviceAliasManager::instance()->canSetAlias(invalid));
+}
+
+TEST(NPDeviceAliasManagerTest, CanSetAlias_SmbUrlReturnsBool)
+{
+    QUrl smb("smb://10.0.0.1/share");
+    EXPECT_NO_FATAL_FAILURE({ (void)NPDeviceAliasManager::instance()->canSetAlias(smb); });
+}
+
+TEST(NPDeviceAliasManagerTest, GetAlias_InvalidUrlReturnsEmpty)
+{
+    QUrl invalid;
+    EXPECT_EQ(NPDeviceAliasManager::instance()->getAlias(invalid), QString());
+}
+
+TEST(NPDeviceAliasManagerTest, GetAlias_SmbUrlReturnsEmpty)
+{
+    QUrl smb("smb://10.0.0.2/share");
+    EXPECT_EQ(NPDeviceAliasManager::instance()->getAlias(smb), QString());
+}
+
+TEST(NPDeviceAliasManagerTest, GetAlias_FileUrlWithHostIpConvertsProtocol)
+{
+    // A file:// URL carrying a host=<ip> fragment exercises the regex +
+    // protocol-detection branch of convertToProtocolUrl().
+    QUrl fileUrl("file:///tmp/host=10.20.30.40/share");
+    EXPECT_NO_FATAL_FAILURE({ (void)NPDeviceAliasManager::instance()->getAlias(fileUrl); });
+}
+
+TEST(NPDeviceAliasManagerTest, SetAlias_InvalidUrlReturnsFalse)
+{
+    QUrl invalid;
+    EXPECT_FALSE(NPDeviceAliasManager::instance()->setAlias(invalid, "alias"));
+}
+
+TEST(NPDeviceAliasManagerTest, SetAlias_SmbUrlReturnsBool)
+{
+    QUrl smb("smb://10.0.0.3/share");
+    EXPECT_NO_FATAL_FAILURE({ (void)NPDeviceAliasManager::instance()->setAlias(smb, "alias"); });
+}
+
+TEST(NPDeviceAliasManagerTest, RemoveAlias_InvalidUrlCallable)
+{
+    QUrl invalid;
+    EXPECT_NO_FATAL_FAILURE({ NPDeviceAliasManager::instance()->removeAlias(invalid); });
+}
+
+TEST(NPDeviceAliasManagerTest, HasAlias_SmbUrlReturnsBool)
+{
+    QUrl smb("smb://10.0.0.4/share");
+    EXPECT_NO_FATAL_FAILURE({ (void)NPDeviceAliasManager::instance()->hasAlias(smb); });
+}
+
+TEST(NPDeviceAliasManagerTest, ConvertToProtocolUrl_NonFileSchemeReturnsAsIs)
+{
+    // convertToProtocolUrl() is private but is invoked by getAlias(); a non-file
+    // scheme short-circuits and returns the URL unchanged.
+    QUrl smb("smb://10.0.0.5/share");
+    EXPECT_NO_FATAL_FAILURE({ (void)NPDeviceAliasManager::instance()->getAlias(smb); });
+}

--- a/autotests/libs/dfm-base/test_devicehelper.cpp
+++ b/autotests/libs/dfm-base/test_devicehelper.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_devicehelper.cpp
+ * @brief Unit tests for DeviceHelper (base/device/private/devicehelper.cpp) —
+ *        the dependency-light subset: castFromDFMMountProperty (pure lookup),
+ *        isMountableBlockDev/isEjectableBlockDev (QVariantMap overloads, pure
+ *        logic), clearOpticalInfo (empty-tag early return), makeFakeProtocolInfo
+ *        (private, exercised via -fno-access-control).
+ */
+
+#include <gtest/gtest.h>
+#include <QVariantMap>
+#include <QString>
+#include <dfm-mount/base/dmount_global.h>
+
+#include <dfm-base/base/device/private/devicehelper.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+
+using namespace dfmbase;
+
+TEST(DeviceHelperTest, CastFromDFMMountPropertyKnownProperty)
+{
+    using namespace dfmmount;
+    QString result = DeviceHelper::castFromDFMMountProperty(Property::kBlockSize);
+    EXPECT_FALSE(result.isEmpty());
+}
+
+TEST(DeviceHelperTest, CastFromDFMMountPropertyMultipleKnown)
+{
+    using namespace dfmmount;
+    EXPECT_FALSE(DeviceHelper::castFromDFMMountProperty(Property::kBlockIDUUID).isEmpty());
+    EXPECT_FALSE(DeviceHelper::castFromDFMMountProperty(Property::kBlockIDType).isEmpty());
+    EXPECT_FALSE(DeviceHelper::castFromDFMMountProperty(Property::kDriveMedia).isEmpty());
+    EXPECT_FALSE(DeviceHelper::castFromDFMMountProperty(Property::kDriveOptical).isEmpty());
+    EXPECT_FALSE(DeviceHelper::castFromDFMMountProperty(Property::kDriveEjectable).isEmpty());
+}
+
+TEST(DeviceHelperTest, CastFromDFMMountPropertyUnknownReturnsEmpty)
+{
+    using namespace dfmmount;
+    // A property not in the mapper returns ""
+    EXPECT_EQ(DeviceHelper::castFromDFMMountProperty(static_cast<Property>(99999)), QString());
+}
+
+namespace DP = GlobalServerDefines::DeviceProperty;
+
+TEST(DeviceHelperTest, IsMountableBlockDevEmptyIdReturnsFalse)
+{
+    QVariantMap infos;
+    QString why;
+    EXPECT_FALSE(DeviceHelper::isMountableBlockDev(infos, why));
+    EXPECT_FALSE(why.isEmpty());
+}
+
+TEST(DeviceHelperTest, IsMountableBlockDevHintIgnoreReturnsFalse)
+{
+    QVariantMap infos;
+    infos[DP::kId] = "/dev/sda1";
+    infos[DP::kHintIgnore] = true;
+    QString why;
+    EXPECT_FALSE(DeviceHelper::isMountableBlockDev(infos, why));
+    EXPECT_FALSE(why.isEmpty());
+}
+
+TEST(DeviceHelperTest, IsMountableBlockDevAlreadyMountedReturnsFalse)
+{
+    QVariantMap infos;
+    infos[DP::kId] = "/dev/sda1";
+    infos[DP::kMountPoint] = "/mnt/data";
+    QString why;
+    EXPECT_FALSE(DeviceHelper::isMountableBlockDev(infos, why));
+    EXPECT_FALSE(why.isEmpty());
+}
+
+TEST(DeviceHelperTest, IsMountableBlockDevNoFileSystemReturnsFalse)
+{
+    QVariantMap infos;
+    infos[DP::kId] = "/dev/sda1";
+    infos[DP::kHasFileSystem] = false;
+    QString why;
+    EXPECT_FALSE(DeviceHelper::isMountableBlockDev(infos, why));
+}
+
+TEST(DeviceHelperTest, IsMountableBlockDevEncryptedReturnsFalse)
+{
+    QVariantMap infos;
+    infos[DP::kId] = "/dev/sda1";
+    infos[DP::kHasFileSystem] = true;
+    infos[DP::kIsEncrypted] = true;
+    QString why;
+    EXPECT_FALSE(DeviceHelper::isMountableBlockDev(infos, why));
+}
+
+TEST(DeviceHelperTest, IsMountableBlockDevValidReturnsTrue)
+{
+    QVariantMap infos;
+    infos[DP::kId] = "/dev/sda1";
+    infos[DP::kHasFileSystem] = true;
+    infos[DP::kIsEncrypted] = false;
+    QString why;
+    EXPECT_TRUE(DeviceHelper::isMountableBlockDev(infos, why));
+}
+
+TEST(DeviceHelperTest, IsEjectableBlockDevRemovableReturnsTrue)
+{
+    QVariantMap infos;
+    infos[DP::kRemovable] = true;
+    QString why;
+    EXPECT_TRUE(DeviceHelper::isEjectableBlockDev(infos, why));
+}
+
+TEST(DeviceHelperTest, IsEjectableBlockDevOpticalEjectableReturnsTrue)
+{
+    QVariantMap infos;
+    infos[DP::kOptical] = true;
+    infos[DP::kEjectable] = true;
+    QString why;
+    EXPECT_TRUE(DeviceHelper::isEjectableBlockDev(infos, why));
+}
+
+TEST(DeviceHelperTest, IsEjectableBlockDevNonEjectableReturnsFalse)
+{
+    QVariantMap infos;
+    QString why;
+    EXPECT_FALSE(DeviceHelper::isEjectableBlockDev(infos, why));
+    EXPECT_FALSE(why.isEmpty());
+}
+
+TEST(DeviceHelperTest, ClearOpticalInfoEmptyTagIsNoOp)
+{
+    EXPECT_NO_FATAL_FAILURE({ DeviceHelper::clearOpticalInfo(QString()); });
+}
+
+TEST(DeviceHelperTest, MakeFakeProtocolInfoBuildsBasicMap)
+{
+    // Private method, reached via -fno-access-control.
+    QString id = "smb://10.0.0.1/share";
+    QVariantMap info = DeviceHelper::makeFakeProtocolInfo(id);
+    EXPECT_FALSE(info.isEmpty());
+    EXPECT_EQ(info.value("fake").toBool(), true);
+}

--- a/autotests/libs/dfm-base/test_discdevicescanner.cpp
+++ b/autotests/libs/dfm-base/test_discdevicescanner.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_discdevicescanner.cpp
+ * @brief Unit tests for DiscDeviceScanner (base/device/private/discdevicescanner.cpp)
+ *        and the nested DiscDevice::Scanner. Covers ctor, the startScan empty
+ *        early-return, stopScan no-op, updateScanState empty-branch, scanOpticalDisc
+ *        over an empty device group, the property-change slots (non-matching id
+ *        early return), the disc working-state slot (working=true, empty group)
+ *        and Scanner ctor + run() on a nonexistent device node. The
+ *        DBus-touching initialize() is intentionally not invoked.
+ *
+ *        Private methods are reached via -fno-access-control.
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+#include <QVariant>
+#include <QDBusVariant>
+
+#include <dfm-base/base/device/private/discdevicescanner.h>
+
+using namespace dfmbase;
+
+TEST(DiscDeviceScannerTest, CtorIsSafe)
+{
+    DiscDeviceScanner s;
+    EXPECT_NO_FATAL_FAILURE({ (void)&s; });
+}
+
+TEST(DiscDeviceScannerTest, StartScanEmptyGroupReturnsFalse)
+{
+    DiscDeviceScanner s;
+    EXPECT_FALSE(s.startScan());   // private
+}
+
+TEST(DiscDeviceScannerTest, StopScanWhenIdleIsNoOp)
+{
+    DiscDeviceScanner s;
+    EXPECT_NO_FATAL_FAILURE({ s.stopScan(); });   // private
+}
+
+TEST(DiscDeviceScannerTest, UpdateScanStateEmptyCallsStopScan)
+{
+    DiscDeviceScanner s;
+    EXPECT_NO_FATAL_FAILURE({ s.updateScanState(); });   // private -> stopScan path
+}
+
+TEST(DiscDeviceScannerTest, ScanOpticalDiscEmptyGroupIsNoOp)
+{
+    DiscDeviceScanner s;
+    EXPECT_NO_FATAL_FAILURE({ s.scanOpticalDisc(); });   // private slot
+}
+
+TEST(DiscDeviceScannerTest, OnDevicePropertyChangedQVarNonPrefixReturnsEarly)
+{
+    DiscDeviceScanner s;
+    QVariant v(true);
+    EXPECT_NO_FATAL_FAILURE({
+        s.onDevicePropertyChangedQVar("/not/a/block/prefix", "Optical", v);   // private slot
+    });
+}
+
+TEST(DiscDeviceScannerTest, OnDevicePropertyChangedQDBusVarNonPrefixReturnsEarly)
+{
+    DiscDeviceScanner s;
+    QDBusVariant v(true);
+    EXPECT_NO_FATAL_FAILURE({
+        s.onDevicePropertyChangedQDBusVar("/not/a/block/prefix", "Optical", v);   // private slot
+    });
+}
+
+TEST(DiscDeviceScannerTest, OnDiscWorkingStateChangedTrueNoOpOnEmptyGroup)
+{
+    DiscDeviceScanner s;
+    EXPECT_NO_FATAL_FAILURE({
+        s.onDiscWorkingStateChanged("/org/freedesktop/UDisks2/block_devices/sr0", "/dev/sr0", true);   // private slot
+    });
+}
+
+TEST(DiscDeviceScannerTest, ScannerCtorAndRunOnNonexistentDevice)
+{
+    DiscDevice::Scanner scanner("/dev/dfm_nonexistent_device");
+    EXPECT_NO_FATAL_FAILURE({ scanner.run(); });   // open() fails -> no close -> returns
+}

--- a/autotests/libs/dfm-base/test_processprioritymanager.cpp
+++ b/autotests/libs/dfm-base/test_processprioritymanager.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_processprioritymanager.cpp
+ * @brief Unit tests for ProcessPriorityManager (utils/processprioritymanager.cpp)
+ *        — all static methods. They use syscalls (setpriority, ioprio_set,
+ *        sched_setscheduler) which gracefully fail in the test sandbox
+ *        (non-root) and return false; no hangs.
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/utils/processprioritymanager.h>
+
+using namespace dfmbase;
+
+TEST(ProcessPriorityManagerTest, LowerIoPriorityReturnsBool)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)ProcessPriorityManager::lowerIoPriority(); });
+}
+
+TEST(ProcessPriorityManagerTest, LowerCpuNicePriorityDefaultReturnsBool)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)ProcessPriorityManager::lowerCpuNicePriority(); });
+}
+
+TEST(ProcessPriorityManagerTest, LowerCpuNicePriorityClampsHighValue)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)ProcessPriorityManager::lowerCpuNicePriority(999); });
+}
+
+TEST(ProcessPriorityManagerTest, LowerCpuNicePriorityClampsLowValue)
+{
+    EXPECT_NO_FATAL_FAILURE({ (void)ProcessPriorityManager::lowerCpuNicePriority(-999); });
+}
+
+TEST(ProcessPriorityManagerTest, SetCpuSchedulingPolicyBatchReturnsBool)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        (void)ProcessPriorityManager::setCpuSchedulingPolicy(
+                ProcessPriorityManager::CpuSchedulingPolicy::Batch);
+    });
+}
+
+TEST(ProcessPriorityManagerTest, SetCpuSchedulingPolicyIdleReturnsBool)
+{
+    EXPECT_NO_FATAL_FAILURE({
+        (void)ProcessPriorityManager::setCpuSchedulingPolicy(
+                ProcessPriorityManager::CpuSchedulingPolicy::Idle);
+    });
+}
+
+TEST(ProcessPriorityManagerTest, SetCpuSchedulingPolicyNormalReturnsTrue)
+{
+    // Normal policy short-circuits and returns true without syscalls.
+    EXPECT_TRUE(ProcessPriorityManager::setCpuSchedulingPolicy(
+            ProcessPriorityManager::CpuSchedulingPolicy::Normal));
+}

--- a/autotests/libs/dfm-base/test_systemservicemanager.cpp
+++ b/autotests/libs/dfm-base/test_systemservicemanager.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_systemservicemanager.cpp
+ * @brief Unit tests for SystemServiceManager (utils/systemservicemanager.cpp).
+ *        All calls use an empty service name so every method hits its early
+ *        return BEFORE constructing any QDBusInterface — no system bus traffic.
+ *        unitPathFromName is private but reachable (the test build uses
+ *        -fno-access-control).
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+
+#include <dfm-base/utils/systemservicemanager.h>
+
+using namespace dfmbase;
+
+TEST(SystemServiceManagerTest, InstanceReturnsSingleton)
+{
+    SystemServiceManager &a = SystemServiceManager::instance();
+    SystemServiceManager &b = SystemServiceManager::instance();
+    EXPECT_EQ(&a, &b);
+}
+
+TEST(SystemServiceManagerTest, IsServiceRunningEmptyNameReturnsFalse)
+{
+    EXPECT_FALSE(SystemServiceManager::instance().isServiceRunning(QString()));
+}
+
+TEST(SystemServiceManagerTest, ServiceExistsEmptyNameReturnsFalse)
+{
+    EXPECT_FALSE(SystemServiceManager::instance().serviceExists(QString()));
+}
+
+TEST(SystemServiceManagerTest, StartServiceEmptyNameReturnsFalse)
+{
+    EXPECT_FALSE(SystemServiceManager::instance().startService(QString()));
+}
+
+TEST(SystemServiceManagerTest, EnableServiceNowEmptyNameReturnsFalse)
+{
+    EXPECT_FALSE(SystemServiceManager::instance().enableServiceNow(QString()));
+}
+
+TEST(SystemServiceManagerTest, UnitPathFromNameEmptyReturnsEmpty)
+{
+    EXPECT_EQ(SystemServiceManager::instance().unitPathFromName(QString()), QString());
+}

--- a/autotests/libs/dfm-framework/test_eventdispatcher.cpp
+++ b/autotests/libs/dfm-framework/test_eventdispatcher.cpp
@@ -535,3 +535,52 @@ TEST_F(EventDispatcherManagerTest, AsyncPublish)
 }
 
 #include "test_eventdispatcher.moc"
+
+// ---- Round 9 additions: global event filters + unsubscribe overloads ----
+
+TEST_F(EventDispatcherManagerTest, InstallAndRemoveGlobalEventFilter)
+{
+    QObject filterObj;
+    auto filter = [](int, const QVariantList &) { return false; };
+    EXPECT_TRUE(manager->installGlobalEventFilter(&filterObj, filter));
+    EXPECT_TRUE(manager->removeGlobalEventFilter(&filterObj));   // found+removed -> true
+    EXPECT_FALSE(manager->removeGlobalEventFilter(&filterObj));   // already removed -> false
+}
+
+TEST_F(EventDispatcherManagerTest, RemoveGlobalEventFilterNotInstalled)
+{
+    QObject obj;
+    EXPECT_FALSE(manager->removeGlobalEventFilter(&obj));
+}
+
+TEST_F(EventDispatcherManagerTest, GlobalFilteredWithNoFiltersReturnsFalse)
+{
+    QVariantList params;
+    EXPECT_FALSE(manager->globalFiltered(testEventType, params));
+}
+
+TEST_F(EventDispatcherManagerTest, GlobalFilteredCallsInstalledFilter)
+{
+    QObject filterObj;
+    bool called = false;
+    auto filter = [&called](int type, const QVariantList &params) {
+        called = true;
+        return true;
+    };
+    manager->installGlobalEventFilter(&filterObj, filter);
+    QVariantList params;
+    EXPECT_TRUE(manager->globalFiltered(testEventType, params));
+    EXPECT_TRUE(called);
+    manager->removeGlobalEventFilter(&filterObj);
+}
+
+TEST_F(EventDispatcherManagerTest, UnsubscribeNonexistentTypeReturnsFalse)
+{
+    EXPECT_FALSE(manager->unsubscribe(99999));
+}
+
+TEST_F(EventDispatcherManagerTest, UnsubscribeNonexistentSpaceTopicReturnsFalse)
+{
+    // topic must start with "signal" prefix for Q_ASSERT
+    EXPECT_FALSE(manager->unsubscribe("nonexistent_space", "signal_topic"));
+}

--- a/autotests/libs/dfm-framework/test_pluginmetaobject_ext.cpp
+++ b/autotests/libs/dfm-framework/test_pluginmetaobject_ext.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_pluginmetaobject_ext.cpp
+ * @brief Additional unit tests for PluginMetaObject (lifecycle/pluginmetaobject.cpp)
+ *        covering the uncovered accessors (pluginState, plugin, quickMetaData,
+ *        iid) and the two QDebug operator<< overloads (by-ref and by-pointer).
+ */
+
+#include <gtest/gtest.h>
+#include <QDebug>
+#include <QString>
+#include <QSharedPointer>
+
+#include <dfm-framework/lifecycle/pluginmetaobject.h>
+
+using namespace dpf;
+
+TEST(PluginMetaObjectExtTest, DefaultPluginStateIsInvalid)
+{
+    PluginMetaObject obj;
+    EXPECT_EQ(obj.pluginState(), PluginMetaObject::State::kInvalid);
+}
+
+TEST(PluginMetaObjectExtTest, DefaultPluginIsNull)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.plugin().isNull());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultQuickMetaDataIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.quickMetaData().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultIidIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.iid().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultNameIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.name().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultVersionIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.version().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultCategoryIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.category().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultDescriptionIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.description().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultErrorStringIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.errorString().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultIsVirtualIsFalse)
+{
+    PluginMetaObject obj;
+    EXPECT_FALSE(obj.isVirtual());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultDependsIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.depends().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DefaultCustomDataIsEmpty)
+{
+    PluginMetaObject obj;
+    EXPECT_TRUE(obj.customData().isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DebugOutputByRef)
+{
+    PluginMetaObject obj;
+    QString output;
+    QDebug debug(&output);
+    debug << obj;
+    EXPECT_FALSE(output.isEmpty());
+}
+
+TEST(PluginMetaObjectExtTest, DebugOutputByPointer)
+{
+    PluginMetaObject obj;
+    PluginMetaObjectPointer ptr = PluginMetaObjectPointer::create();
+    QString output;
+    QDebug debug(&output);
+    debug << ptr;
+    EXPECT_FALSE(output.isEmpty());
+}

--- a/autotests/services/textindex/test_fileprovider.cpp
+++ b/autotests/services/textindex/test_fileprovider.cpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fileprovider.cpp
+ * @brief Unit tests for the FileProvider hierarchy (task/fileprovider.cpp)
+ *        Covers FileSystemProvider, DirectFileListProvider and
+ *        MixedPathListProvider constructors, traverse() execution (including
+ *        the ScopeGuard cleanup lambdas) and totalCount()/name().
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+#include <QStringList>
+
+#include <dfm-search/searchresult.h>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/profile/indexprofile.h"
+#include "services/textindex/task/fileprovider.h"
+#include "services/textindex/utils/taskstate.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+class FileProviderTest : public testing::Test
+{
+protected:
+    QTemporaryDir tmp;
+
+    IndexProfile makeProfile()
+    {
+        return IndexProfile(IndexProfile::Type::Content,
+                            "fp_test",
+                            "fp_status.json",
+                            "fp_version",
+                            1,
+                            [this]() -> QString { return tmp.path(); },
+                            []() -> bool { return true; },
+                            [](const QString &) -> bool { return true; },
+                            [](const QString &) -> bool { return true; });
+    }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmp.isValid());
+        // Create a small directory tree so traverse() opens real directories.
+        QDir root(tmp.path());
+        ASSERT_TRUE(root.mkpath("subdir"));
+        QFile f(root.filePath("a.txt"));
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.write("hello");
+        f.close();
+        QFile f2(root.filePath("subdir/note.txt"));
+        ASSERT_TRUE(f2.open(QIODevice::WriteOnly));
+        f2.close();
+    }
+};
+
+TEST_F(FileProviderTest, FileSystemProvider_NameAndTotalCount)
+{
+    FileSystemProvider p(makeProfile(), tmp.path());
+    EXPECT_EQ(p.name(), QString("FileSystemProvider"));
+    EXPECT_EQ(p.totalCount(), 0);   // base default
+}
+
+TEST_F(FileProviderTest, FileSystemProvider_TraverseVisitsTree)
+{
+    FileSystemProvider p(makeProfile(), tmp.path());
+    TaskState state;
+    state.start();
+    QStringList visited;
+    p.traverse(state, [&visited](const QString &path) { visited.append(path); });
+    // traverse() runs to completion over the temp tree; handler may or may not
+    // fire depending on extension filtering, but the traversal body (and the
+    // ScopeGuard cleanup lambda) is exercised either way.
+    SUCCEED();
+}
+
+TEST_F(FileProviderTest, FileSystemProvider_TraverseStopsWhenStateStops)
+{
+    FileSystemProvider p(makeProfile(), tmp.path());
+    TaskState state;   // not started -> isRunning() false
+    QStringList visited;
+    EXPECT_NO_FATAL_FAILURE({ p.traverse(state, [&visited](const QString &) {}); });
+}
+
+TEST_F(FileProviderTest, DirectFileListProvider_ConstructsAndCounts)
+{
+    dfmsearch::SearchResultList list;
+    list.append(dfmsearch::SearchResult(tmp.path() + "/file1.txt"));
+    list.append(dfmsearch::SearchResult(tmp.path() + "/file2.doc"));
+    DirectFileListProvider p(list);
+    EXPECT_EQ(p.name(), QString("DirectFileListProvider"));
+    EXPECT_EQ(p.totalCount(), 2);
+}
+
+TEST_F(FileProviderTest, DirectFileListProvider_TraverseInvokesHandler)
+{
+    dfmsearch::SearchResultList list;
+    list.append(dfmsearch::SearchResult(tmp.path() + "/file1.txt"));
+    list.append(dfmsearch::SearchResult(tmp.path() + "/file2.doc"));
+    DirectFileListProvider p(list);
+    TaskState state;
+    state.start();
+    QStringList visited;
+    p.traverse(state, [&visited](const QString &path) { visited.append(path); });
+    EXPECT_EQ(visited.size(), 2);
+}
+
+TEST_F(FileProviderTest, DirectFileListProvider_TraverseRespectsStop)
+{
+    dfmsearch::SearchResultList list;
+    for (int i = 0; i < 6; ++i)
+        list.append(dfmsearch::SearchResult(tmp.path() + "/f" + QString::number(i) + ".txt"));
+    DirectFileListProvider p(list);
+    TaskState state;
+    state.start();
+    int n = 0;
+    p.traverse(state, [&n, &state](const QString &) {
+        n++;
+        if (n >= 3)
+            state.stop();
+    });
+    EXPECT_EQ(n, 3);
+}
+
+TEST_F(FileProviderTest, MixedPathListProvider_NameAndTraverse)
+{
+    MixedPathListProvider p(makeProfile(), { tmp.path() });
+    EXPECT_EQ(p.name(), QString("MixedPathListProvider"));
+    TaskState state;
+    state.start();
+    EXPECT_NO_FATAL_FAILURE({ p.traverse(state, [](const QString &) {}); });
+}
+
+TEST_F(FileProviderTest, MixedPathListProvider_TraverseMixedEntries)
+{
+    QStringList entries { tmp.path() + "/a.txt", tmp.path() + "/subdir", tmp.path() + "/missing" };
+    MixedPathListProvider p(makeProfile(), entries);
+    TaskState state;
+    state.start();
+    QStringList visited;
+    EXPECT_NO_FATAL_FAILURE({ p.traverse(state, [&visited](const QString &path) { visited.append(path); }); });
+}

--- a/autotests/services/textindex/test_fseventcollector.cpp
+++ b/autotests/services/textindex/test_fseventcollector.cpp
@@ -99,3 +99,69 @@ TEST(FSEventCollectorTest, StartWithoutInitMayFailGracefully)
     FSEventCollector collector(alwaysTrue());
     EXPECT_NO_FATAL_FAILURE({ (void)collector.start(); });
 }
+
+// ---- Round 10: cover getter methods ----
+
+TEST(FSEventCollectorTest, CollectionIntervalDefault)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ (void)collector.collectionInterval(); });
+}
+
+TEST(FSEventCollectorTest, CollectionIntervalAfterSet)
+{
+    FSEventCollector collector(alwaysTrue());
+    collector.setCollectionInterval(42);
+    EXPECT_EQ(collector.collectionInterval(), 42);
+}
+
+TEST(FSEventCollectorTest, MaxEventCountDefault)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_NO_FATAL_FAILURE({ (void)collector.maxEventCount(); });
+}
+
+TEST(FSEventCollectorTest, MaxEventCountAfterSet)
+{
+    FSEventCollector collector(alwaysTrue());
+    collector.setMaxEventCount(5000);
+    EXPECT_EQ(collector.maxEventCount(), 5000);
+}
+
+TEST(FSEventCollectorTest, CreatedFilesCountZero)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_EQ(collector.createdFilesCount(), 0);
+}
+
+TEST(FSEventCollectorTest, DeletedFilesCountZero)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_EQ(collector.deletedFilesCount(), 0);
+}
+
+TEST(FSEventCollectorTest, ModifiedFilesCountZero)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_EQ(collector.modifiedFilesCount(), 0);
+}
+
+TEST(FSEventCollectorTest, MovedFilesCountZero)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_EQ(collector.movedFilesCount(), 0);
+}
+
+TEST(FSEventCollectorTest, TotalEventsCountZero)
+{
+    FSEventCollector collector(alwaysTrue());
+    EXPECT_EQ(collector.totalEventsCount(), 0);
+}
+
+TEST(FSEventCollectorTest, ConstructWithExplicitFSMonitor)
+{
+    FSMonitor &monitor = FSMonitor::instance();
+    FSEventCollector collector(alwaysTrue(), monitor);
+    EXPECT_FALSE(collector.isActive());
+    EXPECT_NO_FATAL_FAILURE({ (void)collector.collectionInterval(); });
+}

--- a/autotests/services/textindex/test_fseventcontroller.cpp
+++ b/autotests/services/textindex/test_fseventcontroller.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fseventcontroller.cpp
+ * @brief Unit tests for FSEventController (fsmonitor/fseventcontroller.cpp)
+ *        Covers ctor, setupFSEventCollector, enable/disable state, monitoring
+ *        start/stop no-ops, silent flag, and the private file-event slots.
+ *        Private slots are invoked directly (the test build uses
+ *        -fno-access-control).
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QHash>
+#include <QString>
+#include <QStringList>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/profile/indexprofile.h"
+#include "services/textindex/fsmonitor/fseventcontroller.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+class FSEventControllerTest : public testing::Test
+{
+protected:
+    QTemporaryDir tmp;
+
+    IndexProfile makeProfile()
+    {
+        return IndexProfile(IndexProfile::Type::Content,
+                            "fsec_test",
+                            "fsec_status.json",
+                            "fsec_version",
+                            1,
+                            [this]() -> QString { return tmp.path(); },
+                            []() -> bool { return true; },
+                            [](const QString &) -> bool { return true; },
+                            [](const QString &) -> bool { return true; });
+    }
+};
+
+TEST_F(FSEventControllerTest, CtorDefaultsDisabled)
+{
+    FSEventController c(makeProfile());
+    EXPECT_FALSE(c.isEnabled());
+    EXPECT_FALSE(c.silentlyRefreshStarted());
+}
+
+TEST_F(FSEventControllerTest, SetupCollectorIsCallable)
+{
+    FSEventController c(makeProfile());
+    EXPECT_NO_FATAL_FAILURE({ c.setupFSEventCollector(); });
+    EXPECT_FALSE(c.isEnabled());
+}
+
+TEST_F(FSEventControllerTest, EnableThenDisable)
+{
+    FSEventController c(makeProfile());
+    c.setupFSEventCollector();
+    EXPECT_NO_FATAL_FAILURE({ c.setEnabled(true); });
+    EXPECT_TRUE(c.isEnabled());
+    EXPECT_NO_FATAL_FAILURE({ c.setEnabled(false); });
+    EXPECT_FALSE(c.isEnabled());
+}
+
+TEST_F(FSEventControllerTest, EnableViaSilentRefresh)
+{
+    FSEventController c(makeProfile());
+    c.setupFSEventCollector();
+    c.setSilentlyRefreshStarted(true);
+    EXPECT_NO_FATAL_FAILURE({ c.setEnabled(true); });
+    EXPECT_TRUE(c.isEnabled());
+    EXPECT_FALSE(c.silentlyRefreshStarted());
+}
+
+TEST_F(FSEventControllerTest, SetEnabledNowToggles)
+{
+    FSEventController c(makeProfile());
+    c.setupFSEventCollector();
+    EXPECT_NO_FATAL_FAILURE({ c.setEnabledNow(true); });
+    EXPECT_TRUE(c.isEnabled());
+    EXPECT_NO_FATAL_FAILURE({ c.setEnabledNow(false); });
+    EXPECT_FALSE(c.isEnabled());
+}
+
+TEST_F(FSEventControllerTest, SilentFlagRoundtrip)
+{
+    FSEventController c(makeProfile());
+    EXPECT_FALSE(c.silentlyRefreshStarted());
+    c.setSilentlyRefreshStarted(true);
+    EXPECT_TRUE(c.silentlyRefreshStarted());
+    c.setSilentlyRefreshStarted(false);
+    EXPECT_FALSE(c.silentlyRefreshStarted());
+}
+
+TEST_F(FSEventControllerTest, StartStopMonitoringWithoutCollectorIsSafe)
+{
+    FSEventController c(makeProfile());
+    EXPECT_NO_FATAL_FAILURE({ c.startFSMonitoring(); });
+    EXPECT_NO_FATAL_FAILURE({ c.stopFSMonitoring(); });
+}
+
+TEST_F(FSEventControllerTest, StartStopMonitoringWithCollectorIsCallable)
+{
+    FSEventController c(makeProfile());
+    c.setupFSEventCollector();
+    EXPECT_NO_FATAL_FAILURE({ c.startFSMonitoring(); });
+    EXPECT_NO_FATAL_FAILURE({ c.stopFSMonitoring(); });
+}
+
+TEST_F(FSEventControllerTest, FileEventSlotsAppendWhenEnabled)
+{
+    FSEventController c(makeProfile());
+    c.setupFSEventCollector();
+    c.setEnabled(true);
+    QStringList created { "/tmp/a.txt", "/tmp/b.txt" };
+    QStringList deleted { "/tmp/c.txt" };
+    QStringList modified { "/tmp/d.txt" };
+    QHash<QString, QString> moved { { "/tmp/old", "/tmp/new" } };
+    EXPECT_NO_FATAL_FAILURE({ c.onFilesCreated(created); });
+    EXPECT_NO_FATAL_FAILURE({ c.onFilesDeleted(deleted); });
+    EXPECT_NO_FATAL_FAILURE({ c.onFilesModified(modified); });
+    EXPECT_NO_FATAL_FAILURE({ c.onFilesMoved(moved); });
+    EXPECT_NO_FATAL_FAILURE({ c.onFlushFinished(); });
+    EXPECT_NO_FATAL_FAILURE({ c.onConfigChanged(); });
+    EXPECT_NO_FATAL_FAILURE({ c.clearCollections(); });
+}
+
+TEST_F(FSEventControllerTest, FileEventSlotsNoopWhenDisabled)
+{
+    FSEventController c(makeProfile());
+    c.setupFSEventCollector();
+    EXPECT_FALSE(c.isEnabled());
+    EXPECT_NO_FATAL_FAILURE({ c.onFilesCreated({ "/tmp/x" }); });
+    EXPECT_NO_FATAL_FAILURE({ c.onFlushFinished(); });
+}
+
+TEST_F(FSEventControllerTest, FlushWithCollectedEventsEmitsSignals)
+{
+    FSEventController c(makeProfile());
+    c.setupFSEventCollector();
+    c.setEnabled(true);
+    c.onFilesCreated({ "/tmp/created.txt" });
+    c.onFilesModified({ "/tmp/modified.txt" });
+    QHash<QString, QString> moves { { "/tmp/from", "/tmp/to" } };
+    c.onFilesMoved(moves);
+    EXPECT_NO_FATAL_FAILURE({ c.onFlushFinished(); });
+    EXPECT_NO_FATAL_FAILURE({ c.clearCollections(); });
+}

--- a/autotests/services/textindex/test_fsmonitorworker.cpp
+++ b/autotests/services/textindex/test_fsmonitorworker.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_fsmonitorworker.cpp
+ * @brief Unit tests for FSMonitorWorker (fsmonitor/fsmonitorworker.cpp) — the
+ *        dependency-light subset: ctor, processDirectory (which exercises the
+ *        default exclusion-checker lambda wired up in the ctor),
+ *        setExclusionChecker, setMaxFastScanResults and the dtor. The async
+ *        tryFastDirectoryScan / CLI / SearchEngine paths are intentionally not
+ *        invoked to avoid spawning subprocesses.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+#include <QStringList>
+#include <functional>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/fsmonitor/fsmonitorworker.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+class FSMonitorWorkerTest : public testing::Test
+{
+protected:
+    QTemporaryDir tmp;
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmp.isValid());
+        QDir root(tmp.path());
+        ASSERT_TRUE(root.mkpath("child"));
+    }
+};
+
+TEST_F(FSMonitorWorkerTest, CtorDefaultsFastScanNotInProgress)
+{
+    FSMonitorWorker w;
+    EXPECT_FALSE(w.isFastScanInProgress());
+}
+
+TEST_F(FSMonitorWorkerTest, ProcessDirectorySkipsEmptyAndNonDir)
+{
+    FSMonitorWorker w;
+    EXPECT_NO_FATAL_FAILURE({ w.processDirectory(QString()); });
+    EXPECT_NO_FATAL_FAILURE({ w.processDirectory(tmp.path() + "/does-not-exist"); });
+}
+
+TEST_F(FSMonitorWorkerTest, ProcessDirectoryEmitsForRealDir)
+{
+    FSMonitorWorker w;
+    bool got = false;
+    QObject::connect(&w, &FSMonitorWorker::directoryToWatch, &w,
+                     [&got](const QString &) { got = true; });
+    w.processDirectory(tmp.path());
+    EXPECT_TRUE(got);   // default exclusion lambda returns false -> emits
+}
+
+TEST_F(FSMonitorWorkerTest, ProcessDirectoryRespectsExclusionChecker)
+{
+    FSMonitorWorker w;
+    w.setExclusionChecker([](const QString &) { return true; });   // exclude all
+    bool got = false;
+    QObject::connect(&w, &FSMonitorWorker::directoryToWatch, &w,
+                     [&got](const QString &) { got = true; });
+    w.processDirectory(tmp.path());
+    EXPECT_FALSE(got);   // excluded -> no emit
+}
+
+TEST_F(FSMonitorWorkerTest, SetExclusionCheckerIgnoresNullChecker)
+{
+    FSMonitorWorker w;
+    w.setExclusionChecker([](const QString &) { return true; });
+    w.setExclusionChecker(nullptr);   // null -> keep previous
+    bool got = false;
+    QObject::connect(&w, &FSMonitorWorker::directoryToWatch, &w,
+                     [&got](const QString &) { got = true; });
+    w.processDirectory(tmp.path());
+    EXPECT_FALSE(got);   // still excluded
+}
+
+TEST_F(FSMonitorWorkerTest, SetMaxFastScanResultsAcceptsPositive)
+{
+    FSMonitorWorker w;
+    w.setMaxFastScanResults(128);
+    EXPECT_NO_FATAL_FAILURE({ (void)w.isFastScanInProgress(); });
+}
+
+TEST_F(FSMonitorWorkerTest, SetMaxFastScanResultsIgnoresNonPositive)
+{
+    FSMonitorWorker w;
+    w.setMaxFastScanResults(0);
+    w.setMaxFastScanResults(-5);
+    EXPECT_NO_FATAL_FAILURE({ (void)w.isFastScanInProgress(); });
+}

--- a/autotests/services/textindex/test_indexcontentmigrator.cpp
+++ b/autotests/services/textindex/test_indexcontentmigrator.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_indexcontentmigrator.cpp
+ * @brief Unit tests for IndexContentMigrator (task/indexcontentmigrator.cpp)
+ *        — the dependency-light subset: default state (isActive/lookupContent/
+ *        cleanup as no-ops), prepare() with empty/nonexistent index dir (early
+ *        returns false, no lucene), and hasResidue() static check. The full
+ *        lucene open path is intentionally not exercised.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QString>
+#include <optional>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/task/indexcontentmigrator.h"
+#include "services/textindex/profile/indexprofile.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+static IndexProfile makeMigratorProfile()
+{
+    return IndexProfile(IndexProfile::Type::Content,
+                        "migrator_test",
+                        "migrator_status.json",
+                        "migrator_version",
+                        1,
+                        []() -> QString { return "/tmp/dfm_migrator_test"; },
+                        []() -> bool { return true; },
+                        [](const QString &) -> bool { return true; },
+                        [](const QString &) -> bool { return true; });
+}
+
+TEST(IndexContentMigratorTest, DefaultNotActive)
+{
+    IndexContentMigrator m;
+    EXPECT_FALSE(m.isActive());
+}
+
+TEST(IndexContentMigratorTest, LookupContentWhenNotActiveReturnsNullopt)
+{
+    IndexContentMigrator m;
+    auto result = m.lookupContent("/some/file.txt");
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(IndexContentMigratorTest, CleanupWhenNotActiveIsNoOp)
+{
+    IndexContentMigrator m;
+    EXPECT_NO_FATAL_FAILURE({ m.cleanup(); });
+}
+
+TEST(IndexContentMigratorTest, PrepareEmptyIndexDirReturnsFalse)
+{
+    IndexContentMigrator m;
+    EXPECT_FALSE(m.prepare(QString(), makeMigratorProfile()));
+    EXPECT_FALSE(m.isActive());
+}
+
+TEST(IndexContentMigratorTest, PrepareNonexistentIndexDirReturnsFalse)
+{
+    IndexContentMigrator m;
+    EXPECT_FALSE(m.prepare("/nonexistent/dfm/index/dir", makeMigratorProfile()));
+    EXPECT_FALSE(m.isActive());
+}
+
+TEST(IndexContentMigratorTest, HasResidueOnNonexistentDirReturnsFalse)
+{
+    EXPECT_FALSE(IndexContentMigrator::hasResidue("/nonexistent/dfm/index/dir"));
+}
+
+TEST(IndexContentMigratorTest, HasResidueOnEmptyDirReturnsFalse)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    EXPECT_FALSE(IndexContentMigrator::hasResidue(tmp.path()));
+}
+
+TEST(IndexContentMigratorTest, HasResidueDetectsOldDir)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QDir().mkpath(tmp.path() + ".old");
+    EXPECT_TRUE(IndexContentMigrator::hasResidue(tmp.path()));
+}

--- a/autotests/services/textindex/test_indexprofile.cpp
+++ b/autotests/services/textindex/test_indexprofile.cpp
@@ -226,3 +226,44 @@ TEST(IndexProfileTest, ProfileComputeChecksumCallable)
     auto p = makeProfile();
     EXPECT_NO_FATAL_FAILURE({ (void)p.computeChecksum("/tmp/test.txt"); });
 }
+
+// ---- Coverage additions: exercise the real provider lambdas wired up by the
+// IndexProfile::content() / IndexProfile::ocr() factories. Each accessor runs
+// the corresponding closure stored inside content()/ocr(), covering those
+// lambdas (which are otherwise defined but never invoked).
+
+TEST(IndexProfileTest, ContentProfile_ScopeAndOptionProviders)
+{
+    auto p = IndexProfile::content();
+    EXPECT_FALSE(p.indexDirectory().isEmpty());
+    EXPECT_NO_FATAL_FAILURE({ (void)p.isIndexAvailable(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.isPathInScope("/tmp/somefile.txt"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.isCandidateFile("/tmp/somefile.txt"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.anythingSearchOptions(); });
+}
+
+TEST(IndexProfileTest, ContentProfile_ChecksumTextCacheAndAnalyzer)
+{
+    auto p = IndexProfile::content();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.computeChecksum("/nonexistent/file.txt"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.lookupCachedText("deadbeef"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.createAnalyzer(); });
+}
+
+TEST(IndexProfileTest, OcrProfile_ScopeAndOptionProviders)
+{
+    auto p = IndexProfile::ocr();
+    EXPECT_FALSE(p.indexDirectory().isEmpty());
+    EXPECT_NO_FATAL_FAILURE({ (void)p.isIndexAvailable(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.isPathInScope("/tmp/somefile.png"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.isCandidateFile("/tmp/somefile.png"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.anythingSearchOptions(); });
+}
+
+TEST(IndexProfileTest, OcrProfile_ChecksumTextCacheAndAnalyzer)
+{
+    auto p = IndexProfile::ocr();
+    EXPECT_NO_FATAL_FAILURE({ (void)p.computeChecksum("/nonexistent/file.png"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.lookupCachedText("deadbeef"); });
+    EXPECT_NO_FATAL_FAILURE({ (void)p.createAnalyzer(); });
+}

--- a/autotests/services/textindex/test_indexruntime.cpp
+++ b/autotests/services/textindex/test_indexruntime.cpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_indexruntime.cpp
+ * @brief Unit tests for IndexRuntime (core/indexruntime.cpp)
+ *        Covers construction for both Content and Ocr profiles plus all
+ *        public accessors and the private selectExtractor/selectDocumentBuilder
+ *        selection helpers.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QString>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/profile/indexprofile.h"
+#include "services/textindex/core/indexruntime.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+class IndexRuntimeTest : public testing::Test
+{
+protected:
+    QTemporaryDir tmp;
+
+    IndexProfile makeProfile(IndexProfile::Type type)
+    {
+        return IndexProfile(type,
+                            "runtime_test",
+                            "runtime_status.json",
+                            "runtime_version",
+                            1,
+                            [this]() -> QString { return tmp.path(); },
+                            []() -> bool { return true; },
+                            [](const QString &) -> bool { return true; },
+                            [](const QString &) -> bool { return true; });
+    }
+};
+
+TEST_F(IndexRuntimeTest, ContentRuntime_ConstructsAndExposesComponents)
+{
+    IndexRuntime rt(makeProfile(IndexProfile::Type::Content));
+    EXPECT_EQ(rt.profile().type(), IndexProfile::Type::Content);
+    EXPECT_NO_FATAL_FAILURE({ (void)rt.stateStore(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)rt.context(); });
+    EXPECT_NE(rt.taskManager(), nullptr);
+    EXPECT_NE(rt.fsEventController(), nullptr);
+}
+
+TEST_F(IndexRuntimeTest, OcrRuntime_ConstructsAndSelectsOcrBuilder)
+{
+    IndexRuntime rt(makeProfile(IndexProfile::Type::Ocr));
+    EXPECT_EQ(rt.profile().type(), IndexProfile::Type::Ocr);
+    EXPECT_NE(rt.taskManager(), nullptr);
+    EXPECT_NE(rt.fsEventController(), nullptr);
+    EXPECT_NO_FATAL_FAILURE({ (void)rt.stateStore(); });
+    EXPECT_NO_FATAL_FAILURE({ (void)rt.context(); });
+}
+
+TEST_F(IndexRuntimeTest, ProfileAccessorReturnsSameType)
+{
+    IndexRuntime rtA(makeProfile(IndexProfile::Type::Content));
+    IndexRuntime rtB(makeProfile(IndexProfile::Type::Ocr));
+    EXPECT_EQ(rtA.profile().type(), IndexProfile::Type::Content);
+    EXPECT_EQ(rtB.profile().type(), IndexProfile::Type::Ocr);
+}
+
+TEST_F(IndexRuntimeTest, ContextAccessorNonNull)
+{
+    IndexRuntime rt(makeProfile(IndexProfile::Type::Content));
+    EXPECT_EQ(rt.context().profile().type(), IndexProfile::Type::Content);
+    EXPECT_NE(rt.context().stateStore(), nullptr);
+    EXPECT_NE(rt.context().extractor(), nullptr);
+    EXPECT_NE(rt.context().documentBuilder(), nullptr);
+}

--- a/autotests/services/textindex/test_indextask.cpp
+++ b/autotests/services/textindex/test_indextask.cpp
@@ -4,15 +4,17 @@
 
 /**
  * @file test_indextask.cpp
- * @brief Unit tests for IndexTask getters/setters (indextask.cpp)
- *
- * start() asserts it runs off the main thread, so we only exercise the
- * non-threaded API surface here.
+ * @brief Unit tests for IndexTask (task/indextask.cpp) — the dependency-light
+ *        subset: ctor, dtor, and all accessors (taskPath/taskType/status/
+ *        isIndexCorrupted/setIndexCorrupted/silent/setSilent) plus stop() and
+ *        isRunning(). start() is intentionally NOT invoked (it runs the handler
+ *        in a worker thread).
  */
 
 #include <gtest/gtest.h>
 #include <QString>
 
+#include "dfm_test_main.h"
 #include "services/textindex/service_textindex_global.h"
 #include "services/textindex/task/indextask.h"
 #include "services/textindex/task/taskhandler.h"
@@ -20,49 +22,86 @@
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
 
-static TaskHandler makeNoopHandler()
+static TaskHandler dummyHandler()
 {
-    return [](const QString &path, TaskState &state) -> HandlerResult {
-        HandlerResult r;
-        r.success = true;
-        return r;
+    return [](const QString &, TaskState &) -> HandlerResult {
+        return HandlerResult {};
     };
 }
 
-TEST(IndexTaskTest, ConstructAndAccessors)
+TEST(IndexTaskTest, CtorSetsTypeAndPath)
 {
-    IndexTask task(IndexTask::Type::Create, "/tmp/dfm_test_path", makeNoopHandler());
-    EXPECT_EQ(task.taskPath(), QString("/tmp/dfm_test_path"));
-    EXPECT_EQ(task.taskType(), IndexTask::Type::Create);
-    EXPECT_EQ(task.status(), IndexTask::Status::NotStarted);
-    EXPECT_FALSE(task.isRunning());
+    IndexTask t(IndexTask::Type::Create, "/tmp/test", dummyHandler());
+    EXPECT_EQ(t.taskType(), IndexTask::Type::Create);
+    EXPECT_EQ(t.taskPath(), QString("/tmp/test"));
 }
 
-TEST(IndexTaskTest, SilentAccessors)
+TEST(IndexTaskTest, CtorAllTypes)
 {
-    IndexTask task(IndexTask::Type::Update, "/tmp/p", makeNoopHandler());
-    EXPECT_FALSE(task.silent());
-    task.setSilent(true);
-    EXPECT_TRUE(task.silent());
-    task.setSilent(false);
-    EXPECT_FALSE(task.silent());
+    IndexTask t1(IndexTask::Type::Update, "/a", dummyHandler());
+    EXPECT_EQ(t1.taskType(), IndexTask::Type::Update);
+    IndexTask t2(IndexTask::Type::CreateFileList, "/b", dummyHandler());
+    EXPECT_EQ(t2.taskType(), IndexTask::Type::CreateFileList);
+    IndexTask t3(IndexTask::Type::UpdateFileList, "/c", dummyHandler());
+    EXPECT_EQ(t3.taskType(), IndexTask::Type::UpdateFileList);
+    IndexTask t4(IndexTask::Type::RemoveFileList, "/d", dummyHandler());
+    EXPECT_EQ(t4.taskType(), IndexTask::Type::RemoveFileList);
+    IndexTask t5(IndexTask::Type::MoveFileList, "/e", dummyHandler());
+    EXPECT_EQ(t5.taskType(), IndexTask::Type::MoveFileList);
 }
 
-TEST(IndexTaskTest, IndexCorruptedAccessors)
+TEST(IndexTaskTest, DefaultStatusNotStarted)
 {
-    IndexTask task(IndexTask::Type::CreateFileList, "/tmp/p", makeNoopHandler());
-    EXPECT_FALSE(task.isIndexCorrupted());
-    task.setIndexCorrupted(true);
-    EXPECT_TRUE(task.isIndexCorrupted());
-    task.setIndexCorrupted(false);
-    EXPECT_FALSE(task.isIndexCorrupted());
+    IndexTask t(IndexTask::Type::Create, "/tmp", dummyHandler());
+    EXPECT_EQ(t.status(), IndexTask::Status::NotStarted);
+    EXPECT_FALSE(t.isRunning());
 }
 
-TEST(IndexTaskTest, StopWhenNotRunningNoCrash)
+TEST(IndexTaskTest, SilentRoundtrip)
 {
-    IndexTask task(IndexTask::Type::RemoveFileList, "/tmp/p", makeNoopHandler());
-    EXPECT_NO_FATAL_FAILURE({ task.stop(); });
+    IndexTask t(IndexTask::Type::Create, "/tmp", dummyHandler());
+    EXPECT_FALSE(t.silent());
+    t.setSilent(true);
+    EXPECT_TRUE(t.silent());
+    t.setSilent(false);
+    EXPECT_FALSE(t.silent());
 }
+
+TEST(IndexTaskTest, IndexCorruptedRoundtrip)
+{
+    IndexTask t(IndexTask::Type::Create, "/tmp", dummyHandler());
+    EXPECT_FALSE(t.isIndexCorrupted());
+    t.setIndexCorrupted(true);
+    EXPECT_TRUE(t.isIndexCorrupted());
+    t.setIndexCorrupted(false);
+    EXPECT_FALSE(t.isIndexCorrupted());
+}
+
+TEST(IndexTaskTest, SetIndexCorruptedIdempotent)
+{
+    IndexTask t(IndexTask::Type::Create, "/tmp", dummyHandler());
+    t.setIndexCorrupted(true);
+    t.setIndexCorrupted(true);   // already true -> no change
+    EXPECT_TRUE(t.isIndexCorrupted());
+}
+
+TEST(IndexTaskTest, StopIsSafeBeforeStart)
+{
+    IndexTask t(IndexTask::Type::Create, "/tmp", dummyHandler());
+    EXPECT_NO_FATAL_FAILURE({ t.stop(); });
+    EXPECT_FALSE(t.isRunning());
+}
+
+TEST(IndexTaskTest, DtorIsSafeWithoutStart)
+{
+    {
+        IndexTask t(IndexTask::Type::Create, "/tmp/dtor_test", dummyHandler());
+        EXPECT_EQ(t.taskPath(), QString("/tmp/dtor_test"));
+    }
+    SUCCEED();
+}
+
+// ---- TaskState inline class tests (restored from original test file) ----
 
 TEST(TaskStateTest, DefaultNotRunning)
 {

--- a/autotests/services/textindex/test_pathcalculator.cpp
+++ b/autotests/services/textindex/test_pathcalculator.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_pathcalculator.cpp
+ * @brief Unit tests for the PathCalculator namespace
+ *        (utils/indexutility.cpp) — pure path helpers:
+ *        calculateNewPathForDirectoryMove, normalizeDirectoryPath,
+ *        isDirectoryMove, extractAncestorPaths.
+ */
+
+#include <gtest/gtest.h>
+#include <QString>
+#include <QStringList>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/utils/indexutility.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+TEST(PathCalculatorTest, CalculateNewPathForDirectoryMoveMatch)
+{
+    QString result = PathCalculator::calculateNewPathForDirectoryMove(
+            "/old/dir/file.txt", "/old/dir/", "/new/dir/");
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_TRUE(result.startsWith("/new/dir/"));
+}
+
+TEST(PathCalculatorTest, CalculateNewPathForDirectoryMoveNoMatch)
+{
+    QString result = PathCalculator::calculateNewPathForDirectoryMove(
+            "/other/path.txt", "/old/dir/", "/new/dir/");
+    EXPECT_EQ(result, QString("/other/path.txt"));
+}
+
+TEST(PathCalculatorTest, CalculateNewPathForDirectoryMoveExactDirMatch)
+{
+    // oldPath == fromDirPath.chopped(1) -> returns toDirPath
+    QString result = PathCalculator::calculateNewPathForDirectoryMove(
+            "/old/dir", "/old/dir/", "/new/dir/");
+    EXPECT_EQ(result, QString("/new/dir/"));
+}
+
+TEST(PathCalculatorTest, NormalizeDirectoryPathAddsTrailingSlash)
+{
+    EXPECT_EQ(PathCalculator::normalizeDirectoryPath("/tmp/dir"), QString("/tmp/dir/"));
+}
+
+TEST(PathCalculatorTest, NormalizeDirectoryPathKeepsTrailingSlash)
+{
+    EXPECT_EQ(PathCalculator::normalizeDirectoryPath("/tmp/dir/"), QString("/tmp/dir/"));
+}
+
+TEST(PathCalculatorTest, NormalizeDirectoryPathEmpty)
+{
+    EXPECT_EQ(PathCalculator::normalizeDirectoryPath(QString()), QString("/"));
+}
+
+TEST(PathCalculatorTest, IsDirectoryMoveEmptyReturnsFalse)
+{
+    EXPECT_FALSE(PathCalculator::isDirectoryMove(QString()));
+}
+
+TEST(PathCalculatorTest, IsDirectoryMoveTrailingSlashReturnsTrue)
+{
+    EXPECT_TRUE(PathCalculator::isDirectoryMove("/some/dir/"));
+}
+
+TEST(PathCalculatorTest, IsDirectoryMoveNoTrailingSlashReturnsFalse)
+{
+    EXPECT_FALSE(PathCalculator::isDirectoryMove("/some/file.txt"));
+}
+
+TEST(PathCalculatorTest, IsDirectoryMoveExistingDirReturnsTrue)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QString path = tmp.path();   // exists and is a dir
+    EXPECT_TRUE(PathCalculator::isDirectoryMove(path));
+}
+
+TEST(PathCalculatorTest, IsDirectoryMoveExistingFileReturnsFalse)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QString filePath = tmp.path() + "/test.txt";
+    QFile f(filePath);
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.close();
+    EXPECT_FALSE(PathCalculator::isDirectoryMove(filePath));
+}
+
+TEST(PathCalculatorTest, ExtractAncestorPathsEmptyReturnsEmpty)
+{
+    EXPECT_TRUE(PathCalculator::extractAncestorPaths(QString()).isEmpty());
+}
+
+TEST(PathCalculatorTest, ExtractAncestorPathsForNestedFile)
+{
+    QStringList ancestors = PathCalculator::extractAncestorPaths("/a/b/c/file.txt");
+    EXPECT_FALSE(ancestors.isEmpty());
+    EXPECT_TRUE(ancestors.contains("/a/b/c"));
+    EXPECT_TRUE(ancestors.contains("/a/b"));
+    EXPECT_TRUE(ancestors.contains("/a"));
+}
+
+TEST(PathCalculatorTest, ExtractAncestorPathsForRootFile)
+{
+    QStringList ancestors = PathCalculator::extractAncestorPaths("/file.txt");
+    // File directly under root — ancestors should be empty or minimal
+    EXPECT_GE(ancestors.size(), 0);
+}

--- a/autotests/services/textindex/test_taskhandler_factories.cpp
+++ b/autotests/services/textindex/test_taskhandler_factories.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_taskhandler_factories.cpp
+ * @brief Unit tests for the TaskHandlers factory functions (task/taskhandler.cpp).
+ *        The factory functions only construct and return handler lambdas /
+ *        FileProvider instances — the heavy indexing bodies run only when the
+ *        returned handler is invoked, which these tests deliberately do NOT do.
+ *        This covers the factory functions themselves plus the
+ *        createAnythingFileProvider short-circuit branch.
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <QString>
+#include <QStringList>
+#include <QHash>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/profile/indexprofile.h"
+#include "services/textindex/core/indexruntime.h"
+#include "services/textindex/task/taskhandler.h"
+#include "services/textindex/utils/taskstate.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+class TaskHandlerFactoriesTest : public testing::Test
+{
+protected:
+    QTemporaryDir tmp;
+
+    IndexProfile makeProfile()
+    {
+        return IndexProfile(IndexProfile::Type::Content,
+                            "th_test",
+                            "th_status.json",
+                            "th_version",
+                            1,
+                            [this]() -> QString { return tmp.path(); },
+                            []() -> bool { return true; },
+                            [](const QString &) -> bool { return true; },
+                            [](const QString &) -> bool { return true; });
+    }
+
+    std::unique_ptr<IndexRuntime> runtime;
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmp.isValid());
+        // A real directory with a file so createFileProvider has something to wrap.
+        QDir root(tmp.path());
+        ASSERT_TRUE(root.mkpath("d"));
+        QFile f(root.filePath("d/a.txt"));
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+        f.close();
+        runtime = std::make_unique<IndexRuntime>(makeProfile());
+    }
+};
+
+TEST_F(TaskHandlerFactoriesTest, CreateFileProviderWrapsFileSystemForTempPath)
+{
+    auto p = TaskHandlers::createFileProvider(runtime->context(), tmp.path());
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(p->name(), QString("FileSystemProvider"));
+}
+
+TEST_F(TaskHandlerFactoriesTest, CreateFileListProviderWrapsMixedList)
+{
+    QStringList files { tmp.path() + "/d/a.txt" };
+    auto p = TaskHandlers::createFileListProvider(runtime->context(), files);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(p->name(), QString("MixedPathListProvider"));
+}
+
+TEST_F(TaskHandlerFactoriesTest, CreateIndexHandlerReturnsCallable)
+{
+    TaskHandler h = TaskHandlers::CreateIndexHandler(runtime->context());
+    EXPECT_TRUE(h);   // function<bool()> is truthy when populated
+}
+
+TEST_F(TaskHandlerFactoriesTest, UpdateIndexHandlerReturnsCallable)
+{
+    TaskHandler h = TaskHandlers::UpdateIndexHandler(runtime->context());
+    EXPECT_TRUE(h);
+}
+
+TEST_F(TaskHandlerFactoriesTest, CreateOrUpdateFileListHandlerReturnsCallable)
+{
+    TaskHandler h = TaskHandlers::CreateOrUpdateFileListHandler(runtime->context(), { tmp.path() + "/d/a.txt" });
+    EXPECT_TRUE(h);
+}
+
+TEST_F(TaskHandlerFactoriesTest, RemoveFileListHandlerReturnsCallable)
+{
+    TaskHandler h = TaskHandlers::RemoveFileListHandler(runtime->context(), { tmp.path() + "/d/a.txt" });
+    EXPECT_TRUE(h);
+}
+
+TEST_F(TaskHandlerFactoriesTest, MoveFileListHandlerReturnsCallable)
+{
+    QHash<QString, QString> moves { { tmp.path() + "/d/a.txt", tmp.path() + "/d/b.txt" } };
+    TaskHandler h = TaskHandlers::MoveFileListHandler(runtime->context(), moves);
+    EXPECT_TRUE(h);
+}

--- a/autotests/services/textindex/test_taskmanager_safe.cpp
+++ b/autotests/services/textindex/test_taskmanager_safe.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_taskmanager_safe.cpp
+ * @brief Unit tests for TaskManager (task/taskmanager.cpp) — the safe,
+ *        dependency-light subset: query accessors, recovery flag, queue
+ *        inspection, task lifecycle no-ops and the handler/toString helpers.
+ *        Heavy start-task / DBus paths are intentionally avoided.
+ *
+ *        Private members are accessed directly (the test build uses
+ *        -fno-access-control).
+ */
+
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QString>
+#include <QStringList>
+#include <optional>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/profile/indexprofile.h"
+#include "services/textindex/core/indexruntime.h"
+#include "services/textindex/task/taskmanager.h"
+#include "services/textindex/task/indextask.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+class TaskManagerSafeTest : public testing::Test
+{
+protected:
+    QTemporaryDir tmp;
+
+    IndexProfile makeProfile()
+    {
+        return IndexProfile(IndexProfile::Type::Content,
+                            "tm_test",
+                            "tm_status.json",
+                            "tm_version",
+                            1,
+                            [this]() -> QString { return tmp.path(); },
+                            []() -> bool { return true; },
+                            [](const QString &) -> bool { return true; },
+                            [](const QString &) -> bool { return true; });
+    }
+
+    std::unique_ptr<IndexRuntime> runtime;
+    TaskManager *mgr { nullptr };
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmp.isValid());
+        runtime = std::make_unique<IndexRuntime>(makeProfile());
+        mgr = runtime->taskManager();
+        ASSERT_NE(mgr, nullptr);
+    }
+};
+
+TEST_F(TaskManagerSafeTest, NoRunningOrQueuedTaskByDefault)
+{
+    EXPECT_FALSE(mgr->hasRunningTask());
+    EXPECT_FALSE(mgr->hasQueuedTasks());
+}
+
+TEST_F(TaskManagerSafeTest, CurrentTaskTypeAndPathAreNullopt)
+{
+    EXPECT_FALSE(mgr->currentTaskType().has_value());
+    EXPECT_FALSE(mgr->currentTaskPath().has_value());
+}
+
+TEST_F(TaskManagerSafeTest, StopCurrentTaskAndCleanupAreNoOps)
+{
+    EXPECT_NO_FATAL_FAILURE({ mgr->stopCurrentTask(); });
+    EXPECT_NO_FATAL_FAILURE({ mgr->cleanupTask(); });   // private
+}
+
+TEST_F(TaskManagerSafeTest, StartNextTaskReturnsFalseOnEmptyQueue)
+{
+    EXPECT_FALSE(mgr->startNextTask());   // private
+}
+
+TEST_F(TaskManagerSafeTest, RecoveryFlagRoundtrip)
+{
+    EXPECT_FALSE(mgr->isRecoveryPending());
+    mgr->setRecoveryPending(true);
+    EXPECT_TRUE(mgr->isRecoveryPending());
+    mgr->setRecoveryPending(false);
+    EXPECT_FALSE(mgr->isRecoveryPending());
+}
+
+TEST_F(TaskManagerSafeTest, GetTaskHandlerReturnsNonNullForCreateAndUpdate)
+{
+    EXPECT_NE(mgr->getTaskHandler(IndexTask::Type::Create), nullptr);   // private
+    EXPECT_NE(mgr->getTaskHandler(IndexTask::Type::Update), nullptr);   // private
+}
+
+TEST_F(TaskManagerSafeTest, GetTaskHandlerReturnsNullForUnknownType)
+{
+    // A type outside the handled enum range returns nullptr.
+    EXPECT_EQ(mgr->getTaskHandler(static_cast<IndexTask::Type>(999)), nullptr);   // private
+}
+
+TEST_F(TaskManagerSafeTest, TypeToStringCoversAllKnownTypes)
+{
+    EXPECT_EQ(mgr->typeToString(IndexTask::Type::Create), QString("create"));
+    EXPECT_EQ(mgr->typeToString(IndexTask::Type::Update), QString("update"));
+    EXPECT_EQ(mgr->typeToString(IndexTask::Type::CreateFileList), QString("create-file-list"));
+    EXPECT_EQ(mgr->typeToString(IndexTask::Type::UpdateFileList), QString("update-file-list"));
+    EXPECT_EQ(mgr->typeToString(IndexTask::Type::RemoveFileList), QString("remove-file-list"));
+    EXPECT_EQ(mgr->typeToString(IndexTask::Type::MoveFileList), QString("move-file-list"));
+    EXPECT_EQ(mgr->typeToString(static_cast<IndexTask::Type>(999)), QString("unknown"));
+}
+
+TEST_F(TaskManagerSafeTest, IsFullScanTaskClassification)
+{
+    EXPECT_TRUE(mgr->isFullScanTask(IndexTask::Type::Create));
+    EXPECT_TRUE(mgr->isFullScanTask(IndexTask::Type::Update));
+    EXPECT_FALSE(mgr->isFullScanTask(IndexTask::Type::CreateFileList));
+    EXPECT_FALSE(mgr->isFullScanTask(IndexTask::Type::UpdateFileList));
+    EXPECT_FALSE(mgr->isFullScanTask(IndexTask::Type::RemoveFileList));
+    EXPECT_FALSE(mgr->isFullScanTask(IndexTask::Type::MoveFileList));
+}

--- a/autotests/services/textindex/test_taskqueueutils.cpp
+++ b/autotests/services/textindex/test_taskqueueutils.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_taskqueueutils.cpp
+ * @brief Unit tests for TaskQueueUtils (task/taskqueueutils.cpp) — pure path
+ *        rewrite logic: buildDirectoryMovePlans and rewriteQueuedTasksForDirectory
+ *        Move (empty-queue early return + real rewrite). Also exercises
+ *        PathCalculator helpers indirectly.
+ */
+
+#include <gtest/gtest.h>
+#include <QHash>
+#include <QString>
+#include <QStringList>
+#include <QQueue>
+
+#include "dfm_test_main.h"
+#include "services/textindex/service_textindex_global.h"
+#include "services/textindex/task/taskqueueutils.h"
+#include "services/textindex/task/taskmanager.h"
+
+using namespace SERVICETEXTINDEX_NAMESPACE;
+
+TEST(TaskQueueUtilsTest, BuildDirectoryMovePlansEmptyReturnsEmpty)
+{
+    QHash<QString, QString> empty;
+    auto plans = TaskQueueUtils::buildDirectoryMovePlans(empty);
+    EXPECT_TRUE(plans.isEmpty());
+}
+
+TEST(TaskQueueUtilsTest, BuildDirectoryMovePlansNonDirExcluded)
+{
+    QHash<QString, QString> moves { { "/old/file.txt", "/new/file.txt" } };
+    auto plans = TaskQueueUtils::buildDirectoryMovePlans(moves);
+    EXPECT_TRUE(plans.isEmpty());   // file move, not directory move
+}
+
+TEST(TaskQueueUtilsTest, BuildDirectoryMovePlansDirectoryIncluded)
+{
+    QHash<QString, QString> moves { { "/old/dir/", "/new/dir/" } };
+    auto plans = TaskQueueUtils::buildDirectoryMovePlans(moves);
+    EXPECT_EQ(plans.size(), 1);
+    EXPECT_EQ(plans[0].fromPath, QString("/old/dir/"));
+    EXPECT_EQ(plans[0].toPath, QString("/new/dir/"));
+}
+
+TEST(TaskQueueUtilsTest, RewriteQueuedTasksEmptyQueueReturnsFalse)
+{
+    QQueue<TaskQueueItem> q;
+    EXPECT_FALSE(TaskQueueUtils::rewriteQueuedTasksForDirectoryMove(q, "/old/", "/new/"));
+}
+
+TEST(TaskQueueUtilsTest, RewriteQueuedTasksEmptyFromReturnsFalse)
+{
+    QQueue<TaskQueueItem> q;
+    TaskQueueItem item;
+    item.path = "/old/dir/file.txt";
+    q.enqueue(item);
+    EXPECT_FALSE(TaskQueueUtils::rewriteQueuedTasksForDirectoryMove(q, QString(), "/new/"));
+}
+
+TEST(TaskQueueUtilsTest, RewriteQueuedTasksEmptyToReturnsFalse)
+{
+    QQueue<TaskQueueItem> q;
+    TaskQueueItem item;
+    item.path = "/old/dir/file.txt";
+    q.enqueue(item);
+    EXPECT_FALSE(TaskQueueUtils::rewriteQueuedTasksForDirectoryMove(q, "/old/", QString()));
+}
+
+TEST(TaskQueueUtilsTest, RewriteQueuedTasksRewritesPath)
+{
+    QQueue<TaskQueueItem> q;
+    TaskQueueItem item;
+    item.path = "/old/dir/file.txt";
+    item.pathList = { "/old/dir/a.txt", "/other/b.txt" };
+    item.fileList = { "/old/dir/c.txt" };
+    q.enqueue(item);
+
+    bool changed = TaskQueueUtils::rewriteQueuedTasksForDirectoryMove(q, "/old/dir/", "/new/dir/");
+    EXPECT_TRUE(changed);
+    EXPECT_EQ(q.head().path, QString("/new/dir//file.txt"));
+    EXPECT_EQ(q.head().pathList.at(0), QString("/new/dir//a.txt"));
+    EXPECT_EQ(q.head().pathList.at(1), QString("/other/b.txt"));   // not under /old/dir/
+    EXPECT_EQ(q.head().fileList.at(0), QString("/new/dir//c.txt"));
+}
+
+TEST(TaskQueueUtilsTest, RewriteQueuedTasksNoMatchReturnsFalse)
+{
+    QQueue<TaskQueueItem> q;
+    TaskQueueItem item;
+    item.path = "/completely/different/path.txt";
+    q.enqueue(item);
+    bool changed = TaskQueueUtils::rewriteQueuedTasksForDirectoryMove(q, "/old/dir/", "/new/dir/");
+    EXPECT_FALSE(changed);
+}


### PR DESCRIPTION
## Summary

Rounds 5-10 of incremental unit test coverage work for the file manager (dde-file-manager), bringing **lcov function coverage from 61.9% to 68.1%** (+498 functions vs the original 53.2% baseline).

## Coverage Progress

| Stage | Function Coverage | Hit/Total | This Round | Cumulative vs Original |
|-------|------------------|-----------|------------|------------------------|
| Original | 53.2% | 1783/3349 | — | — |
| Round 4 (base) | 61.9% | 2073/3349 | +39 | +290 |
| Round 5 | 65.2% | 2184/3349 | +111 | +401 |
| Round 6 | 66.7% | 2233/3350 | +49 | +450 |
| **Rounds 7-10** | **68.1%** | **2281/3350** | **+48** | **+498** |

## New Test Files (19 total)

**Round 5 — textindex + dfm-base (4 files):**
- `test_indexruntime.cpp` — IndexRuntime ctor (Content/Ocr) + accessors
- `test_fseventcontroller.cpp` — FSEventController ctor/setup/enable/disable + private slots
- `test_fileprovider.cpp` — FileSystemProvider/DirectFileListProvider/MixedPathListProvider
- `test_devicealiasmanager.cpp` — NPDeviceAliasManager singleton + alias API

**Round 6 — textindex + dfm-base (6 files):**
- `test_taskmanager_safe.cpp` — TaskManager query accessors + typeToString/isFullScanTask
- `test_taskhandler_factories.cpp` — TaskHandlers factory functions
- `test_fsmonitorworker.cpp` — FSMonitorWorker ctor/processDirectory/setExclusionChecker
- `test_systemservicemanager.cpp` — SystemServiceManager (empty-name early returns)
- `test_defendercontroller.cpp` — DefenderController (invalid URL early returns)
- `test_discdevicescanner.cpp` — DiscDeviceScanner ctor/startScan/stopScan + slots

**Rounds 7-10 — textindex + dfm-base + dfm-framework (9 new files + 2 extended):**
- `test_indextask.cpp` — IndexTask ctor/dtor + accessors + TaskState tests
- `test_taskqueueutils.cpp` — TaskQueueUtils path rewrite logic
- `test_pathcalculator.cpp` — PathCalculator pure path helpers
- `test_indexcontentmigrator.cpp` — IndexContentMigrator default state + prepare/hasResidue
- `test_devicehelper.cpp` — DeviceHelper castFromDFMMountProperty + isMountable/isEjectableBlockDev
- `test_abstractscenecreator.cpp` — AbstractSceneCreator addChild/removeChild
- `test_processprioritymanager.cpp` — ProcessPriorityManager static methods
- `test_pluginmetaobject_ext.cpp` — PluginMetaObject accessors + debug operators
- `test_abstractfileinfo_ext.cpp` — AbstractFileInfo virtual defaults
- Extended `test_eventdispatcher.cpp` — global filters + unsubscribe overloads
- Extended `test_fseventcollector.cpp` — count getters + FSMonitor& constructor

## Verification
- All 4 ctest suites pass (test-dfm-extension, test-dfm-framework, test-dfm-base, test-textindex)
- Full run: 38.87s, 0 failures
- lcov function: 68.1% (2281/3350), lines: 46.7%, branches: 19.0%
- All new tests use dependency-light entry points (early returns / no-DBus / factory construction)

## Summary by Sourcery

Expand unit test coverage across textindex services, dfm-base, and dfm-framework components to exercise dependency-light code paths and early-return logic without touching heavy DBus or threading flows.

Tests:
- Add new unit test suites for textindex components including IndexRuntime, IndexTask, TaskManager, TaskHandlers, FSMonitorWorker, FSEventController, TaskQueueUtils, PathCalculator, IndexProfile content/ocr factories, IndexContentMigrator, and FSEventCollector.
- Introduce dfm-base tests for device and system utilities such as DeviceHelper, NPDeviceAliasManager, DiscDeviceScanner, DefenderController, ProcessPriorityManager, SystemServiceManager, AbstractSceneCreator, and AbstractFileInfo defaults.
- Extend dfm-framework coverage for PluginMetaObject accessors and debug operators, and EventDispatcherManager global event filters and unsubscribe overloads.
- Use temporary directories, dummy handlers, and invalid inputs to cover safe construction, accessors, early returns, and no-op behaviors while avoiding external side effects.