### PR TITLE
fix(sidebar): unify group header arrow style

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -30,7 +30,6 @@
 #include <QDebug>
 #include <QApplication>
 #include <qdrawutil.h>
-#include <QImage>
 #include <QFontMetrics>
 #include <QEvent>
 #include <QMouseEvent>
@@ -50,6 +49,7 @@ DGUI_USE_NAMESPACE
 
 static constexpr int kRadius = 8;
 static constexpr int kExpandIconSize = 12;
+static constexpr int kSeparatorExpandIconSize = 14;
 static constexpr int kItemMargin = 10;
 static constexpr int kItemIconSize = 16;
 static constexpr int kEjectIconSize = 16;
@@ -58,6 +58,7 @@ static constexpr int kDefaultMaxLength = 40;
 
 #ifdef DTKWIDGET_CLASS_DSizeMode
 static constexpr int kCompactExpandIconSize = 10;
+static constexpr int kCompactSeparatorExpandIconSize = 12;
 static constexpr int kCompactModeIcon = 16;
 #endif
 
@@ -259,7 +260,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     qreal textWidthMax;
     bool isHovering = opt.state.testFlag(QStyle::State_MouseOver) || isDropTarget;
     if (separatorItem) {
-        textWidthMax = isHovering ? (baseValue - kExpandIconSize - 10) : baseValue;
+        textWidthMax = isHovering ? (baseValue - kSeparatorExpandIconSize - 10) : baseValue;
     } else {
         textWidthMax = isEjectable ? min : max;
     }
@@ -591,9 +592,15 @@ void SideBarItemDelegate::drawMouseHoverBackground(QPainter *painter, const DPal
 void SideBarItemDelegate::drawMouseHoverExpandButton(QPainter *painter, const QRect &r, bool isExpanded) const
 {
     painter->save();
-    int iconSize = kExpandIconSize;
+    SideBarView *sidebarView = dynamic_cast<SideBarView *>(this->parent());
+    if (!sidebarView) {
+        painter->restore();
+        return;
+    }
+
+    int iconSize = kSeparatorExpandIconSize;
 #ifdef DTKWIDGET_CLASS_DSizeMode
-    iconSize = DSizeModeHelper::element(kCompactExpandIconSize, kExpandIconSize);
+    iconSize = DSizeModeHelper::element(kCompactSeparatorExpandIconSize, kSeparatorExpandIconSize);
 #endif
 
     int x = r.right() - 10 - iconSize;
@@ -603,20 +610,51 @@ void SideBarItemDelegate::drawMouseHoverExpandButton(QPainter *painter, const QR
 
     bool isDarkType = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
     QColor c(isDarkType ? qRgb(255, 255, 255) : qRgb(0, 0, 0));
+    QColor normalColor = isDarkType ? QColor(255, 255, 255, 102) : QColor(0, 0, 0, 102);
+    QColor hoverColor = isDarkType ? QColor(255, 255, 255, 179) : QColor(0, 0, 0, 179);
 
     painter->setPen(Qt::NoPen);
     painter->setBrush(c);
-    SideBarView *sidebarView = dynamic_cast<SideBarView *>(this->parent());
     QRect bgRect = iconRect.marginsAdded(QMargins(3, 3, 3, 3));
-    if (bgRect.contains(sidebarView->mapFromGlobal(QCursor::pos()))) {
+    const QPoint hoverPos = sidebarView->mapFromGlobal(QCursor::pos());
+    const bool isHoveringExpand = bgRect.contains(hoverPos);
+    if (isHoveringExpand) {
         painter->setOpacity(0.1);
-        painter->drawRoundedRect(bgRect, kRadius, kRadius);
+        painter->drawEllipse(QRectF(bgRect).adjusted(0.5, 0.5, -0.5, -0.5));
     }
 
     painter->setOpacity(1);
-    painter->setPen(Qt::gray);
-    QIcon icon = QIcon::fromTheme(isExpanded ? "go-up" : "go-down");
-    icon.paint(painter, iconRect, Qt::AlignmentFlag::AlignCenter);
+    QColor arrowColor = isHoveringExpand ? hoverColor : normalColor;
+    int arrowSize = kExpandIconSize;
+#ifdef DTKWIDGET_CLASS_DSizeMode
+    arrowSize = DSizeModeHelper::element(kCompactExpandIconSize, kExpandIconSize);
+#endif
+    QRect arrowRect(QPoint(0, 0), QSize(arrowSize, arrowSize));
+    arrowRect.moveCenter(iconRect.center());
+
+    QStyleOptionButton arrowOpt;
+    arrowOpt.initFrom(sidebarView);
+    arrowOpt.rect = QRect(QPoint(0, 0), arrowRect.size());
+    arrowOpt.state |= QStyle::State_Enabled;
+    arrowOpt.palette.setColor(QPalette::ButtonText, Qt::white);
+    arrowOpt.palette.setColor(QPalette::WindowText, Qt::white);
+    arrowOpt.palette.setColor(QPalette::Text, Qt::white);
+
+    if (QStyle *style = sidebarView->style()) {
+        const qreal dpr = painter->device() ? painter->device()->devicePixelRatioF() : qApp->devicePixelRatio();
+        QPixmap arrowPixmap(arrowRect.size() * dpr);
+        arrowPixmap.setDevicePixelRatio(dpr);
+        arrowPixmap.fill(Qt::transparent);
+
+        QPainter arrowPainter(&arrowPixmap);
+        style->drawPrimitive(isExpanded ? QStyle::PE_IndicatorArrowUp : QStyle::PE_IndicatorArrowDown,
+                             &arrowOpt, &arrowPainter, sidebarView);
+        arrowPainter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+        arrowPainter.fillRect(QRect(QPoint(0, 0), arrowRect.size()), arrowColor);
+        arrowPainter.end();
+
+        painter->drawPixmap(arrowRect.topLeft(), arrowPixmap);
+    }
     painter->restore();
 }
 


### PR DESCRIPTION
## Summary / 概述
- Render the sidebar group header arrow with style primitives so it matches the title bar arrow shape and avoids jagged themed icons.
- Use the actual group header button width when calculating hover text space, so the title and arrow spacing stays stable.
- Recolor the arrow with 40% black in light mode and 40% white in dark mode, then raise it to 70% black or white on hover.

- 使用样式原语绘制侧边栏分组标题箭头，使其与标题栏箭头形态一致，并避免主题图标出现锯齿。
- 分组标题在 hover 时按实际按钮宽度预留文字空间，保证标题和箭头的间距稳定。
- 按主题重着色箭头：普通状态下浅色模式使用 40% 不透明度黑色、深色模式使用 40% 不透明度白色；hover 状态下提升为 70% 不透明度黑色或白色。

## Test / 验证
- Sidebar plugin build verified in the original 6.6.3 workspace with the isolated plugin target.
- The change scope is limited to the sidebar group header hover arrow path and does not touch the partition child expand indicator.

- 已在原始 6.6.3 工作区通过独立侧边栏插件目标完成编译验证。
- 改动范围仅限侧边栏分组标题 hover 折叠箭头路径，没有修改分区子项左侧展开箭头。

## PMS
- BUG-373517
- https://pms.uniontech.com/bug-view-373517.html

## Summary by Sourcery

Unify the sidebar group header hover arrow appearance with the title bar arrow and stabilize text spacing when the expand arrow is shown.

Bug Fixes:
- Ensure sidebar group header hover arrows render with consistent shape and anti-aliasing across themes.
- Fix unstable title-to-arrow spacing in sidebar group headers by using the actual hover button width when reserving text space.

Enhancements:
- Adjust sidebar group header hover arrow sizing and background shape for separator items, including compact mode sizing.
- Recolor sidebar group header hover arrows using calibrated opacity levels for light and dark themes to improve visual clarity.