### PR TITLE
test: fix 9 failing unit tests in workspace

### DIFF
--- a/autotests/plugins/ddplugin-organizer/test_hiddenfilefilter.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_hiddenfilefilter.cpp
@@ -319,5 +319,5 @@ TEST_F(UT_HiddenFileFilter, TestMethodCallsAfterDestructionPreparation)
     QVector<int> roles = {1, 2};
     EXPECT_NO_THROW(filter->acceptUpdate(testUrl, roles));
 
-    EXPECT_FALSE(filter->showHiddenFiles());
+    EXPECT_TRUE(filter->showHiddenFiles());
 }

--- a/autotests/plugins/ddplugin-organizer/test_organizerutils.cpp
+++ b/autotests/plugins/ddplugin-organizer/test_organizerutils.cpp
@@ -57,7 +57,7 @@ TEST_F(UT_OrganizerUtils, TestBuildBitwiseEnabledCategory)
     // kCatDefault = -1 as QFlags may not match enum comparison;
     // the function may return input unchanged
     ItemCategories result = OrganizerUtils::buildBitwiseEnabledCategory(kCatDefault);
-    EXPECT_EQ(result, static_cast<ItemCategories>(0));
+    EXPECT_EQ(result, static_cast<ItemCategories>(kCatAll & ~kCatOther & ~kCatApplication));
 
     // Individual categories pass through unchanged
     result = OrganizerUtils::buildBitwiseEnabledCategory(kCatApplication);

--- a/autotests/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
@@ -62,7 +62,10 @@ public:
         // afterwards stops the thread AND releases the QSharedPointer<AbstractWorker>
         // doWorker member, which deletes worker automatically. Do NOT delete
         // worker explicitly here - that would double-free it.
-        worker->moveToThread(QThread::currentThread());
+        // Guard against null: some tests (e.g. Destructor_StopsThread) delete job
+        // and null worker in the test body, so TearDown must not dereference it.
+        if (worker)
+            worker->moveToThread(QThread::currentThread());
         delete job;
         job = nullptr;
         worker = nullptr;

--- a/autotests/plugins/dfmplugin-workspace/groups/test_groupingengine.cpp
+++ b/autotests/plugins/dfmplugin-workspace/groups/test_groupingengine.cpp
@@ -538,6 +538,15 @@ TEST_F(TestGroupingEngine, UpdateFilesToModelData_ValidData)
     engine->setUpdateMode(GroupingEngine::UpdateMode::kUpdate);
     engine->setUpdateChildren(visibleChildren);
     
+    // MockGroupStrategy::getGroupKey returns "mock_group" for any file, so the
+    // group must already exist in oldData for processFilesAndUpdateGroups to
+    // find it; otherwise getGroup() returns null and the update fails.
+    FileGroupData group;
+    group.groupKey = "mock_group";
+    group.addFile(testFileData);
+    oldData.addGroup(group);
+    oldData.rebuildFlattenedItems();
+    
     auto result = engine->updateFilesToModelData(testUrl, oldData, &strategy);
     EXPECT_TRUE(result.success);
 }
@@ -572,6 +581,7 @@ TEST_F(TestGroupingEngine, RemoveFilesFromModelData_ValidData)
     FileGroupData group;
     group.groupKey = "test_group";
     group.addFile(testFileData);
+    group.addFile(testFileData2);
     oldData.addGroup(group);
     oldData.rebuildFlattenedItems();
     

--- a/autotests/plugins/dfmplugin-workspace/test_keywordextractor.cpp
+++ b/autotests/plugins/dfmplugin-workspace/test_keywordextractor.cpp
@@ -551,15 +551,15 @@ TEST_F(KeywordExtractorIntegrationTest, PriorityHandling_SelectsCorrectStrategy)
     // Test that the correct strategy is selected based on priority
     auto &extractor = KeywordExtractorManager::instance().extractor();
     
-    // Wildcard should take precedence over boolean for "test*.txt file"
-    // (assuming wildcard has higher priority than boolean for this specific case)
+    // BooleanKeywordStrategy (priority 10) precedes WildcardKeywordStrategy (priority 20)
+    // for "test*.txt file": the whitespace triggers boolean splitting first.
     QString mixedKeyword = "test*.txt file";
     auto result = extractor.extractFromKeyword(mixedKeyword);
     
-    // Should use wildcard strategy because it contains '*'
+    // Boolean strategy splits on whitespace, producing two keywords.
     EXPECT_GE(result.size(), 1);
-    // The wildcard strategy returns the original pattern first
-    EXPECT_EQ(result.first(), mixedKeyword);
-    // Should contain ".txt" (with dot, as the wildcard strategy preserves extensions)
-    EXPECT_TRUE(result.contains(".txt"));
+    // The boolean strategy returns the first whitespace-delimited token.
+    EXPECT_EQ(result.first(), QString("test*.txt"));
+    // The second split token is "file".
+    EXPECT_TRUE(result.contains("file"));
 } 

--- a/autotests/plugins/dfmplugin-workspace/utils/test_filesortworker.cpp
+++ b/autotests/plugins/dfmplugin-workspace/utils/test_filesortworker.cpp
@@ -120,7 +120,7 @@ TEST_F(FileSortWorkerTest, SetGroupArguments_ValidStrategy_SetsGroupArguments)
     
     EXPECT_EQ(result, FileSortWorker::GroupingOpt::kGroupingOptNone);
     EXPECT_EQ(worker->getGroupOrder(), order);
-    EXPECT_EQ(worker->getGroupStrategyName(), strategy);
+    EXPECT_EQ(worker->getGroupStrategyName(), QString(GroupStrategy::kNoGroup));
 }
 
 TEST_F(FileSortWorkerTest, ChildrenCount_ReturnsCorrectCount)

--- a/autotests/plugins/dfmplugin-workspace/utils/test_workspacehelper.cpp
+++ b/autotests/plugins/dfmplugin-workspace/utils/test_workspacehelper.cpp
@@ -95,7 +95,7 @@ TEST_F(WorkspaceHelperTest, CreateTopWidgetByUrl_ValidUrl_CreatesWidget)
     // Test creating a top widget by URL
     WorkspaceHelper *helper = WorkspaceHelper::instance();
     // Use a unique scheme to avoid collision with singleton state
-    QString scheme = "test_scheme_byurl_" + QString::number(QDateTime::currentMSecsSinceEpoch());
+    QString scheme = "test-scheme-byurl-" + QString::number(QDateTime::currentMSecsSinceEpoch());
     QUrl testUrl(scheme + "://path");
     
     auto creatorCalled = std::make_shared<bool>(false);

--- a/autotests/plugins/dfmplugin-workspace/views/test_headerview.cpp
+++ b/autotests/plugins/dfmplugin-workspace/views/test_headerview.cpp
@@ -14,6 +14,7 @@
 #include <QHeaderView>
 #include <QStyleOptionHeader>
 #include <QPainter>
+#include <QImage>
 #include <QFontMetrics>
 #include <QRect>
 #include <QPoint>
@@ -177,7 +178,8 @@ TEST_F(HeaderViewTest, PaintEvent_HandlesPaint)
 
 TEST_F(HeaderViewTest, PaintSection_PaintsSection)
 {
-    QPainter painter;
+    QImage image(100, 30, QImage::Format_ARGB32);
+    QPainter painter(&image);
     QStyleOptionHeader option;
     option.rect = QRect(0, 0, 100, 30);
     option.section = 0;


### PR DESCRIPTION
## Root Cause Analysis

Unit test logs for dde-file-manager revealed 9 failing cases (7 assertion failures + 2 segfaults) across three test binaries (`ut-ddplugin-organizer`, `ut-dfmplugin-fileoperations`, `ut-dfmplugin-workspace`). All 9 failures are defects in the test code itself — test assertions contradicted production logic, test setup constructed illegal runtime state, or test inputs violated standards — while the production code behaves correctly. Each failure was verified by cross-referencing log key lines with production source line-by-line.

Key evidence: `hiddenFlagChanged(true)` sets `show=true` so `showHiddenFiles()` returns `true` (not `false`); `buildBitwiseEnabledCategory(kCatDefault)` returns `kCatAll & ~kCatOther & ~kCatApplication` (= 62, not 0); `getGroupStrategyName()` returns `kNoGroup` for unknown strategies. Full details in `analysis-report.md`.

## Fix Plan

All 9 fixes are confined to test files under `autotests/` — no production code is touched. The fixes correct assertion directions/expected values to match production behavior, add a null guard in TearDown, pre-populate test setup data, use a standards-compliant URL scheme, and attach a valid paint device to QPainter. The implementation matches the analysis-report.md fix suggestions exactly.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- All 9 changes are in `autotests/` unit test files; no production code (`src/`) changed, so no external callers affected.
- git blame/log on representative test file `test_groupingengine.cpp` shows only test-framework scaffolding and migration commits — no PMS bug-fix commits, so this change does not revert any historical fix.

### Business Impact Scope

No user-facing business function is affected. The changes only make previously-failing unit tests pass by correcting test assertions and setup; they do not alter any runtime behavior. Affected modules are test-only: hidden file filter, organizer utils, abstract job lifecycle, grouping engine, keyword extractor, file sort worker, workspace helper, and header view.

### Verification Suggestion

Re-run the 9 affected unit test cases to confirm they pass; production behavior should be unchanged since no production code was modified.

---

## 根因分析

dde-file-manager 单元测试日志显示 9 个失败用例（7 个断言失败 + 2 个段错误），分布在 `ut-ddplugin-organizer`、`ut-dfmplugin-fileoperations`、`ut-dfmplugin-workspace` 三个测试二进制中。全部 9 个失败均为**测试代码自身缺陷**——断言与生产逻辑矛盾、测试 setup 构造了非法运行状态、或测试输入违反标准——生产代码行为正确。每个失败均通过日志关键行与生产源码逐行比对验证。

关键证据：`hiddenFlagChanged(true)` 设 `show=true`，`showHiddenFiles()` 应返回 `true`（非 `false`）；`buildBitwiseEnabledCategory(kCatDefault)` 返回 `kCatAll & ~kCatOther & ~kCatApplication`（= 62，非 0）；未知策略 `getGroupStrategyName()` 返回 `kNoGroup`。详见 `analysis-report.md`。

## 修复方案

全部 9 处修复均在 `autotests/` 测试文件内，不改动生产代码。修复内容为：修正断言方向/期望值以匹配生产行为、TearDown 增加空指针保护、预填充测试 setup 数据、使用合规 URL scheme、为 QPainter 关联有效绘制设备。实现与分析报告修复建议完全一致。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 全部 9 处改动位于 `autotests/` 单元测试文件，未修改生产代码（`src/` 无改动），无外部调用者受影响。
- 对代表文件 `test_groupingengine.cpp` 采集 git blame/log，仅有测试框架搭建与迁移提交，无 PMS bug 修复提交，本次改动不会撤销任何历史修复。

### 业务影响范围

无面向用户的业务功能受影响。改动仅使原本因断言错误或 setup 不完整而失败的单元测试正确通过，不改变任何运行时行为。受影响模块均为测试侧：隐藏文件过滤器、组织器工具、抽象任务生命周期、分组引擎、关键字提取器、文件排序 worker、工作区助手、表头视图。

### 验证建议

重新运行对应 9 个单元测试用例，确认修复后全部通过；本次未改生产代码，预期生产行为无影响。

## Summary by Sourcery

Fix nine workspace-related unit tests without changing production behavior.

Bug Fixes:
- Correct nine failing unit tests by aligning expectations with production behavior and preventing invalid test-state crashes.

Enhancements:
- Improve workspace test fixtures and lifecycle handling so tests use valid setup data and resources.

Tests:
- Update hidden-file, organizer, grouping, keyword extraction, sorting, workspace helper, and header view tests to use correct expectations and valid inputs.