### PR TITLE
feat: improve VFS monitor reliability and alias handling

### DIFF
--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -162,6 +162,13 @@ bool FSMonitorPrivate::startMonitoring()
     active = true;
     watchedDirectories.clear();
 
+    if (vfsMonitorAvailable) {
+        fmInfo() << "FSMonitor: VfsMonitor active, skipping inotify directory watch setup";
+        fmInfo() << "FSMonitor: Started monitoring with max watches:" << maxWatches
+                 << "usage limit:" << (maxUsagePercentage * 100) << "%";
+        return true;
+    }
+
     // Start worker thread
     if (!workerThread.isRunning()) {
         workerThread.start();
@@ -614,6 +621,11 @@ void FSMonitorPrivate::handleFastScanCompleted(bool success)
 void FSMonitorPrivate::handleDirectoriesBatch(const QStringList &paths)
 {
     if (paths.isEmpty()) {
+        return;
+    }
+
+    if (vfsMonitorAvailable || !watcher) {
+        fmDebug() << "FSMonitor: Ignoring directory watch batch in vfs mode, size:" << paths.size();
         return;
     }
 

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -6,10 +6,12 @@
 
 #include <QDir>
 #include <QFileInfo>
+#include <QTimer>
 
 #include <libmount.h>
 
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 #include <unistd.h>
 
@@ -40,6 +42,13 @@ struct DispatchEvent
     char eventPath[kDispatchMaxPathLen];
 };
 
+struct FileIdentity
+{
+    dev_t deviceId { 0 };
+    ino_t inode { 0 };
+    bool valid { false };
+};
+
 bool isDescendantOfRoot(const QString &path, const QString &root)
 {
     if (root == "/")
@@ -66,6 +75,15 @@ bool mountPointStartsWith(const QString &path, const QString &mountPoint)
 bool cStringEquals(const char *left, const char *right)
 {
     return left && right && qstrcmp(left, right) == 0;
+}
+
+FileIdentity identifyPath(const QString &path)
+{
+    struct stat st {};
+    if (::stat(path.toUtf8().constData(), &st) != 0)
+        return {};
+
+    return { st.st_dev, st.st_ino, true };
 }
 
 bool isParentChainUnderRoot(const QHash<int, MountEntry> &byMountId, const MountEntry &entry)
@@ -166,6 +184,7 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
 {
     mountPoints.clear();
     orderedMountPoints.clear();
+    rootAliases.clear();
 
     libmnt_table *mtab = mnt_new_table();
     if (!mtab)
@@ -201,7 +220,44 @@ bool VfsMonitorFileSystemWatcherPrivate::initMountPoints()
                   return left.mountPoint.length() > right.mountPoint.length();
               });
 
+    rebuildRootAliases();
     return !mountPoints.isEmpty();
+}
+
+void VfsMonitorFileSystemWatcherPrivate::rebuildRootAliases()
+{
+    rootAliases.clear();
+
+    for (const QString &rootPath : std::as_const(rootPaths)) {
+        const FileIdentity rootIdentity = identifyPath(rootPath);
+        if (!rootIdentity.valid)
+            continue;
+
+        for (const MountPointAlias &alias : std::as_const(orderedMountPoints)) {
+            if (alias.mountPoint == "/")
+                continue;
+
+            const QString aliasRoot = QDir::cleanPath(alias.mountPoint + rootPath);
+            if (aliasRoot == rootPath)
+                continue;
+
+            const FileIdentity aliasIdentity = identifyPath(aliasRoot);
+            if (!aliasIdentity.valid)
+                continue;
+
+            if (aliasIdentity.deviceId != rootIdentity.deviceId
+                || aliasIdentity.inode != rootIdentity.inode) {
+                continue;
+            }
+
+            rootAliases.append(qMakePair(aliasRoot, rootPath));
+        }
+    }
+
+    std::sort(rootAliases.begin(), rootAliases.end(),
+              [](const QPair<QString, QString> &left, const QPair<QString, QString> &right) {
+                  return left.first.length() > right.first.length();
+              });
 }
 
 QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char *absolutePath) const
@@ -216,6 +272,17 @@ QString VfsMonitorFileSystemWatcherPrivate::resolveAndFilterFullPath(const char 
     const QString directPath = filterDirectPath(rootPaths, excludePredicate, fullPath);
     if (!directPath.isNull())
         return directPath;
+
+    for (const auto &alias : rootAliases) {
+        if (!isDescendantOfRoot(fullPath, alias.first))
+            continue;
+
+        const QString suffix = fullPath.mid(alias.first.length());
+        const QString translatedPath = alias.second + suffix;
+        const QString filteredTranslated = filterDirectPath(rootPaths, excludePredicate, translatedPath);
+        if (!filteredTranslated.isNull())
+            return filteredTranslated;
+    }
 
     for (const MountPointAlias &sourceAlias : orderedMountPoints) {
         if (!mountPointStartsWith(fullPath, sourceAlias.mountPoint))

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -73,7 +73,6 @@ public:
     // Create the socket, connect, enlarge the receive buffer and build the
     // notifier. Returns true on success. Does not touch the reconnect timer.
     bool establishConnection();
-
     // The event dispatcher sends absolute paths, but they may use a different
     // mount alias than the monitored root path. This helper normalizes across
     // same-device mount aliases before applying rootPaths and excludePredicate.
@@ -101,8 +100,10 @@ public:
     QHash<uint32_t, RenameFromInfo> pendingRenames;
     QHash<dev_t, QStringList> mountPoints;
     QVector<MountPointAlias> orderedMountPoints;
+    QVector<QPair<QString, QString>> rootAliases;
 
     bool initMountPoints();
+    void rebuildRootAliases();
 };
 
 SERVICETEXTINDEX_END_NAMESPACE


### PR DESCRIPTION
1. Added availability verification for VFS monitor through probe files
2. Implemented root alias resolution to handle bind mounts and symlinks
3. Skip inotify setup when VFS monitor is available
4. Added detailed logging for monitoring initialization
5. Improved mount point handling with device/inode identification
6. Added safety checks for socket communication

The changes make the VFS monitor more reliable by verifying its actual
functionality before use and properly handling filesystem aliases that
might exist due to bind mounts or symlinks. This prevents cases where
the monitor would appear connected but not work properly.

Log: Improved filesystem monitoring reliability with better VFS support
and alias handling

Influence:
1. Test file operations in directories with bind mounts
2. Verify monitoring works across symlinked paths
3. Check filesystem operations in monitored directories with various
mount configurations
4. Test monitoring startup with/without VFS monitor available
5. Verify proper logging during monitoring initialization

feat: 增强 VFS 监控可靠性和别名处理

1. 添加通过探测文件验证 VFS 监控可用性的功能
2. 实现了根别名解析以处理绑定挂载和符号链接
3. 当 VFS 监控可用时跳过 inotify 设置
4. 添加了监控初始化的详细日志记录
5. 使用设备/inode 标识改进了挂载点处理
6. 为套接字通信添加了安全检查

这些变更通过在使用前验证其实际功能并正确处理可能由于绑定挂载或符号链接而
存在的文件系统别名，使得 VFS 监控更加可靠。这防止了监控看似连接但无法正
常工作的情况。

Log: 通过增强 VFS 支持和别名处理提高了文件系统监控的可靠性

Influence:
1. 测试绑定挂载目录中的文件操作
2. 验证监控通过符号链接路径是否正常工作
3. 检查具有各种挂载配置的监控目录中的文件系统操作
4. 测试在有/无 VFS 监控可用时的监控启动
5. 验证监控初始化期间的正确日志记录

## Summary by Sourcery

Improve filesystem monitoring reliability by validating VFS monitor availability and better integrating it with the existing directory watch system.

New Features:
- Add an availability probe mechanism to ensure the VFS event dispatcher can deliver events for monitored roots before using it.

Bug Fixes:
- Prevent use of a seemingly connected VFS monitor in cases where its event path is not yet usable, avoiding silent monitoring failures.
- Avoid redundant or conflicting inotify directory watch setup when the VFS monitor is active.

Enhancements:
- Normalize and translate filesystem event paths across bind mounts and symlinked root aliases using device/inode-based alias resolution.
- Refine mount point handling and maintain computed root aliases to ensure events are correctly mapped to monitored roots.
- Add detailed logging around VFS monitor connection, availability checks, and monitoring startup to aid diagnostics.