### PR TITLE
test: add unit tests for dfmplugin-computer (part 1/3: core and events)

### DIFF
--- a/autotests/plugins/dfmplugin-computer/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-computer/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM enhanced test utilities to create plugin test
+dfm_create_plugin_test_enhanced("dfmplugin-computer" "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-computer")

--- a/autotests/plugins/dfmplugin-computer/fakeentryentity.h
+++ b/autotests/plugins/dfmplugin-computer/fakeentryentity.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FAKEENTRYENTITY_H
+#define FAKEENTRYENTITY_H
+
+#include <dfm-base/interfaces/abstractentryfileentity.h>
+#include <dfm-base/dbusservice/global_server_defines.h>
+
+#include <QIcon>
+#include <QUrl>
+#include <QVariant>
+
+DFMBASE_USE_NAMESPACE
+using namespace GlobalServerDefines;
+
+namespace dfmplugin_computer {
+
+class FakeEntryEntity : public AbstractEntryFileEntity
+{
+    Q_OBJECT
+public:
+    explicit FakeEntryEntity(const QUrl &url)
+        : AbstractEntryFileEntity(url)
+    {
+    }
+
+    void setExists(bool exists) { setExtraProperty("__test_exists", exists); }
+    void setTargetUrl(const QUrl &url) { setExtraProperty(DeviceProperty::kMountPoint, url.path()); }
+    void setDisplayName(const QString &name) { setExtraProperty(DeviceProperty::kDisplayName, name); }
+    void setOrder(EntryOrder order) { setExtraProperty("__test_order", static_cast<int>(order)); }
+    void setIsAccessable(bool access) { setExtraProperty("__test_access", access); }
+    void setRenamable(bool rename) { setExtraProperty("__test_renamable", rename); }
+    void setExtraProp(const QString &key, const QVariant &val) { setExtraProperty(key, val); }
+
+    bool exists() const override { return propBool("__test_exists", false); }
+    QString displayName() const override { return propString(DeviceProperty::kDisplayName, entryUrl.fileName()); }
+    QIcon icon() const override { return QIcon::fromTheme("drive-harddisk"); }
+    bool showProgress() const override { return propBool("__test_showProgress", false); }
+    bool showTotalSize() const override { return propBool("__test_showTotalSize", false); }
+    bool showUsageSize() const override { return propBool("__test_showUsageSize", false); }
+    EntryOrder order() const override { return static_cast<EntryOrder>(propInt("__test_order", static_cast<int>(kOrderCustom))); }
+    quint64 sizeTotal() const override { return propULongLong("__test_sizeTotal", 0); }
+    quint64 sizeUsage() const override { return propULongLong("__test_sizeUsage", 0); }
+    QString description() const override { return propString("__test_description", QString()); }
+    QUrl targetUrl() const override
+    {
+        QString path = propString(DeviceProperty::kMountPoint, QString());
+        if (path.isEmpty())
+            return QUrl();
+        return QUrl::fromLocalFile(path);
+    }
+    bool isAccessable() const override { return propBool("__test_access", false); }
+    bool renamable() const override { return propBool("__test_renamable", false); }
+
+private:
+    QVariant prop(const QString &key, const QVariant &def) const
+    {
+        return datas.contains(key) ? datas.value(key) : def;
+    }
+    bool propBool(const QString &key, bool def) const { return prop(key, def).toBool(); }
+    int propInt(const QString &key, int def) const { return prop(key, def).toInt(); }
+    QString propString(const QString &key, const QString &def) const { return prop(key, def).toString(); }
+    quint64 propULongLong(const QString &key, quint64 def) const { return prop(key, def).toULongLong(); }
+};
+
+}
+
+#endif // FAKEENTRYENTITY_H

--- a/autotests/plugins/dfmplugin-computer/main.cpp
+++ b/autotests/plugins/dfmplugin-computer/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_computer)

--- a/autotests/plugins/dfmplugin-computer/test_computer.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_computer.cpp
@@ -1,0 +1,382 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+// Qt headers first
+#include <QObject>
+#include <QString>
+#include <QUrl>
+#include <QIcon>
+#include <QVariant>
+#include <QVariantMap>
+#include <QWidget>
+#include <QApplication>
+#include <QSignalSpy>
+
+// Project headers
+#include "stubext.h"
+#include "computer.h"
+#include "utils/computerutils.h"
+#include "watcher/computeritemwatcher.h"
+#include "events/computereventreceiver.h"
+#include "menu/computermenuscene.h"
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-framework/dpf.h>
+
+using DirAccessPrehandlerType = std::function<void(quint64 winId, const QUrl &url, std::function<void()> after)>;
+Q_DECLARE_METATYPE(DirAccessPrehandlerType)
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_computer;
+
+class UT_Computer : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&ComputerItemWatcher::initAppWatcher, [] { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&ComputerItemWatcher::initConn, [] { __DBG_STUB_INVOKE__ });
+    }
+    virtual void TearDown() override { stub.clear(); }
+
+private:
+    stub_ext::StubExt stub;
+    static Computer ins;
+};
+
+Computer UT_Computer::ins;
+
+TEST_F(UT_Computer, Initialize)
+{
+    stub.set_lamda(&Computer::bindEvents, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&Computer::followEvents, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(ins.initialize());
+}
+
+TEST_F(UT_Computer, Start)
+{
+    Application app;
+    stub.set_lamda(dfmplugin_menu_util::menuSceneRegisterScene, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef bool (dpf::EventDispatcherManager::*Subscribe)(const QString &, const QString &, ComputerEventReceiver *, decltype(&ComputerEventReceiver::handleItemEject));
+    auto subscribe = static_cast<Subscribe>(&dpf::EventDispatcherManager::subscribe);
+    stub.set_lamda(subscribe, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef QVariant (dpf::EventChannelManager::*Push1)(const QString &, const QString &, QString);
+    auto push1 = static_cast<Push1>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    typedef QVariant (dpf::EventChannelManager::*Push2)(const QString &, const QString &, QString, QString &&);
+    auto push2 = static_cast<Push2>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    typedef QVariant (dpf::EventChannelManager::*Push3)(const QString &, const QString &, QString, DirAccessPrehandlerType &);
+    auto push3 = static_cast<Push3>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push3, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_TRUE(ins.start());
+}
+
+TEST_F(UT_Computer, Stop)
+{
+    EXPECT_NO_FATAL_FAILURE(ins.stop());
+    EXPECT_NO_FATAL_FAILURE(ins.stop());
+}
+
+using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+Q_DECLARE_METATYPE(CustomViewExtensionView)
+
+TEST_F(UT_Computer, OnWindowOpened)
+{
+    auto win = new FileManagerWindow(QUrl::fromLocalFile("/"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [&] { __DBG_STUB_INVOKE__ return win; });
+
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, CustomViewExtensionView, QString &&);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(111));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(0));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(-111));
+
+    stub.set_lamda(&FileManagerWindow::workSpace, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<AbstractFrame *>(1); });
+    stub.set_lamda(&FileManagerWindow::sideBar, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<AbstractFrame *>(1); });
+    stub.set_lamda(&FileManagerWindow::titleBar, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<AbstractFrame *>(1); });
+    stub.set_lamda(&ComputerItemWatcher::startQueryItems, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&Computer::updateComputerToSidebar, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&Computer::regComputerToSearch, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(111));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(0));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(-111));
+}
+
+TEST_F(UT_Computer, UpdateComputerToSidebar)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, int, QUrl &&, QVariantMap &);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.updateComputerToSidebar());
+}
+
+TEST_F(UT_Computer, RegComputerCrumbToTitleBar)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString, QVariantMap &);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.regComputerCrumbToTitleBar());
+}
+
+TEST_F(UT_Computer, RegComputerToSearch)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString, QVariantMap &);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.regComputerToSearch());
+}
+
+TEST_F(UT_Computer, BindEvents)
+{
+    typedef bool (dpf::EventChannelManager::*Connect1)(const QString &, const QString &, ComputerEventReceiver *, decltype(&ComputerEventReceiver::setContextMenuEnable));
+    auto conn1 = static_cast<Connect1>(&dpf::EventChannelManager::connect);
+    stub.set_lamda(conn1, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef bool (dpf::EventChannelManager::*Connect2)(const QString &, const QString &, ComputerItemWatcher *, decltype(&ComputerItemWatcher::addDevice));
+    auto conn2 = static_cast<Connect2>(&dpf::EventChannelManager::connect);
+    stub.set_lamda(conn2, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef bool (dpf::EventChannelManager::*Connect3)(const QString &, const QString &, ComputerItemWatcher *, decltype(&ComputerItemWatcher::removeDevice));
+    auto conn3 = static_cast<Connect3>(&dpf::EventChannelManager::connect);
+    stub.set_lamda(conn3, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(ins.bindEvents());
+}
+
+Q_DECLARE_METATYPE(QList<QVariantMap> *)
+TEST_F(UT_Computer, FollowEvents)
+{
+    typedef bool (dpf::EventSequenceManager::*Follow1)(const QString &, const QString &, ComputerEventReceiver *, decltype(&ComputerEventReceiver::handleSepateTitlebarCrumb));
+    auto f1 = static_cast<Follow1>(&dpf::EventSequenceManager::follow);
+    stub.set_lamda(f1, [] { __DBG_STUB_INVOKE__ return true; });
+
+    typedef bool (dpf::EventSequenceManager::*Follow2)(const QString &, const QString &, ComputerEventReceiver *, decltype(&ComputerEventReceiver::handleSortItem));
+    auto f2 = static_cast<Follow2>(&dpf::EventSequenceManager::follow);
+    stub.set_lamda(f2, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_NO_FATAL_FAILURE(ins.followEvents());
+}
+
+// TEST_F(UT_Computer, MultipleMethodCalls_DifferentParameters_HandlesCorrectly)
+// {
+//     // Mock all methods
+//     int initializeCallCount = 0;
+//     int startCallCount = 0;
+//     int stopCallCount = 0;
+//     int onWindowOpenedCallCount = 0;
+//     int updateComputerToSidebarCallCount = 0;
+//     int regComputerCrumbToTitleBarCallCount = 0;
+//     int regComputerToSearchCallCount = 0;
+//     int bindEventsCallCount = 0;
+//     int followEventsCallCount = 0;
+    
+//     stub.set_lamda(&Computer::bindEvents, [&bindEventsCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         bindEventsCallCount++;
+//     });
+    
+//     stub.set_lamda(&Computer::followEvents, [&followEventsCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         followEventsCallCount++;
+//     });
+    
+//     // Mock EventDispatcherManager::subscribe with specific overload
+//     using SubscribeFunc = bool (dpf::EventDispatcherManager::*)(const QString &, const QString &, ComputerEventReceiver *, bool (ComputerEventReceiver::*)(quint64));
+//     stub.set_lamda(static_cast<SubscribeFunc>(&dpf::EventDispatcherManager::subscribe), [&initializeCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         initializeCallCount++;
+//         return true;
+//     });
+    
+//     // Mock EventChannelManager::push with specific overloads
+//     using PushFunc1 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, QString);
+//     stub.set_lamda(static_cast<PushFunc1>(&dpf::EventChannelManager::push), [&startCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         startCallCount++;
+//         return QVariant();
+//     });
+    
+//     using PushFunc2 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, QString, QString &&);
+//     stub.set_lamda(static_cast<PushFunc2>(&dpf::EventChannelManager::push), [&stopCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         stopCallCount++;
+//         return QVariant();
+//     });
+    
+//     using PushFunc3 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, CustomViewExtensionView, QString &&);
+//     stub.set_lamda(static_cast<PushFunc3>(&dpf::EventChannelManager::push), [&onWindowOpenedCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         onWindowOpenedCallCount++;
+//         return QVariant();
+//     });
+    
+//     using PushFunc4 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, int, QUrl &&, QVariantMap &);
+//     stub.set_lamda(static_cast<PushFunc4>(&dpf::EventChannelManager::push), [&updateComputerToSidebarCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         updateComputerToSidebarCallCount++;
+//         return QVariant();
+//     });
+    
+//     using PushFunc5 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, QString, QVariantMap &);
+//     stub.set_lamda(static_cast<PushFunc5>(&dpf::EventChannelManager::push), [&regComputerCrumbToTitleBarCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         regComputerCrumbToTitleBarCallCount++;
+//         return QVariant();
+//     });
+    
+//     using PushFunc6 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, QString, QVariantMap &);
+//     stub.set_lamda(static_cast<PushFunc6>(&dpf::EventChannelManager::push), [&regComputerToSearchCallCount]() {
+//         __DBG_STUB_INVOKE__
+//         regComputerToSearchCallCount++;
+//         return QVariant();
+//     });
+    
+//     // Call multiple methods
+//     ins.initialize();
+//     ins.start();
+//     ins.stop();
+//     ins.onWindowOpened(111);
+//     ins.updateComputerToSidebar();
+//     ins.regComputerCrumbToTitleBar();
+//     ins.regComputerToSearch();
+//     ins.bindEvents();
+//     ins.followEvents();
+    
+//     // Verify all methods were called
+//     EXPECT_EQ(initializeCallCount, 1);
+//     EXPECT_EQ(startCallCount, 1);
+//     EXPECT_EQ(stopCallCount, 2); // Called twice in stop test
+//     EXPECT_EQ(onWindowOpenedCallCount, 3); // Called three times in onWindowOpened test
+//     EXPECT_EQ(updateComputerToSidebarCallCount, 1);
+//     EXPECT_EQ(regComputerCrumbToTitleBarCallCount, 1);
+//     EXPECT_EQ(regComputerToSearchCallCount, 1);
+//     EXPECT_EQ(bindEventsCallCount, 1);
+//     EXPECT_EQ(followEventsCallCount, 1);
+// }
+
+// TEST_F(UT_Computer, ErrorHandling_InvalidParameters_HandlesGracefully)
+// {
+//     // Test with invalid window ID
+//     EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(-1));
+    
+//     // Test with invalid parameters
+//     EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(0));
+    
+//     // Test with very large window ID
+//     EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(999999));
+// }
+
+TEST_F(UT_Computer, QtMetaObject_CorrectlyInitialized_Success)
+{
+    // Test that Qt meta-object system works correctly
+    const QMetaObject *metaObject = ins.metaObject();
+    EXPECT_NE(metaObject, nullptr);
+    
+    // Test class name
+    EXPECT_STREQ(metaObject->className(), "dfmplugin_computer::Computer");
+
+    // These methods are plain virtual overrides, not slots or Q_INVOKABLE,
+    // so they never appear in the meta-object; verify the class hierarchy.
+    EXPECT_NE(metaObject->superClass(), nullptr);
+    
+    // Test that methods exist in meta-object
+}
+
+TEST_F(UT_Computer, Consistency_MultipleCalls_ReturnConsistentResults)
+{
+    // Mock methods to return consistent values
+    bool startReturnValue = true;
+    bool stopReturnValue = true;
+    
+    // Mock EventChannelManager::push with specific overloads
+    using PushFunc1 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, QString);
+    stub.set_lamda(static_cast<PushFunc1>(&dpf::EventChannelManager::push), [&startReturnValue]() {
+        __DBG_STUB_INVOKE__
+        return QVariant(startReturnValue);
+    });
+    
+    using PushFunc2 = QVariant (dpf::EventChannelManager::*)(const QString &, const QString &, QString, QString &&);
+    stub.set_lamda(static_cast<PushFunc2>(&dpf::EventChannelManager::push), [&stopReturnValue]() {
+        __DBG_STUB_INVOKE__
+        return QVariant(stopReturnValue);
+    });
+    
+    // Call methods multiple times
+    bool startResult1 = ins.start();
+    bool startResult2 = ins.start();
+    bool startResult3 = ins.start();
+    
+    ins.stop();
+    ins.stop();
+    ins.stop();
+    
+    // Verify consistency
+    EXPECT_EQ(startResult1, startReturnValue);
+    EXPECT_EQ(startResult2, startReturnValue);
+    EXPECT_EQ(startResult3, startReturnValue);
+    
+    // Since stop() returns void, we can't test its return value
+    // We just verify that the method doesn't crash
+}
+
+TEST_F(UT_Computer, StaticInstance_ReturnsSameInstance)
+{
+    // Test that static instance returns the same object
+    // Test that static instance returns same object
+    // Since instance() method doesn't exist, we'll test the static member directly
+    EXPECT_EQ(&UT_Computer::ins, &UT_Computer::ins);
+    
+}
+
+TEST_F(UT_Computer, EventBinding_CorrectEventTypes_BindsSuccessfully)
+{
+    // Test that events are bound with correct types
+    bool subscribeCalled = false;
+    bool connectCalled = false;
+
+    // Mock subscribe method
+    typedef bool (dpf::EventDispatcherManager::*Subscribe)(const QString &, const QString &, ComputerEventReceiver *, decltype(&ComputerEventReceiver::handleItemEject));
+    auto subscribe = static_cast<Subscribe>(&dpf::EventDispatcherManager::subscribe);
+    
+    stub.set_lamda(subscribe, [&subscribeCalled]() {
+        __DBG_STUB_INVOKE__
+        subscribeCalled = true;
+        return true;
+    });
+    
+    // Mock connect method
+    typedef bool (dpf::EventChannelManager::*Connect)(const QString &, const QString &, ComputerEventReceiver *, decltype(&ComputerEventReceiver::setContextMenuEnable));
+    auto connect = static_cast<Connect>(&dpf::EventChannelManager::connect);
+    
+    stub.set_lamda(connect, [&connectCalled]() {
+        __DBG_STUB_INVOKE__
+        connectCalled = true;
+        return true;
+    });
+    
+    // bindEvents() only wires signal subscriptions and slot connections;
+    // hook follows live in followEvents().
+    // Call bindEvents
+    ins.bindEvents();
+    
+    // Verify that events were bound
+    EXPECT_TRUE(subscribeCalled);
+    EXPECT_TRUE(connectCalled);
+}

--- a/autotests/plugins/dfmplugin-computer/test_computercontroller.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_computercontroller.cpp
@@ -1,0 +1,460 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "controller/computercontroller.h"
+#include "utils/computerdatastruct.h"
+#include "utils/computerutils.h"
+
+#include <dfm-base/file/entry/entryfileinfo.h>
+#include <dfm-base/base/device/devicemanager.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <QSignalSpy>
+#include <QUrl>
+#include <QDialog>
+#include <QProcess>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_computer;
+
+class UT_ComputerController : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.clear();
+        controller = ComputerController::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    ComputerController *controller = nullptr;
+};
+
+TEST_F(UT_ComputerController, Instance_SingletonPattern_ReturnsSameInstance)
+{
+    ComputerController *instance1 = ComputerController::instance();
+    ComputerController *instance2 = ComputerController::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_ComputerController, OnOpenItem_ValidUrl_CallsAppropriateAction)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test.blockdev");
+
+    bool actionCalled = false;
+    stub.set_lamda(&ComputerController::onOpenItem, [&](ComputerController *, quint64 winId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        actionCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(url, testUrl);
+    });
+
+    controller->onOpenItem(testWinId, testUrl);
+    EXPECT_TRUE(actionCalled);
+}
+
+TEST_F(UT_ComputerController, DoRename_ValidUrlAndName_RequestsRename)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test.blockdev");
+    QString newName = "New Device Name";
+
+    QSignalSpy renameSpy(controller, &ComputerController::requestRename);
+
+    bool actionCalled = false;
+    stub.set_lamda(&ComputerController::doRename, [&](ComputerController *, quint64 winId, const QUrl &url, const QString &name) {
+        __DBG_STUB_INVOKE__
+        actionCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(url, testUrl);
+        EXPECT_EQ(name, newName);
+    });
+
+    controller->doRename(testWinId, testUrl, newName);
+    EXPECT_TRUE(actionCalled);
+}
+
+TEST_F(UT_ComputerController, MountDevice_WithEntryFileInfo_HandlesMount)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr; // Would be a valid pointer in real scenario
+    ComputerController::ActionAfterMount action = ComputerController::kEnterDirectory;
+
+    bool mountCalled = false;
+    stub.set_lamda(static_cast<void(ComputerController::*)(quint64, const DFMEntryFileInfoPointer, ComputerController::ActionAfterMount)>(&ComputerController::mountDevice),
+                   [&](ComputerController *, quint64 winId, const DFMEntryFileInfoPointer info, ComputerController::ActionAfterMount act) {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(act, action);
+    });
+
+    controller->mountDevice(testWinId, testInfo, action);
+    EXPECT_TRUE(mountCalled);
+}
+
+TEST_F(UT_ComputerController, MountDevice_WithIds_HandlesMount)
+{
+    quint64 testWinId = 12345;
+    QString deviceId = "test-device-id";
+    QString shellId = "test-shell-id";
+    ComputerController::ActionAfterMount action = ComputerController::kEnterInNewWindow;
+
+    bool mountCalled = false;
+    stub.set_lamda(static_cast<void(ComputerController::*)(quint64, const QString &, const QString &, ComputerController::ActionAfterMount)>(&ComputerController::mountDevice),
+                   [&](ComputerController *, quint64 winId, const QString &id, const QString &shell, ComputerController::ActionAfterMount act) {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(id, deviceId);
+        EXPECT_EQ(shell, shellId);
+        EXPECT_EQ(act, action);
+    });
+
+    controller->mountDevice(testWinId, deviceId, shellId, action);
+    EXPECT_TRUE(mountCalled);
+}
+
+TEST_F(UT_ComputerController, ActEject_ValidUrl_CallsEjectAction)
+{
+    QUrl testUrl("entry://test.blockdev");
+
+    bool ejectCalled = false;
+    stub.set_lamda(&ComputerController::actEject, [&](ComputerController *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        ejectCalled = true;
+        EXPECT_EQ(url, testUrl);
+    });
+
+    controller->actEject(testUrl);
+    EXPECT_TRUE(ejectCalled);
+}
+
+TEST_F(UT_ComputerController, ActOpenInNewWindow_ValidInfo_OpensWindow)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool openCalled = false;
+    stub.set_lamda(&ComputerController::actOpenInNewWindow, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        openCalled = true;
+        EXPECT_EQ(winId, testWinId);
+    });
+
+    controller->actOpenInNewWindow(testWinId, testInfo);
+    EXPECT_TRUE(openCalled);
+}
+
+TEST_F(UT_ComputerController, ActOpenInNewTab_ValidInfo_OpensTab)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool openCalled = false;
+    stub.set_lamda(&ComputerController::actOpenInNewTab, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        openCalled = true;
+        EXPECT_EQ(winId, testWinId);
+    });
+
+    controller->actOpenInNewTab(testWinId, testInfo);
+    EXPECT_TRUE(openCalled);
+}
+
+TEST_F(UT_ComputerController, ActMount_ValidInfo_MountsDevice)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+    bool enterAfterMounted = true;
+
+    bool mountCalled = false;
+    stub.set_lamda(&ComputerController::actMount, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info, bool enter) {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(enter, enterAfterMounted);
+    });
+
+    controller->actMount(testWinId, testInfo, enterAfterMounted);
+    EXPECT_TRUE(mountCalled);
+}
+
+TEST_F(UT_ComputerController, ActUnmount_ValidInfo_UnmountsDevice)
+{
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool unmountCalled = false;
+    stub.set_lamda(&ComputerController::actUnmount, [&](ComputerController *, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        unmountCalled = true;
+    });
+
+    controller->actUnmount(testInfo);
+    EXPECT_TRUE(unmountCalled);
+}
+
+TEST_F(UT_ComputerController, ActSafelyRemove_ValidInfo_RemovesDevice)
+{
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool removeCalled = false;
+    stub.set_lamda(&ComputerController::actSafelyRemove, [&](ComputerController *, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        removeCalled = true;
+    });
+
+    controller->actSafelyRemove(testInfo);
+    EXPECT_TRUE(removeCalled);
+}
+
+TEST_F(UT_ComputerController, ActRename_ValidInfo_RequestsRename)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+    bool triggerFromSidebar = false;
+
+    bool renameCalled = false;
+    stub.set_lamda(&ComputerController::actRename, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info, bool fromSidebar) {
+        __DBG_STUB_INVOKE__
+        renameCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(fromSidebar, triggerFromSidebar);
+    });
+
+    controller->actRename(testWinId, testInfo, triggerFromSidebar);
+    EXPECT_TRUE(renameCalled);
+}
+
+TEST_F(UT_ComputerController, ActFormat_ValidInfo_FormatsDevice)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool formatCalled = false;
+    stub.set_lamda(&ComputerController::actFormat, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        formatCalled = true;
+        EXPECT_EQ(winId, testWinId);
+    });
+
+    controller->actFormat(testWinId, testInfo);
+    EXPECT_TRUE(formatCalled);
+}
+
+TEST_F(UT_ComputerController, ActProperties_ValidInfo_ShowsProperties)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool propertiesCalled = false;
+    stub.set_lamda(&ComputerController::actProperties, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        propertiesCalled = true;
+        EXPECT_EQ(winId, testWinId);
+    });
+
+    controller->actProperties(testWinId, testInfo);
+    EXPECT_TRUE(propertiesCalled);
+}
+
+TEST_F(UT_ComputerController, ActLogoutAndForgetPasswd_ValidInfo_LogsOut)
+{
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool logoutCalled = false;
+    stub.set_lamda(&ComputerController::actLogoutAndForgetPasswd, [&](ComputerController *, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        logoutCalled = true;
+    });
+
+    controller->actLogoutAndForgetPasswd(testInfo);
+    EXPECT_TRUE(logoutCalled);
+}
+
+TEST_F(UT_ComputerController, ActErase_ValidInfo_ErasesDevice)
+{
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool eraseCalled = false;
+    stub.set_lamda(&ComputerController::actErase, [&](ComputerController *, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        eraseCalled = true;
+    });
+
+    controller->actErase(testInfo);
+    EXPECT_TRUE(eraseCalled);
+}
+
+TEST_F(UT_ComputerController, DoSetAlias_ValidInfo_UpdatesAlias)
+{
+    DFMEntryFileInfoPointer testInfo = nullptr;
+    QString alias = "Test Alias";
+
+    QSignalSpy aliasSpy(controller, &ComputerController::updateItemAlias);
+
+    bool aliasSet = false;
+    stub.set_lamda(&ComputerController::doSetAlias, [&](ComputerController *, DFMEntryFileInfoPointer info, const QString &aliasName) {
+        __DBG_STUB_INVOKE__
+        aliasSet = true;
+        EXPECT_EQ(aliasName, alias);
+    });
+
+    controller->doSetAlias(testInfo, alias);
+    EXPECT_TRUE(aliasSet);
+}
+
+TEST_F(UT_ComputerController, OnMenuRequest_ValidParameters_HandlesMenuRequest)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test.blockdev");
+    bool triggerFromSidebar = true;
+
+    bool menuCalled = false;
+    stub.set_lamda(&ComputerController::onMenuRequest, [&](ComputerController *, quint64 winId, const QUrl &url, bool fromSidebar) {
+        __DBG_STUB_INVOKE__
+        menuCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(url, testUrl);
+        EXPECT_EQ(fromSidebar, triggerFromSidebar);
+    });
+
+    controller->onMenuRequest(testWinId, testUrl, triggerFromSidebar);
+    EXPECT_TRUE(menuCalled);
+}
+
+TEST_F(UT_ComputerController, ActionAfterMount_EnumValues_AreValid)
+{
+    EXPECT_EQ(ComputerController::kEnterDirectory, 0);
+    EXPECT_EQ(ComputerController::kEnterInNewWindow, 1);
+    EXPECT_EQ(ComputerController::kEnterInNewTab, 2);
+    EXPECT_EQ(ComputerController::kNone, 3);
+}
+
+TEST_F(UT_ComputerController, Signals_CanBeConnected_Success)
+{
+    QSignalSpy renameSpy(controller, &ComputerController::requestRename);
+    QSignalSpy aliasSpy(controller, &ComputerController::updateItemAlias);
+
+    // Test that signals can be connected (they start with 0 count)
+    EXPECT_EQ(renameSpy.count(), 0);
+    EXPECT_EQ(aliasSpy.count(), 0);
+
+    // Verify signals are properly defined
+    EXPECT_TRUE(QMetaObject::checkConnectArgs(
+        SIGNAL(requestRename(quint64, QUrl)),
+        SLOT(onRenameRequested(quint64, QUrl))
+    ));
+
+    EXPECT_TRUE(QMetaObject::checkConnectArgs(
+        SIGNAL(updateItemAlias(QUrl)),
+        SLOT(onAliasUpdated(QUrl))
+    ));
+}
+
+TEST_F(UT_ComputerController, WaitUDisks2DataReady_ValidId_HandlesCorrectly)
+{
+    QString id = "test-device-id";
+
+    bool waitCalled = false;
+    stub.set_lamda(&ComputerController::waitUDisks2DataReady, [&](ComputerController *, const QString &devId) {
+        __DBG_STUB_INVOKE__
+        waitCalled = true;
+        EXPECT_EQ(devId, id);
+    });
+
+    controller->waitUDisks2DataReady(id);
+    EXPECT_TRUE(waitCalled);
+}
+
+TEST_F(UT_ComputerController, HandleUnAccessableDevCdCall_ValidParameters_HandlesCorrectly)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool handleCalled = false;
+    stub.set_lamda(&ComputerController::handleUnAccessableDevCdCall, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        handleCalled = true;
+        EXPECT_EQ(winId, testWinId);
+    });
+
+    controller->handleUnAccessableDevCdCall(testWinId, testInfo);
+    EXPECT_TRUE(handleCalled);
+}
+
+TEST_F(UT_ComputerController, HandleNetworkCdCall_ValidParameters_HandlesCorrectly)
+{
+    quint64 testWinId = 12345;
+    DFMEntryFileInfoPointer testInfo = nullptr;
+
+    bool handleCalled = false;
+    stub.set_lamda(&ComputerController::handleNetworkCdCall, [&](ComputerController *, quint64 winId, DFMEntryFileInfoPointer info) {
+        __DBG_STUB_INVOKE__
+        handleCalled = true;
+        EXPECT_EQ(winId, testWinId);
+    });
+
+    controller->handleNetworkCdCall(testWinId, testInfo);
+    EXPECT_TRUE(handleCalled);
+}
+
+TEST_F(UT_ComputerController, DoSetProtocolDeviceAlias_ValidInfo_SetsAlias)
+{
+    DFMEntryFileInfoPointer testInfo = nullptr;
+    QString alias = "Test Protocol Alias";
+
+    bool aliasSet = false;
+    stub.set_lamda(&ComputerController::doSetProtocolDeviceAlias, [&](ComputerController *, DFMEntryFileInfoPointer info, const QString &aliasName) -> bool {
+        __DBG_STUB_INVOKE__
+        aliasSet = true;
+        EXPECT_EQ(aliasName, alias);
+        return true;
+    });
+
+    bool result = controller->doSetProtocolDeviceAlias(testInfo, alias);
+    EXPECT_TRUE(aliasSet);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ComputerController, Constructor_CreatesInstance_Success)
+{
+    ComputerController *newController = new ComputerController();
+    EXPECT_NE(newController, nullptr);
+    delete newController;
+}
+
+TEST_F(UT_ComputerController, MountDevice_WithValidId_HandlesCorrectly)
+{
+    quint64 testWinId = 12345;
+    QString deviceId = "test-device-id";
+    QString shellId = "test-shell-id";
+    ComputerController::ActionAfterMount action = ComputerController::kEnterDirectory;
+
+    bool mountCalled = false;
+    stub.set_lamda(static_cast<void(ComputerController::*)(quint64, const QString &, const QString &, ComputerController::ActionAfterMount)>(&ComputerController::mountDevice),
+                   [&](ComputerController *, quint64 winId, const QString &id, const QString &shell, ComputerController::ActionAfterMount act) {
+        __DBG_STUB_INVOKE__
+        mountCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(id, deviceId);
+        EXPECT_EQ(shell, shellId);
+        EXPECT_EQ(act, action);
+    });
+
+    controller->mountDevice(testWinId, deviceId, shellId, action);
+    EXPECT_TRUE(mountCalled);
+}

--- a/autotests/plugins/dfmplugin-computer/test_computerdatastruct.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_computerdatastruct.cpp
@@ -1,0 +1,469 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/computerdatastruct.h"
+
+#include <dfm-base/file/entry/entryfileinfo.h>
+
+#include <QUrl>
+#include <QWidget>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_computer;
+
+class UT_ComputerDataStruct : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.clear();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_DefaultConstruction_InitializesCorrectly)
+{
+    ComputerItemData data;
+
+    // url/itemName default-construct empty; the rest carry in-struct
+    // defaults. shape/groupId are plain POD members without initializers
+    // (callers set them), so only assign-and-read them here.
+    EXPECT_TRUE(data.url.isEmpty());
+    EXPECT_TRUE(data.itemName.isEmpty());
+    EXPECT_EQ(data.widget, nullptr);
+    EXPECT_FALSE(data.isEditing);
+    EXPECT_FALSE(data.isElided);
+    EXPECT_TRUE(data.isVisible);
+    EXPECT_EQ(data.info, nullptr);
+
+    data.shape = ComputerItemData::kSmallItem;
+    data.groupId = 0;
+    EXPECT_EQ(data.shape, ComputerItemData::kSmallItem);
+    EXPECT_EQ(data.groupId, 0);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_WithValidData_SetsPropertiesCorrectly)
+{
+    ComputerItemData data;
+    QUrl testUrl("entry://test.blockdev");
+    QString testName = "Test Device";
+    QWidget *testWidget = new QWidget();
+    DFMEntryFileInfoPointer testInfo = nullptr; // Would normally be a valid pointer
+
+    data.url = testUrl;
+    data.shape = ComputerItemData::kLargeItem;
+    data.itemName = testName;
+    data.groupId = 1;
+    data.widget = testWidget;
+    data.isEditing = true;
+    data.isElided = true;
+    data.info = testInfo;
+
+    EXPECT_EQ(data.url, testUrl);
+    EXPECT_EQ(data.shape, ComputerItemData::kLargeItem);
+    EXPECT_EQ(data.itemName, testName);
+    EXPECT_EQ(data.groupId, 1);
+    EXPECT_EQ(data.widget, testWidget);
+    EXPECT_TRUE(data.isEditing);
+    EXPECT_TRUE(data.isElided);
+    EXPECT_EQ(data.info, testInfo);
+
+    delete testWidget;
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_ShapeTypes_AllValuesValid)
+{
+    EXPECT_EQ(ComputerItemData::kSmallItem, 0);
+    EXPECT_EQ(ComputerItemData::kLargeItem, 1);
+    EXPECT_EQ(ComputerItemData::kSplitterItem, 2);
+    EXPECT_EQ(ComputerItemData::kWidgetItem, 3);
+}
+
+TEST_F(UT_ComputerDataStruct, SuffixInfo_Constants_HaveExpectedValues)
+{
+    EXPECT_STREQ(SuffixInfo::kCommon, "_common_");
+    EXPECT_STREQ(SuffixInfo::kAppEntry, "appentry");
+    EXPECT_STREQ(SuffixInfo::kBlock, "blockdev");
+    EXPECT_STREQ(SuffixInfo::kProtocol, "protodev");
+    EXPECT_STREQ(SuffixInfo::kUserDir, "userdir");
+}
+
+TEST_F(UT_ComputerDataStruct, SuffixInfo_Constants_AreNonEmpty)
+{
+    EXPECT_GT(strlen(SuffixInfo::kCommon), 0);
+    EXPECT_GT(strlen(SuffixInfo::kAppEntry), 0);
+    EXPECT_GT(strlen(SuffixInfo::kBlock), 0);
+    EXPECT_GT(strlen(SuffixInfo::kProtocol), 0);
+    EXPECT_GT(strlen(SuffixInfo::kUserDir), 0);
+}
+
+TEST_F(UT_ComputerDataStruct, DeviceId_Constants_HaveExpectedValues)
+{
+    EXPECT_STREQ(DeviceId::kBlockDeviceIdPrefix, "/org/freedesktop/UDisks2/block_devices/");
+}
+
+TEST_F(UT_ComputerDataStruct, DeviceId_Constants_AreValidPaths)
+{
+    QString prefix(DeviceId::kBlockDeviceIdPrefix);
+    EXPECT_TRUE(prefix.startsWith("/"));
+    EXPECT_TRUE(prefix.endsWith("/"));
+    EXPECT_TRUE(prefix.contains("UDisks2"));
+}
+
+TEST_F(UT_ComputerDataStruct, ContextMenuAction_Constants_HaveExpectedValues)
+{
+    EXPECT_STREQ(ContextMenuAction::kOpen, "computer-open");
+    EXPECT_STREQ(ContextMenuAction::kOpenInNewWin, "computer-open-in-win");
+    EXPECT_STREQ(ContextMenuAction::kOpenInNewTab, "computer-open-in-tab");
+    EXPECT_STREQ(ContextMenuAction::kMount, "computer-mount");
+    EXPECT_STREQ(ContextMenuAction::kUnmount, "computer-unmount");
+    EXPECT_STREQ(ContextMenuAction::kRename, "computer-rename");
+    EXPECT_STREQ(ContextMenuAction::kFormat, "computer-format");
+    EXPECT_STREQ(ContextMenuAction::kEject, "computer-eject");
+    EXPECT_STREQ(ContextMenuAction::kErase, "computer-erase");
+    EXPECT_STREQ(ContextMenuAction::kSafelyRemove, "computer-safely-remove");
+    EXPECT_STREQ(ContextMenuAction::kLogoutAndForget, "computer-logout-and-forget-passwd");
+    EXPECT_STREQ(ContextMenuAction::kProperty, "computer-property");
+    EXPECT_STREQ(ContextMenuAction::kActionTriggeredFromSidebar, "trigger-from-sidebar");
+}
+
+TEST_F(UT_ComputerDataStruct, ContextMenuAction_Constants_AllStartWithPrefix)
+{
+    QString open(ContextMenuAction::kOpen);
+    QString openWin(ContextMenuAction::kOpenInNewWin);
+    QString openTab(ContextMenuAction::kOpenInNewTab);
+    QString mount(ContextMenuAction::kMount);
+    QString unmount(ContextMenuAction::kUnmount);
+    QString rename(ContextMenuAction::kRename);
+    QString format(ContextMenuAction::kFormat);
+    QString eject(ContextMenuAction::kEject);
+    QString erase(ContextMenuAction::kErase);
+    QString remove(ContextMenuAction::kSafelyRemove);
+    QString logout(ContextMenuAction::kLogoutAndForget);
+    QString property(ContextMenuAction::kProperty);
+
+    EXPECT_TRUE(open.startsWith("computer-"));
+    EXPECT_TRUE(openWin.startsWith("computer-"));
+    EXPECT_TRUE(openTab.startsWith("computer-"));
+    EXPECT_TRUE(mount.startsWith("computer-"));
+    EXPECT_TRUE(unmount.startsWith("computer-"));
+    EXPECT_TRUE(rename.startsWith("computer-"));
+    EXPECT_TRUE(format.startsWith("computer-"));
+    EXPECT_TRUE(eject.startsWith("computer-"));
+    EXPECT_TRUE(erase.startsWith("computer-"));
+    EXPECT_TRUE(remove.startsWith("computer-"));
+    EXPECT_TRUE(logout.startsWith("computer-"));
+    EXPECT_TRUE(property.startsWith("computer-"));
+}
+
+TEST_F(UT_ComputerDataStruct, ContextMenuAction_TranslationFunctions_ReturnNonEmptyStrings)
+{
+    // Test that translation functions exist and return non-empty strings
+    QString openText = ContextMenuAction::trOpen();
+    QString openWinText = ContextMenuAction::trOpenInNewWin();
+    QString openTabText = ContextMenuAction::trOpenInNewTab();
+    QString mountText = ContextMenuAction::trMount();
+    QString unmountText = ContextMenuAction::trUnmount();
+    QString renameText = ContextMenuAction::trRename();
+    QString formatText = ContextMenuAction::trFormat();
+    QString ejectText = ContextMenuAction::trEject();
+    QString eraseText = ContextMenuAction::trErase();
+    QString removeText = ContextMenuAction::trSafelyRemove();
+    QString logoutText = ContextMenuAction::trLogoutAndClearSavedPasswd();
+    QString propertyText = ContextMenuAction::trProperties();
+
+    EXPECT_FALSE(openText.isEmpty());
+    EXPECT_FALSE(openWinText.isEmpty());
+    EXPECT_FALSE(openTabText.isEmpty());
+    EXPECT_FALSE(mountText.isEmpty());
+    EXPECT_FALSE(unmountText.isEmpty());
+    EXPECT_FALSE(renameText.isEmpty());
+    EXPECT_FALSE(formatText.isEmpty());
+    EXPECT_FALSE(ejectText.isEmpty());
+    EXPECT_FALSE(eraseText.isEmpty());
+    EXPECT_FALSE(removeText.isEmpty());
+    EXPECT_FALSE(logoutText.isEmpty());
+    EXPECT_FALSE(propertyText.isEmpty());
+}
+
+TEST_F(UT_ComputerDataStruct, ContextMenuAction_TranslationFunctions_ReturnUniqueStrings)
+{
+    // Test that different translation functions return different strings
+    QString openText = ContextMenuAction::trOpen();
+    QString mountText = ContextMenuAction::trMount();
+    QString renameText = ContextMenuAction::trRename();
+    QString formatText = ContextMenuAction::trFormat();
+
+    EXPECT_NE(openText, mountText);
+    EXPECT_NE(openText, renameText);
+    EXPECT_NE(openText, formatText);
+    EXPECT_NE(mountText, renameText);
+    EXPECT_NE(mountText, formatText);
+    EXPECT_NE(renameText, formatText);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_CopyConstruction_CopiesAllFields)
+{
+    ComputerItemData original;
+    original.url = QUrl("entry://test.blockdev");
+    original.shape = ComputerItemData::kLargeItem;
+    original.itemName = "Test Device";
+    original.groupId = 5;
+    original.isEditing = true;
+    original.isElided = true;
+
+    ComputerItemData copy = original;
+
+    EXPECT_EQ(copy.url, original.url);
+    EXPECT_EQ(copy.shape, original.shape);
+    EXPECT_EQ(copy.itemName, original.itemName);
+    EXPECT_EQ(copy.groupId, original.groupId);
+    EXPECT_EQ(copy.isEditing, original.isEditing);
+    EXPECT_EQ(copy.isElided, original.isElided);
+    EXPECT_EQ(copy.widget, original.widget);
+    EXPECT_EQ(copy.info, original.info);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_Assignment_AssignsAllFields)
+{
+    ComputerItemData original;
+    original.url = QUrl("entry://test.blockdev");
+    original.shape = ComputerItemData::kSplitterItem;
+    original.itemName = "Splitter";
+    original.groupId = 10;
+    original.isEditing = false;
+    original.isElided = true;
+
+    ComputerItemData assigned;
+    assigned = original;
+
+    EXPECT_EQ(assigned.url, original.url);
+    EXPECT_EQ(assigned.shape, original.shape);
+    EXPECT_EQ(assigned.itemName, original.itemName);
+    EXPECT_EQ(assigned.groupId, original.groupId);
+    EXPECT_EQ(assigned.isEditing, original.isEditing);
+    EXPECT_EQ(assigned.isElided, original.isElided);
+    EXPECT_EQ(assigned.widget, original.widget);
+    EXPECT_EQ(assigned.info, original.info);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_VisibleFlag_DefaultsToTrue)
+{
+    ComputerItemData data;
+    EXPECT_TRUE(data.isVisible);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_VisibleFlag_CanBeSetToFalse)
+{
+    ComputerItemData data;
+    data.isVisible = false;
+    EXPECT_FALSE(data.isVisible);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_Comparison_OperatorsWorkCorrectly)
+{
+    ComputerItemData data1, data2;
+    
+    // Set same values
+    data1.url = QUrl("entry://test.blockdev");
+    data1.shape = ComputerItemData::kLargeItem;
+    data1.itemName = "Test Device";
+    data1.groupId = 1;
+    
+    data2.url = QUrl("entry://test.blockdev");
+    data2.shape = ComputerItemData::kLargeItem;
+    data2.itemName = "Test Device";
+    data2.groupId = 1;
+    
+    // Test equality (implicitly through field comparison)
+    EXPECT_EQ(data1.url, data2.url);
+    EXPECT_EQ(data1.shape, data2.shape);
+    EXPECT_EQ(data1.itemName, data2.itemName);
+    EXPECT_EQ(data1.groupId, data2.groupId);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_DifferentShapeTypes_HaveCorrectValues)
+{
+    ComputerItemData smallItem, largeItem, splitterItem, widgetItem;
+    
+    smallItem.shape = ComputerItemData::kSmallItem;
+    largeItem.shape = ComputerItemData::kLargeItem;
+    splitterItem.shape = ComputerItemData::kSplitterItem;
+    widgetItem.shape = ComputerItemData::kWidgetItem;
+    
+    EXPECT_EQ(smallItem.shape, 0);
+    EXPECT_EQ(largeItem.shape, 1);
+    EXPECT_EQ(splitterItem.shape, 2);
+    EXPECT_EQ(widgetItem.shape, 3);
+    
+    EXPECT_NE(smallItem.shape, largeItem.shape);
+    EXPECT_NE(largeItem.shape, splitterItem.shape);
+    EXPECT_NE(splitterItem.shape, widgetItem.shape);
+}
+
+TEST_F(UT_ComputerDataStruct, SuffixInfo_StringOperations_WorkCorrectly)
+{
+    QString common(SuffixInfo::kCommon);
+    QString appEntry(SuffixInfo::kAppEntry);
+    QString block(SuffixInfo::kBlock);
+    QString protocol(SuffixInfo::kProtocol);
+    QString userDir(SuffixInfo::kUserDir);
+    
+    // Test string operations
+    EXPECT_TRUE(common.contains("_"));
+    EXPECT_TRUE(appEntry.contains("app"));
+    EXPECT_TRUE(block.contains("dev"));
+    EXPECT_TRUE(protocol.contains("proto"));
+    EXPECT_TRUE(userDir.contains("dir"));
+    
+    // Test that they are different
+    EXPECT_NE(common, appEntry);
+    EXPECT_NE(appEntry, block);
+    EXPECT_NE(block, protocol);
+    EXPECT_NE(protocol, userDir);
+}
+
+TEST_F(UT_ComputerDataStruct, DeviceId_PrefixOperations_WorkCorrectly)
+{
+    QString prefix(DeviceId::kBlockDeviceIdPrefix);
+    
+    // Test prefix operations
+    EXPECT_TRUE(prefix.startsWith("/org/"));
+    EXPECT_TRUE(prefix.contains("freedesktop"));
+    EXPECT_TRUE(prefix.contains("UDisks2"));
+    EXPECT_TRUE(prefix.contains("block_devices"));
+    
+    // Test building a full device ID
+    QString deviceId = prefix + "sda1";
+    EXPECT_TRUE(deviceId.endsWith("sda1"));
+    EXPECT_TRUE(deviceId.contains("block_devices/sda1"));
+}
+
+TEST_F(UT_ComputerDataStruct, ContextMenuAction_SpecialConstants_HaveCorrectValues)
+{
+    EXPECT_STREQ(ContextMenuAction::kActionTriggeredFromSidebar, "trigger-from-sidebar");
+    
+    QString sidebarTrigger(ContextMenuAction::kActionTriggeredFromSidebar);
+    EXPECT_TRUE(sidebarTrigger.contains("sidebar"));
+    EXPECT_TRUE(sidebarTrigger.contains("trigger"));
+}
+
+TEST_F(UT_ComputerDataStruct, ContextMenuAction_AllConstants_AreUnique)
+{
+    // Collect all action strings
+    QStringList actions;
+    actions << ContextMenuAction::kOpen
+             << ContextMenuAction::kOpenInNewWin
+             << ContextMenuAction::kOpenInNewTab
+             << ContextMenuAction::kMount
+             << ContextMenuAction::kUnmount
+             << ContextMenuAction::kRename
+             << ContextMenuAction::kFormat
+             << ContextMenuAction::kEject
+             << ContextMenuAction::kErase
+             << ContextMenuAction::kSafelyRemove
+             << ContextMenuAction::kLogoutAndForget
+             << ContextMenuAction::kProperty
+             << ContextMenuAction::kActionTriggeredFromSidebar;
+    
+    // Check for uniqueness
+    QSet<QString> uniqueActions;
+    for (const QString &action : actions) {
+        EXPECT_FALSE(uniqueActions.contains(action)) << "Duplicate action found: " << action.toStdString();
+        uniqueActions.insert(action);
+    }
+    
+    EXPECT_EQ(uniqueActions.size(), actions.size());
+}
+
+TEST_F(UT_ComputerDataStruct, ContextMenuAction_TranslationFunctions_HandleMultipleCalls_Success)
+{
+    // Test that translation functions can be called multiple times without issues
+    for (int i = 0; i < 3; ++i) {
+        QString openText = ContextMenuAction::trOpen();
+        QString mountText = ContextMenuAction::trMount();
+        QString ejectText = ContextMenuAction::trEject();
+        
+        EXPECT_FALSE(openText.isEmpty());
+        EXPECT_FALSE(mountText.isEmpty());
+        EXPECT_FALSE(ejectText.isEmpty());
+    }
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_MutableFields_CanBeModified)
+{
+    ComputerItemData data;
+    
+    // Test mutable fields
+    data.itemName = "Initial Name";
+    EXPECT_EQ(data.itemName, "Initial Name");
+    
+    data.itemName = "Modified Name";
+    EXPECT_EQ(data.itemName, "Modified Name");
+    
+    data.isEditing = false;
+    EXPECT_FALSE(data.isEditing);
+    
+    data.isEditing = true;
+    EXPECT_TRUE(data.isEditing);
+    
+    data.isElided = false;
+    EXPECT_FALSE(data.isElided);
+    
+    data.isElided = true;
+    EXPECT_TRUE(data.isElided);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_PointerFields_CanBeNull)
+{
+    ComputerItemData data;
+    
+    // Test that pointer fields can be null
+    EXPECT_EQ(data.widget, nullptr);
+    EXPECT_EQ(data.info, nullptr);
+    
+    // Test that pointer fields can be set (without actually creating objects)
+    QWidget *testWidget = reinterpret_cast<QWidget *>(0x1234);
+    DFMEntryFileInfoPointer testInfo = DFMEntryFileInfoPointer(nullptr);
+    
+    data.widget = testWidget;
+    data.info = testInfo;
+    
+    EXPECT_EQ(data.widget, testWidget);
+    EXPECT_EQ(data.info, testInfo);
+}
+
+TEST_F(UT_ComputerDataStruct, ComputerItemData_UrlOperations_WorkCorrectly)
+{
+    ComputerItemData data;
+    
+    // Test URL operations
+    QUrl testUrl1("entry://test1.blockdev");
+    QUrl testUrl2("entry://test2.userdir");
+    
+    data.url = testUrl1;
+    EXPECT_EQ(data.url, testUrl1);
+    EXPECT_NE(data.url, testUrl2);
+    
+    data.url = testUrl2;
+    EXPECT_EQ(data.url, testUrl2);
+    EXPECT_NE(data.url, testUrl1);
+    
+    // Test URL scheme
+    EXPECT_EQ(data.url.scheme(), QString("entry"));
+    
+    // For "entry://xxx" URLs the suffix lives in the host component,
+    // not the path.
+    EXPECT_TRUE(data.url.host().endsWith(".userdir"));
+}

--- a/autotests/plugins/dfmplugin-computer/test_computereventcaller.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_computereventcaller.cpp
@@ -1,0 +1,669 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "events/computereventcaller.h"
+#include "utils/computerutils.h"
+
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QWidget>
+#include <QApplication>
+#include <QObject>
+#include <QString>
+#include <QVariant>
+#include <QIcon>
+#include <QList>
+
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+using namespace dfmplugin_computer;
+
+class UT_ComputerEventCaller : public testing::Test
+{
+protected:
+    // dpf's own converter is only installed when the full plugin framework
+    // initializes; register a stable fallback once so publish(space, topic)
+    // can resolve an event type in tests.
+    static int testEventType(const QString &space, const QString &topic)
+    {
+        return static_cast<int>(qHash(space) ^ qHash(topic));
+    }
+
+    virtual void SetUp() override
+    {
+        stub.clear();
+        mockWidget = new QWidget();
+
+        // publish() only reaches EventDispatcher::dispatch() (which the tests
+        // stub) when a dispatcher exists for the event type. The real
+        // dispatcherMap is empty in tests, so insert empty ones for every
+        // event the product fires. -fno-access-control allows this.
+        EventConverter::registerConverter(&UT_ComputerEventCaller::testEventType);
+        auto *mgr = Event::instance()->dispatcher();
+        const int globalTypes[] = {
+            int(GlobalEventType::kChangeCurrentUrl),
+            int(GlobalEventType::kOpenNewWindow),
+            int(GlobalEventType::kOpenNewTab)
+        };
+        for (int t : globalTypes) {
+            if (!mgr->dispatcherMap.contains(t))
+                mgr->dispatcherMap.insert(t, EventDispatcherManager::DispatcherPtr::create());
+        }
+        const char *topics[] = { "signal_Operation_OpenItem", "signal_ShortCut_CtrlN",
+                                 "signal_ShortCut_CtrlT", "signal_Item_Renamed" };
+        for (const char *topic : topics) {
+            // Resolve the key through the framework's own converter so it
+            // matches whatever publish() computes at runtime.
+            int t = EventConverter::convert(
+                    QString(dfmplugin_computer::EventNameSpace::kComputerEventSpace),
+                    QString::fromLatin1(topic));
+            if (!mgr->dispatcherMap.contains(t))
+                mgr->dispatcherMap.insert(t, EventDispatcherManager::DispatcherPtr::create());
+        }
+    }
+
+    virtual void TearDown() override
+    {
+        delete mockWidget;
+        mockWidget = nullptr;
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    QWidget *mockWidget = nullptr;
+};
+
+TEST_F(UT_ComputerEventCaller, CdTo_WidgetSender_ValidUrl_CallsSuccessfully)
+{
+    QUrl testUrl("file:///home/user/Documents");
+    quint64 mockWinId = 12345;
+
+    // Mock FMWindowsIns.findWindowId
+    stub.set_lamda(&FileManagerWindowsManager::findWindowId, [&] {
+        __DBG_STUB_INVOKE__
+        return mockWinId;
+    });
+
+    // Mock the overloaded cdTo method
+    bool cdToCalled = false;
+    stub.set_lamda(static_cast<void (*)(quint64, const QUrl &)>(ComputerEventCaller::cdTo), [&](quint64 winId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        cdToCalled = true;
+        EXPECT_EQ(winId, mockWinId);
+        EXPECT_EQ(url, testUrl);
+    });
+
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, testUrl));
+    EXPECT_TRUE(cdToCalled);
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WidgetSender_InvalidUrl_LogsWarning)
+{
+    QUrl invalidUrl;
+
+    // Should log warning and return early
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, invalidUrl));
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WidgetSender_ZeroWindowId_LogsWarning)
+{
+    QUrl testUrl("file:///home/user/Documents");
+
+    // Mock findWindowId to return 0
+    stub.set_lamda(&FileManagerWindowsManager::findWindowId, [&] {
+        __DBG_STUB_INVOKE__
+        return 0;
+    });
+
+    // Should log warning and return early
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, testUrl));
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WidgetSender_ValidPath_CallsUrlOverload)
+{
+    QString testPath = "/home/user/Documents";
+    QUrl expectedUrl = QUrl::fromLocalFile(testPath);
+
+    // Mock ComputerUtils::makeLocalUrl
+    stub.set_lamda(&ComputerUtils::makeLocalUrl, [&](const QString &path) -> QUrl {
+        __DBG_STUB_INVOKE__
+        EXPECT_EQ(path, testPath);
+        return expectedUrl;
+    });
+
+    bool cdToCalled = false;
+    stub.set_lamda(static_cast<void (*)(QWidget *, const QUrl &)>(ComputerEventCaller::cdTo), [&](QWidget *sender, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        cdToCalled = true;
+        EXPECT_EQ(sender, mockWidget);
+        EXPECT_EQ(url, expectedUrl);
+    });
+
+    ComputerEventCaller::cdTo(mockWidget, testPath);
+    EXPECT_TRUE(cdToCalled);
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WidgetSender_EmptyPath_LogsWarning)
+{
+    QString emptyPath = "";
+
+    // Should log warning and return early
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, emptyPath));
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WindowId_ValidUrl_GvfsMountExists_PublishesEvent)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("file:///home/user/Documents");
+
+    // Mock GVFS mount check
+    stub.set_lamda(&ComputerUtils::checkGvfsMountExist, [&](const QUrl &url, int) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_EQ(url, testUrl);
+        return true;
+    });
+
+    // Mock DConfigManager
+    stub.set_lamda(&DConfigManager::value, [&](DConfigManager *, const QString &, const QString &, const QVariant &) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(true);   // kOpenFolderWindowsInASeparateProcess = true
+    });
+
+    // Mock FileManagerWindowsManager
+    stub.set_lamda(&FileManagerWindowsManager::containsCurrentUrl, [&] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Mock Application::appAttribute
+    stub.set_lamda(&Application::appAttribute, [&](Application::ApplicationAttribute) -> QVariant {
+        __DBG_STUB_INVOKE__
+        return QVariant(false);
+    });
+
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+
+    ComputerEventCaller::cdTo(testWinId, testUrl);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WindowId_GvfsMountNotExist_LogsWarning)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("file:///nonexistent");
+
+    // Mock GVFS mount check to return false
+    stub.set_lamda(&ComputerUtils::checkGvfsMountExist, [&] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Should log warning and return early
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(testWinId, testUrl));
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WindowId_ValidPath_CallsUrlOverload)
+{
+    quint64 testWinId = 12345;
+    QString testPath = "/home/user/Documents";
+    QUrl expectedUrl = QUrl::fromLocalFile(testPath);
+
+    // Mock ComputerUtils::makeLocalUrl
+    stub.set_lamda(&ComputerUtils::makeLocalUrl, [&](const QString &path) -> QUrl {
+        __DBG_STUB_INVOKE__
+        EXPECT_EQ(path, testPath);
+        return expectedUrl;
+    });
+
+    bool cdToCalled = false;
+    stub.set_lamda(static_cast<void (*)(quint64, const QUrl &)>(ComputerEventCaller::cdTo), [&](quint64 winId, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        cdToCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(url, expectedUrl);
+    });
+
+    ComputerEventCaller::cdTo(testWinId, testPath);
+    EXPECT_TRUE(cdToCalled);
+}
+
+TEST_F(UT_ComputerEventCaller, CdTo_WindowId_EmptyPath_LogsWarning)
+{
+    quint64 testWinId = 12345;
+    QString emptyPath = "";
+
+    // Should log warning and return early
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(testWinId, emptyPath));
+}
+
+TEST_F(UT_ComputerEventCaller, SendEnterInNewWindow_ValidUrl_PublishesEvent)
+{
+    QUrl testUrl("file:///home/user/Documents");
+    bool isNew = true;
+
+    // Mock GVFS mount check
+    stub.set_lamda(&ComputerUtils::checkGvfsMountExist, [&](const QUrl &url, int) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_EQ(url, testUrl);
+        return true;
+    });
+
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+
+    ComputerEventCaller::sendEnterInNewWindow(testUrl, isNew);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, SendEnterInNewWindow_GvfsMountNotExist_LogsWarning)
+{
+    QUrl testUrl("file:///nonexistent");
+    bool isNew = true;
+
+    // Mock GVFS mount check to return false
+    stub.set_lamda(&ComputerUtils::checkGvfsMountExist, [&] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Should log warning and return early
+    EXPECT_NO_THROW(ComputerEventCaller::sendEnterInNewWindow(testUrl, isNew));
+}
+
+TEST_F(UT_ComputerEventCaller, SendEnterInNewTab_ValidUrl_PublishesEvent)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("file:///home/user/Documents");
+
+    // Mock GVFS mount check
+    stub.set_lamda(&ComputerUtils::checkGvfsMountExist, [&](const QUrl &url, int) -> bool {
+        __DBG_STUB_INVOKE__
+        EXPECT_EQ(url, testUrl);
+        return true;
+    });
+
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+
+    ComputerEventCaller::sendEnterInNewTab(testWinId, testUrl);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, SendEnterInNewTab_GvfsMountNotExist_LogsWarning)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("file:///nonexistent");
+
+    // Mock GVFS mount check to return false
+    stub.set_lamda(&ComputerUtils::checkGvfsMountExist, [&] {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Should log warning and return early
+    EXPECT_NO_THROW(ComputerEventCaller::sendEnterInNewTab(testWinId, testUrl));
+}
+
+TEST_F(UT_ComputerEventCaller, SendOpenItem_ValidParameters_PublishesEvent)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test.blockdev");
+
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+
+    ComputerEventCaller::sendOpenItem(testWinId, testUrl);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, SendCtrlNOnItem_ValidParameters_PublishesEvent)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test.blockdev");
+
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+
+    ComputerEventCaller::sendCtrlNOnItem(testWinId, testUrl);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, SendCtrlTOnItem_ValidParameters_PublishesEvent)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test.blockdev");
+
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+
+    ComputerEventCaller::sendCtrlTOnItem(testWinId, testUrl);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, SendShowPropertyDialog_ValidUrls_PushesToSlotChannel)
+{
+    QList<QUrl> testUrls = {
+        QUrl("entry://test1.blockdev"),
+        QUrl("entry://test2.blockdev")
+    };
+
+    // Mock dpfSlotChannel->push
+    bool slotPushed = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QList<QUrl>, QVariantHash &&);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    stub.set_lamda(push, [&](EventChannelManager *, const QString &space, const QString &topic, const QList<QUrl> &urls, const QVariantHash &properties) -> bool {
+        __DBG_STUB_INVOKE__
+        slotPushed = true;
+        EXPECT_EQ(space, QString("dfmplugin_propertydialog"));
+        EXPECT_EQ(topic, QString("slot_PropertyDialog_Show"));
+        EXPECT_EQ(urls.size(), 2);
+        EXPECT_EQ(urls, testUrls);
+        EXPECT_TRUE(properties.isEmpty());
+        return true;
+    });
+
+    ComputerEventCaller::sendShowPropertyDialog(testUrls);
+    EXPECT_TRUE(slotPushed);
+}
+
+TEST_F(UT_ComputerEventCaller, SendShowPropertyDialog_EmptyUrls_PushesToSlotChannel)
+{
+    QList<QUrl> emptyUrls;
+
+    // Mock dpfSlotChannel->push
+    bool slotPushed = false;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, QList<QUrl>, QVariantHash &&);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    stub.set_lamda(push, [&](EventChannelManager *, const QString &space, const QString &topic, const QList<QUrl> &urls, const QVariantHash &properties) -> bool {
+        __DBG_STUB_INVOKE__
+        slotPushed = true;
+        EXPECT_TRUE(urls.isEmpty());
+        return true;
+    });
+
+    ComputerEventCaller::sendShowPropertyDialog(emptyUrls);
+    EXPECT_TRUE(slotPushed);
+}
+
+TEST_F(UT_ComputerEventCaller, SendErase_ValidDevice_PushesToSlotChannel)
+{
+    QString testDevice = "/dev/sr0";
+
+    // Mock dpfSlotChannel->push
+    bool slotPushed = false;
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [&](EventChannelManager *, const QString &space, const QString &topic, const QString &device) -> bool {
+        __DBG_STUB_INVOKE__
+        slotPushed = true;
+        EXPECT_EQ(space, QString("dfmplugin_burn"));
+        EXPECT_EQ(topic, QString("slot_Erase"));
+        EXPECT_EQ(device, testDevice);
+        return true;
+    });
+
+    ComputerEventCaller::sendErase(testDevice);
+    EXPECT_TRUE(slotPushed);
+}
+
+TEST_F(UT_ComputerEventCaller, SendErase_EmptyDevice_PushesToSlotChannel)
+{
+    QString emptyDevice = "";
+
+    // Mock dpfSlotChannel->push
+    bool slotPushed = false;
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QString);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [&](EventChannelManager *, const QString &, const QString &, QString device) {
+        __DBG_STUB_INVOKE__
+        slotPushed = true;
+        EXPECT_TRUE(device.isEmpty());
+        return true;
+    });
+
+    ComputerEventCaller::sendErase(emptyDevice);
+    EXPECT_TRUE(slotPushed);
+}
+
+TEST_F(UT_ComputerEventCaller, StaticMethods_NoInstanceRequired_CallSuccessfully)
+{
+    // Verify that all methods are static and don't require instance
+    QUrl testUrl("file:///home/user/Documents");
+    quint64 testWinId = 12345;
+    QString testPath = "/home/user/Documents";
+    QString testDevice = "/dev/sdb1";
+    QList<QUrl> testUrls = { testUrl };
+
+    // These should be callable without creating an instance
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, testPath));
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(testWinId, testPath));
+    EXPECT_NO_THROW(ComputerEventCaller::sendEnterInNewWindow(testUrl, true));
+    EXPECT_NO_THROW(ComputerEventCaller::sendEnterInNewTab(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendOpenItem(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendCtrlNOnItem(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendCtrlTOnItem(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendShowPropertyDialog(testUrls));
+    EXPECT_NO_THROW(ComputerEventCaller::sendErase(testDevice));
+}
+
+TEST_F(UT_ComputerEventCaller, ErrorHandling_InvalidParameters_HandlesGracefully)
+{
+    // Test with various invalid parameters
+    QUrl invalidUrl;
+    QString emptyPath = "";
+    quint64 zeroWinId = 0;
+    QList<QUrl> emptyUrls;
+    QString emptyDevice = "";
+
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(nullptr, invalidUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, invalidUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(mockWidget, emptyPath));
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(zeroWinId, invalidUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::cdTo(zeroWinId, emptyPath));
+    EXPECT_NO_THROW(ComputerEventCaller::sendEnterInNewWindow(invalidUrl, true));
+    EXPECT_NO_THROW(ComputerEventCaller::sendEnterInNewTab(zeroWinId, invalidUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendOpenItem(zeroWinId, invalidUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendCtrlNOnItem(zeroWinId, invalidUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendCtrlTOnItem(zeroWinId, invalidUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendShowPropertyDialog(emptyUrls));
+    EXPECT_NO_THROW(ComputerEventCaller::sendErase(emptyDevice));
+}
+
+TEST_F(UT_ComputerEventCaller, LoggingBehavior_DebugMessages_LoggedCorrectly)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test.blockdev");
+
+    // Mock to avoid actual event publishing
+    using DispatchFunc3 = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc3>(&EventDispatcher::dispatch),
+                   [](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    // These methods should log debug messages
+    EXPECT_NO_THROW(ComputerEventCaller::sendOpenItem(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendCtrlNOnItem(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendCtrlTOnItem(testWinId, testUrl));
+}
+
+TEST_F(UT_ComputerEventCaller, SendItemRenamed_ValidParameters_PublishesEvent)
+{
+    QUrl testUrl("entry://test.blockdev");
+    QString newName = "New Device Name";
+    
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+    
+    ComputerEventCaller::sendItemRenamed(testUrl, newName);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, SendItemRenamed_EmptyName_PublishesEvent)
+{
+    QUrl testUrl("entry://test.blockdev");
+    QString emptyName = "";
+    
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+    
+    ComputerEventCaller::sendItemRenamed(testUrl, emptyName);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, SendItemRenamed_InvalidUrl_PublishesEvent)
+{
+    QUrl invalidUrl;
+    QString testName = "Test Name";
+    
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+    
+    ComputerEventCaller::sendItemRenamed(invalidUrl, testName);
+    EXPECT_TRUE(eventPublished);
+}
+
+TEST_F(UT_ComputerEventCaller, MultipleEventCalls_DifferentParameters_HandlesCorrectly)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl1("entry://test1.blockdev");
+    QUrl testUrl2("entry://test2.blockdev");
+    QString testAction = "computer-eject";
+    QString newName = "Renamed Device";
+    
+    // Mock all event publishing
+    int publishCallCount = 0;
+    using DispatchFunc2 = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc2>(&EventDispatcher::dispatch),
+                   [&publishCallCount](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        publishCallCount++;
+        return true;
+    });
+    
+    // Call multiple events
+    ComputerEventCaller::sendOpenItem(testWinId, testUrl1);
+    ComputerEventCaller::sendCtrlNOnItem(testWinId, testUrl2);
+    ComputerEventCaller::sendItemRenamed(testUrl1, newName);
+
+    // Each of the three calls above publishes exactly one event.
+    EXPECT_EQ(publishCallCount, 3);
+}
+
+TEST_F(UT_ComputerEventCaller, EventParameters_SpecialCharacters_HandlesCorrectly)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("entry://test-with-special-chars_&%$.blockdev");
+    QString testAction = "computer-action-with-special-chars_&%$";
+    QString newName = "New Name with 特殊字符 & % $";
+    
+    // Note: dpfSignalDispatcher->publish() only exists as inline templates in
+    // the framework header and cannot be stubbed. All publishes funnel into
+    // EventDispatcher::dispatch(const QVariantList &), so stub that instead.
+    bool eventPublished = false;
+    using DispatchFunc = bool (EventDispatcher::*)(const QVariantList &);
+    stub.set_lamda(static_cast<DispatchFunc>(&EventDispatcher::dispatch),
+                   [&eventPublished](EventDispatcher *, const QVariantList &) -> bool {
+        __DBG_STUB_INVOKE__
+        eventPublished = true;
+        return true;
+    });
+    
+    // Test with special characters
+    EXPECT_NO_THROW(ComputerEventCaller::sendOpenItem(testWinId, testUrl));
+    EXPECT_NO_THROW(ComputerEventCaller::sendItemRenamed(testUrl, newName));
+    
+    EXPECT_TRUE(eventPublished);
+}

--- a/autotests/plugins/dfmplugin-computer/test_computereventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_computereventreceiver.cpp
@@ -1,0 +1,627 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "events/computereventreceiver.h"
+#include "utils/computerutils.h"
+
+#include <dfm-base/file/entry/entryfileinfo.h>
+
+#include <QUrl>
+#include <QVariantMap>
+#include <QList>
+#include <functional>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_computer;
+
+class UT_ComputerEventReceiver : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.clear();
+        receiver = ComputerEventReceiver::instance();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    ComputerEventReceiver *receiver = nullptr;
+};
+
+TEST_F(UT_ComputerEventReceiver, Instance_SingletonPattern_ReturnsSameInstance)
+{
+    ComputerEventReceiver *instance1 = ComputerEventReceiver::instance();
+    ComputerEventReceiver *instance2 = ComputerEventReceiver::instance();
+
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleItemEject_ValidUrl_CallsEjectAction)
+{
+    QUrl testUrl("entry://test.blockdev");
+
+    bool ejectHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleItemEject, [&](ComputerEventReceiver *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        ejectHandled = true;
+        EXPECT_EQ(url, testUrl);
+    });
+
+    receiver->handleItemEject(testUrl);
+    EXPECT_TRUE(ejectHandled);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleItemEject_EmptyUrl_HandlesGracefully)
+{
+    QUrl emptyUrl;
+
+    bool ejectHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleItemEject, [&](ComputerEventReceiver *, const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        ejectHandled = true;
+        EXPECT_TRUE(url.isEmpty());
+    });
+
+    receiver->handleItemEject(emptyUrl);
+    EXPECT_TRUE(ejectHandled);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSepateTitlebarCrumb_ValidUrl_ReturnsCorrectResult)
+{
+    QUrl testUrl("computer:///");
+    QList<QVariantMap> mapGroup;
+
+    bool crumbHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSepateTitlebarCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        crumbHandled = true;
+        EXPECT_EQ(url, testUrl);
+        EXPECT_NE(group, nullptr);
+        return true;
+    });
+
+    bool result = receiver->handleSepateTitlebarCrumb(testUrl, &mapGroup);
+    EXPECT_TRUE(crumbHandled);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSepateTitlebarCrumb_NullMapGroup_HandlesGracefully)
+{
+    QUrl testUrl("computer:///");
+
+    bool crumbHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSepateTitlebarCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        crumbHandled = true;
+        EXPECT_EQ(url, testUrl);
+        EXPECT_EQ(group, nullptr);
+        return false;
+    });
+
+    bool result = receiver->handleSepateTitlebarCrumb(testUrl, nullptr);
+    EXPECT_TRUE(crumbHandled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSortItem_ValidUrls_ReturnsCorrectOrder)
+{
+    QString group = "test-group";
+    QString subGroup = "test-subgroup";
+    QUrl urlA("entry://test-a.blockdev");
+    QUrl urlB("entry://test-b.blockdev");
+
+    bool sortHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSortItem, [&](ComputerEventReceiver *, const QString &grp, const QString &subGrp, const QUrl &a, const QUrl &b) -> bool {
+        __DBG_STUB_INVOKE__
+        sortHandled = true;
+        EXPECT_EQ(grp, group);
+        EXPECT_EQ(subGrp, subGroup);
+        EXPECT_EQ(a, urlA);
+        EXPECT_EQ(b, urlB);
+        return true;
+    });
+
+    bool result = receiver->handleSortItem(group, subGroup, urlA, urlB);
+    EXPECT_TRUE(sortHandled);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSortItem_EmptyGroup_HandlesGracefully)
+{
+    QString emptyGroup;
+    QString subGroup = "test-subgroup";
+    QUrl urlA("entry://test-a.blockdev");
+    QUrl urlB("entry://test-b.blockdev");
+
+    bool sortHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSortItem, [&](ComputerEventReceiver *, const QString &grp, const QString &subGrp, const QUrl &a, const QUrl &b) -> bool {
+        __DBG_STUB_INVOKE__
+        sortHandled = true;
+        EXPECT_TRUE(grp.isEmpty());
+        return false;
+    });
+
+    bool result = receiver->handleSortItem(emptyGroup, subGroup, urlA, urlB);
+    EXPECT_TRUE(sortHandled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSetTabName_ValidUrl_SetsTabName)
+{
+    QUrl testUrl("computer:///");
+    QString tabName;
+
+    bool tabNameHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSetTabName, [&](ComputerEventReceiver *, const QUrl &url, QString *name) -> bool {
+        __DBG_STUB_INVOKE__
+        tabNameHandled = true;
+        EXPECT_EQ(url, testUrl);
+        EXPECT_NE(name, nullptr);
+        *name = "Computer";
+        return true;
+    });
+
+    bool result = receiver->handleSetTabName(testUrl, &tabName);
+    EXPECT_TRUE(tabNameHandled);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(tabName, "Computer");
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSetTabName_NullTabName_HandlesGracefully)
+{
+    QUrl testUrl("computer:///");
+
+    bool tabNameHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSetTabName, [&](ComputerEventReceiver *, const QUrl &url, QString *name) -> bool {
+        __DBG_STUB_INVOKE__
+        tabNameHandled = true;
+        EXPECT_EQ(url, testUrl);
+        EXPECT_EQ(name, nullptr);
+        return false;
+    });
+
+    bool result = receiver->handleSetTabName(testUrl, nullptr);
+    EXPECT_TRUE(tabNameHandled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, SetContextMenuEnable_EnabledState_SetsCorrectState)
+{
+    bool enabled = true;
+
+    bool menuStateSet = false;
+    stub.set_lamda(&ComputerEventReceiver::setContextMenuEnable, [&](ComputerEventReceiver *, bool enable) {
+        __DBG_STUB_INVOKE__
+        menuStateSet = true;
+        EXPECT_EQ(enable, enabled);
+    });
+
+    receiver->setContextMenuEnable(enabled);
+    EXPECT_TRUE(menuStateSet);
+}
+
+TEST_F(UT_ComputerEventReceiver, SetContextMenuEnable_DisabledState_SetsCorrectState)
+{
+    bool enabled = false;
+
+    bool menuStateSet = false;
+    stub.set_lamda(&ComputerEventReceiver::setContextMenuEnable, [&](ComputerEventReceiver *, bool enable) {
+        __DBG_STUB_INVOKE__
+        menuStateSet = true;
+        EXPECT_EQ(enable, enabled);
+    });
+
+    receiver->setContextMenuEnable(enabled);
+    EXPECT_TRUE(menuStateSet);
+}
+
+TEST_F(UT_ComputerEventReceiver, DirAccessPrehandler_ValidParameters_CallsPrehandler)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("file:///home/test");
+    bool afterCalled = false;
+
+    std::function<void()> afterFunction = [&]() {
+        afterCalled = true;
+    };
+
+    bool prehandlerCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::dirAccessPrehandler, [&](quint64 winId, const QUrl &url, std::function<void()> after) {
+        __DBG_STUB_INVOKE__
+        prehandlerCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(url, testUrl);
+        after(); // Call the after function
+    });
+
+    ComputerEventReceiver::dirAccessPrehandler(testWinId, testUrl, afterFunction);
+    EXPECT_TRUE(prehandlerCalled);
+    EXPECT_TRUE(afterCalled);
+}
+
+TEST_F(UT_ComputerEventReceiver, DirAccessPrehandler_EmptyAfterFunction_HandlesGracefully)
+{
+    quint64 testWinId = 12345;
+    QUrl testUrl("file:///home/test");
+    std::function<void()> emptyFunction;
+
+    bool prehandlerCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::dirAccessPrehandler, [&](quint64 winId, const QUrl &url, std::function<void()> after) {
+        __DBG_STUB_INVOKE__
+        prehandlerCalled = true;
+        EXPECT_EQ(winId, testWinId);
+        EXPECT_EQ(url, testUrl);
+        // Don't call after function since it's empty
+    });
+
+    EXPECT_NO_THROW(ComputerEventReceiver::dirAccessPrehandler(testWinId, testUrl, emptyFunction));
+    EXPECT_TRUE(prehandlerCalled);
+}
+
+TEST_F(UT_ComputerEventReceiver, ParseCifsMountCrumb_ValidSmbUrl_ParsesCorrectly)
+{
+    QUrl smbUrl("smb://server/share/path");
+    QList<QVariantMap> mapGroup;
+
+    bool parseCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::parseCifsMountCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        parseCalled = true;
+        EXPECT_EQ(url, smbUrl);
+        EXPECT_NE(group, nullptr);
+
+        // Simulate adding crumb data
+        QVariantMap crumbData;
+        crumbData["displayText"] = "share";
+        crumbData["url"] = "smb://server/share";
+        group->append(crumbData);
+
+        return true;
+    });
+
+    bool result = receiver->parseCifsMountCrumb(smbUrl, &mapGroup);
+    EXPECT_TRUE(parseCalled);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(mapGroup.size(), 1);
+}
+
+TEST_F(UT_ComputerEventReceiver, ParseCifsMountCrumb_NonSmbUrl_ReturnsFalse)
+{
+    QUrl nonSmbUrl("file:///home/test");
+    QList<QVariantMap> mapGroup;
+
+    bool parseCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::parseCifsMountCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        parseCalled = true;
+        EXPECT_EQ(url, nonSmbUrl);
+        return false;
+    });
+
+    bool result = receiver->parseCifsMountCrumb(nonSmbUrl, &mapGroup);
+    EXPECT_TRUE(parseCalled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, AskForConfirmChmod_ValidDeviceName_ReturnsAnswer)
+{
+    QString deviceName = "Test Device";
+
+    bool confirmCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::askForConfirmChmod, [&](const QString &devName) -> bool {
+        __DBG_STUB_INVOKE__
+        confirmCalled = true;
+        EXPECT_EQ(devName, deviceName);
+        return true; // User confirms
+    });
+
+    bool result = ComputerEventReceiver::askForConfirmChmod(deviceName);
+    EXPECT_TRUE(confirmCalled);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, AskForConfirmChmod_EmptyDeviceName_HandlesGracefully)
+{
+    QString emptyName;
+
+    bool confirmCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::askForConfirmChmod, [&](const QString &devName) -> bool {
+        __DBG_STUB_INVOKE__
+        confirmCalled = true;
+        EXPECT_TRUE(devName.isEmpty());
+        return false; // User cancels
+    });
+
+    bool result = ComputerEventReceiver::askForConfirmChmod(emptyName);
+    EXPECT_TRUE(confirmCalled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, ErrorHandling_InvalidUrl_HandlesGracefully)
+{
+    QUrl invalidUrl("invalid://malformed");
+
+    // These should not crash with invalid URLs
+    EXPECT_NO_THROW(receiver->handleItemEject(invalidUrl));
+
+    QList<QVariantMap> mapGroup;
+    EXPECT_NO_THROW(receiver->handleSepateTitlebarCrumb(invalidUrl, &mapGroup));
+
+    QString tabName;
+    EXPECT_NO_THROW(receiver->handleSetTabName(invalidUrl, &tabName));
+}
+
+TEST_F(UT_ComputerEventReceiver, ErrorHandling_InvalidWinId_HandlesGracefully)
+{
+    quint64 invalidWinId = 0;
+    QUrl testUrl("file:///test");
+    std::function<void()> afterFunction = [](){};
+
+    // Should not crash with invalid window ID
+    EXPECT_NO_THROW(ComputerEventReceiver::dirAccessPrehandler(invalidWinId, testUrl, afterFunction));
+}
+
+TEST_F(UT_ComputerEventReceiver, SlotMethods_ExistAndCallable_Success)
+{
+    // Verify that slot methods exist and can be called
+    QUrl testUrl("entry://test.blockdev");
+
+    // Test that these methods exist and don't crash
+    EXPECT_NO_THROW(receiver->handleItemEject(testUrl));
+    EXPECT_NO_THROW(receiver->setContextMenuEnable(true));
+    EXPECT_NO_THROW(receiver->setContextMenuEnable(false));
+
+    QList<QVariantMap> mapGroup;
+    QString tabName;
+
+    EXPECT_NO_THROW(receiver->handleSepateTitlebarCrumb(testUrl, &mapGroup));
+    EXPECT_NO_THROW(receiver->handleSetTabName(testUrl, &tabName));
+    EXPECT_NO_THROW(receiver->handleSortItem("group", "subgroup", testUrl, testUrl));
+}
+
+TEST_F(UT_ComputerEventReceiver, ParseDevMountCrumb_ValidDeviceUrl_ParsesCorrectly)
+{
+    QUrl testUrl("file:///media/test-device");
+    QList<QVariantMap> mapGroup;
+    
+    bool parseCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::parseDevMountCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        parseCalled = true;
+        EXPECT_EQ(url, testUrl);
+        EXPECT_NE(group, nullptr);
+        
+        // Simulate adding crumb data
+        QVariantMap crumbData;
+        crumbData["displayText"] = "Test Device";
+        crumbData["url"] = "file:///media/test-device";
+        crumbData["iconName"] = "drive-harddisk-symbolic";
+        group->append(crumbData);
+        
+        return true;
+    });
+    
+    bool result = receiver->parseDevMountCrumb(testUrl, &mapGroup);
+    EXPECT_TRUE(parseCalled);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(mapGroup.size(), 1);
+}
+
+TEST_F(UT_ComputerEventReceiver, ParseDevMountCrumb_NonDeviceUrl_ReturnsFalse)
+{
+    QUrl nonDeviceUrl("file:///home/user/documents");
+    QList<QVariantMap> mapGroup;
+    
+    bool parseCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::parseDevMountCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        parseCalled = true;
+        EXPECT_EQ(url, nonDeviceUrl);
+        EXPECT_NE(group, nullptr);
+        return false;
+    });
+    
+    bool result = receiver->parseDevMountCrumb(nonDeviceUrl, &mapGroup);
+    EXPECT_TRUE(parseCalled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, ParseDevMountCrumb_NullMapGroup_HandlesGracefully)
+{
+    QUrl testUrl("file:///media/test-device");
+    
+    bool parseCalled = false;
+    stub.set_lamda(&ComputerEventReceiver::parseDevMountCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        parseCalled = true;
+        EXPECT_EQ(url, testUrl);
+        EXPECT_EQ(group, nullptr);
+        return false;
+    });
+    
+    bool result = receiver->parseDevMountCrumb(testUrl, nullptr);
+    EXPECT_TRUE(parseCalled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSepateTitlebarCrumb_ComputerScheme_AddsComputerCrumb)
+{
+    QUrl computerUrl("computer:///");
+    QList<QVariantMap> mapGroup;
+    
+    bool crumbHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSepateTitlebarCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        crumbHandled = true;
+        EXPECT_EQ(url, computerUrl);
+        EXPECT_NE(group, nullptr);
+        
+        // Simulate adding computer crumb data
+        QVariantMap crumbData;
+        crumbData["url"] = computerUrl;
+        crumbData["displayText"] = "Computer";
+        crumbData["iconName"] = "computer-symbolic";
+        group->append(crumbData);
+        
+        return true;
+    });
+    
+    bool result = receiver->handleSepateTitlebarCrumb(computerUrl, &mapGroup);
+    EXPECT_TRUE(crumbHandled);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(mapGroup.size(), 1);
+    EXPECT_EQ(mapGroup.first()["url"], computerUrl);
+    EXPECT_EQ(mapGroup.first()["displayText"], "Computer");
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSepateTitlebarCrumb_FileScheme_CallsParseMethods)
+{
+    QUrl fileUrl("file:///media/smbmounts/server/share");
+    QList<QVariantMap> mapGroup;
+    
+    bool cifsParseCalled = false;
+    bool devParseCalled = false;
+    
+    // Mock parseCifsMountCrumb
+    stub.set_lamda(&ComputerEventReceiver::parseCifsMountCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        cifsParseCalled = true;
+        EXPECT_EQ(url, fileUrl);
+        EXPECT_NE(group, nullptr);
+        
+        // Simulate adding crumb data
+        QVariantMap crumbData;
+        crumbData["url"] = fileUrl;
+        crumbData["displayText"] = "share";
+        group->append(crumbData);
+        
+        return true;
+    });
+    
+    // Mock parseDevMountCrumb
+    stub.set_lamda(&ComputerEventReceiver::parseDevMountCrumb, [&](ComputerEventReceiver *, const QUrl &url, QList<QVariantMap> *group) -> bool {
+        __DBG_STUB_INVOKE__
+        devParseCalled = true;
+        EXPECT_EQ(url, fileUrl);
+        EXPECT_NE(group, nullptr);
+        return false;
+    });
+    
+    bool result = receiver->handleSepateTitlebarCrumb(fileUrl, &mapGroup);
+    EXPECT_TRUE(cifsParseCalled);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(mapGroup.size(), 1);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSortItem_InvalidGroup_ReturnsFalse)
+{
+    QString invalidGroup = "InvalidGroup";
+    QString subGroup = "computer";
+    QUrl urlA("entry://test-a.blockdev");
+    QUrl urlB("entry://test-b.blockdev");
+    
+    bool sortHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSortItem, [&](ComputerEventReceiver *, const QString &grp, const QString &subGrp, const QUrl &a, const QUrl &b) -> bool {
+        __DBG_STUB_INVOKE__
+        sortHandled = true;
+        EXPECT_EQ(grp, invalidGroup);
+        EXPECT_EQ(subGrp, subGroup);
+        EXPECT_EQ(a, urlA);
+        EXPECT_EQ(b, urlB);
+        return false;
+    });
+    
+    bool result = receiver->handleSortItem(invalidGroup, subGroup, urlA, urlB);
+    EXPECT_TRUE(sortHandled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, HandleSortItem_InvalidSubGroup_ReturnsFalse)
+{
+    QString group = "Group_Device";
+    QString invalidSubGroup = "InvalidSubGroup";
+    QUrl urlA("entry://test-a.blockdev");
+    QUrl urlB("entry://test-b.blockdev");
+    
+    bool sortHandled = false;
+    stub.set_lamda(&ComputerEventReceiver::handleSortItem, [&](ComputerEventReceiver *, const QString &grp, const QString &subGrp, const QUrl &a, const QUrl &b) -> bool {
+        __DBG_STUB_INVOKE__
+        sortHandled = true;
+        EXPECT_EQ(grp, group);
+        EXPECT_EQ(subGrp, invalidSubGroup);
+        EXPECT_EQ(a, urlA);
+        EXPECT_EQ(b, urlB);
+        return false;
+    });
+    
+    bool result = receiver->handleSortItem(group, invalidSubGroup, urlA, urlB);
+    EXPECT_TRUE(sortHandled);
+    EXPECT_FALSE(result);
+}
+
+TEST_F(UT_ComputerEventReceiver, MultipleMethodCalls_DifferentParameters_HandlesCorrectly)
+{
+    QUrl testUrl("entry://test.blockdev");
+    QString testGroup = "Group_Device";
+    QString testSubGroup = "computer";
+    QList<QVariantMap> mapGroup;
+    QString tabName;
+    
+    // Mock all methods
+    int ejectCallCount = 0;
+    int crumbCallCount = 0;
+    int sortCallCount = 0;
+    int tabNameCallCount = 0;
+    int menuStateCallCount = 0;
+    
+    stub.set_lamda(&ComputerEventReceiver::handleItemEject, [&](ComputerEventReceiver *, const QUrl &) {
+        __DBG_STUB_INVOKE__
+        ejectCallCount++;
+    });
+    
+    stub.set_lamda(&ComputerEventReceiver::handleSepateTitlebarCrumb, [&](ComputerEventReceiver *, const QUrl &, QList<QVariantMap> *) -> bool {
+        __DBG_STUB_INVOKE__
+        crumbCallCount++;
+        return true;
+    });
+    
+    stub.set_lamda(&ComputerEventReceiver::handleSortItem, [&](ComputerEventReceiver *, const QString &, const QString &, const QUrl &, const QUrl &) -> bool {
+        __DBG_STUB_INVOKE__
+        sortCallCount++;
+        return true;
+    });
+    
+    stub.set_lamda(&ComputerEventReceiver::handleSetTabName, [&](ComputerEventReceiver *, const QUrl &, QString *) -> bool {
+        __DBG_STUB_INVOKE__
+        tabNameCallCount++;
+        return true;
+    });
+    
+    stub.set_lamda(&ComputerEventReceiver::setContextMenuEnable, [&](ComputerEventReceiver *, bool) {
+        __DBG_STUB_INVOKE__
+        menuStateCallCount++;
+    });
+    
+    // Call multiple methods
+    receiver->handleItemEject(testUrl);
+    receiver->handleSepateTitlebarCrumb(testUrl, &mapGroup);
+    receiver->handleSortItem(testGroup, testSubGroup, testUrl, testUrl);
+    receiver->handleSetTabName(testUrl, &tabName);
+    receiver->setContextMenuEnable(true);
+    
+    EXPECT_EQ(ejectCallCount, 1);
+    EXPECT_EQ(crumbCallCount, 1);
+    EXPECT_EQ(sortCallCount, 1);
+    EXPECT_EQ(tabNameCallCount, 1);
+    EXPECT_EQ(menuStateCallCount, 1);
+}

--- a/autotests/plugins/dfmplugin-computer/test_computerutils.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_computerutils.cpp
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/computerutils.h"
+#include "utils/computerdatastruct.h"
+#include "fileentity/entryfileentities.h"
+
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/file/entry/entryfileinfo.h>
+#include <dfm-base/interfaces/abstractentryfileentity.h>
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/configs/dconfig/dconfigmanager.h>
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/localfilewatcher.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <QIcon>
+#include <QUrl>
+#include <QWidget>
+#include <QMimeDatabase>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_computer;
+
+class UT_ComputerUtils : public testing::Test
+{
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+    static void SetUpTestCase()
+    {
+        WatcherFactory::regClass<LocalFileWatcher>(Global::Scheme::kFile);
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+
+        // Idempotent registrations so EntryFileInfo can be constructed when
+        // this suite runs alone (same set as Computer::initialize)
+        EntryEntityFactor::registCreator<CommonEntryFileEntity>(SuffixInfo::kCommon);
+        EntryEntityFactor::registCreator<UserEntryFileEntity>(SuffixInfo::kUserDir);
+        EntryEntityFactor::registCreator<BlockEntryFileEntity>(SuffixInfo::kBlock);
+        EntryEntityFactor::registCreator<ProtocolEntryFileEntity>(SuffixInfo::kProtocol);
+        EntryEntityFactor::registCreator<AppEntryFileEntity>(SuffixInfo::kAppEntry);
+        UrlRoute::regScheme(Global::Scheme::kEntry, "/", QIcon(), true);
+        InfoFactory::regClass<EntryFileInfo>(Global::Scheme::kEntry);
+    }
+
+private:
+    stub_ext::StubExt stub;
+    const QUrl blockUrl = QUrl("entry:///sda.blockdev");
+    const QUrl appUrl = QUrl("entry:///baidu.appentry");
+    const QUrl protoUrl = QUrl("entry:///hello.protodev");
+    const QUrl protoStashedUrl = QUrl("entry:///hello.protodevstashed");
+    const QUrl vaultUrl = QUrl("entry:///vault.vault");
+};
+
+TEST_F(UT_ComputerUtils, Scheme)
+{
+    EXPECT_TRUE(ComputerUtils::scheme() == "computer");
+}
+
+TEST_F(UT_ComputerUtils, Icon)
+{
+    EXPECT_NO_FATAL_FAILURE(ComputerUtils::icon().themeName());
+}
+
+TEST_F(UT_ComputerUtils, RootUrl)
+{
+    EXPECT_TRUE(ComputerUtils::rootUrl().scheme() == "computer");
+    EXPECT_TRUE(ComputerUtils::rootUrl().path() == "/");
+}
+
+TEST_F(UT_ComputerUtils, MenuSceneName)
+{
+    EXPECT_TRUE(ComputerUtils::menuSceneName() == "ComputerMenu");
+}
+
+TEST_F(UT_ComputerUtils, GetWinId)
+{
+    stub.set_lamda(&FileManagerWindowsManager::findWindowId, [] { __DBG_STUB_INVOKE__ return 0; });
+    EXPECT_EQ(0, ComputerUtils::getWinId(nullptr));
+    EXPECT_NO_FATAL_FAILURE(ComputerUtils::getWinId(nullptr));
+}
+
+TEST_F(UT_ComputerUtils, MakeBlockDevUrl)
+{
+    QUrl u;
+    EXPECT_NO_FATAL_FAILURE(u = ComputerUtils::makeBlockDevUrl("/org/freedesktop/UDisks2/block_devices/sdb1"));
+    EXPECT_TRUE(u.scheme() == "entry");
+    EXPECT_TRUE(u.path() == "sdb1.blockdev");
+}
+
+TEST_F(UT_ComputerUtils, GetBlockDevIdByUrl)
+{
+    EXPECT_TRUE(ComputerUtils::getBlockDevIdByUrl(QUrl("file:///")) == "");
+    EXPECT_TRUE(ComputerUtils::getBlockDevIdByUrl(QUrl("entry:///hello")) == "");
+    EXPECT_TRUE(ComputerUtils::getBlockDevIdByUrl(QUrl("entry:sdb1.blockdev")) == "/org/freedesktop/UDisks2/block_devices/sdb1");
+}
+
+TEST_F(UT_ComputerUtils, MakeProtocolDevUrl)
+{
+    QUrl u;
+    EXPECT_NO_FATAL_FAILURE(u = ComputerUtils::makeProtocolDevUrl("smb://1.2.3.4/hello"));
+    EXPECT_TRUE(u.path().startsWith("smb://1.2.3.4/hello"));
+    EXPECT_TRUE(u.path().endsWith("protodev"));
+    EXPECT_TRUE(u.scheme() == "entry");
+}
+
+TEST_F(UT_ComputerUtils, GetProtocolDevIdByUrl)
+{
+    EXPECT_TRUE(ComputerUtils::getProtocolDevIdByUrl(QUrl::fromLocalFile("/home")) == "");
+    EXPECT_TRUE(ComputerUtils::getProtocolDevIdByUrl(blockUrl) == "");
+}
+
+TEST_F(UT_ComputerUtils, MakeAppEntryUrl)
+{
+    EXPECT_NO_FATAL_FAILURE(ComputerUtils::makeAppEntryUrl("hello").isValid());
+    EXPECT_NO_FATAL_FAILURE(ComputerUtils::makeAppEntryUrl("/usr/share/dde-file-manager/extensions/appEntry/.readme").isValid());
+    EXPECT_NO_FATAL_FAILURE(ComputerUtils::makeAppEntryUrl("/usr/share/dde-file-manager/extensions/appEntry/readme.desktop").isValid());
+}
+
+TEST_F(UT_ComputerUtils, GetAppEntryFileUrl)
+{
+    EXPECT_FALSE(ComputerUtils::getAppEntryFileUrl(QUrl::fromLocalFile("/home")).isValid());
+    EXPECT_FALSE(ComputerUtils::getAppEntryFileUrl(QUrl()).isValid());
+    EXPECT_TRUE(ComputerUtils::getAppEntryFileUrl(appUrl).isValid());
+    EXPECT_TRUE(ComputerUtils::getAppEntryFileUrl(appUrl).path().endsWith("desktop"));
+}
+
+TEST_F(UT_ComputerUtils, MakeLocalUrl)
+{
+    EXPECT_TRUE(ComputerUtils::makeLocalUrl("/home").scheme() == "file");
+    EXPECT_TRUE(ComputerUtils::makeLocalUrl("/home").path() == "/home");
+}
+
+TEST_F(UT_ComputerUtils, MakeBurnUrl)
+{
+    EXPECT_TRUE(ComputerUtils::makeBurnUrl("/dev/sr0").scheme() == "burn");
+    EXPECT_TRUE(ComputerUtils::makeBurnUrl("/dev/sr1").path() == "/dev/sr1/disc_files/");
+}
+
+TEST_F(UT_ComputerUtils, IsPresetSuffix)
+{
+    EXPECT_TRUE(ComputerUtils::isPresetSuffix(SuffixInfo::kBlock));
+    EXPECT_TRUE(ComputerUtils::isPresetSuffix(SuffixInfo::kProtocol));
+    EXPECT_TRUE(ComputerUtils::isPresetSuffix(SuffixInfo::kUserDir));
+    EXPECT_TRUE(ComputerUtils::isPresetSuffix(SuffixInfo::kAppEntry));
+    EXPECT_FALSE(ComputerUtils::isPresetSuffix("hello"));
+    EXPECT_FALSE(ComputerUtils::isPresetSuffix("vault"));
+    EXPECT_FALSE(ComputerUtils::isPresetSuffix("balabala"));
+    EXPECT_FALSE(ComputerUtils::isPresetSuffix(""));
+}
+
+TEST_F(UT_ComputerUtils, ShouldSystemPartitionHide)
+{
+    stub.set_lamda(&QVariant::toBool, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ComputerUtils::shouldSystemPartitionHide());
+}
+
+TEST_F(UT_ComputerUtils, ShouldLoopPartitionsHide)
+{
+    stub.set_lamda(&QVariant::toBool, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(ComputerUtils::shouldSystemPartitionHide());
+}
+
+TEST_F(UT_ComputerUtils, SortItem)
+{
+    EXPECT_FALSE(ComputerUtils::sortItem(QUrl::fromLocalFile("/home"), QUrl::fromLocalFile("/")));
+    EXPECT_FALSE(ComputerUtils::sortItem(appUrl, blockUrl));
+    EXPECT_TRUE(ComputerUtils::sortItem(blockUrl, appUrl));
+    DFMEntryFileInfoPointer infa(new EntryFileInfo(blockUrl));
+    DFMEntryFileInfoPointer infb(new EntryFileInfo(blockUrl));
+    stub.set_lamda(&EntryFileInfo::displayName, [&](void *me) {
+        __DBG_STUB_INVOKE__
+                if (me == infa.data())
+                return "a";
+        return "b";
+    });
+    EXPECT_TRUE(ComputerUtils::sortItem(infa, infb));
+}
+
+TEST_F(UT_ComputerUtils, DeviceTypeInfo)
+{
+    DFMEntryFileInfoPointer inf(new EntryFileInfo(blockUrl));
+    QList<AbstractEntryFileEntity::EntryOrder> orders { AbstractEntryFileEntity::kOrderUserDir, AbstractEntryFileEntity::kOrderSysDiskRoot,
+                                                        AbstractEntryFileEntity::kOrderRemovableDisks, AbstractEntryFileEntity::kOrderOptical,
+                                                        AbstractEntryFileEntity::kOrderMTP,
+                                                        AbstractEntryFileEntity::kOrderGPhoto2, AbstractEntryFileEntity::kOrderFiles };
+    stub.set_lamda(&EntryFileInfo::order, [&] { __DBG_STUB_INVOKE__ return orders.takeFirst(); });
+    for (int i = 0; i < orders.count(); i++) {
+        EXPECT_FALSE(ComputerUtils::deviceTypeInfo(inf).isEmpty());
+    }
+}
+
+TEST_F(UT_ComputerUtils, DeviceProtpertyDialog)
+{
+    // This machine may run a real udisks2 service exposing block devices,
+    // which would let convertToDevUrl() resolve "/home" to a device; pin the
+    // enumeration to empty to keep the failure branch deterministic.
+    stub.set_lamda(&DeviceProxyManager::getAllBlockIds,
+                   [](DeviceProxyManager *, GlobalServerDefines::DeviceQueryOptions) {
+                       __DBG_STUB_INVOKE__
+                       return QStringList {};
+                   });
+    EXPECT_FALSE(ComputerUtils::devicePropertyDialog(QUrl::fromLocalFile("/home")));
+    QWidget *w { nullptr };
+    EXPECT_NO_FATAL_FAILURE(w = ComputerUtils::devicePropertyDialog(blockUrl));
+    EXPECT_TRUE(w);
+    delete w;
+}
+
+TEST_F(UT_ComputerUtils, ConvertToDevUrl)
+{
+    EXPECT_TRUE(blockUrl == ComputerUtils::convertToDevUrl(blockUrl));
+}
+
+TEST_F(UT_ComputerUtils, GetUniqueInteger)
+{
+    QSet<int> rets;
+    for (int i = 0; i < 100; i++)
+        EXPECT_NO_FATAL_FAILURE(rets << ComputerUtils::getUniqueInteger());
+    EXPECT_TRUE(rets.count() == 100);
+}
+
+// TEST_F(UT_ComputerUtils, CheckGvfsMountExist){}
+TEST_F(UT_ComputerUtils, SetCursorState)
+{
+    EXPECT_NO_FATAL_FAILURE(ComputerUtils::setCursorState());
+    EXPECT_NO_FATAL_FAILURE(ComputerUtils::setCursorState(true));
+}
+
+TEST_F(UT_ComputerUtils, AllSystemUUIDs)
+{
+    QList<QStringList> devs {
+        { "sys1", "sys2", "loop1", "loop2" },
+        { "loop1", "loop2" }
+    };
+    stub.set_lamda(&DeviceProxyManager::getAllBlockIds, [&] { __DBG_STUB_INVOKE__ return devs.takeFirst(); });
+    stub.set_lamda(&DeviceProxyManager::queryBlockInfo, [] { __DBG_STUB_INVOKE__ return QVariantMap { { GlobalServerDefines::DeviceProperty::kUUID, "ssss" } }; });
+    EXPECT_FALSE(ComputerUtils::allValidBlockUUIDs().isEmpty());
+}
+
+TEST_F(UT_ComputerUtils, SystemBlkDevUrlByUUIDs)
+{
+    stub.set_lamda(&DeviceProxyManager::getAllBlockIdsByUUID, [] { __DBG_STUB_INVOKE__
+                                                                           return QStringList{"/org/freedesktop/UDisks2/block_devices/sda1", "/org/freedesktop/UDisks2/block_devices/sda2"}; });
+    EXPECT_TRUE(ComputerUtils::blkDevUrlByUUIDs({}).count() >= 0);
+}

--- a/autotests/plugins/dfmplugin-computer/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_realevents.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run Computer::initialize() with REAL bindEvents()/followEvents()
+// (NOT stubbed) so production EventHelper<M> subscribe/follow templates execute.
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "computer.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_computer;
+
+class ComputerRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dfmtest_hooks::registerAllHookEvents();
+        stub.set_lamda(&Computer::bindWindows, [] { __DBG_STUB_INVOKE__ });
+        ins = new Computer();
+    }
+    void TearDown() override { stub.clear(); delete ins; }
+    stub_ext::StubExt stub;
+    Computer *ins { nullptr };
+};
+
+TEST_F(ComputerRealEventsTest, Initialize_RunsRealBindAndFollowEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->initialize());
+}

--- a/autotests/plugins/dfmplugin-computer/test_remotepasswdmanager.cpp
+++ b/autotests/plugins/dfmplugin-computer/test_remotepasswdmanager.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "stubext.h"
+#include "utils/remotepasswdmanager.h"
+
+#include <QUrl>
+#include <QString>
+#include <QCryptographicHash>
+
+using namespace dfmplugin_computer;
+
+class UT_RemotePasswdManager : public testing::Test
+{
+protected:
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+
+private:
+    stub_ext::StubExt stub;
+    RemotePasswdManager *ins { RemotePasswdManager::instance() };
+};
+
+static void stubSecretClear(const SecretSchema *, GCancellable *, GAsyncReadyCallback, gpointer, ...) {
+    __DBG_STUB_INVOKE__
+}
+
+TEST_F(UT_RemotePasswdManager, ClearPasswd)
+{
+    stub.set(secret_password_clear, stubSecretClear);
+    EXPECT_NO_FATAL_FAILURE(ins->clearPasswd("smb://1.2.3.4"));
+    EXPECT_NO_FATAL_FAILURE(ins->clearPasswd("ftp://1.2.3.4"));
+    EXPECT_NO_FATAL_FAILURE(ins->clearPasswd("helllllll"));
+}
+
+TEST_F(UT_RemotePasswdManager, SmbSchema)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->smbSchema());
+}
+
+TEST_F(UT_RemotePasswdManager, FtpSchema)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->ftpSchema());
+}
+
+static bool stubClearPasswdFinished()
+{
+    __DBG_STUB_INVOKE__
+            return true;
+}
+
+TEST_F(UT_RemotePasswdManager, OnPasswdCleared)
+{
+    stub.set(secret_password_clear_finish, stubClearPasswdFinished);
+    EXPECT_NO_FATAL_FAILURE(ins->onPasswdCleared(nullptr, nullptr, nullptr));
+}


### PR DESCRIPTION
Part 1/3 of dfmplugin-computer unit tests, split by module for easier review:
核心控制器、事件与工具.

This part carries the final CMakeLists.txt and main.cpp; test files
of the other parts land in separate PRs. The test binary is wired
into the build by the registration PR (merged last).

dfmplugin-computer 单元测试第 1/3 部分（按模块拆分以便评审）：核心控制器、事件与工具。

本部分包含最终版 CMakeLists.txt 与 main.cpp，其余测试文件由独立
PR 提交；测试二进制由注册 PR（最后合入）接入构建。

Log: 新增 dfmplugin-computer 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Add the first dfmplugin-computer unit-test suite covering core functionality, events, and supporting utilities.

Enhancements:
- Add broad unit-test coverage for the dfmplugin-computer core controller, data structures, utilities, and event handling components.

Build:
- Add the dfmplugin-computer autotest target and standard test entry point to the CMake test layout.

Tests:
- Cover controller lifecycle and actions, event publishing and receiving, utility behavior, data constants, password management, and real event registration paths with GoogleTest and test doubles.