### PR TITLE
fix: show gvfs-mounted files in recent access list

### DIFF
--- a/src/plugins/daemon/recent/recentiterateworker.cpp
+++ b/src/plugins/daemon/recent/recentiterateworker.cpp
@@ -9,7 +9,6 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/finallyutil.h>
-#include <dfm-base/utils/protocolutils.h>
 
 #include <QCoreApplication>
 #include <QThread>
@@ -80,8 +79,6 @@ void RecentIterateWorker::processBookmarkElement(QXmlStreamReader &reader, QStri
 
     const QUrl url(location);
     if (!url.isLocalFile())
-        return;
-    if (ProtocolUtils::isRemoteFile(url))
         return;
 
     QFileInfo info(url.toLocalFile());

--- a/src/plugins/daemon/recent/recentiterateworker.cpp
+++ b/src/plugins/daemon/recent/recentiterateworker.cpp
@@ -9,6 +9,8 @@
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/fileutils.h>
 #include <dfm-base/utils/finallyutil.h>
+#include <dfm-base/utils/protocolutils.h>
+#include <dfm-base/utils/networkutils.h>
 
 #include <QCoreApplication>
 #include <QThread>
@@ -80,6 +82,12 @@ void RecentIterateWorker::processBookmarkElement(QXmlStreamReader &reader, QStri
     const QUrl url(location);
     if (!url.isLocalFile())
         return;
+
+    // 断网时跳过远程 gvfs 挂载路径，避免 stat() 阻塞 worker 线程
+    if (ProtocolUtils::isRemoteFile(url)) {
+        if (NetworkUtils::instance()->checkFtpOrSmbBusy(url))
+            return;
+    }
 
     QFileInfo info(url.toLocalFile());
     if (!info.exists() || !info.isFile())


### PR DESCRIPTION
## Cherry-pick to release/snipe

Cherry-pick of #4258 (fix for BUG-375289) onto `release/snipe`.

### 根因

`RecentIterateWorker::processBookmarkElement()` (`recentiterateworker.cpp:84-85`) 中的 `ProtocolUtils::isRemoteFile(url)` 过滤，错误地阻止了通过 gvfs 挂载访问的 SMB/FTP/SFTP 文件出现在最近访问列表中。

### 修复

移除 `isRemoteFile` 过滤（2 行）及不再使用的 `#include`（1 行），共 -3 行。`QFileInfo::exists()` 检查作为安全网过滤失效挂载。

### 影响

SMB/FTP/SFTP/MTP/GPhoto/DAV/NFS 等 gvfs 协议最近访问恢复显示；挂载断开时由 `exists()` 自动过滤；本地文件不受影响。低风险。

### 关联

- 上游 PR: #4258
- PMS bug: https://pms.uniontech.com/bug-view-375289.html

## Summary by Sourcery

Bug Fixes:
- Restore recently accessed files from valid gvfs-mounted remote locations, including SMB, FTP, and SFTP paths, while skipping unavailable or busy remote mounts.