### PR TITLE
perf: add TimezoneWatcher to cache TZ and eliminate redundant stat(/etc/localtime)

### DIFF
--- a/src/apps/dde-file-dialog-wayland/main.cpp
+++ b/src/apps/dde-file-dialog-wayland/main.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/signalhandler.h>
+#include <dfm-base/utils/timezonewatcher.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -66,6 +67,9 @@ static void initEnv()
     if (qEnvironmentVariable("CLUTTER_IM_MODULE") == QStringLiteral("fcitx")) {
         setenv("QT_IM_MODULE", "fcitx", 1);
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static bool singlePluginLoad(const QString &pluginName, const QString &libName)

--- a/src/apps/dde-file-dialog-x11/main.cpp
+++ b/src/apps/dde-file-dialog-x11/main.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/signalhandler.h>
+#include <dfm-base/utils/timezonewatcher.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -63,6 +64,9 @@ static void initEnv()
     if (qEnvironmentVariable("CLUTTER_IM_MODULE") == QStringLiteral("fcitx")) {
         setenv("QT_IM_MODULE", "fcitx", 1);
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static bool singlePluginLoad(const QString &pluginName, const QString &libName)

--- a/src/apps/dde-file-dialog/main.cpp
+++ b/src/apps/dde-file-dialog/main.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/signalhandler.h>
+#include <dfm-base/utils/timezonewatcher.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -63,6 +64,9 @@ static void initEnv()
     if (qEnvironmentVariable("CLUTTER_IM_MODULE") == QStringLiteral("fcitx")) {
         setenv("QT_IM_MODULE", "fcitx", 1);
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static bool singlePluginLoad(const QString &pluginName, const QString &libName)

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -15,6 +15,7 @@
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/utils/signalhandler.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/utils/timezonewatcher.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -236,6 +237,7 @@ static bool pluginsLoad()
     return true;
 }
 
+
 static void initEnv()
 {
     // for qt5platform-plugins load DPlatformIntegration or DPlatformIntegrationParent
@@ -255,6 +257,9 @@ static void initEnv()
         }
         setEnvForRoot();
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static void initLogFilter()

--- a/src/dfm-base/utils/timezonewatcher.cpp
+++ b/src/dfm-base/utils/timezonewatcher.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "timezonewatcher.h"
+#include "universalutils.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QDBusConnection>
+#include <QDebug>
+
+// glibc timezone functions
+extern "C" {
+#include <ctime>
+}
+
+namespace dfmbase {
+
+TimezoneWatcher::TimezoneWatcher(QObject *parent)
+    : QObject(parent),
+      m_initialized(false)
+{
+}
+
+TimezoneWatcher::~TimezoneWatcher()
+{
+}
+
+TimezoneWatcher &TimezoneWatcher::instance()
+{
+    static TimezoneWatcher w;
+    return w;
+}
+
+void TimezoneWatcher::init()
+{
+    if (m_initialized)
+        return;
+
+    // 1. Initialize timezone
+    readAndSetTimezone();
+
+    // 2. Connect D-Bus signals
+    connectDbusSignals();
+
+    m_initialized = true;
+
+    qDebug() << "TimezoneWatcher initialized, timezone:" << m_currentTimezone;
+}
+
+QString TimezoneWatcher::currentTimezone() const
+{
+    return m_currentTimezone;
+}
+
+bool TimezoneWatcher::isInitialized() const
+{
+    return m_initialized;
+}
+
+void TimezoneWatcher::readAndSetTimezone()
+{
+    QString tz;
+
+    // 1. Try /etc/timezone first
+    tz = readTimezoneFromEtcTimezone();
+
+    // 2. Fallback: /etc/localtime symlink
+    if (tz.isEmpty()) {
+        tz = readTimezoneFromLocaltime();
+    }
+
+    // 3. Final fallback to UTC
+    if (tz.isEmpty())
+        tz = QStringLiteral("UTC");
+
+    // 4. Update if changed
+    if (tz != m_currentTimezone) {
+        m_currentTimezone = tz;
+        qputenv("TZ", tz.toUtf8());
+        tzset();  // Apply immediately
+        emit timezoneChanged(tz);
+        qInfo() << "Timezone updated to:" << tz;
+    }
+}
+
+QString TimezoneWatcher::readTimezoneFromEtcTimezone()
+{
+    QFile tzFile(QStringLiteral("/etc/timezone"));
+    if (tzFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QString tz = QString::fromUtf8(tzFile.readAll()).trimmed();
+        if (!tz.isEmpty())
+            return tz;
+    }
+    return QString();
+}
+
+QString TimezoneWatcher::readTimezoneFromLocaltime()
+{
+    QFileInfo info(QStringLiteral("/etc/localtime"));
+    if (info.isSymLink()) {
+        QString path = info.symLinkTarget();
+        int pos = path.lastIndexOf(QStringLiteral("/zoneinfo/"));
+        if (pos >= 0)
+            return path.mid(pos + 10);
+    }
+    return QString();
+}
+
+void TimezoneWatcher::connectDbusSignals()
+{
+    // Check if timedate1 service is available before connecting
+    if (!UniversalUtils::checkDbusService(QStringLiteral("org.freedesktop.timedate1")))
+        return;
+
+    // Connect directly to org.freedesktop.timedate1 PropertiesChanged signal
+    // Note: timedate1 may not be running at init time, signal connection will be lazy
+    // D-Bus will deliver matched signals automatically once the service appears
+    QDBusConnection::systemBus().connect(
+                QStringLiteral("org.freedesktop.timedate1"),
+                QStringLiteral("/org/freedesktop/timedate1"),
+                QStringLiteral("org.freedesktop.DBus.Properties"),
+                QStringLiteral("PropertiesChanged"),
+                this,
+                SLOT(onPropertiesChanged(QString,QVariantMap,QStringList)));
+}
+
+void TimezoneWatcher::onPropertiesChanged(const QString &interface,
+                                      const QVariantMap &changed,
+                                      const QStringList &invalidated)
+{
+    Q_UNUSED(invalidated);
+
+    // Only handle org.freedesktop.timedate1 interface
+    if (interface == QStringLiteral("org.freedesktop.timedate1")) {
+        // Check for Timezone property change
+        if (changed.contains(QStringLiteral("Timezone")) || changed.isEmpty()) {
+            qInfo() << "Timezone D-Bus properties changed, re-reading timezone";
+            readAndSetTimezone();
+        }
+    }
+}
+
+}   // namespace dfmbase

--- a/src/dfm-base/utils/timezonewatcher.h
+++ b/src/dfm-base/utils/timezonewatcher.h
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TIMEZONEWATCHER_H
+#define TIMEZONEWATCHER_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QObject>
+#include <QString>
+#include <QVariantMap>
+#include <QStringList>
+
+namespace dfmbase {
+
+/*!
+ * \class TimezoneWatcher
+ * \brief 时区监视器，用于监听系统时区变化并自动更新 TZ 环境变量
+ *
+ * 解决 Qt QDateTime::currentDateTime() 每次调用都会 stat("/etc/localtime") 的问题
+ *
+ * 使用方法:
+ *   TimezoneWatcher::instance().init();
+ *
+ * 监视机制:
+ *   - D-Bus: org.freedesktop.timedate1 PropertiesChanged 信号（服务启动后自动生效）
+ *   - 文件系统 fallback: /etc/timezone 和 /etc/localtime
+ *   - 最终 fallback: UTC
+ */
+class TimezoneWatcher : public QObject
+{
+    Q_OBJECT
+
+public:
+    /*! 获取单例实例
+     * \return TimezoneWatcher 实例引用
+     */
+    static TimezoneWatcher &instance();
+
+    /*! 初始化时区信息
+     * 在应用程序启动时调用，设置 TZ 环境变量并启动监视
+     */
+    void init();
+
+    /*! 获取当前时区
+     * \return 当前时区字符串，如 "Asia/Shanghai"
+     */
+    QString currentTimezone() const;
+
+    /*! 是否已初始化
+     * \return true 表示已成功初始化
+     */
+    bool isInitialized() const;
+
+Q_SIGNALS:
+    /*! 时区变化信号
+     * \param timezone 新的时区字符串
+     */
+    void timezoneChanged(const QString &timezone);
+
+private Q_SLOTS:
+    /*! 处理 D-Bus PropertiesChanged 信号
+     * \param interface D-Bus 接口名
+     * \param changed 变化的属性
+     * \param invalidated 无效的属性列表
+     */
+    void onPropertiesChanged(const QString &interface,
+                          const QVariantMap &changed,
+                          const QStringList &invalidated);
+
+private:
+    explicit TimezoneWatcher(QObject *parent = nullptr);
+    virtual ~TimezoneWatcher();
+
+    /*! 读取时区信息并设置 TZ 环境变量
+     * 优先从 /etc/timezone 读取，回退到 /etc/localtime 符号链接，最终 fallback 到 UTC
+     */
+    void readAndSetTimezone();
+
+    /*! 读取 /etc/timezone 文件
+     * \return 时区字符串，失败返回空
+     */
+    QString readTimezoneFromEtcTimezone();
+
+    /*! 从 /etc/localtime 符号链接读取时区
+     * \return 时区字符串，失败返回空
+     */
+    QString readTimezoneFromLocaltime();
+
+    /*! 连接到 D-Bus 信号
+     */
+    void connectDbusSignals();
+
+private:
+    QString m_currentTimezone;
+    bool m_initialized;
+};
+
+}   // namespace dfmbase
+
+#endif   // TIMEZONEWATCHER_H


### PR DESCRIPTION
Add TimezoneWatcher singleton that reads timezone from /etc/timezone or /etc/localtime at startup, sets TZ env var, and listens for changes via org.freedesktop.timedate1 D-Bus PropertiesChanged signal. Removes standalone initTimezoneCaching.

添加TimezoneWatcher单例类，启动时从/etc/timezone或/etc/localtime 读取时区并设置TZ环境变量，通过D-Bus信号监听时区变化，
移除独立的initTimezoneCaching函数。

Log: 添加TimezoneWatcher时区缓存，消除冗余stat调用
Task: https://pms.uniontech.com/task-view-391003.html (cherry picked from commit ec79d289840b4a6d49e838f3d97c0fbd1c67f971)

## Summary by Sourcery

Centralize timezone initialization and change monitoring to reduce redundant system timezone lookups across applications.

New Features:
- Add a singleton timezone watcher that initializes the process timezone and tracks system timezone changes.

Bug Fixes:
- Avoid repeated timezone filesystem checks by caching the active timezone in the TZ environment variable.

Enhancements:
- Initialize timezone monitoring across the file manager and file dialog applications.
- Provide fallback timezone detection from /etc/timezone, /etc/localtime, and UTC.