### PR TITLE
fix: remove permission settings for marker file and directory

### DIFF
--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -758,10 +758,6 @@ bool DiskEncryptSetupPrivate::createMarkerFile(const QString &path)
             qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to create settings directory:" << disk_encrypt::kOverlayDMSettingsDir;
             return false;
         }
-        if (!dir.setPermissions(QDir::ReadOwner | QDir::WriteOwner | QDir::ExeOwner)) {
-            qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to set permissions on settings directory";
-            return false;
-        }
         qInfo() << "[DiskEncryptSetupPrivate::createMarkerFile] Settings directory created:" << disk_encrypt::kOverlayDMSettingsDir;
     }
 
@@ -774,13 +770,6 @@ bool DiskEncryptSetupPrivate::createMarkerFile(const QString &path)
         }
         qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to create marker file:" << path
                     << "Error:" << file.errorString();
-        return false;
-    }
-
-    // Set owner-only permissions to prevent tampering by non-root users
-    if (!file.setPermissions(QFile::ReadOwner | QFile::WriteOwner)) {
-        qCritical() << "[DiskEncryptSetupPrivate::createMarkerFile] Failed to set permissions on marker file:" << path;
-        file.close();
         return false;
     }
 


### PR DESCRIPTION
The createMarkerFile function previously set restrictive permissions
(owner-only) on the settings directory and the marker file. These
permission changes could fail in certain environments (e.g., when the
process does not have the required privileges), causing the entire
marker file creation to abort. Since the directory and file are created
by the same process (often running as root) and the system's default
umask or parent directory permissions already provide adequate security,
these explicit permission calls are unnecessary and can be removed to
eliminate potential failure points.

Influence:
1. Test marker file creation under root and non-root users (if
applicable)
2. Verify that the created directory and file have appropriate default
permissions (e.g., based on umask)
3. Ensure no regression in disk encryption setup functionality
4. Check that logs no longer show permission-related errors during
marker file creation

fix: 移除标记文件和目录的权限设置

createMarkerFile 函数之前对设置目录和标记文件设置了严格的权限（仅所有者
读写执行）。这些权限更改在某些环境下可能失败（例如，进程没有所需权限），
导致整个标记文件创建中止。由于目录和文件由同一进程（通常以 root 运行）创
建，且系统的默认 umask 或父目录权限已提供足够的安全性，因此这些显式权限
调用是不必要的，可以移除，以消除潜在的失败点。

Influence:
1. 测试在 root 和非 root 用户下创建标记文件（如适用）
2. 验证创建的目录和文件具有适当的默认权限（例如基于 umask）
3. 确保磁盘加密设置功能没有回归
4. 检查日志中不再出现标记文件创建过程中与权限相关的错误

## Summary by Sourcery

Relax marker file creation to rely on default filesystem permissions and avoid failures when explicit permission changes are not allowed.

Bug Fixes:
- Avoid marker file creation failures caused by unsuccessful attempts to set restrictive permissions on the settings directory and marker file.

Enhancements:
- Simplify DiskEncryptSetup marker file handling by removing explicit owner-only permission settings now deemed unnecessary given existing system defaults.