### PR TITLE
fix: emblem still shows after disabling UDisk emblem

### DIFF
--- a/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
+++ b/src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp
@@ -285,7 +285,7 @@ bool EmblemHelper::isExtEmblemProhibited(const FileInfoPointer &info, const QUrl
     // In the block device, all file extension emblem icons are displayed by default,
     // When configuring emblem icons display, all file extension corners are displayed in the block device
     // When emblem icons hiding is configured, all file extension corners are hidden in the block device
-    if ((info ? !info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : !ProtocolUtils::isLocalFile(url))) {
+    if (!ProtocolUtils::isLocalFile(url)) {
         bool enable { DConfigManager::instance()->value("org.deepin.dde.file-manager.emblem", "blockExtEnable", true).toBool() };
         if (enable)
             return false;


### PR DESCRIPTION
Cherry-pick of #4285 to release/snipe.

## 问题

组策略关闭U盘文件角标功能后，重启系统或重启文管，角标仍然存在。

## 根因

`EmblemHelper::isExtEmblemProhibited` 中通过 `kFileLocalDevice` 扩展属性判断是否为本地设备，但该属性 getter 硬编码返回 `true`，导致U盘文件始终被误判为本地设备，跳过了 `blockExtEnable` 配置检查。

## 修复

将 `kFileLocalDevice` 扩展属性查询替换为直接调用 `ProtocolUtils::isLocalFile(url)`，该方法通过 `isFileOfExternalBlockMounts` 正确排除U盘等外部块设备，使U盘文件进入 `blockExtEnable` 配置检查分支。

```diff
- if ((info ? !info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool() : !ProtocolUtils::isLocalFile(url))) {
+ if (!ProtocolUtils::isLocalFile(url)) {
```

## 改动文件

`src/plugins/common/dfmplugin-emblem/utils/emblemhelper.cpp` — 1 行改动

## 关联

- 上游 PR: #4285
- PMS: bug-375625

## Summary by Sourcery

Bug Fixes:
- Fix UDisk file emblems remaining visible after the emblem display policy is disabled.