### PR TITLE
chore: standardize unit test naming conventions

### DIFF
--- a/autotests/libs/dfm-base/CMakeLists.txt
+++ b/autotests/libs/dfm-base/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB_RECURSE TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
 
-dfm_add_test(test-dfm-base
+dfm_add_test(ut-dfm-base
     SOURCES ${TEST_SOURCES}
     LINK_LIBRARIES DFM6::base Qt6::Test
 )

--- a/autotests/libs/dfm-extension/CMakeLists.txt
+++ b/autotests/libs/dfm-extension/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB_RECURSE TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
 
-dfm_add_test(test-dfm-extension
+dfm_add_test(ut-dfm-extension
     SOURCES ${TEST_SOURCES}
     LINK_LIBRARIES DFM::extension Qt6::Test
 )

--- a/autotests/libs/dfm-framework/CMakeLists.txt
+++ b/autotests/libs/dfm-framework/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB_RECURSE TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
 
-dfm_add_test(test-dfm-framework
+dfm_add_test(ut-dfm-framework
     SOURCES ${TEST_SOURCES}
     LINK_LIBRARIES DFM6::framework Qt6::Test
 )

--- a/autotests/run-ut.sh
+++ b/autotests/run-ut.sh
@@ -74,7 +74,7 @@ export QT_QPA_PLATFORM="offscreen"
 
 # Ensure locally-built libraries (dfm6-base, extractor) are found at runtime
 # ahead of older system-installed copies, preventing symbol-resolution
-# failures (e.g. test-textindex needing newer dfm6-base symbols).
+# failures (e.g. ut-textindex needing newer dfm6-base symbols).
 export LD_LIBRARY_PATH="${BUILD_DIR}/src/dfm-base:${BUILD_DIR}/src/apps/dde-file-manager-extractor${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 ctest --output-on-failure --timeout 120

--- a/autotests/services/textindex/CMakeLists.txt
+++ b/autotests/services/textindex/CMakeLists.txt
@@ -11,14 +11,14 @@ file(GLOB_RECURSE TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
 
-dfm_add_test(test-textindex
+dfm_add_test(ut-textindex
     SOURCES ${TEST_SOURCES}
     LINK_LIBRARIES dde-filemanager-textindex dde-file-manager-extractor-lib dfm6-search Qt6::Core Qt6::Test PkgConfig::NL
 )
 
 # textindex source files use relative includes (e.g. "service_textindex_global.h")
 # so the textindex source root must be in the include path.
-target_include_directories(test-textindex PRIVATE
+target_include_directories(ut-textindex PRIVATE
     ${DFM_SOURCE_DIR}/services/textindex
     ${DFM_PROJECT_ROOT}/include
     ${DFM_SOURCE_DIR}/apps/dde-file-manager-extractor/libextractor


### PR DESCRIPTION
1. Changed CMake test target names from "test-" prefix to "ut-" prefix
for consistency
2. Updated related script comments to reflect the new naming convention
3. This affects dfm-base, dfm-extension, dfm-framework, and textindex
test modules
4. Ensures uniform naming across all unit test modules in the project
5. No functional changes to the tests themselves

Influence:
1. Test target names in CMake configurations have changed
2. Need to update any scripts or CI/CD pipelines that reference old
test names
3. Verify that all unit tests still run correctly with the new naming
4. Check that test execution reports show the updated target names
5. Confirm that test coverage reports properly identify the renamed
tests

chore: 标准化单元测试命名规范

1. 将 CMake 测试目标名称从 "test-" 前缀更改为 "ut-" 前缀以保持一致性
2. 更新相关脚本注释以反映新的命名约定
3. 这影响了 dfm-base、dfm-extension、dfm-framework 和 textindex 测试模块
4. 确保项目中所有单元测试模块的命名统一
5. 测试功能本身没有变化

Influence:
1. CMake 配置中的测试目标名称已更改
2. 需要更新引用旧测试名称的任何脚本或 CI/CD 流水线
3. 验证所有单元测试在新命名下仍然能够正确运行
4. 检查测试执行报告是否显示更新后的目标名称
5. 确认测试覆盖率报告能正确识别重命名的测试

## Summary by Sourcery

Standardize unit test target naming in CMake and related scripts for core libraries and services.

Tests:
- Rename CMake unit test targets from the "test-" prefix to the "ut-" prefix for dfm-base, dfm-extension, dfm-framework, and textindex modules.
- Update unit test runner script comments to reference the new "ut-" test target names.