### PR TITLE
修复代码pick到snipe分支

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.cpp
@@ -4,10 +4,8 @@
 
 #include "encryptparamsinputdialog.h"
 #include "utils/encryptutils.h"
-#include "events/eventshandler.h"
 
 #include <dfm-base/utils/finallyutil.h>
-#include <dfm-mount/dmount.h>
 
 #include <QVBoxLayout>
 #include <QLabel>
@@ -248,65 +246,6 @@ bool EncryptParamsInputDialog::validatePassword()
     return true;
 }
 
-bool EncryptParamsInputDialog::validateExportPath(const QString &path, QString *msg)
-{
-    auto setMsg = [&](const QString &info) { if (msg) *msg = info; };
-    if (path.isEmpty()) {
-        setMsg(tr("Recovery key export path cannot be empty!"));
-        return false;
-    }
-
-    if (!QDir(path).exists()) {
-        fmWarning() << "Export path does not exist:" << path;
-        setMsg(tr("Recovery key export path is not exists!"));
-        return false;
-    }
-
-    QStorageInfo storage(path);
-    QString dev = storage.device();
-    QStringList associatedDevs { dev };
-    if (dev.startsWith("/dev/mapper/")) {
-        QFileInfo f(dev);
-        if (f.isSymbolicLink()) {
-            auto linkDev = f.symLinkTarget(); // /dev/dm-*
-            if (!linkDev.isEmpty()) {
-                associatedDevs.append(EventsHandler::instance()->holderDevice(linkDev));
-            }
-        }
-    }
-
-    QString targetDevice = args.value(encrypt_param_keys::kKeyDevice).toString();
-    if (associatedDevs.contains(targetDevice)) {
-        fmWarning() << "Export path is on the same device being encrypted:" << targetDevice;
-        setMsg(tr("Please export to an external device such as a non-encrypted partition or USB flash drive."));
-        return false;
-    }
-
-    if (storage.isReadOnly()) {
-        fmWarning() << "Export path is read-only:" << path;
-        setMsg(tr("This partition is read-only, please export to a writable partition"));
-        return false;
-    }
-
-    // Check if the export path itself is encrypted
-    using namespace dfmmount;
-    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
-    Q_ASSERT(monitor);
-    auto devObjPaths = monitor->resolveDeviceNode(dev, {});
-    if (!devObjPaths.isEmpty()) {
-        auto objPath = devObjPaths.constFirst();
-        auto devPtr = monitor->createDeviceById(objPath);
-        if (devPtr && devPtr->getProperty(Property::kBlockCryptoBackingDevice).toString() != "/") {
-            fmWarning() << "Export path is on an encrypted partition:" << path;
-            setMsg(tr("The partition is encrypted, please export to a non-encrypted "
-                      "partition or external device such as a USB flash drive."));
-            return false;
-        }
-    }
-
-    return true;
-}
-
 void EncryptParamsInputDialog::setPasswordInputVisible(bool visible)
 {
     keyHint1->setVisible(visible);
@@ -412,9 +351,10 @@ void EncryptParamsInputDialog::onExpPathChanged(const QString &path, bool silent
     }
 
     QString msg;
-    btnNext->setEnabled(validateExportPath(path, &msg));
+    btnNext->setEnabled(recovery_key_utils::validateExportPath(
+            path, args.value(encrypt_param_keys::kKeyDevice).toString(), &msg));
     if (!msg.isEmpty() && !silent)
-        keyExportInput->showAlertMessage(msg);
+        keyExportInput->showAlertMessage(msg, 5000);
 }
 
 bool EncryptParamsInputDialog::encryptByTpm(const QString &deviceName)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptparamsinputdialog.h
@@ -36,7 +36,6 @@ protected:
     QWidget *createPasswordPage();
     QWidget *createExportPage();
     bool validatePassword();
-    bool validateExportPath(const QString &path, QString *msg);
     void setPasswordInputVisible(bool visible);
 
 protected Q_SLOTS:

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.cpp
@@ -12,11 +12,8 @@
 #include <QTimer>
 #include <QStackedLayout>
 #include <QIcon>
-#include <QStorageInfo>
 #include <QDebug>
 #include <DFileDialog>
-
-#include <dfm-mount/dmount.h>
 
 #include <dfm-base/utils/iconutils.h>
 
@@ -85,7 +82,7 @@ void EncryptProgressDialog::onCicked(int idx, const QString &btnTxt)
 
     QUrl url = DFileDialog::getExistingDirectoryUrl(this);
     QString msg;
-    if (!validateExportPath(url.toLocalFile(), &msg)) {
+    if (!recovery_key_utils::validateExportPath(url.toLocalFile(), device, &msg)) {
         fmWarning() << "Export path validation failed:" << msg;
         dialog_utils::showDialog(tr("Error"), msg);
     } else {
@@ -151,47 +148,6 @@ void EncryptProgressDialog::initUI()
 
     mainLay->addWidget(progressPage);
     mainLay->addWidget(resultPage);
-}
-
-bool EncryptProgressDialog::validateExportPath(const QString &path, QString *msg)
-{
-    auto setMsg = [&](const QString &info) { if (msg) *msg = info; };
-    if (path.isEmpty()) {
-        setMsg(tr("Recovery key export path cannot be empty!"));
-        return false;
-    }
-
-    if (!QDir(path).exists()) {
-        fmWarning() << "Export path does not exist:" << path;
-        setMsg(tr("Recovery key export path is not exists!"));
-        return false;
-    }
-
-    QStorageInfo storage(path);
-    if (storage.isReadOnly()) {
-        fmWarning() << "Export path is read-only:" << path;
-        setMsg(tr("This partition is read-only, please export to a writable "
-                  "partition"));
-        return false;
-    }
-
-    // Check if the export path itself is encrypted
-    using namespace dfmmount;
-    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
-    Q_ASSERT(monitor);
-    auto devObjPaths = monitor->resolveDeviceNode(storage.device(), {});
-    if (!devObjPaths.isEmpty()) {
-        auto objPath = devObjPaths.constFirst();
-        auto devPtr = monitor->createDeviceById(objPath);
-        if (devPtr && devPtr->getProperty(Property::kBlockCryptoBackingDevice).toString() != "/") {
-            fmWarning() << "Export path is on an encrypted partition:" << path;
-            setMsg(tr("The partition is encrypted, please export to a non-encrypted "
-                      "partition or external device such as a USB flash drive."));
-            return false;
-        }
-    }
-
-    return true;
 }
 
 void EncryptProgressDialog::saveRecKey(const QString &path)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/gui/encryptprogressdialog.h
@@ -34,7 +34,6 @@ protected Q_SLOTS:
 
 protected:
     void initUI();
-    bool validateExportPath(const QString &path, QString *msg);
     void saveRecKey(const QString &path);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -847,7 +847,39 @@ void DiskEncryptMenuScene::updateActions()
         }
     } else if (EventsHandler::instance()->unfinishedDecryptJob() == param.devDesc
                || EventsHandler::instance()->unfinishedDecryptJob() == param.devPhy) {
-        actions[kActIDResumeDecrypt]->setVisible(true);
+        // Defensive check: only show "Continue decrypt" if device is actually LUKS encrypted.
+        // This handles the case where the partition was reformatted after a decrypt job was interrupted.
+        const QString &idType = selectedItemInfo.value("IdType").toString();
+        // For overlay encryption, the device has a 2-layer DM structure:
+        // e.g. nvme0n1p5 -> usec-overlay-unlock-home (crypt/LUKS) -> usec-overlay-home (top).
+        // The top overlay layer is not crypto_LUKS itself, but it sits on top of a crypt layer,
+        // so the resume decrypt option should also be shown for overlay devices.
+        // The top overlay device's symlinks only contain "usec-overlay-xxx" (not "usec-overlay-unlock-xxx"),
+        // so we derive the unlock device name from the overlay name and check if it exists.
+        // Naming rule (see DMInitEncryptWorker): "overlay" -> "overlay-unlock".
+        bool hasOverlayCrypt = false;
+        if (idType != "crypto_LUKS") {
+            auto devSymlinks = selectedItemInfo.value("Symlinks").toStringList();
+            for (const QString &symlink : devSymlinks) {
+                int idx = symlink.indexOf(kOverleyEncPrefix);
+                if (idx < 0)
+                    continue;
+                // Extract the overlay device name, e.g. "usec-overlay-home"
+                QString overlayName = symlink.mid(idx);
+                // Derive the unlock device name, e.g. "usec-overlay-unlock-home"
+                QString unlockName = QString(overlayName).replace("overlay", "overlay-unlock");
+                QString unlockDevPath = "/dev/mapper/" + unlockName;
+                if (QFile::exists(unlockDevPath)) {
+                    hasOverlayCrypt = true;
+                    break;
+                }
+            }
+        }
+        if (idType == "crypto_LUKS" || hasOverlayCrypt) {
+            actions[kActIDResumeDecrypt]->setVisible(true);
+        } else {
+            fmInfo() << "Device has pending decrypt job but is not LUKS (may have been reformatted), hiding resume decrypt option:" << param.devDesc << "idType:" << idType;
+        }
     } else {
         actions[kActIDEncrypt]->setVisible(true);
     }

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -847,14 +847,7 @@ void DiskEncryptMenuScene::updateActions()
         }
     } else if (EventsHandler::instance()->unfinishedDecryptJob() == param.devDesc
                || EventsHandler::instance()->unfinishedDecryptJob() == param.devPhy) {
-        // Defensive check: only show "Continue decrypt" if device is actually LUKS encrypted.
-        // This handles the case where the partition was reformatted after a decrypt job was interrupted.
-        const QString &idType = selectedItemInfo.value("IdType").toString();
-        if (idType == "crypto_LUKS") {
-            actions[kActIDResumeDecrypt]->setVisible(true);
-        } else {
-            fmInfo() << "Device has pending decrypt job but is not LUKS (may have been reformatted), hiding resume decrypt option:" << param.devDesc << "idType:" << idType;
-        }
+        actions[kActIDResumeDecrypt]->setVisible(true);
     } else {
         actions[kActIDEncrypt]->setVisible(true);
     }

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
@@ -10,7 +10,6 @@
 #include <dfm-base/dfm_menu_defines.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
-#include <QTranslator>
 #include <QTimer>
 #include <QMenu>
 
@@ -102,13 +101,19 @@ void DiskEncryptEntry::processUnfinshedDecrypt(const QString &device)
         return;
     }
 
+    QString entryPath = device_utils::resolveEntryBlockDevPath(device);
+    if (entryPath.isEmpty()) {
+        fmWarning() << "Failed to resolve entry block dev path for device:" << device;
+        return;
+    }
+
     QMenu *menu = new QMenu();
     menu->addSeparator();
     DiskEncryptMenuScene *scene = new DiskEncryptMenuScene();
 
     QUrl url;
     url.setScheme("entry");
-    url.setPath(QString("%1.blockdev").arg(device.mid(5)));
+    url.setPath(entryPath);
     QVariant urls = QVariant::fromValue<QList<QUrl>>({ url });
     QVariantHash params;
     params.insert(dfmbase::MenuParamKey::kSelectFiles, urls);

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -21,6 +21,8 @@
 #include <QJsonDocument>
 #include <QDir>
 #include <QApplication>
+#include <QStorageInfo>
+#include <QFileInfo>
 #include <QFutureWatcher>
 #include <QtConcurrent>
 
@@ -30,6 +32,7 @@
 #include <fstab.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <cerrno>
 
 Q_DECLARE_METATYPE(bool *)
@@ -553,6 +556,96 @@ QString recovery_key_utils::formatRecoveryKey(const QString &raw)
     for (; dashCount > 0; dashCount--)
         formatted.insert(dashCount * kSectionLen, '-');
     return formatted;
+}
+
+bool recovery_key_utils::validateExportPath(const QString &path, const QString &targetDevice, QString *msg)
+{
+    auto setMsg = [&](const QString &info) { if (msg) *msg = info; };
+
+    if (path.isEmpty()) {
+        setMsg(QObject::tr("Recovery key export path cannot be empty!"));
+        return false;
+    }
+
+    if (!QDir(path).exists()) {
+        fmWarning() << "Export path does not exist:" << path;
+        setMsg(QObject::tr("Recovery key export path is not exists!"));
+        return false;
+    }
+
+    int dirFd = ::open(path.toLocal8Bit().constData(), O_PATH | O_NOFOLLOW | O_DIRECTORY);
+    if (dirFd < 0) {
+        fmWarning() << "Export path is a symlink or not a directory:" << path;
+        setMsg(QObject::tr("Recovery key export path cannot be a symlink or non-directory!"));
+        return false;
+    }
+
+    struct stat dirStat;
+    if (::fstat(dirFd, &dirStat) != 0) {
+        ::close(dirFd);
+        fmWarning() << "Cannot stat export path directory:" << path;
+        setMsg(QObject::tr("Cannot access the export path directory!"));
+        return false;
+    }
+    if (dirStat.st_mode & S_IWOTH) {
+        ::close(dirFd);
+        fmWarning() << "Export path directory is world-writable:" << path;
+        setMsg(QObject::tr("The export path directory is world-writable, please choose a safer location!"));
+        return false;
+    }
+    ::close(dirFd);
+
+    QStorageInfo storage(path);
+    if (storage.isReadOnly()) {
+        fmWarning() << "Export path is read-only:" << path;
+        setMsg(QObject::tr("This partition is read-only, please export to a writable partition"));
+        return false;
+    }
+
+    if (!targetDevice.isEmpty()) {
+        QString dev = storage.device();
+        QStringList associatedDevs { dev };
+        if (dev.startsWith("/dev/mapper/")) {
+            QFileInfo f(dev);
+            if (f.isSymbolicLink()) {
+                auto linkDev = f.symLinkTarget();
+                if (!linkDev.isEmpty()) {
+                    CREATE_DAEMON_INTERFACE(iface);
+                    if (iface.isValid()) {
+                        QDBusReply<QString> reply = iface.call("HolderDevice", linkDev);
+                        if (reply.isValid())
+                            associatedDevs.append(reply.value());
+                        else
+                            associatedDevs.append(linkDev);
+                    } else {
+                        associatedDevs.append(linkDev);
+                    }
+                }
+            }
+        }
+        if (associatedDevs.contains(targetDevice)) {
+            fmWarning() << "Export path is on the same device being encrypted:" << targetDevice;
+            setMsg(QObject::tr("Please export to an external device such as a non-encrypted partition or USB flash drive."));
+            return false;
+        }
+    }
+
+    using namespace dfmmount;
+    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
+    Q_ASSERT(monitor);
+    auto devObjPaths = monitor->resolveDeviceNode(storage.device(), {});
+    if (!devObjPaths.isEmpty()) {
+        auto objPath = devObjPaths.constFirst();
+        auto devPtr = monitor->createDeviceById(objPath);
+        if (devPtr && devPtr->getProperty(Property::kBlockCryptoBackingDevice).toString() != "/") {
+            fmWarning() << "Export path is on an encrypted partition:" << path;
+            setMsg(QObject::tr("The partition is encrypted, please export to a non-encrypted "
+                              "partition or external device such as a USB flash drive."));
+            return false;
+        }
+    }
+
+    return true;
 }
 
 BlockDev device_utils::createBlockDevice(const QString &devObjPath)

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.cpp
@@ -563,6 +563,138 @@ BlockDev device_utils::createBlockDevice(const QString &devObjPath)
     return monitor->createDeviceById(devObjPath).objectCast<DBlockDevice>();
 }
 
+/*!
+ * \brief Encode a block device name to UDisks2 object path format.
+ *
+ * UDisks2 encodes characters that are not [a-zA-Z0-9] as _<hex> in object paths.
+ * For example, "dm-2" becomes "dm_2d2" (- is 0x2d).
+ */
+static QString encodeBlockDevName(const QString &devName)
+{
+    QString encoded;
+    for (const auto &ch : devName) {
+        if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')) {
+            encoded.append(ch);
+        } else {
+            encoded.append(QString("_%1").arg(ch.unicode(), 2, 16, QChar('0')));
+        }
+    }
+    return encoded;
+}
+
+/*!
+ * \brief Traverse the sysfs holder chain to find the top DM device.
+ *
+ * For overlay encryption: nvme0n1p5 -> dm-0 (mid) -> dm-2 (top).
+ * The traversal stops at the first device that has no DM holders.
+ *
+ * \param device The physical device path (e.g., /dev/nvme0n1p5)
+ * \param devName The device name without /dev/ prefix (e.g., nvme0n1p5)
+ * \return The top DM device path, or the original device if no holders found.
+ */
+static QString traverseHolderChain(const QString &device, const QString &devName)
+{
+    static const QRegularExpression kValidDevName("^[a-zA-Z0-9_-]+$");
+
+    QString currentDev = device;
+    QString currentName = devName;
+
+    while (true) {
+        QString holdersPath = QString("/sys/class/block/%1/holders").arg(currentName);
+        QDir holdersDir(holdersPath);
+        if (!holdersDir.exists())
+            break;
+
+        auto holders = holdersDir.entryList(QDir::AllEntries | QDir::NoDotAndDotDot);
+        if (holders.isEmpty())
+            break;
+
+        // Find the first DM holder (defense in depth: also validate kernel-provided names)
+        QString nextDm;
+        for (const auto &h : holders) {
+            if (h.startsWith("dm-") && kValidDevName.match(h).hasMatch()) {
+                nextDm = h;
+                break;
+            }
+        }
+        if (nextDm.isEmpty())
+            break;
+
+        fmDebug() << "Found DM holder:" << nextDm << "for device:" << currentDev;
+        currentDev = "/dev/" + nextDm;
+        currentName = nextDm;
+    }
+
+    if (currentDev == device) {
+        fmDebug() << "No DM holder found for device, using original:" << device;
+    } else {
+        fmInfo() << "Resolved top DM device:" << currentDev << "from physical device:" << device;
+    }
+
+    return currentDev;
+}
+
+/*!
+ * \brief Resolve a device path to its UDisks2 entry URL path component.
+ *
+ * Uses the block monitor's resolveDeviceNode to get the canonical UDisks2
+ * object path, then strips the prefix and appends ".blockdev".
+ *
+ * \param currentDev The device path to resolve (e.g., /dev/dm-2)
+ * \param currentName The device name for fallback encoding (e.g., dm-2)
+ * \return The entry URL path (e.g., dm_2d2.blockdev), or empty string on failure.
+ */
+static QString resolveToEntryPath(const QString &currentDev, const QString &currentName)
+{
+    using namespace dfmmount;
+    auto monitor = DDeviceManager::instance()->getRegisteredMonitor(DeviceType::kBlockDevice).objectCast<DBlockMonitor>();
+    if (monitor) {
+        auto objPaths = monitor->resolveDeviceNode(currentDev, {});
+        if (!objPaths.isEmpty()) {
+            static constexpr char kBlockDeviceIdPrefix[] { "/org/freedesktop/UDisks2/block_devices/" };
+            QString shortName = objPaths.first();
+            shortName.remove(kBlockDeviceIdPrefix);
+            QString entryPath = QString("%1.blockdev").arg(shortName);
+            fmInfo() << "Resolved entry block dev path:" << entryPath << "from device:" << currentDev;
+            return entryPath;
+        }
+        fmWarning() << "resolveDeviceNode returned empty for:" << currentDev;
+    } else {
+        fmWarning() << "Failed to get block device monitor";
+    }
+
+    // Fallback: manually encode the device name
+    QString encodedName = encodeBlockDevName(currentName);
+    QString entryPath = QString("%1.blockdev").arg(encodedName);
+    fmInfo() << "Using fallback encoding for entry block dev path:" << entryPath << "from device:" << currentDev;
+    return entryPath;
+}
+
+QString device_utils::resolveEntryBlockDevPath(const QString &device)
+{
+    if (device.isEmpty()) {
+        fmWarning() << "Device path is empty, cannot resolve entry block dev path";
+        return QString();
+    }
+
+    // Extract device name from path (e.g., "/dev/nvme0n1p5" -> "nvme0n1p5")
+    QString devName = device;
+    if (devName.startsWith("/dev/"))
+        devName = devName.mid(5);
+
+    // Validate device name to prevent directory traversal attacks.
+    // Block device names only contain alphanumeric characters, hyphens, and underscores.
+    // This rejects inputs like "../../etc" that could escape /sys/class/block/.
+    static const QRegularExpression kValidDevName("^[a-zA-Z0-9_-]+$");
+    if (!kValidDevName.match(devName).hasMatch()) {
+        fmWarning() << "Invalid device name, potential path traversal detected:" << devName;
+        return QString();
+    }
+
+    QString currentDev = traverseHolderChain(device, devName);
+    return resolveToEntryPath(currentDev, currentDev.startsWith("/dev/") ? currentDev.mid(5) : currentDev);
+}
+
 int dialog_utils::showDialog(const QString &title, const QString &msg)
 {
     QString icon;

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -76,6 +76,7 @@ bool useOverlayDMMode();
 
 namespace recovery_key_utils {
 QString formatRecoveryKey(const QString &raw);
+bool validateExportPath(const QString &path, const QString &targetDevice, QString *msg = nullptr);
 }
 
 namespace device_utils {

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/utils/encryptutils.h
@@ -82,6 +82,19 @@ namespace device_utils {
 int encKeyType(const QString &dev);
 void cacheToken(const QString &device, const QVariantMap &token);
 BlockDev createBlockDevice(const QString &devObjPath);
+
+/*!
+ * \brief Resolve the entry URL block device path from a physical device path.
+ *
+ * For overlay encryption, the physical partition (e.g., /dev/nvme0n1p5) has
+ * DM device holders in sysfs. This function traverses the holder chain to
+ * find the top DM device, then resolves its UDisks2 object path to construct
+ * the entry URL path (e.g., dm_2d2.blockdev).
+ *
+ * \param device The physical device path (e.g., /dev/nvme0n1p5)
+ * \return The entry URL path (e.g., dm_2d2.blockdev), or empty string on failure.
+ */
+QString resolveEntryBlockDevPath(const QString &device);
 }   // namespace device_utils
 
 namespace dialog_utils {


### PR DESCRIPTION
- **fix: show resume decrypt option correctly for overlay encryption**
- **fix: hide resume decrypt option for non-LUKS devices after interrupted decrypt job**
- **refactor: extract validateExportPath to recovery_key_utils**

## Summary by Sourcery

Fix interrupted decryption handling for overlay devices and improve recovery-key export destination validation.

New Features:
- Support resuming interrupted decryption for overlay-encrypted devices by detecting their underlying LUKS layer.
- Resolve entry block-device paths through device-mapper holder chains for overlay-encrypted devices.

Bug Fixes:
- Hide the resume-decrypt action for interrupted jobs on devices that are neither LUKS nor overlay encrypted.
- Strengthen recovery-key export validation to reject unsafe, inaccessible, read-only, same-device, or encrypted destinations.

Enhancements:
- Centralize recovery-key export path validation for reuse across encryption dialogs.