### PR TITLE
fix: sidebar quick access missing remove option on same URL

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -238,7 +238,7 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
     if (urlUpdated)
         ret = SideBarInfoCacheMananger::instance()->addItemInfoCache(info);
     else
-        ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(url, info);
+        ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(info.group, url, info);
 
     QList<SideBarWidget *> allSideBar = SideBarHelper::allSideBar();
     if (!allSideBar.isEmpty()) {

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -111,7 +111,7 @@ QString SideBarItem::subGourp() const
 ItemInfo SideBarItem::itemInfo() const
 {
     // if this is storage as a member variable, click item after dragged, dfm crash.
-    return SideBarInfoCacheMananger::instance()->itemInfo(url());
+    return SideBarInfoCacheMananger::instance()->itemInfo(group(), url());
 }
 
 QString SideBarItem::group() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
@@ -67,7 +67,6 @@ bool SideBarInfoCacheMananger::addItemInfoCache(const ItemInfo &info)
 
     CacheInfoList &cache = cacheInfoMap[info.group];
     cache.push_back(info);
-    bindedInfos[info.url] = info;
 
     return true;
 }
@@ -83,9 +82,6 @@ bool SideBarInfoCacheMananger::insertItemInfoCache(SideBarInfoCacheMananger::Ind
         cache.append(info);
     else
         cache.insert(i, info);
-
-    bindedInfos[info.url] = info;
-
     return true;
 }
 
@@ -96,7 +92,6 @@ bool SideBarInfoCacheMananger::removeItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache.removeAt(i);
-            bindedInfos.remove(url);
             return true;
         }
     }
@@ -122,7 +117,6 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache[i] = info;
-            bindedInfos[url] = info;
             return true;
         }
     }
@@ -143,7 +137,27 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const QUrl &url, const ItemIn
 
 ItemInfo SideBarInfoCacheMananger::itemInfo(const QUrl &url)
 {
-    return bindedInfos.value(url);
+    GroupList &&allGroup = cacheInfoMap.keys();
+    for (const Group &name : allGroup) {
+        const CacheInfoList &cache = cacheInfoMap.value(name);
+        int size = cache.size();
+        for (int i = 0; i != size; i++) {
+            if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url))
+                return cache[i];
+        }
+    }
+    return ItemInfo {};
+}
+
+ItemInfo SideBarInfoCacheMananger::itemInfo(const Group &name, const QUrl &url)
+{
+    const CacheInfoList &cache = cacheInfoMap.value(name);
+    int size = cache.size();
+    for (int i = 0; i != size; i++) {
+        if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url))
+            return cache[i];
+    }
+    return ItemInfo {};
 }
 
 bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const
@@ -159,5 +173,14 @@ bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const
 
 bool SideBarInfoCacheMananger::contains(const QUrl &url) const
 {
-    return bindedInfos.contains(url);
+    GroupList &&allGroup = cacheInfoMap.keys();
+    for (const Group &name : allGroup) {
+        const CacheInfoList &cache = cacheInfoMap.value(name);
+        int size = cache.size();
+        for (int i = 0; i != size; i++) {
+            if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url))
+                return true;
+        }
+    }
+    return false;
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
@@ -30,7 +30,8 @@ public:
     bool contains(const QUrl &url) const;
     GroupList groups() const;
     CacheInfoList indexCacheList(const Group &name) const;
-    ItemInfo itemInfo(const QUrl &url);   // the funcs is for QHash<QUrl, ItemInfo> bindedInfos;
+    ItemInfo itemInfo(const QUrl &url);
+    ItemInfo itemInfo(const Group &name, const QUrl &url);
 
     bool addItemInfoCache(const ItemInfo &info);
     bool insertItemInfoCache(Index i, const ItemInfo &info);
@@ -52,7 +53,6 @@ private:
 
 private:
     GroupCacheMap cacheInfoMap;
-    QHash<QUrl, ItemInfo> bindedInfos;
     QStringList lastSettingKeys;
     QStringList lastSettingBindingKeys;
 };


### PR DESCRIPTION
fix: sidebar quick access missing remove option on same URL

1. Root cause: SideBarInfoCacheMananger maintained a flat
   QHash<QUrl, ItemInfo> bindedInfos keyed by URL alone, so when
   a tree directory and a bookmark quick-access shared the same URL
   the last-written ItemInfo overwrote the other's contextMenuCb
2. Fix: remove bindedInfos entirely, add group-scoped
   itemInfo(Group, QUrl) overload, update SideBarItem and
   handleItemUpdate to use group-scoped lookup in cacheInfoMap
3. Impact: quick-access bookmarks now always get their own
   contextMenuCb with the remove option regardless of same-URL
   items in other groups; 1-arg itemInfo/contains iterate all
   groups for backward compatibility
4. 方案层级: 根因层修复（5-Why 在 Why 3 收敛，针对扁平 URL 缓存无法区分分组的设计缺陷）

fix: 侧边栏快捷访问同名目录右键缺失移除选项

1. 根因：SideBarInfoCacheMananger 维护了以 URL 为唯一键的扁平缓存
   bindedInfos，当树形目录与快捷访问书签 URL 相同时，后写入的
   ItemInfo 覆盖前者的 contextMenuCb，导致右键菜单丢失移除选项
2. 方案：移除 bindedInfos，新增分组维度 itemInfo(Group, QUrl) 重载，
   SideBarItem 和 handleItemUpdate 改用 cacheInfoMap 分组查询
3. 影响：快捷访问书签始终获取自身的 contextMenuCb，不受其他分组
   同名条目影响；1-arg itemInfo/contains 遍历全分组以保持兼容
4. 方案层级：根因层修复（5-Why 在 Why 3 收敛，针对扁平 URL 缓存无法区分分组的设计缺陷）

PMS: BUG-374895

## Summary by Sourcery

Fix sidebar item caching so same-URL entries in different groups maintain independent actions and metadata.

Bug Fixes:
- Preserve the sidebar quick-access remove action when an item shares its URL with an entry in another sidebar group.

Enhancements:
- Use group-scoped sidebar item lookups so entries with identical URLs retain their own metadata and context menus, while keeping URL-only lookup compatibility across groups.