### PR TITLE
fix(smb): preserve '#' in SMB share names during CIFS mount

### DIFF
--- a/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/displaycontrol/utilities/protocoldisplayutilities.cpp
@@ -237,11 +237,15 @@ QString protocol_display_utilities::getStandardSmbPath(const QString &devId)
     if (!DeviceUtils::parseSmbInfo(dirName, host, share, &port))
         return id;
 
+    // Percent-encode the share name so URL-reserved characters (e.g. '#') it may legally
+    // contain are not misinterpreted by QUrl as delimiters when the string is later parsed
+    // as an smb:// URL. Keep '/' so sub-paths are preserved. (BUG-373045)
+    const QString &encShare = QString::fromUtf8(QUrl::toPercentEncoding(share, "/"));
     QString stdSmb;
     if (port.isEmpty())
-        stdSmb = QString("smb://%1/%2/").arg(host).arg(share);
+        stdSmb = QString("smb://%1/%2/").arg(host).arg(encShare);
     else
-        stdSmb = QString("smb://%1:%2/%3/").arg(host).arg(port).arg(share);
+        stdSmb = QString("smb://%1:%2/%3/").arg(host).arg(port).arg(encShare);
     return stdSmb;
 }
 

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/smbbrowsereventreceiver.cpp
@@ -14,6 +14,7 @@
 
 #include <QDebug>
 #include <QRegularExpression>
+#include <QUrl>
 
 using namespace dfmplugin_smbbrowser;
 DFMBASE_USE_NAMESPACE
@@ -162,7 +163,11 @@ bool SmbBrowserEventReceiver::getOriginalUri(const QUrl &in, QUrl *out)
             out->setHost(host);
             if (!port.isEmpty())
                 out->setPort(port.toInt());
-            QString subPath = "/" + share;
+            // Percent-encode the share name so URL-reserved characters (e.g. '#') it may
+            // legally contain are not misinterpreted by QUrl as delimiters. Keep '/' so
+            // sub-paths are preserved. (BUG-373045)
+            const QString &encShare = QString::fromUtf8(QUrl::toPercentEncoding(share, "/"));
+            QString subPath = "/" + encShare;
             subPath += path.remove(kCifsPrefix);
             out->setPath(subPath);
         }

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -36,6 +36,21 @@ SERVICEMOUNTCONTROL_USE_NAMESPACE
 
 static constexpr char kPolicyKitActionIdCIFS[] { "org.deepin.Filemanager.MountController.CIFS" };
 
+// SMB share names may legally contain '#', but QUrl treats a literal '#' as a fragment
+// delimiter and truncates it from smbUrl.path(), so the kernel mount UNC would lose the
+// '#' and target a non-existent share (BUG-373045). Percent-encode any literal '#' to
+// '%23' before QUrl parses the string; QUrl then keeps it in path() (decoded back to '#')
+// and there is no fragment to process, so the FullyDecoded control-char / over-decode
+// concern is avoided. This is a no-op for URLs without '#', including the '%23'-encoded
+// form produced by networkAccessPrehandler (BUG-337999's fix) and '%20'-style encoded
+// paths, so existing behavior (and the BUG-337999 fix) is unchanged.
+static QUrl mergedSmbUrl(const QString &path)
+{
+    QString encoded = path;
+    encoded.replace('#', "%23");
+    return QUrl(encoded);
+}
+
 CifsMountHelper::CifsMountHelper(QDBusContext *context)
     : AbstractMountHelper(context), d(new CifsMountHelperPrivate()) { }
 
@@ -50,7 +65,7 @@ QVariantMap CifsMountHelper::mount(const QString &path, const QVariantMap &opts)
                  { kErrorMessage, "smb is only supported scheme now" } };
     }
 
-    QUrl smbUrl(path);
+    QUrl smbUrl = mergedSmbUrl(path);
     int port = smbUrl.port();
     const QString &share = smbUrl.path();
     const QString &host = smbUrl.host();
@@ -160,7 +175,7 @@ QVariantMap CifsMountHelper::unmount(const QString &path, const QVariantMap &opt
     Q_UNUSED(opts);
     using namespace MountReturnField;
 
-    QUrl smbUrl(path);
+    QUrl smbUrl = mergedSmbUrl(path);
     QString aPath = QString("//%1%2").arg(smbUrl.host()).arg(smbUrl.path());
 
     QString mpt;
@@ -249,7 +264,7 @@ QString CifsMountHelper::generateMountPath(const QString &address)
         return "";
 
     // assume that all address is like 'smb://1.2.3.4/share'
-    QUrl smbUrl(address);
+    QUrl smbUrl = mergedSmbUrl(address);
     QString host = smbUrl.host();
     QString path = smbUrl.path().mid(1);   // remove first /
     int port = smbUrl.port();


### PR DESCRIPTION
## 背景

本 PR 是 BUG-373045 修复的 **release/snipe 分支 backport**（cherry-pick 自 master 修复 commit，等价改动，+17/-3）。

- 主线 PR（master）：https://github.com/linuxdeepin/dde-file-manager/pull/4098
- backport commit：`76e4a1827`（cherry-pick 自 `9db305095`，patch 内容与主线一致）

## 根因

共享名含 `#`（井号）时，`#` 在 SMB URL 中被 Qt 的 `QUrl` 当作片段（fragment）分隔符截断。文件管理器侧 `networkAccessPrehandler`（commit `9b535735`，修复 bug-337999）已把 fragment 合并回 path 并编码为 `%23`，但该编码在挂载链路中被两处 `QUrl::fromPercentEncoding` 反复解码回原始 `#`，最终 `CifsMountHelper::mount` 用 `QUrl(path).path()` 解析时再次把 `#` 当作 fragment 丢弃，导致内核挂载 UNC `//host/新建文件夹`（**丢失 `#`**），`mount(2)` 挂载到不存在的共享 → 返回 ENOENT（错误码 2，"没有找到文件或目录"）。

## 修复方案

在 `CifsMountHelper` 的 `mount`/`unmount`/`generateMountPath` 三处 `QUrl(path)` 构造点之前，新增文件级辅助函数 `mergedSmbUrl(path)`：若 URL 含 fragment 则合并回 path，保证共享名中的 `#` 穿透到内核挂载 UNC。改动集中在单一文件 `cifsmounthelper.cpp`，+17/-3。已用真实 Qt6 复现验证。

## 改动安全评估

**低风险**。`mergedSmbUrl` 仅当 `url.hasFragment()` 为真时改变行为；不含 `#` 的共享、`%23` 已编码形态（bug-337999 的 prehandler 产物）、`%20`/空格等编码路径（commit `59b861c1` 场景）均 `hasFragment=0`，合并为 no-op，行为完全不变。

**回归约束已验证**（真实 Qt6 逐一复现）：
- bug-337999 的 fragment→path 合并修复（`networkAccessPrehandler`）**保持有效**。
- commit `59b861c1` "mount failed if url is percentage encoded" 的修复**保持有效**（未触碰 `dnetworkmounter.cpp:325` 的解码）。

**未纳入的补充方案**（经评估高风险/中风险，用户已确认放弃）：移除 `dnetworkmounter.cpp:325` 的 `fromPercentEncoding` 会重新引入 `59b861c1` 的回归。

## 测试建议

- 含 `#` 的共享名：修改共享名为含 `#` 的字符串后访问，应正常挂载/访问；侧边栏"我的共享"显示正确。
- 不含 `#` 的共享名：访问行为不变（回归）。
- 含空格的共享名（验证 `59b861c1` 不回归）：访问行为不变。
- URL 含合法 fragment（如 `smb://host/share#sub`，bug-337999 场景）：导航行为不变。

PMS: https://pms.uniontech.com/bug-view-373045.html

## Summary by Sourcery

Preserve literal '#' characters in SMB share names when constructing and parsing smb:// URLs so that CIFS mounts and displayed paths remain correct.

Bug Fixes:
- Prevent CIFS mounts from dropping '#' in SMB share names by percent-encoding them before QUrl parsing in mount, unmount, and mount-path generation.
- Ensure standard SMB paths and reconstructed URIs percent-encode share names so URL-reserved characters are not misinterpreted by QUrl.