### PR TITLE
fix(openwith): unify separator line lengths in OpenWith dialog

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -200,7 +200,8 @@ OpenWithDialogListSparerItem::OpenWithDialogListSparerItem(const QString &title,
     initUiForSizeMode();
     layout->addWidget(separator);
     layout->addWidget(titleLabel);
-    layout->setContentsMargins(20, 0, 20, 0);
+    layout->setContentsMargins(0, 0, 0, 0);
+    titleLabel->setContentsMargins(20, 0, 0, 0);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 }
 


### PR DESCRIPTION
fix(openwith): unify separator line lengths in OpenWith dialog

1. Changed OpenWithDialogListSparerItem layout margins from (20,0,20,0) to (0,0,0,0) so separator lines span the full content width
2. Added titleLabel->setContentsMargins(20,0,0,0) to preserve the original title text indentation
3. All three separator lines now have consistent 690px width with 10px margins on each side

Log: Unify the three separator line lengths in the OpenWith dialog
Influence: OpenWith dialog separator lines now display with consistent width

fix(openwith): 统一打开方式对话框中分割线长度

1. 将 OpenWithDialogListSparerItem 布局边距从 (20,0,20,0) 改为 (0,0,0,0)，使分割线撑满内容宽度
2. 为 titleLabel 单独设置 setContentsMargins(20,0,0,0)，保持标题文字原有缩进位置不变
3. 三条分割线长度统一为 690px，左右间距各 10px

Log: 统一打开方式对话框中三条分割线的长度
PMS: BUG-373519
Influence: 打开方式对话框分割线长度显示一致

PMS: https://pms.uniontech.com/bug-view-373519.html

## Summary by Sourcery

Enhancements:
- Adjust OpenWith dialog list item and title label margins so separator lines span the full content width while preserving title indentation.