### PR TITLE
fix(common): add AT-SPI accessible names for common-plugins controls

### DIFF
--- a/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
@@ -131,6 +131,8 @@ void BurnOptDialog::initializeUi()
     volnameLabel->setFont(f13);
 
     volnameEdit = new QLineEdit();
+    volnameEdit->setObjectName("VolnameEdit");
+    volnameEdit->setAccessibleName("VolnameEdit");
     QRegularExpression regx("[^\\\\/\':\\*\\?\"<>|%&.]+");   // 屏蔽特殊字符
     QValidator *validator = new QRegularExpressionValidator(regx, volnameEdit);
     volnameEdit->setValidator(validator);
@@ -145,6 +147,8 @@ void BurnOptDialog::initializeUi()
 
     // 高级设置内容
     advanceBtn = new DCommandLinkButton(BurnOptDialog::tr("Advanced settings"), this);
+    advanceBtn->setObjectName("AdvanceBtn");
+    advanceBtn->setAccessibleName("AdvanceBtn");
     QFont f12 = advanceBtn->font();
     f12.setPixelSize(12);
     f12.setWeight(QFont::Normal);
@@ -177,6 +181,8 @@ void BurnOptDialog::initializeUi()
     };
 
     fsComb = new QComboBox;
+    fsComb->setObjectName("FsComb");
+    fsComb->setAccessibleName("FsComb");
     fsComb->addItems(fsTypes);
     fsComb->setCurrentIndex(BurnHelper::defaultBurnFs());
     vLay->addWidget(fsComb);
@@ -194,6 +200,8 @@ void BurnOptDialog::initializeUi()
     writespeedLabel = new QLabel(QObject::tr("Write speed:"));
     vLay->addWidget(writespeedLabel, 0, Qt::AlignTop);
     writespeedComb = new QComboBox();
+    writespeedComb->setObjectName("WritespeedComb");
+    writespeedComb->setAccessibleName("WritespeedComb");
     writespeedComb->addItem(QObject::tr("Maximum"));
     vLay->addWidget(writespeedComb, 0, Qt::AlignTop);
     speedMap[QObject::tr("Maximum")] = 0;
@@ -202,6 +210,8 @@ void BurnOptDialog::initializeUi()
 
     // 刻录选项-封盘设置
     finalizeDiscCheckbox = new QCheckBox(QObject::tr("Finalize disc after burning \n(no additional data can be appended)"));
+    finalizeDiscCheckbox->setObjectName("FinalizeDiscCheckbox");
+    finalizeDiscCheckbox->setAccessibleName("FinalizeDiscCheckbox");
     finalizeDiscCheckbox->setChecked(false);
     vLay->addWidget(finalizeDiscCheckbox, 0, Qt::AlignTop);
     QWidget *wpostburn = new QWidget();
@@ -212,14 +222,20 @@ void BurnOptDialog::initializeUi()
 
     // 刻录选项-校验数据
     checkdiscCheckbox = new QCheckBox(QObject::tr("Verify data"));
+    checkdiscCheckbox->setObjectName("CheckdiscCheckbox");
+    checkdiscCheckbox->setAccessibleName("CheckdiscCheckbox");
     checkdiscCheckbox->setFont(f12);
     wpostburn->layout()->addWidget(checkdiscCheckbox);
     // 刻录选项-校验文件
     checksumCheckbox = new QCheckBox(QObject::tr("Verify files (checksum)"));
+    checksumCheckbox->setObjectName("ChecksumCheckbox");
+    checksumCheckbox->setAccessibleName("ChecksumCheckbox");
     checksumCheckbox->setFont(f12);
     vLay->addWidget(checksumCheckbox, 0, Qt::AlignTop);
     // 刻录选项-弹出光盘（目前禁用）
     ejectCheckbox = new QCheckBox(QObject::tr("Eject"));
+    ejectCheckbox->setObjectName("EjectCheckbox");
+    ejectCheckbox->setAccessibleName("EjectCheckbox");
     ejectCheckbox->setFont(f12);
     ejectCheckbox->setChecked(true);
     wpostburn->layout()->addWidget(ejectCheckbox);

--- a/src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
+++ b/src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
@@ -98,6 +98,8 @@ void DumpISOOptDialog::initliazeUi()
 
     // file chooser
     fileChooser = new DFileChooserEdit;
+    fileChooser->setObjectName("FileChooser");
+    fileChooser->setAccessibleName("FileChooser");
     fileChooser->setFileMode(QFileDialog::FileMode::Directory);
     const QString &stdDocPath = QStandardPaths::writableLocation(QStandardPaths::StandardLocation::DocumentsLocation);
     fileChooser->setDirectoryUrl(QUrl::fromLocalFile(stdDocPath));

--- a/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+++ b/src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
@@ -158,6 +158,8 @@ void ShareControlWidget::setupUi(bool disableState)
 void ShareControlWidget::setupShareSwitcher()
 {
     shareSwitcher = new QCheckBox(this);
+    shareSwitcher->setObjectName("ShareSwitcher");
+    shareSwitcher->setAccessibleName("ShareSwitcher");
     shareSwitcher->setFixedWidth(ConstDef::kWidgetFixedWidth);
     QString text = tr("Share this folder");
     shareSwitcher->setToolTip(text);
@@ -173,6 +175,8 @@ void ShareControlWidget::setupShareSwitcher()
 void ShareControlWidget::setupShareNameEditor()
 {
     shareNameEditor = new DLineEdit(this);
+    shareNameEditor->setObjectName("ShareNameEditor");
+    shareNameEditor->setAccessibleName("ShareNameEditor");
 
     static constexpr char kShareNameRegx[] { R"(^(?![ -])[^%<>*?|/\\+=;:,"]*+ ?$)" };
     QValidator *validator = new QRegularExpressionValidator(QRegularExpression(kShareNameRegx), this);
@@ -184,6 +188,8 @@ void ShareControlWidget::setupShareNameEditor()
 void ShareControlWidget::setupSharePermissionSelector()
 {
     sharePermissionSelector = new QComboBox(this);
+    sharePermissionSelector->setObjectName("SharePermissionSelector");
+    sharePermissionSelector->setAccessibleName("SharePermissionSelector");
 
     QPalette peMenuBg;
     QColor color = palette().color(QPalette::ColorGroup::Active, QPalette::ColorRole::Window);
@@ -197,6 +203,8 @@ void ShareControlWidget::setupSharePermissionSelector()
 void ShareControlWidget::setupShareAnonymousSelector()
 {
     shareAnonymousSelector = new QComboBox(this);
+    shareAnonymousSelector->setObjectName("ShareAnonymousSelector");
+    shareAnonymousSelector->setAccessibleName("ShareAnonymousSelector");
 
     QPalette peMenuBg;
     QColor color = palette().color(QPalette::ColorGroup::Active, QPalette::ColorRole::Window);
@@ -216,6 +224,8 @@ QHBoxLayout *ShareControlWidget::setupNetworkPath()
     networkAddrLabel->setFixedWidth(ConstDef::kWidgetFixedWidth);
 
     copyNetAddr = new QPushButton(this);
+    copyNetAddr->setObjectName("CopyNetAddr");
+    copyNetAddr->setAccessibleName("CopyNetAddr");
     copyNetAddr->setFlat(true);
     copyNetAddr->setToolTip(tr("Copy"));
     auto setBtnIcon = [=] {
@@ -250,6 +260,8 @@ QHBoxLayout *ShareControlWidget::setupUserName()
     userNamelineLabel->setFixedWidth(ConstDef::kWidgetFixedWidth);
 
     copyUserNameBt = new QPushButton(this);
+    copyUserNameBt->setObjectName("CopyUserNameBt");
+    copyUserNameBt->setAccessibleName("CopyUserNameBt");
     copyUserNameBt->setFlat(true);
     copyUserNameBt->setToolTip(tr("Copy"));
     auto setBtnIcon = [=] {
@@ -286,6 +298,8 @@ QHBoxLayout *ShareControlWidget::setupSharePassword()
     sharePassword->setText(isSharePasswordSet ? "●●●●●" : tr("None"));
 
     setPasswordBt = new DCommandLinkButton(tr("Set password"));
+    setPasswordBt->setObjectName("SetPasswordBt");
+    setPasswordBt->setAccessibleName("SetPasswordBt");
     setPasswordBt->setText(isSharePasswordSet ? tr("Change password") : tr("Set password"));
     setPasswordBt->setContentsMargins(0, 0, 0, 0);
     setPasswordBt->setToolTip(setPasswordBt->text());

--- a/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
@@ -185,6 +185,8 @@ void BasicWidget::initUI()
     fileModified = createValueLabel(frameMain, tr("Modified"));
 
     hideFile = new DCheckBox(frameMain);
+    hideFile->setObjectName("HideFile");
+    hideFile->setAccessibleName("HideFile");
     DFontSizeManager::instance()->bind(hideFile, DFontSizeManager::SizeType::T7, QFont::Normal);
     hideFile->setText(tr("Hide this file"));
     hideFile->setToolTip(hideFile->text());

--- a/src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp
@@ -48,6 +48,8 @@ void CloseAllDialog::initUI()
     //    AC_SET_ACCESSIBLE_NAME(messageLabel, AC_CLOSE_ALL_DLG_INDICATOR_MSG_LABEL);
 
     closeButton = new DCommandLinkButton(tr("Close all"), this);
+    closeButton->setObjectName("CloseButton");
+    closeButton->setAccessibleName("CloseButton");
     // 设置按钮无焦点
     closeButton->setFocusPolicy(Qt::NoFocus);
     font = closeButton->font();

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -241,6 +241,7 @@ void EditStackedWidget::initTextShowFrame(QString fileName)
     }
 
     nameEditIcon = new DIconButton(textShowFrame);
+    nameEditIcon->setAccessibleName("NameEditIcon");
     nameEditIcon->setObjectName(QString("EditButton"));
     nameEditIcon->setIcon(QIcon::fromTheme("dfm_rename"));
     nameEditIcon->setIconSize({ 12, 12 });

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
@@ -65,6 +65,8 @@ void MultiFilePermissionWidget::initUI()
                                        QFont::Medium);
     owner->setFixedWidth(kLabelWidth);
     ownerComboBox = new DComboBox(this);
+    ownerComboBox->setObjectName("OwnerComboBox");
+    ownerComboBox->setAccessibleName("OwnerComboBox");
     ownerComboBox->addItem(QObject::tr("Read-write"));
     ownerComboBox->addItem(QObject::tr("Read only"));
 
@@ -73,6 +75,8 @@ void MultiFilePermissionWidget::initUI()
                                        QFont::Medium);
     group->setFixedWidth(kLabelWidth);
     groupComboBox = new DComboBox(this);
+    groupComboBox->setObjectName("GroupComboBox");
+    groupComboBox->setAccessibleName("GroupComboBox");
     groupComboBox->addItem(QObject::tr("Read-write"));
     groupComboBox->addItem(QObject::tr("Read only"));
 
@@ -81,6 +85,8 @@ void MultiFilePermissionWidget::initUI()
                                        QFont::Medium);
     other->setFixedWidth(kLabelWidth);
     otherComboBox = new DComboBox(this);
+    otherComboBox->setObjectName("OtherComboBox");
+    otherComboBox->setAccessibleName("OtherComboBox");
     otherComboBox->addItem(QObject::tr("Read-write"));
     otherComboBox->addItem(QObject::tr("Read only"));
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertiesdialog.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilepropertiesdialog.cpp
@@ -201,6 +201,8 @@ void MultiFilePropertiesDialog::initUI()
     scrollArea->setWidget(scrollWidget);
 
     cancelBtn = new QPushButton(tr("Cancel"), this);
+    cancelBtn->setObjectName("CancelBtn");
+    cancelBtn->setAccessibleName("CancelBtn");
     cancelBtn->setFixedHeight(kBtnHeight);
     cancelBtn->setAttribute(Qt::WA_NoMousePropagation);
 

--- a/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
@@ -157,16 +157,24 @@ void PermissionManagerWidget::initUI()
     DLabel *owner = new DLabel(QObject::tr("Owner"), this);
     DFontSizeManager::instance()->bind(owner, DFontSizeManager::SizeType::T7, QFont::Medium);
     ownerComboBox = new QComboBox(this);
+    ownerComboBox->setObjectName("OwnerComboBox");
+    ownerComboBox->setAccessibleName("OwnerComboBox");
 
     DLabel *group = new DLabel(QObject::tr("Group"), this);
     DFontSizeManager::instance()->bind(group, DFontSizeManager::SizeType::T7, QFont::Medium);
     groupComboBox = new QComboBox(this);
+    groupComboBox->setObjectName("GroupComboBox");
+    groupComboBox->setAccessibleName("GroupComboBox");
 
     DLabel *other = new DLabel(QObject::tr("Others"), this);
     DFontSizeManager::instance()->bind(other, DFontSizeManager::SizeType::T7, QFont::Medium);
     otherComboBox = new QComboBox(this);
+    otherComboBox->setObjectName("OtherComboBox");
+    otherComboBox->setAccessibleName("OtherComboBox");
 
     executableCheckBox = new QCheckBox(this);
+    executableCheckBox->setObjectName("ExecutableCheckBox");
+    executableCheckBox->setAccessibleName("ExecutableCheckBox");
     executableCheckBox->setText(tr("Allow to execute as program"));
     executableCheckBox->setToolTip(executableCheckBox->text());
 

--- a/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
@@ -388,6 +388,8 @@ QWidget *BluetoothTransDialog::createDeviceSelectorPage()
     pLayout->addWidget(statusTxt);
 
     devicesListView = new DListView(this);
+    devicesListView->setObjectName("DevicesListView");
+    devicesListView->setAccessibleName("DevicesListView");
     devModel = new QStandardItemModel(this);
     devicesListView->setFixedHeight(88);
     devicesListView->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
@@ -55,6 +55,8 @@ OpenWithDialogListItem::OpenWithDialogListItem(const QString &iconName, const QS
       label(new DLabel(this))
 
 {
+    checkButton->setObjectName("CheckButton");
+    checkButton->setAccessibleName("CheckButton");
     checkButton->setFixedSize(15, 15);
     checkButton->setFlat(true);
     label->setText(text);
@@ -290,10 +292,18 @@ void OpenWithDialog::initUI()
     otherLayout->setHorizontalSpacing(10);
 
     openFileChooseButton = new DCommandLinkButton(tr("Add other programs"), this);
+    openFileChooseButton->setObjectName("OpenFileChooseButton");
+    openFileChooseButton->setAccessibleName("OpenFileChooseButton");
     setToDefaultCheckBox = new DCheckBox(tr("Set as default"), this);
+    setToDefaultCheckBox->setObjectName("SetToDefaultCheckBox");
+    setToDefaultCheckBox->setAccessibleName("SetToDefaultCheckBox");
     setToDefaultCheckBox->setChecked(true);
     cancelButton = new DPushButton(tr("Cancel", "button"));
+    cancelButton->setObjectName("CancelButton");
+    cancelButton->setAccessibleName("CancelButton");
     chooseButton = new DSuggestButton(tr("Confirm", "button"));
+    chooseButton->setObjectName("ChooseButton");
+    chooseButton->setAccessibleName("ChooseButton");
     cancelButton->setMinimumWidth(78);
     chooseButton->setMinimumWidth(78);
     chooseButton->setFocus();

--- a/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+++ b/src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
@@ -49,6 +49,7 @@ void OpenWithWidget::initUI()
     DFontSizeManager::instance()->bind(openWithListWidget, DFontSizeManager::SizeType::T7, QFont::Normal);
 
     openWithBtnGroup = new QButtonGroup(openWithListWidget);
+    openWithBtnGroup->setObjectName("OpenWithBtnGroup");
 
     this->setContent(openWithListWidget);
 


### PR DESCRIPTION
## Summary

为 common 插件集 (burn/dirshare/propertydialog/utils) 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp`
- `src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp`
- `src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/multifilepropertiesdialog.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp`
- `src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp`
- `src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp`
- `src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Enhancements:
- Add consistent object and accessible names to interactive controls across the common burn, directory-sharing, property-dialog, Bluetooth, and open-with plugins to improve AT-SPI accessibility.