### PR TITLE
refactor: extract validateExportPath to recovery_key_utils

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -4,10 +4,8 @@
 
 #include "encryptparamsinputdialog.h"
 #include "utils/encryptutils.h"
-#include "events/eventshandler.h"
 
 #include <dfm-base/utils/finallyutil.h>
-#include <dfm-mount/dmount.h>
 
 #include <QVBoxLayout>
 #include <QLabel>
@@ -256,65 +254,6 @@ bool EncryptParamsInputDialog::validatePassword()
     return true;
 }
 
-bool EncryptParamsInputDialog::validateExportPath(const QString &path, QString *msg)
-{
-    auto setMsg = [&](const QString &info) { if (msg) *msg = info; };
-    if (path.isEmpty()) {
-        setMsg(tr("Recovery key export path cannot be empty!"));
-        return false;
-    }
-
-    if (!QDir(path).exists()) {
-        fmWarning() << "Export path does not exist:" << path;
-        setMsg(tr("Recovery key export path is not exists!"));
-        return false;
-    }
-
-    QStorageInfo storage(path);
-    QString dev = storage.device();
-    QStringList associatedDevs { dev };
-    if (dev.startsWith("/dev/mapper/")) {
-        QFileInfo f(dev);
-        if (f.isSymbolicLink()) {
-            auto linkDev = f.symLinkTarget(); // /dev/dm-*
-            if (!linkDev.isEmpty()) {
-                associatedDevs.append(EventsHandler::instance()->holderDevice(linkDev));
-            }
-        }
-    }
-
-    QString targetDevice = args.value(encrypt_param_keys::kKeyDevice).toString();
-    if (associatedDevs.contains(targetDevice)) {
-        fmWarning() << "Export path is on the same device being encrypted:" << targetDevice;
-        setMsg(tr("Please export to an external device such as a non-encrypted partition or USB flash drive."));
-        return false;
-    }
-
-    if (storage.isReadOnly()) {
-        fmWarning() << "Export path is read-only:" << path;
-        setMsg(tr("This partition is read-only, please export to a writable partition"));
-        return false;
-    }
-
-    // Check if the export path itself is encrypted
-    using namespace dfmmount;
-    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
-    Q_ASSERT(monitor);
-    auto devObjPaths = monitor->resolveDeviceNode(dev, {});
-    if (!devObjPaths.isEmpty()) {
-        auto objPath = devObjPaths.constFirst();
-        auto devPtr = monitor->createDeviceById(objPath);
-        if (devPtr && devPtr->getProperty(Property::kBlockCryptoBackingDevice).toString() != "/") {
-            fmWarning() << "Export path is on an encrypted partition:" << path;
-            setMsg(tr("The partition is encrypted, please export to a non-encrypted "
-                      "partition or external device such as a USB flash drive."));
-            return false;
-        }
-    }
-
-    return true;
-}
-
 void EncryptParamsInputDialog::setPasswordInputVisible(bool visible)
 {
     keyHint1->setVisible(visible);
@@ -420,9 +359,10 @@ void EncryptParamsInputDialog::onExpPathChanged(const QString &path, bool silent
     }
 
     QString msg;
-    btnNext->setEnabled(validateExportPath(path, &msg));
+    btnNext->setEnabled(recovery_key_utils::validateExportPath(
+            path, args.value(encrypt_param_keys::kKeyDevice).toString(), &msg));
     if (!msg.isEmpty() && !silent)
-        keyExportInput->showAlertMessage(msg);
+        keyExportInput->showAlertMessage(msg, 5000);
 }
 
 bool EncryptParamsInputDialog::encryptByTpm(const QString &deviceName)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.h
@@ -36,7 +36,6 @@ protected:
     QWidget *createPasswordPage();
     QWidget *createExportPage();
     bool validatePassword();
-    bool validateExportPath(const QString &path, QString *msg);
     void setPasswordInputVisible(bool visible);
 
 protected Q_SLOTS:

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -12,11 +12,8 @@
 #include <QTimer>
 #include <QStackedLayout>
 #include <QIcon>
-#include <QStorageInfo>
 #include <QDebug>
 #include <DFileDialog>
-
-#include <dfm-mount/dmount.h>
 
 #include <dfm-base/utils/iconutils.h>
 
@@ -85,7 +82,7 @@ void EncryptProgressDialog::onCicked(int idx, const QString &btnTxt)
 
     QUrl url = DFileDialog::getExistingDirectoryUrl(this);
     QString msg;
-    if (!validateExportPath(url.toLocalFile(), &msg)) {
+    if (!recovery_key_utils::validateExportPath(url.toLocalFile(), device, &msg)) {
         fmWarning() << "Export path validation failed:" << msg;
         dialog_utils::showDialog(tr("Error"), msg);
     } else {
@@ -151,47 +148,6 @@ void EncryptProgressDialog::initUI()
 
     mainLay->addWidget(progressPage);
     mainLay->addWidget(resultPage);
-}
-
-bool EncryptProgressDialog::validateExportPath(const QString &path, QString *msg)
-{
-    auto setMsg = [&](const QString &info) { if (msg) *msg = info; };
-    if (path.isEmpty()) {
-        setMsg(tr("Recovery key export path cannot be empty!"));
-        return false;
-    }
-
-    if (!QDir(path).exists()) {
-        fmWarning() << "Export path does not exist:" << path;
-        setMsg(tr("Recovery key export path is not exists!"));
-        return false;
-    }
-
-    QStorageInfo storage(path);
-    if (storage.isReadOnly()) {
-        fmWarning() << "Export path is read-only:" << path;
-        setMsg(tr("This partition is read-only, please export to a writable "
-                  "partition"));
-        return false;
-    }
-
-    // Check if the export path itself is encrypted
-    using namespace dfmmount;
-    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
-    Q_ASSERT(monitor);
-    auto devObjPaths = monitor->resolveDeviceNode(storage.device(), {});
-    if (!devObjPaths.isEmpty()) {
-        auto objPath = devObjPaths.constFirst();
-        auto devPtr = monitor->createDeviceById(objPath);
-        if (devPtr && devPtr->getProperty(Property::kBlockCryptoBackingDevice).toString() != "/") {
-            fmWarning() << "Export path is on an encrypted partition:" << path;
-            setMsg(tr("The partition is encrypted, please export to a non-encrypted "
-                      "partition or external device such as a USB flash drive."));
-            return false;
-        }
-    }
-
-    return true;
 }
 
 void EncryptProgressDialog::saveRecKey(const QString &path)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.h
@@ -34,7 +34,6 @@ protected Q_SLOTS:
 
 protected:
     void initUI();
-    bool validateExportPath(const QString &path, QString *msg);
     void saveRecKey(const QString &path);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -21,6 +21,8 @@
 #include <QJsonDocument>
 #include <QDir>
 #include <QApplication>
+#include <QStorageInfo>
+#include <QFileInfo>
 #include <QFutureWatcher>
 #include <QtConcurrent>
 
@@ -30,6 +32,7 @@
 #include <fstab.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <cerrno>
 
 Q_DECLARE_METATYPE(bool *)
@@ -553,6 +556,96 @@ QString recovery_key_utils::formatRecoveryKey(const QString &raw)
     for (; dashCount > 0; dashCount--)
         formatted.insert(dashCount * kSectionLen, '-');
     return formatted;
+}
+
+bool recovery_key_utils::validateExportPath(const QString &path, const QString &targetDevice, QString *msg)
+{
+    auto setMsg = [&](const QString &info) { if (msg) *msg = info; };
+
+    if (path.isEmpty()) {
+        setMsg(QObject::tr("Recovery key export path cannot be empty!"));
+        return false;
+    }
+
+    if (!QDir(path).exists()) {
+        fmWarning() << "Export path does not exist:" << path;
+        setMsg(QObject::tr("Recovery key export path is not exists!"));
+        return false;
+    }
+
+    int dirFd = ::open(path.toLocal8Bit().constData(), O_PATH | O_NOFOLLOW | O_DIRECTORY);
+    if (dirFd < 0) {
+        fmWarning() << "Export path is a symlink or not a directory:" << path;
+        setMsg(QObject::tr("Recovery key export path cannot be a symlink or non-directory!"));
+        return false;
+    }
+
+    struct stat dirStat;
+    if (::fstat(dirFd, &dirStat) != 0) {
+        ::close(dirFd);
+        fmWarning() << "Cannot stat export path directory:" << path;
+        setMsg(QObject::tr("Cannot access the export path directory!"));
+        return false;
+    }
+    if (dirStat.st_mode & S_IWOTH) {
+        ::close(dirFd);
+        fmWarning() << "Export path directory is world-writable:" << path;
+        setMsg(QObject::tr("The export path directory is world-writable, please choose a safer location!"));
+        return false;
+    }
+    ::close(dirFd);
+
+    QStorageInfo storage(path);
+    if (storage.isReadOnly()) {
+        fmWarning() << "Export path is read-only:" << path;
+        setMsg(QObject::tr("This partition is read-only, please export to a writable partition"));
+        return false;
+    }
+
+    if (!targetDevice.isEmpty()) {
+        QString dev = storage.device();
+        QStringList associatedDevs { dev };
+        if (dev.startsWith("/dev/mapper/")) {
+            QFileInfo f(dev);
+            if (f.isSymbolicLink()) {
+                auto linkDev = f.symLinkTarget();
+                if (!linkDev.isEmpty()) {
+                    CREATE_DAEMON_INTERFACE(iface);
+                    if (iface.isValid()) {
+                        QDBusReply<QString> reply = iface.call("HolderDevice", linkDev);
+                        if (reply.isValid())
+                            associatedDevs.append(reply.value());
+                        else
+                            associatedDevs.append(linkDev);
+                    } else {
+                        associatedDevs.append(linkDev);
+                    }
+                }
+            }
+        }
+        if (associatedDevs.contains(targetDevice)) {
+            fmWarning() << "Export path is on the same device being encrypted:" << targetDevice;
+            setMsg(QObject::tr("Please export to an external device such as a non-encrypted partition or USB flash drive."));
+            return false;
+        }
+    }
+
+    using namespace dfmmount;
+    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
+    Q_ASSERT(monitor);
+    auto devObjPaths = monitor->resolveDeviceNode(storage.device(), {});
+    if (!devObjPaths.isEmpty()) {
+        auto objPath = devObjPaths.constFirst();
+        auto devPtr = monitor->createDeviceById(objPath);
+        if (devPtr && devPtr->getProperty(Property::kBlockCryptoBackingDevice).toString() != "/") {
+            fmWarning() << "Export path is on an encrypted partition:" << path;
+            setMsg(QObject::tr("The partition is encrypted, please export to a non-encrypted "
+                              "partition or external device such as a USB flash drive."));
+            return false;
+        }
+    }
+
+    return true;
 }
 
 BlockDev device_utils::createBlockDevice(const QString &devObjPath)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -76,6 +76,7 @@ bool useOverlayDMMode();
 
 namespace recovery_key_utils {
 QString formatRecoveryKey(const QString &raw);
+bool validateExportPath(const QString &path, const QString &targetDevice, QString *msg = nullptr);
 }
 
 namespace device_utils {


### PR DESCRIPTION
1. Remove duplicate validateExportPath implementations from
EncryptParamsInputDialog and EncryptProgressDialog
2. Move the validation logic to a shared utility function
recovery_key_utils::validateExportPath in encryptutils.cpp
3. Add additional security checks: symlink validation, directory
writable permission check (refuse world-writable dirs)
4. Replace direct EventsHandler dependency with D-Bus interface call for
holder device resolution
5. Update alert message display duration to 5000ms for better user
experience
6. Clean up unused includes (eventshandler.h, dfm-mount/dmount.h) from
dialog files

Log: Improved export path validation with security checks and code
refactoring

Influence:
1. Test recovery key export to a valid writable path on a different
device
2. Test export to an empty path - should show error message
3. Test export to a non-existent path - should show error message
4. Test export to a symlink directory - should be rejected
5. Test export to a world-writable directory - should be rejected
6. Test export to a read-only filesystem - should show error message
7. Test export to the same device being encrypted - should show error
message
8. Test export to an encrypted partition - should show error message
9. Verify alert message displays for 5 seconds before auto-hiding

refactor: 提取 validateExportPath 到 recovery_key_utils

1. 移除 EncryptParamsInputDialog 和 EncryptProgressDialog 中重复的
validateExportPath 实现
2. 将验证逻辑移动到 encryptutils.cpp 中的共享工具函数
recovery_key_utils::validateExportPath
3. 添加额外的安全检查：符号链接验证、目录可写权限检查（拒绝全局可写
目录）
4. 将直接的 EventsHandler 依赖替换为用于持有设备解析的 D-Bus 接口调用
5. 更新提示消息显示持续时间为 5000 毫秒，以获得更好的用户体验
6. 清理对话框中未使用的头文件包含（eventshandler.h, dfm-mount/dmount.h）

Log: 改进了导出路径验证，增加了安全检查并进行了代码重构

Influence:
1. 测试将恢复密钥导出到另一设备上的有效可写路径
2. 测试导出到空路径 - 应显示错误消息
3. 测试导出到不存在的路径 - 应显示错误消息
4. 测试导出到符号链接目录 - 应被拒绝
5. 测试导出到全局可写目录 - 应被拒绝
6. 测试导出到只读文件系统 - 应显示错误消息
7. 测试导出到正在加密的设备 - 应显示错误消息
8. 测试导出到加密分区 - 应显示错误消息
9. 验证提示消息显示 5 秒后自动隐藏

BUG: https://pms.uniontech.com/bug-view-368235.html

## Summary by Sourcery

Centralize and harden recovery-key export path validation across the encryption dialogs.

Bug Fixes:
- Strengthen recovery-key export path validation by rejecting symlink paths, world-writable directories, read-only filesystems, the device currently being encrypted, and encrypted partitions.

Enhancements:
- Centralize export path validation in the shared recovery_key_utils utility and update both encryption dialogs to use it.
- Resolve holder devices through the D-Bus interface instead of a direct EventsHandler dependency.
- Keep export-path alert messages visible for 5 seconds.

Chores:
- Remove obsolete dialog-level validation methods and unused includes.