### PR TITLE
fix: add AT-SPI accessible names (desktop plugins)

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
@@ -88,6 +88,7 @@ void CanvasViewMenuProxy::showEmptyAreaMenu(const Qt::ItemFlags &indexFlags, con
     }
 
     menuPtr = new DMenu(view);
+    menuPtr->setAccessibleName("MenuPtr");
     canvasScene->create(menuPtr);
     canvasScene->updateState(menuPtr);
     if (QAction *act = menuPtr->exec(QCursor::pos())) {

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
@@ -77,6 +77,7 @@ void CollectionViewMenu::emptyAreaMenu()
         delete menuPtr;
 
     menuPtr = new DMenu(view);
+    menuPtr->setAccessibleName("MenuPtr_2");
     canvasScene->create(menuPtr);
     canvasScene->updateState(menuPtr);
 

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+expected_names:
+- line: 91
+  name: MenuPtr
+  source_file: src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
+  variable: menuPtr
+- line: 80
+  name: MenuPtr_2
+  source_file: src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+  variable: menuPtr


### PR DESCRIPTION
## 变更内容

为 desktop plugins 模块的交互控件添加 setAccessibleName() 调用。

此为 PR #4080 按功能模块拆分的一部分。

## Summary by Sourcery

Add AT-SPI accessible names to desktop plugin context menus and register them in accessibility tests.

New Features:
- Provide accessible names for desktop plugin context menus in canvas and organizer views to improve AT-SPI compatibility.

Tests:
- Add an expected_names.yaml fixture to validate accessible names for desktop plugin menus in AT-SPI tests.