### PR TITLE
test(autotests): add dfm-base unit tests for ThumbnailFactory

### DIFF
--- a/autotests/libs/dfm-base/test_thumbnailfactory.cpp
+++ b/autotests/libs/dfm-base/test_thumbnailfactory.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_thumbnailfactory.cpp
+ * @brief Unit tests for ThumbnailFactory (thumbnailfactory.cpp)
+ *
+ * ThumbnailFactory is a singleton whose constructor registers a set of
+ * built-in thumbnail creators and starts a worker thread. Here we exercise
+ * the singleton accessor and the registerThumbnailCreator() boolean contract
+ * (new type succeeds, already-registered type is rejected). joinThumbnailJob
+ * is intentionally NOT called to avoid spawning real thumbnail work.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/utils/thumbnail/thumbnailfactory.h>
+
+#include <QString>
+#include <QImage>
+
+using namespace dfmbase;
+
+namespace {
+ThumbnailFactory::ThumbnailCreator utNoopCreator =
+    [](const QString &, DFMGLOBAL_NAMESPACE::ThumbnailSize) {
+        return QImage();
+    };
+}   // namespace
+
+TEST(ThumbnailFactoryTest, InstanceReturnsNonNullSingleton)
+{
+    auto *a = ThumbnailFactory::instance();
+    auto *b = ThumbnailFactory::instance();
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(a, b);
+}
+
+TEST(ThumbnailFactoryTest, RegisterNewMimeTypeSucceeds)
+{
+    auto *f = ThumbnailFactory::instance();
+    bool ok = f->registerThumbnailCreator(QStringLiteral("application/x-ut-thumbnail-test"),
+                                          utNoopCreator);
+    EXPECT_TRUE(ok);
+}
+
+TEST(ThumbnailFactoryTest, RegisterDuplicateMimeTypeReturnsFalse)
+{
+    auto *f = ThumbnailFactory::instance();
+    // "image/*" is registered by the constructor.
+    bool ok = f->registerThumbnailCreator(QStringLiteral("image/*"), utNoopCreator);
+    EXPECT_FALSE(ok);
+}
+
+TEST(ThumbnailFactoryTest, RegisterDuplicateOfJustRegisteredReturnsFalse)
+{
+    auto *f = ThumbnailFactory::instance();
+    const QString mime = QStringLiteral("application/x-ut-thumbnail-dup");
+    ASSERT_TRUE(f->registerThumbnailCreator(mime, utNoopCreator));
+    EXPECT_FALSE(f->registerThumbnailCreator(mime, utNoopCreator));
+}


### PR DESCRIPTION
新增 1 个此前未测试的 dfm-base 类的 Google Test 用例（全新独立文件，基于 master，便于独立合并）：autotests/libs/dfm-base/test_*.cpp。ut-dfm-base 1075 tests passed（含本用例，无回归）。仅新增测试文件，不修改源码与既有测试/CMake。Draft 模式。

## Summary by Sourcery

Tests:
- Introduce a new Google Test file for dfm-base ThumbnailFactory, validating singleton instance consistency and MIME-type registration success/failure.