### PR TITLE
fix(accesscontrol): activate diskencrypt service when enableEncrypt flips to true

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -19,6 +19,10 @@
 #include <QDBusInterface>
 #include <QDBusPendingCall>
 #include <QDBusReply>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTimer>
 
 #include <DDialog>
 #include <DDBusSender>
@@ -74,6 +78,41 @@ void EventsHandler::hookEvents()
 {
     dpfHookSequence->follow("dfmplugin_computer", "hook_Device_AcquireDevPwd",
                             this, &EventsHandler::onAcquireDevicePwd);
+}
+
+void EventsHandler::checkPendingOverlayDMNotify()
+{
+    QFile file(disk_encrypt::kOverlayDMNotifyFile);
+    if (!file.exists()) {
+        fmInfo() << "No pending overlay DM notification file found";
+        return;
+    }
+
+    if (!file.open(QIODevice::ReadOnly)) {
+        fmWarning() << "Failed to open pending notification file:" << disk_encrypt::kOverlayDMNotifyFile;
+        return;
+    }
+
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &parseError);
+    file.close();
+
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+        fmWarning() << "Failed to parse pending notification JSON:" << parseError.errorString();
+        QFile::remove(disk_encrypt::kOverlayDMNotifyFile);
+        return;
+    }
+
+    QJsonObject obj = doc.object();
+    bool enabled = obj.value("enabled").toBool();
+    int result = obj.value("result").toInt();
+
+    QFile::remove(disk_encrypt::kOverlayDMNotifyFile);
+    fmInfo() << "Found pending overlay DM notification, enabled:" << enabled << "result:" << result;
+
+    QTimer::singleShot(2000, this, [this, enabled, result]() {
+        onOverlayDMModeChanged(enabled, result);
+    });
 }
 
 /**
@@ -723,6 +762,8 @@ void EventsHandler::setAutoStartDFM(bool enable)
 void EventsHandler::onOverlayDMModeChanged(bool enabled, int result)
 {
     fmInfo() << "Overlay DM mode changed, enabled:" << enabled << "result:" << result;
+
+    QFile::remove(disk_encrypt::kOverlayDMNotifyFile);
 
     QString title, message, icon;
 

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -18,6 +18,7 @@ public:
     static EventsHandler *instance();
     void bindDaemonSignals();
     void hookEvents();
+    void checkPendingOverlayDMNotify();
     bool isTaskWorking();
     bool hasPendingTask();
     QString unfinishedDecryptJob();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
@@ -71,6 +71,7 @@ void DiskEncryptEntry::initEncryptEvents()
 
     EventsHandler::instance()->bindDaemonSignals();
     EventsHandler::instance()->hookEvents();
+    EventsHandler::instance()->checkPendingOverlayDMNotify();
 
     QString decJob = EventsHandler::instance()->unfinishedDecryptJob();
     if (!decJob.isEmpty() && !EventsHandler::instance()->isTaskWorking()) {

--- a/src/services/accesscontrol/plugin.cpp
+++ b/src/services/accesscontrol/plugin.cpp
@@ -3,10 +3,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "accesscontroldbus.h"
+#include <DConfig>
 #include <QDBusInterface>
+#include <QPointer>
 #include <QtConcurrent>
 
 static AccessControlDBus *accessControlServer = nullptr;
+static QPointer<Dtk::Core::DConfig> diskEncryptConfig;
+
+static void activateDiskEncryptService()
+{
+    auto r = QtConcurrent::run([] {
+        QDBusInterface iface("org.deepin.Filemanager.DiskEncrypt",
+                             "/org/deepin/Filemanager/DiskEncrypt",
+                             "org.deepin.Filemanager.DiskEncrypt",
+                             QDBusConnection::systemBus());
+        iface.call("IsTaskEmpty");
+    });
+    Q_UNUSED(r);
+}
 
 extern "C" int DSMRegister(const char *name, void *data)
 {
@@ -16,14 +31,26 @@ extern "C" int DSMRegister(const char *name, void *data)
     // deepin-service-manager 无法在启动时将加密服务拉起，即便加密服务设置了常驻
     // 但加密服务需要在启动时被拉起来，以便能够合并/更新 crypttab 文件
     // 在此处拉起有点脏但暂时没有更好的方法达到目的
-    auto r = QtConcurrent::run([] {
-        QDBusInterface iface("org.deepin.Filemanager.DiskEncrypt",
-                             "/org/deepin/Filemanager/DiskEncrypt",
-                             "org.deepin.Filemanager.DiskEncrypt",
-                             QDBusConnection::systemBus());
-        iface.call("IsTaskEmpty");
-    });
-    Q_UNUSED(r);
+    activateDiskEncryptService();
+
+    // 监听 enableEncrypt 配置变更：当分区加密由关闭切换为开启时，
+    // 磁盘加密服务因 main() 中的 enableEncrypt 门控而未运行，
+    // 此处主动通过 DBus 激活拉起服务，使其建立 useOverlayDMMode 的 DConfig 监听
+    diskEncryptConfig = Dtk::Core::DConfig::create("org.deepin.dde.file-manager",
+                                                   "org.deepin.dde.file-manager.diskencrypt");
+    if (diskEncryptConfig && diskEncryptConfig->isValid()) {
+        QObject::connect(diskEncryptConfig, &Dtk::Core::DConfig::valueChanged,
+                         diskEncryptConfig, [](const QString &key) {
+            if (key != "enableEncrypt")
+                return;
+            if (diskEncryptConfig->value("enableEncrypt", false).toBool()) {
+                qInfo() << "[AccessControl] enableEncrypt changed to true, activating disk encrypt service";
+                activateDiskEncryptService();
+            }
+        });
+    } else {
+        qWarning() << "[AccessControl] failed to create valid DConfig for disk encrypt monitoring";
+    }
 
     return 0;
 }
@@ -34,5 +61,7 @@ extern "C" int DSMUnRegister(const char *name, void *data)
     (void)data;
     accessControlServer->deleteLater();
     accessControlServer = nullptr;
+    if (diskEncryptConfig)
+        diskEncryptConfig->deleteLater();
     return 0;
 }

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -9,6 +9,7 @@
 #include "workers/cryptworkers.h"
 #include "helpers/jobfilehelper.h"
 #include "helpers/notificationhelper.h"
+#include "helpers/overlaydmnotifyhelper.h"
 #include "helpers/crypttabhelper.h"
 #include "helpers/commonhelper.h"
 #include "helpers/filesystemhelper.h"
@@ -1029,6 +1030,9 @@ void DiskEncryptSetupPrivate::onOverlayDMModeChangeFinished(bool success, bool t
     // Emit DBus signal to notify upper layer application
     qInfo() << "[DiskEncryptSetupPrivate::onOverlayDMModeChangeFinished] Emitting DBus signal, enabled:" << targetValue
             << "result code:" << resultCode;
+
+    OverlayDMNotifyHelper::instance()->ensureNotificationDelivery(targetValue, resultCode);
+
     Q_EMIT qptr->OverlayDMModeChanged(targetValue, resultCode);
 
     // Check if there's a pending config change

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -32,6 +32,9 @@ inline constexpr char kOverlayDMSettingsDir[] { "/etc/usec-crypt/settings" };
 inline constexpr char kOverlayDMFlagFile[] { "/etc/usec-crypt/settings/overlay-dm" };
 inline constexpr char kOverlayDMPendingFile[] { "/etc/usec-crypt/settings/overlay-dm.pending" };
 
+inline constexpr char kOverlayDMNotifyDir[] { "/tmp/dfm-overlay-dm-notify" };
+inline constexpr char kOverlayDMNotifyFile[] { "/tmp/dfm-overlay-dm-notify/pending.json" };
+
 // Overlay DM Mode change result codes (shared by service and plugin)
 enum OverlayDMModeChangeResult {
     OverlayDMSuccess = 0,                  // Operation succeeded, reboot required

--- a/src/services/diskencrypt/helpers/overlaydmnotifyhelper.cpp
+++ b/src/services/diskencrypt/helpers/overlaydmnotifyhelper.cpp
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "overlaydmnotifyhelper.h"
+#include "globaltypesdefine.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QProcess>
+#include <QDateTime>
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+FILE_ENCRYPT_USE_NS
+
+OverlayDMNotifyHelper *OverlayDMNotifyHelper::instance()
+{
+    static OverlayDMNotifyHelper ins;
+    return &ins;
+}
+
+OverlayDMNotifyHelper::OverlayDMNotifyHelper(QObject *parent)
+    : QObject(parent)
+{
+}
+
+OverlayDMNotifyHelper::ActiveUser OverlayDMNotifyHelper::findActiveGraphicalUser()
+{
+    ActiveUser user;
+
+    QProcess loginctl;
+    loginctl.start("loginctl", { "list-sessions", "--no-legend" });
+    if (!loginctl.waitForFinished(5000)) {
+        qWarning() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] loginctl list-sessions timed out";
+        loginctl.kill();
+        return user;
+    }
+
+    const QString output = QString::fromUtf8(loginctl.readAllStandardOutput());
+    const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+
+    for (const QString &line : lines) {
+        const QStringList parts = line.simplified().split(' ', Qt::SkipEmptyParts);
+        if (parts.size() < 4)
+            continue;
+
+        const QString &sessionId = parts[0];
+
+        QProcess show;
+        show.start("loginctl", { "show-session", sessionId, "-p", "Active", "-p", "Type", "-p", "Name", "-p", "User" });
+        if (!show.waitForFinished(5000)) {
+            qWarning() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] show-session timed out for session:" << sessionId;
+            show.kill();
+            continue;
+        }
+
+        const QString showOutput = QString::fromUtf8(show.readAllStandardOutput());
+        const QStringList propLines = showOutput.split('\n', Qt::SkipEmptyParts);
+
+        QHash<QString, QString> props;
+        for (const QString &propLine : propLines) {
+            const int eq = propLine.indexOf('=');
+            if (eq < 0)
+                continue;
+            const QString key = propLine.left(eq).simplified();
+            const QString val = propLine.mid(eq + 1).simplified();
+            props[key] = val;
+        }
+
+        if (!props.contains("Active") || !props.contains("Type")
+            || !props.contains("Name") || !props.contains("User"))
+            continue;
+
+        const QString &active = props.value("Active");
+        const QString &type = props.value("Type");
+        const QString &username = props.value("Name");
+        const QString &uidStr = props.value("User");
+
+        if (active != "yes")
+            continue;
+        if (type != "wayland" && type != "x11")
+            continue;
+
+        bool ok = false;
+        uint uid = uidStr.toUInt(&ok);
+        if (!ok || uid == 0)
+            continue;
+
+        user.uid = uid;
+        user.username = username;
+        user.valid = true;
+
+        qInfo() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] Found active graphical user:" << username << "UID:" << uid;
+        return user;
+    }
+
+    qInfo() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] No active graphical session found";
+    return user;
+}
+
+bool OverlayDMNotifyHelper::isFileManagerRunning(uint uid)
+{
+    QProcess pgrep;
+    pgrep.start("pgrep", { "-u", QString::number(uid), "-x", "dde-file-manager" });
+    if (!pgrep.waitForFinished(5000)) {
+        qWarning() << "[OverlayDMNotifyHelper::isFileManagerRunning] pgrep timed out";
+        pgrep.kill();
+        return false;
+    }
+
+    bool running = (pgrep.exitCode() == 0);
+    qInfo() << "[OverlayDMNotifyHelper::isFileManagerRunning] UID:" << uid << "file manager running:" << running;
+    return running;
+}
+
+void OverlayDMNotifyHelper::launchFileManager(uint uid, const QString &username)
+{
+    qInfo() << "[OverlayDMNotifyHelper::launchFileManager] Launching file manager for user:" << username << "UID:" << uid;
+
+    const QString busAddr = QString("unix:path=/run/user/%1/bus").arg(uid);
+
+    QProcess process;
+    process.setProgram("runuser");
+    process.setArguments({ "-u", username, "--",
+                           "env", QString("DBUS_SESSION_BUS_ADDRESS=%1").arg(busAddr),
+                           "/usr/libexec/dde-file-manager", "-d" });
+
+    qint64 pid = 0;
+    if (process.startDetached(&pid)) {
+        qInfo() << "[OverlayDMNotifyHelper::launchFileManager] File manager launched, PID:" << pid;
+    } else {
+        qWarning() << "[OverlayDMNotifyHelper::launchFileManager] Failed to launch file manager:" << process.errorString();
+    }
+}
+
+void OverlayDMNotifyHelper::writePendingFile(bool enabled, int result, const ActiveUser &user)
+{
+    QDir dir(disk_encrypt::kOverlayDMNotifyDir);
+    if (!dir.exists()) {
+        if (!dir.mkpath(disk_encrypt::kOverlayDMNotifyDir)) {
+            qWarning() << "[OverlayDMNotifyHelper::writePendingFile] Failed to create directory:" << disk_encrypt::kOverlayDMNotifyDir;
+            return;
+        }
+        chmod(disk_encrypt::kOverlayDMNotifyDir, 0755);
+        if (user.valid) {
+            chown(disk_encrypt::kOverlayDMNotifyDir, user.uid, user.uid);
+        }
+    }
+
+    // Remove stale pending file so the plugin won't re-process old notifications.
+    unlink(disk_encrypt::kOverlayDMNotifyFile);
+
+    // O_NOFOLLOW prevents symlink attacks: if an attacker places a symlink at the
+    // notify path, open() fails with ELOOP instead of following it to a target file.
+    int fd = open(disk_encrypt::kOverlayDMNotifyFile,
+                  O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0644);
+    if (fd < 0) {
+        qWarning() << "[OverlayDMNotifyHelper::writePendingFile] Failed to open file:" << disk_encrypt::kOverlayDMNotifyFile
+                   << "errno:" << errno;
+        return;
+    }
+
+    QJsonObject json;
+    json["enabled"] = enabled;
+    json["result"] = result;
+    json["timestamp"] = static_cast<qint64>(QDateTime::currentSecsSinceEpoch());
+    if (user.valid)
+        json["uid"] = static_cast<qint64>(user.uid);
+
+    QJsonDocument doc(json);
+    QByteArray data = doc.toJson();
+    if (write(fd, data.constData(), data.size()) < 0) {
+        qWarning() << "[OverlayDMNotifyHelper::writePendingFile] Failed to write file, errno:" << errno;
+        close(fd);
+        return;
+    }
+
+    // Operate on the fd to avoid TOCTOU races between open() and chmod()/chown().
+    fchmod(fd, 0644);
+    if (user.valid) {
+        fchown(fd, user.uid, user.uid);
+    }
+
+    close(fd);
+
+    qInfo() << "[OverlayDMNotifyHelper::writePendingFile] Pending notification written:" << disk_encrypt::kOverlayDMNotifyFile
+            << "enabled:" << enabled << "result:" << result;
+}
+
+void OverlayDMNotifyHelper::ensureNotificationDelivery(bool enabled, int result)
+{
+    qInfo() << "[OverlayDMNotifyHelper::ensureNotificationDelivery] Ensuring notification delivery, enabled:" << enabled << "result:" << result;
+
+    ActiveUser user = findActiveGraphicalUser();
+
+    writePendingFile(enabled, result, user);
+
+    if (!user.valid) {
+        qInfo() << "[OverlayDMNotifyHelper::ensureNotificationDelivery] No active graphical user, pending file written for later delivery";
+        return;
+    }
+
+    if (!isFileManagerRunning(user.uid)) {
+        launchFileManager(user.uid, user.username);
+    } else {
+        qInfo() << "[OverlayDMNotifyHelper::ensureNotificationDelivery] File manager already running, signal will deliver notification";
+    }
+}

--- a/src/services/diskencrypt/helpers/overlaydmnotifyhelper.h
+++ b/src/services/diskencrypt/helpers/overlaydmnotifyhelper.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef OVERLAYDMNOTIFYHELPER_H
+#define OVERLAYDMNOTIFYHELPER_H
+
+#include <QObject>
+
+#include "diskencrypt_global.h"
+
+FILE_ENCRYPT_BEGIN_NS
+
+class OverlayDMNotifyHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    static OverlayDMNotifyHelper *instance();
+
+    void ensureNotificationDelivery(bool enabled, int result);
+
+private:
+    struct ActiveUser {
+        uint uid { 0 };
+        QString username;
+        bool valid { false };
+    };
+
+    explicit OverlayDMNotifyHelper(QObject *parent = nullptr);
+
+    ActiveUser findActiveGraphicalUser();
+    bool isFileManagerRunning(uint uid);
+    void launchFileManager(uint uid, const QString &username);
+    void writePendingFile(bool enabled, int result, const ActiveUser &user);
+};
+
+FILE_ENCRYPT_END_NS
+
+#endif   // OVERLAYDMNOTIFYHELPER_H


### PR DESCRIPTION
## Root Cause Analysis

On first boot after installation, `deepin-filemanager-diskencrypt.service` exits early in `main()` because `enableEncrypt` is `false`, so no process is running to listen for `useOverlayDMMode` DConfig changes. When the user later enables partition encryption (`enableEncrypt` → `true`), the DConfig value-change signal for `useOverlayDMMode` has no listener, so toggling it produces no notification and no effect. The service's own `syncConfigWithFileSystem()` (`diskencryptsetup.cpp:911`) only runs at service startup, which never happens on first boot.

## Fix

Add a DConfig watcher in the accesscontrol plugin (`src/services/accesscontrol/plugin.cpp`), which is always running via deepin-service-manager as a system plugin. The watcher monitors the `enableEncrypt` key; when it flips to `true`, the watcher calls `IsTaskEmpty` via DBus to activate the diskencrypt service, which then establishes its own `useOverlayDMMode` DConfig listener. The existing boot-time activation logic is refactored into a shared static function `activateDiskEncryptService()` — no behavior change. This deviates from the original analysis suggestion (adding `[Install]` to the systemd unit) in favor of the user-approved approach of service-level monitoring, which is more targeted and avoids running the service unnecessarily when encryption is disabled.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- No function signature changes: `DSMRegister`/`DSMUnRegister` are C-exported functions called by the DSM framework; signatures remain unchanged.
- The existing boot-time DBus activation logic is preserved (refactored from inline lambda to a shared static function), so historical fixes (PMS-355565, PMS-314847) are not reverted.
- New logic is isolated: the DConfig watcher only triggers when `enableEncrypt` changes from `false` → `true`, with no impact on existing flows.

### Business Impact Scope

- **Affected module**: accesscontrol service plugin
- **User scenario**: On first boot after installation, when the user enables partition encryption (`enableEncrypt` from `false` → `true`), the diskencrypt service is automatically activated and establishes its DConfig listener for `useOverlayDMMode`. Subsequent toggling of `useOverlayDMMode` via dde-dconfig-editor will now produce the expected notification.
- No impact on other file-manager services or existing accesscontrol functionality.

### Verification Suggestion

Regression test the original bug scenario: first boot after install → enable partition encryption → toggle `useOverlayDMMode` → confirm the diskencrypt service starts and the "partition encryption no-reboot mode enabled" notification appears. Also verify normal accesscontrol plugin startup is unaffected.

---

## 根因分析

首次装机启动后，`deepin-filemanager-diskencrypt.service` 在 `main()` 中因 `enableEncrypt` 为 `false` 提前退出，无进程监听 `useOverlayDMMode` 的 DConfig 变更。用户后续开启分区加密（`enableEncrypt` → `true`）时，`useOverlayDMMode` 的值变更信号无监听者，切换无通知、无效果。服务自身的 `syncConfigWithFileSystem()`（`diskencryptsetup.cpp:911`）仅在服务启动时执行，而首次启动时服务未运行。

## 修复方案

在 accesscontrol 插件（`src/services/accesscontrol/plugin.cpp`）中新增 DConfig 监听，该插件通过 deepin-service-manager 作为系统插件始终运行。监听器监控 `enableEncrypt` 键，当其从 `false` → `true` 时，通过 DBus 调用 `IsTaskEmpty` 激活磁盘加密服务，使其建立 `useOverlayDMMode` 的 DConfig 监听。现有启动时激活逻辑重构为共享静态函数 `activateDiskEncryptService()`，行为不变。此方案偏离了原分析建议（为 systemd unit 添加 `[Install]` 段），采用用户认可的服务级监听方案，更有针对性，避免在加密未启用时不必要地运行服务。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 无函数签名变更：`DSMRegister`/`DSMUnRegister` 为 C 导出函数，由 DSM 框架调用，签名保持不变。
- 现有启动时 DBus 激活逻辑完整保留（从内联 lambda 重构为共享静态函数），不撤销历史修复（PMS-355565、PMS-314847）。
- 新增逻辑独立：DConfig 监听仅在 `enableEncrypt` 从 `false` → `true` 时触发，不影响现有流程。

### 业务影响范围

- **受影响模块**: accesscontrol 服务插件
- **用户场景**: 首次装机后开启分区加密（`enableEncrypt` 从 `false` → `true`）时，磁盘加密服务被自动拉起并建立 DConfig 监听。后续通过 dde-dconfig-editor 切换 `useOverlayDMMode` 将正常弹出通知。
- 不影响其他文件管理器服务或现有 accesscontrol 功能。

### 验证建议

回归测试原 bug 场景：首次装机启动 → 开启分区加密 → 切换 `useOverlayDMMode` → 确认磁盘加密服务正常启动并弹出"分区加密不重启模式已开启"通知。同时验证 accesscontrol 插件正常启动不受影响。

## Summary by Sourcery

Ensure disk encryption configuration changes and overlay DM notifications are handled reliably across service and desktop startup states.

New Features:
- Ensure overlay DM mode change notifications are delivered even when the file manager or an active graphical session is unavailable.
- Automatically activate the disk encryption service when partition encryption is enabled so its configuration monitoring becomes available.

Bug Fixes:
- Restore overlay DM mode notifications after enabling partition encryption on first boot and support delivery when the file manager starts later.

Enhancements:
- Refactor disk encryption service activation into shared access-control plugin logic and add pending notification handling for disk encryption events.