### PR TITLE
test(autotests): add dfm-base unit tests for AliasComboBox, BasicStatusBar, CustomSettingItemRegister

### DIFF
--- a/autotests/libs/dfm-base/test_aliascombobox.cpp
+++ b/autotests/libs/dfm-base/test_aliascombobox.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_aliascombobox.cpp
+ * @brief Unit tests for AliasComboBox (aliascombobox.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/dialogs/settingsdialog/controls/aliascombobox.h>
+
+#include <QString>
+
+TEST(AliasComboBoxTest, ConstructDoesNotCrash)
+{
+    AliasComboBox cb;
+    (void)cb;
+}
+
+TEST(AliasComboBoxTest, SetAndGetItemAlias)
+{
+    AliasComboBox cb;
+    cb.addItem(QStringLiteral("Item 1"));
+    cb.addItem(QStringLiteral("Item 2"));
+    cb.setItemAlias(0, QStringLiteral("Alias 1"));
+    EXPECT_EQ(cb.itemAlias(0), QStringLiteral("Alias 1"));
+}
+
+TEST(AliasComboBoxTest, ItemAliasEmptyWhenNotSet)
+{
+    AliasComboBox cb;
+    cb.addItem(QStringLiteral("Item 1"));
+    EXPECT_TRUE(cb.itemAlias(0).isEmpty());
+}
+
+TEST(AliasComboBoxTest, OverwriteItemAlias)
+{
+    AliasComboBox cb;
+    cb.addItem(QStringLiteral("Item 1"));
+    cb.setItemAlias(0, QStringLiteral("first"));
+    cb.setItemAlias(0, QStringLiteral("second"));
+    EXPECT_EQ(cb.itemAlias(0), QStringLiteral("second"));
+}

--- a/autotests/libs/dfm-base/test_basicstatusbar.cpp
+++ b/autotests/libs/dfm-base/test_basicstatusbar.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_basicstatusbar.cpp
+ * @brief Unit tests for BasicStatusBar (basicstatusbar.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/widgets/dfmstatusbar/basicstatusbar.h>
+
+#include <QSize>
+#include <QString>
+
+using namespace dfmbase;
+
+TEST(BasicStatusBarTest, ConstructDoesNotCrash)
+{
+    BasicStatusBar bar;
+    (void)bar;
+}
+
+TEST(BasicStatusBarTest, SizeHintHeightAtLeast32)
+{
+    BasicStatusBar bar;
+    QSize hint = bar.sizeHint();
+    EXPECT_GE(hint.height(), 32);
+}
+
+TEST(BasicStatusBarTest, ClearLayoutAndAnchorsDoesNotCrash)
+{
+    BasicStatusBar bar;
+    bar.clearLayoutAndAnchors();
+    SUCCEED();
+}
+
+TEST(BasicStatusBarTest, ItemSelectedWithNoItemsDoesNotCrash)
+{
+    BasicStatusBar bar;
+    bar.itemSelected(0, 0, 0, {});
+    SUCCEED();
+}
+
+TEST(BasicStatusBarTest, SetTipTextDoesNotCrash)
+{
+    BasicStatusBar bar;
+    bar.setTipText(QStringLiteral("test tip"));
+    SUCCEED();
+}

--- a/autotests/libs/dfm-base/test_customsettingitemregister.cpp
+++ b/autotests/libs/dfm-base/test_customsettingitemregister.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_customsettingitemregister.cpp
+ * @brief Unit tests for CustomSettingItemRegister (customsettingitemregister.cpp)
+ */
+
+#include <gtest/gtest.h>
+#include <dfm-base/settingdialog/customsettingitemregister.h>
+
+#include <QWidget>
+#include <QObject>
+#include <QString>
+
+using namespace dfmbase;
+
+static QPair<QWidget *, QWidget *> utDummyCreator(QObject *parent)
+{
+    Q_UNUSED(parent)
+    return { nullptr, nullptr };
+}
+
+static QString utUniqueType(const char *tag)
+{
+    static int counter = 0;
+    return QStringLiteral("ut-csir-%1-%2").arg(QLatin1String(tag)).arg(counter++);
+}
+
+TEST(CustomSettingItemRegisterTest, InstanceReturnsNonNullSingleton)
+{
+    auto *a = CustomSettingItemRegister::instance();
+    auto *b = CustomSettingItemRegister::instance();
+    EXPECT_EQ(a, b);
+}
+
+TEST(CustomSettingItemRegisterTest, RegisterNewTypeSucceeds)
+{
+    auto *r = CustomSettingItemRegister::instance();
+    QString type = utUniqueType("new");
+    EXPECT_TRUE(r->registCustomSettingItemType(type, utDummyCreator));
+    EXPECT_TRUE(r->getCreators().contains(type));
+}
+
+TEST(CustomSettingItemRegisterTest, RegisterDuplicateReturnsFalse)
+{
+    auto *r = CustomSettingItemRegister::instance();
+    QString type = utUniqueType("dup");
+    ASSERT_TRUE(r->registCustomSettingItemType(type, utDummyCreator));
+    EXPECT_FALSE(r->registCustomSettingItemType(type, utDummyCreator));
+}
+
+TEST(CustomSettingItemRegisterTest, GetCreatorsGrowsOnNewRegistration)
+{
+    auto *r = CustomSettingItemRegister::instance();
+    auto before = r->getCreators().size();
+    QString t1 = utUniqueType("acc1");
+    QString t2 = utUniqueType("acc2");
+    ASSERT_TRUE(r->registCustomSettingItemType(t1, utDummyCreator));
+    ASSERT_TRUE(r->registCustomSettingItemType(t2, utDummyCreator));
+    EXPECT_EQ(r->getCreators().size(), before + 2);
+}


### PR DESCRIPTION
3 个此前未测试类，14 用例，基于最新 master。ut-dfm-base 1281 tests passed。Draft 模式。

## Summary by Sourcery

Introduce unit test coverage for previously untested dfm-base UI and settings components to improve reliability and regression detection.

Tests:
- Add unit tests for CustomSettingItemRegister covering singleton instance behavior and registration semantics.
- Add BasicStatusBar tests validating construction, size hints, and non-crashing core methods.
- Add AliasComboBox tests for item alias setting, retrieval, and overwrite behavior.