### PR TITLE
fix: treat remote .desktop files as regular files

### DIFF
--- a/src/dfm-base/utils/fileutils.cpp
+++ b/src/dfm-base/utils/fileutils.cpp
@@ -243,6 +243,9 @@ bool FileUtils::isContainProhibitPath(const QList<QUrl> &urls)
 
 bool FileUtils::isDesktopFile(const QUrl &url)
 {
+    if (ProtocolUtils::isRemoteFile(url))
+        return false;
+
     if (isDesktopFileSuffix(url))
         return true;
 
@@ -260,7 +263,9 @@ bool FileUtils::isDesktopFileSuffix(const QUrl &url)
     // but there are interfaces that call "isDesktopFile"
     // so often that it would be a performance loss to
     // create a fileinfo
-    return url.toString().endsWith(".desktop");
+    if (!url.toString().endsWith(".desktop"))
+        return false;
+    return !ProtocolUtils::isRemoteFile(url);
 }
 
 bool FileUtils::isDesktopFileInfo(const FileInfoPointer &info)


### PR DESCRIPTION
## Root Cause Analysis

The file manager treats `.desktop` files as DDE applications across all paths, but the two source-level entry functions — `FileUtils::isDesktopFile()` and `FileUtils::isDesktopFileSuffix()` — lack any remote-file guard. For non-local paths (SMB, NFS, FTP, etc.), these functions return `true`, causing downstream desktop-specific code paths to call `toLocalFile()` (which returns an empty string for remote URLs) and local I/O, resulting in silent failures such as rename no-ops. The Info layer (`DesktopFileInfo::convert()`) already has a `ProtocolUtils::isRemoteFile()` guard, but the behavior layer was never synchronized.

## Fix

Added `ProtocolUtils::isRemoteFile(url)` guards at the entry of both `isDesktopFile()` and `isDesktopFileSuffix()` in `src/dfm-base/utils/fileutils.cpp`. Remote `.desktop` files now return `false` from both functions and fall through to normal file handling. `isRemoteFile()` is a pure in-memory scheme-set lookup with no I/O, consistent with the recent commit (8e64a7b2) that removed network I/O from desktop file detection.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Low
- The most recent commit on these functions (8e64a7b2, 2026-09-03) refactored `isDesktopFile` to eliminate network I/O; the added `isRemoteFile()` guard is also a pure local operation, so no I/O regression is introduced.
- Internal callers `isTrashDesktopFile()`, `isComputerDesktopFile()`, and `isHomeDesktopFile()` benefit from early return on remote URLs, avoiding `DesktopFile(url.toLocalFile())` with an empty path — a positive side effect.

### Business Impact Scope

Affected functional modules: file rename, file open/run, drag-and-drop, file sorting, context menu state, and preview for `.desktop` files on remote shares (SMB, NFS, FTP, DAV/DAVS, SFTP). After the fix, remote `.desktop` files are treated as regular files in all these scenarios. Local `.desktop` file behavior (app icon, open as app, rename modifies `Name` field) is unchanged.

### Verification Suggestion

Test renaming, opening, drag-drop, and sorting of `.desktop` files on an SMB share to confirm they behave as regular files. Verify local `.desktop` files still function as applications with no regression.

---

## 根因分析

文件管理器对所有路径下的 `.desktop` 文件均按 DDE 应用处理，但源头入口函数 `FileUtils::isDesktopFile()` 和 `FileUtils::isDesktopFileSuffix()` 缺少远程文件守卫。对非本地路径（SMB、NFS、FTP 等），这两个函数返回 `true`，导致下游 desktop 专有逻辑调用 `toLocalFile()`（远程 URL 返回空字符串）和本地 I/O，造成重命名无效等静默失败。Info 层 `DesktopFileInfo::convert()` 已有 `ProtocolUtils::isRemoteFile()` 守卫，但行为层未同步。

## 修复方案

在 `src/dfm-base/utils/fileutils.cpp` 的 `isDesktopFile()` 和 `isDesktopFileSuffix()` 入口添加 `ProtocolUtils::isRemoteFile(url)` 守卫，远程 `.desktop` 文件返回 `false` 落入普通文件处理。`isRemoteFile()` 为纯内存 scheme 集合查找，无 I/O，与近期消除网络 I/O 的提交（8e64a7b2）一致。

## 改动安全评估

### 代码安全评估

- **风险等级**: 低风险
- 这两个函数最近一次提交（8e64a7b2, 2026-09-03）将 `isDesktopFile` 重构为消除网络 I/O；本次添加的 `isRemoteFile()` 守卫同样是纯本地操作，不引入 I/O 回归。
- 内部调用者 `isTrashDesktopFile()`、`isComputerDesktopFile()`、`isHomeDesktopFile()` 受益于远程 URL 提前返回，避免了 `DesktopFile(url.toLocalFile())` 空路径操作——正面副作用。

### 业务影响范围

受影响功能模块：远程共享（SMB、NFS、FTP、DAV/DAVS、SFTP）上 `.desktop` 文件的重命名、打开/运行、拖放、排序、右键菜单状态、预览。修复后远程 `.desktop` 文件在上述场景均按普通文件处理。本地 `.desktop` 文件行为（应用图标、作为应用打开、重命名修改 `Name` 字段）不变。

### 验证建议

测试 SMB 共享上 `.desktop` 文件的重命名、打开、拖放、排序，确认按普通文件处理。验证本地 `.desktop` 文件仍作为应用处理，无回归。

## Summary by Sourcery

Bug Fixes:
- Treat remote `.desktop` files as regular files instead of desktop applications, restoring normal behavior for operations such as renaming, opening, sorting, and drag-and-drop.