### PR TITLE
fix: resolve symlink path in search method selection

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/searchmanager/searcher/dfmsearch/dfmsearcher.cpp
@@ -12,6 +12,7 @@
 #include <dfm-search/searchfactory.h>
 
 #include <QDebug>
+#include <QFileInfo>
 
 DFMBASE_USE_NAMESPACE
 DPSEARCH_USE_NAMESPACE
@@ -352,6 +353,16 @@ SearchMethod DFMSearcher::getSearchMethod(const QString &path) const
     // 因此需要切换搜索方法
     if (DevProxyMng->isFileOfExternalMounts(path)) {
         fmInfo() << "Use reltime method to: " << path << " - is external mount";
+        return SearchMethod::Realtime;
+    }
+
+    // 路径可能通过符号链接指向索引目录之外的位置（例如将 /media 下的目录
+    // 软链接到主目录），此时 anything 索引并不包含目标路径的文件，
+    // 需要解析符号链接后重新判断，若实际路径不在索引目录中则使用实时搜索
+    const QString &canonicalPath = QFileInfo(path).canonicalFilePath();
+    if (!canonicalPath.isEmpty()
+        && !DFMSEARCH::Global::isPathInFileNameIndexDirectory(canonicalPath)) {
+        fmInfo() << "Use realtime method to:" << path << "- symlink resolves outside index dir:" << canonicalPath;
         return SearchMethod::Realtime;
     }
 


### PR DESCRIPTION
## Root Cause Analysis

When a user creates a symlink under the home directory (e.g. `/home/user/文档 → /media/user/文档`), file search returns no results. The root cause is that `DFMSearcher::getSearchMethod()` uses string prefix matching (`isPathInFileNameIndexDirectory`) to determine whether to use deepin-anything indexed search. The symlink path `/home/user/文档` matches the index directory `/home/user/`, so indexed search is selected — but anything does not index the symlink target under `/media`, so no results are found. The existing `isFileOfExternalMounts` check (commit `e6c5c7f94`) handles manually mounted filesystems but does not cover symlink scenarios.

Key evidence:
- `dfmsearcher.cpp:327-358` — `getSearchMethod()` uses prefix matching without symlink resolution
- `searchutility.cpp:591` — `isPathInAnyDirectory()` does pure `startsWith` matching
- `deviceproxymanager.cpp:471` — `isFileOfExternalMounts` also uses prefix matching, not resolving symlinks

## Fix

Added a `canonicalFilePath()` resolution check in `getSearchMethod()` after existing checks pass. If the resolved real path is outside the anything index directory, the search method falls back to `Realtime`. This complements the existing `isFileOfExternalMounts` check without affecting normal or in-index symlink paths.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The new check executes only after all existing checks pass (path appears to be in index dir, not hidden, not external mount), so it only triggers for symlink paths that look like they should use indexed search
- Only downgrades (Indexed → Realtime), never upgrades; worst case is slightly slower search for some symlink paths, but results are always correct
- `canonicalFilePath()` returns empty string for non-existent paths, which skips the check and preserves original behavior

### Business Impact Scope

Affects filename search in the file manager only when the search target is a symlink pointing outside the anything index directory (e.g., `/home` → `/media`). Users searching files in such symlinked directories will now get correct results via realtime search. Normal directory search and symlinks within index directories are unaffected.

### Verification Suggestion

Test searching files in a symlinked directory that points to `/media` (outside index dir) — should return results. Also verify no regression on normal directory search and on symlinks pointing within the home directory.

---

## 根因分析

用户在主目录下创建符号链接（如 `/home/user/文档 → /media/user/文档`）后，文件搜索无结果。根因是 `DFMSearcher::getSearchMethod()` 使用字符串前缀匹配（`isPathInFileNameIndexDirectory`）判断是否使用 deepin-anything 索引搜索。符号链接路径 `/home/user/文档` 匹配索引目录 `/home/user/`，因此选择了索引搜索——但 anything 未索引 `/media` 下的链接目标，导致无结果。已有的 `isFileOfExternalMounts` 检查（commit `e6c5c7f94`）处理手动挂载场景，但不覆盖符号链接。

关键证据：
- `dfmsearcher.cpp:327-358` — `getSearchMethod()` 使用前缀匹配，未解析符号链接
- `searchutility.cpp:591` — `isPathInAnyDirectory()` 做纯 `startsWith` 匹配
- `deviceproxymanager.cpp:471` — `isFileOfExternalMounts` 同样基于前缀匹配，不解析符号链接

## 修复方案

在 `getSearchMethod()` 中现有检查通过后，新增 `canonicalFilePath()` 解析检查。若解析后的实际路径不在 anything 索引目录中，则回退为实时搜索（`Realtime`）。此修改补充了已有的 `isFileOfExternalMounts` 检查，不影响正常路径和索引目录内的符号链接。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低
- 新检查仅在所有已有检查通过后执行（路径看似在索引目录、非隐藏、非外部挂载），仅对"看起来应该用索引搜索"的符号链接路径触发
- 仅做降级（Indexed → Realtime），不做升级；最坏情况是部分符号链接路径多用了实时搜索，但结果始终正确
- `canonicalFilePath()` 对不存在的路径返回空字符串，此时跳过检查，保持原有行为

### 业务影响范围

仅当搜索目标是指向 anything 索引目录外（如 `/home` → `/media`）的符号链接时，影响文件管理器的文件名搜索。用户在此类符号链接目录中搜索文件将通过实时搜索获得正确结果。正常目录搜索和索引目录内的符号链接不受影响。

### 验证建议

测试在指向 `/media`（索引目录外）的符号链接目录中搜索文件——应能返回结果。同时验证正常目录搜索和指向主目录内的符号链接搜索无回归。

## Summary by Sourcery

Bug Fixes:
- Ensure searches through symlinks targeting locations outside the indexed directory return results by falling back to realtime search.