### PR TITLE
per: add TTL cache for checkNetConnection to avoid redundant TCP connections

### DIFF
--- a/autotests/libs/dfm-base/test_networkutils.cpp
+++ b/autotests/libs/dfm-base/test_networkutils.cpp
@@ -12,8 +12,11 @@
 #include <QString>
 #include <QStringList>
 #include <QUrl>
+#include <QThread>
+#include "stubext.h"
 
 #include <dfm-base/utils/networkutils.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 using namespace dfmbase;
 
@@ -155,4 +158,106 @@ TEST(NetworkUtilsTest, DoAfterCheckNetEmptyPortsReturnsTrue)
         QTest::qWait(50);
     }
     EXPECT_TRUE(called);
+}
+
+// ---- TTL cache tests ----
+
+TEST(NetworkUtilsTest, MakeCacheKey)
+{
+    EXPECT_EQ(NetworkUtils::makeCacheKey("1.2.3.4", "445"), QString("1.2.3.4:445"));
+    EXPECT_EQ(NetworkUtils::makeCacheKey("host", "21"), QString("host:21"));
+}
+
+TEST(NetworkUtilsTest, ClearCache)
+{
+    auto *nu = NetworkUtils::instance();
+    nu->updateCache("10.0.0.1", "445", true);
+    auto entry = nu->getFromCache("10.0.0.1", "445");
+    EXPECT_TRUE(entry.timestamp.isValid());
+
+    nu->clearCache();
+    entry = nu->getFromCache("10.0.0.1", "445");
+    EXPECT_FALSE(entry.timestamp.isValid());
+}
+
+TEST(NetworkUtilsTest, CacheMissReturnsInvalid)
+{
+    auto *nu = NetworkUtils::instance();
+    nu->clearCache();
+    auto entry = nu->getFromCache("nonexistent.host", "9999");
+    EXPECT_FALSE(entry.timestamp.isValid());
+}
+
+TEST(NetworkUtilsTest, CacheHitBeforeExpiry)
+{
+    auto *nu = NetworkUtils::instance();
+    nu->clearCache();
+
+    nu->updateCache("192.168.1.1", "80", false);
+    auto entry = nu->getFromCache("192.168.1.1", "80");
+    EXPECT_TRUE(entry.timestamp.isValid());
+    EXPECT_FALSE(entry.busy);
+}
+
+TEST(NetworkUtilsTest, CacheHitBusy)
+{
+    auto *nu = NetworkUtils::instance();
+    nu->clearCache();
+
+    nu->updateCache("192.168.1.1", "445", true);
+    auto entry = nu->getFromCache("192.168.1.1", "445");
+    EXPECT_TRUE(entry.timestamp.isValid());
+    EXPECT_TRUE(entry.busy);
+}
+
+TEST(NetworkUtilsTest, CacheExpiryAfterTTL)
+{
+    auto *nu = NetworkUtils::instance();
+    nu->clearCache();
+
+    nu->updateCache("10.0.0.2", "22", true);
+    auto entry = nu->getFromCache("10.0.0.2", "22");
+    EXPECT_TRUE(entry.timestamp.isValid());
+
+    QThread::msleep(NetworkUtils::kNetCacheTTLMs + 50);
+    entry = nu->getFromCache("10.0.0.2", "22");
+    EXPECT_FALSE(entry.timestamp.isValid());
+}
+
+TEST(NetworkUtilsTest, CacheUpdateOverwrites)
+{
+    auto *nu = NetworkUtils::instance();
+    nu->clearCache();
+
+    nu->updateCache("10.0.0.3", "445", true);
+    EXPECT_TRUE(nu->getFromCache("10.0.0.3", "445").busy);
+
+    nu->updateCache("10.0.0.3", "445", false);
+    EXPECT_FALSE(nu->getFromCache("10.0.0.3", "445").busy);
+}
+
+TEST(NetworkUtilsTest, CheckNetConnectionUseCacheFalse)
+{
+    auto *nu = NetworkUtils::instance();
+    nu->clearCache();
+
+    // Populate cache with busy=true
+    nu->updateCache("192.0.2.1", "445", true);
+
+    // useCache=false should bypass cache — but won't connect to fake host.
+    // Just verify it doesn't crash.
+    stub_ext::StubExt stub;
+    stub.set_lamda(ADDR(DConfigManager, value), [](DConfigManager *, const QString &, const QString &, const QVariant &def) -> QVariant {
+        return def;
+    });
+
+    EXPECT_NO_FATAL_FAILURE({
+        (void)nu->checkNetConnection("192.0.2.1", "445", 100, false);
+    });
+}
+
+TEST(NetworkUtilsTest, CheckNetConnectionEmptyHostReturnsTrue)
+{
+    auto *nu = NetworkUtils::instance();
+    EXPECT_TRUE(nu->checkNetConnection("", "445"));
 }

--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -36,7 +36,7 @@ NetworkUtils *NetworkUtils::instance()
     return &s;
 }
 
-bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, int msecs)
+bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, int msecs, const bool useCache)
 {
     if (host.isEmpty())
         return true;
@@ -46,6 +46,13 @@ bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, 
     if (!checkNet) {
         qCInfo(logDFMBase) << "NetworkUtils::checkNetConnection Skip network check." << host << port;
         return true;
+    }
+
+    if (useCache) {
+        // TTL 缓存命中 → 直接返回
+        auto cached = getFromCache(host, port);
+        if (cached.timestamp.isValid())
+            return !cached.busy;
     }
 
     qCInfo(logDFMBase) << "NetworkUtils::checkNetConnection net work check host = " << host << ", port = " << port << " !!!";
@@ -59,14 +66,16 @@ bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, 
     if (!connected) {
         // 检查系统代理设置
         QNetworkProxy proxy = QNetworkProxy::applicationProxy();
-        if (proxy.type() == QNetworkProxy::NoProxy)
-            return connected;
-
-        conn.setProxy(QNetworkProxy::NoProxy);
-        conn.connectToHost(host, port.toUShort());
-        connected = conn.waitForConnected(msecs);
-        conn.close();
+        if (proxy.type() != QNetworkProxy::NoProxy) {
+            conn.setProxy(QNetworkProxy::NoProxy);
+            conn.connectToHost(host, port.toUShort());
+            connected = conn.waitForConnected(msecs);
+            conn.close();
+        }
     }
+
+    // 缓存结果（busy = !connected）
+    updateCache(host, port, !connected);
     return connected;
 }
 
@@ -105,7 +114,7 @@ void NetworkUtils::doAfterCheckNet(const QString &host, const QStringList &ports
 
         for (const auto &port : ports) {
             qApp->processEvents();
-            if (NetworkUtils::instance()->checkNetConnection(host, port, msecs))
+            if (NetworkUtils::instance()->checkNetConnection(host, port, msecs, false))
                 return true;
         }
         return false;
@@ -203,11 +212,63 @@ bool NetworkUtils::checkFtpOrSmbBusy(const QUrl &url)
     if (!parseIp(url.path(), host, ports))
         return false;
 
+    // 先查缓存，所有端口都 hit 且 busy=false 才算可用
+    bool allCached { true };
+    bool anyBusy { false };
+    for (const auto &port : ports) {
+        auto cached = getFromCache(host, port);
+        if (!cached.timestamp.isValid()) {
+            allCached = false;
+            break;
+        }
+        if (cached.busy) {
+            anyBusy = true;
+            break;
+        }
+    }
+    if (allCached)
+        return anyBusy;
+
     auto busy = !checkNetConnection(host, ports);
     if (busy)
         qCWarning(logDFMBase) << "Network connection failed for URL:" << url << "host:" << host << "ports:" << ports;
 
     return busy;
+}
+
+// ─── TTL 缓存实现 ─────────────────────────────────────────
+
+QString NetworkUtils::makeCacheKey(const QString &host, const QString &port)
+{
+    return host + QLatin1Char(':') + port;
+}
+
+NetworkUtils::NetCacheEntry NetworkUtils::getFromCache(const QString &host, const QString &port) const
+{
+    QMutexLocker locker(&cacheMutex);
+    auto it = netCache.find(makeCacheKey(host, port));
+    if (it == netCache.end())
+        return {};
+
+    // 惰性过期检查
+    if (it.value().timestamp.msecsTo(QDateTime::currentDateTime()) >= kNetCacheTTLMs) {
+        netCache.erase(it);
+        return {};
+    }
+
+    return it.value();
+}
+
+void NetworkUtils::updateCache(const QString &host, const QString &port, bool busy)
+{
+    QMutexLocker locker(&cacheMutex);
+    netCache[makeCacheKey(host, port)] = { busy, QDateTime::currentDateTime() };
+}
+
+void NetworkUtils::clearCache()
+{
+    QMutexLocker locker(&cacheMutex);
+    netCache.clear();
 }
 
 QMap<QString, QString> NetworkUtils::cifsMountHostInfo()

--- a/src/dfm-base/utils/networkutils.h
+++ b/src/dfm-base/utils/networkutils.h
@@ -9,6 +9,9 @@
 
 #include <QObject>
 #include <QString>
+#include <QMap>
+#include <QDateTime>
+#include <QMutex>
 
 #include <functional>
 
@@ -21,7 +24,7 @@ class NetworkUtils : public QObject
 public:
     static NetworkUtils *instance();
 
-    bool checkNetConnection(const QString &host, const QString &port, int msecs = 1000);
+    bool checkNetConnection(const QString &host, const QString &port, int msecs = 1000, const bool useCache = true);
     bool checkNetConnection(const QString &host, QStringList ports, int msecs = 1000);
     void doAfterCheckNet(const QString &host, const QStringList &ports,
                          std::function<void(bool)> callback = nullptr, int msecs = 3000);
@@ -29,6 +32,19 @@ public:
     bool parseIp(const QString &mpt, QString &ip, QStringList &ports);
     bool checkAllCIFSBusy();
     bool checkFtpOrSmbBusy(const QUrl &url);
+
+    // TTL 缓存：避免短期内对同一 host:port 重复 TCP 连接
+    struct NetCacheEntry {
+        bool busy { false };
+        QDateTime timestamp;
+    };
+    static constexpr int kNetCacheTTLMs { 500 };   // 500 ms
+
+    static QString makeCacheKey(const QString &host, const QString &port);
+    NetCacheEntry getFromCache(const QString &host, const QString &port) const;
+    void updateCache(const QString &host, const QString &port, bool busy);
+    void clearCache();
+
     // if network mount，get network mount
     static QMap<QString, QString> cifsMountHostInfo();
 
@@ -45,6 +61,12 @@ public:
      * @return     Resolved local URL, or @p url unchanged when not applicable.
      */
     static QUrl resolveLocalSftpMountUrl(const QUrl &url);
+
+private:
+    QString hexIpToString(const QString& hexIp);
+    bool getHostAndPortByReadNet(QString &host, QStringList &ports);
+    mutable QMutex cacheMutex;
+    mutable QHash<QString, NetCacheEntry> netCache;
 
 protected:
     explicit NetworkUtils(QObject *parent = nullptr);


### PR DESCRIPTION
- Add 500ms TTL cache (NetCacheEntry) to NetworkUtils for host:port results
- checkNetConnection checks cache first, returns cached result on hit within TTL
- checkFtpOrSmbBusy queries cache for all ports before making real connections
- doAfterCheckNet bypasses cache to ensure fresh check for async callbacks
- Add makeCacheKey/getFromCache/updateCache/clearCache helper methods

- 新增 500ms TTL 缓存，避免短时间内对同一 host:port 重复 TCP 连接
- checkNetConnection 优先查缓存，命中则直接返回
- checkFtpOrSmbBusy 对所有端口先查缓存，全部命中才跳过真实连接
- doAfterCheckNet 绕过缓存确保异步回调使用新鲜结果

Log: 为 NetworkUtils 添加 TTL 缓存，减少冗余 TCP 连接
Task: https://pms.uniontech.com/task-view-392141.html
Influence: 避免短时间内对同一网络地址重复建立 TCP 连接，降低网络检测延迟和资源消耗。

## Summary by Sourcery

Cache short-lived network connectivity results to avoid redundant TCP connections while preserving fresh asynchronous checks.

New Features:
- Add a 500 ms, thread-safe TTL cache for host-and-port network check results.
- Allow network checks to bypass cached results when fresh results are required.
- Reuse cached results when determining FTP or SMB availability across multiple ports.

Enhancements:
- Reduce redundant TCP connections and network-check latency during short-lived repeated checks.

Tests:
- Add coverage for cache keys, hits, misses, expiration, updates, clearing, and cache bypass behavior.