### PR TITLE
fix: add AT-SPI accessible names (file dialog plugin)

### DIFF
--- a/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+++ b/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
@@ -247,7 +247,9 @@ void FileDialogStatusBar::initializeUi()
     filtersLabel->setObjectName(labelFilters);
 
     fileNameEdit = new DLineEdit(this);
+    fileNameEdit->setAccessibleName("FileNameEdit_2");
     filtersComboBox = new DComboBox(this);
+    filtersComboBox->setAccessibleName("FiltersComboBox");
 #ifdef ENABLE_TESTING
     dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
                          qobject_cast<QWidget *>(fileNameEdit), AcName::kAcFDStatusBarFileNameEdit);

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+expected_names:
+- line: 250
+  name: FileNameEdit_2
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  variable: fileNameEdit
+- line: 252
+  name: FiltersComboBox
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  variable: filtersComboBox


### PR DESCRIPTION
## 变更内容

为 file dialog plugin 模块的交互控件添加 setAccessibleName() 调用。

此为 PR #4080 按功能模块拆分的一部分。

## Summary by Sourcery

Add AT-SPI accessible names to file dialog status bar controls and align tests with the new accessibility identifiers.

New Features:
- Expose accessible names for the file name input and filter selection controls in the file dialog status bar for AT-SPI clients.

Tests:
- Add an expected_names.yaml fixture to validate AT-SPI accessible names for file dialog status bar widgets.