### PR TITLE
fix: correct file grouping in tree-expanded dirs

### DIFF
--- a/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
+++ b/src/plugins/filemanager/dfmplugin-workspace/groups/groupingengine.cpp
@@ -140,18 +140,30 @@ QString GroupingEngine::getGroupKeyForFiles(const QList<FileItemDataPointer> &fi
 {
     QString groupKey;
     FileItemDataPointer groupKeyItem;
+    Q_UNUSED(anchorUrl)
 
     // 区分新增的文件是树形item展开的，还是当前目录新增的
-    // 如果是树形展开的文件，其所属分组应该属于anchorUrl的分组
-    auto anchorPointer = m_childrenDataMap->value(anchorUrl);
-    int anchorExpandedCount = !anchorPointer.isNull() ? findExpandedFiles(anchorPointer).size() : 0;
-    if (anchorExpandedCount == 0) {
+    // 通过检查待插入文件的父目录是否为展开的树形节点来判断，
+    // 而非依赖前置锚点（前置锚点可能是兄弟文件而非父目录）
+    bool isTreeChild = false;
+    QUrl parentUrl;
+    if (!filesToInsert.isEmpty() && filesToInsert.first()) {
+        const QUrl &fileUrl = filesToInsert.first()->data(ItemRoles::kItemUrlRole).toUrl();
+        parentUrl = fileUrl.adjusted(QUrl::RemoveFilename | QUrl::StripTrailingSlash);
+    }
+
+    if (parentUrl.isValid() && m_visibleTreeChildren && parentUrl != m_rootUrl
+        && m_visibleTreeChildren->contains(parentUrl)) {
+        isTreeChild = true;
+    }
+
+    if (isTreeChild) {
+        // 树形item展开：使用顶层祖先的分组 key
+        const QUrl &topLevelUrl = findTopLevelAncestorOf(parentUrl);
+        groupKeyItem = m_childrenDataMap->value(topLevelUrl);
+    } else {
         // 文件新增
         groupKeyItem = filesToInsert.first();
-    } else {
-        // 树形item展开
-        const QUrl &topLevelUrl = findTopLevelAncestorOf(anchorUrl);
-        groupKeyItem = m_childrenDataMap->value(topLevelUrl);
     }
 
     if (!groupKeyItem.isNull()) {


### PR DESCRIPTION
## Root Cause Analysis

In grouped view combined with tree view, when a file is renamed or created inside an expanded tree directory, the new file item incorrectly appears in a root-level group instead of the tree node's group. The root cause is in `GroupingEngine::getGroupKeyForFiles()` (`groupingengine.cpp:141-163`), which uses the preceding anchor item (from `findPrecedingAnchor()`) to determine whether a new file is a tree-expanded child. In tree view, the `visibleChildren` list is flat, so the anchor can be a sibling file rather than the parent directory. When the anchor is a sibling file, `findExpandedFiles()` returns empty (non-expanded item), `anchorExpandedCount == 0`, and the code wrongly takes the "file new" branch, computing the group key from the file itself instead of the top-level ancestor.

## Fix

Replace the anchor-based tree detection with a parent-directory check. The fix computes the parent URL of the file being inserted (`url.adjusted(QUrl::RemoveFilename | QUrl::StripTrailingSlash)`) and checks if the parent is an expanded tree node in `m_visibleTreeChildren`. If so, it uses `findTopLevelAncestorOf(parentUrl)` to get the group key; otherwise, it uses the file's own group key (original behavior). The `anchorUrl` parameter is retained in the signature for ABI compatibility but marked `Q_UNUSED`.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The target code was authored across several commits (initial `fb375ccebd76`, fixes `9befb47c8bd1`, `260fa61c18dd`); all prior fixes added null checks and ancestor tracking on top of the anchor-based logic. This change replaces the detection criterion itself and does not revert any historical fix.
- Two callers (`updateFilesToModelData` at :60, `insertFilesToModelData` at :114) are unaffected — function signature and return value are unchanged.

### Business Impact Scope

Affects the file grouping logic in the workspace plugin when a file is newly inserted or renamed under an expanded tree directory in grouped view. Users performing rename or create operations in grouped+tree view will see files correctly placed in tree node groups instead of root-level groups. No other modules are affected.

### Verification Suggestion

Test renaming and creating files under an expanded tree directory in grouped view (by name/size/type/time). Also verify that root-level new files without tree expansion still group correctly to confirm no regression.

---

## 根因分析

在分组视图+树形视图组合模式下，当展开的树形目录中重命名或新建文件时，新文件 item 错误地出现在根目录级别的分组中，而非树形节点的分组中。根因位于 `GroupingEngine::getGroupKeyForFiles()`（`groupingengine.cpp:141-163`），该函数使用前置锚点（`findPrecedingAnchor()` 返回的 `visibleChildren` 列表中前一个 item）来判断新增文件是否为树形展开子文件。树形视图中 `visibleChildren` 是扁平列表，前置锚点可能是兄弟文件而非父目录。当锚点是兄弟文件时，`findExpandedFiles()` 返回空（非展开 item），`anchorExpandedCount == 0`，代码错误走入"文件新增"分支，用文件自身计算分组 key 而非顶层祖先。

## 修复方案

将锚点判断替换为父目录判断。修复方案计算待插入文件的父目录 URL（`url.adjusted(QUrl::RemoveFilename | QUrl::StripTrailingSlash)`），检查父目录是否为 `m_visibleTreeChildren` 中的展开树形节点。若是，使用 `findTopLevelAncestorOf(parentUrl)` 获取分组 key；否则使用文件自身的分组 key（保持原行为）。`anchorUrl` 参数在签名中保留以维持兼容性，标记为 `Q_UNUSED`。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 目标代码由多个 commit 逐步构建（初始 `fb375ccebd76`，修复 `9befb47c8bd1`、`260fa61c18dd`）；历史修复均在锚点逻辑基础上添加空检查和祖先追踪。本次修复替换判断依据本身，不撤销任何历史修复。
- 两个调用者（`updateFilesToModelData` :60、`insertFilesToModelData` :114）不受影响——函数签名和返回值不变。

### 业务影响范围

影响 workspace 插件中分组视图+树形视图组合模式下新增或重命名文件时的分组逻辑。用户在分组+树形视图下执行重命名或新建操作时，文件将正确出现在树形节点分组中而非根目录分组。其他模块不受影响。

### 验证建议

测试分组视图+树形视图下展开目录中重命名和新建文件的分组显示（按名称/大小/类型/时间分组）。同时验证未展开树形时根目录新增文件的分组正确性以确认无回归。

## Summary by Sourcery

Fix grouped tree-view file placement by basing inserted-file grouping on whether its parent directory is an expanded tree node.

Bug Fixes:
- Correct file grouping for newly created or renamed files inside expanded tree directories so they remain in the appropriate tree-node group.

Enhancements:
- Determine tree-child grouping from the inserted file’s parent directory instead of the preceding visible item, while preserving existing grouping behavior for non-tree files.