### PR TITLE
fix: align sidebar tree with file workspace display

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -8,6 +8,7 @@
 #include <dfm-base/utils/sysinfoutils.h>
 #include <dfm-base/utils/systempathutil.h>
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/utils/threadcontainer.h>
 #include <dfm-base/dfm_global_defines.h>
 #include <dfm-base/utils/dialogmanager.h>
 #include <dfm-base/base/urlroute.h>
@@ -1387,6 +1388,25 @@ QString FileUtils::findIconFromXdg(const QString &iconName)
         qCWarning(logDFMBase) << "qtxdg-iconfinder not found";
         return QString();
     }
+}
+
+bool FileUtils::isDefaultHiddenFile(const QUrl &fileUrl)
+{
+    static DThreadList<QUrl> defaultHiddenUrls;
+    static std::once_flag flg;
+    std::call_once(flg, [&] {
+        using namespace GlobalServerDefines;
+        const auto &systemBlks = DevProxyMng->getAllBlockIds(DeviceQueryOption::kSystem | DeviceQueryOption::kMounted);
+        for (const auto &blk : systemBlks) {
+            auto blkInfo = DevProxyMng->queryBlockInfo(blk);
+            const QStringList &mountPoints = blkInfo.value(DeviceProperty::kMountPoints).toStringList();
+            for (const auto &mpt : mountPoints) {
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
+                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
+            }
+        }
+    });
+    return defaultHiddenUrls.containsByLock(fileUrl);
 }
 
 }

--- a/src/dfm-base/utils/fileutils.h
+++ b/src/dfm-base/utils/fileutils.h
@@ -91,6 +91,7 @@ public:
 
     static QString symlinkTarget(const QUrl &url);
     static QString resolveSymlink(const QUrl &url);
+    static bool isDefaultHiddenFile(const QUrl &url);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     static QImage convertToSRgbColorSpace(const QImage &image);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/application/application.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/utils/filenamesorter.h>
+#include <dfm-base/utils/fileutils.h>
 #include <dfm-framework/event/event.h>
 
 #include <QMimeData>
@@ -598,6 +599,15 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
         return;
     }
 
+    // Hide system-default hidden directories (e.g. /<mount-point>/root, /<mount-point>/lost+found)
+    // to keep the sidebar sub-tree consistent with the file view, which filters them via
+    // FileSortWorker::isDefaultHiddenFile.
+    if (!Application::instance()->genericAttribute(dfmbase::Application::kShowedHiddenFiles).toBool()
+        && FileUtils::isDefaultHiddenFile(url)) {
+        fmInfo() << "Default hidden directory should not be displayed in sidebar" << url;
+        return;
+    }
+
     SideBarItem *parentItem = itemFromIndex(index);
     if (!parentItem) {
         fmDebug() << "Failed to get parent item from index";
@@ -613,7 +623,12 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
     }
 
     QString group = parentItem->group();
-    QString fileName = info ? info->fileName() : "Unknown";
+    // Use the file-view display name (translated via SystemPathUtil) so XDG directories
+    // (Desktop/Documents/...) and /home/<user> show localized names (桌面/文档/主目录) in the
+    // sidebar tree, consistent with the workspace file view.
+    QString fileName = info ? info->displayOf(DisPlayInfoType::kFileDisplayName) : "Unknown";
+    if (fileName.isEmpty())
+        fileName = info ? info->fileName() : "Unknown";
     QIcon folderIcon = QIcon::fromTheme("folder");
 
     SideBarItem *item = new SideBarItem(folderIcon, fileName, group, url);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filesortworker.cpp
@@ -1890,21 +1890,7 @@ bool FileSortWorker::checkFilters(const SortInfoPointer &sortInfo, const bool by
 
 bool FileSortWorker::isDefaultHiddenFile(const QUrl &fileUrl)
 {
-    static DThreadList<QUrl> defaultHiddenUrls;
-    static std::once_flag flg;
-    std::call_once(flg, [&] {
-        using namespace GlobalServerDefines;
-        const auto &systemBlks = DevProxyMng->getAllBlockIds(DeviceQueryOption::kSystem | DeviceQueryOption::kMounted);
-        for (const auto &blk : systemBlks) {
-            auto blkInfo = DevProxyMng->queryBlockInfo(blk);
-            const QStringList &mountPoints = blkInfo.value(DeviceProperty::kMountPoints).toStringList();
-            for (const auto &mpt : mountPoints) {
-                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "root" : "/root")));
-                defaultHiddenUrls.push_backByLock(QUrl::fromLocalFile(mpt + (mpt == "/" ? "lost+found" : "/lost+found")));
-            }
-        }
-    });
-    return defaultHiddenUrls.containsByLock(fileUrl);
+    return FileUtils::isDefaultHiddenFile(fileUrl);
 }
 
 QUrl FileSortWorker::makeParentUrl(const QUrl &url)


### PR DESCRIPTION
1. Root cause: sidebar tree used raw fileName() and only filtered dot-hidden files, diverging from the file view which hides lost+found/root and translates XDG and home dirs via SystemPathUtil
2. Fix: extract isDefaultHiddenFile into FileUtils for shared reuse, switch sidebar to displayOf(kFileDisplayName) for translated names, and filter default hidden dirs in addSubItem
3. Impact: sidebar sub-tree now matches the file view on hidden dir filtering and XDG/home display name translation

Log: sidebar tree directory names now match the file workspace

Influence:
1. Test expanding a partition sidebar node and verify lost+found and root are hidden while XDG dirs show localized names
2. Test with show-hidden-files enabled to confirm they appear then
3. Verify file view and sidebar tree consistency across system and data disks

fix: 对齐侧边栏树形目录与工作区文件视图显示

1. 根因：侧边栏树形目录使用原始 fileName() 取名且仅过滤点号隐藏文件， 与文件视图不一致——文件视图隐藏 lost+found/root 并通过 SystemPathUtil 翻译 XDG 目录和主目录名称
2. 方案：将 isDefaultHiddenFile 抽取到 FileUtils 供复用，侧边栏改用 displayOf(kFileDisplayName) 获取翻译名，并在 addSubItem 中过滤默认隐藏目录
3. 影响：侧边栏子树在隐藏目录过滤与 XDG/主目录显示名翻译上与文件视图一致

Log: 侧边栏树形目录名称与工作区文件视图保持一致

Influence:
1. 展开分区侧边栏节点，验证 lost+found 和 root 被隐藏、XDG 目录显示本地化名称
2. 开启显示隐藏文件后验证这些目录可正常显示
3. 在系统盘和数据盘上验证文件视图与侧边栏树目录一致

PMS: BUG-374145