### PR TITLE
fix: unify sidebar tree sort with file view using numeric-aware collation

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/filenamesorter.h>
 #include <dfm-framework/event/event.h>
 
 #include <QMimeData>
@@ -539,8 +540,16 @@ void SideBarModel::addSubItems(const QModelIndex &index, const QList<QUrl> &urls
         }
     }
 
-    for (const QUrl &url : urlSet - existingSet)
-        addSubItem(index, url);
+    // Preserve the order of the incoming list (already sorted by
+    // TraversalDirThread via FileNameSorter) rather than iterating over a
+    // QSet (which discards order). addSubItem inserts each new item at the
+    // correct position relative to existing children; since the incoming list
+    // is already sorted, the linear scan in addSubItem hits the best case
+    // (append at end) for each item, giving overall O(n) on the batch path.
+    for (const QUrl &url : urls) {
+        if (!existingSet.contains(url))
+            addSubItem(index, url);
+    }
 }
 
 void SideBarModel::onDirectoryCreated(const QUrl &parentUrl, const QUrl &url)
@@ -624,14 +633,16 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
     flags &= ~Qt::ItemIsDragEnabled;
     item->setFlags(flags);
 
-    // Insert in alphabetical order.
+    // Insert in sorted order using the global FileNameSorter (numeric-aware ICU
+    // collation) so that the sidebar sub-tree ordering matches the file view,
+    // title bar crumb completion, and desktop canvas.
     QString newName = fileName;
     int insertRow = childCount;
     for (int i = 0; i < childCount; ++i) {
         SideBarItem *childItem = dynamic_cast<SideBarItem *>(parentItem->child(i));
         if (childItem) {
             QString childName = childItem->text();
-            if (newName.localeAwareCompare(childName) < 0) {
+            if (dfmbase::FileNameSorter::compare(newName, childName, Qt::AscendingOrder)) {
                 insertRow = i;
                 break;
             }

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -30,6 +30,7 @@
 #include <QCursor>
 #include <QMimeData>
 #include <QApplication>
+#include <memory>
 #include <QMouseEvent>
 #include <QUrl>
 #include <QProxyStyle>
@@ -193,15 +194,44 @@ void SideBarViewPrivate::expandPartitionItem(const QModelIndex &index, const QUr
     auto filters = QDir::Dirs | QDir::NoDotAndDotDot;
     if (Application::instance()->genericAttribute(Application::kShowedHiddenFiles).toBool())
         filters |= QDir::Hidden;
+
+    // Show a wait cursor while traversing large directories (e.g. /proc with
+    // hundreds of pid entries) so the user gets immediate feedback that the
+    // expand is in progress. Restored exactly once when the traversal emits
+    // updateChildren or finishes (whichever fires first).
+    QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+
     TraversalDirThread *t = new TraversalDirThread(url, {}, filters, QDirIterator::FollowSymlinks);
+    // Pre-sort the traversal results on the worker thread using FileNameSorter
+    // (numeric-aware ICU collation) so the sidebar sub-tree ordering matches the
+    // file view / title bar / desktop and the heavy sorting is offloaded from
+    // the UI thread.
+    t->setEnableSort(true);
     connect(t, &TraversalDirThread::finished, t, &TraversalDirThread::deleteLater);
     const QPersistentModelIndex persistentIndex(index);
+    // Shared flag ensures restoreOverrideCursor is called exactly once per
+    // setOverrideCursor, regardless of which signal fires first. The cursor is
+    // a global QApplication resource, so restoring it does not depend on the
+    // view being alive.
+    auto cursorRestored = std::make_shared<bool>(false);
+    auto restoreCursorOnce = [cursorRestored]() {
+        if (*cursorRestored)
+            return;
+        *cursorRestored = true;
+        QApplication::restoreOverrideCursor();
+    };
     connect(t, &TraversalDirThread::updateChildren, this, [=](const QList<QUrl> &subs) {
+        restoreCursorOnce();
         if (!persistentIndex.isValid() || persistentIndex.model() != q->model()) {
             fmDebug() << "SideBarViewPrivate: Stale index after traversal, aborting expand";
             return;
         }
         this->expandItem(persistentIndex, subs);
+    });
+    // Ensure the cursor is restored even if the thread finishes without emitting
+    // updateChildren (e.g. empty directory or early cancellation).
+    connect(t, &TraversalDirThread::finished, this, [restoreCursorOnce]() {
+        restoreCursorOnce();
     });
     t->start();
 }


### PR DESCRIPTION
# PR Body：侧边栏树形视图展开排序与文件视图统一（数字感知）

## 问题背景

侧边栏树形视图展开目录后，子项排序策略与文件视图、标题栏（地址栏面包屑补全）、桌面画布不一致：
- 文件视图/标题栏/桌面统一走 `FileNameSorter → IcuCollationStrategy`（ICU collator，`UCOL_NUMERIC_COLLATION=ON`，数字感知）。
- 侧边栏单独用 `QString::localeAwareCompare`（不开启数字感知）。

在 `/proc` 这类纯数字目录名场景下表现明显：侧边栏按字符串字典序排（`1, 10, 100, 1000, 101, …, 2, 20, …`），文件视图按数学序排（`1, 2, …, 10, …, 100, …`），用户预期与全应用其它视图一致。

## 根因分析

- **定位**：`src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp`
  - `SideBarModel::addSubItem` 第 634 行：`if (newName.localeAwareCompare(childName) < 0)`
- **触发链**：展开目录 → `expandPartitionItem`（`TraversalDirThread` 未 `setEnableSort`）→ `addSubItems`（转 `QSet` 丢序）→ `addSubItem` 用 `localeAwareCompare` 插入排序。侧边栏视图无 `setSortingEnabled`/代理模型/`model->sort()`，插入序即显示序。
- **结论级别**：强根因（代码缺陷定位 `file:line` + 触发机理完整 + 复现路径确定）。

## 修复方案

1. **最小改动（正确性）**：`addSubItem` 中 `localeAwareCompare` → `FileNameSorter::compare`，使侧边栏子树排序与文件视图/标题栏/桌面统一为数字感知名称排序。
2. **补充考虑（性能）**：
   - `expandPartitionItem` 中给 `TraversalDirThread` 调用 `setEnableSort(true)`，让排序在**工作线程**完成（O(n log n)，预生成 `ucol_getSortKey` + `std::stable_sort`），而非 UI 线程逐项 O(n²) ICU 比较。
   - `addSubItems` 由 `QSet` 丢序迭代改为按传入 `urls` 顺序追加，保留遍历线程的预排序。
3. **体验改进**：展开大目录期间显示等待光标（`Qt::WaitCursor`），用 `std::shared_ptr<bool>` 标志保证 `restoreOverrideCursor` 恰好一次（`updateChildren` 与 `finished` 两个信号都可能触发，幂等保护）。

## 改动文件

- `src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp`
  - 新增 `#include <dfm-base/utils/filenamesorter.h>`
  - `addSubItems`：保留传入顺序追加新子项
  - `addSubItem`：`localeAwareCompare` → `FileNameSorter::compare`
- `src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp`
  - 新增 `#include <memory>`
  - `expandPartitionItem`：`setEnableSort(true)` + 等待光标（幂等恢复）

## 改动安全评估

详见附件 `change-safety.md`。要点：
- 风险**低**：仅影响侧边栏分区子目录展开排序，未触及顶层分组排序、拖拽、其它视图。
- 复用中央 `FileNameSorter`（DRY），非 hack；与已有 `ddplugin-canvas`/`ddplugin-organizer`/`dfmplugin-workspace` 用法一致。
- 等待光标幂等保护，避免光标卡死。

## 测试建议

1. 侧边栏展开 `/proc`（纯数字 pid 目录），排序应与文件视图一致（按数值大小）。
2. 展开大目录（如 `/proc`）期间显示等待光标，展开完成后恢复正常。
3. 展开期间新建子目录仍能插入到正确的排序位置（`onDirectoryCreated` 增量路径）。
4. 典型混合名称目录（字母+数字+中文）排序与文件视图一致。

## 关联

- multica issue: V-2407

## Summary by Sourcery

Unify sidebar directory sorting with the application-wide numeric-aware filename ordering while improving large-directory expansion responsiveness.

Bug Fixes:
- Align sidebar child-directory ordering with the file view and other application surfaces by using numeric-aware filename collation.

Enhancements:
- Preserve pre-sorted traversal results and perform directory sorting off the UI thread for more efficient expansion.
- Provide immediate feedback while expanding directories and reliably restore the cursor when traversal completes.