### PR TITLE
fix(diskencrypt): skip filesystem freeze on DM suspend/resume and adj…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -279,7 +279,7 @@ void EventsHandler::onChgPwdFinished(const QVariantMap &result)
 
 void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
 {
-    qApp->restoreOverrideCursor();
+    fmDebug() << "[EventsHandler::onRequestAuthArgs] enter";
 
     QString devPath = devInfo.value(encrypt_param_keys::kKeyDevice).toString();
     if (devPath.isEmpty()) {
@@ -292,11 +292,13 @@ void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
         return;
     }
 
+    qApp->restoreOverrideCursor();
+
     QString objPath = "/org/freedesktop/UDisks2/block_devices/" + devPath.mid(5);
     auto blkDev = device_utils::createBlockDevice(objPath);
     auto dlg = new EncryptParamsInputDialog(devInfo, qApp->activeWindow());
     encryptInputs.insert(devPath, dlg);
-
+    fmDebug() << "[EventsHandler::onRequestAuthArgs] Had new Encrypt params input dialog.";
     connect(dlg, &DDialog::finished, this, [=](auto ret) {
         if (ret != QDialog::Accepted) {
             fmInfo() << "User cancelled auth input for device:" << devPath;

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -138,7 +138,7 @@ QWidget *EncryptParamsInputDialog::createPasswordPage()
     encType->addItems({ tr("Unlocked by passphrase"),
                         tr("Use TPM+PIN to unlock on this computer (recommended)"),
                         tr("Automatic unlocking on this computer by TPM") });
-
+    fmDebug() << "[EncryptParamsInputDialog::createPasswordPage] Befor checkTPM()";
     if (tpm_utils::checkTPM() != 0 || tpm_utils::checkTPMLockoutStatus() != 0) {
         // encType->setItemData(kTPMAndPIN, QVariant(0), Qt::UserRole - 1);
         // encType->setItemData(kTPMOnly, QVariant(0), Qt::UserRole - 1);

--- a/src/services/diskencrypt/core/dmsetup.cpp
+++ b/src/services/diskencrypt/core/dmsetup.cpp
@@ -86,14 +86,29 @@ int dm_setup::dmSuspendDevice(const QString &dmDev)
         qCritical() << "[dm_setup::dmSuspendDevice] Failed to create DM task helper for device:" << dmDev;
         return -1;
     }
+    // 挂起设备时，跳过冻结文件系统
+    int r =  dm_task_skip_lockfs(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set skip lockfs for " << dmDev << "error:" << r;
+        return -1;
+    }
+    // 挂起设备时，跳过刷新 I/O 缓冲区
+    r = dm_task_no_flush(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set no flush for " << dmDev << "error:" << r;
+        return -1;
+    }
 
-    int r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
+
+    qDebug() << "[dm_setup::dmSuspendDevice] start call dm_task_set_name";
+    r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
     if (r == 0) {
         auto err = dm_task_get_errno(h.task());
         qCritical() << "[dm_setup::dmSuspendDevice] Failed to set DM device name for suspend:" << dmDev << "error:" << err;
         return -err;
     }
 
+    qDebug() << "[dm_setup::dmSuspendDevice] start call dm_task_set_name";
     r = dm_task_run(h.task());
     if (r == 0) {
         auto err = dm_task_get_errno(h.task());
@@ -114,8 +129,20 @@ int dm_setup::dmResumeDevice(const QString &dmDev)
         qCritical() << "[dm_setup::dmResumeDevice] Failed to create DM task helper for device:" << dmDev;
         return -1;
     }
+    // 挂起设备时，跳过冻结文件系统
+    int r =  dm_task_skip_lockfs(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set skip lockfs for " << dmDev << "error:" << r;
+        return -1;
+    }
+    // 挂起设备时，跳过刷新 I/O 缓冲区
+    r = dm_task_no_flush(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set no flush for " << dmDev << "error:" << r;
+        return -1;
+    }
 
-    int r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
+    r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
     if (r == 0) {
         auto err = dm_task_get_errno(h.task());
         qCritical() << "[dm_setup::dmResumeDevice] Failed to set DM device name for resume:" << dmDev << "error:" << err;

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -393,6 +393,7 @@ void DiskEncryptSetupPrivate::resumeEncryption(const QVariantMap &args)
             qptr, &DiskEncryptSetup::WaitAuthInput);
     connect(worker, &QThread::finished,
             this, &DiskEncryptSetupPrivate::onResumeEncryptFinished);
+    qDebug() << "[DiskEncryptSetupPrivate::resumeEncryption] start resumeEncryption";
     worker->start();
 }
 
@@ -550,7 +551,10 @@ void DiskEncryptSetupPrivate::initThreadConnection(const QThread *thread)
 void DiskEncryptSetupPrivate::onInitEncryptFinished()
 {
     auto worker = dynamic_cast<BaseEncryptWorker *>(sender());
-    if (!worker) return;
+    if (!worker) {
+        qCritical() << "======== the worker is nullptr, so return";
+        return;
+    }
     worker->deleteLater();
 
     auto args = worker->args();


### PR DESCRIPTION
…ust cursor restore timing

- Add dm_task_skip_lockfs() and dm_task_no_flush() calls in dmSuspendDevice() and dmResumeDevice() to skip freezing the filesystem and flushing I/O buffers during device-mapper suspend/resume operations.
- Move qApp->restoreOverrideCursor() in EventsHandler::onRequestAuthArgs to after the existing-dialog check, avoiding premature cursor restore.
- Promote key debug logs to info level across disk-encrypt entry plugin and service workers for better runtime observability.
- Add diagnostic info logs for auth args request, encryption init worker null-check, and resume encryption entry point.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-373557.html

## Summary by Sourcery

Prevent disruptive filesystem and cursor behavior during disk-encryption operations while improving runtime observability.

Bug Fixes:
- Avoid freezing filesystems and flushing I/O buffers during device-mapper suspend and resume operations.
- Restore the override cursor only after confirming that no authentication dialog is already open.

Enhancements:
- Improve disk-encryption runtime diagnostics with additional lifecycle, dialog, TPM, and worker-state logging.