### PR TITLE
test(autotests): add dfm-base unit tests for Splitter, ViewHintMessage, DeviceProxyManager

### DIFF
--- a/autotests/libs/dfm-base/test_deviceproxymanager.cpp
+++ b/autotests/libs/dfm-base/test_deviceproxymanager.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_deviceproxymanager.cpp
+ * @brief Unit tests for DeviceProxyManager (deviceproxymanager.cpp)
+ *
+ * DeviceProxyManager is a singleton proxy that chooses between DBus and
+ * direct API for device operations. In the unit-test environment the DBus
+ * service is not running, so isDBusRunning() returns false and the
+ * direct-API fallback paths are used. No real device hardware is needed.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/device/devicemanager.h>
+
+#include <QString>
+#include <QStringList>
+#include <QVariantMap>
+
+using namespace dfmbase;
+
+TEST(DeviceProxyManagerTest, InstanceReturnsNonNullSingleton)
+{
+    auto *a = DeviceProxyManager::instance();
+    auto *b = DeviceProxyManager::instance();
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(a, b);
+}
+
+TEST(DeviceProxyManagerTest, IsDBusRunningReturnsFalseWithoutService)
+{
+    auto *m = DeviceProxyManager::instance();
+    EXPECT_FALSE(m->isDBusRuning());
+}
+
+TEST(DeviceProxyManagerTest, GetAllBlockIdsDoesNotCrash)
+{
+    auto *m = DeviceProxyManager::instance();
+    QStringList ids = m->getAllBlockIds();
+    // Without hardware/DBus, this returns via DevMngIns which is also empty.
+    (void)ids;
+    SUCCEED();
+}
+
+TEST(DeviceProxyManagerTest, GetAllProtocolIdsesDoesNotCrash)
+{
+    auto *m = DeviceProxyManager::instance();
+    QStringList ids = m->getAllProtocolIds();
+    (void)ids;
+    SUCCEED();
+}
+
+TEST(DeviceProxyManagerTest, QueryBlockInfoReturnsEmptyForNonExistentDevice)
+{
+    auto *m = DeviceProxyManager::instance();
+    QVariantMap info = m->queryBlockInfo(QStringLiteral("/dev/nonexistent-ut-12345"));
+    EXPECT_TRUE(info.isEmpty());
+}
+
+TEST(DeviceProxyManagerTest, QueryProtocolInfoReturnsEmptyForNonExistentDevice)
+{
+    auto *m = DeviceProxyManager::instance();
+    QVariantMap info = m->queryProtocolInfo(QStringLiteral("nonexistent-ut-67890"));
+    EXPECT_TRUE(info.isEmpty());
+}

--- a/autotests/libs/dfm-base/test_splitter.cpp
+++ b/autotests/libs/dfm-base/test_splitter.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_splitter.cpp
+ * @brief Unit tests for Splitter and SplitterHandle (splitter.cpp)
+ *
+ * Splitter is a QSplitter subclass with a splitPosition property and a
+ * custom SplitterHandle that manages cursor override. Constructible in
+ * offscreen mode — no display hardware required.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/widgets/dfmsplitter/splitter.h>
+
+#include <QSplitter>
+#include <Qt>
+
+using namespace dfmbase;
+
+TEST(SplitterTest, ConstructHorizontalDoesNotCrash)
+{
+    Splitter s(Qt::Horizontal);
+    EXPECT_EQ(s.orientation(), Qt::Horizontal);
+}
+
+TEST(SplitterTest, ConstructVerticalDoesNotCrash)
+{
+    Splitter s(Qt::Vertical);
+    EXPECT_EQ(s.orientation(), Qt::Vertical);
+}
+
+TEST(SplitterTest, SplitPositionDefaultsToZero)
+{
+    Splitter s(Qt::Horizontal);
+    EXPECT_EQ(s.splitPosition(), 0);
+}
+
+TEST(SplitterTest, SetSplitPositionUpdatesValue)
+{
+    Splitter s(Qt::Horizontal);
+    s.setSplitPosition(100);
+    EXPECT_EQ(s.splitPosition(), 100);
+}
+
+TEST(SplitterTest, SetSamePositionDoesNotChangeValue)
+{
+    Splitter s(Qt::Horizontal);
+    s.setSplitPosition(50);
+    s.setSplitPosition(50);   // no-op: same value
+    EXPECT_EQ(s.splitPosition(), 50);
+}
+
+TEST(SplitterTest, CreateHandleReturnsSplitterHandle)
+{
+    Splitter s(Qt::Horizontal);
+    QSplitterHandle *handle = s.createHandle();
+    ASSERT_NE(handle, nullptr);
+    EXPECT_EQ(handle->orientation(), Qt::Horizontal);
+    delete handle;
+}

--- a/autotests/libs/dfm-base/test_viewhintmessage.cpp
+++ b/autotests/libs/dfm-base/test_viewhintmessage.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_viewhintmessage.cpp
+ * @brief Unit tests for ViewHintMessage (viewhintmessage.cpp)
+ *
+ * ViewHintMessage is a QObject controller for floating hint messages. The
+ * setter methods and isVisible() are pure data operations that don't need
+ * a visible widget. The show() method is NOT called to avoid needing a real
+ * host widget.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/widgets/viewhintmessage/viewhintmessage.h>
+
+#include <QObject>
+#include <QString>
+#include <QList>
+#include <QPair>
+
+using namespace dfmbase;
+
+TEST(ViewHintMessageTest, ConstructAndDestructWithoutCrash)
+{
+    {
+        ViewHintMessage msg;
+        (void)msg;
+    }
+    SUCCEED();
+}
+
+TEST(ViewHintMessageTest, IsVisibleReturnsFalseBeforeShow)
+{
+    ViewHintMessage msg;
+    EXPECT_FALSE(msg.isVisible());
+}
+
+TEST(ViewHintMessageTest, SetIconDoesNotCrash)
+{
+    ViewHintMessage msg;
+    msg.setIcon(QStringLiteral("dialog-warning"));
+}
+
+TEST(ViewHintMessageTest, SetTextDoesNotCrash)
+{
+    ViewHintMessage msg;
+    msg.setText(QStringLiteral("test message"));
+}
+
+TEST(ViewHintMessageTest, SetActionsDoesNotCrash)
+{
+    ViewHintMessage msg;
+    QList<QPair<QString, QString>> actions;
+    actions << QPair<QString, QString>(QStringLiteral("ok"), QStringLiteral("OK"));
+    actions << QPair<QString, QString>(QStringLiteral("cancel"), QStringLiteral("Cancel"));
+    msg.setActions(actions);
+}
+
+TEST(ViewHintMessageTest, SetAutoDismissOnActionDoesNotCrash)
+{
+    ViewHintMessage msg;
+    msg.setAutoDismissOnAction(false);
+    msg.setAutoDismissOnAction(true);
+}


### PR DESCRIPTION
3 个此前未测试类，18 用例，基于 master。ut-dfm-base 全量通过。Draft 模式。

## Summary by Sourcery

Add unit test coverage for previously untested dfm-base UI and device components.

Tests:
- Introduce DeviceProxyManager tests to validate singleton behavior, DBus fallback, and non-crashing query methods in a test environment without hardware.
- Add ViewHintMessage tests to cover basic construction, visibility, and setter methods for icon, text, actions, and auto-dismiss configuration.
- Add Splitter and SplitterHandle tests to verify construction in both orientations, splitPosition property behavior, and handle creation.