### PR TITLE
fix: percent-encode '#' in smb address before QUrl parsing for cifs mount

### DIFF
--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -36,6 +36,15 @@ SERVICEMOUNTCONTROL_USE_NAMESPACE
 
 static constexpr char kPolicyKitActionIdCIFS[] { "org.deepin.Filemanager.MountController.CIFS" };
 
+// SMB URL 中不会携带真正的 fragment，地址里任何 '#' 都属于共享名/路径的一部分。
+// QUrl 会把字面 '#' 当作 fragment 起始符而在 path() 处截断，故解析前先把 '#' 百分号编码为 "%23"；
+// QUrl::path() 会把 "%23" 解码回 '#'，从而还原真实共享名交给 mount.cifs。
+// 对不含 '#' 的地址是 no-op，零影响。
+static QString normalizeSmbAddress(const QString &address)
+{
+    return QString(address).replace('#', "%23");
+}
+
 CifsMountHelper::CifsMountHelper(QDBusContext *context)
     : AbstractMountHelper(context), d(new CifsMountHelperPrivate()) { }
 
@@ -50,7 +59,8 @@ QVariantMap CifsMountHelper::mount(const QString &path, const QVariantMap &opts)
                  { kErrorMessage, "smb is only supported scheme now" } };
     }
 
-    QUrl smbUrl(path);
+    const QString smbAddr = normalizeSmbAddress(path);
+    QUrl smbUrl(smbAddr);
     int port = smbUrl.port();
     const QString &share = smbUrl.path();
     const QString &host = smbUrl.host();
@@ -66,7 +76,7 @@ QVariantMap CifsMountHelper::mount(const QString &path, const QVariantMap &opts)
                  { kErrorMessage, QString("%1 is already mounted at %2").arg(path).arg(mpt) } };
     }
 
-    auto mntPath = generateMountPath(path);
+    auto mntPath = generateMountPath(smbAddr);
     if (mntPath.isEmpty())
         return { { kMountPoint, "" },
                  { kResult, false },


### PR DESCRIPTION
## 根因分析

共享名中的 `#` 是 URL fragment 分隔符。挂载守护进程 `CifsMountHelper::mount` 用 `QUrl` 解析含**字面 `#`** 的 `smb://` 地址时，把 `#` 当作 fragment 起始符，共享名在 `#` 处被截断；`mount.cifs` 随即请求一个不存在的共享，返回 ENOENT(error 2)，弹窗"挂载失败，没有找到文件或目录"。

关键证据：
- 复现日志：`newUrl smb://…新建文件夹%23`（已编码）↔ `Network mount failed …"smb://…新建文件夹#" error: 2`（实际挂载用字面 `#`），编码态与挂载态不一致。
- 代码链：`traversprehandler.cpp:62` 与 `util-dfm/.../dnetworkmounter.cpp:325` 的 `QUrl::fromPercentEncoding` 把 `%23` 解码回字面 `#`；`cifsmounthelper.cpp:53-57` 的 `QUrl smbUrl(path)` 把字面 `#` 当 fragment → `share` 截断 → 行 125 `::mount(aPath,…,"cifs",…)` 请求错误共享。
- Qt6 实测：`QUrl("…%23").path()`→`/…#`（正确），`QUrl("…#…").path()`→截断。证明守护进程对编码态 `%23` 本就正确，根因在上游把 `%23` 解码成字面 `#`。

## 修复方案

在 `CifsMountHelper::mount` 解析 `QUrl` 前与调用 `generateMountPath` 前，对 smb 地址做归一化——把字面 `#` 百分号编码为 `%23`（`smb://` URL 永不携带真正的 fragment，任何 `#` 都属于共享名/路径），`QUrl::path()` 会把 `%23` 解码回 `#`，正确还原共享名给 `mount.cifs`。对不含 `#` 的地址为 no-op，零影响。新增文件局部 `static QString normalizeSmbAddress(const QString &)` 实现，不改头文件、不改公开 API。

## 改动安全评估

低风险：`mount` 唯一调用者为 DBus 多态分发，`generateMountPath` 为 private 且仅 `mount` 内部调用；签名不变、无公开 API 改动；不含 `#` 的地址归一化为 no-op；本机 Qt6 实测完整测试名 `新建文件夹!@#$^&()_{}lksdfg` 经归一化后 `aPath` 与服务端共享名 `MATCH=YES`、`@` 未被误解析为 userinfo。不改动 `unmount`（与本 bug 无关的既有状况）。

## Summary by Sourcery

Normalize CIFS SMB URLs before parsing to ensure shares containing '#' are mounted correctly.

Bug Fixes:
- Fix CIFS mount failures by percent-encoding literal '#' characters in SMB addresses prior to QUrl parsing to prevent truncation of the share path.

Enhancements:
- Introduce a local normalizeSmbAddress helper to sanitize SMB URLs before both QUrl construction and mount path generation.