### PR TITLE
perf: adopt QCollator buffer strategy for ICU sort key generation

### DIFF
--- a/src/dfm-base/utils/collation/icucollationstrategy.cpp
+++ b/src/dfm-base/utils/collation/icucollationstrategy.cpp
@@ -75,9 +75,10 @@ QByteArray IcuCollationStrategy::sortKey(const QString &s) const
     const UChar *utf16 = reinterpret_cast<const UChar *>(s.utf16());
     const int32_t len = s.size();
 
-    // 启发式缓冲区生成；不够则按返回值扩容重试。ucol_getSortKey 不接收 UErrorCode。
-    QByteArray key;
-    key.resize(len * 4 + 16);
+    // 采用与 QCollator::sortKey (qtbase qcollator_icu.cpp) 相同的缓冲区策略：
+    // Qt::Uninitialized 避免零填充，容量 16+len+len/4 是 Qt 的启发式（多数 sort key
+    // 不会超出此容量，避免扩容重试）。ucol_getSortKey 不接收 UErrorCode。
+    QByteArray key(16 + len + (len >> 2), Qt::Uninitialized);
     int32_t n = ucol_getSortKey(m_collator, utf16, len,
                                 reinterpret_cast<uint8_t *>(key.data()), key.size());
     if (n > key.size()) {


### PR DESCRIPTION
## 背景

PR #4127（feat: add dconfig-gated Latin-first sort strategy for zh_CN）已合入 master。合入后实测 98977 文件排序仍有小幅下降（修改前 best 416ms / 本次 best 551ms）。本 PR 为该性能残留的修复 follow-up。

## 排查结论（微基准实证，locale=zh_CN.UTF-8 / Qt 6.8.0 / ICU 74 / -O2）

- **排除键类型（`QByteArray` 24B vs `QCollatorSortKey` 8B）为根因**：微基准显示 `QByteArray`(32B 元素) 在 sort 阶段反而比 `QCollatorSortKey`(16B 元素) 更快——`QByteArray` 的 `QArrayData` 把引用计数+size+缓冲区分配在一个堆块（1 次 alloc，更好的 cache 局部性），而 `QCollatorSortKey` 的 `QExplicitlySharedDataPointer` 把引用计数(`QSharedData`)与缓冲区(`QByteArray`)分到两个堆块（2 次 alloc，局部性更差）。2.5× 的元素大小被更好的堆局部性抵消。
- **排除"参考 Qt 源码做 8B 共享指针包装器"为 0 损失方案**：实测该方案（复刻 `QCollatorSortKey` 的两段堆分配）反而比 `QByteArray` 更慢。
- **定位残留根因**在 `IcuCollationStrategy::sortKey` 的 keygen 缓冲区分配：原实现 `key.resize(len*4+16)` 会**零填充**且**过量分配**（4× 长度，多写 ~2.7× 内存）；而 QCollator 源码（`qtbase/src/corelib/text/qcollator_icu.cpp` `QCollator::sortKey`）用 `QByteArray(16 + len + (len>>2), Qt::Uninitialized)`——不填充、精确容量启发式。

## 修复

采用 QCollator 源码同款缓冲区策略：

```cpp
- QByteArray key;
- key.resize(len * 4 + 16);
+ QByteArray key(16 + len + (len >> 2), Qt::Uninitialized);
```

微基准（带 cache 污染模拟真实 metadata 抓取，N=98977）证实优化后总耗时不劣于修改前 `QCollator` 方案（keygen 持平、sort 仍更快）。

## 改动

1 文件，+4/-3。仅 `src/dfm-base/utils/collation/icucollationstrategy.cpp` 的 `sortKey` 缓冲区分配方式调整，不改变接口、不改变排序结果。详见 attachment `patch.diff` / `benchmark-evidence.txt`。

## 验证

- 新文件 `-fsyntax-only` 检查通过；微基准隔离复现（详见 `benchmark-evidence.txt`）。
- 建议合入后复测 98977 文件排序耗时确认。

## Summary by Sourcery

Enhancements:
- Align ICU sort key buffer sizing strategy with QCollator by using an uninitialized, heuristic-sized QByteArray to reduce unnecessary zero-filling and memory writes.