### PR TITLE
fix(test): add AT-SPI accessible names for baseline controls

### DIFF
--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1,72 +1,1204 @@
 # SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-expected_names:
-- line: 253
-  name: CloseBtn
+version: '1.0'
+widgets:
+- variable: closeBtn
+  type: Dtk::Widget::DFloatingButton *
+  object_name: ''
+  accessible_name: CloseBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
-  variable: closeBtn
-- line: 19
-  name: PreBtn
+  class_name: ''
+  line: 66
+- variable: statusBar
+  type: FilePreviewDialogStatusBar *
+  object_name: StatusBar
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialog.cpp
+  class_name: ''
+  line: 68
+- variable: nextBtn
+  type: QPushButton *
+  object_name: NextButton
+  accessible_name: NextBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
-  variable: preBtn
-- line: 28
-  name: NextBtn
+  class_name: FilePreviewDialogStatusBar
+  line: 27
+- variable: preBtn
+  type: QPushButton *
+  object_name: PreButton
+  accessible_name: PreBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
-  variable: nextBtn
-- line: 42
-  name: OpenBtn
+  class_name: FilePreviewDialogStatusBar
+  line: 18
+- variable: openBtn
+  type: QPushButton *
+  object_name: OpenButton
+  accessible_name: OpenBtn
   source_file: src/apps/dde-file-manager-preview/libdfm-preview/views/filepreviewdialogstatusbar.cpp
-  variable: openBtn
-- line: 281
-  name: AvailableSizeCombo
+  class_name: FilePreviewDialogStatusBar
+  line: 41
+- variable: availableSizeCombo
+  type: QComboBox *
+  object_name: ''
+  accessible_name: AvailableSizeCombo
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: availableSizeCombo
-- line: 373
-  name: ForegroundPaletteEdit
+  class_name: AbstractBasePreview
+  line: 216
+- variable: foregroundPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: ForegroundPaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: foregroundPaletteEdit
-- line: 386
-  name: BackgroundPaletteEdit
+  class_name: AbstractBasePreview
+  line: 219
+- variable: backgroundPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: BackgroundPaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: backgroundPaletteEdit
-- line: 400
-  name: HightlightPaletteEdit
+  class_name: AbstractBasePreview
+  line: 220
+- variable: hightlightPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: HightlightPaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: hightlightPaletteEdit
-- line: 414
-  name: HFpaletteEdit
+  class_name: AbstractBasePreview
+  line: 221
+- variable: hFPaletteEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: HFpaletteEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: hFPaletteEdit
-- line: 334
-  name: ThemeCom
+  class_name: AbstractBasePreview
+  line: 222
+- variable: themeCom
+  type: QComboBox *
+  object_name: ''
+  accessible_name: ThemeCom
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: themeCom
-- line: 341
-  name: ModeCom
+  class_name: AbstractBasePreview
+  line: 224
+- variable: modeCom
+  type: QComboBox *
+  object_name: ''
+  accessible_name: ModeCom
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: modeCom
-- line: 290
-  name: CustomSizeEdit
+  class_name: AbstractBasePreview
+  line: 225
+- variable: customSizeEdit
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: CustomSizeEdit
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/dciicon-preview/ddciiconpreview.cpp
-  variable: customSizeEdit
-- line: 32
-  name: PlayControlButton
+  class_name: AbstractBasePreview
+  line: 226
+- variable: titleLabel
+  type: QLabel *
+  object_name: Title
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 70
+- variable: artistLabel
+  type: QLabel *
+  object_name: Artist
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 71
+- variable: albumLabel
+  type: QLabel *
+  object_name: Album
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 72
+- variable: artistValue
+  type: QLabel *
+  object_name: artistValue
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 74
+- variable: albumValue
+  type: QLabel *
+  object_name: albumValue
+  accessible_name: ''
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/musicmessageview.cpp
+  class_name: QLabel
+  line: 75
+- variable: playControlButton
+  type: QPushButton *
+  object_name: ''
+  accessible_name: PlayControlButton
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/toolbarframe.cpp
-  variable: playControlButton
-- line: 37
-  name: ProgressSlider
+  class_name: QTimer
+  line: 61
+- variable: progressSlider
+  type: Dtk::Widget::DSlider *
+  object_name: ''
+  accessible_name: ProgressSlider
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/music-preview/toolbarframe.cpp
-  variable: progressSlider
-- line: 39
-  name: PasswordEdit
+  class_name: QTimer
+  line: 62
+- variable: nextbutton
+  type: Dtk::Widget::DPushButton *
+  object_name: ensureBtn
+  accessible_name: ''
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp
-  variable: passwordEdit
-- line: 22
-  name: ItemViewParent
-  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/thumbnaildelegate.cpp
-  variable: itemViewParent
-- line: 53
-  name: ControlButton
+  class_name: ''
+  line: 76
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: PasswordEdit
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/encryptionpage.cpp
+  class_name: ''
+  line: 78
+- variable: pImageListView
+  type: SideBarImageListView *
+  object_name: ''
+  accessible_name: View_ImageList
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/thumbnailwidget.cpp
+  class_name: ''
+  line: 61
+- variable: slider
+  type: Dtk::Widget::DSlider *
+  object_name: ''
+  accessible_name: ''
   source_file: src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
-  variable: controlButton
+  class_name: QEvent
+  line: 35
+- variable: controlButton
+  type: Dtk::Widget::DIconButton *
+  object_name: ''
+  accessible_name: ControlButton
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/video-preview/videostatusbar.cpp
+  class_name: QEvent
+  line: 40
+- variable: usernameLineEdit
+  type: QLineEdit *
+  object_name: UsernameLineEdit
+  accessible_name: UsernameLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 55
+- variable: domainLineEdit
+  type: QLineEdit *
+  object_name: DomainLineEdit
+  accessible_name: DomainLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 56
+- variable: passwordLineEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: PasswordLineEdit
+  accessible_name: PasswordLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 57
+- variable: passwordCheckBox
+  type: QCheckBox *
+  object_name: PasswordCheckBox
+  accessible_name: PasswordCheckBox
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 58
+- variable: passwordButtonGroup
+  type: QButtonGroup *
+  object_name: PasswordButtonGroup
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountaskpassworddialog.cpp
+  class_name: ''
+  line: 60
+- variable: passwordLineEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: PasswordLineEdit
+  accessible_name: PasswordLineEdit
+  source_file: src/dfm-base/dialogs/mountpasswddialog/mountsecretdiskaskpassworddialog.cpp
+  class_name: QLabel
+  line: 41
+- variable: checkBox
+  type: QCheckBox *
+  object_name: CheckBox
+  accessible_name: CheckBox
+  source_file: src/dfm-base/dialogs/settingsdialog/controls/checkboxwithmessage.cpp
+  class_name: CheckBoxWithMessage
+  line: 24
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.cpp
+  class_name: ''
+  line: 33
+- variable: taskListWidget
+  type: QListWidget *
+  object_name: TaskListWidget
+  accessible_name: TaskListWidget
+  source_file: src/dfm-base/dialogs/taskdialog/taskdialog.cpp
+  class_name: QMutex
+  line: 52
+- variable: btnStop
+  type: Dtk::Widget::DIconButton *
+  object_name: TaskWidgetStopButton
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 83
+- variable: btnPause
+  type: Dtk::Widget::DIconButton *
+  object_name: TaskWidgetPauseButton
+  accessible_name: ''
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 84
+- variable: chkboxNotAskAgain
+  type: QCheckBox *
+  object_name: ChkboxNotAskAgain
+  accessible_name: ChkboxNotAskAgain
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 101
+- variable: btnCoexist
+  type: Dtk::Widget::DPushButton *
+  object_name: BtnCoexist
+  accessible_name: BtnCoexist
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 102
+- variable: btnSkip
+  type: Dtk::Widget::DPushButton *
+  object_name: BtnSkip
+  accessible_name: BtnSkip
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 103
+- variable: btnReplace
+  type: Dtk::Widget::DPushButton *
+  object_name: BtnReplace
+  accessible_name: BtnReplace
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: QVBoxLayout
+  line: 104
+- variable: m_iconButton
+  type: Dtk::Widget::DIconButton *
+  object_name: IconButton
+  accessible_name: IconButton
+  source_file: src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
+  class_name: ViewHintWidget
+  line: 46
+- variable: m_closeButton
+  type: Dtk::Widget::DIconButton *
+  object_name: CloseButton
+  accessible_name: CloseButton
+  source_file: src/dfm-base/widgets/viewhintmessage/viewhintwidget.cpp
+  class_name: ViewHintWidget
+  line: 48
+- variable: tipsLabel
+  type: TipsWidget *
+  object_name: diskmount
+  accessible_name: ''
+  source_file: src/external/dde-dock-plugins/disk-mount/diskmountplugin.cpp
+  class_name: DiskMountPlugin
+  line: 79
+- variable: advanceBtn
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: AdvanceBtn
+  accessible_name: AdvanceBtn
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 51
+- variable: volnameEdit
+  type: QLineEdit *
+  object_name: VolnameEdit
+  accessible_name: VolnameEdit
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 55
+- variable: writespeedComb
+  type: QComboBox *
+  object_name: WritespeedComb
+  accessible_name: WritespeedComb
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 57
+- variable: fsComb
+  type: QComboBox *
+  object_name: FsComb
+  accessible_name: FsComb
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 59
+- variable: finalizeDiscCheckbox
+  type: QCheckBox *
+  object_name: FinalizeDiscCheckbox
+  accessible_name: FinalizeDiscCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 60
+- variable: checkdiscCheckbox
+  type: QCheckBox *
+  object_name: CheckdiscCheckbox
+  accessible_name: CheckdiscCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 62
+- variable: checksumCheckbox
+  type: QCheckBox *
+  object_name: ChecksumCheckbox
+  accessible_name: ChecksumCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 63
+- variable: ejectCheckbox
+  type: QCheckBox *
+  object_name: EjectCheckbox
+  accessible_name: EjectCheckbox
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/burnoptdialog.cpp
+  class_name: ''
+  line: 64
+- variable: fileChooser
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: FileChooser
+  accessible_name: FileChooser
+  source_file: src/plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.cpp
+  class_name: ''
+  line: 43
+- variable: shareSwitcher
+  type: QCheckBox *
+  object_name: ShareSwitcher
+  accessible_name: ShareSwitcher
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 75
+- variable: shareNameEditor
+  type: Dtk::Widget::DLineEdit *
+  object_name: ShareNameEditor
+  accessible_name: ShareNameEditor
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 76
+- variable: sharePermissionSelector
+  type: QComboBox *
+  object_name: SharePermissionSelector
+  accessible_name: SharePermissionSelector
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 77
+- variable: shareAnonymousSelector
+  type: QComboBox *
+  object_name: ShareAnonymousSelector
+  accessible_name: ShareAnonymousSelector
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 78
+- variable: copyNetAddr
+  type: QPushButton *
+  object_name: CopyNetAddr
+  accessible_name: CopyNetAddr
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 87
+- variable: copyUserNameBt
+  type: QPushButton *
+  object_name: CopyUserNameBt
+  accessible_name: CopyUserNameBt
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 88
+- variable: setPasswordBt
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: SetPasswordBt
+  accessible_name: SetPasswordBt
+  source_file: src/plugins/common/dfmplugin-dirshare/widget/sharecontrolwidget.cpp
+  class_name: QHBoxLayout
+  line: 89
+- variable: ownerComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: OwnerComboBox
+  accessible_name: OwnerComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+  class_name: ''
+  line: 45
+- variable: groupComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: GroupComboBox
+  accessible_name: GroupComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+  class_name: ''
+  line: 46
+- variable: otherComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: OtherComboBox
+  accessible_name: OtherComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepermissionwidget.cpp
+  class_name: ''
+  line: 47
+- variable: cancelBtn
+  type: QPushButton *
+  object_name: CancelBtn
+  accessible_name: CancelBtn
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilepropertiesdialog.cpp
+  class_name: ''
+  line: 53
+- variable: ownerComboBox
+  type: QComboBox *
+  object_name: OwnerComboBox
+  accessible_name: OwnerComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 61
+- variable: groupComboBox
+  type: QComboBox *
+  object_name: GroupComboBox
+  accessible_name: GroupComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 62
+- variable: otherComboBox
+  type: QComboBox *
+  object_name: OtherComboBox
+  accessible_name: OtherComboBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 63
+- variable: executableCheckBox
+  type: QCheckBox *
+  object_name: ExecutableCheckBox
+  accessible_name: ExecutableCheckBox
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/permissionmanagerwidget.cpp
+  class_name: QCheckBox
+  line: 65
+- variable: tagLable
+  type: DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+  class_name: QHBoxLayout
+  line: 42
+- variable: tagLeftLable
+  type: DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/private/tagwidget_p.cpp
+  class_name: QHBoxLayout
+  line: 43
+- variable: toolTip
+  type: DLabel *
+  object_name: tool_tip
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/tagcolorlistwidget.cpp
+  class_name: QHBoxLayout
+  line: 59
+- variable: edit
+  type: QTextEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-tag/widgets/tagcrumbedit.cpp
+  class_name: ''
+  line: 29
+- variable: devicesListView
+  type: DListView *
+  object_name: DevicesListView
+  accessible_name: DevicesListView
+  source_file: src/plugins/common/dfmplugin-utils/bluetooth/private/bluetoothtransdialog.cpp
+  class_name: QStackedWidget
+  line: 92
+- variable: openWithListWidget
+  type: QListWidget *
+  object_name: OpenWithListWidget
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+  class_name: ''
+  line: 34
+- variable: openWithBtnGroup
+  type: QButtonGroup *
+  object_name: OpenWithBtnGroup
+  accessible_name: ''
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithwidget.cpp
+  class_name: ''
+  line: 35
+- variable: tooltip
+  type: Dtk::Widget::DArrowRectangle *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/delegate/itemeditor.cpp
+  class_name: QGraphicsOpacityEffect
+  line: 103
+- variable: menuPtr
+  type: Dtk::Widget::DMenu *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/view/operator/canvasviewmenuproxy.cpp
+  class_name: ''
+  line: 30
+- variable: textLabel
+  type: QLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/watermask/watermaskframe.cpp
+  class_name: QJsonObject
+  line: 65
+- variable: textLabel
+  type: QLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-canvas/watermask/watermasksystem.cpp
+  class_name: QLabel
+  line: 44
+- variable: tooltip
+  type: Dtk::Widget::DArrowRectangle *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp
+  class_name: QGraphicsOpacityEffect
+  line: 104
+- variable: comboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: ComboBox
+  accessible_name: ComboBox
+  source_file: src/plugins/desktop/ddplugin-organizer/options/methodgroup/methodcombox.cpp
+  class_name: ''
+  line: 29
+- variable: slider
+  type: Dtk::Widget::DSlider *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/desktop/ddplugin-organizer/options/sizeslider.cpp
+  class_name: QLabel
+  line: 33
+- variable: checkBox
+  type: Dtk::Widget::DCheckBox *
+  object_name: CheckBox
+  accessible_name: CheckBox
+  source_file: src/plugins/desktop/ddplugin-organizer/options/widgets/checkboxwidget.cpp
+  class_name: ''
+  line: 25
+- variable: keyEdit
+  type: Dtk::Widget::DKeySequenceEdit *
+  object_name: KeyEdit
+  accessible_name: KeyEdit
+  source_file: src/plugins/desktop/ddplugin-organizer/options/widgets/shortcutwidget.cpp
+  class_name: ''
+  line: 32
+- variable: switchBtn
+  type: Dtk::Widget::DSwitchButton *
+  object_name: SwitchBtn
+  accessible_name: SwitchBtn
+  source_file: src/plugins/desktop/ddplugin-organizer/options/widgets/switchwidget.cpp
+  class_name: ''
+  line: 33
+- variable: menuPtr
+  type: Dtk::Widget::DMenu *
+  object_name: MenuPtr
+  accessible_name: MenuPtr
+  source_file: src/plugins/desktop/ddplugin-organizer/view/collectionviewmenu.cpp
+  class_name: ''
+  line: 29
+- variable: titleLabel
+  type: Dtk::Widget::DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 82
+- variable: fileNameLabel
+  type: Dtk::Widget::DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 83
+- variable: filtersLabel
+  type: Dtk::Widget::DLabel *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 84
+- variable: fileNameEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: FileNameEdit
+  accessible_name: FileNameEdit
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 86
+- variable: filtersComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: FiltersComboBox
+  accessible_name: FiltersComboBox
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 87
+- variable: curAcceptButton
+  type: Dtk::Widget::DSuggestButton *
+  object_name: FileDialogStatusBarAcceptButton
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 89
+- variable: curRejectButton
+  type: Dtk::Widget::DPushButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filedialog/core/views/filedialogstatusbar.cpp
+  class_name: QHBoxLayout
+  line: 90
+- variable: renameEditor
+  type: QLineEdit *
+  object_name: RenameEditor
+  accessible_name: RenameEditor
+  source_file: src/plugins/filemanager/dfmplugin-computer/delegate/computeritemdelegate.cpp
+  class_name: ''
+  line: 52
+- variable: scrollArea
+  type: QScrollArea *
+  object_name: PropertyDialog-QScrollArea
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-computer/deviceproperty/devicepropertydialog.cpp
+  class_name: ''
+  line: 78
+- variable: oldPass
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: OldPass
+  accessible_name: OldPass
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 38
+- variable: newPass1
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPass1
+  accessible_name: NewPass1
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 39
+- variable: newPass2
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPass2
+  accessible_name: NewPass2
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 40
+- variable: recSwitch
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: RecSwitch
+  accessible_name: RecSwitch
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/chgpassphrasedialog.cpp
+  class_name: ''
+  line: 41
+- variable: editor
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
+  class_name: ''
+  line: 37
+- variable: recSwitch
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: RecSwitch
+  accessible_name: RecSwitch
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/decryptparamsinputdialog.cpp
+  class_name: ''
+  line: 38
+- variable: encType
+  type: Dtk::Widget::DComboBox *
+  object_name: EncType
+  accessible_name: EncType
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 53
+- variable: encKeyEdit1
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: EncKeyEdit1
+  accessible_name: EncKeyEdit1
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 54
+- variable: encKeyEdit2
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: EncKeyEdit2
+  accessible_name: EncKeyEdit2
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 55
+- variable: keyExportInput
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: KeyExportInput
+  accessible_name: KeyExportInput
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+  class_name: QLayout
+  line: 56
+- variable: passwordLineEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: PasswordLineEdit
+  accessible_name: PasswordLineEdit
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
+  class_name: QLabel
+  line: 44
+- variable: chgUnlockType
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: ChgUnlockType
+  accessible_name: ChgUnlockType
+  source_file: src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/unlockpartitiondialog.cpp
+  class_name: QLabel
+  line: 45
+- variable: pbBurn
+  type: Dtk::Widget::DPushButton *
+  object_name: PbBurn
+  accessible_name: PbBurn
+  source_file: src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+  class_name: ''
+  line: 47
+- variable: pbDump
+  type: Dtk::Widget::DPushButton *
+  object_name: PbDump
+  accessible_name: PbDump
+  source_file: src/plugins/filemanager/dfmplugin-optical/views/opticalmediawidget.cpp
+  class_name: ''
+  line: 48
+- variable: m_checkBox
+  type: QCheckBox *
+  object_name: CheckBox
+  accessible_name: CheckBox
+  source_file: src/plugins/filemanager/dfmplugin-search/utils/indexstatuscheckbox.cpp
+  class_name: ''
+  line: 67
+- variable: oldPwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: OldPwdEdit
+  accessible_name: OldPwdEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 52
+- variable: newPwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPwdEdit
+  accessible_name: NewPwdEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 53
+- variable: repeatPwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPwdEdit
+  accessible_name: RepeatPwdEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 54
+- variable: saveBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: SaveBtn
+  accessible_name: SaveBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 57
+- variable: cancelBtn
+  type: Dtk::Widget::DPushButton *
+  object_name: CancelBtn
+  accessible_name: CancelBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcconfirmwidget.cpp
+  class_name: QDBusInterface
+  line: 58
+- variable: closeBtn
+  type: Dtk::Widget::DPushButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/dpcwidget/dpcresultwidget.cpp
+  class_name: ''
+  line: 36
+- variable: addBtn
+  type: DIconButton *
+  object_name: ''
+  accessible_name: AddBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  class_name: Tab
+  line: 111
+- variable: leftBtn
+  type: DIconButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  class_name: Tab
+  line: 112
+- variable: tabBar
+  type: QTabBar *
+  object_name: TabBar
+  accessible_name: TabBar
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/tabbar.cpp
+  class_name: Tab
+  line: 113
+- variable: placeholder
+  type: QWidget *
+  object_name: Placeholder
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/titlebarwidget.cpp
+  class_name: DIconButton
+  line: 103
+- variable: finishedBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: FinishedBtn
+  accessible_name: FinishedBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivefinishedview.cpp
+  class_name: QVBoxLayout
+  line: 67
+- variable: nextBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+  class_name: ''
+  line: 73
+- variable: typeCombo
+  type: Dtk::Widget::DComboBox *
+  object_name: TypeCombo
+  accessible_name: TypeCombo
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 71
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 74
+- variable: repeatPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPasswordEdit
+  accessible_name: RepeatPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 77
+- variable: tipsEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: TipsEdit
+  accessible_name: TipsEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 80
+- variable: nextBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: NextBtn
+  accessible_name: NextBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesetunlockmethodview.cpp
+  class_name: QVBoxLayout
+  line: 85
+- variable: pwdEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 56
+- variable: tipsBtn
+  type: QPushButton *
+  object_name: TipsBtn
+  accessible_name: TipsBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 57
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 58
+- variable: toggleModeBtn
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: ToggleModeBtn
+  accessible_name: ToggleModeBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebypasswordview.cpp
+  class_name: QPushButton
+  line: 60
+- variable: filePathEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: FilePathEdit
+  accessible_name: FilePathEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+  class_name: QPlainTextEdit
+  line: 64
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/removevaultview/vaultremovebyrecoverykeyview.cpp
+  class_name: QPlainTextEdit
+  line: 65
+- variable: keyFileEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: KeyFileEdit
+  accessible_name: KeyFileEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 62
+- variable: newPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPasswordEdit
+  accessible_name: NewPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 64
+- variable: repeatPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPasswordEdit
+  accessible_name: RepeatPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 65
+- variable: passwordHintEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: PasswordHintEdit
+  accessible_name: PasswordHintEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbykeyfileview.cpp
+  class_name: ''
+  line: 66
+- variable: oldPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: OldPasswordEdit
+  accessible_name: OldPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 58
+- variable: newPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: NewPasswordEdit
+  accessible_name: NewPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 59
+- variable: repeatPasswordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: RepeatPasswordEdit
+  accessible_name: RepeatPasswordEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 60
+- variable: passwordHintEdit
+  type: Dtk::Widget::DLineEdit *
+  object_name: PasswordHintEdit
+  accessible_name: PasswordHintEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/resetpasswordview/resetpasswordbyoldpasswordview.cpp
+  class_name: ''
+  line: 61
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
+  class_name: QPlainTextEdit
+  line: 58
+- variable: filePathEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: FilePathEdit
+  accessible_name: FilePathEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/retrievepasswordview.cpp
+  class_name: ''
+  line: 93
+- variable: passwordEdit
+  type: Dtk::Widget::DPasswordEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+  class_name: ''
+  line: 80
+- variable: tipsButton
+  type: QPushButton *
+  object_name: TipsButton
+  accessible_name: TipsButton
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+  class_name: ''
+  line: 81
+- variable: tooltip
+  type: Dtk::Widget::DToolTip *
+  object_name: AlertTooltip
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/unlockview.cpp
+  class_name: ''
+  line: 84
+- variable: menuPtr
+  type: Dtk::Widget::DMenu *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-workspace/utils/fileviewmenuhelper.cpp
+  class_name: ''
+  line: 35
+- variable: editor
+  type: QLineEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/baseitemdelegate_p.cpp
+  class_name: QLineEdit
+  line: 39
+- variable: edit
+  type: QTextEdit *
+  object_name: ''
+  accessible_name: ''
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/iconitemeditor_p.cpp
+  class_name: QGraphicsOpacityEffect
+  line: 30
+- variable: comboBox
+  type: QComboBox *
+  object_name: ComboBox
+  accessible_name: ComboBox
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+  class_name: QPushButton
+  line: 68
+- variable: renameBtn
+  type: DSuggestButton *
+  object_name: RenameBtn
+  accessible_name: RenameBtn
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/private/renamebar_p.cpp
+  class_name: QPushButton
+  line: 87
+- variable: itemViewParent
+  type: QAbstractItemView *
+  object_name: ''
+  accessible_name: ItemViewParent
+  source_file: src/apps/dde-file-manager-preview/pluginpreviews/pdf-preview/thumbnaildelegate.cpp
+  class_name: ThumbnailDelegate
+  line: 22
+- variable: hideFile
+  type: QCheckBox *
+  object_name: HideFile
+  accessible_name: HideFile
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/basicwidget.cpp
+  class_name: ''
+  line: 189
+- variable: closeButton
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: CloseButton
+  accessible_name: CloseButton
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/closealldialog.cpp
+  class_name: ''
+  line: 52
+- variable: nameEditIcon
+  type: Dtk::Widget::DIconButton *
+  object_name: EditButton
+  accessible_name: NameEditIcon
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+  class_name: ''
+  line: 244
+- variable: checkButton
+  type: DIconButton *
+  object_name: CheckButton
+  accessible_name: CheckButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 59
+- variable: openFileChooseButton
+  type: Dtk::Widget::DCommandLinkButton *
+  object_name: OpenFileChooseButton
+  accessible_name: OpenFileChooseButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 294
+- variable: setToDefaultCheckBox
+  type: QCheckBox *
+  object_name: SetToDefaultCheckBox
+  accessible_name: SetToDefaultCheckBox
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 297
+- variable: cancelButton
+  type: DPushButton *
+  object_name: CancelButton
+  accessible_name: CancelButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 301
+- variable: chooseButton
+  type: DSuggestButton *
+  object_name: ChooseButton
+  accessible_name: ChooseButton
+  source_file: src/plugins/common/dfmplugin-utils/openwith/openwithdialog.cpp
+  class_name: ''
+  line: 304
+- variable: serverComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: ServerComboBox
+  accessible_name: ServerComboBox
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 395
+- variable: schemeComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: SchemeComboBox
+  accessible_name: SchemeComboBox
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 377
+- variable: theAddButton
+  type: Dtk::Widget::DIconButton *
+  object_name: TheAddButton
+  accessible_name: TheAddButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 403
+- variable: collectionServerView
+  type: Dtk::Widget::DListView *
+  object_name: CollectionServerView
+  accessible_name: CollectionServerView
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 433
+- variable: charsetComboBox
+  type: Dtk::Widget::DComboBox *
+  object_name: CharsetComboBox
+  accessible_name: CharsetComboBox
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/dialogs/connecttoserverdialog.cpp
+  class_name: ''
+  line: 421
+- variable: addItemBtn
+  type: Dtk::Widget::DToolButton *
+  object_name: AddItemBtn
+  accessible_name: AddItemBtn
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/customtabsettingwidget.cpp
+  class_name: ''
+  line: 56
+- variable: searchButton
+  type: Dtk::Widget::DIconButton *
+  object_name: SearchButton
+  accessible_name: SearchButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  class_name: ''
+  line: 323
+- variable: advancedButton
+  type: Dtk::Widget::DToolButton *
+  object_name: AdvancedButton
+  accessible_name: AdvancedButton
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  class_name: ''
+  line: 343
+- variable: searchEdit
+  type: Dtk::Widget::DSearchEdit *
+  object_name: SearchEdit
+  accessible_name: SearchEdit
+  source_file: src/plugins/filemanager/dfmplugin-titlebar/views/searcheditwidget.cpp
+  class_name: ''
+  line: 335
+- variable: selectfileSavePathEdit
+  type: Dtk::Widget::DFileChooserEdit *
+  object_name: SelectfileSavePathEdit
+  accessible_name: SelectfileSavePathEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivesavekeyfileview.cpp
+  class_name: ''
+  line: 96
+- variable: startBtn
+  type: Dtk::Widget::DSuggestButton *
+  object_name: StartBtn
+  accessible_name: StartBtn
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/createvaultview/vaultactivestartview.cpp
+  class_name: ''
+  line: 45
+- variable: scaleSlider
+  type: DSlider *
+  object_name: ScaleSlider
+  accessible_name: ScaleSlider
+  source_file: src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
+  class_name: ''
+  line: 117
+qml_elements: []
+transient_elements: []


### PR DESCRIPTION
## Summary

为 AT-SPI 命名基线 expected_names.yaml 模块的交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用。

### Files changed
- `tests/at/spi/expected_names.yaml`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用
- 不修改任何已有代码逻辑，各 PR 相互独立，不影响编译与运行

### 系列说明
本 PR 属于 AT-SPI 控件补全按模块拆分系列之一。完整预期命名基线见 `expected_names.yaml` 补充 PR。

## Summary by Sourcery

Expand the AT-SPI naming baseline to comprehensively track widget object and accessible names across the application.

Bug Fixes:
- Expand the AT-SPI expected-name baseline to cover accessible and object names for interactive controls across file preview, dialogs, file management, desktop, vault, and related plugins.

Enhancements:
- Replace the legacy name-only baseline format with a versioned widget manifest that records widget types, source locations, classes, object names, and accessible names.
- Preserve entries for controls without assigned names so the baseline can identify missing AT-SPI naming coverage.

Tests:
- Update the AT-SPI expected-name test data with the comprehensive widget naming baseline.