### PR TITLE
fix: async CIFS busy check in TrashCoreEventSender to prevent startup stall

### DIFF
--- a/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.cpp
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.cpp
@@ -17,6 +17,8 @@
 
 #include <QDebug>
 #include <QUrl>
+#include <QtConcurrent>
+#include <QFutureWatcher>
 
 using namespace dfmplugin_trashcore;
 DFMBASE_USE_NAMESPACE
@@ -49,17 +51,34 @@ void TrashCoreEventSender::initTrashWatcher()
 
 bool TrashCoreEventSender::checkAndStartWatcher()
 {
-    if (NetworkUtils::instance()->checkAllCIFSBusy()) {
-        timer.start();
+    if (cifsCheckInProgress)
         return false;
-    }
 
-    if (!trashFileWatcher->startWatcher()) {
-        timer.start();
-        return false;
-    }
+    cifsCheckInProgress = true;
+    auto *watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher]() {
+        cifsCheckInProgress = false;
+        bool cifsBusy = watcher->result();
+        watcher->deleteLater();
 
-    return true;
+        if (cifsBusy) {
+            timer.start();
+            return;
+        }
+
+        if (!trashFileWatcher->startWatcher()) {
+            timer.start();
+            return;
+        }
+
+        watcherInitialized = true;
+        initTrashState();
+    });
+    watcher->setFuture(QtConcurrent::run([]() {
+        return NetworkUtils::instance()->checkAllCIFSBusy();
+    }));
+
+    return false;
 }
 
 TrashCoreEventSender *TrashCoreEventSender::instance()

--- a/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
+++ b/src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h
@@ -52,6 +52,7 @@ private:
     TrashState trashState { TrashState::Unknown };
     QTimer timer;
     bool watcherInitialized { false };
+    bool cifsCheckInProgress { false };
 };
 
 }


### PR DESCRIPTION
## 问题

SMB 服务器挂载后断网，启动文件管理器时速度非常慢。根因是 `TrashCoreEventSender::checkAndStartWatcher()` 在主线程同步调用 `NetworkUtils::checkAllCIFSBusy()`，后者对每个 CIFS 挂载点串行做 TCP 探测，断网时每次探测都需等满超时（含代理重试最坏 ~4s/挂载），阻塞主线程事件循环。

## 修复方案

将 `checkAndStartWatcher()` 中的 CIFS 检查改为异步执行（`QtConcurrent::run` + `QFutureWatcher`），主线程不再阻塞。watcher 启动和 trash 状态初始化在后台检查完成后的回调中执行，语义与原同步逻辑一致。

新增 `cifsCheckInProgress` 标志位防止 `tryInitialize()` 重入时重复发起异步检查。

## 改动文件

- `src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.cpp`
- `src/plugins/common/dfmplugin-trashcore/events/trashcoreeventsender.h`

## 关联

- 关联 issue: V-3515
- 前序修复: #249 (util-dfm), #3525 (dde-file-manager)

## Summary by Sourcery

Move CIFS busy detection off the main thread to keep file manager startup responsive when network mounts are unavailable.

Bug Fixes:
- Prevent startup stalls caused by synchronous CIFS availability checks when network mounts are unreachable.

Enhancements:
- Run CIFS busy checks asynchronously while preserving watcher startup and trash-state initialization behavior.
- Prevent concurrent initialization attempts from launching duplicate CIFS checks.