### PR TITLE
fix(filemanager): add AT-SPI accessible names for filemanager-misc controls

### DIFF
--- a/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+++ b/src/plugins/filedialog/core/views/filedialogstatusbar.cpp
@@ -247,7 +247,11 @@ void FileDialogStatusBar::initializeUi()
     filtersLabel->setObjectName(labelFilters);
 
     fileNameEdit = new DLineEdit(this);
+    fileNameEdit->setObjectName("FileNameEdit");
+    fileNameEdit->setAccessibleName("FileNameEdit");
     filtersComboBox = new DComboBox(this);
+    filtersComboBox->setObjectName("FiltersComboBox");
+    filtersComboBox->setAccessibleName("FiltersComboBox");
 #ifdef ENABLE_TESTING
     dpfSlotChannel->push("dfmplugin_utils", "slot_Accessible_SetAccessibleName",
                          qobject_cast<QWidget *>(fileNameEdit), AcName::kAcFDStatusBarFileNameEdit);

--- a/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
@@ -127,6 +127,8 @@ QWidget *ComputerItemDelegate::createEditor(QWidget *parent, const QStyleOptionV
     editingIndex = index;
     auto editor = new QLineEdit(parent);
     renameEditor = editor;
+    renameEditor->setObjectName("RenameEditor");
+    renameEditor->setAccessibleName("RenameEditor");
 
     int topMargin = editorMarginTop(option.font.family());
     editor->setFrame(false);

--- a/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
@@ -106,7 +106,11 @@ void OpticalMediaWidget::initializeUi()
     lbAvailable = new QLabel("<Space Available>");
     lbUDFSupport = new QLabel(tr("It does not support burning UDF discs"));
     pbDump = new DPushButton();
+    pbDump->setObjectName("PbDump");
+    pbDump->setAccessibleName("PbDump");
     pbBurn = new DPushButton();
+    pbBurn->setObjectName("PbBurn");
+    pbBurn->setAccessibleName("PbBurn");
     iconCaution = new QSvgWidget();
 
     // 设置按钮文本

--- a/src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
@@ -26,6 +26,8 @@ IndexStatusCheckBox::IndexStatusCheckBox(QWidget *parent)
     layout->setSpacing(4);
 
     m_checkBox = new QCheckBox(this);
+    m_checkBox->setObjectName("CheckBox");
+    m_checkBox->setAccessibleName("CheckBox");
     layout->addWidget(m_checkBox);
 
     auto *statusWidget = new QWidget(this);


### PR DESCRIPTION
## Summary

为 文件管理器小插件 (filedialog/computer/optical/search) 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/plugins/filedialog/core/views/filedialogstatusbar.cpp`
- `src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp`
- `src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp`
- `src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Enhancements:
- Add AT-SPI object and accessible names to file dialog, computer, optical media, and search controls for improved accessibility identification.