### PR TITLE
fix: refresh sidebar highlight immediately on url change

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -854,7 +854,32 @@ void SideBarView::saveStateWhenClose()
 
 void SideBarView::setCurrentUrl(const QUrl &url)
 {
+    // The sidebar highlight is URL-based (see SideBarItemDelegate::paint): an item is
+    // highlighted when its URL matches currentUrl(), and the highlight only refreshes
+    // when the item is repainted. setCurrentIndex() is meant to repaint the newly
+    // current item via currentChanged(), but that repaint is unreliable here:
+    //   - QItemSelectionModel::setCurrentIndex() is a no-op (no currentChanged) when
+    //     Qt's current index already equals the target, e.g. returning to a sidebar
+    //     item visited before, or coming back after navigating into a sub-folder that
+    //     has no sidebar item (which never changes the current index);
+    //   - the collapsed-group early-return and the not-found branch below skip
+    //     setCurrentIndex() entirely.
+    // The sidebar-click path works only because SideBarWidget::onItemActived explicitly
+    // update()s the previous/current items afterwards; the file-view navigation path
+    // (cd() -> setCurrentUrl) has no such repaint, so the highlight does not refresh
+    // until a hover triggers a viewport repaint.
+    //
+    // Fix: whenever the URL basis actually changes, repaint the whole viewport so every
+    // visible item re-evaluates its URL-based highlight against the new url -- the
+    // previously highlighted item drops its stale highlight and the newly matching
+    // item gains it, immediately, without depending on setCurrentIndex(). This is safe
+    // because the highlight background is purely URL-matched, so at most one item is
+    // highlighted (no "two items selected").
+    const QUrl previousUrl = d->sidebarUrl;
     d->sidebarUrl = url;
+    if (!UniversalUtils::urlEquals(previousUrl, url))
+        viewport()->update();   // refresh URL-based highlight for all visible items immediately
+
     bool urlNotChanged = UniversalUtils::urlEquals(d->current.data(SideBarItem::kItemUrlRole).toUrl(), url);
     const QModelIndex &index = urlNotChanged ? d->current : findItemIndex(url);
 


### PR DESCRIPTION
1. 在 SideBarView::setCurrentUrl 更新 sidebarUrl 后,当 url 实际变化时重绘整个 viewport,使所有可见条目基于新 url 重新计算高亮;
2. 不再依赖 setCurrentIndex 的隐式重绘——当 Qt 当前索引已等于目标(如回到曾访问过的侧边栏条目,或进入无侧边栏条目的子目录后再返回)时,setCurrentIndex 为 no-op 不触发 currentChanged,折叠分组提前返回与未找到分支也跳过 setCurrentIndex,导致新对应条目不被重绘、高亮需鼠标悬停才刷新;
3. 高亮背景纯由 URL 匹配决定,viewport 整体重绘后同一时刻最多一个条目高亮,避免跳转前后两个条目同时被选中;

=====================================

1. repaint the whole viewport after updating sidebarUrl in SideBarView::setCurrentUrl when the url actually changes, so every visible item re-evaluates its highlight against the new url;
2. stop relying on setCurrentIndex's implicit repaint -- it is a no-op (no currentChanged) when Qt's current index already equals the target (e.g. returning to a previously visited sidebar item, or going back after entering a sub-folder with no sidebar item), and is skipped entirely by the collapsed-group early-return and the not-found branch, leaving the newly matching item unrepainted until a hover;
3. the highlight background is purely URL-matched, so a full viewport repaint highlights at most one item at a time, avoiding two items being highlighted before and after navigation;

Log: 修复文件视图进入目录后侧边栏对应位置高亮需鼠标悬停才刷新的问题,进入目录即时刷新高亮

Change-Id: I0280b515c6cc531e7205b225a99d7209d01f6401

## Summary by Sourcery

Refresh sidebar URL-based highlights immediately on navigation by repainting the sidebar viewport when the current URL changes, avoiding stale or multiple item highlights that previously required hover to update.

Bug Fixes:
- Ensure sidebar item highlight updates instantly when navigating into directories, instead of only refreshing on mouse hover.
- Prevent scenarios where no item or multiple items appear highlighted due to relying on setCurrentIndex’s implicit repaint for URL-based selection.