### PR TITLE
fix: remove network I/O from desktop file detection

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -243,11 +243,15 @@ bool FileUtils::isContainProhibitPath(const QList<QUrl> &urls)
 
 bool FileUtils::isDesktopFile(const QUrl &url)
 {
-    // At present, there is no dfmio library code. For temporary repair, use the method on v20 to obtain mimeType
-    auto info = InfoFactory::create<FileInfo>(url);
-    if (!info)
-        return false;
-    return isDesktopFileInfo(info);
+    if (isDesktopFileSuffix(url))
+        return true;
+
+    const QString &target = symlinkTarget(url);
+    if (!target.isEmpty()
+        && target.endsWith(QString(".") + DFMBASE_NAMESPACE::Global::Scheme::kDesktop, Qt::CaseInsensitive))
+        return true;
+
+    return false;
 }
 
 bool FileUtils::isDesktopFileSuffix(const QUrl &url)
@@ -263,17 +267,14 @@ bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)
 {
     Q_ASSERT(info);
     const QString &suffix = info->nameOf(NameInfoType::kSuffix);
-    if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop
-        || info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
-        || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool()) {
-        const QUrl &url = info->urlOf(UrlInfoType::kUrl);
-        QMimeType type = info->fileMimeType();
-        if (!type.isValid())
-            type = DMimeDatabase().mimeTypeForFile(url.path(), QMimeDatabase::MatchDefault, QString());
+    if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop)
+        return true;
 
-        // QMimeType::suffixes is not the same as fileinfo's `kSuffix`.
-        if (type.name() == "application/x-desktop"
-            && type.suffixes().contains(DFMBASE_NAMESPACE::Global::Scheme::kDesktop, Qt::CaseInsensitive))
+    if ((info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
+         || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool())
+        && info->isAttributes(OptInfoType::kIsSymLink)) {
+        const QString &target = info->pathOf(PathInfoType::kSymLinkTarget);
+        if (target.endsWith(QString(".") + DFMBASE_NAMESPACE::Global::Scheme::kDesktop, Qt::CaseInsensitive))
             return true;
     }
 


### PR DESCRIPTION
## 问题

SMB 服务器断连时，滚动文件视图（包含 SMB 链接文件）会导致主线程卡顿约 2 秒。

### 根因

paint 事件路径中 `FileUtils::isDesktopFileInfo` → `DMimeDatabase::mimeTypeForFile(MatchDefault)` → `NetworkUtils::checkFtpOrSmbBusy` → `checkNetConnection` → `QTcpSocket::waitForConnected(1000ms)` 在主线程同步阻塞，SMB 检查端口 445 和 139 各阻塞约 1 秒，合计约 2 秒。

该性能问题由 [PR #3123](https://github.com/linuxdeepin/dde-file-manager/pull/3123) 引入：为支持桌面重命名后的 desktop 符号链接（无 `.desktop` 后缀）不显示角标，`isDesktopFile` / `isDesktopFileInfo` 改为通过 MIME 内容检测判断，而 MIME 检测会触发网络 I/O。

### 调用链

```
FileView::paintEvent → emblem 绘制 → EmblemHelper::systemEmblems
→ FileUtils::isDesktopFileInfo → DMimeDatabase::mimeTypeForFile(MatchDefault)
→ NetworkUtils::checkFtpOrSmbBusy → checkNetConnection
→ QTcpSocket::waitForConnected(1000) × 2 端口 ≈ 2s 主线程阻塞
```

## 修复方案

用纯本地轻量检查替代 MIME 内容检测，消除 paint 路径中的网络 I/O：

- **`isDesktopFile(const QUrl&)`**：不再创建 `FileInfo`，改为先检查 `.desktop` 后缀（`isDesktopFileSuffix`），再通过 `symlinkTarget`（readlink）读取符号链接目标并检查是否以 `.desktop` 结尾
- **`isDesktopFileInfo(const FileInfoPointer&)`**：不再调用 `fileMimeType()` / `mimeTypeForFile(MatchDefault)`，改为后缀匹配 + 符号链接目标检查

### 保留的业务逻辑

- `.desktop` 后缀文件仍被识别为 desktop 文件
- 桌面路径或本地设备上的重命名符号链接（指向 `/usr/share` 中的 `.desktop` 文件）仍被识别，保持 PR #3123 的角标隐藏效果

## 改动范围

仅修改 `src/dfm-base/utils/fileutils.cpp`，2 个函数内部逻辑替换，不改函数签名，不删除公开接口。

## 改动安全评估

- 风险等级：低风险
- 所有调用者行为兼容（emblem 绘制、右键菜单、拖拽、打开方式等）
- 唯一边界变化：无 `.desktop` 后缀、非符号链接但内容为 desktop 格式的文件不再被识别（实际业务中不存在该场景）

Log: 修复 SMB 断连时滚动文件视图导致主线程卡顿的问题

## Summary by Sourcery

Remove MIME-based network checks from desktop file detection to keep file view rendering responsive during SMB disconnects.

Bug Fixes:
- Prevent desktop file detection from performing synchronous network I/O, eliminating main-thread stalls when viewing files on disconnected SMB shares.

Enhancements:
- Preserve recognition of .desktop files and relevant symbolic links through lightweight local suffix and symlink-target checks.