### PR TITLE
test: prevent unit test from causing full disk traversal

### DIFF
--- a/autotests/services/textindex/test_fseventcollector.cpp
+++ b/autotests/services/textindex/test_fseventcollector.cpp
@@ -12,8 +12,10 @@
 #include <QStringList>
 #include <QHash>
 
+#include "stubext.h"
 #include "services/textindex/service_textindex_global.h"
 #include "services/textindex/fsmonitor/fseventcollector.h"
+#include "services/textindex/fsmonitor/fsmonitor.h"
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
 
@@ -96,6 +98,11 @@ TEST(FSEventCollectorTest, MovedFilesEmpty)
 
 TEST(FSEventCollectorTest, StartWithoutInitMayFailGracefully)
 {
+    stub_ext::StubExt stub;
+    stub.set_lamda(ADDR(FSMonitor, start), [](FSMonitor *) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
     FSEventCollector collector(alwaysTrue());
     EXPECT_NO_FATAL_FAILURE({ (void)collector.start(); });
 }

--- a/autotests/services/textindex/test_fseventcontroller.cpp
+++ b/autotests/services/textindex/test_fseventcontroller.cpp
@@ -17,17 +17,33 @@
 #include <QString>
 #include <QStringList>
 
+#include "stubext.h"
+#include <dfm-search/dsearch_global.h>
+
 #include "dfm_test_main.h"
 #include "services/textindex/service_textindex_global.h"
 #include "services/textindex/profile/indexprofile.h"
 #include "services/textindex/fsmonitor/fseventcontroller.h"
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
+using namespace DFMSEARCH;
 
 class FSEventControllerTest : public testing::Test
 {
 protected:
     QTemporaryDir tmp;
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(tmp.isValid());
+
+        stub.set_lamda(ADDR(Global, defaultIndexedDirectory),
+                       []() -> QStringList {
+                           __DBG_STUB_INVOKE__
+                           return {};
+                       });
+    }
 
     IndexProfile makeProfile()
     {


### PR DESCRIPTION
The unit tests for FSEventCollector and FSEventController were causing
the FSMonitor to start and potentially traverse the entire disk during
testing, which is undesirable for unit test performance and isolation.
To fix this, stubs have been added to mock the FSMonitor::start method
and the defaultIndexedDirectory function. In test_fseventcollector.cpp,
a stub is added to mock FSMonitor::start to return true without actually
starting the monitor. In test_fseventcontroller.cpp, a stub is added to
mock Global::defaultIndexedDirectory to return an empty list, preventing
any real directory scanning during test setup. This ensures that unit
tests run quickly and do not have side effects on the system.

Influence:
1. Verify that FSEventCollector::start does not cause FSMonitor to start
real monitoring
2. Confirm that FSEventController tests do not scan default directories
3. Ensure all existing unit tests pass with the new stubs
4. Check that the stubs do not interfere with other functionality

test: 避免单元测试导致全盘遍历

FSEventCollector 和 FSEventController 的单元测试会导致 FSMonitor 启
动并可能在测试过程中遍历整个磁盘，这对于单元测试的性能和隔离性是
不可取的。为了解决这个问题，添加了存根来模拟 FSMonitor::start 方
法和 defaultIndexedDirectory 函数。在 test_fseventcollector.cpp
中，添加了一个存根来模拟 FSMonitor::start 返回 true 而不实际启
动监控器。在 test_fseventcontroller.cpp 中，添加了一个存根来模拟
Global::defaultIndexedDirectory 返回空列表，防止在测试设置期间进行任何实
际的目录扫描。这确保了单元测试能够快速运行且不会对系统产生副作用。

Influence:
1. 验证 FSEventCollector::start 不会导致 FSMonitor 启动真实监控
2. 确认 FSEventController 测试不会扫描默认目录
3. 确保所有现有单元测试在新的存根下通过
4. 检查存根不会干扰其他功能

## Summary by Sourcery

Isolate filesystem-related unit tests from real disk activity by stubbing monitoring and default directory discovery.

Tests:
- Stub FSMonitor::start in FSEventCollector tests to prevent starting real filesystem monitoring while validating start behavior.
- Stub Global::defaultIndexedDirectory in FSEventController tests to avoid scanning default directories during test setup.