### PR TITLE
fix: fix sidebar setting panel initialization

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -639,7 +639,8 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
 
     ItemInfo itemInfo = ItemInfo(url, { { PropertyKey::kItemExpandable, true },
                                         { PropertyKey::kFinalUrl, url },
-                                        { PropertyKey::kGroup, DefaultGroup::kDevice } });
+                                        { PropertyKey::kGroup, DefaultGroup::kDevice },
+                                        { PropertyKey::kDisplayName, fileName } });
     SideBarInfoCacheMananger::instance()->addItemInfoCache(itemInfo);
 
     // Sub-items are not editable and not draggable.

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarwidget.cpp
@@ -508,7 +508,10 @@ void SideBarWidget::initSettingPannel()
         for (auto item : items) {
             const QString &key { item->itemInfo().visiableControlKey };
             const QString &name { item->itemInfo().visiableDisplayName };
-            Q_ASSERT(!key.isEmpty() && !name.isEmpty());
+            if (key.isEmpty() || name.isEmpty()) {
+                fmWarning() << "skip item with empty key or name, group:" << group << "url:" << item->url();
+                continue;
+            }
             if (itemKeysMap[group].contains(key) || key == "hidden_me") {
                 fmDebug() << "reject key:" << key << group;
                 continue;


### PR DESCRIPTION
1. Fixed a crash when initializing sidebar settings panel due to missing
display name property for device sub-items
2. Added defensive check to skip items with empty visibility keys or
names during settings panel initialization
3. The crash occurred because Q_ASSERT would terminate the application
when encountering empty keys or names in release builds

Log: Fixed sidebar settings panel crash when loading device items

Influence:
1. Test adding removable devices (USB drives, etc.) to the sidebar
2. Verify that device expansion in sidebar works correctly
3. Test settings panel opens without crashes when devices are present
4. Check that all sidebar items display properly with correct names

fix: 修复侧边栏设置面板初始化问题

1. 修复初始化侧边栏设置面板时因设备子项缺少显示名称属性导致的崩溃问题
2. 在设置面板初始化过程中添加防御性检查，跳过键或名称为空的项
3. 之前Q_ASSERT在遇到空的键或名称时会终止应用程序，导致崩溃

Log: 修复加载设备项时侧边栏设置面板崩溃的问题

Influence:
1. 测试向侧边栏添加可移动设备（U盘等）
2. 验证侧边栏中设备展开功能是否正常
3. 测试设备存在时设置面板能否无崩溃打开
4. 检查所有侧边栏项是否正确显示名称

## Summary by Sourcery

Prevent sidebar settings panel crashes and preserve correct display of device sub-items with incomplete metadata.

Bug Fixes:
- Prevent sidebar settings initialization from crashing when device items have missing display names or visibility keys.
- Ensure device sub-items include display names so they appear correctly in the sidebar and settings panel.

Enhancements:
- Skip invalid sidebar items during settings panel initialization while logging the affected group and URL.