### PR TITLE
feat: migrate TimezoneWatcher from v20 to v25 (release/snipe)

### DIFF
--- a/src/apps/dde-file-dialog-wayland/main.cpp
+++ b/src/apps/dde-file-dialog-wayland/main.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/signalhandler.h>
+#include <dfm-base/utils/timezonewatcher.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -66,6 +67,9 @@ static void initEnv()
     if (qEnvironmentVariable("CLUTTER_IM_MODULE") == QStringLiteral("fcitx")) {
         setenv("QT_IM_MODULE", "fcitx", 1);
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static bool singlePluginLoad(const QString &pluginName, const QString &libName)

--- a/src/apps/dde-file-dialog-x11/main.cpp
+++ b/src/apps/dde-file-dialog-x11/main.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/signalhandler.h>
+#include <dfm-base/utils/timezonewatcher.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -63,6 +64,9 @@ static void initEnv()
     if (qEnvironmentVariable("CLUTTER_IM_MODULE") == QStringLiteral("fcitx")) {
         setenv("QT_IM_MODULE", "fcitx", 1);
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static bool singlePluginLoad(const QString &pluginName, const QString &libName)

--- a/src/apps/dde-file-dialog/main.cpp
+++ b/src/apps/dde-file-dialog/main.cpp
@@ -13,6 +13,7 @@
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/signalhandler.h>
+#include <dfm-base/utils/timezonewatcher.h>
 
 #include <dfm-framework/dpf.h>
 
@@ -63,6 +64,9 @@ static void initEnv()
     if (qEnvironmentVariable("CLUTTER_IM_MODULE") == QStringLiteral("fcitx")) {
         setenv("QT_IM_MODULE", "fcitx", 1);
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static bool singlePluginLoad(const QString &pluginName, const QString &libName)

--- a/src/apps/dde-file-manager/main.cpp
+++ b/src/apps/dde-file-manager/main.cpp
@@ -14,6 +14,7 @@
 #include <dfm-base/utils/loggerrules.h>
 #include <dfm-base/utils/windowutils.h>
 #include <dfm-base/utils/signalhandler.h>
+#include <dfm-base/utils/timezonewatcher.h>
 #include <dfm-base/base/configs/dconfig/dconfigmanager.h>
 
 #include <dfm-framework/dpf.h>
@@ -255,6 +256,9 @@ static void initEnv()
         }
         setEnvForRoot();
     }
+
+    // 启动时区监视器和时区环境变量设置
+    dfmbase::TimezoneWatcher::instance().init();
 }
 
 static void initLogFilter()

--- a/src/dfm-base/utils/timezonewatcher.cpp
+++ b/src/dfm-base/utils/timezonewatcher.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "timezonewatcher.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QDBusConnection>
+
+#include <ctime>
+
+namespace dfmbase {
+
+TimezoneWatcher::TimezoneWatcher(QObject *parent)
+    : QObject(parent),
+      m_initialized(false)
+{
+}
+
+TimezoneWatcher &TimezoneWatcher::instance()
+{
+    static TimezoneWatcher w;
+    return w;
+}
+
+void TimezoneWatcher::init()
+{
+    if (m_initialized)
+        return;
+
+    // 1. Initialize timezone
+    readAndSetTimezone();
+
+    // 2. Connect D-Bus signals
+    connectDbusSignals();
+
+    m_initialized = true;
+
+    qCInfo(logDFMBase) << "TimezoneWatcher initialized, timezone:" << m_currentTimezone;
+}
+
+QString TimezoneWatcher::currentTimezone() const
+{
+    return m_currentTimezone;
+}
+
+bool TimezoneWatcher::isInitialized() const
+{
+    return m_initialized;
+}
+
+void TimezoneWatcher::readAndSetTimezone()
+{
+    QString tz;
+
+    // 1. Try /etc/timezone first
+    tz = readTimezoneFromEtcTimezone();
+
+    // 2. Fallback: /etc/localtime symlink
+    if (tz.isEmpty()) {
+        tz = readTimezoneFromLocaltime();
+    }
+
+    // 3. Final fallback to UTC
+    if (tz.isEmpty())
+        tz = QStringLiteral("UTC");
+
+    // 4. Update if changed
+    if (tz != m_currentTimezone) {
+        m_currentTimezone = tz;
+        qputenv("TZ", tz.toUtf8());
+        tzset();  // Apply immediately
+        emit timezoneChanged(tz);
+        qCInfo(logDFMBase) << "Timezone updated to:" << tz;
+    }
+}
+
+QString TimezoneWatcher::readTimezoneFromEtcTimezone()
+{
+    QFile tzFile(QStringLiteral("/etc/timezone"));
+    if (tzFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QString tz = QString::fromUtf8(tzFile.readAll()).trimmed();
+        if (!tz.isEmpty())
+            return tz;
+    }
+    return QString();
+}
+
+QString TimezoneWatcher::readTimezoneFromLocaltime()
+{
+    QFileInfo info(QStringLiteral("/etc/localtime"));
+    if (info.isSymLink()) {
+        QString path = info.symLinkTarget();
+        int pos = path.lastIndexOf(QStringLiteral("/zoneinfo/"));
+        if (pos >= 0)
+            return path.mid(pos + 10);
+    }
+    return QString();
+}
+
+void TimezoneWatcher::connectDbusSignals()
+{
+    // 订阅 org.freedesktop.timedate1 的 PropertiesChanged 信号。
+    //
+    // 这里不传 service（首参留空），原因是：若传入 well-known name
+    // "org.freedesktop.timedate1"，Qt 内部会同步调用 GetNameOwner 解析为
+    // unique name 再下发 AddMatch；当该服务未注册时该调用会阻塞直至
+    // D-Bus 默认超时（约 25s），导致文件管理器启动卡顿 25 秒。
+    //
+    // 留空 service 生成的 match rule 不含 sender 过滤、且不做 GetNameOwner，
+    // 因而是非阻塞的；再通过 pin 住 object path "/org/freedesktop/timedate1"
+    // 与 interface "org.freedesktop.DBus.Properties" + member "PropertiesChanged"
+    // 将匹配范围收敛到该对象路径——而该路径仅由 timedate1 持有，故只有
+    // timedate1 发出的 PropertiesChanged 才会投递到本 slot。
+    //
+    // 这同时解决了两个问题：
+    //   1) 不再因服务未就绪而阻塞启动（无 25s 卡顿）；
+    //   2) 不再因 checkDbusService 守卫而静默放弃订阅——服务随时上线后，
+    //      其发出的 PropertiesChanged 仍会被投递。
+    //
+    // 注意：slot 内仍按 interface == "org.freedesktop.timedate1" 二次过滤。
+    QDBusConnection::systemBus().connect(
+                QString(),   // empty service: non-blocking, no GetNameOwner
+                QStringLiteral("/org/freedesktop/timedate1"),
+                QStringLiteral("org.freedesktop.DBus.Properties"),
+                QStringLiteral("PropertiesChanged"),
+                this,
+                SLOT(onPropertiesChanged(QString,QVariantMap,QStringList)));
+}
+
+void TimezoneWatcher::onPropertiesChanged(const QString &interface,
+                                      const QVariantMap &changed,
+                                      const QStringList &invalidated)
+{
+    // Only handle org.freedesktop.timedate1 interface
+    if (interface == QStringLiteral("org.freedesktop.timedate1")) {
+        // PropertiesChanged 的 changed 是已重新获取的属性，invalidated 是已失效
+        // 需重新读取的属性。Timezone 可能出现在任一列表中，两者都需处理。
+        if (changed.contains(QStringLiteral("Timezone"))
+                || invalidated.contains(QStringLiteral("Timezone"))) {
+            qCInfo(logDFMBase) << "Timezone D-Bus properties changed, re-reading timezone";
+            readAndSetTimezone();
+        }
+    }
+}
+
+}   // namespace dfmbase

--- a/src/dfm-base/utils/timezonewatcher.h
+++ b/src/dfm-base/utils/timezonewatcher.h
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TIMEZONEWATCHER_H
+#define TIMEZONEWATCHER_H
+
+#include <dfm-base/dfm_base_global.h>
+
+#include <QObject>
+#include <QString>
+#include <QVariantMap>
+#include <QStringList>
+
+namespace dfmbase {
+
+/*!
+ * \class TimezoneWatcher
+ * \brief 时区监视器，用于监听系统时区变化并自动更新 TZ 环境变量
+ *
+ * 解决 Qt QDateTime::currentDateTime() 每次调用都会 stat("/etc/localtime") 的问题
+ *
+ * 使用方法:
+ *   TimezoneWatcher::instance().init();
+ *
+ * 监视机制:
+ *   - D-Bus: org.freedesktop.timedate1 PropertiesChanged 信号（服务启动后自动生效）
+ *   - 文件系统 fallback: /etc/timezone 和 /etc/localtime
+ *   - 最终 fallback: UTC
+ */
+class TimezoneWatcher : public QObject
+{
+    Q_OBJECT
+
+public:
+    /*! 获取单例实例
+     * \return TimezoneWatcher 实例引用
+     */
+    static TimezoneWatcher &instance();
+
+    /*! 初始化时区信息
+     * 在应用程序启动时调用，设置 TZ 环境变量并启动监视
+     */
+    void init();
+
+    /*! 获取当前时区
+     * \return 当前时区字符串，如 "Asia/Shanghai"
+     */
+    QString currentTimezone() const;
+
+    /*! 是否已初始化
+     * \return true 表示已成功初始化
+     */
+    bool isInitialized() const;
+
+Q_SIGNALS:
+    /*! 时区变化信号
+     * \param timezone 新的时区字符串
+     */
+    void timezoneChanged(const QString &timezone);
+
+private Q_SLOTS:
+    /*! 处理 D-Bus PropertiesChanged 信号
+     * \param interface D-Bus 接口名
+     * \param changed 变化的属性
+     * \param invalidated 无效的属性列表
+     */
+    void onPropertiesChanged(const QString &interface,
+                          const QVariantMap &changed,
+                          const QStringList &invalidated);
+
+private:
+    explicit TimezoneWatcher(QObject *parent = nullptr);
+    ~TimezoneWatcher() override = default;
+
+    /*! 读取时区信息并设置 TZ 环境变量
+     * 优先从 /etc/timezone 读取，回退到 /etc/localtime 符号链接，最终 fallback 到 UTC
+     */
+    void readAndSetTimezone();
+
+    /*! 读取 /etc/timezone 文件
+     * \return 时区字符串，失败返回空
+     */
+    QString readTimezoneFromEtcTimezone();
+
+    /*! 从 /etc/localtime 符号链接读取时区
+     * \return 时区字符串，失败返回空
+     */
+    QString readTimezoneFromLocaltime();
+
+    /*! 连接到 D-Bus 信号
+     */
+    void connectDbusSignals();
+
+private:
+    QString m_currentTimezone;
+    bool m_initialized;
+};
+
+}   // namespace dfmbase
+
+#endif   // TIMEZONEWATCHER_H


### PR DESCRIPTION
## Cherry-pick: feat: migrate TimezoneWatcher from v20 to v25

将 PR #4215 的 commit `d0daa4a5` cherry-pick 到 `release/snipe` 分支。

### 改动文件

| 文件 | 类型 | 变更 |
|------|------|------|
| `src/dfm-base/utils/timezonewatcher.h` | 新增 | +102 |
| `src/dfm-base/utils/timezonewatcher.cpp` | 新增 | +148 |
| `src/apps/dde-file-manager/main.cpp` | 修改 | +4 |
| `src/apps/dde-file-dialog/main.cpp` | 修改 | +4 |
| `src/apps/dde-file-dialog-wayland/main.cpp` | 修改 | +4 |
| `src/apps/dde-file-dialog-x11/main.cpp` | 修改 | +4 |

### 验证

- Cherry-pick 无冲突，干净应用
- 与原始 PR 的 6 个文件 diff 为空（内容完全一致）
- `logDFMBase` 已在 `include/dfm-base/dfm_base_global.h` 声明
- `dfm-base` 的 CMake 使用 `file(GLOB_RECURSE SRCS)` 自动收集源文件，无需改 CMakeLists.txt

## Summary by Sourcery

Add automatic system timezone monitoring and synchronization across file manager applications.

New Features:
- Add a singleton timezone watcher that initializes the system timezone and updates the TZ environment variable when timedate1 reports changes.

Bug Fixes:
- Prevent application startup delays when the timedate1 D-Bus service is unavailable while retaining support for updates when it becomes available.

Enhancements:
- Initialize timezone monitoring consistently in the file manager and all file dialog variants.