### PR TITLE
fix(propertydialog): add hover/pressed effect for edit button

### DIFF
--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.cpp
@@ -12,6 +12,7 @@
 #include <dfm-base/utils/elidetextlayout.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/widgets/dfmcustombuttons/customiconbutton.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -263,13 +264,12 @@ void EditStackedWidget::initTextShowFrame(QString fileName)
     }
     textShowFrame->setFixedWidth(kExtendedWidgetWidth);
 
-    nameEditIcon = new DIconButton(textShowFrame);
+    nameEditIcon = new CustomDIconButton(textShowFrame);
     nameEditIcon->setAccessibleName("NameEditIcon");
     nameEditIcon->setObjectName(QString("EditButton"));
     nameEditIcon->setIcon(QIcon::fromTheme("dfm_rename"));
     nameEditIcon->setIconSize({ 12, 12 });
-    nameEditIcon->setFixedSize(24, 24);
-    nameEditIcon->setFlat(true);
+    nameEditIcon->setFixedSize(30, 30);
 
     connect(nameEditIcon, &QPushButton::clicked, this, &EditStackedWidget::renameFile);
 
@@ -278,15 +278,21 @@ void EditStackedWidget::initTextShowFrame(QString fileName)
         DLabel *fileNameLabel = new DLabel(labelText, textShowFrame);
         fileNameLabel->setTextFormat(Qt::PlainText);
         fileNameLabel->setAlignment(Qt::AlignHCenter);
+        fileNameLabel->setContentsMargins(0, 0, 0, 0);
+        fileNameLabel->setMargin(0);
         textHeight += fileNameLabel->fontInfo().pixelSize() + 10;
 
         QHBoxLayout *hLayout = new QHBoxLayout;
         hLayout->addStretch(1);
-        hLayout->addWidget(fileNameLabel);
+        hLayout->addWidget(fileNameLabel, 0, Qt::AlignVCenter);
 
         if (labelText == labelTexts.last()) {
-            hLayout->addSpacing(2);
-            hLayout->addWidget(nameEditIcon);
+            fileNameLabel->setStyleSheet("padding-right: 6px;");
+            QVBoxLayout *btnWrap = new QVBoxLayout;
+            btnWrap->setContentsMargins(0, -7, 0, 0);
+            btnWrap->setSpacing(0);
+            btnWrap->addWidget(nameEditIcon);
+            hLayout->addLayout(btnWrap);
         } else if (fileNameLabel->fontMetrics().horizontalAdvance(labelText) > (rect.width() - 10)) {
             fileNameLabel->setFixedWidth(rect.width());
         }

--- a/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.h
+++ b/src/plugins/common/dfmplugin-propertydialog/views/editstackedwidget.h
@@ -9,6 +9,7 @@
 
 #include <DLabel>
 #include <DIconButton>
+#include <dfm-base/widgets/dfmcustombuttons/customiconbutton.h>
 #include <DArrowRectangle>
 #include <DTextEdit>
 
@@ -87,7 +88,7 @@ Q_SIGNALS:
 
 private:
     NameTextEdit *fileNameEdit { nullptr };
-    DTK_WIDGET_NAMESPACE::DIconButton *nameEditIcon { nullptr };
+    dfmbase::CustomDIconButton *nameEditIcon { nullptr };
     QFrame *textShowFrame { nullptr };
     QUrl fileUrl {};
 };


### PR DESCRIPTION
## 问题描述

文件属性对话框中，文件名旁边的编辑按钮在 hover 和 pressed 状态下没有任何视觉反馈效果，交互体验不一致。

## 修改内容

1. 将编辑按钮从 `DIconButton` 替换为 `CustomDIconButton`，获得 hover（10%黑色）和 pressed（20%黑色）的圆角背景反馈，与标题栏导航/搜索按钮效果一致
2. 按钮尺寸从 24x24 调整为 30x30
3. 按钮与文字间距设为 6px，并垂直居中对齐

## 测试

- [x] 浅色模式下 hover 显示 10% 黑色圆角背景
- [x] 浅色模式下 pressed 显示 20% 黑色圆角背景
- [x] 按钮与文字间距 6px
- [x] 按钮与文字垂直居中对齐
- [x] 编译通过

PMS: [BUG-375419](https://pms.uniontech.com/bug-view-375419.html)

## Summary by Sourcery

Improve the property dialog’s filename edit control with consistent interactive feedback and layout.

Bug Fixes:
- Add visible hover and pressed-state feedback to the property dialog’s filename edit button.

Enhancements:
- Align the filename and edit button consistently with updated sizing and spacing.