### PR TITLE
feat(at-spi): add accessible names for tabbar and fileview widgets

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -164,6 +164,15 @@ void TabBarPrivate::initUI()
     rightBtn->setFlat(true);
     rightBtn->installEventFilter(q);
 
+#ifdef ENABLE_TESTING
+    dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
+                         qobject_cast<QWidget *>(q), AcName::kAcViewTabBar);
+    dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
+                         qobject_cast<QWidget *>(addBtn), AcName::kAcViewTabBarNewButton);
+    leftBtn->setAccessibleName("LeftArrowButton");
+    rightBtn->setAccessibleName("RightArrowButton");
+#endif
+
     // for update close button state
     tabBar = q->findChild<QTabBar *>();
     if (tabBar) {

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -57,6 +57,8 @@
 #include <QUrlQuery>
 #include <QMimeData>
 #include <QLayout>
+#include <dfm-framework/event/event.h>
+
 #include <QAccessible>
 
 using namespace dfmplugin_workspace;
@@ -102,6 +104,11 @@ FileView::FileView(const QUrl &url, QWidget *parent)
     initializeGroupHeaderTimer();
 
     viewport()->installEventFilter(this);
+
+#ifdef ENABLE_TESTING
+    dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
+                         qobject_cast<QWidget *>(this), AcName::kAcFileView);
+#endif
 }
 
 FileView::~FileView()

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -2,6 +2,26 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 expected_names:
+- line: 108
+  name: file_view
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+  variable: this
+- line: 167
+  name: TabBar
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  variable: q
+- line: 168
+  name: NewTabButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  variable: addBtn
+- line: 172
+  name: LeftArrowButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  variable: leftBtn
+- line: 173
+  name: RightArrowButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  variable: rightBtn
 - line: 253
   name: CloseBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp


### PR DESCRIPTION
为标题栏标签栏（TabBar、新建标签按钮、左右滚动按钮）和工作区文件视图添加 AT-SPI 可访问名称，补充 expected_names.yaml。

AT-SPI 补全第 2 批（Batch 2），共 3 个文件：
- `tabbar.cpp`
- `fileview.cpp`
- `expected_names.yaml`

## Summary by Sourcery

Add AT-SPI accessible names for the file view and title bar tab bar widgets to improve accessibility and test coverage.

New Features:
- Provide an AT-SPI accessible name for the workspace file view widget.
- Provide AT-SPI accessible names for the title bar tab bar, new tab button, and left/right scroll buttons.

Tests:
- Extend expected_names.yaml with entries for the file view and tab bar-related widgets used in accessibility tests.