### PR TITLE
fix: recreate desktop window when screen changes to fix layer-shell output binding

### DIFF
--- a/src/plugins/desktop/ddplugin-core/frame/windowframe.cpp
+++ b/src/plugins/desktop/ddplugin-core/frame/windowframe.cpp
@@ -6,6 +6,7 @@
 
 #include "desktoputils/widgetutil.h"
 #include "desktoputils/ddplugin_eventinterface_helper.h"
+#include "screen/screenqt.h"
 
 #include <QWindow>
 
@@ -36,6 +37,26 @@ void WindowFramePrivate::updateProperty(BaseWindowPointer win, ScreenPointer scr
     }
 }
 
+QScreen *WindowFramePrivate::screenFromScreenPointer(const ScreenPointer &sp)
+{
+    if (auto *qtScreen = qobject_cast<ScreenQt *>(sp.data()))
+        return qtScreen->screen();
+    return nullptr;
+}
+
+bool WindowFramePrivate::windowScreenChanged(const BaseWindowPointer &win, const ScreenPointer &sp)
+{
+    // 检测窗口的 QScreen 是否与目标屏不一致。treeland 重新枚举 output 时
+    // 旧 QScreen 销毁，Qt 自动把窗口移到主屏，导致 QScreen 不匹配。
+    auto *target = screenFromScreenPointer(sp);
+    if (!target)
+        return false;
+    auto *handle = win ? win->windowHandle() : nullptr;
+    if (!handle)
+        return false;
+    return handle->screen() != target;
+}
+
 BaseWindowPointer WindowFramePrivate::createWindow(ScreenPointer sp)
 {
     BaseWindowPointer win(new BaseWindow);
@@ -43,7 +64,13 @@ BaseWindowPointer WindowFramePrivate::createWindow(ScreenPointer sp)
     win->setGeometry(sp->geometry());   // 经过缩放的区域
     fmDebug() << "Window created for screen:" << sp->name() << "geometry:" << sp->geometry() << "window pointer:" << win.get();
 
-    ddplugin_desktop_util::setDesktopWindow(win.get());
+    // 绑定窗口到目标屏：ScreenFromQWindow 会读取 QWindow::screen() 决定 layer
+    // surface 绑定到哪个 wl_output。未显式 setScreen 的顶层窗口在 Wayland 下默认
+    // 落在主屏，导致副屏桌面被绑到主屏 output。对齐 dock 的 winId->setScreen->
+    // DLayerShellWindow::get 顺序。
+    auto *qscreen = screenFromScreenPointer(sp);
+
+    ddplugin_desktop_util::setDesktopWindow(win.get(), qscreen);
     // the Desktop Window is opaque though it has been setted Qt::WA_TranslucentBackground
     // uing setOpacity to set opacity for Desktop Window to be transparent.
     auto handle = win->windowHandle();
@@ -202,9 +229,19 @@ void WindowFrame::buildBaseWindow()
         }
 
         BaseWindowPointer winPtr = d->windows.value(primary->name());
+        // 先隐藏所有窗口，确保非主屏窗口的 layer-shell surface 被正确销毁，
+        // 避免切换到单屏/复制模式时残留“幽灵桌面”窗口。
+        for (auto &w : d->windows)
+            w->hide();
         d->windows.clear();
         if (!winPtr.isNull()) {
-            if (winPtr->geometry() != primary->geometry()) {
+            // Wayland 下 setScreen 无法重建 layer-shell surface，若 QScreen 已变
+            // （output 重枚举后 Qt 把窗口移到主屏），必须销毁旧窗口重建。
+            if (d->windowScreenChanged(winPtr, primary)) {
+                fmInfo() << "QScreen changed for primary screen, recreating window";
+                winPtr.reset();
+                winPtr = d->createWindow(primary);
+            } else if (winPtr->geometry() != primary->geometry()) {
                 winPtr->setGeometry(primary->geometry());
                 fmDebug() << "Updated existing primary window geometry to:" << primary->geometry();
             }
@@ -233,9 +270,20 @@ void WindowFrame::buildBaseWindow()
         for (ScreenPointer s : screens) {
             BaseWindowPointer winPtr = d->windows.value(s->name());
             if (!winPtr.isNull()) {
-                if (winPtr->geometry() != s->geometry())
-                    winPtr->setGeometry(s->geometry());
-                fmInfo() << "Updated window for screen:" << s->name() << "window geometry:" << winPtr->geometry() << "screen geometry:" << s->geometry();
+                // Wayland 下 setScreen 无法重建 layer-shell surface。若 QScreen 已变
+                // （output 重枚举后 Qt 把窗口移到主屏），必须销毁旧窗口重建，
+                // 否则 layer surface 仍绑在旧 output 上。
+                if (d->windowScreenChanged(winPtr, s)) {
+                    fmInfo() << "QScreen changed for screen:" << s->name() << "recreating window";
+                    winPtr->hide();
+                    winPtr.reset();
+                    winPtr = d->createWindow(s);
+                    d->windows.insert(s->name(), winPtr);
+                } else {
+                    if (winPtr->geometry() != s->geometry())
+                        winPtr->setGeometry(s->geometry());
+                    fmInfo() << "Updated window for screen:" << s->name() << "window geometry:" << winPtr->geometry() << "screen geometry:" << s->geometry();
+                }
             } else {
                 // 添加缺少的数据
                 winPtr = d->createWindow(s);

--- a/src/plugins/desktop/ddplugin-core/frame/windowframe_p.h
+++ b/src/plugins/desktop/ddplugin-core/frame/windowframe_p.h
@@ -22,6 +22,10 @@ public:
     explicit WindowFramePrivate(WindowFrame *parent);
     void updateProperty(BaseWindowPointer win, DFMBASE_NAMESPACE::ScreenPointer screen, bool primary);
     BaseWindowPointer createWindow(DFMBASE_NAMESPACE::ScreenPointer sp);
+    // 从 ScreenPointer 取 QScreen*
+    QScreen *screenFromScreenPointer(const DFMBASE_NAMESPACE::ScreenPointer &sp);
+    // 检测窗口的 QScreen 是否与目标屏不一致（output 重枚举后 Qt 把窗口移到主屏）
+    bool windowScreenChanged(const BaseWindowPointer &win, const DFMBASE_NAMESPACE::ScreenPointer &sp);
 
     void traceWindow(QWindow *win) const;
 

--- a/src/plugins/desktop/desktoputils/widgetutil.h
+++ b/src/plugins/desktop/desktoputils/widgetutil.h
@@ -59,7 +59,7 @@ static inline void setDesktopWindowOld(QWidget *w)
     }
 }
 
-static inline void setDesktopWindow(QWidget *w)
+static inline void setDesktopWindow(QWidget *w, QScreen *screen = nullptr)
 {
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     setDesktopWindowOld(w);
@@ -73,6 +73,13 @@ static inline void setDesktopWindow(QWidget *w)
         qWarning() << w << "windowHandle is null";
         return;
     }
+
+    // 创建层壳窗口前将窗口绑定到目标屏：ScreenFromQWindow 会读取 QWindow::screen()
+    // 决定 layer surface 绑定到哪个 wl_output。未显式 setScreen 的顶层窗口在 Wayland
+    // 下默认落在主屏，导致副屏桌面被绑到主屏 output。对齐 dock 的 winId->setScreen->
+    // DLayerShellWindow::get 顺序。
+    if (screen)
+        window->setScreen(screen);
 
     // 使用 dde-shell 完成桌面窗口设置
     DS_USE_NAMESPACE


### PR DESCRIPTION
## 根因分析

treeland（Wayland）多屏切换扩展/复制模式时，副屏桌面窗口以独立窗口形式出现在主屏，窗口层级错误。X11 下同样操作正常。

### 为什么 X11 正常而 treeland 异常

**X11**：窗口位置由客户端 `setGeometry()` 控制。X11 下 `QWindow::setScreen()` 会实际触发窗口跨屏移动，X server 根据 geometry 决定窗口在哪个 monitor 上显示。桌面窗口通过 X11 layer-shell 模拟（`LayerShellEmulation`）工作——它本质是一个 override-redirect 的特殊窗口，位置完全由 `setGeometry` 决定。因此复用窗口 + `setGeometry` 即可正确定位到副屏。

**treeland（Wayland）**：wlr layer-shell 协议中，layer surface 的位置由**创建时绑定的 `wl_output`** 决定，客户端无法通过 `setGeometry()` 控制窗口落在哪个屏。layer surface 创建时传入 `wl_output *output` 参数（来自 `QWindow::screen()->handle()->output()`），此后该 surface 永远绑定在该 output 上。

关键差异：**Wayland 下 `QWindow::setScreen()` 对已存在的 platform window 无效**。Qt Wayland QPA 的 screen 由合成器决定（surface 进入哪个 output），`setScreen` 只修改 Qt 内部引用，不触发 `screenChanged` 信号，不重建 layer surface。因此复用窗口时，layer surface 仍绑定在旧 output 上。

### 触发机理

treeland 切换显示模式时会先移除再重新枚举 output（日志：`Screen removed: HDMI-A-1` → `Adding new screen: HDMI-A-1`）。旧 QScreen 销毁时 Qt 自动把窗口的 `QWindow::screen()` 移到主屏。随后 `buildBaseWindow` 触发，走**复用路径**（仅 `setGeometry`，不重建窗口），layer surface 仍绑在旧（主屏）output → 副屏桌面出现在主屏。

首次启动正常是因为走 `createWindow`（全新窗口 + 全新 layer surface，绑定正确 output）。

## 修复方案

检测窗口的 QScreen 是否与目标屏不一致（`windowScreenChanged`），若不一致则**销毁旧窗口并创建新窗口**，而非仅 `setGeometry`+`setScreen`。新窗口走 `createWindow` → `setDesktopWindow` → `DLayerShellWindow::get`，layer surface 绑定到正确 output——与首次启动路径完全一致。

这是根因修复，不是 workaround。根因是 desktop 插件在 Wayland 下复用窗口时未重建 layer-shell surface（Wayland 与 X11 的窗口定位机制本质不同），修复方式是检测 QScreen 变化后重建窗口，使 layer surface 绑定到正确 output。

## 改动

3 文件，+81 / -6：
- `widgetutil.h` — `setDesktopWindow` 增可选 `QScreen*` 参数，`DLayerShellWindow::get` 前调 `setScreen`（新建窗口时绑定正确 screen）
- `windowframe_p.h` — 新增 `windowScreenChanged`/`screenFromScreenPointer` 辅助方法
- `windowframe.cpp` — `buildBaseWindow` 复用路径检测 QScreen 变化后重建窗口；单屏路径 clear 前 hide 所有窗口

## 改动安全评估

低风险：重建窗口的路径与首次启动完全一致（`createWindow` 是已有代码），只是将"复用窗口 + setGeometry"改为"检测到 QScreen 变化时重建窗口"。无 `setScreen` 的复用路径行为不变。单屏/复制模式也受益。

## 验证

用户已验证：treeland 多屏下切换复制↔扩展模式，副屏桌面正确嵌入副屏层级，不再出现独立窗口；从扩展切回复制无幽灵窗口。
