### PR TITLE
fix(disk-mount): avoid blurry popup theme icons

### DIFF
--- a/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.cpp
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.cpp
@@ -7,7 +7,8 @@
 
 #include <QLabel>
 #include <QProgressBar>
-#include <QPushButton>
+#include <QIcon>
+#include <QPainter>
 #include <QVBoxLayout>
 #include <QStandardPaths>
 #include <QLoggingCategory>
@@ -21,6 +22,28 @@ Q_DECLARE_LOGGING_CATEGORY(logAppDock)
 
 using namespace Dtk::Gui;
 using namespace Dtk::Widget;
+
+// Renders the theme icon during paint events to avoid blurry cached rasters.
+class IconLabel : public QWidget {
+public:
+    explicit IconLabel(const QString &iconName, int size, QWidget *parent = nullptr)
+        : QWidget(parent), m_icon(QIcon::fromTheme(iconName)), m_size(size)
+    {
+        setFixedSize(m_size, m_size);
+        setAttribute(Qt::WA_TransparentForMouseEvents);
+    }
+
+protected:
+    void paintEvent(QPaintEvent *) override
+    {
+        QPainter painter(this);
+        m_icon.paint(&painter, 0, 0, m_size, m_size);
+    }
+
+private:
+    QIcon m_icon;
+    int m_size;
+};
 
 DeviceItem::DeviceItem(const DockItemData &item, QWidget *parent)
     : QFrame(parent), data(item)
@@ -99,17 +122,12 @@ void DeviceItem::initUI()
     ejectBtn->setIconSize({ 20, 20 });
     ejectBtn->setIcon(QIcon::fromTheme("dfm_dock_unmount"));
 
-    QPushButton *deviceIcon = new QPushButton(this);
-    deviceIcon->setFlat(true);
-    deviceIcon->setIcon(QIcon::fromTheme(data.iconName));
-    deviceIcon->setIconSize({ 48, 48 });
-    deviceIcon->setAttribute(Qt::WA_TransparentForMouseEvents);
-    deviceIcon->setStyleSheet("padding: 0;");
+    deviceIconLabel = new IconLabel(data.iconName, 48, this);
 
     QVBoxLayout *devIconLay = new QVBoxLayout();
     devIconLay->setContentsMargins(10, 8, 0, 8);
     devIconLay->setSpacing(0);
-    devIconLay->addWidget(deviceIcon);
+    devIconLay->addWidget(deviceIconLabel);
 
     QVBoxLayout *devInfoLay = new QVBoxLayout();
     devInfoLay->setSpacing(2);

--- a/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.h
+++ b/src/external/dde-dock-plugins/disk-mount/widgets/deviceitem.h
@@ -10,6 +10,8 @@
 #include <QFrame>
 #include <QMouseEvent>
 
+class IconLabel;
+
 class QLabel;
 class QProgressBar;
 class DeviceItem : public QFrame
@@ -42,6 +44,7 @@ private:
     QLabel *sizeLabel { nullptr };
     QLabel *nameLabel { nullptr };
     QProgressBar *sizeProgress { nullptr };
+    IconLabel *deviceIconLabel { nullptr };
 };
 
 #endif   // DEVICEITEM_H


### PR DESCRIPTION
## Summary
- replace the popup device icon button with a dedicated icon widget
- render theme icons during paint events to avoid the cached raster scaling path
- keep the existing 48px layout and popup interaction behavior unchanged

## 概要
- 将弹窗里的设备图标按钮替换为专用图标控件
- 在绘制阶段渲染主题图标，绕开缓存位图缩放路径导致的模糊问题
- 保持原有 48 像素布局尺寸和弹窗交互行为不变

## Testing
- manually verified the disk mount popup icon is clear at 125% scaling in the local runtime environment
- local rebuild of this clean GitHub clone is blocked by a missing KF6IdleTime dependency in the machine environment

PMS: https://pms.uniontech.com/bug-view-372659.html