### PR TITLE
fix: add ref-counted CPU quota for index tasks

### DIFF
--- a/src/services/textindex/ocrindexdbus.cpp
+++ b/src/services/textindex/ocrindexdbus.cpp
@@ -5,7 +5,6 @@
 #include "ocrindexdbus.h"
 #include "private/ocrindexdbus_p.h"
 #include "utils/indexutility.h"
-#include "utils/systemdcpuutils.h"
 #include "utils/textindexconfig.h"
 
 #include <QDir>
@@ -45,11 +44,6 @@ void OcrIndexDBusPrivate::initConnect()
 {
     QObject::connect(runtime->taskManager(), &TaskManager::taskFinished,
                      q, [this](const QString &type, const QString &path, bool success) {
-                         QString msg;
-                         fmDebug() << "OcrIndexDBus: Resetting CPU limit after task completion";
-                         if (!SystemdCpuUtils::resetCpuQuota(Defines::kTextIndexServiceName, &msg)) {
-                             fmWarning() << "OcrIndexDBus: Failed to reset CPU quota:" << msg;
-                         }
                          emit q->TaskFinished(type, path, success);
                      });
 

--- a/src/services/textindex/task/indextask.cpp
+++ b/src/services/textindex/task/indextask.cpp
@@ -70,13 +70,8 @@ void IndexTask::throttleCpuUsage()
     fmDebug() << "[IndexTask::throttleCpuUsage] Applying CPU usage limit:" << limit << "% for service:"
               << Defines::kTextIndexServiceName;
 
-    QString msg;
-    if (!SystemdCpuUtils::setCpuQuota(Defines::kTextIndexServiceName, limit, &msg)) {
-        fmWarning() << "[IndexTask::throttleCpuUsage] Failed to set CPU quota:" << msg
-                    << "service:" << Defines::kTextIndexServiceName << "limit:" << limit << "%";
-    } else {
-        fmDebug() << "[IndexTask::throttleCpuUsage] CPU quota applied successfully - limit:" << limit << "%";
-    }
+    SystemdCpuUtils::acquireCpuQuota(Defines::kTextIndexServiceName, limit);
+    fmDebug() << "[IndexTask::throttleCpuUsage] CPU quota acquired successfully - limit:" << limit << "%";
 }
 
 void IndexTask::start()
@@ -190,6 +185,13 @@ void IndexTask::doTask()
     } else {
         fmWarning() << "[IndexTask::doTask] Task failed - type:" << static_cast<int>(m_type)
                     << "path:" << m_path << "corrupted:" << m_indexCorrupted;
+    }
+
+    // Release the CPU quota slot acquired in throttleCpuUsage().
+    // Only silent tasks acquire, so only silent tasks release.
+    // Reference counting ensures the quota is reset only when the last silent task finishes.
+    if (silent()) {
+        SystemdCpuUtils::releaseCpuQuota(Defines::kTextIndexServiceName);
     }
 
     emit finished(m_type, result);

--- a/src/services/textindex/textindexdbus.cpp
+++ b/src/services/textindex/textindexdbus.cpp
@@ -5,7 +5,6 @@
 #include "textindexdbus.h"
 #include "private/textindexdbus_p.h"
 #include "utils/indexutility.h"
-#include "utils/systemdcpuutils.h"
 #include "utils/textindexconfig.h"
 
 #include <QDir>
@@ -36,11 +35,6 @@ void TextIndexDBusPrivate::initConnect()
 {
     QObject::connect(runtime->taskManager(), &TaskManager::taskFinished,
                      q, [this](const QString &type, const QString &path, bool success) {
-                         QString msg;
-                         fmDebug() << "TextIndexDBus: Resetting CPU limit after task completion";
-                         if (!SystemdCpuUtils::resetCpuQuota(Defines::kTextIndexServiceName, &msg)) {
-                             fmWarning() << "TextIndexDBus: Failed to reset CPU quota:" << msg;
-                         }
                          emit q->TaskFinished(type, path, success);
                      });
 

--- a/src/services/textindex/utils/systemdcpuutils.cpp
+++ b/src/services/textindex/utils/systemdcpuutils.cpp
@@ -6,6 +6,7 @@
 #include <QProcess>
 #include <QDebug>
 #include <QStringList>
+#include <mutex>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
@@ -99,6 +100,42 @@ bool resetCpuQuota(const QString &serviceName, QString *errorMsg)
               << "CPUQuota=";   // 设置为空字符串以取消限制
 
     return executeSystemctlCommand(arguments, errorMsg);   // 调用匿名命名空间中的辅助函数
+}
+
+// --- Reference-counted CPU quota for concurrent limited tasks ---
+namespace {
+std::mutex g_cpuQuotaMutex;
+int g_limitedTaskCount = 0;
+}   // anonymous namespace
+
+void acquireCpuQuota(const QString &serviceName, int percentage)
+{
+    std::lock_guard<std::mutex> lock(g_cpuQuotaMutex);
+    if (g_limitedTaskCount == 0) {
+        QString msg;
+        if (!setCpuQuota(serviceName, percentage, &msg)) {
+            fmWarning() << "SystemdCpuUtils: acquireCpuQuota failed to set CPU quota:" << msg;
+        }
+    }
+    ++g_limitedTaskCount;
+    fmDebug() << "SystemdCpuUtils: acquireCpuQuota - active limited tasks:" << g_limitedTaskCount;
+}
+
+void releaseCpuQuota(const QString &serviceName)
+{
+    std::lock_guard<std::mutex> lock(g_cpuQuotaMutex);
+    if (g_limitedTaskCount <= 0) {
+        fmWarning() << "SystemdCpuUtils: releaseCpuQuota called with no active limited tasks";
+        return;
+    }
+    --g_limitedTaskCount;
+    fmDebug() << "SystemdCpuUtils: releaseCpuQuota - active limited tasks:" << g_limitedTaskCount;
+    if (g_limitedTaskCount == 0) {
+        QString msg;
+        if (!resetCpuQuota(serviceName, &msg)) {
+            fmWarning() << "SystemdCpuUtils: releaseCpuQuota failed to reset CPU quota:" << msg;
+        }
+    }
 }
 
 }   // namespace SystemdCpuUtils

--- a/src/services/textindex/utils/systemdcpuutils.h
+++ b/src/services/textindex/utils/systemdcpuutils.h
@@ -29,6 +29,21 @@ bool setCpuQuota(const QString &serviceName, int percentage, QString *errorMsg);
  */
 bool resetCpuQuota(const QString &serviceName, QString *errorMsg);
 
+/**
+ * @brief Acquires a CPU quota slot for a limited (silent) task.
+ *        Uses a reference counter: only the first caller actually sets the quota.
+ * @param serviceName Full service name
+ * @param percentage CPU quota percentage
+ */
+void acquireCpuQuota(const QString &serviceName, int percentage);
+
+/**
+ * @brief Releases a CPU quota slot for a limited (silent) task.
+ *        Only the last caller (counter drops to 0) actually resets the quota.
+ * @param serviceName Full service name
+ */
+void releaseCpuQuota(const QString &serviceName);
+
 }   // namespace SystemdCpuUtils
 
 SERVICETEXTINDEX_END_NAMESPACE


### PR DESCRIPTION
## Root Cause Analysis

The `release/snipe` branch's `SystemdCpuUtils` lacks a reference-counting mechanism for CPU quota management. Both `TextIndexDBus` and `OcrIndexDBus` share the same systemd service (`dde-file-manager-extractor`) and unconditionally call `resetCpuQuota()` on any task completion. When an OCR index update triggers an incremental text index (due to new file creation), the text index completion removes the CPU limit while the OCR index is still running — leaving CPU unrestricted.

Key evidence: `textindexdbus.cpp:39-43` and `ocrindexdbus.cpp:48-52` call `resetCpuQuota()` unconditionally; `indextask.cpp:74` calls `setCpuQuota()` without any reference counting. The `master` branch already has `acquireCpuQuota()`/`releaseCpuQuota()` with reference counting that prevents this issue.

## Fix

Ported the `acquireCpuQuota()`/`releaseCpuQuota()` reference-counting mechanism from the `master` branch. Moved quota release from DBus handlers into `IndexTask::doTask()` (guarded by `silent()`), ensuring acquire/release symmetry. Manual (non-silent) tasks no longer interfere with quota state. The `resetCpuQuota()` calls and unused includes were removed from both DBus handlers.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The reference-counting implementation uses `std::mutex` for thread safety, consistent with the `master` branch's verified approach. `acquire/release` are strictly symmetric: only `silent()` tasks acquire in `throttleCpuUsage()` and release in `doTask()`. Manual tasks neither acquire nor release, leaving the counter untouched.
- The counter has underflow protection (`g_limitedTaskCount <= 0` guard in `releaseCpuQuota`), and original `setCpuQuota`/`resetCpuQuota` APIs are preserved for any existing callers.

### Business Impact Scope

Affected module: full-text search indexing (text index + OCR index). User scenario: during OCR index updates, new file creation triggers incremental text indexing. After this fix, CPU remains limited throughout concurrent indexing operations. Single-task indexing behavior is unchanged. Manual index operations no longer trigger spurious CPU quota resets.

### Verification Suggestion

1. Test OCR index update with concurrent new file creation triggering incremental text index — verify CPU stays limited (<50%) throughout the entire process.
2. Test single silent index task — verify CPU limit is correctly applied and removed after completion.
3. Test manual index task — verify no interference with CPU quota state.

---

## 根因分析

`release/snipe` 分支的 `SystemdCpuUtils` 缺少 CPU 限额的引用计数机制。`TextIndexDBus` 和 `OcrIndexDBus` 共享同一 systemd 服务（`dde-file-manager-extractor`），任何任务完成时都无条件调用 `resetCpuQuota()` 移除 CPU 限额。当 OCR 索引更新过程中新建文件触发增量文本索引时，文本索引完成即移除 CPU 限额，而 OCR 索引仍在运行，导致 CPU 不受限。

关键证据：`textindexdbus.cpp:39-43` 和 `ocrindexdbus.cpp:48-52` 无条件调用 `resetCpuQuota()`；`indextask.cpp:74` 的 `setCpuQuota()` 无引用计数。`master` 分支已有 `acquireCpuQuota()`/`releaseCpuQuota()` 引用计数机制，不存在此问题。

## 修复方案

从 `master` 分支移植 `acquireCpuQuota()`/`releaseCpuQuota()` 引用计数机制。将限额释放从 DBus handler 移至 `IndexTask::doTask()`（仅 silent 任务），确保 acquire/release 严格对称。manual 任务不再干扰限额状态。两个 DBus handler 中的 `resetCpuQuota()` 调用和不再使用的 include 已移除。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低
- 引用计数实现使用 `std::mutex` 保证线程安全，与 `master` 分支已验证的方案一致。acquire/release 严格对称：仅 `silent()` 任务在 `throttleCpuUsage()` 中 acquire，在 `doTask()` 中 release。manual 任务不 acquire 也不 release，不影响计数器。
- 计数器有下溢保护（`releaseCpuQuota` 中 `g_limitedTaskCount <= 0` 守卫），原有 `setCpuQuota`/`resetCpuQuota` API 保留，不影响其他潜在调用方。

### 业务影响范围

受影响模块：全文搜索索引（文本索引 + OCR 索引）。用户场景：OCR 索引更新过程中新建文件触发增量文本索引。修复后，并发索引操作期间 CPU 全程受限。单任务索引行为不变。manual 索引操作不再触发多余的 CPU 限额重置。

### 验证建议

1. 测试 OCR 索引更新过程中新建文件触发增量文本索引——验证全程 CPU 受限（<50%）。
2. 测试单个 silent 索引任务——验证 CPU 限额正确设置和完成后移除。
3. 测试 manual 索引任务——验证不干扰 CPU 限额状态。

PMS: BUG-374847

## Summary by Sourcery

Prevent concurrent indexing tasks from prematurely removing the shared CPU quota.

Bug Fixes:
- Keep CPU quotas active until all concurrent silent indexing tasks finish, preventing one task from removing the limit while another is still running.

Enhancements:
- Centralize CPU quota lifecycle management in index tasks with thread-safe reference counting and ensure manual tasks do not affect quota state.