### PR TITLE
fix(preview): 修正多选预览的箭头按钮颜色

### DIFF
--- a/src/apps/dde-file-manager-preview/filepreview/main.cpp
+++ b/src/apps/dde-file-manager-preview/filepreview/main.cpp
@@ -21,6 +21,14 @@ int main(int argc, char *argv[])
         qputenv("QT_QPA_PLATFORM", "dxcb");
     }
 
+#ifdef QT_DEBUG
+    // 未安装的 debug 构建中 DConfig 的 appId 为空，导致无法读取系统主题（DTK 偏好）。
+    // 切换到文件后端绕过此限制，使浅色/深色主题能正确跟随系统。
+    if (qEnvironmentVariableIsEmpty("DSG_DCONFIG_BACKEND_TYPE")) {
+        qputenv("DSG_DCONFIG_BACKEND_TYPE", "FileBackend");
+    }
+#endif
+
     // singlentan process
     PreviewSingleApplication app(argc, argv);
 

--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
@@ -3,9 +3,44 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "filepreviewdialogstatusbar.h"
-#include <QHBoxLayout>
 
+#include <DGuiApplicationHelper>
+
+#include <QApplication>
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QPainter>
+
+DGUI_USE_NAMESPACE
 using namespace dfmplugin_filepreview;
+
+namespace {
+QIcon createColoredIcon(const QString &iconName, const QColor &color, const QSize &size, const QWidget *widget)
+{
+    const qreal dpr = widget ? widget->devicePixelRatioF() : qApp->devicePixelRatio();
+    QPixmap pixmap = QIcon::fromTheme(iconName).pixmap(size, dpr);
+    if (pixmap.isNull())
+        return QIcon();
+
+    QPainter painter(&pixmap);
+    painter.setCompositionMode(QPainter::CompositionMode_SourceIn);
+    painter.fillRect(pixmap.rect(), color);
+
+    return QIcon(pixmap);
+}
+
+QColor arrowIconColor(const QPushButton *button, bool hovered)
+{
+    const bool darkTheme = DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType;
+    QColor color = darkTheme ? QColor(Qt::white) : QColor(Qt::black);
+    if (!button || !button->isEnabled())
+        color.setAlphaF(0.4);
+    else if (!hovered)
+        color.setAlphaF(0.7);
+    return color;
+}
+}   // namespace
 
 Q_DECLARE_LOGGING_CATEGORY(logLibFilePreview)
 
@@ -13,12 +48,11 @@ FilePreviewDialogStatusBar::FilePreviewDialogStatusBar(QWidget *parent)
     : QFrame(parent)
 {
     qCDebug(logLibFilePreview) << "FilePreviewDialogStatusBar: initializing status bar";
-    
+
     QSize iconSize(12, 12);
     preBtn = new QPushButton(this);
     preBtn->setAccessibleName("PreBtn");
     preBtn->setObjectName("PreButton");
-    preBtn->setIcon(QIcon::fromTheme("go-previous").pixmap(iconSize));
     preBtn->setIconSize(iconSize);
     preBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     preBtn->setShortcut(QKeySequence::Back);
@@ -27,7 +61,6 @@ FilePreviewDialogStatusBar::FilePreviewDialogStatusBar(QWidget *parent)
     nextBtn = new QPushButton(this);
     nextBtn->setAccessibleName("NextBtn");
     nextBtn->setObjectName("NextButton");
-    nextBtn->setIcon(QIcon::fromTheme("go-next").pixmap(iconSize));
     nextBtn->setIconSize(iconSize);
     nextBtn->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     nextBtn->setShortcut(QKeySequence::Forward);
@@ -56,7 +89,14 @@ FilePreviewDialogStatusBar::FilePreviewDialogStatusBar(QWidget *parent)
     layout->addWidget(openBtn, 0, Qt::AlignRight);
 
     setLayout(layout);
-    
+
+    preBtn->installEventFilter(this);
+    nextBtn->installEventFilter(this);
+    updateNavButtonIcons();
+
+    connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged,
+            this, [this] { updateNavButtonIcons(); });
+
     qCDebug(logLibFilePreview) << "FilePreviewDialogStatusBar: status bar initialization completed";
 }
 
@@ -78,4 +118,47 @@ QPushButton *FilePreviewDialogStatusBar::nextButton() const
 QPushButton *FilePreviewDialogStatusBar::openButton() const
 {
     return openBtn;
+}
+
+bool FilePreviewDialogStatusBar::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == preBtn || watched == nextBtn) {
+        switch (event->type()) {
+        case QEvent::Enter:
+            if (watched == preBtn)
+                preBtnHovered = true;
+            else
+                nextBtnHovered = true;
+            updateNavButtonIcons();
+            break;
+        case QEvent::Leave:
+            if (watched == preBtn)
+                preBtnHovered = false;
+            else
+                nextBtnHovered = false;
+            updateNavButtonIcons();
+            break;
+        case QEvent::EnabledChange:
+        case QEvent::StyleChange:
+        case QEvent::PaletteChange:
+        case QEvent::ApplicationPaletteChange:
+        case QEvent::ScreenChangeInternal:
+        case QEvent::DevicePixelRatioChange:
+            updateNavButtonIcons();
+            break;
+        default:
+            break;
+        }
+    }
+
+    return QFrame::eventFilter(watched, event);
+}
+
+void FilePreviewDialogStatusBar::updateNavButtonIcons()
+{
+    const QSize iconSize(12, 12);
+    if (preBtn)
+        preBtn->setIcon(createColoredIcon("go-previous", arrowIconColor(preBtn, preBtnHovered), iconSize, preBtn));
+    if (nextBtn)
+        nextBtn->setIcon(createColoredIcon("go-next", arrowIconColor(nextBtn, nextBtnHovered), iconSize, nextBtn));
 }

--- a/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.h
+++ b/src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.h
@@ -11,6 +11,10 @@
 #include <QLabel>
 #include <QPushButton>
 
+QT_BEGIN_NAMESPACE
+class QEvent;
+QT_END_NAMESPACE
+
 namespace dfmplugin_filepreview {
 class FilePreviewDialogStatusBar : public QFrame
 {
@@ -23,12 +27,20 @@ public:
     QPushButton *nextButton() const;
     QPushButton *openButton() const;
 
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
 private:
+    void updateNavButtonIcons();
+
     QLabel *previewTitle { nullptr };
 
     QPushButton *preBtn { nullptr };
     QPushButton *nextBtn { nullptr };
     QPushButton *openBtn { nullptr };
+
+    bool preBtnHovered { false };
+    bool nextBtnHovered { false };
 };
 }
 #endif   // FILEPREVIEWDIALOGSTATUSBAR_H


### PR DESCRIPTION
## 问题描述

多选文件预览时，左右切换箭头按钮（go-previous/go-next）的颜色不正确，未跟随系统深色/浅色主题。

PMS: BUG-373535

## 修改内容

**颜色规范（所有状态均跟随主题）：**

| 状态 | 深色模式 | 浅色模式 |
|------|----------|----------|
| 普通 | 白色 70% | 黑色 70% |
| hover | 白色 100% | 黑色 100% |
| 禁用 | 白色 40% | 黑色 40% |

**涉及文件：**

1. `filepreviewdialogstatusbar.cpp` / `.h`
   - 新增 `createColoredIcon()`，用 `QPainter::CompositionMode_SourceIn` 对主题图标着色，替代原来直接使用未着色的 `QIcon::fromTheme().pixmap()`
   - 新增 `arrowIconColor()`，读取 `DGuiApplicationHelper::themeType()` 判断深色/浅色，按状态设置 alpha 值
   - 新增 `eventFilter()` 处理 `Enter`/`Leave`/`EnabledChange` 等事件，实时刷新箭头图标
   - 新增 `updateNavButtonIcons()` 统一刷新两个按钮图标
   - 构造函数中安装事件过滤器、调用初始刷新、连接 `themeTypeChanged` 信号

2. `main.cpp`
   - `#ifdef QT_DEBUG` 条件下 `qputenv("DSG_DCONFIG_BACKEND_TYPE", "FileBackend")`，解决未安装 debug 构建中 DConfig appId 为空导致主题读取失败的问题
   - 仅 debug 构建生效，Release 构建不受影响

## 测试

- 多选文本/图片/音乐/视频文件，箭头颜色在深色/浅色模式下均正确跟随主题
- hover 时箭头变亮（100%），离开后恢复（70%）
- 禁用状态为 40% 不透明度
- 音乐/视频播放控件（播放按钮、进度条）未受影响
