### PR TITLE
fix: align sidebar tree with file workspace display

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -8,6 +8,7 @@
 #include <dfm-base/utils/sysinfoutils.h>
 #include <dfm-base/utils/systempathutil.h>
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/utils/threadcontainer.h>
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/dialogmanager.h>
 #include <dfm-base/base/urlroute.h>
@@ -1403,6 +1404,25 @@ QString FileUtils::findIconFromXdg(const QString &iconName)
         qCWarning(logDFMBase) << "qtxdg-iconfinder not found";
         return QString();
     }
+}
+
+bool FileUtils::isDefaultHiddenFile(const QUrl &fileUrl)
+{
+    static DThreadList<QUrl> defaultHiddenUrls;
+    static std::once_flag flg;
+    std::call_once(flg, [&] {
+        using namespace GlobalServerDefines;
+        const auto &systemBlks = DevProxyMng->getAllBlockIds(DeviceQueryOption::kSystem | DeviceQueryOption::kMounted);
+        for (const auto &blk : systemBlks) {
+            auto blkInfo = DevProxyMng->queryBlockInfo(blk);
+            const QStringList &mountPoints = blkInfo.value(DeviceProperty::kMountPoints).toStringList();
+            for (const auto &mpt : mountPoints) {
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
+            }
+        }
+    });
+    return defaultHiddenUrls.containsByLock(fileUrl);
 }
 
 }

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -99,6 +99,7 @@ public:
 
     static QString symlinkTarget(const QUrl &url);
     static QString resolveSymlink(const QUrl &url);
+    static bool isDefaultHiddenFile(const QUrl &url);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     static QImage convertToSRgbColorSpace(const QImage &image);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/utils/filenamesorter.h>
+#include <dfm-base/utils/fileutils.h>
 #include <dfm-framework/event/event.h>
 
 #include <QMimeData>
@@ -598,6 +599,15 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
         return;
     }
 
+    // Hide system-default hidden directories (e.g. /<mount-point>/root, /<mount-point>/lost+found)
+    // to keep the sidebar sub-tree consistent with the file view, which filters them via
+    // FileSortWorker::isDefaultHiddenFile.
+    if (!Application::instance()->genericAttribute(dfmbase::Application::kShowedHiddenFiles).toBool()
+        && FileUtils::isDefaultHiddenFile(url)) {
+        fmInfo() << "Default hidden directory should not be displayed in sidebar" << url;
+        return;
+    }
+
     SideBarItem *parentItem = itemFromIndex(index);
     if (!parentItem) {
         fmDebug() << "Failed to get parent item from index";
@@ -613,7 +623,12 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
     }
 
     QString group = parentItem->group();
-    QString fileName = info ? info->fileName() : "Unknown";
+    // Use the file-view display name (translated via SystemPathUtil) so XDG directories
+    // (Desktop/Documents/...) and /home/<user> show localized names (桌面/文档/主目录) in the
+    // sidebar tree, consistent with the workspace file view.
+    QString fileName = info ? info->displayOf(DisPlayInfoType::kFileDisplayName) : "Unknown";
+    if (fileName.isEmpty())
+        fileName = info ? info->fileName() : "Unknown";
     QIcon folderIcon = QIcon::fromTheme("folder");
 
     SideBarItem *item = new SideBarItem(folderIcon, fileName, group, url);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1936,21 +1936,7 @@ bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool by
 
 bool FileSortWorker::isDefaultHiddenFile(const QUrl &fileUrl)
 {
-    static DThreadList<QUrl> defaultHiddenUrls;
-    static std::once_flag flg;
-    std::call_once(flg, [&] {
-        using namespace GlobalServerDefines;
-        const auto &systemBlks = DevProxyMng->getAllBlockIds(DeviceQueryOption::kSystem | DeviceQueryOption::kMounted);
-        for (const auto &blk : systemBlks) {
-            auto blkInfo = DevProxyMng->queryBlockInfo(blk);
-            const QStringList &mountPoints = blkInfo.value(DeviceProperty::kMountPoints).toStringList();
-            for (const auto &mpt : mountPoints) {
-                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
-                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
-            }
-        }
-    });
-    return defaultHiddenUrls.containsByLock(fileUrl);
+    return FileUtils::isDefaultHiddenFile(fileUrl);
 }
 
 QUrl FileSortWorker::makeParentUrl(const QUrl &url)


### PR DESCRIPTION
## Root Cause Analysis

The sidebar tree view (`SideBarModel::addSubItem`) displayed sub-directory entries inconsistently with the workspace file view in three ways: (1) `lost+found` and `root` directories under disk mount points were not filtered (the file view hides them via `FileSortWorker::isDefaultHiddenFile`); (2) XDG directories (Desktop/Documents/Downloads/Music/Pictures/Videos) showed raw English names instead of localized names; (3) `/home/<user>` showed the username instead of "Home". The root cause is that the sidebar used `info->fileName()` for display names (bypassing `SystemPathUtil` translation) and only filtered dot-hidden files (`kIsHidden`), missing the system-default-hidden-directory filter entirely.

## Fix Approach

1. Extracted `isDefaultHiddenFile` logic from `FileSortWorker` into `FileUtils::isDefaultHiddenFile` as a shared static method, so both the workspace file view and sidebar can reuse the same logic (code reuse, DRY).
2. In `SideBarModel::addSubItem`, switched the display name from `info->fileName()` to `info->displayOf(DisPlayInfoType::kFileDisplayName)`, which routes through `SystemPathUtil` for XDG/home directory name translation.
3. Added a `FileUtils::isDefaultHiddenFile(url)` check in `addSubItem` to filter `lost+found`/`root` directories, matching the file view behavior.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- `addSubItem` is only called internally within `sidebarmodel.cpp` (by `addSubItems` and `onDirectoryCreated`); no external callers, so changes are localized.
- `FileSortWorker::isDefaultHiddenFile` now delegates to `FileUtils::isDefaultHiddenFile` with identical logic — behavior-preserving for the file view.

### Business Impact Scope

- **Sidebar tree view**: When expanding a disk partition, sub-directory names now match the file view (XDG dirs localized, home dir shown as "Home", `lost+found`/`root` hidden).
- **File view (workspace)**: No behavior change — `isDefaultHiddenFile` logic was moved, not modified.
- **Affected user scenario**: Users expanding disk partitions in the sidebar tree view will see consistent directory listings with the main file view.

### Verification Suggestion

Test on a dual-disk system: expand the data disk in the sidebar tree and verify `lost+found`/`root` are hidden, XDG directories show localized names, and `/home/<user>` shows "Home". Also test with "show hidden files" enabled to confirm they appear then.

---

## 根因分析

侧边栏树形目录（`SideBarModel::addSubItem`）在展示子目录项时与工作区文件视图存在三方面不一致：（1）磁盘挂载点下的 `lost+found` 和 `root` 目录未被过滤（文件视图通过 `FileSortWorker::isDefaultHiddenFile` 隐藏之）；（2）XDG 目录（Desktop/Documents/Downloads/Music/Pictures/Videos）显示英文原名而非本地化名称；（3）`/home/<用户名>` 显示用户名而非「主目录」。根因是侧边栏使用 `info->fileName()` 取显示名（未经过 `SystemPathUtil` 翻译），且仅过滤点号隐藏文件（`kIsHidden`），完全缺失系统默认隐藏目录的过滤逻辑。

## 修复方案

1. 将 `FileSortWorker::isDefaultHiddenFile` 的逻辑抽取到 `FileUtils::isDefaultHiddenFile` 作为共享静态方法，文件视图和侧边栏复用同一逻辑（代码复用，DRY）。
2. 在 `SideBarModel::addSubItem` 中，将显示名从 `info->fileName()` 改为 `info->displayOf(DisPlayInfoType::kFileDisplayName)`，经 `SystemPathUtil` 翻译 XDG 目录和主目录名称。
3. 在 `addSubItem` 中增加 `FileUtils::isDefaultHiddenFile(url)` 检查，过滤 `lost+found`/`root` 目录，与文件视图行为一致。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- `addSubItem` 仅在 `sidebarmodel.cpp` 内部被 `addSubItems` 和 `onDirectoryCreated` 调用，无外部调用者，改动局部化。
- `FileSortWorker::isDefaultHiddenFile` 改为委托 `FileUtils::isDefaultHiddenFile`，逻辑完全一致——对文件视图行为无变化。

### 业务影响范围

- **侧边栏树形目录**：展开磁盘分区时，子目录名称与文件视图一致（XDG 目录本地化、主目录显示「主目录」、`lost+found`/`root` 隐藏）。
- **文件视图（工作区）**：无行为变化——`isDefaultHiddenFile` 逻辑仅迁移未修改。
- **受影响用户场景**：用户在侧边栏展开磁盘分区时将看到与主文件视图一致的目录列表。

### 验证建议

在双盘环境测试：展开数据盘侧边栏树节点，验证 `lost+found`/`root` 被隐藏、XDG 目录显示本地化名称、`/home/<用户名>` 显示「主目录」。另测试开启「显示隐藏文件」后这些目录可正常显示。

## Summary by Sourcery

Make sidebar tree entries consistent with workspace file listings.

Bug Fixes:
- Align sidebar directory listings with the workspace file view by hiding system-default directories and using localized display names for XDG and home directories.

Enhancements:
- Centralize default-hidden directory detection in FileUtils for reuse across sidebar and workspace views.