### PR TITLE
fix: handle empty address in mount and SMB URL fragment

### DIFF
--- a/src/dfm-base/base/device/devicemanager.cpp
+++ b/src/dfm-base/base/device/devicemanager.cpp
@@ -578,7 +578,10 @@ void DeviceManager::unmountProtocolDevAsync(const QString &id, const QVariantMap
 void DeviceManager::mountNetworkDeviceAsync(const QString &address, CallbackType1 cb, int timeout)
 {
     //    Q_ASSERT(qApp->thread() == QThread::currentThread());
-    Q_ASSERT_X(!address.isEmpty(), __FUNCTION__, "address is emtpy");
+    if (address.isEmpty()) {
+        qCWarning(logDFMBase) << "mountNetworkDeviceAsync: address is empty";
+        return;
+    }
     QUrl u(address);
     if (!u.isValid()) {
         qCWarning(logDFMBase) << "url is not valid: " << u << address;

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/events/traversprehandler.cpp
@@ -44,8 +44,13 @@ void travers_prehandler::networkAccessPrehandler(quint64 winId, const QUrl &url,
     QUrl netUrl = url;
     if (url.hasFragment()) {
         netUrl = url.adjusted(QUrl::RemoveFragment);
-        // # 标识片段起始，后面的内容被分配到了fragment字段中
-        auto path = url.path() + '#' + url.fragment(QUrl::FullyDecoded);
+        // '#' 标识片段起始，后面的内容被分配到了fragment字段中。
+        // 当 '#' 紧跟 host（如 smb://1.2.3.4#share/）时 url.path() 为空，
+        // 此时需补前导 '/'，否则 QUrl::setPath 会生成无效 URL（toString 返回空串）。
+        auto path = url.path();
+        if (path.isEmpty())
+            path = "/";
+        path = path + '#' + url.fragment(QUrl::FullyDecoded);
         netUrl.setPath(path);
         fmInfo() << "networkAccessPrehandler: converted fragment into path."
                  << "oldUrl: " << url

--- a/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-smbbrowser/utils/smbbrowserutils.cpp
@@ -72,7 +72,10 @@ bool isSmbMounted(const QString &stdSmb)
 {
     using namespace protocol_display_utilities;
     const QStringList &mountedSmbs = getStandardSmbPaths(getMountedSmb());
-    QString currSmbPath = stdSmb.toLower();
+    // getStandardSmbPath 返回的路径经过 QUrl::fromPercentEncoding 解码（如 %23 -> #），
+    // 而传入的 stdSmb 可能是 QUrl::toString() 的百分号编码形式。
+    // 为确保编码一致，需对 stdSmb 也进行解码后再比较。
+    QString currSmbPath = QUrl::fromPercentEncoding(stdSmb.toLocal8Bit()).toLower();
     if (!currSmbPath.endsWith("/"))
         currSmbPath.append("/");
     return mountedSmbs.contains(currSmbPath);
@@ -81,7 +84,7 @@ bool isSmbMounted(const QString &stdSmb)
 QString getDeviceIdByStdSmb(const QString &stdSmb)
 {
     using namespace protocol_display_utilities;
-    QString smb = stdSmb.toLower();
+    QString smb = QUrl::fromPercentEncoding(stdSmb.toLocal8Bit()).toLower();
     if (!smb.endsWith("/"))
         smb.append("/");
 

--- a/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
+++ b/src/services/mountcontrol/mounthelpers/cifsmounthelper.cpp
@@ -42,11 +42,20 @@ static constexpr char kPolicyKitActionIdCIFS[] { "org.deepin.Filemanager.MountCo
 // share name. This is a no-op for URLs without a fragment, including the already-percent-
 // encoded form produced by networkAccessPrehandler (BUG-337999's fix) and '%20'-style
 // encoded paths, so existing behavior (and the BUG-337999 fix) is unchanged.
+//
+// 当 '#' 紧跟 host（如 smb://1.2.3.4#share/）时 url.path() 为空，需补前导 '/'
+// 否则 QUrl::setPath 会生成无效 URL。同时合并 fragment 后需清除旧 fragment，
+// 否则 URL 会同时包含合并后的 path 和旧 fragment。
 static QUrl mergedSmbUrl(const QString &path)
 {
     QUrl url(path);
-    if (url.hasFragment())
-        url.setPath(url.path() + '#' + url.fragment(QUrl::FullyDecoded));
+    if (url.hasFragment()) {
+        auto p = url.path();
+        if (p.isEmpty())
+            p = "/";
+        url.setPath(p + '#' + url.fragment(QUrl::FullyDecoded));
+        url.setFragment({});
+    }
     return url;
 }
 


### PR DESCRIPTION
1. Replace Q_ASSERT_X with proper error handling in
mountNetworkDeviceAsync to avoid crashes when address is empty
2. Fix SMB URL fragment handling in travers_prehandler and mergedSmbUrl
by adding leading slash when path is empty
3. Clear fragment after merging to path in mergedSmbUrl to prevent
duplicate fragment issues
4. Improve logging with proper warning messages instead of assertions

Log: Fixed mount network device with empty address causing crashes;
Fixed SMB URL handling when '#' follows host directly

Influence:
1. Test mounting network devices with empty address should not crash
2. Test SMB URLs in format smb://1.2.3.4#share/ should work correctly
3. Test SMB URLs with fragments should properly convert fragments to
path components
4. Verify existing SMB URL formats continue to work (without fragments,
with percent-encoded paths)

fix: 修复空地址挂载和SMB URL片段处理问题

1. 在 mountNetworkDeviceAsync 中用适当的错误处理替换 Q_ASSERT_X，避免地
址为空时崩溃
2. 在 travers_prehandler 和 mergedSmbUrl 中修复 SMB URL 片段处理，路径为
空时添加前导斜杠
3. 在 mergedSmbUrl 中合并片段到路径后清除片段，防止重复片段问题
4. 改进日志记录，使用适当的警告消息而不是断言

Log: 修复空地址挂载网络设备导致崩溃问题；修复'#'紧跟主机名时的SMB URL
处理

Influence:
1. 测试使用空地址挂载网络设备不应导致崩溃
2. 测试格式为 smb://1.2.3.4#share/ 的 SMB URL 应正常工作
3. 测试带有片段的 SMB URL 应正确将片段转换为路径组件
4. 验证现有的 SMB URL 格式（无片段、百分号编码路径）继续正常工作

## Summary by Sourcery

Handle empty network device addresses safely and correct SMB URL fragment-to-path conversion behavior.

Bug Fixes:
- Prevent mountNetworkDeviceAsync from crashing when invoked with an empty address.
- Ensure SMB URLs where '#' directly follows the host correctly convert fragments into path components, including adding a leading '/' when the original path is empty.
- Avoid duplicate SMB URL fragments by clearing the fragment after it is merged into the path.

Enhancements:
- Replace assertions with warning-based error handling and logging for invalid network mount requests.