### PR TITLE
fix: sidebar double highlight on duplicate URL

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -173,7 +173,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         if (foundByCb || (sidebarView && UniversalUtils::urlEquals(subItem->url(), sidebarView->currentUrl())))
             isUrlEqual = true;
     }
-    if (isUrlEqual) {
+    if (isUrlEqual && sidebarView && index == sidebarView->currentTrackedIndex()) {
         // If the dragging and moving source item is not the current highlighted one,
         // the highlighted one must be keep its state.
         keepDrawingHighlighted = true;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -1182,6 +1182,7 @@ void SideBarView::setCurrentUrl(const QUrl &url)
         // the unexpanded group would be expaned again.
         if (groupItem && !groupItem->isExpanded()) {
             fmDebug() << "Group not expanded, skipping current index set for URL:" << url;
+            d->current = index;
             return;
         }
     }
@@ -1196,6 +1197,11 @@ void SideBarView::setCurrentUrl(const QUrl &url)
 QUrl SideBarView::currentUrl() const
 {
     return d->sidebarUrl;
+}
+
+QModelIndex SideBarView::currentTrackedIndex() const
+{
+    return d->current;
 }
 
 QModelIndex SideBarView::findItemIndex(const QUrl &url) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -33,6 +33,7 @@ public:
     void saveStateWhenClose();
     void setCurrentUrl(const QUrl &sidebarUrl);
     QUrl currentUrl() const;
+    QModelIndex currentTrackedIndex() const;
     QModelIndex findItemIndex(const QUrl &url) const;
     QVariantMap groupExpandState() const;
     QModelIndex previousIndex() const;


### PR DESCRIPTION
## Root Cause Analysis

The sidebar item highlight in `SideBarItemDelegate::paint` is decided purely by URL match: each visible item independently checks whether its URL equals `currentUrl()`, and any match draws the highlight background. When the same directory appears in two sidebar groups (the attribute tree and quick access), both entries share one URL, so both match simultaneously and both highlight — producing two focused items. The `setCurrentUrl` comment assumption ("at most one item highlighted") is invalidated by duplicate-URL entries. Key evidence: `sidebaritemdelegate.cpp:168` (`isUrlEqual = urlEquals(itemUrl, currentUrl())`), and `sidebarview_p.h:37-38,55` where the tracked `current` QModelIndex already records the selected item's identity but the delegate ignores it and relies solely on the `sidebarUrl` QUrl.

## Fix Approach

Make the delegate highlight condition require both a URL match AND that the item is the currently tracked item, compared by `QModelIndex` identity via a new `currentTrackedIndex()` accessor exposing `d->current`. This reuses the existing `SideBarViewPrivate::current` tracking set in `currentChanged`; passive URL navigation (`findItemIndex` → set `d->current`) keeps single-focus behavior unchanged. Additionally, set `d->current = index` in the collapsed-group early-return of `setCurrentUrl` so the tracked index stays correct when the group is collapsed. The identity check is applied on the combined `isUrlEqual` flag, so the `findMeCb` callback path is covered uniformly. The actual implementation matches the analysis suggestion (no deviation).

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The target highlight logic was last touched by commit `781b79aae` ("refresh sidebar highlight immediately on url change"), which kept URL-based highlight on a full-viewport repaint assuming "at most one item highlighted"; this fix does not revert that repaint logic — it makes its premise true by adding identity filtering.
- `References=0` (no external callers affected); all changes are additive: one read-only getter, one assignment line, one added identity condition. No signature or public-interface changes.

### Business Impact Scope

- **Sidebar highlight** — the sidebar item highlight indicates the current directory.
- Affected scenarios: sidebar tree view when the same directory exists in multiple groups (attribute tree + quick access); collapse/expand of a group containing the current item.
- Normal single-entry-per-URL navigation and passive file-view URL jumps are unaffected.

### Verification Suggestion

- Test the same directory present in both the attribute tree and quick access groups: after navigating to it, only one sidebar item is highlighted. Verify collapsed-group navigation keeps the correct tracked highlight, and that normal single-item navigation shows no regression.

---

## 根因分析

侧边栏条目高亮由 `SideBarItemDelegate::paint` 纯按 URL 匹配决定：每个可见条目独立判断自身 URL 是否等于 `currentUrl()`，匹配即绘制高亮背景。当同一目录同时出现在「属性目录（树形）」与「快捷访问」两个分组时，两个条目共用同一 URL，二者同时命中匹配从而同时高亮，出现两个焦点。`setCurrentUrl` 中"同一时刻最多一个条目高亮"的注释假设在重复 URL 场景下不成立。关键证据：`sidebaritemdelegate.cpp:168`（`isUrlEqual = urlEquals(itemUrl, currentUrl())`），以及 `sidebarview_p.h:37-38,55`——`current`（QModelIndex）已跟踪被选中条目身份，但 delegate 未使用，仅以 `sidebarUrl`（QUrl）作为高亮唯一依据。

## 修复方案

让 delegate 高亮条件从"纯 URL 匹配"改为"URL 匹配且该条目为当前被跟踪条目"，按 `QModelIndex` 身份判断，经新增 `currentTrackedIndex()` 暴露 `d->current`。复用 `currentChanged` 中已维护的 `SideBarViewPrivate::current` 跟踪；文件视图被动跳转路径（`findItemIndex` → 设 `d->current`）维持单一焦点不变。并在 `setCurrentUrl` 折叠分组提前返回处补 `d->current = index`，保证折叠分组下追踪索引正确。身份判断施加于合并后的 `isUrlEqual` 标志，`findMeCb` 回调路径被统一覆盖。实际实现与分析建议一致，无偏离。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标高亮逻辑最近由 commit `781b79aae`（"refresh sidebar highlight immediately on url change"）修改，保留 URL 高亮 + viewport 全量重绘、假设"最多一个条目高亮"；本次修复不撤销该重绘逻辑，而是通过增加身份过滤使其前提假设变为真值。
- `References=0`（无外部调用者受影响），改动均为增量：一个只读 getter、一行赋值、一个追加的身份条件，不改变函数签名与公开接口。

### 业务影响范围

- **侧边栏高亮**——侧边栏条目高亮指示当前所在目录。
- 受影响场景：同一目录同时存在于多个分组（属性目录树 + 快捷访问）时的侧边栏树形视图；含当前条目的分组的折叠/展开。
- 正常单条目导航与文件视图被动 URL 跳转不受影响。

### 验证建议

- 测试同一目录同时出现在「属性目录」与「快捷访问」两个分组时，导航至该目录后侧边栏仅一个高亮。验证折叠分组导航下高亮追踪索引保持正确，正常单条目导航无回归。

## Summary by Sourcery

Prevent duplicate sidebar highlights by tying URL-based highlighting to the currently tracked item.

Bug Fixes:
- Ensure only the tracked sidebar item is highlighted when duplicate URLs appear in multiple sidebar groups.
- Preserve the tracked sidebar item when navigating to an item in a collapsed group.

Enhancements:
- Expose the sidebar's currently tracked item index for consistent highlight selection.