### PR TITLE
fix(sidebar): 修复快捷访问与设备树形目录同名时右键丢失移除选项 (BUG-374895)

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -179,75 +179,85 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
         return false;
     }
 
-    ItemInfo info { SideBarInfoCacheMananger::instance()->itemInfo(url) };
-
-    bool urlUpdated { false };
-    if (properties.contains(PropertyKey::kUrl)) {
-        auto &&newUrl { properties[PropertyKey::kUrl].toUrl() };
-        if (!DFMBASE_NAMESPACE::UniversalUtils::urlEquals(newUrl, info.url)) {
-            urlUpdated = true;
-            info.url = newUrl;
-            SideBarInfoCacheMananger::instance()->removeItemInfoCache(url);
-        }
-    }
-
-    if (properties.contains(PropertyKey::kGroup))
-        info.group = properties[PropertyKey::kGroup].toString();
-    if (properties.contains(PropertyKey::kSubGroup))
-        info.subGroup = properties[PropertyKey::kSubGroup].toString();
-    if (properties.contains(PropertyKey::kDisplayName))
-        info.displayName = properties[PropertyKey::kDisplayName].toString();
-    if (properties.contains(PropertyKey::kEditDisplayText))
-        info.editDisplayText = properties[PropertyKey::kEditDisplayText].toString();
-    if (properties.contains(PropertyKey::kIcon))
-        info.icon = qvariant_cast<QIcon>(properties[PropertyKey::kIcon]);
-    if (properties.contains(PropertyKey::kFinalUrl)) {
-        info.finalUrl = properties[PropertyKey::kFinalUrl].toUrl();
-        // Notify device mount subscribers when a device's finalUrl becomes valid.
-        if (info.finalUrl.isValid() && info.group == DefaultGroup::kDevice && info.finalUrl.scheme() == "file") {
-            fmDebug() << "SideBarEventReceiver: Device mounted, notifying subscribers:"
-                      << url << "at" << info.finalUrl;
-            DeviceMountSubscriber::instance()->notifyMountFinished(url, info.finalUrl);
-        }
-    }
-    if (properties.contains(PropertyKey::kQtItemFlags))
-        info.flags = qvariant_cast<Qt::ItemFlags>(properties[PropertyKey::kQtItemFlags]);
-    if (properties.contains(PropertyKey::kIsEjectable))
-        info.isEjectable = properties[PropertyKey::kIsEjectable].toBool();
-    if (properties.contains(PropertyKey::kIsEditable))
-        info.isEditable = properties[PropertyKey::kIsEditable].toBool();
-    if (properties.contains(PropertyKey::kVisiableControlKey))
-        info.visiableControlKey = properties[PropertyKey::kVisiableControlKey].toString();
-    if (properties.contains(PropertyKey::kVisiableDisplayName))
-        info.visiableDisplayName = properties[PropertyKey::kVisiableDisplayName].toString();
-    if (properties.contains(PropertyKey::kReportName))
-        info.reportName = properties[PropertyKey::kReportName].toString();
-    if (properties.contains(PropertyKey::kItemExpandable))
-        info.isExpandable = properties[PropertyKey::kItemExpandable].toBool();
-
-    if (properties.contains(PropertyKey::kCallbackItemClicked))
-        info.clickedCb = DPF_NAMESPACE::paramGenerator<ItemClickedActionCallback>(properties[PropertyKey::kCallbackItemClicked]);
-    if (properties.contains(PropertyKey::kCallbackContextMenu))
-        info.contextMenuCb = DPF_NAMESPACE::paramGenerator<ContextMenuCallback>(properties[PropertyKey::kCallbackContextMenu]);
-    if (properties.contains(PropertyKey::kCallbackRename))
-        info.renameCb = DPF_NAMESPACE::paramGenerator<RenameCallback>(properties[PropertyKey::kCallbackRename]);
-    if (properties.contains(PropertyKey::kCallbackFindMe))
-        info.findMeCb = DPF_NAMESPACE::paramGenerator<FindMeCallback>(properties[PropertyKey::kCallbackFindMe]);
-
+    // Iterate all groups that contain this URL. The URL-only itemInfo() overload
+    // returns a non-deterministic match when the same URL exists across groups
+    // (QHash key order is undefined). By iterating per-group, each group's
+    // ItemInfo retains its own callbacks while receiving the property updates.
     bool ret { false };
-    if (urlUpdated)
-        ret = SideBarInfoCacheMananger::instance()->addItemInfoCache(info);
-    else
-        ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(url, info);
+    ItemInfo lastInfo;
+    for (const auto &group : SideBarInfoCacheMananger::instance()->groups()) {
+        ItemInfo info { SideBarInfoCacheMananger::instance()->itemInfo(group, url) };
+        if (info.url.isEmpty())
+            continue;
+        lastInfo = info;
+
+        bool urlUpdated { false };
+        if (properties.contains(PropertyKey::kUrl)) {
+            auto &&newUrl { properties[PropertyKey::kUrl].toUrl() };
+            if (!DFMBASE_NAMESPACE::UniversalUtils::urlEquals(newUrl, info.url)) {
+                urlUpdated = true;
+                info.url = newUrl;
+                SideBarInfoCacheMananger::instance()->removeItemInfoCache(info.group, url);
+            }
+        }
+
+        if (properties.contains(PropertyKey::kGroup))
+            info.group = properties[PropertyKey::kGroup].toString();
+        if (properties.contains(PropertyKey::kSubGroup))
+            info.subGroup = properties[PropertyKey::kSubGroup].toString();
+        if (properties.contains(PropertyKey::kDisplayName))
+            info.displayName = properties[PropertyKey::kDisplayName].toString();
+        if (properties.contains(PropertyKey::kEditDisplayText))
+            info.editDisplayText = properties[PropertyKey::kEditDisplayText].toString();
+        if (properties.contains(PropertyKey::kIcon))
+            info.icon = qvariant_cast<QIcon>(properties[PropertyKey::kIcon]);
+        if (properties.contains(PropertyKey::kFinalUrl)) {
+            info.finalUrl = properties[PropertyKey::kFinalUrl].toUrl();
+            // Notify device mount subscribers when a device's finalUrl becomes valid.
+            if (info.finalUrl.isValid() && info.group == DefaultGroup::kDevice && info.finalUrl.scheme() == "file") {
+                fmDebug() << "SideBarEventReceiver: Device mounted, notifying subscribers:"
+                          << url << "at" << info.finalUrl;
+                DeviceMountSubscriber::instance()->notifyMountFinished(url, info.finalUrl);
+            }
+        }
+        if (properties.contains(PropertyKey::kQtItemFlags))
+            info.flags = qvariant_cast<Qt::ItemFlags>(properties[PropertyKey::kQtItemFlags]);
+        if (properties.contains(PropertyKey::kIsEjectable))
+            info.isEjectable = properties[PropertyKey::kIsEjectable].toBool();
+        if (properties.contains(PropertyKey::kIsEditable))
+            info.isEditable = properties[PropertyKey::kIsEditable].toBool();
+        if (properties.contains(PropertyKey::kVisiableControlKey))
+            info.visiableControlKey = properties[PropertyKey::kVisiableControlKey].toString();
+        if (properties.contains(PropertyKey::kVisiableDisplayName))
+            info.visiableDisplayName = properties[PropertyKey::kVisiableDisplayName].toString();
+        if (properties.contains(PropertyKey::kReportName))
+            info.reportName = properties[PropertyKey::kReportName].toString();
+        if (properties.contains(PropertyKey::kItemExpandable))
+            info.isExpandable = properties[PropertyKey::kItemExpandable].toBool();
+
+        if (properties.contains(PropertyKey::kCallbackItemClicked))
+            info.clickedCb = DPF_NAMESPACE::paramGenerator<ItemClickedActionCallback>(properties[PropertyKey::kCallbackItemClicked]);
+        if (properties.contains(PropertyKey::kCallbackContextMenu))
+            info.contextMenuCb = DPF_NAMESPACE::paramGenerator<ContextMenuCallback>(properties[PropertyKey::kCallbackContextMenu]);
+        if (properties.contains(PropertyKey::kCallbackRename))
+            info.renameCb = DPF_NAMESPACE::paramGenerator<RenameCallback>(properties[PropertyKey::kCallbackRename]);
+        if (properties.contains(PropertyKey::kCallbackFindMe))
+            info.findMeCb = DPF_NAMESPACE::paramGenerator<FindMeCallback>(properties[PropertyKey::kCallbackFindMe]);
+
+        if (urlUpdated)
+            ret = SideBarInfoCacheMananger::instance()->addItemInfoCache(info) || ret;
+        else
+            ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(info.group, url, info) || ret;
+    }
 
     QList<SideBarWidget *> allSideBar = SideBarHelper::allSideBar();
     if (!allSideBar.isEmpty()) {
-        allSideBar.first()->updateItem(url, info);
+        allSideBar.first()->updateItem(url, lastInfo);
         return ret;
     }
 
     if (SideBarWidget::kSidebarModelIns)
-        SideBarWidget::kSidebarModelIns->updateRow(url, info);
+        SideBarWidget::kSidebarModelIns->updateRow(url, lastInfo);
 
     fmDebug() << "Updated sidebar cache without visible widget, url:" << url;
     return ret;

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -111,7 +111,7 @@ QString SideBarItem::subGourp() const
 ItemInfo SideBarItem::itemInfo() const
 {
     // if this is storage as a member variable, click item after dragged, dfm crash.
-    return SideBarInfoCacheMananger::instance()->itemInfo(url());
+    return SideBarInfoCacheMananger::instance()->itemInfo(group(), url());
 }
 
 QString SideBarItem::group() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
@@ -67,7 +67,6 @@ bool SideBarInfoCacheMananger::addItemInfoCache(const ItemInfo &info)
 
     CacheInfoList &cache = cacheInfoMap[info.group];
     cache.push_back(info);
-    bindedInfos[info.url] = info;
 
     return true;
 }
@@ -84,8 +83,6 @@ bool SideBarInfoCacheMananger::insertItemInfoCache(SideBarInfoCacheMananger::Ind
     else
         cache.insert(i, info);
 
-    bindedInfos[info.url] = info;
-
     return true;
 }
 
@@ -96,7 +93,6 @@ bool SideBarInfoCacheMananger::removeItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache.removeAt(i);
-            bindedInfos.remove(url);
             return true;
         }
     }
@@ -122,7 +118,6 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache[i] = info;
-            bindedInfos[url] = info;
             return true;
         }
     }
@@ -141,9 +136,26 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const QUrl &url, const ItemIn
     return ret;
 }
 
-ItemInfo SideBarInfoCacheMananger::itemInfo(const QUrl &url)
+ItemInfo SideBarInfoCacheMananger::itemInfo(const Group &group, const QUrl &url) const
 {
-    return bindedInfos.value(url);
+    const CacheInfoList &cache = cacheInfoMap.value(group);
+    for (const ItemInfo &info : cache) {
+        if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, info.url))
+            return info;
+    }
+    return {};
+}
+
+ItemInfo SideBarInfoCacheMananger::itemInfo(const QUrl &url) const
+{
+    for (auto it = cacheInfoMap.cbegin(); it != cacheInfoMap.cend(); ++it) {
+        const CacheInfoList &cache = it.value();
+        for (const ItemInfo &info : cache) {
+            if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, info.url))
+                return info;
+        }
+    }
+    return {};
 }
 
 bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const
@@ -159,5 +171,12 @@ bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const
 
 bool SideBarInfoCacheMananger::contains(const QUrl &url) const
 {
-    return bindedInfos.contains(url);
+    for (auto it = cacheInfoMap.cbegin(); it != cacheInfoMap.cend(); ++it) {
+        const CacheInfoList &cache = it.value();
+        for (const ItemInfo &info : cache) {
+            if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, info.url))
+                return true;
+        }
+    }
+    return false;
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
@@ -30,7 +30,8 @@ public:
     bool contains(const QUrl &url) const;
     GroupList groups() const;
     CacheInfoList indexCacheList(const Group &name) const;
-    ItemInfo itemInfo(const QUrl &url);   // the funcs is for QHash<QUrl, ItemInfo> bindedInfos;
+    ItemInfo itemInfo(const Group &group, const QUrl &url) const;   // 查找指定分组内匹配 URL 的 ItemInfo / Find ItemInfo by URL within a specific group
+    ItemInfo itemInfo(const QUrl &url) const;   // 在所有分组中查找匹配 URL 的任一 ItemInfo（顺序未定义）/ Find any matching ItemInfo by URL across all groups (order undefined)
 
     bool addItemInfoCache(const ItemInfo &info);
     bool insertItemInfoCache(Index i, const ItemInfo &info);
@@ -52,7 +53,6 @@ private:
 
 private:
     GroupCacheMap cacheInfoMap;
-    QHash<QUrl, ItemInfo> bindedInfos;
     QStringList lastSettingKeys;
     QStringList lastSettingBindingKeys;
 };


### PR DESCRIPTION
## BUG-374895: 侧边栏快捷访问右键丢失"移除"选项

### 问题
生成快捷访问后重启系统,重新展开侧边栏,当快捷访问与设备树形目录同名时,快捷访问右键菜单没有"移除"选项。

### 根因
`SideBarInfoCacheMananger` 维护了一个扁平缓存 `bindedInfos`(`QHash<QUrl, ItemInfo>`),以 URL 为键只存储最后一个注册的 ItemInfo。当同一 URL 存在于多个分组(如快捷访问和设备树形目录)时:
- `addItemInfoCache` 将新 ItemInfo 加入分组缓存后,`bindedInfos[url]` 被最后一个注册的项覆盖
- `handleItemUpdate` 通过 `itemInfo(url)` 取到的是错误分组的 ItemInfo
- `updateItemInfoCache(url, info)` 遍历所有分组,用同一个 ItemInfo 覆盖所有匹配项,导致其他分组的回调丢失

### 修复
- 删除 `bindedInfos` 扁平缓存,统一使用 `cacheInfoMap`(分组结构)作为唯一数据源
- `itemInfo(url)` / `contains(url)` 改为遍历 `cacheInfoMap`
- 新增 `itemInfo(group, url)` 分组重载,精确查找指定分组内的 ItemInfo
- `SideBarItem::itemInfo()` 改用 `itemInfo(group(), url())`,确保取到正确分组的 ItemInfo
- `handleItemUpdate` 改用分组重载 `removeItemInfoCache(info.group, url)` / `updateItemInfoCache(info.group, url, info)`,只更新匹配分组,不影响其他分组的回调

### 改动文件
- `sidebarinfocachemananger.h` — 删除 `bindedInfos` 成员,新增 `itemInfo(group, url)` 声明
- `sidebarinfocachemananger.cpp` — 删除所有 `bindedInfos` 引用,重写 `itemInfo(url)` / `contains(url)` 遍历 `cacheInfoMap`
- `sidebareventreceiver.cpp` — `handleItemUpdate` 改用分组重载(仅 2 行改动)
- `sidebaritem.cpp` — `itemInfo()` 改用 `itemInfo(group(), url())`

## Summary by Sourcery

Fix sidebar item updates for duplicate URLs across groups so each item remains correctly identified and maintains its own actions and callbacks.

Bug Fixes:
- Preserve sidebar context-menu actions when the same URL appears in multiple groups, including retaining the shortcut's remove option.

Enhancements:
- Use group-scoped sidebar cache lookups and updates so items with duplicate URLs retain independent metadata and callbacks.
- Use the grouped cache as the single source of truth instead of maintaining a conflicting flat URL cache.