### PR TITLE
fix: remove redundant hint type check

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhintcontroller.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhintcontroller.cpp
@@ -250,16 +250,6 @@ void SearchHintController::evaluateAndShow(quint64 winId)
     HintType newType = evaluateHint(winId);
     auto &ws = windowStates[winId];
 
-    if (newType == ws.currentType) {
-        if (newType == HintType::None) {
-            if (hints.value(winId)) {
-                hints[winId]->close();
-                hints[winId] = nullptr;
-            }
-        }
-        return;
-    }
-
     if (newType == HintType::None) {
         if (hints.value(winId)) {
             hints[winId]->close();


### PR DESCRIPTION
1. Remove early return logic that skipped hint updates when the hint
type remained unchanged
2. This ensures hints are properly re-evaluated and updated even when
the type stays the same
3. The None type handling is preserved in the subsequent code block to
properly close hints when needed
4. Fixes potential UI inconsistency where search hints would not update
correctly under certain conditions

Influence:
1. Test search hint display when typing the same search term multiple
times
2. Verify hints properly update when search context changes but hint
type remains the same
3. Confirm hints correctly close when search input is cleared
4. Test rapid search input changes to ensure hints respond correctly
5. Verify no memory leaks from hint widgets being improperly managed

fix: 移除冗余的提示类型检查

1. 移除当提示类型未改变时跳过提示更新的提前返回逻辑
2. 确保即使类型保持不变，提示也能被正确重新评估和更新
3. None 类型的处理在后续代码块中保留，以便在需要时正确关闭提示
4. 修复搜索提示在某些条件下无法正确更新的潜在 UI 不一致问题

Influence:
1. 测试输入相同搜索词多次时搜索提示的显示
2. 验证搜索上下文改变但提示类型保持不变时提示是否正确更新
3. 确认清除搜索输入时提示能正确关闭
4. 测试快速更改搜索输入以确保提示正确响应
5. 验证提示控件不会因管理不当而产生内存泄漏

## Summary by Sourcery

Bug Fixes:
- Ensure search hints are re-evaluated and updated when the hint type remains unchanged, preventing stale or inconsistent UI state.