### PR TITLE
fix: invalidate icon cache on item update

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -91,6 +91,20 @@ void SideBarItemDelegate::clearIconCache()
     m_iconCache.clear();
 }
 
+void SideBarItemDelegate::invalidateIconCache(const QUrl &url)
+{
+    if (url.isEmpty())
+        return;
+    // Cache keys are formatted as "iconId|WxH|theme|mode|foreground" where iconId
+    // is the item url (see drawIcon/drawDciIcon). Match the url prefix + delimiter
+    // so all pixmaps of that item (any size/theme/mode) are dropped at once; other
+    // items are left untouched. The trailing "|" avoids matching a url that just
+    // happens to be a string prefix of another one.
+    const QString prefix = url.toString() + QLatin1Char('|');
+    for (auto it = m_iconCache.begin(); it != m_iconCache.end();)
+        it = it.key().startsWith(prefix) ? m_iconCache.erase(it) : ++it;
+}
+
 SideBarItemDelegate::SideBarItemDelegate(QAbstractItemView *parent)
     : DStyledItemDelegate(parent)
 {

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.h
@@ -40,6 +40,8 @@ public:
 
     bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index) override;
 
+    void invalidateIconCache(const QUrl &url);
+
 public Q_SLOTS:
     void onEditorTextChanged(const QString &text, SideBarItem *item) const;
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -120,6 +120,11 @@ bool SideBarWidget::removeItem(const QUrl &url)
 void SideBarWidget::updateItem(const QUrl &url, const ItemInfo &newInfo)
 {
     Q_ASSERT(qApp->thread() == QThread::currentThread());
+    // Drop the delegate's cached icon pixmap for this item before refreshing the
+    // model: the cache keys pixmaps by the item url, so a changed icon for the
+    // same url would otherwise be shadowed by the stale pixmap on the next paint.
+    if (auto *delegate = qobject_cast<SideBarItemDelegate *>(sidebarView->itemDelegate()))
+        delegate->invalidateIconCache(url);
     kSidebarModelIns->updateRow(url, newInfo);
     bool hidden { !SideBarHelper::hiddenRules().value(newInfo.visiableControlKey, true).toBool() };
     if (hidden)


### PR DESCRIPTION
When a sidebar item is updated (e.g., its icon changes), the delegate's
icon cache may still hold the previous pixmap keyed by the same URL.
This caused the old icon to be displayed until the cache was cleared
globally. The new `invalidateIconCache` method removes all cached
pixmaps for a given URL, allowing the next paint to fetch the updated
icon.

The fix calls `invalidateIconCache` before the model row is updated in
`SideBarWidget::updateItem`, ensuring the stale cache entry is dropped
immediately.

Log: Fixed sidebar item icon not refreshing after update

Influence:
1. Test updating a sidebar item's icon (e.g., changing a folder's icon)
and verify the new icon appears immediately.
2. Verify that other items’ icons remain unaffected.
3. Test with various icon sizes and themes to ensure cache invalidation
works correctly.
4. Test urgent updates (e.g., item removal/re-insertion) to confirm no
stale pixmap remains.

fix: 在项目更新时清除图标缓存

当侧边栏项目更新时（例如图标改变），委托的图标缓存可能仍持有以相
同URL为键的旧的像素图。这导致在全局缓存清除前显示旧图标。新增的
`invalidateIconCache`方法会移除指定URL的所有缓存像素图，使得下一次绘制时
获取更新后的图标。

修复在`SideBarWidget::updateItem`中，在模型行更新之前调用
`invalidateIconCache`，立即丢弃过时的缓存条目。

Log: 修复侧边栏项目更新后图标不刷新问题

Influence:
1. 测试更新侧边栏项目的图标（如更改文件夹图标），验证新图标立即显示。
2. 验证其他项目的图标不受影响。
3. 测试不同图标大小和主题，确保缓存清除正常。
4. 测试紧急更新（如删除/重新插入项目），确认无残留旧像素图。

## Summary by Sourcery

Ensure sidebar item icon pixmaps are refreshed when an item is updated by invalidating delegate icon cache entries for the affected URL before updating the model row.

Bug Fixes:
- Fix sidebar item icons not updating immediately after an item’s icon changes due to stale cached pixmaps keyed by the same URL.

Enhancements:
- Add URL-scoped icon cache invalidation to the sidebar item delegate so only the updated item’s cached pixmaps are removed without affecting other items.