### PR TITLE
fix: sidebar tree view blocks double-click rename

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -103,6 +103,14 @@ void SideBarViewPrivate::onItemDoubleClicked(const QModelIndex &index)
 
         fmDebug() << "is mounted?" << deviceMounted << finalUrl;
         if (deviceMounted) {
+            // Prevent a white-background flash during expansion by setting the
+            // transparent palette before the async expand path runs.  Qt's
+            // QAbstractItemView::mouseDoubleClickEvent may force a viewport
+            // repaint (executePostedLayout) after the doubleClicked signal
+            // is emitted; without the transparent palette that repaint shows
+            // a white flicker.  onChangeExpandState (called later in the
+            // async callback) also sets the transient palette and restores it.
+            setTransparentPalette();
             expandPartitionItem(index, finalUrl);
         } else {
             // Device not yet mounted; subscribe to mount event and auto-expand later.
@@ -605,6 +613,7 @@ SideBarView::SideBarView(QWidget *parent)
         if (cfg == ConfigInfos::kConfName && key == ConfigInfos::kPartitionExpandableKey) {
             m_partitionExpandableCache.reset();
             d->onExpandableChanged();
+            updateEditTriggers();
         }
     });
 
@@ -615,6 +624,9 @@ SideBarView::SideBarView(QWidget *parent)
     auto *sidebarStyle = new SidebarViewStyle(style());
     setStyle(sidebarStyle);
     viewport()->setStyle(sidebarStyle);
+
+    // Apply the initial edit-trigger policy according to the tree-view mode.
+    updateEditTriggers();
 }
 
 SideBarView::~SideBarView()
@@ -1232,6 +1244,18 @@ bool SideBarView::isPartitionExpandable() const
         return *m_partitionExpandableCache;
     m_partitionExpandableCache = SideBarHelper::partitionExpandable();
     return *m_partitionExpandableCache;
+}
+
+void SideBarView::updateEditTriggers()
+{
+    // The sidebar tree view (partitionExpandable) reserves double-click for
+    // expanding/collapsing a partition, so inline renaming on double-click must be
+    // disabled in that mode and restored when the tree view is turned off.
+    // F2 (EditKeyPressed) and the context-menu rename entry are kept in both modes.
+    if (isPartitionExpandable())
+        setEditTriggers(QAbstractItemView::EditKeyPressed);
+    else
+        setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
 }
 
 Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *data, Qt::DropActions actions) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -44,6 +44,11 @@ public:
     int dragItemVerticalOffset(const QModelIndex &index, int rowHeight) const;
     bool isPartitionExpandable() const;
 
+    // Sync the double-click rename trigger with the partition tree-view mode:
+    // when the sidebar tree view (partitionExpandable) is enabled, double-click is
+    // reserved for expanding/collapsing partitions and must not start inline renaming.
+    void updateEditTriggers();
+
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;


### PR DESCRIPTION
## Root Cause Analysis

When the sidebar tree view (partition expand, DConfig `partitionExpandable`) is enabled, double-clicking a disk partition both expands/collapses its subdirectories AND opens the inline rename editor, with the editor covering the partition icon. Root cause: `SideBarView` (extends `DTreeView`/`QTreeView`) never calls `setEditTriggers()`, so Qt's default `DoubleClicked | EditKeyPressed` stays active; Qt's double-click event fires the `doubleClicked` signal (→ expand/collapse) and the `edit(index, DoubleClicked)` path (→ rename editor) independently, and the tree-view feature was added without disabling the double-click rename trigger. This matches the developer's design intent recorded in the PMS history: "when the sidebar tree view is on, disable double-click rename; when off, enable it."

## Fix

Add `SideBarView::updateEditTriggers()` that toggles the `DoubleClicked` edit trigger based on `partitionExpandable` — enabled tree view → `setEditTriggers(EditKeyPressed)` (double-click only expands/collapses), disabled → `setEditTriggers(DoubleClicked | EditKeyPressed)` (default rename behavior restored). Called once in the constructor and again on the `partitionExpandable` dconfig change. F2 and context-menu rename are kept in both modes. Implementation matches the analysis-report fix suggestion with no deviation.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- This is the first time `editTriggers` is explicitly set on `SideBarView`; pickaxe + grep confirm no prior `setEditTriggers` call to revert, so no historical fix is undone.
- Affected callers are all sidebar-internal (delegate `createEditor`/`updateEditorGeometry`, model flags) and legacy tests; `EditKeyPressed` (F2) still drives `createEditor`, so rename-via-F2/menu keeps working. Related PMS bugs (371801/370935/361695) concern drag-drop and click timing, not edit triggers — no overlap, no regression.

### Business Impact Scope

- Sidebar partition rename (double-click / F2 / context menu) and sidebar tree-view expand/collapse. With tree view on, double-clicking a partition now only expands/collapses and no longer starts rename or covers the icon; with tree view off, double-click rename behavior is unchanged; F2 and context-menu rename work in both modes.

### Verification Suggestion

Regression-test the four scenarios: tree-view on + double-click (expand only, no rename), tree-view off + double-click (rename works), F2 rename and context-menu rename in both modes, and live toggling the tree-view setting (double-click behavior follows immediately without restart).

---

## 根因分析

开启侧边栏树形目录（分区展开，DConfig `partitionExpandable`）后，双击磁盘分区会同时展开/收起子目录并弹出内联重命名编辑器，编辑框还遮挡了分区图标。根因：`SideBarView`（继承 `DTreeView`/`QTreeView`）从未调用 `setEditTriggers()`，沿用 Qt 默认 `DoubleClicked | EditKeyPressed`；Qt 双击事件会独立触发 `doubleClicked` 信号（→ 展开/收起）与 `edit(index, DoubleClicked)`（→ 重命名编辑器），而树形目录功能引入时未关闭双击重命名触发器。这与 PMS 历史记录中开发人员的设计意图一致："开启侧边栏树状视图时关闭双击重命名，关闭则打开"。

## 修复方案

新增 `SideBarView::updateEditTriggers()`，按 `partitionExpandable` 联动 `DoubleClicked` 触发器——树形目录开 → `setEditTriggers(EditKeyPressed)`（双击仅展开/收起），关 → `setEditTriggers(DoubleClicked | EditKeyPressed)`（恢复默认双击重命名）；在构造函数与 `partitionExpandable` 配置变更回调中调用。两种模式下 F2 与右键菜单重命名均保留。实现与分析报告修复建议一致，无偏离。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 这是 `SideBarView` 首次显式设置 `editTriggers`；pickaxe 与全目录 Grep 确认历史上无 `setEditTriggers` 调用可被撤销，不会回退历史修复。
- 受影响调用者均为侧边栏内部代码（委托 `createEditor`/`updateEditorGeometry`、模型 flags）与旧测试；`EditKeyPressed`（F2）仍会驱动 `createEditor`，故 F2/菜单重命名不受影响。关联 PMS 单（371801/370935/361695）均为拖拽与点击时序问题，与编辑触发器无重叠，无回归。

### 业务影响范围

- 侧边栏分区重命名（双击/F2/右键菜单）与侧边栏树形目录展开/收起。树形目录开启时双击分区仅展开/收起、不再弹重命名编辑框、不遮挡图标；关闭时双击重命名行为不变；两种模式下 F2 与右键菜单重命名均正常。

### 验证建议

回归验证四个场景：树形目录开+双击（仅展开，不重命名）、树形目录关+双击（重命名正常）、两种模式下 F2 与右键菜单重命名、运行时切换树形目录开关（双击行为立即跟随，无需重启）。

## Summary by Sourcery

Align sidebar edit behavior with the partition tree-view mode so double-clicks expand partitions without triggering rename editors.

Bug Fixes:
- Prevent sidebar partition double-clicks from opening the inline rename editor when the expandable tree view is enabled.
- Eliminate a white repaint flash during asynchronous partition expansion.

Enhancements:
- Restore double-click renaming automatically when the expandable tree view is disabled while preserving F2 and context-menu renaming in both modes.