### PR TITLE
test: add unit tests for dfmplugin-propertydialog (part 1/2: core)

### DIFF
--- a/autotests/plugins/dfmplugin-propertydialog/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-propertydialog/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM default test utilities to create plugin test
+dfm_create_plugin_test("dfmplugin-propertydialog" "${DFM_SOURCE_DIR}/plugins/common/dfmplugin-propertydialog") 

--- a/autotests/plugins/dfmplugin-propertydialog/main.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_propertydialog)

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertydialog.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertydialog.cpp
@@ -1,0 +1,693 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include "stubext.h"
+#include <QFileDevice>
+#include <QComboBox>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QCloseEvent>
+#include <QShowEvent>
+#include <QTimer>
+#include <QThread>
+#include <QFocusEvent>
+#include <QKeyEvent>
+#include <QMenu>
+
+#include "dfmplugin_propertydialog_global.h"
+#include "propertydialog.h"
+#include "events/propertyeventreceiver.h"
+#include "events/propertyeventcall.h"
+#include "utils/propertydialogmanager.h"
+#include "utils/propertydialogutil.h"
+#include "utils/computerpropertyhelper.h"
+#include "utils/mediainfofetchworker.h"
+#include "menu/propertymenuscene.h"
+#include "views/filepropertydialog.h"
+#include "views/computerpropertydialog.h"
+#include "views/basicwidget.h"
+#include "views/permissionmanagerwidget.h"
+#include "views/editstackedwidget.h"
+#include "views/multifilepropertiesdialog.h"
+#include "menu/propertymenuscene.h"
+#include "menu/propertymenuscene_p.h"
+
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileinfohelper.h>
+
+using namespace dfmplugin_propertydialog;
+using namespace dfmplugin_menu_util;
+
+class TestPropertyDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        // Ensure plugin is stopped at beginning of each test
+        propertyDialog.stop();
+    }
+
+    void TearDown() override
+    {
+        // Ensure plugin is stopped at end of each test
+        propertyDialog.stop();
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    static PropertyDialog propertyDialog;   // Use static instance like other plugins
+};
+
+PropertyDialog TestPropertyDialog::propertyDialog;
+
+// Test PropertyDialog class - minimal stubbing to avoid memory alignment issues
+TEST_F(TestPropertyDialog, InitializeTest)
+{
+    EXPECT_NO_THROW(propertyDialog.initialize());
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestPropertyDialog, StartTest)
+{
+    bool result = propertyDialog.start();
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, StopTest)
+{
+    // First start the plugin then stop it
+    propertyDialog.start();
+    EXPECT_NO_THROW(propertyDialog.stop());
+    // Stopping again should be safe
+    EXPECT_NO_THROW(propertyDialog.stop());
+}
+
+// Test PropertyEventReceiver class
+TEST_F(TestPropertyDialog, InstanceTest)
+{
+    PropertyEventReceiver *instance1 = PropertyEventReceiver::instance();
+    PropertyEventReceiver *instance2 = PropertyEventReceiver::instance();
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(TestPropertyDialog, BindEventsTest)
+{
+    PropertyEventReceiver receiver;
+    EXPECT_NO_THROW(receiver.bindEvents());
+    EXPECT_TRUE(true);
+}
+
+TEST_F(TestPropertyDialog, HandleShowPropertyDialogTest)
+{
+    PropertyEventReceiver receiver;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+
+    EXPECT_NO_THROW(receiver.handleShowPropertyDialog(urls, option));
+}
+
+TEST_F(TestPropertyDialog, HandleViewExtensionRegisterTest)
+{
+    PropertyEventReceiver receiver;
+    auto viewFunc = [](const QUrl &url) -> QWidget * { return nullptr; };
+    bool result = receiver.handleViewExtensionRegister(viewFunc, "test_name", 0);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, HandleCustomViewRegisterTest)
+{
+    PropertyEventReceiver receiver;
+    auto viewFunc = [](const QUrl &url) -> QWidget * { return nullptr; };
+    bool result = receiver.handleCustomViewRegister(viewFunc, "test_scheme");
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, HandleBasicViewExtensionRegisterTest)
+{
+    PropertyEventReceiver receiver;
+    auto func = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+    bool result = receiver.handleBasicViewExtensionRegister(func, "test_scheme");
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, HandleBasicFiledFilterAddTest)
+{
+    PropertyEventReceiver receiver;
+    QStringList enums;
+    enums << "kBasisInfo";
+    bool result1 = receiver.handleBasicFiledFilterAdd("test_scheme_unique4", enums);
+    EXPECT_TRUE(result1);
+
+    enums.clear();
+    enums << "kBasisInfo"
+          << "kPermission";
+    bool result2 = receiver.handleBasicFiledFilterAdd("test_scheme_unique5", enums);
+    EXPECT_TRUE(result2);
+}
+
+// Test PropertyDialogManager class
+TEST_F(TestPropertyDialog, ManagerInstanceTest)
+{
+    PropertyDialogManager &manager1 = PropertyDialogManager::instance();
+    PropertyDialogManager &manager2 = PropertyDialogManager::instance();
+    EXPECT_EQ(&manager1, &manager2);
+}
+
+TEST_F(TestPropertyDialog, RegisterExtensionViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto viewFunc = [](const QUrl &url) -> QWidget * { return nullptr; };
+    bool result = manager.registerExtensionView(viewFunc, "test_name", 0);
+    EXPECT_TRUE(result);
+}
+
+TEST_F(TestPropertyDialog, CreateExtensionViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, RegisterCustomViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto viewFunc = [](const QUrl &url) -> QWidget * { return nullptr; };
+    bool result = manager.registerCustomView(viewFunc, "test_scheme_unique1");
+    EXPECT_TRUE(result);
+
+    bool result2 = manager.registerCustomView(viewFunc, "test_scheme_unique1");
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialog, CreateCustomViewTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *result = manager.createCustomView(url);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(TestPropertyDialog, RegisterBasicViewExtensionTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto func = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+    bool result = manager.registerBasicViewExtension(func, "test_scheme_unique2");
+    EXPECT_TRUE(result);
+
+    bool result2 = manager.registerBasicViewExtension(func, "test_scheme_unique2");
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialog, CreateBasicViewExtensionFieldTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createBasicViewExtensionField(url);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, AddBasicFiledFiltesTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    bool result = manager.addBasicFiledFiltes("test_scheme_unique3", kPermission);
+    EXPECT_TRUE(result);
+
+    bool result2 = manager.addBasicFiledFiltes("test_scheme_unique3", kFileSizeFiled);
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialog, BasicFiledFiltesTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.basicFiledFiltes(url);
+    EXPECT_EQ(result, kNotFilter);
+}
+
+TEST_F(TestPropertyDialog, GetCreatorOptionByNameTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    auto result = manager.getCreatorOptionByName("nonexistent");
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, AddComputerPropertyDialogTest)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+    EXPECT_NO_THROW(manager.addComputerPropertyDialog());
+}
+
+// Test PropertyDialogUtil class
+TEST_F(TestPropertyDialog, UtilInstanceTest)
+{
+    PropertyDialogUtil *util1 = PropertyDialogUtil::instance();
+    PropertyDialogUtil *util2 = PropertyDialogUtil::instance();
+    EXPECT_EQ(util1, util2);
+}
+
+TEST_F(TestPropertyDialog, ShowPropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+
+    EXPECT_NO_THROW(util.showPropertyDialog(urls, option));
+}
+
+TEST_F(TestPropertyDialog, ShowFilePropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+
+    EXPECT_NO_THROW(util.showFilePropertyDialog(urls, option));
+}
+
+TEST_F(TestPropertyDialog, ShowCustomDialogTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+
+    EXPECT_NO_THROW(util.showCustomDialog(url));
+}
+
+TEST_F(TestPropertyDialog, CloseFilePropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+
+    EXPECT_NO_THROW(util.closeFilePropertyDialog(url));
+}
+
+TEST_F(TestPropertyDialog, CloseCustomPropertyDialogTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+
+    EXPECT_NO_THROW(util.closeCustomPropertyDialog(url));
+}
+
+TEST_F(TestPropertyDialog, CloseAllFilePropertyDialogTest)
+{
+    PropertyDialogUtil util;
+
+    EXPECT_NO_THROW(util.closeAllFilePropertyDialog());
+}
+
+TEST_F(TestPropertyDialog, CloseAllPropertyDialogTest)
+{
+    PropertyDialogUtil util;
+
+    EXPECT_NO_THROW(util.closeAllPropertyDialog());
+}
+
+TEST_F(TestPropertyDialog, CreateControlViewTest)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+
+    EXPECT_NO_THROW(util.createControlView(url, option));
+}
+
+TEST_F(TestPropertyDialog, UpdateCloseIndicatorTest)
+{
+    PropertyDialogUtil util;
+
+    EXPECT_NO_THROW(util.updateCloseIndicator());
+}
+
+// Test ComputerPropertyHelper class
+TEST_F(TestPropertyDialog, ComputerPropertyHelperSchemeTest)
+{
+    QString scheme = ComputerPropertyHelper::scheme();
+    EXPECT_FALSE(scheme.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, ComputerPropertyHelperCreateComputerPropertyTest)
+{
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *widget = ComputerPropertyHelper::createComputerProperty(url);
+    EXPECT_TRUE(widget == nullptr);
+}
+
+// Test MediaInfoFetchWorker class
+TEST_F(TestPropertyDialog, MediaInfoFetchWorkerTest)
+{
+    MediaInfoFetchWorker worker;
+    EXPECT_NO_THROW(worker.getDuration("/tmp/test.mp4"));
+}
+
+// Test PropertyEventCall class
+TEST_F(TestPropertyDialog, PropertyEventCallSendSetPermissionManagerTest)
+{
+    EXPECT_NO_THROW(PropertyEventCall::sendSetPermissionManager(12345, QUrl::fromLocalFile("/tmp/test"), QFileDevice::ReadOwner));
+}
+
+TEST_F(TestPropertyDialog, PropertyEventCallSendFileHideTest)
+{
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    EXPECT_NO_THROW(PropertyEventCall::sendFileHide(12345, urls));
+}
+
+// Test PropertyMenuScene class
+TEST_F(TestPropertyDialog, PropertyMenuCreatorNameTest)
+{
+    QString name = PropertyMenuCreator::name();
+    EXPECT_EQ(name, "PropertyMenu");
+}
+
+TEST_F(TestPropertyDialog, PropertyMenuSceneNameTest)
+{
+    PropertyMenuScene scene;
+    QString name = scene.name();
+    EXPECT_EQ(name, "PropertyMenu");
+}
+
+// Test ComputerPropertyDialog class
+TEST_F(TestPropertyDialog, ComputerPropertyDialogTest)
+{
+    EXPECT_NO_THROW({
+        ComputerPropertyDialog dialog;
+    });
+}
+
+// Test FilePropertyDialog class - comprehensive test coverage
+TEST_F(TestPropertyDialog, FilePropertyDialogConstructorTest)
+{
+    EXPECT_NO_THROW({
+        FilePropertyDialog dialog;
+    });
+}
+
+TEST_F(TestPropertyDialog, FilePropertyDialogDestructorTest)
+{
+    FilePropertyDialog *dialog = new FilePropertyDialog();
+    EXPECT_NO_THROW(delete dialog);
+}
+
+// TEST_F(TestPropertyDialog, FilePropertyDialogContentHeightTest)
+// {
+//     FilePropertyDialog dialog;
+//     int height = dialog.contentHeight();
+//     EXPECT_GE(height, 0);
+// }
+
+TEST_F(TestPropertyDialog, FilePropertyDialogGetFileSizeTest)
+{
+    FilePropertyDialog dialog;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    dialog.selectFileUrl(testUrl);
+    qint64 size = dialog.getFileSize();
+    EXPECT_GE(size, 0);
+}
+
+TEST_F(TestPropertyDialog, FilePropertyDialogGetFileCountTest)
+{
+    FilePropertyDialog dialog;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    dialog.selectFileUrl(testUrl);
+    int count = dialog.getFileCount();
+    EXPECT_GE(count, 0);
+}
+
+TEST_F(TestPropertyDialog, FilePropertyDialogSetBasicInfoExpandTest)
+{
+    FilePropertyDialog dialog;
+    EXPECT_NO_THROW(dialog.setBasicInfoExpand(true));
+    EXPECT_NO_THROW(dialog.setBasicInfoExpand(false));
+}
+
+TEST_F(TestPropertyDialog, FilePropertyDialogCloseDialogTest)
+{
+    FilePropertyDialog dialog;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    dialog.selectFileUrl(testUrl);
+    EXPECT_NO_THROW(dialog.closeDialog());
+}
+
+TEST_F(TestPropertyDialog, FilePropertyDialogOnSelectUrlRenamedTest)
+{
+    FilePropertyDialog dialog;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+
+    // A hidden dialog has no valid DDialog content list in the offscreen
+    // environment, and contentHeight() unconditionally queries it. Stub it
+    // to the null branch so the rename handling itself is exercised.
+    stub.set_lamda((QWidget * (DDialog::*)(int) const) & DDialog::getContent,
+                   [](const DDialog *, int) -> QWidget * {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    EXPECT_NO_THROW(dialog.onSelectUrlRenamed(testUrl));
+}
+
+TEST_F(TestPropertyDialog, FilePropertyDialogOnFileInfoUpdatedTest)
+{
+    FilePropertyDialog dialog;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    EXPECT_NO_THROW(dialog.onFileInfoUpdated(testUrl, "testInfo", false));
+}
+
+// TEST_F(TestPropertyDialog, FilePropertyDialogMousePressEventTest)
+// {
+//     FilePropertyDialog dialog;
+//     QMouseEvent event(QEvent::MouseButtonPress, QPointF(10, 10), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+//     EXPECT_NO_THROW(dialog.mousePressEvent(&event));
+// }
+
+TEST_F(TestPropertyDialog, FilePropertyDialogCloseEventTest)
+{
+    FilePropertyDialog dialog;
+    QCloseEvent event;
+    EXPECT_NO_THROW(dialog.closeEvent(&event));
+}
+
+// Test PermissionManagerWidget class
+TEST_F(TestPropertyDialog, PermissionManagerWidgetConstructorTest)
+{
+    EXPECT_NO_THROW({
+        PermissionManagerWidget widget;
+    });
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetDestructorTest)
+{
+    PermissionManagerWidget *widget = new PermissionManagerWidget();
+    EXPECT_NO_THROW(delete widget);
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetUpdateFileUrlTest)
+{
+    PermissionManagerWidget widget;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    EXPECT_NO_THROW(widget.updateFileUrl(testUrl));
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetGetPermissionStringTest)
+{
+    PermissionManagerWidget widget;
+    QString permission = widget.getPermissionString(QFileDevice::ReadOwner);
+    EXPECT_FALSE(permission.isEmpty());
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetSetComboBoxByPermissionTest)
+{
+    PermissionManagerWidget widget;
+    QComboBox comboBox;
+    EXPECT_NO_THROW(widget.setComboBoxByPermission(&comboBox, QFileDevice::ReadOwner, 0));
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetToggleFileExecutableTest)
+{
+    PermissionManagerWidget widget;
+    EXPECT_NO_THROW(widget.toggleFileExecutable(true));
+    EXPECT_NO_THROW(widget.toggleFileExecutable(false));
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetCanChmodTest)
+{
+    PermissionManagerWidget widget;
+    FileInfoPointer info = DFMBASE_NAMESPACE::InfoFactory::create<DFMBASE_NAMESPACE::FileInfo>(QUrl::fromLocalFile("/tmp/test"));
+    bool canChmod = widget.canChmod(info);
+    EXPECT_TRUE(canChmod || !canChmod);   // Just test it doesn't crash
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetSetExecTextTest)
+{
+    PermissionManagerWidget widget;
+    EXPECT_NO_THROW(widget.setExecText());
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetPaintEventTest)
+{
+    PermissionManagerWidget widget;
+    QPaintEvent event(QRect(0, 0, 100, 100));
+    EXPECT_NO_THROW(widget.paintEvent(&event));
+}
+
+TEST_F(TestPropertyDialog, PermissionManagerWidgetOnComboBoxChangedTest)
+{
+    PermissionManagerWidget widget;
+    EXPECT_NO_THROW(widget.onComboBoxChanged());
+}
+
+// Test ComputerPropertyDialog class methods
+TEST_F(TestPropertyDialog, ComputerPropertyDialogComputerProcessTest)
+{
+    ComputerPropertyDialog dialog;
+    QMap<ComputerInfoItem, QString> computerInfo;
+    computerInfo[ComputerInfoItem::kName] = "TestComputer";
+    computerInfo[ComputerInfoItem::kVersion] = "1.0";
+    EXPECT_NO_THROW(dialog.computerProcess(computerInfo));
+}
+
+TEST_F(TestPropertyDialog, ComputerPropertyDialogShowEventTest)
+{
+    ComputerPropertyDialog dialog;
+    QShowEvent event;
+    EXPECT_NO_THROW(dialog.showEvent(&event));
+}
+
+TEST_F(TestPropertyDialog, ComputerPropertyDialogCloseEventTest)
+{
+    ComputerPropertyDialog dialog;
+    QCloseEvent event;
+    EXPECT_NO_THROW(dialog.closeEvent(&event));
+}
+
+// Test ComputerInfoThread class
+TEST_F(TestPropertyDialog, ComputerInfoThreadConstructorTest)
+{
+    EXPECT_NO_THROW({
+        ComputerInfoThread thread;
+    });
+}
+
+TEST_F(TestPropertyDialog, ComputerInfoThreadDestructorTest)
+{
+    ComputerInfoThread *thread = new ComputerInfoThread();
+    thread->stopThread();
+    EXPECT_NO_THROW(delete thread);
+}
+
+TEST_F(TestPropertyDialog, ComputerInfoThreadStartThreadTest)
+{
+    ComputerInfoThread thread;
+    EXPECT_NO_THROW(thread.startThread());
+    thread.quit();
+    thread.wait();
+}
+
+TEST_F(TestPropertyDialog, ComputerInfoThreadStopThreadTest)
+{
+    ComputerInfoThread thread;
+    EXPECT_NO_THROW(thread.stopThread());
+}
+
+TEST_F(TestPropertyDialog, ComputerInfoThreadRunTest)
+{
+    ComputerInfoThread thread;
+    // Note: run() is called internally by start(), so we just test it doesn't crash
+    EXPECT_NO_THROW(thread.start());
+    thread.quit();
+    thread.wait();
+}
+
+TEST_F(TestPropertyDialog, ComputerInfoThreadComputerProcessTest)
+{
+    ComputerInfoThread thread;
+    EXPECT_NO_THROW(thread.computerProcess());
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetDestructorTest)
+{
+    BasicWidget *widget = new BasicWidget();
+    EXPECT_NO_THROW(delete widget);
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetGetFileSizeTest)
+{
+    BasicWidget widget;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    widget.selectFileUrl(testUrl);
+    qint64 size = widget.getFileSize();
+    EXPECT_GE(size, 0);
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetGetFileCountTest)
+{
+    BasicWidget widget;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    widget.selectFileUrl(testUrl);
+    int count = widget.getFileCount();
+    EXPECT_GE(count, 0);
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetUpdateFileUrlTest)
+{
+    BasicWidget widget;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    EXPECT_NO_THROW(widget.updateFileUrl(testUrl));
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetSlotFileHideTest)
+{
+    BasicWidget widget;
+    EXPECT_NO_THROW(widget.slotFileHide(Qt::Checked));
+    EXPECT_NO_THROW(widget.slotFileHide(Qt::Unchecked));
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetSlotOpenFileLocationTest)
+{
+    BasicWidget widget;
+    EXPECT_NO_THROW(widget.slotOpenFileLocation());
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetCloseEventTest)
+{
+    BasicWidget widget;
+    QCloseEvent event;
+    EXPECT_NO_THROW(widget.closeEvent(&event));
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetImageExtenInfoTest)
+{
+    BasicWidget widget;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test.jpg");
+    QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties;
+    EXPECT_NO_THROW(widget.imageExtenInfo(testUrl, properties));
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetVideoExtenInfoTest)
+{
+    BasicWidget widget;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test.mp4");
+    QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties;
+    EXPECT_NO_THROW(widget.videoExtenInfo(testUrl, properties));
+}
+
+TEST_F(TestPropertyDialog, BasicWidgetAudioExtenInfoTest)
+{
+    BasicWidget widget;
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test.mp3");
+    QMap<DFMIO::DFileInfo::AttributeExtendID, QVariant> properties;
+    EXPECT_NO_THROW(widget.audioExtenInfo(testUrl, properties));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertydialog_global.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertydialog_global.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QMetaObject>
+#include <QMetaEnum>
+#include "dfmplugin_propertydialog_global.h"
+
+#define DPPROPERTYDIALOG_NAMESPACE dfmplugin_propertydialog
+using namespace DPPROPERTYDIALOG_NAMESPACE;
+
+class TestPropertyDialogGlobal : public testing::Test
+{
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+// Test PropertyFilterType enum values
+TEST_F(TestPropertyDialogGlobal, PropertyFilterTypeEnum)
+{
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kNotFilter), 0);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kIconTitle), 1);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kBasisInfo), 2);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kPermission), 4);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileSizeFiled), 8);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileCountFiled), 16);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileTypeFiled), 32);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFilePositionFiled), 64);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileCreateTimeFiled), 128);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileAccessedTimeFiled), 256);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileModifiedTimeFiled), 512);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileMediaResolutionFiled), 1024);
+    EXPECT_EQ(static_cast<int>(DPPROPERTYDIALOG_NAMESPACE::PropertyFilterType::kFileMediaDurationFiled), 2048);
+}
+// Test BasicFieldExpandEnum values
+TEST_F(TestPropertyDialogGlobal, BasicFieldExpandEnum)
+{
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kNotAll), 0);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileSize), 1);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileCount), 2);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileType), 3);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFilePosition), 4);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileCreateTime), 5);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileAccessedTime), 6);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileModifiedTime), 7);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileMediaResolution), 8);
+    EXPECT_EQ(static_cast<int>(BasicFieldExpandEnum::kFileMediaDuration), 9);
+}
+
+// Test BasicExpandType values
+TEST_F(TestPropertyDialogGlobal, BasicExpandType)
+{
+    EXPECT_EQ(static_cast<int>(BasicExpandType::kFieldInsert), 0);
+    EXPECT_EQ(static_cast<int>(BasicExpandType::kFieldReplace), 1);
+}
+
+// Test ComputerInfoItem values
+TEST_F(TestPropertyDialogGlobal, ComputerInfoItem)
+{
+    EXPECT_EQ(static_cast<int>(ComputerInfoItem::kName), 0);
+    EXPECT_EQ(static_cast<int>(ComputerInfoItem::kVersion), 1);
+    EXPECT_EQ(static_cast<int>(ComputerInfoItem::kEdition), 2);
+    EXPECT_EQ(static_cast<int>(ComputerInfoItem::kOSBuild), 3);
+    EXPECT_EQ(static_cast<int>(ComputerInfoItem::kType), 4);
+    EXPECT_EQ(static_cast<int>(ComputerInfoItem::kCpu), 5);
+    EXPECT_EQ(static_cast<int>(ComputerInfoItem::kMemory), 6);
+}
+
+// Test Q_ENUM_NS registration
+TEST_F(TestPropertyDialogGlobal, MetaObjectRegistration)
+{
+    const QMetaObject *metaObj = &staticMetaObject;
+    ASSERT_NE(metaObj, nullptr);
+    
+    // Test PropertyFilterType enum meta-object
+    int propertyFilterTypeIdx = metaObj->indexOfEnumerator("PropertyFilterType");
+    EXPECT_GE(propertyFilterTypeIdx, 0);
+    
+    if (propertyFilterTypeIdx >= 0) {
+        QMetaEnum propertyFilterTypeEnum = metaObj->enumerator(propertyFilterTypeIdx);
+        EXPECT_STREQ(propertyFilterTypeEnum.name(), "PropertyFilterType");
+        EXPECT_GT(propertyFilterTypeEnum.keyCount(), 0);
+    }
+    
+    // Test BasicFieldExpandEnum meta-object
+    int basicFieldExpandEnumIdx = metaObj->indexOfEnumerator("BasicFieldExpandEnum");
+    EXPECT_GE(basicFieldExpandEnumIdx, 0);
+    
+    if (basicFieldExpandEnumIdx >= 0) {
+        QMetaEnum basicFieldExpandEnum = metaObj->enumerator(basicFieldExpandEnumIdx);
+        EXPECT_STREQ(basicFieldExpandEnum.name(), "BasicFieldExpandEnum");
+        EXPECT_GT(basicFieldExpandEnum.keyCount(), 0);
+    }
+    
+    // Test BasicExpandType meta-object
+    int basicExpandTypeIdx = metaObj->indexOfEnumerator("BasicExpandType");
+    EXPECT_GE(basicExpandTypeIdx, 0);
+    
+    if (basicExpandTypeIdx >= 0) {
+        QMetaEnum basicExpandType = metaObj->enumerator(basicExpandTypeIdx);
+        EXPECT_STREQ(basicExpandType.name(), "BasicExpandType");
+        EXPECT_GT(basicExpandType.keyCount(), 0);
+    }
+}
+
+// Test static constants
+TEST_F(TestPropertyDialogGlobal, StaticConstants)
+{
+    EXPECT_STREQ(kOption_Key_Name, "Option_Key_Name");
+    EXPECT_STREQ(kOption_Key_BasicInfoExpand, "Option_Key_BasicInfoExpand");
+    EXPECT_STREQ(kOption_Key_ExtendViewExpand, "Option_Key_ExtendViewExpand");
+    EXPECT_STREQ(kOption_Key_ViewIndex, "Option_Key_ViewIndex");
+    EXPECT_STREQ(kOption_Key_ViewInitCalback, "Option_Key_ViewInitCalback");
+    EXPECT_STREQ(kOption_Key_CreatorCalback, "Option_Key_CreatorCalback");
+}
+
+// Test Q_DECLARE_METATYPE declarations
+TEST_F(TestPropertyDialogGlobal, MetaTypeDeclarations)
+{
+    int customViewExtensionViewTypeId = qMetaTypeId<CustomViewExtensionView>();
+    EXPECT_GT(customViewExtensionViewTypeId, 0);
+    
+    int basicViewFieldFuncTypeId = qMetaTypeId<BasicViewFieldFunc>();
+    EXPECT_GT(basicViewFieldFuncTypeId, 0);
+    
+    int viewIntiCallbackTypeId = qMetaTypeId<ViewIntiCallback>();
+    EXPECT_GT(viewIntiCallbackTypeId, 0);
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertydialogmanager.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertydialogmanager.cpp
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QMetaEnum>
+#include <QUrl>
+#include <QVariantHash>
+#include <QMap>
+#include <QMultiMap>
+#include <QPair>
+
+#include "stubext.h"
+#include "utils/propertydialogmanager.h"
+#include "utils/computerpropertyhelper.h"
+#include "dfmplugin_propertydialog_global.h"
+
+using namespace dfmplugin_propertydialog;
+
+class TestPropertyDialogManager : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TestPropertyDialogManager, instance)
+{
+    PropertyDialogManager &manager1 = PropertyDialogManager::instance();
+    PropertyDialogManager &manager2 = PropertyDialogManager::instance();
+
+    EXPECT_EQ(&manager1, &manager2);
+}
+
+TEST_F(TestPropertyDialogManager, registerExtensionView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return nullptr;
+    };
+
+    bool result = manager.registerExtensionView(mockView, "test_name_unique1", 0);
+    EXPECT_TRUE(result);
+
+    // Test with different index
+    bool result2 = manager.registerExtensionView(mockView, "test_name_unique2", 1);
+    EXPECT_TRUE(result2);
+}
+
+TEST_F(TestPropertyDialogManager, registerExtensionView_WithIndexIncrement)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return nullptr;
+    };
+
+    // Register with index 0
+    bool result = manager.registerExtensionView(mockView, "test_name1_unique", 0);
+    EXPECT_TRUE(result);
+
+    // Register with same index 0, should increment to next available index (1)
+    bool result2 = manager.registerExtensionView(mockView, "test_name2_unique", 0);
+    EXPECT_TRUE(result2);
+
+    // Get the registered options to verify the indexes
+    QVariantHash option1 = manager.getCreatorOptionByName("test_name1_unique");
+    QVariantHash option2 = manager.getCreatorOptionByName("test_name2_unique");
+
+    // PropertyDialogManager is a process-wide singleton and earlier suites may
+    // already occupy the low indexes, so the first registration can start from
+    // a non-zero index. Only the conflict-resolution semantics are verified:
+    // registering two views with the same index must allocate distinct,
+    // increasing indexes.
+    int firstIndex = option1.value(kOption_Key_ViewIndex).toInt();
+    int secondIndex = option2.value(kOption_Key_ViewIndex).toInt();
+    EXPECT_GE(firstIndex, 0);
+    EXPECT_GT(secondIndex, firstIndex);
+}
+
+TEST_F(TestPropertyDialogManager, createExtensionView_Empty)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url);
+
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST_F(TestPropertyDialogManager, createExtensionView_WithRegisteredView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // First register a view
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return new QWidget();
+    };
+    manager.registerExtensionView(mockView, "test_name_unique", 0);
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url);
+
+    EXPECT_FALSE(result.isEmpty());
+    EXPECT_EQ(result.size(), 1);
+
+    // Clean up created widgets
+    for (QWidget *widget : result) {
+        delete widget;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, createExtensionView_WithOptions)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // First register a view to get the original creator callback
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        QWidget *w = new QWidget();
+        w->setObjectName("test_widget");
+        return w;
+    };
+    manager.registerExtensionView(mockView, "test_name_unique", 0);
+
+    // Get the original registered option that contains the creator callback
+    QVariantHash originalOption = manager.getCreatorOptionByName("test_name_unique");
+    ASSERT_FALSE(originalOption.isEmpty());
+    
+    // Create new option with additional parameters but preserving the original creator callback
+    QVariantHash option = originalOption; // Copy all original data including creator callback
+    option.insert(kOption_Key_BasicInfoExpand, false); // Override or add new options
+
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    auto result = manager.createExtensionView(url, option);
+
+    EXPECT_FALSE(result.isEmpty());
+
+    // Clean up created widgets
+    for (QWidget *widget : result) {
+        delete widget;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, registerCustomView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return new QWidget();
+    };
+
+    // PropertyDialogManager is a process-wide singleton; avoid scheme names
+    // used by other suites (e.g. test_propertydialog.cpp registers
+    // "test_scheme_unique1") so this test is order-independent.
+    bool result = manager.registerCustomView(mockView, "test_scheme_mgr_unique1");
+    EXPECT_TRUE(result);
+
+    // Register same scheme again, should fail
+    bool result2 = manager.registerCustomView(mockView, "test_scheme_mgr_unique1");
+    EXPECT_FALSE(result2);
+
+    // Register different scheme, should succeed
+    bool result3 = manager.registerCustomView(mockView, "test_scheme_mgr_unique2");
+    EXPECT_TRUE(result3);
+
+    // Clean up
+    QWidget *testWidget = mockView(QUrl::fromLocalFile("/tmp"));
+    if (testWidget) {
+        delete testWidget;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, createCustomView)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+
+    // Test with no registered views initially
+    QWidget *result = manager.createCustomView(testUrl);
+    
+    // The behavior of createCustomView is to iterate over ALL registered functions
+    // If other tests have registered functions, this may return a widget even for "no registered views"
+
+    // Register a view - it will be used for all URLs as the implementation
+    // iterates over all registered functions and returns the first non-null result
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        // For testing, create a widget for any URL
+        return new QWidget();
+    };
+    bool registerResult = manager.registerCustomView(mockView, "file_unique");
+    EXPECT_TRUE(registerResult);
+
+    // Now calling createCustomView with any URL will return a widget
+    // because the registered function returns a widget for any URL
+    QWidget *result2 = manager.createCustomView(QUrl("ftp://example.com/test"));
+    EXPECT_NE(result2, nullptr);
+
+    QWidget *result3 = manager.createCustomView(testUrl);  // file:///tmp/test 
+    EXPECT_NE(result3, nullptr);
+
+    if (result2) {
+        delete result2;
+    }
+    if (result3) {
+        delete result3;
+    }
+}
+
+TEST_F(TestPropertyDialogManager, registerBasicViewExtension)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    auto mockFunc = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        QMap<QString, QMultiMap<QString, QPair<QString, QString>>> result;
+        QMultiMap<QString, QPair<QString, QString>> subMap;
+        subMap.insert("kFileSize", qMakePair(QString("Size"), QString("100KB")));
+        result.insert("kFieldInsert", subMap);
+        return result;
+    };
+
+    bool result = manager.registerBasicViewExtension(mockFunc, "test_scheme_unique1");
+    EXPECT_TRUE(result);
+
+    // Register same scheme again, should fail
+    bool result2 = manager.registerBasicViewExtension(mockFunc, "test_scheme_unique1");
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialogManager, createBasicViewExtensionField)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+
+    // Test with no registered functions
+    auto result = manager.createBasicViewExtensionField(testUrl);
+    EXPECT_TRUE(result.isEmpty());
+
+    // Register a function
+    auto mockFunc = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        QMap<QString, QMultiMap<QString, QPair<QString, QString>>> result;
+        QMultiMap<QString, QPair<QString, QString>> subMap;
+        subMap.insert("kFileSize", qMakePair(QString("Size"), QString("100KB")));
+        result.insert("kFieldInsert", subMap);
+        return result;
+    };
+    manager.registerBasicViewExtension(mockFunc, "file");
+
+    // Test with registered function
+    auto result2 = manager.createBasicViewExtensionField(testUrl);
+    EXPECT_FALSE(result2.isEmpty());
+}
+
+TEST_F(TestPropertyDialogManager, addBasicFiledFiltes)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    bool result = manager.addBasicFiledFiltes("test_scheme_unique1", kPermission);
+    EXPECT_TRUE(result);
+
+    // Add same scheme again, should fail
+    bool result2 = manager.addBasicFiledFiltes("test_scheme_unique1", kFileSizeFiled);
+    EXPECT_FALSE(result2);
+}
+
+TEST_F(TestPropertyDialogManager, basicFiledFiltes)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+
+    // Test with empty filter hash
+    PropertyFilterType result = manager.basicFiledFiltes(testUrl);
+    EXPECT_EQ(result, kNotFilter);
+
+    // Add a filter
+    manager.addBasicFiledFiltes("file", kPermission);
+
+    // Test with matching scheme
+    QUrl fileUrl = QUrl::fromLocalFile("/tmp/test");
+    PropertyFilterType result2 = manager.basicFiledFiltes(fileUrl);
+    EXPECT_EQ(result2, kPermission);
+
+    // Test with non-matching scheme
+    QUrl ftpUrl("ftp://example.com/test");
+    PropertyFilterType result3 = manager.basicFiledFiltes(ftpUrl);
+    EXPECT_EQ(result3, kNotFilter);
+}
+
+TEST_F(TestPropertyDialogManager, getCreatorOptionByName)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // Test with non-existent name
+    QVariantHash result = manager.getCreatorOptionByName("nonexistent_unique1");
+    EXPECT_TRUE(result.isEmpty());
+
+    // Register a view
+    auto mockView = [](const QUrl &url) -> QWidget* {
+        return nullptr;
+    };
+    manager.registerExtensionView(mockView, "test_name_unique1", 0);
+
+    // Test with existing name
+    QVariantHash result2 = manager.getCreatorOptionByName("test_name_unique1");
+    EXPECT_FALSE(result2.isEmpty());
+    EXPECT_EQ(result2.value(kOption_Key_Name).toString(), "test_name_unique1");
+    // The view index depends on how many options the singleton already holds,
+    // so only verify that a valid index is reported back.
+    EXPECT_GE(result2.value(kOption_Key_ViewIndex).toInt(), 0);
+}
+
+TEST_F(TestPropertyDialogManager, addComputerPropertyDialog)
+{
+    PropertyDialogManager &manager = PropertyDialogManager::instance();
+
+    // Mock ComputerPropertyHelper::scheme() and createComputerProperty
+    stub.set_lamda(&ComputerPropertyHelper::scheme,
+                   []() -> QString {
+                       return "computer_unique";
+                   });
+
+    // createCustomView() iterates ALL registered creators and returns the
+    // first non-null result, and creators registered by earlier suites in the
+    // same process may answer first. Instead of relying on the iteration
+    // order, verify that addComputerPropertyDialog() forwards the computer
+    // creator to registerCustomView() under the stubbed scheme.
+    bool registerCalled = false;
+    QString registeredScheme;
+    stub.set_lamda(&PropertyDialogManager::registerCustomView,
+                   [&registerCalled, &registeredScheme](PropertyDialogManager *, CustomViewExtensionView, const QString &scheme) -> bool {
+                       registerCalled = true;
+                       registeredScheme = scheme;
+                       return true;
+                   });
+
+    manager.addComputerPropertyDialog();
+
+    EXPECT_TRUE(registerCalled);
+    EXPECT_EQ(registeredScheme, QString("computer_unique"));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertydialogutil.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertydialogutil.cpp
@@ -1,0 +1,394 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QTimer>
+#include <QApplication>
+#include <QScreen>
+
+#include "stubext.h"
+#include "utils/propertydialogutil.h"
+#include "utils/propertydialogmanager.h"
+#include "views/filepropertydialog.h"
+#include "views/closealldialog.h"
+#include "dfmplugin_propertydialog_global.h"
+
+// Include DPF framework headers
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/eventsequence.h>
+#include <dfm-base/utils/windowutils.h>
+
+using namespace dfmplugin_propertydialog;
+using namespace dfmbase;
+
+class TestPropertyDialogUtil : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TestPropertyDialogUtil, instance)
+{
+    PropertyDialogUtil *util1 = PropertyDialogUtil::instance();
+    PropertyDialogUtil *util2 = PropertyDialogUtil::instance();
+    
+    EXPECT_NE(util1, nullptr);
+    EXPECT_EQ(util1, util2);
+}
+
+TEST_F(TestPropertyDialogUtil, constructor)
+{
+    PropertyDialogUtil util;
+    
+    EXPECT_NE(util.closeIndicatorTimer, nullptr);
+    EXPECT_NE(util.closeAllDialog, nullptr);
+    EXPECT_EQ(util.closeIndicatorTimer->interval(), 1000);
+}
+
+TEST_F(TestPropertyDialogUtil, showPropertyDialog_SingleFile)
+{
+    PropertyDialogUtil util;
+    
+    // Use correct signature for hook sequence run. The product calls
+    // run(space, topic, url) where the template deduces T = QUrl (by value);
+    // casting to a const QUrl& signature would instantiate a *different*
+    // function and the stub would never take effect.
+    typedef bool (DPF_NAMESPACE::EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl);
+    auto run = static_cast<RunFunc>(&DPF_NAMESPACE::EventSequenceManager::run);
+    
+    bool hookSequenceRunCalled = false;
+    stub.set_lamda(run,
+                   [&hookSequenceRunCalled](DPF_NAMESPACE::EventSequenceManager *self, const QString &ns, const QString &hook, QUrl url) -> bool {
+                        Q_UNUSED(url)
+                        hookSequenceRunCalled = true;
+                        return false; // Don't disable property dialog
+                   });
+    
+    bool showCustomDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showCustomDialog,
+                   [&showCustomDialogCalled](PropertyDialogUtil *self, const QUrl &url) -> bool {
+                        showCustomDialogCalled = true;
+                        return false; // Don't show custom dialog
+                   });
+    
+    bool showFilePropertyDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showFilePropertyDialog,
+                   [&showFilePropertyDialogCalled](PropertyDialogUtil *self, const QList<QUrl> &urls, const QVariantHash &option) {
+                        showFilePropertyDialogCalled = true;
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    util.showPropertyDialog(urls, option);
+    
+    EXPECT_TRUE(hookSequenceRunCalled);
+    EXPECT_TRUE(showCustomDialogCalled);
+    EXPECT_TRUE(showFilePropertyDialogCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, showFilePropertyDialog_SingleFile)
+{
+    PropertyDialogUtil util;
+    
+    bool filterControlViewCalled = false;
+    bool setBasicInfoExpandCalled = false;
+    bool moveCalled = false;
+    bool showCalled = false;
+    
+    // Stub FilePropertyDialog methods with QWidget* as base type
+    stub.set_lamda(&FilePropertyDialog::selectFileUrl,
+                   [](QWidget *self, const QUrl &url) {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        // Mock implementation
+                   });
+    stub.set_lamda(&FilePropertyDialog::filterControlView,
+                   [&filterControlViewCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        filterControlViewCalled = true;
+                   });
+    stub.set_lamda(&FilePropertyDialog::setBasicInfoExpand,
+                   [&setBasicInfoExpandCalled](QWidget *self, bool expand) {
+                        Q_UNUSED(self)
+                        setBasicInfoExpandCalled = true;
+                   });
+    stub.set_lamda(&FilePropertyDialog::size,
+                   [](QWidget *self) -> QSize {
+                        Q_UNUSED(self)
+                        return QSize(400, 300);
+                   });
+    stub.set_lamda(&FilePropertyDialog::initalHeightOfView,
+                   [](QWidget *self) -> int {
+                        Q_UNUSED(self)
+                        return 250;
+                   });
+    
+    // Fix overloaded function issue by using static_cast
+    typedef void (QWidget::*MoveFunc)(const QPoint &);
+    stub.set_lamda(static_cast<MoveFunc>(&FilePropertyDialog::move),
+                   [&moveCalled](QWidget *self, const QPoint &pos) {
+                        Q_UNUSED(self)
+                        Q_UNUSED(pos)
+                        moveCalled = true;
+                   });
+    
+    stub.set_lamda(&FilePropertyDialog::show,
+                   [&showCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        showCalled = true;
+                   });
+    stub.set_lamda(&FilePropertyDialog::activateWindow,
+                   [](QWidget *self) {
+                        Q_UNUSED(self)
+                        // Mock implementation
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    // showFilePropertyDialog only calls setBasicInfoExpand when the option is
+    // not empty; provide the expand key to reach that branch.
+    option.insert(kOption_Key_BasicInfoExpand, true);
+    
+    util.showFilePropertyDialog(urls, option);
+    
+    EXPECT_TRUE(filterControlViewCalled);
+    EXPECT_TRUE(setBasicInfoExpandCalled);
+    EXPECT_TRUE(moveCalled);
+    EXPECT_TRUE(showCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, showCustomDialog_NotInCache)
+{
+    PropertyDialogUtil util;
+    
+    // Initially no custom dialog for this URL
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    bool createCustomizeViewCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::createCustomizeView,
+                   [&createCustomizeViewCalled, &testUrl](PropertyDialogUtil *self, const QUrl &url) -> QWidget* {
+                        Q_UNUSED(self)
+                        createCustomizeViewCalled = (url == testUrl);
+                        if (createCustomizeViewCalled) {
+                            QWidget *mockWidget = new QWidget();
+                            return mockWidget;
+                        }
+                        return nullptr;
+                   });
+    
+    bool showCalled = false;
+    bool activateWindowCalled = false;
+    stub.set_lamda(&QWidget::show,
+                   [&showCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        showCalled = true;
+                   });
+    stub.set_lamda(&QWidget::activateWindow,
+                   [&activateWindowCalled](QWidget *self) {
+                        Q_UNUSED(self)
+                        activateWindowCalled = true;
+                   });
+    
+    bool result = util.showCustomDialog(testUrl);
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(createCustomizeViewCalled);
+    EXPECT_TRUE(showCalled);
+    EXPECT_TRUE(activateWindowCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, closeFilePropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.closeFilePropertyDialog(testUrl));
+}
+
+TEST_F(TestPropertyDialogUtil, closeCustomPropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.closeCustomPropertyDialog(testUrl));
+}
+
+TEST_F(TestPropertyDialogUtil, closeAllFilePropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    bool closeAllDialogCloseCalled = false;
+    bool closeIndicatorTimerStopCalled = false;
+    
+    // Fix the return type issue - QWidget::close returns bool
+    stub.set_lamda(&QWidget::close,
+                   [&closeAllDialogCloseCalled](QWidget *self) -> bool {
+                        Q_UNUSED(self)
+                        closeAllDialogCloseCalled = true;
+                        return true;
+                   });
+    
+    // Fix overloaded function issue by using static_cast
+    typedef void (QTimer::*StopFunc)();
+    stub.set_lamda(static_cast<StopFunc>(&QTimer::stop),
+                   [&closeIndicatorTimerStopCalled](QTimer *self) {
+                        Q_UNUSED(self)
+                        closeIndicatorTimerStopCalled = true;
+                   });
+    
+    util.closeAllFilePropertyDialog();
+    
+    EXPECT_TRUE(closeIndicatorTimerStopCalled);
+    EXPECT_TRUE(closeAllDialogCloseCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, createControlView)
+{
+    PropertyDialogUtil util;
+    
+    bool createViewCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::createView,
+                   [&createViewCalled](PropertyDialogUtil *self, const QUrl &url, const QVariantHash &option) -> QMap<int, QWidget*> {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        Q_UNUSED(option)
+                        createViewCalled = true;
+                        QMap<int, QWidget*> result;
+                        result.insert(-1, new QWidget());
+                        return result;
+                   });
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    util.createControlView(testUrl, option);
+    
+    EXPECT_TRUE(createViewCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, createView)
+{
+    PropertyDialogUtil util;
+    
+    bool createExtensionViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::createExtensionView,
+                   [&createExtensionViewCalled](PropertyDialogManager *self, const QUrl &url, const QVariantHash &option) -> QMap<int, QWidget*> {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        Q_UNUSED(option)
+                        createExtensionViewCalled = true;
+                        return QMap<int, QWidget*>();
+                   });
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    auto result = util.createView(testUrl, option);
+    
+    EXPECT_TRUE(createExtensionViewCalled);
+}
+
+TEST_F(TestPropertyDialogUtil, createCustomizeView)
+{
+    PropertyDialogUtil util;
+    
+    bool createCustomViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::createCustomView,
+                   [&createCustomViewCalled](PropertyDialogManager *self, const QUrl &url) -> QWidget* {
+                        Q_UNUSED(self)
+                        Q_UNUSED(url)
+                        createCustomViewCalled = true;
+                        return nullptr;
+                   });
+    
+    QUrl testUrl = QUrl::fromLocalFile("/tmp/test");
+    
+    QWidget *result = util.createCustomizeView(testUrl);
+    
+    EXPECT_TRUE(createCustomViewCalled);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(TestPropertyDialogUtil, insertExtendedControlFileProperty)
+{
+    PropertyDialogUtil util;
+    
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *widget = new QWidget();
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.insertExtendedControlFileProperty(url, 0, widget));
+    
+    delete widget;
+}
+
+TEST_F(TestPropertyDialogUtil, addExtendedControlFileProperty)
+{
+    PropertyDialogUtil util;
+    
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QWidget *widget = new QWidget();
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.addExtendedControlFileProperty(url, widget));
+    
+    delete widget;
+}
+
+TEST_F(TestPropertyDialogUtil, closeAllPropertyDialog)
+{
+    PropertyDialogUtil util;
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.closeAllPropertyDialog());
+}
+
+TEST_F(TestPropertyDialogUtil, updateCloseIndicator)
+{
+    PropertyDialogUtil util;
+    
+    // This test checks that the function can be called without crashing
+    EXPECT_NO_THROW(util.updateCloseIndicator());
+}
+
+TEST_F(TestPropertyDialogUtil, createViewWithUrl)
+{
+    PropertyDialogUtil util;
+    QUrl url = QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+
+    // createView() is a pure forwarder to the manager's createExtensionView().
+    // The manager is a process-wide singleton whose creatorOptions may already
+    // contain view creators registered by earlier suites, so the returned map
+    // cannot be assumed empty. Verify the forwarding itself with a stubbed
+    // manager call.
+    bool called = false;
+    stub.set_lamda(&PropertyDialogManager::createExtensionView,
+                   [&called](PropertyDialogManager *, const QUrl &, const QVariantHash &) -> QMap<int, QWidget *> {
+                       called = true;
+                       return {};
+                   });
+
+    auto result = util.createView(url, option);
+    EXPECT_TRUE(called);
+    EXPECT_TRUE(result.isEmpty());
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertyeventcall.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertyeventcall.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QUrl>
+#include <QFileDevice>
+#include "stubext.h"
+
+#include "events/propertyeventcall.h"
+#include "dfmplugin_propertydialog_global.h"
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+
+class TestPropertyEventCall : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+// Test PropertyEventCall class
+TEST_F(TestPropertyEventCall, PropertyEventCallSendSetPermissionManager)
+{
+    quint64 winID = 12345;
+    QUrl url = QUrl::fromLocalFile("/tmp/test.txt");
+    QFileDevice::Permissions permissions = QFileDevice::ReadOwner | QFileDevice::WriteOwner;
+    
+    EXPECT_NO_THROW(PropertyEventCall::sendSetPermissionManager(winID, url, permissions));
+}
+
+TEST_F(TestPropertyEventCall, PropertyEventCallSendFileHide)
+{
+    quint64 winID = 12345;
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test1.txt") << QUrl::fromLocalFile("/tmp/test2.txt");
+    
+    EXPECT_NO_THROW(PropertyEventCall::sendFileHide(winID, urls));
+}
+
+// Test Q_DECLARE_METATYPE for QFileDevice::Permissions
+TEST_F(TestPropertyEventCall, MetaTypeDeclarationForQFileDevicePermissions)
+{
+    int permissionTypeId = qMetaTypeId<QFileDevice::Permissions>();
+    EXPECT_GT(permissionTypeId, 0);
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertyeventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertyeventreceiver.cpp
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include "stubext.h"
+#include <QUrl>
+#include <QVariantHash>
+#include <QList>
+#include <QMetaEnum>
+
+#include "events/propertyeventreceiver.h"
+#include "utils/propertydialogutil.h"
+#include "utils/propertydialogmanager.h"
+#include "dfmplugin_propertydialog_global.h"
+#include <dfm-framework/dpf.h>
+
+using namespace dfmplugin_propertydialog;
+using namespace DPF_NAMESPACE;
+
+class TestPropertyEventReceiver : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(TestPropertyEventReceiver, instance)
+{
+    PropertyEventReceiver *instance1 = PropertyEventReceiver::instance();
+    PropertyEventReceiver *instance2 = PropertyEventReceiver::instance();
+    
+    EXPECT_NE(instance1, nullptr);
+    EXPECT_EQ(instance1, instance2);
+}
+
+TEST_F(TestPropertyEventReceiver, bindEvents)
+{
+    PropertyEventReceiver receiver;
+    
+    // We can't easily stub DPF framework's connect function due to its template nature.
+    // Instead, we just call the function to ensure it doesn't crash.
+    // The actual event binding functionality would be tested in integration tests.
+    EXPECT_NO_THROW(receiver.bindEvents());
+}
+
+TEST_F(TestPropertyEventReceiver, handleShowPropertyDialog)
+{
+    PropertyEventReceiver receiver;
+    
+    // Mock PropertyDialogUtil::instance() to return a mock instance
+    PropertyDialogUtil *mockUtil = new PropertyDialogUtil();
+    stub.set_lamda(&PropertyDialogUtil::instance,
+                   [mockUtil]() -> PropertyDialogUtil* {
+                       return mockUtil;
+                   });
+    
+    // Track if showPropertyDialog is called on the mock
+    bool showPropertyDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showPropertyDialog,
+                   [&showPropertyDialogCalled](PropertyDialogUtil *self, const QList<QUrl> &urls, const QVariantHash &option) {
+                       showPropertyDialogCalled = true;
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    
+    receiver.handleShowPropertyDialog(urls, option);
+    
+    EXPECT_TRUE(showPropertyDialogCalled);
+    
+    delete mockUtil;
+}
+
+TEST_F(TestPropertyEventReceiver, handleShowPropertyDialogWithOptions)
+{
+    PropertyEventReceiver receiver;
+    
+    PropertyDialogUtil *mockUtil = new PropertyDialogUtil();
+    stub.set_lamda(&PropertyDialogUtil::instance,
+                   [mockUtil]() -> PropertyDialogUtil* {
+                       return mockUtil;
+                   });
+    
+    // Mock PropertyDialogManager::instance().getCreatorOptionByName
+    QVariantHash mockOption;
+    mockOption.insert(kOption_Key_Name, "test_name");
+    stub.set_lamda(&PropertyDialogManager::getCreatorOptionByName,
+                   [mockOption](PropertyDialogManager *self, const QString &name) -> QVariantHash {
+                       return mockOption;
+                   });
+    
+    bool showPropertyDialogCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showPropertyDialog,
+                   [&showPropertyDialogCalled](PropertyDialogUtil *self, const QList<QUrl> &urls, const QVariantHash &option) {
+                       showPropertyDialogCalled = true;
+                   });
+    
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test");
+    QVariantHash option;
+    option.insert(kOption_Key_Name, "test_name");
+    option.insert("test_key", "override_value");
+    
+    receiver.handleShowPropertyDialog(urls, option);
+    
+    EXPECT_TRUE(showPropertyDialogCalled);
+    
+    delete mockUtil;
+}
+
+TEST_F(TestPropertyEventReceiver, handleViewExtensionRegister)
+{
+    PropertyEventReceiver receiver;
+    
+    bool registerExtensionViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::registerExtensionView,
+                   [&registerExtensionViewCalled](PropertyDialogManager *self, CustomViewExtensionView viewCreator, const QString &name, int index) {
+                       registerExtensionViewCalled = true;
+                       return true;
+                   });
+    
+    auto mockView = [](const QUrl &url) -> QWidget* { return nullptr; };
+    
+    bool result = receiver.handleViewExtensionRegister(mockView, "test_name", 0);
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerExtensionViewCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleCustomViewRegister)
+{
+    PropertyEventReceiver receiver;
+    
+    bool registerCustomViewCalled = false;
+    stub.set_lamda(&PropertyDialogManager::registerCustomView,
+                   [&registerCustomViewCalled](PropertyDialogManager *self, CustomViewExtensionView view, const QString &scheme) {
+                       registerCustomViewCalled = true;
+                       return true;
+                   });
+    
+    auto mockView = [](const QUrl &url) -> QWidget* { return nullptr; };
+    
+    bool result = receiver.handleCustomViewRegister(mockView, "test_scheme");
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerCustomViewCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleBasicViewExtensionRegister)
+{
+    PropertyEventReceiver receiver;
+    
+    bool registerBasicViewExtensionCalled = false;
+    stub.set_lamda(&PropertyDialogManager::registerBasicViewExtension,
+                   [&registerBasicViewExtensionCalled](PropertyDialogManager *self, BasicViewFieldFunc func, const QString &scheme) {
+                       registerBasicViewExtensionCalled = true;
+                       return true;
+                   });
+    
+    auto mockFunc = [](const QUrl &url) -> QMap<QString, QMultiMap<QString, QPair<QString, QString>>> {
+        return QMap<QString, QMultiMap<QString, QPair<QString, QString>>>();
+    };
+    
+    bool result = receiver.handleBasicViewExtensionRegister(mockFunc, "test_scheme");
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(registerBasicViewExtensionCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleBasicFiledFilterAdd_Success)
+{
+    PropertyEventReceiver receiver;
+    
+    bool addBasicFiledFiltesCalled = false;
+    stub.set_lamda(&PropertyDialogManager::addBasicFiledFiltes,
+                   [&addBasicFiledFiltesCalled](PropertyDialogManager *self, const QString &scheme, PropertyFilterType filters) {
+                       addBasicFiledFiltesCalled = true;
+                       return true;
+                   });
+    
+    QStringList enums;
+    enums << "kBasisInfo" << "kPermission";
+    
+    bool result = receiver.handleBasicFiledFilterAdd("test_scheme", enums);
+    
+    EXPECT_TRUE(result);
+    EXPECT_TRUE(addBasicFiledFiltesCalled);
+}
+
+TEST_F(TestPropertyEventReceiver, handleBasicFiledFilterAdd_Failure)
+{
+    PropertyEventReceiver receiver;
+    
+    // Simulate when keysToValue fails
+    bool addBasicFiledFiltesCalled = false;
+    stub.set_lamda(&PropertyDialogManager::addBasicFiledFiltes,
+                   [&addBasicFiledFiltesCalled](PropertyDialogManager *self, const QString &scheme, PropertyFilterType filters) {
+                       addBasicFiledFiltesCalled = true;
+                       return false; // Simulate failure
+                   });
+    
+    QStringList enums;
+    enums << "InvalidEnumValue"; // This will cause keysToValue to fail
+    
+    bool result = receiver.handleBasicFiledFilterAdd("test_scheme", enums);
+    
+    // Result should be false because enum parsing fails
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(addBasicFiledFiltesCalled);
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_propertymenuscene.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_propertymenuscene.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QUrl>
+#include <QMenu>
+#include <QAction>
+#include "stubext.h"
+
+#include "menu/propertymenuscene.h"
+#include "menu/propertymenuscene_p.h"
+#include "events/propertyeventreceiver.h"
+#include "dfmplugin_propertydialog_global.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/dfm_menu_defines.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class TestPropertyMenuScene : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+// Test PropertyMenuCreator class
+TEST_F(TestPropertyMenuScene, PropertyMenuCreatorCreate)
+{
+    PropertyMenuCreator creator;
+    AbstractMenuScene *scene = creator.create();
+    EXPECT_NE(scene, nullptr);
+    delete scene;
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuCreatorName)
+{
+    QString name = PropertyMenuCreator::name();
+    EXPECT_EQ(name, "PropertyMenu");
+}
+
+// Test PropertyMenuScenePrivate class
+TEST_F(TestPropertyMenuScene, PropertyMenuScenePrivateConstructor)
+{
+    PropertyMenuScene *scene = new PropertyMenuScene();
+    PropertyMenuScenePrivate *privateScene = new PropertyMenuScenePrivate(scene);
+    EXPECT_NE(privateScene, nullptr);
+    delete privateScene;
+    delete scene;
+}
+
+// Test PropertyMenuScene class
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneConstructor)
+{
+    PropertyMenuScene *scene = new PropertyMenuScene();
+    EXPECT_NE(scene, nullptr);
+    delete scene;
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneName)
+{
+    PropertyMenuScene scene;
+    QString name = scene.name();
+    EXPECT_EQ(name, "PropertyMenu");
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneInitialize)
+{
+    PropertyMenuScene scene;
+    QVariantHash params;
+    // Test with empty params
+    bool result = scene.initialize(params);
+    EXPECT_FALSE(result); // Should fail with empty params
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneScene)
+{
+    PropertyMenuScene scene;
+    QAction *action = nullptr;
+    AbstractMenuScene *result = scene.scene(action);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneCreate)
+{
+    PropertyMenuScene scene;
+    QMenu menu;
+    bool result = scene.create(&menu);
+    EXPECT_FALSE(result); // Should fail without proper initialization
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneUpdateState)
+{
+    PropertyMenuScene scene;
+    QMenu menu;
+    EXPECT_NO_THROW(scene.updateState(&menu));
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneTriggered)
+{
+    PropertyMenuScene scene;
+    QAction action;
+    bool result = scene.triggered(&action);
+    EXPECT_FALSE(result); // Should return false for unknown action
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneFullFlow)
+{
+    UrlRoute::regScheme(Global::Scheme::kFile, "/");
+    InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+    // Intercept dialog handling so no real property dialog is created.
+    stub.set_lamda(&PropertyEventReceiver::handleShowPropertyDialog,
+                   [](PropertyEventReceiver *, const QList<QUrl> &, const QVariantHash &) {
+                   });
+
+    PropertyMenuScene scene;
+    QVariantHash params;
+    params.insert(MenuParamKey::kCurrentDir, QUrl::fromLocalFile("/tmp"));
+    params.insert(MenuParamKey::kSelectFiles,
+                  QVariant::fromValue(QList<QUrl> { QUrl::fromLocalFile("/tmp") }));
+    params.insert(MenuParamKey::kIsEmptyArea, false);
+    ASSERT_TRUE(scene.initialize(params));
+
+    QMenu menu;
+    ASSERT_TRUE(scene.create(&menu));
+
+    // The menu must contain the property action; scene() must map it back to
+    // this scene and triggered() must forward it to the event receiver.
+    bool foundPropertyAction = false;
+    for (QAction *act : menu.actions()) {
+        if (act->property(ActionPropertyKey::kActionID).toString() == PropertyActionId::kProperty) {
+            foundPropertyAction = true;
+            EXPECT_EQ(scene.scene(act), &scene);
+            EXPECT_TRUE(scene.triggered(act));
+        }
+    }
+    EXPECT_TRUE(foundPropertyAction);
+
+    // updateState reorders the menu (updateMenu) without altering actions.
+    scene.updateState(&menu);
+    EXPECT_FALSE(menu.actions().isEmpty());
+}
+
+TEST_F(TestPropertyMenuScene, PropertyMenuSceneUpdateStateMissingFile)
+{
+    UrlRoute::regScheme(Global::Scheme::kFile, "/");
+    InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+
+    PropertyMenuScene scene;
+    QVariantHash params;
+    params.insert(MenuParamKey::kCurrentDir, QUrl::fromLocalFile("/tmp"));
+    params.insert(MenuParamKey::kSelectFiles,
+                  QVariant::fromValue(QList<QUrl> { QUrl::fromLocalFile("/tmp/no_such_mfscene_file.txt") }));
+    params.insert(MenuParamKey::kIsEmptyArea, false);
+    ASSERT_TRUE(scene.initialize(params));
+
+    QMenu menu;
+    ASSERT_TRUE(scene.create(&menu));
+    scene.updateState(&menu);
+
+    // The property action must be disabled when the focus file does not exist.
+    bool foundPropertyAction = false;
+    for (QAction *act : menu.actions()) {
+        if (act->property(ActionPropertyKey::kActionID).toString() == PropertyActionId::kProperty) {
+            foundPropertyAction = true;
+            EXPECT_FALSE(act->isEnabled());
+        }
+    }
+    EXPECT_TRUE(foundPropertyAction);
+}


### PR DESCRIPTION
Part 1/2 of dfmplugin-propertydialog unit tests, split by module for easier review:
属性对话框核心与事件.

This part carries the final CMakeLists.txt and main.cpp; test files
of the other parts land in separate PRs. The test binary is wired
into the build by the registration PR (merged last).

dfmplugin-propertydialog 单元测试第 1/2 部分（按模块拆分以便评审）：属性对话框核心与事件。

本部分包含最终版 CMakeLists.txt 与 main.cpp，其余测试文件由独立
PR 提交；测试二进制由注册 PR（最后合入）接入构建。

Log: 新增 dfmplugin-propertydialog 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Add core and event unit tests for dfmplugin-propertydialog and wire them into the autotest build.

Build:
- Add the dfmplugin-propertydialog unit-test target and its standard test entry point to the autotest build.

Tests:
- Add broad unit-test coverage for the property dialog plugin’s global types, lifecycle, event handling, dialog utilities and manager, menu scene, property dialogs, permission widgets, metadata helpers, and worker threads.