### PR TITLE
test: extend optical share proxy tests in dfm-base

### DIFF
--- a/autotests/libs/dfm-base/test_opticalshareproxy.cpp
+++ b/autotests/libs/dfm-base/test_opticalshareproxy.cpp
@@ -14,11 +14,14 @@
  */
 
 #include <gtest/gtest.h>
+#include <stub-ext/stubext.h>
 #include <dfm-base/dbusservice/opticalshareproxy.h>
 
 #include <QVariantMap>
 #include <QMetaObject>
 #include <QObject>
+#include <QDBusConnection>
+#include <QDBusMessage>
 
 using namespace dfmbase;
 
@@ -38,6 +41,20 @@ TEST(OpticalShareProxyTest, BurnStateReturnsEmptyWhenServiceUnavailable)
 
 TEST(OpticalShareProxyTest, BurnStatesReturnsEmptyWhenServiceUnavailable)
 {
+    // burnStates() returns whatever the service reports for ALL devices, so
+    // when a real optical-share DBus service happens to run in the test
+    // environment the result is not empty.  Force the "service unavailable"
+    // path instead: QDBusConnection::call (non-virtual) returns a default
+    // (invalid) message, the QDBusReply becomes invalid and the proxy
+    // returns an empty map.
+    stub_ext::StubExt stub;
+    using CallFn = QDBusMessage (QDBusConnection::*)(const QDBusMessage &, QDBus::CallMode, int) const;
+    stub.set_lamda(static_cast<CallFn>(&QDBusConnection::call),
+                   [](const QDBusConnection *, const QDBusMessage &, QDBus::CallMode, int) -> QDBusMessage {
+                       __DBG_STUB_INVOKE__
+                       return QDBusMessage();
+                   });
+
     auto &proxy = OpticalShareProxy::instance();
     QVariantMap result = proxy.burnStates();
     EXPECT_TRUE(result.isEmpty());


### PR DESCRIPTION
Extend test_opticalshareproxy.cpp with additional cases for the
optical share proxy behavior.

扩展 test_opticalshareproxy.cpp 用例，补充光盘共享代理行为覆盖。

Log: 扩充 dfm-base 光盘共享代理测试
Influence: 仅调整测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Strengthen optical share proxy tests by reliably validating behavior when the backing DBus service is unavailable.

Enhancements:
- Make the optical share proxy empty-state test deterministic when the DBus service is unavailable.

Tests:
- Extend optical share proxy coverage for the unavailable-service response path.