### PR TITLE
test: add unit tests for dfmplugin-propertydialog (part 2/2: property widgets)

### DIFF
--- a/autotests/plugins/dfmplugin-propertydialog/test_editstackedwidget.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_editstackedwidget.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QApplication>
+#include <QUrl>
+#include <QTextCursor>
+#include <QFocusEvent>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QTextBlockFormat>
+#include "stubext.h"
+
+#include "views/editstackedwidget.h"
+#include "dfmplugin_propertydialog_global.h"
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+
+class TestEditStackedWidget : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+// Test NameTextEdit class
+TEST_F(TestEditStackedWidget, NameTextEditConstructor)
+{
+    NameTextEdit *textEdit = new NameTextEdit("test");
+    EXPECT_NE(textEdit, nullptr);
+    delete textEdit;
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditDestructor)
+{
+    NameTextEdit *textEdit = new NameTextEdit("test");
+    EXPECT_NO_THROW(delete textEdit);
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditIsCanceled)
+{
+    NameTextEdit textEdit("test");
+    EXPECT_FALSE(textEdit.isCanceled());
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditSetIsCanceled)
+{
+    NameTextEdit textEdit("test");
+    textEdit.setIsCanceled(true);
+    EXPECT_TRUE(textEdit.isCanceled());
+    
+    textEdit.setIsCanceled(false);
+    EXPECT_FALSE(textEdit.isCanceled());
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditSetPlainText)
+{
+    NameTextEdit textEdit("test");
+    textEdit.setPlainText("new text");
+    
+    // Check if text is set correctly
+    EXPECT_EQ(textEdit.toPlainText(), "new text");
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditSlotTextChanged)
+{
+    NameTextEdit textEdit("test");
+    textEdit.setPlainText("new text");
+    
+    // Call slot directly
+    EXPECT_NO_THROW(textEdit.slotTextChanged());
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditFocusOutEvent)
+{
+    NameTextEdit textEdit("test");
+    QFocusEvent event(QEvent::FocusOut);
+    EXPECT_NO_THROW(textEdit.focusOutEvent(&event));
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditKeyPressEventEscape)
+{
+    NameTextEdit textEdit("test");
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    EXPECT_NO_THROW(textEdit.keyPressEvent(&event));
+    EXPECT_TRUE(textEdit.isCanceled());
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditKeyPressEventEnter)
+{
+    NameTextEdit textEdit("test");
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Enter, Qt::NoModifier);
+    EXPECT_NO_THROW(textEdit.keyPressEvent(&event));
+    EXPECT_FALSE(textEdit.isCanceled());
+}
+
+TEST_F(TestEditStackedWidget, NameTextEditKeyPressEventReturn)
+{
+    NameTextEdit textEdit("test");
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
+    EXPECT_NO_THROW(textEdit.keyPressEvent(&event));
+    EXPECT_FALSE(textEdit.isCanceled());
+}
+
+// Test EditStackedWidget class
+TEST_F(TestEditStackedWidget, EditStackedWidgetConstructor)
+{
+    EditStackedWidget *stackedWidget = new EditStackedWidget();
+    EXPECT_NE(stackedWidget, nullptr);
+    delete stackedWidget;
+}
+
+TEST_F(TestEditStackedWidget, EditStackedWidgetDestructor)
+{
+    EditStackedWidget *stackedWidget = new EditStackedWidget();
+    EXPECT_NO_THROW(delete stackedWidget);
+}
+
+TEST_F(TestEditStackedWidget, EditStackedWidgetInitTextShowFrame)
+{
+    EditStackedWidget stackedWidget;
+    EXPECT_NO_THROW(stackedWidget.initTextShowFrame("test file"));
+}
+
+TEST_F(TestEditStackedWidget, EditStackedWidgetRenameFile)
+{
+    EditStackedWidget stackedWidget;
+    stackedWidget.selectFile(QUrl::fromLocalFile("/tmp/test.txt"));
+    // EXPECT_NO_THROW(stackedWidget.renameFile());
+}
+
+TEST_F(TestEditStackedWidget, EditStackedWidgetShowTextShowFrame)
+{
+    EditStackedWidget stackedWidget;
+    stackedWidget.selectFile(QUrl::fromLocalFile("/tmp/test.txt"));
+    EXPECT_NO_THROW(stackedWidget.showTextShowFrame());
+}
+
+TEST_F(TestEditStackedWidget, EditStackedWidgetSelectFile)
+{
+    EditStackedWidget stackedWidget;
+    EXPECT_NO_THROW(stackedWidget.selectFile(QUrl::fromLocalFile("/tmp/test.txt")));
+}
+
+TEST_F(TestEditStackedWidget, EditStackedWidgetMouseProcess)
+{
+    EditStackedWidget stackedWidget;
+    stackedWidget.selectFile(QUrl::fromLocalFile("/tmp/test.txt"));
+    // stackedWidget.renameFile(); // Switch to edit mode
+    
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(0, 0), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+    EXPECT_NO_THROW(stackedWidget.mouseProcess(&event));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/test_multifilepropertydialog.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/test_multifilepropertydialog.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QUrl>
+#include <QList>
+#include <QApplication>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <memory>
+#include "stubext.h"
+
+#include "views/multifilepropertiesdialog.h"
+#include "events/propertyeventcall.h"
+#include "dfmplugin_propertydialog_global.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/utils/universalutils.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class TestMultiFilePropertiesDialog : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        tempDir.reset(new QTemporaryDir);
+        tempFile1.reset(new QTemporaryFile(tempDir->path() + "/mfprop1XXXXXX.txt"));
+        tempFile2.reset(new QTemporaryFile(tempDir->path() + "/mfprop2XXXXXX.txt"));
+        tempFile1->open();
+        tempFile2->open();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempFile1.reset();
+        tempFile2.reset();
+        tempDir.reset();
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    std::unique_ptr<QTemporaryFile> tempFile1;
+    std::unique_ptr<QTemporaryFile> tempFile2;
+};
+
+// Test MultiFilePropertiesDialog class
+TEST_F(TestMultiFilePropertiesDialog, MultiFilePropertiesDialogConstructor)
+{
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test1.txt") << QUrl::fromLocalFile("/tmp/test2.txt");
+
+    MultiFilePropertiesDialog *dialog = new MultiFilePropertiesDialog(urls);
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(TestMultiFilePropertiesDialog, MultiFilePropertiesDialogDestructor)
+{
+    QList<QUrl> urls;
+    urls << QUrl::fromLocalFile("/tmp/test1.txt") << QUrl::fromLocalFile("/tmp/test2.txt");
+
+    MultiFilePropertiesDialog *dialog = new MultiFilePropertiesDialog(urls);
+    EXPECT_NO_THROW(delete dialog);
+}
+
+TEST_F(TestMultiFilePropertiesDialog, ConstructorWithRealFiles)
+{
+    // Real files exercise the normal loadData() paths of the embedded
+    // MultiFileBasicInfoWidget and MultiFilePermissionWidget.
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()),
+                       QUrl::fromLocalFile(tempFile2->fileName()) };
+    EXPECT_NO_THROW({
+        MultiFilePropertiesDialog dialog(urls);
+    });
+}
+
+TEST_F(TestMultiFilePropertiesDialog, ShowEventProcessHeight)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()) };
+    MultiFilePropertiesDialog dialog(urls);
+
+    dialog.show();   // triggers showEvent on the offscreen platform
+    QMetaObject::invokeMethod(&dialog, "processHeight");
+    EXPECT_GT(dialog.height(), 0);
+}
+
+TEST_F(TestMultiFilePropertiesDialog, HandleStateChanged)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()),
+                       QUrl::fromLocalFile(tempFile2->fileName()) };
+    MultiFilePropertiesDialog dialog(urls);
+
+    // Changing a field enables the save button; every handle slot must run.
+    QMetaObject::invokeMethod(&dialog, "handleOwnerBoxStateChanged", Q_ARG(int, 2));
+    EXPECT_TRUE(dialog.saveBtn->isEnabled());
+    QMetaObject::invokeMethod(&dialog, "handleGroupBoxStateChanged", Q_ARG(int, 1));
+    EXPECT_TRUE(dialog.saveBtn->isEnabled());
+    QMetaObject::invokeMethod(&dialog, "handleOtherBoxStateChanged", Q_ARG(int, 1));
+    EXPECT_TRUE(dialog.saveBtn->isEnabled());
+    QMetaObject::invokeMethod(&dialog, "handleHideBoxStateChanged", Q_ARG(int, Qt::Unchecked));
+    EXPECT_TRUE(dialog.saveBtn->isEnabled());
+}
+
+TEST_F(TestMultiFilePropertiesDialog, SaveBtnClickedNoChange)
+{
+    // With no state modification the save handler simply accepts the dialog.
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()) };
+    MultiFilePropertiesDialog dialog(urls);
+
+    QMetaObject::invokeMethod(&dialog, "saveBtnClicked");
+    EXPECT_EQ(dialog.result(), static_cast<int>(QDialog::Accepted));
+}
+
+TEST_F(TestMultiFilePropertiesDialog, SaveBtnClickedWithHideChange)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()),
+                       QUrl::fromLocalFile(tempFile2->fileName()) };
+    MultiFilePropertiesDialog dialog(urls);
+    dialog.show();
+
+    // changeFilesHideState() resolves the active window; make it deterministic
+    // on the offscreen platform.
+    stub.set_lamda(&QApplication::activeWindow,
+                   [&dialog]() -> QWidget * { return &dialog; });
+    // Avoid real event dispatch and desktop notifications.
+    stub.set_lamda(&PropertyEventCall::sendFilesHideOrVisible,
+                   [](quint64, const QUrl &, const QList<QUrl> &, bool) {
+                   });
+    stub.set_lamda(static_cast<void (*)(const QString &, const QString &)>(&UniversalUtils::notifyMessage),
+                   [](const QString &, const QString &) {
+                   });
+
+    QMetaObject::invokeMethod(&dialog, "handleHideBoxStateChanged", Q_ARG(int, Qt::Checked));
+    EXPECT_TRUE(dialog.saveBtn->isEnabled());
+
+    QMetaObject::invokeMethod(&dialog, "saveBtnClicked");
+    EXPECT_EQ(dialog.result(), static_cast<int>(QDialog::Accepted));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/ut_basicwidget.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/ut_basicwidget.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QCloseEvent>
+#include <QDBusInterface>
+
+#include "stubext.h"
+#include "dfmplugin_propertydialog_global.h"
+#include "views/basicwidget.h"
+#include "events/propertyeventcall.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/utils/filescanner.h>
+#include <dfm-base/widgets/dfmkeyvaluelabel/keyvaluelabel.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/utils/universalutils.h>
+#include <dfm-io/dfileinfo.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+USING_IO_NAMESPACE
+
+namespace {
+
+
+}   // namespace
+
+class BasicWidgetImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        tempDir.reset(new QTemporaryDir);
+        tempFile.reset(new QTemporaryFile(tempDir->path() + "/basicXXXXXX.txt"));
+        tempFile->open();
+        url = QUrl::fromLocalFile(tempFile->fileName());
+        parentUrl = QUrl::fromLocalFile(tempDir->path());
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempFile.reset();
+        tempDir.reset();
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    std::unique_ptr<QTemporaryFile> tempFile;
+    QUrl url;
+    QUrl parentUrl;
+};
+
+TEST_F(BasicWidgetImpl, ConstructDestruct)
+{
+    BasicWidget *widget = new BasicWidget();
+    EXPECT_NE(widget, nullptr);
+    delete widget;
+}
+
+TEST_F(BasicWidgetImpl, SelectFileUrlRegularFile)
+{
+
+    BasicWidget widget;
+    EXPECT_NO_THROW(widget.selectFileUrl(url));
+    EXPECT_GE(widget.getFileSize(), 0);
+    EXPECT_GE(widget.getFileCount(), 0);
+    EXPECT_GE(widget.expansionPreditHeight(), 0);
+}
+
+TEST_F(BasicWidgetImpl, UpdateFileUrl)
+{
+
+    BasicWidget widget;
+    widget.selectFileUrl(url);
+
+    QUrl newUrl = QUrl::fromLocalFile(tempDir->path() + "/new.txt");
+    EXPECT_NO_THROW(widget.updateFileUrl(newUrl));
+}
+
+TEST_F(BasicWidgetImpl, SlotFileCountAndSizeChange)
+{
+    // In a real run a plain file keeps no fileCount label (it is removed in
+    // basicFill), and setRightValue would dereference it. Stub the non-virtual
+    // KeyValueLabel::setRightValue so the slot's bookkeeping is verified
+    // without touching the removed label.
+    auto setRightValue = static_cast<void (KeyValueLabel::*)(QString, Qt::TextElideMode,
+                                                             Qt::Alignment, bool, int)>(
+            &KeyValueLabel::setRightValue);
+    stub.set_lamda(setRightValue, [](KeyValueLabel *, QString, Qt::TextElideMode,
+                                     Qt::Alignment, bool, int) {
+        __DBG_STUB_INVOKE__
+    });
+
+    BasicWidget widget;
+    widget.selectFileUrl(url);
+
+    FileScanner::ScanResult result;
+    result.totalSize = 4096;
+    result.fileCount = 5;
+    result.directoryCount = 2;
+    EXPECT_NO_THROW(widget.slotFileCountAndSizeChange(result));
+    EXPECT_EQ(widget.getFileSize(), 4096);
+    EXPECT_EQ(widget.getFileCount(), 7);
+}
+
+TEST_F(BasicWidgetImpl, SlotFileHide)
+{
+
+    bool sent = false;
+    stub.set_lamda(&PropertyEventCall::sendFileHide, [&sent](quint64, const QList<QUrl> &) {
+        Q_UNUSED(sent)
+        sent = true;
+    });
+
+    BasicWidget widget;
+    widget.selectFileUrl(url);
+    widget.slotFileHide(Qt::Checked);
+    EXPECT_TRUE(sent);
+}
+
+TEST_F(BasicWidgetImpl, SlotOpenFileLocation)
+{
+
+    auto isValid = static_cast<bool (QDBusAbstractInterface::*)() const>(&QDBusAbstractInterface::isValid);
+    stub.set_lamda(isValid, [](QDBusAbstractInterface *) -> bool { return false; });
+
+    BasicWidget widget;
+    widget.selectFileUrl(url);
+    EXPECT_NO_THROW(widget.slotOpenFileLocation());
+}
+
+TEST_F(BasicWidgetImpl, ImageExtenInfo)
+{
+
+    BasicWidget widget;
+    widget.selectFileUrl(url);
+
+    QMap<DFileInfo::AttributeExtendID, QVariant> props;
+    props.insert(DFileInfo::AttributeExtendID::kExtendMediaWidth, 1920);
+    props.insert(DFileInfo::AttributeExtendID::kExtendMediaHeight, 1080);
+    EXPECT_NO_THROW(widget.imageExtenInfo(url, props));
+}
+
+TEST_F(BasicWidgetImpl, VideoExtenInfo)
+{
+
+    BasicWidget widget;
+    widget.selectFileUrl(url);
+
+    QMap<DFileInfo::AttributeExtendID, QVariant> props;
+    props.insert(DFileInfo::AttributeExtendID::kExtendMediaWidth, 1920);
+    props.insert(DFileInfo::AttributeExtendID::kExtendMediaHeight, 1080);
+    props.insert(DFileInfo::AttributeExtendID::kExtendMediaDuration, 65000);
+    EXPECT_NO_THROW(widget.videoExtenInfo(url, props));
+}
+
+TEST_F(BasicWidgetImpl, AudioExtenInfo)
+{
+
+    BasicWidget widget;
+    widget.selectFileUrl(url);
+
+    QMap<DFileInfo::AttributeExtendID, QVariant> props;
+    props.insert(DFileInfo::AttributeExtendID::kExtendMediaDuration, 125000);
+    EXPECT_NO_THROW(widget.audioExtenInfo(url, props));
+}
+
+TEST_F(BasicWidgetImpl, CloseEvent)
+{
+    BasicWidget widget;
+    QCloseEvent event;
+    EXPECT_NO_THROW(QApplication::sendEvent(&widget, &event));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/ut_computerpropertydialog.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/ut_computerpropertydialog.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QApplication>
+#include <QShowEvent>
+#include <QCloseEvent>
+
+#include "stubext.h"
+#include "dfmplugin_propertydialog_global.h"
+#include "views/computerpropertydialog.h"
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+
+class ComputerPropertyDialogImpl : public testing::Test
+{
+protected:
+    void SetUp() override { stub.clear(); }
+    void TearDown() override { stub.clear(); }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(ComputerPropertyDialogImpl, ConstructDestruct)
+{
+    ComputerPropertyDialog *dialog = new ComputerPropertyDialog();
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(ComputerPropertyDialogImpl, ComputerProcess)
+{
+    ComputerPropertyDialog dialog;
+    QMap<ComputerInfoItem, QString> info;
+    info.insert(ComputerInfoItem::kName, "test-pc");
+    info.insert(ComputerInfoItem::kVersion, "23");
+    info.insert(ComputerInfoItem::kEdition, "Pro");
+    info.insert(ComputerInfoItem::kOSBuild, "12345");
+    info.insert(ComputerInfoItem::kType, "64Bit");
+    info.insert(ComputerInfoItem::kCpu, "x86");
+    info.insert(ComputerInfoItem::kMemory, "8 GB");
+
+    EXPECT_NO_THROW(dialog.computerProcess(info));
+}
+
+TEST_F(ComputerPropertyDialogImpl, ShowAndCloseEvent)
+{
+    bool started = false;
+    bool stopped = false;
+
+    stub.set_lamda(&ComputerInfoThread::startThread, [&started](ComputerInfoThread *) { started = true; });
+    stub.set_lamda(&ComputerInfoThread::stopThread, [&stopped](ComputerInfoThread *) { stopped = true; });
+
+    ComputerPropertyDialog dialog;
+    QShowEvent showEvent;
+    EXPECT_NO_THROW(QApplication::sendEvent(&dialog, &showEvent));
+    EXPECT_TRUE(started);
+
+    QCloseEvent closeEvent;
+    EXPECT_NO_THROW(dialog.closeEvent(&closeEvent));
+    EXPECT_TRUE(stopped);
+}
+
+TEST_F(ComputerPropertyDialogImpl, ComputerInfoThreadStartStop)
+{
+    class TestThread : public ComputerInfoThread
+    {
+    public:
+        using ComputerInfoThread::ComputerInfoThread;
+        bool runCalled = false;
+
+    protected:
+        void run() override { runCalled = true; }
+    };
+
+    TestThread thread;
+    thread.startThread();
+    EXPECT_TRUE(thread.wait(3000));
+    EXPECT_TRUE(thread.runCalled);
+    thread.stopThread();
+}

--- a/autotests/plugins/dfmplugin-propertydialog/ut_editstackedwidget.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/ut_editstackedwidget.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QFocusEvent>
+
+#include "stubext.h"
+#include "dfmplugin_propertydialog_global.h"
+#include "views/editstackedwidget.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+namespace {
+
+
+}   // namespace
+
+class EditStackedWidgetImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        tempDir.reset(new QTemporaryDir);
+        tempFile.reset(new QTemporaryFile(tempDir->path() + "/editXXXXXX.txt"));
+        tempFile->open();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempFile.reset();
+        tempDir.reset();
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    std::unique_ptr<QTemporaryFile> tempFile;
+};
+
+TEST_F(EditStackedWidgetImpl, NameTextEditConstruct)
+{
+    NameTextEdit *edit = new NameTextEdit("hello");
+    EXPECT_NE(edit, nullptr);
+    EXPECT_EQ(edit->toPlainText(), "hello");
+    delete edit;
+}
+
+TEST_F(EditStackedWidgetImpl, NameTextEditIsCanceled)
+{
+    NameTextEdit edit("test");
+    EXPECT_FALSE(edit.isCanceled());
+    edit.setIsCanceled(true);
+    EXPECT_TRUE(edit.isCanceled());
+    edit.setIsCanceled(false);
+    EXPECT_FALSE(edit.isCanceled());
+}
+
+TEST_F(EditStackedWidgetImpl, NameTextEditSetPlainTextAndSlotChanged)
+{
+    NameTextEdit edit("old");
+    edit.setPlainText("new name");
+    EXPECT_EQ(edit.toPlainText(), "new name");
+    EXPECT_NO_THROW(edit.slotTextChanged());
+}
+
+TEST_F(EditStackedWidgetImpl, NameTextEditFocusOutEvent)
+{
+    NameTextEdit edit("test");
+    QFocusEvent event(QEvent::FocusOut);
+    EXPECT_NO_THROW(edit.focusOutEvent(&event));
+}
+
+TEST_F(EditStackedWidgetImpl, NameTextEditKeyPressEventEscape)
+{
+    NameTextEdit edit("test");
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    EXPECT_NO_THROW(edit.keyPressEvent(&event));
+    EXPECT_TRUE(edit.isCanceled());
+}
+
+TEST_F(EditStackedWidgetImpl, NameTextEditKeyPressEventReturn)
+{
+    NameTextEdit edit("test");
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier);
+    EXPECT_NO_THROW(edit.keyPressEvent(&event));
+    EXPECT_FALSE(edit.isCanceled());
+}
+
+TEST_F(EditStackedWidgetImpl, ConstructDestruct)
+{
+    EditStackedWidget *widget = new EditStackedWidget();
+    EXPECT_NE(widget, nullptr);
+    delete widget;
+}
+
+TEST_F(EditStackedWidgetImpl, InitTextShowFrame)
+{
+    EditStackedWidget widget;
+    EXPECT_NO_THROW(widget.initTextShowFrame("some file name.txt"));
+}
+
+TEST_F(EditStackedWidgetImpl, SelectFile)
+{
+    QUrl url = QUrl::fromLocalFile(tempFile->fileName());
+
+    EditStackedWidget widget;
+    EXPECT_NO_THROW(widget.selectFile(url));
+}
+
+TEST_F(EditStackedWidgetImpl, RenameFile)
+{
+    QUrl url = QUrl::fromLocalFile(tempFile->fileName());
+
+    EditStackedWidget widget;
+    widget.selectFile(url);
+    EXPECT_NO_THROW(widget.renameFile());
+}
+
+TEST_F(EditStackedWidgetImpl, ShowTextShowFrameSameName)
+{
+    QUrl url = QUrl::fromLocalFile(tempFile->fileName());
+
+    EditStackedWidget widget;
+    widget.selectFile(url);
+    widget.renameFile();
+
+    QString name = QFileInfo(tempFile->fileName()).fileName();
+    widget.findChild<NameTextEdit *>()->setPlainText(name);
+    EXPECT_NO_THROW(widget.showTextShowFrame());
+}
+
+TEST_F(EditStackedWidgetImpl, MouseProcess)
+{
+    QUrl url = QUrl::fromLocalFile(tempFile->fileName());
+
+    EditStackedWidget widget;
+    widget.selectFile(url);
+    widget.renameFile();
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(5, 5), Qt::LeftButton, Qt::LeftButton,
+                      Qt::NoModifier);
+    EXPECT_NO_THROW(widget.mouseProcess(&event));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/ut_filepropertydialog.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/ut_filepropertydialog.cpp
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QResizeEvent>
+#include <QWheelEvent>
+#include <QCloseEvent>
+#include <QComboBox>
+#include <QApplication>
+
+#include "stubext.h"
+#include "dfmplugin_propertydialog_global.h"
+#include "views/filepropertydialog.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include "views/basicwidget.h"
+#include "views/editstackedwidget.h"
+#include "views/permissionmanagerwidget.h"
+
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/thumbnail/thumbnailhelper.h>
+#include <dfm-base/utils/iconutils.h>
+#include <dfm-io/dfileinfo.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+USING_IO_NAMESPACE
+
+namespace {
+
+static void installFileInfoStubs(stub_ext::StubExt &stub,
+                                  const QUrl &url,
+                                  const QUrl &parentUrl,
+                                  const QString &path,
+                                  bool isDir,
+                                  bool isHidden,
+                                  bool canHidden,
+                                  bool canRename,
+                                  FileInfo::FileType type)
+{
+    Q_UNUSED(url)
+    Q_UNUSED(parentUrl)
+    Q_UNUSED(path)
+    Q_UNUSED(isDir)
+    Q_UNUSED(isHidden)
+    Q_UNUSED(canHidden)
+    Q_UNUSED(canRename)
+    Q_UNUSED(type)
+
+    // NOTE: FileInfo's virtual methods cannot be stubbed by cpp-stub: the
+    // member pointer of a virtual function encodes a vtable offset instead of
+    // an address, so patching it crashes. The real LocalFileInfo of the temp
+    // file is used instead; only non-virtual helpers are stubbed below.
+    stub.set_lamda(&ThumbnailHelper::checkThumbEnable, [](ThumbnailHelper *, const QUrl &) -> bool { return false; });
+    stub.set_lamda(&IconUtils::hiDpiPixmap, [](const QIcon &, const QSize &, const QWidget *) -> QPixmap {
+        return QPixmap(128, 128);
+    });
+}
+
+}   // namespace
+
+class FilePropertyDialogImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        tempDir.reset(new QTemporaryDir);
+        tempFile.reset(new QTemporaryFile(tempDir->path() + "/testXXXXXX.txt"));
+        tempFile->open();
+        url = QUrl::fromLocalFile(tempFile->fileName());
+        parentUrl = QUrl::fromLocalFile(tempDir->path());
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempFile.reset();
+        tempDir.reset();
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    std::unique_ptr<QTemporaryFile> tempFile;
+    QUrl url;
+    QUrl parentUrl;
+};
+
+TEST_F(FilePropertyDialogImpl, ConstructDestruct)
+{
+    FilePropertyDialog *dialog = new FilePropertyDialog();
+    EXPECT_NE(dialog, nullptr);
+    delete dialog;
+}
+
+TEST_F(FilePropertyDialogImpl, SelectFileUrlAndFilterControlView)
+{
+    installFileInfoStubs(stub, url, parentUrl, tempFile->fileName(), false, false, true, true,
+                         FileInfo::FileType::kRegularFile);
+
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    EXPECT_NO_THROW(dialog.filterControlView());
+    EXPECT_GE(dialog.getFileCount(), 0);
+}
+
+TEST_F(FilePropertyDialogImpl, GetFileSizeAndCount)
+{
+    installFileInfoStubs(stub, url, parentUrl, tempFile->fileName(), false, false, true, true,
+                         FileInfo::FileType::kRegularFile);
+
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    dialog.filterControlView();
+
+    EXPECT_GE(dialog.getFileSize(), 0);
+    EXPECT_GE(dialog.getFileCount(), 0);
+}
+
+TEST_F(FilePropertyDialogImpl, SetBasicInfoExpand)
+{
+    installFileInfoStubs(stub, url, parentUrl, tempFile->fileName(), false, false, true, true,
+                         FileInfo::FileType::kRegularFile);
+
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    dialog.filterControlView();
+
+    EXPECT_NO_THROW(dialog.setBasicInfoExpand(true));
+    EXPECT_NO_THROW(dialog.setBasicInfoExpand(false));
+}
+
+TEST_F(FilePropertyDialogImpl, InitialHeightOfView)
+{
+    installFileInfoStubs(stub, url, parentUrl, tempFile->fileName(), false, false, true, true,
+                         FileInfo::FileType::kRegularFile);
+
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    dialog.filterControlView();
+
+    EXPECT_GT(dialog.initalHeightOfView(), 0);
+}
+
+TEST_F(FilePropertyDialogImpl, InsertAndAddExtendedControl)
+{
+    installFileInfoStubs(stub, url, parentUrl, tempFile->fileName(), false, false, true, true,
+                         FileInfo::FileType::kRegularFile);
+
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    dialog.filterControlView();
+
+    QWidget *w1 = new QWidget(&dialog);
+    QWidget *w2 = new QWidget(&dialog);
+    dialog.insertExtendedControl(0, w1);
+    dialog.addExtendedControl(w2);
+
+    QWidget *w3 = new QWidget(&dialog);
+    dialog.addExtendedControl(w3, [](QWidget *, const QUrl &) {});
+
+    EXPECT_GT(dialog.initalHeightOfView(), 0);
+}
+
+TEST_F(FilePropertyDialogImpl, CloseDialog)
+{
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+
+    bool closed = false;
+    QObject::connect(&dialog, &FilePropertyDialog::closed, [&closed](const QUrl &) { closed = true; });
+    dialog.closeDialog();
+    EXPECT_TRUE(closed);
+}
+
+TEST_F(FilePropertyDialogImpl, OnSelectUrlRenamed)
+{
+    installFileInfoStubs(stub, url, parentUrl, tempFile->fileName(), false, false, true, true,
+                         FileInfo::FileType::kRegularFile);
+
+    // onSelectUrlRenamed() calls processHeight(contentHeight()) and
+    // contentHeight() queries DDialog::getContent(), which crashes on an
+    // unshown dialog in the offscreen environment. Stub it to the null
+    // branch so the rename handling itself is exercised.
+    stub.set_lamda((QWidget * (DDialog::*)(int) const) & DDialog::getContent,
+                   [](const DDialog *, int) -> QWidget * {
+                       __DBG_STUB_INVOKE__
+                       return nullptr;
+                   });
+
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    dialog.filterControlView();
+
+    QUrl newUrl = QUrl::fromLocalFile(tempDir->path() + "/renamed.txt");
+    EXPECT_NO_THROW(dialog.onSelectUrlRenamed(newUrl));
+}
+
+TEST_F(FilePropertyDialogImpl, OnFileInfoUpdated)
+{
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    EXPECT_NO_THROW(dialog.onFileInfoUpdated(url, "0", false));
+}
+
+TEST_F(FilePropertyDialogImpl, ProcessHeightBeforeShown)
+{
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    EXPECT_NO_THROW(dialog.processHeight(100));
+}
+
+TEST_F(FilePropertyDialogImpl, EventFilterWheel)
+{
+    FilePropertyDialog dialog;
+    QComboBox *combo = new QComboBox(&dialog);
+    QWheelEvent event(QPointF(10, 10), QPointF(10, 10), QPoint(0, 0), QPoint(0, 1),
+                      Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
+    EXPECT_TRUE(dialog.eventFilter(combo, &event));
+    delete combo;
+}
+
+TEST_F(FilePropertyDialogImpl, MousePressEvent)
+{
+    installFileInfoStubs(stub, url, parentUrl, tempFile->fileName(), false, false, true, true,
+                         FileInfo::FileType::kRegularFile);
+
+    FilePropertyDialog dialog;
+    dialog.selectFileUrl(url);
+    dialog.filterControlView();
+
+    QMouseEvent event(QEvent::MouseButtonPress, QPointF(10, 10), Qt::LeftButton, Qt::LeftButton,
+                      Qt::NoModifier);
+    EXPECT_NO_THROW(QApplication::sendEvent(&dialog, &event));
+}
+
+TEST_F(FilePropertyDialogImpl, ResizeEvent)
+{
+    FilePropertyDialog dialog;
+    QResizeEvent event(QSize(400, 300), QSize(380, 200));
+    EXPECT_NO_THROW(QApplication::sendEvent(&dialog, &event));
+}
+
+TEST_F(FilePropertyDialogImpl, CloseEvent)
+{
+    FilePropertyDialog dialog;
+    QCloseEvent event;
+    EXPECT_NO_THROW(dialog.closeEvent(&event));
+}
+
+TEST_F(FilePropertyDialogImpl, KeyPressEventNonEscape)
+{
+    FilePropertyDialog dialog;
+    QKeyEvent event(QEvent::KeyPress, Qt::Key_A, Qt::NoModifier);
+    EXPECT_NO_THROW(QApplication::sendEvent(&dialog, &event));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/ut_multifilebasicinfowidget.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/ut_multifilebasicinfowidget.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <memory>
+
+#include "stubext.h"
+#include "dfmplugin_propertydialog_global.h"
+#include "views/multifilebasicinfowidget.h"
+#include "views/skippartiallycheckbox.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/utils/filescanner.h>
+#include <dfm-io/dfileinfo.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+USING_IO_NAMESPACE
+
+namespace {
+
+// NOTE: the FileInfo interface methods (exists/canAttributes/timeOf/
+// isAttributes/fileName...) are all VIRTUAL. cpp-stub cannot patch them:
+// a member-pointer kept as-is decodes to an odd vtable index and crashes
+// Stub::set, while the VADDR() C-style cast yields the address of a
+// compiler-generated thunk that virtual dispatch never goes through
+// (patch succeeds but has no effect). Therefore these tests rely on real
+// files created by the fixture instead of stubbing FileInfo.
+
+}   // namespace
+
+class MultiFileBasicInfoWidgetImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        tempDir.reset(new QTemporaryDir);
+        tempFile1.reset(new QTemporaryFile(tempDir->path() + "/multi1XXXXXX.txt"));
+        tempFile2.reset(new QTemporaryFile(tempDir->path() + "/multi2XXXXXX.txt"));
+        tempFileHidden.reset(new QTemporaryFile(tempDir->path() + "/.multiHiddenXXXXXX.txt"));
+        tempFile1->open();
+        tempFile2->open();
+        tempFileHidden->open();
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempFile1.reset();
+        tempFile2.reset();
+        tempDir.reset();
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    std::unique_ptr<QTemporaryFile> tempFile1;
+    std::unique_ptr<QTemporaryFile> tempFile2;
+    std::unique_ptr<QTemporaryFile> tempFileHidden;
+};
+
+TEST_F(MultiFileBasicInfoWidgetImpl, ConstructDestruct)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()), QUrl::fromLocalFile(tempFile2->fileName()) };
+    MultiFileBasicInfoWidget *widget = new MultiFileBasicInfoWidget(urls);
+    EXPECT_NE(widget, nullptr);
+    delete widget;
+}
+
+TEST_F(MultiFileBasicInfoWidgetImpl, GetOrgHideBoxStateUnchecked)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()), QUrl::fromLocalFile(tempFile2->fileName()) };
+
+    MultiFileBasicInfoWidget widget(urls);
+    FilePropertyState state;
+    widget.getOrgHideBoxState(state);
+    EXPECT_EQ(state.hideState, Qt::Unchecked);
+}
+
+TEST_F(MultiFileBasicInfoWidgetImpl, GetOrgHideBoxStateHiddenFileNotManaged)
+{
+    // setHideState() refuses to manage dot-prefixed files
+    // ("the hidden attribute does not manage files starting with '.'"):
+    // it disables the checkbox and returns without setting
+    // PartiallyChecked, so no real filesystem state can produce it.
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFileHidden->fileName()), QUrl::fromLocalFile(tempFile2->fileName()) };
+
+    MultiFileBasicInfoWidget widget(urls);
+    FilePropertyState state;
+    widget.getOrgHideBoxState(state);
+    EXPECT_EQ(state.hideState, Qt::Unchecked);
+}
+
+TEST_F(MultiFileBasicInfoWidgetImpl, FilesHideStateChanged)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()), QUrl::fromLocalFile(tempFile2->fileName()) };
+
+    MultiFileBasicInfoWidget widget(urls);
+    bool emitted = false;
+    QObject::connect(&widget, &MultiFileBasicInfoWidget::hideBoxStateChanged, [&emitted](int) { emitted = true; });
+
+    QMetaObject::invokeMethod(&widget, "filesHideStateChanged", Q_ARG(int, Qt::Checked));
+    EXPECT_TRUE(emitted);
+}
+
+TEST_F(MultiFileBasicInfoWidgetImpl, UpdateFilesCountAndSizeLabel)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()), QUrl::fromLocalFile(tempFile2->fileName()) };
+
+    MultiFileBasicInfoWidget widget(urls);
+    FileScanner::ScanResult result;
+    result.totalSize = 8192;
+    result.fileCount = 3;
+    result.directoryCount = 1;
+    EXPECT_NO_THROW(widget.updateFilesCountAndSizeLabel(result));
+}

--- a/autotests/plugins/dfmplugin-propertydialog/ut_multifilepermissionwidget.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/ut_multifilepermissionwidget.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QTemporaryFile>
+#include <QTemporaryDir>
+#include <memory>
+
+#include "stubext.h"
+#include "dfmplugin_propertydialog_global.h"
+#include "views/multifilepermissionwidget.h"
+
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/base/urlroute.h>
+#include <dfm-base/file/local/syncfileinfo.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+class MultiFilePermissionWidgetImpl : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub.clear();
+        UrlRoute::regScheme(Global::Scheme::kFile, "/");
+        InfoFactory::regClass<SyncFileInfo>(Global::Scheme::kFile);
+        tempDir.reset(new QTemporaryDir);
+        tempFile1.reset(new QTemporaryFile(tempDir->path() + "/perm1XXXXXX.txt"));
+        tempFile2.reset(new QTemporaryFile(tempDir->path() + "/perm2XXXXXX.txt"));
+        tempFile1->open();
+        tempFile2->open();
+        tempFile1->setPermissions(QFile::ReadOwner | QFile::WriteOwner
+                                  | QFile::ReadGroup);
+        tempFile2->setPermissions(QFile::ReadOwner | QFile::WriteOwner
+                                  | QFile::ReadGroup);
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+        tempFile1.reset();
+        tempFile2.reset();
+        tempDir.reset();
+    }
+
+    stub_ext::StubExt stub;
+    std::unique_ptr<QTemporaryDir> tempDir;
+    std::unique_ptr<QTemporaryFile> tempFile1;
+    std::unique_ptr<QTemporaryFile> tempFile2;
+};
+
+TEST_F(MultiFilePermissionWidgetImpl, ConstructDestruct)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()),
+                       QUrl::fromLocalFile(tempFile2->fileName()) };
+    MultiFilePermissionWidget *widget = new MultiFilePermissionWidget(urls);
+    EXPECT_NE(widget, nullptr);
+    delete widget;
+}
+
+TEST_F(MultiFilePermissionWidgetImpl, ConstructEmptyUrls)
+{
+    // loadData() must bail out early for an empty url list without crashing.
+    EXPECT_NO_THROW({
+        MultiFilePermissionWidget widget(QList<QUrl>());
+    });
+}
+
+TEST_F(MultiFilePermissionWidgetImpl, GetOrgPermissonBoxState)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()),
+                       QUrl::fromLocalFile(tempFile2->fileName()) };
+    MultiFilePermissionWidget widget(urls);
+
+    FilePropertyState state;
+    widget.getOrgPermissonBoxState(state);
+    EXPECT_GE(state.ownerIndex, -1);
+    EXPECT_GE(state.groupIndex, -1);
+    EXPECT_GE(state.otherIndex, -1);
+}
+
+TEST_F(MultiFilePermissionWidgetImpl, CanChmodByFs)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()) };
+    MultiFilePermissionWidget widget(urls);
+
+    // The temp dir lives on a local filesystem that is not in the blocked
+    // list (vfat/fuseblk/cifs) and no plugin hook disables it, so chmod is
+    // allowed.
+    bool ret = widget.canChmodByFs(urls.first());
+    EXPECT_TRUE(ret);
+}
+
+TEST_F(MultiFilePermissionWidgetImpl, CanChmodByFile)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()) };
+    MultiFilePermissionWidget widget(urls);
+
+    // Own existing local file: the current user created it, so it is owned
+    // by the current uid and can be chmod'ed.
+    FileInfoPointer info = InfoFactory::create<FileInfo>(urls.first());
+    EXPECT_FALSE(info.isNull());
+    bool ret = widget.canChmodByFile(info);
+    EXPECT_TRUE(ret);
+
+    // Null info is rejected.
+    FileInfoPointer nullInfo;
+    EXPECT_FALSE(widget.canChmodByFile(nullInfo));
+
+    // Non-existent file is rejected.
+    QUrl missingUrl = QUrl::fromLocalFile(tempDir->path() + "/no_such_file.txt");
+    FileInfoPointer missingInfo = InfoFactory::create<FileInfo>(missingUrl);
+    if (!missingInfo.isNull())
+        EXPECT_FALSE(widget.canChmodByFile(missingInfo));
+
+    // A file owned by another user (root) is rejected. Unregistered scheme
+    // falls back to the null-info path.
+    FileInfoPointer virtualInfo = InfoFactory::create<FileInfo>(QUrl("virtual://no-such"));
+    EXPECT_TRUE(virtualInfo.isNull());
+}
+
+TEST_F(MultiFilePermissionWidgetImpl, DisablePermissionComboBox)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()) };
+    MultiFilePermissionWidget widget(urls);
+
+    EXPECT_NO_THROW(widget.disablePermissionComboBox());
+    EXPECT_FALSE(widget.ownerComboBox->isEnabled());
+    EXPECT_FALSE(widget.groupComboBox->isEnabled());
+    EXPECT_FALSE(widget.otherComboBox->isEnabled());
+}
+
+TEST_F(MultiFilePermissionWidgetImpl, UpdateComboBoxViewPalette)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()) };
+    MultiFilePermissionWidget widget(urls);
+
+    EXPECT_NO_THROW(widget.updateComboBoxViewPalette());
+}
+
+TEST_F(MultiFilePermissionWidgetImpl, OnComboBoxChanged)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile(tempFile1->fileName()) };
+    MultiFilePermissionWidget widget(urls);
+
+    int ownerEmitted = -1;
+    int groupEmitted = -1;
+    int otherEmitted = -1;
+    QObject::connect(&widget, &MultiFilePermissionWidget::ownerComboxChanged,
+                     [&](int i) { ownerEmitted = i; });
+    QObject::connect(&widget, &MultiFilePermissionWidget::groupComboxChanged,
+                     [&](int i) { groupEmitted = i; });
+    QObject::connect(&widget, &MultiFilePermissionWidget::otherComboxChanged,
+                     [&](int i) { otherEmitted = i; });
+
+    // Valid indexes are forwarded, invalid ones are swallowed.
+    widget.onOwnerComboBoxChanged(1);
+    EXPECT_EQ(ownerEmitted, 1);
+    widget.onOwnerComboBoxChanged(5);
+    EXPECT_EQ(ownerEmitted, 1);
+    widget.onGroupComboBoxChanged(2);
+    EXPECT_EQ(groupEmitted, 2);
+    widget.onGroupComboBoxChanged(-1);
+    EXPECT_EQ(groupEmitted, 2);
+    widget.onOtherComboBoxChanged(0);
+    EXPECT_EQ(otherEmitted, 0);
+    widget.onOtherComboBoxChanged(3);
+    EXPECT_EQ(otherEmitted, 0);
+}

--- a/autotests/plugins/dfmplugin-propertydialog/ut_propertydialogutil.cpp
+++ b/autotests/plugins/dfmplugin-propertydialog/ut_propertydialogutil.cpp
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <QTest>
+#include <QUrl>
+#include <QTimer>
+#include <QApplication>
+
+#include "stubext.h"
+#include "dfmplugin_propertydialog_global.h"
+#include "utils/propertydialogutil.h"
+#include "utils/propertydialogmanager.h"
+#include "views/filepropertydialog.h"
+#include "views/closealldialog.h"
+
+#include <dfm-framework/event/eventsequence.h>
+#include <dfm-base/utils/windowutils.h>
+
+DPPROPERTYDIALOG_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+using namespace DPF_NAMESPACE;
+
+class PropertyDialogUtilImpl : public testing::Test
+{
+protected:
+    void SetUp() override { stub.clear(); }
+    void TearDown() override { stub.clear(); }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(PropertyDialogUtilImpl, Instance)
+{
+    PropertyDialogUtil *u1 = PropertyDialogUtil::instance();
+    PropertyDialogUtil *u2 = PropertyDialogUtil::instance();
+    EXPECT_NE(u1, nullptr);
+    EXPECT_EQ(u1, u2);
+}
+
+TEST_F(PropertyDialogUtilImpl, ConstructorDestructor)
+{
+    PropertyDialogUtil *util = new PropertyDialogUtil();
+    EXPECT_NE(util, nullptr);
+    EXPECT_NE(util->closeIndicatorTimer, nullptr);
+    EXPECT_EQ(util->closeIndicatorTimer->interval(), 1000);
+    delete util;
+}
+
+TEST_F(PropertyDialogUtilImpl, ShowPropertyDialogSingle)
+{
+    PropertyDialogUtil util;
+
+    // The product calls run(space, topic, url) with T deduced as QUrl (by
+    // value); casting to a const QUrl& signature would instantiate a
+    // *different* function and the stub would never take effect.
+    typedef bool (EventSequenceManager::*RunFunc)(const QString &, const QString &, QUrl);
+    auto run = static_cast<RunFunc>(&EventSequenceManager::run);
+    bool hookCalled = false;
+    stub.set_lamda(run, [&hookCalled](EventSequenceManager *, const QString &, const QString &, QUrl) -> bool {
+        hookCalled = true;
+        return false;
+    });
+
+    bool customCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showCustomDialog, [&customCalled](PropertyDialogUtil *, const QUrl &) -> bool {
+        customCalled = true;
+        return false;
+    });
+
+    bool fileCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::showFilePropertyDialog, [&fileCalled](PropertyDialogUtil *, const QList<QUrl> &, const QVariantHash &) {
+        fileCalled = true;
+    });
+
+    QList<QUrl> urls { QUrl::fromLocalFile("/tmp/ut-propertydialogutil-a") };
+    util.showPropertyDialog(urls, QVariantHash());
+
+    EXPECT_TRUE(hookCalled);
+    EXPECT_TRUE(customCalled);
+    EXPECT_TRUE(fileCalled);
+}
+
+TEST_F(PropertyDialogUtilImpl, ShowFilePropertyDialogSingle)
+{
+    PropertyDialogUtil util;
+
+    stub.set_lamda(&FilePropertyDialog::selectFileUrl, [](FilePropertyDialog *, const QUrl &) {});
+    stub.set_lamda(&FilePropertyDialog::filterControlView, [](FilePropertyDialog *) {});
+    stub.set_lamda(&FilePropertyDialog::setBasicInfoExpand, [](FilePropertyDialog *, bool) {});
+    stub.set_lamda(&FilePropertyDialog::size, [](QWidget *) -> QSize { return QSize(380, 400); });
+    stub.set_lamda(&FilePropertyDialog::initalHeightOfView, [](FilePropertyDialog *) -> int { return 300; });
+    stub.set_lamda(static_cast<void (FilePropertyDialog::*)(const QPoint &)>(&FilePropertyDialog::move),
+                   [](QWidget *, const QPoint &) {});
+    stub.set_lamda(&FilePropertyDialog::show, [](QWidget *) {});
+    stub.set_lamda(&FilePropertyDialog::activateWindow, [](QWidget *) {});
+
+    bool createViewCalled = false;
+    stub.set_lamda(&PropertyDialogUtil::createView, [&createViewCalled](PropertyDialogUtil *, const QUrl &, const QVariantHash &) -> QMap<int, QWidget *> {
+        createViewCalled = true;
+        return {};
+    });
+
+    QList<QUrl> urls { QUrl::fromLocalFile("/tmp/ut-propertydialogutil-b") };
+    QVariantHash option;
+    option.insert(kOption_Key_BasicInfoExpand, true);
+    util.showFilePropertyDialog(urls, option);
+
+    EXPECT_TRUE(createViewCalled);
+}
+
+TEST_F(PropertyDialogUtilImpl, ShowFilePropertyDialogExisting)
+{
+    PropertyDialogUtil util;
+
+    bool showCalled = false;
+    bool activateCalled = false;
+    stub.set_lamda(&FilePropertyDialog::show, [&showCalled](QWidget *) { showCalled = true; });
+    stub.set_lamda(&FilePropertyDialog::activateWindow, [&activateCalled](QWidget *) { activateCalled = true; });
+    stub.set_lamda(&FilePropertyDialog::selectFileUrl, [](FilePropertyDialog *, const QUrl &) {});
+    stub.set_lamda(&FilePropertyDialog::filterControlView, [](FilePropertyDialog *) {});
+    stub.set_lamda(&FilePropertyDialog::setBasicInfoExpand, [](FilePropertyDialog *, bool) {});
+    stub.set_lamda(&FilePropertyDialog::size, [](QWidget *) -> QSize { return QSize(380, 400); });
+    stub.set_lamda(&FilePropertyDialog::initalHeightOfView, [](FilePropertyDialog *) -> int { return 300; });
+    stub.set_lamda(static_cast<void (FilePropertyDialog::*)(const QPoint &)>(&FilePropertyDialog::move),
+                   [](QWidget *, const QPoint &) {});
+
+    QUrl url = QUrl::fromLocalFile("/tmp/ut-propertydialogutil-c");
+    util.showFilePropertyDialog({ url }, QVariantHash());
+    showCalled = false;
+    activateCalled = false;
+    util.showFilePropertyDialog({ url }, QVariantHash());
+
+    EXPECT_TRUE(showCalled);
+    EXPECT_TRUE(activateCalled);
+}
+
+TEST_F(PropertyDialogUtilImpl, InsertExtendedControlFileProperty)
+{
+    PropertyDialogUtil util;
+
+    QUrl url = QUrl::fromLocalFile("/tmp/ut-propertydialogutil-d");
+    QWidget *w1 = new QWidget();
+    QWidget *w2 = new QWidget();
+    QWidget *w3 = new QWidget();
+
+    EXPECT_NO_THROW(util.insertExtendedControlFileProperty(url, 0, w1));
+    EXPECT_NO_THROW(util.addExtendedControlFileProperty(url, w2));
+    EXPECT_NO_THROW(util.addExtendedControlFileProperty(url, w3, [](QWidget *, const QUrl &) {}));
+
+    util.closeAllFilePropertyDialog();
+}
+
+TEST_F(PropertyDialogUtilImpl, RenameFilePropertyDialog)
+{
+    PropertyDialogUtil util;
+
+    stub.set_lamda(&FilePropertyDialog::selectFileUrl, [](FilePropertyDialog *, const QUrl &) {});
+    stub.set_lamda(&FilePropertyDialog::filterControlView, [](FilePropertyDialog *) {});
+    stub.set_lamda(&FilePropertyDialog::setBasicInfoExpand, [](FilePropertyDialog *, bool) {});
+    stub.set_lamda(&FilePropertyDialog::size, [](QWidget *) -> QSize { return QSize(380, 400); });
+    stub.set_lamda(&FilePropertyDialog::initalHeightOfView, [](FilePropertyDialog *) -> int { return 300; });
+    stub.set_lamda(static_cast<void (FilePropertyDialog::*)(const QPoint &)>(&FilePropertyDialog::move),
+                   [](QWidget *, const QPoint &) {});
+    stub.set_lamda(&FilePropertyDialog::show, [](QWidget *) {});
+    stub.set_lamda(&FilePropertyDialog::activateWindow, [](QWidget *) {});
+    stub.set_lamda(&PropertyDialogUtil::createView, [](PropertyDialogUtil *, const QUrl &, const QVariantHash &) -> QMap<int, QWidget *> {
+        return {};
+    });
+
+    QUrl oldUrl = QUrl::fromLocalFile("/tmp/ut-propertydialogutil-old");
+    QUrl newUrl = QUrl::fromLocalFile("/tmp/ut-propertydialogutil-new");
+    util.showFilePropertyDialog({ oldUrl }, QVariantHash());
+    util.renameFilePropertyDialog(oldUrl, newUrl);
+
+    EXPECT_NO_THROW(util.closeFilePropertyDialog(newUrl));
+}
+
+TEST_F(PropertyDialogUtilImpl, CloseCustomPropertyDialog)
+{
+    PropertyDialogUtil util;
+
+    QUrl url = QUrl::fromLocalFile("/tmp/ut-propertydialogutil-custom");
+    QWidget *widget = new QWidget();
+    widget->setProperty("ForecastDisplayHeight", 200);
+
+    stub.set_lamda(&PropertyDialogUtil::createCustomizeView, [widget](PropertyDialogUtil *, const QUrl &) -> QWidget * { return widget; });
+    stub.set_lamda(&QWidget::show, [](QWidget *) {});
+    stub.set_lamda(&QWidget::activateWindow, [](QWidget *) {});
+    stub.set_lamda(static_cast<void (QWidget::*)(const QPoint &)>(&QWidget::move),
+                   [](QWidget *, const QPoint &) {});
+
+    EXPECT_TRUE(util.showCustomDialog(url));
+    EXPECT_NO_THROW(util.closeCustomPropertyDialog(url));
+    delete widget;
+}
+
+TEST_F(PropertyDialogUtilImpl, CloseAllFilePropertyDialog)
+{
+    PropertyDialogUtil util;
+
+    stub.set_lamda(&FilePropertyDialog::selectFileUrl, [](FilePropertyDialog *, const QUrl &) {});
+    stub.set_lamda(&FilePropertyDialog::filterControlView, [](FilePropertyDialog *) {});
+    stub.set_lamda(&FilePropertyDialog::setBasicInfoExpand, [](FilePropertyDialog *, bool) {});
+    stub.set_lamda(&FilePropertyDialog::size, [](QWidget *) -> QSize { return QSize(380, 400); });
+    stub.set_lamda(&FilePropertyDialog::initalHeightOfView, [](FilePropertyDialog *) -> int { return 300; });
+    stub.set_lamda(static_cast<void (FilePropertyDialog::*)(const QPoint &)>(&FilePropertyDialog::move),
+                   [](QWidget *, const QPoint &) {});
+    stub.set_lamda(&FilePropertyDialog::show, [](QWidget *) {});
+    stub.set_lamda(&FilePropertyDialog::activateWindow, [](QWidget *) {});
+    stub.set_lamda(&PropertyDialogUtil::createView, [](PropertyDialogUtil *, const QUrl &, const QVariantHash &) -> QMap<int, QWidget *> {
+        return {};
+    });
+
+    util.showFilePropertyDialog({ QUrl::fromLocalFile("/tmp/ut-propertydialogutil-e1") }, QVariantHash());
+    util.showFilePropertyDialog({ QUrl::fromLocalFile("/tmp/ut-propertydialogutil-e2") }, QVariantHash());
+    EXPECT_NO_THROW(util.closeAllFilePropertyDialog());
+}
+
+TEST_F(PropertyDialogUtilImpl, UpdateCloseIndicator)
+{
+    PropertyDialogUtil util;
+
+    stub.set_lamda(&FilePropertyDialog::selectFileUrl, [](FilePropertyDialog *, const QUrl &) {});
+    stub.set_lamda(&FilePropertyDialog::filterControlView, [](FilePropertyDialog *) {});
+    stub.set_lamda(&FilePropertyDialog::setBasicInfoExpand, [](FilePropertyDialog *, bool) {});
+    stub.set_lamda(&FilePropertyDialog::size, [](QWidget *) -> QSize { return QSize(380, 400); });
+    stub.set_lamda(&FilePropertyDialog::initalHeightOfView, [](FilePropertyDialog *) -> int { return 300; });
+    stub.set_lamda(static_cast<void (FilePropertyDialog::*)(const QPoint &)>(&FilePropertyDialog::move),
+                   [](QWidget *, const QPoint &) {});
+    stub.set_lamda(&FilePropertyDialog::show, [](QWidget *) {});
+    stub.set_lamda(&FilePropertyDialog::activateWindow, [](QWidget *) {});
+    stub.set_lamda(&PropertyDialogUtil::createView, [](PropertyDialogUtil *, const QUrl &, const QVariantHash &) -> QMap<int, QWidget *> {
+        return {};
+    });
+
+    stub.set_lamda(&FilePropertyDialog::getFileSize, [](FilePropertyDialog *) -> qint64 { return 100; });
+    stub.set_lamda(&FilePropertyDialog::getFileCount, [](FilePropertyDialog *) -> int { return 2; });
+
+    bool setTotal = false;
+    stub.set_lamda(&CloseAllDialog::setTotalMessage, [&setTotal](CloseAllDialog *, qint64, int) { setTotal = true; });
+
+    util.showFilePropertyDialog({ QUrl::fromLocalFile("/tmp/ut-propertydialogutil-f") }, QVariantHash());
+    util.updateCloseIndicator();
+    EXPECT_TRUE(setTotal);
+}


### PR DESCRIPTION
Part 2/2 of dfmplugin-propertydialog unit tests, split by module for easier review:
属性页组件.

Test files only; CMakeLists.txt/main.cpp are carried by part 1.
Build activation is via the registration PR (merged last).

dfmplugin-propertydialog 单元测试第 2/2 部分（按模块拆分以便评审）：属性页组件。

本部分仅含测试文件，CMakeLists.txt/main.cpp 在第 1 部分；
构建接入由注册 PR（最后合入）完成。

Log: 新增 dfmplugin-propertydialog 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Tests:
- Add unit coverage for property dialogs, widgets, file editing interactions, permissions, metadata, and dialog-management utilities in dfmplugin-propertydialog.