### PR TITLE
feat(at-spi): add accessible names for detail space views

### DIFF
--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailspacewidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailspacewidget.cpp
@@ -67,6 +67,9 @@ QUrl DetailSpaceWidget::currentUrl() const
 void DetailSpaceWidget::initializeUi()
 {
     setAutoFillBackground(true);
+#ifdef ENABLE_TESTING
+    setAccessibleName("DetailSpace");
+#endif
     setBackgroundRole(QPalette::ColorRole::Base);
 
     QHBoxLayout *rvLayout = new QHBoxLayout(this);

--- a/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
+++ b/src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
@@ -4,6 +4,8 @@
 
 #include "detailview.h"
 #include "imagepreviewwidget.h"
+
+#include <dfm-framework/event/event.h>
 #include "imagepreviewworker.h"
 #include "fileinfowidget.h"
 #include "utils/detailmanager.h"
@@ -25,6 +27,9 @@ DetailView::DetailView(QWidget *parent)
     : DFrame(parent)
 {
     initInfoUI();
+#ifdef ENABLE_TESTING
+    setAccessibleName("DetailView");
+#endif
 }
 
 DetailView::~DetailView()

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -2,6 +2,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 expected_names:
+- line: 71
+  name: DetailSpace
+  source_file: src/plugins/filemanager/dfmplugin-detailspace/views/detailspacewidget.cpp
+  variable: this
+- line: 31
+  name: DetailView
+  source_file: src/plugins/filemanager/dfmplugin-detailspace/views/detailview.cpp
+  variable: this
+
 - line: 253
   name: CloseBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp


### PR DESCRIPTION
为详情面板（DetailSpace）和详情视图（DetailView）添加 AT-SPI 可访问名称，补充 expected_names.yaml。

AT-SPI 补全第 4 批（Batch 4），共 3 个文件：
- `detailspacewidget.cpp`
- `detailview.cpp`
- `expected_names.yaml`

## Summary by Sourcery

Add AT-SPI accessible names for detail space views and register them in the accessibility name expectations.

New Features:
- Define accessible names for DetailSpaceWidget and DetailView to support AT-SPI-based accessibility tooling.

Tests:
- Extend expected_names.yaml to cover the new DetailSpace and DetailView accessible names used in accessibility tests.