### PR TITLE
feat(at-spi): add accessible names for vault remove views

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
@@ -77,6 +77,7 @@ VaultRemoveByPasswordView::VaultRemoveByPasswordView(QWidget *parent)
     spinner->hide();
 
 #ifdef ENABLE_TESTING
+    AddATTag(qobject_cast<QWidget *>(hintInfo), AcName::kAcLabelVaultRemoveContent);
     AddATTag(qobject_cast<QWidget *>(pwdEdit), AcName::kAcEditVaultRemovePassword);
     AddATTag(qobject_cast<QWidget *>(tipsBtn), AcName::kAcBtnVaultRemovePasswordHint);
 #endif

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
@@ -17,6 +17,8 @@
 #include <QVBoxLayout>
 #include <QTimer>
 #include <QPlainTextEdit>
+
+#include "dfmplugin_vault_global.h"
 #include <QtConcurrent>
 #include <QFutureWatcher>
 #include <QLabel>
@@ -57,6 +59,10 @@ void VaultRemoveByRecoverykeyView::initUI()
         filePathEdit->setFileMode(QFileDialog::ExistingFiles);
         filePathEdit->setNameFilters({ QString("KEY file(*.key)") });
 
+#ifdef ENABLE_TESTING
+        AddATTag(qobject_cast<QWidget *>(label), AcName::kAcLabelVaultRemoveTitle);
+        filePathEdit->setAccessibleName("RecoveryKeyFileEdit");
+#endif
         contentLayout->addWidget(label);
         contentLayout->addWidget(filePathEdit);
     } else {
@@ -64,6 +70,9 @@ void VaultRemoveByRecoverykeyView::initUI()
         keyEdit->setFrameShape(QFrame::NoFrame);
         keyEdit->setPlaceholderText(tr("Input the 32-digit recovery key"));
         keyEdit->installEventFilter(this);
+#ifdef ENABLE_TESTING
+        keyEdit->setAccessibleName("RecoveryKeyEdit");
+#endif
         contentLayout->addWidget(keyEdit);
 
         connect(keyEdit, &QPlainTextEdit::textChanged, this, &VaultRemoveByRecoverykeyView::onRecoveryKeyChanged);

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -2,6 +2,23 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 expected_names:
+- line: 80
+  name: label_vault_remove_content
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  variable: hintInfo
+- line: 63
+  name: label_vault_remove_title
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+  variable: label
+- line: 64
+  name: RecoveryKeyFileEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+  variable: filePathEdit
+- line: 74
+  name: RecoveryKeyEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+  variable: keyEdit
+
 - line: 253
   name: CloseBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp


### PR DESCRIPTION
为保险箱删除视图添加 AT-SPI 可访问名称：删除提示标签、恢复密钥文件选择框、恢复密钥输入框，补充 expected_names.yaml。

AT-SPI 补全第 3 批（Batch 3），共 3 个文件：
- `vaultremovebypasswordview.cpp`
- `vaultremovebyrecoverykeyview.cpp`
- `expected_names.yaml`

## Summary by Sourcery

Add AT-SPI accessible names for vault removal views to improve accessibility testing coverage.

New Features:
- Expose accessible names for vault removal password and recovery key views, including labels and input fields, under ENABLE_TESTING.

Tests:
- Extend expected_names.yaml with entries for the new vault removal accessible elements used in AT-SPI tests.