### PR TITLE
fix: correct encryption type detection for interrupted decrypt

### DIFF
--- a/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
+++ b/src/plugins/filemanager/dfmplugin-disk-encrypt-entry/menu/diskencryptmenuscene.cpp
@@ -166,12 +166,18 @@ bool DiskEncryptMenuScene::initialize(const QVariantHash &params)
     param.deviceDisplayName = info->displayOf(dfmbase::FileInfo::kFileDisplayName);
     param.secType = SecKeyType::kPwd;
 
+    param.devPhy = EventsHandler::instance()->holderDevice(device);
+
     if (param.states != kStatusNotEncrypted) {
         param.secType = static_cast<SecKeyType>(device_utils::encKeyType(device));
         fmDebug() << "Device encryption finished, security type:" << param.secType;
+    } else {
+        const QString &pendingDev = EventsHandler::instance()->unfinishedDecryptJob();
+        if (pendingDev == device || pendingDev == param.devPhy) {
+            param.secType = static_cast<SecKeyType>(device_utils::encKeyType(device));
+            fmDebug() << "Device has unfinished decrypt job, security type:" << param.secType;
+        }
     }
-
-    param.devPhy = EventsHandler::instance()->holderDevice(device);
 
     return true;
 }

--- a/src/services/diskencrypt/core/cryptsetup.cpp
+++ b/src/services/diskencrypt/core/cryptsetup.cpp
@@ -792,8 +792,20 @@ int crypt_setup_helper::getToken(const QString &dev, QString *token)
     struct crypt_device *cdev { nullptr };
     dfmbase::FinallyUtil atFinish([&] {if (cdev) crypt_free(cdev); });
 
-    int r = crypt_init(&cdev,
+    int r = 0;
+    QString detachHeader;
+    r = genDetachHeaderPath(dev, &detachHeader);
+    if (r < 0)
+        return r;
+
+    if (QFile(detachHeader).exists()) {
+        r = crypt_init_data_device(&cdev,
+                                   detachHeader.toStdString().c_str(),
+                                   dev.toStdString().c_str());
+    } else {
+        r = crypt_init(&cdev,
                        dev.toStdString().c_str());
+    }
     if (r < 0) {
         qCritical() << "[crypt_setup_helper::getToken] Cannot initialize crypt device, device:" << dev << "error:" << r << " (" << strerror(-r) << ")";
         return -disk_encrypt::kErrorInitCrypt;


### PR DESCRIPTION
1. Root cause: When PIN-encrypted device decryption is interrupted by
   power loss, deviceEncryptStatus() returns kStatusNotEncrypted, so
   encKeyType() is never called and secType keeps default kPwd.
   Additionally getToken() in cryptsetup.cpp uses crypt_init() on the
   device whose LUKS header was already detached, so it fails to load
   LUKS2 metadata and returns kPwd instead of kPin.
2. Fix: Add else branch in initialize() to check unfinishedDecryptJob()
   and call encKeyType() when an interrupted decrypt job matches the
   device. Modify getToken() to check genDetachHeaderPath() backup
   header file and use crypt_init_data_device() when it exists, matching
   the pattern already used by encryptStatus() and csDecrypt().
3. Impact: Only affects devices with interrupted decrypt jobs where
   deviceEncryptStatus returns kStatusNotEncrypted. Normal encryption
   and decryption flows are unchanged.

Log: Fix wrong encryption type (kPwd instead of kPin) shown after
interrupted PIN decryption resume

Influence:
1. Test PIN-encrypted device decrypt interrupted by power loss, then
   resume decrypt and verify correct PIN type is detected
2. Test normal PIN encryption and decryption flow for regressions
3. Test password-encrypted device decrypt interruption and resume

fix: 修复中断解密恢复时加密类型误判的问题

1. 根因：PIN码加密设备解密被断电中断后，deviceEncryptStatus()返回
   kStatusNotEncrypted，导致encKeyType()未被调用，secType保持默认
   kPwd。同时cryptsetup.cpp的getToken()用crypt_init()加载已分离
   LUKS头部的设备，无法读取LUKS2元数据，返回kPwd而非kPin。
2. 方案：initialize()新增else分支检查unfinishedDecryptJob()，匹配
   时调用encKeyType()获取正确安全类型。getToken()先检查
   genDetachHeaderPath()备份头部文件，存在则用
   crypt_init_data_device()加载，与encryptStatus()/csDecrypt()
   已有模式一致。
3. 影响：仅影响deviceEncryptStatus返回kStatusNotEncrypted且有
   未完成解密任务的设备，正常加解密流程不受影响。

Log: 修复中断解密恢复时加密类型误判为密码加密的问题

Influence:
1. 测试PIN码加密设备解密中断后恢复，验证正确识别为PIN加密
2. 测试正常PIN加解密流程无回归
3. 测试密码加密设备解密中断后恢复

PMS: BUG-375557

## Summary by Sourcery

Correct encryption type detection for interrupted decryption recovery.

Bug Fixes:
- Correct encryption-type detection when resuming devices with interrupted decryption, including PIN-encrypted devices whose status appears unencrypted.
- Restore security-type detection from detached LUKS headers during token lookup.