### PR TITLE
fix: improve sidebar URL highlight deduplication

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -173,7 +173,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
         if (foundByCb || (sidebarView && UniversalUtils::urlEquals(subItem->url(), sidebarView->currentUrl())))
             isUrlEqual = true;
     }
-    if (isUrlEqual && sidebarView && index == sidebarView->currentTrackedIndex()) {
+    if (isUrlEqual && sidebarView && sidebarView->isCurrentUrlHighlightIndex(index)) {
         // If the dragging and moving source item is not the current highlighted one,
         // the highlighted one must be keep its state.
         keepDrawingHighlighted = true;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -1149,9 +1149,9 @@ void SideBarView::setCurrentUrl(const QUrl &url)
     // Fix: whenever the URL basis actually changes, repaint the whole viewport so every
     // visible item re-evaluates its URL-based highlight against the new url -- the
     // previously highlighted item drops its stale highlight and the newly matching
-    // item gains it, immediately, without depending on setCurrentIndex(). This is safe
-    // because the highlight background is purely URL-matched, so at most one item is
-    // highlighted (no "two items selected").
+    // item gains it, immediately, without depending on setCurrentIndex(). Duplicate
+    // URL matches are de-duplicated by SideBarItemDelegate via
+    // isCurrentUrlHighlightIndex().
     const QUrl previousUrl = d->sidebarUrl;
     d->sidebarUrl = url;
     if (!UniversalUtils::urlEquals(previousUrl, url))
@@ -1199,9 +1199,68 @@ QUrl SideBarView::currentUrl() const
     return d->sidebarUrl;
 }
 
-QModelIndex SideBarView::currentTrackedIndex() const
+bool SideBarView::isCurrentUrlHighlightIndex(const QModelIndex &index) const
 {
-    return d->current;
+    if (!index.isValid())
+        return false;
+
+    SideBarModel *sidebarModel = dynamic_cast<SideBarModel *>(model());
+    if (!sidebarModel)
+        return true;
+
+    const auto matchesCurrentUrl = [this, sidebarModel](const QModelIndex &candidate) {
+        if (!candidate.isValid())
+            return false;
+
+        SideBarItem *item = sidebarModel->itemFromIndex(candidate);
+        if (!item)
+            return false;
+
+        return UniversalUtils::urlEquals(item->url(), d->sidebarUrl)
+                || UniversalUtils::urlEquals(item->targetUrl(), d->sidebarUrl)
+                || (item->itemInfo().findMeCb && item->itemInfo().findMeCb(item->url(), d->sidebarUrl));
+    };
+    const auto isVisibleCandidate = [this](const QModelIndex &candidate) {
+        if (isIndexHidden(candidate))
+            return false;
+
+        for (QModelIndex parent = candidate.parent(); parent.isValid(); parent = parent.parent()) {
+            if (isIndexHidden(parent) || !isExpanded(parent))
+                return false;
+        }
+
+        return true;
+    };
+
+    QList<QModelIndex> matches;
+    QList<QModelIndex> pending { QModelIndex() };
+    while (!pending.isEmpty()) {
+        const QModelIndex parent = pending.takeLast();
+        const int childCount = sidebarModel->rowCount(parent);
+        for (int row = 0; row < childCount; ++row) {
+            const QModelIndex candidate = sidebarModel->index(row, 0, parent);
+            if (!candidate.isValid())
+                continue;
+
+            if (matchesCurrentUrl(candidate) && isVisibleCandidate(candidate))
+                matches.append(candidate);
+
+            if (sidebarModel->rowCount(candidate) > 0)
+                pending.append(candidate);
+        }
+    }
+
+    if (matches.size() <= 1)
+        return true;
+
+    if (matches.contains(d->current) && matchesCurrentUrl(d->current))
+        return index == d->current;
+
+    const QModelIndex viewCurrent = currentIndex();
+    if (matches.contains(viewCurrent) && matchesCurrentUrl(viewCurrent))
+        return index == viewCurrent;
+
+    return index == matches.first();
 }
 
 QModelIndex SideBarView::findItemIndex(const QUrl &url) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -33,7 +33,7 @@ public:
     void saveStateWhenClose();
     void setCurrentUrl(const QUrl &sidebarUrl);
     QUrl currentUrl() const;
-    QModelIndex currentTrackedIndex() const;
+    bool isCurrentUrlHighlightIndex(const QModelIndex &index) const;
     QModelIndex findItemIndex(const QUrl &url) const;
     QVariantMap groupExpandState() const;
     QModelIndex previousIndex() const;


### PR DESCRIPTION
Improved the sidebar item highlight logic to properly handle
duplicate URL matches. Replaced currentTrackedIndex() with
isCurrentUrlHighlightIndex() that performs comprehensive duplicate
resolution. The new method traverses the sidebar tree to find all
visible items matching the current URL, then applies priority rules:
if a tracked index exists and matches, use it; otherwise if the view's
current index matches, use it; otherwise use the first match. This
ensures consistent highlighting behavior when multiple sidebar items
have the same URL.

Log: Fixed sidebar item highlight logic for duplicate URL matches

Influence:
1. Test clicking on different files/folders in the main view and verify
sidebar highlights the correct item
2. Test cases where multiple sidebar items point to the same URL (e.g.,
shortcuts/bookmarks to same location)
3. Verify highlight transfers correctly when navigating between
duplicate URL items
4. Test expand/collapse behavior with hidden items and duplicate URLs
5. Verify highlighting works correctly with findMeCb matching functions

fix: 改进侧边栏URL高亮去重逻辑

改进了侧边栏项目高亮逻辑，以正确处理重复的URL匹配。用
isCurrentUrlHighlightIndex()替换currentTrackedIndex()，新方法执行全面的
重复项解析。该方法遍历侧边栏树以查找所有与当前URL匹配的可见项目，然后应
用优先级规则：如果存在跟踪索引且匹配，则使用它；否则如果视图的当前索引匹
配，则使用它；否则使用第一个匹配项。这确保了当多个侧边栏项目具有相同URL
时的高亮行为一致性。

Log: 修复侧边栏项目在重复URL匹配时的高亮逻辑
Bug: 374393

Influence:
1. 测试在主视图中点击不同文件/文件夹，验证侧边栏高亮显示正确的项目
2. 测试多个侧边栏项目指向同一URL的情况（例如指向相同位置的快捷方式/
书签）
3. 验证在重复URL项目间导航时，高亮是否正确转移
4. 测试隐藏项目和重复URL时的展开/折叠行为
5. 验证高亮功能与findMeCb匹配函数正常工作

## Summary by Sourcery

Resolve duplicate sidebar URL matches so navigation and visibility changes maintain the correct highlighted item.

Bug Fixes:
- Ensure sidebar highlighting consistently selects the correct visible item when multiple entries match the current URL.

Enhancements:
- Replace tracked-index highlighting with URL-match resolution that prioritizes the tracked item, then the view's current item, and finally the first visible match, including custom matching callbacks.