### PR TITLE
fix: hide resume decrypt option for non-LUKS devices after interrupted decrypt job

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -843,7 +843,39 @@ void DiskEncryptMenuScene::updateActions()
         }
     } else if (EventsHandler::instance()->unfinishedDecryptJob() == param.devDesc
                || EventsHandler::instance()->unfinishedDecryptJob() == param.devPhy) {
-        actions[kActIDResumeDecrypt]->setVisible(true);
+        // Defensive check: only show "Continue decrypt" if device is actually LUKS encrypted.
+        // This handles the case where the partition was reformatted after a decrypt job was interrupted.
+        const QString &idType = selectedItemInfo.value("IdType").toString();
+        // For overlay encryption, the device has a 2-layer DM structure:
+        // e.g. nvme0n1p5 -> usec-overlay-unlock-home (crypt/LUKS) -> usec-overlay-home (top).
+        // The top overlay layer is not crypto_LUKS itself, but it sits on top of a crypt layer,
+        // so the resume decrypt option should also be shown for overlay devices.
+        // The top overlay device's symlinks only contain "usec-overlay-xxx" (not "usec-overlay-unlock-xxx"),
+        // so we derive the unlock device name from the overlay name and check if it exists.
+        // Naming rule (see DMInitEncryptWorker): "overlay" -> "overlay-unlock".
+        bool hasOverlayCrypt = false;
+        if (idType != "crypto_LUKS") {
+            auto devSymlinks = selectedItemInfo.value("Symlinks").toStringList();
+            for (const QString &symlink : devSymlinks) {
+                int idx = symlink.indexOf(kOverleyEncPrefix);
+                if (idx < 0)
+                    continue;
+                // Extract the overlay device name, e.g. "usec-overlay-home"
+                QString overlayName = symlink.mid(idx);
+                // Derive the unlock device name, e.g. "usec-overlay-unlock-home"
+                QString unlockName = QString(overlayName).replace("overlay", "overlay-unlock");
+                QString unlockDevPath = "/dev/mapper/" + unlockName;
+                if (QFile::exists(unlockDevPath)) {
+                    hasOverlayCrypt = true;
+                    break;
+                }
+            }
+        }
+        if (idType == "crypto_LUKS" || hasOverlayCrypt) {
+            actions[kActIDResumeDecrypt]->setVisible(true);
+        } else {
+            fmInfo() << "Device has pending decrypt job but is not LUKS (may have been reformatted), hiding resume decrypt option:" << param.devDesc << "idType:" << idType;
+        }
     } else {
         actions[kActIDEncrypt]->setVisible(true);
     }


### PR DESCRIPTION
When a decrypt job is interrupted but the partition has been
reformatted, the "Continue Decrypt" option should not be shown. This
commit adds a defensive check that verifies the device is still LUKS
encrypted (or for overlay encryption, the lower unlock device exists)
before showing the resume decrypt action. This prevents confusing users
with an irrelevant menu option.

Log: Fixed inconsistent behavior where "Continue Decrypt" was shown for
reformatted partitions

Influence:
1. Test resume decrypt on a normal LUKS encrypted device with
interrupted decrypt job
2. Test overlay encryption device (e.g., usec-overlay-home) with
interrupted decrypt job
3. Test a device that was cryptographically unlocked but then the
partition was reformatted (no longer LUKS)
4. Verify "Continue Decrypt" is hidden in the reformatted case
5. Verify menu actions for other scenarios (encrypt, decrypt, etc.)
remain unchanged

fix: 在解密任务中断后，对于非LUKS设备隐藏“继续解密”选项

当解密任务中断但分区已被重新格式化时，不应显示“继续解密”选项。此提交添加
了防御性检查，在显示恢复解密操作之前，验证设备仍然是LUKS加密（对于覆盖加
密，检查底层解锁设备是否存在）。这防止了向用户显示无关菜单项造成困惑。

Log: 修复重新格式化分区后仍显示“继续解密”的不一致行为

Influence:
1. 测试在正常LUKS加密设备且解密任务中断时，显示“继续解密”
2. 测试覆盖加密设备（例如usec-overlay-home）且解密任务中断时，显示“继续
解密”
3. 测试设备曾被破解锁但随后分区被重新格式化（不再是LUKS），隐藏“继续
解密”
4. 验证其他场景（加密、解密等）的菜单操作不变

## Summary by Sourcery

Bug Fixes:
- Hide the “Continue Decrypt” action when an interrupted decrypt job targets a device that is no longer LUKS encrypted or has no active overlay encryption layer.