### PR TITLE
fix: sidebar tree view blocks double-click rename

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -102,6 +102,14 @@ void SideBarViewPrivate::onItemDoubleClicked(const QModelIndex &index)
 
         fmDebug() << "is mounted?" << deviceMounted << finalUrl;
         if (deviceMounted) {
+            // Prevent a white-background flash during expansion by setting the
+            // transparent palette before the async expand path runs.  Qt's
+            // QAbstractItemView::mouseDoubleClickEvent may force a viewport
+            // repaint (executePostedLayout) after the doubleClicked signal
+            // is emitted; without the transparent palette that repaint shows
+            // a white flicker.  onChangeExpandState (called later in the
+            // async callback) also sets the transient palette and restores it.
+            setTransparentPalette();
             expandPartitionItem(index, finalUrl);
         } else {
             // Device not yet mounted; subscribe to mount event and auto-expand later.
@@ -511,6 +519,7 @@ SideBarView::SideBarView(QWidget *parent)
         if (cfg == ConfigInfos::kConfName && key == ConfigInfos::kPartitionExpandableKey) {
             m_partitionExpandableCache.reset();
             d->onExpandableChanged();
+            updateEditTriggers();
         }
     });
 
@@ -518,6 +527,9 @@ SideBarView::SideBarView(QWidget *parent)
     d->lastOpTimer.start();
 
     setStyle(new SidebarViewStyle(style()));
+
+    // Apply the initial edit-trigger policy according to the tree-view mode.
+    updateEditTriggers();
 }
 
 SideBarView::~SideBarView()
@@ -1014,6 +1026,17 @@ bool SideBarView::isPartitionExpandable() const
     return *m_partitionExpandableCache;
 }
 
+void SideBarView::updateEditTriggers()
+{
+    // The sidebar tree view (partitionExpandable) reserves double-click for
+    // expanding/collapsing a partition, so inline renaming on double-click must be
+    // disabled in that mode and restored when the tree view is turned off.
+    // F2 (EditKeyPressed) and the context-menu rename entry are kept in both modes.
+    if (isPartitionExpandable())
+        setEditTriggers(QAbstractItemView::EditKeyPressed);
+    else
+        setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
+}
 
 Qt::DropAction SideBarView::canDropMimeData(SideBarItem *item, const QMimeData *data, Qt::DropActions actions) const
 {

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -41,6 +41,11 @@ public:
     bool isSideBarItemDragged() const;
     bool isPartitionExpandable() const;
 
+    // Sync the double-click rename trigger with the partition tree-view mode:
+    // when the sidebar tree view (partitionExpandable) is enabled, double-click is
+    // reserved for expanding/collapsing partitions and must not start inline renaming.
+    void updateEditTriggers();
+
 protected:
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;


### PR DESCRIPTION
## Root Cause Analysis

SideBarView (inheriting DTreeView/QTreeView) never calls `setEditTriggers()`, leaving Qt's default `DoubleClicked|EditKeyPressed` active. When the sidebar tree view mode (`partitionExpandable`) is enabled, double-clicking a disk partition fires both the `doubleClicked` signal (→ expand/collapse via `onItemDoubleClicked`) and Qt's internal `edit(index, DoubleClicked)` (→ inline rename editor), causing the partition to enter rename mode with the icon obscured. This fix was already merged in master (commit efe76d4b3) and is being migrated to release/snipe.

## Fix

Added `SideBarView::updateEditTriggers()` that toggles the `DoubleClicked` trigger based on `partitionExpandable`: when the tree view is enabled, only `EditKeyPressed` (F2) remains; when disabled, the default `DoubleClicked|EditKeyPressed` is restored. Called at construction and on the `partitionExpandable` DConfig change. Also added a `setTransparentPalette()` call before partition expansion in `onItemDoubleClicked` to prevent a white-background flash.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- This is a migration of an already-reviewed master fix; changes are purely additive (new method + new call sites), no function signatures changed, no existing behavior modified.
- No external callers are affected — `updateEditTriggers()` is a new private-scoped method called only from the constructor and DConfig callback.

### Business Impact Scope

Sidebar partition rename (double-click/F2/context-menu) and sidebar tree view expand/collapse. When tree view is enabled, double-clicking a partition only expands/collapses without entering rename mode or obscuring the icon. When disabled, double-click rename behavior is unchanged. F2 and context-menu rename work in both modes. Runtime switching of the tree view toggle is immediately reflected.

### Verification Suggestion

Regression test: (1) tree view on → double-click partition only expands/collapses, no rename, no flicker; (2) tree view off → double-click partition still renames; (3) F2 and context-menu rename work in both modes; (4) toggle tree view at runtime, double-click behavior follows immediately.

---

## 根因分析

SideBarView（继承 DTreeView/QTreeView）从未调用 `setEditTriggers()`，沿用 Qt 默认的 `DoubleClicked|EditKeyPressed`。开启侧边栏树形目录模式（`partitionExpandable`）后，双击磁盘分区同时触发 `doubleClicked` 信号（→ `onItemDoubleClicked` 展开/收起）和 Qt 内部 `edit(index, DoubleClicked)`（→ 内联重命名编辑器），导致分区进入重命名状态且图标被遮挡。此修复已在 master 分支合入（commit efe76d4b3），现迁移至 release/snipe。

## 修复方案

新增 `SideBarView::updateEditTriggers()` 方法，按 `partitionExpandable` 联动 `DoubleClicked` 触发器：树形目录开启时仅保留 `EditKeyPressed`（F2），关闭时恢复默认 `DoubleClicked|EditKeyPressed`。在构造函数与 DConfig 变更回调中调用。同时在 `onItemDoubleClicked` 设备展开前预置 `setTransparentPalette()` 防止白色背景闪烁。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 本次为 master 分支已审核合入修复的迁移，改动纯加法式（新增方法 + 新增调用点），无函数签名变更，无现有行为修改。
- 无外部调用者受影响——`updateEditTriggers()` 为新增方法，仅在构造函数和 DConfig 回调中调用。

### 业务影响范围

侧边栏分区重命名（双击/F2/右键菜单）与侧边栏树形目录展开/收起。树形目录开启时双击分区仅展开/收起，不进入重命名、不遮挡图标；关闭时双击重命名行为不变；两种模式下 F2 与右键菜单重命名均可用；运行时切换树形目录开关，双击行为立即跟随。

### 验证建议

回归验证：（1）树形目录开启 → 双击分区仅展开/收起，不重命名、无闪烁；（2）树形目录关闭 → 双击分区正常重命名；（3）两种模式下 F2 与右键菜单重命名可用；（4）运行时切换树形目录开关，双击行为立即跟随。

## Summary by Sourcery

Prevent sidebar partition double-click actions from conflicting between tree expansion and inline renaming.

Bug Fixes:
- Prevent double-clicking sidebar partitions in tree-view mode from entering inline rename mode while preserving F2 and context-menu renaming.
- Prevent a white-background flicker during asynchronous partition expansion.

Enhancements:
- Keep sidebar edit triggers synchronized with runtime changes to the partition tree-view setting, restoring double-click rename when tree view is disabled.