### PR TITLE
fix: sync sidebar editDisplayText on device rename

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -475,6 +475,7 @@ void ComputerModel::onItemPropertyChanged(const QUrl &url, const QString &key, c
     if (key == DeviceProperty::kIdLabel && !val.toString().isEmpty()) {
         QVariantMap map {
             { "Property_Key_DisplayName", val.toString() },
+            { "Property_Key_EditDisplayText", val.toString() },
             { "Property_Key_Editable", true }
         };
         dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", url, map);

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -636,6 +636,7 @@ void ComputerItemWatcher::updateSidebarItem(const QUrl &url, const QString &newN
     DFMEntryFileInfoPointer info(new EntryFileInfo(url));
     QVariantMap map {
         { "Property_Key_DisplayName", newName },
+        { "Property_Key_EditDisplayText", info->editDisplayText() },
         { "Property_Key_Editable", editable },
         { "Property_Key_FinalUrl", findFinalUrl(info) },
         { "Property_Key_ItemExpandable", info->targetUrl().isValid() }
@@ -921,7 +922,8 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
             // when these properties changed, reload the cache.
             QStringList queryInfoOnChanged { DeviceProperty::kOptical,
                                              DeviceProperty::kFileSystem,
-                                             DeviceProperty::kCleartextDevice };
+                                             DeviceProperty::kCleartextDevice,
+                                             DeviceProperty::kIdLabel };
             if (queryInfoOnChanged.contains(propertyName))
                 onUpdateBlockItem(id);
 


### PR DESCRIPTION
## Root Cause Analysis

When a block device (USB) is renamed, udisks2 changes the device `IdLabel` and emits a `PropertiesChanged` signal that reaches `ComputerModel::onItemPropertyChanged()` (Path B, `computermodel.cpp:475`). This path pushes a sidebar update, but the update map only carries `DisplayName` and `Editable`, omitting `EditDisplayText`. The sidebar's `handleItemUpdate()` only updates `editDisplayText` when that key is present, so the cached value stays stale; the edit-mode `setEditorData()` (`sidebaritemdelegate.cpp:373`) reads the stale `editDisplayText` and shows the old name on the next rename. The computer view is unaffected because it reads directly from its in-memory cache, which `onItemPropertyChanged` updates inline. Additionally, `kIdLabel` is missing from the `queryInfoOnChanged` whitelist (`computeritemwatcher.cpp:923`), so `onUpdateBlockItem()` (the full sidebar refresh) is never triggered on rename.

Key evidence: `computermodel.cpp:475-481` (Path B update map missing `EditDisplayText`); `computeritemwatcher.cpp:923` (`kIdLabel` absent from `queryInfoOnChanged`).

## Fix

Three low-risk additive changes: (1) add `Property_Key_EditDisplayText` to the Path B sidebar update map; (2) add `DeviceProperty::kIdLabel` to the `queryInfoOnChanged` list so rename triggers a full `onUpdateBlockItem` refresh; (3) keep the prior Path A `updateSidebarItem` `EditDisplayText` fix, which Fix 2 now also activates on rename. Implementation matches the analysis recommendation with no deviation.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- All three changes are purely additive (map/list entries); no signature changes, no deletions, no broad caller impact. Blame shows the Path B omission originated in a 2022 refactor (`8a933e167`, "remove sidebarservice") that simplified the sidebar update map and dropped `EditDisplayText` — this fix restores parity with the creation path (`makeSidebarItem`), not reverting any prior bug fix.

### Business Impact Scope

- **Sidebar device rename** — after renaming a USB drive in the sidebar, the edit box shows the previously-renamed name (not the original); full sidebar refresh now occurs in both mounted and unmounted states.
- **Computer view rename** — unaffected (reads from in-memory cache directly).

### Verification Suggestion

Test repeated sidebar USB renames (3+ times) verifying the edit box shows the prior name each time; test sidebar rename in unmounted state; regression-test computer view rename.

---

## 根因分析

重命名块设备（U 盘）时，udisks2 修改设备 `IdLabel` 并发出 `PropertiesChanged` 信号，到达 `ComputerModel::onItemPropertyChanged()`（Path B，`computermodel.cpp:475`）。该路径向侧边栏推送更新，但更新包只携带 `DisplayName` 和 `Editable`，遗漏 `EditDisplayText`。侧边栏 `handleItemUpdate()` 仅在该 key 存在时更新 `editDisplayText`，故缓存值保持旧值；编辑态 `setEditorData()`（`sidebaritemdelegate.cpp:373`）读取旧的 `editDisplayText`，导致下次重命名编辑框显示旧名称。计算机视图直接从内存缓存读取（`onItemPropertyChanged` 已行内更新），故不受影响。此外 `kIdLabel` 不在 `queryInfoOnChanged` 白名单（`computeritemwatcher.cpp:923`），重命名后不触发 `onUpdateBlockItem()` 完整刷新。

关键证据：`computermodel.cpp:475-481`（Path B 更新包缺 `EditDisplayText`）；`computeritemwatcher.cpp:923`（`kIdLabel` 不在 `queryInfoOnChanged`）。

## 修复方案

三处低风险增量改动：(1) Path B 侧边栏更新包补充 `Property_Key_EditDisplayText`；(2) `queryInfoOnChanged` 列表追加 `kIdLabel` 使重命名触发 `onUpdateBlockItem` 完整刷新；(3) 保留上一轮 Path A `updateSidebarItem` 的 `EditDisplayText` 补充，修复 2 使其在重命名时也触发。实现与分析建议完全一致，无偏离。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 三处改动均为纯增量（map/list 条目），无签名变更、无删除、无大范围调用者受影响。Blame 显示 Path B 遗漏源于 2022 年重构（`8a933e167`，"remove sidebarservice"）简化侧边栏更新包时丢掉了 `EditDisplayText`——本次修复恢复与创建路径 `makeSidebarItem` 的一致性，未撤销任何历史 bug 修复。

### 业务影响范围

- **侧边栏设备重命名** — 侧边栏重命名 U 盘后，编辑框显示上次重命名的名称（非原始名称）；挂载与卸载态下均触发完整侧边栏刷新。
- **计算机视图重命名** — 不受影响（直接从内存缓存读取）。

### 验证建议

侧边栏连续多次重命名 U 盘（3 次以上），每次编辑框显示上一次名称；侧边栏卸载态重命名验证界面刷新；回归测试计算机视图重命名。

## Summary by Sourcery

Bug Fixes:
- Synchronize sidebar edit text and trigger full sidebar refreshes when block device labels change, ensuring repeated device renames display the current name in the editor.