### PR TITLE
test: add unit tests for new collation sort strategy in dfm-base

### DIFF
--- a/autotests/libs/dfm-base/test_collationstrategyprovider.cpp
+++ b/autotests/libs/dfm-base/test_collationstrategyprovider.cpp
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_collationstrategyprovider.cpp
+ * @brief CollationStrategyProvider 单元测试 —— 排序策略提供者 + 线程安全。
+ *
+ * 覆盖点：
+ *   - 单例：instance() 返回同一指针
+ *   - strategy() 返回有效引用、可产出排序键
+ *   - 同线程内 strategy() 返回同一实例（thread_local，代际未变时不重建）
+ *   - latinFirstEnabled() 安全可调用
+ *   - strategyChanged 信号：匹配的 dconfig 变更触发、不匹配的不触发
+ *   - 代际失效：valueChanged 后 strategy() 重建出新实例
+ *   - 【线程安全】多线程并发 strategy() 不崩溃、结果有效
+ *   - 【线程安全】并发 strategy() 期间持续变更代际（dconfig 切换竞态）不崩溃
+ *   - 【线程安全】不同线程各自拥有独立 thread_local 实例
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/utils/collation/collationstrategyprovider.h>
+#include <dfm-base/utils/collation/collationstrategy.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/configs/dconfig/global_dconf_defines.h>
+
+#include <QSignalSpy>
+#include <QString>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace dfmbase;
+using GlobalDConfDefines::ConfigPath::kDefaultCfgPath;
+using GlobalDConfDefines::BaseConfig::kSortLatinFirstZhCn;
+
+namespace {
+/// 通过元对象系统触发 DConfigManager::valueChanged 信号，模拟 dconfig 变更。
+/// 信号经 DirectConnection 同步调用已连接的 onDConfigChanged，使代际自增并
+/// 发出 strategyChanged。
+void emitDConfigValueChanged(const QString &config, const QString &key)
+{
+    QMetaObject::invokeMethod(DConfigManager::instance(), "valueChanged",
+                              Qt::DirectConnection,
+                              Q_ARG(QString, config), Q_ARG(QString, key));
+}
+}   // namespace
+
+class CollationStrategyProviderTest : public testing::Test
+{
+protected:
+    /// 触发一次有效代际变更（匹配的 dconfig 键），用于后续测试
+    void bumpGeneration()
+    {
+        emitDConfigValueChanged(kDefaultCfgPath, kSortLatinFirstZhCn);
+    }
+};
+
+// 单例：instance() 始终返回同一指针
+TEST_F(CollationStrategyProviderTest, SingletonReturnsSameInstance)
+{
+    auto *a = CollationStrategyProvider::instance();
+    auto *b = CollationStrategyProvider::instance();
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(a, b);
+}
+
+// strategy() 返回有效引用，可产出非空排序键
+TEST_F(CollationStrategyProviderTest, StrategyReturnsValidReference)
+{
+    const CollationStrategy &s = CollationStrategyProvider::instance()->strategy();
+    EXPECT_FALSE(s.sortKey("test_file.txt").isEmpty());
+    EXPECT_FALSE(s.sortKey("中文文件").isEmpty());
+}
+
+// 同线程内 strategy() 返回同一实例（thread_local，代际未变时不重建）
+TEST_F(CollationStrategyProviderTest, SameThreadGetsSameInstanceWithoutRebuild)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    const CollationStrategy &s1 = provider->strategy();
+    const CollationStrategy &s2 = provider->strategy();
+    EXPECT_EQ(&s1, &s2);
+}
+
+// latinFirstEnabled() 安全可调用、返回 bool
+TEST_F(CollationStrategyProviderTest, LatinFirstEnabledIsCallable)
+{
+    bool ok = false;
+    EXPECT_NO_FATAL_FAILURE({ ok = CollationStrategyProvider::instance()->latinFirstEnabled(); });
+    (void)ok;   // 仅验证不崩溃；默认 dconfig 未注册时为 false
+}
+
+// strategyChanged 信号：匹配的 dconfig 键变更时发出
+TEST_F(CollationStrategyProviderTest, StrategyChangedEmittedOnMatchingKey)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    QSignalSpy spy(provider, &CollationStrategyProvider::strategyChanged);
+    ASSERT_TRUE(spy.isValid());
+    bumpGeneration();
+    EXPECT_GE(spy.count(), 1);
+}
+
+// strategyChanged 信号：不匹配的键变更时不发出
+TEST_F(CollationStrategyProviderTest, StrategyChangedNotEmittedOnUnmatchedKey)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    QSignalSpy spy(provider, &CollationStrategyProvider::strategyChanged);
+    ASSERT_TRUE(spy.isValid());
+    emitDConfigValueChanged(kDefaultCfgPath, "dfm.some.unrelated.key");
+    EXPECT_EQ(spy.count(), 0);
+}
+
+// 代际失效：valueChanged 后 strategy() 重建出新实例（地址不同且功能正常）
+TEST_F(CollationStrategyProviderTest, GenerationChangeRebuildsStrategy)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    const CollationStrategy *before = &provider->strategy();
+    bumpGeneration();
+    const CollationStrategy *after = &provider->strategy();
+    EXPECT_NE(before, after) << "代际变更后应重建出新的策略实例";
+    // 新实例功能正常
+    EXPECT_FALSE(after->sortKey("test").isEmpty());
+}
+
+// 代际多次变更：每次 valueChanged 后 strategy() 实例均重建
+TEST_F(CollationStrategyProviderTest, RepeatedGenerationChangesRebuild)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    const CollationStrategy *prev = &provider->strategy();
+    for (int i = 0; i < 5; ++i) {
+        bumpGeneration();
+        const CollationStrategy *cur = &provider->strategy();
+        EXPECT_NE(prev, cur) << "第 " << i << " 次代际变更后实例应重建";
+        EXPECT_FALSE(cur->sortKey("test").isEmpty());
+        prev = cur;
+    }
+}
+
+// ───────────────────────── 线程安全测试 ─────────────────────────
+
+// 【线程安全】多线程并发 strategy() 不崩溃、所有结果有效
+TEST_F(CollationStrategyProviderTest, ConcurrentStrategyAccessIsSafe)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    const int numThreads = 8;
+    const int iterations = 500;
+    std::atomic<int> emptyKeyFailures { 0 };
+    std::atomic<int> crashes { 0 };
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < numThreads; ++t) {
+        threads.emplace_back([&]() {
+            try {
+                for (int i = 0; i < iterations; ++i) {
+                    const CollationStrategy &s = provider->strategy();
+                    if (s.sortKey("concurrent_test").isEmpty())
+                        ++emptyKeyFailures;
+                }
+            } catch (...) {
+                ++crashes;
+            }
+        });
+    }
+    for (auto &th : threads)
+        th.join();
+
+    EXPECT_EQ(crashes.load(), 0);
+    EXPECT_EQ(emptyKeyFailures.load(), 0);
+}
+
+// 【线程安全】并发 strategy() 期间持续变更代际（dconfig 切换竞态）不崩溃
+// 模拟真实场景：排序工作线程持续取策略，同时 dconfig 变更线程反复触发代际失效。
+TEST_F(CollationStrategyProviderTest, ConcurrentAccessWithGenerationChanges)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    const int numWorkers = 8;
+    std::atomic<bool> stop { false };
+    std::atomic<int> crashes { 0 };
+    std::atomic<int> emptyKeys { 0 };
+    std::vector<std::thread> threads;
+
+    // 工作线程：持续取策略并产出排序键
+    for (int t = 0; t < numWorkers; ++t) {
+        threads.emplace_back([&]() {
+            try {
+                while (!stop.load(std::memory_order_relaxed)) {
+                    const CollationStrategy &s = provider->strategy();
+                    if (s.sortKey("race_test").isEmpty())
+                        ++emptyKeys;
+                }
+            } catch (...) {
+                ++crashes;
+            }
+        });
+    }
+
+    // 主线程：持续触发代际变更
+    for (int i = 0; i < 100; ++i) {
+        bumpGeneration();
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+    }
+    stop.store(true, std::memory_order_relaxed);
+    for (auto &th : threads)
+        th.join();
+
+    EXPECT_EQ(crashes.load(), 0) << "并发 + 代际变更期间不应崩溃";
+    EXPECT_EQ(emptyKeys.load(), 0) << "所有线程产出的排序键应非空";
+}
+
+// 【线程安全】不同线程各自拥有独立的 thread_local 策略实例
+// 代际稳定后：同一线程内 strategy() 返回同一实例；不同线程返回不同实例。
+// 注意：thread_local 对象在线程退出时销毁，故对子线程策略的访问必须在线程内完成，
+// 不得在 join 后解引用子线程返回的策略指针（use-after-free）。
+TEST_F(CollationStrategyProviderTest, ThreadLocalInstancesArePerThread)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    // 稳定代际：先 bump 一次并消费，避免跨测试代际漂移干扰
+    bumpGeneration();
+    (void)provider->strategy();
+
+    const CollationStrategy *mainThreadInstance = &provider->strategy();
+
+    // 在子线程内完成全部验证，避免 join 后访问已销毁的 thread_local 实例
+    std::atomic<bool> differentInstance { false };
+    std::atomic<bool> otherInstanceFunctional { false };
+    std::thread other([&]() {
+        const CollationStrategy *inst = &provider->strategy();
+        differentInstance.store(inst != mainThreadInstance);
+        otherInstanceFunctional.store(!inst->sortKey("test").isEmpty());
+    });
+    other.join();
+
+    EXPECT_TRUE(differentInstance.load())
+        << "不同线程应持有独立的 thread_local 策略实例";
+    EXPECT_TRUE(otherInstanceFunctional.load());
+    // 主线程实例功能正常
+    EXPECT_FALSE(mainThreadInstance->sortKey("test").isEmpty());
+}
+
+// 【线程安全】并发 strategy() 期间代际变更后，线程在下次调用时重建且功能正常
+// 验证代际失效机制在并发下正确传播：变更后各线程都能拿到可用策略。
+TEST_F(CollationStrategyProviderTest, GenerationPropagatesToAllThreads)
+{
+    auto *provider = CollationStrategyProvider::instance();
+    const int numThreads = 6;
+    std::atomic<int> functionalFailures { 0 };
+    std::vector<std::thread> threads;
+
+    // 先让所有线程拿到当前代际的策略
+    for (int t = 0; t < numThreads; ++t) {
+        threads.emplace_back([&]() {
+            (void)provider->strategy();   // 建立本线程 thread_local
+        });
+    }
+    for (auto &th : threads)
+        th.join();
+    threads.clear();
+
+    // 触发代际变更
+    bumpGeneration();
+
+    // 各线程再次取策略：应重建，且功能正常（compare 与 sortKey 一致）
+    for (int t = 0; t < numThreads; ++t) {
+        threads.emplace_back([&]() {
+            const CollationStrategy &s = provider->strategy();
+            // 验证重建后的策略功能正确
+            if (s.compare("a", "b") >= 0 || s.sortKey("x").isEmpty())
+                ++functionalFailures;
+        });
+    }
+    for (auto &th : threads)
+        th.join();
+
+    EXPECT_EQ(functionalFailures.load(), 0)
+        << "代际变更后各线程重建的策略应功能正常";
+}

--- a/autotests/libs/dfm-base/test_filenamesorter.cpp
+++ b/autotests/libs/dfm-base/test_filenamesorter.cpp
@@ -4,113 +4,312 @@
 
 /**
  * @file test_filenamesorter.cpp
- * @brief Unit tests for FileNameSorter (filenamesorter.cpp)
+ * @brief FileNameSorter 单元测试 —— 文件名排序工具 + 线程安全。
+ *
+ * 覆盖点：
+ *   - sortKey 非空 / 确定性
+ *   - sort 升序/降序、数值排序、空列表与单元素 no-op
+ *   - sortUrls 按 fileName 排序
+ *   - compare 升序/降序
+ *   - sortByKey 模板排序
+ *   - 与 CollationStrategyProvider 联动：排序结果稳定一致
+ *   - 【线程安全】多线程并发 sort 不崩溃、结果正确
+ *   - 【线程安全】多线程并发 sortKey + compare 不崩溃、结果正确
  */
 
 #include <gtest/gtest.h>
-#include <QByteArray>
-#include <QStringList>
-#include <QUrl>
 
 #include <dfm-base/utils/filenamesorter.h>
 
+#include <QByteArray>
+#include <QList>
+#include <QString>
+#include <QStringList>
+#include <QUrl>
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
 using namespace dfmbase;
 
-TEST(FileNameSorterTest, SortKeyProducesComparableKey)
+class FileNameSorterTest : public testing::Test
 {
-    QByteArray k1 = FileNameSorter::sortKey("file10");
-    QByteArray k2 = FileNameSorter::sortKey("file2");
-    EXPECT_TRUE(k2 < k1);
+protected:
+    /// 期望数值排序的基准列表
+    QStringList numericNames { "file10", "file2", "file1", "file20", "file3" };
+    QStringList numericExpected { "file1", "file2", "file3", "file10", "file20" };
+};
+
+// sortKey 非空
+TEST_F(FileNameSorterTest, SortKeyNonEmpty)
+{
+    EXPECT_FALSE(FileNameSorter::sortKey("test.txt").isEmpty());
+    EXPECT_FALSE(FileNameSorter::sortKey("文件").isEmpty());
 }
 
-TEST(FileNameSorterTest, SortAscendingNaturalOrder)
+// sortKey 确定性
+TEST_F(FileNameSorterTest, SortKeyDeterministic)
 {
-    QStringList names { "file10", "file2", "file1", "file20" };
+    EXPECT_EQ(FileNameSorter::sortKey("abc"), FileNameSorter::sortKey("abc"));
+    EXPECT_EQ(FileNameSorter::sortKey("文件1"), FileNameSorter::sortKey("文件1"));
+}
+
+// sort 升序
+TEST_F(FileNameSorterTest, SortAscending)
+{
+    QStringList names = { "banana", "apple", "cherry", "date" };
     FileNameSorter::sort(names, Qt::AscendingOrder);
-    EXPECT_EQ(names, QStringList({ "file1", "file2", "file10", "file20" }));
+    EXPECT_EQ(names, QStringList({ "apple", "banana", "cherry", "date" }));
 }
 
-TEST(FileNameSorterTest, SortDescendingNaturalOrder)
+// sort 降序
+TEST_F(FileNameSorterTest, SortDescending)
 {
-    QStringList names { "file10", "file2", "file1", "file20" };
+    QStringList names = { "banana", "apple", "cherry", "date" };
     FileNameSorter::sort(names, Qt::DescendingOrder);
-    EXPECT_EQ(names, QStringList({ "file20", "file10", "file2", "file1" }));
+    EXPECT_EQ(names, QStringList({ "date", "cherry", "banana", "apple" }));
 }
 
-TEST(FileNameSorterTest, SortSingleElementNoOp)
+// sort 数值排序（file2 < file10）
+TEST_F(FileNameSorterTest, SortNumericOrdering)
 {
-    QStringList names { "only" };
-    FileNameSorter::sort(names, Qt::AscendingOrder);
-    EXPECT_EQ(names, QStringList({ "only" }));
+    QStringList names = numericNames;
+    FileNameSorter::sort(names);
+    EXPECT_EQ(names, numericExpected);
 }
 
-TEST(FileNameSorterTest, SortEmptyListNoOp)
+// sort 默认升序
+TEST_F(FileNameSorterTest, SortDefaultIsAscending)
 {
-    QStringList names;
-    FileNameSorter::sort(names, Qt::AscendingOrder);
-    EXPECT_TRUE(names.isEmpty());
+    QStringList names = { "c", "a", "b" };
+    FileNameSorter::sort(names);   // 默认 Qt::AscendingOrder
+    EXPECT_EQ(names, QStringList({ "a", "b", "c" }));
 }
 
-TEST(FileNameSorterTest, SortUrlsAscending)
+// sort 空列表与单元素 no-op
+TEST_F(FileNameSorterTest, SortEmptyAndSingleNoOp)
 {
-    QList<QUrl> urls {
-        QUrl("file:///dir/file10.txt"),
-        QUrl("file:///dir/file2.txt"),
-        QUrl("file:///dir/file1.txt"),
+    QStringList empty;
+    FileNameSorter::sort(empty);
+    EXPECT_TRUE(empty.isEmpty());
+
+    QStringList single = { "only.txt" };
+    FileNameSorter::sort(single);
+    EXPECT_EQ(single, QStringList({ "only.txt" }));
+}
+
+// sort 稳定性：相同排序键的元素保持相对顺序（std::stable_sort）
+TEST_F(FileNameSorterTest, SortIsStable)
+{
+    // 两个 "same" 项应保持输入相对顺序（stable_sort 保证）
+    QStringList names = { "same", "aaa", "same", "bbb" };
+    FileNameSorter::sort(names);
+    EXPECT_EQ(names, QStringList({ "aaa", "bbb", "same", "same" }));
+}
+
+// compare 升序/降序
+TEST_F(FileNameSorterTest, CompareAscendingAndDescending)
+{
+    EXPECT_TRUE(FileNameSorter::compare("apple", "banana"));   // apple < banana
+    EXPECT_FALSE(FileNameSorter::compare("banana", "apple"));   // banana > apple
+    // 降序：banana 应排在 apple 前
+    EXPECT_TRUE(FileNameSorter::compare("banana", "apple", Qt::DescendingOrder));
+    EXPECT_FALSE(FileNameSorter::compare("apple", "banana", Qt::DescendingOrder));
+}
+
+// sortUrls 按 fileName 排序
+TEST_F(FileNameSorterTest, SortUrlsByFileName)
+{
+    QList<QUrl> urls = {
+        QUrl::fromLocalFile("/path/banana.txt"),
+        QUrl::fromLocalFile("/path/apple.txt"),
+        QUrl::fromLocalFile("/path/cherry.txt"),
     };
-    FileNameSorter::sortUrls(urls, Qt::AscendingOrder);
-    EXPECT_EQ(urls[0].fileName(), QString("file1.txt"));
-    EXPECT_EQ(urls[1].fileName(), QString("file2.txt"));
-    EXPECT_EQ(urls[2].fileName(), QString("file10.txt"));
+    FileNameSorter::sortUrls(urls);
+    ASSERT_EQ(urls.size(), 3);
+    EXPECT_EQ(urls[0].fileName(), "apple.txt");
+    EXPECT_EQ(urls[1].fileName(), "banana.txt");
+    EXPECT_EQ(urls[2].fileName(), "cherry.txt");
 }
 
-TEST(FileNameSorterTest, SortUrlsDescending)
+// sortUrls 降序
+TEST_F(FileNameSorterTest, SortUrlsDescending)
 {
-    QList<QUrl> urls {
-        QUrl("file:///dir/file2.txt"),
-        QUrl("file:///dir/file10.txt"),
-        QUrl("file:///dir/file1.txt"),
+    QList<QUrl> urls = {
+        QUrl::fromLocalFile("/path/banana"),
+        QUrl::fromLocalFile("/path/apple"),
+        QUrl::fromLocalFile("/path/cherry"),
     };
     FileNameSorter::sortUrls(urls, Qt::DescendingOrder);
-    EXPECT_EQ(urls[0].fileName(), QString("file10.txt"));
+    ASSERT_EQ(urls.size(), 3);
+    EXPECT_EQ(urls[0].fileName(), "cherry");
+    EXPECT_EQ(urls[2].fileName(), "apple");
 }
 
-TEST(FileNameSorterTest, CompareAscending)
+// sortUrls 空与单元素 no-op
+TEST_F(FileNameSorterTest, SortUrlsEmptyAndSingleNoOp)
 {
-    EXPECT_TRUE(FileNameSorter::compare("file2", "file10", Qt::AscendingOrder));
-    EXPECT_FALSE(FileNameSorter::compare("file10", "file2", Qt::AscendingOrder));
+    QList<QUrl> empty;
+    FileNameSorter::sortUrls(empty);
+    EXPECT_TRUE(empty.isEmpty());
+
+    QList<QUrl> single = { QUrl::fromLocalFile("/x/only") };
+    FileNameSorter::sortUrls(single);
+    ASSERT_EQ(single.size(), 1);
+    EXPECT_EQ(single[0].fileName(), "only");
 }
 
-TEST(FileNameSorterTest, CompareDescending)
+// sortByKey 模板排序
+TEST_F(FileNameSorterTest, SortByKeyTemplate)
 {
-    EXPECT_TRUE(FileNameSorter::compare("file10", "file2", Qt::DescendingOrder));
-    EXPECT_FALSE(FileNameSorter::compare("file2", "file10", Qt::DescendingOrder));
-}
-
-TEST(FileNameSorterTest, SortByKeyAscending)
-{
-    using Item = QPair<QString, QByteArray>;
-    QVector<Item> items {
-        { "b", FileNameSorter::sortKey("b") },
-        { "a", FileNameSorter::sortKey("a") },
-        { "c", FileNameSorter::sortKey("c") },
+    QVector<QPair<QString, QByteArray>> items = {
+        { "banana", FileNameSorter::sortKey("banana") },
+        { "apple", FileNameSorter::sortKey("apple") },
+        { "cherry", FileNameSorter::sortKey("cherry") },
     };
-    FileNameSorter::sortByKey(items, [](const Item &it) { return it.second; }, Qt::AscendingOrder);
-    EXPECT_EQ(items[0].first, QString("a"));
-    EXPECT_EQ(items[1].first, QString("b"));
-    EXPECT_EQ(items[2].first, QString("c"));
+    FileNameSorter::sortByKey(items,
+                              [](const auto &item) { return item.second; });
+    ASSERT_EQ(items.size(), 3);
+    EXPECT_EQ(items[0].first, "apple");
+    EXPECT_EQ(items[1].first, "banana");
+    EXPECT_EQ(items[2].first, "cherry");
 }
 
-TEST(FileNameSorterTest, SortByKeyDescending)
+// sortByKey 模板降序
+TEST_F(FileNameSorterTest, SortByKeyTemplateDescending)
 {
-    using Item = QPair<QString, QByteArray>;
-    QVector<Item> items {
-        { "b", FileNameSorter::sortKey("b") },
-        { "a", FileNameSorter::sortKey("a") },
-        { "c", FileNameSorter::sortKey("c") },
+    QVector<QPair<QString, QByteArray>> items = {
+        { "banana", FileNameSorter::sortKey("banana") },
+        { "apple", FileNameSorter::sortKey("apple") },
+        { "cherry", FileNameSorter::sortKey("cherry") },
     };
-    FileNameSorter::sortByKey(items, [](const Item &it) { return it.second; }, Qt::DescendingOrder);
-    EXPECT_EQ(items[0].first, QString("c"));
-    EXPECT_EQ(items[1].first, QString("b"));
-    EXPECT_EQ(items[2].first, QString("a"));
+    FileNameSorter::sortByKey(items,
+                              [](const auto &item) { return item.second; },
+                              Qt::DescendingOrder);
+    ASSERT_EQ(items.size(), 3);
+    EXPECT_EQ(items[0].first, "cherry");
+    EXPECT_EQ(items[2].first, "apple");
+}
+
+// ───────────────────────── 线程安全测试 ─────────────────────────
+
+// 【线程安全】多线程并发 sort 不崩溃、结果正确
+TEST_F(FileNameSorterTest, ConcurrentSortIsSafeAndCorrect)
+{
+    const int numThreads = 8;
+    const int iterations = 100;
+    std::atomic<int> failures { 0 };
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < numThreads; ++t) {
+        threads.emplace_back([&]() {
+            for (int i = 0; i < iterations; ++i) {
+                QStringList names = numericNames;   // 每线程独立副本
+                FileNameSorter::sort(names);
+                if (names != numericExpected)
+                    ++failures;
+            }
+        });
+    }
+    for (auto &th : threads)
+        th.join();
+
+    EXPECT_EQ(failures.load(), 0) << "并发排序结果应全部正确";
+}
+
+// 【线程安全】多线程并发 sortKey + compare 不崩溃、结果正确
+TEST_F(FileNameSorterTest, ConcurrentSortKeyAndCompareSafe)
+{
+    const int numThreads = 8;
+    std::atomic<int> failures { 0 };
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < numThreads; ++t) {
+        threads.emplace_back([&]() {
+            for (int i = 0; i < 200; ++i) {
+                QByteArray k = FileNameSorter::sortKey("test");
+                if (k.isEmpty()) {
+                    ++failures;
+                    break;
+                }
+                // a < b 升序应返回 true
+                if (!FileNameSorter::compare("a", "b")) {
+                    ++failures;
+                }
+                // 数值序：file2 < file10
+                if (!FileNameSorter::compare("file2", "file10")) {
+                    ++failures;
+                }
+            }
+        });
+    }
+    for (auto &th : threads)
+        th.join();
+
+    EXPECT_EQ(failures.load(), 0);
+}
+
+// 【线程安全】并发 sortUrls 不崩溃、结果正确
+TEST_F(FileNameSorterTest, ConcurrentSortUrlsSafe)
+{
+    const int numThreads = 6;
+    std::atomic<int> failures { 0 };
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < numThreads; ++t) {
+        threads.emplace_back([&]() {
+            for (int i = 0; i < 50; ++i) {
+                QList<QUrl> urls = {
+                    QUrl::fromLocalFile("/d/file10"),
+                    QUrl::fromLocalFile("/d/file2"),
+                    QUrl::fromLocalFile("/d/file1"),
+                };
+                FileNameSorter::sortUrls(urls);
+                if (urls[0].fileName() != "file1" || urls[1].fileName() != "file2"
+                    || urls[2].fileName() != "file10")
+                    ++failures;
+            }
+        });
+    }
+    for (auto &th : threads)
+        th.join();
+
+    EXPECT_EQ(failures.load(), 0);
+}
+
+// 【线程安全】并发 sort + sortKey 混合调用不崩溃
+TEST_F(FileNameSorterTest, ConcurrentMixedOperationsSafe)
+{
+    const int numThreads = 8;
+    std::atomic<int> failures { 0 };
+    std::atomic<int> crashes { 0 };
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < numThreads; ++t) {
+        threads.emplace_back([t, &failures, &crashes]() {
+            try {
+                for (int i = 0; i < 100; ++i) {
+                    if (t % 2 == 0) {
+                        QStringList names = { "c", "a", "b", "a" };
+                        FileNameSorter::sort(names);
+                        if (names != QStringList({ "a", "a", "b", "c" }))
+                            ++failures;
+                    } else {
+                        if (FileNameSorter::sortKey("x").isEmpty())
+                            ++failures;
+                        if (!FileNameSorter::compare("a", "b"))
+                            ++failures;
+                    }
+                }
+            } catch (...) {
+                ++crashes;
+            }
+        });
+    }
+    for (auto &th : threads)
+        th.join();
+
+    EXPECT_EQ(crashes.load(), 0);
+    EXPECT_EQ(failures.load(), 0);
 }

--- a/autotests/libs/dfm-base/test_icucollationstrategy.cpp
+++ b/autotests/libs/dfm-base/test_icucollationstrategy.cpp
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_icucollationstrategy.cpp
+ * @brief IcuCollationStrategy 单元测试 —— 新排序核心策略的功能覆盖。
+ *
+ * 覆盖点：
+ *   - 不可拷贝契约（编译期 static_assert）
+ *   - sortKey 确定性 / 非空 / 排序一致性
+ *   - compare 符号契约（<0 / 0 / >0）与 sortKey 序一致
+ *   - 数值排序（UCOL_NUMERIC_COLLATION=ON：file2 < file10）
+ *   - 大小写敏感（UCOL_DEFAULT_STRENGTH）
+ *   - Unicode（中文）排序键
+ *   - clearReorder 拉丁在前 vs 默认拼音重排（zh_CN 下行为差异）
+ *   - 析构安全（多次构造/析构不泄漏/不崩溃）
+ */
+
+#include <gtest/gtest.h>
+
+#include <dfm-base/utils/collation/icucollationstrategy.h>
+
+#include <QByteArray>
+#include <QLocale>
+#include <QString>
+#include <QStringList>
+#include <algorithm>
+#include <type_traits>
+
+using namespace dfmbase;
+
+namespace {
+/// 当前系统 locale 是否为简体中文（决定 clearReorder 是否有可观测行为差异）
+bool systemIsZhCn()
+{
+    const QLocale loc = QLocale::system();
+    return loc.language() == QLocale::Chinese && loc.country() == QLocale::China;
+}
+}   // namespace
+
+class IcuCollationStrategyTest : public testing::Test
+{
+protected:
+    /// 默认策略（不清空重排），等价于原 QCollator 行为
+    IcuCollationStrategy defaultStrategy;
+    /// 拉丁在前策略（清空脚本重排）
+    IcuCollationStrategy latinFirstStrategy { true };
+};
+
+// 不可拷贝：IcuCollationStrategy 持有 ICU 句柄，禁止拷贝（编译期校验）
+TEST_F(IcuCollationStrategyTest, NonCopyableContract)
+{
+    static_assert(!std::is_copy_constructible<IcuCollationStrategy>::value,
+                  "IcuCollationStrategy 应不可拷贝构造");
+    static_assert(!std::is_copy_assignable<IcuCollationStrategy>::value,
+                  "IcuCollationStrategy 应不可拷贝赋值");
+    SUCCEED();
+}
+
+// sortKey 确定性：相同输入必须产出相同键
+TEST_F(IcuCollationStrategyTest, SortKeyDeterministic)
+{
+    EXPECT_EQ(defaultStrategy.sortKey("hello"), defaultStrategy.sortKey("hello"));
+    EXPECT_EQ(defaultStrategy.sortKey(""), defaultStrategy.sortKey(""));
+    EXPECT_EQ(defaultStrategy.sortKey("文件.txt"), defaultStrategy.sortKey("文件.txt"));
+}
+
+// sortKey 非空：非空输入产出非空键
+TEST_F(IcuCollationStrategyTest, SortKeyNonEmptyForNonEmptyInput)
+{
+    EXPECT_FALSE(defaultStrategy.sortKey("abc").isEmpty());
+    EXPECT_FALSE(defaultStrategy.sortKey("测试文件").isEmpty());
+}
+
+// 不同输入产出不同键（区分明显不同的字符串）
+TEST_F(IcuCollationStrategyTest, SortKeyDistinctForDistinctInput)
+{
+    EXPECT_NE(defaultStrategy.sortKey("apple"), defaultStrategy.sortKey("banana"));
+    EXPECT_NE(defaultStrategy.sortKey("file1"), defaultStrategy.sortKey("file2"));
+}
+
+// sortKey 字母序一致：apple < banana < cherry
+TEST_F(IcuCollationStrategyTest, SortKeyAlphabeticalOrdering)
+{
+    EXPECT_TRUE(defaultStrategy.sortKey("apple") < defaultStrategy.sortKey("banana"));
+    EXPECT_TRUE(defaultStrategy.sortKey("banana") < defaultStrategy.sortKey("cherry"));
+    // 逆序不成立
+    EXPECT_FALSE(defaultStrategy.sortKey("cherry") < defaultStrategy.sortKey("apple"));
+}
+
+// compare 符号契约：<0 / 0 / >0
+TEST_F(IcuCollationStrategyTest, CompareSignContract)
+{
+    EXPECT_LT(defaultStrategy.compare("a", "b"), 0);   // a 排在 b 前
+    EXPECT_EQ(defaultStrategy.compare("same", "same"), 0);   // 相等
+    EXPECT_GT(defaultStrategy.compare("b", "a"), 0);   // b 排在 a 后
+}
+
+// compare 与 sortKey 序一致：compare<0 当且仅当 sortKey 偏小
+TEST_F(IcuCollationStrategyTest, CompareAgreesWithSortKey)
+{
+    const QString a = "apple";
+    const QString b = "banana";
+    EXPECT_LT(defaultStrategy.compare(a, b), 0);
+    EXPECT_TRUE(defaultStrategy.sortKey(a) < defaultStrategy.sortKey(b));
+    EXPECT_GT(defaultStrategy.compare(b, a), 0);
+    EXPECT_FALSE(defaultStrategy.sortKey(b) < defaultStrategy.sortKey(a));
+}
+
+// 数值排序：UCOL_NUMERIC_COLLATION=ON 使 file2 < file10
+TEST_F(IcuCollationStrategyTest, NumericCollationOrdering)
+{
+    EXPECT_LT(defaultStrategy.compare("file2", "file10"), 0);
+    EXPECT_TRUE(defaultStrategy.sortKey("file2") < defaultStrategy.sortKey("file10"));
+
+    // 完整列表排序验证
+    QStringList names = { "file10", "file2", "file1", "file20" };
+    std::sort(names.begin(), names.end(),
+              [this](const QString &l, const QString &r) {
+                  return defaultStrategy.sortKey(l) < defaultStrategy.sortKey(r);
+              });
+    EXPECT_EQ(names, QStringList({ "file1", "file2", "file10", "file20" }));
+}
+
+// 大小写敏感：UCOL_DEFAULT_STRENGTH 下 "A" 与 "a" 不相等
+TEST_F(IcuCollationStrategyTest, CaseSensitiveDistinction)
+{
+    EXPECT_NE(defaultStrategy.compare("A", "a"), 0);
+    EXPECT_NE(defaultStrategy.sortKey("A"), defaultStrategy.sortKey("a"));
+}
+
+// Unicode（中文）排序键有效
+TEST_F(IcuCollationStrategyTest, ChineseStringSortKey)
+{
+    EXPECT_FALSE(defaultStrategy.sortKey("测试文件").isEmpty());
+    EXPECT_EQ(defaultStrategy.sortKey("测试文件"), defaultStrategy.sortKey("测试文件"));
+    EXPECT_NE(defaultStrategy.sortKey("文件A"), defaultStrategy.sortKey("文件B"));
+}
+
+// 两种策略均产出有效键（构造不崩溃、sortKey 可用）
+TEST_F(IcuCollationStrategyTest, BothStrategiesProduceValidKeys)
+{
+    EXPECT_FALSE(defaultStrategy.sortKey("test").isEmpty());
+    EXPECT_FALSE(latinFirstStrategy.sortKey("test").isEmpty());
+    EXPECT_FALSE(defaultStrategy.sortKey("中文").isEmpty());
+    EXPECT_FALSE(latinFirstStrategy.sortKey("中文").isEmpty());
+}
+
+// clearReorder 行为差异：zh_CN 下拉丁在前 vs 默认拼音重排
+TEST_F(IcuCollationStrategyTest, ClearReorderBehaviorZhCn)
+{
+    // 非 zh_CN 环境下 clearReorder 为 no-op，仅验证不崩溃
+    if (!systemIsZhCn()) {
+        SUCCEED() << "非 zh_CN 环境，clearReorder 为 no-op，跳过排序差异断言";
+        return;
+    }
+
+    // zh_CN 默认含 [reorder Hani]：中文字符按拼音与拉丁交错。
+    //   "啊" 拼音 "a" → 在拼音序中排在 "zzz"（z）之前。
+    // clearReorder=true 清空重排：拉丁脚本块整体排在中文之前 → "zzz" < "啊"。
+    const QByteArray keyLatinDefault = defaultStrategy.sortKey("zzz");
+    const QByteArray keyChineseDefault = defaultStrategy.sortKey("啊");
+    const QByteArray keyLatinFirst = latinFirstStrategy.sortKey("zzz");
+    const QByteArray keyChineseFirst = latinFirstStrategy.sortKey("啊");
+
+    // 默认（拼音重排）："啊"(a) < "zzz"(z)
+    EXPECT_TRUE(keyChineseDefault < keyLatinDefault)
+        << "zh_CN 默认应按拼音交错，'啊'(a) 排在 'zzz'(z) 之前";
+
+    // 拉丁在前：所有拉丁排在中文之前 → "zzz" < "啊"
+    EXPECT_TRUE(keyLatinFirst < keyChineseFirst)
+        << "clearReorder=true 应使拉丁排在中文之前，'zzz' < '啊'";
+
+    // 两种策略对同一字符串可能产出不同键（重排规则不同）
+    // 至少存在某些字符串使键不同（已由上面的交错 vs 分块差异隐含覆盖）
+}
+
+// clearReorder 完整列表排序：拉丁在前时拉丁整体先于中文
+TEST_F(IcuCollationStrategyTest, ClearReorderFullListOrderingZhCn)
+{
+    if (!systemIsZhCn()) {
+        SUCCEED() << "非 zh_CN 环境，跳过完整列表排序差异断言";
+        return;
+    }
+
+    // 混合拉丁与中文名
+    QStringList names = { "work", "apple", "文件", "备份" };
+
+    // 拉丁在前排序：所有拉丁排在所有中文之前
+    QStringList latinFirst = names;
+    std::sort(latinFirst.begin(), latinFirst.end(),
+              [this](const QString &l, const QString &r) {
+                  return latinFirstStrategy.sortKey(l) < latinFirstStrategy.sortKey(r);
+              });
+    // 前两个应是拉丁（apple, work），后两个是中文
+    EXPECT_TRUE(latinFirst.at(0) == "apple" || latinFirst.at(0) == "work");
+    EXPECT_TRUE(latinFirst.at(1) == "apple" || latinFirst.at(1) == "work");
+    EXPECT_TRUE(latinFirst.at(2) == "文件" || latinFirst.at(2) == "备份");
+    EXPECT_TRUE(latinFirst.at(3) == "文件" || latinFirst.at(3) == "备份");
+
+    // 默认（拼音重排）：中文与拉丁交错，至少有一个中文排在某个拉丁之前
+    QStringList defaultOrder = names;
+    std::sort(defaultOrder.begin(), defaultOrder.end(),
+              [this](const QString &l, const QString &r) {
+                  return defaultStrategy.sortKey(l) < defaultStrategy.sortKey(r);
+              });
+    bool chineseBeforeLatin = false;
+    for (int i = 0; i < defaultOrder.size(); ++i) {
+        bool iIsChinese = (defaultOrder[i] == "文件" || defaultOrder[i] == "备份");
+        for (int j = i + 1; j < defaultOrder.size(); ++j) {
+            bool jIsLatin = (defaultOrder[j] == "apple" || defaultOrder[j] == "work");
+            if (iIsChinese && jIsLatin)
+                chineseBeforeLatin = true;
+        }
+    }
+    EXPECT_TRUE(chineseBeforeLatin)
+        << "默认拼音重排应使中文（按拼音）与拉丁交错，存在中文排在拉丁之前的情况";
+}
+
+// 析构安全：多次构造/析构不崩溃（验证 ucol_close 正确释放）
+TEST_F(IcuCollationStrategyTest, RepeatedConstructionDestructionSafe)
+{
+    for (int i = 0; i < 100; ++i) {
+        IcuCollationStrategy s(false);
+        EXPECT_FALSE(s.sortKey("test").isEmpty());
+        IcuCollationStrategy s2(true);
+        EXPECT_FALSE(s2.sortKey("test").isEmpty());
+    }
+    SUCCEED();
+}
+
+// 长字符串与特殊字符不崩溃
+TEST_F(IcuCollationStrategyTest, LongAndSpecialStringsSafe)
+{
+    const QString longName(10000, 'a');
+    EXPECT_NO_FATAL_FAILURE({ (void)defaultStrategy.sortKey(longName); });
+    EXPECT_NO_FATAL_FAILURE({ (void)defaultStrategy.sortKey("!@#$%^&*()_+-="); });
+    EXPECT_NO_FATAL_FAILURE({ (void)defaultStrategy.compare(longName, "a"); });
+    EXPECT_FALSE(defaultStrategy.sortKey(longName).isEmpty());
+}


### PR DESCRIPTION
## 背景

承接 V-1958（PR #4141，文件排序性能回退修复）合入后的 follow-up：新排序已落地为 `IcuCollationStrategy`（ICU 直出 `QByteArray` 排序键，`clearReorder` 开关控制拉丁在前）+ `CollationStrategyProvider`（代际计数器 + `thread_local` 无锁线程安全）+ `FileNameSorter`（适配 `QByteArray` 键）。本次为该新排序在 `dfm-base` 中补充单元测试，**重点覆盖功能正确性与线程安全**。

## 改动

新增 / 扩充 3 个测试文件（仅测试代码，不改动业务代码）：

- **`autotests/libs/dfm-base/test_icucollationstrategy.cpp`**（新增，15 用例）
  不可拷贝契约（`static_assert`）、`sortKey` 确定性/非空/字母序、`compare` 符号契约（<0/0/>0）与 `sortKey` 序一致、数值排序（`UCOL_NUMERIC_COLLATION=ON`：file2<file10）、大小写敏感、中文排序键、两种策略均产出有效键、`clearReorder` 拉丁在前 vs 默认拼音重排（zh_CN 下行为差异，非 zh_CN 自动跳过）、完整列表排序差异、多次构造析构安全、长串与特殊字符不崩溃。

- **`autotests/libs/dfm-base/test_collationstrategyprovider.cpp`**（新增，12 用例）
  单例、`strategy()` 有效引用、同线程实例复用（代际未变不重建）、`latinFirstEnabled()` 可调用、`strategyChanged` 信号匹配键触发/不匹配不触发、代际失效重建、多次代际变更重建。
  **线程安全**：并发 `strategy()` 访问、并发访问期间持续代际变更（dconfig 切换竞态）、不同线程 `thread_local` 独立实例、代际变更向各线程传播并重建后功能正常。

- **`autotests/libs/dfm-base/test_filenamesorter.cpp`**（扩充，18 用例）
  适配 `QByteArray` 排序键；`sort` 升序/降序/数值序/默认升序/空与单元素 no-op/稳定排序、`compare` 升序降序、`sortUrls` 按 fileName 排序/降序/空与单元素、`sortByKey` 模板升序降序。
  **线程安全**：多线程并发 `sort`、并发 `sortKey`+`compare`、并发 `sortUrls`、并发混合操作，均断言不崩溃且结果正确。

合计 45 个用例。

## 验证

- 本机构建 `ut-dfm-base` 目标通过（Qt 6.8.0 / ICU 74 / locale=zh_CN.UTF-8 / Debug）。
- 运行新增 3 个 suite 共 45 个用例：全部 PASSED；其中线程安全相关用例连续运行 3 次均稳定通过。
- 运行完整 `ut-dfm-base`（135 suite / 1312 用例）：全部 PASSED，无回归。

> 注：日志中的 `value error key: "dfm.sort.latinfirst.zhCn"` 为测试环境未注册 dconfig schema 时的回退提示（`latinFirstEnabled()` 返回默认 false），不影响用例结果。

## Summary by Sourcery

Add comprehensive unit test coverage for the new ICU-based collation strategy and its provider, including filename sorting behavior and thread-safety under concurrent access.

Tests:
- Introduce unit tests for IcuCollationStrategy covering determinism, numeric collation, case sensitivity, locale-dependent clearReorder behavior, and robustness for long/special strings.
- Add unit tests for CollationStrategyProvider validating singleton behavior, generation-based strategy rebuilding, dconfig-driven signaling, thread-local instances, and concurrent access with configuration races.
- Expand FileNameSorter tests to cover sortKey properties, ascending/descending and numeric filename ordering, URL-based sorting, key-based template sorting, and multi-threaded correctness and stability across mixed operations.