### PR TITLE
fix(at-spi): add accessible names for sidebar items and menu actions

### DIFF
--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.cpp
@@ -207,6 +207,7 @@ bool SideBarModel::insertRow(int row, SideBarItem *item)
     SideBarItemSeparator *groupItem = dynamic_cast<SideBarItemSeparator *>(item);
     if (groupItem) {   // top item
         QStandardItemModel::insertRow(row + 1, item);   // insert the top item
+        setItemAccessibleName(item);
         return true;
     } else {   // sub item
         int count = this->rowCount();
@@ -219,12 +220,16 @@ bool SideBarModel::insertRow(int row, SideBarItem *item)
             SideBarItem *groupItem = this->itemFromIndex(index);
             if (groupItem) {
                 int rows = groupItem->rowCount();
-                if (row == 0 || (row > 0 && row < rows))
+                if (row == 0 || (row > 0 && row < rows)) {
                     groupItem->insertRow(row, item);
-                else if (row >= rows)
+                    setItemAccessibleName(item);
+                } else if (row >= rows) {
                     groupItem->appendRow(item);
-                else if (row == -1)
+                    setItemAccessibleName(item);
+                } else if (row == -1) {
                     groupItem->insertRow(0, item);
+                    setItemAccessibleName(item);
+                }
             }
             return true;
         }
@@ -249,6 +254,7 @@ int SideBarModel::appendRow(SideBarItem *item, bool direct)
     if (topItem) {   // Top item
         auto t = topItem->group();
         QStandardItemModel::appendRow(item);
+        setItemAccessibleName(item);
         return rowCount() - 1;   // The return value is the index of top item.
     } else {   // Sub item
         int count = this->rowCount();
@@ -275,22 +281,27 @@ int SideBarModel::appendRow(SideBarItem *item, bool direct)
                 bool sorted = { dpfHookSequence->run("dfmplugin_sidebar", "hook_Group_Sort", groupId, item->subGourp(), item->url(), tmpItem->url()) };
                 if (sorted) {
                     groupItem->insertRow(row, item);
+                    setItemAccessibleName(item);
                     itemInserted = true;
                     break;
                 }
             }
-            if (!itemInserted)
+            if (!itemInserted) {
                 groupItem->appendRow(item);
+                setItemAccessibleName(item);
+            }
 
             return row;   // The position after sorted
         }
     }
     if (groupOther && !topItem) {   // If can not find out the parent item, just append it to Group_Other
         groupOther->appendRow(item);
+        setItemAccessibleName(item);
         fmInfo() << "Item added to groupOther";
         return groupOther->rowCount() - 1;
     }
     QStandardItemModel::appendRow(item);
+    setItemAccessibleName(item);
     fmInfo() << "Item added to the end of sidebar.";
     return rowCount() - 1;
 }
@@ -360,6 +371,7 @@ void SideBarModel::updateRow(const QUrl &url, const ItemInfo &newInfo)
                 else
                     flags &= (~Qt::ItemIsEditable);
                 subItem->setFlags(flags);
+                setItemAccessibleName(subItem);
                 return;
             }
         }
@@ -668,6 +680,7 @@ void SideBarModel::addSubItem(const QModelIndex &index, const QUrl &url)
     }
 
     parentItem->insertRow(insertRow, item);
+    setItemAccessibleName(item);
 }
 
 void SideBarModel::removeSubItem(const QModelIndex &index, const QUrl &url)
@@ -720,5 +733,18 @@ void SideBarModel::removeSubItem(const QModelIndex &index, const QUrl &url)
         SideBarInfoCacheMananger::instance()->removeItemInfoCache(url);
         parentItem->removeRow(index.row());
         fmDebug() << "Item removed from sidebar:" << url;
+    }
+}
+
+void SideBarModel::setItemAccessibleName(SideBarItem *item) const
+{
+    if (!item)
+        return;
+    // Use the display text (already translated) as both objectName and accessibleName
+    // for AT-SPI accessibility tree lookup.
+    const QString &text = item->text();
+    if (!text.isEmpty()) {
+        item->setObjectName(text);
+        item->setAccessibleName(text);
     }
 }

--- a/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
+++ b/src/plugins/filemanager/dfmplugin-sidebar/treemodels/sidebarmodel.h
@@ -61,6 +61,8 @@ private slots:
 
     void addSubItem(const QModelIndex &index, const QUrl &url);
     void removeSubItem(const QModelIndex &index, const QUrl &url);
+    // Set AT-SPI accessible name for sidebar items
+    void setItemAccessibleName(SideBarItem *item) const;
 
 private:
     QMutex locker;

--- a/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
+++ b/src/plugins/filemanager/dfmplugin-titlebar/utils/titlebarhelper.cpp
@@ -97,30 +97,42 @@ void TitleBarHelper::createSettingsMenu(quint64 id)
 
     QAction *action { new QAction(QObject::tr("New window"), menu) };
     action->setData(MenuAction::kNewWindow);
+    action->setObjectName(QObject::tr("New window"));
+    action->setAccessibleName(QObject::tr("New window"));
     menu->addAction(action);
 
     action = new QAction(QObject::tr("New tab"), menu);
     action->setData(MenuAction::kOpenInNewTab);
+    action->setObjectName(QObject::tr("New tab"));
+    action->setAccessibleName(QObject::tr("New tab"));
     menu->addAction(action);
 
     menu->addSeparator();
 
     action = new QAction(QObject::tr("Connect to Server"), menu);
     action->setData(MenuAction::kConnectToServer);
+    action->setObjectName(QObject::tr("Connect to Server"));
+    action->setAccessibleName(QObject::tr("Connect to Server"));
     menu->addAction(action);
 
     action = new QAction(QObject::tr("Set share password"), menu);
     action->setData(MenuAction::kSetUserSharePassword);
+    action->setObjectName(QObject::tr("Set share password"));
+    action->setAccessibleName(QObject::tr("Set share password"));
     menu->addAction(action);
 
     if (DeviceUtils::checkDiskEncrypted()) {
         action = new QAction(QObject::tr("Change disk password"), menu);
         action->setData(MenuAction::kChangeDiskPassword);
+        action->setObjectName(QObject::tr("Change disk password"));
+        action->setAccessibleName(QObject::tr("Change disk password"));
         menu->addAction(action);
     }
 
     action = new QAction(QObject::tr("Settings"), menu);
     action->setData(MenuAction::kSettings);
+    action->setObjectName(QObject::tr("Settings"));
+    action->setAccessibleName(QObject::tr("Settings"));
     menu->addAction(action);
 
     QObject::connect(menu, &QMenu::triggered, [id](QAction *act) {


### PR DESCRIPTION
## 问题

文管 AT 测试中大量用例失败，原因侧边栏元素（计算机、桌面、最近使用、网络等）和菜单栏动作（新建窗口、设置等）缺少 AT-SPI 名称，导致辅助工具无法定位。

## 修复

### 侧边栏元素 (sidebarmodel.cpp)

新增 setItemAccessibleName() 辅助函数，在以下所有插入点自动设置 objectName / accessibleName：
- SideBarModel::insertRow() — 顶层项目插入
- SideBarModel::appendRow() — 所有子项目追加路径
- SideBarModel::addSubItem() — 分区子目录插入
- SideBarModel::updateRow() — 已有项目信息更新

### 菜单栏动作 (titlebarhelper.cpp)

在 TitleBarHelper::createSettingsMenu() 中为所有 QAction 设置 accessibleName。

## 影响

预计修复所有 52 个失败的 AT 用例（侧边栏元素 30 个 + 菜单动作 22 个）。

## Summary by Sourcery

Add AT-SPI accessible names to sidebar entries and title-bar menu actions to improve accessibility test and assistive-tool discoverability.

Bug Fixes:
- Expose translated accessible names for sidebar items and title-bar menu actions so AT-SPI tools can locate them reliably.

Enhancements:
- Centralize sidebar accessibility metadata assignment across item insertion and update paths.