### PR TITLE
feat: add index creation resume support

### DIFF
--- a/autotests/services/textindex/test_taskmanager_grading.cpp
+++ b/autotests/services/textindex/test_taskmanager_grading.cpp
@@ -350,8 +350,9 @@ TEST_F(TaskManagerGradingOcrTest, GradeFileList_OcrSizeOverThreshold_Medium)
 
 TEST_F(TaskManagerGradingTest, Status_NoTaskNoQueue_CleanState_Idle)
 {
-    // Set index state to Clean → "Idle"
+    // Set index state to Clean with matching version → "Idle"
     runtime->stateStore().setIndexState(IndexUtility::IndexState::Clean);
+    runtime->stateStore().saveIndexStatus(QDateTime::currentDateTime());
     EXPECT_EQ(mgr->currentIndexStatus(), QString("Idle"));
 }
 
@@ -673,18 +674,49 @@ TEST_F(TaskManagerGradingTest, Status_NoTask_DirtyDB_CreateInProgress_NotIdle_Wa
 
 TEST_F(TaskManagerGradingTest, Status_NoTask_CleanIndex_Battery_Idle)
 {
-    // Clean index, no task, on battery → Idle (nothing to do)
+    // Clean index with matching version, no task, on battery → Idle (nothing to do)
     runtime->stateStore().setIndexState(IndexUtility::IndexState::Clean);
+    runtime->stateStore().saveIndexStatus(QDateTime::currentDateTime());
     EnvDetector::instance().m_state = EnvState { true, false, false };
     EXPECT_EQ(mgr->currentIndexStatus(), QString("Idle"));
 }
 
 TEST_F(TaskManagerGradingTest, Status_NoTask_CleanIndex_PowerSave_Idle)
 {
-    // Clean index, no task, power-save → Idle (nothing to do)
+    // Clean index with matching version, no task, power-save → Idle (nothing to do)
     runtime->stateStore().setIndexState(IndexUtility::IndexState::Clean);
+    runtime->stateStore().saveIndexStatus(QDateTime::currentDateTime());
     EnvDetector::instance().m_state = EnvState { false, true, false };
     EXPECT_EQ(mgr->currentIndexStatus(), QString("Idle"));
+}
+
+// --- Sub-scenario D: Clean state but version mismatch → Heavy → WaitingUpgrade ---
+//   When the index version is upgraded, the old status.json may still say
+//   "clean" with an old version number.  Before silentStart fires, the status
+//   should show "WaitingUpgrade", not "Idle".
+
+TEST_F(TaskManagerGradingTest, Status_NoTask_CleanState_VersionMismatch_WaitingUpgrade)
+{
+    // Clean state but with an old version (0 instead of runtime version 1)
+    runtime->stateStore().setIndexState(IndexUtility::IndexState::Clean);
+    runtime->stateStore().saveIndexStatus(QDateTime::currentDateTime(), 0);
+    EXPECT_EQ(mgr->currentIndexStatus(), QString("WaitingUpgrade"));
+}
+
+TEST_F(TaskManagerGradingTest, Status_NoTask_CleanState_VersionMismatch_Battery_WaitingUpgrade)
+{
+    runtime->stateStore().setIndexState(IndexUtility::IndexState::Clean);
+    runtime->stateStore().saveIndexStatus(QDateTime::currentDateTime(), 0);
+    EnvDetector::instance().m_state = EnvState { true, false, false };
+    EXPECT_EQ(mgr->currentIndexStatus(), QString("WaitingUpgrade"));
+}
+
+TEST_F(TaskManagerGradingTest, Status_NoTask_CleanState_VersionMismatch_PowerSave_WaitingUpgrade)
+{
+    runtime->stateStore().setIndexState(IndexUtility::IndexState::Clean);
+    runtime->stateStore().saveIndexStatus(QDateTime::currentDateTime(), 0);
+    EnvDetector::instance().m_state = EnvState { false, true, false };
+    EXPECT_EQ(mgr->currentIndexStatus(), QString("WaitingUpgrade"));
 }
 
 // ===========================================================================

--- a/src/services/textindex/core/indexruntime.cpp
+++ b/src/services/textindex/core/indexruntime.cpp
@@ -15,6 +15,7 @@ IndexRuntime::IndexRuntime(IndexProfile profile, QObject *parent)
       m_taskManager(new TaskManager(&m_context, this)),
       m_fsEventController(new FSEventController(m_profile, this))
 {
+    EnvDetector::instance().setDataPath(m_profile.indexDirectory());
     EnvDetector::instance().start();
 }
 

--- a/src/services/textindex/state/indexstatestore.cpp
+++ b/src/services/textindex/state/indexstatestore.cpp
@@ -244,11 +244,13 @@ void IndexStateStore::saveLastUpdateTime(const QDateTime &lastUpdateTime) const
 
 QStringList IndexStateStore::createFileListCache() const
 {
+    QMutexLocker locker(&m_createFileListCacheMutex);
     return m_createFileListCache;
 }
 
 void IndexStateStore::setCreateFileListCache(const QStringList &cache) const
 {
+    QMutexLocker locker(&m_createFileListCacheMutex);
     m_createFileListCache = cache;
 }
 

--- a/src/services/textindex/state/indexstatestore.cpp
+++ b/src/services/textindex/state/indexstatestore.cpp
@@ -242,4 +242,24 @@ void IndexStateStore::saveLastUpdateTime(const QDateTime &lastUpdateTime) const
     writeStatusJson(statusFilePath(), obj);
 }
 
+QStringList IndexStateStore::createFileListCache() const
+{
+    return m_createFileListCache;
+}
+
+void IndexStateStore::setCreateFileListCache(const QStringList &cache) const
+{
+    m_createFileListCache = cache;
+}
+
+int IndexStateStore::createCheckpoint() const
+{
+    return m_createCheckpoint.loadRelaxed();
+}
+
+void IndexStateStore::setCreateCheckpoint(int checkpoint) const
+{
+    m_createCheckpoint.storeRelaxed(checkpoint);
+}
+
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/state/indexstatestore.h
+++ b/src/services/textindex/state/indexstatestore.h
@@ -8,7 +8,9 @@
 #include "profile/indexprofile.h"
 #include "utils/indexutility.h"
 
+#include <QAtomicInteger>
 #include <QDateTime>
+#include <QStringList>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
 
@@ -238,8 +240,16 @@ public:
      */
     void saveLastUpdateTime(const QDateTime &lastUpdateTime) const;
 
+    QStringList createFileListCache() const;
+    void setCreateFileListCache(const QStringList &cache) const;
+
+    int createCheckpoint() const;
+    void setCreateCheckpoint(int checkpoint) const;
+
 private:
     IndexProfile m_profile;
+    mutable QStringList m_createFileListCache;
+    mutable QAtomicInteger<int> m_createCheckpoint { 0 };
 };
 
 SERVICETEXTINDEX_END_NAMESPACE

--- a/src/services/textindex/state/indexstatestore.h
+++ b/src/services/textindex/state/indexstatestore.h
@@ -10,6 +10,7 @@
 
 #include <QAtomicInteger>
 #include <QDateTime>
+#include <QMutex>
 #include <QStringList>
 
 SERVICETEXTINDEX_BEGIN_NAMESPACE
@@ -240,15 +241,46 @@ public:
      */
     void saveLastUpdateTime(const QDateTime &lastUpdateTime) const;
 
+    /**
+     * @brief 读取 Create 续建缓存的文件列表（线程安全）
+     * @return 缓存的文件路径列表，若不存在或已清除则返回空列表
+     *
+     * 由 worker 线程在 CreateResumeHandler / resolveFileListForCreateResume 中调用，
+     * 与 setCreateFileListCache（可能在主线程调用）通过内部互斥锁保证线程安全。
+     */
     QStringList createFileListCache() const;
+
+    /**
+     * @brief 设置 Create 续建缓存的文件列表（线程安全）
+     * @param cache 从 ANYTHING 获取的全量文件路径列表
+     *
+     * 调用场景：
+     * - 主线程 startTask 启动新 Create 时清除旧缓存（传空列表）
+     * - 主线程 finalizeIndexState 全量任务成功后清除缓存（传空列表）
+     * - worker 线程 CreateIndexHandler / resolveFileListForCreateResume 中缓存文件列表
+     */
     void setCreateFileListCache(const QStringList &cache) const;
 
+    /**
+     * @brief 读取 Create 续建的检查点偏移（线程安全）
+     * @return 已处理的文件索引偏移，0 表示从头开始
+     *
+     * 使用 QAtomicInteger 保证跨线程可见性。
+     */
     int createCheckpoint() const;
+
+    /**
+     * @brief 设置 Create 续建的检查点偏移（线程安全）
+     * @param checkpoint 已处理的文件索引偏移
+     *
+     * 由 worker 线程在遍历文件时每处理一个文件更新一次。
+     */
     void setCreateCheckpoint(int checkpoint) const;
 
 private:
     IndexProfile m_profile;
     mutable QStringList m_createFileListCache;
+    mutable QMutex m_createFileListCacheMutex;
     mutable QAtomicInteger<int> m_createCheckpoint { 0 };
 };
 

--- a/src/services/textindex/task/fileprovider.cpp
+++ b/src/services/textindex/task/fileprovider.cpp
@@ -154,6 +154,15 @@ qint64 DirectFileListProvider::totalCount()
     return m_fileList.count();
 }
 
+QStringList DirectFileListProvider::filePaths() const
+{
+    QStringList paths;
+    paths.reserve(m_fileList.size());
+    for (const auto &result : std::as_const(m_fileList))
+        paths.append(result.path());
+    return paths;
+}
+
 MixedPathListProvider::MixedPathListProvider(IndexProfile profile, const QStringList &pathList)
     : m_profile(std::move(profile)),
       m_pathList(pathList)

--- a/src/services/textindex/task/fileprovider.h
+++ b/src/services/textindex/task/fileprovider.h
@@ -54,6 +54,7 @@ public:
     qint64 totalCount() override;
     QString name() override { return "DirectFileListProvider"; }
 
+    /// Extract all file paths as a QStringList without traversing.
     QStringList filePaths() const;
 
 private:

--- a/src/services/textindex/task/fileprovider.h
+++ b/src/services/textindex/task/fileprovider.h
@@ -54,6 +54,8 @@ public:
     qint64 totalCount() override;
     QString name() override { return "DirectFileListProvider"; }
 
+    QStringList filePaths() const;
+
 private:
     DFMSEARCH::SearchResultList m_fileList;
 };

--- a/src/services/textindex/task/taskhandler.cpp
+++ b/src/services/textindex/task/taskhandler.cpp
@@ -642,6 +642,34 @@ void removeDirectoryIndex(const IndexContext &context, const QString &dirPath, c
     }
 }
 
+/// RAII wrapper that opens IndexReader + IndexWriter on construction and closes them on destruction.
+/// Eliminates duplicated ScopeGuard boilerplate across handler lambdas.
+struct IndexAccessor {
+    IndexReaderPtr reader;
+    IndexWriterPtr writer;
+
+    IndexAccessor(const QString &indexDir, const IndexContext &context)
+    {
+        reader = IndexReader::open(FSDirectory::open(indexDir.toStdWString()), true);
+        writer = newLucene<IndexWriter>(
+                FSDirectory::open(indexDir.toStdWString()),
+                boost::static_pointer_cast<Lucene::Analyzer>(context.profile().createAnalyzer()),
+                false,
+                IndexWriter::MaxFieldLengthUNLIMITED);
+    }
+
+    ~IndexAccessor()
+    {
+        try { if (reader) reader->close(); } catch (...) {
+            fmWarning() << "[IndexAccessor] Exception closing index reader";
+        }
+        try { if (writer) writer->close(); } catch (...) {
+            fmWarning() << "[IndexAccessor] Exception closing index writer";
+        }
+    }
+};
+
+/// Result of resolving the file list for a Create-resume task.
 struct CreateResumeFileList {
     QStringList fileList;
     int checkpoint { 0 };
@@ -649,6 +677,20 @@ struct CreateResumeFileList {
     bool hasFileList { false };   // true = fileList 可直接迭代; false = 需走 BFS traverse
 };
 
+/**
+ * @brief 为 Create 续建任务解析文件列表和检查点
+ * @param context 索引上下文
+ * @param path 索引根路径
+ * @param running 任务运行状态（用于 provider traverse 中的暂停检查）
+ * @param createInProgress 是否处于 Create 续建模式
+ * @return 解析结果，包含文件列表、检查点偏移和来源标记
+ *
+ * 解析优先级：
+ * 1. 若 createInProgress 且 stateStore 中已有缓存列表，直接使用缓存 + checkpoint
+ * 2. 否则通过 createFileProvider 获取文件列表
+ *    - DirectFileListProvider (ANYTHING)：提取路径列表并缓存到 stateStore
+ *    - FileSystemProvider (BFS)：返回 hasFileList=false，调用方需自行 traverse
+ */
 CreateResumeFileList resolveFileListForCreateResume(const IndexContext &context, const QString &path,
                                                     TaskState &running, bool createInProgress)
 {
@@ -687,6 +729,23 @@ CreateResumeFileList resolveFileListForCreateResume(const IndexContext &context,
     return resolved;
 }
 
+/**
+ * @brief 使用检查点偏移迭代处理文件列表，每个文件调用 updateFile
+ * @param context 索引上下文
+ * @param fileList 待处理的文件路径列表
+ * @param checkpoint 起始偏移（跳过前 checkpoint 个文件）
+ * @param createInProgress 是否处于 Create 续建模式（决定是否更新 checkpoint）
+ * @param excludeMatcher 黑名单匹配器
+ * @param reader 索引读取器
+ * @param writer 索引写入器
+ * @param reporter 进度报告器
+ * @param migrator 旧索引内容迁移器
+ * @param running 任务运行状态（用于暂停/中断检查）
+ *
+ * 遍历 fileList[checkpoint..end)，逐文件调用 updateFile。
+ * 若 createInProgress，每处理一个文件更新 stateStore 中的 checkpoint。
+ * 遇到暂停请求或中断时立即退出循环。
+ */
 void processFileListWithCheckpoint(const IndexContext &context, const QStringList &fileList,
                                     int checkpoint, bool createInProgress,
                                     const PathExcludeMatcher &excludeMatcher,
@@ -878,34 +937,10 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
         }
 
         try {
-            IndexReaderPtr reader = IndexReader::open(
-                    FSDirectory::open(indexDir.toStdWString()), true);
+            IndexAccessor accessor(indexDir, context);
+            ProgressReporter reporter(accessor.writer);
 
-            ScopeGuard readerCloser([&reader]() {
-                try {
-                    if (reader) reader->close();
-                } catch (...) {
-                    fmWarning() << "[UpdateIndexHandler] Exception closing index reader";
-                }
-            });
-
-            IndexWriterPtr writer = newLucene<IndexWriter>(
-                    FSDirectory::open(indexDir.toStdWString()),
-                    boost::static_pointer_cast<Lucene::Analyzer>(context.profile().createAnalyzer()),
-                    false,
-                    IndexWriter::MaxFieldLengthUNLIMITED);
-
-            ScopeGuard writerCloser([&writer]() {
-                try {
-                    if (writer) writer->close();
-                } catch (...) {
-                    fmWarning() << "[UpdateIndexHandler] Exception closing index writer";
-                }
-            });
-
-            ProgressReporter reporter(writer);
-
-            if (!cleanupIndexs(context, reader, writer, running, &reporter)) {
+            if (!cleanupIndexs(context, accessor.reader, accessor.writer, running, &reporter)) {
                 fmCritical() << "[UpdateIndexHandler] Index cleanup failed, aborting update";
                 result.success = false;
                 result.fatal = true;
@@ -914,7 +949,7 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
 
             if (running.isPauseRequested()) {
                 fmInfo() << "[UpdateIndexHandler] Index update paused during index cleanup";
-                writer->commit();
+                accessor.writer->commit();
                 result.paused = true;
                 result.success = false;
                 return result;
@@ -936,13 +971,13 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
             fmDebug() << "[UpdateIndexHandler] Starting file update processing, estimated total files:" << provider->totalCount();
 
             provider->traverse(running, [&](const QString &file) {
-                updateFile(context, file, excludeMatcher, reader, writer, &reporter,
+                updateFile(context, file, excludeMatcher, accessor.reader, accessor.writer, &reporter,
                            migrator.isActive() ? &migrator : nullptr);
             });
 
             if (running.isPauseRequested()) {
                 fmInfo() << "[UpdateIndexHandler] Index update paused by scheduler request";
-                writer->commit();
+                accessor.writer->commit();
                 result.paused = true;
                 result.success = false;
                 return result;
@@ -953,7 +988,7 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
                 result.interrupted = true;
             }
 
-            writer->commit();
+            accessor.writer->commit();
             if (!result.interrupted)
                 migrator.cleanup();
 
@@ -987,32 +1022,8 @@ TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
         }
 
         try {
-            IndexReaderPtr reader = IndexReader::open(
-                    FSDirectory::open(indexDir.toStdWString()), true);
-
-            ScopeGuard readerCloser([&reader]() {
-                try {
-                    if (reader) reader->close();
-                } catch (...) {
-                    fmWarning() << "[CreateResumeHandler] Exception closing index reader";
-                }
-            });
-
-            IndexWriterPtr writer = newLucene<IndexWriter>(
-                    FSDirectory::open(indexDir.toStdWString()),
-                    boost::static_pointer_cast<Lucene::Analyzer>(context.profile().createAnalyzer()),
-                    false,
-                    IndexWriter::MaxFieldLengthUNLIMITED);
-
-            ScopeGuard writerCloser([&writer]() {
-                try {
-                    if (writer) writer->close();
-                } catch (...) {
-                    fmWarning() << "[CreateResumeHandler] Exception closing index writer";
-                }
-            });
-
-            ProgressReporter reporter(writer);
+            IndexAccessor accessor(indexDir, context);
+            ProgressReporter reporter(accessor.writer);
             const PathExcludeMatcher excludeMatcher = PathExcludeMatcher::createForIndex();
 
             fmInfo() << "[CreateResumeHandler] Create in progress, skipping cleanup";
@@ -1020,7 +1031,6 @@ TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
             auto resolved = resolveFileListForCreateResume(context, path, running, true);
 
             if (!resolved.hasFileList) {
-                // BFS path: traverse directly, cannot materialize full list.
                 auto provider = createFileProvider(context, path);
                 if (!provider) {
                     fmCritical() << "[CreateResumeHandler] Failed to create file provider for path:" << path;
@@ -1032,7 +1042,7 @@ TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
 
                 int bfsIndex = 0;
                 provider->traverse(running, [&](const QString &file) {
-                    updateFile(context, file, excludeMatcher, reader, writer, &reporter,
+                    updateFile(context, file, excludeMatcher, accessor.reader, accessor.writer, &reporter,
                                migrator.isActive() ? &migrator : nullptr);
                     if (context.stateStore())
                         context.stateStore()->setCreateCheckpoint(++bfsIndex);
@@ -1040,7 +1050,7 @@ TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
 
                 if (running.isPauseRequested()) {
                     fmInfo() << "[CreateResumeHandler] Paused by scheduler request";
-                    writer->commit();
+                    accessor.writer->commit();
                     result.paused = true;
                     result.success = false;
                     return result;
@@ -1049,7 +1059,7 @@ TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
                     fmWarning() << "[CreateResumeHandler] Interrupted by user request";
                     result.interrupted = true;
                 }
-                writer->commit();
+                accessor.writer->commit();
                 if (!result.interrupted)
                     migrator.cleanup();
                 result.success = true;
@@ -1065,11 +1075,11 @@ TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
 
             processFileListWithCheckpoint(context, resolved.fileList, resolved.checkpoint,
                                           true, excludeMatcher,
-                                          reader, writer, reporter, migrator, running);
+                                          accessor.reader, accessor.writer, reporter, migrator, running);
 
             if (running.isPauseRequested()) {
                 fmInfo() << "[CreateResumeHandler] Paused by scheduler request";
-                writer->commit();
+                accessor.writer->commit();
                 result.paused = true;
                 result.success = false;
                 return result;
@@ -1080,7 +1090,7 @@ TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
                 result.interrupted = true;
             }
 
-            writer->commit();
+            accessor.writer->commit();
             if (!result.interrupted)
                 migrator.cleanup();
 

--- a/src/services/textindex/task/taskhandler.cpp
+++ b/src/services/textindex/task/taskhandler.cpp
@@ -143,6 +143,12 @@ public:
         fmInfo() << "[ProgressReporter::setTotal] Total count set to:" << count;
     }
 
+    void setProcessedCount(qint64 count)
+    {
+        processedCount = count;
+        m_lastCommitCount = count;
+    }
+
     void increment()
     {
         ++processedCount;
@@ -636,6 +642,71 @@ void removeDirectoryIndex(const IndexContext &context, const QString &dirPath, c
     }
 }
 
+struct CreateResumeFileList {
+    QStringList fileList;
+    int checkpoint { 0 };
+    bool useAnything { false };
+    bool hasFileList { false };   // true = fileList 可直接迭代; false = 需走 BFS traverse
+};
+
+CreateResumeFileList resolveFileListForCreateResume(const IndexContext &context, const QString &path,
+                                                    TaskState &running, bool createInProgress)
+{
+    CreateResumeFileList resolved;
+
+    if (createInProgress && context.stateStore()) {
+        resolved.fileList = context.stateStore()->createFileListCache();
+        resolved.checkpoint = context.stateStore()->createCheckpoint();
+    }
+
+    if (!resolved.fileList.isEmpty()) {
+        resolved.useAnything = true;
+        resolved.hasFileList = true;
+        return resolved;
+    }
+
+    auto provider = TaskHandlers::createFileProvider(context, path);
+    if (!provider) {
+        fmCritical() << "[resolveFileListForCreateResume] Failed to create file provider for path:" << path;
+        return resolved;
+    }
+
+    if (provider->name() == "DirectFileListProvider") {
+        resolved.useAnything = true;
+        resolved.hasFileList = true;
+        auto *directProvider = static_cast<DirectFileListProvider *>(provider.get());
+        resolved.fileList = directProvider->filePaths();
+        if (createInProgress && context.stateStore()) {
+            context.stateStore()->setCreateFileListCache(resolved.fileList);
+            context.stateStore()->setCreateCheckpoint(0);
+            fmInfo() << "[resolveFileListForCreateResume] Cached" << resolved.fileList.size()
+                     << "files from ANYTHING for Create resume";
+        }
+    }
+
+    return resolved;
+}
+
+void processFileListWithCheckpoint(const IndexContext &context, const QStringList &fileList,
+                                    int checkpoint, bool createInProgress,
+                                    const PathExcludeMatcher &excludeMatcher,
+                                    const IndexReaderPtr &reader, const IndexWriterPtr &writer,
+                                    ProgressReporter &reporter, const IndexContentMigrator &migrator,
+                                    TaskState &running)
+{
+    int fileIndex = checkpoint;
+    for (int i = checkpoint; i < fileList.size(); ++i) {
+        if (!running.isRunning() || running.isPauseRequested()) {
+            fmInfo() << "[processFileListWithCheckpoint] Processing interrupted at index" << i;
+            break;
+        }
+        updateFile(context, fileList[i], excludeMatcher, reader, writer, &reporter,
+                   migrator.isActive() ? &migrator : nullptr);
+        if (createInProgress && context.stateStore())
+            context.stateStore()->setCreateCheckpoint(++fileIndex);
+    }
+}
+
 }   // namespace
 
 // 创建文件提供者
@@ -725,6 +796,12 @@ TaskHandler TaskHandlers::CreateIndexHandler(const IndexContext &context)
             if (provider->name() == "DirectFileListProvider") {
                 result.useAnything = true;
                 fmInfo() << "[CreateIndexHandler] Using ANYTHING for file discovery";
+                if (context.stateStore()) {
+                    auto *directProvider = static_cast<DirectFileListProvider *>(provider.get());
+                    context.stateStore()->setCreateFileListCache(directProvider->filePaths());
+                    context.stateStore()->setCreateCheckpoint(0);
+                    fmInfo() << "[CreateIndexHandler] Cached" << directProvider->totalCount() << "files from ANYTHING";
+                }
             }
 
             ProgressReporter reporter(writer);
@@ -733,9 +810,12 @@ TaskHandler TaskHandlers::CreateIndexHandler(const IndexContext &context)
             reporter.setTotal(totalCount);
             fmInfo() << "[CreateIndexHandler] Starting file processing, estimated total files:" << totalCount;
 
+            int fileIndex = 0;
             provider->traverse(running, [&](const QString &file) {
                 processFile(context, file, excludeMatcher, writer, &reporter,
                             migrator.isActive() ? &migrator : nullptr);
+                if (context.stateStore())
+                    context.stateStore()->setCreateCheckpoint(++fileIndex);
             });
 
             if (running.isPauseRequested()) {
@@ -801,15 +881,11 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
             IndexReaderPtr reader = IndexReader::open(
                     FSDirectory::open(indexDir.toStdWString()), true);
 
-            // 添加 reader 的 ScopeGuard
             ScopeGuard readerCloser([&reader]() {
                 try {
-                    if (reader) {
-                        reader->close();
-                        fmDebug() << "[UpdateIndexHandler] Index reader closed successfully";
-                    }
+                    if (reader) reader->close();
                 } catch (...) {
-                    fmWarning() << "[UpdateIndexHandler] Exception occurred while closing index reader";
+                    fmWarning() << "[UpdateIndexHandler] Exception closing index reader";
                 }
             });
 
@@ -819,23 +895,16 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
                     false,
                     IndexWriter::MaxFieldLengthUNLIMITED);
 
-            // 添加 writer 的 ScopeGuard
             ScopeGuard writerCloser([&writer]() {
                 try {
-                    if (writer) {
-                        writer->close();
-                        fmDebug() << "[UpdateIndexHandler] Index writer closed successfully";
-                    }
+                    if (writer) writer->close();
                 } catch (...) {
-                    fmWarning() << "[UpdateIndexHandler] Exception occurred while closing index writer";
+                    fmWarning() << "[UpdateIndexHandler] Exception closing index writer";
                 }
             });
 
-            fmDebug() << "[UpdateIndexHandler] Index reader and writer initialized for directory:" << indexDir;
-
             ProgressReporter reporter(writer);
 
-            // 清理已删除文件的索引
             if (!cleanupIndexs(context, reader, writer, running, &reporter)) {
                 fmCritical() << "[UpdateIndexHandler] Index cleanup failed, aborting update";
                 result.success = false;
@@ -851,7 +920,7 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
                 return result;
             }
 
-            // 使用文件提供者遍历文件
+            const PathExcludeMatcher excludeMatcher = PathExcludeMatcher::createForIndex();
             auto provider = createFileProvider(context, path);
             if (!provider) {
                 fmCritical() << "[UpdateIndexHandler] Failed to create file provider for path:" << path;
@@ -863,10 +932,8 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
                 fmInfo() << "[UpdateIndexHandler] Using ANYTHING for file discovery";
             }
 
-            const PathExcludeMatcher excludeMatcher = PathExcludeMatcher::createForIndex();
-            qint64 totalCount = provider->totalCount();
-            reporter.setTotal(totalCount);
-            fmDebug() << "[UpdateIndexHandler] Starting file update processing, estimated total files:" << totalCount;
+            reporter.setTotal(provider->totalCount());
+            fmDebug() << "[UpdateIndexHandler] Starting file update processing, estimated total files:" << provider->totalCount();
 
             provider->traverse(running, [&](const QString &file) {
                 updateFile(context, file, excludeMatcher, reader, writer, &reporter,
@@ -886,32 +953,147 @@ TaskHandler TaskHandlers::UpdateIndexHandler(const IndexContext &context)
                 result.interrupted = true;
             }
 
-            // ProgressReporter的析构函数会处理最后的commit，确保所有更改都已提交
-            fmDebug() << "[UpdateIndexHandler] Ensuring all changes are committed";
             writer->commit();
-
-            // 不再调用 optimize()：增量更新场景下 lucene++ 的自动合并策略已足够保证查询性能
-            // optimize() 会强制合并所有 segment 为单个 segment，产生巨大的 IO 开销
-            fmDebug() << "[UpdateIndexHandler] Relying on lucene++ automatic merge policy instead of optimize";
-
-            // 仅在完整完成时清理旧索引；中断时保留 .old 供下次恢复使用
-            if (!result.interrupted) {
+            if (!result.interrupted)
                 migrator.cleanup();
-            }
 
             result.success = true;
             result.indexChanged = reporter.indexChanged();
             fmDebug() << "[UpdateIndexHandler] Index update completed successfully for path:" << path;
-
             return result;
         } catch (const LuceneException &e) {
-            // Lucene异常表示索引损坏
             fmCritical() << "[UpdateIndexHandler] Index update failed with Lucene exception, index may be corrupted:"
                          << QString::fromStdWString(e.getError());
-            throw;   // 重新抛出异常，让 IndexTask 捕获并处理
+            throw;
         } catch (const std::exception &e) {
-            // 其他异常不需要重建
             fmCritical() << "[UpdateIndexHandler] Index update failed with exception:" << e.what();
+        }
+
+        return result;
+    };
+}
+
+TaskHandler TaskHandlers::CreateResumeHandler(const IndexContext &context)
+{
+    return [context](const QString &path, TaskState &running) -> HandlerResult {
+        fmInfo() << "[CreateResumeHandler] Resuming index creation for path:" << path;
+        HandlerResult result { false, false, false };
+
+        QString indexDir = context.profile().indexDirectory();
+
+        IndexContentMigrator migrator;
+        if (IndexContentMigrator::hasResidue(indexDir)) {
+            migrator.prepare(indexDir, context.profile());
+        }
+
+        try {
+            IndexReaderPtr reader = IndexReader::open(
+                    FSDirectory::open(indexDir.toStdWString()), true);
+
+            ScopeGuard readerCloser([&reader]() {
+                try {
+                    if (reader) reader->close();
+                } catch (...) {
+                    fmWarning() << "[CreateResumeHandler] Exception closing index reader";
+                }
+            });
+
+            IndexWriterPtr writer = newLucene<IndexWriter>(
+                    FSDirectory::open(indexDir.toStdWString()),
+                    boost::static_pointer_cast<Lucene::Analyzer>(context.profile().createAnalyzer()),
+                    false,
+                    IndexWriter::MaxFieldLengthUNLIMITED);
+
+            ScopeGuard writerCloser([&writer]() {
+                try {
+                    if (writer) writer->close();
+                } catch (...) {
+                    fmWarning() << "[CreateResumeHandler] Exception closing index writer";
+                }
+            });
+
+            ProgressReporter reporter(writer);
+            const PathExcludeMatcher excludeMatcher = PathExcludeMatcher::createForIndex();
+
+            fmInfo() << "[CreateResumeHandler] Create in progress, skipping cleanup";
+
+            auto resolved = resolveFileListForCreateResume(context, path, running, true);
+
+            if (!resolved.hasFileList) {
+                // BFS path: traverse directly, cannot materialize full list.
+                auto provider = createFileProvider(context, path);
+                if (!provider) {
+                    fmCritical() << "[CreateResumeHandler] Failed to create file provider for path:" << path;
+                    return result;
+                }
+
+                reporter.setTotal(provider->totalCount());
+                fmDebug() << "[CreateResumeHandler] Starting BFS file update processing";
+
+                int bfsIndex = 0;
+                provider->traverse(running, [&](const QString &file) {
+                    updateFile(context, file, excludeMatcher, reader, writer, &reporter,
+                               migrator.isActive() ? &migrator : nullptr);
+                    if (context.stateStore())
+                        context.stateStore()->setCreateCheckpoint(++bfsIndex);
+                });
+
+                if (running.isPauseRequested()) {
+                    fmInfo() << "[CreateResumeHandler] Paused by scheduler request";
+                    writer->commit();
+                    result.paused = true;
+                    result.success = false;
+                    return result;
+                }
+                if (!running.isRunning()) {
+                    fmWarning() << "[CreateResumeHandler] Interrupted by user request";
+                    result.interrupted = true;
+                }
+                writer->commit();
+                if (!result.interrupted)
+                    migrator.cleanup();
+                result.success = true;
+                result.indexChanged = reporter.indexChanged();
+                return result;
+            }
+
+            result.useAnything = resolved.useAnything;
+            reporter.setTotal(resolved.fileList.size());
+            reporter.setProcessedCount(resolved.checkpoint);
+            fmInfo() << "[CreateResumeHandler] Processing" << resolved.fileList.size()
+                     << "files from checkpoint" << resolved.checkpoint;
+
+            processFileListWithCheckpoint(context, resolved.fileList, resolved.checkpoint,
+                                          true, excludeMatcher,
+                                          reader, writer, reporter, migrator, running);
+
+            if (running.isPauseRequested()) {
+                fmInfo() << "[CreateResumeHandler] Paused by scheduler request";
+                writer->commit();
+                result.paused = true;
+                result.success = false;
+                return result;
+            }
+
+            if (!running.isRunning()) {
+                fmWarning() << "[CreateResumeHandler] Interrupted by user request";
+                result.interrupted = true;
+            }
+
+            writer->commit();
+            if (!result.interrupted)
+                migrator.cleanup();
+
+            result.success = true;
+            result.indexChanged = reporter.indexChanged();
+            fmDebug() << "[CreateResumeHandler] Completed successfully for path:" << path;
+            return result;
+        } catch (const LuceneException &e) {
+            fmCritical() << "[CreateResumeHandler] Failed with Lucene exception, index may be corrupted:"
+                         << QString::fromStdWString(e.getError());
+            throw;
+        } catch (const std::exception &e) {
+            fmCritical() << "[CreateResumeHandler] Failed with exception:" << e.what();
         }
 
         return result;

--- a/src/services/textindex/task/taskhandler.cpp
+++ b/src/services/textindex/task/taskhandler.cpp
@@ -815,11 +815,13 @@ TaskHandler TaskHandlers::CreateIndexHandler(const IndexContext &context)
                 fmInfo() << "[CreateIndexHandler] Created index directory:" << indexDir;
             }
 
-            // prepare() 可能将旧索引目录重命名为 .old，导致 status 文件随旧目录被移走
-            // 在新目录确认存在后重新保存 status，防止进程中途退出后重复进入 Create
+            // prepare() 可能将旧索引目录重命名为 .old，导致 status 文件随旧目录被移走。
+            // 在新目录确认存在后重新保存 status（含 createInProgress），防止进程中途退出后
+            // 重启误判为 Light 级 Update。
             if (migrator.isActive() && context.stateStore()) {
                 context.stateStore()->saveIndexStatus(QDateTime::currentDateTime());
-                fmInfo() << "[CreateIndexHandler] Re-saved index status after migration rename";
+                context.stateStore()->setCreateInProgress(true);
+                fmInfo() << "[CreateIndexHandler] Re-saved index status (with createInProgress) after migration rename";
             }
 
             IndexWriterPtr writer = newLucene<IndexWriter>(

--- a/src/services/textindex/task/taskhandler.h
+++ b/src/services/textindex/task/taskhandler.h
@@ -35,6 +35,7 @@ using TaskHandler = std::function<HandlerResult(const QString &path, TaskState &
 namespace TaskHandlers {
 TaskHandler CreateIndexHandler(const IndexContext &context);
 TaskHandler UpdateIndexHandler(const IndexContext &context);
+TaskHandler CreateResumeHandler(const IndexContext &context);
 
 // 文件列表任务处理器
 TaskHandler CreateOrUpdateFileListHandler(const IndexContext &context, const QStringList &fileList);

--- a/src/services/textindex/task/taskhandler.h
+++ b/src/services/textindex/task/taskhandler.h
@@ -35,6 +35,10 @@ using TaskHandler = std::function<HandlerResult(const QString &path, TaskState &
 namespace TaskHandlers {
 TaskHandler CreateIndexHandler(const IndexContext &context);
 TaskHandler UpdateIndexHandler(const IndexContext &context);
+
+/// Handler for resuming an interrupted Create task. Skips cleanupIndexs, uses cached
+/// file list + checkpoint from IndexStateStore when available, or falls back to BFS.
+/// Only selected by TaskManager when createInProgress is true.
 TaskHandler CreateResumeHandler(const IndexContext &context);
 
 // 文件列表任务处理器

--- a/src/services/textindex/task/taskmanager.cpp
+++ b/src/services/textindex/task/taskmanager.cpp
@@ -136,6 +136,24 @@ bool TaskManager::startTask(IndexTask::Type type, const QStringList &pathList,
     // 获取第一个路径作为任务的主路径（用于日志和进度通知）
     QString primaryPath = pathList.first();
 
+    // Create 任务的 createInProgress 标记必须在入队检查之前完成，否则当任务被环境
+    // 阻塞入队时，服务重启后队列丢失，恢复逻辑会误判为 Light 级 Update。
+    //
+    // 注意：此处不调用 saveIndexStatus() 写入版本号。版本号仅在 CreateIndexHandler
+    // 实际执行并创建 .old 目录后才写入（taskhandler.cpp），或任务成功完成后由
+    // updateIndexStatusOnSuccess 写入。若在入队前就写入新版本号，一旦服务在
+    // handler 执行前重启，IndexDatabaseExists() 会因版本匹配返回 true，导致
+    // 进入 CreateResumeHandler 但无 .old 目录可迁移，索引不会真正重建。
+    if (type == IndexTask::Type::Create) {
+        fmInfo() << "[TaskManager::startTask] Create task detected, clearing existing index status";
+        if (m_context && m_context->stateStore()) {
+            m_context->stateStore()->removeIndexStatusFile();
+            m_context->stateStore()->setCreateFileListCache({});
+            m_context->stateStore()->setCreateCheckpoint(0);
+            m_context->stateStore()->setCreateInProgress(true);
+        }
+    }
+
     // 环境检查：如果当前环境不允许该分级任务运行，入队等待而非直接执行
     {
         TaskQueueItem item;
@@ -182,21 +200,6 @@ bool TaskManager::startTask(IndexTask::Type type, const QStringList &pathList,
 
     // 清除队列中与新任务同类型同路径的冗余任务，避免暂停→手动更新→完成后重复执行
     removeDuplicateFullScanTasks(type, pathList);
-
-    // status文件存储了修改时间，清除后外部无法获取时间，外部利用该特性判断索引状态
-    if (type == IndexTask::Type::Create) {
-        fmInfo() << "[TaskManager::startTask] Create task detected, clearing existing index status";
-        if (m_context && m_context->stateStore()) {
-            m_context->stateStore()->removeIndexStatusFile();
-            m_context->stateStore()->setCreateFileListCache({});
-            m_context->stateStore()->setCreateCheckpoint(0);
-        }
-        // 创建索引的任务开销巨大，避免任务未完成时进程退出后，重复进入创建任务
-        if (m_context && m_context->stateStore()) {
-            m_context->stateStore()->saveIndexStatus(QDateTime::currentDateTime());
-            m_context->stateStore()->setCreateInProgress(true);
-        }
-    }
 
     // 获取对应的任务处理器
     TaskHandler handler = getTaskHandler(type);
@@ -715,7 +718,15 @@ QString TaskManager::currentIndexStatus() const
     if (m_lastTaskFailed)
         return "Failed";
 
-    // Index is dirty or not yet built — there's pending work.
+    // There's pending work when: the state is dirty (unsynced changes), a
+    // create was interrupted (needs resuming), or the database doesn't exist
+    // or its version is incompatible (needs creation or upgrade).
+    //
+    // Even a "clean" state needs an upgrade when the stored version doesn't
+    // match the runtime version — the old status.json still says "clean" but
+    // a rebuild is required.  Without this check the user would see "Idle"
+    // until the silent-start timer fires, instead of "WaitingUpgrade".
+    //
     // The status shown to the user depends on the *effective grade* of the
     // pending work, mirroring gradeUpdateTask() / handleSlientStart() logic:
     //
@@ -736,13 +747,15 @@ QString TaskManager::currentIndexStatus() const
     //   power-save mode, which blocks even Light tasks and is worth telling
     //   the user about.
     if (m_context && m_context->stateStore()) {
-        if (!m_context->stateStore()->isCleanState()) {
-            const bool createInProgress = m_context->stateStore()->isCreateInProgress();
-            const bool dbExists = m_context->profile().isIndexAvailable()
-                                && m_context->stateStore()->isCompatibleVersion()
-                                && !m_context->stateStore()->getLastUpdateTime().isEmpty();
-            const bool heavy = createInProgress || !dbExists;
+        const bool createInProgress = m_context->stateStore()->isCreateInProgress();
+        const bool dbExists = m_context->profile().isIndexAvailable()
+                            && m_context->stateStore()->isCompatibleVersion()
+                            && !m_context->stateStore()->getLastUpdateTime().isEmpty();
+        const bool hasPendingWork = !m_context->stateStore()->isCleanState()
+                                  || createInProgress || !dbExists;
 
+        if (hasPendingWork) {
+            const bool heavy = createInProgress || !dbExists;
             if (heavy) {
                 return "WaitingUpgrade";
             } else {

--- a/src/services/textindex/task/taskmanager.cpp
+++ b/src/services/textindex/task/taskmanager.cpp
@@ -188,6 +188,8 @@ bool TaskManager::startTask(IndexTask::Type type, const QStringList &pathList,
         fmInfo() << "[TaskManager::startTask] Create task detected, clearing existing index status";
         if (m_context && m_context->stateStore()) {
             m_context->stateStore()->removeIndexStatusFile();
+            m_context->stateStore()->setCreateFileListCache({});
+            m_context->stateStore()->setCreateCheckpoint(0);
         }
         // 创建索引的任务开销巨大，避免任务未完成时进程退出后，重复进入创建任务
         if (m_context && m_context->stateStore()) {
@@ -402,6 +404,8 @@ TaskHandler TaskManager::getTaskHandler(IndexTask::Type type)
     case IndexTask::Type::Create:
         return TaskHandlers::CreateIndexHandler(*m_context);
     case IndexTask::Type::Update:
+        if (m_context->stateStore() && m_context->stateStore()->isCreateInProgress())
+            return TaskHandlers::CreateResumeHandler(*m_context);
         return TaskHandlers::UpdateIndexHandler(*m_context);
     default:
         fmWarning() << "[TaskManager::getTaskHandler] Unknown task type:" << static_cast<int>(type);
@@ -875,6 +879,8 @@ void TaskManager::finalizeIndexState(IndexTask::Type type, const HandlerResult &
         if (m_context && m_context->stateStore()) {
             m_context->stateStore()->setIndexState(IndexUtility::IndexState::Clean);
             m_context->stateStore()->setCreateInProgress(false);
+            m_context->stateStore()->setCreateFileListCache({});
+            m_context->stateStore()->setCreateCheckpoint(0);
         }
         fmInfo() << "[TaskManager::onTaskFinished] Full-scan task completed, index state set to clean";
     } else if (!m_recoveryPending) {


### PR DESCRIPTION
Added resume functionality for index creation tasks to handle
interruptions gracefully. When a create index task is paused or
interrupted, the system now caches the file list and checkpoint
information to allow resuming from where it left off. Key changes
include:
1. Added CreateResumeHandler to resume interrupted create tasks
2. Added file list caching in IndexStateStore with createFileListCache
and createCheckpoint
3. Enhanced DirectFileListProvider with filePaths() method to expose
file list
4. Added resume logic to distinguish between ANYTHING (cached file list)
and BFS traversal paths
5. Added cleanup of cache and checkpoint when tasks complete or are
cleared

The resume mechanism works by:
- Caching file paths when using ANYTHING search during initial create
- Tracking processing checkpoint index
- Resuming from cached checkpoint on subsequent update tasks when
createInProgress flag is set
- Clearing caches when create task completes successfully

Influence:
1. Test create index task pause/resume functionality with ANYTHING
search
2. Verify cache persistence across application restarts
3. Test create index resume after force quit or crash
4. Verify cache cleanup after successful index creation
5. Test mixed scenarios with both ANYTHING and BFS traversal
6. Validate checkpoint accuracy during resume operations

feat: 添加索引创建恢复支持

为索引创建任务添加恢复功能，以优雅处理中断情况。当创建索引任务被暂停或
中断时，系统现在会缓存文件列表和检查点信息，允许从中断处恢复。主要变更
包括：
1. 添加CreateResumeHandler用于恢复中断的创建任务
2. 在IndexStateStore中添加文件列表缓存（createFileListCache和
createCheckpoint）
3. 增强DirectFileListProvider，添加filePaths()方法暴露文件列表
4. 添加恢复逻辑以区分ANYTHING（缓存文件列表）和BFS遍历路径
5. 任务完成或清除时添加缓存和检查点清理

恢复机制工作原理：
- 在初始创建期间使用ANYTHING搜索时缓存文件路径
- 跟踪处理检查点索引
- 当createInProgress标志设置时，在后续更新任务中从缓存检查点恢复
- 成功创建任务后清除缓存

Influence:
1. 测试使用ANYTHING搜索时创建索引任务的暂停/恢复功能
2. 验证缓存跨应用程序重启的持久性
3. 测试强制退出或崩溃后的索引创建恢复
4. 验证成功创建索引后的缓存清理
5. 测试同时使用ANYTHING和BFS遍历的混合场景
6. 验证恢复操作期间检查点的准确性

## Summary by Sourcery

Enable interrupted index creation to resume from its cached file list and checkpoint while accurately reporting upgrade-required states.

New Features:
- Add support for resuming interrupted index creation tasks from saved progress.

Bug Fixes:
- Report WaitingUpgrade when a clean index is unavailable or has an incompatible version instead of incorrectly reporting Idle.

Enhancements:
- Persist cached file lists and processing checkpoints for resumable creation, supporting both ANYTHING results and BFS traversal.
- Select the create-resume handler for updates after interrupted creation and clear resume state after successful completion.
- Initialize environment detection with the active index data path.

Tests:
- Add coverage for clean-index status behavior with matching and mismatched index versions across battery and power-save states.