### PR TITLE
test: add unit tests for dfmplugin-burn (part 1/2: core and events)

### DIFF
--- a/autotests/plugins/dfmplugin-burn/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-burn/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM test utilities to create plugin test
+dfm_create_plugin_test("dfmplugin-burn" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-burn")

--- a/autotests/plugins/dfmplugin-burn/main.cpp
+++ b/autotests/plugins/dfmplugin-burn/main.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QApplication>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_burn)

--- a/autotests/plugins/dfmplugin-burn/test_burn.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burn.cpp
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/burn.h"
+#include "plugins/common/dfmplugin-burn/utils/discstatemanager.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+#include "plugins/common/dfmplugin-burn/utils/burnsignalmanager.h"
+#include "plugins/common/dfmplugin-burn/events/burneventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+
+#include <QUrl>
+#include <QSet>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_Burn : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        plugin = new Burn();
+    }
+
+    virtual void TearDown() override
+    {
+        delete plugin;
+        plugin = nullptr;
+        stub.clear();
+    }
+
+public:
+    stub_ext::StubExt stub;
+    Burn *plugin = nullptr;
+};
+
+TEST_F(UT_Burn, initialize)
+{
+    bool bindEventsCalled = false;
+    stub.set_lamda(ADDR(Burn, bindEvents), [&bindEventsCalled] {
+        __DBG_STUB_INVOKE__
+        bindEventsCalled = true;
+    });
+
+    plugin->initialize();
+    EXPECT_TRUE(bindEventsCalled);
+}
+
+TEST_F(UT_Burn, initialize_BurnDisabled)
+{
+    bool initializeManagerCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, initilaize), [&initializeManagerCalled] {
+        __DBG_STUB_INVOKE__
+        initializeManagerCalled = true;
+    });
+
+    stub.set_lamda(ADDR(DiscStateManager, instance), [] {
+        __DBG_STUB_INVOKE__
+        static DiscStateManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(ADDR(BurnEventReceiver, instance), [] {
+        __DBG_STUB_INVOKE__
+        static BurnEventReceiver receiver;
+        return &receiver;
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, isBurnEnabled), [] {
+        __DBG_STUB_INVOKE__
+        return false;   // Burn disabled
+    });
+
+    plugin->initialize();
+
+    EXPECT_FALSE(initializeManagerCalled);   // Should not initialize when disabled
+}
+
+TEST_F(UT_Burn, start)
+{
+    bool bindSceneCalled = false;
+
+    stub.set_lamda(ADDR(Burn, bindScene), [&bindSceneCalled] {
+        __DBG_STUB_INVOKE__
+        bindSceneCalled = true;
+    });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(bindSceneCalled);
+}
+
+TEST_F(UT_Burn, bindScene)
+{
+    plugin->bindScene("WorkspaceScene");
+}
+
+TEST_F(UT_Burn, bindSceneOnAdded)
+{
+    plugin->bindSceneOnAdded("WorkspaceScene");
+}
+
+TEST_F(UT_Burn, bindSceneOnAdded_NotInWaitList)
+{
+    bool bindSceneCalled = false;
+
+    stub.set_lamda(ADDR(Burn, bindScene), [&bindSceneCalled] {
+        __DBG_STUB_INVOKE__
+        bindSceneCalled = true;
+    });
+
+    plugin->bindSceneOnAdded("UnknownScene");
+
+    EXPECT_FALSE(bindSceneCalled);   // Should not bind unknown scenes
+}
+
+TEST_F(UT_Burn, bindEvents)
+{
+    plugin->bindEvents();
+}
+
+TEST_F(UT_Burn, changeUrlEventFilter_BurnUrl)
+{
+    QUrl burnUrl;
+    burnUrl.setScheme("burn");
+    burnUrl.setPath("/dev/sr0/disc_files/");
+    stub.set_lamda(&DeviceUtils::isWorkingOpticalDiscDev, []() {
+        return true;
+    });
+
+    bool result = plugin->changeUrlEventFilter(12345, burnUrl);
+
+    EXPECT_TRUE(result);   // Should handle burn URLs
+}
+
+TEST_F(UT_Burn, changeUrlEventFilter_NonBurnUrl)
+{
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test.txt");
+
+    bool result = plugin->changeUrlEventFilter(12345, fileUrl);
+
+    EXPECT_FALSE(result);   // Should not handle non-burn URLs
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_BurnEnable_True)
+{
+    QVariantMap value;
+    value["working"] = true;
+    plugin->onPersistenceDataChanged("/org/freedesktop/UDisks2/block_devices/sr0", value);
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_BurnEnable_False)
+{
+    bool initializeCalled = false;
+
+    stub.set_lamda(VADDR(Burn, initialize), [&initializeCalled] {
+        __DBG_STUB_INVOKE__
+        initializeCalled = true;
+    });
+
+    QVariantMap value;
+    value["working"] = false;
+    plugin->onPersistenceDataChanged("/org/freedesktop/UDisks2/block_devices/sr0", value);
+
+    EXPECT_FALSE(initializeCalled);   // Should not initialize when disabled
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_OtherGroup)
+{
+    bool initializeCalled = false;
+
+    stub.set_lamda(VADDR(Burn, initialize), [&initializeCalled] {
+        __DBG_STUB_INVOKE__
+        initializeCalled = true;
+    });
+
+    QVariantMap value;
+    value["working"] = true;
+    plugin->onPersistenceDataChanged("some_other_key", value);
+
+    EXPECT_FALSE(initializeCalled);   // Should not respond to other groups
+}
+
+TEST_F(UT_Burn, onPersistenceDataChanged_OtherKey)
+{
+    bool initializeCalled = false;
+
+    stub.set_lamda(VADDR(Burn, initialize), [&initializeCalled] {
+        __DBG_STUB_INVOKE__
+        initializeCalled = true;
+    });
+
+    QVariantMap value;
+    value["otherField"] = true;
+    plugin->onPersistenceDataChanged("/org/freedesktop/UDisks2/block_devices/sr0", value);
+
+    EXPECT_FALSE(initializeCalled);   // Should not respond to other keys
+}
+
+TEST_F(UT_Burn, Constructor)
+{
+    Burn burnPlugin;
+
+    // Should construct without crashing
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_Burn, bindEvents_EventSubscription)
+{
+    plugin->bindEvents();
+}
+
+TEST_F(UT_Burn, start_ReturnValue)
+{
+    stub.set_lamda(ADDR(Burn, bindScene), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    stub.set_lamda(ADDR(Burn, bindEvents), [] {
+        __DBG_STUB_INVOKE__
+    });
+
+    bool result = plugin->start();
+
+    EXPECT_TRUE(result);   // Should always return true
+}
+
+TEST_F(UT_Burn, changeUrlEventFilter_EmptyUrl)
+{
+    QUrl emptyUrl;
+
+    bool result = plugin->changeUrlEventFilter(12345, emptyUrl);
+
+    EXPECT_FALSE(result);   // Should not handle empty URLs
+}

--- a/autotests/plugins/dfmplugin-burn/test_burneventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burneventreceiver.cpp
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/events/burneventreceiver.h"
+#include "plugins/common/dfmplugin-burn/events/burneventcaller.h"
+#include "plugins/common/dfmplugin-burn/utils/burnjobmanager.h"
+#include "plugins/common/dfmplugin-burn/dialogs/burnoptdialog.h"
+#include "plugins/common/dfmplugin-burn/dialogs/dumpisooptdialog.h"
+
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/base/device/deviceutils.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-framework/event/event.h>
+
+#include <DDialog>
+#include <QWidget>
+#include <QApplication>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_BurnEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(VADDR(DDialog, exec), [] {
+            __DBG_STUB_INVOKE__
+            return QDialog::Accepted;
+        });
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_BurnEventReceiver, instance)
+{
+    BurnEventReceiver *receiver1 = BurnEventReceiver::instance();
+    BurnEventReceiver *receiver2 = BurnEventReceiver::instance();
+
+    EXPECT_TRUE(receiver1 != nullptr);
+    EXPECT_EQ(receiver1, receiver2);   // Should be singleton
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowBurnDlg_UDFSupported)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    QWidget parent;
+    BurnEventReceiver::instance()->handleShowBurnDlg("/dev/sr0", true, &parent);
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowBurnDlg_UDFNotSupported)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    QWidget parent;
+    BurnEventReceiver::instance()->handleShowBurnDlg("/dev/sr0", false, &parent);
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowBurnDlg_NullParent)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    BurnEventReceiver::instance()->handleShowBurnDlg("/dev/sr0", true, nullptr);
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleShowDumpISODlg)
+{
+    bool dialogShown = false;
+
+    stub.set_lamda(VADDR(DumpISOOptDialog, exec), [&dialogShown] {
+        __DBG_STUB_INVOKE__
+        dialogShown = true;
+        return QDialog::Accepted;
+    });
+
+    BurnEventReceiver::instance()->handleShowDumpISODlg("/dev/sr0");
+
+    EXPECT_TRUE(dialogShown);
+}
+
+TEST_F(UT_BurnEventReceiver, handleErase)
+{
+    bool eraseStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startEraseDisc), [&eraseStarted] {
+        __DBG_STUB_INVOKE__
+        eraseStarted = true;
+    });
+    stub.set_lamda(VADDR(DDialog, exec), [&] { __DBG_STUB_INVOKE__ return DDialog::Accepted; });
+
+    BurnEventReceiver::instance()->handleErase("/dev/sr0");
+
+    EXPECT_TRUE(eraseStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handlePasteTo_Copy)
+{
+    bool pasteFilesCalled = false;
+    QList<QUrl> capturedUrls;
+    QUrl capturedDest;
+    bool capturedIsCopy = false;
+
+    stub.set_lamda(ADDR(BurnEventCaller, sendPasteFiles), [&](const QList<QUrl> &urls, const QUrl &dest, bool isCopy) {
+        __DBG_STUB_INVOKE__
+        pasteFilesCalled = true;
+        capturedUrls = urls;
+        capturedDest = dest;
+        capturedIsCopy = isCopy;
+    });
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/file1.txt"),
+                         QUrl::fromLocalFile("/tmp/file2.txt") };
+    QUrl dest;
+    dest.setScheme("burn");
+    dest.setPath("/dev/sr0/disc_files/");
+
+    BurnEventReceiver::instance()->handlePasteTo(urls, dest, true);
+
+    EXPECT_TRUE(pasteFilesCalled);
+    EXPECT_EQ(capturedUrls, urls);
+    EXPECT_TRUE(capturedIsCopy);
+}
+
+TEST_F(UT_BurnEventReceiver, handlePasteTo_Move)
+{
+    bool pasteFilesCalled = false;
+    QList<QUrl> capturedUrls;
+    QUrl capturedDest;
+    bool capturedIsCopy = true; // Initialize to opposite of expected
+
+    stub.set_lamda(ADDR(BurnEventCaller, sendPasteFiles), [&](const QList<QUrl> &urls, const QUrl &dest, bool isCopy) {
+        __DBG_STUB_INVOKE__
+        pasteFilesCalled = true;
+        capturedUrls = urls;
+        capturedDest = dest;
+        capturedIsCopy = isCopy;
+    });
+
+    QList<QUrl> urls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+    QUrl dest;
+    dest.setScheme("burn");
+    dest.setPath("/dev/sr0/disc_files/");
+
+    BurnEventReceiver::instance()->handlePasteTo(urls, dest, false);
+
+    EXPECT_TRUE(pasteFilesCalled);
+    EXPECT_EQ(capturedUrls, urls);
+    EXPECT_FALSE(capturedIsCopy);
+}
+
+TEST_F(UT_BurnEventReceiver, handleMountImage)
+{
+    // This test requires complex framework event stubbing
+    // For now, just test that the method doesn't crash
+    QUrl isoUrl = QUrl::fromLocalFile("/tmp/test.iso");
+    BurnEventReceiver::instance()->handleMountImage(12345, isoUrl);
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleCopyFilesResult_Success)
+{
+    bool auditLogStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startAuditLogForCopyFromDisc), [&auditLogStarted] {
+        __DBG_STUB_INVOKE__
+        auditLogStarted = true;
+    });
+
+    // Stub DeviceProxyManager to simulate copying from optical disc
+    stub.set_lamda(ADDR(DeviceProxyManager, isFileFromOptical), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleCopyFilesResult(srcUrls, destUrls, true, "");
+
+    EXPECT_TRUE(auditLogStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleCopyFilesResult_Failure)
+{
+    // The method ignores the 'ok' and 'errMsg' parameters and doesn't show error dialogs
+    // This test just verifies the method doesn't crash when called with failure parameters
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleCopyFilesResult(srcUrls, destUrls, false, "Copy failed");
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileCutResult_Success)
+{
+    bool putFilesStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startPutFilesToDisc), [&putFilesStarted] {
+        __DBG_STUB_INVOKE__
+        putFilesStarted = true;
+    });
+
+    // Stub DeviceUtils methods for packet writing conditions
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+    
+    stub.set_lamda(ADDR(DeviceUtils, isPWUserspaceOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleFileCutResult(srcUrls, destUrls, true, "");
+
+    EXPECT_TRUE(putFilesStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileCutResult_Failure)
+{
+    // The method ignores the 'ok' and 'errMsg' parameters and doesn't show error dialogs
+    // This test just verifies the method doesn't crash when called with failure parameters
+    QList<QUrl> srcUrls = { QUrl::fromLocalFile("/media/sr0/file1.txt") };
+    QList<QUrl> destUrls = { QUrl::fromLocalFile("/tmp/file1.txt") };
+
+    BurnEventReceiver::instance()->handleFileCutResult(srcUrls, destUrls, false, "Cut failed");
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRemoveResult_Success)
+{
+    bool removeStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startRemoveFilesFromDisc), [&removeStarted] {
+        __DBG_STUB_INVOKE__
+        removeStarted = true;
+    });
+
+    // Stub DeviceUtils methods for packet writing conditions
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+    
+    stub.set_lamda(ADDR(DeviceUtils, isPWUserspaceOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QList<QUrl> srcUrls;
+    srcUrls << QUrl::fromLocalFile("/media/sr0/file1.txt");
+
+    BurnEventReceiver::instance()->handleFileRemoveResult(srcUrls, true, "");
+
+    EXPECT_TRUE(removeStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRemoveResult_Failure)
+{
+    // The method ignores the 'ok' and 'errMsg' parameters and doesn't show error dialogs
+    // This test just verifies the method doesn't crash when called with failure parameters
+    QList<QUrl> srcUrls;
+    srcUrls << QUrl::fromLocalFile("/media/sr0/file1.txt");
+
+    BurnEventReceiver::instance()->handleFileRemoveResult(srcUrls, false, "Remove failed");
+
+    // Should not crash
+    EXPECT_TRUE(true);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRenameResult_Success)
+{
+    bool renameStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startRenameFileFromDisc), [&renameStarted] {
+        __DBG_STUB_INVOKE__
+        renameStarted = true;
+    });
+
+    // Stub DeviceUtils methods for packet writing conditions
+    stub.set_lamda(ADDR(DeviceUtils, getMountInfo), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+    
+    stub.set_lamda(ADDR(DeviceUtils, isPWUserspaceOpticalDiscDev), [] {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    QMap<QUrl, QUrl> renamedUrls;
+    renamedUrls[QUrl::fromLocalFile("/media/sr0/oldname.txt")] = QUrl::fromLocalFile("/media/sr0/newname.txt");
+
+    BurnEventReceiver::instance()->handleFileRenameResult(12345, renamedUrls, true, "");
+
+    EXPECT_TRUE(renameStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRenameResult_Failure)
+{
+    // The method checks 'ok' parameter and returns early if false, but doesn't show error dialogs
+    // This test verifies that no rename operation is started when ok=false
+    bool renameStarted = false;
+
+    stub.set_lamda(ADDR(BurnJobManager, startRenameFileFromDisc), [&renameStarted] {
+        __DBG_STUB_INVOKE__
+        renameStarted = true;
+    });
+
+    QMap<QUrl, QUrl> renamedUrls;
+    renamedUrls[QUrl::fromLocalFile("/media/sr0/oldname.txt")] = QUrl::fromLocalFile("/media/sr0/newname.txt");
+
+    BurnEventReceiver::instance()->handleFileRenameResult(12345, renamedUrls, false, "Rename failed");
+
+    // Should not start rename operation when ok=false
+    EXPECT_FALSE(renameStarted);
+}
+
+TEST_F(UT_BurnEventReceiver, handleFileRenameResult_EmptyMap)
+{
+    // Should handle empty rename map gracefully
+    QMap<QUrl, QUrl> emptyMap;
+
+    BurnEventReceiver::instance()->handleFileRenameResult(12345, emptyMap, true, "");
+    // Should not crash
+}

--- a/autotests/plugins/dfmplugin-burn/test_burnhelper.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_burnhelper.cpp
@@ -1,0 +1,410 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/utils/burnhelper.h"
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/application/settings.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+#include <dfm-base/dbusservice/opticalshareproxy.h>
+
+#include <DDialog>
+
+#include <QStandardPaths>
+#include <QApplication>
+#include <QDir>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+
+#include <gtest/gtest.h>
+
+DFMBASE_USE_NAMESPACE
+DPBURN_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_BurnHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(ADDR(QWidget, show), [&] {
+            __DBG_STUB_INVOKE__
+        });
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_BurnHelper, IsBurnEnabled)
+{
+    bool ret { false };
+    stub.set_lamda(&DConfigManager::value, [&] { __DBG_STUB_INVOKE__ return ret; });
+    EXPECT_FALSE(BurnHelper::isBurnEnabled());
+
+    ret = true;
+    EXPECT_TRUE(BurnHelper::isBurnEnabled());
+}
+
+TEST_F(UT_BurnHelper, IsBurnEnabled_InvalidValue)
+{
+    stub.set_lamda(&DConfigManager::value, [] {
+        __DBG_STUB_INVOKE__
+        return QVariant();   // Invalid value
+    });
+    EXPECT_TRUE(BurnHelper::isBurnEnabled());   // Should return default true
+}
+
+TEST_F(UT_BurnHelper, showOpticalBlankConfirmationDialog)
+{
+    int expectedResult = 1;
+    stub.set_lamda(VADDR(DDialog, exec), [&expectedResult] {
+        __DBG_STUB_INVOKE__
+        return expectedResult;
+    });
+
+    int result = BurnHelper::showOpticalBlankConfirmationDialog();
+    EXPECT_EQ(result, expectedResult);
+}
+
+TEST_F(UT_BurnHelper, showOpticalImageOpSelectionDialog)
+{
+    int expectedResult = 2;
+    stub.set_lamda(VADDR(DDialog, exec), [&expectedResult] {
+        __DBG_STUB_INVOKE__
+        return expectedResult;
+    });
+
+    int result = BurnHelper::showOpticalImageOpSelectionDialog();
+    EXPECT_EQ(result, expectedResult);
+}
+
+TEST_F(UT_BurnHelper, localStagingFile_WithDevice)
+{
+    QString testDev = "/dev/sr0";
+
+    stub.set_lamda(&QStandardPaths::writableLocation, [] {
+        __DBG_STUB_INVOKE__
+        return QString("/tmp/cache");
+    });
+
+    stub.set_lamda(&QApplication::organizationName, [] {
+        __DBG_STUB_INVOKE__
+        return QString("deepin");
+    });
+
+    QUrl result = BurnHelper::localStagingFile(testDev);
+    EXPECT_TRUE(result.isLocalFile());
+    EXPECT_TRUE(result.toLocalFile().contains("_dev_sr0"));
+}
+
+TEST_F(UT_BurnHelper, localStagingFile_WithUrl)
+{
+    QUrl destUrl;
+    destUrl.setScheme("burn");
+    destUrl.setPath("/dev/sr0/disc_files/test.txt");
+
+    stub.set_lamda(ADDR(BurnHelper, burnDestDevice), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/dev/sr0");
+    });
+
+    stub.set_lamda(ADDR(BurnHelper, burnFilePath), [] {
+        __DBG_STUB_INVOKE__
+        return QString("/test.txt");
+    });
+
+    stub.set_lamda(&QStandardPaths::writableLocation, [] {
+        __DBG_STUB_INVOKE__
+        return QString("/tmp/cache");
+    });
+
+    stub.set_lamda(&QApplication::organizationName, [] {
+        __DBG_STUB_INVOKE__
+        return QString("deepin");
+    });
+
+    QUrl result = BurnHelper::localStagingFile(destUrl);
+    EXPECT_TRUE(result.isLocalFile());
+}
+
+TEST_F(UT_BurnHelper, localStagingFile_WithUrl_EmptyDevice)
+{
+    QUrl destUrl;
+    destUrl.setScheme("burn");
+    destUrl.setPath("/invalid/path");
+
+    stub.set_lamda(ADDR(BurnHelper, burnDestDevice), [] {
+        __DBG_STUB_INVOKE__
+        return QString();   // Empty device
+    });
+
+    QUrl result = BurnHelper::localStagingFile(destUrl);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, fromBurnFile)
+{
+    QString testDev = "/dev/sr0";
+
+    QUrl result = BurnHelper::fromBurnFile(testDev);
+    EXPECT_EQ(result.scheme(), "burn");
+    EXPECT_TRUE(result.path().contains("staging_files"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_DuplicateFile)
+{
+    QStringList messages;
+    // The method expects both conditions in the same message string
+    messages << "While grafting '/path/to/file.txt' file object exists and may not be overwritten";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("duplicate file"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_InsufficientSpace)
+{
+    QStringList messages;
+    messages << "Image size 1024 exceeds free space on media 512";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Insufficient disc space"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_LostConnection)
+{
+    QStringList messages;
+    messages << "Lost connection to drive";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Lost connection to drive"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_ServoFailure)
+{
+    QStringList messages;
+    messages << "servo failure";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("not ready"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_DeviceBusy)
+{
+    QStringList messages;
+    messages << "Device or resource busy";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("busy"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_InvalidVolumeName)
+{
+    QStringList messages;
+    messages << "-volid: Text too long";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Invalid volume name"));
+}
+
+TEST_F(UT_BurnHelper, parseXorrisoErrorMessage_UnknownError)
+{
+    QStringList messages;
+    messages << "Some unknown error message";
+
+    QString result = BurnHelper::parseXorrisoErrorMessage(messages);
+    EXPECT_TRUE(result.contains("Unknown error"));
+}
+
+TEST_F(UT_BurnHelper, burnDestDevice_ValidBurnUrl)
+{
+    QUrl url;
+    url.setScheme("burn");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnDestDevice(url);
+    EXPECT_EQ(result, "/dev/sr0");
+}
+
+TEST_F(UT_BurnHelper, burnDestDevice_InvalidScheme)
+{
+    QUrl url;
+    url.setScheme("file");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnDestDevice(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, burnDestDevice_InvalidPath)
+{
+    QUrl url;
+    url.setScheme("burn");
+    url.setPath("/invalid/path");
+
+    QString result = BurnHelper::burnDestDevice(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, burnFilePath_ValidBurnUrl)
+{
+    QUrl url;
+    url.setScheme("burn");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnFilePath(url);
+    EXPECT_EQ(result, "/test.txt");
+}
+
+TEST_F(UT_BurnHelper, burnFilePath_InvalidScheme)
+{
+    QUrl url;
+    url.setScheme("file");
+    url.setPath("/dev/sr0/disc_files/test.txt");
+
+    QString result = BurnHelper::burnFilePath(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, discDataGroup)
+{
+    QStringList mockIds = { "/org/freedesktop/UDisks2/block_devices/sr0",
+                            "/org/freedesktop/UDisks2/block_devices/sda1" };
+
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [&mockIds] {
+        __DBG_STUB_INVOKE__
+        return mockIds;
+    });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [](DeviceProxyManager *, const QString &id, bool needDBusCall) {
+        __DBG_STUB_INVOKE__
+        Q_UNUSED(needDBusCall)
+        QVariantMap data;
+        if (id.contains("sr0")) {
+            data[DeviceProperty::kOptical] = true;
+            data[DeviceProperty::kOpticalDrive] = true;
+        } else {
+            data[DeviceProperty::kOptical] = false;
+            data[DeviceProperty::kOpticalDrive] = false;
+        }
+        return data;
+    });
+
+    QList<QVariantMap> result = BurnHelper::discDataGroup();
+    EXPECT_EQ(result.size(), 1);   // Only sr0 should be included
+}
+
+TEST_F(UT_BurnHelper, updateBurningStateToPersistence)
+{
+    // Product now forwards state to OpticalShareProxy (non-virtual, stubable)
+    bool setCalled = false;
+    bool clearCalled = false;
+
+    stub.set_lamda(ADDR(OpticalShareProxy, setBurnState), [&setCalled](OpticalShareProxy *, const QString &, const QVariantMap &) -> bool {
+        __DBG_STUB_INVOKE__
+        setCalled = true;
+        return true;
+    });
+
+    stub.set_lamda(ADDR(OpticalShareProxy, clearBurnState), [&clearCalled](OpticalShareProxy *, const QString &) -> bool {
+        __DBG_STUB_INVOKE__
+        clearCalled = true;
+        return true;
+    });
+
+    BurnHelper::updateBurningStateToPersistence("test_id", "/dev/sr0", true);
+    EXPECT_TRUE(setCalled);
+    EXPECT_FALSE(clearCalled);
+
+    BurnHelper::updateBurningStateToPersistence("test_id", "/dev/sr0", false);
+    EXPECT_TRUE(clearCalled);
+}
+
+TEST_F(UT_BurnHelper, mapStagingFilesPath_EmptyList)
+{
+    QList<QUrl> emptyList;
+
+    // Should not crash with empty lists
+    BurnHelper::mapStagingFilesPath(emptyList, emptyList);
+}
+
+TEST_F(UT_BurnHelper, mapStagingFilesPath_SizeMismatch)
+{
+    QList<QUrl> srcList = { QUrl::fromLocalFile("/src/file1.txt") };
+    QList<QUrl> targetList = { QUrl::fromLocalFile("/target/file1.txt"),
+                               QUrl::fromLocalFile("/target/file2.txt") };
+
+    // Should handle size mismatch gracefully
+    BurnHelper::mapStagingFilesPath(srcList, targetList);
+}
+
+TEST_F(UT_BurnHelper, burnIsOnLocalStaging_ValidPath)
+{
+    QUrl url = QUrl::fromLocalFile("/home/user/.cache/deepin/discburn/_dev_sr0/test.txt");
+
+    bool result = BurnHelper::burnIsOnLocalStaging(url);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_BurnHelper, burnIsOnLocalStaging_InvalidPath)
+{
+    QUrl url = QUrl::fromLocalFile("/home/user/Documents/test.txt");
+
+    bool result = BurnHelper::burnIsOnLocalStaging(url);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_BurnHelper, localFileInfoList_ValidDirectory)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    // Create test files
+    QFile file1(tempDir.path() + "/file1.txt");
+    ASSERT_TRUE(file1.open(QIODevice::WriteOnly));
+    file1.close();
+
+    QDir subDir(tempDir.path() + "/subdir");
+    ASSERT_TRUE(subDir.mkpath("."));
+
+    QFileInfoList result = BurnHelper::localFileInfoList(tempDir.path());
+    EXPECT_EQ(result.size(), 2);   // file1.txt and subdir
+}
+
+TEST_F(UT_BurnHelper, localFileInfoList_NonExistentDirectory)
+{
+    QFileInfoList result = BurnHelper::localFileInfoList("/non/existent/path");
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(UT_BurnHelper, localFileInfoListRecursive_ValidDirectory)
+{
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+
+    // Create test files
+    QFile file1(tempDir.path() + "/file1.txt");
+    ASSERT_TRUE(file1.open(QIODevice::WriteOnly));
+    file1.close();
+
+    QDir subDir(tempDir.path() + "/subdir");
+    ASSERT_TRUE(subDir.mkpath("."));
+
+    QFile file2(tempDir.path() + "/subdir/file2.txt");
+    ASSERT_TRUE(file2.open(QIODevice::WriteOnly));
+    file2.close();
+
+    QFileInfoList result = BurnHelper::localFileInfoListRecursive(tempDir.path());
+    EXPECT_EQ(result.size(), 2);   // file1.txt and file2.txt (only files, not dirs)
+}
+
+TEST_F(UT_BurnHelper, localFileInfoListRecursive_NonExistentDirectory)
+{
+    QFileInfoList result = BurnHelper::localFileInfoListRecursive("/non/existent/path");
+    EXPECT_TRUE(result.isEmpty());
+}

--- a/autotests/plugins/dfmplugin-burn/test_discstatemanager.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_discstatemanager.cpp
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+#include "plugins/common/dfmplugin-burn/utils/discstatemanager.h"
+
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+
+#include <QSignalSpy>
+#include <QVariant>
+
+#include <gtest/gtest.h>
+
+DPBURN_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+class UT_DiscStateManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+
+public:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_DiscStateManager, instance)
+{
+    DiscStateManager *manager1 = DiscStateManager::instance();
+    DiscStateManager *manager2 = DiscStateManager::instance();
+
+    EXPECT_TRUE(manager1 != nullptr);
+    EXPECT_EQ(manager1, manager2);   // Should be singleton
+}
+
+TEST_F(UT_DiscStateManager, initilaize)
+{
+    DiscStateManager::instance()->initilaize();
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc)
+{
+    bool getAllBlockIdsCalled = false;
+
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [&getAllBlockIdsCalled] {
+        __DBG_STUB_INVOKE__
+        getAllBlockIdsCalled = true;
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0";
+        return ids;
+    });
+
+    bool queryBlockInfoCalled = false;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [&queryBlockInfoCalled] {
+        __DBG_STUB_INVOKE__
+        queryBlockInfoCalled = true;
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = true;
+        info[DeviceProperty::kOpticalBlank] = true;
+        info[DeviceProperty::kMountPoint] = QString();   // Not mounted
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_TRUE(getAllBlockIdsCalled);
+    EXPECT_TRUE(queryBlockInfoCalled);
+    EXPECT_TRUE(mountCalled);
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_NoOpticalDevices)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sda1";   // Not optical
+        return ids;
+    });
+
+    bool queryBlockInfoCalled = false;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [&queryBlockInfoCalled] {
+        __DBG_STUB_INVOKE__
+        queryBlockInfoCalled = true;
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = false;   // Not optical
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    // Product filters devices by the "sr" prefix before querying, so a non-sr
+    // device is never queried nor mounted
+    EXPECT_FALSE(queryBlockInfoCalled);
+    EXPECT_FALSE(mountCalled);   // Should not mount non-optical devices
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_NotBlank)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0";
+        return ids;
+    });
+
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = true;
+        info[DeviceProperty::kOpticalBlank] = false;   // Not blank
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_FALSE(mountCalled);   // Should not mount non-blank discs
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_AlreadyMounted)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0";
+        return ids;
+    });
+
+    // Product mounts blank discs whose free size is 0 (no mount-point check);
+    // a blank disc with free space must not be mounted
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [] {
+        __DBG_STUB_INVOKE__
+        QVariantMap info;
+        info[DeviceProperty::kOptical] = true;
+        info[DeviceProperty::kOpticalBlank] = true;
+        info[DeviceProperty::kSizeFree] = 100;   // Has data, no ghost mount
+        return info;
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_FALSE(mountCalled);   // Should not mount blank discs that have free space
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_OpticalBlank)
+{
+    // Product handles blank optical discs directly in onDevicePropertyChanged:
+    // it queries info and mounts when blank && free size is 0
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [](DeviceProxyManager *, const QString &, bool) {
+        __DBG_STUB_INVOKE__
+        QVariantMap info;
+        info[DeviceProperty::kOpticalBlank] = true;
+        info[DeviceProperty::kSizeFree] = 0;
+        return info;
+    });
+
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled](DeviceManager *, const QString &, const QVariantMap &, CallbackType1, int) {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sr0",
+            DeviceProperty::kOptical,
+            QVariant(true));
+
+    EXPECT_TRUE(mountCalled);
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_OpticalBlank_False)
+{
+    bool ghostMountCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, ghostMountForBlankDisc), [&ghostMountCalled] {
+        __DBG_STUB_INVOKE__
+        ghostMountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sr0",
+            "OpticalBlank",
+            QVariant(false));
+
+    EXPECT_FALSE(ghostMountCalled);   // Should not call for non-blank
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_OtherProperty)
+{
+    bool ghostMountCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, ghostMountForBlankDisc), [&ghostMountCalled] {
+        __DBG_STUB_INVOKE__
+        ghostMountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sr0",
+            "SomeOtherProperty",
+            QVariant("value"));
+
+    EXPECT_FALSE(ghostMountCalled);   // Should not call for other properties
+}
+
+TEST_F(UT_DiscStateManager, onDevicePropertyChanged_NonOpticalDevice)
+{
+    bool ghostMountCalled = false;
+
+    stub.set_lamda(ADDR(DiscStateManager, ghostMountForBlankDisc), [&ghostMountCalled] {
+        __DBG_STUB_INVOKE__
+        ghostMountCalled = true;
+    });
+
+    DiscStateManager::instance()->onDevicePropertyChanged(
+            "/org/freedesktop/UDisks2/block_devices/sda1",   // Not optical
+            "OpticalBlank",
+            QVariant(true));
+
+    EXPECT_FALSE(ghostMountCalled);   // Should not call for non-optical devices
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_EmptyDeviceList)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        return QStringList();   // Empty list
+    });
+
+    bool mountCalled = false;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCalled] {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_FALSE(mountCalled);   // Should not mount anything
+}
+
+TEST_F(UT_DiscStateManager, ghostMountForBlankDisc_MultipleDevices)
+{
+    stub.set_lamda(ADDR(DeviceProxyManager, getAllBlockIds), [] {
+        __DBG_STUB_INVOKE__
+        QStringList ids;
+        ids << "/org/freedesktop/UDisks2/block_devices/sr0"
+            << "/org/freedesktop/UDisks2/block_devices/sr1"
+            << "/org/freedesktop/UDisks2/block_devices/sda1";   // Mix of optical and non-optical
+        return ids;
+    });
+
+    int queryCount = 0;
+    stub.set_lamda(ADDR(DeviceProxyManager, queryBlockInfo), [&queryCount](DeviceProxyManager *, const QString &id, bool reload) {
+        __DBG_STUB_INVOKE__
+        queryCount++;
+        QVariantMap info;
+        if (id.contains("sr")) {
+            info[DeviceProperty::kOptical] = true;
+            info[DeviceProperty::kOpticalBlank] = true;
+            info[DeviceProperty::kMountPoint] = QString();
+        } else {
+            info[DeviceProperty::kOptical] = false;
+        }
+        return info;
+    });
+
+    int mountCount = 0;
+    stub.set_lamda(ADDR(DeviceManager, mountBlockDevAsync), [&mountCount] {
+        __DBG_STUB_INVOKE__
+        mountCount++;
+    });
+
+    DiscStateManager::instance()->ghostMountForBlankDisc();
+
+    EXPECT_EQ(queryCount, 2);   // Only the two "sr" devices are queried; sda1 is skipped
+    EXPECT_EQ(mountCount, 2);   // Should only mount the two optical devices
+}

--- a/autotests/plugins/dfmplugin-burn/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-burn/test_realevents.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run Burn::initialize() with REAL bindEvents() (NOT stubbed)
+// so production EventHelper<M> subscribe template instantiations execute.
+// bindEvents uses GlobalEventType (always valid, no registration needed).
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "burn.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_burn;
+
+class BurnRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override { dfmtest_hooks::registerAllHookEvents(); ins = new Burn(); }
+    void TearDown() override { delete ins; }
+    Burn *ins { nullptr };
+};
+
+TEST_F(BurnRealEventsTest, Initialize_RunsRealBindEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->initialize());
+}


### PR DESCRIPTION
Part 1/2 of dfmplugin-burn unit tests, split by module for easier review:
刻录核心、事件与光盘状态.

This part carries the final CMakeLists.txt and main.cpp; test files
of the other parts land in separate PRs. The test binary is wired
into the build by the registration PR (merged last).

dfmplugin-burn 单元测试第 1/2 部分（按模块拆分以便评审）：刻录核心、事件与光盘状态。

本部分包含最终版 CMakeLists.txt 与 main.cpp，其余测试文件由独立
PR 提交；测试二进制由注册 PR（最后合入）接入构建。

Log: 新增 dfmplugin-burn 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Add comprehensive unit tests for dfmplugin-burn core behavior, event handling, helper utilities, and optical-disc state management.

Build:
- Add CMake configuration and a GoogleTest entry point for the dfmplugin-burn unit-test target.

Tests:
- Add unit coverage for burn plugin lifecycle, URL handling, persistence updates, event receivers, burn helpers, disc-state management, and real event binding, including optical-disc and error-path scenarios.