### PR TITLE
release/snipe

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-file-manager (6.5.166) unstable; urgency=medium
+
+  * fix: improve sidebar URL highlight deduplication
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 21 Aug 2026 13:58:01 +0800
+
 dde-file-manager (6.5.165) unstable; urgency=medium
 
   * fix(textindex): add auto-reconnect and enlarge SO_RCVBUF for vfsmonitor

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritemdelegate.cpp
@@ -160,7 +160,7 @@ void SideBarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &o
     }
 
     bool isDraggingItemNotHighlighted = selected && !isUrlEqual;
-    if (isUrlEqual && sidebarView && index == sidebarView->currentTrackedIndex()) {
+    if (isUrlEqual && sidebarView && sidebarView->isCurrentUrlHighlightIndex(index)) {
         // If the dragging and moving source item is not the current highlighted one,
         // the highlighted one must be keep its state.
         keepDrawingHighlighted = true;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.cpp
@@ -914,9 +914,9 @@ void SideBarView::setCurrentUrl(const QUrl &url)
     // Fix: whenever the URL basis actually changes, repaint the whole viewport so every
     // visible item re-evaluates its URL-based highlight against the new url -- the
     // previously highlighted item drops its stale highlight and the newly matching
-    // item gains it, immediately, without depending on setCurrentIndex(). This is safe
-    // because the highlight background is purely URL-matched, so at most one item is
-    // highlighted (no "two items selected").
+    // item gains it, immediately, without depending on setCurrentIndex(). Duplicate
+    // URL matches are de-duplicated by SideBarItemDelegate via
+    // isCurrentUrlHighlightIndex().
     const QUrl previousUrl = d->sidebarUrl;
     d->sidebarUrl = url;
     if (!UniversalUtils::urlEquals(previousUrl, url))
@@ -964,9 +964,68 @@ QUrl SideBarView::currentUrl() const
     return d->sidebarUrl;
 }
 
-QModelIndex SideBarView::currentTrackedIndex() const
+bool SideBarView::isCurrentUrlHighlightIndex(const QModelIndex &index) const
 {
-    return d->current;
+    if (!index.isValid())
+        return false;
+
+    SideBarModel *sidebarModel = dynamic_cast<SideBarModel *>(model());
+    if (!sidebarModel)
+        return true;
+
+    const auto matchesCurrentUrl = [this, sidebarModel](const QModelIndex &candidate) {
+        if (!candidate.isValid())
+            return false;
+
+        SideBarItem *item = sidebarModel->itemFromIndex(candidate);
+        if (!item)
+            return false;
+
+        return UniversalUtils::urlEquals(item->url(), d->sidebarUrl)
+                || UniversalUtils::urlEquals(item->targetUrl(), d->sidebarUrl)
+                || (item->itemInfo().findMeCb && item->itemInfo().findMeCb(item->url(), d->sidebarUrl));
+    };
+    const auto isVisibleCandidate = [this](const QModelIndex &candidate) {
+        if (isIndexHidden(candidate))
+            return false;
+
+        for (QModelIndex parent = candidate.parent(); parent.isValid(); parent = parent.parent()) {
+            if (isIndexHidden(parent) || !isExpanded(parent))
+                return false;
+        }
+
+        return true;
+    };
+
+    QList<QModelIndex> matches;
+    QList<QModelIndex> pending { QModelIndex() };
+    while (!pending.isEmpty()) {
+        const QModelIndex parent = pending.takeLast();
+        const int childCount = sidebarModel->rowCount(parent);
+        for (int row = 0; row < childCount; ++row) {
+            const QModelIndex candidate = sidebarModel->index(row, 0, parent);
+            if (!candidate.isValid())
+                continue;
+
+            if (matchesCurrentUrl(candidate) && isVisibleCandidate(candidate))
+                matches.append(candidate);
+
+            if (sidebarModel->rowCount(candidate) > 0)
+                pending.append(candidate);
+        }
+    }
+
+    if (matches.size() <= 1)
+        return true;
+
+    if (matches.contains(d->current) && matchesCurrentUrl(d->current))
+        return index == d->current;
+
+    const QModelIndex viewCurrent = currentIndex();
+    if (matches.contains(viewCurrent) && matchesCurrentUrl(viewCurrent))
+        return index == viewCurrent;
+
+    return index == matches.first();
 }
 
 QModelIndex SideBarView::findItemIndex(const QUrl &url) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebarview.h
@@ -33,7 +33,7 @@ public:
     void saveStateWhenClose();
     void setCurrentUrl(const QUrl &sidebarUrl);
     QUrl currentUrl() const;
-    QModelIndex currentTrackedIndex() const;
+    bool isCurrentUrlHighlightIndex(const QModelIndex &index) const;
     QModelIndex findItemIndex(const QUrl &url) const;
     QVariantMap groupExpandState() const;
     QModelIndex previousIndex() const;


### PR DESCRIPTION
- **fix: sidebar double highlight on duplicate URL**
- **chore: bump version to 6.5.165**
- **fix: improve sidebar URL highlight deduplication**
- **chore: bump version to 6.5.166**

## Summary by Sourcery

Ensure sidebar URL highlighting remains unique and stable when duplicate sidebar entries match the same URL.

Bug Fixes:
- Prevent duplicate sidebar highlights when multiple visible items match the current URL.
- Ensure sidebar highlighting consistently selects a single preferred matching item during URL changes and dragging.

Enhancements:
- Replace tracked-index highlighting with URL-match-aware selection that prioritizes the current or tracked sidebar item.

Chores:
- Bump the application version to 6.5.166.