### PR TITLE
ut: dfm-base SQLite 数据访问层单元测试

### DIFF
--- a/autotests/libs/dfm-base/test_sqliteexpression.cpp
+++ b/autotests/libs/dfm-base/test_sqliteexpression.cpp
@@ -1,0 +1,387 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_sqliteexpression.cpp
+ * @brief Unit tests for the pure-logic query-building helpers in
+ *        src/dfm-base/base/db/sqlitehelper.h.
+ *
+ * Covers:
+ *   - SerializationHelper::serialize / deserialize
+ *   - Expression::SetExpr / ExprField / Aggregate / Expr and all operators
+ *   - Expression::Field<T>() and aggregate factories (count/sum/avg/max/min)
+ *   - SqliteConstraint static factories
+ *   - SqliteHelper::typeString (both overloads)
+ *
+ * These helpers build SQL fragments from in-memory values; none of them touch
+ * the database, so the tests are fully deterministic and require no SQLite
+ * connection. The compile target enables -fno-access-control, which lets the
+ * tests read the protected members of SqliteConstraint to assert on the
+ * generated constraint strings.
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/base/db/sqlitehelper.h>
+
+#include <QList>
+#include <QMetaProperty>
+#include <QObject>
+#include <QString>
+#include <QVariant>
+
+using namespace dfmbase;
+using namespace dfmbase::Expression;
+
+// ---------------------------------------------------------------------------
+// SerializationHelper
+// ---------------------------------------------------------------------------
+
+TEST(SerializationHelperTest, SerializeStringWrapsValueInSingleQuotes)
+{
+    QString out;
+    EXPECT_TRUE(SerializationHelper::serialize(&out, QString("bob")));
+    EXPECT_EQ(out.toStdString(), "'bob'");
+}
+
+TEST(SerializationHelperTest, SerializeIntReturnsPlainDecimal)
+{
+    QString out;
+    EXPECT_TRUE(SerializationHelper::serialize(&out, 42));
+    EXPECT_EQ(out.toStdString(), "42");
+}
+
+TEST(SerializationHelperTest, SerializeNonConvertibleReturnsFalse)
+{
+    // QList<int> cannot be converted to QString (verified), so serialize must
+    // bail out with false and leave the output untouched.
+    QString out = "untouched";
+    QVariant bad = QVariant::fromValue(QList<int> { 1, 2, 3 });
+    EXPECT_FALSE(SerializationHelper::serialize(&out, bad));
+    EXPECT_EQ(out.toStdString(), "untouched");
+}
+
+TEST(SerializationHelperTest, DeserializePopulatesPropertiesOnQObject)
+{
+    // QObject exposes setProperty() for dynamic properties, so a plain QObject
+    // can serve as the deserialization target without a custom Q_OBJECT bean.
+    QVariantMap map;
+    map.insert("foo", 123);
+    map.insert("bar", QString("hello"));
+    QObject *bean = SerializationHelper::deserialize<QObject>(map);
+    ASSERT_NE(bean, nullptr);
+    EXPECT_EQ(bean->property("foo").toInt(), 123);
+    EXPECT_EQ(bean->property("bar").toString().toStdString(), "hello");
+    delete bean;
+}
+
+TEST(SerializationHelperTest, DeserializeEmptyMapYieldsBlankBean)
+{
+    QObject *bean = SerializationHelper::deserialize<QObject>(QVariantMap {});
+    ASSERT_NE(bean, nullptr);
+    delete bean;
+}
+
+// ---------------------------------------------------------------------------
+// Expression::SetExpr
+// ---------------------------------------------------------------------------
+
+TEST(SetExprTest, ToStringReturnsRawExpression)
+{
+    EXPECT_EQ(SetExpr("a=1").toString().toStdString(), "a=1");
+}
+
+TEST(SetExprTest, AndOperatorConcatenatesWithComma)
+{
+    SetExpr combined = SetExpr("a=1") && SetExpr("b=2");
+    EXPECT_EQ(combined.toString().toStdString(), "a=1,b=2");
+}
+
+// ---------------------------------------------------------------------------
+// Expression::ExprField
+// ---------------------------------------------------------------------------
+
+TEST(ExprFieldTest, ConstructorStoresTableNameAndFieldName)
+{
+    ExprField f("tbl", "col");
+    EXPECT_EQ(f.tableName.toStdString(), "tbl");
+    EXPECT_EQ(f.fieldName.toStdString(), "col");
+}
+
+TEST(ExprFieldTest, AssignIntValueProducesFieldEqualsDecimal)
+{
+    ExprField f("tbl", "col");
+    SetExpr se = f = QVariant(5);
+    EXPECT_EQ(se.toString().toStdString(), "col=5");
+}
+
+TEST(ExprFieldTest, AssignStringValueProducesFieldEqualsQuoted)
+{
+    ExprField f("tbl", "col");
+    SetExpr se = f = QVariant(QString("x"));
+    EXPECT_EQ(se.toString().toStdString(), "col='x'");
+}
+
+// ---------------------------------------------------------------------------
+// Expression::Aggregate
+// ---------------------------------------------------------------------------
+
+TEST(AggregateTest, FunctionOnlyConstructorStoresFunctionAsField)
+{
+    Aggregate a("COUNT");
+    EXPECT_EQ(a.fieldName.toStdString(), "COUNT");
+}
+
+TEST(AggregateTest, FunctionWithFieldConstructorStoresFunctionalCall)
+{
+    Aggregate a("MAX", "salary");
+    EXPECT_EQ(a.fieldName.toStdString(), "MAX(salary)");
+}
+
+// ---------------------------------------------------------------------------
+// Expression::Expr
+// ---------------------------------------------------------------------------
+
+TEST(ExprTest, FieldNameAndOperatorConstructor)
+{
+    EXPECT_EQ(Expr("name", "=").toString().toStdString(), "name=");
+}
+
+TEST(ExprTest, ExprFieldAndOperatorConstructorUsesFieldName)
+{
+    ExprField f("tbl", "age");
+    EXPECT_EQ(Expr(f, ">").toString().toStdString(), "age>");
+}
+
+TEST(ExprTest, FieldNameOperatorAndStringVariantValueSerializesQuoted)
+{
+    Expr e("name", "=", QVariant(QString("bob")));
+    EXPECT_EQ(e.toString().toStdString(), "name='bob'");
+}
+
+TEST(ExprTest, FieldNameOperatorAndIntVariantValueSerializesPlain)
+{
+    Expr e("age", ">", QVariant(30));
+    EXPECT_EQ(e.toString().toStdString(), "age>30");
+}
+
+TEST(ExprTest, ExprFieldOperatorAndVariantValueUsesFieldName)
+{
+    ExprField f("tbl", "age");
+    Expr e(f, ">", QVariant(30));
+    EXPECT_EQ(e.toString().toStdString(), "age>30");
+}
+
+TEST(ExprTest, AndOperatorWrapsWithAndKeyword)
+{
+    Expr left("name", "=", QVariant(QString("bob")));
+    Expr right("age", ">");
+    Expr combined = left && right;
+    EXPECT_EQ(combined.toString().toStdString(), "(name='bob' AND age>)");
+}
+
+TEST(ExprTest, OrOperatorWrapsWithOrKeyword)
+{
+    Expr left("name", "=", QVariant(QString("bob")));
+    Expr right("age", ">");
+    Expr combined = left || right;
+    EXPECT_EQ(combined.toString().toStdString(), "(name='bob' OR age>)");
+}
+
+// ---------------------------------------------------------------------------
+// Expression comparison operators (ExprField, QVariant)
+// ---------------------------------------------------------------------------
+
+TEST(ExpressionOperatorsTest, EqualityOperatorProducesEqualsComparison)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col == QVariant(1)).toString().toStdString(), "c=1");
+}
+
+TEST(ExpressionOperatorsTest, InequalityOperatorProducesNotEqualsComparison)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col != QVariant(1)).toString().toStdString(), "c!=1");
+}
+
+TEST(ExpressionOperatorsTest, GreaterThanOperatorProducesGtComparison)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col > QVariant(1)).toString().toStdString(), "c>1");
+}
+
+TEST(ExpressionOperatorsTest, LessThanOperatorProducesLtComparison)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col < QVariant(1)).toString().toStdString(), "c<1");
+}
+
+TEST(ExpressionOperatorsTest, GreaterEqualOperatorProducesGeComparison)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col >= QVariant(1)).toString().toStdString(), "c>=1");
+}
+
+TEST(ExpressionOperatorsTest, LessEqualOperatorProducesLeComparison)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col <= QVariant(1)).toString().toStdString(), "c<=1");
+}
+
+TEST(ExpressionOperatorsTest, EqualityWithNullProducesIsNull)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col == nullptr).toString().toStdString(), "c IS NULL");
+}
+
+TEST(ExpressionOperatorsTest, InequalityWithNullProducesIsNotNull)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col != nullptr).toString().toStdString(), "c IS NOT NULL");
+}
+
+TEST(ExpressionOperatorsTest, BitwiseAndOperatorProducesLike)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col & QString("a%")).toString().toStdString(), "c LIKE 'a%'");
+}
+
+TEST(ExpressionOperatorsTest, BitwiseOrOperatorProducesNotLike)
+{
+    ExprField col("t", "c");
+    EXPECT_EQ((col | QString("a%")).toString().toStdString(), "c NOT LIKE 'a%'");
+}
+
+// ---------------------------------------------------------------------------
+// Expression::Field<T>() and aggregate factories
+// ---------------------------------------------------------------------------
+
+TEST(ExpressionFactoryTest, FieldReturnsExprFieldWithBlankTable)
+{
+    ExprField f = Expression::Field<QObject>("colname");
+    EXPECT_EQ(f.tableName.toStdString(), "");
+    EXPECT_EQ(f.fieldName.toStdString(), "colname");
+}
+
+TEST(ExpressionFactoryTest, CountWithoutArgumentProducesCountStar)
+{
+    EXPECT_EQ(Expression::count().fieldName.toStdString(), "COUNT (*)");
+}
+
+TEST(ExpressionFactoryTest, CountWithArgumentProducesCountField)
+{
+    EXPECT_EQ(Expression::count("c").fieldName.toStdString(), "COUNT(c)");
+}
+
+TEST(ExpressionFactoryTest, SumFactoryProducesSumAggregate)
+{
+    EXPECT_EQ(Expression::sum("c").fieldName.toStdString(), "SUM(c)");
+}
+
+TEST(ExpressionFactoryTest, AvgFactoryProducesAvgAggregate)
+{
+    EXPECT_EQ(Expression::avg("c").fieldName.toStdString(), "AVG(c)");
+}
+
+TEST(ExpressionFactoryTest, MaxFactoryProducesMaxAggregate)
+{
+    EXPECT_EQ(Expression::max("c").fieldName.toStdString(), "MAX(c)");
+}
+
+TEST(ExpressionFactoryTest, MinFactoryProducesMinAggregate)
+{
+    EXPECT_EQ(Expression::min("c").fieldName.toStdString(), "MIN(c)");
+}
+
+// ---------------------------------------------------------------------------
+// SqliteConstraint (protected members read via -fno-access-control)
+// ---------------------------------------------------------------------------
+
+TEST(SqliteConstraintTest, PrimaryFactoryProducesPrimaryKeyConstraint)
+{
+    auto c = SqliteConstraint::primary("id");
+    EXPECT_EQ(c.field.toStdString(), "id");
+    EXPECT_EQ(c.constraint.toStdString(), " PRIMARY KEY");
+}
+
+TEST(SqliteConstraintTest, AutoIncreamentFactoryProducesAutoincrementConstraint)
+{
+    auto c = SqliteConstraint::autoIncreament("id");
+    EXPECT_EQ(c.field.toStdString(), "id");
+    EXPECT_EQ(c.constraint.toStdString(), " AUTOINCREMENT");
+}
+
+TEST(SqliteConstraintTest, NullableFactoryProducesNullableConstraint)
+{
+    auto c = SqliteConstraint::nullable("id");
+    EXPECT_EQ(c.field.toStdString(), "id");
+    EXPECT_EQ(c.constraint.toStdString(), "NULLABLE");
+}
+
+TEST(SqliteConstraintTest, UniqueFactoryProducesUniqueConstraint)
+{
+    auto c = SqliteConstraint::unique("id");
+    EXPECT_TRUE(c.field.isEmpty());
+    EXPECT_EQ(c.constraint.toStdString(), "UNIQUE (id)");
+}
+
+TEST(SqliteConstraintTest, DefaultValueWithIntProducesDefaultConstraint)
+{
+    auto c = SqliteConstraint::defaultValue("id", 0);
+    EXPECT_EQ(c.field.toStdString(), "id");
+    EXPECT_EQ(c.constraint.toStdString(), " DEFAULT 0");
+}
+
+TEST(SqliteConstraintTest, DefaultValueWithStringProducesQuotedDefaultConstraint)
+{
+    auto c = SqliteConstraint::defaultValue("name", QString("x"));
+    EXPECT_EQ(c.field.toStdString(), "name");
+    EXPECT_EQ(c.constraint.toStdString(), " DEFAULT 'x'");
+}
+
+TEST(SqliteConstraintTest, CheckFactoryProducesCheckConstraint)
+{
+    auto c = SqliteConstraint::check(Expr("age", ">", QVariant(0)));
+    EXPECT_TRUE(c.field.isEmpty());
+    EXPECT_EQ(c.constraint.toStdString(), "CHECK (age>0)");
+}
+
+// ---------------------------------------------------------------------------
+// SqliteHelper::typeString
+// ---------------------------------------------------------------------------
+
+TEST(SqliteHelperTypeStringTest, VariantTypeIntMapsToIntegerNotNull)
+{
+    EXPECT_EQ(SqliteHelper::typeString(QVariant::Int).toStdString(), " INTEGER NOT NULL");
+}
+
+TEST(SqliteHelperTypeStringTest, VariantTypeBoolMapsToIntegerNotNull)
+{
+    EXPECT_EQ(SqliteHelper::typeString(QVariant::Bool).toStdString(), " INTEGER NOT NULL");
+}
+
+TEST(SqliteHelperTypeStringTest, VariantTypeDoubleMapsToRealNotNull)
+{
+    EXPECT_EQ(SqliteHelper::typeString(QVariant::Double).toStdString(), " REAL NOT NULL");
+}
+
+TEST(SqliteHelperTypeStringTest, VariantTypeStringMapsToTextNotNull)
+{
+    EXPECT_EQ(SqliteHelper::typeString(QVariant::String).toStdString(), " TEXT NOT NULL");
+}
+
+TEST(SqliteHelperTypeStringTest, InvalidMetaPropertyReturnsEmpty)
+{
+    QMetaProperty invalid;
+    EXPECT_TRUE(SqliteHelper::typeString(invalid).isEmpty());
+}
+
+TEST(SqliteHelperTypeStringTest, ObjectNameMetaPropertyMapsToTextNotNull)
+{
+    // QObject::objectName is a valid String-typed meta-property.
+    QMetaProperty objectName = QObject::staticMetaObject.property(0);
+    ASSERT_FALSE(objectName.name() == nullptr);
+    EXPECT_EQ(std::string(objectName.name()), "objectName");
+    EXPECT_EQ(SqliteHelper::typeString(objectName).toStdString(), " TEXT NOT NULL");
+}

--- a/autotests/libs/dfm-base/test_sqlitequeryable.cpp
+++ b/autotests/libs/dfm-base/test_sqlitequeryable.cpp
@@ -1,0 +1,472 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_sqlitequeryable.cpp
+ * @brief Unit tests for the SQLite data-access layer in
+ *        src/dfm-base/base/db/{sqlitequeryable,sqlitehandle,sqlitehelper}.h.
+ *
+ * Covers:
+ *   - SqliteQueryable<T> query-builder chain (distinct/where/groupBy/having/
+ *     take/skip/orderBy/orderByDescending) and execution (toMaps/toMap/
+ *     toBeans/toBean/aggregate) plus private helpers getFromSql/getLimit/
+ *     queryToMaps.
+ *   - SqliteHelper statics: tableName/visit/fieldNames/fieldTypesMap/
+ *     parseConstraint/excute.
+ *   - SqliteHandle CRUD: transaction/createTable/dropTable/insert/update/
+ *     query/remove (both overloads)/excute/lastQuery.
+ *
+ * The build target enables -fno-access-control, so the builder tests can read
+ * the private SQL-fragment members of SqliteQueryable directly. A tiny
+ * Q_OBJECT bean (UtQueryableBean) is defined in this translation unit and
+ * moc'd via the trailing #include of the generated moc file.
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/base/db/sqliteconnectionpool.h>
+#include <dfm-base/base/db/sqlitehandle.h>
+#include <dfm-base/base/db/sqlitehelper.h>
+#include <dfm-base/base/db/sqlitequeryable.h>
+
+#include <QHash>
+#include <QList>
+#include <QMetaProperty>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QString>
+#include <QStringList>
+#include <QTemporaryDir>
+#include <QVariant>
+#include <QVariantMap>
+
+#include "ut_sqlitebean.h"
+
+using namespace dfmbase;
+using namespace dfmbase::Expression;
+
+// ---------------------------------------------------------------------------
+// Fixture: a fresh on-disk database per test.
+// ---------------------------------------------------------------------------
+
+class SqliteQueryableTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmpDir.isValid());
+        dbPath = tmpDir.path() + "/ut_queryable.db";
+    }
+    QTemporaryDir tmpDir;
+    QString dbPath;
+};
+
+// ---------------------------------------------------------------------------
+// SqliteQueryable<T> builder chain (private members read via -fno-access-control)
+// ---------------------------------------------------------------------------
+
+TEST_F(SqliteQueryableTest, DistinctBuilderSetsSelectDistinct)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.disctinct();
+    EXPECT_EQ(q.sqlSelect.toStdString(), "SELECT DISTINCT ");
+}
+
+TEST_F(SqliteQueryableTest, WhereBuilderSerializesWhereExpression)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    ExprField col = Field<UtQueryableBean>("name");
+    q.where(col == QVariant(QString("alice")));
+    EXPECT_EQ(q.sqlWhere.toStdString(), " WHERE name='alice'");
+}
+
+TEST_F(SqliteQueryableTest, GroupByBuilderAppendsGroupByClause)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.groupBy(Field<UtQueryableBean>("name"));
+    EXPECT_EQ(q.sqlGroupBy.toStdString(), " GROUP BY name");
+}
+
+TEST_F(SqliteQueryableTest, HavingBuilderAppendsHavingClause)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.having(Field<UtQueryableBean>("name") == QVariant(QString("alice")));
+    EXPECT_EQ(q.sqlHaving.toStdString(), " HAVING name='alice'");
+}
+
+TEST_F(SqliteQueryableTest, TakeBuilderSetsLimit)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.take(5);
+    EXPECT_EQ(q.sqlLimit.toStdString(), " LIMIT 5");
+}
+
+TEST_F(SqliteQueryableTest, SkipBuilderSetsOffsetAndInfiniteLimitWhenEmpty)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.skip(3);
+    EXPECT_EQ(q.sqlLimit.toStdString(), " LIMIT ~0");
+    EXPECT_EQ(q.sqlOffset.toStdString(), " OFFSET 3");
+}
+
+TEST_F(SqliteQueryableTest, SkipAfterTakePreservesTakeLimit)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.take(5).skip(2);
+    EXPECT_EQ(q.sqlLimit.toStdString(), " LIMIT 5");
+    EXPECT_EQ(q.sqlOffset.toStdString(), " OFFSET 2");
+}
+
+TEST_F(SqliteQueryableTest, OrderByBuilderSetsOrderByAscending)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.orderBy(Field<UtQueryableBean>("name"));
+    EXPECT_EQ(q.sqlOrderBy.toStdString(), " ORDER BY name");
+}
+
+TEST_F(SqliteQueryableTest, OrderByBuilderAppendsSecondFieldWithComma)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.orderBy(Field<UtQueryableBean>("name")).orderBy(Field<UtQueryableBean>("id"));
+    EXPECT_EQ(q.sqlOrderBy.toStdString(), " ORDER BY name,id");
+}
+
+TEST_F(SqliteQueryableTest, OrderByDescendingBuilderSetsOrderByDesc)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.orderByDescending(Field<UtQueryableBean>("name"));
+    EXPECT_EQ(q.sqlOrderBy.toStdString(), " ORDER BY name DESC");
+}
+
+TEST_F(SqliteQueryableTest, OrderByDescendingBuilderAppendsSecondFieldDesc)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.orderByDescending(Field<UtQueryableBean>("name"))
+            .orderByDescending(Field<UtQueryableBean>("id"));
+    EXPECT_EQ(q.sqlOrderBy.toStdString(), " ORDER BY name DESC,id DESC");
+}
+
+TEST_F(SqliteQueryableTest, PrivateFromSqlAssemblesFromWhereGroupByHaving)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable", "SELECT ", "*", " WHERE id>0");
+    EXPECT_EQ(q.getFromSql().toStdString(), " FROM ut_queryable WHERE id>0");
+}
+
+TEST_F(SqliteQueryableTest, PrivateLimitAssemblesOrderByLimitOffset)
+{
+    SqliteQueryable<UtQueryableBean> q(dbPath, " FROM ut_queryable");
+    q.orderBy(Field<UtQueryableBean>("name")).take(10).skip(2);
+    EXPECT_EQ(q.getLimit().toStdString(), " ORDER BY name LIMIT 10 OFFSET 2");
+}
+
+// ---------------------------------------------------------------------------
+// SqliteHelper statics (bean-aware)
+// ---------------------------------------------------------------------------
+
+TEST_F(SqliteQueryableTest, TableNameReturnsClassInfoValue)
+{
+    EXPECT_EQ(SqliteHelper::tableName<UtQueryableBean>().toStdString(), "ut_queryable");
+}
+
+TEST_F(SqliteQueryableTest, FieldNamesExcludesObjectName)
+{
+    QStringList names = SqliteHelper::fieldNames<UtQueryableBean>();
+    ASSERT_EQ(names.size(), 2);
+    EXPECT_EQ(names[0].toStdString(), "id");
+    EXPECT_EQ(names[1].toStdString(), "name");
+}
+
+TEST_F(SqliteQueryableTest, VisitInvokesCallbackPerProperty)
+{
+    int count = 0;
+    SqliteHelper::visit<UtQueryableBean>([&count](const QMetaProperty &) { ++count; });
+    // objectName + id + name
+    EXPECT_EQ(count, 3);
+}
+
+TEST_F(SqliteQueryableTest, FieldTypesMapMapsFieldsToSqlTypes)
+{
+    QStringList fields = SqliteHelper::fieldNames<UtQueryableBean>();
+    QHash<QString, QString> map;
+    SqliteHelper::fieldTypesMap<UtQueryableBean>(fields, &map);
+    EXPECT_EQ(map.size(), 2);
+    EXPECT_EQ(map.value("id").toStdString(), " INTEGER NOT NULL");
+    EXPECT_EQ(map.value("name").toStdString(), " TEXT NOT NULL");
+}
+
+TEST_F(SqliteQueryableTest, ParseConstraintEmptyBaseCaseIsNoop)
+{
+    QString tableFixes;
+    QHash<QString, QString> fieldFixes;
+    SqliteHelper::parseConstraint(&tableFixes, &fieldFixes);
+    EXPECT_TRUE(tableFixes.isEmpty());
+    EXPECT_TRUE(fieldFixes.isEmpty());
+}
+
+TEST_F(SqliteQueryableTest, ParseConstraintPrimaryKeyModifiesField)
+{
+    QString tableFixes;
+    QHash<QString, QString> fieldFixes;
+    fieldFixes.insert("id", " INTEGER NOT NULL");
+    fieldFixes.insert("name", " TEXT NOT NULL");
+    SqliteHelper::parseConstraint(&tableFixes, &fieldFixes, SqliteConstraint::primary("id"));
+    EXPECT_EQ(fieldFixes.value("id").toStdString(), " INTEGER PRIMARY KEY");
+    EXPECT_TRUE(tableFixes.isEmpty());
+}
+
+TEST_F(SqliteQueryableTest, ParseConstraintUniqueAppendsTableFix)
+{
+    QString tableFixes;
+    QHash<QString, QString> fieldFixes;
+    fieldFixes.insert("id", " INTEGER NOT NULL");
+    SqliteHelper::parseConstraint(&tableFixes, &fieldFixes, SqliteConstraint::unique("id"));
+    EXPECT_EQ(tableFixes.toStdString(), "UNIQUE (id),");
+}
+
+TEST_F(SqliteQueryableTest, ParseConstraintNullableRelaxesNotNull)
+{
+    QString tableFixes;
+    QHash<QString, QString> fieldFixes;
+    fieldFixes.insert("name", " TEXT NOT NULL");
+    SqliteHelper::parseConstraint(&tableFixes, &fieldFixes, SqliteConstraint::nullable("name"));
+    // NULLABLE removes " NOT NULL" and is NOT appended.
+    EXPECT_EQ(fieldFixes.value("name").toStdString(), " TEXT");
+    EXPECT_TRUE(tableFixes.isEmpty());
+}
+
+TEST_F(SqliteQueryableTest, ExcuteValidSqlReturnsTrueAndInvokesCallback)
+{
+    QString lastQuery;
+    bool callbackCalled = false;
+    EXPECT_TRUE(SqliteHelper::excute(dbPath, "CREATE TABLE ut_helper (x INTEGER);",
+                                    &lastQuery,
+                                    [&callbackCalled](QSqlQuery *) { callbackCalled = true; }));
+    EXPECT_TRUE(callbackCalled);
+}
+
+TEST_F(SqliteQueryableTest, ExcuteInvalidSqlReturnsFalse)
+{
+    EXPECT_FALSE(SqliteHelper::excute(dbPath, "THIS IS NOT SQL;"));
+}
+
+TEST_F(SqliteQueryableTest, ExcuteWithDefaultArgsRunsValidSql)
+{
+    EXPECT_TRUE(SqliteHelper::excute(dbPath, "CREATE TABLE ut_helper2 (x INTEGER);"));
+}
+
+// ---------------------------------------------------------------------------
+// SqliteHandle CRUD round-trip on a real database
+// ---------------------------------------------------------------------------
+
+TEST_F(SqliteQueryableTest, HandleCreatesAndDropsTable)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    ASSERT_TRUE(handle.dropTable<UtQueryableBean>());
+}
+
+TEST_F(SqliteQueryableTest, InsertAutoPkReturnsLastInsertId)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean bean;
+    bean.setName("alice");
+    int id = handle.insert<UtQueryableBean>(bean);
+    EXPECT_GT(id, 0);
+}
+
+TEST_F(SqliteQueryableTest, InsertCustomPkIncludesPrimaryKey)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean bean;
+    bean.setId(100);
+    bean.setName("bob");
+    int id = handle.insert<UtQueryableBean>(bean, /*customPK=*/true);
+    EXPECT_EQ(id, 100);
+}
+
+TEST_F(SqliteQueryableTest, QueryToMapsReturnsAllRows)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b1;
+    b1.setName("alice");
+    handle.insert<UtQueryableBean>(b1);
+    UtQueryableBean b2;
+    b2.setName("bob");
+    handle.insert<UtQueryableBean>(b2);
+
+    QList<QVariantMap> maps = handle.query<UtQueryableBean>().toMaps();
+    ASSERT_EQ(maps.size(), 2);
+    EXPECT_EQ(maps[0].value("name").toString().toStdString(), "alice");
+    EXPECT_EQ(maps[1].value("name").toString().toStdString(), "bob");
+}
+
+TEST_F(SqliteQueryableTest, QueryToMapReturnsFirstRow)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b;
+    b.setName("alice");
+    handle.insert<UtQueryableBean>(b);
+
+    QVariantMap m = handle.query<UtQueryableBean>().toMap();
+    ASSERT_FALSE(m.isEmpty());
+    EXPECT_EQ(m.value("name").toString().toStdString(), "alice");
+}
+
+TEST_F(SqliteQueryableTest, QueryToMapOnEmptyTableReturnsEmptyMap)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    QVariantMap m = handle.query<UtQueryableBean>().toMap();
+    EXPECT_TRUE(m.isEmpty());
+}
+
+TEST_F(SqliteQueryableTest, QueryToBeansDeserializesRows)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b1;
+    b1.setName("alice");
+    handle.insert<UtQueryableBean>(b1);
+    UtQueryableBean b2;
+    b2.setName("bob");
+    handle.insert<UtQueryableBean>(b2);
+
+    QList<QSharedPointer<UtQueryableBean>> beans = handle.query<UtQueryableBean>().toBeans();
+    ASSERT_EQ(beans.size(), 2);
+    EXPECT_EQ(beans[0]->name().toStdString(), "alice");
+    EXPECT_EQ(beans[1]->name().toStdString(), "bob");
+}
+
+TEST_F(SqliteQueryableTest, QueryToBeanReturnsFirstBean)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b;
+    b.setName("alice");
+    handle.insert<UtQueryableBean>(b);
+
+    QSharedPointer<UtQueryableBean> bean = handle.query<UtQueryableBean>().toBean();
+    ASSERT_NE(bean, nullptr);
+    EXPECT_EQ(bean->name().toStdString(), "alice");
+}
+
+TEST_F(SqliteQueryableTest, QueryToBeanOnEmptyTableReturnsNull)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    QSharedPointer<UtQueryableBean> bean = handle.query<UtQueryableBean>().toBean();
+    EXPECT_EQ(bean, nullptr);
+}
+
+TEST_F(SqliteQueryableTest, AggregateCountReturnsRowCount)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean empty;
+    handle.insert<UtQueryableBean>(empty);   // name empty
+    UtQueryableBean b;
+    b.setName("x");
+    handle.insert<UtQueryableBean>(b);
+
+    QVariant result = handle.query<UtQueryableBean>().aggregate(Expression::count());
+    EXPECT_EQ(result.toInt(), 2);
+}
+
+TEST_F(SqliteQueryableTest, QueryWithWhereFiltersRows)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b1;
+    b1.setName("alice");
+    handle.insert<UtQueryableBean>(b1);
+    UtQueryableBean b2;
+    b2.setName("bob");
+    handle.insert<UtQueryableBean>(b2);
+
+    QList<QVariantMap> maps = handle.query<UtQueryableBean>()
+                                       .where(Field<UtQueryableBean>("name") == QVariant(QString("bob")))
+                                       .toMaps();
+    ASSERT_EQ(maps.size(), 1);
+    EXPECT_EQ(maps[0].value("name").toString().toStdString(), "bob");
+}
+
+TEST_F(SqliteQueryableTest, UpdateModifiesMatchingRow)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b;
+    b.setName("alice");
+    int id = handle.insert<UtQueryableBean>(b);
+    ASSERT_GT(id, 0);
+
+    ASSERT_TRUE(handle.update<UtQueryableBean>(
+            SetExpr("name='alice2'"), Expr(Field<UtQueryableBean>("id"), "=", QVariant(id))));
+
+    QList<QVariantMap> maps = handle.query<UtQueryableBean>()
+                                       .where(Field<UtQueryableBean>("id") == QVariant(id))
+                                       .toMaps();
+    ASSERT_EQ(maps.size(), 1);
+    EXPECT_EQ(maps[0].value("name").toString().toStdString(), "alice2");
+}
+
+TEST_F(SqliteQueryableTest, RemoveByEntityDeletesRow)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b1;
+    b1.setName("alice");
+    int id1 = handle.insert<UtQueryableBean>(b1);
+    UtQueryableBean b2;
+    b2.setName("bob");
+    handle.insert<UtQueryableBean>(b2);
+
+    UtQueryableBean rm;
+    rm.setId(id1);
+    ASSERT_TRUE(handle.remove<UtQueryableBean>(rm));
+
+    EXPECT_EQ(handle.query<UtQueryableBean>().aggregate(Expression::count()).toInt(), 1);
+}
+
+TEST_F(SqliteQueryableTest, RemoveByExprDeletesMatchingRows)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    UtQueryableBean b1;
+    b1.setName("alice");
+    handle.insert<UtQueryableBean>(b1);
+    UtQueryableBean b2;
+    b2.setName("bob");
+    handle.insert<UtQueryableBean>(b2);
+
+    ASSERT_TRUE(handle.remove<UtQueryableBean>(
+            Field<UtQueryableBean>("name") == QVariant(QString("alice"))));
+
+    EXPECT_EQ(handle.query<UtQueryableBean>().aggregate(Expression::count()).toInt(), 1);
+}
+
+TEST_F(SqliteQueryableTest, TransactionCommitReturnsTrueWhenFuncSucceeds)
+{
+    SqliteHandle handle(dbPath);
+    EXPECT_TRUE(handle.transaction([] { return true; }));
+}
+
+TEST_F(SqliteQueryableTest, TransactionRollbackPathWhenFuncFails)
+{
+    SqliteHandle handle(dbPath);
+    // rollback() succeeds and returns true when there is an active transaction.
+    EXPECT_TRUE(handle.transaction([] { return false; }));
+}
+
+TEST_F(SqliteQueryableTest, LastQueryReflectsMostRecentSql)
+{
+    SqliteHandle handle(dbPath);
+    ASSERT_TRUE(handle.createTable<UtQueryableBean>(SqliteConstraint::primary("id")));
+    EXPECT_FALSE(handle.lastQuery().isEmpty());
+    EXPECT_TRUE(handle.lastQuery().contains("CREATE TABLE"));
+}

--- a/autotests/libs/dfm-base/ut_sqlitebean.h
+++ b/autotests/libs/dfm-base/ut_sqlitebean.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef UT_SQLITEBEAN_H
+#define UT_SQLITEBEAN_H
+
+#include <QObject>
+#include <QString>
+
+/**
+ * @brief Minimal QObject bean used by test_sqlitequeryable.cpp to exercise the
+ *        dfm-base SQLite data-access layer (SqliteHelper / SqliteQueryable /
+ *        SqliteHandle). Declares a TableName classinfo and two Q_PROPERTY
+ *        columns so the meta-object-driven helpers (tableName / fieldNames /
+ *        fieldTypesMap / insert / remove) have something to reflect over.
+ */
+class UtQueryableBean : public QObject
+{
+    Q_OBJECT
+    Q_CLASSINFO("TableName", "ut_queryable")
+    Q_PROPERTY(int id READ id WRITE setId)
+    Q_PROPERTY(QString name READ name WRITE setName)
+public:
+    explicit UtQueryableBean(QObject *parent = nullptr)
+        : QObject(parent) {}
+    int id() const { return m_id; }
+    void setId(int v) { m_id = v; }
+    QString name() const { return m_name; }
+    void setName(const QString &v) { m_name = v; }
+private:
+    int m_id = 0;
+    QString m_name;
+};
+
+#endif   // UT_SQLITEBEAN_H


### PR DESCRIPTION
## 概述

为 `dfm-base` 的 SQLite 数据访问层补充单元测试。这些类（`src/dfm-base/base/db/` 下的 `sqlitehelper.h` / `sqlitequeryable.h` / `sqlitehandle.h`）此前没有任何对应的测试文件。

## 覆盖类（6）

| 类 | 测试文件 | 用例数 | 说明 |
|---|---|---|---|
| SerializationHelper | test_sqliteexpression.cpp | 5 | serialize/deserialize，含不可转换类型分支 |
| Expression (SetExpr/ExprField/Aggregate/Expr + 运算符 + 工厂) | test_sqliteexpression.cpp | 26 | 纯逻辑 SQL 片段构建，全部确定性断言 |
| SqliteConstraint | test_sqliteexpression.cpp | 7 | 6 个静态工厂 + protected 成员经 -fno-access-control 校验 |
| SqliteHelper | test_sqlitequeryable.cpp | 11 | tableName/visit/fieldNames/fieldTypesMap/parseConstraint/typeString/excute |
| SqliteQueryable | test_sqlitequeryable.cpp | 13 | builder 链 (distinct/where/groupBy/having/take/skip/orderBy) + 执行 (toMaps/toMap/toBeans/toBean/aggregate) |
| SqliteHandle | test_sqlitequeryable.cpp | 12 | transaction/createTable/dropTable/insert/update/query/remove/excute/lastQuery |

## 验证

- **编译**：`ut-dfm-base` 目标 0 error（仅 deprecation 警告，源自被测源码本身使用 `QVariant::Type`）
- **运行**：90/90 新增用例通过；完整 `ut-dfm-base` 套件 1224/1224 通过，无回归
- DB 用例使用 `SqliteConnectionPool` 创建临时在盘 SQLite 数据库做真实往返；纯逻辑用例无 DB 依赖

## 文件

- `autotests/libs/dfm-base/test_sqliteexpression.cpp`（纯逻辑，无 DB）
- `autotests/libs/dfm-base/test_sqlitequeryable.cpp`（真实 SQLite 往返）
- `autotests/libs/dfm-base/ut_sqlitebean.h`（Q_OBJECT 测试 bean）

仅新增测试文件，未修改任何源码或已有 CMake（`autotests/libs/dfm-base/CMakeLists.txt` 的 `GLOB_RECURSE` 自动发现新文件）。

## Summary by Sourcery

Add comprehensive unit tests for the dfm-base SQLite data-access layer and its expression helpers using real SQLite round-trips and pure logic assertions.

Tests:
- Introduce test_sqlitequeryable.cpp to cover SqliteQueryable builder chains, SqliteHelper statics, and SqliteHandle CRUD operations against a temporary on-disk SQLite database.
- Introduce test_sqliteexpression.cpp to validate SerializationHelper, Expression helpers, SqliteConstraint factories, and SqliteHelper typeString without any DB dependency.
- Add UtQueryableBean QObject test fixture to support meta-object-driven SQLite helper and queryable tests.