### PR TITLE
6.5.165

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+dde-file-manager (6.5.165) unstable; urgency=medium
+
+  * fix(textindex): add auto-reconnect and enlarge SO_RCVBUF for vfsmonitor
+  * fix: refresh sidebar highlight immediately on url change
+  * fix: correct sidebar tree directory setting translations
+  * fix: unify sidebar tree sort with file view using numeric-aware collation
+  * fix: sidebar tree view blocks double-click rename
+  * fix: align sidebar tree with file workspace display
+  * fix: use icon name instead of url as sidebar icon cache key
+  * fix: store isExpandable in item data role
+  * fix: sync sidebar editDisplayText on device rename
+  * fix: sidebar double highlight on duplicate URL
+  * fix: normalize VFS monitor root aliases and skip inotify watch setup in vfs mode
+  * fix: fix sidebar setting panel initialization
+  * fix(diskencrypt): skip filesystem freeze on DM suspend/resume and adjust cursor restore timing
+  * fix: show resume decrypt option correctly for overlay encryption
+  * fix: hide resume decrypt option for non-LUKS devices after interrupted decrypt job
+  * refactor: extract validateExportPath to recovery_key_utils
+  * chore: update translations
+  * fix: ensure fallback fd for failed D-Bus methods
+
+ -- zhangsheng <zhangsheng@uniontech.com>  Fri, 21 Aug 2026 12:54:44 +0800
+
 dde-file-manager (6.5.164) unstable; urgency=medium
 
   * Fix(disk-encrypt): change translate of tpm

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -76,10 +76,10 @@ void paintSeparator(QPainter *painter, const QStyleOptionViewItem &option)
 }   // namespace GlobalPrivate
 
 QString SideBarItemDelegate::makeIconCacheKey(const QSize &size,
-                                             DTK_GUI_NAMESPACE::DDciIcon::Theme theme,
-                                             DTK_GUI_NAMESPACE::DDciIcon::Mode mode,
-                                             const QString &iconId,
-                                             const QColor &foreground) const
+                                              DTK_GUI_NAMESPACE::DDciIcon::Theme theme,
+                                              DTK_GUI_NAMESPACE::DDciIcon::Mode mode,
+                                              const QString &iconId,
+                                              const QColor &foreground) const
 {
     return QString::asprintf("%s|%dx%d|%d|%d|%08x", iconId.toUtf8().constData(),
                              size.width(), size.height(), static_cast<int>(theme),
@@ -158,8 +158,9 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         if (foundByCb || UniversalUtils::urlEquals(subItem->url(), sidebarView->currentUrl()))
             isUrlEqual = true;
     }
+
     bool isDraggingItemNotHighlighted = selected && !isUrlEqual;
-    if (isUrlEqual) {
+    if (isUrlEqual && sidebarView && index == sidebarView->currentTrackedIndex()) {
         // If the dragging and moving source item is not the current highlighted one,
         // the highlighted one must be keep its state.
         keepDrawingHighlighted = true;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -947,6 +947,7 @@ void SideBarView::setCurrentUrl(const QUrl &url)
         // the unexpanded group would be expaned again.
         if (groupItem && !groupItem->isExpanded()) {
             fmDebug() << "Group not expanded, skipping current index set for URL:" << url;
+            d->current = index;
             return;
         }
     }
@@ -961,6 +962,11 @@ void SideBarView::setCurrentUrl(const QUrl &url)
 QUrl SideBarView::currentUrl() const
 {
     return d->sidebarUrl;
+}
+
+QModelIndex SideBarView::currentTrackedIndex() const
+{
+    return d->current;
 }
 
 QModelIndex SideBarView::findItemIndex(const QUrl &url) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -33,6 +33,7 @@ public:
     void saveStateWhenClose();
     void setCurrentUrl(const QUrl &sidebarUrl);
     QUrl currentUrl() const;
+    QModelIndex currentTrackedIndex() const;
     QModelIndex findItemIndex(const QUrl &url) const;
     QVariantMap groupExpandState() const;
     QModelIndex previousIndex() const;


### PR DESCRIPTION
## Summary by Sourcery

Fix sidebar item tracking and highlighting during navigation and drag-and-drop operations.

Bug Fixes:
- Correct sidebar drag-and-drop highlighting so only the currently tracked item retains its highlighted state.
- Preserve the tracked sidebar index when the current URL belongs to an unexpanded group.

Enhancements:
- Expose the sidebar's currently tracked index for consistent selection and rendering behavior.