### PR TITLE
fix: sidebar quick access missing remove option on same URL

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -238,7 +238,7 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
     if (urlUpdated)
         ret = SideBarInfoCacheMananger::instance()->addItemInfoCache(info);
     else
-        ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(url, info);
+        ret = SideBarInfoCacheMananger::instance()->updateItemInfoCache(info.group, url, info);
 
     QList<SideBarWidget *> allSideBar = SideBarHelper::allSideBar();
     if (!allSideBar.isEmpty()) {

--- a/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treeviews/sidebaritem.cpp
@@ -111,7 +111,7 @@ QString SideBarItem::subGourp() const
 ItemInfo SideBarItem::itemInfo() const
 {
     // if this is storage as a member variable, click item after dragged, dfm crash.
-    return SideBarInfoCacheMananger::instance()->itemInfo(url());
+    return SideBarInfoCacheMananger::instance()->itemInfo(group(), url());
 }
 
 QString SideBarItem::group() const

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
@@ -67,7 +67,6 @@ bool SideBarInfoCacheMananger::addItemInfoCache(const ItemInfo &info)
 
     CacheInfoList &cache = cacheInfoMap[info.group];
     cache.push_back(info);
-    bindedInfos[info.url] = info;
 
     return true;
 }
@@ -83,9 +82,6 @@ bool SideBarInfoCacheMananger::insertItemInfoCache(SideBarInfoCacheMananger::Ind
         cache.append(info);
     else
         cache.insert(i, info);
-
-    bindedInfos[info.url] = info;
-
     return true;
 }
 
@@ -96,7 +92,6 @@ bool SideBarInfoCacheMananger::removeItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache.removeAt(i);
-            bindedInfos.remove(url);
             return true;
         }
     }
@@ -122,7 +117,6 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const SideBarInfoCacheManange
     for (int i = 0; i != size; i++) {
         if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url)) {
             cache[i] = info;
-            bindedInfos[url] = info;
             return true;
         }
     }
@@ -143,7 +137,27 @@ bool SideBarInfoCacheMananger::updateItemInfoCache(const QUrl &url, const ItemIn
 
 ItemInfo SideBarInfoCacheMananger::itemInfo(const QUrl &url)
 {
-    return bindedInfos.value(url);
+    GroupList &&allGroup = cacheInfoMap.keys();
+    for (const Group &name : allGroup) {
+        const CacheInfoList &cache = cacheInfoMap.value(name);
+        int size = cache.size();
+        for (int i = 0; i != size; i++) {
+            if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url))
+                return cache[i];
+        }
+    }
+    return ItemInfo {};
+}
+
+ItemInfo SideBarInfoCacheMananger::itemInfo(const Group &name, const QUrl &url)
+{
+    const CacheInfoList &cache = cacheInfoMap.value(name);
+    int size = cache.size();
+    for (int i = 0; i != size; i++) {
+        if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url))
+            return cache[i];
+    }
+    return ItemInfo {};
 }
 
 bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const
@@ -159,5 +173,14 @@ bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const
 
 bool SideBarInfoCacheMananger::contains(const QUrl &url) const
 {
-    return bindedInfos.contains(url);
+    GroupList &&allGroup = cacheInfoMap.keys();
+    for (const Group &name : allGroup) {
+        const CacheInfoList &cache = cacheInfoMap.value(name);
+        int size = cache.size();
+        for (int i = 0; i != size; i++) {
+            if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url))
+                return true;
+        }
+    }
+    return false;
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
@@ -30,7 +30,8 @@ public:
     bool contains(const QUrl &url) const;
     GroupList groups() const;
     CacheInfoList indexCacheList(const Group &name) const;
-    ItemInfo itemInfo(const QUrl &url);   // the funcs is for QHash<QUrl, ItemInfo> bindedInfos;
+    ItemInfo itemInfo(const QUrl &url);
+    ItemInfo itemInfo(const Group &name, const QUrl &url);
 
     bool addItemInfoCache(const ItemInfo &info);
     bool insertItemInfoCache(Index i, const ItemInfo &info);
@@ -52,7 +53,6 @@ private:
 
 private:
     GroupCacheMap cacheInfoMap;
-    QHash<QUrl, ItemInfo> bindedInfos;
     QStringList lastSettingKeys;
     QStringList lastSettingBindingKeys;
 };


### PR DESCRIPTION
Cherry-pick of #4264 to release/snipe

**PMS: BUG-374895**

Root cause: SideBarInfoCacheMananger flat bindedInfos cache keyed by URL alone caused same-URL items across groups to overwrite each other's contextMenuCb, removing the "remove" option from quick-access bookmarks.

Fix: remove bindedInfos, add group-scoped itemInfo(Group, QUrl) overload.

## Summary by Sourcery

Fix sidebar item caching so same-URL entries in different groups retain their independent actions.

Bug Fixes:
- Preserve the correct context for sidebar items that share the same URL across different groups, restoring the remove option for quick-access bookmarks.

Enhancements:
- Use group-scoped sidebar item lookups and updates instead of a URL-only secondary cache.