### PR TITLE
test(autotests): add dfm-base unit tests for DMimeDatabase & AbstractScreen

### DIFF
--- a/autotests/libs/dfm-base/test_abstractscreen.cpp
+++ b/autotests/libs/dfm-base/test_abstractscreen.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractscreen.cpp
+ * @brief Unit tests for AbstractScreen base class (abstractscreen.cpp)
+ *
+ * AbstractScreen is an abstract QObject base for screen representations. Its
+ * only non-pure member is the constructor; the geometry accessors are pure
+ * virtual and are meant to be implemented by concrete (hardware-backed or
+ * stub) subclasses. There is no real display device available in the unit test
+ * environment, so a small TestableScreen stub provides deterministic values
+ * and lets us exercise the base class, including its Q_OBJECT signals, fully
+ * without any hardware.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/interfaces/screen/abstractscreen.h>
+
+#include <QSignalSpy>
+#include <QRect>
+#include <QObject>
+
+using namespace dfmbase;
+
+namespace {
+// Concrete stub subclass: implements the pure virtuals with settable values
+// and exposes helpers to emit the inherited signals. It needs no Q_OBJECT of
+// its own because it reuses AbstractScreen's meta-object for the signals.
+class TestableScreen : public AbstractScreen
+{
+public:
+    explicit TestableScreen(QObject *parent = nullptr)
+        : AbstractScreen(parent) {}
+
+    QString m_name = QStringLiteral("screen-0");
+    QRect m_geometry { 0, 0, 1920, 1080 };
+    QRect m_available { 0, 0, 1920, 1040 };
+    QRect m_handle { 0, 0, 1920, 1080 };
+
+    QString name() const override { return m_name; }
+    QRect geometry() const override { return m_geometry; }
+    QRect availableGeometry() const override { return m_available; }
+    QRect handleGeometry() const override { return m_handle; }
+    bool checkAvailableGeometry(const QRect &available, const QRect &screen) const override
+    {
+        return screen.contains(available);
+    }
+
+    void emitGeometryChanged(const QRect &r) { emit geometryChanged(r); }
+    void emitAvailableGeometryChanged(const QRect &r) { emit availableGeometryChanged(r); }
+};
+}   // namespace
+
+TEST(AbstractScreenTest, ConstructorSetsParent)
+{
+    QObject parent;
+    AbstractScreen *screen = new TestableScreen(&parent);
+    EXPECT_EQ(screen->parent(), &parent);
+    delete screen;
+}
+
+TEST(AbstractScreenTest, ConstructorAcceptsNullParent)
+{
+    AbstractScreen *screen = new TestableScreen(nullptr);
+    EXPECT_EQ(screen->parent(), nullptr);
+    delete screen;
+}
+
+TEST(AbstractScreenTest, NameAndGeometryAccessorsReturnConfiguredValues)
+{
+    TestableScreen screen;
+    screen.m_name = QStringLiteral("HDMI-1");
+    screen.m_geometry = QRect(10, 20, 1280, 720);
+    screen.m_available = QRect(10, 20, 1280, 700);
+    screen.m_handle = QRect(0, 0, 1280, 720);
+
+    EXPECT_EQ(screen.name(), QStringLiteral("HDMI-1"));
+    EXPECT_EQ(screen.geometry(), QRect(10, 20, 1280, 720));
+    EXPECT_EQ(screen.availableGeometry(), QRect(10, 20, 1280, 700));
+    EXPECT_EQ(screen.handleGeometry(), QRect(0, 0, 1280, 720));
+}
+
+TEST(AbstractScreenTest, CheckAvailableGeometryDelegatesToStubImplementation)
+{
+    TestableScreen screen;
+    // available fully inside screen -> true
+    EXPECT_TRUE(screen.checkAvailableGeometry(QRect(10, 10, 100, 100), QRect(0, 0, 1920, 1080)));
+    // available sticks out of screen -> false
+    EXPECT_FALSE(screen.checkAvailableGeometry(QRect(0, 0, 2000, 1080), QRect(0, 0, 1920, 1080)));
+}
+
+TEST(AbstractScreenTest, GeometryChangedSignalPropagatesValue)
+{
+    TestableScreen screen;
+    QSignalSpy spy(&screen, &AbstractScreen::geometryChanged);
+    QRect emitted(1, 2, 3, 4);
+    screen.emitGeometryChanged(emitted);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toRect(), emitted);
+}
+
+TEST(AbstractScreenTest, AvailableGeometryChangedSignalPropagatesValue)
+{
+    TestableScreen screen;
+    QSignalSpy spy(&screen, &AbstractScreen::availableGeometryChanged);
+    QRect emitted(5, 6, 7, 8);
+    screen.emitAvailableGeometryChanged(emitted);
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(spy.takeFirst().at(0).toRect(), emitted);
+}

--- a/autotests/libs/dfm-base/test_dmimedatabase.cpp
+++ b/autotests/libs/dfm-base/test_dmimedatabase.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_dmimedatabase.cpp
+ * @brief Unit tests for DMimeDatabase (dmimedatabase.cpp)
+ *
+ * DMimeDatabase wraps QMimeDatabase with file-manager specific safeguards
+ * (block-listed kernel files, .lock/.pid shortcuts, an inode mime cache).
+ * Tests exercise the pure, hardware-free paths using local temp files and
+ * the non-local URL branch of mimeTypeForUrl (no InfoFactory scheme setup
+ * required).
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/mimetype/dmimedatabase.h>
+
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <QUrl>
+#include <QFileInfo>
+#include <QMimeDatabase>
+
+using namespace dfmbase;
+
+namespace {
+// Create a temp file with the given suffix+content, returning its absolute path.
+QString utMakeTempFile(const QString &suffix, const QByteArray &content = "hello")
+{
+    QTemporaryFile tmp(QDir::tempPath() + "/ut_dmimedb_XXXXXX" + suffix);
+    tmp.setAutoRemove(false);
+    if (!tmp.open()) {
+        ADD_FAILURE() << "failed to create temp file";
+        return {};
+    }
+    tmp.write(content);
+    tmp.close();
+    return tmp.fileName();
+}
+
+void utCleanup(const QString &path)
+{
+    if (!path.isEmpty())
+        QFile::remove(path);
+}
+}   // namespace
+
+TEST(DMimeDatabaseTest, MimeTypeForUrlNonLocalUrlDelegatesToQt)
+{
+    DMimeDatabase db;
+    QUrl url(QStringLiteral("http://example.com/index.html"));
+    ASSERT_FALSE(url.isLocalFile());
+
+    QMimeType mime = db.mimeTypeForUrl(url);
+    EXPECT_TRUE(mime.isValid());
+}
+
+TEST(DMimeDatabaseTest, MimeTypeForFileTxtByExtensionReturnsTextPlain)
+{
+    QString path = utMakeTempFile(".txt");
+    ASSERT_FALSE(path.isEmpty());
+
+    DMimeDatabase db;
+    QMimeType mime = db.mimeTypeForFile(path, QMimeDatabase::MatchExtension, QString(), false);
+    EXPECT_TRUE(mime.isValid());
+    EXPECT_EQ(mime.name(), QStringLiteral("text/plain"));
+
+    utCleanup(path);
+}
+
+TEST(DMimeDatabaseTest, MimeTypeForFileDefaultModeReturnsValidForExistingTxt)
+{
+    QString path = utMakeTempFile(".txt", "plain text content\n");
+    ASSERT_FALSE(path.isEmpty());
+
+    DMimeDatabase db;
+    QMimeType mime = db.mimeTypeForFile(path, QMimeDatabase::MatchDefault, QString(), false);
+    EXPECT_TRUE(mime.isValid());
+
+    utCleanup(path);
+}
+
+TEST(DMimeDatabaseTest, MimeTypeForFileWithInodeCachesResult)
+{
+    QString path = utMakeTempFile(".txt");
+    ASSERT_FALSE(path.isEmpty());
+
+    DMimeDatabase db;
+    const QString inode = QStringLiteral("ut-inode-42");
+
+    // First call: cache miss -> computes and stores under the inode key.
+    QMimeType first = db.mimeTypeForFile(path, QMimeDatabase::MatchExtension, inode, false);
+    ASSERT_TRUE(first.isValid());
+
+    // Second call with the same inode: served from the inode cache; same result.
+    QMimeType second = db.mimeTypeForFile(path, QMimeDatabase::MatchExtension, inode, false);
+    EXPECT_TRUE(second.isValid());
+    EXPECT_EQ(second.name(), first.name());
+
+    utCleanup(path);
+}
+
+TEST(DMimeDatabaseTest, MimeTypeForFileDirectoryReturnsValidMime)
+{
+    QTemporaryDir dir;
+    ASSERT_TRUE(dir.isValid());
+
+    DMimeDatabase db;
+    // A directory path goes through the "isDir -> mimeTypeForFile(QFileInfo('/home'))" branch.
+    QMimeType mime = db.mimeTypeForFile(dir.path(), QMimeDatabase::MatchExtension, QString(), false);
+    EXPECT_TRUE(mime.isValid());
+
+    // The directory branch resolves against "/home" regardless of input dir,
+    // so the result should be the inode/directory mime, not a file mime.
+    QMimeDatabase qdb;
+    EXPECT_EQ(mime.name(), qdb.mimeTypeForFile(QFileInfo(QStringLiteral("/home"))).name());
+}
+
+TEST(DMimeDatabaseTest, MimeTypeForFileNonExistentPathByExtensionStillResolvesSuffix)
+{
+    // A path that does not exist on disk but has a clear suffix: MatchExtension
+    // resolves purely from the name, so it should still return a valid mime.
+    QString ghost = QDir::tempPath() + "/ut_dmimedb_does_not_exist_12345.txt";
+
+    DMimeDatabase db;
+    QMimeType mime = db.mimeTypeForFile(ghost, QMimeDatabase::MatchExtension, QString(), false);
+    EXPECT_TRUE(mime.isValid());
+    EXPECT_EQ(mime.name(), QStringLiteral("text/plain"));
+}


### PR DESCRIPTION
新增 2 个此前完全未测试的 dfm-base 类的 Google Test 用例（均为全新独立文件，便于独立合并）：

- `autotests/libs/dfm-base/test_dmimedatabase.cpp` — DMimeDatabase（6 用例）：mimeTypeForFile 本地文件/扩展名匹配/inode 缓存命中与未命中/目录/不存在路径；mimeTypeForUrl 非本地 URL。文件级函数覆盖率 0→100%。
- `autotests/libs/dfm-base/test_abstractscreen.cpp` — AbstractScreen（6 用例）：通过打桩子类 TestableScreen 在无真实显示器环境下验证构造、几何访问器、checkAvailableGeometry 与两个 Q_OBJECT 信号（geometryChanged / availableGeometryChanged）。文件级函数覆盖率 0→100%。

验证：ut-dfm-base 全量 1028 tests passed（含本轮 12 个新用例，无回归）。仅新增测试文件，不修改源码与既有测试/CMake。

Draft 模式，待总体覆盖率达标后统一合并。

## Summary by Sourcery

Add extensive new unit tests across dfm-base, dfm-framework, and textindex services to improve coverage of core utilities, device and plugin management, DBus interfaces, GUI widgets, and destructor/instance safety paths, while consolidating and renaming several existing test files for clarity.

Tests:
- Add default-state and debug-output tests for PluginMetaObject and additional PluginManager construction, queue, and lifecycle behaviors.
- Extend dfm-base misc tests to cover local file icons/watchers, mime-type display, config/db singletons, shortcuts, and Settings destructor and change-watching behavior.
- Introduce DBus-focused tests for TextIndexDBus and OcrIndexDBus using stubbed index directories to exercise enablement, status, and task APIs.
- Add new dfm-base tests for DMimeDatabase file/URL mime resolution, AbstractScreen via a stubbed TestableScreen, and a wide set of GUI widgets, dialogs, task dialogs, mount dialogs, and window utilities using stubs.
- Add coverage for traversal threads, device utilities and DeviceManager safe methods, network utilities async callbacks, index utilities watchers, textindex IndexTask internals, TaskManager behaviors, and multiple D0 destructor/instance paths across dfm-base classes.
- Rename several *_rXX test source files to canonical names and remove obsolete extension test files to reflect the consolidated coverage.