### PR TITLE
Revert "feat: support close-write events in vfs monitor"

### DIFF
--- a/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
+++ b/autotests/libs/textindex/test_vfsmonitorfilesystemwatcher.cpp
@@ -267,30 +267,6 @@ TEST_F(TestVfsMonitorFileSystemWatcher, SymlinkCreationEmitsFileCreated)
     EXPECT_EQ(args.at(1).toString(), "symlink_link.txt");
 }
 
-// ========== 文件写入关闭 ==========
-
-TEST_F(TestVfsMonitorFileSystemWatcher, FileClosedSignal)
-{
-    ASSERT_NE(watcher, nullptr);
-
-    QSignalSpy spy(watcher, &VfsMonitorFileSystemWatcher::fileClosed);
-    ASSERT_TRUE(spy.isValid());
-
-    // 创建文件并写入内容后关闭，触发 ACT_CLOSE_WRITE_FILE
-    QString filePath = testDir->path() + "/closewrite.txt";
-    QFile file(filePath);
-    file.open(QIODevice::WriteOnly);
-    file.write("close write test");
-    file.close();
-
-    int count = waitForSignal(spy);
-    ASSERT_GT(count, 0) << "fileClosed signal not received within timeout";
-
-    QList<QVariant> args = spy.takeFirst();
-    EXPECT_EQ(args.at(0).toString(), testDir->path());
-    EXPECT_EQ(args.at(1).toString(), "closewrite.txt");
-}
-
 // ========== 路径排除 ==========
 
 TEST_F(TestVfsMonitorFileSystemWatcher, ExcludePredicateFiltersEvents)

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -106,6 +106,8 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
         return false;
     }
 
+    watcher.reset(new InotifyFileSystemWatcher());
+
     // Use static factory method to create configured blacklist matcher
     // BEFORE creating VfsMonitor watcher (needs it for excludePredicate).
     excludeMatcher = PathExcludeMatcher::createForIndex();
@@ -120,13 +122,13 @@ bool FSMonitorPrivate::init(const QStringList &rootPaths)
     vfsMonitorAvailable = (vfsWatcher != nullptr);
 
     if (vfsMonitorAvailable) {
-        // VfsMonitor handles all events including ACT_CLOSE_WRITE_FILE,
-        // so InotifyFileSystemWatcher is not needed.
+        // deepin-anything dispatcher mode: create/delete/move from vfs, fileClosed from inotify.
+        // Restrict inotify to IN_CLOSE_WRITE only, reducing kernel event delivery.
+        watcher->setWatchFlags(InotifyFileSystemWatcher::WatchFlag::FileClose);
         setupVfsMonitorConnections();
-        fmInfo() << "FSMonitor: Using vfs monitor mode (deepin-anything dispatcher)";
+        fmInfo() << "FSMonitor: Using dual watcher mode (deepin-anything dispatcher + inotify fallback)";
     } else {
-        // Inotify-only mode: create InotifyFileSystemWatcher for all events.
-        watcher.reset(new InotifyFileSystemWatcher());
+        // inotify-only mode: all signals from InotifyFileSystemWatcher (existing behavior).
         setupWatcherConnections();
         fmInfo() << "FSMonitor: Using inotify-only mode (deepin-anything dispatcher not available)";
     }
@@ -387,7 +389,7 @@ bool FSMonitorPrivate::addWatchForDirectory(const QString &path)
     }
 
     // Add to watcher
-    if (watcher && watcher->addPath(path)) {
+    if (watcher->addPath(path)) {
         watchedDirectories.insert(path);
         //   fmDebug() << "FSMonitor: Added watch for directory:" << path;
         return true;
@@ -404,8 +406,7 @@ void FSMonitorPrivate::removeWatchForDirectory(const QString &path)
     }
 
     if (watchedDirectories.contains(path)) {
-        if (watcher)
-            watcher->removePath(path);
+        watcher->removePath(path);
         watchedDirectories.remove(path);
         fmDebug() << "FSMonitor: Removed watch for directory:" << path;
     }
@@ -449,7 +450,7 @@ void FSMonitorPrivate::setupWatcherConnections()
 
 void FSMonitorPrivate::setupVfsMonitorConnections()
 {
-    // All events come from VfsMonitorFileSystemWatcher (create/delete/move/close-write).
+    // Create/delete/move events from VfsMonitorFileSystemWatcher.
     // The kernel already distinguishes files from directories, so we can
     // emit the specific directory* signals directly without QFileInfo checks.
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileCreated,
@@ -460,7 +461,7 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileDeleted,
                      q_ptr, [this](const QString &path, const QString &name) {
                           handleFileDeleted(path, name);
-                      });
+                     });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileMoved,
                      q_ptr, [this](const QString &fromPath, const QString &fromName,
@@ -468,19 +469,24 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
                          handleFileMoved(fromPath, fromName, toPath, toName);
                      });
 
-    QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::fileClosed,
-                     q_ptr, [this](const QString &path, const QString &name) {
-                         handleFileClosed(path, name);
-                     });
-
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryCreated,
                      q_ptr, [this](const QString &path, const QString &name) {
+                         // VfsMonitor already knows it's a directory -- emit directly.
                          Q_EMIT q_ptr->directoryCreated(path, name);
+
+                         // Add new directory to inotify watch for fileClosed support.
+                         QString fullPath = QDir(path).absoluteFilePath(name);
+                         if (!isSymbolicLink(fullPath) && !shouldExcludePath(fullPath)) {
+                             addDirectoryRecursively(fullPath);
+                         }
                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryDeleted,
                      q_ptr, [this](const QString &path, const QString &name) {
                          Q_EMIT q_ptr->directoryDeleted(path, name);
+
+                         QString fullPath = QDir(path).absoluteFilePath(name);
+                         removeWatchForDirectory(fullPath);
                      });
 
     QObject::connect(vfsWatcher.data(), &VfsMonitorFileSystemWatcher::directoryMoved,
@@ -490,6 +496,20 @@ void FSMonitorPrivate::setupVfsMonitorConnections()
                                    << "->" << toPath << "/" << toName;
 
                          Q_EMIT q_ptr->directoryMoved(fromPath, fromName, toPath, toName);
+
+                         QString fromFullPath = QDir(fromPath).absoluteFilePath(fromName);
+                         removeWatchForDirectory(fromFullPath);
+
+                         QString toFullPath = QDir(toPath).absoluteFilePath(toName);
+                         if (!toPath.isEmpty() && !isSymbolicLink(toFullPath) && !shouldExcludePath(toFullPath)) {
+                             addDirectoryRecursively(toFullPath);
+                         }
+                     });
+
+    // fileClosed always comes from InotifyFileSystemWatcher (IN_CLOSE_WRITE).
+    QObject::connect(watcher.data(), &InotifyFileSystemWatcher::fileClosed,
+                     q_ptr, [this](const QString &path, const QString &name) {
+                         handleFileClosed(path, name);
                      });
 }
 
@@ -648,7 +668,7 @@ void FSMonitorPrivate::handleDirectoriesBatch(const QStringList &paths)
         if (!watchedDirectories.contains(path) && !shouldExcludePath(path)) {
             qApp->processEvents();
             // Add each path individually to avoid blocking from addPaths
-            if (watcher && watcher->addPath(path)) {
+            if (watcher->addPath(path)) {
                 watchedDirectories.insert(path);
                 addedCount++;
             } else {

--- a/src/services/textindex/fsmonitor/fsmonitor_p.h
+++ b/src/services/textindex/fsmonitor/fsmonitor_p.h
@@ -64,7 +64,7 @@ public:
     // Parse and connect watcher signals (inotify-only fallback mode)
     void setupWatcherConnections();
 
-    // Connect vfs monitor signals (all events from deepin-anything dispatcher)
+    // Connect deepin-anything watcher signals (create/delete/move from vfs, fileClosed from inotify)
     void setupVfsMonitorConnections();
 
     // Set up the worker thread and connections

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.cpp
@@ -444,7 +444,7 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
         const uint32_t cookie = event.cookie;
         const char *pathCStr = event.eventPath;
 
-        if (act < ACT_NEW_FILE || act > ACT_CLOSE_WRITE_FILE) {
+        if (act < ACT_NEW_FILE || act > ACT_UNMOUNT) {
             continue;
         }
 
@@ -527,9 +527,6 @@ void VfsMonitorFileSystemWatcherPrivate::handleSocketMessage()
             break;
         case ACT_RENAME_FOLDER:
             Q_EMIT q->directoryCreated(parentPath, name);
-            break;
-        case ACT_CLOSE_WRITE_FILE:
-            Q_EMIT q->fileClosed(parentPath, name);
             break;
         default:
             break;

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher.h
@@ -18,9 +18,10 @@ class VfsMonitorFileSystemWatcherPrivate;
 // VfsMonitorFileSystemWatcher: File system watcher using deepin-anything
 // event dispatcher socket exposed by deepin-anything-server.
 //
-// Receives global file system events (create, delete, move, close-write)
-// forwarded by deepin-anything-server from
-// /run/deepin-anything/event-dispatcher.sock.
+// Receives global file system events (create, delete, move) forwarded by
+// deepin-anything-server from /run/deepin-anything/event-dispatcher.sock.
+// File close events (IN_CLOSE_WRITE) are NOT provided -- use
+// InotifyFileSystemWatcher for those.
 //
 // Usage:
 //   auto *watcher = VfsMonitorFileSystemWatcher::create(rootPaths, excludePredicate, parent);
@@ -55,7 +56,6 @@ Q_SIGNALS:
     void directoryDeleted(const QString &path, const QString &name);
     void directoryMoved(const QString &fromPath, const QString &fromName,
                         const QString &toPath, const QString &toName);
-    void fileClosed(const QString &path, const QString &name);
 
 private:
     explicit VfsMonitorFileSystemWatcher(const QStringList &rootPaths,

--- a/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
+++ b/src/services/textindex/fsmonitor/vfsmonitorwatcher_p.h
@@ -47,8 +47,7 @@ enum VfsMonitorAct : uint8_t {
     ACT_RENAME_FROM_FOLDER = 10,
     ACT_RENAME_TO_FOLDER = 11,
     ACT_MOUNT = 12,
-    ACT_UNMOUNT = 13,
-    ACT_CLOSE_WRITE_FILE = 14
+    ACT_UNMOUNT = 13
 };
 
 class VfsMonitorFileSystemWatcherPrivate


### PR DESCRIPTION
This reverts commit e578a9f1782c9991b5f595f0d38bd81aaa2e0506.

## Summary by Sourcery

Separate close-write monitoring from VFS event dispatch by using inotify alongside deepin-anything for filesystem monitoring.

Enhancements:
- Restore close-write event handling through the inotify watcher while retaining deepin-anything for create, delete, and move events.
- Track directory additions, removals, and moves in the inotify watcher so close-write events continue to be observed.

Tests:
- Remove the VFS monitor close-write signal test.

Chores:
- Remove close-write event support from the VFS monitor watcher interface and event processing.