### PR TITLE
perf: 迁移 v20 FTS 文件彻底删除功能到 v25

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.operations.json
+++ b/assets/configs/org.deepin.dde.file-manager.operations.json
@@ -45,6 +45,17 @@
             "description": "Show/hide the 'Run' and 'Run in Terminal' buttons when double clicking on an executable file",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "file.operation.useftsdelete": {
+            "value":true,
+            "serial":0,
+            "flags":[],
+            "name":"FTS delete files",
+            "name[zh_CN]":"使用FTS删除文件",
+            "description[zh_CN]":"是否使用FTS接口删除文件",
+            "description":"Whether to use the FTS interface to delete files",
+            "permissions":"readwrite",
+            "visibility":"private"
         }
     }
 }

--- a/autotests/old/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
+++ b/autotests/old/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
@@ -446,7 +446,7 @@ TEST_F(TestAbstractJob, HandleFileDeleted_EmitsSignal)
 {
     QUrl url = QUrl::fromLocalFile("/tmp/deleted.txt");
 
-    job->handleFileDeleted(url);
+    job->handleFileDeleted({url});
     SUCCEED();
 }
 

--- a/autotests/old/plugins/dfmplugin-fileoperations/test_dodeletefilesworker.cpp
+++ b/autotests/old/plugins/dfmplugin-fileoperations/test_dodeletefilesworker.cpp
@@ -307,7 +307,7 @@ TEST_F(TestDoDeleteFilesWorker, DeleteFilesOnOtherDevice_SingleFile)
 
     bool signalEmitted = false;
     QObject::connect(worker, &DoDeleteFilesWorker::fileDeleted,
-                     [&signalEmitted](const QUrl &) {
+                     [&signalEmitted](const QList<QUrl> &) {
                          signalEmitted = true;
                      });
 
@@ -380,7 +380,7 @@ TEST_F(TestDoDeleteFilesWorker, DeleteFilesOnCanNotRemoveDevice_MultipleFiles)
 
     bool signalEmitted = false;
     QObject::connect(worker, &DoDeleteFilesWorker::fileDeleted,
-                     [&signalEmitted](const QUrl &) {
+                     [&signalEmitted](const QList<QUrl> &) {
                          signalEmitted = true;
                      });
 

--- a/autotests/old/plugins/dfmplugin-fileoperations/test_domovetotrashfilesworker.cpp
+++ b/autotests/old/plugins/dfmplugin-fileoperations/test_domovetotrashfilesworker.cpp
@@ -378,7 +378,7 @@ TEST_F(TestDoMoveToTrashFilesWorker, SignalEmission_FileDeleted)
 
     bool signalEmitted = false;
     QObject::connect(worker, &DoMoveToTrashFilesWorker::fileDeleted,
-                     [&signalEmitted](const QUrl &) {
+                     [&signalEmitted](const QList<QUrl> &) {
                          signalEmitted = true;
                      });
     using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);

--- a/autotests/old/plugins/dfmplugin-search/test_searcheventreceiver.cpp
+++ b/autotests/old/plugins/dfmplugin-search/test_searcheventreceiver.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <QUrl>
+#include <QList>
 #include <QSignalSpy>
 
 #include "events/searcheventreceiver.h"
@@ -252,10 +253,10 @@ TEST_F(TestSearchEventReceiver, HandleFileDelete_EmitsSearchManagerSignal)
     // Use QSignalSpy to verify signal emission
     QSignalSpy spy(&mockManager, &SearchManager::fileDelete);
 
-    receiver->handleFileDelete(url);
+    receiver->handleFileDelete({url});
 
     EXPECT_EQ(spy.count(), 1);
-    EXPECT_EQ(spy.at(0).at(0).toUrl(), url);
+    EXPECT_EQ(spy.at(0).at(0).value<QList<QUrl>>(), QList<QUrl>{url});
 }
 
 TEST_F(TestSearchEventReceiver, HandleFileRename_EmitsSearchManagerSignal)

--- a/autotests/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_abstractjob.cpp
@@ -443,7 +443,7 @@ TEST_F(TestAbstractJob, HandleFileDeleted_EmitsSignal)
 {
     QUrl url = QUrl::fromLocalFile("/tmp/deleted.txt");
 
-    job->handleFileDeleted(url);
+    job->handleFileDeleted({url});
     SUCCEED();
 }
 

--- a/autotests/plugins/dfmplugin-fileoperations/test_dodeletefilesworker.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_dodeletefilesworker.cpp
@@ -307,7 +307,7 @@ TEST_F(TestDoDeleteFilesWorker, DeleteFilesOnOtherDevice_SingleFile)
 
     bool signalEmitted = false;
     QObject::connect(worker, &DoDeleteFilesWorker::fileDeleted,
-                     [&signalEmitted](const QUrl &) {
+                     [&signalEmitted](const QList<QUrl> &) {
                          signalEmitted = true;
                      });
 
@@ -380,7 +380,7 @@ TEST_F(TestDoDeleteFilesWorker, DeleteFilesOnCanNotRemoveDevice_MultipleFiles)
 
     bool signalEmitted = false;
     QObject::connect(worker, &DoDeleteFilesWorker::fileDeleted,
-                     [&signalEmitted](const QUrl &) {
+                     [&signalEmitted](const QList<QUrl> &) {
                          signalEmitted = true;
                      });
 

--- a/autotests/plugins/dfmplugin-fileoperations/test_domovetotrashfilesworker.cpp
+++ b/autotests/plugins/dfmplugin-fileoperations/test_domovetotrashfilesworker.cpp
@@ -378,7 +378,7 @@ TEST_F(TestDoMoveToTrashFilesWorker, SignalEmission_FileDeleted)
 
     bool signalEmitted = false;
     QObject::connect(worker, &DoMoveToTrashFilesWorker::fileDeleted,
-                     [&signalEmitted](const QUrl &) {
+                     [&signalEmitted](const QList<QUrl> &) {
                          signalEmitted = true;
                      });
     using WaitFunc = bool (QWaitCondition::*)(QMutex *, QDeadlineTimer);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/cleantrash/docleantrashfilesworker.cpp
@@ -152,7 +152,7 @@ bool DoCleanTrashFilesWorker::clearTrashFile(const FileInfoPointer &trashInfo)
             action = doHandleErrorAndWait(fileUrl, AbstractJobHandler::JobErrorType::kDeleteTrashFileError,
                                           false, localFileHandler->errorString());
         } else {
-            emit fileDeleted(fileUrl);
+            emit fileDeleted({fileUrl});
         }
 
     } while (isStopped() && action == AbstractJobHandler::SupportAction::kRetryAction);

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.cpp
@@ -4,8 +4,15 @@
 
 #include "dodeletefilesworker.h"
 #include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/finallyutil.h>
 
 #include <QUrl>
+
+#include <unistd.h>
+#include <fts.h>
+// for DFMIO::DFMUtils::isInvalidCodecByPath used in originPath:: encoding handling
+#include <dfm-io/dfmio_utils.h>
 
 DPFILEOPERATIONS_USE_NAMESPACE
 DoDeleteFilesWorker::DoDeleteFilesWorker(QObject *parent)
@@ -27,13 +34,13 @@ bool DoDeleteFilesWorker::doWork()
         return false;
 
     fmInfo() << "Start deleting files - count:" << sourceUrls.count();
-    deleteAllFiles();
+    bool success = deleteAllFiles();
 
     // 完成
     fmInfo() << "Delete operation completed successfully";
     endWork();
 
-    return true;
+    return success;
 }
 
 void DoDeleteFilesWorker::stop()
@@ -57,10 +64,172 @@ bool DoDeleteFilesWorker::deleteAllFiles()
     fmDebug() << "Delete all files - source file local:" << isSourceFileLocal;
     // sources file list is checked
     // delete files on can't remove device
+    useFts = FileOperationsUtils::useFtsDelete();
+    if (useFts) {
+        // FTS only handles local files; if any source is non-local, fall back to the
+        // per-device paths so remote files are actually deleted (not silently dropped).
+        bool allLocal = true;
+        for (const auto &url : sourceUrls) {
+            if (!url.isLocalFile()) {
+                allLocal = false;
+                break;
+            }
+        }
+        if (allLocal)
+            return deleteFilesByFts();
+    }
     if (isSourceFileLocal) {
         return deleteFilesOnCanNotRemoveDevice();
     }
     return deleteFilesOnOtherDevice();
+}
+
+bool DoDeleteFilesWorker::deleteFilesByFts()
+{
+    if (sourceUrls.isEmpty())
+        return false;
+
+    QList<QByteArray> pathData;
+    pathData.reserve(sourceUrls.size());
+    for (const auto &url : sourceUrls) {
+        if (!url.isLocalFile()) {
+            fmWarning() << "deleteFilesByFts: skip non-local path:" << url;
+            continue;
+        }
+        pathData.append(url.toLocalFile().toUtf8());
+    }
+    if (pathData.isEmpty())
+        return false;
+
+    QVector<char *> pathPtrs(pathData.size() + 1, nullptr);
+    for (int i = 0; i < pathData.size(); ++i)
+        pathPtrs[i] = pathData[i].data();
+
+    FTS *fts = fts_open(pathPtrs.data(), FTS_PHYSICAL | FTS_NOSTAT | FTS_NOCHDIR, nullptr);
+    if (!fts) {
+        fmWarning() << "deleteFilesByFts: fts_open failed:" << strerror(errno);
+        return false;
+    }
+    // Flush any buffered fileDeleted signals on every exit path.
+    dfmbase::FinallyUtil atFinish([&] { flushFileDeletedBatch(); });
+
+    // FTS only traverses local files (non-local sources are filtered above), so the
+    // local inotify watcher already delivers delete notifications - no manual notify
+    // is needed here (mirrors deleteFilesOnCanNotRemoveDevice's local behavior).
+    QSet<QUrl> sourceUrlsSet(sourceUrls.begin(), sourceUrls.end());
+    bool success = true;
+    int errorCount = 0;
+
+    FTSENT *ent;
+    AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
+    while ((ent = fts_read(fts)) != nullptr) {
+        if (!stateCheck()) {
+            success = false;
+            break;
+        }
+
+        bool isDir = false;
+        bool shouldDelete = false;
+
+        switch (ent->fts_info) {
+        case FTS_F:
+        case FTS_SL:
+        case FTS_SLNONE:
+        case FTS_NSOK:
+            shouldDelete = true;
+            isDir = false;
+            break;
+        case FTS_DP:
+            shouldDelete = true;
+            isDir = true;
+            break;
+        case FTS_DNR:
+        case FTS_NS:
+        case FTS_ERR:
+        case FTS_DC:
+            fmWarning() << "deleteFilesByFts: traversal error:" << ent->fts_path
+                       << strerror(ent->fts_errno);
+            errorCount++;
+            continue;
+        default:
+            continue;
+        }
+
+        if (!shouldDelete)
+            continue;
+
+        auto url = QUrl::fromLocalFile(ent->fts_path);
+        // Match the encoding used by statisticsFilesSize() so that non-UTF8 / invalid
+        // codec paths produce the same originPath::-prefixed URL, keeping sourceUrlsSet
+        // lookups (completeSourceFiles / completeTargetFiles) consistent.
+        if (DFMIO::DFMUtils::isInvalidCodecByPath(ent->fts_path))
+            url.setUserInfo(QString::fromLatin1("originPath::") + QString::fromLatin1(ent->fts_path));
+        emitCurrentTaskNotify(url, QUrl());
+        // Only emit/count an entry when it was actually removed; a retry that is
+        // interrupted by stop, or a non-retried failure, must not signal deletion.
+        bool deleted = false;
+        do {
+            action = AbstractJobHandler::SupportAction::kNoAction;
+            int ret = isDir ? ::rmdir(ent->fts_accpath) : ::unlink(ent->fts_accpath);
+            if (ret == 0) {
+                deleted = true;
+                break;
+            }
+            // Already gone - nothing left to remove; treat as deleted.
+            if (errno == ENOENT || errno == ENOTDIR) {
+                deleted = true;
+                break;
+            }
+            fmWarning() << "deleteFilesByFts: delete failed:" << ent->fts_path
+                       << strerror(errno);
+            errorCount++;
+            action = doHandleErrorAndWait(url, AbstractJobHandler::JobErrorType::kDeleteFileError,
+                                          strerror(errno));
+        } while (!isStopped() && action == AbstractJobHandler::SupportAction::kRetryAction);
+
+        // Stopped mid-operation: do not emit/count the in-flight entry; abort traversal.
+        if (isStopped()) {
+            success = false;
+            break;
+        }
+        // Not actually deleted (failed/skipped): no signal, no count.
+        if (!deleted)
+            continue;
+
+        batchEmitFileDeleted(url);
+
+        if (sourceUrlsSet.contains(url)) {
+            completeSourceFiles.append(url);
+            completeTargetFiles.append(url);
+        }
+
+        deleteFilesCount++;
+    }
+
+    fts_close(fts);
+
+    fmInfo() << "deleteFilesByFts: done -" << errorCount << "errors," << deleteFilesCount << "deleted";
+
+    return success && errorCount == 0;
+}
+
+void DoDeleteFilesWorker::flushFileDeletedBatch()
+{
+    if (!fileDeletedBuffer.isEmpty()) {
+        emit fileDeleted(fileDeletedBuffer);
+        fileDeletedBuffer.clear();
+    }
+}
+
+void DoDeleteFilesWorker::batchEmitFileDeleted(const QUrl &url)
+{
+    if (fileDeletedBuffer.isEmpty())
+        fileDeletedTimer.start();
+
+    fileDeletedBuffer.append(url);
+
+    if (fileDeletedBuffer.size() >= 1000 || fileDeletedTimer.hasExpired(500))
+        flushFileDeletedBatch();
 }
 /*!
  * \brief DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice Delete files on non removable devices
@@ -69,6 +238,8 @@ bool DoDeleteFilesWorker::deleteAllFiles()
 bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 {
     fmDebug() << "Deleting files on non-removable device - file count:" << allFilesList.count();
+    // Flush any buffered fileDeleted signals on every exit path.
+    dfmbase::FinallyUtil atFinish([&] { flushFileDeletedBatch(); });
 
     if (allFilesList.count() == 1 && isConvert) {
         auto info = InfoFactory::create<FileInfo>(allFilesList.first(), Global::CreateFileInfoType::kCreateFileInfoSync);
@@ -80,8 +251,9 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 
     AbstractJobHandler::SupportAction action { AbstractJobHandler::SupportAction::kNoAction };
     for (QList<QUrl>::iterator it = --allFilesList.end(); it != --allFilesList.begin(); --it) {
-        if (!stateCheck())
+        if (!stateCheck()) {
             return false;
+        }
         const QUrl &url = *it;
         emitCurrentTaskNotify(url, QUrl());
         do {
@@ -109,10 +281,11 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
             continue;
         }
 
-        if (action != AbstractJobHandler::SupportAction::kNoAction)
+        if (action != AbstractJobHandler::SupportAction::kNoAction) {
             return false;
+        }
 
-        emit fileDeleted(url);
+        batchEmitFileDeleted(url);
     }
 
     fmInfo() << "Completed deletion on non-removable device - deleted count:" << deleteFilesCount;
@@ -125,6 +298,8 @@ bool DoDeleteFilesWorker::deleteFilesOnCanNotRemoveDevice()
 bool DoDeleteFilesWorker::deleteFilesOnOtherDevice()
 {
     fmDebug() << "Deleting files on other device - source count:" << sourceUrls.count();
+    // Flush any buffered fileDeleted signals on every exit path.
+    dfmbase::FinallyUtil atFinish([&] { flushFileDeletedBatch(); });
 
     bool ok = true;
     if (sourceUrls.count() == 1 && isConvert) {
@@ -162,7 +337,7 @@ bool DoDeleteFilesWorker::deleteFilesOnOtherDevice()
 
         completeTargetFiles.append(url);
         completeSourceFiles.append(url);
-        emit fileDeleted(url);
+        batchEmitFileDeleted(url);
         fmDebug() << "Successfully deleted item:" << url;
     }
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/deletefiles/dodeletefilesworker.h
@@ -12,6 +12,9 @@
 #include <dfm-base/interfaces/fileinfo.h>
 
 #include <QObject>
+#include <QElapsedTimer>
+#include <QList>
+#include <QUrl>
 
 DPFILEOPERATIONS_BEGIN_NAMESPACE
 DFMBASE_USE_NAMESPACE
@@ -35,12 +38,20 @@ protected:
     bool deleteFilesOnOtherDevice();
     bool deleteFileOnOtherDevice(const QUrl &url);
     bool deleteDirOnOtherDevice(const FileInfoPointer &dir);
+    bool deleteFilesByFts();
     AbstractJobHandler::SupportAction doHandleErrorAndWait(const QUrl &from,
                                                            const AbstractJobHandler::JobErrorType &error,
                                                            const QString &errorMsg = QString());
 
 private:
+    void batchEmitFileDeleted(const QUrl &url);
+    void flushFileDeletedBatch();
+
+private:
     QAtomicInteger<qint64> deleteFilesCount { 0 };
+    QList<QUrl> fileDeletedBuffer;
+    QElapsedTimer fileDeletedTimer;
+    QAtomicInteger<bool> useFts{false};
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.cpp
@@ -183,10 +183,10 @@ void AbstractJob::handleFileRenamed(const QUrl &old, const QUrl &cur)
     dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Rename", old, cur);
 }
 
-void AbstractJob::handleFileDeleted(const QUrl &url)
+void AbstractJob::handleFileDeleted(const QList<QUrl> &urls)
 {
-    fmDebug() << "File deleted:" << url;
-    dpfSignalDispatcher->publish("dfmplugin_fileoperations", "signal_File_Delete", url);
+    dpfSignalDispatcher->publish("dfmplugin_fileoperations",
+                                 "signal_File_Delete", urls);
 }
 
 void AbstractJob::handleFileAdded(const QUrl &url)

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractjob.h
@@ -11,6 +11,7 @@
 
 #include <QObject>
 #include <QUrl>
+#include <QList>
 #include <QThread>
 #include <QSharedPointer>
 #include <QQueue>
@@ -52,7 +53,7 @@ protected slots:
     void handleRetryErrorSuccess(const quint64 Id);
 
     void handleFileRenamed(const QUrl &old, const QUrl &cur);
-    void handleFileDeleted(const QUrl &url);
+    void handleFileDeleted(const QList<QUrl> &urls);
     void handleFileAdded(const QUrl &url);
 
 protected:

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.cpp
@@ -269,9 +269,9 @@ bool AbstractWorker::statisticsFilesSize()
     // Set workData flags for use in DoCopyFileWorker
     workData->isSourceFileLocal = isSourceFileLocal;
 
-    if (isSourceFileLocal) {
+    if (isSourceFileLocal || (firstUrl.isLocalFile() && jobType == AbstractJobHandler::JobType::kDeleteType)) {
         fmDebug() << "Using synchronous file size calculation for local files";
-        const SizeInfoPointer &fileSizeInfo = FileOperationsUtils::statisticsFilesSize(sourceUrls, true);
+        const SizeInfoPointer &fileSizeInfo = FileOperationsUtils::statisticsFilesSize(sourceUrls, true, jobType == AbstractJobHandler::JobType::kDeleteType);
         allFilesList = fileSizeInfo->allFiles;
         sourceFilesTotalSize = fileSizeInfo->totalSize;
         workData->dirSize = fileSizeInfo->dirSize;

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/abstractworker.h
@@ -104,7 +104,7 @@ signals:
     void requestTaskDailog();
 
     void fileRenamed(const QUrl &old, const QUrl &cur);
-    void fileDeleted(const QUrl &url);
+    void fileDeleted(const QList<QUrl> &urls);
     void fileAdded(const QUrl &url);
 
 public:

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.cpp
@@ -10,6 +10,7 @@
 #include <dfm-io/dfmio_utils.h>
 
 #include <QDirIterator>
+#include <QSet>
 #include <QUrl>
 #include <QDebug>
 #include <QMutexLocker>
@@ -33,6 +34,7 @@ inline constexpr char kFileOperations[] { "org.deepin.dde.file-manager.operation
 inline constexpr char kFileBigSize[] { "file.operation.bigfilesize" };
 inline constexpr char kBlockEverySync[] { "file.operation.blockeverysync" };
 inline constexpr char kBroadcastPaste[] { "file.operation.broadcastpastevent" };
+inline constexpr char kUseFtsDelete[] { "file.operation.useftsdelete" };
 
 /*!
  * \brief FileOperationsUtils::statisticsFilesSize 使用c库统计文件大小
@@ -42,15 +44,116 @@ inline constexpr char kBroadcastPaste[] { "file.operation.broadcastpastevent" };
  * \param isRecordUrl 是否统计所有的文件及子目录路径
  * \return QSharedPointer<FileOperationsUtils::FilesSizeInfo> 文件大小信息
  */
-SizeInfoPointer FileOperationsUtils::statisticsFilesSize(const QList<QUrl> &files, const bool &isRecordUrl)
-{
-    SizeInfoPointer filesSizeInfo(new DFMBASE_NAMESPACE::FileUtils::FilesSizeInfo);
-    filesSizeInfo->dirSize = FileUtils::getMemoryPageSize();
 
-    for (auto url : files) {
-        statisticFilesSize(url, filesSizeInfo, isRecordUrl);
+/*!
+ * \brief collectFtsEntries  Common FTS traversal logic shared by
+ *        statisticsFilesSize() (batch) and statisticFilesSize() (single URL).
+ *
+ * Opens fts_open on the given path array, walks the tree, and accumulates
+ * file count, total size, and optionally all file URLs into \a sizeInfo.
+ * Deduplicates overlapping source paths via a QSet.
+ *
+ * \param paths     NULL-terminated array of C strings (as required by fts_open)
+ * \param ftsFlags  flags passed to fts_open (e.g. FTS_PHYSICAL | FTS_NOCHDIR [ | FTS_NOSTAT])
+ * \param sizeInfo  accumulator (modified in place)
+ * \param isRecordUrl  whether to record every URL into sizeInfo->allFiles
+ * \param noStat    whether FTS_NOSTAT was set (skip size accumulation)
+ */
+static void collectFtsEntries(char *const *paths, int ftsFlags,
+                              SizeInfoPointer &sizeInfo,
+                              const bool &isRecordUrl, const bool noStat)
+{
+    FTS *fts = fts_open(paths, ftsFlags, nullptr);
+    if (!fts) {
+        fmWarning() << "collectFtsEntries: fts_open failed:" << strerror(errno);
+        return;
     }
 
+    const qint64 pageSize = FileUtils::getMemoryPageSize();
+
+    // Dedup: fts_open does not dedup overlapping source paths, so entries reachable
+    // via more than one source URL would be counted multiple times.
+    QSet<QUrl> urlCounted;
+    FTSENT *ent;
+    while ((ent = fts_read(fts)) != nullptr) {
+        unsigned short flag = ent->fts_info;
+
+        // Handle errors / unstatable entries
+        if (flag == FTS_DNR || flag == FTS_ERR || flag == FTS_DC || flag == FTS_NS) {
+            fmWarning() << "collectFtsEntries: traversal error:" << ent->fts_path
+                        << strerror(ent->fts_errno);
+            continue;
+        }
+        // Post-order dir: children already processed, skip
+        if (flag == FTS_DP)
+            continue;
+
+        QUrl curUrl = QUrl::fromLocalFile(ent->fts_path);
+        if (DFMIO::DFMUtils::isInvalidCodecByPath(ent->fts_path))
+            curUrl.setUserInfo(QString::fromLatin1("originPath::") + QString::fromLatin1(ent->fts_path));
+
+        // Skip entries already counted via an overlapping source path.
+        if (urlCounted.contains(curUrl))
+            continue;
+        urlCounted.insert(curUrl);
+
+        // url record
+        if (isRecordUrl)
+            sizeInfo->allFiles.append(curUrl);
+
+        // file counted — include FTS_NSOK to match deleteFilesByFts() (FTS_NOSTAT
+        // returns FTS_NSOK instead of FTS_F for regular files when d_type is available).
+        if (flag == FTS_F || flag == FTS_SL || flag == FTS_SLNONE || flag == FTS_NSOK)
+            sizeInfo->fileCount++;
+
+        if (noStat)
+            continue;
+
+        // total size
+        if (flag == FTS_D) {
+            sizeInfo->totalSize += pageSize;
+        } else {
+            const qint64 fileSize = ent->fts_statp->st_size;
+            sizeInfo->totalSize += (fileSize > 0 ? fileSize : pageSize);
+        }
+    }
+
+    fts_close(fts);
+}
+
+SizeInfoPointer FileOperationsUtils::statisticsFilesSize(const QList<QUrl> &files, const bool &isRecordUrl,
+                                                         const bool noStat)
+{
+    SizeInfoPointer filesSizeInfo(new DFMBASE_NAMESPACE::FileUtils::FilesSizeInfo);
+    const qint64 pageSize = FileUtils::getMemoryPageSize();
+    filesSizeInfo->dirSize = pageSize;
+
+    if (files.isEmpty())
+        return filesSizeInfo;
+
+    // Build path array for batch fts_open (handles originPath encoding)
+    QList<QByteArray> pathData;
+    pathData.reserve(files.size());
+    for (const auto &url : files) {
+        if (!url.isLocalFile())
+            continue;
+        if (url.userInfo().contains("originPath::"))
+            pathData.append(url.userInfo().replace("originPath::", "").toLatin1());
+        else
+            pathData.append(url.path().toUtf8());
+    }
+    if (pathData.isEmpty())
+        return filesSizeInfo;
+
+    QVector<char *> pathPtrs(pathData.size() + 1, nullptr);
+    for (int i = 0; i < pathData.size(); ++i)
+        pathPtrs[i] = pathData[i].data();
+
+    auto flags = FTS_PHYSICAL | FTS_NOCHDIR;
+    if (noStat)
+        flags |= FTS_NOSTAT;
+
+    collectFtsEntries(pathPtrs.data(), flags, filesSizeInfo, isRecordUrl, noStat);
     return filesSizeInfo;
 }
 
@@ -89,70 +192,28 @@ bool FileOperationsUtils::isFilesSizeOutLimit(const QUrl &url, const qint64 limi
 
 void FileOperationsUtils::statisticFilesSize(const QUrl &url,
                                              SizeInfoPointer &sizeInfo,
-                                             const bool &isRecordUrl)
+                                             const bool &isRecordUrl, const bool noStat)
 {
-    static const QString kOriginPathPrefix = QLatin1String("originPath::");
+    // Build path string with originPath encoding support
+    QByteArray pathBytes;
+    if (url.userInfo().contains("originPath::"))
+        pathBytes = url.userInfo().replace("originPath::", "").toLatin1();
+    else
+        pathBytes = url.path().toUtf8();
 
-    QSet<QUrl> urlCounted;
+    char *paths[2] = { strdup(pathBytes.constData()), nullptr };
 
-    char *paths[2] = { nullptr, nullptr };
-
-    // 对无效的文件名称进行处理
-    QByteArray pathData;
-    if (url.userInfo().contains(kOriginPathPrefix)) {
-        pathData = url.userInfo().replace(kOriginPathPrefix, "").toLatin1();
-    } else {
-        pathData = url.path().toUtf8();
-    }
-
-    paths[0] = strdup(pathData.constData());
     if (!paths[0]) {
-        fmWarning() << "Failed to allocate memory for path";
+        fmWarning() << "statisticFilesSize: strdup failed for" << url;
         return;
     }
 
-    FTS *fts = fts_open(paths, 0, nullptr);
-    if (!fts) {
-        perror("fts_open");
-        fmWarning() << "fts_open open error : " << QString::fromLocal8Bit(strerror(errno));
-        free(paths[0]);
-        return;
-    }
+    auto flags = FTS_PHYSICAL | FTS_NOCHDIR;
+    if (noStat)
+        flags |= FTS_NOSTAT;
 
+    collectFtsEntries(paths, flags, sizeInfo, isRecordUrl, noStat);
     free(paths[0]);
-
-    while (1) {
-        FTSENT *ent = fts_read(fts);
-        if (ent == nullptr) {
-            break;
-        }
-        QUrl curUrl = QUrl::fromLocalFile(ent->fts_path);
-        if (DFMIO::DFMUtils::isInvalidCodecByPath(ent->fts_path))
-            curUrl.setUserInfo(kOriginPathPrefix + QString::fromLatin1(ent->fts_path));
-        if (urlCounted.contains(curUrl))
-            continue;
-
-        urlCounted.insert(curUrl);
-
-        unsigned short flag = ent->fts_info;
-
-        const auto &fileSize = ent->fts_statp->st_size;
-
-        // url record
-        if (isRecordUrl && flag != FTS_DP)
-            sizeInfo->allFiles.append(curUrl);
-
-        // file counted
-        if (flag == FTS_F || flag == FTS_SL || flag == FTS_SLNONE)
-            sizeInfo->fileCount++;
-
-        // total size
-        if (flag == FTS_D)
-            sizeInfo->totalSize += FileUtils::getMemoryPageSize();
-        else if (flag != FTS_DP)
-            sizeInfo->totalSize += (fileSize > 0 ? fileSize : FileUtils::getMemoryPageSize());
-    }
-    fts_close(fts);
 }
 
 bool FileOperationsUtils::isAncestorUrl(const QUrl &from, const QUrl &to)
@@ -204,4 +265,9 @@ bool FileOperationsUtils::canBroadcastPaste()
 {
     // 组策略中配置
     return DConfigManager::instance()->value(kFileOperations, kBroadcastPaste, false).toBool();
+}
+
+bool FileOperationsUtils::useFtsDelete()
+{
+    return DConfigManager::instance()->value(kFileOperations, kUseFtsDelete, true).toBool();
 }

--- a/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
+++ b/src/plugins/common/dfmplugin-fileoperations/fileoperations/fileoperationutils/fileoperationsutils.h
@@ -64,17 +64,21 @@ class FileOperationsUtils
     friend class DoRestoreTrashFilesWorker;
     friend class FileOperateBaseWorker;
     friend class ErrorMessageAndAction;
+    friend class DoDeleteFilesWorker;
 
 private:
-    static SizeInfoPointer statisticsFilesSize(const QList<QUrl> &files, const bool &isRecordUrl = false);
+    static SizeInfoPointer statisticsFilesSize(const QList<QUrl> &files, const bool &isRecordUrl = false,
+                                               const bool noStat = false);
     static bool isFilesSizeOutLimit(const QUrl &url, const qint64 limitSize);
-    static void statisticFilesSize(const QUrl &url, SizeInfoPointer &sizeInfo, const bool &isRecordUrl = false);
+    static void statisticFilesSize(const QUrl &url, SizeInfoPointer &sizeInfo, const bool &isRecordUrl = false,
+                                   const bool noStat = false);
     static bool isAncestorUrl(const QUrl &from, const QUrl &to);
     static bool isFileOnDisk(const QUrl &url);
     static qint64 bigFileSize();
     static bool blockSync();
     static QUrl parentUrl(const QUrl &url);
     static bool canBroadcastPaste();
+    static bool useFtsDelete();
 };
 DPFILEOPERATIONS_END_NAMESPACE
 

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.cpp
@@ -84,9 +84,9 @@ void SearchEventReceiver::handleFileAdd(const QUrl &url)
     emit SearchManager::instance()->fileAdd(url);
 }
 
-void SearchEventReceiver::handleFileDelete(const QUrl &url)
+void SearchEventReceiver::handleFileDelete(const QList<QUrl> &urls)
 {
-    emit SearchManager::instance()->fileDelete(url);
+    emit SearchManager::instance()->fileDelete(urls);
 }
 
 void SearchEventReceiver::handleFileRename(const QUrl &oldUrl, const QUrl &newUrl)

--- a/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.h
+++ b/src/plugins/filemanager/dfmplugin-search/events/searcheventreceiver.h
@@ -26,7 +26,7 @@ public slots:
     void handleShowAdvanceSearchBar(quint64 winId, bool visible);
     void handleAddressInputStr(quint64 windId, QString *str);
     void handleFileAdd(const QUrl &url);
-    void handleFileDelete(const QUrl &url);
+    void handleFileDelete(const QList<QUrl> &urls);
     void handleFileRename(const QUrl &oldUrl, const QUrl &newUrl);
     void handleUrlChanged(quint64 winId, const QUrl &url);
 

--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searchmanager.h
@@ -53,7 +53,7 @@ signals:
     void enableSemanticSearchChanged(bool enable);
 
     void fileAdd(const QUrl &url);
-    void fileDelete(const QUrl &url);
+    void fileDelete(const QList<QUrl> &urls);
     void fileRename(const QUrl &oldUrl, const QUrl &newUrl);
 
 private:

--- a/src/plugins/filemanager/dfmplugin-search/watcher/searchfilewatcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/watcher/searchfilewatcher.cpp
@@ -152,21 +152,23 @@ void SearchFileWatcher::handleFileAdd(const QUrl &url)
     }
 }
 
-void SearchFileWatcher::handleFileDelete(const QUrl &url)
+void SearchFileWatcher::handleFileDelete(const QList<QUrl> &urls)
 {
     // 首先检查文件是否在搜索目录范围内
     auto targetUrl = SearchHelper::searchTargetUrl(this->url());
-    if (!url.path().startsWith(targetUrl.path())) {
-        fmDebug() << "File delete ignored: not within search target path" << targetUrl.path();
-        return;
-    }
-
     auto searchKey = SearchHelper::instance()->searchKeyword(this->url());
-    if (url.fileName().contains(searchKey) &&
-            !dpfHookSequence->run("dfmplugin_search", "hook_Url_IsNotSubFile",
-                                  targetUrl, url)) {
-        fmDebug() << "File delete matches search criteria:" << url.toString();
-        onFileDeleted(url);
+    for (const QUrl &url : urls) {
+        if (!url.path().startsWith(targetUrl.path())) {
+            fmDebug() << "File delete ignored: not within search target path" << targetUrl.path();
+            continue;
+        }
+
+        if (url.fileName().contains(searchKey) &&
+                !dpfHookSequence->run("dfmplugin_search", "hook_Url_IsNotSubFile",
+                                      targetUrl, url)) {
+            fmDebug() << "File delete matches search criteria:" << url.toString();
+            onFileDeleted(url);
+        }
     }
 }
 

--- a/src/plugins/filemanager/dfmplugin-search/watcher/searchfilewatcher.h
+++ b/src/plugins/filemanager/dfmplugin-search/watcher/searchfilewatcher.h
@@ -32,7 +32,7 @@ private:
 
 private Q_SLOTS:
     void handleFileAdd(const QUrl &url);
-    void handleFileDelete(const QUrl &url);
+    void handleFileDelete(const QList<QUrl> &urls);
     void handleFileRename(const QUrl &oldUrl, const QUrl &newUrl);
 
 private:


### PR DESCRIPTION
## 功能迁移：v20 文件彻底删除（FTS）→ v25

将 v20（gerrit `develop/107x-perf-opt`，commit `81a8e35543`）中的 FTS 文件彻底删除功能迁移到 v25（github `master`）。

### 主要改动

- **FTS 彻底删除**：`DoDeleteFilesWorker` 新增 `deleteFilesByFts()`，使用 `fts_open/fts_read/fts_close` 遍历并删除文件树，在 `doWork()` 中通过 DConfig 开关 `useFtsDelete()` 决定是否走 FTS 路径（FTS 检查在 `isSourceFileLocal` 之前）
- **批量 fileDeleted 信号**：`fileDeleted(const QUrl &)` 改为 `fileDeleted(const QList<QUrl> &)`，减少信号发射次数，提升性能。信号链路同步适配：`AbstractWorker → AbstractJob → SearchEventReceiver → SearchManager → SearchFileWatcher`
- **DConfig 开关**：新增 `file.operation.useftsdelete` 配置项，控制是否启用 FTS 删除
- **statisticsFilesSize 优化**：`FileOperationsUtils::statisticFilesSize()` 新增 `noStat` 参数，FTS 路径批量 `fts_open` 统计文件大小，避免逐个 stat；`DoDeleteFilesWorker` 声明为 `friend class` 以访问私有成员
- **flushFileDeletedBatch RAII**：使用 `dfmbase::FinallyUtil` 守卫在三个删除函数入口自动 flush 缓冲的 `fileDeleted` 信号，消除早退路径漏 flush 风险
- **测试更新**：测试文件同步更新为 `QList<QUrl>` 签名
- **v25 适配**：v20 的 `DeviceUtils::isSamba/isFtp` 适配为 v25 的 `ProtocolUtils::isSMBFile/isFTPFile`；路径中 `core/` 段差异已处理

### Review 记录

经 `lz-code-review` 智能体多轮 review，最终评分 9/10（Approved），并完成 FinallyUtil RAII 重构。详见任务 V-2476 评论记录。

## Summary by Sourcery

Migrate FTS-based permanent deletion to v25 with configurable local traversal and batched file-deletion notifications.

New Features:
- Add configurable FTS-based deletion for local files and directories.

Bug Fixes:
- Ensure deletion failures and interrupted operations are reported accurately while preserving notifications on all exit paths.

Enhancements:
- Batch file-deleted notifications across file-operation and search components to reduce signal traffic.
- Optimize local deletion size accounting with shared FTS traversal and optional stat avoidance.

Tests:
- Update file-operation and search tests for batched deletion notifications.