### PR TITLE
fix: correct sidebar tree directory setting translations

### DIFF
--- a/translations/dde-file-manager_zh_CN.ts
+++ b/translations/dde-file-manager_zh_CN.ts
@@ -1991,12 +1991,12 @@ You need to upgrade this vault to continue using it.</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp" line="246"/>
         <source>Sidebar tree directory</source>
-        <translation>侧边栏树目录</translation>
+        <translation>侧边栏树形目录</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp" line="248"/>
         <source>Display sidebar disk partitions as a tree structure</source>
-        <translation>以树形结构显示侧边栏磁盘分区</translation>
+        <translation>侧边栏磁盘分区以树形结构显示</translation>
     </message>
     <message>
         <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="25"/>

--- a/translations/dde-file-manager_zh_HK.ts
+++ b/translations/dde-file-manager_zh_HK.ts
@@ -1991,12 +1991,12 @@ You need to upgrade this vault to continue using it.</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp" line="246"/>
         <source>Sidebar tree directory</source>
-        <translation>側邊欄樹目錄</translation>
+        <translation>側邊欄樹形目錄</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp" line="248"/>
         <source>Display sidebar disk partitions as a tree structure</source>
-        <translation>以樹形結構顯示側邊欄磁碟分區</translation>
+        <translation>側邊欄磁碟分區以樹形結構顯示</translation>
     </message>
     <message>
         <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="25"/>

--- a/translations/dde-file-manager_zh_TW.ts
+++ b/translations/dde-file-manager_zh_TW.ts
@@ -1991,12 +1991,12 @@ You need to upgrade this vault to continue using it.</source>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp" line="246"/>
         <source>Sidebar tree directory</source>
-        <translation>側邊欄樹目錄</translation>
+        <translation>側邊欄樹狀目錄</translation>
     </message>
     <message>
         <location filename="../src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp" line="248"/>
         <source>Display sidebar disk partitions as a tree structure</source>
-        <translation>以樹狀結構顯示側邊欄磁碟分區</translation>
+        <translation>側邊欄磁碟分區以樹狀結構顯示</translation>
     </message>
     <message>
         <location filename="../src/dfm-base/shortcut/shortcut.cpp" line="25"/>


### PR DESCRIPTION
## Root Cause Analysis

The file manager settings panel added a new "Sidebar tree directory" group (under the "Sidebar" group, below "Items on sidebar pane") with a checkbox to toggle tree-view display of sidebar disk partitions. This feature was added in commit `db0dedacd8` and only exists on `release/snipe`. The Chinese translations (zh_CN/zh_HK/zh_TW) of the group name and the checkbox text did not match the product spec: the group name was missing the "tree-form" word (e.g. `侧边栏树目录` instead of `侧边栏树形目录`), and the checkbox was verb-first (e.g. `以树形结构显示侧边栏磁盘分区` instead of subject-first `侧边栏磁盘分区以树形结构显示`). The developer (PMS history note) confirmed this is a pure translation issue. Source code logic (group position, default unchecked, control type) is all correct and untouched.

## Fix

Correct the two `<translation>` entries in the three locale `.ts` files (zh_CN/zh_HK/zh_TW) so the group name and checkbox text match the spec: add the missing tree-form word (形/狀) and reorder the checkbox to subject-first. No C++ source, English source strings, `<source>`/`<location>`, group position, or default value is changed — a pure translation-text fix.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- This change only edits translation text in `.ts` resource files (XML). No C++ logic, no function signatures, no callers (`References=0`); `.ts` files are loaded by the Qt translation system at runtime by locale and are not invoked by code. The two strings were introduced by the new feature's initial translations (commit `db0dedacd8`) and re-touched only by a translation regen (`a174c1425`); they are not the product of any historical bug fix, so this change does not revert a prior fix.
- No affected callers (translation resources have no code callers).

### Business Impact Scope

Affected: the file manager settings → Sidebar group → "Sidebar tree directory" subgroup display text in zh_CN/zh_HK/zh_TW. User-visible change: the group label and checkbox text now read as specified. No other user scenario is affected; the tree-view toggle behavior, group position, and default (unchecked) are unchanged.

### Verification Suggestion

Under zh_CN, open file manager settings and verify the group shows `侧边栏树形目录` with checkbox `侧边栏磁盘分区以树形结构显示` (unchecked by default); toggle it and confirm sidebar partitions switch between tree/list views. Repeat for zh_HK/zh_TW to confirm locale-consistent wording.

---

## 根因分析

文管设置面板在"侧边栏"分组下（"侧边栏显示项目"下方）新增了"侧边栏树形目录"分组及复选项，用于切换侧边栏磁盘分区的树视图显示。该功能由 commit `db0dedacd8` 新增，仅存在于 `release/snipe`。其分组名与复选项的中文译文（zh_CN/zh_HK/zh_TW）与产品需求文案不符：分组名漏掉"树形/树狀"用词（如「侧边栏树目录」应为「侧边栏树形目录」），复选项为谓语前置语序（如「以树形结构显示侧边栏磁盘分区」应为主语前置「侧边栏磁盘分区以树形结构显示」）。开发人员在 PMS 历史备注中确认这是纯翻译问题。源码逻辑（分组位置、默认不勾选、控件类型）均正确，未改动。

## 修复方案

修正三份语言 `.ts` 文件（zh_CN/zh_HK/zh_TW）中两条 `<translation>` 译文，使分组名与复选项文案符合需求：补上"形/狀"用词、复选项改为主语前置语序。不动 C++ 源码、英文源串、`<source>`/`<location>`、分组位置与默认值——纯翻译文案修复。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 本次改动仅修改 `.ts` 翻译资源文件（XML）中的译文文本，不涉及任何 C++ 逻辑、函数签名、调用者（`References=0`）；`.ts` 文件由 Qt 翻译系统运行时按 locale 加载，不被代码调用。这两条字符串是新增功能初版译文（commit `db0dedacd8`）引入，其后仅被翻译重生成 commit `a174c1425` 再次落盘，并非任何历史 bug 修复的产物，本修复不会撤销历史修复。
- 无受影响调用者（翻译资源无代码调用者）。

### 业务影响范围

受影响：文管设置 → 侧边栏分组 → "侧边栏树形目录"子分组在 zh_CN/zh_HK/zh_TW 下的显示文案。面向用户的变化：分组名与复选项文案改为符合需求。其他用户场景不受影响；树视图开关行为、分组位置、默认值（不勾选）均未改变。

### 验证建议

在 zh_CN 环境打开文管设置，核对分组显示为「侧边栏树形目录」、复选项为「侧边栏磁盘分区以树形结构显示」且默认不勾选；切换复选项确认侧边栏分区在树/列表视图间正常切换。在 zh_HK/zh_TW 环境重复核对，确认语种内文案一致。

PMS: BUG-374117

## Summary by Sourcery

Bug Fixes:
- Correct Chinese sidebar tree directory translations for Simplified Chinese, Hong Kong Chinese, and Traditional Chinese locales.