### PR TITLE
fix: use icon name instead of url as sidebar icon cache key

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -69,6 +69,7 @@ void SideBarItem::setUrl(const QUrl &url)
 void SideBarItem::setIcon(const QIcon &icon)
 {
     const auto &iconName = icon.name();
+    setData(iconName, Roles::kItemIconNameRole);
     DDciIcon dciIcon = DDciIcon::fromTheme(iconName);
     if (!dciIcon.isNull())
         setDciIcon(dciIcon);

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
@@ -23,6 +23,7 @@ public:
         kItemGroupRole,
         kItemTypeRole,
         kItemHiddenRole,
+        kItemIconNameRole,
         kItemUserCustomRole = Dtk::UserRole + 0x0100
     };
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -93,16 +93,12 @@ void SideBarItemDelegate::clearIconCache()
 
 void SideBarItemDelegate::invalidateIconCache(const QUrl &url)
 {
-    if (url.isEmpty())
-        return;
-    // Cache keys are formatted as "iconId|WxH|theme|mode|foreground" where iconId
-    // is the item url (see drawIcon/drawDciIcon). Match the url prefix + delimiter
-    // so all pixmaps of that item (any size/theme/mode) are dropped at once; other
-    // items are left untouched. The trailing "|" avoids matching a url that just
-    // happens to be a string prefix of another one.
-    const QString prefix = url.toString() + QLatin1Char('|');
-    for (auto it = m_iconCache.begin(); it != m_iconCache.end();)
-        it = it.key().startsWith(prefix) ? m_iconCache.erase(it) : ++it;
+    Q_UNUSED(url);
+    // Cache keys are now keyed by icon name (see drawIcon/drawDciIcon), not by
+    // url, so per-url invalidation is no longer possible. The cache is capped at
+    // 50 entries, so a full clear is cheap and avoids stale pixmaps when an
+    // item's icon changes.
+    clearIconCache();
 }
 
 SideBarItemDelegate::SideBarItemDelegate(QAbstractItemView *parent)
@@ -503,7 +499,7 @@ void SideBarItemDelegate::drawIcon(const QStyleOptionViewItem &option,
         option.icon.paint(painter, iconRect, option.decorationAlignment, iconMode, state);
     } else {
         drawDciIcon(optForIcon, painter, dciIcon, iconRect, cg, keepHighlighted,
-                    index.data(SideBarItem::kItemUrlRole).toUrl().toString());
+                    index.data(SideBarItem::kItemIconNameRole).toString());
     }
 
     painter->restore();


### PR DESCRIPTION
1. Root cause: the sidebar icon cache keyed pixmaps by the item url,
   so two items pointing to the same XDG directory (e.g. ~/Documents)
   but with different DCI icons (QuickAccess uses folder-documents-
   symbolic, the tree uses folder) shared the same cache entry,
   causing whichever rendered first to shadow the other
2. Fix: store the themed icon name in a new kItemIconNameRole and use
   it as the cache key identifier instead of the url, so different
   icons never collide; simplify invalidateIconCache to a full clear
   since per-url matching is no longer applicable (cache is capped at
   50 entries so the cost is negligible)
3. Impact: same-icon items now share cache entries (higher hit rate),
   no function signatures changed, no external callers affected

Log: fix sidebar icon mix-up between QuickAccess and directory tree

Influence:
1. Verify QuickAccess XDG directory icons show special style icons
2. Verify directory tree sub-directories show folder icons
3. Verify icons do not mix when both QuickAccess and tree are expanded
4. Verify device eject icons display correctly
5. Verify icon colors correct in selected/hovered states

fix: 修复侧边栏图标缓存键使用URL导致图标混用

1. 根因：侧边栏图标缓存以item的URL作为缓存键标识，当QuickAccess
   和目录树同时出现指向同一XDG目录的item时（如~/Documents），
   两者URL相同但DCI图标不同（QuickAccess用folder-documents-
   symbolic，目录树用folder），缓存键一致导致先渲染方的图标
   被后渲染方错误复用
2. 方案：新增kItemIconNameRole存储图标名，将缓存键标识从URL改为
   图标名，使不同图标不再碰撞；invalidateIconCache简化为全清
   （缓存上限50条，开销可忽略）
3. 影响：相同图标的item共享缓存条目（命中率提升），无函数签名
  变更，无外部调用者受影响

Log: 修复侧边栏QuickAccess与目录树的XDG目录图标混用问题

Influence:
1. 验证QuickAccess中XDG目录显示特殊风格图标
2. 验证目录树展开子目录显示folder图标
3. 验证同时展开QuickAccess和目录树时图标不混用
4. 验证设备弹出图标正常显示
5. 验证选中/悬停状态下图标颜色正确

## Summary by Sourcery

Fix sidebar icon caching to key entries by themed icon name instead of item URL.

Bug Fixes:
- Prevent sidebar icons for QuickAccess and directory-tree items from colliding when they share the same URL but use different themed icons.

Enhancements:
- Use themed icon names as sidebar icon cache keys so identical icons can share entries while distinct icons remain isolated.
- Simplify icon-cache invalidation to clear the bounded cache when an item's icon changes.