### PR TITLE
fix(disk-encrypt): set proper DBus timeout for TPM interface to preve…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
@@ -61,6 +61,11 @@ inline constexpr char kTCMPcrBank[] { "sm3_256" };
 // DBus timeout constant: 2 seconds to prevent UI blocking when service is unavailable
 inline constexpr int kDiskEncryptDBusTimeoutMs = 2000;
 
+// TPM DBus timeout constant: 1 minute. TPM operations (e.g. IsTPMAvailable / Encrypt)
+// may trigger a Polkit authentication dialog; we wait for the user to finish auth
+// instead of timing out after the Qt DBus default 25s and falling back incorrectly.
+inline constexpr int kTPMDBusTimeoutMs = 60 * 1000;   // 1 min
+
 // TPM Control service constants
 inline constexpr char kTPMControlService[] = "org.deepin.Filemanager.TPMControl";
 inline constexpr char kTPMControlPath[] = "/org/deepin/Filemanager/TPMControl";

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -61,7 +61,8 @@ QString config_utils::cipherType()
 
 int tpm_utils::checkTPM()
 {
-    CREATE_TPM_INTERFACE(iface);
+    QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "TPMControl DBus interface is invalid, service may be unavailable";
         return -1;
@@ -73,7 +74,8 @@ int tpm_utils::checkTPM()
 
 int tpm_utils::checkTPMLockoutStatus()
 {
-    CREATE_TPM_INTERFACE(iface);
+    QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "TPMControl DBus interface is invalid, service may be unavailable";
         return -1;
@@ -85,7 +87,8 @@ int tpm_utils::checkTPMLockoutStatus()
 
 int tpm_utils::getRandomByTPM(int size, QString *output)
 {
-    CREATE_TPM_INTERFACE(iface);
+    QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "TPMControl DBus interface is invalid, service may be unavailable";
         return -1;
@@ -143,7 +146,8 @@ int tpm_utils::getRandomByTPM(int size, QString *output)
 
 int tpm_utils::isSupportAlgoByTPM(const QString &algoName, bool *support)
 {
-    CREATE_TPM_INTERFACE(iface);
+    QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "TPMControl DBus interface is invalid, service may be unavailable";
         return -1;
@@ -168,7 +172,8 @@ int tpm_utils::isSupportAlgoByTPM(const QString &algoName, bool *support)
 
 int tpm_utils::encryptByTPM(const QVariantMap &map)
 {
-    CREATE_TPM_INTERFACE(iface);
+    QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "TPMControl DBus interface is invalid, service may be unavailable";
         return -1;
@@ -211,7 +216,8 @@ int tpm_utils::encryptByTPM(const QVariantMap &map)
 
 int tpm_utils::decryptByTPM(const QVariantMap &map, QString *psw)
 {
-    CREATE_TPM_INTERFACE(iface);
+    QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "TPMControl DBus interface is invalid, service may be unavailable";
         return -1;
@@ -300,7 +306,8 @@ int tpm_utils::decryptByTPM(const QVariantMap &map, QString *psw)
 
 int tpm_utils::ownerAuthStatus()
 {
-    CREATE_TPM_INTERFACE(iface);
+    QDBusInterface iface(kTPMControlService, kTPMControlPath, kTPMControlInterface, QDBusConnection::systemBus());
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "TPMControl DBus interface is invalid, service may be unavailable";
         return -1;


### PR DESCRIPTION
…nt premature auth fallback

The CREATE_TPM_INTERFACE macro did not apply any DBus timeout, causing all TPM DBus calls (IsTPMAvailable, CheckTPMLockout, Encrypt, Decrypt, etc.) to fall back to Qt DBus's default 25s timeout.

TPM methods such as IsTPMAvailable trigger a Polkit authentication dialog (auth_admin) on the service side. When the user did not complete the auth within 25s, checkAuthorizationSync() timed out and returned failure, which made checkTPM()/checkTPMLockoutStatus() return non-zero. As a result the encryption params dialog incorrectly removed all TPM-related unlock options and fell back to passphrase-only mode.

Add a dedicated kTPMDBusTimeoutMs constant (1 minute) and apply it in the CREATE_TPM_INTERFACE macro so that the caller waits long enough for the user to finish Polkit authentication, keeping the TPM unlock options visible.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-373403.html

## Summary by Sourcery

Bug Fixes:
- Ensure TPM DBus calls in the disk encryption plugin use a dedicated 1-minute timeout so TPM unlock options remain available while users complete Polkit authentication.