### PR TITLE
fix(disk-encrypt): add AT-SPI accessible names for disk-encrypt controls

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
@@ -63,8 +63,14 @@ void ChgPassphraseDialog::initUI()
 
     oldKeyHint = new QLabel(this);
     oldPass = new Dtk::Widget::DPasswordEdit(this);
+    oldPass->setObjectName("OldPass");
+    oldPass->setAccessibleName("OldPass");
     newPass1 = new Dtk::Widget::DPasswordEdit(this);
+    newPass1->setObjectName("NewPass1");
+    newPass1->setAccessibleName("NewPass1");
     newPass2 = new Dtk::Widget::DPasswordEdit(this);
+    newPass2->setObjectName("NewPass2");
+    newPass2->setAccessibleName("NewPass2");
 
     newPass2->setPlaceholderText(tr("Please enter %1 again").arg(keyTypeStr));
 
@@ -73,6 +79,8 @@ void ChgPassphraseDialog::initUI()
     lay->addRow(tr("Repeat %1").arg(encType), newPass2);
 
     recSwitch = new Dtk::Widget::DCommandLinkButton("", this);
+    recSwitch->setObjectName("RecSwitch");
+    recSwitch->setAccessibleName("RecSwitch");
     contentLay->addWidget(recSwitch, 0, Qt::AlignRight);
 
     addContent(content);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
@@ -114,6 +114,8 @@ void DecryptParamsInputDialog::initUI()
     editor = new Dtk::Widget::DPasswordEdit(this);
     lay->addWidget(editor);
     recSwitch = new Dtk::Widget::DCommandLinkButton("", this);
+    recSwitch->setObjectName("RecSwitch");
+    recSwitch->setAccessibleName("RecSwitch");
     lay->addWidget(recSwitch, 0, Qt::AlignRight);
     addContent(content);
     addButton(tr("Confirm"));

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -114,6 +114,8 @@ QWidget *EncryptParamsInputDialog::createPasswordPage()
     wid->setLayout(lay);
 
     encType = new DComboBox(this);
+    encType->setObjectName("EncType");
+    encType->setAccessibleName("EncType");
     encType->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
     lay->addRow(tr("Unlock type"), encType);
 
@@ -128,11 +130,15 @@ QWidget *EncryptParamsInputDialog::createPasswordPage()
 
     keyHint1 = new QLabel(this);
     encKeyEdit1 = new DPasswordEdit(this);
+    encKeyEdit1->setObjectName("EncKeyEdit1");
+    encKeyEdit1->setAccessibleName("EncKeyEdit1");
     keyHint1->setMinimumWidth(66);
     lay->addRow(keyHint1, encKeyEdit1);
 
     keyHint2 = new QLabel(this);
     encKeyEdit2 = new DPasswordEdit(this);
+    encKeyEdit2->setObjectName("EncKeyEdit2");
+    encKeyEdit2->setAccessibleName("EncKeyEdit2");
     lay->addRow(keyHint2, encKeyEdit2);
 
     encType->addItems({ tr("Unlocked by passphrase"),
@@ -174,6 +180,8 @@ QWidget *EncryptParamsInputDialog::createExportPage()
     hint->setAlignment(Qt::AlignCenter);
 
     keyExportInput = new DFileChooserEdit(this);
+    keyExportInput->setObjectName("KeyExportInput");
+    keyExportInput->setAccessibleName("KeyExportInput");
     keyExportInput->setFileMode(QFileDialog::Directory);
     if (keyExportInput->fileDialog() && dialog_utils::isWayland())
         keyExportInput->fileDialog()->setWindowFlag(Qt::WindowStaysOnTopHint);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
@@ -42,7 +42,11 @@ void UnlockPartitionDialog::initUI()
 
     QFrame *content = new QFrame;
     passwordLineEdit = new DPasswordEdit;
+    passwordLineEdit->setObjectName("PasswordLineEdit");
+    passwordLineEdit->setAccessibleName("PasswordLineEdit");
     chgUnlockType = new DCommandLinkButton("");
+    chgUnlockType->setObjectName("ChgUnlockType");
+    chgUnlockType->setAccessibleName("ChgUnlockType");
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addSpacing(10);


### PR DESCRIPTION
## Summary

为 disk-encrypt-entry 磁盘加密对话框 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp`
- `src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp`
- `src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp`
- `src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Enhancements:
- Add AT-SPI object and accessible names to interactive controls in the disk-encryption dialogs.