### PR TITLE
test(autotests): add dfm-base unit tests for AbstractDesktopFrame, AbstractFilePreviewPlugin, LocalFileIconProvider

### DIFF
--- a/autotests/libs/dfm-base/test_abstractdesktopframe.cpp
+++ b/autotests/libs/dfm-base/test_abstractdesktopframe.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractdesktopframe.cpp
+ * @brief Unit tests for AbstractDesktopFrame base class (abstractdesktopframe.cpp)
+ *
+ * AbstractDesktopFrame is an abstract QObject base for desktop frame
+ * implementations. Only the constructor has a .cpp body; the geometry
+ * accessors are pure virtual and the five Q_OBJECT signals are meant to be
+ * emitted by concrete subclasses. A small TestableFrame stub provides
+ * deterministic implementations and helpers to emit the inherited signals,
+ * exercising the base class fully without any real screen hardware.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/interfaces/abstractdesktopframe.h>
+
+#include <QSignalSpy>
+#include <QWidget>
+#include <QObject>
+#include <QList>
+
+using namespace dfmbase;
+
+namespace {
+class TestableFrame : public AbstractDesktopFrame
+{
+public:
+    explicit TestableFrame(QObject *parent = nullptr)
+        : AbstractDesktopFrame(parent) {}
+
+    QList<QWidget *> m_rootWindows;
+    int m_layoutCalls = 0;
+
+    QList<QWidget *> rootWindows() const override { return m_rootWindows; }
+    void layoutChildren() override { ++m_layoutCalls; }
+
+    void emitWindowAboutToBeBuilded() { emit windowAboutToBeBuilded(); }
+    void emitWindowBuilded() { emit windowBuilded(); }
+    void emitWindowShowed() { emit windowShowed(); }
+    void emitGeometryChanged() { emit geometryChanged(); }
+    void emitAvailableGeometryChanged() { emit availableGeometryChanged(); }
+};
+}   // namespace
+
+TEST(AbstractDesktopFrameTest, ConstructorSetsParent)
+{
+    QObject parent;
+    auto *frame = new TestableFrame(&parent);
+    EXPECT_EQ(frame->parent(), &parent);
+    delete frame;
+}
+
+TEST(AbstractDesktopFrameTest, ConstructorAcceptsNullParent)
+{
+    auto *frame = new TestableFrame(nullptr);
+    EXPECT_EQ(frame->parent(), nullptr);
+    delete frame;
+}
+
+TEST(AbstractDesktopFrameTest, RootWindowsReturnsConfiguredList)
+{
+    TestableFrame frame;
+    QWidget w1, w2;
+    frame.m_rootWindows = { &w1, &w2 };
+    auto roots = frame.rootWindows();
+    EXPECT_EQ(roots.size(), 2);
+    EXPECT_EQ(roots.at(0), &w1);
+    EXPECT_EQ(roots.at(1), &w2);
+}
+
+TEST(AbstractDesktopFrameTest, LayoutChildrenInvokedOnCall)
+{
+    TestableFrame frame;
+    EXPECT_EQ(frame.m_layoutCalls, 0);
+    frame.layoutChildren();
+    frame.layoutChildren();
+    EXPECT_EQ(frame.m_layoutCalls, 2);
+}
+
+TEST(AbstractDesktopFrameTest, AllFiveSignalsPropagate)
+{
+    TestableFrame frame;
+    QSignalSpy aboutSpy(&frame, &AbstractDesktopFrame::windowAboutToBeBuilded);
+    QSignalSpy buildedSpy(&frame, &AbstractDesktopFrame::windowBuilded);
+    QSignalSpy showedSpy(&frame, &AbstractDesktopFrame::windowShowed);
+    QSignalSpy geomSpy(&frame, &AbstractDesktopFrame::geometryChanged);
+    QSignalSpy availSpy(&frame, &AbstractDesktopFrame::availableGeometryChanged);
+
+    frame.emitWindowAboutToBeBuilded();
+    frame.emitWindowBuilded();
+    frame.emitWindowShowed();
+    frame.emitGeometryChanged();
+    frame.emitAvailableGeometryChanged();
+
+    EXPECT_EQ(aboutSpy.count(), 1);
+    EXPECT_EQ(buildedSpy.count(), 1);
+    EXPECT_EQ(showedSpy.count(), 1);
+    EXPECT_EQ(geomSpy.count(), 1);
+    EXPECT_EQ(availSpy.count(), 1);
+}

--- a/autotests/libs/dfm-base/test_abstractfilepreviewplugin.cpp
+++ b/autotests/libs/dfm-base/test_abstractfilepreviewplugin.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractfilepreviewplugin.cpp
+ * @brief Unit tests for AbstractFilePreviewPlugin base class (abstractfilepreviewplugin.cpp)
+ *
+ * AbstractFilePreviewPlugin is an abstract QObject base for file-preview
+ * factories. Only the constructor has a .cpp body; create() is a pure
+ * virtual factory method. A TestablePreviewPlugin stub records the key it
+ * was asked to create and returns nullptr (a contract-permitted result),
+ * exercising the base-class constructor without any real preview backend or
+ * file I/O. Returning nullptr avoids needing a concrete AbstractBasePreview
+ * (which itself declares many pure virtuals).
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/interfaces/abstractfilepreviewplugin.h>
+
+#include <QObject>
+#include <QString>
+
+using namespace dfmbase;
+
+namespace {
+class TestablePreviewPlugin : public AbstractFilePreviewPlugin
+{
+public:
+    explicit TestablePreviewPlugin(QObject *parent = nullptr)
+        : AbstractFilePreviewPlugin(parent) {}
+
+    AbstractBasePreview *create(const QString &key) override
+    {
+        m_lastKey = key;
+        return nullptr;   // contract-permitted: "no preview for this key"
+    }
+
+    QString m_lastKey;
+};
+}   // namespace
+
+TEST(AbstractFilePreviewPluginTest, ConstructorSetsParent)
+{
+    QObject parent;
+    auto *plugin = new TestablePreviewPlugin(&parent);
+    EXPECT_EQ(plugin->parent(), &parent);
+    delete plugin;
+}
+
+TEST(AbstractFilePreviewPluginTest, ConstructorAcceptsNullParent)
+{
+    auto *plugin = new TestablePreviewPlugin(nullptr);
+    EXPECT_EQ(plugin->parent(), nullptr);
+    delete plugin;
+}
+
+TEST(AbstractFilePreviewPluginTest, CreateRecordsKeyAndReturnsNull)
+{
+    TestablePreviewPlugin plugin;
+    AbstractBasePreview *preview = plugin.create(QStringLiteral("image"));
+    EXPECT_EQ(preview, nullptr);
+    EXPECT_EQ(plugin.m_lastKey, QStringLiteral("image"));
+}
+
+TEST(AbstractFilePreviewPluginTest, CreateAcceptsEmptyKey)
+{
+    TestablePreviewPlugin plugin;
+    AbstractBasePreview *preview = plugin.create(QString());
+    EXPECT_EQ(preview, nullptr);
+    EXPECT_TRUE(plugin.m_lastKey.isEmpty());
+}

--- a/autotests/libs/dfm-base/test_localfileiconprovider.cpp
+++ b/autotests/libs/dfm-base/test_localfileiconprovider.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_localfileiconprovider.cpp
+ * @brief Unit tests for LocalFileIconProvider (localfileiconprovider.cpp)
+ *
+ * LocalFileIconProvider wraps QFileIconProvider with DFMIO-based icon
+ * resolution. The icon() overloads resolve a QIcon from the file system;
+ * when the path does not exist (or has no themed icon) they return a null
+ * QIcon, and the feedback overloads fall back to the caller-supplied icon.
+ * All paths here are local temp files / non-existent paths, so no hardware
+ * or network is required.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/file/local/localfileiconprovider.h>
+
+#include <QFileInfo>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QDir>
+#include <QIcon>
+#include <QPixmap>
+#include <QColor>
+#include <QString>
+#include <QFile>
+
+using namespace dfmbase;
+
+namespace {
+// Build a guaranteed non-null QIcon (an offscreen-rendered pixmap) so that
+// feedback assertions are not dependent on the current icon theme.
+QIcon utNonNullIcon()
+{
+    QPixmap pm(16, 16);
+    pm.fill(Qt::red);
+    return QIcon(pm);
+}
+}   // namespace
+
+TEST(LocalFileIconProviderTest, GlobalProviderReturnsNonNullSingleton)
+{
+    auto *a = LocalFileIconProvider::globalProvider();
+    auto *b = LocalFileIconProvider::globalProvider();
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(a, b);
+}
+
+TEST(LocalFileIconProviderTest, ConstructAndDestructWithoutCrash)
+{
+    {
+        LocalFileIconProvider provider;
+        (void)provider;
+    }
+    SUCCEED();
+}
+
+TEST(LocalFileIconProviderTest, IconForNonExistentPathByQStringReturnsNullIcon)
+{
+    LocalFileIconProvider provider;
+    QIcon icon = provider.icon(QStringLiteral("/this/path/does/not/exist/ut_lfip_12345"));
+    EXPECT_TRUE(icon.isNull());
+}
+
+TEST(LocalFileIconProviderTest, IconForNonExistentPathByQFileInfoReturnsNullIcon)
+{
+    LocalFileIconProvider provider;
+    QFileInfo info(QStringLiteral("/this/path/does/not/exist/ut_lfip_67890"));
+    QIcon icon = provider.icon(info);
+    EXPECT_TRUE(icon.isNull());
+}
+
+TEST(LocalFileIconProviderTest, IconByQStringWithFeedbackFallsBackWhenIconNull)
+{
+    LocalFileIconProvider provider;
+    QIcon feedback = utNonNullIcon();
+    ASSERT_FALSE(feedback.isNull());
+    QIcon result = provider.icon(QStringLiteral("/this/path/does/not/exist/ut_lfip_fb1"), feedback);
+    // Non-existent path -> primary icon null -> must return the feedback icon.
+    EXPECT_FALSE(result.isNull());
+}
+
+TEST(LocalFileIconProviderTest, IconByQFileInfoWithFeedbackFallsBackWhenIconNull)
+{
+    LocalFileIconProvider provider;
+    QFileInfo info(QStringLiteral("/this/path/does/not/exist/ut_lfip_fb2"));
+    QIcon feedback = utNonNullIcon();
+    ASSERT_FALSE(feedback.isNull());
+    QIcon result = provider.icon(info, feedback);
+    EXPECT_FALSE(result.isNull());
+}
+
+TEST(LocalFileIconProviderTest, IconForExistingTempFileDoesNotCrash)
+{
+    QTemporaryFile tmp(QDir::tempPath() + "/ut_lfip_XXXXXX.txt");
+    ASSERT_TRUE(tmp.open());
+    tmp.write("x");
+    tmp.close();
+    QString path = tmp.fileName();   // keep file alive until end of test
+
+    LocalFileIconProvider provider;
+    QIcon icon = provider.icon(QFileInfo(path));
+    // The parent dir exists, so fileSystemIcon runs the "exists" path; the
+    // returned QIcon may or may not be null depending on the icon theme, but
+    // the call must not crash.
+    (void)icon.isNull();
+    QFile::remove(path);
+}


### PR DESCRIPTION
新增 3 个此前未测试的 dfm-base 类的 Google Test 用例（基于 master，3 个全新独立文件）：
- AbstractDesktopFrame（5 用例）：打桩子类覆盖构造、rootWindows、layoutChildren、5 个信号
- AbstractFilePreviewPlugin（4 用例）：打桩子类覆盖构造、create 桩
- LocalFileIconProvider（7 用例）：globalProvider、构造/析构、icon 不存在路径返回空、feedback 回退
ut-dfm-base 全量通过。仅新增测试文件。Draft 模式。

## Summary by Sourcery

Add unit tests for previously untested dfm-base classes to validate their construction, behavior, and signal/return contracts.

Tests:
- Add Google Test coverage for AbstractDesktopFrame, including constructor parenting, root window handling, layout invocation, and signal emission.
- Add Google Test coverage for AbstractFilePreviewPlugin, validating constructor behavior and create() contract with various keys.
- Add Google Test coverage for LocalFileIconProvider, ensuring global singleton behavior, safe construction/destruction, null-icon handling for non-existent paths, feedback fallback, and non-crashing icon retrieval for existing files.