### PR TITLE
fix: enable Latin-first sort by default for zh_CN

### DIFF
--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -201,7 +201,7 @@
             "visibility": "public"
         },
         "dfm.sort.latinfirst.zhCn": {
-            "value": false,
+            "value": true,
             "serial": 0,
             "flags": [],
             "name": "Sort Latin letters before Chinese in zh_CN",

--- a/assets/configs/org.deepin.dde.file-manager.json
+++ b/assets/configs/org.deepin.dde.file-manager.json
@@ -199,6 +199,17 @@
             "description[zh_CN]": "日志规则",
             "permissions": "readwrite",
             "visibility": "public"
+        },
+        "dfm.sort.latinfirst.zhCn": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "Sort Latin letters before Chinese in zh_CN",
+            "name[zh_CN]": "简体中文环境下拉丁字母排在中文之前",
+            "description": "When enabled and the system locale is zh_CN, Latin letters are sorted before Chinese characters in filename sorting. Other locales are unaffected.",
+            "description[zh_CN]": "开启后，在简体中文（zh_CN）系统环境下文件名排序时拉丁字母排在中文之前，其余语系不受影响",
+            "permissions": "readwrite",
+            "visibility": "public"
         }
     }
 }

--- a/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
+++ b/src/dfm-base/base/configs/dconfig/global_dconf_defines.h
@@ -25,6 +25,7 @@ inline constexpr char kOpenFolderWindowsInASeparateProcess[] { "dfm.open.in.sing
 inline constexpr char kCunstomFixedTabs[] { "dfm.custom.fixedtab" };
 inline constexpr char kPinnedTabs[] { "dfm.pinned.tabs" };
 inline constexpr char kDetailViewRemoteImageMaxSize[] { "dfm.detailview.remote.image.maxsize" };
+inline constexpr char kSortLatinFirstZhCn[] { "dfm.sort.latinfirst.zhCn" };
 }   // namespace BaseConfig
 
 /*!

--- a/src/dfm-base/dfm-base.cmake
+++ b/src/dfm-base/dfm-base.cmake
@@ -42,6 +42,11 @@ add_library(${BIN_NAME}
 # Configure library using unified configuration function
 dfm_configure_base_library(${BIN_NAME})
 
+# ICU: utils/collation/icucollationstrategy.cpp 使用 ucol_* 做本地化排序
+# （zh_CN 下清除脚本重排）。libicu-dev 已在 debian/control Build-Depends。
+find_package(ICU COMPONENTS i18n uc REQUIRED)
+target_link_libraries(${BIN_NAME} PRIVATE ICU::i18n ICU::uc)
+
 set(ShareDir ${CMAKE_INSTALL_PREFIX}/share/dde-file-manager)
 set(AssetsPath ${DFM_PROJECT_ROOT}/assets)
 

--- a/src/dfm-base/utils/collation/collationstrategy.h
+++ b/src/dfm-base/utils/collation/collationstrategy.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef COLLATIONSTRATEGY_H
+#define COLLATIONSTRATEGY_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QByteArray>
+#include <QString>
+
+DFMBASE_BEGIN_NAMESPACE
+
+/**
+ * @class CollationStrategy
+ * @brief 排序策略抽象接口（Strategy 模式）。
+ *
+ * 将"按哪种排序规则生成排序键 / 比较字符串"抽象为接口，当前唯一实现为
+ * IcuCollationStrategy（基于 ICU，按 clearReorder 决定是否清空脚本重排）。
+ *
+ * 排序键统一为 QByteArray（ucol_getSortKey 直出），避免 QCollatorSortKey 的
+ * 共享指针间接与 std::variant 包装带来的排序热路径性能开销。
+ *
+ * 调用方（FileNameSorter）依赖此抽象而非具体后端（DIP / OCP）。
+ */
+class CollationStrategy
+{
+public:
+    virtual ~CollationStrategy() = default;
+
+    /// 生成排序键（用于批量预计算 + std::stable_sort）
+    virtual QByteArray sortKey(const QString &s) const = 0;
+
+    /// 直接比较两个字符串（用于逐对比较场景）
+    /// @return <0 表示 s1 排在 s2 之前，0 表示相等，>0 表示 s1 排在 s2 之后
+    virtual int compare(const QString &s1, const QString &s2) const = 0;
+};
+
+DFMBASE_END_NAMESPACE
+
+#endif   // COLLATIONSTRATEGY_H

--- a/src/dfm-base/utils/collation/collationstrategyprovider.cpp
+++ b/src/dfm-base/utils/collation/collationstrategyprovider.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "collationstrategyprovider.h"
+#include "icucollationstrategy.h"
+
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/configs/dconfig/global_dconf_defines.h>
+
+#include <QLocale>
+
+DFMBASE_BEGIN_NAMESPACE
+
+using namespace GlobalDConfDefines::ConfigPath;
+using namespace GlobalDConfDefines::BaseConfig;
+
+CollationStrategyProvider *CollationStrategyProvider::instance()
+{
+    static CollationStrategyProvider ins;
+    return &ins;
+}
+
+CollationStrategyProvider::CollationStrategyProvider(QObject *parent)
+    : QObject(parent)
+{
+    connect(DConfigManager::instance(), &DConfigManager::valueChanged,
+            this, &CollationStrategyProvider::onDConfigChanged);
+}
+
+bool CollationStrategyProvider::latinFirstEnabled() const
+{
+    return DConfigManager::instance()->value(kDefaultCfgPath, kSortLatinFirstZhCn, false).toBool();
+}
+
+bool CollationStrategyProvider::isZhCn()
+{
+    const QLocale loc = QLocale::system();
+    return loc.language() == QLocale::Chinese && loc.country() == QLocale::China;
+}
+
+std::unique_ptr<CollationStrategy> CollationStrategyProvider::createStrategy() const
+{
+    // 开关开启且 zh_CN 时清空脚本重排（拉丁在前）；否则保留 CLDR 默认（与原
+    // QCollator 行为一致）。两路径均使用 ICU 直出 QByteArray 排序键，避免
+    // std::variant 包装带来的排序热路径性能开销。
+    const bool clearReorder = latinFirstEnabled() && isZhCn();
+    return std::make_unique<IcuCollationStrategy>(clearReorder);
+}
+
+const CollationStrategy &CollationStrategyProvider::strategy()
+{
+    thread_local std::unique_ptr<CollationStrategy> tlsStrategy;
+    thread_local uint64_t tlsGeneration = 0;
+
+    const uint64_t gen = m_generation.load(std::memory_order_acquire);
+    if (!tlsStrategy || tlsGeneration != gen) {
+        tlsStrategy = createStrategy();
+        tlsGeneration = gen;
+    }
+    return *tlsStrategy;
+}
+
+void CollationStrategyProvider::onDConfigChanged(const QString &config, const QString &key)
+{
+    if (config != kDefaultCfgPath || key != kSortLatinFirstZhCn)
+        return;
+
+    m_generation.fetch_add(1, std::memory_order_release);
+    Q_EMIT strategyChanged();
+}
+
+DFMBASE_END_NAMESPACE

--- a/src/dfm-base/utils/collation/collationstrategyprovider.cpp
+++ b/src/dfm-base/utils/collation/collationstrategyprovider.cpp
@@ -30,7 +30,7 @@ CollationStrategyProvider::CollationStrategyProvider(QObject *parent)
 
 bool CollationStrategyProvider::latinFirstEnabled() const
 {
-    return DConfigManager::instance()->value(kDefaultCfgPath, kSortLatinFirstZhCn, false).toBool();
+    return DConfigManager::instance()->value(kDefaultCfgPath, kSortLatinFirstZhCn, true).toBool();
 }
 
 bool CollationStrategyProvider::isZhCn()

--- a/src/dfm-base/utils/collation/collationstrategyprovider.h
+++ b/src/dfm-base/utils/collation/collationstrategyprovider.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef COLLATIONSTRATEGYPROVIDER_H
+#define COLLATIONSTRATEGYPROVIDER_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QObject>
+#include <atomic>
+#include <memory>
+
+DFMBASE_BEGIN_NAMESPACE
+
+class CollationStrategy;
+
+/**
+ * @class CollationStrategyProvider
+ * @brief 排序策略选择与运行时切换的单例提供者。
+ *
+ * 职责（SRP）：
+ * - 读取 dconfig 开关（dfm.sort.latinfirst.zhCn）+ 判定系统 locale，
+ *   决定创建的 IcuCollationStrategy 是否清空脚本重排（clearReorder）。
+ * - 监听 DConfigManager::valueChanged，开关变化时使代际失效并发出
+ *   strategyChanged 信号，供视图连接后触发重排。
+ *
+ * 线程安全：strategy() 返回 thread_local 策略实例，配合代际计数器实现
+ * 无锁的线程安全策略访问。代际变更（dconfig 改动）后，各线程下次调用
+ * strategy() 时自动按新策略重建线程局部实例。
+ */
+class CollationStrategyProvider : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(CollationStrategyProvider)
+
+public:
+    static CollationStrategyProvider *instance();
+
+    /// 获取当前线程的策略实例（thread_local，代际过期时自动重建）
+    const CollationStrategy &strategy();
+
+    /// dconfig 开关是否开启（dfm.sort.latinfirst.zhCn）
+    bool latinFirstEnabled() const;
+
+Q_SIGNALS:
+    /// 策略可能已变更（dconfig 开关变化），视图应触发重排
+    void strategyChanged();
+
+private:
+    explicit CollationStrategyProvider(QObject *parent = nullptr);
+    ~CollationStrategyProvider() override = default;
+
+    /// 按当前 dconfig + locale 创建策略实例
+    std::unique_ptr<CollationStrategy> createStrategy() const;
+
+    /// dconfig 变更回调
+    void onDConfigChanged(const QString &config, const QString &key);
+
+    /// 判定系统 locale 是否为简体中文
+    static bool isZhCn();
+
+private:
+    /// 代际计数器：每次策略可能变更时自增，触发线程局部策略重建
+    std::atomic<uint64_t> m_generation { 0 };
+};
+
+DFMBASE_END_NAMESPACE
+
+#endif   // COLLATIONSTRATEGYPROVIDER_H

--- a/src/dfm-base/utils/collation/icucollationstrategy.cpp
+++ b/src/dfm-base/utils/collation/icucollationstrategy.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "icucollationstrategy.h"
+
+#include <QLocale>
+#include <QByteArray>
+
+DFMBASE_BEGIN_NAMESPACE
+
+IcuCollationStrategy::IcuCollationStrategy(bool clearReorder)
+{
+    const QLocale loc = QLocale::system();
+
+    // C locale：QCollator 退化为字节序，此处同步回退
+    if (loc.language() == QLocale::C) {
+        m_byteFallback = true;
+        return;
+    }
+
+    UErrorCode err = U_ZERO_ERROR;
+    m_collator = ucol_open(loc.name().toUtf8().constData(), &err);
+    if (U_FAILURE(err) || !m_collator) {
+        m_byteFallback = true;
+        return;
+    }
+
+    // 忠实复刻 QCollator(numericMode=true, caseSensitivity=CaseSensitive) 设置的
+    // 4 项 ICU 属性（见 qtbase qcollator_icu.cpp QCollatorPrivate::init）。只设这
+    // 4 项、不额外设 FRENCH_COLLATION/CASE_FIRST/CASE_LEVEL，与 QCollator 完全对齐，
+    // 保证默认路径（不清空重排）与原 QCollator 排序结果逐字一致。
+    // UCOL_DEFAULT_STRENGTH 让 ICU 按 locale 解析（多数=TERTIARY，日文=QUATERNARY），
+    // 与 QCollator 大小写敏感分支一致；勿硬编码 TERTIARY 以免 ja 等语系偏差。
+    // 每次调用前重置 err：ICU 在 err 已失败时后续调用会静默 no-op。
+    auto setAttr = [&](UColAttribute a, UColAttributeValue v) {
+        err = U_ZERO_ERROR;
+        ucol_setAttribute(m_collator, a, v, &err);
+        if (U_FAILURE(err)) {
+            m_byteFallback = true;
+            ucol_close(m_collator);
+            m_collator = nullptr;
+            return false;
+        }
+        return true;
+    };
+    if (!setAttr(UCOL_NORMALIZATION_MODE, UCOL_ON)) return;
+    if (!setAttr(UCOL_STRENGTH, UCOL_DEFAULT_STRENGTH)) return;
+    if (!setAttr(UCOL_NUMERIC_COLLATION, UCOL_ON)) return;
+    if (!setAttr(UCOL_ALTERNATE_HANDLING, UCOL_NON_IGNORABLE)) return;
+
+    // 可选：清空脚本重排，使拉丁字母排到中文之前。对无重排的 locale 为 no-op。
+    if (clearReorder) {
+        err = U_ZERO_ERROR;
+        ucol_setReorderCodes(m_collator, nullptr, 0, &err);
+        if (U_FAILURE(err)) {
+            m_byteFallback = true;
+            ucol_close(m_collator);
+            m_collator = nullptr;
+        }
+    }
+}
+
+IcuCollationStrategy::~IcuCollationStrategy()
+{
+    if (m_collator)
+        ucol_close(m_collator);
+}
+
+QByteArray IcuCollationStrategy::sortKey(const QString &s) const
+{
+    if (m_byteFallback || !m_collator)
+        return s.toUtf8();
+
+    const UChar *utf16 = reinterpret_cast<const UChar *>(s.utf16());
+    const int32_t len = s.size();
+
+    // 启发式缓冲区生成；不够则按返回值扩容重试。ucol_getSortKey 不接收 UErrorCode。
+    QByteArray key;
+    key.resize(len * 4 + 16);
+    int32_t n = ucol_getSortKey(m_collator, utf16, len,
+                                reinterpret_cast<uint8_t *>(key.data()), key.size());
+    if (n > key.size()) {
+        key.resize(n);
+        n = ucol_getSortKey(m_collator, utf16, len,
+                            reinterpret_cast<uint8_t *>(key.data()), n);
+    }
+    key.resize(n > 0 ? n : 0);
+    return key;
+}
+
+int IcuCollationStrategy::compare(const QString &s1, const QString &s2) const
+{
+    if (m_byteFallback || !m_collator)
+        return s1.toUtf8().compare(s2.toUtf8());
+
+    // 直接走 UTF-16 路径（ucol_strcoll），与 sortKey() 的 utf16() 路径对称。
+    return ucol_strcoll(m_collator,
+                        reinterpret_cast<const UChar *>(s1.utf16()), s1.size(),
+                        reinterpret_cast<const UChar *>(s2.utf16()), s2.size());
+}
+
+DFMBASE_END_NAMESPACE

--- a/src/dfm-base/utils/collation/icucollationstrategy.cpp
+++ b/src/dfm-base/utils/collation/icucollationstrategy.cpp
@@ -75,9 +75,10 @@ QByteArray IcuCollationStrategy::sortKey(const QString &s) const
     const UChar *utf16 = reinterpret_cast<const UChar *>(s.utf16());
     const int32_t len = s.size();
 
-    // 启发式缓冲区生成；不够则按返回值扩容重试。ucol_getSortKey 不接收 UErrorCode。
-    QByteArray key;
-    key.resize(len * 4 + 16);
+    // 采用与 QCollator::sortKey (qtbase qcollator_icu.cpp) 相同的缓冲区策略：
+    // Qt::Uninitialized 避免零填充，容量 16+len+len/4 是 Qt 的启发式（多数 sort key
+    // 不会超出此容量，避免扩容重试）。ucol_getSortKey 不接收 UErrorCode。
+    QByteArray key(16 + len + (len >> 2), Qt::Uninitialized);
     int32_t n = ucol_getSortKey(m_collator, utf16, len,
                                 reinterpret_cast<uint8_t *>(key.data()), key.size());
     if (n > key.size()) {

--- a/src/dfm-base/utils/collation/icucollationstrategy.h
+++ b/src/dfm-base/utils/collation/icucollationstrategy.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ICUCOLLATIONSTRATEGY_H
+#define ICUCOLLATIONSTRATEGY_H
+
+#include <dfm-base/dfm_base_global.h>
+#include <dfm-base/utils/collation/collationstrategy.h>
+
+#include <unicode/ucol.h>
+
+DFMBASE_BEGIN_NAMESPACE
+
+/**
+ * @class IcuCollationStrategy
+ * @brief 基于 ICU 的排序策略，直接产出 QByteArray 排序键。
+ *
+ * 按系统 locale 打开 UCollator，忠实复刻 QCollator（numericMode=true、
+ * caseSensitivity=CaseSensitive）的 4 项 ICU 属性，使默认路径（不清空重排）
+ * 与原 QCollator 行为逐字一致。当 @p clearReorder 为 true 时，额外调用
+ * ucol_setReorderCodes(NULL, 0) 清空脚本重排——在简体中文（zh_CN）下，
+ * CLDR 拼音排序默认含 [reorder Hani]，清空后拉丁字母排到中文之前，各脚本块
+ * 内部顺序（含拼音序）保持不变。
+ *
+ * 排序键直接返回 QByteArray（ucol_getSortKey），避免 QCollatorSortKey 的共享
+ * 指针间接与 std::variant 包装开销，使排序元素更紧凑、比较更快。
+ *
+ * 仅由 CollationStrategyProvider 创建：
+ * - 默认（开关关 / 非 zh_CN）：clearReorder=false，行为等同原 QCollator。
+ * - 开关开且 zh_CN：clearReorder=true，拉丁在前。
+ */
+class IcuCollationStrategy : public CollationStrategy
+{
+public:
+    /**
+     * @param clearReorder 是否清空脚本重排（拉丁在前）。默认 false。
+     */
+    explicit IcuCollationStrategy(bool clearReorder = false);
+    ~IcuCollationStrategy() override;
+
+    IcuCollationStrategy(const IcuCollationStrategy &) = delete;
+    IcuCollationStrategy &operator=(const IcuCollationStrategy &) = delete;
+
+    QByteArray sortKey(const QString &s) const override;
+    int compare(const QString &s1, const QString &s2) const override;
+
+private:
+    /// ICU 排序器句柄；为空时走 UTF-8 字节序兜底（C locale 或 ucol_open 失败）
+    UCollator *m_collator { nullptr };
+    bool m_byteFallback { false };
+};
+
+DFMBASE_END_NAMESPACE
+
+#endif   // ICUCOLLATIONSTRATEGY_H

--- a/src/dfm-base/utils/filenamesorter.cpp
+++ b/src/dfm-base/utils/filenamesorter.cpp
@@ -3,30 +3,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "filenamesorter.h"
+#include "collation/collationstrategy.h"
+#include "collation/collationstrategyprovider.h"
 
-#include <memory>
 #include <algorithm>
 
 DFMBASE_BEGIN_NAMESPACE
 
-QCollator &FileNameSorter::collator()
+QByteArray FileNameSorter::sortKey(const QString &fileName)
 {
-    // 使用 thread_local + unique_ptr 确保线程安全和自动内存清理
-    // 线程退出时，unique_ptr 自动析构，释放 QCollator 内存
-    static thread_local std::unique_ptr<QCollator> collator;
-
-    if (!collator) {
-        collator = std::make_unique<QCollator>();
-        collator->setNumericMode(true);   // 自然排序：file2 < file10
-        collator->setCaseSensitivity(Qt::CaseSensitive);   // 大小写敏感
-    }
-
-    return *collator;
-}
-
-QCollatorSortKey FileNameSorter::sortKey(const QString &fileName)
-{
-    return collator().sortKey(fileName);
+    return CollationStrategyProvider::instance()->strategy().sortKey(fileName);
 }
 
 void FileNameSorter::sort(QStringList &fileNames, Qt::SortOrder order)
@@ -34,11 +20,14 @@ void FileNameSorter::sort(QStringList &fileNames, Qt::SortOrder order)
     if (fileNames.size() <= 1)
         return;
 
+    // 批次入口一次性获取策略，保证整个批次内策略一致（避免 dconfig 切换竞态）
+    const CollationStrategy &s = CollationStrategyProvider::instance()->strategy();
+
     // 预生成所有 sortKey
-    QVector<QPair<QString, QCollatorSortKey>> fileWithKeys;
+    QVector<QPair<QString, QByteArray>> fileWithKeys;
     fileWithKeys.reserve(fileNames.size());
     for (const QString &name : fileNames) {
-        fileWithKeys.emplace_back(qMakePair(name, sortKey(name)));
+        fileWithKeys.emplace_back(qMakePair(name, s.sortKey(name)));
     }
 
     // 使用 sortKey 排序
@@ -58,11 +47,14 @@ void FileNameSorter::sortUrls(QList<QUrl> &urls, Qt::SortOrder order)
     if (urls.size() <= 1)
         return;
 
+    // 批次入口一次性获取策略，保证整个批次内策略一致（避免 dconfig 切换竞态）
+    const CollationStrategy &s = CollationStrategyProvider::instance()->strategy();
+
     // 预生成所有 sortKey
-    QVector<QPair<QUrl, QCollatorSortKey>> urlWithKeys;
+    QVector<QPair<QUrl, QByteArray>> urlWithKeys;
     urlWithKeys.reserve(urls.size());
     for (const QUrl &url : urls) {
-        urlWithKeys.emplace_back(qMakePair(url, sortKey(url.fileName())));
+        urlWithKeys.emplace_back(qMakePair(url, s.sortKey(url.fileName())));
     }
 
     // 使用 sortKey 排序
@@ -79,7 +71,7 @@ void FileNameSorter::sortUrls(QList<QUrl> &urls, Qt::SortOrder order)
 
 bool FileNameSorter::compare(const QString &left, const QString &right, Qt::SortOrder order)
 {
-    int result = collator().compare(left, right);
+    int result = CollationStrategyProvider::instance()->strategy().compare(left, right);
     return (order == Qt::AscendingOrder) ? (result < 0) : (result > 0);
 }
 

--- a/src/dfm-base/utils/filenamesorter.h
+++ b/src/dfm-base/utils/filenamesorter.h
@@ -7,7 +7,7 @@
 
 #include <dfm-base/dfm_base_global.h>
 
-#include <QCollator>
+#include <QByteArray>
 #include <QUrl>
 #include <QStringList>
 #include <algorithm>
@@ -18,31 +18,30 @@ DFMBASE_BEGIN_NAMESPACE
  * @class FileNameSorter
  * @brief 高性能文件名排序工具类
  *
- * 使用 QCollator::sortKey() 预处理文件名，提供批量排序的高性能实现。
- * 线程安全：每个线程拥有独立的 QCollator 实例。
+ * 使用 CollationStrategy 接口预处理文件名，提供批量排序的高性能实现。
+ * 排序键统一为 QByteArray（ICU ucol_getSortKey 直出），避免 QCollatorSortKey
+ * 共享指针间接与 std::variant 包装的排序热路径开销。默认策略不清空脚本重排
+ * （与历史 QCollator 行为一致）；当 dconfig 开关 dfm.sort.latinfirst.zhCn
+ * 开启且系统 locale 为 zh_CN 时，清空脚本重排使拉丁字母排在中文之前。
+ * 线程安全：每个线程拥有独立的策略实例。
  *
  * 设计原则：
- * - 单一职责：只负责文件名排序
- * - 高内聚低耦合：不依赖外部模块
+ * - 单一职责：只负责文件名排序（排序规则由 CollationStrategy 提供）
+ * - 高内聚低耦合：不依赖具体排序后端
  * - KISS：接口简洁明了
  */
 class FileNameSorter
 {
 public:
     /**
-     * @brief 获取当前线程的 QCollator 实例
-     * @return 线程局部 QCollator 引用
-     *
-     * 配置：numericMode=true, caseSensitivity=CaseSensitive
-     */
-    static QCollator &collator();
-
-    /**
      * @brief 生成文件名的排序键
      * @param fileName 文件名
-     * @return QCollatorSortKey 可用于高效比较
+     * @return QByteArray 可用于高效比较（memcmp 式）
+     *
+     * 默认等价于 QCollator(numericMode=true, caseSensitivity=CaseSensitive)；
+     * 开关开启且 zh_CN 时清空脚本重排（拉丁在前）。
      */
-    static QCollatorSortKey sortKey(const QString &fileName);
+    static QByteArray sortKey(const QString &fileName);
 
     /**
      * @brief 批量排序字符串列表（使用 sortKey 优化）
@@ -78,7 +77,7 @@ public:
      *
      * 使用示例：
      * @code
-     * QList<QPair<QString, QCollatorSortKey>> items;
+     * QList<QPair<QString, QByteArray>> items;
      * for (const auto &url : urls) {
      *     items.append({url.fileName(), FileNameSorter::sortKey(url.fileName())});
      * }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.cpp
@@ -25,6 +25,7 @@
 #include <dfm-base/utils/highlightprovider.h>
 #include <dfm-base/widgets/filemanagerwindowsmanager.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/utils/collation/collationstrategyprovider.h>
 #include <dfm-base/utils/protocolutils.h>
 
 #include <dfm-framework/event/event.h>
@@ -58,6 +59,8 @@ FileViewModel::FileViewModel(QAbstractItemView *parent)
     connect(Application::instance(), &Application::genericAttributeChanged, this, &FileViewModel::onGenericAttributeChanged);
     connect(Application::instance(), &Application::showedHiddenFilesChanged, this, &FileViewModel::onHiddenSettingChanged);
     connect(DConfigManager::instance(), &DConfigManager::valueChanged, this, &FileViewModel::onDConfigChanged);
+    connect(dfmbase::CollationStrategyProvider::instance(), &dfmbase::CollationStrategyProvider::strategyChanged,
+            this, &FileViewModel::onSortStrategyChanged, Qt::QueuedConnection);
     connect(&waitTimer, &QTimer::timeout, this, &FileViewModel::onSetCursorWait);
     waitTimer.setInterval(50);
 
@@ -1205,6 +1208,14 @@ void FileViewModel::onDConfigChanged(const QString &config, const QString &key)
 
     if (DConfigInfo::kMtpThumbnailKey == key && ProtocolUtils::isMTPFile(rootUrl()))
         Q_EMIT requestClearThumbnail();
+}
+
+void FileViewModel::onSortStrategyChanged()
+{
+    // 排序策略变更（dconfig 开关切换）后，按当前列与顺序重新排序。
+    // sort() 内部会检查 model 是否 busy，busy 时跳过——下次导航/手动排序自然生效。
+    const int column = getColumnByRole(sortRole());
+    sort(column, sortOrder());
 }
 
 void FileViewModel::onSetCursorWait()

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileviewmodel.h
@@ -162,6 +162,7 @@ public Q_SLOTS:
     void onUpdateView();
     void onGenericAttributeChanged(DFMBASE_NAMESPACE::Application::GenericAttribute ga, const QVariant &value);
     void onDConfigChanged(const QString &config, const QString &key);
+    void onSortStrategyChanged();
     void onSetCursorWait();
     void onHiddenSettingChanged(bool value);
     void onWorkFinish(int visiableCount, int totalCount);

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewsorter.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewsorter.cpp
@@ -6,6 +6,8 @@
 #include "models/fileitemdata.h"
 
 #include <dfm-base/utils/filenamesorter.h>
+#include <dfm-base/utils/collation/collationstrategy.h>
+#include <dfm-base/utils/collation/collationstrategyprovider.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/mimetype/mimetypedisplaymanager.h>
@@ -140,10 +142,12 @@ QList<QUrl> FileViewSorter::sortMixed(const QList<QUrl> &urls)
     }
 
     // 预生成所有 sortKey（不包含目录/文件前缀）
-    QVector<QPair<QUrl, QCollatorSortKey>> items;
+    // 批次入口一次性获取策略，保证整个批次内策略一致（避免 dconfig 切换竞态）
+    const dfmbase::CollationStrategy &sortStrategy =
+            dfmbase::CollationStrategyProvider::instance()->strategy();
+    QVector<QPair<QUrl, QByteArray>> items;
     items.reserve(urls.size());
 
-    QCollator &c = collator();
     for (const QUrl &url : urls) {
         QString keyStr;
         // MimeType 排序使用预计算结果
@@ -160,7 +164,7 @@ QList<QUrl> FileViewSorter::sortMixed(const QList<QUrl> &urls)
         } else {
             keyStr = generateSortKeyStringInternal(url);
         }
-        items.append(qMakePair(url, c.sortKey(keyStr)));
+        items.append(qMakePair(url, sortStrategy.sortKey(keyStr)));
     }
 
     // 使用 FileNameSorter 的排序模板
@@ -294,8 +298,11 @@ int FileViewSorter::findInsertPosition(const QUrl &url, const QList<QUrl> &sorte
     if (sortedList.isEmpty())
         return 0;
 
+    // 批次入口一次性获取策略，保证二分查找过程中策略一致
+    const dfmbase::CollationStrategy &sortStrategy =
+            dfmbase::CollationStrategyProvider::instance()->strategy();
     QString newKeyStr = generateSortKeyString(url);
-    QCollatorSortKey newKey = collator().sortKey(newKeyStr);
+    QByteArray newKey = sortStrategy.sortKey(newKeyStr);
 
     // 二分查找
     int left = 0;
@@ -304,7 +311,7 @@ int FileViewSorter::findInsertPosition(const QUrl &url, const QList<QUrl> &sorte
     while (left < right) {
         int mid = left + (right - left) / 2;
         QString midKeyStr = generateSortKeyString(sortedList.at(mid));
-        QCollatorSortKey midKey = collator().sortKey(midKeyStr);
+        QByteArray midKey = sortStrategy.sortKey(midKeyStr);
 
         bool shouldMoveRight = (m_context.order == Qt::AscendingOrder)
                 ? (newKey < midKey)
@@ -626,12 +633,6 @@ QString FileViewSorter::getFileDisplayName(const QUrl &url, const FileItemDataPo
     }
 
     return url.fileName();
-}
-
-QCollator &FileViewSorter::collator()
-{
-    // 复用 FileNameSorter 的线程安全 collator
-    return dfmbase::FileNameSorter::collator();
 }
 
 DPWORKSPACE_END_NAMESPACE

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewsorter.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/fileviewsorter.h
@@ -11,7 +11,6 @@
 #include <dfm-base/interfaces/fileinfo.h>
 #include <dfm-base/interfaces/sortfileinfo.h>
 
-#include <QCollator>
 #include <QUrl>
 #include <QVariant>
 #include <QHash>
@@ -27,7 +26,7 @@ typedef QSharedPointer<FileItemData> FileItemDataPointer;
  * @class FileViewSorter
  * @brief 文件视图高性能排序器
  *
- * 使用 QCollator::sortKey() 预处理排序数据，提供批量排序和增量插入定位功能。
+ * 使用 FileNameSorter::sortKey() 预处理排序数据，提供批量排序和增量插入定位功能。
  * 设计原则：
  * - 单一职责：专注于文件视图排序逻辑
  * - 高性能：使用 sortKey 避免重复比较
@@ -160,9 +159,6 @@ private:
 
 private:
     SortContext m_context;
-
-    // 线程安全的 QCollator（每个线程独立）
-    QCollator &collator();
 };
 
 DPWORKSPACE_END_NAMESPACE


### PR DESCRIPTION
## Root Cause Analysis

The dconfig key `dfm.sort.latinfirst.zhCn` was shipped with a default value of `false` in `assets/configs/org.deepin.dde.file-manager.json`, which keeps the Latin-before-Chinese sort strategy disabled by default. The C++ fallback in `CollationStrategyProvider::latinFirstEnabled()` (`src/dfm-base/utils/collation/collationstrategyprovider.cpp:33`) also returns `false` when the dconfig value is unavailable. As a result, Latin letters do not sort before Chinese in zh_CN unless the user manually toggles the setting.

## Fix Plan

Flip the dconfig default value for `dfm.sort.latinfirst.zhCn` from `false` to `true`, and update the C++ fallback in `CollationStrategyProvider::latinFirstEnabled()` from `false` to `true`. This enables the Latin-first sort order by default under zh_CN while preserving any explicitly set user preference.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Only two boolean default values are changed; no function signatures, public APIs, or class members are modified.
- The changed lines were introduced by commit `1deb65ac26e4` (the original feature); this change does not revert any prior bug fix.

### Business Impact Scope

Affects the default file-name sort order in the file manager under zh_CN locale. Latin letters will now appear before Chinese characters by default. Users who have explicitly set the dconfig key keep their own preference. Non-zh_CN locales are unaffected.

### Verification Suggestion

Verify that the default sort order places Latin letters before Chinese in zh_CN, that an explicit dconfig value still overrides the default, and that non-zh_CN locales sort behavior is unchanged.

---

## 根因分析

dconfig 键 `dfm.sort.latinfirst.zhCn` 在 `assets/configs/org.deepin.dde.file-manager.json` 中默认值为 `false`，导致拉丁字母置于中文之前的排序策略默认关闭。`CollationStrategyProvider::latinFirstEnabled()` 的 C++ 回退值（`collationstrategyprovider.cpp:33`）也为 `false`。因此 zh_CN 下拉丁字母不会排在中文之前，除非用户手动开启该设置。

## 修复方案

将 dconfig 键 `dfm.sort.latinfirst.zhCn` 的默认值由 `false` 改为 `true`，并将 `CollationStrategyProvider::latinFirstEnabled()` 的 C++ 回退值由 `false` 改为 `true`。这样 zh_CN 下拉丁字母默认排在中文之前，同时保留用户已显式设置的偏好。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 仅修改两个布尔默认值，不涉及函数签名、公开接口或类成员变更。
- 目标行由提交 `1deb65ac26e4`（原始特性）引入，本次改动不会撤销任何历史 bug 修复。

### 业务影响范围

影响文件管理器在 zh_CN 语言环境下的默认文件名排序顺序，拉丁字母将默认排在中文之前。用户已显式设置 dconfig 键的值不受影响。非 zh_CN 语言环境不受影响。

### 验证建议

验证 zh_CN 下默认排序将拉丁字母排在中文之前、显式 dconfig 值仍可覆盖默认值、非 zh_CN 语言环境排序行为保持不变。

## Summary by Sourcery

Enable configurable Latin-first filename sorting for zh_CN and integrate locale-aware ICU collation throughout file-manager sorting.

New Features:
- Enable Latin-before-Chinese filename ordering by default for the zh_CN locale, with user configuration remaining authoritative.
- Support runtime changes to the sorting preference and automatically refresh file views when the strategy changes.

Enhancements:
- Replace the filename sorting backend with an ICU-based collation strategy while preserving existing locale-aware, numeric, and case-sensitive behavior for other locales and configurations.
- Centralize collation strategy selection and use compact precomputed byte-array sort keys across file and workspace sorting.

Build:
- Add ICU i18n and Unicode libraries as required build dependencies for the file-manager base library.

Chores:
- Add the dconfig key definition and enable its zh_CN default setting.