### PR TITLE
fix(smb): preserve '#' in SMB share names during CIFS mount

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -578,7 +578,10 @@ void DeviceManager::unmountProtocolDevAsync(const QString &id, const QVariantMap
 void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType1 cb, int timeout)
 {
     //    Q_ASSERT(qApp->thread() == QThread::currentThread());
-    Q_ASSERT_X(!address.isEmpty(), __FUNCTION__, "address is emtpy");
+    if (address.isEmpty()) {
+        qCWarning(logDFMBase) << "mountNetworkDeviceAsync: address is empty";
+        return;
+    }
     QUrl u(address);
     if (!u.isValid()) {
         qCWarning(logDFMBase) << "url is not valid: " << u << address;

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
@@ -44,8 +44,13 @@ void travers_prehandler::networkAccessPrehandler(quint64 winId, const QUrl &url,
     QUrl netUrl = url;
     if (url.hasFragment()) {
         netUrl = url.adjusted(QUrl::RemoveFragment);
-        // # 标识片段起始，后面的内容被分配到了fragment字段中
-        auto path = url.path() + '#' + url.fragment(QUrl::FullyDecoded);
+        // '#' 标识片段起始，后面的内容被分配到了fragment字段中。
+        // 当 '#' 紧跟 host（如 smb://1.2.3.4#share/）时 url.path() 为空，
+        // 此时需补前导 '/'，否则 QUrl::setPath 会生成无效 URL（toString 返回空串）。
+        auto path = url.path();
+        if (path.isEmpty())
+            path = "/";
+        path = path + '#' + url.fragment(QUrl::FullyDecoded);
         netUrl.setPath(path);
         fmInfo() << "networkAccessPrehandler: converted fragment into path."
                  << "oldUrl: " << url

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.cpp
@@ -72,7 +72,10 @@ bool isSmbMounted(const QString &stdSmb)
 {
     using namespace protocol_display_utilities;
     const QStringList &mountedSmbs = getStandardSmbPaths(getMountedSmb());
-    QString currSmbPath = stdSmb.toLower();
+    // getStandardSmbPath 返回的路径经过 QUrl::fromPercentEncoding 解码（如 %23 -> #），
+    // 而传入的 stdSmb 可能是 QUrl::toString() 的百分号编码形式。
+    // 为确保编码一致，需对 stdSmb 也进行解码后再比较。
+    QString currSmbPath = QUrl::fromPercentEncoding(stdSmb.toLocal8Bit()).toLower();
     if (!currSmbPath.endsWith("/"))
         currSmbPath.append("/");
     return mountedSmbs.contains(currSmbPath);
@@ -81,7 +84,7 @@ bool isSmbMounted(const QString &stdSmb)
 QString getDeviceIdByStdSmb(const QString &stdSmb)
 {
     using namespace protocol_display_utilities;
-    QString smb = stdSmb.toLower();
+    QString smb = QUrl::fromPercentEncoding(stdSmb.toLocal8Bit()).toLower();
     if (!smb.endsWith("/"))
         smb.append("/");
 

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -36,6 +36,20 @@ SERVICEMOUNTCONTROL_USE_NAMESPACE
 
 static constexpr char kPolicyKitActionIdCIFS[] { "org.deepin.Filemanager.MountController.CIFS" };
 
+// SMB share names may legally contain '#', but QUrl treats '#' as a fragment delimiter and
+// truncates it from smbUrl.path(), so the kernel mount UNC would lose the '#' and target a
+// non-existent share (BUG-373045). Merge any fragment back into the path to preserve the
+// share name. This is a no-op for URLs without a fragment, including the already-percent-
+// encoded form produced by networkAccessPrehandler (BUG-337999's fix) and '%20'-style
+// encoded paths, so existing behavior (and the BUG-337999 fix) is unchanged.
+static QUrl mergedSmbUrl(const QString &path)
+{
+    QUrl url(path);
+    if (url.hasFragment())
+        url.setPath(url.path() + '#' + url.fragment(QUrl::FullyDecoded));
+    return url;
+}
+
 CifsMountHelper::CifsMountHelper(QDBusContext *context)
     : AbstractMountHelper(context), d(new CifsMountHelperPrivate()) { }
 
@@ -50,7 +64,7 @@ QVariantMap CifsMountHelper::mount(const QString &path, const QVariantMap &opts)
                  { kErrorMessage, "smb is only supported scheme now" } };
     }
 
-    QUrl smbUrl(path);
+    QUrl smbUrl = mergedSmbUrl(path);
     int port = smbUrl.port();
     const QString &share = smbUrl.path();
     const QString &host = smbUrl.host();
@@ -160,7 +174,7 @@ QVariantMap CifsMountHelper::unmount(const QString &path, const QVariantMap &opt
     Q_UNUSED(opts);
     using namespace MountReturnField;
 
-    QUrl smbUrl(path);
+    QUrl smbUrl = mergedSmbUrl(path);
     QString aPath = QString("//%1%2").arg(smbUrl.host()).arg(smbUrl.path());
 
     QString mpt;
@@ -249,7 +263,7 @@ QString CifsMountHelper::generateMountPath(const QString &address)
         return "";
 
     // assume that all address is like 'smb://1.2.3.4/share'
-    QUrl smbUrl(address);
+    QUrl smbUrl = mergedSmbUrl(address);
     QString host = smbUrl.host();
     QString path = smbUrl.path().mid(1);   // remove first /
     int port = smbUrl.port();

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -42,11 +42,20 @@ static constexpr char kPolicyKitActionIdCIFS[] { "org.deepin.Filemanager.MountCo
 // share name. This is a no-op for URLs without a fragment, including the already-percent-
 // encoded form produced by networkAccessPrehandler (BUG-337999's fix) and '%20'-style
 // encoded paths, so existing behavior (and the BUG-337999 fix) is unchanged.
+//
+// 当 '#' 紧跟 host（如 smb://1.2.3.4#share/）时 url.path() 为空，需补前导 '/'
+// 否则 QUrl::setPath 会生成无效 URL。同时合并 fragment 后需清除旧 fragment，
+// 否则 URL 会同时包含合并后的 path 和旧 fragment。
 static QUrl mergedSmbUrl(const QString &path)
 {
     QUrl url(path);
-    if (url.hasFragment())
-        url.setPath(url.path() + '#' + url.fragment(QUrl::FullyDecoded));
+    if (url.hasFragment()) {
+        auto p = url.path();
+        if (p.isEmpty())
+            p = "/";
+        url.setPath(p + '#' + url.fragment(QUrl::FullyDecoded));
+        url.setFragment({});
+    }
     return url;
 }
 


### PR DESCRIPTION
Merge URL fragment back into the path before building the kernel mount
UNC, so share names containing '#' are no longer truncated by QUrl.

在 CIFS 挂载/卸载/挂载点生成前将 URL fragment 合并回 path，避免 QUrl
把共享名中的 '#' 当作片段分隔符截断，导致内核挂载 UNC 丢失 '#' 而访问
到不存在的共享。

Log: 修复共享名含 '#' 时无法访问共享文件夹的问题
PMS: BUG-373045
Influence: 共享名含 '#' 等被 QUrl 视为 fragment 的字符时，挂载/卸载/
挂载点目录名均保留完整共享名，访问不再失败；不含此类字符的共享行为不变，
且不破坏 bug-337999 的 fragment 合并修复。

## Summary by Sourcery

Bug Fixes:
- Fix CIFS mounts failing when SMB share names contain '#' or other characters treated as URL fragments by QUrl, ensuring the kernel UNC and mount paths use the full share name.