### PR TITLE
fix: ensure sidebar directory display matches workspace view

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -22,6 +22,7 @@
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
 #include <dfm-base/mimetype/dmimedatabase.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
@@ -369,6 +370,39 @@ bool FileUtils::isSameFile(const QString &path1, const QString &path2)
 bool FileUtils::isCdRomDevice(const QUrl &url)
 {
     return DFMIO::DFMUtils::devicePathFromUrl(url).startsWith("/dev/sr");
+}
+
+bool FileUtils::isDefaultHiddenFile(const QUrl &fileUrl)
+{
+    static QSet<QUrl> defaultHiddenUrls;
+    static QMutex mutex;
+    static bool initialized = false;
+
+    QMutexLocker locker(&mutex);
+    if (!initialized) {
+        using namespace GlobalServerDefines;
+        const auto &systemBlks = DevProxyMng->getAllBlockIds(
+                DeviceQueryOption::kSystem | DeviceQueryOption::kMounted);
+        for (const auto &blk : systemBlks) {
+            auto blkInfo = DevProxyMng->queryBlockInfo(blk);
+            const QStringList &mountPoints =
+                    blkInfo.value(DeviceProperty::kMountPoints).toStringList();
+            for (const auto &mpt : mountPoints) {
+                QUrl rootUrl = QUrl::fromLocalFile(
+                        mpt + (mpt == QStringLiteral("/") ? QStringLiteral("root")
+                                                           : QStringLiteral("/root")));
+                QUrl lostFoundUrl = QUrl::fromLocalFile(
+                        mpt + (mpt == QStringLiteral("/")
+                                       ? QStringLiteral("lost+found")
+                                       : QStringLiteral("/lost+found")));
+                defaultHiddenUrls.insert(rootUrl);
+                defaultHiddenUrls.insert(lostFoundUrl);
+            }
+        }
+        initialized = true;
+    }
+
+    return defaultHiddenUrls.contains(fileUrl);
 }
 
 bool FileUtils::trashIsEmpty()

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -55,6 +55,7 @@ public:
                            const Global::CreateFileInfoType infoCache = Global::CreateFileInfoType::kCreateFileInfoAuto);
     static bool isSameFile(const QString &path1, const QString &path2);
     static bool isCdRomDevice(const QUrl &url);
+    static bool isDefaultHiddenFile(const QUrl &fileUrl);
     static bool trashIsEmpty();
     static TrashEmptyState trashEmptyState();
     static void setTrashEmptyState(TrashEmptyState state);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/utils/universalutils.h>
+#include <dfm-base/utils/fileutils.h>
 #include <dfm-framework/event/event.h>
 
 #include <QMimeData>
@@ -589,6 +590,13 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
         return;
     }
 
+    // /mount-point/root, /mount-point/lost+found should be treated as hidden files.
+    if (!Application::instance()->genericAttribute(dfmbase::Application::kShowedHiddenFiles).toBool()
+        && FileUtils::isDefaultHiddenFile(url)) {
+        fmInfo() << "Default hidden file skipped in sidebar" << url;
+        return;
+    }
+
     SideBarItem *parentItem = itemFromIndex(index);
     if (!parentItem) {
         fmDebug() << "Failed to get parent item from index";
@@ -604,10 +612,10 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
     }
 
     QString group = parentItem->group();
-    QString fileName = info ? info->fileName() : "Unknown";
+    QString displayName = info ? info->displayOf(FileInfo::DisplayInfoType::kFileDisplayName) : "Unknown";
     QIcon folderIcon = QIcon::fromTheme("folder");
 
-    SideBarItem *item = new SideBarItem(folderIcon, fileName, group, url);
+    SideBarItem *item = new SideBarItem(folderIcon, displayName, group, url);
     if (!item) {
         fmDebug() << "Failed to create new sidebar item";
         return;
@@ -625,7 +633,7 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
     item->setFlags(flags);
 
     // Insert in alphabetical order.
-    QString newName = fileName;
+    QString newName = displayName;
     int insertRow = childCount;
     for (int i = 0; i < childCount; ++i) {
         SideBarItem *childItem = dynamic_cast<SideBarItem *>(parentItem->child(i));

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1936,21 +1936,7 @@ bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool by
 
 bool FileSortWorker::isDefaultHiddenFile(const QUrl &fileUrl)
 {
-    static DThreadList<QUrl> defaultHiddenUrls;
-    static std::once_flag flg;
-    std::call_once(flg, [&] {
-        using namespace GlobalServerDefines;
-        const auto &systemBlks = DevProxyMng->getAllBlockIds(DeviceQueryOption::kSystem | DeviceQueryOption::kMounted);
-        for (const auto &blk : systemBlks) {
-            auto blkInfo = DevProxyMng->queryBlockInfo(blk);
-            const QStringList &mountPoints = blkInfo.value(DeviceProperty::kMountPoints).toStringList();
-            for (const auto &mpt : mountPoints) {
-                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
-                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
-            }
-        }
-    });
-    return defaultHiddenUrls.containsByLock(fileUrl);
+    return FileUtils::isDefaultHiddenFile(fileUrl);
 }
 
 QUrl FileSortWorker::makeParentUrl(const QUrl &url)


### PR DESCRIPTION
## Root Cause Analysis

The sidebar tree view's `addSubItem` method had two defects causing directory listing inconsistency with the workspace view: (1) it only filtered `.`-prefixed hidden files but missed default hidden directories (`lost+found` and `root` under system block device mount points) that the workspace filters via `FileSortWorker::isDefaultHiddenFile()`; (2) it used `info->fileName()` (raw filename) instead of `info->displayOf(kFileDisplayName)` which provides XDG directory alias translations (e.g., Desktop→桌面) and Home directory display name (主目录).

Key evidence: `sidebarmodel.cpp:578-634` (addSubItem missing checks), `filesortworker.cpp:1922-1927` (workspace's isDefaultHiddenFile check), `syncfileinfo.cpp:836-849` (fileDisplayName with SystemPathUtil translation).

## Fix

Extracted `isDefaultHiddenFile` logic from `FileSortWorker` into a shared `FileUtils::isDefaultHiddenFile()` utility method (with thread-safe lazy initialization using QMutex+QSet). Modified `SideBarModel::addSubItem` to call this shared method for filtering default hidden directories, and replaced `info->fileName()` with `info->displayOf(FileInfo::DisplayInfoType::kFileDisplayName)` for proper XDG alias translation. `FileSortWorker::isDefaultHiddenFile` now delegates to the shared utility (behavior-preserving refactor).

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- New static method added to FileUtils — no existing API changes, no signature modifications, no public member variable changes
- `FileSortWorker::isDefaultHiddenFile` refactored to delegate to shared utility — behavior-preserving, no callers affected
- `SideBarModel::addSubItem` is sidebar-internal, no external callers

### Business Impact Scope

Affected modules: (1) Sidebar tree view — directory listing now filters `lost+found`/`root` and displays translated XDG names; (2) Workspace file view — no behavioral change (implementation refactored to use shared utility). User scenarios: users expanding disk partitions in the sidebar will see directory listings consistent with the workspace view.

### Verification Suggestion

On dual-disk systems, expand data disk in sidebar and compare directory listing with workspace view — verify `lost+found` is hidden, XDG directories show translated names, and Home shows "主目录". Regression: confirm workspace file view filtering is unchanged.

---

## 根因分析

侧边栏树形视图的 `addSubItem` 方法存在两处缺陷导致目录列表与工作区不一致：(1) 仅过滤 `.` 开头的隐藏文件，遗漏了工作区通过 `FileSortWorker::isDefaultHiddenFile()` 过滤的默认隐藏目录（系统块设备挂载点下的 `lost+found` 和 `root`）；(2) 使用 `info->fileName()`（原始文件名）而非 `info->displayOf(kFileDisplayName)`（提供 XDG 目录别名翻译如 Desktop→桌面 和主目录显示名"主目录"）。

关键证据：`sidebarmodel.cpp:578-634`（addSubItem 缺少检查）、`filesortworker.cpp:1922-1927`（工作区的 isDefaultHiddenFile 检查）、`syncfileinfo.cpp:836-849`（fileDisplayName 通过 SystemPathUtil 翻译）。

## 修复方案

将 `isDefaultHiddenFile` 逻辑从 `FileSortWorker` 提取为共享的 `FileUtils::isDefaultHiddenFile()` 工具方法（使用 QMutex+QSet 实现线程安全懒初始化）。修改 `SideBarModel::addSubItem` 调用该共享方法过滤默认隐藏目录，并将 `info->fileName()` 替换为 `info->displayOf(FileInfo::DisplayInfoType::kFileDisplayName)` 实现 XDG 别名翻译。`FileSortWorker::isDefaultHiddenFile` 改为委托调用共享工具方法（行为保持等价的重构）。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- FileUtils 新增静态方法 — 无现有 API 变更、无签名修改、无公开成员变量变更
- `FileSortWorker::isDefaultHiddenFile` 重构为委托调用共享工具方法 — 行为保持等价，无调用者受影响
- `SideBarModel::addSubItem` 为侧边栏内部方法，无外部调用者

### 业务影响范围

受影响模块：(1) 侧边栏树形视图 — 目录列表现在会过滤 `lost+found`/`root` 并显示翻译后的 XDG 名称；(2) 工作区文件视图 — 无行为变化（实现重构为使用共享工具方法）。用户场景：用户在侧边栏展开磁盘分区时将看到与工作区一致的目录列表。

### 验证建议

双盘环境下展开数据盘的侧边栏，与工作区视图对比目录列表 — 验证 `lost+found` 已隐藏、XDG 目录显示翻译名、主目录显示"主目录"。回归：确认工作区文件视图过滤行为无变化。

## Summary by Sourcery

Make sidebar directory filtering and names consistent with the workspace view.

Bug Fixes:
- Align sidebar directory listings with workspace filtering by hiding default system directories such as `root` and `lost+found`.
- Display translated directory names and the localized Home name in the sidebar.

Enhancements:
- Share default-hidden-file detection between the sidebar and workspace views while preserving existing workspace behavior.