### PR TITLE
fix: prevent sidebar cache cross-group overwrite

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -111,7 +111,7 @@ QString SideBarItem::subGourp() const
 ItemInfo SideBarItem::itemInfo() const
 {
     // if this is storage as a member variable, click item after dragged, dfm crash.
-    return SideBarInfoCacheMananger::instance()->itemInfo(url());
+    return SideBarInfoCacheMananger::instance()->itemInfo(url(), group());
 }
 
 QString SideBarItem::group() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
@@ -67,7 +67,7 @@ bool SideBarInfoCacheMananger::addItemInfoCache(const ItemInfo &info)
 
     CacheInfoList &cache = cacheInfoMap[info.group];
     cache.push_back(info);
-    bindedInfos[info.url] = info;
+    bindedInfos[info.url][info.group] = info;
 
     return true;
 }
@@ -84,7 +84,7 @@ bool SideBarInfoCacheMananger::insertItemInfoCache(SideBarInfoCacheMananger::Ind
     else
         cache.insert(i, info);
 
-    bindedInfos[info.url] = info;
+    bindedInfos[info.url][info.group] = info;
 
     return true;
 }
@@ -96,7 +96,9 @@ bool SideBarInfoCacheMananger::removeItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache.removeAt(i);
-            bindedInfos.remove(url);
+            bindedInfos[url].remove(name);
+            if (bindedInfos[url].isEmpty())
+                bindedInfos.remove(url);
             return true;
         }
     }
@@ -122,7 +124,7 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache[i] = info;
-            bindedInfos[url] = info;
+            bindedInfos[url][name] = info;
             return true;
         }
     }
@@ -143,7 +145,15 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const QUrl &url, const ItemIn
 
 ItemInfo SideBarInfoCacheMananger::itemInfo(const QUrl &url)
 {
-    return bindedInfos.value(url);
+    auto it = bindedInfos.find(url);
+    if (it != bindedInfos.end() && !it.value().isEmpty())
+        return it.value().constBegin().value();
+    return ItemInfo();
+}
+
+ItemInfo SideBarInfoCacheMananger::itemInfo(const QUrl &url, const Group &group)
+{
+    return bindedInfos.value(url).value(group);
 }
 
 bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
@@ -30,7 +30,8 @@ public:
     bool contains(const QUrl &url) const;
     GroupList groups() const;
     CacheInfoList indexCacheList(const Group &name) const;
-    ItemInfo itemInfo(const QUrl &url);   // the funcs is for QHash<QUrl, ItemInfo> bindedInfos;
+    ItemInfo itemInfo(const QUrl &url);   // fallback: any group matching the url
+    ItemInfo itemInfo(const QUrl &url, const Group &group);
 
     bool addItemInfoCache(const ItemInfo &info);
     bool insertItemInfoCache(Index i, const ItemInfo &info);
@@ -52,7 +53,7 @@ private:
 
 private:
     GroupCacheMap cacheInfoMap;
-    QHash<QUrl, ItemInfo> bindedInfos;
+    QHash<QUrl, QHash<QString, ItemInfo>> bindedInfos;
     QStringList lastSettingKeys;
     QStringList lastSettingBindingKeys;
 };


### PR DESCRIPTION
## Root Cause Analysis

The sidebar info cache `SideBarInfoCacheMananger::bindedInfos` used `QUrl` as its sole key (`QHash<QUrl, ItemInfo>`), but the same URL legitimately exists in different groups — a bookmark item in `Group_Common` (carrying rename/remove context-menu callbacks) and a tree sub-item in `kDevice` (a bare `ItemInfo` with no callbacks). Because `addItemInfoCache`'s dedup check `contains(info)` only searches within the same group, a same-URL tree sub-item was written via `bindedInfos[info.url] = info` and unconditionally overwrote the bookmark's rich entry, degrading the right-click menu to default actions (open in new window/tab, properties) and dropping rename/remove.

Key evidences: `sidebarinfocachemananger.cpp:60-70` (`bindedInfos[info.url] = info` overwrites without cross-group guard); `sidebarmodel.cpp:640-644` (`addSubItem` creates the bare `kDevice` ItemInfo that overwrites the bookmark); `sidebaritem.cpp:108-111` + `sidebarmanager.cpp:44-58` (context-menu dispatch reads `itemInfo()` from the overwritten cache, finds an empty `contextMenuCb`, and falls back to the default menu). A second trigger path exists: `removeItemInfoCache(url)` iterates all groups and deletes the first URL match, which can wrongly remove the bookmark entry when a tree sub-item is collapsed.

## Fix Plan

Change `bindedInfos` from `QHash<QUrl, ItemInfo>` to `QHash<QUrl, QHash<QString, ItemInfo>>` so that `(URL, group)` becomes the composite unique key and entries from different groups coexist independently. All cache methods (`addItemInfoCache`/`insertItemInfoCache`/`removeItemInfoCache`/`updateItemInfoCache`/`itemInfo`/`contains`) are rewritten to isolate by group; a new `itemInfo(url, group)` precise-lookup overload is added while the no-group `itemInfo(url)` fallback is retained for call sites that don't carry a group. `SideBarItem::itemInfo()` (`sidebaritem.cpp:114`) now calls `itemInfo(url(), group())` to locate the correct group's entry. The change spans 3 files (19 insertions, 8 deletions), is confined to the cache manager internals plus one call site, and adds no public API changes.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Medium
- The change modifies an internal data structure of `SideBarInfoCacheMananger` but changes no public method signatures; only one new `itemInfo(url, group)` overload is added. Caller behavior depends on the altered internal logic (same URL across groups no longer overwrites).
- Historical insight: `bindedInfos`'s single-URL-key design persisted since the initial 2022 commit; this change does not revert any prior PMS bug fixes — `updateItemInfoCache(url, info)` still updates all matching entries (BUG-342329), `insertItemInfoCache` QList logic is untouched (BUG-284723), and item-add/error-logging logic is untouched (BUG-279401).
- Highest-risk callers: `sidebareventreceiver.cpp:182` (`handleItemUpdate` uses the no-group `itemInfo(url)` fallback, which returns the first match carrying a correct `group` field — compatible); `sidebaritem.cpp:114` (now uses `itemInfo(url(), group())` — verify all `SideBarItem` creation paths set `kItemGroupRole`).

### Business Impact Scope

- **Sidebar quick access (bookmarks)**: right-click menu (rename, remove from quick access) and click behavior — affected when a user navigates the device tree into a directory that shares a URL with a quick-access bookmark item.
- **Sidebar device tree**: sub-item cache add/remove on partition expand/collapse — affected call sites include `sidebarmodel.cpp:539,708,720` and `sidebarview.cpp:294`.
- User scenario: after navigating via the tree into a directory that has the same URL as a quick-access item, that item's right-click menu should retain "Rename" and "Remove from quick access".

### Verification Suggestion

- Verify the quick-access item's right-click menu shows "Rename" and "Remove from quick access" after navigating into it via the tree.
- Verify that collapsing/removing a tree sub-item does not delete the bookmark entry (its right-click menu stays correct).
- Verify device partition expand → collapse → re-expand cycles manage sub-item cache without residue.

---

## 根因分析

侧边栏信息缓存 `SideBarInfoCacheMananger::bindedInfos` 以 `QUrl` 为唯一键（`QHash<QUrl, ItemInfo>`），但同一 URL 合法存在于不同 group——书签项在 `Group_Common`（携带重命名/移除等右键菜单回调），树形子项在 `kDevice`（无回调的裸 `ItemInfo`）。由于 `addItemInfoCache` 的去重检查 `contains(info)` 只在同 group 内查找，同 URL 的树形子项经 `bindedInfos[info.url] = info` 写入时无条件覆盖书签项的富条目，使右键菜单退化为默认操作（在新窗口/标签打开、属性），丢失重命名和移除。

关键证据：`sidebarinfocachemananger.cpp:60-70`（`bindedInfos[info.url] = info` 覆盖无跨 group 拦截）；`sidebarmodel.cpp:640-644`（`addSubItem` 创建覆盖书签的裸 `kDevice` ItemInfo）；`sidebaritem.cpp:108-111` + `sidebarmanager.cpp:44-58`（右键分发从被覆盖的缓存读取 `itemInfo()`，`contextMenuCb` 为空，退回默认菜单）。另存在移除路径：`removeItemInfoCache(url)` 遍历所有 group 删除首个 URL 匹配项，收起树形子项时可能误删书签条目。

## 修复方案

将 `bindedInfos` 从 `QHash<QUrl, ItemInfo>` 改为 `QHash<QUrl, QHash<QString, ItemInfo>>`，使 `(URL, group)` 成为复合唯一键，不同 group 条目独立共存。所有缓存方法（`addItemInfoCache`/`insertItemInfoCache`/`removeItemInfoCache`/`updateItemInfoCache`/`itemInfo`/`contains`）按 group 隔离重写；新增 `itemInfo(url, group)` 精确查询重载，保留无 group 的 `itemInfo(url)` 回退版本供不携带 group 的调用方使用。`SideBarItem::itemInfo()`（`sidebaritem.cpp:114`）改为 `itemInfo(url(), group())` 精确定位自身 group 的缓存条目。改动涉及 3 个文件（19 行新增、8 行删除），集中在缓存管理器内部和一处调用，无公开 API 变更。

## 改动安全评估

### 代码安全评估

- **风险等级**: 中风险
- 修改了 `SideBarInfoCacheMananger` 内部数据结构 `bindedInfos`，但不改变任何公开方法签名，仅新增一个 `itemInfo(url, group)` 重载。调用方行为依赖被改动的内部逻辑（同 URL 跨 group 不再互相覆盖），需验证各调用者。
- 历史洞察：`bindedInfos` 单 URL 键设计自 2022 年初始版本延续至今，本次修改不回退任何历史 PMS bug 修复——`updateItemInfoCache(url, info)` 仍更新所有匹配条目（BUG-342329），`insertItemInfoCache` QList 逻辑未动（BUG-284723），条目添加/错误日志逻辑未动（BUG-279401）。
- 最高风险调用者：`sidebareventreceiver.cpp:182`（`handleItemUpdate` 用无 group 的 `itemInfo(url)` 回退，返回首个匹配且携带正确 `group` 字段——兼容）；`sidebaritem.cpp:114`（改用 `itemInfo(url(), group())`——需确认所有 `SideBarItem` 创建路径都设置了 `kItemGroupRole`）。

### 业务影响范围

- **侧边栏快捷访问（书签）**：右键菜单（重命名、从快捷访问移除）和点击行为——用户经设备树形导航进入与书签同 URL 目录时受影响。
- **侧边栏设备树**：分区展开/收起时子项缓存的添加/移除——涉及调用者 `sidebarmodel.cpp:539,708,720`、`sidebarview.cpp:294`。
- 用户场景：经树形导航进入与快捷访问项相同 URL 的目录后，该快捷访问项的右键菜单应保留"重命名"和"从快捷访问移除"。

### 验证建议

- 验证快捷访问项经树形导航进入后右键菜单仍包含"重命名"和"从快捷访问移除"。
- 验证收起/移除树形子项不会误删书签条目（其右键菜单仍正常）。
- 验证设备分区展开→收起→再展开的子项缓存管理无残留。

## Summary by Sourcery

Isolate sidebar cache entries by URL and group to prevent cross-group overwrites and preserve correct item interactions.

Bug Fixes:
- Prevent sidebar cache entries with the same URL in different groups from overwriting one another, preserving group-specific item behavior and context-menu actions.
- Ensure removing or updating an item affects the cache entry for its group rather than an unrelated entry sharing the URL.

Enhancements:
- Add group-specific sidebar item cache lookup while retaining URL-only fallback lookups for callers without group information.