### PR TITLE
fix: remove network I/O from desktop file detection

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -237,11 +237,15 @@ bool FileUtils::isContainProhibitPath(const QList<QUrl> &urls)
 
 bool FileUtils::isDesktopFile(const QUrl &url)
 {
-    // At present, there is no dfmio library code. For temporary repair, use the method on v20 to obtain mimeType
-    auto info = InfoFactory::create<FileInfo>(url);
-    if (!info)
-        return false;
-    return isDesktopFileInfo(info);
+    if (isDesktopFileSuffix(url))
+        return true;
+
+    const QString &target = symlinkTarget(url);
+    if (!target.isEmpty()
+        && target.endsWith(QString(".") + DFMBASE_NAMESPACE::Global::Scheme::kDesktop, Qt::CaseInsensitive))
+        return true;
+
+    return false;
 }
 
 bool FileUtils::isDesktopFileSuffix(const QUrl &url)
@@ -257,17 +261,14 @@ bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)
 {
     Q_ASSERT(info);
     const QString &suffix = info->nameOf(NameInfoType::kSuffix);
-    if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop
-        || info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
-        || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool()) {
-        const QUrl &url = info->urlOf(UrlInfoType::kUrl);
-        QMimeType type = info->fileMimeType();
-        if (!type.isValid())
-            type = DMimeDatabase().mimeTypeForFile(url.path(), QMimeDatabase::MatchDefault, QString());
+    if (suffix == DFMBASE_NAMESPACE::Global::Scheme::kDesktop)
+        return true;
 
-        // QMimeType::suffixes is not the same as fileinfo's `kSuffix`.
-        if (type.name() == "application/x-desktop"
-            && type.suffixes().contains(DFMBASE_NAMESPACE::Global::Scheme::kDesktop, Qt::CaseInsensitive))
+    if ((info->urlOf(UrlInfoType::kParentUrl).path() == StandardPaths::location(StandardPaths::StandardLocation::kDesktopPath)
+         || info->extendAttributes(ExtInfoType::kFileLocalDevice).toBool())
+        && info->isAttributes(OptInfoType::kIsSymLink)) {
+        const QString &target = info->pathOf(PathInfoType::kSymLinkTarget);
+        if (target.endsWith(QString(".") + DFMBASE_NAMESPACE::Global::Scheme::kDesktop, Qt::CaseInsensitive))
             return true;
     }
 


### PR DESCRIPTION
Cherry-pick of #4312 to release/snipe.

## 问题描述

SMB 断连时滚动文件视图导致主线程卡顿：`NetworkUtils::checkNetConnection` 在主线程同步阻塞 `QTcpSocket::waitForConnected`，每次约 2 秒。

## 根因

paint 事件路径中 `DMimeDatabase::mimeTypeForFile` 无条件调用 `checkFtpOrSmbBusy`，后者在主线程同步执行网络连接检查，SMB 断连时阻塞。

## 修复

用纯本地检查（后缀匹配 + readlink 符号链接目标）替代 MIME 内容检测，消除 paint 路径中的网络 I/O。

## Summary by Sourcery

Prevent desktop-file detection from blocking the UI by replacing MIME-based checks with local-only detection.

Bug Fixes:
- Remove synchronous network I/O from desktop-file detection to prevent main-thread stalls when disconnected SMB shares are accessed.

Enhancements:
- Use local filename suffix and symbolic-link target checks for desktop-file identification.