### PR TITLE
fix(workspace): refactor RootInfo to eliminate watcher event race condition

### DIFF
--- a/autotests/plugins/dfmplugin-workspace/models/test_rootinfo.cpp
+++ b/autotests/plugins/dfmplugin-workspace/models/test_rootinfo.cpp
@@ -1,0 +1,529 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "models/rootinfo.h"
+#include "utils/filesortworker.h"
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/localfilewatcher.h>
+#include <dfm-base/file/local/localdiriterator.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/interfaces/sortfileinfo.h>
+#include <dfm-base/dfm_global_defines.h>
+
+#include <QTemporaryDir>
+#include <QDir>
+#include <QFile>
+#include <QSignalSpy>
+#include <QTest>
+#include <QThread>
+#include <QUrl>
+
+DFMBASE_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
+using namespace dfmplugin_workspace;
+
+class RootInfoTest : public ::testing::Test
+{
+protected:
+    static void registerSchemes()
+    {
+        static bool registered = false;
+        if (registered)
+            return;
+        registered = true;
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        WatcherFactory::regClass<LocalFileWatcher>(Global::Scheme::kFile);
+        DirIteratorFactory::regClass<LocalDirIterator>(Global::Scheme::kFile);
+    }
+
+    void SetUp() override
+    {
+        registerSchemes();
+
+        QString templatePath = QDir::homePath() + "/Documents/.test_rootinfo_XXXXXX";
+        testDir = std::make_unique<QTemporaryDir>(templatePath);
+        ASSERT_TRUE(testDir->isValid());
+        QDir().mkpath(testDir->path());
+
+        testUrl = QUrl::fromLocalFile(testDir->path());
+    }
+
+    void TearDown() override
+    {
+        if (rootInfo) {
+            delete rootInfo;
+            rootInfo = nullptr;
+        }
+        // Give event loop time to process pending deletions
+        QTest::qWait(200);
+        testDir.reset();
+    }
+
+    int waitForSignal(QSignalSpy &spy, int timeoutMs = 5000)
+    {
+        spy.wait(timeoutMs);
+        return spy.count();
+    }
+
+    void createFile(const QString &name, const QByteArray &content = "test")
+    {
+        QString path = testDir->path() + "/" + name;
+        QFile file(path);
+        file.open(QIODevice::WriteOnly);
+        file.write(content);
+        file.close();
+    }
+
+    void createRootInfo()
+    {
+        if (rootInfo) {
+            delete rootInfo;
+            rootInfo = nullptr;
+            QTest::qWait(100);
+        }
+        rootInfo = new RootInfo(testUrl);
+    }
+
+    // Full traversal cycle: init + start + wait for finish
+    void doTraversal(const QString &key)
+    {
+        ASSERT_TRUE(rootInfo != nullptr);
+        rootInfo->initThreadOfFileData(key, Global::ItemRoles::kItemFileDisplayNameRole,
+                                       Qt::AscendingOrder, true);
+        rootInfo->startIteratorWork(key);
+    }
+
+    std::unique_ptr<QTemporaryDir> testDir;
+    QUrl testUrl;
+    RootInfo *rootInfo { nullptr };
+};
+
+// ========== Construction ==========
+
+TEST_F(RootInfoTest, Construction_ValidUrl)
+{
+    createRootInfo();
+    ASSERT_NE(rootInfo, nullptr);
+    EXPECT_EQ(rootInfo->watcher, nullptr);
+    EXPECT_TRUE(rootInfo->connectTokens().isEmpty());
+    EXPECT_TRUE(rootInfo->getKeyWords().isEmpty());
+}
+
+TEST_F(RootInfoTest, Construction_HasNoWatcher)
+{
+    createRootInfo();
+    ASSERT_NE(rootInfo, nullptr);
+    EXPECT_EQ(rootInfo->watcher, nullptr);
+}
+
+TEST_F(RootInfoTest, Destructor_DoesNotCrash)
+{
+    createRootInfo();
+    RootInfo *info = new RootInfo(testUrl);
+    delete info;
+    SUCCEED();
+}
+
+// ========== initThreadOfFileData ==========
+
+TEST_F(RootInfoTest, InitThreadOfFileData_CreatesTraversalThread)
+{
+    createRootInfo();
+    rootInfo->initThreadOfFileData("key1", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+    // After init, the traversal thread should be created
+    EXPECT_TRUE(rootInfo->getKeyWords().size() >= 0);
+}
+
+TEST_F(RootInfoTest, InitThreadOfFileData_SecondInitReusesThread)
+{
+    createRootInfo();
+    // First traversal
+    rootInfo->initThreadOfFileData("key1", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    rootInfo->startIteratorWork("key1");
+    waitForSignal(finishSpy, 10000);
+
+    // Second init on same key should not crash
+    rootInfo->initThreadOfFileData("key1", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+    SUCCEED();
+}
+
+// ========== startIteratorWork / Traversal ==========
+
+TEST_F(RootInfoTest, StartIterator_EmptyDir_EmitsTraversalFinished)
+{
+    createRootInfo();
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+
+    int count = waitForSignal(finishSpy, 10000);
+    EXPECT_GE(count, 1);
+}
+
+TEST_F(RootInfoTest, StartIterator_WithFiles_EmitsIteratorLocalFiles)
+{
+    createRootInfo();
+    createFile("file1.txt");
+    createFile("file2.txt");
+
+    QSignalSpy localSpy(rootInfo, &RootInfo::iteratorLocalFiles);
+    doTraversal("key1");
+
+    waitForSignal(localSpy, 10000);
+    EXPECT_GE(localSpy.count(), 1);
+}
+
+TEST_F(RootInfoTest, StartIterator_EmitsIteratorStatus)
+{
+    createRootInfo();
+    createFile("a.txt");
+
+    QSignalSpy statusSpy(rootInfo, &RootInfo::iteratorStatus);
+    doTraversal("key1");
+
+    statusSpy.wait(3000);
+    // Should have at least kRunning signal
+    ASSERT_GE(statusSpy.count(), 1);
+    auto status = statusSpy.takeFirst().at(0).value<RootInfoWorker::IteratorStatus>();
+    EXPECT_EQ(status, RootInfoWorker::IteratorStatus::kRunning);
+}
+
+// ========== traversalFinished signal ==========
+
+TEST_F(RootInfoTest, TraversalFinished_NoDataProduced_WhenFirstBatchTrue)
+{
+    createRootInfo();
+    rootInfo->setFirstBatch(true);
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+
+    int count = waitForSignal(finishSpy, 10000);
+    ASSERT_GE(count, 1);
+
+    QList<QVariant> args = finishSpy.takeFirst();
+    bool noDataProduced = args.at(1).toBool();
+    // Empty dir with setFirstBatch(true) → noDataProduced should be true
+    EXPECT_TRUE(noDataProduced);
+}
+
+TEST_F(RootInfoTest, TraversalFinished_DataProduced_WhenFilesExist)
+{
+    createRootInfo();
+    createFile("data.txt");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+
+    int count = waitForSignal(finishSpy, 10000);
+    ASSERT_GE(count, 1);
+
+    QList<QVariant> args = finishSpy.takeFirst();
+    bool noDataProduced = args.at(1).toBool();
+    EXPECT_FALSE(noDataProduced);
+}
+
+// ========== Watcher events ==========
+
+TEST_F(RootInfoTest, Watcher_FileCreated_EmitsWatcherAddFiles)
+{
+    createRootInfo();
+    createFile("initial.txt");
+
+    // Traverse first to start the watcher (watcher starts after iterator init finishes)
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    // Wait for watcher to be ready
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy addSpy(rootInfo, &RootInfo::watcherAddFiles);
+    createFile("newfile.txt");
+
+    int count = waitForSignal(addSpy, 10000);
+    EXPECT_GE(count, 1);
+}
+
+TEST_F(RootInfoTest, Watcher_FileDeleted_EmitsWatcherRemoveFiles)
+{
+    createRootInfo();
+    createFile("todelete.txt");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy removeSpy(rootInfo, &RootInfo::watcherRemoveFiles);
+    QFile::remove(testDir->path() + "/todelete.txt");
+
+    int count = waitForSignal(removeSpy, 10000);
+    EXPECT_GE(count, 1);
+}
+
+TEST_F(RootInfoTest, Watcher_FileRenamed_EmitsWatcherSignals)
+{
+    createRootInfo();
+    createFile("oldname.txt");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    // Rename should trigger remove + add (or rename process started)
+    QSignalSpy removeSpy(rootInfo, &RootInfo::watcherRemoveFiles);
+    QSignalSpy addSpy(rootInfo, &RootInfo::watcherAddFiles);
+
+    QFile::rename(testDir->path() + "/oldname.txt", testDir->path() + "/newname.txt");
+
+    // Wait for both signals
+    removeSpy.wait(5000);
+    addSpy.wait(5000);
+
+    EXPECT_GE(removeSpy.count() + addSpy.count(), 1);
+}
+
+// ========== reset() ==========
+
+TEST_F(RootInfoTest, Reset_StopsWatcherAndEmitsStatus)
+{
+    createRootInfo();
+    createFile("file1.txt");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy statusSpy(rootInfo, &RootInfo::iteratorStatus);
+    rootInfo->reset();
+
+    statusSpy.wait(2000);
+    ASSERT_GE(statusSpy.count(), 1);
+    auto status = statusSpy.takeFirst().at(0).value<RootInfoWorker::IteratorStatus>();
+    EXPECT_EQ(status, RootInfoWorker::IteratorStatus::kNone);
+}
+
+TEST_F(RootInfoTest, Reset_ThenNewTraversal_WatcherStillWorks)
+{
+    createRootInfo();
+    createFile("initial.txt");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+
+    // Reset (simulating directory switch)
+    rootInfo->reset();
+    QTest::qWait(300);
+
+    // Start new traversal on same dir
+    finishSpy.clear();
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    // Watcher should still be functional
+    QSignalSpy addSpy(rootInfo, &RootInfo::watcherAddFiles);
+    createFile("after_reset.txt");
+
+    int count = waitForSignal(addSpy, 10000);
+    EXPECT_GE(count, 1);
+}
+
+// ========== canDelete() ==========
+
+TEST_F(RootInfoTest, CanDelete_True_AfterTraversalFinishes)
+{
+    createRootInfo();
+    createFile("file.txt");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    // Wait for threads to fully finish
+    QTest::qWait(500);
+    EXPECT_TRUE(rootInfo->canDelete());
+}
+
+TEST_F(RootInfoTest, CanDelete_True_WhenNoTraversalStarted)
+{
+    createRootInfo();
+    EXPECT_TRUE(rootInfo->canDelete());
+}
+
+// ========== checkKeyOnly() ==========
+
+TEST_F(RootInfoTest, CheckKeyOnly_True_WithSingleKey)
+{
+    createRootInfo();
+    rootInfo->initThreadOfFileData("only_key", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+    EXPECT_TRUE(rootInfo->checkKeyOnly("only_key"));
+}
+
+TEST_F(RootInfoTest, CheckKeyOnly_False_WithMultipleKeys)
+{
+    createRootInfo();
+    rootInfo->initThreadOfFileData("key1", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+    rootInfo->initThreadOfFileData("key2", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+    EXPECT_FALSE(rootInfo->checkKeyOnly("key1"));
+    EXPECT_FALSE(rootInfo->checkKeyOnly("key2"));
+}
+
+// ========== clearTraversalThread() ==========
+
+TEST_F(RootInfoTest, ClearTraversalThread_ReduceCount)
+{
+    createRootInfo();
+    rootInfo->initThreadOfFileData("key1", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+    rootInfo->initThreadOfFileData("key2", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+
+    int remaining = rootInfo->clearTraversalThread("key1", false);
+    EXPECT_EQ(remaining, 1);
+}
+
+TEST_F(RootInfoTest, ClearTraversalThread_NeedStartWatcher_WhenEmpty)
+{
+    createRootInfo();
+    rootInfo->initThreadOfFileData("key1", Global::ItemRoles::kItemFileDisplayNameRole,
+                                   Qt::AscendingOrder, true);
+
+    rootInfo->clearTraversalThread("key1", false);
+
+    // After clearing all threads, startWatcher should be needed again.
+    // Create new traversal to verify watcher starts.
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key2");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    EXPECT_FALSE(rootInfo->watcher.isNull());
+}
+
+// ========== connectTokens ==========
+
+TEST_F(RootInfoTest, ConnectTokens_AddAndRetrieve)
+{
+    createRootInfo();
+    rootInfo->addConnectToken("token1");
+    rootInfo->addConnectToken("token2");
+    rootInfo->addConnectToken("token1"); // duplicate, should not add
+
+    QStringList tokens = rootInfo->connectTokens();
+    EXPECT_EQ(tokens.size(), 2);
+    EXPECT_TRUE(tokens.contains("token1"));
+    EXPECT_TRUE(tokens.contains("token2"));
+}
+
+// ========== setFirstBatch ==========
+
+TEST_F(RootInfoTest, SetFirstBatch_AffectsNoDataProduced)
+{
+    createRootInfo();
+
+    // Set first batch to true, then start traversal on empty dir
+    rootInfo->setFirstBatch(true);
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    ASSERT_GE(finishSpy.count(), 1);
+    bool noDataProduced = finishSpy.takeFirst().at(1).toBool();
+    EXPECT_TRUE(noDataProduced);
+}
+
+// ========== Bug scenario: reset then re-create RootInfo ==========
+
+TEST_F(RootInfoTest, BugScenario_ResetAndRecreate_WatcherWorksOnSameDir)
+{
+    createRootInfo();
+    createFile("bug_test.txt");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    // Reset (simulating directory switch away)
+    rootInfo->reset();
+    QTest::qWait(500);
+
+    // Delete old RootInfo and create a new one on the same dir (simulating switch back)
+    delete rootInfo;
+    rootInfo = nullptr;
+    QTest::qWait(300);
+
+    rootInfo = new RootInfo(testUrl);
+
+    finishSpy.clear();
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    // Verify watcher is functional: create a file and check for add signal
+    QSignalSpy addSpy(rootInfo, &RootInfo::watcherAddFiles);
+    createFile("after_recreate.txt");
+
+    int count = waitForSignal(addSpy, 10000);
+    EXPECT_GE(count, 1);
+}
+
+// ========== Multiple rapid operations ==========
+
+TEST_F(RootInfoTest, Watcher_RapidMultipleOperations)
+{
+    createRootInfo();
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy addSpy(rootInfo, &RootInfo::watcherAddFiles);
+
+    // Rapidly create 5 files
+    for (int i = 0; i < 5; ++i) {
+        createFile(QString("rapid_%1.txt").arg(i));
+    }
+
+    addSpy.wait(5000);
+    addSpy.wait(1000); // extra wait for consolidated events
+
+    EXPECT_GE(addSpy.count(), 1);
+}

--- a/autotests/plugins/dfmplugin-workspace/models/test_rootinfo.cpp
+++ b/autotests/plugins/dfmplugin-workspace/models/test_rootinfo.cpp
@@ -76,7 +76,10 @@ protected:
     {
         QString path = testDir->path() + "/" + name;
         QFile file(path);
-        file.open(QIODevice::WriteOnly);
+        if (!file.open(QIODevice::WriteOnly)) {
+            qWarning() << "Failed to open file for writing:" << path;
+            return;
+        }
         file.write(content);
         file.close();
     }
@@ -291,13 +294,16 @@ TEST_F(RootInfoTest, Watcher_FileRenamed_EmitsWatcherSignals)
     // Rename should trigger remove + add (or rename process started)
     QSignalSpy removeSpy(rootInfo, &RootInfo::watcherRemoveFiles);
     QSignalSpy addSpy(rootInfo, &RootInfo::watcherAddFiles);
+    QSignalSpy renameSpy(rootInfo, &RootInfo::renameFileProcessStarted);
 
     QFile::rename(testDir->path() + "/oldname.txt", testDir->path() + "/newname.txt");
 
-    // Wait for both signals
+    // Wait for signals
     removeSpy.wait(5000);
     addSpy.wait(5000);
+    renameSpy.wait(5000);
 
+    EXPECT_GE(renameSpy.count(), 1);
     EXPECT_GE(removeSpy.count() + addSpy.count(), 1);
 }
 
@@ -526,4 +532,147 @@ TEST_F(RootInfoTest, Watcher_RapidMultipleOperations)
     addSpy.wait(1000); // extra wait for consolidated events
 
     EXPECT_GE(addSpy.count(), 1);
+}
+
+// ========== Watcher: file updated ==========
+
+TEST_F(RootInfoTest, Watcher_FileUpdated_EmitsWatcherUpdateFiles)
+{
+    createRootInfo();
+    createFile("update_me.txt", "initial");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy updateSpy(rootInfo, &RootInfo::watcherUpdateFiles);
+
+    createFile("update_me.txt", "modified");
+
+    int count = waitForSignal(updateSpy, 10000);
+    EXPECT_GE(count, 1);
+}
+
+// ========== Watcher: directory created ==========
+
+TEST_F(RootInfoTest, Watcher_DirCreated_EmitsWatcherAddFiles_IsDir)
+{
+    createRootInfo();
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy addSpy(rootInfo, &RootInfo::watcherAddFiles);
+
+    QDir().mkpath(testDir->path() + "/subdir");
+
+    int count = waitForSignal(addSpy, 10000);
+    ASSERT_GE(count, 1);
+
+    QList<QVariant> args = addSpy.takeFirst();
+    auto children = args.at(0).value<QList<SortInfoPointer>>();
+    ASSERT_GE(children.size(), 1);
+
+    bool foundDir = false;
+    for (const auto &child : children) {
+        if (child && child->isDir()) {
+            foundDir = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(foundDir);
+}
+
+// ========== Watcher: directory deleted ==========
+
+TEST_F(RootInfoTest, Watcher_DirDeleted_EmitsWatcherRemoveFilesAndCloseTab)
+{
+    createRootInfo();
+    QDir().mkpath(testDir->path() + "/to_delete_dir");
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy removeSpy(rootInfo, &RootInfo::watcherRemoveFiles);
+    QSignalSpy closeTabSpy(rootInfo, &RootInfo::requestCloseTab);
+
+    QDir(testDir->path() + "/to_delete_dir").removeRecursively();
+
+    removeSpy.wait(10000);
+    closeTabSpy.wait(5000);
+
+    EXPECT_GE(removeSpy.count(), 1);
+    EXPECT_GE(closeTabSpy.count(), 1);
+}
+
+// ========== Watcher: root directory deleted ==========
+
+TEST_F(RootInfoTest, Watcher_RootDirDeleted_EmitsClearRootAndCloseTab)
+{
+    QString nestedPath = testDir->path() + "/nested_root";
+    QDir().mkpath(nestedPath);
+    QUrl nestedUrl = QUrl::fromLocalFile(nestedPath);
+
+    if (rootInfo) {
+        delete rootInfo;
+        rootInfo = nullptr;
+        QTest::qWait(100);
+    }
+    rootInfo = new RootInfo(nestedUrl);
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy clearRootSpy(rootInfo, &RootInfo::requestClearRoot);
+    QSignalSpy closeTabSpy(rootInfo, &RootInfo::requestCloseTab);
+
+    QDir(nestedPath).removeRecursively();
+
+    clearRootSpy.wait(10000);
+    closeTabSpy.wait(5000);
+
+    EXPECT_GE(clearRootSpy.count(), 1);
+    EXPECT_GE(closeTabSpy.count(), 1);
+}
+
+// ========== Watcher: hidden file ==========
+
+TEST_F(RootInfoTest, Watcher_HiddenFile_EmitsWatcherUpdateHideFile)
+{
+    createRootInfo();
+
+    QSignalSpy finishSpy(rootInfo, &RootInfo::traversalFinished);
+    doTraversal("key1");
+    waitForSignal(finishSpy, 10000);
+
+    QTest::qWait(500);
+    ASSERT_FALSE(rootInfo->watcher.isNull());
+
+    QSignalSpy hideSpy(rootInfo, &RootInfo::watcherUpdateHideFile);
+
+    createFile(".hidden", "entry1\n");
+
+    int count = waitForSignal(hideSpy, 10000);
+    EXPECT_GE(count, 1);
+
+    hideSpy.clear();
+    QFile::remove(testDir->path() + "/.hidden");
+
+    int count2 = waitForSignal(hideSpy, 10000);
+    EXPECT_GE(count2, 1);
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -11,7 +11,6 @@
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/utils/fileutils.h>
-#include <dfm-base/utils/finallyutil.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -26,6 +25,7 @@
 using namespace dfmbase;
 using namespace dfmplugin_workspace;
 
+static constexpr int kWatcherEventDelayMs = 100;
 
 FileWatcherWorker::FileWatcherWorker(RootInfoWorker *root, QObject *parent)
     : QObject(parent), rootptr(root)
@@ -38,23 +38,16 @@ FileWatcherWorker::~FileWatcherWorker()
 
 void FileWatcherWorker::doFileDeleted(const QUrl &fileUrl)
 {
-    assert(qApp->thread() != QThread::currentThread());
-    fmInfo() << "FileWatcherWorker::doFileDeleted: url=" << fileUrl << "stopped=" << rootptr->stopped;
-    // 自己删除可以执行
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
+    fmDebug() << "FileWatcherWorker::doFileDeleted: url=" << fileUrl << "stopped=" << rootptr->stopped;
     if (rootptr->stopped || !isSubFile(fileUrl))
         return;
 
-    FinallyUtil defer([this]{
-        doCheckAndStartTimer();
-    });
-    // 删除的是自己
     if (UniversalUtils::urlEquals(fileUrl, rootptr->url)) {
         fmWarning() << "Root directory deleted:" << fileUrl;
-        // 移除缓存和监视器
         emit InfoCacheController::instance().removeCacheFileInfo({ fileUrl });
         WatcherCache::instance().removeCacheWatcherByParent(fileUrl);
 
-        // 处理和关闭窗口
         emit rootptr->requestCloseTab(fileUrl);
         emit rootptr->requestClearRoot(fileUrl);
         rootptr->childrenUrlList.clear();
@@ -66,18 +59,17 @@ void FileWatcherWorker::doFileDeleted(const QUrl &fileUrl)
     updates.remove(fileUrl);
     if (!removes.contains(fileUrl))
         removes.insert(fileUrl);
+    doCheckAndStartTimer();
 }
 
 void FileWatcherWorker::doFileMoved(const QUrl &fromUrl, const QUrl &toUrl)
 {
-    assert(qApp->thread() != QThread::currentThread());
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
     fmInfo() << "FileWatcherWorker::dofileMoved: from=" << fromUrl << "to=" << toUrl;
     if (rootptr->stopped)
         return;
-    // 补充：发射重命名过程开始信号（UI反馈）
     emit rootptr->renameFileProcessStarted();
     doFileDeleted(fromUrl);
-    // 补充：刷新目标URL缓存
     auto info = InfoCacheController::instance().getCacheInfo(toUrl);
     if (info)
         info->updateAttributes();
@@ -87,12 +79,11 @@ void FileWatcherWorker::doFileMoved(const QUrl &fromUrl, const QUrl &toUrl)
 
 void FileWatcherWorker::doFileCreated(const QUrl &fileUrl)
 {
-    assert(qApp->thread() != QThread::currentThread());
-    fmInfo() << "FileWatcherWorker::dofileCreated: url=" << fileUrl << "stopped=" << rootptr->stopped;
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
+    fmDebug() << "FileWatcherWorker::doFileCreated: url=" << fileUrl << "stopped=" << rootptr->stopped;
     if (rootptr->stopped || !isSubFile(fileUrl))
         return;
 
-    // 判断update和remove中是否存在存在就移除
     updates.remove(fileUrl);
     removes.remove(fileUrl);
     if (!adds.contains(fileUrl))
@@ -103,30 +94,26 @@ void FileWatcherWorker::doFileCreated(const QUrl &fileUrl)
 
 void FileWatcherWorker::doFileUpdated(const QUrl &fileUrl)
 {
-    assert(qApp->thread() != QThread::currentThread());
-    fmInfo() << "FileWatcherWorker::doFileUpdated: url=" << fileUrl << "stopped=" << rootptr->stopped;
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
+    fmDebug() << "FileWatcherWorker::doFileUpdated: url=" << fileUrl << "stopped=" << rootptr->stopped;
     if (rootptr->stopped || !isSubFile(fileUrl) || UniversalUtils::urlEquals(fileUrl, rootptr->url))
         return;
 
-    FinallyUtil defer([this]{
-        doCheckAndStartTimer();
-    });
-    // 如果在增加或者移除中就不添加
     if (adds.contains(fileUrl) || removes.contains(fileUrl) || updates.contains(fileUrl))
         return;
 
     bool fileShowNow = rootptr->childrenUrlList.contains(fileUrl);
-    // 收到update信号但是没有收到fileadd信号，那么添加一个fileadd信号
     if (fileShowNow) {
         updates.insert(fileUrl);
     } else if (dfmio::DFile(fileUrl).exists()) {
         adds.insert(fileUrl);
     }
+    doCheckAndStartTimer();
 }
 
 void FileWatcherWorker::doWatcherEvent()
 {
-    assert(qApp->thread() != QThread::currentThread());
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
     delayTimeStart = false;
     doWatcherSubEvent();
 }
@@ -135,7 +122,6 @@ void FileWatcherWorker::doWatcherSubEvent()
 {
     if (rootptr->stopped)
         return;
-    // 处理添加文件
     if (!removes.isEmpty()) {
         rootptr->removeChildren(removes);
         removes.clear();
@@ -155,19 +141,16 @@ void FileWatcherWorker::doCheckAndStartTimer()
     if (delayTimeStart)
         return;
     delayTimeStart = true;
-    emit rootptr->watcherTimerStart();
+    QTimer::singleShot(kWatcherEventDelayMs, this, [this]{ doWatcherEvent(); });
 }
 
 bool FileWatcherWorker::isSubFile(const QUrl &fileUrl)
 {
-    // 不是本地文件判读不了是否是子目录
     if (!fileUrl.isLocalFile())
         return true;
 
     auto url = fileUrl;
-    // 判断是否是当前目录的子文件，不是就不处理
     auto parentUrl = rootptr->url;
-    // 清除掉用户信息和查询信息
     parentUrl.setUserInfo(QString());
     parentUrl.setQuery(QString());
     url.setUserInfo(QString());
@@ -192,10 +175,9 @@ FileIteratorWorker::~FileIteratorWorker()
 {
 }
 
-// 处理迭代器迭代的文件信息，转换为SortInfo
 void FileIteratorWorker::handleTraversalResults(const QList<FileInfoPointer> &children, const QString &travseToken)
 {
-    assert(qApp->thread() != QThread::currentThread());
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
     if (rootptr->stopped)
         return;
 
@@ -217,23 +199,15 @@ void FileIteratorWorker::handleTraversalResults(const QList<FileInfoPointer> &ch
         Q_EMIT rootptr->iteratorAddFiles(travseToken, sortInfos, infos);
 }
 
-// 处理search的后面的搜索结果
 void FileIteratorWorker::handleTraversalResultsUpdate(const QList<SortInfoPointer> &children, const QString &travseToken, bool increment)
 {
-    assert(qApp->thread() != QThread::currentThread());
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
     if (children.isEmpty() || rootptr->stopped)
         return;
 
     if (!increment) {
-        // 首批或全量更新（如搜索结果刷新）：替换整个列表并重建 URL 索引
-        rootptr->childrenUrlList.clear();
-        rootptr->sourceDataList = children;
-        for (const auto &file : children) {
-            if (file)
-                rootptr->childrenUrlList.append(file->fileUrl());
-        }
+        rootptr->replaceChildren(children);
     } else {
-        // 增量批次（如 dirent 逐批遍历）：追加到已有列表
         for (const auto &file : children) {
             if (!file)
                 continue;
@@ -245,17 +219,16 @@ void FileIteratorWorker::handleTraversalResultsUpdate(const QList<SortInfoPointe
     emit rootptr->iteratorUpdateFiles(travseToken, rootptr->sourceDataList, false);
 }
 
-// 处理搜索的第一次推送的结果或者迭代器使用sortFileInfoList迭代出来的文件
 void FileIteratorWorker::handleTraversalLocalResult(QList<SortInfoPointer> children, dfmio::DEnumerator::SortRoleCompareFlag sortRole, Qt::SortOrder sortOrder, bool isMixDirAndFile, const QString &travseToken)
 {
-    assert(qApp->thread() != QThread::currentThread());
+    Q_ASSERT(qApp->thread() != QThread::currentThread());
     if (rootptr->stopped)
         return;
     rootptr->originSortRole = sortRole;
     rootptr->originSortOrder = sortOrder;
     rootptr->originMixSort = isMixDirAndFile;
 
-    rootptr->addChildren(children);
+    rootptr->replaceChildren(children);
 
     Q_EMIT rootptr->iteratorLocalFiles(travseToken, rootptr->sourceDataList, rootptr->originSortRole, rootptr->originSortOrder, rootptr->originMixSort, true);
 }
@@ -278,12 +251,10 @@ void FileIteratorWorker::handleTraversalSort(const QString &travseToken)
 RootInfoWorker::RootInfoWorker(const QUrl &url, QObject *parent)
     : QObject(parent), url(url)
 {
-    // 补充hiddenFileUrl初始化（从旧代码迁移）
     hiddenFileUrl.setScheme(url.scheme());
     hiddenFileUrl.setPath(DFMIO::DFMUtils::buildFilePath(url.path().toStdString().c_str(), ".hidden", nullptr));
     it.reset(new FileIteratorWorker(this));
     watch.reset(new FileWatcherWorker(this));
-    keyWords = KeywordExtractorManager::instance().extractor().extractFromUrl(url);
 }
 
 RootInfoWorker::~RootInfoWorker()
@@ -313,10 +284,9 @@ void RootInfoWorker::addChildren(const QSet<QUrl> &urlList)
     QList<SortInfoPointer> newSortInfo;
 
     bool isContainHidd = false;
-    std::for_each(urlList.begin(), urlList.end(), [this, &isContainHidd, &newSortInfo](QUrl url) {
+    std::for_each(urlList.begin(), urlList.end(), [this, &isContainHidd, &newSortInfo](const QUrl &url) {
         if (stopped)
             return;
-        url.setPath(url.path());
 
         auto child = fileInfo(url);
 
@@ -341,10 +311,8 @@ void RootInfoWorker::addChildren(const QSet<QUrl> &urlList)
         Q_EMIT watcherUpdateHideFile(hiddenFileUrl);
 }
 
-void RootInfoWorker::addChildren(const QList<SortInfoPointer> &children, const int start)
+void RootInfoWorker::replaceChildren(const QList<SortInfoPointer> &children)
 {
-    // 这里搜索时不能使用增量更新，以前的SortInfo也有修改，所以前面搜索出来的有可能搜索的内容没有显示出来
-    Q_UNUSED(start);
     if (stopped)
         return;
 
@@ -406,78 +374,59 @@ void RootInfoWorker::removeChildren(const QSet<QUrl> &urlList)
     if (stopped)
         return;
     QList<SortInfoPointer> removeChildren {};
-    int childIndex = -1;
     QList<QUrl> removeUrls;
-    emit InfoCacheController::instance().removeCacheFileInfo(urlList.values());
-    std::for_each(urlList.begin(), urlList.end(), [this, &removeUrls, &removeChildren, &childIndex](const QUrl &fileUrl){
+
+    std::for_each(urlList.begin(), urlList.end(), [this, &removeUrls, &removeChildren](const QUrl &fileUrl){
         if (stopped)
             return;
-        auto url = fileUrl;
-        url.setPath(url.path());
 
-        // 优化：先检查 childrenUrlList 是否已包含此 URL，命中则直接使用 sourceDataList
-        // 中缓存的 SortInfo，避免创建 FileInfo 的同步 I/O。
-        childIndex = childrenUrlList.indexOf(url);
-        if (childIndex >= 0 && childIndex < childrenUrlList.length()) {
-            bool isDir = sourceDataList.at(childIndex)->isDir();
-            if (isDir) {
-                WatcherCache::instance().removeCacheWatcherByParent(url);
-                emit requestCloseTab(url);
-            }
-            removeUrls.append(url);
-            childrenUrlList.removeAt(childIndex);
-            removeChildren.append(sourceDataList.takeAt(childIndex));
-            return;
+        QUrl realUrl = fileUrl;
+        int childIndex = childrenUrlList.indexOf(fileUrl);
+        FileInfoPointer childInfo;
+
+        if (childIndex < 0) {
+            childInfo = fileInfo(fileUrl);
+            if (!childInfo)
+                return;
+            realUrl = childInfo->urlOf(UrlInfoType::kUrl);
+            childIndex = childrenUrlList.indexOf(realUrl);
         }
 
-        // 未命中缓存，回退到创建 FileInfo 获取真实 URL
-        auto child = fileInfo(url);
-        if (!child)
-            return;
+        bool isDir;
+        if (childIndex >= 0 && childIndex < sourceDataList.length()) {
+            isDir = sourceDataList.at(childIndex)->isDir();
+        } else {
+            if (!childInfo) {
+                childInfo = fileInfo(fileUrl);
+                if (!childInfo)
+                    return;
+            }
+            isDir = childInfo->isDir();
+        }
 
-        auto realUrl = child->urlOf(UrlInfoType::kUrl);
-        childIndex = childrenUrlList.indexOf(realUrl);
-
-        // 处理各个窗口显示的父目录删除
-        // 删除事件到达时文件已不存在，fileInfo() 重新查询 isDir 会失败并返回 false，
-        // 因此优先使用已加载子项列表 sourceDataList 中缓存的 SortInfo（其 isDir 在文件
-        // 存在时设置、可靠）；仅在子项尚未加载时才回退到实时查询，避免删除一个正被其它
-        // 窗口打开的目录后，那些窗口收不到 requestCloseTab 而无法自动跳转。
-        bool isDir = (childIndex >= 0 && childIndex < sourceDataList.length())
-                ? sourceDataList.at(childIndex)->isDir()
-                : child->isDir();
         if (isDir) {
-            WatcherCache::instance().removeCacheWatcherByParent(url);
-            emit requestCloseTab(url);
+            WatcherCache::instance().removeCacheWatcherByParent(realUrl);
+            emit requestCloseTab(realUrl);
         }
 
         removeUrls.append(realUrl);
         if (childIndex < 0 || childIndex >= childrenUrlList.length()) {
-            removeChildren.append(sortFileInfo(child));
+            if (childInfo)
+                removeChildren.append(sortFileInfo(childInfo));
             return;
         }
         childrenUrlList.removeAt(childIndex);
         removeChildren.append(sourceDataList.takeAt(childIndex));
     });
 
-    // 移除缓存
     if (removeUrls.count() > 0)
         emit InfoCacheController::instance().removeCacheFileInfo(removeUrls);
 
-    // 移除显示的项
     if (removeChildren.count() > 0)
         emit watcherRemoveFiles(removeChildren);
 
-    // 跟新隐藏文件的显示项
     if (removeUrls.contains(hiddenFileUrl))
         Q_EMIT watcherUpdateHideFile(hiddenFileUrl);
-}
-
-bool RootInfoWorker::containsChild(const QUrl &url)
-{
-    if (stopped)
-        return false;
-    return childrenUrlList.contains(url);
 }
 
 FileInfoPointer RootInfoWorker::fileInfo(const QUrl &url)
@@ -488,18 +437,19 @@ FileInfoPointer RootInfoWorker::fileInfo(const QUrl &url)
     if (!info.isNull())
         return info;
 
-    // 不是当前目录的就不处理
     const QUrl &parentUrl = QUrl::fromPercentEncoding(this->url.toString().toUtf8());
     auto path = url.path();
     if (path.isEmpty() || path == QDir::separator() || url.fileName().isEmpty())
         return info;
 
     auto pathParent = path.endsWith(QDir::separator()) ? path.left(path.length() - 1) : path;
-    auto parentPath = parentUrl.path().endsWith(QDir::separator())
-            ? parentUrl.path().left(parentUrl.path().length() - 1)
-            : parentUrl.path();
     pathParent = pathParent.left(pathParent.lastIndexOf(QDir::separator()));
-    if (!parentPath.endsWith(pathParent.mid(1)))
+
+    auto parentPath = parentUrl.path();
+    if (parentPath.endsWith(QDir::separator()))
+        parentPath.chop(1);
+
+    if (QDir::cleanPath(parentPath) != QDir::cleanPath(pathParent))
         return info;
 
     auto currentUrl = parentUrl;
@@ -526,8 +476,6 @@ SortInfoPointer RootInfoWorker::updateChild(const QUrl &url)
         return nullptr;
     sourceDataList.replace(childrenUrlList.indexOf(realUrl), sort);
 
-    // NOTE: GlobalEventType::kHideFiles event is watched in fileview, but this can be used to notify update view
-    // when the file is modified in other way.
     if (UniversalUtils::urlEquals(hiddenFileUrl, url))
         Q_EMIT watcherUpdateHideFile(url);
 
@@ -576,7 +524,6 @@ RootInfo::RootInfo(const QUrl &u, QObject *parent)
     keyWords = KeywordExtractorManager::instance().extractor().extractFromUrl(url);
 
     connect(qApp, &QApplication::aboutToQuit, this, [this]{
-        // 保证所有的迭代线程退出
         this->clearAllThread();
     });
     rootThread.start();
@@ -590,7 +537,6 @@ RootInfo::~RootInfo()
 
 void RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::ItemRoles role, Qt::SortOrder order, bool isMixFileAndFolder)
 {
-    // clear old dir iterator thread
     for (auto it = discardedThread.begin(); it != discardedThread.end(); ) {
         if (!(*it)->isRunning()) {
             it = discardedThread.erase(it);
@@ -598,7 +544,6 @@ void RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::Ite
             it++;
         }
     }
-    // create traversal thread
     QSharedPointer<DirIteratorThread> traversalThread = traversalThreads.value(key);
     if (!traversalThread.isNull()) {
         traversalThread->traversalThread->disconnect();
@@ -613,25 +558,6 @@ void RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::Ite
     traversalThread->traversalThread->setTraversalToken(key);
     initIteratorConnection(traversalThread->traversalThread);
     traversalThreads.insert(key, traversalThread);
-
-    switch (role) {
-    case Global::ItemRoles::kItemFileDisplayNameRole:
-        traversalThread->originSortRole = dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareFileName;
-        break;
-    case Global::ItemRoles::kItemFileSizeRole:
-        traversalThread->originSortRole = dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareFileSize;
-        break;
-    case Global::ItemRoles::kItemFileLastReadRole:
-        traversalThread->originSortRole = dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareFileLastRead;
-        break;
-    case Global::ItemRoles::kItemFileLastModifiedRole:
-        traversalThread->originSortRole = dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareFileLastModified;
-        break;
-    default:
-        traversalThread->originSortRole = dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault;
-    }
-    traversalThread->originMixSort = isMixFileAndFolder;
-    traversalThread->originSortOrder = order;
 }
 
 void RootInfo::startIteratorWork(const QString &key)
@@ -642,7 +568,6 @@ void RootInfo::startIteratorWork(const QString &key)
     }
 
     fmInfo() << "startIteratorWork: key=" << key << "url=" << url;
-    traversaling = true;
     emit resetData();
     emit iteratorStatus(RootInfoWorker::IteratorStatus::kRunning);
     traversalThreads.value(key)->traversalThread->start();
@@ -658,14 +583,12 @@ void RootInfo::startWatcher()
         watcher->disconnect(this);
     }
 
-    // create watcher
     watcher = WatcherFactory::create<AbstractFileWatcher>(url);
     if (watcher.isNull()) {
         fmWarning() << "Create watcher failed! url = " << url;
         return;
     }
 
-    // worker 子线程执行
     connect(watcher.data(), &AbstractFileWatcher::fileDeleted,
             rootWorker->watcherWorker().data(), &FileWatcherWorker::doFileDeleted, Qt::QueuedConnection);
     connect(watcher.data(), &AbstractFileWatcher::subfileCreated,
@@ -688,7 +611,6 @@ int RootInfo::clearTraversalThread(const QString &key, const bool isRefresh)
     traversalThread->disconnect(this);
     if (traversalThread->isRunning()) {
         discardedThread.append(traversalThread);
-        traversaling = false;
     }
     thread->traversalThread->stop();
     if (traversalThreads.isEmpty())
@@ -719,7 +641,6 @@ void RootInfo::reset()
     for (const auto &thread : traversalThreads) {
         thread->traversalThread->stop();
     }
-    // wait old dir iterator thread
     for (const auto &thread : discardedThread) {
         thread->disconnect();
         thread->stop();
@@ -735,7 +656,6 @@ bool RootInfo::canDelete() const
         if (!thread->traversalThread->isFinished())
             return false;
     }
-    // wait old dir iterator thread
     for (const auto &thread : discardedThread) {
         if (!thread->isFinished())
             return false;
@@ -758,36 +678,36 @@ QStringList RootInfo::getKeyWords() const
     return keyWords;
 }
 
+void RootInfo::addConnectToken(const QString &token)
+{
+    if (connectedTokens.contains(token))
+        return;
+    connectedTokens << token;
+}
+
+QStringList RootInfo::connectTokens() const
+{
+    return connectedTokens;
+}
+
 void RootInfo::handleTraversalFinish(const QString &travseToken)
 {
     fmInfo() << "RootInfo::handleTraversalFinish:" << travseToken << "url:" << url;
 
-    // Check if isFirstBatch is still true, which means no directory data was produced
     bool noDataProduced = isFirstBatch.load();
-    // Reset isFirstBatch
     isFirstBatch.store(false);
 
     fmDebug() << "Emitting traversal finished signal - noDataProduced:" << noDataProduced;
     emit traversalFinished(travseToken, noDataProduced);
 
-    traversaling = false;
-    traversalFinish = true;
     if (isRefresh) {
         fmDebug() << "RootInfo::handleTraversalFinish: refresh completed";
         isRefresh = false;
     }
 }
 
-void RootInfo::onWatcherTimerStart()
-{
-    QTimer::singleShot(100, this, [this]{
-        emit watcherTimerEvent();
-    });
-}
-
 void RootInfo::initIteratorConnection(const TraversalThreadManagerPointer &traversalThread)
 {
-    // 再worker的子线程中执行
     connect(traversalThread.data(), &TraversalDirThreadManager::updateChildrenManager,
             rootWorker->iteratorWorker().data(), &FileIteratorWorker::handleTraversalResults, Qt::QueuedConnection);
     connect(traversalThread.data(), &TraversalDirThreadManager::updateLocalChildren,
@@ -799,14 +719,12 @@ void RootInfo::initIteratorConnection(const TraversalThreadManagerPointer &trave
     connect(traversalThread.data(), &TraversalDirThreadManager::traversalFinished,
             rootWorker->iteratorWorker().data(), &FileIteratorWorker::handleTraversalFinish, Qt::QueuedConnection);
 
-    // 主线中执行，启动监视器
     connect(traversalThread.data(), &TraversalDirThreadManager::iteratorInitFinished,
             this, &RootInfo::startWatcher, Qt::QueuedConnection);
 }
 
 void RootInfo::initConnection()
 {
-    // 连接迭代器信号 —— 三个数据信号使用 lambda 转发 isFirstBatch
     connect(rootWorker.data(), &RootInfoWorker::iteratorLocalFiles, this,
             [this](const QString &key,
                    const QList<SortInfoPointer> children,
@@ -825,8 +743,6 @@ void RootInfo::initConnection()
                 emit iteratorUpdateFiles(key, children, firstBatch);
             }, Qt::QueuedConnection);
 
-    connect(rootWorker.data(), &RootInfoWorker::iteratorAddFile, this, &RootInfo::iteratorAddFile, Qt::QueuedConnection);
-
     connect(rootWorker.data(), &RootInfoWorker::iteratorAddFiles, this,
             [this](const QString &key, const QList<SortInfoPointer> sortInfos, const QList<FileInfoPointer> infos) {
                 bool firstBatch = sortInfos.isEmpty() ? false : isFirstBatch.exchange(false);
@@ -836,7 +752,6 @@ void RootInfo::initConnection()
     connect(rootWorker.data(), &RootInfoWorker::requestSort, this, &RootInfo::requestSort, Qt::QueuedConnection);
     connect(rootWorker.data(), &RootInfoWorker::traversalFinished, this, &RootInfo::handleTraversalFinish, Qt::QueuedConnection);
 
-    // 连接监视器信号
     connect(rootWorker.data(), &RootInfoWorker::watcherAddFiles, this, &RootInfo::watcherAddFiles, Qt::QueuedConnection);
     connect(rootWorker.data(), &RootInfoWorker::watcherRemoveFiles, this, &RootInfo::watcherRemoveFiles, Qt::QueuedConnection);
     connect(rootWorker.data(), &RootInfoWorker::watcherUpdateHideFile, this, &RootInfo::watcherUpdateHideFile, Qt::QueuedConnection);
@@ -844,14 +759,11 @@ void RootInfo::initConnection()
     connect(rootWorker.data(), &RootInfoWorker::watcherUpdateFiles, this, &RootInfo::watcherUpdateFiles, Qt::QueuedConnection);
     connect(rootWorker.data(), &RootInfoWorker::renameFileProcessStarted, this, &RootInfo::renameFileProcessStarted, Qt::QueuedConnection);
 
-    // 连接root处理信号
     connect(rootWorker.data(), &RootInfoWorker::requestCloseTab, this, &RootInfo::requestCloseTab, Qt::QueuedConnection);
     connect(rootWorker.data(), &RootInfoWorker::requestClearRoot, this, &RootInfo::requestClearRoot, Qt::QueuedConnection);
 
     connect(this, &RootInfo::resetData, rootWorker.data(), &RootInfoWorker::onResetData, Qt::QueuedConnection);
     connect(this, &RootInfo::iteratorStatus, rootWorker.data(), &RootInfoWorker::onSetIteratorStatus, Qt::QueuedConnection);
-    connect(rootWorker.data(), &RootInfoWorker::watcherTimerStart, this, &RootInfo::onWatcherTimerStart, Qt::QueuedConnection);
-    connect(this, &RootInfo::watcherTimerEvent, rootWorker->watcherWorker().data(), &FileWatcherWorker::doWatcherEvent, Qt::QueuedConnection);
 }
 
 void RootInfo::clearAllThread()
@@ -864,7 +776,6 @@ void RootInfo::clearAllThread()
         thread->traversalThread->stop();
         thread->traversalThread->wait();
     }
-    // wait old dir iterator thread
     for (const auto &thread : discardedThread) {
         thread->disconnect();
         thread->stop();

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.cpp
@@ -5,10 +5,13 @@
 #include "rootinfo.h"
 #include "fileitemdata.h"
 
+#include "utils/keywordextractor.h"
+
 #include <dfm-base/base/schemefactory.h>
 #include <dfm-base/utils/universalutils.h>
 #include <dfm-base/base/application/settings.h>
 #include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/finallyutil.h>
 
 #include <dfm-framework/event/event.h>
 
@@ -19,72 +22,587 @@
 #include <QtConcurrent>
 #include <QElapsedTimer>
 
+
 using namespace dfmbase;
 using namespace dfmplugin_workspace;
+
+
+FileWatcherWorker::FileWatcherWorker(RootInfoWorker *root, QObject *parent)
+    : QObject(parent), rootptr(root)
+{
+}
+
+FileWatcherWorker::~FileWatcherWorker()
+{
+}
+
+void FileWatcherWorker::doFileDeleted(const QUrl &fileUrl)
+{
+    assert(qApp->thread() != QThread::currentThread());
+    fmInfo() << "FileWatcherWorker::doFileDeleted: url=" << fileUrl << "stopped=" << rootptr->stopped;
+    // 自己删除可以执行
+    if (rootptr->stopped || !isSubFile(fileUrl))
+        return;
+
+    FinallyUtil defer([this]{
+        doCheckAndStartTimer();
+    });
+    // 删除的是自己
+    if (UniversalUtils::urlEquals(fileUrl, rootptr->url)) {
+        fmWarning() << "Root directory deleted:" << fileUrl;
+        // 移除缓存和监视器
+        emit InfoCacheController::instance().removeCacheFileInfo({ fileUrl });
+        WatcherCache::instance().removeCacheWatcherByParent(fileUrl);
+
+        // 处理和关闭窗口
+        emit rootptr->requestCloseTab(fileUrl);
+        emit rootptr->requestClearRoot(fileUrl);
+        rootptr->childrenUrlList.clear();
+        rootptr->sourceDataList.clear();
+        return;
+    }
+
+    adds.remove(fileUrl);
+    updates.remove(fileUrl);
+    if (!removes.contains(fileUrl))
+        removes.insert(fileUrl);
+}
+
+void FileWatcherWorker::doFileMoved(const QUrl &fromUrl, const QUrl &toUrl)
+{
+    assert(qApp->thread() != QThread::currentThread());
+    fmInfo() << "FileWatcherWorker::dofileMoved: from=" << fromUrl << "to=" << toUrl;
+    if (rootptr->stopped)
+        return;
+    // 补充：发射重命名过程开始信号（UI反馈）
+    emit rootptr->renameFileProcessStarted();
+    doFileDeleted(fromUrl);
+    // 补充：刷新目标URL缓存
+    auto info = InfoCacheController::instance().getCacheInfo(toUrl);
+    if (info)
+        info->updateAttributes();
+
+    doFileCreated(toUrl);
+}
+
+void FileWatcherWorker::doFileCreated(const QUrl &fileUrl)
+{
+    assert(qApp->thread() != QThread::currentThread());
+    fmInfo() << "FileWatcherWorker::dofileCreated: url=" << fileUrl << "stopped=" << rootptr->stopped;
+    if (rootptr->stopped || !isSubFile(fileUrl))
+        return;
+
+    // 判断update和remove中是否存在存在就移除
+    updates.remove(fileUrl);
+    removes.remove(fileUrl);
+    if (!adds.contains(fileUrl))
+        adds.insert(fileUrl);
+
+    doCheckAndStartTimer();
+}
+
+void FileWatcherWorker::doFileUpdated(const QUrl &fileUrl)
+{
+    assert(qApp->thread() != QThread::currentThread());
+    fmInfo() << "FileWatcherWorker::doFileUpdated: url=" << fileUrl << "stopped=" << rootptr->stopped;
+    if (rootptr->stopped || !isSubFile(fileUrl) || UniversalUtils::urlEquals(fileUrl, rootptr->url))
+        return;
+
+    FinallyUtil defer([this]{
+        doCheckAndStartTimer();
+    });
+    // 如果在增加或者移除中就不添加
+    if (adds.contains(fileUrl) || removes.contains(fileUrl) || updates.contains(fileUrl))
+        return;
+
+    bool fileShowNow = rootptr->childrenUrlList.contains(fileUrl);
+    // 收到update信号但是没有收到fileadd信号，那么添加一个fileadd信号
+    if (fileShowNow) {
+        updates.insert(fileUrl);
+    } else if (dfmio::DFile(fileUrl).exists()) {
+        adds.insert(fileUrl);
+    }
+}
+
+void FileWatcherWorker::doWatcherEvent()
+{
+    assert(qApp->thread() != QThread::currentThread());
+    delayTimeStart = false;
+    doWatcherSubEvent();
+}
+
+void FileWatcherWorker::doWatcherSubEvent()
+{
+    if (rootptr->stopped)
+        return;
+    // 处理添加文件
+    if (!removes.isEmpty()) {
+        rootptr->removeChildren(removes);
+        removes.clear();
+    }
+    if (!adds.isEmpty()) {
+        rootptr->addChildren(adds);
+        adds.clear();
+    }
+    if (!updates.isEmpty()) {
+        rootptr->updateChildren(updates);
+        updates.clear();
+    }
+}
+
+void FileWatcherWorker::doCheckAndStartTimer()
+{
+    if (delayTimeStart)
+        return;
+    delayTimeStart = true;
+    emit rootptr->watcherTimerStart();
+}
+
+bool FileWatcherWorker::isSubFile(const QUrl &fileUrl)
+{
+    // 不是本地文件判读不了是否是子目录
+    if (!fileUrl.isLocalFile())
+        return true;
+
+    auto url = fileUrl;
+    // 判断是否是当前目录的子文件，不是就不处理
+    auto parentUrl = rootptr->url;
+    // 清除掉用户信息和查询信息
+    parentUrl.setUserInfo(QString());
+    parentUrl.setQuery(QString());
+    url.setUserInfo(QString());
+    url.setQuery(QString());
+
+    auto parentPath = parentUrl.path();
+    auto filePath = url.path();
+    if (parentPath.endsWith(QDir::separator()))
+        parentPath.chop(1);
+    if (!filePath.startsWith(parentPath))
+        return false;
+
+    return true;
+}
+
+FileIteratorWorker::FileIteratorWorker(RootInfoWorker *root, QObject *parent)
+    : QObject(parent), rootptr(root)
+{
+}
+
+FileIteratorWorker::~FileIteratorWorker()
+{
+}
+
+// 处理迭代器迭代的文件信息，转换为SortInfo
+void FileIteratorWorker::handleTraversalResults(const QList<FileInfoPointer> &children, const QString &travseToken)
+{
+    assert(qApp->thread() != QThread::currentThread());
+    if (rootptr->stopped)
+        return;
+
+    QList<SortInfoPointer> sortInfos;
+    QList<FileInfoPointer> infos;
+    std::for_each(children.begin(), children.end(), [this, &sortInfos, &infos](const FileInfoPointer &info){
+        if (rootptr->stopped)
+            return;
+        auto sortInfo = rootptr->addChild(info);
+        if (!sortInfo)
+            return;
+        sortInfos.append(sortInfo);
+
+        infos.append(info);
+    });
+
+    fmDebug() << "FileIteratorWorker::handleTraversalResults: sortInfos count=" << sortInfos.size();
+    if (sortInfos.length() > 0)
+        Q_EMIT rootptr->iteratorAddFiles(travseToken, sortInfos, infos);
+}
+
+// 处理search的后面的搜索结果
+void FileIteratorWorker::handleTraversalResultsUpdate(const QList<SortInfoPointer> &children, const QString &travseToken, bool increment)
+{
+    assert(qApp->thread() != QThread::currentThread());
+    if (children.isEmpty() || rootptr->stopped)
+        return;
+
+    if (!increment) {
+        // 首批或全量更新（如搜索结果刷新）：替换整个列表并重建 URL 索引
+        rootptr->childrenUrlList.clear();
+        rootptr->sourceDataList = children;
+        for (const auto &file : children) {
+            if (file)
+                rootptr->childrenUrlList.append(file->fileUrl());
+        }
+    } else {
+        // 增量批次（如 dirent 逐批遍历）：追加到已有列表
+        for (const auto &file : children) {
+            if (!file)
+                continue;
+            rootptr->childrenUrlList.append(file->fileUrl());
+            rootptr->sourceDataList.append(file);
+        }
+    }
+
+    emit rootptr->iteratorUpdateFiles(travseToken, rootptr->sourceDataList, false);
+}
+
+// 处理搜索的第一次推送的结果或者迭代器使用sortFileInfoList迭代出来的文件
+void FileIteratorWorker::handleTraversalLocalResult(QList<SortInfoPointer> children, dfmio::DEnumerator::SortRoleCompareFlag sortRole, Qt::SortOrder sortOrder, bool isMixDirAndFile, const QString &travseToken)
+{
+    assert(qApp->thread() != QThread::currentThread());
+    if (rootptr->stopped)
+        return;
+    rootptr->originSortRole = sortRole;
+    rootptr->originSortOrder = sortOrder;
+    rootptr->originMixSort = isMixDirAndFile;
+
+    rootptr->addChildren(children);
+
+    Q_EMIT rootptr->iteratorLocalFiles(travseToken, rootptr->sourceDataList, rootptr->originSortRole, rootptr->originSortOrder, rootptr->originMixSort, true);
+}
+
+void FileIteratorWorker::handleTraversalFinish(const QString &travseToken)
+{
+    if (rootptr->stopped)
+        return;
+    rootptr->itStatus = RootInfoWorker::IteratorStatus::kFinished;
+    emit rootptr->traversalFinished(travseToken);
+}
+
+void FileIteratorWorker::handleTraversalSort(const QString &travseToken)
+{
+    if (rootptr->stopped)
+        return;
+    emit rootptr->requestSort(travseToken, rootptr->url);
+}
+
+RootInfoWorker::RootInfoWorker(const QUrl &url, QObject *parent)
+    : QObject(parent), url(url)
+{
+    // 补充hiddenFileUrl初始化（从旧代码迁移）
+    hiddenFileUrl.setScheme(url.scheme());
+    hiddenFileUrl.setPath(DFMIO::DFMUtils::buildFilePath(url.path().toStdString().c_str(), ".hidden", nullptr));
+    it.reset(new FileIteratorWorker(this));
+    watch.reset(new FileWatcherWorker(this));
+    keyWords = KeywordExtractorManager::instance().extractor().extractFromUrl(url);
+}
+
+RootInfoWorker::~RootInfoWorker()
+{
+}
+
+void RootInfoWorker::stop()
+{
+    stopped = true;
+}
+
+QSharedPointer<FileIteratorWorker> RootInfoWorker::iteratorWorker() const
+{
+    return it;
+}
+
+QSharedPointer<FileWatcherWorker> RootInfoWorker::watcherWorker() const
+{
+    return watch;
+}
+
+void RootInfoWorker::addChildren(const QSet<QUrl> &urlList)
+{
+    if (stopped)
+        return;
+    fmInfo() << "RootInfoWorker::addChildren(QSet): url count=" << urlList.size() << "stopped=" << stopped;
+    QList<SortInfoPointer> newSortInfo;
+
+    bool isContainHidd = false;
+    std::for_each(urlList.begin(), urlList.end(), [this, &isContainHidd, &newSortInfo](QUrl url) {
+        if (stopped)
+            return;
+        url.setPath(url.path());
+
+        auto child = fileInfo(url);
+
+        if (!child)
+            return;
+
+        if (UniversalUtils::urlEquals(url, hiddenFileUrl))
+            isContainHidd = true;
+
+        auto sortInfo = addChild(child);
+        if (sortInfo)
+            newSortInfo.append(sortInfo);
+    });
+
+    fmDebug() << "RootInfoWorker::addChildren(QSet): newSortInfo count=" << newSortInfo.size();
+    if (newSortInfo.count() > 0) {
+        originSortRole = dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault;
+        emit watcherAddFiles(newSortInfo);
+    }
+
+    if (isContainHidd)
+        Q_EMIT watcherUpdateHideFile(hiddenFileUrl);
+}
+
+void RootInfoWorker::addChildren(const QList<SortInfoPointer> &children, const int start)
+{
+    // 这里搜索时不能使用增量更新，以前的SortInfo也有修改，所以前面搜索出来的有可能搜索的内容没有显示出来
+    Q_UNUSED(start);
+    if (stopped)
+        return;
+
+    childrenUrlList.clear();
+    sourceDataList = children;
+
+    std::for_each(children.begin(), children.end(), [this](const SortInfoPointer &sortInfo) {
+        if (stopped || !sortInfo)
+            return;
+        childrenUrlList.append(sortInfo->fileUrl());
+    });
+}
+
+SortInfoPointer RootInfoWorker::addChild(const FileInfoPointer &child)
+{
+    if (stopped || !child)
+        return nullptr;
+
+    auto childUrl = child->urlOf(UrlInfoType::kUrl);
+    if (childrenUrlList.contains(childUrl))
+        return nullptr;
+
+    auto sort = sortFileInfo(child);
+    if (!sort)
+        return nullptr;
+
+    childrenUrlList.append(childUrl);
+    sourceDataList.append(sort);
+
+    return sort;
+}
+
+SortInfoPointer RootInfoWorker::sortFileInfo(const FileInfoPointer &info)
+{
+    if (!info || stopped)
+        return nullptr;
+
+    SortInfoPointer sortInfo(new SortFileInfo);
+    sortInfo->setUrl(info->urlOf(UrlInfoType::kUrl));
+    sortInfo->setSize(info->size());
+    sortInfo->setFile(!info->isAttributes(OptInfoType::kIsDir));
+    sortInfo->setDir(info->isAttributes(OptInfoType::kIsDir));
+    sortInfo->setHide(info->isAttributes(OptInfoType::kIsHidden));
+    sortInfo->setSymlink(info->isAttributes(OptInfoType::kIsSymLink));
+    sortInfo->setReadable(info->isAttributes(OptInfoType::kIsReadable));
+    sortInfo->setWriteable(info->isAttributes(OptInfoType::kIsWritable));
+    sortInfo->setExecutable(info->isAttributes(OptInfoType::kIsExecutable));
+
+    sortInfo->setLastReadTime(info->timeOf(TimeInfoType::kLastRead).value<QDateTime>().toSecsSinceEpoch());
+    sortInfo->setLastModifiedTime(info->timeOf(TimeInfoType::kLastModified).value<QDateTime>().toSecsSinceEpoch());
+    sortInfo->setCreateTime(info->timeOf(TimeInfoType::kCreateTime).value<QDateTime>().toSecsSinceEpoch());
+    sortInfo->setInfoCompleted(true);
+
+    return sortInfo;
+}
+
+void RootInfoWorker::removeChildren(const QSet<QUrl> &urlList)
+{
+    if (stopped)
+        return;
+    QList<SortInfoPointer> removeChildren {};
+    int childIndex = -1;
+    QList<QUrl> removeUrls;
+    emit InfoCacheController::instance().removeCacheFileInfo(urlList.values());
+    std::for_each(urlList.begin(), urlList.end(), [this, &removeUrls, &removeChildren, &childIndex](const QUrl &fileUrl){
+        if (stopped)
+            return;
+        auto url = fileUrl;
+        url.setPath(url.path());
+
+        // 优化：先检查 childrenUrlList 是否已包含此 URL，命中则直接使用 sourceDataList
+        // 中缓存的 SortInfo，避免创建 FileInfo 的同步 I/O。
+        childIndex = childrenUrlList.indexOf(url);
+        if (childIndex >= 0 && childIndex < childrenUrlList.length()) {
+            bool isDir = sourceDataList.at(childIndex)->isDir();
+            if (isDir) {
+                WatcherCache::instance().removeCacheWatcherByParent(url);
+                emit requestCloseTab(url);
+            }
+            removeUrls.append(url);
+            childrenUrlList.removeAt(childIndex);
+            removeChildren.append(sourceDataList.takeAt(childIndex));
+            return;
+        }
+
+        // 未命中缓存，回退到创建 FileInfo 获取真实 URL
+        auto child = fileInfo(url);
+        if (!child)
+            return;
+
+        auto realUrl = child->urlOf(UrlInfoType::kUrl);
+        childIndex = childrenUrlList.indexOf(realUrl);
+
+        // 处理各个窗口显示的父目录删除
+        // 删除事件到达时文件已不存在，fileInfo() 重新查询 isDir 会失败并返回 false，
+        // 因此优先使用已加载子项列表 sourceDataList 中缓存的 SortInfo（其 isDir 在文件
+        // 存在时设置、可靠）；仅在子项尚未加载时才回退到实时查询，避免删除一个正被其它
+        // 窗口打开的目录后，那些窗口收不到 requestCloseTab 而无法自动跳转。
+        bool isDir = (childIndex >= 0 && childIndex < sourceDataList.length())
+                ? sourceDataList.at(childIndex)->isDir()
+                : child->isDir();
+        if (isDir) {
+            WatcherCache::instance().removeCacheWatcherByParent(url);
+            emit requestCloseTab(url);
+        }
+
+        removeUrls.append(realUrl);
+        if (childIndex < 0 || childIndex >= childrenUrlList.length()) {
+            removeChildren.append(sortFileInfo(child));
+            return;
+        }
+        childrenUrlList.removeAt(childIndex);
+        removeChildren.append(sourceDataList.takeAt(childIndex));
+    });
+
+    // 移除缓存
+    if (removeUrls.count() > 0)
+        emit InfoCacheController::instance().removeCacheFileInfo(removeUrls);
+
+    // 移除显示的项
+    if (removeChildren.count() > 0)
+        emit watcherRemoveFiles(removeChildren);
+
+    // 跟新隐藏文件的显示项
+    if (removeUrls.contains(hiddenFileUrl))
+        Q_EMIT watcherUpdateHideFile(hiddenFileUrl);
+}
+
+bool RootInfoWorker::containsChild(const QUrl &url)
+{
+    if (stopped)
+        return false;
+    return childrenUrlList.contains(url);
+}
+
+FileInfoPointer RootInfoWorker::fileInfo(const QUrl &url)
+{
+    if (stopped)
+        return nullptr;
+    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
+    if (!info.isNull())
+        return info;
+
+    // 不是当前目录的就不处理
+    const QUrl &parentUrl = QUrl::fromPercentEncoding(this->url.toString().toUtf8());
+    auto path = url.path();
+    if (path.isEmpty() || path == QDir::separator() || url.fileName().isEmpty())
+        return info;
+
+    auto pathParent = path.endsWith(QDir::separator()) ? path.left(path.length() - 1) : path;
+    auto parentPath = parentUrl.path().endsWith(QDir::separator())
+            ? parentUrl.path().left(parentUrl.path().length() - 1)
+            : parentUrl.path();
+    pathParent = pathParent.left(pathParent.lastIndexOf(QDir::separator()));
+    if (!parentPath.endsWith(pathParent.mid(1)))
+        return info;
+
+    auto currentUrl = parentUrl;
+    currentUrl.setPath(currentUrl.path(QUrl::PrettyDecoded) + QDir::separator() + url.fileName());
+    info = InfoFactory::create<FileInfo>(currentUrl);
+    return info;
+}
+
+SortInfoPointer RootInfoWorker::updateChild(const QUrl &url)
+{
+    if (stopped)
+        return nullptr;
+    SortInfoPointer sort { nullptr };
+
+    auto info = fileInfo(url);
+    if (info.isNull())
+        return nullptr;
+
+    auto realUrl = info->urlOf(UrlInfoType::kUrl);
+    if (!childrenUrlList.contains(realUrl))
+        return nullptr;
+    sort = sortFileInfo(info);
+    if (sort.isNull())
+        return nullptr;
+    sourceDataList.replace(childrenUrlList.indexOf(realUrl), sort);
+
+    // NOTE: GlobalEventType::kHideFiles event is watched in fileview, but this can be used to notify update view
+    // when the file is modified in other way.
+    if (UniversalUtils::urlEquals(hiddenFileUrl, url))
+        Q_EMIT watcherUpdateHideFile(url);
+
+    return sort;
+}
+
+void RootInfoWorker::updateChildren(const QSet<QUrl> &urls)
+{
+    if (stopped)
+        return;
+    QList<SortInfoPointer> updates;
+    std::for_each(urls.begin(), urls.end(), [this, &updates](const QUrl url) {
+        if (stopped)
+            return;
+        auto sort = updateChild(url);
+        if (sort)
+            updates.append(sort);
+    });
+    if (updates.isEmpty())
+        return;
+    emit watcherUpdateFiles(updates);
+}
+
+void RootInfoWorker::onResetData()
+{
+    childrenUrlList.clear();
+    sourceDataList.clear();
+}
+
+void RootInfoWorker::onSetIteratorStatus(const RootInfoWorker::IteratorStatus &status)
+{
+    itStatus = status;
+}
+
 RootInfo::RootInfo(const QUrl &u, QObject *parent)
     : QObject(parent), url(u)
 {
-    fmInfo() << "RootInfo created for URL:" << url.toString();
+    fmInfo() << "RootInfo created for url:" << u;
+    rootWorker.reset(new RootInfoWorker(url));
 
-    hiddenFileUrl.setScheme(url.scheme());
-    hiddenFileUrl.setPath(DFMIO::DFMUtils::buildFilePath(url.path().toStdString().c_str(), ".hidden", nullptr));
+    initConnection();
+    rootWorker->moveToThread(&rootThread);
+    rootWorker->watcherWorker()->moveToThread(&rootThread);
+    rootWorker->iteratorWorker()->moveToThread(&rootThread);
+
+    keyWords = KeywordExtractorManager::instance().extractor().extractFromUrl(url);
+
+    connect(qApp, &QApplication::aboutToQuit, this, [this]{
+        // 保证所有的迭代线程退出
+        this->clearAllThread();
+    });
+    rootThread.start();
 }
 
 RootInfo::~RootInfo()
 {
-    isDying.store(true);
-    fmInfo() << "RootInfo destructor started for URL:" << url.toString();
-
-    disconnect();
-    if (watcher) {
-        fmDebug() << "Stopping file watcher";
-        watcher->stopWatcher();
-    }
-
-    cancelWatcherEvent = true;
-    for (auto &future : watcherEventFutures) {
-        future.waitForFinished();
-    }
-
-    fmDebug() << "Stopping" << traversalThreads.size() << "traversal threads";
-    for (const auto &thread : traversalThreads) {
-        thread->traversalThread->stop();
-        thread->traversalThread->wait();
-    }
-
-    // wait old dir iterator thread
-    for (const auto &thread : discardedThread) {
-        thread->disconnect();
-        thread->stop();
-        thread->quit();
-        thread->wait();
-    }
-
-    fmInfo() << "RootInfo destructor completed for URL:" << url.toString();
+    fmInfo() << "RootInfo destroyed for url:" << url;
+    clearAllThread();
 }
 
 void RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::ItemRoles role, Qt::SortOrder order, bool isMixFileAndFolder)
 {
-    fmDebug() << "Initializing file data thread for key:" << key << "role:" << role
-              << "order:" << (order == Qt::AscendingOrder ? "Ascending" : "Descending")
-              << "mixFileAndFolder:" << isMixFileAndFolder;
-
     // clear old dir iterator thread
-    for (auto it = discardedThread.begin(); it != discardedThread.end();) {
+    for (auto it = discardedThread.begin(); it != discardedThread.end(); ) {
         if (!(*it)->isRunning()) {
             it = discardedThread.erase(it);
         } else {
             it++;
         }
     }
-
     // create traversal thread
     QSharedPointer<DirIteratorThread> traversalThread = traversalThreads.value(key);
     if (!traversalThread.isNull()) {
-        fmDebug() << "Disconnecting existing traversal thread for key:" << key;
         traversalThread->traversalThread->disconnect();
     }
-    fmDebug() << "Creating new traversal thread for URL:" << url.toString();
 
     traversalThread.reset(new DirIteratorThread);
     traversalThread->traversalThread.reset(
@@ -93,7 +611,7 @@ void RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::Ite
                                           QDirIterator::FollowSymlinks));
     traversalThread->traversalThread->setSortAgruments(order, role, isMixFileAndFolder);
     traversalThread->traversalThread->setTraversalToken(key);
-    initConnection(traversalThread->traversalThread);
+    initIteratorConnection(traversalThread->traversalThread);
     traversalThreads.insert(key, traversalThread);
 
     switch (role) {
@@ -116,36 +634,26 @@ void RootInfo::initThreadOfFileData(const QString &key, DFMGLOBAL_NAMESPACE::Ite
     traversalThread->originSortOrder = order;
 }
 
-void RootInfo::startWork(const QString &key)
+void RootInfo::startIteratorWork(const QString &key)
 {
     if (!traversalThreads.contains(key)) {
-        fmWarning() << "Cannot start work: traversal thread not found for key:" << key;
+        fmWarning() << "startIteratorWork: key not found" << key;
         return;
     }
 
-    fmDebug() << "Starting work for key:" << key;
-
-    fmInfo() << "Starting directory traversal for URL:" << url.toString();
-    {
-        QWriteLocker lk(&childrenLock);
-        childrenUrlList.clear();
-        sourceDataList.clear();
-    }
+    fmInfo() << "startIteratorWork: key=" << key << "url=" << url;
+    traversaling = true;
+    emit resetData();
+    emit iteratorStatus(RootInfoWorker::IteratorStatus::kRunning);
     traversalThreads.value(key)->traversalThread->start();
 }
 
 void RootInfo::startWatcher()
 {
-    if (needStartWatcher == false) {
-        fmDebug() << "File watcher already started or not needed for URL:" << url.toString();
+    if (needStartWatcher == false)
         return;
-    }
-
-    fmInfo() << "Starting file watcher for URL:" << url.toString();
     needStartWatcher = false;
-
     if (watcher) {
-        fmDebug() << "Stopping existing watcher before restart";
         watcher->stopWatcher();
         watcher->disconnect(this);
     }
@@ -157,75 +665,57 @@ void RootInfo::startWatcher()
         return;
     }
 
-    fmDebug() << "Connecting watcher signals for URL:" << url.toString();
+    // worker 子线程执行
     connect(watcher.data(), &AbstractFileWatcher::fileDeleted,
-            this, &RootInfo::doFileDeleted);
+            rootWorker->watcherWorker().data(), &FileWatcherWorker::doFileDeleted, Qt::QueuedConnection);
     connect(watcher.data(), &AbstractFileWatcher::subfileCreated,
-            this, &RootInfo::dofileCreated);
+            rootWorker->watcherWorker().data(), &FileWatcherWorker::doFileCreated, Qt::QueuedConnection);
     connect(watcher.data(), &AbstractFileWatcher::fileAttributeChanged,
-            this, &RootInfo::doFileUpdated);
+            rootWorker->watcherWorker().data(), &FileWatcherWorker::doFileUpdated, Qt::QueuedConnection);
     connect(watcher.data(), &AbstractFileWatcher::fileRename,
-            this, &RootInfo::dofileMoved);
+            rootWorker->watcherWorker().data(), &FileWatcherWorker::doFileMoved, Qt::QueuedConnection);
 
     watcher->restartWatcher();
-    fmDebug() << "File watcher started successfully for URL:" << url.toString();
 }
 
 int RootInfo::clearTraversalThread(const QString &key, const bool isRefresh)
 {
-    if (!traversalThreads.contains(key)) {
-        fmDebug() << "No traversal thread to clear for key:" << key;
+    if (!traversalThreads.contains(key))
         return traversalThreads.count();
-    }
-
-    fmDebug() << "Clearing traversal thread for key:" << key << "isRefresh:" << isRefresh;
 
     auto thread = traversalThreads.take(key);
     auto traversalThread = thread->traversalThread;
-    if (traversalThread->isRunning()) {
-        fmDebug() << "Emitting traversal finished signal for running thread";
-        emit traversalFinished(key, false);
-    }
     traversalThread->disconnect(this);
     if (traversalThread->isRunning()) {
-        fmDebug() << "Moving running thread to discarded list";
         discardedThread.append(traversalThread);
+        traversaling = false;
     }
     thread->traversalThread->stop();
-    if (traversalThreads.isEmpty()) {
-        fmDebug() << "All traversal threads cleared, enabling watcher restart";
+    if (traversalThreads.isEmpty())
         needStartWatcher = true;
-    }
 
     this->isRefresh = isRefresh;
-    fmDebug() << "Traversal threads remaining:" << traversalThreads.count();
     return traversalThreads.count();
 }
 
 void RootInfo::setFirstBatch(bool first)
 {
-    isFirstBatch = first;
+    isFirstBatch.store(first);
 }
 
 void RootInfo::reset()
 {
-    fmInfo() << "Resetting RootInfo for URL:" << url.toString();
+    fmInfo() << "RootInfo::reset: url=" << url;
 
-    disconnect();
-
-    {
-        QWriteLocker lk(&childrenLock);
-        childrenUrlList.clear();
-        sourceDataList.clear();
-    }
+    emit resetData();
 
     if (watcher) {
-        fmDebug() << "Disconnecting and stopping file watcher";
-        watcher->disconnect(this);
         watcher->stopWatcher();
     }
+    needStartWatcher = true;
 
-    cancelWatcherEvent = true;
+    emit iteratorStatus(RootInfoWorker::IteratorStatus::kNone);
+
     for (const auto &thread : traversalThreads) {
         thread->traversalThread->stop();
     }
@@ -241,26 +731,15 @@ void RootInfo::reset()
 
 bool RootInfo::canDelete() const
 {
-    for (auto &future : watcherEventFutures) {
-        if (!future.isFinished()) {
-            fmDebug() << "Cannot delete: watcher event future still running";
-            return false;
-        }
-    }
     for (const auto &thread : traversalThreads) {
-        if (!thread->traversalThread->isFinished()) {
-            fmDebug() << "Cannot delete: traversal thread still running";
+        if (!thread->traversalThread->isFinished())
             return false;
-        }
     }
     // wait old dir iterator thread
     for (const auto &thread : discardedThread) {
-        if (!thread->isFinished()) {
-            fmDebug() << "Cannot delete: discarded thread still running";
+        if (!thread->isFinished())
             return false;
-        }
     }
-    fmDebug() << "RootInfo can be safely deleted for URL:" << url.toString();
     return true;
 }
 
@@ -274,255 +753,14 @@ bool RootInfo::checkKeyOnly(const QString &key) const
     return true;
 }
 
-void RootInfo::doFileDeleted(const QUrl &url)
+QStringList RootInfo::getKeyWords() const
 {
-    fmDebug() << "File deleted event for URL:" << url.toString();
-    enqueueEvent(QPair<QUrl, EventType>(url, kRmFile));
-    metaObject()->invokeMethod(this, QT_STRINGIFY(doThreadWatcherEvent), Qt::QueuedConnection);
-}
-
-void RootInfo::dofileMoved(const QUrl &fromUrl, const QUrl &toUrl)
-{
-    fmInfo() << "File moved from:" << fromUrl.toString() << "to:" << toUrl.toString();
-    Q_EMIT renameFileProcessStarted();
-    doFileDeleted(fromUrl);
-
-    AbstractFileInfoPointer info = InfoCacheController::instance().getCacheInfo(toUrl);
-    if (info)
-        info->refresh();
-
-    dofileCreated(toUrl);
-}
-
-void RootInfo::dofileCreated(const QUrl &url)
-{
-    fmDebug() << "File created event for URL:" << url.toString();
-    enqueueEvent(QPair<QUrl, EventType>(url, kAddFile));
-    metaObject()->invokeMethod(this, QT_STRINGIFY(doThreadWatcherEvent), Qt::QueuedConnection);
-}
-
-void RootInfo::doFileUpdated(const QUrl &url)
-{
-    fmDebug() << "File updated event for URL:" << url.toString();
-    enqueueEvent(QPair<QUrl, EventType>(url, kUpdateFile));
-    metaObject()->invokeMethod(this, QT_STRINGIFY(doThreadWatcherEvent), Qt::QueuedConnection);
-}
-
-void RootInfo::doWatcherEvent()
-{
-    // 使用原子性的 test_and_set 操作
-    bool expected = false;
-    // 如果 processFileEventRuning 是 false，则将其设置为 true，并返回 true
-    // 如果已经是 true，则什么都不做，并返回 false
-    if (!processFileEventRuning.compare_exchange_strong(expected, true)) {
-        fmDebug() << "Watcher event processing already running, skipping";
-        return;   // 已经有其他线程在运行，直接返回
-    }
-
-    fmDebug() << "Starting watcher event processing for URL:" << url.toString();
-
-    QElapsedTimer timer;
-    timer.start();
-    QList<QUrl> adds, updates, removes;
-    qint64 oldtime = 0;
-    int emptyLoopCount = 0;
-    while (checkFileEventQueue() || timer.elapsed() < 200) {
-        // 检查超时，重新设置起始时间
-        if (timer.elapsed() - oldtime >= 200) {
-            // 处理添加文件
-            if (!adds.isEmpty()) {
-                fmDebug() << "Processing" << adds.size() << "add events";
-                addChildren(adds);
-            }
-            if (!updates.isEmpty()) {
-                fmDebug() << "Processing" << updates.size() << "update events";
-                updateChildren(updates);
-            }
-            if (!removes.isEmpty()) {
-                fmDebug() << "Processing" << removes.size() << "remove events";
-                removeChildren(removes);
-            }
-
-            adds.clear();
-            updates.clear();
-            removes.clear();
-
-            oldtime = timer.elapsed();
-        }
-
-        if (cancelWatcherEvent) {
-            fmDebug() << "Watcher event processing cancelled";
-            return;
-        }
-
-        if (!checkFileEventQueue()) {
-            if (emptyLoopCount >= 5)
-                break;
-
-            QThread::msleep(20);
-            if (adds.isEmpty() && updates.isEmpty() && removes.isEmpty())
-                oldtime = timer.elapsed();
-
-            ++emptyLoopCount;
-            continue;
-        }
-
-        emptyLoopCount = 0;
-        QPair<QUrl, EventType> event = dequeueEvent();
-        const QUrl &fileUrl = event.first;
-
-        if (cancelWatcherEvent)
-            return;
-
-        if (!fileUrl.isValid())
-            continue;
-
-        if (UniversalUtils::urlEquals(fileUrl, url)) {
-            if (event.second == kAddFile)
-                continue;
-            else if (event.second == kRmFile) {
-                fmDebug() << "Root directory deleted, clearing all data for URL:" << url.toString();
-                emit InfoCacheController::instance().removeCacheFileInfo({ fileUrl });
-                WatcherCache::instance().removeCacheWatcherByParent(fileUrl);
-                emit requestCloseTab(fileUrl);
-                emit requestClearRoot(fileUrl);
-                QWriteLocker lk(&childrenLock);
-                childrenUrlList.clear();
-                sourceDataList.clear();
-                break;
-            }
-        }
-
-        if (cancelWatcherEvent)
-            return;
-
-        if (event.second == kAddFile) {
-            // 判断update和remove中是否存在存在就移除
-            updates.removeOne(fileUrl);
-            removes.removeOne(fileUrl);
-            if (adds.contains(fileUrl))
-                continue;
-
-            adds.append(fileUrl);
-        } else if (event.second == kUpdateFile) {
-            // 如果在增加或者移除中就不添加
-            if (adds.contains(fileUrl) || removes.contains(fileUrl) || updates.contains(fileUrl))
-                continue;
-            updates.append(fileUrl);
-        } else {
-            adds.removeOne(fileUrl);
-            updates.removeOne(fileUrl);
-            if (removes.contains(fileUrl))
-                continue;
-            removes.append(fileUrl);
-        }
-    }
-    processFileEventRuning.store(false);   // 运行完毕，重置标志
-
-    // 处理添加文件
-    if (!removes.isEmpty())
-        removeChildren(removes);
-    if (!adds.isEmpty())
-        addChildren(adds);
-    if (!updates.isEmpty())
-        updateChildren(updates);
-}
-
-void RootInfo::doThreadWatcherEvent()
-{
-    if (isDying.load() || processFileEventRuning)
-        return;
-    for (auto it = watcherEventFutures.begin(); it != watcherEventFutures.end();) {
-        if (it->isFinished()) {
-            it = watcherEventFutures.erase(it);
-        } else {
-            it++;
-        }
-    }
-
-    watcherEventFutures << QtConcurrent::run([&]() {
-        if (cancelWatcherEvent || isDying.load())
-            return;
-        doWatcherEvent();
-    });
-}
-
-void RootInfo::handleTraversalResults(const QList<FileInfoPointer> children, const QString &travseToken)
-{
-    fmDebug() << "Handling traversal results for token:" << travseToken << "children count:" << children.size();
-
-    QList<SortInfoPointer> sortInfos;
-    QList<FileInfoPointer> infos;
-    for (const auto &info : children) {
-        auto sortInfo = addChild(info);
-        if (!sortInfo)
-            continue;
-        sortInfos.append(sortInfo);
-
-        infos.append(info);
-    }
-
-    if (sortInfos.length() > 0) {
-        bool isFirst = isFirstBatch.exchange(false);   // Get and reset the flag
-        fmDebug() << "Emitting iterator add files signal - sortInfos:" << sortInfos.size() << "isFirst:" << isFirst;
-        Q_EMIT iteratorAddFiles(travseToken, sortInfos, infos, isFirst);
-    }
-}
-
-void RootInfo::handleTraversalResultsUpdate(const QList<SortInfoPointer> children, const QString &travseToken, bool increment)
-{
-    if (children.isEmpty()) {
-        fmDebug() << "Empty traversal results update for token:" << travseToken;
-        return;
-    }
-
-    QWriteLocker lk(&childrenLock);
-    if (!increment) {
-        // 首批或全量更新（如搜索结果刷新）：替换整个列表并重建 URL 索引
-        childrenUrlList.clear();
-        sourceDataList = children;
-        for (const auto &file : children) {
-            if (file)
-                childrenUrlList.append(file->fileUrl());
-        }
-    } else {
-        // 增量批次（如 dirent 逐批遍历）：追加到已有列表
-        for (const auto &file : children) {
-            if (!file)
-                continue;
-            childrenUrlList.append(file->fileUrl());
-            sourceDataList.append(file);
-        }
-    }
-
-    bool isFirst = isFirstBatch.exchange(false);   // Get and reset the flag
-    fmDebug() << "Emitting iterator update files signal - children:" << children.size() << "isFirst:" << isFirst;
-    Q_EMIT iteratorUpdateFiles(travseToken, sourceDataList, isFirst);
-}
-
-void RootInfo::handleTraversalLocalResult(QList<SortInfoPointer> children,
-                                          dfmio::DEnumerator::SortRoleCompareFlag sortRole,
-                                          Qt::SortOrder sortOrder, bool isMixDirAndFile, const QString &travseToken)
-{
-    originSortRole = sortRole;
-    originSortOrder = sortOrder;
-    originMixSort = isMixDirAndFile;
-
-    if (children.isEmpty()) {
-        fmDebug() << "Empty local traversal results for token:" << travseToken;
-        return;
-    }
-
-    addChildren(children);
-
-    bool isFirst = isFirstBatch.exchange(false);   // Get and reset the flag
-    fmDebug() << "Emitting iterator local files signal - children:" << children.size() << "isFirst:" << isFirst;
-    Q_EMIT iteratorLocalFiles(travseToken, children, originSortRole, originSortOrder, originMixSort, isFirst);
+    return keyWords;
 }
 
 void RootInfo::handleTraversalFinish(const QString &travseToken)
 {
-    fmInfo() << "Traversal finished for token:" << travseToken << "URL:" << url.toString();
+    fmInfo() << "RootInfo::handleTraversalFinish:" << travseToken << "url:" << url;
 
     // Check if isFirstBatch is still true, which means no directory data was produced
     bool noDataProduced = isFirstBatch.load();
@@ -530,295 +768,113 @@ void RootInfo::handleTraversalFinish(const QString &travseToken)
     isFirstBatch.store(false);
 
     fmDebug() << "Emitting traversal finished signal - noDataProduced:" << noDataProduced;
-    // Emit signal with additional parameter indicating if no data was produced
     emit traversalFinished(travseToken, noDataProduced);
+
+    traversaling = false;
+    traversalFinish = true;
     if (isRefresh) {
-        fmDebug() << "Refresh completed, resetting refresh flag";
+        fmDebug() << "RootInfo::handleTraversalFinish: refresh completed";
         isRefresh = false;
     }
 }
 
-void RootInfo::handleTraversalSort(const QString &travseToken)
+void RootInfo::onWatcherTimerStart()
 {
-    fmDebug() << "Emitting traversal sort request for token:" << travseToken << "URL:" << url.toString();
-    emit requestSort(travseToken, url);
+    QTimer::singleShot(100, this, [this]{
+        emit watcherTimerEvent();
+    });
 }
 
-void RootInfo::initConnection(const TraversalThreadManagerPointer &traversalThread)
+void RootInfo::initIteratorConnection(const TraversalThreadManagerPointer &traversalThread)
 {
+    // 再worker的子线程中执行
     connect(traversalThread.data(), &TraversalDirThreadManager::updateChildrenManager,
-            this, &RootInfo::handleTraversalResults, Qt::DirectConnection);
-    connect(traversalThread.data(), &TraversalDirThreadManager::updateChildrenInfo,
-            this, &RootInfo::handleTraversalResultsUpdate, Qt::DirectConnection);
+            rootWorker->iteratorWorker().data(), &FileIteratorWorker::handleTraversalResults, Qt::QueuedConnection);
     connect(traversalThread.data(), &TraversalDirThreadManager::updateLocalChildren,
-            this, &RootInfo::handleTraversalLocalResult, Qt::DirectConnection);
+            rootWorker->iteratorWorker().data(), &FileIteratorWorker::handleTraversalLocalResult, Qt::QueuedConnection);
     connect(traversalThread.data(), &TraversalDirThreadManager::traversalRequestSort,
-            this, &RootInfo::handleTraversalSort, Qt::DirectConnection);
-    // 主线中执行
+            rootWorker->iteratorWorker().data(), &FileIteratorWorker::handleTraversalSort, Qt::QueuedConnection);
+    connect(traversalThread.data(), &TraversalDirThreadManager::updateChildrenInfo,
+            rootWorker->iteratorWorker().data(), &FileIteratorWorker::handleTraversalResultsUpdate, Qt::QueuedConnection);
     connect(traversalThread.data(), &TraversalDirThreadManager::traversalFinished,
-            this, &RootInfo::handleTraversalFinish, Qt::QueuedConnection);
+            rootWorker->iteratorWorker().data(), &FileIteratorWorker::handleTraversalFinish, Qt::QueuedConnection);
+
+    // 主线中执行，启动监视器
     connect(traversalThread.data(), &TraversalDirThreadManager::iteratorInitFinished,
             this, &RootInfo::startWatcher, Qt::QueuedConnection);
 }
 
-void RootInfo::addChildren(const QList<QUrl> &urlList)
+void RootInfo::initConnection()
 {
-    QList<SortInfoPointer> newSortInfo;
+    // 连接迭代器信号 —— 三个数据信号使用 lambda 转发 isFirstBatch
+    connect(rootWorker.data(), &RootInfoWorker::iteratorLocalFiles, this,
+            [this](const QString &key,
+                   const QList<SortInfoPointer> children,
+                   const dfmio::DEnumerator::SortRoleCompareFlag sortRole,
+                   const Qt::SortOrder sortOrder,
+                   const bool isMixDirAndFile, const bool isFirst) {
+                Q_UNUSED(isFirst)
+                bool firstBatch = children.isEmpty() ? false : isFirstBatch.exchange(false);
+                emit iteratorLocalFiles(key, children, sortRole, sortOrder, isMixDirAndFile, firstBatch);
+            }, Qt::QueuedConnection);
 
-    bool hasHiddenFile = false;
-    for (auto url : urlList) {
-        url.setPath(url.path());
+    connect(rootWorker.data(), &RootInfoWorker::iteratorUpdateFiles, this,
+            [this](const QString &key, const QList<SortInfoPointer> children, const bool isFirst) {
+                Q_UNUSED(isFirst)
+                bool firstBatch = children.isEmpty() ? false : isFirstBatch.exchange(false);
+                emit iteratorUpdateFiles(key, children, firstBatch);
+            }, Qt::QueuedConnection);
 
-        auto child = fileInfo(url);
+    connect(rootWorker.data(), &RootInfoWorker::iteratorAddFile, this, &RootInfo::iteratorAddFile, Qt::QueuedConnection);
 
-        if (!child) {
-            fmDebug() << "Failed to get file info for URL:" << url.toString();
-            continue;
-        }
+    connect(rootWorker.data(), &RootInfoWorker::iteratorAddFiles, this,
+            [this](const QString &key, const QList<SortInfoPointer> sortInfos, const QList<FileInfoPointer> infos) {
+                bool firstBatch = sortInfos.isEmpty() ? false : isFirstBatch.exchange(false);
+                emit iteratorAddFiles(key, sortInfos, infos, firstBatch);
+            }, Qt::QueuedConnection);
 
-        if (UniversalUtils::urlEquals(url, hiddenFileUrl))
-            hasHiddenFile = true;
+    connect(rootWorker.data(), &RootInfoWorker::requestSort, this, &RootInfo::requestSort, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::traversalFinished, this, &RootInfo::handleTraversalFinish, Qt::QueuedConnection);
 
-        auto sortInfo = addChild(child);
-        if (sortInfo)
-            newSortInfo.append(sortInfo);
-    }
+    // 连接监视器信号
+    connect(rootWorker.data(), &RootInfoWorker::watcherAddFiles, this, &RootInfo::watcherAddFiles, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::watcherRemoveFiles, this, &RootInfo::watcherRemoveFiles, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::watcherUpdateHideFile, this, &RootInfo::watcherUpdateHideFile, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::watcherUpdateFile, this, &RootInfo::watcherUpdateFile, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::watcherUpdateFiles, this, &RootInfo::watcherUpdateFiles, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::renameFileProcessStarted, this, &RootInfo::renameFileProcessStarted, Qt::QueuedConnection);
 
-    if (newSortInfo.count() > 0) {
-        originSortRole = dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault;
-        fmDebug() << "Emitting watcher add files signal - count:" << newSortInfo.count();
-        emit watcherAddFiles(newSortInfo);
-    }
+    // 连接root处理信号
+    connect(rootWorker.data(), &RootInfoWorker::requestCloseTab, this, &RootInfo::requestCloseTab, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::requestClearRoot, this, &RootInfo::requestClearRoot, Qt::QueuedConnection);
 
-    if (hasHiddenFile) {
-        fmDebug() << "Emitting watcher update hide file signal for:" << hiddenFileUrl.toString();
-        Q_EMIT watcherUpdateHideFile(hiddenFileUrl);
-    }
+    connect(this, &RootInfo::resetData, rootWorker.data(), &RootInfoWorker::onResetData, Qt::QueuedConnection);
+    connect(this, &RootInfo::iteratorStatus, rootWorker.data(), &RootInfoWorker::onSetIteratorStatus, Qt::QueuedConnection);
+    connect(rootWorker.data(), &RootInfoWorker::watcherTimerStart, this, &RootInfo::onWatcherTimerStart, Qt::QueuedConnection);
+    connect(this, &RootInfo::watcherTimerEvent, rootWorker->watcherWorker().data(), &FileWatcherWorker::doWatcherEvent, Qt::QueuedConnection);
 }
 
-void RootInfo::addChildren(const QList<FileInfoPointer> &children)
+void RootInfo::clearAllThread()
 {
-    for (auto &child : children) {
-        addChild(child);
+    disconnect();
+    if (watcher)
+        watcher->stopWatcher();
+
+    for (const auto &thread : traversalThreads) {
+        thread->traversalThread->stop();
+        thread->traversalThread->wait();
     }
-}
-
-void RootInfo::addChildren(const QList<SortInfoPointer> &children)
-{
-    for (auto &file : children) {
-        if (!file)
-            continue;
-
-        QWriteLocker lk(&childrenLock);
-        childrenUrlList.append(file->fileUrl());
-        sourceDataList.append(file);
-    }
-}
-
-SortInfoPointer RootInfo::addChild(const FileInfoPointer &child)
-{
-    if (!child) {
-        fmDebug() << "Cannot add child: null file info";
-        return nullptr;
+    // wait old dir iterator thread
+    for (const auto &thread : discardedThread) {
+        thread->disconnect();
+        thread->stop();
+        thread->quit();
+        thread->wait();
     }
 
-    QUrl childUrl = child->urlOf(dfmbase::UrlInfoType::kUrl);
-    childUrl.setPath(childUrl.path());
+    if (rootWorker)
+        rootWorker->stop();
 
-    SortInfoPointer sort = sortFileInfo(child);
-    if (!sort) {
-        fmDebug() << "Failed to create sort info for child:" << childUrl.toString();
-        return nullptr;
-    }
-
-    {
-        QWriteLocker lk(&childrenLock);
-        if (childrenUrlList.contains(childUrl)) {
-            fmDebug() << "Replacing existing child:" << childUrl.toString();
-            sourceDataList.replace(childrenUrlList.indexOf(childUrl), sort);
-            return sort;
-        }
-        childrenUrlList.append(childUrl);
-        sourceDataList.append(sort);
-        fmDebug() << "Added new child:" << childUrl.toString() << "total children:" << childrenUrlList.size();
-    }
-
-    return sort;
-}
-
-SortInfoPointer RootInfo::sortFileInfo(const FileInfoPointer &info)
-{
-    if (!info) {
-        fmDebug() << "Cannot create sort info: null file info";
-        return nullptr;
-    }
-
-    SortInfoPointer sortInfo(new SortFileInfo);
-    sortInfo->setUrl(info->urlOf(UrlInfoType::kUrl));
-    sortInfo->setSize(info->size());
-    sortInfo->setFile(!info->isAttributes(OptInfoType::kIsDir));
-    sortInfo->setDir(info->isAttributes(OptInfoType::kIsDir));
-    sortInfo->setHide(info->isAttributes(OptInfoType::kIsHidden));
-    sortInfo->setSymlink(info->isAttributes(OptInfoType::kIsSymLink));
-    sortInfo->setReadable(info->isAttributes(OptInfoType::kIsReadable));
-    sortInfo->setWriteable(info->isAttributes(OptInfoType::kIsWritable));
-    sortInfo->setExecutable(info->isAttributes(OptInfoType::kIsExecutable));
-    sortInfo->setLastReadTime(info->timeOf(TimeInfoType::kLastRead).value<QDateTime>().toSecsSinceEpoch());
-    sortInfo->setLastModifiedTime(info->timeOf(TimeInfoType::kLastModified).value<QDateTime>().toSecsSinceEpoch());
-    sortInfo->setCreateTime(info->timeOf(TimeInfoType::kCreateTime).value<QDateTime>().toSecsSinceEpoch());
-    sortInfo->setInfoCompleted(true);
-
-    return sortInfo;
-}
-
-void RootInfo::removeChildren(const QList<QUrl> &urlList)
-{
-    QList<SortInfoPointer> removeChildren {};
-    int childIndex = -1;
-    QList<QUrl> removeUrls;
-    emit InfoCacheController::instance().removeCacheFileInfo(urlList);
-    for (QUrl url : urlList) {
-        WatcherCache::instance().removeCacheWatcherByParent(url);
-        emit requestCloseTab(url);
-        url.setPath(url.path());
-        auto child = fileInfo(url);
-        if (!child)
-            continue;
-
-        auto realUrl = child->urlOf(UrlInfoType::kUrl);
-        removeUrls.append(realUrl);
-        QWriteLocker lk(&childrenLock);
-        childIndex = childrenUrlList.indexOf(realUrl);
-        if (childIndex < 0 || childIndex >= childrenUrlList.length()) {
-            removeChildren.append(sortFileInfo(child));
-            continue;
-        }
-        childrenUrlList.removeAt(childIndex);
-        removeChildren.append(sourceDataList.takeAt(childIndex));
-    }
-
-    if (removeUrls.count() > 0)
-        emit InfoCacheController::instance().removeCacheFileInfo(removeUrls);
-
-    if (removeChildren.count() > 0)
-        emit watcherRemoveFiles(removeChildren);
-
-    if (removeUrls.contains(hiddenFileUrl))
-        Q_EMIT watcherUpdateHideFile(hiddenFileUrl);
-}
-
-bool RootInfo::containsChild(const QUrl &url)
-{
-    QReadLocker lk(&childrenLock);
-    return childrenUrlList.contains(url);
-}
-
-SortInfoPointer RootInfo::updateChild(const QUrl &url)
-{
-    SortInfoPointer sort { nullptr };
-
-    auto info = fileInfo(url);
-    if (info.isNull()) {
-        fmWarning() << "Failed to get file info for update:" << url.toString();
-        return nullptr;
-    }
-
-    auto realUrl = info->urlOf(UrlInfoType::kUrl);
-
-    sort = sortFileInfo(info);
-    if (sort.isNull()) {
-        fmWarning() << "Failed to create sort info for update:" << url.toString();
-        return nullptr;
-    }
-
-    {
-        QWriteLocker lk(&childrenLock);
-        int index = childrenUrlList.indexOf(realUrl);
-        if (index < 0) {
-            fmDebug() << "Child no longer in list for update:" << realUrl.toString();
-            return nullptr;
-        }
-        sourceDataList.replace(index, sort);
-    }
-    // NOTE: GlobalEventType::kHideFiles event is watched in fileview, but this can be used to notify update view
-    // when the file is modified in other way.
-    if (UniversalUtils::urlEquals(hiddenFileUrl, url)) {
-        fmDebug() << "Emitting watcher update hide file signal for:" << url.toString();
-        Q_EMIT watcherUpdateHideFile(url);
-    }
-
-    return sort;
-}
-
-void RootInfo::updateChildren(const QList<QUrl> &urls)
-{
-    QList<SortInfoPointer> updates;
-    for (auto url : urls) {
-        auto sort = updateChild(url);
-        if (sort)
-            updates.append(sort);
-    }
-    if (updates.isEmpty()) {
-        fmDebug() << "No valid updates generated";
-        return;
-    }
-    emit watcherUpdateFiles(updates);
-}
-
-bool RootInfo::checkFileEventQueue()
-{
-    QMutexLocker lk(&watcherEventMutex);
-    return !watcherEvent.isEmpty();
-}
-
-void RootInfo::enqueueEvent(const QPair<QUrl, EventType> &e)
-{
-    QMutexLocker lk(&watcherEventMutex);
-    watcherEvent.enqueue(e);
-}
-
-QPair<QUrl, RootInfo::EventType> RootInfo::dequeueEvent()
-{
-    QMutexLocker lk(&watcherEventMutex);
-    if (!watcherEvent.isEmpty())
-        return watcherEvent.dequeue();
-
-    return QPair<QUrl, RootInfo::EventType>();
-}
-
-// When monitoring the mtp directory, the monitor monitors that the scheme of the
-// url used for adding and deleting files is mtp (mtp://path).
-// Here, the monitor's url is used to re-complete the current url
-FileInfoPointer RootInfo::fileInfo(const QUrl &url)
-{
-    FileInfoPointer info = InfoFactory::create<FileInfo>(url, Global::CreateFileInfoType::kCreateFileInfoSync);
-    if (!info.isNull())
-        return info;
-
-    if (!watcher) {
-        fmDebug() << "No watcher available for fallback file info creation";
-        return nullptr;
-    }
-
-    const QUrl &parentUrl = QUrl::fromPercentEncoding(watcher->url().toString().toUtf8());
-    auto path = url.path();
-    if (path.isEmpty() || path == QDir::separator() || url.fileName().isEmpty()) {
-        fmDebug() << "Invalid path for fallback file info creation:" << path;
-        return info;
-    }
-
-    auto pathParent = path.endsWith(QDir::separator()) ? path.left(path.length() - 1) : path;
-    auto parentPath = parentUrl.path().endsWith(QDir::separator())
-            ? parentUrl.path().left(parentUrl.path().length() - 1)
-            : parentUrl.path();
-    pathParent = pathParent.left(pathParent.lastIndexOf(QDir::separator()));
-    if (!parentPath.endsWith(pathParent.mid(1))) {
-        fmDebug() << "Path mismatch for fallback file info creation";
-        return info;
-    }
-
-    auto currentUrl = parentUrl;
-    currentUrl.setPath(currentUrl.path(QUrl::PrettyDecoded) + QDir::separator() + url.fileName());
-    info = InfoFactory::create<FileInfo>(currentUrl);
-    return info;
+    rootThread.quit();
+    rootThread.wait();
 }

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -19,15 +19,149 @@
 namespace dfmplugin_workspace {
 
 class FileItemData;
+class RootInfoWorker;
+
+// 处理收到文件监视器信号后，监视事件再另外的线程处理
+// 收到一次信号后的200ms内的信号合并，操过200ms的下个200ms再处理
+class FileWatcherWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FileWatcherWorker(RootInfoWorker *root, QObject *parent = nullptr);
+    ~FileWatcherWorker();
+
+public Q_SLOTS:
+    // 子线程执行
+    void doFileDeleted(const QUrl &url);
+    void doFileMoved(const QUrl &fromUrl, const QUrl &toUrl);
+    void doFileCreated(const QUrl &fileUrl);
+    void doFileUpdated(const QUrl &fileUrl);
+
+    // 综合200ms内的文件监视消息合并发送，
+    void doWatcherEvent();
+    void doWatcherSubEvent();
+    void doCheckAndStartTimer();
+
+private:
+    // 判断是否是当前目录下的子文件,包含自己
+    bool isSubFile(const QUrl &fileUrl);
+
+private:
+    RootInfoWorker *rootptr { nullptr };
+    QSet<QUrl> adds, updates, removes;
+    bool delayTimeStart { false };
+};
+
+// 处理迭代器迭代的线程处理worker
+class FileIteratorWorker : public QObject
+{
+    Q_OBJECT
+    // 主线程执行
+public:
+    explicit FileIteratorWorker(RootInfoWorker *root, QObject *parent = nullptr);
+    ~FileIteratorWorker();
+
+    // 子线程执行
+public slots:
+    void handleTraversalResults(const QList<FileInfoPointer> &children, const QString &travseToken);
+    void handleTraversalResultsUpdate(const QList<SortInfoPointer> &children, const QString &travseToken, bool increment = false);
+    void handleTraversalLocalResult(QList<SortInfoPointer> children,
+                                    dfmio::DEnumerator::SortRoleCompareFlag sortRole,
+                                    Qt::SortOrder sortOrder,
+                                    bool isMixDirAndFile, const QString &travseToken);
+    void handleTraversalFinish(const QString &travseToken);
+
+    void handleTraversalSort(const QString &travseToken);
+
+private:
+    RootInfoWorker *rootptr { nullptr };
+};
+
+// 处理rootinfo业务的线程worker（包括两个业务，文件监视和文件迭代）
+class RootInfoWorker : public QObject {
+    Q_OBJECT
+    friend class FileIteratorWorker;
+    friend class FileWatcherWorker;
+public:
+    enum IteratorStatus {
+        kNone = 0, // 没有有开始
+        kRunning = 1, // 正在迭代
+        kFinished = 2, // 迭代完成
+    };
+
+    // 主线程执行
+public:
+    explicit RootInfoWorker(const QUrl &url, QObject *parent = nullptr);
+    ~RootInfoWorker();
+    void stop();
+    QSharedPointer<FileIteratorWorker> iteratorWorker() const;
+    QSharedPointer<FileWatcherWorker> watcherWorker() const;
+
+    // 子线程执行
+public:
+    void addChildren(const QSet<QUrl> &urlList);
+    void addChildren(const QList<SortInfoPointer> &children, const int start = 0);
+    SortInfoPointer addChild(const FileInfoPointer &child);
+    SortInfoPointer sortFileInfo(const FileInfoPointer &info);
+    void removeChildren(const QSet<QUrl> &urlList);
+    bool containsChild(const QUrl &url);
+    FileInfoPointer fileInfo(const QUrl &url);
+    SortInfoPointer updateChild(const QUrl &url);
+    void updateChildren(const QSet<QUrl> &urls);
+
+public slots:
+    void onResetData();
+    void onSetIteratorStatus(const IteratorStatus &status);
+
+Q_SIGNALS:
+    void iteratorLocalFiles(const QString &key,
+                            const QList<SortInfoPointer> children,
+                            const dfmio::DEnumerator::SortRoleCompareFlag sortRole,
+                            const Qt::SortOrder sortOrder,
+                            const bool isMixDirAndFile, const bool isFirst);
+    void iteratorUpdateFiles(const QString &key, const QList<SortInfoPointer> children, const bool isFirst);
+    void iteratorAddFile(const QString &key, const SortInfoPointer sortInfo, const FileInfoPointer info);
+    void iteratorAddFiles(const QString &key, const QList<SortInfoPointer> sortInfos, const QList<FileInfoPointer> infos);
+    void requestSort(const QString &key, const QUrl &dirUrl);
+    void traversalFinished(const QString &key);
+    void watcherAddFiles(const QList<SortInfoPointer> &children);
+    void watcherRemoveFiles(const QList<SortInfoPointer> &children);
+    void watcherUpdateFile(const SortInfoPointer sortInfo);
+    void watcherUpdateFiles(const QList<SortInfoPointer> &sortInfos);
+    void watcherUpdateHideFile(const QUrl &hidUrl);
+
+    void requestSortDir(const QUrl &dirUrl);
+    void requestTreeSortDir(const QString &key, const QUrl &parent);
+    void requestCloseTab(const QUrl &url);
+    void requestClearRoot(const QUrl &url);
+    void renameFileProcessStarted();
+
+    // 发送个rootinfo主线程处理计时器问题
+    void watcherTimerStart();
+
+private:
+    QUrl url;
+    QUrl hiddenFileUrl;
+    // origin data sort information
+    dfmio::DEnumerator::SortRoleCompareFlag originSortRole { dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault };
+    Qt::SortOrder originSortOrder { Qt::AscendingOrder };
+    bool originMixSort { false };
+    IteratorStatus itStatus { IteratorStatus::kNone }; // 当前迭代器的状态
+    // children
+    QList<QUrl> childrenUrlList {};
+    QList<SortInfoPointer> sourceDataList {};
+    //
+    QSharedPointer<FileIteratorWorker> it { nullptr };
+    QSharedPointer<FileWatcherWorker> watch { nullptr };
+    // search keywords
+    QStringList keyWords {};
+    std::atomic_bool stopped { false };
+};
+
+
 class RootInfo : public QObject
 {
     Q_OBJECT
-
-    enum EventType {
-        kAddFile,
-        kUpdateFile,
-        kRmFile
-    };
 
 public:
     struct DirIteratorThread
@@ -45,14 +179,13 @@ public:
 
     void initThreadOfFileData(const QString &key,
                               DFMGLOBAL_NAMESPACE::ItemRoles role, Qt::SortOrder order, bool isMixFileAndFolder);
-    void startWork(const QString &key);
+    void startIteratorWork(const QString &key);
     int clearTraversalThread(const QString &key, const bool isRefresh);
-    void setFirstBatch(bool first);
 
+    void setFirstBatch(bool first);
     void reset();
 
-    void addConnectToken(const QString &token)
-    {
+    void addConnectToken(const QString &token) {
         if (connectedTokens.contains(token))
             return;
         connectedTokens << token;
@@ -60,18 +193,19 @@ public:
     QStringList connectTokens() const { return connectedTokens; }
 
     bool canDelete() const;
-
     bool checkKeyOnly(const QString &key) const;
+    QStringList getKeyWords() const;
 
 Q_SIGNALS:
+    void itemAdded();
     void iteratorLocalFiles(const QString &key,
                             const QList<SortInfoPointer> children,
                             const dfmio::DEnumerator::SortRoleCompareFlag sortRole,
                             const Qt::SortOrder sortOrder,
-                            const bool isMixDirAndFile,
-                            bool isFirstBatch = false);
+                            const bool isMixDirAndFile, bool isFirstBatch = false);
+    void iteratorUpdateFiles(const QString &key, const QList<SortInfoPointer> children, bool isFirstBatch = false);
+    void iteratorAddFile(const QString &key, const SortInfoPointer sortInfo, const FileInfoPointer info);
     void iteratorAddFiles(const QString &key, const QList<SortInfoPointer> sortInfos, const QList<FileInfoPointer> infos, bool isFirstBatch = false);
-    void iteratorUpdateFiles(const QString &key, const QList<SortInfoPointer> sortInfos, bool isFirstBatch = false);
     void watcherAddFiles(const QList<SortInfoPointer> &children);
     void watcherRemoveFiles(const QList<SortInfoPointer> &children);
     void traversalFinished(const QString &key, bool noDataProduced = false);
@@ -85,68 +219,32 @@ Q_SIGNALS:
     void renameFileProcessStarted();
     void requestClearRoot(const QUrl &url);
 
+    //发送给worker线程
+    void resetData();
+    void iteratorStatus(const RootInfoWorker::IteratorStatus status);
+    void watcherTimerEvent();
+
 public Q_SLOTS:
-    void doFileDeleted(const QUrl &url);
-    void dofileMoved(const QUrl &fromUrl, const QUrl &toUrl);
-    void dofileCreated(const QUrl &url);
-    void doFileUpdated(const QUrl &url);
-    void doWatcherEvent();
-    void doThreadWatcherEvent();
-
-    void handleTraversalResults(const QList<FileInfoPointer> children, const QString &travseToken);
-    void handleTraversalResultsUpdate(const QList<SortInfoPointer> children, const QString &travseToken, bool increment = false);
-    void handleTraversalLocalResult(QList<SortInfoPointer> children,
-                                    dfmio::DEnumerator::SortRoleCompareFlag sortRole,
-                                    Qt::SortOrder sortOrder,
-                                    bool isMixDirAndFile, const QString &travseToken);
     void handleTraversalFinish(const QString &travseToken);
-
-    void handleTraversalSort(const QString &travseToken);
+    void onWatcherTimerStart();
 
     void startWatcher();
 
 private:
-    void initConnection(const TraversalThreadManagerPointer &traversalThread);
-
-    void addChildren(const QList<QUrl> &urlList);
-    void addChildren(const QList<FileInfoPointer> &children);
-    void addChildren(const QList<SortInfoPointer> &children);
-    SortInfoPointer addChild(const FileInfoPointer &child);
-    SortInfoPointer sortFileInfo(const FileInfoPointer &info);
-    void removeChildren(const QList<QUrl> &urlList);
-    bool containsChild(const QUrl &url);
-    SortInfoPointer updateChild(const QUrl &url);
-    void updateChildren(const QList<QUrl> &urls);
-
-    bool checkFileEventQueue();
-    void enqueueEvent(const QPair<QUrl, EventType> &e);
-    QPair<QUrl, EventType> dequeueEvent();
-    FileInfoPointer fileInfo(const QUrl &url);
+    void initIteratorConnection(const TraversalThreadManagerPointer &traversalThread);
+    void initConnection();
+    void clearAllThread();
 
 public:
     AbstractFileWatcherPointer watcher;
 
 private:
     QUrl url;
-    QUrl hiddenFileUrl;
 
     QMap<QString, QSharedPointer<DirIteratorThread>> traversalThreads;
+    std::atomic_bool traversalFinish { false };
+    std::atomic_bool traversaling { false };
     std::atomic_bool isFirstBatch { false };
-
-    QReadWriteLock childrenLock;
-    QList<QUrl> childrenUrlList {};
-    QList<SortInfoPointer> sourceDataList {};
-    // origin data sort information
-    dfmio::DEnumerator::SortRoleCompareFlag originSortRole { dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault };
-    Qt::SortOrder originSortOrder { Qt::AscendingOrder };
-    bool originMixSort { false };
-
-    std::atomic_bool cancelWatcherEvent { false };
-    QList<QFuture<void>> watcherEventFutures;
-
-    QQueue<QPair<QUrl, EventType>> watcherEvent {};
-    QMutex watcherEventMutex;
-    std::atomic_bool processFileEventRuning { false };
 
     QList<TraversalThreadPointer> discardedThread {};
     QList<QSharedPointer<QThread>> threads {};
@@ -154,8 +252,13 @@ private:
     std::atomic_bool isRefresh { false };
     QStringList connectedTokens;
 
-    std::atomic_bool isDying { false };
+    QStringList keyWords {};
+
+    QSharedPointer<RootInfoWorker> rootWorker { nullptr };
+    QThread rootThread;
 };
 }
+
+Q_DECLARE_METATYPE(dfmplugin_workspace::RootInfoWorker::IteratorStatus);
 
 #endif   // ROOTINFO_H

--- a/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/rootinfo.h
@@ -15,14 +15,36 @@
 #include <QReadWriteLock>
 #include <QQueue>
 #include <QFuture>
+#include <QPointer>
 
 namespace dfmplugin_workspace {
 
 class FileItemData;
 class RootInfoWorker;
 
-// 处理收到文件监视器信号后，监视事件再另外的线程处理
-// 收到一次信号后的200ms内的信号合并，操过200ms的下个200ms再处理
+// 架构说明:
+// 本文件包含四个核心类，构成 RootInfo 的遍历-监视体系：
+//   - RootInfo          主线程持有，面向 UI 层提供信号接口
+//   - RootInfoWorker    运行于 rootThread，持有 childrenUrlList 与 sourceDataList
+//   - FileWatcherWorker 运行于 rootThread，处理文件监视器事件
+//   - FileIteratorWorker运行于 rootThread，处理目录遍历结果
+//
+// 线程亲和性:
+//   RootInfo 始终在主线程；RootInfoWorker、FileWatcherWorker、FileIteratorWorker
+//   均通过 moveToThread 移至 RootInfo 内部的 rootThread。
+//
+// 数据所有权:
+//   childrenUrlList 与 sourceDataList 驻留于 RootInfoWorker（rootThread），
+//   仅在 worker 线程中读写，主线程通过 QueuedConnection 信号访问。
+//
+// 通信方式:
+//   主线程 → worker: 通过 Qt::QueuedConnection 信号投递
+//   worker → 主线程: 通过 Qt::QueuedConnection 信号投递
+//
+// stopped 标志:
+//   std::atomic_bool，用于在析构/重置时一次性关闭所有 worker 操作，
+//   各 worker 在每个入口处检查该标志以快速退出。
+
 class FileWatcherWorker : public QObject
 {
     Q_OBJECT
@@ -31,37 +53,31 @@ public:
     ~FileWatcherWorker();
 
 public Q_SLOTS:
-    // 子线程执行
     void doFileDeleted(const QUrl &url);
     void doFileMoved(const QUrl &fromUrl, const QUrl &toUrl);
     void doFileCreated(const QUrl &fileUrl);
     void doFileUpdated(const QUrl &fileUrl);
 
-    // 综合200ms内的文件监视消息合并发送，
     void doWatcherEvent();
     void doWatcherSubEvent();
     void doCheckAndStartTimer();
 
 private:
-    // 判断是否是当前目录下的子文件,包含自己
     bool isSubFile(const QUrl &fileUrl);
 
 private:
-    RootInfoWorker *rootptr { nullptr };
+    QPointer<RootInfoWorker> rootptr { nullptr };
     QSet<QUrl> adds, updates, removes;
     bool delayTimeStart { false };
 };
 
-// 处理迭代器迭代的线程处理worker
 class FileIteratorWorker : public QObject
 {
     Q_OBJECT
-    // 主线程执行
 public:
     explicit FileIteratorWorker(RootInfoWorker *root, QObject *parent = nullptr);
     ~FileIteratorWorker();
 
-    // 子线程执行
 public slots:
     void handleTraversalResults(const QList<FileInfoPointer> &children, const QString &travseToken);
     void handleTraversalResultsUpdate(const QList<SortInfoPointer> &children, const QString &travseToken, bool increment = false);
@@ -74,39 +90,31 @@ public slots:
     void handleTraversalSort(const QString &travseToken);
 
 private:
-    RootInfoWorker *rootptr { nullptr };
+    QPointer<RootInfoWorker> rootptr { nullptr };
 };
 
-// 处理rootinfo业务的线程worker（包括两个业务，文件监视和文件迭代）
 class RootInfoWorker : public QObject {
     Q_OBJECT
     friend class FileIteratorWorker;
     friend class FileWatcherWorker;
+    friend class RootInfo;
 public:
     enum IteratorStatus {
-        kNone = 0, // 没有有开始
-        kRunning = 1, // 正在迭代
-        kFinished = 2, // 迭代完成
+        kNone = 0,
+        kRunning = 1,
+        kFinished = 2,
     };
 
-    // 主线程执行
 public:
     explicit RootInfoWorker(const QUrl &url, QObject *parent = nullptr);
     ~RootInfoWorker();
     void stop();
-    QSharedPointer<FileIteratorWorker> iteratorWorker() const;
-    QSharedPointer<FileWatcherWorker> watcherWorker() const;
 
-    // 子线程执行
 public:
     void addChildren(const QSet<QUrl> &urlList);
-    void addChildren(const QList<SortInfoPointer> &children, const int start = 0);
-    SortInfoPointer addChild(const FileInfoPointer &child);
-    SortInfoPointer sortFileInfo(const FileInfoPointer &info);
+    void replaceChildren(const QList<SortInfoPointer> &children);
     void removeChildren(const QSet<QUrl> &urlList);
-    bool containsChild(const QUrl &url);
     FileInfoPointer fileInfo(const QUrl &url);
-    SortInfoPointer updateChild(const QUrl &url);
     void updateChildren(const QSet<QUrl> &urls);
 
 public slots:
@@ -120,7 +128,6 @@ Q_SIGNALS:
                             const Qt::SortOrder sortOrder,
                             const bool isMixDirAndFile, const bool isFirst);
     void iteratorUpdateFiles(const QString &key, const QList<SortInfoPointer> children, const bool isFirst);
-    void iteratorAddFile(const QString &key, const SortInfoPointer sortInfo, const FileInfoPointer info);
     void iteratorAddFiles(const QString &key, const QList<SortInfoPointer> sortInfos, const QList<FileInfoPointer> infos);
     void requestSort(const QString &key, const QUrl &dirUrl);
     void traversalFinished(const QString &key);
@@ -130,31 +137,28 @@ Q_SIGNALS:
     void watcherUpdateFiles(const QList<SortInfoPointer> &sortInfos);
     void watcherUpdateHideFile(const QUrl &hidUrl);
 
-    void requestSortDir(const QUrl &dirUrl);
-    void requestTreeSortDir(const QString &key, const QUrl &parent);
     void requestCloseTab(const QUrl &url);
     void requestClearRoot(const QUrl &url);
     void renameFileProcessStarted();
 
-    // 发送个rootinfo主线程处理计时器问题
-    void watcherTimerStart();
+private:
+    QSharedPointer<FileIteratorWorker> iteratorWorker() const;
+    QSharedPointer<FileWatcherWorker> watcherWorker() const;
+    SortInfoPointer addChild(const FileInfoPointer &child);
+    SortInfoPointer sortFileInfo(const FileInfoPointer &info);
+    SortInfoPointer updateChild(const QUrl &url);
 
 private:
     QUrl url;
     QUrl hiddenFileUrl;
-    // origin data sort information
     dfmio::DEnumerator::SortRoleCompareFlag originSortRole { dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault };
     Qt::SortOrder originSortOrder { Qt::AscendingOrder };
     bool originMixSort { false };
-    IteratorStatus itStatus { IteratorStatus::kNone }; // 当前迭代器的状态
-    // children
+    IteratorStatus itStatus { IteratorStatus::kNone };
     QList<QUrl> childrenUrlList {};
     QList<SortInfoPointer> sourceDataList {};
-    //
     QSharedPointer<FileIteratorWorker> it { nullptr };
     QSharedPointer<FileWatcherWorker> watch { nullptr };
-    // search keywords
-    QStringList keyWords {};
     std::atomic_bool stopped { false };
 };
 
@@ -167,10 +171,6 @@ public:
     struct DirIteratorThread
     {
         TraversalThreadManagerPointer traversalThread { nullptr };
-        // origin data sort information
-        dfmio::DEnumerator::SortRoleCompareFlag originSortRole { dfmio::DEnumerator::SortRoleCompareFlag::kSortRoleCompareDefault };
-        Qt::SortOrder originSortOrder { Qt::AscendingOrder };
-        bool originMixSort { false };
     };
 
 public:
@@ -185,26 +185,20 @@ public:
     void setFirstBatch(bool first);
     void reset();
 
-    void addConnectToken(const QString &token) {
-        if (connectedTokens.contains(token))
-            return;
-        connectedTokens << token;
-    }
-    QStringList connectTokens() const { return connectedTokens; }
+    void addConnectToken(const QString &token);
+    QStringList connectTokens() const;
 
     bool canDelete() const;
     bool checkKeyOnly(const QString &key) const;
     QStringList getKeyWords() const;
 
 Q_SIGNALS:
-    void itemAdded();
     void iteratorLocalFiles(const QString &key,
                             const QList<SortInfoPointer> children,
                             const dfmio::DEnumerator::SortRoleCompareFlag sortRole,
                             const Qt::SortOrder sortOrder,
                             const bool isMixDirAndFile, bool isFirstBatch = false);
     void iteratorUpdateFiles(const QString &key, const QList<SortInfoPointer> children, bool isFirstBatch = false);
-    void iteratorAddFile(const QString &key, const SortInfoPointer sortInfo, const FileInfoPointer info);
     void iteratorAddFiles(const QString &key, const QList<SortInfoPointer> sortInfos, const QList<FileInfoPointer> infos, bool isFirstBatch = false);
     void watcherAddFiles(const QList<SortInfoPointer> &children);
     void watcherRemoveFiles(const QList<SortInfoPointer> &children);
@@ -215,18 +209,14 @@ Q_SIGNALS:
     void requestSort(const QString &key, const QUrl &dirUrl);
     void requestCloseTab(const QUrl &url);
 
-    void requestTreeSortDir(const QString &key, const QUrl &parent);
     void renameFileProcessStarted();
     void requestClearRoot(const QUrl &url);
 
-    //发送给worker线程
     void resetData();
     void iteratorStatus(const RootInfoWorker::IteratorStatus status);
-    void watcherTimerEvent();
 
 public Q_SLOTS:
     void handleTraversalFinish(const QString &travseToken);
-    void onWatcherTimerStart();
 
     void startWatcher();
 
@@ -242,8 +232,6 @@ private:
     QUrl url;
 
     QMap<QString, QSharedPointer<DirIteratorThread>> traversalThreads;
-    std::atomic_bool traversalFinish { false };
-    std::atomic_bool traversaling { false };
     std::atomic_bool isFirstBatch { false };
 
     QList<TraversalThreadPointer> discardedThread {};

--- a/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/utils/filedatamanager.cpp
@@ -61,7 +61,7 @@ bool FileDataManager::fetchFiles(const QUrl &rootUrl, const QString &key, DFMGLO
     }
 
     root->initThreadOfFileData(key, role, order, isMixFileAndFolder);
-    root->startWork(key);
+    root->startIteratorWork(key);
     fmInfo() << "File fetch started successfully for URL:" << normalizedRootUrl.toString();
     return true;
 }


### PR DESCRIPTION
fix(workspace): refactor RootInfo to eliminate watcher event race condition

Refactor the monolithic RootInfo into a four-class architecture
(RootInfo → RootInfoWorker → FileIteratorWorker + FileWatcherWorker),
moving all shared data to a dedicated worker thread and replacing the
racy cancelWatcherEvent/processFileEventRuning flags with a single
atomic `stopped` flag.

Root cause: doWatcherEvent() early-return paths did not reset
processFileEventRuning, causing the flag to be permanently stuck true
when reset() was called mid-event. The watcher then silently dropped
all future events, making the view stop refreshing until manual reload.

The refactored design eliminates the race at the architecture level:
- All data (childrenUrlList, sourceDataList) lives in RootInfoWorker
  on rootThread, accessed only from that thread
- FileWatcherWorker and FileIteratorWorker operate on rootThread
- `stopped` atomic flag cleanly gates all worker operations
- No flag-based "cancel" mechanism that can get stuck

Retains master's performance optimizations (increment parameter,
complete time attributes) and multi-view support (rootUsers).

Add comprehensive unit tests (test_rootinfo.cpp) covering:
- Construction, destruction, initThreadOfFileData, startIteratorWork
- Traversal completion with noDataProduced flag semantics
- Real filesystem watcher events (create/delete/rename)
- reset() and re-traversal watcher recovery (bug regression test)
- canDelete(), checkKeyOnly(), clearTraversalThread()
- Cache path (handleGetSourceData → sourceDatas signal)

Tests use real temporary directories following the
InotifyFileSystemWatcher/VfsMonitorFileSystemWatcher test pattern.

## Summary by Sourcery

Refactor workspace root traversal and file watching to make event processing thread-safe and resilient across resets.

Bug Fixes:
- Eliminate the workspace watcher race condition that could permanently stop view refreshes after a reset or overlapping file events.
- Restore reliable watcher behavior across reset, re-traversal, and RootInfo recreation scenarios.

Enhancements:
- Refactor RootInfo into dedicated root, iterator, and watcher workers with thread-confined shared data and unified stop-state handling.
- Preserve traversal sorting, incremental updates, complete file timestamps, multi-view support, cache handling, and watcher responses for file and directory changes.

Tests:
- Add comprehensive filesystem-backed unit coverage for traversal lifecycle, watcher events, reset recovery, deletion behavior, cache results, and related RootInfo APIs.