### PR TITLE
fix: refresh sidebar highlight immediately on url change

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -1089,7 +1089,32 @@ void SideBarView::saveStateWhenClose()
 
 void SideBarView::setCurrentUrl(const QUrl &url)
 {
+    // The sidebar highlight is URL-based (see SideBarItemDelegate::paint): an item is
+    // highlighted when its URL matches currentUrl(), and the highlight only refreshes
+    // when the item is repainted. setCurrentIndex() is meant to repaint the newly
+    // current item via currentChanged(), but that repaint is unreliable here:
+    //   - QItemSelectionModel::setCurrentIndex() is a no-op (no currentChanged) when
+    //     Qt's current index already equals the target, e.g. returning to a sidebar
+    //     item visited before, or coming back after navigating into a sub-folder that
+    //     has no sidebar item (which never changes the current index);
+    //   - the collapsed-group early-return and the not-found branch below skip
+    //     setCurrentIndex() entirely.
+    // The sidebar-click path works only because SideBarWidget::onItemActived explicitly
+    // update()s the previous/current items afterwards; the file-view navigation path
+    // (cd() -> setCurrentUrl) has no such repaint, so the highlight does not refresh
+    // until a hover triggers a viewport repaint.
+    //
+    // Fix: whenever the URL basis actually changes, repaint the whole viewport so every
+    // visible item re-evaluates its URL-based highlight against the new url -- the
+    // previously highlighted item drops its stale highlight and the newly matching
+    // item gains it, immediately, without depending on setCurrentIndex(). This is safe
+    // because the highlight background is purely URL-matched, so at most one item is
+    // highlighted (no "two items selected").
+    const QUrl previousUrl = d->sidebarUrl;
     d->sidebarUrl = url;
+    if (!UniversalUtils::urlEquals(previousUrl, url))
+        viewport()->update();   // refresh URL-based highlight for all visible items immediately
+
     bool urlNotChanged = UniversalUtils::urlEquals(d->current.data(SideBarItem::kItemUrlRole).toUrl(), url);
     const QModelIndex &index = urlNotChanged ? d->current : findItemIndex(url);
 


### PR DESCRIPTION
## 根因分析

侧边栏高亮是"基于 URL 匹配"绘制的（`SideBarItemDelegate::paint` 比较条目 URL 与 `currentUrl()`），高亮的视觉更新完全依赖对应条目被重绘（`update()`），与 Qt 选中/当前索引状态解耦。

`SideBarView::setCurrentUrl`（`sidebarview.cpp`）更新 `d->sidebarUrl`（高亮判据数据源）后，新对应条目要高亮必须被重绘。本应靠 `setCurrentIndex(index)` 经 `currentChanged` 重绘新条目，但该重绘不可靠：
- Qt6 `QItemSelectionModel::setCurrentIndex` 在 `index == currentIndex` 时是 no-op（不 emit `currentChanged`），不重绘新条目——常见于回到曾访问过的侧边栏条目，或进入无侧边栏条目的子目录后再返回。
- 折叠分组提前返回、未找到分支也直接跳过 `setCurrentIndex`。

故新对应条目不被重绘、不高亮，直到鼠标悬停触发 viewport 重绘才刷新——表现为"需要鼠标滑过才更新"。

关键证据：
- `sidebaritemdelegate.cpp` `paint`：高亮背景由 `isUrlEqual`（URL 匹配 `currentUrl()`）决定，仅在条目重绘时生效，与 Qt 选中态解耦。
- `sidebarview.cpp` `setCurrentUrl`：折叠分组提前返回 / 未找到分支跳过 `setCurrentIndex`；`QItemSelectionModel::setCurrentIndex` 在索引未变时为 no-op。
- 对照 `sidebarwidget.cpp` `onItemActived`：侧边栏点击路径在 `runCd` 后显式 `update(preIndex/curIndex)`，所以点击正常；文件视图跳转走 `FileManagerWindow::cd()` 直接 `setCurrentUrl`，缺少该重绘。

## 修复方案

在 `SideBarView::setCurrentUrl` 中，更新 `d->sidebarUrl` 后，当 url 实际变化时 `viewport()->update()` 重绘整个 viewport，让所有可见条目基于新 url 重新计算高亮——这正是 hover 实际做的事，必然有效，不再依赖 `setCurrentIndex` 的重绘时机。高亮纯由 URL 匹配决定，整体重绘后同一时刻最多一个条目高亮，避免跳转前后两个条目同时被选中。同 url 调用不触发重绘，行为不变。

## 改动安全评估

低风险：不改函数签名、不新增成员、不删除逻辑，仅追加一次条件 `viewport()->update()`；不依赖 `setCurrentIndex`。`setCurrentUrl` 的所有调用者行为要么不变（同 url），要么得到期望的高亮刷新（url 变化），无调用者依赖"旧条目保留陈旧高亮"这一行为。
