### PR TITLE
fix(disk-encrypt): extend TPM DBus timeout and harden DM suspend/resume

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/dfmplugin_disk_encrypt_global.h
@@ -61,10 +61,10 @@ inline constexpr char kTCMPcrBank[] { "sm3_256" };
 // DBus timeout constant: 2 seconds to prevent UI blocking when service is unavailable
 inline constexpr int kDiskEncryptDBusTimeoutMs = 2000;
 
-// TPM DBus timeout constant: 1 minute. TPM operations (e.g. IsTPMAvailable / Encrypt)
+// DBus timeout constant: 5 minute. TPM operations (e.g. IsTPMAvailable / Encrypt)
 // may trigger a Polkit authentication dialog; we wait for the user to finish auth
 // instead of timing out after the Qt DBus default 25s and falling back incorrectly.
-inline constexpr int kTPMDBusTimeoutMs = 60 * 1000;   // 1 min
+inline constexpr int kTPMDBusTimeoutMs = 5 * 60 * 1000;
 
 // TPM Control service constants
 inline constexpr char kTPMControlService[] = "org.deepin.Filemanager.TPMControl";

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -145,16 +145,15 @@ int EventsHandler::deviceEncryptStatus(const QString &device)
 
 void EventsHandler::resumeEncrypt(const QString &device)
 {
-    QDBusInterface iface(kDaemonBusName,
-                         kDaemonBusPath,
-                         kDaemonBusIface,
-                         QDBusConnection::systemBus());
+    CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     iface.asyncCall("ResumeEncryption", QVariantMap { { encrypt_param_keys::kKeyDevice, device } });
 }
 
 QString EventsHandler::holderDevice(const QString &device)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "Failed to create DBus interface for HolderDevice, service may be unavailable, using original device";
         return device;
@@ -280,7 +279,7 @@ void EventsHandler::onChgPwdFinished(const QVariantMap &result)
 
 void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
 {
-    qApp->restoreOverrideCursor();
+    fmDebug() << "[EventsHandler::onRequestAuthArgs] enter";
 
     QString devPath = devInfo.value(encrypt_param_keys::kKeyDevice).toString();
     if (devPath.isEmpty()) {
@@ -293,11 +292,13 @@ void EventsHandler::onRequestAuthArgs(const QVariantMap &devInfo)
         return;
     }
 
+    qApp->restoreOverrideCursor();
+
     QString objPath = "/org/freedesktop/UDisks2/block_devices/" + devPath.mid(5);
     auto blkDev = device_utils::createBlockDevice(objPath);
     auto dlg = new EncryptParamsInputDialog(devInfo, qApp->activeWindow());
     encryptInputs.insert(devPath, dlg);
-
+    fmDebug() << "[EventsHandler::onRequestAuthArgs] Had new Encrypt params input dialog.";
     connect(dlg, &DDialog::finished, this, [=](auto ret) {
         if (ret != QDialog::Accepted) {
             fmInfo() << "User cancelled auth input for device:" << devPath;

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -144,7 +144,7 @@ QWidget *EncryptParamsInputDialog::createPasswordPage()
     encType->addItems({ tr("Unlocked by passphrase"),
                         tr("Use TPM+PIN to unlock on this computer (recommended)"),
                         tr("Automatic unlocking on this computer by TPM") });
-
+    fmDebug() << "[EncryptParamsInputDialog::createPasswordPage] Befor checkTPM()";
     if (tpm_utils::checkTPM() != 0 || tpm_utils::checkTPMLockoutStatus() != 0) {
         // encType->setItemData(kTPMAndPIN, QVariant(0), Qt::UserRole - 1);
         // encType->setItemData(kTPMOnly, QVariant(0), Qt::UserRole - 1);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -392,6 +392,7 @@ void DiskEncryptMenuScene::unlockDevice(const QString &devObjPath)
 void DiskEncryptMenuScene::doEncryptDevice(const DeviceEncryptParam &param)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for InitEncryption, service may be unavailable";
         return;
@@ -437,6 +438,7 @@ bool DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
     }
 
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for SetupAuthArgs, service may be unavailable";
         return false;
@@ -466,6 +468,7 @@ bool DiskEncryptMenuScene::doReencryptDevice(const DeviceEncryptParam &param)
 void DiskEncryptMenuScene::doDecryptDevice(const DeviceEncryptParam &param)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for Decryption, service may be unavailable";
         return;
@@ -521,6 +524,7 @@ void DiskEncryptMenuScene::doChangePassphrase(const DeviceEncryptParam &param)
     }
 
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmCritical() << "Failed to create DBus interface for ChangePassphrase, service may be unavailable";
         return;

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -320,6 +320,7 @@ int tpm_utils::ownerAuthStatus()
 int device_utils::encKeyType(const QString &dev)
 {
     CREATE_DAEMON_INTERFACE(iface);
+    iface.setTimeout(kTPMDBusTimeoutMs);
     if (!iface.isValid()) {
         fmWarning() << "Failed to create DBus interface for TpmToken, service may be unavailable";
         return 0;

--- a/src/services/diskencrypt/core/dmsetup.cpp
+++ b/src/services/diskencrypt/core/dmsetup.cpp
@@ -86,14 +86,29 @@ int dm_setup::dmSuspendDevice(const QString &dmDev)
         qCritical() << "[dm_setup::dmSuspendDevice] Failed to create DM task helper for device:" << dmDev;
         return -1;
     }
+    // 挂起设备时，跳过冻结文件系统
+    int r =  dm_task_skip_lockfs(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set skip lockfs for " << dmDev << "error:" << r;
+        return -1;
+    }
+    // 挂起设备时，跳过刷新 I/O 缓冲区
+    r = dm_task_no_flush(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set no flush for " << dmDev << "error:" << r;
+        return -1;
+    }
 
-    int r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
+
+    qDebug() << "[dm_setup::dmSuspendDevice] start call dm_task_set_name";
+    r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
     if (r == 0) {
         auto err = dm_task_get_errno(h.task());
         qCritical() << "[dm_setup::dmSuspendDevice] Failed to set DM device name for suspend:" << dmDev << "error:" << err;
         return -err;
     }
 
+    qDebug() << "[dm_setup::dmSuspendDevice] start call dm_task_set_name";
     r = dm_task_run(h.task());
     if (r == 0) {
         auto err = dm_task_get_errno(h.task());
@@ -114,8 +129,20 @@ int dm_setup::dmResumeDevice(const QString &dmDev)
         qCritical() << "[dm_setup::dmResumeDevice] Failed to create DM task helper for device:" << dmDev;
         return -1;
     }
+    // 挂起设备时，跳过冻结文件系统
+    int r =  dm_task_skip_lockfs(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set skip lockfs for " << dmDev << "error:" << r;
+        return -1;
+    }
+    // 挂起设备时，跳过刷新 I/O 缓冲区
+    r = dm_task_no_flush(h.task());
+    if (r != 1) {
+        qCritical() << "[dm_setup::dmSuspendDevice] Failed to set no flush for " << dmDev << "error:" << r;
+        return -1;
+    }
 
-    int r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
+    r = dm_task_set_name(h.task(), dmDev.toStdString().c_str());
     if (r == 0) {
         auto err = dm_task_get_errno(h.task());
         qCritical() << "[dm_setup::dmResumeDevice] Failed to set DM device name for resume:" << dmDev << "error:" << err;

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -393,6 +393,7 @@ void DiskEncryptSetupPrivate::resumeEncryption(const QVariantMap &args)
             qptr, &DiskEncryptSetup::WaitAuthInput);
     connect(worker, &QThread::finished,
             this, &DiskEncryptSetupPrivate::onResumeEncryptFinished);
+    qDebug() << "[DiskEncryptSetupPrivate::resumeEncryption] start resumeEncryption";
     worker->start();
 }
 
@@ -550,7 +551,10 @@ void DiskEncryptSetupPrivate::initThreadConnection(const QThread *thread)
 void DiskEncryptSetupPrivate::onInitEncryptFinished()
 {
     auto worker = dynamic_cast<BaseEncryptWorker *>(sender());
-    if (!worker) return;
+    if (!worker) {
+        qCritical() << "[DiskEncryptSetupPrivate::onInitEncryptFinished] the worker is nullptr, so return";
+        return;
+    }
     worker->deleteLater();
 
     auto args = worker->args();


### PR DESCRIPTION
Increase the TPM DBus timeout from 1 to 5 minutes so that Polkit authentication dialogs are not interrupted by Qt DBus's default 25s timeout. Apply this extended timeout to all TPM-related DBus calls in EventsHandler, DiskEncryptMenuScene and EncryptUtils.

Add skip_lockfs and no_flush options to dmSuspendDevice and dmResumeDevice to avoid freezing the filesystem and flushing I/O buffers during suspend/resume operations.

Additionally, defer qApp->restoreOverrideCursor() until the device path is validated in EventsHandler::onRequestAuthArgs, add debug tracing for the encrypt/resume flows, and guard against a null worker in DiskEncryptSetupPrivate::onInitEncryptFinished.

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-373557.html

## Summary by Sourcery

Improve disk encryption reliability by extending TPM DBus operation timeouts and hardening device suspend and resume handling.

Bug Fixes:
- Prevent TPM-related DBus operations from timing out while users complete Polkit authentication.
- Make disk encryption device suspend and resume avoid filesystem locking and I/O flushing.
- Prevent invalid device paths from restoring the cursor prematurely and handle missing encryption workers safely.

Enhancements:
- Add diagnostic tracing around encryption authentication and resume flows.