### PR TITLE
test(autotests): add dfm-base unit tests for WindowUtils, EventFilterUtils, ThumbnailWorker

### DIFF
--- a/autotests/libs/dfm-base/test_eventfilterutils.cpp
+++ b/autotests/libs/dfm-base/test_eventfilterutils.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_eventfilterutils.cpp
+ * @brief Unit tests for EventFilter::handleRightClickOutsideMenu
+ *        (eventfilterutils.cpp)
+ *
+ * handleRightClickOutsideMenu early-returns false unless the current Qt
+ * platform is X11. Under the offscreen platform it must return false for
+ * any event, covering the non-X11 guard branch without real X11 hardware.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/utils/eventfilterutils.h>
+#include <dfm-base/utils/windowutils.h>
+
+#include <QMouseEvent>
+#include <QEvent>
+#include <QGuiApplication>
+#include <QPointF>
+
+using namespace dfmbase;
+using namespace dfmbase::EventFilter;
+
+TEST(EventFilterUtilsTest, ReturnsFalseForNonX11PlatformMouseButtonPress)
+{
+    ASSERT_FALSE(WindowUtils::isX11());   // offscreen guard
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(0, 0), QPointF(0, 0),
+                      Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_FALSE(handleRightClickOutsideMenu(&press));
+}
+
+TEST(EventFilterUtilsTest, ReturnsFalseForNonMouseButtonEvent)
+{
+    // Even if isX11 were true, a non-MouseButtonPress event returns false.
+    // Under offscreen isX11() is false so this returns false immediately.
+    QEvent other(QEvent::Wheel);
+    EXPECT_FALSE(handleRightClickOutsideMenu(&other));
+}
+
+TEST(EventFilterUtilsTest, ReturnsFalseForNullEvent)
+{
+    // Passing a null event pointer must not crash; under offscreen the X11
+    // guard returns false before dereferencing.
+    EXPECT_FALSE(handleRightClickOutsideMenu(nullptr));
+}
+
+TEST(EventFilterUtilsTest, ReturnsFalseForLeftButtonClickUnderNonX11)
+{
+    QMouseEvent left(QEvent::MouseButtonPress, QPointF(0, 0), QPointF(0, 0),
+                    Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    EXPECT_FALSE(handleRightClickOutsideMenu(&left));
+}

--- a/autotests/libs/dfm-base/test_thumbnailworker.cpp
+++ b/autotests/libs/dfm-base/test_thumbnailworker.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_thumbnailworker.cpp
+ * @brief Unit tests for ThumbnailWorker (thumbnailworker.cpp)
+ *
+ * ThumbnailWorker is a QObject with a public constructor and a
+ * registerCreator() boolean contract (new MIME succeeds, duplicate is
+ * rejected). The worker thread is not started by registerCreator, so no
+ * real thumbnail generation runs. stop() is also exercised.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/utils/thumbnail/thumbnailworker.h>
+
+#include <QString>
+#include <QImage>
+
+using namespace dfmbase;
+
+namespace {
+ThumbnailWorker::ThumbnailCreator utNoopCreator =
+    [](const QString &, DFMGLOBAL_NAMESPACE::ThumbnailSize) {
+        return QImage();
+    };
+}   // namespace
+
+TEST(ThumbnailWorkerTest, ConstructAndDestructWithoutCrash)
+{
+    {
+        ThumbnailWorker worker;
+        (void)worker;
+    }
+    SUCCEED();
+}
+
+TEST(ThumbnailWorkerTest, RegisterNewCreatorSucceeds)
+{
+    ThumbnailWorker worker;
+    bool ok = worker.registerCreator(QStringLiteral("application/x-ut-tw-test"),
+                                      utNoopCreator);
+    EXPECT_TRUE(ok);
+}
+
+TEST(ThumbnailWorkerTest, RegisterDuplicateCreatorReturnsFalse)
+{
+    ThumbnailWorker worker;
+    const QString mime = QStringLiteral("application/x-ut-tw-dup");
+    ASSERT_TRUE(worker.registerCreator(mime, utNoopCreator));
+    EXPECT_FALSE(worker.registerCreator(mime, utNoopCreator));
+}
+
+TEST(ThumbnailWorkerTest, StopIsCallableAndDoesNotCrash)
+{
+    ThumbnailWorker worker;
+    worker.stop();
+    SUCCEED();   // reached only if stop did not crash
+}

--- a/autotests/libs/dfm-base/test_windowutils.cpp
+++ b/autotests/libs/dfm-base/test_windowutils.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_windowutils.cpp
+ * @brief Unit tests for WindowUtils (windowutils.cpp)
+ *
+ * WindowUtils exposes platform / key-modifier helpers as static functions.
+ * Under the offscreen Qt platform (no X11 / no Wayland), isX11() and
+ * isWayLand() return false deterministically; keyboard-modifier helpers
+ * reflect qApp state without any real keyboard. No hardware is needed.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/utils/windowutils.h>
+
+#include <QGuiApplication>
+#include <QScreen>
+#include <QTest>
+
+using namespace dfmbase;
+
+TEST(WindowUtilsTest, IsX11ReturnsFalseUnderOffscreenPlatform)
+{
+    EXPECT_EQ(QGuiApplication::platformName(), QStringLiteral("offscreen"));
+    EXPECT_FALSE(WindowUtils::isX11());
+}
+
+TEST(WindowUtilsTest, IsWayLandReturnsFalseUnderOffscreenPlatform)
+{
+    EXPECT_EQ(QGuiApplication::platformName(), QStringLiteral("offscreen"));
+    EXPECT_FALSE(WindowUtils::isWayLand());
+}
+
+TEST(WindowUtilsTest, KeyShiftIsPressedDefaultFalse)
+{
+    // No real keyboard input; default modifiers are NoModifier.
+    EXPECT_FALSE(WindowUtils::keyShiftIsPressed());
+}
+
+TEST(WindowUtilsTest, KeyCtrlIsPressedDefaultFalse)
+{
+    EXPECT_FALSE(WindowUtils::keyCtrlIsPressed());
+}
+
+TEST(WindowUtilsTest, KeyAltIsPressedDefaultFalse)
+{
+    EXPECT_FALSE(WindowUtils::keyAltIsPressed());
+}
+
+TEST(WindowUtilsTest, CursorScreenReturnsNonNullScreen)
+{
+    // Under offscreen there is at least one (virtual) screen; cursorScreen()
+    // falls back to the primary screen when no screen contains the cursor.
+    QScreen *screen = WindowUtils::cursorScreen();
+    EXPECT_NE(screen, nullptr);
+}


### PR DESCRIPTION
新增 3 个此前未测试的 dfm-base 类的 Google Test 用例（基于 master，3 个全新独立文件）：
- WindowUtils（6 用例）：isX11/isWayLand offscreen 返回 false、keyboard modifier 默认 false、cursorScreen 返回非空
- EventFilterUtils（4 用例）：非 X11 早退分支（offscreen）、非鼠标事件、null 事件、左键点击
- ThumbnailWorker（4 用例）：构造/析构安全、registerCreator 成功/重复拒绝、stop 不崩溃
ut-dfm-base 全量 1089 tests passed。仅新增测试文件。Draft 模式。

## Summary by Sourcery

Add new Google Test coverage for previously untested dfm-base utility classes under the offscreen Qt platform.

Tests:
- Introduce unit tests for WindowUtils covering platform detection, keyboard modifier helpers, and cursor screen retrieval under the offscreen backend.
- Add unit tests for EventFilter::handleRightClickOutsideMenu to validate non-X11 guard behavior and safe handling of various mouse and null event scenarios.
- Add unit tests for ThumbnailWorker to verify safe construction/destruction, creator registration contract, and non-crashing stop() behavior.