### PR TITLE
fix: right-align size labels in conflict dialog

### DIFF
--- a/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
+++ b/src/dfm-base/dialogs/taskdialog/taskwidget.cpp
@@ -506,13 +506,13 @@ QWidget *TaskWidget::createConflictWidget()
     conflictMainLayout->addWidget(lbSrcIcon, 0, 0, 2, 1, Qt::AlignVCenter);
     conflictMainLayout->addWidget(lbSrcTitle, 0, 1, 1, 2, Qt::AlignVCenter);
     conflictMainLayout->addWidget(lbSrcModTime, 1, 1, Qt::AlignVCenter);
-    conflictMainLayout->addWidget(lbSrcFileSize, 1, 2, Qt::AlignVCenter);
+    conflictMainLayout->addWidget(lbSrcFileSize, 1, 2, Qt::AlignVCenter | Qt::AlignRight);
 
     if (createDestLabels) {
         conflictMainLayout->addWidget(lbDstIcon, 2, 0, 2, 1, Qt::AlignVCenter);
         conflictMainLayout->addWidget(lbDstTitle, 2, 1, 1, 2, Qt::AlignVCenter);
         conflictMainLayout->addWidget(lbDstModTime, 3, 1, Qt::AlignVCenter);
-        conflictMainLayout->addWidget(lbDstFileSize, 3, 2, Qt::AlignVCenter);
+        conflictMainLayout->addWidget(lbDstFileSize, 3, 2, Qt::AlignVCenter | Qt::AlignRight);
     }
 
     conflictMainLayout->setHorizontalSpacing(4);


### PR DESCRIPTION
## Root Cause Analysis

In `TaskWidget::createConflictWidget()`, the file size labels `lbSrcFileSize` and `lbDstFileSize` are added to a `QGridLayout` with only `Qt::AlignVCenter`, missing the `Qt::AlignRight` alignment flag. Meanwhile, the speed and remaining time labels (`lbSpeed`, `lbRmTime`) above them use `Qt::AlignRight` in a `QHBoxLayout`. This causes the file size labels to appear left-aligned relative to the speed/time labels, creating a visual misalignment in the conflict/merge/coexist dialog.

The issue became visible after commit `a8c3f10e8ac1` changed file size labels from `setFixedWidth` to `setMinimumWidth`, allowing the labels to dynamically size and exposing the missing alignment flag.

## Fix

Add `Qt::AlignRight` to the `addWidget` calls for `lbSrcFileSize` (line 509) and `lbDstFileSize` (line 515), changing `Qt::AlignVCenter` to `Qt::AlignVCenter | Qt::AlignRight`. This aligns the file size labels with the speed/time labels above them.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The change only adds an alignment flag to two `QGridLayout::addWidget` calls within `createConflictWidget()`. No function signature change, no logic change, no API change.
- All 3 call sites of `createConflictWidget()` (lines 157, 183, 234) are unaffected — the widget creation logic and return value remain identical.
- Historical blame confirms the missing flag existed since the original code (2021) and was carried forward when destination labels were added (2025). No previous bug fix is reverted.

### Business Impact Scope

The change affects only the visual alignment of file size labels in file conflict/merge/coexist dialogs. When users copy files from SMB to local disk (or any file operation that triggers a conflict dialog), the source and destination file size labels will now be right-aligned with the speed and remaining time labels above them.

### Verification Suggestion

Test SMB copy to local disk triggering merge/coexist conflict dialogs — verify file size labels are right-aligned with speed/time labels. Also test local file copy conflict dialogs for consistency.

---

## 根因分析

在 `TaskWidget::createConflictWidget()` 中，文件大小标签 `lbSrcFileSize` 和 `lbDstFileSize` 添加到 `QGridLayout` 时仅使用了 `Qt::AlignVCenter`，缺少 `Qt::AlignRight` 对齐标志。而上方的速度和剩余时间标签（`lbSpeed`、`lbRmTime`）在 `QHBoxLayout` 中使用了 `Qt::AlignRight`。这导致文件大小标签相对于速度/时间标签偏左，在冲突/合并/共存对话框中产生视觉不对齐。

该问题在 commit `a8c3f10e8ac1` 将文件大小标签从 `setFixedWidth` 改为 `setMinimumWidth` 后变得明显，标签可动态调整大小，暴露了缺失的对齐标志。

## 修复方案

为 `lbSrcFileSize`（第 509 行）和 `lbDstFileSize`（第 515 行）的 `addWidget` 调用添加 `Qt::AlignRight`，将 `Qt::AlignVCenter` 改为 `Qt::AlignVCenter | Qt::AlignRight`，使文件大小标签与上方的速度/时间标签右对齐。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 改动仅在 `createConflictWidget()` 内为两个 `QGridLayout::addWidget` 调用添加对齐标志，不改变函数签名、不改变逻辑、不改变 API。
- `createConflictWidget()` 的 3 处调用点（第 157、183、234 行）均不受影响——控件创建逻辑和返回值完全一致。
- blame 历史确认缺失的标志自原始代码（2021 年）就存在，2025 年添加目标标签时延续了该写法。未撤销任何历史修复。

### 业务影响范围

改动仅影响文件冲突/合并/共存对话框中文件大小标签的视觉对齐。用户从 SMB 复制文件至本地磁盘（或任何触发冲突对话框的文件操作）时，源文件和目标文件大小标签将与上方的速度和剩余时间标签右对齐。

### 验证建议

测试 SMB 复制文件至本地磁盘触发合并/共存对话框——验证文件大小标签与速度/时间标签右对齐。同时测试本地文件复制冲突对话框的一致性。

PMS: BUG-375589

## Summary by Sourcery

Bug Fixes:
- Right-align source and destination file size labels in conflict, merge, and coexist dialogs to match the surrounding status labels.