### PR TITLE
fix(titlebar): add AT-SPI accessible names for titlebar controls

### DIFF
--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
@@ -373,6 +373,8 @@ void ConnectToServerDialog::initializeUi()
     // init address area
     {
         schemeComboBox = new DComboBox(this);
+        schemeComboBox->setObjectName("SchemeComboBox");
+        schemeComboBox->setAccessibleName("SchemeComboBox");
         supportedSchemes << QString("%1://").arg(Scheme::kSmb)
                          << QString("%1://").arg(Scheme::kFtp)
                          << QString("%1://").arg(Scheme::kSFtp)
@@ -389,12 +391,16 @@ void ConnectToServerDialog::initializeUi()
         completer->setMaxVisibleItems(kMaxHistoryItems);
 
         serverComboBox = new DComboBox(this);
+        serverComboBox->setObjectName("ServerComboBox");
+        serverComboBox->setAccessibleName("ServerComboBox");
         serverComboBox->setEditable(true);
         serverComboBox->setMaxVisibleItems(kMaxHistoryItems);
         serverComboBox->clearEditText();
         serverComboBox->setCompleter(completer);
 
         theAddButton = new DIconButton(this);
+        theAddButton->setObjectName("TheAddButton");
+        theAddButton->setAccessibleName("TheAddButton");
         theAddButton->setMaximumSize(38, 38);
         theAddButton->setFlat(false);
         theAddButton->setIconSize({ 16, 16 });
@@ -411,6 +417,8 @@ void ConnectToServerDialog::initializeUi()
         charsetLabel->setContentsMargins(8, 0, 0, 0);
 
         charsetComboBox = new DComboBox();
+        charsetComboBox->setObjectName("CharsetComboBox");
+        charsetComboBox->setAccessibleName("CharsetComboBox");
         charsetComboBox->addItems({ tr("Default"), "UTF-8", "GBK" });
         charsetComboBox->setVisible(false);
 
@@ -421,6 +429,8 @@ void ConnectToServerDialog::initializeUi()
     // init collection area
     {
         collectionServerView = new DListView();
+        collectionServerView->setObjectName("CollectionServerView");
+        collectionServerView->setAccessibleName("CollectionServerView");
         collectionServerView->setVerticalScrollMode(DListView::ScrollPerPixel);
         collectionServerView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
         collectionServerView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
@@ -82,12 +82,18 @@ void DPCConfirmWidget::initUI()
     QValidator *validator = new QRegularExpressionValidator(regx, this);
 
     oldPwdEdit = new DPasswordEdit(this);
+    oldPwdEdit->setObjectName("OldPwdEdit");
+    oldPwdEdit->setAccessibleName("OldPwdEdit");
     oldPwdEdit->lineEdit()->setValidator(validator);   // 设置验证器
 
     newPwdEdit = new DPasswordEdit(this);
+    newPwdEdit->setObjectName("NewPwdEdit");
+    newPwdEdit->setAccessibleName("NewPwdEdit");
     newPwdEdit->lineEdit()->setValidator(validator);
 
     repeatPwdEdit = new DPasswordEdit(this);
+    repeatPwdEdit->setObjectName("RepeatPwdEdit");
+    repeatPwdEdit->setAccessibleName("RepeatPwdEdit");
     repeatPwdEdit->lineEdit()->setValidator(validator);
 
     DLabel *oldPwdLabel = new DLabel(tr("Current password:"), this);
@@ -106,8 +112,12 @@ void DPCConfirmWidget::initUI()
     contentLayout->setVerticalSpacing(10);
 
     saveBtn = new DSuggestButton(tr("Save", "button"), this);
+    saveBtn->setObjectName("SaveBtn");
+    saveBtn->setAccessibleName("SaveBtn");
     saveBtn->setAttribute(Qt::WA_NoMousePropagation);
     cancelBtn = new DPushButton(tr("Cancel", "button"), this);
+    cancelBtn->setObjectName("CancelBtn");
+    cancelBtn->setAccessibleName("CancelBtn");
     cancelBtn->setAttribute(Qt::WA_NoMousePropagation);
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
@@ -52,6 +52,8 @@ void CustomTabSettingWidget::initUI()
     mainLayout->setVerticalSpacing(10);
 
     addItemBtn = new DToolButton(this);
+    addItemBtn->setObjectName("AddItemBtn");
+    addItemBtn->setAccessibleName("AddItemBtn");
     addItemBtn->setToolTip(tr("Add Directory"));
     addItemBtn->setIconSize({ 16, 16 });
     addItemBtn->setIcon(DStyle::standardIcon(style(), DStyle::SP_IncreaseElement));

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
@@ -319,6 +319,8 @@ void SearchEditWidget::initUI()
 
     // search button
     searchButton = new CustomDIconButton(this);
+    searchButton->setObjectName("SearchButton");
+    searchButton->setAccessibleName("SearchButton");
     searchButton->setIcon(QIcon::fromTheme("dfm_search_button"));
     searchButton->setFixedSize(kToolButtonSize, kToolButtonSize);
     searchButton->setIconSize(QSize(kToolButtonIconSize, kToolButtonIconSize));
@@ -329,12 +331,16 @@ void SearchEditWidget::initUI()
 
     // search edit
     searchEdit = new DSearchEdit(this);
+    searchEdit->setObjectName("SearchEdit");
+    searchEdit->setAccessibleName("SearchEdit");
     searchEdit->setVisible(true);
     // searchEdit->setFocusPolicy(Qt::StrongFocus);
     searchEdit->lineEdit()->setFocusPolicy(Qt::ClickFocus);
 
     // advanced search button
     advancedButton = new CustomDToolButton(this);
+    advancedButton->setObjectName("AdvancedButton");
+    advancedButton->setAccessibleName("AdvancedButton");
     advancedButton->setIcon(QIcon::fromTheme("dfm_view_filter"));
     advancedButton->setFixedSize(kToolButtonSize, kToolButtonSize);
     advancedButton->setFocusPolicy(Qt::NoFocus);

--- a/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
@@ -145,6 +145,7 @@ void TabBarPrivate::initUI()
     addBtn = q->findChild<DIconButton *>("AddButton");
     Q_ASSERT(addBtn);
 
+    addBtn->setAccessibleName("AddBtn");
     addBtn->setFixedSize(30, 30);
     addBtn->setFlat(true);
     addBtn->setFocusPolicy(Qt::NoFocus);
@@ -167,6 +168,8 @@ void TabBarPrivate::initUI()
     // for update close button state
     tabBar = q->findChild<QTabBar *>();
     if (tabBar) {
+        tabBar->setObjectName("TabBar");
+        tabBar->setAccessibleName("TabBar");
         tabBar->setMouseTracking(true);
         tabBar->installEventFilter(q);
     }


### PR DESCRIPTION
## Summary

为 titlebar 标题栏 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp`
- `src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp`
- `src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp`
- `src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp`
- `src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Bug Fixes:
- Add AT-SPI object and accessible names to titlebar controls so they can be identified by assistive technologies.