### PR TITLE
fix: resolve intermittent QPersistentModelIndex crash on shutdown

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/views/fileview.cpp
@@ -153,6 +153,15 @@ FileView::~FileView()
         d->selectHelper = nullptr;
     }
 
+    // 3.5 显式清理无障碍接口缓存中的 QAccessibleTableCell 对象。
+    //     QAccessibleTableCell 持有 QPersistentModelIndex 且 object() 返回 nullptr,
+    //     不会被 objectDestroyed() 清理, 仅在 ~QAccessibleCache() (~QApplication) 时析构。
+    //     若不在模型存活时清理, 模型销毁后 ~QPersistentModelIndex 将访问悬空模型指针。
+#if QT_CONFIG(accessibility)
+    if (auto *iface = QAccessible::queryAccessibleInterface(this))
+        QAccessible::deleteAccessibleInterface(QAccessible::uniqueId(iface));
+#endif
+
     // 4. 解绑 model(关键步骤): 会触发 QAbstractItemView 清理持有的 QPersistentModelIndex
     DListView::setModel(nullptr);
 


### PR DESCRIPTION
fix: resolve intermittent QPersistentModelIndex crash on shutdown

QAccessibleTableCell objects hold QPersistentModelIndex instances but
return nullptr from object(), so they are never cleaned via
objectDestroyed() and persist in QAccessibleCache until ~QApplication().
When the FileView model has already been deleted by that point,
~QPersistentModelIndex dereferences a dangling model pointer, causing a
segfault.  The crash is intermittent because it requires accessibility
to be active, cells to have been queried, file operations to move
persistent indexes out of the model hash, and deleteLater() to not have
completed before ~QApplication().

Fix: in ~FileView(), call QAccessible::deleteAccessibleInterface() before
detaching/deleting the model, explicitly removing QAccessibleTableCell
objects from the cache while the model is still alive.

Log: none
Bug: https://github.com/linuxdeepin/dde-file-manager

## Summary by Sourcery

Bug Fixes:
- Prevent intermittent shutdown crashes caused by accessibility table-cell interfaces retaining persistent indexes after the file view model is destroyed.