### PR TITLE
test(autotests): add dfm-base unit tests for AbstractSortFilter, AbstractFrame, BaseDialog

### DIFF
--- a/autotests/libs/dfm-base/test_abstractframe.cpp
+++ b/autotests/libs/dfm-base/test_abstractframe.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractframe.cpp
+ * @brief Unit tests for AbstractFrame (abstractframe.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/interfaces/abstractframe.h>
+
+#include <QUrl>
+
+using namespace dfmbase;
+
+namespace {
+class TestableFrame : public AbstractFrame
+{
+public:
+    explicit TestableFrame(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags())
+        : AbstractFrame(parent, f) {}
+
+    QUrl m_url;
+    void setCurrentUrl(const QUrl &url) override { m_url = url; }
+    QUrl currentUrl() const override { return m_url; }
+};
+}   // namespace
+
+TEST(AbstractFrameTest, ConstructDoesNotCrash)
+{
+    TestableFrame f;
+    EXPECT_FALSE(f.currentUrl().isValid());
+}
+
+TEST(AbstractFrameTest, SetCurrentUrlReturnsSameUrl)
+{
+    TestableFrame f;
+    QUrl url(QStringLiteral("file:///tmp"));
+    f.setCurrentUrl(url);
+    EXPECT_EQ(f.currentUrl(), url);
+}
+
+TEST(AbstractFrameTest, ConstructWithParentDoesNotCrash)
+{
+    QWidget parent;
+    auto *f = new TestableFrame(&parent);
+    EXPECT_EQ(f->parent(), &parent);
+    delete f;
+}

--- a/autotests/libs/dfm-base/test_abstractsortfilter.cpp
+++ b/autotests/libs/dfm-base/test_abstractsortfilter.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_abstractsortfilter.cpp
+ * @brief Unit tests for AbstractSortFilter (abstractsortfilter.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/interfaces/abstractsortfilter.h>
+
+#include <QDir>
+
+using namespace dfmbase;
+
+TEST(AbstractSortFilterTest, DefaultLessThanReturnsMinusOne)
+{
+    AbstractSortFilter filter;
+    FileInfoPointer left, right;
+    EXPECT_EQ(filter.lessThan(left, right, false, Global::kItemNameRole,
+                              AbstractSortFilter::SortScenarios::kSortScenariosNormal), -1);
+}
+
+TEST(AbstractSortFilterTest, DefaultLessThanReturnsMinusOneForAllScenarios)
+{
+    AbstractSortFilter filter;
+    FileInfoPointer left, right;
+    EXPECT_EQ(filter.lessThan(left, right, true, Global::kItemFileSizeRole,
+                              AbstractSortFilter::SortScenarios::kSortScenariosIteratorAddFile), -1);
+    EXPECT_EQ(filter.lessThan(left, right, false, Global::kItemFileDisplayNameRole,
+                              AbstractSortFilter::SortScenarios::kSortScenariosWatcherOther), -1);
+}
+
+TEST(AbstractSortFilterTest, DefaultCheckFiltersReturnsMinusOne)
+{
+    AbstractSortFilter filter;
+    FileInfoPointer info;
+    EXPECT_EQ(filter.checkFilters(info, QDir::NoFilter, QVariant()), -1);
+}
+
+TEST(AbstractSortFilterTest, ConstructAndDestructSafe)
+{
+    { AbstractSortFilter f; (void)f; }
+    SUCCEED();
+}

--- a/autotests/libs/dfm-base/test_basedialog.cpp
+++ b/autotests/libs/dfm-base/test_basedialog.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_basedialog.cpp
+ * @brief Unit tests for BaseDialog (basedialog.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/dialogs/basedialog/basedialog.h>
+
+#include <QString>
+#include <QFont>
+
+using namespace dfmbase;
+
+TEST(BaseDialogTest, ConstructDoesNotCrash)
+{
+    BaseDialog dlg;
+    (void)dlg;
+}
+
+TEST(BaseDialogTest, DestructDoesNotCrash)
+{
+    {
+        BaseDialog dlg;
+    }
+    SUCCEED();
+}
+
+TEST(BaseDialogTest, SetTitleDoesNotCrash)
+{
+    BaseDialog dlg;
+    dlg.setTitle(QStringLiteral("Test Dialog"));
+}
+
+TEST(BaseDialogTest, SetTitleFontDoesNotCrash)
+{
+    BaseDialog dlg;
+    QFont font;
+    font.setBold(true);
+    dlg.setTitleFont(font);
+}


### PR DESCRIPTION
3 个此前未测试类，11 用例，基于最新 master。ut-dfm-base 1281 tests passed。Draft 模式。

## Summary by Sourcery

Add dfm-base unit tests for core frame, sort/filter, and dialog abstractions to improve coverage and stability.

Tests:
- Add unit tests for AbstractFrame covering URL handling and parent construction behavior.
- Add unit tests for AbstractSortFilter verifying default comparison and filter results.
- Add unit tests for BaseDialog validating safe construction, destruction, and title customization APIs.