### PR TITLE
fix: store isExpandable in item data role

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -643,6 +643,8 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
                                         { PropertyKey::kDisplayName, fileName } });
     SideBarInfoCacheMananger::instance()->addItemInfoCache(itemInfo);
 
+    item->setExpandable(true);
+
     // Sub-items are not editable and not draggable.
     Qt::ItemFlags flags = item->flags();
     flags &= ~Qt::ItemIsEditable;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -30,6 +30,7 @@ SideBarItem::SideBarItem(const SideBarItem &item)
     setIcon(item.icon());
     setUrl(item.url());
     setGroup(item.group());
+    setExpandable(item.isExpandable());
     setText(item.text());
 
     setData(kSidebarItem, kItemTypeRole);
@@ -90,6 +91,16 @@ bool SideBarItem::isHidden() const
 void SideBarItem::setHiiden(bool hidden)
 {
     setData(hidden, Roles::kItemHiddenRole);
+}
+
+bool SideBarItem::isExpandable() const
+{
+    return data(Roles::kItemExpandableRole).toBool();
+}
+
+void SideBarItem::setExpandable(bool expandable)
+{
+    setData(expandable, Roles::kItemExpandableRole);
 }
 
 QString SideBarItem::subGourp() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
@@ -24,6 +24,7 @@ public:
         kItemTypeRole,
         kItemHiddenRole,
         kItemIconNameRole,
+        kItemExpandableRole,
         kItemUserCustomRole = Dtk::UserRole + 0x0100
     };
 
@@ -51,6 +52,9 @@ public:
 
     bool isHidden() const;
     void setHiiden(bool hidden);
+
+    bool isExpandable() const;
+    void setExpandable(bool expandable);
 
     ItemInfo itemInfo() const;
 };

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -233,7 +233,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         iconMode = QIcon::Disabled;
     if (!suppressDraggedSelection && !isDraggingItemNotHighlighted && (selected || keepDrawingHighlighted))
         iconMode = QIcon::Selected;
-    bool isExpandable = sidebarItem && sidebarItem->itemInfo().isExpandable;
+    bool isExpandable = sidebarItem && sidebarItem->isExpandable();
     if (isExpandable)
         drawExpandIndicator(painter, itemRect, true, index, keepDrawingHighlighted);
     if (opt.features & QStyleOptionViewItem::HasDecoration)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -691,7 +691,7 @@ void SideBarView::mousePressEvent(QMouseEvent *event)
     auto index = indexAt(event->pos());
     if (event->button() == Qt::LeftButton && index.isValid()
         && item && item->group() == DefaultGroup::kDevice) {
-        if (item->itemInfo().isExpandable && SideBarHelper::partitionExpandable()) {
+        if (item->isExpandable() && SideBarHelper::partitionExpandable()) {
             int layer = 0;
             auto parentIdx = index;
             while (parentIdx.parent().isValid()) {

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -133,6 +133,8 @@ SideBarItem *SideBarHelper::createItemByInfo(const ItemInfo &info)
                                         info.group,
                                         info.url);
 
+    item->setExpandable(info.isExpandable);
+
     item->setFlags(info.flags);
 
     // create `unmount action` for removable device


### PR DESCRIPTION
## Root Cause Analysis

The sidebar tree sub-items render their indentation via `SideBarItemDelegate::drawExpandIndicator()`, which was gated on `isExpandable` read from `SideBarInfoCacheMananger::bindedInfos` — a `QMap` keyed solely by URL (`sidebarinfocachemananager.cpp:70`). When a directory already shown in an expanded sidebar tree is added to quick access, the bookmark's `ItemInfo` (where `isExpandable` defaults to false) overwrites the tree sub-item's cache entry under the same URL. The tree sub-item then reads `isExpandable=false` via `SideBarItem::itemInfo()` (`sidebaritem.cpp:102`), `drawExpandIndicator()` is skipped (`sidebaritemdelegate.cpp:236`), and the item jumps to the root indentation level — matching the bookmark offset exactly.

## Fix Approach

Store `isExpandable` in the `SideBarItem`'s own data role (`kItemExpandableRole`), mirroring how `group()` already reads item data rather than the shared cache. Create paths (`createItemByInfo`, `addSubItem`) write the value at construction; consumer paths (`SideBarItemDelegate::paint`, `SideBarView::mousePressEvent`) read it from the item. `bindedInfos` overwrite semantics are left untouched to avoid affecting bookmark refresh and other existing flows.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Target behavior (expand/collapse) was introduced by commit `33a080544` (partition expand/collapse migration); this change only relocates the data storage and does not revert the historical fix
- All consumer paths now read from the item data role, which is equivalent to the original logic while fixing the cache-overwrite problem; no signature changes, no external callers affected

### Business Impact Scope

Affected modules: sidebar tree directory expand/collapse and sidebar bookmarks/quick access. The change ensures tree sub-items keep their indentation after a same-URL directory is added to quick access, and that bookmarks and tree items with the same URL coexist correctly. No user-facing behavior change for valid scenarios.

### Verification Suggestion

Verify device partition expand/collapse still works, and that adding a directory to quick access does not break tree indentation. Confirm bookmarks and tree items with the same URL coexist at their correct positions.

---

## 根因分析

侧边栏树形子项的缩进由 `SideBarItemDelegate::drawExpandIndicator()` 绘制，其判定依据 `isExpandable`，而该值从 `SideBarInfoCacheMananger::bindedInfos`——一个以 URL 为唯一键的 `QMap`——读取（`sidebarinfocachemananager.cpp:70`）。当已展开树形目录中的子目录被添加到快捷访问时，书签的 `ItemInfo`（`isExpandable` 默认 false）按同 URL 覆盖树形子项的缓存条目。树形子项随后经 `SideBarItem::itemInfo()`（`sidebaritem.cpp:102`）读到 `isExpandable=false`，`drawExpandIndicator()` 不再绘制（`sidebaritemdelegate.cpp:236`），子项缩进消失、跳到根 item 位置——与书签位置偏移完全一致。

## 修复方案

将 `isExpandable` 存入 `SideBarItem` 自身数据角色（`kItemExpandableRole`），与 `group()` 读取 item 数据的模式对称。创建处（`createItemByInfo`、`addSubItem`）在构造时写入该值；消费点（`SideBarItemDelegate::paint`、`SideBarView::mousePressEvent`）改为从 item 读取。不动 `bindedInfos` 覆盖语义，避免影响书签刷新等既有流程。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标行为（展开/折叠）由 commit `33a080544`（分区展开/折叠功能迁移）引入；本次改动仅改变数据存储位置，不撤销历史修复
- 所有消费点改为读取 item 数据角色，与原逻辑等价并修复缓存覆盖问题；无签名变更，无外部调用者受影响

### 业务影响范围

受影响模块：侧边栏树形目录展开/折叠与侧边栏书签/快捷访问。改动确保树形子项在添加同 URL 目录到快捷访问后缩进不消失，书签与树形同 URL 项正确共存。有效场景下无面向用户的行为变化。

### 验证建议

验证设备分区展开/折叠功能正常，添加目录到快捷访问后树形目录缩进不消失，并确认书签与树形同 URL 项各自位置正确。

## Summary by Sourcery

Keep sidebar expandability on each item to prevent quick-access entries from disrupting tree layout and interactions.

Bug Fixes:
- Preserve sidebar tree item indentation and expand/collapse behavior when directories and quick-access bookmarks share the same URL.

Enhancements:
- Store each sidebar item's expandable state independently so shared URL cache entries cannot overwrite tree item state.