### PR TITLE
fix(vault): add AT-SPI accessible names for vault controls

### DIFF
--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
@@ -80,6 +80,8 @@ void VaultActiveFinishedView::initUi()
 
     // 加密保险箱按钮
     finishedBtn = new DSuggestButton(tr("Encrypt"), this);
+    finishedBtn->setObjectName("FinishedBtn");
+    finishedBtn->setAccessibleName("FinishedBtn");
     finishedBtn->setFixedWidth(200);
 
     // 布局

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
@@ -92,6 +92,8 @@ void VaultActiveSaveKeyFileView::initUI()
     otherRadioBtnHitMsg->setForegroundRole(DPalette::TextWarning);
 
     selectfileSavePathEdit = new DFileChooserEdit(this);
+    selectfileSavePathEdit->setObjectName("SelectfileSavePathEdit");
+    selectfileSavePathEdit->setAccessibleName("SelectfileSavePathEdit");
     selectfileSavePathEdit->lineEdit()->setPlaceholderText(tr("Select a path"));
     selectfileSavePathEdit->lineEdit()->setReadOnly(true);
     selectfileSavePathEdit->lineEdit()->setClearButtonEnabled(false);
@@ -105,6 +107,8 @@ void VaultActiveSaveKeyFileView::initUI()
     selectfileSavePathEdit->setEnabled(true);
 
     nextBtn = new DSuggestButton(tr("Next"), this);
+    nextBtn->setObjectName("NextBtn");
+    nextBtn->setAccessibleName("NextBtn");
     nextBtn->setFixedWidth(200);
     nextBtn->setEnabled(false);
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
@@ -48,6 +48,8 @@ void VaultActiveSetUnlockMethodView::initUi()
 
     DLabel *pTypeLabel = new DLabel(tr("Encryption method"), this);
     typeCombo = new DComboBox(this);
+    typeCombo->setObjectName("TypeCombo");
+    typeCombo->setAccessibleName("TypeCombo");
     typeCombo->addItem(tr("Key encryption"), EncryptMode::kKeyMode);
     typeCombo->addItem(tr("Transparent encryption"), EncryptMode::kTransparentMode);
 
@@ -62,12 +64,16 @@ void VaultActiveSetUnlockMethodView::initUi()
 
     repeatPasswordLabel = new DLabel(tr("Repeat password"), this);
     repeatPasswordEdit = new DPasswordEdit(this);
+    repeatPasswordEdit->setObjectName("RepeatPasswordEdit");
+    repeatPasswordEdit->setAccessibleName("RepeatPasswordEdit");
     repeatPasswordEdit->lineEdit()->setValidator(validator);
     repeatPasswordEdit->lineEdit()->setPlaceholderText(tr("Input the password again"));
     repeatPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     passwordHintLabel = new DLabel(tr("Password hint"), this);
     tipsEdit = new DLineEdit(this);
+    tipsEdit->setObjectName("TipsEdit");
+    tipsEdit->setAccessibleName("TipsEdit");
     tipsEdit->lineEdit()->setMaxLength(14);
     tipsEdit->setPlaceholderText(tr("Optional"));
 
@@ -83,6 +89,8 @@ void VaultActiveSetUnlockMethodView::initUi()
     transEncryptTextLay->addWidget(transEncryptionText);
 
     nextBtn = new DSuggestButton(tr("Next"), this);
+    nextBtn->setObjectName("NextBtn");
+    nextBtn->setAccessibleName("NextBtn");
     nextBtn->setFixedWidth(200);
     nextBtn->setEnabled(false);
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
@@ -41,6 +41,8 @@ void VaultActiveStartView::initUi()
     pLabel3->setAlignment(Qt::AlignHCenter);
 
     startBtn = new DSuggestButton(tr("Create"), this);
+    startBtn->setObjectName("StartBtn");
+    startBtn->setAccessibleName("StartBtn");
     startBtn->setFixedWidth(200);
 
     QVBoxLayout *play = new QVBoxLayout(this);

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
@@ -41,6 +41,8 @@ VaultRemoveByPasswordView::VaultRemoveByPasswordView(QWidget *parent)
     pwdEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     tipsBtn = new QPushButton(this);
+    tipsBtn->setObjectName("TipsBtn");
+    tipsBtn->setAccessibleName("TipsBtn");
     tipsBtn->setIcon(QIcon(":/icons/images/icons/light_32px.svg"));
 
     QHBoxLayout *layout = new QHBoxLayout();
@@ -49,6 +51,8 @@ VaultRemoveByPasswordView::VaultRemoveByPasswordView(QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
 
     toggleModeBtn = new DCommandLinkButton(tr("Key delete"), this);
+    toggleModeBtn->setObjectName("ToggleModeBtn");
+    toggleModeBtn->setAccessibleName("ToggleModeBtn");
     DFontSizeManager::instance()->bind(toggleModeBtn, DFontSizeManager::T8, QFont::Medium);
 
     QVBoxLayout *mainLay = new QVBoxLayout;

--- a/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
@@ -50,6 +50,8 @@ void VaultRemoveByRecoverykeyView::initUI()
         QLabel *label = new QLabel(tr("Delete file vault with recovery key"), this);
 
         filePathEdit = new DFileChooserEdit(this);
+        filePathEdit->setObjectName("FilePathEdit");
+        filePathEdit->setAccessibleName("FilePathEdit");
         filePathEdit->lineEdit()->setPlaceholderText(tr("Select Key File"));
         filePathEdit->lineEdit()->setReadOnly(true);
         filePathEdit->lineEdit()->setClearButtonEnabled(false);

--- a/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
@@ -44,6 +44,8 @@ void ResetPasswordByKeyFileView::initUI()
 {
     DLabel *keyFileLabel = new DLabel(tr("Select Key File"), this);
     keyFileEdit = new DFileChooserEdit(this);
+    keyFileEdit->setObjectName("KeyFileEdit");
+    keyFileEdit->setAccessibleName("KeyFileEdit");
     keyFileEdit->lineEdit()->setPlaceholderText(tr("Select key file save path"));
     fileDialog = new DFileDialog(this, QDir::homePath());
     keyFileEdit->setDirectoryUrl(QDir::homePath());
@@ -54,6 +56,8 @@ void ResetPasswordByKeyFileView::initUI()
 
     DLabel *newPasswordLabel = new DLabel(tr("Enter New Password"), this);
     newPasswordEdit = new DPasswordEdit(this);
+    newPasswordEdit->setObjectName("NewPasswordEdit");
+    newPasswordEdit->setAccessibleName("NewPasswordEdit");
     QRegularExpression regx("[A-Za-z0-9,.;?@/=()<>_+*&^%$#!`~'\"|]+");
     QValidator *validator = new QRegularExpressionValidator(regx, this);
     newPasswordEdit->lineEdit()->setValidator(validator);
@@ -62,12 +66,16 @@ void ResetPasswordByKeyFileView::initUI()
 
     DLabel *repeatPasswordLabel = new DLabel(tr("Repeat Password"), this);
     repeatPasswordEdit = new DPasswordEdit(this);
+    repeatPasswordEdit->setObjectName("RepeatPasswordEdit");
+    repeatPasswordEdit->setAccessibleName("RepeatPasswordEdit");
     repeatPasswordEdit->lineEdit()->setValidator(validator);
     repeatPasswordEdit->lineEdit()->setPlaceholderText(tr("Enter new password again"));
     repeatPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     DLabel *passwordHintLabel = new DLabel(tr("Password hint"), this);
     passwordHintEdit = new DLineEdit(this);
+    passwordHintEdit->setObjectName("PasswordHintEdit");
+    passwordHintEdit->setAccessibleName("PasswordHintEdit");
     passwordHintEdit->lineEdit()->setMaxLength(14);
     passwordHintEdit->setPlaceholderText(tr("Optional"));
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
@@ -45,11 +45,15 @@ void ResetPasswordByOldPasswordView::initUI()
 {
     DLabel *oldPasswordLabel = new DLabel(tr("Enter Old Password"), this);
     oldPasswordEdit = new DPasswordEdit(this);
+    oldPasswordEdit->setObjectName("OldPasswordEdit");
+    oldPasswordEdit->setAccessibleName("OldPasswordEdit");
     oldPasswordEdit->lineEdit()->setPlaceholderText(tr("Please enter old password"));
     oldPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     DLabel *newPasswordLabel = new DLabel(tr("Enter New Password"), this);
     newPasswordEdit = new DPasswordEdit(this);
+    newPasswordEdit->setObjectName("NewPasswordEdit");
+    newPasswordEdit->setAccessibleName("NewPasswordEdit");
     QRegularExpression regx("[A-Za-z0-9,.;?@/=()<>_+*&^%$#!`~'\"|]+");
     QValidator *validator = new QRegularExpressionValidator(regx, this);
     newPasswordEdit->lineEdit()->setValidator(validator);
@@ -58,12 +62,16 @@ void ResetPasswordByOldPasswordView::initUI()
 
     DLabel *repeatPasswordLabel = new DLabel(tr("Repeat Password"), this);
     repeatPasswordEdit = new DPasswordEdit(this);
+    repeatPasswordEdit->setObjectName("RepeatPasswordEdit");
+    repeatPasswordEdit->setAccessibleName("RepeatPasswordEdit");
     repeatPasswordEdit->lineEdit()->setValidator(validator);
     repeatPasswordEdit->lineEdit()->setPlaceholderText(tr("Enter new password again"));
     repeatPasswordEdit->lineEdit()->setAttribute(Qt::WA_InputMethodEnabled, false);
 
     DLabel *passwordHintLabel = new DLabel(tr("Password hint"), this);
     passwordHintEdit = new DLineEdit(this);
+    passwordHintEdit->setObjectName("PasswordHintEdit");
+    passwordHintEdit->setAccessibleName("PasswordHintEdit");
     passwordHintEdit->lineEdit()->setMaxLength(14);
     passwordHintEdit->setPlaceholderText(tr("Optional"));
 

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
@@ -55,6 +55,8 @@ RetrievePasswordView::RetrievePasswordView(QWidget *parent)
     savePathTypeLabel->setText(tr("Unlock the Safe via Key File"));
 
     filePathEdit = new DFileChooserEdit(this);
+    filePathEdit->setObjectName("FilePathEdit");
+    filePathEdit->setAccessibleName("FilePathEdit");
     filePathEdit->lineEdit()->setPlaceholderText(tr("Select Key File"));
     fileDialog = new DFileDialog(this, QDir::homePath());
     fileDialog->setNameFilters({ QString("KEY file(*.key)") });

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
@@ -85,6 +85,8 @@ void UnlockView::initUI()
 
     // 提示按钮
     tipsButton = new QPushButton(this);
+    tipsButton->setObjectName("TipsButton");
+    tipsButton->setAccessibleName("TipsButton");
     tipsButton->setIcon(QIcon(":/icons/images/icons/light_32px.svg"));
 
     //! 布局


### PR DESCRIPTION
## Summary

为 vault 保险箱 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Enhancements:
- Add AT-SPI object and accessible names to vault creation, removal, password reset, and unlock controls.