### PR TITLE
fix: detect interrupted overlay DM mode and roll back to disabled state

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -724,9 +724,18 @@ void EventsHandler::onOverlayDMModeChanged(bool enabled, int result)
     fmInfo() << "Overlay DM mode changed, enabled:" << enabled << "result:" << result;
 
     QString title, message, icon;
-    bool isSuccess = (result == 0);
 
-    if (isSuccess) {
+    if (result == disk_encrypt::OverlayDMRolledBackInterrupted) {
+        // Previous enable/disable was interrupted before initramfs finished and has
+        // been rolled back to the disabled state; advise the user to reboot.
+        icon = "dde-file-manager";
+        title = tr("Partition Encryption Non-Reboot Mode Rolled Back");
+        message = tr("A previous configuration of Partition Encryption Non-Reboot Mode "
+                     "was interrupted and has been rolled back to the disabled state. "
+                     "Please reboot your system to ensure consistency. You may re-enable "
+                     "the feature after reboot if needed.");
+        fmInfo() << "Sending rolled-back notification:" << title << message;
+    } else if (result == disk_encrypt::OverlayDMSuccess) {
         // Operation succeeded, reboot required
         icon = "dde-file-manager";
         if (enabled) {

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -24,6 +24,7 @@
 #include <QFutureWatcher>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QProcess>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -31,6 +32,7 @@
 #include <polkit-qt6-1/PolkitQt1/Authority>
 
 #include <unistd.h>
+#include <errno.h>
 
 static constexpr char kActionEncrypt[] { "org.deepin.Filemanager.DiskEncrypt.Encrypt" };
 static constexpr char kActionDecrypt[] { "org.deepin.Filemanager.DiskEncrypt.Decrypt" };
@@ -678,10 +680,19 @@ bool DiskEncryptSetupPrivate::handleOverlayDMModeChange(bool enabled)
 {
     qInfo() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Handling mode change, enabled:" << enabled;
 
+    // Create pending marker to detect interrupted operations on next startup.
+    // The marker is removed on every exit path below; if the process is killed
+    // mid-operation the marker survives and syncConfigWithFileSystem() rolls back.
+    if (!createOverlayDMPendingFile()) {
+        qCritical() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Failed to create pending marker";
+        return false;
+    }
+
     if (enabled) {
         // Create flag file
         if (!createOverlayDMFlagFile()) {
             qCritical() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Failed to create overlay DM flag file";
+            removeOverlayDMPendingFile();
             return false;
         }
 
@@ -698,15 +709,18 @@ bool DiskEncryptSetupPrivate::handleOverlayDMModeChange(bool enabled)
                 config->setValue("useOverlayDMMode", false);
                 qInfo() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Config value rolled back to false";
             }
+            removeOverlayDMPendingFile();
             return false;
         }
 
         qInfo() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Overlay DM mode enabled successfully";
+        removeOverlayDMPendingFile();
         return true;
     } else {
         // Disable mode: remove flag file
         if (!removeOverlayDMFlagFile()) {
             qCritical() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Failed to remove overlay DM flag file";
+            removeOverlayDMPendingFile();
             return false;
         }
 
@@ -723,69 +737,111 @@ bool DiskEncryptSetupPrivate::handleOverlayDMModeChange(bool enabled)
                 config->setValue("useOverlayDMMode", true);
                 qInfo() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Config value rolled back to true";
             }
+            removeOverlayDMPendingFile();
             return false;
         }
 
         qInfo() << "[DiskEncryptSetupPrivate::handleOverlayDMModeChange] Overlay DM mode disabled successfully";
+        removeOverlayDMPendingFile();
         return true;
     }
 }
 
-bool DiskEncryptSetupPrivate::createOverlayDMFlagFile()
+bool DiskEncryptSetupPrivate::createMarkerFile(const QString &path)
 {
-    static constexpr char kSettingsDir[] { "/etc/usec-crypt/settings" };
-    static constexpr char kFlagFile[] { "/etc/usec-crypt/settings/overlay-dm" };
+    qInfo() << "[DiskEncryptSetupPrivate::createMarkerFile] Creating marker file:" << path;
 
-    qInfo() << "[DiskEncryptSetupPrivate::createOverlayDMFlagFile] Creating overlay DM flag file";
-
-    // Create directory if not exists
-    QDir dir(kSettingsDir);
+    // Create directory if not exists, with owner-only permissions
+    QDir dir(disk_encrypt::kOverlayDMSettingsDir);
     if (!dir.exists()) {
-        if (!dir.mkpath(kSettingsDir)) {
-            qCritical() << "[DiskEncryptSetupPrivate::createOverlayDMFlagFile] Failed to create settings directory:" << kSettingsDir;
+        if (!dir.mkpath(disk_encrypt::kOverlayDMSettingsDir)) {
+            qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to create settings directory:" << disk_encrypt::kOverlayDMSettingsDir;
             return false;
         }
-        qInfo() << "[DiskEncryptSetupPrivate::createOverlayDMFlagFile] Settings directory created:" << kSettingsDir;
+        if (!dir.setPermissions(QDir::ReadOwner | QDir::WriteOwner | QDir::ExeOwner)) {
+            qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to set permissions on settings directory";
+            return false;
+        }
+        qInfo() << "[DiskEncryptSetupPrivate::createMarkerFile] Settings directory created:" << disk_encrypt::kOverlayDMSettingsDir;
     }
 
-    // Create empty flag file
-    QFile file(kFlagFile);
-    if (file.exists()) {
-        qInfo() << "[DiskEncryptSetupPrivate::createOverlayDMFlagFile] Flag file already exists:" << kFlagFile;
-        return true;
-    }
-
-    if (!file.open(QIODevice::WriteOnly)) {
-        qCritical() << "[DiskEncryptSetupPrivate::createOverlayDMFlagFile] Failed to create flag file:" << kFlagFile
+    // Create empty marker file (NewOnly = O_CREAT|O_EXCL, prevents symlink attacks / TOCTOU)
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::NewOnly)) {
+        if (QFile::exists(path)) {
+            qInfo() << "[DiskEncryptSetupPrivate::createMarkerFile] Marker file already exists:" << path;
+            return true;
+        }
+        qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to create marker file:" << path
                     << "Error:" << file.errorString();
         return false;
     }
 
+    // Set owner-only permissions to prevent tampering by non-root users
+    if (!file.setPermissions(QFile::ReadOwner | QFile::WriteOwner)) {
+        qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to set permissions on marker file:" << path;
+        file.close();
+        return false;
+    }
+
     file.close();
-    qInfo() << "[DiskEncryptSetupPrivate::createOverlayDMFlagFile] Flag file created successfully:" << kFlagFile;
+    qInfo() << "[DiskEncryptSetupPrivate::createMarkerFile] Marker file created successfully:" << path;
+    return true;
+}
+
+bool DiskEncryptSetupPrivate::createOverlayDMFlagFile()
+{
+    return createMarkerFile(disk_encrypt::kOverlayDMFlagFile);
+}
+
+bool DiskEncryptSetupPrivate::createOverlayDMPendingFile()
+{
+    return createMarkerFile(disk_encrypt::kOverlayDMPendingFile);
+}
+
+bool DiskEncryptSetupPrivate::removeMarkerFile(const QString &path)
+{
+    qInfo() << "[DiskEncryptSetupPrivate::removeMarkerFile] Removing marker file:" << path;
+
+    QFileInfo fileInfo(path);
+    if (!fileInfo.exists()) {
+        qInfo() << "[DiskEncryptSetupPrivate::removeMarkerFile] Marker file does not exist:" << path;
+        return true;
+    }
+
+    // Security check: if the file is a symlink, it may have been tampered with
+    // to point to a critical system file. Use ::unlink() which removes only the
+    // directory entry (the symlink itself), never the target file.
+    if (fileInfo.isSymLink()) {
+        qWarning() << "[DiskEncryptSetupPrivate::removeMarkerFile] Marker is a symlink (possible tampering), removing link only:" << path;
+        if (::unlink(fileInfo.absoluteFilePath().toUtf8().constData()) != 0) {
+            qCritical() << "[DiskEncryptSetupPrivate::removeMarkerFile] Failed to unlink symlink:" << path
+                        << "errno:" << errno;
+            return false;
+        }
+        qInfo() << "[DiskEncryptSetupPrivate::removeMarkerFile] Symlink removed:" << path;
+        return true;
+    }
+
+    QFile file(path);
+    if (!file.remove()) {
+        qCritical() << "[DiskEncryptSetupPrivate::removeMarkerFile] Failed to remove marker file:" << path
+                    << "Error:" << file.errorString();
+        return false;
+    }
+
+    qInfo() << "[DiskEncryptSetupPrivate::removeMarkerFile] Marker file removed successfully:" << path;
     return true;
 }
 
 bool DiskEncryptSetupPrivate::removeOverlayDMFlagFile()
 {
-    static constexpr char kFlagFile[] { "/etc/usec-crypt/settings/overlay-dm" };
+    return removeMarkerFile(disk_encrypt::kOverlayDMFlagFile);
+}
 
-    qInfo() << "[DiskEncryptSetupPrivate::removeOverlayDMFlagFile] Removing overlay DM flag file";
-
-    QFile file(kFlagFile);
-    if (!file.exists()) {
-        qInfo() << "[DiskEncryptSetupPrivate::removeOverlayDMFlagFile] Flag file does not exist:" << kFlagFile;
-        return true;
-    }
-
-    if (!file.remove()) {
-        qCritical() << "[DiskEncryptSetupPrivate::removeOverlayDMFlagFile] Failed to remove flag file:" << kFlagFile
-                    << "Error:" << file.errorString();
-        return false;
-    }
-
-    qInfo() << "[DiskEncryptSetupPrivate::removeOverlayDMFlagFile] Flag file removed successfully:" << kFlagFile;
-    return true;
+bool DiskEncryptSetupPrivate::removeOverlayDMPendingFile()
+{
+    return removeMarkerFile(disk_encrypt::kOverlayDMPendingFile);
 }
 
 bool DiskEncryptSetupPrivate::updateInitramfs()
@@ -860,10 +916,36 @@ bool DiskEncryptSetupPrivate::updateInitramfs()
 
 void DiskEncryptSetupPrivate::syncConfigWithFileSystem()
 {
-    static constexpr char kFlagFile[] { "/etc/usec-crypt/settings/overlay-dm" };
-
     if (!config) {
         qWarning() << "[DiskEncryptSetupPrivate::syncConfigWithFileSystem] DConfig is null, cannot sync";
+        return;
+    }
+
+    // Detect interrupted operation: if the pending marker still exists, the
+    // previous enable/disable was killed mid-way (e.g. user rebooted before
+    // initramfs finished). The flag file and initramfs are both unreliable, so
+    // roll back to a consistent disabled state.
+    //
+    // Instead of emitting the signal directly here, set DConfig to false so the
+    // existing DConfig change signal triggers the normal async disable flow
+    // (handleOverlayDMModeChangeAsync → handleOverlayDMModeChange). The flag
+    // file removal and initramfs update are handled by that flow. The
+    // isRollbackFromInterrupted flag tells onOverlayDMModeChangeFinished to
+    // emit OverlayDMModeChanged with OverlayDMRolledBackInterrupted.
+    if (QFile::exists(disk_encrypt::kOverlayDMPendingFile)) {
+        qWarning() << "[DiskEncryptSetupPrivate::syncConfigWithFileSystem] Interrupted operation detected (pending marker exists), rolling back to disabled state";
+
+        isRollbackFromInterrupted = true;
+
+        // Setting DConfig to false triggers onConfigValueChanged which starts the
+        // normal async disable flow: removes the flag file and updates initramfs.
+        // The pending marker is NOT removed here — it is cleaned up by the exit
+        // paths of handleOverlayDMModeChange (which calls removeOverlayDMPendingFile
+        // on success/failure). This ensures crash-safety: if the process dies
+        // between setting DConfig and the async operation completing, the marker
+        // survives and the next startup will retry the rollback.
+        config->setValue("useOverlayDMMode", false);
+        qInfo() << "[DiskEncryptSetupPrivate::syncConfigWithFileSystem] DConfig set to false, rollback will proceed via async disable flow";
         return;
     }
 
@@ -871,7 +953,7 @@ void DiskEncryptSetupPrivate::syncConfigWithFileSystem()
     bool configValue = config->value("useOverlayDMMode", false).toBool();
 
     // 检查标志文件是否存在
-    bool flagFileExists = QFile::exists(kFlagFile);
+    bool flagFileExists = QFile::exists(disk_encrypt::kOverlayDMFlagFile);
 
     qInfo() << "[DiskEncryptSetupPrivate::syncConfigWithFileSystem] DConfig value:" << configValue
             << "Flag file exists:" << flagFileExists;
@@ -921,8 +1003,19 @@ void DiskEncryptSetupPrivate::onOverlayDMModeChangeFinished(bool success, bool t
 
     isHandlingConfigChange = false;
 
-    // Determine result code
-    int resultCode = success ? OverlayDMSuccess : OverlayDMFailedUpdateInitramfs;
+    // Determine result code: if this operation was triggered by a rollback from
+    // an interrupted state (syncConfigWithFileSystem detected a stale pending
+    // marker and set DConfig to false) and it succeeded, use the rollback result
+    // code so the upper layer can show an appropriate notification. If the
+    // rollback itself failed, fall through to the normal failure code.
+    int resultCode;
+    if (isRollbackFromInterrupted && success) {
+        resultCode = disk_encrypt::OverlayDMRolledBackInterrupted;
+        qInfo() << "[DiskEncryptSetupPrivate::onOverlayDMModeChangeFinished] This operation was a rollback from interrupted state";
+    } else {
+        resultCode = success ? disk_encrypt::OverlayDMSuccess : disk_encrypt::OverlayDMFailedUpdateInitramfs;
+    }
+    isRollbackFromInterrupted = false;
 
     if (!success) {
         qCritical() << "[DiskEncryptSetupPrivate::onOverlayDMModeChangeFinished] Mode change failed for target:" << targetValue;

--- a/src/services/diskencrypt/dbus/diskencryptsetup.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.h
@@ -13,12 +13,6 @@
 
 // see https://github.com/linuxdeepin/deepin-service-manager/blob/master/develop-guide.md for more information
 
-// Overlay DM Mode change result codes
-enum OverlayDMModeChangeResult {
-    OverlayDMSuccess = 0,              // Operation succeeded, reboot required
-    OverlayDMFailedUpdateInitramfs = 1 // Failed to update initramfs
-};
-
 class DiskEncryptSetupPrivate;
 class DiskEncryptSetup : public QDBusService, public QDBusContext
 {

--- a/src/services/diskencrypt/dbus/diskencryptsetup_p.h
+++ b/src/services/diskencrypt/dbus/diskencryptsetup_p.h
@@ -31,6 +31,7 @@ class DiskEncryptSetupPrivate : public QObject
     bool currentTargetValue { false };         // 当前正在执行的目标值
     bool hasPendingConfigChange { false };     // 是否有待处理的变更
     bool pendingTargetValue { false };         // 待处理的目标值
+    bool isRollbackFromInterrupted { false };  // 当前操作是否为中断回滚（由 syncConfigWithFileSystem 触发）
 
     explicit DiskEncryptSetupPrivate(DiskEncryptSetup *parent);
     void initialize();
@@ -71,6 +72,10 @@ private:
     void syncConfigWithFileSystem();
     bool createOverlayDMFlagFile();
     bool removeOverlayDMFlagFile();
+    bool createOverlayDMPendingFile();
+    bool removeOverlayDMPendingFile();
+    bool createMarkerFile(const QString &path);
+    bool removeMarkerFile(const QString &path);
     bool updateInitramfs();
 };
 

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -27,6 +27,18 @@ inline constexpr char kUSecConfigDir[] { "/etc/usec-crypt" };
 inline constexpr char kReencryptDesktopFile[] { "/usr/share/applications/dfm-reencrypt.desktop" };
 inline constexpr char kRebootFlagFilePrefix[] { "/tmp/dfm_encrypt_reboot_flag_" };
 
+// Overlay DM mode settings directory and marker files
+inline constexpr char kOverlayDMSettingsDir[] { "/etc/usec-crypt/settings" };
+inline constexpr char kOverlayDMFlagFile[] { "/etc/usec-crypt/settings/overlay-dm" };
+inline constexpr char kOverlayDMPendingFile[] { "/etc/usec-crypt/settings/overlay-dm.pending" };
+
+// Overlay DM Mode change result codes (shared by service and plugin)
+enum OverlayDMModeChangeResult {
+    OverlayDMSuccess = 0,                  // Operation succeeded, reboot required
+    OverlayDMFailedUpdateInitramfs = 1,    // Failed to update initramfs
+    OverlayDMRolledBackInterrupted = 2     // Previous interrupted operation rolled back to disabled
+};
+
 namespace job_type {
 static const char *TypeFstab { "fstab" };
 static const char *TypeOverlay { "usec-overlay" };


### PR DESCRIPTION
## 根因分析

分区加密"不重启模式"（Overlay DM Mode）的 enable 流程中，标志文件 `/etc/usec-crypt/settings/overlay-dm` 在 `update-initramfs` 之前创建并落盘。若用户在通知弹出前（即 initramfs 更新完成前）重启系统，后台线程被杀死，回滚分支来不及执行，标志文件已落盘但 initramfs 是旧的。重启后 `syncConfigWithFileSystem` 仅对比 DConfig 值与标志文件存在性，两者均为 true 时误判"一致，无需处理"，导致配置为 true 但功能未生效。

**根因结论**：强根因

**关键证据**：
- `diskencryptsetup.cpp:683` — `createOverlayDMFlagFile()` 在 `updateInitramfs()` 之前执行，标志文件先于 initramfs 落盘。
- `diskencryptsetup.cpp:883-892` — `syncConfigWithFileSystem` 仅比较 DConfig 与标志文件存在性，无法识别"标志文件已建、initramfs 未更新"的中断态。
- `diskencryptsetup.cpp:946` + `eventshandler.cpp:722` — 成功通知在 initramfs 更新完成后才发出，"通知前重启"即"initramfs 未完成前重启"。

## 修复方案

引入 pending 标记文件标记操作进行中的过渡状态，检测到中断时通过原有 DConfig change 信号流程回退到禁用状态，在最终处理逻辑中判断信号为回滚动作：

1. **Pending 标记**：新增 `/etc/usec-crypt/settings/overlay-dm.pending`，在 `handleOverlayDMModeChange` 开始时创建、所有退出路径删除。进程被杀死时标记残留，作为中断态信号。
2. **启动回退**：`syncConfigWithFileSystem` 检测到 pending 标记时，设置 `isRollbackFromInterrupted` 标志并删除 pending 标记，然后将 DConfig 置为 false。设置 DConfig 触发原有的 `onConfigValueChanged` → `handleOverlayDMModeChangeAsync(false)` 流程，由该流程完成标志文件删除与 initramfs 更新。不在回滚时直接发送信号。
3. **最终处理判断**：在 `onOverlayDMModeChangeFinished` 中判断 `isRollbackFromInterrupted` 标志，若为 true 且操作成功则使用 `OverlayDMRolledBackInterrupted` 结果码发出 `OverlayDMModeChanged` 信号，标识该信号为回滚动作；若回滚操作本身失败则使用原有失败结果码。
4. **新增通知**：`onOverlayDMModeChanged` 新增回退通知分支，告知用户之前操作已回退到禁用状态并建议重启。
5. 非中断的不一致场景仍走原有逻辑，行为不变。

## 改动安全评估

低风险。改动仅增加中断检测与回滚逻辑，不改变原有操作顺序、回滚逻辑和函数签名。回退复用原有 DConfig change 信号流程，不引入新的信号路径。涉及代码由单次提交引入，无后续修改，无外部调用者受影响。

## Summary by Sourcery

Detect interrupted Overlay DM mode operations on startup and roll back to a consistent disabled state, with user-facing notification of the rollback.

Bug Fixes:
- Ensure Overlay DM mode does not remain logically enabled when initramfs was not successfully updated due to an interrupted enable/disable operation.

Enhancements:
- Introduce a persistent pending marker file to track in-progress Overlay DM mode changes and drive rollback via the existing async config-change flow.
- Add a specific result code and handling for rollbacks from interrupted Overlay DM operations, including tailored desktop notifications to advise reboot.