### PR TITLE
fix(at-spi): add AT-SPI accessible names for file manager controls

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -561,6 +561,8 @@ QWidget *TaskWidget::createBtnWidget()
     btnReplace->setProperty(kBtnPropertyActionName, variantReplace);
 
     btnDelete = new DWarningButton();
+    btnDelete->setObjectName("BtnDelete");
+    btnDelete->setAccessibleName("BtnDelete");
     btnDelete->setText(TaskWidget::tr("Permanently delete", "button"));
     QVariant varianDelete;
     varianDelete.setValue<AbstractJobHandler::SupportAction>(AbstractJobHandler::SupportAction::kPermanentlyDelete);

--- a/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp
@@ -76,6 +76,8 @@ void MultiFileBasicInfoWidget::initUI()
     modifyTime->setRightValue("-", Qt::ElideNone, Qt::AlignVCenter, true);
 
     hideFile = new SkipPartiallyCheckBox(frameMain);
+    hideFile->setObjectName("HideFile_2");
+    hideFile->setAccessibleName("HideFile_2");
     DFontSizeManager::instance()->bind(hideFile, DFontSizeManager::SizeType::T7, QFont::Normal);
     hideFile->setText(tr("Hide this file"));
     hideFile->setToolTip(hideFile->text());

--- a/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
+++ b/src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
@@ -98,6 +98,8 @@ void TagEditor::mouseMoveEvent(QMouseEvent *event)
 void TagEditor::initializeWidgets()
 {
     crumbEdit = new DCrumbEdit;
+    crumbEdit->setObjectName("CrumbEdit");
+    crumbEdit->setAccessibleName("CrumbEdit");
     promptLabel = new QLabel(tr("Input tag info, such as work, family. A comma is used between two tags."));
     totalLayout = new QVBoxLayout;
     totalLayout->setSizeConstraint(QLayout::SetFixedSize);

--- a/src/plugins/desktop/ddplugin-canvas/delegate/itemeditor.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/delegate/itemeditor.cpp
@@ -207,6 +207,8 @@ void ItemEditor::setOpacity(qreal opacity)
 RenameEdit *ItemEditor::createEditor()
 {
     auto edit = new RenameEdit();
+    edit->setObjectName("RenameEdit");
+    edit->setAccessibleName("RenameEdit");
     edit->setWordWrapMode(QTextOption::WrapAnywhere);
     edit->setAlignment(Qt::AlignHCenter);
     edit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp
@@ -202,6 +202,8 @@ void ItemEditor::setOpacity(qreal opacity)
 RenameEdit *ItemEditor::createEditor()
 {
     auto edit = new RenameEdit();
+    edit->setObjectName("RenameEdit_2");
+    edit->setAccessibleName("RenameEdit_2");
     edit->setWordWrapMode(QTextOption::WrapAnywhere);
     edit->setAlignment(Qt::AlignHCenter);
     edit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
+++ b/src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
@@ -32,6 +32,8 @@ RecoveryKeyView::RecoveryKeyView(QWidget *parent)
 {
     //! 密钥编辑框
     recoveryKeyEdit = new QPlainTextEdit(this);
+    recoveryKeyEdit->setObjectName("RecoveryKeyEdit");
+    recoveryKeyEdit->setAccessibleName("RecoveryKeyEdit");
     recoveryKeyEdit->setPlaceholderText(tr("Input the 32-digit recovery key"));
     recoveryKeyEdit->setMaximumBlockCount(MAX_KEY_LENGTH + 3);
     recoveryKeyEdit->installEventFilter(this);

--- a/tests/at/spi/expected_names.yaml
+++ b/tests/at/spi/expected_names.yaml
@@ -1200,5 +1200,47 @@ widgets:
   source_file: src/plugins/filemanager/dfmplugin-workspace/views/fileviewstatusbar.cpp
   class_name: ''
   line: 117
+- variable: btnDelete
+  type: Dtk::Widget::DWarningButton *
+  object_name: BtnDelete
+  accessible_name: BtnDelete
+  source_file: src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+  class_name: TaskWidget
+  line: 563
+- variable: hideFile
+  type: SkipPartiallyCheckBox *
+  object_name: HideFile_2
+  accessible_name: HideFile_2
+  source_file: src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp
+  class_name: MultiFileBasicInfoWidget
+  line: 78
+- variable: crumbEdit
+  type: Dtk::Widget::DCrumbEdit *
+  object_name: CrumbEdit
+  accessible_name: CrumbEdit
+  source_file: src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp
+  class_name: TagEditor
+  line: 100
+- variable: edit
+  type: RenameEdit *
+  object_name: RenameEdit
+  accessible_name: RenameEdit
+  source_file: src/plugins/desktop/ddplugin-canvas/delegate/itemeditor.cpp
+  class_name: ItemEditor
+  line: 209
+- variable: edit
+  type: RenameEdit *
+  object_name: RenameEdit_2
+  accessible_name: RenameEdit_2
+  source_file: src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp
+  class_name: ItemEditor
+  line: 204
+- variable: recoveryKeyEdit
+  type: QPlainTextEdit *
+  object_name: RecoveryKeyEdit
+  accessible_name: RecoveryKeyEdit
+  source_file: src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp
+  class_name: RecoveryKeyView
+  line: 34
 qml_elements: []
 transient_elements: []


### PR DESCRIPTION
## Summary

为文件管理器 master 分支上 6 处交互控件补全 AT-SPI `setObjectName` / `setAccessibleName` 调用，并同步更新预期命名基线。

### Files changed
- `src/dfm-base/dialogs/taskdialog/taskwidget.cpp`
- `src/plugins/common/dfmplugin-propertydialog/views/multifilebasicinfowidget.cpp`
- `src/plugins/common/dfmplugin-tag/widgets/tageditor.cpp`
- `src/plugins/desktop/ddplugin-canvas/delegate/itemeditor.cpp`
- `src/plugins/desktop/ddplugin-organizer/delegate/itemeditor.cpp`
- `src/plugins/filemanager/dfmplugin-vault/views/unlockview/recoverykeyview.cpp`
- `tests/at/spi/expected_names.yaml`

### Changes
- 仅增加 `setObjectName()` / `setAccessibleName()` 调用，不修改任何已有代码逻辑
- 新增命名：`BtnDelete`、`HideFile_2`、`CrumbEdit`、`RenameEdit`、`RenameEdit_2`、`RecoveryKeyEdit`
- 同步更新 `expected_names.yaml` 预期命名基线（171 → 177 个控件）

### 系列说明
本 PR 属于父任务 V-2324 的 AT-SPI 控件补全系列，在已合并的 #4183-#4191 基础上对最新 master 重新扫描补全剩余缺口。
