### PR TITLE
fix: hide desktop collections during scaling-triggered re-layout

### DIFF
--- a/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/framemanager.cpp
@@ -162,6 +162,17 @@ QList<SurfacePointer> FrameManagerPrivate::surfaces() const
     return ret;
 }
 
+void FrameManagerPrivate::relayoutSurfaces()
+{
+    QList<QWidget *> root = ddplugin_desktop_util::desktopFrameRootWindows();
+    for (auto win : root) {
+        QString screen = win->property(DesktopFrameProperty::kPropScreenName).toString();
+        auto surface = surfaceWidgets.value(screen);
+        if (surface)
+            layoutSurface(win, surface);
+    }
+}
+
 void FrameManagerPrivate::refeshCanvas()
 {
     // refresh immediately to prevent show the files which is move to collection view.
@@ -439,7 +450,7 @@ void FrameManager::turnOn(bool build)
     CanvasCoreSubscribe(signal_DesktopFrame_WindowAboutToBeBuilded, &FrameManager::onDetachWindows);
     CanvasCoreSubscribe(signal_DesktopFrame_WindowBuilded, &FrameManager::onBuild);
     CanvasCoreSubscribe(signal_DesktopFrame_WindowShowed, &FrameManager::onWindowShowed);
-    CanvasCoreSubscribe(signal_DesktopFrame_GeometryChanged, &FrameManager::onGeometryChanged);
+    CanvasCoreSubscribe(signal_DesktopFrame_GeometryChanged, &FrameManager::onScreenGeometryChanged);
     CanvasCoreSubscribe(signal_DesktopFrame_AvailableGeometryChanged, &FrameManager::onGeometryChanged);
 
     d->canvas = new CanvasInterface(this);
@@ -470,7 +481,7 @@ void FrameManager::turnOff()
     CanvasCoreUnsubscribe(signal_DesktopFrame_WindowAboutToBeBuilded, &FrameManager::onDetachWindows);
     CanvasCoreUnsubscribe(signal_DesktopFrame_WindowBuilded, &FrameManager::onBuild);
     CanvasCoreUnsubscribe(signal_DesktopFrame_WindowShowed, &FrameManager::onWindowShowed);
-    CanvasCoreUnsubscribe(signal_DesktopFrame_GeometryChanged, &FrameManager::onGeometryChanged);
+    CanvasCoreUnsubscribe(signal_DesktopFrame_GeometryChanged, &FrameManager::onScreenGeometryChanged);
     CanvasCoreUnsubscribe(signal_DesktopFrame_AvailableGeometryChanged, &FrameManager::onGeometryChanged);
 
     delete d->organizer;
@@ -530,15 +541,46 @@ void FrameManager::onDetachWindows()
 
 void FrameManager::onGeometryChanged()
 {
-    QList<QWidget *> root = ddplugin_desktop_util::desktopFrameRootWindows();
-    for (auto win : root) {
-        QString screen = win->property(DesktopFrameProperty::kPropScreenName).toString();
-        auto surface = d->surfaceWidgets.value(screen);
-        if (surface)
-            d->layoutSurface(win, surface);
-    }
+    d->relayoutSurfaces();
 
     // layout collection widgets
     if (d->organizer)
         d->organizer->layout();
+}
+
+void FrameManager::onScreenGeometryChanged()
+{
+    // Collections are already visible when the screen geometry changes after
+    // login (e.g. the compositor applies the display scaling after the desktop
+    // is shown). Re-laying them out in place would visibly move/resize them.
+    // Hide the surfaces for the re-layout and restore their previous visibility
+    // so the collections appear directly at their final positions, matching
+    // the canvas icons which also reposition atomically.
+
+    // record each surface's visibility before the re-layout so the "hide all
+    // collections" state (and any other visibility state) is preserved.
+    QMap<QString, bool> surfaceVisible;
+    for (auto it = d->surfaceWidgets.constBegin(); it != d->surfaceWidgets.constEnd(); ++it)
+        surfaceVisible.insert(it.key(), it.value()->isVisible());
+
+    // resize surfaces to the new screen geometry. layoutSurface may reparent
+    // the surface and reset its visibility, so re-hide afterwards to be safe.
+    d->relayoutSurfaces();
+
+    // hide all surfaces so the setGeometry calls done by layout() are not
+    // painted until the final positions are reached.
+    for (const SurfacePointer &sur : d->surfaceWidgets)
+        sur->setVisible(false);
+
+    // re-layout collections while they are invisible.
+    if (d->organizer)
+        d->organizer->layout();
+
+    // restore each surface's previous visibility. surfaces that were visible
+    // are shown again (painting the collections at their final positions),
+    // surfaces that were hidden (e.g. "hide all collections") stay hidden.
+    for (auto it = d->surfaceWidgets.constBegin(); it != d->surfaceWidgets.constEnd(); ++it) {
+        if (surfaceVisible.contains(it.key()))
+            it.value()->setVisible(surfaceVisible.value(it.key()));
+    }
 }

--- a/src/plugins/desktop/ddplugin-organizer/framemanager.h
+++ b/src/plugins/desktop/ddplugin-organizer/framemanager.h
@@ -35,6 +35,12 @@ public slots:
     void onWindowShowed();
     void onDetachWindows();
     void onGeometryChanged();
+    // Triggered by screen geometry changes (display scaling / resolution). The
+    // collections are already visible at this point, so re-laying them out in
+    // place would produce a visible move/resize. Hide the surfaces for the
+    // duration of the re-layout and restore their previous visibility so the
+    // collections appear directly at their final positions.
+    void onScreenGeometryChanged();
 
 protected:
     void switchMode(OrganizerMode mode);

--- a/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
+++ b/src/plugins/desktop/ddplugin-organizer/private/framemanager_p.h
@@ -31,6 +31,8 @@ public:
     void layoutSurface(QWidget *root, SurfacePointer surface, bool hidden = false);
     void buildOrganizer();
     QList<SurfacePointer> surfaces() const;
+    // resize every surface to its root window's current geometry
+    void relayoutSurfaces();
 
 public slots:
     void refeshCanvas();


### PR DESCRIPTION
## 根因分析

桌面整理集合窗口在登录后“已经可见”时，被屏幕几何变化触发的重排直接 `setGeometry` 搬动/缩放，用户看到可见的位移/缩放过程；左侧画布图标由网格随 view 尺寸原子重排，不存在单个 widget 被搬动，所以“原地显示”。

- 触发链：缩放改变→登录后合成器（treeland/Wayland 分数缩放）校准屏幕逻辑几何→`QScreen::geometryChanged`→`ScreenQt`/`ScreenProxyQt`→`WindowFrame::geometryChanged`→`FrameManager::onGeometryChanged`→`NormalizedMode::layout()` 对已可见的集合窗口做分辨率迁移/重排（`setGeometry`）。
- 关键证据：`framemanager.cpp:531` `onGeometryChanged` 在集合窗口已显示后直接 `organizer->layout()`，重排期间未隐藏窗口；`normalizedmode.cpp:611-684` 的分辨率迁移/重排逻辑解释“大变小”（缩小分辨率→重排 kSmall）与“从左往右”（放大分辨率→整体右移）。

## 修复方案

在 `FrameManager` 将“屏幕几何变化”（`signal_DesktopFrame_GeometryChanged`，缩放/分辨率）与“可用区域变化”（`signal_DesktopFrame_AvailableGeometryChanged`，dock）分开订阅：屏幕几何变化触发的重排，先保存各 surface 可见性→隐藏 surface→重排（含分辨率迁移）→恢复可见性，使重排过程对用户不可见，集合窗口直接出现在最终位置；dock 引起的可用区域变化保持原有行为。提取 `relayoutSurfaces` 公共方法避免重复代码。

## 改动安全评估

低风险。仅在外层包一层可见性保存/隐藏/恢复 + 拆分信号订阅槽，无函数签名变更、无新公开 API、无业务逻辑改动；可见性按保存值还原，“一键隐藏集合”状态被正确保留。

## Summary by Sourcery

Handle desktop collection re-layout on screen geometry changes without showing intermediate movement or resizing to the user.

Bug Fixes:
- Prevent visible movement and resizing of desktop collection windows when display scaling or resolution changes trigger a re-layout after login.

Enhancements:
- Extract a shared relayoutSurfaces helper to resize all surfaces to their root windows' current geometry.
- Separate handling of screen geometry changes from available-area geometry changes by introducing a dedicated onScreenGeometryChanged slot that preserves and restores surface visibility.