### PR TITLE
test(preview): add unit tests for dde-file-manager-preview pluginprev…

### DIFF
--- a/autotests/CMakeLists.txt
+++ b/autotests/CMakeLists.txt
@@ -18,3 +18,6 @@ endif()
 add_subdirectory(libs)
 add_subdirectory(services)
 add_subdirectory(plugins)
+
+# App-level plugin tests (dde-file-manager-preview)
+add_subdirectory(apps)

--- a/autotests/apps/CMakeLists.txt
+++ b/autotests/apps/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Unit tests for app-level plugins (e.g. dde-file-manager-preview plugins).
+add_subdirectory(dde-file-manager-preview)

--- a/autotests/apps/dde-file-manager-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Unit tests for src/apps/dde-file-manager-preview/pluginpreviews plugins.
+set(DFM_PREVIEW_PLUGIN_DIR "${DFM_SOURCE_DIR}/apps/dde-file-manager-preview/pluginpreviews")
+add_subdirectory(dciicon-preview)
+add_subdirectory(image-preview)
+add_subdirectory(markdown-preview)
+add_subdirectory(text-preview)
+add_subdirectory(music-preview)
+add_subdirectory(pdf-preview)
+add_subdirectory(video-preview)

--- a/autotests/apps/dde-file-manager-preview/dciicon-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/dciicon-preview/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Unit tests for dciicon-preview: recompile plugin sources into the test binary
+# so stub-ext can access private members (see autotests/README.md).
+set(_preview_dir "${DFM_PREVIEW_PLUGIN_DIR}/dciicon-preview")
+
+file(GLOB_RECURSE _ut_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+file(GLOB_RECURSE _plugin_files
+    "${_preview_dir}/*.cpp"
+    "${_preview_dir}/*.h")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+
+dfm_create_test_executable(ut-dciicon-preview
+    SOURCES ${_ut_files} ${_plugin_files}
+    LINK_LIBRARIES DFM6::base DFM6::framework Qt6::Widgets 
+)
+
+target_include_directories(ut-dciicon-preview PRIVATE
+    "${DFM_PREVIEW_PLUGIN_DIR}"
+    ${_preview_dir}
+)
+

--- a/autotests/apps/dde-file-manager-preview/dciicon-preview/main.cpp
+++ b/autotests/apps/dde-file-manager-preview/dciicon-preview/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dciicon_preview)

--- a/autotests/apps/dde-file-manager-preview/dciicon-preview/test_ddciiconpreview.cpp
+++ b/autotests/apps/dde-file-manager-preview/dciicon-preview/test_ddciiconpreview.cpp
@@ -1,0 +1,1011 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "ddciiconpreview.h"
+
+#include <dfm-base/interfaces/abstractbasepreview.h>
+
+#include <dtkgui_config.h>
+
+#ifdef DTKGUI_CLASS_DDciIcon
+#    include <DDciIcon>
+#endif
+
+#include <gtest/gtest.h>
+#include <QTest>
+
+#include <QApplication>
+#include <QBasicTimer>
+#include <QComboBox>
+#include <QFile>
+#include <QGraphicsPixmapItem>
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QHBoxLayout>
+#include <QImage>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMimeDatabase>
+#include <QPainter>
+#include <QPixmap>
+#include <QPoint>
+#include <QPushButton>
+#include <QRegion>
+#include <QResizeEvent>
+#include <QSlider>
+#include <QSplitter>
+#include <QTimer>
+#include <QTimerEvent>
+#include <QVBoxLayout>
+#include <QWheelEvent>
+
+#ifdef DTKGUI_CLASS_DDciIcon
+
+DFMBASE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
+
+namespace plugin_filepreview {
+class IconOptionWidget : public QWidget
+{
+public:
+    explicit IconOptionWidget(QWidget *parent = nullptr);
+
+    void setTitleText(const QString &title);
+    void addHeaderWidget(QWidget *w);
+    void addContentWidget(QWidget *w);
+
+protected:
+    void paintEvent(QPaintEvent *) override;
+
+private:
+    QLabel *titleLabel;
+    QVBoxLayout *mainLayout;
+    QHBoxLayout *titleLayout;
+};
+
+class IconPreviewView : public QGraphicsView
+{
+public:
+    explicit IconPreviewView(QWidget *parent = nullptr);
+
+protected:
+    void wheelEvent(QWheelEvent *event) override;
+    void drawBackground(QPainter *painter, const QRectF &rect) override;
+
+private:
+    QLabel *scaleFactorLabel;
+    QTimer scaleHideTimer;
+};
+
+class DDciIconPreview : public DFMBASE_NAMESPACE::AbstractBasePreview
+{
+public:
+    explicit DDciIconPreview(QObject *parent = nullptr);
+    virtual ~DDciIconPreview() override;
+
+    void initialize(QWidget *window, QWidget *statusBar) override;
+    QString title() const override;
+    QWidget *statusBarWidget() const override;
+    bool setFileUrl(const QUrl &url) override;
+    QUrl fileUrl() const override;
+    QWidget *contentWidget() const override;
+
+protected:
+    void initControlWidgets();
+    void initPreviewWidgets();
+    void initializeSettings(const QString &localUrl);
+    DDciIconPalette generateDciIconPalette();
+    void updateIconMatchedResult();
+    void updatePixmap();
+    void updatePixmapImpl();
+    bool eventFilter(QObject *watched, QEvent *event) override;
+    void timerEvent(QTimerEvent *e) override;
+    int getIconSize();
+
+private:
+    IconPreviewView *view;
+    QGraphicsScene *scene;
+    QGraphicsPixmapItem *iconItem;
+    QWidget *mainWidget;
+    QWidget *controlWidget;
+    QComboBox *availableSizeCombo;
+    QLabel *devicePixelRatioLabel;
+    QLabel *paletteNosupportedText;
+    QLineEdit *foregroundPaletteEdit;
+    QLineEdit *backgroundPaletteEdit;
+    QLineEdit *hightlightPaletteEdit;
+    QLineEdit *hFPaletteEdit;
+    IconOptionWidget *paletteWidget;
+    QComboBox *themeCom;
+    QComboBox *modeCom;
+    QLineEdit *customSizeEdit;
+    QUrl url;
+    DDciIcon *dciIcon;
+    DDciIconMatchResult dciIconMatched;
+    QBasicTimer updateTimer;
+    QString titleText;
+};
+}   // namespace plugin_filepreview
+
+using namespace plugin_filepreview;
+
+class UT_IconOptionWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        option = new IconOptionWidget();
+    }
+
+    virtual void TearDown() override
+    {
+        delete option;
+        option = nullptr;
+        stub.clear();
+    }
+
+protected:
+    IconOptionWidget *option { nullptr };
+    stub_ext::StubExt stub;
+};
+
+class UT_IconPreviewView : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        view = new IconPreviewView();
+        view->resize(400, 300);
+    }
+
+    virtual void TearDown() override
+    {
+        delete view;
+        view = nullptr;
+        stub.clear();
+    }
+
+    // Qt 6.8 中 QApplication::notify 会将直接发给 QGraphicsView 的 wheel 事件按位置重定向，
+    // 未 show 的窗口下该事件被直接丢弃；真实滚轮事件本就是先到达 viewport 再由
+    // QGraphicsView::viewportEvent 转发给 wheelEvent，因此这里直接发给 viewport
+    QWheelEvent makeWheelEvent(int deltaY)
+    {
+        return QWheelEvent(QPointF(10, 10), QPointF(10, 10), QPoint(0, 0), QPoint(0, deltaY),
+                           Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    }
+
+protected:
+    IconPreviewView *view { nullptr };
+    stub_ext::StubExt stub;
+};
+
+class UT_DDciIconPreview : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        preview = new DDciIconPreview();
+    }
+
+    virtual void TearDown() override
+    {
+        delete preview;
+        preview = nullptr;
+        stub.clear();
+    }
+
+protected:
+    DDciIconPreview *preview { nullptr };
+    stub_ext::StubExt stub;
+};
+
+class UT_DDciIconPreviewInitialized : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        preview = new DDciIconPreview();
+        preview->initialize(nullptr, nullptr);
+        if (preview->updateTimer.isActive())
+            preview->updateTimer.stop();
+    }
+
+    virtual void TearDown() override
+    {
+        QFile::remove(kTempDciPath);
+        stub.clear();
+        if (preview) {
+            delete preview->mainWidget;
+            preview->mainWidget = nullptr;
+            delete preview;
+            preview = nullptr;
+        }
+    }
+
+    QString createTempDciFile(const QByteArray &content)
+    {
+        QFile file(kTempDciPath);
+        file.open(QIODevice::WriteOnly | QIODevice::Truncate);
+        file.write(content);
+        file.close();
+        return kTempDciPath;
+    }
+
+    void loadFakeIconSuccessfully(QList<int> sizes)
+    {
+        stub.set_lamda(ADDR(DDciIcon, isNull), [](const DDciIcon *) {
+            __DBG_STUB_INVOKE__
+            return false;
+        });
+        stub.set_lamda(ADDR(DDciIcon, availableSizes),
+                       [sizes](const DDciIcon *, DDciIcon::Theme, DDciIcon::Mode) {
+                           __DBG_STUB_INVOKE__
+                           return sizes;
+                       });
+        preview->initializeSettings("/tmp/ut_dciicon_fake_icon.dci");
+        preview->updateTimer.stop();
+    }
+
+protected:
+    static const QString kTempDciPath;
+    DDciIconPreview *preview { nullptr };
+    stub_ext::StubExt stub;
+};
+
+const QString UT_DDciIconPreviewInitialized::kTempDciPath = "/tmp/ut_dciicon_preview_temp.dci";
+
+class UT_DDciIconPreviewPlugin : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        plugin = new DDciIconPreviewPlugin();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+protected:
+    DDciIconPreviewPlugin *plugin { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DDciIconPreviewPlugin, Create_WithArbitraryKey_ReturnsNonNullPreviewInstance)
+{
+    DFMBASE_NAMESPACE::AbstractBasePreview *result = plugin->create("dci");
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(result->title().isEmpty());
+    delete result;
+}
+
+TEST_F(UT_DDciIconPreviewPlugin, Create_WithEmptyKey_ReturnsNonNullPreviewInstance)
+{
+    DFMBASE_NAMESPACE::AbstractBasePreview *result = plugin->create("");
+    EXPECT_NE(result, nullptr);
+    delete result;
+}
+
+TEST_F(UT_IconOptionWidget, Construction_DefaultState_FocusPolicyAndLayoutsConfigured)
+{
+    EXPECT_EQ(option->focusPolicy(), Qt::ClickFocus);
+    ASSERT_NE(option->titleLabel, nullptr);
+    ASSERT_NE(option->mainLayout, nullptr);
+    ASSERT_NE(option->titleLayout, nullptr);
+    EXPECT_EQ(option->mainLayout->contentsMargins(), QMargins(10, 10, 10, 10));
+    EXPECT_EQ(option->mainLayout->spacing(), 5);
+    EXPECT_EQ(option->titleLayout->contentsMargins(), QMargins(0, 0, 0, 0));
+    EXPECT_EQ(option->titleLabel->parentWidget(), option);
+}
+
+TEST_F(UT_IconOptionWidget, SetTitleText_GivenText_LabelUpdated)
+{
+    option->setTitleText("Available sizes: ");
+    EXPECT_EQ(option->titleLabel->text(), QString("Available sizes: "));
+
+    option->setTitleText("Palette");
+    EXPECT_EQ(option->titleLabel->text(), QString("Palette"));
+}
+
+TEST_F(UT_IconOptionWidget, AddHeaderWidget_GivenWidget_WidgetReparentedIntoTitleRow)
+{
+    auto *header = new QPushButton();
+    option->addHeaderWidget(header);
+    EXPECT_EQ(header->parentWidget(), option);
+    EXPECT_EQ(option->titleLayout->count(), 3);
+    EXPECT_EQ(option->titleLayout->itemAt(2)->widget(), header);
+}
+
+TEST_F(UT_IconOptionWidget, AddContentWidget_GivenWidget_WidgetReparentedIntoMainLayout)
+{
+    auto *content = new QWidget();
+    option->addContentWidget(content);
+    EXPECT_EQ(content->parentWidget(), option);
+    EXPECT_EQ(option->mainLayout->count(), 2);
+    EXPECT_EQ(option->mainLayout->itemAt(1)->widget(), content);
+}
+
+TEST_F(UT_IconOptionWidget, PaintEvent_RenderWidget_DrawsRoundedBackground)
+{
+    option->resize(120, 80);
+    QPixmap pm(120, 80);
+    pm.fill(Qt::transparent);
+    // Qt6 的 QWidget::render() 默认带 DrawWindowBackground 标志，会先用不透明背景
+    // 填充整个目标区域，导致圆角外像素断言失效；去掉该标志后只绘制 paintEvent 自身内容
+    EXPECT_NO_FATAL_FAILURE(option->render(&pm, QPoint(), QRegion(),
+                                           QWidget::RenderFlags(QWidget::DrawChildren)));
+    EXPECT_EQ(pm.toImage().pixelColor(60, 40).alpha(), 255);
+    EXPECT_EQ(pm.toImage().pixelColor(1, 1).alpha(), 0);
+}
+
+TEST_F(UT_IconPreviewView, Construction_DefaultState_ViewPropertiesConfigured)
+{
+    EXPECT_EQ(view->frameShape(), QFrame::NoFrame);
+    EXPECT_EQ(view->horizontalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(view->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_TRUE(view->isInteractive());
+    EXPECT_EQ(view->transformationAnchor(), QGraphicsView::AnchorUnderMouse);
+    EXPECT_EQ(view->viewportUpdateMode(), QGraphicsView::FullViewportUpdate);
+    EXPECT_TRUE(view->renderHints().testFlag(QPainter::SmoothPixmapTransform));
+    EXPECT_EQ(view->backgroundBrush(), QBrush(Qt::white));
+    EXPECT_EQ(view->dragMode(), QGraphicsView::ScrollHandDrag);
+    ASSERT_EQ(view->scaleFactorLabel->isVisibleTo(view), false);
+}
+
+TEST_F(UT_IconPreviewView, WheelEvent_ScrollUp_ZoomsInAndShowsScaleLabel)
+{
+    QWheelEvent event = makeWheelEvent(240);
+    EXPECT_TRUE(QApplication::sendEvent(view->viewport(), &event));
+    EXPECT_NEAR(view->transform().m11(), 1.2, 0.001);
+    EXPECT_FALSE(view->scaleFactorLabel->isHidden());
+    EXPECT_EQ(view->scaleFactorLabel->text(), QString("120%"));
+}
+
+TEST_F(UT_IconPreviewView, WheelEvent_ScrollDown_ZoomsOutAndShowsScaleLabel)
+{
+    QWheelEvent event = makeWheelEvent(-240);
+    EXPECT_TRUE(QApplication::sendEvent(view->viewport(), &event));
+    EXPECT_NEAR(view->transform().m11(), 1.0 / 1.2, 0.001);
+    EXPECT_FALSE(view->scaleFactorLabel->isHidden());
+    EXPECT_EQ(view->scaleFactorLabel->text(), QString("83%"));
+}
+
+TEST_F(UT_IconPreviewView, WheelEvent_LargeUpDelta_ScaleFactorCappedToUpperBound)
+{
+    QWheelEvent event = makeWheelEvent(240 * 38);
+    EXPECT_TRUE(QApplication::sendEvent(view->viewport(), &event));
+    EXPECT_NEAR(view->transform().m11(), 1000.0, 0.5);
+    EXPECT_EQ(view->scaleFactorLabel->text(), QString("100000%"));
+}
+
+TEST_F(UT_IconPreviewView, WheelEvent_LargeDownDelta_ScaleFactorCappedToLowerBound)
+{
+    QWheelEvent event = makeWheelEvent(-240 * 38);
+    EXPECT_TRUE(QApplication::sendEvent(view->viewport(), &event));
+    EXPECT_NEAR(view->transform().m11(), 0.001, 0.0005);
+    EXPECT_EQ(view->scaleFactorLabel->text(), QString("0%"));
+}
+
+TEST_F(UT_IconPreviewView, WheelEvent_AfterTimeout_ScaleLabelHidden)
+{
+    QWheelEvent event = makeWheelEvent(240);
+    QApplication::sendEvent(view->viewport(), &event);
+    EXPECT_FALSE(view->scaleFactorLabel->isHidden());
+
+    QTest::qWait(1100);
+    EXPECT_TRUE(view->scaleFactorLabel->isHidden());
+}
+
+TEST_F(UT_IconPreviewView, DrawBackground_PlainColorBrush_RendersRoundedBackground)
+{
+    auto *graphicsScene = new QGraphicsScene(view);
+    graphicsScene->setSceneRect(0, 0, 200, 150);
+    view->setScene(graphicsScene);
+    view->resize(200, 150);
+
+    QPixmap pm(200, 150);
+    pm.fill(Qt::transparent);
+    EXPECT_NO_FATAL_FAILURE(view->QWidget::render(&pm));
+    EXPECT_EQ(pm.toImage().pixelColor(100, 75).alpha(), 255);
+}
+
+TEST_F(UT_IconPreviewView, DrawBackground_TextureBrush_RendersTiledTexture)
+{
+    QPixmap texture(32, 32);
+    texture.fill(Qt::red);
+    view->setBackgroundBrush(QBrush(texture));
+    auto *graphicsScene = new QGraphicsScene(view);
+    graphicsScene->setSceneRect(0, 0, 200, 150);
+    view->setScene(graphicsScene);
+    view->resize(200, 150);
+
+    QPixmap pm(200, 150);
+    pm.fill(Qt::transparent);
+    EXPECT_NO_FATAL_FAILURE(view->QWidget::render(&pm));
+    EXPECT_EQ(pm.toImage().pixelColor(100, 75), QColor(Qt::red));
+}
+
+TEST_F(UT_DDciIconPreview, Construction_DefaultState_AllFieldsEmpty)
+{
+    EXPECT_TRUE(preview->title().isEmpty());
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+    EXPECT_EQ(preview->statusBarWidget(), nullptr);
+    EXPECT_EQ(preview->view, nullptr);
+    EXPECT_EQ(preview->scene, nullptr);
+    // 源码缺陷: DDciIconPreview 构造函数初始化列表遗漏了 iconItem，该指针构造后为
+    // 未初始化的野指针（运行时观测到非空垃圾值），无法对其做确定性断言，故跳过
+    // EXPECT_EQ(preview->iconItem, nullptr);
+    EXPECT_EQ(preview->mainWidget, nullptr);
+    EXPECT_EQ(preview->controlWidget, nullptr);
+    EXPECT_EQ(preview->dciIcon, nullptr);
+    EXPECT_EQ(preview->dciIconMatched, nullptr);
+    EXPECT_FALSE(preview->updateTimer.isActive());
+}
+
+TEST_F(UT_DDciIconPreview, InitControlWidgets_WithMainWidget_BuildsAllControlPanels)
+{
+    preview->mainWidget = new QWidget();
+    preview->initControlWidgets();
+
+    ASSERT_NE(preview->controlWidget, nullptr);
+    EXPECT_EQ(preview->controlWidget->focusPolicy(), Qt::ClickFocus);
+    EXPECT_NE(preview->availableSizeCombo, nullptr);
+    EXPECT_EQ(preview->availableSizeCombo->count(), 1);
+    EXPECT_NE(preview->devicePixelRatioLabel, nullptr);
+    EXPECT_NE(preview->themeCom, nullptr);
+    EXPECT_EQ(preview->themeCom->count(), 2);
+    EXPECT_NE(preview->modeCom, nullptr);
+    EXPECT_EQ(preview->modeCom->count(), 4);
+    EXPECT_NE(preview->paletteWidget, nullptr);
+    EXPECT_NE(preview->foregroundPaletteEdit, nullptr);
+    EXPECT_NE(preview->backgroundPaletteEdit, nullptr);
+    EXPECT_NE(preview->hightlightPaletteEdit, nullptr);
+    EXPECT_NE(preview->hFPaletteEdit, nullptr);
+    EXPECT_NE(preview->customSizeEdit, nullptr);
+    EXPECT_EQ(preview->controlWidget->findChildren<QSlider *>().size(), 1);
+
+    preview->updateTimer.stop();
+    delete preview->mainWidget;
+    preview->mainWidget = nullptr;
+    preview->controlWidget = nullptr;
+    preview->availableSizeCombo = nullptr;
+    preview->devicePixelRatioLabel = nullptr;
+    preview->themeCom = nullptr;
+    preview->modeCom = nullptr;
+    preview->paletteWidget = nullptr;
+    preview->paletteNosupportedText = nullptr;
+    preview->foregroundPaletteEdit = nullptr;
+    preview->backgroundPaletteEdit = nullptr;
+    preview->hightlightPaletteEdit = nullptr;
+    preview->hFPaletteEdit = nullptr;
+    preview->customSizeEdit = nullptr;
+}
+
+TEST_F(UT_DDciIconPreview, InitPreviewWidgets_Standalone_CreatesViewSceneAndIconItem)
+{
+    preview->initPreviewWidgets();
+
+    ASSERT_NE(preview->view, nullptr);
+    ASSERT_NE(preview->scene, nullptr);
+    ASSERT_NE(preview->iconItem, nullptr);
+    EXPECT_EQ(preview->view->scene(), preview->scene);
+    EXPECT_EQ(preview->scene->items().size(), 1);
+    EXPECT_EQ(preview->scene->items().first(), preview->iconItem);
+    EXPECT_EQ(preview->iconItem->transformationMode(), Qt::SmoothTransformation);
+    EXPECT_FALSE(preview->iconItem->flags() & QGraphicsItem::ItemIsSelectable);
+    EXPECT_FALSE(preview->iconItem->flags() & QGraphicsItem::ItemIsMovable);
+    EXPECT_EQ(preview->iconItem->shapeMode(), QGraphicsPixmapItem::BoundingRectShape);
+
+    delete preview->view;
+    preview->view = nullptr;
+    preview->scene = nullptr;
+    preview->iconItem = nullptr;
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, Initialize_WithNullParents_CreatesMainWidgetWithSplitter)
+{
+    EXPECT_NE(preview->contentWidget(), nullptr);
+    EXPECT_EQ(preview->contentWidget(), preview->mainWidget);
+    EXPECT_EQ(preview->mainWidget->size(), QSize(1200, 800));
+    auto splitters = preview->mainWidget->findChildren<QSplitter *>();
+    ASSERT_EQ(splitters.size(), 1);
+    EXPECT_EQ(splitters.first()->count(), 2);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, Title_BeforeFileUrlSet_ReturnsEmptyString)
+{
+    EXPECT_TRUE(preview->title().isEmpty());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, StatusBarWidget_AnyState_ReturnsNull)
+{
+    EXPECT_EQ(preview->statusBarWidget(), nullptr);
+}
+
+// 真实行为: 新建预览的初始 url 为空，setFileUrl(空URL) 命中 this->url == url 的
+// “URL 未变化”短路分支直接返回 true，空 URL 不会被拒绝（疑似源码缺陷：空路径未校验即返回成功）
+TEST_F(UT_DDciIconPreviewInitialized, SetFileUrl_EmptyUrlOnFreshPreview_TreatedAsUnchangedReturnsTrue)
+{
+    EXPECT_TRUE(preview->setFileUrl(QUrl()));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_TRUE(preview->title().isEmpty());
+    EXPECT_EQ(preview->dciIcon, nullptr);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, SetFileUrl_NotDciExtension_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/ut_dciicon_not_dci.txt");
+    EXPECT_FALSE(preview->setFileUrl(url));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, SetFileUrl_RemoteHttpUrl_ReturnsFalse)
+{
+    QUrl url("http://example.com/icon.dci");
+    EXPECT_FALSE(preview->setFileUrl(url));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, SetFileUrl_TextContentDciFile_ReturnsFalse)
+{
+    const QString path = createTempDciFile("plain text content for mime sniffing\n");
+    QUrl url = QUrl::fromLocalFile(path);
+    EXPECT_FALSE(preview->setFileUrl(url));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_TRUE(preview->title().isEmpty());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, SetFileUrl_ValidDciFile_LoadsSettingsAndSetsTitle)
+{
+    stub.set_lamda(ADDR(QMimeType, preferredSuffix), [](const QMimeType *) {
+        __DBG_STUB_INVOKE__
+        return QString("dci");
+    });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->availableSizeCombo->clear();
+    preview->availableSizeCombo->insertItem(0, "Custom Size");
+    preview->updateTimer.stop();
+
+    const QString path = createTempDciFile("DCI-UNIT-TEST-GARBAGE");
+    QUrl url = QUrl::fromLocalFile(path);
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(path));
+    EXPECT_EQ(preview->title(), QString("ut_dciicon_preview_temp.dci"));
+    EXPECT_NE(preview->dciIcon, nullptr);
+    EXPECT_EQ(preview->availableSizeCombo->count(), 3);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, SetFileUrl_SameUrlTwice_SkipsReloading)
+{
+    stub.set_lamda(ADDR(QMimeType, preferredSuffix), [](const QMimeType *) {
+        __DBG_STUB_INVOKE__
+        return QString("dci");
+    });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->availableSizeCombo->clear();
+    preview->availableSizeCombo->insertItem(0, "Custom Size");
+    preview->updateTimer.stop();
+
+    const QString path = createTempDciFile("DCI-UNIT-TEST-GARBAGE");
+    QUrl url = QUrl::fromLocalFile(path);
+    ASSERT_TRUE(preview->setFileUrl(url));
+
+    int reloadCount = 0;
+    stub.set_lamda(&DDciIconPreview::initializeSettings, [&reloadCount](DDciIconPreview *, const QString &) {
+        __DBG_STUB_INVOKE__
+        reloadCount++;
+    });
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(reloadCount, 0);
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(path));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, SetFileUrl_DifferentInvalidUrlAfterValid_KeepsPreviousUrl)
+{
+    stub.set_lamda(ADDR(QMimeType, preferredSuffix), [](const QMimeType *) {
+        __DBG_STUB_INVOKE__
+        return QString("dci");
+    });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->availableSizeCombo->clear();
+    preview->availableSizeCombo->insertItem(0, "Custom Size");
+    preview->updateTimer.stop();
+
+    const QString path = createTempDciFile("DCI-UNIT-TEST-GARBAGE");
+    QUrl validUrl = QUrl::fromLocalFile(path);
+    ASSERT_TRUE(preview->setFileUrl(validUrl));
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile("/tmp/ut_dciicon_other.txt")));
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(path));
+    EXPECT_EQ(preview->title(), QString("ut_dciicon_preview_temp.dci"));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, InitializeSettings_EmptyPath_ReturnsEarlyWithoutLoadingIcon)
+{
+    preview->initializeSettings("");
+    EXPECT_EQ(preview->dciIcon, nullptr);
+    EXPECT_TRUE(preview->iconItem->pixmap().isNull());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, InitializeSettings_UnloadableIconFile_LeavesDanglingNonNullPointer)
+{
+    const QString path = createTempDciFile("DEFINITELY-NOT-A-DCI-FILE");
+    preview->initializeSettings(path);
+
+    EXPECT_NE(preview->dciIcon, nullptr);
+    preview->dciIcon = nullptr;
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, InitializeSettings_ValidIcon_PopulatesAvailableSizes)
+{
+    loadFakeIconSuccessfully(QList<int> { 16, 32, 48 });
+
+    EXPECT_NE(preview->dciIcon, nullptr);
+    EXPECT_EQ(preview->availableSizeCombo->count(), 4);
+    EXPECT_EQ(preview->availableSizeCombo->itemText(0), QString("16"));
+    EXPECT_EQ(preview->availableSizeCombo->itemText(1), QString("32"));
+    EXPECT_EQ(preview->availableSizeCombo->itemText(2), QString("48"));
+    EXPECT_EQ(preview->availableSizeCombo->itemText(3), QString("Custom Size"));
+    EXPECT_EQ(preview->availableSizeCombo->currentIndex(), 0);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, GenerateDciIconPalette_CustomColorTexts_ReturnsMatchingPalette)
+{
+    preview->foregroundPaletteEdit->setText("#112233");
+    preview->backgroundPaletteEdit->setText("#445566");
+    preview->hightlightPaletteEdit->setText("#778899");
+    preview->hFPaletteEdit->setText("#aabbcc");
+
+    DDciIconPalette palette = preview->generateDciIconPalette();
+    EXPECT_EQ(palette.foreground(), QColor("#112233"));
+    EXPECT_EQ(palette.background(), QColor("#445566"));
+    EXPECT_EQ(palette.highlight(), QColor("#778899"));
+    EXPECT_EQ(palette.highlightForeground(), QColor("#aabbcc"));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdateIconMatchedResult_NoIconLoaded_ReturnsEarly)
+{
+    preview->dciIconMatched = reinterpret_cast<DDciIconMatchResult>(0x1);
+    preview->updateIconMatchedResult();
+    EXPECT_EQ(preview->dciIconMatched, reinterpret_cast<DDciIconMatchResult>(0x1));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdateIconMatchedResult_ZeroIconSize_ResetsMatchedToNull)
+{
+    int matchIconCalls = 0;
+    stub.set_lamda(ADDR(DDciIcon, matchIcon),
+                   [&matchIconCalls](const DDciIcon *, int, DDciIcon::Theme, DDciIcon::Mode, DDciIcon::IconMatchedFlags) {
+                       __DBG_STUB_INVOKE__
+                       matchIconCalls++;
+                       return reinterpret_cast<DDciIconMatchResult>(0x1);
+                   });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+
+    preview->availableSizeCombo->setCurrentIndex(preview->availableSizeCombo->count() - 1);
+    preview->customSizeEdit->setText("");
+
+    preview->updateIconMatchedResult();
+    EXPECT_EQ(preview->dciIconMatched, nullptr);
+    EXPECT_EQ(matchIconCalls, 0);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdateIconMatchedResult_ValidInputs_MatchesSelectedThemeAndMode)
+{
+    int capturedSize = -1;
+    DDciIcon::Theme capturedTheme = DDciIcon::Light;
+    DDciIcon::Mode capturedMode = DDciIcon::Normal;
+    DDciIcon::IconMatchedFlags capturedFlags;
+    stub.set_lamda(ADDR(DDciIcon, matchIcon),
+                   [&capturedSize, &capturedTheme, &capturedMode, &capturedFlags](const DDciIcon *, int size, DDciIcon::Theme theme, DDciIcon::Mode mode, DDciIcon::IconMatchedFlags flags) {
+                       __DBG_STUB_INVOKE__
+                       capturedSize = size;
+                       capturedTheme = theme;
+                       capturedMode = mode;
+                       capturedFlags = flags;
+                       return reinterpret_cast<DDciIconMatchResult>(0x1234);
+                   });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+
+    preview->themeCom->setCurrentIndex(1);
+    preview->modeCom->setCurrentIndex(2);
+    preview->updateIconMatchedResult();
+
+    EXPECT_EQ(capturedSize, 16);
+    EXPECT_EQ(capturedTheme, DDciIcon::Dark);
+    EXPECT_EQ(capturedMode, DDciIcon::Mode(2));
+    EXPECT_TRUE(capturedFlags & DDciIcon::DontFallbackMode);
+    EXPECT_EQ(preview->dciIconMatched, reinterpret_cast<DDciIconMatchResult>(0x1234));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdatePixmap_TimerNotActive_SchedulesDelayedUpdate)
+{
+    preview->updatePixmap();
+    EXPECT_TRUE(preview->updateTimer.isActive());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdatePixmap_TimerAlreadyActive_SecondRequestIgnored)
+{
+    int implCalls = 0;
+    stub.set_lamda(&DDciIconPreview::updatePixmapImpl, [&implCalls](DDciIconPreview *) {
+        __DBG_STUB_INVOKE__
+        implCalls++;
+    });
+
+    preview->updatePixmap();
+    preview->updatePixmap();
+    QTest::qWait(150);
+
+    EXPECT_EQ(implCalls, 1);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdatePixmapImpl_NoMatchedResult_ShowsInvalidPixmap)
+{
+    preview->updatePixmapImpl();
+    EXPECT_EQ(preview->iconItem->pixmap().size(), QSize(150, 80));
+    EXPECT_TRUE(preview->paletteWidget->isEnabled());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdatePixmapImpl_MatchedButZeroIconSize_ShowsInvalidPixmap)
+{
+    stub.set_lamda(ADDR(DDciIcon, matchIcon), [](const DDciIcon *, int, DDciIcon::Theme, DDciIcon::Mode, DDciIcon::IconMatchedFlags) {
+        __DBG_STUB_INVOKE__
+        return reinterpret_cast<DDciIconMatchResult>(0x1);
+    });
+    stub.set_lamda(static_cast<bool (DDciIcon::*)(DDciIconMatchResult, DDciIcon::IconAttribute) const>(&DDciIcon::isSupportedAttribute),
+                   [](const DDciIcon *, DDciIconMatchResult, DDciIcon::IconAttribute) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->updateIconMatchedResult();
+
+    preview->availableSizeCombo->setCurrentIndex(preview->availableSizeCombo->count() - 1);
+    preview->customSizeEdit->setText("");
+
+    preview->updatePixmapImpl();
+    EXPECT_EQ(preview->iconItem->pixmap().size(), QSize(150, 80));
+    EXPECT_TRUE(preview->paletteWidget->isEnabled());
+    EXPECT_TRUE(preview->paletteNosupportedText->isHidden());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdatePixmapImpl_ZeroDevicePixelRatio_ShowsInvalidPixmap)
+{
+    stub.set_lamda(ADDR(DDciIcon, matchIcon), [](const DDciIcon *, int, DDciIcon::Theme, DDciIcon::Mode, DDciIcon::IconMatchedFlags) {
+        __DBG_STUB_INVOKE__
+        return reinterpret_cast<DDciIconMatchResult>(0x1);
+    });
+    stub.set_lamda(static_cast<bool (DDciIcon::*)(DDciIconMatchResult, DDciIcon::IconAttribute) const>(&DDciIcon::isSupportedAttribute),
+                   [](const DDciIcon *, DDciIconMatchResult, DDciIcon::IconAttribute) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->updateIconMatchedResult();
+
+    preview->devicePixelRatioLabel->setText("0");
+
+    preview->updatePixmapImpl();
+    EXPECT_EQ(preview->iconItem->pixmap().size(), QSize(150, 80));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdatePixmapImpl_AllValid_RendersIconPixmap)
+{
+    stub.set_lamda(ADDR(DDciIcon, matchIcon), [](const DDciIcon *, int, DDciIcon::Theme, DDciIcon::Mode, DDciIcon::IconMatchedFlags) {
+        __DBG_STUB_INVOKE__
+        return reinterpret_cast<DDciIconMatchResult>(0x1);
+    });
+    stub.set_lamda(static_cast<bool (DDciIcon::*)(DDciIconMatchResult, DDciIcon::IconAttribute) const>(&DDciIcon::isSupportedAttribute),
+                   [](const DDciIcon *, DDciIconMatchResult, DDciIcon::IconAttribute) {
+                       __DBG_STUB_INVOKE__
+                       return true;
+                   });
+    bool pixmapGenerated = false;
+    stub.set_lamda(static_cast<QPixmap (DDciIcon::*)(qreal, int, DDciIconMatchResult, const DDciIconPalette &) const>(&DDciIcon::pixmap),
+                   [&pixmapGenerated](const DDciIcon *, qreal, int size, DDciIconMatchResult, const DDciIconPalette &) {
+                       __DBG_STUB_INVOKE__
+                       pixmapGenerated = true;
+                       QPixmap pm(size, size);
+                       pm.fill(Qt::red);
+                       return pm;
+                   });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->updateIconMatchedResult();
+    preview->devicePixelRatioLabel->setText("1");
+
+    preview->updatePixmapImpl();
+
+    EXPECT_TRUE(pixmapGenerated);
+    EXPECT_EQ(preview->iconItem->pixmap().size(), QSize(16, 16));
+    EXPECT_TRUE(preview->paletteWidget->isEnabled());
+    EXPECT_TRUE(preview->paletteNosupportedText->isHidden());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, UpdatePixmapImpl_PaletteNotSupported_DisablesPaletteControls)
+{
+    stub.set_lamda(ADDR(DDciIcon, matchIcon), [](const DDciIcon *, int, DDciIcon::Theme, DDciIcon::Mode, DDciIcon::IconMatchedFlags) {
+        __DBG_STUB_INVOKE__
+        return reinterpret_cast<DDciIconMatchResult>(0x1);
+    });
+    stub.set_lamda(static_cast<bool (DDciIcon::*)(DDciIconMatchResult, DDciIcon::IconAttribute) const>(&DDciIcon::isSupportedAttribute),
+                   [](const DDciIcon *, DDciIconMatchResult, DDciIcon::IconAttribute) {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(static_cast<QPixmap (DDciIcon::*)(qreal, int, DDciIconMatchResult, const DDciIconPalette &) const>(&DDciIcon::pixmap),
+                   [](const DDciIcon *, qreal, int size, DDciIconMatchResult, const DDciIconPalette &) {
+                       __DBG_STUB_INVOKE__
+                       QPixmap pm(size, size);
+                       pm.fill(Qt::red);
+                       return pm;
+                   });
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->updateIconMatchedResult();
+    preview->devicePixelRatioLabel->setText("1");
+
+    preview->updatePixmapImpl();
+
+    EXPECT_FALSE(preview->paletteWidget->isEnabled());
+    EXPECT_FALSE(preview->paletteNosupportedText->isHidden());
+    EXPECT_EQ(preview->iconItem->pixmap().size(), QSize(16, 16));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, EventFilter_ViewResize_UpdatesSceneRectAndRecentersItem)
+{
+    QResizeEvent resizeEvent(QSize(500, 400), QSize(400, 300));
+    EXPECT_FALSE(preview->eventFilter(preview->view, &resizeEvent));
+    EXPECT_EQ(preview->scene->sceneRect(), QRectF(0, 0, 500, 400));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, EventFilter_OtherObjectWatched_IgnoredWithoutSideEffect)
+{
+    QResizeEvent resizeEvent(QSize(500, 400), QSize(400, 300));
+    EXPECT_FALSE(preview->eventFilter(preview->mainWidget, &resizeEvent));
+    EXPECT_EQ(preview->scene->sceneRect(), QRectF());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, TimerEvent_UpdateTimerFires_RunsUpdatePixmapImplOnce)
+{
+    int implCalls = 0;
+    stub.set_lamda(&DDciIconPreview::updatePixmapImpl, [&implCalls](DDciIconPreview *) {
+        __DBG_STUB_INVOKE__
+        implCalls++;
+    });
+
+    preview->updatePixmap();
+    QTest::qWait(150);
+
+    EXPECT_EQ(implCalls, 1);
+    EXPECT_FALSE(preview->updateTimer.isActive());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, TimerEvent_UnrelatedTimerId_Ignored)
+{
+    int implCalls = 0;
+    stub.set_lamda(&DDciIconPreview::updatePixmapImpl, [&implCalls](DDciIconPreview *) {
+        __DBG_STUB_INVOKE__
+        implCalls++;
+    });
+
+    QTimerEvent unrelatedEvent(123456);
+    EXPECT_NO_FATAL_FAILURE(preview->timerEvent(&unrelatedEvent));
+    EXPECT_EQ(implCalls, 0);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, GetIconSize_NumericComboCurrent_ReturnsSelectedSize)
+{
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    EXPECT_EQ(preview->getIconSize(), 16);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, GetIconSize_CustomIndexWithText_ReturnsCustomSize)
+{
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->availableSizeCombo->setCurrentIndex(preview->availableSizeCombo->count() - 1);
+    preview->customSizeEdit->setText("72");
+    EXPECT_EQ(preview->getIconSize(), 72);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, GetIconSize_CustomIndexEmptyText_ReturnsZero)
+{
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    preview->availableSizeCombo->setCurrentIndex(preview->availableSizeCombo->count() - 1);
+    preview->customSizeEdit->setText("");
+    EXPECT_EQ(preview->getIconSize(), 0);
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, AvailableSizeCombo_SelectCustomIndex_ShowsCustomSizeEdit)
+{
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    EXPECT_TRUE(preview->customSizeEdit->isHidden());
+
+    preview->availableSizeCombo->setCurrentIndex(preview->availableSizeCombo->count() - 1);
+    EXPECT_FALSE(preview->customSizeEdit->isHidden());
+
+    preview->updateTimer.stop();
+    preview->availableSizeCombo->setCurrentIndex(0);
+    EXPECT_TRUE(preview->customSizeEdit->isHidden());
+    EXPECT_TRUE(preview->updateTimer.isActive());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, CustomSizeEdit_EditingFinished_SchedulesDelayedUpdate)
+{
+    preview->updateTimer.stop();
+    preview->customSizeEdit->setText("100");
+    emit preview->customSizeEdit->editingFinished();
+    EXPECT_TRUE(preview->updateTimer.isActive());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, DevicePixelSlider_ValueChanged_UpdatesRatioLabelAndSchedulesUpdate)
+{
+    auto sliders = preview->controlWidget->findChildren<QSlider *>();
+    ASSERT_EQ(sliders.size(), 1);
+
+    preview->updateTimer.stop();
+    sliders.first()->setValue(25);
+    EXPECT_EQ(preview->devicePixelRatioLabel->text(), QString("2.5"));
+    EXPECT_TRUE(preview->updateTimer.isActive());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, BackgroundColorCombo_SelectPresetColors_UpdatesViewBackground)
+{
+    QComboBox *backgroundCombo = nullptr;
+    for (QComboBox *combo : preview->controlWidget->findChildren<QComboBox *>()) {
+        if (combo->objectName().isEmpty() && combo->count() == 4)
+            backgroundCombo = combo;
+    }
+    ASSERT_NE(backgroundCombo, nullptr);
+
+    backgroundCombo->setCurrentIndex(0);
+    EXPECT_EQ(preview->view->backgroundBrush().color(), QColor(Qt::white));
+
+    backgroundCombo->setCurrentIndex(1);
+    EXPECT_EQ(preview->view->backgroundBrush().color(), QColor(Qt::black));
+
+    backgroundCombo->setCurrentIndex(2);
+    EXPECT_FALSE(preview->view->backgroundBrush().texture().isNull());
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, BackgroundColorCombo_CustomColorApplied_UpdatesViewBackground)
+{
+    QComboBox *backgroundCombo = nullptr;
+    for (QComboBox *combo : preview->controlWidget->findChildren<QComboBox *>()) {
+        if (combo->objectName().isEmpty() && combo->count() == 4)
+            backgroundCombo = combo;
+    }
+    ASSERT_NE(backgroundCombo, nullptr);
+    backgroundCombo->setCurrentIndex(3);
+
+    QLineEdit *customBackgroundEdit = nullptr;
+    for (QLineEdit *edit : preview->controlWidget->findChildren<QLineEdit *>()) {
+        if (edit->objectName().isEmpty())
+            customBackgroundEdit = edit;
+    }
+    ASSERT_NE(customBackgroundEdit, nullptr);
+    EXPECT_FALSE(customBackgroundEdit->isHidden());
+
+    customBackgroundEdit->setText("#123456");
+    emit customBackgroundEdit->editingFinished();
+    EXPECT_EQ(preview->view->backgroundBrush().color(), QColor("#123456"));
+
+    customBackgroundEdit->setText("not-a-color");
+    emit customBackgroundEdit->editingFinished();
+    EXPECT_EQ(preview->view->backgroundBrush().color(), QColor("#123456"));
+}
+
+TEST_F(UT_DDciIconPreviewInitialized, Destruction_AfterLoadingIcon_DeletesIconSafely)
+{
+    loadFakeIconSuccessfully(QList<int> { 16, 32 });
+    ASSERT_NE(preview->dciIcon, nullptr);
+    QWidget *main = preview->mainWidget;
+    EXPECT_NO_FATAL_FAILURE(delete preview);
+    preview = nullptr;
+    delete main;
+}
+
+#endif   // DTKGUI_CLASS_DDciIcon

--- a/autotests/apps/dde-file-manager-preview/image-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/image-preview/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Unit tests for image-preview: recompile plugin sources into the test binary
+# so stub-ext can access private members (see autotests/README.md).
+set(_preview_dir "${DFM_PREVIEW_PLUGIN_DIR}/image-preview")
+
+file(GLOB_RECURSE _ut_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+file(GLOB_RECURSE _plugin_files
+    "${_preview_dir}/*.cpp"
+    "${_preview_dir}/*.h")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+
+dfm_create_test_executable(ut-image-preview
+    SOURCES ${_ut_files} ${_plugin_files}
+    LINK_LIBRARIES DFM6::base DFM6::framework Qt6::Widgets 
+)
+
+target_include_directories(ut-image-preview PRIVATE
+    "${DFM_PREVIEW_PLUGIN_DIR}"
+    ${_preview_dir}
+)
+

--- a/autotests/apps/dde-file-manager-preview/image-preview/main.cpp
+++ b/autotests/apps/dde-file-manager-preview/image-preview/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(image_preview)

--- a/autotests/apps/dde-file-manager-preview/image-preview/test_imagepreview.cpp
+++ b/autotests/apps/dde-file-manager-preview/image-preview/test_imagepreview.cpp
@@ -1,0 +1,334 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "imagepreview.h"
+#include "imagepreviewplugin.h"
+#include "imageview.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QDir>
+#include <QFile>
+#include <QIcon>
+#include <QLabel>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <QWidget>
+
+#include <mutex>
+
+DFMBASE_USE_NAMESPACE
+using namespace plugin_filepreview;
+
+class UT_ImagePreview : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        preview = new ImagePreview();
+        window = new QWidget();
+        statusBar = new QWidget();
+    }
+
+    void TearDown() override
+    {
+        delete preview;
+        delete statusBar;
+        delete window;
+        qApp->processEvents();
+        stub.clear();
+    }
+
+    QString makeImageFile(const QString &name, int width, int height, const char *format)
+    {
+        QImage image(width, height, QImage::Format_ARGB32);
+        image.fill(Qt::red);
+        const QString &path = dir.filePath(name);
+        if (!image.save(path, format))
+            return QString();
+        return path;
+    }
+
+    QString makeTextFile(const QString &name, const QByteArray &content)
+    {
+        const QString &path = dir.filePath(name);
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly))
+            return QString();
+        file.write(content);
+        file.close();
+        return path;
+    }
+
+protected:
+    ImagePreview *preview { nullptr };
+    QWidget *window { nullptr };
+    QWidget *statusBar { nullptr };
+    QTemporaryDir dir;
+    stub_ext::StubExt stub;
+    static std::once_flag flag;
+};
+
+std::once_flag UT_ImagePreview::flag;
+
+TEST_F(UT_ImagePreview, Construct_FreshInstance_AllAccessorsReturnDefaults)
+{
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+    EXPECT_TRUE(preview->title().isEmpty());
+    EXPECT_EQ(preview->statusBarWidget(), nullptr);
+    EXPECT_EQ(static_cast<int>(preview->statusBarWidgetAlignment()), 0);
+}
+
+TEST_F(UT_ImagePreview, Initialize_WithStatusBar_CreatesConfiguredLabel)
+{
+    preview->initialize(window, statusBar);
+
+    QWidget *widget = preview->statusBarWidget();
+    ASSERT_NE(widget, nullptr);
+    auto *label = qobject_cast<QLabel *>(widget);
+    ASSERT_NE(label, nullptr);
+    EXPECT_EQ(label->parentWidget(), statusBar);
+    EXPECT_EQ(label->font().pixelSize(), 12);
+    EXPECT_EQ(label->sizePolicy().horizontalPolicy(), QSizePolicy::Expanding);
+    EXPECT_EQ(label->sizePolicy().verticalPolicy(), QSizePolicy::Preferred);
+    EXPECT_EQ(static_cast<int>(label->alignment()), static_cast<int>(Qt::AlignCenter));
+    EXPECT_FALSE(label->isHidden());
+}
+
+TEST_F(UT_ImagePreview, CanPreview_ValidPngFile_ReturnsTrueAndFillsFormat)
+{
+    const QString &path = makeImageFile("sample.png", 64, 48, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+
+    QByteArray format;
+    EXPECT_TRUE(preview->canPreview(QUrl::fromLocalFile(path), &format));
+    EXPECT_EQ(format, QByteArray("png"));
+}
+
+TEST_F(UT_ImagePreview, CanPreview_ValidJpegFile_ReturnsTrueAndFillsFormat)
+{
+    const QString &path = makeImageFile("photo.jpg", 32, 32, "JPG");
+    ASSERT_FALSE(path.isEmpty());
+
+    QByteArray format;
+    EXPECT_TRUE(preview->canPreview(QUrl::fromLocalFile(path), &format));
+    EXPECT_EQ(format, QByteArray("jpeg"));
+}
+
+TEST_F(UT_ImagePreview, CanPreview_NonImageFile_ReturnsFalseWithMimeSuffix)
+{
+    const QString &path = makeTextFile("notes.txt", "plain text content");
+    ASSERT_FALSE(path.isEmpty());
+
+    QByteArray format;
+    EXPECT_FALSE(preview->canPreview(QUrl::fromLocalFile(path), &format));
+    EXPECT_EQ(format, QByteArray("txt"));
+}
+
+TEST_F(UT_ImagePreview, CanPreview_NonExistentFile_ReturnsFalseWithEmptyFormat)
+{
+    QByteArray format("sentinel");
+    EXPECT_FALSE(preview->canPreview(QUrl::fromLocalFile(dir.filePath("missing.png")), &format));
+    EXPECT_TRUE(format.isEmpty());
+}
+
+TEST_F(UT_ImagePreview, CanPreview_NullFormatPointer_ReturnsTrueWithoutCrash)
+{
+    const QString &path = makeImageFile("nopointer.png", 16, 16, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+
+    EXPECT_TRUE(preview->canPreview(QUrl::fromLocalFile(path)));
+}
+
+TEST_F(UT_ImagePreview, SetFileUrl_UnknownScheme_ReturnsFalseAndKeepsState)
+{
+    QSignalSpy spy(preview, SIGNAL(titleChanged()));
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl("fake://somehost/image.png")));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+    EXPECT_TRUE(preview->title().isEmpty());
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_ImagePreview, SetFileUrl_NonExistentLocalFile_ReturnsFalse)
+{
+    QSignalSpy spy(preview, SIGNAL(titleChanged()));
+    preview->initialize(window, statusBar);
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(dir.filePath("missing.png"))));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_ImagePreview, SetFileUrl_NonImageLocalFile_ReturnsFalse)
+{
+    const QString &path = makeTextFile("document.txt", "not an image at all");
+    ASSERT_FALSE(path.isEmpty());
+    preview->initialize(window, statusBar);
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_TRUE(preview->title().isEmpty());
+}
+
+TEST_F(UT_ImagePreview, SetFileUrl_RedirectedToNonLocalUrl_ReturnsFalse)
+{
+    const QString &path = makeImageFile("redirected.png", 64, 48, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+    preview->initialize(window, statusBar);
+
+    stub.set_lamda(VADDR(SyncFileInfo, canAttributes),
+                   [](SyncFileInfo *, CanableInfoType) -> bool { return true; });
+    stub.set_lamda(VADDR(SyncFileInfo, urlOf),
+                   [](SyncFileInfo *, UrlInfoType) -> QUrl { return QUrl("http://example.com/remote.png"); });
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+}
+
+TEST_F(UT_ImagePreview, SetFileUrl_ValidPng_ReturnsTrueAndUpdatesAllState)
+{
+    const QString &path = makeImageFile("valid.png", 64, 48, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+    preview->initialize(window, statusBar);
+    QSignalSpy spy(preview, SIGNAL(titleChanged()));
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(path));
+    EXPECT_EQ(preview->title(), QString("valid.png"));
+    ASSERT_NE(preview->contentWidget(), nullptr);
+    EXPECT_NE(qobject_cast<ImageView *>(preview->contentWidget()), nullptr);
+    EXPECT_EQ(qobject_cast<QLabel *>(preview->statusBarWidget())->text(), QString("64x48"));
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ImagePreview, SetFileUrl_SameUrlTwice_ReturnsTrueWithoutReloading)
+{
+    const QString &path = makeImageFile("same.png", 64, 48, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+    preview->initialize(window, statusBar);
+    QSignalSpy spy(preview, SIGNAL(titleChanged()));
+
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(spy.count(), 1);
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(preview->title(), QString("same.png"));
+}
+
+TEST_F(UT_ImagePreview, SetFileUrl_DifferentValidFile_ReusesImageViewAndUpdatesState)
+{
+    const QString &firstPath = makeImageFile("first.png", 64, 48, "PNG");
+    const QString &secondPath = makeImageFile("second.png", 32, 24, "PNG");
+    ASSERT_FALSE(firstPath.isEmpty());
+    ASSERT_FALSE(secondPath.isEmpty());
+    preview->initialize(window, statusBar);
+
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(firstPath)));
+    QWidget *firstWidget = preview->contentWidget();
+    ASSERT_NE(firstWidget, nullptr);
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(secondPath)));
+    EXPECT_EQ(preview->contentWidget(), firstWidget);
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(secondPath));
+    EXPECT_EQ(preview->title(), QString("second.png"));
+    EXPECT_EQ(qobject_cast<QLabel *>(preview->statusBarWidget())->text(), QString("32x24"));
+}
+
+TEST_F(UT_ImagePreview, Destructor_AfterInitializeAndSetFile_SchedulesWidgetDeletion)
+{
+    const QString &path = makeImageFile("destroy.png", 16, 16, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+    preview->initialize(window, statusBar);
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    QPointer<QWidget> content(preview->contentWidget());
+    QPointer<QWidget> status(preview->statusBarWidget());
+
+    delete preview;
+    preview = nullptr;
+    qApp->processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
+    EXPECT_TRUE(content.isNull());
+    EXPECT_TRUE(status.isNull());
+}
+
+TEST_F(UT_ImagePreview, Destructor_WithoutInitialize_NoCrash)
+{
+    delete preview;
+    preview = nullptr;
+    qApp->processEvents();
+    SUCCEED();
+}
+
+class UT_ImagePreviewPlugin : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        plugin = new ImagePreviewPlugin();
+    }
+
+    void TearDown() override
+    {
+        delete plugin;
+    }
+
+protected:
+    ImagePreviewPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_ImagePreviewPlugin, Create_AnyKey_ReturnsImagePreviewInstance)
+{
+    AbstractBasePreview *result = plugin->create("image");
+    ASSERT_NE(result, nullptr);
+    EXPECT_NE(qobject_cast<ImagePreview *>(result), nullptr);
+    delete result;
+}
+
+TEST_F(UT_ImagePreviewPlugin, Create_EmptyKey_ReturnsImagePreviewInstance)
+{
+    AbstractBasePreview *result = plugin->create("");
+    ASSERT_NE(result, nullptr);
+    EXPECT_NE(qobject_cast<ImagePreview *>(result), nullptr);
+    delete result;
+}
+
+TEST_F(UT_ImagePreviewPlugin, Create_MultipleCalls_ReturnsDistinctInstances)
+{
+    AbstractBasePreview *first = plugin->create("image");
+    AbstractBasePreview *second = plugin->create("image");
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+    EXPECT_NE(first, second);
+    delete first;
+    delete second;
+}
+
+TEST_F(UT_ImagePreviewPlugin, MetaObject_PluginInstance_ReportsPluginClassName)
+{
+    EXPECT_EQ(QString(plugin->metaObject()->className()), QString("plugin_filepreview::ImagePreviewPlugin"));
+}

--- a/autotests/apps/dde-file-manager-preview/image-preview/test_imageview.cpp
+++ b/autotests/apps/dde-file-manager-preview/image-preview/test_imageview.cpp
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "imageview.h"
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QFile>
+#include <QImage>
+#include <QLabel>
+#include <QMovie>
+#include <QPixmap>
+#include <QTemporaryDir>
+#include <QWidget>
+
+using namespace plugin_filepreview;
+
+class UT_ImageView : public testing::Test
+{
+protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+    QString makeImageFile(const QString &name, int width, int height, const char *format)
+    {
+        QImage image(width, height, QImage::Format_ARGB32);
+        image.fill(Qt::blue);
+        const QString &path = dir.filePath(name);
+        if (!image.save(path, format))
+            return QString();
+        return path;
+    }
+
+    QString makeGifFile(const QString &name)
+    {
+        const QByteArray &gifData = QByteArray::fromBase64(
+                "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+        const QString &path = dir.filePath(name);
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly))
+            return QString();
+        file.write(gifData);
+        file.close();
+        return path;
+    }
+
+protected:
+    QTemporaryDir dir;
+};
+
+TEST_F(UT_ImageView, Construct_WithValidPng_LoadsPixmapAndAppliesDefaults)
+{
+    const QString &path = makeImageFile("construct.png", 64, 48, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+
+    ImageView view(path, QByteArray("png"));
+
+    EXPECT_EQ(view.sourceSize(), QSize(64, 48));
+
+    EXPECT_FALSE(view.pixmap().isNull());
+    EXPECT_GE(view.pixmap().devicePixelRatio(), 1.0);
+    EXPECT_EQ(view.minimumSize(), QSize(400, 300));
+    EXPECT_EQ(view.maximumSize(), QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
+    EXPECT_EQ(static_cast<int>(view.alignment()), static_cast<int>(Qt::AlignCenter));
+}
+
+TEST_F(UT_ImageView, Construct_WithNonExistentFile_ShowsEmptyPixmap)
+{
+    ImageView view(dir.filePath("missing.png"), QByteArray("png"));
+
+    EXPECT_TRUE(view.pixmap().isNull());
+    EXPECT_FALSE(view.sourceSize().isValid());
+}
+
+TEST_F(UT_ImageView, SetFile_AnotherValidPng_UpdatesPixmapAndSourceSize)
+{
+    const QString &firstPath = makeImageFile("first.png", 64, 48, "PNG");
+    const QString &secondPath = makeImageFile("second.png", 100, 50, "PNG");
+    ASSERT_FALSE(firstPath.isEmpty());
+    ASSERT_FALSE(secondPath.isEmpty());
+
+    ImageView view(firstPath, QByteArray("png"));
+    view.setFile(secondPath, QByteArray("png"));
+
+    EXPECT_EQ(view.sourceSize(), QSize(100, 50));
+
+    EXPECT_FALSE(view.pixmap().isNull());
+}
+
+TEST_F(UT_ImageView, SetFile_LargeImage_KeepsOriginalSourceSize)
+{
+    const QString &path = makeImageFile("large.png", 3000, 2000, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+
+    ImageView view(path, QByteArray("png"));
+
+    EXPECT_EQ(view.sourceSize(), QSize(3000, 2000));
+
+    EXPECT_FALSE(view.pixmap().isNull());
+}
+
+TEST_F(UT_ImageView, SetFile_EmptyFormat_DetectsFormatFromContent)
+{
+    const QString &path = makeImageFile("noformat.png", 40, 30, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+
+    ImageView view(path, QByteArray());
+
+    EXPECT_EQ(view.sourceSize(), QSize(40, 30));
+
+    EXPECT_FALSE(view.pixmap().isNull());
+}
+
+TEST_F(UT_ImageView, SetFile_GifFile_CreatesAndStartsMovie)
+{
+    const QString &path = makeGifFile("animated.gif");
+    ASSERT_FALSE(path.isEmpty());
+
+    ImageView view(path, QByteArray("gif"));
+
+    QMovie *movie = view.movie;
+    ASSERT_NE(movie, nullptr);
+    EXPECT_EQ(movie->fileName(), path);
+    EXPECT_EQ(movie->state(), QMovie::Running);
+    EXPECT_EQ(view.sourceSize(), QSize(1, 1));
+}
+
+TEST_F(UT_ImageView, SetFile_SecondGif_ReusesSameMovieObject)
+{
+    const QString &firstPath = makeGifFile("first.gif");
+    const QString &secondPath = makeGifFile("second.gif");
+    ASSERT_FALSE(firstPath.isEmpty());
+    ASSERT_FALSE(secondPath.isEmpty());
+
+    ImageView view(firstPath, QByteArray("gif"));
+    QMovie *firstMovie = view.movie;
+    ASSERT_NE(firstMovie, nullptr);
+
+    view.setFile(secondPath, QByteArray("gif"));
+
+    EXPECT_EQ(view.movie, firstMovie);
+    EXPECT_EQ(view.movie->fileName(), secondPath);
+}
+
+TEST_F(UT_ImageView, SetFile_GifThenStaticImage_StopsAndClearsMovie)
+{
+    const QString &gifPath = makeGifFile("clip.gif");
+    const QString &pngPath = makeImageFile("static.png", 50, 40, "PNG");
+    ASSERT_FALSE(gifPath.isEmpty());
+    ASSERT_FALSE(pngPath.isEmpty());
+
+    ImageView view(gifPath, QByteArray("gif"));
+    ASSERT_NE(view.movie, nullptr);
+
+    view.setFile(pngPath, QByteArray("png"));
+    qApp->processEvents();
+
+    EXPECT_EQ(view.movie, nullptr);
+
+    EXPECT_FALSE(view.pixmap().isNull());
+    EXPECT_EQ(view.sourceSize(), QSize(50, 40));
+    EXPECT_EQ(view.minimumSize(), QSize(400, 300));
+    EXPECT_EQ(view.maximumSize(), QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
+}
+
+TEST_F(UT_ImageView, SetFile_GifOnConstructedView_AppliesFixedShowSize)
+{
+    const QString &pngPath = makeImageFile("initial.png", 64, 48, "PNG");
+    const QString &gifPath = makeGifFile("fixed.gif");
+    ASSERT_FALSE(pngPath.isEmpty());
+    ASSERT_FALSE(gifPath.isEmpty());
+
+    ImageView view(pngPath, QByteArray("png"));
+    view.setFile(gifPath, QByteArray("gif"));
+
+    EXPECT_NE(view.movie, nullptr);
+    EXPECT_EQ(view.minimumSize(), QSize(1, 1));
+    EXPECT_EQ(view.maximumSize(), QSize(1, 1));
+    EXPECT_EQ(view.movie->scaledSize(), QSize(1, 1));
+}
+
+TEST_F(UT_ImageView, SetFile_NonExistentFile_ClearsPixmap)
+{
+    const QString &path = makeImageFile("loaded.png", 64, 48, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+
+    ImageView view(path, QByteArray("png"));
+
+
+    view.setFile(dir.filePath("vanished.png"), QByteArray("png"));
+
+    EXPECT_TRUE(view.pixmap().isNull());
+    EXPECT_FALSE(view.sourceSize().isValid());
+}
+
+TEST_F(UT_ImageView, SourceSize_AfterLoad_MatchesImageDimensions)
+{
+    const QString &path = makeImageFile("dimensions.png", 123, 45, "PNG");
+    ASSERT_FALSE(path.isEmpty());
+
+    ImageView view(path, QByteArray("png"));
+
+    EXPECT_EQ(view.sourceSize().width(), 123);
+    EXPECT_EQ(view.sourceSize().height(), 45);
+}

--- a/autotests/apps/dde-file-manager-preview/markdown-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/markdown-preview/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Unit tests for markdown-preview: recompile plugin sources into the test binary
+# so stub-ext can access private members (see autotests/README.md).
+set(_preview_dir "${DFM_PREVIEW_PLUGIN_DIR}/markdown-preview")
+
+file(GLOB_RECURSE _ut_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+file(GLOB_RECURSE _plugin_files
+    "${_preview_dir}/*.cpp"
+    "${_preview_dir}/*.h")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+
+dfm_create_test_executable(ut-markdown-preview
+    SOURCES ${_ut_files} ${_plugin_files}
+    LINK_LIBRARIES DFM6::base DFM6::framework Qt6::Widgets 
+)
+
+target_include_directories(ut-markdown-preview PRIVATE
+    "${DFM_PREVIEW_PLUGIN_DIR}"
+    ${_preview_dir}
+)
+

--- a/autotests/apps/dde-file-manager-preview/markdown-preview/main.cpp
+++ b/autotests/apps/dde-file-manager-preview/markdown-preview/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(markdown_preview)

--- a/autotests/apps/dde-file-manager-preview/markdown-preview/test_markdownbrowser.cpp
+++ b/autotests/apps/dde-file-manager-preview/markdown-preview/test_markdownbrowser.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "markdownbrowser.h"
+
+#include <gtest/gtest.h>
+
+#include <QDir>
+#include <QFrame>
+#include <QPointer>
+#include <QTemporaryDir>
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QWidget>
+
+using namespace plugin_filepreview;
+
+class UT_MarkdownBrowser : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        browser = new MarkdownBrowser();
+    }
+
+    virtual void TearDown() override
+    {
+        delete browser;
+        browser = nullptr;
+        stub.clear();
+    }
+
+protected:
+    MarkdownBrowser *browser { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_MarkdownBrowser, Constructor_DefaultArguments_ReadOnlyWithFixedGeometry)
+{
+    EXPECT_TRUE(browser->isReadOnly());
+    EXPECT_TRUE(browser->textInteractionFlags() & Qt::TextSelectableByMouse);
+    EXPECT_TRUE(browser->textInteractionFlags() & Qt::TextSelectableByKeyboard);
+    EXPECT_TRUE(browser->textInteractionFlags() & Qt::LinksAccessibleByMouse);
+    EXPECT_TRUE(browser->openExternalLinks());
+    EXPECT_EQ(browser->lineWrapMode(), QTextEdit::WidgetWidth);
+    EXPECT_EQ(browser->size(), QSize(800, 500));
+    EXPECT_EQ(browser->frameShape(), QFrame::NoFrame);
+    EXPECT_EQ(browser->parentWidget(), nullptr);
+}
+
+TEST_F(UT_MarkdownBrowser, Constructor_WithParentWidget_ParentAssigned)
+{
+    QWidget parent;
+    auto child = new MarkdownBrowser(&parent);
+    EXPECT_EQ(child->parentWidget(), &parent);
+    EXPECT_TRUE(child->isReadOnly());
+    delete child;
+}
+
+TEST_F(UT_MarkdownBrowser, SetMarkdownContent_ExistingBasePath_SetsSearchPathsAndDocumentUrl)
+{
+    QTemporaryDir baseDir;
+    ASSERT_TRUE(baseDir.isValid());
+
+    browser->setMarkdownContent("# Unit Heading\n\nBrowser body text", baseDir.path());
+
+    EXPECT_EQ(browser->searchPaths(), QStringList { baseDir.path() });
+    EXPECT_EQ(browser->document()->metaInformation(QTextDocument::DocumentUrl),
+              QUrl::fromLocalFile(baseDir.path()).toString());
+    EXPECT_TRUE(browser->document()->toPlainText().contains("Unit Heading"));
+    EXPECT_TRUE(browser->document()->toPlainText().contains("Browser body text"));
+}
+
+TEST_F(UT_MarkdownBrowser, SetMarkdownContent_EmptyBasePath_KeepsSearchPathsEmpty)
+{
+    browser->setMarkdownContent("# NoBase", "");
+
+    EXPECT_TRUE(browser->searchPaths().isEmpty());
+    EXPECT_TRUE(browser->document()->toPlainText().contains("NoBase"));
+    EXPECT_FALSE(browser->document()->isEmpty());
+}
+
+TEST_F(UT_MarkdownBrowser, SetMarkdownContent_NonExistingBasePath_KeepsSearchPathsEmpty)
+{
+    QString ghostPath;
+    {
+        QTemporaryDir removedDir;
+        ghostPath = removedDir.path();
+    }
+    ASSERT_FALSE(QDir(ghostPath).exists());
+
+    browser->setMarkdownContent("# GhostBase", ghostPath);
+
+    EXPECT_TRUE(browser->searchPaths().isEmpty());
+    EXPECT_TRUE(browser->document()->toPlainText().contains("GhostBase"));
+}
+
+TEST_F(UT_MarkdownBrowser, SetMarkdownContent_EmptyMarkdown_ClearsPreviousDocument)
+{
+    QTemporaryDir baseDir;
+    ASSERT_TRUE(baseDir.isValid());
+
+    browser->setMarkdownContent("# First content", baseDir.path());
+    ASSERT_TRUE(browser->document()->toPlainText().contains("First content"));
+
+    browser->setMarkdownContent("", "");
+
+    EXPECT_TRUE(browser->document()->isEmpty());
+    EXPECT_TRUE(browser->document()->toPlainText().isEmpty());
+    EXPECT_EQ(browser->searchPaths(), QStringList { baseDir.path() });
+}
+
+TEST_F(UT_MarkdownBrowser, SetMarkdownContent_CursorAtEnd_MovesCursorToDocumentStart)
+{
+    browser->setMarkdownContent("# First\n\npara one", "");
+    browser->moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
+    ASSERT_GT(browser->textCursor().position(), 0);
+
+    browser->setMarkdownContent("# Second\n\npara two", "");
+
+    EXPECT_EQ(browser->textCursor().position(), 0);
+    EXPECT_TRUE(browser->document()->toPlainText().contains("Second"));
+}
+
+TEST_F(UT_MarkdownBrowser, Destructor_DeleteBrowser_InvalidatesQPointer)
+{
+    auto disposable = new MarkdownBrowser();
+    QPointer<MarkdownBrowser> guard(disposable);
+    ASSERT_FALSE(guard.isNull());
+
+    delete disposable;
+
+    EXPECT_TRUE(guard.isNull());
+}

--- a/autotests/apps/dde-file-manager-preview/markdown-preview/test_markdowncontextwidget.cpp
+++ b/autotests/apps/dde-file-manager-preview/markdown-preview/test_markdowncontextwidget.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "markdowncontextwidget.h"
+#include "markdownbrowser.h"
+
+#include <gtest/gtest.h>
+
+#include <QMargins>
+#include <QPlainTextEdit>
+#include <QVBoxLayout>
+#include <QWidget>
+
+using namespace plugin_filepreview;
+
+class UT_MarkdownContextWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        widget = new MarkdownContextWidget();
+    }
+
+    virtual void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+        stub.clear();
+    }
+
+protected:
+    MarkdownContextWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_MarkdownContextWidget, Constructor_DefaultArguments_CreatesBrowserChild)
+{
+    auto browser = widget->markdownBrowser();
+    EXPECT_NE(nullptr, browser);
+    EXPECT_EQ(widget, browser->parentWidget());
+    EXPECT_NE(nullptr, widget->findChild<MarkdownBrowser *>());
+}
+
+TEST_F(UT_MarkdownContextWidget, Constructor_DefaultArguments_BuildsZeroMarginVBoxLayout)
+{
+    auto layout = qobject_cast<QVBoxLayout *>(widget->layout());
+    EXPECT_NE(nullptr, layout);
+    EXPECT_EQ(layout->contentsMargins(), QMargins(0, 0, 0, 0));
+    EXPECT_EQ(layout->spacing(), 0);
+    EXPECT_EQ(layout->count(), 2);
+}
+
+TEST_F(UT_MarkdownContextWidget, Constructor_DefaultArguments_PlacesReadOnlyTitleAboveBrowser)
+{
+    auto layout = qobject_cast<QVBoxLayout *>(widget->layout());
+    ASSERT_NE(nullptr, layout);
+
+    auto plainEdits = widget->findChildren<QPlainTextEdit *>();
+    ASSERT_EQ(plainEdits.size(), 1);
+
+    EXPECT_EQ(layout->itemAt(0)->widget(), plainEdits.first());
+    EXPECT_EQ(layout->itemAt(1)->widget(), widget->markdownBrowser());
+    EXPECT_TRUE(plainEdits.first()->isReadOnly());
+    EXPECT_EQ(plainEdits.first()->minimumHeight(), 30);
+    EXPECT_EQ(plainEdits.first()->maximumHeight(), 30);
+}
+
+TEST_F(UT_MarkdownContextWidget, Constructor_WithParentWidget_ParentAssigned)
+{
+    QWidget parent;
+    auto child = new MarkdownContextWidget(&parent);
+    EXPECT_EQ(child->parentWidget(), &parent);
+    EXPECT_NE(nullptr, child->markdownBrowser());
+    delete child;
+}
+
+TEST_F(UT_MarkdownContextWidget, MarkdownBrowser_RepeatedCalls_ReturnSameInstance)
+{
+    auto first = widget->markdownBrowser();
+    auto second = widget->markdownBrowser();
+    EXPECT_NE(nullptr, first);
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(widget->findChild<MarkdownBrowser *>(), first);
+}

--- a/autotests/apps/dde-file-manager-preview/markdown-preview/test_markdownpreview.cpp
+++ b/autotests/apps/dde-file-manager-preview/markdown-preview/test_markdownpreview.cpp
@@ -1,0 +1,321 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "markdownpreview.h"
+#include "markdownpreviewplugin.h"
+#include "markdowncontextwidget.h"
+#include "markdownbrowser.h"
+
+#include <dfm-base/interfaces/abstractbasepreview.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QPointer>
+#include <QSignalSpy>
+#include <QTemporaryFile>
+
+DFMBASE_USE_NAMESPACE
+using namespace plugin_filepreview;
+
+class UT_MarkdownPreview : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        preview = new MarkdownPreview();
+    }
+
+    virtual void TearDown() override
+    {
+        for (const QString &path : tempFiles)
+            QFile::remove(path);
+        delete preview;
+        preview = nullptr;
+        stub.clear();
+        qApp->processEvents();
+    }
+
+    QString createTempFile(const QString &suffix, const QByteArray &content)
+    {
+        QTemporaryFile file;
+        file.setAutoRemove(false);
+        file.setFileTemplate(QDir::temp().absoluteFilePath("ut-markdown-XXXXXX" + suffix));
+        if (!file.open())
+            return QString();
+        file.write(content);
+        file.close();
+        tempFiles.append(file.fileName());
+        return file.fileName();
+    }
+
+protected:
+    MarkdownPreview *preview { nullptr };
+    stub_ext::StubExt stub;
+    QStringList tempFiles;
+};
+
+class UT_MarkdownPreviewPlugin : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        plugin = new MarkdownPreviewPlugin();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+protected:
+    MarkdownPreviewPlugin *plugin { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_MarkdownPreview, Constructor_FreshInstance_AllAccessorsEmpty)
+{
+    EXPECT_EQ(QUrl(), preview->fileUrl());
+    EXPECT_TRUE(preview->title().isEmpty());
+    EXPECT_EQ(nullptr, preview->contentWidget());
+    EXPECT_EQ(nullptr, qobject_cast<MarkdownContextWidget *>(preview->contentWidget()));
+}
+
+TEST_F(UT_MarkdownPreview, FileUrl_BeforeAnyLoad_ReturnsEmptyUrl)
+{
+    EXPECT_EQ(QUrl(), preview->fileUrl());
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+}
+
+TEST_F(UT_MarkdownPreview, Title_BeforeAnyLoad_ReturnsEmptyString)
+{
+    EXPECT_EQ(QString(), preview->title());
+    EXPECT_TRUE(preview->title().isEmpty());
+}
+
+TEST_F(UT_MarkdownPreview, ContentWidget_BeforeAnyLoad_ReturnsNullPointer)
+{
+    EXPECT_EQ(nullptr, preview->contentWidget());
+    EXPECT_TRUE(preview->title().isEmpty());
+}
+
+TEST_F(UT_MarkdownPreview, ShowStatusBarSeparator_AnyCall_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->showStatusBarSeparator());
+    EXPECT_FALSE(preview->showStatusBarSeparator());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_EmptyUrlOnFreshInstance_ReturnsTrueWithoutLoading)
+{
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl()));
+
+    EXPECT_EQ(0, spy.count());
+    EXPECT_EQ(nullptr, preview->contentWidget());
+    EXPECT_TRUE(preview->title().isEmpty());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_RemoteUrl_ReturnsFalse)
+{
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl("https://example.com/readme.md")));
+
+    EXPECT_EQ(0, spy.count());
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(nullptr, preview->contentWidget());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_NonExistentLocalFile_ReturnsFalse)
+{
+    QUrl url = QUrl::fromLocalFile(QDir::temp().absoluteFilePath("ut-markdown-ghost-not-exist.md"));
+    ASSERT_FALSE(QFileInfo::exists(url.toLocalFile()));
+
+    EXPECT_FALSE(preview->setFileUrl(url));
+
+    EXPECT_NE(url, preview->fileUrl());
+    EXPECT_EQ(nullptr, preview->contentWidget());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_EmptyLocalFile_ReturnsFalse)
+{
+    QString path = createTempFile(".md", QByteArray());
+    ASSERT_FALSE(path.isEmpty());
+    ASSERT_EQ(QFileInfo(path).size(), 0);
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(nullptr, preview->contentWidget());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_FileOpenFailure_ReturnsFalse)
+{
+    QString path = createTempFile(".md", "# OpenFail\n\nbody");
+    ASSERT_FALSE(path.isEmpty());
+    QFile permissionHolder(path);
+    ASSERT_TRUE(permissionHolder.setPermissions(QFileDevice::Permissions()));
+    ASSERT_TRUE(QFileInfo::exists(path));
+    ASSERT_GT(QFileInfo(path).size(), 0);
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(nullptr, preview->contentWidget());
+    permissionHolder.setPermissions(QFileDevice::ReadOwner);
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_FileReadFailure_ReturnsFalse)
+{
+    QString path = createTempFile(".md", "# ReadFail\n\nbody");
+    ASSERT_FALSE(path.isEmpty());
+
+    stub.set_lamda(static_cast<QByteArray (QIODevice::*)(qint64)>(&QIODevice::read),
+                   [](QIODevice *, qint64) -> QByteArray {
+                       __DBG_STUB_INVOKE__
+                       return QByteArray();
+                   });
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(nullptr, preview->contentWidget());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_ValidMarkdownFile_ReturnsTrueAndUpdatesState)
+{
+    QString path = createTempFile(".md", "# Preview Heading\n\nMarkdown body content");
+    ASSERT_FALSE(path.isEmpty());
+    QUrl url = QUrl::fromLocalFile(path);
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+
+    EXPECT_TRUE(preview->setFileUrl(url));
+
+    EXPECT_EQ(url, preview->fileUrl());
+    EXPECT_EQ(QFileInfo(path).fileName(), preview->title());
+    EXPECT_EQ(1, spy.count());
+
+    auto context = qobject_cast<MarkdownContextWidget *>(preview->contentWidget());
+    ASSERT_NE(nullptr, context);
+    EXPECT_TRUE(context->markdownBrowser()->document()->toPlainText().contains("Preview Heading"));
+    EXPECT_EQ(context->markdownBrowser()->searchPaths(), QStringList { QFileInfo(path).absolutePath() });
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_SameUrlRepeated_ReturnsTrueWithoutReloading)
+{
+    QString path = createTempFile(".md", "# Stable content");
+    ASSERT_FALSE(path.isEmpty());
+    QUrl url = QUrl::fromLocalFile(path);
+    ASSERT_TRUE(preview->setFileUrl(url));
+
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+    QWidget *widgetBefore = preview->contentWidget();
+
+    EXPECT_TRUE(preview->setFileUrl(url));
+
+    EXPECT_EQ(0, spy.count());
+    EXPECT_EQ(widgetBefore, preview->contentWidget());
+    EXPECT_EQ(url, preview->fileUrl());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_SecondFile_ReusesSameContentWidget)
+{
+    QString firstPath = createTempFile(".md", "# First document");
+    QString secondPath = createTempFile(".md", "# Second document");
+    ASSERT_FALSE(firstPath.isEmpty());
+    ASSERT_FALSE(secondPath.isEmpty());
+
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(firstPath)));
+    QWidget *widgetBefore = preview->contentWidget();
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(secondPath)));
+
+    EXPECT_EQ(widgetBefore, preview->contentWidget());
+    EXPECT_EQ(QUrl::fromLocalFile(secondPath), preview->fileUrl());
+    EXPECT_EQ(QFileInfo(secondPath).fileName(), preview->title());
+
+    auto context = qobject_cast<MarkdownContextWidget *>(preview->contentWidget());
+    ASSERT_NE(nullptr, context);
+    EXPECT_TRUE(context->markdownBrowser()->document()->toPlainText().contains("Second document"));
+    EXPECT_FALSE(context->markdownBrowser()->document()->toPlainText().contains("First document"));
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_FileOverSizeLimit_TruncatesContentToFiveMB)
+{
+    const QByteArray oversized(5 * 1024 * 1024 + 1, 'a');
+    QString path = createTempFile(".md", oversized);
+    ASSERT_FALSE(path.isEmpty());
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    auto context = qobject_cast<MarkdownContextWidget *>(preview->contentWidget());
+    ASSERT_NE(nullptr, context);
+    EXPECT_EQ(5 * 1024 * 1024, context->markdownBrowser()->document()->toPlainText().size());
+    EXPECT_EQ(QFileInfo(path).fileName(), preview->title());
+}
+
+TEST_F(UT_MarkdownPreview, SetFileUrl_TextSuffixFile_StillLoadsAsMarkdown)
+{
+    QString path = createTempFile(".txt", "# Txt as markdown");
+    ASSERT_FALSE(path.isEmpty());
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    auto context = qobject_cast<MarkdownContextWidget *>(preview->contentWidget());
+    ASSERT_NE(nullptr, context);
+    EXPECT_TRUE(context->markdownBrowser()->document()->toPlainText().contains("Txt as markdown"));
+    EXPECT_EQ(QFileInfo(path).fileName(), preview->title());
+}
+
+TEST_F(UT_MarkdownPreview, Destructor_AfterLoad_DefersWidgetDeletionToEventLoop)
+{
+    QString path = createTempFile(".md", "# Deferred delete");
+    ASSERT_FALSE(path.isEmpty());
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    QPointer<MarkdownContextWidget> guard = qobject_cast<MarkdownContextWidget *>(preview->contentWidget());
+    ASSERT_FALSE(guard.isNull());
+
+    delete preview;
+    preview = nullptr;
+
+    EXPECT_FALSE(guard.isNull());
+    qApp->processEvents();
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    EXPECT_TRUE(guard.isNull());
+}
+
+TEST_F(UT_MarkdownPreviewPlugin, Create_WithMarkdownKey_ReturnsMarkdownPreviewInstance)
+{
+    AbstractBasePreview *created = plugin->create("markdown");
+    EXPECT_NE(nullptr, created);
+    EXPECT_NE(nullptr, qobject_cast<MarkdownPreview *>(created));
+    delete created;
+}
+
+TEST_F(UT_MarkdownPreviewPlugin, Create_WithEmptyKey_ReturnsMarkdownPreviewInstance)
+{
+    AbstractBasePreview *created = plugin->create("");
+    EXPECT_NE(nullptr, created);
+    EXPECT_NE(nullptr, qobject_cast<MarkdownPreview *>(created));
+    delete created;
+}
+
+TEST_F(UT_MarkdownPreviewPlugin, Create_RepeatedCalls_ReturnDistinctInstances)
+{
+    AbstractBasePreview *first = plugin->create("markdown");
+    AbstractBasePreview *second = plugin->create("other-key");
+    EXPECT_NE(nullptr, first);
+    EXPECT_NE(nullptr, second);
+    EXPECT_NE(first, second);
+    delete first;
+    delete second;
+}

--- a/autotests/apps/dde-file-manager-preview/music-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/music-preview/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Unit tests for music-preview: recompile plugin sources into the test binary
+# so stub-ext can access private members (see autotests/README.md).
+set(_preview_dir "${DFM_PREVIEW_PLUGIN_DIR}/music-preview")
+
+file(GLOB_RECURSE _ut_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+file(GLOB_RECURSE _plugin_files
+    "${_preview_dir}/*.cpp"
+    "${_preview_dir}/*.h")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+find_package(Qt6 COMPONENTS Multimedia REQUIRED)
+find_package(ICU COMPONENTS i18n io uc REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_search_module(taglib REQUIRED taglib)
+
+dfm_create_test_executable(ut-music-preview
+    SOURCES ${_ut_files} ${_plugin_files}
+    LINK_LIBRARIES DFM6::base DFM6::framework Qt6::Widgets Qt6::Multimedia ICU::i18n ${taglib_LIBRARIES}
+)
+
+target_include_directories(ut-music-preview PRIVATE
+    "${DFM_PREVIEW_PLUGIN_DIR}"
+    ${_preview_dir}
+)
+target_include_directories(ut-music-preview PRIVATE ${taglib_INCLUDE_DIRS})

--- a/autotests/apps/dde-file-manager-preview/music-preview/main.cpp
+++ b/autotests/apps/dde-file-manager-preview/music-preview/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(music_preview)

--- a/autotests/apps/dde-file-manager-preview/music-preview/test_musicmessageview.cpp
+++ b/autotests/apps/dde-file-manager-preview/music-preview/test_musicmessageview.cpp
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "musicmessageview.h"
+#include "cover.h"
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QBuffer>
+#include <QFile>
+#include <QResizeEvent>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <QLabel>
+
+#include <taglib/attachedpictureframe.h>
+#include <taglib/fileref.h>
+#include <taglib/id3v2tag.h>
+#include <taglib/mpegfile.h>
+#include <taglib/tag.h>
+
+using namespace plugin_filepreview;
+
+class UT_MusicMessageView : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+        delete view;
+        view = nullptr;
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        qApp->processEvents();
+        stub.clear();
+    }
+
+    QString toUri(const QString &path)
+    {
+        return QUrl::fromLocalFile(path).toString();
+    }
+
+    QByteArray makePng(int w, int h, const QColor &color)
+    {
+        QImage img(w, h, QImage::Format_ARGB32);
+        img.fill(color);
+        QBuffer buf;
+        img.save(&buf, "PNG");
+        return buf.data();
+    }
+
+    QString makeMp3(const QString &name, const char *title, const char *artist, const char *album, const QByteArray &coverPng = {})
+    {
+        const QString &path = dir.filePath(name);
+        {
+            QFile file(path);
+            if (!file.open(QIODevice::WriteOnly))
+                return QString();
+            QByteArray frame(4 + 417, '\0');
+            frame[0] = char(0xFF);
+            frame[1] = char(0xFB);
+            frame[2] = char(0x90);
+            frame[3] = '\0';
+            file.write(frame);
+        }
+
+        TagLib::MPEG::File tf(path.toLocal8Bit());
+        if (!tf.isValid())
+            return path;
+        TagLib::ID3v2::Tag *tag = tf.ID3v2Tag(true);
+        if (title)
+            tag->setTitle(TagLib::String(title, TagLib::String::UTF8));
+        if (artist)
+            tag->setArtist(TagLib::String(artist, TagLib::String::UTF8));
+        if (album)
+            tag->setAlbum(TagLib::String(album, TagLib::String::UTF8));
+        if (!coverPng.isEmpty()) {
+            auto *pic = new TagLib::ID3v2::AttachedPictureFrame;
+            pic->setMimeType("image/png");
+            pic->setType(TagLib::ID3v2::AttachedPictureFrame::FrontCover);
+            pic->setPicture(TagLib::ByteVector(coverPng.constData(), coverPng.size()));
+            tag->addFrame(pic);
+        }
+        tf.save();
+        return path;
+    }
+
+protected:
+    MusicMessageView *view { nullptr };
+    QTemporaryDir dir;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_MusicMessageView, Construct_Mp3WithTag_ShowsTagValues)
+{
+    const QString &path = makeMp3("tagged.mp3", "TestTitle", "TestArtist", "TestAlbum");
+    ASSERT_FALSE(path.isEmpty());
+
+    view = new MusicMessageView(toUri(path));
+    EXPECT_EQ(view->titleLabel->text(), QString("TestTitle"));
+    EXPECT_EQ(view->artistValue->text(), QString("TestArtist"));
+    EXPECT_EQ(view->albumValue->text(), QString("TestAlbum"));
+}
+
+TEST_F(UT_MusicMessageView, Construct_Mp3WithoutTag_FallsBackToFileInfo)
+{
+    const QString &path = makeMp3("plain.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+
+    view = new MusicMessageView(toUri(path));
+    EXPECT_EQ(view->titleLabel->text(), QString("plain"));
+    EXPECT_EQ(view->artistValue->text(), MusicMessageView::tr("unknown artist"));
+    EXPECT_EQ(view->albumValue->text(), MusicMessageView::tr("unknown album"));
+}
+
+TEST_F(UT_MusicMessageView, Construct_NonExistentFile_FallsBackToFileInfo)
+{
+    view = new MusicMessageView("/nonexistent-dir/nonexistent.mp3");
+    EXPECT_EQ(view->titleLabel->text(), QString("nonexistent"));
+    EXPECT_EQ(view->artistValue->text(), MusicMessageView::tr("unknown artist"));
+    EXPECT_EQ(view->albumValue->text(), MusicMessageView::tr("unknown album"));
+}
+
+TEST_F(UT_MusicMessageView, Construct_EmptyUrl_FallsBackToEmptyInfo)
+{
+    view = new MusicMessageView(QString(""));
+    EXPECT_TRUE(view->titleLabel->text().isEmpty());
+    EXPECT_EQ(view->artistValue->text(), MusicMessageView::tr("unknown artist"));
+}
+
+TEST_F(UT_MusicMessageView, Construct_Mp3WithCoverArt_ShowsCoverPixmap)
+{
+    const QString &path = makeMp3("covered.mp3", "T", "A", "B", makePng(64, 64, Qt::red));
+    ASSERT_FALSE(path.isEmpty());
+
+    view = new MusicMessageView(toUri(path));
+    view->imgLabel->resize(240, 240);
+    const QImage &shot = view->imgLabel->grab().toImage();
+    EXPECT_EQ(shot.pixelColor(shot.width() / 2, shot.height() / 2).rgb(), qRgb(255, 0, 0));
+}
+
+TEST_F(UT_MusicMessageView, SetMediaInfo_AfterManualFieldChange_RefreshesLabels)
+{
+    const QString &path = makeMp3("tagged2.mp3", "TestTitle", "TestArtist", "TestAlbum");
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    view->fileTitle = "ManualTitle";
+    view->fileArtist = "ManualArtist";
+    view->fileAlbum = "ManualAlbum";
+    view->setMediaInfo();
+
+    EXPECT_EQ(view->titleLabel->text(), QString("TestTitle"));
+    EXPECT_EQ(view->artistValue->text(), QString("TestArtist"));
+    EXPECT_EQ(view->albumValue->text(), QString("TestAlbum"));
+}
+
+TEST_F(UT_MusicMessageView, UpdateElidedText_LongTitle_TextElidedWithEllipsis)
+{
+    const QString &path = makeMp3("longtitle.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    view->viewMargins = 10;
+    view->fileTitle = QString(300, 'A');
+    view->fileArtist = QString(300, 'B');
+    view->fileAlbum = QString(300, 'C');
+    view->updateElidedText();
+
+    EXPECT_TRUE(view->titleLabel->text().endsWith(QString::fromUtf8("…")));
+    EXPECT_LT(view->titleLabel->text().size(), 300);
+    EXPECT_TRUE(view->artistValue->text().endsWith(QString::fromUtf8("…")));
+    EXPECT_TRUE(view->albumValue->text().endsWith(QString::fromUtf8("…")));
+}
+
+TEST_F(UT_MusicMessageView, UpdateElidedText_ShortTitle_TextKeptIntact)
+{
+    const QString &path = makeMp3("short.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    view->viewMargins = 10;
+    view->fileTitle = "Short";
+    view->fileArtist = "Yes";
+    view->fileAlbum = "Ok";
+    view->updateElidedText();
+
+    EXPECT_EQ(view->titleLabel->text(), QString("Short"));
+    EXPECT_EQ(view->artistValue->text(), QString("Yes"));
+    EXPECT_EQ(view->albumValue->text(), QString("Ok"));
+}
+
+TEST_F(UT_MusicMessageView, ResizeEvent_LargerSize_MarginsCentered)
+{
+    const QString &path = makeMp3("resize.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    QResizeEvent event(QSize(700, 400), QSize(600, 300));
+    QApplication::sendEvent(view, &event);
+
+    EXPECT_EQ(view->contentsMargins().left(), 80);
+    EXPECT_EQ(view->contentsMargins().top(), 80);
+    EXPECT_EQ(view->contentsMargins().right(), 0);
+}
+
+TEST_F(UT_MusicMessageView, ResizeEvent_NarrowSize_MarginsClamped)
+{
+    const QString &path = makeMp3("narrow.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    QResizeEvent event(QSize(300, 250), QSize(600, 300));
+    QApplication::sendEvent(view, &event);
+
+    EXPECT_EQ(view->contentsMargins().left(), 300 - 250 - 240);
+}
+
+TEST_F(UT_MusicMessageView, IsChinese_ChineseCharacter_ReturnsTrue)
+{
+    const QString &path = makeMp3("cn.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    EXPECT_TRUE(view->isChinese(QString::fromUtf8("中")[0]));
+    EXPECT_TRUE(view->isChinese(QChar(0x4E00)));
+    EXPECT_TRUE(view->isChinese(QChar(0x9FBF)));
+}
+
+TEST_F(UT_MusicMessageView, IsChinese_NonChineseCharacter_ReturnsFalse)
+{
+    const QString &path = makeMp3("cn2.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    EXPECT_FALSE(view->isChinese(QChar('A')));
+    EXPECT_FALSE(view->isChinese(QChar(0x4E00 - 1)));
+    EXPECT_FALSE(view->isChinese(QChar(0x9FBF + 1)));
+}
+
+TEST_F(UT_MusicMessageView, DetectEncodings_EmptyInput_ReturnsLocaleCharset)
+{
+    const QString &path = makeMp3("det.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    const QList<QByteArray> &charsets = view->detectEncodings(QByteArray());
+    EXPECT_GE(charsets.size(), 1);
+    EXPECT_FALSE(charsets.first().isEmpty());
+}
+
+TEST_F(UT_MusicMessageView, DetectEncodings_Utf8ChineseText_ReturnsCandidates)
+{
+    const QString &path = makeMp3("det2.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    const QByteArray &raw = QString::fromUtf8("中文编码检测").toUtf8();
+    const QList<QByteArray> &charsets = view->detectEncodings(raw);
+    EXPECT_GE(charsets.size(), 1);
+}
+
+TEST_F(UT_MusicMessageView, TagOpenMusicFile_ValidMp3_ReturnsMeta)
+{
+    const QString &path = makeMp3("meta.mp3", "MetaTitle", "MetaArtist", "MetaAlbum");
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    MediaMeta meta = view->tagOpenMusicFile(toUri(path));
+    EXPECT_EQ(meta.title, QString("MetaTitle"));
+    EXPECT_EQ(meta.artist, QString("MetaArtist"));
+    EXPECT_EQ(meta.album, QString("MetaAlbum"));
+}
+
+TEST_F(UT_MusicMessageView, TagOpenMusicFile_MissingFile_ReturnsEmptyMeta)
+{
+    const QString &path = makeMp3("meta2.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    MediaMeta meta = view->tagOpenMusicFile("/nonexistent-dir/none.mp3");
+    EXPECT_TRUE(meta.title.isEmpty());
+    EXPECT_TRUE(meta.artist.isEmpty());
+    EXPECT_TRUE(meta.album.isEmpty());
+}
+
+TEST_F(UT_MusicMessageView, CharacterEncodingTransform_UnicodeChinese_KeepsTextAndUtf8Codec)
+{
+    const QString &path = makeMp3("unicode.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    TagLib::FileRef ref(path.toLocal8Bit());
+    ASSERT_TRUE(ref.tag() != nullptr);
+    ref.tag()->setTitle(TagLib::String("中文标题", TagLib::String::UTF8));
+    ref.tag()->setArtist(TagLib::String("中文歌手", TagLib::String::UTF8));
+
+    MediaMeta meta;
+    view->characterEncodingTransform(meta, static_cast<void *>(ref.tag()));
+    EXPECT_EQ(meta.title, QString::fromUtf8("中文标题"));
+    EXPECT_EQ(meta.artist, QString::fromUtf8("中文歌手"));
+    EXPECT_EQ(meta.codec, QString("UTF-8"));
+}
+
+TEST_F(UT_MusicMessageView, CharacterEncodingTransform_AsciiText_SetsDetectedCodec)
+{
+    const QString &path = makeMp3("ascii.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    TagLib::FileRef ref(path.toLocal8Bit());
+    ASSERT_TRUE(ref.tag() != nullptr);
+    ref.tag()->setTitle(TagLib::String("AsciiTitle", TagLib::String::UTF8));
+    ref.tag()->setArtist(TagLib::String("AsciiArtist", TagLib::String::UTF8));
+    ref.tag()->setAlbum(TagLib::String("AsciiAlbum", TagLib::String::UTF8));
+
+    MediaMeta meta;
+    view->characterEncodingTransform(meta, static_cast<void *>(ref.tag()));
+    EXPECT_EQ(meta.title, QString("AsciiTitle"));
+    EXPECT_EQ(meta.artist, QString("AsciiArtist"));
+    EXPECT_EQ(meta.album, QString("AsciiAlbum"));
+    EXPECT_FALSE(meta.codec.isEmpty());
+}
+
+TEST_F(UT_MusicMessageView, CharacterEncodingTransform_GbkRawBytes_DetectsGbFamilyCodec)
+{
+    const QString &path = makeMp3("gbk.mp3", nullptr, nullptr, nullptr);
+    ASSERT_FALSE(path.isEmpty());
+    view = new MusicMessageView(toUri(path));
+
+    TagLib::FileRef ref(path.toLocal8Bit());
+    ASSERT_TRUE(ref.tag() != nullptr);
+    const char gbkTitle[] = { char(0xD6), char(0xD0), char(0xCE), char(0xC4), '\0' };
+    ref.tag()->setTitle(TagLib::String(gbkTitle, TagLib::String::Latin1));
+    ref.tag()->setArtist(TagLib::String(gbkTitle, TagLib::String::Latin1));
+
+    MediaMeta meta;
+    view->characterEncodingTransform(meta, static_cast<void *>(ref.tag()));
+    EXPECT_FALSE(meta.codec.isEmpty());
+    EXPECT_TRUE(meta.codec.contains("GB") || meta.codec.contains("Big5") || meta.codec.contains("UTF")
+                || meta.codec.contains("EUC") || meta.codec.contains("ASCII"));
+}

--- a/autotests/apps/dde-file-manager-preview/music-preview/test_musicpreview.cpp
+++ b/autotests/apps/dde-file-manager-preview/music-preview/test_musicpreview.cpp
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "musicpreview.h"
+#include "musicpreviewplugin.h"
+#include "musicmessageview.h"
+#include "toolbarframe.h"
+#include "cusmediaplayer.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QFile>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <QWidget>
+
+#include <mutex>
+
+DFMBASE_USE_NAMESPACE
+using namespace plugin_filepreview;
+
+class UT_MusicPreview : public testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        std::call_once(flag, [] {
+            UrlRoute::regScheme(Global::Scheme::kFile, QDir::homePath(), QIcon(), false, "file");
+            InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        });
+    }
+
+    void SetUp() override
+    {
+        preview = new MusicPreview();
+    }
+
+    void TearDown() override
+    {
+        delete preview;
+        preview = nullptr;
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        qApp->processEvents();
+        stub.clear();
+    }
+
+    QString makeMp3File(const QString &name)
+    {
+        const QString &path = dir.filePath(name);
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly))
+            return QString();
+        QByteArray frame(4 + 417, '\0');
+        frame[0] = char(0xFF);
+        frame[1] = char(0xFB);
+        frame[2] = char(0x90);
+        frame[3] = '\0';
+        file.write(frame);
+        file.close();
+        return path;
+    }
+
+    QString makeTextFile(const QString &name)
+    {
+        const QString &path = dir.filePath(name);
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly))
+            return QString();
+        file.write("plain text");
+        file.close();
+        return path;
+    }
+
+protected:
+    MusicPreview *preview { nullptr };
+    QTemporaryDir dir;
+    stub_ext::StubExt stub;
+    static std::once_flag flag;
+};
+
+std::once_flag UT_MusicPreview::flag;
+
+TEST_F(UT_MusicPreview, CanPreview_LocalMp3File_ReturnsTrue)
+{
+    const QString &path = makeMp3File("song.mp3");
+    ASSERT_FALSE(path.isEmpty());
+    EXPECT_TRUE(preview->canPreview(QUrl::fromLocalFile(path)));
+}
+
+TEST_F(UT_MusicPreview, CanPreview_TextFile_ReturnsFalse)
+{
+    const QString &path = makeTextFile("note.txt");
+    ASSERT_FALSE(path.isEmpty());
+    EXPECT_FALSE(preview->canPreview(QUrl::fromLocalFile(path)));
+}
+
+TEST_F(UT_MusicPreview, CanPreview_UnregisteredScheme_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->canPreview(QUrl("bogus:///tmp/song.mp3")));
+}
+
+TEST_F(UT_MusicPreview, SetFileUrl_RemoteHttpUrl_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->setFileUrl(QUrl("http://example.com/song.mp3")));
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+}
+
+TEST_F(UT_MusicPreview, SetFileUrl_NonAudioFile_ReturnsFalse)
+{
+    const QString &path = makeTextFile("note.txt");
+    ASSERT_FALSE(path.isEmpty());
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+    EXPECT_EQ(preview->statusBarWidget(), nullptr);
+}
+
+TEST_F(UT_MusicPreview, SetFileUrl_ValidMp3_CreatesWidgetsAndReturnsTrue)
+{
+    const QString &path = makeMp3File("song.mp3");
+    ASSERT_FALSE(path.isEmpty());
+    const QUrl url = QUrl::fromLocalFile(path);
+
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(preview->fileUrl(), url);
+    EXPECT_NE(preview->contentWidget(), nullptr);
+    EXPECT_NE(preview->statusBarWidget(), nullptr);
+    EXPECT_EQ(static_cast<int>(preview->statusBarWidgetAlignment()), 0);
+    EXPECT_TRUE(preview->contentWidget()->size() == QSize(600, 336));
+}
+
+TEST_F(UT_MusicPreview, SetFileUrl_SameUrlTwice_ReturnsTrueWithoutRecreating)
+{
+    const QString &path = makeMp3File("song.mp3");
+    const QUrl url = QUrl::fromLocalFile(path);
+    ASSERT_TRUE(preview->setFileUrl(url));
+    QWidget *view = preview->contentWidget();
+    QWidget *bar = preview->statusBarWidget();
+
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(preview->contentWidget(), view);
+    EXPECT_EQ(preview->statusBarWidget(), bar);
+}
+
+TEST_F(UT_MusicPreview, SetFileUrl_DifferentUrlAfterWidgetsCreated_ReturnsFalse)
+{
+    const QString &pathA = makeMp3File("a.mp3");
+    const QString &pathB = makeMp3File("b.mp3");
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(pathA)));
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(pathB)));
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(pathA));
+}
+
+TEST_F(UT_MusicPreview, SetFileUrl_FailureThenSuccess_StillSucceeds)
+{
+    const QString &textPath = makeTextFile("note.txt");
+    const QString &mp3Path = makeMp3File("song.mp3");
+    ASSERT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(textPath)));
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(mp3Path)));
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(mp3Path));
+}
+
+TEST_F(UT_MusicPreview, Play_WithWidgets_EmitsSingletonPlaySignal)
+{
+    const QString &path = makeMp3File("song.mp3");
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPlay);
+
+    preview->play();
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_MusicPreview, Pause_WithWidgets_EmitsSingletonPauseSignal)
+{
+    const QString &path = makeMp3File("song.mp3");
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPause);
+
+    preview->pause();
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_MusicPreview, Stop_WithWidgets_EmitsSingletonStopSignal)
+{
+    const QString &path = makeMp3File("song.mp3");
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigStop);
+
+    preview->stop();
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_MusicPreview, HandleBeforDestroy_EmitsSingletonStopSignal)
+{
+    const QString &path = makeMp3File("song.mp3");
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigStop);
+
+    preview->handleBeforDestroy();
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_MusicPreview, Destroy_WidgetsDeletedViaDeferredDelete)
+{
+    const QString &path = makeMp3File("song.mp3");
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    QWidget *view = preview->contentWidget();
+    QWidget *bar = preview->statusBarWidget();
+    bool viewDestroyed = false;
+    bool barDestroyed = false;
+    QObject::connect(view, &QObject::destroyed, [&viewDestroyed](QObject *) { viewDestroyed = true; });
+    QObject::connect(bar, &QObject::destroyed, [&barDestroyed](QObject *) { barDestroyed = true; });
+
+    delete preview;
+    preview = nullptr;
+    EXPECT_FALSE(viewDestroyed);
+    EXPECT_FALSE(barDestroyed);
+
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    EXPECT_TRUE(viewDestroyed);
+    EXPECT_TRUE(barDestroyed);
+}
+
+class UT_MusicPreviewPlugin : public testing::Test
+{
+};
+
+TEST_F(UT_MusicPreviewPlugin, Create_AnyKey_ReturnsMusicPreviewInstance)
+{
+    MusicPreviewPlugin plugin;
+    AbstractBasePreview *obj = plugin.create("music");
+    ASSERT_NE(obj, nullptr);
+    EXPECT_NE(qobject_cast<MusicPreview *>(obj), nullptr);
+    delete obj;
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}

--- a/autotests/apps/dde-file-manager-preview/music-preview/test_toolbarframe.cpp
+++ b/autotests/apps/dde-file-manager-preview/music-preview/test_toolbarframe.cpp
@@ -1,0 +1,649 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "toolbarframe.h"
+#include "cusmediaplayer.h"
+#include "mediawork.h"
+#include "cover.h"
+
+#include <gtest/gtest.h>
+
+#include <DSlider>
+
+#include <QApplication>
+#include <QPainter>
+#include <QEvent>
+#include <QLabel>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QSlider>
+#include <QTemporaryDir>
+#include <QThread>
+#include <QUrl>
+
+#include <atomic>
+
+using namespace plugin_filepreview;
+
+static std::atomic<int> g_mediaWorkPlayCount { 0 };
+
+class UT_ToolBarFrame : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        frame = new ToolBarFrame(QUrl::fromLocalFile(dir.filePath("song.mp3")).toString());
+    }
+
+    void TearDown() override
+    {
+        delete frame;
+        frame = nullptr;
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        qApp->processEvents();
+        stub.clear();
+    }
+
+protected:
+    ToolBarFrame *frame { nullptr };
+    QTemporaryDir dir;
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ToolBarFrame, Constructor_CreatesAllUiElements)
+{
+    EXPECT_NE(frame->playControlButton, nullptr);
+    EXPECT_NE(frame->progressSlider, nullptr);
+    EXPECT_NE(frame->durationLabel, nullptr);
+    EXPECT_EQ(frame->playControlButton->accessibleName(), QString("PlayControlButton"));
+    EXPECT_EQ(frame->progressSlider->accessibleName(), QString("ProgressSlider"));
+    EXPECT_EQ(frame->curState, QMediaPlayer::StoppedState);
+}
+
+TEST_F(UT_ToolBarFrame, DurationToLabel_ZeroDuration_ShowsPlaceholderAndDisablesSlider)
+{
+    frame->durationToLabel(0);
+    EXPECT_EQ(frame->durationLabel->text(), QString("--"));
+    EXPECT_EQ(frame->progressSlider->minimum(), 0);
+    EXPECT_EQ(frame->progressSlider->maximum(), 0);
+}
+
+TEST_F(UT_ToolBarFrame, DurationToLabel_NegativeDuration_ShowsPlaceholder)
+{
+    frame->durationToLabel(-5);
+    EXPECT_EQ(frame->durationLabel->text(), QString("--"));
+}
+
+TEST_F(UT_ToolBarFrame, DurationToLabel_65Seconds_ShowsFormattedTime)
+{
+    frame->durationToLabel(65000);
+    EXPECT_EQ(frame->durationLabel->text(), QString("01: 05"));
+    EXPECT_EQ(frame->progressSlider->maximum(), 65000);
+}
+
+TEST_F(UT_ToolBarFrame, DurationToLabel_TenMinutes_ShowsTwoDigitMinutes)
+{
+    frame->durationToLabel(599000);
+    EXPECT_EQ(frame->durationLabel->text(), QString("09: 59"));
+}
+
+TEST_F(UT_ToolBarFrame, DurationToLabel_ExactMinute_ShowsDoubleZeroSeconds)
+{
+    frame->durationToLabel(60000);
+    EXPECT_EQ(frame->durationLabel->text(), QString("01: 00"));
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayDurationChanged_ForwardsToDurationLabel)
+{
+    frame->onPlayDurationChanged(125000);
+    EXPECT_EQ(frame->durationLabel->text(), QString("02: 05"));
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayStateChanged_Playing_ShowsPauseIcon)
+{
+    frame->onPlayDurationChanged(1000);
+    frame->onPlayStateChanged(QMediaPlayer::PlayingState);
+    EXPECT_TRUE(frame->controlButtonShowsPause);
+    EXPECT_EQ(frame->curState, QMediaPlayer::PlayingState);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayStateChanged_Stopped_ResetsSlider)
+{
+    frame->onPlayDurationChanged(1000);
+    frame->progressSlider->setValue(500);
+    frame->onPlayStateChanged(QMediaPlayer::StoppedState);
+    EXPECT_EQ(frame->progressSlider->value(), 0);
+    EXPECT_FALSE(frame->controlButtonShowsPause);
+    EXPECT_EQ(frame->curState, QMediaPlayer::StoppedState);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayStateChanged_Paused_ShowsPlayIcon)
+{
+    frame->onPlayStateChanged(QMediaPlayer::PausedState);
+    EXPECT_FALSE(frame->controlButtonShowsPause);
+    EXPECT_EQ(frame->curState, QMediaPlayer::PausedState);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayPositionChanged_Playing_UpdatesSliderValue)
+{
+    frame->onPlayStateChanged(QMediaPlayer::PlayingState);
+    frame->onPlayDurationChanged(1000);
+    frame->onPlayPositionChanged(300);
+    EXPECT_EQ(frame->progressSlider->value(), 300);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayPositionChanged_SamePositionTwice_UpdatesOnlyOnce)
+{
+    frame->onPlayStateChanged(QMediaPlayer::PlayingState);
+    frame->onPlayDurationChanged(1000);
+    frame->onPlayPositionChanged(300);
+    frame->onPlayPositionChanged(300);
+    EXPECT_EQ(frame->progressSlider->value(), 300);
+    EXPECT_EQ(frame->lastPos, 300);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayPositionChanged_StoppedState_Ignored)
+{
+    frame->onPlayDurationChanged(1000);
+    frame->onPlayPositionChanged(300);
+    EXPECT_EQ(frame->progressSlider->value(), 0);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayStatusChanged_LoadedMedia_ShowsDurationFromPlayer)
+{
+    stub.set_lamda(&CusMediaPlayer::duration, [](const CusMediaPlayer *) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return 65000;
+    });
+    frame->onPlayStatusChanged(QMediaPlayer::LoadedMedia);
+    EXPECT_EQ(frame->durationLabel->text(), QString("01: 05"));
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayStatusChanged_OtherStatus_LabelUntouched)
+{
+    frame->onPlayStatusChanged(QMediaPlayer::LoadingMedia);
+    EXPECT_TRUE(frame->durationLabel->text().isEmpty());
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayControlButtonClicked_PlayingState_PausesPlayback)
+{
+    stub.set_lamda(&CusMediaPlayer::state, [](const CusMediaPlayer *) -> QMediaPlayer::PlaybackState {
+        __DBG_STUB_INVOKE__
+        return QMediaPlayer::PlayingState;
+    });
+    QSignalSpy pauseSpy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPause);
+    QSignalSpy playSpy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPlay);
+
+    frame->onPlayControlButtonClicked();
+    EXPECT_EQ(pauseSpy.count(), 1);
+    EXPECT_EQ(playSpy.count(), 0);
+    EXPECT_EQ(frame->curState, QMediaPlayer::PausedState);
+    EXPECT_FALSE(frame->controlButtonShowsPause);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayControlButtonClicked_StoppedState_PlaysFromStart)
+{
+    stub.set_lamda(&CusMediaPlayer::state, [](const CusMediaPlayer *) -> QMediaPlayer::PlaybackState {
+        __DBG_STUB_INVOKE__
+        return QMediaPlayer::StoppedState;
+    });
+    frame->onPlayDurationChanged(1000);
+    frame->progressSlider->setValue(500);
+    QSignalSpy playSpy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPlay);
+
+    frame->onPlayControlButtonClicked();
+    EXPECT_EQ(playSpy.count(), 1);
+    EXPECT_EQ(frame->progressSlider->value(), 0);
+    EXPECT_EQ(frame->curState, QMediaPlayer::PlayingState);
+}
+
+TEST_F(UT_ToolBarFrame, OnPlayControlButtonClicked_PausedState_ResumesPlayback)
+{
+    stub.set_lamda(&CusMediaPlayer::state, [](const CusMediaPlayer *) -> QMediaPlayer::PlaybackState {
+        __DBG_STUB_INVOKE__
+        return QMediaPlayer::PausedState;
+    });
+    QSignalSpy playSpy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPlay);
+
+    frame->onPlayControlButtonClicked();
+    EXPECT_EQ(playSpy.count(), 1);
+    EXPECT_EQ(frame->curState, QMediaPlayer::PlayingState);
+}
+
+TEST_F(UT_ToolBarFrame, Play_EmitsSignalAndSwitchesToPlayingState)
+{
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPlay);
+    frame->play();
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(frame->curState, QMediaPlayer::PlayingState);
+    EXPECT_TRUE(frame->controlButtonShowsPause);
+}
+
+TEST_F(UT_ToolBarFrame, Pause_EmitsSignalAndSwitchesToPausedState)
+{
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigPause);
+    frame->pause();
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(frame->curState, QMediaPlayer::PausedState);
+    EXPECT_FALSE(frame->controlButtonShowsPause);
+}
+
+TEST_F(UT_ToolBarFrame, Stop_EmitsSignalResetsSliderAndState)
+{
+    frame->onPlayDurationChanged(1000);
+    frame->progressSlider->setValue(500);
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigStop);
+
+    frame->stop();
+    EXPECT_EQ(spy.count(), 1);
+    EXPECT_EQ(frame->progressSlider->value(), 0);
+    EXPECT_EQ(frame->curState, QMediaPlayer::StoppedState);
+    EXPECT_FALSE(frame->controlButtonShowsPause);
+}
+
+TEST_F(UT_ToolBarFrame, SeekPosition_BeyondThreshold_EmitsSetPosition)
+{
+    stub.set_lamda(&CusMediaPlayer::position, [](const CusMediaPlayer *) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return 0;
+    });
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigSetPosition);
+
+    frame->seekPosition(50);
+    EXPECT_EQ(spy.count(), 1);
+    ASSERT_EQ(spy.size(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toInt(), 50);
+}
+
+TEST_F(UT_ToolBarFrame, SeekPosition_WithinThreshold_DoesNotEmit)
+{
+    stub.set_lamda(&CusMediaPlayer::position, [](const CusMediaPlayer *) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return 0;
+    });
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigSetPosition);
+
+    frame->seekPosition(2);
+    frame->seekPosition(3);
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_ToolBarFrame, SliderValueChanged_ConnectedToSeekPosition)
+{
+    stub.set_lamda(&CusMediaPlayer::position, [](const CusMediaPlayer *) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return 0;
+    });
+    frame->onPlayDurationChanged(1000);
+    QSignalSpy spy(CusMediaPlayer::instance(), &CusMediaPlayer::sigSetPosition);
+
+    frame->progressSlider->setValue(80);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_ToolBarFrame, EventFilter_EnterOnPlayButton_SetsHovered)
+{
+    QEvent event(QEvent::Enter);
+    frame->eventFilter(frame->playControlButton, &event);
+    EXPECT_TRUE(frame->playControlButtonHovered);
+}
+
+TEST_F(UT_ToolBarFrame, EventFilter_LeaveOnPlayButton_ClearsHovered)
+{
+    frame->playControlButtonHovered = true;
+    QEvent event(QEvent::Leave);
+    frame->eventFilter(frame->playControlButton, &event);
+    EXPECT_FALSE(frame->playControlButtonHovered);
+}
+
+TEST_F(UT_ToolBarFrame, EventFilter_StyleChange_RefreshesIconWithoutCrash)
+{
+    QEvent styleEvent(QEvent::StyleChange);
+    frame->eventFilter(frame->playControlButton, &styleEvent);
+    QEvent paletteEvent(QEvent::PaletteChange);
+    frame->eventFilter(frame->playControlButton, &paletteEvent);
+    QEvent appPaletteEvent(QEvent::ApplicationPaletteChange);
+    frame->eventFilter(frame->playControlButton, &appPaletteEvent);
+    SUCCEED();
+}
+
+TEST_F(UT_ToolBarFrame, EventFilter_OtherObject_DoesNotAffectHoverState)
+{
+    QWidget other;
+    QEvent event(QEvent::Enter);
+    frame->eventFilter(&other, &event);
+    EXPECT_FALSE(frame->playControlButtonHovered);
+}
+
+TEST_F(UT_ToolBarFrame, UpdatePlayButtonIcon_KeepsIconSizeConfigured)
+{
+    frame->controlButtonShowsPause = true;
+    frame->updatePlayButtonIcon();
+    EXPECT_EQ(frame->playControlButton->iconSize(), QSize(16, 16));
+}
+
+class UT_Cover : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        cover = new Cover();
+        cover->resize(40, 40);
+    }
+
+    void TearDown() override
+    {
+        delete cover;
+        cover = nullptr;
+    }
+
+    QImage grabCover()
+    {
+        QPixmap shot(cover->size());
+        shot.fill(Qt::transparent);
+        QPainter painter(&shot);
+        cover->render(&painter, QPoint(), QRegion(), QWidget::RenderFlags(QWidget::DrawChildren));
+        return shot.toImage();
+    }
+
+protected:
+    Cover *cover { nullptr };
+};
+
+TEST_F(UT_Cover, Constructor_TranslucentBackgroundEnabled)
+{
+    EXPECT_TRUE(cover->testAttribute(Qt::WA_TranslucentBackground));
+}
+
+TEST_F(UT_Cover, PaintEvent_NoBackground_FillsWhite)
+{
+    const QImage &shot = grabCover();
+    const QColor &center = shot.pixelColor(shot.width() / 2, shot.height() / 2);
+    EXPECT_EQ(center.rgb(), qRgb(255, 255, 255));
+    EXPECT_EQ(center.alpha(), 255);
+}
+
+TEST_F(UT_Cover, SetCoverPixmap_WithPixmap_DrawsScaledPixmap)
+{
+    QPixmap pixmap(8, 8);
+    pixmap.fill(Qt::red);
+    cover->setCoverPixmap(pixmap);
+
+    const QImage &shot = grabCover();
+    EXPECT_EQ(shot.pixelColor(shot.width() / 2, shot.height() / 2).rgb(), qRgb(255, 0, 0));
+}
+
+TEST_F(UT_Cover, PaintEvent_RoundedCorners_CornerOutsideClipIsTransparent)
+{
+    QPixmap pixmap(8, 8);
+    pixmap.fill(Qt::red);
+    cover->setCoverPixmap(pixmap);
+
+    const QImage &shot = grabCover();
+    EXPECT_EQ(shot.pixelColor(0, 0).alpha(), 0);
+    EXPECT_EQ(shot.pixelColor(shot.width() - 1, 0).alpha(), 0);
+    EXPECT_EQ(shot.pixelColor(0, shot.height() - 1).alpha(), 0);
+    EXPECT_EQ(shot.pixelColor(shot.width() - 1, shot.height() - 1).alpha(), 0);
+}
+
+class UT_CusMediaPlayer : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        g_mediaWorkPlayCount = 0;
+        stub.set_lamda(&MediaWork::createMediaPlayer, [](MediaWork *) { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&MediaWork::setMedia, [](MediaWork *, const QUrl &) { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&MediaWork::setPosition, [](MediaWork *, qint64) { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&MediaWork::pause, [](MediaWork *) { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&MediaWork::stop, [](MediaWork *) { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&MediaWork::play, [](MediaWork *) { __DBG_STUB_INVOKE__ ++g_mediaWorkPlayCount; });
+    }
+
+    void TearDown() override
+    {
+        qApp->processEvents();
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_CusMediaPlayer, Instance_ReturnsSameSingleton)
+{
+    EXPECT_NE(CusMediaPlayer::instance(), nullptr);
+    EXPECT_EQ(CusMediaPlayer::instance(), CusMediaPlayer::instance());
+}
+
+TEST_F(UT_CusMediaPlayer, CreateMediaPlayer_EmitsCreateSignalAtMostOnce)
+{
+    CusMediaPlayer *player = CusMediaPlayer::instance();
+    QSignalSpy spy(player, &CusMediaPlayer::sigCreateMediaPlayer);
+    player->createMediaPlayer();
+    player->createMediaPlayer();
+    player->createMediaPlayer();
+    EXPECT_LE(spy.count(), 1);
+}
+
+TEST_F(UT_CusMediaPlayer, SetMedia_EmitsStopAndSetMediaSignals)
+{
+    CusMediaPlayer *player = CusMediaPlayer::instance();
+    QSignalSpy stopSpy(player, &CusMediaPlayer::sigStop);
+    QSignalSpy setSpy(player, &CusMediaPlayer::sigSetMedia);
+    const QUrl url = QUrl::fromLocalFile("/tmp/song.mp3");
+
+    player->setMedia(url);
+    EXPECT_EQ(stopSpy.count(), 1);
+    EXPECT_EQ(setSpy.count(), 1);
+    ASSERT_EQ(setSpy.size(), 1);
+    EXPECT_EQ(setSpy.at(0).at(0).toUrl(), url);
+}
+
+TEST_F(UT_CusMediaPlayer, Duration_ForwardsToWorker)
+{
+    stub.set_lamda(&MediaWork::duration, [](const MediaWork *) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return 4242;
+    });
+    EXPECT_EQ(CusMediaPlayer::instance()->duration(), 4242);
+}
+
+TEST_F(UT_CusMediaPlayer, State_ForwardsToWorker)
+{
+    stub.set_lamda(&MediaWork::state, [](const MediaWork *) -> QMediaPlayer::PlaybackState {
+        __DBG_STUB_INVOKE__
+        return QMediaPlayer::PlayingState;
+    });
+    EXPECT_EQ(CusMediaPlayer::instance()->state(), QMediaPlayer::PlayingState);
+}
+
+TEST_F(UT_CusMediaPlayer, Position_ForwardsToWorker)
+{
+    stub.set_lamda(&MediaWork::position, [](const MediaWork *) -> qint64 {
+        __DBG_STUB_INVOKE__
+        return 777;
+    });
+    EXPECT_EQ(CusMediaPlayer::instance()->position(), 777);
+}
+
+TEST_F(UT_CusMediaPlayer, SignalPlay_IsDeliveredToWorkerThread)
+{
+    CusMediaPlayer *player = CusMediaPlayer::instance();
+    emit player->sigPlay();
+
+    bool delivered = false;
+    for (int i = 0; i < 100 && !delivered; ++i) {
+        QThread::msleep(20);
+        delivered = g_mediaWorkPlayCount.load() >= 1;
+    }
+    EXPECT_TRUE(delivered);
+}
+
+static QUrl g_capturedSourceUrl;
+static qint64 g_capturedPosition { -1 };
+static std::atomic<int> g_playerPlayCount { 0 };
+static std::atomic<int> g_playerPauseCount { 0 };
+static std::atomic<int> g_playerStopCount { 0 };
+
+class UT_MediaWork : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        g_capturedSourceUrl = QUrl();
+        g_capturedPosition = -1;
+        g_playerPlayCount = 0;
+        g_playerPauseCount = 0;
+        g_playerStopCount = 0;
+        work = new MediaWork();
+    }
+
+    void TearDown() override
+    {
+        delete work;
+        work = nullptr;
+        stub.clear();
+    }
+
+protected:
+    MediaWork *work { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_MediaWork, QueryMethods_BeforePlayerCreated_ReturnDefaults)
+{
+    EXPECT_EQ(work->duration(), -1);
+    EXPECT_EQ(work->position(), -1);
+    EXPECT_EQ(work->state(), QMediaPlayer::StoppedState);
+}
+
+TEST_F(UT_MediaWork, ControlSlots_BeforePlayerCreated_AreSafeNoOps)
+{
+    work->setMedia(QUrl::fromLocalFile("/tmp/song.mp3"));
+    work->setPosition(1000);
+    work->play();
+    work->pause();
+    work->stop();
+    EXPECT_EQ(work->state(), QMediaPlayer::StoppedState);
+    EXPECT_EQ(work->duration(), -1);
+    EXPECT_EQ(work->position(), -1);
+}
+
+TEST_F(UT_MediaWork, CreateMediaPlayer_CreatesPlayerWithInitialValues)
+{
+    work->createMediaPlayer();
+    ASSERT_NE(work->mediaPlayer, nullptr);
+    EXPECT_EQ(work->state(), QMediaPlayer::StoppedState);
+    EXPECT_EQ(work->position(), 0);
+    EXPECT_EQ(work->duration(), 0);
+}
+
+TEST_F(UT_MediaWork, CreateMediaPlayer_ConnectsPositionSignal)
+{
+    work->createMediaPlayer();
+    QSignalSpy spy(work, &MediaWork::playerPositionChanged);
+
+    const bool invoked = QMetaObject::invokeMethod(work->mediaPlayer, "positionChanged", Q_ARG(qint64, 7));
+    EXPECT_TRUE(invoked);
+    EXPECT_EQ(spy.count(), 1);
+    ASSERT_EQ(spy.size(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toLongLong(), qint64(7));
+}
+
+TEST_F(UT_MediaWork, CreateMediaPlayer_ConnectsDurationSignal)
+{
+    work->createMediaPlayer();
+    QSignalSpy spy(work, &MediaWork::playerDurationChanged);
+
+    const bool invoked = QMetaObject::invokeMethod(work->mediaPlayer, "durationChanged", Q_ARG(qint64, 9));
+    EXPECT_TRUE(invoked);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_MediaWork, CreateMediaPlayer_ConnectsStatusSignal)
+{
+    work->createMediaPlayer();
+    QSignalSpy spy(work, &MediaWork::playerStatusChanged);
+
+    const bool invoked = QMetaObject::invokeMethod(
+            work->mediaPlayer, "mediaStatusChanged",
+            Q_ARG(QMediaPlayer::MediaStatus, QMediaPlayer::LoadedMedia));
+    EXPECT_TRUE(invoked);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_MediaWork, CreateMediaPlayer_ConnectsStateSignal)
+{
+    work->createMediaPlayer();
+    QSignalSpy spy(work, &MediaWork::playerStateChanged);
+
+    const bool invoked = QMetaObject::invokeMethod(
+            work->mediaPlayer, "playbackStateChanged",
+            Q_ARG(QMediaPlayer::PlaybackState, QMediaPlayer::PlayingState));
+    EXPECT_TRUE(invoked);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_MediaWork, SetMedia_AfterPlayerCreated_ForwardsSourceToPlayer)
+{
+    work->createMediaPlayer();
+    stub.set_lamda(&QMediaPlayer::setSource, [](QMediaPlayer *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        g_capturedSourceUrl = url;
+    });
+    const QUrl url = QUrl::fromLocalFile("/tmp/forwarded.mp3");
+
+    work->setMedia(url);
+    EXPECT_EQ(g_capturedSourceUrl, url);
+}
+
+TEST_F(UT_MediaWork, SetPosition_AfterPlayerCreated_ForwardsPositionToPlayer)
+{
+    work->createMediaPlayer();
+    stub.set_lamda(&QMediaPlayer::setPosition, [](QMediaPlayer *, qint64 pos) {
+        __DBG_STUB_INVOKE__
+        g_capturedPosition = pos;
+    });
+
+    work->setPosition(1234);
+    EXPECT_EQ(g_capturedPosition, 1234);
+}
+
+TEST_F(UT_MediaWork, Play_AfterPlayerCreated_ForwardsToPlayer)
+{
+    work->createMediaPlayer();
+    stub.set_lamda(&QMediaPlayer::play, [](QMediaPlayer *) {
+        __DBG_STUB_INVOKE__
+        ++g_playerPlayCount;
+    });
+
+    work->play();
+    EXPECT_EQ(g_playerPlayCount.load(), 1);
+}
+
+TEST_F(UT_MediaWork, Pause_AfterPlayerCreated_ForwardsToPlayer)
+{
+    work->createMediaPlayer();
+    stub.set_lamda(&QMediaPlayer::pause, [](QMediaPlayer *) {
+        __DBG_STUB_INVOKE__
+        ++g_playerPauseCount;
+    });
+
+    work->pause();
+    EXPECT_EQ(g_playerPauseCount.load(), 1);
+}
+
+TEST_F(UT_MediaWork, Stop_AfterPlayerCreated_ForwardsToPlayer)
+{
+    work->createMediaPlayer();
+    stub.set_lamda(&QMediaPlayer::stop, [](QMediaPlayer *) {
+        __DBG_STUB_INVOKE__
+        ++g_playerStopCount;
+    });
+
+    work->stop();
+    EXPECT_EQ(g_playerStopCount.load(), 1);
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Unit tests for pdf-preview: recompile plugin sources into the test binary
+# so stub-ext can access private members (see autotests/README.md).
+set(_preview_dir "${DFM_PREVIEW_PLUGIN_DIR}/pdf-preview")
+
+file(GLOB_RECURSE _ut_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+file(GLOB_RECURSE _plugin_files
+    "${_preview_dir}/*.cpp"
+    "${_preview_dir}/*.h")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+find_package(Dtk6 COMPONENTS Widget REQUIRED)
+find_package(deepin-pdfium REQUIRED)
+
+dfm_create_test_executable(ut-pdf-preview
+    SOURCES ${_ut_files} ${_plugin_files}
+    LINK_LIBRARIES DFM6::base DFM6::framework Qt6::Widgets Dtk6::Widget deepin-pdfium::deepin-pdfium
+)
+
+target_include_directories(ut-pdf-preview PRIVATE
+    "${DFM_PREVIEW_PLUGIN_DIR}"
+    ${_preview_dir}
+)
+

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/main.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(pdf_preview)

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_browserpage.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_browserpage.cpp
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "browserpage.h"
+#include "docsheet.h"
+#include "sheetbrowser.h"
+#include "ut_common.h"
+
+#include <gtest/gtest.h>
+
+#include <QImage>
+#include <QStyleOptionGraphicsItem>
+#include <QWidget>
+
+using namespace plugin_filepreview;
+
+class UT_BrowserPage : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        ASSERT_TRUE(sheet->openFileExec(""));
+        browser = sheet->findChild<SheetBrowser *>();
+        ASSERT_NE(nullptr, browser);
+        page = new BrowserPage(browser, 0, sheet);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+        delete page;
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SheetBrowser *browser { nullptr };
+    BrowserPage *page { nullptr };
+};
+
+TEST_F(UT_BrowserPage, Construct_WithOpenedSheet_SetsOriginSize)
+{
+    QSizeF origin = page->originSizeF;
+    EXPECT_GT(origin.width(), 0.0);
+    EXPECT_GT(origin.height(), 0.0);
+}
+
+TEST_F(UT_BrowserPage, Construct_InitialIndexZero)
+{
+    EXPECT_EQ(0, page->itemIndex());
+}
+
+TEST_F(UT_BrowserPage, BoundingRect_BeforeRender_NegativeScale)
+{
+    EXPECT_LT(page->boundingRect().width(), 0.0);
+}
+
+TEST_F(UT_BrowserPage, Render_SetsScaleFactorAndPositiveBoundingRect)
+{
+    page->render(1.0, kRotateBy0);
+    EXPECT_DOUBLE_EQ(1.0, page->currentScaleFactor);
+    EXPECT_GT(page->boundingRect().width(), 0.0);
+    EXPECT_GT(page->boundingRect().height(), 0.0);
+    EXPECT_NEAR(kImageBrowserWidth, page->boundingRect().width(), 0.01);
+}
+
+TEST_F(UT_BrowserPage, Render_Rotation90_SwapsRectDimensions)
+{
+    page->render(1.0, kRotateBy0);
+    QRectF rect0 = page->rect();
+    page->render(1.0, kRotateBy90);
+    QRectF rect90 = page->rect();
+    EXPECT_NEAR(rect90.width(), rect0.height(), 0.01);
+    EXPECT_NEAR(rect90.height(), rect0.width(), 0.01);
+}
+
+TEST_F(UT_BrowserPage, Render_Rotation180_SetsItemRotation)
+{
+    page->render(1.0, kRotateBy180);
+    EXPECT_EQ(qreal(180.0), page->rotation());
+    EXPECT_EQ(kRotateBy180, page->currentRotation);
+}
+
+TEST_F(UT_BrowserPage, Render_Rotation270_SetsItemRotation)
+{
+    page->render(1.0, kRotateBy270);
+    EXPECT_EQ(qreal(270.0), page->rotation());
+}
+
+TEST_F(UT_BrowserPage, Render_RenderLaterWithSameRotation_SkipsUpdate)
+{
+    page->render(1.0, kRotateBy90, true);
+    qreal rotationAfterFirst = page->rotation();
+    page->render(1.0, kRotateBy90, true);
+    EXPECT_EQ(rotationAfterFirst, page->rotation());
+    EXPECT_LT(page->renderPixmapScaleFactor, 0.0);
+}
+
+TEST_F(UT_BrowserPage, Render_RenderLaterFalse_CreatesPixmapAndTask)
+{
+    page->render(1.0, kRotateBy0);
+    EXPECT_FALSE(page->currentPixmap.isNull());
+    EXPECT_GT(page->currentPixmapId, 0);
+    EXPECT_DOUBLE_EQ(1.0, page->renderPixmapScaleFactor);
+}
+
+TEST_F(UT_BrowserPage, Render_RealRenderTask_UpdatesPixmapContent)
+{
+    page->render(1.0, kRotateBy0);
+    QImage before = page->getCurrentImage(80, 100);
+    ASSERT_FALSE(before.isNull());
+    ut_utils::processEventsUntil([&]() {
+        QImage after = page->getCurrentImage(80, 100);
+        return !after.isNull() && after != before;
+    });
+    QImage after = page->getCurrentImage(80, 100);
+    EXPECT_FALSE(after.isNull());
+}
+
+TEST_F(UT_BrowserPage, Render_DifferentScale_ReplacesPixmap)
+{
+    page->render(1.0, kRotateBy0);
+    int idAfterFirst = page->currentPixmapId;
+    page->render(0.5, kRotateBy0);
+    EXPECT_GT(page->currentPixmapId, idAfterFirst);
+    EXPECT_DOUBLE_EQ(0.5, page->renderPixmapScaleFactor);
+}
+
+TEST_F(UT_BrowserPage, RenderRect_NullBrowserParent_ReturnsEarly)
+{
+    BrowserPage *orphan = new BrowserPage(nullptr, 0, sheet);
+    orphan->renderRect(QRectF(0, 0, 10, 10));
+    delete orphan;
+}
+
+TEST_F(UT_BrowserPage, RenderRect_WithParent_NoCrash)
+{
+    page->renderRect(QRectF(0, 0, 10, 10));
+    SUCCEED();
+}
+
+TEST_F(UT_BrowserPage, RenderViewPort_NullBrowserParent_ReturnsEarly)
+{
+    BrowserPage *orphan = new BrowserPage(nullptr, 0, sheet);
+    orphan->renderViewPort();
+    delete orphan;
+}
+
+TEST_F(UT_BrowserPage, RenderViewPort_WithParent_MarksViewportRendered)
+{
+    sheet->resize(800, 600);
+    browser->resize(800, 600);
+    ut_utils::drainEvents(50);
+    page->render(1.0, kRotateBy0);
+    page->renderViewPort();
+    EXPECT_TRUE(page->viewportRendered);
+}
+
+TEST_F(UT_BrowserPage, GetCurrentImage_NullPixmap_ReturnsNull)
+{
+    EXPECT_TRUE(page->getCurrentImage(50, 60).isNull());
+}
+
+TEST_F(UT_BrowserPage, GetCurrentImage_RequestedLargerThanOriginal_ReturnsNull)
+{
+    page->render(0.1, kRotateBy0);
+    int pixmapWidth = page->currentPixmap.width();
+    int pixmapHeight = page->currentPixmap.height();
+    int big = qMax(pixmapWidth, pixmapHeight) + 10;
+    EXPECT_TRUE(page->getCurrentImage(big, big).isNull());
+}
+
+TEST_F(UT_BrowserPage, GetCurrentImage_ValidRequest_ReturnsScaledImage)
+{
+    page->render(1.0, kRotateBy0);
+    QImage image = page->getCurrentImage(60, 80);
+    EXPECT_FALSE(image.isNull());
+    EXPECT_LE(image.width(), 60);
+    EXPECT_LE(image.height(), 80);
+}
+
+TEST_F(UT_BrowserPage, ClearPixmap_BeforeAnyRender_NoEffect)
+{
+    page->clearPixmap();
+    EXPECT_LT(page->renderPixmapScaleFactor, 0.0);
+}
+
+TEST_F(UT_BrowserPage, ClearPixmap_AfterRender_ClearsImage)
+{
+    page->render(1.0, kRotateBy0);
+    EXPECT_FALSE(page->currentPixmap.isNull());
+    page->clearPixmap();
+    EXPECT_TRUE(page->currentPixmap.isNull());
+    EXPECT_LT(page->renderPixmapScaleFactor, 0.0);
+    EXPECT_TRUE(page->getCurrentImage(50, 60).isNull());
+}
+
+TEST_F(UT_BrowserPage, GetTopLeftPos_RotateBy0_ReturnsPosition)
+{
+    page->setPos(100, 200);
+    page->render(1.0, kRotateBy0);
+    QPointF topLeft = page->getTopLeftPos();
+    EXPECT_DOUBLE_EQ(100.0, topLeft.x());
+    EXPECT_DOUBLE_EQ(200.0, topLeft.y());
+}
+
+TEST_F(UT_BrowserPage, GetTopLeftPos_RotateBy90_ShiftsLeftByHeight)
+{
+    page->render(1.0, kRotateBy0);
+    page->setPos(100, 200);
+    page->render(1.0, kRotateBy90);
+    QPointF topLeft = page->getTopLeftPos();
+    EXPECT_DOUBLE_EQ(100.0 - page->rect().width(), topLeft.x());
+    EXPECT_DOUBLE_EQ(200.0, topLeft.y());
+}
+
+TEST_F(UT_BrowserPage, GetTopLeftPos_RotateBy180_ShiftsByRectSize)
+{
+    page->render(1.0, kRotateBy0);
+    page->setPos(100, 200);
+    page->render(1.0, kRotateBy180);
+    QPointF topLeft = page->getTopLeftPos();
+    EXPECT_DOUBLE_EQ(100.0 - page->rect().width(), topLeft.x());
+    EXPECT_DOUBLE_EQ(200.0 - page->rect().height(), topLeft.y());
+}
+
+TEST_F(UT_BrowserPage, GetTopLeftPos_RotateBy270_ShiftsUpByHeight)
+{
+    page->render(1.0, kRotateBy0);
+    page->setPos(100, 200);
+    page->render(1.0, kRotateBy270);
+    QPointF topLeft = page->getTopLeftPos();
+    EXPECT_DOUBLE_EQ(100.0, topLeft.x());
+    EXPECT_DOUBLE_EQ(200.0 - page->rect().height(), topLeft.y());
+}
+
+TEST_F(UT_BrowserPage, HandleRenderFinished_MatchingId_UpdatesPixmap)
+{
+    page->render(1.0, kRotateBy0);
+    int id = page->currentPixmapId;
+    QPixmap pixmap(20, 20);
+    pixmap.fill(Qt::blue);
+    page->handleRenderFinished(id, pixmap);
+    EXPECT_TRUE(page->pixmapHasRendered);
+    EXPECT_EQ(QColor(Qt::blue), QColor(page->currentPixmap.toImage().pixelColor(5, 5)));
+}
+
+TEST_F(UT_BrowserPage, HandleRenderFinished_StaleId_Ignored)
+{
+    page->render(1.0, kRotateBy0);
+    QPixmap pixmap(20, 20);
+    pixmap.fill(Qt::blue);
+    page->handleRenderFinished(page->currentPixmapId + 100, pixmap);
+    EXPECT_FALSE(page->pixmapHasRendered);
+}
+
+TEST_F(UT_BrowserPage, HandleRenderFinished_WithSlice_PaintsIntoPixmap)
+{
+    page->render(1.0, kRotateBy0);
+    int id = page->currentPixmapId;
+    QPixmap slice(10, 10);
+    slice.fill(Qt::green);
+    page->handleRenderFinished(id, slice, QRect(0, 0, 10, 10));
+    EXPECT_EQ(QColor(Qt::green), QColor(page->currentPixmap.toImage().pixelColor(3, 3)));
+    EXPECT_FALSE(page->pixmapHasRendered);
+}
+
+TEST_F(UT_BrowserPage, Paint_Offscreen_NoCrash)
+{
+    page->render(1.0, kRotateBy0);
+    QImage canvas(400, 500, QImage::Format_ARGB32_Premultiplied);
+    canvas.fill(Qt::white);
+    QPainter painter(&canvas);
+    QStyleOptionGraphicsItem option;
+    option.rect = QRect(0, 0, 400, 500);
+    page->paint(&painter, &option);
+    painter.end();
+    SUCCEED();
+}
+
+TEST_F(UT_BrowserPage, Destructor_ClearsPendingTasks_NoCrash)
+{
+    BrowserPage *temp = new BrowserPage(browser, 1, sheet);
+    temp->render(1.0, kRotateBy0);
+    delete temp;
+    SUCCEED();
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_docsheet.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_docsheet.cpp
@@ -1,0 +1,442 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "docsheet.h"
+#include "encryptionpage.h"
+#include "sheetbrowser.h"
+#include "sheetrenderer.h"
+#include "sheetsidebar.h"
+#include "sidebarimageviewmodel.h"
+#include "thumbnailwidget.h"
+#include "ut_common.h"
+
+#include <gtest/gtest.h>
+
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QScrollBar>
+#include <QSignalSpy>
+#include <QWidget>
+
+using namespace plugin_filepreview;
+
+class UT_DocSheet : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+        delete sheet;
+        sheet = nullptr;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+};
+
+TEST_F(UT_DocSheet, Construct_RegistersSheetInGlobalList)
+{
+    EXPECT_TRUE(DocSheet::existSheet(sheet));
+    EXPECT_TRUE(DocSheet::getSheets().contains(sheet));
+    EXPECT_EQ(sheet, DocSheet::getSheetByFilePath(pdfPath));
+}
+
+TEST_F(UT_DocSheet, Construct_PdfType_CreatesThumbnailSidebar)
+{
+    EXPECT_NE(nullptr, sheet->findChild<SheetSidebar *>());
+}
+
+TEST_F(UT_DocSheet, Construct_PdfType_CreatesBrowserAndRenderer)
+{
+    EXPECT_NE(nullptr, sheet->findChild<SheetBrowser *>());
+    EXPECT_NE(nullptr, sheet->renderer());
+}
+
+TEST_F(UT_DocSheet, Construct_UnknownFileType_CreatesSidebarWithoutThumbnails)
+{
+    DocSheet *unknownSheet = new DocSheet(kUnknown, "/tmp/unknown-file");
+    SheetSidebar *sidebar = unknownSheet->findChild<SheetSidebar *>();
+    ASSERT_NE(nullptr, sidebar);
+    EXPECT_EQ(nullptr, sidebar->findChild<ThumbnailWidget *>());
+    delete unknownSheet;
+}
+
+TEST_F(UT_DocSheet, Destructor_RemovesSheetFromGlobalList)
+{
+    DocSheet *temp = new DocSheet(kPDF, "/tmp/removed.pdf");
+    ASSERT_TRUE(DocSheet::existSheet(temp));
+    delete temp;
+    EXPECT_FALSE(DocSheet::existSheet(temp));
+    EXPECT_EQ(nullptr, DocSheet::getSheetByFilePath("/tmp/removed.pdf"));
+}
+
+TEST_F(UT_DocSheet, Opened_BeforeOpen_ReturnsFalse)
+{
+    EXPECT_FALSE(sheet->opened());
+}
+
+TEST_F(UT_DocSheet, PageCount_BeforeOpen_ReturnsZero)
+{
+    EXPECT_EQ(0, sheet->pageCount());
+}
+
+TEST_F(UT_DocSheet, CurrentPage_BeforeOpen_ClampsToOne)
+{
+    EXPECT_EQ(1, sheet->currentPage());
+    EXPECT_EQ(0, sheet->currentIndex());
+}
+
+TEST_F(UT_DocSheet, Format_ReturnsPdf)
+{
+    EXPECT_EQ(QString("PDF"), sheet->format());
+}
+
+TEST_F(UT_DocSheet, Operation_DefaultValues)
+{
+    SheetOperation op = sheet->operation();
+    EXPECT_EQ(SinglePageMode, op.layoutMode);
+    EXPECT_EQ(kRotateBy0, op.rotation);
+    EXPECT_DOUBLE_EQ(0.9, op.scaleFactor);
+    EXPECT_EQ(1, op.currentPage);
+    EXPECT_TRUE(op.sidebarVisible);
+}
+
+TEST_F(UT_DocSheet, FileType_ReturnsConstructorValue)
+{
+    EXPECT_EQ(kPDF, sheet->fileType());
+}
+
+TEST_F(UT_DocSheet, FilePath_ReturnsConstructorValue)
+{
+    EXPECT_EQ(pdfPath, sheet->filePath());
+    EXPECT_EQ(pdfPath, sheet->openedFilePath());
+}
+
+TEST_F(UT_DocSheet, SetThumbnail_ThenThumbnailReturnsPixmap)
+{
+    QPixmap pixmap(10, 10);
+    pixmap.fill(Qt::red);
+    sheet->setThumbnail(3, pixmap);
+    EXPECT_EQ(pixmap.toImage(), sheet->thumbnail(3).toImage());
+}
+
+TEST_F(UT_DocSheet, Thumbnail_UnknownIndex_ReturnsNull)
+{
+    EXPECT_TRUE(sheet->thumbnail(99).isNull());
+}
+
+TEST_F(UT_DocSheet, GetImage_BeforeOpen_ReturnsNull)
+{
+    EXPECT_TRUE(sheet->getImage(0, 50, 50).isNull());
+}
+
+TEST_F(UT_DocSheet, GetImage_InvalidIndex_ReturnsNull)
+{
+    EXPECT_TRUE(sheet->getImage(9999, 50, 50).isNull());
+}
+
+TEST_F(UT_DocSheet, PageSizeByIndex_BeforeOpen_ReturnsEmpty)
+{
+    EXPECT_EQ(QSizeF(), sheet->pageSizeByIndex(0));
+}
+
+TEST_F(UT_DocSheet, MaxScaleFactor_BeforeOpen_BoundedToFive)
+{
+    EXPECT_DOUBLE_EQ(5.0, sheet->maxScaleFactor());
+}
+
+TEST_F(UT_DocSheet, MaxScaleFactor_AlwaysWithinBounds)
+{
+    qreal factor = sheet->maxScaleFactor();
+    EXPECT_GE(factor, 0.1);
+    EXPECT_LE(factor, 5.0);
+}
+
+TEST_F(UT_DocSheet, ScaleFactorList_WithinMaxFactor)
+{
+    QList<qreal> factors = sheet->scaleFactorList();
+    EXPECT_FALSE(factors.isEmpty());
+    EXPECT_TRUE(factors.contains(1.0));
+    qreal max = sheet->maxScaleFactor();
+    foreach (qreal factor, factors) {
+        EXPECT_LE(factor, max + 0.0001);
+    }
+}
+
+TEST_F(UT_DocSheet, SetSidebarVisible_False_UpdatesOperation)
+{
+    sheet->setSidebarVisible(false);
+    EXPECT_FALSE(sheet->operation().sidebarVisible);
+    sheet->setSidebarVisible(true);
+    EXPECT_TRUE(sheet->operation().sidebarVisible);
+}
+
+TEST_F(UT_DocSheet, SetSidebarVisible_NotifyFalse_KeepsOperation)
+{
+    sheet->setSidebarVisible(false, false);
+    EXPECT_TRUE(sheet->operation().sidebarVisible);
+}
+
+TEST_F(UT_DocSheet, SetLayoutMode_TwoPages_UpdatesOperation)
+{
+    sheet->setLayoutMode(TwoPagesMode);
+    EXPECT_EQ(TwoPagesMode, sheet->operation().layoutMode);
+}
+
+TEST_F(UT_DocSheet, SetLayoutMode_InvalidMode_Ignored)
+{
+    sheet->setLayoutMode(static_cast<LayoutMode>(99));
+    EXPECT_EQ(SinglePageMode, sheet->operation().layoutMode);
+}
+
+TEST_F(UT_DocSheet, OpenFileExec_MissingFile_ReturnsFalse)
+{
+    DocSheet missing(kPDF, "/nonexistent-dir/no-such.pdf");
+    EXPECT_FALSE(missing.openFileExec(""));
+    EXPECT_FALSE(missing.opened());
+}
+
+TEST_F(UT_DocSheet, OpenFileExec_NotPdfContent_ReturnsFalse)
+{
+    QString textPath = ut_utils::prepareFile("/etc/hostname");
+    DocSheet textSheet(kPDF, textPath);
+    EXPECT_FALSE(textSheet.openFileExec(""));
+}
+
+TEST_F(UT_DocSheet, OpenFileAsync_MissingFile_EmitsOpenedWithError)
+{
+    qRegisterMetaType<Document::Error>("Document::Error");
+    DocSheet missing(kPDF, "/nonexistent-dir/no-such.pdf");
+    QSignalSpy spy(&missing, SIGNAL(sigFileOpened(DocSheet *, Document::Error)));
+    missing.openFileAsync("");
+    ut_utils::processEventsUntil([&spy]() { return spy.count() >= 1; });
+    ASSERT_GE(spy.count(), 1);
+    EXPECT_EQ(Document::kFileError, qvariant_cast<Document::Error>(spy.at(0).at(1)));
+    EXPECT_FALSE(missing.opened());
+}
+
+TEST_F(UT_DocSheet, OnBrowserPageChanged_UpdatesOperationCurrentPage)
+{
+    sheet->onBrowserPageChanged(5);
+    EXPECT_EQ(5, sheet->operation().currentPage);
+    EXPECT_EQ(1, sheet->currentPage());
+}
+
+TEST_F(UT_DocSheet, OnBrowserPageChanged_InvalidPage_Clamped)
+{
+    sheet->onBrowserPageChanged(0);
+    EXPECT_EQ(1, sheet->currentPage());
+    EXPECT_EQ(0, sheet->currentIndex());
+}
+
+TEST_F(UT_DocSheet, JumpToPage_BeforeOpen_NoCrash)
+{
+    sheet->jumpToPage(0);
+    sheet->jumpToPage(1);
+    sheet->jumpToIndex(0);
+}
+
+TEST_F(UT_DocSheet, ResizeEvent_NoEncryptionPage_NoCrash)
+{
+    sheet->resize(600, 400);
+    EXPECT_EQ(QSize(600, 400), sheet->size());
+}
+
+TEST_F(UT_DocSheet, ResizeEvent_WithEncryptionPage_AdjustsGeometry)
+{
+    sheet->onOpened(Document::kNeedPassword);
+    EncryptionPage *page = sheet->findChild<EncryptionPage *>();
+    ASSERT_NE(nullptr, page);
+    sheet->resize(800, 500);
+    EXPECT_GE(sheet->width(), 800);
+    EXPECT_EQ(500, sheet->height());
+}
+
+TEST_F(UT_DocSheet, OnOpened_NeedPassword_ShowsEncryptionPage)
+{
+    sheet->onOpened(Document::kNeedPassword);
+    EXPECT_NE(nullptr, sheet->findChild<EncryptionPage *>());
+}
+
+TEST_F(UT_DocSheet, OnOpened_WrongPassword_ShowsEncryptionPage)
+{
+    sheet->onOpened(Document::kWrongPassword);
+    EXPECT_NE(nullptr, sheet->findChild<EncryptionPage *>());
+}
+
+TEST_F(UT_DocSheet, OnOpened_NoErrorWithoutPassword_SkipsEncryptionCleanup)
+{
+    sheet->onOpened(Document::kNeedPassword);
+    EncryptionPage *page = sheet->findChild<EncryptionPage *>();
+    ASSERT_NE(nullptr, page);
+    sheet->onOpened(Document::kNoError);
+    EXPECT_NE(nullptr, sheet->findChild<EncryptionPage *>());
+}
+
+TEST_F(UT_DocSheet, ChildEvent_AddChild_NoCrash)
+{
+    QWidget *child = new QWidget(sheet);
+    child->deleteLater();
+    ut_utils::drainEvents(50);
+}
+
+TEST_F(UT_DocSheet, SigPageModified_ConnectedBySideBarModel)
+{
+    SideBarImageViewModel *model = sheet->findChild<SideBarImageViewModel *>();
+    ASSERT_NE(nullptr, model);
+    EXPECT_TRUE(sheet->isSignalConnected(
+            QMetaMethod::fromSignal(&DocSheet::sigPageModified)));
+}
+
+class UT_DocSheetOpened : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        opened = sheet->openFileExec("");
+        ASSERT_TRUE(opened);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+        delete sheet;
+        sheet = nullptr;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    bool opened { false };
+};
+
+TEST_F(UT_DocSheetOpened, OpenFileExec_ValidPdf_ReturnsTrue)
+{
+    EXPECT_TRUE(opened);
+    EXPECT_TRUE(sheet->opened());
+}
+
+TEST_F(UT_DocSheetOpened, SigFileOpened_EmittedWithNoError)
+{
+    QSignalSpy spy(sheet, SIGNAL(sigFileOpened(DocSheet *, Document::Error)));
+    sheet->openFileAsync("");
+    ut_utils::processEventsUntil([&spy]() { return spy.count() >= 1; });
+    ASSERT_GE(spy.count(), 1);
+    EXPECT_EQ(Document::kNoError, qvariant_cast<Document::Error>(spy.at(0).at(1)));
+}
+
+TEST_F(UT_DocSheetOpened, PageCount_AfterOpen_MatchesRenderer)
+{
+    EXPECT_GE(sheet->pageCount(), 2);
+    EXPECT_EQ(sheet->pageCount(), sheet->renderer()->getPageCount());
+}
+
+TEST_F(UT_DocSheetOpened, Browser_HasLoadedAfterOpen)
+{
+    SheetBrowser *browser = sheet->findChild<SheetBrowser *>();
+    ASSERT_NE(nullptr, browser);
+    EXPECT_TRUE(browser->hasLoaded());
+    EXPECT_EQ(sheet->pageCount(), browser->allPages());
+}
+
+TEST_F(UT_DocSheetOpened, JumpToPage_Two_ScrollsBrowserToPageTwo)
+{
+    SheetBrowser *browser = sheet->findChild<SheetBrowser *>();
+    ASSERT_NE(nullptr, browser);
+    ASSERT_GE(sheet->pageCount(), 2);
+    sheet->jumpToPage(2);
+    EXPECT_EQ(2, browser->currentPage());
+    sheet->jumpToIndex(0);
+    EXPECT_EQ(1, browser->currentPage());
+}
+
+TEST_F(UT_DocSheetOpened, JumpToPage_OutOfRange_Ignored)
+{
+    SheetBrowser *browser = sheet->findChild<SheetBrowser *>();
+    ASSERT_NE(nullptr, browser);
+    sheet->jumpToPage(2);
+    int value = browser->verticalScrollBar()->value();
+    sheet->jumpToPage(0);
+    EXPECT_EQ(value, browser->verticalScrollBar()->value());
+    sheet->jumpToPage(sheet->pageCount() + 1);
+    EXPECT_EQ(value, browser->verticalScrollBar()->value());
+}
+
+TEST_F(UT_DocSheetOpened, CurrentPage_WithinRange_ReturnsOperationPage)
+{
+    sheet->onBrowserPageChanged(3);
+    EXPECT_EQ(3, sheet->currentPage());
+    EXPECT_EQ(2, sheet->currentIndex());
+}
+
+TEST_F(UT_DocSheetOpened, CurrentPage_OutOfRange_Clamps)
+{
+    sheet->onBrowserPageChanged(sheet->pageCount() + 5);
+    EXPECT_EQ(1, sheet->currentPage());
+    EXPECT_EQ(0, sheet->currentIndex());
+}
+
+TEST_F(UT_DocSheetOpened, SetLayoutMode_TwoPages_DeformsBrowser)
+{
+    SheetBrowser *browser = sheet->findChild<SheetBrowser *>();
+    ASSERT_NE(nullptr, browser);
+    qreal singleWidth = browser->sceneRect().width();
+    sheet->setLayoutMode(TwoPagesMode);
+    EXPECT_EQ(TwoPagesMode, sheet->operation().layoutMode);
+    EXPECT_GT(browser->sceneRect().width(), singleWidth);
+}
+
+TEST_F(UT_DocSheetOpened, GetImage_ValidIndex_ReturnsRenderedImage)
+{
+    QImage image = sheet->getImage(0, 60, 80);
+    EXPECT_FALSE(image.isNull());
+}
+
+TEST_F(UT_DocSheetOpened, PageSizeByIndex_ValidIndex_ReturnsPositiveSize)
+{
+    QSizeF size = sheet->pageSizeByIndex(0);
+    EXPECT_GT(size.width(), 0.0);
+    EXPECT_GT(size.height(), 0.0);
+}
+
+TEST_F(UT_DocSheetOpened, PageSizeByIndex_OutOfRange_ReturnsEmpty)
+{
+    EXPECT_EQ(QSizeF(), sheet->pageSizeByIndex(sheet->pageCount()));
+}
+
+TEST_F(UT_DocSheetOpened, MaxScaleFactor_PositiveAfterOpen)
+{
+    EXPECT_GT(sheet->maxScaleFactor(), 0.1);
+}
+
+TEST_F(UT_DocSheetOpened, OpenedFilePath_AfterOpen_EqualsPath)
+{
+    EXPECT_EQ(pdfPath, sheet->openedFilePath());
+}
+
+TEST_F(UT_DocSheetOpened, OnExtractPassword_ValidPassword_ReopensAndHidesEncryption)
+{
+    sheet->onOpened(Document::kNeedPassword);
+    ASSERT_NE(nullptr, sheet->findChild<EncryptionPage *>());
+    QSignalSpy spy(sheet, SIGNAL(sigFileOpened(DocSheet *, Document::Error)));
+    sheet->onExtractPassword("valid-password");
+    ut_utils::processEventsUntil([&spy]() { return spy.count() >= 1; });
+    ASSERT_GE(spy.count(), 1);
+    EXPECT_EQ(Document::kNoError, qvariant_cast<Document::Error>(spy.at(0).at(1)));
+    ut_utils::drainEvents(100);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    EXPECT_EQ(nullptr, sheet->findChild<EncryptionPage *>());
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_global.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_global.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "global.h"
+#include "ut_common.h"
+
+#include "stubext.h"
+#include <dfm-base/mimetype/dmimedatabase.h>
+
+#include <gtest/gtest.h>
+
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QWidget>
+
+using namespace plugin_filepreview;
+
+static QMimeType pdfMime()
+{
+    QMimeDatabase db;
+    return db.mimeTypeForName("application/pdf");
+}
+
+TEST(UT_Global, FileType_PdfContent_ReturnsKPDF)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(static_cast<QMimeType (DFMBASE_NAMESPACE::DMimeDatabase::*)(const QUrl &, QMimeDatabase::MatchMode) const>(&DFMBASE_NAMESPACE::DMimeDatabase::mimeTypeForFile),
+                   [](DFMBASE_NAMESPACE::DMimeDatabase *, const QUrl &, QMimeDatabase::MatchMode) {
+                       __DBG_STUB_INVOKE__
+                       return pdfMime();
+                   });
+
+    EXPECT_EQ(kPDF, fileType(ut_utils::prepareFile(ut_utils::kSinglePagePdfSrc)));
+}
+
+TEST(UT_Global, FileType_TextContent_ReturnsKUnknown)
+{
+    EXPECT_EQ(kUnknown, fileType(ut_utils::prepareFile("/etc/hostname")));
+}
+
+TEST(UT_Global, FileType_NonExistentFile_ReturnsKUnknown)
+{
+    EXPECT_EQ(kUnknown, fileType("/nonexistent-dir/nonexistent-file.pdf"));
+}
+
+TEST(UT_Global, SetMainWidget_GetMainDialog_ReturnsSameWidget)
+{
+    QWidget widget;
+    setMainWidget(&widget);
+    EXPECT_EQ(&widget, getMainDialog());
+}
+
+TEST(UT_Global, SetMainWidgetNull_GetMainDialog_ReturnsNull)
+{
+    setMainWidget(nullptr);
+    EXPECT_EQ(nullptr, getMainDialog());
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_pagerenderthread.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_pagerenderthread.cpp
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "browserpage.h"
+#include "docsheet.h"
+#include "pagerenderthread.h"
+#include "pdfmodel.h"
+#include "sheetbrowser.h"
+#include "sheetrenderer.h"
+#include "sidebarimageviewmodel.h"
+#include "ut_common.h"
+
+#include <gtest/gtest.h>
+
+using namespace plugin_filepreview;
+
+class UT_PageRenderThread : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        browser = sheet->findChild<SheetBrowser *>();
+        ASSERT_NE(nullptr, browser);
+        model = new SideBarImageViewModel(sheet);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+        delete model;
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SheetBrowser *browser { nullptr };
+    SideBarImageViewModel *model { nullptr };
+};
+
+TEST_F(UT_PageRenderThread, ClearImageTasks_NullPage_ReturnsTrue)
+{
+    EXPECT_TRUE(PageRenderThread::clearImageTasks(nullptr, nullptr));
+}
+
+TEST_F(UT_PageRenderThread, ClearImageTasks_ValidPage_ReturnsTrue)
+{
+    BrowserPage page(browser, 0, sheet);
+    EXPECT_TRUE(PageRenderThread::clearImageTasks(sheet, &page));
+}
+
+TEST_F(UT_PageRenderThread, ClearImageTasks_RemovesAppendedTasks)
+{
+    BrowserPage page(browser, 0, sheet);
+    DocPageNormalImageTask task;
+    task.sheet = sheet;
+    task.page = &page;
+    task.pixmapId = 1;
+    task.rect = QRect(0, 0, 50, 50);
+    PageRenderThread::appendTask(task);
+    EXPECT_TRUE(PageRenderThread::clearImageTasks(sheet, &page));
+    ut_utils::drainEvents(150);
+    SUCCEED();
+}
+
+TEST_F(UT_PageRenderThread, AppendTask_OpenTask_OpensDocumentAsync)
+{
+    SheetRenderer *renderer = sheet->findChild<SheetRenderer *>();
+    ASSERT_NE(nullptr, renderer);
+    EXPECT_FALSE(renderer->opened());
+
+    DocOpenTask task;
+    task.sheet = sheet;
+    task.password = "";
+    task.renderer = renderer;
+    PageRenderThread::appendTask(task);
+
+    ut_utils::processEventsUntil([&renderer]() { return renderer->opened(); });
+    EXPECT_TRUE(renderer->opened());
+    EXPECT_GE(renderer->getPageCount(), 2);
+}
+
+TEST_F(UT_PageRenderThread, AppendTask_ThumbnailTask_RendersThumbnail)
+{
+    SheetRenderer *renderer = sheet->findChild<SheetRenderer *>();
+    ASSERT_NE(nullptr, renderer);
+    ASSERT_TRUE(renderer->openFileExec(""));
+    EXPECT_TRUE(sheet->thumbnail(0).isNull());
+
+    DocPageThumbnailTask task;
+    task.sheet = sheet;
+    task.model = model;
+    task.index = 0;
+    PageRenderThread::appendTask(task);
+
+    ut_utils::processEventsUntil([&]() { return !sheet->thumbnail(0).isNull(); });
+    QPixmap thumbnail = sheet->thumbnail(0);
+    EXPECT_FALSE(thumbnail.isNull());
+    EXPECT_GT(thumbnail.width(), 0);
+    EXPECT_LE(thumbnail.width(), 200);
+}
+
+TEST_F(UT_PageRenderThread, AppendTask_NormalImageTask_NoCrashWhenOrphanPage)
+{
+    BrowserPage *page = new BrowserPage(nullptr, 0, sheet);
+    DocPageNormalImageTask task;
+    task.sheet = sheet;
+    task.page = page;
+    task.pixmapId = 1;
+    task.rect = QRect(0, 0, 60, 80);
+    PageRenderThread::appendTask(task);
+    ut_utils::drainEvents(300);
+    delete page;
+    SUCCEED();
+}
+
+TEST_F(UT_PageRenderThread, AppendTask_SliceImageTask_NoCrash)
+{
+    BrowserPage *page = new BrowserPage(browser, 0, sheet);
+    page->render(1.0, kRotateBy0);
+    DocPageSliceImageTask task;
+    task.sheet = sheet;
+    task.page = page;
+    task.pixmapId = page->currentPixmapId;
+    task.whole = QRect(0, 0, 100, 130);
+    task.slice = QRect(0, 0, 50, 65);
+    PageRenderThread::appendTask(task);
+    ut_utils::drainEvents(300);
+    delete page;
+    SUCCEED();
+}
+
+TEST_F(UT_PageRenderThread, AppendTask_CloseTask_DeletesDocument)
+{
+    Document::Error error = Document::kFileError;
+    PDFDocument *document = PDFDocument::loadDocument(pdfPath, "", error);
+    ASSERT_NE(nullptr, document);
+    QList<Page *> pages;
+    for (int i = 0; i < document->pageCount(); ++i)
+        pages.append(document->page(i));
+
+    DocCloseTask task;
+    task.document = document;
+    task.pages = pages;
+    PageRenderThread::appendTask(task);
+
+    ut_utils::drainEvents(300);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    SUCCEED();
+}
+
+TEST_F(UT_PageRenderThread, OnDocOpenTask_ForMissingFile_ReportsFileError)
+{
+    DocSheet missing(kPDF, "/nonexistent-dir/no-such.pdf");
+    SheetRenderer *renderer = missing.findChild<SheetRenderer *>();
+    ASSERT_NE(nullptr, renderer);
+
+    DocOpenTask task;
+    task.sheet = &missing;
+    task.password = "";
+    task.renderer = renderer;
+    PageRenderThread::appendTask(task);
+
+    ut_utils::processEventsUntil([&renderer]() { return renderer->docError == Document::kFileError; });
+    EXPECT_EQ(Document::kFileError, renderer->docError);
+    EXPECT_FALSE(renderer->opened());
+}
+
+TEST_F(UT_PageRenderThread, OnDocPageNormalImageTaskFinished_UpdatesPage)
+{
+    BrowserPage page(browser, 0, sheet);
+    page.render(1.0, kRotateBy0);
+    DocPageNormalImageTask task;
+    task.sheet = sheet;
+    task.page = &page;
+    task.pixmapId = page.currentPixmapId;
+
+    QPixmap pixmap(20, 20);
+    pixmap.fill(Qt::red);
+    PageRenderThread::instance()->onDocPageNormalImageTaskFinished(task, pixmap);
+    EXPECT_TRUE(page.pixmapHasRendered);
+}
+
+TEST_F(UT_PageRenderThread, OnDocPageThumbnailTask_UpdatesModelThumbnail)
+{
+    QPixmap pixmap(30, 30);
+    pixmap.fill(Qt::blue);
+    PageRenderThread::instance()->onDocPageThumbnailTask([&]() {
+        DocPageThumbnailTask task;
+        task.sheet = sheet;
+        task.model = model;
+        task.index = 2;
+        return task;
+    }(), pixmap);
+    EXPECT_EQ(30, sheet->thumbnail(2).width());
+}
+
+TEST_F(UT_PageRenderThread, OnDocOpenTask_DeliversToRenderer)
+{
+    Document::Error error = Document::kFileError;
+    PDFDocument *document = PDFDocument::loadDocument(pdfPath, "", error);
+    ASSERT_NE(nullptr, document);
+    QList<Page *> pages;
+    for (int i = 0; i < document->pageCount(); ++i)
+        pages.append(document->page(i));
+
+    DocOpenTask task;
+    task.sheet = sheet;
+    task.password = "";
+    task.renderer = sheet->findChild<SheetRenderer *>();
+    PageRenderThread::instance()->onDocOpenTask(task, Document::kNoError, document, pages);
+
+    SheetRenderer *renderer = sheet->findChild<SheetRenderer *>();
+    EXPECT_TRUE(renderer->opened());
+    EXPECT_EQ(pages.count(), renderer->getPageCount());
+
+    delete renderer->documentObj;
+    qDeleteAll(renderer->pageList);
+    renderer->documentObj = nullptr;
+    renderer->pageList.clear();
+}
+
+TEST_F(UT_PageRenderThread, TaskForDeadSheet_IsSkipped)
+{
+    DocSheet *tempSheet = new DocSheet(kPDF, pdfPath);
+    SheetRenderer *renderer = tempSheet->findChild<SheetRenderer *>();
+    delete tempSheet;
+
+    DocOpenTask task;
+    task.sheet = nullptr;
+    task.password = "";
+    task.renderer = renderer;
+    PageRenderThread::appendTask(task);
+    ut_utils::drainEvents(200);
+    SUCCEED();
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_pdfmodel.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_pdfmodel.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "model.h"
+#include "pdfmodel.h"
+#include "ut_common.h"
+
+#include <gtest/gtest.h>
+
+#include <QImage>
+#include <QSizeF>
+
+using namespace plugin_filepreview;
+
+class UT_PdfModel : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        Document::Error error = Document::kFileError;
+        document = PDFDocument::loadDocument(pdfPath, "", error);
+        ASSERT_NE(nullptr, document);
+        ASSERT_EQ(Document::kNoError, error);
+    }
+
+    virtual void TearDown() override
+    {
+        delete document;
+        document = nullptr;
+        ut_utils::drainEvents();
+    }
+
+protected:
+    QString pdfPath;
+    PDFDocument *document { nullptr };
+};
+
+TEST_F(UT_PdfModel, LoadDocument_ValidPdf_ReturnsDocumentWithErrorCleared)
+{
+    Document::Error error = Document::kFileError;
+    PDFDocument *doc = PDFDocument::loadDocument(pdfPath, "", error);
+    EXPECT_NE(nullptr, doc);
+    EXPECT_EQ(Document::kNoError, error);
+    delete doc;
+}
+
+TEST_F(UT_PdfModel, LoadDocument_NonExistentFile_ReturnsNullWithFileError)
+{
+    Document::Error error = Document::kNoError;
+    PDFDocument *doc = PDFDocument::loadDocument("/nonexistent-dir/no-such.pdf", "", error);
+    EXPECT_EQ(nullptr, doc);
+    EXPECT_EQ(Document::kFileError, error);
+}
+
+TEST_F(UT_PdfModel, LoadDocument_NotPdfContent_ReturnsNullWithFileError)
+{
+    QString textPath = ut_utils::prepareFile("/etc/hostname");
+    Document::Error error = Document::kNoError;
+    PDFDocument *doc = PDFDocument::loadDocument(textPath, "", error);
+    EXPECT_EQ(nullptr, doc);
+    EXPECT_EQ(Document::kFileError, error);
+}
+
+TEST_F(UT_PdfModel, LoadDocument_ValidPdfWithPassword_ReturnsDocument)
+{
+    Document::Error error = Document::kFileError;
+    PDFDocument *doc = PDFDocument::loadDocument(pdfPath, "whatever", error);
+    EXPECT_NE(nullptr, doc);
+    EXPECT_EQ(Document::kNoError, error);
+    delete doc;
+}
+
+TEST_F(UT_PdfModel, DocumentFactory_PdfType_ReturnsPdfDocument)
+{
+    Document::Error error = Document::kFileError;
+    Document *doc = DocumentFactory::getDocument(kPDF, pdfPath, "", error);
+    EXPECT_NE(nullptr, doc);
+    EXPECT_EQ(Document::kNoError, error);
+    delete doc;
+}
+
+TEST_F(UT_PdfModel, DocumentFactory_NonPdfType_ReturnsNull)
+{
+    Document::Error error = Document::kNoError;
+    Document *doc = DocumentFactory::getDocument(kDJVU, pdfPath, "", error);
+    EXPECT_EQ(nullptr, doc);
+    delete doc;
+}
+
+TEST_F(UT_PdfModel, PageCount_MultiPagePdf_ReturnsPositiveCount)
+{
+    EXPECT_GE(document->pageCount(), 2);
+}
+
+TEST_F(UT_PdfModel, Page_ValidIndex_ReturnsPageWithPositiveSize)
+{
+    Page *page = document->page(0);
+    ASSERT_NE(nullptr, page);
+    QSizeF size = page->sizeF();
+    EXPECT_GT(size.width(), 0.0);
+    EXPECT_GT(size.height(), 0.0);
+    delete page;
+}
+
+TEST_F(UT_PdfModel, Page_OutOfRangeIndex_ReturnsNull)
+{
+    EXPECT_EQ(nullptr, document->page(document->pageCount()));
+    EXPECT_EQ(nullptr, document->page(-1));
+}
+
+TEST_F(UT_PdfModel, PageRender_FullPage_ReturnsNonEmptyImage)
+{
+    Page *page = document->page(0);
+    ASSERT_NE(nullptr, page);
+    QImage image = page->render(120, 160);
+    EXPECT_FALSE(image.isNull());
+    delete page;
+}
+
+TEST_F(UT_PdfModel, PageRender_WithSlice_ReturnsNonEmptyImage)
+{
+    Page *page = document->page(0);
+    ASSERT_NE(nullptr, page);
+    QImage image = page->render(200, 260, QRect(10, 10, 60, 80));
+    EXPECT_FALSE(image.isNull());
+    delete page;
+}
+
+TEST_F(UT_PdfModel, PageRender_LargeScale_ReturnsNonEmptyImage)
+{
+    Page *page = document->page(0);
+    ASSERT_NE(nullptr, page);
+    QImage image = page->render(600, 800);
+    EXPECT_FALSE(image.isNull());
+    delete page;
+}
+
+TEST_F(UT_PdfModel, DocumentDestructor_AfterPageFetch_NoCrash)
+{
+    Document::Error error = Document::kFileError;
+    PDFDocument *doc = PDFDocument::loadDocument(pdfPath, "", error);
+    ASSERT_NE(nullptr, doc);
+    Page *page = doc->page(0);
+    ASSERT_NE(nullptr, page);
+    QImage image = page->render(50, 60);
+    EXPECT_FALSE(image.isNull());
+    delete page;
+    delete doc;
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_sheetbrowser.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_sheetbrowser.cpp
@@ -1,0 +1,405 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "browserpage.h"
+#include "docsheet.h"
+#include "global.h"
+#include "sheetbrowser.h"
+#include "ut_common.h"
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QFocusEvent>
+#include <QMouseEvent>
+#include <QResizeEvent>
+#include <QScrollBar>
+#include <QSignalSpy>
+#include <QWheelEvent>
+#include <QWidget>
+
+using namespace plugin_filepreview;
+
+class UT_SheetBrowser : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        browser = sheet->findChild<SheetBrowser *>();
+        ASSERT_NE(nullptr, browser);
+    }
+
+    virtual void TearDown() override
+    {
+        setMainWidget(nullptr);
+        ut_utils::waitRenderIdle();
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SheetBrowser *browser { nullptr };
+};
+
+TEST_F(UT_SheetBrowser, Construct_CreatesScene)
+{
+    EXPECT_NE(nullptr, browser->scene());
+}
+
+TEST_F(UT_SheetBrowser, Construct_ScrollbarsSetup)
+{
+    EXPECT_EQ(QStringLiteral("verticalScrollBar"), browser->verticalScrollBar()->accessibleName());
+    EXPECT_EQ(QStringLiteral("horizontalScrollBar"), browser->horizontalScrollBar()->accessibleName());
+}
+
+TEST_F(UT_SheetBrowser, HasLoaded_BeforeInit_False)
+{
+    EXPECT_FALSE(browser->hasLoaded());
+}
+
+TEST_F(UT_SheetBrowser, AllPages_BeforeInit_Zero)
+{
+    EXPECT_EQ(0, browser->allPages());
+}
+
+TEST_F(UT_SheetBrowser, CurrentPage_BeforeInit_ReturnsOne)
+{
+    EXPECT_EQ(1, browser->currentPage());
+}
+
+TEST_F(UT_SheetBrowser, SetCurrentPage_BeforeInit_Ignored)
+{
+    browser->setCurrentPage(1);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetBrowser, GetExistImage_BeforeInit_ReturnsFalse)
+{
+    QImage image;
+    EXPECT_FALSE(browser->getExistImage(0, image, 50, 50));
+}
+
+TEST_F(UT_SheetBrowser, MaxWidthHeight_BeforeInit_Zero)
+{
+    EXPECT_DOUBLE_EQ(0.0, browser->maxWidth());
+    EXPECT_DOUBLE_EQ(0.0, browser->maxHeight());
+}
+
+TEST_F(UT_SheetBrowser, Pages_BeforeInit_Empty)
+{
+    EXPECT_TRUE(browser->pages().isEmpty());
+}
+
+TEST_F(UT_SheetBrowser, Deform_EmptyList_NoCrash)
+{
+    SheetOperation operation;
+    browser->deform(operation);
+    EXPECT_TRUE(browser->sceneRect().isEmpty());
+}
+
+TEST_F(UT_SheetBrowser, WheelEvent_BeforeInit_NoPageEmitted)
+{
+    QSignalSpy spy(browser, SIGNAL(sigPageChanged(int)));
+    QWheelEvent event(QPointF(10, 10), QPointF(110, 110), QPoint(0, 0), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(browser->viewport(), &event);
+    EXPECT_EQ(0, spy.count());
+}
+
+TEST_F(UT_SheetBrowser, MouseDragSequence_NoMainWidget_NoCrash)
+{
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(10, 10), QPointF(100, 100),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(browser->viewport(), &press);
+    QMouseEvent move(QEvent::MouseMove, QPointF(30, 30), QPointF(120, 120),
+                     Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(browser->viewport(), &move);
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(30, 30), QPointF(120, 120),
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent(browser->viewport(), &release);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetBrowser, ResizeEvent_NoCrash)
+{
+    browser->resize(500, 400);
+    EXPECT_EQ(400, browser->height());
+}
+
+TEST_F(UT_SheetBrowser, FocusOutEvent_NoCrash)
+{
+    QFocusEvent event(QEvent::FocusOut);
+    QApplication::sendEvent(browser, &event);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetBrowser, OnRemoveDocSlideGesture_StopsScroller)
+{
+    browser->onRemoveDocSlideGesture();
+    SUCCEED();
+}
+
+TEST_F(UT_SheetBrowser, BeginViewportChange_TimerEventuallyFires)
+{
+    browser->beginViewportChange();
+    ut_utils::drainEvents(200);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetBrowser, OnViewportChanged_WithEmptyList_NoCrash)
+{
+    browser->onViewportChanged();
+    SUCCEED();
+}
+
+class UT_SheetBrowserOpened : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        ASSERT_TRUE(sheet->openFileExec(""));
+        browser = sheet->findChild<SheetBrowser *>();
+        ASSERT_NE(nullptr, browser);
+    }
+
+    virtual void TearDown() override
+    {
+        setMainWidget(nullptr);
+        ut_utils::waitRenderIdle();
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SheetBrowser *browser { nullptr };
+};
+
+TEST_F(UT_SheetBrowserOpened, HasLoaded_AfterInit_True)
+{
+    EXPECT_TRUE(browser->hasLoaded());
+}
+
+TEST_F(UT_SheetBrowserOpened, AllPages_MatchesPageCount)
+{
+    EXPECT_EQ(sheet->pageCount(), browser->allPages());
+}
+
+TEST_F(UT_SheetBrowserOpened, Pages_CountMatchesAllPages)
+{
+    EXPECT_EQ(browser->allPages(), browser->pages().count());
+}
+
+TEST_F(UT_SheetBrowserOpened, MaxWidthHeight_PositiveAfterInit)
+{
+    EXPECT_GT(browser->maxWidth(), 0.0);
+    EXPECT_GT(browser->maxHeight(), 0.0);
+    EXPECT_DOUBLE_EQ(sheet->pageSizeByIndex(0).width(), browser->maxWidth());
+}
+
+TEST_F(UT_SheetBrowserOpened, CurrentPage_InitiallyOne)
+{
+    EXPECT_EQ(1, browser->currentPage());
+}
+
+TEST_F(UT_SheetBrowserOpened, SetCurrentPage_SecondPage_ScrollsToPageTwo)
+{
+    ASSERT_GE(browser->allPages(), 2);
+    browser->setCurrentPage(2);
+    EXPECT_EQ(2, browser->currentPage());
+}
+
+TEST_F(UT_SheetBrowserOpened, SetCurrentPage_OutOfRange_Ignored)
+{
+    ASSERT_GE(browser->allPages(), 2);
+    browser->setCurrentPage(2);
+    int value = browser->verticalScrollBar()->value();
+    browser->setCurrentPage(0);
+    EXPECT_EQ(value, browser->verticalScrollBar()->value());
+    browser->setCurrentPage(browser->allPages() + 1);
+    EXPECT_EQ(value, browser->verticalScrollBar()->value());
+}
+
+TEST_F(UT_SheetBrowserOpened, GetExistImage_IndexOutOfRange_False)
+{
+    QImage image;
+    EXPECT_FALSE(browser->getExistImage(browser->allPages(), image, 50, 50));
+}
+
+TEST_F(UT_SheetBrowserOpened, GetExistImage_AfterRender_True)
+{
+    browser->pages().at(0)->render(1.0, kRotateBy0);
+    QImage image;
+    EXPECT_TRUE(browser->getExistImage(0, image, 50, 60));
+    EXPECT_FALSE(image.isNull());
+}
+
+TEST_F(UT_SheetBrowserOpened, Deform_TwoPagesMode_WidensSceneRect)
+{
+    qreal singleWidth = browser->sceneRect().width();
+    SheetOperation operation = sheet->operation();
+    operation.layoutMode = TwoPagesMode;
+    browser->deform(operation);
+    EXPECT_GT(browser->sceneRect().width(), singleWidth);
+}
+
+TEST_F(UT_SheetBrowserOpened, Deform_RotateBy90_NoCrash)
+{
+    SheetOperation operation = sheet->operation();
+    operation.rotation = kRotateBy90;
+    browser->deform(operation);
+    EXPECT_GT(browser->sceneRect().height(), 0.0);
+}
+
+TEST_F(UT_SheetBrowserOpened, Deform_RotateBy180_NoCrash)
+{
+    SheetOperation operation = sheet->operation();
+    operation.rotation = kRotateBy180;
+    browser->deform(operation);
+    EXPECT_GT(browser->sceneRect().height(), 0.0);
+}
+
+TEST_F(UT_SheetBrowserOpened, Deform_RotateBy270_NoCrash)
+{
+    SheetOperation operation = sheet->operation();
+    operation.rotation = kRotateBy270;
+    browser->deform(operation);
+    EXPECT_GT(browser->sceneRect().height(), 0.0);
+}
+
+TEST_F(UT_SheetBrowserOpened, Deform_WithCurrentPage_ScrollsToPage)
+{
+    SheetOperation operation = sheet->operation();
+    operation.currentPage = 2;
+    browser->deform(operation);
+    EXPECT_EQ(2, browser->currentPage());
+}
+
+TEST_F(UT_SheetBrowserOpened, Deform_InvalidCurrentPage_NoCrash)
+{
+    SheetOperation operation = sheet->operation();
+    operation.currentPage = 999;
+    browser->deform(operation);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetBrowserOpened, WheelEvent_PageUnderCursor_EmitsPageChanged)
+{
+    sheet->resize(900, 700);
+    sheet->show();
+    ut_utils::drainEvents(150);
+    QSignalSpy spy(browser, SIGNAL(sigPageChanged(int)));
+    QPoint center = browser->viewport()->rect().center();
+    QWheelEvent event(QPointF(center), QPointF(center + QPoint(100, 100)),
+                      QPoint(0, 0), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    QApplication::sendEvent(browser->viewport(), &event);
+    EXPECT_GE(spy.count(), 1);
+    if (spy.count() > 0)
+        EXPECT_EQ(1, qvariant_cast<int>(spy.at(0).at(0)));
+    sheet->hide();
+}
+
+TEST_F(UT_SheetBrowserOpened, MouseDragSequence_WithMainWidget_MovesWindow)
+{
+    QWidget host;
+    host.resize(400, 300);
+    host.move(10, 10);
+    host.show();
+    setMainWidget(&host);
+    QPoint before = host.pos();
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(10, 10), QPointF(100, 100),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(browser->viewport(), &press);
+    QMouseEvent move(QEvent::MouseMove, QPointF(30, 30), QPointF(130, 130),
+                     Qt::NoButton, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(browser->viewport(), &move);
+    EXPECT_EQ(before + QPoint(30, 30), host.pos());
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(30, 30), QPointF(130, 130),
+                        Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent(browser->viewport(), &release);
+    host.hide();
+}
+
+TEST_F(UT_SheetBrowserOpened, VerticalScrollChange_TriggersViewportRefresh)
+{
+    ASSERT_GE(browser->allPages(), 2);
+    browser->setCurrentPage(2);
+    EXPECT_GT(browser->verticalScrollBar()->value(), 0);
+    ut_utils::drainEvents(250);
+    EXPECT_EQ(2, browser->currentPage());
+}
+
+TEST_F(UT_SheetBrowserOpened, GetBrowserPageForPoint_OnFirstPage_ReturnsPage)
+{
+    sheet->resize(900, 700);
+    sheet->show();
+    ut_utils::drainEvents(150);
+    QPointF point(browser->viewport()->rect().center());
+    BrowserPage *found = browser->getBrowserPageForPoint(point);
+    EXPECT_NE(nullptr, found);
+    if (found)
+        EXPECT_EQ(0, found->itemIndex());
+    sheet->hide();
+}
+
+TEST_F(UT_SheetBrowserOpened, GetBrowserPageForPoint_EmptyArea_ReturnsNull)
+{
+    sheet->show();
+    ut_utils::drainEvents(150);
+    QPointF point(3000, 3000);
+    BrowserPage *found = browser->getBrowserPageForPoint(point);
+    EXPECT_EQ(nullptr, found);
+    sheet->hide();
+}
+
+TEST_F(UT_SheetBrowserOpened, ShowEvent_TriggersDelayedInit_NoCrash)
+{
+    browser->show();
+    ut_utils::drainEvents(200);
+    EXPECT_TRUE(browser->hasLoaded());
+    browser->hide();
+}
+
+TEST_F(UT_SheetBrowserOpened, CurrentIndexRange_CoversVisiblePages)
+{
+    int fromIndex = 0;
+    int toIndex = 0;
+    browser->currentIndexRange(fromIndex, toIndex);
+    EXPECT_EQ(0, fromIndex);
+    EXPECT_GE(toIndex, 0);
+}
+
+TEST_F(UT_SheetBrowserOpened, OnViewportChanged_ClearsFarPages)
+{
+    BrowserPage *lastPage = browser->pages().last();
+    lastPage->render(1.0, kRotateBy0);
+    EXPECT_FALSE(lastPage->currentPixmap.isNull());
+    browser->onViewportChanged();
+    EXPECT_TRUE(lastPage->currentPixmap.isNull());
+}
+
+TEST_F(UT_SheetBrowserOpened, OnInit_WithJumpPage_ScrollsToTarget)
+{
+    browser->jumpPageNumber = 2;
+    browser->onInit();
+    EXPECT_EQ(2, browser->currentPage());
+    EXPECT_EQ(1, browser->jumpPageNumber);
+}
+
+TEST_F(UT_SheetBrowserOpened, TimerEvent_UnknownTimerId_Ignored)
+{
+    QTimerEvent event(-1);
+    QApplication::sendEvent(browser, &event);
+    SUCCEED();
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_sheetrenderer.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_sheetrenderer.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "docsheet.h"
+#include "pdfmodel.h"
+#include "sheetrenderer.h"
+#include "ut_common.h"
+
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+
+using namespace plugin_filepreview;
+
+class UT_SheetRenderer : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        renderer = sheet->findChild<SheetRenderer *>();
+        ASSERT_NE(nullptr, renderer);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SheetRenderer *renderer { nullptr };
+};
+
+TEST_F(UT_SheetRenderer, Construct_DefaultState)
+{
+    EXPECT_FALSE(renderer->opened());
+    EXPECT_EQ(0, renderer->getPageCount());
+}
+
+TEST_F(UT_SheetRenderer, GetImage_BeforeOpen_ReturnsNull)
+{
+    EXPECT_TRUE(renderer->getImage(0, 50, 50).isNull());
+}
+
+TEST_F(UT_SheetRenderer, GetPageSize_BeforeOpen_ReturnsEmpty)
+{
+    EXPECT_EQ(QSizeF(), renderer->getPageSize(0));
+    EXPECT_EQ(QSizeF(), renderer->getPageSize(5));
+}
+
+TEST_F(UT_SheetRenderer, HandleOpened_Error_KeepsClosed)
+{
+    QSignalSpy spy(renderer, SIGNAL(sigOpened(Document::Error)));
+    renderer->handleOpened(Document::kFileError, nullptr, QList<Page *>());
+    EXPECT_FALSE(renderer->opened());
+    EXPECT_EQ(1, spy.count());
+    EXPECT_EQ(Document::kFileError, qvariant_cast<Document::Error>(spy.at(0).at(0)));
+}
+
+TEST_F(UT_SheetRenderer, HandleOpened_Success_SetsDocumentAndPages)
+{
+    Document::Error error = Document::kFileError;
+    PDFDocument *document = PDFDocument::loadDocument(pdfPath, "", error);
+    ASSERT_NE(nullptr, document);
+    QList<Page *> pages;
+    for (int i = 0; i < document->pageCount(); ++i)
+        pages.append(document->page(i));
+
+    QSignalSpy spy(renderer, SIGNAL(sigOpened(Document::Error)));
+    renderer->handleOpened(Document::kNoError, document, pages);
+    EXPECT_TRUE(renderer->opened());
+    EXPECT_EQ(pages.count(), renderer->getPageCount());
+    EXPECT_EQ(1, spy.count());
+
+    delete renderer->documentObj;
+    qDeleteAll(renderer->pageList);
+    renderer->documentObj = nullptr;
+    renderer->pageList.clear();
+}
+
+TEST_F(UT_SheetRenderer, OpenFileExec_ValidPdf_ReturnsTrue)
+{
+    EXPECT_TRUE(renderer->openFileExec(""));
+    EXPECT_TRUE(renderer->opened());
+    EXPECT_GE(renderer->getPageCount(), 2);
+}
+
+TEST_F(UT_SheetRenderer, OpenFileAsync_ValidPdf_EmitsOpenedWithNoError)
+{
+    QSignalSpy spy(renderer, SIGNAL(sigOpened(Document::Error)));
+    renderer->openFileAsync("");
+    ut_utils::processEventsUntil([&spy]() { return spy.count() >= 1; });
+    ASSERT_GE(spy.count(), 1);
+    EXPECT_EQ(Document::kNoError, qvariant_cast<Document::Error>(spy.at(0).at(0)));
+    EXPECT_TRUE(renderer->opened());
+}
+
+class UT_SheetRendererOpened : public UT_SheetRenderer
+{
+protected:
+    void SetUp() override
+    {
+        UT_SheetRenderer::SetUp();
+        ASSERT_TRUE(renderer->openFileExec(""));
+    }
+};
+
+TEST_F(UT_SheetRendererOpened, GetPageSize_ValidIndex_ReturnsPositiveSize)
+{
+    QSizeF size = renderer->getPageSize(0);
+    EXPECT_GT(size.width(), 0.0);
+    EXPECT_GT(size.height(), 0.0);
+}
+
+TEST_F(UT_SheetRendererOpened, GetImage_ValidIndex_ReturnsRenderedImage)
+{
+    QImage image = renderer->getImage(0, 60, 80);
+    EXPECT_FALSE(image.isNull());
+}
+
+TEST_F(UT_SheetRendererOpened, GetImage_OutOfRange_ReturnsNull)
+{
+    EXPECT_TRUE(renderer->getImage(renderer->getPageCount(), 60, 80).isNull());
+}
+
+TEST_F(UT_SheetRendererOpened, ReopenSameFile_SucceedsAgain)
+{
+    EXPECT_TRUE(renderer->openFileExec(""));
+    EXPECT_TRUE(renderer->opened());
+}
+
+TEST_F(UT_SheetRendererOpened, Destructor_WithLoadedDocument_AppendsCloseTask)
+{
+    DocSheet *tempSheet = new DocSheet(kPDF, pdfPath);
+    SheetRenderer *tempRenderer = tempSheet->findChild<SheetRenderer *>();
+    ASSERT_NE(nullptr, tempRenderer);
+    ASSERT_TRUE(tempRenderer->openFileExec(""));
+    ut_utils::waitRenderIdle();
+    delete tempSheet;
+    ut_utils::waitRenderIdle();
+    SUCCEED();
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_sidebar.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_sidebar.cpp
@@ -1,0 +1,595 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "docsheet.h"
+#include "sheetbrowser.h"
+#include "sheetsidebar.h"
+#include "sidebarimagelistview.h"
+#include "sidebarimageviewmodel.h"
+#include "thumbnaildelegate.h"
+#include "thumbnailwidget.h"
+#include "ut_common.h"
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QSignalSpy>
+#include <QStyleOptionViewItem>
+
+using namespace plugin_filepreview;
+
+TEST(UT_ImagePageInfo, Operators_CompareByPageIndex)
+{
+    ImagePageInfo_t left(1);
+    ImagePageInfo_t right(2);
+
+    EXPECT_TRUE(left == ImagePageInfo_t(1));
+    EXPECT_TRUE(left < right);
+    EXPECT_TRUE(right > left);
+    EXPECT_FALSE(left == right);
+}
+
+TEST(UT_ImagePageInfo, DefaultConstructor_HasInvalidIndex)
+{
+    ImagePageInfo_t info;
+    EXPECT_EQ(-1, info.pageIndex);
+}
+
+class UT_SideBarImageViewModel : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        ASSERT_TRUE(sheet->openFileExec(""));
+        model = new SideBarImageViewModel(sheet);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+                delete model;
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SideBarImageViewModel *model { nullptr };
+};
+
+TEST_F(UT_SideBarImageViewModel, RowCount_EmptyByDefault)
+{
+    EXPECT_EQ(0, model->rowCount());
+}
+
+TEST_F(UT_SideBarImageViewModel, ColumnCount_AlwaysOne)
+{
+    EXPECT_EQ(1, model->columnCount(QModelIndex()));
+}
+
+TEST_F(UT_SideBarImageViewModel, InitModelLst_Unsorted_KeepsOrder)
+{
+    QList<ImagePageInfo_t> list { ImagePageInfo_t(2), ImagePageInfo_t(0), ImagePageInfo_t(1) };
+    model->initModelLst(list);
+    EXPECT_EQ(3, model->rowCount());
+    EXPECT_EQ(2, model->getPageIndexForModelIndex(0));
+    EXPECT_EQ(0, model->getPageIndexForModelIndex(1));
+    EXPECT_EQ(1, model->getPageIndexForModelIndex(2));
+}
+
+TEST_F(UT_SideBarImageViewModel, InitModelLst_Sorted_SortsAscending)
+{
+    QList<ImagePageInfo_t> list { ImagePageInfo_t(2), ImagePageInfo_t(0), ImagePageInfo_t(1) };
+    model->initModelLst(list, true);
+    EXPECT_EQ(0, model->getPageIndexForModelIndex(0));
+    EXPECT_EQ(1, model->getPageIndexForModelIndex(1));
+    EXPECT_EQ(2, model->getPageIndexForModelIndex(2));
+}
+
+TEST_F(UT_SideBarImageViewModel, ResetData_ClearsAllRows)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0), ImagePageInfo_t(1) });
+    EXPECT_EQ(2, model->rowCount());
+    model->resetData();
+    EXPECT_EQ(0, model->rowCount());
+}
+
+TEST_F(UT_SideBarImageViewModel, ChangeModelData_ReplacesListWithoutReset)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    model->changeModelData(QList<ImagePageInfo_t> { ImagePageInfo_t(3), ImagePageInfo_t(4) });
+    EXPECT_EQ(2, model->rowCount());
+    EXPECT_EQ(3, model->getPageIndexForModelIndex(0));
+}
+
+TEST_F(UT_SideBarImageViewModel, GetModelIndexForPageIndex_Found_ReturnsIndices)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(5), ImagePageInfo_t(7) });
+    QList<QModelIndex> indices = model->getModelIndexForPageIndex(7);
+    ASSERT_EQ(1, indices.count());
+    EXPECT_EQ(1, indices.first().row());
+}
+
+TEST_F(UT_SideBarImageViewModel, GetModelIndexForPageIndex_NotFound_ReturnsEmpty)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(5) });
+    EXPECT_TRUE(model->getModelIndexForPageIndex(9).isEmpty());
+}
+
+TEST_F(UT_SideBarImageViewModel, GetPageIndexForModelIndex_OutOfRange_ReturnsMinusOne)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(5) });
+    EXPECT_EQ(-1, model->getPageIndexForModelIndex(-1));
+    EXPECT_EQ(-1, model->getPageIndexForModelIndex(1));
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_InvalidIndex_ReturnsInvalidVariant)
+{
+    EXPECT_FALSE(model->data(QModelIndex(), Qt::DisplayRole).isValid());
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_InvalidPageRow_ReturnsInvalidVariant)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(-1) });
+    EXPECT_FALSE(model->data(model->index(0), ImageinfoType_e::IMAGE_PIXMAP).isValid());
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_PixmapRole_MissingThumbnailFillsPlaceholder)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    QVariant first = model->data(model->index(0), ImageinfoType_e::IMAGE_PIXMAP);
+    EXPECT_TRUE(first.value<QPixmap>().isNull());
+
+    QVariant second = model->data(model->index(0), ImageinfoType_e::IMAGE_PIXMAP);
+    QPixmap placeholder = second.value<QPixmap>();
+    EXPECT_FALSE(placeholder.isNull());
+    EXPECT_EQ(200, placeholder.width());
+    EXPECT_EQ(200, placeholder.height());
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_PixmapRole_ExistingThumbnailReturned)
+{
+    QPixmap known(40, 40);
+    known.fill(Qt::red);
+    sheet->setThumbnail(0, known);
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    QVariant result = model->data(model->index(0), ImageinfoType_e::IMAGE_PIXMAP);
+    EXPECT_EQ(40, result.value<QPixmap>().width());
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_RotateRole_ReturnsRotationDegrees)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    QVariant result = model->data(model->index(0), ImageinfoType_e::IMAGE_ROTATE);
+    EXPECT_EQ(sheet->operation().rotation * 90, result.toInt());
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_AccessibleRole_ReturnsRow)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0), ImagePageInfo_t(1) });
+    EXPECT_EQ(1, model->data(model->index(1), Qt::AccessibleTextRole).toInt());
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_PageSizeRole_ReturnsPageSize)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    QVariant result = model->data(model->index(0), ImageinfoType_e::IMAGE_PAGE_SIZE);
+    QSizeF size = result.toSizeF();
+    EXPECT_GT(size.width(), 0.0);
+}
+
+TEST_F(UT_SideBarImageViewModel, Data_UnhandledRole_ReturnsInvalid)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    EXPECT_FALSE(model->data(model->index(0), Qt::DisplayRole).isValid());
+}
+
+TEST_F(UT_SideBarImageViewModel, SetData_InvalidIndex_ReturnsFalse)
+{
+    EXPECT_FALSE(model->setData(QModelIndex(), QVariant("x"), Qt::EditRole));
+}
+
+TEST_F(UT_SideBarImageViewModel, HandleRenderThumbnail_UpdatesThumbnailAndEmitsDataChanged)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    QSignalSpy spy(model, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)));
+    QPixmap pixmap(35, 45);
+    pixmap.fill(Qt::green);
+    model->handleRenderThumbnail(0, pixmap);
+    EXPECT_EQ(35, sheet->thumbnail(0).width());
+    EXPECT_EQ(1, spy.count());
+}
+
+TEST_F(UT_SideBarImageViewModel, OnUpdateImage_NoCrash)
+{
+    model->onUpdateImage(0);
+    ut_utils::drainEvents(150);
+    SUCCEED();
+}
+
+TEST_F(UT_SideBarImageViewModel, SigPageModified_FromSheet_LeadsToThumbnailTask)
+{
+    model->initModelLst(QList<ImagePageInfo_t> { ImagePageInfo_t(0) });
+    emit sheet->sigPageModified(0);
+    ut_utils::drainEvents(200);
+    SUCCEED();
+}
+
+class UT_SideBarImageListView : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        ASSERT_TRUE(sheet->openFileExec(""));
+        listView = new SideBarImageListView(sheet);
+        listView->resize(266, 500);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+                delete listView;
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SideBarImageListView *listView { nullptr };
+};
+
+TEST_F(UT_SideBarImageListView, Construct_InstallsModel)
+{
+    EXPECT_NE(nullptr, listView->model());
+}
+
+TEST_F(UT_SideBarImageListView, HandleOpenSuccess_PopulatesModelWithAllPages)
+{
+    listView->handleOpenSuccess();
+    EXPECT_EQ(sheet->pageCount(), listView->model()->rowCount());
+}
+
+TEST_F(UT_SideBarImageListView, ScrollToIndex_ExistingPage_SelectsAndReturnsTrue)
+{
+    listView->handleOpenSuccess();
+    EXPECT_TRUE(listView->scrollToIndex(1));
+    EXPECT_EQ(1, listView->currentIndex().row());
+}
+
+TEST_F(UT_SideBarImageListView, ScrollToIndex_WithoutScrollFlag_StillSelects)
+{
+    listView->handleOpenSuccess();
+    EXPECT_TRUE(listView->scrollToIndex(2, false));
+    EXPECT_EQ(2, listView->currentIndex().row());
+}
+
+TEST_F(UT_SideBarImageListView, ScrollToIndex_MissingPage_ReturnsFalseAndClears)
+{
+    listView->handleOpenSuccess();
+    EXPECT_FALSE(listView->scrollToIndex(999));
+    EXPECT_FALSE(listView->currentIndex().isValid());
+}
+
+TEST_F(UT_SideBarImageListView, PageUpIndex_WithModel_ReturnsValidIndex)
+{
+    listView->handleOpenSuccess();
+    listView->scrollToIndex(2);
+    QModelIndex up = listView->pageUpIndex();
+    EXPECT_TRUE(up.isValid() || up.row() >= 0);
+}
+
+TEST_F(UT_SideBarImageListView, PageDownIndex_WithModel_ReturnsValidIndex)
+{
+    listView->handleOpenSuccess();
+    QModelIndex down = listView->pageDownIndex();
+    EXPECT_TRUE(down.isValid() || down.row() >= 0);
+}
+
+TEST_F(UT_SideBarImageListView, OnItemClicked_ValidIndex_JumpsAndEmits)
+{
+    listView->handleOpenSuccess();
+    SheetBrowser *browser = sheet->findChild<SheetBrowser *>();
+    ASSERT_NE(nullptr, browser);
+    QSignalSpy spy(listView, SIGNAL(sigListItemClicked(int)));
+    listView->onItemClicked(listView->model()->index(1, 0));
+    EXPECT_EQ(1, spy.count());
+    EXPECT_EQ(2, browser->currentPage());
+}
+
+TEST_F(UT_SideBarImageListView, OnItemClicked_InvalidIndex_NoSignal)
+{
+    QSignalSpy spy(listView, SIGNAL(sigListItemClicked(int)));
+    listView->onItemClicked(QModelIndex());
+    EXPECT_EQ(0, spy.count());
+}
+
+TEST_F(UT_SideBarImageListView, MousePressEvent_OnItem_NoCrash)
+{
+    listView->handleOpenSuccess();
+    listView->show();
+    ut_utils::drainEvents(100);
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(50, 20), QPointF(200, 200),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    QApplication::sendEvent(listView->viewport(), &press);
+    SUCCEED();
+}
+
+class UT_SheetSidebar : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+                delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+};
+
+TEST_F(UT_SheetSidebar, Construct_ThumbnailFlag_CreatesThumbnailWidget)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_THUMBNAIL);
+    EXPECT_NE(nullptr, sidebar.findChild<ThumbnailWidget *>());
+}
+
+TEST_F(UT_SheetSidebar, Construct_NullFlag_NoThumbnailWidget)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_NULL);
+    EXPECT_EQ(nullptr, sidebar.findChild<ThumbnailWidget *>());
+}
+
+TEST_F(UT_SheetSidebar, Construct_FixedWidthApplied)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_THUMBNAIL);
+    sidebar.show();
+    ut_utils::drainEvents(50);
+    EXPECT_EQ(50, sidebar.width());
+}
+
+TEST_F(UT_SheetSidebar, SetCurrentPage_WithThumbnailWidget_NoCrash)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_THUMBNAIL);
+    sidebar.setCurrentPage(1);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetSidebar, SetCurrentPage_NullFlag_NoCrash)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_NULL);
+    sidebar.setCurrentPage(1);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetSidebar, HandleOpenSuccess_VisiblePerOperation)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_THUMBNAIL);
+    sidebar.handleOpenSuccess();
+    EXPECT_EQ(sheet->operation().sidebarVisible, !sidebar.isHidden());
+}
+
+TEST_F(UT_SheetSidebar, ShowEvent_TriggersDelayedOpenSuccess_NoCrash)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_THUMBNAIL);
+    sidebar.show();
+    ut_utils::drainEvents(200);
+    SUCCEED();
+}
+
+TEST_F(UT_SheetSidebar, OnHandWidgetDocOpenSuccess_WhileHidden_NoCrash)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_THUMBNAIL);
+    sidebar.openDocOpenSuccess = true;
+    sidebar.onHandWidgetDocOpenSuccess();
+    SUCCEED();
+}
+
+TEST_F(UT_SheetSidebar, ResizeEvent_NoCrash)
+{
+    SheetSidebar sidebar(sheet, PREVIEW_THUMBNAIL);
+    sidebar.resize(100, 400);
+    SUCCEED();
+}
+
+class UT_ThumbnailWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        ASSERT_TRUE(sheet->openFileExec(""));
+        widget = new ThumbnailWidget(sheet);
+        widget->resize(266, 500);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+                delete widget;
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    ThumbnailWidget *widget { nullptr };
+};
+
+TEST_F(UT_ThumbnailWidget, Construct_CreatesListViewWithDelegate)
+{
+    SideBarImageListView *listView = widget->findChild<SideBarImageListView *>();
+    ASSERT_NE(nullptr, listView);
+    EXPECT_NE(nullptr, dynamic_cast<ThumbnailDelegate *>(listView->itemDelegate()));
+}
+
+TEST_F(UT_ThumbnailWidget, HandleOpenSuccess_PopulatesModel)
+{
+    widget->show();
+    widget->handleOpenSuccess();
+    SideBarImageListView *listView = widget->findChild<SideBarImageListView *>();
+    ASSERT_NE(nullptr, listView);
+    EXPECT_EQ(sheet->pageCount(), listView->model()->rowCount());
+}
+
+TEST_F(UT_ThumbnailWidget, HandleOpenSuccess_SecondCall_SkipsDuplicateInit)
+{
+    widget->show();
+    widget->handleOpenSuccess();
+    SideBarImageListView *listView = widget->findChild<SideBarImageListView *>();
+    ASSERT_NE(nullptr, listView);
+    int countAfterFirst = listView->model()->rowCount();
+    widget->handleOpenSuccess();
+    EXPECT_EQ(countAfterFirst, listView->model()->rowCount());
+}
+
+TEST_F(UT_ThumbnailWidget, HandlePage_ScrollsToIndex)
+{
+    widget->handleOpenSuccess();
+    widget->handlePage(1);
+    SideBarImageListView *listView = widget->findChild<SideBarImageListView *>();
+    ASSERT_NE(nullptr, listView);
+    EXPECT_EQ(1, listView->currentIndex().row());
+}
+
+TEST_F(UT_ThumbnailWidget, AdaptWindowSize_UpdatesScaleProperty)
+{
+    SideBarImageListView *listView = widget->findChild<SideBarImageListView *>();
+    ASSERT_NE(nullptr, listView);
+    widget->adaptWindowSize(1.5);
+    EXPECT_DOUBLE_EQ(1.5, listView->property("adaptScale").toDouble());
+}
+
+TEST_F(UT_ThumbnailWidget, AdaptWindowSize_ClampsMinimumHeight)
+{
+    SideBarImageListView *listView = widget->findChild<SideBarImageListView *>();
+    ASSERT_NE(nullptr, listView);
+    widget->adaptWindowSize(0.5);
+    EXPECT_DOUBLE_EQ(0.5, listView->property("adaptScale").toDouble());
+    SUCCEED();
+}
+
+class UT_ThumbnailDelegate : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        sheet = new DocSheet(kPDF, pdfPath);
+        ASSERT_TRUE(sheet->openFileExec(""));
+        listView = new SideBarImageListView(sheet);
+        listView->resize(266, 500);
+        delegate = new ThumbnailDelegate(listView);
+        listView->setItemDelegate(delegate);
+    }
+
+    virtual void TearDown() override
+    {
+        ut_utils::waitRenderIdle();
+                delete listView;
+        delete sheet;
+        ut_utils::waitRenderIdle();
+    }
+
+protected:
+    QString pdfPath;
+    DocSheet *sheet { nullptr };
+    SideBarImageListView *listView { nullptr };
+    ThumbnailDelegate *delegate { nullptr };
+};
+
+TEST_F(UT_ThumbnailDelegate, Construct_SetsParentObjectNames)
+{
+    EXPECT_EQ(QStringLiteral("ItemViewParent"), listView->objectName());
+    EXPECT_EQ(QStringLiteral("ItemViewParent"), listView->accessibleName());
+}
+
+TEST_F(UT_ThumbnailDelegate, SizeHint_DelegatesToBase)
+{
+    listView->handleOpenSuccess();
+    QStyleOptionViewItem option;
+    QSize hint = delegate->sizeHint(option, listView->model()->index(0, 0));
+    EXPECT_TRUE(hint.isValid());
+}
+
+TEST_F(UT_ThumbnailDelegate, Paint_InvalidIndex_NoCrash)
+{
+    QImage canvas(266, 110, QImage::Format_ARGB32_Premultiplied);
+    canvas.fill(Qt::white);
+    QPainter painter(&canvas);
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 266, 110);
+    delegate->paint(&painter, option, QModelIndex());
+    painter.end();
+    SUCCEED();
+}
+
+TEST_F(UT_ThumbnailDelegate, Paint_UnselectedRow_NoCrash)
+{
+    listView->handleOpenSuccess();
+    listView->show();
+    ut_utils::drainEvents(100);
+    QImage canvas(266, 110, QImage::Format_ARGB32_Premultiplied);
+    canvas.fill(Qt::white);
+    QPainter painter(&canvas);
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 266, 110);
+    delegate->paint(&painter, option, listView->model()->index(0, 0));
+    painter.end();
+    SUCCEED();
+}
+
+TEST_F(UT_ThumbnailDelegate, Paint_SelectedRow_HighlightsNoCrash)
+{
+    listView->handleOpenSuccess();
+    listView->show();
+    ut_utils::drainEvents(100);
+    listView->selectionModel()->select(listView->model()->index(0, 0), QItemSelectionModel::SelectCurrent);
+    QImage canvas(266, 110, QImage::Format_ARGB32_Premultiplied);
+    canvas.fill(Qt::white);
+    QPainter painter(&canvas);
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 266, 110);
+    delegate->paint(&painter, option, listView->model()->index(0, 0));
+    painter.end();
+    SUCCEED();
+}
+
+TEST_F(UT_ThumbnailDelegate, Paint_WithThumbnailPixmap_NoCrash)
+{
+    listView->handleOpenSuccess();
+    QPixmap thumbnail(174, 220);
+    thumbnail.fill(Qt::yellow);
+    sheet->setThumbnail(0, thumbnail);
+    QImage canvas(266, 110, QImage::Format_ARGB32_Premultiplied);
+    canvas.fill(Qt::white);
+    QPainter painter(&canvas);
+    QStyleOptionViewItem option;
+    option.rect = QRect(0, 0, 266, 110);
+    delegate->paint(&painter, option, listView->model()->index(0, 0));
+    painter.end();
+    SUCCEED();
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/test_zz_pdfpreview.cpp
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/test_zz_pdfpreview.cpp
@@ -1,0 +1,530 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "docsheet.h"
+#include "encryptionpage.h"
+#include "global.h"
+#include "pagerenderthread.h"
+#include "pdfpreview.h"
+#include "pdfpreviewplugin.h"
+#include "pdfwidget.h"
+#include "ut_common.h"
+
+#include "stubext.h"
+#include <dfm-base/mimetype/dmimedatabase.h>
+
+#include <gtest/gtest.h>
+
+#include <DPasswordEdit>
+#include <DPushButton>
+
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QSignalSpy>
+
+using namespace plugin_filepreview;
+
+static QMimeType pdfMime()
+{
+    QMimeDatabase db;
+    return db.mimeTypeForName("application/pdf");
+}
+
+class UT_EncryptionPage : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        page = new EncryptionPage();
+    }
+
+    virtual void TearDown() override
+    {
+        delete page;
+        ut_utils::drainEvents(50);
+    }
+
+protected:
+    EncryptionPage *page { nullptr };
+
+    DTK_WIDGET_NAMESPACE::DPushButton *nextButton() const
+    {
+        return page->findChild<DTK_WIDGET_NAMESPACE::DPushButton *>("ensureBtn");
+    }
+
+    DTK_WIDGET_NAMESPACE::DPasswordEdit *passwordEdit() const
+    {
+        return page->findChild<DTK_WIDGET_NAMESPACE::DPasswordEdit *>("PasswordEdit");
+    }
+};
+
+TEST_F(UT_EncryptionPage, Construct_CreatesControls)
+{
+    EXPECT_NE(nullptr, nextButton());
+    EXPECT_NE(nullptr, passwordEdit());
+}
+
+TEST_F(UT_EncryptionPage, Construct_NextButtonDisabledInitially)
+{
+    EXPECT_FALSE(nextButton()->isEnabled());
+}
+
+TEST_F(UT_EncryptionPage, PasswordChanged_EmptyPassword_KeepsButtonDisabled)
+{
+    passwordEdit()->setText("");
+    ut_utils::drainEvents(50);
+    EXPECT_FALSE(nextButton()->isEnabled());
+}
+
+TEST_F(UT_EncryptionPage, PasswordChanged_NonEmptyPassword_EnablesButton)
+{
+    passwordEdit()->setText("secret");
+    ut_utils::drainEvents(50);
+    EXPECT_TRUE(nextButton()->isEnabled());
+}
+
+TEST_F(UT_EncryptionPage, NextbuttonClicked_EmitsPasswordSignal)
+{
+    passwordEdit()->setText("secret");
+    ut_utils::drainEvents(50);
+    QSignalSpy spy(page, SIGNAL(sigExtractPassword(const QString &)));
+    page->nextbuttonClicked();
+    ASSERT_EQ(1, spy.count());
+    EXPECT_EQ(QStringLiteral("secret"), spy.at(0).at(0).toString());
+}
+
+TEST_F(UT_EncryptionPage, WrongPasswordSlot_ClearsTextAndSetsAlert)
+{
+    passwordEdit()->setText("bad");
+    ut_utils::drainEvents(50);
+    page->wrongPassWordSlot();
+    EXPECT_TRUE(passwordEdit()->text().isEmpty());
+    EXPECT_TRUE(passwordEdit()->isAlert());
+}
+
+TEST_F(UT_EncryptionPage, TypingAfterWrongPassword_ClearsAlert)
+{
+    page->wrongPassWordSlot();
+    EXPECT_TRUE(passwordEdit()->isAlert());
+    passwordEdit()->setText("retry");
+    ut_utils::drainEvents(50);
+    EXPECT_FALSE(passwordEdit()->isAlert());
+}
+
+TEST_F(UT_EncryptionPage, OnSetPasswdFocus_WhileHidden_NoCrash)
+{
+    page->onSetPasswdFocus();
+    SUCCEED();
+}
+
+TEST_F(UT_EncryptionPage, OnSetPasswdFocus_WhileShown_SetsFocus)
+{
+    page->show();
+    ut_utils::drainEvents(50);
+    page->onSetPasswdFocus();
+    EXPECT_EQ(passwordEdit()->lineEdit(), qApp->focusWidget());
+    page->hide();
+}
+
+TEST_F(UT_EncryptionPage, OnUpdateTheme_AppliesPalette)
+{
+    page->onUpdateTheme();
+    SUCCEED();
+}
+
+TEST_F(UT_EncryptionPage, InitUI_SecondCall_NoCrash)
+{
+    page->InitUI();
+    SUCCEED();
+}
+
+TEST_F(UT_EncryptionPage, InitConnection_SecondCall_NoCrash)
+{
+    page->InitConnection();
+    SUCCEED();
+}
+
+class UT_recordSheetPath : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        sheetA = new DocSheet(kPDF, "/tmp/record-a.pdf");
+        sheetB = new DocSheet(kPDF, "/tmp/record-b.pdf");
+    }
+
+    virtual void TearDown() override
+    {
+        delete sheetA;
+        delete sheetB;
+        ut_utils::drainEvents(50);
+    }
+
+protected:
+    DocSheet *sheetA { nullptr };
+    DocSheet *sheetB { nullptr };
+};
+
+TEST_F(UT_recordSheetPath, InsertSheet_Null_Ignored)
+{
+    recordSheetPath record;
+    record.insertSheet(nullptr);
+    EXPECT_TRUE(record.getSheets().isEmpty());
+}
+
+TEST_F(UT_recordSheetPath, RemoveSheet_Null_Ignored)
+{
+    recordSheetPath record;
+    record.removeSheet(nullptr);
+    EXPECT_TRUE(record.getSheets().isEmpty());
+}
+
+TEST_F(UT_recordSheetPath, InsertSheet_RecordsFilePath)
+{
+    recordSheetPath record;
+    record.insertSheet(sheetA);
+    ASSERT_EQ(1, record.getSheets().count());
+    EXPECT_EQ(sheetA, record.getSheets().first());
+}
+
+TEST_F(UT_recordSheetPath, IndexOfFilePath_KnownPath_Found)
+{
+    recordSheetPath record;
+    record.insertSheet(sheetA);
+    record.insertSheet(sheetB);
+    int indexA = record.indexOfFilePath("/tmp/record-a.pdf");
+    int indexB = record.indexOfFilePath("/tmp/record-b.pdf");
+    EXPECT_NE(indexA, indexB);
+    EXPECT_TRUE(indexA == 0 || indexA == 1);
+    EXPECT_TRUE(indexB == 0 || indexB == 1);
+}
+
+TEST_F(UT_recordSheetPath, IndexOfFilePath_UnknownPath_ReturnsMinusOne)
+{
+    recordSheetPath record;
+    record.insertSheet(sheetA);
+    EXPECT_EQ(-1, record.indexOfFilePath("/tmp/no-such.pdf"));
+}
+
+TEST_F(UT_recordSheetPath, RemoveSheet_RemovesEntry)
+{
+    recordSheetPath record;
+    record.insertSheet(sheetA);
+    record.insertSheet(sheetB);
+    record.removeSheet(sheetA);
+    EXPECT_EQ(1, record.getSheets().count());
+    EXPECT_EQ(-1, record.indexOfFilePath("/tmp/record-a.pdf"));
+}
+
+static PdfWidget *g_sharedWidget = nullptr;
+
+static PdfWidget *sharedWidget()
+{
+    if (!g_sharedWidget)
+        g_sharedWidget = new PdfWidget();
+    return g_sharedWidget;
+}
+
+class UT_PdfWidget : public testing::Test
+{
+protected:
+    virtual void TearDown() override
+    {
+        ut_utils::drainEvents(100);
+    }
+};
+
+TEST_F(UT_PdfWidget, AddFileAsync_ValidPdf_OpensAndRegistersSheet)
+{
+    qRegisterMetaType<Document::Error>("Document::Error");
+    qRegisterMetaType<DocSheet *>("DocSheet *");
+    stub_ext::StubExt stub;
+    stub.set_lamda(static_cast<QMimeType (DFMBASE_NAMESPACE::DMimeDatabase::*)(const QUrl &, QMimeDatabase::MatchMode) const>(&DFMBASE_NAMESPACE::DMimeDatabase::mimeTypeForFile),
+                   [](DFMBASE_NAMESPACE::DMimeDatabase *, const QUrl &, QMimeDatabase::MatchMode) {
+                       __DBG_STUB_INVOKE__
+                       return pdfMime();
+                   });
+
+    QString pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+    sharedWidget()->addFileAsync(pdfPath);
+
+    DocSheet *sheet = DocSheet::getSheetByFilePath(pdfPath);
+    ASSERT_NE(nullptr, sheet);
+    ut_utils::processEventsUntil([sheet]() { return sheet->opened(); });
+    EXPECT_TRUE(sheet->opened());
+}
+
+TEST_F(UT_PdfWidget, AddFileAsync_SamePathAgain_SwitchesToExistingSheet)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(static_cast<QMimeType (DFMBASE_NAMESPACE::DMimeDatabase::*)(const QUrl &, QMimeDatabase::MatchMode) const>(&DFMBASE_NAMESPACE::DMimeDatabase::mimeTypeForFile),
+                   [](DFMBASE_NAMESPACE::DMimeDatabase *, const QUrl &, QMimeDatabase::MatchMode) {
+                       __DBG_STUB_INVOKE__
+                       return pdfMime();
+                   });
+
+    QString pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+    DocSheet *before = DocSheet::getSheetByFilePath(pdfPath);
+    ASSERT_NE(nullptr, before);
+    int sheetsBefore = DocSheet::getSheets().count();
+
+    sharedWidget()->addFileAsync(pdfPath);
+
+    EXPECT_EQ(before, DocSheet::getSheetByFilePath(pdfPath));
+    EXPECT_EQ(sheetsBefore, DocSheet::getSheets().count());
+}
+
+TEST_F(UT_PdfWidget, AddFileAsync_NotPdfContent_Ignored)
+{
+    QString textPath = ut_utils::prepareFile("/etc/hostname");
+    int sheetsBefore = DocSheet::getSheets().count();
+    sharedWidget()->addFileAsync(textPath);
+    ut_utils::drainEvents(100);
+    EXPECT_EQ(sheetsBefore, DocSheet::getSheets().count());
+    EXPECT_EQ(nullptr, DocSheet::getSheetByFilePath(textPath));
+}
+
+TEST_F(UT_PdfWidget, AddSheet_NullSheet_Ignored)
+{
+    int sheetsBefore = DocSheet::getSheets().count();
+    sharedWidget()->addSheet(nullptr);
+    EXPECT_EQ(sheetsBefore, DocSheet::getSheets().count());
+}
+
+TEST_F(UT_PdfWidget, AddSheet_ValidSheet_RepresentsWidget)
+{
+    DocSheet *sheet = new DocSheet(kPDF, "/tmp/pdfwidget-add.pdf");
+    sharedWidget()->addSheet(sheet);
+    EXPECT_TRUE(DocSheet::existSheet(sheet));
+    EXPECT_EQ(sharedWidget(), sheet->parent());
+
+    sharedWidget()->closeSheet(sheet);
+    EXPECT_FALSE(DocSheet::existSheet(sheet));
+}
+
+TEST_F(UT_PdfWidget, EnterSheet_NullSheet_Ignored)
+{
+    sharedWidget()->enterSheet(nullptr);
+    SUCCEED();
+}
+
+TEST_F(UT_PdfWidget, LeaveSheet_NullSheet_Ignored)
+{
+    sharedWidget()->leaveSheet(nullptr);
+    SUCCEED();
+}
+
+TEST_F(UT_PdfWidget, LeaveSheet_ValidSheet_NoCrash)
+{
+    DocSheet *sheet = new DocSheet(kPDF, "/tmp/pdfwidget-leave.pdf");
+    sharedWidget()->addSheet(sheet);
+    sharedWidget()->leaveSheet(sheet);
+    EXPECT_TRUE(DocSheet::existSheet(sheet));
+    sharedWidget()->closeSheet(sheet);
+}
+
+TEST_F(UT_PdfWidget, CloseSheet_NullSheet_ReturnsFalse)
+{
+    EXPECT_FALSE(sharedWidget()->closeSheet(nullptr));
+}
+
+TEST_F(UT_PdfWidget, CloseSheet_SheetNotInWidgetMap_StillClosesByGlobalRegistry)
+{
+    DocSheet *sheet = new DocSheet(kPDF, "/tmp/pdfwidget-close-unreg.pdf");
+    EXPECT_TRUE(DocSheet::existSheet(sheet));
+    EXPECT_TRUE(sharedWidget()->closeSheet(sheet));
+    EXPECT_FALSE(DocSheet::existSheet(sheet));
+}
+
+TEST_F(UT_PdfWidget, CloseSheet_RegisteredSheet_ReturnsTrueAndDeletes)
+{
+    DocSheet *sheet = new DocSheet(kPDF, "/tmp/pdfwidget-close.pdf");
+    sharedWidget()->addSheet(sheet);
+    EXPECT_TRUE(sharedWidget()->closeSheet(sheet));
+    EXPECT_FALSE(DocSheet::existSheet(sheet));
+    ut_utils::drainEvents(100);
+}
+
+TEST_F(UT_PdfWidget, CloseAllSheets_MultipleSheets_ClosesEverything)
+{
+    DocSheet *first = new DocSheet(kPDF, "/tmp/pdfwidget-all-1.pdf");
+    DocSheet *second = new DocSheet(kPDF, "/tmp/pdfwidget-all-2.pdf");
+    sharedWidget()->addSheet(first);
+    sharedWidget()->addSheet(second);
+
+    EXPECT_TRUE(sharedWidget()->closeAllSheets());
+    EXPECT_FALSE(DocSheet::existSheet(first));
+    EXPECT_FALSE(DocSheet::existSheet(second));
+    ut_utils::drainEvents(100);
+}
+
+TEST_F(UT_PdfWidget, OnOpened_FileError_SchedulesSheetDeletion)
+{
+    qRegisterMetaType<DocSheet *>("DocSheet *");
+    DocSheet *sheet = new DocSheet(kPDF, "/nonexistent-dir/broken.pdf");
+    sharedWidget()->addSheet(sheet);
+    ASSERT_TRUE(DocSheet::existSheet(sheet));
+
+    sharedWidget()->onOpened(sheet, Document::kFileError);
+
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    EXPECT_FALSE(DocSheet::existSheet(sheet));
+}
+
+TEST_F(UT_PdfWidget, OnOpened_FileDamaged_SchedulesSheetDeletion)
+{
+    qRegisterMetaType<DocSheet *>("DocSheet *");
+    DocSheet *sheet = new DocSheet(kPDF, "/nonexistent-dir/damaged.pdf");
+    sharedWidget()->addSheet(sheet);
+    ASSERT_TRUE(DocSheet::existSheet(sheet));
+
+    sharedWidget()->onOpened(sheet, Document::kFileDamaged);
+
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    EXPECT_FALSE(DocSheet::existSheet(sheet));
+}
+
+TEST_F(UT_PdfWidget, OnOpened_NullSheet_Ignored)
+{
+    sharedWidget()->onOpened(nullptr, Document::kNoError);
+    SUCCEED();
+}
+
+TEST_F(UT_PdfWidget, OnOpened_Success_KeepsSheet)
+{
+    qRegisterMetaType<DocSheet *>("DocSheet *");
+    DocSheet *sheet = new DocSheet(kPDF, "/tmp/pdfwidget-success.pdf");
+    sharedWidget()->addSheet(sheet);
+
+    sharedWidget()->onOpened(sheet, Document::kNoError);
+
+    EXPECT_TRUE(DocSheet::existSheet(sheet));
+    sharedWidget()->closeSheet(sheet);
+}
+
+TEST(UT_PDFPreviewPlugin, Create_AnyKey_ReturnsNewPreviewInstance)
+{
+    PDFPreviewPlugin plugin;
+    DFMBASE_NAMESPACE::AbstractBasePreview *preview = plugin.create("pdf");
+    EXPECT_NE(nullptr, preview);
+    delete preview;
+}
+
+class UT_PDFPreview : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        qRegisterMetaType<Document::Error>("Document::Error");
+        qRegisterMetaType<DocSheet *>("DocSheet *");
+        pdfPath = ut_utils::prepareFile(ut_utils::kMultiPagePdfSrc);
+        preview = new PDFPreview();
+    }
+
+    virtual void TearDown() override
+    {
+        setMainWidget(nullptr);
+        delete preview;
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        ut_utils::drainEvents(50);
+    }
+
+protected:
+    QString pdfPath;
+    PDFPreview *preview { nullptr };
+};
+
+TEST_F(UT_PDFPreview, SetFileUrl_NotLocalFile_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->setFileUrl(QUrl("http://example.com/file.pdf")));
+    EXPECT_EQ(QUrl(), preview->fileUrl());
+}
+
+TEST_F(UT_PDFPreview, SetFileUrl_MissingLocalFile_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile("/nonexistent-dir/no.pdf")));
+    EXPECT_EQ(QUrl(), preview->fileUrl());
+}
+
+TEST_F(UT_PDFPreview, ShowStatusBarSeparator_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->showStatusBarSeparator());
+}
+
+TEST_F(UT_PDFPreview, ContentWidget_InitiallyNull)
+{
+    EXPECT_EQ(nullptr, preview->contentWidget());
+}
+
+TEST_F(UT_PDFPreview, Title_InitiallyEmpty)
+{
+    EXPECT_TRUE(preview->title().isEmpty());
+}
+
+TEST_F(UT_PDFPreview, SetFileUrl_ValidPdf_ReturnsTrueAndUpdatesState)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(static_cast<QMimeType (DFMBASE_NAMESPACE::DMimeDatabase::*)(const QUrl &, QMimeDatabase::MatchMode) const>(&DFMBASE_NAMESPACE::DMimeDatabase::mimeTypeForFile),
+                   [](DFMBASE_NAMESPACE::DMimeDatabase *, const QUrl &, QMimeDatabase::MatchMode) {
+                       __DBG_STUB_INVOKE__
+                       return pdfMime();
+                   });
+
+    QSignalSpy spy(preview, SIGNAL(titleChanged()));
+    QUrl url = QUrl::fromLocalFile(pdfPath);
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(url, preview->fileUrl());
+    EXPECT_EQ(QFileInfo(pdfPath).fileName(), preview->title());
+    EXPECT_NE(nullptr, preview->contentWidget());
+    EXPECT_GE(spy.count(), 1);
+}
+
+TEST_F(UT_PDFPreview, SetFileUrl_SameUrlTwice_ReturnsTrueWithoutReopen)
+{
+    stub_ext::StubExt stub;
+    stub.set_lamda(static_cast<QMimeType (DFMBASE_NAMESPACE::DMimeDatabase::*)(const QUrl &, QMimeDatabase::MatchMode) const>(&DFMBASE_NAMESPACE::DMimeDatabase::mimeTypeForFile),
+                   [](DFMBASE_NAMESPACE::DMimeDatabase *, const QUrl &, QMimeDatabase::MatchMode) {
+                       __DBG_STUB_INVOKE__
+                       return pdfMime();
+                   });
+
+    QUrl url = QUrl::fromLocalFile(pdfPath);
+    ASSERT_TRUE(preview->setFileUrl(url));
+    QWidget *widgetAfterFirst = preview->contentWidget();
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(widgetAfterFirst, preview->contentWidget());
+}
+
+TEST_F(UT_PDFPreview, Initialize_SetsGlobalMainWidget)
+{
+    QWidget window;
+    preview->initialize(&window, nullptr);
+    EXPECT_EQ(&window, getMainDialog());
+}
+
+TEST(UT_PageRenderThread_Final, DestroyForever_StopsThreadAndAppendTasksBecomeNoOp)
+{
+    if (g_sharedWidget) {
+        g_sharedWidget->closeAllSheets();
+        ut_utils::waitRenderIdle();
+        delete g_sharedWidget;
+        g_sharedWidget = nullptr;
+    }
+    PageRenderThread::destroyForever();
+
+    DocPageNormalImageTask normalTask;
+    PageRenderThread::appendTask(normalTask);
+    DocPageSliceImageTask sliceTask;
+    PageRenderThread::appendTask(sliceTask);
+    DocPageThumbnailTask thumbnailTask;
+    PageRenderThread::appendTask(thumbnailTask);
+    DocOpenTask openTask;
+    PageRenderThread::appendTask(openTask);
+    DocCloseTask closeTask;
+    PageRenderThread::appendTask(closeTask);
+
+    PageRenderThread::destroyForever();
+    SUCCEED();
+}

--- a/autotests/apps/dde-file-manager-preview/pdf-preview/ut_common.h
+++ b/autotests/apps/dde-file-manager-preview/pdf-preview/ut_common.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PDF_PREVIEW_UT_COMMON_H
+#define PDF_PREVIEW_UT_COMMON_H
+
+#include "pagerenderthread.h"
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QFileInfo>
+#include <QMutexLocker>
+#include <QTemporaryDir>
+
+#include <functional>
+
+namespace ut_utils {
+
+inline const char *kMultiPagePdfSrc = "/usr/share/doc/shared-mime-info/shared-mime-info-spec.pdf";
+inline const char *kSinglePagePdfSrc = "/usr/share/cups/data/default.pdf";
+
+inline QString prepareFile(const QString &source)
+{
+    static QTemporaryDir dir;
+    QString dst = dir.path() + "/" + QFileInfo(source).fileName();
+    if (!QFile::exists(dst))
+        QFile::copy(source, dst);
+    return dst;
+}
+
+inline void processEventsUntil(const std::function<bool()> &cond, int timeoutMs = 5000)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (!cond()) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        if (timer.elapsed() > timeoutMs)
+            break;
+    }
+}
+
+inline void drainEvents(int ms = 200)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < ms)
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}
+
+inline void waitRenderIdle(int extraMs = 300)
+{
+    plugin_filepreview::PageRenderThread *thread = plugin_filepreview::PageRenderThread::instance();
+    if (thread) {
+        processEventsUntil([&thread]() {
+            {
+                QMutexLocker closeLocker(&thread->closeMutex);
+                if (!thread->closeTasks.isEmpty()) {
+                    QMutexLocker normalLocker(&thread->pageNormalImageMutex);
+                    if (thread->pageNormalImageTasks.isEmpty())
+                        thread->pageNormalImageTasks.append(plugin_filepreview::DocPageNormalImageTask());
+                }
+            }
+            QMutexLocker normalLocker(&thread->pageNormalImageMutex);
+            QMutexLocker thumbLocker(&thread->pageThumbnailMutex);
+            QMutexLocker openLocker(&thread->openMutex);
+            QMutexLocker closeLocker(&thread->closeMutex);
+            return thread->pageNormalImageTasks.isEmpty()
+                    && thread->pageThumbnailTasks.isEmpty()
+                    && thread->openTasks.isEmpty()
+                    && thread->closeTasks.isEmpty();
+        },
+                           8000);
+        QMutexLocker sliceLocker(&thread->pageSliceImageMutex);
+        thread->pageSliceImageTasks.clear();
+    }
+    drainEvents(extraMs);
+}
+
+}
+
+#endif

--- a/autotests/apps/dde-file-manager-preview/text-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/text-preview/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Unit tests for text-preview: recompile plugin sources into the test binary
+# so stub-ext can access private members (see autotests/README.md).
+set(_preview_dir "${DFM_PREVIEW_PLUGIN_DIR}/text-preview")
+
+file(GLOB_RECURSE _ut_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+file(GLOB_RECURSE _plugin_files
+    "${_preview_dir}/*.cpp"
+    "${_preview_dir}/*.h")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+find_package(KF6SyntaxHighlighting REQUIRED)
+
+dfm_create_test_executable(ut-text-preview
+    SOURCES ${_ut_files} ${_plugin_files}
+    LINK_LIBRARIES DFM6::base DFM6::framework Qt6::Widgets KF6::SyntaxHighlighting
+)
+
+target_include_directories(ut-text-preview PRIVATE
+    "${DFM_PREVIEW_PLUGIN_DIR}"
+    ${_preview_dir}
+)
+

--- a/autotests/apps/dde-file-manager-preview/text-preview/main.cpp
+++ b/autotests/apps/dde-file-manager-preview/text-preview/main.cpp
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(text_preview)

--- a/autotests/apps/dde-file-manager-preview/text-preview/test_textbrowseredit.cpp
+++ b/autotests/apps/dde-file-manager-preview/text-preview/test_textbrowseredit.cpp
@@ -1,0 +1,395 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "textbrowseredit.h"
+
+#include <dfm-base/dfm_log_defines.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QFont>
+#include <QPointer>
+#include <QScrollBar>
+#include <QTextCursor>
+#include <QWheelEvent>
+
+#include <KSyntaxHighlighting/Definition>
+#include <KSyntaxHighlighting/Repository>
+#include <KSyntaxHighlighting/SyntaxHighlighter>
+#include <KSyntaxHighlighting/Theme>
+
+#include <string>
+
+using namespace plugin_filepreview;
+
+namespace {
+constexpr int kChunkLimit { 1024 * 1024 * 5 };
+}
+
+class UT_TextBrowserEdit : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        edit = new TextBrowserEdit();
+    }
+
+    virtual void TearDown() override
+    {
+        delete edit;
+        edit = nullptr;
+    }
+
+    QString knownCodeFilePath()
+    {
+        const auto defs = edit->m_repository.definitions();
+        for (const auto &def : defs) {
+            if (!def.isValid())
+                continue;
+            for (const QString &ext : def.extensions()) {
+                QString candidate;
+                if (ext.startsWith("*."))
+                    candidate = "ut_text_sample" + ext.mid(1);
+                else if (ext.startsWith('.'))
+                    candidate = "ut_text_sample" + ext;
+                else
+                    candidate = "ut_text_sample." + ext;
+                if (edit->m_repository.definitionForFileName(candidate).isValid())
+                    return candidate;
+            }
+        }
+        return QString();
+    }
+
+protected:
+    TextBrowserEdit *edit { nullptr };
+};
+
+TEST_F(UT_TextBrowserEdit, Constructor_DefaultArgs_WidgetConfiguredForPreview)
+{
+    EXPECT_TRUE(edit->isReadOnly());
+    EXPECT_EQ(edit->textInteractionFlags(),
+              Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+    EXPECT_EQ(edit->lineWrapMode(), QPlainTextEdit::WidgetWidth);
+    EXPECT_EQ(edit->size(), QSize(800, 500));
+    EXPECT_EQ(edit->frameShape(), QFrame::NoFrame);
+
+    QFont font = edit->font();
+    EXPECT_EQ(font.family(), QString("Noto Mono"));
+    EXPECT_TRUE(font.fixedPitch());
+    EXPECT_DOUBLE_EQ(font.pointSizeF(), 10.0);
+}
+
+TEST_F(UT_TextBrowserEdit, Destructor_WithActiveHighlighter_DestroysHighlighterWithoutCrash)
+{
+    const QString path = knownCodeFilePath();
+    if (path.isEmpty())
+        GTEST_SKIP() << "no syntax definitions available";
+
+    edit->setSyntaxDefinition(path);
+    ASSERT_TRUE(edit->m_highlighter);
+
+    QPointer<KSyntaxHighlighting::SyntaxHighlighter> highlighter = edit->m_highlighter;
+
+    delete edit;
+    edit = nullptr;
+
+    EXPECT_TRUE(highlighter.isNull());
+}
+
+TEST_F(UT_TextBrowserEdit, SetFileData_PlainText_ContentLoadedAndCursorAtStart)
+{
+    std::string data = "hello world\nsecond line";
+    edit->setFileData(data);
+
+    EXPECT_TRUE(edit->toPlainText().contains("hello world"));
+    EXPECT_TRUE(edit->toPlainText().contains("second line"));
+    EXPECT_EQ(edit->textCursor().position(), 0);
+    EXPECT_TRUE(edit->filestr.empty());
+}
+
+TEST_F(UT_TextBrowserEdit, SetFileData_EmptyString_NothingLoaded)
+{
+    std::string data;
+    edit->setFileData(data);
+
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_TRUE(edit->filestr.empty());
+}
+
+TEST_F(UT_TextBrowserEdit, SetFileData_DataExceedsChunkLimit_ChunkAppendedAndRemainderKept)
+{
+    std::string data;
+    data.reserve(kChunkLimit + 10);
+    while (data.size() < kChunkLimit + 10)
+        data += "abcdefghijklmnopqrstuvwxyz0123456789\n";
+    data.resize(kChunkLimit + 10);
+
+    edit->setFileData(data);
+
+    EXPECT_EQ(edit->toPlainText().size(), kChunkLimit);
+    EXPECT_EQ(static_cast<int>(edit->filestr.size()), 10);
+}
+
+TEST_F(UT_TextBrowserEdit, WheelEvent_ScrollDownAtBottomWithPendingData_AppendsPendingData)
+{
+    edit->filestr = std::string("pending tail");
+
+    QWheelEvent event(QPointF(0, 0), QPointF(0, 0), QPoint(0, -120), QPoint(0, -120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    edit->wheelEvent(&event);
+
+    EXPECT_TRUE(edit->toPlainText().contains("pending tail"));
+    EXPECT_TRUE(edit->filestr.empty());
+}
+
+TEST_F(UT_TextBrowserEdit, WheelEvent_ScrollUpWithPendingData_PendingDataNotAppended)
+{
+    edit->filestr = std::string("pending tail");
+
+    QWheelEvent event(QPointF(0, 0), QPointF(0, 0), QPoint(0, 120), QPoint(0, 120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    edit->wheelEvent(&event);
+
+    EXPECT_FALSE(edit->toPlainText().contains("pending tail"));
+    EXPECT_EQ(edit->filestr, std::string("pending tail"));
+}
+
+TEST_F(UT_TextBrowserEdit, WheelEvent_ScrollDownAwayFromBottom_PendingDataNotAppended)
+{
+    QString content;
+    for (int i = 0; i < 500; ++i)
+        content += QString("line %1\n").arg(i);
+    edit->setPlainText(content);
+    edit->verticalScrollBar()->setValue(0);
+    ASSERT_GT(edit->verticalScrollBar()->maximum(), 0);
+
+    edit->filestr = std::string("tail");
+
+    QWheelEvent event(QPointF(0, 0), QPointF(0, 0), QPoint(0, -120), QPoint(0, -120),
+                      Qt::NoButton, Qt::NoModifier, Qt::ScrollUpdate, false);
+    edit->wheelEvent(&event);
+
+    EXPECT_FALSE(edit->toPlainText().contains("tail"));
+    EXPECT_EQ(edit->filestr, std::string("tail"));
+}
+
+TEST_F(UT_TextBrowserEdit, ScrollbarValueChange_ValueAtMaximum_NoCrash)
+{
+    QString content;
+    for (int i = 0; i < 500; ++i)
+        content += QString("line %1\n").arg(i);
+    edit->setPlainText(content);
+    ASSERT_GT(edit->verticalScrollBar()->maximum(), 0);
+
+    EXPECT_NO_FATAL_FAILURE(edit->scrollbarValueChange(edit->verticalScrollBar()->maximum()));
+}
+
+TEST_F(UT_TextBrowserEdit, ScrollbarValueChange_ValueBelowMaximum_ValueUnchanged)
+{
+    QString content;
+    for (int i = 0; i < 500; ++i)
+        content += QString("line %1\n").arg(i);
+    edit->setPlainText(content);
+    edit->verticalScrollBar()->setValue(0);
+    ASSERT_GT(edit->verticalScrollBar()->maximum(), 0);
+
+    edit->scrollbarValueChange(0);
+
+    EXPECT_EQ(edit->verticalScrollBar()->value(), 0);
+}
+
+TEST_F(UT_TextBrowserEdit, SliderPositionValueChange_PositionIncreasesToMaximum_AppendsPendingData)
+{
+    edit->filestr = std::string("chunk two");
+    edit->lastPosition = 0;
+    ASSERT_EQ(edit->verticalScrollBar()->maximum(), 0);
+
+    edit->sliderPositionValueChange(1);
+
+    EXPECT_TRUE(edit->toPlainText().contains("chunk two"));
+    EXPECT_TRUE(edit->filestr.empty());
+    EXPECT_EQ(edit->lastPosition, 1);
+}
+
+TEST_F(UT_TextBrowserEdit, SliderPositionValueChange_PositionDecreases_PendingDataNotAppended)
+{
+    edit->filestr = std::string("chunk two");
+    edit->lastPosition = 5;
+
+    edit->sliderPositionValueChange(3);
+
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_EQ(edit->filestr, std::string("chunk two"));
+    EXPECT_EQ(edit->lastPosition, 3);
+}
+
+TEST_F(UT_TextBrowserEdit, SliderPositionValueChange_PositionIncreasesBelowMaximum_PendingDataNotAppended)
+{
+    QString content;
+    for (int i = 0; i < 500; ++i)
+        content += QString("line %1\n").arg(i);
+    edit->setPlainText(content);
+    edit->lastPosition = 0;
+    ASSERT_GT(edit->verticalScrollBar()->maximum(), 1);
+
+    edit->filestr = std::string("tail");
+
+    edit->sliderPositionValueChange(1);
+
+    EXPECT_FALSE(edit->toPlainText().contains("tail"));
+    EXPECT_EQ(edit->filestr, std::string("tail"));
+    EXPECT_EQ(edit->lastPosition, 1);
+}
+
+TEST_F(UT_TextBrowserEdit, SliderPositionValueChange_EmptyPendingData_NothingAppended)
+{
+    edit->lastPosition = 0;
+    ASSERT_EQ(edit->verticalScrollBar()->maximum(), 0);
+
+    edit->sliderPositionValueChange(1);
+
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+    EXPECT_EQ(edit->lastPosition, 1);
+}
+
+TEST_F(UT_TextBrowserEdit, SetSyntaxDefinition_KnownCodeFile_HighlighterCreated)
+{
+    const QString path = knownCodeFilePath();
+    if (path.isEmpty())
+        GTEST_SKIP() << "no syntax definitions available";
+
+    edit->setSyntaxDefinition(path);
+
+    EXPECT_TRUE(edit->m_highlighter);
+}
+
+TEST_F(UT_TextBrowserEdit, SetSyntaxDefinition_UnknownSuffix_HighlighterNotCreated)
+{
+    edit->setSyntaxDefinition("/tmp/ut_text_no_def.zzzz123");
+
+    EXPECT_FALSE(edit->m_highlighter);
+}
+
+TEST_F(UT_TextBrowserEdit, SetSyntaxDefinition_RepeatedCall_OldHighlighterDeleted)
+{
+    const QString path = knownCodeFilePath();
+    if (path.isEmpty())
+        GTEST_SKIP() << "no syntax definitions available";
+
+    edit->setSyntaxDefinition(path);
+    QPointer<KSyntaxHighlighting::SyntaxHighlighter> oldHighlighter = edit->m_highlighter;
+    ASSERT_TRUE(oldHighlighter);
+
+    edit->setSyntaxDefinition(path);
+
+    EXPECT_TRUE(oldHighlighter.isNull());
+    EXPECT_TRUE(edit->m_highlighter);
+}
+
+TEST_F(UT_TextBrowserEdit, OnThemeTypeChanged_WithHighlighter_NoCrash)
+{
+    const QString path = knownCodeFilePath();
+    if (path.isEmpty())
+        GTEST_SKIP() << "no syntax definitions available";
+
+    edit->setSyntaxDefinition(path);
+    ASSERT_TRUE(edit->m_highlighter);
+
+    EXPECT_NO_FATAL_FAILURE(edit->onThemeTypeChanged());
+}
+
+TEST_F(UT_TextBrowserEdit, OnThemeTypeChanged_WithoutHighlighter_NoCrash)
+{
+    EXPECT_FALSE(edit->m_highlighter);
+
+    EXPECT_NO_FATAL_FAILURE(edit->onThemeTypeChanged());
+}
+
+TEST_F(UT_TextBrowserEdit, UpdateHighlighterTheme_WithHighlighter_NoCrash)
+{
+    const QString path = knownCodeFilePath();
+    if (path.isEmpty())
+        GTEST_SKIP() << "no syntax definitions available";
+
+    edit->setSyntaxDefinition(path);
+    ASSERT_TRUE(edit->m_highlighter);
+
+    EXPECT_NO_FATAL_FAILURE(edit->updateHighlighterTheme());
+}
+
+TEST_F(UT_TextBrowserEdit, UpdateHighlighterTheme_WithoutHighlighter_EarlyReturn)
+{
+    EXPECT_FALSE(edit->m_highlighter);
+
+    EXPECT_NO_FATAL_FAILURE(edit->updateHighlighterTheme());
+    EXPECT_FALSE(edit->m_highlighter);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_NullInput_ReturnsZero)
+{
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(nullptr, 10), 0);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_EmptyInput_ReturnsZero)
+{
+    const char *empty = "";
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(empty, 10), 0);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_NonPositiveLength_ReturnsZero)
+{
+    const char ascii[] = "abc";
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(ascii, 0), 0);
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(ascii, -5), 0);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_AsciiShorterThanLimit_ReturnsFullLength)
+{
+    const QByteArray ascii = QByteArrayLiteral("abcdef");
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(ascii.constData(), 10), 6);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_AsciiExactLimit_ReturnsLimit)
+{
+    const QByteArray ascii = QByteArrayLiteral("abcd");
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(ascii.constData(), 4), 4);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_MultibyteExactLimit_ReturnsByteLength)
+{
+    const QByteArray multibyte = QByteArray::fromHex("e4bda0");
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(multibyte.constData(), 3), 3);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_MultibyteExceedsLimit_TrimsTrailingCharacter)
+{
+    const QByteArray multibyte = QByteArray::fromHex("e4bda0e4bda0");
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(multibyte.constData(), 4), 3);
+}
+
+TEST_F(UT_TextBrowserEdit, VerifyEndOfStrIntegrity_TruncatedMultibyteAtEnd_ReturnsPartialLength)
+{
+    const QByteArray truncated = QByteArray::fromHex("61e4");
+    EXPECT_EQ(edit->verifyEndOfStrIntegrity(truncated.constData(), 10), 1);
+}
+
+TEST_F(UT_TextBrowserEdit, AppendText_EmptyPendingData_NothingInserted)
+{
+    auto it = edit->filestr.begin();
+    edit->appendText(it);
+
+    EXPECT_TRUE(edit->toPlainText().isEmpty());
+}
+
+TEST_F(UT_TextBrowserEdit, AppendText_SmallPendingData_InsertsAndClearsPending)
+{
+    edit->filestr = std::string("hello");
+    auto it = edit->filestr.begin();
+    edit->appendText(it);
+
+    EXPECT_EQ(edit->toPlainText(), QString("hello"));
+    EXPECT_TRUE(edit->filestr.empty());
+}

--- a/autotests/apps/dde-file-manager-preview/text-preview/test_textcontextwidget.cpp
+++ b/autotests/apps/dde-file-manager-preview/text-preview/test_textcontextwidget.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "textcontextwidget.h"
+#include "textbrowseredit.h"
+
+#include <dfm-base/dfm_log_defines.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QLayout>
+#include <QPlainTextEdit>
+#include <QScrollBar>
+#include <QVBoxLayout>
+
+using namespace plugin_filepreview;
+
+class UT_TextContextWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        widget = new TextContextWidget();
+    }
+
+    virtual void TearDown() override
+    {
+        delete widget;
+        widget = nullptr;
+    }
+
+protected:
+    TextContextWidget *widget { nullptr };
+};
+
+TEST_F(UT_TextContextWidget, Constructor_DefaultArgs_TitleAndEditWidgetsLaidOut)
+{
+    auto *layout = qobject_cast<QVBoxLayout *>(widget->layout());
+    ASSERT_TRUE(layout);
+    ASSERT_EQ(layout->count(), 2);
+    EXPECT_EQ(layout->contentsMargins(), QMargins(0, 0, 0, 0));
+    EXPECT_EQ(layout->spacing(), 0);
+
+    auto *titleWidget = qobject_cast<QPlainTextEdit *>(layout->itemAt(0)->widget());
+    ASSERT_TRUE(titleWidget);
+    EXPECT_EQ(titleWidget->minimumHeight(), 30);
+    EXPECT_EQ(titleWidget->maximumHeight(), 30);
+    EXPECT_TRUE(titleWidget->isReadOnly());
+    EXPECT_EQ(titleWidget->verticalScrollBarPolicy(), Qt::ScrollBarAlwaysOff);
+    EXPECT_EQ(titleWidget->frameShape(), QFrame::NoFrame);
+
+    auto *editWidget = qobject_cast<TextBrowserEdit *>(layout->itemAt(1)->widget());
+    ASSERT_TRUE(editWidget);
+    EXPECT_EQ(editWidget, widget->textBrowserEdit());
+    EXPECT_NE(titleWidget, editWidget);
+}
+
+TEST_F(UT_TextContextWidget, TextBrowserEdit_AfterConstruction_ReturnsNonNullInstance)
+{
+    EXPECT_NE(widget->textBrowserEdit(), nullptr);
+}
+
+TEST_F(UT_TextContextWidget, TextBrowserEdit_RepeatedCalls_ReturnsSameInstance)
+{
+    TextBrowserEdit *first = widget->textBrowserEdit();
+    TextBrowserEdit *second = widget->textBrowserEdit();
+    EXPECT_EQ(first, second);
+}
+
+TEST_F(UT_TextContextWidget, TextBrowserEdit_InstanceIsChildOfContextWidget)
+{
+    EXPECT_EQ(widget->textBrowserEdit()->parentWidget(), widget);
+}

--- a/autotests/apps/dde-file-manager-preview/text-preview/test_textpreview.cpp
+++ b/autotests/apps/dde-file-manager-preview/text-preview/test_textpreview.cpp
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "textpreview.h"
+#include "textpreviewplugin.h"
+#include "textcontextwidget.h"
+#include "textbrowseredit.h"
+
+#include <dfm-base/dfm_log_defines.h>
+#include <dfm-base/interfaces/abstractbasepreview.h>
+#include <dfm-base/interfaces/abstractfilepreviewplugin.h>
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QFile>
+#include <QFileInfo>
+#include <QSignalSpy>
+#include <QTemporaryFile>
+#include <QUrl>
+
+#include <DTextEncoding>
+
+#include <QByteArray>
+#include <QStringList>
+
+DFMBASE_USE_NAMESPACE
+using namespace plugin_filepreview;
+
+namespace {
+constexpr int kPreviewSizeLimit { 1024 * 1024 * 5 };
+}
+
+class UT_TextPreview : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        preview = new TextPreview();
+    }
+
+    virtual void TearDown() override
+    {
+        delete preview;
+        preview = nullptr;
+        if (qApp)
+            qApp->processEvents();
+        for (const QString &path : tempFiles)
+            QFile::remove(path);
+        tempFiles.clear();
+        stub.clear();
+    }
+
+    QString createTempFile(const QByteArray &content)
+    {
+        QTemporaryFile file;
+        file.setAutoRemove(false);
+        if (!file.open())
+            return QString();
+        file.write(content);
+        file.close();
+        tempFiles << file.fileName();
+        return file.fileName();
+    }
+
+    QByteArray invalidUtf8Content()
+    {
+        return QByteArray::fromHex("d6d0cec4") + QByteArrayLiteral(" tail");
+    }
+
+protected:
+    TextPreview *preview { nullptr };
+    stub_ext::StubExt stub;
+    QStringList tempFiles;
+};
+
+TEST_F(UT_TextPreview, Constructor_InitialState_AllAccessorsEmpty)
+{
+    EXPECT_EQ(preview->fileUrl(), QUrl());
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+    EXPECT_TRUE(preview->title().isEmpty());
+    EXPECT_FALSE(preview->showStatusBarSeparator());
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_RemoteUrl_ReturnsFalse)
+{
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl("http://example.com/readme.txt")));
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+    EXPECT_EQ(preview->fileUrl(), QUrl());
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_NonExistentLocalFile_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile("/tmp/ut_text_not_exist_1234.txt")));
+    EXPECT_EQ(preview->contentWidget(), nullptr);
+    EXPECT_EQ(preview->fileUrl(), QUrl());
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_EmptyLocalFile_ReturnsFalse)
+{
+    const QString path = createTempFile(QByteArray());
+
+    EXPECT_FALSE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_NE(preview->contentWidget(), nullptr);
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_ValidUtf8File_ReturnsTrueAndEmitsTitleChanged)
+{
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+    const QString path = createTempFile(QByteArrayLiteral("hello text preview\nsecond line"));
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->title(), QFileInfo(path).fileName());
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(path));
+    EXPECT_EQ(spy.count(), 1);
+
+    auto *context = dynamic_cast<TextContextWidget *>(preview->contentWidget());
+    ASSERT_TRUE(context);
+    EXPECT_TRUE(context->textBrowserEdit()->toPlainText().contains("hello text preview"));
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_SameUrlCalledTwice_ReturnsTrueWithoutReload)
+{
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+    const QString path = createTempFile(QByteArrayLiteral("once only"));
+    const QUrl url = QUrl::fromLocalFile(path);
+
+    ASSERT_TRUE(preview->setFileUrl(url));
+    ASSERT_EQ(spy.count(), 1);
+
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_Gb18030EncodedFile_ReturnsTrueAfterConversion)
+{
+    QSignalSpy spy(preview, &AbstractBasePreview::titleChanged);
+    const QString path = createTempFile(QByteArray::fromHex("d6d0cec4"));
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->title(), QFileInfo(path).fileName());
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_AllConversionsFailWithDetectedEncoding_ReturnsTrue)
+{
+    stub.set_lamda(ADDR(DTK_CORE_NAMESPACE::DTextEncoding, convertTextEncoding),
+                   [](QByteArray &content, QByteArray &outContent, const QByteArray &toEncoding,
+                      const QByteArray &fromEncoding, QString *errString) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(ADDR(DTK_CORE_NAMESPACE::DTextEncoding, detectFileEncoding),
+                   [](const QString &fileName, bool *isOk) -> QByteArray {
+                       __DBG_STUB_INVOKE__
+                       if (isOk)
+                           *isOk = true;
+                       return QByteArrayLiteral("GB18030");
+                   });
+
+    const QString path = createTempFile(invalidUtf8Content());
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->title(), QFileInfo(path).fileName());
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_EncodingDetectionFails_ReturnsTrueWithRawData)
+{
+    stub.set_lamda(ADDR(DTK_CORE_NAMESPACE::DTextEncoding, convertTextEncoding),
+                   [](QByteArray &content, QByteArray &outContent, const QByteArray &toEncoding,
+                      const QByteArray &fromEncoding, QString *errString) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(ADDR(DTK_CORE_NAMESPACE::DTextEncoding, detectFileEncoding),
+                   [](const QString &fileName, bool *isOk) -> QByteArray {
+                       __DBG_STUB_INVOKE__
+                       if (isOk)
+                           *isOk = false;
+                       return QByteArray();
+                   });
+
+    const QString path = createTempFile(invalidUtf8Content());
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->title(), QFileInfo(path).fileName());
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_DetectedEncodingIsUtf8_SkipsSecondConversion)
+{
+    stub.set_lamda(ADDR(DTK_CORE_NAMESPACE::DTextEncoding, convertTextEncoding),
+                   [](QByteArray &content, QByteArray &outContent, const QByteArray &toEncoding,
+                      const QByteArray &fromEncoding, QString *errString) -> bool {
+                       __DBG_STUB_INVOKE__
+                       return false;
+                   });
+    stub.set_lamda(ADDR(DTK_CORE_NAMESPACE::DTextEncoding, detectFileEncoding),
+                   [](const QString &fileName, bool *isOk) -> QByteArray {
+                       __DBG_STUB_INVOKE__
+                       if (isOk)
+                           *isOk = true;
+                       return QByteArrayLiteral("UTF-8");
+                   });
+
+    const QString path = createTempFile(invalidUtf8Content());
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->title(), QFileInfo(path).fileName());
+}
+
+TEST_F(UT_TextPreview, SetFileUrl_FileLargerThanSizeLimit_TruncatesAndReturnsTrue)
+{
+    QByteArray big;
+    big.reserve(kPreviewSizeLimit + 10);
+    while (big.size() < kPreviewSizeLimit + 10)
+        big += QByteArrayLiteral("0123456789abcdefghijklmnopqrstuvwxyz\n");
+    big.resize(kPreviewSizeLimit + 10);
+
+    const QString path = createTempFile(big);
+
+    EXPECT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->title(), QFileInfo(path).fileName());
+
+    auto *context = dynamic_cast<TextContextWidget *>(preview->contentWidget());
+    ASSERT_TRUE(context);
+    EXPECT_EQ(context->textBrowserEdit()->toPlainText().size(), kPreviewSizeLimit);
+}
+
+TEST_F(UT_TextPreview, FileUrl_AfterSuccessfulLoad_ReturnsSelectedUrl)
+{
+    const QString path = createTempFile(QByteArrayLiteral("url check"));
+    const QUrl url = QUrl::fromLocalFile(path);
+
+    ASSERT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(preview->fileUrl(), url);
+}
+
+TEST_F(UT_TextPreview, Title_AfterSuccessfulLoad_ReturnsFileName)
+{
+    const QString path = createTempFile(QByteArrayLiteral("title check"));
+
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_EQ(preview->title(), QFileInfo(path).fileName());
+}
+
+TEST_F(UT_TextPreview, ContentWidget_AfterSuccessfulLoad_ReturnsTextContextWidget)
+{
+    const QString path = createTempFile(QByteArrayLiteral("widget check"));
+
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    auto *context = dynamic_cast<TextContextWidget *>(preview->contentWidget());
+    EXPECT_TRUE(context);
+    EXPECT_TRUE(context->textBrowserEdit());
+}
+
+TEST_F(UT_TextPreview, ShowStatusBarSeparator_AnyState_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->showStatusBarSeparator());
+
+    const QString path = createTempFile(QByteArrayLiteral("separator check"));
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+    EXPECT_FALSE(preview->showStatusBarSeparator());
+}
+
+TEST_F(UT_TextPreview, Destructor_AfterSuccessfulLoad_DestroysBrowserWithoutCrash)
+{
+    const QString path = createTempFile(QByteArrayLiteral("destroy check"));
+    ASSERT_TRUE(preview->setFileUrl(QUrl::fromLocalFile(path)));
+
+    delete preview;
+    preview = nullptr;
+
+    EXPECT_NO_FATAL_FAILURE(qApp->processEvents());
+}
+
+class UT_TextPreviewPlugin : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        plugin = new TextPreviewPlugin();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+    }
+
+protected:
+    TextPreviewPlugin *plugin { nullptr };
+};
+
+TEST_F(UT_TextPreviewPlugin, Create_WithArbitraryKey_ReturnsTextPreviewInstance)
+{
+    AbstractBasePreview *result = plugin->create("text");
+
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(dynamic_cast<TextPreview *>(result));
+    delete result;
+}
+
+TEST_F(UT_TextPreviewPlugin, Create_WithEmptyKey_ReturnsInstance)
+{
+    AbstractBasePreview *result = plugin->create("");
+
+    ASSERT_NE(result, nullptr);
+    delete result;
+}
+
+TEST_F(UT_TextPreviewPlugin, Create_RepeatedCalls_ReturnsDistinctInstances)
+{
+    AbstractBasePreview *first = plugin->create("text");
+    AbstractBasePreview *second = plugin->create("text");
+
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+    EXPECT_NE(first, second);
+
+    delete first;
+    delete second;
+}

--- a/autotests/apps/dde-file-manager-preview/video-preview/CMakeLists.txt
+++ b/autotests/apps/dde-file-manager-preview/video-preview/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Unit tests for video-preview: recompile plugin sources into the test binary
+# so stub-ext can access private members (see autotests/README.md).
+set(_preview_dir "${DFM_PREVIEW_PLUGIN_DIR}/video-preview")
+
+file(GLOB_RECURSE _ut_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+file(GLOB_RECURSE _plugin_files
+    "${_preview_dir}/*.cpp"
+    "${_preview_dir}/*.h")
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_search_module(libdmr REQUIRED libdmr)
+
+dfm_create_test_executable(ut-video-preview
+    SOURCES ${_ut_files} ${_plugin_files}
+    LINK_LIBRARIES DFM6::base DFM6::framework Qt6::Widgets ${libdmr_LIBRARIES}
+)
+
+target_include_directories(ut-video-preview PRIVATE
+    "${DFM_PREVIEW_PLUGIN_DIR}"
+    ${_preview_dir}
+)
+target_include_directories(ut-video-preview PRIVATE ${libdmr_INCLUDE_DIRS})

--- a/autotests/apps/dde-file-manager-preview/video-preview/main.cpp
+++ b/autotests/apps/dde-file-manager-preview/video-preview/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(video_preview)

--- a/autotests/apps/dde-file-manager-preview/video-preview/test_videopreview.cpp
+++ b/autotests/apps/dde-file-manager-preview/video-preview/test_videopreview.cpp
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "videopreview.h"
+#include "videopreviewplugin.h"
+#include "videowidget.h"
+#include "videostatusbar.h"
+
+#include "stubext.h"
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QSignalSpy>
+#include <QTest>
+#include <QTemporaryFile>
+#include <QMetaObject>
+
+DFMBASE_USE_NAMESPACE
+using namespace plugin_filepreview;
+
+namespace {
+
+dmr::PlayerEngine *fakeEngine()
+{
+    static QObject obj;
+    return reinterpret_cast<dmr::PlayerEngine *>(&obj);
+}
+
+struct DmrCallLog
+{
+    int enginePlayCalls { 0 };
+    int pauseResumeCalls { 0 };
+    int stopCalls { 0 };
+    bool playable { true };
+    bool parseOk { true };
+    dmr::MovieInfo info;
+    qint64 elapsedValue { 0 };
+    dmr::PlayerEngine::CoreState engineState { dmr::PlayerEngine::Playing };
+    QUrl lastPlayedUrl;
+    int lastSeekPos { -1 };
+    QString lastBackendProperty;
+};
+
+DmrCallLog dmrLog;
+
+struct PlayerWidgetCtorStub
+{
+    PlayerWidgetCtorStub()
+    {
+        auto self = reinterpret_cast<dmr::PlayerWidget *>(this);
+        new (self) QWidget(nullptr);
+        self->_engine = nullptr;
+    }
+};
+
+void installDmrStubs(stub_ext::StubExt &stub)
+{
+    stub.set(stub_ext::StubExt::get_ctor_addr<dmr::PlayerWidget>(),
+             stub_ext::StubExt::get_ctor_addr<PlayerWidgetCtorStub>());
+
+    stub.set_lamda(&dmr::PlayerWidget::engine,
+                   [](dmr::PlayerWidget *) -> dmr::PlayerEngine & { return *fakeEngine(); });
+    stub.set_lamda(&dmr::PlayerWidget::play,
+                   [](dmr::PlayerWidget *, const QUrl &url) { dmrLog.lastPlayedUrl = url; });
+    stub.set_lamda(&dmr::PlayerEngine::play, []() { ++dmrLog.enginePlayCalls; });
+    stub.set_lamda(&dmr::PlayerEngine::pauseResume, []() { ++dmrLog.pauseResumeCalls; });
+    stub.set_lamda(&dmr::PlayerEngine::stop, []() { ++dmrLog.stopCalls; });
+    stub.set_lamda(&dmr::PlayerEngine::seekAbsolute, [](dmr::PlayerEngine *, int pos) { dmrLog.lastSeekPos = pos; });
+    stub.set_lamda(&dmr::PlayerEngine::elapsed, []() { return dmrLog.elapsedValue; });
+    stub.set_lamda(&dmr::PlayerEngine::state, []() { return dmrLog.engineState; });
+    stub.set_lamda(&dmr::PlayerEngine::setBackendProperty,
+                   [](dmr::PlayerEngine *, const QString &name, const QVariant &) { dmrLog.lastBackendProperty = name; });
+    stub.set_lamda(static_cast<bool (dmr::PlayerEngine::*)(const QUrl &)>(&dmr::PlayerEngine::isPlayableFile),
+                   [](dmr::PlayerEngine *, const QUrl &) { return dmrLog.playable; });
+    stub.set_lamda(&dmr::MovieInfo::parseFromFile, [](const QFileInfo &, bool *ok) {
+        if (ok)
+            *ok = dmrLog.parseOk;
+        return dmrLog.info;
+    });
+    stub.set_lamda(&dmr::utils::Time2str, [](qint64) { return QStringLiteral("00:00:00"); });
+}
+
+QString createVideoFile()
+{
+    QTemporaryFile file;
+    file.setAutoRemove(false);
+    file.open();
+    file.write("fake-video");
+    file.close();
+    return file.fileName();
+}
+
+void destroyPreview(VideoPreview *preview)
+{
+    delete preview;
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+}
+
+}   // namespace
+
+class UT_VideoPreview : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        dmrLog = DmrCallLog();
+        dmrLog.info.title = "Test Movie";
+        dmrLog.info.duration = 120;
+        dmrLog.info.width = 1920;
+        dmrLog.info.height = 1080;
+        installDmrStubs(stub);
+        preview = new VideoPreview();
+    }
+
+    virtual void TearDown() override
+    {
+        if (preview) {
+            destroyPreview(preview);
+            preview = nullptr;
+        }
+        stub.clear();
+    }
+
+protected:
+    VideoPreview *preview { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VideoPreview, Construct_CreatesPlayerAndStatusBarWidgets)
+{
+    EXPECT_NE(preview->contentWidget(), nullptr);
+    EXPECT_NE(preview->statusBarWidget(), nullptr);
+    EXPECT_NE(preview->playerWidget, nullptr);
+    EXPECT_NE(preview->playerWidget->titleBar, nullptr);
+    EXPECT_EQ(preview->playerWidget->minimumSize(), QSize(800, 355));
+    EXPECT_EQ(dmrLog.lastBackendProperty, QStringLiteral("keep-open"));
+}
+
+TEST_F(UT_VideoPreview, Destruct_CleansUpWithoutCrash)
+{
+    QPointer<VideoWidget> player = preview->playerWidget;
+    QPointer<VideoStatusBar> status = preview->statusBar;
+    EXPECT_NO_FATAL_FAILURE(destroyPreview(preview));
+    preview = nullptr;
+    EXPECT_TRUE(player.isNull());
+    EXPECT_TRUE(status.isNull());
+}
+
+TEST_F(UT_VideoPreview, SetFileUrl_RemoteUrl_ReturnsFalse)
+{
+    const QUrl url("http://example.com/video.mp4");
+    EXPECT_FALSE(preview->setFileUrl(url));
+    EXPECT_FALSE(preview->fileUrl().isValid());
+}
+
+TEST_F(UT_VideoPreview, SetFileUrl_NonExistentFile_ReturnsFalse)
+{
+    const QUrl url = QUrl::fromLocalFile("/nonexistent/path/video.mp4");
+    EXPECT_FALSE(preview->setFileUrl(url));
+    EXPECT_NE(preview->fileUrl(), url);
+}
+
+TEST_F(UT_VideoPreview, SetFileUrl_UnplayableFile_ReturnsFalse)
+{
+    dmrLog.playable = false;
+    const QString path = createVideoFile();
+    const QUrl url = QUrl::fromLocalFile(path);
+    EXPECT_FALSE(preview->setFileUrl(url));
+    QFile::remove(path);
+}
+
+TEST_F(UT_VideoPreview, SetFileUrl_ParseFailure_ReturnsFalse)
+{
+    dmrLog.parseOk = false;
+    const QString path = createVideoFile();
+    const QUrl url = QUrl::fromLocalFile(path);
+    EXPECT_FALSE(preview->setFileUrl(url));
+    QFile::remove(path);
+}
+
+TEST_F(UT_VideoPreview, SetFileUrl_ValidVideoFile_ReturnsTrueAndAppliesInfo)
+{
+    const QString path = createVideoFile();
+    const QUrl url = QUrl::fromLocalFile(path);
+
+    EXPECT_TRUE(preview->setFileUrl(url));
+    EXPECT_EQ(preview->fileUrl(), QUrl::fromLocalFile(path));
+    EXPECT_EQ(preview->videoUrl, QUrl::fromLocalFile(path));
+    EXPECT_EQ(preview->playerWidget->titleBar->text(), QStringLiteral("Test Movie"));
+    EXPECT_EQ(preview->statusBar->slider->maximum(), 120);
+
+    QFile::remove(path);
+}
+
+TEST_F(UT_VideoPreview, FileUrl_DefaultConstruction_IsEmpty)
+{
+    EXPECT_TRUE(preview->fileUrl().isEmpty());
+    EXPECT_FALSE(preview->fileUrl().isValid());
+}
+
+TEST_F(UT_VideoPreview, ContentWidget_ReturnsPlayerWidget)
+{
+    EXPECT_EQ(preview->contentWidget(), static_cast<QWidget *>(preview->playerWidget.data()));
+}
+
+TEST_F(UT_VideoPreview, StatusBarWidget_ReturnsVideoStatusBar)
+{
+    EXPECT_EQ(preview->statusBarWidget(), static_cast<QWidget *>(preview->statusBar.data()));
+}
+
+TEST_F(UT_VideoPreview, ShowStatusBarSeparator_Always_ReturnsFalse)
+{
+    EXPECT_FALSE(preview->showStatusBarSeparator());
+}
+
+TEST_F(UT_VideoPreview, StatusBarWidgetAlignment_Always_ReturnsEmptyAlignment)
+{
+    EXPECT_EQ(preview->statusBarWidgetAlignment(), Qt::Alignment());
+}
+
+TEST_F(UT_VideoPreview, Play_WithValidUrl_PlaysFileAndStartsAutoHideTimer)
+{
+    const QString path = createVideoFile();
+    const QUrl url = QUrl::fromLocalFile(path);
+    ASSERT_TRUE(preview->setFileUrl(url));
+
+    preview->play();
+    EXPECT_EQ(preview->playerWidget->videoUrl, url);
+    EXPECT_TRUE(preview->playerWidget->titleBar->m_autoHideTimer->isActive());
+
+    QFile::remove(path);
+}
+
+TEST_F(UT_VideoPreview, Play_WithoutUrl_DoesNothing)
+{
+    preview->play();
+    EXPECT_TRUE(dmrLog.lastPlayedUrl.isEmpty());
+    EXPECT_FALSE(preview->playerWidget->titleBar->m_autoHideTimer->isActive());
+}
+
+TEST_F(UT_VideoPreview, Pause_ForwardsToEnginePauseResume)
+{
+    preview->pause();
+    EXPECT_EQ(dmrLog.pauseResumeCalls, 1);
+}
+
+TEST_F(UT_VideoPreview, Stop_ForwardsToEngineStop)
+{
+    preview->stop();
+    EXPECT_EQ(dmrLog.stopCalls, 1);
+}
+
+TEST_F(UT_VideoPreview, SigPlayState_EmittedByPreview_IsReceivedByStatusBar)
+{
+    QSignalSpy spy(preview, &VideoPreview::sigPlayState);
+    QMetaObject::invokeMethod(preview, "sigPlayState");
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(UT_VideoPreview, ElapsedChanged_EmittedByPreview_IsReceivedByStatusBar)
+{
+    QSignalSpy spy(preview, &VideoPreview::elapsedChanged);
+    QMetaObject::invokeMethod(preview, "elapsedChanged");
+    EXPECT_EQ(spy.count(), 1);
+}
+
+class UT_VideoPreviewPlugin : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        dmrLog = DmrCallLog();
+        installDmrStubs(stub);
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VideoPreviewPlugin, Create_AnyKey_ReturnsVideoPreviewInstance)
+{
+    VideoPreviewPlugin plugin;
+    AbstractBasePreview *preview = plugin.create("video");
+    EXPECT_NE(preview, nullptr);
+    EXPECT_NE(dynamic_cast<VideoPreview *>(preview), nullptr);
+    destroyPreview(static_cast<VideoPreview *>(preview));
+}
+
+TEST_F(UT_VideoPreviewPlugin, Create_EmptyKey_ReturnsVideoPreviewInstance)
+{
+    VideoPreviewPlugin plugin;
+    AbstractBasePreview *preview = plugin.create("");
+    EXPECT_NE(preview, nullptr);
+    destroyPreview(static_cast<VideoPreview *>(preview));
+}

--- a/autotests/apps/dde-file-manager-preview/video-preview/test_videowidget.cpp
+++ b/autotests/apps/dde-file-manager-preview/video-preview/test_videowidget.cpp
@@ -1,0 +1,495 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "videopreview.h"
+#include "videowidget.h"
+#include "videostatusbar.h"
+#include "titlebarwidget.h"
+
+#include "stubext.h"
+
+#include <gtest/gtest.h>
+
+#include <QApplication>
+#include <QSignalSpy>
+#include <QTest>
+#include <QTemporaryFile>
+#include <QMetaObject>
+#include <QMouseEvent>
+#include <QShowEvent>
+#include <QResizeEvent>
+#include <QEnterEvent>
+#include <QTimer>
+#include <QPropertyAnimation>
+#include <DIconButton>
+#include <DSlider>
+#include <DGuiApplicationHelper>
+
+using namespace plugin_filepreview;
+
+namespace {
+
+dmr::PlayerEngine *fakeEngine()
+{
+    static QObject obj;
+    return reinterpret_cast<dmr::PlayerEngine *>(&obj);
+}
+
+struct DmrCallLog
+{
+    int enginePlayCalls { 0 };
+    int pauseResumeCalls { 0 };
+    int stopCalls { 0 };
+    bool playable { true };
+    bool parseOk { true };
+    dmr::MovieInfo info;
+    qint64 elapsedValue { 0 };
+    dmr::PlayerEngine::CoreState engineState { dmr::PlayerEngine::Playing };
+    QUrl lastPlayedUrl;
+    int lastSeekPos { -1 };
+    QString lastBackendProperty;
+};
+
+DmrCallLog dmrLog;
+
+struct PlayerWidgetCtorStub
+{
+    PlayerWidgetCtorStub()
+    {
+        auto self = reinterpret_cast<dmr::PlayerWidget *>(this);
+        new (self) QWidget(nullptr);
+        self->_engine = nullptr;
+    }
+};
+
+void installDmrStubs(stub_ext::StubExt &stub)
+{
+    stub.set(stub_ext::StubExt::get_ctor_addr<dmr::PlayerWidget>(),
+             stub_ext::StubExt::get_ctor_addr<PlayerWidgetCtorStub>());
+
+    stub.set_lamda(&dmr::PlayerWidget::engine,
+                   [](dmr::PlayerWidget *) -> dmr::PlayerEngine & { return *fakeEngine(); });
+    stub.set_lamda(&dmr::PlayerWidget::play,
+                   [](dmr::PlayerWidget *, const QUrl &url) { dmrLog.lastPlayedUrl = url; });
+    stub.set_lamda(&dmr::PlayerEngine::play, []() { ++dmrLog.enginePlayCalls; });
+    stub.set_lamda(&dmr::PlayerEngine::pauseResume, []() { ++dmrLog.pauseResumeCalls; });
+    stub.set_lamda(&dmr::PlayerEngine::stop, []() { ++dmrLog.stopCalls; });
+    stub.set_lamda(&dmr::PlayerEngine::seekAbsolute, [](dmr::PlayerEngine *, int pos) { dmrLog.lastSeekPos = pos; });
+    stub.set_lamda(&dmr::PlayerEngine::elapsed, []() { return dmrLog.elapsedValue; });
+    stub.set_lamda(&dmr::PlayerEngine::state, []() { return dmrLog.engineState; });
+    stub.set_lamda(&dmr::PlayerEngine::setBackendProperty,
+                   [](dmr::PlayerEngine *, const QString &name, const QVariant &) { dmrLog.lastBackendProperty = name; });
+    stub.set_lamda(static_cast<bool (dmr::PlayerEngine::*)(const QUrl &)>(&dmr::PlayerEngine::isPlayableFile),
+                   [](dmr::PlayerEngine *, const QUrl &) { return dmrLog.playable; });
+    stub.set_lamda(&dmr::MovieInfo::parseFromFile, [](const QFileInfo &, bool *ok) {
+        if (ok)
+            *ok = dmrLog.parseOk;
+        return dmrLog.info;
+    });
+    stub.set_lamda(&dmr::utils::Time2str, [](qint64) { return QStringLiteral("00:00:00"); });
+}
+
+}   // namespace
+
+class UT_VideoWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        dmrLog = DmrCallLog();
+        dmrLog.info.title = "Test Movie";
+        dmrLog.info.duration = 120;
+        dmrLog.info.width = 1920;
+        dmrLog.info.height = 1080;
+        installDmrStubs(stub);
+        preview = new VideoPreview();
+        preview->info.width = 1920;
+        preview->info.height = 1080;
+        preview->info.duration = 120;
+        widget = preview->playerWidget.data();
+    }
+
+    virtual void TearDown() override
+    {
+        if (preview) {
+            delete preview;
+            QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+            preview = nullptr;
+            widget = nullptr;
+        }
+        stub.clear();
+    }
+
+protected:
+    VideoPreview *preview { nullptr };
+    VideoWidget *widget { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VideoWidget, Construct_InitializesMembers)
+{
+    EXPECT_EQ(widget->p, preview);
+    EXPECT_NE(widget->titleBar, nullptr);
+    EXPECT_FALSE(widget->isVisible());
+    EXPECT_TRUE(widget->videoUrl.isEmpty());
+}
+
+TEST_F(UT_VideoWidget, SizeHint_WithoutWindowHandle_UsesPrimaryScreenHalf)
+{
+    const QSize screen = QGuiApplication::primaryScreen()->availableSize();
+    const QSize expected = QSize(preview->info.width, preview->info.height)
+                                   .scaled(qMin(preview->info.width, int(screen.width() * 0.5)),
+                                           qMin(preview->info.height, int(screen.height() * 0.5)),
+                                           Qt::KeepAspectRatio);
+    EXPECT_EQ(widget->sizeHint(), expected);
+    EXPECT_FALSE(widget->sizeHint().isEmpty());
+}
+
+TEST_F(UT_VideoWidget, SizeHint_WithWindowHandle_ScalesWithoutCrash)
+{
+    widget->show();
+    EXPECT_NE(widget->window()->windowHandle(), nullptr);
+    EXPECT_NO_FATAL_FAILURE(widget->sizeHint());
+    EXPECT_FALSE(widget->sizeHint().isEmpty());
+}
+
+TEST_F(UT_VideoWidget, PlayFile_NotVisible_StoresUrlOnly)
+{
+    const QUrl url = QUrl::fromLocalFile("/tmp/video.mp4");
+    widget->playFile(url);
+    EXPECT_EQ(widget->videoUrl, url);
+    EXPECT_TRUE(dmrLog.lastPlayedUrl.isEmpty());
+}
+
+TEST_F(UT_VideoWidget, PlayFile_VisibleWithEmptyUrl_DoesNotPlay)
+{
+    widget->show();
+    widget->playFile(QUrl());
+    EXPECT_TRUE(widget->videoUrl.isEmpty());
+    EXPECT_TRUE(dmrLog.lastPlayedUrl.isEmpty());
+}
+
+TEST_F(UT_VideoWidget, PlayFile_Visible_PlaysImmediately)
+{
+    widget->show();
+    const QUrl url = QUrl::fromLocalFile("/tmp/video.mp4");
+    widget->playFile(url);
+    EXPECT_EQ(dmrLog.lastPlayedUrl, url);
+}
+
+TEST_F(UT_VideoWidget, ShowEvent_WithUrlSet_PlaysVideo)
+{
+    const QUrl url = QUrl::fromLocalFile("/tmp/video.mp4");
+    widget->playFile(url);
+    ASSERT_TRUE(dmrLog.lastPlayedUrl.isEmpty());
+
+    QShowEvent event;
+    QApplication::sendEvent(widget, &event);
+    EXPECT_EQ(dmrLog.lastPlayedUrl, url);
+}
+
+TEST_F(UT_VideoWidget, ShowEvent_WithoutUrl_SkipsPlayback)
+{
+    QShowEvent event;
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(widget, &event));
+    EXPECT_TRUE(dmrLog.lastPlayedUrl.isEmpty());
+}
+
+TEST_F(UT_VideoWidget, MouseReleaseEvent_ForwardsToPreviewPause)
+{
+    QMouseEvent event(QEvent::MouseButtonRelease, QPointF(10, 10), QPointF(10, 10),
+                      Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(widget, &event));
+    EXPECT_EQ(dmrLog.pauseResumeCalls, 1);
+}
+
+TEST_F(UT_VideoWidget, EnterEvent_StopsTimerAndShowsTitleBarAnimated)
+{
+    widget->titleBar->startAutoHideTimer();
+    ASSERT_TRUE(widget->titleBar->m_autoHideTimer->isActive());
+
+    QEnterEvent event(QPointF(10, 10), QPointF(10, 10), QPointF(10, 10));
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(widget, &event));
+
+    EXPECT_FALSE(widget->titleBar->m_autoHideTimer->isActive());
+    EXPECT_FALSE(widget->titleBar->isHidden());
+    EXPECT_EQ(widget->titleBar->m_fadeAnimation->state(), QAbstractAnimation::Running);
+    EXPECT_EQ(widget->titleBar->m_fadeAnimation->endValue().toReal(), 1.0);
+}
+
+TEST_F(UT_VideoWidget, LeaveEvent_StartsHideAnimation)
+{
+    QEvent event(QEvent::Leave);
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(widget, &event));
+
+    EXPECT_EQ(widget->titleBar->m_fadeAnimation->state(), QAbstractAnimation::Running);
+    EXPECT_EQ(widget->titleBar->m_fadeAnimation->endValue().toReal(), 0.0);
+}
+
+TEST_F(UT_VideoWidget, ResizeEvent_RepositionsTitleBar)
+{
+    widget->resize(1000, 500);
+    EXPECT_EQ(widget->size(), QSize(1000, 500));
+
+    QResizeEvent event(widget->size(), QSize(800, 400));
+    EXPECT_NO_FATAL_FAILURE(QApplication::sendEvent(widget, &event));
+    EXPECT_EQ(widget->titleBar->geometry(), QRect(0, 0, 1000, 40));
+    EXPECT_EQ(widget->titleBar->height(), 40);
+}
+
+class UT_VideoStatusBar : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        dmrLog = DmrCallLog();
+        installDmrStubs(stub);
+        preview = new VideoPreview();
+        bar = preview->statusBar.data();
+    }
+
+    virtual void TearDown() override
+    {
+        if (preview) {
+            delete preview;
+            QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+            preview = nullptr;
+            bar = nullptr;
+        }
+        stub.clear();
+    }
+
+protected:
+    VideoPreview *preview { nullptr };
+    VideoStatusBar *bar { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_VideoStatusBar, Construct_InitializesDefaults)
+{
+    EXPECT_EQ(bar->p, preview);
+    EXPECT_FALSE(bar->sliderIsPressed);
+    EXPECT_EQ(bar->slider->minimum(), 0);
+    EXPECT_NE(bar->timeLabel, nullptr);
+    ASSERT_NE(bar->controlButton, nullptr);
+    EXPECT_EQ(bar->controlButton->objectName(), QStringLiteral("ControlButton"));
+    EXPECT_FALSE(bar->controlButtonHovered);
+    EXPECT_TRUE(bar->controlButtonShowsPause);
+}
+
+TEST_F(UT_VideoStatusBar, EventFilter_Enter_SetsHoveredFlag)
+{
+    QEvent event(QEvent::Enter);
+    EXPECT_FALSE(bar->eventFilter(bar->controlButton, &event));
+    EXPECT_TRUE(bar->controlButtonHovered);
+}
+
+TEST_F(UT_VideoStatusBar, EventFilter_Leave_ClearsHoveredFlag)
+{
+    bar->controlButtonHovered = true;
+    QEvent event(QEvent::Leave);
+    EXPECT_FALSE(bar->eventFilter(bar->controlButton, &event));
+    EXPECT_FALSE(bar->controlButtonHovered);
+}
+
+TEST_F(UT_VideoStatusBar, EventFilter_StyleAndDisplayChanges_RefreshIconWithoutCrash)
+{
+    const QList<QEvent::Type> types { QEvent::StyleChange, QEvent::PaletteChange,
+                                      QEvent::ApplicationPaletteChange, QEvent::ScreenChangeInternal,
+                                      QEvent::DevicePixelRatioChange };
+    for (const QEvent::Type type : types) {
+        QEvent event(type);
+        EXPECT_NO_FATAL_FAILURE(bar->eventFilter(bar->controlButton, &event));
+    }
+}
+
+TEST_F(UT_VideoStatusBar, EventFilter_UnrelatedEvent_Ignored)
+{
+    QEvent event(QEvent::MouseButtonRelease);
+    EXPECT_FALSE(bar->eventFilter(bar->controlButton, &event));
+    EXPECT_FALSE(bar->controlButtonHovered);
+}
+
+TEST_F(UT_VideoStatusBar, EventFilter_OtherWatchedObject_Ignored)
+{
+    QEvent event(QEvent::Enter);
+    EXPECT_FALSE(bar->eventFilter(bar->slider, &event));
+    EXPECT_FALSE(bar->controlButtonHovered);
+}
+
+TEST_F(UT_VideoStatusBar, SliderPressedAndReleased_TogglesPressedFlag)
+{
+    QMetaObject::invokeMethod(bar->slider, "sliderPressed");
+    EXPECT_TRUE(bar->sliderIsPressed);
+
+    QMetaObject::invokeMethod(bar->slider, "sliderReleased");
+    EXPECT_FALSE(bar->sliderIsPressed);
+}
+
+TEST_F(UT_VideoStatusBar, SliderValueChanged_SeeksEngineAbsolutely)
+{
+    bar->slider->setValue(30);
+    EXPECT_EQ(dmrLog.lastSeekPos, 30);
+}
+
+TEST_F(UT_VideoStatusBar, ElapsedChanged_NotPressed_UpdatesSliderAndLabel)
+{
+    dmrLog.elapsedValue = 61;
+    QMetaObject::invokeMethod(preview, "elapsedChanged");
+    EXPECT_EQ(bar->slider->value(), 61);
+    EXPECT_EQ(bar->timeLabel->text(), QStringLiteral("00:00:00"));
+}
+
+TEST_F(UT_VideoStatusBar, ElapsedChanged_Pressed_KeepsSliderButUpdatesLabel)
+{
+    bar->slider->setValue(5);
+    QMetaObject::invokeMethod(bar->slider, "sliderPressed");
+    ASSERT_TRUE(bar->sliderIsPressed);
+
+    dmrLog.elapsedValue = 99;
+    QMetaObject::invokeMethod(preview, "elapsedChanged");
+    EXPECT_NE(bar->slider->value(), 99);
+    EXPECT_EQ(bar->slider->value(), 5);
+    EXPECT_EQ(bar->timeLabel->text(), QStringLiteral("00:00:00"));
+}
+
+TEST_F(UT_VideoStatusBar, ControlButtonClicked_PausesThenPlaysEngine)
+{
+    auto *button = bar->findChild<DTK_WIDGET_NAMESPACE::DIconButton *>("ControlButton");
+    ASSERT_NE(button, nullptr);
+    button->click();
+    EXPECT_EQ(dmrLog.pauseResumeCalls, 1);
+    EXPECT_EQ(dmrLog.enginePlayCalls, 1);
+}
+
+TEST_F(UT_VideoStatusBar, SigPlayState_PlayingState_ShowsPauseButton)
+{
+    dmrLog.engineState = dmr::PlayerEngine::Playing;
+    QMetaObject::invokeMethod(preview, "sigPlayState");
+    EXPECT_TRUE(bar->controlButtonShowsPause);
+}
+
+TEST_F(UT_VideoStatusBar, SigPlayState_IdleState_ShowsStartButton)
+{
+    dmrLog.engineState = dmr::PlayerEngine::Idle;
+    QMetaObject::invokeMethod(preview, "sigPlayState");
+    EXPECT_FALSE(bar->controlButtonShowsPause);
+}
+
+TEST_F(UT_VideoStatusBar, ThemeTypeChanged_RefreshesControlButtonIcon)
+{
+    using ColorType = DTK_GUI_NAMESPACE::DGuiApplicationHelper::ColorType;
+    auto *helper = DTK_GUI_NAMESPACE::DGuiApplicationHelper::instance();
+    EXPECT_TRUE(QMetaObject::invokeMethod(helper, "themeTypeChanged", Q_ARG(ColorType, DTK_GUI_NAMESPACE::DGuiApplicationHelper::LightType)));
+    EXPECT_NO_FATAL_FAILURE(bar->updateControlButtonIcon());
+}
+
+class UT_TitleBarWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        bar = new TitleBarWidget();
+    }
+
+    virtual void TearDown() override
+    {
+        delete bar;
+        bar = nullptr;
+    }
+
+protected:
+    TitleBarWidget *bar { nullptr };
+};
+
+TEST_F(UT_TitleBarWidget, Construct_DefaultState)
+{
+    EXPECT_EQ(bar->text(), QString());
+    EXPECT_EQ(bar->opacity(), 1.0);
+    EXPECT_FALSE(bar->isVisible());
+    EXPECT_EQ(bar->height(), 40);
+    EXPECT_TRUE(bar->hasMouseTracking());
+    EXPECT_NE(bar->m_autoHideTimer, nullptr);
+    EXPECT_NE(bar->m_fadeAnimation, nullptr);
+    EXPECT_FALSE(bar->m_autoHideTimer->isActive());
+}
+
+TEST_F(UT_TitleBarWidget, SetText_NewText_UpdatesStoredText)
+{
+    bar->setText("Deepin Movie");
+    EXPECT_EQ(bar->text(), QStringLiteral("Deepin Movie"));
+
+    EXPECT_NO_FATAL_FAILURE(bar->setText("Deepin Movie"));
+}
+
+TEST_F(UT_TitleBarWidget, StartAutoHideTimer_ActivatesSingleShotTimer)
+{
+    bar->startAutoHideTimer();
+    EXPECT_TRUE(bar->m_autoHideTimer->isActive());
+    EXPECT_TRUE(bar->m_autoHideTimer->isSingleShot());
+}
+
+TEST_F(UT_TitleBarWidget, StopAutoHideTimer_DeactivatesTimer)
+{
+    bar->startAutoHideTimer();
+    bar->stopAutoHideTimer();
+    EXPECT_FALSE(bar->m_autoHideTimer->isActive());
+
+    EXPECT_NO_FATAL_FAILURE(bar->stopAutoHideTimer());
+}
+
+TEST_F(UT_TitleBarWidget, AutoHideTimeout_HidesTitleBarViaAnimation)
+{
+    bar->show();
+    bar->startAutoHideTimer();
+    QTRY_COMPARE_WITH_TIMEOUT(bar->opacity(), 0.0, 10000);
+}
+
+TEST_F(UT_TitleBarWidget, ShowAnimated_FadesInToFullOpacity)
+{
+    bar->setOpacity(0.2);
+    bar->showAnimated();
+    EXPECT_TRUE(bar->isVisible());
+    EXPECT_EQ(bar->m_fadeAnimation->state(), QAbstractAnimation::Running);
+    QTRY_COMPARE_WITH_TIMEOUT(bar->opacity(), 1.0, 5000);
+}
+
+TEST_F(UT_TitleBarWidget, HideAnimated_FadesOutToTransparent)
+{
+    bar->show();
+    bar->hideAnimated();
+    EXPECT_EQ(bar->m_fadeAnimation->state(), QAbstractAnimation::Running);
+    QTRY_COMPARE_WITH_TIMEOUT(bar->opacity(), 0.0, 5000);
+    // source defect: widget remains visible (only fully transparent) after hide
+    // animation, it still occupies and intercepts mouse input in the video area.
+    EXPECT_TRUE(bar->isVisible());
+}
+
+TEST_F(UT_TitleBarWidget, SetOpacity_ValueOutOfRange_ClampedToUnitInterval)
+{
+    bar->setOpacity(1.7);
+    EXPECT_EQ(bar->opacity(), 1.0);
+
+    bar->setOpacity(-0.3);
+    EXPECT_EQ(bar->opacity(), 0.0);
+
+    bar->setOpacity(0.5);
+    EXPECT_EQ(bar->opacity(), 0.5);
+}
+
+TEST_F(UT_TitleBarWidget, PaintEvent_WithAndWithoutText_RendersWithoutCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(bar->grab());
+
+    bar->setText("Sample Title");
+    const QPixmap rendered = bar->grab();
+    EXPECT_FALSE(rendered.isNull());
+}
+
+TEST_F(UT_TitleBarWidget, ResizeEvent_NewSize_AppliesWidthKeepsFixedHeight)
+{
+    bar->resize(250, 90);
+    EXPECT_EQ(bar->width(), 250);
+    EXPECT_EQ(bar->height(), 40);
+}


### PR DESCRIPTION
…iews

Add Google Test suites for 7 preview plugins with per-plugin test binaries.

为全部 7 个预览插件补充单元测试，按插件独立测试二进制重编译源码。

Log: 补充预览插件单元测试，函数覆盖率98.8%
Influence: 仅新增 autotests 测试代码与 CMake 注册，不影响现有功能。