### PR TITLE
fix: preserve file emblems metadata on trash restore

### DIFF
--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/trashfiles/dorestoretrashfilesworker.cpp
@@ -199,9 +199,23 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
             continue;
         }
 
+        // Prefer the local file:// URI (from STANDARD_TARGET_URI) over the
+        // trash:// URI for the move operation. Using a trash:// source causes
+        // g_file_move() to go through the GVFS daemon, where GVFS metadata
+        // (e.g. metadata::emblems) is transferred via an async fire-and-forget
+        // D-Bus call that can silently fail. A direct local-to-local move
+        // calls local_file_moved() in the client process, reliably migrating
+        // the metadata.
+        QUrl moveSourceUrl = trashUrl.isValid() ? trashUrl : url;
+
         DFMBASE_NAMESPACE::LocalFileHandler fileHandler;
-        bool trashSucc = fileHandler.moveFile(url, newTargetInfo->uri(), DFMIO::DFile::CopyFlag::kOverwrite);
+        bool trashSucc = fileHandler.moveFile(moveSourceUrl, newTargetInfo->uri(), DFMIO::DFile::CopyFlag::kOverwrite);
         if (trashSucc) {
+            // When using the local file:// URI we bypass trash_item_restore()
+            // which would normally delete the .trashinfo file, so do it here.
+            if (moveSourceUrl == trashUrl && trashInfoUrl.isValid())
+                removeTrashInfo(trashInfoUrl);
+
             completeFilesCount++;
             if (!completeSourceFiles.contains(fileUrl)) {
                 completeSourceFiles.append(fileUrl);
@@ -214,8 +228,10 @@ bool DoRestoreTrashFilesWorker::doRestoreTrashFiles()
             auto errorCode = fileHandler.errorCode();
             switch (errorCode) {
             case DFMIOErrorCode::DFM_IO_ERROR_WOULD_MERGE: {
-                fmDebug() << "Directory merge needed for restore - from:" << url << "to:" << newTargetInfo->uri();
-                trashSucc = this->mergeDir(url, newTargetInfo->uri(), DFMIO::DFile::CopyFlag::kOverwrite);
+                fmDebug() << "Directory merge needed for restore - from:" << moveSourceUrl << "to:" << newTargetInfo->uri();
+                trashSucc = this->mergeDir(moveSourceUrl, newTargetInfo->uri(), DFMIO::DFile::CopyFlag::kOverwrite);
+                if (trashSucc && trashInfoUrl.isValid())
+                    removeTrashInfo(trashInfoUrl);
                 break;
             };
             default:


### PR DESCRIPTION
## 根因分析

**PMS Bug**: [BUG-373375](https://pms.uniontech.com/bug-view-373375.html)

删除已设置角标（`metadata::emblems`）的文件到回收站后，按 Ctrl+Z 恢复，文件角标不会恢复。

**根因**：`DoRestoreTrashFilesWorker::doRestoreTrashFiles()` 使用 `trash:///` URI 作为 `moveFile()` 的源，而非已获取的本地 `file:///` URI（`trashUrl`）。`trash:///` URI 导致 `g_file_move()` 经 GVFS 守护进程执行，GVFS 元数据（`metadata::emblems`）通过异步 fire-and-forget D-Bus 调用迁移，可能静默失败。

**关键证据**：
1. 删除到回收站使用 `g_file_trash()` 直接对 `file:///` URI 操作，`local_file_moved()` 在客户端进程同步执行 → 元数据保留
2. 还原使用 `trash:///` URI，`local_file_moved()` 在 gvfsd 进程通过异步 D-Bus 调用 → 元数据可能丢失
3. 代码已在第 186 行通过 `kStandardTargetUri` 获取到本地 `file:///` URI（`trashUrl`），但 `moveFile()` 未使用

## 修复方案

将 `moveFile()` 和 `mergeDir()` 的源从 `url`（`trash:///`）改为 `trashUrl`（`file:///`），使 `g_file_move()` 成为直接本地文件移动，在客户端进程执行 `local_file_moved()` 可靠迁移元数据。同时显式删除 `.trashinfo` 文件（原由 trash 后端 `trash_item_restore()` 处理）。

## 改动安全评估

低风险。无函数签名变更，无公开 API 变更，仅修改 `doRestoreTrashFiles()` 内部逻辑。`trashUrl` 无效时回退使用 `url` 保持原有行为。

## Summary by Sourcery

Preserve GVFS metadata (such as file emblems) when restoring trashed files by using the local file URI as the restore source and cleaning up associated trash metadata files.

Bug Fixes:
- Ensure file emblems (metadata::emblems) are correctly restored when files are recovered from the trash using undo or restore actions.

Enhancements:
- Improve trash restore logic to prefer local file URIs, falling back to trash URIs only when necessary, and explicitly remove obsolete .trashinfo metadata after successful restores.