### PR TITLE
test: add real-events test for dfmplugin-myshares

### DIFF
--- a/autotests/plugins/dfmplugin-myshares/test_realevents.cpp
+++ b/autotests/plugins/dfmplugin-myshares/test_realevents.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Real-events test: call MyShares::doInitialize() directly (skipping the lazy
+// dirshare-plugin-started gate) with REAL followEvents() so production follow
+// templates execute. bindWindows remains stubbed.
+#include <gtest/gtest.h>
+#include "stubext.h"
+#include "dfm_hookreg.h"
+#include "myshares.h"
+#include <dfm-framework/dpf.h>
+
+DPF_USE_NAMESPACE
+using namespace dfmplugin_myshares;
+
+class MySharesRealEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        dfmtest_hooks::registerAllHookEvents();
+        stub.set_lamda(&MyShares::bindWindows, [] { __DBG_STUB_INVOKE__ });
+        ins = new MyShares();
+    }
+    void TearDown() override { stub.clear(); delete ins; }
+    stub_ext::StubExt stub;
+    MyShares *ins { nullptr };
+};
+
+TEST_F(MySharesRealEventsTest, DoInitialize_RunsRealFollowEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ins->doInitialize());
+}


### PR DESCRIPTION
Add a real-events test for the myshares plugin, running
initialize() with real bindEvents().

为我的共享插件新增真实事件测试，以真实 bindEvents() 执行
initialize()。

Log: 新增 dfmplugin-myshares 真实事件测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Tests:
- Add a real-events unit test for the myshares plugin that runs initialization with production event handling and verifies it completes without failure.