### PR TITLE
chore: add hook-event registry, UT timeout and build ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Makefile.*
 debug
 release
 build
+build-autotests/
 
 *.pro.user
 *.pro.user*

--- a/autotests/dfm_hookreg.h
+++ b/autotests/dfm_hookreg.h
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Auto-generated helper: registers ALL hook event types used by every
+// plugin followEvents() call. Normally these are registered at static-init
+// by the *owning* plugins DPF_EVENT_REG_HOOK members, but those plugin libs
+// are not linked into per-plugin test binaries. Calling this before running
+// a real followEvents()/bindEvents() lets the subscribe templates execute.
+#pragma once
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+namespace dfmtest_hooks {
+inline void registerAllHookEvents(dpf::Event *evt = dpf::Event::instance()) {
+    using S = dpf::EventStratege;
+    evt->registerEventType(S::kHook, "ddplugin_canvas", "hook_CanvasItemDelegate_LayoutText");
+    evt->registerEventType(S::kHook, "ddplugin_canvas", "hook_CanvasView_DragMove");
+    evt->registerEventType(S::kHook, "ddplugin_canvas", "hook_CanvasView_DropData");
+    evt->registerEventType(S::kHook, "ddplugin_core", "hook_ScreenProxy_ScreensInUse");
+    evt->registerEventType(S::kHook, "ddplugin_organizer", "hook_CollectionView_DragMove");
+    evt->registerEventType(S::kHook, "ddplugin_organizer", "hook_CollectionView_DropData");
+    evt->registerEventType(S::kHook, "dfmplugin_computer", "hook_Device_AcquireDevPwd");
+    evt->registerEventType(S::kHook, "dfmplugin_detailspace", "hook_Icon_Fetch");
+    evt->registerEventType(S::kHook, "dfmplugin_emblem", "hook_ExtendEmblems_Fetch");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_OpenLocalFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CopyFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CopyFromFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CutFromFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CutToFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_DeleteFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_MakeDir");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_MoveToTrash");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_OpenInTerminal");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_RenameFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_RenameFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_RenameFilesAddText");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_SetPermission");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_TouchCustomFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_TouchFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_WriteUrlsToClipboard");
+    evt->registerEventType(S::kHook, "dfmplugin_propertydialog", "hook_PermissionView_Ash");
+    evt->registerEventType(S::kHook, "dfmplugin_propertydialog", "hook_PropertyDialog_Disable");
+    evt->registerEventType(S::kHook, "dfmplugin_search", "hook_Url_IsSubFile");
+    evt->registerEventType(S::kHook, "dfmplugin_sidebar", "hook_Group_Sort");
+    evt->registerEventType(S::kHook, "dfmplugin_sidebar", "hook_Item_DragMoveData");
+    evt->registerEventType(S::kHook, "dfmplugin_sidebar", "hook_Item_DropData");
+    evt->registerEventType(S::kHook, "dfmplugin_tag", "hook_CanTaged");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Copy_Addr");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Crumb_RedirectUrl");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Crumb_Seprate");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Show_Addr");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_Closeable");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_EnterDir");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_FileDeleteNotCdComputer");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_SetTabName");
+    evt->registerEventType(S::kHook, "dfmplugin_utils", "hook_AppendCompress_Prohibit");
+    evt->registerEventType(S::kHook, "dfmplugin_utils", "hook_OpenWith_DisabledOpenWithWidget");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Allow_Repeat_Url");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Delegate_CheckTransparent");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Delegate_LayoutText");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Delegate_PaintListItem");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_FileCanMove");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_FileDragMove");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_FileDrop");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_IsDrop");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Model_FetchCustomRoleDisplayName");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_SendChangeCurrentUrl");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_SendOpenWindow");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_CopyFilePath");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_CopyFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_CutFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_DeleteFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_EnterPressed");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_MoveToTrash");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_PasteFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_PreViewFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Url_FetchPathtoVirtual");
+}
+} // namespace dfmtest_hooks

--- a/autotests/run-ut.sh
+++ b/autotests/run-ut.sh
@@ -103,15 +103,23 @@ echo ""
 # Run each test binary with gtest XML output
 # Temporarily disable 'set -e' so a failing test binary doesn't abort the script;
 # we track failures via any_failed and report them at the end.
+# Each binary is capped at 10 minutes so a hung test can never block the
+# remaining ones; the run always produces a complete result set.
+UT_TIMEOUT_SEC=600
 any_failed=0
 set +e
 for bin in "${test_bins[@]}"; do
     name=$(basename "$bin")
-    echo "---- Running ${name} ----"
-    if "$bin" --gtest_output="xml:${GTEST_RESULTS_DIR}/${name}.xml"; then
+    echo "---- Running ${name} (timeout ${UT_TIMEOUT_SEC}s) ----"
+    if timeout "${UT_TIMEOUT_SEC}" "$bin" --gtest_output="xml:${GTEST_RESULTS_DIR}/${name}.xml"; then
         echo "  ${name}: PASSED"
     else
-        echo "  ${name}: FAILED"
+        rc=$?
+        if [ "$rc" -eq 124 ]; then
+            echo "  ${name}: FAILED (timeout after ${UT_TIMEOUT_SEC}s)"
+        else
+            echo "  ${name}: FAILED (exit ${rc})"
+        fi
         any_failed=1
     fi
 done


### PR DESCRIPTION
## Summary
Add UT infrastructure: dfm_hookreg.h helper for plugin hook-event registration in tests, per-binary timeout support in run-ut.sh, and gitignore entry for the autotest build dir.

新增单测基础设施：dfm_hookreg.h 插件 hook 事件注册辅助头、run-ut.sh 增加单测超时控制、.gitignore 忽略 autotest 构建目录。

## Test
- Full build & run via `autotests/run-ut.sh` (Debug + OPT_ENABLE_BUILD_UT=ON): all 41 test binaries pass.
- Note: new plugin test binaries take effect with the registration commit (ut-10-register-tools PR); this keeps every intermediate PR build-safe.

Log: 新增/扩充 dde-file-manager 单元测试
Influence: 仅新增/调整测试代码，不影响功能。

## Summary by Sourcery

Improve unit-test infrastructure with hook-event registration support, execution timeouts, and build-artifact cleanup.

New Features:
- Add a shared test helper for registering plugin hook events in isolated unit-test binaries.

Enhancements:
- Add per-test-binary timeouts and clearer failure reporting to the unit-test runner.

Tests:
- Extend unit-test infrastructure to support hook-event subscription tests.

Chores:
- Ignore the autotest build directory in Git.