### PR TITLE
fix(at-spi): add accessible names for custom view widgets

### DIFF
--- a/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
+++ b/src/plugins/desktop/ddplugin-canvas/view/canvasview.cpp
@@ -35,6 +35,8 @@ using namespace GlobalDConfDefines::BaseConfig;
 CanvasView::CanvasView(QWidget *parent)
     : QAbstractItemView(parent), d(new CanvasViewPrivate(this))
 {
+    setObjectName("dd_canvas_view");
+    setAccessibleName("dd_canvas_view");
 }
 
 QRect CanvasView::visualRect(const QModelIndex &index) const

--- a/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
+++ b/src/plugins/desktop/ddplugin-organizer/view/collectionview.cpp
@@ -1225,6 +1225,7 @@ CollectionView::CollectionView(const QString &uuid, CollectionDataProvider *data
     d->initUI();
     d->initConnect();
     setObjectName("dd_collection_view");
+    setAccessibleName("dd_collection_view");
 }
 
 CollectionView::~CollectionView()

--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -69,6 +69,8 @@ using namespace GlobalDConfDefines::BaseConfig;
 FileView::FileView(const QUrl &url, QWidget *parent)
     : DListView(parent), d(new FileViewPrivate(this))
 {
+    setObjectName("dd_file_view");
+    setAccessibleName("dd_file_view");
     d->url = url;
     setMinimumHeight(10);
     setDragDropMode(QAbstractItemView::DragDrop);

--- a/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/headerview.cpp
@@ -26,6 +26,8 @@ HeaderView::HeaderView(Qt::Orientation orientation, FileView *parent)
     : QHeaderView(orientation, parent),
       view(parent)
 {
+    setObjectName("dd_file_view_header");
+    setAccessibleName("dd_file_view_header");
     fmInfo() << "Creating HeaderView with orientation:" << (orientation == Qt::Horizontal ? "Horizontal" : "Vertical");
 
     setHighlightSections(false);


### PR DESCRIPTION
## Summary

Add `setObjectName`/`setAccessibleName` to 4 custom view widget constructors that were missing AT-SPI accessibility names.

These custom `QAbstractItemView`/`QHeaderView` subclasses were invisible to the AT-SPI coverage scanner because the custom types are absent from its type database. This is a proactive fix ("强制处理") beyond the scanner-reported gaps.

## Changes

| Widget | File | Added |
|--------|------|-------|
| CanvasView | `ddplugin-canvas/view/canvasview.cpp` | `setObjectName` + `setAccessibleName` |
| CollectionView | `ddplugin-organizer/view/collectionview.cpp` | `setAccessibleName` (already had `setObjectName`) |
| FileView | `dfmplugin-workspace/views/fileview.cpp` | `setObjectName` + `setAccessibleName` |
| HeaderView | `dfmplugin-workspace/views/headerview.cpp` | `setObjectName` + `setAccessibleName` |

## Context

Multica issue V-3176: AT-SPI-文件管理器-核对补全

## Summary by Sourcery

Bug Fixes:
- Add AT-SPI object and accessible names to custom canvas, collection, file, and header view widgets.