### PR TITLE
feat: optimize fileinfo query and add isCacheMiss overload

### DIFF
--- a/include/dfm-base/base/schemefactory.h
+++ b/include/dfm-base/base/schemefactory.h
@@ -294,6 +294,20 @@ public:
                                     const Global::CreateFileInfoType type = Global::CreateFileInfoType::kCreateFileInfoAuto,
                                     QString *errorString = nullptr)
     {
+        return create<T>(url, nullptr, type, errorString);
+    }
+
+    // isCacheMiss 仅对走缓存逻辑的路径(kCreateFileInfoAuto / kCreateFileInfoAutoNoCache)有意义:
+    // 缓存未命中(新建对象)时置为 true,其余早期返回路径保持 false。
+    template<class T>
+    static QSharedPointer<T> create(const QUrl &url,
+                                    bool *isCacheMiss,
+                                    const Global::CreateFileInfoType type = Global::CreateFileInfoType::kCreateFileInfoAuto,
+                                    QString *errorString = nullptr)
+    {
+        if (isCacheMiss)
+            *isCacheMiss = false;
+
         if (!url.isValid()) {
             qCWarning(logDFMBase) << "url is invalid !!! url = " << url;
             return nullptr;
@@ -331,6 +345,9 @@ public:
 
             if (type != Global::CreateFileInfoType::kCreateFileInfoAutoNoCache)
                 emit InfoCacheController::instance().cacheFileInfo(url, info);
+
+            if (isCacheMiss)
+                *isCacheMiss = true;
         }
 
         if (!info)

--- a/src/dfm-base/file/local/asyncfileinfo.cpp
+++ b/src/dfm-base/file/local/asyncfileinfo.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "asyncfileinfo.h"
+#include "localfileinfodefs.h"
 #include "private/asyncfileinfo_p.h"
 
 #include <dfm-base/base/urlroute.h>
@@ -683,7 +684,7 @@ void AsyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo
         tokenKey = quintptr(dfmFileInfo.data());
         return;
     }
-    dfmFileInfo.reset(new DFileInfo(cvtResultUrl));
+    dfmFileInfo.reset(new DFileInfo(cvtResultUrl, kFileAttributes));
     if (!dfmFileInfo) {
         qCWarning(logDFMBase, "Failed, dfm-io use factory create fileinfo");
         abort();

--- a/src/dfm-base/file/local/localfileinfodefs.h
+++ b/src/dfm-base/file/local/localfileinfodefs.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef LOCALFILEINFODEFS_H
+#define LOCALFILEINFODEFS_H
+
+#include <dfm-base/dfm_base_global.h>
+
+DFMBASE_BEGIN_NAMESPACE
+
+// SyncFileInfo 与 AsyncFileInfo 共用的 DFileInfo 属性查询集合。
+// 仅查询实际需要的属性以替代默认的 "*"，减少不必要的 I/O 开销。
+// 后续如需调整查询属性，只需在此处统一修改。
+//
+// 注意：
+// - standard::is-file、standard::is-dir 不是 GIO 标准属性，而是 dfm-io 自定义属性
+//   (AttributeID kStandardIsFile=610, kStandardIsDir=611)，dfm-io 解析属性字符串来
+//   决定是否计算这两个值。若移除，isFile()/isDir() 将失效，请勿删除。
+// - standard::icon、standard::content-type 被有意排除：查询它们会触发 GIO 的
+//   mimetype 检测（额外 I/O 开销），而文件管理器通过 QMimeDatabase 独立计算
+//   mimetype，不依赖 GIO 的 content-type。
+inline constexpr char kFileAttributes[] { "standard::name,standard::type,standard::is-file,standard::is-dir,"
+    "standard::display-name,standard::size,standard::is-symlink,standard::symlink-target,standard::is-hidden,"
+    "access::*,time::*,"
+    "owner::*,unix::uid,unix::inode,unix::gid,unix::mode,id::filesystem" };
+
+DFMBASE_END_NAMESPACE
+
+#endif   // LOCALFILEINFODEFS_H

--- a/src/dfm-base/file/local/syncfileinfo.cpp
+++ b/src/dfm-base/file/local/syncfileinfo.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "syncfileinfo.h"
+#include "localfileinfodefs.h"
 #include "private/syncfileinfo_p.h"
 
 #include <dfm-base/base/urlroute.h>
@@ -637,7 +638,7 @@ void SyncFileInfoPrivate::init(const QUrl &url, QSharedPointer<DFMIO::DFileInfo>
         return;
     }
 
-    dfmFileInfo.reset(new DFileInfo(cvtResultUrl));
+    dfmFileInfo.reset(new DFileInfo(cvtResultUrl, kFileAttributes));
 
     if (!dfmFileInfo) {
         qCWarning(logDFMBase, "Failed, dfm-io use factory create fileinfo");

--- a/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp
@@ -159,10 +159,12 @@ QVariant FileItemData::data(int role) const
     case kItemCreateFileInfoRole:
         assert(qApp->thread() == QThread::currentThread());
         if (info.isNull()) {
-            const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url);
+            bool isCacheMiss = false;
+            const_cast<FileItemData *>(this)->info = InfoFactory::create<FileInfo>(url, &isCacheMiss);
             if (info) {
                 info->customData(kItemFileRefreshIcon);
-                info->updateAttributes();
+                if (isCacheMiss)
+                    info->updateAttributes();
             } else {
                 fmWarning() << "Failed to create FileInfo for URL:" << url.toString();
             }


### PR DESCRIPTION
## 迁移 PR #4239 到 release/snipe

将 master 分支上 PR #4239（optimize fileinfo query and add isCacheMiss overload）的提交迁移到 `release/snipe` 分支。

### 改动内容（5 个源文件，+55 -4）

- `include/dfm-base/base/schemefactory.h` — 新增带 `bool *isCacheMiss` 参数的 `InfoFactory::create()` 重载；原 3 参数版本委托至新重载（`isCacheMiss=nullptr`），无破坏性变更
- `src/dfm-base/file/local/localfileinfodefs.h` — 新增共享常量 `kFileAttributes`，仅查询文管实际需要的属性（name/type/size/time/access/owner/unix/id::filesystem），替代默认 `"*"`
- `src/dfm-base/file/local/syncfileinfo.cpp` — `DFileInfo` 构造传入 `kFileAttributes`
- `src/dfm-base/file/local/asyncfileinfo.cpp` — 同上
- `src/plugins/filemanager/dfmplugin-workspace/models/fileitemdata.cpp` — 使用 `isCacheMiss` 重载，仅在缓存未命中时调用 `updateAttributes()`，缓存命中时跳过冗余刷新

### 冲突解决

21 个 autotest 文件在 `release/snipe` 上已被删除，而 PR #4239 在 master 上对它们做了 `static_cast` 适配。解决方式为 `git rm` 移除这些文件，与 release/snipe 一致。

### 兼容性

- 原 `create()` 3 参数签名完全不变，新重载的 `isCacheMiss` 无默认值，源码兼容
- `kFileAttributes` 排除了 `standard::icon`、`standard::content-type`（会触发 GIO mimetype 检测），保留 `standard::is-file`、`standard::is-dir`

## Summary by Sourcery

Optimize local file information retrieval and use cache status to skip redundant attribute refreshes.

New Features:
- Add an optional cache-miss indicator to file information creation while preserving the existing API.

Enhancements:
- Limit local file metadata queries to attributes required by the file manager to reduce unnecessary I/O.
- Avoid refreshing file attributes when file information is served from cache.