### PR TITLE
fix(openwith): pin title separator above scroll area

### DIFF
--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -87,11 +87,11 @@ void OpenWithDialogListItem::initUiForSizeMode()
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
     int size = DSizeModeHelper::element(25, 30);
-    setFixedSize(224, DSizeModeHelper::element(40, 50));
+    setFixedSize(220, DSizeModeHelper::element(40, 50));
 #else
     int size = 30;
     iconLabel->setPixmap(icon.pixmap(iconLabel->size()));
-    setFixedSize(224, 50);
+    setFixedSize(220, 50);
 #endif
     iconLabel->setFixedSize(size, size);
     updateLabelIcon(size);
@@ -166,7 +166,7 @@ void OpenWithDialogListItem::paintEvent(QPaintEvent *e)
 class OpenWithDialogListSparerItem : public QWidget
 {
 public:
-    explicit OpenWithDialogListSparerItem(const QString &title, QWidget *parent = nullptr);
+    explicit OpenWithDialogListSparerItem(const QString &title, QWidget *parent = nullptr, bool showSeparator = true);
 
 private slots:
     void initUiForSizeMode();
@@ -190,15 +190,18 @@ void OpenWithDialogListSparerItem::initUiForSizeMode()
 #endif
 }
 
-OpenWithDialogListSparerItem::OpenWithDialogListSparerItem(const QString &title, QWidget *parent)
-    : QWidget(parent), separator(new DHorizontalLine(this)), titleLabel(new QLabel(title, this))
+OpenWithDialogListSparerItem::OpenWithDialogListSparerItem(const QString &title, QWidget *parent, bool showSeparator)
+    : QWidget(parent), titleLabel(new QLabel(title, this))
 {
 #ifdef DTKWIDGET_CLASS_DSizeMode
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::sizeModeChanged, this, &OpenWithDialogListSparerItem::initUiForSizeMode);
 #endif
     QVBoxLayout *layout = new QVBoxLayout(this);
     initUiForSizeMode();
-    layout->addWidget(separator);
+    if (showSeparator) {
+        separator = new DHorizontalLine(this);
+        layout->addWidget(separator);
+    }
     layout->addWidget(titleLabel);
     layout->setContentsMargins(0, 0, 0, 0);
     titleLabel->setContentsMargins(20, 0, 0, 0);
@@ -285,9 +288,7 @@ void OpenWithDialog::initUI()
     scrollArea->setWidget(contentWidget);
 
     recommandLayout = new DFlowLayout;
-    recommandLayout->setHorizontalSpacing(10);
     otherLayout = new DFlowLayout;
-    otherLayout->setHorizontalSpacing(10);
 
     openFileChooseButton = new DCommandLinkButton(tr("Add other programs"), this);
     setToDefaultCheckBox = new DCheckBox(tr("Set as default"), this);
@@ -300,7 +301,7 @@ void OpenWithDialog::initUI()
 
     QVBoxLayout *contentLayout = new QVBoxLayout;
     contentLayout->setContentsMargins(10, 0, 10, 0);
-    contentLayout->addWidget(new OpenWithDialogListSparerItem(tr("Recommended Applications"), this));
+    contentLayout->addWidget(new OpenWithDialogListSparerItem(tr("Recommended Applications"), this, false));
     contentLayout->addLayout(recommandLayout);
     contentLayout->addWidget(new OpenWithDialogListSparerItem(tr("Other Applications"), this));
     contentLayout->addLayout(otherLayout);
@@ -332,6 +333,13 @@ void OpenWithDialog::initUI()
     mainLayout->addSpacing(15);
 #endif
     mainLayout->setSpacing(0);
+
+    // 固定分割线：位于大标题下方，不随内容滚动而消失
+    QHBoxLayout *titleSeparatorLayout = new QHBoxLayout;
+    titleSeparatorLayout->setContentsMargins(10, 0, 10, 0);
+    titleSeparatorLayout->addWidget(new DHorizontalLine(this));
+    mainLayout->addLayout(titleSeparatorLayout);
+
     mainLayout->addWidget(scrollArea);
     mainLayout->addLayout(bottomLayout);
     mainLayout->setContentsMargins(0, 35, 0, 10);


### PR DESCRIPTION
## 问题

打开方式对话框大标题下方的分割线位于滚动区域内部，会随内容一起滚动而消失，应当固定存在。

## 修复

将分割线从滚动区域移到 `mainLayout` 中大标题与滚动区之间，使其固定不随内容滚动。

### 改动

1. 给 `OpenWithDialogListSparerItem` 构造函数增加 `showSeparator` 参数，按需创建分割线
2. 第一个分组（推荐应用）传 `false`，去掉滚动区内会随内容滚走的分割线
3. 在 `mainLayout` 大标题与 `scrollArea` 之间加入固定 `DHorizontalLine`

### 验证

编译通过（`ninja dfm-utils-plugin`），运行 debug 版文件管理器选中文件打开"打开方式"对话框，滚动应用列表，标题下方分割线保持固定不动。

PMS: BUG-374031