### PR TITLE
fix(openwith): adjust list item width and spacing

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -87,11 +87,11 @@ void OpenWithDialogListItem::initUiForSizeMode()
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
     int size = DSizeModeHelper::element(25, 30);
-    setFixedSize(220, DSizeModeHelper::element(40, 50));
+    setFixedSize(224, DSizeModeHelper::element(40, 50));
 #else
     int size = 30;
     iconLabel->setPixmap(icon.pixmap(iconLabel->size()));
-    setFixedSize(220, 50);
+    setFixedSize(224, 50);
 #endif
     iconLabel->setFixedSize(size, size);
     updateLabelIcon(size);
@@ -281,7 +281,9 @@ void OpenWithDialog::initUI()
     scrollArea->setWidget(contentWidget);
 
     recommandLayout = new DFlowLayout;
+    recommandLayout->setHorizontalSpacing(10);
     otherLayout = new DFlowLayout;
+    otherLayout->setHorizontalSpacing(10);
 
     openFileChooseButton = new DCommandLinkButton(tr("Add other programs"), this);
     setToDefaultCheckBox = new DCheckBox(tr("Set as default"), this);


### PR DESCRIPTION
## 问题

打开方式对话框中，三列应用列表项之间无间距，右侧到窗口边缘间距过大且不对称（Bug #373491）。

## 原因

`OpenWithDialog` 中的两个 `DFlowLayout`（推荐应用、其他应用）未设置水平间距，列表项固定宽度 220px。三列紧靠左排列，右侧多出约 30px 空白。此外 `DFlowLayout` 在 `horizontalSpacing=10` 时实际仅给出 9px 间距（取整误差），导致即使加间距后右侧仍不对称。

## 修改

- 为 `recommandLayout` 和 `otherLayout` 添加 `setHorizontalSpacing(10)`
- 列表项宽度从 220 调整为 224，补偿流式布局的取整误差，使三列 + 间距 + 左右 margin 正好填满 710px 对话框

## 效果

三列列表项左右及列间间距均为 10px，左右对称。

PMS: BUG-373491

## Summary by Sourcery

Adjust OpenWith dialog list item sizing and layout spacing for consistent three-column alignment.

Enhancements:
- Increase OpenWith dialog list item width to better align three columns within the dialog.
- Add horizontal spacing to recommended and other application flow layouts to provide consistent gaps between list items.