### PR TITLE
fix: add AT-SPI accessible names for file manager widgets

### DIFF
--- a/examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+++ b/examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
@@ -36,20 +36,40 @@ void MainWindow::initUi()
     mainWidget->setLayout(mainLay);
 
     editInput = new QLineEdit(mainWidget);
+    editInput->setObjectName("EditInput");
+    editInput->setAccessibleName("EditInput");
 
     textBrowser = new QTextBrowser(mainWidget);
     textBrowser->setReadOnly(true);
 
     QGridLayout *btnLay = new QGridLayout;
     btnCheckTpm = new QPushButton(tr("Check TPM"), mainWidget);
+    btnCheckTpm->setObjectName("BtnCheckTpm");
+    btnCheckTpm->setAccessibleName("BtnCheckTpm");
     btnGetRandom = new QPushButton(tr("Get Random"), mainWidget);
+    btnGetRandom->setObjectName("BtnGetRandom");
+    btnGetRandom->setAccessibleName("BtnGetRandom");
     btnCheckAlgo = new QPushButton(tr("Check Algo"), mainWidget);
+    btnCheckAlgo->setObjectName("BtnCheckAlgo");
+    btnCheckAlgo->setAccessibleName("BtnCheckAlgo");
     btnEncrypt = new QPushButton(tr("Encrypt"), mainWidget);
+    btnEncrypt->setObjectName("BtnEncrypt");
+    btnEncrypt->setAccessibleName("BtnEncrypt");
     btnDecrypt = new QPushButton(tr("Decrypt"), mainWidget);
+    btnDecrypt->setObjectName("BtnDecrypt");
+    btnDecrypt->setAccessibleName("BtnDecrypt");
     btnEncryptTwo = new QPushButton(tr("EncryptInProcess"), mainWidget);
+    btnEncryptTwo->setObjectName("BtnEncryptTwo");
+    btnEncryptTwo->setAccessibleName("BtnEncryptTwo");
     btnDecryptTwo = new QPushButton(tr("DecryptInProcess"), mainWidget);
+    btnDecryptTwo->setObjectName("BtnDecryptTwo");
+    btnDecryptTwo->setAccessibleName("BtnDecryptTwo");
     btnEncryptThree = new QPushButton(tr("EncryptByCommand"), mainWidget);
+    btnEncryptThree->setObjectName("BtnEncryptThree");
+    btnEncryptThree->setAccessibleName("BtnEncryptThree");
     btnDecryptThree = new QPushButton(tr("DecryptByCommand"), mainWidget);
+    btnDecryptThree->setObjectName("BtnDecryptThree");
+    btnDecryptThree->setAccessibleName("BtnDecryptThree");
     btnLay->addWidget(btnCheckTpm, 0, 0);
     btnLay->addWidget(btnGetRandom, 0, 1);
     btnLay->addWidget(btnCheckAlgo, 0, 2);

--- a/src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+++ b/src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
@@ -66,6 +66,8 @@ void MountAskPasswordDialog::initUI()
     usernameLable->setFixedWidth(95);
 
     usernameLineEdit = new QLineEdit;
+    usernameLineEdit->setObjectName("UsernameLineEdit");
+    usernameLineEdit->setAccessibleName("UsernameLineEdit");
     usernameLineEdit->setMinimumWidth(240);
     usernameLineEdit->setText(qgetenv("USER"));
 
@@ -74,6 +76,8 @@ void MountAskPasswordDialog::initUI()
     domainLabel->setFixedWidth(95);
 
     domainLineEdit = new QLineEdit;
+    domainLineEdit->setObjectName("DomainLineEdit");
+    domainLineEdit->setAccessibleName("DomainLineEdit");
     domainLineEdit->setMinimumWidth(240);
     domainLineEdit->setText("WORKGROUP");
 
@@ -82,13 +86,18 @@ void MountAskPasswordDialog::initUI()
     passwordLable->setFixedWidth(90);
 
     passwordLineEdit = new DPasswordEdit;
+    passwordLineEdit->setObjectName("PasswordLineEdit");
+    passwordLineEdit->setAccessibleName("PasswordLineEdit");
     passwordLineEdit->setMinimumWidth(240);
     passwordLineEdit->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     passwordButtonGroup = new QButtonGroup(this);
+    passwordButtonGroup->setObjectName("PasswordButtonGroup");
     passwordButtonGroup->setExclusive(true);
 
     passwordCheckBox = new QCheckBox();
+    passwordCheckBox->setObjectName("PasswordCheckBox");
+    passwordCheckBox->setAccessibleName("PasswordCheckBox");
     QWidget *empty = new QWidget();
     passwordCheckBox->setText(tr("Remember password"));
 

--- a/src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
+++ b/src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
@@ -44,6 +44,8 @@ void MountSecretDiskAskPasswordDialog::initUI()
     descriptionLabel->setFont(tipfont);
 
     passwordLineEdit = new DPasswordEdit;
+    passwordLineEdit->setObjectName("PasswordLineEdit");
+    passwordLineEdit->setAccessibleName("PasswordLineEdit");
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(titleLabel);

--- a/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
@@ -16,6 +16,8 @@ CheckBoxWithMessage::CheckBoxWithMessage(QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
 
     checkBox = new QCheckBox(this);
+    checkBox->setObjectName("CheckBox");
+    checkBox->setAccessibleName("CheckBox");
     layout->addWidget(checkBox);
 
     QHBoxLayout *hLayout = new QHBoxLayout();

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -78,6 +78,8 @@ void TaskDialog::initUI()
     titlebar->setAutoFillBackground(false);
 
     taskListWidget = new QListWidget(this);
+    taskListWidget->setObjectName("TaskListWidget");
+    taskListWidget->setAccessibleName("TaskListWidget");
     taskListWidget->setSelectionMode(QListWidget::NoSelection);
     taskListWidget->viewport()->setAutoFillBackground(false);
     taskListWidget->setFrameShape(QFrame::NoFrame);

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -542,14 +542,20 @@ QWidget *TaskWidget::createBtnWidget()
     QVariant variantCoexit;
     variantCoexit.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kCoexistAction);
     btnCoexist = new DPushButton(TaskWidget::tr("Keep both", "button"));
+    btnCoexist->setObjectName("BtnCoexist");
+    btnCoexist->setAccessibleName("BtnCoexist");
     btnCoexist->setProperty(kBtnPropertyActionName, variantCoexit);
 
     btnSkip = new DPushButton(TaskWidget::tr("Skip", "button"));
+    btnSkip->setObjectName("BtnSkip");
+    btnSkip->setAccessibleName("BtnSkip");
     QVariant variantSkip;
     variantSkip.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kSkipAction);
     btnSkip->setProperty(kBtnPropertyActionName, variantSkip);
 
     btnReplace = new DPushButton(TaskWidget::tr("Replace", "button"));
+    btnReplace->setObjectName("BtnReplace");
+    btnReplace->setAccessibleName("BtnReplace");
     QVariant variantReplace;
     variantReplace.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kReplaceAction);
     btnReplace->setProperty(kBtnPropertyActionName, variantReplace);
@@ -583,6 +589,8 @@ QWidget *TaskWidget::createBtnWidget()
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
     chkboxNotAskAgain = new QCheckBox(TaskWidget::tr("Do not ask again"));
+    chkboxNotAskAgain->setObjectName("ChkboxNotAskAgain");
+    chkboxNotAskAgain->setAccessibleName("ChkboxNotAskAgain");
     layout->addSpacing(100);
     layout->addWidget(chkboxNotAskAgain);
 

--- a/src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
+++ b/src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
@@ -46,6 +46,8 @@ void ViewHintWidget::initLayout()
     // 原因: 基类的 changeEvent() 会访问内部 d-pointer，复用其控件会导致悬空指针崩溃。
 
     m_iconButton = new DIconButton(this);
+    m_iconButton->setObjectName("IconButton");
+    m_iconButton->setAccessibleName("IconButton");
     m_iconButton->setFlat(true);
     m_iconButton->setFocusPolicy(Qt::NoFocus);
     m_iconButton->setAttribute(Qt::WA_TransparentForMouseEvents);
@@ -57,6 +59,8 @@ void ViewHintWidget::initLayout()
     m_messageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     m_closeButton = new DIconButton(this);
+    m_closeButton->setObjectName("CloseButton");
+    m_closeButton->setAccessibleName("CloseButton");
     m_closeButton->setFlat(true);
     m_closeButton->setFocusPolicy(Qt::NoFocus);
     m_closeButton->setIcon(DDciIcon::fromTheme("dfm-clear"));

--- a/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
@@ -131,6 +131,8 @@ void BurnOptDialog::initializeUi()
     volnameLabel->setFont(f13);
 
     volnameEdit = new QLineEdit();
+    volnameEdit->setObjectName("VolnameEdit");
+    volnameEdit->setAccessibleName("VolnameEdit");
     QRegularExpression regx("[^\\\\/\':\\*\\?\"<>|%&.]+");   // 屏蔽特殊字符
     QValidator *validator = new QRegularExpressionValidator(regx, volnameEdit);
     volnameEdit->setValidator(validator);
@@ -145,6 +147,8 @@ void BurnOptDialog::initializeUi()
 
     // 高级设置内容
     advanceBtn = new DCommandLinkButton(BurnOptDialog::tr("Advanced settings"), this);
+    advanceBtn->setObjectName("AdvanceBtn");
+    advanceBtn->setAccessibleName("AdvanceBtn");
     QFont f12 = advanceBtn->font();
     f12.setPixelSize(12);
     f12.setWeight(QFont::Normal);
@@ -177,6 +181,8 @@ void BurnOptDialog::initializeUi()
     };
 
     fsComb = new QComboBox;
+    fsComb->setObjectName("FsComb");
+    fsComb->setAccessibleName("FsComb");
     fsComb->addItems(fsTypes);
     fsComb->setCurrentIndex(BurnHelper::defaultBurnFs());
     vLay->addWidget(fsComb);
@@ -194,6 +200,8 @@ void BurnOptDialog::initializeUi()
     writespeedLabel = new QLabel(QObject::tr("Write speed:"));
     vLay->addWidget(writespeedLabel, 0, Qt::AlignTop);
     writespeedComb = new QComboBox();
+    writespeedComb->setObjectName("WritespeedComb");
+    writespeedComb->setAccessibleName("WritespeedComb");
     writespeedComb->addItem(QObject::tr("Maximum"));
     vLay->addWidget(writespeedComb, 0, Qt::AlignTop);
     speedMap[QObject::tr("Maximum")] = 0;
@@ -202,6 +210,8 @@ void BurnOptDialog::initializeUi()
 
     // 刻录选项-封盘设置
     finalizeDiscCheckbox = new QCheckBox(QObject::tr("Finalize disc after burning \n(no additional data can be appended)"));
+    finalizeDiscCheckbox->setObjectName("FinalizeDiscCheckbox");
+    finalizeDiscCheckbox->setAccessibleName("FinalizeDiscCheckbox");
     finalizeDiscCheckbox->setChecked(false);
     vLay->addWidget(finalizeDiscCheckbox, 0, Qt::AlignTop);
     QWidget *wpostburn = new QWidget();
@@ -212,14 +222,20 @@ void BurnOptDialog::initializeUi()
 
     // 刻录选项-校验数据
     checkdiscCheckbox = new QCheckBox(QObject::tr("Verify data"));
+    checkdiscCheckbox->setObjectName("CheckdiscCheckbox");
+    checkdiscCheckbox->setAccessibleName("CheckdiscCheckbox");
     checkdiscCheckbox->setFont(f12);
     wpostburn->layout()->addWidget(checkdiscCheckbox);
     // 刻录选项-校验文件
     checksumCheckbox = new QCheckBox(QObject::tr("Verify files (checksum)"));
+    checksumCheckbox->setObjectName("ChecksumCheckbox");
+    checksumCheckbox->setAccessibleName("ChecksumCheckbox");
     checksumCheckbox->setFont(f12);
     vLay->addWidget(checksumCheckbox, 0, Qt::AlignTop);
     // 刻录选项-弹出光盘（目前禁用）
     ejectCheckbox = new QCheckBox(QObject::tr("Eject"));
+    ejectCheckbox->setObjectName("EjectCheckbox");
+    ejectCheckbox->setAccessibleName("EjectCheckbox");
     ejectCheckbox->setFont(f12);
     ejectCheckbox->setChecked(true);
     wpostburn->layout()->addWidget(ejectCheckbox);

--- a/src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
@@ -98,6 +98,8 @@ void DumpISOOptDialog::initliazeUi()
 
     // file chooser
     fileChooser = new DFileChooserEdit;
+    fileChooser->setObjectName("FileChooser");
+    fileChooser->setAccessibleName("FileChooser");
     fileChooser->setFileMode(QFileDialog::FileMode::Directory);
     const QString &stdDocPath = QStandardPaths::writableLocation(QStandardPaths::StandardLocation::DocumentsLocation);
     fileChooser->setDirectoryUrl(QUrl::fromLocalFile(stdDocPath));

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -158,6 +158,8 @@ void ShareControlWidget::setupUi(bool disableState)
 void ShareControlWidget::setupShareSwitcher()
 {
     shareSwitcher = new QCheckBox(this);
+    shareSwitcher->setObjectName("ShareSwitcher");
+    shareSwitcher->setAccessibleName("ShareSwitcher");
     shareSwitcher->setFixedWidth(ConstDef::kWidgetFixedWidth);
     QString text = tr("Share this folder");
     shareSwitcher->setToolTip(text);
@@ -173,6 +175,8 @@ void ShareControlWidget::setupShareSwitcher()
 void ShareControlWidget::setupShareNameEditor()
 {
     shareNameEditor = new DLineEdit(this);
+    shareNameEditor->setObjectName("ShareNameEditor");
+    shareNameEditor->setAccessibleName("ShareNameEditor");
 
     static constexpr char kShareNameRegx[] { R"(^(?![ -])[^%<>*?|/\\+=;:,"]*+ ?$)" };
     QValidator *validator = new QRegularExpressionValidator(QRegularExpression(kShareNameRegx), this);
@@ -184,6 +188,8 @@ void ShareControlWidget::setupShareNameEditor()
 void ShareControlWidget::setupSharePermissionSelector()
 {
     sharePermissionSelector = new QComboBox(this);
+    sharePermissionSelector->setObjectName("SharePermissionSelector");
+    sharePermissionSelector->setAccessibleName("SharePermissionSelector");
 
     QPalette peMenuBg;
     QColor color = palette().color(QPalette::ColorGroup::Active, QPalette::ColorRole::Window);
@@ -197,6 +203,8 @@ void ShareControlWidget::setupSharePermissionSelector()
 void ShareControlWidget::setupShareAnonymousSelector()
 {
     shareAnonymousSelector = new QComboBox(this);
+    shareAnonymousSelector->setObjectName("ShareAnonymousSelector");
+    shareAnonymousSelector->setAccessibleName("ShareAnonymousSelector");
 
     QPalette peMenuBg;
     QColor color = palette().color(QPalette::ColorGroup::Active, QPalette::ColorRole::Window);
@@ -216,6 +224,8 @@ QHBoxLayout *ShareControlWidget::setupNetworkPath()
     networkAddrLabel->setFixedWidth(ConstDef::kWidgetFixedWidth);
 
     copyNetAddr = new QPushButton(this);
+    copyNetAddr->setObjectName("CopyNetAddr");
+    copyNetAddr->setAccessibleName("CopyNetAddr");
     copyNetAddr->setFlat(true);
     copyNetAddr->setToolTip(tr("Copy"));
     auto setBtnIcon = [=] {
@@ -250,6 +260,8 @@ QHBoxLayout *ShareControlWidget::setupUserName()
     userNamelineLabel->setFixedWidth(ConstDef::kWidgetFixedWidth);
 
     copyUserNameBt = new QPushButton(this);
+    copyUserNameBt->setObjectName("CopyUserNameBt");
+    copyUserNameBt->setAccessibleName("CopyUserNameBt");
     copyUserNameBt->setFlat(true);
     copyUserNameBt->setToolTip(tr("Copy"));
     auto setBtnIcon = [=] {
@@ -286,6 +298,8 @@ QHBoxLayout *ShareControlWidget::setupSharePassword()
     sharePassword->setText(isSharePasswordSet ? "●●●●●" : tr("None"));
 
     setPasswordBt = new DCommandLinkButton(tr("Set password"));
+    setPasswordBt->setObjectName("SetPasswordBt");
+    setPasswordBt->setAccessibleName("SetPasswordBt");
     setPasswordBt->setText(isSharePasswordSet ? tr("Change password") : tr("Set password"));
     setPasswordBt->setContentsMargins(0, 0, 0, 0);
     setPasswordBt->setToolTip(setPasswordBt->text());

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -185,6 +185,8 @@ void BasicWidget::initUI()
     fileModified = createValueLabel(frameMain, tr("Modified"));
 
     hideFile = new DCheckBox(frameMain);
+    hideFile->setObjectName("HideFile");
+    hideFile->setAccessibleName("HideFile");
     DFontSizeManager::instance()->bind(hideFile, DFontSizeManager::SizeType::T7, QFont::Normal);
     hideFile->setText(tr("Hide this file"));
     hideFile->setToolTip(hideFile->text());

--- a/src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp
@@ -48,6 +48,8 @@ void CloseAllDialog::initUI()
     //    AC_SET_ACCESSIBLE_NAME(messageLabel, AC_CLOSE_ALL_DLG_INDICATOR_MSG_LABEL);
 
     closeButton = new DCommandLinkButton(tr("Close all"), this);
+    closeButton->setObjectName("CloseButton");
+    closeButton->setAccessibleName("CloseButton");
     // 设置按钮无焦点
     closeButton->setFocusPolicy(Qt::NoFocus);
     font = closeButton->font();

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -241,6 +241,7 @@ void EditStackedWidget::initTextShowFrame(QString fileName)
     }
 
     nameEditIcon = new DIconButton(textShowFrame);
+    nameEditIcon->setAccessibleName("NameEditIcon");
     nameEditIcon->setObjectName(QString("EditButton"));
     nameEditIcon->setIcon(QIcon::fromTheme("dfm_rename"));
     nameEditIcon->setIconSize({ 12, 12 });

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
@@ -65,6 +65,8 @@ void MultiFilePermissionWidget::initUI()
                                        QFont::Medium);
     owner->setFixedWidth(kLabelWidth);
     ownerComboBox = new DComboBox(this);
+    ownerComboBox->setObjectName("OwnerComboBox");
+    ownerComboBox->setAccessibleName("OwnerComboBox");
     ownerComboBox->addItem(QObject::tr("Read-write"));
     ownerComboBox->addItem(QObject::tr("Read only"));
 
@@ -73,6 +75,8 @@ void MultiFilePermissionWidget::initUI()
                                        QFont::Medium);
     group->setFixedWidth(kLabelWidth);
     groupComboBox = new DComboBox(this);
+    groupComboBox->setObjectName("GroupComboBox");
+    groupComboBox->setAccessibleName("GroupComboBox");
     groupComboBox->addItem(QObject::tr("Read-write"));
     groupComboBox->addItem(QObject::tr("Read only"));
 
@@ -81,6 +85,8 @@ void MultiFilePermissionWidget::initUI()
                                        QFont::Medium);
     other->setFixedWidth(kLabelWidth);
     otherComboBox = new DComboBox(this);
+    otherComboBox->setObjectName("OtherComboBox");
+    otherComboBox->setAccessibleName("OtherComboBox");
     otherComboBox->addItem(QObject::tr("Read-write"));
     otherComboBox->addItem(QObject::tr("Read only"));
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertiesdialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertiesdialog.cpp
@@ -201,6 +201,8 @@ void MultiFilePropertiesDialog::initUI()
     scrollArea->setWidget(scrollWidget);
 
     cancelBtn = new QPushButton(tr("Cancel"), this);
+    cancelBtn->setObjectName("CancelBtn");
+    cancelBtn->setAccessibleName("CancelBtn");
     cancelBtn->setFixedHeight(kBtnHeight);
     cancelBtn->setAttribute(Qt::WA_NoMousePropagation);
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -157,16 +157,24 @@ void PermissionManagerWidget::initUI()
     DLabel *owner = new DLabel(QObject::tr("Owner"), this);
     DFontSizeManager::instance()->bind(owner, DFontSizeManager::SizeType::T7, QFont::Medium);
     ownerComboBox = new QComboBox(this);
+    ownerComboBox->setObjectName("OwnerComboBox");
+    ownerComboBox->setAccessibleName("OwnerComboBox");
 
     DLabel *group = new DLabel(QObject::tr("Group"), this);
     DFontSizeManager::instance()->bind(group, DFontSizeManager::SizeType::T7, QFont::Medium);
     groupComboBox = new QComboBox(this);
+    groupComboBox->setObjectName("GroupComboBox");
+    groupComboBox->setAccessibleName("GroupComboBox");
 
     DLabel *other = new DLabel(QObject::tr("Others"), this);
     DFontSizeManager::instance()->bind(other, DFontSizeManager::SizeType::T7, QFont::Medium);
     otherComboBox = new QComboBox(this);
+    otherComboBox->setObjectName("OtherComboBox");
+    otherComboBox->setAccessibleName("OtherComboBox");
 
     executableCheckBox = new QCheckBox(this);
+    executableCheckBox->setObjectName("ExecutableCheckBox");
+    executableCheckBox->setAccessibleName("ExecutableCheckBox");
     executableCheckBox->setText(tr("Allow to execute as program"));
     executableCheckBox->setToolTip(executableCheckBox->text());
 

--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
@@ -388,6 +388,8 @@ QWidget *BluetoothTransDialog::createDeviceSelectorPage()
     pLayout->addWidget(statusTxt);
 
     devicesListView = new DListView(this);
+    devicesListView->setObjectName("DevicesListView");
+    devicesListView->setAccessibleName("DevicesListView");
     devModel = new QStandardItemModel(this);
     devicesListView->setFixedHeight(88);
     devicesListView->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -55,6 +55,8 @@ OpenWithDialogListItem::OpenWithDialogListItem(const QString &iconName, const QS
       label(new DLabel(this))
 
 {
+    checkButton->setObjectName("CheckButton");
+    checkButton->setAccessibleName("CheckButton");
     checkButton->setFixedSize(15, 15);
     checkButton->setFlat(true);
     label->setText(text);
@@ -288,10 +290,18 @@ void OpenWithDialog::initUI()
     otherLayout = new DFlowLayout;
 
     openFileChooseButton = new DCommandLinkButton(tr("Add other programs"), this);
+    openFileChooseButton->setObjectName("OpenFileChooseButton");
+    openFileChooseButton->setAccessibleName("OpenFileChooseButton");
     setToDefaultCheckBox = new DCheckBox(tr("Set as default"), this);
+    setToDefaultCheckBox->setObjectName("SetToDefaultCheckBox");
+    setToDefaultCheckBox->setAccessibleName("SetToDefaultCheckBox");
     setToDefaultCheckBox->setChecked(true);
     cancelButton = new DPushButton(tr("Cancel", "button"));
+    cancelButton->setObjectName("CancelButton");
+    cancelButton->setAccessibleName("CancelButton");
     chooseButton = new DSuggestButton(tr("Confirm", "button"));
+    chooseButton->setObjectName("ChooseButton");
+    chooseButton->setAccessibleName("ChooseButton");
     cancelButton->setMinimumWidth(78);
     chooseButton->setMinimumWidth(78);
     chooseButton->setFocus();

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
@@ -49,6 +49,7 @@ void OpenWithWidget::initUI()
     DFontSizeManager::instance()->bind(openWithListWidget, DFontSizeManager::SizeType::T7, QFont::Normal);
 
     openWithBtnGroup = new QButtonGroup(openWithListWidget);
+    openWithBtnGroup->setObjectName("OpenWithBtnGroup");
 
     this->setContent(openWithListWidget);
 

--- a/src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
@@ -88,6 +88,8 @@ void CanvasViewMenuProxy::showEmptyAreaMenu(const Qt::ItemFlags &indexFlags, con
     }
 
     menuPtr = new DMenu(view);
+    menuPtr->setObjectName("MenuPtr");
+    menuPtr->setAccessibleName("MenuPtr");
     canvasScene->create(menuPtr);
     canvasScene->updateState(menuPtr);
     if (QAction *act = menuPtr->exec(QCursor::pos())) {

--- a/src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp
@@ -16,6 +16,8 @@ MethodComBox::MethodComBox(const QString &title, QWidget *parent)
 
     comboBox = qobject_cast<DComboBox *>(rightWidget);
     comboBox->setParent(this);
+    comboBox->setObjectName("ComboBox");
+    comboBox->setAccessibleName("ComboBox");
     comboBox->setFixedSize(198, 36);
 
     //Enable the combo box

--- a/src/plugins/desktop/ddplugin-organizer/options/widgets/checkboxwidget.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/widgets/checkboxwidget.cpp
@@ -11,6 +11,8 @@ CheckBoxWidget::CheckBoxWidget(const QString &text, QWidget *parent)
     : EntryWidget(new DCheckBox(text), nullptr, parent)
 {
     checkBox = qobject_cast<DCheckBox *>(leftWidget);
+    checkBox->setObjectName("CheckBox");
+    checkBox->setAccessibleName("CheckBox");
     connect(checkBox, &QCheckBox::stateChanged, this, [this](int stat) {
         emit changed(stat == Qt::Checked);
     });

--- a/src/plugins/desktop/ddplugin-organizer/options/widgets/shortcutwidget.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/widgets/shortcutwidget.cpp
@@ -16,6 +16,8 @@ ShortcutWidget::ShortcutWidget(const QString &title, QWidget *parent)
     label->setParent(this);
     label->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     keyEdit = qobject_cast<DKeySequenceEdit *>(rightWidget);
+    keyEdit->setObjectName("KeyEdit");
+    keyEdit->setAccessibleName("KeyEdit");
     keyEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
     auto p = keyEdit->palette();

--- a/src/plugins/desktop/ddplugin-organizer/options/widgets/switchwidget.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/widgets/switchwidget.cpp
@@ -20,6 +20,8 @@ SwitchWidget::SwitchWidget(const QString &title, QWidget *parent)
 
     switchBtn = qobject_cast<DSwitchButton *>(rightWidget);
     switchBtn->setParent(this);
+    switchBtn->setObjectName("SwitchBtn");
+    switchBtn->setAccessibleName("SwitchBtn");
 
     connect(switchBtn, &DSwitchButton::toggled, this, &SwitchWidget::checkedChanged);
 }

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
@@ -77,6 +77,8 @@ void CollectionViewMenu::emptyAreaMenu()
         delete menuPtr;
 
     menuPtr = new DMenu(view);
+    menuPtr->setObjectName("MenuPtr");
+    menuPtr->setAccessibleName("MenuPtr");
     canvasScene->create(menuPtr);
     canvasScene->updateState(menuPtr);
 

--- a/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+++ b/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
@@ -247,7 +247,11 @@ void FileDialogStatusBar::initializeUi()
     filtersLabel->setObjectName(labelFilters);
 
     fileNameEdit = new DLineEdit(this);
+    fileNameEdit->setObjectName("FileNameEdit");
+    fileNameEdit->setAccessibleName("FileNameEdit");
     filtersComboBox = new DComboBox(this);
+    filtersComboBox->setObjectName("FiltersComboBox");
+    filtersComboBox->setAccessibleName("FiltersComboBox");
 #ifdef ENABLE_TESTING
     dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
                          qobject_cast<QWidget *>(fileNameEdit), AcName::kAcFDStatusBarFileNameEdit);

--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -127,6 +127,8 @@ QWidget *ComputerItemDelegate::createEditor(QWidget *parent, const QStyleOptionV
     editingIndex = index;
     auto editor = new QLineEdit(parent);
     renameEditor = editor;
+    renameEditor->setObjectName("RenameEditor");
+    renameEditor->setAccessibleName("RenameEditor");
 
     int topMargin = editorMarginTop(option.font.family());
     editor->setFrame(false);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
@@ -63,8 +63,14 @@ void ChgPassphraseDialog::initUI()
 
     oldKeyHint = new QLabel(this);
     oldPass = new Dtk::Widget::DPasswordEdit(this);
+    oldPass->setObjectName("OldPass");
+    oldPass->setAccessibleName("OldPass");
     newPass1 = new Dtk::Widget::DPasswordEdit(this);
+    newPass1->setObjectName("NewPass1");
+    newPass1->setAccessibleName("NewPass1");
     newPass2 = new Dtk::Widget::DPasswordEdit(this);
+    newPass2->setObjectName("NewPass2");
+    newPass2->setAccessibleName("NewPass2");
 
     newPass2->setPlaceholderText(tr("Please enter %1 again").arg(keyTypeStr));
 
@@ -73,6 +79,8 @@ void ChgPassphraseDialog::initUI()
     lay->addRow(tr("Repeat %1").arg(encType), newPass2);
 
     recSwitch = new Dtk::Widget::DCommandLinkButton("", this);
+    recSwitch->setObjectName("RecSwitch");
+    recSwitch->setAccessibleName("RecSwitch");
     contentLay->addWidget(recSwitch, 0, Qt::AlignRight);
 
     addContent(content);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
@@ -114,6 +114,8 @@ void DecryptParamsInputDialog::initUI()
     editor = new Dtk::Widget::DPasswordEdit(this);
     lay->addWidget(editor);
     recSwitch = new Dtk::Widget::DCommandLinkButton("", this);
+    recSwitch->setObjectName("RecSwitch");
+    recSwitch->setAccessibleName("RecSwitch");
     lay->addWidget(recSwitch, 0, Qt::AlignRight);
     addContent(content);
     addButton(tr("Confirm"));

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -114,6 +114,8 @@ QWidget *EncryptParamsInputDialog::createPasswordPage()
     wid->setLayout(lay);
 
     encType = new DComboBox(this);
+    encType->setObjectName("EncType");
+    encType->setAccessibleName("EncType");
     encType->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     lay->addRow(tr("Unlock type"), encType);
 
@@ -128,11 +130,15 @@ QWidget *EncryptParamsInputDialog::createPasswordPage()
 
     keyHint1 = new QLabel(this);
     encKeyEdit1 = new DPasswordEdit(this);
+    encKeyEdit1->setObjectName("EncKeyEdit1");
+    encKeyEdit1->setAccessibleName("EncKeyEdit1");
     keyHint1->setMinimumWidth(66);
     lay->addRow(keyHint1, encKeyEdit1);
 
     keyHint2 = new QLabel(this);
     encKeyEdit2 = new DPasswordEdit(this);
+    encKeyEdit2->setObjectName("EncKeyEdit2");
+    encKeyEdit2->setAccessibleName("EncKeyEdit2");
     lay->addRow(keyHint2, encKeyEdit2);
 
     encType->addItems({ tr("Unlocked by passphrase"),
@@ -174,6 +180,8 @@ QWidget *EncryptParamsInputDialog::createExportPage()
     hint->setAlignment(Qt::AlignCenter);
 
     keyExportInput = new DFileChooserEdit(this);
+    keyExportInput->setObjectName("KeyExportInput");
+    keyExportInput->setAccessibleName("KeyExportInput");
     keyExportInput->setFileMode(QFileDialog::Directory);
     if (keyExportInput->fileDialog() && dialog_utils::isWayland())
         keyExportInput->fileDialog()->setWindowFlag(Qt::WindowStaysOnTopHint);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
@@ -42,7 +42,11 @@ void UnlockPartitionDialog::initUI()
 
     QFrame *content = new QFrame;
     passwordLineEdit = new DPasswordEdit;
+    passwordLineEdit->setObjectName("PasswordLineEdit");
+    passwordLineEdit->setAccessibleName("PasswordLineEdit");
     chgUnlockType = new DCommandLinkButton("");
+    chgUnlockType->setObjectName("ChgUnlockType");
+    chgUnlockType->setAccessibleName("ChgUnlockType");
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addSpacing(10);

--- a/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
@@ -106,7 +106,11 @@ void OpticalMediaWidget::initializeUi()
     lbAvailable = new QLabel("<Space Available>");
     lbUDFSupport = new QLabel(tr("It does not support burning UDF discs"));
     pbDump = new DPushButton();
+    pbDump->setObjectName("PbDump");
+    pbDump->setAccessibleName("PbDump");
     pbBurn = new DPushButton();
+    pbBurn->setObjectName("PbBurn");
+    pbBurn->setAccessibleName("PbBurn");
     iconCaution = new QSvgWidget();
 
     // 设置按钮文本

--- a/src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
@@ -26,6 +26,8 @@ IndexStatusCheckBox::IndexStatusCheckBox(QWidget *parent)
     layout->setSpacing(4);
 
     m_checkBox = new QCheckBox(this);
+    m_checkBox->setObjectName("CheckBox");
+    m_checkBox->setAccessibleName("CheckBox");
     layout->addWidget(m_checkBox);
 
     auto *statusWidget = new QWidget(this);

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -373,6 +373,8 @@ void ConnectToServerDialog::initializeUi()
     // init address area
     {
         schemeComboBox = new DComboBox(this);
+        schemeComboBox->setObjectName("SchemeComboBox");
+        schemeComboBox->setAccessibleName("SchemeComboBox");
         supportedSchemes << QString("%1://").arg(Scheme::kSmb)
                          << QString("%1://").arg(Scheme::kFtp)
                          << QString("%1://").arg(Scheme::kSFtp)
@@ -389,12 +391,16 @@ void ConnectToServerDialog::initializeUi()
         completer->setMaxVisibleItems(kMaxHistoryItems);
 
         serverComboBox = new DComboBox(this);
+        serverComboBox->setObjectName("ServerComboBox");
+        serverComboBox->setAccessibleName("ServerComboBox");
         serverComboBox->setEditable(true);
         serverComboBox->setMaxVisibleItems(kMaxHistoryItems);
         serverComboBox->clearEditText();
         serverComboBox->setCompleter(completer);
 
         theAddButton = new DIconButton(this);
+        theAddButton->setObjectName("TheAddButton");
+        theAddButton->setAccessibleName("TheAddButton");
         theAddButton->setMaximumSize(38, 38);
         theAddButton->setFlat(false);
         theAddButton->setIconSize({ 16, 16 });
@@ -411,6 +417,8 @@ void ConnectToServerDialog::initializeUi()
         charsetLabel->setContentsMargins(8, 0, 0, 0);
 
         charsetComboBox = new DComboBox();
+        charsetComboBox->setObjectName("CharsetComboBox");
+        charsetComboBox->setAccessibleName("CharsetComboBox");
         charsetComboBox->addItems({ tr("Default"), "UTF-8", "GBK" });
         charsetComboBox->setVisible(false);
 
@@ -421,6 +429,8 @@ void ConnectToServerDialog::initializeUi()
     // init collection area
     {
         collectionServerView = new DListView();
+        collectionServerView->setObjectName("CollectionServerView");
+        collectionServerView->setAccessibleName("CollectionServerView");
         collectionServerView->setVerticalScrollMode(DListView::ScrollPerPixel);
         collectionServerView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
         collectionServerView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
@@ -82,12 +82,18 @@ void DPCConfirmWidget::initUI()
     QValidator *validator = new QRegularExpressionValidator(regx, this);
 
     oldPwdEdit = new DPasswordEdit(this);
+    oldPwdEdit->setObjectName("OldPwdEdit");
+    oldPwdEdit->setAccessibleName("OldPwdEdit");
     oldPwdEdit->lineEdit()->setValidator(validator);   // 设置验证器
 
     newPwdEdit = new DPasswordEdit(this);
+    newPwdEdit->setObjectName("NewPwdEdit");
+    newPwdEdit->setAccessibleName("NewPwdEdit");
     newPwdEdit->lineEdit()->setValidator(validator);
 
     repeatPwdEdit = new DPasswordEdit(this);
+    repeatPwdEdit->setObjectName("RepeatPwdEdit");
+    repeatPwdEdit->setAccessibleName("RepeatPwdEdit");
     repeatPwdEdit->lineEdit()->setValidator(validator);
 
     DLabel *oldPwdLabel = new DLabel(tr("Current password:"), this);
@@ -106,8 +112,12 @@ void DPCConfirmWidget::initUI()
     contentLayout->setVerticalSpacing(10);
 
     saveBtn = new DSuggestButton(tr("Save", "button"), this);
+    saveBtn->setObjectName("SaveBtn");
+    saveBtn->setAccessibleName("SaveBtn");
     saveBtn->setAttribute(Qt::WA_NoMousePropagation);
     cancelBtn = new DPushButton(tr("Cancel", "button"), this);
+    cancelBtn->setObjectName("CancelBtn");
+    cancelBtn->setAccessibleName("CancelBtn");
     cancelBtn->setAttribute(Qt::WA_NoMousePropagation);
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
@@ -52,6 +52,8 @@ void CustomTabSettingWidget::initUI()
     mainLayout->setVerticalSpacing(10);
 
     addItemBtn = new DToolButton(this);
+    addItemBtn->setObjectName("AddItemBtn");
+    addItemBtn->setAccessibleName("AddItemBtn");
     addItemBtn->setToolTip(tr("Add Directory"));
     addItemBtn->setIconSize({ 16, 16 });
     addItemBtn->setIcon(DStyle::standardIcon(style(), DStyle::SP_IncreaseElement));

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -319,6 +319,8 @@ void SearchEditWidget::initUI()
 
     // search button
     searchButton = new CustomDIconButton(this);
+    searchButton->setObjectName("SearchButton");
+    searchButton->setAccessibleName("SearchButton");
     searchButton->setIcon(QIcon::fromTheme("dfm_search_button"));
     searchButton->setFixedSize(kToolButtonSize, kToolButtonSize);
     searchButton->setIconSize(QSize(kToolButtonIconSize, kToolButtonIconSize));
@@ -329,12 +331,16 @@ void SearchEditWidget::initUI()
 
     // search edit
     searchEdit = new DSearchEdit(this);
+    searchEdit->setObjectName("SearchEdit");
+    searchEdit->setAccessibleName("SearchEdit");
     searchEdit->setVisible(true);
     // searchEdit->setFocusPolicy(Qt::StrongFocus);
     searchEdit->lineEdit()->setFocusPolicy(Qt::ClickFocus);
 
     // advanced search button
     advancedButton = new CustomDToolButton(this);
+    advancedButton->setObjectName("AdvancedButton");
+    advancedButton->setAccessibleName("AdvancedButton");
     advancedButton->setIcon(QIcon::fromTheme("dfm_view_filter"));
     advancedButton->setFixedSize(kToolButtonSize, kToolButtonSize);
     advancedButton->setFocusPolicy(Qt::NoFocus);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -145,6 +145,7 @@ void TabBarPrivate::initUI()
     addBtn = q->findChild<DIconButton *>("AddButton");
     Q_ASSERT(addBtn);
 
+    addBtn->setAccessibleName("AddBtn");
     addBtn->setFixedSize(30, 30);
     addBtn->setFlat(true);
     addBtn->setFocusPolicy(Qt::NoFocus);
@@ -167,6 +168,8 @@ void TabBarPrivate::initUI()
     // for update close button state
     tabBar = q->findChild<QTabBar *>();
     if (tabBar) {
+        tabBar->setObjectName("TabBar");
+        tabBar->setAccessibleName("TabBar");
         tabBar->setMouseTracking(true);
         tabBar->installEventFilter(q);
     }

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
@@ -80,6 +80,8 @@ void VaultActiveFinishedView::initUi()
 
     // 加密保险箱按钮
     finishedBtn = new DSuggestButton(tr("Encrypt"), this);
+    finishedBtn->setObjectName("FinishedBtn");
+    finishedBtn->setAccessibleName("FinishedBtn");
     finishedBtn->setFixedWidth(200);
 
     // 布局

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
@@ -92,6 +92,8 @@ void VaultActiveSaveKeyFileView::initUI()
     otherRadioBtnHitMsg->setForegroundRole(DPalette::TextWarning);
 
     selectfileSavePathEdit = new DFileChooserEdit(this);
+    selectfileSavePathEdit->setObjectName("SelectfileSavePathEdit");
+    selectfileSavePathEdit->setAccessibleName("SelectfileSavePathEdit");
     selectfileSavePathEdit->lineEdit()->setPlaceholderText(tr("Select a path"));
     selectfileSavePathEdit->lineEdit()->setReadOnly(true);
     selectfileSavePathEdit->lineEdit()->setClearButtonEnabled(false);
@@ -105,6 +107,8 @@ void VaultActiveSaveKeyFileView::initUI()
     selectfileSavePathEdit->setEnabled(true);
 
     nextBtn = new DSuggestButton(tr("Next"), this);
+    nextBtn->setObjectName("NextBtn");
+    nextBtn->setAccessibleName("NextBtn");
     nextBtn->setFixedWidth(200);
     nextBtn->setEnabled(false);
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
@@ -48,6 +48,8 @@ void VaultActiveSetUnlockMethodView::initUi()
 
     DLabel *pTypeLabel = new DLabel(tr("Encryption method"), this);
     typeCombo = new DComboBox(this);
+    typeCombo->setObjectName("TypeCombo");
+    typeCombo->setAccessibleName("TypeCombo");
     typeCombo->addItem(tr("Key encryption"), EncryptMode::kKeyMode);
     typeCombo->addItem(tr("Transparent encryption"), EncryptMode::kTransparentMode);
 
@@ -62,12 +64,16 @@ void VaultActiveSetUnlockMethodView::initUi()
 
     repeatPasswordLabel = new DLabel(tr("Repeat password"), this);
     repeatPasswordEdit = new DPasswordEdit(this);
+    repeatPasswordEdit->setObjectName("RepeatPasswordEdit");
+    repeatPasswordEdit->setAccessibleName("RepeatPasswordEdit");
     repeatPasswordEdit->lineEdit()->setValidator(validator);
     repeatPasswordEdit->lineEdit()->setPlaceholderText(tr("Input the password again"));
     repeatPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     passwordHintLabel = new DLabel(tr("Password hint"), this);
     tipsEdit = new DLineEdit(this);
+    tipsEdit->setObjectName("TipsEdit");
+    tipsEdit->setAccessibleName("TipsEdit");
     tipsEdit->lineEdit()->setMaxLength(14);
     tipsEdit->setPlaceholderText(tr("Optional"));
 
@@ -83,6 +89,8 @@ void VaultActiveSetUnlockMethodView::initUi()
     transEncryptTextLay->addWidget(transEncryptionText);
 
     nextBtn = new DSuggestButton(tr("Next"), this);
+    nextBtn->setObjectName("NextBtn");
+    nextBtn->setAccessibleName("NextBtn");
     nextBtn->setFixedWidth(200);
     nextBtn->setEnabled(false);
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
@@ -41,6 +41,8 @@ void VaultActiveStartView::initUi()
     pLabel3->setAlignment(Qt::AlignHCenter);
 
     startBtn = new DSuggestButton(tr("Create"), this);
+    startBtn->setObjectName("StartBtn");
+    startBtn->setAccessibleName("StartBtn");
     startBtn->setFixedWidth(200);
 
     QVBoxLayout *play = new QVBoxLayout(this);

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
@@ -41,6 +41,8 @@ VaultRemoveByPasswordView::VaultRemoveByPasswordView(QWidget *parent)
     pwdEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     tipsBtn = new QPushButton(this);
+    tipsBtn->setObjectName("TipsBtn");
+    tipsBtn->setAccessibleName("TipsBtn");
     tipsBtn->setIcon(QIcon(":/icons/images/icons/light_32px.svg"));
 
     QHBoxLayout *layout = new QHBoxLayout();
@@ -49,6 +51,8 @@ VaultRemoveByPasswordView::VaultRemoveByPasswordView(QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
 
     toggleModeBtn = new DCommandLinkButton(tr("Key delete"), this);
+    toggleModeBtn->setObjectName("ToggleModeBtn");
+    toggleModeBtn->setAccessibleName("ToggleModeBtn");
     DFontSizeManager::instance()->bind(toggleModeBtn, DFontSizeManager::T8, QFont::Medium);
 
     QVBoxLayout *mainLay = new QVBoxLayout;

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
@@ -50,6 +50,8 @@ void VaultRemoveByRecoverykeyView::initUI()
         QLabel *label = new QLabel(tr("Delete file vault with recovery key"), this);
 
         filePathEdit = new DFileChooserEdit(this);
+        filePathEdit->setObjectName("FilePathEdit");
+        filePathEdit->setAccessibleName("FilePathEdit");
         filePathEdit->lineEdit()->setPlaceholderText(tr("Select Key File"));
         filePathEdit->lineEdit()->setReadOnly(true);
         filePathEdit->lineEdit()->setClearButtonEnabled(false);

--- a/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
@@ -44,6 +44,8 @@ void ResetPasswordByKeyFileView::initUI()
 {
     DLabel *keyFileLabel = new DLabel(tr("Select Key File"), this);
     keyFileEdit = new DFileChooserEdit(this);
+    keyFileEdit->setObjectName("KeyFileEdit");
+    keyFileEdit->setAccessibleName("KeyFileEdit");
     keyFileEdit->lineEdit()->setPlaceholderText(tr("Select key file save path"));
     fileDialog = new DFileDialog(this, QDir::homePath());
     keyFileEdit->setDirectoryUrl(QDir::homePath());
@@ -54,6 +56,8 @@ void ResetPasswordByKeyFileView::initUI()
 
     DLabel *newPasswordLabel = new DLabel(tr("Enter New Password"), this);
     newPasswordEdit = new DPasswordEdit(this);
+    newPasswordEdit->setObjectName("NewPasswordEdit");
+    newPasswordEdit->setAccessibleName("NewPasswordEdit");
     QRegularExpression regx("[A-Za-z0-9,.;?@/=()<>_+*&^%$#!`~'\"|]+");
     QValidator *validator = new QRegularExpressionValidator(regx, this);
     newPasswordEdit->lineEdit()->setValidator(validator);
@@ -62,12 +66,16 @@ void ResetPasswordByKeyFileView::initUI()
 
     DLabel *repeatPasswordLabel = new DLabel(tr("Repeat Password"), this);
     repeatPasswordEdit = new DPasswordEdit(this);
+    repeatPasswordEdit->setObjectName("RepeatPasswordEdit");
+    repeatPasswordEdit->setAccessibleName("RepeatPasswordEdit");
     repeatPasswordEdit->lineEdit()->setValidator(validator);
     repeatPasswordEdit->lineEdit()->setPlaceholderText(tr("Enter new password again"));
     repeatPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     DLabel *passwordHintLabel = new DLabel(tr("Password hint"), this);
     passwordHintEdit = new DLineEdit(this);
+    passwordHintEdit->setObjectName("PasswordHintEdit");
+    passwordHintEdit->setAccessibleName("PasswordHintEdit");
     passwordHintEdit->lineEdit()->setMaxLength(14);
     passwordHintEdit->setPlaceholderText(tr("Optional"));
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
@@ -45,11 +45,15 @@ void ResetPasswordByOldPasswordView::initUI()
 {
     DLabel *oldPasswordLabel = new DLabel(tr("Enter Old Password"), this);
     oldPasswordEdit = new DPasswordEdit(this);
+    oldPasswordEdit->setObjectName("OldPasswordEdit");
+    oldPasswordEdit->setAccessibleName("OldPasswordEdit");
     oldPasswordEdit->lineEdit()->setPlaceholderText(tr("Please enter old password"));
     oldPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     DLabel *newPasswordLabel = new DLabel(tr("Enter New Password"), this);
     newPasswordEdit = new DPasswordEdit(this);
+    newPasswordEdit->setObjectName("NewPasswordEdit");
+    newPasswordEdit->setAccessibleName("NewPasswordEdit");
     QRegularExpression regx("[A-Za-z0-9,.;?@/=()<>_+*&^%$#!`~'\"|]+");
     QValidator *validator = new QRegularExpressionValidator(regx, this);
     newPasswordEdit->lineEdit()->setValidator(validator);
@@ -58,12 +62,16 @@ void ResetPasswordByOldPasswordView::initUI()
 
     DLabel *repeatPasswordLabel = new DLabel(tr("Repeat Password"), this);
     repeatPasswordEdit = new DPasswordEdit(this);
+    repeatPasswordEdit->setObjectName("RepeatPasswordEdit");
+    repeatPasswordEdit->setAccessibleName("RepeatPasswordEdit");
     repeatPasswordEdit->lineEdit()->setValidator(validator);
     repeatPasswordEdit->lineEdit()->setPlaceholderText(tr("Enter new password again"));
     repeatPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     DLabel *passwordHintLabel = new DLabel(tr("Password hint"), this);
     passwordHintEdit = new DLineEdit(this);
+    passwordHintEdit->setObjectName("PasswordHintEdit");
+    passwordHintEdit->setAccessibleName("PasswordHintEdit");
     passwordHintEdit->lineEdit()->setMaxLength(14);
     passwordHintEdit->setPlaceholderText(tr("Optional"));
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -55,6 +55,8 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
     savePathTypeLabel->setText(tr("Unlock the Safe via Key File"));
 
     filePathEdit = new DFileChooserEdit(this);
+    filePathEdit->setObjectName("FilePathEdit");
+    filePathEdit->setAccessibleName("FilePathEdit");
     filePathEdit->lineEdit()->setPlaceholderText(tr("Select Key File"));
     fileDialog = new DFileDialog(this, QDir::homePath());
     fileDialog->setNameFilters({ QString("KEY file(*.key)") });

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
@@ -85,6 +85,8 @@ void UnlockView::initUI()
 
     // 提示按钮
     tipsButton = new QPushButton(this);
+    tipsButton->setObjectName("TipsButton");
+    tipsButton->setAccessibleName("TipsButton");
     tipsButton->setIcon(QIcon(":/icons/images/icons/light_32px.svg"));
 
     //! 布局

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
@@ -72,6 +72,8 @@ void FileViewMenuHelper::showEmptyAreaMenu()
         delete menuPtr;
 
     menuPtr = new DMenu(this->view);
+    menuPtr->setObjectName("MenuPtr");
+    menuPtr->setAccessibleName("MenuPtr");
     scene->create(menuPtr);
     scene->updateState(menuPtr);
     reloadCursor();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
@@ -113,6 +113,8 @@ void FileViewStatusBar::initScalingSlider()
     fmDebug() << "Initializing scaling slider";
 
     scaleSlider = new DSlider(Qt::Horizontal, this);
+    scaleSlider->setObjectName("ScaleSlider");
+    scaleSlider->setAccessibleName("ScaleSlider");
     scaleSlider->adjustSize();
     scaleSlider->setFixedWidth(120);
     scaleSlider->setMaximum(1);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
@@ -44,6 +44,8 @@ void RenameBarPrivate::initUI()
 
     mainLayout = new QHBoxLayout(widget);
     comboBox = new QComboBox;
+   comboBox->setObjectName("ComboBox");
+   comboBox->setAccessibleName("ComboBox");
     stackWidget = new QStackedWidget;
 
     replaceOperatorItems = std::make_tuple(new QLabel, new QLineEdit, new QLabel, new QLineEdit);
@@ -133,6 +135,8 @@ void RenameBarPrivate::setUIParameters()
     button->setText(QObject::tr("Cancel", "button"));
     button->setFixedWidth(82);
     renameBtn = new DSuggestButton();
+    renameBtn->setObjectName("RenameBtn");
+    renameBtn->setAccessibleName("RenameBtn");
     renameBtn->setText(QObject::tr("Rename", "button"));
     renameBtn->setFixedWidth(82);
     button->setEnabled(true);

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1186,5 +1186,145 @@ widgets:
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/thumbnaildelegate.cpp
   class_name: ThumbnailDelegate
   line: 22
+- variable: hideFile
+  type: QCheckBox *
+  object_name: HideFile
+  accessible_name: HideFile
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+  class_name: ''
+  line: 189
+- variable: closeButton
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: CloseButton
+  accessible_name: CloseButton
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp
+  class_name: ''
+  line: 52
+- variable: nameEditIcon
+  type: Dtk::Widget::DIconButton *
+  object_name: EditButton
+  accessible_name: NameEditIcon
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+  class_name: ''
+  line: 244
+- variable: checkButton
+  type: DIconButton *
+  object_name: CheckButton
+  accessible_name: CheckButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 59
+- variable: openFileChooseButton
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: OpenFileChooseButton
+  accessible_name: OpenFileChooseButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 294
+- variable: setToDefaultCheckBox
+  type: QCheckBox *
+  object_name: SetToDefaultCheckBox
+  accessible_name: SetToDefaultCheckBox
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 297
+- variable: cancelButton
+  type: DPushButton *
+  object_name: CancelButton
+  accessible_name: CancelButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 301
+- variable: chooseButton
+  type: DSuggestButton *
+  object_name: ChooseButton
+  accessible_name: ChooseButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 304
+- variable: serverComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: ServerComboBox
+  accessible_name: ServerComboBox
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 395
+- variable: schemeComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: SchemeComboBox
+  accessible_name: SchemeComboBox
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 377
+- variable: theAddButton
+  type: Dtk::Widget::DIconButton *
+  object_name: TheAddButton
+  accessible_name: TheAddButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 403
+- variable: collectionServerView
+  type: Dtk::Widget::DListView *
+  object_name: CollectionServerView
+  accessible_name: CollectionServerView
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 433
+- variable: charsetComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: CharsetComboBox
+  accessible_name: CharsetComboBox
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 421
+- variable: addItemBtn
+  type: Dtk::Widget::DToolButton *
+  object_name: AddItemBtn
+  accessible_name: AddItemBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
+  class_name: ''
+  line: 56
+- variable: searchButton
+  type: Dtk::Widget::DIconButton *
+  object_name: SearchButton
+  accessible_name: SearchButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  class_name: ''
+  line: 323
+- variable: advancedButton
+  type: Dtk::Widget::DToolButton *
+  object_name: AdvancedButton
+  accessible_name: AdvancedButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  class_name: ''
+  line: 343
+- variable: searchEdit
+  type: Dtk::Widget::DSearchEdit *
+  object_name: SearchEdit
+  accessible_name: SearchEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  class_name: ''
+  line: 335
+- variable: selectfileSavePathEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: SelectfileSavePathEdit
+  accessible_name: SelectfileSavePathEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+  class_name: ''
+  line: 96
+- variable: startBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: StartBtn
+  accessible_name: StartBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
+  class_name: ''
+  line: 45
+- variable: scaleSlider
+  type: DSlider *
+  object_name: ScaleSlider
+  accessible_name: ScaleSlider
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
+  class_name: ''
+  line: 117
 qml_elements: []
 transient_elements: []

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1,72 +1,1190 @@
 # SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-expected_names:
-- line: 253
-  name: CloseBtn
+version: '1.0'
+widgets:
+- variable: editInput
+  type: QLineEdit *
+  object_name: EditInput
+  accessible_name: EditInput
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 23
+- variable: btnCheckTpm
+  type: QPushButton *
+  object_name: BtnCheckTpm
+  accessible_name: BtnCheckTpm
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 25
+- variable: btnGetRandom
+  type: QPushButton *
+  object_name: BtnGetRandom
+  accessible_name: BtnGetRandom
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 26
+- variable: btnCheckAlgo
+  type: QPushButton *
+  object_name: BtnCheckAlgo
+  accessible_name: BtnCheckAlgo
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 27
+- variable: btnEncrypt
+  type: QPushButton *
+  object_name: BtnEncrypt
+  accessible_name: BtnEncrypt
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 28
+- variable: btnDecrypt
+  type: QPushButton *
+  object_name: BtnDecrypt
+  accessible_name: BtnDecrypt
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 29
+- variable: btnEncryptTwo
+  type: QPushButton *
+  object_name: BtnEncryptTwo
+  accessible_name: BtnEncryptTwo
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 31
+- variable: btnDecryptTwo
+  type: QPushButton *
+  object_name: BtnDecryptTwo
+  accessible_name: BtnDecryptTwo
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 32
+- variable: btnEncryptThree
+  type: QPushButton *
+  object_name: BtnEncryptThree
+  accessible_name: BtnEncryptThree
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 34
+- variable: btnDecryptThree
+  type: QPushButton *
+  object_name: BtnDecryptThree
+  accessible_name: BtnDecryptThree
+  source_file: examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp
+  class_name: MainWindow
+  line: 35
+- variable: m_valueLabel
+  type: QLabel *
+  object_name: BadgeValue
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 56
+- variable: m_captionLabel
+  type: QLabel *
+  object_name: BadgeCaption
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 57
+- variable: m_folderIconLabel
+  type: QLabel *
+  object_name: FolderIcon
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 116
+- variable: m_nameLabel
+  type: QLabel *
+  object_name: FolderName
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 117
+- variable: m_pathLabel
+  type: QLabel *
+  object_name: FolderPath
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 118
+- variable: m_separator
+  type: QFrame *
+  object_name: Separator
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 124
+- variable: m_listWidget
+  type: QTreeWidget *
+  object_name: FileList
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 125
+- variable: m_loadingLabel
+  type: QLabel *
+  object_name: LoadingLabel
+  accessible_name: ''
+  source_file: examples/folder-preview-example/foldercontentwidget.cpp
+  class_name: QTreeWidgetItem
+  line: 126
+- variable: closeBtn
+  type: Dtk::Widget::DFloatingButton *
+  object_name: ''
+  accessible_name: CloseBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
-  variable: closeBtn
-- line: 19
-  name: PreBtn
+  class_name: ''
+  line: 66
+- variable: statusBar
+  type: FilePreviewDialogStatusBar *
+  object_name: StatusBar
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
+  class_name: ''
+  line: 68
+- variable: nextBtn
+  type: QPushButton *
+  object_name: NextButton
+  accessible_name: NextBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
-  variable: preBtn
-- line: 28
-  name: NextBtn
+  class_name: FilePreviewDialogStatusBar
+  line: 27
+- variable: preBtn
+  type: QPushButton *
+  object_name: PreButton
+  accessible_name: PreBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
-  variable: nextBtn
-- line: 42
-  name: OpenBtn
+  class_name: FilePreviewDialogStatusBar
+  line: 18
+- variable: openBtn
+  type: QPushButton *
+  object_name: OpenButton
+  accessible_name: OpenBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
-  variable: openBtn
-- line: 281
-  name: AvailableSizeCombo
+  class_name: FilePreviewDialogStatusBar
+  line: 41
+- variable: availableSizeCombo
+  type: QComboBox *
+  object_name: ''
+  accessible_name: AvailableSizeCombo
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: availableSizeCombo
-- line: 373
-  name: ForegroundPaletteEdit
+  class_name: AbstractBasePreview
+  line: 216
+- variable: foregroundPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: ForegroundPaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: foregroundPaletteEdit
-- line: 386
-  name: BackgroundPaletteEdit
+  class_name: AbstractBasePreview
+  line: 219
+- variable: backgroundPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: BackgroundPaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: backgroundPaletteEdit
-- line: 400
-  name: HightlightPaletteEdit
+  class_name: AbstractBasePreview
+  line: 220
+- variable: hightlightPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: HightlightPaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: hightlightPaletteEdit
-- line: 414
-  name: HFpaletteEdit
+  class_name: AbstractBasePreview
+  line: 221
+- variable: hFPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: HFpaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: hFPaletteEdit
-- line: 334
-  name: ThemeCom
+  class_name: AbstractBasePreview
+  line: 222
+- variable: themeCom
+  type: QComboBox *
+  object_name: ''
+  accessible_name: ThemeCom
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: themeCom
-- line: 341
-  name: ModeCom
+  class_name: AbstractBasePreview
+  line: 224
+- variable: modeCom
+  type: QComboBox *
+  object_name: ''
+  accessible_name: ModeCom
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: modeCom
-- line: 290
-  name: CustomSizeEdit
+  class_name: AbstractBasePreview
+  line: 225
+- variable: customSizeEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: CustomSizeEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: customSizeEdit
-- line: 32
-  name: PlayControlButton
+  class_name: AbstractBasePreview
+  line: 226
+- variable: titleLabel
+  type: QLabel *
+  object_name: Title
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 70
+- variable: artistLabel
+  type: QLabel *
+  object_name: Artist
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 71
+- variable: albumLabel
+  type: QLabel *
+  object_name: Album
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 72
+- variable: artistValue
+  type: QLabel *
+  object_name: artistValue
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 74
+- variable: albumValue
+  type: QLabel *
+  object_name: albumValue
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 75
+- variable: playControlButton
+  type: QPushButton *
+  object_name: ''
+  accessible_name: PlayControlButton
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/toolbarframe.cpp
-  variable: playControlButton
-- line: 37
-  name: ProgressSlider
+  class_name: QTimer
+  line: 61
+- variable: progressSlider
+  type: Dtk::Widget::DSlider *
+  object_name: ''
+  accessible_name: ProgressSlider
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/toolbarframe.cpp
-  variable: progressSlider
-- line: 39
-  name: PasswordEdit
+  class_name: QTimer
+  line: 62
+- variable: nextbutton
+  type: Dtk::Widget::DPushButton *
+  object_name: ensureBtn
+  accessible_name: ''
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp
-  variable: passwordEdit
-- line: 22
-  name: ItemViewParent
-  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/thumbnaildelegate.cpp
-  variable: itemViewParent
-- line: 53
-  name: ControlButton
+  class_name: ''
+  line: 76
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: PasswordEdit
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp
+  class_name: ''
+  line: 78
+- variable: pImageListView
+  type: SideBarImageListView *
+  object_name: ''
+  accessible_name: View_ImageList
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/thumbnailwidget.cpp
+  class_name: ''
+  line: 61
+- variable: slider
+  type: Dtk::Widget::DSlider *
+  object_name: ''
+  accessible_name: ''
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
-  variable: controlButton
+  class_name: QEvent
+  line: 35
+- variable: controlButton
+  type: Dtk::Widget::DIconButton *
+  object_name: ''
+  accessible_name: ControlButton
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
+  class_name: QEvent
+  line: 40
+- variable: usernameLineEdit
+  type: QLineEdit *
+  object_name: UsernameLineEdit
+  accessible_name: UsernameLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 55
+- variable: domainLineEdit
+  type: QLineEdit *
+  object_name: DomainLineEdit
+  accessible_name: DomainLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 56
+- variable: passwordLineEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: PasswordLineEdit
+  accessible_name: PasswordLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 57
+- variable: passwordCheckBox
+  type: QCheckBox *
+  object_name: PasswordCheckBox
+  accessible_name: PasswordCheckBox
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 58
+- variable: passwordButtonGroup
+  type: QButtonGroup *
+  object_name: PasswordButtonGroup
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 60
+- variable: passwordLineEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: PasswordLineEdit
+  accessible_name: PasswordLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
+  class_name: QLabel
+  line: 41
+- variable: checkBox
+  type: QCheckBox *
+  object_name: CheckBox
+  accessible_name: CheckBox
+  source_file: src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
+  class_name: CheckBoxWithMessage
+  line: 24
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp
+  class_name: ''
+  line: 33
+- variable: taskListWidget
+  type: QListWidget *
+  object_name: TaskListWidget
+  accessible_name: TaskListWidget
+  source_file: src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+  class_name: QMutex
+  line: 52
+- variable: btnStop
+  type: Dtk::Widget::DIconButton *
+  object_name: TaskWidgetStopButton
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 83
+- variable: btnPause
+  type: Dtk::Widget::DIconButton *
+  object_name: TaskWidgetPauseButton
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 84
+- variable: chkboxNotAskAgain
+  type: QCheckBox *
+  object_name: ChkboxNotAskAgain
+  accessible_name: ChkboxNotAskAgain
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 101
+- variable: btnCoexist
+  type: Dtk::Widget::DPushButton *
+  object_name: BtnCoexist
+  accessible_name: BtnCoexist
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 102
+- variable: btnSkip
+  type: Dtk::Widget::DPushButton *
+  object_name: BtnSkip
+  accessible_name: BtnSkip
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 103
+- variable: btnReplace
+  type: Dtk::Widget::DPushButton *
+  object_name: BtnReplace
+  accessible_name: BtnReplace
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 104
+- variable: m_iconButton
+  type: Dtk::Widget::DIconButton *
+  object_name: IconButton
+  accessible_name: IconButton
+  source_file: src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
+  class_name: ViewHintWidget
+  line: 46
+- variable: m_closeButton
+  type: Dtk::Widget::DIconButton *
+  object_name: CloseButton
+  accessible_name: CloseButton
+  source_file: src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
+  class_name: ViewHintWidget
+  line: 48
+- variable: tipsLabel
+  type: TipsWidget *
+  object_name: diskmount
+  accessible_name: ''
+  source_file: src/external/dde-dock-plugins/disk-mount/diskmountplugin.cpp
+  class_name: DiskMountPlugin
+  line: 79
+- variable: advanceBtn
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: AdvanceBtn
+  accessible_name: AdvanceBtn
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 51
+- variable: volnameEdit
+  type: QLineEdit *
+  object_name: VolnameEdit
+  accessible_name: VolnameEdit
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 55
+- variable: writespeedComb
+  type: QComboBox *
+  object_name: WritespeedComb
+  accessible_name: WritespeedComb
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 57
+- variable: fsComb
+  type: QComboBox *
+  object_name: FsComb
+  accessible_name: FsComb
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 59
+- variable: finalizeDiscCheckbox
+  type: QCheckBox *
+  object_name: FinalizeDiscCheckbox
+  accessible_name: FinalizeDiscCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 60
+- variable: checkdiscCheckbox
+  type: QCheckBox *
+  object_name: CheckdiscCheckbox
+  accessible_name: CheckdiscCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 62
+- variable: checksumCheckbox
+  type: QCheckBox *
+  object_name: ChecksumCheckbox
+  accessible_name: ChecksumCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 63
+- variable: ejectCheckbox
+  type: QCheckBox *
+  object_name: EjectCheckbox
+  accessible_name: EjectCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 64
+- variable: fileChooser
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: FileChooser
+  accessible_name: FileChooser
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
+  class_name: ''
+  line: 43
+- variable: shareSwitcher
+  type: QCheckBox *
+  object_name: ShareSwitcher
+  accessible_name: ShareSwitcher
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 75
+- variable: shareNameEditor
+  type: Dtk::Widget::DLineEdit *
+  object_name: ShareNameEditor
+  accessible_name: ShareNameEditor
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 76
+- variable: sharePermissionSelector
+  type: QComboBox *
+  object_name: SharePermissionSelector
+  accessible_name: SharePermissionSelector
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 77
+- variable: shareAnonymousSelector
+  type: QComboBox *
+  object_name: ShareAnonymousSelector
+  accessible_name: ShareAnonymousSelector
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 78
+- variable: copyNetAddr
+  type: QPushButton *
+  object_name: CopyNetAddr
+  accessible_name: CopyNetAddr
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 87
+- variable: copyUserNameBt
+  type: QPushButton *
+  object_name: CopyUserNameBt
+  accessible_name: CopyUserNameBt
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 88
+- variable: setPasswordBt
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: SetPasswordBt
+  accessible_name: SetPasswordBt
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 89
+- variable: ownerComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: OwnerComboBox
+  accessible_name: OwnerComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+  class_name: ''
+  line: 45
+- variable: groupComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: GroupComboBox
+  accessible_name: GroupComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+  class_name: ''
+  line: 46
+- variable: otherComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: OtherComboBox
+  accessible_name: OtherComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+  class_name: ''
+  line: 47
+- variable: cancelBtn
+  type: QPushButton *
+  object_name: CancelBtn
+  accessible_name: CancelBtn
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepropertiesdialog.cpp
+  class_name: ''
+  line: 53
+- variable: ownerComboBox
+  type: QComboBox *
+  object_name: OwnerComboBox
+  accessible_name: OwnerComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 61
+- variable: groupComboBox
+  type: QComboBox *
+  object_name: GroupComboBox
+  accessible_name: GroupComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 62
+- variable: otherComboBox
+  type: QComboBox *
+  object_name: OtherComboBox
+  accessible_name: OtherComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 63
+- variable: executableCheckBox
+  type: QCheckBox *
+  object_name: ExecutableCheckBox
+  accessible_name: ExecutableCheckBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 65
+- variable: tagLable
+  type: DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+  class_name: QHBoxLayout
+  line: 42
+- variable: tagLeftLable
+  type: DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+  class_name: QHBoxLayout
+  line: 43
+- variable: toolTip
+  type: DLabel *
+  object_name: tool_tip
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.cpp
+  class_name: QHBoxLayout
+  line: 59
+- variable: edit
+  type: QTextEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/tagcrumbedit.cpp
+  class_name: ''
+  line: 29
+- variable: devicesListView
+  type: DListView *
+  object_name: DevicesListView
+  accessible_name: DevicesListView
+  source_file: src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
+  class_name: QStackedWidget
+  line: 92
+- variable: openWithListWidget
+  type: QListWidget *
+  object_name: OpenWithListWidget
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+  class_name: ''
+  line: 34
+- variable: openWithBtnGroup
+  type: QButtonGroup *
+  object_name: OpenWithBtnGroup
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+  class_name: ''
+  line: 35
+- variable: tooltip
+  type: Dtk::Widget::DArrowRectangle *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/delegate/itemeditor.cpp
+  class_name: QGraphicsOpacityEffect
+  line: 103
+- variable: menuPtr
+  type: Dtk::Widget::DMenu *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
+  class_name: ''
+  line: 30
+- variable: textLabel
+  type: QLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/watermask/watermaskframe.cpp
+  class_name: QJsonObject
+  line: 65
+- variable: textLabel
+  type: QLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/watermask/watermasksystem.cpp
+  class_name: QLabel
+  line: 44
+- variable: tooltip
+  type: Dtk::Widget::DArrowRectangle *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp
+  class_name: QGraphicsOpacityEffect
+  line: 104
+- variable: comboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: ComboBox
+  accessible_name: ComboBox
+  source_file: src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp
+  class_name: ''
+  line: 29
+- variable: slider
+  type: Dtk::Widget::DSlider *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-organizer/options/sizeslider.cpp
+  class_name: QLabel
+  line: 33
+- variable: checkBox
+  type: Dtk::Widget::DCheckBox *
+  object_name: CheckBox
+  accessible_name: CheckBox
+  source_file: src/plugins/desktop/ddplugin-organizer/options/widgets/checkboxwidget.cpp
+  class_name: ''
+  line: 25
+- variable: keyEdit
+  type: Dtk::Widget::DKeySequenceEdit *
+  object_name: KeyEdit
+  accessible_name: KeyEdit
+  source_file: src/plugins/desktop/ddplugin-organizer/options/widgets/shortcutwidget.cpp
+  class_name: ''
+  line: 32
+- variable: switchBtn
+  type: Dtk::Widget::DSwitchButton *
+  object_name: SwitchBtn
+  accessible_name: SwitchBtn
+  source_file: src/plugins/desktop/ddplugin-organizer/options/widgets/switchwidget.cpp
+  class_name: ''
+  line: 33
+- variable: menuPtr
+  type: Dtk::Widget::DMenu *
+  object_name: MenuPtr
+  accessible_name: MenuPtr
+  source_file: src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+  class_name: ''
+  line: 29
+- variable: titleLabel
+  type: Dtk::Widget::DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 82
+- variable: fileNameLabel
+  type: Dtk::Widget::DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 83
+- variable: filtersLabel
+  type: Dtk::Widget::DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 84
+- variable: fileNameEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: FileNameEdit
+  accessible_name: FileNameEdit
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 86
+- variable: filtersComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: FiltersComboBox
+  accessible_name: FiltersComboBox
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 87
+- variable: curAcceptButton
+  type: Dtk::Widget::DSuggestButton *
+  object_name: FileDialogStatusBarAcceptButton
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 89
+- variable: curRejectButton
+  type: Dtk::Widget::DPushButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 90
+- variable: renameEditor
+  type: QLineEdit *
+  object_name: RenameEditor
+  accessible_name: RenameEditor
+  source_file: src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+  class_name: ''
+  line: 52
+- variable: scrollArea
+  type: QScrollArea *
+  object_name: PropertyDialog-QScrollArea
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
+  class_name: ''
+  line: 78
+- variable: oldPass
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: OldPass
+  accessible_name: OldPass
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 38
+- variable: newPass1
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPass1
+  accessible_name: NewPass1
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 39
+- variable: newPass2
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPass2
+  accessible_name: NewPass2
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 40
+- variable: recSwitch
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: RecSwitch
+  accessible_name: RecSwitch
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 41
+- variable: editor
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
+  class_name: ''
+  line: 37
+- variable: recSwitch
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: RecSwitch
+  accessible_name: RecSwitch
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
+  class_name: ''
+  line: 38
+- variable: encType
+  type: Dtk::Widget::DComboBox *
+  object_name: EncType
+  accessible_name: EncType
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 53
+- variable: encKeyEdit1
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: EncKeyEdit1
+  accessible_name: EncKeyEdit1
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 54
+- variable: encKeyEdit2
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: EncKeyEdit2
+  accessible_name: EncKeyEdit2
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 55
+- variable: keyExportInput
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: KeyExportInput
+  accessible_name: KeyExportInput
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 56
+- variable: passwordLineEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: PasswordLineEdit
+  accessible_name: PasswordLineEdit
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
+  class_name: QLabel
+  line: 44
+- variable: chgUnlockType
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: ChgUnlockType
+  accessible_name: ChgUnlockType
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
+  class_name: QLabel
+  line: 45
+- variable: pbBurn
+  type: Dtk::Widget::DPushButton *
+  object_name: PbBurn
+  accessible_name: PbBurn
+  source_file: src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+  class_name: ''
+  line: 47
+- variable: pbDump
+  type: Dtk::Widget::DPushButton *
+  object_name: PbDump
+  accessible_name: PbDump
+  source_file: src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+  class_name: ''
+  line: 48
+- variable: m_checkBox
+  type: QCheckBox *
+  object_name: CheckBox
+  accessible_name: CheckBox
+  source_file: src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
+  class_name: ''
+  line: 67
+- variable: oldPwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: OldPwdEdit
+  accessible_name: OldPwdEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 52
+- variable: newPwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPwdEdit
+  accessible_name: NewPwdEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 53
+- variable: repeatPwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPwdEdit
+  accessible_name: RepeatPwdEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 54
+- variable: saveBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: SaveBtn
+  accessible_name: SaveBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 57
+- variable: cancelBtn
+  type: Dtk::Widget::DPushButton *
+  object_name: CancelBtn
+  accessible_name: CancelBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 58
+- variable: closeBtn
+  type: Dtk::Widget::DPushButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcresultwidget.cpp
+  class_name: ''
+  line: 36
+- variable: addBtn
+  type: DIconButton *
+  object_name: ''
+  accessible_name: AddBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  class_name: Tab
+  line: 111
+- variable: leftBtn
+  type: DIconButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  class_name: Tab
+  line: 112
+- variable: tabBar
+  type: QTabBar *
+  object_name: TabBar
+  accessible_name: TabBar
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  class_name: Tab
+  line: 113
+- variable: placeholder
+  type: QWidget *
+  object_name: Placeholder
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+  class_name: DIconButton
+  line: 103
+- variable: finishedBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: FinishedBtn
+  accessible_name: FinishedBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
+  class_name: QVBoxLayout
+  line: 67
+- variable: nextBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+  class_name: ''
+  line: 73
+- variable: typeCombo
+  type: Dtk::Widget::DComboBox *
+  object_name: TypeCombo
+  accessible_name: TypeCombo
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 71
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 74
+- variable: repeatPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPasswordEdit
+  accessible_name: RepeatPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 77
+- variable: tipsEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: TipsEdit
+  accessible_name: TipsEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 80
+- variable: nextBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: NextBtn
+  accessible_name: NextBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 85
+- variable: pwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 56
+- variable: tipsBtn
+  type: QPushButton *
+  object_name: TipsBtn
+  accessible_name: TipsBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 57
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 58
+- variable: toggleModeBtn
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: ToggleModeBtn
+  accessible_name: ToggleModeBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 60
+- variable: filePathEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: FilePathEdit
+  accessible_name: FilePathEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+  class_name: QPlainTextEdit
+  line: 64
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+  class_name: QPlainTextEdit
+  line: 65
+- variable: keyFileEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: KeyFileEdit
+  accessible_name: KeyFileEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 62
+- variable: newPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPasswordEdit
+  accessible_name: NewPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 64
+- variable: repeatPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPasswordEdit
+  accessible_name: RepeatPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 65
+- variable: passwordHintEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: PasswordHintEdit
+  accessible_name: PasswordHintEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 66
+- variable: oldPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: OldPasswordEdit
+  accessible_name: OldPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 58
+- variable: newPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPasswordEdit
+  accessible_name: NewPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 59
+- variable: repeatPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPasswordEdit
+  accessible_name: RepeatPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 60
+- variable: passwordHintEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: PasswordHintEdit
+  accessible_name: PasswordHintEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 61
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
+  class_name: QPlainTextEdit
+  line: 58
+- variable: filePathEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: FilePathEdit
+  accessible_name: FilePathEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+  class_name: ''
+  line: 93
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+  class_name: ''
+  line: 80
+- variable: tipsButton
+  type: QPushButton *
+  object_name: TipsButton
+  accessible_name: TipsButton
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+  class_name: ''
+  line: 81
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+  class_name: ''
+  line: 84
+- variable: menuPtr
+  type: Dtk::Widget::DMenu *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+  class_name: ''
+  line: 35
+- variable: editor
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/baseitemdelegate_p.cpp
+  class_name: QLineEdit
+  line: 39
+- variable: edit
+  type: QTextEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/iconitemeditor_p.cpp
+  class_name: QGraphicsOpacityEffect
+  line: 30
+- variable: comboBox
+  type: QComboBox *
+  object_name: ComboBox
+  accessible_name: ComboBox
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+  class_name: QPushButton
+  line: 68
+- variable: renameBtn
+  type: DSuggestButton *
+  object_name: RenameBtn
+  accessible_name: RenameBtn
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+  class_name: QPushButton
+  line: 87
+- variable: itemViewParent
+  type: QAbstractItemView *
+  object_name: ''
+  accessible_name: ItemViewParent
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/thumbnaildelegate.cpp
+  class_name: ThumbnailDelegate
+  line: 22
+qml_elements: []
+transient_elements: []


### PR DESCRIPTION
## Summary

补全文件管理器各插件和对话框的交互控件 AT-SPI 可访问名称。

### Changes
- 为 122 个控件新增 setObjectName()/setAccessibleName() 调用
- 涉及 51 个 .cpp 文件，覆盖 dfm-base、titlebar、vault、disk-encrypt、burn、propertydialog、workspace、search 等组件
- 更新 expected_names.yaml 命名基线

### Coverage
- 补全前：32.6% (193 widgets, 63 named)
- 补全后：86.0% (193 widgets, 166 named)
- 剩余 27 个未命名控件为扫描器盲区误报和死代码变量

### Verification
- 修改均为纯增量 setObjectName/setAccessibleName 调用
- 版权年份已检查，无需更新
- 编译验证因缺少 deepin-pdfium 依赖未能完成（需在 CI 中验证）

## Summary by Sourcery

Improve file manager accessibility by assigning stable AT-SPI names to interactive widgets and expanding the corresponding validation baseline.

Bug Fixes:
- Add AT-SPI object and accessible names to file manager controls across dialogs, plugins, previews, and workspace views to improve accessibility identification.

Enhancements:
- Expand accessible-widget coverage across the file manager UI, including encryption, vault, search, title bar, sharing, properties, burning, and desktop components.

Tests:
- Replace the minimal accessibility name baseline with a versioned expected widget inventory covering object names and accessible names.