### PR TITLE
fix: enable Latin-first sort by default for zh_CN

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -201,7 +201,7 @@
             "visibility": "public"
         },
         "dfm.sort.latinfirst.zhCn": {
-            "value": false,
+            "value": true,
             "serial": 0,
             "flags": [],
             "name": "Sort Latin letters before Chinese in zh_CN",

--- a/src/dfm-base/utils/collation/collationstrategyprovider.cpp
+++ b/src/dfm-base/utils/collation/collationstrategyprovider.cpp
@@ -30,7 +30,7 @@ CollationStrategyProvider::CollationStrategyProvider(QObject *parent)
 
 bool CollationStrategyProvider::latinFirstEnabled() const
 {
-    return DConfigManager::instance()->value(kDefaultCfgPath, kSortLatinFirstZhCn, false).toBool();
+    return DConfigManager::instance()->value(kDefaultCfgPath, kSortLatinFirstZhCn, true).toBool();
 }
 
 bool CollationStrategyProvider::isZhCn()


### PR DESCRIPTION
## Root Cause Analysis

The dconfig key `dfm.sort.latinfirst.zhCn` was shipped with a default value of `false` in `assets/configs/org.deepin.dde.file-manager.json`, which keeps the Latin-before-Chinese sort strategy disabled by default. The C++ fallback in `CollationStrategyProvider::latinFirstEnabled()` (`src/dfm-base/utils/collation/collationstrategyprovider.cpp:33`) also returns `false` when the dconfig value is unavailable. As a result, Latin letters do not sort before Chinese in zh_CN unless the user manually toggles the setting.

## Fix Plan

Flip the dconfig default value for `dfm.sort.latinfirst.zhCn` from `false` to `true`, and update the C++ fallback in `CollationStrategyProvider::latinFirstEnabled()` from `false` to `true`. This enables the Latin-first sort order by default under zh_CN while preserving any explicitly set user preference.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Only two boolean default values are changed; no function signatures, public APIs, or class members are modified.
- The changed lines were introduced by commit `1deb65ac26e4` (the original feature); this change does not revert any prior bug fix.

### Business Impact Scope

Affects the default file-name sort order in the file manager under zh_CN locale. Latin letters will now appear before Chinese characters by default. Users who have explicitly set the dconfig key keep their own preference. Non-zh_CN locales are unaffected.

### Verification Suggestion

Verify that the default sort order places Latin letters before Chinese in zh_CN, that an explicit dconfig value still overrides the default, and that non-zh_CN locales sort behavior is unchanged.

---

## 根因分析

dconfig 键 `dfm.sort.latinfirst.zhCn` 在 `assets/configs/org.deepin.dde.file-manager.json` 中默认值为 `false`，导致拉丁字母置于中文之前的排序策略默认关闭。`CollationStrategyProvider::latinFirstEnabled()` 的 C++ 回退值（`collationstrategyprovider.cpp:33`）也为 `false`。因此 zh_CN 下拉丁字母不会排在中文之前，除非用户手动开启该设置。

## 修复方案

将 dconfig 键 `dfm.sort.latinfirst.zhCn` 的默认值由 `false` 改为 `true`，并将 `CollationStrategyProvider::latinFirstEnabled()` 的 C++ 回退值由 `false` 改为 `true`。这样 zh_CN 下拉丁字母默认排在中文之前，同时保留用户已显式设置的偏好。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 仅修改两个布尔默认值，不涉及函数签名、公开接口或类成员变更。
- 目标行由提交 `1deb65ac26e4`（原始特性）引入，本次改动不会撤销任何历史 bug 修复。

### 业务影响范围

影响文件管理器在 zh_CN 语言环境下的默认文件名排序顺序，拉丁字母将默认排在中文之前。用户已显式设置 dconfig 键的值不受影响。非 zh_CN 语言环境不受影响。

### 验证建议

验证 zh_CN 下默认排序将拉丁字母排在中文之前、显式 dconfig 值仍可覆盖默认值、非 zh_CN 语言环境排序行为保持不变。

## Summary by Sourcery

Bug Fixes:
- Enable Latin-before-Chinese filename sorting by default for the zh_CN locale while preserving explicit user preferences.