### PR TITLE
test(autotests): add dfm-base unit tests for FileManagerWindowsManager, DeviceWatcher, ViewHintWidget

### DIFF
--- a/autotests/libs/dfm-base/test_devicewatcher.cpp
+++ b/autotests/libs/dfm-base/test_devicewatcher.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_devicewatcher.cpp
+ * @brief Unit tests for DeviceWatcher (devicewatcher.cpp)
+ *
+ * DeviceWatcher has a public constructor and polling/watch control methods.
+ * Without any real block/protocol device or DBus daemon, the query methods
+ * return empty results and the polling timer is not active. No hardware
+ * is needed.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/base/device/private/devicewatcher.h>
+
+#include <QString>
+#include <QStringList>
+#include <QVariantMap>
+#include <dfm-mount/base/dmount_global.h>
+
+using namespace dfmbase;
+
+TEST(DeviceWatcherTest, ConstructAndDestructWithoutCrash)
+{
+    {
+        DeviceWatcher watcher;
+        (void)watcher;
+    }
+    SUCCEED();
+}
+
+TEST(DeviceWatcherTest, StartAndStopPollingUsageDoesNotCrash)
+{
+    DeviceWatcher watcher;
+    watcher.startPollingUsage();
+    watcher.stopPollingUsage();
+    SUCCEED();
+}
+
+TEST(DeviceWatcherTest, StopPollingWhenNotStartedDoesNotCrash)
+{
+    DeviceWatcher watcher;
+    watcher.stopPollingUsage();
+    SUCCEED();
+}
+
+TEST(DeviceWatcherTest, InitUsageCacheDoesNotCrash)
+{
+    DeviceWatcher watcher;
+    watcher.initUsageCache();
+    SUCCEED();
+}
+
+TEST(DeviceWatcherTest, GetSiblingsReturnsEmptyForNonExistentDevice)
+{
+    DeviceWatcher watcher;
+    QStringList siblings = watcher.getSiblings(QStringLiteral("/dev/nonexistent-ut-12345"));
+    EXPECT_TRUE(siblings.isEmpty());
+}
+
+TEST(DeviceWatcherTest, InitDevDatasDoesNotCrash)
+{
+    DeviceWatcher watcher;
+    watcher.initDevDatas();
+    SUCCEED();
+}

--- a/autotests/libs/dfm-base/test_filemanagerwindowsmanager.cpp
+++ b/autotests/libs/dfm-base/test_filemanagerwindowsmanager.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_filemanagerwindowsmanager.cpp
+ * @brief Unit tests for FileManagerWindowsManager (filemanagerwindowsmanager.cpp)
+ *
+ * FileManagerWindowsManager is a singleton that tracks file-manager windows.
+ * With no windows created, the query methods return empty/zero values. No
+ * real window is needed.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <QList>
+#include <QUrl>
+
+using namespace dfmbase;
+
+TEST(FileManagerWindowsManagerTest, InstanceReturnsNonNullSingleton)
+{
+    auto &a = FileManagerWindowsManager::instance();
+    auto &b = FileManagerWindowsManager::instance();
+    EXPECT_EQ(&a, &b);
+}
+
+TEST(FileManagerWindowsManagerTest, WindowIdListIsEmptyBeforeAnyWindowCreated)
+{
+    auto &m = FileManagerWindowsManager::instance();
+    EXPECT_TRUE(m.windowIdList().isEmpty());
+}
+
+TEST(FileManagerWindowsManagerTest, PreviousActivedWindowIdIsZero)
+{
+    auto &m = FileManagerWindowsManager::instance();
+    EXPECT_EQ(m.previousActivedWindowId(), 0);
+}
+
+TEST(FileManagerWindowsManagerTest, LastActivedWindowIdIsZeroWhenEmpty)
+{
+    auto &m = FileManagerWindowsManager::instance();
+    EXPECT_EQ(m.lastActivedWindowId(), 0);
+}
+
+TEST(FileManagerWindowsManagerTest, ResetPreviousActivedWindowIdDoesNotCrash)
+{
+    auto &m = FileManagerWindowsManager::instance();
+    m.resetPreviousActivedWindowId();
+    SUCCEED();
+}
+
+TEST(FileManagerWindowsManagerTest, ContainsCurrentUrlReturnsFalseForNoWindows)
+{
+    auto &m = FileManagerWindowsManager::instance();
+    EXPECT_FALSE(m.containsCurrentUrl(QUrl(QStringLiteral("file:///tmp"))));
+}

--- a/autotests/libs/dfm-base/test_viewhintwidget.cpp
+++ b/autotests/libs/dfm-base/test_viewhintwidget.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_viewhintwidget.cpp
+ * @brief Unit tests for ViewHintWidget (viewhintwidget.cpp)
+ *
+ * ViewHintWidget is a DFloatingMessage subclass with custom icon/message
+ * setters and a custom-widget slot. Constructible in offscreen mode — no
+ * display hardware needed.
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/widgets/viewhintmessage/viewhintwidget.h>
+
+#include <QWidget>
+#include <QString>
+#include <QLabel>
+
+using namespace dfmbase;
+
+TEST(ViewHintWidgetTest, ConstructAndDestructWithoutCrash)
+{
+    {
+        ViewHintWidget w;
+        (void)w;
+    }
+    SUCCEED();
+}
+
+TEST(ViewHintWidgetTest, SetMessageUpdatesLabel)
+{
+    ViewHintWidget w;
+    w.setMessage(QStringLiteral("hello world"));
+    SUCCEED();
+}
+
+TEST(ViewHintWidgetTest, SetIconDoesNotCrash)
+{
+    ViewHintWidget w;
+    w.setIcon(QStringLiteral("dialog-warning"));
+    SUCCEED();
+}
+
+TEST(ViewHintWidgetTest, SetCustomWidgetAndRetrieve)
+{
+    ViewHintWidget w;
+    auto *custom = new QWidget();
+    w.setCustomWidget(custom);
+    EXPECT_EQ(w.customWidget(), custom);
+}
+
+TEST(ViewHintWidgetTest, ReplaceCustomWidgetDoesNotCrash)
+{
+    ViewHintWidget w;
+    auto *first = new QWidget();
+    w.setCustomWidget(first);
+    auto *second = new QWidget();
+    w.setCustomWidget(second);
+    EXPECT_EQ(w.customWidget(), second);
+}


### PR DESCRIPTION
3 个此前未测试类，17 用例，基于 master。ut-dfm-base 全量通过。Draft 模式。

## Summary by Sourcery

Add initial unit test coverage for dfm-base components that were previously untested.

Tests:
- Introduce crash-safety and basic behavior tests for DeviceWatcher without requiring real hardware or DBus.
- Add unit tests for ViewHintWidget covering message, icon, and custom widget handling.
- Add singleton and empty-state behavior tests for FileManagerWindowsManager when no windows are registered.