### PR TITLE
fix(workspace): add AT-SPI accessible names for workspace controls

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
@@ -72,6 +72,8 @@ void FileViewMenuHelper::showEmptyAreaMenu()
         delete menuPtr;
 
     menuPtr = new DMenu(this->view);
+    menuPtr->setObjectName("MenuPtr");
+    menuPtr->setAccessibleName("MenuPtr");
     scene->create(menuPtr);
     scene->updateState(menuPtr);
     reloadCursor();

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
@@ -113,6 +113,8 @@ void FileViewStatusBar::initScalingSlider()
     fmDebug() << "Initializing scaling slider";
 
     scaleSlider = new DSlider(Qt::Horizontal, this);
+    scaleSlider->setObjectName("ScaleSlider");
+    scaleSlider->setAccessibleName("ScaleSlider");
     scaleSlider->adjustSize();
     scaleSlider->setFixedWidth(120);
     scaleSlider->setMaximum(1);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
@@ -44,6 +44,8 @@ void RenameBarPrivate::initUI()
 
     mainLayout = new QHBoxLayout(widget);
     comboBox = new QComboBox;
+    comboBox->setObjectName("ComboBox");
+    comboBox->setAccessibleName("ComboBox");
     stackWidget = new QStackedWidget;
 
     replaceOperatorItems = std::make_tuple(new QLabel, new QLineEdit, new QLabel, new QLineEdit);
@@ -133,6 +135,8 @@ void RenameBarPrivate::setUIParameters()
     button->setText(QObject::tr("Cancel", "button"));
     button->setFixedWidth(82);
     renameBtn = new DSuggestButton();
+    renameBtn->setObjectName("RenameBtn");
+    renameBtn->setAccessibleName("RenameBtn");
     renameBtn->setText(QObject::tr("Rename", "button"));
     renameBtn->setFixedWidth(82);
     button->setEnabled(true);


### PR DESCRIPTION
## Summary

为 workspace 工作区 + 加密示例 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp`
- `src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp`
- `src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp`
- `examples/dfmplugin-encrypt-manager-demo/mainwindow.cpp`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Improve accessibility metadata for workspace and encryption example controls by assigning consistent AT-SPI names.

Enhancements:
- Add AT-SPI object and accessible names to workspace menus, rename controls, and scaling slider.
- Add AT-SPI names to controls in the encryption manager example.