### PR TITLE
fix: emblem still shows after disabling UDisk emblem

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -285,7 +285,7 @@ bool EmblemHelper::isExtEmblemProhibited(const FileInfoPointer &info, const QUrl
     // In the block device, all file extension emblem icons are displayed by default,
     // When configuring emblem icons display, all file extension corners are displayed in the block device
     // When emblem icons hiding is configured, all file extension corners are hidden in the block device
-    if ((info ? !info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : !ProtocolUtils::isLocalFile(url))) {
+    if (!ProtocolUtils::isLocalFile(url)) {
         bool enable { DConfigManager::instance()->value("org.deepin.dde.file-manager.emblem", "blockExtEnable", true).toBool() };
         if (enable)
             return false;


### PR DESCRIPTION
## Root Cause Analysis

`EmblemHelper::isExtEmblemProhibited()` uses `kFileLocalDevice` extend attribute to decide whether a file resides on a block device (UDisk). When `info` is available, it queries `info->extendAttributes(kFileLocalDevice)` instead of calling `ProtocolUtils::isLocalFile(url)` directly. However, `SyncFileInfo::extendAttributes(kFileLocalDevice)` hardcodes `return true` (`syncfileinfo.cpp:271`), ignoring the actual `d->isLocalDevice` member. This makes `isExtEmblemProhibited()` always treat UDisk files as "local device", skipping the `blockExtEnable` DConfig check entirely — so emblems persist even after group policy disables them.

Key evidence: `syncfileinfo.cpp:271` getter hardcodes `return true` while setter (`syncfileinfo.cpp:531`) correctly writes `d->isLocalDevice`; `emblemhelper.cpp:288` evaluates `!true = false`, bypassing the `blockExtEnable` branch; `schemefactory.cpp:22-26` creates `SyncFileInfo` for `file://` non-remote URLs including UDisk.

## Fix

Replace the `kFileLocalDevice` extend-attribute query with a direct `ProtocolUtils::isLocalFile(url)` call in `emblemhelper.cpp:288`. `isLocalFile()` uses `isFileOfExternalBlockMounts` to correctly return `false` for UDisk (external block mounts), ensuring UDisk files enter the `blockExtEnable` config check. This deviates from the analysis-report's recommended root-cause fix (which also patches `syncfileinfo.cpp` getter + init) — per user direction, only `emblemhelper.cpp` is changed to minimize scope.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The target line was last modified by commit `8411fb6a4d1f` which introduced the ternary expression relying on `kFileLocalDevice`; this fix reverts to the pre-refactor direct `isLocalFile` call, restoring original behavior.
- Only production caller is `EmblemManager::onPaintEmblems` (`emblemmanager.cpp:46`); signature unchanged, non-UDisk local files and remote files behave identically.

### Business Impact Scope

- **File emblem display** — controls whether extension emblems (e.g., gio emblem) are shown on files across different storage devices.
- Affected scenario: group policy disables UDisk emblem (`blockExtEnable=false`), after restart file manager or system, UDisk file emblems should now be correctly hidden.
- Local disk file emblems, remote file (SMB/FTP) emblems are unaffected (remote files return early at line 282).

### Verification Suggestion

Focus regression on UDisk emblem toggle: disable via group policy → restart file manager → verify UDisk emblems hidden; re-enable → verify emblems show. Confirm local disk and remote file emblems are unaffected.

---

## 根因分析

`EmblemHelper::isExtEmblemProhibited()` 使用 `kFileLocalDevice` 扩展属性判断文件是否位于块设备（U盘）上。当 `info` 可用时，它查询 `info->extendAttributes(kFileLocalDevice)` 而非直接调用 `ProtocolUtils::isLocalFile(url)`。但 `SyncFileInfo::extendAttributes(kFileLocalDevice)` 硬编码 `return true`（`syncfileinfo.cpp:271`），忽略了实际的 `d->isLocalDevice` 成员。这导致 `isExtEmblemProhibited()` 始终将U盘文件视为"本地设备"，跳过 `blockExtEnable` DConfig 检查——组策略关闭角标后角标仍然显示。

关键证据：`syncfileinfo.cpp:271` getter 硬编码 `return true`，而 setter（`syncfileinfo.cpp:531`）正确写入 `d->isLocalDevice`；`emblemhelper.cpp:288` 计算结果 `!true = false`，跳过 `blockExtEnable` 分支；`schemefactory.cpp:22-26` 对 `file://` 非远程 URL（含U盘）创建 `SyncFileInfo`。

## 修复方案

将 `emblemhelper.cpp:288` 中的 `kFileLocalDevice` 扩展属性查询替换为直接调用 `ProtocolUtils::isLocalFile(url)`。`isLocalFile()` 通过 `isFileOfExternalBlockMounts` 对U盘（外部块设备挂载）正确返回 `false`，确保U盘文件进入 `blockExtEnable` 配置检查。此方案偏离了 analysis-report 推荐的根因层修复（同时修改 `syncfileinfo.cpp` getter + init）——按用户要求仅修改 `emblemhelper.cpp` 以最小化改动范围。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标行最后由 commit `8411fb6a4d1f` 修改，该 commit 引入了依赖 `kFileLocalDevice` 的三元表达式；本次修复还原为重构前的直接 `isLocalFile` 调用，恢复原始行为。
- 唯一生产调用方为 `EmblemManager::onPaintEmblems`（`emblemmanager.cpp:46`）；签名不变，非U盘本地文件和远程文件行为一致。

### 业务影响范围

- **文件角标显示** — 控制文件扩展角标（如 gio emblem）在不同存储设备上的显示行为。
- 受影响场景：组策略关闭U盘角标（`blockExtEnable=false`）后，重启文管或系统，U盘文件角标应正确隐藏。
- 本地磁盘文件角标、远程文件（SMB/FTP）角标不受影响（远程文件在 line 282 提前返回）。

### 验证建议

重点回归U盘角标开关：组策略关闭 → 重启文管 → 验证U盘角标已隐藏；开启 → 验证角标正常显示。确认本地磁盘和远程文件角标不受影响。

## Summary by Sourcery

Bug Fixes:
- Correctly apply the UDisk emblem display policy so file emblems are hidden when disabled by configuration.