### PR TITLE
fix(disk-encrypt): extend DBus timeout to 5m for long-running operat…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
@@ -61,10 +61,10 @@ inline constexpr char kTCMPcrBank[] { "sm3_256" };
 // DBus timeout constant: 2 seconds to prevent UI blocking when service is unavailable
 inline constexpr int kDiskEncryptDBusTimeoutMs = 2000;
 
-// TPM DBus timeout constant: 1 minute. TPM operations (e.g. IsTPMAvailable / Encrypt)
+// DBus timeout constant: 5 minute. TPM operations (e.g. IsTPMAvailable / Encrypt)
 // may trigger a Polkit authentication dialog; we wait for the user to finish auth
 // instead of timing out after the Qt DBus default 25s and falling back incorrectly.
-inline constexpr int kTPMDBusTimeoutMs = 60 * 1000;   // 1 min
+inline constexpr int kTPMDBusTimeoutMs = 5 * 60 * 1000;
 
 // TPM Control service constants
 inline constexpr char kTPMControlService[] = "org.deepin.Filemanager.TPMControl";

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -145,16 +145,15 @@ int EventsHandler::deviceEncryptStatus(const QString &device)
 
 void EventsHandler::resumeEncrypt(const QString &device)
 {
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     iface.asyncCall("ResumeEncryption", QVariantMap { { encrypt_param_keys::kKeyDevice, device } });
 }
 
 QString EventsHandler::holderDevice(const QString &device)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "Failed to create DBus interface for HolderDevice, service may be unavailable, using original device";
         return device;

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -392,6 +392,7 @@ void DiskEncryptMenuScene::unlockDevice(const QString &devObjPath)
 void DiskEncryptMenuScene::doEncryptDevice(const DeviceEncryptParam &param)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for InitEncryption, service may be unavailable";
         return;
@@ -437,6 +438,7 @@ bool DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
     }
 
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for SetupAuthArgs, service may be unavailable";
         return false;
@@ -466,6 +468,7 @@ bool DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
 void DiskEncryptMenuScene::doDecryptDevice(const DeviceEncryptParam &param)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for Decryption, service may be unavailable";
         return;
@@ -521,6 +524,7 @@ void DiskEncryptMenuScene::doChangePassphrase(const DeviceEncryptParam &param)
     }
 
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for ChangePassphrase, service may be unavailable";
         return;

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -320,6 +320,7 @@ int tpm_utils::ownerAuthStatus()
 int device_utils::encKeyType(const QString &dev)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "Failed to create DBus interface for TpmToken, service may be unavailable";
         return 0;


### PR DESCRIPTION
…ions

Disk encryption, decryption, re-encryption and passphrase-change calls that go through the daemon DBus interface may block for a long time — they can wait on Polkit authentication, TPM operations or a full-disk re-encryption that takes hours. The previous 1-minute timeout could expire while the user was still interacting with the Polkit dialog, causing premature fallback and failed/aborted operations.

Increase kTPMDBusTimeoutMs to 5m (5 * 60 * 1000 ms) and apply it to every daemon interface call. Replace the CREATE_DAEMON_INTERFACE macro (which sets no timeout) with explicit QDBusInterface construction followed by setTimeout(kTPMDBusTimeoutMs) in EventsHandler, DiskEncryptMenuScene and encryptutils, so all daemon calls honour the extended timeout consistently.

Files changed:
- dfmplugin_disk_encrypt_global.h: bump kTPMDBusTimeoutMs to 24h
- events/eventshandler.cpp: set timeout on all daemon interface calls
- menu/diskencryptmenuscene.cpp: set timeout on all daemon interface calls
- utils/encryptutils.cpp: set timeout on daemon interface call

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-373557.html

## Summary by Sourcery

Extend TPM-related disk encryption DBus timeouts to support long-running operations without premature failure

Bug Fixes:
- Prevent disk encryption, decryption and related TPM DBus calls from timing out during long-running operations or user Polkit interaction

Enhancements:
- Apply a consistent extended timeout to all disk-encryption daemon DBus interfaces by replacing the macro-based interface creation with explicit QDBusInterface instances.