### PR TITLE
fix: fix vfs mode directory monitoring for fileClose events

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-file-manager (6.5.167) unstable; urgency=medium
+
+  * feat: add dconfig-gated Latin-first sort strategy for zh_CN
+  * perf: adopt QCollator buffer strategy for ICU sort key generation
+  * fix: enable Latin-first sort by default for zh_CN
+  * fix: fix vfs mode directory monitoring for fileClose events
+
+ -- zhangsheng <zhangsheng@uniontech.com>  Mon, 24 Aug 2026 16:35:08 +0800
+
 dde-file-manager (6.5.166) unstable; urgency=medium
 
   * fix: improve sidebar URL highlight deduplication

--- a/src/services/textindex/fsmonitor/fsmonitor.cpp
+++ b/src/services/textindex/fsmonitor/fsmonitor.cpp
@@ -164,14 +164,9 @@ bool FSMonitorPrivate::startMonitoring()
     active = true;
     watchedDirectories.clear();
 
-    if (vfsMonitorAvailable) {
-        fmInfo() << "FSMonitor: VfsMonitor active, skipping inotify directory watch setup";
-        fmInfo() << "FSMonitor: Started monitoring with max watches:" << maxWatches
-                 << "usage limit:" << (maxUsagePercentage * 100) << "%";
-        return true;
-    }
-
-    // Start worker thread
+    // Start worker thread -- needed even in vfs mode, because inotify
+    // (restricted to IN_CLOSE_WRITE) must traverse and watch directories
+    // to deliver fileClosed events.  VfsMonitor handles create/delete/move.
     if (!workerThread.isRunning()) {
         workerThread.start();
     }
@@ -644,8 +639,8 @@ void FSMonitorPrivate::handleDirectoriesBatch(const QStringList &paths)
         return;
     }
 
-    if (vfsMonitorAvailable || !watcher) {
-        fmDebug() << "FSMonitor: Ignoring directory watch batch in vfs mode, size:" << paths.size();
+    if (!watcher) {
+        fmDebug() << "FSMonitor: No watcher available, ignoring directory watch batch, size:" << paths.size();
         return;
     }
 


### PR DESCRIPTION
The previous implementation skipped directory watch in vfsMonitor mode,
assuming vfs handles everything. However, for accurate fileClose events
(IN_CLOSE_WRITE), inotify must traverse and watch directories even in
vfs mode. VfsMonitor only handles create/delete/move events. This change
ensures the worker thread runs in all modes and directory watching logic
executes when vfsMonitorAvailable is true but a watcher exists.

1. Modified startMonitoring to always start worker thread regardless of
vfsMonitorAvailable
2. Changed handleDirectoriesBatch condition to check only for watcher
existence, not vfs mode
3. Updated debug messages to reflect the new behavior
4. Added clear comment explaining the worker thread necessity for
IN_CLOSE_WRITE events

Log: Fixed file monitoring to properly detect when files are saved and
closed in vfs mode

Influence:
1. Test file operations (create, save, close) in vfs mode environments
2. Verify fileClose events are properly detected when using inotify
backend
3. Test mixed environments where vfsMonitorAvailable may be true
4. Monitor system resources to ensure no excessive directory watches in
vfs mode

fix: 修复 vfs 模式目录监控以支持 fileClose 事件

先前实现中，在 vfsMonitor 模式下跳过了目录监听，假设 vfs 会处理所有事
件。然而，要准确检测文件关闭事件 (IN_CLOSE_WRITE)，即使是在 vfs 模式下，
inotify 也必须遍历并监听目录。VfsMonitor 仅处理创建、删除和移动事件。本
次更改确保在所有模式下都启动工作线程，并且在 vfsMonitorAvailable 为 true
但监视器存在时执行目录监听逻辑。

1. 修改 startMonitoring 以确保无论 vfsMonitorAvailable 状态如何都启动工
作线程
2. 更改 handleDirectoriesBatch 条件，仅检查监视器是否存在，而不检查 vfs
模式
3. 更新调试消息以反映新的行为
4. 添加清晰注释说明工作线程对 IN_CLOSE_WRITE 事件的必要性

Log: 修复文件监控功能，在 vfs 模式下正确检测文件保存和关闭操作

Influence:
1. 在 vfs 模式环境中测试文件操作（创建、保存、关闭）
2. 验证在使用 inotify 后端时是否正确检测到 fileClose 事件
3. 测试 vfsMonitorAvailable 可能为 true 的混合环境
4. 监控系统资源，确保在 vfs 模式下不会产生过多的目录监听

Fixes: #374841

## Summary by Sourcery

Enable inotify directory monitoring alongside VfsMonitor to correctly report file-close events in VFS mode.

Bug Fixes:
- Restore directory watching in VFS mode so file-close events are detected reliably through inotify.

Enhancements:
- Run the filesystem monitor worker and directory watch handling across VFS and non-VFS modes while retaining VfsMonitor coverage for create, delete, and move events.