### PR TITLE
fix: correct encryption type detection for interrupted decrypt

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -166,12 +166,18 @@ bool DiskEncryptMenuScene::initialize(const QVariantHash &params)
     param.deviceDisplayName = info->displayOf(dfmbase::FileInfo::kFileDisplayName);
     param.secType = SecKeyType::kPwd;
 
+    param.devPhy = EventsHandler::instance()->holderDevice(device);
+
     if (param.states != kStatusNotEncrypted) {
         param.secType = static_cast<SecKeyType>(device_utils::encKeyType(device));
         fmDebug() << "Device encryption finished, security type:" << param.secType;
+    } else {
+        const QString &pendingDev = EventsHandler::instance()->unfinishedDecryptJob();
+        if (pendingDev == device || pendingDev == param.devPhy) {
+            param.secType = static_cast<SecKeyType>(device_utils::encKeyType(device));
+            fmDebug() << "Device has unfinished decrypt job, security type:" << param.secType;
+        }
     }
-
-    param.devPhy = EventsHandler::instance()->holderDevice(device);
 
     return true;
 }

--- a/src/services/diskencrypt/core/cryptsetup.cpp
+++ b/src/services/diskencrypt/core/cryptsetup.cpp
@@ -792,8 +792,20 @@ int crypt_setup_helper::getToken(const QString &dev, QString *token)
     struct crypt_device *cdev { nullptr };
     dfmbase::FinallyUtil atFinish([&] {if (cdev) crypt_free(cdev); });
 
-    int r = crypt_init(&cdev,
+    int r = 0;
+    QString detachHeader;
+    r = genDetachHeaderPath(dev, &detachHeader);
+    if (r < 0)
+        return r;
+
+    if (QFile(detachHeader).exists()) {
+        r = crypt_init_data_device(&cdev,
+                                   detachHeader.toStdString().c_str(),
+                                   dev.toStdString().c_str());
+    } else {
+        r = crypt_init(&cdev,
                        dev.toStdString().c_str());
+    }
     if (r < 0) {
         qCritical() << "[crypt_setup_helper::getToken] Cannot initialize crypt device, device:" << dev << "error:" << r << " (" << strerror(-r) << ")";
         return -disk_encrypt::kErrorInitCrypt;


### PR DESCRIPTION
## Root Cause Analysis

When a PIN-encrypted device's decryption is interrupted by a hard reboot, `deviceEncryptStatus()` returns `kStatusNotEncrypted` for the device. The condition `param.states != kStatusNotEncrypted` in `DiskEncryptMenuScene::initialize()` is then false, so `encKeyType()` is never called and `param.secType` keeps the default `kPwd`. The decrypt flow then uses the user's PIN directly as the LUKS passphrase instead of deriving it via TPM+PIN, causing a "wrong passphrase" error.

Additionally, even when `encKeyType()` is called, `getToken()` in `cryptsetup.cpp` uses `crypt_init()` on a device whose LUKS header was already detached during the interrupted offline decrypt. It fails to load the LUKS2 metadata (including TPM tokens), so `encKeyType()` returns `kPwd` instead of `kPin`.

Key evidence:
- `diskencryptmenuscene.cpp:169` — condition `param.states != kStatusNotEncrypted` is false in the interrupted-decrypt scenario
- `cryptsetup.cpp:792` — `getToken()` uses `crypt_init()` which cannot find the detached LUKS2 header

## Fix

**Client side** (`diskencryptmenuscene.cpp`): Move `param.devPhy` assignment before the secType logic and add an else branch that checks `unfinishedDecryptJob()` to call `encKeyType()` for devices with an interrupted decrypt job.

**Daemon side** (`cryptsetup.cpp`): Modify `getToken()` to check `genDetachHeaderPath()` backup header file before `crypt_init()`. When the backup header exists, use `crypt_init_data_device()` to load LUKS metadata from it, matching the pattern already used by `encryptStatus()` and `csDecrypt()` in the same file.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- No function signature changes; both changes add conditional branches that only activate in the interrupted-decrypt scenario
- The `unfinishedDecryptJob()` matching pattern is already used in `updateActions()`; `crypt_init_data_device()` + `genDetachHeaderPath()` is already used by `encryptStatus()` and `csDecrypt()`
- Normal encryption/decryption flows are unchanged — new branches only trigger when `kStatusNotEncrypted` + unfinished decrypt job, or when a backup header file exists

### Business Impact Scope

Affects the disk encryption module's "resume cancel encryption" feature for PIN-encrypted system disks. When a user interrupts PIN decryption (e.g., power loss) and then resumes, the correct encryption type (PIN) will now be detected instead of incorrectly defaulting to password encryption. Password-encrypted devices and normal (non-interrupted) encryption/decryption flows are not affected.

### Verification Suggestion

Test PIN-encrypted device decryption interrupted by power loss, then resume decrypt and verify the correct PIN type is detected and decryption succeeds. Also verify normal PIN and password encryption/decryption flows have no regression.

---

## 根因分析

PIN码加密设备的解密被硬重启中断后，`deviceEncryptStatus()` 对该设备返回 `kStatusNotEncrypted`。`DiskEncryptMenuScene::initialize()` 中的条件 `param.states != kStatusNotEncrypted` 为 false，`encKeyType()` 未被调用，`param.secType` 保持默认值 `kPwd`。解密流程直接使用用户输入的 PIN 作为 LUKS passphrase，而非通过 TPM+PIN 派生，导致"口令或PIN码错误"。

此外，即使调用了 `encKeyType()`，`cryptsetup.cpp` 的 `getToken()` 使用 `crypt_init()` 加载已分离 LUKS 头部的设备，无法读取 LUKS2 元数据（含 TPM tokens），导致 `encKeyType()` 返回 `kPwd` 而非 `kPin`。

关键证据：
- `diskencryptmenuscene.cpp:169` — 中断解密场景下条件 `param.states != kStatusNotEncrypted` 为 false
- `cryptsetup.cpp:792` — `getToken()` 使用 `crypt_init()` 无法找到已分离的 LUKS2 头部

## 修复方案

**客户端**（`diskencryptmenuscene.cpp`）：将 `param.devPhy` 赋值提前到 secType 逻辑之前，新增 else 分支检查 `unfinishedDecryptJob()`，匹配时调用 `encKeyType()` 获取正确安全类型。

**守护进程**（`cryptsetup.cpp`）：修改 `getToken()`，在 `crypt_init()` 前通过 `genDetachHeaderPath()` 检查备份头部文件，存在则使用 `crypt_init_data_device()` 从备份文件加载 LUKS 头部，与同文件 `encryptStatus()`/`csDecrypt()` 已有模式一致。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 无函数签名变更，两处改动均为新增条件分支，仅在中断解密场景下触发
- `unfinishedDecryptJob()` 匹配模式已在 `updateActions()` 中使用；`crypt_init_data_device()` + `genDetachHeaderPath()` 已在 `encryptStatus()` 和 `csDecrypt()` 中使用
- 正常加解密流程不受影响——新分支仅在 `kStatusNotEncrypted` + 存在未完成解密任务，或备份头部文件存在时触发

### 业务影响范围

影响磁盘加密模块的"继续取消加密"功能，针对 PIN 码加密的系统盘。用户中断 PIN 解密（如断电）后恢复时，将正确检测到 PIN 加密类型，而非错误地默认为密码加密。密码加密设备及正常（非中断）加解密流程不受影响。

### 验证建议

测试 PIN 码加密设备解密中断后恢复，验证正确识别为 PIN 加密且解密成功。同时验证正常 PIN 和密码加解密流程无回归。

PMS: BUG-375557

## Summary by Sourcery

Fix resumed interrupted decryption so PIN-encrypted devices are identified correctly and decrypted with the appropriate credentials.

Bug Fixes:
- Correct encryption type detection when resuming a decryption interrupted by a reboot, ensuring PIN-encrypted devices continue using PIN-derived LUKS credentials.

Enhancements:
- Support reading encryption metadata from detached backup LUKS headers when determining the device security type.