### PR TITLE
feat: add idle and upgrade pause hints

### DIFF
--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhintcontroller.cpp
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhintcontroller.cpp
@@ -291,7 +291,7 @@ SearchHintController::HintType SearchHintController::evaluateHint(quint64 winId)
             return HintType::IndexFailed;
     }
 
-    // 3. Paused (battery > power save)
+    // 3. Paused (battery > power save > idle > upgrade)
     if (!ws.dismissedTypes.contains(HintType::IndexPausedBattery)) {
         if ((m_textStatusValid && m_textState == "WaitingPower")
             || (m_ocrStatusValid && m_ocrState == "WaitingPower"))
@@ -304,7 +304,19 @@ SearchHintController::HintType SearchHintController::evaluateHint(quint64 winId)
             return HintType::IndexPausedPowerSave;
     }
 
-    // 4. Updating
+    if (!ws.dismissedTypes.contains(HintType::IndexPausedIdle)) {
+        if ((m_textStatusValid && m_textState == "WaitingIdle")
+            || (m_ocrStatusValid && m_ocrState == "WaitingIdle"))
+            return HintType::IndexPausedIdle;
+    }
+
+    if (!ws.dismissedTypes.contains(HintType::IndexWaitingUpgrade)) {
+        if ((m_textStatusValid && m_textState == "WaitingUpgrade")
+            || (m_ocrStatusValid && m_ocrState == "WaitingUpgrade"))
+            return HintType::IndexWaitingUpgrade;
+    }
+
+    // 5. Updating
     if (!ws.dismissedTypes.contains(HintType::IndexUpdating)) {
         if ((m_textStatusValid && m_textState == "Running")
             || (m_ocrStatusValid && m_ocrState == "Running"))
@@ -345,6 +357,18 @@ QVariantMap SearchHintController::buildHintContent(quint64 winId, HintType type)
         content[QStringLiteral("icon")] = QStringLiteral("waiting");
         content[QStringLiteral("text")] = tr("Power save mode is enabled. Some content indexing has been paused.");
         actions.append(QVariantMap { { "id", "continue-update" }, { "label", tr("Continue updating") } });
+        actions.append(QVariantMap { { "id", "view-status" }, { "label", tr("View") } });
+        break;
+    case HintType::IndexPausedIdle:
+        content[QStringLiteral("icon")] = QStringLiteral("waiting");
+        content[QStringLiteral("text")] = tr("Waiting for the device to become idle. Some content indexing has been paused.");
+        actions.append(QVariantMap { { "id", "continue-update" }, { "label", tr("Continue updating") } });
+        actions.append(QVariantMap { { "id", "view-status" }, { "label", tr("View") } });
+        break;
+    case HintType::IndexWaitingUpgrade:
+        content[QStringLiteral("icon")] = QStringLiteral("waiting");
+        content[QStringLiteral("text")] = tr("Waiting for index service upgrade. Some content indexing has been paused.");
+        actions.append(QVariantMap { { "id", "retry-update" }, { "label", tr("Update index now") } });
         actions.append(QVariantMap { { "id", "view-status" }, { "label", tr("View") } });
         break;
     case HintType::IndexUpdating:
@@ -414,11 +438,8 @@ void SearchHintController::onHintAction(quint64 winId, const QString &id)
         dismissAndReevaluate(winId, actedType);
     } else if (id == "close") {
         dismissAndReevaluate(winId, actedType);
-    } else if (id == "continue-update") {
-        requestContinueUpdate(actedType);
-        dismissAndReevaluate(winId, actedType);
-    } else if (id == "retry-update") {
-        requestRetryUpdate(actedType);
+    } else if (id == "continue-update" || id == "retry-update") {
+        requestUpdate(actedType);
         dismissAndReevaluate(winId, actedType);
     } else if (id == "view-status") {
         openSettingsPage(winId);
@@ -443,39 +464,48 @@ void SearchHintController::openSettingsPage(quint64 winId) const
     dpfSignalDispatcher->publish(GlobalEventType::kShowSettingDialog, winId, QString(SEARCH_SETTING_GROUP));
 }
 
-void SearchHintController::requestContinueUpdate(HintType type) const
+void SearchHintController::requestUpdate(HintType type) const
 {
-    // Only update the index that is actually in the paused state matching the hint type.
+    // Only update the index that is actually in the state matching the hint type.
     QString targetState;
-    if (type == HintType::IndexPausedBattery)
+    bool force = false;
+    switch (type) {
+    case HintType::IndexPausedBattery:
         targetState = QStringLiteral("WaitingPower");
-    else if (type == HintType::IndexPausedPowerSave)
+        break;
+    case HintType::IndexPausedPowerSave:
         targetState = QStringLiteral("WaitingPowerSave");
-    else
-        return;   // No continue-update action for other hint types
+        break;
+    case HintType::IndexPausedIdle:
+        targetState = QStringLiteral("WaitingIdle");
+        break;
+    case HintType::IndexFailed:
+        targetState = QStringLiteral("Failed");
+        force = true;
+        break;
+    case HintType::IndexWaitingUpgrade:
+        targetState = QStringLiteral("WaitingUpgrade");
+        force = true;
+        break;
+    default:
+        return;   // No update action for other hint types
+    }
 
     const QStringList &paths = DFMSEARCH::Global::defaultIndexedDirectory();
-    fmInfo() << "User requested continue update (bypass env) for" << paths.size() << "paths, type:" << static_cast<int>(type);
+    fmInfo() << "User requested" << (force ? "force update" : "continue update (bypass env)")
+             << "for" << paths.size() << "paths, type:" << static_cast<int>(type);
+
+    auto applyToClient = [force, &paths](AbstractIndexClient *client) {
+        if (force)
+            client->forceUpdateIndex(paths);
+        else
+            client->updateIndexBypassEnv(paths);
+    };
 
     if (m_textStatusValid && m_textState == targetState)
-        TextIndexClient::instance()->updateIndexBypassEnv(paths);
+        applyToClient(TextIndexClient::instance());
     if (m_ocrStatusValid && m_ocrState == targetState)
-        OcrIndexClient::instance()->updateIndexBypassEnv(paths);
-}
-
-void SearchHintController::requestRetryUpdate(HintType type) const
-{
-    // Only retry the index that is actually in the Failed state.
-    if (type != HintType::IndexFailed)
-        return;
-
-    const QStringList &paths = DFMSEARCH::Global::defaultIndexedDirectory();
-    fmInfo() << "User requested retry update (force) for" << paths.size() << "paths, type:" << static_cast<int>(type);
-
-    if (m_textStatusValid && m_textState == "Failed")
-        TextIndexClient::instance()->forceUpdateIndex(paths);
-    if (m_ocrStatusValid && m_ocrState == "Failed")
-        OcrIndexClient::instance()->forceUpdateIndex(paths);
+        applyToClient(OcrIndexClient::instance());
 }
 
 QStringList SearchHintController::disabledSearchModes() const

--- a/src/plugins/filemanager/dfmplugin-search/utils/searchhintcontroller.h
+++ b/src/plugins/filemanager/dfmplugin-search/utils/searchhintcontroller.h
@@ -29,6 +29,8 @@ public:
         IndexFailed,
         IndexPausedBattery,
         IndexPausedPowerSave,
+        IndexPausedIdle,
+        IndexWaitingUpgrade,
         IndexUpdating,
     };
 
@@ -67,8 +69,7 @@ private:
     void dismissAndReevaluate(quint64 winId, HintType actedType);
 
     void openSettingsPage(quint64 winId) const;
-    void requestContinueUpdate(HintType type) const;
-    void requestRetryUpdate(HintType type) const;
+    void requestUpdate(HintType type) const;
 
     struct WindowState
     {


### PR DESCRIPTION
1. Add IndexPausedIdle and IndexWaitingUpgrade to HintType enum
2. Implement evaluation logic for WaitingIdle and WaitingUpgrade states
3. Add hint content with appropriate icons and descriptive text for
new states
4. Refactor requestContinueUpdate and requestRetryUpdate into unified
requestUpdate
5. Add force flag to differentiate between bypass-env and force-update
operations
6. Update priority order comment for paused states

Log: Added new search index pause hints for idle and upgrade states

Influence:
1. Trigger index pause by simulating WaitingIdle state and verify hint
appears
2. Trigger index pause by simulating WaitingUpgrade state and verify
hint appears
3. Click "Continue updating" on idle hint and verify indexing resumes
4. Click "Update index now" on upgrade hint and verify forced update
triggers
5. Dismiss new hint types and verify they do not reappear for same
window
6. Verify correct priority order when multiple pause conditions exist
7. Test that "View" button still opens search settings page correctly

feat: 添加空闲和升级暂停提示

1. 在 HintType 枚举中添加 IndexPausedIdle 和 IndexWaitingUpgrade
2. 实现 WaitingIdle 和 WaitingUpgrade 状态的评估逻辑
3. 为新状态添加带有适当图标和描述性文本的提示内容
4. 将 requestContinueUpdate 和 requestRetryUpdate 重构为统一的
requestUpdate
5. 添加 force 标志以区分绕过环境和强制更新操作
6. 更新暂停状态的优先级顺序注释

Log: 新增空闲和升级状态下的搜索索引暂停提示

Influence:
1. 模拟 WaitingIdle 状态触发索引暂停，验证提示正确显示
2. 模拟 WaitingUpgrade 状态触发索引暂停，验证提示正确显示
3. 点击空闲提示的"继续更新"按钮，验证索引恢复
4. 点击升级提示的"立即更新索引"按钮，验证强制更新触发
5. 关闭新提示类型，验证同一窗口不会再次出现
6. 验证多个暂停条件同时存在时的正确优先级顺序
7. 测试"查看"按钮仍能正确打开搜索设置页面

## Summary by Sourcery

Add idle and upgrade pause hints to help users resume or force search index updates.

New Features:
- Add search index hints for idle-paused and service-upgrade-waiting states, including contextual actions and settings access.

Enhancements:
- Unify continue and retry index actions while supporting bypass-environment and forced updates.
- Define priority ordering for the new paused states alongside existing pause conditions.