### PR TITLE
test: fix 4 failing unit tests in workspace views

### DIFF
--- a/autotests/plugins/dfmplugin-workspace/views/test_headerview.cpp
+++ b/autotests/plugins/dfmplugin-workspace/views/test_headerview.cpp
@@ -223,11 +223,11 @@ TEST_F(HeaderViewTest, SectionName_ReturnsSectionName)
     
     QString result = headerView->sectionName(0);
     
-    EXPECT_EQ(result, "File Name");
+    EXPECT_EQ(result, "Name");
     
     result = headerView->sectionName(1);
     
-    EXPECT_EQ(result, "File Size");
+    EXPECT_EQ(result, "Size");
 }
 
 TEST_F(HeaderViewTest, SectionElidedName_ReturnsElidedName)
@@ -246,9 +246,9 @@ TEST_F(HeaderViewTest, SectionElidedName_ReturnsElidedName)
     
     // Test with long name that should be elided
     QString result = headerView->sectionElidedName(0, 20); // Small width
-    EXPECT_TRUE(result.length() < 10); // Should be elided
+    EXPECT_NE(result, "Name"); // Should be elided
     
     // Test with short name that should not be elided
     result = headerView->sectionElidedName(0, 100); // Large width
-    EXPECT_FALSE(result.length() < 10); // Should not be elided
+    EXPECT_EQ(result, "Name"); // Should not be elided
 }

--- a/autotests/plugins/dfmplugin-workspace/views/test_listitemdelegate.cpp
+++ b/autotests/plugins/dfmplugin-workspace/views/test_listitemdelegate.cpp
@@ -128,7 +128,7 @@ TEST_F(ListItemDelegateTest, CanGetSizeHint)
     
     QSize size = delegate->sizeHint(option, index);
     
-    EXPECT_GT(size.width(), 0);
+    EXPECT_EQ(size.width(), -1);
     EXPECT_GT(size.height(), 0);
 }
 
@@ -370,21 +370,21 @@ TEST_F(ListItemDelegateTest, CanHandleSizeHintWithDifferentOptions)
     option.rect = QRect(0, 0, 100, 30);
     EXPECT_NO_FATAL_FAILURE({
         QSize size = delegate->sizeHint(option, index);
-        EXPECT_GT(size.width(), 0);
+        EXPECT_EQ(size.width(), -1);
         EXPECT_GT(size.height(), 0);
     });
     
     option.rect = QRect(0, 0, 200, 30);
     EXPECT_NO_FATAL_FAILURE({
         QSize size = delegate->sizeHint(option, index);
-        EXPECT_GT(size.width(), 0);
+        EXPECT_EQ(size.width(), -1);
         EXPECT_GT(size.height(), 0);
     });
     
     option.rect = QRect(0, 0, 500, 30);
     EXPECT_NO_FATAL_FAILURE({
         QSize size = delegate->sizeHint(option, index);
-        EXPECT_GT(size.width(), 0);
+        EXPECT_EQ(size.width(), -1);
         EXPECT_GT(size.height(), 0);
     });
 }


### PR DESCRIPTION
## 修复 4 个失败的单元测试（工作区视图）

### 问题

运行日志中 4 个单元测试失败，均为测试断言与生产代码行为不一致。

### 根因

| 失败测试 | 根因 |
|---------|------|
| `HeaderViewTest.SectionName` | 断言期望 `"File Name"`/`"File Size"`，但 `roleDisplayString()` 返回 `tr("Name")`/`tr("Size")` |
| `HeaderViewTest.SectionElidedName` | 用 `result.length() < 10` 判断省略，但 `"Name"` 仅 4 字符恒为 true，`EXPECT_FALSE` 必然失败 |
| `ListItemDelegateTest`（2 个） | 断言 `size.width() > 0`，但 `itemSizeHint` 宽度按设计为 -1（列表视图行宽由 View 决定） |

### 修复

仅修改 2 个测试文件的断言，不改动生产代码：

- `test_headerview.cpp`: 修正字符串断言和省略判断逻辑
- `test_listitemdelegate.cpp`: `EXPECT_GT(size.width(), 0)` → `EXPECT_EQ(size.width(), -1)`

### 影响

- 仅修改测试断言，不涉及生产代码
- 4 个受影响的测试用例应通过

## Summary by Sourcery

Fix workspace view unit-test assertions to match the implemented UI behavior.

Bug Fixes:
- Align workspace view unit-test expectations with the current header labels, elision behavior, and delegate sizing contract.

Tests:
- Correct four workspace view unit tests so they validate the production behavior and pass reliably.