### PR TITLE
fix: resolve intermittent QPersistentModelIndex crash on shutdown

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -158,6 +158,15 @@ FileView::~FileView()
         d->selectHelper = nullptr;
     }
 
+    // 3.5 显式清理无障碍接口缓存中的 QAccessibleTableCell 对象。
+    //     QAccessibleTableCell 持有 QPersistentModelIndex 且 object() 返回 nullptr,
+    //     不会被 objectDestroyed() 清理, 仅在 ~QAccessibleCache() (~QApplication) 时析构。
+    //     若不在模型存活时清理, 模型销毁后 ~QPersistentModelIndex 将访问悬空模型指针。
+#if QT_CONFIG(accessibility)
+    if (auto *iface = QAccessible::queryAccessibleInterface(this))
+        QAccessible::deleteAccessibleInterface(QAccessible::uniqueId(iface));
+#endif
+
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 


### PR DESCRIPTION
## 修复：关闭程序偶现段错误（QPersistentModelIndex 析构崩溃）

### 问题

在文件视图进行新建、删除、重命名等操作后关闭程序，偶现段错误，崩溃堆栈：

```
QAbstractItemModelPrivate::removePersistentIndexData
QPersistentModelIndex::~QPersistentModelIndex
QAccessibleCache::~QAccessibleCache
qt_call_post_routines()
QApplication::~QApplication
```

### 根因

`QAccessibleTableCell` 持有 `QPersistentModelIndex` 且 `object()` 返回 `nullptr`，导致其缓存条目永远不会通过 `objectDestroyed()` 清理，仅在 `~QAccessibleCache()`（即 `~QApplication()`）时才被析构。此时 FileView 的模型已被删除，`~QPersistentModelIndex` 解引用悬空模型指针 → 段错误。

崩溃偶现的原因：需同时满足 ① 无障碍系统激活 ② FileView 单元格被查询过 ③ 文件操作将 persistent index 移出哈希 ④ 窗口 `deleteLater()` 未在 `~QApplication()` 前完成。

### 修复方案

1. **`main.cpp`**：在 `QAccessible::cleanup()` 之前同步 `delete` 所有顶层窗口，确保 `~QObject()` → `objectDestroyed()` 在模型存活时清理 `QAccessibleTableCell`。
2. **`~FileView()`**：在 `setModel(nullptr)` 之前调用 `QAccessible::deleteAccessibleInterface(QAccessible::uniqueId(this))`，显式删除 `QAccessibleTable` 及其子 `QAccessibleTableCell`。

两处改动均仅调整退出阶段对象销毁时序，使用 Qt 公开 API，不改变业务逻辑。

Log: none
Bug: https://github.com/linuxdeepin/dde-file-manager

## Summary by Sourcery

Fix shutdown-time crashes by ordering accessibility and file view cleanup so persistent model indexes are released while their models remain valid.

Bug Fixes:
- Prevent intermittent shutdown crashes caused by stale accessibility table cells retaining persistent model indexes after file view operations.

Enhancements:
- Ensure accessibility interfaces and top-level windows are destroyed before their underlying models during application shutdown.