### PR TITLE
fix: sync title-bar placeholder with actual sidebar width during resize

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -297,7 +297,12 @@ void FileManagerWindowPrivate::connectAnimationSignals()
 
     connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
         Q_UNUSED(value);
-        emit q->windowSplitterWidthChanged(value.toInt());
+        // Emit the *actual* sidebar width (after rightArea minimum-width
+        // clamping via Splitter::setSizes) rather than the animated intended
+        // value, so the title-bar placeholder tracks real geometry and the
+        // TabBar is not pushed into the top-left corner during rapid window
+        // narrowing.
+        emit q->windowSplitterWidthChanged(splitter->sizes().at(0));
         // 动画过程中实时更新分割线位置
         updateSideBarSeparatorPosition();
     });
@@ -640,6 +645,14 @@ void FileManagerWindowPrivate::updateSideBarState()
         && !(curSplitterAnimation && curSplitterAnimation->state() == QAbstractAnimation::Running)) {
         lastSidebarExpandedPostion = sideBarWidth;
     }
+
+    // Keep the title-bar placeholder in sync with the *actual* sidebar width.
+    // The sidebar geometry can change during a plain window resize (clamped by
+    // rightArea's minimum width) without any animation running, and the
+    // placeholder must follow so the TabBar never drifts into the top-left
+    // corner. handleSplitterAnimation() early-returns when the width is
+    // unchanged, so this is a cheap no-op in the steady state.
+    emit q->windowSplitterWidthChanged(sideBarWidth);
 }
 
 void FileManagerWindowPrivate::updateSideBarVisibility()
@@ -740,7 +753,12 @@ void FileManagerWindowPrivate::animateSideBarHideForResize()
     });
 
     connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
-        emit q->windowSplitterWidthChanged(value.toInt());
+        Q_UNUSED(value);
+        // Emit the *actual* sidebar width (after rightArea minimum-width
+        // clamping) rather than the animated intended value, so the title-bar
+        // placeholder tracks real geometry and the TabBar is not pushed into
+        // the top-left corner during rapid window narrowing.
+        emit q->windowSplitterWidthChanged(splitter->sizes().at(0));
         updateSideBarSeparatorPosition();
     });
 
@@ -814,7 +832,10 @@ void FileManagerWindowPrivate::animateSideBarShowForResize()
     });
 
     connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
-        emit q->windowSplitterWidthChanged(value.toInt());
+        Q_UNUSED(value);
+        // See animateSideBarHideForResize: emit the actual clamped sidebar
+        // width so the title-bar placeholder stays in sync with real geometry.
+        emit q->windowSplitterWidthChanged(splitter->sizes().at(0));
         updateSideBarSeparatorPosition();
     });
 


### PR DESCRIPTION
## 根因分析

快速拖窄窗口时标题栏 tab 会先跳到左上角再被隐藏。根因：标题栏 placeholder（为左上角浮动 iconArea 让位）跟随的是侧边栏收缩动画的**意图宽度**，而非被 rightArea 最小宽度(550)钳制后的**实际宽度**——两者在快速拖窄时脱节，把 TabBar 整体推到 iconArea 区域。

关键证据：
- `filemanagerwindow.cpp` 动画 `valueChanged` 发出 `value.toInt()`（意图值），非 `splitter->sizes().at(0)`（实际钳制值）；`resizeEvent` 的 update 链不发 `windowSplitterWidthChanged`。
- `splitter.cpp` 的 `setSizes` 按 rightArea 最小宽度钳制侧边栏，导致实际值远小于意图值。
- 回归来源：commit `1029e2b0f`（BUG-353081）引入 resize 收缩动画后出现，之前同步 `hideSideBar()` 无此问题。

## 修复方案

让 placeholder 跟随**实际几何**而非动画意图值（最小改动）：
1. 三处动画 `valueChanged`（`connectAnimationSignals`/`animateSideBarHideForResize`/`animateSideBarShowForResize`）改为 `emit windowSplitterWidthChanged(splitter->sizes().at(0))`。
2. `updateSideBarState()` 末尾补发 `windowSplitterWidthChanged(sideBarWidth)`，使非动画的纯窗口 resize 也同步 placeholder（消费者有 `if (newWidth == placeholder->width()) return;` 早退，稳态无额外开销）。

`windowSplitterWidthChanged` 唯一消费者是 `TitleBarWidget::handleSplitterAnimation`（placeholder），低风险。

## 改动安全评估

低风险。`updateSideBarState` 仅由 `resizeEvent` 调用，新增 emit 为纯增量（信号消费者有早退保护，无副作用）；三处 lambda 仅改 emit 的数据源（意图值→实际值），不改签名、不改调用方。与 commit `1029e2b0f` 的状态语义（手动隐藏 early-return、动画期不保存中间宽度）无冲突。


Closes V-2080
