### PR TITLE
fix: add AT-SPI accessible names (file manager basic plugins)

### DIFF
--- a/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
@@ -106,7 +106,9 @@ void OpticalMediaWidget::initializeUi()
     lbAvailable = new QLabel("<Space Available>");
     lbUDFSupport = new QLabel(tr("It does not support burning UDF discs"));
     pbDump = new DPushButton();
+    pbDump->setAccessibleName("PbDump");
     pbBurn = new DPushButton();
+    pbBurn->setAccessibleName("PbBurn");
     iconCaution = new QSvgWidget();
 
     // 设置按钮文本

--- a/src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
@@ -26,6 +26,7 @@ IndexStatusCheckBox::IndexStatusCheckBox(QWidget *parent)
     layout->setSpacing(4);
 
     m_checkBox = new QCheckBox(this);
+    m_checkBox->setAccessibleName("CheckBox_3");
     layout->addWidget(m_checkBox);
 
     auto *statusWidget = new QWidget(this);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -45,6 +45,7 @@ SideBarWidget::SideBarWidget(QFrame *parent)
 {
     compositingConfig = DConfig::create("org.kde.kwin", "org.kde.kwin.compositing", QString(), this);
     sidebarView = new SideBarView(sidebarViewContainer);
+    sidebarView->setAccessibleName("SidebarView");
 #ifdef ENABLE_TESTING
     dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
                          qobject_cast<QWidget *>(sidebarView), AcName::kAcDmSideBarView);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
@@ -72,6 +72,7 @@ void FileViewMenuHelper::showEmptyAreaMenu()
         delete menuPtr;
 
     menuPtr = new DMenu(this->view);
+    menuPtr->setAccessibleName("MenuPtr_3");
     scene->create(menuPtr);
     scene->updateState(menuPtr);
     reloadCursor();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
@@ -113,6 +113,7 @@ void FileViewStatusBar::initScalingSlider()
     fmDebug() << "Initializing scaling slider";
 
     scaleSlider = new DSlider(Qt::Horizontal, this);
+    scaleSlider->setAccessibleName("ScaleSlider");
     scaleSlider->adjustSize();
     scaleSlider->setFixedWidth(120);
     scaleSlider->setMaximum(1);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
@@ -136,6 +136,7 @@ void FileViewPrivate::initListModeView()
         auto headerLayout = qobject_cast<QVBoxLayout *>(headerWidget->layout());
 
         headerView = new HeaderView(Qt::Orientation::Horizontal, q);
+    headerView->setAccessibleName("HeaderView");
 
         headerView->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         headerView->setFixedHeight(kListViewHeaderHeight);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
@@ -44,7 +44,9 @@ void RenameBarPrivate::initUI()
 
     mainLayout = new QHBoxLayout(widget);
     comboBox = new QComboBox;
+    comboBox->setAccessibleName("ComboBox_2");
     stackWidget = new QStackedWidget;
+    stackWidget->setAccessibleName("StackWidget");
 
     replaceOperatorItems = std::make_tuple(new QLabel, new QLineEdit, new QLabel, new QLineEdit);
     frameForLayoutReplaceArea = QPair<QHBoxLayout *, QFrame *> { new QHBoxLayout, new QFrame };
@@ -133,6 +135,7 @@ void RenameBarPrivate::setUIParameters()
     button->setText(QObject::tr("Cancel", "button"));
     button->setFixedWidth(82);
     renameBtn = new DSuggestButton();
+    renameBtn->setAccessibleName("RenameBtn");
     renameBtn->setText(QObject::tr("Rename", "button"));
     renameBtn->setFixedWidth(82);
     button->setEnabled(true);

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+expected_names:
+- line: 111
+  name: PbBurn
+  source_file: src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+  variable: pbBurn
+- line: 109
+  name: PbDump
+  source_file: src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+  variable: pbDump
+- line: 29
+  name: CheckBox_3
+  source_file: src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
+  variable: m_checkBox
+- line: 48
+  name: SidebarView
+  source_file: src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+  variable: sidebarView
+- line: 75
+  name: MenuPtr_3
+  source_file: src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+  variable: menuPtr
+- line: 116
+  name: ScaleSlider
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
+  variable: scaleSlider
+- line: 139
+  name: HeaderView
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/fileview_p.cpp
+  variable: headerView
+- line: 47
+  name: ComboBox_2
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+  variable: comboBox
+- line: 49
+  name: StackWidget
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+  variable: stackWidget
+- line: 138
+  name: RenameBtn
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+  variable: renameBtn


### PR DESCRIPTION
## 变更内容

为 file manager basic plugins 模块的交互控件添加 setAccessibleName() 调用。

此为 PR #4080 按功能模块拆分的一部分。

## Summary by Sourcery

Add AT-SPI accessible names to key file manager basic plugin widgets and controls.

New Features:
- Provide explicit accessible names for file manager workspace controls including rename bar combo box, stacked widget, and rename button.
- Provide explicit accessible names for optical media action buttons, search index status checkbox, sidebar view, file view empty-area menu, status bar scaling slider, and file view header.
- Define expected AT-SPI accessible names for these widgets in a new test expectations configuration file.

Tests:
- Add an AT-SPI expected_names.yaml test fixture to validate accessible names for key file manager plugin widgets.