### PR TITLE
fix: store isExpandable in item data role

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -643,6 +643,8 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
                                         { PropertyKey::kDisplayName, fileName } });
     SideBarInfoCacheMananger::instance()->addItemInfoCache(itemInfo);
 
+    item->setExpandable(true);
+
     // Sub-items are not editable and not draggable.
     Qt::ItemFlags flags = item->flags();
     flags &= ~Qt::ItemIsEditable;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -30,6 +30,7 @@ SideBarItem::SideBarItem(const SideBarItem &item)
     setIcon(item.icon());
     setUrl(item.url());
     setGroup(item.group());
+    setExpandable(item.isExpandable());
     setText(item.text());
 
     setData(kSidebarItem, kItemTypeRole);
@@ -90,6 +91,16 @@ bool SideBarItem::isHidden() const
 void SideBarItem::setHiiden(bool hidden)
 {
     setData(hidden, Roles::kItemHiddenRole);
+}
+
+bool SideBarItem::isExpandable() const
+{
+    return data(Roles::kItemExpandableRole).toBool();
+}
+
+void SideBarItem::setExpandable(bool expandable)
+{
+    setData(expandable, Roles::kItemExpandableRole);
 }
 
 QString SideBarItem::subGourp() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.h
@@ -24,6 +24,7 @@ public:
         kItemTypeRole,
         kItemHiddenRole,
         kItemIconNameRole,
+        kItemExpandableRole,
         kItemUserCustomRole = Dtk::UserRole + 0x0100
     };
 
@@ -51,6 +52,9 @@ public:
 
     bool isHidden() const;
     void setHiiden(bool hidden);
+
+    bool isExpandable() const;
+    void setExpandable(bool expandable);
 
     ItemInfo itemInfo() const;
 };

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -214,7 +214,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         iconMode = QIcon::Disabled;
     if (!isDraggingItemNotHighlighted && (selected || keepDrawingHighlighted))
         iconMode = QIcon::Selected;
-    bool isExpandable = sidebarItem && sidebarItem->itemInfo().isExpandable;
+    bool isExpandable = sidebarItem && sidebarItem->isExpandable();
     if (isExpandable)
         drawExpandIndicator(painter, itemRect, true, index, keepDrawingHighlighted);
     if (opt.features & QStyleOptionViewItem::HasDecoration)

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -562,7 +562,7 @@ void SideBarView::mousePressEvent(QMouseEvent *event)
     auto index = indexAt(event->pos());
     if (event->button() == Qt::LeftButton && index.isValid()
         && item && item->group() == DefaultGroup::kDevice) {
-        if (item->itemInfo().isExpandable && SideBarHelper::partitionExpandable()) {
+        if (item->isExpandable() && SideBarHelper::partitionExpandable()) {
             int layer = 0;
             auto parentIdx = index;
             while (parentIdx.parent().isValid()) {

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarhelper.cpp
@@ -133,6 +133,8 @@ SideBarItem *SideBarHelper::createItemByInfo(const ItemInfo &info)
                                         info.group,
                                         info.url);
 
+    item->setExpandable(info.isExpandable);
+
     item->setFlags(info.flags);
 
     // create `unmount action` for removable device


### PR DESCRIPTION
## 背景

侧边栏展开树形目录后，对其中的子目录右键「添加到快捷访问」，该子项在树形展开目录中的位置会跳到根 item 位置（缩进消失），与书签位置偏移现象完全一致。

PMS: 374389

## 根因

树形子项缩进依赖从以 URL 为键的共享缓存（`SideBarInfoCache`）读取的 `isExpandable` 字段。当对同 URL 目录添加快捷访问时，书签创建会覆盖该缓存条目，导致 `isExpandable` 被置为 false，子项缩进丢失。

## 修复方案

将 `isExpandable` 存入 `SideBarItem` 自身的数据角色，与 `group()` 读取 item 数据的模式对称：创建路径写入、消费点改读 item 数据，不再依赖会被书签覆盖的共享缓存。

## 改动

- 6 个文件 +21/-2，全部位于 `dfmplugin-sidebar`
- 不改动 `bindedInfos` 覆盖语义，无签名变更，无外部调用者受影响

## 影响评估

- 验证侧边栏设备分区展开/折叠功能正常
- 验证添加目录到快捷访问后树形目录缩进不消失
- 验证书签与树形同 URL 项正确共存

注：此为 `release/snipe` 分支的 cherry-pick，内容与 master 修复一致（仅上下文行号因基线较旧而不同），对应 master PR #4219。

PMS: BUG-374389

## Summary by Sourcery

Prevent shared URL cache updates from altering the expandability state of sidebar tree items.

Bug Fixes:
- Preserve sidebar tree-item indentation and expandability when a directory with the same URL is added to quick access or bookmarks.

Enhancements:
- Store expandability on each sidebar item and use that item state for expansion indicators and interaction logic, preventing shared cache entries from being overwritten.