### PR TITLE
test: add unit tests for dfmplugin-recent

### DIFF
--- a/autotests/plugins/dfmplugin-recent/CMakeLists.txt
+++ b/autotests/plugins/dfmplugin-recent/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Use DFM enhanced test utilities to create plugin test
+dfm_create_plugin_test_enhanced("dfmplugin-recent" "${DFM_SOURCE_DIR}/plugins/filemanager/dfmplugin-recent")

--- a/autotests/plugins/dfmplugin-recent/main.cpp
+++ b/autotests/plugins/dfmplugin-recent/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "dfm_test_main.h"
+
+DFM_TEST_MAIN(dfmplugin_recent)

--- a/autotests/plugins/dfmplugin-recent/test_followevents_real.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_followevents_real.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Integration-style test: register hook event types then run the recent plugin's
+// REAL followEvents()/bindEvents() (not stubbed) so the production EventHelper<M>
+// template instantiations in recent.cpp actually execute -> cover framework
+// event templates (eventhelper.h / invokehelper.h) attributed to the headers.
+#include "stubext.h"
+
+#include "recent.h"
+#include "utils/recentmanager.h"
+#include "utils/recentfilehelper.h"
+#include "events/recenteventreceiver.h"
+
+#include <dfm-framework/dpf.h>
+#include <dfm-framework/event/event.h>
+#include <dfm-framework/event/eventhelper.h>
+
+#include <gtest/gtest.h>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_recent;
+using namespace dpf;
+
+Q_DECLARE_METATYPE(QString *)
+Q_DECLARE_METATYPE(bool *)
+Q_DECLARE_METATYPE(Qt::DropAction *)
+Q_DECLARE_METATYPE(QList<QVariantMap> *)
+Q_DECLARE_METATYPE(QFlags<QFileDevice::Permission>)
+
+// Register every hook event type that Recent::followEvents() depends on. These
+// are normally registered by constructing the *other* plugins' instances (their
+// DPF_EVENT_REG_HOOK members), but those libraries are not linked into this
+// test binary, so we register the custom event ids manually.
+static void registerRecentHookEvents(dpf::Event *evt)
+{
+    using S = dpf::EventStratege;
+    // workspace hooks
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Model_FetchCustomColumnRoles");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Model_FetchCustomRoleDisplayName");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_Delegate_CheckTransparent");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_CheckDragDropAction");
+    evt->registerEventType(S::kHook, "dfmplugin_workspace", "hook_DragDrop_FileDrop");
+    // detailspace hook
+    evt->registerEventType(S::kHook, "dfmplugin_detailspace", "hook_Icon_Fetch");
+    // titlebar hook
+    evt->registerEventType(S::kHook, "dfmplugin_titlebar", "hook_Crumb_Seprate");
+    // propertydialog hook
+    evt->registerEventType(S::kHook, "dfmplugin_propertydialog", "hook_PropertyDialog_Disable");
+    // fileoperations hooks
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CutToFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_CopyFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_MoveToTrash");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_DeleteFile");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_OpenFileInPlugin");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_WriteUrlsToClipboard");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_OpenInTerminal");
+    evt->registerEventType(S::kHook, "dfmplugin_fileoperations", "hook_Operation_SetPermission");
+}
+
+class RecentFollowEventsTest : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        registerRecentHookEvents(dpf::Event::instance());
+        // Only stub the genuinely unsafe paths; let followEvents/bindEvents run for real.
+        stub.set_lamda(&RecentManager::init, [] { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&Recent::bindWindows, [] { __DBG_STUB_INVOKE__ });
+    }
+    void TearDown() override { stub.clear(); }
+    stub_ext::StubExt stub;
+    Recent ins;
+};
+
+// Run the real followEvents + bindEvents path (initialize calls both) so the
+// EventHelper<M> template instantiations in recent.cpp execute and get covered.
+TEST_F(RecentFollowEventsTest, Initialize_RunsRealFollowAndBindEvents_NoCrash)
+{
+    EXPECT_NO_FATAL_FAILURE(ins.initialize());
+}

--- a/autotests/plugins/dfmplugin-recent/test_recent.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recent.cpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "recent.h"
+#include "utils/recentmanager.h"
+#include "utils/recentfilehelper.h"
+#include "events/recenteventreceiver.h"
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/widgets/filemanagerwindowsmanager.h>
+
+#include <gtest/gtest.h>
+
+#include <QPaintEvent>
+#include <QPainter>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_recent;
+using namespace dpf;
+
+Q_DECLARE_METATYPE(QString *)
+Q_DECLARE_METATYPE(bool *)
+Q_DECLARE_METATYPE(Qt::DropAction *)
+Q_DECLARE_METATYPE(QList<QVariantMap> *)
+Q_DECLARE_METATYPE(QFlags<QFileDevice::Permission>)
+
+class RecentTest : public testing::Test
+{
+
+protected:
+    virtual void SetUp() override { }
+    virtual void TearDown() override { stub.clear(); }
+
+private:
+    stub_ext::StubExt stub;
+    Recent ins;
+};
+
+TEST_F(RecentTest, Initialize)
+{
+    stub.set_lamda(&RecentManager::init, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&Recent::bindWindows, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&Recent::followEvents, [] { __DBG_STUB_INVOKE__ });
+    EXPECT_NO_FATAL_FAILURE(ins.initialize());
+}
+
+TEST_F(RecentTest, Start)
+{
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, QString);
+    typedef QVariant (EventChannelManager::*Push2)(const QString &, const QString &, QString, QString &);
+    typedef QVariant (EventChannelManager::*Push3)(const QString &, const QString &, QString, QStringList &);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    auto push2 = static_cast<Push2>(&EventChannelManager::push);
+    auto push3 = static_cast<Push3>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    stub.set_lamda(push3, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    stub.set_lamda(&RecentManager::init, []() {});
+    // type of RecentFileHelper::setPermissionHandle
+    typedef bool (RecentFileHelper::*HookFunc1)(const quint64, const QUrl, QFileDevice::Permissions, bool *, QString *);
+    typedef bool (EventSequenceManager::*HookType1)(const QString &, const QString &, RecentFileHelper *, HookFunc1);
+
+    auto follow1 = static_cast<HookType1>(&EventSequenceManager::follow);
+    stub.set_lamda(follow1, [] { return true; });
+
+    EXPECT_TRUE(ins.start());
+}
+
+TEST_F(RecentTest, addRecentItem)
+{
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, const QVariantMap &);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    typedef QVariant (EventChannelManager::*Push2)(const QString &, const QString &, const QUrl &, const QVariantMap &);
+    auto push2 = static_cast<Push2>(&EventChannelManager::push);
+    stub.set_lamda(push2, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.updateRecentItemToSideBar());
+}
+
+TEST_F(RecentTest, onWindowOpened)
+{
+    DFMBASE_USE_NAMESPACE
+    FileManagerWindow *win = new FileManagerWindow(QUrl::fromLocalFile("/hello/world"));
+    stub.set_lamda(&FileManagerWindowsManager::findWindowById, [win] { __DBG_STUB_INVOKE__ return win; });
+    stub.set_lamda(&FileManagerWindow::sideBar, [] { __DBG_STUB_INVOKE__ return reinterpret_cast<AbstractFrame *>(1); });
+
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, const QString &, const QVariantMap &);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+    EXPECT_NO_FATAL_FAILURE(ins.regRecentCrumbToTitleBar());
+
+    stub.set_lamda(&Recent::updateRecentItemToSideBar, [] {});
+    stub.set_lamda(&Application::genericAttribute, []() -> bool {
+        return true;
+    });
+
+    stub.set_lamda(&Recent::regRecentCrumbToTitleBar, [] { __DBG_STUB_INVOKE__ });
+
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(1));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(2));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(3));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(-10086));
+
+    stub.set_lamda(&FileManagerWindow::sideBar, [] { __DBG_STUB_INVOKE__ return nullptr; });
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(1));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(2));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(3));
+    EXPECT_NO_FATAL_FAILURE(ins.onWindowOpened(-10086));
+    delete win;
+}
+
+TEST_F(RecentTest, FollowEvents)
+{
+    stub_ext::StubExt st;
+    st.set_lamda(&RecentManager::init, []() {});
+    // type of RecentManager::customColumnRole
+    typedef bool (RecentManager::*HookFunc1)(const QUrl &, QList<Global::ItemRoles> *);
+    typedef bool (EventSequenceManager::*HookType1)(const QString &, const QString &, RecentManager *, HookFunc1);
+
+    // type of RecentManager::customRoleDisplayName
+    typedef bool (RecentManager::*HookFunc2)(const QUrl &, const Global::ItemRoles, QString *);
+    typedef bool (EventSequenceManager::*HookType2)(const QString &, const QString &, RecentManager *, HookFunc2);
+
+    // type of RecentManager::isTransparent
+    typedef bool (RecentManager::*HookFunc3)(const QUrl &, DFMGLOBAL_NAMESPACE::TransparentStatus *);
+    typedef bool (EventSequenceManager::*HookType3)(const QString &, const QString &, RecentManager *, HookFunc3);
+
+    // type of RecentManager::checkDragDropAction
+    typedef bool (RecentManager::*HookFunc4)(const QList<QUrl> &, const QUrl &, Qt::DropAction *);
+    typedef bool (EventSequenceManager::*HookType4)(const QString &, const QString &, RecentManager *, HookFunc4);
+
+    // type of RecentManager::handleDropFiles
+    typedef bool (RecentManager::*HookFunc5)(const QList<QUrl> &, const QUrl &);
+    typedef bool (EventSequenceManager::*HookType5)(const QString &, const QString &, RecentManager *, HookFunc5);
+
+    // type of RecentManager::detailViewIcon
+    typedef bool (RecentManager::*HookFunc6)(const QUrl &, QString *);
+    typedef bool (EventSequenceManager::*HookType6)(const QString &, const QString &, RecentManager *, HookFunc6);
+
+    // type of RecentManager::sepateTitlebarCrumb
+    typedef bool (RecentManager::*HookFunc7)(const QUrl &, QList<QVariantMap> *);
+    typedef bool (EventSequenceManager::*HookType7)(const QString &, const QString &, RecentManager *, HookFunc7);
+
+    // type of RecentFileHelper::cutFile
+    typedef bool (RecentFileHelper::*HookFunc8)(const quint64, const QList<QUrl>,
+                                                const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags);
+    typedef bool (EventSequenceManager::*HookType8)(const QString &, const QString &, RecentFileHelper *, HookFunc8);
+
+    // type of RecentFileHelper::copyFile
+    typedef bool (RecentFileHelper::*HookFunc9)(const quint64, const QList<QUrl>,
+                                                const QUrl, const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags);
+    typedef bool (EventSequenceManager::*HookType9)(const QString &, const QString &, RecentFileHelper *, HookFunc9);
+
+    // type of RecentFileHelper::moveToTrash
+    typedef bool (RecentFileHelper::*HookFunc10)(const quint64, const QList<QUrl>,
+                                                 const DFMBASE_NAMESPACE::AbstractJobHandler::JobFlags);
+    typedef bool (EventSequenceManager::*HookType10)(const QString &, const QString &, RecentFileHelper *, HookFunc10);
+
+    // type of RecentFileHelper::moveToTrash
+    typedef bool (EventSequenceManager::*HookType11)(const QString &, const QString &, RecentFileHelper *, HookFunc10);
+
+    // type of RecentFileHelper::openFileInPlugin
+    typedef bool (RecentFileHelper::*HookFunc12)(quint64, QList<QUrl>);
+    typedef bool (EventSequenceManager::*HookType12)(const QString &, const QString &, RecentFileHelper *, HookFunc12);
+
+    // type of RecentFileHelper::linkFile
+    typedef bool (RecentFileHelper::*HookFunc13)(const quint64, const QUrl, const QUrl, const bool, const bool);
+    typedef bool (EventSequenceManager::*HookType13)(const QString &, const QString &, RecentFileHelper *, HookFunc13);
+
+    // type of RecentFileHelper::writeUrlsToClipboard
+    typedef bool (RecentFileHelper::*HookFunc14)(const quint64, const DFMBASE_NAMESPACE::ClipBoard::ClipboardAction,
+                                                 const QList<QUrl>);
+    typedef bool (EventSequenceManager::*HookType14)(const QString &, const QString &, RecentFileHelper *, HookFunc14);
+
+    // type of RecentFileHelper::openFileInTerminal
+    typedef bool (RecentFileHelper::*HookFunc15)(const quint64, const QList<QUrl>);
+    typedef bool (EventSequenceManager::*HookType15)(const QString &, const QString &, RecentFileHelper *, HookFunc15);
+
+    auto follow1 = static_cast<HookType1>(&EventSequenceManager::follow);
+    st.set_lamda(follow1, [] { return true; });
+    auto follow2 = static_cast<HookType2>(&EventSequenceManager::follow);
+    st.set_lamda(follow2, [] { return true; });
+    auto follow3 = static_cast<HookType3>(&EventSequenceManager::follow);
+    st.set_lamda(follow3, [] { return true; });
+    auto follow4 = static_cast<HookType4>(&EventSequenceManager::follow);
+    st.set_lamda(follow4, [] { return true; });
+    auto follow5 = static_cast<HookType5>(&EventSequenceManager::follow);
+    st.set_lamda(follow5, [] { return true; });
+    auto follow6 = static_cast<HookType6>(&EventSequenceManager::follow);
+    st.set_lamda(follow6, [] { return true; });
+    auto follow7 = static_cast<HookType7>(&EventSequenceManager::follow);
+    st.set_lamda(follow7, [] { return true; });
+    auto follow8 = static_cast<HookType8>(&EventSequenceManager::follow);
+    st.set_lamda(follow8, [] { return true; });
+    auto follow9 = static_cast<HookType9>(&EventSequenceManager::follow);
+    st.set_lamda(follow9, [] { return true; });
+    auto follow10 = static_cast<HookType10>(&EventSequenceManager::follow);
+    st.set_lamda(follow10, [] { return true; });
+    auto follow11 = static_cast<HookType11>(&EventSequenceManager::follow);
+    st.set_lamda(follow11, [] { return true; });
+    auto follow12 = static_cast<HookType12>(&EventSequenceManager::follow);
+    st.set_lamda(follow12, [] { return true; });
+    auto follow13 = static_cast<HookType13>(&EventSequenceManager::follow);
+    st.set_lamda(follow13, [] { return true; });
+    auto follow14 = static_cast<HookType14>(&EventSequenceManager::follow);
+    st.set_lamda(follow14, [] { return true; });
+    auto follow15 = static_cast<HookType15>(&EventSequenceManager::follow);
+    st.set_lamda(follow15, [] { return true; });
+
+    EXPECT_NO_FATAL_FAILURE(ins.followEvents());
+}
+
+TEST_F(RecentTest, BindWindows)
+{
+    stub.set_lamda(&Recent::onWindowOpened, [] { __DBG_STUB_INVOKE__ });
+    stub.set_lamda(&FileManagerWindowsManager::windowIdList, [] { __DBG_STUB_INVOKE__ return QList<quint64> { 1, 2, 3 }; });
+    EXPECT_NO_FATAL_FAILURE(ins.bindWindows());
+}

--- a/autotests/plugins/dfmplugin-recent/test_recentdiriterator.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentdiriterator.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "files/recentdiriterator.h"
+#include "utils/recentmanager.h"
+#include <dfm-base/base/application/application.h>
+
+#include <gtest/gtest.h>
+
+#include <QPaintEvent>
+#include <QPainter>
+
+DFMBASE_USE_NAMESPACE
+        using namespace dfmplugin_recent;
+
+class RecentDirIteratorTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        stub.set_lamda(&RecentManager::init, [] { __DBG_STUB_INVOKE__ });
+        stub.set_lamda(&RecentManager::getRecentNodes, []() -> QMap<QUrl, FileInfoPointer> {
+            QMap<QUrl, FileInfoPointer> map;
+            map[QUrl("recent:/hello/world")] = nullptr;
+            return map;
+        });
+        iter = new RecentDirIterator(QUrl::fromLocalFile("/"), {}, QDir::AllEntries);
+        d = iter->d.data();
+    }
+
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete iter;
+        iter = nullptr;
+    }
+
+private:
+    stub_ext::StubExt stub;
+    RecentDirIterator *iter { nullptr };
+    RecentDirIteratorPrivate *d { nullptr };
+};
+
+TEST_F(RecentDirIteratorTest, Next)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->next());
+    EXPECT_FALSE(iter->next().isValid());
+}
+
+TEST_F(RecentDirIteratorTest, HasNext)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->hasNext());
+    EXPECT_TRUE(iter->hasNext());
+}
+
+TEST_F(RecentDirIteratorTest, FileName)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->fileName());
+    EXPECT_TRUE(iter->fileName() == "");
+}
+
+TEST_F(RecentDirIteratorTest, FileUrl)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->fileUrl());
+    EXPECT_FALSE(iter->fileUrl().isValid());
+}
+
+TEST_F(RecentDirIteratorTest, FileInfo)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->fileInfo());
+    EXPECT_TRUE(iter->fileInfo() == nullptr);
+}
+
+TEST_F(RecentDirIteratorTest, Url)
+{
+    EXPECT_NO_FATAL_FAILURE(iter->url());
+    EXPECT_TRUE(iter->url().isValid());
+}

--- a/autotests/plugins/dfmplugin-recent/test_recenteventcaller.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recenteventcaller.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "events/recenteventcaller.h"
+#include <dfm-base/base/application/application.h>
+#include <dfm-framework/event/event.h>
+#include <gtest/gtest.h>
+
+#include <QPaintEvent>
+#include <QPainter>
+
+DPF_USE_NAMESPACE
+        using namespace dfmplugin_recent;
+
+class RecentEventCallerTest : public testing::Test
+{
+public:
+    void SetUp() override
+    {
+    }
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+};
+
+TEST_F(RecentEventCallerTest, sendOpenWindow)
+{
+    stub_ext::StubExt st;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, const QUrl &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(RecentEventCaller::sendOpenWindow(QUrl()));
+}
+
+TEST_F(RecentEventCallerTest, sendOpenTab)
+{
+    stub_ext::StubExt st;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, quint64, const QUrl &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(RecentEventCaller::sendOpenTab(123, QUrl()));
+}
+
+TEST_F(RecentEventCallerTest, sendOpenFiles)
+{
+    stub_ext::StubExt st;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, const quint64, const QList<QUrl> &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(RecentEventCaller::sendOpenFiles(123, QList<QUrl>()));
+}
+
+TEST_F(RecentEventCallerTest, sendWriteToClipboard)
+{
+    stub_ext::StubExt st;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, const quint64, const QList<QUrl> &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(RecentEventCaller::sendWriteToClipboard(123, ClipBoard::ClipboardAction::kCopyAction, QList<QUrl>()));
+}
+
+TEST_F(RecentEventCallerTest, sendCopyFiles)
+{
+    stub_ext::StubExt st;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, const quint64, const QList<QUrl> &, const QUrl &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(RecentEventCaller::sendCopyFiles(123, QList<QUrl>(), QUrl(), {}));
+}
+
+TEST_F(RecentEventCallerTest, sendCutFiles)
+{
+    stub_ext::StubExt st;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, const quint64, const QList<QUrl> &, const QUrl &);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(RecentEventCaller::sendCutFiles(123, QList<QUrl>(), QUrl(), {}));
+}
+
+TEST_F(RecentEventCallerTest, sendCheckTabAddable)
+{
+    stub_ext::StubExt st;
+    typedef QVariant (EventChannelManager::*Push)(const QString &, const QString &, const quint64);
+    auto push = static_cast<Push>(&EventChannelManager::push);
+    st.set_lamda(push, [] { return QVariant(); });
+
+    EXPECT_NO_FATAL_FAILURE(RecentEventCaller::sendCheckTabAddable(123));
+}

--- a/autotests/plugins/dfmplugin-recent/test_recenteventreceiver.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recenteventreceiver.cpp
@@ -1,0 +1,640 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QTest>
+#include <QUrl>
+#include <QDir>
+#include <QTimer>
+#include <QVariantMap>
+
+// 包含待测试的类
+#include "events/recenteventreceiver.h"
+#include "utils/recentmanager.h"
+#include "dfmplugin_recent_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/dfm_event_defines.h>
+#include <dfm-base/dfm_global_defines.h>
+#include <dfm-framework/dpf.h>
+
+DPRECENT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DFMGLOBAL_USE_NAMESPACE
+DPF_USE_NAMESPACE
+
+/**
+ * @brief RecentEventReceiver类单元测试
+ *
+ * 测试范围：
+ * 1. URL变化处理
+ * 2. 文件操作事件处理
+ * 3. UI事件响应
+ * 4. Hook机制功能
+ * 5. 透明度和属性处理
+ * 6. 错误处理和边界条件
+ */
+class RecentEventReceiverTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Initialize event receiver
+        receiver = RecentEventReceiver::instance();
+        ASSERT_NE(receiver, nullptr);
+
+        // Setup test data
+        testWindowId = 12345;
+        testUrl = QUrl("recent:///test.txt");
+        testUrls = { QUrl("recent:///test1.txt"), QUrl("recent:///test2.txt") };
+        globalPos = QPoint(100, 100);
+
+        // Mock basic operations
+        stub.set_lamda(&QThread::currentThread, []() {
+            __DBG_STUB_INVOKE__
+            return QCoreApplication::instance() ? QCoreApplication::instance()->thread() : nullptr;
+        });
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    RecentEventReceiver *receiver { nullptr };
+    quint64 testWindowId;
+    QUrl testUrl;
+    QList<QUrl> testUrls;
+    QPoint globalPos;
+};
+
+/**
+ * @brief 测试单例模式
+ * 验证RecentEventReceiver::instance()返回同一个实例
+ */
+TEST_F(RecentEventReceiverTest, SingletonPattern_ReturnsSameInstance)
+{
+    RecentEventReceiver *instance1 = RecentEventReceiver::instance();
+    RecentEventReceiver *instance2 = RecentEventReceiver::instance();
+
+    // 验证是同一个实例
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_EQ(receiver, instance1);
+
+    // 验证实例不为空
+    EXPECT_NE(instance1, nullptr);
+}
+
+/**
+ * @brief 测试URL变化处理 - recent scheme
+ * 验证handleWindowUrlChanged方法对recent scheme的处理
+ */
+TEST_F(RecentEventReceiverTest, HandleWindowUrlChanged_SetsCorrectFilters)
+{
+    QUrl recentUrl("recent:///");
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Mock dpfSlotChannel push
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, quint64, QFlags<QDir::Filter> &);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push), [&]() {
+        __DBG_STUB_INVOKE__
+        return QVariant();
+    });
+
+    // Mock QTimer::singleShot
+    typedef void (*FuncType)(int, Qt::TimerType, const QObject *, QtPrivate::QSlotObjectBase *);
+    stub.set_lamda(static_cast<FuncType>(&QTimer::singleShotImpl),
+                   []() {
+                       __DBG_STUB_INVOKE__
+                   });
+
+    // Test URL change handling
+    receiver->handleWindowUrlChanged(testWindowId, recentUrl);
+
+    // Note: Due to QTimer::singleShot, we need to process events or mock the timer
+    // For now, we just verify the method doesn't crash
+    EXPECT_NO_THROW(receiver->handleWindowUrlChanged(testWindowId, recentUrl));
+}
+
+/**
+ * @brief 测试URL变化处理 - 其他scheme
+ * 验证handleWindowUrlChanged方法忽略非相关scheme
+ */
+TEST_F(RecentEventReceiverTest, HandleWindowUrlChanged_IgnoresIrrelevantSchemes)
+{
+    QUrl fileUrl("file:///test.txt");
+    bool slotChannelCalled = false;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Mock dpfSlotChannel push
+    typedef QVariant (EventChannelManager::*PushFunc)(const QString &, const QString &, quint64, QFlags<QDir::Filter> &);
+    stub.set_lamda(static_cast<PushFunc>(&EventChannelManager::push), [&]() {
+        __DBG_STUB_INVOKE__
+        slotChannelCalled = true;
+        return QVariant();
+    });
+
+    // Test with non-recent URL
+    receiver->handleWindowUrlChanged(testWindowId, fileUrl);
+
+    // Should not call slot channel for non-recent schemes
+    EXPECT_FALSE(slotChannelCalled);
+}
+
+/**
+ * @brief 测试文件删除结果处理
+ * 验证handleRemoveFilesResult方法在成功时重新加载
+ */
+TEST_F(RecentEventReceiverTest, HandleRemoveFilesResult_ReloadsOnSuccess)
+{
+    bool reloadCalled = false;
+
+    // Mock RecentManager::instance and reloadRecent
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, [&]() {
+        __DBG_STUB_INVOKE__
+        reloadCalled = true;
+    });
+
+    // Test successful removal
+    receiver->handleRemoveFilesResult(testUrls, true, "");
+
+    EXPECT_TRUE(reloadCalled);
+}
+
+/**
+ * @brief 测试文件删除结果处理 - 失败情况
+ * 验证删除失败时不重新加载
+ */
+TEST_F(RecentEventReceiverTest, HandleRemoveFilesResult_NoReloadOnFailure)
+{
+    bool reloadCalled = false;
+
+    // Mock RecentManager::instance and reloadRecent
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, [&]() {
+        __DBG_STUB_INVOKE__
+        reloadCalled = true;
+    });
+
+    // Test failed removal
+    receiver->handleRemoveFilesResult(testUrls, false, "Error occurred");
+
+    EXPECT_FALSE(reloadCalled);
+}
+
+/**
+ * @brief 测试文件重命名结果处理
+ * 验证handleFileRenameResult方法更新最近文件列表
+ */
+TEST_F(RecentEventReceiverTest, HandleFileRenameResult_UpdatesRecentList)
+{
+    QMap<QUrl, QUrl> renamedUrls;
+    renamedUrls.insert(testUrls[0], QUrl("recent:///renamed1.txt"));
+    renamedUrls.insert(testUrls[1], QUrl("recent:///renamed2.txt"));
+
+    bool reloadCalled = false;
+
+    // Mock RecentManager::instance and reloadRecent
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, [&]() {
+        __DBG_STUB_INVOKE__
+        reloadCalled = true;
+    });
+
+    // Test successful rename
+    receiver->handleFileRenameResult(testWindowId, renamedUrls, true, "");
+
+    EXPECT_TRUE(reloadCalled);
+}
+
+/**
+ * @brief 测试文件重命名结果处理 - 空映射
+ * 验证空重命名映射的处理
+ */
+TEST_F(RecentEventReceiverTest, HandleFileRenameResult_EmptyMap_NoReload)
+{
+    QMap<QUrl, QUrl> emptyMap;
+    bool reloadCalled = false;
+
+    // Mock RecentManager::instance and reloadRecent
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, [&]() {
+        __DBG_STUB_INVOKE__
+        reloadCalled = true;
+    });
+
+    // Test with empty rename map
+    receiver->handleFileRenameResult(testWindowId, emptyMap, true, "");
+
+    EXPECT_FALSE(reloadCalled);
+}
+
+/**
+ * @brief 测试文件剪切结果处理
+ * 验证handleFileCutResult方法刷新视图
+ */
+TEST_F(RecentEventReceiverTest, HandleFileCutResult_RefreshesView)
+{
+    QList<QUrl> srcUrls = testUrls;
+    QList<QUrl> destUrls = { QUrl("file:///dest1.txt"), QUrl("file:///dest2.txt") };
+
+    bool reloadCalled = false;
+
+    // Mock RecentManager::instance and reloadRecent
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, [&]() {
+        __DBG_STUB_INVOKE__
+        reloadCalled = true;
+    });
+
+    // Test successful cut
+    receiver->handleFileCutResult(srcUrls, destUrls, true, "");
+
+    EXPECT_TRUE(reloadCalled);
+}
+
+/**
+ * @brief 测试自定义列角色
+ * 验证customColumnRole方法返回正确的角色列表
+ */
+TEST_F(RecentEventReceiverTest, CustomColumnRole_ReturnsCorrectRoles)
+{
+    QUrl rootUrl("recent:///");
+    QList<ItemRoles> roleList;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test custom column role
+    bool result = receiver->customColumnRole(rootUrl, &roleList);
+
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(roleList.isEmpty());
+
+    // Verify expected roles are present
+    EXPECT_TRUE(roleList.contains(kItemFileDisplayNameRole));
+    EXPECT_TRUE(roleList.contains(kItemFilePathRole));
+    EXPECT_TRUE(roleList.contains(kItemFileLastReadRole));
+    EXPECT_TRUE(roleList.contains(kItemFileSizeRole));
+    EXPECT_TRUE(roleList.contains(kItemFileMimeTypeRole));
+}
+
+/**
+ * @brief 测试非recent URL的自定义列角色
+ * 验证非recent scheme返回false
+ */
+TEST_F(RecentEventReceiverTest, CustomColumnRole_NonRecentUrl_ReturnsFalse)
+{
+    QUrl fileUrl("file:///test.txt");
+    QList<ItemRoles> roleList;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test with non-recent URL
+    bool result = receiver->customColumnRole(fileUrl, &roleList);
+
+    EXPECT_FALSE(result);
+}
+
+/**
+ * @brief 测试自定义角色显示名称
+ * 验证customRoleDisplayName方法格式化正确
+ */
+TEST_F(RecentEventReceiverTest, CustomRoleDisplayName_FormatsCorrectly)
+{
+    QString displayName;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test different roles
+    bool result1 = receiver->customRoleDisplayName(testUrl, kItemFilePathRole, &displayName);
+    EXPECT_TRUE(result1);
+
+    bool result2 = receiver->customRoleDisplayName(testUrl, kItemFileLastReadRole, &displayName);
+    EXPECT_TRUE(result2);
+
+    // Test with invalid role
+    bool result3 = receiver->customRoleDisplayName(testUrl, static_cast<ItemRoles>(999999), &displayName);
+    EXPECT_FALSE(result3);
+}
+
+/**
+ * @brief 测试详情视图图标
+ * 验证detailViewIcon方法返回合适的图标
+ */
+TEST_F(RecentEventReceiverTest, DetailViewIcon_ReturnsAppropriateIcon)
+{
+    QString iconName;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test detail view icon
+    bool result = receiver->detailViewIcon(testUrl, &iconName);
+
+    // Should handle recent URLs
+    EXPECT_NO_THROW(receiver->detailViewIcon(testUrl, &iconName));
+}
+
+/**
+ * @brief 测试标题栏面包屑分离
+ * 验证sepateTitlebarCrumb方法处理面包屑
+ */
+TEST_F(RecentEventReceiverTest, SepateTitlebarCrumb_HandlesCrumb)
+{
+    QList<QVariantMap> mapGroup;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test titlebar crumb separation
+    bool result = receiver->sepateTitlebarCrumb(testUrl, &mapGroup);
+
+    // Should handle recent URLs appropriately
+    EXPECT_NO_THROW(receiver->sepateTitlebarCrumb(testUrl, &mapGroup));
+}
+
+/**
+ * @brief 测试透明度检查
+ * 验证isTransparent方法正确检查透明度状态
+ */
+TEST_F(RecentEventReceiverTest, IsTransparent_ChecksCorrectly)
+{
+    TransparentStatus status;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test transparency check
+    bool result = receiver->isTransparent(testUrl, &status);
+
+    // Should handle transparency check
+    EXPECT_NO_THROW(receiver->isTransparent(testUrl, &status));
+}
+
+/**
+ * @brief 测试拖拽操作检查
+ * 验证checkDragDropAction方法验证操作
+ */
+TEST_F(RecentEventReceiverTest, CheckDragDropAction_ValidatesOperation)
+{
+    QUrl targetUrl("file:///target/");
+    Qt::DropAction action = Qt::CopyAction;
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test drag drop action check
+    bool result = receiver->checkDragDropAction(testUrls, targetUrl, &action);
+
+    // Should validate drag drop operations
+    EXPECT_NO_THROW(receiver->checkDragDropAction(testUrls, targetUrl, &action));
+}
+
+/**
+ * @brief 测试文件拖拽处理
+ * 验证handleDropFiles方法处理文件拖拽
+ */
+TEST_F(RecentEventReceiverTest, HandleDropFiles_ProcessesDrops)
+{
+    QUrl targetUrl("file:///target/");
+
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test drop files handling
+    bool result = receiver->handleDropFiles(testUrls, targetUrl);
+
+    // Should handle file drops
+    EXPECT_NO_THROW(receiver->handleDropFiles(testUrls, targetUrl));
+}
+
+/**
+ * @brief 测试属性对话框禁用处理
+ * 验证handlePropertydialogDisable方法返回正确状态
+ */
+TEST_F(RecentEventReceiverTest, HandlePropertydialogDisable_ReturnsCorrectState)
+{
+    // Mock RecentHelper::scheme
+    stub.set_lamda(&RecentHelper::scheme, []() {
+        __DBG_STUB_INVOKE__
+        return QString("recent");
+    });
+
+    // Test property dialog disable
+    bool result = receiver->handlePropertydialogDisable(testUrl);
+
+    // Should return appropriate state
+    EXPECT_NO_THROW(receiver->handlePropertydialogDisable(testUrl));
+}
+
+/**
+ * @brief 测试边界条件 - 空URL列表
+ * 验证空URL列表的处理
+ */
+TEST_F(RecentEventReceiverTest, EmptyUrlList_HandlesGracefully)
+{
+    QList<QUrl> emptyList;
+    Qt::DropAction act;
+
+    // Test operations with empty URL list
+    EXPECT_NO_THROW(receiver->handleRemoveFilesResult(emptyList, true, ""));
+    EXPECT_NO_THROW(receiver->handleFileCutResult(emptyList, emptyList, true, ""));
+    EXPECT_NO_THROW(receiver->checkDragDropAction(emptyList, testUrl, &act));
+    EXPECT_NO_THROW(receiver->handleDropFiles(emptyList, testUrl));
+}
+
+/**
+ * @brief 测试边界条件 - 无效窗口ID
+ * 验证无效窗口ID的处理
+ */
+TEST_F(RecentEventReceiverTest, InvalidWindowId_HandlesGracefully)
+{
+    quint64 invalidWindowId = 0;
+    QMap<QUrl, QUrl> renamedUrls;
+
+    // Test operations with invalid window ID
+    EXPECT_NO_THROW(receiver->handleWindowUrlChanged(invalidWindowId, testUrl));
+    EXPECT_NO_THROW(receiver->handleFileRenameResult(invalidWindowId, renamedUrls, true, ""));
+}
+
+/**
+ * @brief 测试边界条件 - 无效URL
+ * 验证无效URL的安全处理
+ */
+TEST_F(RecentEventReceiverTest, InvalidUrl_HandlesSafely)
+{
+    QList<QUrl> invalidUrls = {
+        QUrl(),   // Empty URL
+        QUrl(""),   // Empty string URL
+        QUrl("invalid-url"),   // Malformed URL
+    };
+
+    // Test operations with invalid URLs
+    for (const QUrl &invalidUrl : invalidUrls) {
+        EXPECT_NO_THROW(receiver->handleWindowUrlChanged(testWindowId, invalidUrl));
+        EXPECT_NO_THROW(receiver->detailViewIcon(invalidUrl, nullptr));
+        EXPECT_NO_THROW(receiver->isTransparent(invalidUrl, nullptr));
+        EXPECT_NO_THROW(receiver->handlePropertydialogDisable(invalidUrl));
+    }
+}
+
+/**
+ * @brief 测试错误消息处理
+ * 验证错误消息的正确处理
+ */
+TEST_F(RecentEventReceiverTest, ErrorMessages_HandledCorrectly)
+{
+    QString errorMsg = "Test error message";
+    bool reloadCalled = false;
+
+    // Mock RecentManager to track reload calls
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, [&]() {
+        __DBG_STUB_INVOKE__
+        reloadCalled = true;
+    });
+
+    // Test error handling - should not reload on failure
+    receiver->handleRemoveFilesResult(testUrls, false, errorMsg);
+    EXPECT_FALSE(reloadCalled);
+
+    receiver->handleFileRenameResult(testWindowId, QMap<QUrl, QUrl>(), false, errorMsg);
+    EXPECT_FALSE(reloadCalled);
+
+    receiver->handleFileCutResult(testUrls, QList<QUrl>(), false, errorMsg);
+    EXPECT_FALSE(reloadCalled);
+}
+
+/**
+ * @brief 测试并发事件处理
+ * 验证多个同时事件的处理安全性
+ */
+TEST_F(RecentEventReceiverTest, ConcurrentEvents_ThreadSafe)
+{
+    // Mock thread safety
+    std::atomic<int> eventCount { 0 };
+
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, [&]() {
+        __DBG_STUB_INVOKE__
+        eventCount++;
+    });
+
+    // Simulate concurrent events
+    EXPECT_NO_THROW({
+        receiver->handleRemoveFilesResult(testUrls, true, "");
+        receiver->handleFileRenameResult(testWindowId, QMap<QUrl, QUrl> { { testUrl, QUrl("recent:///new.txt") } }, true, "");
+        receiver->handleFileCutResult(testUrls, testUrls, true, "");
+    });
+
+    // Should handle concurrent operations safely
+    EXPECT_GE(eventCount.load(), 0);
+}
+
+/**
+ * @brief 测试大量URL处理
+ * 验证处理大量URL时的性能
+ */
+TEST_F(RecentEventReceiverTest, LargeUrlList_PerformanceTest)
+{
+    // Create large URL list
+    QList<QUrl> largeUrlList;
+    for (int i = 0; i < 1000; ++i) {
+        largeUrlList.append(QUrl(QString("recent:///file%1.txt").arg(i)));
+    }
+
+    // Mock RecentManager
+    stub.set_lamda(&RecentManager::instance, []() {
+        __DBG_STUB_INVOKE__
+        static RecentManager manager;
+        return &manager;
+    });
+
+    stub.set_lamda(&RecentManager::reloadRecent, []() {
+        __DBG_STUB_INVOKE__
+        // Simulate reload operation
+    });
+
+    // Test performance with large URL list
+    EXPECT_NO_THROW(receiver->handleRemoveFilesResult(largeUrlList, true, ""));
+    EXPECT_NO_THROW(receiver->handleFileCutResult(largeUrlList, largeUrlList, true, ""));
+}

--- a/autotests/plugins/dfmplugin-recent/test_recentfilehelper.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentfilehelper.cpp
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <DDialog>
+
+#include <QUrl>
+#include <QFileDevice>
+#include <QString>
+
+// 包含待测试的类
+#include "utils/recentfilehelper.h"
+#include "dfmplugin_recent_global.h"
+#include "utils/recentmanager.h"
+
+// 包含依赖的头文件
+#include <dfm-base/interfaces/abstractjobhandler.h>
+#include <dfm-base/utils/clipboard.h>
+
+DPRECENT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+DWIDGET_USE_NAMESPACE
+
+/**
+ * @brief RecentFileHelper类单元测试
+ *
+ * 测试范围：
+ * 1. 单例模式验证
+ * 2. 方法调用参数验证
+ * 3. 返回值验证
+ * 4. 错误处理和边界条件
+ */
+class RecentFileHelperTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Initialize helper instance
+        helper = RecentFileHelper::instance();
+        ASSERT_NE(helper, nullptr);
+
+        // Setup test URLs
+        testUrl1 = QUrl("recent:///test1.txt");
+        testUrl2 = QUrl("recent:///test2.txt");
+        targetUrl = QUrl("file:///target/");
+
+        // Setup test window ID
+        testWindowId = 12345;
+    }
+
+    void TearDown() override
+    {
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    RecentFileHelper *helper { nullptr };
+    QUrl testUrl1;
+    QUrl testUrl2;
+    QUrl targetUrl;
+    quint64 testWindowId;
+};
+
+/**
+ * @brief 测试单例模式
+ * 验证RecentFileHelper::instance()返回同一个实例
+ */
+TEST_F(RecentFileHelperTest, SingletonPattern_ReturnsSameInstance)
+{
+    RecentFileHelper *instance1 = RecentFileHelper::instance();
+    RecentFileHelper *instance2 = RecentFileHelper::instance();
+
+    // 验证是同一个实例
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_EQ(helper, instance1);
+
+    // 验证实例不为空
+    EXPECT_NE(instance1, nullptr);
+}
+
+/**
+ * @brief 测试文件剪切操作
+ * 验证cutFile方法能正确调用
+ */
+TEST_F(RecentFileHelperTest, CutFile_CanBeCalled)
+{
+    QList<QUrl> sources = { testUrl1, testUrl2 };
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+
+    // Test cutFile - 测试方法能正常调用而不崩溃
+    EXPECT_NO_THROW(helper->cutFile(testWindowId, sources, targetUrl, flags));
+}
+
+/**
+ * @brief 测试文件复制操作
+ * 验证copyFile方法能正确调用
+ */
+TEST_F(RecentFileHelperTest, CopyFile_CanBeCalled)
+{
+    QList<QUrl> sources = { testUrl1, testUrl2 };
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+
+    // Test copyFile - 测试方法能正常调用而不崩溃
+    EXPECT_NO_THROW(helper->copyFile(testWindowId, sources, targetUrl, flags));
+}
+
+/**
+ * @brief 测试移动到回收站操作
+ * 验证moveToTrash方法能正确调用
+ */
+TEST_F(RecentFileHelperTest, MoveToTrash_CanBeCalled)
+{
+    stub.set_lamda(VADDR(DDialog, exec), [] { return 1; });
+    stub.set_lamda(&RecentManagerDBusInterface::RemoveItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+
+    QList<QUrl> sources = { testUrl1, testUrl2 };
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+
+    // Test moveToTrash - 测试方法能正常调用而不崩溃
+    EXPECT_NO_THROW(helper->moveToTrash(testWindowId, sources, flags));
+}
+
+/**
+ * @brief 测试权限设置功能
+ * 验证setPermissionHandle方法能正确调用
+ */
+TEST_F(RecentFileHelperTest, SetPermissions_CanBeCalled)
+{
+    QFileDevice::Permissions validPermissions = QFileDevice::ReadOwner | QFileDevice::WriteOwner;
+    bool operationResult = false;
+    QString errorMessage;
+
+    // Test setPermissionHandle - 测试方法能正常调用而不崩溃
+    EXPECT_NO_THROW(helper->setPermissionHandle(testWindowId, testUrl1, validPermissions, &operationResult, &errorMessage));
+}
+
+/**
+ * @brief 测试剪贴板写入功能
+ * 验证writeUrlsToClipboard方法能正确调用
+ */
+TEST_F(RecentFileHelperTest, WriteToClipboard_CanBeCalled)
+{
+    QList<QUrl> urls = { testUrl1, testUrl2 };
+    ClipBoard::ClipboardAction action = ClipBoard::ClipboardAction::kCopyAction;
+
+    // Test writeUrlsToClipboard - 测试方法能正常调用而不崩溃
+    EXPECT_NO_THROW(helper->writeUrlsToClipboard(testWindowId, action, urls));
+}
+
+/**
+ * @brief 测试在插件中打开文件
+ * 验证openFileInPlugin方法能正确调用
+ */
+TEST_F(RecentFileHelperTest, OpenFileInPlugin_CanBeCalled)
+{
+    QList<QUrl> urls = { testUrl1 };
+
+    // Test openFileInPlugin - 测试方法能正常调用而不崩溃
+    EXPECT_NO_THROW(helper->openFileInPlugin(testWindowId, urls));
+}
+
+/**
+ * @brief 测试在终端中打开文件
+ * 验证openFileInTerminal方法能正确调用
+ */
+TEST_F(RecentFileHelperTest, OpenFileInTerminal_CanBeCalled)
+{
+    QList<QUrl> urls = { testUrl1 };
+
+    // Test openFileInTerminal - 测试方法能正常调用而不崩溃
+    EXPECT_NO_THROW(helper->openFileInTerminal(testWindowId, urls));
+}
+
+/**
+ * @brief 测试空文件列表处理
+ * 验证空文件列表时方法的健壮性
+ */
+TEST_F(RecentFileHelperTest, EmptyFileList_HandlesGracefully)
+{
+    QList<QUrl> emptyList;
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+
+    // Test operations with empty list
+    EXPECT_NO_THROW(helper->cutFile(testWindowId, emptyList, targetUrl, flags));
+    EXPECT_NO_THROW(helper->copyFile(testWindowId, emptyList, targetUrl, flags));
+    EXPECT_NO_THROW(helper->moveToTrash(testWindowId, emptyList, flags));
+    EXPECT_NO_THROW(helper->openFileInPlugin(testWindowId, emptyList));
+    EXPECT_NO_THROW(helper->openFileInTerminal(testWindowId, emptyList));
+
+    ClipBoard::ClipboardAction action = ClipBoard::ClipboardAction::kCopyAction;
+    EXPECT_NO_THROW(helper->writeUrlsToClipboard(testWindowId, action, emptyList));
+}
+
+/**
+ * @brief 测试无效URL处理
+ * 验证无效URL时方法的健壮性
+ */
+TEST_F(RecentFileHelperTest, InvalidUrl_HandlesGracefully)
+{
+    stub.set_lamda(VADDR(DDialog, exec), [] { return 1; });
+    stub.set_lamda(&RecentManagerDBusInterface::RemoveItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+
+    QList<QUrl> invalidUrls = {
+        QUrl(""),   // Empty URL
+        QUrl("invalid-url"),   // Malformed URL
+        QUrl("recent://"),   // Incomplete URL
+    };
+
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+
+    // Test operations with invalid URLs should not crash
+    for (const QUrl &invalidUrl : invalidUrls) {
+        QList<QUrl> sources = { invalidUrl };
+        EXPECT_NO_THROW(helper->cutFile(testWindowId, sources, targetUrl, flags));
+        EXPECT_NO_THROW(helper->copyFile(testWindowId, sources, targetUrl, flags));
+        EXPECT_NO_THROW(helper->moveToTrash(testWindowId, sources, flags));
+    }
+}
+
+/**
+ * @brief 测试无效窗口ID处理
+ * 验证无效窗口ID时方法的健壮性
+ */
+TEST_F(RecentFileHelperTest, InvalidWindowId_HandlesGracefully)
+{
+    stub.set_lamda(VADDR(DDialog, exec), [] { return 1; });
+    stub.set_lamda(&RecentManagerDBusInterface::RemoveItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+
+    quint64 invalidWindowId = 0;
+    QList<QUrl> sources = { testUrl1 };
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+
+    // Test operations with invalid window ID
+    EXPECT_NO_THROW(helper->cutFile(invalidWindowId, sources, targetUrl, flags));
+    EXPECT_NO_THROW(helper->copyFile(invalidWindowId, sources, targetUrl, flags));
+    EXPECT_NO_THROW(helper->moveToTrash(invalidWindowId, sources, flags));
+}
+
+/**
+ * @brief 测试大量文件选择
+ * 验证处理大量文件时的性能和稳定性
+ */
+TEST_F(RecentFileHelperTest, LargeFileSelection_HandlesGracefully)
+{
+    stub.set_lamda(VADDR(DDialog, exec), [] { return 1; });
+    stub.set_lamda(&RecentManagerDBusInterface::RemoveItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+
+    // Create large file list
+    QList<QUrl> largeFileList;
+    for (int i = 0; i < 100; ++i) {
+        largeFileList.append(QUrl(QString("recent:///file%1.txt").arg(i)));
+    }
+
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+    ClipBoard::ClipboardAction action = ClipBoard::ClipboardAction::kCopyAction;
+
+    // Test operations with large file lists should not crash
+    EXPECT_NO_THROW(helper->cutFile(testWindowId, largeFileList, targetUrl, flags));
+    EXPECT_NO_THROW(helper->copyFile(testWindowId, largeFileList, targetUrl, flags));
+    EXPECT_NO_THROW(helper->moveToTrash(testWindowId, largeFileList, flags));
+    EXPECT_NO_THROW(helper->writeUrlsToClipboard(testWindowId, action, largeFileList));
+}
+
+/**
+ * @brief 测试不同剪贴板动作
+ * 验证不同剪贴板动作类型的处理
+ */
+TEST_F(RecentFileHelperTest, ClipboardActions_AllTypesHandled)
+{
+    QList<QUrl> urls = { testUrl1, testUrl2 };
+
+    QList<ClipBoard::ClipboardAction> actions = {
+        ClipBoard::ClipboardAction::kCopyAction,
+        ClipBoard::ClipboardAction::kCutAction,
+        ClipBoard::ClipboardAction::kUnknownAction
+    };
+
+    // Test all clipboard action types
+    for (ClipBoard::ClipboardAction action : actions) {
+        EXPECT_NO_THROW(helper->writeUrlsToClipboard(testWindowId, action, urls));
+    }
+}
+
+/**
+ * @brief 测试不同作业标志
+ * 验证不同作业标志组合的处理
+ */
+TEST_F(RecentFileHelperTest, JobFlags_AllCombinationsHandled)
+{
+    stub.set_lamda(VADDR(DDialog, exec), [] { return 1; });
+    stub.set_lamda(&RecentManagerDBusInterface::RemoveItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+
+    QList<QUrl> sources = { testUrl1 };
+
+    // Test all flag combinations
+    EXPECT_NO_THROW(helper->cutFile(testWindowId, sources, targetUrl, {}));
+    EXPECT_NO_THROW(helper->copyFile(testWindowId, sources, targetUrl, {}));
+    EXPECT_NO_THROW(helper->moveToTrash(testWindowId, sources, {}));
+}
+
+/**
+ * @brief 测试权限设置的边界情况
+ * 验证权限设置时空指针参数的处理
+ */
+TEST_F(RecentFileHelperTest, SetPermissions_NullPointers_HandlesGracefully)
+{
+    QFileDevice::Permissions permissions = QFileDevice::ReadOwner | QFileDevice::WriteOwner;
+
+    // Test with null pointers
+    EXPECT_NO_THROW(helper->setPermissionHandle(testWindowId, testUrl1, permissions, nullptr, nullptr));
+
+    bool operationResult = false;
+    EXPECT_NO_THROW(helper->setPermissionHandle(testWindowId, testUrl1, permissions, &operationResult, nullptr));
+
+    QString errorMessage;
+    EXPECT_NO_THROW(helper->setPermissionHandle(testWindowId, testUrl1, permissions, nullptr, &errorMessage));
+}
+
+/**
+ * @brief 测试并发操作安全性
+ * 验证多个同时操作的线程安全性
+ */
+TEST_F(RecentFileHelperTest, ConcurrentOperations_ThreadSafe)
+{
+    stub.set_lamda(VADDR(DDialog, exec), [] { return 1; });
+    stub.set_lamda(&RecentManagerDBusInterface::RemoveItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+    stub.set_lamda(&RecentManagerDBusInterface::PurgeItems, [] {
+        __DBG_STUB_INVOKE__
+        return QDBusPendingReply<>();
+    });
+
+    QList<QUrl> sources = { testUrl1 };
+    AbstractJobHandler::JobFlags flags = AbstractJobHandler::JobFlag::kNoHint;
+
+    // Simulate multiple concurrent operations
+    EXPECT_NO_THROW({
+        helper->cutFile(testWindowId, sources, targetUrl, flags);
+        helper->copyFile(testWindowId + 1, sources, targetUrl, flags);
+        helper->moveToTrash(testWindowId + 2, sources, flags);
+        helper->openFileInPlugin(testWindowId + 3, sources);
+    });
+}

--- a/autotests/plugins/dfmplugin-recent/test_recentfileinfo.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentfileinfo.cpp
@@ -1,0 +1,550 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QTest>
+#include <QUrl>
+#include <QDateTime>
+#include <QFile>
+
+// 包含待测试的类
+#include "files/recentfileinfo.h"
+#include "utils/recentmanager.h"
+#include "dfmplugin_recent_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/utils/fileutils.h>
+#include <dfm-base/interfaces/fileinfo.h>
+
+DPRECENT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+/**
+ * @brief RecentFileInfo类单元测试
+ *
+ * 测试范围：
+ * 1. Proxy模式实现
+ * 2. 文件属性判断
+ * 3. 权限计算
+ * 4. 自定义数据提供
+ * 5. 名称和URL处理
+ * 6. 边界条件和错误处理
+ */
+class RecentFileInfoTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Setup test URLs
+        testUrl = QUrl("recent:///test.txt");
+        rootUrl = QUrl("recent:///");
+        localFileUrl = QUrl("file:///home/user/test.txt");
+
+        // Create RecentFileInfo instance
+        fileInfo = new RecentFileInfo(testUrl);
+        ASSERT_NE(fileInfo, nullptr);
+
+        // Create root RecentFileInfo
+        rootFileInfo = new RecentFileInfo(rootUrl);
+        ASSERT_NE(rootFileInfo, nullptr);
+    }
+
+    void TearDown() override
+    {
+        delete fileInfo;
+        delete rootFileInfo;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    RecentFileInfo *fileInfo { nullptr };
+    RecentFileInfo *rootFileInfo { nullptr };
+    QUrl testUrl;
+    QUrl rootUrl;
+    QUrl localFileUrl;
+};
+
+/**
+ * @brief 测试构造函数
+ * 验证RecentFileInfo构造时正确初始化代理
+ */
+TEST_F(RecentFileInfoTest, Constructor_InitializesProxy)
+{
+    // Mock InfoFactory::create for non-root URLs
+    bool factoryCreateCalled = false;
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [&] {
+        __DBG_STUB_INVOKE__
+        factoryCreateCalled = true;
+        return nullptr;   // Return null for testing
+    });
+
+    // Test with non-root URL (should create proxy)
+    QUrl nonRootUrl("recent:///test.txt");
+    RecentFileInfo testInfo(nonRootUrl);
+
+    // Factory should be called for non-root URLs
+    EXPECT_TRUE(factoryCreateCalled);
+}
+
+/**
+ * @brief 测试根URL构造函数
+ * 验证根URL不创建代理
+ */
+TEST_F(RecentFileInfoTest, Constructor_RootUrl_NoProxy)
+{
+    bool factoryCreateCalled = false;
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [&] {
+        __DBG_STUB_INVOKE__
+        factoryCreateCalled = true;
+        return nullptr;
+    });
+
+    // Test with root URL (should not create proxy)
+    QUrl rootUrl("recent:///");
+    RecentFileInfo rootInfo(rootUrl);
+
+    // Factory should not be called for root URL
+    EXPECT_FALSE(factoryCreateCalled);
+}
+
+/**
+ * @brief 测试文件存在性检查
+ * 验证exists方法正确检查代理和根URL
+ */
+TEST_F(RecentFileInfoTest, Exists_ChecksProxyAndRoot)
+{
+    // Mock ProxyFileInfo::exists for non-root file
+    stub.set_lamda(VADDR(ProxyFileInfo, exists), [](const ProxyFileInfo *) {
+        __DBG_STUB_INVOKE__
+        return true;   // Simulate file exists
+    });
+
+    // Mock RecentHelper::rootUrl
+    stub.set_lamda(&RecentHelper::rootUrl, []() {
+        __DBG_STUB_INVOKE__
+        return QUrl("recent:///");
+    });
+
+    // Test exists for regular file
+    EXPECT_TRUE(fileInfo->exists());
+
+    // Test exists for root URL
+    EXPECT_TRUE(rootFileInfo->exists());
+}
+
+/**
+ * @brief 测试文件不存在情况
+ * 验证不存在文件的处理
+ */
+TEST_F(RecentFileInfoTest, Exists_NonexistentFile_ReturnsFalse)
+{
+    // Mock ProxyFileInfo::exists to return false
+    stub.set_lamda(VADDR(ProxyFileInfo, exists), [](const ProxyFileInfo *) {
+        __DBG_STUB_INVOKE__
+        return false;   // Simulate file doesn't exist
+    });
+
+    // Mock RecentHelper::rootUrl to different URL
+    stub.set_lamda(&RecentHelper::rootUrl, []() {
+        __DBG_STUB_INVOKE__
+        return QUrl("recent:///other");
+    });
+
+    // Test should return false for non-existent file
+    EXPECT_FALSE(fileInfo->exists());
+}
+
+/**
+ * @brief 测试权限计算
+ * 验证permissions方法正确计算权限
+ */
+TEST_F(RecentFileInfoTest, Permissions_CalculatesCorrectly)
+{
+    // Mock RecentHelper::rootUrl
+    stub.set_lamda(&RecentHelper::rootUrl, []() {
+        __DBG_STUB_INVOKE__
+        return QUrl("recent:///");
+    });
+
+    // Mock ProxyFileInfo::permissions for regular file
+    stub.set_lamda(VADDR(ProxyFileInfo, permissions), [](const ProxyFileInfo *) {
+        __DBG_STUB_INVOKE__
+        return QFileDevice::ReadOwner | QFileDevice::WriteOwner;
+    });
+
+    // Test permissions for regular file
+    QFile::Permissions filePerms = fileInfo->permissions();
+    EXPECT_TRUE(filePerms.testFlag(QFileDevice::ReadOwner));
+
+    // Test permissions for root URL (should be read-only)
+    QFile::Permissions rootPerms = rootFileInfo->permissions();
+    EXPECT_TRUE(rootPerms.testFlag(QFileDevice::ReadOwner));
+    EXPECT_TRUE(rootPerms.testFlag(QFileDevice::ReadGroup));
+    EXPECT_TRUE(rootPerms.testFlag(QFileDevice::ReadOther));
+    EXPECT_FALSE(rootPerms.testFlag(QFileDevice::WriteOwner));
+}
+
+/**
+ * @brief 测试可读属性判断
+ * 验证isAttributes方法正确判断可读性
+ */
+TEST_F(RecentFileInfoTest, IsAttributes_ReadableCheck)
+{
+    // Mock permissions to include read permission
+    stub.set_lamda(VADDR(RecentFileInfo, permissions), [](const RecentFileInfo *) {
+        __DBG_STUB_INVOKE__
+        return QFileDevice::ReadUser | QFileDevice::WriteUser;
+    });
+
+    // Test readable attribute
+    bool isReadable = fileInfo->isAttributes(OptInfoType::kIsReadable);
+    EXPECT_TRUE(isReadable);
+}
+
+/**
+ * @brief 测试可写属性判断
+ * 验证isAttributes方法正确判断可写性
+ */
+TEST_F(RecentFileInfoTest, IsAttributes_WritableCheck)
+{
+    // Mock permissions to include write permission
+    stub.set_lamda(VADDR(RecentFileInfo, permissions), [](const RecentFileInfo *) {
+        __DBG_STUB_INVOKE__
+        return QFileDevice::ReadUser | QFileDevice::WriteUser;
+    });
+
+    // Test writable attribute
+    bool isWritable = fileInfo->isAttributes(OptInfoType::kIsWritable);
+    EXPECT_TRUE(isWritable);
+}
+
+/**
+ * @brief 测试只读文件属性
+ * 验证只读文件的属性判断
+ */
+TEST_F(RecentFileInfoTest, IsAttributes_ReadOnlyFile)
+{
+    // Mock permissions to be read-only
+    stub.set_lamda(VADDR(RecentFileInfo, permissions), [](const RecentFileInfo *) {
+        __DBG_STUB_INVOKE__
+        return QFileDevice::ReadUser;   // Only read permission
+    });
+
+    // Test readable attribute
+    bool isReadable = fileInfo->isAttributes(OptInfoType::kIsReadable);
+    EXPECT_TRUE(isReadable);
+
+    // Test writable attribute
+    bool isWritable = fileInfo->isAttributes(OptInfoType::kIsWritable);
+    EXPECT_FALSE(isWritable);
+}
+
+/**
+ * @brief 测试删除和重命名能力
+ * 验证canAttributes对删除、回收站、重命名返回false
+ */
+TEST_F(RecentFileInfoTest, CanAttributes_DeleteTrashRename_ReturnsFalse)
+{
+    // Test delete capability
+    bool canDelete = fileInfo->canAttributes(CanableInfoType::kCanDelete);
+    EXPECT_FALSE(canDelete);
+
+    // Test trash capability
+    bool canTrash = fileInfo->canAttributes(CanableInfoType::kCanTrash);
+    EXPECT_FALSE(canTrash);
+
+    // Test rename capability
+    bool canRename = fileInfo->canAttributes(CanableInfoType::kCanRename);
+    EXPECT_FALSE(canRename);
+}
+
+/**
+ * @brief 测试重定向能力
+ * 验证canAttributes对重定向的处理
+ */
+TEST_F(RecentFileInfoTest, CanAttributes_Redirection_ChecksProxy)
+{
+    // Mock proxy existence
+    fileInfo->proxy = FileInfoPointer(nullptr);   // No proxy
+
+    // Test redirection capability without proxy
+    bool canRedirect = fileInfo->canAttributes(CanableInfoType::kCanRedirectionFileUrl);
+    EXPECT_FALSE(canRedirect);
+
+    // Mock proxy existence
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [] {
+        __DBG_STUB_INVOKE__
+        return nullptr;
+    });
+
+    // Create new instance with proxy
+    RecentFileInfo infoWithProxy(testUrl);
+
+    // Test redirection capability with proxy
+    // Note: This test might need adjustment based on actual proxy handling
+    EXPECT_NO_THROW(infoWithProxy.canAttributes(CanableInfoType::kCanRedirectionFileUrl));
+}
+
+/**
+ * @brief 测试文件名获取
+ * 验证nameOf方法返回正确的文件名
+ */
+TEST_F(RecentFileInfoTest, NameOf_FileName_ReturnsCorrectName)
+{
+    // Mock proxy nameOf
+    stub.set_lamda(VADDR(FileInfo, nameOf), [](const FileInfo *, NameInfoType) {
+        __DBG_STUB_INVOKE__
+        return QString("test.txt");
+    });
+
+    // Test file name for regular file
+    QString fileName = fileInfo->nameOf(NameInfoType::kFileName);
+    // Note: Actual behavior depends on proxy implementation
+    EXPECT_NO_THROW(fileInfo->nameOf(NameInfoType::kFileName));
+}
+
+/**
+ * @brief 测试根URL名称
+ * 验证根URL返回"Recent"名称
+ */
+TEST_F(RecentFileInfoTest, NameOf_RootUrl_ReturnsRecent)
+{
+    // Mock UrlRoute::isRootUrl
+    stub.set_lamda(&UrlRoute::isRootUrl, [](const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        return url.path() == "/";
+    });
+
+    // Test file name for root URL
+    QString rootName = rootFileInfo->nameOf(NameInfoType::kFileName);
+    EXPECT_TRUE(rootName == "Recent" || rootName.isEmpty());   // Allow for different implementations
+}
+
+/**
+ * @brief 测试URL重定向
+ * 验证urlOf方法返回正确的重定向URL
+ */
+TEST_F(RecentFileInfoTest, UrlOf_Redirection_ReturnsProxyUrl)
+{
+    // Mock proxy urlOf
+    stub.set_lamda(VADDR(FileInfo, urlOf), [](const FileInfo *, UrlInfoType) {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///home/user/test.txt");
+    });
+
+    // Test redirected URL
+    QUrl redirectedUrl = fileInfo->urlOf(UrlInfoType::kRedirectedFileUrl);
+    EXPECT_NO_THROW(fileInfo->urlOf(UrlInfoType::kRedirectedFileUrl));
+
+    // Test regular URL
+    QUrl regularUrl = fileInfo->urlOf(UrlInfoType::kUrl);
+    EXPECT_EQ(regularUrl, testUrl);
+}
+
+/**
+ * @brief 测试自定义数据 - 文件路径
+ * 验证customData返回正确的文件路径
+ */
+TEST_F(RecentFileInfoTest, CustomData_FilePath_ReturnsRedirectedPath)
+{
+    // Mock urlOf for redirection
+    stub.set_lamda(VADDR(RecentFileInfo, urlOf), [](const RecentFileInfo *, UrlInfoType) {
+        __DBG_STUB_INVOKE__
+        return QUrl("file:///home/user/test.txt");
+    });
+
+    // Test file path role
+    QVariant pathData = fileInfo->customData(Global::kItemFilePathRole);
+    EXPECT_TRUE(pathData.isValid());
+    EXPECT_FALSE(pathData.toString().isEmpty());
+}
+
+/**
+ * @brief 测试自定义数据 - 最后访问时间
+ * 验证customData返回格式化的最后访问时间
+ */
+TEST_F(RecentFileInfoTest, CustomData_LastRead_ReturnsFormattedTime)
+{
+    // RecentFileInfo overrides timeOf(), so stubbing the base FileInfo::timeOf
+    // has no effect on its vtable slot; stub the override directly.
+    stub.set_lamda(VADDR(RecentFileInfo, timeOf), [](const RecentFileInfo *, TimeInfoType) {
+        __DBG_STUB_INVOKE__
+        QDateTime testTime = QDateTime::fromSecsSinceEpoch(1234567890);
+        return QVariant(testTime);
+    });
+
+    // Mock FileUtils::dateTimeFormat
+    stub.set_lamda(&FileUtils::dateTimeFormat, []() {
+        __DBG_STUB_INVOKE__
+        return QString("yyyy-MM-dd hh:mm:ss");
+    });
+
+    // Test last read role
+    QVariant lastReadData = fileInfo->customData(Global::kItemFileLastReadRole);
+    EXPECT_TRUE(lastReadData.isValid());
+    EXPECT_FALSE(lastReadData.toString().isEmpty());
+}
+
+/**
+ * @brief 测试自定义数据 - 无效角色
+ * 验证无效角色返回空QVariant
+ */
+TEST_F(RecentFileInfoTest, CustomData_InvalidRole_ReturnsNull)
+{
+    // Test with invalid role
+    QVariant invalidData = fileInfo->customData(999999);
+    EXPECT_FALSE(invalidData.isValid());
+}
+
+/**
+ * @brief 测试显示名称
+ * 验证displayOf方法返回正确的显示名称
+ */
+TEST_F(RecentFileInfoTest, DisplayOf_FileName_ReturnsCorrectDisplayName)
+{
+    // Mock UrlRoute::isRootUrl
+    stub.set_lamda(&UrlRoute::isRootUrl, [](const QUrl &url) {
+        __DBG_STUB_INVOKE__
+        return url.path() == "/";
+    });
+
+    // Test display name for root URL
+    QString rootDisplayName = rootFileInfo->displayOf(DisPlayInfoType::kFileDisplayName);
+    EXPECT_TRUE(rootDisplayName == "Recent" || rootDisplayName.isEmpty());
+
+    // Mock ProxyFileInfo::displayOf for regular file
+    stub.set_lamda(VADDR(ProxyFileInfo, displayOf), [](const ProxyFileInfo *, DisPlayInfoType) {
+        __DBG_STUB_INVOKE__
+        return QString("test.txt");
+    });
+
+    // Test display name for regular file
+    EXPECT_NO_THROW(fileInfo->displayOf(DisPlayInfoType::kFileDisplayName));
+}
+
+/**
+ * @brief 测试边界条件 - 空代理
+ * 验证空代理的处理
+ */
+TEST_F(RecentFileInfoTest, NullProxy_HandlesGracefully)
+{
+    // Ensure proxy is null
+    fileInfo->proxy = FileInfoPointer(nullptr);
+
+    // Test operations with null proxy
+    EXPECT_NO_THROW(fileInfo->exists());
+    EXPECT_NO_THROW(fileInfo->permissions());
+    EXPECT_NO_THROW(fileInfo->nameOf(NameInfoType::kFileName));
+    EXPECT_NO_THROW(fileInfo->urlOf(UrlInfoType::kRedirectedFileUrl));
+    EXPECT_NO_THROW(fileInfo->customData(Global::kItemFilePathRole));
+}
+
+/**
+ * @brief 测试边界条件 - 无效URL
+ * 验证无效URL的安全处理
+ */
+TEST_F(RecentFileInfoTest, InvalidUrl_HandlesSafely)
+{
+    // Test with various invalid URLs
+    QList<QUrl> invalidUrls = {
+        QUrl(),   // Empty URL
+        QUrl(""),   // Empty string URL
+        QUrl("invalid-url"),   // Malformed URL
+        QUrl("recent://"),   // Incomplete URL
+    };
+
+    for (const QUrl &invalidUrl : invalidUrls) {
+        EXPECT_NO_THROW({
+            RecentFileInfo invalidInfo(invalidUrl);
+            invalidInfo.exists();
+            invalidInfo.permissions();
+        });
+    }
+}
+
+/**
+ * @brief 测试边界条件 - 超长路径
+ * 验证超长路径的处理
+ */
+TEST_F(RecentFileInfoTest, LongPath_HandlesGracefully)
+{
+    // Create very long path
+    QString longPath = "recent:///" + QString(10000, 'a') + ".txt";
+    QUrl longUrl(longPath);
+
+    EXPECT_NO_THROW({
+        RecentFileInfo longPathInfo(longUrl);
+        longPathInfo.exists();
+        longPathInfo.nameOf(NameInfoType::kFileName);
+    });
+}
+
+/**
+ * @brief 测试属性一致性
+ * 验证相同URL的多个实例返回一致的属性
+ */
+TEST_F(RecentFileInfoTest, MultipleInstances_ConsistentAttributes)
+{
+    // Create another instance with same URL
+    RecentFileInfo anotherInfo(testUrl);
+
+    // Mock consistent returns
+    stub.set_lamda(VADDR(ProxyFileInfo, exists), [](const ProxyFileInfo *) {
+        __DBG_STUB_INVOKE__
+        return true;
+    });
+
+    // Test consistency
+    EXPECT_EQ(fileInfo->exists(), anotherInfo.exists());
+    EXPECT_EQ(fileInfo->urlOf(UrlInfoType::kUrl), anotherInfo.urlOf(UrlInfoType::kUrl));
+}
+
+/**
+ * @brief 测试内存管理
+ * 验证对象创建和销毁的内存安全性
+ */
+TEST_F(RecentFileInfoTest, MemoryManagement_Safe)
+{
+    // Create and destroy multiple instances
+    for (int i = 0; i < 100; ++i) {
+        QUrl testUrl(QString("recent:///test%1.txt").arg(i));
+        RecentFileInfo *info = new RecentFileInfo(testUrl);
+        EXPECT_NE(info, nullptr);
+
+        // Test basic operations
+        info->exists();
+        info->permissions();
+
+        delete info;
+    }
+}
+
+/**
+ * @brief 测试代理工厂调用
+ * 验证InfoFactory::create的正确调用
+ */
+TEST_F(RecentFileInfoTest, ProxyFactory_CalledCorrectly)
+{
+    bool factoryCalled = false;
+    QUrl capturedUrl;
+
+    stub.set_lamda(static_cast<FileInfoPointer(*)(const QUrl&, Global::CreateFileInfoType, QString*)>(&InfoFactory::create<FileInfo>), [&](const QUrl &url, const Global::CreateFileInfoType, QString *) -> FileInfoPointer {
+        __DBG_STUB_INVOKE__
+        factoryCalled = true;
+        capturedUrl = url;
+        return FileInfoPointer(nullptr);
+    });
+
+    // Create new instance
+    QUrl testUrl("recent:///factory_test.txt");
+    RecentFileInfo testInfo(testUrl);
+
+    // Verify factory was called with correct URL
+    EXPECT_TRUE(factoryCalled);
+    EXPECT_EQ(capturedUrl.path(), "/factory_test.txt");
+}

--- a/autotests/plugins/dfmplugin-recent/test_recentfilewatcher.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentfilewatcher.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "files/recentfilewatcher.h"
+#include "private/recentfilewatcher_p.h"
+#include "utils/recentmanager.h"
+
+#include <dfm-base/file/local/localfilewatcher.h>
+#include <dfm-base/base/schemefactory.h>
+
+#include <gtest/gtest.h>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_recent;
+
+class RecentFileWatcherTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        // RecentFileWatcher now just wraps AbstractFileWatcher with start/stop
+        watcher = new RecentFileWatcher(RecentHelper::rootUrl());
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete watcher;
+        watcher = nullptr;
+    }
+
+protected:
+    RecentFileWatcher *watcher = { nullptr };
+    stub_ext::StubExt stub;
+};
+
+TEST_F(RecentFileWatcherTest, Constructor_CreatesSuccessfully)
+{
+    EXPECT_NE(watcher, nullptr);
+}
+
+TEST_F(RecentFileWatcherTest, Destructor_CleansUp)
+{
+    RecentFileWatcher *tempWatcher = new RecentFileWatcher(RecentHelper::rootUrl());
+    EXPECT_NO_THROW(delete tempWatcher);
+}
+
+TEST_F(RecentFileWatcherTest, Start_ReturnsTrue)
+{
+    // RecentFileWatcherPrivate::start just sets started = true
+    EXPECT_TRUE(watcher->dptr->start());
+}
+
+TEST_F(RecentFileWatcherTest, Stop_ReturnsTrue)
+{
+    // RecentFileWatcherPrivate::stop just sets started = false
+    watcher->dptr->start();   // start first
+    EXPECT_TRUE(watcher->dptr->stop());
+}
+
+TEST_F(RecentFileWatcherTest, Inherits_AbstractFileWatcher)
+{
+    auto *base = dynamic_cast<AbstractFileWatcher *>(watcher);
+    EXPECT_NE(base, nullptr);
+}

--- a/autotests/plugins/dfmplugin-recent/test_recentmanager.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentmanager.cpp
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <gtest/gtest.h>
+#include <stubext.h>
+
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QTest>
+#include <QDBusReply>
+#include <QDBusInterface>
+#include <QTemporaryDir>
+#include <QTimer>
+
+// 包含待测试的类
+#include "utils/recentmanager.h"
+#include "dfmplugin_recent_global.h"
+
+// 包含依赖的头文件
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-base/interfaces/abstractfilewatcher.h>
+#include <dfm-base/utils/universalutils.h>
+
+DPRECENT_USE_NAMESPACE
+DFMBASE_USE_NAMESPACE
+
+/**
+ * @brief RecentManager类单元测试
+ *
+ * 测试范围：
+ * 1. 单例模式验证
+ * 2. 初始化和清理流程
+ * 3. DBus接口通信
+ * 4. 最近文件数据管理
+ * 5. 文件监视控制
+ * 6. 异常处理和边界条件
+ */
+class RecentManagerTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        // Mock QCoreApplication thread check
+        stub.set_lamda(&QThread::currentThread, []() {
+            __DBG_STUB_INVOKE__
+            return QCoreApplication::instance() ? QCoreApplication::instance()->thread() : nullptr;
+        });
+
+        // Create temporary directory for testing
+        tempDir = new QTemporaryDir();
+        ASSERT_TRUE(tempDir->isValid());
+
+        // Initialize manager
+        manager = RecentManager::instance();
+        ASSERT_NE(manager, nullptr);
+    }
+
+    void TearDown() override
+    {
+        // Clean up resources
+        delete tempDir;
+        stub.clear();
+    }
+
+    stub_ext::StubExt stub;
+    RecentManager *manager { nullptr };
+    QTemporaryDir *tempDir { nullptr };
+};
+
+/**
+ * @brief 测试单例模式
+ * 验证RecentManager::instance()返回同一个实例
+ */
+TEST_F(RecentManagerTest, SingletonPattern_ReturnsSameInstance)
+{
+    RecentManager *instance1 = RecentManager::instance();
+    RecentManager *instance2 = RecentManager::instance();
+
+    // 验证是同一个实例
+    EXPECT_EQ(instance1, instance2);
+    EXPECT_EQ(manager, instance1);
+
+    // 验证实例不为空
+    EXPECT_NE(instance1, nullptr);
+}
+
+/**
+ * @brief 测试初始化流程
+ * 验证RecentManager初始化时正确设置所有组件
+ */
+TEST_F(RecentManagerTest, Initialize_SetsUpCorrectly)
+{
+    bool dbusInterfaceCreated = false;
+
+    // Mock DBus interface creation
+    stub.set_lamda(&RecentManagerDBusInterface::Reload,
+                   [&]() {
+        __DBG_STUB_INVOKE__
+        dbusInterfaceCreated = true;
+        return QDBusPendingReply<qlonglong>();
+    });
+
+    // Call init method
+    manager->init();
+
+    // Verify DBus interface was created
+    EXPECT_TRUE(dbusInterfaceCreated);
+}
+
+/**
+ * @brief 测试DBus接口连接
+ * 验证与RecentManager DBus服务的连接建立
+ */
+TEST_F(RecentManagerTest, DBusInterface_ConnectsSuccessfully)
+{
+    EXPECT_NO_FATAL_FAILURE(manager->dbus());
+}
+
+/**
+ * @brief 测试获取最近文件节点
+ * 验证getRecentNodes方法返回正确的文件信息映射
+ */
+TEST_F(RecentManagerTest, GetRecentNodes_ReturnsValidData)
+{
+    EXPECT_NO_FATAL_FAILURE(manager->getRecentNodes());
+}
+
+/**
+ * @brief 测试获取不存在路径的原始路径
+ * 验证对不存在URL的处理
+ */
+TEST_F(RecentManagerTest, GetRecentOriginPaths_NonexistentUrl_ReturnsEmpty)
+{
+    QUrl nonexistentUrl = QUrl("recent:///nonexistent.txt");
+
+    // Clear internal data
+    manager->recentItems.clear();
+
+    // Test with nonexistent URL
+    QString result = manager->getRecentOriginPaths(nonexistentUrl);
+
+    // Verify empty result
+    EXPECT_TRUE(result.isEmpty());
+}
+
+/**
+ * @brief 测试重置最近文件节点
+ * 验证resetRecentNodes方法正确处理DBus返回的数据
+ */
+TEST_F(RecentManagerTest, ResetRecentNodes_UpdatesData)
+{
+    bool dbusCallMade = false;
+    QVariantList mockData;
+
+    // Prepare mock DBus response
+    QVariantMap item1;
+    item1["Path"] = "/test1.txt";
+    item1["Href"] = "file:///test1.txt";
+    item1["modified"] = static_cast<qint64>(1234567890);
+
+    QDBusArgument arg1;
+    // Note: QDBusArgument construction is complex, mock it
+    mockData.append(QVariant::fromValue(arg1));
+
+    // Mock DBus GetItemsInfo call
+    stub.set_lamda(&RecentManagerDBusInterface::GetItemsInfo,
+                   [&](RecentManagerDBusInterface *) -> QDBusPendingReply<QVariantList> {
+        __DBG_STUB_INVOKE__
+        dbusCallMade = true;
+        QDBusPendingReply<QVariantList> reply;
+        // Mock successful reply
+        return reply;
+    });
+
+    // Mock QDBusPendingReply waitForFinished and value
+    stub.set_lamda(&QDBusPendingCallWatcher::waitForFinished, [](QDBusPendingCallWatcher *) {
+        __DBG_STUB_INVOKE__
+    });
+
+    // Test resetRecentNodes
+    manager->resetRecentNodes();
+
+    // Verify DBus call was made
+    EXPECT_TRUE(dbusCallMade);
+}
+
+/**
+ * @brief 测试DBus调用失败处理
+ * 验证DBus服务不可用时的错误处理
+ */
+TEST_F(RecentManagerTest, DBusFailure_HandlesGracefully)
+{
+    // Mock DBus interface to be invalid
+    stub.set_lamda(&QDBusAbstractInterface::isValid, [](const QDBusAbstractInterface *) {
+        __DBG_STUB_INVOKE__
+        return false;
+    });
+
+    // Mock failed DBus call
+    stub.set_lamda(&RecentManagerDBusInterface::GetItemsInfo,
+                   [](RecentManagerDBusInterface *) -> QDBusPendingReply<QVariantList> {
+        __DBG_STUB_INVOKE__
+        QDBusPendingReply<QVariantList> reply;
+        return reply;  // Return invalid reply
+    });
+
+    // Test should not crash
+    EXPECT_NO_THROW(manager->resetRecentNodes());
+}
+
+/**
+ * @brief 测试边界条件 - 空URL
+ * 验证空URL的处理
+ */
+TEST_F(RecentManagerTest, EmptyUrl_HandlesGracefully)
+{
+    QUrl emptyUrl;
+
+    // Test with empty URL
+    QString result = manager->getRecentOriginPaths(emptyUrl);
+
+    // Should return empty string for empty URL
+    EXPECT_TRUE(result.isEmpty());
+}
+
+/**
+ * @brief 测试边界条件 - 无效URL格式
+ * 验证无效URL格式的处理
+ */
+TEST_F(RecentManagerTest, InvalidUrlFormat_HandlesGracefully)
+{
+    // Test with various invalid URL formats
+    QStringList invalidUrls = {
+        "not-a-url",
+        "://invalid",
+        "recent://",
+        "recent:///../../outside",
+        QString(10000, 'a')  // Very long string
+    };
+
+    for (const QString &urlStr : invalidUrls) {
+        QUrl invalidUrl(urlStr);
+        EXPECT_NO_THROW({
+            QString result = manager->getRecentOriginPaths(invalidUrl);
+            // Should handle gracefully without crashing
+        });
+    }
+}
+
+/**
+ * @brief 测试多线程访问安全性
+ * 验证在多线程环境下的安全性
+ */
+TEST_F(RecentManagerTest, MultiThreadAccess_ThreadSafe)
+{
+    // Mock thread operations
+    stub.set_lamda(&QThread::currentThread, []() {
+        __DBG_STUB_INVOKE__
+        return QCoreApplication::instance()->thread();
+    });
+
+    // Test concurrent access
+    EXPECT_NO_THROW({
+        RecentManager *instance1 = RecentManager::instance();
+        RecentManager *instance2 = RecentManager::instance();
+        EXPECT_EQ(instance1, instance2);
+    });
+}
+
+/**
+ * @brief 测试析构函数清理
+ * 验证对象销毁时的资源清理
+ */
+TEST_F(RecentManagerTest, Destructor_CleansUpProperly)
+{
+    // Note: Since RecentManager is a singleton, we can't easily test destructor
+    // But we can test cleanup methods
+
+    manager->recentItems.clear();
+
+    // Verify cleanup
+    auto nodes = manager->getRecentNodes();
+    EXPECT_EQ(nodes.size(), 0);
+}

--- a/autotests/plugins/dfmplugin-recent/test_recentmenuscene.cpp
+++ b/autotests/plugins/dfmplugin-recent/test_recentmenuscene.cpp
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "stubext.h"
+
+#include "menus/recentmenuscene.h"
+#include "private/recentmenuscene_p.h"
+#include "utils/recentmanager.h"
+#include <dfm-base/base/application/application.h>
+#include <dfm-base/dfm_menu_defines.h>
+#include <dfm-base/interfaces/fileinfo.h>
+#include <dfm-base/base/schemefactory.h>
+#include <dfm-framework/event/event.h>
+#include "plugins/common/dfmplugin-menu/menuscene/action_defines.h"
+#include "plugins/common/dfmplugin-menu/menu_eventinterface_helper.h"
+#include <gtest/gtest.h>
+
+#include <QPaintEvent>
+#include <QPainter>
+#include <QMenu>
+#include <QAction>
+
+DFMBASE_USE_NAMESPACE
+using namespace dfmplugin_recent;
+
+class RecentMenuSceneTest : public testing::Test
+{
+protected:
+    virtual void SetUp() override
+    {
+        auto creator = new RecentMenuCreator();
+        scene = static_cast<dfmplugin_recent::RecentMenuScene *>(creator->create());
+        d = scene->d.data();
+    }
+    virtual void TearDown() override
+    {
+        stub.clear();
+        delete scene;
+    }
+
+protected:
+    stub_ext::StubExt stub;
+    RecentMenuScene *scene { nullptr };
+    RecentMenuScenePrivate *d { nullptr };
+};
+
+TEST_F(RecentMenuSceneTest, name)
+{
+    EXPECT_TRUE(scene->name() == "RecentMenu");
+}
+
+TEST_F(RecentMenuSceneTest, initialize)
+{
+    QList<QUrl> urls { QUrl::fromLocalFile("/hello/world"), QUrl::fromLocalFile("/i/can/eat/glass/without/hurt") };
+    EXPECT_FALSE(scene->initialize({ { "currentDir", true } }));
+    EXPECT_FALSE(scene->initialize({ { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+    EXPECT_FALSE(scene->initialize({ { "onDesktop", true } }));
+    EXPECT_TRUE(scene->initialize({ { "isEmptyArea", true } }));
+    EXPECT_FALSE(scene->initialize({ { "indexFlags", true } }));
+    d->focusFile = QUrl::fromLocalFile("/hello/world");
+    stub.set_lamda(VADDR(AbstractMenuScenePrivate, initializeParamsIsValid), [] {
+        return true;
+    });
+    EXPECT_TRUE(scene->initialize({ { "isEmptyArea", true } }));
+    urls.takeFirst();
+    EXPECT_NO_FATAL_FAILURE(scene->initialize({ { "isEmptyArea", false },
+                                                { "selectFiles", QVariant::fromValue<QList<QUrl>>(urls) } }));
+}
+
+TEST_F(RecentMenuSceneTest, create)
+{
+    EXPECT_FALSE(scene->create(nullptr));
+
+    QMenu menu;
+    EXPECT_NO_FATAL_FAILURE(scene->create(&menu));
+    d->isEmptyArea = true;
+    EXPECT_NO_FATAL_FAILURE(scene->create(&menu));
+}
+
+TEST_F(RecentMenuSceneTest, triggered)
+{
+    DPF_USE_NAMESPACE
+    auto act = new QAction("hello");
+    act->setProperty(ActionPropertyKey::kActionID, "hello");
+    d->predicateAction.insert("hello", act);
+    d->predicateAction.insert("remove", act);
+    d->predicateAction.insert("open-file-location", act);
+    d->predicateAction.insert("sort-by-path", act);
+    d->predicateAction.insert("sort-by-lastRead", act);
+    EXPECT_FALSE(scene->triggered(act));
+
+    stub.set_lamda(&RecentHelper::removeRecent, []() {});
+
+    void (*func)(const QList<QUrl> &) = &RecentHelper::openFileLocation;
+    stub.set_lamda(func, []() {});
+
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, const quint64 &, Global::ItemRoles &);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    stub.set_lamda(push1, [] { __DBG_STUB_INVOKE__ return QVariant(); });
+
+    act->setProperty(ActionPropertyKey::kActionID, "remove");
+    EXPECT_TRUE(scene->triggered(act));
+    act->setProperty(ActionPropertyKey::kActionID, "open-file-location");
+    EXPECT_TRUE(scene->triggered(act));
+    act->setProperty(ActionPropertyKey::kActionID, "sort-by-path");
+    EXPECT_TRUE(scene->triggered(act));
+    act->setProperty(ActionPropertyKey::kActionID, "sort-by-lastRead");
+    EXPECT_TRUE(scene->triggered(act));
+}
+
+TEST_F(RecentMenuSceneTest, scene)
+{
+    EXPECT_EQ(nullptr, scene->scene(nullptr));
+
+    auto act = new QAction("hello");
+    d->predicateAction.insert("hello", act);
+    EXPECT_STREQ(scene->scene(act)->metaObject()->className(), "dfmplugin_recent::RecentMenuScene");
+
+    d->predicateAction.clear();
+    EXPECT_NO_FATAL_FAILURE(scene->scene(act));
+    delete act;
+    act = nullptr;
+}
+
+TEST_F(RecentMenuSceneTest, updateMenu)
+{
+    QMenu menu;
+    menu.addSeparator();
+    auto act = menu.addAction("1");
+    auto act1 = menu.addAction("2");
+    auto act2 = menu.addAction("3");
+    auto act3 = menu.addAction("4");
+    act->setProperty(ActionPropertyKey::kActionID, "remove");
+    act1->setProperty(ActionPropertyKey::kActionID, "open-file-location");
+    act2->setProperty(ActionPropertyKey::kActionID, "sort-by-path");
+    act3->setProperty(ActionPropertyKey::kActionID, "sort-by-lastRead");
+    d->predicateAction.insert("hello", act);
+    d->predicateAction.insert("remove", act);
+    d->predicateAction.insert("open-file-location", act);
+    d->predicateAction.insert("sort-by-path", act);
+    d->predicateAction.insert("sort-by-lastRead", act);
+    d->isEmptyArea = true;
+    EXPECT_NO_FATAL_FAILURE(d->updateMenu(&menu));
+    d->isEmptyArea = false;
+    EXPECT_NO_FATAL_FAILURE(d->updateMenu(&menu));
+}
+
+TEST_F(RecentMenuSceneTest, updateSubMenu)
+{
+    DPF_USE_NAMESPACE
+    int flag = 0;
+    stub.set_lamda(&QAction::setChecked, [&flag] {
+        __DBG_STUB_INVOKE__
+        flag++;
+    });
+    QMenu menu;
+    auto act = menu.addAction("1");
+    auto act1 = menu.addAction("2");
+    act->setProperty(ActionPropertyKey::kActionID, "remove");
+    act1->setProperty(ActionPropertyKey::kActionID, "sort-by-time-modified");
+    d->predicateAction[RecentActionID::kSortByPath] = act;
+    d->predicateAction[RecentActionID::kSortByLastRead] = act1;
+    typedef QVariant (EventChannelManager::*Push1)(const QString &, const QString &, quint64);
+    auto push1 = static_cast<Push1>(&EventChannelManager::push);
+    stub.set_lamda(push1, [&flag] {
+        __DBG_STUB_INVOKE__
+        flag++;
+        return QVariant();
+    });
+    d->updateSortSubMenu(&menu);
+
+    QMenu menu1;
+    auto act2 = menu1.addAction("1");
+    act2->setProperty(ActionPropertyKey::kActionID, "sort-by-time-modified");
+    stub.set_lamda(push1, [&flag] {
+        __DBG_STUB_INVOKE__
+        flag++;
+        return QVariant(Global::ItemRoles::kItemFilePathRole);
+    });
+    d->updateSortSubMenu(&menu);
+
+    QMenu menu2;
+    auto act3 = menu2.addAction("1");
+    act3->setProperty(ActionPropertyKey::kActionID, "sort-by-time-modified");
+    stub.set_lamda(push1, [&flag] {
+        __DBG_STUB_INVOKE__
+        flag++;
+        return QVariant(Global::ItemRoles::kItemFileLastReadRole);
+    });
+    d->updateSortSubMenu(&menu2);
+    // Three updateSortSubMenu() calls each push the current sort role once
+    // (flag++), and the 2nd/3rd return a mapped role so setChecked is invoked
+    // on the matching action (flag++ each): 3 + 2 = 5 total increments.
+    EXPECT_EQ(5, flag);
+}
+
+TEST_F(RecentMenuSceneTest, updateState)
+{
+    QMenu menu;
+    EXPECT_NO_FATAL_FAILURE(scene->updateState(&menu));
+}


### PR DESCRIPTION
Port recent plugin tests from autotests/old, covering recent
storage, iterators and events.

从 autotests/old 移植最近使用插件测试，覆盖存储、迭代器
与事件。

Log: 新增 dfmplugin-recent 单元测试
Influence: 仅新增测试代码，不影响功能。

---
All 39 test commits verified together via `autotests/run-ut.sh` full build: 41/41 test binaries pass (incl. 140 cases of ut-dfmplugin-smbbrowser).

## Summary by Sourcery

Add comprehensive unit tests for the dfmplugin-recent plugin without changing production functionality.

Build:
- Add CMake configuration and test entry point for the dfmplugin-recent unit-test target.

Tests:
- Add broad unit and integration coverage for recent-plugin initialization, event wiring, recent-item management, file information, file operations, iterators, watchers, menu behavior, and event handling, including boundary and error cases.