### PR TITLE
fix: use icon name instead of url as sidebar icon cache key

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -69,6 +69,7 @@ void SideBarItem::setUrl(const QUrl &url)
 void SideBarItem::setIcon(const QIcon &icon)
 {
     const auto &iconName = icon.name();
+    setData(iconName, Roles::kItemIconNameRole);
     DDciIcon dciIcon = DDciIcon::fromTheme(iconName);
     if (!dciIcon.isNull())
         setDciIcon(dciIcon);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
@@ -23,6 +23,7 @@ public:
         kItemGroupRole,
         kItemTypeRole,
         kItemHiddenRole,
+        kItemIconNameRole,
         kItemUserCustomRole = Dtk::UserRole + 0x0100
     };
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -93,16 +93,12 @@ void SideBarItemDelegate::clearIconCache()
 
 void SideBarItemDelegate::invalidateIconCache(const QUrl &url)
 {
-    if (url.isEmpty())
-        return;
-    // Cache keys are formatted as "iconId|WxH|theme|mode|foreground" where iconId
-    // is the item url (see drawIcon/drawDciIcon). Match the url prefix + delimiter
-    // so all pixmaps of that item (any size/theme/mode) are dropped at once; other
-    // items are left untouched. The trailing "|" avoids matching a url that just
-    // happens to be a string prefix of another one.
-    const QString prefix = url.toString() + QLatin1Char('|');
-    for (auto it = m_iconCache.begin(); it != m_iconCache.end();)
-        it = it.key().startsWith(prefix) ? m_iconCache.erase(it) : ++it;
+    Q_UNUSED(url);
+    // Cache keys are now keyed by icon name (see drawIcon/drawDciIcon), not by
+    // url, so per-url invalidation is no longer possible. The cache is capped at
+    // 50 entries, so a full clear is cheap and avoids stale pixmaps when an
+    // item's icon changes.
+    clearIconCache();
 }
 
 SideBarItemDelegate::SideBarItemDelegate(QAbstractItemView *parent)
@@ -522,7 +518,7 @@ void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option,
         option.icon.paint(painter, iconRect, option.decorationAlignment, iconMode, state);
     } else {
         drawDciIcon(optForIcon, painter, dciIcon, iconRect, cg, keepHighlighted,
-                    index.data(SideBarItem::kItemUrlRole).toUrl().toString());
+                    index.data(SideBarItem::kItemIconNameRole).toString());
     }
 
     painter->restore();


### PR DESCRIPTION
## Root Cause Analysis

The sidebar icon cache in `SideBarItemDelegate::drawDciIcon` keyed cached pixmaps by the item URL (`iconId`), not by the icon's actual identity. When QuickAccess (bookmarks) and the directory tree both display the same XDG directory (e.g., `~/Documents`), they share the same URL but use different DCI icons — QuickAccess uses `folder-documents-symbolic` while the tree uses `folder`. The identical cache key causes whichever item renders first to cache its icon, and the second item incorrectly reuses that cached pixmap.

## Fix

Store the themed icon name in a new `kItemIconNameRole` on `SideBarItem`, and use it as the cache key identifier in `drawDciIcon` instead of the URL. This ensures different icons never share a cache entry. `invalidateIconCache` is simplified to a full clear since per-URL matching no longer applies (the cache is capped at 50 entries, so the cost is negligible). When an item's icon changes, the new icon name produces a new cache key automatically, making selective invalidation unnecessary.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- No function signatures changed, no public members modified, only 2 internal call sites affected (both in the same file)
- The `invalidateIconCache` change is safe: icon changes naturally produce new cache keys, so stale entries are bounded by the 50-entry cap and auto-evicted

### Business Impact Scope

Affects sidebar icon rendering for all item types (QuickAccess bookmarks, directory tree sub-directories, device eject buttons). The fix ensures each icon identity gets its own cache entry, preventing cross-contamination between QuickAccess and tree items that point to the same directory.

### Verification Suggestion

Verify that QuickAccess XDG directory icons (Documents, Downloads, Pictures, etc.) and directory tree folder icons display correctly when both are visible simultaneously. Also verify device eject icons and icon colors in selected/hovered states.

---

## 根因分析

侧边栏图标缓存 `SideBarItemDelegate::drawDciIcon` 以 item 的 URL 作为缓存键标识，而非图标的实际身份。当 QuickAccess（书签）和目录树同时显示同一 XDG 目录（如 `~/Documents`）时，两者 URL 相同但 DCI 图标不同——QuickAccess 用 `folder-documents-symbolic`，目录树用 `folder`。缓存键一致导致先渲染方的图标被后渲染方错误复用。

## 修复方案

在 `SideBarItem` 中新增 `kItemIconNameRole` 存储图标名，在 `drawDciIcon` 中用图标名替代 URL 作为缓存键标识，确保不同图标不再碰撞。`invalidateIconCache` 简化为全清（缓存上限 50 条，开销可忽略）。当 item 图标变更时，新图标名自动产生新缓存键，无需选择性失效。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 无函数签名变更，无公开成员修改，仅影响 2 处内部调用（均在同一文件内）
- `invalidateIconCache` 改动安全：图标变更时新图标名自动产生新缓存键，过期条目由 50 条上限自动淘汰

### 业务影响范围

影响侧边栏所有 item 类型的图标渲染（QuickAccess 书签、目录树子目录、设备弹出按钮）。修复确保每个图标身份拥有独立缓存条目，防止 QuickAccess 和目录树中指向同一目录的 item 图标交叉污染。

### 验证建议

验证同时展开 QuickAccess 和目录树时，XDG 目录（文档/下载/图片等）在两处分别显示正确的图标（特殊风格图标 vs folder 图标），不发生混用。同时验证设备弹出图标和选中/悬停状态下图标颜色正确。

## Summary by Sourcery

Fix sidebar icon caching so each themed icon is rendered and cached independently.

Bug Fixes:
- Prevent sidebar items with the same URL but different themed icons from sharing cached pixmaps.
- Ensure icon changes cannot reuse stale URL-based cache entries.

Enhancements:
- Key sidebar icon caching by icon identity rather than item URL and simplify cache invalidation to clear the bounded cache.