### PR TITLE
feat(at-spi): add accessible names for titlebar search and preview widgets

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -30,6 +30,8 @@
 #include <QResizeEvent>
 #include <QKeyEvent>
 
+#include <dfm-framework/event/event.h>
+
 DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 DFMBASE_USE_NAMESPACE
@@ -326,12 +328,19 @@ void SearchEditWidget::initUI()
     searchButton->setToolTip(QObject::tr("search"));
     searchButton->setFlat(true);
     searchButton->setVisible(false);
+#ifdef ENABLE_TESTING
+    dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
+                         qobject_cast<QWidget *>(searchButton), AcName::kAcComputerTitleBarSearchBtn);
+#endif
 
     // search edit
     searchEdit = new DSearchEdit(this);
     searchEdit->setVisible(true);
     // searchEdit->setFocusPolicy(Qt::StrongFocus);
     searchEdit->lineEdit()->setFocusPolicy(Qt::ClickFocus);
+#ifdef ENABLE_TESTING
+    searchEdit->setAccessibleName("SearchEdit");
+#endif
 
     // advanced search button
     advancedButton = new CustomDToolButton(this);
@@ -341,6 +350,9 @@ void SearchEditWidget::initUI()
     advancedButton->setToolTip(QObject::tr("advanced search"));
     advancedButton->setCheckable(true);
     advancedButton->setVisible(false);
+#ifdef ENABLE_TESTING
+    advancedButton->setAccessibleName("AdvancedSearchButton");
+#endif
 
     layout->addWidget(searchButton);
     layout->addWidget(searchEdit);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
@@ -20,6 +20,8 @@
 #include <QVBoxLayout>
 #include <QStandardItemModel>
 #include <QKeyEvent>
+
+#include <dfm-framework/event/event.h>
 #include <QApplication>
 #include <QScreen>
 #include <QToolTip>
@@ -176,6 +178,10 @@ void ViewOptionsWidgetPrivate::initializeUi()
     // Initialize checkbox state from window
     if (currentWindow)
         displayPreviewCheckBox->setChecked(currentWindow->isDetailSpaceVisible());
+#ifdef ENABLE_TESTING
+    dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
+                         qobject_cast<QWidget *>(displayPreviewCheckBox), AcName::kAcComputerTitleBarDetailBtn);
+#endif
     QHBoxLayout *displayPreviewLayout = new QHBoxLayout(displayPreviewWidget);
     displayPreviewLayout->setContentsMargins(kViewOptionsFrameMargin, kViewOptionsFrameMargin,
                                              kViewOptionsFrameMargin, kViewOptionsFrameMargin);

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -3,6 +3,22 @@
 
 expected_names:
 - line: 253
+  name: search_button
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  variable: searchButton
+- line: 342
+  name: SearchEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  variable: searchEdit
+- line: 354
+  name: AdvancedSearchButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  variable: advancedButton
+- line: 181
+  name: detail_button
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/viewoptionswidget.cpp
+  variable: displayPreviewCheckBox
+- line: 253
   name: CloseBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
   variable: closeBtn


### PR DESCRIPTION
为标题栏搜索控件（搜索按钮、搜索编辑框、高级搜索按钮）和预览开关复选框添加 AT-SPI 可访问名称，补充 expected_names.yaml。

AT-SPI 补全第 1 批（Batch 1），共 3 个文件：
- `searcheditwidget.cpp`
- `viewoptionswidget.cpp`
- `expected_names.yaml`

## Summary by Sourcery

Add AT-SPI accessible names for titlebar search and preview controls to improve accessibility testing coverage.

New Features:
- Provide accessible names for the titlebar search button, search edit field, advanced search button, and preview toggle checkbox via AT-SPI in testing builds.

Enhancements:
- Extend expected_names.yaml to include the new titlebar search and preview accessibility entries used in automated AT-SPI verification.