### PR TITLE
fix: handle top padding selection in non-grouped views

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewgeometryhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewgeometryhelper.cpp
@@ -57,6 +57,14 @@ ViewGeometryHelper::RangeIndexList ViewGeometryHelper::visibleIndexes(const QRec
         QModelIndex firstIdx = m_view->indexAtForSelection(viewportRect.topLeft());
         QModelIndex lastIdx = m_view->indexAtForSelection(viewportRect.bottomRight());
 
+        // Non-grouped list/tree: if both corners fall in the first-row top
+        // padding, the rect is entirely within the gap — no items selected.
+        if (!m_view->isGroupedView()
+                && m_view->isClickInTopPadding(viewportRect.topLeft(), firstIdx)
+                && m_view->isClickInTopPadding(viewportRect.bottomRight(), lastIdx)) {
+            return list;
+        }
+
         if (!firstIdx.isValid()) {
             if (viewportRect.top() < 0) {
                 firstIdx = m_view->model()->index(0, 0, m_view->rootIndex());
@@ -112,6 +120,14 @@ ViewGeometryHelper::RangeIndexList ViewGeometryHelper::rectContainsIndexes(const
         // Use indexAtForSelection to get items at corners (doesn't skip spacing areas)
         QModelIndex firstIndex = m_view->indexAtForSelection(viewportRect.topLeft());
         QModelIndex lastIndex = m_view->indexAtForSelection(viewportRect.bottomRight());
+
+        // Non-grouped list/tree: if both corners fall in the first-row top
+        // padding, the rect is entirely within the gap — no items selected.
+        if (!m_view->isGroupedView()
+                && m_view->isClickInTopPadding(viewportRect.topLeft(), firstIndex)
+                && m_view->isClickInTopPadding(viewportRect.bottomRight(), lastIndex)) {
+            return list;
+        }
 
         // Handle invalid indices by clamping to valid range
         if (!firstIndex.isValid()) {


### PR DESCRIPTION
1. Added boundary checks in ViewGeometryHelper to prevent incorrect
item selection
2. When both selection rectangle corners fall within first-row top
padding area in non-grouped views, return empty selection
3. Applied fix to both visibleIndexes() and rectContainsIndexes()
methods for consistency

Influence:
1. Test selection behavior in icon/list view modes with empty top area
2. Verify group view selection behavior remains unchanged
3. Test boundary cases where selection rectangle includes both padding
and item areas
4. Verify no regression in existing selection functionality
5. Test with various viewport sizes and scroll positions

fix: 修复非分组视图中顶部填充区域的错误选择问题

1. 在 ViewGeometryHelper 中添加边界检查，防止错误选择项目
2. 当非分组视图中选择矩形的两个角点都位于首行顶部填充区域时，返回空选择
3. 在 visibleIndexes() 和 rectContainsIndexes() 方法中应用相同的修复以确
保一致性

Influence:
1. 测试图标/列表视图模式下空白顶部区域的选择行为
2. 验证分组视图选择行为保持不变
3. 测试选择矩形同时包含填充区域和项目区域的边界情况
4. 验证现有选择功能没有回归问题
5. 使用不同视图大小和滚动位置进行测试

## Summary by Sourcery

Bug Fixes:
- Avoid selecting items when the selection rectangle lies fully within the first-row top padding in non-grouped list/tree views by short-circuiting the selection logic in visibleIndexes() and rectContainsIndexes().