### PR TITLE
test: stub singleShotImpl in deferred-init UT for CI stability

### DIFF
--- a/autotests/plugins/dfmplugin-menu/test_extensionmonitor.cpp
+++ b/autotests/plugins/dfmplugin-menu/test_extensionmonitor.cpp
@@ -284,7 +284,6 @@ TEST_F(UT_ExtensionMonitor, ProcessExtensionDirectory_MissingTarget_CreatesTarge
     EXPECT_TRUE(QDir(targetPath).exists());
 }
 
-// 不打桩 QTimer：真实等待 5 秒超时，执行 start() 中注册的延迟初始化 lambda。
 TEST_F(UT_ExtensionMonitor, Start_DeferredInitLambda_RunsAfterTimeout)
 {
     auto *monitor = ExtensionMonitor::instance();
@@ -300,12 +299,20 @@ TEST_F(UT_ExtensionMonitor, Start_DeferredInitLambda_RunsAfterTimeout)
         setupCalled = true;
     });
 
-    monitor->start();
+    // Stub singleShotImpl to execute the deferred-init slot synchronously
+    // instead of waiting for a real 5-second timer (flaky under CI load).
+    typedef void (*FuncType)(std::chrono::nanoseconds, Qt::TimerType, const QObject *, QtPrivate::QSlotObjectBase *);
+    stub.set_lamda(static_cast<FuncType>(&QTimer::singleShotImpl),
+        [](std::chrono::nanoseconds, Qt::TimerType, const QObject *receiver, QtPrivate::QSlotObjectBase *slotObj) {
+            __DBG_STUB_INVOKE__
+            if (slotObj) {
+                void *args[1] = { nullptr };
+                slotObj->call(const_cast<QObject *>(receiver), args);
+                slotObj->destroyIfLastRef();
+            }
+        });
 
-    QElapsedTimer elapsed;
-    elapsed.start();
-    while (elapsed.elapsed() < 5200)
-        QApplication::processEvents(QEventLoop::AllEvents, 100);
+    EXPECT_NO_FATAL_FAILURE(monitor->start());
 
     EXPECT_TRUE(copyCalled);
     EXPECT_TRUE(setupCalled);


### PR DESCRIPTION
## Root Cause Analysis

The test `UT_ExtensionMonitor.Start_DeferredInitLambda_RunsAfterTimeout` relied on a real 5-second `QTimer::singleShot` firing within a 5200ms event-loop poll window. Under CI load the timer does not fire reliably, so the deferred initialization lambda never executes and the stubbed `copyInitialFiles` / `setupFileWatchers` callbacks are never called, causing assertion failures (`copyCalled` and `setupCalled` both `false`).

Production code `ExtensionMonitor::start()` (`extensionmonitor.cpp:34-40`) is correct — it intentionally schedules deferred init via `QTimer::singleShot(5000, ...)`. The problem is the test's timing fragility, not a production defect.

## Fix

Replace the real 5200ms event-loop wait with a `QTimer::singleShotImpl` stub (nanoseconds overload, matching the actual call site) that synchronously invokes the deferred slot. This mirrors the pattern already used by the passing test `Start_SchedulesDeferredInitialization` in the same file. Only test code is changed; no production code is touched.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Only test file `test_extensionmonitor.cpp` is modified; no production code changed
- No external callers affected; stub pattern consistent with existing passing test

### Business Impact Scope

No user-facing functionality affected. The change is purely in unit test code — `ExtensionMonitor::start()` behavior is unchanged.

### Verification Suggestion

Run the `UT_ExtensionMonitor` suite to confirm `Start_DeferredInitLambda_RunsAfterTimeout` passes stably and no regression in other tests.

---

## 根因分析

测试用例 `UT_ExtensionMonitor.Start_DeferredInitLambda_RunsAfterTimeout` 依赖真实 5 秒 `QTimer::singleShot` 在 5200ms 事件循环窗口内触发。CI 高负载下定时器不可靠触发，导致延迟初始化 lambda 未执行，桩函数 `copyInitialFiles` / `setupFileWatchers` 未被调用，断言失败（`copyCalled` 和 `setupCalled` 均为 `false`）。

生产代码 `ExtensionMonitor::start()`（`extensionmonitor.cpp:34-40`）行为正确，通过 `QTimer::singleShot(5000, ...)` 注册延迟初始化为正常设计。问题在于测试时序的脆弱性，非生产代码缺陷。

## 修复方案

将真实 5200ms 事件循环等待替换为 `QTimer::singleShotImpl` 桩（nanoseconds 重载，与实际调用一致），使延迟槽函数同步执行。沿用同文件已有通过测试 `Start_SchedulesDeferredInitialization` 的桩模式。仅修改测试代码，不改动生产代码。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 仅修改测试文件 `test_extensionmonitor.cpp`，不涉及生产代码
- 无外部调用者受影响，桩模式与已有通过测试一致

### 业务影响范围

无面向用户的功能受影响。改动仅限于单元测试代码，`ExtensionMonitor::start()` 行为不变。

### 验证建议

运行 `UT_ExtensionMonitor` 套件，确认 `Start_DeferredInitLambda_RunsAfterTimeout` 稳定通过且其他测试无回归。

## Summary by Sourcery

Replace the deferred-initialization test’s real timer wait with a synchronous timer stub to improve CI reliability without changing production behavior.

Enhancements:
- Make deferred-initialization unit testing deterministic by invoking the scheduled callback synchronously instead of relying on a real timer and event-loop delay.

Tests:
- Stabilize `Start_DeferredInitLambda_RunsAfterTimeout` by stubbing the timer implementation, eliminating CI timing flakiness.