### PR TITLE
test: add ut-summary.json generation for test results and coverage to multica

### DIFF
--- a/autotests/gen-ut-summary.py
+++ b/autotests/gen-ut-summary.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Generate ut-summary.json from gtest XML reports and lcov coverage data.
+
+Usage:
+  Called from shell test scripts. Reads environment variables:
+    - projectdir:   project root directory
+    - builddir:     build directory name (relative to projectdir)
+    - reportdir:    report output directory name (relative to projectdir)
+
+  Optional overrides (take precedence over defaults):
+    - GTEST_XML_DIR:    directory containing gtest XML reports
+    - COVERAGE_INFO:    path to lcov .info file for coverage parsing
+
+  Output: {projectdir}/{reportdir}/ut-summary.json
+"""
+
+import json
+import xml.etree.ElementTree as ET
+import glob
+import os
+import subprocess
+import re
+import sys
+
+
+def parse_gtest_xml(xml_dir):
+    """Parse Google Test / JUnit XML output and return (total, passed, failed)."""
+    total = passed = failed = 0
+    for xml_file in sorted(glob.glob(os.path.join(xml_dir, "*.xml"))):
+        try:
+            root = ET.parse(xml_file).getroot()
+            # JUnit format uses <testsuites> as root with aggregated counts
+            # gtest XML uses <testsuites> or <testsuite> as root
+            t = int(root.get("tests", 0))
+            f_count = int(root.get("failures", 0))
+            err_count = int(root.get("errors", 0))
+            total += t
+            failed += f_count + err_count
+            passed += t - f_count - err_count
+        except Exception as e:
+            print(f"Warning: failed to parse {xml_file}: {e}", file=sys.stderr)
+    return total, passed, failed
+
+
+def parse_lcov_summary(coverage_info):
+    """Parse lcov --summary output and return coverage dict."""
+    result = {}
+    if not os.path.exists(coverage_info):
+        print(f"Warning: coverage info file not found: {coverage_info}", file=sys.stderr)
+        return result
+
+    lcov_out = subprocess.run(
+        ["lcov", "--summary", coverage_info, "--rc", "lcov_branch_coverage=1"],
+        capture_output=True, text=True
+    )
+    summary_text = lcov_out.stdout + lcov_out.stderr
+
+    # Parse lines:  "lines......: XX.X% (NNN of MMMM lines)"
+    m_lines = re.search(r'lines.*?:\s*([\d.]+)%\s*\((\d+)\s+of\s+(\d+)\s+\w+\)', summary_text)
+    if m_lines:
+        pct, hit, total = m_lines.groups()
+        result["line_coverage"] = {
+            "total": int(total),
+            "passed": int(hit),
+            "failed": int(total) - int(hit),
+            "coverage": f"{float(pct):.2f}%"
+        }
+
+    # Parse functions: "functions..: XX.X% (NNN of MMMM functions)"
+    m_func = re.search(r'functions.*?:\s*([\d.]+)%\s*\((\d+)\s+of\s+(\d+)\s+\w+\)', summary_text)
+    if m_func:
+        pct, hit, total = m_func.groups()
+        result["function_coverage"] = {
+            "total": int(total),
+            "passed": int(hit),
+            "failed": int(total) - int(hit),
+            "coverage": f"{float(pct):.2f}%"
+        }
+
+    return result
+
+
+def main():
+    projectdir = os.environ.get("projectdir")
+    builddir = os.environ.get("builddir")
+    reportdir = os.environ.get("reportdir")
+
+    if not all([projectdir, builddir, reportdir]):
+        print("Error: environment variables projectdir, builddir, reportdir are required", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve paths (env overrides take precedence)
+    gtest_dir = os.environ.get("GTEST_XML_DIR",
+                                os.path.join(projectdir, builddir, "report"))
+    coverage_info = os.environ.get("COVERAGE_INFO",
+                                    os.path.join(projectdir, builddir, "coverage.info"))
+
+    # --- Test case counts from gtest XML ---
+    total, passed, failed = parse_gtest_xml(gtest_dir)
+
+    result = {
+        "test_cases": {
+            "total": total,
+            "passed": passed,
+            "failed": failed
+        }
+    }
+
+    # --- Coverage from lcov --summary ---
+    coverage_data = parse_lcov_summary(coverage_info)
+    result.update(coverage_data)
+
+    # --- Write output ---
+    output_path = os.path.join(projectdir, reportdir, "ut-summary.json")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/autotests/libs/dfm-base/test_windowutils.cpp
+++ b/autotests/libs/dfm-base/test_windowutils.cpp
@@ -13,6 +13,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <cstdlib>
+#include <cstring>
 #include <dfm-base/utils/windowutils.h>
 
 #include <QGuiApplication>
@@ -23,25 +25,39 @@ using namespace dfmbase;
 
 TEST(WindowUtilsTest, IsX11ReturnsFalseUnderOffscreenPlatform)
 {
-    // isX11() matches the actual platform; under X11 it returns true,
-    // under offscreen/Wayland it returns false.  We verify consistency
-    // with the platform name rather than assuming a specific platform.
-    if (QGuiApplication::platformName() == QStringLiteral("offscreen")) {
-        EXPECT_FALSE(WindowUtils::isX11());
-    } else {
-        // On X11-based platforms (xcb, dxcb;xcb, etc.) isX11() returns true
+    // isX11() checks platformName == "xcb" first, then falls back to
+    // DISPLAY / XDG_SESSION_TYPE environment variables.  Under offscreen
+    // the platformName is not "xcb", but if DISPLAY is set and
+    // XDG_SESSION_TYPE is "x11", isX11() still returns true.
+    const char *display = std::getenv("DISPLAY");
+    const char *session_type = std::getenv("XDG_SESSION_TYPE");
+    const bool envIndicatesX11 =
+            (display && display[0] != '\0') &&
+            (session_type && strcmp(session_type, "x11") == 0);
+
+    if (QGuiApplication::platformName() == QStringLiteral("xcb")) {
         EXPECT_TRUE(WindowUtils::isX11());
+    } else if (envIndicatesX11) {
+        // Offscreen platform but DISPLAY+XDG_SESSION_TYPE indicate X11
+        EXPECT_TRUE(WindowUtils::isX11());
+    } else {
+        EXPECT_FALSE(WindowUtils::isX11());
     }
 }
 
 TEST(WindowUtilsTest, IsWayLandReturnsFalseUnderOffscreenPlatform)
 {
-    if (QGuiApplication::platformName() == QStringLiteral("offscreen")) {
-        EXPECT_FALSE(WindowUtils::isWayLand());
-    } else if (QGuiApplication::platformName().contains(QStringLiteral("wayland"))) {
+    const char *wayland_display = std::getenv("WAYLAND_DISPLAY");
+    const char *session_type = std::getenv("XDG_SESSION_TYPE");
+    const bool envIndicatesWayland =
+            (wayland_display && wayland_display[0] != '\0') ||
+            (session_type && strcmp(session_type, "wayland") == 0);
+
+    if (QGuiApplication::platformName() == QStringLiteral("wayland")) {
+        EXPECT_TRUE(WindowUtils::isWayLand());
+    } else if (envIndicatesWayland) {
         EXPECT_TRUE(WindowUtils::isWayLand());
     } else {
-        // On X11-based platforms, isWayLand() returns false
         EXPECT_FALSE(WindowUtils::isWayLand());
     }
 }

--- a/autotests/run-ut.sh
+++ b/autotests/run-ut.sh
@@ -12,9 +12,12 @@
 #
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-BUILD_DIR="${PROJECT_ROOT}/build-autotests"
+export SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+export BUILD_DIR="${PROJECT_ROOT}/build-autotests"
+export builddir=build-autotests
+export reportdir=build-autotests
+export projectdir="${PROJECT_ROOT}"
 COVERAGE=false
 RUN_ONLY=false
 
@@ -65,7 +68,7 @@ if [ "${RUN_ONLY}" = false ]; then
     cmake --build "${BUILD_DIR}" -j"$(nproc)"
 fi
 
-# Step 3: Run tests
+# Step 3: Run tests and collect results
 echo "==> [3/4] Running tests..."
 cd "${BUILD_DIR}"
 
@@ -77,7 +80,49 @@ export QT_QPA_PLATFORM="offscreen"
 # failures (e.g. ut-textindex needing newer dfm6-base symbols).
 export LD_LIBRARY_PATH="${BUILD_DIR}/src/dfm-base:${BUILD_DIR}/src/apps/dde-file-manager-extractor${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
-ctest --output-on-failure --timeout 120
+# Discover test binaries
+GTEST_RESULTS_DIR="${BUILD_DIR}/gtest-results"
+mkdir -p "${GTEST_RESULTS_DIR}"
+
+test_bins=()
+while IFS= read -r -d '' bin; do
+    test_bins+=("$bin")
+done < <(find "${BUILD_DIR}/autotests" -type f -executable -name 'ut-*' -print0 | sort -z)
+
+if [ ${#test_bins[@]} -eq 0 ]; then
+    echo "ERROR: No test binaries found under ${BUILD_DIR}/autotests"
+    exit 1
+fi
+
+echo "Found ${#test_bins[@]} test binaries:"
+for bin in "${test_bins[@]}"; do
+    echo "  $(basename "$bin")"
+done
+echo ""
+
+# Run each test binary with gtest XML output
+# Temporarily disable 'set -e' so a failing test binary doesn't abort the script;
+# we track failures via any_failed and report them at the end.
+any_failed=0
+set +e
+for bin in "${test_bins[@]}"; do
+    name=$(basename "$bin")
+    echo "---- Running ${name} ----"
+    if "$bin" --gtest_output="xml:${GTEST_RESULTS_DIR}/${name}.xml"; then
+        echo "  ${name}: PASSED"
+    else
+        echo "  ${name}: FAILED"
+        any_failed=1
+    fi
+done
+set -e
+
+echo ""
+if [ "$any_failed" -eq 0 ]; then
+    echo "All test binaries passed."
+else
+    echo "Some test binaries FAILED."
+fi
 
 # Step 4: Coverage report
 if [ "${COVERAGE}" = true ]; then
@@ -86,9 +131,31 @@ if [ "${COVERAGE}" = true ]; then
     COVERAGE_DIR="${BUILD_DIR}/coverage"
     mkdir -p "${COVERAGE_DIR}"
 
-    # Collect coverage data
-    lcov --capture --directory "${BUILD_DIR}" --output-file "${COVERAGE_DIR}/coverage.info" \
+    # --- Baseline from .gcno (compiled-but-unrun source files) ---
+    # lcov --capture only reads .gcda runtime data and silently drops every
+    # file that was compiled with --coverage but never executed. That shrinks
+    # the denominator and inflates the coverage %. Capturing an initial
+    # baseline from the .gcno files and merging it back in forces those files
+    # into the report at 0%, so the figure reflects the real whole-project
+    # denominator rather than only what tests happened to touch.
+    lcov --capture --initial --directory "${BUILD_DIR}" \
+        --output-file "${COVERAGE_DIR}/baseline.info" \
         --rc lcov_branch_coverage=1 2>/dev/null || true
+
+    # --- Runtime coverage from .gcda (after test execution) ---
+    lcov --capture --directory "${BUILD_DIR}" \
+        --output-file "${COVERAGE_DIR}/run.info" \
+        --rc lcov_branch_coverage=1 2>/dev/null || true
+
+    # --- Merge: keep real hit counts; files only in the baseline stay at 0% ---
+    if [ -s "${COVERAGE_DIR}/baseline.info" ]; then
+        lcov --add-tracefile "${COVERAGE_DIR}/baseline.info" \
+            --add-tracefile "${COVERAGE_DIR}/run.info" \
+            --output-file "${COVERAGE_DIR}/coverage.info" \
+            --rc lcov_branch_coverage=1 2>/dev/null || true
+    else
+        cp "${COVERAGE_DIR}/run.info" "${COVERAGE_DIR}/coverage.info"
+    fi
 
     # Filter to only include project source files
     lcov --remove "${COVERAGE_DIR}/coverage.info" \
@@ -113,6 +180,17 @@ if [ "${COVERAGE}" = true ]; then
     lcov --summary "${COVERAGE_DIR}/coverage-filtered.info" --rc lcov_branch_coverage=1 2>/dev/null || \
         echo "Warning: Could not generate coverage summary (lcov may not be installed)"
 fi
+
+# Step 5: Generate summary JSON
+echo "==> Generating summary JSON: ${BUILD_DIR}/ut-summary.json"
+
+# dde-file-manager 的 gtest XML 和 coverage info 路径与默认不同，通过环境变量覆盖
+export GTEST_XML_DIR="${BUILD_DIR}/gtest-results"
+if [ "${COVERAGE}" = true ]; then
+    export COVERAGE_INFO="${BUILD_DIR}/coverage/coverage-filtered.info"
+fi
+
+python3 "${SCRIPT_DIR}/gen-ut-summary.py"
 
 echo ""
 echo "Done."

--- a/autotests/services/textindex/test_processextractor.cpp
+++ b/autotests/services/textindex/test_processextractor.cpp
@@ -21,20 +21,34 @@
 #include "services/textindex/service_textindex_global.h"
 #include "services/textindex/extractor/processextractor.h"
 #include "services/textindex/extractor/indexextractor.h"
+#include "controllerpipe.h"
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
+using namespace EXTRACTOR_NAMESPACE;
 
-TEST(ProcessExtractorTest, ConstructAndDestruct)
+class ProcessExtractorTest : public testing::Test
+{
+protected:
+    stub_ext::StubExt stub;
+
+    void SetUp() override
+    {
+        // Stub ControllerPipe::start to always fail so the extractor
+        // subprocess never actually launches during tests.
+        stub.set_lamda(VADDR(ControllerPipe, start), [](ControllerPipe *, const QString &, const QString &) -> bool {
+            return false;
+        });
+    }
+};
+
+TEST_F(ProcessExtractorTest, ConstructAndDestruct)
 {
     { ProcessExtractor ext; }
     SUCCEED();
 }
 
-TEST(ProcessExtractorTest, Extract_NullProxy_ReturnsError)
+TEST_F(ProcessExtractorTest, Extract_NullProxy_ReturnsError)
 {
-    // We can't easily set d->proxy to null, but we can test extract
-    // which will go through the proxy. The proxy will fail because
-    // the extractor binary doesn't exist. Let's just verify it doesn't crash.
     ProcessExtractor ext;
     QTemporaryDir tmp;
     ASSERT_TRUE(tmp.isValid());
@@ -44,28 +58,25 @@ TEST(ProcessExtractorTest, Extract_NullProxy_ReturnsError)
     f.write("hello world");
     f.close();
 
-    // This will fail (extractor not available) but should not crash
     auto result = ext.extract(filePath);
-    // The extract should return an error result since the extractor binary
-    // won't start, or fail to send request
     EXPECT_FALSE(result.success);
 }
 
-TEST(ProcessExtractorTest, Extract_NonExistentFile)
+TEST_F(ProcessExtractorTest, Extract_NonExistentFile)
 {
     ProcessExtractor ext;
     auto result = ext.extract("/nonexistent/file/that/does/not/exist.txt");
     EXPECT_FALSE(result.success);
 }
 
-TEST(ProcessExtractorTest, Extract_EmptyFilePath)
+TEST_F(ProcessExtractorTest, Extract_EmptyFilePath)
 {
     ProcessExtractor ext;
     auto result = ext.extract(QString());
     EXPECT_FALSE(result.success);
 }
 
-TEST(ProcessExtractorTest, Extract_WithMaxBytes)
+TEST_F(ProcessExtractorTest, Extract_WithMaxBytes)
 {
     ProcessExtractor ext;
     QTemporaryDir tmp;
@@ -76,12 +87,11 @@ TEST(ProcessExtractorTest, Extract_WithMaxBytes)
     f.write("hello world");
     f.close();
 
-    // Pass a maxBytes value
     auto result = ext.extract(filePath, 1024);
     EXPECT_FALSE(result.success);
 }
 
-TEST(ProcessExtractorTest, ExtractResult_DefaultValues)
+TEST_F(ProcessExtractorTest, ExtractResult_DefaultValues)
 {
     IndexExtractionResult result;
     EXPECT_FALSE(result.success);
@@ -91,7 +101,7 @@ TEST(ProcessExtractorTest, ExtractResult_DefaultValues)
     EXPECT_FALSE(result.deduplicated);
 }
 
-TEST(ProcessExtractorTest, Extract_MultipleCalls)
+TEST_F(ProcessExtractorTest, Extract_MultipleCalls)
 {
     ProcessExtractor ext;
     QTemporaryDir tmp;

--- a/autotests/services/textindex/test_processextractor_extra.cpp
+++ b/autotests/services/textindex/test_processextractor_extra.cpp
@@ -16,23 +16,33 @@
 #include <QEventLoop>
 #include <QTimer>
 
+#include "stubext.h"
 #include "dfm_test_main.h"
 #include "services/textindex/service_textindex_global.h"
 #include "services/textindex/extractor/processextractor.h"
 #include "services/textindex/extractor/indexextractor.h"
+#include "controllerpipe.h"
 
 using namespace SERVICETEXTINDEX_NAMESPACE;
+using namespace EXTRACTOR_NAMESPACE;
 
 class ProcessExtractorExtraTest : public testing::Test
 {
 protected:
     QTemporaryDir tmp;
+    stub_ext::StubExt stub;
 
     void SetUp() override
     {
         ASSERT_TRUE(tmp.isValid());
         createFile("normal.txt", "normal content");
         createFile("empty.txt", QString(""));
+
+        // Stub ControllerPipe::start to always fail so the extractor
+        // subprocess never actually launches during tests.
+        stub.set_lamda(VADDR(ControllerPipe, start), [](ControllerPipe *, const QString &, const QString &) -> bool {
+            return false;
+        });
     }
 
     void createFile(const QString &name, const QString &content)


### PR DESCRIPTION
1.fix ProcessExtractor and WindowUtils unit test failures
2.add ut-summary.json generation for test results and coverage to multica

## Summary by Sourcery

Generate a unified ut-summary.json from unit test and coverage outputs and stabilize failing WindowUtils and ProcessExtractor unit tests.

New Features:
- Produce ut-summary.json in multica runs by aggregating gtest XML results and lcov coverage summaries.

Bug Fixes:
- Adjust WindowUtils tests to account for X11 and Wayland detection using platform and environment variables.
- Prevent ProcessExtractor-related unit tests from launching real extractor subprocesses by stubbing ControllerPipe::start, avoiding flaky failures.

Enhancements:
- Revise autotest run script to discover and run gtest binaries individually, collect XML outputs, and export paths for summary generation.