### PR TITLE
fix(sidebar): store isExpandable in item data role to prevent cache o…

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -643,6 +643,8 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
                                         { PropertyKey::kDisplayName, fileName } });
     SideBarInfoCacheMananger::instance()->addItemInfoCache(itemInfo);
 
+    item->setExpandable(true);
+
     // Sub-items are not editable and not draggable.
     Qt::ItemFlags flags = item->flags();
     flags &= ~Qt::ItemIsEditable;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -30,6 +30,7 @@ SideBarItem::SideBarItem(const SideBarItem &item)
     setIcon(item.icon());
     setUrl(item.url());
     setGroup(item.group());
+    setExpandable(item.isExpandable());
     setText(item.text());
 
     setData(kSidebarItem, kItemTypeRole);
@@ -90,6 +91,16 @@ bool SideBarItem::isHidden() const
 void SideBarItem::setHiiden(bool hidden)
 {
     setData(hidden, Roles::kItemHiddenRole);
+}
+
+bool SideBarItem::isExpandable() const
+{
+    return data(Roles::kItemExpandableRole).toBool();
+}
+
+void SideBarItem::setExpandable(bool expandable)
+{
+    setData(expandable, Roles::kItemExpandableRole);
 }
 
 QString SideBarItem::subGourp() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
@@ -24,6 +24,7 @@ public:
         kItemTypeRole,
         kItemHiddenRole,
         kItemIconNameRole,
+        kItemExpandableRole,
         kItemUserCustomRole = Dtk::UserRole + 0x0100
     };
 
@@ -51,6 +52,9 @@ public:
 
     bool isHidden() const;
     void setHiiden(bool hidden);
+
+    bool isExpandable() const;
+    void setExpandable(bool expandable);
 
     ItemInfo itemInfo() const;
 };

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -233,7 +233,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         iconMode = QIcon::Disabled;
     if (!suppressDraggedSelection && !isDraggingItemNotHighlighted && (selected || keepDrawingHighlighted))
         iconMode = QIcon::Selected;
-    bool isExpandable = sidebarItem && sidebarItem->itemInfo().isExpandable;
+    bool isExpandable = sidebarItem && sidebarItem->isExpandable();
     if (isExpandable)
         drawExpandIndicator(painter, itemRect, true, index, keepDrawingHighlighted);
     if (opt.features & QStyleOptionViewItem::HasDecoration)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -691,7 +691,7 @@ void SideBarView::mousePressEvent(QMouseEvent *event)
     auto index = indexAt(event->pos());
     if (event->button() == Qt::LeftButton && index.isValid()
         && item && item->group() == DefaultGroup::kDevice) {
-        if (item->itemInfo().isExpandable && SideBarHelper::partitionExpandable()) {
+        if (item->isExpandable() && SideBarHelper::partitionExpandable()) {
             int layer = 0;
             auto parentIdx = index;
             while (parentIdx.parent().isValid()) {

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -133,6 +133,8 @@ SideBarItem *SideBarHelper::createItemByInfo(const ItemInfo &info)
                                         info.group,
                                         info.url);
 
+    item->setExpandable(info.isExpandable);
+
     item->setFlags(info.flags);
 
     // create `unmount action` for removable device


### PR DESCRIPTION
…verwrite

The sidebar tree sub-items render their indentation via SideBarItemDelegate::drawExpandIndicator(), which was gated on isExpandable read from SideBarInfoCacheMananger::bindedInfos -- a QMap keyed solely by URL.  When a directory already shown in an expanded sidebar tree is added to quick access (bookmark), the bookmark's ItemInfo (isExpandable defaults to false) overwrites the tree sub-item's cache entry under the same URL.  The tree sub-item then reads isExpandable=false, drawExpandIndicator() is skipped, and the item jumps to the root indentation level -- matching the bookmark offset exactly.

Store isExpandable in the SideBarItem's own data role (kItemExpandableRole), mirroring how group() already reads item data rather than the shared cache.  Create paths (createItemByInfo, addSubItem) write the value at construction; consumer paths (SideBarItemDelegate::paint, SideBarView::mousePressEvent) read it from the item.  bindedInfos overwrite semantics are left untouched to avoid affecting bookmark refresh and other existing flows.

Log: BUG-374389
Bug: https://pms.uniontech.com/bug-view-374389.html

## Summary by Sourcery

Preserve sidebar item expansion state independently of shared cache updates.

Bug Fixes:
- Prevent sidebar tree items from losing their indentation when the same directory is also added to quick access.

Enhancements:
- Store each sidebar item's expandable state in its own model data so rendering and interaction remain independent of shared URL-based cache entries.