### PR TITLE
multi screen sort animation

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/canvasmanager.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/canvasmanager.cpp
@@ -7,6 +7,7 @@
 #include "grid/canvasgrid.h"
 #include "displayconfig.h"
 #include "view/operator/fileoperatorproxy.h"
+#include "view/operator/sortanimationoper.h"
 #include "desktoputils/ddplugin_eventinterface_helper.h"
 #include "menu/canvasmenuscene.h"
 #include "menu/canvasbasesortmenuscene.h"
@@ -641,23 +642,28 @@ void CanvasManagerPrivate::onFileModelReset()
 
 void CanvasManagerPrivate::onAboutToFileSort()
 {
-    // TODO(liuyangming): only one screen is valid now.
-    if (q->views().count() != 1)
+    if (q->views().isEmpty())
         return;
 
-    if (auto view = q->views().first())
-        view->aboutToResortFiles();
+    QStringList existItems;
+    const QList<QUrl> &actualList = canvasModel->files();
+    for (const QUrl &df : actualList)
+        existItems.append(df.toString());
+
+    SortAnimationOper::instance()->setMoveValue(existItems);
 }
 
 void CanvasManagerPrivate::onFileSorted()
 {
     bool animEnable = DConfigManager::instance()->value(kAnimationDConfName, kAnimationResortEnable, true).toBool();
-    // TODO(liuyangming): only one screen can play sort animation now.
-    if (animEnable && q->views().count() == 1) {
-        if (auto view = q->views().first()) {
-            view->filesResorted();
+    if (animEnable && !q->views().isEmpty()) {
+        QStringList existItems;
+        const QList<QUrl> &actualList = canvasModel->files();
+        for (const QUrl &df : actualList)
+            existItems.append(df.toString());
+
+        if (SortAnimationOper::instance()->tryMove(existItems))
             return;
-        }
     }
 
     auto oldMode = GridIns->mode();

--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
@@ -584,7 +584,12 @@ void CanvasView::filesResorted()
     if (!d->sortAnimOper)
         return;
 
-    d->sortAnimOper->tryMove();
+    QStringList existItems;
+    const QList<QUrl> &actualList = model()->files();
+    for (const QUrl &df : actualList)
+        existItems.append(df.toString());
+
+    d->sortAnimOper->tryMove(existItems);
 }
 
 void CanvasView::refresh(bool silent)
@@ -831,7 +836,7 @@ CanvasViewPrivate::CanvasViewPrivate(CanvasView *qq)
 
     dragDropOper = new DragDropOper(q);
     dodgeOper = new DodgeOper(q);
-    sortAnimOper = new SortAnimationOper(q);
+    sortAnimOper = SortAnimationOper::instance();
     shortcutOper = new ShortcutOper(q);
     menuProxy = new CanvasViewMenuProxy(q);
     viewSetting = new ViewSettingUtil(q);

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/sortanimationoper.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/sortanimationoper.cpp
@@ -5,7 +5,6 @@
 #include "sortanimationoper.h"
 #include "canvasmanager.h"
 #include "grid/canvasgrid.h"
-#include "model/canvasproxymodel.h"
 
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
@@ -14,8 +13,18 @@ using namespace ddplugin_canvas;
 using namespace GlobalDConfDefines::ConfigPath;
 using namespace GlobalDConfDefines::AnimationConfig;
 
-SortAnimationOper::SortAnimationOper(CanvasView *parent)
-    : QObject(parent), view(parent)
+class SortAnimationOperGlobal : public SortAnimationOper
+{
+};
+Q_GLOBAL_STATIC(SortAnimationOperGlobal, sortAnimationOperGlobal)
+
+SortAnimationOper *SortAnimationOper::instance()
+{
+    return sortAnimationOperGlobal;
+}
+
+SortAnimationOper::SortAnimationOper(QObject *parent)
+    : QObject(parent)
 {
     moveDelayTimer.setInterval(100);
     moveDelayTimer.setSingleShot(true);
@@ -25,12 +34,24 @@ SortAnimationOper::SortAnimationOper(CanvasView *parent)
 
 void SortAnimationOper::setMoveValue(const QStringList &moveItems)
 {
+    if (moveAnimationing)
+        return;
+
     if (moveItems.isEmpty()) {
         fmDebug() << "Empty move items list - ignoring";
         return;
     }
 
     this->moveItems = moveItems;
+    originPos.clear();
+    itemsPixmap.clear();
+    prepareMove = false;
+
+    for (const QString &item : moveItems) {
+        GridPos pos;
+        if (GridIns->point(item, pos))
+            originPos.insert(item, pos);
+    }
 }
 
 void SortAnimationOper::setItemPixmap(const QString &item, const QPixmap &pix)
@@ -46,21 +67,26 @@ QPixmap SortAnimationOper::findPixmap(const QString &item) const
     return itemsPixmap.contains(item) ? itemsPixmap.value(item) : QPixmap();
 }
 
-void SortAnimationOper::tryMove()
+bool SortAnimationOper::tryMove(const QStringList &existItems)
 {
     if (moveAnimationing) {
         fmDebug() << "Move animation already in progress - ignoring";
-        return;
+        return false;
     }
 
-    QPair<int, QPoint> originPos;
-    if (moveItems.isEmpty() || !GridIns->point(moveItems.first(), originPos)) {
+    if (moveItems.isEmpty() || originPos.isEmpty()) {
         fmDebug() << "No move items or invalid origin position";
-        return;
+        return false;
     }
 
-    if (originPos.first == view->screenNum())
-        startDelayMove();
+    if (!calcMoveTargetGrid(existItems)) {
+        fmDebug() << "No moved items after sorting";
+        return false;
+    }
+
+    prepareMove = true;
+    startDelayMove();
+    return true;
 }
 
 bool SortAnimationOper::getMoveItemGridPos(const QString &item, GridPos &gridPos)
@@ -69,6 +95,15 @@ bool SortAnimationOper::getMoveItemGridPos(const QString &item, GridPos &gridPos
         return false;
 
     return oper->position(item, gridPos);
+}
+
+bool SortAnimationOper::getOriginItemGridPos(const QString &item, GridPos &gridPos) const
+{
+    if (!originPos.contains(item))
+        return false;
+
+    gridPos = originPos.value(item);
+    return true;
 }
 
 void SortAnimationOper::setMoveDuration(double duration)
@@ -92,9 +127,7 @@ void SortAnimationOper::stopDelayMove()
 void SortAnimationOper::startMoveAnimation()
 {
     moveAnimationing = true;
-
-    calcMoveTargetGrid();
-    itemsPixmap.clear();
+    prepareMove = false;
 
     if (animation.get())
         animation->disconnect();
@@ -147,17 +180,28 @@ void SortAnimationOper::moveAnimationFinished()
 
     GridIns->core().applay(oper.get());
     GridIns->requestSync();
+    itemsPixmap.clear();
+    originPos.clear();
+    moveItems.clear();
 }
 
-void SortAnimationOper::calcMoveTargetGrid()
+bool SortAnimationOper::calcMoveTargetGrid(const QStringList &existItems)
 {
-    QStringList existItems;
-    const QList<QUrl> &actualList = view->model()->files();
-    for (const QUrl &df : actualList)
-        existItems.append(df.toString());
-
     oper.reset(new SortItemsOper(&GridIns->core()));
-    oper->tryMove(moveItems, existItems);
+    QStringList targetItems = existItems;
+    oper->tryMove(moveItems, targetItems);
+
+    for (const QString &item : moveItems) {
+        GridPos from;
+        GridPos to;
+        if (!getOriginItemGridPos(item, from) || !oper->position(item, to))
+            continue;
+        if (from != to)
+            return true;
+    }
+
+    oper.reset();
+    return false;
 }
 
 SortItemsOper::SortItemsOper(GridCore *core)

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/sortanimationoper.h
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/sortanimationoper.h
@@ -34,12 +34,13 @@ class SortAnimationOper : public QObject
 
     Q_PROPERTY(double moveDuration READ getMoveDuration WRITE setMoveDuration NOTIFY moveDurationChanged)
 public:
-    explicit SortAnimationOper(CanvasView *parent);
+    static SortAnimationOper *instance();
+    explicit SortAnimationOper(QObject *parent = nullptr);
 
     void setMoveValue(const QStringList &moveItems);
     void setItemPixmap(const QString &item, const QPixmap &pix);
     QPixmap findPixmap(const QString &item) const;
-    void tryMove();
+    bool tryMove(const QStringList &existItems);
 
     inline bool getPrepareMove() const { return prepareMove; }
     inline bool getMoveAnimationing() const { return moveAnimationing; }
@@ -47,6 +48,7 @@ public:
     inline double getMoveDuration() const { return moveDuration; }
 
     bool getMoveItemGridPos(const QString &item, GridPos &gridPos);
+    bool getOriginItemGridPos(const QString &item, GridPos &gridPos) const;
     void setMoveDuration(double duration);
     void startDelayMove();
     void stopDelayMove();
@@ -60,10 +62,9 @@ private slots:
     void moveAnimationFinished();
 
 private:
-    void calcMoveTargetGrid();
+    bool calcMoveTargetGrid(const QStringList &existItems);
 
 private:
-    CanvasView *view = nullptr;
     QSharedPointer<SortItemsOper> oper;
 
     QTimer moveDelayTimer;
@@ -72,6 +73,7 @@ private:
     QAtomicInteger<bool> moveAnimationing = false;
     double moveDuration = 0.0;
     QStringList moveItems;
+    QHash<QString, GridPos> originPos;
     QMap<QString, QPixmap> itemsPixmap;
 };
 

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/viewpainter.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/viewpainter.cpp
@@ -12,6 +12,33 @@
 
 using namespace ddplugin_canvas;
 
+static QRect mappedAnimationRect(CanvasViewPrivate *viewData, const GridPos &gridPos)
+{
+    if (!viewData || !viewData->q)
+        return QRect();
+
+    auto *view = viewData->q;
+    auto *d = viewData;
+    if (gridPos.first == view->screenNum())
+        return d->visualRect(gridPos.second).marginsRemoved(d->gridMargins);
+
+    const QSize sourceSize = GridIns->surfaceSize(gridPos.first);
+    const QSize targetSize = GridIns->surfaceSize(view->screenNum());
+    if (!sourceSize.isValid() || !targetSize.isValid())
+        return QRect();
+
+    const int srcWidth = qMax(1, sourceSize.width() - 1);
+    const int srcHeight = qMax(1, sourceSize.height() - 1);
+    const int dstWidth = qMax(1, targetSize.width() - 1);
+    const int dstHeight = qMax(1, targetSize.height() - 1);
+
+    const qreal xRatio = srcWidth > 0 ? static_cast<qreal>(gridPos.second.x()) / srcWidth : 0.0;
+    const qreal yRatio = srcHeight > 0 ? static_cast<qreal>(gridPos.second.y()) / srcHeight : 0.0;
+    const QPoint mappedPos(qBound(0, qRound(xRatio * dstWidth), dstWidth),
+                           qBound(0, qRound(yRatio * dstHeight), dstHeight));
+    return d->visualRect(mappedPos).marginsRemoved(d->gridMargins);
+}
+
 ViewPainter::ViewPainter(CanvasViewPrivate *dd)
     : QPainter(dd->q->viewport()), d(dd)
 {
@@ -243,19 +270,25 @@ void ViewPainter::drawMove(QStyleOptionViewItem option)
             if (!index.isValid())
                 continue;
 
-            GridPos gridPos;
-            if (!d->sortAnimOper->getMoveItemGridPos(animationItem, gridPos))
+            GridPos fromPos;
+            GridPos toPos;
+            if (!d->sortAnimOper->getOriginItemGridPos(animationItem, fromPos)
+                || !d->sortAnimOper->getMoveItemGridPos(animationItem, toPos))
                 continue;
 
-            if (gridPos.first != view()->screenNum())
+            if (fromPos.first != view()->screenNum() && toPos.first != view()->screenNum())
                 continue;
 
-            QRect end = view()->d->visualRect(gridPos.second).marginsRemoved(margins);
+            QRect start = mappedAnimationRect(d, fromPos);
+            QRect end = mappedAnimationRect(d, toPos);
+            if (!start.isValid() || !end.isValid())
+                continue;
+
             auto tempCurrent = d->sortAnimOper->getMoveDuration();
-            option.rect = view()->visualRect(index).marginsRemoved(margins);
+            option.rect = start;
 
-            auto nx = option.rect.x() + (end.x() - option.rect.x()) * tempCurrent;
-            auto ny = option.rect.y() + (end.y() - option.rect.y()) * tempCurrent;
+            auto nx = start.x() + (end.x() - start.x()) * tempCurrent;
+            auto ny = start.y() + (end.y() - start.y()) * tempCurrent;
             option.rect.setX(static_cast<int>(nx));
             option.rect.setY(static_cast<int>(ny));
             option.rect.setSize(end.size());

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/viewgeometryhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/viewgeometryhelper.cpp
@@ -57,6 +57,14 @@ ViewGeometryHelper::RangeIndexList ViewGeometryHelper::visibleIndexes(const QRec
         QModelIndex firstIdx = m_view->indexAtForSelection(viewportRect.topLeft());
         QModelIndex lastIdx = m_view->indexAtForSelection(viewportRect.bottomRight());
 
+        // Non-grouped list/tree: if both corners fall in the first-row top
+        // padding, the rect is entirely within the gap — no items selected.
+        if (!m_view->isGroupedView()
+                && m_view->isClickInTopPadding(viewportRect.topLeft(), firstIdx)
+                && m_view->isClickInTopPadding(viewportRect.bottomRight(), lastIdx)) {
+            return list;
+        }
+
         if (!firstIdx.isValid()) {
             if (viewportRect.top() < 0) {
                 firstIdx = m_view->model()->index(0, 0, m_view->rootIndex());
@@ -112,6 +120,14 @@ ViewGeometryHelper::RangeIndexList ViewGeometryHelper::rectContainsIndexes(const
         // Use indexAtForSelection to get items at corners (doesn't skip spacing areas)
         QModelIndex firstIndex = m_view->indexAtForSelection(viewportRect.topLeft());
         QModelIndex lastIndex = m_view->indexAtForSelection(viewportRect.bottomRight());
+
+        // Non-grouped list/tree: if both corners fall in the first-row top
+        // padding, the rect is entirely within the gap — no items selected.
+        if (!m_view->isGroupedView()
+                && m_view->isClickInTopPadding(viewportRect.topLeft(), firstIndex)
+                && m_view->isClickInTopPadding(viewportRect.bottomRight(), lastIndex)) {
+            return list;
+        }
 
         // Handle invalid indices by clamping to valid range
         if (!firstIndex.isValid()) {


### PR DESCRIPTION
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **fix(workspace): improve group header expand button hit area**
- **fix: adjust notification titles for search experience**
- **chore: update translations**
- **feat: adjust icon spacing on grouping state change**
- **fix: restore desktop context menu on non-primary screens in treeland extend mode**
- **fix: improve search auto-grouping behavior**
- **fix(search): use birth time for create-time filtering**
- **fix: optimize disc device scanning logic**
- **ci(cppcheck): bump actions/checkout to v7 and enable unsafe pr checkout**
- **i18n: Translate dde-file-manager.ts in fi**
- **i18n: Translate dde-file-manager.ts in fi**
- **fix(search): sync smart search checkbox on restore default**
- **fix: handle Ctrl+Left/Right key events properly**
- **fix(titlebar): stabilize virtual keyboard display**
- **fix(sidebar): avoid stale drop targets during external drags**
- **fix(burn): show error details in erase failure dialog**
- **i18n: Translate dde-file-manager.ts in pl**
- **fix(propertydialog): use D-Bus SystemInfo for installed memory size**
- **refactor: switch from netlink to socket for deepin-anything events**
- **fix: improve mount point resolution in filesystem watcher**
- **chore: bump version to 6.6.1**
- **feat: add USB repair service with D-Bus interface and PolKit authentication**
- **feat: add configurable search and exec run**
- **feat: integrate file close events into vfs monitor mode**
- **docs: add TagManager DBus interface guide**
- **test: add stress tests for VFS monitor file system watcher**
- **fix: correct icon layout after maximizing window following touch long-press**
- **feat(usbrepair): add USB device repair dialog with error code, simulated progress and device ignore support**
- **chore(translations): add USB repair dialog translations**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **i18n: Translate dde-file-manager.ts in pt_BR**
- **feat: add configurable device polling and network check**
- **fix: persist list view column hidden state per URL**
- **fix(sidebar): refine drag reorder feedback**
- **fix: ensure sidebar drag-drop consistency between visual and actual position**
- **fix: batch-process recent items on startup to avoid UI freeze**
- **i18n: Translate dde-file-manager.ts in ca**
- **i18n: Translate dde-file-manager.ts in ca**
- **i18n: Translate dde-file-manager.ts in ca**
- **i18n: Translate dde-file-manager.ts in ca**
- **feat: add last read time support for recent items**
- **fix: ship dfm-reencrypt.desktop via package instead of runtime creation**
- **fix: animate sidebar collapse/expand on window resize**
- **fix: remove GIF from wallpaper supported types in file context menu**
- **fix(image-preview): fix italic font and color issue in status bar**
- **feat: make vault context menu actions configurable via DConfig**
- **fix(preview): reduce arrow icon size to match play/pause icons**
- **feat: add configurable default burn filesystem type**
- **feat: add built-in icons for search indexing status**
- **feat(desktop): migrate wallpaper fill style from v20 to v25**
- **fix(music-preview): adapt play icons for dark theme**
- **chore: reorganize autotests directory structure**
- **docs: refactor index state store constants and add documentation**
- **feat: track index creation progress to prevent duplicate builds**
- **feat(sidebar): migrate partition expand/collapse feature from v20**
- **fix(sidebar): guard use-after-free in mount subscription callback**
- **test: add AT-SPI test suite for dde-file-manager (30 passing cases)**
- **Revert "fix: keep desktop canvas origin for top and left dock"**
- **chore: bump version to 6.6.2**
- **fix(openwith): adjust dialog button gap**
- **fix(openwith): adapt hover color for dark mode**
- **fix: show broken-link dialog for deleted SMB share target**
- **fix(textindex): add auto-reconnect and enlarge SO_RCVBUF for vfsmonitor**
- **i18n: Translate dde-file-manager.ts in pl**
- **i18n: Translate dde-file-manager.ts in pl**
- **i18n: Translate dde-file-manager.ts in pl**
- **i18n: Translate dde-file-manager.ts in pl**
- **i18n: Translate dde-file-manager.ts in pl**
- **feat: add environment detection for strategic indexing**
- **test(dde-file-manager): add dfm-base unit tests (batch 1)**
- **test(dde-file-manager): add dfm-base unit tests (batch 2)**
- **test(dde-file-manager): add dfm-base unit tests (batch 3)**
- **test(dde-file-manager): add dfm-base unit tests (batch 4)**
- **test(dde-file-manager): add textindex service unit tests (batch 5)**
- **test(dde-file-manager): add more tests, reach 50% function coverage (batch 6)**
- **fix(openwith): increase bottom action gap**
- **fix: use decode-validation-first strategy for text preview encoding**
- **test(dde-file-manager): add entryfileinfo/thumbnail/indextask tests (round 7)**
- **fix: correct polkit prompt for partition passphrase change**
- **test(autotests): add dfm-base unit tests, function coverage 53.2% -> 55.8% (+87)**
- **fix(sidebar): include foreground color in icon cache key**
- **Fix(disk-encrypt): Enhance security.**
- **test(autotests): add dfm-base unit tests round 2, function coverage 55.8% -> 59.2% (cumulative +200)**
- **fix: avoid parenting delete dialog to WA_DeleteOnClose popup**
- **test(autotests): round 3 coverage push, 59.2% -> 60.7% (cumulative +251 vs original)**
- **fix: fix special chars in tag editor clearing existing tags**
- **test(autotests): round 4 - strengthen assertions + new test files, 60.7% -> 61.9% (cumulative +290)**
- **test(autotests): round 5 coverage push, 61.9% -> 65.2% (cumulative +401 vs original)**
- **test(autotests): round 6 coverage push, 65.2% -> 66.7% (cumulative +450 vs original)**
- **test(autotests): rounds 7-10 coverage push, 66.7% -> 68.1% (cumulative +498 vs original)**
- **test(autotests): rounds 11-12 coverage push, 68.1% -> 69.6% (cumulative +549 vs original)**
- **test(autotests): rounds 13-18 coverage push, 69.6% -> 71.0% (cumulative +595 vs original)**
- **fix(shred): cache file info in model to avoid blank rows**
- **chore: standardize unit test naming conventions**
- **fix(disk-mount): avoid blurry popup theme icons**
- **test(autotests): rounds 19-20 coverage push, 71.0% -> 74.8% (cumulative +642 vs original)**
- **test(autotests): consolidate split test files and normalize naming**
- **fix(workspace): make list/tree top gap part of viewport content for rubber-band**
- **fix: handle top padding selection in non-grouped views**
- **feat: enhance multi-screen support for sort animation**

## Summary by Sourcery

Enhance desktop sort animation to support multi-screen setups and improve selection behavior in non-grouped list/tree views.

New Features:
- Introduce a global sort animation operator instance usable across multiple canvas views.
- Support cross-screen mapping of sort animation positions so items can animate when moving between displays.

Bug Fixes:
- Prevent sort animations from starting with empty or invalid move sets and avoid redundant animations when items do not change position.
- Ensure desktop sort animations run correctly when multiple views are present instead of limiting to a single screen.
- Fix rubber-band and rectangle selection in non-grouped list/tree views so dragging entirely in the top padding gap no longer selects items.

Enhancements:
- Refine sort animation lifecycle by resetting cached pixmaps and positions after completion and centralizing move preparation based on current file lists.