### PR TITLE
test(autotests): add dfm-base unit tests for CustomDIconButton, CustomDToolButton, CheckBoxWithMessage

### DIFF
--- a/autotests/libs/dfm-base/test_checkboxwithmessage.cpp
+++ b/autotests/libs/dfm-base/test_checkboxwithmessage.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_checkboxwithmessage.cpp
+ * @brief Unit tests for CheckBoxWithMessage (checkboxwithmessage.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.h>
+
+#include <QSignalSpy>
+#include <QString>
+
+TEST(CheckBoxWithMessageTest, ConstructDoesNotCrash)
+{
+    CheckBoxWithMessage w;
+    (void)w;
+}
+
+TEST(CheckBoxWithMessageTest, SetDisplayTextDoesNotCrash)
+{
+    CheckBoxWithMessage w;
+    w.setDisplayText(QStringLiteral("check me"), QStringLiteral("message text"));
+}
+
+TEST(CheckBoxWithMessageTest, SetCheckedTrueEmitsStateChanged)
+{
+    CheckBoxWithMessage w;
+    QSignalSpy spy(&w, &CheckBoxWithMessage::stateChanged);
+    w.setChecked(true);
+    EXPECT_GE(spy.count(), 1);
+}
+
+TEST(CheckBoxWithMessageTest, SetCheckedFalseDoesNotEmitWhenAlreadyUnchecked)
+{
+    CheckBoxWithMessage w;
+    QSignalSpy spy(&w, &CheckBoxWithMessage::stateChanged);
+    w.setChecked(false);   // already unchecked
+    EXPECT_EQ(spy.count(), 0);
+}

--- a/autotests/libs/dfm-base/test_customdtoolbutton.cpp
+++ b/autotests/libs/dfm-base/test_customdtoolbutton.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_customdtoolbutton.cpp
+ * @brief Unit tests for CustomDToolButton (customdtoolbutton.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/widgets/dfmcustombuttons/customdtoolbutton.h>
+
+using namespace dfmbase;
+
+TEST(CustomDToolButtonTest, ConstructDoesNotCrash)
+{
+    CustomDToolButton btn;
+    (void)btn;
+}
+
+TEST(CustomDToolButtonTest, ConstructWithParentDoesNotCrash)
+{
+    QWidget parent;
+    CustomDToolButton *btn = new CustomDToolButton(&parent);
+    EXPECT_EQ(btn->parent(), &parent);
+    delete btn;
+}
+
+TEST(CustomDToolButtonTest, SetTextDoesNotCrash)
+{
+    CustomDToolButton btn;
+    btn.setText(QStringLiteral("test"));
+    EXPECT_EQ(btn.text(), QStringLiteral("test"));
+}

--- a/autotests/libs/dfm-base/test_customiconbutton.cpp
+++ b/autotests/libs/dfm-base/test_customiconbutton.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_customiconbutton.cpp
+ * @brief Unit tests for CustomDIconButton (customiconbutton.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/widgets/dfmcustombuttons/customiconbutton.h>
+
+#include <DStyle>
+
+using namespace dfmbase;
+
+TEST(CustomDIconButtonTest, ConstructWithParentDoesNotCrash)
+{
+    CustomDIconButton btn;
+    EXPECT_TRUE(btn.isFlat());
+}
+
+TEST(CustomDIconButtonTest, ConstructWithIconTypeDoesNotCrash)
+{
+    CustomDIconButton btn(DTK_NAMESPACE::Widget::DStyle::SP_DeleteButton);
+    EXPECT_TRUE(btn.isFlat());
+}
+
+TEST(CustomDIconButtonTest, ConstructWithExplicitParentDoesNotCrash)
+{
+    QWidget parent;
+    CustomDIconButton *btn = new CustomDIconButton(&parent);
+    EXPECT_EQ(btn->parent(), &parent);
+    delete btn;
+}


### PR DESCRIPTION
3 个此前未测试 widget 类，10 用例，基于 master。ut-dfm-base 全量 1134 tests passed。Draft 模式。

## Summary by Sourcery

Add new unit tests for dfm-base UI widgets to improve coverage and basic behavior validation.

Tests:
- Add construction and state-change tests for CheckBoxWithMessage, including display text and stateChanged signal behavior.
- Add construction tests for CustomDIconButton with various constructors and verify default flat state and parent assignment.
- Add construction and text-setting tests for CustomDToolButton, including parent handling and text property verification.