### PR TITLE
fix(desktop): add AT-SPI accessible names for desktop controls

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
@@ -88,6 +88,8 @@ void CanvasViewMenuProxy::showEmptyAreaMenu(const Qt::ItemFlags &indexFlags, con
     }
 
     menuPtr = new DMenu(view);
+    menuPtr->setObjectName("MenuPtr");
+    menuPtr->setAccessibleName("MenuPtr");
     canvasScene->create(menuPtr);
     canvasScene->updateState(menuPtr);
     if (QAction *act = menuPtr->exec(QCursor::pos())) {

--- a/src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp
@@ -16,6 +16,8 @@ MethodComBox::MethodComBox(const QString &title, QWidget *parent)
 
     comboBox = qobject_cast<DComboBox *>(rightWidget);
     comboBox->setParent(this);
+    comboBox->setObjectName("ComboBox");
+    comboBox->setAccessibleName("ComboBox");
     comboBox->setFixedSize(198, 36);
 
     //Enable the combo box

--- a/src/plugins/desktop/ddplugin-organizer/options/widgets/checkboxwidget.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/widgets/checkboxwidget.cpp
@@ -11,6 +11,8 @@ CheckBoxWidget::CheckBoxWidget(const QString &text, QWidget *parent)
     : EntryWidget(new DCheckBox(text), nullptr, parent)
 {
     checkBox = qobject_cast<DCheckBox *>(leftWidget);
+    checkBox->setObjectName("CheckBox");
+    checkBox->setAccessibleName("CheckBox");
     connect(checkBox, &QCheckBox::stateChanged, this, [this](int stat) {
         emit changed(stat == Qt::Checked);
     });

--- a/src/plugins/desktop/ddplugin-organizer/options/widgets/shortcutwidget.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/widgets/shortcutwidget.cpp
@@ -16,6 +16,8 @@ ShortcutWidget::ShortcutWidget(const QString &title, QWidget *parent)
     label->setParent(this);
     label->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     keyEdit = qobject_cast<DKeySequenceEdit *>(rightWidget);
+    keyEdit->setObjectName("KeyEdit");
+    keyEdit->setAccessibleName("KeyEdit");
     keyEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
     auto p = keyEdit->palette();

--- a/src/plugins/desktop/ddplugin-organizer/options/widgets/switchwidget.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/options/widgets/switchwidget.cpp
@@ -20,6 +20,8 @@ SwitchWidget::SwitchWidget(const QString &title, QWidget *parent)
 
     switchBtn = qobject_cast<DSwitchButton *>(rightWidget);
     switchBtn->setParent(this);
+    switchBtn->setObjectName("SwitchBtn");
+    switchBtn->setAccessibleName("SwitchBtn");
 
     connect(switchBtn, &DSwitchButton::toggled, this, &SwitchWidget::checkedChanged);
 }

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
@@ -77,6 +77,8 @@ void CollectionViewMenu::emptyAreaMenu()
         delete menuPtr;
 
     menuPtr = new DMenu(view);
+    menuPtr->setObjectName("MenuPtr");
+    menuPtr->setAccessibleName("MenuPtr");
     canvasScene->create(menuPtr);
     canvasScene->updateState(menuPtr);
 


### PR DESCRIPTION
## Summary

为 桌面插件 (canvas/organizer) 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp`
- `src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp`
- `src/plugins/desktop/ddplugin-organizer/options/widgets/checkboxwidget.cpp`
- `src/plugins/desktop/ddplugin-organizer/options/widgets/shortcutwidget.cpp`
- `src/plugins/desktop/ddplugin-organizer/options/widgets/switchwidget.cpp`
- `src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Bug Fixes:
- Add AT-SPI object and accessible names to desktop menus and organizer option controls to improve accessibility identification.