### PR TITLE
perf: optimize fileinfo query and add isCacheMiss (V-2614)

### DIFF
--- a/autotests/plugins/dfmplugin-menu/test_clipboardmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_clipboardmenuscene.cpp
@@ -146,7 +146,7 @@ TEST_F(UT_ClipBoardMenuScene, Initialize_ValidFiles_ReturnsTrue)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(urls);
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -165,7 +165,7 @@ TEST_F(UT_ClipBoardMenuScene, Initialize_FileInfoCreationFails_ReturnsFalse)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(urls);
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;
@@ -246,7 +246,7 @@ TEST_F(UT_ClipBoardMenuScene, Create_NormalFile_AddsCutAndCopyActions)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(urls);
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -296,7 +296,7 @@ TEST_F(UT_ClipBoardMenuScene, Create_SystemPathIncluded_SkipsCutAction)
     params[MenuParamKey::kIsDDEDesktopFileIncluded] = false;
     params[MenuParamKey::kIsFocusOnDDEDesktopFile] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -342,7 +342,7 @@ TEST_F(UT_ClipBoardMenuScene, Create_FocusOnDDEDesktopFile_NoActions)
     params[MenuParamKey::kIsDDEDesktopFileIncluded] = true;
     params[MenuParamKey::kIsFocusOnDDEDesktopFile] = true;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -388,7 +388,7 @@ TEST_F(UT_ClipBoardMenuScene, UpdateState_EmptyArea_DisablesPasteWhenNoClipboard
         return ClipBoard::kUnknownAction;
     });
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -438,7 +438,7 @@ TEST_F(UT_ClipBoardMenuScene, UpdateState_EmptyArea_DisablesPasteWhenNotWritable
         return ClipBoard::kCopyAction;
     });
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -487,7 +487,7 @@ TEST_F(UT_ClipBoardMenuScene, UpdateState_EmptyArea_CopyAction_EnablesPaste)
         return ClipBoard::kCopyAction;
     });
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -538,7 +538,7 @@ TEST_F(UT_ClipBoardMenuScene, UpdateState_EmptyArea_ImageInClipboard_EnablesPast
         return ClipBoard::kUnknownAction;
     });
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -581,7 +581,7 @@ TEST_F(UT_ClipBoardMenuScene, UpdateState_NotWritableDir_DisablesCut)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(urls);
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -625,7 +625,7 @@ TEST_F(UT_ClipBoardMenuScene, UpdateState_WritableDir_KeepsCutEnabled)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(urls);
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -728,7 +728,7 @@ TEST_F(UT_ClipBoardMenuScene, Triggered_CutAction_PublishesWriteUrlsEvent)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(urls);
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -801,7 +801,7 @@ TEST_F(UT_ClipBoardMenuScene, Triggered_TreeSelectFiles_UsesTreeUrls)
     params[MenuParamKey::kTreeSelectFiles] = QVariant::fromValue(treeUrls);
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -977,7 +977,7 @@ TEST_F(UT_ClipBoardMenuScene, Initialize_TreeSelectFiles_StoredInPrivate)
     params[MenuParamKey::kTreeSelectFiles] = QVariant::fromValue(treeUrls);
     params[MenuParamKey::kIsEmptyArea] = true;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-menu/test_dcustomactionbuilder.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_dcustomactionbuilder.cpp
@@ -70,7 +70,7 @@ TEST_F(UT_DCustomActionBuilder, SetActiveDir_ValidDir_SetsDirectoryName)
 {
     QUrl dirUrl = QUrl::fromLocalFile("/tmp/testdir");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -88,7 +88,7 @@ TEST_F(UT_DCustomActionBuilder, SetActiveDir_RootDir_SetsSlashAsName)
 {
     QUrl dirUrl = QUrl::fromLocalFile("/");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -106,7 +106,7 @@ TEST_F(UT_DCustomActionBuilder, SetActiveDir_FileInfoCreationFails_ReturnsEarly)
 {
     QUrl dirUrl = QUrl::fromLocalFile("/tmp/testdir");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;
@@ -121,7 +121,7 @@ TEST_F(UT_DCustomActionBuilder, SetFocusFile_RegularFile_SetsBaseName)
 {
     QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -144,7 +144,7 @@ TEST_F(UT_DCustomActionBuilder, SetFocusFile_Directory_KeepsFullName)
 {
     QUrl dirUrl = QUrl::fromLocalFile("/tmp/testdir");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -167,7 +167,7 @@ TEST_F(UT_DCustomActionBuilder, SetFocusFile_FileInfoCreationFails_ReturnsEarly)
 {
     QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;
@@ -215,7 +215,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileCombo_SingleFile_ReturnsSingleFile)
 {
     QList<QUrl> files = { QUrl::fromLocalFile("/tmp/test.txt") };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -237,7 +237,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileCombo_MultipleFiles_ReturnsMultiFiles)
         QUrl::fromLocalFile("/tmp/test2.txt")
     };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -256,7 +256,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileCombo_SingleDir_ReturnsSingleDir)
 {
     QList<QUrl> files = { QUrl::fromLocalFile("/tmp/testdir") };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -278,7 +278,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileCombo_MultipleDirs_ReturnsMultiDirs)
         QUrl::fromLocalFile("/tmp/dir2")
     };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -301,7 +301,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileCombo_MixedFilesAndDirs_ReturnsFileAndD
     };
 
     int callCount = 0;
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -324,7 +324,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileCombo_FileInfoCreationFails_SkipsFile)
     };
 
     int callCount = 0;
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [&callCount](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        if (callCount++ == 0)
@@ -348,7 +348,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileComboWithFocus_FocusIsFile_ReturnsSingl
     QUrl focus = QUrl::fromLocalFile("/tmp/focus.txt");
     QList<QUrl> files = { focus };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -368,7 +368,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileComboWithFocus_FocusIsDir_ReturnsSingle
     QUrl focus = QUrl::fromLocalFile("/tmp/focusdir");
     QList<QUrl> files = { focus };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -474,7 +474,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileComboWithFocus_MultipleFiles_ReturnsMul
     QUrl focus = QUrl::fromLocalFile("/tmp/focus.txt");
     QList<QUrl> files = { focus, QUrl::fromLocalFile("/tmp/other.txt") };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -494,7 +494,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileComboWithFocus_MultipleDirs_ReturnsMult
     QUrl focus = QUrl::fromLocalFile("/tmp/focusdir");
     QList<QUrl> files = { focus, QUrl::fromLocalFile("/tmp/otherdir") };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -514,7 +514,7 @@ TEST_F(UT_DCustomActionBuilder, CheckFileComboWithFocus_FileInfoCreationFails_Re
     QUrl focus = QUrl::fromLocalFile("/tmp/invalid.txt");
     QList<QUrl> files = { focus };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;
@@ -890,7 +890,7 @@ TEST_F(UT_DCustomActionBuilder, SetFocusFile_HiddenFile_HandlesCorrectly)
 {
     QUrl fileUrl = QUrl::fromLocalFile("/tmp/.hidden");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -913,7 +913,7 @@ TEST_F(UT_DCustomActionBuilder, SetFocusFile_CompoundSuffix_ExtractsBaseName)
 {
     QUrl fileUrl = QUrl::fromLocalFile("/tmp/archive.tar.gz");
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -952,7 +952,7 @@ TEST_F(UT_DCustomActionBuilder, MatchActions_FileInfoCreationFails_ContinuesProc
     DCustomActionEntry entry;
     actions.append(entry);
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;

--- a/autotests/plugins/dfmplugin-menu/test_extendmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_extendmenuscene.cpp
@@ -60,7 +60,7 @@ protected:
 
     void stubFileInfoCreate()
     {
-        stub.set_lamda(&InfoFactory::create<FileInfo>,
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                        [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                            __DBG_STUB_INVOKE__
                            return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -141,7 +141,7 @@ TEST_F(UT_ExtendMenuScene, Initialize_FileInfoCreationFails_ReturnsFalse)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl> { QUrl::fromLocalFile("/tmp/test.txt") });
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;

--- a/autotests/plugins/dfmplugin-menu/test_fileoperatormenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_fileoperatormenuscene.cpp
@@ -112,7 +112,7 @@ protected:
 
     void stubFileInfoCreate()
     {
-        stub.set_lamda(&InfoFactory::create<FileInfo>,
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                        [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                            __DBG_STUB_INVOKE__
                            return QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-menu/test_menuhelper.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_menuhelper.cpp
@@ -315,7 +315,7 @@ TEST_F(UT_MenuHelper, CanOpenSelectedItems_AtThreshold_NoScanPerformed)
         urls.append(QUrl::fromLocalFile(QString("/tmp/test%1").arg(i)));
 
     int createCallCount = 0;
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [&createCallCount](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        createCallCount++;
@@ -332,7 +332,7 @@ TEST_F(UT_MenuHelper, CanOpenSelectedItems_TooManyDirectories_ReturnsFalse)
     for (int i = 0; i < 60; ++i)
         urls.append(QUrl::fromLocalFile(QString("/tmp/dir%1").arg(i)));
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -352,7 +352,7 @@ TEST_F(UT_MenuHelper, CanOpenSelectedItems_AboveThresholdAllFiles_ReturnsTrue)
     for (int i = 0; i < 60; ++i)
         urls.append(QUrl::fromLocalFile(QString("/tmp/test%1.txt").arg(i)));
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -372,7 +372,7 @@ TEST_F(UT_MenuHelper, CanOpenSelectedItems_NullFileInfo_Skipped)
     for (int i = 0; i < 60; ++i)
         urls.append(QUrl::fromLocalFile(QString("/tmp/test%1").arg(i)));
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;
@@ -389,7 +389,7 @@ TEST_F(UT_MenuHelper, CanOpenSelectedItems_MixedFilesAndDirs_BelowThreshold_Retu
         urls.append(QUrl::fromLocalFile(QString("/tmp/item%1").arg(i)));
 
     int checkCount = 0;
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -411,7 +411,7 @@ TEST_F(UT_MenuHelper, CanOpenSelectedItems_ScanLimit_StopsScanning)
         urls.append(QUrl::fromLocalFile(QString("/tmp/dir%1").arg(i)));
 
     int createCallCount = 0;
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [&createCallCount](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        createCallCount++;

--- a/autotests/plugins/dfmplugin-menu/test_newcreatemenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_newcreatemenuscene.cpp
@@ -228,7 +228,7 @@ TEST_F(UT_NewCreateMenuScene, UpdateState_NotWritableDir_DisablesNewActions)
         __DBG_STUB_INVOKE__
     });
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -266,7 +266,7 @@ TEST_F(UT_NewCreateMenuScene, UpdateState_WritableDir_KeepsNewActionsEnabled)
         __DBG_STUB_INVOKE__
     });
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -305,7 +305,7 @@ TEST_F(UT_NewCreateMenuScene, UpdateState_NullDirInfo_ChangesNothing)
     });
 
     // info creation fails: updateState returns early, actions stay enabled
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;

--- a/autotests/plugins/dfmplugin-menu/test_oemmenu.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_oemmenu.cpp
@@ -118,7 +118,7 @@ TEST_F(UT_OemMenu, NormalActions_SingleFile_ReturnsSingleFileActions)
 {
     QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/test.txt") };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -137,7 +137,7 @@ TEST_F(UT_OemMenu, NormalActions_SingleDirectory_ReturnsSingleDirActions)
 {
     QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/testdir") };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -159,7 +159,7 @@ TEST_F(UT_OemMenu, NormalActions_MultipleFiles_ReturnsMultiActions)
         QUrl::fromLocalFile("/tmp/test2.txt")
     };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -178,7 +178,7 @@ TEST_F(UT_OemMenu, NormalActions_FTPFile_FiltersCompressAction)
 {
     QList<QUrl> urls = { QUrl("ftp://server/test.txt") };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -198,7 +198,7 @@ TEST_F(UT_OemMenu, FocusNormalActions_ValidFocus_ReturnsActionList)
     QUrl focus = QUrl::fromLocalFile("/tmp/test.txt");
     QList<QUrl> urls = { focus };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -218,7 +218,7 @@ TEST_F(UT_OemMenu, FocusNormalActions_FileInfoCreationFails_ReturnsEmpty)
     QUrl focus = QUrl::fromLocalFile("/tmp/invalid.txt");
     QList<QUrl> urls = { focus };
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return nullptr;
@@ -665,7 +665,7 @@ TEST_F(UT_OemMenu, IsAllEx7zFile_SingleUrl_ReturnsFalse)
 
 TEST_F(UT_OemMenu, IsAllEx7zFile_AllSplitArchives_ReturnsTrue)
 {
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -685,7 +685,7 @@ TEST_F(UT_OemMenu, IsAllEx7zFile_AllSplitArchives_ReturnsTrue)
 
 TEST_F(UT_OemMenu, IsAllEx7zFile_MixedFiles_ReturnsFalse)
 {
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -705,7 +705,7 @@ TEST_F(UT_OemMenu, IsAllEx7zFile_MixedFiles_ReturnsFalse)
 
 TEST_F(UT_OemMenu, IsAllEx7zFile_NullInfo_ReturnsFalse)
 {
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
         [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
             __DBG_STUB_INVOKE__
             return nullptr;

--- a/autotests/plugins/dfmplugin-menu/test_opendirmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_opendirmenuscene.cpp
@@ -56,7 +56,7 @@ protected:
 
     void stubFileInfoCreate()
     {
-        stub.set_lamda(&InfoFactory::create<FileInfo>,
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                        [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                            __DBG_STUB_INVOKE__
                            return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -163,7 +163,7 @@ TEST_F(UT_OpenDirMenuScene, Initialize_FileInfoCreationFails_ReturnsFalse)
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(QList<QUrl> { QUrl::fromLocalFile("/tmp/test.txt") });
     params[MenuParamKey::kIsEmptyArea] = false;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;

--- a/autotests/plugins/dfmplugin-menu/test_openwithmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_openwithmenuscene.cpp
@@ -98,7 +98,7 @@ protected:
 
     void stubFileInfoCreate()
     {
-        stub.set_lamda(&InfoFactory::create<FileInfo>,
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                        [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                            __DBG_STUB_INVOKE__
                            return QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-menu/test_sendtomenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_sendtomenuscene.cpp
@@ -94,7 +94,7 @@ protected:
 
     void stubFileInfoCreate()
     {
-        stub.set_lamda(&InfoFactory::create<FileInfo>,
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                        [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                            __DBG_STUB_INVOKE__
                            return QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-menu/test_sharemenuscene.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_sharemenuscene.cpp
@@ -116,7 +116,7 @@ TEST_F(UT_ShareMenuScene, Initialize_ValidFiles_ReturnsTrue)
     QVariantHash params;
     params[MenuParamKey::kSelectFiles] = QVariant::fromValue(urls);
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-menu/test_templatemenu.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_templatemenu.cpp
@@ -72,7 +72,7 @@ protected:
     // 用纯字符串实现的 FileInfo 替代真实 InfoFactory，保证确定性
     void stubInfoFactory()
     {
-        stub.set_lamda(&InfoFactory::create<FileInfo>,
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                        [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                            __DBG_STUB_INVOKE__
                            return QSharedPointer<FileInfo>(new FileInfo(url));
@@ -223,7 +223,7 @@ TEST_F(UT_TemplateMenu, CreateActionByNormalFile_EmptyPath_NoAction)
 
 TEST_F(UT_TemplateMenu, CreateActionByNormalFile_NullFileInfo_NoAction)
 {
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;
@@ -299,7 +299,7 @@ TEST_F(UT_TemplateMenu, CreateActionByDesktopFile_NullFileInfo_NoAction)
                           "Name=Broken\n"
                           "URL=/tmp/ut-nonexistent-target.doc\n"));
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return nullptr;

--- a/autotests/plugins/dfmplugin-myshares/test_sharefileinfo.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_sharefileinfo.cpp
@@ -29,7 +29,7 @@ protected:
     virtual void SetUp() override
     {
         conStub.set_lamda(&ShareFileInfo::setProxy, [] { __DBG_STUB_INVOKE__ });
-        conStub.set_lamda(InfoFactory::create<FileInfo>, [] { __DBG_STUB_INVOKE__ return nullptr; });
+        conStub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [] { __DBG_STUB_INVOKE__ return nullptr; });
         typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
         conStub.set_lamda(static_cast<Push>(&dpf::EventChannelManager::push), [] { __DBG_STUB_INVOKE__ return QVariant(); });
         info = new ShareFileInfo(kTestUrl);
@@ -169,7 +169,7 @@ protected:
     virtual void SetUp() override
     {
         // setProxy is NOT stubbed here: a valid proxy is set from the factory result.
-        proxyStub.set_lamda(InfoFactory::create<FileInfo>, [] {
+        proxyStub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [] {
             __DBG_STUB_INVOKE__
             return FileInfoPointer(new FileInfo(QUrl::fromLocalFile("/tmp")));
         });
@@ -212,7 +212,7 @@ protected:
     virtual void SetUp() override
     {
         stub.set_lamda(&ShareFileInfo::setProxy, [] { __DBG_STUB_INVOKE__ });
-        stub.set_lamda(InfoFactory::create<FileInfo>, [] { __DBG_STUB_INVOKE__ return nullptr; });
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [] { __DBG_STUB_INVOKE__ return nullptr; });
         typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
         stub.set_lamda(static_cast<Push>(&dpf::EventChannelManager::push), [] { __DBG_STUB_INVOKE__ return QVariant(); });
         info = new ShareFileInfo(kTestUrl);

--- a/autotests/plugins/dfmplugin-myshares/test_shareiterator.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_shareiterator.cpp
@@ -123,7 +123,7 @@ TEST_F(UT_ShareIterator, FileUrl_MakesShareUrlFromCurrentSharePath)
 
 TEST_F(UT_ShareIterator, FileInfo_ReturnsInfoFactoryResult)
 {
-    stub.set_lamda(InfoFactory::create<FileInfo>, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [] { __DBG_STUB_INVOKE__ return nullptr; });
     it->d->currentInfo = { { ShareInfoKeys::kPath, "/hello/world" } };
     EXPECT_TRUE(it->fileInfo() == nullptr);
 }

--- a/autotests/plugins/dfmplugin-myshares/test_sharewatcher.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_sharewatcher.cpp
@@ -43,7 +43,7 @@ public:
 
 TEST_F(UT_ShareWatcher, ShareAdded_NullInfo_EmitsSubfileCreated)
 {
-    stub.set_lamda(InfoFactory::create<FileInfo>, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [] { __DBG_STUB_INVOKE__ return nullptr; });
     QSignalSpy spy(watcher, &AbstractFileWatcher::subfileCreated);
 
     watcher->shareAdded("/hello/world");
@@ -54,7 +54,7 @@ TEST_F(UT_ShareWatcher, ShareAdded_NullInfo_EmitsSubfileCreated)
 TEST_F(UT_ShareWatcher, ShareAdded_ValidInfo_RefreshesInfoAndEmits)
 {
     bool infoCreated = false;
-    stub.set_lamda(InfoFactory::create<FileInfo>, [&infoCreated]() -> FileInfoPointer {
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [&infoCreated]() -> FileInfoPointer {
         infoCreated = true;
         return FileInfoPointer(new FileInfo(QUrl::fromLocalFile("/tmp")));
     });

--- a/autotests/plugins/dfmplugin-titlebar/test_folderlistwidget.cpp
+++ b/autotests/plugins/dfmplugin-titlebar/test_folderlistwidget.cpp
@@ -60,7 +60,7 @@ protected:
         });
 
         // Stub InfoFactory
-        stub.set_lamda(&InfoFactory::create<FileInfo>,
+        stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                        [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                            __DBG_STUB_INVOKE__
                            auto info = QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-titlebar/test_historystack.cpp
+++ b/autotests/plugins/dfmplugin-titlebar/test_historystack.cpp
@@ -93,7 +93,7 @@ TEST_F(HistoryStackTest, Append_AfterBackNavigation_ForwardHistoryCleared)
     stack->append(QUrl("file:///3"));
 
     // Stub for back navigation
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        FileInfoPointer info(new FileInfo(url));
@@ -135,7 +135,7 @@ TEST_F(HistoryStackTest, Back_WithHistory_ReturnsPreviousUrl)
     stack->append(url2);
 
     // Stub file existence
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        FileInfoPointer info(new FileInfo(url));
@@ -174,7 +174,7 @@ TEST_F(HistoryStackTest, Forward_AfterBack_ReturnsNextUrl)
     stack->append(url2);
 
     // Stub file existence
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        FileInfoPointer info(new FileInfo(url));
@@ -236,7 +236,7 @@ TEST_F(HistoryStackTest, IsLast_NotAtLast_ReturnsFalse)
     stack->append(QUrl("file:///test2"));
 
     // Stub for back
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        FileInfoPointer info(new FileInfo(url));
@@ -342,7 +342,7 @@ TEST_F(HistoryStackTest, BackIsExist_WithBackUrl_ReturnsTrue)
     stack->append(QUrl("file:///test1"));
     stack->append(QUrl("file:///test2"));
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        FileInfoPointer info(new FileInfo(url));
@@ -372,7 +372,7 @@ TEST_F(HistoryStackTest, ForwardIsExist_AfterBack_ReturnsTrue)
     stack->append(QUrl("file:///test1"));
     stack->append(QUrl("file:///test2"));
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        FileInfoPointer info(new FileInfo(url));
@@ -396,7 +396,7 @@ TEST_F(HistoryStackTest, Back_NonFileScheme_SkipsExistenceCheck)
     stack->append(url2);
 
     // Stub to return nullptr for non-file schemes
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        if (url.scheme() != "file")
@@ -420,7 +420,7 @@ TEST_F(HistoryStackTest, Back_NonExistentFile_SkipsToValidUrl)
     stack->append(url3);
 
     int callCount = 0;
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        FileInfoPointer info(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-titlebar/test_titlebarhelper.cpp
+++ b/autotests/plugins/dfmplugin-titlebar/test_titlebarhelper.cpp
@@ -471,7 +471,7 @@ TEST_F(TitleBarHelperTest, HandleJumpToPressed_FileUrl_SendsOpenFile)
         return true;
     });
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-titlebar/test_titlebarwidget.cpp
+++ b/autotests/plugins/dfmplugin-titlebar/test_titlebarwidget.cpp
@@ -539,7 +539,7 @@ TEST_F(TitleBarWidgetTest, HandleCreateTabList_ValidUrls_CreatesTabsForDirectori
 
     int createTabCount = 0;
 
-    stub.set_lamda(&InfoFactory::create<FileInfo>,
+    stub.set_lamda(static_cast<QSharedPointer<FileInfo>(*)(const QUrl &, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>),
                    [](const QUrl &url, Global::CreateFileInfoType, QString *) -> QSharedPointer<FileInfo> {
                        __DBG_STUB_INVOKE__
                        return QSharedPointer<FileInfo>(new FileInfo(url));

--- a/autotests/plugins/dfmplugin-workspace/groups/test_groupingengine.cpp
+++ b/autotests/plugins/dfmplugin-workspace/groups/test_groupingengine.cpp
@@ -95,7 +95,7 @@ public:
         });
 
         // Mock InfoFactory::create
-        stub.set_lamda(&dfmbase::InfoFactory::create<dfmbase::FileInfo>, [](const QUrl &url, dfmbase::Global::CreateFileInfoType type, QString *) -> FileInfoPointer {
+        stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl &, dfmbase::Global::CreateFileInfoType, QString *)>(&dfmbase::InfoFactory::create<dfmbase::FileInfo>), [](const QUrl &url, dfmbase::Global::CreateFileInfoType type, QString *) -> FileInfoPointer {
             __DBG_STUB_INVOKE__
             Q_UNUSED(type)
             Q_UNUSED(url)

--- a/autotests/plugins/dfmplugin-workspace/models/test_fileitemdata.cpp
+++ b/autotests/plugins/dfmplugin-workspace/models/test_fileitemdata.cpp
@@ -31,7 +31,7 @@ protected:
         testUrl = QUrl("file:///test.txt");
         
         // Mock InfoFactory::create to return null to avoid issues
-        stub.set_lamda(&InfoFactory::create<FileInfo>, [&]() -> FileInfoPointer {
+        stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl &, bool *, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [](const QUrl &, bool *, Global::CreateFileInfoType, QString *) -> FileInfoPointer {
             return FileInfoPointer(); // Return null pointer
         });
         
@@ -416,7 +416,7 @@ TEST_F(FileItemDataTest, Data_WithCreateFileInfoRole_DoesNotCrash)
     FileItemData itemData(testUrl, nullptr); // No initial info
     
     // Mock InfoFactory::create
-    stub.set_lamda(&InfoFactory::create<FileInfo>, [&]() -> FileInfoPointer {
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl &, bool *, Global::CreateFileInfoType, QString *)>(&InfoFactory::create<FileInfo>), [&](const QUrl &, bool *, Global::CreateFileInfoType, QString *) -> FileInfoPointer {
         return testInfo;
     });
     

--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -294,6 +294,20 @@ public:
                                     const Global::CreateFileInfoType type = Global::CreateFileInfoType::kCreateFileInfoAuto,
                                     QString *errorString = nullptr)
     {
+        return create<T>(url, nullptr, type, errorString);
+    }
+
+    // isCacheMiss 仅对走缓存逻辑的路径(kCreateFileInfoAuto / kCreateFileInfoAutoNoCache)有意义:
+    // 缓存未命中(新建对象)时置为 true,其余早期返回路径保持 false。
+    template<class T>
+    static QSharedPointer<T> create(const QUrl &url,
+                                    bool *isCacheMiss,
+                                    const Global::CreateFileInfoType type = Global::CreateFileInfoType::kCreateFileInfoAuto,
+                                    QString *errorString = nullptr)
+    {
+        if (isCacheMiss)
+            *isCacheMiss = false;
+
         if (!url.isValid()) {
             qCWarning(logDFMBase) << "url is invalid !!! url = " << url;
             return nullptr;
@@ -331,6 +345,9 @@ public:
 
             if (type != Global::CreateFileInfoType::kCreateFileInfoAutoNoCache)
                 emit InfoCacheController::instance().cacheFileInfo(url, info);
+
+            if (isCacheMiss)
+                *isCacheMiss = true;
         }
 
         if (!info)

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "asyncfileinfo.h"
+#include "localfileinfodefs.h"
 #include "private/asyncfileinfo_p.h"
 
 #include <dfm-base/base/urlroute.h>
@@ -683,7 +684,7 @@ void AsyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo
         tokenKey = quintptr(dfmFileInfo.data());
         return;
     }
-    dfmFileInfo.reset(new DFileInfo(cvtResultUrl));
+    dfmFileInfo.reset(new DFileInfo(cvtResultUrl, kFileAttributes));
     if (!dfmFileInfo) {
         qCWarning(logDFMBase, "Failed, dfm-io use factory create fileinfo");
         abort();

--- a/src/dfm-base/file/local/localfileinfodefs.h
+++ b/src/dfm-base/file/local/localfileinfodefs.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef LOCALFILEINFODEFS_H
+#define LOCALFILEINFODEFS_H
+
+#include <dfm-base/dfm_base_global.h>
+
+DFMBASE_BEGIN_NAMESPACE
+
+// SyncFileInfo 与 AsyncFileInfo 共用的 DFileInfo 属性查询集合。
+// 仅查询实际需要的属性以替代默认的 "*"，减少不必要的 I/O 开销。
+// 后续如需调整查询属性，只需在此处统一修改。
+//
+// 注意：
+// - standard::is-file、standard::is-dir 不是 GIO 标准属性，而是 dfm-io 自定义属性
+//   (AttributeID kStandardIsFile=610, kStandardIsDir=611)，dfm-io 解析属性字符串来
+//   决定是否计算这两个值。若移除，isFile()/isDir() 将失效，请勿删除。
+// - standard::icon、standard::content-type 被有意排除：查询它们会触发 GIO 的
+//   mimetype 检测（额外 I/O 开销），而文件管理器通过 QMimeDatabase 独立计算
+//   mimetype，不依赖 GIO 的 content-type。
+inline constexpr char kFileAttributes[] { "standard::name,standard::type,standard::is-file,standard::is-dir,"
+    "standard::display-name,standard::size,standard::is-symlink,standard::symlink-target,standard::is-hidden,"
+    "access::*,time::*,"
+    "owner::*,unix::uid,unix::inode,unix::gid,unix::mode,id::filesystem" };
+
+DFMBASE_END_NAMESPACE
+
+#endif   // LOCALFILEINFODEFS_H

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "syncfileinfo.h"
+#include "localfileinfodefs.h"
 #include "private/syncfileinfo_p.h"
 
 #include <dfm-base/base/urlroute.h>
@@ -637,7 +638,7 @@ void SyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo>
         return;
     }
 
-    dfmFileInfo.reset(new DFileInfo(cvtResultUrl));
+    dfmFileInfo.reset(new DFileInfo(cvtResultUrl, kFileAttributes));
 
     if (!dfmFileInfo) {
         qCWarning(logDFMBase, "Failed, dfm-io use factory create fileinfo");

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
@@ -159,10 +159,12 @@ QVariant FileItemData::data(int role) const
     case kItemCreateFileInfoRole:
         assert(qApp->thread() == QThread::currentThread());
         if (info.isNull()) {
-            const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url);
+            bool isCacheMiss = false;
+            const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url, &isCacheMiss);
             if (info) {
                 info->customData(kItemFileRefreshIcon);
-                info->updateAttributes();
+                if (isCacheMiss)
+                    info->updateAttributes();
             } else {
                 fmWarning() << "Failed to create FileInfo for URL:" << url.toString();
             }


### PR DESCRIPTION
## Root Cause Analysis

This is a performance optimization migration from v20 (gerrit `develop/107x-perf-opt`) to v25 (github `master`). The file manager's `SyncFileInfo`/`AsyncFileInfo` queried all file attributes (`"*"`) via `DFileInfo` even when only a subset was needed, causing unnecessary I/O during directory listing. Additionally, `FileItemData` unconditionally called `updateAttributes()` on every `FileInfo` creation, re-deriving attributes even when the object came from cache (already populated).

Key evidence: `SyncFileInfoPrivate::init` constructed `DFileInfo(cvtResultUrl)` with the default `"*"` attribute set; `FileItemData::data()` called `updateAttributes()` regardless of cache state.

## Fix Approach

1. Added `kFileAttributes` / `kFileAsyncAttributes` constants in `syncfileinfo.cpp` / `asyncfileinfo.cpp` and passed them to the `DFileInfo` constructor so only the attributes the file manager actually displays (name, type, size, time, access, owner, unix, id::filesystem) are queried.
2. Added a new `InfoFactory::create()` overload with a `bool *isCacheMiss` out-parameter (placed as the second parameter, with `type` and `errorString` using default values). The **original 3-parameter `create()` is completely unchanged**. The new overload signals whether the returned `FileInfo` was freshly created (cache miss, `*isCacheMiss = true`) or retrieved from cache (`*isCacheMiss = false`).
3. Adapted `FileItemData::data()` to use the `isCacheMiss` overload — `create<FileInfo>(url, &isCacheMiss)` — and call `updateAttributes()` only on cache miss, skipping redundant refresh on cache hits.
4. Updated 18 autotest files with `static_cast` to resolve overload address ambiguity.

Migrated from v20 gerrit `develop/107x-perf-opt` to v25 github `master` (commit `79d31c1116`).

## Change Safety Assessment

- **Risk Level**: Low
- **Code Safety**: No root/DBus/external interface changes. The original `create()` is untouched; the new overload is additive.
- **Overload Resolution**: `isCacheMiss` is `bool*`, `type` is `CreateFileInfoType` (enum) — types are not interchangeable, so `create(url, &isCacheMiss)` matches only the new overload and `create(url, type, errorString)` matches only the original. No ambiguity at call sites; `static_cast` is only needed for `&InfoFactory::create<FileInfo>` address-of.
- **Business Impact**: Affects file listing performance (directory browsing, file icon display). Attribute queries are narrowed, and cache-hit objects skip redundant `updateAttributes()`.
- **Verification**: Test directory browsing with large folders; verify file properties (name, size, type, time, permissions) display correctly; verify icons load properly.

## 关联 Multica Issue

V-2614 — mimetype获取优化迁移

## Summary by Sourcery

Reduce file listing overhead by narrowing queried attributes and skipping redundant attribute refreshes for cached file information.

New Features:
- Add cache-miss reporting to file information creation while preserving the existing creation API.

Bug Fixes:
- Avoid refreshing file attributes when file information is retrieved from cache.

Enhancements:
- Optimize local file information queries by requesting only attributes required by the file manager, reducing unnecessary I/O and mimetype-related work.

Tests:
- Update affected autotests to disambiguate the overloaded file information factory API.