### PR TITLE
fix: clear task queue on force-bypass full scan

### DIFF
--- a/src/services/textindex/task/taskmanager.cpp
+++ b/src/services/textindex/task/taskmanager.cpp
@@ -201,6 +201,17 @@ bool TaskManager::startTask(IndexTask::Type type, const QStringList &pathList,
     // 清除队列中与新任务同类型同路径的冗余任务，避免暂停→手动更新→完成后重复执行
     removeDuplicateFullScanTasks(type, pathList);
 
+    // force-bypass 全量任务覆盖了所有增量变更，清除队列中所有被阻塞的任务。
+    // 否则任务完成后队列非空 → finalizeIndexState 不设 Clean → 状态卡在 Waiting*。
+    // 全量扫描覆盖了所有路径，包括 FileList 任务的 path 格式（FileList-yyyymmdd-hhmmss）
+    // 和 MoveFileList 任务的 path 格式（MoveList-yyyymmdd-hhmmss），这些路径无法通过
+    // 路径匹配来识别，因此直接清空整个队列。
+    if (forceBypass && isFullScanTask(type) && !taskQueue.isEmpty()) {
+        fmInfo() << "[TaskManager::startTask] Clearing" << taskQueue.size()
+                 << "blocked task(s) from queue - force-bypass full-scan supersedes all pending work";
+        taskQueue.clear();
+    }
+
     // 获取对应的任务处理器
     TaskHandler handler = getTaskHandler(type);
     if (!handler) {


### PR DESCRIPTION
Added queue clearing logic in TaskManager::startTask when a force-bypass
full scan task is initiated. The force-bypass full scan task supersedes
all pending incremental work, so any blocked tasks in the queue become
irrelevant. If these tasks are not cleared, the system state can get
stuck in Waiting* states because finalizeIndexState won't set the
Clean flag when the queue is non-empty after task completion. The task
queue contains both FileList and MoveFileList tasks with date-time
stamped path formats that cannot be matched via simple path comparison,
necessitating a complete queue clear rather than selective removal for
this specific scenario.

Log: Fixed indexing state getting stuck after force-bypass updates

Influence:
1. Test initiating a force-bypass full scan on a library with pending
tasks
2. Verify the task queue is cleared when the full scan starts
3. Confirm the indexing state transitions to Clean after the full scan
completes
4. Test normal incremental updates still work correctly without force-
bypass
5. Check that the system doesn't get stuck in WaitingUpdate or
WaitingRescan states

fix: 强制绕过全量扫描时清空任务队列

在 TaskManager::startTask 中增加了当强制绕过全量扫描任务启动时的队列清空
逻辑。强制绕过全量扫描任务将覆盖所有挂起的增量工作，因此队列中任何被阻塞
的任务都变得无关紧要。如果不清理这些任务，系统状态可能会卡在 Waiting* 状
态，因为在任务完成队列非空时，finalizeIndexState 不会设置 Clean 标志。任
务队列包含带有日期时间戳路径格式的 FileList 和 MoveFileList 任务，这些路
径无法通过简单的路径比较来匹配，因此在这种特定场景下需要完全清空队列而不
是选择性删除。

Log: 修复强制绕过更新后索引状态卡住的问题

Influence:
1. 测试在有待处理任务的库上启动强制绕过全量扫描
2. 验证全量扫描开始时任务队列是否被清空
3. 确认全量扫描完成后索引状态正确转换到 Clean
4. 测试没有强制绕过时正常的增量更新是否仍然正常工作
5. 检查系统不会卡在 WaitingUpdate 或 WaitingRescan 状态

## Summary by Sourcery

Bug Fixes:
- Prevent force-bypass full scans from leaving indexing stuck in Waiting* states by clearing superseded pending tasks before the scan starts.