### PR TITLE
fix: preserve backup header during interrupted decryption

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
@@ -103,6 +103,7 @@ void DiskEncryptEntry::processUnfinshedDecrypt(const QString &device)
     }
 
     QMenu *menu = new QMenu();
+    menu->addSeparator();
     DiskEncryptMenuScene *scene = new DiskEncryptMenuScene();
 
     QUrl url;

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -304,16 +304,25 @@ QString DiskEncryptSetup::PendingDecryptionDevice()
     for (auto f : files) {
         auto name = m_dptr->resolveDeviceByDetachHeaderName(f);
         if (!name.isEmpty()) {
-            // Validate that the device is still encrypted; if it has been reformatted
-            // (e.g. via mke2fs), the LUKS header is gone and this backup file is stale.
-            auto status = crypt_setup_helper::encryptStatus(name);
-            if (status == disk_encrypt::kStatusNotEncrypted || status < 0) {
-                qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Device is no longer encrypted, removing stale backup:"
-                         << name << "file:" << f;
-                QFile::remove(d.absoluteFilePath(f));
+            // Judge staleness by the backup header file itself, not by the device's
+            // own LUKS state: during an interrupted offline decrypt the on-disk LUKS
+            // header is already detached/rewritten, so the device no longer reports
+            // crypto_LUKS even though the decrypt is still in progress. The backup
+            // header is the only source for resuming the decrypt and must be kept
+            // unless headerStatus confirms the decrypt has fully completed.
+            //
+            // headerStatus is a best-effort heuristic (readLine-at-4096 JSON parse)
+            // and may return kInvalidHeader even for a valid interrupted-decrypt
+            // backup. Only delete when it definitively reports kDecryptFully.
+            const QString &backupPath = d.absoluteFilePath(f);
+            int hs = crypt_setup_helper::headerStatus(backupPath);
+            if (hs == crypt_setup_helper::kDecryptFully) {
+                qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Backup header indicates the decrypt has fully completed, removing stale backup:"
+                         << name << "file:" << f << "headerStatus:" << hs;
+                QFile::remove(backupPath);
                 continue;
             }
-            qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Found pending decryption device:" << name << "from header file:" << f;
+            qInfo() << "[DiskEncryptSetup::PendingDecryptionDevice] Found pending decryption device:" << name << "from header file:" << f << "headerStatus:" << hs;
             return name;
         }
     }


### PR DESCRIPTION
1. Changed backup header staleness check from device LUKS status to
header file status
2. Previously deleted backup if device reported not encrypted, but
during interrupted offline decrypt the device LUKS header is already
detached/rewritten, causing false staleness and losing the only recovery
source
3. Now only delete backup when headerStatus() returns kDecryptFully,
which definitively indicates the decrypt has completed
4. Added separator to disk encrypt context menu for better UI

Log: Fixed disk decrypt backup header being incorrectly removed during
interrupted decryption

Influence:
1. Test interrupted offline decryption: verify backup header is
preserved and decrypt can resume
2. Test successful decryption: verify backup header is removed after
full completion
3. Test decryption on devices with reformatted LUKS headers: verify
backup header is kept until decrypt fully completes
4. Test disk encrypt context menu: verify separator appears correctly

fix: 修复中断解密时备份头文件被错误删除的问题

1. 将备份头文件的过期判断逻辑从设备加密状态改为头文件自身状态
2. 之前根据设备是否显示加密状态来删除备份，但离线解密中断时设备LUKS头已
被分离/重写，导致误判，丢失唯一恢复源
3. 现在仅当headerStatus()返回kDecryptFully时才删除备份，表示解密已完全
完成
4. 在磁盘加密上下文菜单中添加分隔符，改善UI

Log: 修复了磁盘加密中断解密时备份头文件被错误删除的问题

Influence:
1. 测试中断的离线解密：验证备份头文件被保留并能恢复解密
2. 测试成功完成解密：验证解密完全完成后备份头文件被删除
3. 测试设备LUKS头被重新格式化的情况：验证备份头文件会保留到解密完全完成
4. 测试磁盘加密右键菜单：验证分隔符显示正确

BUG: https://pms.uniontech.com/bug-view-372281.html BUG: https://pms.uniontech.com/bug-view-372719.html

## Summary by Sourcery

Preserve disk decryption backup headers during interrupted or in-progress offline decrypts and improve the disk encryption context menu UI.

Bug Fixes:
- Prevent backup LUKS header files from being incorrectly deleted when a device no longer reports as encrypted during an interrupted or in-progress decryption.

Enhancements:
- Determine backup header staleness based on the header file status rather than the device encryption status, only removing backups when the header explicitly indicates decryption has fully completed.
- Add a visual separator to the disk encryption context menu in the file manager for clearer action grouping.