### PR TITLE
fix(workspace): make list/tree top gap part of viewport content for rubber-band

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewgeometryhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewgeometryhelper.cpp
@@ -46,17 +46,36 @@ ViewGeometryHelper::RangeIndexList ViewGeometryHelper::visibleIndexes(const QRec
     QSize itemSize = m_view->itemSizeHint();
 
     int count = m_view->count();
-    int spacing = m_view->spacing();
-    int itemHeight = itemSize.height() + spacing * 2;
 
     if (m_view->isListViewMode() || m_view->isTreeViewMode()) {
-        int firstIndex = (rect.top() + spacing) / itemHeight;
-        int lastIndex = (rect.bottom() - spacing) / itemHeight;
+        // List/tree items may have variable heights (group-header spacing or
+        // first-row top padding). Use indexAtForSelection (Qt native, variable-
+        // height aware) instead of the uniform-height formula.
+        QRect viewportRect = rect;
+        viewportRect.translate(-m_view->horizontalOffset(), -m_view->verticalOffset());
 
-        if (firstIndex >= count)
-            return list;
+        QModelIndex firstIdx = m_view->indexAtForSelection(viewportRect.topLeft());
+        QModelIndex lastIdx = m_view->indexAtForSelection(viewportRect.bottomRight());
 
-        list << RangeIndex(qMax(firstIndex, 0), qMin(lastIndex, count - 1));
+        if (!firstIdx.isValid()) {
+            if (viewportRect.top() < 0) {
+                firstIdx = m_view->model()->index(0, 0, m_view->rootIndex());
+            } else {
+                return list;
+            }
+        }
+        if (!lastIdx.isValid()) {
+            if (viewportRect.bottom() >= 0) {
+                lastIdx = m_view->model()->index(count - 1, 0, m_view->rootIndex());
+            } else {
+                return list;
+            }
+        }
+        if (firstIdx.isValid() && lastIdx.isValid()) {
+            int startRow = qMin(firstIdx.row(), lastIdx.row());
+            int endRow = qMax(firstIdx.row(), lastIdx.row());
+            list << RangeIndex(qMax(startRow, 0), qMin(endRow, count - 1));
+        }
     } else if (m_view->isIconViewMode()) {
 
         // 分组绘制时计算区域内的list
@@ -82,54 +101,42 @@ ViewGeometryHelper::RangeIndexList ViewGeometryHelper::rectContainsIndexes(const
         return list;
 
     if (m_view->isListViewMode() || m_view->isTreeViewMode()) {
-        // For variable-height items (grouping enabled), use indexAtForSelection
-        if (m_view->isGroupedView()) {
-            // Convert rect to viewport coordinates for comparison
-            QRect viewportRect = rect;
-            viewportRect.translate(-m_view->horizontalOffset(), -m_view->verticalOffset());
+        // List/tree items may have variable heights in both grouped mode
+        // (non-first group headers add kGroupHeaderInterval) and non-grouped
+        // mode (first row adds a kDefaultHeaderBottomMargin top padding). Use
+        // indexAtForSelection (Qt native, variable-height aware) for both.
+        // Convert rect to viewport coordinates for comparison
+        QRect viewportRect = rect;
+        viewportRect.translate(-m_view->horizontalOffset(), -m_view->verticalOffset());
 
-            // Use indexAtForSelection to get items at corners (doesn't skip spacing areas)
-            QModelIndex firstIndex = m_view->indexAtForSelection(viewportRect.topLeft());
-            QModelIndex lastIndex = m_view->indexAtForSelection(viewportRect.bottomRight());
+        // Use indexAtForSelection to get items at corners (doesn't skip spacing areas)
+        QModelIndex firstIndex = m_view->indexAtForSelection(viewportRect.topLeft());
+        QModelIndex lastIndex = m_view->indexAtForSelection(viewportRect.bottomRight());
 
-            // Handle invalid indices by clamping to valid range
-            if (!firstIndex.isValid()) {
-                // Check if above viewport
-                if (viewportRect.top() < 0) {
-                    firstIndex = m_view->model()->index(0, 0, m_view->rootIndex());
-                } else {
-                    return list;   // Empty selection
-                }
+        // Handle invalid indices by clamping to valid range
+        if (!firstIndex.isValid()) {
+            // Check if above viewport
+            if (viewportRect.top() < 0) {
+                firstIndex = m_view->model()->index(0, 0, m_view->rootIndex());
+            } else {
+                return list;   // Empty selection
             }
+        }
 
-            if (!lastIndex.isValid()) {
-                // Check if below viewport content
-                if (viewportRect.bottom() >= 0) {
-                    lastIndex = m_view->model()->index(count - 1, 0, m_view->rootIndex());
-                } else {
-                    return list;   // Empty selection
-                }
+        if (!lastIndex.isValid()) {
+            // Check if below viewport content
+            if (viewportRect.bottom() >= 0) {
+                lastIndex = m_view->model()->index(count - 1, 0, m_view->rootIndex());
+            } else {
+                return list;   // Empty selection
             }
+        }
 
-            if (firstIndex.isValid() && lastIndex.isValid()) {
-                // Normalize rows to handle reversed selection (dragging upwards)
-                int startRow = qMin(firstIndex.row(), lastIndex.row());
-                int endRow = qMax(firstIndex.row(), lastIndex.row());
-                list << RangeIndex(startRow, endRow);
-            }
-        } else {
-            // Uniform height items (no grouping): use optimized calculation
-            QSize itemSize = m_view->itemSizeHint();
-            int spacing = m_view->spacing();
-            int itemHeight = itemSize.height() + spacing * 2;
-
-            int firstIndex = (rect.top() + spacing) / itemHeight;
-            int lastIndex = (rect.bottom() - spacing) / itemHeight;
-
-            if (firstIndex >= count)
-                return list;
-
-            list << RangeIndex(qMax(firstIndex, 0), qMin(lastIndex, count - 1));
+        if (firstIndex.isValid() && lastIndex.isValid()) {
+            // Normalize rows to handle reversed selection (dragging upwards)
+            int startRow = qMin(firstIndex.row(), lastIndex.row());
+            int endRow = qMax(firstIndex.row(), lastIndex.row());
+            list << RangeIndex(startRow, endRow);
         }
     } else if (m_view->isIconViewMode()) {
         QSize itemSize = m_view->itemSizeHint();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -317,10 +317,6 @@ bool FileView::setRootUrl(const QUrl &url)
     resetSelectionModes();
     updateListHeaderView();
 
-    // Adjust header layout margins based on grouping state for list/tree mode
-    // This handles both initialization and directory switching scenarios
-    d->adjustHeaderLayoutMargin(model()->groupingStrategy());
-
     // 初始化分组状态追踪
     d->previousGroupStrategy = model()->groupingStrategy();
 
@@ -844,9 +840,7 @@ void FileView::setGroup(const QString &strategyName, const Qt::SortOrder order)
         setFileViewStateValue(url, "groupingOrder", static_cast<int>(order));
     }
 
-    // Dynamically adjust header layout margins based on grouped view state
-    // For list/tree mode: remove bottom margin when in grouped view to eliminate gap above first group-header
-    d->adjustHeaderLayoutMargin(strategyName);
+    // Dynamically adjust icon mode spacing based on grouped view state
     d->adjustIconModeSpacing(strategyName);
 }
 
@@ -1767,28 +1761,27 @@ QModelIndex FileView::indexAt(const QPoint &pos) const
         return index;
     }
 
-    // For list/tree mode with variable-height items (grouping enabled),
-    // use Qt's native indexAt which correctly handles variable heights
-    if (isGroupedView()) {
+    // For list/tree mode (both grouped and non-grouped) items may have variable
+    // heights: grouped views add kGroupHeaderInterval to non-first group headers,
+    // and non-grouped views add a kDefaultHeaderBottomMargin top padding to the
+    // first row. Use Qt's native indexAt which handles variable heights correctly,
+    // and treat the transparent spacing/padding areas as empty for selection.
+    if (isListViewMode() || isTreeViewMode()) {
         QModelIndex index = DListView::indexAt(pos);
 
-        // Return invalid index if click is in group header spacing area
-        if (isClickInGroupHeaderSpacing(pos, index))
+        // Group-header inter-group spacing is an empty area for selection.
+        if (isGroupedView() && isClickInGroupHeaderSpacing(pos, index))
+            return QModelIndex();
+
+        // Non-grouped first-row top padding (the 10px gap above the list) is an
+        // empty area for rubber-band selection, just like the inter-group gap.
+        if (!isGroupedView() && isClickInTopPadding(pos, index))
             return QModelIndex();
 
         return index;
     }
 
-    // For list/tree mode with uniform heights (no grouping),
-    // use optimized custom calculation
-    QSize itemSize = itemSizeHint();
-    QPoint actualPos = QPoint(pos.x() + horizontalOffset(), pos.y() + verticalOffset());
-    int index = FileViewHelper::caculateListItemIndex(itemSize, actualPos);
-
-    if (index == -1 || index >= model()->rowCount(rootIndex()))
-        return QModelIndex();
-
-    return model()->index(index, 0, rootIndex());
+    return QModelIndex();
 }
 
 QRect FileView::visualRect(const QModelIndex &index) const
@@ -1877,6 +1870,12 @@ void FileView::updateGeometries()
                 // Add spacing for non-first group headers: (groupsCount - 1) * kGroupHeaderInterval
                 listHeight += (groupsCount - 1) * kGroupHeaderInterval;
             }
+        } else {
+            // In non-grouped list/tree mode the first row carries a transparent
+            // top padding (kDefaultHeaderBottomMargin) as a content-level gap above
+            // the file list, so the scrollable content height must include it.
+            if (rowCount > 0)
+                listHeight += kDefaultHeaderBottomMargin;
         }
 
         int contentHeight = contentsSize().height();
@@ -2183,20 +2182,6 @@ bool FileView::eventFilter(QObject *obj, QEvent *event)
             return true;
         }
     } break;
-    case QEvent::MouseButtonPress: {
-        if (obj != d->headerWidget)
-            break;
-        auto e = dynamic_cast<QMouseEvent *>(event);
-        if (!e)
-            break;
-
-        if (e->button() == Qt::RightButton) {
-            d->mouseLeftPressed = false;
-            QContextMenuEvent menuEvent(QContextMenuEvent::Mouse, { -1, -1 });
-            contextMenuEvent(&menuEvent);
-            return true;
-        }
-    } break;
     case QEvent::Move:
         if (obj != horizontalScrollBar()->parentWidget())
             return DListView::eventFilter(obj, event);
@@ -2256,10 +2241,6 @@ bool FileView::eventFilter(QObject *obj, QEvent *event)
         break;
     default:
         break;
-    }
-
-    if (obj == d->headerWidget && event->type() == QEvent::Resize) {
-        d->headerView->adjustSize();
     }
 
     return DListView::eventFilter(obj, event);
@@ -2509,30 +2490,6 @@ void FileView::initializeScrollBarWatcher()
         if (d->scrollBarSliderPressed)
             d->scrollBarValueChangedTimer->start();
 
-        if (d->headerWidget && d->headerWidget->isVisible()) {
-            auto headerLayout = d->headerWidget->layout();
-            auto margins = headerLayout->contentsMargins();
-            if (value > 0 && margins.bottom() != 0) {
-                headerLayout->setContentsMargins(0, 0, 0, 0);
-                QTimer::singleShot(0, this, [this]() {
-                    if (!d->headerView)
-                        return;
-                    int hVal = horizontalScrollBar() ? horizontalScrollBar()->value() : 0;
-                    d->headerView->syncOffset(hVal);
-                });
-            } else if (value == 0 && margins.bottom() == 0) {
-                // Only restore bottom margin in non-grouped mode
-                int bottomMargin = isGroupedView() ? 0 : kDefaultHeaderBottomMargin;
-                headerLayout->setContentsMargins(0, 0, 0, bottomMargin);
-                QTimer::singleShot(0, this, [this]() {
-                    if (!d->headerView)
-                        return;
-                    int hVal = horizontalScrollBar() ? horizontalScrollBar()->value() : 0;
-                    d->headerView->syncOffset(hVal);
-                });
-            }
-        }
-
         if (isGroupedView()) {
             viewport()->update();
         }
@@ -2640,12 +2597,6 @@ void FileView::updateContentLabel()
         }
     } else {
         d->contentLabel->setText(QString());
-    }
-
-    // Remove header bottom margin when empty to avoid unnecessary spacing
-    if (d->headerWidget && (isListViewMode() || isTreeViewMode())) {
-        int bottomMargin = isEmpty ? 0 : (isGroupedView() ? 0 : kDefaultHeaderBottomMargin);
-        d->headerWidget->layout()->setContentsMargins(0, 0, 0, bottomMargin);
     }
 }
 
@@ -2908,6 +2859,23 @@ bool FileView::isClickInGroupHeaderSpacing(const QPoint &pos, const QModelIndex 
     return (relativeY >= 0 && relativeY < kGroupHeaderInterval);
 }
 
+bool FileView::isClickInTopPadding(const QPoint &pos, const QModelIndex &index) const
+{
+    // Only the root's first row in non-grouped list/tree carries the top padding.
+    // Requiring parent == rootIndex avoids matching tree-mode expanded sub-items
+    // whose row is also 0 under a different parent.
+    if (!index.isValid() || isGroupedView() || isIconViewMode())
+        return false;
+    if (index.row() != 0 || index.parent() != rootIndex())
+        return false;
+
+    // The transparent top padding (kDefaultHeaderBottomMargin) sits at the top of
+    // the first row's visual rect; a click there is an empty area for selection.
+    QRect itemRect = visualRect(index);
+    int relativeY = pos.y() - itemRect.top();
+    return (relativeY >= 0 && relativeY < kDefaultHeaderBottomMargin);
+}
+
 QModelIndex FileView::indexAtForSelection(const QPoint &pos) const
 {
     // Similar to indexAt(), but doesn't skip 16px spacing areas for box selection
@@ -2915,7 +2883,9 @@ QModelIndex FileView::indexAtForSelection(const QPoint &pos) const
         return iconIndexAt(pos, itemSizeHint());
     }
 
-    if (isGroupedView()) {
+    // For list/tree mode (grouped or not) use Qt's native indexAt to support
+    // variable row heights (group-header spacing / first-row top padding).
+    if (isListViewMode() || isTreeViewMode()) {
         // For list mode (single column), clamp X coordinate to viewport range
         // Only Y coordinate matters for determining which row is selected
         QPoint clampedPos = pos;
@@ -2923,15 +2893,7 @@ QModelIndex FileView::indexAtForSelection(const QPoint &pos) const
         return DListView::indexAt(clampedPos);
     }
 
-    // For list/tree mode with uniform heights, use optimized calculation
-    QSize itemSize = itemSizeHint();
-    QPoint actualPos = QPoint(pos.x() + horizontalOffset(), pos.y() + verticalOffset());
-    int index = FileViewHelper::caculateListItemIndex(itemSize, actualPos);
-
-    if (index == -1 || index >= model()->rowCount(rootIndex()))
-        return QModelIndex();
-
-    return model()->index(index, 0, rootIndex());
+    return QModelIndex();
 }
 
 // Grouping-related slot implementations

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.h
@@ -42,6 +42,7 @@ class FileView final : public DListView, public DFMBASE_NAMESPACE::AbstractBaseV
     friend class ViewGeometryHelper;
     friend class StickyGroupHeaderHelper;
     friend class IconItemDelegate;
+    friend class ListItemDelegate;
 
     QSharedPointer<FileViewPrivate> d;
 
@@ -270,6 +271,7 @@ private:
 
     bool isGroupHeader(const QModelIndex &index) const;
     bool isClickInGroupHeaderSpacing(const QPoint &pos, const QModelIndex &index) const;
+    bool isClickInTopPadding(const QPoint &pos, const QModelIndex &index) const;
     QModelIndex indexAtForSelection(const QPoint &pos) const;
 
     QModelIndex findStickyGroupIndex(int headerHeight);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.cpp
@@ -55,6 +55,24 @@ ListItemDelegate::~ListItemDelegate()
 {
 }
 
+bool ListItemDelegate::isFirstRowWithTopPadding(const QModelIndex &index) const
+{
+    // Centralised guard for the non-grouped list/tree first-row 10px transparent
+    // top padding. parent()->parent() is the FileView (delegate is parented to
+    // the FileViewHelper which is parented to the FileView); qobject_cast keeps
+    // the cast type-safe if that hierarchy ever changes.
+    // parent == rootIndex() excludes tree-mode expanded sub-items (whose row is
+    // also 0 under a different parent) and the rootIndex itself (used by
+    // FileView::itemSizeHint).
+    FileView *view = qobject_cast<FileView *>(parent()->parent());
+    return view
+        && !view->isGroupedView()
+        && (view->isListViewMode() || view->isTreeViewMode())
+        && !isGroupHeaderItem(index)
+        && index.row() == 0
+        && index.parent() == view->rootIndex();
+}
+
 void ListItemDelegate::paint(QPainter *painter,
                              const QStyleOptionViewItem &option,
                              const QModelIndex &index) const
@@ -89,6 +107,13 @@ void ListItemDelegate::paint(QPainter *painter,
         painter->setOpacity(0.3);
     }
 
+    // First row in non-grouped list/tree carries a 10px transparent top padding
+    // (the design gap above the file list). Shift the painted content down by
+    // that padding so the top 10px stays transparent, mirroring how non-first
+    // group headers skip their top kGroupHeaderInterval spacing.
+    if (isFirstRowWithTopPadding(index))
+        opt.rect.setTop(opt.rect.top() + kDefaultHeaderBottomMargin);
+
     paintItemBackground(painter, opt, index);
 
     QRectF iconRect = paintItemIcon(painter, opt, index);
@@ -111,11 +136,17 @@ QSize ListItemDelegate::sizeHint(const QStyleOptionViewItem &option, const QMode
         return size;
     }
 
-    Q_UNUSED(index)
     Q_D(const ListItemDelegate);
 
-    // Todo(yanghao): isColumnCompact (fontMetrics.height() * 2 + 10)
-    return QSize(d->itemSizeHint.width(), qMax(option.fontMetrics.height(), d->itemSizeHint.height()));
+    // In non-grouped list/tree mode the first row carries a 10px transparent top
+    // padding (the design-level gap above the file list). It is part of the row's
+    // content height, so it scrolls with the content and the empty top area is
+    // treated as an empty area for rubber-band selection, just like the inter-
+    // group gap in the grouped view (which adds kGroupHeaderInterval instead).
+    int height = qMax(option.fontMetrics.height(), d->itemSizeHint.height());
+    if (isFirstRowWithTopPadding(index))
+        height += kDefaultHeaderBottomMargin;
+    return QSize(d->itemSizeHint.width(), height);
 }
 
 QWidget *ListItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -127,8 +158,10 @@ QWidget *ListItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
     const quint64 sessionId = d->editingSessionId;
     d->editingIndex = index;
     d->editor = new ListItemEditor(parent);
-    auto size = sizeHint(option, index);
-    d->editor->setFixedHeight(size.height());
+    // Use the baseline item height (without the first-row top padding) for the
+    // editor so inline rename / Ctrl+M+M editing boxes are not 10px taller on row 0.
+    int editorHeight = qMax(option.fontMetrics.height(), d->itemSizeHint.height());
+    d->editor->setFixedHeight(editorHeight);
 
     connect(static_cast<ListItemEditor *>(d->editor), &ListItemEditor::inputFocusOut, this, &ListItemDelegate::editorFinished);
 
@@ -149,7 +182,15 @@ QWidget *ListItemDelegate::createEditor(QWidget *parent, const QStyleOptionViewI
 
 void ListItemDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    const QRect &optRect = option.rect + QMargins(-kListModeLeftMargin - kListModeLeftPadding, 0, -kListModeRightMargin - kListModeRightMargin, 0);
+    QRect optRect = option.rect + QMargins(-kListModeLeftMargin - kListModeLeftPadding, 0, -kListModeRightMargin - kListModeRightPadding, 0);
+
+    // First row in non-grouped list/tree carries a 10px transparent top padding.
+    // The editor is positioned within the row's content area (below the padding),
+    // otherwise it would be vertically centered over the full itemH+10 row and sit
+    // a few px higher than the actual text/icon content (and higher than other rows).
+    if (isFirstRowWithTopPadding(index))
+        optRect.setTop(optRect.top() + kDefaultHeaderBottomMargin);
+
     QRect iconRect = getRectOfItem(RectOfItemType::kItemIconRect, index);
 
     const QList<ItemRoles> &columnRoleList = parent()->parent()->model()->getColumnRoles();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/listitemdelegate.h
@@ -63,6 +63,12 @@ private:
 
     int dataWidth(const QStyleOptionViewItem &option, const QModelIndex &index, int role) const;
 
+    // Whether `index` is the root's first row in non-grouped list/tree mode,
+    // i.e. the row that carries the 10px transparent top padding (the design
+    // gap above the file list). Centralised so paint/sizeHint/updateEditorGeometry
+    // share one copy of the guard instead of drifting.
+    bool isFirstRowWithTopPadding(const QModelIndex &index) const;
+
     // Group functionality implementation
     int getGroupHeaderHeight(const QStyleOptionViewItem &option) const override;
     QRectF getGroupHeaderBackgroundRect(const QStyleOptionViewItem &option) const override;

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -77,17 +77,13 @@ void FileViewPrivate::initIconModeView()
 {
     fmDebug() << "Initializing icon mode view";
 
-    if (headerWidget) {
-        headerWidget->setVisible(false);
-
-        if (headerView) {
-            headerView->disconnect();
-            auto headerLayout = qobject_cast<QVBoxLayout *>(headerWidget->layout());
-            headerLayout->removeWidget(headerView);
-            headerView->deleteLater();
-            headerView = nullptr;
-            fmDebug() << "Header view removed for icon mode";
-        }
+    if (headerView) {
+        headerView->setVisible(false);
+        headerView->disconnect();
+        q->removeHeaderWidget(0);
+        headerView->deleteLater();
+        headerView = nullptr;
+        fmDebug() << "Header view removed for icon mode";
     }
 
     if (statusBar) {
@@ -121,19 +117,8 @@ void FileViewPrivate::initListModeView()
         fmDebug() << "Item delegate height level set to:" << currentListHeightLevel;
     }
 
-    if (!headerWidget) {
-        headerWidget = new QWidget(q);
-        QVBoxLayout *headerLayout = new QVBoxLayout(headerWidget);
-        headerLayout->setContentsMargins(0, 0, 0, 10);
-        headerLayout->setAlignment(Qt::AlignTop);
-        headerWidget->installEventFilter(q);
-        q->addHeaderWidget(headerWidget);
-        fmDebug() << "Header widget created for list mode";
-    }
-
     if (!headerView) {
         q->initDefaultHeaderView();
-        auto headerLayout = qobject_cast<QVBoxLayout *>(headerWidget->layout());
 
         headerView = new HeaderView(Qt::Orientation::Horizontal, q);
 
@@ -146,7 +131,8 @@ void FileViewPrivate::initListModeView()
             headerView->setSelectionModel(q->selectionModel());
         }
 
-        headerLayout->addWidget(headerView);
+        q->addHeaderWidget(headerView);
+        fmDebug() << "Header view created and added for list mode";
 
         QObject::connect(headerView, &HeaderView::mousePressed, q, &FileView::onHeaderViewMousePressed);
         QObject::connect(headerView, &HeaderView::mouseReleased, q, &FileView::onHeaderViewMouseReleased);
@@ -162,10 +148,8 @@ void FileViewPrivate::initListModeView()
         fmDebug() << "Header view created and configured for list mode";
     }
 
-    headerWidget->setVisible(true);
-
-    // Adjust header layout margin based on grouping state
-    adjustHeaderLayoutMargin(q->model()->groupingStrategy());
+    if (headerView)
+        headerView->setVisible(true);
 
     if (statusBar) {
         statusBar->setScalingVisible(false);
@@ -360,29 +344,6 @@ void FileViewPrivate::updateHorizontalOffset()
         }
         horizontalOffset = -(contentWidth - itemWidth * itemColumn) / 2;
     }
-}
-
-void FileViewPrivate::adjustHeaderLayoutMargin(const QString &strategyName)
-{
-    // Only adjust margins for list/tree mode
-    if (!(q->isListViewMode() || q->isTreeViewMode()))
-        return;
-
-    // Ensure headerWidget exists and is visible
-    if (!headerWidget || !headerWidget->isVisible())
-        return;
-
-    auto headerLayout = headerWidget->layout();
-    if (!headerLayout)
-        return;
-
-    // Determine margin based on grouping state
-    bool isGrouped = strategyName != GroupStrategy::kNoGroup;
-    int bottomMargin = isGrouped ? 0 : kDefaultHeaderBottomMargin;
-
-    headerLayout->setContentsMargins(0, 0, 0, bottomMargin);
-    fmDebug() << "Header layout bottom margin adjusted to:" << bottomMargin
-              << "for grouped view:" << isGrouped << "URL:" << q->rootUrl().toString();
 }
 
 void FileViewPrivate::adjustIconModeSpacing(const QString &strategyName)

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.h
@@ -56,7 +56,6 @@ class FileViewPrivate
     ViewAnimationHelper *animationHelper { nullptr };
     ViewGeometryHelper *geometryHelper { nullptr };
     StickyGroupHeaderHelper *stickyHelper { nullptr };
-    QWidget *headerWidget { nullptr };
 
     QList<FileView::SelectionMode> enabledSelectionModes;
     DFMBASE_NAMESPACE::Global::ViewMode currentViewMode = DFMBASE_NAMESPACE::Global::ViewMode::kIconMode;
@@ -117,8 +116,6 @@ class FileViewPrivate
     bool shouldPersistState(const QUrl &url) const;
 
     void updateHorizontalOffset();
-    // 使用 strategyName 是因为当 setGroup 时，model并不是分组状态
-    void adjustHeaderLayoutMargin(const QString &strategyName);
     void adjustIconModeSpacing(const QString &strategyName);
 };
 


### PR DESCRIPTION
## 根因分析

非分组 list/tree 视图顶部的 10px 间隙是 `headerWidget`（经 `addHeaderWidget` 挂到 DListView 的、viewport 之外的固定子控件）的底部 margin。它**不消费鼠标左键**：既不触发 `FileView::mousePressEvent` 的框选，其事件过滤器又只处理右键。于是左键拖拽被无标题栏的 `DMainWindow`（`enableSystemMove`）接管，导致文管窗口被整体拖动。

关键证据：
- `dfmplugin_workspace_global.h:89` + `views/private/fileview_p.cpp:124-130,365-384`：list/tree 视图顶部 `headerWidget = new QWidget`，经 `addHeaderWidget` 挂为 viewport 之外子控件；非分组时底部 margin = `kDefaultHeaderBottomMargin`(10px)。
- `views/fileview.cpp:2187-2202`：`headerWidget` 事件过滤器只处理右键，左键不消费。
- `src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp:1296-1299`：`DMainWindow` 且 DTitlebar 隐藏（无标题栏）；全仓库无窗口移动代码，窗口移动由 DTK `enableSystemMove` 在未消费拖拽时发起。

PMS: https://pms.uniontech.com/bug-view-372987.html

## 修复方案

参考分组视图 group-header 16px 间隙机制（把间隙算进行高、绘制下移、点击落空走框选），将顶部 10px 留白从 `headerWidget` 的 margin 移进 viewport 内容区，作为首行的透明顶部留白：

1. 去除 `headerWidget` 中间包装层，`HeaderView` 直接 `addHeaderWidget`，自管右键菜单，删除围着 `headerWidget`/margin 的全部代码。
2. 非分组 list/tree 首行 `sizeHint` 加 10px 透明顶部留白（参考 `displayIndex>0` 时 `+kGroupHeaderInterval`），绘制时内容下移 10px，留白随内容自然滚动。
3. `indexAt`/`indexAtForSelection`/`rectContainsIndexes`/`visibleIndexes` 非分组 list/tree 改用 Qt 原生 `DListView::indexAt`（变高支持）+ `isClickInTopPadding` 判断，留白区返回 invalid 走 `isEmptyArea` 框选路径。
4. `updateGeometries` 非分组 `listHeight` 加上首行 10px 留白。

不变项：分组视图（`kGroupHeaderInterval` 原逻辑）、图标视图、sticky group header、HeaderView 列宽/排序/拖拽均不受影响。

## 改动安全评估

中风险。改动涉及 delegate `sizeHint`/`paint` + 几何计算（`indexAt`/`indexAtForSelection`/`rectContainsIndexes`/`visibleIndexes`/`updateGeometries`）多处一致性改动，由非分组 list/tree 的"等高优化"统一改为 Qt 原生变高路径（与分组视图同）。未改函数签名，未删公开成员。分组视图与图标模式不触碰。当前环境无法编译验证，需自测：首行位置、滚动留白消失、首行点击/框选、分组视图回归。

## 自测建议

- 列表/树形视图：顶部 10px 留白处左键拖拽 → 应框选（非拖窗）
- 滚动到顶 → 留白可见；往下滚 → 留白随内容消失
- 分组视图 → 行为不变（无留白，组间间隙框选正常）
- 列头右键 → 列显隐菜单正常
- 图标视图 → 无回归

## Summary by Sourcery

Adjust list/tree workspace view so the 10px top gap is part of the scrollable content instead of a fixed header margin, ensuring it behaves as empty area for selection rather than dragging the window.

Bug Fixes:
- Prevent window dragging when rubber-band selecting from the 10px gap above non-grouped list/tree content by treating that area as selectable empty space tied to the first row.

Enhancements:
- Unify list/tree geometry handling to use Qt's variable-height index resolution for both grouped and non-grouped modes, simplifying index and visibility calculations.
- Simplify header setup by removing the intermediate header container widget and attaching the header view directly as a header widget in list mode.