### PR TITLE
test: add unit tests for dfmplugin-dirshare

### DIFF
--- a/autotests/plugins/dfmplugin-dirshare/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-dirshare/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM enhanced test utilities to create plugin test
+dfm_create_plugin_test_enhanced("dfmplugin-dirshare" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-dirshare")

--- a/autotests/plugins/dfmplugin-dirshare/main.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_dirshare)

--- a/autotests/plugins/dfmplugin-dirshare/test_dirshare.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_dirshare.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "dirshare.h"
+#include "utils/usersharehelper.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-framework/dpf.h>
+
+#include <QUrl>
+#include <QWidget>
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+using namespace dfmplugin_dirshare;
+
+using CustomViewExtensionView = std::function<QWidget *(const QUrl &url)>;
+Q_DECLARE_METATYPE(CustomViewExtensionView)
+
+class UT_DirShare : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        ins = new DirShare();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete ins;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    DirShare *ins { nullptr };
+};
+
+TEST_F(UT_DirShare, Initialize)
+{
+    stub.set_lamda(&DirShare::bindEvents, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(ins->initialize());
+}
+
+TEST_F(UT_DirShare, Start)
+{
+    stub.set_lamda(&DirShare::bindScene, [] { __DBG_STUB_INVOKE__ });
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, CustomViewExtensionView, const QString &&, const int &&);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_TRUE(ins->start());
+}
+
+TEST_F(UT_DirShare, CreateShareControlWidget)
+{
+    EXPECT_EQ(nullptr, ins->createShareControlWidget(QUrl("smb://1.2.3.4")));
+
+    stub.set_lamda(&UserShareHelper::needDisableShareWidget, [] { __DBG_STUB_INVOKE__ return true; });
+    bool canShare = false;
+    stub.set_lamda(&UserShareHelper::canShare, [&] { __DBG_STUB_INVOKE__ return canShare; });
+
+    EXPECT_EQ(nullptr, ins->createShareControlWidget(QUrl::fromLocalFile("/home")));
+    canShare = true;
+    EXPECT_NO_FATAL_FAILURE(QScopedPointer<QWidget>(ins->createShareControlWidget(QUrl::fromLocalFile("/home"))));
+}
+
+TEST_F(UT_DirShare, BindScene)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push1)(const QString &, const QString &, QString);
+    auto menu_contains_event_caller = static_cast<Push1>(&dpf::EventChannelManager::push);
+    bool contains = true;
+    stub.set_lamda(menu_contains_event_caller, [&] { __DBG_STUB_INVOKE__ return contains; });
+
+    typedef QVariant (dpf::EventChannelManager::*Push2)(const QString &, const QString &, QString, const QString &);
+    auto menu_bind_event_caller = static_cast<Push1>(&dpf::EventChannelManager::push);
+    stub.set_lamda(menu_bind_event_caller, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene("sss"));
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene(""));
+
+    typedef bool (dpf::EventDispatcherManager::*Subscribe)(const QString &, const QString &, DirShare *, decltype(&DirShare::bindSceneOnAdded));
+    auto sub = static_cast<Subscribe>(&dpf::EventDispatcherManager::subscribe);
+    stub.set_lamda(sub, [] { __DBG_STUB_INVOKE__ return true; });
+
+    contains = false;
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene("sss"));
+    EXPECT_NO_FATAL_FAILURE(ins->bindScene(""));
+}
+
+TEST_F(UT_DirShare, BindSceneOnAdded)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->waitToBind.insert("Hello"));
+    EXPECT_TRUE(ins->waitToBind.count() == 1);
+
+    typedef bool (dpf::EventDispatcherManager::*Unsubscribe)(const QString &, const QString &, DirShare *, decltype(&DirShare::bindSceneOnAdded));
+    auto unsub = static_cast<Unsubscribe>(&dpf::EventDispatcherManager::unsubscribe);
+    stub.set_lamda(unsub, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&DirShare::bindScene, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ins->bindSceneOnAdded("Hello"));
+    EXPECT_NO_FATAL_FAILURE(ins->bindSceneOnAdded("World"));
+}
+
+TEST_F(UT_DirShare, BindEvents)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->bindEvents());
+}
+
+TEST_F(UT_DirShare, OnShareStateChanged)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->onShareStateChanged(""));
+
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QUrl);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins->onShareStateChanged("/home"));
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_dirsharemenuscene.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_dirsharemenuscene.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "dirsharemenu/dirsharemenuscene.h"
+#include "private/dirsharemenuscene_p.h"
+#include "utils/usersharehelper.h"
+
+#include <dfm-base/interfaces/abstractmenuscene.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/file/local/asyncfileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+
+#include <dfm-framework/dpf.h>
+
+#include <QMenu>
+#include <QAction>
+#include <QUrl>
+#include <QStandardPaths>
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+class UT_DirShareMenuScene : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        UrlRoute::regScheme(Global::Scheme::kAsyncFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        InfoFactory::regClass<AsyncFileInfo>(Global::Scheme::kAsyncFile);
+
+        scene = qobject_cast<DirShareMenuScene *>(DirShareMenuCreator().create());
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    DirShareMenuScene *scene { nullptr };
+};
+
+TEST_F(UT_DirShareMenuScene, Name)
+{
+    EXPECT_TRUE("DirShareMenu" == scene->name());
+    EXPECT_FALSE(scene->name().isEmpty());
+}
+
+TEST_F(UT_DirShareMenuScene, Initialize)
+{
+    QVariantHash params;
+    EXPECT_FALSE(scene->initialize(params));
+
+    QList<QUrl> selectedUrls;
+    QUrl nonFileUrl("smb://1.2.3.4");
+    selectedUrls.append(nonFileUrl);
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(selectedUrls));
+    EXPECT_FALSE(scene->initialize(params));
+
+    params.clear();
+    selectedUrls.clear();
+    selectedUrls.append(QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)));
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(selectedUrls));
+    EXPECT_TRUE(scene->initialize(params));
+    EXPECT_NO_FATAL_FAILURE(scene->initialize(params));
+}
+
+TEST_F(UT_DirShareMenuScene, Create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu *menu = new QMenu;
+    EXPECT_FALSE(scene->create(menu));
+
+    QList<QUrl> selectedUrls;
+    selectedUrls.append(QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)));
+    QVariantHash params;
+    params.insert(MenuParamKey::kSelectFiles, QVariant::fromValue<QList<QUrl>>(selectedUrls));
+
+    bool shared = false;
+    stub.set_lamda(&UserShareHelper::isShared, [&] { __DBG_STUB_INVOKE__ return shared; });
+    stub.set_lamda(&UserShareHelper::canShare, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&UserShareHelper::needDisableShareWidget, [] { __DBG_STUB_INVOKE__ return false; });
+
+    EXPECT_NO_FATAL_FAILURE(scene->initialize(params));
+    EXPECT_TRUE(scene->create(menu));
+    EXPECT_FALSE(menu->actions().isEmpty());
+    EXPECT_TRUE(menu->actions().first()->property(ActionPropertyKey::kActionID).toString() == "add-share");
+
+    shared = true;
+    delete menu;
+    menu = new QMenu;
+    EXPECT_TRUE(scene->create(menu));
+    EXPECT_FALSE(menu->actions().isEmpty());
+    EXPECT_TRUE(menu->actions().first()->property(ActionPropertyKey::kActionID).toString() == "remove-share");
+
+    delete menu;
+}
+
+TEST_F(UT_DirShareMenuScene, UpdateState)
+{
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(nullptr));
+
+    QMenu *menu = new QMenu;
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(menu));
+    delete menu;
+}
+
+TEST_F(UT_DirShareMenuScene, Triggered)
+{
+    EXPECT_FALSE(scene->triggered(nullptr));
+
+    QAction *addAct = new QAction;
+    addAct->setProperty(ActionPropertyKey::kActionID, "add-share");
+    scene->d->predicateAction.insert("add-share", addAct);
+
+    QAction *delAct = new QAction;
+    delAct->setProperty(ActionPropertyKey::kActionID, "remove-share");
+    scene->d->predicateAction.insert("remove-act", delAct);
+
+    scene->d->selectFiles.append(QUrl::fromLocalFile(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)));
+
+    stub.set_lamda(&DirShareMenuScenePrivate::addShare, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::removeShareByPath, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_TRUE(scene->triggered(addAct));
+    EXPECT_TRUE(scene->triggered(delAct));
+
+    delete addAct;
+    delete delAct;
+}
+
+TEST_F(UT_DirShareMenuScene, Scene)
+{
+    QAction *addAct = new QAction;
+    addAct->setProperty(ActionPropertyKey::kActionID, "add-share");
+    scene->d->predicateAction.insert("add-share", addAct);
+
+    QAction *delAct = new QAction;
+    delAct->setProperty(ActionPropertyKey::kActionID, "remove-share");
+
+    EXPECT_FALSE(scene->scene(nullptr));
+    EXPECT_TRUE(scene == scene->scene(addAct));
+    EXPECT_TRUE(nullptr == scene->scene(delAct));
+}
+
+TEST_F(UT_DirShareMenuScene, DirShareMenuScenePrivate_addShare)
+{
+    typedef QVariant (dpf::EventChannelManager::*Push)(const QString &, const QString &, QList<QUrl>, QVariantHash &);
+    auto push = static_cast<Push>(&dpf::EventChannelManager::push);
+    stub.set_lamda(push, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(scene->d->addShare(QUrl()));
+    EXPECT_NO_FATAL_FAILURE(scene->d->addShare(QUrl::fromLocalFile("/")));
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_realevents.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: run DirShare::initialize() with REAL bindEvents() (NOT stubbed)
+// so production EventHelper<M> subscribe templates execute.
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "dirshare.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_dirshare;
+
+class DirShareRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override { dfmtest_hooks::registerAllHookEvents(); ins = new DirShare(); }
+    void TearDown() override { delete ins; }
+    DirShare *ins { nullptr };
+};
+
+TEST_F(DirShareRealEventsTest, Initialize_RunsRealBindEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->initialize());
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_sharecontrolwidget.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_sharecontrolwidget.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "widget/sharecontrolwidget.h"
+#include "utils/usersharehelper.h"
+#include "dfmplugin_dirshare_global.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-base/dialogs/smbsharepasswddialog/usersharepasswordsettingdialog.h>
+
+#include <QLineEdit>
+#include <QDir>
+#include <QFileInfo>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QTextBrowser>
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+
+class UT_ShareControlWidget : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        widget = new ShareControlWidget(QUrl::fromLocalFile("/home"));
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete widget;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    ShareControlWidget *widget { nullptr };
+};
+
+TEST_F(UT_ShareControlWidget, SetOption)
+{
+    EXPECT_NO_FATAL_FAILURE(ShareControlWidget::setOption(widget, {}));
+}
+
+TEST_F(UT_ShareControlWidget, ValidateShareName)
+{
+    widget->shareNameEditor->clear();
+    EXPECT_FALSE(widget->validateShareName());
+
+    stub.set_lamda(&DialogManager::showErrorDialog, [] { __DBG_STUB_INVOKE__ });
+    widget->shareNameEditor->setText(".");
+    EXPECT_FALSE(widget->validateShareName());
+    widget->shareNameEditor->setText("..");
+    EXPECT_FALSE(widget->validateShareName());
+
+    widget->shareNameEditor->setText("Hello");
+    bool isShared = true;
+    stub.set_lamda(&UserShareHelper::isShared, [&] { __DBG_STUB_INVOKE__ return isShared; });
+    QString name = "Hello";
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [&] { __DBG_STUB_INVOKE__ return name; });
+    EXPECT_TRUE(widget->validateShareName());
+
+    typedef QFileInfoList (QDir::*EntryInfoList)(QDir::Filters, QDir::SortFlags) const;
+    auto entryInfoList = static_cast<EntryInfoList>(&QDir::entryInfoList);
+    stub.set_lamda(entryInfoList, [] { __DBG_STUB_INVOKE__ return QList<QFileInfo> { QFileInfo() }; });
+    stub.set_lamda(&QFileInfo::fileName, [] { __DBG_STUB_INVOKE__ return "hello"; });
+    bool writable = false;
+    stub.set_lamda(&QFileInfo::isWritable, [&] { __DBG_STUB_INVOKE__ return writable; });
+    int execRet = QDialog::Rejected;
+    stub.set_lamda(VADDR(QDialog, exec), [&] { __DBG_STUB_INVOKE__ return execRet; });
+    widget->shareNameEditor->setText("Hello");
+    isShared = false;
+    EXPECT_FALSE(widget->validateShareName());
+
+    execRet = QDialog::Accepted;
+    writable = true;
+    EXPECT_TRUE(widget->validateShareName());
+}
+
+TEST_F(UT_ShareControlWidget, UpdateShare)
+{
+    stub.set_lamda(&ShareControlWidget::shareFolder, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(widget->updateShare());
+}
+
+TEST_F(UT_ShareControlWidget, ShareFolder)
+{
+    QSignalBlocker b4(widget->shareSwitcher);
+    QSignalBlocker b3(widget->sharePermissionSelector);
+    QSignalBlocker b2(widget->shareAnonymousSelector);
+    QSignalBlocker b1(widget->shareNameEditor);
+
+    // switcher unchecked: shareFolder() aborts early
+    widget->shareSwitcher->setChecked(false);
+    EXPECT_FALSE(widget->shareFolder());
+
+    // invalid share name: aborted before sharing
+    bool validName = false;
+    stub.set_lamda(&ShareControlWidget::validateShareName, [&] { __DBG_STUB_INVOKE__ return validName; });
+    widget->shareSwitcher->setChecked(true);
+    EXPECT_FALSE(widget->shareFolder());
+
+    validName = true;
+    // UserShareHelper::share() fails
+    // (anonymous selector stays disabled so the anonymous permission chmod
+    // path in shareFolder() is never exercised in the test environment)
+    stub.set_lamda(&UserShareHelper::share, [] { __DBG_STUB_INVOKE__ return false; });
+    EXPECT_FALSE(widget->shareFolder());
+}
+
+TEST_F(UT_ShareControlWidget, UnshareFolder)
+{
+    stub.set_lamda(&UserShareHelper::removeShareByPath, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(widget->unshareFolder());
+}
+
+TEST_F(UT_ShareControlWidget, UpdateWidgetStatus)
+{
+    QSignalBlocker b1(widget->shareSwitcher);
+    QSignalBlocker b2(widget->sharePermissionSelector);
+    QSignalBlocker b3(widget->shareAnonymousSelector);
+    QSignalBlocker b4(widget->shareNameEditor);
+
+    widget->url = QUrl::fromLocalFile("/home");
+    EXPECT_NO_FATAL_FAILURE(widget->updateWidgetStatus("/"));
+
+    QVariantMap share;
+    stub.set_lamda(&UserShareHelper::shareInfoByPath, [&] { __DBG_STUB_INVOKE__ return share; });
+    EXPECT_NO_FATAL_FAILURE(widget->updateWidgetStatus("/home"));
+    EXPECT_EQ(false, widget->shareSwitcher->isChecked());
+    EXPECT_EQ(false, widget->sharePermissionSelector->isEnabled());
+    EXPECT_EQ(false, widget->shareAnonymousSelector->isEnabled());
+
+    share.insert(ShareInfoKeys::kName, "hello");
+    share.insert(ShareInfoKeys::kPath, "/home");
+    stub.set_lamda(&UserShareHelper::whoShared, [] { __DBG_STUB_INVOKE__ return 1000; });
+    EXPECT_NO_FATAL_FAILURE(widget->updateWidgetStatus("/home"));
+    //    EXPECT_EQ(true, widget->sharePermissionSelector->isEnabled());
+    //    EXPECT_EQ(true, widget->shareAnonymousSelector->isEnabled());
+}
+
+TEST_F(UT_ShareControlWidget, OnSambapasswordSet)
+{
+    QSignalBlocker b1(widget->shareSwitcher);
+    QSignalBlocker b2(widget->sharePermissionSelector);
+    QSignalBlocker b3(widget->shareAnonymousSelector);
+    QSignalBlocker b4(widget->shareNameEditor);
+
+    EXPECT_NO_FATAL_FAILURE(widget->onSambaPasswordSet(true));
+    EXPECT_TRUE(widget->isSharePasswordSet);
+}
+
+TEST_F(UT_ShareControlWidget, ShowMoreInfo)
+{
+    // showMoreInfo() only toggles moreInfoFrame visibility (and the refreshIp
+    // timer when that has been created by the share init path); m_shareNotes
+    // lives inside moreInfoFrame.
+    EXPECT_NO_FATAL_FAILURE(widget->showMoreInfo(true));
+    EXPECT_FALSE(widget->moreInfoFrame->isHidden());
+    EXPECT_NO_FATAL_FAILURE(widget->showMoreInfo(false));
+    EXPECT_TRUE(widget->moreInfoFrame->isHidden());
+}
+
+TEST_F(UT_ShareControlWidget, UserShareOperation)
+{
+    QSignalBlocker b1(widget->shareSwitcher);
+    QSignalBlocker b2(widget->sharePermissionSelector);
+    QSignalBlocker b3(widget->shareAnonymousSelector);
+    QSignalBlocker b4(widget->shareNameEditor);
+
+    stub.set_lamda(&ShareControlWidget::showSharePasswordSettingsDialog, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&ShareControlWidget::shareFolder, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&ShareControlWidget::unshareFolder, [] { __DBG_STUB_INVOKE__ return true; });
+    stub.set_lamda(&ShareControlWidget::showMoreInfo, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(widget->userShareOperation(false));
+    EXPECT_NO_FATAL_FAILURE(widget->userShareOperation(true));
+}
+
+TEST_F(UT_ShareControlWidget, ShowSharePasswordSettingsDialog)
+{
+    widget->setProperty("UserSharePwdSettingDialogShown", true);
+    EXPECT_NO_FATAL_FAILURE(widget->showSharePasswordSettingsDialog());
+
+    widget->setProperty("UserSharePwdSettingDialogShown", false);
+    stub.set_lamda(VADDR(QDialog, show), [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserSharePasswordSettingDialog::onButtonClicked, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::currentUserName, [] { __DBG_STUB_INVOKE__ return "test"; });
+    stub.set_lamda(&UserShareHelper::setSambaPasswd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(widget->showSharePasswordSettingsDialog());
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_sharewatchermanager.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_sharewatchermanager.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "utils/sharewatchermanager.h"
+
+#include <dfm-base/file/local/localfilewatcher.h>
+
+using namespace dfmplugin_dirshare;
+
+class UT_ShareWatcherManager : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        manager = new ShareWatcherManager;
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete manager;
+    }
+
+private:
+    stub_ext::StubExt stub;
+
+    ShareWatcherManager *manager { nullptr };
+};
+
+TEST_F(UT_ShareWatcherManager, Add)
+{
+    EXPECT_TRUE(manager->watchers.count() == 0);
+    EXPECT_TRUE(manager->add("/"));
+    EXPECT_NO_FATAL_FAILURE(manager->add("/"));
+    EXPECT_TRUE(manager->watchers.count() == 1);
+}
+
+TEST_F(UT_ShareWatcherManager, Remove)
+{
+    EXPECT_NO_FATAL_FAILURE(manager->add("/"));
+    EXPECT_TRUE(manager->watchers.count() == 1);
+    EXPECT_NO_FATAL_FAILURE(manager->remove("/"));
+    EXPECT_TRUE(manager->watchers.count() == 0);
+}

--- a/autotests/plugins/dfmplugin-dirshare/test_usersharehelper.cpp
+++ b/autotests/plugins/dfmplugin-dirshare/test_usersharehelper.cpp
@@ -1,0 +1,375 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include "utils/usersharehelper.h"
+#include "utils/sharewatchermanager.h"
+#include "dfmplugin_dirshare_global.h"
+
+#include <dfm-base/base/device/deviceproxymanager.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/utils/dialogmanager.h>
+#include <dfm-framework/event/event.h>
+
+#include <QStandardPaths>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QDBusMessage>
+#include <QSettings>
+#include <QProcess>
+
+#define DeclareDBusCallFunc_Full()                                         \
+    typedef QDBusMessage (QDBusAbstractInterface::*Call)(const QString &,  \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &, \
+                                                         const QVariant &)
+
+#define DeclareDBusCallFunc_Custom(params...) \
+    typedef QDBusMessage (QDBusAbstractInterface::*Call)(params)
+
+using namespace dfmplugin_dirshare;
+DFMBASE_USE_NAMESPACE
+
+class UT_UserShareHelper : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+    }
+
+private:
+    stub_ext::StubExt stub;
+};
+
+TEST_F(UT_UserShareHelper, Instance)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelper::instance());
+    EXPECT_EQ(UserShareHelper::instance(), UserShareHelper::instance());
+}
+
+TEST_F(UT_UserShareHelper, CanShare)
+{
+    EXPECT_FALSE(UserShareHelperInstance->canShare(nullptr));
+
+    bool isProtocolFile = true;
+    stub.set_lamda(&DeviceProxyManager::isFileOfProtocolMounts, [&] { __DBG_STUB_INVOKE__ return isProtocolFile; });
+    auto info = InfoFactory::create<SyncFileInfo>(QUrl::fromLocalFile("/home"));
+    EXPECT_TRUE(info);
+
+    EXPECT_FALSE(UserShareHelperInstance->canShare(info));
+
+    isProtocolFile = false;
+    bool isBurnFile = true;
+    stub.set_lamda(&DeviceProxyManager::isFileFromOptical, [&] { __DBG_STUB_INVOKE__ return isBurnFile; });
+    EXPECT_FALSE(UserShareHelperInstance->canShare(info));
+
+    isBurnFile = false;
+    EXPECT_TRUE(UserShareHelperInstance->canShare(info));
+}
+
+TEST_F(UT_UserShareHelper, NeedDisableShareWidget)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->needDisableShareWidget(nullptr));
+    EXPECT_FALSE(UserShareHelperInstance->needDisableShareWidget(nullptr));
+}
+
+TEST_F(UT_UserShareHelper, Share)
+{
+    bool serviceRunning = false;
+    stub.set_lamda(&UserShareHelper::isSambaServiceRunning, [&] { __DBG_STUB_INVOKE__ return serviceRunning; });
+    bool startSmbResult = false;
+    stub.set_lamda(&UserShareHelper::startSambaServiceAsync, [&](void *, StartSambaFinished finished) {
+        __DBG_STUB_INVOKE__
+        serviceRunning = startSmbResult;
+        if (finished) finished(startSmbResult, "");
+    });
+
+    EXPECT_FALSE(UserShareHelperInstance->share({}));
+
+    startSmbResult = true;
+    EXPECT_FALSE(UserShareHelperInstance->share({}));
+    EXPECT_TRUE(serviceRunning);
+
+    QString execPath;
+    stub.set_lamda(&QStandardPaths::findExecutable, [&] { __DBG_STUB_INVOKE__ return execPath; });
+    stub.set_lamda(&DialogManager::showErrorDialog, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_FALSE(UserShareHelperInstance->share({}));
+
+    execPath = "this is where net command located";
+    stub.set_lamda(&UserShareHelper::getOldShareByNewShare, [] { __DBG_STUB_INVOKE__ return QVariantMap(); });
+    bool isValidShare = false;
+    stub.set_lamda(&UserShareHelper::isValidShare, [&] { __DBG_STUB_INVOKE__ return isValidShare; });
+    EXPECT_TRUE(UserShareHelperInstance->share({}));
+
+    isValidShare = true;
+    QVariantMap shareInfo { { ShareInfoKeys::kName, "-" } };
+    EXPECT_FALSE(UserShareHelperInstance->share(shareInfo));
+
+    shareInfo.insert(ShareInfoKeys::kName, "hello");
+    shareInfo.insert(ShareInfoKeys::kWritable, true);
+    shareInfo.insert(ShareInfoKeys::kAnonymous, true);
+    stub.set_lamda(&UserShareHelper::readPort, [] { __DBG_STUB_INVOKE__ return 139; });
+    int cmdResult = -1;
+    stub.set_lamda(&UserShareHelper::runNetCmd, [&] { __DBG_STUB_INVOKE__ return cmdResult; });
+    stub.set_lamda(&UserShareHelper::removeShareByPath, [] { __DBG_STUB_INVOKE__ return true; });
+
+    EXPECT_FALSE(UserShareHelperInstance->share(shareInfo));
+
+    cmdResult = 0;
+    EXPECT_TRUE(UserShareHelperInstance->share(shareInfo));
+}
+
+TEST_F(UT_UserShareHelper, IsUserSharepasswordSet)
+{
+    DeclareDBusCallFunc_Custom(const QString &, const QString &);
+    auto call = static_cast<Call>(&QDBusAbstractInterface::call);
+    stub.set_lamda(call, [] { __DBG_STUB_INVOKE__ return QDBusMessage(); });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->isUserSharePasswordSet("test"));
+}
+
+// TEST_F(UT_UserShareHelper, SetSambaPasswd)
+// {
+//     DeclareDBusCallFunc_Custom(const QString &, const QString &, const QString &);
+//     auto call = static_cast<Call>(&QDBusAbstractInterface::call);
+//     stub.set_lamda(call, [] { __DBG_STUB_INVOKE__ return QDBusMessage(); });
+//     EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->setSambaPasswd("test", "test"));
+// }
+
+TEST_F(UT_UserShareHelper, RemoveShareByPath)
+{
+    QString shareName;
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [&] { __DBG_STUB_INVOKE__ return shareName; });
+    stub.set_lamda(&UserShareHelper::removeShareByShareName, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->removeShareByPath("/"));
+}
+
+TEST_F(UT_UserShareHelper, ReadPort)
+{
+    int port = 0;
+    stub.set_lamda(static_cast<QVariant (QSettings::*)(QAnyStringView, const QVariant &) const>(&QSettings::value), [&] { __DBG_STUB_INVOKE__ return QVariant(port); });
+    EXPECT_EQ(0, UserShareHelperInstance->readPort());
+    port = 100;
+    EXPECT_EQ(port, UserShareHelperInstance->readPort());
+}
+
+TEST_F(UT_UserShareHelper, ShareInfos)
+{
+    EXPECT_EQ(UserShareHelperInstance->sharedInfos.count(), UserShareHelperInstance->shareInfos().count());
+}
+
+TEST_F(UT_UserShareHelper, ShareInfoByPath)
+{
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [] { __DBG_STUB_INVOKE__ return ""; });
+    stub.set_lamda(&UserShareHelper::shareInfoByShareName, [] { __DBG_STUB_INVOKE__ return QVariantMap { { ShareInfoKeys::kName, "hello" } }; });
+    EXPECT_TRUE(UserShareHelperInstance->shareInfoByPath("/").value(ShareInfoKeys::kName).toString() == "hello");
+}
+
+TEST_F(UT_UserShareHelper, ShareInfoByShareName)
+{
+    EXPECT_TRUE(UserShareHelperInstance->shareInfoByShareName("").isEmpty());
+    UserShareHelperInstance->sharedInfos.insert("hello", QVariantMap { { ShareInfoKeys::kName, "hello" } });
+    EXPECT_TRUE(UserShareHelperInstance->shareInfoByShareName("hello").value(ShareInfoKeys::kName).toString() == "hello");
+    UserShareHelperInstance->sharedInfos.clear();
+}
+
+TEST_F(UT_UserShareHelper, ShareNameByPath)
+{
+    EXPECT_TRUE(UserShareHelperInstance->shareNameByPath("/").isEmpty());
+
+    UserShareHelperInstance->sharePathToShareName.insert("/", QStringList { "hello", "world" });
+    EXPECT_EQ("world", UserShareHelperInstance->shareNameByPath("/"));
+    UserShareHelperInstance->sharePathToShareName.clear();
+}
+
+TEST_F(UT_UserShareHelper, WhoShared)
+{
+    stub.set_lamda(&QFileInfo::ownerId, [] { __DBG_STUB_INVOKE__ return 1000; });
+    EXPECT_EQ(1000, UserShareHelperInstance->whoShared("hello"));
+}
+
+TEST_F(UT_UserShareHelper, IsShared)
+{
+    UserShareHelperInstance->sharePathToShareName.insert("/", QStringList { "hello", "world" });
+    EXPECT_TRUE(UserShareHelperInstance->isShared("/"));
+    EXPECT_FALSE(UserShareHelperInstance->isShared("/home"));
+    UserShareHelperInstance->sharePathToShareName.clear();
+}
+
+TEST_F(UT_UserShareHelper, CurrentUserName)
+{
+    EXPECT_TRUE(!UserShareHelperInstance->currentUserName().isEmpty());
+}
+
+TEST_F(UT_UserShareHelper, IsSambaServiceRunning)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->isSambaServiceRunning());
+}
+
+TEST_F(UT_UserShareHelper, SharedIP)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->sharedIP());
+    EXPECT_FALSE(UserShareHelperInstance->sharedIP().isEmpty());
+}
+
+TEST_F(UT_UserShareHelper, HandleSetPassword)
+{
+    stub.set_lamda(&UserShareHelper::setSambaPasswd, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleSetPassword("1234"));
+}
+
+TEST_F(UT_UserShareHelper, ReadShareInfos)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->readShareInfos(false));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->readShareInfos(true));
+}
+
+TEST_F(UT_UserShareHelper, OnShareChanged)
+{
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareChanged("/"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareChanged("/:tmp"));
+}
+
+TEST_F(UT_UserShareHelper, OnShareFileDeleted)
+{
+    stub.set_lamda(&UserShareHelper::onShareChanged, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::removeShareWhenShareFolderDeleted, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareFileDeleted("/var/lib/samba/usershares/hello"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareFileDeleted("/home/test"));
+}
+
+TEST_F(UT_UserShareHelper, OnShareMoved)
+{
+    stub.set_lamda(&UserShareHelper::onShareFileDeleted, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&UserShareHelper::onShareChanged, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->onShareMoved("a", "b"));
+}
+
+TEST_F(UT_UserShareHelper, InitConnect)
+{
+    delete UserShareHelperInstance->pollingSharesTimer;
+    UserShareHelperInstance->pollingSharesTimer = nullptr;
+    EXPECT_TRUE(UserShareHelperInstance->pollingSharesTimer == nullptr);
+
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->initConnect());
+    EXPECT_TRUE(UserShareHelperInstance->pollingSharesTimer);
+}
+
+TEST_F(UT_UserShareHelper, InitMonitorPath)
+{
+    ShareInfoList lst;
+    lst.append(QVariantMap { {} });
+    stub.set_lamda(&UserShareHelper::shareInfos, [&] { __DBG_STUB_INVOKE__ return lst; });
+    stub.set_lamda(&ShareWatcherManager::add, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->initMonitorPath());
+}
+
+TEST_F(UT_UserShareHelper, RemoveShareWhenShareFolderDeleted)
+{
+    QString name;
+    stub.set_lamda(&UserShareHelper::shareNameByPath, [&] { __DBG_STUB_INVOKE__ return name; });
+    stub.set_lamda(&UserShareHelper::removeShareByShareName, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->removeShareWhenShareFolderDeleted("/"));
+
+    name = "hello";
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->removeShareWhenShareFolderDeleted("/"));
+}
+
+TEST_F(UT_UserShareHelper, GetOldShareByNewShare)
+{
+    UserShareHelperInstance->sharePathToShareName.insert("hello", QStringList { "a", "B" });
+    UserShareHelperInstance->sharePathToShareName.insert("world", QStringList { "c", "d" });
+
+    stub.set_lamda(&UserShareHelper::shareInfoByShareName, [] { __DBG_STUB_INVOKE__ return QVariantMap(); });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->getOldShareByNewShare(QVariantMap { { ShareInfoKeys::kName, "hello" },
+                                                                                         { ShareInfoKeys::kPath, "world" } }));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->getOldShareByNewShare(QVariantMap {}));
+
+    UserShareHelperInstance->sharePathToShareName.clear();
+}
+
+TEST_F(UT_UserShareHelper, RunNetCmd) { }
+
+TEST_F(UT_UserShareHelper, HandleErrorWhenShareFailed)
+{
+    stub.set_lamda(&DialogManager::showErrorDialog, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, ""));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "is already a valid system user name"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "as we are restricted to only sharing directories we own."));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "contains invalid characters"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "net usershare add: failed to add share Error was"));
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->handleErrorWhenShareFailed(0, "gethostname failed  net usershare add: cannot convert name"));
+}
+
+TEST_F(UT_UserShareHelper, MakeInfoByFileContent)
+{
+    QMap<QString, QString> fileContent { { "sharename", "hello" },
+                                         { "path", "/home" },
+                                         { "usershare_acl", "acl" } };
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->makeInfoByFileContent(fileContent));
+    QVariantMap share = UserShareHelperInstance->makeInfoByFileContent(fileContent);
+    EXPECT_TRUE(share.value(ShareInfoKeys::kName, "").toString() == "hello");
+}
+
+TEST_F(UT_UserShareHelper, ValidShareInfoCount)
+{
+    stub.set_lamda(&UserShareHelper::isValidShare, [] { __DBG_STUB_INVOKE__ return true; });
+    UserShareHelperInstance->sharedInfos.clear();
+    UserShareHelperInstance->sharedInfos.insert("hello", QVariantMap());
+    EXPECT_EQ(1, UserShareHelperInstance->validShareInfoCount());
+    UserShareHelperInstance->sharedInfos.clear();
+}
+
+TEST_F(UT_UserShareHelper, StartSmbService) { }
+
+TEST_F(UT_UserShareHelper, SetSmbdAutoStart)
+{
+    DeclareDBusCallFunc_Custom(const QString &);
+    auto call = static_cast<Call>(&QDBusAbstractInterface::call);
+    stub.set_lamda(call, [] { __DBG_STUB_INVOKE__ return QDBusMessage(); });
+}
+
+TEST_F(UT_UserShareHelper, IsValidShare)
+{
+    EXPECT_TRUE(UserShareHelperInstance->isValidShare(QVariantMap { { ShareInfoKeys::kName, "hello" },
+                                                                    { ShareInfoKeys::kPath, "/" } }));
+
+    EXPECT_FALSE(UserShareHelperInstance->isValidShare(QVariantMap { { ShareInfoKeys::kName, "world" },
+                                                                     { ShareInfoKeys::kPath, "/where/not/exists" } }));
+}
+
+TEST_F(UT_UserShareHelper, EmitShareCountChanged)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(const QString &, const QString &, int);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->emitShareCountChanged(10));
+}
+
+TEST_F(UT_UserShareHelper, EmitShareAdded)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(const QString &, const QString &, QString);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->emitShareAdded("/home/xxxx"));
+}
+
+TEST_F(UT_UserShareHelper, EmitShareRemoved)
+{
+    typedef bool (dpf::EventDispatcherManager::*Publish)(const QString &, const QString &, QString);
+    auto publish = static_cast<Publish>(&dpf::EventDispatcherManager::publish);
+    stub.set_lamda(publish, [] { __DBG_STUB_INVOKE__ return true; });
+    EXPECT_NO_FATAL_FAILURE(UserShareHelperInstance->emitShareAdded("/home/xxxx"));
+}


### PR DESCRIPTION
Port dir-share plugin tests from autotests/old, covering share
iterators, watchers and event helpers.

从 autotests/old 移植目录共享插件测试，覆盖共享迭代器、
监视器与事件辅助。

Log: 新增 dfmplugin-dirshare 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Add unit tests covering the dirshare plugin’s sharing workflows, UI components, watchers, helpers, and event integration.

Enhancements:
- Add unit-test coverage for the dirshare plugin’s lifecycle, menu scene, sharing widget, watcher manager, and share helper behavior.
- Exercise real event binding during dirshare initialization in a dedicated test.

Build:
- Register the dfmplugin-dirshare autotest target with the enhanced plugin test utilities.

Tests:
- Add comprehensive GoogleTest coverage for directory sharing operations, share state handling, menu actions, file watching, Samba helpers, and related event notifications.