### PR TITLE
feat: support close-write events in vfs monitor

### DIFF
--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -267,6 +267,30 @@ TEST_F(TestVfsMonitorFileSystemWatcher, SymlinkCreationEmitsFileCreated)
     EXPECT_EQ(args.at(1).toString(), "symlink_link.txt");
 }
 
+// ========== 文件写入关闭 ==========
+
+TEST_F(TestVfsMonitorFileSystemWatcher, FileClosedSignal)
+{
+    ASSERT_NE(watcher, nullptr);
+
+    QSignalSpy spy(watcher, &VfsMonitorFileSystemWatcher::fileClosed);
+    ASSERT_TRUE(spy.isValid());
+
+    // 创建文件并写入内容后关闭，触发 ACT_CLOSE_WRITE_FILE
+    QString filePath = testDir->path() + "/closewrite.txt";
+    QFile file(filePath);
+    file.open(QIODevice::WriteOnly);
+    file.write("close write test");
+    file.close();
+
+    int count = waitForSignal(spy);
+    ASSERT_GT(count, 0) << "fileClosed signal not received within timeout";
+
+    QList<QVariant> args = spy.takeFirst();
+    EXPECT_EQ(args.at(0).toString(), testDir->path());
+    EXPECT_EQ(args.at(1).toString(), "closewrite.txt");
+}
+
 // ========== 路径排除 ==========
 
 TEST_F(TestVfsMonitorFileSystemWatcher, ExcludePredicateFiltersEvents)

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -106,8 +106,6 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
         return false;
     }
 
-    watcher.reset(new InotifyFileSystemWatcher());
-
     // Use static factory method to create configured blacklist matcher
     // BEFORE creating VfsMonitor watcher (needs it for excludePredicate).
     excludeMatcher = PathExcludeMatcher::createForIndex();
@@ -122,13 +120,13 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
     vfsMonitorAvailable = (vfsWatcher != nullptr);
 
     if (vfsMonitorAvailable) {
-        // deepin-anything dispatcher mode: create/delete/move from vfs, fileClosed from inotify.
-        // Restrict inotify to IN_CLOSE_WRITE only, reducing kernel event delivery.
-        watcher->setWatchFlags(InotifyFileSystemWatcher::WatchFlag::FileClose);
+        // VfsMonitor handles all events including ACT_CLOSE_WRITE_FILE,
+        // so InotifyFileSystemWatcher is not needed.
         setupVfsMonitorConnections();
-        fmInfo() << "FSMonitor: Using dual watcher mode (deepin-anything dispatcher + inotify fallback)";
+        fmInfo() << "FSMonitor: Using vfs monitor mode (deepin-anything dispatcher)";
     } else {
-        // inotify-only mode: all signals from InotifyFileSystemWatcher (existing behavior).
+        // Inotify-only mode: create InotifyFileSystemWatcher for all events.
+        watcher.reset(new InotifyFileSystemWatcher());
         setupWatcherConnections();
         fmInfo() << "FSMonitor: Using inotify-only mode (deepin-anything dispatcher not available)";
     }
@@ -389,7 +387,7 @@ bool FSMonitorPrivate::addWatchForDirectory(const QString &path)
     }
 
     // Add to watcher
-    if (watcher->addPath(path)) {
+    if (watcher && watcher->addPath(path)) {
         watchedDirectories.insert(path);
         //   fmDebug() << "FSMonitor: Added watch for directory:" << path;
         return true;
@@ -406,7 +404,8 @@ void FSMonitorPrivate::removeWatchForDirectory(const QString &path)
     }
 
     if (watchedDirectories.contains(path)) {
-        watcher->removePath(path);
+        if (watcher)
+            watcher->removePath(path);
         watchedDirectories.remove(path);
         fmDebug() << "FSMonitor: Removed watch for directory:" << path;
     }
@@ -450,7 +449,7 @@ void FSMonitorPrivate::setupWatcherConnections()
 
 void FSMonitorPrivate::setupVfsMonitorConnections()
 {
-    // Create/delete/move events from VfsMonitorFileSystemWatcher.
+    // All events come from VfsMonitorFileSystemWatcher (create/delete/move/close-write).
     // The kernel already distinguishes files from directories, so we can
     // emit the specific directory* signals directly without QFileInfo checks.
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileCreated,
@@ -461,7 +460,7 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileDeleted,
                      q_ptr, [this](const QString &path, const QString &name) {
                           handleFileDeleted(path, name);
-                     });
+                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileMoved,
                      q_ptr, [this](const QString &fromPath, const QString &fromName,
@@ -469,24 +468,19 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
                          handleFileMoved(fromPath, fromName, toPath, toName);
                      });
 
+    QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileClosed,
+                     q_ptr, [this](const QString &path, const QString &name) {
+                         handleFileClosed(path, name);
+                     });
+
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryCreated,
                      q_ptr, [this](const QString &path, const QString &name) {
-                         // VfsMonitor already knows it's a directory -- emit directly.
                          Q_EMIT q_ptr->directoryCreated(path, name);
-
-                         // Add new directory to inotify watch for fileClosed support.
-                         QString fullPath = QDir(path).absoluteFilePath(name);
-                         if (!isSymbolicLink(fullPath) && !shouldExcludePath(fullPath)) {
-                             addDirectoryRecursively(fullPath);
-                         }
                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryDeleted,
                      q_ptr, [this](const QString &path, const QString &name) {
                          Q_EMIT q_ptr->directoryDeleted(path, name);
-
-                         QString fullPath = QDir(path).absoluteFilePath(name);
-                         removeWatchForDirectory(fullPath);
                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryMoved,
@@ -496,20 +490,6 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
                                    << "->" << toPath << "/" << toName;
 
                          Q_EMIT q_ptr->directoryMoved(fromPath, fromName, toPath, toName);
-
-                         QString fromFullPath = QDir(fromPath).absoluteFilePath(fromName);
-                         removeWatchForDirectory(fromFullPath);
-
-                         QString toFullPath = QDir(toPath).absoluteFilePath(toName);
-                         if (!toPath.isEmpty() && !isSymbolicLink(toFullPath) && !shouldExcludePath(toFullPath)) {
-                             addDirectoryRecursively(toFullPath);
-                         }
-                     });
-
-    // fileClosed always comes from InotifyFileSystemWatcher (IN_CLOSE_WRITE).
-    QObject::connect(watcher.data(), &InotifyFileSystemWatcher::fileClosed,
-                     q_ptr, [this](const QString &path, const QString &name) {
-                         handleFileClosed(path, name);
                      });
 }
 
@@ -668,7 +648,7 @@ void FSMonitorPrivate::handleDirectoriesBatch(const QStringList &paths)
         if (!watchedDirectories.contains(path) && !shouldExcludePath(path)) {
             qApp->processEvents();
             // Add each path individually to avoid blocking from addPaths
-            if (watcher->addPath(path)) {
+            if (watcher && watcher->addPath(path)) {
                 watchedDirectories.insert(path);
                 addedCount++;
             } else {

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -64,7 +64,7 @@ public:
     // Parse and connect watcher signals (inotify-only fallback mode)
     void setupWatcherConnections();
 
-    // Connect deepin-anything watcher signals (create/delete/move from vfs, fileClosed from inotify)
+    // Connect vfs monitor signals (all events from deepin-anything dispatcher)
     void setupVfsMonitorConnections();
 
     // Set up the worker thread and connections

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -444,7 +444,7 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
         const uint32_t cookie = event.cookie;
         const char *pathCStr = event.eventPath;
 
-        if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
+        if (act < ACT_NEW_FILE || act > ACT_CLOSE_WRITE_FILE) {
             continue;
         }
 
@@ -527,6 +527,9 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
             break;
         case ACT_RENAME_FOLDER:
             Q_EMIT q->directoryCreated(parentPath, name);
+            break;
+        case ACT_CLOSE_WRITE_FILE:
+            Q_EMIT q->fileClosed(parentPath, name);
             break;
         default:
             break;

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
@@ -18,10 +18,9 @@ class VfsMonitorFileSystemWatcherPrivate;
 // VfsMonitorFileSystemWatcher: File system watcher using deepin-anything
 // event dispatcher socket exposed by deepin-anything-server.
 //
-// Receives global file system events (create, delete, move) forwarded by
-// deepin-anything-server from /run/deepin-anything/event-dispatcher.sock.
-// File close events (IN_CLOSE_WRITE) are NOT provided -- use
-// InotifyFileSystemWatcher for those.
+// Receives global file system events (create, delete, move, close-write)
+// forwarded by deepin-anything-server from
+// /run/deepin-anything/event-dispatcher.sock.
 //
 // Usage:
 //   auto *watcher = VfsMonitorFileSystemWatcher::create(rootPaths, excludePredicate, parent);
@@ -56,6 +55,7 @@ Q_SIGNALS:
     void directoryDeleted(const QString &path, const QString &name);
     void directoryMoved(const QString &fromPath, const QString &fromName,
                         const QString &toPath, const QString &toName);
+    void fileClosed(const QString &path, const QString &name);
 
 private:
     explicit VfsMonitorFileSystemWatcher(const QStringList &rootPaths,

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -47,7 +47,8 @@ enum VfsMonitorAct : uint8_t {
     ACT_RENAME_FROM_FOLDER = 10,
     ACT_RENAME_TO_FOLDER = 11,
     ACT_MOUNT = 12,
-    ACT_UNMOUNT = 13
+    ACT_UNMOUNT = 13,
+    ACT_CLOSE_WRITE_FILE = 14
 };
 
 class VfsMonitorFileSystemWatcherPrivate


### PR DESCRIPTION
## Root Cause Analysis

On the `release/snipe` branch, commit `d59f84feb` added early returns in `startMonitoring()` (`fsmonitor.cpp:167-172`) and `handleDirectoriesBatch()` (`fsmonitor.cpp:647-650`) that skipped all inotify watch setup when the VfsMonitor (deepin-anything dispatcher) was available. This meant zero inotify watches were established — no inotify resources consumed and no `IN_CLOSE_WRITE` (file close) events delivered. Meanwhile the VfsMonitor itself lacked handling for `ACT_CLOSE_WRITE_FILE` (event code 14), so close-write monitoring was entirely missing in vfs mode. The two early returns exist on master as well (`df93e558f`), but master's `9a7c548eb` resolved the issue by making VfsMonitor natively handle `ACT_CLOSE_WRITE_FILE`, eliminating the need for InotifyFileSystemWatcher in vfs mode entirely.

## Fix

Cherry-pick master commit `9a7c548eb` ("feat: integrate file close events into vfs monitor mode") onto `release/snipe`. The commit adds `ACT_CLOSE_WRITE_FILE = 14` to the VfsMonitor event enum, emits `fileClosed` when code 14 is received, connects this signal in `setupVfsMonitorConnections()`, removes the dual-watcher architecture (InotifyFileSystemWatcher is no longer created in vfs mode), and adds null-pointer guards on all `watcher` calls. After cherry-pick, `src/services/textindex/fsmonitor/` on snipe is identical to master (`git diff origin/master` is empty).

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- Cherry-pick of a master-reviewed commit (`9a7c548eb`); no function signatures changed, only new enum value, new signal, new switch-case branch, and null-pointer guards added.
- The early returns introduced by `d59f84feb` (the root cause) transition from "harmful" to "harmless" — vfs mode no longer needs InotifyFileSystemWatcher, so skipping it is correct behavior.
- All affected callers are internal to `FSMonitorPrivate`; no external API impact.

### Business Impact Scope

- **Full-text index file monitoring** — the textindex service's file system event listening and dispatching.
- Affected scenarios: in vfs mode (deepin-anything available), file create/edit/save/close events should now correctly trigger index updates. Directory create/delete/move monitoring remains functional. Inotify-only mode (deepin-anything unavailable) is unaffected.

### Verification Suggestion

- In vfs mode: create, write, and close a file in an indexed directory; verify the index updates to reflect content changes.
- Confirm `/proc/sys/fs/inotify/max_user_watches` usage does not increase when deepin-anything is active (no inotify watches created).
- Regression: verify inotify-only mode still works when deepin-anything is unavailable.

---

## 根因分析

`release/snipe` 分支上提交 `d59f84feb` 在 `startMonitoring()`（`fsmonitor.cpp:167-172`）和 `handleDirectoriesBatch()`（`fsmonitor.cpp:647-650`）中新增了提前返回，在 VfsMonitor（deepin-anything 调度器）可用时跳过了全部 inotify 目录监听建立。结果是 inotify 监听数为零——既不消耗 inotify 资源，也无法投递 `IN_CLOSE_WRITE`（文件关闭）事件。同时 VfsMonitor 本身缺少对 `ACT_CLOSE_WRITE_FILE`（event code 14）的处理，导致 vfs 模式下 close_write 监控完全缺失。这两处提前返回在 master 上同样存在（`df93e558f`），但 master 的 `9a7c548eb` 已通过让 VfsMonitor 原生处理 `ACT_CLOSE_WRITE_FILE` 解决了此问题，使 vfs 模式不再依赖 InotifyFileSystemWatcher。

## 修复方案

将 master 提交 `9a7c548eb`（"feat: integrate file close events into vfs monitor mode"）cherry-pick 到 `release/snipe`。该提交在 VfsMonitor 事件枚举中新增 `ACT_CLOSE_WRITE_FILE = 14`，收到 code 14 时 emit `fileClosed` 信号，在 `setupVfsMonitorConnections()` 中连接该信号，移除双 watcher 架构（vfs 模式下不再创建 InotifyFileSystemWatcher），并对所有 `watcher` 调用加空指针保护。cherry-pick 后 snipe 的 `src/services/textindex/fsmonitor/` 与 master 完全一致（`git diff origin/master` 为空）。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 本次改动为 master 已评审提交 `9a7c548eb` 的 cherry-pick，未修改函数签名，仅新增枚举值、信号、switch-case 分支及空指针保护。
- `d59f84feb` 引入的提前返回从「有害」变为「无害」——vfs 模式本就不需要 InotifyFileSystemWatcher，跳过是正确行为，无需额外回退。
- 所有受影响调用方均在 `FSMonitorPrivate` 内部，无外部 API 影响。

### 业务影响范围

- **全文索引文件监控** — 文管 textindex 服务对文件系统事件的监听与分发。
- 受影响场景：vfs 模式（deepin-anything 可用）下，文件创建/编辑/保存/关闭事件应正确触发索引更新。目录创建/删除/移动监听仍正常。inotify-only 模式（deepin-anything 不可用）不受影响。

### 验证建议

- vfs 模式下在索引目录中创建、写入并关闭文件，验证索引更新反映文件内容变化。
- 确认 deepin-anything 可用时 `/proc/sys/fs/inotify/max_user_watches` 使用量不增加（不创建 inotify watch）。
- 回归：验证 deepin-anything 不可用时 inotify-only 模式仍正常工作。

## Summary by Sourcery

Integrate close-write event handling into VfsMonitor mode and eliminate the dual-watcher setup.

New Features:
- Support file close-write events directly through the VfsMonitor watcher.

Bug Fixes:
- Restore file index updates for files written and closed while VfsMonitor mode is active.

Enhancements:
- Use a single VfsMonitor watcher for all events when deepin-anything is available, while retaining Inotify as the fallback mode.
- Add null-safety around Inotify watcher operations when it is not used.

Tests:
- Add coverage for fileClosed signal delivery after writing and closing a file.