### PR TITLE
Revert "fix: sync title-bar placeholder with actual sidebar width during resize"

### DIFF
--- a/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
+++ b/src/dfm-base/widgets/dfmwindow/filemanagerwindow.cpp
@@ -297,12 +297,7 @@ void FileManagerWindowPrivate::connectAnimationSignals()
 
     connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
         Q_UNUSED(value);
-        // Emit the *actual* sidebar width (after rightArea minimum-width
-        // clamping via Splitter::setSizes) rather than the animated intended
-        // value, so the title-bar placeholder tracks real geometry and the
-        // TabBar is not pushed into the top-left corner during rapid window
-        // narrowing.
-        emit q->windowSplitterWidthChanged(splitter->sizes().at(0));
+        emit q->windowSplitterWidthChanged(value.toInt());
         // 动画过程中实时更新分割线位置
         updateSideBarSeparatorPosition();
     });
@@ -645,14 +640,6 @@ void FileManagerWindowPrivate::updateSideBarState()
         && !(curSplitterAnimation && curSplitterAnimation->state() == QAbstractAnimation::Running)) {
         lastSidebarExpandedPostion = sideBarWidth;
     }
-
-    // Keep the title-bar placeholder in sync with the *actual* sidebar width.
-    // The sidebar geometry can change during a plain window resize (clamped by
-    // rightArea's minimum width) without any animation running, and the
-    // placeholder must follow so the TabBar never drifts into the top-left
-    // corner. handleSplitterAnimation() early-returns when the width is
-    // unchanged, so this is a cheap no-op in the steady state.
-    emit q->windowSplitterWidthChanged(sideBarWidth);
 }
 
 void FileManagerWindowPrivate::updateSideBarVisibility()
@@ -753,12 +740,7 @@ void FileManagerWindowPrivate::animateSideBarHideForResize()
     });
 
     connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
-        Q_UNUSED(value);
-        // Emit the *actual* sidebar width (after rightArea minimum-width
-        // clamping) rather than the animated intended value, so the title-bar
-        // placeholder tracks real geometry and the TabBar is not pushed into
-        // the top-left corner during rapid window narrowing.
-        emit q->windowSplitterWidthChanged(splitter->sizes().at(0));
+        emit q->windowSplitterWidthChanged(value.toInt());
         updateSideBarSeparatorPosition();
     });
 
@@ -832,10 +814,7 @@ void FileManagerWindowPrivate::animateSideBarShowForResize()
     });
 
     connect(curSplitterAnimation, &QPropertyAnimation::valueChanged, q, [this](const QVariant &value) {
-        Q_UNUSED(value);
-        // See animateSideBarHideForResize: emit the actual clamped sidebar
-        // width so the title-bar placeholder stays in sync with real geometry.
-        emit q->windowSplitterWidthChanged(splitter->sizes().at(0));
+        emit q->windowSplitterWidthChanged(value.toInt());
         updateSideBarSeparatorPosition();
     });
 


### PR DESCRIPTION
This reverts commit 6efc8412b72b5395dd0a71a2b849fbc63115e0bd.

## Summary by Sourcery

Enhancements:
- Restore emission of windowSplitterWidthChanged based on animation values instead of clamped splitter sizes during sidebar resize animations.