### PR TITLE
fix(sidebar): guard stale QModelIndex across async sidebar expansion

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/private/sidebarview_p.h
@@ -36,7 +36,7 @@ class SideBarViewPrivate : public QObject
     QPoint dropPos;
     QModelIndex previous;
     QModelIndex current;
-    QModelIndex currentHoverIndex;
+    QPersistentModelIndex currentHoverIndex;
     bool isItemDragged = false;
     bool isRenderingDragPreview = false;
     QList<QUrl> urlsForDragEvent;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -115,10 +115,11 @@ void SideBarViewPrivate::onItemDoubleClicked(const QModelIndex &index)
             QPointer<SideBarView> view = q;
             QPointer<SideBarViewPrivate> guard(this);
             QUrl deviceUrl = nodeUrl;
+            const QPersistentModelIndex persistentCapturedIndex(capturedIndex);
 
             int subId = DeviceMountSubscriber::instance()->subscribe(
                     nodeUrl,
-                    [capturedIndex, view, guard, deviceUrl](const QUrl &mountedUrl) {
+                    [persistentCapturedIndex, view, guard, deviceUrl](const QUrl &mountedUrl) {
                         if (!view || !guard) {
                             fmDebug() << "SideBarViewPrivate: View destroyed before mount completed";
                             return;
@@ -129,15 +130,21 @@ void SideBarViewPrivate::onItemDoubleClicked(const QModelIndex &index)
                         fmDebug() << "SideBarViewPrivate: Device mounted at" << mountedUrl
                                   << ", auto-expanding directory";
 
-                        QTimer::singleShot(100, view, [capturedIndex, mountedUrl, view, guard]() {
+                        QTimer::singleShot(100, view, [persistentCapturedIndex, mountedUrl, view, guard]() {
                             if (!view || !guard) {
                                 fmDebug() << "SideBarViewPrivate: View destroyed during delayed expansion";
                                 return;
                             }
 
+                            if (!persistentCapturedIndex.isValid()
+                                || persistentCapturedIndex.model() != view->model()) {
+                                fmDebug() << "SideBarViewPrivate: Stale index after mount, aborting auto-expand";
+                                return;
+                            }
+
                             if (mountedUrl.isValid() && mountedUrl.scheme() == "file"
                                 && QDir(mountedUrl.path()).exists()) {
-                                guard->expandPartitionItem(capturedIndex, mountedUrl);
+                                guard->expandPartitionItem(persistentCapturedIndex, mountedUrl);
                             } else {
                                 fmDebug() << "SideBarViewPrivate: Unable to expand - invalid mounted URL:"
                                           << mountedUrl;
@@ -188,8 +195,13 @@ void SideBarViewPrivate::expandPartitionItem(const QModelIndex &index, const QUr
         filters |= QDir::Hidden;
     TraversalDirThread *t = new TraversalDirThread(url, {}, filters, QDirIterator::FollowSymlinks);
     connect(t, &TraversalDirThread::finished, t, &TraversalDirThread::deleteLater);
+    const QPersistentModelIndex persistentIndex(index);
     connect(t, &TraversalDirThread::updateChildren, this, [=](const QList<QUrl> &subs) {
-        this->expandItem(index, subs);
+        if (!persistentIndex.isValid() || persistentIndex.model() != q->model()) {
+            fmDebug() << "SideBarViewPrivate: Stale index after traversal, aborting expand";
+            return;
+        }
+        this->expandItem(persistentIndex, subs);
     });
     t->start();
 }
@@ -254,10 +266,12 @@ void SideBarViewPrivate::updateHoverIndex(const QModelIndex &index)
     const QModelIndex previousHoverIndex = currentHoverIndex;
     currentHoverIndex = index;
 
-    if (previousHoverIndex.isValid())
-        q->update(previousHoverIndex);
-    if (currentHoverIndex.isValid())
-        q->update(currentHoverIndex);
+    auto safeUpdate = [this](const QModelIndex &idx) {
+        if (idx.isValid() && idx.model() == q->model())
+            q->update(idx);
+    };
+    safeUpdate(previousHoverIndex);
+    safeUpdate(currentHoverIndex);
 }
 
 void SideBarViewPrivate::clearHoverIndex()
@@ -1408,12 +1422,13 @@ void SideBarView::onChangeExpandState(const QModelIndex &index, bool expand)
         sidebarModel->onItemCollapsed(index);
     }
 
-    update(index);
+    if (index.isValid() && index.model() == sidebarModel)
+        update(index);
 }
 
 void SideBarView::onRequestCollapseItem(const QModelIndex &index)
 {
-    if (index.isValid()) {
+    if (index.isValid() && index.model() == model()) {
         collapse(index);
         onChangeExpandState(index, false);
         fmDebug() << "Collapsed item per model request:" << index.data(Qt::DisplayRole).toString();


### PR DESCRIPTION
## 根因分析

侧边栏分区树运行在「共享 `SideBarModel`（所有窗口共用）+ `setAnimated(true)`」结构下，多个异步源（inotify 文件监听、设备挂载/卸载、`TraversalDirThread` 完成、`partitionExpandable` dconfig 切换）会在展开动画运行期间 `removeRow` 释放模型项。但侧边栏仍以**普通 `QModelIndex`**（非 `QPersistentModelIndex`）跨这些异步边界持有索引（`currentHoverIndex` 成员、`expandPartitionItem` 的 `TraversalDirThread` 捕获 `index`、挂载回调 `capturedIndex`），且 `update(index)` 仅以 `isValid()` 防护——而 `QModelIndex::isValid()` 不解引用 `internalPointer`，无法识别父项已被释放的悬空索引。

悬空索引经 `QAbstractItemView::update(QModelIndex)`（崩溃栈 #5）→ 重绘取 `QStandardItemModel::data`（#1）→ `QStandardItem::child`（#0）解引用**已释放的父 `QStandardItem`** → use-after-free → SIGSEGV。这是偶现崩溃（仅一次、未能复现）的根因；与历史提交 `a83ab18d1`（加 `isValid()` 守卫）、`b482b622e`（V-854，文件监听路径加固）方向一致，本次补齐其未覆盖的 `currentHoverIndex` 与异步捕获索引。

### 关键证据

- `treeviews/private/sidebarview_p.h:39` `QModelIndex currentHoverIndex;` 为普通 QModelIndex（同文件 `dragSourceIndex/placeholderParent` 已用 `QPersistentModelIndex`）。
- `sidebarview.cpp` `expandPartitionItem` 在 `TraversalDirThread::updateChildren` lambda 按值捕获普通 `index`；`onItemDoubleClicked` 挂载回调 `capturedIndex` 跨挂载事件 + 100ms 定时器后 `expandPartitionItem(...)`，均未重新校验。
- `sidebarwidget.cpp:38/54/391` `kSidebarModelIns` 静态共享 + `sidebarview.cpp:567 setAnimated(true)`；`sidebarmodel.cpp`/`sidebarfilewatcher.cpp`/`sidebareventreceiver.cpp:171` 多个异步 `removeRow` 释放项。

## 修复方案

沿用团队 `b482b622e` 已采用的 `QPersistentModelIndex` 安全模式：

1. `currentHoverIndex` 改为 `QPersistentModelIndex`，`updateHoverIndex` 既有 `isValid()` 守卫随之对「父项已释放」生效。
2. `expandPartitionItem` 的 `TraversalDirThread` 捕获改为 `QPersistentModelIndex`，回调内先 `isValid()` + `index.model() == model()` 校验再 `expandItem`。
3. `onItemDoubleClicked` 挂载回调 `capturedIndex` 改为 `QPersistentModelIndex`，100ms 定时器回调内重新校验后再 `expandPartitionItem`。
4. `onChangeExpandState`/`onRequestCollapseItem`/`updateHoverIndex` 的 `update(index)`/`collapse(index)` 统一加 `index.model() == model()` 守卫。

未改任何公开 API，未改非竞态路径的可观察行为；动画与异步变更协调（移除动画中项前先停动画）列为后续增强，本轮不扩范围。

## 改动安全评估

低风险：均为函数内部防御性加固，未改函数签名、未删公开成员；`QPersistentModelIndex` 是 `QModelIndex` 的超集语义，非竞态路径行为完全等价。不撤销历史修复（`a83ab18d1`、`b482b622e`）。`updateHoverIndex` 调用者（`clearHoverIndex`/`dragMoveEvent`）、`isDropTarget` 的 `index == currentHoverIndex` 比较均兼容（`QPersistentModelIndex` 提供 `operator==(const QModelIndex&)`）。

## Summary by Sourcery

Guard sidebar view against stale model indexes during asynchronous expansion and hover updates to prevent crashes from use-after-free.

Bug Fixes:
- Prevent auto-expansion after device mount when the captured sidebar index has become stale or belongs to a different model.
- Prevent expansion after directory traversal when the target sidebar index has become invalid or detached from the current model.
- Avoid updating or collapsing sidebar items using indexes whose model no longer matches the sidebar view model to eliminate potential crashes.

Enhancements:
- Use a persistent model index for the sidebar hover state so it remains safe across asynchronous model changes and animations.