### PR TITLE
chore: bump version to 6.5.163

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+dde-file-manager (6.5.163) unstable; urgency=medium
+
+  * fix: show broken-link dialog for deleted SMB share target
+  * fix: avoid parenting delete dialog to WA_DeleteOnClose popup
+  * fix: fix special chars in tag editor clearing existing tags
+  * fix(shred): cache file info in model to avoid blank rows
+  * fix: use decode-validation-first strategy for text preview encoding
+  * fix: correct polkit prompt for partition passphrase change
+  * fix: remove deepin prefix from Chinese translations in desktop file
+  * Fix(disk-encrypt): Enhance security.
+
+ -- zhangsheng <zhangsheng@uniontech.com>  Fri, 07 Aug 2026 09:42:07 +0800
+
 dde-file-manager (6.5.162) unstable; urgency=medium
 
   * Revert "fix: keep desktop canvas origin for top and left dock"


### PR DESCRIPTION
6.5.163

Log:

## Summary by Sourcery

Chores:
- Update Debian changelog entry to reflect version 6.5.163.