### PR TITLE
fix(dfm-base): add AT-SPI accessible names for dfm-base controls

### DIFF
--- a/src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+++ b/src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
@@ -66,6 +66,8 @@ void MountAskPasswordDialog::initUI()
     usernameLable->setFixedWidth(95);
 
     usernameLineEdit = new QLineEdit;
+    usernameLineEdit->setObjectName("UsernameLineEdit");
+    usernameLineEdit->setAccessibleName("UsernameLineEdit");
     usernameLineEdit->setMinimumWidth(240);
     usernameLineEdit->setText(qgetenv("USER"));
 
@@ -74,6 +76,8 @@ void MountAskPasswordDialog::initUI()
     domainLabel->setFixedWidth(95);
 
     domainLineEdit = new QLineEdit;
+    domainLineEdit->setObjectName("DomainLineEdit");
+    domainLineEdit->setAccessibleName("DomainLineEdit");
     domainLineEdit->setMinimumWidth(240);
     domainLineEdit->setText("WORKGROUP");
 
@@ -82,13 +86,18 @@ void MountAskPasswordDialog::initUI()
     passwordLable->setFixedWidth(90);
 
     passwordLineEdit = new DPasswordEdit;
+    passwordLineEdit->setObjectName("PasswordLineEdit");
+    passwordLineEdit->setAccessibleName("PasswordLineEdit");
     passwordLineEdit->setMinimumWidth(240);
     passwordLineEdit->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     passwordButtonGroup = new QButtonGroup(this);
+    passwordButtonGroup->setObjectName("PasswordButtonGroup");
     passwordButtonGroup->setExclusive(true);
 
     passwordCheckBox = new QCheckBox();
+    passwordCheckBox->setObjectName("PasswordCheckBox");
+    passwordCheckBox->setAccessibleName("PasswordCheckBox");
     QWidget *empty = new QWidget();
     passwordCheckBox->setText(tr("Remember password"));
 

--- a/src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
+++ b/src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
@@ -44,6 +44,8 @@ void MountSecretDiskAskPasswordDialog::initUI()
     descriptionLabel->setFont(tipfont);
 
     passwordLineEdit = new DPasswordEdit;
+    passwordLineEdit->setObjectName("PasswordLineEdit");
+    passwordLineEdit->setAccessibleName("PasswordLineEdit");
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(titleLabel);

--- a/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
+++ b/src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
@@ -16,6 +16,8 @@ CheckBoxWithMessage::CheckBoxWithMessage(QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
 
     checkBox = new QCheckBox(this);
+    checkBox->setObjectName("CheckBox");
+    checkBox->setAccessibleName("CheckBox");
     layout->addWidget(checkBox);
 
     QHBoxLayout *hLayout = new QHBoxLayout();

--- a/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskdialog.cpp
@@ -78,6 +78,8 @@ void TaskDialog::initUI()
     titlebar->setAutoFillBackground(false);
 
     taskListWidget = new QListWidget(this);
+    taskListWidget->setObjectName("TaskListWidget");
+    taskListWidget->setAccessibleName("TaskListWidget");
     taskListWidget->setSelectionMode(QListWidget::NoSelection);
     taskListWidget->viewport()->setAutoFillBackground(false);
     taskListWidget->setFrameShape(QFrame::NoFrame);

--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -542,14 +542,20 @@ QWidget *TaskWidget::createBtnWidget()
     QVariant variantCoexit;
     variantCoexit.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kCoexistAction);
     btnCoexist = new DPushButton(TaskWidget::tr("Keep both", "button"));
+    btnCoexist->setObjectName("BtnCoexist");
+    btnCoexist->setAccessibleName("BtnCoexist");
     btnCoexist->setProperty(kBtnPropertyActionName, variantCoexit);
 
     btnSkip = new DPushButton(TaskWidget::tr("Skip", "button"));
+    btnSkip->setObjectName("BtnSkip");
+    btnSkip->setAccessibleName("BtnSkip");
     QVariant variantSkip;
     variantSkip.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kSkipAction);
     btnSkip->setProperty(kBtnPropertyActionName, variantSkip);
 
     btnReplace = new DPushButton(TaskWidget::tr("Replace", "button"));
+    btnReplace->setObjectName("BtnReplace");
+    btnReplace->setAccessibleName("BtnReplace");
     QVariant variantReplace;
     variantReplace.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kReplaceAction);
     btnReplace->setProperty(kBtnPropertyActionName, variantReplace);
@@ -583,6 +589,8 @@ QWidget *TaskWidget::createBtnWidget()
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
     chkboxNotAskAgain = new QCheckBox(TaskWidget::tr("Do not ask again"));
+    chkboxNotAskAgain->setObjectName("ChkboxNotAskAgain");
+    chkboxNotAskAgain->setAccessibleName("ChkboxNotAskAgain");
     layout->addSpacing(100);
     layout->addWidget(chkboxNotAskAgain);
 

--- a/src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
+++ b/src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
@@ -46,6 +46,8 @@ void ViewHintWidget::initLayout()
     // 原因: 基类的 changeEvent() 会访问内部 d-pointer，复用其控件会导致悬空指针崩溃。
 
     m_iconButton = new DIconButton(this);
+    m_iconButton->setObjectName("IconButton");
+    m_iconButton->setAccessibleName("IconButton");
     m_iconButton->setFlat(true);
     m_iconButton->setFocusPolicy(Qt::NoFocus);
     m_iconButton->setAttribute(Qt::WA_TransparentForMouseEvents);
@@ -57,6 +59,8 @@ void ViewHintWidget::initLayout()
     m_messageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     m_closeButton = new DIconButton(this);
+    m_closeButton->setObjectName("CloseButton");
+    m_closeButton->setAccessibleName("CloseButton");
     m_closeButton->setFlat(true);
     m_closeButton->setFocusPolicy(Qt::NoFocus);
     m_closeButton->setIcon(DDciIcon::fromTheme("dfm-clear"));


### PR DESCRIPTION
## Summary

为 DFM Base 基础库（挂载密码/任务/提示对话框） 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp`
- `src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp`
- `src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp`
- `src/dfm-base/dialogs/taskdialog/taskdialog.cpp`
- `src/dfm-base/dialogs/taskdialog/taskwidget.cpp`
- `src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Enhancements:
- Add consistent AT-SPI object and accessible names to interactive controls across DFM Base password, task, settings, and view-hint dialogs.