### PR TITLE
fix(shred): cache file info in model to avoid blank rows

### DIFF
--- a/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.cpp
+++ b/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.cpp
@@ -20,7 +20,7 @@ QModelIndex ShredFileModel::index(int row, int column, const QModelIndex &parent
 
     if (row >= rowCount() || row < 0)
         return QModelIndex();
-    return createIndex(row, column, &urlList[row]);
+    return createIndex(row, column, &files[row]);
 }
 
 QModelIndex ShredFileModel::parent(const QModelIndex &child) const
@@ -32,7 +32,7 @@ QModelIndex ShredFileModel::parent(const QModelIndex &child) const
 int ShredFileModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return urlList.count();
+    return files.count();
 }
 
 int ShredFileModel::columnCount(const QModelIndex &parent) const
@@ -43,31 +43,29 @@ int ShredFileModel::columnCount(const QModelIndex &parent) const
 
 QVariant ShredFileModel::data(const QModelIndex &index, int role) const
 {
-    if (!index.isValid() || urlList.count() <= index.row()) {
-        fmWarning() << "ComputerModel::data invalid index row:" << index.row() << "items count:" << urlList.count();
+    if (!index.isValid() || files.count() <= index.row()) {
+        fmWarning() << "ShredFileModel::data invalid index row:" << index.row() << "items count:" << files.count();
         return {};
     }
 
-    const auto &url = urlList[index.row()];
-    auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto);
-    if (!info || !info->exists()) {
-        fmWarning() << "The file is invalid: " << url;
-        return {};
-    }
-
-    switch (role) {
-    case Qt::DisplayRole:
-        return info->displayOf(DisPlayInfoType::kFileDisplayName);
-    case Qt::DecorationRole:
-        return info->fileIcon();
-    default:
-        return {};
-    }
+    if (role == Qt::DisplayRole)
+        return files[index.row()].displayName;
+    if (role == Qt::DecorationRole)
+        return files[index.row()].icon;
+    return {};
 }
 
 void ShredFileModel::setFileList(const QList<QUrl> &fileList)
 {
     beginResetModel();
-    urlList = fileList;
+    files.clear();
+    for (const auto &url : fileList) {
+        auto info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoAuto);
+        if (info && info->exists()) {
+            files.append({url, info->displayOf(DisPlayInfoType::kFileDisplayName), info->fileIcon()});
+        } else {
+            fmWarning() << "The file is invalid: " << url;
+        }
+    }
     endResetModel();
 }

--- a/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.h
+++ b/src/plugins/common/dfmplugin-utils/shred/shredfilemodel.h
@@ -8,6 +8,8 @@
 #include "dfmplugin_utils_global.h"
 
 #include <QAbstractItemModel>
+#include <QIcon>
+#include <QUrl>
 
 namespace dfmplugin_utils {
 
@@ -27,7 +29,12 @@ public:
     void setFileList(const QList<QUrl> &fileList);
 
 private:
-    QList<QUrl> urlList;
+    struct CachedFile {
+        QUrl url;
+        QString displayName;
+        QIcon icon;
+    };
+    QList<CachedFile> files;
 };
 }
 


### PR DESCRIPTION
Cache display name and icon when setting the file list in
ShredFileModel, so data() returns pre-fetched values instead
of querying FileInfo on every paint. When a file is deleted
externally while the dialog is open, the cached display remains
unchanged — no blank row appears.

在 setFileList 时缓存文件显示名称和图标，data() 直接返回缓存值
而非每次实时查询 FileInfo。对话框打开期间文件被外部删除时，
界面保持不变，不会出现空白行。

Log: 修复文件粉碎界面文件被删除后显示空白行的问题
PMS: BUG-372927
Influence: 文件粉碎界面中文件被外部删除后，对应行不再空白，界面保持稳定

## Summary by Sourcery

Cache file metadata in ShredFileModel to avoid runtime FileInfo lookups and prevent blank rows when files are externally deleted.

Bug Fixes:
- Prevent blank rows in the shred file list when files are deleted externally while the dialog is open by serving data from cached metadata.

Enhancements:
- Store URL, display name, and icon in a cached file list and simplify data() to read from this cache instead of querying FileInfo on each access.