### PR TITLE
perf: 网络检查优化迁移 — NetworkUtils TTL 缓存

### DIFF
--- a/autotests/libs/dfm-base/test_devicehelper.cpp
+++ b/autotests/libs/dfm-base/test_devicehelper.cpp
@@ -425,11 +425,12 @@ TEST(DeviceHelperTest, CheckNetworkConnectionNonExistent)
 {
     stub_ext::StubExt stub;
     // Stub network check to avoid TCP timeout to broadcast address
-    // Select the (QString, QString, int) overload explicitly
-    bool (NetworkUtils::*checkNetFn)(const QString &, const QString &, int) =
+    // Select the (QString, QString, int, bool) overload explicitly
+    // (the bool useCache param was added to enable the TTL cache)
+    bool (NetworkUtils::*checkNetFn)(const QString &, const QString &, int, bool) =
         &NetworkUtils::checkNetConnection;
     stub.set_lamda(checkNetFn,
-                   [](NetworkUtils *, const QString &, const QString &, int) -> bool {
+                   [](NetworkUtils *, const QString &, const QString &, int, bool) -> bool {
                        return false;
                    });
 

--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -6,6 +6,7 @@
 #include "devicemanager.h"
 #include "deviceutils.h"
 #include "private/deviceproxymanager_p.h"
+#include <dfm-base/utils/networkutils.h>
 
 #include <QDBusServiceWatcher>
 #include <QCoreApplication>
@@ -515,6 +516,9 @@ void DeviceProxyManagerPrivate::addMounts(const QString &id, const QString &mpt)
 
 void DeviceProxyManagerPrivate::removeMounts(const QString &id, const QString &mpt)
 {
+    // 网络连接缓存可能与挂载点状态相关，挂载点移除时清除缓存
+    NetworkUtils::instance()->clearCache();
+
     // NOTE: signals are emitted outside the write lock to avoid deadlock.
     if (!mpt.isEmpty()) {
         // A specific mount point was unmounted: remove only that one.

--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -214,22 +214,21 @@ bool NetworkUtils::checkFtpOrSmbBusy(const QUrl &url)
     if (!parseIp(url.path(), host, ports))
         return false;
 
-    // 先查缓存，所有端口都 hit 且 busy=false 才算可用
+    // 先查缓存：所有端口都有缓存命中时，仅当全部 busy 才判 busy，
+    // 与非缓存路径 !checkNetConnection(host, ports) 语义一致
     bool allCached { true };
-    bool anyBusy { false };
+    bool allBusy { true };
     for (const auto &port : ports) {
         auto cached = getFromCache(host, port);
         if (!cached.timestamp.isValid()) {
             allCached = false;
             break;
         }
-        if (cached.busy) {
-            anyBusy = true;
-            break;
-        }
+        if (!cached.busy)
+            allBusy = false;
     }
     if (allCached)
-        return anyBusy;
+        return allBusy;
 
     auto busy = !checkNetConnection(host, ports);
     if (busy)

--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -36,7 +36,7 @@ NetworkUtils *NetworkUtils::instance()
     return &s;
 }
 
-bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, int msecs)
+bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, int msecs, const bool useCache)
 {
     if (host.isEmpty())
         return true;
@@ -46,6 +46,13 @@ bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, 
     if (!checkNet) {
         qCInfo(logDFMBase) << "NetworkUtils::checkNetConnection Skip network check." << host << port;
         return true;
+    }
+
+    if (useCache) {
+        // TTL 缓存命中 → 直接返回
+        auto cached = getFromCache(host, port);
+        if (cached.timestamp.isValid())
+            return !cached.busy;
     }
 
     qCInfo(logDFMBase) << "NetworkUtils::checkNetConnection net work check host = " << host << ", port = " << port << " !!!";
@@ -58,15 +65,19 @@ bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, 
     // 在QTcpSocket使用代理不能访问目标host的情况下，将QTcpSocket设置为不使用代理再次连接host，检查能否访问目标host
     if (!connected) {
         // 检查系统代理设置
+        // 注意：与 v20 不同，v25 仅在确实配置了代理（type != NoProxy）时才重试 NoProxy 连接；
+        // v20 无论是否有代理都会重置为 NoProxy 重连一次。此处保留 v25 既有语义。
         QNetworkProxy proxy = QNetworkProxy::applicationProxy();
-        if (proxy.type() == QNetworkProxy::NoProxy)
-            return connected;
-
-        conn.setProxy(QNetworkProxy::NoProxy);
-        conn.connectToHost(host, port.toUShort());
-        connected = conn.waitForConnected(msecs);
-        conn.close();
+        if (proxy.type() != QNetworkProxy::NoProxy) {
+            conn.setProxy(QNetworkProxy::NoProxy);
+            conn.connectToHost(host, port.toUShort());
+            connected = conn.waitForConnected(msecs);
+            conn.close();
+        }
     }
+
+    // 缓存结果（busy = !connected）
+    updateCache(host, port, !connected);
     return connected;
 }
 
@@ -105,7 +116,7 @@ void NetworkUtils::doAfterCheckNet(const QString &host, const QStringList &ports
 
         for (const auto &port : ports) {
             qApp->processEvents();
-            if (NetworkUtils::instance()->checkNetConnection(host, port, msecs))
+            if (NetworkUtils::instance()->checkNetConnection(host, port, msecs, false))
                 return true;
         }
         return false;
@@ -202,6 +213,23 @@ bool NetworkUtils::checkFtpOrSmbBusy(const QUrl &url)
     QStringList ports;
     if (!parseIp(url.path(), host, ports))
         return false;
+
+    // 先查缓存，所有端口都 hit 且 busy=false 才算可用
+    bool allCached { true };
+    bool anyBusy { false };
+    for (const auto &port : ports) {
+        auto cached = getFromCache(host, port);
+        if (!cached.timestamp.isValid()) {
+            allCached = false;
+            break;
+        }
+        if (cached.busy) {
+            anyBusy = true;
+            break;
+        }
+    }
+    if (allCached)
+        return anyBusy;
 
     auto busy = !checkNetConnection(host, ports);
     if (busy)
@@ -317,6 +345,41 @@ QUrl NetworkUtils::resolveLocalSftpMountUrl(const QUrl &url)
                           " resolved symlink target to local path:"
                        << localPath << "(original:" << url.toLocalFile() << ")";
     return QFile::exists(localPath) ? QUrl::fromLocalFile(localPath) : url;
+}
+
+// ─── TTL 缓存实现 ─────────────────────────────────────────
+
+QString NetworkUtils::makeCacheKey(const QString &host, const QString &port)
+{
+    return host + QLatin1Char(':') + port;
+}
+
+NetworkUtils::NetCacheEntry NetworkUtils::getFromCache(const QString &host, const QString &port) const
+{
+    QMutexLocker locker(&cacheMutex);
+    auto it = netCache.find(makeCacheKey(host, port));
+    if (it == netCache.end())
+        return {};
+
+    // 惰性过期检查
+    if (it.value().timestamp.msecsTo(QDateTime::currentDateTime()) >= kNetCacheTTLMs) {
+        netCache.erase(it);
+        return {};
+    }
+
+    return it.value();
+}
+
+void NetworkUtils::updateCache(const QString &host, const QString &port, bool busy)
+{
+    QMutexLocker locker(&cacheMutex);
+    netCache[makeCacheKey(host, port)] = { busy, QDateTime::currentDateTime() };
+}
+
+void NetworkUtils::clearCache()
+{
+    QMutexLocker locker(&cacheMutex);
+    netCache.clear();
 }
 
 NetworkUtils::NetworkUtils(QObject *parent)

--- a/src/dfm-base/utils/networkutils.h
+++ b/src/dfm-base/utils/networkutils.h
@@ -9,6 +9,9 @@
 
 #include <QObject>
 #include <QString>
+#include <QMap>
+#include <QDateTime>
+#include <QMutex>
 
 #include <functional>
 
@@ -21,7 +24,7 @@ class NetworkUtils : public QObject
 public:
     static NetworkUtils *instance();
 
-    bool checkNetConnection(const QString &host, const QString &port, int msecs = 1000);
+    bool checkNetConnection(const QString &host, const QString &port, int msecs = 1000, const bool useCache = true);
     bool checkNetConnection(const QString &host, QStringList ports, int msecs = 1000);
     void doAfterCheckNet(const QString &host, const QStringList &ports,
                          std::function<void(bool)> callback = nullptr, int msecs = 3000);
@@ -29,6 +32,19 @@ public:
     bool parseIp(const QString &mpt, QString &ip, QStringList &ports);
     bool checkAllCIFSBusy();
     bool checkFtpOrSmbBusy(const QUrl &url);
+
+    // TTL 缓存：避免短期内对同一 host:port 重复 TCP 连接
+    struct NetCacheEntry {
+        bool busy { false };
+        QDateTime timestamp;
+    };
+    static constexpr int kNetCacheTTLMs { 500 };   // 500 ms
+
+    static QString makeCacheKey(const QString &host, const QString &port);
+    NetCacheEntry getFromCache(const QString &host, const QString &port) const;
+    void updateCache(const QString &host, const QString &port, bool busy);
+    void clearCache();
+
     // if network mount，get network mount
     static QMap<QString, QString> cifsMountHostInfo();
 
@@ -45,6 +61,10 @@ public:
      * @return     Resolved local URL, or @p url unchanged when not applicable.
      */
     static QUrl resolveLocalSftpMountUrl(const QUrl &url);
+
+private:
+    mutable QMutex cacheMutex;
+    mutable QMap<QString, NetCacheEntry> netCache;
 
 protected:
     explicit NetworkUtils(QObject *parent = nullptr);


### PR DESCRIPTION
V-2474: 网络检查优化迁移 — NetworkUtils TTL 缓存

Closes V-2474

## 背景

将 v20 文管（gerrit `develop/107x-perf-opt` 分支）中 NetworkUtils 的网络连接检查缓存功能迁移到 v25（github master 分支）。该缓存通过 TTL（500ms）避免短期内对同一 `host:port` 重复发起 TCP 探测，降低 `checkFtpOrSmbBusy` / `checkAllCIFSBusy` 等热路径延迟。

## 改动内容

基于 v25 master `6e467555a`，共 3 个提交，涉及 4 个文件：

- `1b8c4efbe` feat: 缓存主体迁移
- `63f68bfd3` refine: `checkFtpOrSmbBusy` 缓存短路语义对齐
- `8472f6708` fix(ut): 适配 UT 中 `checkNetConnection` 新签名

**`src/dfm-base/utils/networkutils.h`**
- 新增 `QMap`/`QDateTime`/`QMutex` 头引用
- `checkNetConnection(host, port, msecs)` 增加 `useCache` 参数（默认 `true`）
- 新增 `NetCacheEntry`（`busy`+`timestamp`）、`kNetCacheTTLMs`(500ms)
- 新增 `makeCacheKey` / `getFromCache` / `updateCache` / `clearCache` 声明
- 新增 `cacheMutex`、`netCache` 私有成员（`mutable` 以支持 const 方法内惰性清理）

**`src/dfm-base/utils/networkutils.cpp`**
- `checkNetConnection`：TCP 探测前查缓存命中即返回，探测后写缓存；代理重试重构为仅在 `proxy.type()!=NoProxy` 时重试，确保所有路径均更新缓存（顺手修正 v25 原有「`NoProxy` 早返回跳过缓存写入」的盲区）。代理重试处补注释说明与 v20 的差异
- `doAfterCheckNet`：异步检查传 `useCache=false`，保证获取实时结果
- `checkFtpOrSmbBusy`：先遍历所有端口查缓存，全部命中时以 `allBusy`（全部 busy 才判 busy）短路返回，与非缓存路径 `!checkNetConnection(host, ports)` 语义一致
- 新增 `makeCacheKey` / `getFromCache`（惰性过期）/ `updateCache` / `clearCache` 实现，`QMutex` 保护线程安全

**`src/dfm-base/base/device/deviceproxymanager.cpp`**
- `removeMounts` 起始处调用 `NetworkUtils::instance()->clearCache()`，挂载点移除时清除缓存（与 v20 行为一致）

**`autotests/libs/dfm-base/test_devicehelper.cpp`**
- `CheckNetworkConnectionNonExistent` 用例的成员函数指针与 `set_lamda` 回调适配新的 4 参数 `checkNetConnection` 签名，修复 UT 编译失败

## 兼容性

- v25 独有方法（`checkAllCIFSBusy`、`cifsMountHostInfo`、`resolveLocalSftpMountUrl`）保持不变
- `useCache` 参数有默认值 `true`，现有调用方源码兼容
- 代理处理逻辑保留 v25 既有语义（仅在有代理时重试），与 v20 无条件重试有意不同，已补注释

## 验证

- 本环境无完整构建链（缺 `dfm6-io/mount/burn`、`libheif` 等），用 `g++ -fsyntax-only` 对受影响翻译单元逐个语法检查通过：`networkutils.cpp`、`test_networkutils.cpp`、修复后的 `test_devicehelper.cpp`
- 已通过 3 轮 @lz-code-review 代码审查，最终评分 A-，UT 编译修复通过第三轮复审
- 待本地完整编译 + UT 运行验证（用户已本地验证 UT 编译通过）

## Review 历史

issue 内已附完整审查记录（8/10 → A- → 通过），核心结论：缓存逻辑与 v20 逐行一致，线程安全与惰性过期正确，G01 缓存短路语义对齐提升健壮性，UT 修复最小且正确。

## Summary by Sourcery

Reduce repeated short-term TCP probes by migrating TTL-based NetworkUtils caching while preserving current connection-check semantics.

New Features:
- Add a 500 ms TTL cache for network connection checks keyed by host and port, with explicit cache bypass support for real-time checks.

Bug Fixes:
- Ensure network results are cached across all connection-check paths and clear cached results when mounts are removed.
- Align FTP/SMB cached short-circuit behavior with the existing all-ports busy semantics.
- Update the network-check unit test for the extended method signature.

Enhancements:
- Protect network cache access for concurrent use and lazily remove expired entries.

Tests:
- Adapt the device helper network-check test to the cache-enabled API.