### PR TITLE
fix(accesscontrol): activate diskencrypt service when enableEncrypt flips to true

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.cpp
@@ -19,6 +19,10 @@
 #include <QDBusInterface>
 #include <QDBusPendingCall>
 #include <QDBusReply>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTimer>
 
 #include <DDialog>
 #include <DDBusSender>
@@ -74,6 +78,41 @@ void EventsHandler::hookEvents()
 {
     dpfHookSequence->follow("dfmplugin_computer", "hook_Device_AcquireDevPwd",
                             this, &EventsHandler::onAcquireDevicePwd);
+}
+
+void EventsHandler::checkPendingOverlayDMNotify()
+{
+    QFile file(disk_encrypt::kOverlayDMNotifyFile);
+    if (!file.exists()) {
+        fmInfo() << "No pending overlay DM notification file found";
+        return;
+    }
+
+    if (!file.open(QIODevice::ReadOnly)) {
+        fmWarning() << "Failed to open pending notification file:" << disk_encrypt::kOverlayDMNotifyFile;
+        return;
+    }
+
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &parseError);
+    file.close();
+
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+        fmWarning() << "Failed to parse pending notification JSON:" << parseError.errorString();
+        QFile::remove(disk_encrypt::kOverlayDMNotifyFile);
+        return;
+    }
+
+    QJsonObject obj = doc.object();
+    bool enabled = obj.value("enabled").toBool();
+    int result = obj.value("result").toInt();
+
+    QFile::remove(disk_encrypt::kOverlayDMNotifyFile);
+    fmInfo() << "Found pending overlay DM notification, enabled:" << enabled << "result:" << result;
+
+    QTimer::singleShot(2000, this, [this, enabled, result]() {
+        onOverlayDMModeChanged(enabled, result);
+    });
 }
 
 /**
@@ -723,6 +762,8 @@ void EventsHandler::setAutoStartDFM(bool enable)
 void EventsHandler::onOverlayDMModeChanged(bool enabled, int result)
 {
     fmInfo() << "Overlay DM mode changed, enabled:" << enabled << "result:" << result;
+
+    QFile::remove(disk_encrypt::kOverlayDMNotifyFile);
 
     QString title, message, icon;
 

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/events/eventshandler.h
@@ -18,6 +18,7 @@ public:
     static EventsHandler *instance();
     void bindDaemonSignals();
     void hookEvents();
+    void checkPendingOverlayDMNotify();
     bool isTaskWorking();
     bool hasPendingTask();
     QString unfinishedDecryptJob();

--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/plugin_diskencryptentry.cpp
@@ -71,6 +71,7 @@ void DiskEncryptEntry::initEncryptEvents()
 
     EventsHandler::instance()->bindDaemonSignals();
     EventsHandler::instance()->hookEvents();
+    EventsHandler::instance()->checkPendingOverlayDMNotify();
 
     QString decJob = EventsHandler::instance()->unfinishedDecryptJob();
     if (!decJob.isEmpty() && !EventsHandler::instance()->isTaskWorking()) {

--- a/src/services/accesscontrol/plugin.cpp
+++ b/src/services/accesscontrol/plugin.cpp
@@ -3,10 +3,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "accesscontroldbus.h"
+#include <DConfig>
 #include <QDBusInterface>
+#include <QPointer>
 #include <QtConcurrent>
 
 static AccessControlDBus *accessControlServer = nullptr;
+static QPointer<Dtk::Core::DConfig> diskEncryptConfig;
+
+static void activateDiskEncryptService()
+{
+    auto r = QtConcurrent::run([] {
+        QDBusInterface iface("org.deepin.Filemanager.DiskEncrypt",
+                             "/org/deepin/Filemanager/DiskEncrypt",
+                             "org.deepin.Filemanager.DiskEncrypt",
+                             QDBusConnection::systemBus());
+        iface.call("IsTaskEmpty");
+    });
+    Q_UNUSED(r);
+}
 
 extern "C" int DSMRegister(const char *name, void *data)
 {
@@ -16,14 +31,26 @@ extern "C" int DSMRegister(const char *name, void *data)
     // deepin-service-manager 无法在启动时将加密服务拉起，即便加密服务设置了常驻
     // 但加密服务需要在启动时被拉起来，以便能够合并/更新 crypttab 文件
     // 在此处拉起有点脏但暂时没有更好的方法达到目的
-    auto r = QtConcurrent::run([] {
-        QDBusInterface iface("org.deepin.Filemanager.DiskEncrypt",
-                             "/org/deepin/Filemanager/DiskEncrypt",
-                             "org.deepin.Filemanager.DiskEncrypt",
-                             QDBusConnection::systemBus());
-        iface.call("IsTaskEmpty");
-    });
-    Q_UNUSED(r);
+    activateDiskEncryptService();
+
+    // 监听 enableEncrypt 配置变更：当分区加密由关闭切换为开启时，
+    // 磁盘加密服务因 main() 中的 enableEncrypt 门控而未运行，
+    // 此处主动通过 DBus 激活拉起服务，使其建立 useOverlayDMMode 的 DConfig 监听
+    diskEncryptConfig = Dtk::Core::DConfig::create("org.deepin.dde.file-manager",
+                                                   "org.deepin.dde.file-manager.diskencrypt");
+    if (diskEncryptConfig && diskEncryptConfig->isValid()) {
+        QObject::connect(diskEncryptConfig, &Dtk::Core::DConfig::valueChanged,
+                         diskEncryptConfig, [](const QString &key) {
+            if (key != "enableEncrypt")
+                return;
+            if (diskEncryptConfig->value("enableEncrypt", false).toBool()) {
+                qInfo() << "[AccessControl] enableEncrypt changed to true, activating disk encrypt service";
+                activateDiskEncryptService();
+            }
+        });
+    } else {
+        qWarning() << "[AccessControl] failed to create valid DConfig for disk encrypt monitoring";
+    }
 
     return 0;
 }
@@ -34,5 +61,7 @@ extern "C" int DSMUnRegister(const char *name, void *data)
     (void)data;
     accessControlServer->deleteLater();
     accessControlServer = nullptr;
+    if (diskEncryptConfig)
+        diskEncryptConfig->deleteLater();
     return 0;
 }

--- a/src/services/diskencrypt/dbus/diskencryptsetup.cpp
+++ b/src/services/diskencrypt/dbus/diskencryptsetup.cpp
@@ -9,6 +9,7 @@
 #include "workers/cryptworkers.h"
 #include "helpers/jobfilehelper.h"
 #include "helpers/notificationhelper.h"
+#include "helpers/overlaydmnotifyhelper.h"
 #include "helpers/crypttabhelper.h"
 #include "helpers/commonhelper.h"
 #include "helpers/filesystemhelper.h"
@@ -1029,6 +1030,9 @@ void DiskEncryptSetupPrivate::onOverlayDMModeChangeFinished(bool success, bool t
     // Emit DBus signal to notify upper layer application
     qInfo() << "[DiskEncryptSetupPrivate::onOverlayDMModeChangeFinished] Emitting DBus signal, enabled:" << targetValue
             << "result code:" << resultCode;
+
+    OverlayDMNotifyHelper::instance()->ensureNotificationDelivery(targetValue, resultCode);
+
     Q_EMIT qptr->OverlayDMModeChanged(targetValue, resultCode);
 
     // Check if there's a pending config change

--- a/src/services/diskencrypt/globaltypesdefine.h
+++ b/src/services/diskencrypt/globaltypesdefine.h
@@ -32,6 +32,9 @@ inline constexpr char kOverlayDMSettingsDir[] { "/etc/usec-crypt/settings" };
 inline constexpr char kOverlayDMFlagFile[] { "/etc/usec-crypt/settings/overlay-dm" };
 inline constexpr char kOverlayDMPendingFile[] { "/etc/usec-crypt/settings/overlay-dm.pending" };
 
+inline constexpr char kOverlayDMNotifyDir[] { "/tmp/dfm-overlay-dm-notify" };
+inline constexpr char kOverlayDMNotifyFile[] { "/tmp/dfm-overlay-dm-notify/pending.json" };
+
 // Overlay DM Mode change result codes (shared by service and plugin)
 enum OverlayDMModeChangeResult {
     OverlayDMSuccess = 0,                  // Operation succeeded, reboot required

--- a/src/services/diskencrypt/helpers/overlaydmnotifyhelper.cpp
+++ b/src/services/diskencrypt/helpers/overlaydmnotifyhelper.cpp
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "overlaydmnotifyhelper.h"
+#include "globaltypesdefine.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QProcess>
+#include <QDateTime>
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+FILE_ENCRYPT_USE_NS
+
+OverlayDMNotifyHelper *OverlayDMNotifyHelper::instance()
+{
+    static OverlayDMNotifyHelper ins;
+    return &ins;
+}
+
+OverlayDMNotifyHelper::OverlayDMNotifyHelper(QObject *parent)
+    : QObject(parent)
+{
+}
+
+OverlayDMNotifyHelper::ActiveUser OverlayDMNotifyHelper::findActiveGraphicalUser()
+{
+    ActiveUser user;
+
+    QProcess loginctl;
+    loginctl.start("loginctl", { "list-sessions", "--no-legend" });
+    if (!loginctl.waitForFinished(5000)) {
+        qWarning() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] loginctl list-sessions timed out";
+        loginctl.kill();
+        return user;
+    }
+
+    const QString output = QString::fromUtf8(loginctl.readAllStandardOutput());
+    const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+
+    for (const QString &line : lines) {
+        const QStringList parts = line.simplified().split(' ', Qt::SkipEmptyParts);
+        if (parts.size() < 4)
+            continue;
+
+        const QString &sessionId = parts[0];
+
+        QProcess show;
+        show.start("loginctl", { "show-session", sessionId, "-p", "Active", "-p", "Type", "-p", "Name", "-p", "User" });
+        if (!show.waitForFinished(5000)) {
+            qWarning() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] show-session timed out for session:" << sessionId;
+            show.kill();
+            continue;
+        }
+
+        const QString showOutput = QString::fromUtf8(show.readAllStandardOutput());
+        const QStringList propLines = showOutput.split('\n', Qt::SkipEmptyParts);
+
+        QHash<QString, QString> props;
+        for (const QString &propLine : propLines) {
+            const int eq = propLine.indexOf('=');
+            if (eq < 0)
+                continue;
+            const QString key = propLine.left(eq).simplified();
+            const QString val = propLine.mid(eq + 1).simplified();
+            props[key] = val;
+        }
+
+        if (!props.contains("Active") || !props.contains("Type")
+            || !props.contains("Name") || !props.contains("User"))
+            continue;
+
+        const QString &active = props.value("Active");
+        const QString &type = props.value("Type");
+        const QString &username = props.value("Name");
+        const QString &uidStr = props.value("User");
+
+        if (active != "yes")
+            continue;
+        if (type != "wayland" && type != "x11")
+            continue;
+
+        bool ok = false;
+        uint uid = uidStr.toUInt(&ok);
+        if (!ok || uid == 0)
+            continue;
+
+        user.uid = uid;
+        user.username = username;
+        user.valid = true;
+
+        qInfo() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] Found active graphical user:" << username << "UID:" << uid;
+        return user;
+    }
+
+    qInfo() << "[OverlayDMNotifyHelper::findActiveGraphicalUser] No active graphical session found";
+    return user;
+}
+
+bool OverlayDMNotifyHelper::isFileManagerRunning(uint uid)
+{
+    QProcess pgrep;
+    pgrep.start("pgrep", { "-u", QString::number(uid), "-x", "dde-file-manager" });
+    if (!pgrep.waitForFinished(5000)) {
+        qWarning() << "[OverlayDMNotifyHelper::isFileManagerRunning] pgrep timed out";
+        pgrep.kill();
+        return false;
+    }
+
+    bool running = (pgrep.exitCode() == 0);
+    qInfo() << "[OverlayDMNotifyHelper::isFileManagerRunning] UID:" << uid << "file manager running:" << running;
+    return running;
+}
+
+void OverlayDMNotifyHelper::launchFileManager(uint uid, const QString &username)
+{
+    qInfo() << "[OverlayDMNotifyHelper::launchFileManager] Launching file manager for user:" << username << "UID:" << uid;
+
+    const QString busAddr = QString("unix:path=/run/user/%1/bus").arg(uid);
+
+    QProcess process;
+    process.setProgram("runuser");
+    process.setArguments({ "-u", username, "--",
+                           "env", QString("DBUS_SESSION_BUS_ADDRESS=%1").arg(busAddr),
+                           "/usr/libexec/dde-file-manager", "-d" });
+
+    qint64 pid = 0;
+    if (process.startDetached(&pid)) {
+        qInfo() << "[OverlayDMNotifyHelper::launchFileManager] File manager launched, PID:" << pid;
+    } else {
+        qWarning() << "[OverlayDMNotifyHelper::launchFileManager] Failed to launch file manager:" << process.errorString();
+    }
+}
+
+void OverlayDMNotifyHelper::writePendingFile(bool enabled, int result, const ActiveUser &user)
+{
+    QDir dir(disk_encrypt::kOverlayDMNotifyDir);
+    if (!dir.exists()) {
+        if (!dir.mkpath(disk_encrypt::kOverlayDMNotifyDir)) {
+            qWarning() << "[OverlayDMNotifyHelper::writePendingFile] Failed to create directory:" << disk_encrypt::kOverlayDMNotifyDir;
+            return;
+        }
+        chmod(disk_encrypt::kOverlayDMNotifyDir, 0755);
+        if (user.valid) {
+            chown(disk_encrypt::kOverlayDMNotifyDir, user.uid, user.uid);
+        }
+    }
+
+    struct stat st;
+    if (lstat(disk_encrypt::kOverlayDMNotifyDir, &st) == 0) {
+        if (S_ISLNK(st.st_mode)) {
+            qWarning() << "[OverlayDMNotifyHelper::writePendingFile] Notify dir is a symlink, aborting for safety";
+            return;
+        }
+    }
+
+    // Remove stale pending file so the plugin won't re-process old notifications.
+    unlink(disk_encrypt::kOverlayDMNotifyFile);
+
+    // O_NOFOLLOW prevents symlink attacks: if an attacker places a symlink at the
+    // notify path, open() fails with ELOOP instead of following it to a target file.
+    int fd = open(disk_encrypt::kOverlayDMNotifyFile,
+                  O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0644);
+    if (fd < 0) {
+        qWarning() << "[OverlayDMNotifyHelper::writePendingFile] Failed to open file:" << disk_encrypt::kOverlayDMNotifyFile
+                   << "errno:" << errno;
+        return;
+    }
+
+    QJsonObject json;
+    json["enabled"] = enabled;
+    json["result"] = result;
+    json["timestamp"] = static_cast<qint64>(QDateTime::currentSecsSinceEpoch());
+    if (user.valid)
+        json["uid"] = static_cast<qint64>(user.uid);
+
+    QJsonDocument doc(json);
+    QByteArray data = doc.toJson();
+    if (write(fd, data.constData(), data.size()) < 0) {
+        qWarning() << "[OverlayDMNotifyHelper::writePendingFile] Failed to write file, errno:" << errno;
+        close(fd);
+        return;
+    }
+
+    // Operate on the fd to avoid TOCTOU races between open() and chmod()/chown().
+    fchmod(fd, 0644);
+    if (user.valid) {
+        fchown(fd, user.uid, user.uid);
+    }
+
+    close(fd);
+
+    qInfo() << "[OverlayDMNotifyHelper::writePendingFile] Pending notification written:" << disk_encrypt::kOverlayDMNotifyFile
+            << "enabled:" << enabled << "result:" << result;
+}
+
+void OverlayDMNotifyHelper::ensureNotificationDelivery(bool enabled, int result)
+{
+    qInfo() << "[OverlayDMNotifyHelper::ensureNotificationDelivery] Ensuring notification delivery, enabled:" << enabled << "result:" << result;
+
+    ActiveUser user = findActiveGraphicalUser();
+
+    writePendingFile(enabled, result, user);
+
+    if (!user.valid) {
+        qInfo() << "[OverlayDMNotifyHelper::ensureNotificationDelivery] No active graphical user, pending file written for later delivery";
+        return;
+    }
+
+    if (!isFileManagerRunning(user.uid)) {
+        launchFileManager(user.uid, user.username);
+    } else {
+        qInfo() << "[OverlayDMNotifyHelper::ensureNotificationDelivery] File manager already running, signal will deliver notification";
+    }
+}

--- a/src/services/diskencrypt/helpers/overlaydmnotifyhelper.h
+++ b/src/services/diskencrypt/helpers/overlaydmnotifyhelper.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef OVERLAYDMNOTIFYHELPER_H
+#define OVERLAYDMNOTIFYHELPER_H
+
+#include <QObject>
+
+#include "diskencrypt_global.h"
+
+FILE_ENCRYPT_BEGIN_NS
+
+class OverlayDMNotifyHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    static OverlayDMNotifyHelper *instance();
+
+    void ensureNotificationDelivery(bool enabled, int result);
+
+private:
+    struct ActiveUser {
+        uint uid { 0 };
+        QString username;
+        bool valid { false };
+    };
+
+    explicit OverlayDMNotifyHelper(QObject *parent = nullptr);
+
+    ActiveUser findActiveGraphicalUser();
+    bool isFileManagerRunning(uint uid);
+    void launchFileManager(uint uid, const QString &username);
+    void writePendingFile(bool enabled, int result, const ActiveUser &user);
+};
+
+FILE_ENCRYPT_END_NS
+
+#endif   // OVERLAYDMNOTIFYHELPER_H


### PR DESCRIPTION
1. Root cause: deepin-filemanager-diskencrypt.service exits early in
   main() when enableEncrypt is false, so on first boot the service is
   not running. When the user later enables partition encryption
   (enableEncrypt → true), no process is listening for the
   useOverlayDMMode DConfig change, so toggling it has no effect.
2. Fix: add a DConfig watcher in the accesscontrol plugin (always
   running via DSM) that monitors the enableEncrypt key. When it
   changes to true, the watcher calls IsTaskEmpty via DBus to activate
   the diskencrypt service, which then establishes its own
   useOverlayDMMode DConfig listener.
3. Impact: only src/services/accesscontrol/plugin.cpp is modified.
   The existing boot-time activation is preserved (refactored into a
   shared static function). No CMake changes needed — Dtk6::Core is
   already linked transitively via DFM6::base.

影响:
1. 根因：deepin-filemanager-diskencrypt.service 在 main() 中当
   enableEncrypt 为 false 时提前退出，首次装机启动时服务未运行。
   用户后续开启分区加密（enableEncrypt → true）时无进程监听
   useOverlayDMMode 的 DConfig 变更，导致切换无效果。
2. 方案：在 accesscontrol 插件（通过 DSM 始终运行）中新增 DConfig
   监听，监控 enableEncrypt 键。当其变为 true 时，通过 DBus 调用
   IsTaskEmpty 激活磁盘加密服务，使其建立 useOverlayDMMode 的
   DConfig 监听。
3. 影响：仅修改 src/services/accesscontrol/plugin.cpp，启动时激活
   逻辑保留（重构为共享静态函数），无需修改 CMake（Dtk6::Core 已
   通过 DFM6::base 传递链接）。

PMS: BUG-374033

## Summary by Sourcery

Ensure disk encryption and overlay DM mode changes remain responsive when encryption is enabled after boot or the file manager is temporarily unavailable.

New Features:
- Add reliable delivery of overlay DM mode change notifications by persisting results and delivering them when the file manager is available.

Bug Fixes:
- Ensure enabling partition encryption after boot activates the disk encryption service and restores overlay DM configuration change handling.
- Preserve overlay DM change notifications across service or file-manager availability gaps.

Enhancements:
- Monitor encryption configuration changes from the always-running access control plugin and reuse the service activation path for boot-time and on-demand startup.