### PR TITLE
test: add event template and invoke helper tests for framework

### DIFF
--- a/autotests/libs/dfm-framework/CMakeLists.txt
+++ b/autotests/libs/dfm-framework/CMakeLists.txt
@@ -8,5 +8,5 @@ file(GLOB_RECURSE TEST_SOURCES
 
 dfm_add_test(ut-dfm-framework
     SOURCES ${TEST_SOURCES}
-    LINK_LIBRARIES DFM6::framework Qt6::Test
+    LINK_LIBRARIES DFM6::framework DFM6::base Qt6::Test Qt6::Widgets Qt6::Gui
 )

--- a/autotests/libs/dfm-framework/test_eventtemplate.cpp
+++ b/autotests/libs/dfm-framework/test_eventtemplate.cpp
@@ -1,0 +1,597 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// test_eventtemplate.cpp - Comprehensive template instantiation tests
+// Targets include/dfm-framework/event/ template headers to increase
+// coverage of ApplyReturnValue<T>, resultGenerator<T>, paramGenerator<T>,
+// EventHelper::invoke(), InvokeHelper, and EventChannel template methods
+// by exercising many type combinations.
+
+#include <gtest/gtest.h>
+
+#include <dfm-framework/event/eventchannel.h>
+#include <dfm-framework/event/event.h>
+#include <dfm-framework/event/eventhelper.h>
+#include <dfm-framework/event/invokehelper.h>
+#include <dfm-framework/event/eventsequence.h>
+#include <dfm-framework/event/eventdispatcher.h>
+
+#include <QObject>
+#include <QString>
+#include <QUrl>
+#include <QPoint>
+#include <QRect>
+#include <QRectF>
+#include <QSize>
+#include <QVariant>
+#include <QVariantList>
+#include <QList>
+#include <QMap>
+#include <QHash>
+#include <QModelIndex>
+#include <QSharedPointer>
+#include <QAbstractItemModel>
+#include <QAbstractItemView>
+#include <QItemSelectionModel>
+#include <QWidget>
+
+using namespace dpf;
+
+// ---------------------------------------------------------------------------
+// Test receivers with slots returning many different types
+// ---------------------------------------------------------------------------
+class MultiTypeReceiver : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MultiTypeReceiver(QObject *parent = nullptr) : QObject(parent) {}
+
+    // Void return
+    void voidSlot() { ++callCount; }
+    void voidSlotInt(int) { ++callCount; }
+    void voidSlotStr(const QString &) { ++callCount; }
+
+    // Basic type returns
+    bool retBool(bool v) { return v; }
+    int retInt(int v) { return v + 1; }
+    double retDouble(double v) { return v * 2.0; }
+    QString retString(const QString &s) { return s + "_ret"; }
+
+    // Qt value types
+    QPoint retPoint(int x, int y) { return QPoint(x, y); }
+    QRect retRect(int x, int y, int w, int h) { return QRect(x, y, w, h); }
+    QRectF retRectF(qreal x, qreal y, qreal w, qreal h) { return QRectF(x, y, w, h); }
+    QSize retSize(int w, int h) { return QSize(w, h); }
+    QUrl retUrl(const QString &path) { return QUrl(path); }
+    QVariant retVariant(const QVariant &v) { return v; }
+    QModelIndex retIndex() { return QModelIndex(); }
+
+    // Container returns
+    QList<QString> retStringList() { return {"a", "b", "c"}; }
+    QList<QUrl> retUrlList() { return {QUrl("file:///a"), QUrl("file:///b")}; }
+    QList<QVariant> retVariantList() { return {QVariant(1), QVariant("x")}; }
+    QList<QMap<QString, QVariant>> retMapList() { return {QMap<QString, QVariant>{{"k", "v"}}}; }
+    QMap<QString, QVariant> retMap() { return {{"key", QVariant(42)}}; }
+    QHash<QString, QVariant> retHash() { return {{"hkey", QVariant(true)}}; }
+    QList<QWidget *> retWidgetList() { return {}; }
+
+    // Pointer returns
+    QWidget *retWidgetPtr() { return nullptr; }
+    QAbstractItemModel *retModelPtr() { return nullptr; }
+    QItemSelectionModel *retSelectionPtr() { return nullptr; }
+    QObject *retObjectPtr() { return nullptr; }
+    QAbstractItemView *retItemViewPtr() { return nullptr; }
+
+    // Multi-arg slots
+    int twoArgs(int a, int b) { return a + b; }
+    int threeArgs(int a, int b, int c) { return a + b + c; }
+    int fourArgs(int a, int b, int c, int d) { return a + b + c + d; }
+    int fiveArgs(int a, int b, int c, int d, int e) { return a + b + c + d + e; }
+
+    int callCount = 0;
+};
+
+// ---------------------------------------------------------------------------
+// EventChannel template instantiation tests
+// ---------------------------------------------------------------------------
+class EventTemplateTest : public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        Event::instance();
+    }
+
+    void SetUp() override
+    {
+        receiver = new MultiTypeReceiver();
+        event = Event::instance();
+        channelMgr = event->channel();
+    }
+
+    void TearDown() override
+    {
+        for (const auto &topic : registeredTopics)
+            channelMgr->disconnect("tmpltest", topic);
+        registeredTopics.clear();
+        delete receiver;
+    }
+
+    EventType regEvent(const QString &topic)
+    {
+        event->registerEventType(EventStratege::kSlot, "tmpltest", topic);
+        EventType type = EventConverter::convert("tmpltest", topic);
+        registeredTopics.append(topic);
+        return type;
+    }
+
+    MultiTypeReceiver *receiver = nullptr;
+    Event *event = nullptr;
+    EventChannelManager *channelMgr = nullptr;
+    QStringList registeredTopics;
+};
+
+// --- Direct EventHelper invocation for many return types ---
+
+TEST_F(EventTemplateTest, EventHelper_VoidReturn_Invoke)
+{
+    using Func = void (MultiTypeReceiver::*)();
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::voidSlot);
+    QVariant ret = helper.invoke({});
+    EXPECT_TRUE(ret.isNull() || !ret.isValid());
+    EXPECT_EQ(receiver->callCount, 1);
+}
+
+TEST_F(EventTemplateTest, EventHelper_BoolReturn_Invoke)
+{
+    using Func = bool (MultiTypeReceiver::*)(bool);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retBool);
+    QVariant ret = helper.invoke({QVariant(true)});
+    EXPECT_EQ(ret.toBool(), true);
+}
+
+TEST_F(EventTemplateTest, EventHelper_IntReturn_Invoke)
+{
+    using Func = int (MultiTypeReceiver::*)(int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retInt);
+    QVariant ret = helper.invoke({QVariant(5)});
+    EXPECT_EQ(ret.toInt(), 6);
+}
+
+TEST_F(EventTemplateTest, EventHelper_DoubleReturn_Invoke)
+{
+    using Func = double (MultiTypeReceiver::*)(double);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retDouble);
+    QVariant ret = helper.invoke({QVariant(3.5)});
+    EXPECT_DOUBLE_EQ(ret.toDouble(), 7.0);
+}
+
+TEST_F(EventTemplateTest, EventHelper_StringReturn_Invoke)
+{
+    using Func = QString (MultiTypeReceiver::*)(const QString &);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retString);
+    QVariant ret = helper.invoke({QVariant("hello")});
+    EXPECT_EQ(ret.toString(), "hello_ret");
+}
+
+TEST_F(EventTemplateTest, EventHelper_PointReturn_Invoke)
+{
+    using Func = QPoint (MultiTypeReceiver::*)(int, int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retPoint);
+    QVariant ret = helper.invoke({QVariant(10), QVariant(20)});
+    EXPECT_EQ(ret.toPoint(), QPoint(10, 20));
+}
+
+TEST_F(EventTemplateTest, EventHelper_RectReturn_Invoke)
+{
+    using Func = QRect (MultiTypeReceiver::*)(int, int, int, int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retRect);
+    QVariant ret = helper.invoke({QVariant(1), QVariant(2), QVariant(3), QVariant(4)});
+    EXPECT_EQ(ret.toRect(), QRect(1, 2, 3, 4));
+}
+
+TEST_F(EventTemplateTest, EventHelper_RectFReturn_Invoke)
+{
+    using Func = QRectF (MultiTypeReceiver::*)(qreal, qreal, qreal, qreal);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retRectF);
+    QVariant ret = helper.invoke({QVariant(1.0), QVariant(2.0), QVariant(3.0), QVariant(4.0)});
+    EXPECT_EQ(ret.toRectF(), QRectF(1.0, 2.0, 3.0, 4.0));
+}
+
+TEST_F(EventTemplateTest, EventHelper_SizeReturn_Invoke)
+{
+    using Func = QSize (MultiTypeReceiver::*)(int, int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retSize);
+    QVariant ret = helper.invoke({QVariant(100), QVariant(200)});
+    EXPECT_EQ(ret.toSize(), QSize(100, 200));
+}
+
+TEST_F(EventTemplateTest, EventHelper_UrlReturn_Invoke)
+{
+    using Func = QUrl (MultiTypeReceiver::*)(const QString &);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retUrl);
+    QVariant ret = helper.invoke({QVariant("file:///test")});
+    EXPECT_EQ(ret.toUrl(), QUrl("file:///test"));
+}
+
+TEST_F(EventTemplateTest, EventHelper_VariantReturn_Invoke)
+{
+    using Func = QVariant (MultiTypeReceiver::*)(const QVariant &);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::retVariant);
+    QVariant ret = helper.invoke({QVariant(42)});
+    // EventHelper wraps a slot returning QVariant in an outer variant whose
+    // metatype is QVariant, so the result must be unwrapped one level before
+    // being read (a nested QVariant does not auto-convert to int).
+    EXPECT_EQ(ret.value<QVariant>().toInt(), 42);
+}
+
+TEST_F(EventTemplateTest, EventHelper_TwoArgs_Invoke)
+{
+    using Func = int (MultiTypeReceiver::*)(int, int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::twoArgs);
+    QVariant ret = helper.invoke({QVariant(3), QVariant(4)});
+    EXPECT_EQ(ret.toInt(), 7);
+}
+
+TEST_F(EventTemplateTest, EventHelper_ThreeArgs_Invoke)
+{
+    using Func = int (MultiTypeReceiver::*)(int, int, int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::threeArgs);
+    QVariant ret = helper.invoke({QVariant(1), QVariant(2), QVariant(3)});
+    EXPECT_EQ(ret.toInt(), 6);
+}
+
+TEST_F(EventTemplateTest, EventHelper_FourArgs_Invoke)
+{
+    using Func = int (MultiTypeReceiver::*)(int, int, int, int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::fourArgs);
+    QVariant ret = helper.invoke({QVariant(1), QVariant(2), QVariant(3), QVariant(4)});
+    EXPECT_EQ(ret.toInt(), 10);
+}
+
+TEST_F(EventTemplateTest, EventHelper_FiveArgs_Invoke)
+{
+    using Func = int (MultiTypeReceiver::*)(int, int, int, int, int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::fiveArgs);
+    QVariant ret = helper.invoke({QVariant(1), QVariant(2), QVariant(3), QVariant(4), QVariant(5)});
+    EXPECT_EQ(ret.toInt(), 15);
+}
+
+TEST_F(EventTemplateTest, EventHelper_VoidIntSlot_Invoke)
+{
+    using Func = void (MultiTypeReceiver::*)(int);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::voidSlotInt);
+    QVariant ret = helper.invoke({QVariant(42)});
+    EXPECT_EQ(receiver->callCount, 1);
+}
+
+TEST_F(EventTemplateTest, EventHelper_VoidStrSlot_Invoke)
+{
+    using Func = void (MultiTypeReceiver::*)(const QString &);
+    EventHelper<Func> helper(receiver, &MultiTypeReceiver::voidSlotStr);
+    QVariant ret = helper.invoke({QVariant("test")});
+    EXPECT_EQ(receiver->callCount, 1);
+}
+
+// --- resultGenerator and paramGenerator templates ---
+
+TEST_F(EventTemplateTest, ResultGenerator_Int)
+{
+    QVariant ret = resultGenerator<int>();
+    EXPECT_EQ(ret.typeId(), QMetaType::Int);
+}
+
+TEST_F(EventTemplateTest, ResultGenerator_Bool)
+{
+    QVariant ret = resultGenerator<bool>();
+    EXPECT_TRUE(ret.isValid());
+}
+
+TEST_F(EventTemplateTest, ResultGenerator_String)
+{
+    QVariant ret = resultGenerator<QString>();
+    EXPECT_TRUE(ret.isValid());
+}
+
+TEST_F(EventTemplateTest, ResultGenerator_Void)
+{
+    QVariant ret = resultGenerator<void>();
+    EXPECT_TRUE(ret.isNull() || !ret.isValid());
+}
+
+TEST_F(EventTemplateTest, ResultGenerator_QPoint)
+{
+    QVariant ret = resultGenerator<QPoint>();
+    EXPECT_TRUE(ret.isValid());
+}
+
+TEST_F(EventTemplateTest, ResultGenerator_QUrl)
+{
+    QVariant ret = resultGenerator<QUrl>();
+    EXPECT_TRUE(ret.isValid());
+}
+
+TEST_F(EventTemplateTest, ResultGenerator_QVariant)
+{
+    QVariant ret = resultGenerator<QVariant>();
+    EXPECT_TRUE(ret.isValid());
+}
+
+TEST_F(EventTemplateTest, ResultGenerator_Double)
+{
+    QVariant ret = resultGenerator<double>();
+    EXPECT_EQ(ret.typeId(), QMetaType::Double);
+}
+
+TEST_F(EventTemplateTest, ParamGenerator_Int)
+{
+    QVariant input(42);
+    int result = paramGenerator<int>(input);
+    EXPECT_EQ(result, 42);
+}
+
+TEST_F(EventTemplateTest, ParamGenerator_String)
+{
+    QVariant input("hello");
+    QString result = paramGenerator<QString>(input);
+    EXPECT_EQ(result, "hello");
+}
+
+TEST_F(EventTemplateTest, ParamGenerator_Bool)
+{
+    QVariant input(true);
+    bool result = paramGenerator<bool>(input);
+    EXPECT_EQ(result, true);
+}
+
+TEST_F(EventTemplateTest, ParamGenerator_Double)
+{
+    QVariant input(3.14);
+    double result = paramGenerator<double>(input);
+    EXPECT_DOUBLE_EQ(result, 3.14);
+}
+
+TEST_F(EventTemplateTest, ParamGenerator_QPoint)
+{
+    QVariant input(QPoint(5, 10));
+    QPoint result = paramGenerator<QPoint>(input);
+    EXPECT_EQ(result, QPoint(5, 10));
+}
+
+TEST_F(EventTemplateTest, ParamGenerator_QUrl)
+{
+    QVariant input(QUrl("file:///test"));
+    QUrl result = paramGenerator<QUrl>(input);
+    EXPECT_EQ(result, QUrl("file:///test"));
+}
+
+// --- EventChannel send with different types ---
+
+TEST_F(EventTemplateTest, ChannelConnectAndPush_BoolReturn)
+{
+    EventType type = regEvent("slot_BoolRet");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::retBool));
+    QVariant ret = channelMgr->push(type, QVariant(true));
+    EXPECT_EQ(ret.toBool(), true);
+}
+
+TEST_F(EventTemplateTest, ChannelConnectAndPush_IntReturn)
+{
+    EventType type = regEvent("slot_IntRet");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::retInt));
+    QVariant ret = channelMgr->push(type, QVariant(10));
+    EXPECT_EQ(ret.toInt(), 11);
+}
+
+TEST_F(EventTemplateTest, ChannelConnectAndPush_StringReturn)
+{
+    EventType type = regEvent("slot_StrRet");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::retString));
+    QVariant ret = channelMgr->push(type, QVariant("world"));
+    EXPECT_EQ(ret.toString(), "world_ret");
+}
+
+TEST_F(EventTemplateTest, ChannelConnectAndPush_DoubleReturn)
+{
+    EventType type = regEvent("slot_DblRet");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::retDouble));
+    QVariant ret = channelMgr->push(type, QVariant(2.5));
+    EXPECT_DOUBLE_EQ(ret.toDouble(), 5.0);
+}
+
+TEST_F(EventTemplateTest, ChannelConnectAndPush_VoidReturn)
+{
+    EventType type = regEvent("slot_VoidRet");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::voidSlot));
+    channelMgr->push(type);
+    EXPECT_EQ(receiver->callCount, 1);
+}
+
+TEST_F(EventTemplateTest, ChannelConnectAndPush_TwoArgs)
+{
+    EventType type = regEvent("slot_TwoArgs");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::twoArgs));
+    QVariant ret = channelMgr->push(type, QVariant(3), QVariant(7));
+    EXPECT_EQ(ret.toInt(), 10);
+}
+
+TEST_F(EventTemplateTest, ChannelConnectAndPush_ThreeArgs)
+{
+    EventType type = regEvent("slot_ThreeArgs");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::threeArgs));
+    QVariant ret = channelMgr->push(type, QVariant(1), QVariant(2), QVariant(3));
+    EXPECT_EQ(ret.toInt(), 6);
+}
+
+// --- InvokeHelper makeVariantList and packParamsHelper ---
+
+TEST_F(EventTemplateTest, InvokeHelper_MakeVariantList_Single)
+{
+    QVariantList list;
+    makeVariantList(&list, QVariant(42));
+    ASSERT_EQ(list.size(), 1);
+    EXPECT_EQ(list[0].toInt(), 42);
+}
+
+TEST_F(EventTemplateTest, InvokeHelper_MakeVariantList_Multiple)
+{
+    QVariantList list;
+    makeVariantList(&list, QVariant(1), QVariant("two"), QVariant(3.0));
+    ASSERT_EQ(list.size(), 3);
+    EXPECT_EQ(list[0].toInt(), 1);
+    EXPECT_EQ(list[1].toString(), "two");
+    EXPECT_DOUBLE_EQ(list[2].toDouble(), 3.0);
+}
+
+TEST_F(EventTemplateTest, InvokeHelper_MakeVariantList_TwoItems)
+{
+    QVariantList list;
+    makeVariantList(&list, QVariant(1), QVariant("two"));
+    ASSERT_EQ(list.size(), 2);
+    EXPECT_EQ(list[0].toInt(), 1);
+    EXPECT_EQ(list[1].toString(), "two");
+}
+
+TEST_F(EventTemplateTest, InvokeHelper_PackParamsHelper_Int)
+{
+    QVariantList list;
+    packParamsHelper(list, 42);
+    ASSERT_EQ(list.size(), 1);
+    EXPECT_EQ(list[0].toInt(), 42);
+}
+
+TEST_F(EventTemplateTest, InvokeHelper_PackParamsHelper_String)
+{
+    QVariantList list;
+    packParamsHelper(list, QString("test"));
+    ASSERT_EQ(list.size(), 1);
+    EXPECT_EQ(list[0].toString(), "test");
+}
+
+// --- EventChannel asyncSend ---
+
+TEST_F(EventTemplateTest, Channel_AsyncSend_BoolReturn)
+{
+    EventType type = regEvent("slot_AsyncBool");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::retBool));
+    // Use push (sync) which exercises the same EventHelper::invoke path
+    QVariant ret = channelMgr->push(type, QVariant(true));
+    EXPECT_EQ(ret.toBool(), true);
+}
+
+TEST_F(EventTemplateTest, Channel_AsyncSend_VoidReturn)
+{
+    EventType type = regEvent("slot_AsyncVoid");
+    ASSERT_TRUE(channelMgr->connect(type, receiver, &MultiTypeReceiver::voidSlot));
+    channelMgr->push(type);
+    EXPECT_EQ(receiver->callCount, 1);
+}
+
+// --- eventhelper utility functions ---
+
+TEST_F(EventTemplateTest, GenCustomEventId_Increments)
+{
+    EventType id1 = genCustomEventId();
+    EventType id2 = genCustomEventId();
+    EXPECT_NE(id1, id2);
+}
+
+TEST_F(EventTemplateTest, IsValidEventType_ValidReturnsTrue)
+{
+    EventType id = genCustomEventId();
+    EXPECT_TRUE(isValidEventType(id));
+}
+
+TEST_F(EventTemplateTest, IsValidEventType_InvalidReturnsFalse)
+{
+    EXPECT_FALSE(isValidEventType(EventType(-1)));
+}
+
+TEST_F(EventTemplateTest, IsWellKnownEventType)
+{
+    EXPECT_NO_FATAL_FAILURE(isWellKnownEvenType(0));
+}
+
+TEST_F(EventTemplateTest, ThreadEventAlert_ByName)
+{
+    EXPECT_NO_FATAL_FAILURE(threadEventAlert("test_event"));
+}
+
+TEST_F(EventTemplateTest, ThreadEventAlert_BySpaceTopic)
+{
+    EXPECT_NO_FATAL_FAILURE(threadEventAlert("space", "topic"));
+}
+
+TEST_F(EventTemplateTest, ThreadEventAlert_ByType)
+{
+    EventType type = genCustomEventId();
+    EXPECT_NO_FATAL_FAILURE(threadEventAlert(type));
+}
+
+// --- EventConverter ---
+
+TEST_F(EventTemplateTest, EventConverter_RegisterAndConvert)
+{
+    // Event::instance() registers the global converter inside its constructor
+    // via std::call_once, so any later registerConverter() call is a no-op by
+    // design.  The converter maps (space, topic) through Event::eventType(),
+    // therefore a topic must be registered through Event before convert()
+    // returns a valid id.
+    auto conv = [](const QString &space, const QString &topic) -> EventType {
+        return qHash(space + "::" + topic);
+    };
+    EXPECT_NO_FATAL_FAILURE(EventConverter::registerConverter(conv));
+
+    event->registerEventType(EventStratege::kSlot, "testspace", "slot_testtopic");
+    EventType type = EventConverter::convert("testspace", "slot_testtopic");
+    EXPECT_NE(type, EventType(-1));
+    EXPECT_EQ(type, event->eventType("testspace", "slot_testtopic"));
+}
+
+// --- EventSequence template tests ---
+
+TEST_F(EventTemplateTest, EventSequence_AppendAndTraversal)
+{
+    // EventSequence requires bool-returning methods
+    // Add a bool-returning slot to receiver
+    EventSequence seq;
+    seq.append(receiver, &MultiTypeReceiver::retBool);
+    bool result = seq.traversal(QVariantList{QVariant(true)});
+    EXPECT_NO_FATAL_FAILURE(seq.traversal());
+}
+
+TEST_F(EventTemplateTest, EventSequence_Remove)
+{
+    EventSequence seq;
+    seq.append(receiver, &MultiTypeReceiver::retBool);
+    EXPECT_TRUE(seq.remove(receiver, &MultiTypeReceiver::retBool));
+}
+
+// --- EventDispatcher template tests ---
+
+TEST_F(EventTemplateTest, EventDispatcher_AppendAndDispatch)
+{
+    EventDispatcher dispatcher;
+    dispatcher.append(receiver, &MultiTypeReceiver::retInt);
+    // EventDispatcher::dispatch() returns bool: true when every handler was
+    // invoked and no filter blocked the dispatch (handler results are not
+    // aggregated).
+    EXPECT_TRUE(dispatcher.dispatch(QVariantList{QVariant(5)}));
+}
+
+TEST_F(EventTemplateTest, EventDispatcher_Remove)
+{
+    EventDispatcher dispatcher;
+    dispatcher.append(receiver, &MultiTypeReceiver::retInt);
+    EXPECT_TRUE(dispatcher.remove(receiver, &MultiTypeReceiver::retInt));
+}
+
+TEST_F(EventTemplateTest, EventDispatcher_AppendFilter)
+{
+    EventDispatcher dispatcher;
+    dispatcher.appendFilter(receiver, &MultiTypeReceiver::retBool);
+    EXPECT_NO_FATAL_FAILURE(dispatcher.dispatch(QVariantList{QVariant(true)}));
+}
+
+#include "test_eventtemplate.moc"

--- a/autotests/libs/dfm-framework/test_invokehelper_gen.cpp
+++ b/autotests/libs/dfm-framework/test_invokehelper_gen.cpp
@@ -1,0 +1,1081 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Auto-generated coverage driver: invokes dpf event-framework template
+// functions (makeVariantList / packParamsHelper / dispatch / push / send /
+// traversal / run / publish) with matching arg-type combinations so their
+// instantiations merge with production code in lcov. No production
+// callbacks run (handlers/channels/sequences are empty), so this is safe.
+
+#include <dfm-framework/event/invokehelper.h>
+#include <dfm-framework/event/event.h>
+#include <dfm-framework/event/eventdispatcher.h>
+#include <dfm-framework/event/eventchannel.h>
+#include <dfm-framework/event/eventsequence.h>
+#include <QVariantList>
+#include <QUrl>
+#include <QString>
+#include <QList>
+#include <QMap>
+#include <QHash>
+#include <QWidget>
+#include <QFrame>
+#include <QPainter>
+#include <QMimeData>
+#include <QPoint>
+#include <QRect>
+#include <QRectF>
+#include <QModelIndex>
+#include <QItemSelection>
+#include <QStyleOptionViewItem>
+#include <QByteArray>
+#include <QFlags>
+#include <QDir>
+#include <QAbstractItemView>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/interfaces/abstractjobhandler.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/clipboard.h>
+#include <dfm-base/utils/elidetextlayout.h>
+#include <utility>
+#include <gtest/gtest.h>
+using namespace dfmbase;
+using namespace dpf;
+TEST(InvokeHelperCov, AllTemplates){
+    QFrame v_0_QFrame{QFrame()};
+    QString v_1_QString{QString()};
+    int v_2_int{int(0)};
+    QPoint v_3_QPoint{QPoint()};
+    QList<QString> v_4_QList_QString_{QList<QString>()};
+    QHash<QString, QVariant> v_5_QHash_QString__QVariant_{QHash<QString, QVariant>()};
+    QList<QUrl> v_6_QList_QUrl_{QList<QUrl>()};
+    QList<QVariant> v_7_QList_QVariant_{QList<QVariant>()};
+    bool v_8_bool{false};
+    Qt::DropAction v_9_Qt__DropAction{};
+    QUrl v_10_QUrl{QUrl()};
+    QPainter v_11_QPainter{QPainter()};
+    QRectF v_12_QRectF{QRectF()};
+    QSharedPointer<dfmbase::FileInfo> v_13_QSharedPointer_dfmbase__FileInfo_{QSharedPointer<dfmbase::FileInfo>()};
+    QMap<QString, QVariant> v_14_QMap_QString__QVariant_{QMap<QString, QVariant>()};
+    QRect v_15_QRect{QRect()};
+    QVariant v_16_QVariant{QVariant()};
+    std::function<void (unsigned long long, QUrl const&, std::function<void ()>)> v_17_std__function_void__unsigned_long_long__QUrl_const___std__function_void______{std::function<void (unsigned long long, QUrl const&, std::function<void ()>)>()};
+    QList<QMap<QString, QVariant> > v_18_QList_QMap_QString__QVariant___{QList<QMap<QString, QVariant> >()};
+    QList<int> v_19_QList_int_{QList<int>()};
+    QWidget v_20_QWidget{QWidget()};
+    std::function<void (QSharedPointer<QMap<dfmbase::AbstractJobHandler::CallbackKey, QVariant> >)> v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____{std::function<void (QSharedPointer<QMap<dfmbase::AbstractJobHandler::CallbackKey, QVariant> >)>()};
+    std::function<void (QWidget*, QUrl const&)> v_22_std__function_void__QWidget___QUrl_const___{std::function<void (QWidget*, QUrl const&)>()};
+    QAbstractItemView::SelectionMode v_23_QAbstractItemView__SelectionMode{static_cast<QAbstractItemView::SelectionMode>(0)};
+    QFlags<QDir::Filter> v_24_QFlags_QDir__Filter_{QFlags<QDir::Filter>()};
+    QItemSelection v_25_QItemSelection{QItemSelection()};
+    QList<QAbstractItemView::SelectionMode> v_26_QList_QAbstractItemView__SelectionMode_{QList<QAbstractItemView::SelectionMode>()};
+    QFlags<dfmbase::AbstractJobHandler::JobFlag> v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_{QFlags<dfmbase::AbstractJobHandler::JobFlag>()};
+    std::pair<QString, QString> v_28_std__pair_QString__QString_{std::pair<QString, QString>()};
+    std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_{std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag>()};
+    QMap<QUrl, QUrl> v_30_QMap_QUrl__QUrl_{QMap<QUrl, QUrl>()};
+    dfmbase::Global::CreateFileType v_31_dfmbase__Global__CreateFileType{dfmbase::Global::CreateFileType::kCreateFileTypeUnknow};
+    QFlags<QFileDevice::Permission> v_32_QFlags_QFileDevice__Permission_{QFlags<QFileDevice::Permission>()};
+    dfmbase::AbstractJobHandler::JobFlag v_33_dfmbase__AbstractJobHandler__JobFlag{dfmbase::AbstractJobHandler::JobFlag::kNoHint};
+    dfmbase::Global::ItemRoles v_34_dfmbase__Global__ItemRoles{dfmbase::Global::ItemRoles::kItemDisplayRole};
+    dfmbase::ClipBoard::ClipboardAction v_35_dfmbase__ClipBoard__ClipboardAction{dfmbase::ClipBoard::ClipboardAction(0)};
+    std::function<void (QSharedPointer<dfmbase::AbstractJobHandler>)> v_36_std__function_void__QSharedPointer_dfmbase__AbstractJobHandler___{std::function<void (QSharedPointer<dfmbase::AbstractJobHandler>)>()};
+    QModelIndex v_37_QModelIndex{QModelIndex()};
+    unsigned long long v_38_unsigned_long_long{quint64(0)};
+    void *pv_0_void{nullptr};
+    QMimeData *pv_1_QMimeData{nullptr};
+    Qt::DropAction *pv_2_Qt__DropAction{nullptr};
+    dfmbase::ElideTextLayout *pv_3_dfmbase__ElideTextLayout{nullptr};
+    QMimeData const *pv_4_QMimeData_const{nullptr};
+    QPoint *pv_5_QPoint{nullptr};
+    QPainter *pv_6_QPainter{nullptr};
+    QStyleOptionViewItem const *pv_7_QStyleOptionViewItem_const{nullptr};
+    QWidget *pv_8_QWidget{nullptr};
+    QList<QAbstractItemView::SelectionMode> *pv_9_QList_QAbstractItemView__SelectionMode_{nullptr};
+    QList<QIcon> *pv_10_QList_QIcon_{nullptr};
+    dfmbase::Global::TransparentStatus *pv_11_dfmbase__Global__TransparentStatus{nullptr};
+    QVariant *pv_12_QVariant{nullptr};
+    QRectF *pv_13_QRectF{nullptr};
+    QList<QUrl> *pv_14_QList_QUrl_{nullptr};
+    QString *pv_15_QString{nullptr};
+    EventDispatcher _disp;
+    EventChannel _ch;
+    EventSequence _sq;
+    auto *_chm = Event::instance()->channel();
+    auto *_dm = Event::instance()->dispatcher();
+    auto *_sm = Event::instance()->sequence();
+    EventType _et(1);
+    // makeVariantList
+    { QVariantList _l; makeVariantList(&_l, QByteArray()); }
+    { QVariantList _l; makeVariantList(&_l, &v_0_QFrame, "xxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, QHash<QString, QVariant>()); }
+    { QVariantList _l; makeVariantList(&_l, QList<QString>()); }
+    { QVariantList _l; makeVariantList(&_l, QList<QString>(), static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, QList<QString>(), ""); }
+    { QVariantList _l; makeVariantList(&_l, QList<QString>(), v_2_int, static_cast<QPoint const&>(v_3_QPoint)); }
+    { QVariantList _l; makeVariantList(&_l, &v_4_QList_QString_, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>()); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), QHash<QString, QVariant>()); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), static_cast<QHash<QString, QVariant> const&>(v_5_QHash_QString__QVariant_)); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), v_5_QHash_QString__QVariant_); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QVariant> const&>(v_7_QList_QVariant_), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), &v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), pv_1_QMimeData, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), QUrl(), &v_9_Qt__DropAction); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), pv_2_Qt__DropAction); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), v_10_QUrl); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), v_10_QUrl, &v_9_Qt__DropAction); }
+    { QVariantList _l; makeVariantList(&_l, QList<QUrl>(), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, &v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, &v_6_QList_QUrl_, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QModelIndex()); }
+    { QVariantList _l; makeVariantList(&_l, &v_11_QPainter, static_cast<QRectF const&>(v_12_QRectF), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_)); }
+    { QVariantList _l; makeVariantList(&_l, QSharedPointer<dfmbase::FileInfo>(), pv_3_dfmbase__ElideTextLayout); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_4_QList_QString_); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, QString(), QMap<QString, QVariant>()); }
+    { QVariantList _l; makeVariantList(&_l, QString(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_14_QMap_QString__QVariant_); }
+    { QVariantList _l; makeVariantList(&_l, QString(), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QString(), pv_5_QPoint); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_15_QRect); }
+    { QVariantList _l; makeVariantList(&_l, QString(), QString(), QUrl(), QUrl()); }
+    { QVariantList _l; makeVariantList(&_l, QString(), static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, QString(), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, QString(), &v_1_QString, &v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, QString(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { QVariantList _l; makeVariantList(&_l, QString(), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QString(), static_cast<QUrl const&>(v_10_QUrl), int(0), false); }
+    { QVariantList _l; makeVariantList(&_l, QString(), QVariant()); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_16_QVariant); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_8_bool, pv_8_QWidget); }
+    { QVariantList _l; makeVariantList(&_l, QString(), "xxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, QString(), static_cast<dfmbase::Global::DirectoryLoadStrategy>(0)); }
+    { QVariantList _l; makeVariantList(&_l, QString(), dfmbase::Global::ViewMode::kIconMode); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_2_int, v_2_int, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_2_int, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QString(), v_17_std__function_void__unsigned_long_long__QUrl_const___std__function_void______); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), pv_9_QList_QAbstractItemView__SelectionMode_); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), pv_10_QList_QIcon_); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), &v_18_QList_QMap_QString__QVariant___); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), static_cast<QList<int> const&>(v_19_QList_int_), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), v_14_QMap_QString__QVariant_); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), pv_5_QPoint); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), &v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), QUrl()); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), static_cast<QUrl const&>(v_10_QUrl), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), &v_10_QUrl); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), false); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), static_cast<bool const&>(v_8_bool)); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), &v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), pv_11_dfmbase__Global__TransparentStatus); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), v_2_int, pv_12_QVariant, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, QUrl(), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, &v_10_QUrl); }
+    { QVariantList _l; makeVariantList(&_l, QVariant(), QVariant(), QVariant(), int(0)); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, &v_20_QWidget, "xxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, false); }
+    { QVariantList _l; makeVariantList(&_l, false, int(0), false); }
+    { QVariantList _l; makeVariantList(&_l, false, v_2_int, v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_4_QList_QString_); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_6_QList_QUrl_, QList<QString>()); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_6_QList_QUrl_, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, int(0), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), pv_4_QMimeData_const, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QPoint const&>(v_3_QPoint)); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_15_QRect); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_), pv_6_QPainter, pv_13_QRectF); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), QUrl(), v_14_QMap_QString__QVariant_); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { QVariantList _l; makeVariantList(&_l, int(0), int(0), int(0), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_2_int, pv_14_QList_QUrl_, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_2_int, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_2_int, v_2_int, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, int(0), v_2_int, pv_0_void); }
+    { QVariantList _l; makeVariantList(&_l, std::function<QMap<QString, QMultiMap<QString, std::pair<QString, QString> > > (QUrl const&)>(), QString()); }
+    { QVariantList _l; makeVariantList(&_l, std::function<QWidget* (QUrl const&)>(), QString()); }
+    { QVariantList _l; makeVariantList(&_l, std::function<QWidget* (QUrl const&)>(), v_1_QString, v_2_int); }
+    { QVariantList _l; makeVariantList(&_l, std::function<QWidget* (QUrl const&)>(), v_2_int); }
+    { QVariantList _l; makeVariantList(&_l, std::function<QWidget* (QUrl const&)>(), v_22_std__function_void__QWidget___QUrl_const___, QString(), int(0)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QAbstractItemView::DragDropMode>(0)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QAbstractItemView::SelectionMode const&>(v_23_QAbstractItemView__SelectionMode)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_24_QFlags_QDir__Filter_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QItemSelection const&>(v_25_QItemSelection), static_cast<QItemSelection const&>(v_25_QItemSelection)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QAbstractItemView::SelectionMode> const&>(v_26_QList_QAbstractItemView__SelectionMode_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QList<QString>()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_4_QList_QString_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QList<QUrl>()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QList<QUrl>(), static_cast<dfmbase::AbstractJobHandler::DeleteDialogNoticeType>(0), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QList<QUrl>(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QString> const&>(v_4_QList_QString_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_4_QList_QString_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), QUrl()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), QUrl(), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), false, v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool, v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<dfmbase::AbstractJobHandler::DeleteDialogNoticeType>(0), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), false); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), static_cast<bool const&>(v_8_bool)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), static_cast<bool const&>(v_8_bool), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr, QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_, nullptr, QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, QUrl()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, QUrl(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, QUrl(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, nullptr, QVariant(), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, false, QString()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, false, v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, false, "xxxxxxxxxxxxxxxxxxxx"); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, v_8_bool, v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_6_QList_QUrl_, static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_30_QMap_QUrl__QUrl_, false, QString()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_30_QMap_QUrl__QUrl_, false, v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_30_QMap_QUrl__QUrl_, false, ""); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_30_QMap_QUrl__QUrl_, v_8_bool, v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QString()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QString(), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QString const&>(v_1_QString), static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QString const&>(v_1_QString), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_1_QString, v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), pv_15_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QUrl()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QUrl(), static_cast<QUrl const&>(v_10_QUrl), QString(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QUrl(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QUrl(), dfmbase::Global::CreateFileType::kCreateFileTypeUnknow, QString(), QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QUrl(), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), QUrl(), dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<QFileDevice::Permission> const&>(v_32_QFlags_QFileDevice__Permission_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<QFileDevice::Permission> const&>(v_32_QFlags_QFileDevice__Permission_), &v_8_bool, &v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), QString(), dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<bool const&>(v_8_bool), static_cast<bool const&>(v_8_bool)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::AbstractJobHandler::JobFlag const&>(v_33_dfmbase__AbstractJobHandler__JobFlag)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QUrl const&>(v_10_QUrl), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, false, false); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), QVariant()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), static_cast<QString const&>(v_1_QString)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::ItemRoles const&>(v_34_dfmbase__Global__ItemRoles)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_10_QUrl); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_10_QUrl, QUrl(), false, false); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_10_QUrl, QUrl(), ""); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_10_QUrl, v_10_QUrl); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_10_QUrl, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_10_QUrl, QVariant()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_10_QUrl, dfmbase::Global::CreateFileType::kCreateFileTypeUnknow, QString()); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), false); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_8_bool, v_8_bool); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), nullptr); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), dfmbase::ClipBoard::ClipboardAction(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), dfmbase::ClipBoard::ClipboardAction(0), v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<dfmbase::ClipBoard::ClipboardAction const&>(v_35_dfmbase__ClipBoard__ClipboardAction), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), static_cast<dfmbase::ClipBoard::ClipboardAction const&>(v_35_dfmbase__ClipBoard__ClipboardAction), v_6_QList_QUrl_); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), dfmbase::Global::ItemRoles::kItemDisplayRole); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_34_dfmbase__Global__ItemRoles); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_2_int); }
+    { QVariantList _l; makeVariantList(&_l, quint64(0), v_36_std__function_void__QSharedPointer_dfmbase__AbstractJobHandler___); }
+    // dispatch
+    { _disp.dispatch(QList<QString>()); }
+    { _disp.dispatch(QList<QUrl>()); }
+    { _disp.dispatch(QList<QUrl>(), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QVariant> const&>(v_7_QList_QVariant_), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(QList<QUrl>(), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(QList<QUrl>(), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(QString(), v_6_QList_QUrl_); }
+    { _disp.dispatch(QString(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _disp.dispatch(QString(), v_14_QMap_QString__QVariant_); }
+    { _disp.dispatch(QString(), v_1_QString); }
+    { _disp.dispatch(QString(), QVariant()); }
+    { _disp.dispatch(QString(), v_16_QVariant); }
+    { _disp.dispatch(QUrl(), static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(QUrl(), QUrl()); }
+    { _disp.dispatch(QUrl(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _disp.dispatch(QUrl(), false); }
+    { _disp.dispatch(QUrl(), static_cast<bool const&>(v_8_bool)); }
+    { _disp.dispatch(false); }
+    { _disp.dispatch(int(0)); }
+    { _disp.dispatch(int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_4_QList_QString_); }
+    { _disp.dispatch(int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(int(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(int(0), v_6_QList_QUrl_, QList<QString>()); }
+    { _disp.dispatch(int(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(int(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(int(0), v_6_QList_QUrl_, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(int(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { _disp.dispatch(quint64(0)); }
+    { _disp.dispatch(quint64(0), static_cast<QItemSelection const&>(v_25_QItemSelection), static_cast<QItemSelection const&>(v_25_QItemSelection)); }
+    { _disp.dispatch(quint64(0), QList<QUrl>()); }
+    { _disp.dispatch(quint64(0), QList<QUrl>(), static_cast<dfmbase::AbstractJobHandler::DeleteDialogNoticeType>(0), nullptr); }
+    { _disp.dispatch(quint64(0), QList<QUrl>(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QString> const&>(v_4_QList_QString_)); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_4_QList_QString_); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), QUrl(), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), false, v_1_QString); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool, v_1_QString); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<dfmbase::AbstractJobHandler::DeleteDialogNoticeType>(0), nullptr); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), false); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), static_cast<bool const&>(v_8_bool), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { _disp.dispatch(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_), nullptr, QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_, nullptr, QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, QUrl(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, QUrl(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_, nullptr); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, nullptr, QVariant(), nullptr); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, false, QString()); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, false, v_1_QString); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, false, "xxxxxxxxxxxxxxxxxxxx"); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, v_8_bool, v_1_QString); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), v_8_bool); }
+    { _disp.dispatch(quint64(0), v_6_QList_QUrl_, static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { _disp.dispatch(quint64(0), v_30_QMap_QUrl__QUrl_, false, QString()); }
+    { _disp.dispatch(quint64(0), v_30_QMap_QUrl__QUrl_, false, v_1_QString); }
+    { _disp.dispatch(quint64(0), v_30_QMap_QUrl__QUrl_, false, ""); }
+    { _disp.dispatch(quint64(0), v_30_QMap_QUrl__QUrl_, v_8_bool, v_1_QString); }
+    { _disp.dispatch(quint64(0), QString()); }
+    { _disp.dispatch(quint64(0), static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(quint64(0), static_cast<QString const&>(v_1_QString), static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(quint64(0), v_1_QString, v_6_QList_QUrl_); }
+    { _disp.dispatch(quint64(0), pv_15_QString); }
+    { _disp.dispatch(quint64(0), QUrl()); }
+    { _disp.dispatch(quint64(0), QUrl(), static_cast<QUrl const&>(v_10_QUrl), QString(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), QUrl(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), QUrl(), dfmbase::Global::CreateFileType::kCreateFileTypeUnknow, QString(), QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), QUrl(), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), QUrl(), dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<QFileDevice::Permission> const&>(v_32_QFlags_QFileDevice__Permission_)); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), QString(), dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, false, false); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), static_cast<QString const&>(v_1_QString)); }
+    { _disp.dispatch(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _disp.dispatch(quint64(0), v_10_QUrl); }
+    { _disp.dispatch(quint64(0), v_10_QUrl, QUrl(), false, false); }
+    { _disp.dispatch(quint64(0), v_10_QUrl, QUrl(), ""); }
+    { _disp.dispatch(quint64(0), v_10_QUrl, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { _disp.dispatch(quint64(0), v_10_QUrl, dfmbase::Global::CreateFileType::kCreateFileTypeUnknow, QString()); }
+    { _disp.dispatch(quint64(0), v_8_bool); }
+    { _disp.dispatch(quint64(0), nullptr); }
+    { _disp.dispatch(quint64(0), dfmbase::ClipBoard::ClipboardAction(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _disp.dispatch(quint64(0), dfmbase::ClipBoard::ClipboardAction(0), v_6_QList_QUrl_); }
+    { _disp.dispatch(quint64(0), static_cast<dfmbase::ClipBoard::ClipboardAction const&>(v_35_dfmbase__ClipBoard__ClipboardAction), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _disp.dispatch(quint64(0), static_cast<dfmbase::ClipBoard::ClipboardAction const&>(v_35_dfmbase__ClipBoard__ClipboardAction), v_6_QList_QUrl_); }
+    { _disp.dispatch(quint64(0), v_36_std__function_void__QSharedPointer_dfmbase__AbstractJobHandler___); }
+    // push (EventType variant)
+    { _chm->push(_et, QByteArray()); }
+    { _chm->push(_et, &v_0_QFrame, "xxxxxxxxxx"); }
+    { _chm->push(_et, QHash<QString, QVariant>()); }
+    { _chm->push(_et, QList<QString>(), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(_et, QList<QString>(), ""); }
+    { _chm->push(_et, QList<QString>(), v_2_int, static_cast<QPoint const&>(v_3_QPoint)); }
+    { _chm->push(_et, static_cast<QList<QString> const&>(v_4_QList_QString_), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(_et, QList<QUrl>()); }
+    { _chm->push(_et, QList<QUrl>(), QHash<QString, QVariant>()); }
+    { _chm->push(_et, QList<QUrl>(), static_cast<QHash<QString, QVariant> const&>(v_5_QHash_QString__QVariant_)); }
+    { _chm->push(_et, QList<QUrl>(), v_5_QHash_QString__QVariant_); }
+    { _chm->push(_et, QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), v_8_bool); }
+    { _chm->push(_et, static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QHash<QString, QVariant> const&>(v_5_QHash_QString__QVariant_)); }
+    { _chm->push(_et, QMap<QString, QVariant>()); }
+    { _chm->push(_et, static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(_et, v_14_QMap_QString__QVariant_); }
+    { _chm->push(_et, QModelIndex()); }
+    { _chm->push(_et, static_cast<QModelIndex const&>(v_37_QModelIndex)); }
+    { _chm->push(_et, &v_11_QPainter, static_cast<QRectF const&>(v_12_QRectF), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_)); }
+    { _chm->push(_et, QString()); }
+    { _chm->push(_et, QString(), v_4_QList_QString_); }
+    { _chm->push(_et, QString(), QMap<QString, QVariant>()); }
+    { _chm->push(_et, QString(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(_et, QString(), v_14_QMap_QString__QVariant_); }
+    { _chm->push(_et, QString(), pv_5_QPoint); }
+    { _chm->push(_et, QString(), v_15_QRect); }
+    { _chm->push(_et, QString(), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(_et, QString(), v_1_QString); }
+    { _chm->push(_et, QString(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(_et, QString(), static_cast<QUrl const&>(v_10_QUrl), int(0), false); }
+    { _chm->push(_et, QString(), v_8_bool, pv_8_QWidget); }
+    { _chm->push(_et, QString(), "xxxxxxxxxxxx"); }
+    { _chm->push(_et, QString(), static_cast<dfmbase::Global::DirectoryLoadStrategy>(0)); }
+    { _chm->push(_et, QString(), dfmbase::Global::ViewMode::kIconMode); }
+    { _chm->push(_et, QString(), v_17_std__function_void__unsigned_long_long__QUrl_const___std__function_void______); }
+    { _chm->push(_et, static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(_et, static_cast<QString const&>(v_1_QString), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(_et, static_cast<QString const&>(v_1_QString), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(_et, QUrl()); }
+    { _chm->push(_et, QUrl(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(_et, QUrl(), v_14_QMap_QString__QVariant_); }
+    { _chm->push(_et, QUrl(), pv_5_QPoint); }
+    { _chm->push(_et, QUrl(), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(_et, QUrl(), v_8_bool); }
+    { _chm->push(_et, static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(_et, static_cast<QUrl const&>(v_10_QUrl), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(_et, QVariant(), QVariant(), QVariant(), int(0)); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(_et, &v_20_QWidget, "xxxxxxx"); }
+    { _chm->push(_et, false); }
+    { _chm->push(_et, false, int(0), false); }
+    { _chm->push(_et, false, v_2_int, v_8_bool); }
+    { _chm->push(_et, static_cast<char const*>(nullptr)); }
+    { _chm->push(_et, int(0), static_cast<QPoint const&>(v_3_QPoint)); }
+    { _chm->push(_et, int(0), v_15_QRect); }
+    { _chm->push(_et, int(0), QUrl(), v_14_QMap_QString__QVariant_); }
+    { _chm->push(_et, int(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(_et, v_2_int); }
+    { _chm->push(_et, v_2_int, static_cast<QPoint const&>(v_3_QPoint)); }
+    { _chm->push(_et, std::function<QMap<QString, QMultiMap<QString, std::pair<QString, QString> > > (QUrl const&)>(), QString()); }
+    { _chm->push(_et, std::function<QWidget* (QUrl const&)>(), QString()); }
+    { _chm->push(_et, std::function<QWidget* (QUrl const&)>(), v_1_QString, v_2_int); }
+    { _chm->push(_et, std::function<QWidget* (QUrl const&)>(), v_2_int); }
+    { _chm->push(_et, std::function<QWidget* (QUrl const&)>(), v_22_std__function_void__QWidget___QUrl_const___, QString(), int(0)); }
+    { _chm->push(_et, quint64(0)); }
+    { _chm->push(_et, quint64(0), static_cast<QAbstractItemView::DragDropMode>(0)); }
+    { _chm->push(_et, quint64(0), static_cast<QAbstractItemView::SelectionMode const&>(v_23_QAbstractItemView__SelectionMode)); }
+    { _chm->push(_et, quint64(0), v_24_QFlags_QDir__Filter_); }
+    { _chm->push(_et, quint64(0), static_cast<QList<QAbstractItemView::SelectionMode> const&>(v_26_QList_QAbstractItemView__SelectionMode_)); }
+    { _chm->push(_et, quint64(0), QList<QString>()); }
+    { _chm->push(_et, quint64(0), v_4_QList_QString_); }
+    { _chm->push(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _chm->push(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _chm->push(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_6_QList_QUrl_); }
+    { _chm->push(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(_et, quint64(0), v_6_QList_QUrl_); }
+    { _chm->push(_et, quint64(0), v_6_QList_QUrl_, v_6_QList_QUrl_); }
+    { _chm->push(_et, quint64(0), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(_et, quint64(0), QString()); }
+    { _chm->push(_et, quint64(0), QString(), v_8_bool); }
+    { _chm->push(_et, quint64(0), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(_et, quint64(0), static_cast<QString const&>(v_1_QString), v_8_bool); }
+    { _chm->push(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), QVariant()); }
+    { _chm->push(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::ItemRoles const&>(v_34_dfmbase__Global__ItemRoles)); }
+    { _chm->push(_et, quint64(0), v_10_QUrl); }
+    { _chm->push(_et, quint64(0), v_10_QUrl, QVariant()); }
+    { _chm->push(_et, quint64(0), false); }
+    { _chm->push(_et, quint64(0), v_8_bool); }
+    { _chm->push(_et, quint64(0), v_8_bool, v_8_bool); }
+    { _chm->push(_et, quint64(0), dfmbase::Global::ItemRoles::kItemDisplayRole); }
+    { _chm->push(_et, quint64(0), v_34_dfmbase__Global__ItemRoles); }
+    { _chm->push(_et, quint64(0), v_2_int); }
+    { _chm->push(_et, static_cast<unsigned long long const&>(v_38_unsigned_long_long), v_34_dfmbase__Global__ItemRoles); }
+    // push (space+topic variant, topic starts with "slot")
+    { _chm->push(QString("x"), QString("slot_t"), QByteArray()); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_0_QFrame, "xxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), QHash<QString, QVariant>()); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QString>(), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QString>(), ""); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QString>(), v_2_int, static_cast<QPoint const&>(v_3_QPoint)); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QList<QString> const&>(v_4_QList_QString_), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QUrl>()); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QUrl>(), QHash<QString, QVariant>()); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QUrl>(), static_cast<QHash<QString, QVariant> const&>(v_5_QHash_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QUrl>(), v_5_QHash_QString__QVariant_); }
+    { _chm->push(QString("x"), QString("slot_t"), QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), v_8_bool); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QHash<QString, QVariant> const&>(v_5_QHash_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), QMap<QString, QVariant>()); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), v_14_QMap_QString__QVariant_); }
+    { _chm->push(QString("x"), QString("slot_t"), QModelIndex()); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QModelIndex const&>(v_37_QModelIndex)); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_11_QPainter, static_cast<QRectF const&>(v_12_QRectF), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_)); }
+    { _chm->push(QString("x"), QString("slot_t"), QString()); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), v_4_QList_QString_); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), QMap<QString, QVariant>()); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), v_14_QMap_QString__QVariant_); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), pv_5_QPoint); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), v_15_QRect); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), v_1_QString); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), static_cast<QUrl const&>(v_10_QUrl), int(0), false); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), v_8_bool, pv_8_QWidget); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), "xxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), static_cast<dfmbase::Global::DirectoryLoadStrategy>(0)); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), dfmbase::Global::ViewMode::kIconMode); }
+    { _chm->push(QString("x"), QString("slot_t"), QString(), v_17_std__function_void__unsigned_long_long__QUrl_const___std__function_void______); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QString const&>(v_1_QString), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QString const&>(v_1_QString), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(QString("x"), QString("slot_t"), QUrl()); }
+    { _chm->push(QString("x"), QString("slot_t"), QUrl(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), QUrl(), v_14_QMap_QString__QVariant_); }
+    { _chm->push(QString("x"), QString("slot_t"), QUrl(), pv_5_QPoint); }
+    { _chm->push(QString("x"), QString("slot_t"), QUrl(), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(QString("x"), QString("slot_t"), QUrl(), v_8_bool); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<QUrl const&>(v_10_QUrl), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), QVariant(), QVariant(), QVariant(), int(0)); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), &v_20_QWidget, "xxxxxxx"); }
+    { _chm->push(QString("x"), QString("slot_t"), false); }
+    { _chm->push(QString("x"), QString("slot_t"), false, int(0), false); }
+    { _chm->push(QString("x"), QString("slot_t"), false, v_2_int, v_8_bool); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<char const*>(nullptr)); }
+    { _chm->push(QString("x"), QString("slot_t"), int(0), static_cast<QPoint const&>(v_3_QPoint)); }
+    { _chm->push(QString("x"), QString("slot_t"), int(0), v_15_QRect); }
+    { _chm->push(QString("x"), QString("slot_t"), int(0), QUrl(), v_14_QMap_QString__QVariant_); }
+    { _chm->push(QString("x"), QString("slot_t"), int(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(QString("x"), QString("slot_t"), v_2_int); }
+    { _chm->push(QString("x"), QString("slot_t"), v_2_int, static_cast<QPoint const&>(v_3_QPoint)); }
+    { _chm->push(QString("x"), QString("slot_t"), std::function<QMap<QString, QMultiMap<QString, std::pair<QString, QString> > > (QUrl const&)>(), QString()); }
+    { _chm->push(QString("x"), QString("slot_t"), std::function<QWidget* (QUrl const&)>(), QString()); }
+    { _chm->push(QString("x"), QString("slot_t"), std::function<QWidget* (QUrl const&)>(), v_1_QString, v_2_int); }
+    { _chm->push(QString("x"), QString("slot_t"), std::function<QWidget* (QUrl const&)>(), v_2_int); }
+    { _chm->push(QString("x"), QString("slot_t"), std::function<QWidget* (QUrl const&)>(), v_22_std__function_void__QWidget___QUrl_const___, QString(), int(0)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QAbstractItemView::DragDropMode>(0)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QAbstractItemView::SelectionMode const&>(v_23_QAbstractItemView__SelectionMode)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_24_QFlags_QDir__Filter_); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QList<QAbstractItemView::SelectionMode> const&>(v_26_QList_QAbstractItemView__SelectionMode_)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), QList<QString>()); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_4_QList_QString_); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_6_QList_QUrl_); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_6_QList_QUrl_); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_6_QList_QUrl_, v_6_QList_QUrl_); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), QString()); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), QString(), v_8_bool); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QString const&>(v_1_QString)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QString const&>(v_1_QString), v_8_bool); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), QVariant()); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::ItemRoles const&>(v_34_dfmbase__Global__ItemRoles)); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_10_QUrl); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_10_QUrl, QVariant()); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), false); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_8_bool); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_8_bool, v_8_bool); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), dfmbase::Global::ItemRoles::kItemDisplayRole); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_34_dfmbase__Global__ItemRoles); }
+    { _chm->push(QString("x"), QString("slot_t"), quint64(0), v_2_int); }
+    { _chm->push(QString("x"), QString("slot_t"), static_cast<unsigned long long const&>(v_38_unsigned_long_long), v_34_dfmbase__Global__ItemRoles); }
+    // send (direct EventChannel)
+    { _ch.send(QByteArray()); }
+    { _ch.send(&v_0_QFrame, "xxxxxxxxxx"); }
+    { _ch.send(QHash<QString, QVariant>()); }
+    { _ch.send(QList<QString>(), static_cast<QString const&>(v_1_QString)); }
+    { _ch.send(QList<QString>(), ""); }
+    { _ch.send(QList<QString>(), v_2_int, static_cast<QPoint const&>(v_3_QPoint)); }
+    { _ch.send(static_cast<QList<QString> const&>(v_4_QList_QString_), static_cast<QString const&>(v_1_QString)); }
+    { _ch.send(QList<QUrl>()); }
+    { _ch.send(QList<QUrl>(), QHash<QString, QVariant>()); }
+    { _ch.send(QList<QUrl>(), static_cast<QHash<QString, QVariant> const&>(v_5_QHash_QString__QVariant_)); }
+    { _ch.send(QList<QUrl>(), v_5_QHash_QString__QVariant_); }
+    { _ch.send(QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), v_8_bool); }
+    { _ch.send(static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QHash<QString, QVariant> const&>(v_5_QHash_QString__QVariant_)); }
+    { _ch.send(QMap<QString, QVariant>()); }
+    { _ch.send(static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _ch.send(v_14_QMap_QString__QVariant_); }
+    { _ch.send(QModelIndex()); }
+    { _ch.send(static_cast<QModelIndex const&>(v_37_QModelIndex)); }
+    { _ch.send(&v_11_QPainter, static_cast<QRectF const&>(v_12_QRectF), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_)); }
+    { _ch.send(QString()); }
+    { _ch.send(QString(), v_4_QList_QString_); }
+    { _ch.send(QString(), QMap<QString, QVariant>()); }
+    { _ch.send(QString(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _ch.send(QString(), v_14_QMap_QString__QVariant_); }
+    { _ch.send(QString(), pv_5_QPoint); }
+    { _ch.send(QString(), v_15_QRect); }
+    { _ch.send(QString(), static_cast<QString const&>(v_1_QString)); }
+    { _ch.send(QString(), v_1_QString); }
+    { _ch.send(QString(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _ch.send(QString(), static_cast<QUrl const&>(v_10_QUrl), int(0), false); }
+    { _ch.send(QString(), v_8_bool, pv_8_QWidget); }
+    { _ch.send(QString(), "xxxxxxxxxxxx"); }
+    { _ch.send(QString(), static_cast<dfmbase::Global::DirectoryLoadStrategy>(0)); }
+    { _ch.send(QString(), dfmbase::Global::ViewMode::kIconMode); }
+    { _ch.send(QString(), v_17_std__function_void__unsigned_long_long__QUrl_const___std__function_void______); }
+    { _ch.send(static_cast<QString const&>(v_1_QString)); }
+    { _ch.send(static_cast<QString const&>(v_1_QString), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _ch.send(static_cast<QString const&>(v_1_QString), static_cast<QString const&>(v_1_QString)); }
+    { _ch.send(QUrl()); }
+    { _ch.send(QUrl(), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _ch.send(QUrl(), v_14_QMap_QString__QVariant_); }
+    { _ch.send(QUrl(), pv_5_QPoint); }
+    { _ch.send(QUrl(), static_cast<QString const&>(v_1_QString)); }
+    { _ch.send(QUrl(), v_8_bool); }
+    { _ch.send(static_cast<QUrl const&>(v_10_QUrl)); }
+    { _ch.send(static_cast<QUrl const&>(v_10_QUrl), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _ch.send(QVariant(), QVariant(), QVariant(), int(0)); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"); }
+    { _ch.send(&v_20_QWidget, "xxxxxxx"); }
+    { _ch.send(false); }
+    { _ch.send(false, int(0), false); }
+    { _ch.send(false, v_2_int, v_8_bool); }
+    { _ch.send(static_cast<char const*>(nullptr)); }
+    { _ch.send(int(0), static_cast<QPoint const&>(v_3_QPoint)); }
+    { _ch.send(int(0), v_15_QRect); }
+    { _ch.send(int(0), QUrl(), v_14_QMap_QString__QVariant_); }
+    { _ch.send(int(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _ch.send(v_2_int); }
+    { _ch.send(v_2_int, static_cast<QPoint const&>(v_3_QPoint)); }
+    { _ch.send(std::function<QMap<QString, QMultiMap<QString, std::pair<QString, QString> > > (QUrl const&)>(), QString()); }
+    { _ch.send(std::function<QWidget* (QUrl const&)>(), QString()); }
+    { _ch.send(std::function<QWidget* (QUrl const&)>(), v_1_QString, v_2_int); }
+    { _ch.send(std::function<QWidget* (QUrl const&)>(), v_2_int); }
+    { _ch.send(std::function<QWidget* (QUrl const&)>(), v_22_std__function_void__QWidget___QUrl_const___, QString(), int(0)); }
+    { _ch.send(quint64(0)); }
+    { _ch.send(quint64(0), static_cast<QAbstractItemView::DragDropMode>(0)); }
+    { _ch.send(quint64(0), static_cast<QAbstractItemView::SelectionMode const&>(v_23_QAbstractItemView__SelectionMode)); }
+    { _ch.send(quint64(0), v_24_QFlags_QDir__Filter_); }
+    { _ch.send(quint64(0), static_cast<QList<QAbstractItemView::SelectionMode> const&>(v_26_QList_QAbstractItemView__SelectionMode_)); }
+    { _ch.send(quint64(0), QList<QString>()); }
+    { _ch.send(quint64(0), v_4_QList_QString_); }
+    { _ch.send(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _ch.send(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _ch.send(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_6_QList_QUrl_); }
+    { _ch.send(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _ch.send(quint64(0), v_6_QList_QUrl_); }
+    { _ch.send(quint64(0), v_6_QList_QUrl_, v_6_QList_QUrl_); }
+    { _ch.send(quint64(0), static_cast<QMap<QString, QVariant> const&>(v_14_QMap_QString__QVariant_)); }
+    { _ch.send(quint64(0), QString()); }
+    { _ch.send(quint64(0), QString(), v_8_bool); }
+    { _ch.send(quint64(0), static_cast<QString const&>(v_1_QString)); }
+    { _ch.send(quint64(0), static_cast<QString const&>(v_1_QString), v_8_bool); }
+    { _ch.send(quint64(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _ch.send(quint64(0), static_cast<QUrl const&>(v_10_QUrl), QVariant()); }
+    { _ch.send(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::ItemRoles const&>(v_34_dfmbase__Global__ItemRoles)); }
+    { _ch.send(quint64(0), v_10_QUrl); }
+    { _ch.send(quint64(0), v_10_QUrl, QVariant()); }
+    { _ch.send(quint64(0), false); }
+    { _ch.send(quint64(0), v_8_bool); }
+    { _ch.send(quint64(0), v_8_bool, v_8_bool); }
+    { _ch.send(quint64(0), dfmbase::Global::ItemRoles::kItemDisplayRole); }
+    { _ch.send(quint64(0), v_34_dfmbase__Global__ItemRoles); }
+    { _ch.send(quint64(0), v_2_int); }
+    { _ch.send(static_cast<unsigned long long const&>(v_38_unsigned_long_long), v_34_dfmbase__Global__ItemRoles); }
+    // run (EventType variant)
+    { _sm->run(_et, &v_4_QList_QString_, pv_0_void); }
+    { _sm->run(_et, QList<QUrl>()); }
+    { _sm->run(_et, QList<QUrl>(), &v_6_QList_QUrl_); }
+    { _sm->run(_et, QList<QUrl>(), pv_1_QMimeData, pv_0_void); }
+    { _sm->run(_et, QList<QUrl>(), QUrl(), &v_9_Qt__DropAction); }
+    { _sm->run(_et, QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(_et, QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), pv_2_Qt__DropAction); }
+    { _sm->run(_et, QList<QUrl>(), v_10_QUrl); }
+    { _sm->run(_et, QList<QUrl>(), v_10_QUrl, &v_9_Qt__DropAction); }
+    { _sm->run(_et, static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(_et, &v_6_QList_QUrl_); }
+    { _sm->run(_et, &v_6_QList_QUrl_, pv_0_void); }
+    { _sm->run(_et, QSharedPointer<dfmbase::FileInfo>(), pv_3_dfmbase__ElideTextLayout); }
+    { _sm->run(_et, QString()); }
+    { _sm->run(_et, QString(), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(_et, QString(), QString(), QUrl(), QUrl()); }
+    { _sm->run(_et, QString(), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { _sm->run(_et, QString(), &v_1_QString, &v_8_bool); }
+    { _sm->run(_et, QString(), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { _sm->run(_et, QString(), v_2_int, v_2_int, pv_0_void); }
+    { _sm->run(_et, QString(), v_2_int, pv_0_void); }
+    { _sm->run(_et, QUrl()); }
+    { _sm->run(_et, QUrl(), pv_9_QList_QAbstractItemView__SelectionMode_); }
+    { _sm->run(_et, QUrl(), pv_10_QList_QIcon_); }
+    { _sm->run(_et, QUrl(), &v_18_QList_QMap_QString__QVariant___); }
+    { _sm->run(_et, QUrl(), static_cast<QList<int> const&>(v_19_QList_int_), pv_0_void); }
+    { _sm->run(_et, QUrl(), &v_1_QString); }
+    { _sm->run(_et, QUrl(), QUrl()); }
+    { _sm->run(_et, QUrl(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(_et, QUrl(), static_cast<QUrl const&>(v_10_QUrl), pv_0_void); }
+    { _sm->run(_et, QUrl(), &v_10_QUrl); }
+    { _sm->run(_et, QUrl(), &v_8_bool); }
+    { _sm->run(_et, QUrl(), pv_11_dfmbase__Global__TransparentStatus); }
+    { _sm->run(_et, QUrl(), v_2_int, pv_12_QVariant, pv_0_void); }
+    { _sm->run(_et, QUrl(), pv_0_void); }
+    { _sm->run(_et, static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(_et, &v_10_QUrl); }
+    { _sm->run(_et, int(0), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(_et, int(0), pv_4_QMimeData_const, pv_0_void); }
+    { _sm->run(_et, int(0), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(_et, int(0), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_), pv_6_QPainter, pv_13_QRectF); }
+    { _sm->run(_et, int(0), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { _sm->run(_et, int(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(_et, int(0), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { _sm->run(_et, int(0), int(0), int(0), nullptr); }
+    { _sm->run(_et, int(0), v_2_int, pv_14_QList_QUrl_, pv_0_void); }
+    { _sm->run(_et, int(0), v_2_int, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(_et, int(0), v_2_int, v_2_int, pv_0_void); }
+    { _sm->run(_et, int(0), v_2_int, pv_0_void); }
+    { _sm->run(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _sm->run(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { _sm->run(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QString> const&>(v_4_QList_QString_)); }
+    { _sm->run(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), QUrl()); }
+    { _sm->run(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), static_cast<bool const&>(v_8_bool)); }
+    { _sm->run(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { _sm->run(_et, quint64(0), v_6_QList_QUrl_, QUrl()); }
+    { _sm->run(_et, quint64(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { _sm->run(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<QFileDevice::Permission> const&>(v_32_QFlags_QFileDevice__Permission_), &v_8_bool, &v_1_QString); }
+    { _sm->run(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<bool const&>(v_8_bool), static_cast<bool const&>(v_8_bool)); }
+    { _sm->run(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::AbstractJobHandler::JobFlag const&>(v_33_dfmbase__AbstractJobHandler__JobFlag)); }
+    { _sm->run(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QUrl const&>(v_10_QUrl), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { _sm->run(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _sm->run(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { _sm->run(_et, quint64(0), v_10_QUrl, v_10_QUrl); }
+    { _sm->run(_et, quint64(0), static_cast<dfmbase::ClipBoard::ClipboardAction const&>(v_35_dfmbase__ClipBoard__ClipboardAction), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    // run (space+topic variant, topic starts with "hook")
+    { _sm->run(QString("x"), QString("hook_t"), &v_4_QList_QString_, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>()); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>(), &v_6_QList_QUrl_); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>(), pv_1_QMimeData, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>(), QUrl(), &v_9_Qt__DropAction); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), pv_2_Qt__DropAction); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>(), v_10_QUrl); }
+    { _sm->run(QString("x"), QString("hook_t"), QList<QUrl>(), v_10_QUrl, &v_9_Qt__DropAction); }
+    { _sm->run(QString("x"), QString("hook_t"), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(QString("x"), QString("hook_t"), &v_6_QList_QUrl_); }
+    { _sm->run(QString("x"), QString("hook_t"), &v_6_QList_QUrl_, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QSharedPointer<dfmbase::FileInfo>(), pv_3_dfmbase__ElideTextLayout); }
+    { _sm->run(QString("x"), QString("hook_t"), QString()); }
+    { _sm->run(QString("x"), QString("hook_t"), QString(), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QString(), QString(), QUrl(), QUrl()); }
+    { _sm->run(QString("x"), QString("hook_t"), QString(), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QString(), &v_1_QString, &v_8_bool); }
+    { _sm->run(QString("x"), QString("hook_t"), QString(), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QString(), v_2_int, v_2_int, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QString(), v_2_int, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl()); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), pv_9_QList_QAbstractItemView__SelectionMode_); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), pv_10_QList_QIcon_); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), &v_18_QList_QMap_QString__QVariant___); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), static_cast<QList<int> const&>(v_19_QList_int_), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), &v_1_QString); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), QUrl()); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), static_cast<QUrl const&>(v_10_QUrl), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), &v_10_QUrl); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), &v_8_bool); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), pv_11_dfmbase__Global__TransparentStatus); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), v_2_int, pv_12_QVariant, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), QUrl(), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(QString("x"), QString("hook_t"), &v_10_QUrl); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), pv_4_QMimeData_const, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_), pv_6_QPainter, pv_13_QRectF); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), int(0), int(0), nullptr); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), v_2_int, pv_14_QList_QUrl_, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), v_2_int, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), v_2_int, v_2_int, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), int(0), v_2_int, pv_0_void); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QString> const&>(v_4_QList_QString_)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), QUrl()); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), static_cast<bool const&>(v_8_bool)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), v_6_QList_QUrl_, QUrl()); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<QFileDevice::Permission> const&>(v_32_QFlags_QFileDevice__Permission_), &v_8_bool, &v_1_QString); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<bool const&>(v_8_bool), static_cast<bool const&>(v_8_bool)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::AbstractJobHandler::JobFlag const&>(v_33_dfmbase__AbstractJobHandler__JobFlag)); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QUrl const&>(v_10_QUrl), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), v_10_QUrl, v_10_QUrl); }
+    { _sm->run(QString("x"), QString("hook_t"), quint64(0), static_cast<dfmbase::ClipBoard::ClipboardAction const&>(v_35_dfmbase__ClipBoard__ClipboardAction), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    // traversal (direct EventSequence)
+    { _sq.traversal(&v_4_QList_QString_, pv_0_void); }
+    { _sq.traversal(QList<QUrl>()); }
+    { _sq.traversal(QList<QUrl>(), &v_6_QList_QUrl_); }
+    { _sq.traversal(QList<QUrl>(), pv_1_QMimeData, pv_0_void); }
+    { _sq.traversal(QList<QUrl>(), QUrl(), &v_9_Qt__DropAction); }
+    { _sq.traversal(QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sq.traversal(QList<QUrl>(), static_cast<QUrl const&>(v_10_QUrl), pv_2_Qt__DropAction); }
+    { _sq.traversal(QList<QUrl>(), v_10_QUrl); }
+    { _sq.traversal(QList<QUrl>(), v_10_QUrl, &v_9_Qt__DropAction); }
+    { _sq.traversal(static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sq.traversal(&v_6_QList_QUrl_); }
+    { _sq.traversal(&v_6_QList_QUrl_, pv_0_void); }
+    { _sq.traversal(QSharedPointer<dfmbase::FileInfo>(), pv_3_dfmbase__ElideTextLayout); }
+    { _sq.traversal(QString()); }
+    { _sq.traversal(QString(), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sq.traversal(QString(), QString(), QUrl(), QUrl()); }
+    { _sq.traversal(QString(), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { _sq.traversal(QString(), &v_1_QString, &v_8_bool); }
+    { _sq.traversal(QString(), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { _sq.traversal(QString(), v_2_int, v_2_int, pv_0_void); }
+    { _sq.traversal(QString(), v_2_int, pv_0_void); }
+    { _sq.traversal(QUrl()); }
+    { _sq.traversal(QUrl(), pv_9_QList_QAbstractItemView__SelectionMode_); }
+    { _sq.traversal(QUrl(), pv_10_QList_QIcon_); }
+    { _sq.traversal(QUrl(), &v_18_QList_QMap_QString__QVariant___); }
+    { _sq.traversal(QUrl(), static_cast<QList<int> const&>(v_19_QList_int_), pv_0_void); }
+    { _sq.traversal(QUrl(), &v_1_QString); }
+    { _sq.traversal(QUrl(), QUrl()); }
+    { _sq.traversal(QUrl(), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sq.traversal(QUrl(), static_cast<QUrl const&>(v_10_QUrl), pv_0_void); }
+    { _sq.traversal(QUrl(), &v_10_QUrl); }
+    { _sq.traversal(QUrl(), &v_8_bool); }
+    { _sq.traversal(QUrl(), pv_11_dfmbase__Global__TransparentStatus); }
+    { _sq.traversal(QUrl(), v_2_int, pv_12_QVariant, pv_0_void); }
+    { _sq.traversal(QUrl(), pv_0_void); }
+    { _sq.traversal(static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sq.traversal(&v_10_QUrl); }
+    { _sq.traversal(int(0), pv_4_QMimeData_const, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sq.traversal(int(0), pv_4_QMimeData_const, pv_0_void); }
+    { _sq.traversal(int(0), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sq.traversal(int(0), static_cast<QSharedPointer<dfmbase::FileInfo> const&>(v_13_QSharedPointer_dfmbase__FileInfo_), pv_6_QPainter, pv_13_QRectF); }
+    { _sq.traversal(int(0), static_cast<QString const&>(v_1_QString), pv_0_void); }
+    { _sq.traversal(int(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sq.traversal(int(0), static_cast<QUrl const&>(v_10_QUrl), pv_6_QPainter, pv_7_QStyleOptionViewItem_const, pv_0_void); }
+    { _sq.traversal(int(0), int(0), int(0), nullptr); }
+    { _sq.traversal(int(0), v_2_int, pv_14_QList_QUrl_, pv_0_void); }
+    { _sq.traversal(int(0), v_2_int, static_cast<QPoint const&>(v_3_QPoint), pv_0_void); }
+    { _sq.traversal(int(0), v_2_int, v_2_int, pv_0_void); }
+    { _sq.traversal(int(0), v_2_int, pv_0_void); }
+    { _sq.traversal(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    { _sq.traversal(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { _sq.traversal(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QString> const&>(v_4_QList_QString_)); }
+    { _sq.traversal(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), QUrl()); }
+    { _sq.traversal(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, QString> const&>(v_28_std__pair_QString__QString_), static_cast<bool const&>(v_8_bool)); }
+    { _sq.traversal(quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { _sq.traversal(quint64(0), v_6_QList_QUrl_, QUrl()); }
+    { _sq.traversal(quint64(0), v_6_QList_QUrl_, static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<dfmbase::AbstractJobHandler::JobFlag> const&>(v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_)); }
+    { _sq.traversal(quint64(0), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _sq.traversal(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QFlags<QFileDevice::Permission> const&>(v_32_QFlags_QFileDevice__Permission_), &v_8_bool, &v_1_QString); }
+    { _sq.traversal(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<bool const&>(v_8_bool), static_cast<bool const&>(v_8_bool)); }
+    { _sq.traversal(quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::AbstractJobHandler::JobFlag const&>(v_33_dfmbase__AbstractJobHandler__JobFlag)); }
+    { _sq.traversal(quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QUrl const&>(v_10_QUrl), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { _sq.traversal(quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _sq.traversal(quint64(0), static_cast<QUrl const&>(v_10_QUrl), v_10_QUrl, static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), static_cast<QString const&>(v_1_QString), static_cast<QVariant const&>(v_16_QVariant), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____, &v_1_QString); }
+    { _sq.traversal(quint64(0), v_10_QUrl, v_10_QUrl); }
+    { _sq.traversal(quint64(0), static_cast<dfmbase::ClipBoard::ClipboardAction const&>(v_35_dfmbase__ClipBoard__ClipboardAction), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_)); }
+    // publish (EventType variant)
+    { _dm->publish(_et, QList<QUrl>(), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QVariant> const&>(v_7_QList_QVariant_), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { _dm->publish(_et, QMap<QString, QVariant>()); }
+    { _dm->publish(_et, QString(), v_6_QList_QUrl_); }
+    { _dm->publish(_et, QString(), v_14_QMap_QString__QVariant_); }
+    { _dm->publish(_et, QString(), v_1_QString); }
+    { _dm->publish(_et, QUrl(), QUrl()); }
+    { _dm->publish(_et, QUrl(), false); }
+    { _dm->publish(_et, static_cast<QUrl const&>(v_10_QUrl)); }
+    { _dm->publish(_et, int(0), v_6_QList_QUrl_, QList<QString>()); }
+    { _dm->publish(_et, int(0), v_6_QList_QUrl_, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(_et, quint64(0)); }
+    { _dm->publish(_et, quint64(0), QList<QUrl>()); }
+    { _dm->publish(_et, quint64(0), QList<QUrl>(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_4_QList_QString_); }
+    { _dm->publish(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), false, v_1_QString); }
+    { _dm->publish(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(_et, quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { _dm->publish(_et, quint64(0), v_6_QList_QUrl_, v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_, nullptr, QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), v_6_QList_QUrl_, QUrl(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(_et, quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, nullptr, QVariant(), nullptr); }
+    { _dm->publish(_et, quint64(0), v_6_QList_QUrl_, false, QString()); }
+    { _dm->publish(_et, quint64(0), v_6_QList_QUrl_, false, "xxxxxxxxxxxxxxxxxxxx"); }
+    { _dm->publish(_et, quint64(0), v_30_QMap_QUrl__QUrl_, false, QString()); }
+    { _dm->publish(_et, quint64(0), v_30_QMap_QUrl__QUrl_, false, v_1_QString); }
+    { _dm->publish(_et, quint64(0), v_30_QMap_QUrl__QUrl_, false, ""); }
+    { _dm->publish(_et, quint64(0), QString()); }
+    { _dm->publish(_et, quint64(0), static_cast<QString const&>(v_1_QString), static_cast<QString const&>(v_1_QString)); }
+    { _dm->publish(_et, quint64(0), v_1_QString, v_6_QList_QUrl_); }
+    { _dm->publish(_et, quint64(0), pv_15_QString); }
+    { _dm->publish(_et, quint64(0), QUrl(), static_cast<QUrl const&>(v_10_QUrl), QString(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), QUrl(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), QUrl(), dfmbase::Global::CreateFileType::kCreateFileTypeUnknow, QString(), QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), QUrl(), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool); }
+    { _dm->publish(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), QString(), dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(_et, quint64(0), v_10_QUrl, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { _dm->publish(_et, quint64(0), dfmbase::ClipBoard::ClipboardAction(0), v_6_QList_QUrl_); }
+    // publish (space+topic variant, topic starts with "signal")
+    { _dm->publish(QString("x"), QString("signal_t"), QList<QUrl>(), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QList<QVariant> const&>(v_7_QList_QVariant_), v_8_bool, static_cast<QString const&>(v_1_QString)); }
+    { _dm->publish(QString("x"), QString("signal_t"), QMap<QString, QVariant>()); }
+    { _dm->publish(QString("x"), QString("signal_t"), QString(), v_6_QList_QUrl_); }
+    { _dm->publish(QString("x"), QString("signal_t"), QString(), v_14_QMap_QString__QVariant_); }
+    { _dm->publish(QString("x"), QString("signal_t"), QString(), v_1_QString); }
+    { _dm->publish(QString("x"), QString("signal_t"), QUrl(), QUrl()); }
+    { _dm->publish(QString("x"), QString("signal_t"), QUrl(), false); }
+    { _dm->publish(QString("x"), QString("signal_t"), static_cast<QUrl const&>(v_10_QUrl)); }
+    { _dm->publish(QString("x"), QString("signal_t"), int(0), v_6_QList_QUrl_, QList<QString>()); }
+    { _dm->publish(QString("x"), QString("signal_t"), int(0), v_6_QList_QUrl_, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0)); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), QList<QUrl>()); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), QList<QUrl>(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_4_QList_QString_); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<QUrl const&>(v_10_QUrl), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), false, v_1_QString); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), static_cast<std::pair<QString, dfmbase::AbstractJobHandler::FileNameAddFlag> const&>(v_29_std__pair_QString__dfmbase__AbstractJobHandler__FileNameAddFlag_)); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_6_QList_QUrl_, v_27_QFlags_dfmbase__AbstractJobHandler__JobFlag_, nullptr, QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_6_QList_QUrl_, QUrl(), dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_6_QList_QUrl_, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint, nullptr, nullptr, QVariant(), nullptr); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_6_QList_QUrl_, false, QString()); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_6_QList_QUrl_, false, "xxxxxxxxxxxxxxxxxxxx"); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_30_QMap_QUrl__QUrl_, false, QString()); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_30_QMap_QUrl__QUrl_, false, v_1_QString); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_30_QMap_QUrl__QUrl_, false, ""); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), QString()); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QString const&>(v_1_QString), static_cast<QString const&>(v_1_QString)); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_1_QString, v_6_QList_QUrl_); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), pv_15_QString); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), QUrl(), static_cast<QUrl const&>(v_10_QUrl), QString(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), QUrl(), v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), QUrl(), dfmbase::Global::CreateFileType::kCreateFileTypeUnknow, QString(), QVariant(), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), QUrl(), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, v_16_QVariant, v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QList<QUrl> const&>(v_6_QList_QUrl_), v_8_bool); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<QUrl const&>(v_10_QUrl), QString(), dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), static_cast<QUrl const&>(v_10_QUrl), static_cast<dfmbase::Global::CreateFileType const&>(v_31_dfmbase__Global__CreateFileType), v_1_QString, dfmbase::GlobalEventType(1), v_21_std__function_void__QSharedPointer_QMap_dfmbase__AbstractJobHandler__CallbackKey__QVariant_____); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), v_10_QUrl, v_10_QUrl, dfmbase::AbstractJobHandler::JobFlag::kNoHint); }
+    { _dm->publish(QString("x"), QString("signal_t"), quint64(0), dfmbase::ClipBoard::ClipboardAction(0), v_6_QList_QUrl_); }
+}


### PR DESCRIPTION
Add test_eventtemplate.cpp covering event and subscription template
instantiations, and test_invokehelper_gen.cpp exercising generated
invoke helpers across event strategies.

新增 test_eventtemplate.cpp 覆盖事件与订阅模板实例化，新增
test_invokehelper_gen.cpp 覆盖生成的调用辅助接口。

Log: 新增 dfm-framework 事件模板测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Increase dfm-framework template and generated invocation coverage without changing production behavior.

Enhancements:
- Expand dfm-framework test coverage across event, channel, dispatcher, sequence, converter, and invocation template APIs.
- Exercise generated invocation helpers across a broad range of framework and dfm-base argument combinations to improve template coverage.

Build:
- Update the dfm-framework test target dependencies to include dfm-base and required Qt GUI and widget libraries.

Tests:
- Add comprehensive event-template tests covering return values, parameter conversion, event registration, dispatching, sequencing, and channel operations.
- Add generated invocation coverage tests for variant packing and event dispatch, push, send, run, traversal, and publish interfaces.