### PR TITLE
fix: show resume decrypt option correctly for overlay encryption

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -843,14 +843,7 @@ void DiskEncryptMenuScene::updateActions()
         }
     } else if (EventsHandler::instance()->unfinishedDecryptJob() == param.devDesc
                || EventsHandler::instance()->unfinishedDecryptJob() == param.devPhy) {
-        // Defensive check: only show "Continue decrypt" if device is actually LUKS encrypted.
-        // This handles the case where the partition was reformatted after a decrypt job was interrupted.
-        const QString &idType = selectedItemInfo.value("IdType").toString();
-        if (idType == "crypto_LUKS") {
-            actions[kActIDResumeDecrypt]->setVisible(true);
-        } else {
-            fmInfo() << "Device has pending decrypt job but is not LUKS (may have been reformatted), hiding resume decrypt option:" << param.devDesc << "idType:" << idType;
-        }
+        actions[kActIDResumeDecrypt]->setVisible(true);
     } else {
         actions[kActIDEncrypt]->setVisible(true);
     }

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
@@ -10,7 +10,6 @@
 #include <dfm-base/dfm_menu_defines.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
-#include <QTranslator>
 #include <QTimer>
 #include <QMenu>
 
@@ -102,13 +101,19 @@ void DiskEncryptEntry::processUnfinshedDecrypt(const QString &device)
         return;
     }
 
+    QString entryPath = device_utils::resolveEntryBlockDevPath(device);
+    if (entryPath.isEmpty()) {
+        fmWarning() << "Failed to resolve entry block dev path for device:" << device;
+        return;
+    }
+
     QMenu *menu = new QMenu();
     menu->addSeparator();
     DiskEncryptMenuScene *scene = new DiskEncryptMenuScene();
 
     QUrl url;
     url.setScheme("entry");
-    url.setPath(QString("%1.blockdev").arg(device.mid(5)));
+    url.setPath(entryPath);
     QVariant urls = QVariant::fromValue<QList<QUrl>>({ url });
     QVariantHash params;
     params.insert(dfmbase::MenuParamKey::kSelectFiles, urls);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -562,6 +562,138 @@ BlockDev device_utils::createBlockDevice(const QString &devObjPath)
     return monitor->createDeviceById(devObjPath).objectCast<DBlockDevice>();
 }
 
+/*!
+ * \brief Encode a block device name to UDisks2 object path format.
+ *
+ * UDisks2 encodes characters that are not [a-zA-Z0-9] as _<hex> in object paths.
+ * For example, "dm-2" becomes "dm_2d2" (- is 0x2d).
+ */
+static QString encodeBlockDevName(const QString &devName)
+{
+    QString encoded;
+    for (const auto &ch : devName) {
+        if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')) {
+            encoded.append(ch);
+        } else {
+            encoded.append(QString("_%1").arg(ch.unicode(), 2, 16, QChar('0')));
+        }
+    }
+    return encoded;
+}
+
+/*!
+ * \brief Traverse the sysfs holder chain to find the top DM device.
+ *
+ * For overlay encryption: nvme0n1p5 -> dm-0 (mid) -> dm-2 (top).
+ * The traversal stops at the first device that has no DM holders.
+ *
+ * \param device The physical device path (e.g., /dev/nvme0n1p5)
+ * \param devName The device name without /dev/ prefix (e.g., nvme0n1p5)
+ * \return The top DM device path, or the original device if no holders found.
+ */
+static QString traverseHolderChain(const QString &device, const QString &devName)
+{
+    static const QRegularExpression kValidDevName("^[a-zA-Z0-9_-]+$");
+
+    QString currentDev = device;
+    QString currentName = devName;
+
+    while (true) {
+        QString holdersPath = QString("/sys/class/block/%1/holders").arg(currentName);
+        QDir holdersDir(holdersPath);
+        if (!holdersDir.exists())
+            break;
+
+        auto holders = holdersDir.entryList(QDir::AllEntries | QDir::NoDotAndDotDot);
+        if (holders.isEmpty())
+            break;
+
+        // Find the first DM holder (defense in depth: also validate kernel-provided names)
+        QString nextDm;
+        for (const auto &h : holders) {
+            if (h.startsWith("dm-") && kValidDevName.match(h).hasMatch()) {
+                nextDm = h;
+                break;
+            }
+        }
+        if (nextDm.isEmpty())
+            break;
+
+        fmDebug() << "Found DM holder:" << nextDm << "for device:" << currentDev;
+        currentDev = "/dev/" + nextDm;
+        currentName = nextDm;
+    }
+
+    if (currentDev == device) {
+        fmDebug() << "No DM holder found for device, using original:" << device;
+    } else {
+        fmInfo() << "Resolved top DM device:" << currentDev << "from physical device:" << device;
+    }
+
+    return currentDev;
+}
+
+/*!
+ * \brief Resolve a device path to its UDisks2 entry URL path component.
+ *
+ * Uses the block monitor's resolveDeviceNode to get the canonical UDisks2
+ * object path, then strips the prefix and appends ".blockdev".
+ *
+ * \param currentDev The device path to resolve (e.g., /dev/dm-2)
+ * \param currentName The device name for fallback encoding (e.g., dm-2)
+ * \return The entry URL path (e.g., dm_2d2.blockdev), or empty string on failure.
+ */
+static QString resolveToEntryPath(const QString &currentDev, const QString &currentName)
+{
+    using namespace dfmmount;
+    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
+    if (monitor) {
+        auto objPaths = monitor->resolveDeviceNode(currentDev, {});
+        if (!objPaths.isEmpty()) {
+            static constexpr char kBlockDeviceIdPrefix[] { "/org/freedesktop/UDisks2/block_devices/" };
+            QString shortName = objPaths.first();
+            shortName.remove(kBlockDeviceIdPrefix);
+            QString entryPath = QString("%1.blockdev").arg(shortName);
+            fmInfo() << "Resolved entry block dev path:" << entryPath << "from device:" << currentDev;
+            return entryPath;
+        }
+        fmWarning() << "resolveDeviceNode returned empty for:" << currentDev;
+    } else {
+        fmWarning() << "Failed to get block device monitor";
+    }
+
+    // Fallback: manually encode the device name
+    QString encodedName = encodeBlockDevName(currentName);
+    QString entryPath = QString("%1.blockdev").arg(encodedName);
+    fmInfo() << "Using fallback encoding for entry block dev path:" << entryPath << "from device:" << currentDev;
+    return entryPath;
+}
+
+QString device_utils::resolveEntryBlockDevPath(const QString &device)
+{
+    if (device.isEmpty()) {
+        fmWarning() << "Device path is empty, cannot resolve entry block dev path";
+        return QString();
+    }
+
+    // Extract device name from path (e.g., "/dev/nvme0n1p5" -> "nvme0n1p5")
+    QString devName = device;
+    if (devName.startsWith("/dev/"))
+        devName = devName.mid(5);
+
+    // Validate device name to prevent directory traversal attacks.
+    // Block device names only contain alphanumeric characters, hyphens, and underscores.
+    // This rejects inputs like "../../etc" that could escape /sys/class/block/.
+    static const QRegularExpression kValidDevName("^[a-zA-Z0-9_-]+$");
+    if (!kValidDevName.match(devName).hasMatch()) {
+        fmWarning() << "Invalid device name, potential path traversal detected:" << devName;
+        return QString();
+    }
+
+    QString currentDev = traverseHolderChain(device, devName);
+    return resolveToEntryPath(currentDev, currentDev.startsWith("/dev/") ? currentDev.mid(5) : currentDev);
+}
+
 int dialog_utils::showDialog(const QString &title, const QString &msg)
 {
     QString icon;

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -82,6 +82,19 @@ namespace device_utils {
 int encKeyType(const QString &dev);
 void cacheToken(const QString &device, const QVariantMap &token);
 BlockDev createBlockDevice(const QString &devObjPath);
+
+/*!
+ * \brief Resolve the entry URL block device path from a physical device path.
+ *
+ * For overlay encryption, the physical partition (e.g., /dev/nvme0n1p5) has
+ * DM device holders in sysfs. This function traverses the holder chain to
+ * find the top DM device, then resolves its UDisks2 object path to construct
+ * the entry URL path (e.g., dm_2d2.blockdev).
+ *
+ * \param device The physical device path (e.g., /dev/nvme0n1p5)
+ * \return The entry URL path (e.g., dm_2d2.blockdev), or empty string on failure.
+ */
+QString resolveEntryBlockDevPath(const QString &device);
 }   // namespace device_utils
 
 namespace dialog_utils {


### PR DESCRIPTION
Remove the defensive check that hid the "Continue decrypt" action when
the device was not LUKS (e.g., after reformat). Now it always shows
if there is an unfinished decrypt job. Add `resolveEntryBlockDevPath`
to correctly resolve the entry block device path for overlay
encryption, where the physical partition has DM device holders. Updated
`processUnfinshedDecrypt` to use the new resolution function instead of
simple path suffix.

Influence:
1. Test with a device that has an unfinished decrypt job and has been
reformatted (should show "Continue decrypt").
2. Test overlay encryption scenario (e.g., nvme0n1p5 -> dm-0 -> dm-2) to
verify the entry URL is correctly resolved.
3. Verify that the "Continue decrypt" action works correctly when
selected.
4. Test with non-overlay encryption (single LUKS partition) to ensure
no regression.

fix: 修复overlay加密场景下继续解密选项的显示问题

移除当设备不是LUKS时隐藏“继续解密”的防御性检查，现在只要存在未完成的
解密任务就显示该选项。新增`resolveEntryBlockDevPath`函数，用于正确解析
overlay加密场景下的entry块设备路径，通过遍历sysfs中的holder链找到顶层DM
设备。更新`processUnfinshedDecrypt`使用新的解析函数，替代简单的路径后缀
拼接。

Influence:
1. 测试设备存在未完成的解密任务且已被重新格式化的情况，应显示“继续解
密”选项。
2. 测试overlay加密场景（如nvme0n1p5 -> dm-0 -> dm-2），验证entry URL是否
正确解析。
3. 验证点击“继续解密”选项后功能正常。
4. 测试非overlay加密（单一LUKS分区）确保无回归。

BUG: https://pms.uniontech.com/bug-view-374085.html

## Summary by Sourcery

Fix resume-decryption handling for reformatted devices and overlay encryption.

Bug Fixes:
- Ensure the “Continue decrypt” action remains available whenever an unfinished decrypt job exists, including after the device has been reformatted.
- Correctly resolve entry URLs for overlay-encrypted devices by following their device-mapper hierarchy.

Enhancements:
- Add secure block-device path resolution with UDisks2 lookup and validated fallback encoding.