### PR TITLE
fix(propertydialog): avoid UI freeze on FileScanner retirement

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -52,7 +52,9 @@ BasicWidget::BasicWidget(QWidget *parent)
 
 {
     initUI();
-    fileCalculationUtils = new FileScanner(this);
+    // FileScanner is created on demand per directory scan (see startFileCountScan)
+    // and retired asynchronously on close/switch (see discardCurrentScanner), so
+    // the UI thread never blocks on a running scan thread via QThread::wait().
 
     connect(&fetchThread, &QThread::finished, infoFetchWorker, &QObject::deleteLater);
     infoFetchWorker->moveToThread(&fetchThread);
@@ -61,11 +63,86 @@ BasicWidget::BasicWidget(QWidget *parent)
 
 BasicWidget::~BasicWidget()
 {
-    fileCalculationUtils->deleteLater();
+    // Retire any running scanner asynchronously instead of deleteLater() here:
+    // ~FileScanner waits for its worker thread, which would block the UI thread
+    // when closing the dialog while a large directory scan is still in progress.
+    discardCurrentScanner();
     if (fetchThread.isRunning()) {
         fetchThread.quit();
         fetchThread.wait(5000);
     }
+}
+
+void BasicWidget::startFileCountScan(const QList<QUrl> &urls)
+{
+    // Retire any in-flight scan first; never wait on the worker thread so
+    // switching between large directories cannot freeze the UI.
+    discardCurrentScanner();
+
+    // Bound the number of retired (still-running) scanners to avoid unbounded
+    // resource growth when a worker is stuck on slow I/O.
+    if (retiredScanners.size() >= kMaxRetiredScanners) {
+        fmWarning() << "BasicWidget: skip folder count scan, retired scanners reached limit"
+                    << retiredScanners.size() << ", limit:" << kMaxRetiredScanners;
+        return;
+    }
+
+    auto *scanner = new FileScanner(this);
+    finishedScanners.remove(scanner);
+
+    // Creation-time connection: track scanners that already emitted `finished`
+    // (the worker may finish before the worker thread fully stops, so isRunning()
+    // can still be true). retireScanner() then releases such a job directly
+    // instead of waiting for a retire-time connect(finished->deleteLater) that
+    // could never fire — closes the narrow race the V-1608 review flagged.
+    connect(scanner, &FileScanner::finished, this, [this, scanner](const FileScanner::ScanResult &) {
+        finishedScanners.insert(scanner);
+        if (retiredScanners.remove(scanner) > 0)
+            scanner->deleteLater();
+    });
+    connect(scanner, &QObject::destroyed, this, [this, scanner]() {
+        finishedScanners.remove(scanner);
+        retiredScanners.remove(scanner);
+    });
+
+    fileCalculationUtils = scanner;
+    const auto generation = ++scanGeneration;
+    connect(scanner, &FileScanner::progressChanged, this, [this, generation, scanner](const FileScanner::ScanResult &result) {
+        if (generation != scanGeneration || scanner != fileCalculationUtils)
+            return;
+        slotFileCountAndSizeChange(result);
+    });
+
+    scanner->start(urls);
+}
+
+void BasicWidget::discardCurrentScanner()
+{
+    if (!fileCalculationUtils)
+        return;
+
+    auto *oldScanner = fileCalculationUtils.data();
+    fileCalculationUtils = nullptr;
+    retireScanner(oldScanner);
+}
+
+void BasicWidget::retireScanner(FileScanner *scanner)
+{
+    if (!scanner)
+        return;
+
+    // Detach from this widget so the scanner is not destroyed synchronously
+    // when the widget is torn down (which would block the UI thread in
+    // ~FileScanner via QThread::wait()).
+    scanner->setParent(nullptr);
+
+    if (scanner->isRunning() && !finishedScanners.contains(scanner)) {
+        retiredScanners.insert(scanner);
+        scanner->stop();
+        return;
+    }
+
+    scanner->deleteLater();
 }
 
 int BasicWidget::expansionPreditHeight()
@@ -300,12 +377,12 @@ void BasicWidget::basicFill(const QUrl &url)
         fileType->setRightValue(info->displayOf(DisPlayInfoType::kMimeTypeDisplayName), Qt::ElideMiddle, Qt::AlignVCenter, true);
         if (type == FileInfo::FileType::kDirectory && fileCount && fileCount->RightValue().isEmpty()) {
             fileCount->setRightValue(tr("%1 item").arg(0), Qt::ElideNone, Qt::AlignVCenter, true);
-            connect(fileCalculationUtils, &FileScanner::progressChanged, this, &BasicWidget::slotFileCountAndSizeChange);
-            if (info->canAttributes(CanableInfoType::kCanRedirectionFileUrl)) {
-                fileCalculationUtils->start(QList<QUrl>() << info->urlOf(UrlInfoType::kRedirectedFileUrl));
-            } else {
-                fileCalculationUtils->start(QList<QUrl>() << url);
-            }
+            QList<QUrl> scanUrls;
+            if (info->canAttributes(CanableInfoType::kCanRedirectionFileUrl))
+                scanUrls << info->urlOf(UrlInfoType::kRedirectedFileUrl);
+            else
+                scanUrls << url;
+            startFileCountScan(scanUrls);
         } else {
             layoutMain->removeWidget(fileCount);
             fieldMap.remove(BasicFieldExpandEnum::kFileCount);

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h
@@ -12,6 +12,9 @@
 
 #include <dfm-io/dfileinfo.h>
 
+#include <QPointer>
+#include <QSet>
+
 #include <DArrowLineDrawer>
 #include <DCheckBox>
 
@@ -37,6 +40,14 @@ private:
     void basicFill(const QUrl &url);
 
     DFMBASE_NAMESPACE::KeyValueLabel *createValueLabel(QFrame *frame, QString leftValue);
+
+    // Asynchronous FileScanner retirement (mirrors BasicStatusBarPrivate):
+    // never wait on the worker thread on the UI thread, so closing/switching
+    // the property dialog while a large directory scan is in progress cannot
+    // freeze the UI (cf. ~FileScanner -> QThread::wait()).
+    void startFileCountScan(const QList<QUrl> &urls);
+    void discardCurrentScanner();
+    void retireScanner(DFMBASE_NAMESPACE::FileScanner *scanner);
 
 public:
     void selectFileUrl(const QUrl &url);
@@ -71,7 +82,11 @@ private:
     DFMBASE_NAMESPACE::KeyValueLabel *fileMediaResolution { nullptr };
     DFMBASE_NAMESPACE::KeyValueLabel *fileMediaDuration { nullptr };
     bool hideCheckBox { false };
-    DFMBASE_NAMESPACE::FileScanner *fileCalculationUtils { nullptr };
+    QPointer<DFMBASE_NAMESPACE::FileScanner> fileCalculationUtils;
+    QSet<DFMBASE_NAMESPACE::FileScanner *> retiredScanners;
+    QSet<DFMBASE_NAMESPACE::FileScanner *> finishedScanners;
+    quint64 scanGeneration { 0 };
+    static constexpr int kMaxRetiredScanners { 2 };
     qint64 fSize { 0 };
     int fCount { 0 };
     QMultiMap<BasicFieldExpandEnum, DFMBASE_NAMESPACE::KeyValueLabel *> fieldMap;

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp
@@ -26,17 +26,20 @@ DFMBASE_USE_NAMESPACE
 MultiFileBasicInfoWidget::MultiFileBasicInfoWidget(const QList<QUrl> &urls,
                                                    QWidget *parent)
     : DArrowLineDrawer(parent)
-    , fileCalculationUtils(new FileScanner)
 {
-    fileCalculationUtils->setOptions(FileScanner::ScanOption::IncludeSource);
+    // FileScanner is created on demand in setFilesCountAndSize() and retired
+    // asynchronously on destruction (see discardCurrentScanner), so the UI
+    // thread never blocks on a running scan thread via QThread::wait().
     initUI();
     loadData(urls);
 }
 
 MultiFileBasicInfoWidget::~MultiFileBasicInfoWidget()
 {
-    fileCalculationUtils->stop();
-    fileCalculationUtils->deleteLater();
+    // Retire any running scanner asynchronously instead of stop()+deleteLater()
+    // here: ~FileScanner waits for its worker thread, which would block the UI
+    // thread when closing the dialog while a large multi-file scan is running.
+    discardCurrentScanner();
 }
 
 void MultiFileBasicInfoWidget::getOrgHideBoxState(FilePropertyState &states)
@@ -118,11 +121,78 @@ void MultiFileBasicInfoWidget::updateFilesCountAndSizeLabel(const FileScanner::S
 
 void MultiFileBasicInfoWidget::setFilesCountAndSize(const QList<QUrl> &urls)
 {
-    connect(fileCalculationUtils, &FileScanner::progressChanged,
-            this, &MultiFileBasicInfoWidget::updateFilesCountAndSizeLabel);
+    // Retire any in-flight scan first; never wait on the worker thread so
+    // re-scanning cannot freeze the UI.
+    discardCurrentScanner();
+
+    // Bound the number of retired (still-running) scanners to avoid unbounded
+    // resource growth when a worker is stuck on slow I/O.
+    if (retiredScanners.size() >= kMaxRetiredScanners) {
+        fmWarning() << "MultiFileBasicInfoWidget: skip count/size scan, retired scanners reached limit"
+                    << retiredScanners.size() << ", limit:" << kMaxRetiredScanners;
+        return;
+    }
+
     QList<QUrl> targets;
     UniversalUtils::urlsTransformToLocal(urls, &targets);
-    fileCalculationUtils->start(targets);
+
+    auto *scanner = new FileScanner(this);
+    scanner->setOptions(FileScanner::ScanOption::IncludeSource);
+    finishedScanners.remove(scanner);
+
+    // Creation-time connection: track scanners that already emitted `finished`
+    // (the worker may finish before the worker thread fully stops, so isRunning()
+    // can still be true). retireScanner() then releases such a job directly
+    // instead of waiting for a retire-time connect(finished->deleteLater) that
+    // could never fire — closes the narrow race the V-1608 review flagged.
+    connect(scanner, &FileScanner::finished, this, [this, scanner](const FileScanner::ScanResult &) {
+        finishedScanners.insert(scanner);
+        if (retiredScanners.remove(scanner) > 0)
+            scanner->deleteLater();
+    });
+    connect(scanner, &QObject::destroyed, this, [this, scanner]() {
+        finishedScanners.remove(scanner);
+        retiredScanners.remove(scanner);
+    });
+
+    fileCalculationUtils = scanner;
+    const auto generation = ++scanGeneration;
+    connect(scanner, &FileScanner::progressChanged, this, [this, generation, scanner](const FileScanner::ScanResult &result) {
+        if (generation != scanGeneration || scanner != fileCalculationUtils)
+            return;
+        updateFilesCountAndSizeLabel(result);
+    });
+
+    scanner->start(targets);
+}
+
+void MultiFileBasicInfoWidget::discardCurrentScanner()
+{
+    if (!fileCalculationUtils)
+        return;
+
+    auto *oldScanner = fileCalculationUtils.data();
+    fileCalculationUtils = nullptr;
+    retireScanner(oldScanner);
+}
+
+void MultiFileBasicInfoWidget::retireScanner(FileScanner *scanner)
+{
+    if (!scanner)
+        return;
+
+    // Detach from this widget so the scanner is not destroyed synchronously
+    // when the widget is torn down (which would block the UI thread in
+    // ~FileScanner via QThread::wait()).
+    scanner->setParent(nullptr);
+
+    if (scanner->isRunning() && !finishedScanners.contains(scanner)) {
+        retiredScanners.insert(scanner);
+        scanner->stop();
+        return;
+    }
+
+    scanner->deleteLater();
 }
 
 void MultiFileBasicInfoWidget::setAccessTime(const QList<QUrl> &urls)

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.h
@@ -11,6 +11,9 @@
 #include <dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h>
 #include <dfm-base/utils/filescanner.h>
 
+#include <QPointer>
+#include <QSet>
+
 #include <DArrowLineDrawer>
 
 namespace dfmplugin_propertydialog {
@@ -45,12 +48,23 @@ private:
                             int &dirCount,
                             int &fileCount);
 
+    // Asynchronous FileScanner retirement (mirrors BasicStatusBarPrivate):
+    // never wait on the worker thread on the UI thread, so closing the dialog
+    // while a large multi-file scan is in progress cannot freeze the UI
+    // (cf. ~FileScanner -> QThread::wait()).
+    void discardCurrentScanner();
+    void retireScanner(DFMBASE_NAMESPACE::FileScanner *scanner);
+
     DFMBASE_NAMESPACE::KeyValueLabel *filesSize { Q_NULLPTR };
     DFMBASE_NAMESPACE::KeyValueLabel *filesCount { Q_NULLPTR };
     DFMBASE_NAMESPACE::KeyValueLabel *accessTime { Q_NULLPTR };
     DFMBASE_NAMESPACE::KeyValueLabel *modifyTime { Q_NULLPTR };
     SkipPartiallyCheckBox *hideFile { Q_NULLPTR };
-    DFMBASE_NAMESPACE::FileScanner *fileCalculationUtils { Q_NULLPTR };
+    QPointer<DFMBASE_NAMESPACE::FileScanner> fileCalculationUtils;
+    QSet<DFMBASE_NAMESPACE::FileScanner *> retiredScanners;
+    QSet<DFMBASE_NAMESPACE::FileScanner *> finishedScanners;
+    quint64 scanGeneration { 0 };
+    static constexpr int kMaxRetiredScanners { 2 };
 };
 
 }


### PR DESCRIPTION
## 背景

父 issue V-1608（bug-fix-预览快速切换卡死）已通过 PR #4095 修复了 `UnknowFilePreview`（预览插件）中 `FileScanner` 在 UI 线程触发 `QThread::wait()` 的卡死问题。V-1608 的代码审核报告指出同仓库另有调用方仍使用旧的风险模式，本 PR 将其中 `dfmplugin-propertydialog`（属性对话框插件）的两处用法一并修复。

## 问题现象

查看含大量子文件夹的目录属性时（单选 → `BasicWidget`；多选 → `MultiFileBasicInfoWidget`），若目录统计扫描尚未完成就关闭/切换对话框，UI 线程被阻塞导致卡死。

## 根因

`~FileScanner()` 会对其 worker 线程执行 `QThread::wait()`（`src/dfm-base/utils/filescanner.cpp`，`startWorker` 对运行中的 scanner 再次 `start()` 同样会 `wait()`）。属性对话框的两个 widget 在析构时以 `deleteLater()` 销毁可能仍在运行的 scanner，延迟删除触发 `~FileScanner → wait()`，在 UI 线程同步等待大目录扫描结束 → 卡死。

- `BasicWidget::~BasicWidget()`：`fileCalculationUtils->deleteLater();`
- `MultiFileBasicInfoWidget::~MultiFileBasicInfoWidget()`：`stop(); deleteLater();`（`stop()` 仅异步置位，紧接的 `deleteLater` 时 worker 多半未退出）

## 修复方案

参照同仓库 `BasicStatusBarPrivate`（`src/dfm-base/widgets/dfmstatusbar/private/basicstatusbar_p.cpp`）的成熟模式「按需新建 + 异步退役 + 代际守卫 + finishedJobs 创建期连接」，将两处 `FileScanner` 用法重构：

1. `FileScanner *` → `QPointer<FileScanner>`；新增 `retiredScanners` / `finishedScanners` 集合、`scanGeneration` 代际计数、`kMaxRetiredScanners { 2 }` 上限。
2. 扫描改为按需新建 scanner，在 `start()` 之前（创建期）连接 `finished`（记入 `finishedScanners`，对已退役的执行 `deleteLater()`）与 `destroyed`（清理两个集合）。
3. 进度回调用「代际 + 当前 scanner 身份」双守卫，忽略已退役 scanner 的迟到结果。
4. 新增 `discardCurrentScanner()` / `retireScanner()`：退役时 `setParent(nullptr)` 脱离父对象；`isRunning() && !finishedScanners.contains(scanner)` → 入 `retiredScanners` 并 `stop()`（不 wait、不 deleteLater），否则 `deleteLater()`。析构改为调用 `discardCurrentScanner()`。

### 相对 V-1608 的改进（规避审核报告指出的竞态）

V-1608 的 `discardCurrentScanner()` 在退役时才 `connect(finished, deleteLater)`，存在 `finished` 信号在 `isRunning()` 窄窗口内已发出、该连接永不触发导致 scanner 泄漏的竞态。本 PR 采用 `BasicStatusBarPrivate` 的「finishedJobs 集合 + 创建期连接」：在 `start()` 之前连接 `finished` 记入 `finishedScanners`，retire 时用 `finishedScanners.contains(scanner)` 直接 `deleteLater()` 已完成的 scanner，从源头规避该竞态，无需后续改进。

## 涉及文件（4 个，仅 FileScanner 用法）

- `src/plugins/common/dfmplugin-propertydialog/views/basicwidget.h` / `.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.h` / `.cpp`

未改动 `dfm-base` 的 `FileScanner` 本身、统计逻辑、UI 布局或其它字段。

## 本地编译验证

```
cmake --build build --target dfm-propertydialog-plugin   # Qt 6.8.0 / cmake 3.31.4
→ [100%] Built target dfm-propertydialog-plugin          # 链接生成 libdfm-propertydialog-plugin.so
```

编译成功，无错误。仅 2 条预先存在的 `QCheckBox::stateChanged` 弃用告警，位于本次未改动的 `MultiFileBasicInfoWidget::setHideState()`，与本次修复无关；本次新增/修改代码零告警。

## 取舍

与 `BasicStatusBar` 完全一致：对话框关闭时若扫描仍在运行，scanner 脱离父对象并 `stop()`，其 worker 线程经 `FileScanner` 内部 `onWorkerFinished → workerThread.quit()` 自行退出（不 hang），scanner 对象在该窄场景延后回收或随进程退出释放；不再阻塞 UI、不崩溃。

## Summary by Sourcery

Refactor property dialog directory scanning to retire FileScanner instances asynchronously and prevent UI freezes when closing or switching dialogs during large scans.

Bug Fixes:
- Resolve UI hangs in single- and multi-file property dialogs caused by synchronous FileScanner destruction waiting on worker threads.
- Prevent stale FileScanner progress callbacks from updating widgets after scans are retired or dialogs are closed.

Enhancements:
- Introduce on-demand FileScanner creation with generational tracking and guarded progress updates in BasicWidget and MultiFileBasicInfoWidget.
- Add bounded retired/finished scanner tracking using QPointer and QSet to avoid leaks and unbounded resource usage when scans are stopped mid-flight.