### PR TITLE
feat: add actionID support for menu items

### DIFF
--- a/autotests/libs/dfm-extension/test_dfmextmenuproxy.cpp
+++ b/autotests/libs/dfm-extension/test_dfmextmenuproxy.cpp
@@ -35,6 +35,9 @@ public:
     void setToolTip(const std::string &tip) override { this->m_toolTip = tip; }
     std::string toolTip() const override { return m_toolTip; }
 
+    void setActionId(const std::string &actionId) override { this->m_actionId = actionId; }
+    std::string actionId() const override { return m_actionId; }
+
     void setMenu(DFMEXT::DFMExtMenu *menu) override { this->m_menu = menu; }
     DFMEXT::DFMExtMenu *menu() const override { return m_menu; }
 
@@ -54,6 +57,7 @@ private:
     std::string m_text;
     std::string m_icon;
     std::string m_toolTip;
+    std::string m_actionId;
     DFMExtMenu *m_menu = nullptr;
     bool m_separator = false;
     bool m_checkable = false;
@@ -908,6 +912,24 @@ TEST_F(DFMExtMenuTest, InsertAction)
     EXPECT_EQ(actions.back(), testAction3);
     
     delete nonExistentAction;
+}
+
+TEST_F(DFMExtMenuTest, ActionIdLookup)
+{
+    EXPECT_EQ(testAction1->actionId(), "");
+
+    testAction1->setActionId("custom.refresh");
+    EXPECT_EQ(testAction1->actionId(), "custom.refresh");
+
+    testAction2->setActionId("refresh");
+    testAction3->setActionId("refresh");
+
+    testMenu->addAction(testAction1);
+    testMenu->addAction(testAction2);
+    testMenu->addAction(testAction3);
+
+    EXPECT_EQ(testMenu->findActionById("refresh"), testAction2);
+    EXPECT_EQ(testMenu->findActionById("missing"), nullptr);
 }
 
 /**

--- a/docs/extension/05-dfm-extension-plugin.md
+++ b/docs/extension/05-dfm-extension-plugin.md
@@ -241,6 +241,7 @@ public:
 - `setIcon()`：设置菜单图标，参数为主题图标名称或绝对路径
 - `addAction()`：添加菜单项到末尾
 - `insertAction()`：在指定菜单项前插入
+- `findActionById()`：按 `actionID` 查找菜单项，返回第一个匹配
 - `deleted()`：菜单销毁前的回调，用于释放插件自定义资源
 
 #### DFMExtAction 接口
@@ -261,6 +262,8 @@ public:
     std::string icon() const;
     void setToolTip(const std::string &tip);
     std::string toolTip() const;
+    void setActionId(const std::string &actionId);
+    std::string actionId() const;
 
     // 菜单关联
     void setMenu(DFMExtMenu *menu);
@@ -291,6 +294,7 @@ public:
 **常用方法说明**：
 - `setText()`：设置菜单项显示文本
 - `setIcon()`：设置图标，支持主题图标名或绝对路径
+- `setActionId()`：设置动作标识，底层复用文件管理器已有 `actionID`
 - `setMenu()`：关联子菜单，实现多级菜单
 - `setSeparator()`：设置为分隔线
 - `setCheckable()`：设置为可选中的菜单项
@@ -765,22 +769,17 @@ std::string removeScheme(const std::string &url) {
 
 ```cpp
 // 查找"刷新"菜单项
-auto actions = main->actions();
-auto it = std::find_if(actions.cbegin(), actions.cend(),
-    [](const DFMExtAction *action) {
-        return action->text().find("刷新") == 0;
-    });
-
-if (it != actions.cend()) {
+auto refreshAction = main->findActionById("refresh");
+if (refreshAction) {
     // 在"刷新"前插入分隔线和自定义项
     auto separator = m_proxy->createAction();
     separator->setSeparator(true);
-    main->insertAction(*it, separator);
-    main->insertAction(*it, myAction);
+    main->insertAction(refreshAction, separator);
+    main->insertAction(refreshAction, myAction);
 }
 ```
 
-- **注：**当前不满足国际化场景，后续提供action id
+- **注：**`actionId` 由插件作者设置，底层直接复用已有 `actionID`
 
 #### 4. 多选文件处理
 
@@ -1202,4 +1201,3 @@ ldd my-plugin.so
 |------|------|---------|
 | 6.0.0 | 2024 | 移除 URL 前缀，新增 Window 和 File 插件接口 |
 | 5.x | 2020-2023 | 初始版本，提供 Menu 和 Emblem 插件接口 |
-

--- a/examples/dfm-extension-example/mymenuplugin.cpp
+++ b/examples/dfm-extension-example/mymenuplugin.cpp
@@ -120,6 +120,9 @@ bool MyMenuPlugin::buildEmptyAreaMenu(DFMExtMenu *main, const std::string &curre
         action->setText("从文件管理器打开桌面");
     else
         action->setText("打开当前路径");
+#if DFMEXT_VERSION >= DFMEXT_VERSION_CHECK(6, 6, 4)
+    action->setActionId("example.open-current-path");
+#endif
     // 添加图标，也支持图片的文件绝对路径
     // 例如：/usr/share/icons/Adwaita/16x16/emblems/emblem-generic.png
     action->setIcon("emblem-generic");
@@ -142,18 +145,23 @@ bool MyMenuPlugin::buildEmptyAreaMenu(DFMExtMenu *main, const std::string &curre
         }
     });
 
-    // TODO: add interface id()
+    DFMExtAction *refreshAction = nullptr;
+#if DFMEXT_VERSION >= DFMEXT_VERSION_CHECK(6, 6, 4)
+    refreshAction = main->findActionById("refresh");
+#else
     auto actions = main->actions();
     auto it = std::find_if(actions.cbegin(), actions.cend(), [](const DFMExtAction *action) {
         const std::string &text = action->text();
         return (text.find("刷新") == 0) || (text.find("Refresh") == 0);
     });
-
-    if (it != actions.cend()) {
+    if (it != actions.cend())
+        refreshAction = *it;
+#endif
+    if (refreshAction) {
         auto separator = m_proxy->createAction();
         separator->setSeparator(true);
-        main->insertAction(*it, separator);
-        main->insertAction(*it, action);
+        main->insertAction(refreshAction, separator);
+        main->insertAction(refreshAction, action);
     } else {
         main->addAction(action);
     }

--- a/include/dfm-extension/menu/dfmextaction.h
+++ b/include/dfm-extension/menu/dfmextaction.h
@@ -36,6 +36,10 @@ public:
     void setToolTip(const std::string &tip);
     std::string toolTip() const;
 
+    // since 6.6.4
+    void setActionId(const std::string &actionId);
+    std::string actionId() const;
+
     void setMenu(DFMExtMenu *menu);
     DFMExtMenu *menu() const;
 

--- a/include/dfm-extension/menu/dfmextmenu.h
+++ b/include/dfm-extension/menu/dfmextmenu.h
@@ -38,6 +38,8 @@ public:
 
     DFMExtAction *menuAction() const;
     std::list<DFMExtAction *> actions() const;
+    // since 6.6.4
+    DFMExtAction *findActionById(const std::string &actionId) const;
 
     DFM_FAKE_VIRTUAL void triggered(DFMExtAction *action);
     DFM_FAKE_VIRTUAL void hovered(DFMExtAction *action);

--- a/src/dfm-extension/menu/dfmextaction.cpp
+++ b/src/dfm-extension/menu/dfmextaction.cpp
@@ -51,6 +51,16 @@ std::string DFMExtAction::toolTip() const
     return d->toolTip();
 }
 
+void DFMExtAction::setActionId(const std::string &actionId)
+{
+    d->setActionId(actionId);
+}
+
+std::string DFMExtAction::actionId() const
+{
+    return d->actionId();
+}
+
 void DFMExtAction::setMenu(DFMExtMenu *menu)
 {
     d->setMenu(menu);

--- a/src/dfm-extension/menu/dfmextmenu.cpp
+++ b/src/dfm-extension/menu/dfmextmenu.cpp
@@ -5,6 +5,7 @@
 #include "private/dfmextmenuprivate.h"
 
 #include <dfm-extension/menu/dfmextmenu.h>
+#include <dfm-extension/menu/dfmextaction.h>
 
 #include <cassert>
 
@@ -60,6 +61,15 @@ DFMExtAction *DFMExtMenu::menuAction() const
 std::list<DFMExtAction *> DFMExtMenu::actions() const
 {
     return d->actions();
+}
+
+DFMExtAction *DFMExtMenu::findActionById(const std::string &actionId) const
+{
+    for (DFMExtAction *action : actions()) {
+        if (action && action->actionId() == actionId)
+            return action;
+    }
+    return nullptr;
 }
 
 void DFMExtMenu::triggered(DFMExtAction *action)

--- a/src/dfm-extension/menu/private/dfmextactionprivate.h
+++ b/src/dfm-extension/menu/private/dfmextactionprivate.h
@@ -31,6 +31,9 @@ public:
     virtual void setToolTip(const std::string &tip) = 0;
     virtual std::string toolTip() const = 0;
 
+    virtual void setActionId(const std::string &actionId) = 0;
+    virtual std::string actionId() const = 0;
+
     virtual void setMenu(DFMExtMenu *menu) = 0;
     virtual DFMExtMenu *menu() const = 0;
 

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.cpp
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/dfmextactionimpl.cpp
@@ -8,6 +8,8 @@
 #include "dfmextmendefine.h"
 #include "dfmextmenuimpl.h"
 
+#include <dfm-base/dfm_menu_defines.h>
+
 #include <QAction>
 #include <QMenu>
 #include <QFile>
@@ -123,6 +125,23 @@ std::string DFMExtActionImplPrivate::toolTip() const
 {
     if (action)
         return action->toolTip().toStdString();
+
+    return "";
+}
+
+void DFMExtActionImplPrivate::setActionId(const std::string &actionId)
+{
+    if (interiorEntity)
+        return;
+
+    if (action)
+        action->setProperty(dfmbase::ActionPropertyKey::kActionID, QString::fromStdString(actionId));
+}
+
+std::string DFMExtActionImplPrivate::actionId() const
+{
+    if (action)
+        return action->property(dfmbase::ActionPropertyKey::kActionID).toString().toStdString();
 
     return "";
 }

--- a/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextactionimpl_p.h
+++ b/src/plugins/common/dfmplugin-utils/extensionimpl/menuimpl/private/dfmextactionimpl_p.h
@@ -36,6 +36,9 @@ public:
     void setToolTip(const std::string &tip) Q_DECL_OVERRIDE;
     std::string toolTip() const Q_DECL_OVERRIDE;
 
+    void setActionId(const std::string &actionId) Q_DECL_OVERRIDE;
+    std::string actionId() const Q_DECL_OVERRIDE;
+
     void setMenu(DFMEXT::DFMExtMenu *menu) Q_DECL_OVERRIDE;
     DFMEXT::DFMExtMenu *menu() const Q_DECL_OVERRIDE;
 


### PR DESCRIPTION
1. Added setActionId() and actionId() methods to DFMExtAction for
managing action identifiers
2. Implemented findActionById() in DFMExtMenu to locate actions by their
ID
3. Updated documentation to reflect new actionID functionality
4. Added version guards (DFMEXT_VERSION_CHECK) for backward
compatibility
5. Modified example code to demonstrate using actionId for menu item
lookup
6. Added comprehensive unit tests for action ID functionality

Log: Added actionID support for easier menu item identification and
lookup

Influence:
1. Test action ID setting and retrieval through DFMExtAction interface
2. Verify menu action lookup functionality with various ID scenarios
3. Test backward compatibility with older versions
4. Verify behavior with duplicate action IDs (first match should be
returned)
5. Check menu building and navigation with action IDs
6. Test integration with existing action properties and menu features

feat: 为菜单项添加 actionID 支持

1. 在 DFMExtAction 中添加 setActionId() 和 actionId() 方法用于管理动作标
识符
2. 在 DFMExtMenu 中实现 findActionById() 方法通过 ID 查找动作
3. 更新文档反映新的 actionID 功能
4. 添加版本检查(DFMEXT_VERSION_CHECK)保证向后兼容
5. 修改示例代码展示如何使用 actionId 查找菜单项
6. 添加全面的单元测试验证 action ID 功能

Log: 新增 actionID 支持便于菜单项识别和查找

Influence:
1. 测试通过 DFMExtAction 接口设置和获取 action ID
2. 验证不同 ID 场景下的菜单项查找功能
3. 测试与旧版本的兼容性
4. 验证重复 action ID 时的行为(应返回第一个匹配项)
5. 检查带 action ID 的菜单构建和导航
6. 测试与现有动作属性和菜单功能的集成

## Summary by Sourcery

Add action ID support to identify and locate menu items more reliably.

New Features:
- Add action ID assignment and retrieval for menu actions and lookup of menu actions by ID, returning the first match.

Enhancements:
- Use stable action IDs for menu-item lookup while retaining a fallback for older extension versions.

Documentation:
- Document the action ID APIs and update menu customization examples to use ID-based lookup.

Tests:
- Add coverage for action ID setting, retrieval, successful lookup, missing IDs, and duplicate-ID ordering.