### PR TITLE
perf: 网络检查优化迁移 — NetworkUtils TTL 缓存 (release/snipe)

### DIFF
--- a/src/dfm-base/base/device/deviceproxymanager.cpp
+++ b/src/dfm-base/base/device/deviceproxymanager.cpp
@@ -6,6 +6,7 @@
 #include "devicemanager.h"
 #include "deviceutils.h"
 #include "private/deviceproxymanager_p.h"
+#include <dfm-base/utils/networkutils.h>
 
 #include <QDBusServiceWatcher>
 #include <QCoreApplication>
@@ -515,6 +516,9 @@ void DeviceProxyManagerPrivate::addMounts(const QString &id, const QString &mpt)
 
 void DeviceProxyManagerPrivate::removeMounts(const QString &id, const QString &mpt)
 {
+    // 网络连接缓存可能与挂载点状态相关，挂载点移除时清除缓存
+    NetworkUtils::instance()->clearCache();
+
     // NOTE: signals are emitted outside the write lock to avoid deadlock.
     if (!mpt.isEmpty()) {
         // A specific mount point was unmounted: remove only that one.

--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -31,11 +31,19 @@ NetworkUtils *NetworkUtils::instance()
     return &s;
 }
 
-bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, int msecs)
+bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, int msecs, const bool useCache)
 {
     if (host.isEmpty())
         return true;
 
+    if (useCache) {
+        // TTL 缓存命中 → 直接返回
+        auto cached = getFromCache(host, port);
+        if (cached.timestamp.isValid())
+            return !cached.busy;
+    }
+
+    qCInfo(logDFMBase) << "NetworkUtils::checkNetConnection net work check host = " << host << ", port = " << port << " !!!";
     QTcpSocket conn;
     conn.connectToHost(host, port.toUShort());
     bool connected = conn.waitForConnected(msecs);
@@ -44,15 +52,19 @@ bool NetworkUtils::checkNetConnection(const QString &host, const QString &port, 
     // 在QTcpSocket使用代理不能访问目标host的情况下，将QTcpSocket设置为不使用代理再次连接host，检查能否访问目标host
     if (!connected) {
         // 检查系统代理设置
+        // 注意：与 v20 不同，v25 仅在确实配置了代理（type != NoProxy）时才重试 NoProxy 连接；
+        // v20 无论是否有代理都会重置为 NoProxy 重连一次。此处保留 v25 既有语义。
         QNetworkProxy proxy = QNetworkProxy::applicationProxy();
-        if (proxy.type() == QNetworkProxy::NoProxy)
-            return connected;
-
-        conn.setProxy(QNetworkProxy::NoProxy);
-        conn.connectToHost(host, port.toUShort());
-        connected = conn.waitForConnected(msecs);
-        conn.close();
+        if (proxy.type() != QNetworkProxy::NoProxy) {
+            conn.setProxy(QNetworkProxy::NoProxy);
+            conn.connectToHost(host, port.toUShort());
+            connected = conn.waitForConnected(msecs);
+            conn.close();
+        }
     }
+
+    // 缓存结果（busy = !connected）
+    updateCache(host, port, !connected);
     return connected;
 }
 
@@ -91,7 +103,7 @@ void NetworkUtils::doAfterCheckNet(const QString &host, const QStringList &ports
 
         for (const auto &port : ports) {
             qApp->processEvents();
-            if (NetworkUtils::instance()->checkNetConnection(host, port, msecs))
+            if (NetworkUtils::instance()->checkNetConnection(host, port, msecs, false))
                 return true;
         }
         return false;
@@ -188,6 +200,23 @@ bool NetworkUtils::checkFtpOrSmbBusy(const QUrl &url)
     QStringList ports;
     if (!parseIp(url.path(), host, ports))
         return false;
+
+    // 先查缓存，所有端口都 hit 且 busy=false 才算可用
+    bool allCached { true };
+    bool anyBusy { false };
+    for (const auto &port : ports) {
+        auto cached = getFromCache(host, port);
+        if (!cached.timestamp.isValid()) {
+            allCached = false;
+            break;
+        }
+        if (cached.busy) {
+            anyBusy = true;
+            break;
+        }
+    }
+    if (allCached)
+        return anyBusy;
 
     auto busy = !checkNetConnection(host, ports);
     if (busy)
@@ -303,6 +332,41 @@ QUrl NetworkUtils::resolveLocalSftpMountUrl(const QUrl &url)
                           " resolved symlink target to local path:"
                        << localPath << "(original:" << url.toLocalFile() << ")";
     return QFile::exists(localPath) ? QUrl::fromLocalFile(localPath) : url;
+}
+
+// ─── TTL 缓存实现 ─────────────────────────────────────────
+
+QString NetworkUtils::makeCacheKey(const QString &host, const QString &port)
+{
+    return host + QLatin1Char(':') + port;
+}
+
+NetworkUtils::NetCacheEntry NetworkUtils::getFromCache(const QString &host, const QString &port) const
+{
+    QMutexLocker locker(&cacheMutex);
+    auto it = netCache.find(makeCacheKey(host, port));
+    if (it == netCache.end())
+        return {};
+
+    // 惰性过期检查
+    if (it.value().timestamp.msecsTo(QDateTime::currentDateTime()) >= kNetCacheTTLMs) {
+        netCache.erase(it);
+        return {};
+    }
+
+    return it.value();
+}
+
+void NetworkUtils::updateCache(const QString &host, const QString &port, bool busy)
+{
+    QMutexLocker locker(&cacheMutex);
+    netCache[makeCacheKey(host, port)] = { busy, QDateTime::currentDateTime() };
+}
+
+void NetworkUtils::clearCache()
+{
+    QMutexLocker locker(&cacheMutex);
+    netCache.clear();
 }
 
 NetworkUtils::NetworkUtils(QObject *parent)

--- a/src/dfm-base/utils/networkutils.cpp
+++ b/src/dfm-base/utils/networkutils.cpp
@@ -201,22 +201,21 @@ bool NetworkUtils::checkFtpOrSmbBusy(const QUrl &url)
     if (!parseIp(url.path(), host, ports))
         return false;
 
-    // 先查缓存，所有端口都 hit 且 busy=false 才算可用
+    // 先查缓存：所有端口都有缓存命中时，仅当全部 busy 才判 busy，
+    // 与非缓存路径 !checkNetConnection(host, ports) 语义一致
     bool allCached { true };
-    bool anyBusy { false };
+    bool allBusy { true };
     for (const auto &port : ports) {
         auto cached = getFromCache(host, port);
         if (!cached.timestamp.isValid()) {
             allCached = false;
             break;
         }
-        if (cached.busy) {
-            anyBusy = true;
-            break;
-        }
+        if (!cached.busy)
+            allBusy = false;
     }
     if (allCached)
-        return anyBusy;
+        return allBusy;
 
     auto busy = !checkNetConnection(host, ports);
     if (busy)

--- a/src/dfm-base/utils/networkutils.h
+++ b/src/dfm-base/utils/networkutils.h
@@ -9,6 +9,9 @@
 
 #include <QObject>
 #include <QString>
+#include <QMap>
+#include <QDateTime>
+#include <QMutex>
 
 #include <functional>
 
@@ -21,7 +24,7 @@ class NetworkUtils : public QObject
 public:
     static NetworkUtils *instance();
 
-    bool checkNetConnection(const QString &host, const QString &port, int msecs = 1000);
+    bool checkNetConnection(const QString &host, const QString &port, int msecs = 1000, const bool useCache = true);
     bool checkNetConnection(const QString &host, QStringList ports, int msecs = 1000);
     void doAfterCheckNet(const QString &host, const QStringList &ports,
                          std::function<void(bool)> callback = nullptr, int msecs = 3000);
@@ -29,6 +32,19 @@ public:
     bool parseIp(const QString &mpt, QString &ip, QStringList &ports);
     bool checkAllCIFSBusy();
     bool checkFtpOrSmbBusy(const QUrl &url);
+
+    // TTL 缓存：避免短期内对同一 host:port 重复 TCP 连接
+    struct NetCacheEntry {
+        bool busy { false };
+        QDateTime timestamp;
+    };
+    static constexpr int kNetCacheTTLMs { 500 };   // 500 ms
+
+    static QString makeCacheKey(const QString &host, const QString &port);
+    NetCacheEntry getFromCache(const QString &host, const QString &port) const;
+    void updateCache(const QString &host, const QString &port, bool busy);
+    void clearCache();
+
     // if network mount，get network mount
     static QMap<QString, QString> cifsMountHostInfo();
 
@@ -45,6 +61,10 @@ public:
      * @return     Resolved local URL, or @p url unchanged when not applicable.
      */
     static QUrl resolveLocalSftpMountUrl(const QUrl &url);
+
+private:
+    mutable QMutex cacheMutex;
+    mutable QMap<QString, NetCacheEntry> netCache;
 
 protected:
     explicit NetworkUtils(QObject *parent = nullptr);


### PR DESCRIPTION
## Migration: NetworkUtils TTL Cache → release/snipe

Migrates PR [#4223](https://github.com/linuxdeepin/dde-file-manager/pull/4223) (NetworkUtils TTL cache) from `master` to `release/snipe`.

### Root Cause

Repeated TCP connection checks to the same `host:port` within short intervals cause unnecessary network overhead and latency, especially during SMB/FTP mount status checks.

### Fix

Introduces a 500ms TTL cache in `NetworkUtils` to avoid redundant TCP connections:
- `checkNetConnection()` checks cache before connecting; caches result after
- `checkFtpOrSmbBusy()` short-circuits when all ports have valid cache entries
- `doAfterCheckNet()` bypasses cache (`useCache=false`) for real-time async checks
- `DeviceProxyManager::removeMounts()` calls `clearCache()` to invalidate on mount changes
- Proxy handling refactored to ensure cache is always updated (semantically equivalent)

### Change Safety

Risk level: **Low**
- `useCache` parameter defaults `true` — backward compatible with existing callers
- Proxy refactor is semantically equivalent (retry NoProxy only when proxy configured)
- `QMutex` protects all cache read/write operations
- Based on merged and reviewed PR #4223

### Differences from master (PR #4223)

1. **DConfig checkNet check excluded**: `master` has `kMountDConfName`/`kCheckNetworkAccessable` DConfig switch; `release/snipe` lacks this infrastructure. Cache feature is independent of this check.
2. **UT adaptation skipped**: `test_devicehelper.cpp` was deleted on `release/snipe`, so the UT signature adaptation commit has no target file.

### Files Changed (3 files, +97/-10)

- `src/dfm-base/utils/networkutils.h` — cache structs, method declarations, QMutex/QMap members
- `src/dfm-base/utils/networkutils.cpp` — TTL cache logic, proxy refactor, checkFtpOrSmbBusy short-circuit
- `src/dfm-base/base/device/deviceproxymanager.cpp` — `clearCache()` in `removeMounts`

---

## 迁移：NetworkUtils TTL 缓存 → release/snipe

将 PR [#4223](https://github.com/linuxdeepin/dde-file-manager/pull/4223)（NetworkUtils TTL 缓存）从 `master` 迁移到 `release/snipe`。

### 根因

短时间内对同一 `host:port` 的重复 TCP 连接检查造成不必要的网络开销和延迟，尤其在 SMB/FTP 挂载状态检查时。

### 修复

在 `NetworkUtils` 中引入 500ms TTL 缓存，避免冗余 TCP 连接：
- `checkNetConnection()` 连接前查缓存，连接后缓存结果
- `checkFtpOrSmbBusy()` 所有端口有缓存时短路返回
- `doAfterCheckNet()` 传 `useCache=false` 保证实时异步检查
- `DeviceProxyManager::removeMounts()` 调用 `clearCache()` 清除缓存
- 代理处理重构确保缓存始终更新（语义等价）

### 改动安全评估

风险等级：**低**
- `useCache` 参数默认 `true`，现有调用方源码兼容
- 代理处理重构语义等价
- `QMutex` 保护所有缓存读写
- 基于已合并并通过审查的 PR #4223

### 与 master 的差异

1. **DConfig checkNet 检查未迁移**：master 有 `kMountDConfName` DConfig 开关，release/snipe 无此基础设施。缓存功能独立于此检查。
2. **UT 适配跳过**：`test_devicehelper.cpp` 在 release/snipe 已删除，无需适配。

## Summary by Sourcery

Optimize network connectivity checks by caching short-lived host and port results and invalidating them when mount state changes.

New Features:
- Add a 500 ms TTL cache for network connectivity results keyed by host and port.
- Allow asynchronous network checks to bypass cached results for real-time validation.
- Clear cached network results when mount points are removed.

Enhancements:
- Reduce redundant TCP connection checks during FTP and SMB mount status detection while preserving existing proxy behavior.