### PR TITLE
refactor: move version definitions to cmake configuration

### DIFF
--- a/include/dfm-extension/dfm-extension-global.h.in
+++ b/include/dfm-extension/dfm-extension-global.h.in
@@ -22,9 +22,9 @@
     Class(const Class &) = delete; \
     Class &operator=(const Class &) = delete;
 
-#define DFMEXT_VERSION_MAJOR 6
-#define DFMEXT_VERSION_MINOR 0
-#define DFMEXT_VERSION_PATCH 0
+#define DFMEXT_VERSION_MAJOR @DFMEXT_VERSION_MAJOR@
+#define DFMEXT_VERSION_MINOR @DFMEXT_VERSION_MINOR@
+#define DFMEXT_VERSION_PATCH @DFMEXT_VERSION_PATCH@
 
 /*
    DFMEXT_VERSION is (major << 16) + (minor << 8) + patch.

--- a/src/dfm-extension/CMakeLists.txt
+++ b/src/dfm-extension/CMakeLists.txt
@@ -7,20 +7,7 @@ set(CMAKE_AUTOUIC OFF)
 set (VERSION "1.0.0" CACHE STRING "define project version")
 
 set(BIN_NAME dfm-extension)
-
-file(GLOB_RECURSE INCLUDE_FILES CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/include/${BIN_NAME}/*")
-file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS
-    "./*.h"
-    "./*.cpp"
-)
-
-add_library(${BIN_NAME} SHARED
-    ${INCLUDE_FILES}
-    ${SRCS}
-)
-
-# Configure library using unified configuration function
-dfm_configure_extension_library(${BIN_NAME})
+set(DFMEXT_GENERATED_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
 
 if (NOT VERSION)
     set(VERSION "1.0.0")
@@ -29,6 +16,39 @@ endif()
 if (NOT PROJECT_VERSION_MAJOR)
     set(PROJECT_VERSION_MAJOR 1)
 endif()
+
+string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" DFMEXT_VERSION_MATCH "${VERSION}")
+if (NOT DFMEXT_VERSION_MATCH)
+    message(FATAL_ERROR "dfm-extension VERSION must start with <major>.<minor>.<patch>, got: ${VERSION}")
+endif()
+
+set(DFMEXT_VERSION_MAJOR "${CMAKE_MATCH_1}")
+set(DFMEXT_VERSION_MINOR "${CMAKE_MATCH_2}")
+set(DFMEXT_VERSION_PATCH "${CMAKE_MATCH_3}")
+
+configure_file(
+    ${PROJECT_SOURCE_DIR}/include/${BIN_NAME}/dfm-extension-global.h.in
+    ${DFMEXT_GENERATED_INCLUDE_DIR}/${BIN_NAME}/dfm-extension-global.h
+    @ONLY
+)
+
+file(GLOB_RECURSE INCLUDE_FILES CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/include/${BIN_NAME}/*.h")
+file(GLOB_RECURSE SRCS CONFIGURE_DEPENDS
+    "./*.h"
+    "./*.cpp"
+)
+
+add_library(${BIN_NAME} SHARED
+    ${INCLUDE_FILES}
+    ${SRCS}
+    ${DFMEXT_GENERATED_INCLUDE_DIR}/${BIN_NAME}/dfm-extension-global.h
+)
+
+# Configure library using unified configuration function
+dfm_configure_extension_library(${BIN_NAME})
+target_include_directories(${BIN_NAME} BEFORE PUBLIC
+    ${DFMEXT_GENERATED_INCLUDE_DIR}
+)
 
 set_target_properties(${BIN_NAME} PROPERTIES
     VERSION ${VERSION}
@@ -46,6 +66,10 @@ install(DIRECTORY
     DESTINATION include
     FILES_MATCHING PATTERN "*.h"
 )
+install(
+    FILES ${DFMEXT_GENERATED_INCLUDE_DIR}/${BIN_NAME}/dfm-extension-global.h
+    DESTINATION include/${BIN_NAME}
+)
 
 # config pkgconfig file
 configure_file(${PROJECT_SOURCE_DIR}/assets/dev/${BIN_NAME}/${BIN_NAME}.pc.in ${BIN_NAME}.pc @ONLY)
@@ -54,4 +78,3 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}.pc DESTINATION ${CMAKE_INS
 # config cmake file
 configure_file(${PROJECT_SOURCE_DIR}/assets/dev/${BIN_NAME}/${BIN_NAME}Config.cmake.in ${BIN_NAME}Config.cmake @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}Config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${BIN_NAME})
-


### PR DESCRIPTION
1. Changed dfm-extension-global.h to template file (dfm-extension-
global.h.in)
2. Removed hardcoded version numbers (6.0.0) and replaced with CMake
variables
3. Added version number validation and parsing in CMakeLists.txt
4. Generated header file is now placed in build directory and installed
properly
5. Added include directory for generated headers in build system
6. Simplified version management through single VERSION variable in
CMake

The changes allow for centralized version management through CMake
configuration, making it easier to maintain and update version numbers.
This is particularly important for release builds where version numbers
need to be synchronized across different components.

Influence:
1. Verify build system correctly generates version header
2. Check compiled library reports correct version
3. Test installation process includes generated headers
4. Ensure backward compatibility with existing builds

refactor: 将版本定义移至 CMake 配置

1. 将 dfm-extension-global.h 改为模板文件 (dfm-extension-global.h.in)
2. 移除硬编码版本号(6.0.0)并使用 CMake 变量替代
3. 在 CMakeLists.txt 中添加版本号验证和解析
4. 生成的头文件现在被正确放置在构建目录并正确安装
5. 在构建系统中为生成的头文件添加包含目录
6. 通过 CMake 中的单一 VERSION 变量简化版本管理

这些更改允许通过 CMake 配置集中管理版本，使得维护和更新版本号更加容易。
这对于需要在不同组件间同步版本号的发布版本尤为重要。

Influence:
1. 验证构建系统正确生成版本头文件
2. 检查编译库报告的正确版本
3. 测试安装过程是否包含生成的头文件
4. 确保向后兼容现有的构建

## Summary by Sourcery

Centralize dfm-extension version definition in CMake and generate a versioned header at build time.

Enhancements:
- Parse and validate the VERSION string in CMake to derive major, minor, and patch components for dfm-extension.
- Generate dfm-extension-global.h from a template using CMake-configured version values and include it in the library build.
- Add the build directory for generated headers to the public include paths and install the generated version header alongside other public headers.

Build:
- Ensure dfm-extension version information is driven by a single VERSION variable in CMake instead of hardcoded macros in the header.