### PR TITLE
fix(preview): avoid UI freeze on rapid preview switching

### DIFF
--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.cpp
@@ -61,8 +61,9 @@ UnknowFilePreview::UnknowFilePreview(QObject *parent)
     hlayout->addLayout(vlayout);
     hlayout->addStretch();
 
-    fileCalculationUtils = new FileScanner(this);
-    connect(fileCalculationUtils, &FileScanner::progressChanged, this, &UnknowFilePreview::updateFolderSizeCount);
+    // FileScanner is created on demand per directory preview (see setFileInfo) and
+    // retired asynchronously on switch/destroy (see discardCurrentScanner), so the
+    // UI thread never blocks on a running scan thread via QThread::wait().
 
     qCDebug(logLibFilePreview) << "UnknowFilePreview: initialization completed";
 }
@@ -75,9 +76,10 @@ UnknowFilePreview::~UnknowFilePreview()
         contentView->deleteLater();
     }
 
-    if (fileCalculationUtils) {
-        fileCalculationUtils->deleteLater();
-    }
+    // Retire any running scanner asynchronously instead of deleteLater() here:
+    // ~FileScanner waits for its worker thread, which would block the UI thread
+    // when previewing large directory trees is still in progress.
+    discardCurrentScanner();
 }
 
 bool UnknowFilePreview::setFileUrl(const QUrl &url)
@@ -116,9 +118,10 @@ void UnknowFilePreview::setFileInfo(const FileInfoPointer &info)
 
     qCDebug(logLibFilePreview) << "UnknowFilePreview: setting file info for:" << info->nameOf(NameInfoType::kFileName);
 
-    if (fileCalculationUtils) {
-        fileCalculationUtils->stop();
-    }
+    // Retire any in-flight scan before refreshing the view. discardCurrentScanner()
+    // never waits on the worker thread, so switching between large directories
+    // cannot freeze the UI (cf. BasicStatusBar's retire/generation handling).
+    discardCurrentScanner();
 
     QIcon icon;
     ThumbnailHelper helper;
@@ -154,10 +157,42 @@ void UnknowFilePreview::setFileInfo(const FileInfoPointer &info)
         typeLabel->setText(QObject::tr("Type: %1").arg(typeText));
 
         qCDebug(logLibFilePreview) << "UnknowFilePreview: file info set - size:" << sizeText << "type:" << typeText;
-    } else if (fileCalculationUtils && info->isAttributes(OptInfoType::kIsDir)) {
+    } else if (info->isAttributes(OptInfoType::kIsDir)) {
         qCInfo(logLibFilePreview) << "UnknowFilePreview: starting directory size calculation for:" << info->urlOf(UrlInfoType::kUrl).toString();
-        fileCalculationUtils->start(QList<QUrl>() << info->urlOf(UrlInfoType::kUrl));
+        // Create a fresh scanner per directory and guard progress callbacks with a
+        // generation token so results from a retired (previous) scanner are ignored.
+        auto *scanner = new FileScanner();
+        fileCalculationUtils = scanner;
+        const auto generation = ++scanGeneration;
+        connect(scanner, &FileScanner::progressChanged, this, [this, generation](const FileScanner::ScanResult &result) {
+            if (generation != scanGeneration || !fileCalculationUtils)
+                return;
+            updateFolderSizeCount(result);
+        });
+        scanner->start(QList<QUrl>() << info->urlOf(UrlInfoType::kUrl));
         sizeLabel->setText(QObject::tr("Size: 0"));
+    }
+}
+
+void UnknowFilePreview::discardCurrentScanner()
+{
+    if (!fileCalculationUtils)
+        return;
+
+    auto *oldScanner = fileCalculationUtils.data();
+    fileCalculationUtils = nullptr;
+
+    // Detach from this preview so the scanner is not destroyed synchronously when
+    // the preview is torn down (which would block the UI thread in ~FileScanner).
+    oldScanner->setParent(nullptr);
+
+    if (oldScanner->isRunning()) {
+        // Let the worker finish on its own, then self-delete from its finished
+        // signal; never call deleteLater() while the thread is still running.
+        connect(oldScanner, &FileScanner::finished, oldScanner, &QObject::deleteLater);
+        oldScanner->stop();
+    } else {
+        oldScanner->deleteLater();
     }
 }
 

--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.h
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.h
@@ -28,6 +28,7 @@ public:
 
 private:
     void setFileInfo(const FileInfoPointer &info);
+    void discardCurrentScanner();
 
 signals:
     void requestStartFolderSize();
@@ -42,7 +43,8 @@ private:
     QLabel *nameLabel { nullptr };
     QLabel *sizeLabel { nullptr };
     QLabel *typeLabel { nullptr };
-    DFMBASE_NAMESPACE::FileScanner *fileCalculationUtils { nullptr };
+    QPointer<DFMBASE_NAMESPACE::FileScanner> fileCalculationUtils;
+    quint64 scanGeneration { 0 };
 };
 }
 #endif   // UNKNOWFILEPREVIEW_H


### PR DESCRIPTION
## 根因分析

预览快速切换卡死：`UnknowFilePreview` 复用单个 `FileScanner`，每次切换目录对其 `start()`，而 `FileScannerPrivate::startWorker`（`src/dfm-base/utils/filescanner.cpp:179`）检测到工作线程仍运行时在**主线程**执行 `workerThread.wait()` 同步等待，遍历大目录树时线程退出耗时，UI 被阻塞。析构 `deleteLater()` 走 `~FileScanner` 的 `wait()` 是第二条同源阻塞路径。与 `BasicStatusBar` 已处理的同类 `FileScanner` 问题一致。

## 修复方案

在 `UnknowFilePreview` 中参照 `BasicStatusBar` 的"退役(retire)+代际(generation)"模式重构 `FileScanner` 用法，不在主线程对运行中的 scanner 调用 `start()`/`deleteLater()`：

- 成员 `FileScanner *` 改为 `QPointer<FileScanner>`，新增 `quint64 scanGeneration`；
- 新增 `discardCurrentScanner()`：`setParent(nullptr)` 脱离父对象 → 若 `isRunning()` 则连接 `finished→deleteLater` 异步退役、`stop()` 不等待；否则直接 `deleteLater()`；
- 构造不再预建 `FileScanner`，按需（预览目录时）新建；
- `setFileInfo` 先 `discardCurrentScanner()`，目录分支新建 scanner 并以代际守卫的 lambda 连接 `progressChanged`（过期代际回调直接 return）；
- 析构改为 `discardCurrentScanner()`（异步退役，不触发 `~FileScanner` 的 `wait`）。

改动仅限 `src/apps/dde-file-manager-preview/libdfm-preview/views/unknowfilepreview.{h,cpp}`，不动 `dfm-base` 公共 `FileScanner`。

## 改动安全评估

低风险。不修改任何公开函数签名（`setFileUrl`/`fileUrl`/`contentWidget`/构造/析构均保持 override 不变），`AbstractBasePreview` 接口契约不变。两处调用者（`filepreviewdialog.cpp:402/409`）仅通过不变的 `setFileUrl` 接口访问。可观察行为（进度/结果展示）与原一致，仅消除 UI 线程阻塞。

## 验证

本地编译验证通过：`cmake` 配置 + `cmake --build . --target dfm-preview`，`[100%] Built target dfm-preview`，`libdfm-preview.so` 链接成功，改动文件 `unknowfilepreview.cpp` 无新增告警/错误。

## Summary by Sourcery

Prevent UI freezes in the unknown file preview when rapidly switching between directory previews by changing how directory size scans are managed.

Bug Fixes:
- Eliminate UI thread blocking caused by synchronously waiting on running FileScanner threads during preview teardown or directory switches.

Enhancements:
- Create FileScanner instances on demand per directory preview and retire them asynchronously via a dedicated discardCurrentScanner helper using generation-based guarding of progress callbacks.