### PR TITLE
chore: add hook-event registry, UT timeout and build ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Makefile.*
 debug
 release
 build
+build-autotests/
 
 *.pro.user
 *.pro.user*

--- a/autotests/dfm_hookreg.h
+++ b/autotests/dfm_hookreg.h
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Auto-generated helper: registers ALL hook event types used by every
+// plugin followEvents() call. Normally these are registered at static-init
+// by the *owning* plugins DPF_EVENT_REG_HOOK members, but those plugin libs
+// are not linked into per-plugin test binaries. Calling this before running
+// a real followEvents()/bindEvents() lets the subscribe templates execute.
+#pragma once
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+
+namespace dfmtest_hooks {
+inline void registerAllHookEvents(dpf::Event *evt = dpf::Event::instance()) {
+    using S = dpf::EventStratege;
+    evt->registerEventType(S::kHook, "ddplugin_canvas", "hook_CanvasItemDelegate_LayoutText");
+    evt->registerEventType(S::kHook, "ddplugin_canvas", "hook_CanvasView_DragMove");
+    evt->registerEventType(S::kHook, "ddplugin_canvas", "hook_CanvasView_DropData");
+    evt->registerEventType(S::kHook, "ddplugin_core", "hook_ScreenProxy_ScreensInUse");
+    evt->registerEventType(S::kHook, "ddplugin_organizer", "hook_CollectionView_DragMove");
+    evt->registerEventType(S::kHook, "ddplugin_organizer", "hook_CollectionView_DropData");
+    evt->registerEventType(S::kHook, "dfmplugin_computer", "hook_Device_AcquireDevPwd");
+    evt->registerEventType(S::kHook, "dfmplugin_detailspace", "hook_Icon_Fetch");
+    evt->registerEventType(S::kHook, "dfmplugin_emblem", "hook_ExtendEmblems_Fetch");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_OpenLocalFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CopyFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CopyFromFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CutFromFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CutToFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_DeleteFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_MakeDir");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_MoveToTrash");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_OpenInTerminal");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_RenameFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_RenameFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_RenameFilesAddText");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_SetPermission");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_TouchCustomFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_TouchFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_WriteUrlsToClipboard");
+    evt->registerEventType(S::kHook, "dfmplugin_propertydialog", "hook_PermissionView_Ash");
+    evt->registerEventType(S::kHook, "dfmplugin_propertydialog", "hook_PropertyDialog_Disable");
+    evt->registerEventType(S::kHook, "dfmplugin_search", "hook_Url_IsSubFile");
+    evt->registerEventType(S::kHook, "dfmplugin_sidebar", "hook_Group_Sort");
+    evt->registerEventType(S::kHook, "dfmplugin_sidebar", "hook_Item_DragMoveData");
+    evt->registerEventType(S::kHook, "dfmplugin_sidebar", "hook_Item_DropData");
+    evt->registerEventType(S::kHook, "dfmplugin_tag", "hook_CanTaged");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Copy_Addr");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Crumb_RedirectUrl");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Crumb_Seprate");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Show_Addr");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_Closeable");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_EnterDir");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_FileDeleteNotCdComputer");
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Tab_SetTabName");
+    evt->registerEventType(S::kHook, "dfmplugin_utils", "hook_AppendCompress_Prohibit");
+    evt->registerEventType(S::kHook, "dfmplugin_utils", "hook_OpenWith_DisabledOpenWithWidget");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Allow_Repeat_Url");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Delegate_CheckTransparent");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Delegate_LayoutText");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Delegate_PaintListItem");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_FileCanMove");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_FileDragMove");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_FileDrop");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_IsDrop");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Model_FetchCustomRoleDisplayName");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_SendChangeCurrentUrl");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_SendOpenWindow");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_CopyFilePath");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_CopyFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_CutFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_DeleteFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_EnterPressed");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_MoveToTrash");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_PasteFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_ShortCut_PreViewFiles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Url_FetchPathtoVirtual");
+}
+} // namespace dfmtest_hooks

--- a/autotests/run-ut.sh
+++ b/autotests/run-ut.sh
@@ -103,15 +103,23 @@ echo ""
 # Run each test binary with gtest XML output
 # Temporarily disable 'set -e' so a failing test binary doesn't abort the script;
 # we track failures via any_failed and report them at the end.
+# Each binary is capped at 10 minutes so a hung test can never block the
+# remaining ones; the run always produces a complete result set.
+UT_TIMEOUT_SEC=600
 any_failed=0
 set +e
 for bin in "${test_bins[@]}"; do
     name=$(basename "$bin")
-    echo "---- Running ${name} ----"
-    if "$bin" --gtest_output="xml:${GTEST_RESULTS_DIR}/${name}.xml"; then
+    echo "---- Running ${name} (timeout ${UT_TIMEOUT_SEC}s) ----"
+    if timeout "${UT_TIMEOUT_SEC}" "$bin" --gtest_output="xml:${GTEST_RESULTS_DIR}/${name}.xml"; then
         echo "  ${name}: PASSED"
     else
-        echo "  ${name}: FAILED"
+        rc=$?
+        if [ "$rc" -eq 124 ]; then
+            echo "  ${name}: FAILED (timeout after ${UT_TIMEOUT_SEC}s)"
+        else
+            echo "  ${name}: FAILED (exit ${rc})"
+        fi
         any_failed=1
     fi
 done


### PR DESCRIPTION
Add dfm_hookreg.h to register all hook event types needed by per-plugin
test binaries, cap each UT binary at 10 minutes in run-ut.sh so a hung
test cannot block the remaining ones, and add build-autotests/ to
.gitignore.

新增 dfm_hookreg.h 为各插件测试二进制注册全部钩子事件类型；
run-ut.sh 为每个测试二进制增加 10 分钟超时，避免挂起测试阻塞
整体执行；.gitignore 增加 build-autotests/ 目录。

Log: 完善单测基础设施（钩子注册、超时、忽略构建目录）
Influence: 仅影响单测执行，不影响产品功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Improve unit-test infrastructure with hook-event registration, per-binary timeouts, and build-directory cleanup.

New Features:
- Add a shared helper for registering hook event types required by plugin unit-test binaries.

Enhancements:
- Ensure each unit-test binary is isolated by a ten-minute execution limit so hung tests do not block the suite.

Build:
- Ignore the autotest build output directory in version control.

Tests:
- Improve unit-test execution reporting by distinguishing timeout failures from regular test failures and continuing through the full test set.