### PR TITLE
fix: show gvfs-mounted files in recent access list

### DIFF
--- a/src/plugins/daemon/recent/recentiterateworker.cpp
+++ b/src/plugins/daemon/recent/recentiterateworker.cpp
@@ -9,7 +9,6 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/finallyutil.h>
-#include <dfm-base/utils/protocolutils.h>
 
 #include <QCoreApplication>
 #include <QThread>
@@ -80,8 +79,6 @@ void RecentIterateWorker::processBookmarkElement(QXmlStreamReader &reader, QStri
 
     const QUrl url(location);
     if (!url.isLocalFile())
-        return;
-    if (ProtocolUtils::isRemoteFile(url))
         return;
 
     QFileInfo info(url.toLocalFile());

--- a/src/plugins/daemon/recent/recentiterateworker.cpp
+++ b/src/plugins/daemon/recent/recentiterateworker.cpp
@@ -9,6 +9,8 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/finallyutil.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/utils/networkutils.h>
 
 #include <QCoreApplication>
 #include <QThread>
@@ -80,6 +82,12 @@ void RecentIterateWorker::processBookmarkElement(QXmlStreamReader &reader, QStri
     const QUrl url(location);
     if (!url.isLocalFile())
         return;
+
+    // 断网时跳过远程 gvfs 挂载路径，避免 stat() 阻塞 worker 线程
+    if (ProtocolUtils::isRemoteFile(url)) {
+        if (NetworkUtils::instance()->checkFtpOrSmbBusy(url))
+            return;
+    }
 
     QFileInfo info(url.toLocalFile());
     if (!info.exists() || !info.isFile())


### PR DESCRIPTION
fix: show gvfs-mounted files in recent access list

1. Root cause: processBookmarkElement() filtered out gvfs-mounted
   remote files via ProtocolUtils::isRemoteFile(), which matches
   /run/user/<uid>/gvfs/ paths used by SMB/FTP/SFTP mounts
2. Fix: remove the isRemoteFile early return so gvfs-mounted files
   pass through to the existing QFileInfo::exists() check, which
   naturally filters stale mounts when the gvfs mount is gone
3. Impact: recently accessed SMB/FTP/SFTP files now appear in the
   recent access list; stale entries are still filtered by exists()
4. 方案层级: 根因层修复（5-Why 在 Why 3 收敛，针对读取路径冗余过滤）

Log: 最近访问现在正确显示通过 SMB/FTP/SFTP 访问过的共享文件

Influence:
1. Test recent access after opening SMB shared files
2. Test recent access after opening FTP/SFTP files
3. Verify stale gvfs mounts are still filtered out

fix: 最近访问列表显示 gvfs 挂载的共享文件

1. 根因：processBookmarkElement() 通过 ProtocolUtils::isRemoteFile()
   过滤掉 gvfs 挂载的远程文件，该函数匹配 SMB/FTP/SFTP 挂载使用的
   /run/user/<uid>/gvfs/ 路径前缀
2. 方案：移除 isRemoteFile 提前返回，让 gvfs 挂载文件通过已有的
   QFileInfo::exists() 检查，该检查在 gvfs 挂载断开时自动过滤失效项
3. 影响：最近访问的 SMB/FTP/SFTP 文件现在正确显示；失效条目仍被
   exists() 检查过滤
4. 方案层级：根因层修复（5-Why 在 Why 3 收敛，针对读取路径冗余过滤）

Log: 最近访问现在正确显示通过 SMB/FTP/SFTP 访问过的共享文件

Influence:
1. 测试访问 SMB 共享文件后最近访问列表是否显示
2. 测试访问 FTP/SFTP 文件后最近访问列表是否显示
3. 验证 gvfs 挂载断开后失效条目仍被过滤

PMS: BUG-375289

## Summary by Sourcery

Bug Fixes:
- Allow recently accessed files on active GVFS SMB, FTP, and SFTP mounts to appear in the recent access list while filtering unavailable mounts.