### PR TITLE
fix(sidebar): route partition expand/collapse through onChangeExpandState

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -171,7 +171,6 @@ void SideBarViewPrivate::expandItem(const QModelIndex &index, const QList<QUrl> 
         return;
 
     q->model()->addSubItems(index, subFolders);
-    q->expand(index);
     q->onChangeExpandState(index, true);
     q->setCurrentUrl(sidebarUrl);
 }
@@ -180,7 +179,6 @@ void SideBarViewPrivate::expandPartitionItem(const QModelIndex &index, const QUr
 {
     // If already expanded, collapse it.
     if (q->isExpanded(index)) {
-        q->collapse(index);
         q->onChangeExpandState(index, false);
         return;
     }
@@ -236,7 +234,6 @@ void SideBarViewPrivate::onExpandableChanged()
             // Collapse the partition and remove its sub-items so file watchers are released.
             if (q->isExpanded(index)) {
                 fmDebug() << "SideBarViewPrivate: Collapsing expanded partition:" << sidebarItem->url();
-                q->collapse(index);
                 q->onChangeExpandState(index, false);
             }
             // Remove dynamically-added sub-items (keep the partition item itself).


### PR DESCRIPTION
## 根因分析

侧边栏分区树形展开时背景变白，与静态透明模糊效果不一致。

分区展开/折叠功能（`33a080544`）的新增路径在调用 `SideBarView::onChangeExpandState()` 之前，先直接调用了 `QTreeView::expand()`/`collapse()`，导致展开/折叠动画在**不透明 palette** 下启动，新区域按白色 `QPalette::Base` 绘制；动画结束回到静态重绘才恢复透明模糊。

关键证据：
- `sidebarview.cpp` `expandItem`/`expandPartitionItem`/`onExpandableChanged` 中 `expand()`/`collapse()` 先于 `onChangeExpandState` 启动动画，绕过透明 palette。
- `onChangeExpandState` 内 `setTransparentPalette()`→`setExpanded()`→`restorePalette()` 的正确时序（`3611c7c9a` 引入），透明 palette 必须先于 `setExpanded` 生效；`setAnimated(true)` 下对已处目标状态的项 `setExpanded` 是空操作、不重启动画，故后到的透明 palette 对已启动动画无效。
- 分组（separator）展开只走 `onChangeExpandState` 单一入口、不预展开，故不闪白——对照组。

## 修复方案

把分区展开/折叠统一收敛到 `onChangeExpandState` 单一入口，删除其前冗余的 `expand()`/`collapse()` 直调（`onChangeExpandState` 内部已 `setExpanded` 并管理文件监听/重绘，功能完备）。改动仅删 3 行、不动数据流，与既有分组展开路径对齐。

## 改动安全评估

低风险。三处修改均为函数体内冗余调用删除，无签名变更、无外部调用者受影响；待删代码均出自功能引入提交 `33a080544`，不撤销任何历史修复；本修复与 `3611c7c9a` 的透明 palette 机制方向一致、无冲突。

## Summary by Sourcery

Route sidebar partition expand/collapse through the unified onChangeExpandState entry point to ensure consistent visual behavior.

Bug Fixes:
- Prevent sidebar partition items from briefly rendering with an opaque white background during expand/collapse animations by avoiding direct QTreeView expand/collapse calls.

Enhancements:
- Align partition expand/collapse behavior with existing group expansion flow by removing redundant direct expand/collapse calls and relying solely on onChangeExpandState for state changes and related side effects.