### PR TITLE
fix: scope sidebar item update to group on rename

### DIFF
--- a/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
+++ b/src/plugins/common/dfmplugin-bookmark/controller/bookmarkmanager.cpp
@@ -564,7 +564,8 @@ void BookMarkManager::fileRenamed(const QUrl &oldUrl, const QUrl &newUrl)
 
             QVariantMap map {
                 { "Property_Key_Url", newUrl },
-                { "Property_Key_Editable", true }
+                { "Property_Key_Editable", true },
+                { "Property_Key_Group", "Group_Common" }
             };
             dpfSlotChannel->push("dfmplugin_sidebar", "slot_Item_Update", oldUrl, map);
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/events/sidebareventreceiver.cpp
@@ -174,12 +174,17 @@ bool SideBarEventReceiver::handleItemRemove(const QUrl &url)
 
 bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &properties)
 {
-    if (!SideBarInfoCacheMananger::instance()->contains(url)) {
+    bool hasGroup = properties.contains(PropertyKey::kGroup);
+    QString group = hasGroup ? properties[PropertyKey::kGroup].toString() : QString();
+
+    auto *cacheMgr = SideBarInfoCacheMananger::instance();
+    bool found = hasGroup ? cacheMgr->contains(group, url) : cacheMgr->contains(url);
+    if (!found) {
         fmWarning() << "Item not found in cache for update, url:" << url;
         return false;
     }
 
-    ItemInfo info { SideBarInfoCacheMananger::instance()->itemInfo(url) };
+    ItemInfo info = hasGroup ? cacheMgr->itemInfo(group, url) : cacheMgr->itemInfo(url);
 
     bool urlUpdated { false };
     if (properties.contains(PropertyKey::kUrl)) {
@@ -187,7 +192,10 @@ bool SideBarEventReceiver::handleItemUpdate(const QUrl &url, const QVariantMap &
         if (!DFMBASE_NAMESPACE::UniversalUtils::urlEquals(newUrl, info.url)) {
             urlUpdated = true;
             info.url = newUrl;
-            SideBarInfoCacheMananger::instance()->removeItemInfoCache(url);
+            if (hasGroup)
+                cacheMgr->removeItemInfoCache(group, url);
+            else
+                cacheMgr->removeItemInfoCache(url);
         }
     }
 

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.cpp
@@ -171,6 +171,17 @@ bool SideBarInfoCacheMananger::contains(const ItemInfo &info) const
     return false;
 }
 
+bool SideBarInfoCacheMananger::contains(const SideBarInfoCacheMananger::Group &name, const QUrl &url) const
+{
+    const CacheInfoList &cache = cacheInfoMap.value(name);
+    int size = cache.size();
+    for (int i = 0; i != size; i++) {
+        if (DFMBASE_NAMESPACE::UniversalUtils::urlEquals(url, cache[i].url))
+            return true;
+    }
+    return false;
+}
+
 bool SideBarInfoCacheMananger::contains(const QUrl &url) const
 {
     GroupList &&allGroup = cacheInfoMap.keys();

--- a/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/utils/sidebarinfocachemananger.h
@@ -28,6 +28,7 @@ public:
 
     bool contains(const ItemInfo &info) const;
     bool contains(const QUrl &url) const;
+    bool contains(const Group &name, const QUrl &url) const;
     GroupList groups() const;
     CacheInfoList indexCacheList(const Group &name) const;
     ItemInfo itemInfo(const QUrl &url);


### PR DESCRIPTION
## Root Cause Analysis

When a sidebar tree directory expansion (Group_Device) and a bookmark quick-access entry (Group_Common) share the same URL, `handleItemUpdate` in `sidebareventreceiver.cpp` used group-agnostic cache operations — `contains(url)`, `itemInfo(url)`, and `removeItemInfoCache(url)` — which traverse all groups. On rename, `removeItemInfoCache(url)` deleted the cache entry from ALL groups (including the bookmark's Group_Common entry), and `itemInfo(url)` returned the first match from any group (possibly Group_Device's data). This caused the bookmark's icon/callback data to be lost and the wrong display name to appear. The preceding fix commit `9b07a2027` (BUG-374895) introduced group-scoped overloads but missed three call sites in `handleItemUpdate` and the missing `kGroup` in `fileRenamed`.

Key evidence:
- `sidebareventreceiver.cpp:177,182,190` — `contains(url)`, `itemInfo(url)`, `removeItemInfoCache(url)` all use global overloads
- `bookmarkmanager.cpp:565-568` — `fileRenamed` sends `slot_Item_Update` without `Property_Key_Group`

## Fix

When `kGroup` is present in the update properties, `handleItemUpdate` now uses group-scoped overloads (`contains(group, url)`, `itemInfo(group, url)`, `removeItemInfoCache(group, url)`) to touch only the specified group's cache entry. A new `contains(Group, Url)` overload was added to `SideBarInfoCacheMananger` (the other two group-scoped overloads already existed). `BookMarkManager::fileRenamed` now passes `kGroup=DefaultGroup::kCommon` with the update. When `kGroup` is absent, the original global path is used — fully backward compatible.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Medium
- The fix modifies `handleItemUpdate`'s internal data flow (global → group-scoped operations when `kGroup` is present) but changes no function signatures. All 10+ other `slot_Item_Update` callers omit `kGroup` and fall through to the original global path with zero behavior change.
- The group-scoped `itemInfo(Group, QUrl)` and `removeItemInfoCache(Group, QUrl)` overloads already exist (introduced by `9b07a2027`); only `contains(Group, QUrl)` is newly added.
- The existing unit test `HandleItemUpdate_NotFound` (which passes no `kGroup`) remains compatible — it hits the original global `contains(url)` stub and returns false as before.
- Three related PMS bugs (374895, 342329, 335293) were checked; none of their fixes are reverted. 374895's fix is directly complemented by this change.

### Business Impact Scope

- **Quick Access (Bookmarks)**: Renaming a bookmarked directory now correctly updates only the Group_Common cache entry, preserving icon and display name. This is the bug fix itself.
- **Sidebar Tree Expansion**: Expanded tree sub-items (Group_Device) are no longer erroneously deleted when a co-URL'd quick-access entry is renamed.
- **All other sidebar update paths** (device mount/unmount, SMB shares, tags, recent files, trash, vault): No behavior change — they don't pass `kGroup`.

### Verification Suggestion

Primary: expand a sidebar directory, add the same folder to quick access, rename it twice — verify icon and name stay correct. Regression: verify other sidebar update scenarios (bookmark add/remove, device mount, SMB, tag color) still work, and that BUG-374895's "remove" context menu still appears for co-URL'd items.

---

## 根因分析

当侧边栏树形目录展开项（Group_Device）与快捷访问书签项（Group_Common）共用同一 URL 时，`sidebareventreceiver.cpp` 中的 `handleItemUpdate` 使用了不限分组的缓存操作——`contains(url)`、`itemInfo(url)`、`removeItemInfoCache(url)`——这些操作遍历所有分组。重命名时，`removeItemInfoCache(url)` 删除了所有分组中的同 URL 缓存条目（包括书签的 Group_Common 条目），而 `itemInfo(url)` 返回的是任意分组的第一个匹配（可能是 Group_Device 的数据）。这导致书签的图标/回调数据丢失，显示名称错误。前序修复提交 `9b07a2027`（BUG-374895）已引入分组限定重载，但遗漏了 `handleItemUpdate` 中的三处调用和 `fileRenamed` 中缺失的 `kGroup`。

关键证据：
- `sidebareventreceiver.cpp:177,182,190` — `contains(url)`、`itemInfo(url)`、`removeItemInfoCache(url)` 均使用全局重载
- `bookmarkmanager.cpp:565-568` — `fileRenamed` 发送 `slot_Item_Update` 时未携带 `Property_Key_Group`

## 修复方案

当更新属性中包含 `kGroup` 时，`handleItemUpdate` 改用分组限定重载（`contains(group, url)`、`itemInfo(group, url)`、`removeItemInfoCache(group, url)`），仅操作指定分组的缓存条目。为 `SideBarInfoCacheMananger` 新增 `contains(Group, Url)` 重载（其余两个分组限定重载已存在）。`BookMarkManager::fileRenamed` 现在传入 `kGroup=DefaultGroup::kCommon`。当不传 `kGroup` 时走原全局路径，完全向后兼容。

## 改动安全评估

### 代码安全评估

- **风险等级**: 中风险
- 修复修改了 `handleItemUpdate` 的内部数据流（携带 `kGroup` 时从全局操作改为分组限定操作），但未改变任何函数签名。其余 10+ 个 `slot_Item_Update` 调用方均不传 `kGroup`，走原全局路径，行为零变化。
- 分组限定的 `itemInfo(Group, QUrl)` 和 `removeItemInfoCache(Group, QUrl)` 重载已由 `9b07a2027` 引入，本次仅新增 `contains(Group, QUrl)`。
- 现有单元测试 `HandleItemUpdate_NotFound`（不传 `kGroup`）仍兼容——命中原全局 `contains(url)` 桩函数，返回 false 不变。
- 已检查三个关联 PMS bug（374895、342329、335293），均不受本次改动破坏。374895 的修复由本次改动直接补全。

### 业务影响范围

- **快捷访问（书签）**：重命名书签目录时仅更新 Group_Common 缓存条目，图标和显示名称正确保留。此即 bug 修复本身。
- **侧边栏树形目录展开**：展开的树形子项（Group_Device）在快捷访问项重命名时不再被误删。
- **其他侧边栏更新路径**（设备挂载/卸载、SMB 共享、标签、最近使用、回收站、保险箱）：无行为变化——不传 `kGroup`。

### 验证建议

主要验证：展开侧边栏目录，将同一文件夹添加到快捷访问，连续重命名两次——验证图标和名称正确。回归验证：其他侧边栏更新场景（书签添加/移除、设备挂载、SMB、标签颜色）正常，BUG-374895 的同名右键"移除"选项仍存在。

## Summary by Sourcery

Prevent sidebar cache corruption during bookmark renames by applying updates only to the relevant group when one is specified.

Bug Fixes:
- Scope sidebar cache updates to the specified group so renaming co-located bookmark and tree entries no longer removes or uses data from the wrong group.
- Include the common group when propagating bookmark rename updates.

Enhancements:
- Preserve the existing group-agnostic update behavior for callers that do not provide a group.