### PR TITLE
refactor: move sort utility functions to namespace and add error logging

### DIFF
--- a/src/dfm-base/file/local/localdiriterator.cpp
+++ b/src/dfm-base/file/local/localdiriterator.cpp
@@ -249,7 +249,7 @@ QList<SortInfoPointer> LocalDirIterator::sortFileInfoList()
         return {};
 
     d->canceled.storeRelease(false);
-    const QSet<QString> hideList = loadHideFileList(d->rootPath);
+    const QSet<QString> hideList = SortInfoUtils::loadHideFileList(d->rootPath);
 
     DIR *dir = ::opendir(QFile::encodeName(d->rootPath).constData());
     if (!dir) {
@@ -275,7 +275,7 @@ QList<SortInfoPointer> LocalDirIterator::sortFileInfoList()
         if (fileName == "." || fileName == "..")
             continue;
 
-        auto info = createSortInfo(d->rootPath, fileName, hideList);
+        auto info = SortInfoUtils::createSortInfo(d->rootPath, fileName, hideList);
         if (info.isNull())
             continue;
         sortList.append(info);

--- a/src/dfm-base/utils/sortfileinfoutils.cpp
+++ b/src/dfm-base/utils/sortfileinfoutils.cpp
@@ -5,6 +5,7 @@
 #include "sortfileinfoutils.h"
 
 #include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/dfm_log_defines.h>
 
 #include <QDir>
 #include <QFile>
@@ -16,6 +17,8 @@
 #include <unistd.h>
 
 DFMBASE_BEGIN_NAMESPACE
+
+namespace SortInfoUtils {
 
 /**
  * @brief 解析符号链接目标路径
@@ -61,8 +64,10 @@ SortInfoPointer createSortInfo(const QString &parentPath,
     // 使用 statx 获取所有文件属性（包括创建时间 birth time）
     struct statx stx;
     unsigned int mask = STATX_BASIC_STATS | STATX_BTIME;
-    if (statx(AT_FDCWD, nativePath.constData(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &stx) != 0)
+    if (statx(AT_FDCWD, nativePath.constData(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &stx) != 0) {
+        qCWarning(logDFMBase) << "createSortInfo: statx failed for" << entryPath << ":" << strerror(errno);
         return nullptr;
+    }
 
     const bool isSymLink = S_ISLNK(stx.stx_mode);
     mode_t effectiveMode = stx.stx_mode;
@@ -77,13 +82,15 @@ SortInfoPointer createSortInfo(const QString &parentPath,
         if (!targetPath.isEmpty() && !ProtocolUtils::isRemoteFile(QUrl::fromLocalFile(targetPath))) {
             const QByteArray targetNativePath = QFile::encodeName(targetPath);
             struct statx targetStx;
-            if (statx(AT_FDCWD, targetNativePath.constData(), AT_SYMLINK_FOLLOW | AT_NO_AUTOMOUNT, mask, &targetStx) == 0) {
+            if (statx(AT_FDCWD, targetNativePath.constData(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &targetStx) == 0) {
                 effectiveMode = targetStx.stx_mode;
                 effectiveSize = targetStx.stx_size;
                 effectiveAtime = targetStx.stx_atime.tv_sec;
                 effectiveMtime = targetStx.stx_mtime.tv_sec;
                 if (targetStx.stx_mask & STATX_BTIME)
                     effectiveBtime = targetStx.stx_btime.tv_sec;
+            } else {
+                qCWarning(logDFMBase) << "createSortInfo: statx failed for symlink target" << targetPath << ":" << strerror(errno);
             }
         }
     }
@@ -104,5 +111,7 @@ SortInfoPointer createSortInfo(const QString &parentPath,
     info->setInfoCompleted(true);
     return info;
 }
+
+}   // namespace SortInfoUtils
 
 DFMBASE_END_NAMESPACE

--- a/src/dfm-base/utils/sortfileinfoutils.h
+++ b/src/dfm-base/utils/sortfileinfoutils.h
@@ -13,6 +13,8 @@
 
 DFMBASE_BEGIN_NAMESPACE
 
+namespace SortInfoUtils {
+
 /**
  * @brief 加载 .hidden 文件中的隐藏文件列表
  * @param dirPath 目录路径
@@ -33,6 +35,8 @@ QSet<QString> loadHideFileList(const QString &dirPath);
 SortInfoPointer createSortInfo(const QString &parentPath,
                                const QString &fileName,
                                const QSet<QString> &hideList);
+
+}   // namespace SortInfoUtils
 
 DFMBASE_END_NAMESPACE
 

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/traversaldirthreadmanager.cpp
@@ -296,7 +296,7 @@ int TraversalDirThreadManager::iteratorOneByOneByDirent()
         return 0;
     }
 
-    const QSet<QString> hideList = loadHideFileList(dirUrl.path());
+    const QSet<QString> hideList = SortInfoUtils::loadHideFileList(dirUrl.path());
 
     timer.restart();
 
@@ -328,7 +328,7 @@ int TraversalDirThreadManager::iteratorOneByOneByDirent()
         if (fileName == "." || fileName == "..")
             continue;
 
-        auto info = createSortInfo(dirUrl.path(), fileName, hideList);
+        auto info = SortInfoUtils::createSortInfo(dirUrl.path(), fileName, hideList);
         if (info.isNull())
             continue;
         sortList.append(info);


### PR DESCRIPTION
Extracted sort-related utility functions (loadHideFileList and
createSortInfo) into a new SortInfoUtils namespace to improve code
organization and modularity. Added comprehensive error logging using
qCWarning for statx failures to aid debugging of file information
retrieval issues. Fixed a potential bug where symlink target statx
incorrectly used AT_SYMLINK_FOLLOW which would follow symlinks
recursively, changing it to AT_SYMLINK_NOFOLLOW for consistency
with symbolic link handling. Updated all call sites across multiple
components to use the namespaced functions.

Influence:
1. Verify directory listing still works correctly for various file types
2. Test symbolic link handling - ensure both broken and valid links
are processed
3. Check .hidden file functionality continues to work
4. Validate error logging appears in logs for invalid file paths or
permissions issues
5. Confirm sorting behavior remains unchanged with the namespace
refactor
6. Test with files that may trigger statx errors to see warnings in logs

refactor: 将排序工具函数移至命名空间并添加错误日志

将排序相关的工具函数（loadHideFileList 和 createSortInfo）提取到新的
SortInfoUtils 命名空间中，以提高代码组织和模块化。添加了使用 qCWarning
的全面错误日志，用于记录 statx 失败情况，帮助调试文件信息检索问题。修复
了一个潜在错误：符号链接目标的 statx 错误地使用了 AT_SYMLINK_FOLLOW，这
会导致递归跟踪符号链接，现已改为使用 AT_SYMLINK_NOFOLLOW 以保持符号链接
处理的一致性。更新了所有调用点，使其使用命名空间内的函数。

Influence:
1. 验证各种文件类型的目录列表功能是否正常工作
2. 测试符号链接处理 - 确保损坏和有效的链接都被正确处理
3. 检查 .hidden 文件功能是否继续正常工作
4. 验证错误日志是否出现在日志中，用于无效文件路径或权限问题
5. 确认代码重构后排序行为保持不变
6. 测试可能触发 statx 错误的文件，查看日志中的告警信息

## Summary by Sourcery

Refactor sort metadata utilities into a dedicated namespace while improving symlink handling and diagnostics for metadata retrieval failures.

Bug Fixes:
- Correct symlink target metadata handling to avoid recursively following symbolic links.
- Add warnings when file or symlink-target metadata retrieval fails.

Enhancements:
- Organize sorting helpers under the SortInfoUtils namespace and update their callers.