### PR TITLE
fix: sync sidebar editDisplayText on device rename

### DIFF
--- a/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/models/computermodel.cpp
@@ -475,6 +475,7 @@ void ComputerModel::onItemPropertyChanged(const QUrl &url, const QString &key, c
     if (key == DeviceProperty::kIdLabel && !val.toString().isEmpty()) {
         QVariantMap map {
             { "Property_Key_DisplayName", val.toString() },
+            { "Property_Key_EditDisplayText", val.toString() },
             { "Property_Key_Editable", true }
         };
         dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", url, map);

--- a/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-computer/watcher/computeritemwatcher.cpp
@@ -636,6 +636,7 @@ void ComputerItemWatcher::updateSidebarItem(const QUrl &url, const QString &newN
     DFMEntryFileInfoPointer info(new EntryFileInfo(url));
     QVariantMap map {
         { "Property_Key_DisplayName", newName },
+        { "Property_Key_EditDisplayText", info->editDisplayText() },
         { "Property_Key_Editable", editable },
         { "Property_Key_FinalUrl", findFinalUrl(info) },
         { "Property_Key_ItemExpandable", info->targetUrl().isValid() }
@@ -921,7 +922,8 @@ void ComputerItemWatcher::onDevicePropertyChangedQDBusVar(const QString &id, con
             // when these properties changed, reload the cache.
             QStringList queryInfoOnChanged { DeviceProperty::kOptical,
                                              DeviceProperty::kFileSystem,
-                                             DeviceProperty::kCleartextDevice };
+                                             DeviceProperty::kCleartextDevice,
+                                             DeviceProperty::kIdLabel };
             if (queryInfoOnChanged.contains(propertyName))
                 onUpdateBlockItem(id);
 


### PR DESCRIPTION
1. Root cause: onItemPropertyChanged (Path B) pushes only DisplayName
   and Editable to sidebar on kIdLabel change, omitting EditDisplayText,
   so the sidebar cache keeps the stale name and the edit box shows it
   on the next rename. kIdLabel is also missing from queryInfoOnChanged
   so onUpdateBlockItem is not called after rename, leaving the sidebar
   refresh incomplete
2. Fix: add Property_Key_EditDisplayText to the Path B update map; add
   DeviceProperty::kIdLabel to queryInfoOnChanged so rename triggers a
   full onUpdateBlockItem refresh; keep the prior updateSidebarItem
   (Path A) editDisplayText fix
3. Impact: sidebar edit box shows the last renamed name on repeated
   renames; sidebar refreshes after rename in mounted and unmounted
   states; computer view unaffected

Log: Sidebar edit box now shows the correct name on device rename

Influence:
1. Test sidebar USB rename repeatedly, edit box shows the previous
   name each time
2. Test sidebar rename in unmounted state, verify sidebar refreshes
3. Regression: computer view rename still works correctly

fix: 修复侧边栏重命名后编辑框显示旧名称

1. 根因：onItemPropertyChanged（Path B）在 kIdLabel 变化时只向侧边栏
   推送 DisplayName 和 Editable，遗漏 EditDisplayText，侧边栏缓存保留
   旧名称导致下次重命名编辑框显示旧值；kIdLabel 未加入
   queryInfoOnChanged 导致重命名后不触发 onUpdateBlockItem 完整刷新
2. 方案：Path B 更新包补充 Property_Key_EditDisplayText；
   queryInfoOnChanged 列表追加 kIdLabel 使重命名触发完整刷新；
   保留上一轮 updateSidebarItem（Path A）的 editDisplayText 补充
3. 影响：侧边栏连续重命名编辑框显示上次名称；挂载/卸载态重命名后
   侧边栏均正确刷新；计算机视图不受影响

Log: 修复侧边栏设备重命名后编辑框显示旧名称的问题

Influence:
1. 测试侧边栏 U 盘连续多次重命名，每次编辑框均显示上一次名称
2. 测试侧边栏卸载态重命名，验证界面正确刷新
3. 回归：计算机视图重命名功能不受影响

PMS: BUG-374545

## Summary by Sourcery

Bug Fixes:
- Fix sidebar device renames so the edit field displays the current name across repeated renames and refreshes correctly in mounted and unmounted states.