### PR TITLE
fix: ensure fallback fd for failed D-Bus methods

### DIFF
--- a/src/services/tpmcontrol/tpmcontroldbus.cpp
+++ b/src/services/tpmcontrol/tpmcontroldbus.cpp
@@ -11,6 +11,7 @@
 #include <QDataStream>
 #include <QIODevice>
 
+#include <fcntl.h>
 #include <unistd.h>
 #include <cerrno>
 
@@ -22,13 +23,26 @@ SERVICETPMCONTROL_USE_NAMESPACE
 
 using ServiceCommon::PolicyKitHelper;
 
+namespace {
+bool setFallbackFd(QDBusUnixFileDescriptor *fd)
+{
+    int fallbackFd = ::open("/dev/null", O_RDONLY | O_CLOEXEC);
+    if (fallbackFd < 0) {
+        fmCritical() << "Failed to create fallback D-Bus fd, errno:" << errno;
+        return false;
+    }
+
+    *fd = QDBusUnixFileDescriptor(fallbackFd);
+    ::close(fallbackFd);
+    return fd->isValid();
+}
+}
+
 TPMControlDBus::TPMControlDBus(const char *name, QObject *parent)
     : QObject(parent), QDBusContext(), m_tpmWork(new TPMWork(this))
 {
     QDBusConnection::RegisterOptions opts =
-            QDBusConnection::ExportAllSlots |
-            QDBusConnection::ExportAllSignals |
-            QDBusConnection::ExportAllProperties;
+            QDBusConnection::ExportAllSlots | QDBusConnection::ExportAllSignals | QDBusConnection::ExportAllProperties;
 
     QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SystemBus, QString(name));
     if (!conn.isConnected()) {
@@ -124,7 +138,7 @@ bool TPMControlDBus::sendDataViaFd(const QByteArray &data, QDBusUnixFileDescript
 
     // Write data to pipe
     ssize_t written = write(pipefd[1], data.constData(), data.size());
-    close(pipefd[1]);  // Close write end immediately
+    close(pipefd[1]);   // Close write end immediately
 
     if (written != data.size()) {
         fmCritical() << "Failed to write data to pipe, written:" << written << "expected:" << data.size();
@@ -197,6 +211,7 @@ int TPMControlDBus::GetRandom(int size, QDBusUnixFileDescriptor &randomData)
     fmInfo() << "GetRandom called with size:" << size;
 
     if (!checkAuthentication(PolicyKitActionId::kAccess)) {
+        setFallbackFd(&randomData);
         return kAuthFailed;
     }
 
@@ -204,12 +219,14 @@ int TPMControlDBus::GetRandom(int size, QDBusUnixFileDescriptor &randomData)
     int ret = m_tpmWork->getRandom(size, &output);
     if (ret != 0) {
         fmWarning() << "getRandom failed with code:" << ret;
+        setFallbackFd(&randomData);
         return ret;
     }
 
     // Send random data via file descriptor
     QByteArray data = output.toUtf8();
     if (!sendDataViaFd(data, randomData)) {
+        setFallbackFd(&randomData);
         return kFdCreateFailed;
     }
 
@@ -240,6 +257,7 @@ int TPMControlDBus::Decrypt(const QDBusUnixFileDescriptor &params, QDBusUnixFile
     fmInfo() << "Decrypt called";
 
     if (!checkAuthentication(PolicyKitActionId::kAccess)) {
+        setFallbackFd(&password);
         return kAuthFailed;
     }
 
@@ -247,6 +265,7 @@ int TPMControlDBus::Decrypt(const QDBusUnixFileDescriptor &params, QDBusUnixFile
     QVariantMap args;
     if (!parseCredentialsFromFd(params, &args)) {
         fmCritical() << "Failed to parse decrypt parameters from fd";
+        setFallbackFd(&password);
         return kFdReadFailed;
     }
 
@@ -254,12 +273,14 @@ int TPMControlDBus::Decrypt(const QDBusUnixFileDescriptor &params, QDBusUnixFile
     int ret = m_tpmWork->decrypt(args, &pwd);
     if (ret != 0) {
         fmWarning() << "decrypt failed with code:" << ret;
+        setFallbackFd(&password);
         return ret;
     }
 
     // Send decrypted password via file descriptor
     QByteArray data = pwd.toUtf8();
     if (!sendDataViaFd(data, password)) {
+        setFallbackFd(&password);
         return kFdCreateFailed;
     }
 


### PR DESCRIPTION
1. Add setFallbackFd helper to create a valid QDBusUnixFileDescriptor
pointing to /dev/null
2. Call setFallbackFd on all failure paths in GetRandom and Decrypt
methods
3. Prevent uninitialized file descriptors from being returned to D-
Bus clients
4. Include <fcntl.h> for O_RDONLY and O_CLOEXEC flags

Log: Fixed D-Bus methods returning invalid file descriptors on failure;
now returns fallback fd to /dev/null

Influence:
1. Test GetRandom with authentication failure: verify returned fd is
valid (e.g., /dev/null)
2. Test GetRandom when TPM operation fails: ensure fd is not left
uninitialized
3. Test GetRandom when sendDataViaFd fails: confirm fallback fd is set
4. Test Decrypt with authentication failure: check returned fd validity
5. Test Decrypt when parsing parameters fails: verify fallback fd
6. Test Decrypt when decrypt operation fails: ensure fd is valid
7. Test Decrypt when sendDataViaFd fails: confirm fallback behavior
8. General regression: ensure no segfault or D-Bus errors when failures
occur

fix: 确保失败的 D-Bus 方法返回有效的 fallback 文件描述符

1. 添加 setFallbackFd 辅助函数，创建指向 /dev/null 的有效
QDBusUnixFileDescriptor
2. 在 GetRandom 和 Decrypt 方法的所有失败路径上调用 setFallbackFd
3. 防止向 D-Bus 客户端返回未初始化的文件描述符
4. 包含 <fcntl.h> 以使用 O_RDONLY 和 O_CLOEXEC 标志

Log: 修复 D-Bus 方法在失败时返回无效文件描述符的问题；现在返回指向 /dev/
null 的 fallback fd

Influence:
1. 测试 GetRandom 认证失败场景：验证返回的 fd 有效（例如指向 /dev/null）
2. 测试 GetRandom 在 TPM 操作失败时：确保 fd 未被保持未初始化
3. 测试 GetRandom 在 sendDataViaFd 失败时：确认设置了 fallback fd
4. 测试 Decrypt 认证失败场景：检查返回的 fd 有效性
5. 测试 Decrypt 参数解析失败时：验证 fallback fd
6. 测试 Decrypt 解密操作失败时：确保 fd 有效
7. 测试 Decrypt 在 sendDataViaFd 失败时：确认 fallback 行为
8. 常规回归：确保失败时不会出现段错误或 D-Bus 错误

## Summary by Sourcery

Return valid fallback file descriptors from failed TPM control D-Bus methods.

Bug Fixes:
- Ensure GetRandom and Decrypt return a valid /dev/null fallback file descriptor on every failure path instead of exposing uninitialized descriptors.

Enhancements:
- Centralize fallback file descriptor creation for failed D-Bus operations.